### PR TITLE
fix(daemon): quote agent bin path when spawning with shell:true on Windows

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1863,7 +1863,15 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
       // OS command-line length limit (Windows CreateProcess caps at ~32 KB)
       // which causes `spawn ENAMETOOLONG` for any non-trivial prompt.
       const stdinMode = def.promptViaStdin || def.streamFormat === 'acp-json-rpc' || needsFilePrompt ? 'pipe' : 'ignore';
-      child = spawn(resolvedBin, args, {
+      // With shell:true on Windows, Node.js builds `cmd.exe /d /s /c "<bin> <args>"`
+      // and escapes argv items but does NOT quote the bin path itself. If
+      // `resolvedBin` contains spaces (e.g. an npm shim under a user directory
+      // like `C:\Users\First Last\AppData\...\claude.CMD`), cmd.exe parses up
+      // to the first space as the command and the rest as arguments, yielding
+      // "The system cannot find the file 'C:\Users\First'". Quote the bin so
+      // the entire path is treated as one token.
+      const spawnBin = useShell ? `"${resolvedBin}"` : resolvedBin;
+      child = spawn(spawnBin, args, {
         env: { ...process.env, ...odMediaEnv },
         stdio: [stdinMode, 'pipe', 'pipe'],
         cwd: cwd || undefined,


### PR DESCRIPTION
## Summary

On Windows, when the daemon spawns an agent CLI shipped as a `.cmd`/`.bat` shim (the common case for npm-installed CLIs), it sets `shell: true` to comply with Node ≥21's CVE-2024-27980 mitigation. With `shell: true`, Node builds `cmd.exe /d /s /c "<bin> <escaped-args>"` and escapes the **args** for cmd.exe — but it does **not** quote the **bin path** itself. That's the caller's responsibility.

If `resolvedBin` contains a space (the typical case for an npm shim under a user directory whose Windows account name contains a space, e.g. `C:\Users\First Last\AppData\Local\…\claude.CMD`), cmd.exe stops parsing the command at the first whitespace and tries to launch `C:\Users\First`, then fails with:

> `The system cannot find the file 'C:\Users\First'`
> *(or its localized equivalent — German on the affected machine: `Der Befehl "C:\Users\Max" ist entweder falsch geschrieben oder konnte nicht gefunden werden.`)*

The agent process exits with code 1 in ~0.1s and the chat surfaces the cmd.exe error verbatim. The Node DEP0190 deprecation warning that fires alongside (`Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated`) is the same root cause from the runtime side.

## Fix

Wrap `resolvedBin` in double quotes when `useShell` is true so the full path stays a single token. The `/s` flag Node already passes to cmd.exe handles the resulting `cmd /d /s /c ""path with spaces" args"` correctly.

```diff
+      const spawnBin = useShell ? `"${resolvedBin}"` : resolvedBin;
-      child = spawn(resolvedBin, args, {
+      child = spawn(spawnBin, args, {
```

## Repro

Any Windows account name with a space (`Max Mustermann`, `John Doe`, `Jane Smith`, etc.) hits this whenever the agent CLI is installed via `npm i -g` or `pnpm add -g`. Workaround pre-fix is to install the agent CLI to a path without spaces or use a junction.

## Test plan

- [x] `pnpm --filter @open-design/daemon build` — clean (this is where the change lives)
- [x] `pnpm typecheck` — clean across all workspaces (after pre-existing build-order bootstrap of daemon/desktop dist)
- [x] `pnpm --filter @open-design/daemon test` — 122/122 pass
- [x] `pnpm --filter @open-design/tools-dev test` — 3/3 pass
- [x] `pnpm test` — only failures are 2 pre-existing i18n assertions in `apps/web/src/i18n/content.test.ts` (`"Game UI"` and prompt-template categories missing from German content); confirmed identical failures on stock `main` without this patch
- [x] Manual: dev server (`pnpm tools-dev run web`) restarts cleanly with the patched daemon on the affected machine

End-to-end UI verification (sending a chat prompt to a working agent) is pending and will be done by the reporter.