### PR TITLE
docs: add Windows native setup notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ This file is the single source of truth for agents entering this repository. Rea
 
 - macOS, Linux, and WSL2 are the primary supported paths. Windows native is best-effort — file an issue if it doesn't work.
 - Historical Windows-specific friction is documented in closed issues #10, #96, #100, #203, and #315; check the issue tracker for the current state before filing new reports.
-- Install Node 24 via `winget install OpenJS.NodeJS.LTS`; do not use a portable Node 22 — see FAQ.
+- Install Node 24. Either `winget install OpenJS.NodeJS.LTS` (currently Node 24.x) or download from https://nodejs.org. After install, verify with `node --version` — the WinGet LTS pointer rolls to the next major in October 2026, so re-verify if you re-run the install command later. Do not use Node 22 — see FAQ.
 - `corepack enable` fails with EPERM on Windows (cannot write shims to `Program Files`). Use `npm install -g pnpm@10.33.2` instead.
 - `better-sqlite3` has no prebuilt binary for win32/Node 24; `pnpm install` will compile it from source via node-gyp (~2 min). Requires Visual Studio Build Tools 2022 or newer. This is expected — not a sign of version incompatibility.
 - For `tools-dev` start/stop/status usage, see "Local lifecycle" below.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,10 +40,11 @@ This file is the single source of truth for agents entering this repository. Rea
 ## Windows native
 
 - macOS, Linux, and WSL2 are the primary supported paths. Windows native is best-effort — file an issue if it doesn't work.
+- Historical Windows-specific friction is documented in closed issues #10, #96, #100, #203, and #315; check the issue tracker for the current state before filing new reports.
 - Install Node 24 via `winget install OpenJS.NodeJS.LTS`; do not use a portable Node 22 — see FAQ.
 - `corepack enable` fails with EPERM on Windows (cannot write shims to `Program Files`). Use `npm install -g pnpm@10.33.2` instead.
-- `better-sqlite3` has no prebuilt binary for win32/Node 24; `pnpm install` will compile it from source via node-gyp (~2 min). Requires VS Build Tools. This is expected — not a sign of version incompatibility.
-- `pnpm tools-dev` (no args) starts daemon + web + Electron desktop window in the background. Ports are ephemeral; use `pnpm tools-dev status` to find current URLs.
+- `better-sqlite3` has no prebuilt binary for win32/Node 24; `pnpm install` will compile it from source via node-gyp (~2 min). Requires Visual Studio Build Tools 2022 or newer. This is expected — not a sign of version incompatibility.
+- For `tools-dev` start/stop/status usage, see "Local lifecycle" below.
 
 ## Local lifecycle
 
@@ -139,6 +140,6 @@ The daemon writes `.od/` by default: SQLite at `.od/app.sqlite`, agent CWDs unde
 
 Run `pnpm install` after changing package manifests, workspace layout, command entrypoints, bin/link-related content, or after adding/removing workspace packages.
 
-## Why does the community note say to use Node 22?
+## Can I use Node 22 instead of Node 24?
 
-That note is stale. It was written when this repo used `better-sqlite3` v8/v9, which had no Node 24 support. The current lockfile pins `better-sqlite3@11.10.0` with `engines: {node: 18 || 20 || >=22}` — Node 24 is fully supported. Use Node 24 as required by `package.json#engines`.
+No. `package.json#engines` specifies `node: "~24"`, which is the only supported runtime. The current lockfile pins `better-sqlite3@11.10.0`; on Windows it has no prebuilt binary for Node 24 and is built from source via node-gyp (see the Windows native section). Older Node versions are not tested and may hit lockfile or dependency incompatibilities.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,14 @@ This file is the single source of truth for agents entering this repository. Rea
 - New project-owned entrypoints, modules, scripts, tests, reporters, and configs should default to TypeScript.
 - Residual JavaScript is limited to generated output, vendored dependencies, explicitly documented compatibility build artifacts, and the allowlist in `scripts/check-residual-js.ts`.
 
+## Windows native
+
+- macOS, Linux, and WSL2 are the primary supported paths. Windows native is best-effort — file an issue if it doesn't work.
+- Install Node 24 via `winget install OpenJS.NodeJS.LTS`; do not use a portable Node 22 — see FAQ.
+- `corepack enable` fails with EPERM on Windows (cannot write shims to `Program Files`). Use `npm install -g pnpm@10.33.2` instead.
+- `better-sqlite3` has no prebuilt binary for win32/Node 24; `pnpm install` will compile it from source via node-gyp (~2 min). Requires VS Build Tools. This is expected — not a sign of version incompatibility.
+- `pnpm tools-dev` (no args) starts daemon + web + Electron desktop window in the background. Ports are ephemeral; use `pnpm tools-dev status` to find current URLs.
+
 ## Local lifecycle
 
 - Use `pnpm tools-dev` as the only local development lifecycle entry point.
@@ -130,3 +138,7 @@ The daemon writes `.od/` by default: SQLite at `.od/app.sqlite`, agent CWDs unde
 ## When is `pnpm install` required?
 
 Run `pnpm install` after changing package manifests, workspace layout, command entrypoints, bin/link-related content, or after adding/removing workspace packages.
+
+## Why does the community note say to use Node 22?
+
+That note is stale. It was written when this repo used `better-sqlite3` v8/v9, which had no Node 24 support. The current lockfile pins `better-sqlite3@11.10.0` with `engines: {node: 18 || 20 || >=22}` — Node 24 is fully supported. Use Node 24 as required by `package.json#engines`.


### PR DESCRIPTION
## What

Adds a `## Windows native` section to `AGENTS.md` and a matching FAQ entry covering three quirks I hit doing a fresh Windows native install today:

1. `corepack enable` fails with EPERM on Windows (can't write shims into `C:\Program Files\nodejs`). Workaround: `npm install -g pnpm@10.33.2`.
2. `better-sqlite3@11.10.0` has no prebuilt binary for win32/Node 24, so `pnpm install` falls back to node-gyp source compilation via VS Build Tools (~2 min). This looks alarming the first time but is expected.
3. A community note recommending Node 22 (to dodge a different `better-sqlite3` issue) is stale — the current lockfile pins `better-sqlite3@11.10.0` whose `engines` field includes `>=22`, so Node 24 (this repo's `engines` target) works.

The new section opens by mirroring the existing CONTRIBUTING.md framing — macOS, Linux, and WSL2 are primary; Windows native is best-effort — so it does not imply Windows is now a tier-1 target. It just documents the known quirks for people who hit them.

## Why

`CONTRIBUTING.md` already says "Windows native should work but isn't a primary target — file an issue if it doesn't". This PR is the lighter alternative: it surfaces the known quirks in the docs so the friction shows up there instead of in the next Windows user's afternoon.

## Scope

`AGENTS.md` only — one file, ~12 lines added. No code, no dependency changes, no behavior changes.
