### PR TITLE
feat(desktop): native Save As dialog for .pptx downloads

### DIFF
--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -180,6 +180,30 @@ function ensureWindowVisible(window: BrowserWindow): void {
   window.focus();
 }
 
+// PPTX is rendered by the agent into the project folder and reaches the
+// renderer through a normal `<a download>` link to /api/projects/:id/raw/*.
+// Without this hook Electron writes the bytes straight to the OS Downloads
+// folder, so the user never gets to pick a destination. setSaveDialogOptions
+// makes Electron show the native Save As panel before the download starts.
+const SAVE_AS_EXTENSIONS = new Set([".pptx"]);
+
+function attachDownloadSaveAsDialog(window: BrowserWindow): void {
+  window.webContents.session.on("will-download", (_event, item) => {
+    const filename = item.getFilename();
+    const dot = filename.lastIndexOf(".");
+    const ext = dot >= 0 ? filename.slice(dot).toLowerCase() : "";
+    if (!SAVE_AS_EXTENSIONS.has(ext)) return;
+    item.setSaveDialogOptions({
+      title: "Save As",
+      defaultPath: filename,
+      filters: [
+        { name: "PowerPoint Presentation", extensions: ["pptx"] },
+        { name: "All Files", extensions: ["*"] },
+      ],
+    });
+  });
+}
+
 export async function createDesktopRuntime(options: DesktopRuntimeOptions): Promise<DesktopRuntime> {
   const consoleEntries: DesktopConsoleEntry[] = [];
   const window = new BrowserWindow({
@@ -196,6 +220,7 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
   });
   installWindowChromeCssHook(window);
   showWindowButtons(window);
+  attachDownloadSaveAsDialog(window);
   let currentUrl: string | null = null;
   let stopped = false;
   let timer: NodeJS.Timeout | null = null;


### PR DESCRIPTION
Follow-up to #307 / #308. The PPTX export flow generates a `.pptx` inside the project folder and surfaces it via the existing `/api/projects/:id/raw/*` route, the same path used by the produced-files chip and the document toolbar. Browser users get a normal download.

In the Electron desktop app the same `<a download>` link silently drops the file into the OS Downloads folder — the user never gets to pick a destination, can't tell when the download finished, and has to dig through Finder to locate it. PDF goes through `window.print()` (OS dialog) and ZIP is small enough for the browser default to be acceptable, but PPTX is the user-deliverable artifact and deserves a real Save As experience.

## What changes

- `apps/desktop/src/main/runtime.ts` — adds a `session.on('will-download')` hook on the main `BrowserWindow`. For files in `SAVE_AS_EXTENSIONS` (currently just `.pptx`), it calls `item.setSaveDialogOptions({ title, defaultPath, filters })` before the download starts; Electron then shows the OS-native Save As panel.

That's it. No preload script, no `ipcMain`/`contextBridge` plumbing, no renderer-side changes. The web build is untouched and continues to use the browser's default `<a download>` behavior.

## Why this approach (over alternatives)

| Approach | Cost | Outcome |
|---|---|---|
| **`will-download` + `setSaveDialogOptions`** (this PR) | 25-line single-file change in main process | OS-native Save As panel; renderer untouched |
| Preload + `contextBridge` + `ipcMain.handle('save-pptx', …)` + frontend bridge | New preload file, IPC channel, web `window.electronBridge` guard, fetch-and-write-bytes round trip | Same UX, but invasive across desktop + web |
| Daemon endpoint that writes to user-picked path | Daemon would need Electron access (it's a separate Node process) | Architecturally wrong |

The session-level `will-download` hook is the canonical Electron pattern for "intercept before the download starts and show a save dialog" and avoids touching the renderer entirely.

## Scope

Allowlist starts at `.pptx`. ZIP / HTML downloads keep their default behavior to avoid surprising existing users. Adding `.docx` / other formats later is a one-line change to `SAVE_AS_EXTENSIONS`.

## Test plan

- [ ] Build desktop, open a project with an HTML artifact, click **Export as PPTX**, wait for the agent to finish.
- [ ] Click the produced-files download chip → confirm the OS-native Save As panel appears with the suggested filename and `.pptx` filter; pick a folder → confirm the file lands there.
- [ ] Same flow from the document toolbar download button → same Save As panel.
- [ ] Click the toolbar **Export as ZIP** button → confirm default browser-download behavior is preserved (no Save As panel; goes to Downloads).
- [ ] Web (browser, not desktop) build → confirm `<a download>` continues to work and `.pptx` download is unaffected.
- [ ] Cancel the Save As dialog → confirm Electron handles cancellation cleanly with no zombie download.