### PR TITLE
fix(web): keep Design Files view active after deleting a file

### DIFF
--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -267,7 +267,6 @@ export function DesignFilesPanel({
             href={projectFileUrl(projectId, menuPos.name)}
             download={menuPos.name}
             style={{ textDecoration: 'none' }}
-            onClick={(e) => e.stopPropagation()}
           >
             <button
               type="button"

--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -250,10 +250,12 @@ export function DesignFilesPanel({
           className="df-row-popover"
           style={{ top: menuPos.top, left: menuPos.left }}
           onMouseDown={(e) => e.stopPropagation()}
+          onClick={(e) => e.stopPropagation()}
         >
           <button
             type="button"
-            onClick={() => {
+            onClick={(e) => {
+              e.stopPropagation();
               const name = menuPos.name;
               setMenuPos(null);
               onOpenFile(name);
@@ -265,8 +267,15 @@ export function DesignFilesPanel({
             href={projectFileUrl(projectId, menuPos.name)}
             download={menuPos.name}
             style={{ textDecoration: 'none' }}
+            onClick={(e) => e.stopPropagation()}
           >
-            <button type="button" onClick={() => setMenuPos(null)}>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                setMenuPos(null);
+              }}
+            >
               {t('designFiles.download')}
             </button>
           </a>
@@ -274,7 +283,9 @@ export function DesignFilesPanel({
             type="button"
             className="danger"
             data-testid={`design-file-delete-${menuPos.name}`}
-            onClick={() => {
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
               const name = menuPos.name;
               setMenuPos(null);
               onDeleteFile(name);

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -216,9 +216,11 @@ export function FileWorkspace({
         setActiveTab(nextActive ?? DESIGN_FILES_TAB);
       } else {
         // Deletion was triggered from the Design Files panel (or another
-        // tab). Keep the user where they are. Only clear the persisted
-        // active reference when it points at the deleted file so we don't
-        // leave a dangling pointer behind.
+        // tab). We preserve `activeTab` because the user is viewing a
+        // different context (Design Files or another tab) and shouldn't
+        // be navigated away. Only clear the persisted active reference
+        // when it points at the deleted file so we don't leave a dangling
+        // pointer behind.
         const nextActive = tabsState.active === name ? null : tabsState.active;
         onTabsStateChange({ tabs: nextTabs, active: nextActive });
       }

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -208,12 +208,20 @@ export function FileWorkspace({
     if (ok) {
       await onRefreshFiles();
       const nextTabs = persistedTabs.filter((n) => n !== name);
-      const nextActive =
-        tabsState.active === name
-          ? nextTabs[nextTabs.length - 1] ?? null
-          : tabsState.active;
-      onTabsStateChange({ tabs: nextTabs, active: nextActive });
-      setActiveTab(nextActive ?? DESIGN_FILES_TAB);
+      if (activeTab === name) {
+        // User is viewing the file being deleted: fall back to another
+        // open tab (or the Design Files panel if none remain).
+        const nextActive = nextTabs[nextTabs.length - 1] ?? null;
+        onTabsStateChange({ tabs: nextTabs, active: nextActive });
+        setActiveTab(nextActive ?? DESIGN_FILES_TAB);
+      } else {
+        // Deletion was triggered from the Design Files panel (or another
+        // tab). Keep the user where they are. Only clear the persisted
+        // active reference when it points at the deleted file so we don't
+        // leave a dangling pointer behind.
+        const nextActive = tabsState.active === name ? null : tabsState.active;
+        onTabsStateChange({ tabs: nextTabs, active: nextActive });
+      }
       setSketches((curr) => {
         const next = { ...curr };
         delete next[name];

--- a/e2e/specs/app.spec.ts
+++ b/e2e/specs/app.spec.ts
@@ -756,13 +756,25 @@ async function runDesignFilesDeleteFlow(
     await dialog.accept();
   });
 
+  const pngBytes = Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO5W6McAAAAASUVORK5CYII=',
+    'base64',
+  );
+
+  // Upload a sibling file first so that, after deleting trash-me.png, there
+  // is a fallback tab the buggy code would have navigated to. The fix must
+  // keep the user in the Design Files panel instead.
+  await page.getByTestId('design-files-upload-input').setInputFiles({
+    name: 'keep-me.png',
+    mimeType: 'image/png',
+    buffer: pngBytes,
+  });
+  await expect(page.getByRole('tab', { name: /keep-me\.png/i })).toBeVisible();
+
   await page.getByTestId('design-files-upload-input').setInputFiles({
     name: 'trash-me.png',
     mimeType: 'image/png',
-    buffer: Buffer.from(
-      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO5W6McAAAAASUVORK5CYII=',
-      'base64',
-    ),
+    buffer: pngBytes,
   });
 
   await expect(page.getByRole('tab', { name: /trash-me\.png/i })).toBeVisible();
@@ -779,6 +791,15 @@ async function runDesignFilesDeleteFlow(
 
   await expect(fileRow).toHaveCount(0);
   await expect(page.getByRole('tab', { name: /trash-me\.png/i })).toHaveCount(0);
+
+  // Bug #115: deleting from the Design Files panel must not navigate the
+  // user into another tab. The Design Files tab should remain the active
+  // view, and the sibling tab should still exist (just not auto-activated).
+  await expect(page.getByTestId('design-files-tab')).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
+  await expect(page.getByRole('tab', { name: /keep-me\.png/i })).toBeVisible();
 }
 
 async function runDesignFilesTabPersistenceFlow(


### PR DESCRIPTION
## Summary

Fixes #115. Deleting a file from the **Design Files** panel was navigating the user into another file's tab (typically the previously-opened `index.html`) instead of staying in the list view.

## Root cause

Two pieces of state are at play in `FileWorkspace`:

- `activeTab` — local React state. Clicking the **Design Files** tab only updates this (to `DESIGN_FILES_TAB`).
- `tabsState.active` — persisted state. Updated when a file tab is clicked / a file is opened or uploaded, but **not** when the Design Files tab is clicked.

Reproduction trace:
1. Project loads → `tabsState.active = 'index.html'`.
2. Upload `test_image.png` → upload flow calls `openFile`, syncing both states to `'test_image.png'`.
3. Click **Design Files** tab → `activeTab = DESIGN_FILES_TAB`, but `tabsState.active` still `'test_image.png'`.
4. Delete `test_image.png` → `handleDelete` computed `nextActive` from the remaining tabs (`'index.html'`) and called `setActiveTab(nextActive ?? DESIGN_FILES_TAB)`, yanking the user into `index.html`.

## Changes

### `apps/web/src/components/FileWorkspace.tsx` — the real fix

`handleDelete` now branches on whether the user is actually viewing the file being deleted:

- **`activeTab === name`** — the user is on the file they're deleting; fall back to another open tab (or the Design Files panel if none remain). This is the prior behavior, kept because it's correct here.
- **otherwise** — deletion was triggered from the Design Files panel (the typical path) or from another file tab. Leave `activeTab` alone so the user stays where they are. Only null out `tabsState.active` if it pointed at the deleted file, so we don't leave a dangling reference for the hydration `useEffect` to resync against.

### `apps/web/src/components/DesignFilesPanel.tsx` — defensive cleanup

The popover already had `onMouseDown` propagation guard but no matching `onClick` guard. Added:

- `onClick={(e) => e.stopPropagation()}` on the popover wrapper.
- `e.stopPropagation()` on each popover button (Open in Tab / Download / Delete).

These don't fix the navigation bug on their own (popover is rendered as a sibling of the row, so clicks don't bubble through it), but they align with the issue's "stop propagation on the menu and destructive action path" guidance and harden the destructive path against any future DOM rearrangement.

### `e2e/specs/app.spec.ts` — regression lock-in

Extended `runDesignFilesDeleteFlow` to upload **two** files (`keep-me.png` then `trash-me.png`) before deletion, so the buggy code path actually has a sibling tab to navigate to. After deleting `trash-me.png` from the Design Files panel, the test now asserts:

- `design-files-tab` has `aria-selected="true"` (panel stayed active).
- `keep-me.png` tab is still visible (sibling tab preserved, just not auto-activated).

The previous single-file flow couldn't catch this regression because `nextTabs` was empty, so even the buggy code fell back to `DESIGN_FILES_TAB`.

## Test plan

- [x] `pnpm --filter @open-design/web typecheck` — passes
- [x] `pnpm --filter @open-design/web test` — 129 tests, all pass
- [x] `pnpm --filter @open-design/web build` — passes
- [x] Manual: upload a file in a project that already has `index.html` → click Design Files tab → delete the uploaded file via row menu → verify file disappears AND Design Files panel stays active (no navigation to `index.html`)
- [x] Manual: single-click row → preview pane appears (regression check)
- [x] Manual: double-click row → file opens in tab (regression check)
- [x] Manual: open `a.html` in a tab, click Design Files, delete `a.html` from the panel → falls back to another open tab, or Design Files if none remain (existing behavior preserved)
- [x] `runDesignFilesDeleteFlow` extended with multi-tab assertions to lock in #115 specifically

Closes #115