### PR TITLE
Refresh contributors wall daily

### DIFF
--- a/.github/workflows/refresh-contributors-wall.yml
+++ b/.github/workflows/refresh-contributors-wall.yml
@@ -1,0 +1,39 @@
+name: refresh-contributors-wall
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: refresh-contributors-wall
+  cancel-in-progress: true
+
+jobs:
+  refresh:
+    name: Refresh contributors wall cache bust
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Refresh cache bust date
+        run: |
+          DATE="$(date -u +%F)"
+          perl -0pi -e "s/cache_bust=\d{4}-\d{2}-\d{2}/cache_bust=$DATE/g" \
+            README.md \
+            README.zh-CN.md \
+            README.zh-TW.md \
+            README.ko.md \
+            README.de.md \
+            README.ja-JP.md
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v6
+        with:
+          commit_message: 'docs(readme): refresh contributors wall'
+          file_pattern: 'README*.md'

--- a/.github/workflows/refresh-contributors-wall.yml
+++ b/.github/workflows/refresh-contributors-wall.yml
@@ -1,8 +1,13 @@
 name: refresh-contributors-wall
 
 on:
+  # Daily refresh keeps the contributors wall CDN cache moving even when
+  # contributor data changes outside pull request merges.
   schedule:
     - cron: '0 1 * * *'
+  # Manual trigger: Use when you need to force-refresh the contributors wall
+  # outside the daily schedule (e.g., after a bulk contributor update or
+  # after fixing the cache_bust pattern in README files).
   workflow_dispatch:
 
 permissions:
@@ -24,13 +29,12 @@ jobs:
       - name: Refresh cache bust date
         run: |
           DATE="$(date -u +%F)"
-          perl -0pi -e "s/cache_bust=\d{4}-\d{2}-\d{2}/cache_bust=$DATE/g" \
-            README.md \
-            README.zh-CN.md \
-            README.zh-TW.md \
-            README.ko.md \
-            README.de.md \
-            README.ja-JP.md
+          MATCHES="$(perl -0ne '$count += () = /cache_bust=\d{4}-\d{2}-\d{2}/g; END { print $count + 0 }' README*.md)"
+          if [ "$MATCHES" -eq 0 ]; then
+            echo "Warning: No cache_bust patterns found. README format may have changed."
+            exit 1
+          fi
+          perl -0pi -e "s/cache_bust=\d{4}-\d{2}-\d{2}/cache_bust=$DATE/g" README*.md
 
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v6


### PR DESCRIPTION
## Summary
- Add a scheduled GitHub Actions workflow to refresh the contributors wall cache bust date every day at 01:00 UTC.
- Keep manual refresh support through workflow_dispatch.
- Limit cache bust updates to the root localized README files.

## Testing
- Not run; workflow-only change.