### PR TITLE
fix(daemon): stop passing literal dash to cursor-agent

### DIFF
--- a/apps/daemon/src/agents.ts
+++ b/apps/daemon/src/agents.ts
@@ -311,8 +311,10 @@ export const AGENT_DEFS = [
       { id: 'sonnet-4-thinking', label: 'sonnet-4-thinking' },
       { id: 'gpt-5', label: 'gpt-5' },
     ],
-    // Prompt delivered via stdin (`cursor-agent -`) to avoid Windows
-    // `spawn ENAMETOOLONG` while preserving Cursor Agent's structured stream.
+    // Cursor Agent does not use `-` as a "read prompt from stdin" sentinel.
+    // Passing it makes the CLI treat the dash as the literal user prompt,
+    // which then surfaces as "your message only contains '-'". Keep stdin
+    // piped for prompt delivery, but do not append a fake prompt arg.
     buildArgs: (_prompt, _imagePaths, _extra, options = {}, runtimeContext = {}) => {
       const args = [];
       args.push('--print', '--output-format', 'stream-json', '--stream-partial-output', '--force', '--trust');
@@ -322,7 +324,6 @@ export const AGENT_DEFS = [
       if (options.model && options.model !== 'default') {
         args.push('--model', options.model);
       }
-      args.push('-');
       return args;
     },
     promptViaStdin: true,

--- a/apps/daemon/tests/agents.test.ts
+++ b/apps/daemon/tests/agents.test.ts
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict';
 import { AGENT_DEFS } from '../src/agents.js';
 
 const codex = AGENT_DEFS.find((agent) => agent.id === 'codex');
+const cursorAgent = AGENT_DEFS.find((agent) => agent.id === 'cursor-agent');
 const originalDisablePlugins = process.env.OD_CODEX_DISABLE_PLUGINS;
 
 afterEach(() => {
@@ -48,4 +49,19 @@ test('codex args keep plugins enabled when OD_CODEX_DISABLE_PLUGINS is not 1', (
   assert.equal(args.includes('--disable'), false);
   assert.equal(args.includes('plugins'), false);
   assert.equal(args.at(-1), '-');
+});
+
+test('cursor-agent args deliver prompts via stdin without passing a literal dash prompt', () => {
+  const args = cursorAgent.buildArgs('', [], [], {}, { cwd: '/tmp/od-project' });
+
+  assert.deepEqual(args, [
+    '--print',
+    '--output-format',
+    'stream-json',
+    '--stream-partial-output',
+    '--force',
+    '--trust',
+    '--workspace',
+    '/tmp/od-project',
+  ]);
 });


### PR DESCRIPTION
## Summary

Fix Cursor Agent prompt delivery in the daemon adapter.

`cursor-agent` does not treat `-` as a stdin prompt sentinel. Passing it causes the CLI to interpret `-` as the literal user prompt, which then surfaces responses like “your message only contains '-'”.

This change:
- removes the literal `-` argument from the `cursor-agent` adapter
- keeps stdin-based prompt delivery unchanged
- adds a regression test covering the expected argv shape

## Scope

This addresses the Cursor-specific sub-problem described in issue #113.
It does not attempt to resolve the other behaviors discussed there.

## Test Plan

- [x] `pnpm --filter @open-design/daemon test`
