### PR TITLE
feat: macOS one-click install via tools-pack packaged mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release Desktop
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-mac:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        arch: [arm64, x64]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build app
+        run: pnpm tools-pack mac build --to app --${{ matrix.arch }}
+
+      - name: Create DMG
+        run: |
+          APP=$(find . -maxdepth 3 -name "*.app" | head -1)
+          DMG_NAME="open-design-${{ github.ref_name }}-mac-${{ matrix.arch }}.dmg"
+          hdiutil create -volname "Open Design" -srcfolder "$APP" -ov -format UDZO "$DMG_NAME"
+
+      - name: Generate SHA256 checksums
+        run: shasum -a 256 *.dmg > SHA256SUMS.txt
+
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            *.dmg
+            SHA256SUMS.txt

--- a/README.md
+++ b/README.md
@@ -321,6 +321,14 @@ pnpm tools-dev run web
 # open the web URL printed by tools-dev
 ```
 
+**macOS Desktop App (one-click install):**
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/nexu-io/open-design/main/scripts/install.sh)
+```
+
+This clones the repo, builds a self-contained `.app` via `tools-pack`, and copies it to `/Applications/`. After installation, find **Open Design** in Launchpad or Spotlight. Requires macOS and an internet connection; the script handles Node, pnpm, and all dependencies automatically.
+
 Windows launcher: build `OpenDesign.exe` yourself with the instructions in `tools/launcher/README.md`, or download it from GitHub Releases. Then place it in the repo root and double-click it to run `pnpm install` if needed and start Open Design with `pnpm tools-dev`.
 
 Environment requirements: Node `~24` and pnpm `10.33.x`. `nvm`/`fnm` are optional helpers only; if you use one, run `nvm install 24 && nvm use 24` or `fnm install 24 && fnm use 24` before `pnpm install`.

--- a/adapters/claude-code/SKILL.md
+++ b/adapters/claude-code/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: design
+description: Open Design local-first AI design tool
+model: sonnet
+---
+
+# /design — Open Design
+
+Launch or connect to your local Open Design instance.
+
+## Prerequisites
+
+- Open Design installed at `/Applications/Open Design.app` (macOS)
+- Or running via `pnpm tools-dev` in the repo
+
+## Usage
+
+1. Check if Open Design is running:
+   ```bash
+   curl -sf http://localhost:7457/api/health || echo "Not running"
+   ```
+
+2. If not running, start it:
+   - **Desktop app**: Open "Open Design" from Launchpad
+   - **Dev mode**: `cd <repo> && pnpm tools-dev run web`
+
+3. Open in browser:
+   ```bash
+   open http://localhost:7457
+   ```
+
+## Ports
+
+- Daemon: `7456` (default)
+- Web UI: `7457` (default)
+- Custom: `pnpm tools-dev run web --daemon-port <port> --web-port <port>`

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# install.sh — Open Design macOS 一鍵安裝腳本
+#
+# 使用方式：
+#   bash <(curl -s https://your-url/install.sh)
+#
+# 注意：此腳本設計為 idempotent（重跑安全），不需要 chmod +x 即可透過 bash 直接執行。
+
+set -euo pipefail
+
+# ── 顏色輸出 ────────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+info()    { echo -e "${BLUE}[INFO]${NC} $*"; }
+success() { echo -e "${GREEN}[OK]${NC}   $*"; }
+warn()    { echo -e "${YELLOW}[WARN]${NC} $*"; }
+error()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+# ── 1. 檢查 macOS ────────────────────────────────────────────────────────────
+info "檢查作業系統..."
+if [ "$(uname -s)" != "Darwin" ]; then
+  error "此腳本僅支援 macOS（Darwin）。偵測到：$(uname -s)"
+  exit 1
+fi
+success "macOS 確認。"
+
+# ── 2. 檢查 / 安裝 nvm ──────────────────────────────────────────────────────
+info "檢查 nvm..."
+# nvm 是 shell function，不是獨立執行檔；透過 source 載入
+NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+  # shellcheck source=/dev/null
+  source "$NVM_DIR/nvm.sh"
+  success "nvm 已存在（$(nvm --version)）。"
+else
+  warn "nvm 未安裝，正在安裝..."
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+  # 安裝後立即 source，使當前 shell session 可用
+  if [ -s "$NVM_DIR/nvm.sh" ]; then
+    # shellcheck source=/dev/null
+    source "$NVM_DIR/nvm.sh"
+    success "nvm 安裝完成（$(nvm --version)）。"
+  else
+    error "nvm 安裝失敗。請手動安裝後重試：https://github.com/nvm-sh/nvm"
+    exit 1
+  fi
+fi
+
+# ── 3. 安裝並使用 Node 24 ────────────────────────────────────────────────────
+info "安裝 Node.js 24..."
+nvm install 24
+nvm use 24
+success "Node.js 版本：$(node --version)"
+
+# ── 4. 啟用 corepack ─────────────────────────────────────────────────────────
+info "啟用 corepack..."
+corepack enable
+success "corepack 已啟用。"
+
+# ── 5. Clone 或 pull repo ────────────────────────────────────────────────────
+REPO_URL="https://github.com/nicepkg/open-design.git"
+INSTALL_DIR="$HOME/open-design"
+
+info "設定 open-design 原始碼到 $INSTALL_DIR..."
+if [ -d "$INSTALL_DIR/.git" ]; then
+  info "目錄已存在，執行 git pull..."
+  git -C "$INSTALL_DIR" pull --ff-only || {
+    error "git pull 失敗。請確認網路連線，或手動解決 $INSTALL_DIR 內的衝突後重試。"
+    exit 1
+  }
+  success "原始碼已更新。"
+else
+  if [ -d "$INSTALL_DIR" ] && [ "$(ls -A "$INSTALL_DIR")" ]; then
+    error "目錄 $INSTALL_DIR 已存在且非空，但不是 git repo。請手動清除後重試。"
+    exit 1
+  fi
+  info "Clone repo..."
+  git clone "$REPO_URL" "$INSTALL_DIR" || {
+    error "git clone 失敗。請確認網路連線及 repo URL：$REPO_URL"
+    exit 1
+  }
+  success "Clone 完成。"
+fi
+
+# ── 6. 安裝依賴 ──────────────────────────────────────────────────────────────
+info "安裝 pnpm 依賴..."
+cd "$INSTALL_DIR"
+pnpm install || {
+  error "pnpm install 失敗。請查看上方錯誤訊息。"
+  exit 1
+}
+success "依賴安裝完成。"
+
+# ── 7. 建置 app ──────────────────────────────────────────────────────────────
+info "建置 Open Design app（此步驟需要數分鐘）..."
+pnpm tools-pack mac build --to app || {
+  error "建置失敗。請查看上方錯誤訊息。"
+  exit 1
+}
+success "建置完成。"
+
+# ── 8. 安裝到 /Applications ──────────────────────────────────────────────────
+APP_SRC="$INSTALL_DIR/.tmp/tools-pack/out/mac/namespaces/default/builder/mac-arm64/Open Design.app"
+APP_DEST="/Applications/Open Design.app"
+
+info "安裝 Open Design.app 到 /Applications/..."
+if [ ! -d "$APP_SRC" ]; then
+  error "找不到建置產物：$APP_SRC"
+  error "請確認 pnpm tools-pack mac build --to app 是否成功完成。"
+  exit 1
+fi
+
+# 若已有舊版，先移除
+if [ -d "$APP_DEST" ]; then
+  warn "偵測到已安裝的舊版，正在覆蓋..."
+  rm -rf "$APP_DEST"
+fi
+
+cp -R "$APP_SRC" /Applications/ || {
+  error "複製 app 到 /Applications/ 失敗。可能需要管理員權限，請加上 sudo 重試最後一個步驟。"
+  exit 1
+}
+success "Open Design.app 已複製到 /Applications/。"
+
+# ── 完成 ─────────────────────────────────────────────────────────────────────
+echo ""
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${GREEN}  Open Design installed to /Applications/.${NC}"
+echo -e "${GREEN}  You can find it in Launchpad.${NC}"
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"


### PR DESCRIPTION
## Summary

Replaces the previous launchd + shell script approach from the original PR with the project's built-in `tools-pack` packaged mode.

### What changed (v2 — complete rewrite)

The original PR (#265 v1) used `apps/desktop` (shell-only Electron entry) + LaunchAgent + custom shell scripts. Reviewer feedback (thanks @mrcfps, @lefarcen) identified that the correct approach is to use the project's existing `tools-pack mac build` pipeline with `apps/packaged` as the entry point.

**This v2 is a clean rewrite** — reset to `main`, single commit:

### Files Added
- **`scripts/install.sh`** — One-line macOS installer: clones repo, installs Node 24 via nvm, builds via `pnpm tools-pack mac build --to app`, copies to `/Applications/`
- **`.github/workflows/release.yml`** — Tag-triggered CI: builds macOS `.dmg` for arm64/x64, generates SHA256 checksums, uploads to GitHub Release (`permissions: contents: write`)
- **`adapters/claude-code/SKILL.md`** — Claude Code `/design` skill for launching Open Design from CLI

### Files Modified
- **`README.md`** — Added macOS Desktop App one-click install section

### How it works

1. `apps/packaged` is the full Electron entry — it auto-starts all 3 sidecars (daemon, web, desktop) via IPC
2. `pnpm tools-pack mac build --to app` builds the self-contained `.app` bundle (copies a statically-linked Node binary into resources)
3. The `.app` goes to `/Applications/` so it appears in Launchpad and Spotlight

### Key learnings
- **Node must be statically linked**: NVM Node v24 works; Homebrew Node v25 uses shared `libnode.141.dylib` which causes `dyld` errors inside `.app`
- **Install to `/Applications/`** not `~/Applications/`: macOS Launchpad only reliably indexes the system-level folder

### Non-Goals (follow-up PRs)
- Windows support (`tools-pack` currently only has `mac` subcommand)
- Code signing / Notarization
- Homebrew Cask distribution

Closes #264