### PR TITLE
fix(web): include Japanese locale in registry test

### DIFF
--- a/apps/web/src/i18n/locales.test.ts
+++ b/apps/web/src/i18n/locales.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { en } from './locales/en';
 import { LOCALES, LOCALE_LABEL, type Dict, type Locale } from './types';
 
-const EXPECTED_LOCALES = ['en', 'de', 'zh-CN', 'zh-TW', 'pt-BR', 'es-ES', 'ru', 'fa'];
+const EXPECTED_LOCALES = ['en', 'de', 'zh-CN', 'zh-TW', 'pt-BR', 'es-ES', 'ru', 'fa', 'ja'];
 
 function placeholders(value: string): string[] {
   const names: string[] = [];


### PR DESCRIPTION
## Summary

Fix the web locale registry test after the Japanese locale was added to `LOCALES`.

`LOCALES` now includes `ja`, but `EXPECTED_LOCALES` in `locales.test.ts` still omitted it. This made the full `@open-design/web` test suite fail on current `main` even before unrelated feature branches are applied.

## Changes

- Add `ja` to `EXPECTED_LOCALES` in `apps/web/src/i18n/locales.test.ts`.

## Validation

- `corepack pnpm --dir apps/web exec vitest run -c vitest.config.ts src/i18n/locales.test.ts`
- `corepack pnpm --filter @open-design/web test`
- `corepack pnpm --filter @open-design/web typecheck`
- `git diff --check`

All commands pass locally. Node emits the existing engine warning because this machine is on Node v22.16.0 while the repo targets Node ~24.
