### PR TITLE
fix(web): suppress hydration warning on <body>

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -21,7 +21,7 @@ export const viewport: Viewport = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang='en' suppressHydrationWarning>
-      <body>
+      <body suppressHydrationWarning>
         <I18nProvider>{children}</I18nProvider>
       </body>
     </html>


### PR DESCRIPTION
## Summary

Browser extensions like YouMind, Grammarly, and ColorZilla inject attributes onto `<body>` before React hydrates, producing a "server rendered HTML didn't match client" console error in development.

`<html>` already had `suppressHydrationWarning`; mirror it on `<body>` so any extension that mutates the body element no longer surfaces a false-positive hydration mismatch to end users.

## Repro (from #243)

User had the YouMind extension installed, which injects `youmind-sidebar-open` and `youmind-extension-version` onto `<body>`. Next.js dev mode then logged:

> A tree hydrated but some attributes of the server rendered HTML didn't match the client properties.
> `app/layout.tsx (24:7) @ RootLayout`

Adding `suppressHydrationWarning` on `<body>` is the official Next.js-recommended fix for extension-induced mismatches ([docs](https://nextjs.org/docs/messages/react-hydration-error#solution-3-using-suppresshydrationwarning)).

## Test plan

- [ ] `pnpm -C apps/web dev` with YouMind (or any extension that mutates body) installed — verify no hydration error in console
- [ ] Verify SSR'd HTML and client render still match for our own attributes (we don't set any on body, so this is a no-op for us)

Closes #243