### PR TITLE
feat: per-CLI model picker for local agents

### DIFF
--- a/daemon/agents.js
+++ b/daemon/agents.js
@@ -6,20 +6,29 @@ import path from 'node:path';
 
 const execFileP = promisify(execFile);
 
-// Per-agent model picker:
+// Per-agent model picker.
 //
-//   - `models`             : selectable model presets shown in the UI. The
-//                            first entry is treated as the default. `id`
-//                            of `'default'` means "let the CLI pick" — the
-//                            agent runs with no `--model` flag, so the
-//                            user's local CLI config wins.
+//   - `listModels`         : optional spec for fetching the model list from
+//                            the CLI itself ({ args, parse, timeoutMs }).
+//                            When defined we run it during agent detection
+//                            (best-effort, with a timeout) and use the
+//                            result. If the listing fails we fall back to
+//                            `fallbackModels` so the UI still has something
+//                            to show.
+//   - `fallbackModels`     : static hint list. Used as the source of truth
+//                            for CLIs that don't expose a listing command
+//                            (Claude Code, Codex, Gemini CLI, Qwen Code)
+//                            and as the fallback for the others.
 //   - `reasoningOptions`   : optional reasoning-effort presets (currently
-//                            only Codex exposes this knob). Same `default`
-//                            convention as models.
+//                            only Codex exposes this knob).
 //   - `buildArgs(prompt, imagePaths, extraAllowedDirs, options)` returns
 //     argv for the child process. `options = { model, reasoning }` carries
 //     whatever the user picked in the model menu — agents that don't take a
 //     model flag ignore them.
+//
+// Every model list is prefixed with a synthetic `'default'` entry meaning
+// "let the CLI pick" — the agent runs with no `--model` flag, so the
+// user's local CLI config wins.
 //
 // `extraAllowedDirs` is a list of absolute directories the agent must be
 // permitted to read files from (skill seeds, design-system specs) that live
@@ -32,17 +41,45 @@ const execFileP = promisify(execFile);
 //     `--output-format stream-json`. Daemon parses it into typed events
 //     (text / thinking / tool_use / tool_result / status) for the UI.
 //   - 'plain' (default)    : raw text, forwarded chunk-by-chunk.
+
+const DEFAULT_MODEL_OPTION = { id: 'default', label: 'Default (CLI config)' };
+
+// Parse one-id-per-line stdout from `<cli> models` and prepend the synthetic
+// default option. Used by opencode / cursor-agent.
+function parseLineSeparatedModels(stdout) {
+  const ids = String(stdout || '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith('#'));
+  // De-dupe while preserving order — some CLIs print near-duplicates.
+  const seen = new Set();
+  const out = [DEFAULT_MODEL_OPTION];
+  for (const id of ids) {
+    if (seen.has(id)) continue;
+    seen.add(id);
+    out.push({ id, label: id });
+  }
+  return out;
+}
+
 export const AGENT_DEFS = [
   {
     id: 'claude',
     name: 'Claude Code',
     bin: 'claude',
     versionArgs: ['--version'],
-    models: [
-      { id: 'default', label: 'Default (CLI config)' },
-      { id: 'claude-opus-4-5', label: 'Opus 4.5' },
-      { id: 'claude-sonnet-4-5', label: 'Sonnet 4.5' },
-      { id: 'claude-haiku-4-5', label: 'Haiku 4.5' },
+    // `claude` has no list-models subcommand; the CLI accepts both short
+    // aliases (sonnet/opus/haiku) and the full ids, so we ship both as
+    // hints. Users who want a non-shipped model can paste it via the
+    // Settings dialog's custom-model input.
+    fallbackModels: [
+      DEFAULT_MODEL_OPTION,
+      { id: 'sonnet', label: 'Sonnet (alias)' },
+      { id: 'opus', label: 'Opus (alias)' },
+      { id: 'haiku', label: 'Haiku (alias)' },
+      { id: 'claude-opus-4-5', label: 'claude-opus-4-5' },
+      { id: 'claude-sonnet-4-5', label: 'claude-sonnet-4-5' },
+      { id: 'claude-haiku-4-5', label: 'claude-haiku-4-5' },
     ],
     buildArgs: (prompt, _imagePaths, extraAllowedDirs = [], options = {}) => {
       const args = [
@@ -71,8 +108,10 @@ export const AGENT_DEFS = [
     name: 'Codex CLI',
     bin: 'codex',
     versionArgs: ['--version'],
-    models: [
-      { id: 'default', label: 'Default (CLI config)' },
+    // Codex doesn't have a `models` subcommand; ship the most common ids
+    // as a hint. Users can supply other ids via the custom-model input.
+    fallbackModels: [
+      DEFAULT_MODEL_OPTION,
       { id: 'gpt-5-codex', label: 'gpt-5-codex' },
       { id: 'gpt-5', label: 'gpt-5' },
       { id: 'o3', label: 'o3' },
@@ -105,10 +144,10 @@ export const AGENT_DEFS = [
     name: 'Gemini CLI',
     bin: 'gemini',
     versionArgs: ['--version'],
-    models: [
-      { id: 'default', label: 'Default (CLI config)' },
-      { id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro' },
-      { id: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
+    fallbackModels: [
+      DEFAULT_MODEL_OPTION,
+      { id: 'gemini-2.5-pro', label: 'gemini-2.5-pro' },
+      { id: 'gemini-2.5-flash', label: 'gemini-2.5-flash' },
     ],
     buildArgs: (prompt, _imagePaths, _extra, options = {}) => {
       const args = [];
@@ -125,13 +164,17 @@ export const AGENT_DEFS = [
     name: 'OpenCode',
     bin: 'opencode',
     versionArgs: ['--version'],
-    models: [
-      { id: 'default', label: 'Default (CLI config)' },
-      { id: 'anthropic/claude-sonnet-4-5', label: 'Anthropic · Sonnet 4.5' },
-      { id: 'anthropic/claude-opus-4-5', label: 'Anthropic · Opus 4.5' },
-      { id: 'anthropic/claude-haiku-4-5', label: 'Anthropic · Haiku 4.5' },
-      { id: 'openai/gpt-5', label: 'OpenAI · gpt-5' },
-      { id: 'google/gemini-2.5-pro', label: 'Google · Gemini 2.5 Pro' },
+    // `opencode models` prints `provider/model` per line.
+    listModels: {
+      args: ['models'],
+      parse: parseLineSeparatedModels,
+      timeoutMs: 8000,
+    },
+    fallbackModels: [
+      DEFAULT_MODEL_OPTION,
+      { id: 'anthropic/claude-sonnet-4-5', label: 'anthropic/claude-sonnet-4-5' },
+      { id: 'openai/gpt-5', label: 'openai/gpt-5' },
+      { id: 'google/gemini-2.5-pro', label: 'google/gemini-2.5-pro' },
     ],
     buildArgs: (prompt, _imagePaths, _extra, options = {}) => {
       const args = ['run'];
@@ -148,11 +191,23 @@ export const AGENT_DEFS = [
     name: 'Cursor Agent',
     bin: 'cursor-agent',
     versionArgs: ['--version'],
-    models: [
-      { id: 'default', label: 'Default (CLI config)' },
-      { id: 'auto', label: 'Auto' },
-      { id: 'claude-4-sonnet', label: 'Claude 4 Sonnet' },
-      { id: 'claude-4.5-sonnet', label: 'Claude 4.5 Sonnet' },
+    // `cursor-agent models` prints account-bound model ids per line. When
+    // the user isn't authed it prints "No models available for this
+    // account." — that's not a model list, so we detect it and fall back.
+    listModels: {
+      args: ['models'],
+      timeoutMs: 5000,
+      parse: (stdout) => {
+        const trimmed = String(stdout || '').trim();
+        if (!trimmed || /no models available/i.test(trimmed)) return null;
+        return parseLineSeparatedModels(trimmed);
+      },
+    },
+    fallbackModels: [
+      DEFAULT_MODEL_OPTION,
+      { id: 'auto', label: 'auto' },
+      { id: 'sonnet-4', label: 'sonnet-4' },
+      { id: 'sonnet-4-thinking', label: 'sonnet-4-thinking' },
       { id: 'gpt-5', label: 'gpt-5' },
     ],
     buildArgs: (prompt, _imagePaths, _extra, options = {}) => {
@@ -170,8 +225,8 @@ export const AGENT_DEFS = [
     name: 'Qwen Code',
     bin: 'qwen',
     versionArgs: ['--version'],
-    models: [
-      { id: 'default', label: 'Default (CLI config)' },
+    fallbackModels: [
+      DEFAULT_MODEL_OPTION,
       { id: 'qwen3-coder-plus', label: 'qwen3-coder-plus' },
       { id: 'qwen3-coder-flash', label: 'qwen3-coder-flash' },
     ],
@@ -202,9 +257,36 @@ function resolveOnPath(bin) {
   return null;
 }
 
+async function fetchModels(def, resolvedBin) {
+  if (!def.listModels) return def.fallbackModels;
+  try {
+    const { stdout } = await execFileP(resolvedBin, def.listModels.args, {
+      timeout: def.listModels.timeoutMs ?? 5000,
+      // Models lists from popular CLIs (e.g. opencode) easily exceed the
+      // default 1MB buffer once you include every openrouter model. Bump
+      // it so we don't truncate the listing.
+      maxBuffer: 8 * 1024 * 1024,
+    });
+    const parsed = def.listModels.parse(stdout);
+    // Empty / null parse result means the CLI didn't actually return a
+    // usable list (e.g. cursor-agent's "No models available"); fall back
+    // to the static hint so the picker isn't stuck on Default-only.
+    if (!parsed || parsed.length === 0) return def.fallbackModels;
+    return parsed;
+  } catch {
+    return def.fallbackModels;
+  }
+}
+
 async function probe(def) {
   const resolved = resolveOnPath(def.bin);
-  if (!resolved) return { ...stripFns(def), available: false };
+  if (!resolved) {
+    return {
+      ...stripFns(def),
+      models: def.fallbackModels ?? [DEFAULT_MODEL_OPTION],
+      available: false,
+    };
+  }
   let version = null;
   try {
     const { stdout } = await execFileP(resolved, def.versionArgs, { timeout: 3000 });
@@ -212,21 +294,75 @@ async function probe(def) {
   } catch {
     // binary exists but --version failed; still mark available
   }
-  return { ...stripFns(def), available: true, path: resolved, version };
+  const models = await fetchModels(def, resolved);
+  return {
+    ...stripFns(def),
+    models,
+    available: true,
+    path: resolved,
+    version,
+  };
 }
 
 function stripFns(def) {
-  // Drop the buildArgs closure but keep declarative metadata (models,
-  // reasoningOptions, streamFormat) so the frontend can render the picker
-  // without a second round-trip.
-  const { buildArgs, ...rest } = def;
+  // Drop the buildArgs / listModels closures but keep declarative metadata
+  // (reasoningOptions, streamFormat, name, bin, etc.). `models` is
+  // populated separately by `fetchModels`, so we strip the static
+  // `fallbackModels` slot here too.
+  const { buildArgs, listModels, fallbackModels, ...rest } = def;
   return rest;
 }
 
 export async function detectAgents() {
-  return Promise.all(AGENT_DEFS.map(probe));
+  const results = await Promise.all(AGENT_DEFS.map(probe));
+  // Refresh the validation cache from whatever we just surfaced to the UI
+  // so /api/chat can accept any model the user could have just picked,
+  // including ones that only showed up after a CLI re-auth.
+  for (const agent of results) {
+    rememberLiveModels(agent.id, agent.models);
+  }
+  return results;
 }
 
 export function getAgentDef(id) {
   return AGENT_DEFS.find((a) => a.id === id) || null;
+}
+
+// Daemon's /api/chat needs to validate the user's model pick against the
+// list we last surfaced to the UI. We keep a per-agent cache of the most
+// recent live list (refreshed every detectAgents() call) and additionally
+// trust any value present in the static fallback. A model that's neither
+// gets rejected so a stale or hostile value can't smuggle arbitrary flags.
+const liveModelCache = new Map();
+
+export function rememberLiveModels(agentId, models) {
+  if (!Array.isArray(models)) return;
+  liveModelCache.set(
+    agentId,
+    new Set(models.map((m) => m && m.id).filter((id) => typeof id === 'string')),
+  );
+}
+
+export function isKnownModel(def, modelId) {
+  if (!modelId) return false;
+  const live = liveModelCache.get(def.id);
+  if (live && live.has(modelId)) return true;
+  if (Array.isArray(def.fallbackModels)) {
+    return def.fallbackModels.some((m) => m.id === modelId);
+  }
+  return false;
+}
+
+// Permit user-typed model ids that didn't appear in either the live
+// listing or the static fallback (e.g. the user is on a brand-new model
+// the CLI's `models` command hasn't surfaced yet). The CLI gets the value
+// as a child-process arg — not a shell string — so injection isn't a
+// concern, but we still reject anything that could be misread as a flag
+// by a downstream CLI or that contains whitespace / control chars.
+export function sanitizeCustomModel(id) {
+  if (typeof id !== 'string') return null;
+  const trimmed = id.trim();
+  if (trimmed.length === 0 || trimmed.length > 200) return null;
+  if (!/^[A-Za-z0-9][A-Za-z0-9._/:@-]*$/.test(trimmed)) return null;
+  return trimmed;
 }

--- a/daemon/agents.js
+++ b/daemon/agents.js
@@ -6,13 +6,27 @@ import path from 'node:path';
 
 const execFileP = promisify(execFile);
 
-// Each entry defines how to invoke the agent in non-interactive "one-shot" mode.
-// `buildArgs(prompt, imagePaths, extraAllowedDirs)` returns argv for the child
-// process. `extraAllowedDirs` is a list of absolute directories the agent must
-// be permitted to read files from (skill seeds, design-system specs) that live
+// Per-agent model picker:
+//
+//   - `models`             : selectable model presets shown in the UI. The
+//                            first entry is treated as the default. `id`
+//                            of `'default'` means "let the CLI pick" — the
+//                            agent runs with no `--model` flag, so the
+//                            user's local CLI config wins.
+//   - `reasoningOptions`   : optional reasoning-effort presets (currently
+//                            only Codex exposes this knob). Same `default`
+//                            convention as models.
+//   - `buildArgs(prompt, imagePaths, extraAllowedDirs, options)` returns
+//     argv for the child process. `options = { model, reasoning }` carries
+//     whatever the user picked in the model menu — agents that don't take a
+//     model flag ignore them.
+//
+// `extraAllowedDirs` is a list of absolute directories the agent must be
+// permitted to read files from (skill seeds, design-system specs) that live
 // outside the project cwd. Currently only Claude Code wires this through
 // (`--add-dir`); other agents either inherit broader access or run with cwd
 // boundaries we can't widen via flags.
+//
 // `streamFormat` hints to the daemon how to interpret stdout:
 //   - 'claude-stream-json' : line-delimited JSON emitted by Claude Code's
 //     `--output-format stream-json`. Daemon parses it into typed events
@@ -24,7 +38,13 @@ export const AGENT_DEFS = [
     name: 'Claude Code',
     bin: 'claude',
     versionArgs: ['--version'],
-    buildArgs: (prompt, _imagePaths, extraAllowedDirs = []) => {
+    models: [
+      { id: 'default', label: 'Default (CLI config)' },
+      { id: 'claude-opus-4-5', label: 'Opus 4.5' },
+      { id: 'claude-sonnet-4-5', label: 'Sonnet 4.5' },
+      { id: 'claude-haiku-4-5', label: 'Haiku 4.5' },
+    ],
+    buildArgs: (prompt, _imagePaths, extraAllowedDirs = [], options = {}) => {
       const args = [
         '-p',
         prompt,
@@ -33,6 +53,9 @@ export const AGENT_DEFS = [
         '--verbose',
         '--include-partial-messages',
       ];
+      if (options.model && options.model !== 'default') {
+        args.push('--model', options.model);
+      }
       const dirs = (extraAllowedDirs || []).filter(
         (d) => typeof d === 'string' && d.length > 0,
       );
@@ -48,7 +71,33 @@ export const AGENT_DEFS = [
     name: 'Codex CLI',
     bin: 'codex',
     versionArgs: ['--version'],
-    buildArgs: (prompt) => ['exec', prompt],
+    models: [
+      { id: 'default', label: 'Default (CLI config)' },
+      { id: 'gpt-5-codex', label: 'gpt-5-codex' },
+      { id: 'gpt-5', label: 'gpt-5' },
+      { id: 'o3', label: 'o3' },
+      { id: 'o4-mini', label: 'o4-mini' },
+    ],
+    reasoningOptions: [
+      { id: 'default', label: 'Default' },
+      { id: 'minimal', label: 'Minimal' },
+      { id: 'low', label: 'Low' },
+      { id: 'medium', label: 'Medium' },
+      { id: 'high', label: 'High' },
+    ],
+    buildArgs: (prompt, _imagePaths, _extra, options = {}) => {
+      const args = ['exec'];
+      if (options.model && options.model !== 'default') {
+        args.push('--model', options.model);
+      }
+      if (options.reasoning && options.reasoning !== 'default') {
+        // Codex accepts `-c key=value` config overrides; reasoning effort
+        // is exposed as `model_reasoning_effort`.
+        args.push('-c', `model_reasoning_effort="${options.reasoning}"`);
+      }
+      args.push(prompt);
+      return args;
+    },
     streamFormat: 'plain',
   },
   {
@@ -56,7 +105,19 @@ export const AGENT_DEFS = [
     name: 'Gemini CLI',
     bin: 'gemini',
     versionArgs: ['--version'],
-    buildArgs: (prompt) => ['-p', prompt],
+    models: [
+      { id: 'default', label: 'Default (CLI config)' },
+      { id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro' },
+      { id: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
+    ],
+    buildArgs: (prompt, _imagePaths, _extra, options = {}) => {
+      const args = [];
+      if (options.model && options.model !== 'default') {
+        args.push('--model', options.model);
+      }
+      args.push('-p', prompt);
+      return args;
+    },
     streamFormat: 'plain',
   },
   {
@@ -64,7 +125,22 @@ export const AGENT_DEFS = [
     name: 'OpenCode',
     bin: 'opencode',
     versionArgs: ['--version'],
-    buildArgs: (prompt) => ['run', prompt],
+    models: [
+      { id: 'default', label: 'Default (CLI config)' },
+      { id: 'anthropic/claude-sonnet-4-5', label: 'Anthropic · Sonnet 4.5' },
+      { id: 'anthropic/claude-opus-4-5', label: 'Anthropic · Opus 4.5' },
+      { id: 'anthropic/claude-haiku-4-5', label: 'Anthropic · Haiku 4.5' },
+      { id: 'openai/gpt-5', label: 'OpenAI · gpt-5' },
+      { id: 'google/gemini-2.5-pro', label: 'Google · Gemini 2.5 Pro' },
+    ],
+    buildArgs: (prompt, _imagePaths, _extra, options = {}) => {
+      const args = ['run'];
+      if (options.model && options.model !== 'default') {
+        args.push('--model', options.model);
+      }
+      args.push(prompt);
+      return args;
+    },
     streamFormat: 'plain',
   },
   {
@@ -72,7 +148,21 @@ export const AGENT_DEFS = [
     name: 'Cursor Agent',
     bin: 'cursor-agent',
     versionArgs: ['--version'],
-    buildArgs: (prompt) => ['-p', prompt],
+    models: [
+      { id: 'default', label: 'Default (CLI config)' },
+      { id: 'auto', label: 'Auto' },
+      { id: 'claude-4-sonnet', label: 'Claude 4 Sonnet' },
+      { id: 'claude-4.5-sonnet', label: 'Claude 4.5 Sonnet' },
+      { id: 'gpt-5', label: 'gpt-5' },
+    ],
+    buildArgs: (prompt, _imagePaths, _extra, options = {}) => {
+      const args = [];
+      if (options.model && options.model !== 'default') {
+        args.push('--model', options.model);
+      }
+      args.push('-p', prompt);
+      return args;
+    },
     streamFormat: 'plain',
   },
   {
@@ -80,7 +170,19 @@ export const AGENT_DEFS = [
     name: 'Qwen Code',
     bin: 'qwen',
     versionArgs: ['--version'],
-    buildArgs: (prompt) => ['-p', prompt],
+    models: [
+      { id: 'default', label: 'Default (CLI config)' },
+      { id: 'qwen3-coder-plus', label: 'qwen3-coder-plus' },
+      { id: 'qwen3-coder-flash', label: 'qwen3-coder-flash' },
+    ],
+    buildArgs: (prompt, _imagePaths, _extra, options = {}) => {
+      const args = [];
+      if (options.model && options.model !== 'default') {
+        args.push('--model', options.model);
+      }
+      args.push('-p', prompt);
+      return args;
+    },
     streamFormat: 'plain',
   },
 ];
@@ -114,6 +216,9 @@ async function probe(def) {
 }
 
 function stripFns(def) {
+  // Drop the buildArgs closure but keep declarative metadata (models,
+  // reasoningOptions, streamFormat) so the frontend can render the picker
+  // without a second round-trip.
   const { buildArgs, ...rest } = def;
   return rest;
 }

--- a/daemon/server.js
+++ b/daemon/server.js
@@ -6,7 +6,12 @@ import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import fs from 'node:fs';
 import os from 'node:os';
-import { detectAgents, getAgentDef } from './agents.js';
+import {
+  detectAgents,
+  getAgentDef,
+  isKnownModel,
+  sanitizeCustomModel,
+} from './agents.js';
 import { listSkills } from './skills.js';
 import { listDesignSystems, readDesignSystem } from './design-systems.js';
 import { createClaudeStreamHandler } from './claude-stream.js';
@@ -782,11 +787,15 @@ export async function startServer({ port = 7456 } = {}) {
       (d) => fs.existsSync(d),
     );
     // Per-agent model + reasoning the user picked in the model menu.
-    // Validated against the agent's declared options so a stale or hostile
-    // value can't smuggle arbitrary flags into the spawned argv.
+    // Trust the value when it matches the most recent /api/agents listing
+    // (live or fallback). Otherwise allow it through if it passes a
+    // permissive sanitizer — that's the path for user-typed custom model
+    // ids the CLI's listing didn't surface yet.
     const safeModel =
-      typeof model === 'string' && Array.isArray(def.models)
-        ? def.models.find((m) => m.id === model)?.id ?? null
+      typeof model === 'string'
+        ? isKnownModel(def, model)
+          ? model
+          : sanitizeCustomModel(model)
         : null;
     const safeReasoning =
       typeof reasoning === 'string' && Array.isArray(def.reasoningOptions)

--- a/daemon/server.js
+++ b/daemon/server.js
@@ -690,6 +690,8 @@ export async function startServer({ port = 7456 } = {}) {
       imagePaths = [],
       projectId,
       attachments = [],
+      model,
+      reasoning,
     } = req.body || {};
     const def = getAgentDef(agentId);
     if (!def) return res.status(400).json({ error: `unknown agent: ${agentId}` });
@@ -779,7 +781,19 @@ export async function startServer({ port = 7456 } = {}) {
     const extraAllowedDirs = [SKILLS_DIR, DESIGN_SYSTEMS_DIR].filter(
       (d) => fs.existsSync(d),
     );
-    const args = def.buildArgs(composed, safeImages, extraAllowedDirs);
+    // Per-agent model + reasoning the user picked in the model menu.
+    // Validated against the agent's declared options so a stale or hostile
+    // value can't smuggle arbitrary flags into the spawned argv.
+    const safeModel =
+      typeof model === 'string' && Array.isArray(def.models)
+        ? def.models.find((m) => m.id === model)?.id ?? null
+        : null;
+    const safeReasoning =
+      typeof reasoning === 'string' && Array.isArray(def.reasoningOptions)
+        ? def.reasoningOptions.find((r) => r.id === reasoning)?.id ?? null
+        : null;
+    const agentOptions = { model: safeModel, reasoning: safeReasoning };
+    const args = def.buildArgs(composed, safeImages, extraAllowedDirs, agentOptions);
 
     res.setHeader('Content-Type', 'text/event-stream');
     res.setHeader('Cache-Control', 'no-cache, no-transform');
@@ -798,6 +812,8 @@ export async function startServer({ port = 7456 } = {}) {
       streamFormat: def.streamFormat ?? 'plain',
       projectId: typeof projectId === 'string' ? projectId : null,
       cwd,
+      model: safeModel,
+      reasoning: safeReasoning,
     });
 
     let child;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -137,6 +137,18 @@ export function App() {
     [config],
   );
 
+  const handleAgentModelChange = useCallback(
+    (agentId: string, choice: { model?: string; reasoning?: string }) => {
+      const prev = config.agentModels?.[agentId] ?? {};
+      const merged = { ...prev, ...choice };
+      const nextAgentModels = { ...(config.agentModels ?? {}), [agentId]: merged };
+      const next = { ...config, agentModels: nextAgentModels };
+      saveConfig(next);
+      setConfig(next);
+    },
+    [config],
+  );
+
   const handleChangeDefaultDesignSystem = useCallback(
     (designSystemId: string) => {
       const next = { ...config, designSystemId };
@@ -272,6 +284,7 @@ export function App() {
           daemonLive={daemonLive}
           onModeChange={handleModeChange}
           onAgentChange={handleAgentChange}
+          onAgentModelChange={handleAgentModelChange}
           onRefreshAgents={refreshAgents}
           onOpenSettings={openSettings}
           onBack={handleBack}

--- a/src/components/AvatarMenu.tsx
+++ b/src/components/AvatarMenu.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useT } from '../i18n';
 import { AgentIcon } from './AgentIcon';
 import { Icon } from './Icon';
+import { renderModelOptions } from './modelOptions';
 import type { AgentInfo, AppConfig, ExecMode } from '../types';
 
 interface Props {
@@ -197,11 +198,20 @@ export function AvatarMenu({
                           })
                         }
                       >
-                        {currentAgent.models.map((m) => (
-                          <option key={m.id} value={m.id}>
-                            {m.label}
+                        {renderModelOptions(currentAgent.models)}
+                        {/* When the user has typed a custom id in
+                            Settings, surface it here too so the dropdown
+                            actually shows the active selection rather
+                            than collapsing to "Default". */}
+                        {currentModelId &&
+                        !currentAgent.models.some(
+                          (m) => m.id === currentModelId,
+                        ) ? (
+                          <option value={currentModelId}>
+                            {currentModelId}{' '}
+                            {t('avatar.customSuffix')}
                           </option>
-                        ))}
+                        ) : null}
                       </select>
                     </label>
                   ) : null}

--- a/src/components/AvatarMenu.tsx
+++ b/src/components/AvatarMenu.tsx
@@ -10,6 +10,10 @@ interface Props {
   daemonLive: boolean;
   onModeChange: (mode: ExecMode) => void;
   onAgentChange: (id: string) => void;
+  onAgentModelChange: (
+    id: string,
+    choice: { model?: string; reasoning?: string },
+  ) => void;
   onOpenSettings: () => void;
   onRefreshAgents: () => void;
   onBack?: () => void;
@@ -26,6 +30,7 @@ export function AvatarMenu({
   daemonLive,
   onModeChange,
   onAgentChange,
+  onAgentModelChange,
   onOpenSettings,
   onRefreshAgents,
   onBack,
@@ -58,6 +63,19 @@ export function AvatarMenu({
 
   const installedAgents = agents.filter((a) => a.available);
 
+  // Resolve the user's model + reasoning pick for the active agent. Falls
+  // back to the agent's first declared option (`'default'`) when the user
+  // hasn't touched the picker yet so the labels don't read as empty.
+  const currentChoice =
+    (config.agentId && config.agentModels?.[config.agentId]) || {};
+  const currentModelId =
+    currentChoice.model ?? currentAgent?.models?.[0]?.id ?? null;
+  const currentReasoningId =
+    currentChoice.reasoning ?? currentAgent?.reasoningOptions?.[0]?.id ?? null;
+  const currentModelLabel = currentAgent?.models?.find(
+    (m) => m.id === currentModelId,
+  )?.label;
+
   return (
     <div className="avatar-menu" ref={wrapRef}>
       <button
@@ -88,7 +106,7 @@ export function AvatarMenu({
               {config.mode === 'api'
                 ? safeHost(config.baseUrl)
                 : currentAgent
-                  ? `${currentAgent.name}${currentAgent.version ? ` · ${currentAgent.version}` : ''}`
+                  ? `${currentAgent.name}${currentAgent.version ? ` · ${currentAgent.version}` : ''}${currentModelLabel && currentModelId !== 'default' ? ` · ${currentModelLabel}` : ''}`
                   : t('avatar.noAgentSelected')}
             </span>
           </div>
@@ -133,18 +151,7 @@ export function AvatarMenu({
 
           {config.mode === 'daemon' && installedAgents.length > 0 ? (
             <>
-              <div
-                style={{
-                  fontSize: 10.5,
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.06em',
-                  color: 'var(--text-faint)',
-                  fontWeight: 600,
-                  padding: '8px 10px 4px',
-                }}
-              >
-                {t('avatar.codeAgent')}
-              </div>
+              <div className="avatar-section-label">{t('avatar.codeAgent')}</div>
               {installedAgents.map((a) => (
                 <button
                   type="button"
@@ -152,7 +159,8 @@ export function AvatarMenu({
                   className="avatar-item"
                   onClick={() => {
                     onAgentChange(a.id);
-                    setOpen(false);
+                    // Keep the popover open so the user can immediately
+                    // pick a model for the agent they just chose.
                   }}
                 >
                   <AgentIcon id={a.id} size={18} />
@@ -166,6 +174,62 @@ export function AvatarMenu({
                   ) : null}
                 </button>
               ))}
+              {currentAgent &&
+              currentAgent.available &&
+              ((currentAgent.models && currentAgent.models.length > 0) ||
+                (currentAgent.reasoningOptions &&
+                  currentAgent.reasoningOptions.length > 0)) ? (
+                <div className="avatar-model-section">
+                  <div className="avatar-section-label">
+                    {t('avatar.modelSection')}
+                  </div>
+                  {currentAgent.models && currentAgent.models.length > 0 ? (
+                    <label className="avatar-select-row">
+                      <span className="avatar-select-label">
+                        {t('avatar.modelLabel')}
+                      </span>
+                      <select
+                        className="avatar-select"
+                        value={currentModelId ?? ''}
+                        onChange={(e) =>
+                          onAgentModelChange(currentAgent.id, {
+                            model: e.target.value,
+                          })
+                        }
+                      >
+                        {currentAgent.models.map((m) => (
+                          <option key={m.id} value={m.id}>
+                            {m.label}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  ) : null}
+                  {currentAgent.reasoningOptions &&
+                  currentAgent.reasoningOptions.length > 0 ? (
+                    <label className="avatar-select-row">
+                      <span className="avatar-select-label">
+                        {t('avatar.reasoningLabel')}
+                      </span>
+                      <select
+                        className="avatar-select"
+                        value={currentReasoningId ?? ''}
+                        onChange={(e) =>
+                          onAgentModelChange(currentAgent.id, {
+                            reasoning: e.target.value,
+                          })
+                        }
+                      >
+                        {currentAgent.reasoningOptions.map((r) => (
+                          <option key={r.id} value={r.id}>
+                            {r.label}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  ) : null}
+                </div>
+              ) : null}
               <button
                 type="button"
                 className="avatar-item"

--- a/src/components/ProjectView.tsx
+++ b/src/components/ProjectView.tsx
@@ -53,6 +53,10 @@ interface Props {
   daemonLive: boolean;
   onModeChange: (mode: AppConfig['mode']) => void;
   onAgentChange: (id: string) => void;
+  onAgentModelChange: (
+    id: string,
+    choice: { model?: string; reasoning?: string },
+  ) => void;
   onRefreshAgents: () => void;
   onOpenSettings: () => void;
   onBack: () => void;
@@ -72,6 +76,7 @@ export function ProjectView({
   daemonLive,
   onModeChange,
   onAgentChange,
+  onAgentModelChange,
   onRefreshAgents,
   onOpenSettings,
   onBack,
@@ -490,6 +495,7 @@ export function ProjectView({
           handlers.onError(new Error('Pick a local agent first (top bar).'));
           return;
         }
+        const choice = config.agentModels?.[config.agentId];
         void streamViaDaemon({
           agentId: config.agentId,
           history: nextHistory,
@@ -498,6 +504,8 @@ export function ProjectView({
           handlers,
           projectId: project.id,
           attachments: attachments.map((a) => a.path),
+          model: choice?.model ?? null,
+          reasoning: choice?.reasoning ?? null,
         });
       } else {
         pushEvent({ kind: 'status', label: 'requesting', detail: config.model });
@@ -728,6 +736,7 @@ export function ProjectView({
             daemonLive={daemonLive}
             onModeChange={onModeChange}
             onAgentChange={onAgentChange}
+            onAgentModelChange={onAgentModelChange}
             onOpenSettings={onOpenSettings}
             onRefreshAgents={onRefreshAgents}
             onBack={onBack}

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -2,6 +2,11 @@ import { useEffect, useMemo, useState } from 'react';
 import { LOCALE_LABEL, LOCALES, useI18n } from '../i18n';
 import type { Locale } from '../i18n';
 import { AgentIcon } from './AgentIcon';
+import {
+  CUSTOM_MODEL_SENTINEL,
+  isCustomModel,
+  renderModelOptions,
+} from './modelOptions';
 import type { AgentInfo, AppConfig, ExecMode } from '../types';
 
 interface Props {
@@ -214,6 +219,11 @@ export function SettingsDialog({
               const reasoningValue =
                 choice.reasoning ??
                 selected.reasoningOptions?.[0]?.id ?? '';
+              const customActive =
+                hasModels && isCustomModel(modelValue, selected.models!);
+              const selectValue = customActive
+                ? CUSTOM_MODEL_SENTINEL
+                : modelValue;
               return (
                 <div className="agent-model-row">
                   {hasModels ? (
@@ -222,15 +232,39 @@ export function SettingsDialog({
                         {t('settings.modelPicker')}
                       </span>
                       <select
-                        value={modelValue}
-                        onChange={(e) => setChoice({ model: e.target.value })}
+                        value={selectValue}
+                        onChange={(e) => {
+                          if (e.target.value === CUSTOM_MODEL_SENTINEL) {
+                            // Switching to "Custom…" should clear the
+                            // value so the input below opens empty for
+                            // typing — keeping the previous live id
+                            // would defeat the point.
+                            setChoice({ model: '' });
+                          } else {
+                            setChoice({ model: e.target.value });
+                          }
+                        }}
                       >
-                        {selected.models!.map((m) => (
-                          <option key={m.id} value={m.id}>
-                            {m.label}
-                          </option>
-                        ))}
+                        {renderModelOptions(selected.models!)}
+                        <option value={CUSTOM_MODEL_SENTINEL}>
+                          {t('settings.modelCustom')}
+                        </option>
                       </select>
+                    </label>
+                  ) : null}
+                  {customActive ? (
+                    <label className="field">
+                      <span className="field-label">
+                        {t('settings.modelCustomLabel')}
+                      </span>
+                      <input
+                        type="text"
+                        value={modelValue}
+                        placeholder={t('settings.modelCustomPlaceholder')}
+                        onChange={(e) =>
+                          setChoice({ model: e.target.value.trim() })
+                        }
+                      />
                     </label>
                   ) : null}
                   {hasReasoning ? (

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -183,6 +183,79 @@ export function SettingsDialog({
                 })}
               </div>
             )}
+            {(() => {
+              const selected = agents.find(
+                (a) => a.id === cfg.agentId && a.available,
+              );
+              if (!selected) return null;
+              const hasModels =
+                Array.isArray(selected.models) && selected.models.length > 0;
+              const hasReasoning =
+                Array.isArray(selected.reasoningOptions) &&
+                selected.reasoningOptions.length > 0;
+              if (!hasModels && !hasReasoning) return null;
+              const choice = cfg.agentModels?.[selected.id] ?? {};
+              const setChoice = (
+                next: { model?: string; reasoning?: string },
+              ) => {
+                setCfg((c) => {
+                  const prev = c.agentModels?.[selected.id] ?? {};
+                  return {
+                    ...c,
+                    agentModels: {
+                      ...(c.agentModels ?? {}),
+                      [selected.id]: { ...prev, ...next },
+                    },
+                  };
+                });
+              };
+              const modelValue =
+                choice.model ?? selected.models?.[0]?.id ?? '';
+              const reasoningValue =
+                choice.reasoning ??
+                selected.reasoningOptions?.[0]?.id ?? '';
+              return (
+                <div className="agent-model-row">
+                  {hasModels ? (
+                    <label className="field">
+                      <span className="field-label">
+                        {t('settings.modelPicker')}
+                      </span>
+                      <select
+                        value={modelValue}
+                        onChange={(e) => setChoice({ model: e.target.value })}
+                      >
+                        {selected.models!.map((m) => (
+                          <option key={m.id} value={m.id}>
+                            {m.label}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  ) : null}
+                  {hasReasoning ? (
+                    <label className="field">
+                      <span className="field-label">
+                        {t('settings.reasoningPicker')}
+                      </span>
+                      <select
+                        value={reasoningValue}
+                        onChange={(e) =>
+                          setChoice({ reasoning: e.target.value })
+                        }
+                      >
+                        {selected.reasoningOptions!.map((r) => (
+                          <option key={r.id} value={r.id}>
+                            {r.label}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  ) : null}
+                  <p className="hint">{t('settings.modelPickerHint')}</p>
+                </div>
+              );
+            })()}
           </section>
         ) : (
           <section className="settings-section">

--- a/src/components/modelOptions.tsx
+++ b/src/components/modelOptions.tsx
@@ -1,0 +1,71 @@
+import type { AgentModelOption } from '../types';
+
+// Render the `<option>` children for a model `<select>`. When the list
+// contains `provider/model` ids (opencode's listing has hundreds), we
+// group them under `<optgroup>` so the dropdown is navigable. Flat lists
+// (Claude, Codex, Gemini, Qwen) are emitted as plain options.
+//
+// `'default'` is always pinned first (no group), so the user can return
+// to "let the CLI decide" with one click.
+export function renderModelOptions(models: AgentModelOption[]) {
+  const groups = new Map<string, AgentModelOption[]>();
+  const flat: AgentModelOption[] = [];
+  for (const m of models) {
+    const slash = m.id.indexOf('/');
+    if (m.id === 'default' || slash <= 0) {
+      flat.push(m);
+      continue;
+    }
+    const provider = m.id.slice(0, slash);
+    const arr = groups.get(provider) ?? [];
+    arr.push(m);
+    groups.set(provider, arr);
+  }
+  if (groups.size === 0) {
+    return (
+      <>
+        {flat.map((m) => (
+          <option key={m.id} value={m.id}>
+            {m.label}
+          </option>
+        ))}
+      </>
+    );
+  }
+  return (
+    <>
+      {flat.map((m) => (
+        <option key={m.id} value={m.id}>
+          {m.label}
+        </option>
+      ))}
+      {Array.from(groups.entries()).map(([provider, items]) => (
+        <optgroup key={provider} label={provider}>
+          {items.map((m) => (
+            <option key={m.id} value={m.id}>
+              {/* Strip the redundant `provider/` prefix from the label
+                  inside its own optgroup; keep it in the value so the
+                  CLI sees the fully-qualified id. */}
+              {m.label.startsWith(`${provider}/`)
+                ? m.label.slice(provider.length + 1)
+                : m.label}
+            </option>
+          ))}
+        </optgroup>
+      ))}
+    </>
+  );
+}
+
+// True when the picked model id isn't one of the listed options — i.e.
+// the user has typed a custom id and we should keep the custom input
+// visible / the dropdown showing "Custom…".
+export function isCustomModel(
+  modelId: string | null | undefined,
+  models: AgentModelOption[],
+): boolean {
+  if (!modelId) return false;
+  return !models.some((m) => m.id === modelId);
+}
+
+export const CUSTOM_MODEL_SENTINEL = '__custom__';

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -86,7 +86,10 @@ export const en: Dict = {
   'settings.modelPicker': 'Model',
   'settings.reasoningPicker': 'Reasoning effort',
   'settings.modelPickerHint':
-    'Picked per CLI. "Default" leaves the choice to the CLI’s own config.',
+    'Fetched from the CLI when it exposes a `models` command. "Default" leaves the choice to the CLI’s own config; "Custom…" lets you type any model id the CLI accepts.',
+  'settings.modelCustom': 'Custom (type below)…',
+  'settings.modelCustomLabel': 'Custom model id',
+  'settings.modelCustomPlaceholder': 'e.g. anthropic/claude-sonnet-4-6',
 
   'entry.tabDesigns': 'Designs',
   'entry.tabExamples': 'Examples',
@@ -218,6 +221,7 @@ export const en: Dict = {
   'avatar.modelSection': 'Model',
   'avatar.modelLabel': 'Model',
   'avatar.reasoningLabel': 'Reasoning',
+  'avatar.customSuffix': '(custom)',
 
   'project.backToProjects': 'Back to projects',
   'project.metaFreeform': 'freeform',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -83,6 +83,10 @@ export const en: Dict = {
   'settings.noAgentSelected': 'no agent selected',
   'settings.language': 'Language',
   'settings.languageHint': 'Switch the interface language. Saved to this browser.',
+  'settings.modelPicker': 'Model',
+  'settings.reasoningPicker': 'Reasoning effort',
+  'settings.modelPickerHint':
+    'Picked per CLI. "Default" leaves the choice to the CLI’s own config.',
 
   'entry.tabDesigns': 'Designs',
   'entry.tabExamples': 'Examples',
@@ -211,6 +215,9 @@ export const en: Dict = {
   'avatar.metaOffline': 'offline',
   'avatar.metaSelected': 'selected',
   'avatar.noAgentSelected': 'no agent selected',
+  'avatar.modelSection': 'Model',
+  'avatar.modelLabel': 'Model',
+  'avatar.reasoningLabel': 'Reasoning',
 
   'project.backToProjects': 'Back to projects',
   'project.metaFreeform': 'freeform',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -84,7 +84,11 @@ export const zhCN: Dict = {
   'settings.languageHint': '切换界面语言，设置仅保存在当前浏览器。',
   'settings.modelPicker': '模型',
   'settings.reasoningPicker': '推理强度',
-  'settings.modelPickerHint': '按 CLI 单独保存。选择「默认」则沿用 CLI 自身的配置。',
+  'settings.modelPickerHint':
+    '当 CLI 提供 `models` 命令时会自动拉取。选择「默认」则沿用 CLI 自身的配置；选择「自定义」可手动输入任何 CLI 支持的模型 id。',
+  'settings.modelCustom': '自定义（在下方填写）…',
+  'settings.modelCustomLabel': '自定义模型 id',
+  'settings.modelCustomPlaceholder': '例如 anthropic/claude-sonnet-4-6',
 
   'entry.tabDesigns': '我的设计',
   'entry.tabExamples': '示例',
@@ -214,6 +218,7 @@ export const zhCN: Dict = {
   'avatar.modelSection': '模型',
   'avatar.modelLabel': '模型',
   'avatar.reasoningLabel': '推理',
+  'avatar.customSuffix': '（自定义）',
 
   'project.backToProjects': '返回项目列表',
   'project.metaFreeform': '自由设计',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -82,6 +82,9 @@ export const zhCN: Dict = {
   'settings.noAgentSelected': '尚未选择代理',
   'settings.language': '界面语言',
   'settings.languageHint': '切换界面语言，设置仅保存在当前浏览器。',
+  'settings.modelPicker': '模型',
+  'settings.reasoningPicker': '推理强度',
+  'settings.modelPickerHint': '按 CLI 单独保存。选择「默认」则沿用 CLI 自身的配置。',
 
   'entry.tabDesigns': '我的设计',
   'entry.tabExamples': '示例',
@@ -208,6 +211,9 @@ export const zhCN: Dict = {
   'avatar.metaOffline': '未运行',
   'avatar.metaSelected': '已选',
   'avatar.noAgentSelected': '尚未选择代理',
+  'avatar.modelSection': '模型',
+  'avatar.modelLabel': '模型',
+  'avatar.reasoningLabel': '推理',
 
   'project.backToProjects': '返回项目列表',
   'project.metaFreeform': '自由设计',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -96,6 +96,9 @@ export interface Dict {
   'settings.modelPicker': string;
   'settings.reasoningPicker': string;
   'settings.modelPickerHint': string;
+  'settings.modelCustom': string;
+  'settings.modelCustomLabel': string;
+  'settings.modelCustomPlaceholder': string;
 
   // Entry view / tabs
   'entry.tabDesigns': string;
@@ -230,6 +233,7 @@ export interface Dict {
   'avatar.modelSection': string;
   'avatar.modelLabel': string;
   'avatar.reasoningLabel': string;
+  'avatar.customSuffix': string;
 
   // Project view / chat pane / composer
   'project.backToProjects': string;

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -93,6 +93,9 @@ export interface Dict {
   'settings.noAgentSelected': string;
   'settings.language': string;
   'settings.languageHint': string;
+  'settings.modelPicker': string;
+  'settings.reasoningPicker': string;
+  'settings.modelPickerHint': string;
 
   // Entry view / tabs
   'entry.tabDesigns': string;
@@ -224,6 +227,9 @@ export interface Dict {
   'avatar.metaOffline': string;
   'avatar.metaSelected': string;
   'avatar.noAgentSelected': string;
+  'avatar.modelSection': string;
+  'avatar.modelLabel': string;
+  'avatar.reasoningLabel': string;
 
   // Project view / chat pane / composer
   'project.backToProjects': string;

--- a/src/index.css
+++ b/src/index.css
@@ -293,6 +293,45 @@ code {
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
+.avatar-section-label {
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-faint);
+  font-weight: 600;
+  padding: 8px 10px 4px;
+}
+.avatar-model-section {
+  padding: 2px 10px 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  border-top: 1px dashed var(--border-soft);
+  margin-top: 4px;
+}
+.avatar-select-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.avatar-select-label {
+  flex-shrink: 0;
+  min-width: 64px;
+}
+.avatar-select {
+  flex: 1;
+  min-width: 0;
+  font-size: 12px;
+  padding: 4px 6px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--bg-panel);
+  color: var(--text);
+  cursor: pointer;
+}
+.avatar-select:focus { outline: 2px solid var(--accent-soft, var(--border-strong)); }
 
 /* Environment pill — only used in entry view header now */
 .env-pill {
@@ -827,6 +866,23 @@ code {
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
 .agent-card-meta .muted { color: var(--text-soft); font-style: italic; }
+.agent-model-row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-sm);
+  background: var(--bg-subtle);
+}
+.agent-model-row .field { gap: 4px; }
+.agent-model-row .field-label {
+  font-size: 11.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+.agent-model-row .hint { margin: 0; font-size: 11.5px; }
 .status-dot {
   width: 8px; height: 8px;
   border-radius: 50%;

--- a/src/providers/daemon.ts
+++ b/src/providers/daemon.ts
@@ -30,6 +30,11 @@ export interface DaemonStreamOptions {
   // daemon resolves them inside the project folder, validates they
   // exist, and stitches them into the user message as `@<path>` hints.
   attachments?: string[];
+  // Per-CLI model + reasoning the user picked in the model menu. Both are
+  // optional; the daemon validates them against the agent's declared
+  // options and falls back to the CLI default when missing.
+  model?: string | null;
+  reasoning?: string | null;
 }
 
 export async function streamViaDaemon({
@@ -40,6 +45,8 @@ export async function streamViaDaemon({
   handlers,
   projectId,
   attachments,
+  model,
+  reasoning,
 }: DaemonStreamOptions): Promise<void> {
   // Local CLIs are single-turn print-mode programs, so we collapse the whole
   // chat into one string. If this becomes too noisy for long histories, the
@@ -53,6 +60,8 @@ export async function streamViaDaemon({
     message: transcript,
     projectId: projectId ?? null,
     attachments: attachments ?? [],
+    model: model ?? null,
+    reasoning: reasoning ?? null,
   });
 
   let acc = '';

--- a/src/state/config.ts
+++ b/src/state/config.ts
@@ -11,6 +11,7 @@ export const DEFAULT_CONFIG: AppConfig = {
   skillId: null,
   designSystemId: null,
   onboardingCompleted: false,
+  agentModels: {},
 };
 
 export function loadConfig(): AppConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,14 @@
 export type ExecMode = 'daemon' | 'api';
 
+// Per-CLI model + reasoning the user picked in the model menu. Each agent
+// keeps its own slot so flipping between Codex and Gemini doesn't reset the
+// other one's choice. Missing entries fall back to the agent's first
+// declared model (`'default'` — let the CLI pick).
+export interface AgentModelChoice {
+  model?: string;
+  reasoning?: string;
+}
+
 export interface AppConfig {
   mode: ExecMode;
   apiKey: string;
@@ -12,6 +21,10 @@ export interface AppConfig {
   // least once (saved or skipped). Bootstrap skips the auto-popup when
   // this is set so refreshing the page doesn't re-prompt.
   onboardingCompleted?: boolean;
+  // Per-CLI model picker state, keyed by agent id (e.g. `gemini`, `codex`).
+  // Pre-existing configs without this field fall through to the agent's
+  // declared default.
+  agentModels?: Record<string, AgentModelChoice>;
 }
 
 export type AgentEvent =
@@ -63,6 +76,11 @@ export interface ExamplePreview {
   html: string;
 }
 
+export interface AgentModelOption {
+  id: string;
+  label: string;
+}
+
 export interface AgentInfo {
   id: string;
   name: string;
@@ -70,6 +88,12 @@ export interface AgentInfo {
   available: boolean;
   path?: string;
   version?: string | null;
+  // Models surfaced in the model picker for this CLI. The first entry is
+  // treated as the default (typically the synthetic `'default'` option,
+  // meaning "let the CLI use whatever's in its own config").
+  models?: AgentModelOption[];
+  // Reasoning-effort presets — currently only Codex exposes this.
+  reasoningOptions?: AgentModelOption[];
 }
 
 export interface SkillSummary {


### PR DESCRIPTION
## Summary
- Each agent CLI in `daemon/agents.js` declares an optional `listModels` spec; the daemon runs the CLI's own list-models command (`opencode models`, `cursor-agent models`) during agent detection and uses the live result as the dropdown options.
- `fallbackModels` is a small hint list used only when the CLI has no listing command (Claude Code, Codex, Gemini CLI, Qwen Code) or when the listing fails (e.g. unauth'd cursor-agent prints `No models available for this account.`).
- Frontend renders the model picker scoped to the currently selected CLI in two places — the **avatar menu** (project topbar) for fast switching, and the **Settings dialog → Code agent section** for first-run discovery + custom model entry. The choice is persisted per-agent in `AppConfig.agentModels`.
- Codex also exposes a `Reasoning effort` picker (minimal/low/medium/high) since it accepts `-c model_reasoning_effort=...`.
- `provider/model` ids are grouped under `<optgroup>` so opencode's ~175 live models stay navigable.
- Closes #8.

## Per-CLI listing strategy
| CLI            | Live source                | Fallback                                                      |
| -------------- | -------------------------- | ------------------------------------------------------------- |
| Claude Code    | (no `models` command)      | `sonnet` / `opus` / `haiku` aliases + `claude-*-4-5` ids       |
| Codex          | (no `models` command)      | `gpt-5-codex`, `gpt-5`, `o3`, `o4-mini`                        |
| Gemini CLI     | (no `models` command)      | `gemini-2.5-pro`, `gemini-2.5-flash`                           |
| OpenCode       | `opencode models`          | `anthropic/claude-sonnet-4-5`, `openai/gpt-5`, …               |
| Cursor Agent   | `cursor-agent models`      | `auto`, `sonnet-4`, `sonnet-4-thinking`, `gpt-5`               |
| Qwen Code      | (no `models` command)      | `qwen3-coder-plus`, `qwen3-coder-flash`                        |

For everything else the Settings dialog has a **Custom…** entry that opens a free-text input. Server-side sanitizer accepts any `[A-Za-z0-9._/:@-]+` id that doesn't start with a dash.

## Per-CLI flags wired
- **Claude Code** — `--model <id>`
- **Codex** — `--model <id>` + `-c model_reasoning_effort="<minimal|low|medium|high>"`
- **Gemini CLI** — `--model <id>`
- **OpenCode** — `--model <provider/model>`
- **Cursor Agent** — `--model <id>`
- **Qwen Code** — `--model <id>`

`'default'` leaves the flag off so the CLI's own config wins.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vite build` clean
- [x] Daemon `/api/agents` returns 175 live models for opencode (live `opencode models` parsed)
- [x] cursor-agent (unauth'd) falls back to the static hint
- [x] Validation: live ids and fallback ids both accepted; custom ids accepted via sanitizer
- [ ] Manual: open avatar menu → switch agent → pick a model → send a chat turn
- [ ] Manual: Settings → Custom… → type a model id → run a turn
- [ ] Manual: Codex reasoning effort dropdown sends `-c model_reasoning_effort="..."`