### PR TITLE
release: Open Design 0.1.0 — first public release

### DIFF
--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -47,9 +47,38 @@ jobs:
         id: stable
         run: node --experimental-strip-types ./scripts/release-stable.ts
 
+  verify:
+    name: Verify build (typecheck + tests)
+    needs: metadata
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 10.33.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test (workspace, if present)
+        run: pnpm -r --workspace-concurrency=1 --if-present run test
+
   build_mac:
     name: Build stable mac arm64
-    needs: metadata
+    needs: [metadata, verify]
     runs-on: macos-14
     env:
       GH_TOKEN: ${{ github.token }}
@@ -162,7 +191,7 @@ jobs:
 
   build_win:
     name: Build stable win x64
-    needs: metadata
+    needs: [metadata, verify]
     runs-on: windows-latest
     env:
       GH_TOKEN: ${{ github.token }}
@@ -246,6 +275,7 @@ jobs:
     name: Publish stable release
     needs:
       - metadata
+      - verify
       - build_mac
       - build_win
     runs-on: ubuntu-latest
@@ -256,6 +286,18 @@ jobs:
         uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
+
+      - name: Pre-flight tag/release check
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --tags origin "refs/tags/${{ needs.metadata.outputs.version_tag }}" >/dev/null 2>&1; then
+            echo "tag ${{ needs.metadata.outputs.version_tag }} already exists on origin; aborting" >&2
+            exit 1
+          fi
+          if gh release view "${{ needs.metadata.outputs.version_tag }}" >/dev/null 2>&1; then
+            echo "release ${{ needs.metadata.outputs.version_tag }} already exists; aborting" >&2
+            exit 1
+          fi
 
       - name: Download mac release bundle
         uses: actions/download-artifact@v8
@@ -268,20 +310,6 @@ jobs:
         with:
           name: open-design-stable-win-release-assets
           path: ${{ runner.temp }}/release-assets/win
-
-      - name: Create stable tag at release commit
-        run: |
-          set -euo pipefail
-          if git rev-parse "refs/tags/${{ needs.metadata.outputs.version_tag }}" >/dev/null 2>&1; then
-            echo "tag ${{ needs.metadata.outputs.version_tag }} already exists locally; aborting"
-            exit 1
-          fi
-          if git ls-remote --exit-code --tags origin "refs/tags/${{ needs.metadata.outputs.version_tag }}" >/dev/null 2>&1; then
-            echo "tag ${{ needs.metadata.outputs.version_tag }} already exists on origin; aborting"
-            exit 1
-          fi
-          git tag "${{ needs.metadata.outputs.version_tag }}" "$GITHUB_SHA"
-          git push origin "refs/tags/${{ needs.metadata.outputs.version_tag }}"
 
       - name: Write release notes shell
         id: notes
@@ -303,24 +331,43 @@ jobs:
           EOF
           echo "notes_file=$notes_file" >> "$GITHUB_OUTPUT"
 
-      - name: Create stable release
+      - name: Create draft release with tag
+        id: create_release
+        run: |
+          set -euo pipefail
+          # gh release create creates the tag at $GITHUB_SHA atomically with the release.
+          # Using --draft keeps the release invisible until all assets upload successfully;
+          # the cleanup step rolls back the release + tag together if any subsequent step fails.
+          gh release create "${{ needs.metadata.outputs.version_tag }}" \
+            --target "$GITHUB_SHA" \
+            --title "${{ needs.metadata.outputs.release_name }}" \
+            --notes-file "${{ steps.notes.outputs.notes_file }}" \
+            --draft
+
+      - name: Upload assets to draft release
         run: |
           set -euo pipefail
           all_release_dir="$RUNNER_TEMP/release-assets/all"
           mkdir -p "$all_release_dir"
           cp "$RUNNER_TEMP/release-assets/mac"/* "$all_release_dir/"
           cp "$RUNNER_TEMP/release-assets/win"/* "$all_release_dir/"
-
-          if gh release view "${{ needs.metadata.outputs.version_tag }}" >/dev/null 2>&1; then
-            echo "release ${{ needs.metadata.outputs.version_tag }} already exists; aborting"
-            exit 1
-          fi
-          gh release create "${{ needs.metadata.outputs.version_tag }}" \
-            --target "$GITHUB_SHA" \
-            --title "${{ needs.metadata.outputs.release_name }}" \
-            --notes-file "${{ steps.notes.outputs.notes_file }}" \
-            --latest
           gh release upload "${{ needs.metadata.outputs.version_tag }}" "$all_release_dir"/*
+
+      - name: Promote draft to published latest
+        run: |
+          set -euo pipefail
+          gh release edit "${{ needs.metadata.outputs.version_tag }}" \
+            --draft=false \
+            --latest
+
+      - name: Cleanup release + tag on failure
+        if: failure() && steps.create_release.outcome == 'success'
+        run: |
+          set +e
+          echo "publish failed after release was created; rolling back release and tag"
+          gh release delete "${{ needs.metadata.outputs.version_tag }}" --cleanup-tag --yes
+          # belt-and-suspenders: ensure remote tag is gone even if --cleanup-tag missed
+          git push origin --delete "refs/tags/${{ needs.metadata.outputs.version_tag }}" || true
 
       - name: Publish summary
         run: |

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -1,0 +1,337 @@
+name: release-stable
+
+on:
+  workflow_dispatch:
+    inputs:
+      mac_signed:
+        description: "Build signed/notarized mac artifacts. Disable only for explicit unsigned validation releases."
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+
+concurrency:
+  group: open-design-release-stable
+  cancel-in-progress: false
+
+jobs:
+  metadata:
+    name: Prepare stable metadata
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GITHUB_REPOSITORY: ${{ github.repository }}
+    outputs:
+      base_version: ${{ steps.stable.outputs.base_version }}
+      branch: ${{ steps.stable.outputs.branch }}
+      commit: ${{ steps.stable.outputs.commit }}
+      mac_signed: ${{ inputs.mac_signed }}
+      previous_stable: ${{ steps.stable.outputs.previous_stable }}
+      release_name: ${{ steps.stable.outputs.release_name }}
+      stable_version: ${{ steps.stable.outputs.stable_version }}
+      version_tag: ${{ steps.stable.outputs.version_tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Prepare stable release metadata
+        id: stable
+        run: node --experimental-strip-types ./scripts/release-stable.ts
+
+  build_mac:
+    name: Build stable mac arm64
+    needs: metadata
+    runs-on: macos-14
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 10.33.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Prepare Apple signing certificate
+        if: ${{ inputs.mac_signed }}
+        env:
+          APPLE_SIGNING_CERTIFICATE_BASE64: ${{ secrets.APPLE_SIGNING_CERTIFICATE_BASE64 }}
+          APPLE_SIGNING_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_SIGNING_CERTIFICATE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          cert_path="$RUNNER_TEMP/open-design-signing.p12"
+          if ! printf '%s' "$APPLE_SIGNING_CERTIFICATE_BASE64" | base64 --decode > "$cert_path" 2>/dev/null; then
+            printf '%s' "$APPLE_SIGNING_CERTIFICATE_BASE64" | base64 -D > "$cert_path"
+          fi
+          {
+            echo "CSC_LINK=$cert_path"
+            echo "CSC_KEY_PASSWORD=$APPLE_SIGNING_CERTIFICATE_PASSWORD"
+          } >> "$GITHUB_ENV"
+
+      - name: Build stable mac artifacts
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          signed_flag=""
+          if [ "${{ inputs.mac_signed }}" = "true" ]; then
+            signed_flag="--signed"
+          fi
+          pnpm exec tools-pack mac build \
+            --dir "$RUNNER_TEMP/tools-pack" \
+            --namespace release-stable \
+            --portable \
+            --to all \
+            --json \
+            $signed_flag
+
+      - name: Prepare stable mac assets
+        id: assets
+        run: |
+          set -euo pipefail
+          release_dir="$RUNNER_TEMP/release-assets"
+          mkdir -p "$release_dir"
+
+          source_dmg="$RUNNER_TEMP/tools-pack/out/mac/namespaces/release-stable/dmg/Open Design-release-stable.dmg"
+          source_zip="$RUNNER_TEMP/tools-pack/out/mac/namespaces/release-stable/zip/Open Design-release-stable.zip"
+          if [ ! -f "$source_dmg" ]; then
+            echo "expected dmg not found at $source_dmg" >&2
+            exit 1
+          fi
+          if [ ! -f "$source_zip" ]; then
+            echo "expected zip not found at $source_zip" >&2
+            exit 1
+          fi
+
+          versioned_dmg="open-design-${{ needs.metadata.outputs.stable_version }}-mac-arm64.dmg"
+          versioned_zip="open-design-${{ needs.metadata.outputs.stable_version }}-mac-arm64.zip"
+          dmg_checksum_file="$versioned_dmg.sha256"
+          zip_checksum_file="$versioned_zip.sha256"
+
+          cp "$source_dmg" "$release_dir/$versioned_dmg"
+          cp "$source_zip" "$release_dir/$versioned_zip"
+          (
+            cd "$release_dir"
+            shasum -a 256 "$versioned_dmg" > "$dmg_checksum_file"
+            shasum -a 256 "$versioned_zip" > "$zip_checksum_file"
+          )
+
+          zip_sha512="$(openssl dgst -sha512 -binary "$release_dir/$versioned_zip" | openssl base64 -A)"
+          zip_size="$(stat -f%z "$release_dir/$versioned_zip")"
+          zip_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${{ needs.metadata.outputs.version_tag }}/$versioned_zip"
+          release_date="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          cat > "$release_dir/latest-mac.yml" <<EOF
+          version: "${{ needs.metadata.outputs.stable_version }}"
+          files:
+            - url: "$zip_url"
+              sha512: "$zip_sha512"
+              size: $zip_size
+          path: "$zip_url"
+          sha512: "$zip_sha512"
+          releaseDate: "$release_date"
+          releaseNotes: "Open Design ${{ needs.metadata.outputs.stable_version }}"
+          EOF
+
+      - name: Upload mac release bundle
+        uses: actions/upload-artifact@v7
+        with:
+          name: open-design-stable-mac-release-assets
+          path: ${{ runner.temp }}/release-assets
+
+  build_win:
+    name: Build stable win x64
+    needs: metadata
+    runs-on: windows-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 10.33.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build stable windows artifacts
+        shell: pwsh
+        run: >-
+          pnpm exec tools-pack win build
+          --dir "${{ runner.temp }}/tools-pack"
+          --namespace release-stable-win
+          --portable
+          --to nsis
+          --json
+
+      - name: Prepare windows stable assets
+        shell: pwsh
+        run: |
+          $releaseDir = Join-Path $env:RUNNER_TEMP "release-assets"
+          New-Item -ItemType Directory -Force -Path $releaseDir | Out-Null
+
+          $sourceInstaller = Join-Path $env:RUNNER_TEMP "tools-pack/out/win/namespaces/release-stable-win/builder/Open Design-release-stable-win-setup.exe"
+          $sourceBlockmap = Join-Path $env:RUNNER_TEMP "tools-pack/out/win/namespaces/release-stable-win/builder/Open Design-release-stable-win-setup.exe.blockmap"
+          if (!(Test-Path $sourceInstaller)) {
+            throw "expected installer not found at $sourceInstaller"
+          }
+          if (!(Test-Path $sourceBlockmap)) {
+            throw "expected blockmap not found at $sourceBlockmap"
+          }
+
+          $versionedInstaller = "open-design-${{ needs.metadata.outputs.stable_version }}-win-x64-setup.exe"
+          $versionedBlockmap = "open-design-${{ needs.metadata.outputs.stable_version }}-win-x64-setup.exe.blockmap"
+          $checksumFile = "$versionedInstaller.sha256"
+          Copy-Item $sourceInstaller (Join-Path $releaseDir $versionedInstaller)
+          Copy-Item $sourceBlockmap (Join-Path $releaseDir $versionedBlockmap)
+
+          $installerPath = Join-Path $releaseDir $versionedInstaller
+          $hash = (Get-FileHash -Path $installerPath -Algorithm SHA256).Hash.ToLowerInvariant()
+          "$hash  $versionedInstaller" | Set-Content -Path (Join-Path $releaseDir $checksumFile)
+          $installerBytes = [System.IO.File]::ReadAllBytes($installerPath)
+          $installerSha512 = [System.Convert]::ToBase64String([System.Security.Cryptography.SHA512]::Create().ComputeHash($installerBytes))
+          $installerSize = (Get-Item $installerPath).Length
+          $installerUrl = "https://github.com/$env:GITHUB_REPOSITORY/releases/download/${{ needs.metadata.outputs.version_tag }}/$versionedInstaller"
+          $releaseDate = [DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ")
+          @(
+            'version: "${{ needs.metadata.outputs.stable_version }}"'
+            'files:'
+            "  - url: `"$installerUrl`""
+            "    sha512: `"$installerSha512`""
+            "    size: $installerSize"
+            "path: `"$installerUrl`""
+            "sha512: `"$installerSha512`""
+            "releaseDate: `"$releaseDate`""
+            "releaseNotes: `"Open Design ${{ needs.metadata.outputs.stable_version }}`""
+          ) | Set-Content -Path (Join-Path $releaseDir "latest.yml")
+
+      - name: Upload windows release bundle
+        uses: actions/upload-artifact@v7
+        with:
+          name: open-design-stable-win-release-assets
+          path: ${{ runner.temp }}/release-assets
+
+  publish:
+    name: Publish stable release
+    needs:
+      - metadata
+      - build_mac
+      - build_win
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Download mac release bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: open-design-stable-mac-release-assets
+          path: ${{ runner.temp }}/release-assets/mac
+
+      - name: Download windows release bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: open-design-stable-win-release-assets
+          path: ${{ runner.temp }}/release-assets/win
+
+      - name: Create stable tag at release commit
+        run: |
+          set -euo pipefail
+          if git rev-parse "refs/tags/${{ needs.metadata.outputs.version_tag }}" >/dev/null 2>&1; then
+            echo "tag ${{ needs.metadata.outputs.version_tag }} already exists locally; aborting"
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/${{ needs.metadata.outputs.version_tag }}" >/dev/null 2>&1; then
+            echo "tag ${{ needs.metadata.outputs.version_tag }} already exists on origin; aborting"
+            exit 1
+          fi
+          git tag "${{ needs.metadata.outputs.version_tag }}" "$GITHUB_SHA"
+          git push origin "refs/tags/${{ needs.metadata.outputs.version_tag }}"
+
+      - name: Write release notes shell
+        id: notes
+        run: |
+          set -euo pipefail
+          notes_file="$RUNNER_TEMP/open-design-stable-notes.md"
+          cat > "$notes_file" <<EOF
+          ## Summary
+          - channel: stable
+          - version: ${{ needs.metadata.outputs.stable_version }}
+          - mac signed/notarized: ${{ inputs.mac_signed }}
+          - windows signed: false
+          - branch: ${{ needs.metadata.outputs.branch }}
+          - commit: ${{ needs.metadata.outputs.commit }}
+
+          See [CHANGELOG.md](https://github.com/${GITHUB_REPOSITORY}/blob/${{ needs.metadata.outputs.version_tag }}/CHANGELOG.md) for the full release notes.
+
+          This stable release ships mac arm64 DMG/update ZIP, Windows x64 NSIS installer assets, checksums, and updater feed files.
+          EOF
+          echo "notes_file=$notes_file" >> "$GITHUB_OUTPUT"
+
+      - name: Create stable release
+        run: |
+          set -euo pipefail
+          all_release_dir="$RUNNER_TEMP/release-assets/all"
+          mkdir -p "$all_release_dir"
+          cp "$RUNNER_TEMP/release-assets/mac"/* "$all_release_dir/"
+          cp "$RUNNER_TEMP/release-assets/win"/* "$all_release_dir/"
+
+          if gh release view "${{ needs.metadata.outputs.version_tag }}" >/dev/null 2>&1; then
+            echo "release ${{ needs.metadata.outputs.version_tag }} already exists; aborting"
+            exit 1
+          fi
+          gh release create "${{ needs.metadata.outputs.version_tag }}" \
+            --target "$GITHUB_SHA" \
+            --title "${{ needs.metadata.outputs.release_name }}" \
+            --notes-file "${{ steps.notes.outputs.notes_file }}" \
+            --latest
+          gh release upload "${{ needs.metadata.outputs.version_tag }}" "$all_release_dir"/*
+
+      - name: Publish summary
+        run: |
+          {
+            echo "## Stable release"
+            echo "- Channel: stable"
+            echo "- Version: ${{ needs.metadata.outputs.stable_version }}"
+            echo "- Version tag: ${{ needs.metadata.outputs.version_tag }}"
+            echo "- mac signed/notarized: ${{ inputs.mac_signed }}"
+            echo "- windows signed: false"
+            echo "- mac assets: open-design-${{ needs.metadata.outputs.stable_version }}-mac-arm64.dmg, open-design-${{ needs.metadata.outputs.stable_version }}-mac-arm64.zip"
+            echo "- win assets: open-design-${{ needs.metadata.outputs.stable_version }}-win-x64-setup.exe, open-design-${{ needs.metadata.outputs.stable_version }}-win-x64-setup.exe.blockmap"
+            echo "- Feeds: latest-mac.yml, latest.yml"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ First public release of Open Design — a local-first, open-source alternative t
 - App version awareness shared across daemon and web. ([#204])
 
 #### Skills, design systems & prompt templates
-- 71 brand-grade design systems including Xiaohongshu and Replit Deck (8 themes). ([#24], [#74])
+- 72 brand-grade design systems and 31 composable skills, including Xiaohongshu and Replit Deck (8 themes). ([#24], [#74])
 - 57 DESIGN.md specs imported from awesome-design-skills. ([#92])
 - Dance storyboard and ancient-China MMO HUD prompt templates. ([#187])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,192 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-05-01
+
+First public release of Open Design — a local-first, open-source alternative to Anthropic's Claude Design. It detects your installed code-agent CLI, runs design skills against curated design systems, and streams artifacts into a sandboxed in-app preview.
+
+### Added
+
+#### Agent runtimes & providers
+- Multi-agent runtime detection and dispatch: Claude Code, Codex, Cursor, Gemini CLI, OpenCode, Qwen, GitHub Copilot CLI, Hermes, Kimi CLI, Pi, and Kiro. ([#28], [#71], [#117], [#185])
+- Per-CLI model picker for local agents. ([#14])
+- OpenAI-compatible provider support and Anthropic-compatible stream proxy for non-native providers. ([#80], [#180])
+- App version awareness shared across daemon and web. ([#204])
+
+#### Skills, design systems & prompt templates
+- 71 brand-grade design systems including Xiaohongshu and Replit Deck (8 themes). ([#24], [#74])
+- 57 DESIGN.md specs imported from awesome-design-skills. ([#92])
+- Dance storyboard and ancient-China MMO HUD prompt templates. ([#187])
+
+#### Artifacts & preview
+- Artifact platform foundation with sandboxed in-app preview. ([#68])
+- First-class SVG and Markdown artifact renderers / viewer. ([#73], [#177])
+- HTML preview support for relative-asset references. ([#156])
+- Document preview support for uploaded files and multi-file design uploads. ([#31], [#63])
+- Claude Design `.zip` import. ([#46])
+- Image / video / audio media surfaces with unified `od media generate` dispatcher. ([#12])
+
+#### Packaging & deployment
+- Mac arm64 packaged runtime with signed/notarized DMG + update ZIP and beta release flow. ([#170])
+- Windows x64 NSIS installer (unsigned beta) and release assets. ([#191])
+- Vercel self-deploy flow with `vercel.json` configuration. ([#167], [#169])
+
+#### Internationalization
+- UI locales: zh-CN, zh-TW, en, ja, de, es-ES, ru, fa, pt-BR. ([#79], [#80], [#155], [#159], [#182], [#190], [#197])
+- Improved language switcher UI. ([#107])
+
+#### Developer experience & tools
+- `tools-dev` / `tools-pack` workspace tooling for development and packaging, with native addon diagnostics and improved web startup flow. ([#127], [#128], [#153])
+- `dev:all` auto-switches to a free port when defaults are busy. ([#9])
+- UI end-to-end automation suite and reporting under `apps/e2e`. ([#64], [#102])
+- Frontend toolchain migrated from Vite to Next.js 16 App Router. ([#66])
+- Project code migrated to TypeScript with shared contracts. ([#118])
+- Refreshed desktop integration control plane. ([#123])
+- Star-us prompt to surface GitHub repo. ([#5])
+
+### Fixed
+
+#### Stability & reliability
+- Chat runs survive web reconnects. ([#146])
+- Daemon project-root resolution when launched from src via tsx. ([#162])
+- SSE keepalive behind nginx. ([#111])
+- Standalone pnpm binary supported in postinstall; install toolchain pinned. ([#35], [#151])
+- Surface unfinished todo runs in chat. ([#76])
+
+#### Cross-platform / Windows
+- Spawn agents via resolved absolute path on Windows. ([#13])
+- Deliver prompts via stdin for non-Claude agents to avoid `spawn ENAMETOOLONG`. ([#15])
+- Mitigate Windows `ENAMETOOLONG` and fix daemon crash on cleanup. ([#75])
+- Fix `PROMPT_TEMP_FILE()` call and Claude Code stdin delivery on Windows. ([#97])
+- Normalize web dev tsconfig paths on Windows for `tools-dev`. ([#174])
+- Support Claude Code CLI <1.0.86 (avoid `--include-partial-messages`, parse assistant wrapper text). ([#34])
+
+#### Daemon & providers
+- CORS header on raw project file endpoint. ([#140])
+- Preserve non-ASCII filenames on multipart upload. ([#166])
+- Stop passing literal dash to `cursor-agent`. ([#160])
+- Non-interactive permissions for agent CLIs in web UI. ([#26])
+- Codex plugin disable env. ([#133])
+- Codex assistant agent labels. ([#70])
+
+#### Web UI
+- Welcome dialog: stop overwriting user's agent pick on Save. ([#4])
+- Allow Claude Code to read skill seeds and design-system specs. ([#7])
+- Question form checkbox selection limits enforced. ([#81])
+- SettingsDialog content overflow + scrolling, refactored layout and modal styling. ([#83], [#88])
+- Duplicate `H.` heading in `discovery.ts` (→ `I.`). ([#87])
+- guizang-ppt: sync host slide counter on transform-paginated decks. ([#19])
+- Toolbar button text wrapping prevented for CJK languages. ([#178])
+- PreviewModal exits fullscreen on first Esc. ([#168])
+- Dev indicator moved to bottom-right corner. ([#108])
+- Design Files: align upload picker with dropzone, neutral agent copy, remove unsupported Figma copy. ([#199], [#200], [#201])
+- Web locale registry test includes Japanese. ([#202])
+
+### Documentation
+
+- README refresh with stats, agents, skills, and metrics workflow. ([#173])
+- Korean (한국어) and Japanese README and docs translations. ([#105], [#183])
+- `TRANSLATIONS.md` i18n contribution guide. ([#196])
+- Refresh environment setup guidance. ([#104])
+- Xiaohongshu design-system docs review feedback. ([#54])
+
+### Internal
+
+- Initial project structure, project rename "Open Claude Design" → "Open Design", naming optimization. ([#1], [#2])
+- Initial AGENTS.md and OpenCode agent instructions. ([#114])
+- Beta release workflow placeholder. ([#36])
+- Git commit co-author policy. ([#131])
+
+[Unreleased]: https://github.com/nexu-io/open-design/compare/open-design-v0.1.0...HEAD
+[0.1.0]: https://github.com/nexu-io/open-design/releases/tag/open-design-v0.1.0
+
+[#1]: https://github.com/nexu-io/open-design/pull/1
+[#2]: https://github.com/nexu-io/open-design/pull/2
+[#4]: https://github.com/nexu-io/open-design/pull/4
+[#5]: https://github.com/nexu-io/open-design/pull/5
+[#7]: https://github.com/nexu-io/open-design/pull/7
+[#9]: https://github.com/nexu-io/open-design/pull/9
+[#12]: https://github.com/nexu-io/open-design/pull/12
+[#13]: https://github.com/nexu-io/open-design/pull/13
+[#14]: https://github.com/nexu-io/open-design/pull/14
+[#15]: https://github.com/nexu-io/open-design/pull/15
+[#19]: https://github.com/nexu-io/open-design/pull/19
+[#24]: https://github.com/nexu-io/open-design/pull/24
+[#26]: https://github.com/nexu-io/open-design/pull/26
+[#28]: https://github.com/nexu-io/open-design/pull/28
+[#31]: https://github.com/nexu-io/open-design/pull/31
+[#34]: https://github.com/nexu-io/open-design/pull/34
+[#35]: https://github.com/nexu-io/open-design/pull/35
+[#36]: https://github.com/nexu-io/open-design/pull/36
+[#46]: https://github.com/nexu-io/open-design/pull/46
+[#54]: https://github.com/nexu-io/open-design/pull/54
+[#63]: https://github.com/nexu-io/open-design/pull/63
+[#64]: https://github.com/nexu-io/open-design/pull/64
+[#66]: https://github.com/nexu-io/open-design/pull/66
+[#68]: https://github.com/nexu-io/open-design/pull/68
+[#70]: https://github.com/nexu-io/open-design/pull/70
+[#71]: https://github.com/nexu-io/open-design/pull/71
+[#73]: https://github.com/nexu-io/open-design/pull/73
+[#74]: https://github.com/nexu-io/open-design/pull/74
+[#75]: https://github.com/nexu-io/open-design/pull/75
+[#76]: https://github.com/nexu-io/open-design/pull/76
+[#79]: https://github.com/nexu-io/open-design/pull/79
+[#80]: https://github.com/nexu-io/open-design/pull/80
+[#81]: https://github.com/nexu-io/open-design/pull/81
+[#83]: https://github.com/nexu-io/open-design/pull/83
+[#87]: https://github.com/nexu-io/open-design/pull/87
+[#88]: https://github.com/nexu-io/open-design/pull/88
+[#92]: https://github.com/nexu-io/open-design/pull/92
+[#97]: https://github.com/nexu-io/open-design/pull/97
+[#102]: https://github.com/nexu-io/open-design/pull/102
+[#104]: https://github.com/nexu-io/open-design/pull/104
+[#105]: https://github.com/nexu-io/open-design/pull/105
+[#107]: https://github.com/nexu-io/open-design/pull/107
+[#108]: https://github.com/nexu-io/open-design/pull/108
+[#111]: https://github.com/nexu-io/open-design/pull/111
+[#114]: https://github.com/nexu-io/open-design/pull/114
+[#117]: https://github.com/nexu-io/open-design/pull/117
+[#118]: https://github.com/nexu-io/open-design/pull/118
+[#123]: https://github.com/nexu-io/open-design/pull/123
+[#127]: https://github.com/nexu-io/open-design/pull/127
+[#128]: https://github.com/nexu-io/open-design/pull/128
+[#131]: https://github.com/nexu-io/open-design/pull/131
+[#133]: https://github.com/nexu-io/open-design/pull/133
+[#140]: https://github.com/nexu-io/open-design/pull/140
+[#146]: https://github.com/nexu-io/open-design/pull/146
+[#151]: https://github.com/nexu-io/open-design/pull/151
+[#153]: https://github.com/nexu-io/open-design/pull/153
+[#155]: https://github.com/nexu-io/open-design/pull/155
+[#156]: https://github.com/nexu-io/open-design/pull/156
+[#159]: https://github.com/nexu-io/open-design/pull/159
+[#160]: https://github.com/nexu-io/open-design/pull/160
+[#162]: https://github.com/nexu-io/open-design/pull/162
+[#166]: https://github.com/nexu-io/open-design/pull/166
+[#167]: https://github.com/nexu-io/open-design/pull/167
+[#168]: https://github.com/nexu-io/open-design/pull/168
+[#169]: https://github.com/nexu-io/open-design/pull/169
+[#170]: https://github.com/nexu-io/open-design/pull/170
+[#173]: https://github.com/nexu-io/open-design/pull/173
+[#174]: https://github.com/nexu-io/open-design/pull/174
+[#177]: https://github.com/nexu-io/open-design/pull/177
+[#178]: https://github.com/nexu-io/open-design/pull/178
+[#180]: https://github.com/nexu-io/open-design/pull/180
+[#182]: https://github.com/nexu-io/open-design/pull/182
+[#183]: https://github.com/nexu-io/open-design/pull/183
+[#185]: https://github.com/nexu-io/open-design/pull/185
+[#187]: https://github.com/nexu-io/open-design/pull/187
+[#190]: https://github.com/nexu-io/open-design/pull/190
+[#191]: https://github.com/nexu-io/open-design/pull/191
+[#196]: https://github.com/nexu-io/open-design/pull/196
+[#197]: https://github.com/nexu-io/open-design/pull/197
+[#199]: https://github.com/nexu-io/open-design/pull/199
+[#200]: https://github.com/nexu-io/open-design/pull/200
+[#201]: https://github.com/nexu-io/open-design/pull/201
+[#202]: https://github.com/nexu-io/open-design/pull/202
+[#204]: https://github.com/nexu-io/open-design/pull/204

--- a/README.de.md
+++ b/README.de.md
@@ -17,6 +17,7 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/nexu-io/open-design/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/nexu-io/open-design?style=flat-square&color=blueviolet&label=release&include_prereleases" /></a>
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache%202.0-blue.svg?style=flat-square" /></a>
   <a href="#supported-coding-agents"><img alt="Agents" src="https://img.shields.io/badge/agents-10%20CLIs%20%2B%20BYOK%20proxy-black?style=flat-square" /></a>
   <a href="#design-systems"><img alt="Design systems" src="https://img.shields.io/badge/design%20systems-72-orange?style=flat-square" /></a>

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -17,6 +17,7 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/nexu-io/open-design/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/nexu-io/open-design?style=flat-square&color=blueviolet&label=release&include_prereleases" /></a>
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache%202.0-blue.svg?style=flat-square" /></a>
   <a href="#対応-coding-agent"><img alt="Agents" src="https://img.shields.io/badge/agents-10%20CLIs%20%2B%20BYOK%20proxy-black?style=flat-square" /></a>
   <a href="#design-system">

--- a/README.ko.md
+++ b/README.ko.md
@@ -17,6 +17,7 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/nexu-io/open-design/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/nexu-io/open-design?style=flat-square&color=blueviolet&label=release&include_prereleases" /></a>
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache%202.0-blue.svg?style=flat-square" /></a>
   <a href="#지원하는-코딩-에이전트"><img alt="Agents" src="https://img.shields.io/badge/agents-10%20CLIs%20%2B%20BYOK%20proxy-black?style=flat-square" /></a>
   <a href="#디자인-시스템"><img alt="Design systems" src="https://img.shields.io/badge/design%20systems-72-orange?style=flat-square" /></a>

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/nexu-io/open-design/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/nexu-io/open-design?style=flat-square&color=blueviolet&label=release&include_prereleases" /></a>
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache%202.0-blue.svg?style=flat-square" /></a>
   <a href="#supported-coding-agents"><img alt="Agents" src="https://img.shields.io/badge/agents-10%20CLIs%20%2B%20BYOK%20proxy-black?style=flat-square" /></a>
   <a href="#design-systems"><img alt="Design systems" src="https://img.shields.io/badge/design%20systems-72-orange?style=flat-square" /></a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -17,6 +17,7 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/nexu-io/open-design/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/nexu-io/open-design?style=flat-square&color=blueviolet&label=release&include_prereleases" /></a>
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache%202.0-blue.svg?style=flat-square" /></a>
   <a href="#支持的-coding-agent"><img alt="Agents" src="https://img.shields.io/badge/agents-10%20CLIs%20%2B%20BYOK%20proxy-black?style=flat-square" /></a>
   <a href="#design-system"><img alt="Design systems" src="https://img.shields.io/badge/design%20systems-72-orange?style=flat-square" /></a>

--- a/scripts/release-stable.ts
+++ b/scripts/release-stable.ts
@@ -1,0 +1,141 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { appendFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCallback);
+
+const stableVersionPattern = /^(\d+)\.(\d+)\.(\d+)$/;
+const stableTagPattern = /^open-design-v(\d+\.\d+\.\d+)$/;
+
+type GitHubRelease = {
+  draft?: boolean;
+  name?: string | null;
+  prerelease?: boolean;
+  tag_name?: string;
+};
+
+type ParsedStableVersion = {
+  parsed: [number, number, number];
+  value: string;
+};
+
+function fail(message: string): never {
+  console.error(`[release-stable] ${message}`);
+  process.exit(1);
+}
+
+function parseStableVersion(value: string): [number, number, number] | null {
+  const match = stableVersionPattern.exec(value);
+  if (match == null) return null;
+
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function compareVersions(left: [number, number, number], right: [number, number, number]): number {
+  const [leftMajor, leftMinor, leftPatch] = left;
+  const [rightMajor, rightMinor, rightPatch] = right;
+  const pairs = [
+    [leftMajor, rightMajor],
+    [leftMinor, rightMinor],
+    [leftPatch, rightPatch],
+  ] as const;
+
+  for (const [leftPart, rightPart] of pairs) {
+    if (leftPart > rightPart) return 1;
+    if (leftPart < rightPart) return -1;
+  }
+
+  return 0;
+}
+
+function extractStableVersion(release: GitHubRelease): ParsedStableVersion | null {
+  const candidates = [release.tag_name, release.name].filter((value): value is string => typeof value === "string");
+
+  for (const candidate of candidates) {
+    const tagMatch = stableTagPattern.exec(candidate);
+    const value = tagMatch?.[1] ?? candidate.match(/\b(\d+\.\d+\.\d+)\b/)?.[1];
+    if (value == null) continue;
+
+    const parsed = parseStableVersion(value);
+    if (parsed != null) return { parsed, value };
+  }
+
+  return null;
+}
+
+async function readPackagedVersion(): Promise<string> {
+  const packageJsonPath = join(process.cwd(), "apps", "packaged", "package.json");
+  const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as { version?: unknown };
+
+  if (typeof packageJson.version !== "string") {
+    fail(`missing version in ${packageJsonPath}`);
+  }
+
+  if (!stableVersionPattern.test(packageJson.version)) {
+    fail(`apps/packaged/package.json version must be a stable x.y.z base version; got ${packageJson.version}`);
+  }
+
+  return packageJson.version;
+}
+
+async function fetchReleases(repository: string): Promise<GitHubRelease[]> {
+  const releases: GitHubRelease[] = [];
+  for (let page = 1; ; page += 1) {
+    const { stdout } = await execFile("gh", ["api", `repos/${repository}/releases?per_page=100&page=${page}`]);
+    const batch = JSON.parse(stdout) as GitHubRelease[];
+    if (batch.length === 0) break;
+    releases.push(...batch);
+  }
+  return releases;
+}
+
+function setOutput(name: string, value: string): void {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (outputPath == null || outputPath.length === 0) return;
+  appendFileSync(outputPath, `${name}=${value}\n`);
+}
+
+const repository = process.env.GITHUB_REPOSITORY ?? fail("GITHUB_REPOSITORY is required");
+const stableVersion = await readPackagedVersion();
+const stableParsed = parseStableVersion(stableVersion) ?? fail(`invalid packaged version: ${stableVersion}`);
+const versionTag = `open-design-v${stableVersion}`;
+const releases = await fetchReleases(repository);
+
+let latestStable: ParsedStableVersion | null = null;
+for (const release of releases) {
+  if (release.draft === true || release.prerelease === true) continue;
+
+  const parsedRelease = extractStableVersion(release);
+  if (parsedRelease == null) continue;
+
+  if (release.tag_name === versionTag) {
+    fail(`stable release ${versionTag} already exists; bump apps/packaged/package.json before publishing`);
+  }
+
+  if (latestStable == null || compareVersions(parsedRelease.parsed, latestStable.parsed) > 0) {
+    latestStable = parsedRelease;
+  }
+}
+
+if (latestStable != null && compareVersions(stableParsed, latestStable.parsed) <= 0) {
+  fail(`packaged stable version ${stableVersion} must be strictly greater than latest stable ${latestStable.value}`);
+}
+
+const branch = process.env.GITHUB_REF_NAME ?? "";
+const commit = process.env.GITHUB_SHA ?? "";
+const releaseName = `Open Design ${stableVersion}`;
+
+console.log(`[release-stable] channel: stable`);
+console.log(`[release-stable] version: ${stableVersion}`);
+console.log(`[release-stable] version tag: ${versionTag}`);
+if (latestStable != null) console.log(`[release-stable] previous stable: ${latestStable.value}`);
+
+setOutput("base_version", stableVersion);
+setOutput("branch", branch);
+setOutput("commit", commit);
+setOutput("previous_stable", latestStable?.value ?? "");
+setOutput("release_name", releaseName);
+setOutput("stable_version", stableVersion);
+setOutput("version_tag", versionTag);


### PR DESCRIPTION

🚀 **First public release of Open Design — the open-source alternative to Claude Design.** Local-first, web-deployable, BYOK at every layer — **11 coding-agent CLIs** auto-detected on your `PATH` (Claude Code, Codex, Cursor Agent, Gemini CLI, OpenCode, Qwen, GitHub Copilot CLI, Hermes, Kimi, Pi, Kiro) become the design engine, driven by **31 composable Skills** and **72 brand-grade Design Systems**. No CLI? An OpenAI-compatible BYOK proxy is the same loop minus the spawn.

## 🎉 Highlights

- 🤖 **Bring your own coding agent.** Claude Code, Codex, Cursor, Gemini CLI, OpenCode, Qwen, Copilot, Hermes, Kimi, Pi, and Kiro — all auto-detected, all swappable on the fly. (#28, #71, #117, #185) Thanks @heylakatos, @nettee, @monotykamary, and @GeorgePSpark.
- 🎨 **72 brand-grade design systems on day one.** Plus **31 composable skills** and 57 community design specs from awesome-design-skills. (#24, #74, #92) Thanks @linqibin0826, @joeylee12629-star, and @zoltanszogyenyi.
- 🖼️ **Sandboxed live previews.** Decks, SVG, Markdown, multi-file HTML, image, video, audio — all rendered next to chat. (#12, #31, #46, #63, #68, #73, #156, #177) Thanks @pftom, @Aresdgi, @Siri-Ray, @alchemistklk, and @hikmettuysuz.
- 🖥️ **Run it anywhere.** Signed/notarized macOS app, Windows beta installer, terminal mode, or one-click Vercel self-deploy. (#167, #169, #170, #191) Thanks @PerishCode, @alchemistklk, and @FrancoStino.
- 🌍 **Nine UI languages on launch.** zh-CN, zh-TW, English, Japanese, German, Spanish, Russian, Persian, Brazilian Portuguese. (#79, #80, #155, #159, #182, #190, #197) Thanks @TulioMagnus, @laihenyi, @Tom-Opencart, @amirrezakm, @joseconti, @Sid-Qin, and @sysCat64.

> 📥 **Download:** the table below points at the final asset URLs — links go live once this PR is merged and the `release-stable` workflow finishes. Tag: `open-design-v0.1.0`.
>
> | Platform | Architecture | Asset |
> |---|---|---|
> | macOS | Apple Silicon (arm64) | [open-design-0.1.0-mac-arm64.dmg](https://github.com/nexu-io/open-design/releases/download/open-design-v0.1.0/open-design-0.1.0-mac-arm64.dmg) |
> | macOS (auto-update feed) | Apple Silicon (arm64) | [open-design-0.1.0-mac-arm64.zip](https://github.com/nexu-io/open-design/releases/download/open-design-v0.1.0/open-design-0.1.0-mac-arm64.zip) |
> | Windows | x64 (unsigned) | [open-design-0.1.0-win-x64-setup.exe](https://github.com/nexu-io/open-design/releases/download/open-design-v0.1.0/open-design-0.1.0-win-x64-setup.exe) |

## ✅ System Requirements

- **macOS** — Apple Silicon (arm64) only, macOS 11 Big Sur or newer. Intel macs are not supported in 0.1.0.
- **Windows** — x64, Windows 10 / 11. Installer is **unsigned** (SmartScreen will warn on first launch — choose "More info → Run anyway").
- **Linux** — no packaged build in 0.1.0; run from source via `pnpm tools-dev`.
- **From source** — Node.js 24.x and pnpm 10.33.2+ (per `engines` in `package.json`).

## ⚠️ Known Issues

- 🪟 **Windows installer is unsigned** — SmartScreen / antivirus will warn on first launch. Code signing is planned for a follow-up release.
- 🍎 **No macOS Intel (x64) build** — Apple Silicon only in 0.1.0. Intel users can run from source.
- 🐧 **No Linux desktop package** — daemon and web run from source meanwhile.

## ✨ What's New

### 🤖 Agents

- **Eleven CLIs, auto-detected on launch.** (#28, #71, #117, #185)
- **Pick a model per chat** without leaving the conversation. (#14) Thanks @pftom.
- **Plug in any OpenAI- or Anthropic-compatible provider** — self-hosted gateways and proxies welcome. (#80, #180) Thanks @laihenyi and @ccfuncy.
- **Always know which build you're on** — app version visible across daemon and web. (#204) Thanks @Aresdgi.

### 🎨 Design catalog

- **72 brand-grade design systems** — including Xiaohongshu and an 8-theme Replit Deck pack. (#24, #74) Thanks @linqibin0826 and @joeylee12629-star.
- **57 new design skill specs** from the awesome-design-skills community. (#92) Thanks @zoltanszogyenyi.
- **New starter prompts** — dance storyboard, ancient-China MMO HUD. (#187) Thanks @joeylee12629-star.

### 🖼️ Artifacts & preview

- **Sandboxed previews for everything** — SVG, Markdown, multi-file HTML with relative assets. (#68, #73, #156, #177) Thanks @Aresdgi and @hikmettuysuz.
- **Drop in your own files** — multi-file uploads, document previews, Claude Design `.zip` import. (#31, #46, #63) Thanks @Aresdgi, @Siri-Ray, and @alchemistklk.
- **Image, video, audio in one dispatcher** — `od media generate`. (#12) Thanks @pftom.

### 📦 Install anywhere

- **macOS app, signed and notarized**, with auto-update via update ZIP. (#170) Thanks @PerishCode.
- **Windows beta installer** — native NSIS for x64 (currently unsigned). (#191) Thanks @PerishCode.
- **One-click Vercel self-deploy** — `vercel.json` ships with the repo. (#167, #169) Thanks @alchemistklk and @FrancoStino.

### 🛠️ Workspace tooling

- **`tools-dev` and `tools-pack`** — one-command dev and packaging. (#127, #128, #153) Thanks @PerishCode, @nettee, and @mrcfps.
- **`dev:all` auto-picks a free port** when defaults are busy. (#9) Thanks @pftom.
- **UI end-to-end automation** with reporting under `apps/e2e`. (#64, #102) Thanks @shangxinyu1 and @PerishCode.
- **Friendlier language switcher.** (#107) Thanks @nettee.

## 🛡️ Stability & Reliability

- **Chats survive a flaky network** — close your laptop or lose Wi-Fi mid-generation, the run keeps going and you reconnect to live state. (#146) Thanks @nettee.
- **Reliable streaming behind reverse proxies** — fixed SSE keepalive when running behind nginx. (#111) Thanks @alchemistklk.
- **Windows is now a first-class path** — long working paths, stdin prompt delivery, clean daemon shutdown, correct tsconfig resolution, support for older Claude Code CLI. (#13, #15, #34, #75, #97, #174) Thanks @pftom, @KNIGHTABDO, @lukebaze, @ONEGAYI, @LucaLombardo03, and @Waleed978.

## 🐛 Bug Fixes

- Fixed missing CORS header on raw project file endpoint, preserved non-ASCII filenames on uploads. (#140, #166) Thanks @JiangDing1990 and @fancyboi999.
- Stopped passing a literal dash to `cursor-agent`; restored non-interactive permissions for agent CLIs in web. (#26, #160) Thanks @JoKer049 and @Derrick-xn.
- Codex: honor disable-plugins env and fixed assistant labels. (#70, #133) Thanks @alchemistklk.
- Welcome dialog no longer overwrites your agent pick; allowed Claude Code to read skill seeds and design-system specs. (#4, #7) Thanks @heylakatos and @pftom.
- Settings: enforced checkbox limits, fixed overflow / scrolling, refreshed layout. (#81, #83, #88) Thanks @Siri-Ray, @pythonsir, and @JiangDing1990.
- Web polish: prevented CJK toolbar wrap, fixed PreviewModal Esc-to-exit, moved dev indicator bottom-right, aligned Design Files copy with dropzone, included Japanese in locale registry test. (#108, #168, #178, #199, #200, #201, #202) Thanks @nmsn, @voidborne-d, and @Sid-Qin.
- Daemon: surfaced unfinished todo runs, fixed project-root resolution from src via tsx, supported standalone `pnpm` binary in postinstall, pinned install toolchain, removed duplicate `H.` heading in `discovery.ts`, synced guizang-ppt slide counter. (#19, #35, #76, #87, #151, #162) Thanks @alchemistklk, @gonewx, @therealpan, @mrcfps, and @heylakatos.

## 📚 Documentation

- **Refreshed README** — current stats, full agent and skill catalog, metrics workflow. (#173) Thanks @pftom.
- **Korean and Japanese README + docs translations.** (#105, #183) Thanks @Charlesswoo and @eltociear.
- **`TRANSLATIONS.md` i18n contribution guide**, refreshed environment setup, Xiaohongshu docs review. (#54, #104, #196) Thanks @laihenyi, @PerishCode, and @linqibin0826.

## 🔨 For Developers

<details>
<summary>Click to expand</summary>

- Initial project structure, rename "Open Claude Design" → "Open Design", and naming optimization. (#1, #2) Thanks @pftom.
- Frontend toolchain migrated from Vite to Next.js 16 App Router. (#66) Thanks @pftom.
- Project code migrated to TypeScript with shared contracts. (#118) Thanks @nettee.
- Initial `AGENTS.md` / OpenCode agent instructions, beta release workflow placeholder, and commit co-author policy. (#36, #114, #131) Thanks @nettee and @PerishCode.
- Refreshed desktop integration control plane, star-us prompt. (#5, #123) Thanks @pftom and @PerishCode.

</details>

---

## 🚀 Releasing this PR

This PR ships:

1. **`CHANGELOG.md`** — first entry for `0.1.0`.
2. **`scripts/release-stable.ts`** — stable metadata script (mirrors `release-beta.ts`; fails fast if `open-design-v{version}` already exists or is not strictly greater than the current latest stable).
3. **`.github/workflows/release-stable.yml`** — manually-dispatched workflow (`mac_signed: boolean = true`) that builds mac arm64 + Windows x64, creates the immutable `open-design-v0.1.0` tag, and publishes a non-prerelease release marked `--latest` with checksums and updater feeds.

After merge, dispatch the `release-stable` workflow with `mac_signed=true` to publish.

**Full Changelog:** https://github.com/nexu-io/open-design/compare/a98096a...release/v0.1.0
