### PR TITLE
fix(sidecar): attach error listener on server-side IPC sockets

### DIFF
--- a/packages/sidecar/src/index.ts
+++ b/packages/sidecar/src/index.ts
@@ -485,6 +485,7 @@ export async function createJsonIpcServer({
   await prepareIpcPath(socketPath);
   const server = createNetServer((socket) => {
     let buffer = "";
+    socket.on("error", () => {});
     socket.on("data", async (chunk) => {
       buffer += chunk.toString();
       const newlineIndex = buffer.indexOf("\n");


### PR DESCRIPTION
## Summary

The IPC server in `createJsonIpcServer` (`packages/sidecar/src/index.ts`) attached only a `data` handler to incoming sockets. The server's response is sent via `socket.end(payload)`, which races with the client's own `socket.end()` in `requestJsonIpc` (called immediately after reading the response). On Windows named pipes with Node 24 this race produces an `EPIPE` write error on the server side. With no `error` listener, that error is unhandled and crashes the entire daemon process, so `tools-dev` reports `daemon did not expose status in time`.

This adds a no-op `error` listener on the connection socket to absorb benign close-races. The client side (`requestJsonIpc`) already has an `error` listener, so this just matches the existing pattern.

## Repro

- Windows 11 Pro + Node v24.14.0 + pnpm 10.33.2
- `pnpm tools-dev start daemon` consistently crashes with `EPIPE` from `Socket.end` at `packages/sidecar/dist/index.mjs:319` (the `socket.end(\`\${...}\n\`)` line)
- After the patch: daemon stays up, status reports `running` cleanly

## Test plan

- [x] Manual repro on Win11 / Node 24 — daemon now starts cleanly and serves IPC
- [ ] Verify existing `packages/sidecar/src/index.test.ts` still passes
- [ ] No behavior change on POSIX (the listener is a no-op)