### PR TITLE
fix(i18n): replace hardcoded 'Claude' with '助手' in zh-TW assistant role

### DIFF
--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -581,7 +581,7 @@ export const zhTW: Dict = {
   'tool.error': '錯誤',
   'tool.done': '完成',
 
-  'assistant.role': 'Claude',
+  'assistant.role': '助手',
   'assistant.workingLabel': '執行中',
   'assistant.doneLabel': '已完成',
   'assistant.outTokens': '{n} 輸出',


### PR DESCRIPTION
## Summary

Spotted by @lefarcen in [the follow-up review on #59](https://github.com/nexu-io/open-design/issues/59#issuecomment-4363208883): every locale file uses a neutral, localized label for `'assistant.role'` *except* `zh-TW.ts`, which still hardcodes `'Claude'`. This PR aligns it with `zh-CN`.

`Refs #59`.

## Why this matters

`'assistant.role'` is the per-message fallback used by [`assistantRoleLabel()` in `AssistantMessage.tsx`](https://github.com/nexu-io/open-design/blob/main/apps/web/src/components/AssistantMessage.tsx#L152) when no agent metadata is attached to a turn:

```ts
return agentDisplayName(starting?.detail) ?? t('assistant.role');
```

So on Traditional Chinese installs running Codex / Cursor / Gemini / OpenCode, older messages without `agentId` metadata can still render as **\"Claude\"** instead of a neutral label — exactly the symptom #59 was originally about.

## Locale audit (before this PR)

| Locale | `'assistant.role'` |
|---|---|
| `en` | `Assistant` |
| `zh-CN` | `助手` |
| **`zh-TW`** | **`Claude` ← outlier** |
| `ja` | `アシスタント` |
| `ko` | `어시스턴트 (Assistant)` |
| `de` | `Assistent` |
| `pt-BR` | `Assistente` |
| `ru` | `Ассистент` |
| `tr` | `Asistan` |
| `fa` | `دستیار` |
| `es-ES` | `Asistente` |

## Fix

```diff
-  'assistant.role': 'Claude',
+  'assistant.role': '助手',
```

`助手` is the same glyph in Simplified and Traditional Chinese, so this matches the rest of `zh-TW.ts`'s register without introducing any character-form drift.

## Verification

- Single-line locale change; no logic, no build-affecting code.
- Surrounding zh-TW values use Traditional forms (`'執行中'`, `'已完成'`) — unchanged.
- `zh-CN` already uses `'助手'`, so this is the established translation choice for this product.
- After the change, all 11 locales render a localized neutral label by default.

## Acknowledgement

I missed this when I posted [the locale audit comment on #59](https://github.com/nexu-io/open-design/issues/59#issuecomment-4363208883) — I asserted `zh-TW` matched `zh-CN` without actually checking. Thanks @lefarcen for the catch.