### PR TITLE
fix: spawn agents via resolved absolute path on Windows (closes #10)

### DIFF
--- a/daemon/agents.js
+++ b/daemon/agents.js
@@ -125,3 +125,13 @@ export async function detectAgents() {
 export function getAgentDef(id) {
   return AGENT_DEFS.find((a) => a.id === id) || null;
 }
+
+// Resolve the absolute path of an agent's binary on the current PATH.
+// Used by the chat handler so spawn() gets the same executable that
+// detection reported as available — fixes Windows ENOENT when the bare
+// bin name isn't on the child process's PATH (issue #10).
+export function resolveAgentBin(id) {
+  const def = getAgentDef(id);
+  if (!def?.bin) return null;
+  return resolveOnPath(def.bin);
+}

--- a/daemon/server.js
+++ b/daemon/server.js
@@ -820,10 +820,44 @@ export async function startServer({ port = 7456 } = {}) {
     // already locates the executable via PATH, but spawning the bare name here
     // fails on Windows (ENOENT) when the child process's PATH doesn't contain
     // the user's npm-global / shim directory — see issue #10.
-    const resolvedBin = resolveAgentBin(agentId) || def.bin;
+    //
+    // If detection can't find the binary, surface a friendly SSE error
+    // pointing at /api/agents instead of silently falling back to
+    // spawn(def.bin) — that fallback re-introduces the exact ENOENT symptom
+    // from issue #10 the rest of this block is meant to prevent.
+    const resolvedBin = resolveAgentBin(agentId);
+    if (!resolvedBin) {
+      send('error', {
+        message:
+          `Agent "${def.name}" (\`${def.bin}\`) is not installed or not on PATH. ` +
+          'Install it and refresh the agent list (GET /api/agents) before retrying.',
+      });
+      return res.end();
+    }
     // npm shims on Windows are .cmd/.bat files; Node ≥21 refuses to spawn
     // those without `shell: true` (CVE-2024-27980). When `shell: true` is set
-    // on Windows, Node escapes args automatically for the cmd.exe shell.
+    // on Windows, Node escapes argv items for the cmd.exe shell — that
+    // escape is what currently keeps user-controlled prompt text in `args`
+    // (composed via `def.buildArgs(prompt, ...)` above) from being
+    // interpreted as shell metacharacters. Two caveats this leaves on the
+    // table for a future contributor to be aware of:
+    //   1. Defensibility relies on Node's escaper staying correct. The
+    //      stronger fix is to keep user text out of argv entirely by piping
+    //      the composed prompt through child stdin instead of passing it
+    //      as a `-p $prompt`-style flag. Do NOT add a new prompt-bearing
+    //      flag in `buildArgs` thinking shell:true makes it safe — route
+    //      it through stdin instead.
+    //   2. cmd.exe caps the full command line at ~8191 chars (well below
+    //      Node's direct-spawn argv cap), so long prompts can fail with an
+    //      ENAMETOOLONG-class error here. Same mitigation: stdin.
+    //
+    // We only flip shell:true for `.cmd`/`.bat` because those are the only
+    // PATHEXT entries that strictly require cmd.exe to launch. `.exe`/`.com`
+    // launch directly (no shell needed); `.ps1`/`.vbs` etc. would need a
+    // different host (powershell / wscript) — `shell: true` (which uses
+    // cmd.exe) wouldn't actually help those, so we don't pretend it would.
+    // In practice npm-installed CLIs ship as `.cmd` shims, which is the
+    // case this branch covers.
     const useShell =
       process.platform === 'win32' && /\.(cmd|bat)$/i.test(resolvedBin);
 

--- a/daemon/server.js
+++ b/daemon/server.js
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import fs from 'node:fs';
 import os from 'node:os';
-import { detectAgents, getAgentDef } from './agents.js';
+import { detectAgents, getAgentDef, resolveAgentBin } from './agents.js';
 import { listSkills } from './skills.js';
 import { listDesignSystems, readDesignSystem } from './design-systems.js';
 import { createClaudeStreamHandler } from './claude-stream.js';
@@ -792,9 +792,20 @@ export async function startServer({ port = 7456 } = {}) {
       res.write(`data: ${JSON.stringify(data)}\n\n`);
     };
 
+    // Resolve the agent's bin to its absolute path. Detection (`/api/agents`)
+    // already locates the executable via PATH, but spawning the bare name here
+    // fails on Windows (ENOENT) when the child process's PATH doesn't contain
+    // the user's npm-global / shim directory — see issue #10.
+    const resolvedBin = resolveAgentBin(agentId) || def.bin;
+    // npm shims on Windows are .cmd/.bat files; Node ≥21 refuses to spawn
+    // those without `shell: true` (CVE-2024-27980). When `shell: true` is set
+    // on Windows, Node escapes args automatically for the cmd.exe shell.
+    const useShell =
+      process.platform === 'win32' && /\.(cmd|bat)$/i.test(resolvedBin);
+
     send('start', {
       agentId,
-      bin: def.bin,
+      bin: resolvedBin,
       streamFormat: def.streamFormat ?? 'plain',
       projectId: typeof projectId === 'string' ? projectId : null,
       cwd,
@@ -802,10 +813,11 @@ export async function startServer({ port = 7456 } = {}) {
 
     let child;
     try {
-      child = spawn(def.bin, args, {
+      child = spawn(resolvedBin, args, {
         env: { ...process.env },
         stdio: ['ignore', 'pipe', 'pipe'],
         cwd: cwd || undefined,
+        shell: useShell,
       });
     } catch (err) {
       send('error', { message: `spawn failed: ${err.message}` });


### PR DESCRIPTION
## Summary

- Fixes #10: on Windows, `/api/chat` failed with `spawn claude ENOENT` even though `/api/agents` had reported the agent as available with a resolved path.
- The chat handler now spawns the **resolved absolute path** returned by detection (via a new `resolveAgentBin(id)` export from `daemon/agents.js`), so the binary the picker reports is the binary that actually runs.
- When that resolved path is a Windows `.cmd`/`.bat` shim (the common case for npm-installed CLIs), spawn is invoked with `shell: true` so Node ≥21 doesn't refuse to execute it (CVE-2024-27980 hardening). On Unix-like systems behaviour is unchanged.

## Why this fixes the bug

`detectAgents()` walks `PATH` (with `PATHEXT` on Windows) and returns the full executable path. The previous `/api/chat` code ignored that and called `spawn('claude', ...)`, relying on the child process inheriting a PATH that contained the user's npm-global directory. On Windows that PATH propagation is unreliable when the daemon is launched from an IDE / `concurrently` / a different shell, so spawn errored out.

By spawning the resolved path directly, the child process no longer has to re-discover the binary.

## Test plan

- [x] `npm run typecheck` passes.
- [x] `node --check` on edited files passes.
- [x] `detectAgents()` still returns the same shape (verified locally on macOS).
- [x] `resolveAgentBin('claude')` returns the absolute path; unknown ids return `null`.
- [ ] Windows verification: with `claude` installed via `npm i -g @anthropic-ai/claude-code`, send a chat message — expect a streamed response instead of `spawn claude ENOENT`.

Closes #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)