### PR TITLE
fix(sidecar): accept port 0 as auto-pick in daemon and web parsePort

### DIFF
--- a/apps/daemon/sidecar/server.ts
+++ b/apps/daemon/sidecar/server.ts
@@ -27,7 +27,7 @@ export type DaemonSidecarHandle = {
 function parsePort(value: string | undefined): number {
   if (value == null || value.trim().length === 0) return 0;
   const port = Number(value);
-  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
     throw new Error(`${DAEMON_PORT_ENV} must be an integer between 1 and 65535`);
   }
   return port;

--- a/apps/web/sidecar/server.ts
+++ b/apps/web/sidecar/server.ts
@@ -58,7 +58,7 @@ function resolveWebRoot(): string {
 function parsePort(value: string | undefined): number {
   if (value == null || value.trim().length === 0) return 0;
   const port = Number(value);
-  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
     throw new Error(`${WEB_PORT_ENV} must be an integer between 1 and 65535`);
   }
   return port;


### PR DESCRIPTION
## Summary

- `pnpm tools-dev run web` fails on a fresh clone with `daemon did not expose status in time`.
- Root cause: `tools/dev/src/index.ts` passes `OD_PORT=String(daemonPort ?? 0)` (and the same for `OD_WEB_PORT`) to signal "let the OS pick a free port". The sidecars' `parsePort` then rejects `"0"` because of `port <= 0`, throwing `OD_PORT must be an integer between 1 and 65535` before the daemon can listen.
- Loosen the guard in both `apps/daemon/sidecar/server.ts` and `apps/web/sidecar/server.ts` from `port <= 0` to `port < 0`. `port = 0` is a valid argument to `app.listen()` / `httpServer.listen()` and is exactly the contract tools-dev already uses.

User-supplied ports remain validated: `tools/dev/src/config.ts#parsePortOption` still rejects `--daemon-port 0` / `--web-port 0` (`parsed <= 0`), so this only opens the internal auto-pick path.

Reproduced before fix in `.tmp/tools-dev/default/logs/daemon/latest.log`:

```
[tools-dev] launching daemon at 2026-04-30T06:38:23.034Z
Error: OD_PORT must be an integer between 1 and 65535
    at parsePort (apps/daemon/sidecar/server.ts:31:11)
    at startDaemonSidecar (apps/daemon/sidecar/server.ts:65:45)
```

After the fix, the same command brings up daemon and web on auto-picked ports:

```
"daemon": { "state": "running", "url": "http://127.0.0.1:53300" }
"web":    { "state": "running", "url": "http://127.0.0.1:53304" }
```

## Test plan

- [x] `pnpm tools-dev stop && pnpm tools-dev run web` — daemon + web come up cleanly, web responds with HTTP 200
- [x] Forced port still works: `pnpm tools-dev run web --daemon-port 7456 --web-port 3000`
- [x] Invalid forced port still rejected: `pnpm tools-dev run web --daemon-port 0` → upstream error from `parsePortOption`

🤖 Generated with [Claude Code](https://claude.com/claude-code)