### PR TITLE
fix(windows): daemon startup crash and tools-dev hang on Windows

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -77,11 +77,14 @@ for (let i = 0; i < argv.length; i++) {
 startServer({ port }).then(url => {
   console.log(`[od] listening on ${url}`);
   if (open) {
-    const opener = process.platform === 'darwin' ? 'open'
-      : process.platform === 'win32' ? 'start'
-      : 'xdg-open';
     import('node:child_process').then(({ spawn }) => {
-      spawn(opener, [url], { detached: true, stdio: 'ignore' }).unref();
+      if (process.platform === 'win32') {
+        // `start` is a cmd.exe built-in, not a standalone binary — must use shell
+        spawn('cmd', ['/c', 'start', url], { detached: true, stdio: 'ignore', shell: false }).unref();
+      } else {
+        const opener = process.platform === 'darwin' ? 'open' : 'xdg-open';
+        spawn(opener, [url], { detached: true, stdio: 'ignore' }).unref();
+      }
     });
   }
 });

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -256,10 +256,13 @@ async function listWindowsProcessSnapshots(): Promise<ProcessSnapshot[]> {
     "Get-CimInstance Win32_Process | Select-Object ProcessId, ParentProcessId, CommandLine | ConvertTo-Json -Compress",
   ].join("; ");
   const stdout = await new Promise<string>((resolveList, rejectList) => {
-    execFile("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", command], { encoding: "utf8", maxBuffer: 8 * 1024 * 1024 }, (error, out) => {
+    const child = execFile("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", command], { encoding: "utf8", maxBuffer: 8 * 1024 * 1024 }, (error, out) => {
       if (error) rejectList(error);
       else resolveList(out);
     });
+    // WMI can hang indefinitely on some Windows systems; bail out after 5 s
+    // and return an empty snapshot list so tools-dev can still start.
+    setTimeout(() => { child.kill(); rejectList(new Error("WMI timeout")); }, 5000);
   });
   const payload = stdout.trim();
   if (!payload) return [];


### PR DESCRIPTION
## Problem

  Two bugs that prevent Open Design from starting at all on Windows:

  ### 1. Daemon crashes immediately on startup (`apps/daemon/src/cli.ts`)

  `spawn('start', [url])` throws `ENOENT` because `start` is a `cmd.exe`
  built-in, not a standalone executable. The daemon exits before the web
  server even starts.

  ### 2. `pnpm tools-dev run web` hangs forever (`packages/platform/src/index.ts`)

  `listWindowsProcessSnapshots()` runs `Get-CimInstance Win32_Process` via
  PowerShell with no timeout. On some Windows systems WMI is slow or
  unresponsive, so `tools-dev` hangs indefinitely with no output or error.

  ## Fix

  1. Use `spawn('cmd', ['/c', 'start', url])` on Windows.
  2. Add a 5 s timeout to the PowerShell child process — `listProcessSnapshots()`
     already catches rejections and returns `[]`, so tools-dev continues normally.

  ## Testing

  Reproduced and fixed on Windows 11 (build 26200). Both bugs are
  hit on a clean install before any design is generated.