### PR TITLE
fix(daemon): deliver Claude Code prompt via stdin to avoid spawn E2BIG/ENAMETOOLONG

### DIFF
--- a/apps/daemon/src/agents.ts
+++ b/apps/daemon/src/agents.ts
@@ -110,11 +110,17 @@ export const AGENT_DEFS = [
       { id: 'claude-sonnet-4-5', label: 'claude-sonnet-4-5' },
       { id: 'claude-haiku-4-5', label: 'claude-haiku-4-5' },
     ],
-    buildArgs: (prompt, _imagePaths, extraAllowedDirs = [], options = {}) => {
+    // Prompt delivered via stdin to avoid both Linux `spawn E2BIG`
+    // (MAX_ARG_STRLEN caps a single argv entry at ~128 KB) and Windows
+    // `spawn ENAMETOOLONG` (CreateProcess caps the full command line at
+    // ~32 KB direct, ~8 KB via .cmd shim). `claude -p` with no positional
+    // prompt reads the prompt from stdin under `--input-format text` (the
+    // default), which has no length cap. Mirrors the codex/gemini/opencode/
+    // cursor/qwen entries below.
+    buildArgs: (_prompt, _imagePaths, extraAllowedDirs = [], options = {}) => {
       const caps = agentCapabilities.get('claude') || {};
       const args = [
         '-p',
-        prompt,
         '--output-format',
         'stream-json',
         '--verbose',
@@ -139,6 +145,7 @@ export const AGENT_DEFS = [
       args.push('--permission-mode', 'bypassPermissions');
       return args;
     },
+    promptViaStdin: true,
     streamFormat: 'claude-stream-json',
   },
   {

--- a/apps/daemon/tests/agents.test.ts
+++ b/apps/daemon/tests/agents.test.ts
@@ -6,6 +6,7 @@ import { AGENT_DEFS } from '../src/agents.js';
 const codex = AGENT_DEFS.find((agent) => agent.id === 'codex');
 const cursorAgent = AGENT_DEFS.find((agent) => agent.id === 'cursor-agent');
 const kiro = AGENT_DEFS.find((agent) => agent.id === 'kiro');
+const claude = AGENT_DEFS.find((agent) => agent.id === 'claude');
 const originalDisablePlugins = process.env.OD_CODEX_DISABLE_PLUGINS;
 
 afterEach(() => {
@@ -84,4 +85,28 @@ test('kiro fetchModels falls back to fallbackModels when detection fails', async
   assert.equal(result, null);
   assert.ok(Array.isArray(kiro.fallbackModels));
   assert.equal(kiro.fallbackModels[0].id, 'default');
+});
+
+test('claude flags promptViaStdin and never embeds the prompt in argv', () => {
+  // Long composed prompts (system prompt + design system + skill body +
+  // user message) routinely exceed Linux MAX_ARG_STRLEN (~128 KB) and the
+  // Windows CreateProcess command-line cap (~32 KB direct, ~8 KB via .cmd
+  // shim). The fix is to deliver the prompt on stdin instead of argv —
+  // these assertions guard that contract.
+  assert.equal(claude.promptViaStdin, true);
+
+  const longPrompt = 'x'.repeat(200_000);
+  const args = claude.buildArgs(longPrompt, [], [], {}, { cwd: '/tmp/od-project' });
+
+  assert.ok(Array.isArray(args), 'claude.buildArgs must return argv');
+  assert.equal(args.includes(longPrompt), false, 'prompt must not appear in argv');
+  for (const arg of args) {
+    assert.ok(
+      typeof arg === 'string' && arg.length < 1000,
+      `no argv entry should carry the prompt body (saw length ${arg.length})`,
+    );
+  }
+  // `-p` (print mode) must still be present; without it claude drops into
+  // an interactive REPL that the daemon has no TTY for.
+  assert.ok(args.includes('-p'), 'claude argv must include -p');
 });


### PR DESCRIPTION
## Summary

Brings the **Claude Code** agent in line with the `promptViaStdin` pattern that #15 introduced for codex / gemini / opencode / cursor / qwen.

Claude Code was the last agent still embedding the full composed prompt in argv (`-p <prompt>`), which hits two OS limits on long prompts:

| Platform | Limit | Symptom |
|---|---|---|
| Linux / WSL | `MAX_ARG_STRLEN` ≈ 128 KB per argv entry | `spawn E2BIG` (#82) |
| Windows direct `.exe` | `CreateProcess` ≈ 32 KB total command line | `spawn ENAMETOOLONG` (#100) |
| Windows via `.cmd` shim | cmd.exe ≈ 8 KB after escaping | `spawn ENAMETOOLONG` |

#97 added a Windows-only `.od-prompt.md` temp-file fallback for Claude, which works but leaves a file in the project and doesn't trigger on Linux/WSL — so #82 stays open. This PR replaces both the argv path and the temp-file workaround for Claude with the same stdin pipe everyone else already uses.

## What changed

`apps/daemon/src/agents.ts`:
- Drop `prompt` from Claude's argv; keep the bare `-p` flag (print mode)
- Set `promptViaStdin: true` so `server.ts` pipes `composed` on stdin

`apps/daemon/tests/agents.test.ts`:
- New regression test: asserts `claude.promptViaStdin === true`, that a 200 KB prompt body never appears in argv, and that `-p` is still emitted

No new dependencies. No changes to `server.ts` — its existing `def.promptViaStdin` branch already does the right thing.

## Why this works

`claude --help` documents `-p, --print` as a flag (no value), and `--input-format` defaults to `text`, which reads from stdin. Verified locally:

```bash
$ echo "Hello, are you there? Just say hi back." \
    | claude -p --output-format stream-json --verbose
{"type":"system","subtype":"init",...}
{"type":"assistant",...,"content":[{"type":"text","text":"Hi!"}],...}
{"type":"result","subtype":"success",...,"result":"Hi!",...}
```

(Claude Code `2.1.123` on Linux.)

## Verification

- `pnpm --filter @open-design/daemon run test` → 24 passed (5 files), incl. the new `claude flags promptViaStdin and never embeds the prompt in argv` case
- `pnpm test` → 24 daemon + 15 web = 39 passed
- `pnpm typecheck` → green (`Residual JavaScript check passed`)

## Test plan

- [x] `pnpm test` passes
- [x] `pnpm typecheck` passes
- [x] Manual: `echo … | claude -p --output-format stream-json --verbose` returns a streamed result
- [ ] Reviewer: pick a heavy skill (e.g. `magazine-web-ppt`) on Linux/WSL with Claude Code selected, send a prompt large enough to have hit `spawn E2BIG` previously, confirm it now streams normally and no `.od-prompt.md` file appears in `.od/projects/<id>/`

Fixes #82
Refs #100, #52