### PR TITLE
fix: enforce question form checkbox selection limits

### DIFF
--- a/src/artifacts/question-form.ts
+++ b/src/artifacts/question-form.ts
@@ -61,6 +61,8 @@ export interface FormQuestion {
   required?: boolean;
   help?: string;
   defaultValue?: string | string[];
+  /** Only applies when `type === 'checkbox'`. Caps the number of selected options. */
+  maxSelections?: number;
   /** Only present when `type === 'direction-cards'`. Mapped to options by `id`. */
   cards?: DirectionCard[];
 }
@@ -163,6 +165,12 @@ function tryParseForm(body: string, attrs: Record<string, string>): QuestionForm
     const placeholder = typeof qo.placeholder === 'string' ? qo.placeholder : undefined;
     const help = typeof qo.help === 'string' ? qo.help : undefined;
     const required = qo.required === true;
+    const maxSelections =
+      typeof qo.maxSelections === 'number' &&
+      Number.isInteger(qo.maxSelections) &&
+      qo.maxSelections > 0
+        ? qo.maxSelections
+        : undefined;
     const cards = parseDirectionCards(qo.cards);
     const defaultValue =
       typeof qo.defaultValue === 'string'
@@ -181,6 +189,7 @@ function tryParseForm(body: string, attrs: Record<string, string>): QuestionForm
       ...(help ? { help } : {}),
       ...(required ? { required } : {}),
       ...(defaultValue !== undefined ? { defaultValue } : {}),
+      ...(maxSelections !== undefined && type === 'checkbox' ? { maxSelections } : {}),
       ...(cards ? { cards } : {}),
     });
   });

--- a/src/components/QuestionForm.tsx
+++ b/src/components/QuestionForm.tsx
@@ -27,10 +27,14 @@ export function QuestionFormView({ form, interactive, submittedAnswers, onSubmit
     setAnswers((prev) => ({ ...prev, [id]: value }));
   }
 
-  function toggleCheckbox(id: string, option: string) {
+  function toggleCheckbox(id: string, option: string, maxSelections?: number) {
+    if (locked) return;
     setAnswers((prev) => {
       const current = Array.isArray(prev[id]) ? (prev[id] as string[]) : [];
       const has = current.includes(option);
+      if (!has && maxSelections !== undefined && current.length >= maxSelections) {
+        return prev;
+      }
       const next = has ? current.filter((v) => v !== option) : [...current, option];
       return { ...prev, [id]: next };
     });
@@ -49,6 +53,7 @@ export function QuestionFormView({ form, interactive, submittedAnswers, onSubmit
 
   function handleSubmit() {
     if (locked || !onSubmit) return;
+    if (!withinSelectionLimits) return;
     const missing = missingRequired();
     if (missing) {
       // Soft inline guard — surface via aria but don't alert; the disabled
@@ -59,7 +64,12 @@ export function QuestionFormView({ form, interactive, submittedAnswers, onSubmit
   }
 
   const required = form.questions.filter((q) => q.required);
-  const ready = required.every((q) => {
+  const withinSelectionLimits = form.questions.every((q) => {
+    if (q.type !== 'checkbox' || q.maxSelections === undefined) return true;
+    const v = answers[q.id];
+    return !Array.isArray(v) || v.length <= q.maxSelections;
+  });
+  const ready = withinSelectionLimits && required.every((q) => {
     const v = answers[q.id];
     return Array.isArray(v) ? v.length > 0 : typeof v === 'string' && v.trim().length > 0;
   });
@@ -110,14 +120,19 @@ export function QuestionFormView({ form, interactive, submittedAnswers, onSubmit
                   {q.options.map((opt) => {
                     const arr = Array.isArray(value) ? value : [];
                     const on = arr.includes(opt);
+                    const maxed =
+                      q.maxSelections !== undefined && !on && arr.length >= q.maxSelections;
                     return (
-                      <label key={opt} className={`qf-chip${on ? ' qf-chip-on' : ''}`}>
+                      <label
+                        key={opt}
+                        className={`qf-chip${on ? ' qf-chip-on' : ''}${maxed ? ' qf-chip-disabled' : ''}`}
+                      >
                         <input
                           type="checkbox"
                           value={opt}
                           checked={on}
-                          disabled={locked}
-                          onChange={() => toggleCheckbox(q.id, opt)}
+                          disabled={locked || maxed}
+                          onChange={() => toggleCheckbox(q.id, opt, q.maxSelections)}
                         />
                         <span>{opt}</span>
                       </label>

--- a/src/index.css
+++ b/src/index.css
@@ -3766,6 +3766,11 @@ code {
 }
 .qf-chip input { width: auto; margin: 0; display: none; }
 .qf-chip:hover { border-color: var(--border-strong); }
+.qf-chip-disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
+}
+.qf-chip-disabled:hover { border-color: var(--border); }
 .qf-chip-on {
   border-color: var(--accent);
   background: var(--accent-soft);

--- a/src/prompts/discovery.ts
+++ b/src/prompts/discovery.ts
@@ -46,7 +46,7 @@ When the user opens a new project or sends a fresh design brief, your **very fir
       "options": ["Mobile (iOS/Android)", "Desktop web", "Tablet", "Responsive — all sizes", "Fixed canvas (1920×1080)"] },
     { "id": "audience", "label": "Who is this for?", "type": "text",
       "placeholder": "e.g. early-stage investors, dev-tools buyers, internal exec review" },
-    { "id": "tone", "label": "Visual tone (pick up to two)", "type": "checkbox",
+    { "id": "tone", "label": "Visual tone", "type": "checkbox", "maxSelections": 2,
       "options": ["Editorial / magazine", "Modern minimal", "Playful / illustrative", "Tech / utility", "Luxury / refined", "Brutalist / experimental", "Soft / warm"] },
     { "id": "brand", "label": "Brand context", "type": "radio",
       "options": ["Pick a direction for me", "I have a brand spec — I'll share it", "Match a reference site / screenshot — I'll attach it"] },
@@ -62,6 +62,7 @@ When the user opens a new project or sends a fresh design brief, your **very fir
 Form authoring rules:
 - Body must be valid JSON. No comments. No trailing commas.
 - \`type\` is one of: \`radio\`, \`checkbox\`, \`select\`, \`text\`, \`textarea\`.
+- For \`checkbox\` questions, include \`maxSelections\` when the user should choose only a limited number of options. Do not encode limits only in the label text.
 - Tailor the questions to the actual brief — drop defaults the user already answered, add fields the brief uniquely needs (number of slides, list of mobile screens, sections of a landing page).
 - **Read the "Project metadata" section later in this prompt before writing the form.** That block lists what the user already chose at create time (kind, fidelity, speakerNotes, animations, template). Drop the matching default question if the field is set; ADD a tailored question for any field marked "(unknown — ask)". For example, on a deck with \`speakerNotes: (unknown — ask…)\`, include a yes/no on speaker notes; on a template project where animations is unknown, include a motion radio. Don't re-ask the kind itself if metadata.kind is set — the user already told you.
 - Keep it under ~7 questions. Second batch in a follow-up form if needed.


### PR DESCRIPTION
## Summary
- Add `maxSelections` to the question-form protocol for checkbox questions.
- Enforce checkbox limits in the quick confirm renderer by disabling unselected options after the cap is reached.
- Update the discovery prompt to emit `maxSelections: 2` for visual tone instead of encoding the limit in label text.

Closes #58

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `git diff --check`