### PR TITLE
release: Open Design 0.2.0 — 45 PRs in 24 hours, image/video/audio gen, html-ppt skill, dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,87 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-05-02
+
+A feature-heavy follow-up to 0.1.0 — dark mode, xAI Grok Imagine media generation, headless deploy mode, OpenClaude fallback, four new locales, and a much richer skill / design-system / prompt-template catalog. 45 merged PRs from 27 contributors.
+
+### Added
+
+#### Web / UI
+- Dark mode with system / light / dark toggle. ([#259])
+- Visible conversation timestamps. ([#120])
+- React artifact output support. ([#121])
+- Preview comment attachments. ([#284])
+
+#### Agents & daemon
+- Auto-detect OpenClaude as a fallback for Claude Code. ([#263])
+- Standardize agent communication via stdin and remove Windows-specific shims. ([#258])
+
+#### Media generation
+- xAI Grok Imagine integration covering image, video, and native audio. ([#276])
+
+#### Skills, design systems & prompt templates
+- `kami` editorial paper design system with deck starter. ([#226])
+- `html-ppt` skill (lewislulu/html-ppt-skill) with 15 per-template Examples cards. ([#193])
+- `design-brief` skill with structured I-Lang input format. ([#184])
+- Brand-agnostic craft references and Refero-derived lint rules. ([#225])
+- 11 HyperFrames video prompt templates and media generation README section. ([#227])
+- Three Kingdoms ARPG Seedance 2.0 video templates (3). ([#212])
+- Three Kingdoms ARPG gameplay screenshot templates (3). ([#207])
+- Otaku-dance choreography breakdown infographic template. ([#209])
+- Anime fighting game screenshot template. ([#208])
+
+#### Deployment & tooling
+- `--prod` flag and `OD_HOST` for headless server deployment in `tools-dev`. ([#222])
+- GitHub CI workflow. ([#271])
+- Daemon `kindFor` / `mimeFor` file classifier tests. ([#269])
+
+#### Internationalization
+- Hungarian (`hu`) UI locale. ([#288])
+- Polish (`pl`) UI locale. ([#273])
+- Korean (`ko`) UI locale. ([#253])
+- Turkish (`tr`) UI locale. ([#233])
+
+### Changed
+
+- Image / video projects now pick from prompt templates (not design systems). ([#192])
+- Optimize Electron release artifact size. ([#249])
+
+### Fixed
+
+#### Daemon
+- Restore `startServer` Promise contract — return `url` / `{ url, server }`. ([#268])
+- Emit `tool_use` from `tool_execution_start` in pi-rpc. ([#186])
+- Clamp Codex reasoning effort to model-supported values. ([#223])
+- Deliver Claude Code prompt via stdin to avoid spawn `E2BIG` / `ENAMETOOLONG`. ([#143])
+- Include `package.json` in tarball so packaged app reports correct version. ([#260])
+- Treat `.py` files as previewable code in Design Files. ([#261])
+- `OD_DAEMON_URL` uses port 0 instead of actual allocated port (now reports the real port). ([#240])
+- Quote agent bin path when spawning with `shell:true` on Windows. ([#232])
+- Make `max_tokens` configurable. ([#78])
+
+#### Web UI
+- Suppress hydration warning on `<body>`. ([#248])
+- Fix language dropdown overflow in Settings modal. ([#281], [#287])
+- Add scroll to Settings language menu when it overflows view. ([#247])
+- Preserve deck preview pagination per file. ([#119])
+- Fix deck preview pagination controls. ([#112])
+
+#### Cross-platform
+- Use junction instead of dir symlink on Windows in `tools-dev`. ([#231])
+
+#### Internationalization
+- Replace hardcoded `Claude` with `助手` in zh-TW assistant role copy. ([#262])
+
+### Documentation
+
+- Traditional Chinese (繁體中文) README. ([#194])
+
+### Internal
+
+- Auto-generated metrics SVG updates. ([#228], [#241])
+- Fix metrics workflow protected branch updates. ([#219])
+
 ## [0.1.0] - 2026-05-01
 
 First public release of Open Design — a local-first, open-source alternative to Anthropic's Claude Design. It detects your installed code-agent CLI, runs design skills against curated design systems, and streams artifacts into a sandboxed in-app preview.
@@ -103,7 +184,8 @@ First public release of Open Design — a local-first, open-source alternative t
 - Beta release workflow placeholder. ([#36])
 - Git commit co-author policy. ([#131])
 
-[Unreleased]: https://github.com/nexu-io/open-design/compare/open-design-v0.1.0...HEAD
+[Unreleased]: https://github.com/nexu-io/open-design/compare/open-design-v0.2.0...HEAD
+[0.2.0]: https://github.com/nexu-io/open-design/releases/tag/open-design-v0.2.0
 [0.1.0]: https://github.com/nexu-io/open-design/releases/tag/open-design-v0.1.0
 
 [#1]: https://github.com/nexu-io/open-design/pull/1
@@ -190,3 +272,49 @@ First public release of Open Design — a local-first, open-source alternative t
 [#201]: https://github.com/nexu-io/open-design/pull/201
 [#202]: https://github.com/nexu-io/open-design/pull/202
 [#204]: https://github.com/nexu-io/open-design/pull/204
+[#78]: https://github.com/nexu-io/open-design/pull/78
+[#112]: https://github.com/nexu-io/open-design/pull/112
+[#119]: https://github.com/nexu-io/open-design/pull/119
+[#120]: https://github.com/nexu-io/open-design/pull/120
+[#121]: https://github.com/nexu-io/open-design/pull/121
+[#143]: https://github.com/nexu-io/open-design/pull/143
+[#184]: https://github.com/nexu-io/open-design/pull/184
+[#186]: https://github.com/nexu-io/open-design/pull/186
+[#192]: https://github.com/nexu-io/open-design/pull/192
+[#193]: https://github.com/nexu-io/open-design/pull/193
+[#194]: https://github.com/nexu-io/open-design/pull/194
+[#207]: https://github.com/nexu-io/open-design/pull/207
+[#208]: https://github.com/nexu-io/open-design/pull/208
+[#209]: https://github.com/nexu-io/open-design/pull/209
+[#212]: https://github.com/nexu-io/open-design/pull/212
+[#219]: https://github.com/nexu-io/open-design/pull/219
+[#222]: https://github.com/nexu-io/open-design/pull/222
+[#223]: https://github.com/nexu-io/open-design/pull/223
+[#225]: https://github.com/nexu-io/open-design/pull/225
+[#226]: https://github.com/nexu-io/open-design/pull/226
+[#227]: https://github.com/nexu-io/open-design/pull/227
+[#228]: https://github.com/nexu-io/open-design/pull/228
+[#231]: https://github.com/nexu-io/open-design/pull/231
+[#232]: https://github.com/nexu-io/open-design/pull/232
+[#233]: https://github.com/nexu-io/open-design/pull/233
+[#240]: https://github.com/nexu-io/open-design/pull/240
+[#241]: https://github.com/nexu-io/open-design/pull/241
+[#247]: https://github.com/nexu-io/open-design/pull/247
+[#248]: https://github.com/nexu-io/open-design/pull/248
+[#249]: https://github.com/nexu-io/open-design/pull/249
+[#253]: https://github.com/nexu-io/open-design/pull/253
+[#258]: https://github.com/nexu-io/open-design/pull/258
+[#259]: https://github.com/nexu-io/open-design/pull/259
+[#260]: https://github.com/nexu-io/open-design/pull/260
+[#261]: https://github.com/nexu-io/open-design/pull/261
+[#262]: https://github.com/nexu-io/open-design/pull/262
+[#263]: https://github.com/nexu-io/open-design/pull/263
+[#268]: https://github.com/nexu-io/open-design/pull/268
+[#269]: https://github.com/nexu-io/open-design/pull/269
+[#271]: https://github.com/nexu-io/open-design/pull/271
+[#273]: https://github.com/nexu-io/open-design/pull/273
+[#276]: https://github.com/nexu-io/open-design/pull/276
+[#281]: https://github.com/nexu-io/open-design/pull/281
+[#284]: https://github.com/nexu-io/open-design/pull/284
+[#287]: https://github.com/nexu-io/open-design/pull/287
+[#288]: https://github.com/nexu-io/open-design/pull/288

--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/daemon",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "main": "./dist/cli.js",
@@ -32,10 +32,10 @@
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.sidecar.json --noEmit && tsc -p tsconfig.tests.json --noEmit"
   },
   "dependencies": {
-    "@open-design/contracts": "workspace:0.1.0",
-    "@open-design/platform": "workspace:0.1.0",
-    "@open-design/sidecar": "workspace:0.1.0",
-    "@open-design/sidecar-proto": "workspace:0.1.0",
+    "@open-design/contracts": "workspace:0.2.0",
+    "@open-design/platform": "workspace:0.2.0",
+    "@open-design/sidecar": "workspace:0.2.0",
+    "@open-design/sidecar-proto": "workspace:0.2.0",
     "better-sqlite3": "^11.10.0",
     "express": "^4.19.2",
     "jszip": "^3.10.1",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/desktop",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "main": "./dist/main/index.js",
@@ -18,9 +18,9 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@open-design/platform": "workspace:0.1.0",
-    "@open-design/sidecar": "workspace:0.1.0",
-    "@open-design/sidecar-proto": "workspace:0.1.0"
+    "@open-design/platform": "workspace:0.2.0",
+    "@open-design/sidecar": "workspace:0.2.0",
+    "@open-design/sidecar-proto": "workspace:0.2.0"
   },
   "devDependencies": {
     "@types/node": "24.12.2",

--- a/apps/packaged/package.json
+++ b/apps/packaged/package.json
@@ -20,12 +20,12 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@open-design/daemon": "workspace:0.1.0",
-    "@open-design/desktop": "workspace:0.1.0",
-    "@open-design/platform": "workspace:0.1.0",
-    "@open-design/sidecar": "workspace:0.1.0",
-    "@open-design/sidecar-proto": "workspace:0.1.0",
-    "@open-design/web": "workspace:0.1.0"
+    "@open-design/daemon": "workspace:0.2.0",
+    "@open-design/desktop": "workspace:0.2.0",
+    "@open-design/platform": "workspace:0.2.0",
+    "@open-design/sidecar": "workspace:0.2.0",
+    "@open-design/sidecar-proto": "workspace:0.2.0",
+    "@open-design/web": "workspace:0.2.0"
   },
   "devDependencies": {
     "@types/node": "24.12.2",

--- a/apps/packaged/package.json
+++ b/apps/packaged/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/packaged",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/web",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "exports": {
@@ -29,10 +29,10 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.32.1",
-    "@open-design/contracts": "workspace:0.1.0",
-    "@open-design/platform": "workspace:0.1.0",
-    "@open-design/sidecar": "workspace:0.1.0",
-    "@open-design/sidecar-proto": "workspace:0.1.0",
+    "@open-design/contracts": "workspace:0.2.0",
+    "@open-design/platform": "workspace:0.2.0",
+    "@open-design/sidecar": "workspace:0.2.0",
+    "@open-design/sidecar-proto": "workspace:0.2.0",
     "next": "^16.2.4",
     "openai": "^6.35.0",
     "react": "^18.3.1",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/e2e",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "typecheck": "pnpm -r --workspace-concurrency=1 --if-present run typecheck && pnpm --filter @open-design/daemon build && pnpm check:residual-js"
   },
   "devDependencies": {
-    "@open-design/tools-dev": "workspace:0.1.0",
-    "@open-design/tools-pack": "workspace:0.1.0"
+    "@open-design/tools-dev": "workspace:0.2.0",
+    "@open-design/tools-pack": "workspace:0.2.0"
   },
   "engines": {
     "node": "~24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-design",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "packageManager": "pnpm@10.33.2",
   "type": "module",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/contracts",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "description": "Shared pure TypeScript contracts for the Open Design web/daemon boundary.",

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/platform",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/sidecar-proto/package.json
+++ b/packages/sidecar-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/sidecar-proto",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/sidecar/package.json
+++ b/packages/sidecar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/sidecar",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,25 +9,25 @@ importers:
   .:
     devDependencies:
       '@open-design/tools-dev':
-        specifier: workspace:0.1.0
+        specifier: workspace:0.2.0
         version: link:tools/dev
       '@open-design/tools-pack':
-        specifier: workspace:0.1.0
+        specifier: workspace:0.2.0
         version: link:tools/pack
 
   apps/daemon:
     dependencies:
       '@open-design/contracts':
-        specifier: workspace:0.1.0
+        specifier: workspace:0.2.0
         version: link:../../packages/contracts
       '@open-design/platform':
-        specifier: workspace:0.1.0
+        specifier: workspace:0.2.0
         version: link:../../packages/platform
       '@open-design/sidecar':
-        specifier: workspace:0.1.0
+        specifier: workspace:0.2.0
         version: link:../../packages/sidecar
       '@open-design/sidecar-proto':
-        specifier: workspace:0.1.0
+        specifier: workspace:0.2.0
         version: link:../../packages/sidecar-proto
       better-sqlite3:
         specifier: ^11.10.0
@@ -64,13 +64,13 @@ importers:
   apps/desktop:
     dependencies:
       '@open-design/platform':
-        specifier: workspace:0.1.0
+        specifier: workspace:0.2.0
         version: link:../../packages/platform
       '@open-design/sidecar':
-        specifier: workspace:0.1.0
+        specifier: workspace:0.2.0
         version: link:../../packages/sidecar
       '@open-design/sidecar-proto':
-        specifier: workspace:0.1.0
+        specifier: workspace:0.2.0
         version: link:../../packages/sidecar-proto
     devDependencies:
       '@types/node':
@@ -86,22 +86,22 @@ importers:
   apps/packaged:
     dependencies:
       '@open-design/daemon':
-        specifier: workspace:0.1.0
+        specifier: workspace:0.2.0
         version: link:../daemon
       '@open-design/desktop':
-        specifier: workspace:0.1.0
+        specifier: workspace:0.2.0
         version: link:../desktop
       '@open-design/platform':
-        specifier: workspace:0.1.0
+        specifier: workspace:0.2.0
         version: link:../../packages/platform
       '@open-design/sidecar':
-        specifier: workspace:0.1.0
+        specifier: workspace:0.2.0
         version: link:../../packages/sidecar
       '@open-design/sidecar-proto':
-        specifier: workspace:0.1.0
+        specifier: workspace:0.2.0
         version: link:../../packages/sidecar-proto
       '@open-design/web':
-        specifier: workspace:0.1.0
+        specifier: workspace:0.2.0
         version: link:../web
     devDependencies:
       '@types/node':
@@ -123,16 +123,16 @@ importers:
         specifier: ^0.32.1
         version: 0.32.1
       '@open-design/contracts':
-        specifier: workspace:0.1.0
+        specifier: workspace:0.2.0
         version: link:../../packages/contracts
       '@open-design/platform':
-        specifier: workspace:0.1.0
+        specifier: workspace:0.2.0
         version: link:../../packages/platform
       '@open-design/sidecar':
-        specifier: workspace:0.1.0
+        specifier: workspace:0.2.0
         version: link:../../packages/sidecar
       '@open-design/sidecar-proto':
-        specifier: workspace:0.1.0
+        specifier: workspace:0.2.0
         version: link:../../packages/sidecar-proto
       next:
         specifier: ^16.2.4
@@ -244,13 +244,13 @@ importers:
   tools/dev:
     dependencies:
       '@open-design/platform':
-        specifier: workspace:0.1.0
+        specifier: workspace:0.2.0
         version: link:../../packages/platform
       '@open-design/sidecar':
-        specifier: workspace:0.1.0
+        specifier: workspace:0.2.0
         version: link:../../packages/sidecar
       '@open-design/sidecar-proto':
-        specifier: workspace:0.1.0
+        specifier: workspace:0.2.0
         version: link:../../packages/sidecar-proto
       cac:
         specifier: 6.7.14
@@ -275,13 +275,13 @@ importers:
         specifier: 3.1.0
         version: 3.1.0
       '@open-design/platform':
-        specifier: workspace:0.1.0
+        specifier: workspace:0.2.0
         version: link:../../packages/platform
       '@open-design/sidecar':
-        specifier: workspace:0.1.0
+        specifier: workspace:0.2.0
         version: link:../../packages/sidecar
       '@open-design/sidecar-proto':
-        specifier: workspace:0.1.0
+        specifier: workspace:0.2.0
         version: link:../../packages/sidecar-proto
       cac:
         specifier: 6.7.14

--- a/tools/dev/package.json
+++ b/tools/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-dev",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "bin": {
@@ -13,9 +13,9 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@open-design/platform": "workspace:0.1.0",
-    "@open-design/sidecar": "workspace:0.1.0",
-    "@open-design/sidecar-proto": "workspace:0.1.0",
+    "@open-design/platform": "workspace:0.2.0",
+    "@open-design/sidecar": "workspace:0.2.0",
+    "@open-design/sidecar-proto": "workspace:0.2.0",
     "cac": "6.7.14"
   },
   "devDependencies": {

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-pack",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "bin": {
@@ -12,9 +12,9 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@open-design/platform": "workspace:0.1.0",
-    "@open-design/sidecar": "workspace:0.1.0",
-    "@open-design/sidecar-proto": "workspace:0.1.0",
+    "@open-design/platform": "workspace:0.2.0",
+    "@open-design/sidecar": "workspace:0.2.0",
+    "@open-design/sidecar-proto": "workspace:0.2.0",
     "@electron/notarize": "3.1.0",
     "cac": "6.7.14",
     "electron-builder": "26.8.1"


### PR DESCRIPTION

🎉 **`45 PRs` · `23 contributors` · `24 hours`** — Open Design 0.2.0 is here, and it's the biggest single-day product wave this project has shipped. ⚡ Generate image / video / audio inside the chat. Ship cinematic videos with 11 ready-to-go HyperFrames prompts. Build polished slide decks with the new `html-ppt` skill. Drop screenshots straight into preview comments. Toggle dark mode. Speak 13 languages. And under the hood: headless `--prod` deploy + OpenClaude fallback. **Built by the community, in a single day.** 🚀

## 🔥 Highlights

- 💬 **Click-to-comment on HTML previews — pins anchor to elements, feed straight to your agent.** Pick an element, drop a pin or screenshot; selected comments become hidden agent context, turning "make this blue" into a real revision. (#284) Thanks @alchemistklk.
- 🎬 **xAI Grok Imagine integration — image, video, and native audio in one stack.** Bring your own xAI key, generate all three media types right inside chat. (#276) Thanks @lefarcen.
- 🎞️ **11 new HyperFrames video prompt templates.** Cinematic openers, product reveals, character intros — pick a template, swap a couple of details, get a video that looks director-shot. Zero prompt engineering, zero blank canvas. (#227) Thanks @pftom.
- 🖼️ **New `html-ppt` skill for HTML slide decks.** The lewislulu/html-ppt-skill is now built in with **15 production-ready Example cards**. Idea → polished deck in minutes — no PowerPoint, no Figma file, no design tax. (#193) Thanks @pftom.
- 🌒 **Dark mode — system / light / dark toggle across the entire UI.** Settings, Chat, and Preview panes all got a fresh coat. Finally. (#259) Thanks @sysCat64.
- 🌍 **Four new UI languages: Hungarian, Polish, Korean, Turkish.** Open Design now ships with 13 UI locales out of the box — the localization community keeps showing up. (#233, #253, #273, #288) Thanks @codefl0w, @2YoungKim, @karolgajda-techsquare, and @komlosizsolt.

> 📥 **Download:** the table below points at the final asset URLs — links go live once this PR is merged and the `release-stable` workflow finishes. Tag: `open-design-v0.2.0`.
>
> | Platform | Architecture | Asset |
> |---|---|---|
> | macOS | Apple Silicon (arm64) | [open-design-0.2.0-mac-arm64.dmg](https://github.com/nexu-io/open-design/releases/download/open-design-v0.2.0/open-design-0.2.0-mac-arm64.dmg) |
> | macOS (auto-update feed) | Apple Silicon (arm64) | [open-design-0.2.0-mac-arm64.zip](https://github.com/nexu-io/open-design/releases/download/open-design-v0.2.0/open-design-0.2.0-mac-arm64.zip) |
> | Windows | x64 (unsigned) | [open-design-0.2.0-win-x64-setup.exe](https://github.com/nexu-io/open-design/releases/download/open-design-v0.2.0/open-design-0.2.0-win-x64-setup.exe) |

## ✨ What's New

### 🌒 Dark mode and UI polish

- 🌒 **System / light / dark toggle.** Refreshed styling across Settings, Chat, and Preview. (#259) Thanks @sysCat64.
- ⏱️ **Visible conversation timestamps.** Every chat turn shows when it happened. (#120) Thanks @Siri-Ray.
- 💬 **Preview comment attachments.** Drop screenshots / files straight into comments. (#284) Thanks @alchemistklk.
- 🟦 **React artifact output.** Render React components inline next to chat. (#121) Thanks @Siri-Ray.

### 🎬 Media generation

- 🎨 **xAI Grok Imagine integration.** Image, video, and native audio via your own xAI key. (#276) Thanks @lefarcen.

### 🤖 Agents & daemon

- 🔀 **OpenClaude auto-detected as a Claude Code fallback.** No more "agent not found" on machines without Claude Code installed. (#263) Thanks @Sid-Qin.
- 📥 **Standardized stdin agent communication.** Single code path across all agents, Windows-specific shims removed. (#258) Thanks @RinZ27.

### 🎨 Skills, design systems & prompt templates

- 📰 **`kami` editorial paper design system** with a deck starter. (#226) Thanks @pftom.
- 🖼️ **`html-ppt` skill** — lewislulu/html-ppt-skill integrated with 15 per-template Examples cards. (#193) Thanks @pftom.
- 📋 **`design-brief` skill** with structured I-Lang input format. (#184) Thanks @adsorgcn.
- 🎯 **Brand-agnostic craft references and Refero-derived lint rules.** (#225) Thanks @pftom.
- 🎞️ **11 HyperFrames video prompt templates** + media generation README section. (#227) Thanks @pftom.
- 🎮 **Three Kingdoms ARPG bundle** — 3 Seedance 2.0 video templates + 3 gameplay screenshot templates. (#207, #212) Thanks @Tuola-waj.
- 💃 **Otaku-dance choreography breakdown** + 🥋 **anime fighting game screenshot** templates. (#208, #209) Thanks @Tuola-waj.

### 📦 Deployment & tooling

- 🖥️ **`--prod` flag and `OD_HOST` for headless server deployment** in `tools-dev`. (#222) Thanks @yamsfeer.
- 🛠️ **GitHub CI workflow** — typecheck + test on every push. (#271) Thanks @mrcfps.
- 🧪 **Daemon `kindFor` / `mimeFor` file classifier tests.** (#269) Thanks @Sid-Qin.

### 🌍 Internationalization

- 🇭🇺 Hungarian (`hu`). (#288) Thanks @komlosizsolt.
- 🇵🇱 Polish (`pl`). (#273) Thanks @karolgajda-techsquare.
- 🇰🇷 Korean (`ko`). (#253) Thanks @2YoungKim.
- 🇹🇷 Turkish (`tr`). (#233) Thanks @codefl0w.

## 🛡️ Stability & Reliability

- 🟢 **`startServer` Promise contract restored** — daemon embedders get back `url` / `{ url, server }` reliably again. (#268) Thanks @Sid-Qin.
- 🛂 **Codex reasoning effort clamped to model-supported values** — no more silent rejection from upstream. (#223) Thanks @heylakatos.
- 📬 **Claude Code prompts always go through stdin now** — fixes `spawn E2BIG` / `ENAMETOOLONG` on long conversations and large file uploads. (#143) Thanks @pcherkashin.
- 🪟 **Windows hardening** — quote agent bin path on `shell:true` spawn, switch to junctions instead of dir symlinks in `tools-dev`. (#231, #232) Thanks @Foximo24 and @VitaminBFFM.
- 📦 **Packaged app reports correct version** — `package.json` now lands inside the daemon tarball. (#260) Thanks @Sid-Qin.

## 🐛 Bug Fixes

- 📡 Emit `tool_use` from `tool_execution_start` in pi-rpc. (#186) Thanks @monotykamary.
- 🐍 `.py` files treated as previewable code in Design Files. (#261) Thanks @Sid-Qin.
- 🌐 `OD_DAEMON_URL` reports the actual allocated port instead of 0. (#240) Thanks @yuyihan666.
- 🅰️ Suppress Next.js hydration warning on `<body>`. (#248) Thanks @lefarcen.
- 📋 Settings language dropdown overflow + scroll fixes. (#247, #281, #287) Thanks @zhujie007 and @sinamashini.
- 📑 Deck preview pagination — preserved per file, controls fixed. (#112, #119) Thanks @Siri-Ray.
- 🌐 zh-TW assistant role — replace hardcoded `Claude` with `助手`. (#262) Thanks @Sid-Qin.
- 🎚️ `max_tokens` now configurable (closes #29). (#78) Thanks @lefarcen.
- 🖼️ Image / video projects now pick from prompt templates (not design systems). (#192) Thanks @pftom.

## ✅ System Requirements

- **macOS** — Apple Silicon (arm64) only, macOS 11 Big Sur or newer. Intel macs are not supported in 0.2.0.
- **Windows** — x64, Windows 10 / 11. Installer is **unsigned** (SmartScreen will warn on first launch — choose "More info → Run anyway").
- **Linux** — no packaged build; run from source or via the new `--prod` headless mode.
- **From source** — Node.js 24.x and pnpm 10.33.2+ (per `engines` in `package.json`).

## ⚠️ Known Issues

- 🪟 **Windows installer is unsigned** — SmartScreen / antivirus warnings on first launch. Code signing tracked for a follow-up release.
- 🍎 **No macOS Intel (x64) build** — Apple Silicon only.
- 🐧 **No Linux desktop package** — `--prod` headless mode now makes self-hosting straightforward.
- 🌐 **i18n metadata drift on new prompt templates** — A handful of recent prompt templates don't yet have display titles in every UI locale; the `release-stable` i18n coverage test is currently skipped. Tracked as a follow-up.

## 📚 Documentation

- 🇹🇼 Traditional Chinese (繁體中文) README. (#194) Thanks @laihenyi.

## 🔨 For Developers

<details>
<summary>Click to expand</summary>

- ⚡ **Optimize Electron release artifact size.** (#249) Thanks @mrcfps.
- 📊 Auto-generated metrics SVG updates. (#228, #241)
- 🔧 Fix metrics workflow protected branch updates. (#219) Thanks @mrcfps.

</details>

---

## 🚀 Releasing this PR

This PR ships:

1. **`apps/packaged/package.json` and root `package.json` bumped to `0.2.0`** — required by `release-stable.ts` (strict greater than current latest stable `0.1.0`).
2. **`CHANGELOG.md`** — new `[0.2.0] - 2026-05-02` entry above the existing `[0.1.0]` block.

The release-stable workflow already lives on `main` from 0.1.0; no infrastructure changes here. After merge, dispatch `release-stable` with `mac_signed=true` to publish.

Local verify dry-run already passed against the latest `main`: `pnpm install --frozen-lockfile` → `pnpm --filter @open-design/daemon build` → `pnpm --filter @open-design/desktop build` → `pnpm -r run typecheck` (exit 0, 10 workspaces) → `pnpm check:residual-js` (exit 0). CI verify job should be green on first try.

**Full Changelog:** https://github.com/nexu-io/open-design/compare/open-design-v0.1.0...release/v0.2.0
