### PR TITLE
Improve tools-dev native addon diagnostics

### DIFF
--- a/tools/dev/package.json
+++ b/tools/dev/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build": "node ./esbuild.config.mjs",
     "dev": "tsx ./src/index.ts",
+    "test": "node --import tsx --test src/*.test.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/tools/dev/src/diagnostics.test.ts
+++ b/tools/dev/src/diagnostics.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  appendStartupLogDiagnostics,
+  createStartupLogDiagnostics,
+  detectLogDiagnostics,
+} from "./diagnostics.js";
+
+describe("tools-dev diagnostics", () => {
+  it("detects native addon ABI mismatches", () => {
+    const diagnostics = detectLogDiagnostics([
+      "Error: The module '/repo/node_modules/better-sqlite3/build/Release/better_sqlite3.node'",
+      "was compiled against a different Node.js version using",
+      "NODE_MODULE_VERSION 127. This version of Node.js requires",
+      "NODE_MODULE_VERSION 137. Please try re-compiling or re-installing",
+    ]);
+
+    assert.equal(diagnostics.length, 1);
+    assert.match(diagnostics[0].message, /native Node addon ABI mismatch/);
+    assert.match(diagnostics[0].recommendation, /rebuild better-sqlite3 --pending/);
+    assert.match(diagnostics[0].recommendation, /pnpm install/);
+  });
+
+  it("does not report diagnostics for unrelated logs", () => {
+    assert.deepEqual(detectLogDiagnostics(["daemon booting", "ready"]), []);
+  });
+
+  it("appends log tails and recommendations to startup timeout errors", () => {
+    const error = appendStartupLogDiagnostics(
+      new Error("daemon did not expose status in time"),
+      "daemon",
+      createStartupLogDiagnostics("/tmp/daemon.log", [
+        "better_sqlite3.node was compiled against a different Node.js version using",
+        "NODE_MODULE_VERSION 127. This version of Node.js requires NODE_MODULE_VERSION 137.",
+      ]),
+    );
+
+    assert.match(error.message, /daemon did not expose status in time/);
+    assert.match(error.message, /daemon log tail \(\/tmp\/daemon\.log\)/);
+    assert.match(error.message, /better_sqlite3\.node/);
+    assert.match(error.message, /pnpm --filter @open-design\/daemon rebuild better-sqlite3 --pending/);
+  });
+});

--- a/tools/dev/src/diagnostics.ts
+++ b/tools/dev/src/diagnostics.ts
@@ -1,0 +1,56 @@
+export type LogDiagnostic = {
+  message: string;
+  recommendation: string;
+};
+
+export type StartupLogDiagnostics = {
+  diagnostics: LogDiagnostic[];
+  logPath: string;
+  lines: string[];
+};
+
+const NATIVE_ADDON_ABI_MISMATCH_PATTERN = /was compiled against a different Node\.js version[\s\S]*?NODE_MODULE_VERSION\s+\d+[\s\S]*?requires\s+NODE_MODULE_VERSION\s+\d+/i;
+const NODE_MODULE_VERSION_PATTERN = /NODE_MODULE_VERSION\s+\d+[\s\S]*?NODE_MODULE_VERSION\s+\d+/i;
+
+export function detectLogDiagnostics(lines: readonly string[]): LogDiagnostic[] {
+  const logText = lines.join("\n");
+  if (!NATIVE_ADDON_ABI_MISMATCH_PATTERN.test(logText) && !NODE_MODULE_VERSION_PATTERN.test(logText)) return [];
+
+  return [
+    {
+      message: "Detected a native Node addon ABI mismatch in the daemon log.",
+      recommendation: [
+        "Rebuild native daemon dependencies for the active Node version:",
+        "  pnpm --filter @open-design/daemon rebuild better-sqlite3 --pending",
+        "or refresh the workspace install:",
+        "  pnpm install",
+      ].join("\n"),
+    },
+  ];
+}
+
+export function formatLogDiagnostics(diagnostics: readonly LogDiagnostic[]): string | null {
+  if (diagnostics.length === 0) return null;
+  return diagnostics
+    .map((diagnostic) => `${diagnostic.message}\n${diagnostic.recommendation}`)
+    .join("\n\n");
+}
+
+export function createStartupLogDiagnostics(logPath: string, lines: readonly string[]): StartupLogDiagnostics {
+  return {
+    diagnostics: detectLogDiagnostics(lines),
+    lines: [...lines],
+    logPath,
+  };
+}
+
+export function appendStartupLogDiagnostics(error: unknown, appName: string, details: StartupLogDiagnostics): Error {
+  const baseMessage = error instanceof Error ? error.message : String(error);
+  const sections = [baseMessage, `${appName} log tail (${details.logPath}):`];
+  sections.push(details.lines.length > 0 ? details.lines.join("\n") : "(no log lines)");
+
+  const formattedDiagnostics = formatLogDiagnostics(details.diagnostics);
+  if (formattedDiagnostics != null) sections.push(formattedDiagnostics);
+
+  return new Error(sections.join("\n\n"), error instanceof Error ? { cause: error } : undefined);
+}

--- a/tools/dev/src/index.ts
+++ b/tools/dev/src/index.ts
@@ -46,6 +46,13 @@ import {
   type ToolDevOptions,
 } from "./config.js";
 import {
+  appendStartupLogDiagnostics,
+  createStartupLogDiagnostics,
+  detectLogDiagnostics,
+  formatLogDiagnostics,
+  type LogDiagnostic,
+} from "./diagnostics.js";
+import {
   inspectDaemonRuntime,
   inspectDesktopRuntime,
   inspectWebRuntime,
@@ -539,8 +546,10 @@ async function startDaemon(config: ToolDevConfig, options: CliOptions) {
       status,
     };
   } catch (error) {
+    const logPath = config.apps.daemon.latestLogPath;
+    const lines = await readLogTail(logPath, 80).catch(() => []);
     await stopApp(config, APP_KEYS.DAEMON).catch(() => undefined);
-    throw error;
+    throw appendStartupLogDiagnostics(error, APP_KEYS.DAEMON, createStartupLogDiagnostics(logPath, lines));
   }
 }
 
@@ -700,6 +709,12 @@ async function readLogs(config: ToolDevConfig, appName: ToolDevAppName) {
   return { app: appName, lines: await readLogTail(logPath, 200), logPath };
 }
 
+function createLogDiagnostics(logs: Record<string, LogResult>): Record<string, LogDiagnostic[]> {
+  return Object.fromEntries(
+    Object.entries(logs).map(([appName, log]) => [appName, detectLogDiagnostics(log.lines)] as const),
+  );
+}
+
 type LogResult = Awaited<ReturnType<typeof readLogs>>;
 
 function isLogResult(value: LogResult | Record<string, LogResult>): value is LogResult {
@@ -739,6 +754,19 @@ function printCheckResult(result: unknown, options: CliOptions): void {
   if (logs != null) {
     process.stdout.write("\nLogs\n");
     printLogs(logs as Record<string, LogResult>, options);
+  }
+
+  const diagnostics = asRecord(record?.diagnostics);
+  if (diagnostics != null) {
+    const entries = Object.entries(diagnostics)
+      .map(([appName, value]) => [appName, Array.isArray(value) ? formatLogDiagnostics(value as LogDiagnostic[]) : null] as const)
+      .filter((entry): entry is readonly [string, string] => entry[1] != null);
+    if (entries.length > 0) {
+      process.stdout.write("\nDiagnostics\n");
+      for (const [appName, message] of entries) {
+        process.stdout.write(`[${appName}] ${message}\n`);
+      }
+    }
   }
 }
 
@@ -912,7 +940,7 @@ addSharedOptions(cli.command("check [app]", "Print status and recent logs for qu
     const logs = Object.fromEntries(
       await Promise.all(targets.map(async (target) => [target, await readLogs(config, target)] as const)),
     );
-    printCheckResult({ apps, logs, namespace: config.namespace }, options);
+    printCheckResult({ apps, diagnostics: createLogDiagnostics(logs), logs, namespace: config.namespace }, options);
   },
 );
 


### PR DESCRIPTION
## Summary
- Surface the daemon log tail when `tools-dev` times out waiting for daemon sidecar status.
- Detect native Node addon ABI mismatch messages in daemon logs and suggest rebuilding `better-sqlite3` or refreshing the workspace install.
- Add `tools-dev check` diagnostics output and focused unit coverage for ABI mismatch detection.

## Validation
- `pnpm --filter @open-design/tools-dev test`
- `pnpm --filter @open-design/tools-dev typecheck`
- `pnpm test`
- `pnpm --filter @open-design/daemon build && pnpm typecheck`
- `pnpm build`
- `pnpm tools-dev check --json`

Closes #149

<!-- looper:stamp v=1 -->
<sub>Generated by looper 0.0.0-dev · runner=worker · agent=gpt-5.5</sub>