### PR TITLE
fix(daemon): startServer returns url/handle so sidecar IPC can boot

### DIFF
--- a/apps/daemon/sidecar/server.ts
+++ b/apps/daemon/sidecar/server.ts
@@ -62,10 +62,11 @@ function attachParentMonitor(stop: () => Promise<void>): void {
 }
 
 export async function startDaemonSidecar(runtime: SidecarRuntimeContext<SidecarStamp>): Promise<DaemonSidecarHandle> {
-  const started = await startServer({ port: parsePort(process.env[DAEMON_PORT_ENV]), returnServer: true }) as
+  const started = (await startServer({ port: parsePort(process.env[DAEMON_PORT_ENV]), returnServer: true })) as unknown as
     | string
-    | { server: Server; url: string };
-  if (typeof started === "string") {
+    | { server: Server; url: string }
+    | undefined;
+  if (started == null || typeof started === "string") {
     throw new Error("daemon startServer did not return a server handle");
   }
   const serverHandle = started;

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -2119,14 +2119,16 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
     }
   });
 
-  const server = app.listen(port, () => {
-    resolvedPort = server.address().port;
-    if (!returnServer) {
-      console.log(`[od] daemon listening on http://127.0.0.1:${resolvedPort}`);
-    }
+  const server = app.listen(port);
+  await new Promise((res, rej) => {
+    server.once('listening', res);
+    server.once('error', rej);
   });
-
-  if (returnServer) return server;
+  resolvedPort = server.address().port;
+  const url = `http://127.0.0.1:${resolvedPort}`;
+  if (returnServer) return { server, url };
+  console.log(`[od] daemon listening on ${url}`);
+  return url;
 }
 
 function randomId() {


### PR DESCRIPTION
## Problem

`pnpm tools-dev run web` consistently fails on a fresh clone of `main` (verified at `b9d8bd3`):

```
daemon did not expose status in time

daemon log tail (.tmp/tools-dev/default/logs/daemon/latest.log):
[tools-dev] launching daemon at 2026-05-02T07:32:46Z
{ "pid": 25125, "state": "running", "updatedAt": "..." }
ELIFECYCLE  Command failed with exit code 1.
```

The daemon process spawns and exits 0 — but never opens its sidecar IPC socket at `/tmp/open-design/ipc/<namespace>/daemon.sock`, so `tools-dev` times out after 35s in `waitForDaemonRuntime`.

## Root cause

`apps/daemon/src/server.ts#startServer` returns either:
- `undefined` (default), or
- a raw `http.Server` (when `returnServer: true`)

…but two callers expect different shapes:

1. **`apps/daemon/src/cli.ts`** awaits a `url` string and prints `[od] listening on ${url}` — gets `[od] listening on undefined` because nothing is returned in default mode.

2. **`apps/daemon/sidecar/server.ts:65`** casts the result to `string | { server: Server; url: string }`, which:
   - fails `tsc -p tsconfig.sidecar.json` with `TS2352: Conversion of type 'Server | undefined' to type 'string | { server, url }' may be a mistake` (so `pnpm --filter @open-design/daemon build` errors out), and
   - at runtime never matches the `{ server, url }` shape, so `serverHandle.url` is `undefined` and the IPC server is never wired against a real URL.

Net effect: the daemon's HTTP listener boots (`app.listen` is called), but the sidecar IPC socket creation in `startDaemonSidecar` never succeeds, so `tools-dev` can't reach the daemon.

## Fix

Make `startServer` `await` the `listening` event and return the canonical shape per caller:

```ts
const server = app.listen(port);
await new Promise((res, rej) => {
  server.once('listening', res);
  server.once('error', rej);
});
const url = `http://127.0.0.1:${server.address().port}`;
if (returnServer) return { server, url };
console.log(`[od] daemon listening on ${url}`);
return url;
```

In `apps/daemon/sidecar/server.ts`, narrow via `unknown` and reject `undefined`:

```ts
const started = (await startServer({ ..., returnServer: true })) as unknown as
  | string
  | { server: Server; url: string }
  | undefined;
if (started == null || typeof started === "string") {
  throw new Error("daemon startServer did not return a server handle");
}
```

## Verification

Local clone of `main` at `b9d8bd3` on macOS, Node 24.7.0, pnpm 10.33.2:

- Before: `pnpm tools-dev run web` -> "daemon did not expose status in time" after 35s.
- After: `pnpm tools-dev run web` -> "Open Design dev server ready" with both web + daemon URLs printed in seconds.
- `pnpm --filter @open-design/daemon build` clean (was failing with TS2352).
- `tools-dev check` reports daemon + web as running.

Two-file change. No behavior change for callers that already worked.