### PR TITLE
fix(i18n): add missing designFiles.showMore key to ar/hu/ko/pl/tr

### DIFF
--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -451,6 +451,7 @@ export const ar: Dict = {
   'designFiles.sectionImages': 'صور',
   'designFiles.sectionSketches': 'رسومات',
   'designFiles.sectionOther': 'أخرى',
+  'designFiles.showMore': 'عرض +{n} أخرى',
   'designFiles.kindHtml': 'صفحة HTML',
   'designFiles.kindImage': 'صورة',
   'designFiles.kindSketch': 'رسم',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -451,6 +451,7 @@ export const hu: Dict = {
   'designFiles.sectionImages': 'Képek',
   'designFiles.sectionSketches': 'Vázlatok',
   'designFiles.sectionOther': 'Egyéb',
+  'designFiles.showMore': '+{n} további megjelenítése',
   'designFiles.kindHtml': 'HTML oldal',
   'designFiles.kindImage': 'Kép',
   'designFiles.kindSketch': 'Vázlat',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -451,6 +451,7 @@ export const ko: Dict = {
   'designFiles.sectionImages': '이미지',
   'designFiles.sectionSketches': '스케치',
   'designFiles.sectionOther': '기타',
+  'designFiles.showMore': '+{n}개 더 보기',
   'designFiles.kindHtml': 'HTML 페이지',
   'designFiles.kindImage': '이미지',
   'designFiles.kindSketch': '스케치',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -451,6 +451,7 @@ export const pl: Dict = {
   'designFiles.sectionImages': 'Obrazy',
   'designFiles.sectionSketches': 'Szkice',
   'designFiles.sectionOther': 'Inne',
+  'designFiles.showMore': 'Pokaż +{n} więcej',
   'designFiles.kindHtml': 'Strona HTML',
   'designFiles.kindImage': 'Obraz',
   'designFiles.kindSketch': 'Szkic',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -450,6 +450,7 @@ export const tr: Dict = {
   'designFiles.sectionImages': 'Görseller',
   'designFiles.sectionSketches': 'Taslaklar',
   'designFiles.sectionOther': 'Diğer',
+  'designFiles.showMore': '+{n} tane daha göster',
   'designFiles.kindHtml': 'HTML sayfası',
   'designFiles.kindImage': 'Görsel',
   'designFiles.kindSketch': 'Taslak',


### PR DESCRIPTION
## Summary

PR #239 added the `designFiles.showMore` key to `en.ts` and 8 other locales but missed **ar, hu, ko, pl, tr**, leaving `pnpm --filter @open-design/web typecheck` red on `main` (TS2741 × 5):

```
src/i18n/locales/ar.ts(3,14): error TS2741: Property ''designFiles.showMore'' is missing
src/i18n/locales/hu.ts(3,14): error TS2741: Property ''designFiles.showMore'' is missing
src/i18n/locales/ko.ts(3,14): error TS2741: Property ''designFiles.showMore'' is missing
src/i18n/locales/pl.ts(3,14): error TS2741: Property ''designFiles.showMore'' is missing
src/i18n/locales/tr.ts(3,14): error TS2741: Property ''designFiles.showMore'' is missing
```

This fails CI on every PR opened off `main` since #239 (commit `b06021c`) landed.

This PR adds the key to the 5 missing locales with native translations, following the verb/counter conventions PR #239 used in the locales it did update. Native speakers welcome to refine.

| Locale | Value | Notes |
|---|---|---|
| ar | `عرض +{n} أخرى` | "show +{n} other" |
| hu | `+{n} további megjelenítése` | matches German verb-final pattern |
| ko | `+{n}개 더 보기` | standard `개` counter + `더 보기` |
| pl | `Pokaż +{n} więcej` | matches es/pt-BR verb-first pattern |
| tr | `+{n} tane daha göster` | counter `tane` + `daha göster` |

## Test plan

- [x] `pnpm --filter @open-design/web typecheck` — clean
- [x] `pnpm --filter @open-design/web test` — 131/131 pass (incl. `locales.test.ts` placeholder-alignment check)
- [x] No other locale files touched