### PR TITLE
[codex] Fix SSE keepalive behind nginx

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -63,6 +63,27 @@ Root scripts are orchestration only. App-specific commands live in workspace pac
 
 For the daemon-only production mode, the daemon serves the static Next.js export itself at `http://localhost:7456`, so no reverse proxy is involved.
 
+If you place nginx in front of the daemon, keep SSE routes unbuffered and uncompressed. A common failure is the browser console showing `net::ERR_INCOMPLETE_CHUNKED_ENCODING 200 (OK)` after 80-90 seconds because nginx `gzip on` buffers chunked SSE responses even when the daemon sends `X-Accel-Buffering: no`.
+
+```nginx
+location /api/ {
+    proxy_pass http://127.0.0.1:7456;
+
+    proxy_buffering off;
+    gzip off;
+
+    proxy_read_timeout 86400s;
+    proxy_send_timeout 86400s;
+    proxy_http_version 1.1;
+    proxy_set_header Connection "";
+
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+}
+```
+
 During local development, `apps/web/next.config.ts` rewrites `/api/*`, `/artifacts/*`, and `/frames/*` to the daemon port so the App Router app can talk to the sibling Express process without CORS setup.
 
 ## Two execution modes

--- a/apps/daemon/server.js
+++ b/apps/daemon/server.js
@@ -83,6 +83,7 @@ const promptFileBootstrap = (fp) =>
   'Open that file first and follow every instruction in it exactly — ' +
   'it contains the system prompt, design system, skill workflow, and user request. ' +
   'Do not begin your response until you have read the entire file.';
+export const SSE_KEEPALIVE_INTERVAL_MS = 25_000;
 
 const UPLOAD_DIR = path.join(os.tmpdir(), 'od-uploads');
 fs.mkdirSync(UPLOAD_DIR, { recursive: true });
@@ -175,6 +176,56 @@ function sendMulterError(res, err) {
   }
 
   return res.status(500).json({ code: 'UPLOAD_ERROR', error: 'upload failed' });
+}
+
+export function createSseResponse(res, { keepAliveIntervalMs = SSE_KEEPALIVE_INTERVAL_MS } = {}) {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache, no-transform');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no');
+  res.flushHeaders?.();
+
+  const canWrite = () => !res.destroyed && !res.writableEnded;
+  const writeKeepAlive = () => {
+    if (canWrite()) {
+      res.write(': keepalive\n\n');
+      return true;
+    }
+    return false;
+  };
+
+  let heartbeat = null;
+  if (keepAliveIntervalMs > 0) {
+    heartbeat = setInterval(writeKeepAlive, keepAliveIntervalMs);
+    heartbeat.unref?.();
+  }
+
+  const cleanup = () => {
+    if (heartbeat) {
+      clearInterval(heartbeat);
+      heartbeat = null;
+    }
+  };
+
+  res.on('close', cleanup);
+  res.on('finish', cleanup);
+
+  return {
+    send(event, data) {
+      if (!canWrite()) return false;
+      res.write(`event: ${event}\n`);
+      res.write(`data: ${JSON.stringify(data)}\n\n`);
+      return true;
+    },
+    writeKeepAlive,
+    cleanup,
+    end() {
+      cleanup();
+      if (canWrite()) {
+        res.end();
+      }
+    },
+  };
 }
 
 export async function startServer({ port = 7456, returnServer = false } = {}) {
@@ -1032,16 +1083,8 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
 
     const args = def.buildArgs(effectivePrompt, safeImages, extraAllowedDirs, agentOptions, { cwd });
 
-    res.setHeader('Content-Type', 'text/event-stream');
-    res.setHeader('Cache-Control', 'no-cache, no-transform');
-    res.setHeader('Connection', 'keep-alive');
-    res.setHeader('X-Accel-Buffering', 'no');
-    res.flushHeaders?.();
-
-    const send = (event, data) => {
-      res.write(`event: ${event}\n`);
-      res.write(`data: ${JSON.stringify(data)}\n\n`);
-    };
+    const sse = createSseResponse(res);
+    const send = sse.send;
 
     // resolvedBin was already looked up above for the ENAMETOOLONG check.
     // If detection can't find the binary, surface a friendly SSE error
@@ -1055,7 +1098,7 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
           `Agent "${def.name}" (\`${def.bin}\`) is not installed or not on PATH. ` +
           'Install it and refresh the agent list (GET /api/agents) before retrying.',
       });
-      return res.end();
+      return sse.end();
     }
     // npm shims on Windows are .cmd/.bat files; Node ≥21 refuses to spawn
     // those without `shell: true` (CVE-2024-27980). When `shell: true` is set
@@ -1123,7 +1166,7 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
     } catch (err) {
       cleanPromptFile();
       send('error', { message: `spawn failed: ${err.message}` });
-      return res.end();
+      return sse.end();
     }
 
     child.stdout.setEncoding('utf8');
@@ -1169,15 +1212,15 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
 
     child.on('error', (err) => {
       send('error', { message: err.message });
-      res.end();
+      sse.end();
     });
     child.on('close', (code, signal) => {
       if (acpSession?.hasFatalError()) {
-        return res.end();
+        return sse.end();
       }
       cleanPromptFile();
       send('end', { code, signal });
-      res.end();
+      sse.end();
     });
   });
 
@@ -1238,16 +1281,8 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
     };
     const body = JSON.stringify(payload);
 
-    res.setHeader('Content-Type', 'text/event-stream');
-    res.setHeader('Cache-Control', 'no-cache, no-transform');
-    res.setHeader('Connection', 'keep-alive');
-    res.setHeader('X-Accel-Buffering', 'no');
-    res.flushHeaders?.();
-
-    const send = (event, data) => {
-      res.write(`event: ${event}\n`);
-      res.write(`data: ${JSON.stringify(data)}\n\n`);
-    };
+    const sse = createSseResponse(res);
+    const send = sse.send;
 
     let upstream;
     try {
@@ -1261,7 +1296,7 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
       });
     } catch (fetchErr) {
       send('error', { message: `fetch failed: ${fetchErr.message}` });
-      return res.end();
+      return sse.end();
     }
 
     if (!upstream.ok) {
@@ -1269,7 +1304,7 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
       const safeErr = errText.slice(0, 500).replace(/Bearer [A-Za-z0-9_\-\.]+/g, 'Bearer [REDACTED]');
       console.error(`[proxy] upstream ${upstream.status}: ${safeErr.slice(0, 200)}`);
       send('error', { message: `upstream ${upstream.status}: ${safeErr}` });
-      return res.end();
+      return sse.end();
     }
 
     send('start', { model });
@@ -1291,7 +1326,7 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
         const payload = line.slice(6).trim();
         if (payload === '[DONE]') {
           send('end', {});
-          return res.end();
+          return sse.end();
         }
         try {
           const chunk = JSON.parse(payload);
@@ -1318,7 +1353,7 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
     }
 
     send('end', {});
-    res.end();
+    sse.end();
   });
 
   // SPA fallback for the built web app. Put this LAST so it never shadows

--- a/apps/daemon/sse-response.test.mjs
+++ b/apps/daemon/sse-response.test.mjs
@@ -1,0 +1,88 @@
+import { EventEmitter } from 'node:events';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createSseResponse } from './server.js';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('createSseResponse', () => {
+  it('sets SSE headers and sends JSON app events', () => {
+    const res = new FakeResponse();
+    const sse = createSseResponse(res, { keepAliveIntervalMs: 0 });
+
+    expect(res.headers).toEqual({
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+      'Content-Type': 'text/event-stream',
+      'X-Accel-Buffering': 'no',
+    });
+    expect(res.flushed).toBe(true);
+
+    expect(sse.send('start', { ok: true })).toBe(true);
+    expect(res.writes.join('')).toBe('event: start\ndata: {"ok":true}\n\n');
+  });
+
+  it('emits heartbeat comments before real events', () => {
+    const res = new FakeResponse();
+    const sse = createSseResponse(res, { keepAliveIntervalMs: 0 });
+
+    expect(sse.writeKeepAlive()).toBe(true);
+    expect(sse.send('end', {})).toBe(true);
+    expect(res.writes.join('')).toBe(': keepalive\n\nevent: end\ndata: {}\n\n');
+  });
+
+  it('clears interval heartbeat on close', () => {
+    vi.useFakeTimers();
+    const res = new FakeResponse();
+    createSseResponse(res, { keepAliveIntervalMs: 10 });
+
+    vi.advanceTimersByTime(10);
+    expect(res.writes).toEqual([': keepalive\n\n']);
+
+    res.emit('close');
+    vi.advanceTimersByTime(30);
+    expect(res.writes).toEqual([': keepalive\n\n']);
+  });
+
+  it('skips writes after the response ends', () => {
+    const res = new FakeResponse();
+    const sse = createSseResponse(res, { keepAliveIntervalMs: 0 });
+
+    sse.end();
+
+    expect(res.ended).toBe(true);
+    expect(sse.writeKeepAlive()).toBe(false);
+    expect(sse.send('end', {})).toBe(false);
+    expect(res.writes).toEqual([]);
+  });
+});
+
+class FakeResponse extends EventEmitter {
+  headers = {};
+  writes = [];
+  destroyed = false;
+  writableEnded = false;
+  flushed = false;
+  ended = false;
+
+  setHeader(name, value) {
+    this.headers[name] = value;
+  }
+
+  flushHeaders() {
+    this.flushed = true;
+  }
+
+  write(chunk) {
+    this.writes.push(chunk);
+    return true;
+  }
+
+  end() {
+    this.ended = true;
+    this.writableEnded = true;
+    this.emit('finish');
+  }
+}

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -11,6 +11,7 @@
  */
 import type { AgentEvent, ChatMessage } from '../types';
 import type { StreamHandlers } from './anthropic';
+import { parseSseFrame } from './sse';
 
 export interface DaemonStreamHandlers extends StreamHandlers {
   onAgentEvent: (ev: AgentEvent) => void;
@@ -94,8 +95,8 @@ export async function streamViaDaemon({
       while ((idx = buf.indexOf('\n\n')) !== -1) {
         const frame = buf.slice(0, idx);
         buf = buf.slice(idx + 2);
-        const parsed = parseFrame(frame);
-        if (!parsed) continue;
+        const parsed = parseSseFrame(frame);
+        if (!parsed || parsed.kind !== 'event') continue;
 
         if (parsed.event === 'stdout') {
           const chunk = String(parsed.data.chunk ?? '');
@@ -152,26 +153,6 @@ export async function streamViaDaemon({
   } catch (err) {
     if ((err as Error).name === 'AbortError') return;
     handlers.onError(err instanceof Error ? err : new Error(String(err)));
-  }
-}
-
-interface ParsedFrame {
-  event: string;
-  data: Record<string, unknown>;
-}
-
-function parseFrame(frame: string): ParsedFrame | null {
-  const lines = frame.split('\n');
-  let event = 'message';
-  let data = '';
-  for (const line of lines) {
-    if (line.startsWith('event: ')) event = line.slice(7).trim();
-    else if (line.startsWith('data: ')) data += line.slice(6);
-  }
-  try {
-    return { event, data: JSON.parse(data) };
-  } catch {
-    return null;
   }
 }
 

--- a/apps/web/src/providers/openai-compatible.ts
+++ b/apps/web/src/providers/openai-compatible.ts
@@ -7,6 +7,7 @@
  */
 import type { AppConfig, ChatMessage } from '../types';
 import type { StreamHandlers } from './anthropic';
+import { parseSseFrame } from './sse';
 
 export async function streamMessageOpenAI(
   cfg: AppConfig,
@@ -56,22 +57,11 @@ export async function streamMessageOpenAI(
         const frame = buf.slice(0, idx);
         buf = buf.slice(idx + 2);
 
-        let event = 'message';
-        let data = '';
-        for (const line of frame.split('\n')) {
-          if (line.startsWith('event: ')) event = line.slice(7).trim();
-          else if (line.startsWith('data: ')) data += line.slice(6);
-        }
+        const parsed = parseSseFrame(frame);
+        if (!parsed || parsed.kind !== 'event') continue;
 
-        let parsed: Record<string, unknown>;
-        try {
-          parsed = JSON.parse(data);
-        } catch {
-          continue;
-        }
-
-        if (event === 'delta') {
-          const text = String(parsed.text ?? '');
+        if (parsed.event === 'delta') {
+          const text = String(parsed.data.text ?? '');
           if (text) {
             acc += text;
             handlers.onDelta(text);
@@ -79,12 +69,12 @@ export async function streamMessageOpenAI(
           continue;
         }
 
-        if (event === 'error') {
-          handlers.onError(new Error(String(parsed.message ?? 'proxy error')));
+        if (parsed.event === 'error') {
+          handlers.onError(new Error(String(parsed.data.message ?? 'proxy error')));
           return;
         }
 
-        if (event === 'end') {
+        if (parsed.event === 'end') {
           handlers.onDone(acc);
           return;
         }

--- a/apps/web/src/providers/sse.test.ts
+++ b/apps/web/src/providers/sse.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { streamViaDaemon } from './daemon';
+import { streamMessageOpenAI } from './openai-compatible';
+import { parseSseFrame } from './sse';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('parseSseFrame', () => {
+  it('parses JSON event frames', () => {
+    expect(parseSseFrame('event: stdout\ndata: {"chunk":"hello"}')).toEqual({
+      kind: 'event',
+      event: 'stdout',
+      data: { chunk: 'hello' },
+    });
+  });
+
+  it('parses SSE comment frames', () => {
+    expect(parseSseFrame(': keepalive')).toEqual({
+      kind: 'comment',
+      comment: 'keepalive',
+    });
+  });
+
+  it('returns empty for frames without data or comments', () => {
+    expect(parseSseFrame('')).toEqual({ kind: 'empty' });
+  });
+});
+
+describe('streamViaDaemon', () => {
+  it('ignores comment frames without notifying handlers', async () => {
+    const handlers = createDaemonHandlers();
+    vi.stubGlobal('fetch', vi.fn(async () => sseResponse(': keepalive\n\n')));
+
+    await streamViaDaemon({
+      agentId: 'mock',
+      history: [{ id: '1', role: 'user', content: 'hello' }],
+      systemPrompt: '',
+      signal: new AbortController().signal,
+      handlers,
+    });
+
+    expect(handlers.onDelta).not.toHaveBeenCalled();
+    expect(handlers.onError).not.toHaveBeenCalled();
+    expect(handlers.onAgentEvent).not.toHaveBeenCalled();
+    expect(handlers.onDone).toHaveBeenCalledWith('');
+  });
+
+  it('continues normal stdout and end handling around comments', async () => {
+    const handlers = createDaemonHandlers();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        sseResponse(
+          [
+            ': keepalive',
+            '',
+            'event: start',
+            'data: {"bin":"mock-agent"}',
+            '',
+            'event: stdout',
+            'data: {"chunk":"hello"}',
+            '',
+            ': keepalive',
+            '',
+            'event: end',
+            'data: {"code":0}',
+            '',
+          ].join('\n'),
+        ),
+      ),
+    );
+
+    await streamViaDaemon({
+      agentId: 'mock',
+      history: [{ id: '1', role: 'user', content: 'hello' }],
+      systemPrompt: '',
+      signal: new AbortController().signal,
+      handlers,
+    });
+
+    expect(handlers.onDelta).toHaveBeenCalledWith('hello');
+    expect(handlers.onError).not.toHaveBeenCalled();
+    expect(handlers.onDone).toHaveBeenCalledWith('hello');
+  });
+});
+
+describe('streamMessageOpenAI', () => {
+  it('ignores comments and keeps delta/end behavior unchanged', async () => {
+    const handlers = createStreamHandlers();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        sseResponse(
+          [
+            ': keepalive',
+            '',
+            'event: delta',
+            'data: {"text":"hi"}',
+            '',
+            ': keepalive',
+            '',
+            'event: end',
+            'data: {}',
+            '',
+          ].join('\n'),
+        ),
+      ),
+    );
+
+    await streamMessageOpenAI(
+      {
+        mode: 'api',
+        apiKey: 'test-key',
+        baseUrl: 'https://example.test',
+        model: 'gpt-test',
+        agentId: null,
+        skillId: null,
+        designSystemId: null,
+      },
+      '',
+      [{ id: '1', role: 'user', content: 'hello' }],
+      new AbortController().signal,
+      handlers,
+    );
+
+    expect(handlers.onDelta).toHaveBeenCalledTimes(1);
+    expect(handlers.onDelta).toHaveBeenCalledWith('hi');
+    expect(handlers.onError).not.toHaveBeenCalled();
+    expect(handlers.onDone).toHaveBeenCalledWith('hi');
+  });
+});
+
+function createStreamHandlers() {
+  return {
+    onDelta: vi.fn(),
+    onDone: vi.fn(),
+    onError: vi.fn(),
+  };
+}
+
+function createDaemonHandlers() {
+  return {
+    ...createStreamHandlers(),
+    onAgentEvent: vi.fn(),
+  };
+}
+
+function sseResponse(text: string): Response {
+  const encoder = new TextEncoder();
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(text));
+        controller.close();
+      },
+    }),
+    {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    },
+  );
+}

--- a/apps/web/src/providers/sse.ts
+++ b/apps/web/src/providers/sse.ts
@@ -1,0 +1,35 @@
+export type ParsedSseFrame =
+  | { kind: 'event'; event: string; data: Record<string, unknown> }
+  | { kind: 'comment'; comment: string }
+  | { kind: 'empty' };
+
+export function parseSseFrame(frame: string): ParsedSseFrame | null {
+  const lines = frame.split('\n');
+  const comments: string[] = [];
+  let event = 'message';
+  const dataLines: string[] = [];
+
+  for (const rawLine of lines) {
+    const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine;
+    if (line.startsWith(':')) {
+      comments.push(line.slice(1).trimStart());
+    } else if (line.startsWith('event: ')) {
+      event = line.slice(7).trim();
+    } else if (line.startsWith('data: ')) {
+      dataLines.push(line.slice(6));
+    }
+  }
+
+  if (dataLines.length === 0) {
+    if (comments.length > 0) {
+      return { kind: 'comment', comment: comments.join('\n') };
+    }
+    return { kind: 'empty' };
+  }
+
+  try {
+    return { kind: 'event', event, data: JSON.parse(dataLines.join('\n')) };
+  } catch {
+    return null;
+  }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -279,6 +279,8 @@ pnpm install
 pnpm dev:all       # starts daemon on :7456, next on :3000
 ```
 
+When a reverse proxy sits in front of the daemon, `/api/*` includes SSE streams and must stay unbuffered. The daemon sends `Cache-Control: no-cache, no-transform` and `X-Accel-Buffering: no`, and also emits SSE comment keepalives, but nginx can still break chunked streams if gzip is enabled. For nginx, set `proxy_buffering off;`, `gzip off;`, and long `proxy_read_timeout` / `proxy_send_timeout` values on the API location. Otherwise browsers can report `net::ERR_INCOMPLETE_CHUNKED_ENCODING 200 (OK)` on long generations.
+
 ### Docker
 ```yaml
 # docker-compose.yml

--- a/e2e/scripts/runtime-adapter.e2e.live.test.mjs
+++ b/e2e/scripts/runtime-adapter.e2e.live.test.mjs
@@ -217,8 +217,11 @@ async function collectSseEvents(res, events, agentId) {
 }
 
 function parseSseEvent(chunk) {
-  const eventLine = chunk.split('\n').find((line) => line.startsWith('event: '));
-  const dataLine = chunk.split('\n').find((line) => line.startsWith('data: '));
+  const lines = chunk.split('\n');
+  if (lines.every((line) => line === '' || line.startsWith(':'))) return null;
+
+  const eventLine = lines.find((line) => line.startsWith('event: '));
+  const dataLine = lines.find((line) => line.startsWith('data: '));
   if (!eventLine || !dataLine) return null;
   return {
     event: eventLine.slice('event: '.length),


### PR DESCRIPTION
## Summary

- Add a shared daemon SSE response helper that keeps existing SSE headers and emits transport-level `: keepalive` comment frames every 25 seconds.
- Update web SSE parsing so daemon and OpenAI-compatible streams intentionally ignore comment-only frames.
- Document nginx reverse-proxy requirements for SSE, including `proxy_buffering off`, `gzip off`, and long proxy timeouts for issue #99.

## Root cause

Issue #99 reports `net::ERR_INCOMPLETE_CHUNKED_ENCODING 200 (OK)` after long SSE generations behind nginx. The daemon already sent `X-Accel-Buffering: no`, but nginx `gzip on` can still buffer chunked SSE responses. The keepalive comments reduce idle-stream fragility, and the docs map the nginx config needed to avoid gzip buffering.

## Validation

- `pnpm --filter @open-design/web test`
- `pnpm --filter @open-design/daemon test`
- `pnpm --filter @open-design/e2e test`
- `pnpm --filter @open-design/web typecheck`

Note: local commands emitted Node engine warnings because the shell uses Node v22.22.2 while the repo asks for Node ~24, but all checks passed.