### PR TITLE
feat(daemon): add OD_BIND_HOST env var and --host flag for interface binding

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -60,12 +60,15 @@ if (first && SUBCOMMAND_MAP[first]) {
 
 // Default: daemon mode.
 let port = Number(process.env.OD_PORT) || 7456;
+let host = process.env.OD_BIND_HOST || '0.0.0.0';
 let open = true;
 
 for (let i = 0; i < argv.length; i++) {
   const a = argv[i];
   if (a === '-p' || a === '--port') {
     port = Number(argv[++i]);
+  } else if (a === '--host') {
+    host = argv[++i];
   } else if (a === '--no-open') {
     open = false;
   } else if (a === '-h' || a === '--help') {
@@ -74,7 +77,7 @@ for (let i = 0; i < argv.length; i++) {
   }
 }
 
-startServer({ port }).then(url => {
+startServer({ port, host }).then(url => {
   console.log(`[od] listening on ${url}`);
   if (open) {
     const opener = process.platform === 'darwin' ? 'open'
@@ -88,7 +91,7 @@ startServer({ port }).then(url => {
 
 function printRootHelp() {
   console.log(`Usage:
-  od [--port <n>] [--no-open]
+  od [--port <n>] [--host <addr>] [--no-open]
       Start the local daemon and open the web UI.
 
   od media generate --surface <image|video|audio> --model <id> [opts]
@@ -96,9 +99,16 @@ function printRootHelp() {
       Designed to be invoked by a code agent — picks up OD_DAEMON_URL
       and OD_PROJECT_ID from the env that the daemon injected on spawn.
 
+Options:
+  --port <n>       Port to listen on (default: 7456, env: OD_PORT).
+  --host <addr>    Interface address to bind to (default: 0.0.0.0, env: OD_BIND_HOST).
+                   Set to a specific IP (e.g. a Tailscale address) to restrict access
+                   to that interface only.
+  --no-open        Do not open the browser after start.
+
 What the daemon does:
   * scans PATH for installed code-agent CLIs (claude, codex, devin, gemini, opencode, cursor-agent, ...)
-  * serves the chat UI at http://localhost:<port>
+  * serves the chat UI at http://<host>:<port>
   * proxies messages (text + images) to the selected agent via child-process spawn
   * exposes /api/projects/:id/media/generate — the unified image/video/audio
     dispatcher that the agent calls via \`od media generate\`.`);

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -560,7 +560,7 @@ export function createSseResponse(res, { keepAliveIntervalMs = SSE_KEEPALIVE_INT
   };
 }
 
-export async function startServer({ port = 7456, returnServer = false } = {}) {
+export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST || '0.0.0.0', returnServer = false } = {}) {
   let resolvedPort = port;
   const app = express();
   app.use(express.json({ limit: '4mb' }));
@@ -2373,7 +2373,7 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
   //   - `apps/daemon/sidecar/server.ts`     → expects `{ url, server }`
   //   - `apps/daemon/tests/version-route.test.ts` → expects `{ url, server }`
   return await new Promise((resolve, reject) => {
-    const server = app.listen(port, () => {
+    const server = app.listen(port, host, () => {
       const address = server.address();
       // `address()` can in theory return `string | AddressInfo | null`. For
       // a TCP listener it's always `AddressInfo` with a `.port` — the guard
@@ -2385,7 +2385,11 @@ export async function startServer({ port = 7456, returnServer = false } = {}) {
         return;
       }
       resolvedPort = boundPort;
-      const url = `http://127.0.0.1:${resolvedPort}`;
+      // When binding to all interfaces report localhost for local callers;
+      // when binding to a specific address (e.g. a Tailscale IP) report that
+      // address so remote callers and the sidecar use the correct URL.
+      const reportHost = host === '0.0.0.0' || host === '::' ? '127.0.0.1' : host;
+      const url = `http://${reportHost}:${resolvedPort}`;
       if (!returnServer) {
         console.log(`[od] daemon listening on ${url}`);
       }


### PR DESCRIPTION
## What

Adds an `OD_BIND_HOST` environment variable and a `--host` CLI flag so the daemon can be restricted to a single network interface at startup.

```sh
# Bind to loopback only
OD_BIND_HOST=127.0.0.1 open-design

# Bind to a specific IP (e.g. Tailscale) via env var
OD_BIND_HOST=$(tailscale ip -4) open-design --port 3110 --no-open

# Or via CLI flag
open-design --host $(tailscale ip -4) --port 3110 --no-open
```

## Why

Tailscale users and other self-hosted deployments often need the daemon reachable on one network interface only (e.g. the tailnet), without exposing the port on the LAN.

Currently `app.listen(port)` has no host argument, so Node binds to `0.0.0.0` (all interfaces) with no way to override it from environment or CLI.

## Backward compatibility

`OD_BIND_HOST` defaults to `'0.0.0.0'` — **no behaviour change** for existing installs that do not set the variable.

When binding to `0.0.0.0` / `::`, the reported URL uses `127.0.0.1` (unchanged, so the CLI and sidecar work without modification). When binding to a specific address, the returned URL uses that address so remote callers get a reachable endpoint.

## Files changed

| File | Change |
|---|---|
| `apps/daemon/src/server.ts` | `startServer()` gains `host` param (default: `OD_BIND_HOST \|\| '0.0.0.0'`); `app.listen` passes it; reported URL reflects actual bound host |
| `apps/daemon/src/cli.ts` | Reads `OD_BIND_HOST`, adds `--host` flag, passes host to `startServer`, documents both in `--help` output |

## Local test

```sh
# Terminal 1 — start bound to loopback only
OD_BIND_HOST=127.0.0.1 open-design &
# [od] daemon listening on http://127.0.0.1:7456

# Terminal 2 — confirm bind
lsof -i TCP:7456 -P | grep LISTEN
# node   … TCP 127.0.0.1:7456 (LISTEN)   ← not *:7456

# LAN access should be refused
curl http://<lan-ip>:7456/api/health     # ECONNREFUSED
curl http://127.0.0.1:7456/api/health   # 200 OK
```

## Checklist

- [x] Default behaviour unchanged (no `OD_BIND_HOST` → binds `*:7456` as before)
- [x] `--host` flag and `OD_BIND_HOST` env documented in `od --help`
- [x] Backward-compatible: sidecar and test callers unaffected when using default `0.0.0.0`
- [x] `lsof` confirms loopback-only binding when `OD_BIND_HOST=127.0.0.1`