### PR TITLE
feat(daemon): auto-detect OpenClaude as a fallback for Claude Code

### DIFF
--- a/apps/daemon/src/agents.ts
+++ b/apps/daemon/src/agents.ts
@@ -117,6 +117,11 @@ export const AGENT_DEFS = [
     id: 'claude',
     name: 'Claude Code',
     bin: 'claude',
+    // Drop-in forks that ship a CLI argv-compatible with `claude`. Tried in
+    // order if `claude` itself isn't on PATH, so users on a single-binary
+    // install (e.g. only OpenClaude — https://github.com/Gitlawb/openclaude
+    // — issue #235) get auto-detected without writing wrapper scripts.
+    fallbackBins: ['openclaude'],
     versionArgs: ['--version'],
     helpArgs: ['--help'],
     capabilityFlags: {
@@ -543,6 +548,21 @@ export function resolveOnPath(bin) {
   return null;
 }
 
+// Resolve the first available binary for an agent definition. Tries
+// `def.bin` first, then walks `def.fallbackBins` in order. Used for
+// agents whose forks ship under a different binary name but speak the
+// exact same CLI (Claude Code → OpenClaude, issue #235). Returns null
+// when no candidate is on PATH.
+export function resolveAgentExecutable(def) {
+  if (!def?.bin) return null;
+  const candidates = [def.bin, ...(Array.isArray(def.fallbackBins) ? def.fallbackBins : [])];
+  for (const bin of candidates) {
+    const resolved = resolveOnPath(bin);
+    if (resolved) return resolved;
+  }
+  return null;
+}
+
 async function fetchModels(def, resolvedBin) {
   if (typeof def.fetchModels === 'function') {
     try {
@@ -574,7 +594,7 @@ async function fetchModels(def, resolvedBin) {
 }
 
 async function probe(def) {
-  const resolved = resolveOnPath(def.bin);
+  const resolved = resolveAgentExecutable(def);
   if (!resolved) {
     return {
       ...stripFns(def),
@@ -621,8 +641,9 @@ function stripFns(def) {
   // Drop the buildArgs / listModels closures but keep declarative metadata
   // (reasoningOptions, streamFormat, name, bin, etc.). `models` is
   // populated separately by `fetchModels`, so we strip the static
-  // `fallbackModels` slot here too. `helpArgs` / `capabilityFlags` are
-  // probe-only metadata and shouldn't bleed into the API response either.
+  // `fallbackModels` slot here too. `helpArgs` / `capabilityFlags` /
+  // `fallbackBins` are probe-only metadata and shouldn't bleed into the
+  // API response either.
   const {
     buildArgs,
     listModels,
@@ -630,6 +651,7 @@ function stripFns(def) {
     fallbackModels,
     helpArgs,
     capabilityFlags,
+    fallbackBins,
     ...rest
   } = def;
   return rest;
@@ -658,7 +680,7 @@ export function getAgentDef(id) {
 export function resolveAgentBin(id) {
   const def = getAgentDef(id);
   if (!def?.bin) return null;
-  return resolveOnPath(def.bin);
+  return resolveAgentExecutable(def);
 }
 
 // Daemon's /api/chat needs to validate the user's model pick against the

--- a/apps/daemon/tests/agents.test.ts
+++ b/apps/daemon/tests/agents.test.ts
@@ -1,13 +1,17 @@
 // @ts-nocheck
 import { afterEach, test } from 'vitest';
 import assert from 'node:assert/strict';
-import { AGENT_DEFS } from '../src/agents.js';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AGENT_DEFS, resolveAgentExecutable } from '../src/agents.js';
 
 const codex = AGENT_DEFS.find((agent) => agent.id === 'codex');
 const cursorAgent = AGENT_DEFS.find((agent) => agent.id === 'cursor-agent');
 const kiro = AGENT_DEFS.find((agent) => agent.id === 'kiro');
 const claude = AGENT_DEFS.find((agent) => agent.id === 'claude');
 const originalDisablePlugins = process.env.OD_CODEX_DISABLE_PLUGINS;
+const originalPath = process.env.PATH;
 
 afterEach(() => {
   if (originalDisablePlugins == null) {
@@ -15,6 +19,7 @@ afterEach(() => {
   } else {
     process.env.OD_CODEX_DISABLE_PLUGINS = originalDisablePlugins;
   }
+  process.env.PATH = originalPath;
 });
 
 test('codex args disable plugins when OD_CODEX_DISABLE_PLUGINS is 1', () => {
@@ -160,4 +165,99 @@ test('claude flags promptViaStdin and never embeds the prompt in argv', () => {
   // `-p` (print mode) must still be present; without it claude drops into
   // an interactive REPL that the daemon has no TTY for.
   assert.ok(args.includes('-p'), 'claude argv must include -p');
+});
+
+// ---- OpenClaude fallback (issue #235) -------------------------------------
+// OpenClaude (https://github.com/Gitlawb/openclaude) is a Claude Code fork
+// that ships under a different binary name but speaks an argv-compatible
+// CLI. Users with only `openclaude` on PATH should be auto-detected as the
+// Claude Code agent without writing a wrapper script. The mechanism is the
+// `fallbackBins` array on the Claude AGENT_DEF, consumed by
+// `resolveAgentExecutable`.
+
+test('claude entry declares openclaude as a fallback bin (issue #235)', () => {
+  assert.ok(
+    Array.isArray(claude.fallbackBins),
+    'claude.fallbackBins must be an array',
+  );
+  assert.ok(
+    claude.fallbackBins.includes('openclaude'),
+    `claude.fallbackBins must include 'openclaude'; got ${JSON.stringify(claude.fallbackBins)}`,
+  );
+});
+
+// resolveAgentExecutable touches the filesystem via existsSync; on
+// Windows resolveOnPath also walks PATHEXT extensions, which our fixture
+// files don't carry. Skip the filesystem-backed cases there — the
+// declarative `fallbackBins`-on-claude assertion above still runs on
+// every platform and is what catches regressions in the AGENT_DEF.
+const fsTest = process.platform === 'win32' ? test.skip : test;
+
+fsTest('resolveAgentExecutable prefers def.bin over fallbackBins when bin is on PATH', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'od-agents-resolve-'));
+  try {
+    writeFileSync(join(dir, 'claude'), '');
+    writeFileSync(join(dir, 'openclaude'), '');
+    chmodSync(join(dir, 'claude'), 0o755);
+    chmodSync(join(dir, 'openclaude'), 0o755);
+    process.env.PATH = dir;
+
+    const resolved = resolveAgentExecutable({
+      bin: 'claude',
+      fallbackBins: ['openclaude'],
+    });
+    assert.equal(resolved, join(dir, 'claude'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+fsTest('resolveAgentExecutable falls back through fallbackBins when def.bin is missing', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'od-agents-resolve-'));
+  try {
+    // Only `openclaude` is installed (Claude Code fork-only setup).
+    writeFileSync(join(dir, 'openclaude'), '');
+    chmodSync(join(dir, 'openclaude'), 0o755);
+    process.env.PATH = dir;
+
+    const resolved = resolveAgentExecutable({
+      bin: 'claude',
+      fallbackBins: ['openclaude'],
+    });
+    assert.equal(resolved, join(dir, 'openclaude'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+fsTest('resolveAgentExecutable returns null when neither def.bin nor any fallback is on PATH', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'od-agents-resolve-'));
+  try {
+    process.env.PATH = dir;
+
+    const resolved = resolveAgentExecutable({
+      bin: 'claude',
+      fallbackBins: ['openclaude'],
+    });
+    assert.equal(resolved, null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+fsTest('resolveAgentExecutable still resolves agents without a fallbackBins field', () => {
+  // Guard against a regression that would require every AGENT_DEF to
+  // declare fallbackBins. Most agents (codex / gemini / opencode / ...)
+  // only have a single binary name and must keep working unchanged.
+  const dir = mkdtempSync(join(tmpdir(), 'od-agents-resolve-'));
+  try {
+    writeFileSync(join(dir, 'codex'), '');
+    chmodSync(join(dir, 'codex'), 0o755);
+    process.env.PATH = dir;
+
+    const resolved = resolveAgentExecutable({ bin: 'codex' });
+    assert.equal(resolved, join(dir, 'codex'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary

Adds a generic `fallbackBins` slot on agent definitions and uses it to make [OpenClaude](https://github.com/Gitlawb/openclaude) — an argv-compatible Claude Code fork — auto-detect as the **Claude Code** agent. Users with only `openclaude` on PATH no longer need to write a wrapper script.

`Closes #235`.

## Why

Today, agent detection in [`apps/daemon/src/agents.ts`](https://github.com/nexu-io/open-design/blob/main/apps/daemon/src/agents.ts) keys off a single binary name (`def.bin`):

```ts
async function probe(def) {
  const resolved = resolveOnPath(def.bin);
  if (!resolved) {
    return { ...stripFns(def), available: false, ... };
  }
  // …
}
```

OpenClaude ships as a Node-distributed CLI under the binary name `openclaude`, so on a `openclaude`-only install Claude Code is reported as "not detected" even though the CLI is fully argv-compatible. @GarryLai (issue author) confirmed in #235 that a wrapper script (`Path B`) works, then asked for the same to happen automatically. @lefarcen replied with two designs (fallback vs separate entry) and asked which to take. This PR implements the **fallback** approach the author suggested.

## Design choice — fallback vs separate AGENT_DEFS entry

I went with **fallback** rather than a second `id: 'openclaude'` entry because:

1. The issue author explicitly preferred fallback (\"add a detention if `claude` not found then try to find `openclaude`\").
2. OpenClaude is a verbatim Claude Code fork — `buildArgs` / `fallbackModels` / `streamFormat` / `capabilityFlags` would all be duplicated. A new `fallbackBins` slot keeps the Claude config single-sourced and lets future drop-in forks be added with one extra string.
3. The agent picker stays a single \"Claude Code\" entry instead of confusingly splitting into two for what is effectively the same agent.
4. If OpenClaude ever diverges in flags, splitting it back out into its own entry is straightforward (this PR doesn't paint anyone into a corner).

If maintainers prefer the **separate-entry** shape instead, happy to redo — just say the word.

## What changes

[`apps/daemon/src/agents.ts`](https://github.com/nexu-io/open-design/blob/main/apps/daemon/src/agents.ts):

- `AGENT_DEFS[claude]` gains `fallbackBins: ['openclaude']` — a new optional declarative slot. Agents without it (codex, gemini, opencode, cursor-agent, qwen, kiro, hermes) are unchanged.
- New exported helper `resolveAgentExecutable(def)` walks `[def.bin, ...def.fallbackBins]` and returns the first PATH hit (or null). The two existing `resolveOnPath(def.bin)` callsites in `probe()` and `resolveAgentBin()` route through this helper instead of reading `def.bin` directly.
- `stripFns()` drops `fallbackBins` from the API response payload — same posture as `helpArgs` / `capabilityFlags` / probe-only metadata that shouldn't bleed into the public `/api/agents` list.

## Behavior contract

| Setup | Before | After |
|---|---|---|
| Only `claude` on PATH | Detected as Claude Code | Same — primary still wins |
| Both `claude` and `openclaude` on PATH | Detected as Claude Code | Same — `claude` always wins (candidate order matters) |
| Only `openclaude` on PATH | **Not detected** → wrapper required | **Detected as Claude Code**, all chat / model-listing / spawn paths use the resolved `openclaude` binary |
| Neither on PATH | Not detected | Same |
| Other agents (codex / gemini / …) | Detected via `def.bin` | Same — no `fallbackBins` field, unchanged path |

## Tests (5 new, all pass locally)

Added to [`apps/daemon/tests/agents.test.ts`](https://github.com/nexu-io/open-design/blob/main/apps/daemon/tests/agents.test.ts):

1. **Declarative AGENT_DEF guard** — \`claude.fallbackBins\` includes \`'openclaude'\`. Catches silent drift if someone refactors the AGENT_DEF.
2. **Primary wins** — \`resolveAgentExecutable\` returns \`def.bin\` when both candidates exist on PATH (no behavior change for users with both installed).
3. **Fallback engages** — when \`claude\` is missing but \`openclaude\` is on PATH, returns the openclaude path.
4. **All-missing returns null** — when neither candidate is on PATH, returns null (preserves the existing \"not available\" probe outcome).
5. **No-regression for single-bin agents** — defs without \`fallbackBins\` (codex / gemini / opencode / cursor-agent / qwen / kiro / hermes) still resolve through \`def.bin\` exactly as before.

The 4 filesystem-backed cases skip on Windows because \`resolveOnPath\` walks \`PATHEXT\` extensions there and the fixture files don't carry them; the declarative AGENT_DEF assertion runs on every platform.

\`\`\`
Test Files  15 passed (15)
     Tests  230 passed (230)        ← was 225 before this PR
\`\`\`

## Verification

- `pnpm --filter @open-design/daemon test` — 15 files, 230 tests pass (5 new).
- `tsc -p apps/daemon/tsconfig.json --noEmit` — clean.
- `tsc -p apps/daemon/tsconfig.tests.json --noEmit` — clean.
- Built `dist/agents.js` exports the new \`resolveAgentExecutable\` symbol.
- Manual: with `openclaude` symlinked to a no-op script and \`claude\` missing from PATH, \`/api/agents\` reports \`{ id: 'claude', available: true, path: '<path-to-openclaude>' }\` — same shape it would for an authentic `claude` install.

## Out of scope

- Doesn't change OpenClaude's npm-only distribution story (`npm install -g openclaude` still required).
- Doesn't add OpenClaude-specific model fallbacks — Claude Code's existing \`fallbackModels\` (sonnet / opus / haiku / claude-opus-4-5 / …) are reused, which matches what users would expect from a drop-in fork.
- Doesn't add other Claude forks today, but the slot is generic — adding e.g. \`'claude-pro-cli'\` later is a one-string change.