### PR TITLE
feat: add first-class SVG artifact viewer

### DIFF
--- a/apps/web/src/artifacts/renderer-registry.test.ts
+++ b/apps/web/src/artifacts/renderer-registry.test.ts
@@ -110,7 +110,7 @@ describe('RendererRegistry', () => {
     expect(MarkdownRenderer.supportsStreaming).toBe(true);
     expect(MarkdownRenderer.renderPartial).toBe(renderMarkdownToSafeHtml);
 
-    expect(SvgRenderer.supportsStreaming).toBe(true);
+    expect(SvgRenderer.supportsStreaming).toBe(false);
     expect(SvgRenderer.renderPartial).toBeUndefined();
   });
 

--- a/apps/web/src/artifacts/renderer-registry.ts
+++ b/apps/web/src/artifacts/renderer-registry.ts
@@ -68,7 +68,7 @@ export const MarkdownRenderer: ArtifactRenderer = {
 
 export const SvgRenderer: ArtifactRenderer = {
   id: 'svg',
-  supportsStreaming: true,
+  supportsStreaming: false,
   canRender: ({ file }) => {
     const manifest = resolveManifest(file);
     if (!manifest) return false;

--- a/apps/web/src/components/FileViewer.test.tsx
+++ b/apps/web/src/components/FileViewer.test.tsx
@@ -1,0 +1,99 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { FileViewer, SvgViewer } from './FileViewer';
+import type { ProjectFile } from '../types';
+
+function baseFile(overrides: Partial<ProjectFile>): ProjectFile {
+  return {
+    name: 'asset.png',
+    path: 'asset.png',
+    type: 'file',
+    size: 1024,
+    mtime: 1710000000,
+    kind: 'image',
+    mime: 'image/png',
+    ...overrides,
+  };
+}
+
+describe('FileViewer SVG artifacts', () => {
+  it('routes SVG artifacts to the SVG viewer instead of the generic image viewer', () => {
+    const file = baseFile({
+      name: 'diagram.svg',
+      path: 'diagram.svg',
+      mime: 'image/svg+xml',
+      artifactManifest: {
+        version: 1,
+        kind: 'svg',
+        title: 'Diagram',
+        entry: 'diagram.svg',
+        renderer: 'svg',
+        exports: ['svg'],
+      },
+    });
+
+    const markup = renderToStaticMarkup(<FileViewer projectId="project-1" file={file} />);
+
+    expect(markup).toContain('class="viewer svg-viewer"');
+    expect(markup).not.toContain('class="viewer image-viewer"');
+    expect(markup).toContain('Preview');
+    expect(markup).toContain('Source');
+    expect(markup).toContain('src="/api/projects/project-1/raw/diagram.svg?v=1710000000&amp;r=0"');
+  });
+
+  it('keeps normal image artifacts on the existing image viewer path', () => {
+    const file = baseFile({ name: 'photo.png', path: 'photo.png' });
+
+    const markup = renderToStaticMarkup(<FileViewer projectId="project-1" file={file} />);
+
+    expect(markup).toContain('class="viewer image-viewer"');
+    expect(markup).not.toContain('class="viewer svg-viewer"');
+    expect(markup).not.toContain('class="viewer-tabs"');
+  });
+
+  it('marks preview and source modes through the SVG viewer toggle controls', () => {
+    const file = baseFile({ name: 'diagram.svg', path: 'diagram.svg', mime: 'image/svg+xml' });
+
+    const previewMarkup = renderToStaticMarkup(
+      <SvgViewer projectId="project-1" file={file} initialMode="preview" />,
+    );
+    const sourceMarkup = renderToStaticMarkup(
+      <SvgViewer
+        projectId="project-1"
+        file={file}
+        initialMode="source"
+        initialSource="<svg><title>Diagram</title></svg>"
+      />,
+    );
+
+    expect(previewMarkup).toContain('class="viewer-tab active" aria-pressed="true">Preview</button>');
+    expect(previewMarkup).toContain('aria-pressed="false">Source</button>');
+    expect(previewMarkup).toContain('<img');
+
+    expect(sourceMarkup).toContain('aria-pressed="false">Preview</button>');
+    expect(sourceMarkup).toContain('class="viewer-tab active" aria-pressed="true">Source</button>');
+    expect(sourceMarkup).toContain('class="viewer-source"');
+    expect(sourceMarkup).not.toContain('<img');
+  });
+
+  it('renders unsafe SVG source as escaped text instead of executable markup', () => {
+    const file = baseFile({ name: 'unsafe.svg', path: 'unsafe.svg', mime: 'image/svg+xml' });
+    const unsafeSource = '<svg onload="alert(1)"><script>alert(2)</script><text>Logo</text></svg>';
+
+    const markup = renderToStaticMarkup(
+      <SvgViewer
+        projectId="project-1"
+        file={file}
+        initialMode="source"
+        initialSource={unsafeSource}
+      />,
+    );
+
+    expect(markup).toContain('&lt;svg onload=&quot;alert(1)&quot;&gt;');
+    expect(markup).toContain('&lt;script&gt;alert(2)&lt;/script&gt;');
+    expect(markup).not.toContain('<svg onload');
+    expect(markup).not.toContain('<script>');
+    expect(markup).not.toContain('dangerouslySetInnerHTML');
+  });
+});

--- a/apps/web/src/components/FileViewer.test.tsx
+++ b/apps/web/src/components/FileViewer.test.tsx
@@ -79,7 +79,10 @@ describe('FileViewer SVG artifacts', () => {
 
   it('renders unsafe SVG source as escaped text instead of executable markup', () => {
     const file = baseFile({ name: 'unsafe.svg', path: 'unsafe.svg', mime: 'image/svg+xml' });
-    const unsafeSource = '<svg onload="alert(1)"><script>alert(2)</script><text>Logo</text></svg>';
+    const unsafeSource = [
+      '<svg onload="alert(1)"><script>alert(2)</script><text>Logo</text></svg>',
+      '<svg><![CDATA[<script>alert(3)</script>]]></svg>',
+    ].join('\n');
 
     const markup = renderToStaticMarkup(
       <SvgViewer
@@ -92,8 +95,10 @@ describe('FileViewer SVG artifacts', () => {
 
     expect(markup).toContain('&lt;svg onload=&quot;alert(1)&quot;&gt;');
     expect(markup).toContain('&lt;script&gt;alert(2)&lt;/script&gt;');
+    expect(markup).toContain('&lt;![CDATA[&lt;script&gt;alert(3)&lt;/script&gt;]]&gt;');
     expect(markup).not.toContain('<svg onload');
     expect(markup).not.toContain('<script>');
+    expect(markup).not.toContain('<![CDATA[');
     expect(markup).not.toContain('dangerouslySetInnerHTML');
   });
 });

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -61,7 +61,7 @@ export function FileViewer({
     return <MarkdownViewer projectId={projectId} file={file} />;
   }
   if (rendererMatch?.renderer.id === 'svg') {
-    return <ImageViewer projectId={projectId} file={file} />;
+    return <SvgViewer projectId={projectId} file={file} />;
   }
   if (file.kind === 'image') {
     return <ImageViewer projectId={projectId} file={file} />;
@@ -1185,6 +1185,122 @@ function AudioViewer({
           <div className="audio-card-name">{file.name}</div>
           <audio src={url} controls preload="metadata" />
         </div>
+      </div>
+    </div>
+  );
+}
+
+type SvgViewerMode = 'preview' | 'source';
+
+interface SvgViewerProps {
+  projectId: string;
+  file: ProjectFile;
+  initialMode?: SvgViewerMode;
+  initialSource?: string | null | undefined;
+}
+
+export function SvgViewer({
+  projectId,
+  file,
+  initialMode = 'preview',
+  initialSource,
+}: SvgViewerProps) {
+  const t = useT();
+  const [mode, setMode] = useState<SvgViewerMode>(initialMode);
+  const [source, setSource] = useState<string | null>(initialSource ?? null);
+  const [loadingSource, setLoadingSource] = useState(false);
+  const [sourceError, setSourceError] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
+  const url = `${projectFileUrl(projectId, file.name)}?v=${Math.round(file.mtime)}&r=${reloadKey}`;
+
+  useEffect(() => {
+    if (mode !== 'source') return;
+    if (initialSource !== undefined && reloadKey === 0) return;
+    let cancelled = false;
+    setLoadingSource(true);
+    setSourceError(false);
+    void fetchProjectFileText(projectId, file.name, {
+      cache: 'no-store',
+      cacheBustKey: `${Math.round(file.mtime)}-${reloadKey}`,
+    }).then((next) => {
+      if (cancelled) return;
+      if (next === null) {
+        setSource('');
+        setSourceError(true);
+      } else {
+        setSource(next);
+      }
+      setLoadingSource(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId, file.name, file.mtime, initialSource, mode, reloadKey]);
+
+  return (
+    <div className="viewer svg-viewer">
+      <div className="viewer-toolbar">
+        <div className="viewer-toolbar-left">
+          <span className="viewer-meta">
+            {t('fileViewer.imageMeta', { size: humanSize(file.size) })}
+          </span>
+        </div>
+        <div className="viewer-toolbar-actions">
+          <div className="viewer-tabs">
+            <button
+              type="button"
+              className={`viewer-tab ${mode === 'preview' ? 'active' : ''}`}
+              aria-pressed={mode === 'preview'}
+              onClick={() => setMode('preview')}
+            >
+              {t('fileViewer.preview')}
+            </button>
+            <button
+              type="button"
+              className={`viewer-tab ${mode === 'source' ? 'active' : ''}`}
+              aria-pressed={mode === 'source'}
+              onClick={() => setMode('source')}
+            >
+              {t('fileViewer.source')}
+            </button>
+          </div>
+          <span className="viewer-divider" aria-hidden />
+          <button
+            type="button"
+            className="viewer-action"
+            onClick={() => setReloadKey((n) => n + 1)}
+            title={t('fileViewer.reloadDisk')}
+          >
+            <Icon name="reload" size={13} />
+            <span>{t('fileViewer.reload')}</span>
+          </button>
+          <a
+            className="ghost-link"
+            href={projectFileUrl(projectId, file.name)}
+            download={file.name}
+          >
+            {t('fileViewer.download')}
+          </a>
+          <a
+            className="ghost-link"
+            href={projectFileUrl(projectId, file.name)}
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            {t('fileViewer.open')}
+          </a>
+        </div>
+      </div>
+      <div className={`viewer-body ${mode === 'preview' ? 'image-body' : ''}`}>
+        {mode === 'preview' ? (
+          <img alt={file.name} src={url} />
+        ) : loadingSource ? (
+          <div className="viewer-empty">{t('fileViewer.loading')}</div>
+        ) : sourceError ? (
+          <div className="viewer-empty">{t('fileViewer.previewUnavailable')}</div>
+        ) : (
+          <pre className="viewer-source">{source ?? ''}</pre>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/providers/registry.test.ts
+++ b/apps/web/src/providers/registry.test.ts
@@ -4,6 +4,7 @@ import { fetchProjectFileText } from './registry';
 
 describe('fetchProjectFileText', () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
@@ -21,6 +22,44 @@ describe('fetchProjectFileText', () => {
     expect(fetchMock).toHaveBeenCalledWith(
       '/api/projects/project-1/raw/diagram.svg?cacheBust=1710000000-2',
       { cache: 'no-store' },
+    );
+  });
+
+  it('logs HTTP failure context before returning null', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('missing', { status: 404, statusText: 'Not Found' })));
+
+    await expect(fetchProjectFileText('project-1', 'missing.svg')).resolves.toBeNull();
+
+    expect(warn).toHaveBeenCalledWith(
+      '[fetchProjectFileText] failed:',
+      expect.objectContaining({
+        name: 'missing.svg',
+        projectId: 'project-1',
+        status: 404,
+        statusText: 'Not Found',
+        url: '/api/projects/project-1/raw/missing.svg',
+      }),
+    );
+  });
+
+  it('logs thrown fetch errors before returning null', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const error = new Error('network down');
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      throw error;
+    }));
+
+    await expect(fetchProjectFileText('project-1', 'diagram.svg')).resolves.toBeNull();
+
+    expect(warn).toHaveBeenCalledWith(
+      '[fetchProjectFileText] failed:',
+      expect.objectContaining({
+        error,
+        name: 'diagram.svg',
+        projectId: 'project-1',
+        url: '/api/projects/project-1/raw/diagram.svg',
+      }),
     );
   });
 });

--- a/apps/web/src/providers/registry.test.ts
+++ b/apps/web/src/providers/registry.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchProjectFileText } from './registry';
+
+describe('fetchProjectFileText', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('can bypass caches when fetching source text', async () => {
+    const fetchMock = vi.fn(async () => new Response('<svg />', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      fetchProjectFileText('project-1', 'diagram.svg', {
+        cache: 'no-store',
+        cacheBustKey: '1710000000-2',
+      }),
+    ).resolves.toBe('<svg />');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/projects/project-1/raw/diagram.svg?cacheBust=1710000000-2',
+      { cache: 'no-store' },
+    );
+  });
+});

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -236,17 +236,35 @@ export async function fetchProjectFileText(
   name: string,
   options?: { cache?: RequestCache; cacheBustKey?: string | number },
 ): Promise<string | null> {
+  const url = projectFileUrl(projectId, name);
+  const cacheBustKey = options?.cacheBustKey;
+  const requestUrl =
+    cacheBustKey == null
+      ? url
+      : `${url}${url.includes('?') ? '&' : '?'}cacheBust=${encodeURIComponent(String(cacheBustKey))}`;
+  const init: RequestInit = {};
+  if (options?.cache) init.cache = options.cache;
+
   try {
-    const url = projectFileUrl(projectId, name);
-    const cacheBustKey = options?.cacheBustKey;
-    const requestUrl =
-      cacheBustKey == null
-        ? url
-        : `${url}${url.includes('?') ? '&' : '?'}cacheBust=${encodeURIComponent(String(cacheBustKey))}`;
-    const resp = await fetch(requestUrl, options?.cache ? { cache: options.cache } : undefined);
-    if (!resp.ok) return null;
+    const resp = await fetch(requestUrl, init);
+    if (!resp.ok) {
+      console.warn('[fetchProjectFileText] failed:', {
+        name,
+        projectId,
+        status: resp.status,
+        statusText: resp.statusText,
+        url: requestUrl,
+      });
+      return null;
+    }
     return await resp.text();
-  } catch {
+  } catch (err) {
+    console.warn('[fetchProjectFileText] failed:', {
+      error: err,
+      name,
+      projectId,
+      url: requestUrl,
+    });
     return null;
   }
 }

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -234,9 +234,16 @@ export async function fetchProjectFilePreview(
 export async function fetchProjectFileText(
   projectId: string,
   name: string,
+  options?: { cache?: RequestCache; cacheBustKey?: string | number },
 ): Promise<string | null> {
   try {
-    const resp = await fetch(projectFileUrl(projectId, name));
+    const url = projectFileUrl(projectId, name);
+    const cacheBustKey = options?.cacheBustKey;
+    const requestUrl =
+      cacheBustKey == null
+        ? url
+        : `${url}${url.includes('?') ? '&' : '?'}cacheBust=${encodeURIComponent(String(cacheBustKey))}`;
+    const resp = await fetch(requestUrl, options?.cache ? { cache: options.cache } : undefined);
     if (!resp.ok) return null;
     return await resp.text();
   } catch {


### PR DESCRIPTION
Summary
This PR continues the artifact-platform work from #73 by completing first-class SVG artifact viewing in the web file viewer.

The important move is still incremental: SVG artifacts already resolve through the artifact renderer registry, and this PR replaces the generic image-viewer fallback with a dedicated SVG viewer that supports both visual preview and source inspection. Existing image behavior is preserved.

Why this matters
SVG artifacts need slightly different handling than normal images: reviewers and users often need to inspect the raw SVG source, but rendering SVG inline can introduce avoidable safety risk.

This PR keeps SVG preview useful while making the source path explicit and safe. Preview mode loads the SVG as an image; source mode renders the SVG text as escaped React content, not executable markup.

What this PR includes
1. Dedicated SVG viewer
Adds a dedicated `SvgViewer` route for artifacts resolved by the SVG renderer.

The viewer includes:

- Preview / Source toggle
- Reload action
- Download action
- Open action
- Existing image layout reuse for preview mode

Normal image files continue to use the existing `ImageViewer` path.

2. Safer SVG preview/source behavior
SVG content is never rendered with `dangerouslySetInnerHTML`.

Preview mode uses an `<img>` pointing at the raw artifact URL with cache-busting parameters. Source mode fetches the SVG text and renders it inside a React-managed `<pre>`, so potentially unsafe markup such as `<script>` or event handlers is displayed as escaped text rather than executable DOM.

Source reloads also bypass cache with `cache: no-store` and a cache-busting query parameter.

3. Renderer metadata correction
Updates `SvgRenderer.supportsStreaming` to `false`.

The previous value advertised streaming support even though SVG has no `renderPartial` implementation. This PR makes the contract conservative until partial SVG rendering is intentionally designed.

4. Test coverage
Adds and updates Vitest coverage for:

- SVG artifacts routing to the dedicated SVG viewer
- Normal image artifacts continuing to use the existing image viewer
- Preview/source mode rendering
- Unsafe SVG source being escaped as text
- Source text fetch cache-busting behavior
- SVG renderer streaming capability metadata

What this PR intentionally does NOT include
This PR intentionally avoids:

- React component rendering
- TSX support
- mini-app runtime
- dynamic dependency handling
- artifact versioning / refinement metadata
- migration scripts
- broad artifact save-pipeline changes
- SVG sanitization or transformation beyond safe preview/source presentation

Changes
| File | Change |
|------|--------|
| `apps/web/src/components/FileViewer.tsx` | Adds `SvgViewer` and routes SVG renderer matches to it. |
| `apps/web/src/components/FileViewer.test.tsx` | Adds SVG viewer routing, preview/source, image fallback, and escaped-source coverage. |
| `apps/web/src/providers/registry.ts` | Adds optional cache/no-store support to `fetchProjectFileText`. |
| `apps/web/src/providers/registry.test.ts` | Covers source fetch cache-busting behavior. |
| `apps/web/src/artifacts/renderer-registry.ts` | Marks SVG renderer as non-streaming. |
| `apps/web/src/artifacts/renderer-registry.test.ts` | Updates SVG renderer streaming contract expectation. |

Validation
- [x] `pnpm --filter @open-design/web test`
- [x] `pnpm --filter @open-design/web typecheck`
- [x] `pnpm typecheck`

Notes for review
This is meant as a small follow-up after #73. It keeps the scope focused on SVG artifact viewing and safety without pulling in the larger React/runtime/versioning work.