### PR TITLE
docs: add Japanese Documents

### DIFF
--- a/CONTRIBUTING.ja-JP.md
+++ b/CONTRIBUTING.ja-JP.md
@@ -1,0 +1,267 @@
+# Open Design へのコントリビューション
+
+コントリビューションを検討してくださりありがとうございます。OD は意図的に小さく保っています — 価値の大部分はフレームワークコードではなく**ファイル**（Skill、Design System、プロンプトフラグメント）にあります。そのため、最も効果の高いコントリビューションは通常、フォルダ 1 つ、Markdown ファイル 1 つ、または PR サイズの adapter です。
+
+このガイドでは、各種コントリビューションの対象場所と、PR がマージされるために満たすべき基準を正確に説明します。
+
+<p align="center"><a href="CONTRIBUTING.md">English</a> · <a href="CONTRIBUTING.zh-CN.md">简体中文</a> · <b>日本語</b></p>
+
+---
+
+## 午後一回で出荷できる 3 つのこと
+
+| やりたいこと | 実際に追加するもの | 配置場所 | 規模 |
+|---|---|---|---|
+| OD に新しい種類の artifact をレンダリングさせる（請求書、iOS Settings 画面、ワンページャー…） | **Skill** | [`skills/<your-skill>/`](skills/) | フォルダ 1 つ、約 2 ファイル |
+| OD に新しいブランドのビジュアル言語を話させる | **Design System** | [`design-systems/<brand>/DESIGN.md`](design-systems/) | Markdown ファイル 1 つ |
+| 新しい coding-agent CLI を接続する | **Agent adapter** | [`apps/daemon/src/agents.ts`](apps/daemon/src/agents.ts) | 1 つの配列に約 10 行 |
+| 機能追加、バグ修正、[`open-codesign`][ocod] から UX パターンを移植 | コード | `apps/web/src/`、`apps/daemon/` | 通常の PR |
+| ドキュメント改善、他言語への翻訳、タイポ修正 | ドキュメント | `README.md`、`README.zh-CN.md`、`docs/`、`QUICKSTART.md` | PR 1 つ |
+
+アイデアがどのカテゴリに該当するか分からない場合は、[まず discussion / issue を作成](https://github.com/nexu-io/open-design/issues/new)してください。適切な場所をご案内します。
+
+---
+
+## ローカル環境セットアップ
+
+完全なセットアップ手順は [`QUICKSTART.md`](QUICKSTART.md) にあります。コントリビューター向けの要約：
+
+```bash
+git clone https://github.com/nexu-io/open-design.git
+cd open-design
+corepack enable           # packageManager で指定された pnpm を選択
+pnpm install
+pnpm tools-dev run web    # daemon + web フォアグラウンドループ
+pnpm typecheck            # tsc -b --noEmit
+pnpm build                # プロダクションビルド
+```
+
+Node `~24` と pnpm `10.33.x` が必要です。`nvm` / `fnm` はオプション。使用する場合は `nvm install 24 && nvm use 24` または `fnm install 24 && fnm use 24` を実行してください。macOS、Linux、WSL2 が主要プラットフォームです。Windows ネイティブでも動作するはずですが、主要ターゲットではありません — 動作しない場合は issue を作成してください。
+
+OD 自体の開発に agent CLI は `PATH` 上に不要です — daemon は「no agents found」と表示し、**Anthropic API · BYOK** パスにフォールバックします。このパスが最も高速な開発ループです。
+
+---
+
+## 新しい Skill の追加
+
+Skill は [`skills/`](skills/) 配下のフォルダで、ルートに `SKILL.md` を持ち、Claude Code の [`SKILL.md` 規約][skill]とオプションの `od:` 拡張に従います。**登録ステップは不要です。** フォルダを配置して daemon を再起動すれば、ピッカーに表示されます。
+
+### Skill フォルダ構成
+
+```text
+skills/your-skill/
+├── SKILL.md                    # 必須
+├── assets/template.html        # オプションだが推奨 — seed ファイル
+├── references/                 # オプション — エージェントが読むナレッジファイル
+│   ├── layouts.md
+│   ├── components.md
+│   └── checklist.md
+└── example.html                # 強く推奨 — 実際の手作りサンプル
+```
+
+### `SKILL.md` frontmatter
+
+最初の 3 キーは Claude Code のベース仕様 — `name`、`description`、`triggers`。`od:` 配下はすべて OD 固有のオプションですが、**`od.mode`** が Skill の表示グループ（Prototype / Deck / Template / Design system）を決定します。
+
+```yaml
+---
+name: your-skill
+description: |
+  1 段落のエレベーターピッチ。エージェントはこれをそのまま読んで、
+  ユーザーの要件にマッチするか判断します。具体的に：surface、
+  ターゲット、artifact に含まれるもの、含まれないもの。
+triggers:
+  - "your trigger phrase"
+  - "another phrase"
+  - "日本語のトリガーフレーズ"
+od:
+  mode: prototype           # prototype | deck | template | design-system
+  platform: desktop         # desktop | mobile
+  scenario: marketing       # グループ化用の自由形式タグ
+  featured: 1               # 正の整数を設定すると「ショーケース」セクションに表示
+  preview:
+    type: html              # html | jsx | pptx | markdown
+    entry: index.html
+  design_system:
+    requires: true          # Skill がアクティブな DESIGN.md を読むか？
+    sections: [color, typography, layout, components]
+  example_prompt: "この Skill の機能をわかりやすく示すコピペ可能なプロンプト。"
+---
+
+# Your Skill
+
+本文はエージェントが従うべきワークフローを記述する自由形式の Markdown…
+```
+
+型付き入力、スライダーパラメータ、ケイパビリティゲーティングの完全な文法は [`docs/skills-protocol.md`](docs/skills-protocol.md) にあります。
+
+### 新しい Skill のマージ基準
+
+Skill はユーザーに直接見える面であるため、厳しく審査します。新しい Skill は以下を満たす必要があります：
+
+1. **実際の `example.html` を同梱すること。** 手作りで、ディスクから直接開けて、デザイナーが実際に納品するレベルの見た目であること。Lorem ipsum や `<svg><rect/></svg>` のプレースホルダー hero は不可。自分で example を作れないなら、その Skill はまだ準備できていません。
+2. **本文で anti-AI-slop チェックリストをパスすること。** 紫グラデーション、汎用 emoji アイコン、左ボーダー付き角丸カード、Inter を *display* フォントとして使用、架空の統計データは不可。完全なリストは README の **anti-AI-slop 機構**セクションを参照。
+3. **正直なプレースホルダー。** エージェントが実数値を持たない場合は `—` またはラベル付きグレーブロックを書き、「10 倍高速」とは書かない。
+4. **`references/checklist.md` を持つこと。** 少なくとも P0 ゲート（エージェントが `<artifact>` を出力する前にパスすべき項目）を含む。フォーマットは [`skills/guizang-ppt/references/checklist.md`](skills/guizang-ppt/) または [`skills/dating-web/references/checklist.md`](skills/dating-web/) を参考にしてください。
+5. **スクリーンショットを追加。** Skill が featured の場合、`docs/screenshots/skills/<skill>.png` に配置。PNG、約 1024×640 Retina、実際の `example.html` からズームアウトしたブラウザ縮尺でキャプチャ。
+6. **単一の自己完結フォルダであること。** 他の Skill が既に使用しているもの以外の CDN インポート禁止。ライセンスのないフォント禁止。約 250 KB を超える画像禁止。
+
+既存の Skill を fork する場合（例：`dating-web` から `recruiting-web` にリミックス）、元の LICENSE と帰属表示を `references/` に保持し、PR の説明で明記してください。
+
+### 同梱済み Skill — 模倣するものを選ぶ
+
+- ビジュアルショーケース、単一画面プロトタイプ：[`skills/dating-web/`](skills/dating-web/)、[`skills/digital-eguide/`](skills/digital-eguide/)
+- マルチフレームモバイルフロー：[`skills/mobile-onboarding/`](skills/mobile-onboarding/)、[`skills/gamified-app/`](skills/gamified-app/)
+- ドキュメント / テンプレート（Design System 不要）：[`skills/pm-spec/`](skills/pm-spec/)、[`skills/weekly-update/`](skills/weekly-update/)
+- Deck モード：[`skills/guizang-ppt/`](skills/guizang-ppt/)（[op7418/guizang-ppt-skill][guizang] からそのまま同梱）および [`skills/simple-deck/`](skills/simple-deck/)
+
+---
+
+## 新しい Design System の追加
+
+Design System は `design-systems/<slug>/` 配下の単一の [`DESIGN.md`](design-systems/README.md) ファイルです。**ファイル 1 つ、コード不要。** 配置して daemon を再起動すれば、ピッカーにカテゴリ別にグループ化されて表示されます。
+
+### Design System フォルダ構成
+
+```text
+design-systems/your-brand/
+└── DESIGN.md
+```
+
+### `DESIGN.md` の構造
+
+```markdown
+# Design System Inspired by YourBrand
+
+> Category: Developer Tools
+> ピッカーのプレビューに表示される 1 行の要約。
+
+## 1. Visual Theme & Atmosphere
+…
+
+## 2. Color
+- Primary: `#hex` / `oklch(...)`
+- …
+
+## 3. Typography
+…
+
+## 4. Spacing & Grid
+## 5. Layout & Composition
+## 6. Components
+## 7. Motion & Interaction
+## 8. Voice & Brand
+## 9. Anti-patterns
+```
+
+9 セクションスキーマは固定です — Skill 本文の grep 対象だからです。最初の H1 がピッカーのラベルになり（`Design System Inspired by` プレフィックスは自動的に除去）、`> Category: …` 行がグループを決定します。既存のカテゴリは [`design-systems/README.md`](design-systems/README.md) に記載されています。ブランドが本当にどのカテゴリにも合わない場合は新しいカテゴリを導入できますが、**まず既存カテゴリに合わないか試してください**。
+
+### 新しい Design System のマージ基準
+
+1. **全 9 セクションが存在すること。** データが見つかりにくいセクション（例：モーショントークン）は本文が空でも構いませんが、見出しは必須です。見出しがないとプロンプトの grep が壊れます。
+2. **Hex コードが実物であること。** ブランドのサイトやプロダクトから直接サンプリングし、記憶や AI の推測ではないこと。README の「ブランドアセット抽出」5 ステッププロトコルはメンテナにも適用されます。
+3. **アクセントカラーの OKLch 値**はあると良い。ライト/ダーク間で予測可能な補間が可能になります。
+4. **マーケティングの美辞麗句は不要。** ブランドのタグラインはデザイントークンではありません。削除してください。
+5. **スラッグは ASCII を使用** — `linear.app` は `linear-app`、`x.ai` は `x-ai` になります。インポート済みの 69 システムがこの規約に従っています。それに合わせてください。
+
+出荷している 69 のプロダクトシステムは [`VoltAgent/awesome-design-md`][acd2] から [`scripts/sync-design-systems.ts`](scripts/sync-design-systems.ts) 経由でインポートされています。ブランドが上流に属する場合は、**まずそちらに PR を送ってください** — 次の sync で自動的に反映されます。`design-systems/` フォルダは上流に合わないシステムと、手作りの 2 つのスターター用です。
+
+---
+
+## 新しい coding-agent CLI の追加
+
+新しいエージェント（例：`foo-coder` CLI）の接続は [`apps/daemon/src/agents.ts`](apps/daemon/src/agents.ts) にエントリを 1 つ追加するだけです：
+
+```javascript
+{
+  id: 'foo',
+  name: 'Foo Coder',
+  bin: 'foo',
+  versionArgs: ['--version'],
+  buildArgs: (prompt) => ['exec', '-p', prompt],
+  streamFormat: 'plain',           // Claude Code と同じプロトコルなら 'claude-stream-json'
+}
+```
+
+これだけです — daemon が `PATH` 上で検出し、ピッカーに表示され、チャットパスが動作します。CLI が**型付きイベント**を出力する場合（Claude Code の `--output-format stream-json` のように）、[`apps/daemon/src/claude-stream.ts`](apps/daemon/src/claude-stream.ts) にパーサーを追加して `streamFormat: 'claude-stream-json'` を設定してください。
+
+マージ基準：
+
+1. **新しいエージェントで実際のセッションがエンドツーエンドで動作すること** — artifact がストリーミングされたことを示す daemon ログを PR の説明に貼り付けてください。
+2. **`docs/agent-adapters.md`** を CLI の特徴で更新（キーファイルは必要か？画像入力に対応しているか？非対話モードのフラグは何か？）。
+3. **README の「対応 Coding Agent」テーブル**に 1 行追加。
+
+---
+
+## コードスタイル
+
+フォーマットについて厳格ではありません（保存時の Prettier で OK）が、2 つのルールはプロンプトスタックとユーザー向け API に影響するため交渉の余地がありません：
+
+1. **JS/TS ではシングルクォート。** エスケープが見苦しくなる場合を除き、文字列はシングルクォート。コードベースは既に一貫しています — 合わせてください。
+2. **コメントは英語。** PR が何かを日本語に翻訳する場合でも、コードコメントは英語を維持します。grep 可能なリファレンスを 1 セットに保つためです。
+
+その他：
+
+- **ナレーションしない。** `// import the module`、`// loop through items` は不要。コードが明らかに読める場合、コメントはノイズです。コメントはコードで表現できない非自明な意図や制約のために残してください。
+- **TypeScript** は `apps/web/src/` 用。daemon（`apps/daemon/`）は型が重要な箇所で JSDoc 付きのプレーン ESM JavaScript です — そのまま維持してください。
+- **新しいトップレベル依存関係は追加しない**（PR の説明で得られるものと出荷バイト数について 1 段落の説明がない限り）。[`package.json`](package.json) の依存関係リストは意図的に小さく保っています。
+- **プッシュ前に `pnpm typecheck` を実行。** CI で実行されます。失敗すると「please fix」コメントが付きます。
+
+---
+
+## コミットとプルリクエスト
+
+- **PR 1 つにつき 1 つの関心事。** Skill の追加 + パーサーのリファクタリング + 依存関係のバンプは 3 つの PR です。
+- **タイトルは命令形 + スコープ。** `add dating-web skill`、`fix daemon SSE backpressure when CLI hangs`、`docs: clarify .od layout`。
+- **本文は「なぜ」を説明。** 「何をするか」は通常 diff から明らかです。「なぜこれが必要か」はほとんどの場合そうではありません。
+- **issue がある場合は参照。** ない場合で、PR が自明でないなら、先に issue を作成して変更が求められていることを合意してから時間を費やしてください。
+- **レビュー中にスカッシュしない。** fixup をプッシュしてください。マージ時にスカッシュします。
+- **共有ブランチへの force-push 禁止。** レビュアーが依頼した場合を除きます。
+
+CLA は求めません。Apache-2.0 でカバーされます。あなたのコントリビューションは同じライセンスの下でライセンスされます。
+
+---
+
+## バグ報告
+
+以下の情報を含めて issue を作成してください：
+
+- 実行したコマンド（正確な `pnpm tools-dev ...` の呼び出し）。
+- 選択されたエージェント CLI（または BYOK パスを使用していたか）。
+- トリガーとなった Skill + Design System のペア。
+- 関連する **daemon stderr のテール** — 「artifact がレンダリングされない」という報告のほとんどは、`spawn ENOENT` や CLI の実際のエラーが見えれば 30 秒で診断できます。
+- UI に関する場合はスクリーンショット。
+
+プロンプトスタックのバグ（「エージェントが紫グラデーションの hero を出力した、slop ブラックリストで禁止されているはずなのに」）の場合、**アシスタントメッセージの全文**を含めてください。違反がモデル側かプロンプト側かを判断できます。
+
+---
+
+## 質問する
+
+- アーキテクチャの質問、設計の質問、「これはバグか使い方の問題か」→ [GitHub Discussions](https://github.com/nexu-io/open-design/discussions)（推奨 — 次の人が検索できます）。
+- 「X をする Skill はどう書けばいい？」→ Discussion を作成してください。回答し、不足しているパターンであれば [`docs/skills-protocol.md`](docs/skills-protocol.md) に反映します。
+
+---
+
+## 受け入れないもの
+
+プロジェクトの焦点を維持するため、以下のような PR は作成しないでください：
+
+- **モデルランタイムを vendor する。** OD の根幹は「あなたの既存 CLI で十分」です。`pi-ai`、OpenAI キー、モデルローダーは同梱しません。
+- **事前の議論なくフロントエンドを現在のスタックから書き換える。** Next.js 16 App Router + React 18 + TS がラインです。メンテナが明示的にそのマイグレーションを望まない限り、Astro、Solid、Svelte、その他のフレームワークへの書き換えは不可。
+- **daemon をサーバーレス関数に置き換える。** daemon の存在意義は実際の `cwd` を所有し、実際の CLI を spawn することです。SPA の Vercel デプロイは OK。daemon は daemon のまま。
+- **テレメトリ / アナリティクス / phone-home を追加する。** OD はローカルファーストです。外向きの呼び出しはユーザーが明示的に設定したプロバイダへのもののみ。
+- **ライセンスファイルと帰属表示なしでバイナリを同梱する。**
+
+アイデアが適合するか分からない場合は、コードを書く前に discussion を作成してください。
+
+---
+
+## ライセンス
+
+コントリビューションすることにより、あなたのコントリビューションがこのリポジトリの [Apache-2.0 License](LICENSE) の下でライセンスされることに同意するものとします。ただし、[`skills/guizang-ppt/`](skills/guizang-ppt/) 内のファイルは元の MIT ライセンスと [op7418](https://github.com/op7418) の帰属表示を保持します。
+
+[skill]: https://docs.anthropic.com/en/docs/claude-code/skills
+[guizang]: https://github.com/op7418/guizang-ppt-skill
+[acd2]: https://github.com/VoltAgent/awesome-design-md
+[ocod]: https://github.com/OpenCoworkAI/open-codesign

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for thinking about contributing. OD is small on purpose — most of the v
 
 This guide tells you exactly where to look for each type of contribution and what bar a PR has to clear before we merge it.
 
-<p align="center"><b>English</b> · <a href="CONTRIBUTING.zh-CN.md">简体中文</a></p>
+<p align="center"><b>English</b> · <a href="CONTRIBUTING.zh-CN.md">简体中文</a> · <a href="CONTRIBUTING.ja-JP.md">日本語</a></p>
 
 ---
 

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -4,7 +4,7 @@
 
 这份指南会告诉你：每种贡献该往哪里看、合并之前 PR 需要过哪些线。
 
-<p align="center"><a href="CONTRIBUTING.md">English</a> · <b>简体中文</b></p>
+<p align="center"><a href="CONTRIBUTING.md">English</a> · <b>简体中文</b> · <a href="CONTRIBUTING.ja-JP.md">日本語</a></p>
 
 ---
 

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -613,7 +613,7 @@ Issue、PR、新 Skill、新 Design System を歓迎します。最も効果の�
 - **Design System を追加** — [`design-systems/<brand>/`](design-systems/) に 9 セクションスキーマの `DESIGN.md` をドロップ。
 - **新しい coding-agent CLI を接続** — [`apps/daemon/src/agents.ts`](apps/daemon/src/agents.ts) にエントリを 1 つ追加。
 
-完全なワークフロー、マージ基準、コードスタイル、受け入れない PR の種類 → [`CONTRIBUTING.md`](CONTRIBUTING.md)（[简体中文](CONTRIBUTING.zh-CN.md)）。
+完全なワークフロー、マージ基準、コードスタイル、受け入れない PR の種類 → [`CONTRIBUTING.ja-JP.md`](CONTRIBUTING.ja-JP.md)（[English](CONTRIBUTING.md) · [简体中文](CONTRIBUTING.zh-CN.md)）。
 
 ## コントリビューター
 

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -1,0 +1,650 @@
+# Open Design
+
+> **[Claude Design][cd] のオープンソース代替。** ローカルファースト、Vercel デプロイ可能、あらゆるレイヤーで BYOK（Bring Your Own Key） — `PATH` 上で自動検出される **10 種類の coding-agent CLI**（Claude Code、Codex、Cursor Agent、Gemini CLI、OpenCode、Qwen、GitHub Copilot CLI、Hermes、Kimi、Pi）がデザインエンジンとなり、**31 個の組み合わせ可能な Skill** と **72 種のブランドグレード Design System** で駆動されます。CLI が未インストールでも、OpenAI 互換の BYOK プロキシ `/api/proxy/stream` で同じループを spawn なしで実行できます。
+
+<p align="center">
+  <img src="docs/assets/banner.png" alt="Open Design — ノートパソコン上のエージェントとデザインする" width="100%" />
+</p>
+
+<p align="center">
+  <a href="https://github.com/nexu-io/open-design/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/nexu-io/open-design?style=for-the-badge&labelColor=0d1117&color=ffd700&logo=github&logoColor=white" /></a>
+  <a href="https://github.com/nexu-io/open-design/network/members"><img alt="Forks" src="https://img.shields.io/github/forks/nexu-io/open-design?style=for-the-badge&labelColor=0d1117&color=2ecc71&logo=github&logoColor=white" /></a>
+  <a href="https://github.com/nexu-io/open-design/issues"><img alt="Issues" src="https://img.shields.io/github/issues/nexu-io/open-design?style=for-the-badge&labelColor=0d1117&color=ff6b6b&logo=github&logoColor=white" /></a>
+  <a href="https://github.com/nexu-io/open-design/pulls"><img alt="Pull Requests" src="https://img.shields.io/github/issues-pr/nexu-io/open-design?style=for-the-badge&labelColor=0d1117&color=9b59b6&logo=github&logoColor=white" /></a>
+  <a href="https://github.com/nexu-io/open-design/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/nexu-io/open-design?style=for-the-badge&labelColor=0d1117&color=3498db&logo=github&logoColor=white" /></a>
+  <a href="https://github.com/nexu-io/open-design/commits/main"><img alt="Commit activity" src="https://img.shields.io/github/commit-activity/m/nexu-io/open-design?style=for-the-badge&labelColor=0d1117&color=e67e22&logo=git&logoColor=white" /></a>
+  <a href="https://github.com/nexu-io/open-design/commits/main"><img alt="Last commit" src="https://img.shields.io/github/last-commit/nexu-io/open-design?style=for-the-badge&labelColor=0d1117&color=8e44ad&logo=git&logoColor=white" /></a>
+</p>
+
+<p align="center">
+  <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache%202.0-blue.svg?style=flat-square" /></a>
+  <a href="#対応-coding-agent"><img alt="Agents" src="https://img.shields.io/badge/agents-10%20CLIs%20%2B%20BYOK%20proxy-black?style=flat-square" /></a>
+  <a href="#design-system">
+  <img alt="Design systems" src="https://img.shields.io/badge/design%20systems-72-orange?style=flat-square" /></a>
+  <a href="#組み込み-skill"><img alt="Skills" src="https://img.shields.io/badge/skills-31-teal?style=flat-square" /></a>
+  <a href="QUICKSTART.md"><img alt="Quickstart" src="https://img.shields.io/badge/quickstart-3%20commands-green?style=flat-square" /></a>
+</p>
+
+<p align="center"><a href="README.md">English</a> · <a href="README.zh-CN.md">简体中文</a> · <a href="README.ko.md">한국어</a> · <b>日本語</b></p>
+
+---
+
+## なぜこれを作ったのか
+
+Anthropic の [Claude Design][cd]（2026-04-17 リリース、Opus 4.7 搭載）は、LLM が文章を書くのをやめてデザイン成果物を直接出力し始めたらどうなるかを世に示しました。瞬く間にバズり — そして**クローズドソース**、有料限定、クラウド限定、Anthropic のモデルと Anthropic の Skill に縛られたままでした。checkout もセルフホストも Vercel デプロイも、エージェントの差し替えもできません。
+
+**Open Design（OD）はそのオープンソース代替です。** 同じループ、同じ「artifact-first」のメンタルモデル、しかしロックインなし。私たちはエージェントを同梱しません — あなたのノートパソコンにある最強の coding agent がすでにインストール済みです。それを Skill 駆動のデザインワークフローに接続するのが私たちの仕事です。ローカルでは `pnpm tools-dev` で完結し、Web レイヤーは Vercel にデプロイ可能で、すべてのレイヤーが BYOK です。
+
+「`雑誌風のシードラウンド pitch deck を作って`」と入力してください。モデルが最初の 1 ピクセルを描く前に、**初期化質問フォーム**がポップアップします。エージェントは 5 つの厳選されたビジュアルディレクションから 1 つを選びます。ライブの `TodoWrite` 計画カードが UI にストリーミングされます。Daemon がディスク上に実際のプロジェクトフォルダを構築し、seed テンプレート、レイアウトライブラリ、セルフチェック用チェックリストを配置します。エージェントはそれらを**pre-flight で強制的に**読み取り、自身の出力に対して**五次元評価**を実行し、数秒後に `<artifact>` を 1 つ出力してサンドボックス iframe にレンダリングします。
+
+これは「AI がデザインを試みる」ではありません。プロンプトスタックによって、使えるファイルシステムと、決定論的なカラーパレットライブラリと、チェックリスト文化を持つシニアデザイナーのように振る舞うよう訓練された AI です — まさに Claude Design が設定した水準そのもの、ただしオープンで、あなたのものです。
+
+OD は 4 つのオープンソースプロジェクトの上に立っています：
+
+- [**`alchaincyf/huashu-design`**（花叔の画術）](https://github.com/alchaincyf/huashu-design) — デザイン哲学の羅針盤。Junior-Designer ワークフロー、5 ステップのブランドアセットプロトコル、anti-AI-slop チェックリスト、五次元セルフ評価、そしてディレクションピッカーの背後にある「5 流派 × 20 のデザイン哲学」のアイデア — すべて [`apps/web/src/prompts/discovery.ts`](apps/web/src/prompts/discovery.ts) に蒸留されています。
+- [**`op7418/guizang-ppt-skill`**（歸藏の雑誌風 PPT Skill）](https://github.com/op7418/guizang-ppt-skill) — Deck モード。[`skills/guizang-ppt/`](skills/guizang-ppt/) 以下にオリジナルのまま同梱、元の LICENSE を保持。雑誌レイアウト、WebGL hero、P0/P1/P2 チェックリスト。
+- [**`OpenCoworkAI/open-codesign`**](https://github.com/OpenCoworkAI/open-codesign) — UX の北極星であり、最も近い同類プロジェクト。初のオープンソース Claude-Design 代替。ストリーミング artifact ループ、サンドボックス iframe プレビュー（React 18 + Babel 同梱）、ライブエージェントパネル（todo + tool calls + 中断可能な生成）、5 種類のエクスポート形式リスト（HTML / PDF / PPTX / ZIP / Markdown）を借用。形態では意図的に分岐しています — 彼らは [`pi-ai`][piai] を同梱するデスクトップ Electron アプリ、私たちは既存の CLI に委任する Web アプリ + ローカル daemon です。
+- [**`multica-ai/multica`**](https://github.com/multica-ai/multica) — Daemon とランタイムのアーキテクチャ。PATH スキャンによるエージェント検出、ローカル daemon を唯一の特権プロセスとする思想、agent-as-teammate の世界観。
+
+## 概要
+
+| | 提供される機能 |
+|---|---|
+| **Coding-agent CLI（10 種類）** | Claude Code · Codex CLI · Cursor Agent · Gemini CLI · OpenCode · Qwen Code · GitHub Copilot CLI · Hermes（ACP）· Kimi CLI（ACP）· Pi（RPC）— `PATH` 上で自動検出、ピッカーでワンクリック切り替え |
+| **BYOK フォールバック** | OpenAI 互換プロキシ `/api/proxy/stream` — `baseUrl` + `apiKey` + `model` を貼れば、任意のベンダー（Anthropic-via-OpenAI、DeepSeek、Groq、MiMo、OpenRouter、セルフホスト vLLM、その他の OpenAI 互換プロバイダ）がエンジンになります。daemon 側で loopback / link-local / RFC1918 を拒否し SSRF を防御。 |
+| **組み込み Design System** | **72 種** — 2 つの手書きスターター + [`awesome-design-md`][acd2] からインポートした 70 のプロダクトシステム（Linear、Stripe、Vercel、Airbnb、Tesla、Notion、Anthropic、Apple、Cursor、Supabase、Figma、小紅書…） |
+| **組み込み Skill** | **31 個** — `prototype` モード 27 個（web-prototype、saas-landing、dashboard、mobile-app、gamified-app、social-carousel、magazine-poster、dating-web、sprite-animation、motion-frames、critique、tweaks、wireframe-sketch、pm-spec、eng-runbook、finance-report、hr-onboarding、invoice、kanban-board、team-okrs…）+ `deck` モード 4 個（`guizang-ppt` · `simple-deck` · `replit-deck` · `weekly-update`）。ピッカーは `scenario` でグループ化：design / marketing / operation / engineering / product / finance / hr / sale / personal。 |
+| **ビジュアルディレクション** | 5 つの厳選流派（Editorial Monocle · Modern Minimal · Warm Soft · Tech Utility · Brutalist Experimental）— 各々に OKLch パレット + フォントスタック付き（[`apps/web/src/prompts/directions.ts`](apps/web/src/prompts/directions.ts)） |
+| **デバイスフレーム** | iPhone 15 Pro · Pixel · iPad Pro · MacBook · Browser Chrome — ピクセル単位で正確、Skill 間で共有、[`assets/frames/`](assets/frames/) に集約 |
+| **エージェントランタイム** | ローカル daemon がプロジェクトフォルダ内で CLI を spawn — エージェントは実際のディスク上で `Read` / `Write` / `Bash` / `WebFetch` を使用。各 adapter に Windows `ENAMETOOLONG` フォールバック（stdin / 一時 prompt ファイル）あり |
+| **インポート** | [Claude Design][cd] のエクスポート ZIP をウェルカムダイアログにドロップ — `POST /api/import/claude-design` が実プロジェクトとして展開し、Anthropic の中断箇所からエージェントが編集を続行 |
+| **永続化** | SQLite（`.od/app.sqlite`）：projects · conversations · messages · tabs · ユーザー templates。翌日開いても、todo カードと開いていたファイルはそのまま。 |
+| **ライフサイクル** | 唯一のエントリポイント `pnpm tools-dev`（start / stop / run / status / logs / inspect / check）— 型付き sidecar stamp で daemon + web（+ desktop）を起動 |
+| **デスクトップ** | オプションの Electron シェル：サンドボックスレンダラ + sidecar IPC（STATUS / EVAL / SCREENSHOT / CONSOLE / CLICK / SHUTDOWN）— 同じチャネルで `tools-dev inspect desktop screenshot` を駆動、E2E テスト対応 |
+| **デプロイ先** | ローカル（`pnpm tools-dev`）· Vercel Web レイヤー · パッケージ版 Electron（`apps/packaged/` プレースホルダー） |
+| **ライセンス** | Apache-2.0 |
+
+[acd2]: https://github.com/VoltAgent/awesome-design-md
+
+## デモ
+
+<table>
+<tr>
+<td width="50%">
+<img src="docs/screenshots/01-entry-view.png" alt="01 · エントリビュー" /><br/>
+<sub><b>エントリビュー</b> — Skill を選び、Design System を選び、要件を入力。プロトタイプ、デッキ、モバイルアプリ、ダッシュボード、エディトリアルページ — すべて同じ画面で。</sub>
+</td>
+<td width="50%">
+<img src="docs/screenshots/02-question-form.png" alt="02 · 初期化質問フォーム" /><br/>
+<sub><b>初期化質問フォーム</b> — モデルが 1 ピクセルも描く前に、OD が要件をロック：surface、ターゲット、トーン、ブランドコンテキスト、規模。30 秒のラジオ選択が 30 分の手戻りを消し去ります。</sub>
+</td>
+</tr>
+<tr>
+<td width="50%">
+<img src="docs/screenshots/03-direction-picker.png" alt="03 · ディレクションピッカー" /><br/>
+<sub><b>ディレクションピッカー</b> — ユーザーにブランドコンテキストがない場合、エージェントが 5 つの厳選ディレクション（Monocle / Modern Minimal / Tech Utility / Brutalist / Soft Warm）を提示する 2 つ目のフォームを表示。ラジオ 1 クリックでパレット + フォントスタックが確定、フリースタイルの余地なし。</sub>
+</td>
+<td width="50%">
+<img src="docs/screenshots/04-todo-progress.png" alt="04 · ライブ todo 進捗" /><br/>
+<sub><b>ライブ todo 進捗</b> — エージェントの計画がライブカードとして UI に流れ込みます。<code>in_progress</code> → <code>completed</code> がリアルタイムで更新。ユーザーは最小コストで途中介入・軌道修正が可能。</sub>
+</td>
+</tr>
+<tr>
+<td width="50%">
+<img src="docs/screenshots/05-preview-iframe.png" alt="05 · サンドボックスプレビュー" /><br/>
+<sub><b>サンドボックスプレビュー</b> — すべての <code>&lt;artifact&gt;</code> がクリーンな srcdoc iframe でレンダリングされます。ファイルワークスペースでその場編集可能。HTML / PDF / ZIP でダウンロード。</sub>
+</td>
+<td width="50%">
+<img src="docs/screenshots/06-design-systems-library.png" alt="06 · 72 種 Design System ライブラリ" /><br/>
+<sub><b>72 種 Design System ライブラリ</b> — 各プロダクトシステムが 4 色のカラーカードを表示。クリックで完全な <code>DESIGN.md</code>、スウォッチグリッド、ライブショーケースを閲覧。</sub>
+</td>
+</tr>
+<tr>
+<td width="50%">
+<img src="docs/screenshots/07-magazine-deck.png" alt="07 · 雑誌風デッキ" /><br/>
+<sub><b>Deck モード（guizang-ppt）</b> — 同梱の <a href="https://github.com/op7418/guizang-ppt-skill"><code>guizang-ppt-skill</code></a> をそのまま統合。雑誌レイアウト、WebGL hero 背景、単一ファイル HTML 出力、PDF エクスポート対応。</sub>
+</td>
+<td width="50%">
+<img src="docs/screenshots/08-mobile-app.png" alt="08 · モバイルプロトタイプ" /><br/>
+<sub><b>モバイルプロトタイプ</b> — ピクセル単位で正確な iPhone 15 Pro クローム（Dynamic Island、ステータスバー SVG、ホームインジケータ）。マルチスクリーンプロトタイプは <code>/frames/</code> の共有アセットを再利用するため、エージェントが端末を描き直す必要は一切ありません。</sub>
+</td>
+</tr>
+</table>
+
+## 組み込み Skill
+
+**31 個の Skill が同梱されています。** 各 Skill は [`skills/`](skills/) 配下のフォルダで、Claude Code の [`SKILL.md`][skill] 規約に従いつつ、daemon がそのままパースする OD 拡張 `od:` frontmatter を持ちます — `mode`、`platform`、`scenario`、`preview.type`、`design_system.requires`、`default_for`、`featured`、`fidelity`、`speaker_notes`、`animations`、`example_prompt`（[`apps/daemon/src/skills.ts`](apps/daemon/src/skills.ts)）。
+
+2 つのトップレベル **mode** がカタログを構成します：**`prototype`**（27 個 — 雑誌風ランディングからモバイル画面、PM 仕様書まで、単一ページ artifact としてレンダリングされるすべて）と **`deck`**（4 個 — デッキフレームワーク付きの横スワイプ型プレゼンテーション）。**`scenario`** フィールドがピッカーのグループ化に使われます：`design` · `marketing` · `operation` · `engineering` · `product` · `finance` · `hr` · `sale` · `personal`。
+
+### ショーケース
+
+ビジュアル的に最も特徴的で、最初に試す Skill として最適なものです。各 Skill には実際の `example.html` が付属しており、リポジトリから直接開いてエージェントの出力を確認できます — 認証もセットアップも不要。
+
+<table>
+<tr>
+<td width="50%" valign="top">
+<a href="skills/dating-web/"><img src="docs/screenshots/skills/dating-web.png" alt="dating-web" /></a><br/>
+<sub><b><a href="skills/dating-web/"><code>dating-web</code></a></b> · <i>prototype</i><br/>コンシューマー向けマッチングダッシュボード — 左サイドバー、ティッカーバー、KPI、30 日間の相互マッチチャート、エディトリアルタイポグラフィ。</sub>
+</td>
+<td width="50%" valign="top">
+<a href="skills/digital-eguide/"><img src="docs/screenshots/skills/digital-eguide.png" alt="digital-eguide" /></a><br/>
+<sub><b><a href="skills/digital-eguide/"><code>digital-eguide</code></a></b> · <i>template</i><br/>2 見開きのデジタル e-guide — 表紙（タイトル、著者、TOC ティーザー）+ レッスン見開き（プルクオート + ステップリスト）。クリエイター / ライフスタイルトーン。</sub>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+<a href="skills/email-marketing/"><img src="docs/screenshots/skills/email-marketing.png" alt="email-marketing" /></a><br/>
+<sub><b><a href="skills/email-marketing/"><code>email-marketing</code></a></b> · <i>prototype</i><br/>ブランド新製品発売 HTML メール — ワードマーク、hero 画像、見出しロックアップ、CTA、スペックグリッド。中央揃え単一カラム + テーブルフォールバックでメールクライアント安全。</sub>
+</td>
+<td width="50%" valign="top">
+<a href="skills/gamified-app/"><img src="docs/screenshots/skills/gamified-app.png" alt="gamified-app" /></a><br/>
+<sub><b><a href="skills/gamified-app/"><code>gamified-app</code></a></b> · <i>prototype</i><br/>ダークステージ上の 3 画面ゲーミフィケーションモバイルアプリプロトタイプ — カバー / 今日のクエスト（XP リボン + レベルバー）/ クエスト詳細。</sub>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+<a href="skills/mobile-onboarding/"><img src="docs/screenshots/skills/mobile-onboarding.png" alt="mobile-onboarding" /></a><br/>
+<sub><b><a href="skills/mobile-onboarding/"><code>mobile-onboarding</code></a></b> · <i>prototype</i><br/>3 画面モバイルオンボーディングフロー — スプラッシュ、バリュープロポジション、サインイン。ステータスバー、スワイプドット、プライマリ CTA。</sub>
+</td>
+<td width="50%" valign="top">
+<a href="skills/motion-frames/"><img src="docs/screenshots/skills/motion-frames.png" alt="motion-frames" /></a><br/>
+<sub><b><a href="skills/motion-frames/"><code>motion-frames</code></a></b> · <i>prototype</i><br/>ループ CSS アニメーション付きの単一フレームモーションデザイン hero — 回転タイプリング、地球、タイマー。HyperFrames 等へのハンドオフ対応。</sub>
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+<a href="skills/social-carousel/"><img src="docs/screenshots/skills/social-carousel.png" alt="social-carousel" /></a><br/>
+<sub><b><a href="skills/social-carousel/"><code>social-carousel</code></a></b> · <i>prototype</i><br/>1080×1080 の 3 枚 SNS カルーセル — シネマティックなパネル、シリーズを横断する大見出し、ブランドマーク、ループインジケータ。</sub>
+</td>
+<td width="50%" valign="top">
+<a href="skills/sprite-animation/"><img src="docs/screenshots/skills/sprite-animation.png" alt="sprite-animation" /></a><br/>
+<sub><b><a href="skills/sprite-animation/"><code>sprite-animation</code></a></b> · <i>prototype</i><br/>ピクセル / 8-bit アニメーション解説スライド — クリーム地フルブリード、アニメーションピクセルマスコット、キネティックな日本語ディスプレイタイプ、ループ CSS keyframes。</sub>
+</td>
+</tr>
+</table>
+
+### デザイン & マーケティング系（prototype モード）
+
+| Skill | プラットフォーム | シナリオ | 出力 |
+|---|---|---|---|
+| [`web-prototype`](skills/web-prototype/) | デスクトップ | design | 単一ページ HTML — ランディング、マーケティング、hero（prototype のデフォルト） |
+| [`saas-landing`](skills/saas-landing/) | デスクトップ | marketing | hero / features / pricing / CTA マーケティングレイアウト |
+| [`dashboard`](skills/dashboard/) | デスクトップ | operation | サイドバー + データ密度の高い管理画面 |
+| [`pricing-page`](skills/pricing-page/) | デスクトップ | sale | 単独料金ページ + 比較表 |
+| [`docs-page`](skills/docs-page/) | デスクトップ | engineering | 3 カラムドキュメントレイアウト |
+| [`blog-post`](skills/blog-post/) | デスクトップ | marketing | エディトリアル長文 |
+| [`mobile-app`](skills/mobile-app/) | モバイル | design | iPhone 15 Pro / Pixel フレーム付きアプリ画面 |
+| [`mobile-onboarding`](skills/mobile-onboarding/) | モバイル | design | マルチスクリーンモバイルオンボーディング（スプラッシュ · バリュープロポジション · サインイン） |
+| [`gamified-app`](skills/gamified-app/) | モバイル | personal | 3 画面ゲーミフィケーションアプリプロトタイプ |
+| [`email-marketing`](skills/email-marketing/) | デスクトップ | marketing | ブランド新製品発売メール（テーブルフォールバック対応） |
+| [`social-carousel`](skills/social-carousel/) | デスクトップ | marketing | 1080×1080 3 枚 SNS カルーセル |
+| [`magazine-poster`](skills/magazine-poster/) | デスクトップ | marketing | 単一ページ雑誌風ポスター |
+| [`motion-frames`](skills/motion-frames/) | デスクトップ | marketing | CSS ループアニメーション付きモーション hero |
+| [`sprite-animation`](skills/sprite-animation/) | デスクトップ | marketing | ピクセル / 8-bit アニメーション解説 |
+| [`dating-web`](skills/dating-web/) | デスクトップ | personal | コンシューマー向けマッチングダッシュボード |
+| [`digital-eguide`](skills/digital-eguide/) | デスクトップ | marketing | 2 見開きデジタル e-guide（表紙 + レッスン見開き） |
+| [`wireframe-sketch`](skills/wireframe-sketch/) | デスクトップ | design | 手描きスケッチ風ワイヤーフレーム — 「まず目に見えるものを早く出す」初期パス |
+| [`critique`](skills/critique/) | デスクトップ | design | 五次元セルフ評価スコアシート（Philosophy · Hierarchy · Detail · Function · Innovation） |
+| [`tweaks`](skills/tweaks/) | デスクトップ | design | AI が出力する tweaks パネル — モデル自身が調整すべきパラメータを提示 |
+
+### Deck 系（deck モード）
+
+| Skill | デフォルト | 出力 |
+|---|---|---|
+| [`guizang-ppt`](skills/guizang-ppt/) | **deck のデフォルト** | 雑誌風 Web PPT — [op7418/guizang-ppt-skill][guizang] からそのまま同梱、元の LICENSE 保持 |
+| [`simple-deck`](skills/simple-deck/) | — | ミニマル横スワイプデッキ |
+| [`replit-deck`](skills/replit-deck/) | — | プロダクトウォークスルーデッキ（Replit スタイル） |
+| [`weekly-update`](skills/weekly-update/) | — | チーム週次報告デッキ（進捗 · ブロッカー · 次のステップ） |
+
+### ドキュメント & 業務系（prototype モード、ドキュメント系シナリオ）
+
+| Skill | シナリオ | 出力 |
+|---|---|---|
+| [`pm-spec`](skills/pm-spec/) | product | PM 仕様書 + 目次 + 意思決定ログ |
+| [`team-okrs`](skills/team-okrs/) | product | OKR スコアシート |
+| [`meeting-notes`](skills/meeting-notes/) | operation | 会議議事録 |
+| [`kanban-board`](skills/kanban-board/) | operation | カンバンボードスナップショット |
+| [`eng-runbook`](skills/eng-runbook/) | engineering | インシデント Runbook |
+| [`finance-report`](skills/finance-report/) | finance | 経営層向け財務サマリー |
+| [`invoice`](skills/invoice/) | finance | 単一ページ請求書 |
+| [`hr-onboarding`](skills/hr-onboarding/) | hr | 職位オンボーディング計画 |
+
+Skill の追加はフォルダ 1 つで完了します。拡張 frontmatter の詳細は [`docs/skills-protocol.md`](docs/skills-protocol.md) を参照し、既存の Skill を fork して daemon を再起動すればピッカーに表示されます。カタログエンドポイントは `GET /api/skills`、個別 Skill の seed 組み立て（テンプレート + 副ファイル）は `GET /api/skills/:id/example` です。
+
+## 6 つの基本設計思想
+
+### 1 · エージェントは同梱しない — あなたのもので十分
+
+Daemon は起動時に `PATH` を走査し、[`claude`](https://docs.anthropic.com/en/docs/claude-code)、[`codex`](https://github.com/openai/codex)、[`cursor-agent`](https://www.cursor.com/cli)、[`gemini`](https://github.com/google-gemini/gemini-cli)、[`opencode`](https://opencode.ai/)、[`qwen`](https://github.com/QwenLM/qwen-code)、[`copilot`](https://github.com/features/copilot/cli)、`hermes`、`kimi`、[`pi`](https://github.com/mariozechner/pi-ai) を検索します。見つかったものすべてが候補デザインエンジンになります — stdio 経由で CLI ごとに 1 つの adapter を持ち、モデルピッカーからワンクリックで切り替え可能。[`multica`](https://github.com/multica-ai/multica) と [`cc-switch`](https://github.com/farion1231/cc-switch) に着想を得ています。CLI が 1 つもない？`POST /api/proxy/stream` が spawn を除いた同じパイプラインです — 任意の OpenAI 互換 `baseUrl` + `apiKey` を貼れば、daemon が SSE チャンクをブラウザに転送し、loopback / link-local / RFC1918 はエッジで拒否されます。
+
+### 2 · Skill はファイルであり、プラグインではない
+
+Claude Code の [`SKILL.md` 規約](https://docs.anthropic.com/en/docs/claude-code/skills)に従い、各 Skill は `SKILL.md` + `assets/` + `references/` です。[`skills/`](skills/) にフォルダを入れて daemon を再起動すれば、ピッカーに表示されます。同梱の `magazine-web-ppt` は [`op7418/guizang-ppt-skill`](https://github.com/op7418/guizang-ppt-skill) を**そのまま**同梱 — 元の LICENSE 保持、元の帰属表示保持。
+
+### 3 · Design System は移植可能な Markdown であり、theme JSON ではない
+
+[`VoltAgent/awesome-design-md`][acd2] の 9 セクション `DESIGN.md` スキーマ — color、typography、spacing、layout、components、motion、voice、brand、anti-patterns。すべての artifact はアクティブなシステムからトークンを読み取ります。システムを切り替えれば、次のレンダリングは新しいトークンを使用します。ドロップダウンには **Linear、Stripe、Vercel、Airbnb、Tesla、Notion、Apple、Anthropic、Cursor、Supabase、Figma、Resend、Raycast、Lovable、Cohere、Mistral、ElevenLabs、X.AI、Spotify、Webflow、Sanity、PostHog、Sentry、MongoDB、ClickHouse、Cal、Replicate、Clay、Composio、小紅書…** — 全 72 種が揃っています。
+
+### 4 · 初期化質問フォームが手戻りの 80% を解消
+
+OD のプロンプトスタックは `RULE 1` をハードコードしています：新しいデザイン要件はすべて `<question-form id="discovery">` で始まり、**コードではありません**。Surface · ターゲット · トーン · ブランドコンテキスト · 規模 · 制約。長い要件でもデザイン上の判断は残ります — ビジュアルトーン、カラースタンス、スケール — まさにフォームが 30 秒のラジオ選択で確定させるポイントです。方向を間違えたコストは 1 往復のチャットであり、完成済みのデッキではありません。
+
+これは [`huashu-design`](https://github.com/alchaincyf/huashu-design) から蒸留された **Junior-Designer モード**です：着手前に質問を一括で済ませ、早い段階で何か目に見えるもの（グレーブロックのワイヤーフレームでも可）を提示し、ユーザーが最小コストで軌道修正できるようにします。ブランドアセットプロトコル（特定 · ダウンロード · `grep` hex · `brand-spec.md` 作成 · 復唱）と組み合わせることで、出力が「AI のフリースタイル」から「資料を見てから描くデザイナー」に変わる最大の要因です。
+
+### 5 · Daemon がエージェントをあなたのノートパソコン上に感じさせる — 実際にそこにいるから
+
+Daemon は CLI を spawn する際、`cwd` を `.od/projects/<id>/` 配下のプロジェクト artifact フォルダに設定します。エージェントが使う `Read` / `Write` / `Bash` / `WebFetch` は実際のファイルシステムに作用する本物のツールです。Skill の `assets/template.html` を `Read` し、CSS から `grep` で hex 値を取得し、`brand-spec.md` を作成し、生成画像を配置し、`.pptx` / `.zip` / `.pdf` を出力できます — これらのファイルはターン終了時にファイルワークスペース上のダウンロードチップとして表示されます。セッション、会話、メッセージ、タブはすべてローカル SQLite に永続化されます — 翌日プロジェクトを開けば、エージェントの todo カードは昨日閉じた場所にそのまま残っています。
+
+### 6 · プロンプトスタック自体がプロダクト
+
+送信時に組み立てられるのは「system + user」ではありません。以下の構成です：
+
+```
+DISCOVERY ディレクティブ     （turn-1 フォーム、turn-2 ブランド分岐、TodoWrite、五次元評価）
+  + アイデンティティ憲章      （OFFICIAL_DESIGNER_PROMPT、anti-AI-slop、Junior Designer モード）
+  + アクティブな DESIGN.md    （72 種から選択）
+  + アクティブな SKILL.md     （31 個から選択）
+  + プロジェクトメタデータ     （kind、fidelity、speakerNotes、animations、インスピレーション system id）
+  + Skill 副ファイル         （自動注入 pre-flight：assets/template.html + references/*.md を先読み）
+  + （deck kind かつ Skill seed なし時） DECK_FRAMEWORK_DIRECTIVE   （nav / counter / scroll / print）
+```
+
+すべてのレイヤーが組み合わせ可能で、すべてのレイヤーが編集可能なファイルです。実際の契約は [`apps/web/src/prompts/system.ts`](apps/web/src/prompts/system.ts) と [`apps/web/src/prompts/discovery.ts`](apps/web/src/prompts/discovery.ts) で確認できます。
+
+## アーキテクチャ
+
+```
+┌───────────────── ブラウザ（Next.js 16）─────────────────────────┐
+│  chat · ファイルワークスペース · iframe プレビュー · 設定 · インポート │
+└──────────────┬──────────────────────────────────┬──────────────┘
+               │ /api/*（dev は rewrites 経由）     │
+               ▼                                   ▼
+   ┌──────────────────────────────────┐  /api/proxy/stream (SSE)
+   │  ローカル daemon（Express + SQLite）│  ─→ 任意の OpenAI 互換
+   │                                   │      エンドポイント（BYOK）
+   │  /api/agents         /api/skills  │      SSRF 防御付き
+   │  /api/design-systems /api/projects/…
+   │  /api/chat (SSE)     /api/proxy/stream (SSE)
+   │  /api/templates      /api/import/claude-design
+   │  /api/artifacts/save /api/artifacts/lint
+   │  /api/upload         /api/projects/:id/files…
+   │  /artifacts (静的)   /frames (静的)
+   │
+   │  オプション sidecar IPC：/tmp/open-design/ipc/<ns>/<app>.sock
+   │  （STATUS · EVAL · SCREENSHOT · CONSOLE · CLICK · SHUTDOWN）
+   └─────────┬───────────────────────────┘
+             │ spawn(cli, [...], { cwd: .od/projects/<id> })
+             ▼
+   ┌──────────────────────────────────────────────────────────────────┐
+   │  claude · codex · gemini · opencode · cursor-agent · qwen        │
+   │  copilot · hermes (ACP) · kimi (ACP) · pi (RPC)                  │
+   │  SKILL.md + DESIGN.md を読み、artifact をディスクに書き出す         │
+   └──────────────────────────────────────────────────────────────────┘
+```
+
+| レイヤー | 技術スタック |
+|---|---|
+| フロントエンド | Next.js 16 App Router + React 18 + TypeScript、Vercel デプロイ可能 |
+| Daemon | Node 24 · Express · SSE ストリーミング · `better-sqlite3`；テーブル：`projects` · `conversations` · `messages` · `tabs` · `templates` |
+| エージェント転送 | `child_process.spawn`；Claude Code は `claude-stream-json`、Copilot は `copilot-stream-json`、Codex / Gemini / OpenCode / Cursor Agent は `json-event-stream`（CLI ごとのパーサー）、Hermes / Kimi は `acp-json-rpc`（Agent Client Protocol）、Pi は `pi-rpc`（stdio JSON-RPC）、Qwen Code は `plain` |
+| BYOK プロキシ | `POST /api/proxy/stream` → OpenAI 互換 `/v1/chat/completions` SSE パススルー；daemon エッジで loopback / link-local / RFC1918 を拒否 |
+| ストレージ | プレーンファイル `.od/projects/<id>/` + SQLite `.od/app.sqlite`（gitignore 済み、daemon 起動時に自動作成）。`OD_DATA_DIR` でルートを変更可能（テスト分離用） |
+| プレビュー | サンドボックス iframe（`srcdoc`）+ Skill ごとの `<artifact>` パーサー（[`apps/web/src/artifacts/parser.ts`](apps/web/src/artifacts/parser.ts)） |
+| エクスポート | HTML（インラインアセット）· PDF（ブラウザ印刷、デッキ対応）· PPTX（エージェント駆動、Skill 経由）· ZIP（archiver）· Markdown |
+| ライフサイクル | `pnpm tools-dev start \| stop \| run \| status \| logs \| inspect \| check`；ポートは `--daemon-port` / `--web-port`、ネームスペースは `--namespace` |
+| デスクトップ（オプション） | Electron シェル — sidecar IPC 経由で Web URL を取得、ポート推測なし；同じチャネル（`STATUS`/`EVAL`/`SCREENSHOT`/`CONSOLE`/`CLICK`/`SHUTDOWN`）で `tools-dev inspect desktop …` を駆動し E2E 対応 |
+
+## クイックスタート
+
+```bash
+git clone https://github.com/nexu-io/open-design.git
+cd open-design
+corepack enable
+corepack pnpm --version   # 10.33.2 と表示されるはず
+pnpm install
+pnpm tools-dev run web
+# tools-dev が出力した Web URL を開く
+```
+
+環境要件：Node `~24`、pnpm `10.33.x`。`nvm` / `fnm` はあくまでオプションのヘルパーです。使用する場合は `pnpm install` の前に `nvm install 24 && nvm use 24` または `fnm install 24 && fnm use 24` を実行してください。
+
+デスクトップ / バックグラウンド起動、固定ポート再起動、メディア生成ディスパッチャの確認（`OD_BIN`、`OD_DAEMON_URL`、`apps/daemon/dist/cli.js`）は [`QUICKSTART.md`](QUICKSTART.md) を参照。
+
+初回ロード時：
+
+1. `PATH` 上のエージェント CLI を検出し、自動的に 1 つを選択。
+2. 31 個の Skill + 72 種の Design System をロード。
+3. ウェルカムダイアログが表示され、Anthropic キーの貼り付けを促す（BYOK フォールバックパスのみ必要）。
+4. **`./.od/` を自動作成** — SQLite プロジェクト DB、プロジェクトごとの artifact、保存されたレンダリングを格納するローカルランタイムフォルダ。`od init` ステップは不要、daemon が起動時に必要なディレクトリをすべて `mkdir` します。
+
+プロンプトを入力し、**Send** を押し、質問フォームの到着を確認、記入し、todo カードのストリーミングを見守り、artifact のレンダリングを確認。**Save to disk** をクリックするか、プロジェクト ZIP としてダウンロード。
+
+### 初回起動時の状態（`./.od/`）
+
+Daemon はリポジトリルートに 1 つの隠しフォルダを管理します。中身はすべて gitignore 済みのマシンローカルデータです — **絶対に commit しないでください**。
+
+```
+.od/
+├── app.sqlite                 ← プロジェクト · 会話 · メッセージ · 開いているタブ
+├── artifacts/                 ← Save to disk の一回限りレンダリング（タイムスタンプ付き）
+└── projects/<id>/             ← プロジェクトごとの作業ディレクトリ（エージェントの cwd）
+```
+
+| やりたいこと | 方法 |
+|---|---|
+| 中身を確認する | `ls -la .od && sqlite3 .od/app.sqlite '.tables'` |
+| 完全にリセット | `pnpm tools-dev stop` → `rm -rf .od` → `pnpm tools-dev run web` を再実行 |
+| 別の場所に移動 | 未対応 — パスはリポジトリルートからの相対パスで固定 |
+
+完全なファイルマップ、スクリプト、トラブルシューティング → [`QUICKSTART.md`](QUICKSTART.md)。
+
+## リポジトリ構成
+
+```
+open-design/
+├── README.md                      ← 英語
+├── README.zh-CN.md                ← 简体中文
+├── README.ja-JP.md                ← 本ファイル
+├── QUICKSTART.md                  ← 実行 / ビルド / デプロイガイド
+├── package.json                   ← 単一 bin: od
+│
+├── apps/
+│   ├── daemon/                    ← Node + Express、唯一のサーバー
+│   │   ├── src/                   ← TypeScript daemon ソース
+│   │   │   ├── cli.ts             ← `od` bin ソース、dist/cli.js にコンパイル
+│   │   │   ├── server.ts          ← /api/* ルート（projects、chat、files、exports）
+│   │   │   ├── agents.ts          ← PATH スキャナ + CLI ごとの argv ビルダー
+│   │   │   ├── claude-stream.ts   ← Claude Code stdout ストリーミング JSON パーサー
+│   │   │   ├── skills.ts          ← SKILL.md frontmatter ローダー
+│   │   │   └── db.ts              ← SQLite スキーマ（projects/messages/templates/tabs）
+│   │   ├── sidecar/               ← tools-dev daemon sidecar ラッパー
+│   │   └── tests/                 ← daemon パッケージテスト
+│   │
+│   └── web/                       ← Next.js 16 App Router + React クライアント
+│       ├── app/                   ← App Router エントリポイント
+│       ├── next.config.ts         ← dev rewrites + 本番 out/ 静的エクスポート
+│       └── src/                   ← React + TS クライアントモジュール
+│           ├── App.tsx            ← ルーティング、ブートストラップ、設定
+│           ├── components/        ← chat、composer、picker、preview、sketch…
+│           ├── prompts/           ← system、discovery、directions、deck framework
+│           ├── artifacts/         ← ストリーミング <artifact> パーサー + マニフェスト
+│           ├── runtime/           ← iframe srcdoc、markdown、エクスポートヘルパー
+│           ├── providers/         ← daemon SSE + BYOK API トランスポート
+│           └── state/             ← localStorage + daemon バックドプロジェクト状態
+│
+├── e2e/                           ← Playwright UI + 外部統合/Vitest ハーネス
+│
+├── packages/
+│   ├── contracts/                 ← web/daemon 共有アプリ contracts
+│   ├── sidecar-proto/             ← Open Design sidecar プロトコル contract
+│   ├── sidecar/                   ← 汎用 sidecar ランタイムプリミティブ
+│   └── platform/                  ← 汎用 process/platform プリミティブ
+│
+├── skills/                        ← 31 個の SKILL.md Skill バンドル（27 prototype + 4 deck）
+│   ├── web-prototype/             ← prototype のデフォルト
+│   ├── saas-landing/  dashboard/  pricing-page/  docs-page/  blog-post/
+│   ├── mobile-app/  mobile-onboarding/  gamified-app/
+│   ├── email-marketing/  social-carousel/  magazine-poster/
+│   ├── motion-frames/  sprite-animation/  digital-eguide/  dating-web/
+│   ├── critique/  tweaks/  wireframe-sketch/
+│   ├── pm-spec/  team-okrs/  meeting-notes/  kanban-board/
+│   ├── eng-runbook/  finance-report/  invoice/  hr-onboarding/
+│   ├── simple-deck/  replit-deck/  weekly-update/   ← deck モード
+│   └── guizang-ppt/               ← 同梱 magazine-web-ppt（deck のデフォルト）
+│       ├── SKILL.md
+│       ├── assets/template.html   ← seed
+│       └── references/{themes,layouts,components,checklist}.md
+│
+├── design-systems/                ← 72 種の DESIGN.md
+│   ├── default/                   ← Neutral Modern（スターター）
+│   ├── warm-editorial/            ← Warm Editorial（スターター）
+│   ├── linear-app/  vercel/  stripe/  airbnb/  notion/  cursor/  apple/  …
+│   └── README.md
+│
+├── assets/
+│   └── frames/                    ← Skill 間共有のデバイスフレーム
+│       ├── iphone-15-pro.html
+│       ├── android-pixel.html
+│       ├── ipad-pro.html
+│       ├── macbook.html
+│       └── browser-chrome.html
+│
+├── templates/
+│   └── deck-framework.html        ← デッキベースライン（nav / counter / print）
+│
+├── scripts/
+│   └── sync-design-systems.ts     ← 上流 awesome-design-md tarball からの再インポート
+│
+├── docs/
+│   ├── spec.md                    ← プロダクト定義、シナリオ、差別化
+│   ├── architecture.md            ← トポロジ、データフロー、コンポーネント
+│   ├── skills-protocol.md         ← SKILL.md 拡張 od: frontmatter
+│   ├── agent-adapters.md          ← CLI ごとの検出 + ディスパッチ
+│   ├── modes.md                   ← prototype / deck / template / design-system
+│   ├── references.md              ← 詳細な出典・系譜
+│   ├── roadmap.md                 ← フェーズ別デリバリー
+│   ├── schemas/                   ← JSON スキーマ
+│   └── examples/                  ← 標準 artifact サンプル
+│
+└── .od/                           ← ランタイムデータ、gitignore 済み、daemon 起動時に自動作成
+    ├── app.sqlite                 ← プロジェクト / 会話 / メッセージ / タブ
+    ├── projects/<id>/             ← プロジェクトごとの作業ディレクトリ（エージェントの cwd）
+    └── artifacts/                 ← 一回限りのレンダリング保存
+```
+
+## Design System
+
+<p align="center">
+  <img src="docs/assets/design-systems-library.png" alt="72 種の Design System ライブラリ — スタイルガイド見開き" width="100%" />
+</p>
+
+72 種がすぐ使えます。各システムは 1 つの [`DESIGN.md`](design-systems/README.md)：
+
+<details>
+<summary><b>全カタログ</b>（クリックで展開）</summary>
+
+**AI & LLM** — `claude` · `cohere` · `mistral-ai` · `minimax` · `together-ai` · `replicate` · `runwayml` · `elevenlabs` · `ollama` · `x-ai`
+
+**開発者ツール** — `cursor` · `vercel` · `linear-app` · `framer` · `expo` · `clickhouse` · `mongodb` · `supabase` · `hashicorp` · `posthog` · `sentry` · `warp` · `webflow` · `sanity` · `mintlify` · `lovable` · `composio` · `opencode-ai` · `voltagent`
+
+**プロダクティビティ** — `notion` · `figma` · `miro` · `airtable` · `superhuman` · `intercom` · `zapier` · `cal` · `clay` · `raycast`
+
+**フィンテック** — `stripe` · `coinbase` · `binance` · `kraken` · `mastercard` · `revolut` · `wise`
+
+**E コマース / モビリティ** — `shopify` · `airbnb` · `uber` · `nike` · `starbucks` · `pinterest`
+
+**メディア** — `spotify` · `playstation` · `wired` · `theverge` · `meta`
+
+**自動車** — `tesla` · `bmw` · `ferrari` · `lamborghini` · `bugatti` · `renault`
+
+**その他** — `apple` · `ibm` · `nvidia` · `vodafone` · `sentry` · `resend` · `spacex`
+
+**スターター** — `default`（Neutral Modern）· `warm-editorial`
+
+</details>
+
+ライブラリ全体は [`scripts/sync-design-systems.ts`](scripts/sync-design-systems.ts) を通じて [`VoltAgent/awesome-design-md`][acd2] からインポートされています。再実行で更新可能。
+
+## ビジュアルディレクション
+
+ユーザーにブランドアセットがない場合、エージェントは 5 つの厳選ディレクションを提示する 2 つ目のフォームを出力します — [`huashu-design` の「デザインディレクション顧問 · 5 流派 × 20 のデザイン哲学」フォールバック](https://github.com/alchaincyf/huashu-design#%E8%AE%BE%E8%AE%A1%E6%96%B9%E5%90%91%E9%A1%BE%E9%97%AE-fallback)を OD に適用したものです。各ディレクションは決定論的な仕様です — OKLch パレット、フォントスタック、レイアウトポスチャのヒント、リファレンス — エージェントはこれを seed テンプレートの `:root` にそのままバインドします。ラジオを 1 つクリックすれば、完全なビジュアルシステムが確定します。即興なし、AI slop なし。
+
+| ディレクション | ムード | リファレンス |
+|---|---|---|
+| Editorial — Monocle / FT | 印刷雑誌、インク + クリーム + ウォームラスト | Monocle · FT Weekend · NYT Magazine |
+| Modern minimal — Linear / Vercel | クール、構造的、ミニマルアクセント | Linear · Vercel · Stripe |
+| Tech utility | 情報密度、モノスペース、ターミナル風 | Bloomberg · Bauhaus ツール |
+| Brutalist | 生々しい、巨大タイプ、シャドウなし、鮮烈なアクセント | Bloomberg Businessweek · Achtung |
+| Soft warm | おおらか、低コントラスト、ピーチ系ニュートラル | Notion マーケティングページ · Apple Health |
+
+完全な仕様 → [`apps/web/src/prompts/directions.ts`](apps/web/src/prompts/directions.ts)。
+
+## チャット以外に同梱されているもの
+
+チャット / artifact ループが最も目立ちますが、OD を他と比較する前に把握しておく価値のある、目立たないが既に実装済みの機能がいくつかあります：
+
+- **Claude Design ZIP インポート。** claude.ai からのエクスポート ZIP をウェルカムダイアログにドロップ。`POST /api/import/claude-design` が `.od/projects/<id>/` に展開し、エントリファイルをタブとして開き、ローカルエージェント向けに「Anthropic の中断箇所から編集を続行」するプロンプトを用意します。再プロンプティング不要、「モデルに作り直してもらう」必要なし。（[`apps/daemon/src/server.ts`](apps/daemon/src/server.ts) — `/api/import/claude-design`）
+- **OpenAI 互換 BYOK プロキシ。** `POST /api/proxy/stream` は `{ baseUrl, apiKey, model, messages }` を受け取り、パスを正規化（`…/v1/chat/completions`）、SSE チャンクをブラウザに転送、loopback / link-local / RFC1918 を拒否して SSRF を防御。OpenAI chat スキーマを話す任意のベンダーが使えます — Anthropic-via-OpenAI shim、DeepSeek、Groq、MiMo、OpenRouter、セルフホスト vLLM。MiMo は自動的に `tool_choice: 'none'` が付加されます（tool スキーマがフリーフォーム生成と相性が悪いため）。
+- **ユーザー保存テンプレート。** レンダリング結果が気に入ったら、`POST /api/templates` で HTML + メタデータを SQLite `templates` テーブルにスナップショット。次のプロジェクトのピッカーに「あなたのテンプレート」行が追加されます — 同梱の 31 個と同じ選択画面で、ただしあなたのもの。
+- **タブ永続化。** 各プロジェクトは開いているファイルとアクティブタブを `tabs` テーブルに記録。翌日開いてもワークスペースは昨日の状態そのまま。
+- **Artifact lint API。** `POST /api/artifacts/lint` は生成された artifact に対して構造チェックを実行（`<artifact>` フレーミングの破損、必須副ファイルの欠落、古いパレットトークン）し、エージェントが次のターンで読み返せる findings を返します。五次元セルフ評価はこれを使ってスコアを vibes ではなくエビデンスに基づかせます。
+- **Sidecar プロトコル + デスクトップ自動化。** Daemon、web、desktop プロセスは型付き 5 フィールドスタンプ（`app · mode · namespace · ipc · source`）を持ち、`/tmp/open-design/ipc/<namespace>/<app>.sock` に JSON-RPC IPC チャネルを公開。`tools-dev inspect desktop status \| eval \| screenshot` はこのチャネル上で動作するため、ヘッドレス E2E テストが実際の Electron シェルに対して、カスタムハーネスなしで実行可能（[`packages/sidecar-proto/`](packages/sidecar-proto/)、[`apps/desktop/src/main/`](apps/desktop/src/main/)）。
+- **Windows フレンドリーな spawn。** 長いプロンプトで `CreateProcess` の約 32 KB argv 上限に達する adapter（Codex、Gemini、OpenCode、Cursor Agent、Qwen、Pi）はすべて stdin 経由でプロンプトを渡します。Claude Code と Copilot は `-p` を維持。stdin でも溢れる場合、daemon は一時 prompt ファイルにフォールバック。
+- **ネームスペースごとのランタイムデータ分離。** `OD_DATA_DIR` + `--namespace` で完全に分離された `.od/` スタイルのディレクトリツリーを提供。Playwright、beta チャネル、本番プロジェクトが同一 SQLite ファイルを共有することはありません。
+
+## anti-AI-slop 機構
+
+以下の機構はすべて [`huashu-design`](https://github.com/alchaincyf/huashu-design) のプレイブックを OD のプロンプトスタックに移植し、Skill 副ファイルの pre-flight で各 Skill に適用可能にしたものです。実際の文言は [`apps/web/src/prompts/discovery.ts`](apps/web/src/prompts/discovery.ts) を参照：
+
+- **まずフォーム。** Turn 1 は `<question-form>` のみ — thinking 禁止、tools 禁止、ナレーション禁止。ユーザーはラジオの速度でデフォルトを選択。
+- **ブランドアセットプロトコル。** ユーザーがスクリーンショットや URL を添付した場合、エージェントは 5 ステップのプロトコル（特定 · ダウンロード · grep hex · `brand-spec.md` 作成 · 復唱）を実行してから CSS を書きます。**記憶からブランドカラーを推測することは絶対にありません。**
+- **五次元評価。** `<artifact>` を出力する前に、エージェントはサイレントに 5 次元（哲学 / 階層 / 実行 / 具体性 / 抑制）で 1–5 点の自己評価を行います。いずれかが 3/5 未満なら退行と見なし、修正して再評価。2 パスが通常。
+- **P0/P1/P2 チェックリスト。** 各 Skill には `references/checklist.md` が付属し、ハードな P0 ゲートを含みます。エージェントは P0 をすべてパスしてから emit 可能。
+- **Slop ブラックリスト。** 攻撃的な紫グラデーション、汎用 emoji アイコン、左ボーダー付き角丸カード、手描き SVG 人物、Inter を *display* フォントとして使用、架空のメトリクス — すべてプロンプトで明示的に禁止。
+- **正直なプレースホルダー > 偽データ。** エージェントが実数値を持たない場合は `—` またはラベル付きグレーブロックを書き、「10 倍高速」とは書きません。
+
+## 比較
+
+| 軸 | [Claude Design][cd]（Anthropic） | [Open CoDesign][ocod] | **Open Design** |
+|---|---|---|---|
+| ライセンス | クローズド | MIT | **Apache-2.0** |
+| 形態 | Web (claude.ai) | デスクトップ (Electron) | **Web アプリ + ローカル daemon** |
+| Vercel デプロイ | ❌ | ❌ | **✅** |
+| エージェントランタイム | 同梱 (Opus 4.7) | 同梱 ([`pi-ai`][piai]) | **ユーザーの既存 CLI に委任** |
+| Skill | プロプライエタリ | 12 個のカスタム TS モジュール + `SKILL.md` | **31 個のファイルベース [`SKILL.md`][skill] バンドル、ドロップイン** |
+| Design System | プロプライエタリ | `DESIGN.md`（v0.2 ロードマップ） | **`DESIGN.md` × 72 種、すぐに利用可能** |
+| プロバイダ柔軟性 | Anthropic のみ | 7+（[`pi-ai`][piai]） | **10 種の CLI adapter + OpenAI 互換 BYOK プロキシ** |
+| 初期化質問フォーム | ❌ | ❌ | **✅ ハードルール、turn 1** |
+| ディレクションピッカー | ❌ | ❌ | **✅ 5 つの決定論的ディレクション** |
+| ライブ todo 進捗 + tool ストリーム | ❌ | ✅ | **✅**（UX パターンは open-codesign 由来） |
+| サンドボックス iframe プレビュー | ❌ | ✅ | **✅**（パターンは open-codesign 由来） |
+| Claude Design ZIP インポート | n/a | ❌ | **✅ `POST /api/import/claude-design` — Anthropic の中断箇所から編集続行** |
+| コメントモード精密編集 | ❌ | ✅ | 🚧 ロードマップ（open-codesign から移植予定） |
+| AI 出力 tweaks パネル | ❌ | ✅ | 🟡 部分的 — [`tweaks` Skill](skills/tweaks/) は出荷済み、専用チャットサイドパネル UX はロードマップ |
+| ファイルシステムレベルのワークスペース | ❌ | 部分的（Electron サンドボックス） | **✅ 実 cwd、実ツール、SQLite 永続化（projects · conversations · messages · tabs · templates）** |
+| 五次元セルフ評価 | ❌ | ❌ | **✅ emit 前ゲート** |
+| Artifact lint | ❌ | ❌ | **✅ `POST /api/artifacts/lint` — findings をエージェントにフィードバック** |
+| Sidecar IPC + ヘッドレスデスクトップ | ❌ | ❌ | **✅ スタンプ付きプロセス + `tools-dev inspect desktop status \| eval \| screenshot`** |
+| エクスポート形式 | 限定的 | HTML / PDF / PPTX / ZIP / Markdown | **HTML / PDF / PPTX（エージェント駆動）/ ZIP / Markdown** |
+| PPT Skill 再利用 | N/A | 組み込み | **[`guizang-ppt-skill`][guizang] がドロップイン（deck モードのデフォルト）** |
+| 最低課金 | Pro / Max / Team | BYOK | **BYOK — 任意の OpenAI 互換 `baseUrl` を貼り付け** |
+
+[cd]: https://x.com/claudeai/status/2045156267690213649
+[ocod]: https://github.com/OpenCoworkAI/open-codesign
+[piai]: https://github.com/mariozechner/pi-ai
+[acd]: https://github.com/VoltAgent/awesome-claude-design
+[guizang]: https://github.com/op7418/guizang-ppt-skill
+[skill]: https://docs.anthropic.com/en/docs/claude-code/skills
+
+## 対応 Coding Agent
+
+Daemon 起動時に `PATH` から自動検出。設定不要。ストリーミングディスパッチは [`apps/daemon/src/agents.ts`](apps/daemon/src/agents.ts) の `AGENT_DEFS` に、CLI ごとのパーサーも同ディレクトリにあります。モデルリストは `<bin> --list-models` / `<bin> models` / ACP ハンドシェイクのいずれかで取得するか、CLI がリスト機能を持たない場合は厳選フォールバックリストを使用。
+
+| エージェント | バイナリ | ストリーム形式 | argv 形態（組み立て済みプロンプトパス） |
+|---|---|---|---|
+| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | `claude` | `claude-stream-json`（型付きイベント） | `claude -p <prompt> --output-format stream-json --verbose [--include-partial-messages] [--add-dir …] --permission-mode bypassPermissions` |
+| [Codex CLI](https://github.com/openai/codex) | `codex` | `json-event-stream` + `codex` パーサー | `codex exec --json --skip-git-repo-check --full-auto [-C cwd] [--model …] [-c model_reasoning_effort=…] -`（プロンプトは stdin） |
+| [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `gemini` | `json-event-stream` + `gemini` パーサー | `gemini --output-format stream-json --skip-trust --yolo [--model …] -`（プロンプトは stdin） |
+| [OpenCode](https://opencode.ai/) | `opencode` | `json-event-stream` + `opencode` パーサー | `opencode run --format json --dangerously-skip-permissions [--model …] -`（プロンプトは stdin） |
+| [Cursor Agent](https://www.cursor.com/cli) | `cursor-agent` | `json-event-stream` + `cursor-agent` パーサー | `cursor-agent --print --output-format stream-json --stream-partial-output --force --trust [--workspace cwd] [--model …] -`（プロンプトは stdin） |
+| [Qwen Code](https://github.com/QwenLM/qwen-code) | `qwen` | `plain`（生 stdout チャンク） | `qwen --yolo [--model …] -`（プロンプトは stdin） |
+| [GitHub Copilot CLI](https://github.com/features/copilot/cli) | `copilot` | `copilot-stream-json`（型付きイベント） | `copilot -p <prompt> --allow-all-tools --output-format json [--model …] [--add-dir …]` |
+| [Hermes](https://github.com/eqlabs/hermes) | `hermes` | `acp-json-rpc`（Agent Client Protocol） | `hermes acp --accept-hooks` |
+| Kimi CLI | `kimi` | `acp-json-rpc` | `kimi acp` |
+| [Pi](https://github.com/mariozechner/pi-ai) | `pi` | `pi-rpc`（stdio JSON-RPC） | `pi --mode rpc --no-session [--model …] [--thinking …]`（プロンプトは RPC `prompt` コマンドで送信） |
+| **OpenAI 互換 BYOK** | n/a | SSE パススルー | `POST /api/proxy/stream` → `<baseUrl>/v1/chat/completions`；loopback / link-local / RFC1918 を拒否 |
+
+新しい CLI の追加 = [`apps/daemon/src/agents.ts`](apps/daemon/src/agents.ts) にエントリを 1 つ追加。ストリーム形式は `claude-stream-json` / `copilot-stream-json` / `json-event-stream`（CLI ごとの `eventParser` 付き）/ `acp-json-rpc` / `pi-rpc` / `plain` から選択。
+
+## 参考文献 & 系譜
+
+本リポジトリが参考にしたすべての外部プロジェクト。各リンクからソースを確認できます。
+
+| プロジェクト | 本リポジトリでの役割 |
+|---|---|
+| [`Claude Design`][cd] | 本リポジトリがオープンソース代替を提供するクローズドソースプロダクト。 |
+| [**`alchaincyf/huashu-design`**（花叔の画術）](https://github.com/alchaincyf/huashu-design) | デザイン哲学のコア。Junior-Designer ワークフロー、5 ステップブランドアセットプロトコル、anti-AI-slop チェックリスト、五次元セルフ評価、ディレクションピッカーの背後にある「5 流派 × 20 のデザイン哲学」ライブラリ — すべて [`apps/web/src/prompts/discovery.ts`](apps/web/src/prompts/discovery.ts) と [`apps/web/src/prompts/directions.ts`](apps/web/src/prompts/directions.ts) に蒸留。 |
+| [**`op7418/guizang-ppt-skill`**（歸藏）][guizang] | Magazine-web-PPT Skill を [`skills/guizang-ppt/`](skills/guizang-ppt/) にそのまま同梱、元の LICENSE 保持。Deck モードのデフォルト。P0/P1/P2 チェックリスト文化を他のすべての Skill に波及。 |
+| [**`multica-ai/multica`**](https://github.com/multica-ai/multica) | Daemon + adapter アーキテクチャ。PATH スキャンによるエージェント検出、ローカル daemon を唯一の特権プロセスとする思想、agent-as-teammate の世界観。モデルを採用、コードは vendor せず。 |
+| [**`OpenCoworkAI/open-codesign`**][ocod] | 初のオープンソース Claude-Design 代替、最も近い同類。採用済み UX パターン：ストリーミング artifact ループ、サンドボックス iframe プレビュー（React 18 + Babel 同梱）、ライブエージェントパネル（todo + tool calls + 中断可能）、5 種エクスポート形式リスト（HTML/PDF/PPTX/ZIP/Markdown）、ローカルファーストストレージハブ、`SKILL.md` テイスト注入。ロードマップ上の UX パターン：コメントモード精密編集、AI 出力 tweaks パネル。**[`pi-ai`][piai] は意図的に vendor していません** — open-codesign はそれをエージェントランタイムとして同梱していますが、私たちはユーザーの既存 CLI に委任します。 |
+| [`VoltAgent/awesome-claude-design`][acd] / [`awesome-design-md`][acd2] | 9 セクション `DESIGN.md` スキーマのソース。69 のプロダクトシステムが [`scripts/sync-design-systems.ts`](scripts/sync-design-systems.ts) 経由でインポート。 |
+| [`farion1231/cc-switch`](https://github.com/farion1231/cc-switch) | 複数エージェント CLI 間の symlink ベース Skill 配布のインスピレーション源。 |
+| [Claude Code skills][skill] | `SKILL.md` 規約をそのまま採用 — 任意の Claude Code Skill を `skills/` に入れれば daemon が認識。 |
+
+詳細な系譜（各プロジェクトから何を採用し、何を意図的に採用しなかったか）は [`docs/references.md`](docs/references.md) にあります。
+
+## ロードマップ
+
+- [x] Daemon + エージェント検出（10 種 CLI adapter）+ Skill レジストリ + Design System カタログ
+- [x] Web アプリ + チャット + 質問フォーム + 5 つのディレクションピッカー + todo 進捗 + サンドボックスプレビュー
+- [x] 31 個の Skill + 72 種の Design System + 5 つのビジュアルディレクション + 5 つのデバイスフレーム
+- [x] SQLite バックドの projects · conversations · messages · tabs · templates
+- [x] OpenAI 互換 BYOK プロキシ（`/api/proxy/stream`）SSRF 防御付き
+- [x] Claude Design ZIP インポート（`/api/import/claude-design`）
+- [x] Sidecar プロトコル + Electron デスクトップ + IPC 自動化（STATUS / EVAL / SCREENSHOT / CONSOLE / CLICK / SHUTDOWN）
+- [x] Artifact lint API + 五次元セルフ評価 emit 前ゲート
+- [ ] コメントモード精密編集（要素をクリック → 指示 → パッチ）— パターンは [`open-codesign`][ocod] から
+- [ ] AI 出力 tweaks パネル UX — ビルディングブロック（[`tweaks` Skill](skills/tweaks/)）は出荷済み、チャット統合パネルは未完
+- [ ] Vercel + トンネルデプロイレシピ（Topology B）
+- [ ] ワンコマンド `npx od init` で `DESIGN.md` 付きプロジェクトをスキャフォールド
+- [ ] Skill マーケットプレイス（`od skills install <github-repo>`）と `od skill add | list | remove | test` CLI サーフェス（[`docs/skills-protocol.md`](docs/skills-protocol.md) にドラフトあり、daemon 実装は未着手）
+- [ ] `apps/packaged/` からの配布可能 Electron ビルド
+
+フェーズ別デリバリー計画 → [`docs/roadmap.md`](docs/roadmap.md)。
+
+## プロジェクトの状態
+
+これは初期実装です — クローズドループ（検出 → Skill + Design System を選択 → チャット → `<artifact>` をパース → プレビュー → 保存）はエンドツーエンドで動作しています。プロンプトスタックと Skill ライブラリが最も価値の大きい部分であり、安定しています。コンポーネントレベルの UI は日々更新中です。
+
+## Star をお願いします
+
+<p align="center">
+  <a href="https://github.com/nexu-io/open-design"><img src="docs/assets/star-us.png" alt="Open Design に Star を — github.com/nexu-io/open-design" width="100%" /></a>
+</p>
+
+30 分の時間を節約できたなら、★ をお願いします。Star は家賃を払いませんが、次のデザイナー、エージェント、コントリビューターに「この実験は注目する価値がある」と伝えます。1 クリック、3 秒、リアルなシグナル：[github.com/nexu-io/open-design](https://github.com/nexu-io/open-design)。
+
+## コントリビューション
+
+Issue、PR、新 Skill、新 Design System を歓迎します。最も効果の高いコントリビューションは通常、フォルダ 1 つ、Markdown ファイル 1 つ、または PR サイズの adapter です：
+
+- **Skill を追加** — [`skills/`](skills/) にフォルダをドロップし、[`SKILL.md`][skill] 規約に従う。
+- **Design System を追加** — [`design-systems/<brand>/`](design-systems/) に 9 セクションスキーマの `DESIGN.md` をドロップ。
+- **新しい coding-agent CLI を接続** — [`apps/daemon/src/agents.ts`](apps/daemon/src/agents.ts) にエントリを 1 つ追加。
+
+完全なワークフロー、マージ基準、コードスタイル、受け入れない PR の種類 → [`CONTRIBUTING.md`](CONTRIBUTING.md)（[简体中文](CONTRIBUTING.zh-CN.md)）。
+
+## コントリビューター
+
+コード、ドキュメント、フィードバック、新 Skill、新 Design System、あるいは鋭い Issue — あらゆる形で Open Design を前進させてくださったすべての方に感謝します。すべての実質的なコントリビューションは大切であり、以下のウォールは最もシンプルな感謝の表明です。
+
+<a href="https://github.com/nexu-io/open-design/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=nexu-io/open-design&cache_bust=2026-04-30" alt="Open Design コントリビューター" />
+</a>
+
+初めての PR を送った方 — ようこそ。[`good-first-issue`](https://github.com/nexu-io/open-design/labels/good-first-issue) ラベルがエントリポイントです。
+
+## リポジトリ活動
+
+<picture>
+  <img alt="Open Design リポジトリメトリクス" src="docs/assets/github-metrics.svg" />
+</picture>
+
+上記の SVG は [`.github/workflows/metrics.yml`](.github/workflows/metrics.yml) が [`lowlighter/metrics`](https://github.com/lowlighter/metrics) を使って毎日自動再生成しています。すぐに更新したい場合は **Actions** タブから手動トリガーしてください。より充実したプラグイン（traffic、follow-up time など）を有効にするには、リポジトリシークレットに細粒度 PAT を `METRICS_TOKEN` として追加してください。
+
+## Star History
+
+<a href="https://star-history.com/#nexu-io/open-design&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=nexu-io/open-design&type=Date&theme=dark&cache_bust=2026-04-30" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=nexu-io/open-design&type=Date&cache_bust=2026-04-30" />
+    <img alt="Open Design star history" src="https://api.star-history.com/svg?repos=nexu-io/open-design&type=Date&cache_bust=2026-04-30" />
+  </picture>
+</a>
+
+カーブが上向きなら — それが私たちの求めるシグナルです。★ で後押ししてください。
+
+## ライセンス
+
+Apache-2.0。同梱の [`skills/guizang-ppt/`](skills/guizang-ppt/) は元の [LICENSE](skills/guizang-ppt/LICENSE)（MIT）と [op7418](https://github.com/op7418) の帰属表示を保持しています。

--- a/README.ko.md
+++ b/README.ko.md
@@ -24,7 +24,7 @@
   <a href="QUICKSTART.md"><img alt="Quickstart" src="https://img.shields.io/badge/quickstart-3%20commands-green?style=flat-square" /></a>
 </p>
 
-<p align="center"><a href="README.md">English</a> · <a href="README.zh-CN.md">简体中文</a> · <b>한국어</b></p>
+<p align="center"><a href="README.md">English</a> · <a href="README.zh-CN.md">简体中文</a> · <b>한국어</b> · <a href="README.ja-JP.md">日本語</a></p>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   <a href="QUICKSTART.md"><img alt="Quickstart" src="https://img.shields.io/badge/quickstart-3%20commands-green?style=flat-square" /></a>
 </p>
 
-<p align="center"><b>English</b> · <a href="README.zh-CN.md">简体中文</a> · <a href="README.ko.md">한국어</a></p>
+<p align="center"><b>English</b> · <a href="README.zh-CN.md">简体中文</a> · <a href="README.ko.md">한국어</a> · <a href="README.ja-JP.md">日本語</a></p>
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -24,7 +24,7 @@
   <a href="QUICKSTART.md"><img alt="Quickstart" src="https://img.shields.io/badge/quickstart-3%20commands-green?style=flat-square" /></a>
 </p>
 
-<p align="center"><a href="README.md">English</a> · <b>简体中文</b> · <a href="README.ko.md">한국어</a></p>
+<p align="center"><a href="README.md">English</a> · <b>简体中文</b> · <a href="README.ko.md">한국어</a> · <a href="README.ja-JP.md">日本語</a></p>
 
 ---
 


### PR DESCRIPTION
## Summary

- Added Japanese translation of `README.md` → `README.ja-JP.md`
- Added Japanese translation of `CONTRIBUTING.md` → `CONTRIBUTING.ja-JP.md`
- Updated language navigation links in `README.md`, `README.zh-CN.md`, `README.ko.md`, `CONTRIBUTING.md`, and `CONTRIBUTING.zh-CN.md` to include the new Japanese documents

## Notes

- **Version numbers (31 skills / 72 design systems / 10 CLIs):** The JA translation was based on the most recent internal state of the codebase, which had already been updated in the EN `README.md` (via #173). All numbers are consistent across EN, JA, ZH-CN, and KO READMEs.
- **Terminology:** "coding-agent CLI" (hyphenated) and "artifact" (loanword) are used consistently throughout the JA documents, matching the EN originals.
- **Links:** All relative links (`QUICKSTART.md`, `skills/`, `design-systems/`, etc.) and external links are intact. The `[Claude Design][cd]` reference link points to the same X/Twitter announcement URL as in EN.

## Test plan

- [ ] Verify all relative links in `README.ja-JP.md` resolve correctly
- [ ] Verify all relative links in `CONTRIBUTING.ja-JP.md` resolve correctly
- [ ] Verify language navigation links in all README variants include 日本語
- [ ] Verify language navigation links in all CONTRIBUTING variants include 日本語
- [ ] Spot-check translation accuracy of key sections (architecture table, agent table, skill catalog)