### PR TITLE
fix(daemon): treat .py files as previewable code in Design Files

### DIFF
--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -289,7 +289,7 @@ export function kindFor(name) {
   if (['.mp4', '.mov', '.webm'].includes(ext)) return 'video';
   if (['.mp3', '.wav', '.m4a'].includes(ext)) return 'audio';
   if (['.md', '.txt'].includes(ext)) return 'text';
-  if (['.js', '.mjs', '.cjs', '.ts', '.tsx', '.json', '.css'].includes(ext)) {
+  if (['.js', '.mjs', '.cjs', '.ts', '.tsx', '.json', '.css', '.py'].includes(ext)) {
     return 'code';
   }
   if (ext === '.pdf') return 'pdf';


### PR DESCRIPTION
## Summary

Python (`.py`) files in Design Files currently fall back to `BinaryViewer` and cannot be previewed inline, even though they are plain text and the `'code'` viewer (`TextViewer`) is already wired up for similar source files.

`Closes #61`.

## Root cause

[`kindFor()`](https://github.com/nexu-io/open-design/blob/main/apps/daemon/src/projects.ts#L278) maps a filename to a coarse \`kind\` bucket the frontend uses to pick a viewer. The \`'code'\` branch covers \`.js / .mjs / .cjs / .ts / .tsx / .json / .css\` — \`.py\` is not in the list, so Python files fall through to \`'binary'\` and [`FileViewer.tsx`](https://github.com/nexu-io/open-design/blob/main/apps/web/src/components/FileViewer.tsx) renders them with `BinaryViewer` (download / open externally only).

The frontend already renders \`'code'\` via \`TextViewer\` (\`file.kind === 'text' || file.kind === 'code'\`), so once a file lands in the \`'code'\` bucket it gets the existing read-only code preview for free — no frontend change is needed.

## Fix

```diff
-  if (['.js', '.mjs', '.cjs', '.ts', '.tsx', '.json', '.css'].includes(ext)) {
+  if (['.js', '.mjs', '.cjs', '.ts', '.tsx', '.json', '.css', '.py'].includes(ext)) {
     return 'code';
   }
```

## Scope

Kept intentionally minimal to match the issue title (`.py` only). Other commonly-requested text-like extensions are easy follow-ups if you want them as part of this PR or a later one — happy to extend either way:

- shell / config: `.sh`, `.yaml`, `.yml`, `.toml`, `.env.example`, `.ini`
- other languages: `.rb`, `.go`, `.java`, `.kt`, `.rs`, `.c`, `.cpp`, `.lua`, `.php`, `.swift`

I left those out so the diff stays single-concern; ping me if you'd prefer them bundled.

## Verification

- Single-line array extension; all callers (\`projects.ts\` itself, \`media.ts\`, \`document-preview.ts\`) only branch on the \`kind\` returned, and none gate on \`'code'\` in a way that would regress (e.g. \`document-preview.ts\` only handles \`pdf / document / presentation / spreadsheet\`).
- Frontend already handles \`'code'\` via \`TextViewer\` — no UI changes required.
- Manual: drop a \`.py\` file into Design Files in a local dev run; the side panel should show inline source instead of a download-only binary state.