### PR TITLE
feat(media): integrate xAI Grok Imagine (image + video + native audio)

### DIFF
--- a/apps/daemon/src/media-config.ts
+++ b/apps/daemon/src/media-config.ts
@@ -32,6 +32,10 @@ const ENV_KEYS = {
     'AZURE_OPENAI_API_KEY',
   ],
   volcengine: ['OD_VOLCENGINE_API_KEY', 'ARK_API_KEY', 'VOLCENGINE_API_KEY'],
+  // xAI canonical env is XAI_API_KEY (per docs.x.ai quickstart). We
+  // honour that ahead of any reserved OD_* override so users who already
+  // export it for the official SDK don't have to re-paste into Settings.
+  grok: ['OD_GROK_API_KEY', 'XAI_API_KEY'],
   bfl: ['OD_BFL_API_KEY', 'BFL_API_KEY'],
   fal: ['OD_FAL_KEY', 'FAL_KEY'],
   replicate: ['OD_REPLICATE_API_TOKEN', 'REPLICATE_API_TOKEN'],

--- a/apps/daemon/src/media-config.ts
+++ b/apps/daemon/src/media-config.ts
@@ -32,9 +32,10 @@ const ENV_KEYS = {
     'AZURE_OPENAI_API_KEY',
   ],
   volcengine: ['OD_VOLCENGINE_API_KEY', 'ARK_API_KEY', 'VOLCENGINE_API_KEY'],
-  // xAI canonical env is XAI_API_KEY (per docs.x.ai quickstart). We
-  // honour that ahead of any reserved OD_* override so users who already
-  // export it for the official SDK don't have to re-paste into Settings.
+  // OD_GROK_API_KEY first (the project-reserved override, same shape as
+  // every other provider above), then XAI_API_KEY as the canonical
+  // upstream env per docs.x.ai quickstart — so users who already export
+  // it for the official SDK don't have to re-paste into Settings.
   grok: ['OD_GROK_API_KEY', 'XAI_API_KEY'],
   bfl: ['OD_BFL_API_KEY', 'BFL_API_KEY'],
   fal: ['OD_FAL_KEY', 'FAL_KEY'],

--- a/apps/daemon/src/media-models.ts
+++ b/apps/daemon/src/media-models.ts
@@ -11,6 +11,7 @@
 export const MEDIA_PROVIDERS = [
   { id: 'openai', label: 'OpenAI', hint: 'gpt-image-2 / dall-e-3', integrated: true, defaultBaseUrl: 'https://api.openai.com/v1' },
   { id: 'volcengine', label: 'Volcengine Ark (Doubao)', hint: 'Seedance 2.0 / Seedream', integrated: true, defaultBaseUrl: 'https://ark.cn-beijing.volces.com/api/v3' },
+  { id: 'grok', label: 'xAI Grok Imagine', hint: 'grok-imagine — image + video with native audio', integrated: true, defaultBaseUrl: 'https://api.x.ai/v1' },
   { id: 'hyperframes', label: 'HyperFrames', hint: 'Local HTML -> MP4 renderer', integrated: true, credentialsRequired: false, settingsVisible: false },
   { id: 'bfl', label: 'Black Forest Labs', hint: 'FLUX 1.1 Pro / FLUX Pro / Dev', integrated: false, defaultBaseUrl: 'https://api.bfl.ai' },
   { id: 'fal', label: 'Fal.ai', hint: 'Sora / Seedance / Veo / FLUX', integrated: false, defaultBaseUrl: 'https://fal.run' },
@@ -37,6 +38,8 @@ export const IMAGE_MODELS = [
   { id: 'doubao-seedream-3-0-t2i-250415', label: 'seedream-3.0', hint: 'ByteDance · Doubao image', provider: 'volcengine', caps: ['t2i'] },
   { id: 'doubao-seededit-3-0-i2i-250628', label: 'seededit-3.0', hint: 'ByteDance · image edit', provider: 'volcengine', caps: ['i2i'] },
 
+  { id: 'grok-imagine-image', label: 'grok-imagine-image', hint: 'xAI · 2K text-to-image', provider: 'grok', caps: ['t2i'] },
+
   { id: 'flux-1.1-pro', label: 'flux-1.1-pro', hint: 'BFL · flagship', provider: 'bfl', caps: ['t2i', 'i2i'] },
   { id: 'flux-pro', label: 'flux-pro', hint: 'BFL', provider: 'bfl', caps: ['t2i'] },
   { id: 'flux-dev', label: 'flux-dev', hint: 'BFL · open weights', provider: 'bfl', caps: ['t2i'] },
@@ -60,6 +63,8 @@ export const VIDEO_MODELS = [
   { id: 'doubao-seedance-1-0-pro-250528', label: 'seedance-1.0-pro', hint: 'ByteDance · 1.0', provider: 'volcengine', caps: ['t2v', 'i2v'] },
   { id: 'doubao-seedance-1-0-lite-i2v-250428', label: 'seedance-1.0-lite-i2v', hint: 'ByteDance · image-to-video', provider: 'volcengine', caps: ['i2v'] },
   { id: 'doubao-seedance-1-0-lite-t2v-250428', label: 'seedance-1.0-lite-t2v', hint: 'ByteDance · text-to-video', provider: 'volcengine', caps: ['t2v'] },
+
+  { id: 'grok-imagine-video', label: 'grok-imagine-video', hint: 'xAI · 720p t2v + i2v + native audio', provider: 'grok', caps: ['t2v', 'i2v', 'audio'] },
 
   { id: 'kling-2.0', label: 'kling-2.0', hint: 'Kuaishou · latest', provider: 'kling', caps: ['t2v', 'i2v'] },
   { id: 'kling-1.6', label: 'kling-1.6', hint: 'Kuaishou', provider: 'kling', caps: ['t2v', 'i2v'] },

--- a/apps/daemon/src/media.ts
+++ b/apps/daemon/src/media.ts
@@ -24,6 +24,10 @@
 //   * provider 'volcengine' → Volcengine Ark async tasks API for
 //                              Doubao Seedance 2.0 (video) and Seedream
 //                              (image)
+//   * provider 'grok'       → xAI Imagine API: synchronous
+//                              /v1/images/generations for grok-imagine-image
+//                              and async /v1/videos/generations + GET poll
+//                              for grok-imagine-video (t2v + i2v + audio)
 //
 // The fallback stub handlers are gated behind OD_MEDIA_ALLOW_STUBS=1; in
 // release builds they throw StubProviderDisabledError (mapped to HTTP
@@ -347,6 +351,16 @@ export async function generateMedia(args) {
       suggestedExt = result.suggestedExt;
     } else if (def.provider === 'volcengine' && surface === 'image') {
       const result = await renderVolcengineImage(ctx, credentials);
+      bytes = result.bytes;
+      providerNote = result.providerNote;
+      suggestedExt = result.suggestedExt;
+    } else if (def.provider === 'grok' && surface === 'image') {
+      const result = await renderGrokImage(ctx, credentials);
+      bytes = result.bytes;
+      providerNote = result.providerNote;
+      suggestedExt = result.suggestedExt;
+    } else if (def.provider === 'grok' && surface === 'video') {
+      const result = await renderGrokVideo(ctx, credentials, args.onProgress);
       bytes = result.bytes;
       providerNote = result.providerNote;
       suggestedExt = result.suggestedExt;
@@ -944,6 +958,233 @@ async function renderVolcengineImage(ctx, credentials) {
     providerNote: `volcengine/${ctx.model} · ${ctx.aspect} · ${bytes.length} bytes`,
     suggestedExt: '.png',
   };
+}
+
+// ---------------------------------------------------------------------------
+// Provider: xAI Grok Imagine.
+//
+// Docs: https://docs.x.ai/developers/model-capabilities/{images,video}/generation
+//   * Image: POST /v1/images/generations — synchronous, returns
+//            {data:[{b64_json|url}]}; we ask for b64_json so the bytes
+//            arrive in one round-trip.
+//   * Video: POST /v1/videos/generations — may return the finished video
+//            inline ({status:'done', video:{url}}) or an async stub
+//            ({id, status:'pending'}); in the async case we poll
+//            GET /v1/videos/{id} until status flips to done/failed.
+//
+// xAI's video model produces native audio (background music + SFX +
+// ambient) synchronised with the visual; that's the headline
+// differentiator vs Seedance and Sora and is why grok-imagine-video
+// declares the `audio` capability.
+// ---------------------------------------------------------------------------
+
+async function renderGrokImage(ctx, credentials) {
+  if (!credentials.apiKey) {
+    throw new Error(
+      'no xAI API key — configure it in Settings or set XAI_API_KEY',
+    );
+  }
+  const baseUrl = (credentials.baseUrl || 'https://api.x.ai/v1').replace(/\/$/, '');
+
+  const aspectRatio = grokAspectFor(ctx.aspect);
+  const body = {
+    model: ctx.model,
+    prompt: ctx.prompt || 'A high-quality reference image.',
+    n: 1,
+    aspect_ratio: aspectRatio,
+    response_format: 'b64_json',
+  };
+  const resp = await fetch(`${baseUrl}/images/generations`, {
+    method: 'POST',
+    headers: {
+      'authorization': `Bearer ${credentials.apiKey}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  const text = await resp.text();
+  if (!resp.ok) {
+    throw new Error(`grok image ${resp.status}: ${truncate(text, 240)}`);
+  }
+  let data;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    throw new Error(`grok image non-JSON: ${truncate(text, 200)}`);
+  }
+  const entry = data && Array.isArray(data.data) ? data.data[0] : null;
+  if (!entry) throw new Error('grok image response had no data[0]');
+  let bytes;
+  if (entry.b64_json) {
+    bytes = Buffer.from(entry.b64_json, 'base64');
+  } else if (entry.url) {
+    const imgResp = await fetch(entry.url);
+    if (!imgResp.ok) throw new Error(`grok image fetch ${imgResp.status}`);
+    bytes = Buffer.from(await imgResp.arrayBuffer());
+  } else {
+    throw new Error('grok image response missing b64_json/url');
+  }
+  // xAI's Imagine returns JPEG by default (no format option in the API
+  // surface), but PNG/WebP are technically possible. Sniff the magic
+  // bytes so the on-disk extension matches reality — saving JPEG bytes
+  // as `.png` confuses Finder previews and any downstream consumer that
+  // trusts the extension.
+  return {
+    bytes,
+    providerNote: `grok/${ctx.model} · ${aspectRatio} · ${bytes.length} bytes`,
+    suggestedExt: sniffImageExt(bytes),
+  };
+}
+
+function sniffImageExt(bytes) {
+  if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+    return '.jpg';
+  }
+  if (
+    bytes.length >= 8
+    && bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47
+  ) {
+    return '.png';
+  }
+  if (
+    bytes.length >= 12
+    && bytes[0] === 0x52 && bytes[1] === 0x49 && bytes[2] === 0x46 && bytes[3] === 0x46
+    && bytes[8] === 0x57 && bytes[9] === 0x45 && bytes[10] === 0x42 && bytes[11] === 0x50
+  ) {
+    return '.webp';
+  }
+  return '.png';
+}
+
+async function renderGrokVideo(ctx, credentials, onProgress) {
+  if (!credentials.apiKey) {
+    throw new Error(
+      'no xAI API key — configure it in Settings or set XAI_API_KEY',
+    );
+  }
+  const baseUrl = (credentials.baseUrl || 'https://api.x.ai/v1').replace(/\/$/, '');
+
+  // Grok caps duration at 15s. The dispatcher already clamps to
+  // VIDEO_LENGTHS_SEC (which goes up to 30) — re-clamp here so a user
+  // who picked 30 doesn't bounce off the upstream API with a 4xx.
+  const requested = ctx.length || 5;
+  const durationSec = Math.min(Math.max(requested, 1), 15);
+  const aspectRatio = grokAspectFor(ctx.aspect);
+
+  const body = {
+    model: ctx.model,
+    prompt: ctx.prompt || 'A short cinematic clip.',
+    duration: durationSec,
+    aspect_ratio: aspectRatio,
+    resolution: '720p',
+  };
+  if (ctx.imageRef && ctx.imageRef.dataUrl) {
+    // grok-imagine-video accepts a base64 data URI in `image` for i2v.
+    // Same surface as Seedance — the dispatcher already produced the
+    // data URL via resolveProjectImage, so we just hand it through.
+    body.image = ctx.imageRef.dataUrl;
+  }
+
+  const submitResp = await fetch(`${baseUrl}/videos/generations`, {
+    method: 'POST',
+    headers: {
+      'authorization': `Bearer ${credentials.apiKey}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  const submitText = await submitResp.text();
+  if (!submitResp.ok) {
+    throw new Error(`grok video submit ${submitResp.status}: ${truncate(submitText, 240)}`);
+  }
+  let submitData;
+  try {
+    submitData = JSON.parse(submitText);
+  } catch {
+    throw new Error(`grok video non-JSON: ${truncate(submitText, 200)}`);
+  }
+
+  // Two paths: (a) the API returned the finished video synchronously
+  // (cached/short jobs), in which case we skip polling; (b) we got an
+  // {id, status:'pending'} stub and need to poll GET /videos/{id}
+  // until status flips to done/failed/expired.
+  let videoUrl = submitData?.video?.url || null;
+  let lastStatus = submitData?.status || '';
+  const requestId = submitData?.id || submitData?.request_id || null;
+
+  if (!videoUrl && requestId) {
+    const startedAt = Date.now();
+    const configuredMaxMs = Number(process.env.OD_GROK_VIDEO_MAX_POLL_MS);
+    const maxMs =
+      Number.isFinite(configuredMaxMs) && configuredMaxMs >= 60_000
+        ? configuredMaxMs
+        : 8 * 60 * 1000;
+    if (typeof onProgress === 'function') {
+      const mode = ctx.imageRef ? 'i2v' : 't2v';
+      onProgress(`grok ${mode} task ${requestId} accepted; polling status…`);
+    }
+    while (Date.now() - startedAt < maxMs) {
+      await sleep(4000);
+      const pollResp = await fetch(`${baseUrl}/videos/${encodeURIComponent(requestId)}`, {
+        headers: { 'authorization': `Bearer ${credentials.apiKey}` },
+      });
+      const pollText = await pollResp.text();
+      if (!pollResp.ok) {
+        throw new Error(`grok poll ${pollResp.status}: ${truncate(pollText, 240)}`);
+      }
+      let pollData;
+      try {
+        pollData = JSON.parse(pollText);
+      } catch {
+        throw new Error(`grok poll non-JSON: ${truncate(pollText, 200)}`);
+      }
+      lastStatus = pollData.status || '';
+      if (typeof onProgress === 'function') {
+        const elapsedSec = Math.round((Date.now() - startedAt) / 1000);
+        onProgress(`grok task ${requestId} status=${lastStatus || 'pending'} (elapsed ${elapsedSec}s)`);
+      }
+      if (lastStatus === 'done' || lastStatus === 'succeeded') {
+        videoUrl = pollData?.video?.url || null;
+        break;
+      }
+      if (lastStatus === 'failed' || lastStatus === 'expired') {
+        const reasonRaw = pollData?.error?.message || pollData?.error || lastStatus;
+        const reason = typeof reasonRaw === 'string' ? reasonRaw : JSON.stringify(reasonRaw);
+        throw new Error(`grok task ${lastStatus}: ${reason}`);
+      }
+    }
+  }
+
+  if (!videoUrl) {
+    throw new Error(`grok task did not return a video url (last status: ${lastStatus || 'unknown'})`);
+  }
+
+  const dlResp = await fetch(videoUrl);
+  if (!dlResp.ok) throw new Error(`grok video fetch ${dlResp.status}`);
+  const arr = await dlResp.arrayBuffer();
+  const bytes = Buffer.from(arr);
+
+  return {
+    bytes,
+    providerNote: `grok/${ctx.model} · ${aspectRatio} · ${durationSec}s · ${bytes.length} bytes`,
+    suggestedExt: '.mp4',
+  };
+}
+
+function grokAspectFor(aspect) {
+  // xAI accepts a wide list (1:1, 16:9, 9:16, 4:3, 3:4, 3:2, 2:3, 2:1,
+  // 1:2, 19.5:9, 9:19.5, 20:9, 9:20, auto). Our MEDIA_ASPECTS subset
+  // is a strict subset — pass through known values, otherwise 16:9.
+  if (
+    aspect === '1:1'
+    || aspect === '16:9'
+    || aspect === '9:16'
+    || aspect === '4:3'
+    || aspect === '3:4'
+  ) {
+    return aspect;
+  }
+  return '16:9';
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/daemon/src/media.ts
+++ b/apps/daemon/src/media.ts
@@ -1153,10 +1153,30 @@ async function renderGrokVideo(ctx, credentials, onProgress) {
         throw new Error(`grok task ${lastStatus}: ${reason}`);
       }
     }
+    // Loop exited without a videoUrl. Distinguish the two reachable
+    // cases so operators know which lever to pull: bumping the poll
+    // ceiling (timeout) vs filing a bug against the upstream contract
+    // (status=done but no video.url).
+    if (!videoUrl) {
+      const elapsedSec = Math.round((Date.now() - startedAt) / 1000);
+      const ceilingSec = Math.round(maxMs / 1000);
+      throw new Error(
+        `grok video timed out after ${elapsedSec}s waiting for status=done `
+        + `(last status: ${lastStatus || 'pending'}, ceiling ${ceilingSec}s). `
+        + `If your jobs legitimately need longer, raise OD_GROK_VIDEO_MAX_POLL_MS.`,
+      );
+    }
   }
 
   if (!videoUrl) {
-    throw new Error(`grok task did not return a video url (last status: ${lastStatus || 'unknown'})`);
+    // Submit returned neither an inline video.url nor a request_id —
+    // upstream broke its own contract. Surfacing the last status helps
+    // pinpoint whether it was a transient API blip or a malformed
+    // response we should add a parser branch for.
+    throw new Error(
+      `grok video submit returned no inline video and no request_id to poll `
+      + `(status=${lastStatus || 'unknown'})`,
+    );
   }
 
   const dlResp = await fetch(videoUrl);

--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -1453,8 +1453,8 @@ function MediaProjectOptions(props:
 
 function supportedModels(surface: 'image' | 'video' | 'audio', models: MediaModel[]): MediaModel[] {
   const supportedProviders: Record<'image' | 'video' | 'audio', Set<string>> = {
-    image: new Set(['openai', 'volcengine']),
-    video: new Set(['volcengine', 'hyperframes']),
+    image: new Set(['openai', 'volcengine', 'grok']),
+    video: new Set(['volcengine', 'hyperframes', 'grok']),
     audio: new Set(['minimax', 'fishaudio']),
   };
   return models.filter((model) => {

--- a/apps/web/src/i18n/locales.test.ts
+++ b/apps/web/src/i18n/locales.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { en } from './locales/en';
 import { LOCALES, LOCALE_LABEL, type Dict, type Locale } from './types';
 
-const EXPECTED_LOCALES = ['en', 'de', 'zh-CN', 'zh-TW', 'pt-BR', 'es-ES', 'ru', 'fa', 'ja', 'ko'];
+const EXPECTED_LOCALES = ['en', 'de', 'zh-CN', 'zh-TW', 'pt-BR', 'es-ES', 'ru', 'fa', 'ja', 'ko', 'pl'];
 
 function placeholders(value: string): string[] {
   const names: string[] = [];

--- a/apps/web/src/media/models.ts
+++ b/apps/web/src/media/models.ts
@@ -30,6 +30,7 @@ import type { AudioKind, MediaAspect } from '../types';
 export type MediaProviderId =
   | 'openai'
   | 'volcengine'
+  | 'grok'
   | 'hyperframes'
   | 'bfl'
   | 'fal'
@@ -84,6 +85,14 @@ export const MEDIA_PROVIDERS: MediaProvider[] = [
     integrated: true,
     defaultBaseUrl: 'https://ark.cn-beijing.volces.com/api/v3',
     docsUrl: 'https://console.volcengine.com/ark',
+  },
+  {
+    id: 'grok',
+    label: 'xAI Grok Imagine',
+    hint: 'grok-imagine — image + video with native audio',
+    integrated: true,
+    defaultBaseUrl: 'https://api.x.ai/v1',
+    docsUrl: 'https://docs.x.ai/developers/model-capabilities/video/generation',
   },
   {
     id: 'hyperframes',
@@ -265,6 +274,15 @@ export const IMAGE_MODELS: MediaModel[] = [
     caps: ['i2i'],
   },
 
+  // xAI Grok Imagine — text-to-image (1k/2k, 11+ aspect ratios).
+  {
+    id: 'grok-imagine-image',
+    label: 'grok-imagine-image',
+    hint: 'xAI · 2K text-to-image',
+    provider: 'grok',
+    caps: ['t2i'],
+  },
+
   // Black Forest Labs FLUX family.
   { id: 'flux-1.1-pro', label: 'flux-1.1-pro', hint: 'BFL · flagship', provider: 'bfl', caps: ['t2i', 'i2i'] },
   { id: 'flux-pro', label: 'flux-pro', hint: 'BFL', provider: 'bfl', caps: ['t2i'] },
@@ -327,6 +345,15 @@ export const VIDEO_MODELS: MediaModel[] = [
     hint: 'ByteDance · text-to-video',
     provider: 'volcengine',
     caps: ['t2v'],
+  },
+
+  // xAI Grok Imagine — 720p t2v + i2v with natively generated audio.
+  {
+    id: 'grok-imagine-video',
+    label: 'grok-imagine-video',
+    hint: 'xAI · 720p t2v + i2v + native audio',
+    provider: 'grok',
+    caps: ['t2v', 'i2v', 'audio'],
   },
 
   // Kuaishou Kling.


### PR DESCRIPTION
## Summary

- Adds **xAI Grok Imagine** as a real media provider alongside OpenAI, Volcengine, and HyperFrames — surfaces as `grok-imagine-image` (t2i) and `grok-imagine-video` (t2v + i2v + native audio).
- Image goes through synchronous `POST /v1/images/generations` with `b64_json` (one round-trip); video uses `POST /v1/videos/generations` + `GET /v1/videos/{id}` polling with the same 4s-tick + onProgress heartbeat pattern as the Volcengine handler.
- Native AAC audio is generated alongside the H.264 video in a single file — that's the differentiator vs Seedance and Sora and is why the model declares the `audio` capability.
- Credentials honour `XAI_API_KEY` (canonical, matches the official SDK) or `OD_GROK_API_KEY` ahead of anything pasted into Settings; the Settings UI picks up the provider automatically off `MEDIA_PROVIDERS`. Picker visibility added to the hardcoded surface→provider allowlist in `NewProjectPanel.tsx`.

## Test plan

- [x] `node scripts/verify-media-models.mjs` — TS/JS registry parity holds
- [x] `pnpm --filter @open-design/daemon test` — 225/225 pass, no regressions
- [x] `pnpm --filter @open-design/daemon build` — clean
- [x] Live `grok-imagine-image` round-trip — 1024×1024 JPEG, real provider call, sniffer lands `.jpg` extension
- [x] Live `grok-imagine-video` round-trip — 5s 16:9 H.264 + AAC, ~46s wall clock, `pending → done` poll loop verified
- [x] `pnpm tools-dev start web` + browser refresh — `xAI Grok Imagine` group appears in New Video / New Image picker; Settings shows `configured · source: env`
- [ ] Reviewer: spot-check the polling loop tolerates an `expired` status (rare; surfaces as a clean throw)
- [ ] Reviewer: confirm `OD_GROK_VIDEO_MAX_POLL_MS` override works for very long jobs (default 8 min)

## Out of scope (follow-ups)

- Image edit via `/v1/images/edits` (declare `i2i` cap on `grok-imagine-image`)
- Spicy mode toggle (default Normal; product decision)
- Curated prompt-template gallery JSONs for Grok under `prompt-templates/{image,video}/`