### PR TITLE
fix(web/i18n): remove three duplicate keys in content.ts (unblocks main CI)

### DIFF
--- a/apps/web/src/i18n/content.ts
+++ b/apps/web/src/i18n/content.ts
@@ -355,7 +355,6 @@ const DE_PROMPT_TEMPLATE_CATEGORIES: Record<string, string> = {
   'Social / Meme': 'Social / Meme',
   Branding: 'Branding',
   Data: 'Daten',
-  'Game UI': 'Game UI',
   Marketing: 'Marketing',
   Product: 'Produkt',
   'Short Form': 'Short Form',
@@ -624,7 +623,6 @@ const DE_PROMPT_TEMPLATE_COPY: Record<string, Partial<Pick<PromptTemplateSummary
     summary:
       'Warme Editorial-Seite zu einem japanischen Feiertag mit Anime-Charakterkunst, nostalgischer Showa-Straßenszene und Magazinlayout.',
   },
-  'social-media-post-sensational-girl-dance-storyboard-8-shots': {},
   'social-media-post-social-media-fashion-outfit-generation': {
     title: 'Social-Media-Post - Fashion-Outfit-Generierung',
     summary:
@@ -744,7 +742,6 @@ const DE_PROMPT_TEMPLATE_COPY: Record<string, Partial<Pick<PromptTemplateSummary
   'game-screenshot-three-kingdoms-guanyu-slaying-yanliang': {},
   'game-screenshot-three-kingdoms-lyubu-yuanmen-archery': {},
   'game-screenshot-three-kingdoms-zhaoyun-cradle-escape': {},
-  'game-ui-ancient-china-open-world-mmo-hud': {},
   'hollywood-haute-couture-fantasy-video-prompt': {
     title: 'Hollywood-Haute-Couture-Fantasy-Video-Prompt',
     summary:


### PR DESCRIPTION
## Why

Main CI has been red since #295 landed (`feat(prompt-templates): add crayon kid-drawing style-transfer template`). The Validate workspace job fails with three TS1117 errors:

\`\`\`
apps/web/src/i18n/content.ts(358,3): An object literal cannot have multiple properties with the same name.
apps/web/src/i18n/content.ts(891,3): An object literal cannot have multiple properties with the same name.
apps/web/src/i18n/content.ts(901,3): An object literal cannot have multiple properties with the same name.
\`\`\`

Last 3 main CI runs:
- \`ba4055e\` (#294 contributors wall) ❌
- \`569f280\` (#295 — first failing run) ❌
- \`37c8364\` ✅

The errors are pre-existing latent duplicates that #295 (or somewhere around it) tipped over the threshold. This is also blocking release/v0.2.0 (#297) because GitHub's PR validation runs against the potential merge commit, which inherits main's broken state.

## What this PR does

Three duplicate-key removals — in each case there's already a populated copy of the same key, so deleting the redundant entry is the minimal fix:

| Line removed | Why |
|---|---|
| 358 — \`'Game UI': 'Game UI'\` | Already declared at line 345 with the real German translation \`'Spiel-UI'\`. The line-358 duplicate was a fallback that just restated the English label. |
| 627 — empty placeholder for \`'social-media-post-sensational-girl-dance-storyboard-8-shots': {}\` | Same key already populated with full \`title\` + \`summary\` at line 901. |
| 747 — empty placeholder for \`'game-ui-ancient-china-open-world-mmo-hud': {}\` | Same key already populated at line 891. |

Net: \`-3 lines, +0 lines\`.

## Locally verified

\`\`\`
find apps/web -name "*.tsbuildinfo" -delete  # clear incremental cache
pnpm --filter @open-design/web run typecheck  # exit 0
\`\`\`

## Test plan

- [ ] CI \`Validate workspace\` job goes green on this PR
- [ ] main CI goes green after merge
- [ ] release/v0.2.0 (#297) becomes mergeable once main CI is healthy