### PR TITLE
fix(web): prevent toolbar button text wrapping for CJK languages

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2807,6 +2807,7 @@ code {
   border-radius: var(--radius-sm);
   color: var(--text-muted);
   font-size: 12.5px;
+  white-space: nowrap;
 }
 .viewer-action:hover:not(:disabled) { background: var(--bg-subtle); color: var(--text); }
 .viewer-action.primary {
@@ -2832,6 +2833,7 @@ code {
   color: var(--text-muted);
   padding: 4px 10px;
   border-radius: var(--radius-sm);
+  white-space: nowrap;
 }
 .viewer-toggle .switch {
   position: relative;
@@ -2863,6 +2865,7 @@ code {
   font-size: 12px;
   border-radius: var(--radius-sm);
   color: var(--text-muted);
+  white-space: nowrap;
 }
 .viewer-tab:hover { background: var(--bg-subtle); color: var(--text); }
 .viewer-tab.active {


### PR DESCRIPTION
## Summary

- Add `white-space: nowrap` to `.viewer-action`, `.viewer-toggle`, and `.viewer-tab` to prevent CJK text from breaking to a new line when the toolbar runs out of horizontal space
- English text was unaffected because browsers treat whole words as atomic units, but CJK characters can break between any two characters by default

## Test plan

- Switch language to Chinese (zh-CN)
- Narrow the browser window until the toolbar buttons are compressed
- Verify button text (Preview, Source, Comment, Edit, Draw, Tweaks) does not wrap to a second line
- Switch to English and verify the same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)