### PR TITLE
fix(daemon): preserve non-ASCII filenames on multipart upload

### DIFF
--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -217,7 +217,14 @@ export function sanitizeName(raw) {
 // decode as UTF-8 when the result round-trips back to the original
 // bytes; otherwise the source was genuine latin1 and we leave it alone.
 export function decodeMultipartFilename(name) {
-  if (typeof name !== 'string' || name.length === 0) return name;
+  if (!name || typeof name !== 'string') return name ?? '';
+  // If any code point exceeds 0xFF the source is already a properly
+  // decoded Unicode string — for example, multer received an RFC 5987
+  // `filename*` parameter and decoded it as UTF-8. Re-running latin1
+  // -> utf8 here would corrupt those names, so exit early.
+  for (let i = 0; i < name.length; i++) {
+    if (name.charCodeAt(i) > 0xff) return name;
+  }
   const buf = Buffer.from(name, 'latin1');
   const utf8 = buf.toString('utf8');
   return Buffer.from(utf8, 'utf8').equals(buf) ? utf8 : name;

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -196,16 +196,31 @@ export function validateProjectPath(raw) {
   return parts.join('/');
 }
 
-// Replace anything outside [A-Za-z0-9._-] with underscore. Spaces collapse
+// Keep Unicode letters/digits as-is; replace path separators, control
+// characters, and reserved punctuation with underscore. Spaces collapse
 // to dashes (matches the kebab-case style used by the agent's slugs).
+// The previous ASCII-only filter collapsed every non-ASCII character to
+// '_', so a Chinese filename like '测试文档.docx' became '____.docx'
+// (issue #144).
 export function sanitizeName(raw) {
   const cleaned = String(raw ?? '')
     .replace(/[\\/]/g, '_')
     .replace(/\s+/g, '-')
-    .replace(/[^A-Za-z0-9._-]/g, '_')
+    .replace(/[^\p{L}\p{N}._-]/gu, '_')
     .replace(/^\.+/, '_')
     .trim();
   return cleaned || `file-${Date.now()}`;
+}
+
+// multer@1 decodes multipart filenames as latin1, which mangles any
+// UTF-8 bytes (Chinese, Japanese, Cyrillic, ...) the user uploads. Re-
+// decode as UTF-8 when the result round-trips back to the original
+// bytes; otherwise the source was genuine latin1 and we leave it alone.
+export function decodeMultipartFilename(name) {
+  if (typeof name !== 'string' || name.length === 0) return name;
+  const buf = Buffer.from(name, 'latin1');
+  const utf8 = buf.toString('utf8');
+  return Buffer.from(utf8, 'utf8').equals(buf) ? utf8 : name;
 }
 
 function toProjectPath(raw) {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -152,7 +152,7 @@ const upload = multer({
     destination: UPLOAD_DIR,
     filename: (_req, file, cb) => {
       file.originalname = decodeMultipartFilename(file.originalname);
-      const safe = file.originalname.replace(/[^\p{L}\p{N}.\-]/gu, '_');
+      const safe = sanitizeName(file.originalname);
       cb(null, `${Date.now()}-${Math.random().toString(36).slice(2, 8)}-${safe}`);
     },
   }),
@@ -164,7 +164,7 @@ const importUpload = multer({
     destination: UPLOAD_DIR,
     filename: (_req, file, cb) => {
       file.originalname = decodeMultipartFilename(file.originalname);
-      const safe = file.originalname.replace(/[^\p{L}\p{N}.\-]/gu, '_');
+      const safe = sanitizeName(file.originalname);
       cb(null, `${Date.now()}-${Math.random().toString(36).slice(2, 8)}-${safe}`);
     },
   }),

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -27,6 +27,7 @@ import { importClaudeDesignZip } from './claude-design-import.js';
 import { buildDocumentPreview } from './document-preview.js';
 import { lintArtifact, renderFindingsForAgent } from './lint-artifact.js';
 import {
+  decodeMultipartFilename,
   deleteProjectFile,
   ensureProject,
   listFiles,
@@ -150,7 +151,8 @@ const upload = multer({
   storage: multer.diskStorage({
     destination: UPLOAD_DIR,
     filename: (_req, file, cb) => {
-      const safe = file.originalname.replace(/[^\w.\-]/g, '_');
+      file.originalname = decodeMultipartFilename(file.originalname);
+      const safe = file.originalname.replace(/[^\p{L}\p{N}.\-]/gu, '_');
       cb(null, `${Date.now()}-${Math.random().toString(36).slice(2, 8)}-${safe}`);
     },
   }),
@@ -161,7 +163,8 @@ const importUpload = multer({
   storage: multer.diskStorage({
     destination: UPLOAD_DIR,
     filename: (_req, file, cb) => {
-      const safe = file.originalname.replace(/[^\w.\-]/g, '_');
+      file.originalname = decodeMultipartFilename(file.originalname);
+      const safe = file.originalname.replace(/[^\p{L}\p{N}.\-]/gu, '_');
       cb(null, `${Date.now()}-${Math.random().toString(36).slice(2, 8)}-${safe}`);
     },
   }),
@@ -183,9 +186,12 @@ const projectUpload = multer({
       }
     },
     filename: (_req, file, cb) => {
-      // Reuse the same sanitiser used everywhere else, then prepend a
-      // base36 timestamp so multiple uploads with the same original name
-      // don't clobber each other.
+      // multer@1 hands us latin1-decoded multipart filenames; restore the
+      // original UTF-8 so the response (and the on-disk name) preserves
+      // non-ASCII characters instead of mangling them. Then run the
+      // shared sanitiser and prepend a base36 timestamp so multiple
+      // uploads with the same original name don't clobber each other.
+      file.originalname = decodeMultipartFilename(file.originalname);
       const safe = sanitizeName(file.originalname);
       cb(null, `${Date.now().toString(36)}-${safe}`);
     },

--- a/apps/daemon/tests/sanitize-name.test.ts
+++ b/apps/daemon/tests/sanitize-name.test.ts
@@ -57,4 +57,16 @@ describe('decodeMultipartFilename', () => {
   it('treats empty input as a no-op', () => {
     expect(decodeMultipartFilename('')).toBe('');
   });
+
+  it('returns input untouched when any code point exceeds 0xff', () => {
+    // Simulates multer receiving an RFC 5987 `filename*` parameter and
+    // decoding it to UTF-8 itself. Re-decoding would corrupt the name.
+    const alreadyDecoded = '测试文档.docx';
+    expect(decodeMultipartFilename(alreadyDecoded)).toBe(alreadyDecoded);
+  });
+
+  it('handles null and undefined defensively', () => {
+    expect(decodeMultipartFilename(null as unknown as string)).toBe('');
+    expect(decodeMultipartFilename(undefined as unknown as string)).toBe('');
+  });
 });

--- a/apps/daemon/tests/sanitize-name.test.ts
+++ b/apps/daemon/tests/sanitize-name.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { decodeMultipartFilename, sanitizeName } from '../src/projects.js';
+
+describe('sanitizeName', () => {
+  it('keeps ASCII letters, digits, dot, dash, underscore as-is', () => {
+    expect(sanitizeName('Report_v2.final-1.pdf')).toBe('Report_v2.final-1.pdf');
+  });
+
+  it('collapses whitespace runs to a single dash', () => {
+    expect(sanitizeName('Hello World  page.html')).toBe('Hello-World-page.html');
+  });
+
+  it('preserves Unicode letters/digits (Chinese, Japanese, Cyrillic, accented)', () => {
+    expect(sanitizeName('测试文档-中文文件名.docx')).toBe('测试文档-中文文件名.docx');
+    expect(sanitizeName('資料.pdf')).toBe('資料.pdf');
+    expect(sanitizeName('Cafe-naïveté.docx')).toBe('Cafe-naïveté.docx');
+    expect(sanitizeName('документ.txt')).toBe('документ.txt');
+  });
+
+  it('replaces path separators with underscore', () => {
+    expect(sanitizeName('a/b\\c.txt')).toBe('a_b_c.txt');
+  });
+
+  it('replaces reserved punctuation with underscore', () => {
+    expect(sanitizeName('a:b*c?d.txt')).toBe('a_b_c_d.txt');
+  });
+
+  it('rewrites leading dot runs to underscore so dotfiles cannot land on disk', () => {
+    expect(sanitizeName('..hidden.txt')).toBe('_hidden.txt');
+  });
+
+  it('falls back to a generated name when the input is empty after cleanup', () => {
+    const out = sanitizeName('');
+    expect(out).toMatch(/^file-\d+$/);
+  });
+});
+
+describe('decodeMultipartFilename', () => {
+  it('restores UTF-8 names that multer parsed as latin1', () => {
+    // multer@1 hands callers the latin1 decoding of the multipart bytes.
+    // Re-encoding 'measure' to latin1 lets us simulate that exact input.
+    const utf8 = '测试文档-中文文件名.docx';
+    const latin1 = Buffer.from(utf8, 'utf8').toString('latin1');
+    expect(decodeMultipartFilename(latin1)).toBe(utf8);
+  });
+
+  it('leaves genuine latin1 names untouched when bytes do not form valid UTF-8', () => {
+    // 0xE9 alone is not valid UTF-8 — keep the raw latin1 representation.
+    const latin1Only = Buffer.from([0x43, 0x61, 0x66, 0xe9]).toString('latin1');
+    expect(decodeMultipartFilename(latin1Only)).toBe(latin1Only);
+  });
+
+  it('round-trips ASCII names without modification', () => {
+    expect(decodeMultipartFilename('plain.txt')).toBe('plain.txt');
+  });
+
+  it('treats empty input as a no-op', () => {
+    expect(decodeMultipartFilename('')).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #144 — DOCX (and any non-ASCII-named file) upload failed with garbled UI text and a misleading "some files could not be stored" toast.

## Root cause

Three independent bugs lined up to produce the reported behavior:

1. **multer@1 hands callers latin1-decoded multipart filenames.** `测试文档.docx` arrives as the latin1 reading of its UTF-8 bytes. The response shipped that mangled string back as `originalName`, which is what the user sees in the chat composer.
2. **`sanitizeName` (`apps/daemon/src/projects.ts`) collapsed every non-ASCII character to `_`.** A 12-byte Chinese filename therefore landed on disk as `____________.docx` — the file is intact, the name isn't.
3. **The chat composer's success accounting compared `originalName` (latin1-mangled) to `File.name` (UTF-8) as Map keys** (`apps/web/src/providers/registry.ts`), so even though the file *was* on disk, the comparison missed and the UI flipped to `"some files could not be stored"`.

DOCX has no special handling here — it was never blocked by a `fileFilter`. The "upload failed" half of the report is the third bug surfacing as a UX false alarm.

## Fix

- **`projects.ts`**
  - New `decodeMultipartFilename(name)`: re-decodes latin1 → UTF-8, but only when the bytes round-trip back to the original (so genuine latin1 names like `Cafe-naïveté.docx` stay untouched).
  - `sanitizeName` now keeps `\p{L}\p{N}` (Unicode letters/digits) plus `._-`, while still stripping path separators, control characters, and Windows-reserved punctuation. Whitespace still collapses to `-`, leading dots still become `_`.
- **`server.ts`** — applies the decoder in all three multer storage `filename` callbacks (`/api/upload`, `/api/import/claude-design`, `/api/projects/:id/upload`) so `req.file(s).originalname` is UTF-8 by the time any handler reads it. The single-file `/api/projects/:id/files` route inherits the fix because it shares the `upload` instance.
- **No frontend change required** — once `originalName` matches `File.name`, the existing `uploadedNames` accounting in `registry.ts` lines up and the spurious error disappears.

## Verification

Repro before the fix:

```
$ curl -sX POST .../upload -F "files=@测试文档-中文文件名.docx"
{"files":[{"name":"molcl32p-____________-_______________.docx",
           "originalName":"æµè¯ææ¡£-ä¸­ææä»¶å.docx", ... }]}
```

After the fix:

```
$ curl -sX POST .../upload -F "files=@测试文档-中文文件名.docx"
{"files":[{"name":"molcrmpd-测试文档-中文文件名.docx",
           "originalName":"测试文档-中文文件名.docx", ... }]}
$ curl -sX POST .../upload -F "files=@Cafe-naïveté.docx"
{"files":[{"name":"molcrmpu-Cafe-naïveté.docx",
           "originalName":"Cafe-naïveté.docx", ... }]}
$ ls .od/projects/repro-144-fix/
molcrmpd-测试文档-中文文件名.docx
molcrmpu-Cafe-naïveté.docx
```

File is 928 bytes, matches the source; chat composer no longer reports `"some files could not be stored"` because `originalName === File.name`.

## Tests

- Added `apps/daemon/tests/sanitize-name.test.ts` (11 cases): ASCII pass-through, whitespace collapse, Chinese / Japanese / Cyrillic / accented preservation, path separator scrubbing, reserved punctuation, leading-dot rewrite, empty-input fallback, latin1→UTF-8 round-trip, genuine-latin1 leave-alone, ASCII no-op, empty no-op.
- `pnpm --filter @open-design/daemon test` — **56/56 passing** (45 existing + 11 new).
- `pnpm typecheck` — clean across the workspace (web / daemon / desktop / contracts / sidecar-proto / tools-dev / e2e).
- `pnpm check:residual-js` — clean.

## Notes

- Issue #144 is assigned to @Siri-Ray. I have a working fix in hand, posting the PR rather than just dropping a comment so the diff is reviewable; happy to defer if @Siri-Ray is already mid-flight on a different approach.
- The decoder is intentionally conservative: it only flips a name to UTF-8 when the bytes round-trip cleanly. That keeps existing latin1-only filenames working and avoids corrupting them. Long-term, bumping multer to 2.x (which defaults to UTF-8) would make this helper unnecessary, but that's a separate dep upgrade.

Closes #144
