### PR TITLE
Fix chat runs surviving web disconnects

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -274,8 +274,9 @@ export function createSseResponse(res, { keepAliveIntervalMs = SSE_KEEPALIVE_INT
 
   return {
     /** @param {ChatSseEvent['event'] | ProxySseEvent['event'] | string} event */
-    send(event, data) {
+    send(event, data, id = null) {
       if (!canWrite()) return false;
+      if (id !== null && id !== undefined) res.write(`id: ${id}\n`);
       res.write(`event: ${event}\n`);
       res.write(`data: ${JSON.stringify(data)}\n\n`);
       return true;
@@ -1005,9 +1006,96 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
     },
   );
 
-  app.post('/api/chat', async (req, res) => {
+  const chatRuns = new Map();
+  const MAX_RUN_EVENTS = 2_000;
+  const TERMINAL_RUN_STATUSES = new Set(['succeeded', 'failed', 'canceled']);
+  const CHAT_RUN_TTL_MS = 30 * 60 * 1000;
+
+  const createChatRun = () => {
+    const now = Date.now();
+    const run = {
+      id: randomUUID(),
+      status: 'queued',
+      createdAt: now,
+      updatedAt: now,
+      events: [],
+      nextEventId: 1,
+      clients: new Set(),
+      child: null,
+      acpSession: null,
+      exitCode: null,
+      signal: null,
+      cancelRequested: false,
+      promptFileCleaned: null,
+    };
+    chatRuns.set(run.id, run);
+    return run;
+  };
+
+  const scheduleRunCleanup = (run) => {
+    setTimeout(() => {
+      if (TERMINAL_RUN_STATUSES.has(run.status)) chatRuns.delete(run.id);
+    }, CHAT_RUN_TTL_MS).unref?.();
+  };
+
+  const emitRunEvent = (run, event, data) => {
+    const id = run.nextEventId++;
+    const record = { id, event, data };
+    run.events.push(record);
+    if (run.events.length > MAX_RUN_EVENTS) run.events.splice(0, run.events.length - MAX_RUN_EVENTS);
+    run.updatedAt = Date.now();
+    for (const sse of run.clients) sse.send(event, data, id);
+  };
+
+  const finishRun = (run, status, code = null, signal = null) => {
+    if (TERMINAL_RUN_STATUSES.has(run.status)) return;
+    run.status = status;
+    run.exitCode = code;
+    run.signal = signal;
+    run.updatedAt = Date.now();
+    run.promptFileCleaned?.();
+    emitRunEvent(run, 'end', { code, signal, status });
+    for (const sse of run.clients) sse.end();
+    run.clients.clear();
+    scheduleRunCleanup(run);
+  };
+
+  const failRun = (run, code, message, init = {}) => {
+    emitRunEvent(run, 'error', createSseErrorPayload(code, message, init));
+    finishRun(run, 'failed', 1, null);
+  };
+
+  const attachRunStream = (run, req, res) => {
+    const sse = createSseResponse(res);
+    const lastEventId = Number(req.get('Last-Event-ID') || req.query.after || 0);
+    for (const record of run.events) {
+      if (!Number.isFinite(lastEventId) || record.id > lastEventId) {
+        sse.send(record.event, record.data, record.id);
+      }
+    }
+    if (TERMINAL_RUN_STATUSES.has(run.status)) {
+      sse.end();
+      return;
+    }
+    run.clients.add(sse);
+    res.on('close', () => {
+      run.clients.delete(sse);
+      sse.cleanup();
+    });
+  };
+
+  const runStatusBody = (run) => ({
+    id: run.id,
+    status: run.status,
+    createdAt: run.createdAt,
+    updatedAt: run.updatedAt,
+    exitCode: run.exitCode,
+    signal: run.signal,
+  });
+
+  const startChatRun = async (chatBody, run) => {
     /** @type {Partial<ChatRequest> & { imagePaths?: string[] }} */
-    const chatBody = req.body || {};
+    chatBody = chatBody || {};
     const {
       agentId,
       message,
@@ -1019,11 +1107,12 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
       reasoning,
     } = chatBody;
     const def = getAgentDef(agentId);
-    if (!def) return sendApiError(res, 400, 'AGENT_UNAVAILABLE', `unknown agent: ${agentId}`);
-    if (!def.bin) return sendApiError(res, 400, 'AGENT_UNAVAILABLE', 'agent has no binary');
+    if (!def) return failRun(run, 'AGENT_UNAVAILABLE', `unknown agent: ${agentId}`);
+    if (!def.bin) return failRun(run, 'AGENT_UNAVAILABLE', 'agent has no binary');
     if (typeof message !== 'string' || !message.trim()) {
-      return sendApiError(res, 400, 'BAD_REQUEST', 'message required');
+      return failRun(run, 'BAD_REQUEST', 'message required');
     }
+    if (run.cancelRequested || TERMINAL_RUN_STATUSES.has(run.status)) return;
 
     // Resolve the project working directory (creating the folder if it
     // doesn't exist yet). Without one we don't pass cwd to spawn — the
@@ -1039,6 +1128,7 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
         cwd = null;
       }
     }
+    if (run.cancelRequested || TERMINAL_RUN_STATUSES.has(run.status)) return;
 
     // Sanitise supplied image paths: must live under UPLOAD_DIR.
     const safeImages = imagePaths.filter((p) => {
@@ -1172,10 +1262,9 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
       }
     }
 
+    run.promptFileCleaned = cleanPromptFile;
     const args = def.buildArgs(effectivePrompt, safeImages, extraAllowedDirs, agentOptions, { cwd });
-
-    const sse = createSseResponse(res);
-    const send = sse.send;
+    const send = (event, data) => emitRunEvent(run, event, data);
 
     // resolvedBin was already looked up above for the ENAMETOOLONG check.
     // If detection can't find the binary, surface a friendly SSE error
@@ -1184,13 +1273,13 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
     // from issue #10 the rest of this block is meant to prevent.
     if (!resolvedBin) {
       cleanPromptFile();
-      send('error', createSseErrorPayload(
+      emitRunEvent(run, 'error', createSseErrorPayload(
         'AGENT_UNAVAILABLE',
         `Agent "${def.name}" (\`${def.bin}\`) is not installed or not on PATH. ` +
           'Install it and refresh the agent list (GET /api/agents) before retrying.',
         { retryable: true },
       ));
-      return sse.end();
+      return finishRun(run, 'failed', 1, null);
     }
     // npm shims on Windows are .cmd/.bat files; Node ≥21 refuses to spawn
     // those without `shell: true` (CVE-2024-27980). When `shell: true` is set
@@ -1219,7 +1308,12 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
     const useShell =
       process.platform === 'win32' && CMD_BAT_RE.test(resolvedBin);
 
+    if (run.cancelRequested || TERMINAL_RUN_STATUSES.has(run.status)) return;
+
+    run.status = 'running';
+    run.updatedAt = Date.now();
     send('start', {
+      runId: run.id,
       agentId,
       bin: resolvedBin,
       streamFormat: def.streamFormat ?? 'plain',
@@ -1243,6 +1337,7 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
         cwd: cwd || undefined,
         shell: useShell,
       });
+      run.child = child;
       if ((def.promptViaStdin || needsFilePrompt) && child.stdin) {
         // EPIPE from a fast-exiting CLI (bad auth, missing model, exit on
         // launch) would otherwise surface as an unhandled stream error and
@@ -1257,8 +1352,8 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
       }
     } catch (err) {
       cleanPromptFile();
-      send('error', createSseErrorPayload('AGENT_EXECUTION_FAILED', `spawn failed: ${err.message}`));
-      return sse.end();
+      emitRunEvent(run, 'error', createSseErrorPayload('AGENT_EXECUTION_FAILED', `spawn failed: ${err.message}`));
+      return finishRun(run, 'failed', 1, null);
     }
 
     child.stdout.setEncoding('utf8');
@@ -1295,24 +1390,64 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
     }
     child.stderr.on('data', (chunk) => send('stderr', { chunk }));
 
-    const kill = () => {
-      if (child && !child.killed) child.kill('SIGTERM');
-    };
-    res.on('close', () => {
-      if (!res.writableEnded) kill();
-    });
-
     child.on('error', (err) => {
       send('error', createSseErrorPayload('AGENT_EXECUTION_FAILED', err.message));
-      sse.end();
+      finishRun(run, 'failed', 1, null);
     });
     child.on('close', (code, signal) => {
       if (acpSession?.hasFatalError()) {
-        return sse.end();
+        return finishRun(run, 'failed', code ?? 1, signal ?? null);
       }
-      cleanPromptFile();
-      send('end', { code, signal });
-      sse.end();
+      const status = run.cancelRequested
+        ? 'canceled'
+        : code === 0
+          ? 'succeeded'
+          : 'failed';
+      finishRun(run, status, code, signal);
+    });
+  };
+
+  app.post('/api/runs', (req, res) => {
+    const run = createChatRun();
+    /** @type {import('@open-design/contracts').ChatRunCreateResponse} */
+    const body = { runId: run.id };
+    res.status(202).json(body);
+    void startChatRun(req.body || {}, run).catch((err) => {
+      failRun(run, 'AGENT_EXECUTION_FAILED', err instanceof Error ? err.message : String(err));
+    });
+  });
+
+  app.get('/api/runs/:id', (req, res) => {
+    const run = chatRuns.get(req.params.id);
+    if (!run) return sendApiError(res, 404, 'NOT_FOUND', 'run not found');
+    res.json(runStatusBody(run));
+  });
+
+  app.get('/api/runs/:id/events', (req, res) => {
+    const run = chatRuns.get(req.params.id);
+    if (!run) return sendApiError(res, 404, 'NOT_FOUND', 'run not found');
+    attachRunStream(run, req, res);
+  });
+
+  app.post('/api/runs/:id/cancel', (req, res) => {
+    const run = chatRuns.get(req.params.id);
+    if (!run) return sendApiError(res, 404, 'NOT_FOUND', 'run not found');
+    if (!TERMINAL_RUN_STATUSES.has(run.status)) {
+      run.cancelRequested = true;
+      run.updatedAt = Date.now();
+      if (run.child && !run.child.killed) run.child.kill('SIGTERM');
+      else finishRun(run, 'canceled', null, 'SIGTERM');
+    }
+    /** @type {import('@open-design/contracts').ChatRunCancelResponse} */
+    const body = { ok: true };
+    res.json(body);
+  });
+
+  app.post('/api/chat', (req, res) => {
+    const run = createChatRun();
+    attachRunStream(run, req, res);
+    void startChatRun(req.body || {}, run).catch((err) => {
+      failRun(run, 'AGENT_EXECUTION_FAILED', err instanceof Error ? err.message : String(err));
     });
   });
 

--- a/apps/daemon/tests/sse-response.test.ts
+++ b/apps/daemon/tests/sse-response.test.ts
@@ -25,6 +25,15 @@ describe('createSseResponse', () => {
     expect(res.writes.join('')).toBe('event: start\ndata: {"ok":true}\n\n');
   });
 
+  it('can attach SSE event ids for resumable streams', () => {
+    const res = new FakeResponse();
+    const sse = createSseResponse(res, { keepAliveIntervalMs: 0 });
+
+    expect(sse.send('stdout', { chunk: 'hello' }, 12)).toBe(true);
+
+    expect(res.writes.join('')).toBe('id: 12\nevent: stdout\ndata: {"chunk":"hello"}\n\n');
+  });
+
   it('emits heartbeat comments before real events', () => {
     const res = new FakeResponse();
     const sse = createSseResponse(res, { keepAliveIntervalMs: 0 });

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -84,8 +84,14 @@ export async function runDesktopMain(
 ): Promise<void> {
   await app.whenReady();
 
+  let appQuitRequested = false;
+  app.on("before-quit", () => {
+    appQuitRequested = true;
+  });
+
   const desktop = await createDesktopRuntime({
     discoverUrl: options.discoverWebUrl ?? createWebDiscovery(runtime),
+    shouldHideOnClose: () => !appQuitRequested,
   });
   let ipcServer: JsonIpcServerHandle | null = null;
   let shuttingDown = false;

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -64,6 +64,7 @@ export type DesktopRuntime = {
 
 export type DesktopRuntimeOptions = {
   discoverUrl(): Promise<string | null>;
+  shouldHideOnClose?: () => boolean;
 };
 
 function createPendingHtml(): string {
@@ -146,6 +147,12 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
     if (consoleEntries.length > MAX_CONSOLE_ENTRIES) {
       consoleEntries.splice(0, consoleEntries.length - MAX_CONSOLE_ENTRIES);
     }
+  });
+
+  window.on("close", (event) => {
+    if (stopped || options.shouldHideOnClose?.() === false) return;
+    event.preventDefault();
+    window.hide();
   });
 
   await window.loadURL(createPendingHtml());

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -87,6 +87,7 @@ export async function streamViaDaemon({
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body,
+      signal,
     });
 
     if (!createResp.ok) {

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -134,7 +134,7 @@ export async function streamViaDaemon({
       const reader = resp.body.getReader();
       const decoder = new TextDecoder();
       let buf = '';
-      let sawEvent = false;
+      let sawStreamProgress = false;
 
       while (true) {
         const { value, done } = await reader.read();
@@ -145,8 +145,13 @@ export async function streamViaDaemon({
           const frame = buf.slice(0, idx);
           buf = buf.slice(idx + 2);
           const parsed = parseSseFrame(frame);
-          if (!parsed || parsed.kind !== 'event') continue;
-          sawEvent = true;
+          if (!parsed) continue;
+          if (parsed.kind === 'comment') {
+            sawStreamProgress = true;
+            continue;
+          }
+          if (parsed.kind !== 'event') continue;
+          sawStreamProgress = true;
           if (parsed.id) lastEventId = parsed.id;
 
           const event = parsed as unknown as ChatSseEvent;
@@ -199,7 +204,7 @@ export async function streamViaDaemon({
           }
         }
       }
-      reconnects = sawEvent ? 0 : reconnects + 1;
+      reconnects = sawStreamProgress ? 0 : reconnects + 1;
     }
 
     if (endStatus === null) {

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -11,6 +11,7 @@
  */
 import type { AgentEvent, ChatMessage } from '../types';
 import type {
+  ChatRunCreateResponse,
   ChatRequest,
   ChatSseEvent,
   ChatSseStartPayload,
@@ -76,91 +77,150 @@ export async function streamViaDaemon({
   let acc = '';
   let stderrBuf = '';
   let exitCode: number | null = null;
+  let exitSignal: string | null = null;
+  let endStatus: string | null = null;
+  let lastEventId: string | null = null;
+  let abortListener: (() => void) | null = null;
 
   try {
-    const resp = await fetch('/api/chat', {
+    const createResp = await fetch('/api/runs', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body,
-      signal,
     });
 
-    if (!resp.ok || !resp.body) {
-      const text = await resp.text().catch(() => '');
-      handlers.onError(new Error(`daemon ${resp.status}: ${text || 'no body'}`));
+    if (!createResp.ok) {
+      const text = await createResp.text().catch(() => '');
+      handlers.onError(new Error(`daemon ${createResp.status}: ${text || 'no body'}`));
       return;
     }
 
-    const reader = resp.body.getReader();
-    const decoder = new TextDecoder();
-    let buf = '';
+    const created = (await createResp.json()) as ChatRunCreateResponse;
+    const runId = created.runId;
+    let canceled = false;
+    const cancelRun = () => {
+      if (canceled) return;
+      canceled = true;
+      void fetch(`/api/runs/${encodeURIComponent(runId)}/cancel`, { method: 'POST' }).catch(() => {});
+    };
+    if (signal.aborted) {
+      cancelRun();
+      return;
+    }
+    abortListener = cancelRun;
+    signal.addEventListener('abort', cancelRun, { once: true });
 
-    while (true) {
-      const { value, done } = await reader.read();
-      if (done) break;
-      buf += decoder.decode(value, { stream: true });
-      let idx: number;
-      while ((idx = buf.indexOf('\n\n')) !== -1) {
-        const frame = buf.slice(0, idx);
-        buf = buf.slice(idx + 2);
-        const parsed = parseSseFrame(frame);
-        if (!parsed || parsed.kind !== 'event') continue;
+    for (let reconnects = 0; endStatus === null && reconnects < 5;) {
+      const qs = lastEventId ? `?after=${encodeURIComponent(lastEventId)}` : '';
+      let resp: Response;
+      try {
+        resp = await fetch(`/api/runs/${encodeURIComponent(runId)}/events${qs}`, {
+          method: 'GET',
+          signal,
+        });
+      } catch (err) {
+        if ((err as Error).name === 'AbortError') throw err;
+        reconnects += 1;
+        continue;
+      }
 
-        const event = parsed as unknown as ChatSseEvent;
+      if (!resp.ok || !resp.body) {
+        const text = await resp.text().catch(() => '');
+        handlers.onError(new Error(`daemon ${resp.status}: ${text || 'no body'}`));
+        return;
+      }
 
-        if (event.event === 'stdout') {
-          const chunk = String(event.data.chunk ?? '');
-          acc += chunk;
-          handlers.onDelta(chunk);
-          handlers.onAgentEvent({ kind: 'text', text: chunk });
-          continue;
-        }
+      const reader = resp.body.getReader();
+      const decoder = new TextDecoder();
+      let buf = '';
+      let sawEvent = false;
 
-        if (event.event === 'stderr') {
-          stderrBuf += event.data.chunk ?? '';
-          continue;
-        }
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+        let idx: number;
+        while ((idx = buf.indexOf('\n\n')) !== -1) {
+          const frame = buf.slice(0, idx);
+          buf = buf.slice(idx + 2);
+          const parsed = parseSseFrame(frame);
+          if (!parsed || parsed.kind !== 'event') continue;
+          sawEvent = true;
+          if (parsed.id) lastEventId = parsed.id;
 
-        if (event.event === 'agent') {
-          const translated = translateAgentEvent(event.data);
-          if (!translated) continue;
-          if (translated.kind === 'text') {
-            acc += translated.text;
-            handlers.onDelta(translated.text);
+          const event = parsed as unknown as ChatSseEvent;
+
+          if (event.event === 'stdout') {
+            const chunk = String(event.data.chunk ?? '');
+            acc += chunk;
+            handlers.onDelta(chunk);
+            handlers.onAgentEvent({ kind: 'text', text: chunk });
+            continue;
           }
-          handlers.onAgentEvent(translated);
-          continue;
-        }
 
-        if (event.event === 'start') {
-          const data = event.data as ChatSseStartPayload;
-          handlers.onAgentEvent({
-            kind: 'status',
-            label: 'starting',
-            detail: typeof data.bin === 'string' ? data.bin : undefined,
-          });
-          continue;
-        }
+          if (event.event === 'stderr') {
+            stderrBuf += event.data.chunk ?? '';
+            continue;
+          }
 
-        if (event.event === 'error') {
-          const data = event.data as SseErrorPayload;
-          handlers.onError(new Error(String(data.error?.message ?? data.message ?? 'daemon error')));
-          return;
-        }
+          if (event.event === 'agent') {
+            const translated = translateAgentEvent(event.data);
+            if (!translated) continue;
+            if (translated.kind === 'text') {
+              acc += translated.text;
+              handlers.onDelta(translated.text);
+            }
+            handlers.onAgentEvent(translated);
+            continue;
+          }
 
-        if (event.event === 'end') {
-          exitCode = typeof event.data.code === 'number' ? event.data.code : null;
+          if (event.event === 'start') {
+            const data = event.data as ChatSseStartPayload;
+            handlers.onAgentEvent({
+              kind: 'status',
+              label: 'starting',
+              detail: typeof data.bin === 'string' ? data.bin : undefined,
+            });
+            continue;
+          }
+
+          if (event.event === 'error') {
+            const data = event.data as SseErrorPayload;
+            handlers.onError(new Error(String(data.error?.message ?? data.message ?? 'daemon error')));
+            if (abortListener) signal.removeEventListener('abort', abortListener);
+            return;
+          }
+
+          if (event.event === 'end') {
+            exitCode = typeof event.data.code === 'number' ? event.data.code : null;
+            exitSignal = typeof event.data.signal === 'string' ? event.data.signal : null;
+            endStatus = typeof event.data.status === 'string' ? event.data.status : 'succeeded';
+          }
         }
       }
+      reconnects = sawEvent ? 0 : reconnects + 1;
     }
 
-    if (exitCode !== null && exitCode !== 0) {
-      const tail = stderrBuf.trim().slice(-400);
-      handlers.onError(
-        new Error(`agent exited with code ${exitCode}${tail ? `\n${tail}` : ''}`),
-      );
+    if (endStatus === null) {
+      handlers.onError(new Error('daemon stream disconnected before run completed'));
+      if (abortListener) signal.removeEventListener('abort', abortListener);
       return;
     }
+
+    if (endStatus === 'canceled') {
+      if (abortListener) signal.removeEventListener('abort', abortListener);
+      return;
+    }
+
+    if (endStatus === 'failed' || exitSignal || (exitCode !== null && exitCode !== 0)) {
+      const tail = stderrBuf.trim().slice(-400);
+      handlers.onError(
+        new Error(`agent exited with ${exitSignal ? `signal ${exitSignal}` : `code ${exitCode}`}${tail ? `\n${tail}` : ''}`),
+      );
+      if (abortListener) signal.removeEventListener('abort', abortListener);
+      return;
+    }
+    if (abortListener) signal.removeEventListener('abort', abortListener);
     handlers.onDone(acc);
   } catch (err) {
     if ((err as Error).name === 'AbortError') return;

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -104,12 +104,13 @@ export async function streamViaDaemon({
       canceled = true;
       void fetch(`/api/runs/${encodeURIComponent(runId)}/cancel`, { method: 'POST' }).catch(() => {});
     };
-    if (signal.aborted) {
-      cancelRun();
-      return;
-    }
     abortListener = cancelRun;
     signal.addEventListener('abort', cancelRun, { once: true });
+    if (signal.aborted) {
+      cancelRun();
+      signal.removeEventListener('abort', abortListener);
+      return;
+    }
 
     for (let reconnects = 0; endStatus === null && reconnects < 5;) {
       const qs = lastEventId ? `?after=${encodeURIComponent(lastEventId)}` : '';

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -127,6 +127,7 @@ export async function streamViaDaemon({
 
       if (!resp.ok || !resp.body) {
         const text = await resp.text().catch(() => '');
+        cancelRun();
         handlers.onError(new Error(`daemon ${resp.status}: ${text || 'no body'}`));
         return;
       }
@@ -208,6 +209,7 @@ export async function streamViaDaemon({
     }
 
     if (endStatus === null) {
+      cancelRun();
       handlers.onError(new Error('daemon stream disconnected before run completed'));
       if (abortListener) signal.removeEventListener('abort', abortListener);
       return;

--- a/apps/web/src/providers/sse.test.ts
+++ b/apps/web/src/providers/sse.test.ts
@@ -228,6 +228,30 @@ describe('streamViaDaemon', () => {
     expect(handlers.onError).not.toHaveBeenCalled();
     expect(handlers.onDone).toHaveBeenCalledWith('');
   });
+
+  it('cancels the daemon run when reconnects are exhausted before an end event', async () => {
+    const handlers = createDaemonHandlers();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/runs') return jsonResponse({ runId: 'run-1' });
+      if (url === '/api/runs/run-1/cancel') return jsonResponse({ ok: true });
+      if (url === '/api/runs/run-1/events') return sseResponse('');
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await streamViaDaemon({
+      agentId: 'mock',
+      history: [{ id: '1', role: 'user', content: 'hello' }],
+      systemPrompt: '',
+      signal: new AbortController().signal,
+      handlers,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/runs/run-1/cancel', { method: 'POST' });
+    expect(handlers.onError).toHaveBeenCalledWith(new Error('daemon stream disconnected before run completed'));
+    expect(handlers.onDone).not.toHaveBeenCalled();
+  });
 });
 
 describe('streamMessageOpenAI', () => {

--- a/apps/web/src/providers/sse.test.ts
+++ b/apps/web/src/providers/sse.test.ts
@@ -203,6 +203,31 @@ describe('streamViaDaemon', () => {
     });
     expect(handlers.onDone).toHaveBeenCalledWith('hello');
   });
+
+  it('keeps reconnecting when quiet resumed streams only receive keepalives', async () => {
+    const handlers = createDaemonHandlers();
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({ runId: 'run-1' }))
+      .mockResolvedValueOnce(sseResponse(': keepalive\n\n'))
+      .mockResolvedValueOnce(sseResponse(': keepalive\n\n'))
+      .mockResolvedValueOnce(sseResponse(': keepalive\n\n'))
+      .mockResolvedValueOnce(sseResponse(': keepalive\n\n'))
+      .mockResolvedValueOnce(sseResponse(': keepalive\n\n'))
+      .mockResolvedValueOnce(sseResponse('event: end\ndata: {"code":0,"status":"succeeded"}\n\n'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await streamViaDaemon({
+      agentId: 'mock',
+      history: [{ id: '1', role: 'user', content: 'hello' }],
+      systemPrompt: '',
+      signal: new AbortController().signal,
+      handlers,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(7);
+    expect(handlers.onError).not.toHaveBeenCalled();
+    expect(handlers.onDone).toHaveBeenCalledWith('');
+  });
 });
 
 describe('streamMessageOpenAI', () => {

--- a/apps/web/src/providers/sse.test.ts
+++ b/apps/web/src/providers/sse.test.ts
@@ -150,6 +150,55 @@ describe('streamViaDaemon', () => {
     expect(handlers.onError).not.toHaveBeenCalled();
   });
 
+  it('cancels the daemon run when abort fires after the post-create aborted check', async () => {
+    const handlers = createDaemonHandlers();
+    const controller = new AbortController();
+    const abortedGetter = Object.getOwnPropertyDescriptor(AbortSignal.prototype, 'aborted')?.get;
+    let triggeredAbortRace = false;
+
+    Object.defineProperty(controller.signal, 'aborted', {
+      configurable: true,
+      get() {
+        if (!triggeredAbortRace) {
+          triggeredAbortRace = true;
+          controller.abort();
+          return false;
+        }
+        return abortedGetter?.call(this) ?? true;
+      },
+    });
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/runs') return jsonResponse({ runId: 'run-1' });
+      if (url === '/api/runs/run-1/cancel') return jsonResponse({ ok: true });
+      if (url === '/api/runs/run-1/events') throw new DOMException('aborted', 'AbortError');
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await streamViaDaemon({
+      agentId: 'mock',
+      history: [{ id: '1', role: 'user', content: 'hello' }],
+      systemPrompt: '',
+      signal: controller.signal,
+      handlers,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenNthCalledWith(1, '/api/runs', expect.objectContaining({
+      method: 'POST',
+      signal: controller.signal,
+    }));
+    expect(fetchMock).toHaveBeenNthCalledWith(2, '/api/runs/run-1/cancel', { method: 'POST' });
+    expect(fetchMock).toHaveBeenNthCalledWith(3, '/api/runs/run-1/events', {
+      method: 'GET',
+      signal: controller.signal,
+    });
+    expect(handlers.onDone).not.toHaveBeenCalled();
+    expect(handlers.onError).not.toHaveBeenCalled();
+  });
+
   it('passes the caller signal to the initial create-run request', async () => {
     const handlers = createDaemonHandlers();
     const controller = new AbortController();

--- a/apps/web/src/providers/sse.test.ts
+++ b/apps/web/src/providers/sse.test.ts
@@ -10,8 +10,9 @@ afterEach(() => {
 
 describe('parseSseFrame', () => {
   it('parses JSON event frames', () => {
-    expect(parseSseFrame('event: stdout\ndata: {"chunk":"hello"}')).toEqual({
+    expect(parseSseFrame('id: 12\nevent: stdout\ndata: {"chunk":"hello"}')).toEqual({
       kind: 'event',
+      id: '12',
       event: 'stdout',
       data: { chunk: 'hello' },
     });
@@ -32,7 +33,9 @@ describe('parseSseFrame', () => {
 describe('streamViaDaemon', () => {
   it('ignores comment frames without notifying handlers', async () => {
     const handlers = createDaemonHandlers();
-    vi.stubGlobal('fetch', vi.fn(async () => sseResponse(': keepalive\n\n')));
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(jsonResponse({ runId: 'run-1' }))
+      .mockResolvedValueOnce(sseResponse(': keepalive\n\nevent: end\ndata: {"code":0,"status":"succeeded"}\n\n')));
 
     await streamViaDaemon({
       agentId: 'mock',
@@ -52,8 +55,10 @@ describe('streamViaDaemon', () => {
     const handlers = createDaemonHandlers();
     vi.stubGlobal(
       'fetch',
-      vi.fn(async () =>
-        sseResponse(
+      vi.fn()
+        .mockResolvedValueOnce(jsonResponse({ runId: 'run-1' }))
+        .mockResolvedValueOnce(
+          sseResponse(
           [
             ': keepalive',
             '',
@@ -68,9 +73,10 @@ describe('streamViaDaemon', () => {
             'event: end',
             'data: {"code":0}',
             '',
+            '',
           ].join('\n'),
+          ),
         ),
-      ),
     );
 
     await streamViaDaemon({
@@ -90,16 +96,18 @@ describe('streamViaDaemon', () => {
     const handlers = createDaemonHandlers();
     vi.stubGlobal(
       'fetch',
-      vi.fn(async () =>
-        sseResponse(
+      vi.fn()
+        .mockResolvedValueOnce(jsonResponse({ runId: 'run-1' }))
+        .mockResolvedValueOnce(
+          sseResponse(
           [
             'event: error',
             'data: {"message":"legacy message","error":{"code":"AGENT_UNAVAILABLE","message":"typed message"}}',
             '',
             '',
           ].join('\n'),
+          ),
         ),
-      ),
     );
 
     await streamViaDaemon({
@@ -112,6 +120,57 @@ describe('streamViaDaemon', () => {
 
     expect(handlers.onError).toHaveBeenCalledWith(new Error('typed message'));
     expect(handlers.onDone).not.toHaveBeenCalled();
+  });
+
+  it('cancels the daemon run when the caller aborts', async () => {
+    const handlers = createDaemonHandlers();
+    const controller = new AbortController();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/runs') return jsonResponse({ runId: 'run-1' });
+      if (url === '/api/runs/run-1/cancel') return jsonResponse({ ok: true });
+      if (url === '/api/runs/run-1/events') {
+        controller.abort();
+        throw new DOMException('aborted', 'AbortError');
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await streamViaDaemon({
+      agentId: 'mock',
+      history: [{ id: '1', role: 'user', content: 'hello' }],
+      systemPrompt: '',
+      signal: controller.signal,
+      handlers,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/runs/run-1/cancel', { method: 'POST' });
+    expect(handlers.onDone).not.toHaveBeenCalled();
+    expect(handlers.onError).not.toHaveBeenCalled();
+  });
+
+  it('reconnects to a daemon run after an incomplete stream closes', async () => {
+    const handlers = createDaemonHandlers();
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({ runId: 'run-1' }))
+      .mockResolvedValueOnce(sseResponse('id: 1\nevent: stdout\ndata: {"chunk":"he"}\n\n'))
+      .mockResolvedValueOnce(sseResponse('id: 2\nevent: stdout\ndata: {"chunk":"llo"}\n\nid: 3\nevent: end\ndata: {"code":0,"status":"succeeded"}\n\n'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await streamViaDaemon({
+      agentId: 'mock',
+      history: [{ id: '1', role: 'user', content: 'hello' }],
+      systemPrompt: '',
+      signal: new AbortController().signal,
+      handlers,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/runs/run-1/events?after=1', {
+      method: 'GET',
+      signal: expect.any(AbortSignal),
+    });
+    expect(handlers.onDone).toHaveBeenCalledWith('hello');
   });
 });
 
@@ -190,4 +249,11 @@ function sseResponse(text: string): Response {
       headers: { 'content-type': 'text/event-stream' },
     },
   );
+}
+
+function jsonResponse(value: unknown): Response {
+  return new Response(JSON.stringify(value), {
+    status: 202,
+    headers: { 'content-type': 'application/json' },
+  });
 }

--- a/apps/web/src/providers/sse.test.ts
+++ b/apps/web/src/providers/sse.test.ts
@@ -150,6 +150,37 @@ describe('streamViaDaemon', () => {
     expect(handlers.onError).not.toHaveBeenCalled();
   });
 
+  it('passes the caller signal to the initial create-run request', async () => {
+    const handlers = createDaemonHandlers();
+    const controller = new AbortController();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === '/api/runs') {
+        expect(init?.signal).toBe(controller.signal);
+        controller.abort();
+        throw new DOMException('aborted', 'AbortError');
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await streamViaDaemon({
+      agentId: 'mock',
+      history: [{ id: '1', role: 'user', content: 'hello' }],
+      systemPrompt: '',
+      signal: controller.signal,
+      handlers,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith('/api/runs', expect.objectContaining({
+      method: 'POST',
+      signal: controller.signal,
+    }));
+    expect(handlers.onDone).not.toHaveBeenCalled();
+    expect(handlers.onError).not.toHaveBeenCalled();
+  });
+
   it('reconnects to a daemon run after an incomplete stream closes', async () => {
     const handlers = createDaemonHandlers();
     const fetchMock = vi.fn()

--- a/apps/web/src/providers/sse.ts
+++ b/apps/web/src/providers/sse.ts
@@ -1,5 +1,5 @@
 export type ParsedSseFrame =
-  | { kind: 'event'; event: string; data: Record<string, unknown> }
+  | { kind: 'event'; event: string; data: Record<string, unknown>; id?: string }
   | { kind: 'comment'; comment: string }
   | { kind: 'empty' };
 
@@ -7,6 +7,7 @@ export function parseSseFrame(frame: string): ParsedSseFrame | null {
   const lines = frame.split('\n');
   const comments: string[] = [];
   let event = 'message';
+  let id: string | undefined;
   const dataLines: string[] = [];
 
   for (const rawLine of lines) {
@@ -15,6 +16,8 @@ export function parseSseFrame(frame: string): ParsedSseFrame | null {
       comments.push(line.slice(1).trimStart());
     } else if (line.startsWith('event: ')) {
       event = line.slice(7).trim();
+    } else if (line.startsWith('id: ')) {
+      id = line.slice(4).trim();
     } else if (line.startsWith('data: ')) {
       dataLines.push(line.slice(6));
     }
@@ -28,7 +31,7 @@ export function parseSseFrame(frame: string): ParsedSseFrame | null {
   }
 
   try {
-    return { kind: 'event', event, data: JSON.parse(dataLines.join('\n')) };
+    return { kind: 'event', event, data: JSON.parse(dataLines.join('\n')), ...(id ? { id } : {}) };
   } catch {
     return null;
   }

--- a/e2e/specs/app.spec.ts
+++ b/e2e/specs/app.spec.ts
@@ -91,7 +91,10 @@ for (const entry of automatedCases()) {
     }
 
     if (entry.mockArtifact) {
-      await page.route('**/api/chat', async (route) => {
+      await page.route('**/api/runs', async (route) => {
+        await route.fulfill({ status: 202, contentType: 'application/json', body: '{"runId":"mock-run"}' });
+      });
+      await page.route('**/api/runs/*/events', async (route) => {
         const artifact =
           `<artifact identifier="${entry.mockArtifact!.identifier}" type="text/html" title="${entry.mockArtifact!.title}">` +
           entry.mockArtifact!.html +
@@ -121,7 +124,10 @@ for (const entry of automatedCases()) {
     }
 
     if (entry.flow === 'question-form-selection-limit') {
-      await page.route('**/api/chat', async (route) => {
+      await page.route('**/api/runs', async (route) => {
+        await route.fulfill({ status: 202, contentType: 'application/json', body: '{"runId":"mock-run"}' });
+      });
+      await page.route('**/api/runs/*/events', async (route) => {
         const form = [
           '<question-form id="discovery" title="Quick brief — 30 seconds">',
           JSON.stringify(
@@ -169,7 +175,10 @@ for (const entry of automatedCases()) {
 
     if (entry.flow === 'question-form-submit-persistence') {
       let requestCount = 0;
-      await page.route('**/api/chat', async (route) => {
+      await page.route('**/api/runs', async (route) => {
+        await route.fulfill({ status: 202, contentType: 'application/json', body: '{"runId":"mock-run"}' });
+      });
+      await page.route('**/api/runs/*/events', async (route) => {
         requestCount += 1;
         const chunk =
           requestCount === 1
@@ -203,7 +212,7 @@ for (const entry of automatedCases()) {
           `data: ${JSON.stringify({ chunk })}`,
           '',
           'event: end',
-          'data: {"code":0}',
+          'data: {"code":0,"status":"succeeded"}',
           '',
           '',
         ].join('\n');
@@ -314,7 +323,7 @@ async function sendPrompt(
       await expect(input).toHaveValue(prompt, { timeout: 1500 });
       await expect(sendButton).toBeEnabled({ timeout: 1500 });
       const chatResponse = page.waitForResponse(
-        (resp) => resp.url().includes('/api/chat') && resp.request().method() === 'POST',
+        (resp) => resp.url().includes('/api/runs') && resp.request().method() === 'POST',
         { timeout: 2000 },
       );
       await sendButton.evaluate((button: HTMLButtonElement) => button.click());
@@ -329,7 +338,7 @@ async function sendPrompt(
         await expect(input).toHaveValue(prompt, { timeout: 1500 });
         await expect(sendButton).toBeEnabled({ timeout: 1500 });
         const chatResponse = page.waitForResponse(
-          (resp) => resp.url().includes('/api/chat') && resp.request().method() === 'POST',
+          (resp) => resp.url().includes('/api/runs') && resp.request().method() === 'POST',
           { timeout: 2000 },
         );
         await sendButton.evaluate((button: HTMLButtonElement) => button.click());

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -12,6 +12,23 @@ export interface ChatRequest {
   reasoning?: string | null;
 }
 
+export interface ChatRunCreateResponse {
+  runId: string;
+}
+
+export interface ChatRunStatusResponse {
+  id: string;
+  status: 'queued' | 'running' | 'succeeded' | 'failed' | 'canceled';
+  createdAt: number;
+  updatedAt: number;
+  exitCode?: number | null;
+  signal?: string | null;
+}
+
+export interface ChatRunCancelResponse {
+  ok: true;
+}
+
 export interface ChatAttachment {
   path: string;
   name: string;

--- a/packages/contracts/src/sse/chat.ts
+++ b/packages/contracts/src/sse/chat.ts
@@ -4,10 +4,15 @@ import type { SseTransportEvent } from './common';
 export const CHAT_SSE_PROTOCOL_VERSION = 1;
 
 export interface ChatSseStartPayload {
+  runId?: string;
+  agentId?: string;
   bin: string;
   protocolVersion?: typeof CHAT_SSE_PROTOCOL_VERSION;
   /** Legacy daemon-internal absolute cwd. Kept for compatibility during W2 adoption. */
-  cwd?: string;
+  cwd?: string | null;
+  projectId?: string | null;
+  model?: string | null;
+  reasoning?: string | null;
 }
 
 export interface ChatSseChunkPayload {
@@ -16,6 +21,8 @@ export interface ChatSseChunkPayload {
 
 export interface ChatSseEndPayload {
   code: number | null;
+  signal?: string | null;
+  status?: 'succeeded' | 'failed' | 'canceled';
 }
 
 export type DaemonAgentPayload =

--- a/packages/contracts/src/sse/common.ts
+++ b/packages/contracts/src/sse/common.ts
@@ -1,4 +1,5 @@
 export interface SseTransportEvent<Name extends string, Payload> {
+  id?: string;
   event: Name;
   data: Payload;
 }


### PR DESCRIPTION
## Summary
- Move local agent chat execution into daemon-managed runs with resumable SSE event streams.
- Add explicit run cancellation and preserve background execution when the web SSE connection closes.
- Update web streaming, contracts, and tests for run creation, reconnect, cancel, and terminal statuses.

## Verification
- pnpm typecheck && pnpm test && pnpm build