### PR TITLE
[codex] Add Docker setup for OpenDesign

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.github
+.od
+node_modules
+**/node_modules
+**/.next
+**/out
+**/dist
+coverage
+playwright-report
+test-results
+*.log
+.DS_Store
+npm-debug.log*
+pnpm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+FROM node:24-bookworm-slim
+
+ENV CI=1 \
+    HOME=/app/.agent-home \
+    NEXT_TELEMETRY_DISABLED=1 \
+    OD_HOST=0.0.0.0 \
+    OD_PORT=7456 \
+    PNPM_HOME=/pnpm
+
+ENV PATH="${PNPM_HOME}:${PATH}"
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gosu python3 make g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN corepack enable
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps ./apps
+COPY packages ./packages
+COPY tools ./tools
+COPY scripts ./scripts
+COPY assets ./assets
+COPY craft ./craft
+COPY design-systems ./design-systems
+COPY prompt-templates ./prompt-templates
+COPY skills ./skills
+COPY templates ./templates
+COPY docker-entrypoint.sh ./docker-entrypoint.sh
+
+RUN pnpm install --frozen-lockfile
+RUN npm install -g @anthropic-ai/claude-code @openai/codex opencode-ai
+RUN pnpm build
+RUN mkdir -p /app/.agent-home /app/.od /app/.tmp \
+    && chown -R node:node /app/.agent-home /app/.od /app/.tmp \
+    && chmod +x /app/docker-entrypoint.sh
+
+EXPOSE 22095
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD node -e "fetch('http://127.0.0.1:22095/').then((response) => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1))"
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["pnpm", "tools-dev", "run", "web", "--namespace", "docker", "--daemon-port", "7456", "--web-port", "22095", "--prod"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  opendesign:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: OpenDesign
+    environment:
+      OD_HOST: 0.0.0.0
+      OD_PORT: 7456
+      NEXT_TELEMETRY_DISABLED: "1"
+    ports:
+      - "22095:22095"
+    volumes:
+      - opendesign-agent-home:/app/.agent-home
+      - opendesign-data:/app/.od
+    restart: unless-stopped
+
+volumes:
+  opendesign-agent-home:
+  opendesign-data:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+mkdir -p /app/.agent-home /app/.od /app/.tmp
+chown -R node:node /app/.agent-home /app/.od /app/.tmp
+
+export HOME="${HOME:-/app/.agent-home}"
+
+exec gosu node "$@"


### PR DESCRIPTION
## What changed
- Added a Dockerfile that builds the full pnpm workspace on Node 24 and runs Open Design with daemon + web through `tools-dev`.
- Added `docker-compose.yml` with container name `OpenDesign` and host port `22095`.
- Added `.dockerignore` to keep Docker builds focused and avoid local build artifacts.

## Validation
- `docker compose build`
- `docker compose up -d`
- `Invoke-WebRequest http://127.0.0.1:22095/` returned `200`
- `Invoke-WebRequest http://127.0.0.1:22095/api/projects` returned `200 {"projects":[]}`
- `docker exec OpenDesign pnpm tools-dev status --namespace docker --json` showed daemon and web running
