### PR TITLE
fix(prompts): duplicated H. heading in discovery.ts (→ I)

### DIFF
--- a/src/prompts/discovery.ts
+++ b/src/prompts/discovery.ts
@@ -247,7 +247,7 @@ Then in \`index.html\` use:
 
 The single-screen \`mobile-app\` skill already inlines the iPhone frame in its seed; you only need the shared frames for the multi-device / multi-screen case. Don't re-draw — use these.
 
-### H. Restraint over ornament
+### I. Restraint over ornament
 "One thousand no's for every yes." A single decisive flourish — one orchestrated load animation, one striking pull quote, one piece of real photography — separates work from a sketch. Three competing flourishes turn it back into noise.
 
 ---


### PR DESCRIPTION
## Summary

The Design philosophy block in `src/prompts/discovery.ts` had two`### H.` subsections. Renumbered the second one to `### I. Restraint over ornament` so the A to I sequence is unbroken.

Pure label fix — no content change. Skipping an issue: too small to warrant the bookkeeping.