### PR TITLE
feat(settings): split API provider protocols

### DIFF
--- a/apps/web/src/components/SettingsDialog.test.ts
+++ b/apps/web/src/components/SettingsDialog.test.ts
@@ -3,13 +3,18 @@ import { KNOWN_PROVIDERS } from '../state/config';
 import type { ApiProtocol, AppConfig } from '../types';
 
 function switchApiProtocol(config: AppConfig, protocol: ApiProtocol): AppConfig {
-  const currentIsKnown = KNOWN_PROVIDERS.some((p) => p.baseUrl === config.baseUrl);
+  const currentProvider = config.apiProviderBaseUrl
+    ? KNOWN_PROVIDERS.find((p) => p.baseUrl === config.apiProviderBaseUrl)
+    : undefined;
+  const stillOnSelectedProvider = Boolean(currentProvider && config.baseUrl === currentProvider.baseUrl);
   const provider = KNOWN_PROVIDERS.find((p) => p.protocol === protocol);
   return {
     ...config,
     mode: 'api',
     apiProtocol: protocol,
-    ...(currentIsKnown && provider ? { baseUrl: provider.baseUrl, model: provider.model } : {}),
+    ...(stillOnSelectedProvider && provider
+      ? { baseUrl: provider.baseUrl, model: provider.model, apiProviderBaseUrl: provider.baseUrl }
+      : { apiProviderBaseUrl: null }),
   };
 }
 
@@ -19,6 +24,7 @@ const baseConfig: AppConfig = {
   apiProtocol: 'anthropic',
   baseUrl: 'https://api.anthropic.com',
   model: 'claude-sonnet-4-5',
+  apiProviderBaseUrl: 'https://api.anthropic.com',
   agentId: null,
   skillId: null,
   designSystemId: null,
@@ -40,12 +46,30 @@ describe('SettingsDialog API protocol switching', () => {
     });
   });
 
-  it('auto-fills the new protocol default when switching from a known provider', () => {
+  it('auto-fills the new protocol default when switching from a selected known provider', () => {
     expect(switchApiProtocol(baseConfig, 'openai')).toMatchObject({
       mode: 'api',
       apiProtocol: 'openai',
       baseUrl: 'https://api.openai.com/v1',
       model: 'gpt-4o',
+      apiProviderBaseUrl: 'https://api.openai.com/v1',
+    });
+  });
+
+  it('preserves user-customized known-looking baseUrl when provider tracking was cleared', () => {
+    const config: AppConfig = {
+      ...baseConfig,
+      apiProviderBaseUrl: null,
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'custom-openai-model',
+    };
+
+    expect(switchApiProtocol(config, 'anthropic')).toMatchObject({
+      mode: 'api',
+      apiProtocol: 'anthropic',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'custom-openai-model',
+      apiProviderBaseUrl: null,
     });
   });
 });

--- a/apps/web/src/components/SettingsDialog.test.ts
+++ b/apps/web/src/components/SettingsDialog.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { KNOWN_PROVIDERS } from '../state/config';
+import type { ApiProtocol, AppConfig } from '../types';
+
+function switchApiProtocol(config: AppConfig, protocol: ApiProtocol): AppConfig {
+  const currentIsKnown = KNOWN_PROVIDERS.some((p) => p.baseUrl === config.baseUrl);
+  const provider = KNOWN_PROVIDERS.find((p) => p.protocol === protocol);
+  return {
+    ...config,
+    mode: 'api',
+    apiProtocol: protocol,
+    ...(currentIsKnown && provider ? { baseUrl: provider.baseUrl, model: provider.model } : {}),
+  };
+}
+
+const baseConfig: AppConfig = {
+  mode: 'api',
+  apiKey: 'sk-test',
+  apiProtocol: 'anthropic',
+  baseUrl: 'https://api.anthropic.com',
+  model: 'claude-sonnet-4-5',
+  agentId: null,
+  skillId: null,
+  designSystemId: null,
+};
+
+describe('SettingsDialog API protocol switching', () => {
+  it('preserves custom baseUrl and model when switching protocol tabs', () => {
+    const config: AppConfig = {
+      ...baseConfig,
+      baseUrl: 'https://my-proxy.example.com',
+      model: 'my-model',
+    };
+
+    expect(switchApiProtocol(config, 'openai')).toMatchObject({
+      mode: 'api',
+      apiProtocol: 'openai',
+      baseUrl: 'https://my-proxy.example.com',
+      model: 'my-model',
+    });
+  });
+
+  it('auto-fills the new protocol default when switching from a known provider', () => {
+    expect(switchApiProtocol(baseConfig, 'openai')).toMatchObject({
+      mode: 'api',
+      apiProtocol: 'openai',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-4o',
+    });
+  });
+});

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -166,13 +166,18 @@ export function SettingsDialog({
   const setMode = (mode: ExecMode) => setCfg((c) => ({ ...c, mode }));
   const setApiProtocol = (protocol: 'anthropic' | 'openai') => {
     setCfg((c) => {
-      const currentIsKnown = KNOWN_PROVIDERS.some((p) => p.baseUrl === c.baseUrl);
+      const currentProvider = c.apiProviderBaseUrl
+        ? KNOWN_PROVIDERS.find((p) => p.baseUrl === c.apiProviderBaseUrl)
+        : undefined;
+      const stillOnSelectedProvider = Boolean(currentProvider && c.baseUrl === currentProvider.baseUrl);
       const provider = KNOWN_PROVIDERS.find((p) => p.protocol === protocol);
       return {
         ...c,
         mode: 'api',
         apiProtocol: protocol,
-        ...(currentIsKnown && provider ? { baseUrl: provider.baseUrl, model: provider.model } : {}),
+        ...(stillOnSelectedProvider && provider
+          ? { baseUrl: provider.baseUrl, model: provider.model, apiProviderBaseUrl: provider.baseUrl }
+          : { apiProviderBaseUrl: null }),
       };
     });
   };
@@ -546,7 +551,7 @@ export function SettingsDialog({
                   value={selectedProviderIndex >= 0 ? String(selectedProviderIndex) : ''}
                   onChange={(e) => {
                     if (e.target.value === '') {
-                      setCfg((c) => ({ ...c, baseUrl: '', model: '' }));
+                      setCfg((c) => ({ ...c, baseUrl: '', model: '', apiProviderBaseUrl: null }));
                       return;
                     }
                     const idx = Number(e.target.value);
@@ -557,6 +562,7 @@ export function SettingsDialog({
                         apiProtocol: p.protocol,
                         baseUrl: p.baseUrl,
                         model: p.model,
+                        apiProviderBaseUrl: p.baseUrl,
                       }));
                     }
                   }}
@@ -607,6 +613,9 @@ export function SettingsDialog({
                   <option value={CUSTOM_MODEL_SENTINEL}>{t('settings.modelCustom')}</option>
                 </select>
               </label>
+              {!selectedProvider ? (
+                <p className="hint">These are suggested models for this protocol. Your provider may support different models.</p>
+              ) : null}
               {apiModelCustom || apiModelSelectValue === CUSTOM_MODEL_SENTINEL ? (
                 <label className="field">
                   <span className="field-label">{t('settings.modelCustomLabel')}</span>
@@ -623,7 +632,7 @@ export function SettingsDialog({
                 <input
                   type="text"
                   value={cfg.baseUrl}
-                  onChange={(e) => setCfg({ ...cfg, baseUrl: e.target.value })}
+                  onChange={(e) => setCfg({ ...cfg, baseUrl: e.target.value, apiProviderBaseUrl: null })}
                 />
               </label>
               <p className="hint">{t('settings.apiHint')}</p>

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -42,23 +42,43 @@ interface Props {
   onRefreshAgents: () => void;
 }
 
-const SUGGESTED_MODELS = [
-  'claude-opus-4-5',
-  'claude-sonnet-4-5',
-  'claude-haiku-4-5',
-  'deepseek-chat',
-  'deepseek-reasoner',
-  'deepseek-v4-flash',
-  'deepseek-v4-pro',
-  'MiniMax-M2.7-highspeed',
-  'MiniMax-M2.7',
-  'MiniMax-M2.5-highspeed',
-  'MiniMax-M2.5',
-  'MiniMax-M2.1-highspeed',
-  'MiniMax-M2.1',
-  'MiniMax-M2',
-  'mimo-v2.5-pro',
-];
+const SUGGESTED_MODELS_BY_PROTOCOL = {
+  anthropic: [
+    'claude-opus-4-5',
+    'claude-sonnet-4-5',
+    'claude-haiku-4-5',
+    'deepseek-chat',
+    'deepseek-reasoner',
+    'deepseek-v4-flash',
+    'deepseek-v4-pro',
+    'MiniMax-M2.7-highspeed',
+    'MiniMax-M2.7',
+    'MiniMax-M2.5-highspeed',
+    'MiniMax-M2.5',
+    'MiniMax-M2.1-highspeed',
+    'MiniMax-M2.1',
+    'MiniMax-M2',
+    'mimo-v2.5-pro',
+  ],
+  openai: [
+    'gpt-4o',
+    'gpt-4o-mini',
+    'o3',
+    'o4-mini',
+    'deepseek-chat',
+    'deepseek-reasoner',
+    'deepseek-v4-flash',
+    'deepseek-v4-pro',
+    'MiniMax-M2.7-highspeed',
+    'MiniMax-M2.7',
+    'MiniMax-M2.5-highspeed',
+    'MiniMax-M2.5',
+    'MiniMax-M2.1-highspeed',
+    'MiniMax-M2.1',
+    'MiniMax-M2',
+    'mimo-v2.5-pro',
+  ],
+} as const;
 
 export function SettingsDialog({
   initial,
@@ -145,13 +165,16 @@ export function SettingsDialog({
 
   const setMode = (mode: ExecMode) => setCfg((c) => ({ ...c, mode }));
   const setApiProtocol = (protocol: 'anthropic' | 'openai') => {
-    const provider = KNOWN_PROVIDERS.find((p) => p.protocol === protocol);
-    setCfg((c) => ({
-      ...c,
-      mode: 'api',
-      apiProtocol: protocol,
-      ...(provider ? { baseUrl: provider.baseUrl, model: provider.model } : {}),
-    }));
+    setCfg((c) => {
+      const currentIsKnown = KNOWN_PROVIDERS.some((p) => p.baseUrl === c.baseUrl);
+      const provider = KNOWN_PROVIDERS.find((p) => p.protocol === protocol);
+      return {
+        ...c,
+        mode: 'api',
+        apiProtocol: protocol,
+        ...(currentIsKnown && provider ? { baseUrl: provider.baseUrl, model: provider.model } : {}),
+      };
+    });
   };
 
   const canSave =
@@ -167,11 +190,15 @@ export function SettingsDialog({
   const selectedProviderIndex = protocolProviders.findIndex((p) => p.baseUrl === cfg.baseUrl);
   const selectedProvider = selectedProviderIndex >= 0 ? protocolProviders[selectedProviderIndex] : undefined;
   const apiModelOptions = useMemo(
-    () => Array.from(new Set(selectedProvider?.models?.length ? selectedProvider.models : SUGGESTED_MODELS)),
-    [selectedProvider],
+    () => Array.from(new Set(
+      selectedProvider?.models?.length
+        ? selectedProvider.models
+        : SUGGESTED_MODELS_BY_PROTOCOL[apiProtocol],
+    )),
+    [apiProtocol, cfg.baseUrl, selectedProvider],
   );
-  const apiModelCustom = !cfg.model || !apiModelOptions.includes(cfg.model);
-  const apiModelSelectValue = apiModelCustom ? CUSTOM_MODEL_SENTINEL : cfg.model;
+  const apiModelCustom = Boolean(cfg.model) && !apiModelOptions.includes(cfg.model);
+  const apiModelSelectValue = apiModelCustom || !cfg.model ? CUSTOM_MODEL_SENTINEL : cfg.model;
 
   return (
     <div className="modal-backdrop" onClick={onClose}>

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -46,6 +46,17 @@ const SUGGESTED_MODELS = [
   'claude-opus-4-5',
   'claude-sonnet-4-5',
   'claude-haiku-4-5',
+  'deepseek-chat',
+  'deepseek-reasoner',
+  'deepseek-v4-flash',
+  'deepseek-v4-pro',
+  'MiniMax-M2.7-highspeed',
+  'MiniMax-M2.7',
+  'MiniMax-M2.5-highspeed',
+  'MiniMax-M2.5',
+  'MiniMax-M2.1-highspeed',
+  'MiniMax-M2.1',
+  'MiniMax-M2',
   'mimo-v2.5-pro',
 ];
 
@@ -133,11 +144,34 @@ export function SettingsDialog({
   );
 
   const setMode = (mode: ExecMode) => setCfg((c) => ({ ...c, mode }));
+  const setApiProtocol = (protocol: 'anthropic' | 'openai') => {
+    const provider = KNOWN_PROVIDERS.find((p) => p.protocol === protocol);
+    setCfg((c) => ({
+      ...c,
+      mode: 'api',
+      apiProtocol: protocol,
+      ...(provider ? { baseUrl: provider.baseUrl, model: provider.model } : {}),
+    }));
+  };
 
   const canSave =
     cfg.mode === 'daemon'
       ? Boolean(cfg.agentId && agents.find((a) => a.id === cfg.agentId)?.available)
       : Boolean(cfg.apiKey.trim() && cfg.model.trim() && cfg.baseUrl.trim());
+
+  const apiProtocol = cfg.apiProtocol ?? 'anthropic';
+  const protocolProviders = useMemo(
+    () => KNOWN_PROVIDERS.filter((p) => p.protocol === apiProtocol),
+    [apiProtocol],
+  );
+  const selectedProviderIndex = protocolProviders.findIndex((p) => p.baseUrl === cfg.baseUrl);
+  const selectedProvider = selectedProviderIndex >= 0 ? protocolProviders[selectedProviderIndex] : undefined;
+  const apiModelOptions = useMemo(
+    () => Array.from(new Set(selectedProvider?.models?.length ? selectedProvider.models : SUGGESTED_MODELS)),
+    [selectedProvider],
+  );
+  const apiModelCustom = !cfg.model || !apiModelOptions.includes(cfg.model);
+  const apiModelSelectValue = apiModelCustom ? CUSTOM_MODEL_SENTINEL : cfg.model;
 
   return (
     <div className="modal-backdrop" onClick={onClose}>
@@ -259,6 +293,7 @@ export function SettingsDialog({
                 className="seg-control"
                 role="tablist"
                 aria-label={t('settings.modeAria')}
+                style={{ gridTemplateColumns: 'repeat(3, 1fr)' }}
               >
                 <button
                   type="button"
@@ -283,12 +318,22 @@ export function SettingsDialog({
                 <button
                   type="button"
                   role="tab"
-                  aria-selected={cfg.mode === 'api'}
-                  className={'seg-btn' + (cfg.mode === 'api' ? ' active' : '')}
-                  onClick={() => setMode('api')}
+                  aria-selected={cfg.mode === 'api' && apiProtocol === 'anthropic'}
+                  className={'seg-btn' + (cfg.mode === 'api' && apiProtocol === 'anthropic' ? ' active' : '')}
+                  onClick={() => setApiProtocol('anthropic')}
                 >
-                  <span className="seg-title">{t('settings.modeApi')}</span>
-                  <span className="seg-meta">{t('settings.modeApiMeta')}</span>
+                  <span className="seg-title">Anthropic API</span>
+                  <span className="seg-meta">/v1/messages</span>
+                </button>
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={cfg.mode === 'api' && apiProtocol === 'openai'}
+                  className={'seg-btn' + (cfg.mode === 'api' && apiProtocol === 'openai' ? ' active' : '')}
+                  onClick={() => setApiProtocol('openai')}
+                >
+                  <span className="seg-title">OpenAI API</span>
+                  <span className="seg-meta">/v1/chat/completions</span>
                 </button>
               </div>
           {cfg.mode === 'daemon' ? (
@@ -466,8 +511,35 @@ export function SettingsDialog({
           ) : (
             <section className="settings-section">
               <div className="section-head">
-                <h3>{t('settings.apiSection')}</h3>
+                <h3>{apiProtocol === 'anthropic' ? 'Anthropic API' : 'OpenAI API'}</h3>
               </div>
+              <label className="field">
+                <span className="field-label">Quick fill provider</span>
+                <select
+                  value={selectedProviderIndex >= 0 ? String(selectedProviderIndex) : ''}
+                  onChange={(e) => {
+                    if (e.target.value === '') {
+                      setCfg((c) => ({ ...c, baseUrl: '', model: '' }));
+                      return;
+                    }
+                    const idx = Number(e.target.value);
+                    if (!isNaN(idx) && protocolProviders[idx]) {
+                      const p = protocolProviders[idx]!;
+                      setCfg((c) => ({
+                        ...c,
+                        apiProtocol: p.protocol,
+                        baseUrl: p.baseUrl,
+                        model: p.model,
+                      }));
+                    }
+                  }}
+                >
+                  <option value="">Custom provider</option>
+                  {protocolProviders.map((p, i) => (
+                    <option key={p.label} value={i}>{p.label}</option>
+                  ))}
+                </select>
+              </label>
               <label className="field">
                 <span className="field-label">{t('settings.apiKey')}</span>
                 <div className="field-row">
@@ -492,18 +564,33 @@ export function SettingsDialog({
               </label>
               <label className="field">
                 <span className="field-label">{t('settings.model')}</span>
-                <input
-                  type="text"
-                  value={cfg.model}
-                  list="suggested-models"
-                  onChange={(e) => setCfg({ ...cfg, model: e.target.value })}
-                />
-                <datalist id="suggested-models">
-                  {SUGGESTED_MODELS.map((m) => (
-                    <option value={m} key={m} />
+                <select
+                  value={apiModelSelectValue}
+                  onChange={(e) => {
+                    if (e.target.value === CUSTOM_MODEL_SENTINEL) {
+                      setCfg((c) => ({ ...c, model: '' }));
+                    } else {
+                      setCfg((c) => ({ ...c, model: e.target.value }));
+                    }
+                  }}
+                >
+                  {apiModelOptions.map((m) => (
+                    <option value={m} key={m}>{m}</option>
                   ))}
-                </datalist>
+                  <option value={CUSTOM_MODEL_SENTINEL}>{t('settings.modelCustom')}</option>
+                </select>
               </label>
+              {apiModelCustom || apiModelSelectValue === CUSTOM_MODEL_SENTINEL ? (
+                <label className="field">
+                  <span className="field-label">{t('settings.modelCustomLabel')}</span>
+                  <input
+                    type="text"
+                    value={cfg.model}
+                    placeholder={t('settings.modelCustomPlaceholder')}
+                    onChange={(e) => setCfg({ ...cfg, model: e.target.value.trim() })}
+                  />
+                </label>
+              ) : null}
               <label className="field">
                 <span className="field-label">{t('settings.baseUrl')}</span>
                 <input
@@ -511,45 +598,6 @@ export function SettingsDialog({
                   value={cfg.baseUrl}
                   onChange={(e) => setCfg({ ...cfg, baseUrl: e.target.value })}
                 />
-              </label>
-              <label className="field">
-                <span className="field-label">Quick fill provider</span>
-                <select
-                  value=""
-                  onChange={(e) => {
-                    const idx = Number(e.target.value);
-                    if (!isNaN(idx) && KNOWN_PROVIDERS[idx]) {
-                      const p = KNOWN_PROVIDERS[idx]!;
-                      setCfg((c) => ({ ...c, baseUrl: p.baseUrl, model: p.model }));
-                    }
-                  }}
-                >
-                  <option value="">— choose a provider —</option>
-                  {KNOWN_PROVIDERS.map((p, i) => (
-                    <option key={i} value={i}>{p.label}</option>
-                  ))}
-                </select>
-              </label>
-              <label className="field">
-                <span className="field-label">{t('settings.maxTokens')}</span>
-                <input
-                  type="number"
-                  min={MIN_MAX_TOKENS}
-                  max={MAX_MAX_TOKENS}
-                  step={MIN_MAX_TOKENS}
-                  placeholder={String(modelMaxTokensDefault(cfg.model))}
-                  value={cfg.maxTokens ?? ''}
-                  onChange={(e) => {
-                    const raw = e.target.value.trim();
-                    if (raw === '') {
-                      setCfg({ ...cfg, maxTokens: undefined });
-                      return;
-                    }
-                    const val = parseInt(raw, 10);
-                    setCfg({ ...cfg, maxTokens: Number.isFinite(val) ? val : undefined });
-                  }}
-                />
-                <p className="hint">{t('settings.maxTokensHint')}</p>
               </label>
               <p className="hint">{t('settings.apiHint')}</p>
             </section>

--- a/apps/web/src/providers/anthropic.ts
+++ b/apps/web/src/providers/anthropic.ts
@@ -37,8 +37,9 @@ export async function streamMessage(
   signal: AbortSignal,
   handlers: StreamHandlers,
 ): Promise<void> {
-  // Route to OpenAI-compatible provider for non-Anthropic models.
-  if (isOpenAICompatible(cfg.model, cfg.baseUrl)) {
+  // Prefer the explicit Settings protocol; keep the legacy heuristic as a
+  // fallback for configs saved before apiProtocol existed.
+  if (cfg.apiProtocol === 'openai' || (!cfg.apiProtocol && isOpenAICompatible(cfg.model, cfg.baseUrl))) {
     return streamMessageOpenAI(cfg, system, history, signal, handlers);
   }
 

--- a/apps/web/src/providers/openai-compatible.test.ts
+++ b/apps/web/src/providers/openai-compatible.test.ts
@@ -15,4 +15,13 @@ describe('isOpenAICompatible', () => {
   it('preserves MiMo OpenAI-compatible endpoint routing', () => {
     expect(isOpenAICompatible('mimo-v2.5-pro', 'https://token-plan-cn.xiaomimimo.com/v1')).toBe(true);
   });
+
+  it('routes MiniMax Anthropic endpoint paths away from OpenAI-compatible chat completions', () => {
+    expect(isOpenAICompatible('MiniMax-M2.7-highspeed', 'https://api.minimaxi.com/v1/anthropic')).toBe(false);
+    expect(isOpenAICompatible('MiniMax-M2.7-highspeed', 'https://api.minimaxi.com/anthropic/v1')).toBe(false);
+  });
+
+  it('lets explicit OpenAI models win when only the host name contains anthropic', () => {
+    expect(isOpenAICompatible('gpt-4o', 'https://anthropic-proxy.example.com/v1')).toBe(true);
+  });
 });

--- a/apps/web/src/providers/openai-compatible.ts
+++ b/apps/web/src/providers/openai-compatible.ts
@@ -107,6 +107,7 @@ export function isOpenAICompatible(model: string, baseUrl: string): boolean {
   // Explicit OpenAI-compatible providers/models should win even when a host or
   // unrelated path segment happens to contain the word "anthropic".
   if (u.includes('xiaomimimo.com/v1')) return true;
+  if (u.includes('api.minimaxi.com/v1')) return true;
   if (u.includes('api.deepseek')) return true;
   if (u.includes('api.groq')) return true;
   if (u.includes('api.together')) return true;

--- a/apps/web/src/providers/openai-compatible.ts
+++ b/apps/web/src/providers/openai-compatible.ts
@@ -104,6 +104,10 @@ export function isOpenAICompatible(model: string, baseUrl: string): boolean {
     /^v\d+$/.test(pathSegments.at(-1) ?? '') && pathSegments.at(-2) === 'anthropic'
   );
 
+  // Anthropic endpoint paths should win for providers that expose both
+  // protocol shapes on the same host, e.g. /v1/anthropic or /anthropic/v1.
+  if (isAnthropicEndpoint) return false;
+
   // Explicit OpenAI-compatible providers/models should win even when a host or
   // unrelated path segment happens to contain the word "anthropic".
   if (u.includes('xiaomimimo.com/v1')) return true;
@@ -120,9 +124,7 @@ export function isOpenAICompatible(model: string, baseUrl: string): boolean {
   // MiMo exposes both OpenAI-compatible (/v1) and Anthropic-compatible
   // (/anthropic) endpoints with the same model names, so path shape must break
   // the tie for this provider.
-  if (m.startsWith('mimo')) return !isAnthropicEndpoint;
-
-  if (isAnthropicEndpoint) return false;
+  if (m.startsWith('mimo')) return true;
 
   // If the base URL is custom and not clearly Anthropic-compatible, preserve
   // the existing OpenAI-compatible fallback for third-party providers.

--- a/apps/web/src/state/config.test.ts
+++ b/apps/web/src/state/config.test.ts
@@ -40,6 +40,7 @@ describe('loadConfig', () => {
     expect(config.baseUrl).toBe('https://api.deepseek.com');
     expect(config.model).toBe('deepseek-chat');
     expect(config.apiProtocol).toBe('openai');
+    expect(config.configMigrationVersion).toBe(1);
   });
 
   it('migrates legacy Anthropic API configs to an explicit apiProtocol', () => {
@@ -59,7 +60,72 @@ describe('loadConfig', () => {
     expect(config.apiProtocol).toBe('anthropic');
   });
 
-  it('keeps apiProtocol unset in DEFAULT_CONFIG so missing saved config remains uncommitted', () => {
-    expect(DEFAULT_CONFIG.apiProtocol).toBeUndefined();
+  it('does not migrate daemon-mode configs', () => {
+    const daemonConfig: Partial<AppConfig> = {
+      mode: 'daemon',
+      apiKey: 'sk-test',
+      baseUrl: 'https://api.deepseek.com',
+      model: 'deepseek-chat',
+      agentId: 'codex',
+      skillId: null,
+      designSystemId: null,
+    };
+    store.set('open-design:config', JSON.stringify(daemonConfig));
+
+    const config = loadConfig();
+
+    expect(config.mode).toBe('daemon');
+    expect(config.apiProtocol).toBe('anthropic');
+    expect(config.configMigrationVersion).toBe(1);
+  });
+
+  it('does not overwrite an already explicit apiProtocol', () => {
+    const explicitConfig: Partial<AppConfig> = {
+      mode: 'api',
+      apiProtocol: 'anthropic',
+      apiKey: 'sk-test',
+      baseUrl: 'https://api.deepseek.com',
+      model: 'deepseek-chat',
+      agentId: null,
+      skillId: null,
+      designSystemId: null,
+    };
+    store.set('open-design:config', JSON.stringify(explicitConfig));
+
+    const config = loadConfig();
+
+    expect(config.apiProtocol).toBe('anthropic');
+  });
+
+  it('preserves saved settings when migration sees a malformed base URL', () => {
+    const legacyConfig: Partial<AppConfig> = {
+      mode: 'api',
+      apiKey: 'sk-test',
+      baseUrl: 'https://[broken-ipv6',
+      model: 'custom-model',
+      agentId: null,
+      skillId: null,
+      designSystemId: null,
+    };
+    store.set('open-design:config', JSON.stringify(legacyConfig));
+
+    const config = loadConfig();
+
+    expect(config.mode).toBe('api');
+    expect(config.apiKey).toBe('sk-test');
+    expect(config.baseUrl).toBe('https://[broken-ipv6');
+    expect(config.model).toBe('custom-model');
+    expect(config.apiProtocol).toBe('anthropic');
+  });
+
+  it('returns defaults for malformed localStorage JSON', () => {
+    store.set('open-design:config', '{broken-json');
+
+    expect(loadConfig()).toEqual(DEFAULT_CONFIG);
+  });
+
+  it('sets an explicit apiProtocol for new default configs', () => {
+    expect(DEFAULT_CONFIG.apiProtocol).toBe('anthropic');
+    expect(DEFAULT_CONFIG.configMigrationVersion).toBe(1);
   });
 });

--- a/apps/web/src/state/config.test.ts
+++ b/apps/web/src/state/config.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_CONFIG, loadConfig } from './config';
+import type { AppConfig } from '../types';
+
+const store = new Map<string, string>();
+
+vi.stubGlobal('localStorage', {
+  getItem: vi.fn((key: string) => store.get(key) ?? null),
+  setItem: vi.fn((key: string, value: string) => {
+    store.set(key, value);
+  }),
+  removeItem: vi.fn((key: string) => {
+    store.delete(key);
+  }),
+  clear: vi.fn(() => {
+    store.clear();
+  }),
+});
+
+afterEach(() => {
+  store.clear();
+});
+
+describe('loadConfig', () => {
+  it('migrates legacy OpenAI-compatible API configs to an explicit apiProtocol', () => {
+    const legacyConfig: Partial<AppConfig> = {
+      mode: 'api',
+      apiKey: 'sk-test',
+      baseUrl: 'https://api.deepseek.com',
+      model: 'deepseek-chat',
+      agentId: null,
+      skillId: null,
+      designSystemId: null,
+    };
+    store.set('open-design:config', JSON.stringify(legacyConfig));
+
+    const config = loadConfig();
+
+    expect(config.mode).toBe('api');
+    expect(config.baseUrl).toBe('https://api.deepseek.com');
+    expect(config.model).toBe('deepseek-chat');
+    expect(config.apiProtocol).toBe('openai');
+  });
+
+  it('migrates legacy Anthropic API configs to an explicit apiProtocol', () => {
+    const legacyConfig: Partial<AppConfig> = {
+      mode: 'api',
+      apiKey: 'sk-test',
+      baseUrl: 'https://api.anthropic.com',
+      model: 'claude-sonnet-4-5',
+      agentId: null,
+      skillId: null,
+      designSystemId: null,
+    };
+    store.set('open-design:config', JSON.stringify(legacyConfig));
+
+    const config = loadConfig();
+
+    expect(config.apiProtocol).toBe('anthropic');
+  });
+
+  it('keeps apiProtocol unset in DEFAULT_CONFIG so missing saved config remains uncommitted', () => {
+    expect(DEFAULT_CONFIG.apiProtocol).toBeUndefined();
+  });
+});

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -2,6 +2,7 @@ import { isOpenAICompatible } from '../providers/openai-compatible';
 import type { ApiProtocol, AppConfig, MediaProviderCredentials, PetConfig } from '../types';
 
 const STORAGE_KEY = 'open-design:config';
+const CONFIG_MIGRATION_VERSION = 1;
 
 // Hatched out of the box, but tucked away — the user has to go through
 // either the entry-view "adopt a pet" callout or Settings → Pets to
@@ -23,9 +24,12 @@ export const DEFAULT_CONFIG: AppConfig = {
   apiKey: '',
   baseUrl: 'https://api.anthropic.com',
   model: 'claude-sonnet-4-5',
-  // Keep apiProtocol unset in defaults so loadConfig() does not backfill it
-  // into legacy saved configs. streamMessage() uses the legacy provider
-  // heuristic whenever apiProtocol is absent.
+  // New configs should be explicit. loadConfig() still detects parsed legacy
+  // saved configs that did not have this field and migrates those from their
+  // saved baseUrl/model before applying the current migration version.
+  apiProtocol: 'anthropic',
+  configMigrationVersion: CONFIG_MIGRATION_VERSION,
+  apiProviderBaseUrl: 'https://api.anthropic.com',
   agentId: null,
   skillId: null,
   designSystemId: null,
@@ -47,6 +51,16 @@ export interface KnownProvider {
   models?: string[];
 }
 
+// Some providers appear more than once because they expose both
+// Anthropic-compatible (/v1/messages) and OpenAI-compatible
+// (/v1/chat/completions) gateways. Keep those entries separate so the Settings
+// UI can scope quick-fill presets and model suggestions to the selected
+// protocol.
+//
+// Model lists are hand-curated from provider docs/current public presets rather
+// than fetched dynamically. To add a provider, include a user-facing label, the
+// protocol that determines request routing, the base URL, a default model, and
+// optional provider-specific model choices.
 export const KNOWN_PROVIDERS: KnownProvider[] = [
   {
     label: 'Anthropic (Claude)',
@@ -133,11 +147,23 @@ function normalizePet(input: Partial<PetConfig> | undefined): PetConfig {
   };
 }
 
+function inferApiProtocol(model: string, baseUrl: string): ApiProtocol {
+  try {
+    return isOpenAICompatible(model, baseUrl) ? 'openai' : 'anthropic';
+  } catch {
+    // Preserve the rest of the user's settings even if an old saved base URL is
+    // malformed enough for URL parsing to throw. Anthropic is the safest default
+    // because it matches the original built-in provider.
+    return 'anthropic';
+  }
+}
+
 export function loadConfig(): AppConfig {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return { ...DEFAULT_CONFIG, pet: normalizePet(DEFAULT_PET) };
     const parsed = JSON.parse(raw) as Partial<AppConfig>;
+    const parsedHasApiProtocol = Object.prototype.hasOwnProperty.call(parsed, 'apiProtocol');
     const merged: AppConfig = {
       ...DEFAULT_CONFIG,
       ...parsed,
@@ -146,11 +172,15 @@ export function loadConfig(): AppConfig {
       pet: normalizePet(parsed.pet),
     };
 
-    // One-time migration for configs saved before apiProtocol existed: make
-    // the inferred protocol explicit so old OpenAI-compatible endpoints keep
-    // routing correctly after the Settings UI splits protocol tabs.
-    if (!merged.apiProtocol && merged.mode === 'api') {
-      merged.apiProtocol = isOpenAICompatible(merged.model, merged.baseUrl) ? 'openai' : 'anthropic';
+    if (parsed.configMigrationVersion !== CONFIG_MIGRATION_VERSION) {
+      // Migration v1: configs saved before apiProtocol existed need an explicit
+      // protocol so old OpenAI-compatible endpoints keep routing correctly.
+      // This is version-gated instead of only field-gated so a later imported
+      // legacy config can be migrated when it is loaded.
+      if (!parsedHasApiProtocol && merged.mode === 'api') {
+        merged.apiProtocol = inferApiProtocol(merged.model, merged.baseUrl);
+      }
+      merged.configMigrationVersion = CONFIG_MIGRATION_VERSION;
     }
 
     return merged;

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -179,6 +179,12 @@ export function loadConfig(): AppConfig {
       // legacy config can be migrated when it is loaded.
       if (!parsedHasApiProtocol && merged.mode === 'api') {
         merged.apiProtocol = inferApiProtocol(merged.model, merged.baseUrl);
+        // Also set apiProviderBaseUrl so setApiProtocol() can correctly identify
+        // whether the user is on a known provider and switch defaults appropriately.
+        // null means "custom/unknown provider" so the protocol switch won't override
+        // their custom base URL.
+        const knownProvider = KNOWN_PROVIDERS.find((p) => p.baseUrl === merged.baseUrl);
+        merged.apiProviderBaseUrl = knownProvider?.baseUrl ?? null;
       }
       merged.configMigrationVersion = CONFIG_MIGRATION_VERSION;
     }

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -1,4 +1,4 @@
-import type { AppConfig, MediaProviderCredentials, PetConfig } from '../types';
+import type { ApiProtocol, AppConfig, MediaProviderCredentials, PetConfig } from '../types';
 
 const STORAGE_KEY = 'open-design:config';
 
@@ -22,6 +22,9 @@ export const DEFAULT_CONFIG: AppConfig = {
   apiKey: '',
   baseUrl: 'https://api.anthropic.com',
   model: 'claude-sonnet-4-5',
+  // Keep apiProtocol unset in defaults so loadConfig() does not backfill it
+  // into legacy saved configs. streamMessage() uses the legacy provider
+  // heuristic whenever apiProtocol is absent.
   agentId: null,
   skillId: null,
   designSystemId: null,
@@ -33,10 +36,89 @@ export const DEFAULT_CONFIG: AppConfig = {
 };
 
 /** Well-known providers with pre-filled base URLs. */
-export const KNOWN_PROVIDERS: Array<{ label: string; baseUrl: string; model: string }> = [
-  { label: 'Anthropic (Claude)', baseUrl: 'https://api.anthropic.com', model: 'claude-sonnet-4-5' },
-  { label: 'MiMo (Xiaomi) — OpenAI', baseUrl: 'https://token-plan-cn.xiaomimimo.com/v1', model: 'mimo-v2.5-pro' },
-  { label: 'MiMo (Xiaomi) — Anthropic', baseUrl: 'https://token-plan-cn.xiaomimimo.com/anthropic', model: 'mimo-v2.5-pro' },
+export interface KnownProvider {
+  label: string;
+  protocol: ApiProtocol;
+  baseUrl: string;
+  /** Default model to apply when the provider is selected. */
+  model: string;
+  /** Optional provider-specific model choices shown in Settings. */
+  models?: string[];
+}
+
+export const KNOWN_PROVIDERS: KnownProvider[] = [
+  {
+    label: 'Anthropic (Claude)',
+    protocol: 'anthropic',
+    baseUrl: 'https://api.anthropic.com',
+    model: 'claude-sonnet-4-5',
+    models: ['claude-sonnet-4-5', 'claude-opus-4-5', 'claude-haiku-4-5'],
+  },
+  {
+    label: 'DeepSeek — Anthropic',
+    protocol: 'anthropic',
+    baseUrl: 'https://api.deepseek.com/anthropic',
+    model: 'deepseek-chat',
+    models: ['deepseek-chat', 'deepseek-reasoner', 'deepseek-v4-flash', 'deepseek-v4-pro'],
+  },
+  {
+    label: 'MiniMax — Anthropic',
+    protocol: 'anthropic',
+    baseUrl: 'https://api.minimaxi.com/anthropic',
+    model: 'MiniMax-M2.7-highspeed',
+    models: [
+      'MiniMax-M2.7-highspeed',
+      'MiniMax-M2.7',
+      'MiniMax-M2.5-highspeed',
+      'MiniMax-M2.5',
+      'MiniMax-M2.1-highspeed',
+      'MiniMax-M2.1',
+      'MiniMax-M2',
+    ],
+  },
+  {
+    label: 'OpenAI',
+    protocol: 'openai',
+    baseUrl: 'https://api.openai.com/v1',
+    model: 'gpt-4o',
+    models: ['gpt-4o', 'gpt-4o-mini', 'o3', 'o4-mini'],
+  },
+  {
+    label: 'DeepSeek — OpenAI',
+    protocol: 'openai',
+    baseUrl: 'https://api.deepseek.com',
+    model: 'deepseek-chat',
+    models: ['deepseek-chat', 'deepseek-reasoner', 'deepseek-v4-flash', 'deepseek-v4-pro'],
+  },
+  {
+    label: 'MiniMax — OpenAI',
+    protocol: 'openai',
+    baseUrl: 'https://api.minimaxi.com/v1',
+    model: 'MiniMax-M2.7-highspeed',
+    models: [
+      'MiniMax-M2.7-highspeed',
+      'MiniMax-M2.7',
+      'MiniMax-M2.5-highspeed',
+      'MiniMax-M2.5',
+      'MiniMax-M2.1-highspeed',
+      'MiniMax-M2.1',
+      'MiniMax-M2',
+    ],
+  },
+  {
+    label: 'MiMo (Xiaomi) — OpenAI',
+    protocol: 'openai',
+    baseUrl: 'https://token-plan-cn.xiaomimimo.com/v1',
+    model: 'mimo-v2.5-pro',
+    models: ['mimo-v2.5-pro'],
+  },
+  {
+    label: 'MiMo (Xiaomi) — Anthropic',
+    protocol: 'anthropic',
+    baseUrl: 'https://token-plan-cn.xiaomimimo.com/anthropic',
+    model: 'mimo-v2.5-pro',
+    models: ['mimo-v2.5-pro'],
+  },
 ];
 
 function normalizePet(input: Partial<PetConfig> | undefined): PetConfig {

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -1,3 +1,4 @@
+import { isOpenAICompatible } from '../providers/openai-compatible';
 import type { ApiProtocol, AppConfig, MediaProviderCredentials, PetConfig } from '../types';
 
 const STORAGE_KEY = 'open-design:config';
@@ -137,13 +138,22 @@ export function loadConfig(): AppConfig {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return { ...DEFAULT_CONFIG, pet: normalizePet(DEFAULT_PET) };
     const parsed = JSON.parse(raw) as Partial<AppConfig>;
-    return {
+    const merged: AppConfig = {
       ...DEFAULT_CONFIG,
       ...parsed,
       mediaProviders: { ...(parsed.mediaProviders ?? {}) },
       agentModels: { ...(parsed.agentModels ?? {}) },
       pet: normalizePet(parsed.pet),
     };
+
+    // One-time migration for configs saved before apiProtocol existed: make
+    // the inferred protocol explicit so old OpenAI-compatible endpoints keep
+    // routing correctly after the Settings UI splits protocol tabs.
+    if (!merged.apiProtocol && merged.mode === 'api') {
+      merged.apiProtocol = isOpenAICompatible(merged.model, merged.baseUrl) ? 'openai' : 'anthropic';
+    }
+
+    return merged;
   } catch {
     return { ...DEFAULT_CONFIG, pet: normalizePet(DEFAULT_PET) };
   }

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -35,6 +35,7 @@ import type {
 } from '@open-design/contracts';
 
 export type ExecMode = 'daemon' | 'api';
+export type ApiProtocol = 'anthropic' | 'openai';
 
 export interface MediaProviderCredentials {
   apiKey: string;
@@ -133,6 +134,7 @@ export interface AppConfig {
   apiKey: string;
   baseUrl: string;
   model: string;
+  apiProtocol?: ApiProtocol;
   agentId: string | null;
   skillId: string | null;
   designSystemId: string | null;

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -135,6 +135,10 @@ export interface AppConfig {
   baseUrl: string;
   model: string;
   apiProtocol?: ApiProtocol;
+  /** Internal config schema/migration version for localStorage upgrades. */
+  configMigrationVersion?: number;
+  /** Base URL of the selected known provider; cleared once the user customizes provider fields. */
+  apiProviderBaseUrl?: string | null;
   agentId: string | null;
   skillId: string | null;
   designSystemId: string | null;


### PR DESCRIPTION
## Summary

Split API provider setup in Settings into explicit protocol choices:

* Local CLI
* Anthropic API
* OpenAI API

This makes the selected API protocol visible and avoids relying only on base URL / model-name heuristics.

## Changes

* Add `apiProtocol?: 'anthropic' | 'openai'` to `AppConfig`.
* Add top-level Settings tabs for:
  * Local CLI
  * Anthropic API
  * OpenAI API
* Route API calls by explicit `apiProtocol` when present.
* Keep the existing OpenAI-compatible heuristic as a fallback for older saved configs.
* Add an explicit `loadConfig()` migration for existing saved API configs:
  * OpenAI-compatible saved configs migrate to `apiProtocol: 'openai'`
  * Other API configs default to `apiProtocol: 'anthropic'`
* Filter quick-fill providers by selected API protocol.
* Move `Quick fill provider` above API key/model/base URL fields.
* Keep the selected quick-fill provider visible in the dropdown.
* Add provider-specific model dropdowns.
* Split fallback model suggestions by API protocol.
* Support `Custom provider` and `Custom…` model input without falling back to the first option.
* Preserve custom `baseUrl` and `model` values when switching API protocol tabs unless the current base URL matches a known provider.
* Preserve Anthropic-compatible streaming through the existing daemon proxy.
* Add/update provider presets for:
  * Anthropic
  * OpenAI
  * DeepSeek — Anthropic
  * DeepSeek — OpenAI
  * MiniMax — Anthropic
  * MiniMax — OpenAI
  * MiMo — Anthropic
  * MiMo — OpenAI
  
![Uploading image.png…]()


## Why

Anthropic-compatible and OpenAI-compatible providers use different APIs:

* Anthropic-compatible providers use `/v1/messages`
* OpenAI-compatible providers use `/v1/chat/completions`

Previously, Settings showed a single API mode and routing depended mostly on inferred provider/model behavior. That made it easy to mix an Anthropic-compatible endpoint with an OpenAI-compatible model, or vice versa.

Making the protocol explicit improves provider setup clarity and keeps model choices scoped to the selected provider.

## Validation

* Started locally from `feat/api-protocol-tabs-from-main`
  * Web: `http://127.0.0.1:17573/`
  * Daemon: `http://127.0.0.1:17456/api/health`
* Verified:
  * Web returns `200`
  * Daemon health returns `{"ok":true,"version":"0.1.0"}`