### PR TITLE
fix(daemon): include package.json in tarball so packaged app reports correct version

### DIFF
--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -20,7 +20,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "package.json"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json && tsc -p tsconfig.sidecar.json",


### PR DESCRIPTION
## Summary

The packaged app's **Settings → About** page displays version `0.0.0` instead of the actual release version, because the daemon's `package.json` is excluded from its `pnpm pack` tarball.

`Closes #224`.

## Root cause

`apps/daemon/package.json` declares:

```json
"files": ["dist"]
```

So `pnpm pack` packs only the `dist/` directory. At runtime, `readCurrentAppVersionInfo()` in [`apps/daemon/src/app-version.ts`](https://github.com/nexu-io/open-design/blob/main/apps/daemon/src/app-version.ts) resolves:

```ts
const DEFAULT_PACKAGE_JSON_URL = new URL('../package.json', import.meta.url);
```

…from the compiled `dist/app-version.js`. In a packaged install that points at the tarball's root `package.json`, which isn't packed. `readPackageMetadata()` catches the `ENOENT` silently, returns `null`, and `resolveAppVersionInfo()` falls back to the `APP_VERSION_FALLBACK = '0.0.0'` constant. `/api/version` and `/api/health` then both report `'0.0.0'` for every packaged install (Windows / macOS / Linux).

## Fix

```diff
   "files": [
-    "dist"
+    "dist",
+    "package.json"
   ],
```

The package already declares `"./package.json": "./package.json"` in its `exports` map, so consumers (including the daemon's own `app-version.ts`) already expect this file to be available. This change makes that expectation match reality in packaged builds.

This is **Option A** as proposed by @ONEGAYI in #224 and approved by @lefarcen in [the issue thread](https://github.com/nexu-io/open-design/issues/224). I chose Option A over Option B (injecting the version at build time via `tools/pack/src/win.ts`) because it's a one-line manifest change with zero new build-time machinery — the runtime keeps reading `package.json` exactly as it does in dev, so packaged and dev paths converge instead of diverging into two version-resolution modes.

## Verification

- `git diff` shows a single 1-line addition to `apps/daemon/package.json`.
- Packaged-tarball check: `cd apps/daemon && pnpm pack && tar -tzf open-design-daemon-*.tgz` lists `package/package.json` after this change (and only `package/dist/...` before).
- No code changes — purely an npm `files`-glob expansion.
- No risk to local dev or build flows: the file is already present at that path on disk during builds; only tarball composition changes.
