### PR TITLE
chore: add release beta workflow placeholder

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -1,0 +1,17 @@
+name: release-beta
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  placeholder:
+    name: Release beta placeholder
+    runs-on: ubuntu-latest
+    steps:
+      - name: Note pending release-beta implementation
+        run: |
+          echo "release-beta workflow placeholder"
+          echo "TODO: wire build, packaging, e2e, and beta publishing after release boundaries are defined."

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ tsconfig.tsbuildinfo
 .claude-sessions/*
 
 .cursor/*
+
+# Commander task scratchpad; keep local task notes out of git by default.
+.task/


### PR DESCRIPTION
## Summary
- Add a manual-only `release-beta` GitHub Actions workflow placeholder with read-only permissions and no publishing side effects.
- Keep `.task/` ignored so local long-running task notes stay out of git by default.

## Validation
- `git diff --cached --check` passed before commit.