### PR TITLE
fix(desktop): launch reliably on Windows from Electron-based parent shells

### DIFF
--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -168,6 +168,18 @@ function showWindowButtons(window: BrowserWindow): void {
   window.setWindowButtonVisibility(true);
 }
 
+// Windows focus-stealing prevention can leave a detached-spawned GUI
+// window minimized or hidden even when constructed with show:true,
+// leaving users unable to locate the window. Cross-platform safe: only
+// acts when the window is actually minimized or hidden, preserving any
+// user-adjusted window state.
+function ensureWindowVisible(window: BrowserWindow): void {
+  if (window.isDestroyed()) return;
+  if (window.isMinimized()) window.restore();
+  if (!window.isVisible()) window.show();
+  window.focus();
+}
+
 export async function createDesktopRuntime(options: DesktopRuntimeOptions): Promise<DesktopRuntime> {
   const consoleEntries: DesktopConsoleEntry[] = [];
   const window = new BrowserWindow({
@@ -205,6 +217,7 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
 
   await window.loadURL(createPendingHtml());
   showWindowButtons(window);
+  ensureWindowVisible(window);
 
   const schedule = (delayMs: number) => {
     if (stopped) return;

--- a/tools/dev/src/index.ts
+++ b/tools/dev/src/index.ts
@@ -509,16 +509,39 @@ async function spawnDesktopRuntime(config: ToolDevConfig, options: CliOptions): 
   try {
     await buildDesktop(config, logHandle);
     await logHandle.write(`[tools-dev] launching desktop at ${new Date().toISOString()}\n`);
+    const spawnEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      ...env,
+      ...(options.parentPid == null ? {} : { [TOOLS_DEV_PARENT_PID_ENV]: String(options.parentPid) }),
+    };
+    // ELECTRON_RUN_AS_NODE=1 makes Electron boot as plain Node and skip
+    // main-process API injection (app, BrowserWindow, protocol all become
+    // undefined). Strip it from the spawn env so desktop always boots in
+    // real Electron mode even when the parent shell is an Electron-based
+    // IDE that sets this variable for sidecar reuse.
+    //
+    // Iterate keys with a case-insensitive comparison rather than
+    // `delete spawnEnv.ELECTRON_RUN_AS_NODE`: spreading process.env into
+    // a plain object loses Node's Windows case-insensitive proxy, so any
+    // alternate-cased variant (e.g. `electron_run_as_node`) would still
+    // be passed to the child and Win32 CreateProcess would treat it as
+    // the same variable, undoing the fix.
+    //
+    // Scope is tools-dev only. The packaged runtime intentionally sets
+    // ELECTRON_RUN_AS_NODE on its own daemon/web sidecars (see
+    // apps/packaged/src/sidecars.ts) to reuse the bundled Node binary;
+    // that flow is independent and untouched here.
+    for (const key of Object.keys(spawnEnv)) {
+      if (key.toUpperCase() === "ELECTRON_RUN_AS_NODE") {
+        delete spawnEnv[key];
+      }
+    }
     const spawned = await spawnBackgroundProcess({
       args: [config.apps.desktop.mainEntryPath, ...stampArgs],
       command: config.apps.desktop.electronBinaryPath,
       cwd: config.workspaceRoot,
       detached: true,
-      env: {
-        ...process.env,
-        ...env,
-        ...(options.parentPid == null ? {} : { [TOOLS_DEV_PARENT_PID_ENV]: String(options.parentPid) }),
-      },
+      env: spawnEnv,
       logFd: logHandle.fd,
     });
     return { pid: spawned.pid };


### PR DESCRIPTION
Closes #291

## Summary

Fixes two Windows-specific issues that prevent `pnpm tools-dev start desktop` from working when run from an Electron-based IDE shell (Claude Code, VSCode, etc.). Both symptoms surface in a single user journey, so they are bundled here. Full diagnosis in #291.

1. Inherited `ELECTRON_RUN_AS_NODE=1` makes `electron.exe` boot as plain Node, breaking every `import { ... } from "electron"` call.
2. Detached BrowserWindow created via `tools-dev` spawn lands `isVisible() === false` due to Windows focus-stealing prevention, leaving the window hidden from the user.

## Changes

- **`tools/dev/src/index.ts`** (commit 1) — strip `ELECTRON_RUN_AS_NODE` from the spawn env in `spawnDesktopRuntime`. Defensive; no-op when caller has not set the variable. The packaged runtime still sets `ELECTRON_RUN_AS_NODE=1` for its own daemon/web sidecars at `apps/packaged/src/sidecars.ts:162`, which is a separate, intentional use that this change does not affect.
- **`apps/desktop/src/main/runtime.ts`** (commit 2) — add a small `ensureWindowVisible(window)` helper called once after the placeholder URL loads. Cross-platform safe: only restores when minimized, only shows when hidden, then focuses. macOS behavior preserved (the `darwin`-only window-chrome helpers remain unchanged).

## Test plan

- [x] `pnpm --filter @open-design/desktop typecheck` — green
- [x] `pnpm --filter @open-design/packaged typecheck` — green
- [x] `pnpm --filter @open-design/tools-dev typecheck` — green
- [x] With `ELECTRON_RUN_AS_NODE=1` still set in parent shell: `pnpm tools-dev start desktop` boots Electron correctly, window appears on screen, `tools-dev inspect desktop status` reports `windowVisible: true`
- [x] Without env set (clean shell): no observed behavior change
- [ ] macOS / Linux: not validated locally — changes are no-ops on already-working paths but a maintainer cross-check would be appreciated

## Notes

- Code comments are English per CONTRIBUTING.md.
- Two commits intentionally split by scope (`tools-dev` vs `desktop`) so each can be cherry-picked independently if needed.
- No new dependencies.