### PR TITLE
fix: welcome dialog Save overwriting user's agent pick

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -116,6 +116,7 @@ export function App() {
     const withOnboarding: AppConfig = { ...next, onboardingCompleted: true };
     saveConfig(withOnboarding);
     setConfig(withOnboarding);
+    setSettingsOpen(false);
   }, []);
 
   const handleModeChange = useCallback(

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -276,10 +276,7 @@ export function SettingsDialog({
             type="button"
             className="primary"
             disabled={!canSave}
-            onClick={() => {
-              onSave(cfg);
-              onClose();
-            }}
+            onClick={() => onSave(cfg)}
           >
             {welcome ? t('settings.getStarted') : t('common.save')}
           </button>


### PR DESCRIPTION
Fixes #3 

## Summary

The welcome `SettingsDialog`'s Save button silently reverted the user's agent pick back to the bootstrap default on the very first page load.
See the linked issue for the full reproduction steps, code citations, and stale-closure analysis.

This PR splits the dialog's Save and dismiss flows into two non-overlapping callsites:

- `handleConfigSave` (in `src/App.tsx`) now closes the dialog itself after writing config.
- The Save button (in `src/components/SettingsDialog.tsx`) calls only`onSave(cfg)` — it no longer also fires `onClose()`.

`onClose` therefore stays scoped to genuine dismiss flows (Skip for now / backdrop click), where its closed-over `config` snapshot can't clobber a fresh save because nothing is being saved on those paths.

## Test plan

- [x] `pnpm typecheck` passes.
- [x] Reproduce per issue steps — clear`localStorage['open-design:config']`, open the welcome dialog, pick a non-default agent, click **Get Started**, confirm the top-bar picker and `localStorage` both reflect the choice.
- [x] Verify `Skip for now` and backdrop click still set `onboardingCompleted: true` so the welcome dialog doesn't re-pop on the next page load.
- [x] Re-open Settings via the env pill (non-welcome path) — Save should still persist changes and close the modal.

