### PR TITLE
fix(release-stable): build daemon before workspace typecheck

### DIFF
--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -70,8 +70,19 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Typecheck
-        run: pnpm typecheck
+      # Build the daemon's dist before workspace typecheck — the e2e workspace's
+      # typecheck imports types from `apps/daemon/dist/*.js`, which only exist
+      # after the daemon build runs. The root `typecheck` script builds the
+      # daemon AFTER running -r typecheck, so on a fresh clone (CI) it fails.
+      # Driving the order explicitly here keeps the root script untouched.
+      - name: Build daemon (e2e typecheck depends on its dist)
+        run: pnpm --filter @open-design/daemon build
+
+      - name: Typecheck workspaces
+        run: pnpm -r --workspace-concurrency=1 --if-present run typecheck
+
+      - name: Check residual JS in TypeScript packages
+        run: pnpm check:residual-js
 
       - name: Test (workspace, if present)
         run: pnpm -r --workspace-concurrency=1 --if-present run test


### PR DESCRIPTION
## Why

PR #206 shipped the stable release workflow with a new `verify` quality gate (`pnpm typecheck` + workspace tests). The first dispatch ([run 25213930746](https://github.com/nexu-io/open-design/actions/runs/25213930746)) failed at typecheck:

```
e2e/scripts/runtime-adapter.e2e.live.test.ts(50,35): error TS2307:
Cannot find module '../../apps/daemon/dist/server.js'
```

The `e2e` workspace's `typecheck` imports types from `apps/daemon/dist/*.js`, which only exists after the daemon's `build` runs. The root `typecheck` script orders things wrong for a fresh clone:

```
pnpm -r run typecheck && pnpm --filter @open-design/daemon build && pnpm check:residual-js
```

\`-r typecheck\` runs first, so e2e fails before daemon dist gets built. Locally this rarely surfaces because devs already have a previous daemon build sitting in `apps/daemon/dist/`. CI fresh clone hits it every time.

## What this changes

The verify job now drives the order explicitly:

1. `pnpm install --frozen-lockfile`
2. `pnpm --filter @open-design/daemon build` ← builds dist before typecheck
3. `pnpm -r run typecheck` (workspaces)
4. `pnpm check:residual-js`
5. `pnpm -r run test` (workspaces)

The root `typecheck` script is **untouched** — other contributor / dev flows that rely on it still work the same. Only the release workflow imposes the correct ordering.

## Why not fix the root script?

Cross-cutting change with broader blast radius (every contributor's local dev experience). Worth tackling separately as its own issue / PR — for now this hotfix unblocks `release-stable` so we can publish 0.1.0.

## After merge

Re-dispatch `release-stable` workflow with `mac_signed=true`. The atomic publish path means the original failed run left no tag / release / artifact behind — main is clean.

## Test plan

- [ ] verify job runs to green on this PR (typecheck + tests pass with daemon pre-built)
- [ ] after merge, re-dispatch `release-stable` and confirm the verify → build_mac → build_win → publish chain completes