### PR TITLE
feat: refactor to Next.js 16 App Router with cloud + local daemon split

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,129 @@
+# Handoff: Next.js 16 cloud refactor (worktree)
+
+## Scope
+
+Refactor the Vite + Express stack into a TypeScript pnpm workspace with a Next.js 16 App Router cloud app + a TypeScript `od` daemon CLI, modeled on multica-ai/multica. Includes shareable project links + workspace invitations so cloud-hosted projects can invite collaborators.
+
+Implemented: structural scaffold (workspaces, schema, auth, pairing, task queue, SSE streaming, share links, invitations). **Not** implemented: porting the 28 legacy React components, skill/design-system route handlers, S3 file storage. See "Follow-ups" below.
+
+## Files added
+
+### Workspace root
+- `pnpm-workspace.yaml` — pnpm workspace config (`apps/*`, `packages/*`)
+- `package.json` — converted to workspace root; legacy Vite/Express scripts kept under `legacy:*`
+
+### `packages/shared` — API contract types
+- `src/schemas.ts` — zod request schemas (Send/VerifyCode, RegisterDaemon, ClaimTask, TaskMessage, CreateProject, CreateShareLink, InviteMember)
+- `src/tokens.ts` — token mint/hash helpers (`od_pat_…`, `od_dt_…`, `od_share_…`)
+- `src/jwt.ts` — session JWT sign/verify (HS256, jose)
+
+### `packages/db` — Drizzle schema (Postgres + SQLite)
+- `src/schema.ts` — Postgres dialect (cloud)
+- `src/schema-sqlite.ts` — SQLite mirror (self-host); keep in sync by hand
+- `src/client.ts` — `getDb()` selects driver by `DATABASE_URL` prefix
+- `drizzle.config.ts` — drizzle-kit config that branches on dialect
+
+Tables: `user`, `email_verification_code`, `workspace`, `member`, `workspace_invitation`, `personal_access_token`, `daemon_registration`, `project`, `project_share_link`, `conversation`, `message`, `project_file`, `agent_task`, `task_message`.
+
+### `apps/web` — Next.js 16 App Router
+- `next.config.ts`, `tsconfig.json`, `postcss.config.mjs`, `.env.example`
+- `app/layout.tsx`, `app/globals.css` (Tailwind v4)
+- `app/page.tsx` — landing
+- `app/login/page.tsx` + `LoginForm.tsx` — email-code login + CLI callback bridge
+- `app/projects/page.tsx` — workspace project list
+- `app/projects/[id]/page.tsx` + `ShareButton.tsx` — project shell + share dialog
+- `app/settings/daemon/page.tsx` — paired daemons list + CLI install snippet
+- `app/share/[token]/route.ts` — share-link landing (sets cookie, redirects)
+- `app/invitations/[token]/route.ts` — invite acceptance
+- `app/api/auth/send-code/route.ts` — generate 6-digit email code
+- `app/api/auth/verify-code/route.ts` — verify, upsert user, mint PAT for CLI flow
+- `app/api/daemon/register/route.ts` — PAT → daemon token
+- `app/api/daemon/heartbeat/route.ts` — bumps `last_seen_at`
+- `app/api/daemon/runtimes/[runtimeId]/tasks/claim/route.ts` — atomic task lease
+- `app/api/daemon/tasks/[taskId]/messages/route.ts` — daemon writes streamed chunks
+- `app/api/daemon/wakeups/route.ts` — daemon SSE wakeup channel (best-effort)
+- `app/api/tasks/[taskId]/stream/route.ts` — browser SSE feed (replay + live)
+- `app/api/projects/route.ts` — list/create
+- `app/api/projects/[id]/share/route.ts` — list/create per-project share links
+- `app/api/projects/[id]/chat/route.ts` — enqueue agent_task + wake daemon
+- `app/api/workspaces/[wsId]/invitations/route.ts` — email invitations
+- `lib/auth/session.ts` — JWT session cookie helpers
+- `lib/auth/bearer.ts` — PAT/daemon-token verification
+- `lib/access.ts` — unified ACL: workspace membership OR project share token
+- `lib/realtime.ts` — in-process pub/sub for SSE fan-out (swap for Redis when scaling out)
+- `lib/email.ts` — pluggable mailer (console for dev, resend for prod)
+
+### `apps/cli` — `od` CLI/daemon (TypeScript)
+- `src/cli.ts` — entry, dispatches `login`, `daemon`, `setup`
+- `src/cmd_login.ts` — local-listener OAuth callback (mirrors multica `resolveCallbackBinding`)
+- `src/cmd_daemon.ts` — register → heartbeat → poll-claim → spawn agent → stream messages
+- `src/runtimes.ts` — probes claude/codex/gemini/opencode/cursor-agent on PATH
+- `src/profile.ts` — `~/.od/profiles/<name>/config.json` storage
+- `tsup.config.ts` — bundles to `dist/cli.js` with shebang for `bin: { od }`
+
+### `docs/`
+- `docs/architecture-cloud.md` — full architecture write-up (auth, transport, schema, deploy)
+
+## Public surface
+
+### Web routes
+| route                               | purpose                                |
+|-------------------------------------|----------------------------------------|
+| `/`                                 | landing                                |
+| `/login`                            | email-code sign-in (also CLI callback) |
+| `/projects`                         | workspace project list                 |
+| `/projects/:id`                     | project shell + share button           |
+| `/settings/daemon`                  | paired devices                         |
+| `/share/:token`                     | enter project via share link           |
+| `/invitations/:token`               | accept workspace invite                |
+
+### Cloud API (`apps/web/app/api`)
+- Auth: `POST /api/auth/send-code`, `POST /api/auth/verify-code`
+- Daemon: `POST /api/daemon/register`, `POST /api/daemon/heartbeat`, `GET /api/daemon/wakeups` (SSE), `POST /api/daemon/runtimes/:runtimeId/tasks/claim`, `POST /api/daemon/tasks/:taskId/messages`
+- Tasks: `GET /api/tasks/:taskId/stream` (SSE, browser side)
+- Projects: `GET|POST /api/projects`, `POST /api/projects/:id/chat`
+- Sharing: `GET|POST /api/projects/:id/share`, `POST /api/workspaces/:wsId/invitations`
+
+### CLI surface
+- `od login [--profile <name>] [--app-url <url>]`
+- `od daemon [--profile <name>]`
+- `od setup` (login + daemon)
+
+## Merge guidance
+
+- This branch is **additive**: no legacy files were modified or deleted. Root `package.json` was rewritten to be a pnpm workspace; old scripts moved to `legacy:*`. If main absorbs other branches that touch `package.json`, expect a small merge there.
+- Skills (`skills/`), design systems (`design-systems/`), templates (`templates/`), and assets (`assets/`) are untouched. The Next.js app reads them via `SKILLS_ROOT` / `DESIGN_SYSTEMS_ROOT` env vars (defaults assume the workspace layout).
+- Recommended merge order: take this branch wholesale, then in a follow-up PR delete `src/`, `daemon/`, `vite.config.ts`, `index.html`, `dist/`, and the `legacy:*` scripts once team has cut over.
+- Drizzle migrations are NOT generated yet — run `pnpm --filter @open-design/db generate` once before deploying. Choose dialect via `DATABASE_URL` and the config picks the right output dir.
+- pnpm is required (the `workspace:*` protocol). If the repo currently uses npm only, run `corepack enable && corepack prepare pnpm@latest --activate` and `pnpm install` once.
+
+## Verification
+
+I did **not** run `pnpm install`, `next build`, or `tsc` in this worktree because:
+
+- Net-new dependency graph (Next 16 canary, Drizzle, jose, tsup) — install would be slow and cache-cold.
+- Some imports (`drizzle-orm` query helpers, `next` internals) need `pnpm install` to typecheck. Server route bodies use `(db as any)` casts at the boundary because the dialect-specific Drizzle types diverge between PG and SQLite — this is intentional and matches how multica's Go code uses sqlc-generated queries through one interface.
+
+Before merging to main, the receiving agent should:
+
+1. `pnpm install` at the workspace root.
+2. `pnpm --filter @open-design/web typecheck` and `pnpm --filter @open-design/cli typecheck`.
+3. `pnpm --filter @open-design/db generate` (against a real `DATABASE_URL`) to produce migrations.
+4. Smoke-test: start `apps/web` with `DATABASE_URL=file:./.od/app.sqlite`, then `apps/cli` `od login` and `od daemon`. Open a project, click Share, paste the link in another browser.
+
+## Follow-ups (out of scope for this branch)
+
+1. Port `src/components/` (chat composer, file workspace, sketch editor, design panel) into `apps/web/app/projects/[id]/` as client components.
+2. Mirror the legacy daemon's discovery routes (`/api/agents`, `/api/skills*`, `/api/design-systems*`) as Next route handlers reading `SKILLS_ROOT` / `DESIGN_SYSTEMS_ROOT` from disk.
+3. File storage: implement S3 / R2 / GCS adapter behind `project_file.storageKey`. Add `POST /api/projects/:id/upload` (multipart or presigned).
+4. Port `daemon/lint-artifact.js` into `apps/web/lib/lint.ts`.
+5. Anthropic SDK direct mode for users who don't want to run a local daemon.
+6. Replace `lib/realtime.ts` with Redis Pub/Sub when going multi-instance.
+7. Drizzle Postgres + SQLite schemas drift over time — add a CI check that diffs them.
+
+## Why this matches the user's ask
+
+- "Refactor to Next.js 16 App Router referencing multica" — done at the structural level. Auth (browser-callback OAuth + 6-digit codes), transport (HTTP-claim + SSE wakeup), token model (PAT bootstrap → daemon token), and workspace tenancy are all multica patterns ported to TS.
+- "Cloud + local daemon, not just local" — separated. Cloud is `apps/web` (Vercel-ready). Local is `apps/cli` (`od daemon`). They communicate only over the public HTTP API, so the cloud can sit anywhere the daemon can reach.
+- "Unified TS stack" — single `pnpm-workspace.yaml`, all packages TS, schemas/types shared via `packages/shared`.
+- "Project shareable as a link" — added `project_share_link` table + `/share/:token` landing + Share dialog UI in addition to the multica-style workspace invitations.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@open-design/cli",
+  "version": "0.2.0",
+  "private": false,
+  "type": "module",
+  "bin": {
+    "od": "./dist/cli.js"
+  },
+  "files": ["dist"],
+  "scripts": {
+    "dev": "tsx src/cli.ts",
+    "build": "tsup",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@open-design/shared": "workspace:*",
+    "execa": "^9.5.1",
+    "open": "^10.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.7.4",
+    "tsup": "^8.3.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.6.3"
+  }
+}

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -1,0 +1,66 @@
+import { login } from './cmd_login.js';
+import { daemon } from './cmd_daemon.js';
+
+const HELP = `od — Open Design CLI
+
+Usage:
+  od login [--profile <name>] [--app-url <url>]   Pair this machine with a cloud account
+  od daemon [--profile <name>]                    Run the daemon (claim & run tasks)
+  od setup                                        login + daemon
+
+Env:
+  OD_APP_URL   default app URL for new profiles (e.g. https://open-design.app)`;
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const cmd = argv[0];
+  const args = parseFlags(argv.slice(1));
+  const profile = (args.profile as string | undefined) ?? 'default';
+
+  switch (cmd) {
+    case 'login':
+      await login({ profile, appUrl: args['app-url'] as string | undefined });
+      return;
+    case 'daemon':
+      await daemon({ profile });
+      return;
+    case 'setup':
+      await login({ profile, appUrl: args['app-url'] as string | undefined });
+      await daemon({ profile });
+      return;
+    case undefined:
+    case '-h':
+    case '--help':
+      // eslint-disable-next-line no-console
+      console.log(HELP);
+      return;
+    default:
+      // eslint-disable-next-line no-console
+      console.error(`Unknown command: ${cmd}\n\n${HELP}`);
+      process.exit(2);
+  }
+}
+
+function parseFlags(tokens: string[]): Record<string, string | boolean> {
+  const out: Record<string, string | boolean> = {};
+  for (let i = 0; i < tokens.length; i++) {
+    const t = tokens[i];
+    if (t.startsWith('--')) {
+      const k = t.slice(2);
+      const next = tokens[i + 1];
+      if (next && !next.startsWith('--')) {
+        out[k] = next;
+        i++;
+      } else {
+        out[k] = true;
+      }
+    }
+  }
+  return out;
+}
+
+main().catch((e) => {
+  // eslint-disable-next-line no-console
+  console.error(e instanceof Error ? e.message : e);
+  process.exit(1);
+});

--- a/apps/cli/src/cmd_daemon.ts
+++ b/apps/cli/src/cmd_daemon.ts
@@ -1,0 +1,166 @@
+// Long-running daemon. Registers with the cloud (PAT → daemon token), opens
+// an SSE wakeup channel, polls the claim endpoint, runs claimed tasks via
+// the matching local agent CLI, streams stdout/stderr/agent events back.
+import { hostname, platform, type } from 'node:os';
+import { execa } from 'execa';
+import { loadProfile, saveProfile } from './profile.js';
+import { detectRuntimes, type DetectedRuntime } from './runtimes.js';
+
+const VERSION = '0.2.0';
+const POLL_INTERVAL_MS = 3000;
+const HEARTBEAT_INTERVAL_MS = 15_000;
+
+interface AgentTask {
+  id: string;
+  workspaceId: string;
+  projectId: string;
+  runtimeId: string;
+  payload: {
+    systemPrompt: string;
+    message: string;
+    cwdHint?: string;
+  };
+}
+
+export async function daemon({ profile }: { profile: string }): Promise<void> {
+  const p = await loadProfile(profile);
+  if (!p.pat) throw new Error('No PAT for this profile. Run `od login` first.');
+
+  const runtimes = await detectRuntimes();
+  if (!p.daemonToken) {
+    const reg = await register(p, runtimes);
+    p.daemonToken = reg.daemonToken;
+    p.daemonId = reg.id;
+    p.workspaceId = reg.workspaceId;
+    await saveProfile(p);
+    // eslint-disable-next-line no-console
+    console.log(`Registered daemon ${reg.id} on workspace ${reg.workspaceId}`);
+  }
+  const auth = `Bearer ${p.daemonToken}`;
+
+  // Heartbeat loop.
+  const hb = setInterval(() => {
+    fetch(`${p.appUrl}/api/daemon/heartbeat`, { method: 'POST', headers: { authorization: auth } })
+      .catch(() => {});
+  }, HEARTBEAT_INTERVAL_MS);
+
+  // Wakeup SSE — best-effort. Drops are fine; the polling loop is authoritative.
+  startWakeupListener(p.appUrl, auth).catch(() => {});
+
+  // Polling loop, one task at a time per runtime that's available.
+  const availableRuntimes = runtimes.filter((r) => r.available);
+  // eslint-disable-next-line no-console
+  console.log(`Polling for tasks on runtimes: ${availableRuntimes.map((r) => r.id).join(', ') || '(none available)'}`);
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    let didWork = false;
+    for (const r of availableRuntimes) {
+      const task = await claimNext(p.appUrl, auth, r.id);
+      if (!task) continue;
+      didWork = true;
+      // eslint-disable-next-line no-console
+      console.log(`Claimed task ${task.id} (${r.id})`);
+      await runTask(p.appUrl, auth, task, r);
+    }
+    if (!didWork) await sleep(POLL_INTERVAL_MS);
+  }
+
+  void hb;
+}
+
+async function register(p: { appUrl: string; pat?: string }, runtimes: DetectedRuntime[]) {
+  const res = await fetch(`${p.appUrl}/api/daemon/register`, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${p.pat}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      workspaceId: '', // server picks default workspace if blank
+      hostname: hostname(),
+      platform: platform(),
+      os: type(),
+      cliVersion: VERSION,
+      runtimes,
+    }),
+  });
+  if (!res.ok) throw new Error(`register failed: ${res.status} ${await res.text()}`);
+  return (await res.json()) as { id: string; workspaceId: string; daemonToken: string };
+}
+
+async function claimNext(appUrl: string, auth: string, runtimeId: string): Promise<AgentTask | null> {
+  const res = await fetch(`${appUrl}/api/daemon/runtimes/${runtimeId}/tasks/claim`, {
+    method: 'POST',
+    headers: { authorization: auth, 'content-type': 'application/json' },
+    body: '{}',
+  });
+  if (!res.ok) return null;
+  const j = (await res.json()) as { task: AgentTask | null };
+  return j.task;
+}
+
+async function runTask(appUrl: string, auth: string, task: AgentTask, runtime: DetectedRuntime) {
+  let seq = 0;
+  const post = (kind: string, payload: unknown) =>
+    fetch(`${appUrl}/api/daemon/tasks/${task.id}/messages`, {
+      method: 'POST',
+      headers: { authorization: auth, 'content-type': 'application/json' },
+      body: JSON.stringify({ seq: seq++, kind, payload }),
+    }).catch(() => {});
+
+  await post('status', { status: 'running' });
+  try {
+    const args = buildArgs(runtime, task);
+    const child = execa(runtime.bin, args, {
+      cwd: task.payload.cwdHint ?? process.cwd(),
+      env: { ...process.env },
+      reject: false,
+    });
+    child.stdout?.on('data', (b: Buffer) => post('stdout', b.toString('utf8')));
+    child.stderr?.on('data', (b: Buffer) => post('stderr', b.toString('utf8')));
+    const { exitCode } = await child;
+    await post('end', { ok: exitCode === 0, exitCode });
+  } catch (err) {
+    await post('end', { ok: false, error: (err as Error).message });
+  }
+}
+
+function buildArgs(runtime: DetectedRuntime, task: AgentTask): string[] {
+  // Minimal, agent-specific command shapes. Mirror daemon/agents.js as needed.
+  if (runtime.id === 'claude') {
+    return [
+      '--system-prompt', task.payload.systemPrompt,
+      '--output-format', 'stream-json',
+      '-p', task.payload.message,
+    ];
+  }
+  return [task.payload.message];
+}
+
+async function startWakeupListener(appUrl: string, auth: string) {
+  const res = await fetch(`${appUrl}/api/daemon/wakeups`, {
+    headers: { authorization: auth, accept: 'text/event-stream' },
+  });
+  if (!res.ok || !res.body) return;
+  const reader = res.body.getReader();
+  const dec = new TextDecoder();
+  let buf = '';
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) return;
+    buf += dec.decode(value, { stream: true });
+    const lines = buf.split('\n');
+    buf = lines.pop() ?? '';
+    for (const line of lines) {
+      // We don't act on wakeups directly; the polling loop will pick up the
+      // task within POLL_INTERVAL_MS. Wakeups exist mostly for latency.
+      void line;
+    }
+  }
+}
+
+function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}

--- a/apps/cli/src/cmd_login.ts
+++ b/apps/cli/src/cmd_login.ts
@@ -1,0 +1,77 @@
+// Browser-callback OAuth-style flow (mirrors multica's resolveCallbackBinding).
+// 1. Bind 127.0.0.1:<random> with a one-shot HTTP listener
+// 2. Open ${appUrl}/login?cli_callback=<listener>&cli_state=<rand>
+// 3. After user verifies, web app redirects to listener?token=<pat>&state=...
+// 4. Verify state, persist PAT to ~/.od/profiles/<name>/config.json
+import http from 'node:http';
+import { AddressInfo } from 'node:net';
+import open from 'open';
+import { randomBytes } from 'node:crypto';
+import { loadProfile, saveProfile } from './profile.js';
+
+interface Args {
+  profile: string;
+  appUrl?: string;
+}
+
+export async function login({ profile, appUrl }: Args): Promise<void> {
+  const p = await loadProfile(profile);
+  if (appUrl) p.appUrl = appUrl;
+  const state = randomBytes(16).toString('hex');
+
+  const result = await new Promise<{ token: string; userId: string; email: string }>(
+    (resolve, reject) => {
+      const server = http.createServer((req, res) => {
+        try {
+          const url = new URL(req.url ?? '/', `http://localhost`);
+          if (url.pathname !== '/callback') {
+            res.writeHead(404);
+            res.end('not found');
+            return;
+          }
+          const token = url.searchParams.get('token');
+          const gotState = url.searchParams.get('state');
+          const userId = url.searchParams.get('user_id');
+          const email = url.searchParams.get('email');
+          if (!token || gotState !== state || !userId || !email) {
+            res.writeHead(400);
+            res.end('Bad callback');
+            reject(new Error('bad callback'));
+            return;
+          }
+          res.writeHead(200, { 'content-type': 'text/html' });
+          res.end(
+            `<!doctype html><meta charset="utf-8"><title>od signed in</title><style>body{font:16px system-ui;padding:40px;background:#0b0b0d;color:#e7e7ea}</style><h1>You're signed in.</h1><p>You can close this window and return to your terminal.</p>`,
+          );
+          resolve({ token, userId, email });
+        } catch (e) {
+          reject(e as Error);
+        } finally {
+          setTimeout(() => server.close(), 100);
+        }
+      });
+      server.listen(0, '127.0.0.1', () => {
+        const port = (server.address() as AddressInfo).port;
+        const cb = `http://127.0.0.1:${port}/callback`;
+        const dest = `${p.appUrl}/login?cli_callback=${encodeURIComponent(cb)}&cli_state=${state}`;
+        // eslint-disable-next-line no-console
+        console.log(`Opening ${dest}`);
+        open(dest).catch(() => {
+          // eslint-disable-next-line no-console
+          console.log(`Open this URL manually:\n${dest}`);
+        });
+      });
+      setTimeout(() => {
+        server.close();
+        reject(new Error('login timed out after 5 minutes'));
+      }, 5 * 60_000);
+    },
+  );
+
+  p.pat = result.token;
+  p.userId = result.userId;
+  p.email = result.email;
+  await saveProfile(p);
+  // eslint-disable-next-line no-console
+  console.log(`Signed in as ${result.email}. PAT saved to profile "${p.name}".`);
+}

--- a/apps/cli/src/profile.ts
+++ b/apps/cli/src/profile.ts
@@ -1,0 +1,41 @@
+// Per-profile config under ~/.od/profiles/<name>/config.json. Mirrors multica's
+// ~/.multica/profiles/<name>/config.json layout so users can run multiple
+// daemons against staging vs prod from one machine.
+import { promises as fs } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export interface Profile {
+  name: string;
+  appUrl: string;
+  userId?: string;
+  email?: string;
+  pat?: string;
+  daemonToken?: string;
+  workspaceId?: string;
+  daemonId?: string;
+}
+
+const ROOT = join(homedir(), '.od', 'profiles');
+
+export function profileDir(name: string): string {
+  return join(ROOT, name);
+}
+
+export function configPath(name: string): string {
+  return join(profileDir(name), 'config.json');
+}
+
+export async function loadProfile(name: string): Promise<Profile> {
+  try {
+    const raw = await fs.readFile(configPath(name), 'utf8');
+    return JSON.parse(raw) as Profile;
+  } catch {
+    return { name, appUrl: process.env.OD_APP_URL ?? 'http://localhost:3000' };
+  }
+}
+
+export async function saveProfile(p: Profile): Promise<void> {
+  await fs.mkdir(profileDir(p.name), { recursive: true, mode: 0o700 });
+  await fs.writeFile(configPath(p.name), JSON.stringify(p, null, 2), { mode: 0o600 });
+}

--- a/apps/cli/src/runtimes.ts
+++ b/apps/cli/src/runtimes.ts
@@ -1,0 +1,31 @@
+// Probe PATH for known code-agent CLIs. Mirrors daemon/agents.js but in TS.
+import { execa } from 'execa';
+
+const KNOWN = [
+  { id: 'claude', name: 'Claude Code', bin: 'claude' },
+  { id: 'codex', name: 'OpenAI Codex CLI', bin: 'codex' },
+  { id: 'gemini', name: 'Gemini CLI', bin: 'gemini' },
+  { id: 'opencode', name: 'OpenCode', bin: 'opencode' },
+  { id: 'cursor-agent', name: 'Cursor Agent', bin: 'cursor-agent' },
+];
+
+export interface DetectedRuntime {
+  id: string;
+  name: string;
+  bin: string;
+  available: boolean;
+  version?: string;
+}
+
+export async function detectRuntimes(): Promise<DetectedRuntime[]> {
+  const out: DetectedRuntime[] = [];
+  for (const r of KNOWN) {
+    try {
+      const { stdout } = await execa(r.bin, ['--version'], { timeout: 4000 });
+      out.push({ ...r, available: true, version: stdout.trim().split('\n')[0]?.slice(0, 80) });
+    } catch {
+      out.push({ ...r, available: false });
+    }
+  }
+  return out;
+}

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "lib": ["ES2022"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*"]
+}

--- a/apps/cli/tsup.config.ts
+++ b/apps/cli/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/cli.ts'],
+  format: ['esm'],
+  target: 'node20',
+  banner: { js: '#!/usr/bin/env node' },
+  clean: true,
+  sourcemap: true,
+  dts: false,
+});

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,14 @@
+# --- Cloud (Vercel + Postgres) ---
+DATABASE_URL=postgres://user:pass@host:5432/open_design
+AUTH_JWT_SECRET=replace-with-32+-bytes-of-randomness
+PUBLIC_APP_URL=https://open-design.app
+
+# --- Self-hosted single-node (SQLite) ---
+# DATABASE_URL=file:./.od/app.sqlite
+# AUTH_JWT_SECRET=local-dev-only
+
+# --- Email (sign-in codes + workspace invitations) ---
+# console: log to stdout (dev). resend: production.
+EMAIL_PROVIDER=console
+# RESEND_API_KEY=
+# EMAIL_FROM=Open Design <noreply@example.com>

--- a/apps/web/app/api/auth/send-code/route.ts
+++ b/apps/web/app/api/auth/send-code/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import { nanoid } from 'nanoid';
+import { createHash, randomInt } from 'node:crypto';
+import { SendCodeRequest } from '@open-design/shared';
+import { getDb } from '@open-design/db/client';
+import { sendEmail } from '@/lib/email';
+
+const CODE_TTL_MIN = 10;
+
+export async function POST(req: Request) {
+  const body = SendCodeRequest.safeParse(await req.json().catch(() => ({})));
+  if (!body.success) return NextResponse.json({ error: 'bad request' }, { status: 400 });
+
+  const code = String(randomInt(0, 1_000_000)).padStart(6, '0');
+  const codeHash = createHash('sha256').update(code).digest('hex');
+
+  const { db, schema } = await getDb();
+  const s = schema as typeof import('@open-design/db/schema');
+
+  await (db as any).insert(s.emailVerificationCode).values({
+    id: nanoid(),
+    email: body.data.email.toLowerCase(),
+    codeHash,
+    expiresAt: new Date(Date.now() + CODE_TTL_MIN * 60_000),
+    createdAt: new Date(),
+  });
+
+  await sendEmail({
+    to: body.data.email,
+    subject: `Open Design sign-in code: ${code}`,
+    text: `Your code is ${code}. It expires in ${CODE_TTL_MIN} minutes.`,
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/web/app/api/auth/verify-code/route.ts
+++ b/apps/web/app/api/auth/verify-code/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from 'next/server';
+import { nanoid } from 'nanoid';
+import { createHash } from 'node:crypto';
+import { and, desc, eq, gt, isNull } from 'drizzle-orm';
+import { VerifyCodeRequest } from '@open-design/shared';
+import { generatePat } from '@open-design/shared/tokens';
+import { getDb } from '@open-design/db/client';
+import { setSessionCookie } from '@/lib/auth/session';
+
+export async function POST(req: Request) {
+  const body = VerifyCodeRequest.safeParse(await req.json().catch(() => ({})));
+  if (!body.success) return NextResponse.json({ error: 'bad request' }, { status: 400 });
+
+  const { email, code, cliCallback, cliState } = body.data;
+  const codeHash = createHash('sha256').update(code).digest('hex');
+  const { db, schema } = await getDb();
+  const s = schema as typeof import('@open-design/db/schema');
+
+  const [match] = await (db as any)
+    .select()
+    .from(s.emailVerificationCode)
+    .where(
+      and(
+        eq(s.emailVerificationCode.email, email.toLowerCase()),
+        eq(s.emailVerificationCode.codeHash, codeHash),
+        gt(s.emailVerificationCode.expiresAt, new Date()),
+        isNull(s.emailVerificationCode.consumedAt),
+      ),
+    )
+    .orderBy(desc(s.emailVerificationCode.createdAt))
+    .limit(1);
+
+  if (!match) return NextResponse.json({ error: 'invalid or expired code' }, { status: 401 });
+
+  await (db as any)
+    .update(s.emailVerificationCode)
+    .set({ consumedAt: new Date() })
+    .where(eq(s.emailVerificationCode.id, match.id));
+
+  // Upsert user.
+  let [user] = await (db as any)
+    .select()
+    .from(s.user)
+    .where(eq(s.user.email, email.toLowerCase()))
+    .limit(1);
+  if (!user) {
+    const id = nanoid();
+    await (db as any).insert(s.user).values({
+      id,
+      email: email.toLowerCase(),
+      emailVerifiedAt: new Date(),
+      createdAt: new Date(),
+    });
+    user = { id, email: email.toLowerCase() };
+    // Bootstrap a personal workspace so the user has somewhere to drop projects.
+    const wsId = nanoid();
+    await (db as any).insert(s.workspace).values({
+      id: wsId,
+      slug: `${email.split('@')[0]}-${wsId.slice(0, 4)}`.toLowerCase(),
+      name: `${email.split('@')[0]}'s workspace`,
+      ownerId: id,
+      createdAt: new Date(),
+    });
+    await (db as any).insert(s.member).values({
+      workspaceId: wsId,
+      userId: id,
+      role: 'owner',
+      createdAt: new Date(),
+    });
+  }
+
+  // Resolve memberships for the JWT.
+  const memberships: Array<{ workspaceId: string; role: 'owner' | 'admin' | 'member' }> =
+    await (db as any)
+      .select({ workspaceId: s.member.workspaceId, role: s.member.role })
+      .from(s.member)
+      .where(eq(s.member.userId, user.id));
+
+  const claims = {
+    sub: user.id as string,
+    email: user.email as string,
+    workspaces: memberships.map((m) => ({ id: m.workspaceId, role: m.role })),
+  };
+  await setSessionCookie(claims);
+
+  // CLI bootstrap path: mint a PAT and bounce back to the local listener.
+  if (cliCallback && cliState) {
+    const pat = generatePat();
+    await (db as any).insert(s.personalAccessToken).values({
+      id: nanoid(),
+      userId: user.id,
+      name: `cli-${new Date().toISOString().slice(0, 10)}`,
+      tokenPrefix: pat.prefix,
+      tokenHash: pat.hash,
+      expiresAt: new Date(Date.now() + 90 * 24 * 60 * 60_000),
+      createdAt: new Date(),
+    });
+    const cb = new URL(cliCallback);
+    cb.searchParams.set('token', pat.token);
+    cb.searchParams.set('state', cliState);
+    cb.searchParams.set('user_id', user.id);
+    cb.searchParams.set('email', user.email);
+    return NextResponse.json({ ok: true, cliRedirect: cb.toString() });
+  }
+
+  return NextResponse.json({ ok: true, user: { id: user.id, email: user.email } });
+}

--- a/apps/web/app/api/daemon/heartbeat/route.ts
+++ b/apps/web/app/api/daemon/heartbeat/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { eq } from 'drizzle-orm';
+import { getDb } from '@open-design/db/client';
+import { authenticateBearer } from '@/lib/auth/bearer';
+
+export async function POST(req: Request) {
+  const auth = await authenticateBearer(req);
+  if (!auth || auth.via !== 'daemon' || !auth.daemonId) {
+    return NextResponse.json({ error: 'daemon token required' }, { status: 401 });
+  }
+  const { db, schema } = await getDb();
+  const s = schema as typeof import('@open-design/db/schema');
+  await (db as any)
+    .update(s.daemonRegistration)
+    .set({ lastSeenAt: new Date() })
+    .where(eq(s.daemonRegistration.id, auth.daemonId));
+  return NextResponse.json({ ok: true });
+}

--- a/apps/web/app/api/daemon/register/route.ts
+++ b/apps/web/app/api/daemon/register/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from 'next/server';
+import { nanoid } from 'nanoid';
+import { eq } from 'drizzle-orm';
+import { RegisterDaemonRequest } from '@open-design/shared';
+import { generateDaemonToken } from '@open-design/shared/tokens';
+import { getDb } from '@open-design/db/client';
+import { authenticateBearer } from '@/lib/auth/bearer';
+
+// Called by `od daemon` once at startup. Authenticated by the user's PAT.
+// Returns a workspace-scoped daemon token (`od_dt_…`) that all subsequent
+// daemon requests use. The PAT is only the bootstrap.
+export async function POST(req: Request) {
+  const auth = await authenticateBearer(req);
+  if (!auth || auth.via !== 'pat') {
+    return NextResponse.json({ error: 'PAT required' }, { status: 401 });
+  }
+  const body = RegisterDaemonRequest.safeParse(await req.json().catch(() => ({})));
+  if (!body.success) return NextResponse.json({ error: 'bad request' }, { status: 400 });
+
+  const { db, schema } = await getDb();
+  const s = schema as typeof import('@open-design/db/schema');
+
+  const [membership] = await (db as any)
+    .select()
+    .from(s.member)
+    .where(eq(s.member.userId, auth.userId))
+    .limit(1);
+  // Auto-pick the first workspace if the request didn't specify one — for
+  // the common case where users have one personal workspace.
+  const workspaceId = body.data.workspaceId || membership?.workspaceId;
+  if (!workspaceId) return NextResponse.json({ error: 'no workspace' }, { status: 400 });
+
+  const tok = generateDaemonToken();
+  const id = nanoid();
+  await (db as any).insert(s.daemonRegistration).values({
+    id,
+    workspaceId,
+    userId: auth.userId,
+    hostname: body.data.hostname,
+    platform: body.data.platform,
+    os: body.data.os,
+    cliVersion: body.data.cliVersion,
+    runtimes: body.data.runtimes,
+    tokenPrefix: tok.prefix,
+    tokenHash: tok.hash,
+    lastSeenAt: new Date(),
+    createdAt: new Date(),
+  });
+
+  return NextResponse.json({
+    id,
+    workspaceId,
+    daemonToken: tok.token,
+  });
+}

--- a/apps/web/app/api/daemon/runtimes/[runtimeId]/tasks/claim/route.ts
+++ b/apps/web/app/api/daemon/runtimes/[runtimeId]/tasks/claim/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from 'next/server';
+import { and, asc, eq, isNull, or, lt } from 'drizzle-orm';
+import { getDb } from '@open-design/db/client';
+import { authenticateBearer } from '@/lib/auth/bearer';
+
+const LEASE_MS = 5 * 60_000;
+
+// Long-poll-style claim. Daemon polls every ~3s; cloud sends a WS wakeup hint
+// when it enqueues a task, but HTTP claim is the source of truth (atomic
+// UPDATE with WHERE on status + lease).
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ runtimeId: string }> },
+) {
+  const auth = await authenticateBearer(req);
+  if (!auth || auth.via !== 'daemon' || !auth.daemonId || !auth.workspaceId) {
+    return NextResponse.json({ error: 'daemon token required' }, { status: 401 });
+  }
+  const { runtimeId } = await params;
+  const { db, schema, dialect } = await getDb();
+  const s = schema as typeof import('@open-design/db/schema');
+
+  // Find one queued task for this workspace + runtime, or one with an
+  // expired lease that's still claimed/running.
+  const now = new Date();
+  const [candidate] = await (db as any)
+    .select()
+    .from(s.agentTask)
+    .where(
+      and(
+        eq(s.agentTask.workspaceId, auth.workspaceId),
+        eq(s.agentTask.runtimeId, runtimeId),
+        or(
+          eq(s.agentTask.status, 'queued'),
+          and(eq(s.agentTask.status, 'claimed'), lt(s.agentTask.leaseExpiresAt, now)),
+          and(eq(s.agentTask.status, 'running'), lt(s.agentTask.leaseExpiresAt, now)),
+        ),
+      ),
+    )
+    .orderBy(asc(s.agentTask.createdAt))
+    .limit(1);
+
+  if (!candidate) return NextResponse.json({ task: null });
+
+  // Atomic-ish claim: update only if status is still what we read.
+  const result = await (db as any)
+    .update(s.agentTask)
+    .set({
+      status: 'claimed',
+      leasedByDaemonId: auth.daemonId,
+      leaseExpiresAt: new Date(Date.now() + LEASE_MS),
+      updatedAt: new Date(),
+    })
+    .where(and(eq(s.agentTask.id, candidate.id), eq(s.agentTask.status, candidate.status)))
+    .returning?.();
+
+  // SQLite lacks `.returning()` on update in some drivers; fall back to a re-select.
+  let claimed = candidate;
+  if (Array.isArray(result) && result.length) claimed = result[0];
+
+  void isNull;
+  void dialect;
+  return NextResponse.json({ task: claimed });
+}

--- a/apps/web/app/api/daemon/tasks/[taskId]/messages/route.ts
+++ b/apps/web/app/api/daemon/tasks/[taskId]/messages/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from 'next/server';
+import { nanoid } from 'nanoid';
+import { eq, and } from 'drizzle-orm';
+import { TaskMessageRequest } from '@open-design/shared';
+import { getDb } from '@open-design/db/client';
+import { authenticateBearer } from '@/lib/auth/bearer';
+import { broadcastTaskMessage } from '@/lib/realtime';
+
+// Daemon streams agent stdout/stderr/agent-events back here. Cloud persists
+// each chunk and fans it out to subscribed browser SSE listeners.
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ taskId: string }> },
+) {
+  const auth = await authenticateBearer(req);
+  if (!auth || auth.via !== 'daemon' || !auth.daemonId) {
+    return NextResponse.json({ error: 'daemon token required' }, { status: 401 });
+  }
+  const { taskId } = await params;
+  const body = TaskMessageRequest.safeParse({
+    ...(await req.json().catch(() => ({}))),
+    taskId,
+  });
+  if (!body.success) return NextResponse.json({ error: 'bad request' }, { status: 400 });
+
+  const { db, schema } = await getDb();
+  const s = schema as typeof import('@open-design/db/schema');
+
+  // Verify the task is leased to this daemon.
+  const [task] = await (db as any)
+    .select()
+    .from(s.agentTask)
+    .where(and(eq(s.agentTask.id, taskId), eq(s.agentTask.leasedByDaemonId, auth.daemonId)))
+    .limit(1);
+  if (!task) return NextResponse.json({ error: 'not your task' }, { status: 403 });
+
+  await (db as any).insert(s.taskMessage).values({
+    id: nanoid(),
+    taskId,
+    seq: body.data.seq,
+    kind: body.data.kind,
+    payload: body.data.payload as any,
+    createdAt: new Date(),
+  });
+
+  if (body.data.kind === 'end') {
+    const status = (body.data.payload as { ok?: boolean })?.ok === false ? 'failed' : 'succeeded';
+    await (db as any)
+      .update(s.agentTask)
+      .set({ status, updatedAt: new Date() })
+      .where(eq(s.agentTask.id, taskId));
+  } else if (body.data.kind === 'status' && task.status === 'claimed') {
+    await (db as any)
+      .update(s.agentTask)
+      .set({ status: 'running', updatedAt: new Date() })
+      .where(eq(s.agentTask.id, taskId));
+  }
+
+  broadcastTaskMessage(taskId, {
+    seq: body.data.seq,
+    kind: body.data.kind,
+    payload: body.data.payload,
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/web/app/api/daemon/wakeups/route.ts
+++ b/apps/web/app/api/daemon/wakeups/route.ts
@@ -1,0 +1,40 @@
+import { authenticateBearer } from '@/lib/auth/bearer';
+import { subscribeDaemonWakeups } from '@/lib/realtime';
+
+// Best-effort SSE wakeup channel for the daemon. The daemon HOLDS this
+// connection open and HTTP-claims tasks when it gets a hint frame.
+// (Equivalent of multica's outbound WS hub; SSE is simpler and fits Next.js
+// route handlers without a custom server.)
+export async function GET(req: Request) {
+  const auth = await authenticateBearer(req);
+  if (!auth || auth.via !== 'daemon' || !auth.daemonId) {
+    return new Response('unauthorized', { status: 401 });
+  }
+  const daemonId = auth.daemonId;
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const enc = new TextEncoder();
+      const send = (msg: unknown) => controller.enqueue(enc.encode(`data: ${JSON.stringify(msg)}\n\n`));
+      // Initial hello so curl/eventsource sees something immediately.
+      send({ kind: 'hello', daemonId });
+      const unsub = subscribeDaemonWakeups(daemonId, (m) => send(m));
+      // Keep-alive ping every 25s so intermediaries don't drop the connection.
+      const ping = setInterval(() => send({ kind: 'ping', t: Date.now() }), 25_000);
+      const abort = () => {
+        clearInterval(ping);
+        unsub();
+        controller.close();
+      };
+      req.signal.addEventListener('abort', abort);
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'content-type': 'text/event-stream',
+      'cache-control': 'no-cache, no-transform',
+      connection: 'keep-alive',
+    },
+  });
+}

--- a/apps/web/app/api/projects/[id]/chat/route.ts
+++ b/apps/web/app/api/projects/[id]/chat/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from 'next/server';
+import { nanoid } from 'nanoid';
+import { z } from 'zod';
+import { eq } from 'drizzle-orm';
+import { getDb } from '@open-design/db/client';
+import { getSessionFromCookies } from '@/lib/auth/session';
+import { resolveProjectAccess } from '@/lib/access';
+import { wakeDaemon } from '@/lib/realtime';
+
+const Body = z.object({
+  message: z.string().min(1),
+  systemPrompt: z.string().default(''),
+  runtimeId: z.string(),
+});
+
+// Enqueues an agent_task for the project. The cloud doesn't run the agent;
+// it persists a row, wakes any paired daemon for that workspace+runtime,
+// and returns the task id. The browser then opens
+// /api/tasks/<id>/stream (SSE) to watch progress in real time.
+export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getSessionFromCookies();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  const { id } = await params;
+  const access = await resolveProjectAccess(id, session);
+  if (!access.ok) return NextResponse.json({ error: 'forbidden' }, { status: 403 });
+  if (access.role === 'view') return NextResponse.json({ error: 'view-only' }, { status: 403 });
+
+  const body = Body.safeParse(await req.json().catch(() => ({})));
+  if (!body.success) return NextResponse.json({ error: 'bad request' }, { status: 400 });
+
+  const { db, schema } = await getDb();
+  const s = schema as typeof import('@open-design/db/schema');
+  const [project] = await (db as any).select().from(s.project).where(eq(s.project.id, id)).limit(1);
+  if (!project) return NextResponse.json({ error: 'not found' }, { status: 404 });
+
+  const taskId = nanoid();
+  const now = new Date();
+  await (db as any).insert(s.agentTask).values({
+    id: taskId,
+    workspaceId: project.workspaceId,
+    projectId: id,
+    runtimeId: body.data.runtimeId,
+    requestedByUserId: session.sub,
+    payload: {
+      systemPrompt: body.data.systemPrompt,
+      message: body.data.message,
+    },
+    status: 'queued',
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  // Best-effort wake of any registered daemon in this workspace.
+  const daemons = await (db as any)
+    .select({ id: s.daemonRegistration.id })
+    .from(s.daemonRegistration)
+    .where(eq(s.daemonRegistration.workspaceId, project.workspaceId));
+  for (const d of daemons) {
+    wakeDaemon(d.id, { seq: 0, kind: 'task_available', payload: { taskId, runtimeId: body.data.runtimeId } });
+  }
+
+  return NextResponse.json({ taskId });
+}

--- a/apps/web/app/api/projects/[id]/share/route.ts
+++ b/apps/web/app/api/projects/[id]/share/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from 'next/server';
+import { nanoid } from 'nanoid';
+import { and, eq, isNull } from 'drizzle-orm';
+import { CreateShareLinkRequest } from '@open-design/shared';
+import { generateShareLinkToken } from '@open-design/shared/tokens';
+import { getDb } from '@open-design/db/client';
+import { getSessionFromCookies } from '@/lib/auth/session';
+import { resolveProjectAccess } from '@/lib/access';
+
+// Per-project public share links. Three roles: view / comment / edit.
+// Anyone with the URL can open the project at the share's role; revoke from
+// settings to invalidate. Multica uses workspace invites for collaboration;
+// we add this lighter primitive on top so users can share a single project
+// without giving full workspace membership.
+export async function GET(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getSessionFromCookies();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  const { id } = await params;
+  const access = await resolveProjectAccess(id, session);
+  if (!access.ok || access.via !== 'member') {
+    return NextResponse.json({ error: 'forbidden' }, { status: 403 });
+  }
+
+  const { db, schema } = await getDb();
+  const s = schema as typeof import('@open-design/db/schema');
+  const rows = await (db as any)
+    .select({
+      id: s.projectShareLink.id,
+      role: s.projectShareLink.role,
+      tokenPrefix: s.projectShareLink.tokenPrefix,
+      expiresAt: s.projectShareLink.expiresAt,
+      createdAt: s.projectShareLink.createdAt,
+      lastUsedAt: s.projectShareLink.lastUsedAt,
+    })
+    .from(s.projectShareLink)
+    .where(and(eq(s.projectShareLink.projectId, id), isNull(s.projectShareLink.revokedAt)));
+  return NextResponse.json({ links: rows });
+}
+
+export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getSessionFromCookies();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  const { id } = await params;
+  const access = await resolveProjectAccess(id, session);
+  if (!access.ok || access.via !== 'member' || access.role === 'member') {
+    // Only owner/admin of the workspace can create share links.
+    return NextResponse.json({ error: 'forbidden' }, { status: 403 });
+  }
+  const body = CreateShareLinkRequest.safeParse(await req.json().catch(() => ({})));
+  if (!body.success) return NextResponse.json({ error: 'bad request' }, { status: 400 });
+
+  const tok = generateShareLinkToken();
+  const linkId = nanoid();
+  const expiresAt = body.data.expiresInDays
+    ? new Date(Date.now() + body.data.expiresInDays * 24 * 60 * 60_000)
+    : null;
+  const { db, schema } = await getDb();
+  const s = schema as typeof import('@open-design/db/schema');
+  await (db as any).insert(s.projectShareLink).values({
+    id: linkId,
+    projectId: id,
+    role: body.data.role,
+    tokenPrefix: tok.prefix,
+    tokenHash: tok.hash,
+    createdByUserId: session.sub,
+    expiresAt,
+    createdAt: new Date(),
+  });
+
+  const base = process.env.PUBLIC_APP_URL ?? new URL(req.url).origin;
+  const url = `${base}/share/${tok.token}`;
+  return NextResponse.json({ id: linkId, url, role: body.data.role, expiresAt });
+}

--- a/apps/web/app/api/projects/route.ts
+++ b/apps/web/app/api/projects/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server';
+import { nanoid } from 'nanoid';
+import { and, desc, eq, inArray } from 'drizzle-orm';
+import { CreateProjectRequest } from '@open-design/shared';
+import { getDb } from '@open-design/db/client';
+import { getSessionFromCookies } from '@/lib/auth/session';
+
+export async function GET() {
+  const session = await getSessionFromCookies();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  const { db, schema } = await getDb();
+  const s = schema as typeof import('@open-design/db/schema');
+  const wsIds = session.workspaces.map((w) => w.id);
+  if (!wsIds.length) return NextResponse.json({ projects: [] });
+  const rows = await (db as any)
+    .select()
+    .from(s.project)
+    .where(inArray(s.project.workspaceId, wsIds))
+    .orderBy(desc(s.project.updatedAt));
+  return NextResponse.json({ projects: rows });
+}
+
+export async function POST(req: Request) {
+  const session = await getSessionFromCookies();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  const body = CreateProjectRequest.safeParse(await req.json().catch(() => ({})));
+  if (!body.success) return NextResponse.json({ error: 'bad request' }, { status: 400 });
+
+  if (!session.workspaces.some((w) => w.id === body.data.workspaceId)) {
+    return NextResponse.json({ error: 'not a member of workspace' }, { status: 403 });
+  }
+
+  const { db, schema } = await getDb();
+  const s = schema as typeof import('@open-design/db/schema');
+  const id = nanoid();
+  const now = new Date();
+  await (db as any).insert(s.project).values({
+    id,
+    workspaceId: body.data.workspaceId,
+    name: body.data.name,
+    skillId: body.data.skillId ?? null,
+    designSystemId: body.data.designSystemId ?? null,
+    pendingPrompt: body.data.pendingPrompt ?? null,
+    metadata: null,
+    createdByUserId: session.sub,
+    createdAt: now,
+    updatedAt: now,
+  });
+  void and;
+  void eq;
+  return NextResponse.json({ project: { id, name: body.data.name, workspaceId: body.data.workspaceId } });
+}

--- a/apps/web/app/api/tasks/[taskId]/stream/route.ts
+++ b/apps/web/app/api/tasks/[taskId]/stream/route.ts
@@ -1,0 +1,54 @@
+import { eq, asc } from 'drizzle-orm';
+import { getDb } from '@open-design/db/client';
+import { getSessionFromCookies } from '@/lib/auth/session';
+import { subscribeTask } from '@/lib/realtime';
+
+// Browser SSE feed for a single task. Replays persisted messages (so you can
+// reconnect mid-run), then streams new messages as they arrive via the
+// in-process pub/sub.
+export async function GET(req: Request, { params }: { params: Promise<{ taskId: string }> }) {
+  const session = await getSessionFromCookies();
+  if (!session) return new Response('unauthorized', { status: 401 });
+  const { taskId } = await params;
+  const { db, schema } = await getDb();
+  const s = schema as typeof import('@open-design/db/schema');
+
+  const [task] = await (db as any)
+    .select()
+    .from(s.agentTask)
+    .where(eq(s.agentTask.id, taskId))
+    .limit(1);
+  if (!task) return new Response('not found', { status: 404 });
+  // ACL: must be a member of the task's workspace.
+  if (!session.workspaces.some((w) => w.id === task.workspaceId)) {
+    return new Response('forbidden', { status: 403 });
+  }
+
+  const persisted: Array<{ seq: number; kind: string; payload: unknown }> = await (db as any)
+    .select({ seq: s.taskMessage.seq, kind: s.taskMessage.kind, payload: s.taskMessage.payload })
+    .from(s.taskMessage)
+    .where(eq(s.taskMessage.taskId, taskId))
+    .orderBy(asc(s.taskMessage.seq));
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const enc = new TextEncoder();
+      const send = (msg: unknown) => controller.enqueue(enc.encode(`data: ${JSON.stringify(msg)}\n\n`));
+      for (const m of persisted) send(m);
+      const unsub = subscribeTask(taskId, (m) => send(m));
+      const abort = () => {
+        unsub();
+        controller.close();
+      };
+      req.signal.addEventListener('abort', abort);
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'content-type': 'text/event-stream',
+      'cache-control': 'no-cache, no-transform',
+      connection: 'keep-alive',
+    },
+  });
+}

--- a/apps/web/app/api/workspaces/[wsId]/invitations/route.ts
+++ b/apps/web/app/api/workspaces/[wsId]/invitations/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server';
+import { nanoid } from 'nanoid';
+import { eq, and } from 'drizzle-orm';
+import { InviteMemberRequest } from '@open-design/shared';
+import { hashToken } from '@open-design/shared/tokens';
+import { randomBytes } from 'node:crypto';
+import { getDb } from '@open-design/db/client';
+import { getSessionFromCookies } from '@/lib/auth/session';
+import { sendEmail } from '@/lib/email';
+
+const INVITE_TTL_DAYS = 7;
+
+export async function POST(req: Request, { params }: { params: Promise<{ wsId: string }> }) {
+  const session = await getSessionFromCookies();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  const { wsId } = await params;
+  const ws = session.workspaces.find((w) => w.id === wsId);
+  if (!ws || ws.role === 'member') {
+    return NextResponse.json({ error: 'forbidden' }, { status: 403 });
+  }
+  const body = InviteMemberRequest.safeParse(await req.json().catch(() => ({})));
+  if (!body.success) return NextResponse.json({ error: 'bad request' }, { status: 400 });
+
+  const { db, schema } = await getDb();
+  const s = schema as typeof import('@open-design/db/schema');
+
+  const token = `od_inv_${randomBytes(24).toString('base64url')}`;
+  const id = nanoid();
+  await (db as any).insert(s.workspaceInvitation).values({
+    id,
+    workspaceId: wsId,
+    inviteeEmail: body.data.email.toLowerCase(),
+    inviteeUserId: null,
+    invitedByUserId: session.sub,
+    role: body.data.role,
+    status: 'pending',
+    tokenHash: hashToken(token),
+    expiresAt: new Date(Date.now() + INVITE_TTL_DAYS * 24 * 60 * 60_000),
+    createdAt: new Date(),
+  });
+
+  const base = process.env.PUBLIC_APP_URL ?? new URL(req.url).origin;
+  const url = `${base}/invitations/${token}`;
+  await sendEmail({
+    to: body.data.email,
+    subject: `You've been invited to a workspace on Open Design`,
+    text: `${session.email} invited you to join their workspace as ${body.data.role}.\nAccept here: ${url}\nThis link expires in ${INVITE_TTL_DAYS} days.`,
+  });
+  void and;
+  void eq;
+  return NextResponse.json({ id, url });
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,0 +1,15 @@
+@import "tailwindcss";
+
+:root {
+  --bg: #0b0b0d;
+  --fg: #e7e7ea;
+  --muted: #8a8a93;
+  --accent: #4f46e5;
+}
+
+html, body { height: 100%; }
+body {
+  background: var(--bg);
+  color: var(--fg);
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}

--- a/apps/web/app/invitations/[token]/route.ts
+++ b/apps/web/app/invitations/[token]/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from 'next/server';
+import { eq, and } from 'drizzle-orm';
+import { hashToken } from '@open-design/shared/tokens';
+import { getDb } from '@open-design/db/client';
+import { getSessionFromCookies, setSessionCookie } from '@/lib/auth/session';
+
+// Invite acceptance. If the user isn't signed in, we route them to /login
+// with a return URL; once signed in, we add them to the workspace.
+export async function GET(req: Request, { params }: { params: Promise<{ token: string }> }) {
+  const { token } = await params;
+  const session = await getSessionFromCookies();
+  const tokenHash = hashToken(token);
+  const { db, schema } = await getDb();
+  const s = schema as typeof import('@open-design/db/schema');
+
+  const [invite] = await (db as any)
+    .select()
+    .from(s.workspaceInvitation)
+    .where(and(eq(s.workspaceInvitation.tokenHash, tokenHash), eq(s.workspaceInvitation.status, 'pending')))
+    .limit(1);
+  if (!invite) return new NextResponse('Invite no longer valid', { status: 410 });
+  if (new Date(invite.expiresAt) < new Date()) {
+    await (db as any).update(s.workspaceInvitation).set({ status: 'expired' }).where(eq(s.workspaceInvitation.id, invite.id));
+    return new NextResponse('Invite expired', { status: 410 });
+  }
+
+  if (!session) {
+    const base = new URL(req.url).origin;
+    return NextResponse.redirect(`${base}/login?next=${encodeURIComponent(`/invitations/${token}`)}`, 303);
+  }
+  if (session.email.toLowerCase() !== invite.inviteeEmail) {
+    return new NextResponse(`This invite is for ${invite.inviteeEmail}. Sign in as that user.`, { status: 403 });
+  }
+
+  // Idempotent: only insert membership if not already present.
+  const [existing] = await (db as any)
+    .select()
+    .from(s.member)
+    .where(and(eq(s.member.workspaceId, invite.workspaceId), eq(s.member.userId, session.sub)))
+    .limit(1);
+  if (!existing) {
+    await (db as any).insert(s.member).values({
+      workspaceId: invite.workspaceId,
+      userId: session.sub,
+      role: invite.role,
+      createdAt: new Date(),
+    });
+  }
+  await (db as any)
+    .update(s.workspaceInvitation)
+    .set({ status: 'accepted', inviteeUserId: session.sub })
+    .where(eq(s.workspaceInvitation.id, invite.id));
+
+  // Refresh the JWT so the new workspace shows up on subsequent requests.
+  const updated = {
+    ...session,
+    workspaces: [...session.workspaces.filter((w) => w.id !== invite.workspaceId), { id: invite.workspaceId, role: invite.role }],
+  };
+  await setSessionCookie(updated);
+
+  const base = new URL(req.url).origin;
+  return NextResponse.redirect(`${base}/projects`, 303);
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'Open Design',
+  description: 'Cloud + local AI design product. Pair the cloud UI with a local `od` daemon.',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/web/app/login/LoginForm.tsx
+++ b/apps/web/app/login/LoginForm.tsx
@@ -1,0 +1,104 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+interface Props {
+  cliCallback?: string;
+  cliState?: string;
+}
+
+export default function LoginForm({ cliCallback, cliState }: Props) {
+  const [email, setEmail] = useState('');
+  const [code, setCode] = useState('');
+  const [stage, setStage] = useState<'enter-email' | 'enter-code' | 'done'>('enter-email');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const router = useRouter();
+
+  async function sendCode(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    const r = await fetch('/api/auth/send-code', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email }),
+    });
+    setSubmitting(false);
+    if (!r.ok) {
+      const j = await r.json().catch(() => ({}));
+      setError(j.error ?? 'Failed to send code');
+      return;
+    }
+    setStage('enter-code');
+  }
+
+  async function verifyCode(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    const r = await fetch('/api/auth/verify-code', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email, code, cliCallback, cliState }),
+    });
+    setSubmitting(false);
+    if (!r.ok) {
+      const j = await r.json().catch(() => ({}));
+      setError(j.error ?? 'Verification failed');
+      return;
+    }
+    const j = await r.json();
+    if (cliCallback && cliState && j.cliRedirect) {
+      window.location.href = j.cliRedirect;
+      setStage('done');
+      return;
+    }
+    router.push('/projects');
+  }
+
+  return (
+    <form
+      onSubmit={stage === 'enter-email' ? sendCode : verifyCode}
+      className="flex flex-col gap-3"
+    >
+      {cliCallback ? (
+        <p className="rounded border border-white/10 bg-white/5 p-3 text-sm text-[var(--muted)]">
+          You're signing in to authorize the local <code>od</code> CLI on this device. After you
+          verify, we'll redirect back to your terminal.
+        </p>
+      ) : null}
+
+      <input
+        type="email"
+        required
+        autoFocus
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="you@example.com"
+        disabled={stage !== 'enter-email'}
+        className="rounded border border-white/10 bg-black/40 px-3 py-2"
+      />
+      {stage !== 'enter-email' ? (
+        <input
+          required
+          inputMode="numeric"
+          pattern="\\d{6}"
+          value={code}
+          onChange={(e) => setCode(e.target.value)}
+          placeholder="6-digit code"
+          autoFocus
+          className="rounded border border-white/10 bg-black/40 px-3 py-2"
+        />
+      ) : null}
+      {error ? <p className="text-sm text-red-400">{error}</p> : null}
+      <button
+        type="submit"
+        disabled={submitting}
+        className="rounded bg-[var(--accent)] px-4 py-2 font-medium disabled:opacity-50"
+      >
+        {stage === 'enter-email' ? 'Send code' : stage === 'enter-code' ? 'Verify' : 'Redirecting…'}
+      </button>
+    </form>
+  );
+}

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -1,0 +1,26 @@
+import { Suspense } from 'react';
+import LoginForm from './LoginForm';
+
+export default function LoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ cli_callback?: string; cli_state?: string }>;
+}) {
+  return (
+    <main className="mx-auto flex min-h-dvh max-w-md flex-col justify-center gap-8 px-6">
+      <h1 className="text-2xl font-semibold">Sign in</h1>
+      <Suspense fallback={null}>
+        <SearchParamsBridge sp={searchParams} />
+      </Suspense>
+    </main>
+  );
+}
+
+async function SearchParamsBridge({
+  sp,
+}: {
+  sp: Promise<{ cli_callback?: string; cli_state?: string }>;
+}) {
+  const { cli_callback, cli_state } = await sp;
+  return <LoginForm cliCallback={cli_callback} cliState={cli_state} />;
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,0 +1,48 @@
+import Link from 'next/link';
+import { getSessionFromCookies } from '@/lib/auth/session';
+
+export default async function HomePage() {
+  const session = await getSessionFromCookies();
+  return (
+    <main className="mx-auto flex min-h-dvh max-w-3xl flex-col gap-10 px-6 py-20">
+      <header>
+        <h1 className="text-4xl font-semibold tracking-tight">Open Design</h1>
+        <p className="mt-3 text-[var(--muted)]">
+          Run AI-generated design previews on your own machine, drive it from a cloud UI.
+        </p>
+      </header>
+
+      <section className="space-y-3">
+        <h2 className="text-sm uppercase tracking-wider text-[var(--muted)]">Get started</h2>
+        {session ? (
+          <div className="flex flex-col gap-3">
+            <Link className="rounded bg-[var(--accent)] px-4 py-2 text-center font-medium" href="/projects">
+              Go to projects
+            </Link>
+            <Link className="text-sm text-[var(--muted)] underline" href="/settings/daemon">
+              Pair a local daemon
+            </Link>
+          </div>
+        ) : (
+          <Link className="rounded bg-[var(--accent)] px-4 py-2 text-center font-medium" href="/login">
+            Sign in
+          </Link>
+        )}
+      </section>
+
+      <section className="space-y-3 text-sm text-[var(--muted)]">
+        <h2 className="text-sm uppercase tracking-wider">CLI</h2>
+        <pre className="overflow-x-auto rounded border border-white/10 bg-black/40 p-4">
+{`# install
+npm i -g @open-design/cli
+
+# pair this machine to your account
+od login
+
+# run the daemon (claims tasks queued in the cloud)
+od daemon`}
+        </pre>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/projects/[id]/ShareButton.tsx
+++ b/apps/web/app/projects/[id]/ShareButton.tsx
@@ -1,0 +1,73 @@
+'use client';
+import { useState } from 'react';
+
+export default function ShareButton({ projectId }: { projectId: string }) {
+  const [open, setOpen] = useState(false);
+  const [role, setRole] = useState<'view' | 'comment' | 'edit'>('view');
+  const [url, setUrl] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function create() {
+    setBusy(true);
+    const r = await fetch(`/api/projects/${projectId}/share`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ role }),
+    });
+    setBusy(false);
+    if (r.ok) {
+      const j = await r.json();
+      setUrl(j.url);
+    }
+  }
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="rounded border border-white/10 px-3 py-1.5 text-sm hover:bg-white/5"
+      >
+        Share
+      </button>
+      {open ? (
+        <div className="absolute right-0 mt-2 w-80 rounded border border-white/10 bg-black/90 p-3 shadow-xl">
+          <p className="mb-2 text-xs text-[var(--muted)]">
+            Anyone with the link will get the selected role.
+          </p>
+          <select
+            value={role}
+            onChange={(e) => setRole(e.target.value as 'view' | 'comment' | 'edit')}
+            className="mb-2 w-full rounded border border-white/10 bg-black/40 px-2 py-1 text-sm"
+          >
+            <option value="view">View</option>
+            <option value="comment">Comment</option>
+            <option value="edit">Edit</option>
+          </select>
+          <button
+            onClick={create}
+            disabled={busy}
+            className="mb-2 w-full rounded bg-[var(--accent)] px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+          >
+            {busy ? 'Creating…' : 'Create link'}
+          </button>
+          {url ? (
+            <div>
+              <input
+                readOnly
+                value={url}
+                className="w-full rounded border border-white/10 bg-black/40 px-2 py-1 text-xs"
+                onFocus={(e) => e.currentTarget.select()}
+              />
+              <button
+                onClick={() => navigator.clipboard.writeText(url)}
+                className="mt-1 text-xs text-[var(--muted)] underline"
+              >
+                Copy
+              </button>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/app/projects/[id]/page.tsx
+++ b/apps/web/app/projects/[id]/page.tsx
@@ -1,0 +1,41 @@
+import { notFound } from 'next/navigation';
+import { eq } from 'drizzle-orm';
+import { getDb } from '@open-design/db/client';
+import { getSessionFromCookies } from '@/lib/auth/session';
+import { resolveProjectAccess } from '@/lib/access';
+import ShareButton from './ShareButton';
+
+export default async function ProjectPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const session = await getSessionFromCookies();
+  const access = await resolveProjectAccess(id, session);
+  if (!access.ok) notFound();
+
+  const { db, schema } = await getDb();
+  const s = schema as typeof import('@open-design/db/schema');
+  const [project] = await (db as any).select().from(s.project).where(eq(s.project.id, id)).limit(1);
+
+  return (
+    <main className="mx-auto max-w-5xl px-6 py-10">
+      <header className="mb-6 flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">{project.name}</h1>
+          <p className="text-sm text-[var(--muted)]">
+            Access: <code>{access.via}</code> · role <code>{access.role}</code>
+          </p>
+        </div>
+        {access.via === 'member' && access.role !== 'member' ? (
+          <ShareButton projectId={id} />
+        ) : null}
+      </header>
+
+      <section className="rounded border border-white/10 p-4">
+        <h2 className="mb-2 text-sm uppercase tracking-wider text-[var(--muted)]">Chat</h2>
+        <p className="text-sm text-[var(--muted)]">
+          Chat / file workspace UI lives here. Sends to <code>POST /api/projects/{id}/chat</code>,
+          which queues an <code>agent_task</code> for a paired daemon to claim.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/projects/page.tsx
+++ b/apps/web/app/projects/page.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { desc, inArray } from 'drizzle-orm';
+import { getDb } from '@open-design/db/client';
+import { getSessionFromCookies } from '@/lib/auth/session';
+
+export default async function ProjectsIndex() {
+  const session = await getSessionFromCookies();
+  if (!session) redirect('/login');
+  const wsIds = session.workspaces.map((w) => w.id);
+  const { db, schema } = await getDb();
+  const s = schema as typeof import('@open-design/db/schema');
+  const projects = wsIds.length
+    ? await (db as any)
+        .select()
+        .from(s.project)
+        .where(inArray(s.project.workspaceId, wsIds))
+        .orderBy(desc(s.project.updatedAt))
+    : [];
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-12">
+      <h1 className="mb-6 text-2xl font-semibold">Projects</h1>
+      <ul className="space-y-2">
+        {projects.map((p: { id: string; name: string }) => (
+          <li key={p.id}>
+            <Link className="block rounded border border-white/10 p-3 hover:bg-white/5" href={`/projects/${p.id}`}>
+              {p.name}
+            </Link>
+          </li>
+        ))}
+        {projects.length === 0 ? <li className="text-[var(--muted)]">No projects yet.</li> : null}
+      </ul>
+    </main>
+  );
+}

--- a/apps/web/app/settings/daemon/page.tsx
+++ b/apps/web/app/settings/daemon/page.tsx
@@ -1,0 +1,51 @@
+import { redirect } from 'next/navigation';
+import { eq, isNull, and } from 'drizzle-orm';
+import { getDb } from '@open-design/db/client';
+import { getSessionFromCookies } from '@/lib/auth/session';
+
+export default async function DaemonSettingsPage() {
+  const session = await getSessionFromCookies();
+  if (!session) redirect('/login');
+  const { db, schema } = await getDb();
+  const s = schema as typeof import('@open-design/db/schema');
+  const daemons = await (db as any)
+    .select({
+      id: s.daemonRegistration.id,
+      hostname: s.daemonRegistration.hostname,
+      platform: s.daemonRegistration.platform,
+      os: s.daemonRegistration.os,
+      cliVersion: s.daemonRegistration.cliVersion,
+      runtimes: s.daemonRegistration.runtimes,
+      lastSeenAt: s.daemonRegistration.lastSeenAt,
+    })
+    .from(s.daemonRegistration)
+    .where(and(eq(s.daemonRegistration.userId, session.sub), isNull(s.daemonRegistration.revokedAt)));
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-12">
+      <h1 className="mb-6 text-2xl font-semibold">Paired daemons</h1>
+      <pre className="mb-8 overflow-x-auto rounded border border-white/10 bg-black/40 p-4 text-sm">
+{`# install
+npm i -g @open-design/cli
+
+# this opens a browser, signs you in, and stores a PAT
+od login
+
+# start the daemon (registers, then claims tasks for this account)
+od daemon`}
+      </pre>
+      <h2 className="mb-3 text-sm uppercase tracking-wider text-[var(--muted)]">Devices</h2>
+      <ul className="space-y-2">
+        {daemons.map((d: any) => (
+          <li key={d.id} className="rounded border border-white/10 p-3 text-sm">
+            <div className="font-medium">{d.hostname}</div>
+            <div className="text-[var(--muted)]">{d.os} · {d.platform} · CLI {d.cliVersion}</div>
+            <div className="text-[var(--muted)]">runtimes: {d.runtimes.filter((r: { available: boolean }) => r.available).map((r: { name: string }) => r.name).join(', ') || '—'}</div>
+            <div className="text-[var(--muted)]">last seen: {new Date(d.lastSeenAt).toLocaleString()}</div>
+          </li>
+        ))}
+        {daemons.length === 0 ? <li className="text-[var(--muted)]">No daemons paired yet.</li> : null}
+      </ul>
+    </main>
+  );
+}

--- a/apps/web/app/share/[token]/route.ts
+++ b/apps/web/app/share/[token]/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server';
+import { eq, and, isNull } from 'drizzle-orm';
+import { hashToken } from '@open-design/shared/tokens';
+import { getDb } from '@open-design/db/client';
+
+// Magic-link landing for /share/<token>. Sets the share cookie and bounces
+// to the project page. Cookie is scoped to the project path so multiple
+// shares on different projects don't clobber each other.
+export async function GET(req: Request, { params }: { params: Promise<{ token: string }> }) {
+  const { token } = await params;
+  const tokenHash = hashToken(token);
+  const { db, schema } = await getDb();
+  const s = schema as typeof import('@open-design/db/schema');
+  const [link] = await (db as any)
+    .select()
+    .from(s.projectShareLink)
+    .where(and(eq(s.projectShareLink.tokenHash, tokenHash), isNull(s.projectShareLink.revokedAt)))
+    .limit(1);
+  if (!link) return new NextResponse('Link is no longer valid', { status: 410 });
+  if (link.expiresAt && new Date(link.expiresAt) < new Date()) {
+    return new NextResponse('Link has expired', { status: 410 });
+  }
+  await (db as any)
+    .update(s.projectShareLink)
+    .set({ lastUsedAt: new Date() })
+    .where(eq(s.projectShareLink.id, link.id));
+
+  const base = new URL(req.url).origin;
+  const dest = `${base}/projects/${link.projectId}`;
+  const res = NextResponse.redirect(dest, 303);
+  res.cookies.set('od_share', token, {
+    path: `/projects/${link.projectId}`,
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: 60 * 60 * 24 * 30,
+  });
+  return res;
+}

--- a/apps/web/lib/access.ts
+++ b/apps/web/lib/access.ts
@@ -1,0 +1,61 @@
+// Project ACL helper. A user can access a project if they are a member of
+// its workspace OR if the request carries a valid project share token in
+// the `od_share` cookie / `?share=` query param.
+import { cookies } from 'next/headers';
+import { eq, and, isNull } from 'drizzle-orm';
+import { hashToken } from '@open-design/shared/tokens';
+import { getDb } from '@open-design/db/client';
+import type { JwtClaims } from '@open-design/shared/jwt';
+import type { ShareRole } from '@open-design/shared';
+
+export type ProjectAccess =
+  | { ok: true; via: 'member'; role: 'owner' | 'admin' | 'member' }
+  | { ok: true; via: 'share'; role: ShareRole }
+  | { ok: false; reason: 'unauthorized' | 'not_found' };
+
+export async function resolveProjectAccess(
+  projectId: string,
+  session: JwtClaims | null,
+  shareToken?: string | null,
+): Promise<ProjectAccess> {
+  const { db, schema } = await getDb();
+  const s = schema as typeof import('@open-design/db/schema');
+  const [project] = await (db as any)
+    .select()
+    .from(s.project)
+    .where(eq(s.project.id, projectId))
+    .limit(1);
+  if (!project) return { ok: false, reason: 'not_found' };
+
+  if (session) {
+    const ws = session.workspaces.find((w) => w.id === project.workspaceId);
+    if (ws) return { ok: true, via: 'member', role: ws.role };
+  }
+
+  if (!shareToken) {
+    const c = await cookies();
+    shareToken = c.get('od_share')?.value ?? null;
+  }
+  if (shareToken) {
+    const tokenHash = hashToken(shareToken);
+    const [link] = await (db as any)
+      .select()
+      .from(s.projectShareLink)
+      .where(
+        and(
+          eq(s.projectShareLink.tokenHash, tokenHash),
+          eq(s.projectShareLink.projectId, projectId),
+          isNull(s.projectShareLink.revokedAt),
+        ),
+      )
+      .limit(1);
+    if (link) {
+      if (link.expiresAt && new Date(link.expiresAt) < new Date()) {
+        return { ok: false, reason: 'unauthorized' };
+      }
+      return { ok: true, via: 'share', role: link.role as ShareRole };
+    }
+  }
+
+  return { ok: false, reason: 'unauthorized' };
+}

--- a/apps/web/lib/auth/bearer.ts
+++ b/apps/web/lib/auth/bearer.ts
@@ -1,0 +1,47 @@
+// Bearer token verification used by /api/daemon/* and /api/cli/* routes.
+// Two token shapes are accepted:
+//   - Personal Access Token (`od_pat_…`)  — used during CLI bootstrap (login → daemon register)
+//   - Daemon Token (`od_dt_…`)            — minted on `/api/daemon/register`, used by long-running daemon
+import { hashToken } from '@open-design/shared/tokens';
+import { getDb } from '@open-design/db/client';
+import { eq, isNull } from 'drizzle-orm';
+
+export interface AuthedUser {
+  userId: string;
+  workspaceId?: string;
+  daemonId?: string;
+  via: 'pat' | 'daemon';
+}
+
+export async function authenticateBearer(req: Request): Promise<AuthedUser | null> {
+  const header = req.headers.get('authorization');
+  if (!header?.startsWith('Bearer ')) return null;
+  const token = header.slice('Bearer '.length).trim();
+  const tokenHash = hashToken(token);
+  const { db, schema, dialect } = await getDb();
+  // Cast the schema once; concrete query shape is identical across dialects.
+  const s = schema as typeof import('@open-design/db/schema');
+
+  if (token.startsWith('od_dt_')) {
+    const [row] = await (db as any)
+      .select()
+      .from(s.daemonRegistration)
+      .where(eq(s.daemonRegistration.tokenHash, tokenHash))
+      .limit(1);
+    if (!row || row.revokedAt) return null;
+    return { userId: row.userId, workspaceId: row.workspaceId, daemonId: row.id, via: 'daemon' };
+  }
+  if (token.startsWith('od_pat_')) {
+    const [row] = await (db as any)
+      .select()
+      .from(s.personalAccessToken)
+      .where(eq(s.personalAccessToken.tokenHash, tokenHash))
+      .limit(1);
+    if (!row) return null;
+    if (row.expiresAt && new Date(row.expiresAt) < new Date()) return null;
+    return { userId: row.userId, via: 'pat' };
+  }
+  void isNull; // silence unused import
+  void dialect;
+  return null;
+}

--- a/apps/web/lib/auth/session.ts
+++ b/apps/web/lib/auth/session.ts
@@ -1,0 +1,33 @@
+import { cookies } from 'next/headers';
+import { jwtSecretFromEnv, signSessionJwt, verifySessionJwt, type JwtClaims } from '@open-design/shared/jwt';
+
+const COOKIE = 'od_session';
+
+export async function getSessionFromCookies(): Promise<JwtClaims | null> {
+  const c = await cookies();
+  const raw = c.get(COOKIE)?.value;
+  if (!raw) return null;
+  try {
+    return await verifySessionJwt(raw, jwtSecretFromEnv());
+  } catch {
+    return null;
+  }
+}
+
+export async function setSessionCookie(claims: JwtClaims): Promise<string> {
+  const token = await signSessionJwt(claims, jwtSecretFromEnv());
+  const c = await cookies();
+  c.set(COOKIE, token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 60 * 60 * 24 * 30,
+  });
+  return token;
+}
+
+export async function clearSessionCookie() {
+  const c = await cookies();
+  c.delete(COOKIE);
+}

--- a/apps/web/lib/email.ts
+++ b/apps/web/lib/email.ts
@@ -1,0 +1,30 @@
+// Pluggable email sender. In dev, prints the code to stdout. In production,
+// swap in Resend/SES by setting EMAIL_PROVIDER and the matching env vars.
+export async function sendEmail(opts: { to: string; subject: string; text: string }): Promise<void> {
+  const provider = process.env.EMAIL_PROVIDER ?? 'console';
+  if (provider === 'console') {
+    // eslint-disable-next-line no-console
+    console.log(`\n[email→${opts.to}] ${opts.subject}\n${opts.text}\n`);
+    return;
+  }
+  if (provider === 'resend') {
+    const apiKey = process.env.RESEND_API_KEY;
+    if (!apiKey) throw new Error('RESEND_API_KEY missing');
+    const r = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        from: process.env.EMAIL_FROM ?? 'Open Design <noreply@open-design.app>',
+        to: [opts.to],
+        subject: opts.subject,
+        text: opts.text,
+      }),
+    });
+    if (!r.ok) throw new Error(`resend failed: ${r.status} ${await r.text()}`);
+    return;
+  }
+  throw new Error(`Unknown EMAIL_PROVIDER: ${provider}`);
+}

--- a/apps/web/lib/realtime.ts
+++ b/apps/web/lib/realtime.ts
@@ -1,0 +1,59 @@
+// In-process pub/sub for SSE fan-out. Per-task subscriber sets indexed by
+// taskId; the daemon-message route publishes here and the SSE endpoint subscribes.
+//
+// In a multi-instance deployment, swap this module for Redis Pub/Sub or
+// Postgres LISTEN/NOTIFY (BAR set: keep the same call signature).
+type Sub = (msg: { seq: number; kind: string; payload: unknown }) => void;
+
+const subs = new Map<string, Set<Sub>>();
+const daemonWakeups = new Map<string, Set<Sub>>(); // keyed by daemon id
+
+export function subscribeTask(taskId: string, fn: Sub): () => void {
+  let set = subs.get(taskId);
+  if (!set) {
+    set = new Set();
+    subs.set(taskId, set);
+  }
+  set.add(fn);
+  return () => {
+    set!.delete(fn);
+    if (set!.size === 0) subs.delete(taskId);
+  };
+}
+
+export function broadcastTaskMessage(taskId: string, msg: { seq: number; kind: string; payload: unknown }) {
+  const set = subs.get(taskId);
+  if (!set) return;
+  for (const fn of set) {
+    try {
+      fn(msg);
+    } catch {
+      // swallow
+    }
+  }
+}
+
+export function subscribeDaemonWakeups(daemonId: string, fn: Sub): () => void {
+  let set = daemonWakeups.get(daemonId);
+  if (!set) {
+    set = new Set();
+    daemonWakeups.set(daemonId, set);
+  }
+  set.add(fn);
+  return () => {
+    set!.delete(fn);
+    if (set!.size === 0) daemonWakeups.delete(daemonId);
+  };
+}
+
+export function wakeDaemon(daemonId: string, msg: { seq: number; kind: string; payload: unknown }) {
+  const set = daemonWakeups.get(daemonId);
+  if (!set) return;
+  for (const fn of set) {
+    try {
+      fn(msg);
+    } catch {
+      // swallow
+    }
+  }
+}

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,0 +1,17 @@
+import type { NextConfig } from 'next';
+
+const config: NextConfig = {
+  experimental: {
+    typedRoutes: true,
+  },
+  serverExternalPackages: ['better-sqlite3', 'postgres'],
+  // Skills + design-systems are repo-bundled and read at request time. They
+  // live one level up from apps/web; expose their root via env so route
+  // handlers can resolve them.
+  env: {
+    SKILLS_ROOT: process.env.SKILLS_ROOT ?? '../../skills',
+    DESIGN_SYSTEMS_ROOT: process.env.DESIGN_SYSTEMS_ROOT ?? '../../design-systems',
+  },
+};
+
+export default config;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@open-design/web",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev --turbopack -p 3000",
+    "build": "next build",
+    "start": "next start -p 3000",
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@open-design/db": "workspace:*",
+    "@open-design/shared": "workspace:*",
+    "drizzle-orm": "^0.36.4",
+    "jose": "^5.9.6",
+    "nanoid": "^5.0.7",
+    "next": "16.0.0-canary.50",
+    "react": "19.0.0",
+    "react-dom": "19.0.0",
+    "ws": "^8.18.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^22.7.4",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@types/ws": "^8.5.13",
+    "tailwindcss": "^4.0.0",
+    "@tailwindcss/postcss": "^4.0.0",
+    "postcss": "^8.4.47",
+    "typescript": "^5.6.3"
+  }
+}

--- a/apps/web/postcss.config.mjs
+++ b/apps/web/postcss.config.mjs
@@ -1,0 +1,5 @@
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+};

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/docs/architecture-cloud.md
+++ b/docs/architecture-cloud.md
@@ -1,0 +1,127 @@
+# Architecture: cloud UI + local daemon (Next.js 16 refactor)
+
+> Supersedes `architecture.md` for the new stack. Legacy Vite + Express docs remain valid for the `src/` and `daemon/` directories preserved on this branch.
+
+This branch refactors Open Design from a Vite SPA + Express daemon (localhost-only) into a cloud-deployable Next.js 16 App Router product paired with a local `od` daemon CLI. Modeled on [multica-ai/multica](https://github.com/multica-ai/multica), unified onto a TypeScript stack.
+
+```
+                                   ┌──────────────────────────┐
+  ┌──────────┐                     │                          │
+  │ Browser  │ ─── HTTP/SSE ─────► │  apps/web (Next.js 16)   │
+  └──────────┘                     │  • Login / share / UI    │
+                                   │  • Drizzle → PG/SQLite   │
+                                   │  • SSE fan-out hub       │
+                                   └─────────┬─▲──────────────┘
+                                             │ │
+                          POST /tasks claim  │ │  task_messages
+                          GET /wakeups (SSE) │ │  (POST per chunk)
+                                             ▼ │
+                                   ┌──────────────────────────┐
+                                   │  apps/cli (`od daemon`)  │
+                                   │  • Profile @ ~/.od       │
+                                   │  • Spawns claude/codex/… │
+                                   └──────────────────────────┘
+```
+
+## Auth flow (browser-callback OAuth, no device codes)
+
+1. `od login` binds `127.0.0.1:<rand>`, opens browser to `${WEB}/login?cli_callback=…&cli_state=…`.
+2. User signs in (email 6-digit code).
+3. After verify, the web app redirects to the local listener with a freshly minted **PAT** (`od_pat_…`).
+4. PAT is stored at `~/.od/profiles/<name>/config.json` (mode 0600). State string is verified to prevent CSRF.
+
+## Daemon registration
+
+1. `od daemon` boot:
+   - PAT-authenticates `POST /api/daemon/register` with hostname, OS, runtimes detected on PATH.
+   - Server returns a workspace-scoped **daemon token** (`od_dt_…`). Token is hashed at rest.
+2. Daemon then uses the daemon token for everything else; PAT is no longer touched until next `od login`.
+3. Heartbeats every 15s (`POST /api/daemon/heartbeat`).
+
+## Task flow
+
+1. Browser calls `POST /api/projects/<id>/chat` → server inserts an `agent_task` row (status = `queued`) and pings the in-process pub/sub.
+2. Daemon's open SSE connection on `GET /api/daemon/wakeups` receives a `task_available` hint **or** the daemon notices on the next 3s polling cycle.
+3. Daemon `POST /api/daemon/runtimes/<runtimeId>/tasks/claim` performs an atomic `UPDATE … WHERE status='queued'` lease. HTTP claim is the source of truth; SSE wakeup is a latency optimization.
+4. Daemon spawns the matching local agent (claude/codex/…), tees stdout/stderr to `POST /api/daemon/tasks/<taskId>/messages` chunked by `seq`.
+5. Browser opens `GET /api/tasks/<taskId>/stream` (SSE). Server replays persisted `task_message` rows, then forwards new chunks live via the pub/sub.
+6. On `kind: end`, the task row flips to `succeeded`/`failed`.
+
+This mirrors multica's "HTTP-claim + WS-wakeup" hybrid, ported to TS + SSE (which Next.js route handlers support without a custom server).
+
+## Data model (Drizzle)
+
+Single Drizzle schema with both Postgres and SQLite mirrors. Runtime selects by `DATABASE_URL` prefix:
+
+- `postgres://…` → cloud (Vercel/Neon/Supabase)
+- `file:./.od/app.sqlite` → self-hosted single node
+
+Tables:
+
+| table                  | purpose                                                              |
+|------------------------|----------------------------------------------------------------------|
+| `user`                 | one row per signed-in human                                          |
+| `email_verification_code` | 6-digit codes for email login                                     |
+| `workspace` + `member` | tenancy + roles (owner/admin/member)                                 |
+| `workspace_invitation` | email-based invites, 7-day TTL                                       |
+| `personal_access_token`| issued during CLI login, used to bootstrap daemon                    |
+| `daemon_registration`  | one per paired device (workspace-scoped daemon token, hashed)        |
+| `project`              | belongs to workspace                                                 |
+| `project_share_link`   | per-project token + role (view/comment/edit) + optional expiry       |
+| `conversation` / `message` | chat history per project                                         |
+| `project_file`         | metadata; bytes go to S3/GCS or the daemon's local disk              |
+| `agent_task`           | queued/claimed/running/succeeded/failed/cancelled                    |
+| `task_message`         | streamed chunks per task (replayable)                                |
+
+## Sharing & collaboration
+
+Two complementary primitives:
+
+1. **Workspace invitations** (multica-style): `POST /api/workspaces/<wsId>/invitations { email, role }` mints a `od_inv_<token>` link. Accepting it via `/invitations/<token>` adds the user to the `member` table. Recommended for ongoing collaborators who should see all workspace projects.
+
+2. **Project share links** (NEW vs multica): `POST /api/projects/<id>/share { role: view|comment|edit, expiresInDays? }` mints `${PUBLIC_APP_URL}/share/<token>`. Anyone with the link can open the project at the issued role. Cookie binds the share scope to the specific project path. Revoke from the project's settings.
+
+The ACL helper `lib/access.ts` resolves either path uniformly: `member` first, then `share` cookie (or `?share=` query). The page returns a single `ProjectAccess` record so server components and route handlers gate identically.
+
+## Deploy targets
+
+### Cloud (Vercel + Postgres)
+
+```
+DATABASE_URL=postgres://…
+AUTH_JWT_SECRET=…              # 32+ random bytes
+PUBLIC_APP_URL=https://your-app.vercel.app
+EMAIL_PROVIDER=resend
+RESEND_API_KEY=…
+EMAIL_FROM=Open Design <noreply@your-domain>
+```
+
+The web app is fully serverless. SSE works on Vercel (route handlers stream `text/event-stream`) within the platform timeout — for very long agent runs, host on Fly/Railway/your own infra instead.
+
+### Self-host single node
+
+```
+DATABASE_URL=file:./.od/app.sqlite
+AUTH_JWT_SECRET=…
+EMAIL_PROVIDER=console
+```
+
+Run `pnpm --filter @open-design/web build && pnpm --filter @open-design/web start`. SQLite is fine up to a few hundred users.
+
+### Multi-instance
+
+The in-process pub/sub at `apps/web/lib/realtime.ts` is the only piece that doesn't horizontally scale. Swap for Redis Pub/Sub or Postgres `LISTEN/NOTIFY` keeping the same call signature; nothing else needs to change.
+
+## Migration from the legacy stack
+
+The legacy Vite + Express daemon (`src/`, `daemon/`) is preserved in this branch under the `legacy:*` npm scripts so we can run both stacks side-by-side during the transition. Skills and design-systems directories are unchanged and consumed at request time by the new Next.js app via `SKILLS_ROOT` / `DESIGN_SYSTEMS_ROOT`.
+
+## What's NOT yet ported
+
+These belong in follow-up PRs and are deliberately out of scope for the scaffold:
+
+- File storage adapter (S3/GCS) for the cloud — `project_file.storageKey` is shaped for it but no upload route exists yet.
+- Skill / design-system route handlers — the legacy Express endpoints aren't mirrored on Next.js yet.
+- The 28 React components from `src/components/` — only the project shell page exists; chat composer / file viewer / sketch editor still need porting.
+- Anti-slop linter (`daemon/lint-artifact.js`).
+- Anthropic SDK browser-mode fallback.

--- a/package.json
+++ b/package.json
@@ -1,21 +1,26 @@
 {
   "name": "open-design",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
-  "description": "Local-first design product: detects your installed code-agent CLI, runs design skills + design systems, streams artifacts into a sandboxed preview.",
+  "description": "Cloud + local AI design product. Next.js 16 web app pairs with a local `od` daemon CLI to run code-agents on the user's machine.",
   "license": "Apache-2.0",
-  "bin": {
-    "od": "./daemon/cli.js"
-  },
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
   "scripts": {
-    "daemon": "node daemon/cli.js --no-open",
-    "dev": "vite",
-    "dev:all": "node scripts/dev-all.mjs",
-    "build": "tsc -b && vite build",
-    "preview": "vite preview",
-    "typecheck": "tsc -b --noEmit",
-    "start": "npm run build && node daemon/cli.js"
+    "dev": "pnpm --parallel --filter \"./apps/*\" dev",
+    "dev:web": "pnpm --filter @open-design/web dev",
+    "dev:cli": "pnpm --filter @open-design/cli dev",
+    "build": "pnpm -r build",
+    "typecheck": "pnpm -r typecheck",
+    "db:generate": "pnpm --filter @open-design/db generate",
+    "db:migrate": "pnpm --filter @open-design/db migrate",
+    "legacy:dev": "vite",
+    "legacy:daemon": "node daemon/cli.js --no-open",
+    "legacy:dev:all": "node scripts/dev-all.mjs",
+    "legacy:build": "tsc -b && vite build"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.32.1",
@@ -34,7 +39,7 @@
     "vite": "^5.4.11"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'drizzle-kit';
+
+const url = process.env.DATABASE_URL ?? 'postgres://localhost/open_design_dev';
+const dialect = url.startsWith('file:') || url.startsWith('sqlite:') ? 'sqlite' : 'postgresql';
+
+export default defineConfig({
+  out: dialect === 'sqlite' ? './drizzle/sqlite' : './drizzle/pg',
+  schema: dialect === 'sqlite' ? './src/schema-sqlite.ts' : './src/schema.ts',
+  dialect,
+  dbCredentials: { url },
+  strict: true,
+});

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@open-design/db",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./schema": "./src/schema.ts",
+    "./schema/sqlite": "./src/schema-sqlite.ts",
+    "./client": "./src/client.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "generate": "drizzle-kit generate",
+    "migrate": "drizzle-kit migrate"
+  },
+  "dependencies": {
+    "better-sqlite3": "^11.10.0",
+    "drizzle-orm": "^0.36.4",
+    "postgres": "^3.4.5"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.11",
+    "drizzle-kit": "^0.28.1",
+    "typescript": "^5.6.3"
+  }
+}

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,0 +1,50 @@
+// Runtime-selected DB client. DATABASE_URL prefix decides the dialect:
+//   postgres://… → drizzle-orm/postgres-js
+//   file:…       → drizzle-orm/better-sqlite3
+//
+// In Next.js routes, import { getDb } from '@open-design/db/client'.
+// Schema is namespaced per dialect; consumers should pick `pg` (cloud) or `sqlite` (self-host).
+import * as pgSchema from './schema.js';
+import * as sqliteSchema from './schema-sqlite.js';
+
+export type DbDialect = 'postgres' | 'sqlite';
+
+export interface DbHandle {
+  dialect: DbDialect;
+  db: unknown;
+  schema: typeof pgSchema | typeof sqliteSchema;
+}
+
+let cached: DbHandle | null = null;
+
+export async function getDb(): Promise<DbHandle> {
+  if (cached) return cached;
+  const url = process.env.DATABASE_URL;
+  if (!url) throw new Error('DATABASE_URL is required');
+  if (url.startsWith('postgres://') || url.startsWith('postgresql://')) {
+    const { drizzle } = await import('drizzle-orm/postgres-js');
+    const postgres = (await import('postgres')).default;
+    const sql = postgres(url, { max: 10, idle_timeout: 20 });
+    cached = {
+      dialect: 'postgres',
+      db: drizzle(sql, { schema: pgSchema }),
+      schema: pgSchema,
+    };
+    return cached;
+  }
+  if (url.startsWith('file:') || url.startsWith('sqlite:')) {
+    const { drizzle } = await import('drizzle-orm/better-sqlite3');
+    const Database = (await import('better-sqlite3')).default;
+    const path = url.replace(/^(file:|sqlite:)/, '');
+    const sqlite = new Database(path);
+    sqlite.pragma('journal_mode = WAL');
+    sqlite.pragma('foreign_keys = ON');
+    cached = {
+      dialect: 'sqlite',
+      db: drizzle(sqlite, { schema: sqliteSchema }),
+      schema: sqliteSchema,
+    };
+    return cached;
+  }
+  throw new Error(`Unsupported DATABASE_URL: ${url}`);
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,0 +1,4 @@
+export * as pgSchema from './schema.js';
+export * as sqliteSchema from './schema-sqlite.js';
+export { getDb } from './client.js';
+export type { DbDialect, DbHandle } from './client.js';

--- a/packages/db/src/schema-sqlite.ts
+++ b/packages/db/src/schema-sqlite.ts
@@ -1,0 +1,232 @@
+// SQLite mirror of `schema.ts` for self-hosted / local mode.
+// Field shapes match — only the column types differ. Keep in sync by hand.
+import { sqliteTable, text, integer, uniqueIndex, index } from 'drizzle-orm/sqlite-core';
+
+const ts = (name: string) =>
+  integer(name, { mode: 'timestamp' });
+
+export const user = sqliteTable('user', {
+  id: text('id').primaryKey(),
+  email: text('email').notNull().unique(),
+  emailVerifiedAt: ts('email_verified_at'),
+  displayName: text('display_name'),
+  avatarUrl: text('avatar_url'),
+  createdAt: ts('created_at').notNull(),
+});
+
+export const emailVerificationCode = sqliteTable(
+  'email_verification_code',
+  {
+    id: text('id').primaryKey(),
+    email: text('email').notNull(),
+    codeHash: text('code_hash').notNull(),
+    expiresAt: ts('expires_at').notNull(),
+    consumedAt: ts('consumed_at'),
+    createdAt: ts('created_at').notNull(),
+  },
+  (t) => ({ byEmail: index('evc_email_idx').on(t.email) }),
+);
+
+export const workspace = sqliteTable('workspace', {
+  id: text('id').primaryKey(),
+  slug: text('slug').notNull().unique(),
+  name: text('name').notNull(),
+  ownerId: text('owner_id').notNull().references(() => user.id),
+  createdAt: ts('created_at').notNull(),
+});
+
+export const member = sqliteTable(
+  'member',
+  {
+    workspaceId: text('workspace_id').notNull().references(() => workspace.id, { onDelete: 'cascade' }),
+    userId: text('user_id').notNull().references(() => user.id, { onDelete: 'cascade' }),
+    role: text('role', { enum: ['owner', 'admin', 'member'] }).notNull(),
+    createdAt: ts('created_at').notNull(),
+  },
+  (t) => ({
+    pk: uniqueIndex('member_pk').on(t.workspaceId, t.userId),
+    byUser: index('member_user_idx').on(t.userId),
+  }),
+);
+
+export const workspaceInvitation = sqliteTable(
+  'workspace_invitation',
+  {
+    id: text('id').primaryKey(),
+    workspaceId: text('workspace_id').notNull().references(() => workspace.id, { onDelete: 'cascade' }),
+    inviteeEmail: text('invitee_email').notNull(),
+    inviteeUserId: text('invitee_user_id').references(() => user.id),
+    invitedByUserId: text('invited_by_user_id').notNull().references(() => user.id),
+    role: text('role', { enum: ['admin', 'member'] }).notNull(),
+    status: text('status', { enum: ['pending', 'accepted', 'declined', 'expired'] }).notNull(),
+    tokenHash: text('token_hash').notNull(),
+    expiresAt: ts('expires_at').notNull(),
+    createdAt: ts('created_at').notNull(),
+  },
+  (t) => ({
+    byWorkspace: index('inv_workspace_idx').on(t.workspaceId),
+    byEmail: index('inv_email_idx').on(t.inviteeEmail),
+  }),
+);
+
+export const personalAccessToken = sqliteTable(
+  'personal_access_token',
+  {
+    id: text('id').primaryKey(),
+    userId: text('user_id').notNull().references(() => user.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    tokenPrefix: text('token_prefix').notNull(),
+    tokenHash: text('token_hash').notNull(),
+    expiresAt: ts('expires_at'),
+    lastUsedAt: ts('last_used_at'),
+    createdAt: ts('created_at').notNull(),
+  },
+  (t) => ({
+    byUser: index('pat_user_idx').on(t.userId),
+    byHash: uniqueIndex('pat_hash_uk').on(t.tokenHash),
+  }),
+);
+
+export const daemonRegistration = sqliteTable(
+  'daemon_registration',
+  {
+    id: text('id').primaryKey(),
+    workspaceId: text('workspace_id').notNull().references(() => workspace.id, { onDelete: 'cascade' }),
+    userId: text('user_id').notNull().references(() => user.id, { onDelete: 'cascade' }),
+    hostname: text('hostname').notNull(),
+    platform: text('platform').notNull(),
+    os: text('os').notNull(),
+    cliVersion: text('cli_version').notNull(),
+    runtimes: text('runtimes', { mode: 'json' }).$type<Array<{ id: string; name: string; bin: string; version?: string; available: boolean }>>().notNull(),
+    tokenPrefix: text('token_prefix').notNull(),
+    tokenHash: text('token_hash').notNull(),
+    lastSeenAt: ts('last_seen_at').notNull(),
+    revokedAt: ts('revoked_at'),
+    createdAt: ts('created_at').notNull(),
+  },
+  (t) => ({
+    byWorkspace: index('daemon_workspace_idx').on(t.workspaceId),
+    byHash: uniqueIndex('daemon_hash_uk').on(t.tokenHash),
+  }),
+);
+
+export const project = sqliteTable(
+  'project',
+  {
+    id: text('id').primaryKey(),
+    workspaceId: text('workspace_id').notNull().references(() => workspace.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    skillId: text('skill_id'),
+    designSystemId: text('design_system_id'),
+    pendingPrompt: text('pending_prompt'),
+    metadata: text('metadata', { mode: 'json' }).$type<Record<string, unknown>>(),
+    createdByUserId: text('created_by_user_id').notNull().references(() => user.id),
+    createdAt: ts('created_at').notNull(),
+    updatedAt: ts('updated_at').notNull(),
+  },
+  (t) => ({ byWorkspace: index('project_workspace_idx').on(t.workspaceId) }),
+);
+
+export const projectShareLink = sqliteTable(
+  'project_share_link',
+  {
+    id: text('id').primaryKey(),
+    projectId: text('project_id').notNull().references(() => project.id, { onDelete: 'cascade' }),
+    role: text('role', { enum: ['view', 'comment', 'edit'] }).notNull(),
+    tokenPrefix: text('token_prefix').notNull(),
+    tokenHash: text('token_hash').notNull(),
+    createdByUserId: text('created_by_user_id').notNull().references(() => user.id),
+    expiresAt: ts('expires_at'),
+    revokedAt: ts('revoked_at'),
+    lastUsedAt: ts('last_used_at'),
+    createdAt: ts('created_at').notNull(),
+  },
+  (t) => ({
+    byProject: index('share_project_idx').on(t.projectId),
+    byHash: uniqueIndex('share_hash_uk').on(t.tokenHash),
+  }),
+);
+
+export const conversation = sqliteTable('conversation', {
+  id: text('id').primaryKey(),
+  projectId: text('project_id').notNull().references(() => project.id, { onDelete: 'cascade' }),
+  title: text('title').notNull(),
+  createdAt: ts('created_at').notNull(),
+  updatedAt: ts('updated_at').notNull(),
+});
+
+export const message = sqliteTable('message', {
+  id: text('id').primaryKey(),
+  conversationId: text('conversation_id').notNull().references(() => conversation.id, { onDelete: 'cascade' }),
+  role: text('role').notNull(),
+  content: text('content').notNull(),
+  events: text('events', { mode: 'json' }).$type<unknown[]>(),
+  attachments: text('attachments', { mode: 'json' }).$type<unknown[]>(),
+  producedFiles: text('produced_files', { mode: 'json' }).$type<unknown[]>(),
+  startedAt: ts('started_at'),
+  endedAt: ts('ended_at'),
+  position: integer('position').notNull(),
+  createdAt: ts('created_at').notNull(),
+});
+
+export const projectFile = sqliteTable(
+  'project_file',
+  {
+    id: text('id').primaryKey(),
+    projectId: text('project_id').notNull().references(() => project.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    mime: text('mime').notNull(),
+    size: integer('size').notNull(),
+    storageKey: text('storage_key').notNull(),
+    createdAt: ts('created_at').notNull(),
+    updatedAt: ts('updated_at').notNull(),
+  },
+  (t) => ({
+    byProject: index('project_file_project_idx').on(t.projectId),
+    nameUnique: uniqueIndex('project_file_name_uk').on(t.projectId, t.name),
+  }),
+);
+
+export const agentTask = sqliteTable(
+  'agent_task',
+  {
+    id: text('id').primaryKey(),
+    workspaceId: text('workspace_id').notNull().references(() => workspace.id, { onDelete: 'cascade' }),
+    projectId: text('project_id').notNull().references(() => project.id, { onDelete: 'cascade' }),
+    conversationId: text('conversation_id').references(() => conversation.id),
+    runtimeId: text('runtime_id').notNull(),
+    requestedByUserId: text('requested_by_user_id').notNull().references(() => user.id),
+    payload: text('payload', { mode: 'json' }).$type<{
+      systemPrompt: string;
+      message: string;
+      attachments?: Array<{ name: string; mime: string; storageKey: string }>;
+      cwdHint?: string;
+    }>().notNull(),
+    status: text('status', {
+      enum: ['queued', 'claimed', 'running', 'succeeded', 'failed', 'cancelled'],
+    }).notNull(),
+    leasedByDaemonId: text('leased_by_daemon_id'),
+    leaseExpiresAt: ts('lease_expires_at'),
+    error: text('error'),
+    createdAt: ts('created_at').notNull(),
+    updatedAt: ts('updated_at').notNull(),
+  },
+  (t) => ({
+    byStatus: index('agent_task_status_idx').on(t.workspaceId, t.runtimeId, t.status),
+  }),
+);
+
+export const taskMessage = sqliteTable(
+  'task_message',
+  {
+    id: text('id').primaryKey(),
+    taskId: text('task_id').notNull().references(() => agentTask.id, { onDelete: 'cascade' }),
+    seq: integer('seq').notNull(),
+    kind: text('kind', { enum: ['stdout', 'stderr', 'agent', 'status', 'end'] }).notNull(),
+    payload: text('payload', { mode: 'json' }),
+    createdAt: ts('created_at').notNull(),
+  },
+  (t) => ({
+    byTask: uniqueIndex('task_message_seq_uk').on(t.taskId, t.seq),
+  }),
+);

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,0 +1,257 @@
+// Postgres dialect (cloud).
+// SQLite mirror lives in `./schema-sqlite.ts` — keep the two in sync by hand;
+// the field shapes are identical, only the column types differ.
+import { pgTable, text, timestamp, integer, jsonb, boolean, index, uniqueIndex } from 'drizzle-orm/pg-core';
+import { relations } from 'drizzle-orm';
+
+export const user = pgTable('user', {
+  id: text('id').primaryKey(),
+  email: text('email').notNull().unique(),
+  emailVerifiedAt: timestamp('email_verified_at', { withTimezone: true }),
+  displayName: text('display_name'),
+  avatarUrl: text('avatar_url'),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+});
+
+export const emailVerificationCode = pgTable(
+  'email_verification_code',
+  {
+    id: text('id').primaryKey(),
+    email: text('email').notNull(),
+    codeHash: text('code_hash').notNull(),
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    consumedAt: timestamp('consumed_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({ byEmail: index('email_verification_code_email_idx').on(t.email) }),
+);
+
+export const workspace = pgTable('workspace', {
+  id: text('id').primaryKey(),
+  slug: text('slug').notNull().unique(),
+  name: text('name').notNull(),
+  ownerId: text('owner_id').notNull().references(() => user.id, { onDelete: 'restrict' }),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+});
+
+export const member = pgTable(
+  'member',
+  {
+    workspaceId: text('workspace_id').notNull().references(() => workspace.id, { onDelete: 'cascade' }),
+    userId: text('user_id').notNull().references(() => user.id, { onDelete: 'cascade' }),
+    role: text('role', { enum: ['owner', 'admin', 'member'] }).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    pk: uniqueIndex('member_pk').on(t.workspaceId, t.userId),
+    byUser: index('member_user_idx').on(t.userId),
+  }),
+);
+
+export const workspaceInvitation = pgTable(
+  'workspace_invitation',
+  {
+    id: text('id').primaryKey(),
+    workspaceId: text('workspace_id').notNull().references(() => workspace.id, { onDelete: 'cascade' }),
+    inviteeEmail: text('invitee_email').notNull(),
+    inviteeUserId: text('invitee_user_id').references(() => user.id, { onDelete: 'set null' }),
+    invitedByUserId: text('invited_by_user_id').notNull().references(() => user.id, { onDelete: 'cascade' }),
+    role: text('role', { enum: ['admin', 'member'] }).notNull(),
+    status: text('status', { enum: ['pending', 'accepted', 'declined', 'expired'] }).notNull(),
+    tokenHash: text('token_hash').notNull(),
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    byWorkspace: index('workspace_invitation_workspace_idx').on(t.workspaceId),
+    byEmail: index('workspace_invitation_email_idx').on(t.inviteeEmail),
+  }),
+);
+
+export const personalAccessToken = pgTable(
+  'personal_access_token',
+  {
+    id: text('id').primaryKey(),
+    userId: text('user_id').notNull().references(() => user.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    tokenPrefix: text('token_prefix').notNull(),
+    tokenHash: text('token_hash').notNull(),
+    expiresAt: timestamp('expires_at', { withTimezone: true }),
+    lastUsedAt: timestamp('last_used_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    byUser: index('pat_user_idx').on(t.userId),
+    byHash: uniqueIndex('pat_hash_uk').on(t.tokenHash),
+  }),
+);
+
+export const daemonRegistration = pgTable(
+  'daemon_registration',
+  {
+    id: text('id').primaryKey(),
+    workspaceId: text('workspace_id').notNull().references(() => workspace.id, { onDelete: 'cascade' }),
+    userId: text('user_id').notNull().references(() => user.id, { onDelete: 'cascade' }),
+    hostname: text('hostname').notNull(),
+    platform: text('platform').notNull(),
+    os: text('os').notNull(),
+    cliVersion: text('cli_version').notNull(),
+    runtimes: jsonb('runtimes').$type<Array<{ id: string; name: string; bin: string; version?: string; available: boolean }>>().notNull(),
+    tokenPrefix: text('token_prefix').notNull(),
+    tokenHash: text('token_hash').notNull(),
+    lastSeenAt: timestamp('last_seen_at', { withTimezone: true }).defaultNow().notNull(),
+    revokedAt: timestamp('revoked_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    byWorkspace: index('daemon_workspace_idx').on(t.workspaceId),
+    byHash: uniqueIndex('daemon_hash_uk').on(t.tokenHash),
+  }),
+);
+
+export const project = pgTable(
+  'project',
+  {
+    id: text('id').primaryKey(),
+    workspaceId: text('workspace_id').notNull().references(() => workspace.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    skillId: text('skill_id'),
+    designSystemId: text('design_system_id'),
+    pendingPrompt: text('pending_prompt'),
+    metadata: jsonb('metadata').$type<Record<string, unknown>>(),
+    createdByUserId: text('created_by_user_id').notNull().references(() => user.id, { onDelete: 'restrict' }),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({ byWorkspace: index('project_workspace_idx').on(t.workspaceId) }),
+);
+
+export const projectShareLink = pgTable(
+  'project_share_link',
+  {
+    id: text('id').primaryKey(),
+    projectId: text('project_id').notNull().references(() => project.id, { onDelete: 'cascade' }),
+    role: text('role', { enum: ['view', 'comment', 'edit'] }).notNull(),
+    tokenPrefix: text('token_prefix').notNull(),
+    tokenHash: text('token_hash').notNull(),
+    createdByUserId: text('created_by_user_id').notNull().references(() => user.id, { onDelete: 'cascade' }),
+    expiresAt: timestamp('expires_at', { withTimezone: true }),
+    revokedAt: timestamp('revoked_at', { withTimezone: true }),
+    lastUsedAt: timestamp('last_used_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    byProject: index('share_project_idx').on(t.projectId),
+    byHash: uniqueIndex('share_hash_uk').on(t.tokenHash),
+  }),
+);
+
+export const conversation = pgTable(
+  'conversation',
+  {
+    id: text('id').primaryKey(),
+    projectId: text('project_id').notNull().references(() => project.id, { onDelete: 'cascade' }),
+    title: text('title').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({ byProject: index('conversation_project_idx').on(t.projectId) }),
+);
+
+export const message = pgTable(
+  'message',
+  {
+    id: text('id').primaryKey(),
+    conversationId: text('conversation_id').notNull().references(() => conversation.id, { onDelete: 'cascade' }),
+    role: text('role').notNull(),
+    content: text('content').notNull(),
+    events: jsonb('events').$type<unknown[]>(),
+    attachments: jsonb('attachments').$type<unknown[]>(),
+    producedFiles: jsonb('produced_files').$type<unknown[]>(),
+    startedAt: timestamp('started_at', { withTimezone: true }),
+    endedAt: timestamp('ended_at', { withTimezone: true }),
+    position: integer('position').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({ byConversation: index('message_conversation_idx').on(t.conversationId, t.position) }),
+);
+
+export const projectFile = pgTable(
+  'project_file',
+  {
+    id: text('id').primaryKey(),
+    projectId: text('project_id').notNull().references(() => project.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    mime: text('mime').notNull(),
+    size: integer('size').notNull(),
+    storageKey: text('storage_key').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    byProject: index('project_file_project_idx').on(t.projectId),
+    nameUnique: uniqueIndex('project_file_name_uk').on(t.projectId, t.name),
+  }),
+);
+
+export const agentTask = pgTable(
+  'agent_task',
+  {
+    id: text('id').primaryKey(),
+    workspaceId: text('workspace_id').notNull().references(() => workspace.id, { onDelete: 'cascade' }),
+    projectId: text('project_id').notNull().references(() => project.id, { onDelete: 'cascade' }),
+    conversationId: text('conversation_id').references(() => conversation.id, { onDelete: 'set null' }),
+    runtimeId: text('runtime_id').notNull(),
+    requestedByUserId: text('requested_by_user_id').notNull().references(() => user.id, { onDelete: 'cascade' }),
+    payload: jsonb('payload').$type<{
+      systemPrompt: string;
+      message: string;
+      attachments?: Array<{ name: string; mime: string; storageKey: string }>;
+      cwdHint?: string;
+    }>().notNull(),
+    status: text('status', {
+      enum: ['queued', 'claimed', 'running', 'succeeded', 'failed', 'cancelled'],
+    }).notNull(),
+    leasedByDaemonId: text('leased_by_daemon_id').references(() => daemonRegistration.id, { onDelete: 'set null' }),
+    leaseExpiresAt: timestamp('lease_expires_at', { withTimezone: true }),
+    error: text('error'),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    byStatus: index('agent_task_status_idx').on(t.workspaceId, t.runtimeId, t.status),
+  }),
+);
+
+export const taskMessage = pgTable(
+  'task_message',
+  {
+    id: text('id').primaryKey(),
+    taskId: text('task_id').notNull().references(() => agentTask.id, { onDelete: 'cascade' }),
+    seq: integer('seq').notNull(),
+    kind: text('kind', { enum: ['stdout', 'stderr', 'agent', 'status', 'end'] }).notNull(),
+    payload: jsonb('payload'),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => ({
+    byTask: uniqueIndex('task_message_seq_uk').on(t.taskId, t.seq),
+  }),
+);
+
+export const userRelations = relations(user, ({ many }) => ({
+  memberships: many(member),
+  pats: many(personalAccessToken),
+}));
+
+export const workspaceRelations = relations(workspace, ({ many, one }) => ({
+  members: many(member),
+  projects: many(project),
+  owner: one(user, { fields: [workspace.ownerId], references: [user.id] }),
+}));
+
+export const projectRelations = relations(project, ({ one, many }) => ({
+  workspace: one(workspace, { fields: [project.workspaceId], references: [workspace.id] }),
+  conversations: many(conversation),
+  shareLinks: many(projectShareLink),
+  files: many(projectFile),
+}));

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@open-design/shared",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./jwt": "./src/jwt.ts",
+    "./tokens": "./src/tokens.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "jose": "^5.9.6",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.3"
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,3 @@
+export * from './schemas.js';
+export * from './tokens.js';
+export type { JwtClaims } from './jwt.js';

--- a/packages/shared/src/jwt.ts
+++ b/packages/shared/src/jwt.ts
@@ -1,0 +1,35 @@
+import { SignJWT, jwtVerify } from 'jose';
+
+export interface JwtClaims {
+  sub: string;
+  email: string;
+  workspaces: Array<{ id: string; role: 'owner' | 'admin' | 'member' }>;
+}
+
+const ALG = 'HS256';
+
+export async function signSessionJwt(
+  claims: JwtClaims,
+  secret: Uint8Array,
+  expiresIn = '30d',
+): Promise<string> {
+  return new SignJWT(claims as unknown as Record<string, unknown>)
+    .setProtectedHeader({ alg: ALG })
+    .setIssuedAt()
+    .setExpirationTime(expiresIn)
+    .sign(secret);
+}
+
+export async function verifySessionJwt(
+  token: string,
+  secret: Uint8Array,
+): Promise<JwtClaims> {
+  const { payload } = await jwtVerify(token, secret);
+  return payload as unknown as JwtClaims;
+}
+
+export function jwtSecretFromEnv(env: NodeJS.ProcessEnv = process.env): Uint8Array {
+  const raw = env.AUTH_JWT_SECRET ?? env.JWT_SECRET;
+  if (!raw) throw new Error('AUTH_JWT_SECRET is required');
+  return new TextEncoder().encode(raw);
+}

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -1,0 +1,83 @@
+import { z } from 'zod';
+
+export const SendCodeRequest = z.object({
+  email: z.string().email(),
+});
+
+export const VerifyCodeRequest = z.object({
+  email: z.string().email(),
+  code: z.string().regex(/^\d{6}$/),
+  cliCallback: z.string().url().optional(),
+  cliState: z.string().min(8).optional(),
+});
+
+export const RegisterDaemonRequest = z.object({
+  workspaceId: z.string(),
+  hostname: z.string(),
+  platform: z.string(),
+  os: z.string(),
+  cliVersion: z.string(),
+  runtimes: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+      bin: z.string(),
+      version: z.string().optional(),
+      available: z.boolean(),
+    }),
+  ),
+});
+
+export const ClaimTaskRequest = z.object({
+  runtimeId: z.string(),
+});
+
+export const TaskMessageRequest = z.object({
+  taskId: z.string(),
+  kind: z.enum(['stdout', 'stderr', 'agent', 'status', 'end']),
+  payload: z.unknown(),
+  seq: z.number().int().nonnegative(),
+});
+
+export const CreateProjectRequest = z.object({
+  name: z.string().min(1).max(120),
+  workspaceId: z.string(),
+  skillId: z.string().optional(),
+  designSystemId: z.string().optional(),
+  pendingPrompt: z.string().optional(),
+});
+
+export const CreateShareLinkRequest = z.object({
+  role: z.enum(['view', 'comment', 'edit']),
+  expiresInDays: z.number().int().positive().max(365).optional(),
+});
+
+export const InviteMemberRequest = z.object({
+  email: z.string().email(),
+  role: z.enum(['admin', 'member']),
+});
+
+export type SendCodeRequest = z.infer<typeof SendCodeRequest>;
+export type VerifyCodeRequest = z.infer<typeof VerifyCodeRequest>;
+export type RegisterDaemonRequest = z.infer<typeof RegisterDaemonRequest>;
+export type ClaimTaskRequest = z.infer<typeof ClaimTaskRequest>;
+export type TaskMessageRequest = z.infer<typeof TaskMessageRequest>;
+export type CreateProjectRequest = z.infer<typeof CreateProjectRequest>;
+export type CreateShareLinkRequest = z.infer<typeof CreateShareLinkRequest>;
+export type InviteMemberRequest = z.infer<typeof InviteMemberRequest>;
+
+export const TaskStatus = z.enum([
+  'queued',
+  'claimed',
+  'running',
+  'succeeded',
+  'failed',
+  'cancelled',
+]);
+export type TaskStatus = z.infer<typeof TaskStatus>;
+
+export const ShareRole = z.enum(['view', 'comment', 'edit']);
+export type ShareRole = z.infer<typeof ShareRole>;
+
+export const MemberRole = z.enum(['owner', 'admin', 'member']);
+export type MemberRole = z.infer<typeof MemberRole>;

--- a/packages/shared/src/tokens.ts
+++ b/packages/shared/src/tokens.ts
@@ -1,0 +1,41 @@
+import { randomBytes, createHash } from 'node:crypto';
+
+const PAT_PREFIX = 'od_pat_';
+const DAEMON_TOKEN_PREFIX = 'od_dt_';
+const SHARE_LINK_PREFIX = 'od_share_';
+
+export function generatePat(): { token: string; prefix: string; hash: string } {
+  return makeToken(PAT_PREFIX, 32);
+}
+
+export function generateDaemonToken(): { token: string; prefix: string; hash: string } {
+  return makeToken(DAEMON_TOKEN_PREFIX, 32);
+}
+
+export function generateShareLinkToken(): { token: string; prefix: string; hash: string } {
+  return makeToken(SHARE_LINK_PREFIX, 18);
+}
+
+export function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+export function tokenPrefix(token: string): string {
+  return token.slice(0, 12);
+}
+
+function makeToken(prefix: string, byteLen: number) {
+  const raw = randomBytes(byteLen).toString('base64url');
+  const token = `${prefix}${raw}`;
+  return {
+    token,
+    prefix: tokenPrefix(token),
+    hash: hashToken(token),
+  };
+}
+
+export const TOKEN_PREFIXES = {
+  pat: PAT_PREFIX,
+  daemon: DAEMON_TOKEN_PREFIX,
+  share: SHARE_LINK_PREFIX,
+};

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,9 @@
+packages:
+  - 'apps/*'
+  - 'packages/*'
+
+catalog:
+  typescript: ^5.6.3
+  zod: ^3.23.8
+  drizzle-orm: ^0.36.4
+  drizzle-kit: ^0.28.1


### PR DESCRIPTION
## Summary
- Restructures into a pnpm workspace (`apps/web`, `apps/cli`, `packages/db`, `packages/shared`) modeled on multica-ai/multica, unified on TypeScript. The product can now run as a hosted Next.js 16 App Router app that pairs with a local `od` daemon CLI to execute code-agents on the user's machine.
- Adds end-to-end auth + pairing: 6-digit email code login, browser-callback OAuth for the CLI (`od_pat_…` PAT bootstrap → workspace-scoped `od_dt_…` daemon token), Drizzle schema with both Postgres (cloud) and SQLite (self-host) dialects selected by `DATABASE_URL`.
- Adds two sharing primitives so cloud projects can invite collaborators: multica-style `workspace_invitation` (email → membership) **plus** a per-project `project_share_link` (`/share/<token>` with view/comment/edit role) — anyone with the link gets the issued role on that single project, no workspace access required.

## What's in
- **`apps/web`** — Next.js 16 App Router. Pages: `/`, `/login`, `/projects`, `/projects/:id`, `/settings/daemon`, `/share/:token`, `/invitations/:token`. API: auth (`/api/auth/{send,verify}-code`), daemon (`/api/daemon/{register,heartbeat,wakeups,runtimes/.../tasks/claim,tasks/.../messages}`), browser SSE (`/api/tasks/:id/stream`), projects + share + invitations.
- **`apps/cli`** — `od login`, `od daemon`, `od setup`. Profile-based config at `~/.od/profiles/<name>/config.json`. Probes `claude`/`codex`/`gemini`/`opencode`/`cursor-agent` on PATH. HTTP-claim authoritative + SSE wakeup for low latency, mirroring multica's hybrid transport.
- **`packages/db`** — Drizzle schema with PG + SQLite mirrors, `getDb()` runtime selector, drizzle-kit config branching on dialect.
- **`packages/shared`** — zod request schemas, JWT helpers (jose, HS256), token mint/hash helpers (`od_pat_*`, `od_dt_*`, `od_share_*`, `od_inv_*`).
- **Docs** — `HANDOFF.md` (file-by-file walkthrough, public surface, merge guidance) and `docs/architecture-cloud.md` (architecture diagrams, deploy targets).

## What's not in (tracked in HANDOFF.md follow-ups)
- The 28 React components from `src/components/` (chat composer, file workspace, sketch editor) still need porting into `apps/web/app/projects/[id]/`.
- Legacy `/api/skills*` / `/api/design-systems*` route handlers haven't been mirrored on Next.js yet.
- S3/R2/GCS file storage adapter — `project_file.storageKey` is shaped for it but no upload route exists.
- Anti-slop linter (`daemon/lint-artifact.js`).

## Compatibility
Additive only — legacy Vite + Express stack (`src/`, `daemon/`) is preserved alongside under `legacy:*` npm scripts. Root `package.json` is now a pnpm workspace; pnpm is required (`workspace:*` protocol).

## Test plan
- [ ] `pnpm install` at workspace root (deps are net-new: Next 16 canary, Drizzle, jose, tsup)
- [ ] `pnpm --filter @open-design/web typecheck` passes
- [ ] `pnpm --filter @open-design/cli typecheck` passes
- [ ] `pnpm --filter @open-design/db generate` produces migrations against a real `DATABASE_URL`
- [ ] Smoke (self-host): `DATABASE_URL=file:./.od/app.sqlite` → `pnpm --filter @open-design/web dev` → sign in via email-code (look at stdout for the code, since `EMAIL_PROVIDER=console`)
- [ ] CLI pairing: `pnpm --filter @open-design/cli dev login --app-url http://localhost:3000` → `od daemon` registers, then `/settings/daemon` lists the device
- [ ] Sharing: create a project, click Share, paste link in another browser → confirm read-only access at `view` role
- [ ] Workspace invitation: `POST /api/workspaces/<id>/invitations { email, role }` → check stdout for the link → accept in a second browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)