### PR TITLE
fix(web): use neutral Design Files agent copy

### DIFF
--- a/apps/web/src/i18n/design-files-agent-copy.test.ts
+++ b/apps/web/src/i18n/design-files-agent-copy.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { de } from './locales/de';
+import { en } from './locales/en';
+import { esES } from './locales/es-ES';
+import { fa } from './locales/fa';
+import { ja } from './locales/ja';
+import { ptBR } from './locales/pt-BR';
+import { ru } from './locales/ru';
+import { zhCN } from './locales/zh-CN';
+import { zhTW } from './locales/zh-TW';
+
+const LOCALE_DICTS = {
+  de,
+  en,
+  esES,
+  fa,
+  ja,
+  ptBR,
+  ru,
+  zhCN,
+  zhTW,
+};
+
+describe('Design Files agent copy', () => {
+  it('uses neutral agent wording in shared helper text', () => {
+    for (const [locale, dict] of Object.entries(LOCALE_DICTS)) {
+      expect(dict['designFiles.dropDesc'], locale).not.toMatch(/claude/i);
+    }
+  });
+});

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -391,7 +391,7 @@ export const de: Dict = {
   'designFiles.download': 'Herunterladen',
   'designFiles.dropTitle': '⤓ Dateien hier ablegen',
   'designFiles.dropDesc':
-    'Bilder, Docs, Referenzen, Figma-Links oder Ordner — Claude nutzt sie als Kontext.',
+    'Bilder, Docs, Referenzen, Figma-Links oder Ordner — der Agent nutzt sie als Kontext.',
   'designFiles.upload.title': 'Dateien hochladen',
   'designFiles.paste.title': 'Text als Datei einfügen',
   'designFiles.upload.label': 'Hochladen',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -391,7 +391,7 @@ export const en: Dict = {
   'designFiles.download': 'Download',
   'designFiles.dropTitle': '⤓ Drop files here',
   'designFiles.dropDesc':
-    'Images, docs, references, Figma links, or folders — Claude will use them as context.',
+    'Images, docs, references, Figma links, or folders — the agent will use them as context.',
   'designFiles.upload.title': 'Upload files',
   'designFiles.paste.title': 'Paste text as a file',
   'designFiles.upload.label': 'Upload',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -392,7 +392,7 @@ export const esES: Dict = {
   'designFiles.download': 'Descargar',
   'designFiles.dropTitle': '⤓ Suelta archivos aquí',
   'designFiles.dropDesc':
-    'Imágenes, documentos, referencias, enlaces de Figma o carpetas: Claude los usará como contexto.',
+    'Imágenes, documentos, referencias, enlaces de Figma o carpetas: el agente los usará como contexto.',
   'designFiles.upload.title': 'Subir archivos',
   'designFiles.paste.title': 'Pegar texto como archivo',
   'designFiles.upload.label': 'Subir',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -392,7 +392,7 @@ export const fa: Dict = {
   'designFiles.download': 'دانلود',
   'designFiles.dropTitle': '⤓ فایل‌ها را اینجا رها کنید',
   'designFiles.dropDesc':
-    'تصاویر، اسناد، مراجع، لینک‌های Figma، یا پوشه‌ها — Claude از آن‌ها به عنوان زمینه استفاده خواهد کرد.',
+    'تصاویر، اسناد، مراجع، لینک‌های Figma، یا پوشه‌ها — عامل از آن‌ها به عنوان زمینه استفاده خواهد کرد.',
   'designFiles.upload.title': 'آپلود فایل‌ها',
   'designFiles.paste.title': 'چسباندن متن به عنوان فایل',
   'designFiles.upload.label': 'آپلود',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -391,7 +391,7 @@ export const ja: Dict = {
   'designFiles.download': 'ダウンロード',
   'designFiles.dropTitle': '⤓ ファイルをここにドロップ',
   'designFiles.dropDesc':
-    '画像、ドキュメント、参考資料、Figma リンク、フォルダー — Claude がコンテキストとして使用します。',
+    '画像、ドキュメント、参考資料、Figma リンク、フォルダー — エージェントがコンテキストとして使用します。',
   'designFiles.upload.title': 'ファイルをアップロード',
   'designFiles.paste.title': 'テキストをファイルとして貼り付け',
   'designFiles.upload.label': 'アップロード',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -390,7 +390,7 @@ export const ptBR: Dict = {
   'designFiles.download': 'Baixar',
   'designFiles.dropTitle': '⤓ Solte arquivos aqui',
   'designFiles.dropDesc':
-    'Imagens, docs, referências, links do Figma ou pastas — Claude usará tudo como contexto.',
+    'Imagens, docs, referências, links do Figma ou pastas — o agente usará tudo como contexto.',
   'designFiles.upload.title': 'Enviar arquivos',
   'designFiles.paste.title': 'Colar texto como arquivo',
   'designFiles.upload.label': 'Enviar',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -390,7 +390,7 @@ export const ru: Dict = {
   'designFiles.download': 'Скачать',
   'designFiles.dropTitle': '⤓ Перетащите файлы сюда',
   'designFiles.dropDesc':
-    'Изображения, документы, ссылки, ссылки Figma или папки — Claude будет использовать их как контекст.',
+    'Изображения, документы, ссылки, ссылки Figma или папки — агент будет использовать их как контекст.',
   'designFiles.upload.title': 'Загрузить файлы',
   'designFiles.paste.title': 'Вставить текст как файл',
   'designFiles.upload.label': 'Загрузить',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -382,7 +382,7 @@ export const zhCN: Dict = {
   'designFiles.openInTab': '在标签页中打开',
   'designFiles.download': '下载',
   'designFiles.dropTitle': '⤓ 把文件拖到这里',
-  'designFiles.dropDesc': '图片、文档、参考资料、Figma 链接或文件夹 — Claude 都会用作上下文。',
+  'designFiles.dropDesc': '图片、文档、参考资料、Figma 链接或文件夹 — 智能体都会用作上下文。',
   'designFiles.upload.title': '上传文件',
   'designFiles.paste.title': '将文本粘贴为文件',
   'designFiles.upload.label': '上传',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -382,7 +382,7 @@ export const zhTW: Dict = {
   'designFiles.openInTab': '在分頁中開啟',
   'designFiles.download': '下載',
   'designFiles.dropTitle': '⤓ 把檔案拖到這裡',
-  'designFiles.dropDesc': '圖片、文件、參考資料、Figma 連結或資料夾 — Claude 都會用作上下文。',
+  'designFiles.dropDesc': '圖片、文件、參考資料、Figma 連結或資料夾 — 智慧體都會用作上下文。',
   'designFiles.upload.title': '上傳一張圖片',
   'designFiles.paste.title': '將文字貼上為檔案',
   'designFiles.upload.label': '上傳',


### PR DESCRIPTION
## Summary

Fixes #110 by replacing the provider-specific `Claude` reference in the shared Design Files helper copy with neutral agent wording.

Design Files can be used while the selected runtime is Codex, OpenCode, Gemini CLI, or another supported agent. The dropzone helper text should therefore not imply that Claude is always the runtime consuming uploaded context.

## Changes

- Update `designFiles.dropDesc` across registered UI locales to use neutral agent wording instead of `Claude`.
- Add a focused i18n regression test that prevents this shared helper copy from reintroducing a hardcoded `Claude` provider name.

## User Impact

The Design Files page now stays consistent with multi-agent runtime selection.

```text
Before:
Images, docs, references, Figma links, or folders — Claude will use them as context.

After:
Images, docs, references, Figma links, or folders — the agent will use them as context.
```

## Validation

- `corepack pnpm --dir apps/web exec vitest run -c vitest.config.ts src/i18n/design-files-agent-copy.test.ts`
- `corepack pnpm --filter @open-design/web typecheck`
- `git diff --check`

Note: full `@open-design/web` test runs currently hit a pre-existing upstream-main failure in `src/i18n/locales.test.ts`: `LOCALES` includes `ja`, but `EXPECTED_LOCALES` has not been updated to include it.

## Merge Note

This PR intentionally only addresses the provider-specific agent wording. It may need a tiny rebase if #200 merges first, because #200 edits the same helper sentence to remove the unsupported Figma link claim.
