### PR TITLE
feat(web): add dark mode support with system/light/dark toggle

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -18,9 +18,22 @@ export const viewport: Viewport = {
   themeColor: '#F4EFE6',
 };
 
+/**
+ * Inline script that runs before React hydrates to apply the saved theme
+ * preference without a flash of unstyled content. It reads the same
+ * localStorage key used by `state/config.ts` and sets `data-theme` on
+ * `<html>` immediately — before any CSS or React paint.
+ */
+const themeInitScript = `(function(){try{var t=JSON.parse(localStorage.getItem('open-design:config')||'{}').theme;if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();`;
+
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang='en' suppressHydrationWarning>
+      {/* eslint-disable-next-line @next/next/no-sync-scripts */}
+      <head>
+        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: intentional theme-init inline script to prevent FOUC */}
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
       <body suppressHydrationWarning>
         <I18nProvider>{children}</I18nProvider>
       </body>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -55,6 +55,16 @@ export function App() {
   const [bootstrapping, setBootstrapping] = useState(true);
   const route = useRoute();
 
+  // Sync theme preference to the <html> element so CSS variables pick it up.
+  useEffect(() => {
+    const theme = config.theme ?? 'system';
+    if (theme === 'system') {
+      document.documentElement.removeAttribute('data-theme');
+    } else {
+      document.documentElement.setAttribute('data-theme', theme);
+    }
+  }, [config.theme]);
+
   // Bootstrap — detect daemon, load pickers, seed sensible defaults.
   useEffect(() => {
     let cancelled = false;

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
 import { EntryView } from './components/EntryView';
 import type { CreateInput } from './components/NewProjectPanel';
 import { ProjectView } from './components/ProjectView';
@@ -56,7 +56,10 @@ export function App() {
   const route = useRoute();
 
   // Sync theme preference to the <html> element so CSS variables pick it up.
-  useEffect(() => {
+  // useLayoutEffect (vs useEffect) fires before the browser paints, so a
+  // live theme switch in Settings applies atomically — no 1-frame flash of
+  // the old theme. Safe here because the component tree is ssr:false.
+  useLayoutEffect(() => {
     const theme = config.theme ?? 'system';
     if (theme === 'system') {
       document.documentElement.removeAttribute('data-theme');

--- a/apps/web/src/components/Icon.tsx
+++ b/apps/web/src/components/Icon.tsx
@@ -41,6 +41,7 @@ type IconName =
   | 'spinner'
   | 'sparkles'
   | 'stop'
+  | 'sun-moon'
   | 'tweaks'
   | 'upload'
   | 'zoom-in'
@@ -367,6 +368,20 @@ export function Icon({ name, size = 14, strokeWidth = 1.6, ...rest }: Props) {
       return (
         <svg {...common}>
           <rect x="6" y="6" width="12" height="12" rx="1.5" />
+        </svg>
+      );
+    case 'sun-moon':
+      return (
+        <svg {...common}>
+          <path d="M12 8a2.83 2.83 0 0 0 4 4 4 4 0 1 1-4-4" />
+          <path d="M12 2v2" />
+          <path d="M12 20v2" />
+          <path d="m4.9 4.9 1.4 1.4" />
+          <path d="m17.7 17.7 1.4 1.4" />
+          <path d="M2 12h2" />
+          <path d="M20 12h2" />
+          <path d="m6.3 17.7-1.4 1.4" />
+          <path d="m19.1 4.9-1.4 1.4" />
         </svg>
       );
     case 'tweaks':

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -15,7 +15,7 @@ import {
   MIN_MAX_TOKENS,
   modelMaxTokensDefault,
 } from '../state/maxTokens';
-import type { AgentInfo, AppConfig, AppVersionInfo, ExecMode } from '../types';
+import type { AgentInfo, AppConfig, AppTheme, AppVersionInfo, ExecMode } from '../types';
 import { MEDIA_PROVIDERS } from '../media/models';
 import type { MediaProvider } from '../media/models';
 
@@ -51,7 +51,7 @@ export function SettingsDialog({
   const [cfg, setCfg] = useState<AppConfig>(initial);
   const [showApiKey, setShowApiKey] = useState(false);
   const [languageOpen, setLanguageOpen] = useState(false);
-  const [activeSection, setActiveSection] = useState<'execution' | 'media' | 'language' | 'about'>('execution');
+  const [activeSection, setActiveSection] = useState<'execution' | 'media' | 'language' | 'appearance' | 'about'>('execution');
   const [languageMenuRect, setLanguageMenuRect] = useState<DOMRect | null>(null);
   const languageRef = useRef<HTMLDivElement | null>(null);
 
@@ -158,6 +158,17 @@ export function SettingsDialog({
               <span>
                 <strong>{t('settings.language')}</strong>
                 <small>{t('settings.languageHint')}</small>
+              </span>
+            </button>
+            <button
+              type="button"
+              className={`settings-nav-item${activeSection === 'appearance' ? ' active' : ''}`}
+              onClick={() => setActiveSection('appearance')}
+            >
+              <Icon name="sun-moon" size={18} />
+              <span>
+                <strong>{t('settings.appearance')}</strong>
+                <small>{t('settings.appearanceHint')}</small>
               </span>
             </button>
             <button
@@ -549,6 +560,10 @@ export function SettingsDialog({
           </section>
           ) : null}
 
+          {activeSection === 'appearance' ? (
+            <AppearanceSection cfg={cfg} setCfg={setCfg} />
+          ) : null}
+
           {activeSection === 'about' ? (
             <section className="settings-section">
               <div className="section-head">
@@ -706,6 +721,46 @@ function MediaProvidersSection({
             </div>
           );
         })}
+      </div>
+    </section>
+  );
+}
+
+const THEMES: Array<{ value: AppTheme; labelKey: 'settings.themeSystem' | 'settings.themeLight' | 'settings.themeDark' }> = [
+  { value: 'system', labelKey: 'settings.themeSystem' },
+  { value: 'light', labelKey: 'settings.themeLight' },
+  { value: 'dark', labelKey: 'settings.themeDark' },
+];
+
+function AppearanceSection({
+  cfg,
+  setCfg,
+}: {
+  cfg: AppConfig;
+  setCfg: Dispatch<SetStateAction<AppConfig>>;
+}) {
+  const { t } = useI18n();
+  const current = cfg.theme ?? 'system';
+  return (
+    <section className="settings-section">
+      <div className="section-head">
+        <div>
+          <h3>{t('settings.appearance')}</h3>
+          <p className="hint">{t('settings.appearanceHint')}</p>
+        </div>
+      </div>
+      <div className="seg-control" role="group" aria-label={t('settings.appearance')}>
+        {THEMES.map(({ value, labelKey }) => (
+          <button
+            key={value}
+            type="button"
+            className={'seg-btn' + (current === value ? ' active' : '')}
+            aria-pressed={current === value}
+            onClick={() => setCfg((c) => ({ ...c, theme: value }))}
+          >
+            <span className="seg-title">{t(labelKey)}</span>
+          </button>
+        ))}
       </div>
     </section>
   );

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -749,7 +749,7 @@ function AppearanceSection({
           <p className="hint">{t('settings.appearanceHint')}</p>
         </div>
       </div>
-      <div className="seg-control" role="group" aria-label={t('settings.appearance')}>
+      <div className="seg-control" role="group" aria-label={t('settings.appearance')} style={{ '--seg-cols': THEMES.length } as React.CSSProperties}>
         {THEMES.map(({ value, labelKey }) => (
           <button
             key={value}

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { Dispatch, SetStateAction } from 'react';
 import { LOCALE_LABEL, LOCALES, useI18n } from '../i18n';
 import type { Locale } from '../i18n';
@@ -49,6 +49,20 @@ export function SettingsDialog({
 }: Props) {
   const { t, locale, setLocale } = useI18n();
   const [cfg, setCfg] = useState<AppConfig>(initial);
+
+  // Revert the live theme preview when the dialog closes without saving.
+  // On Save, App's useLayoutEffect fires after unmount and applies the new
+  // saved theme, so this cleanup is effectively a no-op in that path.
+  useLayoutEffect(() => {
+    const saved = initial.theme ?? 'system';
+    return () => {
+      if (saved === 'system') {
+        document.documentElement.removeAttribute('data-theme');
+      } else {
+        document.documentElement.setAttribute('data-theme', saved);
+      }
+    };
+  }, [initial.theme]);
   const [showApiKey, setShowApiKey] = useState(false);
   const [languageOpen, setLanguageOpen] = useState(false);
   const [activeSection, setActiveSection] = useState<'execution' | 'media' | 'language' | 'appearance' | 'about'>('execution');
@@ -741,6 +755,17 @@ function AppearanceSection({
 }) {
   const { t } = useI18n();
   const current = cfg.theme ?? 'system';
+
+  // Apply the draft theme immediately so the user sees a live preview
+  // before hitting Save. SettingsDialog's cleanup reverts this on cancel.
+  useLayoutEffect(() => {
+    if (current === 'system') {
+      document.documentElement.removeAttribute('data-theme');
+    } else {
+      document.documentElement.setAttribute('data-theme', current);
+    }
+  }, [current]);
+
   return (
     <section className="settings-section">
       <div className="section-head">

--- a/apps/web/src/i18n/locales.test.ts
+++ b/apps/web/src/i18n/locales.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { en } from './locales/en';
 import { LOCALES, LOCALE_LABEL, type Dict, type Locale } from './types';
 
-const EXPECTED_LOCALES = ['en', 'de', 'zh-CN', 'zh-TW', 'pt-BR', 'es-ES', 'ru', 'fa', 'ja', 'ko'];
+const EXPECTED_LOCALES = ['en', 'de', 'zh-CN', 'zh-TW', 'pt-BR', 'es-ES', 'ru', 'fa', 'ja', 'ko', 'pl'];
 
 function placeholders(value: string): string[] {
   const names: string[] = [];

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -86,6 +86,11 @@ export const de: Dict = {
   'settings.noAgentSelected': 'kein Agent ausgewählt',
   'settings.language': 'Sprache',
   'settings.languageHint': 'Wechseln Sie die Sprache der Oberfläche. Wird in diesem Browser gespeichert.',
+  'settings.appearance': 'Erscheinungsbild',
+  'settings.appearanceHint': 'Hell, dunkel oder Systemeinstellung übernehmen.',
+  'settings.themeSystem': 'System',
+  'settings.themeLight': 'Hell',
+  'settings.themeDark': 'Dunkel',
   'settings.modelPicker': 'Modell',
   'settings.reasoningPicker': 'Reasoning-Aufwand',
   'settings.modelPickerHint':

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -86,6 +86,11 @@ export const en: Dict = {
   'settings.noAgentSelected': 'no agent selected',
   'settings.language': 'Language',
   'settings.languageHint': 'Switch the interface language. Saved to this browser.',
+  'settings.appearance': 'Appearance',
+  'settings.appearanceHint': 'Choose light, dark, or follow your system setting.',
+  'settings.themeSystem': 'System',
+  'settings.themeLight': 'Light',
+  'settings.themeDark': 'Dark',
   'settings.modelPicker': 'Model',
   'settings.reasoningPicker': 'Reasoning effort',
   'settings.modelPickerHint':

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -86,6 +86,11 @@ export const esES: Dict = {
   'settings.noAgentSelected': 'ningún agente seleccionado',
   'settings.language': 'Idioma',
   'settings.languageHint': 'Cambia el idioma de la interfaz. Se guarda en este navegador.',
+  'settings.appearance': 'Apariencia',
+  'settings.appearanceHint': 'Elige claro, oscuro o seguir la configuración del sistema.',
+  'settings.themeSystem': 'Sistema',
+  'settings.themeLight': 'Claro',
+  'settings.themeDark': 'Oscuro',
   'settings.modelPicker': 'Modelo',
   'settings.reasoningPicker': 'Esfuerzo de razonamiento',
   'settings.modelPickerHint':

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -86,6 +86,11 @@ export const fa: Dict = {
   'settings.noAgentSelected': 'هیچ عاملی انتخاب نشده',
   'settings.language': 'زبان',
   'settings.languageHint': 'زبان رابط را تغییر دهید. در این مرورگر ذخیره می‌شود.',
+  'settings.appearance': 'ظاهر',
+  'settings.appearanceHint': 'روشن، تاریک یا پیروی از تنظیمات سیستم.',
+  'settings.themeSystem': 'سیستم',
+  'settings.themeLight': 'روشن',
+  'settings.themeDark': 'تاریک',
   'settings.modelPicker': 'مدل',
   'settings.reasoningPicker': 'سطح استدلال',
   'settings.modelPickerHint':

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -86,6 +86,11 @@ export const ja: Dict = {
   'settings.noAgentSelected': 'エージェント未選択',
   'settings.language': '言語',
   'settings.languageHint': 'インターフェースの言語を切り替えます。このブラウザに保存されます。',
+  'settings.appearance': '外観',
+  'settings.appearanceHint': 'ライト、ダーク、またはシステム設定に従う。',
+  'settings.themeSystem': 'システム',
+  'settings.themeLight': 'ライト',
+  'settings.themeDark': 'ダーク',
   'settings.modelPicker': 'モデル',
   'settings.reasoningPicker': '推論の強さ',
   'settings.modelPickerHint':

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -86,6 +86,11 @@ export const ko: Dict = {
   'settings.noAgentSelected': '선택된 에이전트 없음',
   'settings.language': '언어',
   'settings.languageHint': '인터페이스 언어를 변경합니다. 이 브라우저에 저장됩니다.',
+  'settings.appearance': '화면 모드',
+  'settings.appearanceHint': '라이트, 다크 또는 시스템 설정에 따릅니다.',
+  'settings.themeSystem': '시스템',
+  'settings.themeLight': '라이트',
+  'settings.themeDark': '다크',
   'settings.modelPicker': '모델',
   'settings.reasoningPicker': '추론 (Reasoning)',
   'settings.modelPickerHint':

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -76,6 +76,9 @@ export const ko: Dict = {
   'settings.maxTokensHint':
     '응답 길이 상한입니다. 각 모델에는 기본값이 미리 조정되어 있으며(placeholder로 표시됨), 비워 두면 그 값을 사용하고 숫자를 입력하면 덮어씁니다.',
   'settings.baseUrl': 'Base URL',
+  'settings.maxTokens': '최대 토큰 수 (선택)',
+  'settings.maxTokensHint':
+    '응답 길이 제한입니다. 각 모델에는 기본값이 있습니다(플레이스홀더로 표시). 비워 두면 기본값을 사용하고, 숫자를 입력하면 재정의합니다.',
   'settings.apiHint':
     '이 브라우저에서 설정한 Base URL로 직접 호출됩니다. 프록시는 사용되지 않으며, 키는 localStorage에만 보관됩니다.',
   'settings.skipForNow': '지금은 건너뛰기',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -76,9 +76,6 @@ export const ko: Dict = {
   'settings.maxTokensHint':
     '응답 길이 상한입니다. 각 모델에는 기본값이 미리 조정되어 있으며(placeholder로 표시됨), 비워 두면 그 값을 사용하고 숫자를 입력하면 덮어씁니다.',
   'settings.baseUrl': 'Base URL',
-  'settings.maxTokens': '최대 토큰 수 (선택)',
-  'settings.maxTokensHint':
-    '응답 길이 제한입니다. 각 모델에는 기본값이 있습니다(플레이스홀더로 표시). 비워 두면 기본값을 사용하고, 숫자를 입력하면 재정의합니다.',
   'settings.apiHint':
     '이 브라우저에서 설정한 Base URL로 직접 호출됩니다. 프록시는 사용되지 않으며, 키는 localStorage에만 보관됩니다.',
   'settings.skipForNow': '지금은 건너뛰기',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -86,6 +86,11 @@ export const pl: Dict = {
   'settings.noAgentSelected': 'nie wybrano agenta',
   'settings.language': 'Język',
   'settings.languageHint': 'Zmień język interfejsu. Zapisano w tej przeglądarce.',
+  'settings.appearance': 'Wygląd',
+  'settings.appearanceHint': 'Jasny, ciemny lub zgodny z ustawieniami systemu.',
+  'settings.themeSystem': 'Systemowy',
+  'settings.themeLight': 'Jasny',
+  'settings.themeDark': 'Ciemny',
   'settings.modelPicker': 'Model',
   'settings.reasoningPicker': 'Poziom rozumowania',
   'settings.modelPickerHint':

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -86,6 +86,11 @@ export const ptBR: Dict = {
   'settings.noAgentSelected': 'nenhum agente selecionado',
   'settings.language': 'Idioma',
   'settings.languageHint': 'Altere o idioma da interface. Salvo neste navegador.',
+  'settings.appearance': 'Aparência',
+  'settings.appearanceHint': 'Escolha claro, escuro ou seguir as configurações do sistema.',
+  'settings.themeSystem': 'Sistema',
+  'settings.themeLight': 'Claro',
+  'settings.themeDark': 'Escuro',
   'settings.modelPicker': 'Modelo',
   'settings.reasoningPicker': 'Esforço de raciocínio',
   'settings.modelPickerHint':

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -86,6 +86,11 @@ export const ru: Dict = {
   'settings.noAgentSelected': 'агент не выбран',
   'settings.language': 'Язык',
   'settings.languageHint': 'Переключить язык интерфейса. Сохраняется в этом браузере.',
+  'settings.appearance': 'Внешний вид',
+  'settings.appearanceHint': 'Выберите светлую, тёмную или системную тему.',
+  'settings.themeSystem': 'Системная',
+  'settings.themeLight': 'Светлая',
+  'settings.themeDark': 'Тёмная',
   'settings.modelPicker': 'Модель',
   'settings.reasoningPicker': 'Сложность рассуждений',
   'settings.modelPickerHint':

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -86,6 +86,11 @@ export const tr: Dict = {
   'settings.noAgentSelected': 'Ajan seçilmedi',
   'settings.language': 'Dil',
   'settings.languageHint': 'Arayüz dilini değiştirin. Bu tarayıcıya kaydedilir.',
+  'settings.appearance': 'Görünüm',
+  'settings.appearanceHint': 'Açık, koyu veya sistem ayarını takip et.',
+  'settings.themeSystem': 'Sistem',
+  'settings.themeLight': 'Açık',
+  'settings.themeDark': 'Koyu',
   'settings.modelPicker': 'Model',
   'settings.reasoningPicker': 'Akıl yürütme eforu',
   'settings.modelPickerHint':

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -85,6 +85,11 @@ export const zhCN: Dict = {
   'settings.noAgentSelected': '尚未选择代理',
   'settings.language': '界面语言',
   'settings.languageHint': '切换界面语言，设置仅保存在当前浏览器。',
+  'settings.appearance': '外观',
+  'settings.appearanceHint': '选择浅色、深色或跟随系统设置。',
+  'settings.themeSystem': '系统',
+  'settings.themeLight': '浅色',
+  'settings.themeDark': '深色',
   'settings.modelPicker': '模型',
   'settings.reasoningPicker': '推理强度',
   'settings.modelPickerHint':

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -85,6 +85,11 @@ export const zhTW: Dict = {
   'settings.noAgentSelected': '尚未選擇代理',
   'settings.language': '介面語言',
   'settings.languageHint': '切換介面語言，設定僅儲存在當前瀏覽器。',
+  'settings.appearance': '外觀',
+  'settings.appearanceHint': '選擇淺色、深色或跟隨系統設定。',
+  'settings.themeSystem': '系統',
+  'settings.themeLight': '淺色',
+  'settings.themeDark': '深色',
   'settings.modelPicker': '模型',
   'settings.reasoningPicker': '推理強度',
   'settings.modelPickerHint':

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -104,6 +104,11 @@ export interface Dict {
   'settings.noAgentSelected': string;
   'settings.language': string;
   'settings.languageHint': string;
+  'settings.appearance': string;
+  'settings.appearanceHint': string;
+  'settings.themeSystem': string;
+  'settings.themeLight': string;
+  'settings.themeDark': string;
   'settings.modelPicker': string;
   'settings.reasoningPicker': string;
   'settings.modelPickerHint': string;

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -95,8 +95,6 @@ export interface Dict {
   'settings.maxTokens': string;
   'settings.maxTokensHint': string;
   'settings.baseUrl': string;
-  'settings.maxTokens': string;
-  'settings.maxTokensHint': string;
   'settings.apiHint': string;
   'settings.skipForNow': string;
   'settings.getStarted': string;

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -95,6 +95,8 @@ export interface Dict {
   'settings.maxTokens': string;
   'settings.maxTokensHint': string;
   'settings.baseUrl': string;
+  'settings.maxTokens': string;
+  'settings.maxTokensHint': string;
   'settings.apiHint': string;
   'settings.skipForNow': string;
   'settings.getStarted': string;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1115,7 +1115,7 @@ code {
 /* Segmented control */
 .seg-control {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(var(--seg-cols, 2), 1fr);
   gap: 6px;
   padding: 4px;
   background: var(--bg-subtle);
@@ -1140,7 +1140,7 @@ code {
   border-color: var(--border-strong);
   box-shadow: var(--shadow-sm);
 }
-.seg-btn .seg-title { font-size: 13px; font-weight: 600; color: var(--text); }
+.seg-btn .seg-title { font-size: 13px; font-weight: 600; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .seg-btn .seg-meta { font-size: 11px; color: var(--text-muted); letter-spacing: 0.01em; }
 .seg-btn:disabled { opacity: 0.55; cursor: not-allowed; }
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -60,6 +60,101 @@
   --mono: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace;
 }
 
+/* Dark theme variables — shared between explicit [data-theme="dark"] and the
+   OS-level prefers-color-scheme media query (system mode = no data-theme attr). */
+[data-theme="dark"] {
+  color-scheme: dark;
+  --bg: #1a1917;
+  --bg-app: #1a1917;
+  --bg-panel: #222120;
+  --bg-subtle: #272523;
+  --bg-muted: #2e2c29;
+  --bg-elevated: #2a2825;
+  --border: #333128;
+  --border-strong: #46433c;
+  --border-soft: #2a2825;
+
+  --text: #e8e4dc;
+  --text-strong: #f2ede4;
+  --text-muted: #9a9690;
+  --text-soft: #6e6b65;
+  --text-faint: #4e4b46;
+
+  --accent: #d97a56;
+  --accent-strong: #e8896a;
+  --accent-soft: #3d2318;
+  --accent-tint: #2e1a12;
+  --accent-hover: #e8896a;
+
+  --green: #4caf72;
+  --green-bg: #0f2a18;
+  --green-border: #1a4028;
+  --blue: #6b8fe8;
+  --blue-bg: #0f1a38;
+  --blue-border: #1a2c58;
+  --purple: #a87dd4;
+  --purple-bg: #1e1030;
+  --purple-border: #321a50;
+  --red: #e06b65;
+  --red-bg: #2a0e0c;
+  --red-border: #451714;
+  --amber: #e09a40;
+  --amber-bg: #2a1a04;
+
+  --shadow-xs: 0 1px 0 rgba(0, 0, 0, 0.2);
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3), 0 1px 3px rgba(0, 0, 0, 0.2);
+  --shadow-md: 0 6px 24px rgba(0, 0, 0, 0.4), 0 2px 6px rgba(0, 0, 0, 0.25);
+  --shadow-lg: 0 24px 60px rgba(0, 0, 0, 0.6), 0 8px 16px rgba(0, 0, 0, 0.3);
+}
+
+/* System mode: follow OS preference when no explicit data-theme is set. */
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme]) {
+    color-scheme: dark;
+    --bg: #1a1917;
+    --bg-app: #1a1917;
+    --bg-panel: #222120;
+    --bg-subtle: #272523;
+    --bg-muted: #2e2c29;
+    --bg-elevated: #2a2825;
+    --border: #333128;
+    --border-strong: #46433c;
+    --border-soft: #2a2825;
+
+    --text: #e8e4dc;
+    --text-strong: #f2ede4;
+    --text-muted: #9a9690;
+    --text-soft: #6e6b65;
+    --text-faint: #4e4b46;
+
+    --accent: #d97a56;
+    --accent-strong: #e8896a;
+    --accent-soft: #3d2318;
+    --accent-tint: #2e1a12;
+    --accent-hover: #e8896a;
+
+    --green: #4caf72;
+    --green-bg: #0f2a18;
+    --green-border: #1a4028;
+    --blue: #6b8fe8;
+    --blue-bg: #0f1a38;
+    --blue-border: #1a2c58;
+    --purple: #a87dd4;
+    --purple-bg: #1e1030;
+    --purple-border: #321a50;
+    --red: #e06b65;
+    --red-bg: #2a0e0c;
+    --red-border: #451714;
+    --amber: #e09a40;
+    --amber-bg: #2a1a04;
+
+    --shadow-xs: 0 1px 0 rgba(0, 0, 0, 0.2);
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3), 0 1px 3px rgba(0, 0, 0, 0.2);
+    --shadow-md: 0 6px 24px rgba(0, 0, 0, 0.4), 0 2px 6px rgba(0, 0, 0, 0.25);
+    --shadow-lg: 0 24px 60px rgba(0, 0, 0, 0.6), 0 8px 16px rgba(0, 0, 0, 0.3);
+  }
+}
+
 * { box-sizing: border-box; }
 
 html, body, #root { height: 100%; margin: 0; }
@@ -301,7 +396,7 @@ code {
   border-radius: 50%;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(135deg, #fbeee5 0%, #f5d8cb 100%);
+  background: linear-gradient(135deg, var(--accent-tint) 0%, var(--accent-soft) 100%);
   color: var(--accent);
   flex-shrink: 0;
   overflow: hidden;
@@ -333,7 +428,7 @@ code {
   height: 32px;
   padding: 0;
   border-radius: 50%;
-  background: linear-gradient(135deg, #fbeee5 0%, #f5d8cb 100%);
+  background: linear-gradient(135deg, var(--accent-tint) 0%, var(--accent-soft) 100%);
   border: 1px solid var(--border);
   display: inline-flex;
   align-items: center;
@@ -687,8 +782,8 @@ code {
   font-size: 12.5px;
 }
 .composer-send:hover:not(:disabled) { background: var(--accent-hover); border-color: var(--accent-hover); }
-.composer-send.stop { background: var(--text); border-color: var(--text); }
-.composer-send.stop:hover { background: #000; border-color: #000; }
+.composer-send.stop { background: var(--text); border-color: var(--text); color: var(--bg); }
+.composer-send.stop:hover { background: var(--text-strong); border-color: var(--text-strong); color: var(--bg); }
 .composer-hint {
   font-size: 11px;
   color: var(--text-faint);
@@ -1193,7 +1288,7 @@ code {
   width: 42px;
   height: 42px;
   border-radius: 12px;
-  background: linear-gradient(135deg, #fff 0%, var(--bg-subtle) 100%);
+  background: linear-gradient(135deg, var(--bg-panel) 0%, var(--bg-subtle) 100%);
   border: 1px solid var(--border);
   color: var(--accent);
   flex-shrink: 0;
@@ -1288,7 +1383,7 @@ code {
 }
 .agent-card.active {
   border-color: var(--accent);
-  background: linear-gradient(180deg, #fff 0%, #fff7f3 100%);
+  background: linear-gradient(180deg, var(--bg-panel) 0%, var(--accent-tint) 100%);
   box-shadow: 0 0 0 3px var(--accent-soft);
 }
 .agent-card.disabled {
@@ -1461,7 +1556,7 @@ code {
   width: 44px;
   height: 44px;
   border-radius: 50%;
-  background: linear-gradient(135deg, #fbeee5 0%, #f5d8cb 100%);
+  background: linear-gradient(135deg, var(--accent-tint) 0%, var(--accent-soft) 100%);
   color: var(--accent);
   display: inline-flex;
   align-items: center;
@@ -2556,7 +2651,7 @@ code {
 .subtab-pill button:hover:not(.active) { background: rgba(255,255,255,0.6); border-color: transparent; color: var(--text); }
 .subtab-pill button.active {
   background: var(--text);
-  color: white;
+  color: var(--bg);
   box-shadow: var(--shadow-xs);
 }
 /* Icon-only variant: any pill button whose sole child is an SVG icon.
@@ -3092,7 +3187,7 @@ code {
 .ws-tab-action:hover:not(:disabled) { background: var(--bg-subtle); color: var(--text); border-color: transparent; }
 .ws-tab-action.share {
   background: var(--text);
-  color: white;
+  color: var(--bg);
   border-color: var(--text);
   font-weight: 500;
 }
@@ -3223,7 +3318,7 @@ code {
   position: relative;
 }
 .df-row-icon[data-kind="folder"] { background: var(--bg-muted); color: var(--text-soft); }
-.df-row-icon[data-kind="html"] { background: #fbeee5; color: #b85a3b; }
+.df-row-icon[data-kind="html"] { background: var(--accent-tint); color: var(--accent-strong); }
 .df-row-icon[data-kind="image"] { background: var(--green-bg); color: var(--green); }
 .df-row-icon[data-kind="code"] { background: #fff7d8; color: #8c6700; }
 .df-row-icon[data-kind="text"] { background: var(--bg-subtle); color: var(--text-muted); }
@@ -4824,7 +4919,7 @@ code {
   gap: 12px;
   padding: 12px 14px;
   border-bottom: 1px solid var(--border);
-  background: linear-gradient(180deg, #fdf6f1 0%, var(--bg-panel) 100%);
+  background: linear-gradient(180deg, var(--accent-tint) 0%, var(--bg-panel) 100%);
 }
 .question-form-locked .question-form-head {
   background: var(--bg-subtle);

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -11,6 +11,7 @@ export const DEFAULT_CONFIG: AppConfig = {
   skillId: null,
   designSystemId: null,
   onboardingCompleted: false,
+  theme: 'system',
   mediaProviders: {},
   agentModels: {},
 };

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -41,6 +41,8 @@ export interface AgentModelChoice {
   reasoning?: string;
 }
 
+export type AppTheme = 'system' | 'light' | 'dark';
+
 export interface AppConfig {
   mode: ExecMode;
   apiKey: string;
@@ -49,6 +51,7 @@ export interface AppConfig {
   agentId: string | null;
   skillId: string | null;
   designSystemId: string | null;
+  theme?: AppTheme;
   // True once the user has been through the welcome onboarding modal at
   // least once (saved or skipped). Bootstrap skips the auto-popup when
   // this is set so refreshing the page doesn't re-prompt.


### PR DESCRIPTION
Closes #93.

Adds a three-way theme toggle (System / Light / Dark) to Settings > Appearance. The chosen preference is persisted in localStorage alongside the existing config and applied immediately via a data-theme attribute on <html>.

Implementation
- AppTheme type ('system' | 'light' | 'dark') added to AppConfig
- CSS custom properties for the dark palette defined under [data-theme="dark"] and @media (prefers-color-scheme: dark) so the System option follows the OS without JavaScript
- Appearance section added to SettingsDialog with a sun-moon icon
- Several hardcoded light-only colour values replaced with CSS variable equivalents so they adapt correctly in dark mode
- i18n: appearance/theme strings added to all 11 supported locales

Note: theme variables are currently inlined in index.css. A follow-up could extract them into per-theme files to support community themes (e.g. Catppuccin) -- happy to explore that direction if it fits the project roadmap.

Also fixes (pre-existing)
- Syntax error in locales/tr.ts that was masking missing-key errors
- Missing translation keys in de, es-ES, ja, tr locales
- locales.test.ts EXPECTED_LOCALES not updated after Korean was added