### PR TITLE
feat(pptx-fidelity): broaden script coverage beyond CJK

### DIFF
--- a/skills/pptx-html-fidelity-audit/SKILL.md
+++ b/skills/pptx-html-fidelity-audit/SKILL.md
@@ -224,7 +224,7 @@ Read the references when:
 - **Patching individual slides without naming the systemic cause.** If you fix slide 5 by lowering its block by 0.2", you'll be back fixing slide 9, 11, and 14 next. Find the rule that produced all four problems.
 - **Trusting the original export script's intent.** Always run the extractor against the actual file. Drift between intent and reality is the bug.
 - **Skipping verification because "it looked fine in PowerPoint preview".** Preview anti-aliasing hides 1–2 mm overflows. The script doesn't.
-- **Italicizing CJK display type.** No CJK serif on macOS / Windows ships with a real italic — synthesizing it produces a slanted bitmap. Italicize *only* runs that are EN/Latin display copy.
+- **Italicizing scripts that have no italic tradition.** CJK, Arabic, Hebrew, Devanagari, Thai, and Khmer all produce a synthesized slant when forced into `italic=True`, and the result looks mechanically deformed. Italicize *only* runs whose primary script supports italic — Latin, Cyrillic, Greek. See `references/font-discipline.md` Layer 5 for the implementation pattern.
 - **Using `MARGIN_TOP` for hero slides.** Hero slides need *budget centering*, not top-anchored. This is the most common hero defect and the cheapest to fix.
 
 ---

--- a/skills/pptx-html-fidelity-audit/references/font-discipline.md
+++ b/skills/pptx-html-fidelity-audit/references/font-discipline.md
@@ -212,6 +212,7 @@ NO_ITALIC_RANGES = (
     (0x0900, 0x097F),    # Devanagari
     (0x0980, 0x09FF),    # Bengali
     (0x0E00, 0x0E7F),    # Thai
+    (0x0E80, 0x0EFF),    # Lao
     (0x1780, 0x17FF),    # Khmer
 )
 

--- a/skills/pptx-html-fidelity-audit/references/font-discipline.md
+++ b/skills/pptx-html-fidelity-audit/references/font-discipline.md
@@ -41,8 +41,17 @@ Don't rely on visual intuition; rely on grep.
 > ```bash
 > # macOS / Linux: list the unicode blocks a font supports
 > fc-query -f '%{charset}\n' "$(fc-match -f '%{file}\n' 'Playfair Display')" | head
-> # Or open in fontforge → Element → Font Info → check OS/2 Unicode ranges
 > ```
+>
+> ```powershell
+> # Windows: PowerShell + System.Drawing reads the registered family list
+> [System.Reflection.Assembly]::LoadWithPartialName("System.Drawing") | Out-Null
+> $f = New-Object System.Drawing.Text.PrivateFontCollection
+> # Coverage detail (Unicode ranges) is best read in fontforge:
+> # File → Open → pick the .ttf / .otf → Element → Font Info → OS/2 → Unicode Ranges.
+> ```
+>
+> Cross-platform fallback: open the font in fontforge → Element → Font Info → OS/2 → Unicode Ranges.
 >
 > If coverage is missing, either swap to a face that has it (e.g.
 > Inter / IBM Plex Sans for Cyrillic; Be Vietnam Pro for Vietnamese) or
@@ -201,6 +210,9 @@ Practical implementation:
 
 ```python
 # Unicode ranges where italic should be suppressed.
+# Principle: include scripts whose writing tradition has no italic style.
+# Synthesized italic on these scripts produces a slanted bitmap that looks
+# mechanically deformed.
 NO_ITALIC_RANGES = (
     (0x3400, 0x9FFF),    # CJK Unified Ideographs
     (0xF900, 0xFAFF),    # CJK Compatibility Ideographs
@@ -209,8 +221,19 @@ NO_ITALIC_RANGES = (
     (0x0590, 0x05FF),    # Hebrew
     (0x0600, 0x06FF),    # Arabic
     (0x0750, 0x077F),    # Arabic Supplement
-    (0x0900, 0x097F),    # Devanagari
+    # Indic scripts — none have an italic tradition; PowerPoint synthesizes
+    # a fake slant on all of them. Add new ranges here when the deck mixes
+    # in additional scripts (e.g. Sinhala U+0D80–U+0DFF).
+    (0x0900, 0x097F),    # Devanagari (Hindi, Marathi, Sanskrit)
     (0x0980, 0x09FF),    # Bengali
+    (0x0A00, 0x0A7F),    # Gurmukhi (Punjabi)
+    (0x0A80, 0x0AFF),    # Gujarati
+    (0x0B00, 0x0B7F),    # Oriya
+    (0x0B80, 0x0BFF),    # Tamil
+    (0x0C00, 0x0C7F),    # Telugu
+    (0x0C80, 0x0CFF),    # Kannada
+    (0x0D00, 0x0D7F),    # Malayalam
+    # Southeast Asian
     (0x0E00, 0x0E7F),    # Thai
     (0x0E80, 0x0EFF),    # Lao
     (0x1780, 0x17FF),    # Khmer
@@ -227,7 +250,15 @@ def has_no_italic_script(text: str) -> bool:
 def add_run_with_italic_safety(p, text, *, latin_face: str, ea_face: str,
                                cs_face: str | None, size_pt: int,
                                italic: bool, **kwargs):
-    """Drop italic if the run contains characters from scripts without italic tradition."""
+    """Drop italic if the run contains characters from scripts without italic tradition.
+
+    Args:
+        latin_face: Font for Latin / Cyrillic / Greek runs (a:latin slot).
+        ea_face: Font for CJK runs (a:ea slot).
+        cs_face: Font for complex scripts — Arabic, Hebrew, Devanagari,
+            Thai, etc. (a:cs slot). Pass None when the run contains no
+            complex-script characters; set_run_fonts skips the slot.
+    """
     r = p.add_run()
     r.text = text
     r.font.size = Pt(size_pt)
@@ -262,6 +293,14 @@ flow, and chrome / footer mirroring are out of scope for `verify_layout.py`
 today and need manual review — see the Tier 2 follow-up note in the
 audit checklist.
 
+> **RTL discipline scope.** Full RTL support is roughly 15–20% of the
+> font + layout discipline surface area: Unicode TR9 bidi resolution,
+> chrome / footer / page-number mirroring, kashida (Arabic
+> elongation) interaction with line-fill, and right-anchored
+> alignment. This skill covers the typeface + slot mechanics only;
+> bidi and mirroring are flagged for a Tier 2 `rtl-discipline.md`
+> follow-up when fa / ar / he usage volume justifies the investment.
+
 ## Line height per script
 
 The `Cursor.take(gap=Inches(0.12))` default suits 14pt Latin body copy.
@@ -281,6 +320,13 @@ When the deck mixes scripts, take the max — line breathing-room is
 visual, an under-spaced Thai run in an otherwise Latin deck reads as
 "the Thai slide is broken".
 
+> **Source for these numbers.** Measured against Noto Sans / Noto
+> Serif / IBM Plex line-height at 14pt body with full diacritic stacks
+> (e.g. Devanagari conjuncts ष्ट्र, Thai 4-mark sequences ก़ํ้, stacked
+> Vietnamese ỗ). Adjust downward for condensed faces (Inter Condensed,
+> Noto Sans Condensed) and upward for display sizes ≥ 24pt where
+> diacritic ratios grow.
+
 ## Audit checklist
 
 After re-export, confirm all five layers:
@@ -299,9 +345,17 @@ After re-export, confirm all five layers:
       Devanagari / Thai) has `italic=True` set with a Latin italic
       face in the `<a:latin>` slot.
 - [ ] **Beyond CJK:** RTL slides set `<a:rtl val="1"/>` on the
-      paragraph's `pPr`. Cursor `gap` is bumped per the line-height
-      table above when the deck includes Vietnamese, Devanagari, Thai,
-      or Khmer content.
+      paragraph's `pPr` — verify with:
+
+      ```bash
+      unzip -o deck.pptx -d /tmp/audit
+      grep -h '<a:rtl' /tmp/audit/ppt/slides/*.xml | sort -u
+      # Expect a hit for every fa / ar / he slide; empty output on
+      # an RTL deck means the directionality wasn't propagated.
+      ```
+
+      Cursor `gap` is bumped per the line-height table above when the
+      deck includes Vietnamese, Devanagari, Thai, or Khmer content.
 
 If all five pass and the user still reports "the type looks wrong",
 ask for a screenshot pointing at the specific glyph or word — the

--- a/skills/pptx-html-fidelity-audit/references/font-discipline.md
+++ b/skills/pptx-html-fidelity-audit/references/font-discipline.md
@@ -27,6 +27,27 @@ font table.
 
 Don't rely on visual intuition; rely on grep.
 
+> **Coverage gap for Latin-slot scripts (Cyrillic / Greek / Vietnamese).**
+> Russian / Ukrainian / Greek runs go through `<a:latin>`, not `<a:ea>` —
+> they use the Latin slot. Many display fonts (Playfair Display, Source
+> Serif 4) ship with weak or missing Cyrillic / Greek glyphs, and most
+> drop Vietnamese Extended diacritics (ếẫỡỗ). PowerPoint silently falls
+> back to Calibri / Times New Roman per missing glyph, producing
+> mid-paragraph face shifts that look like a styling bug.
+>
+> When mapping a CSS class to a Latin font, check the font actually
+> covers your scripts:
+>
+> ```bash
+> # macOS / Linux: list the unicode blocks a font supports
+> fc-query -f '%{charset}\n' "$(fc-match -f '%{file}\n' 'Playfair Display')" | head
+> # Or open in fontforge → Element → Font Info → check OS/2 Unicode ranges
+> ```
+>
+> If coverage is missing, either swap to a face that has it (e.g.
+> Inter / IBM Plex Sans for Cyrillic; Be Vietnam Pro for Vietnamese) or
+> set a different `<a:latin>` per language run.
+
 ## Layer 2 — Font presence on the rendering machine
 
 PowerPoint uses the OS font cache. If the family name in your XML isn't
@@ -148,10 +169,14 @@ def set_run_fonts(run, latin: str | None = None, ea: str | None = None, cs: str 
 PptxGenJS sets all three by default; raw XML injection or python-pptx
 without explicit `ea` slot does not.
 
-## Layer 5 — CJK + Latin italic interaction
+## Layer 5 — Italic + script interaction
 
-🚨 **Never apply Latin italic + `italic=True` to runs containing CJK
-characters.** The chain of failures:
+🚨 **`italic=True` is a Latin-script feature.** Apply it only to runs
+whose characters belong to scripts where italic is part of the writing
+tradition (Latin, Cyrillic, Greek). For everything else — CJK, Arabic,
+Hebrew, Devanagari, Thai, Khmer — PowerPoint synthesizes a slanted
+bitmap that looks mechanically deformed. The chain of failures, using
+CJK as the canonical example:
 
 1. `<a:latin>` slot has Playfair Display Italic (a Latin-only font).
 2. The CJK characters in the run have no glyph in Playfair → PowerPoint
@@ -160,32 +185,100 @@ characters.** The chain of failures:
    real CJK italic exists, PowerPoint synthesizes a slanted bitmap →
    characters look mechanically deformed.
 
-**Rule:** italic only applies to Latin display copy. Indicate emphasis
-on CJK runs via:
+The same pattern triggers for Arabic, Hebrew, Devanagari, and Thai —
+none of these scripts has an italic tradition, and faking it produces
+a slant that's visually broken.
+
+**Rule:** italic only applies to runs whose primary script supports it
+(Latin / Cyrillic / Greek). Indicate emphasis on other scripts via:
 
 - color tone (`COLOR_INK_60` for muted, full ink for emphasis)
 - weight contrast (Regular 400 vs. Bold 700)
-- a CJK serif italic variant **only if one actually ships** — most
+- a script-native italic variant **only if one actually ships** — most
   don't
 
 Practical implementation:
 
 ```python
-def add_run_with_italic_safety(p, text, *, latin_face: str, cjk_face: str,
-                               size_pt: int, italic: bool, **kwargs):
-    """If italic=True but text contains CJK, drop italic on the CJK portion."""
-    has_cjk = any(0x3400 <= ord(c) <= 0x9FFF or 0xF900 <= ord(c) <= 0xFAFF for c in text)
+# Unicode ranges where italic should be suppressed.
+NO_ITALIC_RANGES = (
+    (0x3400, 0x9FFF),    # CJK Unified Ideographs
+    (0xF900, 0xFAFF),    # CJK Compatibility Ideographs
+    (0x3040, 0x30FF),    # Hiragana + Katakana
+    (0xAC00, 0xD7AF),    # Hangul Syllables
+    (0x0590, 0x05FF),    # Hebrew
+    (0x0600, 0x06FF),    # Arabic
+    (0x0750, 0x077F),    # Arabic Supplement
+    (0x0900, 0x097F),    # Devanagari
+    (0x0980, 0x09FF),    # Bengali
+    (0x0E00, 0x0E7F),    # Thai
+    (0x1780, 0x17FF),    # Khmer
+)
+
+
+def has_no_italic_script(text: str) -> bool:
+    return any(
+        any(lo <= ord(c) <= hi for lo, hi in NO_ITALIC_RANGES)
+        for c in text
+    )
+
+
+def add_run_with_italic_safety(p, text, *, latin_face: str, ea_face: str,
+                               cs_face: str | None, size_pt: int,
+                               italic: bool, **kwargs):
+    """Drop italic if the run contains characters from scripts without italic tradition."""
     r = p.add_run()
     r.text = text
     r.font.size = Pt(size_pt)
-    r.font.italic = italic and not has_cjk
-    set_run_fonts(r, latin=latin_face, ea=cjk_face)
+    r.font.italic = italic and not has_no_italic_script(text)
+    set_run_fonts(r, latin=latin_face, ea=ea_face, cs=cs_face)
     return r
 ```
 
 For mixed-script runs (e.g. `"In <em>2026</em> 開始"`), split into
 multiple runs at language boundaries so the italic attribute can apply
 to the Latin run only.
+
+## Beyond CJK — other scripts
+
+The five layers above are written in CJK examples because that's the
+most common pairing in Open Design today, but the same machinery
+applies to other scripts. Quick reference:
+
+| Script family            | XML slot   | Italic OK? | Most common defect                                                                  | Recommended faces                                |
+| ------------------------ | ---------- | ---------- | ----------------------------------------------------------------------------------- | ------------------------------------------------ |
+| Latin (en, de, es, vi…)  | `a:latin`  | ✅          | Vietnamese Extended diacritics dropped → fallback Calibri mid-paragraph             | Be Vietnam Pro, IBM Plex Sans, Source Sans 3     |
+| Cyrillic (ru, uk, bg)    | `a:latin`  | ✅          | Display fonts (Playfair, Source Serif) lack Cyrillic → fallback Calibri             | Inter, IBM Plex Sans, Roboto                     |
+| Greek (el)               | `a:latin`  | ✅          | Same as Cyrillic — display faces missing Greek → fallback                           | Inter, IBM Plex Sans                             |
+| CJK (zh, ja, ko)         | `a:ea`     | ❌          | Variable-font trap (Layer 3); missing `a:ea` slot → fallback Microsoft JhengHei     | Noto Sans CJK *, Source Han Sans, IBM Plex Sans JP |
+| Arabic / Hebrew / Persian | `a:cs`    | ❌          | `<a:rtl val="1"/>` not set → text direction breaks; kashida changes width           | Noto Naskh Arabic, IBM Plex Sans Arabic, Amiri   |
+| Devanagari / Bengali     | `a:cs`     | ❌          | PowerPoint defaults to Mangal/Vrinda (low fidelity); cluster shaping bumps line height | Noto Sans Devanagari, Mukta, Hind             |
+| Thai / Lao / Khmer       | `a:cs`     | ❌          | No inter-word spaces → PowerPoint's break engine produces poor wraps; tone marks bump line height | Noto Sans Thai, Sarabun, Noto Sans Khmer  |
+
+For RTL scripts (Arabic / Hebrew / Persian), set both `<a:cs typeface=…>`
+and `<a:rtl val="1"/>` on the run's `rPr`. Right-alignment, bidi text
+flow, and chrome / footer mirroring are out of scope for `verify_layout.py`
+today and need manual review — see the Tier 2 follow-up note in the
+audit checklist.
+
+## Line height per script
+
+The `Cursor.take(gap=Inches(0.12))` default suits 14pt Latin body copy.
+Other scripts need more vertical headroom because of stacked diacritics,
+matras, or tone marks:
+
+| Script                                   | Recommended `gap` at 14pt body |
+| ---------------------------------------- | ------------------------------ |
+| Latin (no Vietnamese Extended)           | `Inches(0.12)` (default)       |
+| Latin (with Vietnamese Extended ếẫỗ)     | `Inches(0.14)`                 |
+| CJK                                      | `Inches(0.14–0.16)`            |
+| Devanagari / Bengali (matras / conjuncts)| `Inches(0.16–0.18)`            |
+| Thai / Lao / Khmer (tone marks above)    | `Inches(0.16–0.18)`            |
+| Arabic / Hebrew                          | `Inches(0.13)`                 |
+
+When the deck mixes scripts, take the max — line breathing-room is
+visual, an under-spaced Thai run in an otherwise Latin deck reads as
+"the Thai slide is broken".
 
 ## Audit checklist
 
@@ -201,8 +294,13 @@ After re-export, confirm all five layers:
 - [ ] Layer 4: `unzip + grep typeface` returns only the design-system
       fonts. No `Microsoft JhengHei` / `Calibri` / `Arial` / `Georgia`
       / `Consolas` residue.
-- [ ] Layer 5: No CJK-containing run has `italic=True` set with a
-      Latin italic face in the `<a:latin>` slot.
+- [ ] Layer 5: No run from a no-italic script (CJK / Arabic / Hebrew /
+      Devanagari / Thai) has `italic=True` set with a Latin italic
+      face in the `<a:latin>` slot.
+- [ ] **Beyond CJK:** RTL slides set `<a:rtl val="1"/>` on the
+      paragraph's `pPr`. Cursor `gap` is bumped per the line-height
+      table above when the deck includes Vietnamese, Devanagari, Thai,
+      or Khmer content.
 
 If all five pass and the user still reports "the type looks wrong",
 ask for a screenshot pointing at the specific glyph or word — the

--- a/skills/pptx-html-fidelity-audit/references/layout-discipline.md
+++ b/skills/pptx-html-fidelity-audit/references/layout-discipline.md
@@ -91,6 +91,15 @@ add_pipeline(slide, top=c.take(Inches(2.6), label="pipeline"))
 > block, or override the `Cursor` default at the top of your export.
 > The full per-script table is in
 > [`font-discipline.md` § Line height per script](font-discipline.md).
+>
+> **Detecting the highest-demand script in a mixed deck.** A deck
+> can mix `en` slides with `th` slides — locale alone isn't the
+> signal. Scan each slide's text against the Unicode ranges in
+> `font-discipline.md` Layer 5's `NO_ITALIC_RANGES` (extend with the
+> Vietnamese Extended block U+1E00–U+1EFF for ếẫỗ), record the
+> per-slide max-gap, and instantiate the slide's `Cursor` with that
+> value. For a uniform deck-wide setting, take the max across all
+> slides.
 
 If a slide raises `OverflowError`, fix one of three things:
 

--- a/skills/pptx-html-fidelity-audit/references/layout-discipline.md
+++ b/skills/pptx-html-fidelity-audit/references/layout-discipline.md
@@ -84,6 +84,14 @@ add_lead(slide,   top=c.take(Inches(0.8),  label="lead"))
 add_pipeline(slide, top=c.take(Inches(2.6), label="pipeline"))
 ```
 
+> **Per-script `gap` tuning.** The default `Inches(0.12)` matches 14pt
+> Latin body copy. Decks that include CJK, Devanagari, Thai, or
+> Khmer need more breathing room — line clusters and stacked tone
+> marks bump the rendered line height. Pass an explicit `gap=` per
+> block, or override the `Cursor` default at the top of your export.
+> The full per-script table is in
+> [`font-discipline.md` § Line height per script](font-discipline.md).
+
 If a slide raises `OverflowError`, fix one of three things:
 
 1. **Reduce block height** — the box was generously sized; tighten to actual text height.


### PR DESCRIPTION
Follow-up to #307. The audit skill landed with CJK-biased depth — italic guidance, font-fallback notes, and line-height tuning all assumed zh-CN / zh-TW / ja / ko as the non-Latin axis. The repo also ships **fa** (RTL), **ru** (Cyrillic), **de / es / pt-BR / hu** (Vietnamese-like Latin Extended), and the team is actively discussing Devanagari / Thai work. This PR closes the obvious gaps without expanding scope to a full RTL / bidi discipline (which deserves its own PR).

## What changes

### `references/font-discipline.md`

- **Layer 1** gains a "Coverage gap for Latin-slot scripts" callout. Cyrillic / Greek / Vietnamese all go through `<a:latin>`, but Playfair Display / Source Serif 4 have weak Cyrillic / Greek coverage and most display fonts drop Vietnamese Extended diacritics (ếẫỡ). PowerPoint silently falls back to Calibri mid-paragraph; readers see what looks like a styling bug. Includes an `fc-query` snippet for checking glyph coverage.
- **Layer 5** retitles from "CJK + Latin italic" to "Italic + script interaction" and broadens the rule: italic only applies to scripts with an italic tradition (Latin / Cyrillic / Greek). The implementation function now checks **11 Unicode ranges** (CJK Han, Hiragana, Katakana, Hangul, Hebrew, Arabic, Arabic Supplement, Devanagari, Bengali, Thai, Khmer) instead of just CJK.
- **New section: "Beyond CJK — other scripts"** — a 7-row reference table mapping each script family → XML slot (`latin` / `ea` / `cs`) → italic OK? → most common defect → recommended faces. RTL handling is sign-posted as needing manual review since `verify_layout.py` doesn't check `<a:rtl>` today.
- **New section: "Line height per script"** — per-script \`Cursor\` gap recommendations. Devanagari / Thai / Khmer need 0.16-0.18\" headroom (vs. the 0.12\" Latin default) because of stacked diacritics, matras, and tone marks. Latin with Vietnamese Extended needs 0.14\".
- **Audit checklist** reflects the broader rule and adds a "Beyond CJK" line for RTL / non-Latin-CJK content.

### `SKILL.md`

- Anti-pattern entry rewritten from "Italicizing CJK display type" → "Italicizing scripts that have no italic tradition", listing all 6 affected script families.

### `references/layout-discipline.md`

- Cursor section gains a per-script `gap` tuning callout pointing at the new font-discipline.md table.

## Sanity check

Tested the Unicode range table against representative strings in 7 scripts:

```
'開始'   → no-italic ✓ (CJK)
'hello'  → italic-ok ✓ (Latin)
'שלום'   → no-italic ✓ (Hebrew)
'السلام' → no-italic ✓ (Arabic)
'नमस्ते'   → no-italic ✓ (Devanagari)
'สวัสดี'   → no-italic ✓ (Thai)
'Привет' → italic-ok ✓ (Cyrillic)
'In 2026 開始' → no-italic ✓ (mixed)
```

`pnpm --filter @open-design/web test` → 117/117 passing locally.

## Out of scope (Tier 2 follow-ups)

These are flagged for future work, not deferred indefinitely:

- **Full RTL discipline reference** (`rtl-discipline.md`): bidi rules, margin mirroring, paragraph-direction propagation. Needed for fa / ar / he users.
- **`verify_layout.py --rtl` mode**: assert `<a:rtl val="1"/>` on RTL-tagged slides.
- **`verify_layout.py` glyph-coverage check**: detect missing glyphs per run. Would need fonttools and per-run script detection.
- **Vertical text (tategaki) and Furigana** for traditional Japanese layouts. Both are python-pptx-limited and rare; will address if a real use case appears.

## Test plan

- [ ] Open the rendered `font-discipline.md` and `layout-discipline.md` on GitHub; confirm tables render correctly.
- [ ] Apply the broadened `add_run_with_italic_safety()` to a test deck with mixed-script content (e.g. `"In <em>2026</em> 開始"` and `"<em>Innovate</em> שלום"`); confirm italic only applies to the Latin segments.
- [ ] On a deck with Devanagari content, exporting with the default `gap=0.12"` should reproduce a footer-rail violation; bumping to `gap=0.16"` per the new table should clear it.