### PR TITLE
[codex] disable Codex plugins via env

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -174,6 +174,7 @@ open-design/
 
 - **"no agents found on PATH"** — install one of: `claude`, `codex`, `gemini`, `opencode`, `cursor-agent`, `qwen`, `copilot`. Or switch to "Anthropic API · BYOK" in the top bar and paste a key in **Settings**.
 - **daemon 500 on /api/chat** — check the daemon terminal for the stderr tail; usually the CLI rejected its args. Different CLIs take different argv shapes; see `apps/daemon/src/agents.ts` `buildArgs` if you need to tweak.
+- **Codex loads too much plugin context** — start Open Design with `OD_CODEX_DISABLE_PLUGINS=1 pnpm tools-dev` to make daemon-spawned Codex processes run with `--disable plugins`.
 - **artifact never renders** — the model produced text without wrapping in `<artifact>`. Confirm the system prompt is going through (check daemon log) and consider switching to a more capable model or a stricter skill.
 
 ## Mapping back to the vision

--- a/apps/daemon/src/agents.ts
+++ b/apps/daemon/src/agents.ts
@@ -165,6 +165,9 @@ export const AGENT_DEFS = [
     // `spawn ENAMETOOLONG` while keeping Codex on its structured JSON stream.
     buildArgs: (_prompt, _imagePaths, _extra, options = {}, runtimeContext = {}) => {
       const args = ['exec', '--json', '--skip-git-repo-check', '--full-auto'];
+      if (process.env.OD_CODEX_DISABLE_PLUGINS === '1') {
+        args.push('--disable', 'plugins');
+      }
       if (runtimeContext.cwd) {
         args.push('-C', runtimeContext.cwd);
       }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -296,6 +296,10 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
   app.use(express.json({ limit: '4mb' }));
   const db = openDatabase(PROJECT_ROOT, { dataDir: RUNTIME_DATA_DIR });
 
+  if (process.env.OD_CODEX_DISABLE_PLUGINS === '1') {
+    console.log('[od] Codex plugins disabled via OD_CODEX_DISABLE_PLUGINS=1');
+  }
+
   // Warm agent-capability probes (e.g. whether the installed Claude Code
   // build advertises --include-partial-messages) so the first /api/chat
   // hits a populated cache even if /api/agents hasn't been called yet.

--- a/apps/daemon/tests/agents.test.ts
+++ b/apps/daemon/tests/agents.test.ts
@@ -1,0 +1,51 @@
+// @ts-nocheck
+import { afterEach, test } from 'vitest';
+import assert from 'node:assert/strict';
+import { AGENT_DEFS } from '../src/agents.js';
+
+const codex = AGENT_DEFS.find((agent) => agent.id === 'codex');
+const originalDisablePlugins = process.env.OD_CODEX_DISABLE_PLUGINS;
+
+afterEach(() => {
+  if (originalDisablePlugins == null) {
+    delete process.env.OD_CODEX_DISABLE_PLUGINS;
+  } else {
+    process.env.OD_CODEX_DISABLE_PLUGINS = originalDisablePlugins;
+  }
+});
+
+test('codex args disable plugins when OD_CODEX_DISABLE_PLUGINS is 1', () => {
+  process.env.OD_CODEX_DISABLE_PLUGINS = '1';
+
+  const args = codex.buildArgs('', [], [], {}, { cwd: '/tmp/od-project' });
+
+  assert.deepEqual(args.slice(0, 6), [
+    'exec',
+    '--json',
+    '--skip-git-repo-check',
+    '--full-auto',
+    '--disable',
+    'plugins',
+  ]);
+  assert.equal(args.at(-1), '-');
+});
+
+test('codex args keep plugins enabled when OD_CODEX_DISABLE_PLUGINS is unset', () => {
+  delete process.env.OD_CODEX_DISABLE_PLUGINS;
+
+  const args = codex.buildArgs('', [], [], {}, { cwd: '/tmp/od-project' });
+
+  assert.equal(args.includes('--disable'), false);
+  assert.equal(args.includes('plugins'), false);
+  assert.equal(args.at(-1), '-');
+});
+
+test('codex args keep plugins enabled when OD_CODEX_DISABLE_PLUGINS is not 1', () => {
+  process.env.OD_CODEX_DISABLE_PLUGINS = 'true';
+
+  const args = codex.buildArgs('', [], [], {}, { cwd: '/tmp/od-project' });
+
+  assert.equal(args.includes('--disable'), false);
+  assert.equal(args.includes('plugins'), false);
+  assert.equal(args.at(-1), '-');
+});


### PR DESCRIPTION
## Summary
- Add OD_CODEX_DISABLE_PLUGINS=1 support for daemon-spawned Codex processes.
- Pass --disable plugins only for the Codex adapter when the env var is exactly 1.
- Log the active setting on daemon startup and document the troubleshooting path.

## Validation
- pnpm --filter @open-design/daemon test
- pnpm --filter @open-design/daemon typecheck
