### PR TITLE
fix(daemon): strip ANTHROPIC_API_KEY from agent spawn env

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1828,8 +1828,13 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
       // OS command-line length limit (Windows CreateProcess caps at ~32 KB)
       // which causes `spawn ENAMETOOLONG` for any non-trivial prompt.
       const stdinMode = def.promptViaStdin || def.streamFormat === 'acp-json-rpc' || needsFilePrompt ? 'pipe' : 'ignore';
+      const spawnEnv = { ...process.env, ...odMediaEnv };
+      // Remove any inherited API key so CLI agents (Claude Code, Copilot, etc.)
+      // authenticate via their own stored credentials (OAuth / subscription)
+      // rather than a key that may be revoked or belong to a different account.
+      delete spawnEnv['ANTHROPIC_API_KEY'];
       child = spawn(resolvedBin, args, {
-        env: { ...process.env, ...odMediaEnv },
+        env: spawnEnv,
         stdio: [stdinMode, 'pipe', 'pipe'],
         cwd: cwd || undefined,
         shell: useShell,


### PR DESCRIPTION
## Problem

  When the daemon process inherits `ANTHROPIC_API_KEY` from its parent
  environment (a terminal, IDE, or another process that had it set), that
  key is forwarded to every spawned CLI agent via `{ ...process.env }`.

  If the key is revoked or belongs to a different account, the agent exits
  immediately with a 401 authentication error — making the product
  unusable even when the CLI (e.g. Claude Code) is correctly authenticated
  via OAuth / subscription.

  Reproduced on Windows 11 with Claude Code as the agent.

  ## Fix

  Build a dedicated `spawnEnv` object and `delete spawnEnv['ANTHROPIC_API_KEY']`
  before passing it to `spawn()`, so CLI agents always authenticate via
  their own stored credentials rather than an inherited ambient key.

  ## Testing

  - Confirmed broken: daemon inherits revoked `ANTHROPIC_API_KEY` → agent exits with `Invalid API key · Fix external API key`
  - Confirmed fixed: after this change, Claude Code authenticates via OAuth (Claude Pro) and generates artifacts normally