### PR TITLE
feat: add artifact platform foundation

### DIFF
--- a/daemon/artifact-manifest.js
+++ b/daemon/artifact-manifest.js
@@ -1,0 +1,221 @@
+import path from 'node:path';
+
+const MANIFEST_VERSION = 1;
+const MAX_TITLE_LENGTH = 200;
+const MAX_ENTRY_LENGTH = 260;
+const MAX_SOURCE_SKILL_ID_LENGTH = 128;
+const MAX_DESIGN_SYSTEM_ID_LENGTH = 128;
+const MAX_SUPPORTING_FILE_LENGTH = 260;
+const MAX_SUPPORTING_FILES = 128;
+const MAX_METADATA_BYTES = 16 * 1024;
+
+const ALLOWED_KINDS = new Set([
+  'html',
+  'deck',
+  'react-component',
+  'markdown-document',
+  'svg',
+  'diagram',
+  'code-snippet',
+  'mini-app',
+  'design-system',
+]);
+
+const ALLOWED_RENDERERS = new Set([
+  'html',
+  'deck-html',
+  'react-component',
+  'markdown',
+  'svg',
+  'diagram',
+  'code',
+  'mini-app',
+  'design-system',
+]);
+
+const ALLOWED_EXPORTS = new Set(['html', 'pdf', 'zip', 'pptx', 'jsx', 'md', 'svg', 'txt']);
+
+function isPlainObject(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function validateBoundedString(value, field, maxLen, { allowEmpty = false } = {}) {
+  if (typeof value !== 'string') return `${field} must be a string`;
+  if (!allowEmpty && value.length === 0) return `${field} is required`;
+  if (value.length > maxLen) return `${field} exceeds max length (${maxLen})`;
+  return null;
+}
+
+function validateSupportingPath(value) {
+  if (typeof value !== 'string') return 'supportingFiles entries must be strings';
+  if (value.length === 0) return 'supportingFiles entries cannot be empty';
+  if (value.length > MAX_SUPPORTING_FILE_LENGTH) {
+    return `supportingFiles entries exceed max length (${MAX_SUPPORTING_FILE_LENGTH})`;
+  }
+  if (/^[A-Za-z]:/.test(value) || value.startsWith('/')) {
+    return 'supportingFiles cannot contain absolute paths';
+  }
+  if (value.includes('\u0000')) return 'supportingFiles cannot contain null bytes';
+  const normalized = value.replace(/\\/g, '/');
+  if (normalized.includes('..')) return 'supportingFiles cannot contain traversal segments';
+  const parts = normalized.split('/').filter(Boolean);
+  if (parts.length === 0 || parts.some((p) => p === '.' || p === '..')) {
+    return 'supportingFiles cannot contain traversal segments';
+  }
+  return null;
+}
+
+export function validateArtifactManifestInput(manifest, entry) {
+  if (manifest == null) return { ok: true, value: null };
+  if (!isPlainObject(manifest)) {
+    return { ok: false, error: 'artifactManifest must be an object' };
+  }
+
+  const kindErr = validateBoundedString(manifest.kind, 'artifactManifest.kind', 64);
+  if (kindErr) return { ok: false, error: kindErr };
+  if (!ALLOWED_KINDS.has(manifest.kind)) {
+    return { ok: false, error: 'artifactManifest.kind is not allowed' };
+  }
+
+  const rendererErr = validateBoundedString(manifest.renderer, 'artifactManifest.renderer', 64);
+  if (rendererErr) return { ok: false, error: rendererErr };
+  if (!ALLOWED_RENDERERS.has(manifest.renderer)) {
+    return { ok: false, error: 'artifactManifest.renderer is not allowed' };
+  }
+
+  if (!Array.isArray(manifest.exports) || manifest.exports.length === 0) {
+    return { ok: false, error: 'artifactManifest.exports must be a non-empty array' };
+  }
+  for (const exp of manifest.exports) {
+    if (typeof exp !== 'string') {
+      return { ok: false, error: 'artifactManifest.exports must contain strings' };
+    }
+    if (!ALLOWED_EXPORTS.has(exp)) {
+      return { ok: false, error: `artifactManifest.exports contains unsupported value: ${exp}` };
+    }
+  }
+
+  if (manifest.supportingFiles !== undefined) {
+    if (!Array.isArray(manifest.supportingFiles)) {
+      return { ok: false, error: 'artifactManifest.supportingFiles must be an array' };
+    }
+    if (manifest.supportingFiles.length > MAX_SUPPORTING_FILES) {
+      return {
+        ok: false,
+        error: `artifactManifest.supportingFiles exceeds max items (${MAX_SUPPORTING_FILES})`,
+      };
+    }
+    for (const rel of manifest.supportingFiles) {
+      const relErr = validateSupportingPath(rel);
+      if (relErr) return { ok: false, error: relErr };
+    }
+  }
+
+  if (manifest.title !== undefined) {
+    const titleErr = validateBoundedString(
+      manifest.title,
+      'artifactManifest.title',
+      MAX_TITLE_LENGTH,
+      { allowEmpty: false },
+    );
+    if (titleErr) return { ok: false, error: titleErr };
+  }
+
+  if (manifest.sourceSkillId !== undefined) {
+    const skillErr = validateBoundedString(
+      manifest.sourceSkillId,
+      'artifactManifest.sourceSkillId',
+      MAX_SOURCE_SKILL_ID_LENGTH,
+      { allowEmpty: true },
+    );
+    if (skillErr) return { ok: false, error: skillErr };
+  }
+
+  if (manifest.designSystemId !== undefined && manifest.designSystemId !== null) {
+    const dsErr = validateBoundedString(
+      manifest.designSystemId,
+      'artifactManifest.designSystemId',
+      MAX_DESIGN_SYSTEM_ID_LENGTH,
+      { allowEmpty: true },
+    );
+    if (dsErr) return { ok: false, error: dsErr };
+  }
+
+  if (manifest.metadata !== undefined) {
+    if (!isPlainObject(manifest.metadata)) {
+      return { ok: false, error: 'artifactManifest.metadata must be a plain object' };
+    }
+    const serialized = JSON.stringify(manifest.metadata);
+    if (typeof serialized !== 'string') {
+      return { ok: false, error: 'artifactManifest.metadata must be JSON-serializable' };
+    }
+    if (Buffer.byteLength(serialized, 'utf8') > MAX_METADATA_BYTES) {
+      return {
+        ok: false,
+        error: `artifactManifest.metadata exceeds max size (${MAX_METADATA_BYTES} bytes)`,
+      };
+    }
+  }
+
+  const safeEntry = typeof entry === 'string' ? entry : '';
+  if (!safeEntry || safeEntry.length > MAX_ENTRY_LENGTH) {
+    return { ok: false, error: `artifact entry exceeds max length (${MAX_ENTRY_LENGTH})` };
+  }
+
+  return { ok: true, value: sanitizeManifest(manifest, safeEntry) };
+}
+
+export function sanitizeManifest(manifest, entry) {
+  const now = new Date().toISOString();
+  return {
+    version: MANIFEST_VERSION,
+    kind: manifest.kind,
+    title: manifest.title || entry,
+    entry,
+    renderer: manifest.renderer,
+    exports: manifest.exports,
+    supportingFiles: Array.isArray(manifest.supportingFiles)
+      ? manifest.supportingFiles.map((x) => x.replace(/\\/g, '/'))
+      : undefined,
+    createdAt: typeof manifest.createdAt === 'string' ? manifest.createdAt : now,
+    updatedAt: now,
+    sourceSkillId: manifest.sourceSkillId,
+    designSystemId: manifest.designSystemId ?? undefined,
+    metadata: manifest.metadata,
+  };
+}
+
+export function parsePersistedManifest(raw, fallbackEntry) {
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || parsed.version !== MANIFEST_VERSION) return null;
+    const entry = typeof parsed.entry === 'string' && parsed.entry ? parsed.entry : fallbackEntry;
+    const result = validateArtifactManifestInput(parsed, entry);
+    return result.ok ? result.value : null;
+  } catch {
+    return null;
+  }
+}
+
+export function inferLegacyManifest(entry) {
+  const lower = entry.toLowerCase();
+  const ext = path.extname(lower);
+  // NOTE: This duplicate heuristic must stay in sync with
+  // src/artifacts/manifest.ts::inferLegacyManifest() until frontend+daemon
+  // inference is moved to a shared runtime-safe module.
+  const isDeck = ext === '.html' && (lower.includes('deck') || lower.includes('slides') || lower.includes('pitch'));
+  if (ext === '.html' || ext === '.htm') {
+    return {
+      version: MANIFEST_VERSION,
+      kind: isDeck ? 'deck' : 'html',
+      title: entry,
+      entry,
+      renderer: isDeck ? 'deck-html' : 'html',
+      exports: isDeck ? ['html', 'pdf', 'pptx', 'zip'] : ['html', 'pdf', 'zip'],
+      metadata: { inferred: true },
+    };
+  }
+  return null;
+}

--- a/daemon/artifact-manifest.test.ts
+++ b/daemon/artifact-manifest.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { validateArtifactManifestInput } from './artifact-manifest.js';
+
+function validBase() {
+  return {
+    kind: 'html',
+    renderer: 'html',
+    title: 'Test',
+    exports: ['html'],
+  };
+}
+
+describe('validateArtifactManifestInput', () => {
+  it('rejects empty exports', () => {
+    const res = validateArtifactManifestInput({ ...validBase(), exports: [] }, 'index.html');
+    expect(res.ok).toBe(false);
+  });
+
+  it('rejects invalid kind and renderer and export', () => {
+    expect(
+      validateArtifactManifestInput(
+        { ...validBase(), kind: 'evil-kind', renderer: 'html', exports: ['html'] },
+        'index.html',
+      ).ok,
+    ).toBe(false);
+    expect(
+      validateArtifactManifestInput(
+        { ...validBase(), kind: 'html', renderer: 'evil-renderer', exports: ['html'] },
+        'index.html',
+      ).ok,
+    ).toBe(false);
+    expect(
+      validateArtifactManifestInput(
+        { ...validBase(), kind: 'html', renderer: 'html', exports: ['exe'] },
+        'index.html',
+      ).ok,
+    ).toBe(false);
+  });
+
+  it('rejects traversal in supportingFiles', () => {
+    const res = validateArtifactManifestInput(
+      { ...validBase(), supportingFiles: ['../secret.txt'] },
+      'index.html',
+    );
+    expect(res.ok).toBe(false);
+  });
+});

--- a/daemon/projects.js
+++ b/daemon/projects.js
@@ -129,7 +129,7 @@ export async function writeProjectFile(
 }
 
 function artifactManifestNameFor(name) {
-  return name.replace(/\.[^/.]+$/, '') + '.artifact.json';
+  return `${name}.artifact.json`;
 }
 
 async function readManifestForPath(projectDirPath, relPath) {

--- a/daemon/projects.js
+++ b/daemon/projects.js
@@ -10,6 +10,7 @@ import { mkdir, readdir, readFile, rm, stat, unlink, writeFile } from 'node:fs/p
 import path from 'node:path';
 
 const FORBIDDEN_SEGMENT = /^$|^\.\.?$/;
+const MANIFEST_VERSION = 1;
 
 export function projectDir(projectsRoot, projectId) {
   if (!isSafeId(projectId)) throw new Error('invalid project id');
@@ -48,7 +49,9 @@ async function collectFiles(dir, relDir, out) {
       continue;
     }
     if (!e.isFile()) continue;
+    if (e.name.endsWith('.artifact.json')) continue;
     const st = await stat(full);
+    const manifest = await readManifestForPath(dir, rel);
     out.push({
       name: rel,
       path: rel,
@@ -57,6 +60,8 @@ async function collectFiles(dir, relDir, out) {
       mtime: st.mtimeMs,
       kind: kindFor(rel),
       mime: mimeFor(rel),
+      artifactKind: manifest?.kind,
+      artifactManifest: manifest,
     });
   }
 }
@@ -67,6 +72,7 @@ export async function readProjectFile(projectsRoot, projectId, name) {
   const buf = await readFile(file);
   const st = await stat(file);
   const rel = toProjectPath(path.relative(dir, file));
+  const manifest = await readManifestForPath(dir, rel);
   return {
     buffer: buf,
     name: rel,
@@ -75,6 +81,8 @@ export async function readProjectFile(projectsRoot, projectId, name) {
     mtime: st.mtimeMs,
     mime: mimeFor(rel),
     kind: kindFor(rel),
+    artifactKind: manifest?.kind,
+    artifactManifest: manifest,
   };
 }
 
@@ -83,7 +91,7 @@ export async function writeProjectFile(
   projectId,
   name,
   body,
-  { overwrite = true } = {},
+  { overwrite = true, artifactManifest = null } = {},
 ) {
   const dir = await ensureProject(projectsRoot, projectId);
   const safeName = sanitizePath(name);
@@ -98,7 +106,16 @@ export async function writeProjectFile(
   }
   await mkdir(path.dirname(target), { recursive: true });
   await writeFile(target, body);
+  if (artifactManifest && typeof artifactManifest === 'object') {
+    const manifestFileName = artifactManifestNameFor(safeName);
+    const manifestTarget = resolveSafe(dir, manifestFileName);
+    const nextManifest = normalizeManifest(artifactManifest, safeName);
+    if (nextManifest) {
+      await writeFile(manifestTarget, JSON.stringify(nextManifest, null, 2));
+    }
+  }
   const st = await stat(target);
+  const persistedManifest = await readManifestForPath(dir, safeName);
   return {
     name: safeName,
     path: safeName,
@@ -106,7 +123,79 @@ export async function writeProjectFile(
     mtime: st.mtimeMs,
     kind: kindFor(safeName),
     mime: mimeFor(safeName),
+    artifactKind: persistedManifest?.kind,
+    artifactManifest: persistedManifest,
   };
+}
+
+function artifactManifestNameFor(name) {
+  return name.replace(/\.[^/.]+$/, '') + '.artifact.json';
+}
+
+async function readManifestForPath(projectDirPath, relPath) {
+  const manifestPath = path.join(projectDirPath, artifactManifestNameFor(relPath));
+  try {
+    const raw = await readFile(manifestPath, 'utf8');
+    const parsed = parseManifest(raw);
+    if (parsed) return parsed;
+  } catch (err) {
+    if (!err || err.code !== 'ENOENT') {
+      // ignore malformed/invalid manifests and fallback to inference
+    }
+  }
+  return inferLegacyManifest(relPath);
+}
+
+function parseManifest(raw) {
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || parsed.version !== MANIFEST_VERSION) return null;
+    if (typeof parsed.entry !== 'string' || !parsed.entry) return null;
+    if (typeof parsed.title !== 'string') return null;
+    if (!Array.isArray(parsed.exports)) return null;
+    if (typeof parsed.kind !== 'string' || typeof parsed.renderer !== 'string') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeManifest(manifest, entry) {
+  if (!manifest || typeof manifest !== 'object') return null;
+  const exports = Array.isArray(manifest.exports)
+    ? manifest.exports.filter((x) => typeof x === 'string')
+    : [];
+  if (typeof manifest.kind !== 'string' || typeof manifest.renderer !== 'string') return null;
+  if (exports.length === 0) return null;
+  const title = typeof manifest.title === 'string' && manifest.title ? manifest.title : entry;
+  const now = new Date().toISOString();
+  return {
+    ...manifest,
+    version: MANIFEST_VERSION,
+    title,
+    entry,
+    exports,
+    updatedAt: now,
+    createdAt: typeof manifest.createdAt === 'string' ? manifest.createdAt : now,
+  };
+}
+
+function inferLegacyManifest(entry) {
+  const lower = entry.toLowerCase();
+  const ext = path.extname(lower);
+  const isDeck = ext === '.html' && (lower.includes('deck') || lower.includes('slides') || lower.includes('pitch'));
+  if (ext === '.html' || ext === '.htm') {
+    return {
+      version: MANIFEST_VERSION,
+      kind: isDeck ? 'deck' : 'html',
+      title: entry,
+      entry,
+      renderer: isDeck ? 'deck-html' : 'html',
+      exports: isDeck ? ['html', 'pdf', 'pptx', 'zip'] : ['html', 'pdf', 'zip'],
+      metadata: { inferred: true },
+    };
+  }
+  return null;
 }
 
 export async function deleteProjectFile(projectsRoot, projectId, name) {

--- a/daemon/projects.js
+++ b/daemon/projects.js
@@ -8,9 +8,13 @@
 
 import { mkdir, readdir, readFile, rm, stat, unlink, writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import {
+  inferLegacyManifest,
+  parsePersistedManifest,
+  validateArtifactManifestInput,
+} from './artifact-manifest.js';
 
 const FORBIDDEN_SEGMENT = /^$|^\.\.?$/;
-const MANIFEST_VERSION = 1;
 
 export function projectDir(projectsRoot, projectId) {
   if (!isSafeId(projectId)) throw new Error('invalid project id');
@@ -109,8 +113,9 @@ export async function writeProjectFile(
   if (artifactManifest && typeof artifactManifest === 'object') {
     const manifestFileName = artifactManifestNameFor(safeName);
     const manifestTarget = resolveSafe(dir, manifestFileName);
-    const nextManifest = normalizeManifest(artifactManifest, safeName);
-    if (nextManifest) {
+    const validated = validateArtifactManifestInput(artifactManifest, safeName);
+    if (validated.ok && validated.value) {
+      const nextManifest = validated.value;
       await writeFile(manifestTarget, JSON.stringify(nextManifest, null, 2));
     }
   }
@@ -147,55 +152,7 @@ async function readManifestForPath(projectDirPath, relPath) {
 }
 
 function parseManifest(raw) {
-  try {
-    const parsed = JSON.parse(raw);
-    if (!parsed || parsed.version !== MANIFEST_VERSION) return null;
-    if (typeof parsed.entry !== 'string' || !parsed.entry) return null;
-    if (typeof parsed.title !== 'string') return null;
-    if (!Array.isArray(parsed.exports)) return null;
-    if (typeof parsed.kind !== 'string' || typeof parsed.renderer !== 'string') return null;
-    return parsed;
-  } catch {
-    return null;
-  }
-}
-
-function normalizeManifest(manifest, entry) {
-  if (!manifest || typeof manifest !== 'object') return null;
-  const exports = Array.isArray(manifest.exports)
-    ? manifest.exports.filter((x) => typeof x === 'string')
-    : [];
-  if (typeof manifest.kind !== 'string' || typeof manifest.renderer !== 'string') return null;
-  if (exports.length === 0) return null;
-  const title = typeof manifest.title === 'string' && manifest.title ? manifest.title : entry;
-  const now = new Date().toISOString();
-  return {
-    ...manifest,
-    version: MANIFEST_VERSION,
-    title,
-    entry,
-    exports,
-    updatedAt: now,
-    createdAt: typeof manifest.createdAt === 'string' ? manifest.createdAt : now,
-  };
-}
-
-function inferLegacyManifest(entry) {
-  const lower = entry.toLowerCase();
-  const ext = path.extname(lower);
-  const isDeck = ext === '.html' && (lower.includes('deck') || lower.includes('slides') || lower.includes('pitch'));
-  if (ext === '.html' || ext === '.htm') {
-    return {
-      version: MANIFEST_VERSION,
-      kind: isDeck ? 'deck' : 'html',
-      title: entry,
-      entry,
-      renderer: isDeck ? 'deck-html' : 'html',
-      exports: isDeck ? ['html', 'pdf', 'pptx', 'zip'] : ['html', 'pdf', 'zip'],
-      metadata: { inferred: true },
-    };
-  }
-  return null;
+  return parsePersistedManifest(raw, '');
 }
 
 export async function deleteProjectFile(projectsRoot, projectId, name) {

--- a/daemon/server.js
+++ b/daemon/server.js
@@ -31,6 +31,7 @@ import {
   sanitizeName,
   writeProjectFile,
 } from './projects.js';
+import { validateArtifactManifestInput } from './artifact-manifest.js';
 import {
   deleteConversation,
   deleteProject as dbDeleteProject,
@@ -770,6 +771,12 @@ export async function startServer({ port = 7456 } = {}) {
         const { name, content, encoding, artifactManifest } = req.body || {};
         if (typeof name !== 'string' || typeof content !== 'string') {
           return res.status(400).json({ error: 'name and content required' });
+        }
+        if (artifactManifest !== undefined && artifactManifest !== null) {
+          const validated = validateArtifactManifestInput(artifactManifest, name);
+          if (!validated.ok) {
+            return res.status(400).json({ error: `invalid artifactManifest: ${validated.error}` });
+          }
         }
         const buf =
           encoding === 'base64'

--- a/daemon/server.js
+++ b/daemon/server.js
@@ -767,7 +767,7 @@ export async function startServer({ port = 7456 } = {}) {
           fs.promises.unlink(req.file.path).catch(() => {});
           return res.json({ file: meta });
         }
-        const { name, content, encoding } = req.body || {};
+        const { name, content, encoding, artifactManifest } = req.body || {};
         if (typeof name !== 'string' || typeof content !== 'string') {
           return res.status(400).json({ error: 'name and content required' });
         }
@@ -775,7 +775,9 @@ export async function startServer({ port = 7456 } = {}) {
           encoding === 'base64'
             ? Buffer.from(content, 'base64')
             : Buffer.from(content, 'utf8');
-        const meta = await writeProjectFile(PROJECTS_DIR, req.params.id, name, buf);
+        const meta = await writeProjectFile(PROJECTS_DIR, req.params.id, name, buf, {
+          artifactManifest,
+        });
         res.json({ file: meta });
       } catch (err) {
         res.status(500).json({ error: 'upload failed' });

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dev:all": "node scripts/dev-all.mjs",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
+    "test": "vitest run",
     "typecheck": "tsc -b --noEmit",
     "start": "npm run build && node daemon/cli.js"
   },
@@ -32,7 +33,8 @@
     "@vitejs/plugin-react": "^4.3.4",
     "concurrently": "^9.0.1",
     "typescript": "^5.6.3",
-    "vite": "^5.4.11"
+    "vite": "^5.4.11",
+    "vitest": "^2.1.8"
   },
   "engines": {
     "node": ">=20 <23"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       vite:
         specifier: ^5.4.11
         version: 5.4.21(@types/node@18.19.130)
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@18.19.130)
 
 packages:
 
@@ -325,79 +328,66 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -467,6 +457,35 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -492,6 +511,10 @@ packages:
 
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -536,6 +559,10 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -547,9 +574,17 @@ packages:
   caniuse-lite@1.0.30001791:
     resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
@@ -623,6 +658,10 @@ packages:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -671,6 +710,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -691,6 +733,9 @@ packages:
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
@@ -702,6 +747,10 @@ packages:
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
@@ -831,8 +880,14 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -941,6 +996,13 @@ packages:
 
   path-to-regexp@0.1.13:
     resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1069,6 +1131,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
 
@@ -1079,9 +1144,15 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
@@ -1119,6 +1190,24 @@ packages:
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -1173,6 +1262,11 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite@5.4.21:
     resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -1204,6 +1298,31 @@ packages:
       terser:
         optional: true
 
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-streams-polyfill@4.0.0-beta.3:
     resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
     engines: {node: '>= 14'}
@@ -1213,6 +1332,11 @@ packages:
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -1586,6 +1710,46 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@18.19.130))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@18.19.130)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -1608,6 +1772,8 @@ snapshots:
   append-field@1.0.0: {}
 
   array-flatten@1.1.1: {}
+
+  assertion-error@2.0.1: {}
 
   asynckit@0.4.0: {}
 
@@ -1668,6 +1834,8 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -1680,10 +1848,20 @@ snapshots:
 
   caniuse-lite@1.0.30001791: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  check-error@2.1.3: {}
 
   chownr@1.1.4: {}
 
@@ -1747,6 +1925,8 @@ snapshots:
     dependencies:
       mimic-response: 3.1.0
 
+  deep-eql@5.0.2: {}
+
   deep-extend@0.6.0: {}
 
   delayed-stream@1.0.0: {}
@@ -1778,6 +1958,8 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@1.7.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -1820,11 +2002,17 @@ snapshots:
 
   escape-html@1.0.3: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   etag@1.8.1: {}
 
   event-target-shim@5.0.1: {}
 
   expand-template@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   express@4.22.1:
     dependencies:
@@ -1978,9 +2166,15 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   math-intrinsics@1.1.0: {}
 
@@ -2055,6 +2249,10 @@ snapshots:
   parseurl@1.3.3: {}
 
   path-to-regexp@0.1.13: {}
+
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -2253,6 +2451,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   simple-concat@1.0.1: {}
 
   simple-get@4.0.1:
@@ -2263,7 +2463,11 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  stackback@0.0.2: {}
+
   statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
 
   streamsearch@1.1.0: {}
 
@@ -2310,6 +2514,16 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
+
   toidentifier@1.0.1: {}
 
   tr46@0.0.3: {}
@@ -2347,6 +2561,24 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vite-node@2.1.9(@types/node@18.19.130):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@18.19.130)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite@5.4.21(@types/node@18.19.130):
     dependencies:
       esbuild: 0.21.5
@@ -2356,6 +2588,41 @@ snapshots:
       '@types/node': 18.19.130
       fsevents: 2.3.3
 
+  vitest@2.1.9(@types/node@18.19.130):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@18.19.130))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@18.19.130)
+      vite-node: 2.1.9(@types/node@18.19.130)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 18.19.130
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   web-streams-polyfill@4.0.0-beta.3: {}
 
   webidl-conversions@3.0.1: {}
@@ -2364,6 +2631,11 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/src/artifacts/manifest.test.ts
+++ b/src/artifacts/manifest.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  artifactManifestNameFor,
+  createHtmlArtifactManifest,
+  inferLegacyManifest,
+  parseArtifactManifest,
+} from './manifest';
+
+describe('parseArtifactManifest', () => {
+  it('returns null for malformed json', () => {
+    expect(parseArtifactManifest('{"version":1')).toBeNull();
+  });
+
+  it('returns null when required fields are missing', () => {
+    expect(parseArtifactManifest(JSON.stringify({ version: 1, kind: 'html' }))).toBeNull();
+  });
+
+  it('returns null for wrong version', () => {
+    const raw = JSON.stringify({
+      version: 2,
+      kind: 'html',
+      title: 'x',
+      entry: 'index.html',
+      renderer: 'html',
+      exports: ['html'],
+    });
+    expect(parseArtifactManifest(raw)).toBeNull();
+  });
+});
+
+describe('inferLegacyManifest', () => {
+  it('returns null for non-artifact file types', () => {
+    expect(inferLegacyManifest({ entry: 'photo.png' })).toBeNull();
+    expect(inferLegacyManifest({ entry: 'archive.bin' })).toBeNull();
+  });
+});
+
+describe('artifactManifestNameFor', () => {
+  it('handles names without extension', () => {
+    expect(artifactManifestNameFor('README')).toBe('README.artifact.json');
+  });
+
+  it('handles names with multiple dots', () => {
+    expect(artifactManifestNameFor('page.v2.final.html')).toBe('page.v2.final.html.artifact.json');
+  });
+
+  it('avoids collisions between different extensions', () => {
+    expect(artifactManifestNameFor('foo.html')).not.toBe(artifactManifestNameFor('foo.md'));
+  });
+});
+
+describe('createHtmlArtifactManifest', () => {
+  it('creates expected default html manifest shape', () => {
+    const out = createHtmlArtifactManifest({ entry: 'index.html', title: 'Landing' });
+    expect(out.version).toBe(1);
+    expect(out.kind).toBe('html');
+    expect(out.renderer).toBe('html');
+    expect(out.exports).toEqual(['html', 'pdf', 'zip']);
+    expect(out.entry).toBe('index.html');
+    expect(out.title).toBe('Landing');
+    expect(typeof out.createdAt).toBe('string');
+    expect(typeof out.updatedAt).toBe('string');
+  });
+});

--- a/src/artifacts/manifest.ts
+++ b/src/artifacts/manifest.ts
@@ -32,7 +32,7 @@ function exportsForKind(kind: ArtifactKind): ArtifactExportKind[] {
 }
 
 export function artifactManifestNameFor(entry: string): string {
-  return entry.replace(/\.[^/.]+$/, '') + '.artifact.json';
+  return `${entry}.artifact.json`;
 }
 
 export function createHtmlArtifactManifest(input: {

--- a/src/artifacts/manifest.ts
+++ b/src/artifacts/manifest.ts
@@ -6,6 +6,38 @@ import type {
 } from './types';
 
 const MANIFEST_VERSION = 1;
+const ALLOWED_KINDS: ReadonlySet<ArtifactKind> = new Set([
+  'html',
+  'deck',
+  'react-component',
+  'markdown-document',
+  'svg',
+  'diagram',
+  'code-snippet',
+  'mini-app',
+  'design-system',
+]);
+const ALLOWED_RENDERERS: ReadonlySet<ArtifactRendererId> = new Set([
+  'html',
+  'deck-html',
+  'react-component',
+  'markdown',
+  'svg',
+  'diagram',
+  'code',
+  'mini-app',
+  'design-system',
+]);
+const ALLOWED_EXPORTS: ReadonlySet<ArtifactExportKind> = new Set([
+  'html',
+  'pdf',
+  'zip',
+  'pptx',
+  'jsx',
+  'md',
+  'svg',
+  'txt',
+]);
 
 function normalizeExt(name: string): string {
   const i = name.lastIndexOf('.');
@@ -67,12 +99,37 @@ export function parseArtifactManifest(raw: string): ArtifactManifest | null {
     const parsed = JSON.parse(raw) as Partial<ArtifactManifest>;
     if (parsed?.version !== MANIFEST_VERSION) return null;
     if (typeof parsed.entry !== 'string' || !parsed.entry) return null;
-    if (typeof parsed.title !== 'string') return null;
+    if (typeof parsed.title !== 'string' || !parsed.title) return null;
     if (!Array.isArray(parsed.exports)) return null;
     if (typeof parsed.kind !== 'string' || typeof parsed.renderer !== 'string') {
       return null;
     }
-    return parsed as ArtifactManifest;
+    if (!ALLOWED_KINDS.has(parsed.kind as ArtifactKind)) return null;
+    if (!ALLOWED_RENDERERS.has(parsed.renderer as ArtifactRendererId)) return null;
+    if (parsed.exports.length === 0) return null;
+    if (parsed.exports.some((value) => !ALLOWED_EXPORTS.has(value as ArtifactExportKind))) return null;
+    return {
+      version: MANIFEST_VERSION,
+      kind: parsed.kind as ArtifactKind,
+      title: parsed.title,
+      entry: parsed.entry,
+      renderer: parsed.renderer as ArtifactRendererId,
+      exports: parsed.exports as ArtifactExportKind[],
+      supportingFiles: Array.isArray(parsed.supportingFiles)
+        ? parsed.supportingFiles.filter((x): x is string => typeof x === 'string')
+        : undefined,
+      createdAt: typeof parsed.createdAt === 'string' ? parsed.createdAt : undefined,
+      updatedAt: typeof parsed.updatedAt === 'string' ? parsed.updatedAt : undefined,
+      sourceSkillId: typeof parsed.sourceSkillId === 'string' ? parsed.sourceSkillId : undefined,
+      designSystemId:
+        typeof parsed.designSystemId === 'string' || parsed.designSystemId === null
+          ? parsed.designSystemId
+          : undefined,
+      metadata:
+        parsed.metadata && typeof parsed.metadata === 'object' && !Array.isArray(parsed.metadata)
+          ? parsed.metadata
+          : undefined,
+    };
   } catch {
     return null;
   }

--- a/src/artifacts/manifest.ts
+++ b/src/artifacts/manifest.ts
@@ -1,0 +1,116 @@
+import type {
+  ArtifactExportKind,
+  ArtifactKind,
+  ArtifactManifest,
+  ArtifactRendererId,
+} from './types';
+
+const MANIFEST_VERSION = 1;
+
+function normalizeExt(name: string): string {
+  const i = name.lastIndexOf('.');
+  return i >= 0 ? name.slice(i).toLowerCase() : '';
+}
+
+function inferKindFromEntry(entry: string): ArtifactKind | null {
+  const ext = normalizeExt(entry);
+  if (['.html', '.htm'].includes(ext)) return 'html';
+  if (ext === '.svg') return 'svg';
+  if (ext === '.md') return 'markdown-document';
+  if (['.jsx', '.tsx'].includes(ext)) return 'react-component';
+  if (['.js', '.ts', '.json', '.css'].includes(ext)) return 'code-snippet';
+  return null;
+}
+
+function exportsForKind(kind: ArtifactKind): ArtifactExportKind[] {
+  if (kind === 'deck') return ['html', 'pdf', 'pptx', 'zip'];
+  if (kind === 'react-component') return ['jsx', 'html', 'zip'];
+  if (kind === 'markdown-document') return ['md', 'html', 'pdf', 'zip'];
+  if (kind === 'svg' || kind === 'diagram') return ['svg', 'zip'];
+  if (kind === 'code-snippet') return ['txt', 'zip'];
+  return ['html', 'pdf', 'zip'];
+}
+
+export function artifactManifestNameFor(entry: string): string {
+  return entry.replace(/\.[^/.]+$/, '') + '.artifact.json';
+}
+
+export function createHtmlArtifactManifest(input: {
+  entry: string;
+  title: string;
+  metadata?: Record<string, unknown>;
+  sourceSkillId?: string;
+  designSystemId?: string | null;
+}): ArtifactManifest {
+  const now = new Date().toISOString();
+  return {
+    version: MANIFEST_VERSION,
+    kind: 'html',
+    title: input.title,
+    entry: input.entry,
+    renderer: 'html',
+    exports: ['html', 'pdf', 'zip'],
+    createdAt: now,
+    updatedAt: now,
+    sourceSkillId: input.sourceSkillId,
+    designSystemId: input.designSystemId,
+    metadata: input.metadata,
+  };
+}
+
+export function serializeArtifactManifest(manifest: ArtifactManifest): string {
+  return JSON.stringify(manifest, null, 2);
+}
+
+export function parseArtifactManifest(raw: string): ArtifactManifest | null {
+  try {
+    const parsed = JSON.parse(raw) as Partial<ArtifactManifest>;
+    if (parsed?.version !== MANIFEST_VERSION) return null;
+    if (typeof parsed.entry !== 'string' || !parsed.entry) return null;
+    if (typeof parsed.title !== 'string') return null;
+    if (!Array.isArray(parsed.exports)) return null;
+    if (typeof parsed.kind !== 'string' || typeof parsed.renderer !== 'string') {
+      return null;
+    }
+    return parsed as ArtifactManifest;
+  } catch {
+    return null;
+  }
+}
+
+export function inferLegacyManifest(input: {
+  entry: string;
+  title?: string;
+  metadata?: Record<string, unknown>;
+}): ArtifactManifest | null {
+  const kind = inferKindFromEntry(input.entry);
+  if (!kind) return null;
+  const lowerEntry = input.entry.toLowerCase();
+  const isDeck =
+    kind === 'html' &&
+    (lowerEntry.includes('deck') || lowerEntry.includes('slides') || lowerEntry.includes('pitch'));
+  const renderer: ArtifactRendererId =
+    isDeck
+      ? 'deck-html'
+      : kind === 'html'
+        ? 'html'
+        : kind === 'markdown-document'
+          ? 'markdown'
+          : kind === 'react-component'
+            ? 'react-component'
+            : kind === 'code-snippet'
+              ? 'code'
+              : kind === 'deck'
+                ? 'deck-html'
+                : kind;
+  const resolvedKind = isDeck ? 'deck' : kind;
+  return {
+    version: MANIFEST_VERSION,
+    kind: resolvedKind,
+    title: input.title || input.entry,
+    entry: input.entry,
+    renderer,
+    exports: exportsForKind(resolvedKind),
+    metadata: input.metadata,
+  };
+}

--- a/src/artifacts/renderer-registry.ts
+++ b/src/artifacts/renderer-registry.ts
@@ -1,0 +1,60 @@
+import { inferLegacyManifest } from './manifest';
+import type { ArtifactManifest, ArtifactRendererId } from './types';
+import type { ProjectFile } from '../types';
+
+export interface ArtifactRendererContext {
+  file: ProjectFile;
+  isDeckHint: boolean;
+}
+
+export interface ArtifactRenderer {
+  id: ArtifactRendererId;
+  canRender: (ctx: ArtifactRendererContext) => boolean;
+}
+
+export interface ArtifactRenderMatch {
+  renderer: ArtifactRenderer;
+  manifest: ArtifactManifest;
+}
+
+function resolveManifest(file: ProjectFile): ArtifactManifest | null {
+  return file.artifactManifest ?? inferLegacyManifest({ entry: file.name });
+}
+
+export const HtmlRenderer: ArtifactRenderer = {
+  id: 'html',
+  canRender: ({ file, isDeckHint }) => {
+    const manifest = resolveManifest(file);
+    if (!manifest) return false;
+    if (manifest.kind === 'deck' || manifest.renderer === 'deck-html') return false;
+    if (manifest.renderer === 'html' || manifest.kind === 'html') return true;
+    return file.kind === 'html' && !isDeckHint;
+  },
+};
+
+export const DeckHtmlRenderer: ArtifactRenderer = {
+  id: 'deck-html',
+  canRender: ({ file, isDeckHint }) => {
+    const manifest = resolveManifest(file);
+    if (!manifest) return false;
+    if (manifest.kind === 'deck' || manifest.renderer === 'deck-html') return true;
+    return file.kind === 'html' && isDeckHint;
+  },
+};
+
+export class RendererRegistry {
+  constructor(private readonly renderers: ArtifactRenderer[]) {}
+
+  resolve(ctx: ArtifactRendererContext): ArtifactRenderMatch | null {
+    const manifest = resolveManifest(ctx.file);
+    if (!manifest) return null;
+    const renderer = this.renderers.find((item) => item.canRender(ctx));
+    if (!renderer) return null;
+    return { renderer, manifest };
+  }
+}
+
+export const artifactRendererRegistry = new RendererRegistry([
+  DeckHtmlRenderer,
+  HtmlRenderer,
+]);

--- a/src/artifacts/types.ts
+++ b/src/artifacts/types.ts
@@ -1,0 +1,46 @@
+export type ArtifactKind =
+  | 'html'
+  | 'deck'
+  | 'react-component'
+  | 'markdown-document'
+  | 'svg'
+  | 'diagram'
+  | 'code-snippet'
+  | 'mini-app'
+  | 'design-system';
+
+export type ArtifactRendererId =
+  | 'html'
+  | 'deck-html'
+  | 'react-component'
+  | 'markdown'
+  | 'svg'
+  | 'diagram'
+  | 'code'
+  | 'mini-app'
+  | 'design-system';
+
+export type ArtifactExportKind =
+  | 'html'
+  | 'pdf'
+  | 'zip'
+  | 'pptx'
+  | 'jsx'
+  | 'md'
+  | 'svg'
+  | 'txt';
+
+export interface ArtifactManifest {
+  version: 1;
+  kind: ArtifactKind;
+  title: string;
+  entry: string;
+  renderer: ArtifactRendererId;
+  exports: ArtifactExportKind[];
+  supportingFiles?: string[];
+  createdAt?: string;
+  updatedAt?: string;
+  sourceSkillId?: string;
+  designSystemId?: string | null;
+  metadata?: Record<string, unknown>;
+}

--- a/src/artifacts/types.ts
+++ b/src/artifacts/types.ts
@@ -37,6 +37,10 @@ export interface ArtifactManifest {
   entry: string;
   renderer: ArtifactRendererId;
   exports: ArtifactExportKind[];
+  /**
+   * Reserved for future multi-file artifact packaging.
+   * Current generators only persist a single entry file, so this is not yet populated.
+   */
   supportingFiles?: string[];
   createdAt?: string;
   updatedAt?: string;

--- a/src/components/FileViewer.tsx
+++ b/src/components/FileViewer.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { artifactRendererRegistry } from '../artifacts/renderer-registry';
 import { useT } from '../i18n';
 import { fetchProjectFileText, projectFileUrl, projectRawUrl } from '../providers/registry';
 import { exportAsHtml, exportAsPdf, exportAsZip } from '../runtime/exports';
@@ -24,13 +25,18 @@ export function FileViewer({
   onExportAsPptx,
   streaming,
 }: Props) {
-  if (file.kind === 'html') {
+  const rendererMatch = artifactRendererRegistry.resolve({
+    file,
+    isDeckHint: Boolean(isDeck),
+  });
+
+  if (rendererMatch?.renderer.id === 'html' || rendererMatch?.renderer.id === 'deck-html') {
     return (
       <HtmlViewer
         projectId={projectId}
         file={file}
         liveHtml={liveHtml}
-        isDeck={Boolean(isDeck)}
+        isDeck={rendererMatch.renderer.id === 'deck-html'}
         onExportAsPptx={onExportAsPptx}
         streaming={Boolean(streaming)}
       />

--- a/src/components/ProjectView.tsx
+++ b/src/components/ProjectView.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createHtmlArtifactManifest } from '../artifacts/manifest';
 import { createArtifactParser } from '../artifacts/parser';
 import { useT } from '../i18n';
 import { streamMessage } from '../providers/anthropic';
@@ -552,7 +553,19 @@ export function ProjectView({
       }
       if (savedArtifactRef.current === fileName) return;
       savedArtifactRef.current = fileName;
-      const file = await writeProjectTextFile(project.id, fileName, art.html);
+      const manifest = createHtmlArtifactManifest({
+        entry: fileName,
+        title: art.title || art.identifier || fileName,
+        sourceSkillId: project.skillId ?? undefined,
+        designSystemId: project.designSystemId,
+        metadata: {
+          identifier: art.identifier,
+          inferred: false,
+        },
+      });
+      const file = await writeProjectTextFile(project.id, fileName, art.html, {
+        artifactManifest: manifest,
+      });
       if (file) {
         setFilesRefresh((n) => n + 1);
         // Auto-open the freshly-persisted artifact as a tab so the user

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -7,6 +7,7 @@ import type {
   SkillDetail,
   SkillSummary,
 } from '../types';
+import type { ArtifactManifest } from '../artifacts/types';
 
 export async function fetchAgents(): Promise<AgentInfo[]> {
   try {
@@ -114,12 +115,13 @@ export async function writeProjectTextFile(
   projectId: string,
   name: string,
   content: string,
+  options?: { artifactManifest?: ArtifactManifest },
 ): Promise<ProjectFile | null> {
   try {
     const resp = await fetch(`/api/projects/${encodeURIComponent(projectId)}/files`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, content }),
+      body: JSON.stringify({ name, content, artifactManifest: options?.artifactManifest }),
     });
     if (!resp.ok) return null;
     const json = (await resp.json()) as { file: ProjectFile };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { ArtifactKind, ArtifactManifest } from './artifacts/types';
+
 export type ExecMode = 'daemon' | 'api';
 
 // Per-CLI model + reasoning the user picked in the model menu. Each agent
@@ -166,6 +168,8 @@ export interface ProjectFile {
   mtime: number;
   kind: ProjectFileKind;
   mime: string;
+  artifactKind?: ArtifactKind;
+  artifactManifest?: ArtifactManifest;
 }
 
 // Per-project metadata captured at creation time. The agent reads this


### PR DESCRIPTION
## Summary

This PR starts turning Open Design from an HTML-first artifact generator into a general artifact platform that can later support Claude Artifacts-style outputs: HTML pages, decks, Markdown documents, SVGs, code snippets, React components, and eventually small apps.

The important architectural move is to stop treating HTML as the product's only artifact model. Instead, HTML becomes one artifact kind among many, described by a manifest and routed through a renderer registry.

## Why this matters

Right now, Open Design is strongest when the generated output is a self-contained HTML artifact. That works well for websites and deck-like HTML presentations, but it does not scale cleanly to other artifact classes. Without a formal artifact contract, each new type would add more extension checks and special cases across the UI and daemon.

This PR introduces the foundation needed for a maintainable artifact pipeline:

```txt
ArtifactKind -> ArtifactManifest -> RendererRegistry -> future renderers/exporters/skills
```

That gives the project a stable vocabulary before adding visible support for Markdown, SVG, React components, diagrams, or mini-apps.

## What this PR includes

### 1. Artifact manifest foundation

Adds a first-class artifact contract:

- `ArtifactKind`
- `ArtifactManifest`
- renderer/export type vocabulary
- manifest parse/serialize/create helpers
- legacy manifest inference
- strict daemon-side validation and sanitization for user-supplied manifests

Generated HTML artifacts now carry manifest metadata when saved, and the daemon can persist a sidecar manifest next to the artifact entry file.

Example direction:

```json
{
  "version": 1,
  "kind": "html",
  "title": "Landing Page",
  "entry": "index.html",
  "renderer": "html",
  "exports": ["html", "pdf", "zip"]
}
```

Versioning strategy: manifests carry `version: 1`. Unknown manifest versions are rejected fail-closed by the parser/validator. Future breaking schema changes should add explicit version-specific parser/validator paths and daemon-side migration for persisted manifests. Backward-compatible additions should remain optional within the same version rather than requiring permissive unknown-field persistence.

### 2. Legacy-safe metadata surfacing

Project file metadata can now expose:

- `artifactKind`
- `artifactManifest`

If no sidecar manifest exists, legacy inference provides metadata for known artifact-like files. Unknown files still fall back to the existing file viewer behavior.

Sidecar manifest files are intentionally hidden from the regular project file list so this foundation does not clutter the current UI. Sidecar names include the full entry filename (for example, `foo.html.artifact.json`) to avoid basename collisions between sibling files like `foo.html` and `foo.md`.

### 3. Incremental renderer registry

Adds a small renderer registry and routes only the existing HTML/deck preview decision through it:

- `RendererRegistry`
- `HtmlRenderer`
- `DeckHtmlRenderer`

This is deliberately minimal. It does not rewrite `FileViewer`, and it keeps the existing iframe/srcdoc preview path intact.

### 4. Test coverage

Adds Vitest coverage for the artifact manifest foundation:

- manifest parsing failure cases
- legacy inference for non-artifact files
- sidecar naming edge cases and collision prevention
- HTML manifest creation shape
- daemon validation for exports, allowlisted values, and unsafe `supportingFiles`

## What this PR intentionally does NOT include

This PR is architectural foundation only. It intentionally avoids:

- React component rendering
- TSX support
- mini-app runtime
- npm dependency handling
- skill parser rewrite
- export system rewrite
- Markdown/SVG renderers
- Mermaid/diagram rendering
- publishing or embed infrastructure

Those should come later, in smaller follow-up PRs.

## Intended follow-up direction

If this direction is accepted, the next clean steps would be:

1. Add Markdown and SVG renderers using the registry.
2. Add code snippet preview/copy support.
3. Add single-file JSX React component artifacts using a sandboxed iframe with React/Babel.
4. Make `SKILL.md` artifact metadata executable instead of descriptive-only.
5. Only later consider mini-apps, publishing, persistent storage, or embed flows.

## Changes

| File | Change |
|------|--------|
| `src/artifacts/types.ts` | Adds artifact kind, renderer/export, and manifest types. |
| `src/artifacts/manifest.ts` | Adds manifest creation, parsing, serialization, sidecar naming, and legacy inference helpers. |
| `src/artifacts/manifest.test.ts` | Adds frontend manifest helper coverage. |
| `src/artifacts/renderer-registry.ts` | Adds initial renderer registry with HTML and deck HTML renderers. |
| `src/types.ts` | Adds optional artifact metadata to project file records. |
| `src/providers/registry.ts` | Allows writing project text files with optional artifact manifest metadata. |
| `src/components/ProjectView.tsx` | Saves generated HTML artifacts with manifest metadata. |
| `src/components/FileViewer.tsx` | Routes HTML/deck preview selection through the renderer registry while preserving fallback paths. |
| `daemon/artifact-manifest.js` | Adds daemon manifest validation, sanitization, persisted parsing, and legacy inference. |
| `daemon/artifact-manifest.test.ts` | Adds daemon validation coverage. |
| `daemon/projects.js` | Persists sidecar manifests, hides them from file listings, and surfaces manifest metadata. |
| `daemon/server.js` | Accepts and validates optional artifact manifest payloads in file writes. |
| `package.json` / `pnpm-lock.yaml` | Adds Vitest test script/dependency. |

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`

## Notes for review

This is meant as an RFC-like implementation PR: enough working code to evaluate whether this artifact-platform direction is worth continuing, without committing the project to the larger React/mini-app/platform work yet.
