### PR TITLE
feat(craft): add brand-agnostic craft references + Refero-derived lint rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ This file is the single source of truth for agents entering this repository. Rea
 ## Workspace directories
 
 - Workspace packages come from `pnpm-workspace.yaml`: `apps/*`, `packages/*`, `tools/*`, and `e2e`.
+- Top-level content directories: `skills/` (artifact-shape skills), `design-systems/` (brand `DESIGN.md` files), `craft/` (universal brand-agnostic craft rules a skill can opt into via `od.craft.requires`).
 - `apps/web` is the Next.js 16 App Router + React 18 web runtime; do not restore `apps/nextjs`.
 - `apps/daemon` is the local privileged daemon and `od` bin. It owns `/api/*`, agent spawning, skills, design systems, artifacts, and static serving.
 - `apps/desktop` is the Electron shell; it discovers the web URL through sidecar IPC.

--- a/apps/daemon/src/craft.ts
+++ b/apps/daemon/src/craft.ts
@@ -1,0 +1,46 @@
+// @ts-nocheck
+// Craft references loader. The active skill declares which sections it
+// needs via `od.craft.requires`; this module reads the matching files
+// from <projectRoot>/craft/<slug>.md and returns a single concatenated
+// body ready to splice into the system prompt. Missing files are
+// dropped silently — a skill that lists `motion` before we ship a
+// motion.md should still work, just without the motion section.
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const SLUG_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+/**
+ * @param {string} craftDir absolute path to the craft/ directory
+ * @param {string[]} requested slugs from `od.craft.requires`
+ * @returns {Promise<{ body: string, sections: string[] }>}
+ *   body is the concatenated markdown (each file preceded by a level-3
+ *   section header). sections lists which slugs actually resolved.
+ */
+export async function loadCraftSections(craftDir, requested) {
+  if (!craftDir || !Array.isArray(requested) || requested.length === 0) {
+    return { body: "", sections: [] };
+  }
+  const seen = new Set();
+  const parts = [];
+  const sections = [];
+  for (const raw of requested) {
+    if (typeof raw !== "string") continue;
+    const slug = raw.trim().toLowerCase();
+    if (!SLUG_RE.test(slug) || seen.has(slug)) continue;
+    seen.add(slug);
+    try {
+      const filePath = path.join(craftDir, `${slug}.md`);
+      const text = await readFile(filePath, "utf8");
+      const trimmed = text.trim();
+      if (!trimmed) continue;
+      parts.push(`### ${slug}\n\n${trimmed}`);
+      sections.push(slug);
+    } catch {
+      // File doesn't exist or unreadable — skip silently. Skills can
+      // forward-reference future craft sections without breaking.
+    }
+  }
+  return { body: parts.join("\n\n---\n\n"), sections };
+}

--- a/apps/daemon/src/lint-artifact.ts
+++ b/apps/daemon/src/lint-artifact.ts
@@ -130,8 +130,8 @@ export function lintArtifact(rawHtml) {
   // check didn't already, since they overlap in spirit. Strip
   // token-definition blocks first: a brief whose accent is
   // intentionally indigo declares it as `--accent: #6366f1` inside
-  // a selector list containing `:root` (or another global token
-  // scope like `html` / bare `[data-theme="..."]`) and uses
+  // a selector list containing `:root` (or another known global
+  // theme scope like `html` / bare `[data-theme="..."]`) and uses
   // var(--accent) downstream. That is the design system speaking,
   // not the model defaulting, and must not fire. Component-local
   // variables (e.g. `.cta { --cta-bg: #6366f1; }`) stay in scope so
@@ -460,10 +460,13 @@ function escapeRe(s) {
 // A rule is treated as a token block only when BOTH conditions hold:
 //   1. every selector in the list is a global theme-scope selector
 //      (`:root`, `:root[data-theme="..."]`, `html`, `body`, or a bare
-//      `[data-theme="..."]`). Selector lists that mix in a component
-//      selector — e.g. `:root, .cta { --cta-bg: #6366f1 }` — fail
-//      this test, so indigo laundered through a local var or rule
-//      still trips the lint.
+//      attribute selector for a known global-theme switch —
+//      `data-theme`, `data-color-scheme`, `data-mode`). Selector lists
+//      that mix in a component selector — e.g.
+//      `:root, .cta { --cta-bg: #6366f1 }` — or that target an
+//      arbitrary component/state attribute like `[data-variant="primary"]`
+//      or `[aria-current="page"]` fail this test, so indigo laundered
+//      through a local var or rule still trips the lint.
 //   2. its body is token-shaped: only CSS custom properties
 //      (`--name: value`), with a small allowlist for global-theme
 //      metadata such as `color-scheme` that legitimately accompanies
@@ -479,7 +482,13 @@ function stripTokenBlocks(input) {
 }
 
 function stripTokenBlocksFromCss(css) {
-  return css.replace(/([^{}]*)\{([^}]*)\}/g, (full, selector, body) => {
+  // Strip CSS comments before any structural matching: a block like
+  // `:root { /* brand accent */ --accent: #6366f1; }` would otherwise
+  // produce a declaration fragment that begins with the comment,
+  // fail `isTokenShapedDeclaration`, and leave a legitimate token
+  // definition in scope of the indigo scan.
+  const cleaned = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  return cleaned.replace(/([^{}]*)\{([^}]*)\}/g, (full, selector, body) => {
     const sel = (selector || '').trim();
     if (!selectorListIsGlobalThemeScope(sel)) return full;
     const decls = (body || '')
@@ -509,6 +518,18 @@ function selectorListIsGlobalThemeScope(selector) {
   return parts.every(isGlobalThemeScopeSelector);
 }
 
+// Bare attribute selectors are exempted only when the attribute is one
+// of the known global-theme switches. A broader exemption would also
+// strip arbitrary component/state attribute rules
+// (e.g. `[data-variant="primary"] { --button-bg: #6366f1; }` or
+// `[aria-current="page"] { --nav-accent: #6366f1; }`), which is the
+// exact component-local indigo laundering this lint is meant to catch.
+const GLOBAL_THEME_ATTRIBUTES = new Set([
+  'data-theme',
+  'data-color-scheme',
+  'data-mode',
+]);
+
 function isGlobalThemeScopeSelector(s) {
   // :root, :root[data-theme="dark"]
   if (/^:root(?:\[[^\]]*\])?$/.test(s)) return true;
@@ -516,7 +537,10 @@ function isGlobalThemeScopeSelector(s) {
   if (/^html(?:\[[^\]]*\])?$/.test(s)) return true;
   // body, body[data-theme="dark"]
   if (/^body(?:\[[^\]]*\])?$/.test(s)) return true;
-  // bare attribute selector: [data-theme="dark"], [data-color-scheme="..."]
-  if (/^\[[a-zA-Z-]+(?:[*^$|~]?=[^\]]*)?\]$/.test(s)) return true;
+  // Bare attribute selector restricted to known global-theme switches.
+  const bareAttr = /^\[([a-zA-Z-]+)(?:[*^$|~]?=[^\]]*)?\]$/.exec(s);
+  if (bareAttr && GLOBAL_THEME_ATTRIBUTES.has(bareAttr[1].toLowerCase())) {
+    return true;
+  }
   return false;
 }

--- a/apps/daemon/src/lint-artifact.ts
+++ b/apps/daemon/src/lint-artifact.ts
@@ -500,14 +500,25 @@ function escapeRe(s) {
 // it enforces is the per-element em floor; convert `rem` to absolute
 // px and reuse the same px-vs-element-font-size resolution.
 //
-// px (and the converted-rem path) resolve in two steps:
-//   1. If the same rule body declares `font-size: <n>px`, compare px
-//      tracking against `n * 0.06` — exact translation of the em rule.
-//   2. Otherwise (font-size inherited or in a different unit), use a
-//      conservative `>= 1px` absolute fallback. That stays correct for
-//      the typical body-text default of 16px (1px / 16px ≈ 0.0625em,
-//      just over the floor) and for any smaller label (1px / 14px ≈
-//      0.071em, 1px / 12px ≈ 0.083em).
+// px (and the converted-rem path) resolve in three steps:
+//   1. If the same rule body declares `font-size` in `px` or `rem`
+//      (after `var()` resolution), convert it to absolute px and
+//      compare px tracking against `fs * 0.06` — exact translation
+//      of the em rule. `rem` font sizes resolve via the same root
+//      assumption used for tracking, so a `font-size: 3rem` heading
+//      enforces a 2.88px floor instead of the lenient body fallback.
+//   2. If the rule explicitly declares a `font-size` in a unit we
+//      can't resolve (`em`, `%`, `calc(...)`, an unresolved var,
+//      etc.), refuse the lenient fallback: the heading might be
+//      arbitrarily large, in which case 1px tracking is well below
+//      0.06em. Treat as missing tracking — the agent can either
+//      switch to `em` letter-spacing or declare an explicit px/rem
+//      font-size we can verify.
+//   3. Otherwise (no font-size declared at all, font-size inherited),
+//      use a conservative `>= 1px` absolute fallback. That stays
+//      correct for the typical body-text default of 16px (1px / 16px
+//      ≈ 0.0625em, just over the floor) and for any smaller label
+//      (1px / 14px ≈ 0.071em, 1px / 12px ≈ 0.083em).
 //
 // `tokens` (optional) is a map of CSS custom properties harvested from
 // global theme scopes elsewhere in the artifact. When provided, simple
@@ -529,12 +540,27 @@ function hasAdequateUppercaseTracking(body, tokens) {
   const unit = lsMatch[2].toLowerCase();
   if (unit === 'em') return v >= 0.06;
   const trackingPx = unit === 'rem' ? v * ROOT_FONT_PX : v;
-  const fsMatch = /font-size\s*:\s*(-?\d*\.?\d+)\s*px/i.exec(resolved);
-  if (fsMatch) {
-    const fs = parseFloat(fsMatch[1]);
-    return fs > 0 && trackingPx >= fs * 0.06;
+  const fsPx = resolveFontSizePx(resolved);
+  if (fsPx != null) {
+    return fsPx > 0 && trackingPx >= fsPx * 0.06;
   }
+  if (/font-size\s*:/i.test(resolved)) return false;
   return trackingPx >= 1;
+}
+
+// Resolve a same-rule `font-size` declaration to absolute px. Returns
+// the px value when font-size is declared in `px` or `rem` (rem maps
+// via the root font-size assumption shared with tracking); returns
+// `null` when font-size is absent OR present in an unresolvable unit
+// (`em`, `%`, `calc(...)`, an unresolved `var(--...)`). The caller
+// distinguishes those two `null` cases by re-checking for the
+// `font-size:` literal.
+function resolveFontSizePx(body) {
+  const m = /font-size\s*:\s*(-?\d*\.?\d+)\s*(px|rem)\b/i.exec(body);
+  if (!m) return null;
+  const v = parseFloat(m[1]);
+  const unit = m[2].toLowerCase();
+  return unit === 'rem' ? v * ROOT_FONT_PX : v;
 }
 
 // Collect CSS custom properties (`--name: value`) declared in global

--- a/apps/daemon/src/lint-artifact.ts
+++ b/apps/daemon/src/lint-artifact.ts
@@ -38,6 +38,27 @@ const PURPLE_HEXES = [
   '#818cf8', '#a5b4fc', '#c7d2fe', '#e0e7ff', '#eef2ff',
 ];
 
+// Blue / cyan stops used in the documented "blue→cyan two-stop trust
+// gradient" cardinal sin. The purple-gradient rule above only catches
+// gradients that contain a violet/indigo hex or the literal
+// `purple`/`violet` keyword, so an artifact emitting
+// `linear-gradient(90deg, #3b82f6, #06b6d4)` (or the keyword form
+// `linear-gradient(90deg, blue, cyan)`) slipped past P0 even though
+// `craft/anti-ai-slop.md` explicitly flags it. The `trust-gradient`
+// rule below pairs these against each other to close the gap.
+const TRUST_GRADIENT_BLUE_HEXES = [
+  // Tailwind blue 500–900 + 400/300/200.
+  '#3b82f6', '#2563eb', '#1d4ed8', '#1e40af', '#1e3a8a',
+  '#60a5fa', '#93c5fd', '#bfdbfe',
+  // Tailwind sky 400–700 — the same blue→cyan ramp under a different name.
+  '#0ea5e9', '#0284c7', '#0369a1', '#38bdf8', '#7dd3fc',
+];
+const TRUST_GRADIENT_CYAN_HEXES = [
+  // Tailwind cyan 500–900 + 400/300/200.
+  '#06b6d4', '#0891b2', '#0e7490', '#155e75', '#164e63',
+  '#22d3ee', '#67e8f9', '#a5f3fc',
+];
+
 // Subset of PURPLE_HEXES that constitute the canonical "default LLM
 // accent" — even a single solid use is a tell. The DESIGN.md provides
 // `var(--accent)`; if a brief truly needs indigo, the design system
@@ -127,6 +148,29 @@ export function lintArtifact(rawHtml) {
         message: `Found a "${m[1]}" keyword inside a gradient — anti-slop.`,
         fix: 'Remove the gradient or swap to a single solid color from the active design tokens.',
         snippet: clip(m[0]),
+      });
+    }
+  }
+
+  // ── P0-1c: blue→cyan "trust" two-stop gradient ─────────────────────
+  // craft/anti-ai-slop.md documents three flavours of the two-stop
+  // "trust" gradient — purple→blue, blue→cyan, indigo→pink. The first
+  // and third are caught by `purple-gradient` above because the
+  // relevant indigo/violet hex appears in PURPLE_HEXES, but a pure
+  // blue→cyan gradient has no overlap with that list and slipped
+  // past unflagged. Detect a `linear-gradient(...)` whose stop list
+  // contains both a blue token (hex or keyword) and a cyan token
+  // (hex or keyword). Skip if the purple-gradient rule already fired
+  // so we emit a single corrective signal per artifact.
+  if (out.find((f) => f.id === 'purple-gradient') === undefined) {
+    const tg = detectBlueCyanTrustGradient(html);
+    if (tg) {
+      out.push({
+        severity: 'P0',
+        id: 'trust-gradient',
+        message: `Found a blue→cyan two-stop "trust" gradient — anti-slop list says no.`,
+        fix: 'Replace the gradient with a flat surface (var(--bg) or var(--surface)) or use a single design-token color. Two-stop blue→cyan trust gradients are a SaaS hero cliché.',
+        snippet: clip(tg),
       });
     }
   }
@@ -486,6 +530,28 @@ function escapeRe(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+// Scan every `linear-gradient(...)` body for a blue→cyan two-stop
+// trust gradient. Returns the first matching gradient text or `null`.
+// The check accepts either Tailwind blue/sky/cyan hex stops or the
+// literal `blue`/`cyan` keywords, so both
+// `linear-gradient(90deg, #3b82f6, #06b6d4)` and
+// `linear-gradient(90deg, blue, cyan)` fire P0.
+function detectBlueCyanTrustGradient(html) {
+  const re = /linear-gradient\([^)]*\)/gi;
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    const grad = m[0].toLowerCase();
+    const hasBlue =
+      TRUST_GRADIENT_BLUE_HEXES.some((h) => grad.includes(h.toLowerCase())) ||
+      /\bblue\b/.test(grad);
+    const hasCyan =
+      TRUST_GRADIENT_CYAN_HEXES.some((h) => grad.includes(h.toLowerCase())) ||
+      /\bcyan\b/.test(grad);
+    if (hasBlue && hasCyan) return m[0];
+  }
+  return null;
+}
+
 // True when the declaration body has letter-spacing satisfying the
 // craft rule: `letter-spacing >= 0.06em` of the element's own font.
 //
@@ -521,26 +587,56 @@ function escapeRe(s) {
 //      (1px / 14px ≈ 0.071em, 1px / 12px ≈ 0.083em).
 //
 // `tokens` (optional) is a map of CSS custom properties harvested from
-// global theme scopes elsewhere in the artifact. When provided, simple
-// `var(--name)` (and `var(--name, fallback)`) references in the body
-// are expanded to their literal token values before the regexes run,
-// so a tokenized rule such as `letter-spacing: var(--caps-tracking)`
+// global theme scopes elsewhere in the artifact, keyed by token name to
+// the array of distinct values seen across scopes. When provided,
+// simple `var(--name)` (and `var(--name, fallback)`) references in the
+// body are expanded to their literal token values before the regexes
+// run, so a tokenized rule such as `letter-spacing: var(--caps-tracking)`
 // with `:root { --caps-tracking: 0.08em }` is judged by 0.08em rather
 // than reported as missing tracking. References without a matching
 // token but with an inline fallback (`var(--x, 0.08em)`) resolve to
 // the fallback; unresolved references with no fallback stay in place
 // so the existing "no numeric value" path returns false.
+//
+// When the same token name resolves to multiple distinct values
+// (e.g. `:root { --caps-tracking: 0.02em }` overridden by
+// `[data-theme="dark"] { --caps-tracking: 0.08em }`), the helper is
+// conservative: it enumerates every applicable value combination and
+// returns true only if EVERY resolution satisfies the 0.06em floor.
+// A theme-scoped override that lifts the value above the floor must
+// not silently rescue a default value that renders below it.
 const ROOT_FONT_PX = 16;
 function hasAdequateUppercaseTracking(body, tokens) {
-  const resolved = tokens ? resolveCssVars(body, tokens) : body;
-  // Parse the declaration list and match exact property names so that
-  // CSS custom-property declarations (`--letter-spacing: 0.08em`,
-  // `--display-font-size: 48px`) — which are token definitions with no
-  // rendered effect — cannot satisfy the rule. The previous substring
-  // regex would mistake `--letter-spacing` for `letter-spacing` and
-  // let real violations bypass the P1 lint.
-  const decls = parseDeclarations(resolved);
-  const ls = decls.find((d) => d.prop === 'letter-spacing');
+  const tokensMap = tokens ?? new Map();
+  // Restrict the cartesian to tokens reachable from the body, so a
+  // brand with many unrelated multi-valued tokens does not blow up
+  // the combination count.
+  const relevant = collectRelevantTokens(body, tokensMap);
+  if (relevant.size === 0) {
+    // No global tokens reach the body — but body may still contain
+    // `var(--name, fallback)` refs whose fallback should resolve;
+    // pass through the resolver with an empty token map so fallbacks
+    // collapse to literal values before the regexes run.
+    return isResolvedTrackingAdequate(resolveCssVars(body, new Map()));
+  }
+  const combos = enumerateTokenCombos(relevant);
+  for (const combo of combos) {
+    const resolved = resolveCssVars(body, combo);
+    if (!isResolvedTrackingAdequate(resolved)) return false;
+  }
+  return true;
+}
+
+// Single-resolution tracking check. Parses the declaration list with
+// exact property names (so token-name declarations such as
+// `--letter-spacing: 0.08em` cannot satisfy the rule) and selects the
+// LAST matching `letter-spacing` and `font-size` declarations to model
+// CSS source-order cascade — `.eyebrow { letter-spacing: 0.08em;
+// letter-spacing: 0.02em }` renders the noncompliant `0.02em` value,
+// so the lint must judge against the last declaration, not the first.
+function isResolvedTrackingAdequate(body) {
+  const decls = parseDeclarations(body);
+  const ls = findLastDecl(decls, 'letter-spacing');
   if (!ls) return false;
   const lsMatch = /^(-?\d*\.?\d+)\s*(em|px|rem)\b/i.exec(ls.value);
   if (!lsMatch) return false;
@@ -554,6 +650,62 @@ function hasAdequateUppercaseTracking(body, tokens) {
   }
   if (decls.some((d) => d.prop === 'font-size')) return false;
   return trackingPx >= 1;
+}
+
+// Walk the body's `var(--name)` references transitively through token
+// values, collecting only the tokens that can actually affect the
+// resolved body. Returns a Map<name, string[]> of distinct values.
+function collectRelevantTokens(body, tokens) {
+  const out = new Map();
+  const queue = [];
+  const seen = new Set();
+  for (const m of body.matchAll(/var\(\s*(--[\w-]+)/g)) {
+    if (!seen.has(m[1])) {
+      seen.add(m[1]);
+      queue.push(m[1]);
+    }
+  }
+  while (queue.length > 0) {
+    const name = queue.shift();
+    const values = tokens.get(name);
+    if (!values || values.length === 0) continue;
+    out.set(name, values);
+    for (const value of values) {
+      for (const m of value.matchAll(/var\(\s*(--[\w-]+)/g)) {
+        if (!seen.has(m[1])) {
+          seen.add(m[1]);
+          queue.push(m[1]);
+        }
+      }
+    }
+  }
+  return out;
+}
+
+// Cartesian product over the relevant tokens. Yields one
+// `Map<name, value>` per combination so the existing single-value
+// resolver can be reused unchanged.
+function enumerateTokenCombos(relevant) {
+  let combos = [new Map()];
+  for (const [name, values] of relevant.entries()) {
+    const next = [];
+    for (const c of combos) {
+      for (const v of values) {
+        const copy = new Map(c);
+        copy.set(name, v);
+        next.push(copy);
+      }
+    }
+    combos = next;
+  }
+  return combos;
+}
+
+function findLastDecl(decls, prop) {
+  for (let i = decls.length - 1; i >= 0; i--) {
+    if (decls[i].prop === prop) return decls[i];
+  }
+  return undefined;
 }
 
 // Split a CSS declaration body into `{ prop, value }` entries, lowercasing
@@ -581,8 +733,14 @@ function parseDeclarations(body) {
 // (`em`, `%`, `calc(...)`, an unresolved `var(--...)`). The caller
 // distinguishes those two `null` cases by re-checking the parsed
 // declarations for an exact `font-size` property.
+//
+// Selects the LAST `font-size` declaration in source order so that a
+// rule like `.display { font-size: 48px; font-size: 1em }` is judged
+// against the noncompliant `1em` the browser actually renders, not the
+// stale earlier `48px`. CSS cascade is last-write-wins on conflicting
+// declarations within a single rule body.
 function resolveFontSizePx(decls) {
-  const fs = decls.find((d) => d.prop === 'font-size');
+  const fs = findLastDecl(decls, 'font-size');
   if (!fs) return null;
   const m = /^(-?\d*\.?\d+)\s*(px|rem)\b/i.exec(fs.value);
   if (!m) return null;
@@ -597,10 +755,20 @@ function resolveFontSizePx(decls) {
 // selectors are intentionally ignored: the lint must still catch
 // indigo / under-tracking laundered through a local var, and the
 // tracking helper resolves only the global-scope tokens artifacts use
-// to express design intent. Last-write-wins when the same name is
-// declared in multiple scopes — the canonical artifact pattern is a
-// single :root block per token, so collisions are rare and the rule
-// stays a conservative lint signal regardless.
+// to express design intent.
+//
+// Returns a `Map<name, string[]>` of distinct values seen across
+// scopes — preserving every conflicting value rather than collapsing
+// to last-write-wins. A scoped override that bumps the token above the
+// 0.06em floor must not silently rescue the default-theme value that
+// renders below it: e.g.
+// `:root { --caps-tracking: 0.02em }` paired with
+// `[data-theme="dark"] { --caps-tracking: 0.08em }` is two distinct
+// values, and the tracking helper enumerates both before deciding the
+// rule passes (it must satisfy the floor under EVERY applicable
+// theme). The canonical single-`:root`-per-token artifact pattern still
+// produces a single-element array, so the existing tests are
+// unaffected.
 function extractCssTokens(html) {
   const tokens = new Map();
   for (const styleBlock of html.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/gi)) {
@@ -613,7 +781,12 @@ function extractCssTokens(html) {
       const body = m[2] ?? '';
       for (const decl of body.split(';').map((d) => d.trim()).filter(Boolean)) {
         const dm = /^(--[\w-]+)\s*:\s*(.+)$/.exec(decl);
-        if (dm) tokens.set(dm[1], dm[2].trim());
+        if (dm) {
+          const value = dm[2].trim();
+          const arr = tokens.get(dm[1]) ?? [];
+          if (!arr.includes(value)) arr.push(value);
+          tokens.set(dm[1], arr);
+        }
       }
     }
   }

--- a/apps/daemon/src/lint-artifact.ts
+++ b/apps/daemon/src/lint-artifact.ts
@@ -130,10 +130,12 @@ export function lintArtifact(rawHtml) {
   // check didn't already, since they overlap in spirit. Strip
   // token-definition blocks first: a brief whose accent is
   // intentionally indigo declares it as `--accent: #6366f1` inside
-  // a selector list containing `:root` (or any selector whose body
-  // is custom-property-only — common for theme-variant blocks) and
-  // uses var(--accent) downstream. That is the design system
-  // speaking, not the model defaulting, and must not fire.
+  // a selector list containing `:root` (or another global token
+  // scope like `html` / bare `[data-theme="..."]`) and uses
+  // var(--accent) downstream. That is the design system speaking,
+  // not the model defaulting, and must not fire. Component-local
+  // variables (e.g. `.cta { --cta-bg: #6366f1; }`) stay in scope so
+  // the lint still catches indigo laundered through a local var.
   if (out.find((f) => f.id === 'purple-gradient') === undefined) {
     const htmlForIndigo = stripTokenBlocks(html);
     for (const hex of AI_DEFAULT_INDIGO) {
@@ -449,25 +451,41 @@ function escapeRe(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-// Remove CSS rule blocks that look like design-token definitions:
-//   1. selector list contains `:root` (with optional attribute selector)
-//      — covers `:root { ... }`, `:root[data-theme="dark"] { ... }`, and
-//      lists like `:root, [data-theme="light"] { ... }`.
-//   2. body declares only CSS custom properties (`--name: value`),
-//      regardless of selector — covers theme-variant blocks like
-//      `[data-theme="dark"] { --accent: ... }` that omit `:root`.
-// Real component rules (any declaration that isn't a custom property)
-// are preserved verbatim so hardcoded indigo still trips the lint.
+// Remove CSS rule blocks that look like design-token definitions.
+// Operates only on CSS extracted from <style> blocks — running the
+// rule-shaped regex against the full HTML string makes the first
+// selector capture include leading text like `<style>`, which then
+// fails the `:root` selector test.
+//
+// A rule is treated as a token block when:
+//   1. its selector list contains `:root` (with optional attribute
+//      selector) — covers `:root { ... }`, `:root[data-theme="dark"]
+//      { ... }`, and lists like `:root, [data-theme="light"] { ... }`.
+//   2. its body declares only CSS custom properties (`--name: value`)
+//      AND every selector in the list is a global theme-scope
+//      selector (`html`, `html[data-theme="..."]`, bare
+//      `[data-theme="..."]`, `body[data-theme="..."]`). Component
+//      selectors like `.cta { --cta-bg: #6366f1 }` are NOT exempted,
+//      so indigo laundered through a local custom property still
+//      trips the lint.
 function stripTokenBlocks(input) {
-  return input.replace(/([^{}]*)\{([^}]*)\}/g, (full, selector, body) => {
-    if (selectorListContainsRoot(selector || '')) return '';
+  return input.replace(
+    /(<style[^>]*>)([\s\S]*?)(<\/style>)/gi,
+    (_m, open, css, close) => `${open}${stripTokenBlocksFromCss(css)}${close}`,
+  );
+}
+
+function stripTokenBlocksFromCss(css) {
+  return css.replace(/([^{}]*)\{([^}]*)\}/g, (full, selector, body) => {
+    const sel = (selector || '').trim();
+    if (selectorListContainsRoot(sel)) return '';
     const decls = (body || '')
       .split(';')
       .map((d) => d.trim())
       .filter(Boolean);
-    if (decls.length > 0 && decls.every((d) => /^--[\w-]+\s*:/.test(d))) {
-      return '';
-    }
+    const customOnly =
+      decls.length > 0 && decls.every((d) => /^--[\w-]+\s*:/.test(d));
+    if (customOnly && selectorListIsGlobalThemeScope(sel)) return '';
     return full;
   });
 }
@@ -476,4 +494,22 @@ function selectorListContainsRoot(selector) {
   return selector
     .split(',')
     .some((s) => /^\s*:root(?:\[[^\]]*\])?\s*$/.test(s));
+}
+
+function selectorListIsGlobalThemeScope(selector) {
+  const parts = selector.split(',').map((s) => s.trim()).filter(Boolean);
+  if (parts.length === 0) return false;
+  return parts.every(isGlobalThemeScopeSelector);
+}
+
+function isGlobalThemeScopeSelector(s) {
+  // :root, :root[data-theme="dark"]
+  if (/^:root(?:\[[^\]]*\])?$/.test(s)) return true;
+  // html, html[data-theme="dark"]
+  if (/^html(?:\[[^\]]*\])?$/.test(s)) return true;
+  // body, body[data-theme="dark"]
+  if (/^body(?:\[[^\]]*\])?$/.test(s)) return true;
+  // bare attribute selector: [data-theme="dark"], [data-color-scheme="..."]
+  if (/^\[[a-zA-Z-]+(?:[*^$|~]?=[^\]]*)?\]$/.test(s)) return true;
+  return false;
 }

--- a/apps/daemon/src/lint-artifact.ts
+++ b/apps/daemon/src/lint-artifact.ts
@@ -769,6 +769,16 @@ function resolveFontSizePx(decls) {
 // theme). The canonical single-`:root`-per-token artifact pattern still
 // produces a single-element array, so the existing tests are
 // unaffected.
+//
+// Within a single rule body, CSS cascade is last-write-wins: a block
+// like `:root { --caps-tracking: 0.02em; --caps-tracking: 0.08em; }`
+// renders the second value, and the first never reaches any element.
+// Treating both as simultaneous theme alternatives would feed the
+// stale 0.02em into the tracking helper and emit a spurious P1 on
+// what is normal CSS source-order overriding. So per-scope, we keep
+// only the LAST value declared for each token name; only after that
+// per-scope cascade do we merge into the cross-scope distinct-value
+// map.
 function extractCssTokens(html) {
   const tokens = new Map();
   for (const styleBlock of html.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/gi)) {
@@ -779,14 +789,17 @@ function extractCssTokens(html) {
       const sel = (m[1] ?? '').trim();
       if (!selectorListIsGlobalThemeScope(sel)) continue;
       const body = m[2] ?? '';
+      const perScope = new Map();
       for (const decl of body.split(';').map((d) => d.trim()).filter(Boolean)) {
         const dm = /^(--[\w-]+)\s*:\s*(.+)$/.exec(decl);
         if (dm) {
-          const value = dm[2].trim();
-          const arr = tokens.get(dm[1]) ?? [];
-          if (!arr.includes(value)) arr.push(value);
-          tokens.set(dm[1], arr);
+          perScope.set(dm[1], dm[2].trim());
         }
+      }
+      for (const [name, value] of perScope.entries()) {
+        const arr = tokens.get(name) ?? [];
+        if (!arr.includes(value)) arr.push(value);
+        tokens.set(name, arr);
       }
     }
   }

--- a/apps/daemon/src/lint-artifact.ts
+++ b/apps/daemon/src/lint-artifact.ts
@@ -275,18 +275,7 @@ export function lintArtifact(rawHtml) {
     while ((m = upperRe.exec(css)) !== null) {
       const selector = (m[1] ?? '').trim();
       const body = m[2] ?? '';
-      const lsMatch =
-        /letter-spacing\s*:\s*(-?\d*\.?\d+)\s*(em|px|rem)/i.exec(body);
-      let ok = false;
-      if (lsMatch) {
-        const v = parseFloat(lsMatch[1]);
-        const unit = lsMatch[2].toLowerCase();
-        // 0.06em is the floor; in px, ~1px on a 16px line is borderline,
-        // 1.5px+ comfortably passes for typical heading sizes.
-        if (unit === 'em' || unit === 'rem') ok = v >= 0.06;
-        else if (unit === 'px') ok = v >= 1.5;
-      }
-      if (!ok) {
+      if (!hasAdequateUppercaseTracking(body)) {
         out.push({
           severity: 'P1',
           id: 'all-caps-no-tracking',
@@ -303,26 +292,18 @@ export function lintArtifact(rawHtml) {
   // The <style>-block scan above misses inline declarations such as
   // `<span style="text-transform: uppercase">NEW</span>`, which the
   // browser still renders ALL CAPS. craft/typography.md treats the
-  // tracking floor as having no exceptions, so the inline form needs
-  // the same ≥0.06em / ≥1.5px check. Only fire if the <style>-block
-  // scan above didn't already produce this id, so the agent gets a
-  // single corrective signal per artifact.
+  // tracking floor as having no exceptions, so the inline form runs
+  // through the same `hasAdequateUppercaseTracking` check used by the
+  // <style>-block branch — no separate threshold. Only fire if the
+  // <style>-block scan above didn't already produce this id, so the
+  // agent gets a single corrective signal per artifact.
   if (out.find((f) => f.id === 'all-caps-no-tracking') === undefined) {
     const inlineStyleRe = /(?:^|\s)style\s*=\s*(["'])([\s\S]*?)\1/gi;
     let im;
     while ((im = inlineStyleRe.exec(html)) !== null) {
       const decl = im[2] ?? '';
       if (!/text-transform\s*:\s*uppercase/i.test(decl)) continue;
-      const lsMatch =
-        /letter-spacing\s*:\s*(-?\d*\.?\d+)\s*(em|px|rem)/i.exec(decl);
-      let ok = false;
-      if (lsMatch) {
-        const v = parseFloat(lsMatch[1]);
-        const unit = lsMatch[2].toLowerCase();
-        if (unit === 'em' || unit === 'rem') ok = v >= 0.06;
-        else if (unit === 'px') ok = v >= 1.5;
-      }
-      if (!ok) {
+      if (!hasAdequateUppercaseTracking(decl)) {
         out.push({
           severity: 'P1',
           id: 'all-caps-no-tracking',
@@ -498,6 +479,39 @@ function clip(s) {
 
 function escapeRe(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// True when the declaration body has letter-spacing satisfying the
+// craft rule: `letter-spacing >= 0.06em` of the element's own font.
+//
+// em/rem values map directly to the 0.06 floor.
+//
+// px is the tricky case. A naive absolute floor (e.g. >= 1.5px) is
+// stricter than the rule and rejects compliant small-label CSS — the
+// common `font-size: 12px; letter-spacing: 1px` pair is `0.083em`
+// (above the 0.06em rule) but a 1.5px floor would reject it. Two-step
+// resolution keeps the px branch faithful to the em rule:
+//   1. If the same rule body declares `font-size: <n>px`, compare px
+//      tracking against `n * 0.06` — exact translation of the em rule.
+//   2. Otherwise (font-size inherited or in a different unit), use a
+//      conservative `>= 1px` absolute fallback. That stays correct for
+//      the typical body-text default of 16px (1px / 16px ≈ 0.0625em,
+//      just over the floor) and for any smaller label (1px / 14px ≈
+//      0.071em, 1px / 12px ≈ 0.083em).
+function hasAdequateUppercaseTracking(body) {
+  const lsMatch =
+    /letter-spacing\s*:\s*(-?\d*\.?\d+)\s*(em|px|rem)/i.exec(body);
+  if (!lsMatch) return false;
+  const v = parseFloat(lsMatch[1]);
+  const unit = lsMatch[2].toLowerCase();
+  if (unit === 'em' || unit === 'rem') return v >= 0.06;
+  // unit === 'px'
+  const fsMatch = /font-size\s*:\s*(-?\d*\.?\d+)\s*px/i.exec(body);
+  if (fsMatch) {
+    const fs = parseFloat(fsMatch[1]);
+    return fs > 0 && v >= fs * 0.06;
+  }
+  return v >= 1;
 }
 
 // Remove CSS rule blocks that look like design-token definitions.

--- a/apps/daemon/src/lint-artifact.ts
+++ b/apps/daemon/src/lint-artifact.ts
@@ -248,13 +248,13 @@ export function lintArtifact(rawHtml) {
   // ── P1-0: ALL-CAPS without letter-spacing ─────────────────────────
   // Refero's typography rules: any `text-transform: uppercase` rule
   // must pair with `letter-spacing: >= 0.06em` (or an absolute px
-  // equivalent). We scan the <style> block for an uppercase declaration
-  // inside any selector and check whether the SAME selector body
-  // declares a sufficient letter-spacing. The check is intentionally
-  // conservative — only fires when the rule body is missing
-  // letter-spacing entirely OR sets it visibly too low.
-  const styleBlock = /<style[^>]*>([\s\S]*?)<\/style>/i.exec(html);
-  if (styleBlock) {
+  // equivalent). Iterate every <style> block (artifacts often emit
+  // a reset block followed by a tokens/components block) and scan
+  // each CSS body for an uppercase declaration whose selector body
+  // is missing letter-spacing or sets it visibly too low.
+  outer: for (const styleBlock of html.matchAll(
+    /<style[^>]*>([\s\S]*?)<\/style>/gi,
+  )) {
     const css = styleBlock[1] ?? '';
     // Match a CSS rule body containing text-transform: uppercase.
     // Capture the selector + body so we can inspect tracking.
@@ -282,7 +282,7 @@ export function lintArtifact(rawHtml) {
           fix: 'Add `letter-spacing: 0.08em` (typical) to the same rule. ALL CAPS without tracking looks cramped — Refero\'s typography rules call this out as a top-tier amateur tell.',
           snippet: clip(`${selector} { ${body.trim()} }`),
         });
-        break;
+        break outer;
       }
     }
   }
@@ -457,17 +457,20 @@ function escapeRe(s) {
 // selector capture include leading text like `<style>`, which then
 // fails the `:root` selector test.
 //
-// A rule is treated as a token block when:
-//   1. its selector list contains `:root` (with optional attribute
-//      selector) — covers `:root { ... }`, `:root[data-theme="dark"]
-//      { ... }`, and lists like `:root, [data-theme="light"] { ... }`.
-//   2. its body declares only CSS custom properties (`--name: value`)
-//      AND every selector in the list is a global theme-scope
-//      selector (`html`, `html[data-theme="..."]`, bare
-//      `[data-theme="..."]`, `body[data-theme="..."]`). Component
-//      selectors like `.cta { --cta-bg: #6366f1 }` are NOT exempted,
-//      so indigo laundered through a local custom property still
-//      trips the lint.
+// A rule is treated as a token block only when BOTH conditions hold:
+//   1. every selector in the list is a global theme-scope selector
+//      (`:root`, `:root[data-theme="..."]`, `html`, `body`, or a bare
+//      `[data-theme="..."]`). Selector lists that mix in a component
+//      selector — e.g. `:root, .cta { --cta-bg: #6366f1 }` — fail
+//      this test, so indigo laundered through a local var or rule
+//      still trips the lint.
+//   2. its body is token-shaped: only CSS custom properties
+//      (`--name: value`), with a small allowlist for global-theme
+//      metadata such as `color-scheme` that legitimately accompanies
+//      tokens in `:root` and cannot smuggle a visible color.
+//      A non-token declaration on `:root` (e.g.
+//      `:root { background: #6366f1 }`) keeps the rule in scope so
+//      the indigo check fires.
 function stripTokenBlocks(input) {
   return input.replace(
     /(<style[^>]*>)([\s\S]*?)(<\/style>)/gi,
@@ -478,22 +481,26 @@ function stripTokenBlocks(input) {
 function stripTokenBlocksFromCss(css) {
   return css.replace(/([^{}]*)\{([^}]*)\}/g, (full, selector, body) => {
     const sel = (selector || '').trim();
-    if (selectorListContainsRoot(sel)) return '';
+    if (!selectorListIsGlobalThemeScope(sel)) return full;
     const decls = (body || '')
       .split(';')
       .map((d) => d.trim())
       .filter(Boolean);
-    const customOnly =
-      decls.length > 0 && decls.every((d) => /^--[\w-]+\s*:/.test(d));
-    if (customOnly && selectorListIsGlobalThemeScope(sel)) return '';
-    return full;
+    if (decls.length === 0) return full;
+    const tokenShaped = decls.every(isTokenShapedDeclaration);
+    if (!tokenShaped) return full;
+    return '';
   });
 }
 
-function selectorListContainsRoot(selector) {
-  return selector
-    .split(',')
-    .some((s) => /^\s*:root(?:\[[^\]]*\])?\s*$/.test(s));
+function isTokenShapedDeclaration(decl) {
+  // CSS custom property — the canonical token shape.
+  if (/^--[\w-]+\s*:/.test(decl)) return true;
+  // Global-theme metadata that legitimately accompanies tokens in
+  // `:root` / `html` / `[data-theme="..."]` and whose values are
+  // keywords, so they cannot smuggle a hardcoded color.
+  if (/^color-scheme\s*:/i.test(decl)) return true;
+  return false;
 }
 
 function selectorListIsGlobalThemeScope(selector) {

--- a/apps/daemon/src/lint-artifact.ts
+++ b/apps/daemon/src/lint-artifact.ts
@@ -484,13 +484,18 @@ function escapeRe(s) {
 // True when the declaration body has letter-spacing satisfying the
 // craft rule: `letter-spacing >= 0.06em` of the element's own font.
 //
-// em/rem values map directly to the 0.06 floor.
+// `em` maps directly to the 0.06 floor — it is relative to the
+// element's own font-size, which is what the rule measures against.
 //
-// px is the tricky case. A naive absolute floor (e.g. >= 1.5px) is
-// stricter than the rule and rejects compliant small-label CSS — the
-// common `font-size: 12px; letter-spacing: 1px` pair is `0.083em`
-// (above the 0.06em rule) but a 1.5px floor would reject it. Two-step
-// resolution keeps the px branch faithful to the em rule:
+// `rem` and `px` are absolute relative to the element: `rem` resolves
+// against the root font-size (assumed 16px — the browser default and
+// the value all OD seed templates use), so `0.06rem` on a 48px heading
+// is `0.96px`, only `0.02em` of the element. Treating `rem` like `em`
+// (the previous behaviour) accepts that as compliant when the rule
+// it enforces is the per-element em floor; convert `rem` to absolute
+// px and reuse the same px-vs-element-font-size resolution.
+//
+// px (and the converted-rem path) resolve in two steps:
 //   1. If the same rule body declares `font-size: <n>px`, compare px
 //      tracking against `n * 0.06` — exact translation of the em rule.
 //   2. Otherwise (font-size inherited or in a different unit), use a
@@ -498,20 +503,21 @@ function escapeRe(s) {
 //      the typical body-text default of 16px (1px / 16px ≈ 0.0625em,
 //      just over the floor) and for any smaller label (1px / 14px ≈
 //      0.071em, 1px / 12px ≈ 0.083em).
+const ROOT_FONT_PX = 16;
 function hasAdequateUppercaseTracking(body) {
   const lsMatch =
     /letter-spacing\s*:\s*(-?\d*\.?\d+)\s*(em|px|rem)/i.exec(body);
   if (!lsMatch) return false;
   const v = parseFloat(lsMatch[1]);
   const unit = lsMatch[2].toLowerCase();
-  if (unit === 'em' || unit === 'rem') return v >= 0.06;
-  // unit === 'px'
+  if (unit === 'em') return v >= 0.06;
+  const trackingPx = unit === 'rem' ? v * ROOT_FONT_PX : v;
   const fsMatch = /font-size\s*:\s*(-?\d*\.?\d+)\s*px/i.exec(body);
   if (fsMatch) {
     const fs = parseFloat(fsMatch[1]);
-    return fs > 0 && v >= fs * 0.06;
+    return fs > 0 && trackingPx >= fs * 0.06;
   }
-  return v >= 1;
+  return trackingPx >= 1;
 }
 
 // Remove CSS rule blocks that look like design-token definitions.

--- a/apps/daemon/src/lint-artifact.ts
+++ b/apps/daemon/src/lint-artifact.ts
@@ -128,15 +128,14 @@ export function lintArtifact(rawHtml) {
   // Even outside a gradient, a single use of #6366f1 et al. is the
   // textbook LLM tell. We only fire if the existing purple-gradient
   // check didn't already, since they overlap in spirit. Strip
-  // :root token-definition blocks first: a brief whose accent is
-  // intentionally indigo declares it as `--accent: #6366f1` in
-  // :root and uses var(--accent) downstream — that is the design
-  // system speaking, not the model defaulting, and must not fire.
+  // token-definition blocks first: a brief whose accent is
+  // intentionally indigo declares it as `--accent: #6366f1` inside
+  // a selector list containing `:root` (or any selector whose body
+  // is custom-property-only — common for theme-variant blocks) and
+  // uses var(--accent) downstream. That is the design system
+  // speaking, not the model defaulting, and must not fire.
   if (out.find((f) => f.id === 'purple-gradient') === undefined) {
-    const htmlForIndigo = html.replace(
-      /:root(?:\[[^\]]*\])?\s*\{[^}]*\}/gi,
-      '',
-    );
+    const htmlForIndigo = stripTokenBlocks(html);
     for (const hex of AI_DEFAULT_INDIGO) {
       const re = new RegExp(escapeRe(hex), 'i');
       const m = re.exec(htmlForIndigo);
@@ -448,4 +447,33 @@ function clip(s) {
 
 function escapeRe(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Remove CSS rule blocks that look like design-token definitions:
+//   1. selector list contains `:root` (with optional attribute selector)
+//      — covers `:root { ... }`, `:root[data-theme="dark"] { ... }`, and
+//      lists like `:root, [data-theme="light"] { ... }`.
+//   2. body declares only CSS custom properties (`--name: value`),
+//      regardless of selector — covers theme-variant blocks like
+//      `[data-theme="dark"] { --accent: ... }` that omit `:root`.
+// Real component rules (any declaration that isn't a custom property)
+// are preserved verbatim so hardcoded indigo still trips the lint.
+function stripTokenBlocks(input) {
+  return input.replace(/([^{}]*)\{([^}]*)\}/g, (full, selector, body) => {
+    if (selectorListContainsRoot(selector || '')) return '';
+    const decls = (body || '')
+      .split(';')
+      .map((d) => d.trim())
+      .filter(Boolean);
+    if (decls.length > 0 && decls.every((d) => /^--[\w-]+\s*:/.test(d))) {
+      return '';
+    }
+    return full;
+  });
+}
+
+function selectorListContainsRoot(selector) {
+  return selector
+    .split(',')
+    .some((s) => /^\s*:root(?:\[[^\]]*\])?\s*$/.test(s));
 }

--- a/apps/daemon/src/lint-artifact.ts
+++ b/apps/daemon/src/lint-artifact.ts
@@ -255,7 +255,12 @@ export function lintArtifact(rawHtml) {
   outer: for (const styleBlock of html.matchAll(
     /<style[^>]*>([\s\S]*?)<\/style>/gi,
   )) {
-    const css = styleBlock[1] ?? '';
+    // Strip CSS comments before structural matching: a `<style>` body
+    // such as `/* .eyebrow { text-transform: uppercase; } */` is
+    // commented-out by the browser but the rule-shaped regex below
+    // would otherwise match it and emit a P1 finding for CSS that has
+    // no rendered effect.
+    const css = (styleBlock[1] ?? '').replace(/\/\*[\s\S]*?\*\//g, '');
     // Match a CSS rule body containing text-transform: uppercase.
     // Capture the selector + body so we can inspect tracking.
     const upperRe = /([^{}]*)\{([^}]*text-transform\s*:\s*uppercase[^}]*)\}/gi;
@@ -488,7 +493,15 @@ function stripTokenBlocksFromCss(css) {
   // fail `isTokenShapedDeclaration`, and leave a legitimate token
   // definition in scope of the indigo scan.
   const cleaned = css.replace(/\/\*[\s\S]*?\*\//g, '');
-  return cleaned.replace(/([^{}]*)\{([^}]*)\}/g, (full, selector, body) => {
+  // The body alternation is `[^{}]*` (not `[^}]*`) so the regex matches
+  // only innermost `selector { body }` rules. That lets us recognize
+  // global token blocks nested inside at-rule wrappers — e.g.
+  // `@media (prefers-color-scheme: dark) { :root { --accent: #6366f1 } }`
+  // — by matching the inner `:root { ... }` directly. The outer
+  // `@media` wrapper is preserved with the inner token block stripped,
+  // so the indigo scan no longer fires on legitimate responsive theme
+  // declarations.
+  return cleaned.replace(/([^{}]*)\{([^{}]*)\}/g, (full, selector, body) => {
     const sel = (selector || '').trim();
     if (!selectorListIsGlobalThemeScope(sel)) return full;
     const decls = (body || '')

--- a/apps/daemon/src/lint-artifact.ts
+++ b/apps/daemon/src/lint-artifact.ts
@@ -42,7 +42,14 @@ const PURPLE_HEXES = [
 // accent" — even a single solid use is a tell. The DESIGN.md provides
 // `var(--accent)`; if a brief truly needs indigo, the design system
 // should encode it explicitly so we know it's intentional.
-const AI_DEFAULT_INDIGO = ['#6366f1', '#4f46e5', '#4338ca', '#8b5cf6', '#7c3aed'];
+//
+// Keep this in sync with the explicit list in `craft/anti-ai-slop.md`'s
+// "Default Tailwind indigo as accent" cardinal-sin entry — the prompt
+// contract documents the exact set the lint enforces.
+const AI_DEFAULT_INDIGO = [
+  '#6366f1', '#4f46e5', '#4338ca', '#3730a3',
+  '#8b5cf6', '#7c3aed', '#a855f7',
+];
 
 const SLOP_EMOJI = [
   '✨', '🚀', '🎯', '⚡', '🔥', '💡', '📈', '🎨', '🛡️', '🌟',

--- a/apps/daemon/src/lint-artifact.ts
+++ b/apps/daemon/src/lint-artifact.ts
@@ -127,11 +127,19 @@ export function lintArtifact(rawHtml) {
   // ── P0-1b: solid AI-default indigo as accent ──────────────────────
   // Even outside a gradient, a single use of #6366f1 et al. is the
   // textbook LLM tell. We only fire if the existing purple-gradient
-  // check didn't already, since they overlap in spirit.
+  // check didn't already, since they overlap in spirit. Strip
+  // :root token-definition blocks first: a brief whose accent is
+  // intentionally indigo declares it as `--accent: #6366f1` in
+  // :root and uses var(--accent) downstream — that is the design
+  // system speaking, not the model defaulting, and must not fire.
   if (out.find((f) => f.id === 'purple-gradient') === undefined) {
+    const htmlForIndigo = html.replace(
+      /:root(?:\[[^\]]*\])?\s*\{[^}]*\}/gi,
+      '',
+    );
     for (const hex of AI_DEFAULT_INDIGO) {
       const re = new RegExp(escapeRe(hex), 'i');
-      const m = re.exec(html);
+      const m = re.exec(htmlForIndigo);
       if (m) {
         out.push({
           severity: 'P0',

--- a/apps/daemon/src/lint-artifact.ts
+++ b/apps/daemon/src/lint-artifact.ts
@@ -533,19 +533,45 @@ function escapeRe(s) {
 const ROOT_FONT_PX = 16;
 function hasAdequateUppercaseTracking(body, tokens) {
   const resolved = tokens ? resolveCssVars(body, tokens) : body;
-  const lsMatch =
-    /letter-spacing\s*:\s*(-?\d*\.?\d+)\s*(em|px|rem)/i.exec(resolved);
+  // Parse the declaration list and match exact property names so that
+  // CSS custom-property declarations (`--letter-spacing: 0.08em`,
+  // `--display-font-size: 48px`) — which are token definitions with no
+  // rendered effect — cannot satisfy the rule. The previous substring
+  // regex would mistake `--letter-spacing` for `letter-spacing` and
+  // let real violations bypass the P1 lint.
+  const decls = parseDeclarations(resolved);
+  const ls = decls.find((d) => d.prop === 'letter-spacing');
+  if (!ls) return false;
+  const lsMatch = /^(-?\d*\.?\d+)\s*(em|px|rem)\b/i.exec(ls.value);
   if (!lsMatch) return false;
   const v = parseFloat(lsMatch[1]);
   const unit = lsMatch[2].toLowerCase();
   if (unit === 'em') return v >= 0.06;
   const trackingPx = unit === 'rem' ? v * ROOT_FONT_PX : v;
-  const fsPx = resolveFontSizePx(resolved);
+  const fsPx = resolveFontSizePx(decls);
   if (fsPx != null) {
     return fsPx > 0 && trackingPx >= fsPx * 0.06;
   }
-  if (/font-size\s*:/i.test(resolved)) return false;
+  if (decls.some((d) => d.prop === 'font-size')) return false;
   return trackingPx >= 1;
+}
+
+// Split a CSS declaration body into `{ prop, value }` entries, lowercasing
+// the property name and skipping custom properties (`--name`). Used by
+// the uppercase-tracking lint so substring matches on `letter-spacing`
+// or `font-size` cannot collide with token-name declarations.
+function parseDeclarations(body) {
+  const out = [];
+  for (const raw of body.split(';')) {
+    const idx = raw.indexOf(':');
+    if (idx < 0) continue;
+    const prop = raw.slice(0, idx).trim().toLowerCase();
+    if (!prop || prop.startsWith('--')) continue;
+    const value = raw.slice(idx + 1).trim();
+    if (!value) continue;
+    out.push({ prop, value });
+  }
+  return out;
 }
 
 // Resolve a same-rule `font-size` declaration to absolute px. Returns
@@ -553,10 +579,12 @@ function hasAdequateUppercaseTracking(body, tokens) {
 // via the root font-size assumption shared with tracking); returns
 // `null` when font-size is absent OR present in an unresolvable unit
 // (`em`, `%`, `calc(...)`, an unresolved `var(--...)`). The caller
-// distinguishes those two `null` cases by re-checking for the
-// `font-size:` literal.
-function resolveFontSizePx(body) {
-  const m = /font-size\s*:\s*(-?\d*\.?\d+)\s*(px|rem)\b/i.exec(body);
+// distinguishes those two `null` cases by re-checking the parsed
+// declarations for an exact `font-size` property.
+function resolveFontSizePx(decls) {
+  const fs = decls.find((d) => d.prop === 'font-size');
+  if (!fs) return null;
+  const m = /^(-?\d*\.?\d+)\s*(px|rem)\b/i.exec(fs.value);
   if (!m) return null;
   const v = parseFloat(m[1]);
   const unit = m[2].toLowerCase();

--- a/apps/daemon/src/lint-artifact.ts
+++ b/apps/daemon/src/lint-artifact.ts
@@ -303,11 +303,12 @@ export function lintArtifact(rawHtml) {
   // a reset block followed by a tokens/components block) and scan
   // each CSS body for an uppercase declaration whose selector body
   // is missing letter-spacing or sets it visibly too low.
-  // Token-aware tracking: collect `--name: value` declarations from
-  // global theme scopes once, then pass them to the tracking helper
-  // so a rule like `letter-spacing: var(--caps-tracking)` is judged
-  // by the token's literal value instead of being treated as missing.
-  const cssTokens = extractCssTokens(html);
+  // Token-aware tracking: collect per-scope `--name: value` declarations
+  // from global theme scopes once, then pass them to the tracking helper
+  // so a rule like `letter-spacing: var(--caps-tracking)` is judged by
+  // the token's literal value in every applicable theme instead of being
+  // treated as missing.
+  const tokenScopes = extractCssTokens(html);
   outer: for (const styleBlock of html.matchAll(
     /<style[^>]*>([\s\S]*?)<\/style>/gi,
   )) {
@@ -318,13 +319,25 @@ export function lintArtifact(rawHtml) {
     // no rendered effect.
     const css = (styleBlock[1] ?? '').replace(/\/\*[\s\S]*?\*\//g, '');
     // Match a CSS rule body containing text-transform: uppercase.
-    // Capture the selector + body so we can inspect tracking.
-    const upperRe = /([^{}]*)\{([^}]*text-transform\s*:\s*uppercase[^}]*)\}/gi;
+    // Capture the selector + body so we can inspect tracking. The body
+    // alternation is `[^{}]*` (not `[^}]*`) so the regex matches only
+    // innermost `selector { body }` rules. With `[^}]*`, an outer
+    // `@media (...) { .display { font-size: 48px; text-transform:
+    // uppercase; … } }` matches as a single rule whose selector is the
+    // `@media (...)` wrapper and whose body begins with `.display {
+    // font-size: …` — so `parseDeclarations()` sees the first property
+    // as `.display { font-size`, not `font-size`, the same-rule
+    // font-size is lost, and `hasAdequateUppercaseTracking()` falls
+    // back to the lenient inherited-size path that accepts 1px
+    // tracking on a 48px heading. Restricting the body to `[^{}]*`
+    // makes the regex skip the wrapper and match the inner rule
+    // directly.
+    const upperRe = /([^{}]*)\{([^{}]*text-transform\s*:\s*uppercase[^{}]*)\}/gi;
     let m;
     while ((m = upperRe.exec(css)) !== null) {
       const selector = (m[1] ?? '').trim();
       const body = m[2] ?? '';
-      if (!hasAdequateUppercaseTracking(body, cssTokens)) {
+      if (!hasAdequateUppercaseTracking(body, tokenScopes)) {
         out.push({
           severity: 'P1',
           id: 'all-caps-no-tracking',
@@ -352,7 +365,7 @@ export function lintArtifact(rawHtml) {
     while ((im = inlineStyleRe.exec(html)) !== null) {
       const decl = im[2] ?? '';
       if (!/text-transform\s*:\s*uppercase/i.test(decl)) continue;
-      if (!hasAdequateUppercaseTracking(decl, cssTokens)) {
+      if (!hasAdequateUppercaseTracking(decl, tokenScopes)) {
         out.push({
           severity: 'P1',
           id: 'all-caps-no-tracking',
@@ -586,42 +599,38 @@ function detectBlueCyanTrustGradient(html) {
 //      ≈ 0.0625em, just over the floor) and for any smaller label
 //      (1px / 14px ≈ 0.071em, 1px / 12px ≈ 0.083em).
 //
-// `tokens` (optional) is a map of CSS custom properties harvested from
-// global theme scopes elsewhere in the artifact, keyed by token name to
-// the array of distinct values seen across scopes. When provided,
-// simple `var(--name)` (and `var(--name, fallback)`) references in the
-// body are expanded to their literal token values before the regexes
-// run, so a tokenized rule such as `letter-spacing: var(--caps-tracking)`
-// with `:root { --caps-tracking: 0.08em }` is judged by 0.08em rather
-// than reported as missing tracking. References without a matching
-// token but with an inline fallback (`var(--x, 0.08em)`) resolve to
-// the fallback; unresolved references with no fallback stay in place
-// so the existing "no numeric value" path returns false.
+// `scopes` (optional) is the array of per-scope token records
+// harvested from global theme scopes elsewhere in the artifact (see
+// `extractCssTokens`). Each record carries the scope's per-scope
+// last-write-wins token map plus enough metadata to identify which
+// themes the scope applies to. Per-theme effective maps are built
+// here via `buildResolvedThemes` so simple `var(--name)` (and
+// `var(--name, fallback)`) references in the body resolve to the
+// value the browser would render in that theme — keeping values
+// declared in the same scope paired together. References without a
+// matching token but with an inline fallback (`var(--x, 0.08em)`)
+// resolve to the fallback; unresolved references with no fallback
+// stay in place so the existing "no numeric value" path returns
+// false.
 //
-// When the same token name resolves to multiple distinct values
+// When a token resolves to different values in different themes
 // (e.g. `:root { --caps-tracking: 0.02em }` overridden by
 // `[data-theme="dark"] { --caps-tracking: 0.08em }`), the helper is
-// conservative: it enumerates every applicable value combination and
-// returns true only if EVERY resolution satisfies the 0.06em floor.
-// A theme-scoped override that lifts the value above the floor must
-// not silently rescue a default value that renders below it.
+// conservative: it walks every per-theme map produced by
+// `buildResolvedThemes` and returns true only if EVERY theme satisfies
+// the 0.06em floor. A theme-scoped override that lifts the value
+// above the floor must not silently rescue a default value that
+// renders below it. Crucially, theme maps preserve the scope-internal
+// relationship between tokens, so a paired declaration such as
+// `:root { --display-size: 16px; --caps-tracking: 1px }` is judged
+// against (16px, 1px) — never against the impossible cross-theme
+// pairing (48px, 1px) that an independent per-token cartesian would
+// emit.
 const ROOT_FONT_PX = 16;
-function hasAdequateUppercaseTracking(body, tokens) {
-  const tokensMap = tokens ?? new Map();
-  // Restrict the cartesian to tokens reachable from the body, so a
-  // brand with many unrelated multi-valued tokens does not blow up
-  // the combination count.
-  const relevant = collectRelevantTokens(body, tokensMap);
-  if (relevant.size === 0) {
-    // No global tokens reach the body — but body may still contain
-    // `var(--name, fallback)` refs whose fallback should resolve;
-    // pass through the resolver with an empty token map so fallbacks
-    // collapse to literal values before the regexes run.
-    return isResolvedTrackingAdequate(resolveCssVars(body, new Map()));
-  }
-  const combos = enumerateTokenCombos(relevant);
-  for (const combo of combos) {
-    const resolved = resolveCssVars(body, combo);
+function hasAdequateUppercaseTracking(body, scopes) {
+  const themes = buildResolvedThemes(scopes ?? []);
+  for (const themeMap of themes) {
+    const resolved = resolveCssVars(body, themeMap);
     if (!isResolvedTrackingAdequate(resolved)) return false;
   }
   return true;
@@ -652,53 +661,53 @@ function isResolvedTrackingAdequate(body) {
   return trackingPx >= 1;
 }
 
-// Walk the body's `var(--name)` references transitively through token
-// values, collecting only the tokens that can actually affect the
-// resolved body. Returns a Map<name, string[]> of distinct values.
-function collectRelevantTokens(body, tokens) {
-  const out = new Map();
-  const queue = [];
-  const seen = new Set();
-  for (const m of body.matchAll(/var\(\s*(--[\w-]+)/g)) {
-    if (!seen.has(m[1])) {
-      seen.add(m[1]);
-      queue.push(m[1]);
-    }
+// Build per-theme effective token maps from the per-scope records
+// produced by `extractCssTokens`. A "theme" is the default rendering
+// (no theme attribute set) plus one entry per distinct theme-attribute
+// selector seen across scopes. Default-applying scopes (whose selector
+// list contains a bare `:root` / `html` / `body`) apply to every theme
+// as a baseline; variant scopes apply only to the themes their
+// selector targets. Within a single theme, scopes are applied in
+// source order so the final value reflects the cascade the browser
+// would render.
+//
+// Returned as an array — one map per theme. The lint passes only when
+// every theme map satisfies the rule, so a default-theme value below
+// the floor flags even if a variant overrides it above the floor (and
+// vice versa). Building per-theme maps preserves the scope-internal
+// relationship between tokens, so values declared together in the
+// same scope (e.g. `--display-size` and `--caps-tracking` both on
+// `:root`) stay paired during evaluation. The previous design merged
+// values by token name across scopes and then took an independent
+// per-token cartesian product, which generated impossible cross-theme
+// pairings such as `(default-size, dark-track)` and emitted false
+// positives on legitimate light/dark theme variants.
+function buildResolvedThemes(scopes) {
+  const themeKeys = new Set(['default']);
+  for (const scope of scopes) {
+    for (const k of scope.themeKeys) themeKeys.add(k);
   }
-  while (queue.length > 0) {
-    const name = queue.shift();
-    const values = tokens.get(name);
-    if (!values || values.length === 0) continue;
-    out.set(name, values);
-    for (const value of values) {
-      for (const m of value.matchAll(/var\(\s*(--[\w-]+)/g)) {
-        if (!seen.has(m[1])) {
-          seen.add(m[1]);
-          queue.push(m[1]);
+  const themes = new Map();
+  for (const k of themeKeys) themes.set(k, new Map());
+  for (const scope of scopes) {
+    if (scope.isDefault) {
+      for (const map of themes.values()) {
+        for (const [k, v] of scope.tokens) map.set(k, v);
+      }
+    } else {
+      for (const themeKey of scope.themeKeys) {
+        const map = themes.get(themeKey);
+        if (map) {
+          for (const [k, v] of scope.tokens) map.set(k, v);
         }
       }
     }
   }
-  return out;
+  return Array.from(themes.values());
 }
 
-// Cartesian product over the relevant tokens. Yields one
-// `Map<name, value>` per combination so the existing single-value
-// resolver can be reused unchanged.
-function enumerateTokenCombos(relevant) {
-  let combos = [new Map()];
-  for (const [name, values] of relevant.entries()) {
-    const next = [];
-    for (const c of combos) {
-      for (const v of values) {
-        const copy = new Map(c);
-        copy.set(name, v);
-        next.push(copy);
-      }
-    }
-    combos = next;
-  }
-  return combos;
+function isBareGlobalSelector(s) {
+  return /^(?::root|html|body)$/.test(s);
 }
 
 function findLastDecl(decls, prop) {
@@ -757,30 +766,30 @@ function resolveFontSizePx(decls) {
 // tracking helper resolves only the global-scope tokens artifacts use
 // to express design intent.
 //
-// Returns a `Map<name, string[]>` of distinct values seen across
-// scopes — preserving every conflicting value rather than collapsing
-// to last-write-wins. A scoped override that bumps the token above the
-// 0.06em floor must not silently rescue the default-theme value that
-// renders below it: e.g.
-// `:root { --caps-tracking: 0.02em }` paired with
-// `[data-theme="dark"] { --caps-tracking: 0.08em }` is two distinct
-// values, and the tracking helper enumerates both before deciding the
-// rule passes (it must satisfy the floor under EVERY applicable
-// theme). The canonical single-`:root`-per-token artifact pattern still
-// produces a single-element array, so the existing tests are
-// unaffected.
+// Returns an array of per-scope records:
+//   `{ selectors, tokens, isDefault, themeKeys }`
+// where `tokens` is the per-scope last-write-wins map of CSS custom
+// properties, `selectors` lists the parsed selectors from the rule,
+// `isDefault` is true if any selector is a bare global
+// (`:root` / `html` / `body` without an attribute suffix), and
+// `themeKeys` is the set of theme-attribute selector strings the rule
+// targets. Per-theme effective maps are derived downstream from these
+// records by `buildResolvedThemes`, which preserves the scope-internal
+// relationship between values so a paired declaration like
+// `:root { --display-size: 16px; --caps-tracking: 1px }` is judged
+// as `(16px, 1px)` together, not against the impossible cross-theme
+// pairing `(48px, 1px)` that an independent per-token cartesian over
+// distinct values would emit.
 //
 // Within a single rule body, CSS cascade is last-write-wins: a block
 // like `:root { --caps-tracking: 0.02em; --caps-tracking: 0.08em; }`
 // renders the second value, and the first never reaches any element.
-// Treating both as simultaneous theme alternatives would feed the
-// stale 0.02em into the tracking helper and emit a spurious P1 on
-// what is normal CSS source-order overriding. So per-scope, we keep
-// only the LAST value declared for each token name; only after that
-// per-scope cascade do we merge into the cross-scope distinct-value
-// map.
+// Per-scope, we keep only the LAST value declared for each token
+// name; cross-scope merging happens later in `buildResolvedThemes`,
+// where the same source-order cascade is applied between scopes that
+// target the same theme.
 function extractCssTokens(html) {
-  const tokens = new Map();
+  const scopes = [];
   for (const styleBlock of html.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/gi)) {
     const css = (styleBlock[1] ?? '').replace(/\/\*[\s\S]*?\*\//g, '');
     const ruleRe = /([^{}]*)\{([^{}]*)\}/g;
@@ -788,22 +797,24 @@ function extractCssTokens(html) {
     while ((m = ruleRe.exec(css)) !== null) {
       const sel = (m[1] ?? '').trim();
       if (!selectorListIsGlobalThemeScope(sel)) continue;
+      const selectors = sel.split(',').map((s) => s.trim()).filter(Boolean);
+      const isDefault = selectors.some(isBareGlobalSelector);
+      const themeKeys = new Set(
+        selectors.filter((s) => !isBareGlobalSelector(s)),
+      );
       const body = m[2] ?? '';
-      const perScope = new Map();
+      const tokens = new Map();
       for (const decl of body.split(';').map((d) => d.trim()).filter(Boolean)) {
         const dm = /^(--[\w-]+)\s*:\s*(.+)$/.exec(decl);
         if (dm) {
-          perScope.set(dm[1], dm[2].trim());
+          tokens.set(dm[1], dm[2].trim());
         }
       }
-      for (const [name, value] of perScope.entries()) {
-        const arr = tokens.get(name) ?? [];
-        if (!arr.includes(value)) arr.push(value);
-        tokens.set(name, arr);
-      }
+      if (tokens.size === 0) continue;
+      scopes.push({ selectors, tokens, isDefault, themeKeys });
     }
   }
-  return tokens;
+  return scopes;
 }
 
 // Replace simple `var(--name)` (and `var(--name, fallback)`) references

--- a/apps/daemon/src/lint-artifact.ts
+++ b/apps/daemon/src/lint-artifact.ts
@@ -259,6 +259,11 @@ export function lintArtifact(rawHtml) {
   // a reset block followed by a tokens/components block) and scan
   // each CSS body for an uppercase declaration whose selector body
   // is missing letter-spacing or sets it visibly too low.
+  // Token-aware tracking: collect `--name: value` declarations from
+  // global theme scopes once, then pass them to the tracking helper
+  // so a rule like `letter-spacing: var(--caps-tracking)` is judged
+  // by the token's literal value instead of being treated as missing.
+  const cssTokens = extractCssTokens(html);
   outer: for (const styleBlock of html.matchAll(
     /<style[^>]*>([\s\S]*?)<\/style>/gi,
   )) {
@@ -275,7 +280,7 @@ export function lintArtifact(rawHtml) {
     while ((m = upperRe.exec(css)) !== null) {
       const selector = (m[1] ?? '').trim();
       const body = m[2] ?? '';
-      if (!hasAdequateUppercaseTracking(body)) {
+      if (!hasAdequateUppercaseTracking(body, cssTokens)) {
         out.push({
           severity: 'P1',
           id: 'all-caps-no-tracking',
@@ -303,7 +308,7 @@ export function lintArtifact(rawHtml) {
     while ((im = inlineStyleRe.exec(html)) !== null) {
       const decl = im[2] ?? '';
       if (!/text-transform\s*:\s*uppercase/i.test(decl)) continue;
-      if (!hasAdequateUppercaseTracking(decl)) {
+      if (!hasAdequateUppercaseTracking(decl, cssTokens)) {
         out.push({
           severity: 'P1',
           id: 'all-caps-no-tracking',
@@ -503,21 +508,89 @@ function escapeRe(s) {
 //      the typical body-text default of 16px (1px / 16px ≈ 0.0625em,
 //      just over the floor) and for any smaller label (1px / 14px ≈
 //      0.071em, 1px / 12px ≈ 0.083em).
+//
+// `tokens` (optional) is a map of CSS custom properties harvested from
+// global theme scopes elsewhere in the artifact. When provided, simple
+// `var(--name)` (and `var(--name, fallback)`) references in the body
+// are expanded to their literal token values before the regexes run,
+// so a tokenized rule such as `letter-spacing: var(--caps-tracking)`
+// with `:root { --caps-tracking: 0.08em }` is judged by 0.08em rather
+// than reported as missing tracking. References without a matching
+// token but with an inline fallback (`var(--x, 0.08em)`) resolve to
+// the fallback; unresolved references with no fallback stay in place
+// so the existing "no numeric value" path returns false.
 const ROOT_FONT_PX = 16;
-function hasAdequateUppercaseTracking(body) {
+function hasAdequateUppercaseTracking(body, tokens) {
+  const resolved = tokens ? resolveCssVars(body, tokens) : body;
   const lsMatch =
-    /letter-spacing\s*:\s*(-?\d*\.?\d+)\s*(em|px|rem)/i.exec(body);
+    /letter-spacing\s*:\s*(-?\d*\.?\d+)\s*(em|px|rem)/i.exec(resolved);
   if (!lsMatch) return false;
   const v = parseFloat(lsMatch[1]);
   const unit = lsMatch[2].toLowerCase();
   if (unit === 'em') return v >= 0.06;
   const trackingPx = unit === 'rem' ? v * ROOT_FONT_PX : v;
-  const fsMatch = /font-size\s*:\s*(-?\d*\.?\d+)\s*px/i.exec(body);
+  const fsMatch = /font-size\s*:\s*(-?\d*\.?\d+)\s*px/i.exec(resolved);
   if (fsMatch) {
     const fs = parseFloat(fsMatch[1]);
     return fs > 0 && trackingPx >= fs * 0.06;
   }
   return trackingPx >= 1;
+}
+
+// Collect CSS custom properties (`--name: value`) declared in global
+// theme scopes (`:root`, `html`, theme-attribute selectors) from every
+// `<style>` block in the artifact. Tokens declared on component
+// selectors are intentionally ignored: the lint must still catch
+// indigo / under-tracking laundered through a local var, and the
+// tracking helper resolves only the global-scope tokens artifacts use
+// to express design intent. Last-write-wins when the same name is
+// declared in multiple scopes — the canonical artifact pattern is a
+// single :root block per token, so collisions are rare and the rule
+// stays a conservative lint signal regardless.
+function extractCssTokens(html) {
+  const tokens = new Map();
+  for (const styleBlock of html.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/gi)) {
+    const css = (styleBlock[1] ?? '').replace(/\/\*[\s\S]*?\*\//g, '');
+    const ruleRe = /([^{}]*)\{([^{}]*)\}/g;
+    let m;
+    while ((m = ruleRe.exec(css)) !== null) {
+      const sel = (m[1] ?? '').trim();
+      if (!selectorListIsGlobalThemeScope(sel)) continue;
+      const body = m[2] ?? '';
+      for (const decl of body.split(';').map((d) => d.trim()).filter(Boolean)) {
+        const dm = /^(--[\w-]+)\s*:\s*(.+)$/.exec(decl);
+        if (dm) tokens.set(dm[1], dm[2].trim());
+      }
+    }
+  }
+  return tokens;
+}
+
+// Replace simple `var(--name)` (and `var(--name, fallback)`) references
+// in a CSS declaration body with the literal token value. Iterates a
+// few times so a token whose value is itself another `var(--...)`
+// resolves through one or two hops; bounded depth so a cyclic
+// definition (`--a: var(--b); --b: var(--a)`) terminates instead of
+// looping forever. Only one-level fallbacks are recognised — enough
+// for the typography pattern this lint cares about, and keeps the
+// regex linear-time on artifact-sized inputs.
+const VAR_RESOLVE_MAX_DEPTH = 4;
+function resolveCssVars(body, tokens) {
+  let out = body;
+  for (let i = 0; i < VAR_RESOLVE_MAX_DEPTH; i++) {
+    const next = out.replace(
+      /var\(\s*(--[\w-]+)\s*(?:,\s*([^()]*))?\)/g,
+      (full, name, fallback) => {
+        const v = tokens.get(name);
+        if (v != null) return v;
+        if (fallback != null) return fallback.trim();
+        return full;
+      },
+    );
+    if (next === out) break;
+    out = next;
+  }
+  return out;
 }
 
 // Remove CSS rule blocks that look like design-token definitions.

--- a/apps/daemon/src/lint-artifact.ts
+++ b/apps/daemon/src/lint-artifact.ts
@@ -28,9 +28,21 @@
  */
 
 const PURPLE_HEXES = [
+  // Tailwind violet / purple — the original AI-slop palette.
   '#a855f7', '#9333ea', '#7c3aed', '#6d28d9', '#581c87',
   '#8b5cf6', '#a78bfa', '#c4b5fd', '#ddd6fe', '#ede9fe',
+  // Tailwind indigo — Refero's #1 reported AI tell. Common solid uses
+  // (button fill, accent badge), not just gradients, are flagged
+  // separately by `ai-default-indigo` below.
+  '#6366f1', '#4f46e5', '#4338ca', '#3730a3', '#312e81',
+  '#818cf8', '#a5b4fc', '#c7d2fe', '#e0e7ff', '#eef2ff',
 ];
+
+// Subset of PURPLE_HEXES that constitute the canonical "default LLM
+// accent" — even a single solid use is a tell. The DESIGN.md provides
+// `var(--accent)`; if a brief truly needs indigo, the design system
+// should encode it explicitly so we know it's intentional.
+const AI_DEFAULT_INDIGO = ['#6366f1', '#4f46e5', '#4338ca', '#8b5cf6', '#7c3aed'];
 
 const SLOP_EMOJI = [
   '✨', '🚀', '🎯', '⚡', '🔥', '💡', '📈', '🎨', '🛡️', '🌟',
@@ -109,6 +121,27 @@ export function lintArtifact(rawHtml) {
         fix: 'Remove the gradient or swap to a single solid color from the active design tokens.',
         snippet: clip(m[0]),
       });
+    }
+  }
+
+  // ── P0-1b: solid AI-default indigo as accent ──────────────────────
+  // Even outside a gradient, a single use of #6366f1 et al. is the
+  // textbook LLM tell. We only fire if the existing purple-gradient
+  // check didn't already, since they overlap in spirit.
+  if (out.find((f) => f.id === 'purple-gradient') === undefined) {
+    for (const hex of AI_DEFAULT_INDIGO) {
+      const re = new RegExp(escapeRe(hex), 'i');
+      const m = re.exec(html);
+      if (m) {
+        out.push({
+          severity: 'P0',
+          id: 'ai-default-indigo',
+          message: `Found a default LLM accent color (${hex}) — this is the most-reported AI design tell.`,
+          fix: 'Replace with var(--accent) from the active DESIGN.md. If the brief truly requires indigo, encode it as the design system\'s accent so it reads as intentional, not default.',
+          snippet: clip(m[0]),
+        });
+        break;
+      }
     }
   }
 
@@ -201,6 +234,48 @@ export function lintArtifact(rawHtml) {
       message: 'Element.scrollIntoView() detected — yanks the host page when an iframe boundary is crossed.',
       fix: 'Use `scrollTo({ left, top, behavior: "smooth" })` on the actual scroller (see simple-deck seed for the proven pattern).',
     });
+  }
+
+  // ── P1-0: ALL-CAPS without letter-spacing ─────────────────────────
+  // Refero's typography rules: any `text-transform: uppercase` rule
+  // must pair with `letter-spacing: >= 0.06em` (or an absolute px
+  // equivalent). We scan the <style> block for an uppercase declaration
+  // inside any selector and check whether the SAME selector body
+  // declares a sufficient letter-spacing. The check is intentionally
+  // conservative — only fires when the rule body is missing
+  // letter-spacing entirely OR sets it visibly too low.
+  const styleBlock = /<style[^>]*>([\s\S]*?)<\/style>/i.exec(html);
+  if (styleBlock) {
+    const css = styleBlock[1] ?? '';
+    // Match a CSS rule body containing text-transform: uppercase.
+    // Capture the selector + body so we can inspect tracking.
+    const upperRe = /([^{}]*)\{([^}]*text-transform\s*:\s*uppercase[^}]*)\}/gi;
+    let m;
+    while ((m = upperRe.exec(css)) !== null) {
+      const selector = (m[1] ?? '').trim();
+      const body = m[2] ?? '';
+      const lsMatch =
+        /letter-spacing\s*:\s*(-?\d*\.?\d+)\s*(em|px|rem)/i.exec(body);
+      let ok = false;
+      if (lsMatch) {
+        const v = parseFloat(lsMatch[1]);
+        const unit = lsMatch[2].toLowerCase();
+        // 0.06em is the floor; in px, ~1px on a 16px line is borderline,
+        // 1.5px+ comfortably passes for typical heading sizes.
+        if (unit === 'em' || unit === 'rem') ok = v >= 0.06;
+        else if (unit === 'px') ok = v >= 1.5;
+      }
+      if (!ok) {
+        out.push({
+          severity: 'P1',
+          id: 'all-caps-no-tracking',
+          message: `Selector \`${selector.slice(0, 60)}\` sets text-transform: uppercase without sufficient letter-spacing (≥0.06em).`,
+          fix: 'Add `letter-spacing: 0.08em` (typical) to the same rule. ALL CAPS without tracking looks cramped — Refero\'s typography rules call this out as a top-tier amateur tell.',
+          snippet: clip(`${selector} { ${body.trim()} }`),
+        });
+        break;
+      }
+    }
   }
 
   // ── P1-1: external image URLs (CDN / unsplash / placehold.co) ─────

--- a/apps/daemon/src/lint-artifact.ts
+++ b/apps/daemon/src/lint-artifact.ts
@@ -299,6 +299,43 @@ export function lintArtifact(rawHtml) {
     }
   }
 
+  // ── P1-0b: ALL-CAPS in inline style attributes ────────────────────
+  // The <style>-block scan above misses inline declarations such as
+  // `<span style="text-transform: uppercase">NEW</span>`, which the
+  // browser still renders ALL CAPS. craft/typography.md treats the
+  // tracking floor as having no exceptions, so the inline form needs
+  // the same ≥0.06em / ≥1.5px check. Only fire if the <style>-block
+  // scan above didn't already produce this id, so the agent gets a
+  // single corrective signal per artifact.
+  if (out.find((f) => f.id === 'all-caps-no-tracking') === undefined) {
+    const inlineStyleRe = /(?:^|\s)style\s*=\s*(["'])([\s\S]*?)\1/gi;
+    let im;
+    while ((im = inlineStyleRe.exec(html)) !== null) {
+      const decl = im[2] ?? '';
+      if (!/text-transform\s*:\s*uppercase/i.test(decl)) continue;
+      const lsMatch =
+        /letter-spacing\s*:\s*(-?\d*\.?\d+)\s*(em|px|rem)/i.exec(decl);
+      let ok = false;
+      if (lsMatch) {
+        const v = parseFloat(lsMatch[1]);
+        const unit = lsMatch[2].toLowerCase();
+        if (unit === 'em' || unit === 'rem') ok = v >= 0.06;
+        else if (unit === 'px') ok = v >= 1.5;
+      }
+      if (!ok) {
+        out.push({
+          severity: 'P1',
+          id: 'all-caps-no-tracking',
+          message:
+            'Inline style sets text-transform: uppercase without sufficient letter-spacing (≥0.06em).',
+          fix: 'Add `letter-spacing: 0.08em` (typical) to the same inline style. ALL CAPS without tracking looks cramped — Refero\'s typography rules call this out as a top-tier amateur tell.',
+          snippet: clip(decl.trim()),
+        });
+        break;
+      }
+    }
+  }
+
   // ── P1-1: external image URLs (CDN / unsplash / placehold.co) ─────
   // Allow data: urls and same-origin paths.
   const extImg =
@@ -538,12 +575,15 @@ function selectorListIsGlobalThemeScope(selector) {
   return parts.every(isGlobalThemeScopeSelector);
 }
 
-// Bare attribute selectors are exempted only when the attribute is one
-// of the known global-theme switches. A broader exemption would also
-// strip arbitrary component/state attribute rules
-// (e.g. `[data-variant="primary"] { --button-bg: #6366f1; }` or
-// `[aria-current="page"] { --nav-accent: #6366f1; }`), which is the
-// exact component-local indigo laundering this lint is meant to catch.
+// Attribute selectors — bare or attached to `:root`/`html`/`body` —
+// are exempted only when the attribute is one of the known
+// global-theme switches. A broader exemption would also strip
+// arbitrary component/state attribute rules
+// (e.g. `[data-variant="primary"] { --button-bg: #6366f1; }`,
+// `:root[data-variant="primary"] { --button-bg: #6366f1; }`, or
+// `html[aria-current="page"] { --nav-accent: #6366f1; }`), which
+// is the exact component-local indigo laundering this lint is
+// meant to catch.
 const GLOBAL_THEME_ATTRIBUTES = new Set([
   'data-theme',
   'data-color-scheme',
@@ -551,12 +591,18 @@ const GLOBAL_THEME_ATTRIBUTES = new Set([
 ]);
 
 function isGlobalThemeScopeSelector(s) {
-  // :root, :root[data-theme="dark"]
-  if (/^:root(?:\[[^\]]*\])?$/.test(s)) return true;
-  // html, html[data-theme="dark"]
-  if (/^html(?:\[[^\]]*\])?$/.test(s)) return true;
-  // body, body[data-theme="dark"]
-  if (/^body(?:\[[^\]]*\])?$/.test(s)) return true;
+  // :root / html / body, optionally suffixed with a single attribute
+  // selector. The bare form (no attribute) is always a global theme
+  // scope; the prefixed form is only a theme scope when the attribute
+  // names one of GLOBAL_THEME_ATTRIBUTES. A component/state attribute
+  // suffix (`:root[data-variant="primary"]`, `html[aria-current="page"]`)
+  // must keep the rule in scope of the indigo lint.
+  const tagAttr = /^(?::root|html|body)(?:\[([a-zA-Z-]+)(?:[*^$|~]?=[^\]]*)?\])?$/.exec(s);
+  if (tagAttr) {
+    const attrName = tagAttr[1];
+    if (!attrName) return true;
+    return GLOBAL_THEME_ATTRIBUTES.has(attrName.toLowerCase());
+  }
   // Bare attribute selector restricted to known global-theme switches.
   const bareAttr = /^\[([a-zA-Z-]+)(?:[*^$|~]?=[^\]]*)?\]$/.exec(s);
   if (bareAttr && GLOBAL_THEME_ATTRIBUTES.has(bareAttr[1].toLowerCase())) {

--- a/apps/daemon/src/lint-artifact.ts
+++ b/apps/daemon/src/lint-artifact.ts
@@ -653,7 +653,7 @@ function resolveCssVars(body, tokens) {
 // selector capture include leading text like `<style>`, which then
 // fails the `:root` selector test.
 //
-// A rule is treated as a token block only when BOTH conditions hold:
+// A rule is treated as a token block only when ALL THREE conditions hold:
 //   1. every selector in the list is a global theme-scope selector
 //      (`:root`, `:root[data-theme="..."]`, `html`, `body`, or a bare
 //      attribute selector for a known global-theme switch —
@@ -670,6 +670,13 @@ function resolveCssVars(body, tokens) {
 //      A non-token declaration on `:root` (e.g.
 //      `:root { background: #6366f1 }`) keeps the rule in scope so
 //      the indigo check fires.
+//   3. no token in the body launders an indigo hex through a
+//      non-`--accent` name. The craft contract's escape hatch is to
+//      encode indigo as the active design system's `--accent` token;
+//      anything else (`:root { --primary: #6366f1 }`,
+//      `:root { --button-bg: #4f46e5 }`) is still the LLM-default
+//      color hidden behind an arbitrary token name and must stay in
+//      scope of the indigo scan.
 function stripTokenBlocks(input) {
   return input.replace(
     /(<style[^>]*>)([\s\S]*?)(<\/style>)/gi,
@@ -702,8 +709,25 @@ function stripTokenBlocksFromCss(css) {
     if (decls.length === 0) return full;
     const tokenShaped = decls.every(isTokenShapedDeclaration);
     if (!tokenShaped) return full;
+    // The `--accent` escape hatch is for `--accent` only. Any other
+    // global token whose value carries an AI-default indigo hex is
+    // still laundering the LLM-default color through an arbitrary
+    // name (`--primary: #6366f1`, `--button-bg: #4f46e5`, …). Keep
+    // the rule in scope so the indigo lint fires on the literal hex.
+    if (decls.some(declarationLaundersIndigo)) return full;
     return '';
   });
+}
+
+function declarationLaundersIndigo(decl) {
+  const m = /^(--[\w-]+)\s*:\s*(.+)$/.exec(decl);
+  if (!m) return false;
+  if (m[1].toLowerCase() === '--accent') return false;
+  const value = m[2].toLowerCase();
+  for (const hex of AI_DEFAULT_INDIGO) {
+    if (value.includes(hex.toLowerCase())) return true;
+  }
+  return false;
 }
 
 function isTokenShapedDeclaration(decl) {

--- a/apps/daemon/src/prompts/system.ts
+++ b/apps/daemon/src/prompts/system.ts
@@ -71,6 +71,13 @@ export interface ComposeInput {
     | undefined;
   designSystemBody?: string | undefined;
   designSystemTitle?: string | undefined;
+  // Craft references the active skill opted into via `od.craft.requires`.
+  // The daemon resolves the slug list to file contents and concatenates
+  // them with section headers; we inject them between the DESIGN.md and
+  // the skill body so brand tokens win on conflict but craft rules
+  // (letter-spacing, accent caps, anti-slop) cover everything below.
+  craftBody?: string | undefined;
+  craftSections?: string[] | undefined;
   // Project-level metadata captured by the new-project panel. Drives the
   // agent's understanding of artifact kind, fidelity, speaker-notes intent
   // and animation intent. Missing fields here are exactly what the
@@ -88,6 +95,8 @@ export function composeSystemPrompt({
   skillMode,
   designSystemBody,
   designSystemTitle,
+  craftBody,
+  craftSections,
   metadata,
   template,
 }: ComposeInput): string {
@@ -104,6 +113,16 @@ export function composeSystemPrompt({
   if (designSystemBody && designSystemBody.trim().length > 0) {
     parts.push(
       `\n\n## Active design system${designSystemTitle ? ` — ${designSystemTitle}` : ''}\n\nTreat the following DESIGN.md as authoritative for color, typography, spacing, and component rules. Do not invent tokens outside this palette. When you copy the active skill's seed template, bind these tokens into its \`:root\` block before generating any layout.\n\n${designSystemBody.trim()}`,
+    );
+  }
+
+  if (craftBody && craftBody.trim().length > 0) {
+    const sectionLabel =
+      Array.isArray(craftSections) && craftSections.length > 0
+        ? ` — ${craftSections.join(', ')}`
+        : '';
+    parts.push(
+      `\n\n## Active craft references${sectionLabel}\n\nThe following craft rules are universal — they apply on top of the active design system above, regardless of brand. The DESIGN.md decides *which* tokens to use; craft rules decide *how* to use them. On any conflict between a craft rule and a brand DESIGN.md, the brand wins for token values; craft rules still apply to anything the brand does not override (letter-spacing, accent overuse caps, anti-slop patterns).\n\n${craftBody.trim()}`,
     );
   }
 

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -29,6 +29,7 @@ import { importClaudeDesignZip } from './claude-design-import.js';
 import { listPromptTemplates, readPromptTemplate } from './prompt-templates.js';
 import { buildDocumentPreview } from './document-preview.js';
 import { lintArtifact, renderFindingsForAgent } from './lint-artifact.js';
+import { loadCraftSections } from './craft.js';
 import { generateMedia } from './media.js';
 import {
   AUDIO_DURATIONS_SEC,
@@ -169,6 +170,11 @@ const DESIGN_SYSTEMS_DIR = resolveDaemonResourceDir(
   DAEMON_RESOURCE_ROOT,
   'design-systems',
   path.join(PROJECT_ROOT, 'design-systems'),
+);
+const CRAFT_DIR = resolveDaemonResourceDir(
+  DAEMON_RESOURCE_ROOT,
+  'craft',
+  path.join(PROJECT_ROOT, 'craft'),
 );
 const FRAMES_DIR = resolveDaemonResourceDir(
   DAEMON_RESOURCE_ROOT,
@@ -1551,12 +1557,24 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
     let skillBody;
     let skillName;
     let skillMode;
+    let skillCraftRequires = [];
     if (effectiveSkillId) {
       const skill = (await listSkills(SKILLS_DIR)).find((s) => s.id === effectiveSkillId);
       if (skill) {
         skillBody = skill.body;
         skillName = skill.name;
         skillMode = skill.mode;
+        if (Array.isArray(skill.craftRequires)) skillCraftRequires = skill.craftRequires;
+      }
+    }
+
+    let craftBody;
+    let craftSections;
+    if (skillCraftRequires.length > 0) {
+      const loaded = await loadCraftSections(CRAFT_DIR, skillCraftRequires);
+      if (loaded.body) {
+        craftBody = loaded.body;
+        craftSections = loaded.sections;
       }
     }
 
@@ -1579,6 +1597,8 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
       skillMode,
       designSystemBody,
       designSystemTitle,
+      craftBody,
+      craftSections,
       metadata,
       template,
     });

--- a/apps/daemon/src/skills.ts
+++ b/apps/daemon/src/skills.ts
@@ -34,6 +34,7 @@ export async function listSkills(skillsRoot) {
         triggers: Array.isArray(data.triggers) ? data.triggers : [],
         mode,
         surface,
+        craftRequires: normalizeCraftRequires(data.od?.craft?.requires),
         platform: normalizePlatform(
           data.od?.platform,
           mode,
@@ -95,6 +96,27 @@ async function dirHasAttachments(dir) {
   } catch {
     return false;
   }
+}
+
+// Craft sections live at <projectRoot>/craft/<name>.md. We accept any
+// alphanumeric+dash slug here so adding a new section is as simple as
+// dropping a file in craft/ and listing its name in the skill — no
+// daemon-side allowlist to keep in sync. The compose path checks the
+// file actually exists before injecting; missing files fall through
+// silently. The frontend can render the requested list verbatim.
+function normalizeCraftRequires(value) {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set();
+  const out = [];
+  for (const v of value) {
+    if (typeof v !== "string") continue;
+    const slug = v.trim().toLowerCase();
+    if (!slug || !/^[a-z0-9][a-z0-9-]*$/.test(slug)) continue;
+    if (seen.has(slug)) continue;
+    seen.add(slug);
+    out.push(slug);
+  }
+  return out;
 }
 
 function normalizeDefaultFor(value) {

--- a/apps/daemon/tests/craft.test.ts
+++ b/apps/daemon/tests/craft.test.ts
@@ -1,0 +1,72 @@
+// @ts-nocheck
+import { describe, expect, it, beforeAll, afterAll } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { loadCraftSections } from '../src/craft.js';
+
+let craftDir;
+
+beforeAll(async () => {
+  craftDir = await mkdtemp(path.join(tmpdir(), 'od-craft-test-'));
+  await writeFile(
+    path.join(craftDir, 'typography.md'),
+    '# typography\n\nALL CAPS ≥ 0.06em.\n',
+    'utf8',
+  );
+  await writeFile(
+    path.join(craftDir, 'color.md'),
+    '# color\n\nAccent ≤ 2 per screen.\n',
+    'utf8',
+  );
+  await writeFile(path.join(craftDir, 'empty.md'), '   \n\n', 'utf8');
+});
+
+afterAll(async () => {
+  if (craftDir) await rm(craftDir, { recursive: true, force: true });
+});
+
+describe('loadCraftSections', () => {
+  it('returns empty when nothing requested', async () => {
+    const r = await loadCraftSections(craftDir, []);
+    expect(r.body).toBe('');
+    expect(r.sections).toEqual([]);
+  });
+
+  it('concatenates requested sections in order with section headers', async () => {
+    const r = await loadCraftSections(craftDir, ['typography', 'color']);
+    expect(r.sections).toEqual(['typography', 'color']);
+    expect(r.body.startsWith('### typography')).toBe(true);
+    expect(r.body.includes('### color')).toBe(true);
+    expect(r.body.indexOf('### typography')).toBeLessThan(r.body.indexOf('### color'));
+  });
+
+  it('drops missing files silently (forward-compatible)', async () => {
+    const r = await loadCraftSections(craftDir, ['typography', 'motion', 'color']);
+    expect(r.sections).toEqual(['typography', 'color']);
+  });
+
+  it('drops empty files silently', async () => {
+    const r = await loadCraftSections(craftDir, ['empty', 'typography']);
+    expect(r.sections).toEqual(['typography']);
+  });
+
+  it('rejects bogus slugs (path traversal, special chars)', async () => {
+    const r = await loadCraftSections(craftDir, [
+      '../etc/passwd',
+      'typo/graphy',
+      'typography',
+    ]);
+    expect(r.sections).toEqual(['typography']);
+  });
+
+  it('dedupes repeated requests', async () => {
+    const r = await loadCraftSections(craftDir, [
+      'typography',
+      'TYPOGRAPHY',
+      'typography',
+    ]);
+    expect(r.sections).toEqual(['typography']);
+  });
+});

--- a/apps/daemon/tests/lint-artifact.test.ts
+++ b/apps/daemon/tests/lint-artifact.test.ts
@@ -723,4 +723,111 @@ describe('all-caps-no-tracking', () => {
     const findings = lintArtifact(html);
     expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeUndefined();
   });
+
+  it('flags a 3rem heading with 1px tracking (rem font-size resolves to 48px, 0.06em floor = 2.88px)', () => {
+    // Regression: the px-vs-element-font-size resolution previously
+    // matched only `font-size: <n>px`, so a `font-size: 3rem` heading
+    // fell through to the lenient `>= 1px` fallback and accepted 1px
+    // tracking — even though the rendered ~48px display has a 2.88px
+    // floor and 1px is well below the 0.06em rule. The helper now
+    // resolves `rem` font-size via the same root assumption used for
+    // tracking and applies the strict per-element floor.
+    const html = `
+      <style>
+        .display { font-size: 3rem; text-transform: uppercase; letter-spacing: 1px; }
+      </style>
+      <h1 class="display">Headline</h1>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeDefined();
+  });
+
+  it('passes a 3rem heading with 0.06em tracking (em path is unaffected by font-size unit)', () => {
+    // Sanity check: the rem font-size fix must not regress the em
+    // letter-spacing branch. `0.06em` is the rule, regardless of how
+    // font-size is expressed.
+    const html = `
+      <style>
+        .display { font-size: 3rem; text-transform: uppercase; letter-spacing: 0.06em; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeUndefined();
+  });
+
+  it('passes a 3rem heading with 3px tracking (3 ≥ 48 * 0.06 = 2.88)', () => {
+    const html = `
+      <style>
+        .display { font-size: 3rem; text-transform: uppercase; letter-spacing: 3px; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeUndefined();
+  });
+
+  it('flags a tokenized display size with 1px tracking (var() resolves to 3rem, then to 48px)', () => {
+    // Regression: same root cause via a CSS variable. The agent often
+    // hides the size behind a token (`--display-size: 3rem`); after
+    // `resolveCssVars` the body reads `font-size: 3rem;` and must take
+    // the same strict-floor branch. Without the fix, the rule slipped
+    // past via the lenient fallback.
+    const html = `
+      <style>
+        :root { --display-size: 3rem; }
+        .display { font-size: var(--display-size); text-transform: uppercase; letter-spacing: 1px; }
+      </style>
+      <h1 class="display">Headline</h1>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeDefined();
+  });
+
+  it('flags a tokenized px display size with 1px tracking', () => {
+    // The token-resolution path must also catch a px-valued token —
+    // `font-size: var(--display-size)` with `--display-size: 48px`
+    // resolves the same way and the 2.88px floor still applies.
+    const html = `
+      <style>
+        :root { --display-size: 48px; }
+        .display { font-size: var(--display-size); text-transform: uppercase; letter-spacing: 1px; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeDefined();
+  });
+
+  it('flags a heading with 1em font-size (unresolvable unit) and 1px tracking', () => {
+    // When the rule explicitly declares font-size in a unit we cannot
+    // resolve (`em`, `%`, `calc(...)`, unresolved var), the helper
+    // refuses the lenient body-text fallback — the element might be
+    // arbitrarily large. The rule must use `em` letter-spacing or an
+    // explicit px/rem font-size to be verifiable.
+    const html = `
+      <style>
+        .display { font-size: 2em; text-transform: uppercase; letter-spacing: 1px; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeDefined();
+  });
+
+  it('passes a heading with 1em font-size and 0.06em tracking (em path is verifiable)', () => {
+    // The conservative refusal applies only when the caller leans on
+    // the px fallback. Em letter-spacing is per-element by definition,
+    // so an em font-size declaration is irrelevant to the check.
+    const html = `
+      <style>
+        .display { font-size: 2em; text-transform: uppercase; letter-spacing: 0.08em; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeUndefined();
+  });
+
+  it('flags inline 3rem heading with 1px tracking', () => {
+    // Same regression reproduced through the inline-style branch.
+    const html = `<h1 style="font-size: 3rem; text-transform: uppercase; letter-spacing: 1px">Headline</h1>`;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeDefined();
+  });
 });

--- a/apps/daemon/tests/lint-artifact.test.ts
+++ b/apps/daemon/tests/lint-artifact.test.ts
@@ -184,6 +184,91 @@ describe('ai-default-indigo', () => {
     expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeDefined();
   });
 
+  it('still flags indigo on a bare component-attribute selector', () => {
+    // Regression: the bare-attribute branch of the global-theme-scope
+    // test used to accept ANY attribute selector (e.g.
+    // `[data-variant="primary"]`), so a custom-property-only rule on
+    // a component/state attribute was treated as a global token block
+    // and the indigo lint silently disappeared. The exemption now
+    // requires the attribute name to be one of the known global-theme
+    // switches (`data-theme`, `data-color-scheme`, `data-mode`).
+    const html = `
+      <style>
+        [data-variant="primary"] { --button-bg: #6366f1; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeDefined();
+  });
+
+  it('still flags indigo on a bare aria-state attribute selector', () => {
+    const html = `
+      <style>
+        [aria-current="page"] { --nav-accent: #6366f1; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeDefined();
+  });
+
+  it('still exempts indigo on a bare data-color-scheme theme block', () => {
+    // The bare-attribute exemption still covers the canonical
+    // global-theme switches; a token block keyed off
+    // `[data-color-scheme="dark"]` is a theme variant, not a
+    // component-local rule, and must not fire.
+    const html = `
+      <style>
+        [data-color-scheme="dark"] { --accent: #6366f1; --bg: #0b0b10; }
+        .cta { background: var(--accent); color: white; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeUndefined();
+  });
+
+  it('does not flag a :root token block whose body contains CSS comments', () => {
+    // Regression: `stripTokenBlocksFromCss` used to split the body on
+    // `;` and run `isTokenShapedDeclaration` from the start of each
+    // fragment. A common token block such as
+    // `:root { /* brand accent */ --accent: #6366f1; }` produced a
+    // declaration fragment beginning with the comment, failed the
+    // token-shape test, and the rule was left in scope of the
+    // indigo scan — a false P0 on a legitimate token definition.
+    const html = `
+      <style>
+        :root { /* brand accent */ --accent: #6366f1; --bg: #ffffff; }
+        .cta { background: var(--accent); color: white; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeUndefined();
+  });
+
+  it('does not flag a :root token block with a trailing CSS comment', () => {
+    const html = `
+      <style>
+        :root { --accent: #6366f1; /* brand accent */ }
+      </style>
+      <button style="background: var(--accent)">Get started</button>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeUndefined();
+  });
+
+  it('does not flag a :root token block with a comment between declarations', () => {
+    const html = `
+      <style>
+        :root {
+          --bg: #ffffff;
+          /* brand accent — keep in sync with DESIGN.md */
+          --accent: #6366f1;
+        }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeUndefined();
+  });
+
 });
 
 describe('all-caps-no-tracking', () => {

--- a/apps/daemon/tests/lint-artifact.test.ts
+++ b/apps/daemon/tests/lint-artifact.test.ts
@@ -1045,6 +1045,28 @@ describe('all-caps-no-tracking', () => {
     const findings = lintArtifact(html);
     expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeUndefined();
   });
+
+  it('passes when a single :root block redeclares the token with a compliant value last', () => {
+    // Regression: `extractCssTokens` used to record every distinct
+    // value seen for a custom property, even when the duplicates lived
+    // in the SAME cascade scope. CSS source-order cascade collapses
+    // `:root { --caps-tracking: 0.02em; --caps-tracking: 0.08em; }`
+    // to the second declaration — the first is dead weight, never
+    // reaches any element. Treating both as theme alternatives fed the
+    // stale 0.02em into `hasAdequateUppercaseTracking` and emitted a
+    // spurious P1 on what is normal CSS overriding. The fix collapses
+    // duplicate declarations within a single rule body to the last
+    // value before merging into the cross-scope token map.
+    const html = `
+      <style>
+        :root { --caps-tracking: 0.02em; --caps-tracking: 0.08em; }
+        .eyebrow { text-transform: uppercase; letter-spacing: var(--caps-tracking); }
+      </style>
+      <span class="eyebrow">New</span>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeUndefined();
+  });
 });
 
 describe('trust-gradient', () => {

--- a/apps/daemon/tests/lint-artifact.test.ts
+++ b/apps/daemon/tests/lint-artifact.test.ts
@@ -122,6 +122,37 @@ describe('ai-default-indigo', () => {
     expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeUndefined();
   });
 
+  it('does not flag a :root token block that also declares non-custom properties like color-scheme', () => {
+    // Regression: the strip pass used to run its rule-shaped regex
+    // against the full HTML string, so the first selector capture
+    // included the leading `<style>` text and the `:root` test
+    // failed. A common token block such as
+    // `:root { color-scheme: light; --accent: #6366f1; }` should be
+    // recognized as a token definition even when the body mixes
+    // CSS variables with non-custom declarations.
+    const html = `<style>:root { color-scheme: light; --accent: #6366f1; }</style>
+      <button class="cta" style="background: var(--accent)">Get started</button>`;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeUndefined();
+  });
+
+  it('still flags indigo laundered through a component-local custom property', () => {
+    // Regression: the custom-property-only exemption used to apply
+    // to *any* selector, so an agent could hide #6366f1 in a local
+    // var (e.g. `.cta { --cta-bg: #6366f1 }`) and the linter would
+    // strip the rule and miss the P0. The exemption is now scoped
+    // to global theme selectors (:root, html, [data-theme=...], …).
+    const html = `
+      <style>
+        .cta { --cta-bg: #6366f1; }
+        .cta { background: var(--cta-bg); color: white; }
+      </style>
+      <button class="cta">Get started</button>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeDefined();
+  });
+
 });
 
 describe('all-caps-no-tracking', () => {

--- a/apps/daemon/tests/lint-artifact.test.ts
+++ b/apps/daemon/tests/lint-artifact.test.ts
@@ -940,4 +940,174 @@ describe('all-caps-no-tracking', () => {
     const findings = lintArtifact(html);
     expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeDefined();
   });
+
+  it('flags an uppercase rule whose compliant letter-spacing is overridden by a later noncompliant one', () => {
+    // Regression: the helper used to pick the FIRST matching
+    // letter-spacing declaration in the rule, but CSS applies the LAST
+    // effective declaration in source order. So
+    // `.eyebrow { letter-spacing: 0.08em; letter-spacing: 0.02em }`
+    // renders the noncompliant 0.02em — the lint must judge against the
+    // last declaration, not the first.
+    const html = `
+      <style>
+        .eyebrow { text-transform: uppercase; letter-spacing: 0.08em; letter-spacing: 0.02em; }
+      </style>
+      <span class="eyebrow">New</span>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeDefined();
+  });
+
+  it('flags an inline uppercase whose compliant letter-spacing is overridden by a later noncompliant one', () => {
+    const html = `<span style="text-transform: uppercase; letter-spacing: 0.08em; letter-spacing: 0.02em">NEW</span>`;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeDefined();
+  });
+
+  it('flags a 14px label whose 1px tracking would pass but a later font-size: 100px shifts the floor', () => {
+    // Regression: `resolveFontSizePx` used to pick the FIRST matching
+    // font-size declaration; the cascade resolves to the LAST. With
+    // `font-size: 14px; font-size: 100px`, the rendered floor is
+    // `100 * 0.06 = 6px`, so 1px tracking is well below the rule and
+    // must flag — even though the stale 14px would have accepted it
+    // (14 * 0.06 = 0.84px floor).
+    const html = `
+      <style>
+        .badge { font-size: 14px; font-size: 100px; text-transform: uppercase; letter-spacing: 1px; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeDefined();
+  });
+
+  it('passes when the compliant letter-spacing is the LAST declaration (override of an earlier noncompliant one)', () => {
+    // Sanity check: the cascade fix must not regress the inverse case.
+    // An author intentionally restoring the floor with a later override
+    // — `letter-spacing: 0.02em; letter-spacing: 0.08em` — renders 0.08em
+    // and must not fire the lint.
+    const html = `
+      <style>
+        .eyebrow { text-transform: uppercase; letter-spacing: 0.02em; letter-spacing: 0.08em; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeUndefined();
+  });
+
+  it('flags an uppercase rule when conflicting :root and [data-theme] tokens disagree on the floor', () => {
+    // Regression: `extractCssTokens` used to flatten all global theme-
+    // scope tokens to one map with last-write-wins, regardless of the
+    // selector that scoped each value. A scoped override that lifted
+    // the token above the floor could rescue a default-theme value
+    // that rendered below it, just because the second declaration
+    // happened to be parsed last. The helper now enumerates every
+    // applicable value and only passes if all resolutions satisfy the
+    // 0.06em floor — so the default-theme 0.02em still trips the lint.
+    const html = `
+      <style>
+        :root { --caps-tracking: 0.02em; }
+        [data-theme="dark"] { --caps-tracking: 0.08em; }
+        .eyebrow { text-transform: uppercase; letter-spacing: var(--caps-tracking); }
+      </style>
+      <span class="eyebrow">New</span>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeDefined();
+  });
+
+  it('flags an uppercase rule even when the conflicting :root override comes second', () => {
+    // Same regression but with declaration order swapped — the previous
+    // last-write-wins behaviour was order-dependent, so both orderings
+    // must fail when ANY resolution is below the floor.
+    const html = `
+      <style>
+        [data-theme="dark"] { --caps-tracking: 0.08em; }
+        :root { --caps-tracking: 0.02em; }
+        .eyebrow { text-transform: uppercase; letter-spacing: var(--caps-tracking); }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeDefined();
+  });
+
+  it('passes when every conflicting scoped token value clears the floor', () => {
+    // The conservative cascade must not over-fire: when ALL theme
+    // variants of a token satisfy the 0.06em rule, the artifact is
+    // compliant under every applicable theme and the lint must not
+    // fire.
+    const html = `
+      <style>
+        :root { --caps-tracking: 0.08em; }
+        [data-theme="dark"] { --caps-tracking: 0.10em; }
+        .eyebrow { text-transform: uppercase; letter-spacing: var(--caps-tracking); }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeUndefined();
+  });
+});
+
+describe('trust-gradient', () => {
+  it('flags a blue→cyan two-stop gradient with hex stops', () => {
+    // Regression: `craft/anti-ai-slop.md` documents blue→cyan as a
+    // P0 cardinal-sin trust gradient, but the existing purple-gradient
+    // rule only matches violet/indigo hex stops or the literal
+    // `purple`/`violet` keywords. A pure blue→cyan gradient slipped
+    // past unflagged. The new `trust-gradient` rule closes that gap.
+    const html = `<div style="background: linear-gradient(90deg, #3b82f6, #06b6d4)">Hi</div>`;
+    const findings = lintArtifact(html);
+    const hit = findings.find((f) => f.id === 'trust-gradient');
+    expect(hit).toBeDefined();
+    expect(hit.severity).toBe('P0');
+  });
+
+  it('flags a blue→cyan two-stop gradient with keyword stops', () => {
+    const html = `<div style="background: linear-gradient(90deg, blue, cyan)">Hi</div>`;
+    const findings = lintArtifact(html);
+    const hit = findings.find((f) => f.id === 'trust-gradient');
+    expect(hit).toBeDefined();
+    expect(hit.severity).toBe('P0');
+  });
+
+  it('flags a sky→cyan gradient (sky shares the blue ramp under another name)', () => {
+    const html = `<div style="background: linear-gradient(135deg, #0ea5e9, #22d3ee)">Hi</div>`;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'trust-gradient')).toBeDefined();
+  });
+
+  it('does not double-fire when purple-gradient already caught a purple→blue/cyan stop list', () => {
+    // A gradient that mixes purple/indigo with blue/cyan triggers
+    // purple-gradient first. The trust-gradient rule must skip in that
+    // case so the agent gets a single corrective signal.
+    const html = `<div style="background: linear-gradient(90deg, #6366f1, #06b6d4)">Hi</div>`;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'purple-gradient')).toBeDefined();
+    expect(findings.find((f) => f.id === 'trust-gradient')).toBeUndefined();
+  });
+
+  it('does not flag a blue-only gradient (no cyan stop)', () => {
+    // A single-color gradient (blue→darker-blue) is a different
+    // pattern; only the documented two-color blue→cyan trust ramp
+    // is the AI tell.
+    const html = `<div style="background: linear-gradient(90deg, #3b82f6, #1e40af)">Hi</div>`;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'trust-gradient')).toBeUndefined();
+  });
+
+  it('does not flag a gradient with only cyan stops', () => {
+    const html = `<div style="background: linear-gradient(90deg, #06b6d4, #0891b2)">Hi</div>`;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'trust-gradient')).toBeUndefined();
+  });
+
+  it('flags a blue→cyan gradient declared inside a <style> block', () => {
+    const html = `
+      <style>
+        .hero { background: linear-gradient(90deg, #3b82f6, #06b6d4); }
+      </style>
+      <div class="hero">Welcome</div>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'trust-gradient')).toBeDefined();
+  });
 });

--- a/apps/daemon/tests/lint-artifact.test.ts
+++ b/apps/daemon/tests/lint-artifact.test.ts
@@ -153,6 +153,37 @@ describe('ai-default-indigo', () => {
     expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeDefined();
   });
 
+  it('still flags a non-token :root declaration containing #6366f1', () => {
+    // Regression: the `:root` exemption used to be unconditional, so
+    // a rule whose body wasn't actually a token definition (e.g.
+    // `:root { background: #6366f1 }`) was stripped before the indigo
+    // scan and the P0 silently disappeared. The exemption now requires
+    // a token-shaped body, so a non-token `:root` declaration keeps
+    // its hex in scope and the lint still fires.
+    const html = `
+      <style>
+        :root { background: #6366f1; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeDefined();
+  });
+
+  it('still flags indigo when :root sits in a list with a component selector', () => {
+    // Regression: `:root, .cta { --cta-bg: #6366f1 }` used to be
+    // exempted because the selector list contained `:root`, even
+    // though `.cta` is a component selector. The exemption now
+    // requires every selector in the list to be a global theme
+    // scope, so this mixed list is preserved and the P0 still fires.
+    const html = `
+      <style>
+        :root, .cta { --cta-bg: #6366f1; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeDefined();
+  });
+
 });
 
 describe('all-caps-no-tracking', () => {
@@ -203,5 +234,22 @@ describe('all-caps-no-tracking', () => {
     const html = `<style>.x { color: red; }</style>`;
     const findings = lintArtifact(html);
     expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeUndefined();
+  });
+
+  it('flags an uppercase rule in a SECOND <style> block', () => {
+    // Regression: the scan used to call `exec` once on a non-global
+    // regex, so only the first <style> block was inspected. Artifacts
+    // commonly emit a reset/normalize block before the components
+    // block; the offending uppercase rule sat in block #2 and slipped
+    // past. The scan now iterates every <style> block.
+    const html = `
+      <style>.reset { box-sizing: border-box; }</style>
+      <style>.eyebrow { text-transform: uppercase; font-size: 12px; }</style>
+      <span class="eyebrow">New</span>
+    `;
+    const findings = lintArtifact(html);
+    const hit = findings.find((f) => f.id === 'all-caps-no-tracking');
+    expect(hit).toBeDefined();
+    expect(hit.severity).toBe('P1');
   });
 });

--- a/apps/daemon/tests/lint-artifact.test.ts
+++ b/apps/daemon/tests/lint-artifact.test.ts
@@ -543,4 +543,67 @@ describe('all-caps-no-tracking', () => {
     const hits = findings.filter((f) => f.id === 'all-caps-no-tracking');
     expect(hits.length).toBe(1);
   });
+
+  it('passes a 12px label with 1px tracking (resolves 0.06em via same-rule font-size)', () => {
+    // Regression: the previous absolute-fallback floor of >=1.5px was
+    // stricter than the craft rule. `font-size: 12px; letter-spacing: 1px`
+    // is `1 / 12 = 0.083em` — well above the 0.06em rule — and must pass.
+    const html = `
+      <style>
+        .eyebrow { font-size: 12px; text-transform: uppercase; letter-spacing: 1px; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeUndefined();
+  });
+
+  it('passes a 14px label with 1px tracking (resolves 0.06em via same-rule font-size)', () => {
+    // 14px * 0.06 = 0.84px floor, so 1px tracking satisfies the rule.
+    const html = `
+      <style>
+        .badge { font-size: 14px; text-transform: uppercase; letter-spacing: 1px; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeUndefined();
+  });
+
+  it('flags a 14px label with 0.5px tracking (below same-rule 0.06em floor)', () => {
+    // 14px * 0.06 = 0.84px floor; 0.5px is below the rule and must flag.
+    const html = `
+      <style>
+        .badge { font-size: 14px; text-transform: uppercase; letter-spacing: 0.5px; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeDefined();
+  });
+
+  it('passes inline 12px label with 1px tracking', () => {
+    // Same regression as the <style>-block case but in the inline branch.
+    const html = `<span style="font-size: 12px; text-transform: uppercase; letter-spacing: 1px">NEW</span>`;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeUndefined();
+  });
+
+  it('passes inline 14px label with 1px tracking', () => {
+    const html = `<span style="font-size: 14px; text-transform: uppercase; letter-spacing: 1px">NEW</span>`;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeUndefined();
+  });
+
+  it('flags inline 14px label with 0.5px tracking', () => {
+    const html = `<span style="font-size: 14px; text-transform: uppercase; letter-spacing: 0.5px">NEW</span>`;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeDefined();
+  });
+
+  it('passes inline 1px tracking even without a font-size (16px default fallback)', () => {
+    // When the same rule does not declare font-size, the conservative
+    // absolute fallback of >=1px keeps default-16px-body labels passing
+    // (1 / 16 ≈ 0.0625em, just over the 0.06em rule).
+    const html = `<span style="text-transform: uppercase; letter-spacing: 1px">NEW</span>`;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeUndefined();
+  });
 });

--- a/apps/daemon/tests/lint-artifact.test.ts
+++ b/apps/daemon/tests/lint-artifact.test.ts
@@ -606,4 +606,56 @@ describe('all-caps-no-tracking', () => {
     const findings = lintArtifact(html);
     expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeUndefined();
   });
+
+  it('flags a 48px heading with 0.06rem tracking (rem ignores element font-size)', () => {
+    // Regression: `rem` was previously folded into the same branch as
+    // `em` and accepted at the 0.06 threshold. But `rem` is relative
+    // to the root font-size (16px default), not the element's own
+    // font-size, so on a 48px heading `0.06rem` resolves to 0.96px —
+    // about 0.02em of the element, well below the 0.06em rule.
+    const html = `
+      <style>
+        .display { font-size: 48px; text-transform: uppercase; letter-spacing: 0.06rem; }
+      </style>
+      <h1 class="display">Headline</h1>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeDefined();
+  });
+
+  it('passes a 16px label with 0.06rem tracking (rem ≈ 1px ≈ 0.06em on 16px)', () => {
+    // 0.06rem * 16px/rem = 0.96px; on a 16px element that is 0.06em —
+    // exactly at the floor. The rem branch must accept it.
+    const html = `
+      <style>
+        .eyebrow { font-size: 16px; text-transform: uppercase; letter-spacing: 0.06rem; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeUndefined();
+  });
+
+  it('passes a 48px heading with 0.18rem tracking (rem converted, meets element 0.06em)', () => {
+    // 0.18rem * 16px/rem = 2.88px; 48px * 0.06 = 2.88px floor — the
+    // converted rem matches the per-element em floor exactly.
+    const html = `
+      <style>
+        .display { font-size: 48px; text-transform: uppercase; letter-spacing: 0.18rem; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeUndefined();
+  });
+
+  it('flags inline 48px heading with 0.06rem tracking', () => {
+    const html = `<h1 style="font-size: 48px; text-transform: uppercase; letter-spacing: 0.06rem">Headline</h1>`;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeDefined();
+  });
+
+  it('passes inline 16px label with 0.06rem tracking (rem ≈ 0.06em on 16px)', () => {
+    const html = `<span style="font-size: 16px; text-transform: uppercase; letter-spacing: 0.06rem">NEW</span>`;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeUndefined();
+  });
 });

--- a/apps/daemon/tests/lint-artifact.test.ts
+++ b/apps/daemon/tests/lint-artifact.test.ts
@@ -1,0 +1,95 @@
+// @ts-nocheck
+import { describe, expect, it } from 'vitest';
+
+import { lintArtifact } from '../src/lint-artifact.js';
+
+describe('ai-default-indigo', () => {
+  it('flags solid #6366f1 used as accent', () => {
+    const html = `
+      <style>
+        .cta { background: #6366f1; color: white; }
+      </style>
+      <button class="cta">Get started</button>
+    `;
+    const findings = lintArtifact(html);
+    const hit = findings.find((f) => f.id === 'ai-default-indigo');
+    expect(hit).toBeDefined();
+    expect(hit.severity).toBe('P0');
+  });
+
+  it('flags solid #4f46e5 (indigo-600) too', () => {
+    const html = `<div style="background: #4f46e5">Hi</div>`;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeDefined();
+  });
+
+  it('does not double-fire when purple-gradient already caught the same color', () => {
+    const html = `<div style="background: linear-gradient(90deg, #6366f1, #ec4899)">Hi</div>`;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'purple-gradient')).toBeDefined();
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeUndefined();
+  });
+
+  it('does not flag artifacts that use var(--accent) only', () => {
+    const html = `
+      <style>
+        :root { --accent: #2f6feb; }
+        .cta { background: var(--accent); color: white; }
+      </style>
+      <button class="cta">Get started</button>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeUndefined();
+  });
+});
+
+describe('all-caps-no-tracking', () => {
+  it('flags uppercase rule with no letter-spacing at all', () => {
+    const html = `
+      <style>
+        .eyebrow { text-transform: uppercase; font-size: 12px; }
+      </style>
+      <span class="eyebrow">New</span>
+    `;
+    const findings = lintArtifact(html);
+    const hit = findings.find((f) => f.id === 'all-caps-no-tracking');
+    expect(hit).toBeDefined();
+    expect(hit.severity).toBe('P1');
+  });
+
+  it('flags uppercase rule with too-small letter-spacing', () => {
+    const html = `
+      <style>
+        .eyebrow { text-transform: uppercase; letter-spacing: 0.02em; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeDefined();
+  });
+
+  it('passes uppercase rule with adequate letter-spacing in em', () => {
+    const html = `
+      <style>
+        .eyebrow { text-transform: uppercase; letter-spacing: 0.08em; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeUndefined();
+  });
+
+  it('passes uppercase rule with adequate letter-spacing in px', () => {
+    const html = `
+      <style>
+        .eyebrow { text-transform: uppercase; letter-spacing: 2px; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeUndefined();
+  });
+
+  it('does not flag a style block with no uppercase rule', () => {
+    const html = `<style>.x { color: red; }</style>`;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeUndefined();
+  });
+});

--- a/apps/daemon/tests/lint-artifact.test.ts
+++ b/apps/daemon/tests/lint-artifact.test.ts
@@ -378,6 +378,78 @@ describe('ai-default-indigo', () => {
     expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeUndefined();
   });
 
+  it('still flags indigo declared on a non-accent global token feeding a CTA', () => {
+    // Regression: the strip pass used to remove every custom-property-only
+    // global theme block, even when the indigo hid behind a non-`--accent`
+    // token like `--primary` or `--button-bg`. The craft contract's escape
+    // hatch is `--accent` specifically — encoding indigo as any other
+    // token name still launders the LLM-default color, so the rule must
+    // stay in scope of the indigo scan.
+    const html = `
+      <style>
+        :root { --primary: #6366f1; }
+        .cta { background: var(--primary); color: white; }
+      </style>
+      <button class="cta">Get started</button>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeDefined();
+  });
+
+  it('still flags indigo declared on a --button-bg global token alongside other tokens', () => {
+    // A laundered indigo token mixed with legitimate tokens in the same
+    // :root block must not be stripped — the non-`--accent` indigo
+    // declaration keeps the whole rule in scope so the literal hex is
+    // visible to the indigo scan.
+    const html = `
+      <style>
+        :root { --bg: #ffffff; --button-bg: #4f46e5; }
+        .cta { background: var(--button-bg); color: white; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeDefined();
+  });
+
+  it('still flags indigo on a non-accent token inside an @media-wrapped :root block', () => {
+    // The at-rule unwrapping must not bypass the non-accent check:
+    // a media-query-wrapped :root that declares indigo on `--primary`
+    // is still laundering the LLM default through an arbitrary name.
+    const html = `
+      <style>
+        @media (prefers-color-scheme: dark) {
+          :root { --primary: #6366f1; --bg: #0b0b10; }
+        }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeDefined();
+  });
+
+  it('still flags indigo on a non-accent token declared via a theme-attribute selector', () => {
+    const html = `
+      <style>
+        [data-theme="dark"] { --primary: #6366f1; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeDefined();
+  });
+
+  it('still exempts a :root token block that mixes --accent indigo with non-indigo tokens', () => {
+    // The non-accent check should fire only on indigo-bearing tokens;
+    // legitimate sibling tokens whose values are unrelated colors must
+    // not be misread as laundering.
+    const html = `
+      <style>
+        :root { --accent: #6366f1; --primary: #ff7700; --bg: #ffffff; }
+        .cta { background: var(--accent); color: white; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeUndefined();
+  });
+
   it('still flags indigo on a component rule nested inside @media', () => {
     // The exemption only applies to global token blocks. A component
     // rule that hard-codes the indigo hex inside an at-rule wrapper

--- a/apps/daemon/tests/lint-artifact.test.ts
+++ b/apps/daemon/tests/lint-artifact.test.ts
@@ -830,4 +830,42 @@ describe('all-caps-no-tracking', () => {
     const findings = lintArtifact(html);
     expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeDefined();
   });
+
+  it('flags an uppercase rule whose only `letter-spacing` is a custom-property declaration', () => {
+    // Regression: the previous substring regex matched
+    // `--letter-spacing: 0.08em` because it scanned the whole rule body
+    // for `letter-spacing\s*:`. Token-name declarations have no rendered
+    // effect, so the rule renders ALL CAPS without tracking and must
+    // still trip the P1 lint.
+    const html = `
+      <style>
+        .eyebrow { text-transform: uppercase; --letter-spacing: 0.08em; }
+      </style>
+      <span class="eyebrow">New</span>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeDefined();
+  });
+
+  it('flags a 48px heading whose only `font-size` is a custom-property declaration and tracking is below the floor', () => {
+    // Regression: `--display-font-size: 48px` previously satisfied the
+    // bail-out branch that detected an unresolvable font-size, masking
+    // the fact that no real font-size is declared. With token names
+    // ignored, the rule falls back to the conservative >=1px floor and
+    // 0.5px tracking is correctly flagged.
+    const html = `
+      <style>
+        .display { text-transform: uppercase; --display-font-size: 48px; letter-spacing: 0.5px; }
+      </style>
+      <h1 class="display">Headline</h1>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeDefined();
+  });
+
+  it('flags inline uppercase whose only `letter-spacing` is a custom-property declaration', () => {
+    const html = `<span style="text-transform: uppercase; --letter-spacing: 0.08em">NEW</span>`;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeDefined();
+  });
 });

--- a/apps/daemon/tests/lint-artifact.test.ts
+++ b/apps/daemon/tests/lint-artifact.test.ts
@@ -1067,6 +1067,97 @@ describe('all-caps-no-tracking', () => {
     const findings = lintArtifact(html);
     expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeUndefined();
   });
+
+  it('flags a 48px heading with 1px tracking nested inside @media (innermost-rule scan)', () => {
+    // Regression: `upperRe` used `[^}]*` for the rule body, so an
+    // outer `@media (...) { .display { font-size: 48px; text-transform:
+    // uppercase; letter-spacing: 1px; } }` matched as one rule whose
+    // selector was `@media (...)` and whose body began with
+    // `.display { font-size: 48px`. `parseDeclarations` then read the
+    // first property as `.display { font-size`, lost the same-rule
+    // font-size, and `hasAdequateUppercaseTracking` fell back to the
+    // lenient inherited-size path that accepts 1px on a 48px heading.
+    // Restricting the body alternation to `[^{}]*` makes the regex
+    // skip the `@media` wrapper and match the inner rule directly,
+    // restoring the strict per-element 0.06em floor (48 * 0.06 =
+    // 2.88px), so 1px tracking is correctly flagged.
+    const html = `
+      <style>
+        @media (min-width: 768px) {
+          .display { font-size: 48px; text-transform: uppercase; letter-spacing: 1px; }
+        }
+      </style>
+      <h1 class="display">Headline</h1>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeDefined();
+  });
+
+  it('flags a 48px heading with 1px tracking nested inside @supports', () => {
+    // Same regression reproduced through @supports, the other
+    // common at-rule wrapper that previously hid noncompliant
+    // tracking from the lint.
+    const html = `
+      <style>
+        @supports (color: oklch(0 0 0)) {
+          .display { font-size: 48px; text-transform: uppercase; letter-spacing: 1px; }
+        }
+      </style>
+      <h1 class="display">Headline</h1>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeDefined();
+  });
+
+  it('passes paired light/dark token values that are each compliant in their own scope', () => {
+    // Regression: `extractCssTokens` merged token values by name across
+    // scopes (`--caps-tracking = [1px, 3px]`, `--display-size = [16px,
+    // 48px]`), and the tracking helper then took an independent
+    // per-token cartesian product. The impossible cross-theme pairing
+    // `(--display-size: 48px, --caps-tracking: 1px)` failed the
+    // 0.06em floor (48 * 0.06 = 2.88px > 1px) and emitted a false
+    // `all-caps-no-tracking` even though the artifact is compliant
+    // under both real themes:
+    //   default: 16px size + 1px tracking — 1 / 16 ≈ 0.0625em ≥ 0.06em
+    //   dark:    48px size + 3px tracking — 3 / 48 ≈ 0.0625em ≥ 0.06em
+    // The fix preserves per-scope token maps and evaluates per-theme
+    // effective maps so paired declarations stay paired.
+    const html = `
+      <style>
+        :root { --caps-tracking: 1px; --display-size: 16px; }
+        [data-theme="dark"] { --caps-tracking: 3px; --display-size: 48px; }
+        .display {
+          font-size: var(--display-size);
+          text-transform: uppercase;
+          letter-spacing: var(--caps-tracking);
+        }
+      </style>
+      <h1 class="display">Headline</h1>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeUndefined();
+  });
+
+  it('flags paired theme tokens when one scope is internally noncompliant', () => {
+    // The per-theme evaluation must not silently rescue a scope whose
+    // own paired values fall below the floor. Default theme here is
+    // 48px size + 1px tracking — 1 / 48 ≈ 0.021em, well below the
+    // 0.06em rule — and must flag, even though the dark scope is
+    // internally compliant.
+    const html = `
+      <style>
+        :root { --caps-tracking: 1px; --display-size: 48px; }
+        [data-theme="dark"] { --caps-tracking: 3px; --display-size: 48px; }
+        .display {
+          font-size: var(--display-size);
+          text-transform: uppercase;
+          letter-spacing: var(--caps-tracking);
+        }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeDefined();
+  });
 });
 
 describe('trust-gradient', () => {

--- a/apps/daemon/tests/lint-artifact.test.ts
+++ b/apps/daemon/tests/lint-artifact.test.ts
@@ -658,4 +658,69 @@ describe('all-caps-no-tracking', () => {
     const findings = lintArtifact(html);
     expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeUndefined();
   });
+
+  it('passes uppercase rule whose letter-spacing dereferences a compliant :root token', () => {
+    // Regression: the tracking helper used to recognise only literal
+    // numeric values, so a tokenized rule — exactly the pattern the
+    // craft prompt steers artifacts toward — was wrongly reported as
+    // `all-caps-no-tracking`. The helper now resolves `var(--name)` to
+    // its `:root` definition and judges the literal value against the
+    // 0.06em floor.
+    const html = `
+      <style>
+        :root { --caps-tracking: 0.08em; }
+        .eyebrow { text-transform: uppercase; letter-spacing: var(--caps-tracking); }
+      </style>
+      <span class="eyebrow">New</span>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeUndefined();
+  });
+
+  it('flags uppercase rule whose letter-spacing dereferences a noncompliant :root token', () => {
+    // The token-resolution path must not blanket-pass `var()` refs:
+    // a token defined below the 0.06em floor still trips the lint.
+    const html = `
+      <style>
+        :root { --caps-tracking: 0.02em; }
+        .eyebrow { text-transform: uppercase; letter-spacing: var(--caps-tracking); }
+      </style>
+      <span class="eyebrow">New</span>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeDefined();
+  });
+
+  it('flags uppercase rule whose letter-spacing var() has no matching :root definition', () => {
+    // Unresolved references stay in place; the existing "no numeric
+    // letter-spacing" path then reports the rule as missing tracking.
+    const html = `
+      <style>
+        .eyebrow { text-transform: uppercase; letter-spacing: var(--caps-tracking); }
+      </style>
+      <span class="eyebrow">New</span>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeDefined();
+  });
+
+  it('passes uppercase rule whose letter-spacing var() has a compliant fallback', () => {
+    const html = `
+      <style>
+        .eyebrow { text-transform: uppercase; letter-spacing: var(--caps-tracking, 0.08em); }
+      </style>
+      <span class="eyebrow">New</span>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeUndefined();
+  });
+
+  it('passes inline uppercase whose letter-spacing dereferences a compliant :root token', () => {
+    const html = `
+      <style>:root { --caps-tracking: 0.08em; }</style>
+      <span style="text-transform: uppercase; letter-spacing: var(--caps-tracking)">NEW</span>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeUndefined();
+  });
 });

--- a/apps/daemon/tests/lint-artifact.test.ts
+++ b/apps/daemon/tests/lint-artifact.test.ts
@@ -269,6 +269,52 @@ describe('ai-default-indigo', () => {
     expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeUndefined();
   });
 
+  it('does not flag indigo declared in a :root token block nested inside @media', () => {
+    // Regression: `stripTokenBlocksFromCss` only matched flat
+    // `selector { body }` rules, so a media-query-wrapped token block
+    // like `@media (prefers-color-scheme: dark) { :root { --accent: #6366f1 } }`
+    // had its outer `@media` rule treated as the selector/body pair and
+    // the inner `:root` token block was never stripped — producing a
+    // P0 false positive on legitimate responsive theme CSS.
+    const html = `
+      <style>
+        @media (prefers-color-scheme: dark) {
+          :root { --accent: #6366f1; --bg: #0b0b10; }
+        }
+        .cta { background: var(--accent); color: white; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeUndefined();
+  });
+
+  it('does not flag indigo declared in a :root token block nested inside @supports', () => {
+    const html = `
+      <style>
+        @supports (color: oklch(0 0 0)) {
+          :root { --accent: #6366f1; }
+        }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeUndefined();
+  });
+
+  it('still flags indigo on a component rule nested inside @media', () => {
+    // The exemption only applies to global token blocks. A component
+    // rule that hard-codes the indigo hex inside an at-rule wrapper
+    // is still raw indigo and must fire.
+    const html = `
+      <style>
+        @media (prefers-color-scheme: dark) {
+          .cta { background: #6366f1; }
+        }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeDefined();
+  });
+
 });
 
 describe('all-caps-no-tracking', () => {
@@ -336,5 +382,36 @@ describe('all-caps-no-tracking', () => {
     const hit = findings.find((f) => f.id === 'all-caps-no-tracking');
     expect(hit).toBeDefined();
     expect(hit.severity).toBe('P1');
+  });
+
+  it('does not flag an uppercase rule that is entirely inside a CSS comment', () => {
+    // Regression: the scan ran against the raw <style> body, so a
+    // commented-out rule like `/* .eyebrow { text-transform: uppercase; } */`
+    // matched `upperRe` and fired a P1 even though the browser ignores it.
+    // CSS comments are stripped before structural matching now.
+    const html = `
+      <style>
+        /* .eyebrow { text-transform: uppercase; } */
+        .eyebrow { font-size: 12px; }
+      </style>
+      <span class="eyebrow">New</span>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeUndefined();
+  });
+
+  it('still flags an active uppercase rule when surrounded by comments', () => {
+    // Comments are stripped only for structural matching; the live rule
+    // outside the comment must still fire.
+    const html = `
+      <style>
+        /* historical: removed in 2024 */
+        .eyebrow { text-transform: uppercase; font-size: 12px; }
+        /* trailing note */
+      </style>
+      <span class="eyebrow">New</span>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeDefined();
   });
 });

--- a/apps/daemon/tests/lint-artifact.test.ts
+++ b/apps/daemon/tests/lint-artifact.test.ts
@@ -81,6 +81,47 @@ describe('ai-default-indigo', () => {
     const findings = lintArtifact(html);
     expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeUndefined();
   });
+
+  it('does not flag indigo declared in a selector list containing :root', () => {
+    // Theme CSS often pairs `:root` with an attribute selector via a
+    // selector list so the same tokens apply to both default and
+    // light-themed roots. Whichever side comes first, the block is a
+    // token definition and must not fire P0.
+    const html = `
+      <style>
+        :root, [data-theme="light"] { --accent: #6366f1; --bg: #ffffff; }
+        .cta { background: var(--accent); color: white; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeUndefined();
+  });
+
+  it('does not flag indigo declared in a selector list with :root second', () => {
+    const html = `
+      <style>
+        [data-theme="light"], :root { --accent: #6366f1; }
+        .cta { background: var(--accent); color: white; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeUndefined();
+  });
+
+  it('does not flag indigo declared in a custom-property-only theme block without :root', () => {
+    // Theme-variant blocks that omit `:root` entirely (e.g. only
+    // `[data-theme="dark"]`) are still token definitions when their
+    // body is custom-property-only; treat them the same way.
+    const html = `
+      <style>
+        [data-theme="dark"] { --accent: #6366f1; --bg: #0b0b10; }
+        .cta { background: var(--accent); color: white; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeUndefined();
+  });
+
 });
 
 describe('all-caps-no-tracking', () => {

--- a/apps/daemon/tests/lint-artifact.test.ts
+++ b/apps/daemon/tests/lint-artifact.test.ts
@@ -228,6 +228,67 @@ describe('ai-default-indigo', () => {
     expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeDefined();
   });
 
+  it('still flags indigo on a :root prefixed with a component-attribute selector', () => {
+    // Regression: `:root[data-variant="primary"]` used to be exempted
+    // because the regex only checked the tag prefix and not the
+    // attribute name. A component/state attribute attached to `:root`
+    // is exactly the laundering pattern this lint must catch — the
+    // exemption now requires the attribute (when present) to name a
+    // known global-theme switch.
+    const html = `
+      <style>
+        :root[data-variant="primary"] { --button-bg: #6366f1; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeDefined();
+  });
+
+  it('still flags indigo on an html prefixed with an aria-state attribute selector', () => {
+    const html = `
+      <style>
+        html[aria-current="page"] { --nav-accent: #6366f1; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeDefined();
+  });
+
+  it('still flags indigo on a body prefixed with a component-attribute selector', () => {
+    const html = `
+      <style>
+        body[data-variant="primary"] { --button-bg: #6366f1; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeDefined();
+  });
+
+  it('still exempts indigo on :root prefixed with the canonical data-theme switch', () => {
+    // Sanity check: the prefixed-attribute change must keep exempting
+    // legitimate theme-switch selectors (`:root[data-theme="dark"]`),
+    // even though the prefixed-form regex changed shape.
+    const html = `
+      <style>
+        :root[data-theme="dark"] { --accent: #6366f1; --bg: #0b0b10; }
+        .cta { background: var(--accent); color: white; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeUndefined();
+  });
+
+  it('still exempts indigo on html and body prefixed with data-theme', () => {
+    const html = `
+      <style>
+        html[data-theme="dark"] { --accent: #6366f1; }
+        body[data-mode="compact"] { --bg: #0b0b10; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeUndefined();
+  });
+
   it('still exempts indigo on a bare data-color-scheme theme block', () => {
     // The bare-attribute exemption still covers the canonical
     // global-theme switches; a token block keyed off
@@ -430,5 +491,56 @@ describe('all-caps-no-tracking', () => {
     `;
     const findings = lintArtifact(html);
     expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeDefined();
+  });
+
+  it('flags inline style with text-transform: uppercase and no letter-spacing', () => {
+    // Regression: the rule used to scan only <style> blocks, so an
+    // artifact emitting `<span style="text-transform: uppercase">NEW</span>`
+    // produced no finding even though the rendered output is the same
+    // ALL CAPS the typography rule prohibits without tracking.
+    const html = `<span style="text-transform: uppercase">NEW</span>`;
+    const findings = lintArtifact(html);
+    const hit = findings.find((f) => f.id === 'all-caps-no-tracking');
+    expect(hit).toBeDefined();
+    expect(hit.severity).toBe('P1');
+  });
+
+  it('flags inline style with text-transform: uppercase and too-small letter-spacing', () => {
+    const html = `<span style="text-transform: uppercase; letter-spacing: 0.02em">NEW</span>`;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeDefined();
+  });
+
+  it('passes inline style with text-transform: uppercase and adequate letter-spacing in em', () => {
+    const html = `<span style="text-transform: uppercase; letter-spacing: 0.08em">NEW</span>`;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeUndefined();
+  });
+
+  it('passes inline style with text-transform: uppercase and adequate letter-spacing in px', () => {
+    const html = `<span style="text-transform: uppercase; letter-spacing: 2px">NEW</span>`;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeUndefined();
+  });
+
+  it('flags inline style on a tag that already carries other attributes', () => {
+    // Make sure the inline-style scan handles tags whose `style` is not
+    // the first attribute. The leading-boundary anchor must not anchor
+    // to start-of-string only.
+    const html = `<span class="x" style="text-transform: uppercase">NEW</span>`;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'all-caps-no-tracking')).toBeDefined();
+  });
+
+  it('does not double-fire when both <style> block and inline style are offending', () => {
+    // The inline-style scan should be skipped when the <style>-block
+    // scan already produced this finding — single corrective signal.
+    const html = `
+      <style>.eyebrow { text-transform: uppercase; font-size: 12px; }</style>
+      <span style="text-transform: uppercase">NEW</span>
+    `;
+    const findings = lintArtifact(html);
+    const hits = findings.filter((f) => f.id === 'all-caps-no-tracking');
+    expect(hits.length).toBe(1);
   });
 });

--- a/apps/daemon/tests/lint-artifact.test.ts
+++ b/apps/daemon/tests/lint-artifact.test.ts
@@ -23,6 +23,23 @@ describe('ai-default-indigo', () => {
     expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeDefined();
   });
 
+  // Regression: the AI_DEFAULT_INDIGO list used to omit `#3730a3` and
+  // `#a855f7` even though `craft/anti-ai-slop.md` documents both as
+  // P0-blocked solid accents. An artifact could hard-code one of these
+  // as a button fill and slip past the lint. The list now matches the
+  // craft doc exactly; these regression tests pin the contract.
+  it.each([
+    ['#3730a3', 'tailwind indigo-800'],
+    ['#a855f7', 'tailwind purple-500'],
+    ['#7c3aed', 'tailwind violet-600'],
+  ])('flags solid %s (%s) as a documented cardinal-sin accent', (hex) => {
+    const html = `<div style="background: ${hex}">Hi</div>`;
+    const findings = lintArtifact(html);
+    const hit = findings.find((f) => f.id === 'ai-default-indigo');
+    expect(hit).toBeDefined();
+    expect(hit.severity).toBe('P0');
+  });
+
   it('does not double-fire when purple-gradient already caught the same color', () => {
     const html = `<div style="background: linear-gradient(90deg, #6366f1, #ec4899)">Hi</div>`;
     const findings = lintArtifact(html);

--- a/apps/daemon/tests/lint-artifact.test.ts
+++ b/apps/daemon/tests/lint-artifact.test.ts
@@ -41,6 +41,46 @@ describe('ai-default-indigo', () => {
     const findings = lintArtifact(html);
     expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeUndefined();
   });
+
+  it('does not flag indigo declared as a token in :root and consumed via var(--accent)', () => {
+    // Brand whose accent is intentionally indigo: defines #6366f1 once
+    // in :root and uses var(--accent) downstream. This is the design
+    // system speaking, not the model defaulting — must not fire P0.
+    const html = `
+      <style>
+        :root { --accent: #6366f1; --bg: #ffffff; }
+        .cta { background: var(--accent); color: white; }
+      </style>
+      <button class="cta">Get started</button>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeUndefined();
+  });
+
+  it('still flags indigo when it appears outside :root even if also defined as a token', () => {
+    // If the artifact both defines the accent AND hard-codes the same
+    // hex in a component rule, the component rule is still raw indigo
+    // — fire as before.
+    const html = `
+      <style>
+        :root { --accent: #6366f1; }
+        .cta { background: #6366f1; color: white; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeDefined();
+  });
+
+  it('does not flag indigo in :root with attribute selector (theme variants)', () => {
+    const html = `
+      <style>
+        :root[data-theme="dark"] { --accent: #6366f1; }
+        .cta { background: var(--accent); color: white; }
+      </style>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'ai-default-indigo')).toBeUndefined();
+  });
 });
 
 describe('all-caps-no-tracking', () => {

--- a/craft/README.md
+++ b/craft/README.md
@@ -32,6 +32,16 @@ od:
 Allowed values match the file names in this directory minus the `.md`
 extension. Unknown values are silently ignored (forward-compatible).
 
+### Why silent fallback instead of fail-fast?
+
+A skeptical reader will ask: "If a skill requests `motion` and we don't
+ship `motion.md` yet, shouldn't we warn the user?" We chose
+forward-compatibility over fail-fast: a skill authored today can list
+`motion` and start benefiting the moment we vendor `craft/motion.md` in
+a follow-up PR, with no skill edit needed. The cost of a missed
+reference is a missing paragraph in the system prompt, not a broken
+skill — so the loud failure mode is not worth the friction.
+
 ## Files
 
 | File | Section name | When to require |

--- a/craft/README.md
+++ b/craft/README.md
@@ -1,0 +1,52 @@
+# Craft references
+
+Brand-agnostic craft knowledge. Each file is a small, dense rulebook on one
+dimension of professional UI craft (typography, color, motion, …). Skills
+opt into the references they need; the daemon injects only the requested
+ones into the system prompt above the active skill body.
+
+## Why a third axis next to `skills/` and `design-systems/`
+
+| Axis | Scope | Example |
+|---|---|---|
+| `skills/` | Artifact shape | `saas-landing`, `dashboard`, `pricing-page` |
+| `design-systems/` | Brand visual language (the 9-section `DESIGN.md`) | `linear-app`, `apple`, `notion` |
+| `craft/` | **Universal** craft knowledge — true regardless of brand | letter-spacing rules, accent-overuse caps, anti-AI-slop |
+
+`DESIGN.md` tells the agent which colors and fonts a brand uses. `craft/`
+tells the agent the universal rules a competent designer applies on top —
+e.g. ALL CAPS always needs ≥0.06em tracking, regardless of the brand.
+
+## How a skill opts in
+
+Add an `od.craft.requires` array to the skill's front-matter. Only the
+listed sections are injected, so a skill that needs only typography pays
+no token cost for color/motion content.
+
+```yaml
+od:
+  craft:
+    requires: [typography, color, anti-ai-slop]
+```
+
+Allowed values match the file names in this directory minus the `.md`
+extension. Unknown values are silently ignored (forward-compatible).
+
+## Files
+
+| File | Section name | When to require |
+|---|---|---|
+| `typography.md` | `typography` | Any skill that emits typed content (~all skills) |
+| `color.md` | `color` | Any skill that emits styled output (~all skills) |
+| `anti-ai-slop.md` | `anti-ai-slop` | Marketing pages, landing pages, decks |
+
+More sections (`motion`, `icons`, `craft-details`) will be added in
+follow-up PRs as we wire the linter side.
+
+## Attribution
+
+Craft content is adapted from the MIT-licensed
+[refero_skill](https://github.com/referodesign/refero_skill) project
+(© Refero Design), with edits to fit Open Design's house style and link
+back to OD's design tokens (`var(--accent)` etc.) instead of generic
+Tailwind hex values.

--- a/craft/anti-ai-slop.md
+++ b/craft/anti-ai-slop.md
@@ -1,9 +1,12 @@
 # Anti-AI-slop rules
 
 Concrete, checkable rules that distinguish "designed by a human who has
-shipped product" from "default LLM output." Every rule below is also
-enforced by the daemon's `lint-artifact` linter — failing one is not
-a style preference, it is a regression.
+shipped product" from "default LLM output." Several rules below are
+auto-enforced by the daemon's `lint-artifact` linter — failing an
+enforced rule is not a style preference, it is a regression. The
+rest are guidance for agents and reviewers and are flagged inline as
+"(guidance, not auto-checked)" so the contract with the linter stays
+honest.
 
 > Adapted from [refero_skill](https://github.com/referodesign/refero_skill)
 > (MIT), tightened to match Open Design's lint surface.
@@ -38,9 +41,10 @@ These are the patterns the linter blocks at P0 (must-fix):
 ## Soft tells (P1 — should fix)
 
 - **Standard "Hero → Features → Pricing → FAQ → CTA" sequence with no
-  variation.** This is the AI-template skeleton; introduce at least one
-  unconventional section (testimonial wall as full-bleed quote, pricing
-  as comparison-against-status-quo, an inline mini-product-demo).
+  variation** *(guidance, not auto-checked)*. This is the AI-template
+  skeleton; introduce at least one unconventional section (testimonial
+  wall as full-bleed quote, pricing as comparison-against-status-quo,
+  an inline mini-product-demo).
 - **External placeholder image CDNs** (`unsplash.com`, `placehold.co`,
   `placekitten.com`, `picsum.photos`). Fragile and obvious. Use the
   shipped `.ph-img` placeholder class.
@@ -52,10 +56,11 @@ These are the patterns the linter blocks at P0 (must-fix):
 ## Polish tells (P2 — nice to fix)
 
 - **Sections without `data-od-id`** — comment mode can't target them.
-- **Decorative blob / wave SVG backgrounds** — meaningless geometry.
-- **Perfect symmetric layout with no visual tension** — alternating
-  density (one tight section, one breathing section) reads as
-  intentional.
+- **Decorative blob / wave SVG backgrounds** *(guidance, not
+  auto-checked)* — meaningless geometry.
+- **Perfect symmetric layout with no visual tension** *(guidance, not
+  auto-checked)* — alternating density (one tight section, one
+  breathing section) reads as intentional.
 
 ## How to add soul without breaking the rules
 

--- a/craft/anti-ai-slop.md
+++ b/craft/anti-ai-slop.md
@@ -15,10 +15,12 @@ honest.
 
 These are the patterns the linter blocks at P0 (must-fix):
 
-1. **Default Tailwind indigo as accent** — `#6366f1`, `#4f46e5`,
-   `#4338ca`, `#3730a3`, `#8b5cf6`, `#a855f7`, etc. The active
+1. **Default Tailwind indigo as accent** — exactly `#6366f1`, `#4f46e5`,
+   `#4338ca`, `#3730a3`, `#8b5cf6`, `#7c3aed`, `#a855f7`. The active
    `DESIGN.md` provides `--accent`; use it. Indigo is the textbook AI
-   tell.
+   tell. (The daemon's `lint-artifact` flags any of these as a solid
+   accent; keep this list in sync with `AI_DEFAULT_INDIGO` in
+   `apps/daemon/src/lint-artifact.ts`.)
 2. **Two-stop "trust" gradient on the hero** — purple→blue, blue→cyan,
    indigo→pink. A flat surface + intentional type beats this every
    time.

--- a/craft/anti-ai-slop.md
+++ b/craft/anti-ai-slop.md
@@ -1,0 +1,77 @@
+# Anti-AI-slop rules
+
+Concrete, checkable rules that distinguish "designed by a human who has
+shipped product" from "default LLM output." Every rule below is also
+enforced by the daemon's `lint-artifact` linter — failing one is not
+a style preference, it is a regression.
+
+> Adapted from [refero_skill](https://github.com/referodesign/refero_skill)
+> (MIT), tightened to match Open Design's lint surface.
+
+## The seven cardinal sins
+
+These are the patterns the linter blocks at P0 (must-fix):
+
+1. **Default Tailwind indigo as accent** — `#6366f1`, `#4f46e5`,
+   `#4338ca`, `#3730a3`, `#8b5cf6`, `#a855f7`, etc. The active
+   `DESIGN.md` provides `--accent`; use it. Indigo is the textbook AI
+   tell.
+2. **Two-stop "trust" gradient on the hero** — purple→blue, blue→cyan,
+   indigo→pink. A flat surface + intentional type beats this every
+   time.
+3. **Emoji as feature icons** — `✨`, `🚀`, `🎯`, `⚡`, `🔥`, `💡`
+   inside `<h*>`, `<button>`, `<li>`, or `class*="icon"`. Use
+   1.6–1.8px-stroke monoline SVG with `currentColor`.
+4. **Sans-serif on display text when the seed binds a serif** — h1/h2
+   must use `var(--font-display)`, not a hardcoded Inter / Roboto /
+   `system-ui`.
+5. **Rounded card with a colored left-border accent** — the canonical
+   "AI dashboard tile" shape. Drop either the radius or the left
+   border.
+6. **Invented metrics** — "10× faster", "99.9% uptime", "3× more
+   productive". Either pull from a real source or use a labelled
+   placeholder.
+7. **Filler copy** — `lorem ipsum`, `feature one / two / three`,
+   `placeholder text`, `sample content`. An empty section is a design
+   problem to solve with composition, not by inventing words.
+
+## Soft tells (P1 — should fix)
+
+- **Standard "Hero → Features → Pricing → FAQ → CTA" sequence with no
+  variation.** This is the AI-template skeleton; introduce at least one
+  unconventional section (testimonial wall as full-bleed quote, pricing
+  as comparison-against-status-quo, an inline mini-product-demo).
+- **External placeholder image CDNs** (`unsplash.com`, `placehold.co`,
+  `placekitten.com`, `picsum.photos`). Fragile and obvious. Use the
+  shipped `.ph-img` placeholder class.
+- **More than ~12 raw hex values outside `:root`.** Tokens were not
+  honoured.
+- **`var(--accent)` used 6+ times in the rendered body.** Cap at 2
+  visible uses per screen.
+
+## Polish tells (P2 — nice to fix)
+
+- **Sections without `data-od-id`** — comment mode can't target them.
+- **Decorative blob / wave SVG backgrounds** — meaningless geometry.
+- **Perfect symmetric layout with no visual tension** — alternating
+  density (one tight section, one breathing section) reads as
+  intentional.
+
+## How to add soul without breaking the rules
+
+Aim for **~80% proven patterns + ~20% distinctive choice**. The 20%
+should live in:
+
+- One bold visual move — a typography choice, a single color decision,
+  an unexpected proportion.
+- Voice and microcopy — a button that says "Start tracking" beats one
+  that says "Get started".
+- One micro-interaction the user will remember — a button press that
+  moves 2px, a number that counts up.
+- One detail that could only have been put there by someone who used
+  the product (a subtle kbd shortcut hint, a status badge with
+  product-specific phrasing).
+
+If a reviewer screenshots the artifact and someone outside the project
+can identify which product it's from — you have soul. If not, you
+shipped a template.

--- a/craft/color.md
+++ b/craft/color.md
@@ -76,7 +76,10 @@ Always name tokens by **purpose**, never by hue:
 
 - **Indigo `#6366f1`** (Tailwind `indigo-500`) is the most reliable
   AI-slop tell. The active `DESIGN.md` provides `--accent`; use it. If
-  the brief truly needs indigo, make the user say so explicitly.
+  the brief truly needs indigo, make the user say so explicitly. If
+  your `DESIGN.md` encodes indigo as `--accent`, that is intentional —
+  the linter only flags hardcoded hex, so `var(--accent)` uses are
+  unaffected even when the resolved color happens to be `#6366f1`.
 - **Two-stop "trust" gradient** (purple → blue, blue → cyan, etc.) on a
   hero is the second most reliable tell. A flat surface + one
   type-driven hierarchy beats it every time.

--- a/craft/color.md
+++ b/craft/color.md
@@ -1,0 +1,85 @@
+# Color craft rules
+
+Universal color rules applied on top of the active `DESIGN.md`. The
+design system supplies the palette tokens; this file enforces how to
+*use* them.
+
+> Adapted from [refero_skill](https://github.com/referodesign/refero_skill)
+> (MIT). All examples reference Open Design's standard tokens
+> (`--bg`, `--surface`, `--fg`, `--muted`, `--border`, `--accent`).
+
+## Palette structure
+
+A coherent palette has four layers. Plan all four before writing any CSS.
+
+| Layer | Share of pixels | Tokens |
+|---|---|---|
+| **Neutrals** | 70–90% | `--bg`, `--surface`, `--fg`, `--muted`, `--border` |
+| **Accent** (one) | 5–10% | `--accent` only — never invent a second accent |
+| **Semantic** | 0–5% | `--success`, `--warn`, `--danger` |
+| **Effect** | <1% | gradients, glows; rarely justified |
+
+## Accent discipline
+
+The single biggest readability failure in AI-generated UIs is accent
+overuse. Hard caps:
+
+- **At most 2 visible uses of `--accent` per screen.** Typical pair:
+  one eyebrow / chip + one primary CTA. Or one accent card + one tab
+  pill. Pick a pair, not a flood.
+- Links count as accent; demote to `--fg` underline if you also have a
+  CTA on the same screen.
+- Hover/focus rings count as accent. Ration accordingly.
+
+## Contrast minimums
+
+Run these as gates, not goals:
+
+| Pair | Minimum |
+|---|---|
+| Body text (≤16 px) on background | **4.5:1** |
+| Large text (>18 px or 14 px bold) | **3:1** |
+| UI components against adjacent surfaces | **3:1** |
+
+When the brand color clashes (low-contrast indigo on light background is
+common), darken the accent to a `600`-level shade for text use; reserve
+the brand-bright variant for fills only.
+
+## Dark themes
+
+Avoid pure black and pure white — both cause vibration and eye strain.
+
+| Token | Dark theme | Light theme |
+|---|---|---|
+| Background | `#0f0f0f` (not `#000`) | `#fafafa` (not `#fff`) |
+| Foreground | `#f0f0f0` (not `#fff`) | `#111111` (not `#000`) |
+
+On dark surfaces, prefer **semi-transparent white borders** over solid
+dark borders — a 1px `rgba(255,255,255,0.08)` reads as structure
+without adding visual noise.
+
+## Semantic color naming
+
+Always name tokens by **purpose**, never by hue:
+
+```css
+/* good */
+--accent: #2f6feb;
+--success: #17a34a;
+
+/* bad — locks you out of theming */
+--blue-500: #2f6feb;
+--green-500: #17a34a;
+```
+
+## Anti-defaults
+
+- **Indigo `#6366f1`** (Tailwind `indigo-500`) is the most reliable
+  AI-slop tell. The active `DESIGN.md` provides `--accent`; use it. If
+  the brief truly needs indigo, make the user say so explicitly.
+- **Two-stop "trust" gradient** (purple → blue, blue → cyan, etc.) on a
+  hero is the second most reliable tell. A flat surface + one
+  type-driven hierarchy beats it every time.
+- **Decorative gradients with no functional purpose**. Gradients should
+  separate hierarchies (header → body, primary CTA → secondary), not
+  decorate empty space.

--- a/craft/typography.md
+++ b/craft/typography.md
@@ -47,6 +47,14 @@ ALL CAPS without positive tracking looks cramped and amateur. Display
 text without negative tracking looks loose and weak. These two failures
 are the most reliable AI-slop tells.
 
+The `0.06em` floor is not arbitrary: it is the empirical lower bound
+that print and web typographers have converged on for uppercase
+tracking (cf. Bringhurst's *Elements of Typographic Style* §3.2.7,
+which recommends 5–10% of the em for caps; modern screen practice
+rounds the lower end to 0.06em). Anything tighter and the counters
+collide on screen; the upper bound `0.1em` keeps the word from
+disintegrating into letters.
+
 ## Font pairing
 
 - Maximum 2 typefaces per artifact (display + body, or one variable face

--- a/craft/typography.md
+++ b/craft/typography.md
@@ -1,0 +1,80 @@
+# Typography craft rules
+
+Universal typography rules that apply on top of any `DESIGN.md`. The
+active design system decides *which* fonts; this file decides *how* they
+behave at every size.
+
+> Adapted from [refero_skill](https://github.com/referodesign/refero_skill)
+> (MIT) — distilled and re-tuned for Open Design's token system.
+
+## Type scale
+
+Use a multiplicative scale (1.2 or 1.25). Cap at 6–8 sizes per artifact.
+
+| Role | Range |
+|---|---|
+| Display | 48–72 px |
+| H1 | 32–48 px |
+| H2 | 24–32 px |
+| H3 | 20–24 px |
+| Body | 15–18 px |
+| Small | 13–14 px |
+| Caption | 11–12 px |
+
+## Line height (leading)
+
+| Text size | Line height |
+|---|---|
+| Display / H1 (≥32 px) | `1.0`–`1.2` (tight) |
+| Body (15–18 px) | `1.5`–`1.6` |
+| Small (≤14 px) | `1.5` |
+
+## Letter-spacing — the rule that makes or breaks craft
+
+This is the single most-skipped rule in AI-generated design. **No
+exceptions.**
+
+| Context | Letter-spacing |
+|---|---|
+| Body text (14–18 px) | `0` (default) |
+| Small text (11–13 px) | `0.01em` to `0.02em` (positive) |
+| UI labels and button text | `0.02em` |
+| **ALL CAPS** | **`0.06em` to `0.1em` (required)** |
+| Headings 32 px+ | `-0.01em` to `-0.02em` |
+| Display 48 px+ | `-0.02em` to `-0.03em` |
+
+ALL CAPS without positive tracking looks cramped and amateur. Display
+text without negative tracking looks loose and weak. These two failures
+are the most reliable AI-slop tells.
+
+## Font pairing
+
+- Maximum 2 typefaces per artifact (display + body, or one variable face
+  used at multiple weights).
+- Always declare a system fallback chain. If the active `DESIGN.md`
+  ships a webfont URL, the fallback must still produce a coherent look.
+- Never set `font-family: system-ui` alone on a heading — that is the
+  textbook AI default; always pair it with an intentional first choice.
+
+## Line length
+
+Limit body copy to **50–75 characters** per line. In CSS:
+`max-width: 65ch` is a safe default.
+
+## Three-weight system
+
+Most well-crafted UIs use exactly 3 weights:
+- **Read** (400 / 450) — body copy
+- **Emphasize** (510 / 550) — UI text, labels, navigation
+- **Announce** (590 / 600) — headlines, buttons
+
+Weight 700+ is rarely needed. If your design uses bold for "emphasis on
+emphasis," it likely lacks weight discipline elsewhere.
+
+## Common mistakes (lint these)
+
+- ALL CAPS without `letter-spacing` ≥ `0.06em`.
+- Display text (≥32 px) without negative tracking.
+- More than 3 type sizes visible above the fold.
+- Mixed serif and slab on the same screen without a clear role split.
+- Body copy in `text-align: justify` (creates rivers; never use on the web).

--- a/docs/skills-protocol.md
+++ b/docs/skills-protocol.md
@@ -237,7 +237,7 @@ od:
 Resolution at compose time:
 
 1. `apps/daemon/src/skills.ts` reads `od.craft.requires` from front-matter and surfaces it on the skill record.
-2. `apps/daemon/src/craft.ts` reads each `<slug>.md` from `CRAFT_DIR`. Missing files are dropped silently — a skill can forward-reference `craft/motion.md` before we ship it.
+2. `apps/daemon/src/craft.ts` reads each `<slug>.md` from `CRAFT_DIR`. Missing files are dropped silently — a skill can forward-reference `craft/motion.md` before we ship it. See [`craft/README.md`](../craft/README.md) for the canonical slug list and the rationale behind the silent-fallback choice.
 3. `apps/daemon/src/prompts/system.ts` injects the concatenated craft body **between** the active DESIGN.md and the skill body. Brand tokens in DESIGN.md win on conflict; craft rules cover everything DESIGN.md does not override.
 
 The split keeps DESIGN.md authors free of universal-craft duplication and keeps craft authors free of brand-specific drift.

--- a/docs/skills-protocol.md
+++ b/docs/skills-protocol.md
@@ -63,6 +63,8 @@ od:
   design_system:
     requires: true                  # this skill reads the active DESIGN.md
     sections: [color, typography]   # which sections it actually uses (for prompt pruning)
+  craft:                            # universal, brand-agnostic craft references
+    requires: [typography, color, anti-ai-slop]
   inputs:                           # typed inputs the user can fill in the UI
     - name: title
       type: string
@@ -102,6 +104,7 @@ od:
 | `od.preview.type` | picking the right iframe renderer |
 | `od.design_system.requires` | whether to inject `DESIGN.md` |
 | `od.design_system.sections` | pruning the injected DESIGN.md to relevant sections only (token savings) |
+| `od.craft.requires` | which brand-agnostic `craft/<slug>.md` references to inject (e.g. `typography`, `color`, `anti-ai-slop`); injected between DESIGN.md and the skill body |
 | `od.inputs` | rendering a typed form in the sidebar instead of only free-text |
 | `od.parameters` | rendering live sliders that re-prompt on change |
 | `od.outputs.primary` | which file the iframe loads |
@@ -208,6 +211,36 @@ The 9-section DESIGN.md format is **not invented by OD**; it's the [awesome-clau
 ```
 
 Full schema and examples: [`schemas/design-system.md`](schemas/design-system.md) and [`examples/DESIGN.sample.md`](examples/DESIGN.sample.md) (TODO).
+
+## 5.5 Craft references (`craft/`)
+
+Some craft knowledge is **universal** — true regardless of brand. ALL CAPS always needs ≥0.06em letter-spacing; `var(--accent)` should appear at most 2 times per screen; `#6366f1` is always the AI-default tell. These rules don't belong in any one `DESIGN.md` because they apply across every brand.
+
+OD ships these as a third axis at `<projectRoot>/craft/`:
+
+```
+craft/
+├── README.md
+├── typography.md
+├── color.md
+└── anti-ai-slop.md
+```
+
+A skill opts in by listing the slugs it needs:
+
+```yaml
+od:
+  craft:
+    requires: [typography, color, anti-ai-slop]
+```
+
+Resolution at compose time:
+
+1. `apps/daemon/src/skills.ts` reads `od.craft.requires` from front-matter and surfaces it on the skill record.
+2. `apps/daemon/src/craft.ts` reads each `<slug>.md` from `CRAFT_DIR`. Missing files are dropped silently — a skill can forward-reference `craft/motion.md` before we ship it.
+3. `apps/daemon/src/prompts/system.ts` injects the concatenated craft body **between** the active DESIGN.md and the skill body. Brand tokens in DESIGN.md win on conflict; craft rules cover everything DESIGN.md does not override.
+
+The split keeps DESIGN.md authors free of universal-craft duplication and keeps craft authors free of brand-specific drift.
 
 ## 6. Skill installation
 

--- a/packages/contracts/src/api/registry.ts
+++ b/packages/contracts/src/api/registry.ts
@@ -42,6 +42,7 @@ export interface SkillSummary {
   fidelity?: 'wireframe' | 'high-fidelity' | null;
   speakerNotes?: boolean | null;
   animations?: boolean | null;
+  craftRequires?: string[];
   hasBody: boolean;
   examplePrompt: string;
 }

--- a/skills/saas-landing/SKILL.md
+++ b/skills/saas-landing/SKILL.md
@@ -19,6 +19,8 @@ od:
   design_system:
     requires: true
     sections: [color, typography, layout, components]
+  craft:
+    requires: [typography, color, anti-ai-slop]
   inputs:
     - name: product_name
       type: string

--- a/tools/pack/src/mac.ts
+++ b/tools/pack/src/mac.ts
@@ -269,6 +269,9 @@ async function copyResourceTree(config: ToolPackConfig, paths: MacPaths): Promis
   await cp(join(config.workspaceRoot, "design-systems"), join(paths.resourceRoot, "design-systems"), {
     recursive: true,
   });
+  await cp(join(config.workspaceRoot, "craft"), join(paths.resourceRoot, "craft"), {
+    recursive: true,
+  });
   await cp(join(config.workspaceRoot, "assets", "frames"), join(paths.resourceRoot, "frames"), {
     recursive: true,
   });


### PR DESCRIPTION
## Summary

Introduces a **third content axis** (`craft/`) alongside `skills/` and `design-systems/` for universal, brand-agnostic craft rules that apply on top of any DESIGN.md. Pilots the integration with the saas-landing skill, and extends the existing anti-slop linter with two high-leverage rules adapted from [refero_skill](https://github.com/referodesign/refero_skill).

This is PR-1 of a phased plan to integrate Refero's research-first design methodology into Open Design. It ships the parts that need **no external service** — craft rules that universally improve output quality, plus the protocol surface for follow-up PRs to plug in Refero MCP.

- **`craft/` axis** — `typography.md`, `color.md`, `anti-ai-slop.md` (MIT, attributed) — referencing OD's `var(--accent)` token system instead of generic Tailwind hexes.
- **Skill protocol extension** — `od.craft.requires: [typography, color, anti-ai-slop]` opts a skill into selected craft sections; the daemon injects them between DESIGN.md and the skill body. Missing files are dropped silently (forward-compatible for future `motion`, `icons`, etc.).
- **Linter rules** — `ai-default-indigo` (P0): solid `#6366f1` / `#4f46e5` / `#4338ca` / `#8b5cf6` as accent (not just gradients) is the most-reported AI tell. `all-caps-no-tracking` (P1): uppercase rules without ≥0.06em letter-spacing.
- **Pilot** — `skills/saas-landing` opts in.

## Architecture

```
DESIGN.md   →  brand visual language (linear-app, apple, notion, …)
craft/      →  universal craft rules (letter-spacing, accent caps, anti-slop)  ← new
skills/     →  artifact shape (saas-landing, dashboard, …)
```

Compose order in the system prompt:
1. Discovery + base charter
2. Active DESIGN.md (brand)
3. **Active craft references** (universal) ← new
4. Active skill body
5. Project metadata

DESIGN.md tokens win on conflict; craft rules cover anything DESIGN.md does not override.

## Files

| New | Purpose |
|---|---|
| `craft/README.md` | Explainer + opt-in convention |
| `craft/typography.md` | Letter-spacing rules, scale, weights |
| `craft/color.md` | Palette structure, accent caps, contrast minimums |
| `craft/anti-ai-slop.md` | The cardinal sins, with linter cross-references |
| `apps/daemon/src/craft.ts` | `loadCraftSections(craftDir, slugs)` with path-traversal defense |
| `apps/daemon/tests/craft.test.ts` | 6 tests covering loader behavior |
| `apps/daemon/tests/lint-artifact.test.ts` | 9 tests for the new rules + negatives |

| Modified | Change |
|---|---|
| `apps/daemon/src/skills.ts` | Read `od.craft.requires`, surface `craftRequires` on skill record |
| `apps/daemon/src/prompts/system.ts` | `composeSystemPrompt` accepts `craftBody` / `craftSections` |
| `apps/daemon/src/server.ts` | `CRAFT_DIR` constant; resolve craft sections in `composeDaemonSystemPrompt` |
| `apps/daemon/src/lint-artifact.ts` | New `ai-default-indigo` (P0) and `all-caps-no-tracking` (P1) rules |
| `skills/saas-landing/SKILL.md` | Pilot opt-in: `od.craft.requires: [typography, color, anti-ai-slop]` |
| `docs/skills-protocol.md` | Document `od.craft.requires`, new §5.5 on craft references |
| `AGENTS.md` | Document the third content axis |

## Test plan

- [x] `pnpm --filter @open-design/daemon test` → 118 passed (15 new)
- [x] `pnpm --filter @open-design/daemon typecheck` → clean
- [x] `pnpm --filter @open-design/web typecheck` → clean
- [x] `pnpm --filter @open-design/contracts typecheck` → clean
- [x] `pnpm check:residual-js` → passed
- [x] `pnpm --filter @open-design/daemon build` → clean
- [ ] Manual: generate a saas-landing artifact, confirm `## Active craft references` section appears in the system prompt and that `#6366f1`-using output is flagged at P0
- [ ] Manual: skill with no `od.craft.requires` still composes identically (no behavior change for existing skills)

Pre-existing typecheck failures in `e2e` and `apps/packaged` (depend on unbuilt `dist/` outputs from sibling packages) are unaffected.

## Follow-ups

- **PR-2**: vendor `craft/motion.md`, `craft/icons.md`, `craft/craft-details.md`; extend linter with motion-duration cap + display-tracking checks.
- **PR-3**: optional Refero MCP connector (paid; BYO token) — adds research-first phase to prototype mode.
- **PR-4**: "brand name → DESIGN.md" generator using research output + craft schema.