### PR TITLE
fix(daemon): deliver Claude prompt via stdin to avoid Windows ENAMETOOLONG

### DIFF
--- a/daemon/agents.js
+++ b/daemon/agents.js
@@ -102,11 +102,16 @@ export const AGENT_DEFS = [
       { id: 'claude-sonnet-4-5', label: 'claude-sonnet-4-5' },
       { id: 'claude-haiku-4-5', label: 'claude-haiku-4-5' },
     ],
-    buildArgs: (prompt, _imagePaths, extraAllowedDirs = [], options = {}) => {
+    // Prompt delivered via stdin (`claude -p` reads from stdin when no
+    // positional prompt argument is given — documented as "useful for
+    // pipes" in `claude --help`). Avoids Windows `spawn ENAMETOOLONG`
+    // for the composed prompt (base output contract + design system +
+    // skill body + user message), which routinely exceeds CreateProcess's
+    // ~32 KB combined-command-line cap for skills like `magazine-web-ppt`.
+    buildArgs: (_prompt, _imagePaths, extraAllowedDirs = [], options = {}) => {
       const caps = agentCapabilities.get('claude') || {};
       const args = [
         '-p',
-        prompt,
         '--output-format',
         'stream-json',
         '--verbose',
@@ -131,6 +136,7 @@ export const AGENT_DEFS = [
       args.push('--permission-mode', 'bypassPermissions');
       return args;
     },
+    promptViaStdin: true,
     streamFormat: 'claude-stream-json',
   },
   {


### PR DESCRIPTION
Closes #52.

## Why

#15 introduced `promptViaStdin: true` for Codex / Gemini / OpenCode / Cursor / Qwen but explicitly excluded Claude Code (PR description: *"Claude Code is unaffected — it uses the `-p` argv path plus its own stream-json parser"*).

On Windows that exclusion still bites. The composed system prompt (base output contract + design-system body + skill body + user message) routinely exceeds CreateProcess's ~32 KB combined-command-line cap for skills like `magazine-web-ppt` / `guizang-ppt`, and `spawn` errors out with `ENAMETOOLONG` on the very first send. Reproduced by @valkryhx in #51 (Node v22.17.0, `claude.CMD` v2.1.81 npm-installed at `d:\nodejs\node_global\claude.CMD`).

## Verification that Claude Code reads stdin

`-p, --print` in `claude --help` (v2.1.123) is documented as *"Print response and exit (useful for pipes)"*. Confirmed locally:

```
$ echo 'What is 2+2?' | claude -p --output-format stream-json --verbose
{"type":"system","subtype":"init",...}
{"type":"assistant","message":{...,"content":[{"type":"text","text":"4"}]}...}
{"type":"result","subtype":"success",...}
```

When `-p` is given **without** a positional prompt argument, Claude reads from stdin until EOF, then processes — exactly the shape `daemon/server.js` already pipes for the other non-Claude agents.

## What changed

`daemon/agents.js` only:

- Drop the positional `prompt` from Claude's argv. Rename the param to `_prompt` to mark it unused.
- Set `promptViaStdin: true` on the Claude agent def so `daemon/server.js`'s existing stdin-pipe branch (introduced in #15) routes the composed prompt through `child.stdin`.
- Add a comment explaining the change, mirroring the wording on the other five agents.

`daemon/claude-stream.js` is unchanged — the parser only consumes stdout, indifferent to how the prompt arrives. The EPIPE handler #15 added in `daemon/server.js` for fast-exiting CLIs covers Claude for free now.

## Test plan

- [x] `claude -p` reads stdin when no positional prompt arg given (verified above).
- [x] Local syntax check: `node --check daemon/agents.js` passes.
- [ ] Local UI: send a prompt to Claude with a multi-KB skill (`magazine-web-ppt`); confirm SSE streams `text_delta` / `thinking_delta` events as before.
- [ ] Windows verification: @valkryhx to confirm `spawn ENAMETOOLONG` no longer fires after pulling this PR.