### PR TITLE
[codex] Fix README metadata drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open Design
 
-> **The open-source alternative to [Claude Design][cd].** Local-first, web-deployable, BYOK at every layer — **11 coding-agent CLIs** auto-detected on your `PATH` (Claude Code, Codex, Cursor Agent, Gemini CLI, OpenCode, Qwen, GitHub Copilot CLI, Hermes, Kimi, Pi, Kiro) become the design engine, driven by **31 composable Skills** and **72 brand-grade Design Systems**. No CLI? An OpenAI-compatible BYOK proxy is the same loop minus the spawn.
+> **The open-source alternative to [Claude Design][cd].** Local-first, web-deployable, BYOK at every layer — **11 coding-agent CLIs** auto-detected on your `PATH` (Claude Code, Codex, Cursor Agent, Gemini CLI, OpenCode, Qwen, GitHub Copilot CLI, Hermes, Kimi, Pi, Kiro) become the design engine, driven by **52 composable Skills** and **130 brand-grade Design Systems**. No CLI? An OpenAI-compatible BYOK proxy is the same loop minus the spawn.
 
 <p align="center">
   <img src="docs/assets/banner.png" alt="Open Design — editorial cover: design with the agent on your laptop" width="100%" />
@@ -20,8 +20,8 @@
   <a href="https://github.com/nexu-io/open-design/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/nexu-io/open-design?style=flat-square&color=blueviolet&label=release&include_prereleases" /></a>
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache%202.0-blue.svg?style=flat-square" /></a>
   <a href="#supported-coding-agents"><img alt="Agents" src="https://img.shields.io/badge/agents-10%20CLIs%20%2B%20BYOK%20proxy-black?style=flat-square" /></a>
-  <a href="#design-systems"><img alt="Design systems" src="https://img.shields.io/badge/design%20systems-72-orange?style=flat-square" /></a>
-  <a href="#skills"><img alt="Skills" src="https://img.shields.io/badge/skills-31-teal?style=flat-square" /></a>
+  <a href="#design-systems"><img alt="Design systems" src="https://img.shields.io/badge/design%20systems-130-orange?style=flat-square" /></a>
+  <a href="#skills"><img alt="Skills" src="https://img.shields.io/badge/skills-52-teal?style=flat-square" /></a>
   <a href="QUICKSTART.md"><img alt="Quickstart" src="https://img.shields.io/badge/quickstart-3%20commands-green?style=flat-square" /></a>
 </p>
 
@@ -52,8 +52,8 @@ OD stands on four open-source shoulders:
 |---|---|
 | **Coding-agent CLIs (11)** | Claude Code · Codex CLI · Cursor Agent · Gemini CLI · OpenCode · Qwen Code · GitHub Copilot CLI · Hermes (ACP) · Kimi CLI (ACP) · Pi (RPC) · Kiro CLI (ACP) — auto-detected on `PATH`, swap with one click |
 | **BYOK fallback** | OpenAI-compatible proxy at `/api/proxy/stream` — paste `baseUrl` + `apiKey` + `model` and any vendor (Anthropic-via-OpenAI, DeepSeek, Groq, MiMo, OpenRouter, your self-hosted vLLM, or any other OpenAI-compatible provider) becomes the engine. Internal-IP/SSRF blocked at the daemon edge. |
-| **Design systems built-in** | **129** — 2 hand-authored starters + 70 product systems (Linear, Stripe, Vercel, Airbnb, Tesla, Notion, Anthropic, Apple, Cursor, Supabase, Figma, Xiaohongshu, …) from [`awesome-design-md`][acd2], plus 57 design skills from [`awesome-design-skills`][ads] added directly under `design-systems/` |
-| **Skills built-in** | **31** — 27 in `prototype` mode (web-prototype, saas-landing, dashboard, mobile-app, gamified-app, social-carousel, magazine-poster, dating-web, sprite-animation, motion-frames, critique, tweaks, wireframe-sketch, pm-spec, eng-runbook, finance-report, hr-onboarding, invoice, kanban-board, team-okrs, …) + 4 in `deck` mode (`guizang-ppt` · `simple-deck` · `replit-deck` · `weekly-update`). Grouped in the picker by `scenario`: design / marketing / operation / engineering / product / finance / hr / sale / personal. |
+| **Design systems built-in** | **130** — 2 hand-authored starters + 1 `kami` editorial paper system + 70 product systems (Linear, Stripe, Vercel, Airbnb, Tesla, Notion, Anthropic, Apple, Cursor, Supabase, Figma, Xiaohongshu, …) from [`awesome-design-md`][acd2], plus 57 design skills from [`awesome-design-skills`][ads] added directly under `design-systems/` |
+| **Skills built-in** | **52** — 27 in `prototype` mode (web-prototype, saas-landing, dashboard, mobile-app, gamified-app, social-carousel, magazine-poster, dating-web, sprite-animation, motion-frames, critique, tweaks, wireframe-sketch, pm-spec, eng-runbook, finance-report, hr-onboarding, invoice, kanban-board, team-okrs, …) + 20 in `deck` mode (`guizang-ppt`, `simple-deck`, `replit-deck`, `weekly-update`, and the `html-ppt-*` wrappers) + 5 specialist media / system skills (`image-poster`, `video-shortform`, `hyperframes`, `audio-jingle`, `design-brief`). Grouped in the picker by `scenario`: design / marketing / operations / engineering / product / finance / hr / sales / personal / education / planning. |
 | **Media generation** | Image · video · audio surfaces ship alongside the design loop. **gpt-image-2** (Azure / OpenAI) for posters, avatars, infographics, illustrated maps · **Seedance 2.0** (ByteDance) for cinematic 15s text-to-video and image-to-video · **HyperFrames** ([heygen-com/hyperframes](https://github.com/heygen-com/hyperframes)) for HTML→MP4 motion graphics (product reveals, kinetic typography, data charts, social overlays, logo outros). **93** ready-to-replicate prompts gallery — 43 gpt-image-2 + 39 Seedance + 11 HyperFrames — under [`prompt-templates/`](prompt-templates/), with preview thumbnails and source attribution. Same chat surface as code; outputs a real `.mp4` / `.png` chip into the project workspace. |
 | **Visual directions** | 5 curated schools (Editorial Monocle · Modern Minimal · Warm Soft · Tech Utility · Brutalist Experimental) — each ships a deterministic OKLch palette + font stack ([`apps/web/src/prompts/directions.ts`](apps/web/src/prompts/directions.ts)) |
 | **Device frames** | iPhone 15 Pro · Pixel · iPad Pro · MacBook · Browser Chrome — pixel-accurate, shared across skills under [`assets/frames/`](assets/frames/) |
@@ -97,8 +97,8 @@ OD stands on four open-source shoulders:
 <sub><b>Sandboxed preview</b> — every <code>&lt;artifact&gt;</code> renders in a clean srcdoc iframe. Editable in place via the file workspace; downloadable as HTML, PDF, ZIP.</sub>
 </td>
 <td width="50%">
-<img src="docs/screenshots/06-design-systems-library.png" alt="06 · 72-system library" /><br/>
-<sub><b>72-system library</b> — every product system shows its 4-color signature. Click for the full <code>DESIGN.md</code>, swatch grid, and live showcase.</sub>
+<img src="docs/screenshots/06-design-systems-library.png" alt="06 · 130-system library" /><br/>
+<sub><b>130-system library</b> — every product system shows its 4-color signature. Click for the full <code>DESIGN.md</code>, swatch grid, and live showcase.</sub>
 </td>
 </tr>
 <tr>
@@ -115,9 +115,9 @@ OD stands on four open-source shoulders:
 
 ## Skills
 
-**31 skills ship in the box.** Each is a folder under [`skills/`](skills/) following the Claude Code [`SKILL.md`][skill] convention with an extended `od:` frontmatter that the daemon parses verbatim — `mode`, `platform`, `scenario`, `preview.type`, `design_system.requires`, `default_for`, `featured`, `fidelity`, `speaker_notes`, `animations`, `example_prompt` ([`apps/daemon/src/skills.ts`](apps/daemon/src/skills.ts)).
+**52 skills ship in the box.** Each is a folder under [`skills/`](skills/) following the Claude Code [`SKILL.md`][skill] convention with an extended `od:` frontmatter that the daemon parses verbatim — `mode`, `platform`, `scenario`, `preview.type`, `design_system.requires`, `default_for`, `featured`, `fidelity`, `speaker_notes`, `animations`, `example_prompt` ([`apps/daemon/src/skills.ts`](apps/daemon/src/skills.ts)).
 
-Two top-level **modes** carry the catalog: **`prototype`** (27 skills — anything that renders as a single-page artifact, from a magazine landing to a phone screen to a PM spec doc) and **`deck`** (4 skills — horizontal-swipe presentations with deck-framework chrome). The **`scenario`** field is what the picker groups them by: `design` · `marketing` · `operation` · `engineering` · `product` · `finance` · `hr` · `sale` · `personal`.
+Two top-level **modes** carry the catalog: **`prototype`** (27 skills — anything that renders as a single-page artifact, from a magazine landing to a phone screen to a PM spec doc) and **`deck`** (20 skills — horizontal-swipe presentations with deck-framework chrome, including the bundled `html-ppt-*` wrappers). Additional specialist modes cover **image** (1), **video** (2), **audio** (1), and **design-system** (1). The **`scenario`** field is what the picker groups them by: `design` · `marketing` · `operations` · `engineering` · `product` · `finance` · `hr` · `sales` · `personal` · `education` · `planning`.
 
 ### Showcase examples
 
@@ -245,8 +245,8 @@ What you compose at send time isn't "system + user". It's:
 ```
 DISCOVERY directives  (turn-1 form, turn-2 brand branch, TodoWrite, 5-dim critique)
   + identity charter   (OFFICIAL_DESIGNER_PROMPT, anti-AI-slop, junior-pass)
-  + active DESIGN.md   (72 systems available)
-  + active SKILL.md    (31 skills available)
+  + active DESIGN.md   (130 systems available)
+  + active SKILL.md    (52 skills available)
   + project metadata   (kind, fidelity, speakerNotes, animations, inspiration ids)
   + skill side files   (auto-injected pre-flight: read assets/template.html + references/*.md)
   + (deck kind, no skill seed) DECK_FRAMEWORK_DIRECTIVE   (nav / counter / scroll / print)
@@ -316,7 +316,7 @@ For desktop/background startup, fixed-port restarts, and media generation dispat
 The first load:
 
 1. Detects which agent CLIs you have on `PATH` and picks one automatically.
-2. Loads 31 skills + 72 design systems.
+2. Loads 52 skills + 130 design systems.
 3. Pops the welcome dialog so you can paste an Anthropic key (only needed for the BYOK fallback path).
 4. **Auto-creates `./.od/`** — the local runtime folder for the SQLite project DB, per-project artifacts, and saved renders. There is no `od init` step; the daemon `mkdir`s everything it needs on boot.
 
@@ -386,7 +386,7 @@ open-design/
 │   ├── sidecar/                   ← generic sidecar runtime primitives
 │   └── platform/                  ← generic process/platform primitives
 │
-├── skills/                        ← 31 SKILL.md skill bundles (27 prototype + 4 deck)
+├── skills/                        ← 52 SKILL.md skill bundles across prototype, deck, and specialist media/system modes
 │   ├── web-prototype/             ← default for prototype mode
 │   ├── saas-landing/  dashboard/  pricing-page/  docs-page/  blog-post/
 │   ├── mobile-app/  mobile-onboarding/  gamified-app/
@@ -401,7 +401,7 @@ open-design/
 │       ├── assets/template.html   ← seed
 │       └── references/{themes,layouts,components,checklist}.md
 │
-├── design-systems/                ← 72 DESIGN.md systems
+├── design-systems/                ← 130 DESIGN.md systems
 │   ├── default/                   ← Neutral Modern (starter)
 │   ├── warm-editorial/            ← Warm Editorial (starter)
 │   ├── linear-app/  vercel/  stripe/  airbnb/  notion/  cursor/  apple/  …
@@ -442,10 +442,10 @@ open-design/
 ## Design Systems
 
 <p align="center">
-  <img src="docs/assets/design-systems-library.png" alt="The 72 design systems library — style guide spread" width="100%" />
+  <img src="docs/assets/design-systems-library.png" alt="The 130 design systems library — style guide spread" width="100%" />
 </p>
 
-72 systems out of the box, each as a single [`DESIGN.md`](design-systems/README.md):
+130 systems out of the box, each as a single [`DESIGN.md`](design-systems/README.md):
 
 <details>
 <summary><b>Full catalog</b> (click to expand)</summary>
@@ -565,7 +565,7 @@ The chat / artifact loop gets the spotlight, but a handful of less-visible capab
 
 - **Claude Design ZIP import.** Drop an export from claude.ai onto the welcome dialog. `POST /api/import/claude-design` extracts it into a real `.od/projects/<id>/`, opens the entry file as a tab, and stages a continue-where-Anthropic-left-off prompt for your local agent. No re-prompting, no "ask the model to re-create what we just had". ([`apps/daemon/src/server.ts`](apps/daemon/src/server.ts) — `/api/import/claude-design`)
 - **OpenAI-compatible BYOK proxy.** `POST /api/proxy/stream` takes `{ baseUrl, apiKey, model, messages }`, normalises the path (`…/v1/chat/completions`), forwards SSE chunks back to the browser, and rejects loopback / link-local / RFC1918 destinations to head off SSRF. Anything that speaks the OpenAI chat schema works — Anthropic-via-OpenAI shim, DeepSeek, Groq, MiMo, OpenRouter, your self-hosted vLLM. MiMo gets `tool_choice: 'none'` automatically because its tool schema misbehaves on free-form generation.
-- **User-saved templates.** Once you like a render, `POST /api/templates` snapshots the HTML + metadata into the SQLite `templates` table. The next project picks it from a "your templates" row in the picker — same surface as the shipped 31, but yours.
+- **User-saved templates.** Once you like a render, `POST /api/templates` snapshots the HTML + metadata into the SQLite `templates` table. The next project picks it from a "your templates" row in the picker — same surface as the shipped catalog, but yours.
 - **Tab persistence.** Every project remembers its open files and active tab in the `tabs` table. Reopen the project tomorrow and the workspace looks exactly the way you left it.
 - **Artifact lint API.** `POST /api/artifacts/lint` runs structural checks on a generated artifact (broken `<artifact>` framing, missing required side files, stale palette tokens) and returns findings the agent can read back into its next turn. The five-dim self-critique uses this to ground its score in real evidence, not vibes.
 - **Sidecar protocol + desktop automation.** Daemon, web, and desktop processes carry typed five-field stamps (`app · mode · namespace · ipc · source`) and expose a JSON-RPC IPC channel at `/tmp/open-design/ipc/<namespace>/<app>.sock`. `tools-dev inspect desktop status \| eval \| screenshot` drives that channel, so headless E2E works against a real Electron shell without bespoke harnesses ([`packages/sidecar-proto/`](packages/sidecar-proto/), [`apps/desktop/src/main/`](apps/desktop/src/main/)).
@@ -591,9 +591,9 @@ The whole machinery below is the [`huashu-design`](https://github.com/alchaincyf
 | Form factor | Web (claude.ai) | Desktop (Electron) | **Web app + local daemon** |
 | Deployable on Vercel | ❌ | ❌ | **✅** |
 | Agent runtime | Bundled (Opus 4.7) | Bundled ([`pi-ai`][piai]) | **Delegated to user's existing CLI** |
-| Skills | Proprietary | 12 custom TS modules + `SKILL.md` | **31 file-based [`SKILL.md`][skill] bundles, droppable** |
-| Design system | Proprietary | `DESIGN.md` (v0.2 roadmap) | **`DESIGN.md` × 129 systems shipped** |
-| Provider flexibility | Anthropic only | 7+ via [`pi-ai`][piai] | **10 CLI adapters + OpenAI-compatible BYOK proxy** |
+| Skills | Proprietary | 12 custom TS modules + `SKILL.md` | **52 file-based [`SKILL.md`][skill] bundles, droppable** |
+| Design system | Proprietary | `DESIGN.md` (v0.2 roadmap) | **`DESIGN.md` × 130 systems shipped** |
+| Provider flexibility | Anthropic only | 7+ via [`pi-ai`][piai] | **11 CLI adapters + OpenAI-compatible BYOK proxy** |
 | Init question form | ❌ | ❌ | **✅ Hard rule, turn 1** |
 | Direction picker | ❌ | ❌ | **✅ 5 deterministic directions** |
 | Live todo progress + tool stream | ❌ | ✅ | **✅** (UX pattern from open-codesign) |
@@ -657,9 +657,9 @@ Long-form provenance write-up — what we take from each, what we deliberately d
 
 ## Roadmap
 
-- [x] Daemon + agent detection (10 CLI adapters) + skill registry + design-system catalog
+- [x] Daemon + agent detection (11 CLI adapters) + skill registry + design-system catalog
 - [x] Web app + chat + question form + 5-direction picker + todo progress + sandboxed preview
-- [x] 31 skills + 72 design systems + 5 visual directions + 5 device frames
+- [x] 52 skills + 130 design systems + 5 visual directions + 5 device frames
 - [x] SQLite-backed projects · conversations · messages · tabs · templates
 - [x] OpenAI-compatible BYOK proxy (`/api/proxy/stream`) with SSRF guard
 - [x] Claude Design ZIP import (`/api/import/claude-design`)

--- a/apps/web/src/i18n/readme-metadata.test.ts
+++ b/apps/web/src/i18n/readme-metadata.test.ts
@@ -1,0 +1,113 @@
+import { readdir, readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { parseFrontmatter } from '../../../daemon/src/frontmatter';
+
+const repoRoot = fileURLToPath(new URL('../../../../', import.meta.url));
+
+async function countDirsWithFile(root: string, fileName: string): Promise<number> {
+  const entries = await readdir(root, { withFileTypes: true });
+  let count = 0;
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    try {
+      if ((await stat(path.join(root, entry.name, fileName))).isFile()) count++;
+    } catch {
+      // Ignore directories that do not expose the target file.
+    }
+  }
+  return count;
+}
+
+async function collectSkillStats() {
+  const skillsRoot = path.join(repoRoot, 'skills');
+  const entries = await readdir(skillsRoot, { withFileTypes: true });
+  let total = 0;
+  let prototype = 0;
+  let deck = 0;
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const skillPath = path.join(skillsRoot, entry.name, 'SKILL.md');
+    try {
+      if (!(await stat(skillPath)).isFile()) continue;
+      const raw = await readFile(skillPath, 'utf8');
+      const { data } = parseFrontmatter(raw) as {
+        data?: { od?: { mode?: unknown } };
+      };
+      total++;
+      const mode = data?.od?.mode;
+      if (mode === 'prototype' || mode == null) prototype++;
+      if (mode === 'deck') deck++;
+    } catch {
+      // Discovery mirrors the daemon: unreadable skill folders are skipped.
+    }
+  }
+
+  return { total, prototype, deck };
+}
+
+async function countAgentDefs(): Promise<number> {
+  const agentsSource = await readFile(
+    path.join(repoRoot, 'apps/daemon/src/agents.ts'),
+    'utf8',
+  );
+  return (agentsSource.match(/\n  {\n    id: '/g) ?? []).length;
+}
+
+function expectMatch(readme: string, pattern: RegExp, expected: string) {
+  const match = pattern.exec(readme);
+  expect(match?.[1]).toBe(expected);
+}
+
+describe('README metadata stays in sync with the repo', () => {
+  it('keeps the English README counts aligned with the codebase', async () => {
+    const [readme, skillStats, designSystems, agents] = await Promise.all([
+      readFile(path.join(repoRoot, 'README.md'), 'utf8'),
+      collectSkillStats(),
+      countDirsWithFile(path.join(repoRoot, 'design-systems'), 'DESIGN.md'),
+      countAgentDefs(),
+    ]);
+
+    expectMatch(
+      readme,
+      /driven by \*\*(\d+) composable Skills\*\* and \*\*(\d+) brand-grade Design Systems\*\*/,
+      String(skillStats.total),
+    );
+    expectMatch(
+      readme,
+      /driven by \*\*\d+ composable Skills\*\* and \*\*(\d+) brand-grade Design Systems\*\*/,
+      String(designSystems),
+    );
+    expectMatch(
+      readme,
+      /alt="Agents" src="https:\/\/img\.shields\.io\/badge\/agents-(\d+)%20CLIs/,
+      String(agents - 1),
+    );
+    expectMatch(
+      readme,
+      /alt="Design systems" src="https:\/\/img\.shields\.io\/badge\/design%20systems-(\d+)-orange/,
+      String(designSystems),
+    );
+    expectMatch(
+      readme,
+      /alt="Skills" src="https:\/\/img\.shields\.io\/badge\/skills-(\d+)-teal/,
+      String(skillStats.total),
+    );
+    expectMatch(readme, /\| \*\*Coding-agent CLIs \((\d+)\)\*\* \|/, String(agents));
+    expectMatch(readme, /\| \*\*Design systems built-in\*\* \| \*\*(\d+)\*\* —/, String(designSystems));
+    expectMatch(readme, /\| \*\*Skills built-in\*\* \| \*\*(\d+)\*\* —/, String(skillStats.total));
+    expectMatch(readme, /\*\*`prototype`\*\* \((\d+) skills/, String(skillStats.prototype));
+    expectMatch(readme, /\*\*`deck`\*\* \((\d+) skills/, String(skillStats.deck));
+    expectMatch(readme, /06 · (\d+)-system library/, String(designSystems));
+    expectMatch(readme, /\+ active DESIGN\.md\s+\((\d+) systems available\)/, String(designSystems));
+    expectMatch(readme, /\+ active SKILL\.md\s+\((\d+) skills available\)/, String(skillStats.total));
+    expectMatch(readme, /\n2\. Loads (\d+) skills \+ \d+ design systems\./, String(skillStats.total));
+    expectMatch(readme, /\n2\. Loads \d+ skills \+ (\d+) design systems\./, String(designSystems));
+    expectMatch(readme, /Provider flexibility \| Anthropic only \| 7\+ via \[`pi-ai`]\[piai] \| \*\*(\d+) CLI adapters \+ OpenAI-compatible BYOK proxy\*\*/, String(agents));
+    expectMatch(readme, /\[x] Daemon \+ agent detection \((\d+) CLI adapters\)/, String(agents));
+    expectMatch(readme, /\n(\d+) systems out of the box, each as a single \[`DESIGN\.md`\]/, String(designSystems));
+    expectMatch(readme, /\*\*`DESIGN\.md` × (\d+) systems shipped\*\*/, String(designSystems));
+  });
+});


### PR DESCRIPTION
## Summary

- update the English README counts so the public metadata matches the current repo contents
- add a targeted Vitest check that fails when those README counts drift again

## Why

The README still advertised older catalog sizes even though the repository now ships more skills, more design systems, and one more CLI adapter. That makes the project look stale on first read and invites future drift whenever new catalog entries land.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts src/i18n/readme-metadata.test.ts`

## Notes

- Running the broader `@open-design/web` test suite still surfaces pre-existing failures in `src/i18n/content.test.ts` and `src/i18n/locales.test.ts` due to existing German-content and locale-key drift. Those failures were present while validating this PR and are not introduced by the README metadata change itself.
