### PR TITLE
fix(daemon): increase projectUpload limit from 20MB to 200MB

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -411,7 +411,7 @@ const projectUpload = multer({
       cb(null, `${Date.now().toString(36)}-${safe}`);
     },
   }),
-  limits: { fileSize: 20 * 1024 * 1024 },
+  limits: { fileSize: 200 * 1024 * 1024 },  // 200MB — covers the largest design assets we expect (PPTX/PDF/raw images)
 });
 
 function handleProjectUpload(req, res, next) {


### PR DESCRIPTION
Fixes #318

## Problem

The `/api/projects/:id/upload` endpoint used the `projectUpload` multer handler with a **20MB** limit. Large design files (e.g., 47MB PPTX) were rejected with **HTTP 413 Payload Too Large**.

## Root cause

`apps/daemon/src/server.ts:414` set:
```ts
limits: { fileSize: 20 * 1024 * 1024 },  // 20MB
```

## Fix

Bumped to **200MB** (originally proposed 100MB; widened during review so the ceiling comfortably clears heavy design assets — high-fidelity PPTX exports, raw camera images, multi-page PDF sources — without forcing chunked-upload work on the project-side path).

The daemon listens on `127.0.0.1` only and uses multer's disk-storage backend, so per-request memory pressure stays bounded regardless of file size.

`importUpload` (separate `/api/import/claude-design` route) keeps its 100MB limit — the two endpoints don't have to match and bumping import in lockstep is a separate decision.

## Testing

- Verified the change in `apps/daemon/src/server.ts:414`
- Inline comment updated to reflect the 200MB rationale
- External contributor @GarryLai confirmed the original 20MB issue with a 47MB PPTX

## Related

- External contributor: @GarryLai
- Issue: #318