### PR TITLE
fix(desktop): show window on macOS dock activate

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -131,6 +131,10 @@ export async function runDesktopMain(
     void shutdown().finally(() => process.exit(0));
   });
 
+  app.on("activate", () => {
+    desktop.show();
+  });
+
   for (const signal of ["SIGINT", "SIGTERM"] as const) {
     process.on(signal, () => {
       void shutdown().finally(() => process.exit(0));

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -59,6 +59,7 @@ export type DesktopRuntime = {
   console(): DesktopConsoleResult;
   eval(input: DesktopEvalInput): Promise<DesktopEvalResult>;
   screenshot(input: DesktopScreenshotInput): Promise<DesktopScreenshotResult>;
+  show(): void;
   status(): DesktopStatusSnapshot;
 };
 
@@ -273,6 +274,12 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
       await mkdir(dirname(outputPath), { recursive: true });
       await writeFile(outputPath, image.toPNG());
       return { path: outputPath };
+    },
+    show() {
+      if (!window.isDestroyed()) {
+        window.show();
+        window.focus();
+      }
     },
     status() {
       return {

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -192,6 +192,15 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
   window.on("focus", () => showWindowButtons(window));
   window.on("blur", () => showWindowButtons(window));
 
+  if (process.platform === "darwin") {
+    window.on("close", (event) => {
+      if (!stopped) {
+        event.preventDefault();
+        window.hide();
+      }
+    });
+  }
+
   (window.webContents as any).on("console-message", (event: { level?: number | string; message?: string }) => {
     const level = typeof event.level === "number" ? mapConsoleLevel(event.level) : (event.level ?? "log");
     consoleEntries.push({


### PR DESCRIPTION
## Problem

On macOS, clicking the red close button on the Electron window **hides** it rather than destroying the app. Without an `app.on('activate')` handler, clicking the dock icon afterward does nothing — the window stays hidden indefinitely and the only way to get it back is `open-design restart`.

## Root cause

`index.ts` handled `window-all-closed` but not `activate`. The `activate` event fires when the user clicks the dock icon while the app is running with no visible windows — the standard macOS re-open pattern.

## Fix

- Add `app.on('activate')` in `runDesktopMain` that calls `desktop.show()`
- Add `show()` method to `DesktopRuntime` / `createDesktopRuntime` that calls `window.show()` + `window.focus()` when the window is not destroyed

This is the [standard Electron macOS pattern](https://www.electronjs.org/docs/latest/tutorial/quick-start#open-a-window-if-none-are-open-macos).

## Test

1. `open-design start`
2. Close the window with the red X button
3. Click the Open Design icon in the dock → window reappears