### PR TITLE
fix(daemon): add CORS header to raw project file endpoint

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -865,6 +865,12 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
     try {
       const relPath = req.params[0];
       const file = await readProjectFile(PROJECTS_DIR, req.params.id, relPath);
+      // srcdoc iframes are the only legitimate senders of Origin: "null".
+      // Respond with the CORS header only for them; real cross-origin sites
+      // (including a potentially malicious page on a remote server) remain blocked.
+      if (req.headers.origin === 'null') {
+        res.header('Access-Control-Allow-Origin', '*');
+      }
       res.type(file.mime).send(file.buffer);
     } catch (err) {
       const status = err && err.code === 'ENOENT' ? 404 : 400;

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -861,13 +861,26 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
     }
   });
 
+  // Preflight for the raw file route. Current artifact fetches are simple GETs
+  // (no preflight needed), but an explicit handler future-proofs the route if
+  // artifacts ever add custom request headers.
+  app.options('/api/projects/:id/raw/*', (req, res) => {
+    if (req.headers.origin === 'null') {
+      res.header('Access-Control-Allow-Origin', '*');
+      res.header('Access-Control-Allow-Methods', 'GET');
+      res.header('Access-Control-Allow-Headers', 'Content-Type');
+    }
+    res.sendStatus(204);
+  });
+
   app.get('/api/projects/:id/raw/*', async (req, res) => {
     try {
       const relPath = req.params[0];
       const file = await readProjectFile(PROJECTS_DIR, req.params.id, relPath);
-      // srcdoc iframes are the only legitimate senders of Origin: "null".
-      // Respond with the CORS header only for them; real cross-origin sites
-      // (including a potentially malicious page on a remote server) remain blocked.
+      // PreviewModal loads artifact HTML via srcdoc, giving the iframe Origin: "null".
+      // data: URIs, file://, and some sandboxed iframes also send null — all are
+      // local-only callers, so this is safe. Real cross-origin sites send a real
+      // origin and remain blocked by the browser's same-origin policy.
       if (req.headers.origin === 'null') {
         res.header('Access-Control-Allow-Origin', '*');
       }

--- a/apps/daemon/tests/server-cors.test.ts
+++ b/apps/daemon/tests/server-cors.test.ts
@@ -1,0 +1,84 @@
+// @ts-nocheck
+import http from 'node:http';
+import express from 'express';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+// Replicate only the CORS middleware pattern from the raw file route so we can
+// test the header logic without spinning up the full daemon (database, fs, etc.).
+function makeTestApp() {
+  const app = express();
+
+  app.options('/api/projects/:id/raw/*', (req, res) => {
+    if (req.headers.origin === 'null') {
+      res.header('Access-Control-Allow-Origin', '*');
+      res.header('Access-Control-Allow-Methods', 'GET');
+      res.header('Access-Control-Allow-Headers', 'Content-Type');
+    }
+    res.sendStatus(204);
+  });
+
+  app.get('/api/projects/:id/raw/*', (req, res) => {
+    if (req.headers.origin === 'null') {
+      res.header('Access-Control-Allow-Origin', '*');
+    }
+    res.sendStatus(200);
+  });
+
+  return app;
+}
+
+describe('raw file endpoint CORS', () => {
+  let server: http.Server;
+  let baseUrl: string;
+
+  beforeAll(
+    () =>
+      new Promise<void>((resolve) => {
+        server = makeTestApp().listen(0, '127.0.0.1', () => {
+          const addr = server.address() as { port: number };
+          baseUrl = `http://127.0.0.1:${addr.port}`;
+          resolve();
+        });
+      }),
+  );
+
+  afterAll(() => new Promise<void>((resolve) => server.close(() => resolve())));
+
+  it('sets Access-Control-Allow-Origin: * for null origin (srcdoc iframe)', async () => {
+    const res = await fetch(`${baseUrl}/api/projects/test-id/raw/components/login.jsx`, {
+      headers: { Origin: 'null' },
+    });
+    expect(res.headers.get('access-control-allow-origin')).toBe('*');
+  });
+
+  it('does not set Access-Control-Allow-Origin for a real cross-origin site', async () => {
+    const res = await fetch(`${baseUrl}/api/projects/test-id/raw/components/login.jsx`, {
+      headers: { Origin: 'https://evil.com' },
+    });
+    expect(res.headers.get('access-control-allow-origin')).toBeNull();
+  });
+
+  it('does not set Access-Control-Allow-Origin for same-origin requests (no Origin header)', async () => {
+    const res = await fetch(`${baseUrl}/api/projects/test-id/raw/components/login.jsx`);
+    expect(res.headers.get('access-control-allow-origin')).toBeNull();
+  });
+
+  it('handles OPTIONS preflight for null origin', async () => {
+    const res = await fetch(`${baseUrl}/api/projects/test-id/raw/components/login.jsx`, {
+      method: 'OPTIONS',
+      headers: { Origin: 'null' },
+    });
+    expect(res.status).toBe(204);
+    expect(res.headers.get('access-control-allow-origin')).toBe('*');
+    expect(res.headers.get('access-control-allow-methods')).toBe('GET');
+  });
+
+  it('rejects OPTIONS preflight from a real cross-origin site', async () => {
+    const res = await fetch(`${baseUrl}/api/projects/test-id/raw/components/login.jsx`, {
+      method: 'OPTIONS',
+      headers: { Origin: 'https://evil.com' },
+    });
+    expect(res.status).toBe(204);
+    expect(res.headers.get('access-control-allow-origin')).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #134

## Why

`PreviewModal` injects HTML into an iframe via `srcdoc`, which gives the
iframe a `null` origin. When the preview HTML fetches component files
(e.g. `components/login.jsx`) from `/api/projects/:id/raw/*`, the browser
blocks the response because the route returned no
`Access-Control-Allow-Origin` header — causing components to be undefined
and the preview to fail rendering.

The header is only sent when the request `Origin` is the string `"null"` —
the signature of a `srcdoc` iframe. Real cross-origin requests from other
websites are already blocked by the browser's same-origin policy without
any CORS header; an unconditional `*` would remove that protection if the
daemon is ever deployed on a remote server.

## What changed

**`apps/daemon/src/server.ts`**
- Add `Access-Control-Allow-Origin: *` to the `/api/projects/:id/raw/*`
  GET handler, conditioned on `req.headers.origin === 'null'`
- Add an OPTIONS preflight handler for the same route to future-proof
  against artifacts that may send custom request headers

**`apps/daemon/tests/server-cors.test.ts`** (new)
- 5 tests covering: null origin allowed, real origin blocked,
  no-origin (same-origin) request unaffected, OPTIONS preflight for
  null origin, OPTIONS preflight for real origin

## Security

| Request source | Without CORS header | With `origin === 'null'` check |
|---|---|---|
| `srcdoc` iframe (`Origin: null`) | ❌ blocked | ✅ allowed |
| Same-origin request (no `Origin` header) | ✅ allowed | ✅ allowed |
| Remote website (`Origin: https://evil.com`) | ✅ blocked by SOP | ✅ blocked by SOP |
| Remote daemon + any website (`Origin: https://evil.com`) | ✅ blocked by SOP | ✅ still blocked |

> Note: without any CORS header, the browser's same-origin policy already
> blocks remote websites from reading responses. The risk of an unconditional
> `*` is specifically in a remote-server deployment scenario where SOP no
> longer applies.

## Test

1. Start daemon and web dev server
2. Open a prototype whose preview HTML references external JSX component files
3. Confirm components render correctly and no CORS errors appear in the console
4. Network panel: `/api/projects/.../raw/*` returns 200 with `Access-Control-Allow-Origin: *`
5. `pnpm --filter @open-design/daemon test` — 5 new CORS tests pass