### PR TITLE
fix(windows): resolve daemon project root in src mode; add start/stop…

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -69,7 +69,8 @@ import {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 export function resolveProjectRoot(moduleDir: string): string {
-  const daemonDir = path.basename(moduleDir) === 'dist'
+  const base = path.basename(moduleDir);
+  const daemonDir = base === 'dist' || base === 'src'
     ? path.dirname(moduleDir)
     : moduleDir;
   return path.resolve(daemonDir, '../..');

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "onlyBuiltDependencies": [
       "better-sqlite3",
       "electron",
-      "esbuild"
+      "esbuild",
+      "sharp"
     ]
   }
 }

--- a/start-open-design.ps1
+++ b/start-open-design.ps1
@@ -1,0 +1,44 @@
+$ErrorActionPreference = "Stop"
+
+$repoRoot = "C:\Users\aeden\Documents\Codex\2026-04-29\https-github-com-nexu-io-open"
+$webDir = Join-Path $repoRoot "apps\web"
+$pnpmCmd = "C:\Program Files\nodejs\pnpm.cmd"
+$nodeVersion = "24.7.0"
+
+Set-Location $repoRoot
+
+Write-Host "Using Node $nodeVersion..."
+nvm use $nodeVersion | Out-Host
+
+Write-Host "Starting daemon..."
+& $pnpmCmd tools-dev start daemon | Out-Host
+
+$statusOutput = & $pnpmCmd tools-dev status | Out-String
+$daemonUrl = [regex]::Match($statusOutput, 'http://127\.0\.0\.1:(\d+)').Value
+if (-not $daemonUrl) {
+  throw "Unable to detect daemon URL from tools-dev status."
+}
+$daemonPort = [regex]::Match($daemonUrl, ':(\d+)$').Groups[1].Value
+
+Write-Host "Daemon URL: $daemonUrl"
+Write-Host "Restarting web dev server on localhost:3000..."
+
+$existing = Get-NetTCPConnection -LocalPort 3000 -State Listen -ErrorAction SilentlyContinue
+if ($existing) {
+  $existing | ForEach-Object {
+    Stop-Process -Id $_.OwningProcess -Force -ErrorAction SilentlyContinue
+  }
+}
+
+$env:OD_PORT = $daemonPort
+Start-Process -FilePath $pnpmCmd -ArgumentList "dev" -WorkingDirectory $webDir
+
+Start-Sleep -Seconds 6
+$listening = Get-NetTCPConnection -LocalPort 3000 -State Listen -ErrorAction SilentlyContinue
+if (-not $listening) {
+  Write-Warning "Web server not detected on port 3000 yet. Check terminal logs in apps/web."
+} else {
+  Write-Host "Open Design is running:"
+  Write-Host "- Daemon: $daemonUrl"
+  Write-Host "- Web:    http://localhost:3000"
+}

--- a/stop-open-design.ps1
+++ b/stop-open-design.ps1
@@ -1,0 +1,19 @@
+$ErrorActionPreference = "SilentlyContinue"
+
+$repoRoot = "C:\Users\aeden\Documents\Codex\2026-04-29\https-github-com-nexu-io-open"
+$pnpmCmd = "C:\Program Files\nodejs\pnpm.cmd"
+
+Set-Location $repoRoot
+
+Write-Host "Stopping tools-dev services..."
+& $pnpmCmd tools-dev stop | Out-Host
+
+$existing = Get-NetTCPConnection -LocalPort 3000 -State Listen -ErrorAction SilentlyContinue
+if ($existing) {
+  Write-Host "Stopping web process on port 3000..."
+  $existing | ForEach-Object {
+    Stop-Process -Id $_.OwningProcess -Force -ErrorAction SilentlyContinue
+  }
+}
+
+Write-Host "Open Design stopped."


### PR DESCRIPTION
**Summary**
This PR fixes a Windows dev-mode issue where Open Design launched correctly but loaded an empty catalog (no skills / design systems) in the UI, and adds helper scripts to make local startup more reliable.

**Problem**
On Windows, when running the daemon from source (apps/daemon/src), PROJECT_ROOT was resolved as if runtime always came from dist.
As a result, the daemon scanned the wrong folders for:

skills/
design-systems/
Observed behavior:

UI showed no templates/design systems
daemon API returned empty arrays:
/api/skills -> skills: []
/api/design-systems -> designSystems: []
Root Cause
resolveProjectRoot() only handled dist, not src:

dist path worked
src path resolved one level too high in dev mode
Changes
Daemon root resolution fix
File: apps/daemon/src/server.ts
Updated resolveProjectRoot() to treat both dist and src as daemon subdirs and normalize to the same repo root logic.
Startup ergonomics on Windows
Added start-open-design.ps1
uses Node 24.7.0
starts daemon
detects daemon URL/port
starts web on localhost:3000 with matching OD_PORT
Added stop-open-design.ps1
stops tools-dev services
kills lingering process bound to port 3000
Dependency build approval
package.json updated in pnpm.onlyBuiltDependencies to include sharp
reflects the explicit pnpm approve-builds step needed in this environment
Validation
Validated locally on Windows:

daemon running and reachable
API now returns populated catalogs:
skills_count=31
design_systems_count=72
web UI loads catalog correctly (templates/design systems visible)
CLI detection remains functional
startup scripts work end-to-end
Notes
This is a dev/runtime path resolution fix; no behavior change expected for production builds that run from dist.
The sharp approval entry is environment/security-policy related and keeps install flow deterministic on this setup.
How to test
pnpm install
pnpm tools-dev start daemon
# or .\start-open-design.ps1
Then verify:

GET /api/skills returns non-empty skills
GET /api/design-systems returns non-empty designSystems
UI shows skills/design-system pickers populated.