### PR TITLE
fix: daemon OD_DAEMON_URL uses port 0 instead of actual allocated port

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -465,6 +465,7 @@ export function createSseResponse(res, { keepAliveIntervalMs = SSE_KEEPALIVE_INT
 }
 
 export async function startServer({ port = 7456, returnServer = false } = {}) {
+  let resolvedPort = port;
   const app = express();
   app.use(express.json({ limit: '4mb' }));
   const db = openDatabase(PROJECT_ROOT, { dataDir: RUNTIME_DATA_DIR });
@@ -1359,7 +1360,7 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
   });
 
   app.post('/api/projects/:id/media/generate', async (req, res) => {
-    if (!isLocalSameOrigin(req, port)) {
+    if (!isLocalSameOrigin(req, resolvedPort)) {
       return res.status(403).json({
         error: 'cross-origin request rejected: media generation is restricted to the local UI / CLI',
       });
@@ -1441,7 +1442,7 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
   });
 
   app.post('/api/media/tasks/:id/wait', async (req, res) => {
-    if (!isLocalSameOrigin(req, port)) {
+    if (!isLocalSameOrigin(req, resolvedPort)) {
       return res.status(403).json({ error: 'cross-origin request rejected' });
     }
     const taskId = req.params.id;
@@ -1491,7 +1492,7 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
   });
 
   app.get('/api/projects/:id/media/tasks', (req, res) => {
-    if (!isLocalSameOrigin(req, port)) {
+    if (!isLocalSameOrigin(req, resolvedPort)) {
       return res.status(403).json({ error: 'cross-origin request rejected' });
     }
     const projectId = req.params.id;
@@ -1831,7 +1832,7 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
       process.platform === 'win32' && CMD_BAT_RE.test(resolvedBin);
     const odMediaEnv = {
       OD_BIN,
-      OD_DAEMON_URL: `http://127.0.0.1:${port}`,
+      OD_DAEMON_URL: `http://127.0.0.1:${resolvedPort}`,
       ...(typeof projectId === 'string' && projectId && cwd
         ? {
             OD_PROJECT_ID: projectId,
@@ -2268,6 +2269,7 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
     const server = app.listen(port, '127.0.0.1', () => {
       const address = server.address();
       const actualPort = typeof address === 'object' && address ? address.port : port;
+      resolvedPort = actualPort;
       const url = `http://127.0.0.1:${actualPort}`;
       resolve(returnServer ? { url, server } : url);
     });


### PR DESCRIPTION
## Summary

When `tools-dev` launches the daemon with `OD_PORT=0` (letting the OS assign a free port), `app.listen` correctly resolves the actual port in its callback. However, the enclosing closure still references the original `port` parameter (value `0`), which causes:

- `OD_DAEMON_URL` to be set to `http://127.0.0.1:0` in the environment passed to agent subprocesses, breaking media generation (image generation fails with "daemon port is 0")
- `isLocalSameOrigin` checks in media-related routes (`/api/media/generate`, `/api/media/tasks/wait`, `/api/media/tasks`) to compare against port `0` instead of the real port

## Root cause

`startServer()` in `apps/daemon/src/server.ts` accepts `port` as a parameter. When `port=0`, Express asks the OS for a random free port and the listen callback computes `actualPort` correctly. But `OD_DAEMON_URL` (line 1834) and `isLocalSameOrigin` calls (lines 1362, 1444, 1494) still read the original `port` variable (still `0`) from the closure.

## Fix

Introduce a mutable `resolvedPort` variable at the top of `startServer`, assigned from `actualPort` inside the `app.listen` callback. All downstream consumers now read the resolved value.

**Files changed:** `apps/daemon/src/server.ts` (6 insertions, 4 deletions)

## Test plan

- [x] `pnpm --filter @open-design/daemon typecheck` passes
- [ ] Start with `pnpm tools-dev run web` (no fixed ports), verify daemon logs show the actual port (not 0)
- [ ] Trigger media generation from the web UI, confirm `OD_DAEMON_URL` in agent subprocess env is correct
- [ ] Verify `isLocalSameOrigin` allows legitimate same-origin requests on the resolved port