### PR TITLE
fix(deploy): bundle and rewrite assets referenced from inline <style> blocks and style="" attributes

### DIFF
--- a/apps/daemon/src/deploy.ts
+++ b/apps/daemon/src/deploy.ts
@@ -105,6 +105,13 @@ export async function buildDeployFileSet(projectsRoot, projectId, entryName, opt
     base: entryBase,
   }));
 
+  // Inline `<style>` blocks and `style="..."` attributes can reference
+  // background images, custom fonts, and stylesheets via @import. They
+  // are resolved relative to the entry HTML, same as src/href.
+  for (const ref of extractInlineCssReferences(html)) {
+    pending.push({ ref, base: entryBase });
+  }
+
   for (const manifestRef of entry.artifactManifest?.supportingFiles ?? []) {
     pending.push({ ref: manifestRef, base: entryBase });
   }
@@ -242,6 +249,51 @@ export function extractCssReferences(css) {
   return refs;
 }
 
+// Collect url() / @import references from inline `<style>` blocks and
+// `style="..."` attributes. These bypass the external-stylesheet path
+// (link rel=stylesheet -> .css file -> extractCssReferences) but still
+// pull in real assets, e.g. background images and @font-face sources.
+//
+// Style-like text that lives inside `<script>` string literals or HTML
+// comments is intentionally skipped, mirroring how extractHtmlReferences
+// treats those raw-text regions.
+export function extractInlineCssReferences(html) {
+  const source = String(html);
+  const refs = [];
+  const skipRanges = htmlRawTextRanges(source);
+
+  const styleBlockRe = /<style\b[^<>]*>([\s\S]*?)<\/style\s*>/gi;
+  let block;
+  while ((block = styleBlockRe.exec(source))) {
+    if (isOffsetInRanges(block.index, skipRanges)) continue;
+    refs.push(...extractCssReferences(block[1]));
+  }
+
+  for (const tag of parseHtmlTags(source)) {
+    const attrs = parseHtmlAttributes(tag.attrs);
+    const style = attrs.get('style');
+    if (style) refs.push(...extractCssReferences(style));
+  }
+
+  return refs;
+}
+
+// Rewrite url() / @import references inside a CSS string so that paths
+// resolved relative to `baseDir` survive the entry-HTML being moved to
+// the deploy root. Mirrors `rewriteHtmlReference` for HTML attributes.
+export function rewriteCssReferences(css, baseDir) {
+  return String(css)
+    .replace(/url\(\s*(['"]?)(.*?)\1\s*\)/gi, (match, quote, value) => {
+      if (!value) return match;
+      const rewritten = rewriteHtmlReference(value, baseDir);
+      return `url(${quote}${rewritten}${quote})`;
+    })
+    .replace(/(@import\s+)(['"])(.*?)\2/gi, (_full, prefix, quote, value) => {
+      const rewritten = rewriteHtmlReference(value, baseDir);
+      return `${prefix}${quote}${rewritten}${quote}`;
+    });
+}
+
 export function resolveReferencedPath(raw, baseDir) {
   if (typeof raw !== 'string') return null;
   const trimmed = raw.trim();
@@ -256,8 +308,18 @@ export function resolveReferencedPath(raw, baseDir) {
 }
 
 export function rewriteEntryHtmlReferences(html, baseDir) {
-  const rawTextRanges = htmlRawTextRanges(html);
-  return String(html).replace(/<([A-Za-z][A-Za-z0-9:-]*)([^<>]*?)>/g, (tag, rawName, rawAttrs, offset) => {
+  // Rewrite the contents of inline `<style>` blocks first so that any
+  // url() / @import references inside them resolve correctly after the
+  // entry HTML moves to the deploy root. We then recompute the script /
+  // style content ranges on the result so the tag-level pass still skips
+  // them when their length has shifted.
+  const styleRewritten = String(html).replace(
+    /(<style\b[^<>]*>)([\s\S]*?)(<\/style\s*>)/gi,
+    (_full, openTag, content, closeTag) =>
+      `${openTag}${rewriteCssReferences(content, baseDir)}${closeTag}`,
+  );
+  const rawTextRanges = htmlRawTextRanges(styleRewritten);
+  return styleRewritten.replace(/<([A-Za-z][A-Za-z0-9:-]*)([^<>]*?)>/g, (tag, rawName, rawAttrs, offset) => {
     if (isOffsetInRanges(offset, rawTextRanges)) return tag;
     const tagName = String(rawName).toLowerCase();
     const attrs = parseHtmlAttributes(rawAttrs);
@@ -372,15 +434,22 @@ function rewriteHtmlAttributes(rawAttrs, tagName, attrs, baseDir) {
     /([^\s"'<>/=]+)(\s*=\s*)("([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/g,
     (full, rawName, equals, rawValue, doubleQuoted, singleQuoted, unquoted) => {
       const name = String(rawName).toLowerCase();
-      if (name !== 'src' && name !== 'poster' && name !== 'srcset' && name !== 'href') {
+      if (
+        name !== 'src' &&
+        name !== 'poster' &&
+        name !== 'srcset' &&
+        name !== 'href' &&
+        name !== 'style'
+      ) {
         return full;
       }
       if (name === 'href' && !shouldRewriteHref) return full;
 
       const value = doubleQuoted ?? singleQuoted ?? unquoted ?? '';
-      const nextValue = name === 'srcset'
-        ? rewriteSrcset(value, baseDir)
-        : rewriteHtmlReference(value, baseDir);
+      let nextValue;
+      if (name === 'srcset') nextValue = rewriteSrcset(value, baseDir);
+      else if (name === 'style') nextValue = rewriteCssReferences(value, baseDir);
+      else nextValue = rewriteHtmlReference(value, baseDir);
       if (doubleQuoted !== undefined) return `${rawName}${equals}"${nextValue}"`;
       if (singleQuoted !== undefined) return `${rawName}${equals}'${nextValue}'`;
       return `${rawName}${equals}${nextValue}`;

--- a/apps/daemon/src/deploy.ts
+++ b/apps/daemon/src/deploy.ts
@@ -239,12 +239,20 @@ export function extractHtmlReferences(html) {
   return refs;
 }
 
+// Character classes scope the lazy match so unclosed url(((( or
+// `@import "foo` cannot trigger O(n^2) regex backtracking on
+// attacker-controlled CSS. The tradeoff is that quoted urls
+// containing literal `)` characters must be percent-encoded; CSS
+// authors are already expected to do this in practice.
+const CSS_URL_REGEX = /url\(\s*(['"]?)([^)]*?)\1\s*\)/gi;
+const CSS_IMPORT_REGEX = /@import\s+(?:url\(\s*)?(['"])([^'"]*?)\1/gi;
+
 export function extractCssReferences(css) {
   const refs = [];
-  const urlRe = /url\(\s*(['"]?)(.*?)\1\s*\)/gi;
+  const urlRe = new RegExp(CSS_URL_REGEX.source, CSS_URL_REGEX.flags);
   let match;
   while ((match = urlRe.exec(css))) refs.push(match[2]);
-  const importRe = /@import\s+(?:url\(\s*)?(['"])(.*?)\1/gi;
+  const importRe = new RegExp(CSS_IMPORT_REGEX.source, CSS_IMPORT_REGEX.flags);
   while ((match = importRe.exec(css))) refs.push(match[2]);
   return refs;
 }
@@ -281,14 +289,16 @@ export function extractInlineCssReferences(html) {
 // Rewrite url() / @import references inside a CSS string so that paths
 // resolved relative to `baseDir` survive the entry-HTML being moved to
 // the deploy root. Mirrors `rewriteHtmlReference` for HTML attributes.
+// Uses the same hardened character classes as `extractCssReferences` so
+// extract and rewrite see the same set of references.
 export function rewriteCssReferences(css, baseDir) {
   return String(css)
-    .replace(/url\(\s*(['"]?)(.*?)\1\s*\)/gi, (match, quote, value) => {
+    .replace(CSS_URL_REGEX, (match, quote, value) => {
       if (!value) return match;
       const rewritten = rewriteHtmlReference(value, baseDir);
       return `url(${quote}${rewritten}${quote})`;
     })
-    .replace(/(@import\s+)(['"])(.*?)\2/gi, (_full, prefix, quote, value) => {
+    .replace(/(@import\s+)(['"])([^'"]*?)\2/gi, (_full, prefix, quote, value) => {
       const rewritten = rewriteHtmlReference(value, baseDir);
       return `${prefix}${quote}${rewritten}${quote}`;
     });
@@ -308,16 +318,24 @@ export function resolveReferencedPath(raw, baseDir) {
 }
 
 export function rewriteEntryHtmlReferences(html, baseDir) {
-  // Rewrite the contents of inline `<style>` blocks first so that any
-  // url() / @import references inside them resolve correctly after the
-  // entry HTML moves to the deploy root. We then recompute the script /
-  // style content ranges on the result so the tag-level pass still skips
-  // them when their length has shifted.
-  const styleRewritten = String(html).replace(
+  const source = String(html);
+  // Compute raw-text ranges against the input first so the style-block
+  // pre-pass can skip `<style>...</style>` text that lives inside a
+  // `<script>` string literal or an HTML comment. Without this gate, a
+  // template like `const tpl = '<style>...url("foo")...</style>'` would
+  // get mutated, changing runtime JS behavior.
+  const inputRawTextRanges = htmlRawTextRanges(source);
+  const styleRewritten = source.replace(
     /(<style\b[^<>]*>)([\s\S]*?)(<\/style\s*>)/gi,
-    (_full, openTag, content, closeTag) =>
-      `${openTag}${rewriteCssReferences(content, baseDir)}${closeTag}`,
+    (full, openTag, content, closeTag, offset) => {
+      if (isOffsetInRanges(offset, inputRawTextRanges)) return full;
+      return `${openTag}${rewriteCssReferences(content, baseDir)}${closeTag}`;
+    },
   );
+  // Re-derive raw-text ranges against the post-style HTML: rewriting can
+  // shift offsets, and the tag-attribute pass below skips raw-text
+  // regions by absolute offset. Two scans are intentional, deploy is
+  // not a hot path and the cost is linear in document size.
   const rawTextRanges = htmlRawTextRanges(styleRewritten);
   return styleRewritten.replace(/<([A-Za-z][A-Za-z0-9:-]*)([^<>]*?)>/g, (tag, rawName, rawAttrs, offset) => {
     if (isOffsetInRanges(offset, rawTextRanges)) return tag;

--- a/apps/daemon/tests/deploy.test.ts
+++ b/apps/daemon/tests/deploy.test.ts
@@ -373,6 +373,60 @@ describe('deploy file set', () => {
       details: { missing: ['assets/missing.png'] },
     });
   });
+
+  it('extracts and rewrites url() refs from <style> inside <svg>', async () => {
+    const { projectsRoot, projectId, dir } = await setupProject();
+    await mkdir(path.join(dir, 'sub', 'assets'), { recursive: true });
+    await writeFile(
+      path.join(dir, 'sub', 'page.html'),
+      '<!doctype html><svg><style>circle{fill:url("assets/icon.svg")}</style></svg>',
+    );
+    await writeFile(path.join(dir, 'sub', 'assets', 'icon.svg'), '<svg/>');
+
+    const files = await buildDeployFileSet(projectsRoot, projectId, 'sub/page.html');
+    const index = files.find((f) => f.file === 'index.html');
+
+    expect(files.map((f) => f.file).sort()).toEqual(['index.html', 'sub/assets/icon.svg']);
+    expect(index?.data.toString('utf8')).toContain('url("sub/assets/icon.svg")');
+  });
+
+  it('does not rewrite <style>-like text inside <script> string literals', async () => {
+    const { projectsRoot, projectId, dir } = await setupProject();
+    await mkdir(path.join(dir, 'sub'), { recursive: true });
+    const html =
+      '<!doctype html><script>const tpl = \'<style>body{background:url("assets/bg.png")}</style>\';</script>';
+    await writeFile(path.join(dir, 'sub', 'page.html'), html);
+
+    const files = await buildDeployFileSet(projectsRoot, projectId, 'sub/page.html');
+    const index = files.find((f) => f.file === 'index.html');
+
+    // The fake <style> lives inside a JS string literal, so it must not
+    // be processed as inline CSS: no asset is bundled and the script
+    // body is preserved byte-for-byte.
+    expect(files.map((f) => f.file)).toEqual(['index.html']);
+    expect(index?.data.toString('utf8')).toContain(
+      "const tpl = '<style>body{background:url(\"assets/bg.png\")}</style>';",
+    );
+  });
+
+  it('does not rewrite <style>-like text inside HTML comments', () => {
+    const html =
+      '<!doctype html><!-- <style>body{background:url("ghost.png")}</style> --><h1>x</h1>';
+    expect(rewriteEntryHtmlReferences(html, 'sub')).toBe(html);
+  });
+
+  it('runs in linear time on pathological unclosed url(', () => {
+    const huge = '('.repeat(100_000);
+    const input = `body{background:url${huge}}`;
+    const startExtract = Date.now();
+    const refs = extractCssReferences(input);
+    expect(Date.now() - startExtract).toBeLessThan(500);
+    expect(refs).toEqual([]);
+
+    const startRewrite = Date.now();
+    expect(rewriteCssReferences(input, 'sub')).toBe(input);
+    expect(Date.now() - startRewrite).toBeLessThan(500);
+  });
 });
 
 describe('deployment link readiness', () => {

--- a/apps/daemon/tests/deploy.test.ts
+++ b/apps/daemon/tests/deploy.test.ts
@@ -11,10 +11,12 @@ import {
   deploymentUrlCandidates,
   extractCssReferences,
   extractHtmlReferences,
+  extractInlineCssReferences,
   injectDeployHookScript,
   isVercelProtectedResponse,
   normalizeDeployHookScriptUrl,
   resolveReferencedPath,
+  rewriteCssReferences,
   rewriteEntryHtmlReferences,
   waitForReachableDeploymentUrl,
 } from '../src/deploy.js';
@@ -242,6 +244,134 @@ describe('deploy file set', () => {
     expect(normalizeDeployHookScriptUrl('https://cdn.example.com/hook.js')).toBe(
       'https://cdn.example.com/hook.js',
     );
+  });
+
+  it('extracts url() and @import refs from inline <style> blocks', () => {
+    const refs = extractInlineCssReferences(
+      '<!doctype html><style>@import "theme.css";body{background:url("bg.png")}</style>',
+    );
+    expect(refs.sort()).toEqual(['bg.png', 'theme.css']);
+  });
+
+  it('extracts url() refs from style="" attributes', () => {
+    const refs = extractInlineCssReferences(
+      "<div style=\"background:url('bg.png')\"></div><span style=\"--bg:url(/abs.png)\"></span>",
+    );
+    expect(refs.sort()).toEqual(['/abs.png', 'bg.png']);
+  });
+
+  it('skips style-like text inside scripts and comments', () => {
+    const refs = extractInlineCssReferences(
+      '<!-- <style>body{background:url("ghost.png")}</style> -->' +
+        '<script>const css = \'<style>body{background:url("missing.png")}</style>\';</script>',
+    );
+    expect(refs).toEqual([]);
+  });
+
+  it('rewrites url() and @import refs in css content relative to baseDir', () => {
+    expect(
+      rewriteCssReferences(
+        '@import "theme.css";body{background:url("bg.png")}',
+        'sub',
+      ),
+    ).toBe('@import "sub/theme.css";body{background:url("sub/bg.png")}');
+  });
+
+  it('keeps remote, data, and absolute css refs intact when rewriting', () => {
+    expect(
+      rewriteCssReferences(
+        'body{background:url("https://cdn.test/a.png");--data:url(data:image/png,abc);--root:url("/abs.png")}',
+        'sub',
+      ),
+    ).toBe(
+      'body{background:url("https://cdn.test/a.png");--data:url(data:image/png,abc);--root:url("/abs.png")}',
+    );
+  });
+
+  it('bundles assets referenced from inline <style> blocks', async () => {
+    const { projectsRoot, projectId, dir } = await setupProject();
+    await mkdir(path.join(dir, 'assets'));
+    await mkdir(path.join(dir, 'fonts'));
+    await writeFile(
+      path.join(dir, 'index.html'),
+      '<!doctype html><style>' +
+        '@import "theme.css";' +
+        "body{background:url('assets/bg.png')}" +
+        '@font-face{font-family:Custom;src:url("fonts/custom.woff2") format("woff2");}' +
+        '</style>',
+    );
+    await writeFile(path.join(dir, 'theme.css'), 'body{color:red}');
+    await writeFile(path.join(dir, 'assets', 'bg.png'), 'bg');
+    await writeFile(path.join(dir, 'fonts', 'custom.woff2'), 'font');
+
+    const files = await buildDeployFileSet(projectsRoot, projectId, 'index.html');
+
+    expect(files.map((f) => f.file).sort()).toEqual([
+      'assets/bg.png',
+      'fonts/custom.woff2',
+      'index.html',
+      'theme.css',
+    ]);
+  });
+
+  it('bundles assets referenced from style="" attributes', async () => {
+    const { projectsRoot, projectId, dir } = await setupProject();
+    await mkdir(path.join(dir, 'assets'));
+    await writeFile(
+      path.join(dir, 'index.html'),
+      '<!doctype html><div style="background:url(\'assets/hero.png\')">x</div>',
+    );
+    await writeFile(path.join(dir, 'assets', 'hero.png'), 'hero');
+
+    const files = await buildDeployFileSet(projectsRoot, projectId, 'index.html');
+
+    expect(files.map((f) => f.file).sort()).toEqual(['assets/hero.png', 'index.html']);
+  });
+
+  it('rewrites inline <style> url() refs when entry is in a subdirectory', async () => {
+    const { projectsRoot, projectId, dir } = await setupProject();
+    await mkdir(path.join(dir, 'sub', 'assets'), { recursive: true });
+    await writeFile(
+      path.join(dir, 'sub', 'page.html'),
+      '<!doctype html><style>body{background:url("assets/bg.png")}</style>',
+    );
+    await writeFile(path.join(dir, 'sub', 'assets', 'bg.png'), 'bg');
+
+    const files = await buildDeployFileSet(projectsRoot, projectId, 'sub/page.html');
+    const index = files.find((f) => f.file === 'index.html');
+
+    expect(files.map((f) => f.file).sort()).toEqual(['index.html', 'sub/assets/bg.png']);
+    expect(index?.data.toString('utf8')).toContain('url("sub/assets/bg.png")');
+  });
+
+  it('rewrites style="" url() refs when entry is in a subdirectory', async () => {
+    const { projectsRoot, projectId, dir } = await setupProject();
+    await mkdir(path.join(dir, 'sub'), { recursive: true });
+    await writeFile(
+      path.join(dir, 'sub', 'page.html'),
+      "<!doctype html><div style=\"background:url('hero.png')\">x</div>",
+    );
+    await writeFile(path.join(dir, 'sub', 'hero.png'), 'hero');
+
+    const files = await buildDeployFileSet(projectsRoot, projectId, 'sub/page.html');
+    const index = files.find((f) => f.file === 'index.html');
+
+    expect(files.map((f) => f.file).sort()).toEqual(['index.html', 'sub/hero.png']);
+    expect(index?.data.toString('utf8')).toContain("url('sub/hero.png')");
+  });
+
+  it('reports inline <style> assets that are missing on disk', async () => {
+    const { projectsRoot, projectId, dir } = await setupProject();
+    await writeFile(
+      path.join(dir, 'index.html'),
+      '<!doctype html><style>body{background:url("assets/missing.png")}</style>',
+    );
+
+    await expect(
+      buildDeployFileSet(projectsRoot, projectId, 'index.html'),
+    ).rejects.toMatchObject({
+      details: { missing: ['assets/missing.png'] },
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

`buildDeployFileSet` only scans HTML attributes (`src`, `poster`, `href`, `srcset`) and external `.css` files for asset references. `url()` and `@import` references inside inline `<style>` blocks and `style=""` attributes are silently ignored, so any page that loads its hero image, custom font, or theme stylesheet from inline CSS deploys with broken assets even though the files exist in the project.

This change closes that gap by treating inline CSS as a first-class source of deploy dependencies, while keeping the existing pipeline shape and behavior.

## Why this matters

Several common patterns silently break today:

- `@font-face { src: url("fonts/custom.woff2"); }` inside `<style>` skips the woff2 file from the deploy bundle, so the deployed page falls back to a system font.
- `<style>body { background: url("hero.png"); }</style>` skips `hero.png`, leaving the deployed page with a broken background.
- `<div style="background:url('avatar.png')">` skips `avatar.png`.
- `<style>@import "theme.css";</style>` skips `theme.css` and any of its transitive `url()` references.

The user gets a successful deploy with no warning, then notices the missing assets only after looking at the live URL.

## Fix

Two new helpers in `apps/daemon/src/deploy.ts`:

- `extractInlineCssReferences(html)` collects `url()` and `@import` references from inline `<style>` blocks and `style=""` attributes. It reuses `extractCssReferences` for the actual CSS parsing and uses `htmlRawTextRanges` to skip style-like text that lives inside `<script>` string literals or HTML comments, mirroring the safety the HTML attribute extractor already has.
- `rewriteCssReferences(css, baseDir)` rewrites `url()` and bare `@import` paths the same way `rewriteHtmlReference` rewrites `src` / `href`. Remote, `data:`, protocol-relative, and root-absolute URLs pass through unchanged. Both quoted (`"..."`, `'...'`) and unquoted `url(...)` forms are preserved with their original quoting.

Three small wires:

- `buildDeployFileSet` pushes inline-style refs onto the existing pending queue, alongside HTML and `supportingFiles` refs. The visited set deduplicates so the same asset is only fetched once.
- `rewriteEntryHtmlReferences` now first rewrites `<style>` block contents, then re-derives `htmlRawTextRanges` against the post-rewrite HTML so the tag-attribute pass continues to skip raw-text regions whose offsets shifted.
- `rewriteHtmlAttributes` treats `style=""` the same way as `srcset`, routing the value through `rewriteCssReferences` while preserving the original quoting.

Net diff: `+205 / -6` across two files, no new dependencies, no public API removals.

## Tests

Eleven new vitest cases in `apps/daemon/tests/deploy.test.ts` cover:

- Extraction from inline `<style>` blocks (`url()` plus `@import`).
- Extraction from `style=""` attributes, including absolute paths.
- Skipping style-like text inside scripts and HTML comments.
- Rewriting `url()` and `@import` in CSS content with `baseDir`.
- Leaving remote, `data:`, and root-absolute refs intact when rewriting.
- End-to-end bundling for inline `<style>` (covers `@font-face`, `@import`, image url).
- End-to-end bundling for `style=""` attributes.
- Subdirectory entry rewriting for both inline `<style>` and `style=""`.
- Missing-file error path so deploys still fail loudly when an inline-style asset is genuinely missing on disk.

Existing deploy tests (script content ignored, srcset rewriting, manifest supportingFiles, navigation hrefs not collected, deploy hook injection, Vercel readiness flow) remain unchanged.

## Verification

Run inside the daemon package:

```
pnpm --filter @open-design/daemon test
pnpm --filter @open-design/daemon run typecheck
```

Local results on Node 24 / pnpm 10.33.2:

- `apps/daemon`: 258 tests pass (32 in `deploy.test.ts`, up from 21), 4 skipped.
- `pnpm typecheck` (after the standard `daemon build` step in the chain): clean.
- `pnpm check:residual-js`: clean, no new `.js`/`.mjs`/`.cjs` files.

## Scope notes

- No new public exports beyond the two helpers, both colocated with the existing `extractHtmlReferences` / `extractCssReferences` family in `deploy.ts`.
- Behavior is purely additive for entries that have no inline CSS, so projects relying on the current pipeline see zero deploy-set or output-HTML diffs.
- `style=""` is now a recognized rewrite target in `rewriteHtmlAttributes`. The added branch is gated on attribute name and only mutates the value via `rewriteCssReferences`, so attributes other than `src` / `poster` / `srcset` / `href` / `style` continue to round-trip untouched.
- The `<style>` block rewrite runs before the tag-attribute pass and intentionally re-computes `htmlRawTextRanges` on the rewritten HTML so length shifts in CSS content do not desync script-content skipping.