### PR TITLE
feat(deploy): add /api/projects/:id/deploy/preflight for pre-upload inspection

### DIFF
--- a/apps/daemon/src/deploy.ts
+++ b/apps/daemon/src/deploy.ts
@@ -76,7 +76,12 @@ export function publicDeployConfig(config) {
   };
 }
 
-export async function buildDeployFileSet(projectsRoot, projectId, entryName, options = {}) {
+// Walk the entry HTML and any referenced CSS, producing the full set of
+// files that would be uploaded for a deploy along with the lists of
+// missing and invalid references. Does not throw on a partial result so
+// callers can distinguish between "ready to ship" and "ready except for
+// these specific issues" without parsing an error string.
+export async function buildDeployFilePlan(projectsRoot, projectId, entryName, options = {}) {
   const entryPath = validateProjectPath(entryName);
   if (!/\.html?$/i.test(entryPath)) {
     throw new DeployError('Only HTML files can be deployed.', 400);
@@ -150,17 +155,27 @@ export async function buildDeployFileSet(projectsRoot, projectId, entryName, opt
     }
   }
 
-  if (missing.length || invalid.length) {
+  return {
+    entryPath,
+    html,
+    files: Array.from(files.values()),
+    missing,
+    invalid,
+  };
+}
+
+export async function buildDeployFileSet(projectsRoot, projectId, entryName, options = {}) {
+  const plan = await buildDeployFilePlan(projectsRoot, projectId, entryName, options);
+  if (plan.missing.length || plan.invalid.length) {
     const parts = [];
-    if (missing.length) parts.push(`missing: ${missing.join(', ')}`);
-    if (invalid.length) parts.push(`invalid: ${invalid.join(', ')}`);
+    if (plan.missing.length) parts.push(`missing: ${plan.missing.join(', ')}`);
+    if (plan.invalid.length) parts.push(`invalid: ${plan.invalid.join(', ')}`);
     throw new DeployError(`Could not deploy referenced files (${parts.join('; ')}).`, 400, {
-      missing,
-      invalid,
+      missing: plan.missing,
+      invalid: plan.invalid,
     });
   }
-
-  return Array.from(files.values());
+  return plan.files;
 }
 
 export async function deployToVercel({ config, files, projectId }) {
@@ -263,6 +278,170 @@ export function rewriteEntryHtmlReferences(html, baseDir) {
     const attrs = parseHtmlAttributes(rawAttrs);
     return `<${rawName}${rewriteHtmlAttributes(rawAttrs, tagName, attrs, baseDir)}>`;
   });
+}
+
+// Soft thresholds chosen against Vercel's v13 deployment shape and
+// typical first-paint budgets. Per-asset is a usability hint, not a
+// hard cap; bundle is a margin against Vercel's 100MB request body
+// (each file is base64-encoded which adds ~33%, so 75MiB pre-encoded
+// is the safer ceiling).
+export const DEPLOY_PREFLIGHT_LARGE_ASSET_BYTES = 4 * 1024 * 1024;
+export const DEPLOY_PREFLIGHT_LARGE_BUNDLE_BYTES = 75 * 1024 * 1024;
+export const DEPLOY_PREFLIGHT_LARGE_HTML_BYTES = 1 * 1024 * 1024;
+
+function isExternalUrl(value) {
+  if (typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  if (/^[A-Za-z][A-Za-z0-9+.-]*:/.test(trimmed)) return true;
+  if (trimmed.startsWith('//')) return true;
+  return false;
+}
+
+function pushUnique(list, warning) {
+  const key = `${warning.code}:${warning.path ?? ''}:${warning.url ?? ''}`;
+  if (list.seen.has(key)) return;
+  list.seen.add(key);
+  list.warnings.push(warning);
+}
+
+// Walk the entry HTML once to gather signals that affect deployment
+// quality without touching the network. Returns a structured warning
+// list the UI can render verbatim.
+export function analyzeDeployPlan(input: {
+  entryPath: string;
+  html: string;
+  files: any[];
+  missing?: any[];
+  invalid?: any[];
+}): { warnings: any[]; totalBytes: number; totalFiles: number } {
+  const { entryPath, html, files } = input;
+  const missing = input.missing ?? [];
+  const invalid = input.invalid ?? [];
+  const acc: { warnings: any[]; seen: Set<string> } = { warnings: [], seen: new Set() };
+
+  for (const ref of missing) {
+    pushUnique(acc, {
+      code: 'broken-reference',
+      path: ref,
+      message: `Referenced file is missing on disk: ${ref}`,
+    });
+  }
+  for (const ref of invalid) {
+    pushUnique(acc, {
+      code: 'invalid-reference',
+      path: ref,
+      message: `Reference is not a valid project path: ${ref}`,
+    });
+  }
+
+  let totalBytes = 0;
+  let entrySize = 0;
+  for (const f of files || []) {
+    const size = f.data?.length ?? 0;
+    totalBytes += size;
+    if (f.file === 'index.html') entrySize = size;
+    if (size > DEPLOY_PREFLIGHT_LARGE_ASSET_BYTES && f.file !== 'index.html') {
+      pushUnique(acc, {
+        code: 'large-asset',
+        path: f.file,
+        size,
+        message: `Asset is ${formatMib(size)}, larger than ${formatMib(DEPLOY_PREFLIGHT_LARGE_ASSET_BYTES)}; consider compressing or hosting on a CDN.`,
+      });
+    }
+  }
+
+  if (entrySize > DEPLOY_PREFLIGHT_LARGE_HTML_BYTES) {
+    pushUnique(acc, {
+      code: 'large-html',
+      path: 'index.html',
+      size: entrySize,
+      message: `Entry HTML is ${formatMib(entrySize)}; large HTML inflates time-to-first-paint.`,
+    });
+  }
+  if (totalBytes > DEPLOY_PREFLIGHT_LARGE_BUNDLE_BYTES) {
+    pushUnique(acc, {
+      code: 'large-bundle',
+      size: totalBytes,
+      message: `Bundle is ${formatMib(totalBytes)}; Vercel rejects deploy bodies above ~100MB after base64 encoding.`,
+    });
+  }
+
+  const source = String(html ?? '');
+  if (!/<!doctype\s+html/i.test(source)) {
+    pushUnique(acc, {
+      code: 'no-doctype',
+      path: entryPath,
+      message: 'Entry HTML is missing `<!DOCTYPE html>`; browsers may render in quirks mode.',
+    });
+  }
+
+  let hasViewport = false;
+  for (const tag of parseHtmlTags(source)) {
+    const attrs = parseHtmlAttributes(tag.attrs);
+    if (
+      tag.name === 'meta' &&
+      String(attrs.get('name') || '').toLowerCase() === 'viewport'
+    ) {
+      hasViewport = true;
+    }
+    if (tag.name === 'script') {
+      const src = attrs.get('src');
+      if (isExternalUrl(src)) {
+        pushUnique(acc, {
+          code: 'external-script',
+          path: entryPath,
+          url: src,
+          message: `External script will not be vendored into the deploy: ${src}`,
+        });
+      }
+    }
+    if (tag.name === 'link') {
+      const rel = String(attrs.get('rel') || '').toLowerCase();
+      const href = attrs.get('href');
+      if (rel.split(/\s+/).includes('stylesheet') && isExternalUrl(href)) {
+        pushUnique(acc, {
+          code: 'external-stylesheet',
+          path: entryPath,
+          url: href,
+          message: `External stylesheet will not be vendored into the deploy: ${href}`,
+        });
+      }
+    }
+  }
+  if (!hasViewport) {
+    pushUnique(acc, {
+      code: 'no-viewport',
+      path: entryPath,
+      message: 'Entry HTML is missing `<meta name="viewport">`; mobile rendering will be off.',
+    });
+  }
+
+  return { warnings: acc.warnings, totalBytes, totalFiles: (files || []).length };
+}
+
+function formatMib(bytes) {
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MiB`;
+}
+
+// One-shot orchestrator: build the file plan, run the analyzer, and
+// return the typed preflight payload exposed by the daemon.
+export async function prepareDeployPreflight(projectsRoot, projectId, entryName, options = {}) {
+  const plan = await buildDeployFilePlan(projectsRoot, projectId, entryName, options);
+  const { warnings, totalBytes, totalFiles } = analyzeDeployPlan(plan);
+  return {
+    providerId: VERCEL_PROVIDER_ID,
+    entry: plan.entryPath,
+    files: plan.files.map((f) => ({
+      path: f.file,
+      size: f.data?.length ?? 0,
+      mime: f.contentType || 'application/octet-stream',
+      sourcePath: f.sourcePath,
+    })),
+    totalFiles,
+    totalBytes,
+    warnings,
+  };
 }
 
 export function injectDeployHookScript(html, scriptUrl) {

--- a/apps/daemon/src/deploy.ts
+++ b/apps/daemon/src/deploy.ts
@@ -308,6 +308,22 @@ function pushUnique(list, warning) {
 // Walk the entry HTML once to gather signals that affect deployment
 // quality without touching the network. Returns a structured warning
 // list the UI can render verbatim.
+//
+// `entryPath` is used as the warning `path` for HTML-level findings so
+// the UI can deep-link from a warning into the source file the author
+// is actually editing. `files` carries deploy-relative paths (the entry
+// HTML is always renamed to `index.html`) so per-asset warnings live in
+// the deploy namespace.
+/**
+ * @param {{
+ *   entryPath: string,
+ *   html: string,
+ *   files: any[],
+ *   missing?: any[],
+ *   invalid?: any[]
+ * }} input
+ * @returns {{ warnings: any[], totalBytes: number, totalFiles: number }}
+ */
 export function analyzeDeployPlan(input: {
   entryPath: string;
   html: string;
@@ -353,8 +369,11 @@ export function analyzeDeployPlan(input: {
 
   if (entrySize > DEPLOY_PREFLIGHT_LARGE_HTML_BYTES) {
     pushUnique(acc, {
+      // Report against the source entry path so the UI can deep-link
+      // back to the file the author edits, not the deploy-renamed
+      // `index.html` which does not exist in the project tree.
       code: 'large-html',
-      path: 'index.html',
+      path: entryPath,
       size: entrySize,
       message: `Entry HTML is ${formatMib(entrySize)}; large HTML inflates time-to-first-paint.`,
     });
@@ -368,7 +387,14 @@ export function analyzeDeployPlan(input: {
   }
 
   const source = String(html ?? '');
-  if (!/<!doctype\s+html/i.test(source)) {
+  // Anchor to the document prolog so a `<!doctype html>` substring that
+  // happens to live inside a `<script>` template literal or a comment
+  // is not treated as a real declaration. Per HTML5, the prolog may
+  // begin with an optional BOM, then any number of HTML comments and
+  // whitespace, then the doctype. Built via `new RegExp` so the BOM
+  // appears as an explicit U+FEFF escape rather than a literal
+  // zero-width character in the regex source.
+  if (!new RegExp('^\\uFEFF?\\s*(?:<!--[\\s\\S]*?-->\\s*)*<!doctype\\s+html', 'i').test(source)) {
     pushUnique(acc, {
       code: 'no-doctype',
       path: entryPath,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -96,6 +96,7 @@ import {
   checkDeploymentUrl,
   DeployError,
   deployToVercel,
+  prepareDeployPreflight,
   publicDeployConfig,
   readVercelConfig,
   VERCEL_PROVIDER_ID,
@@ -1389,6 +1390,24 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
       const status = err instanceof DeployError ? err.status : 400;
       const init = err instanceof DeployError && err.details ? { details: err.details } : {};
       sendApiError(res, status, status === 404 ? 'FILE_NOT_FOUND' : 'BAD_REQUEST', String(err?.message || err), init);
+    }
+  });
+
+  app.post('/api/projects/:id/deploy/preflight', async (req, res) => {
+    try {
+      const { fileName, providerId = VERCEL_PROVIDER_ID } = req.body || {};
+      if (providerId !== VERCEL_PROVIDER_ID) {
+        return sendApiError(res, 400, 'BAD_REQUEST', 'unsupported deploy provider');
+      }
+      if (typeof fileName !== 'string' || !fileName.trim()) {
+        return sendApiError(res, 400, 'BAD_REQUEST', 'fileName required');
+      }
+      /** @type {import('@open-design/contracts').DeployPreflightResponse} */
+      const body = await prepareDeployPreflight(PROJECTS_DIR, req.params.id, fileName);
+      res.json(body);
+    } catch (err) {
+      const status = err instanceof DeployError ? err.status : 400;
+      sendApiError(res, status, status === 404 ? 'FILE_NOT_FOUND' : 'BAD_REQUEST', String(err?.message || err));
     }
   });
 

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1406,6 +1406,13 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
       const body = await prepareDeployPreflight(PROJECTS_DIR, req.params.id, fileName);
       res.json(body);
     } catch (err) {
+      // DeployError is a known/expected outcome (validation, missing file).
+      // Anything else points at a bug or an unexpected runtime state, so
+      // surface it in the daemon log without leaking internals to the
+      // client which still gets a generic 400.
+      if (!(err instanceof DeployError)) {
+        console.error('[deploy/preflight]', err);
+      }
       const status = err instanceof DeployError ? err.status : 400;
       sendApiError(res, status, status === 404 ? 'FILE_NOT_FOUND' : 'BAD_REQUEST', String(err?.message || err));
     }

--- a/apps/daemon/tests/deploy.test.ts
+++ b/apps/daemon/tests/deploy.test.ts
@@ -6,14 +6,19 @@ import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import {
+  analyzeDeployPlan,
+  buildDeployFilePlan,
   buildDeployFileSet,
   checkDeploymentUrl,
+  DEPLOY_PREFLIGHT_LARGE_ASSET_BYTES,
+  DEPLOY_PREFLIGHT_LARGE_HTML_BYTES,
   deploymentUrlCandidates,
   extractCssReferences,
   extractHtmlReferences,
   injectDeployHookScript,
   isVercelProtectedResponse,
   normalizeDeployHookScriptUrl,
+  prepareDeployPreflight,
   resolveReferencedPath,
   rewriteEntryHtmlReferences,
   waitForReachableDeploymentUrl,
@@ -242,6 +247,190 @@ describe('deploy file set', () => {
     expect(normalizeDeployHookScriptUrl('https://cdn.example.com/hook.js')).toBe(
       'https://cdn.example.com/hook.js',
     );
+  });
+});
+
+describe('deploy plan and analyzer', () => {
+  async function setupProject() {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'od-deploy-plan-test-'));
+    const projectId = 'p1';
+    const dir = await ensureProject(path.join(root, 'projects'), projectId);
+    return { projectsRoot: path.join(root, 'projects'), projectId, dir };
+  }
+
+  it('returns the file set plus missing and invalid lists without throwing', async () => {
+    const { projectsRoot, projectId, dir } = await setupProject();
+    await writeFile(
+      path.join(dir, 'index.html'),
+      '<!doctype html><meta name="viewport" content="width=device-width"><img src="missing.png">',
+    );
+
+    const plan = await buildDeployFilePlan(projectsRoot, projectId, 'index.html');
+    expect(plan.entryPath).toBe('index.html');
+    expect(plan.files.map((f) => f.file)).toEqual(['index.html']);
+    expect(plan.missing).toEqual(['missing.png']);
+    expect(plan.invalid).toEqual([]);
+  });
+
+  it('flags missing assets as broken-reference warnings', () => {
+    const { warnings } = analyzeDeployPlan({
+      entryPath: 'index.html',
+      html: '<!doctype html><meta name="viewport" content="width=device-width">',
+      files: [
+        { file: 'index.html', data: Buffer.from('<!doctype html>'), contentType: 'text/html', sourcePath: 'index.html' },
+      ],
+      missing: ['logo.png'],
+      invalid: [],
+    });
+    expect(warnings).toContainEqual(
+      expect.objectContaining({ code: 'broken-reference', path: 'logo.png' }),
+    );
+  });
+
+  it('flags invalid references separately from missing ones', () => {
+    const { warnings } = analyzeDeployPlan({
+      entryPath: 'index.html',
+      html: '<!doctype html><meta name="viewport" content="width=device-width">',
+      files: [],
+      missing: [],
+      invalid: ['../escape.png'],
+    });
+    expect(warnings).toContainEqual(
+      expect.objectContaining({ code: 'invalid-reference', path: '../escape.png' }),
+    );
+  });
+
+  it('flags missing doctype and viewport', () => {
+    const { warnings } = analyzeDeployPlan({
+      entryPath: 'index.html',
+      html: '<html><body><h1>hi</h1></body></html>',
+      files: [],
+    });
+    const codes = warnings.map((w) => w.code).sort();
+    expect(codes).toEqual(['no-doctype', 'no-viewport']);
+  });
+
+  it('flags external scripts and stylesheets', () => {
+    const { warnings } = analyzeDeployPlan({
+      entryPath: 'index.html',
+      html:
+        '<!doctype html><meta name="viewport" content="width=device-width">' +
+        '<link rel="stylesheet" href="https://cdn.test/x.css">' +
+        '<script src="https://cdn.test/x.js"></script>',
+      files: [],
+    });
+    const codes = warnings.map((w) => w.code).sort();
+    expect(codes).toEqual(['external-script', 'external-stylesheet']);
+    const ext = warnings.find((w) => w.code === 'external-script');
+    expect(ext?.url).toBe('https://cdn.test/x.js');
+  });
+
+  it('does not flag protocol-relative scripts as external when they are in fact external', () => {
+    const { warnings } = analyzeDeployPlan({
+      entryPath: 'index.html',
+      html:
+        '<!doctype html><meta name="viewport" content="width=device-width">' +
+        '<script src="//cdn.test/x.js"></script>',
+      files: [],
+    });
+    expect(warnings).toContainEqual(
+      expect.objectContaining({ code: 'external-script', url: '//cdn.test/x.js' }),
+    );
+  });
+
+  it('flags large per-file assets but not the entry HTML', () => {
+    const big = Buffer.alloc(DEPLOY_PREFLIGHT_LARGE_ASSET_BYTES + 1);
+    const { warnings } = analyzeDeployPlan({
+      entryPath: 'index.html',
+      html: '<!doctype html><meta name="viewport" content="width=device-width">',
+      files: [
+        { file: 'index.html', data: Buffer.alloc(50), contentType: 'text/html', sourcePath: 'index.html' },
+        { file: 'hero.jpg', data: big, contentType: 'image/jpeg', sourcePath: 'hero.jpg' },
+      ],
+    });
+    expect(warnings).toContainEqual(
+      expect.objectContaining({ code: 'large-asset', path: 'hero.jpg' }),
+    );
+    expect(warnings.some((w) => w.code === 'large-html')).toBe(false);
+  });
+
+  it('flags large entry HTML', () => {
+    const huge = Buffer.alloc(DEPLOY_PREFLIGHT_LARGE_HTML_BYTES + 1);
+    const { warnings } = analyzeDeployPlan({
+      entryPath: 'index.html',
+      html: '<!doctype html><meta name="viewport" content="width=device-width">',
+      files: [
+        { file: 'index.html', data: huge, contentType: 'text/html', sourcePath: 'index.html' },
+      ],
+    });
+    expect(warnings).toContainEqual(
+      expect.objectContaining({ code: 'large-html', path: 'index.html' }),
+    );
+  });
+
+  it('returns no warnings on a healthy entry HTML', () => {
+    const { warnings, totalFiles, totalBytes } = analyzeDeployPlan({
+      entryPath: 'index.html',
+      html: '<!doctype html><meta name="viewport" content="width=device-width"><h1>Hello</h1>',
+      files: [
+        { file: 'index.html', data: Buffer.from('<!doctype html><h1>Hello</h1>'), contentType: 'text/html', sourcePath: 'index.html' },
+      ],
+    });
+    expect(warnings).toEqual([]);
+    expect(totalFiles).toBe(1);
+    expect(totalBytes).toBeGreaterThan(0);
+  });
+
+  it('preflight payload includes provider, entry, file list, totals and warnings', async () => {
+    const { projectsRoot, projectId, dir } = await setupProject();
+    await mkdir(path.join(dir, 'assets'));
+    await writeFile(
+      path.join(dir, 'index.html'),
+      '<!doctype html><meta name="viewport" content="width=device-width">' +
+        '<script src="https://cdn.test/x.js"></script>' +
+        '<img src="assets/logo.png">',
+    );
+    await writeFile(path.join(dir, 'assets', 'logo.png'), 'logo');
+
+    const result = await prepareDeployPreflight(projectsRoot, projectId, 'index.html');
+    expect(result.providerId).toBe('vercel-self');
+    expect(result.entry).toBe('index.html');
+    expect(result.totalFiles).toBe(2);
+    expect(result.totalBytes).toBeGreaterThan(0);
+    expect(result.files.map((f) => f.path).sort()).toEqual(['assets/logo.png', 'index.html']);
+    const codes = result.warnings.map((w) => w.code);
+    expect(codes).toContain('external-script');
+    expect(codes).not.toContain('broken-reference');
+  });
+
+  it('preflight reports broken references instead of throwing', async () => {
+    const { projectsRoot, projectId, dir } = await setupProject();
+    await writeFile(
+      path.join(dir, 'index.html'),
+      '<!doctype html><meta name="viewport" content="width=device-width"><img src="missing.png">',
+    );
+
+    const result = await prepareDeployPreflight(projectsRoot, projectId, 'index.html');
+    expect(result.warnings).toContainEqual(
+      expect.objectContaining({ code: 'broken-reference', path: 'missing.png' }),
+    );
+    expect(result.totalFiles).toBe(1);
+  });
+
+  it('preflight rejects non-html entry names', async () => {
+    const { projectsRoot, projectId, dir } = await setupProject();
+    await writeFile(path.join(dir, 'data.json'), '{}');
+    await expect(
+      prepareDeployPreflight(projectsRoot, projectId, 'data.json'),
+    ).rejects.toThrow(/HTML/);
+  });
+
+  it('buildDeployFileSet still throws when missing or invalid refs exist', async () => {
+    const { projectsRoot, projectId, dir } = await setupProject();
+    await writeFile(path.join(dir, 'index.html'), '<img src="missing.png">');
+    await expect(
+      buildDeployFileSet(projectsRoot, projectId, 'index.html'),
+    ).rejects.toMatchObject({ details: { missing: ['missing.png'] } });
   });
 });
 

--- a/apps/daemon/tests/deploy.test.ts
+++ b/apps/daemon/tests/deploy.test.ts
@@ -310,6 +310,25 @@ describe('deploy plan and analyzer', () => {
     expect(codes).toEqual(['no-doctype', 'no-viewport']);
   });
 
+  it('flags missing doctype even when a fake doctype lives inside a <script> string', () => {
+    const html =
+      '<html>' +
+      '<head><meta name="viewport" content="width=device-width">' +
+      '<script>const tpl = `<!doctype html><html></html>`;</script>' +
+      '</head><body><h1>hi</h1></body></html>';
+    const { warnings } = analyzeDeployPlan({ entryPath: 'index.html', html, files: [] });
+    expect(warnings.map((w: any) => w.code)).toContain('no-doctype');
+  });
+
+  it('accepts a doctype that follows a leading HTML comment and BOM', () => {
+    const html =
+      '﻿<!-- generated 2026-05-02 -->\n<!doctype html>' +
+      '<meta name="viewport" content="width=device-width">' +
+      '<h1>hi</h1>';
+    const { warnings } = analyzeDeployPlan({ entryPath: 'index.html', html, files: [] });
+    expect(warnings.map((w: any) => w.code)).not.toContain('no-doctype');
+  });
+
   it('flags external scripts and stylesheets', () => {
     const { warnings } = analyzeDeployPlan({
       entryPath: 'index.html',
@@ -366,6 +385,19 @@ describe('deploy plan and analyzer', () => {
     expect(warnings).toContainEqual(
       expect.objectContaining({ code: 'large-html', path: 'index.html' }),
     );
+  });
+
+  it('reports large-html against the source entry path, not the renamed deploy file', () => {
+    const huge = Buffer.alloc(DEPLOY_PREFLIGHT_LARGE_HTML_BYTES + 1);
+    const { warnings } = analyzeDeployPlan({
+      entryPath: 'pages/landing.html',
+      html: '<!doctype html><meta name="viewport" content="width=device-width">',
+      files: [
+        { file: 'index.html', data: huge, contentType: 'text/html', sourcePath: 'pages/landing.html' },
+      ],
+    });
+    const found = warnings.find((w: any) => w.code === 'large-html');
+    expect(found?.path).toBe('pages/landing.html');
   });
 
   it('returns no warnings on a healthy entry HTML', () => {

--- a/packages/contracts/src/api/projects.ts
+++ b/packages/contracts/src/api/projects.ts
@@ -209,3 +209,47 @@ export interface DeployProjectFileRequest {
 export interface DeployProjectFileResponse extends DeploymentInfo {}
 
 export interface CheckDeploymentLinkResponse extends DeploymentInfo {}
+
+// Preflight inspects the file set that would be uploaded for a deploy
+// without sending anything to the provider. Lets the UI show file count,
+// total size, and warnings before the user pays the network round-trip.
+
+export type DeployPreflightWarningCode =
+  | 'broken-reference'
+  | 'invalid-reference'
+  | 'large-asset'
+  | 'large-bundle'
+  | 'large-html'
+  | 'external-script'
+  | 'external-stylesheet'
+  | 'no-doctype'
+  | 'no-viewport';
+
+export interface DeployPreflightWarning {
+  code: DeployPreflightWarningCode;
+  message: string;
+  path?: string;
+  url?: string;
+  size?: number;
+}
+
+export interface DeployPreflightFile {
+  path: string;
+  size: number;
+  mime: string;
+  sourcePath: string;
+}
+
+export interface DeployPreflightRequest {
+  fileName: string;
+  providerId?: DeployProviderId;
+}
+
+export interface DeployPreflightResponse {
+  providerId: DeployProviderId;
+  entry: string;
+  files: DeployPreflightFile[];
+  totalFiles: number;
+  totalBytes: number;
+  warnings: DeployPreflightWarning[];
+}


### PR DESCRIPTION
## Summary

The current deploy flow is a single POST that builds the file set, ships it to Vercel, and waits for the public URL to come up. There is no way to see what is actually being uploaded, no way to spot a missing background image or an oversized bundle, and no way to recover from a 400 without parsing an error string. End-to-end the loop can take ~110 seconds.

This PR adds a preflight endpoint that produces the same plan a real deploy would produce, runs a structured analyzer over it, and returns a typed report. No network round-trips. No mutations. The UI can show a "ready to deploy / fix these N issues first" panel before the user clicks the button.

## API surface

```
POST /api/projects/:id/deploy/preflight
Body:    { fileName: string, providerId?: 'vercel-self' }
Response: DeployPreflightResponse
```

```ts
interface DeployPreflightResponse {
  providerId: DeployProviderId;
  entry: string;
  files: { path: string; size: number; mime: string; sourcePath: string }[];
  totalFiles: number;
  totalBytes: number;
  warnings: DeployPreflightWarning[];
}
```

The closed warning enum is:

```ts
type DeployPreflightWarningCode =
  | 'broken-reference'    // referenced file missing on disk
  | 'invalid-reference'   // ref is not a valid project path
  | 'large-asset'         // per-file > 4 MiB
  | 'large-bundle'        // total > 75 MiB (Vercel rejects ~100 MiB after base64)
  | 'large-html'          // entry HTML > 1 MiB
  | 'external-script'     // <script src="https://..."> will not be vendored
  | 'external-stylesheet' // <link rel=stylesheet href="https://..."> will not be vendored
  | 'no-doctype'          // missing <!DOCTYPE html>
  | 'no-viewport';        // missing <meta name="viewport">
```

Soft thresholds are exported as `DEPLOY_PREFLIGHT_LARGE_ASSET_BYTES`, `DEPLOY_PREFLIGHT_LARGE_BUNDLE_BYTES`, `DEPLOY_PREFLIGHT_LARGE_HTML_BYTES` so tests and future tuning use the same numbers.

## Implementation

Three small additions, one careful refactor.

**Refactor** Extract the walk-and-collect logic from `buildDeployFileSet` into a non-throwing `buildDeployFilePlan` that returns `{ entryPath, html, files, missing, invalid }`. `buildDeployFileSet` becomes a thin wrapper that throws if `missing` or `invalid` is non-empty, so every existing caller, every existing test, and the existing POST /deploy semantics are byte-for-byte unchanged.

**Analyzer** `analyzeDeployPlan({ entryPath, html, files, missing, invalid })` walks the entry HTML once using the existing `parseHtmlTags` and `parseHtmlAttributes` helpers (no new parser added) and emits the closed warning vocabulary. Internal-only helper for protocol detection (`isExternalUrl`) treats anything with a scheme or starting with `//` as external. Warnings are deduped by code+path+url.

**Orchestrator** `prepareDeployPreflight(projectsRoot, projectId, entryName, options)` calls plan, then analyzer, then maps to the public `DeployPreflightResponse` shape.

**Route** `POST /api/projects/:id/deploy/preflight` mirrors the validation and error mapping of `POST /api/projects/:id/deploy` (`BAD_REQUEST` for malformed input, `FILE_NOT_FOUND` for missing entry, providerId guarded the same way) so the client error-handling code stays uniform.

## Tests

Fourteen new vitest cases under a new `describe('deploy plan and analyzer', ...)` block in `apps/daemon/tests/deploy.test.ts`:

- `buildDeployFilePlan` returns files plus missing and invalid lists without throwing.
- `buildDeployFileSet` still throws on missing or invalid (regression guard for the refactor).
- Analyzer unit tests: broken-reference, invalid-reference, no-doctype, no-viewport, external-script, external-stylesheet, protocol-relative external script, large-asset (per-file only, entry HTML excluded), large-html (entry HTML threshold), and a healthy-input case that produces zero warnings.
- Preflight integration tests: full payload shape on a healthy project (provider, entry, files, totals, warnings), broken-reference reporting on a missing asset, and a non-HTML entry rejection.

## Verification

```
pnpm --filter @open-design/daemon test
pnpm --filter @open-design/daemon run typecheck
pnpm --filter @open-design/contracts run typecheck
```

Local results on Node 24 / pnpm 10.33.2:

- `apps/daemon`: 261 tests pass, 4 skipped (deploy.test.ts at 35, up from 21 on `main`).
- `pnpm --filter @open-design/daemon run typecheck`: clean.
- `pnpm --filter @open-design/contracts run typecheck`: clean.

## Scope notes

- Purely additive: no public API removed, no runtime behavior changed for the existing POST /deploy. The refactor is internal.
- No new dependencies. The analyzer reuses `parseHtmlTags` and `parseHtmlAttributes` already exported from `deploy.ts`.
- No frontend changes in this PR. The endpoint is shaped so the UI can wire a "Preflight" button without further server work.
- The warning vocabulary is intentionally narrow and well-defined. Adding new codes (e.g. mixed-content, inline-eval, missing-cache-headers) is a one-line addition to the enum plus a check in `analyzeDeployPlan`.