### PR TITLE
Optimize Electron release artifact size

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
   },
   "files": [
     ".next",
+    "!.next/cache",
     "app",
     "dist",
     "next.config.ts",

--- a/tools/pack/src/mac.ts
+++ b/tools/pack/src/mac.ts
@@ -390,7 +390,7 @@ async function runElectronBuilder(
     afterSign: config.signed ? macResources.notarizeHook : undefined,
     asar: false,
     buildDependenciesFromSource: false,
-    compression: "store",
+    compression: "maximum",
     directories: {
       output: paths.appBuilderOutputRoot,
     },

--- a/tools/pack/src/win.ts
+++ b/tools/pack/src/win.ts
@@ -722,7 +722,7 @@ async function runElectronBuilder(config: ToolPackConfig, paths: WinPaths): Prom
     appId: "io.open-design.desktop",
     asar: false,
     buildDependenciesFromSource: false,
-    compression: "store",
+    compression: "maximum",
     directories: { output: paths.appBuilderOutputRoot },
     electronDist: config.electronDistPath,
     electronVersion: config.electronVersion,


### PR DESCRIPTION
## Summary
- Enable maximum Electron builder compression for macOS and Windows release artifacts.
- Exclude Next.js build cache from the packaged web tarball.
- Reduces the local macOS ZIP from the v0.1.0 release size (~749 MB) to ~449 MB in validation.

## Validation
- pnpm install
- pnpm --filter @open-design/tools-pack typecheck
- pnpm --filter @open-design/web typecheck
- pnpm check:residual-js
- pnpm --filter @open-design/tools-pack build
- pnpm tools-pack mac build --to zip --namespace sizecheck --portable
- pnpm tools-pack mac start/logs/stop --namespace sizecheck

## Notes
- `pnpm test` was run; existing unrelated German i18n metadata coverage failures remain in `apps/web/src/i18n/content.test.ts`.