### PR TITLE
fix(web): align Design Files upload picker with dropzone

### DIFF
--- a/apps/web/src/components/FileWorkspace.test.tsx
+++ b/apps/web/src/components/FileWorkspace.test.tsx
@@ -1,0 +1,22 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+import { FileWorkspace } from './FileWorkspace';
+
+describe('FileWorkspace upload input', () => {
+  it('keeps the Design Files picker aligned with drag-and-drop file support', () => {
+    const markup = renderToStaticMarkup(
+      <FileWorkspace
+        projectId="project-1"
+        files={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        tabsState={{ tabs: [], active: null }}
+        onTabsStateChange={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain('data-testid="design-files-upload-input"');
+    expect(markup).not.toContain('accept=');
+  });
+});

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -415,7 +415,6 @@ export function FileWorkspace({
         type="file"
         multiple
         data-testid="design-files-upload-input"
-        accept="image/*"
         style={{ display: 'none' }}
         onChange={handleFilePicked}
       />


### PR DESCRIPTION
## Summary

Fixes #130 by aligning the Design Files upload button with the drag-and-drop upload path.

The hidden file input used by the Upload button was restricted to `accept="image/*"`, while the dropzone accepted documents, text files, and other Design Files reference types. This made the two upload affordances behave inconsistently.

## Changes

- Remove the image-only `accept` restriction from the Design Files file picker.
- Add a focused component test that renders `FileWorkspace` and verifies the picker no longer advertises an image-only constraint.

## User Impact

Users can now select the same broad set of Design Files references from the Upload button that they could already drag into the page.

```text
Before:
[Upload] -> file picker only allows images
[Dropzone] -> accepts images, docs, text, and other references

After:
[Upload] -> accepts the same broad file set as the dropzone
[Dropzone] -> unchanged
```

## Validation

- `corepack pnpm --dir apps/web exec vitest run -c vitest.config.ts src/components/FileWorkspace.test.tsx`
- `corepack pnpm --filter @open-design/web typecheck`
- `git diff --check`

Note: `corepack pnpm --filter @open-design/web test -- FileWorkspace.test.tsx` also surfaced a pre-existing upstream-main failure in `src/i18n/locales.test.ts`: `LOCALES` now includes `ja`, but the test's `EXPECTED_LOCALES` array does not. The focused FileWorkspace test passes after this change.
