### PR TITLE
Fix metrics workflow protected branch updates

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -33,8 +33,11 @@ jobs:
           committer_token: ${{ secrets.GITHUB_TOKEN }}
 
           # Use the repository template (per-repo metrics, not user metrics).
-          base: ''
+          # Organization-owned repositories must be targeted explicitly, otherwise
+          # lowlighter/metrics infers the token owner and treats the target as an org.
           template: repository
+          user: nexu-io
+          repo: open-design
 
           # Plugins. Anything that requires a personal token will silently no-op
           # without METRICS_TOKEN — the rest still produce a useful SVG.

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -23,7 +23,8 @@ jobs:
       - name: Generate GitHub repository metrics
         uses: lowlighter/metrics@latest
         with:
-          # Output path; the action opens a PR when this file changes.
+          # Output path; the action opens/updates a PR when this file changes.
+          # Requires manual review to merge. If metrics unchanged, no PR is created.
           filename: docs/assets/github-metrics.svg
 
           # Auth: prefers a fine-grained PAT (richer plugins) but falls back to GITHUB_TOKEN.
@@ -39,6 +40,7 @@ jobs:
           # Organization-owned repositories must be targeted explicitly, otherwise
           # lowlighter/metrics infers the token owner and treats the target as an org.
           template: repository
+          base: ''
           user: nexu-io
           repo: open-design
 

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   metrics:
@@ -22,7 +23,7 @@ jobs:
       - name: Generate GitHub repository metrics
         uses: lowlighter/metrics@latest
         with:
-          # Output path; the action commits this file back into the repo on changes.
+          # Output path; the action opens a PR when this file changes.
           filename: docs/assets/github-metrics.svg
 
           # Auth: prefers a fine-grained PAT (richer plugins) but falls back to GITHUB_TOKEN.
@@ -31,6 +32,8 @@ jobs:
           # plugins simply silently no-op and the rest of the SVG still renders.
           token: ${{ secrets.METRICS_TOKEN || secrets.GITHUB_TOKEN }}
           committer_token: ${{ secrets.GITHUB_TOKEN }}
+          output_action: pull-request
+          output_condition: data-changed
 
           # Use the repository template (per-repo metrics, not user metrics).
           # Organization-owned repositories must be targeted explicitly, otherwise


### PR DESCRIPTION
## Summary
- Switch the GitHub metrics workflow output action to create a pull request when the generated SVG changes.
- Add `pull-requests: write` permission and `output_condition: data-changed` to avoid direct pushes to protected `main`.

## Validation
- Parsed `.github/workflows/metrics.yml` with Ruby YAML loader.