### PR TITLE
fix(guizang-ppt): sync host slide counter on transform-paginated decks

### DIFF
--- a/skills/guizang-ppt/assets/template.html
+++ b/skills/guizang-ppt/assets/template.html
@@ -565,6 +565,7 @@ function go(n){
   if(lock)return;
   idx=Math.max(0,Math.min(total-1,n));
   deck.style.transform=`translateX(${-idx*100}vw)`;
+  slides.forEach((s,i)=>s.classList.toggle('active',i===idx));
   nav.querySelectorAll('.dot').forEach((d,i)=>d.classList.toggle('active',i===idx));
   /* 主题切换：优先读 data-theme，其次从 class（light/dark）推断 */
   const el=slides[idx];

--- a/skills/guizang-ppt/assets/template.html
+++ b/skills/guizang-ppt/assets/template.html
@@ -565,6 +565,9 @@ function go(n){
   if(lock)return;
   idx=Math.max(0,Math.min(total-1,n));
   deck.style.transform=`translateX(${-idx*100}vw)`;
+  /* load-bearing: .slide.active is read by Open Design's host bridge
+     (src/runtime/srcdoc.ts findActiveByClass) to drive the slide counter.
+     No CSS targets it — do not remove. */
   slides.forEach((s,i)=>s.classList.toggle('active',i===idx));
   nav.querySelectorAll('.dot').forEach((d,i)=>d.classList.toggle('active',i===idx));
   /* 主题切换：优先读 data-theme，其次从 class（light/dark）推断 */


### PR DESCRIPTION
Fixes #18 

## Summary

The host deck counter could stay stuck at `1 / N` for decks generated from the `guizang-ppt` template, even though the deck itself advanced correctly.

The template moves between slides by translating the shared `#deck` container and updating `#nav .dot.active`, but it did not mark the active `.slide`. The iframe bridge in `src/runtime/srcdoc.ts` already knows how to report slide state from `.slide.active`, so the host kept receiving `active: 0`.

This PR updates the source template, not generated `.od/projects/...` output:

- `skills/guizang-ppt/assets/template.html` now toggles `.slide.active` inside `go(n)`.
- The existing deck transform navigation, nav dots, theme switching, and keyboard/wheel/touch behavior are unchanged.
- No runtime bridge changes are needed.

## Test plan

- [x] `npm run typecheck` passes.
- [x] `npm run build` passes.
- [x] Confirm generated `guizang-ppt` decks now update `.slide.active` when `go(n)` runs.
