### PR TITLE
fix(tools-dev): use junction instead of dir symlink on Windows

### DIFF
--- a/tools/dev/src/index.ts
+++ b/tools/dev/src/index.ts
@@ -476,7 +476,7 @@ async function ensureWebDevNodeModules(config: ToolDevConfig): Promise<void> {
   const current = await lstat(runtimeNodeModules).catch(() => null);
   if (current?.isSymbolicLink()) return;
   if (current != null) await rm(runtimeNodeModules, { force: true, recursive: true });
-  await symlink(webNodeModules, runtimeNodeModules, "dir");
+  await symlink(webNodeModules, runtimeNodeModules, "junction");
 }
 
 async function writeWebDevTsconfig(config: ToolDevConfig): Promise<void> {


### PR DESCRIPTION
## Summary

`ensureWebDevNodeModules()` in `tools/dev/src/index.ts` called `fs.symlink(target, path, "dir")` to link `apps/web/node_modules` into the web runtime root. On Windows, `"dir"` symlinks require either Administrator rights or Developer Mode (`SeCreateSymbolicLinkPrivilege`). A standard non-elevated user account without Developer Mode hits `EPERM` and \`tools-dev\` exits before web ever starts.

`"junction"` is functionally equivalent for directory-only links on the same volume, works for any user without elevation or Developer Mode, and is silently treated as a regular symlink on POSIX (Node's `fs.symlink` ignores the `type` argument outside Windows). The existing `isSymbolicLink()` check on the next launch still matches junctions on Node.

## Repro

- Windows 11 Pro + Node v24.14.0, non-elevated PowerShell, Developer Mode off
- `pnpm tools-dev start web` fails with: `EPERM: operation not permitted, symlink 'O:\open-design\apps\web\node_modules' -> 'O:\open-design\.tmp\tools-dev\default\web\node_modules'`
- After patch: link is created as a junction (`Get-Item ... | LinkType: Junction`) and tools-dev brings up daemon + web cleanly

## Test plan

- [x] Manual repro on Win11 (no admin, no Developer Mode) — \`pnpm tools-dev start web\` succeeds, web reachable on its allocated port
- [ ] No regression on POSIX — \`type\` arg is ignored by Node outside Windows