### PR TITLE
Fix daemon project-root resolution when launched from src via tsx

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -69,7 +69,8 @@ import {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 export function resolveProjectRoot(moduleDir: string): string {
-  const daemonDir = path.basename(moduleDir) === 'dist'
+  const base = path.basename(moduleDir);
+  const daemonDir = base === 'dist' || base === 'src'
     ? path.dirname(moduleDir)
     : moduleDir;
   return path.resolve(daemonDir, '../..');

--- a/apps/daemon/tests/server-paths.test.ts
+++ b/apps/daemon/tests/server-paths.test.ts
@@ -14,4 +14,10 @@ describe('resolveProjectRoot', () => {
 
     expect(resolveProjectRoot(path.join(root, 'apps', 'daemon', 'dist'))).toBe(root);
   });
+
+  it('resolves the repository root from the daemon src directory (tsx entry)', () => {
+    const root = path.resolve(import.meta.dirname, '../../..');
+
+    expect(resolveProjectRoot(path.join(root, 'apps', 'daemon', 'src'))).toBe(root);
+  });
 });


### PR DESCRIPTION
## Summary

- `resolveProjectRoot` only stripped a `dist` suffix from the caller's module directory. When the daemon sidecar is started by `tools-dev` it runs `apps/daemon/src/server.ts` directly through tsx, so `__dirname` is `apps/daemon/src` and the computed `PROJECT_ROOT` resolved to `apps/` instead of the repo root.
- That made `SKILLS_DIR`, `DESIGN_SYSTEMS_DIR`, `STATIC_DIR`, and the default `RUNTIME_DATA_DIR` all point at non-existent paths. `GET /api/skills` returned `{"skills":[]}` and the web *examples* page reported "No skills available. Is the daemon running?".
- Fix: treat `src` the same as `dist` in `resolveProjectRoot` so resolution works for both the tsx source entry and the compiled build.
- Added a regression test for the `src` case alongside the existing `dist` and `apps/daemon` cases (`apps/daemon/tests/server-paths.test.ts`).

## Repro before the fix

```
pnpm tools-dev start web
curl http://127.0.0.1:<web-port>/api/skills   # -> {"skills":[]}
# web "examples" page: "No skills available. Is the daemon running?"
```

## Verification after the fix

- `pnpm --filter @open-design/daemon test` → 24 passed (5 files), incl. the new `src` regression test.
- Restarted via `pnpm tools-dev restart daemon && pnpm tools-dev restart web`.
- `curl http://127.0.0.1:<daemon-port>/api/skills` → 31 skills (`blog-post`, `critique`, `dashboard`, ...).
- Same response via the web proxy on the web port.

## Test plan

- [x] `pnpm --filter @open-design/daemon test`
- [x] Manual: `pnpm tools-dev start web` → `curl /api/skills` returns the populated list both directly on the daemon and through the web proxy.
- [ ] Reviewer: run `pnpm typecheck` and `pnpm test` (full workspace) if desired — only the daemon package was touched.