### PR TITLE
fix(daemon): SSE keep-alive so Next dev rewrite doesn't kill long agent runs

### DIFF
--- a/daemon/server.js
+++ b/daemon/server.js
@@ -1160,18 +1160,39 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
     }
     child.stderr.on('data', (chunk) => send('stderr', { chunk }));
 
+    // SSE keep-alive. The dev-mode `next.config.ts` rewrites `/api/:path*` to
+    // this daemon, and Next.js's dev rewrite proxy abandons an upstream
+    // connection that goes idle for ~30 s — long thinking turns and large
+    // tool-input serializations regularly cross that threshold. When the
+    // proxy abandons the request the browser's EventSource closes, which
+    // cascades into `res.on('close')` below and SIGTERMs the agent
+    // mid-generation (observed: `code=143` exits at exactly Δ30 s). A
+    // standard SSE comment frame on a 20 s cadence keeps the byte stream
+    // active so the proxy never sees an idle window. The frame is invisible
+    // to clients (per the EventSource spec, lines starting with `:` are
+    // ignored) and harmless under the production daemon path.
+    const keepAlive = setInterval(() => {
+      if (!res.writableEnded) {
+        try { res.write(': keep-alive\n\n'); } catch { /* socket already gone */ }
+      }
+    }, 20000);
+    keepAlive.unref?.();
+
     const kill = () => {
       if (child && !child.killed) child.kill('SIGTERM');
     };
     res.on('close', () => {
+      clearInterval(keepAlive);
       if (!res.writableEnded) kill();
     });
 
     child.on('error', (err) => {
+      clearInterval(keepAlive);
       send('error', { message: err.message });
       res.end();
     });
     child.on('close', (code, signal) => {
+      clearInterval(keepAlive);
       if (acpSession?.hasFatalError()) {
         return res.end();
       }


### PR DESCRIPTION
## Summary

Long agent turns die with exit code 143 in dev mode because Next.js's dev rewrite proxy abandons SSE connections that go idle for ~30 s. This patch sends a standard SSE comment frame (`: keep-alive\n\n`) every 20 s so the byte stream is never idle.

## Root cause

`next.config.ts` rewrites `/api/:path*` to the daemon at `127.0.0.1:7456` in dev mode. The comment there optimistically claims "SSE on /api/chat works through this rewrite because Next.js's dev server streams responses unbuffered" — and it does, *until* the upstream goes silent for 30 seconds. At that point Next.js's dev rewrite proxy aborts the upstream request, which closes the browser's EventSource, which fires `res.on('close')` in the daemon, which SIGTERMs the agent mid-generation.

The symptom is the assistant "stopping near the end" of bigger artifact runs (long thinking turns and large tool-input serializations both regularly cross the 30 s threshold). The exit code is always `143` (= 128 + 15 = SIGTERM), and the death always lands at exactly Δ30 s of stdout silence.

This only affects dev mode. The production path (`pnpm build && node daemon/cli.js`) serves `out/` directly from the daemon — no Next.js rewrite, no idle proxy timeout, no death.

## Fix

20 s `setInterval` that writes `: keep-alive\n\n` to the SSE response while it's open. Per the EventSource spec, lines starting with `:` are comments and are ignored by clients, so it's invisible to the UI. The interval is `unref`'d so it never holds the daemon open, and it's cleared on `res.on('close')`, `child.on('error')`, and `child.on('close')`.

## Verification

Reproduced and fixed against a 16-minute, 17-slide deck generation run that previously failed at the artifact-emit step:

| | Before patch | After patch |
|---|---|---|
| longest gap survived | 30.00 s (the kill) | 269.64 s + 265.47 s |
| child exit | `code=143` (SIGTERM) | `code=0` (normal) |
| SSE end | `ok=false` (already closed) | `ok=true` (clean) |
| outcome | "Stopped with unfinished work" near end | 17 slides, all critique gates passed |

`npm test` passes (29/29). `tsc -b --noEmit` clean.

## Test plan

- [ ] `npm run dev:all`, generate a multi-slide deck or a long prototype, observe survival across long thinking phases
- [ ] `pnpm build && node daemon/cli.js`, verify the production path still works (keep-alive is harmless there)