### PR TITLE
docs: fix spelling mistakes in CLI comment, spec, and video prompt

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -17,7 +17,7 @@ const argv = process.argv.slice(2);
 // parsed inside each handler.
 
 // Flags accepted by `od media generate`. Whitelisted so a hallucinated
-// `--lenght 5` from the LLM fails fast instead of silently no-op'ing
+// `--length 5` from the LLM fails fast instead of silently no-op'ing
 // while we route a bogus body to the daemon.
 //
 // Hoisted to the top of the module *before* the subcommand dispatch

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -98,7 +98,7 @@ Module responsibilities:
 - **We do not ship a model router.** If the user's agent supports 20 providers, great. If it only supports Anthropic, that's the ceiling. We don't layer our own provider abstraction on top of someone else's.
 - **We do not ship a desktop app.** No Electron, no Tauri. The "local" story is a Next.js dev server + a Node daemon. If someone wants a tray icon, that's [`cc-switch`][ccsw]'s job, not ours.
 - **We do not reinvent the agent loop.** No custom tool-use harness, no bespoke context-manager. Everything goes through the detected agent's native loop.
-- **We do not maintain a skill marketplace in v1.** Skills are git URLs and local folders. A browseable UI is v2.
+- **We do not maintain a skill marketplace in v1.** Skills are git URLs and local folders. A browsable UI is v2.
 - **We do not try to compete with Figma.** Output is code (HTML/JSX) and content (`DESIGN.md`, Markdown, PPTX), not editable vector canvases.
 - **We do not implement auth / billing / orgs in MVP.** Single-user, single-machine. Multi-user is post-v1 and optional.
 

--- a/prompt-templates/video/animation-transfer-and-camera-tracking-prompt.json
+++ b/prompt-templates/video/animation-transfer-and-camera-tracking-prompt.json
@@ -7,7 +7,7 @@
   "tags": [],
   "model": "seedance-2.0",
   "aspect": "16:9",
-  "prompt": "apply the walking animation of @anim excatly as it is to @char7 . the camera tracks the character exactly in place, camera angle does not change",
+  "prompt": "apply the walking animation of @anim exactly as it is to @char7. the camera tracks the character exactly in place, camera angle does not change",
   "previewImageUrl": "https://customer-qs6wnyfuv0gcybzj.cloudflarestream.com/089e7cd70d20131d6d1b44741520eaee/thumbnails/thumbnail.jpg",
   "previewVideoUrl": "https://customer-qs6wnyfuv0gcybzj.cloudflarestream.com/089e7cd70d20131d6d1b44741520eaee/downloads/default.mp4",
   "source": {


### PR DESCRIPTION
## Summary
- correct a typo in the daemon CLI comment
- fix a spelling mistake in `docs/spec.md`
- fix the `animation-transfer-and-camera-tracking` prompt text and remove the extra space before the period

## Why
These are small user-facing text fixes across docs and prompt/template content.

Closes #299.

## Validation
- `typos` on the three touched files: no spelling errors found after the fixes
- `jq -e . prompt-templates/video/animation-transfer-and-camera-tracking-prompt.json`
- `pnpm typecheck` could not complete in this environment because `node_modules` are missing and the current Node is `v22.17.1` while the repo requires Node `~24`
