### PR TITLE
[codex] Improve project input performance

### DIFF
--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState, useTransition } from 'react';
 import { useT } from '../i18n';
 import type { Dict } from '../i18n/types';
 import { projectFileUrl } from '../providers/registry';
@@ -58,6 +58,7 @@ export function DesignFilesPanel({
   const [menuPos, setMenuPos] = useState<{ name: string; top: number; left: number } | null>(null);
   const [preview, setPreview] = useState<string | null>(null);
   const [sectionLimits, setSectionLimits] = useState<Partial<Record<Section, number>>>({});
+  const [isSectionExpansionPending, startSectionExpansion] = useTransition();
 
   const grouped = useMemo(() => {
     const groups: Record<Section, ProjectFile[]> = {
@@ -219,19 +220,26 @@ export function DesignFilesPanel({
                   <button
                     type="button"
                     className="df-section-more"
+                    disabled={isSectionExpansionPending}
+                    aria-busy={isSectionExpansionPending}
                     onClick={() =>
-                      setSectionLimits((curr) => ({
-                        ...curr,
-                        [section]: Math.min(
-                          sectionFiles.length,
-                          visibleLimit + SECTION_FILE_LIMIT_INCREMENT,
-                        ),
-                      }))
+                      startSectionExpansion(() => {
+                        setSectionLimits((curr) => ({
+                          ...curr,
+                          [section]: Math.min(
+                            sectionFiles.length,
+                            visibleLimit + SECTION_FILE_LIMIT_INCREMENT,
+                          ),
+                        }));
+                      })
                     }
                   >
-                    {t('assistant.unfinishedMore', {
-                      n: Math.min(hiddenCount, SECTION_FILE_LIMIT_INCREMENT),
-                    })}
+                    <Icon name={isSectionExpansionPending ? 'spinner' : 'plus'} size={12} />
+                    <span>
+                      {t('designFiles.showMore', {
+                        n: Math.min(hiddenCount, SECTION_FILE_LIMIT_INCREMENT),
+                      })}
+                    </span>
                   </button>
                 ) : null}
               </div>

--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -30,6 +30,8 @@ const SECTION_LABEL_KEY: Record<Section, keyof Dict> = {
 };
 
 const SECTION_ORDER: Section[] = ['pages', 'sketches', 'scripts', 'images', 'other'];
+const INITIAL_SECTION_FILE_LIMIT = 30;
+const SECTION_FILE_LIMIT_INCREMENT = 200;
 
 /**
  * Full-panel browser for a project's `.od/projects/<id>/` folder. Mirrors
@@ -55,6 +57,7 @@ export function DesignFilesPanel({
   const [hover, setHover] = useState<string | null>(null);
   const [menuPos, setMenuPos] = useState<{ name: string; top: number; left: number } | null>(null);
   const [preview, setPreview] = useState<string | null>(null);
+  const [sectionLimits, setSectionLimits] = useState<Partial<Record<Section, number>>>({});
 
   const grouped = useMemo(() => {
     const groups: Record<Section, ProjectFile[]> = {
@@ -156,12 +159,18 @@ export function DesignFilesPanel({
           {files.length === 0 ? (
             <div className="df-empty">{t('designFiles.empty')}</div>
           ) : (
-            SECTION_ORDER.filter((s) => grouped[s].length > 0).map((section) => (
+            SECTION_ORDER.filter((s) => grouped[s].length > 0).map((section) => {
+              const sectionFiles = grouped[section];
+              const visibleLimit = sectionLimits[section] ?? INITIAL_SECTION_FILE_LIMIT;
+              const visibleFiles = sectionFiles.slice(0, visibleLimit);
+              const hiddenCount = sectionFiles.length - visibleFiles.length;
+              return (
               <div className="df-section" key={section}>
                 <div className="df-section-label">
                   {t(SECTION_LABEL_KEY[section])}
+                  <span className="df-section-count">{sectionFiles.length}</span>
                 </div>
-                {grouped[section].map((f) => {
+                {visibleFiles.map((f) => {
                   const active = preview === f.name;
                   const isHovered = hover === f.name;
                   return (
@@ -206,8 +215,28 @@ export function DesignFilesPanel({
                     </button>
                   );
                 })}
+                {hiddenCount > 0 ? (
+                  <button
+                    type="button"
+                    className="df-section-more"
+                    onClick={() =>
+                      setSectionLimits((curr) => ({
+                        ...curr,
+                        [section]: Math.min(
+                          sectionFiles.length,
+                          visibleLimit + SECTION_FILE_LIMIT_INCREMENT,
+                        ),
+                      }))
+                    }
+                  >
+                    {t('assistant.unfinishedMore', {
+                      n: Math.min(hiddenCount, SECTION_FILE_LIMIT_INCREMENT),
+                    })}
+                  </button>
+                ) : null}
               </div>
-            ))
+              );
+            })
           )}
           <div
             className={`df-drop ${draggingFiles ? 'dragging' : ''}`}

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -118,6 +118,8 @@ export function ProjectView({
   const [openRequest, setOpenRequest] = useState<{ name: string; nonce: number } | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const cancelRef = useRef<AbortController | null>(null);
+  const sendTextBufferCancelRef = useRef<(() => void) | null>(null);
+  const reattachTextBufferCancelsRef = useRef<Set<() => void>>(new Set());
   const reattachControllersRef = useRef<Map<string, AbortController>>(new Map());
   const reattachCancelControllersRef = useRef<Map<string, AbortController>>(new Map());
   const completedReattachRunsRef = useRef<Set<string>>(new Set());
@@ -186,6 +188,10 @@ export function ProjectView({
 
   useEffect(() => {
     return () => {
+      sendTextBufferCancelRef.current?.();
+      sendTextBufferCancelRef.current = null;
+      for (const cancel of reattachTextBufferCancelsRef.current) cancel();
+      reattachTextBufferCancelsRef.current.clear();
       for (const controller of reattachControllersRef.current.values()) {
         controller.abort();
       }
@@ -196,6 +202,16 @@ export function ProjectView({
       reattachCancelControllersRef.current.clear();
     };
   }, [project.id, activeConversationId]);
+
+  const cancelSendTextBuffer = useCallback(() => {
+    sendTextBufferCancelRef.current?.();
+    sendTextBufferCancelRef.current = null;
+  }, []);
+
+  const cancelReattachTextBuffers = useCallback(() => {
+    for (const cancel of reattachTextBufferCancelsRef.current) cancel();
+    reattachTextBufferCancelsRef.current.clear();
+  }, []);
 
   // Hydrate the open-tabs state once per project. After this initial
   // load, every mutation flows through saveTabsState() which keeps DB +
@@ -472,6 +488,10 @@ export function ProjectView({
           updateMessage: (updater) => updateMessageById(message.id, updater),
           persistSoon,
         });
+        reattachTextBufferCancelsRef.current.add(textBuffer.cancel);
+        const unregisterTextBuffer = () => {
+          reattachTextBufferCancelsRef.current.delete(textBuffer.cancel);
+        };
 
         void reattachDaemonRun({
           runId,
@@ -487,6 +507,8 @@ export function ProjectView({
             },
             onDone: () => {
               textBuffer.flush();
+              textBuffer.cancel();
+              unregisterTextBuffer();
               updateMessageById(
                 message.id,
                 (prev) => ({ ...prev, runStatus: 'succeeded', endedAt: prev.endedAt ?? Date.now() }),
@@ -504,6 +526,8 @@ export function ProjectView({
             },
             onError: (err) => {
               textBuffer.flush();
+              textBuffer.cancel();
+              unregisterTextBuffer();
               setError(err.message);
               updateMessageById(
                 message.id,
@@ -531,6 +555,8 @@ export function ProjectView({
               true,
             );
             if (runStatus === 'canceled') {
+              textBuffer.cancel();
+              unregisterTextBuffer();
               completedReattachRunsRef.current.add(runId);
               reattachControllersRef.current.delete(runId);
               reattachCancelControllersRef.current.delete(runId);
@@ -553,6 +579,8 @@ export function ProjectView({
           })
           .finally(() => {
             textBuffer.flush();
+            textBuffer.cancel();
+            unregisterTextBuffer();
             if (persistTimer) clearTimeout(persistTimer);
             reattachControllersRef.current.delete(runId);
             reattachCancelControllersRef.current.delete(runId);
@@ -565,6 +593,7 @@ export function ProjectView({
     void attachRecoverableRuns();
     return () => {
       cancelled = true;
+      cancelReattachTextBuffers();
     };
   }, [
     daemonLive,
@@ -576,6 +605,7 @@ export function ProjectView({
     persistMessageById,
     refreshProjectFiles,
     onProjectsRefresh,
+    cancelReattachTextBuffers,
   ]);
 
   const handleSend = useCallback(
@@ -707,6 +737,7 @@ export function ProjectView({
         persistSoon: persistAssistantSoon,
         onContentDelta: applyContentDelta,
       });
+      sendTextBufferCancelRef.current = textBuffer.cancel;
 
       const controller = new AbortController();
       const cancelController = new AbortController();
@@ -720,6 +751,8 @@ export function ProjectView({
         },
         onDone: () => {
           textBuffer.flush();
+          textBuffer.cancel();
+          cancelSendTextBuffer();
           for (const ev of parser.flush()) {
             if (ev.type === 'artifact:end') {
               setArtifact((prev) => (prev ? { ...prev, html: ev.fullContent } : null));
@@ -763,6 +796,8 @@ export function ProjectView({
         },
         onError: (err: Error) => {
           textBuffer.flush();
+          textBuffer.cancel();
+          cancelSendTextBuffer();
           setError(err.message);
           updateAssistant((prev) => ({
             ...prev,
@@ -938,6 +973,8 @@ export function ProjectView({
 
   const handleStop = useCallback(() => {
     const stoppedAt = Date.now();
+    cancelSendTextBuffer();
+    cancelReattachTextBuffers();
     cancelRef.current?.abort();
     cancelRef.current = null;
     for (const controller of reattachCancelControllersRef.current.values()) {
@@ -970,7 +1007,7 @@ export function ProjectView({
       for (const message of finalized) persistMessage(message);
       return next;
     });
-  }, [persistMessage]);
+  }, [cancelSendTextBuffer, cancelReattachTextBuffers, persistMessage]);
 
   const handleNewConversation = useCallback(async () => {
     const fresh = await createConversation(project.id);
@@ -1174,47 +1211,84 @@ function createBufferedTextUpdates({
   let pendingContentDelta = '';
   let pendingTextEventDelta = '';
   let flushFrame: number | null = null;
+  let flushTimer: ReturnType<typeof setTimeout> | null = null;
+  let disposed = false;
+  let flushing = false;
+  let needsFlush = false;
+  const hasDocument = typeof document !== 'undefined';
 
-  const flush = () => {
+  const cancelScheduledFlush = () => {
     if (flushFrame !== null) {
       cancelAnimationFrame(flushFrame);
       flushFrame = null;
     }
-    if (!pendingContentDelta && !pendingTextEventDelta) return;
+    if (flushTimer !== null) {
+      clearTimeout(flushTimer);
+      flushTimer = null;
+    }
+  };
+
+  const flush = () => {
+    if (disposed) return;
+    if (flushing) {
+      needsFlush = true;
+      return;
+    }
+    cancelScheduledFlush();
+    if (!pendingContentDelta && !pendingTextEventDelta && !needsFlush) return;
+    flushing = true;
+    needsFlush = false;
     const contentDelta = pendingContentDelta;
     const textEventDelta = pendingTextEventDelta;
     pendingContentDelta = '';
     pendingTextEventDelta = '';
-    updateMessage((prev) => ({
-      ...prev,
-      content: prev.content + contentDelta,
-      events: textEventDelta
-        ? [...(prev.events ?? []), { kind: 'text', text: textEventDelta }]
-        : prev.events,
-    }));
-    persistSoon();
-    if (contentDelta) onContentDelta?.(contentDelta);
+    try {
+      updateMessage((prev) => ({
+        ...prev,
+        content: prev.content + contentDelta,
+        events: textEventDelta
+          ? [...(prev.events ?? []), { kind: 'text', text: textEventDelta }]
+          : prev.events,
+      }));
+      persistSoon();
+      if (contentDelta) onContentDelta?.(contentDelta);
+    } finally {
+      flushing = false;
+    }
+    if (pendingContentDelta || pendingTextEventDelta || needsFlush) {
+      needsFlush = false;
+      scheduleFlush();
+    }
   };
 
   const scheduleFlush = () => {
-    if (flushFrame !== null) return;
+    if (disposed || flushFrame !== null || flushTimer !== null) return;
     flushFrame = requestAnimationFrame(() => {
       flushFrame = null;
       flush();
     });
+    flushTimer = setTimeout(() => {
+      flushTimer = null;
+      flush();
+    }, 250);
   };
 
   const appendContent = (delta: string) => {
+    if (disposed) return;
     pendingContentDelta += delta;
+    needsFlush = true;
     scheduleFlush();
   };
 
   const appendTextEvent = (delta: string) => {
+    if (disposed) return;
     pendingTextEventDelta += delta;
+    needsFlush = true;
     scheduleFlush();
   };
 
   const appendEvent = (ev: AgentEvent) => {
+    if (disposed) return;
     if (ev.kind === 'text') {
       appendTextEvent(ev.text);
       return;
@@ -1224,5 +1298,26 @@ function createBufferedTextUpdates({
     persistSoon();
   };
 
-  return { appendContent, appendTextEvent, appendEvent, flush };
+  const cancel = () => {
+    disposed = true;
+    cancelScheduledFlush();
+    pendingContentDelta = '';
+    pendingTextEventDelta = '';
+    needsFlush = false;
+    if (hasDocument) {
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    }
+  };
+
+  function onVisibilityChange() {
+    if (document.visibilityState === 'hidden') {
+      flush();
+    }
+  }
+
+  if (hasDocument) {
+    document.addEventListener('visibilitychange', onVisibilityChange);
+  }
+
+  return { appendContent, appendTextEvent, appendEvent, flush, cancel };
 }

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -465,8 +465,13 @@ export function ProjectView({
             clearTimeout(persistTimer);
             persistTimer = null;
           }
+          textBuffer.flush();
           persistMessageById(message.id);
         };
+        const textBuffer = createBufferedTextUpdates({
+          updateMessage: (updater) => updateMessageById(message.id, updater),
+          persistSoon,
+        });
 
         void reattachDaemonRun({
           runId,
@@ -475,14 +480,13 @@ export function ProjectView({
           initialLastEventId: message.lastRunEventId ?? null,
           handlers: {
             onDelta: (delta) => {
-              updateMessageById(message.id, (prev) => ({ ...prev, content: prev.content + delta }));
-              persistSoon();
+              textBuffer.appendContent(delta);
             },
             onAgentEvent: (ev) => {
-              updateMessageById(message.id, (prev) => ({ ...prev, events: [...(prev.events ?? []), ev] }));
-              persistSoon();
+              textBuffer.appendEvent(ev);
             },
             onDone: () => {
+              textBuffer.flush();
               updateMessageById(
                 message.id,
                 (prev) => ({ ...prev, runStatus: 'succeeded', endedAt: prev.endedAt ?? Date.now() }),
@@ -499,6 +503,7 @@ export function ProjectView({
               onProjectsRefresh();
             },
             onError: (err) => {
+              textBuffer.flush();
               setError(err.message);
               updateMessageById(
                 message.id,
@@ -515,6 +520,7 @@ export function ProjectView({
             },
           },
           onRunStatus: (runStatus) => {
+            textBuffer.flush();
             updateMessageById(
               message.id,
               (prev) => ({
@@ -535,6 +541,7 @@ export function ProjectView({
             }
           },
           onRunEventId: (lastRunEventId) => {
+            textBuffer.flush();
             updateMessageById(message.id, (prev) => ({ ...prev, lastRunEventId }));
             persistSoon();
           },
@@ -545,6 +552,7 @@ export function ProjectView({
             }
           })
           .finally(() => {
+            textBuffer.flush();
             if (persistTimer) clearTimeout(persistTimer);
             reattachControllersRef.current.delete(runId);
             reattachCancelControllersRef.current.delete(runId);
@@ -647,6 +655,7 @@ export function ProjectView({
         }, 500);
       };
       const pushEvent = (ev: AgentEvent) => {
+        textBuffer.flush();
         updateAssistant((prev) => ({ ...prev, events: [...(prev.events ?? []), ev] }));
         persistAssistantSoon();
         // Track Write tool invocations so we can auto-open the destination
@@ -675,9 +684,7 @@ export function ProjectView({
         }
       };
 
-      const appendContent = (delta: string) => {
-        updateAssistant((prev) => ({ ...prev, content: prev.content + delta }));
-        persistAssistantSoon();
+      const applyContentDelta = (delta: string) => {
         for (const ev of parser.feed(delta)) {
           if (ev.type === 'artifact:start') {
             liveHtml = '';
@@ -695,14 +702,24 @@ export function ProjectView({
         }
       };
 
+      const textBuffer = createBufferedTextUpdates({
+        updateMessage: updateAssistant,
+        persistSoon: persistAssistantSoon,
+        onContentDelta: applyContentDelta,
+      });
+
       const controller = new AbortController();
       const cancelController = new AbortController();
       abortRef.current = controller;
       cancelRef.current = cancelController;
       const handlers = {
-        onDelta: appendContent,
-        onAgentEvent: pushEvent,
+        onDelta: textBuffer.appendContent,
+        onAgentEvent: (ev: AgentEvent) => {
+          if (ev.kind === 'text') textBuffer.appendTextEvent(ev.text);
+          else pushEvent(ev);
+        },
         onDone: () => {
+          textBuffer.flush();
           for (const ev of parser.flush()) {
             if (ev.type === 'artifact:end') {
               setArtifact((prev) => (prev ? { ...prev, html: ev.fullContent } : null));
@@ -745,6 +762,7 @@ export function ProjectView({
           onProjectsRefresh();
         },
         onError: (err: Error) => {
+          textBuffer.flush();
           setError(err.message);
           updateAssistant((prev) => ({
             ...prev,
@@ -1142,4 +1160,69 @@ function isTerminalRunStatus(status: ChatMessage['runStatus']): boolean {
 
 function isActiveRunStatus(status: ChatMessage['runStatus']): boolean {
   return status === 'queued' || status === 'running';
+}
+
+function createBufferedTextUpdates({
+  updateMessage,
+  persistSoon,
+  onContentDelta,
+}: {
+  updateMessage: (updater: (prev: ChatMessage) => ChatMessage) => void;
+  persistSoon: () => void;
+  onContentDelta?: (delta: string) => void;
+}) {
+  let pendingContentDelta = '';
+  let pendingTextEventDelta = '';
+  let flushFrame: number | null = null;
+
+  const flush = () => {
+    if (flushFrame !== null) {
+      cancelAnimationFrame(flushFrame);
+      flushFrame = null;
+    }
+    if (!pendingContentDelta && !pendingTextEventDelta) return;
+    const contentDelta = pendingContentDelta;
+    const textEventDelta = pendingTextEventDelta;
+    pendingContentDelta = '';
+    pendingTextEventDelta = '';
+    updateMessage((prev) => ({
+      ...prev,
+      content: prev.content + contentDelta,
+      events: textEventDelta
+        ? [...(prev.events ?? []), { kind: 'text', text: textEventDelta }]
+        : prev.events,
+    }));
+    persistSoon();
+    if (contentDelta) onContentDelta?.(contentDelta);
+  };
+
+  const scheduleFlush = () => {
+    if (flushFrame !== null) return;
+    flushFrame = requestAnimationFrame(() => {
+      flushFrame = null;
+      flush();
+    });
+  };
+
+  const appendContent = (delta: string) => {
+    pendingContentDelta += delta;
+    scheduleFlush();
+  };
+
+  const appendTextEvent = (delta: string) => {
+    pendingTextEventDelta += delta;
+    scheduleFlush();
+  };
+
+  const appendEvent = (ev: AgentEvent) => {
+    if (ev.kind === 'text') {
+      appendTextEvent(ev.text);
+      return;
+    }
+    flush();
+    updateMessage((prev) => ({ ...prev, events: [...(prev.events ?? []), ev] }));
+    persistSoon();
+  };
+
+  return { appendContent, appendTextEvent, appendEvent, flush };
 }

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -118,8 +118,8 @@ export function ProjectView({
   const [openRequest, setOpenRequest] = useState<{ name: string; nonce: number } | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const cancelRef = useRef<AbortController | null>(null);
-  const sendTextBufferCancelRef = useRef<(() => void) | null>(null);
-  const reattachTextBufferCancelsRef = useRef<Set<() => void>>(new Set());
+  const sendTextBufferRef = useRef<BufferedTextUpdates | null>(null);
+  const reattachTextBuffersRef = useRef<Set<BufferedTextUpdates>>(new Set());
   const reattachControllersRef = useRef<Map<string, AbortController>>(new Map());
   const reattachCancelControllersRef = useRef<Map<string, AbortController>>(new Map());
   const completedReattachRunsRef = useRef<Set<string>>(new Set());
@@ -188,10 +188,10 @@ export function ProjectView({
 
   useEffect(() => {
     return () => {
-      sendTextBufferCancelRef.current?.();
-      sendTextBufferCancelRef.current = null;
-      for (const cancel of reattachTextBufferCancelsRef.current) cancel();
-      reattachTextBufferCancelsRef.current.clear();
+      sendTextBufferRef.current?.cancel();
+      sendTextBufferRef.current = null;
+      for (const textBuffer of reattachTextBuffersRef.current) textBuffer.cancel();
+      reattachTextBuffersRef.current.clear();
       for (const controller of reattachControllersRef.current.values()) {
         controller.abort();
       }
@@ -203,14 +203,18 @@ export function ProjectView({
     };
   }, [project.id, activeConversationId]);
 
-  const cancelSendTextBuffer = useCallback(() => {
-    sendTextBufferCancelRef.current?.();
-    sendTextBufferCancelRef.current = null;
+  const cancelSendTextBuffer = useCallback((flushPending = false) => {
+    if (flushPending) sendTextBufferRef.current?.flush();
+    sendTextBufferRef.current?.cancel();
+    sendTextBufferRef.current = null;
   }, []);
 
-  const cancelReattachTextBuffers = useCallback(() => {
-    for (const cancel of reattachTextBufferCancelsRef.current) cancel();
-    reattachTextBufferCancelsRef.current.clear();
+  const cancelReattachTextBuffers = useCallback((flushPending = false) => {
+    for (const textBuffer of reattachTextBuffersRef.current) {
+      if (flushPending) textBuffer.flush();
+      textBuffer.cancel();
+    }
+    reattachTextBuffersRef.current.clear();
   }, []);
 
   // Hydrate the open-tabs state once per project. After this initial
@@ -488,9 +492,9 @@ export function ProjectView({
           updateMessage: (updater) => updateMessageById(message.id, updater),
           persistSoon,
         });
-        reattachTextBufferCancelsRef.current.add(textBuffer.cancel);
+        reattachTextBuffersRef.current.add(textBuffer);
         const unregisterTextBuffer = () => {
-          reattachTextBufferCancelsRef.current.delete(textBuffer.cancel);
+          reattachTextBuffersRef.current.delete(textBuffer);
         };
 
         void reattachDaemonRun({
@@ -593,7 +597,6 @@ export function ProjectView({
     void attachRecoverableRuns();
     return () => {
       cancelled = true;
-      cancelReattachTextBuffers();
     };
   }, [
     daemonLive,
@@ -605,7 +608,6 @@ export function ProjectView({
     persistMessageById,
     refreshProjectFiles,
     onProjectsRefresh,
-    cancelReattachTextBuffers,
   ]);
 
   const handleSend = useCallback(
@@ -737,7 +739,7 @@ export function ProjectView({
         persistSoon: persistAssistantSoon,
         onContentDelta: applyContentDelta,
       });
-      sendTextBufferCancelRef.current = textBuffer.cancel;
+      sendTextBufferRef.current = textBuffer;
 
       const controller = new AbortController();
       const cancelController = new AbortController();
@@ -973,8 +975,8 @@ export function ProjectView({
 
   const handleStop = useCallback(() => {
     const stoppedAt = Date.now();
-    cancelSendTextBuffer();
-    cancelReattachTextBuffers();
+    cancelSendTextBuffer(true);
+    cancelReattachTextBuffers(true);
     cancelRef.current?.abort();
     cancelRef.current = null;
     for (const controller of reattachCancelControllersRef.current.values()) {
@@ -1198,6 +1200,8 @@ function isTerminalRunStatus(status: ChatMessage['runStatus']): boolean {
 function isActiveRunStatus(status: ChatMessage['runStatus']): boolean {
   return status === 'queued' || status === 'running';
 }
+
+type BufferedTextUpdates = ReturnType<typeof createBufferedTextUpdates>;
 
 function createBufferedTextUpdates({
   updateMessage,

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -427,6 +427,7 @@ export const de: Dict = {
   'designFiles.sectionImages': 'Bilder',
   'designFiles.sectionSketches': 'Sketches',
   'designFiles.sectionOther': 'Andere',
+  'designFiles.showMore': '+{n} weitere anzeigen',
   'designFiles.kindHtml': 'HTML-Seite',
   'designFiles.kindImage': 'Bild',
   'designFiles.kindSketch': 'Sketch',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -427,6 +427,7 @@ export const en: Dict = {
   'designFiles.sectionImages': 'Images',
   'designFiles.sectionSketches': 'Sketches',
   'designFiles.sectionOther': 'Other',
+  'designFiles.showMore': 'Show +{n} more',
   'designFiles.kindHtml': 'HTML page',
   'designFiles.kindImage': 'Image',
   'designFiles.kindSketch': 'Sketch',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -428,6 +428,7 @@ export const esES: Dict = {
   'designFiles.sectionImages': 'Imágenes',
   'designFiles.sectionSketches': 'Bocetos',
   'designFiles.sectionOther': 'Otros',
+  'designFiles.showMore': 'Mostrar +{n} más',
   'designFiles.kindHtml': 'Página HTML',
   'designFiles.kindImage': 'Imagen',
   'designFiles.kindSketch': 'Boceto',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -427,6 +427,7 @@ export const fa: Dict = {
   'designFiles.sectionImages': 'تصاویر',
   'designFiles.sectionSketches': 'طرح‌ها',
   'designFiles.sectionOther': 'سایر',
+  'designFiles.showMore': '+{n} بیشتر',
   'designFiles.kindHtml': 'صفحه HTML',
   'designFiles.kindImage': 'تصویر',
   'designFiles.kindSketch': 'طرح',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -426,6 +426,7 @@ export const ja: Dict = {
   'designFiles.sectionImages': '画像',
   'designFiles.sectionSketches': 'スケッチ',
   'designFiles.sectionOther': 'その他',
+  'designFiles.showMore': 'さらに {n} 件表示',
   'designFiles.kindHtml': 'HTML ページ',
   'designFiles.kindImage': '画像',
   'designFiles.kindSketch': 'スケッチ',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -426,6 +426,7 @@ export const ptBR: Dict = {
   'designFiles.sectionImages': 'Imagens',
   'designFiles.sectionSketches': 'Esboços',
   'designFiles.sectionOther': 'Outros',
+  'designFiles.showMore': 'Mostrar +{n} mais',
   'designFiles.kindHtml': 'Página HTML',
   'designFiles.kindImage': 'Imagem',
   'designFiles.kindSketch': 'Esboço',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -426,6 +426,7 @@ export const ru: Dict = {
   'designFiles.sectionImages': 'Изображения',
   'designFiles.sectionSketches': 'Эскизы',
   'designFiles.sectionOther': 'Другое',
+  'designFiles.showMore': 'Показать ещё +{n}',
   'designFiles.kindHtml': 'HTML страница',
   'designFiles.kindImage': 'Изображение',
   'designFiles.kindSketch': 'Эскиз',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -417,6 +417,7 @@ export const zhCN: Dict = {
   'designFiles.sectionImages': '图片',
   'designFiles.sectionSketches': '草图',
   'designFiles.sectionOther': '其它',
+  'designFiles.showMore': '再显示 {n} 个',
   'designFiles.kindHtml': 'HTML 页面',
   'designFiles.kindImage': '图片',
   'designFiles.kindSketch': '草图',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -417,6 +417,7 @@ export const zhTW: Dict = {
   'designFiles.sectionImages': '圖片',
   'designFiles.sectionSketches': '草圖',
   'designFiles.sectionOther': '其它',
+  'designFiles.showMore': '再顯示 {n} 個',
   'designFiles.kindHtml': 'HTML 頁面',
   'designFiles.kindImage': '圖片',
   'designFiles.kindSketch': '草圖',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -440,6 +440,7 @@ export interface Dict {
   'designFiles.sectionImages': string;
   'designFiles.sectionSketches': string;
   'designFiles.sectionOther': string;
+  'designFiles.showMore': string;
   'designFiles.kindHtml': string;
   'designFiles.kindImage': string;
   'designFiles.kindSketch': string;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -3236,11 +3236,15 @@ code {
 .df-section-more {
   margin: 6px 20px 10px;
   width: auto;
+  display: inline-flex;
+  align-items: center;
   justify-content: center;
+  gap: 6px;
   background: var(--bg-subtle);
   border: 1px solid var(--border);
   color: var(--text-muted);
   font-size: 12px;
+  line-height: 1;
 }
 .df-section-more:hover:not(:disabled) {
   background: var(--bg-muted);

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -3157,6 +3157,12 @@ code {
   font-weight: 600;
   padding: 12px 20px 6px;
 }
+.df-section-count {
+  margin-left: 8px;
+  color: var(--text-faint);
+  font-weight: 500;
+  letter-spacing: 0;
+}
 .df-row {
   display: grid;
   grid-template-columns: 36px 1fr auto auto;
@@ -3227,6 +3233,19 @@ code {
 }
 .df-row:hover .df-row-menu { opacity: 1; }
 .df-row-menu:hover { background: var(--border); color: var(--text); }
+.df-section-more {
+  margin: 6px 20px 10px;
+  width: auto;
+  justify-content: center;
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.df-section-more:hover:not(:disabled) {
+  background: var(--bg-muted);
+  color: var(--text);
+}
 .df-row-collapse {
   background: transparent;
   border: none;


### PR DESCRIPTION
## Summary

- batch streaming text updates so chat output does not trigger a React render for every delta
- limit the initial Design Files rows rendered per section and add a load-more control
- add small styles for Design Files section counts and load-more buttons

## Root Cause

Large projects could render every file row in Design Files at once. On the tested project this produced over 113k DOM nodes and more than 16k buttons, which made the whole page sluggish while typing in the chat composer. Streaming chat responses also updated message state for every text delta, adding more render pressure.

## Validation

- `pnpm.cmd --filter @open-design/web typecheck`
- local tools-dev profiling on a large project:
  - DOM nodes dropped from about 113k to about 3.1k
  - input p95 latency improved from about 20ms to about 7ms
