### PR TITLE
fix: support standalone pnpm binary in postinstall

### DIFF
--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { dirname, resolve } from "node:path";
+import { dirname, extname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
@@ -12,10 +12,15 @@ const buildTargets = [
   "tools/dev",
 ];
 
+const jsExtensions = new Set([".js", ".cjs", ".mjs"]);
+
 function resolvePackageManagerInvocation() {
   const pnpmExecPath = process.env.npm_execpath;
   if (pnpmExecPath != null && pnpmExecPath.length > 0) {
-    return { argsPrefix: [pnpmExecPath], command: process.execPath };
+    if (jsExtensions.has(extname(pnpmExecPath).toLowerCase())) {
+      return { argsPrefix: [pnpmExecPath], command: process.execPath };
+    }
+    return { argsPrefix: [], command: pnpmExecPath };
   }
 
   return { argsPrefix: [], command: process.platform === "win32" ? "pnpm.cmd" : "pnpm" };


### PR DESCRIPTION
## Summary

- `pnpm install` fails on machines where pnpm is installed as a standalone binary (e.g. via [`mise`](https://mise.jdx.dev/) using `@pnpm/exe`, or via `volta`). The `node ./scripts/postinstall.mjs` step crashes with `SyntaxError: Invalid or unexpected token` because the script feeds the pnpm ELF/Mach-O/PE executable to `node` as if it were a JS file.
- Root cause: `resolvePackageManagerInvocation` in `scripts/postinstall.mjs` always wraps `npm_execpath` with `process.execPath` (i.e. `node $npm_execpath`). That assumption only holds for JS entries (corepack, `npm install -g pnpm`); it breaks for the standalone binary distribution.
- Fix: branch on the executable's extension. Keep wrapping `.js` / `.cjs` / `.mjs` entries with `node`, but spawn other paths (ELF, Mach-O, `.exe`) directly.

## Repro

```
$ pnpm i
. postinstall$ node ./scripts/postinstall.mjs
│ /home/<user>/.local/share/mise/installs/pnpm/10.33.2/pnpm:1
│ ELF
│ ^
│ SyntaxError: Invalid or unexpected token
```
The first byte `\x7f` plus the literal `ELF` at offset 1 confirms Node is parsing the binary as JS source.

## Test plan

- [x] `pnpm i` (with `mise`-installed standalone pnpm) — postinstall now builds `packages/sidecar-proto`, `packages/sidecar`, `packages/platform`, and `tools/dev` cleanly.
- [ ] Reviewer: verify still works on corepack / `npm i -g pnpm` setups (where `npm_execpath` ends in `.cjs`).