### PR TITLE
[codex] Add Windows Bud Check launchers

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -75,6 +75,28 @@ pnpm typecheck                 # workspace typecheck
 
 `pnpm tools-dev` is the only local lifecycle entry point. Do not use the removed legacy root aliases (`pnpm dev`, `pnpm dev:all`, `pnpm daemon`, `pnpm preview`, `pnpm start`).
 
+## Windows helper launchers
+
+For native Windows setups that need Open Design to coexist with another local app, this repo includes helper batch files:
+
+```bat
+start_open_design_budcheck.bat
+stop_open_design_budcheck.bat
+```
+
+`start_open_design_budcheck.bat` runs Open Design in the dedicated `budcheck-design` namespace and pins ports to avoid conflict with a typical Bud Check local setup:
+
+- Bud Check frontend: `127.0.0.1:3000`
+- Bud Check backend: `127.0.0.1:8000`
+- Open Design web: `127.0.0.1:5175`
+- Open Design daemon: `127.0.0.1:7457`
+
+Equivalent manual command:
+
+```bash
+corepack pnpm exec tools-dev run web --namespace budcheck-design --daemon-port 7457 --web-port 5175
+```
+
 During local development, `tools-dev` starts the daemon first, passes its port into `apps/web`, and `apps/web/next.config.ts` rewrites `/api/*`, `/artifacts/*`, and `/frames/*` to that daemon port so the App Router app can talk to the sibling Express process without CORS setup.
 
 ## Media generation / agent dispatcher checks

--- a/README.md
+++ b/README.md
@@ -697,6 +697,15 @@ Issues, PRs, new skills, and new design systems are all welcome. The highest-lev
 
 Full walkthrough, bar-for-merging, code style, and what we don't accept → [`CONTRIBUTING.md`](CONTRIBUTING.md) ([Deutsch](CONTRIBUTING.de.md), [简体中文](CONTRIBUTING.zh-CN.md)).
 
+## Windows local coexistence
+
+If you are running Open Design alongside another local product on Windows, use the bundled helper launchers:
+
+- [`start_open_design_budcheck.bat`](start_open_design_budcheck.bat)
+- [`stop_open_design_budcheck.bat`](stop_open_design_budcheck.bat)
+
+They reserve a separate runtime namespace and fixed ports so Open Design can run next to a Bud Check dev stack without colliding with `127.0.0.1:3000` or `127.0.0.1:8000`.
+
 ## Contributors
 
 Thanks to everyone who has helped move Open Design forward — through code, docs, feedback, new skills, new design systems, or even a sharp issue. Every real contribution counts, and the wall below is the easiest way to say so out loud.

--- a/start_open_design_budcheck.bat
+++ b/start_open_design_budcheck.bat
@@ -1,0 +1,41 @@
+@echo off
+setlocal
+
+cd /d "%~dp0"
+
+set "OD_NAMESPACE=budcheck-design"
+set "OD_WEB_PORT=5175"
+set "OD_DAEMON_PORT=7457"
+
+echo [INFO] Starting Open Design in parallel with Bud Check...
+echo [INFO] Bud Check uses:        http://127.0.0.1:3000 and http://127.0.0.1:8000
+echo [INFO] Open Design will use:  http://127.0.0.1:%OD_WEB_PORT% and http://127.0.0.1:%OD_DAEMON_PORT%
+echo.
+
+where corepack >nul 2>&1
+if errorlevel 1 (
+  echo [ERROR] corepack was not found in PATH.
+  echo [ERROR] Install Node.js 24.x and ensure corepack is available, then try again.
+  pause
+  exit /b 1
+)
+
+call corepack pnpm exec tools-dev stop web --namespace %OD_NAMESPACE% >nul 2>&1
+
+echo [INFO] Launching Open Design web runtime...
+echo [INFO] Web:    http://127.0.0.1:%OD_WEB_PORT%/
+echo [INFO] Daemon: http://127.0.0.1:%OD_DAEMON_PORT%/
+echo [INFO] Press Ctrl+C in this window to stop Open Design.
+echo.
+
+call corepack pnpm exec tools-dev run web --namespace %OD_NAMESPACE% --daemon-port %OD_DAEMON_PORT% --web-port %OD_WEB_PORT%
+set "EXIT_CODE=%ERRORLEVEL%"
+
+if not "%EXIT_CODE%"=="0" (
+  echo.
+  echo [ERROR] Open Design failed to start.
+  echo [HINT] Check whether port %OD_WEB_PORT% or %OD_DAEMON_PORT% is already busy.
+  pause
+)
+
+endlocal & exit /b %EXIT_CODE%

--- a/stop_open_design_budcheck.bat
+++ b/stop_open_design_budcheck.bat
@@ -1,0 +1,24 @@
+@echo off
+setlocal
+
+cd /d "%~dp0"
+set "OD_NAMESPACE=budcheck-design"
+
+where corepack >nul 2>&1
+if errorlevel 1 (
+  echo [ERROR] corepack was not found in PATH.
+  pause
+  exit /b 1
+)
+
+echo [INFO] Stopping Open Design runtime for namespace %OD_NAMESPACE%...
+call corepack pnpm exec tools-dev stop web --namespace %OD_NAMESPACE%
+set "EXIT_CODE=%ERRORLEVEL%"
+
+if "%EXIT_CODE%"=="0" (
+  echo [INFO] Open Design stopped.
+) else (
+  echo [WARN] tools-dev returned exit code %EXIT_CODE%.
+)
+
+endlocal & exit /b %EXIT_CODE%


### PR DESCRIPTION
## What changed

- added `start_open_design_budcheck.bat` for a Windows-native Open Design launcher that avoids Bud Check port collisions
- added `stop_open_design_budcheck.bat` to stop that dedicated runtime cleanly
- documented the fixed `5175` web and `7457` daemon ports in `QUICKSTART.md`
- added a short Windows coexistence note to `README.md`

## Why

Running Open Design next to a local Bud Check stack on Windows should not collide with Bud Check's `127.0.0.1:3000` frontend or `127.0.0.1:8000` backend.

## Impact

Windows users can now launch Open Design in a dedicated namespace with deterministic ports and keep Bud Check running at the same time.

## Validation

- `start_open_design_budcheck.bat`
- `corepack pnpm exec tools-dev status web --namespace budcheck-design`
- `Invoke-WebRequest http://127.0.0.1:5175/`
- `Invoke-WebRequest http://127.0.0.1:7457/api/health`
