### PR TITLE
fix(platform): wrap cmd.exe shim invocations to survive /s /c quote stripping

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -2082,6 +2082,10 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
         stdio: [stdinMode, 'pipe', 'pipe'],
         cwd: cwd || undefined,
         shell: false,
+        // Required when invocation wraps a Windows .cmd/.bat shim through
+        // cmd.exe; without this, Node re-escapes the inner command line and
+        // breaks paths containing spaces (issue #315).
+        windowsVerbatimArguments: invocation.windowsVerbatimArguments,
       });
       run.child = child;
       if (def.promptViaStdin && child.stdin && def.streamFormat !== 'pi-rpc') {

--- a/packages/platform/src/index.test.ts
+++ b/packages/platform/src/index.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  createCommandInvocation,
+  createPackageManagerInvocation,
   createProcessStampArgs,
   matchesStampedProcess,
   readProcessStampFromCommand,
@@ -78,5 +80,167 @@ describe("generic process stamp primitives", () => {
     expect(matchesStampedProcess({ command }, { app: "ui", namespace: stamp.namespace, source: "tool" }, fakeContract)).toBe(true);
     expect(matchesStampedProcess({ command }, { namespace: "stamp-boundary-b" }, fakeContract)).toBe(false);
     expect(matchesStampedProcess({ command }, { source: "pack" }, fakeContract)).toBe(false);
+  });
+});
+
+// `createCommandInvocation` makes a platform-conditional choice based on
+// `process.platform`. These tests stub it both ways so we exercise the
+// Windows .cmd / .bat shim path on every CI runner, not just Windows.
+describe("createCommandInvocation", () => {
+  const originalPlatform = process.platform;
+  function setPlatform(value: NodeJS.Platform): void {
+    Object.defineProperty(process, "platform", { configurable: true, value });
+  }
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+  });
+
+  it("returns the raw command and args unchanged on POSIX", () => {
+    setPlatform("linux");
+    const invocation = createCommandInvocation({
+      command: "/usr/local/bin/codex",
+      args: ["--help"],
+    });
+    expect(invocation).toEqual({
+      args: ["--help"],
+      command: "/usr/local/bin/codex",
+    });
+    expect(invocation.windowsVerbatimArguments).toBeUndefined();
+  });
+
+  it("returns the raw command and args unchanged on Windows for non-shim binaries", () => {
+    setPlatform("win32");
+    const invocation = createCommandInvocation({
+      command: "C:\\Program Files\\node\\node.exe",
+      args: ["script.js"],
+    });
+    expect(invocation).toEqual({
+      args: ["script.js"],
+      command: "C:\\Program Files\\node\\node.exe",
+    });
+    expect(invocation.windowsVerbatimArguments).toBeUndefined();
+  });
+
+  it("wraps a Windows .CMD shim through cmd.exe with verbatim arguments", () => {
+    setPlatform("win32");
+    const invocation = createCommandInvocation({
+      command: "C:\\Users\\Ethical Byte\\AppData\\Local\\Programs\\nodejs\\codex.CMD",
+      args: ["--version"],
+      env: { ComSpec: "C:\\Windows\\System32\\cmd.exe" } as NodeJS.ProcessEnv,
+    });
+
+    expect(invocation.command).toBe("C:\\Windows\\System32\\cmd.exe");
+    expect(invocation.windowsVerbatimArguments).toBe(true);
+    // Critical: the inner command line is wrapped in extra `"…"` so that
+    // cmd.exe's `/s /c` quote-stripping (strip first + last `"`) leaves the
+    // path quoting intact. Without the outer wrap, `Ethical Byte` gets
+    // split on the space and cmd reports "not recognized" (issue #315).
+    expect(invocation.args).toEqual([
+      "/d",
+      "/s",
+      "/c",
+      '""C:\\Users\\Ethical Byte\\AppData\\Local\\Programs\\nodejs\\codex.CMD" --version"',
+    ]);
+  });
+
+  it("treats .bat shims the same as .cmd shims", () => {
+    setPlatform("win32");
+    const invocation = createCommandInvocation({
+      command: "C:\\tools\\bin\\my tool.bat",
+      args: [],
+      env: { ComSpec: "cmd.exe" } as NodeJS.ProcessEnv,
+    });
+    expect(invocation.windowsVerbatimArguments).toBe(true);
+    expect(invocation.args).toEqual(["/d", "/s", "/c", '""C:\\tools\\bin\\my tool.bat""']);
+  });
+
+  it("quotes argv elements containing spaces alongside the shim path", () => {
+    setPlatform("win32");
+    const invocation = createCommandInvocation({
+      command: "C:\\Users\\First Last\\codex.cmd",
+      args: ["--cwd", "C:\\Some Path\\proj", "exec", "echo hi"],
+      env: { ComSpec: "cmd.exe" } as NodeJS.ProcessEnv,
+    });
+    // After the outer wrap and `/s /c` stripping, cmd will see:
+    //   "C:\Users\First Last\codex.cmd" --cwd "C:\Some Path\proj" exec "echo hi"
+    expect(invocation.args).toEqual([
+      "/d",
+      "/s",
+      "/c",
+      '""C:\\Users\\First Last\\codex.cmd" --cwd "C:\\Some Path\\proj" exec "echo hi""',
+    ]);
+  });
+
+  it("does not quote argv elements without whitespace or shell metacharacters", () => {
+    setPlatform("win32");
+    const invocation = createCommandInvocation({
+      command: "codex.cmd",
+      args: ["--model", "claude-opus-4", "--max-tokens=4096"],
+      env: { ComSpec: "cmd.exe" } as NodeJS.ProcessEnv,
+    });
+    expect(invocation.args).toEqual([
+      "/d",
+      "/s",
+      "/c",
+      '"codex.cmd --model claude-opus-4 --max-tokens=4096"',
+    ]);
+  });
+
+  it("falls back to process.env.ComSpec when env override is absent", () => {
+    setPlatform("win32");
+    const original = process.env.ComSpec;
+    process.env.ComSpec = "C:\\Windows\\System32\\cmd.exe";
+    try {
+      const invocation = createCommandInvocation({
+        command: "tool.cmd",
+        args: [],
+      });
+      expect(invocation.command).toBe("C:\\Windows\\System32\\cmd.exe");
+    } finally {
+      if (original == null) delete process.env.ComSpec;
+      else process.env.ComSpec = original;
+    }
+  });
+});
+
+describe("createPackageManagerInvocation", () => {
+  const originalPlatform = process.platform;
+  function setPlatform(value: NodeJS.Platform): void {
+    Object.defineProperty(process, "platform", { configurable: true, value });
+  }
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+  });
+
+  it("uses npm_execpath via process.execPath when set, regardless of platform", () => {
+    setPlatform("win32");
+    const invocation = createPackageManagerInvocation(["install"], {
+      npm_execpath: "C:\\Users\\u\\.nvm\\pnpm.cjs",
+    } as NodeJS.ProcessEnv);
+    expect(invocation.command).toBe(process.execPath);
+    expect(invocation.args[0]).toBe("C:\\Users\\u\\.nvm\\pnpm.cjs");
+    expect(invocation.args.slice(1)).toEqual(["install"]);
+    expect(invocation.windowsVerbatimArguments).toBeUndefined();
+  });
+
+  it("returns plain pnpm invocation on POSIX without npm_execpath", () => {
+    setPlatform("linux");
+    const invocation = createPackageManagerInvocation(["install"], {} as NodeJS.ProcessEnv);
+    expect(invocation).toEqual({ args: ["install"], command: "pnpm" });
+  });
+
+  it("wraps pnpm through cmd.exe with verbatim arguments on Windows", () => {
+    setPlatform("win32");
+    const invocation = createPackageManagerInvocation(["--filter", "@open-design/desktop", "build"], {
+      ComSpec: "cmd.exe",
+    } as NodeJS.ProcessEnv);
+    expect(invocation.command).toBe("cmd.exe");
+    expect(invocation.windowsVerbatimArguments).toBe(true);
+    expect(invocation.args).toEqual([
+      "/d",
+      "/s",
+      "/c",
+      '"pnpm --filter @open-design/desktop build"',
+    ]);
   });
 });

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -5,6 +5,11 @@ import { setTimeout as sleep } from "node:timers/promises";
 export type CommandInvocation = {
   args: string[];
   command: string;
+  // When true, callers must forward this to `child_process.spawn` /
+  // `child_process.execFile` options. Required for Windows `.bat` / `.cmd`
+  // shims so cmd.exe's `/s /c` quoting survives Node's default per-arg
+  // CommandLineToArgvW escaping. See `createCommandInvocation`.
+  windowsVerbatimArguments?: boolean;
 };
 
 export type ProcessStampShape = object;
@@ -147,12 +152,32 @@ function quoteWindowsCommandArg(value: string): string {
   return `"${value.replace(/"/g, '""')}"`;
 }
 
+// Build the `cmd.exe /d /s /c "<line>"` invocation Node uses internally for
+// `shell: true`. The outer `"..."` plus `windowsVerbatimArguments: true` is
+// the only shape that survives both layers of quoting:
+//
+// 1. Node would otherwise escape each argv element with CommandLineToArgvW
+//    rules (turning `"path with space"` into `\"path with space\"`), which
+//    cmd.exe does not understand.
+// 2. cmd.exe with `/s /c` strips exactly one leading and one trailing `"`
+//    from the rest of the command line. The outer wrap absorbs that strip
+//    so any inner per-arg quoting stays intact.
+//
+// Without this, paths containing spaces (`C:\Users\First Last\...\foo.cmd`)
+// get split on the first space and cmd.exe reports "not recognized as an
+// internal or external command" — see issue #315.
+function buildCmdShimInvocation(command: string, args: string[], env: NodeJS.ProcessEnv): CommandInvocation {
+  const inner = [command, ...args].map(quoteWindowsCommandArg).join(" ");
+  return {
+    args: ["/d", "/s", "/c", `"${inner}"`],
+    command: env.ComSpec ?? process.env.ComSpec ?? "cmd.exe",
+    windowsVerbatimArguments: true,
+  };
+}
+
 export function createCommandInvocation({ args = [], command, env = process.env }: CommandInvocationRequest): CommandInvocation {
   if (process.platform === "win32" && /\.(bat|cmd)$/i.test(command)) {
-    return {
-      args: ["/d", "/s", "/c", [command, ...args].map(quoteWindowsCommandArg).join(" ")],
-      command: env.ComSpec ?? process.env.ComSpec ?? "cmd.exe",
-    };
+    return buildCmdShimInvocation(command, args, env);
   }
   return { args, command };
 }
@@ -161,10 +186,7 @@ export function createPackageManagerInvocation(args: string[], env: NodeJS.Proce
   const execPath = env.npm_execpath;
   if (execPath) return { args: [execPath, ...args], command: process.execPath };
   if (process.platform === "win32") {
-    return {
-      args: ["/d", "/s", "/c", ["pnpm", ...args].map(quoteWindowsCommandArg).join(" ")],
-      command: env.ComSpec ?? process.env.ComSpec ?? "cmd.exe",
-    };
+    return buildCmdShimInvocation("pnpm", args, env);
   }
   return { args, command: "pnpm" };
 }
@@ -188,6 +210,7 @@ export async function spawnBackgroundProcess(request: SpawnProcessRequest): Prom
     env: request.env,
     stdio: createLoggedStdio(request.logFd),
     windowsHide: process.platform === "win32",
+    windowsVerbatimArguments: invocation.windowsVerbatimArguments,
   });
   await waitForChildSpawn(child);
   if (child.pid == null) throw new Error(`failed to spawn background process: ${invocation.command}`);
@@ -203,6 +226,7 @@ export async function spawnLoggedProcess(request: SpawnProcessRequest): Promise<
     env: request.env,
     stdio: createLoggedStdio(request.logFd),
     windowsHide: process.platform === "win32",
+    windowsVerbatimArguments: invocation.windowsVerbatimArguments,
   });
   await waitForChildSpawn(child);
   if (child.pid == null) throw new Error(`failed to spawn process: ${invocation.command}`);

--- a/tools/dev/src/index.ts
+++ b/tools/dev/src/index.ts
@@ -302,12 +302,14 @@ async function runLoggedCommand(request: {
   cwd: string;
   env?: NodeJS.ProcessEnv;
   logFd: number;
+  windowsVerbatimArguments?: boolean;
 }): Promise<void> {
   const child = spawn(request.command, request.args, {
     cwd: request.cwd,
     env: request.env,
     stdio: ["ignore", request.logFd, request.logFd],
     windowsHide: process.platform === "win32",
+    windowsVerbatimArguments: request.windowsVerbatimArguments,
   });
 
   await new Promise<void>((resolveRun, rejectRun) => {
@@ -467,6 +469,7 @@ async function buildDesktop(config: ToolDevConfig, logHandle: FileHandle): Promi
     cwd: config.workspaceRoot,
     env: process.env,
     logFd: logHandle.fd,
+    windowsVerbatimArguments: invocation.windowsVerbatimArguments,
   });
 }
 

--- a/tools/pack/src/win.ts
+++ b/tools/pack/src/win.ts
@@ -580,6 +580,7 @@ async function runPnpm(config: ToolPackConfig, args: string[], extraEnv: NodeJS.
   await execFileAsync(invocation.command, invocation.args, {
     cwd: config.workspaceRoot,
     env: { ...process.env, ...extraEnv },
+    windowsVerbatimArguments: invocation.windowsVerbatimArguments,
   });
 }
 
@@ -588,7 +589,11 @@ async function runNpmInstall(appRoot: string): Promise<void> {
     args: ["install", "--omit=dev", "--no-package-lock"],
     command: process.platform === "win32" ? "npm.cmd" : "npm",
   });
-  await execFileAsync(invocation.command, invocation.args, { cwd: appRoot, env: process.env });
+  await execFileAsync(invocation.command, invocation.args, {
+    cwd: appRoot,
+    env: process.env,
+    windowsVerbatimArguments: invocation.windowsVerbatimArguments,
+  });
 }
 
 async function readPackagedVersion(config: ToolPackConfig): Promise<string> {


### PR DESCRIPTION
## Summary

Fixes [#315](https://github.com/nexu-io/open-design/issues/315) — on Windows, when an agent CLI is installed at a path containing a space (default for many user accounts) and the binary is a `.CMD` shim (e.g. npm-installed Codex CLI), the daemon spawns it with mangled quoting and the agent fails immediately with `'Ethical' is not recognized as an internal or external command`.

This is a quoting regression in PR #258, which standardized agent spawning through `createCommandInvocation` and routed Windows `.cmd` / `.bat` paths through `cmd.exe /d /s /c <line>`. PR #232's earlier `shell:true` fix didn't survive that refactor, and the new shape has its own quoting bug on argv-style spawn.

## Root cause

Two layers of quoting collide:

1. **`cmd.exe /s /c`** strips exactly one leading and one trailing `"` from the rest of the command line.
2. **Node's default Windows arg escaping** (CommandLineToArgvW rules) turns `"path with space"` into `\"path with space\"` for each argv element. cmd.exe doesn't understand backslash-escaped quotes.

So `[\"/d\", \"/s\", \"/c\", '\"C:\\\\Users\\\\Ethical Byte\\\\...\\\\codex.CMD\" --help']` → cmd.exe sees the `\"` Node wrote, fails to parse the quoting, and after `/s` strips the visible outer `\"`, what's left is `C:\\Users\\Ethical Byte\\...\\codex.CMD --help` with no quotes at all. The first space wins, and `Ethical` becomes the command.

## Fix

Mirror what Node's own `child_process.spawn({ shell: true })` does internally:

1. Wrap the entire joined command line in an extra `\"…\"` so cmd.exe's `/s /c` strip eats the outer pair and leaves inner per-arg quoting intact.
2. Set `windowsVerbatimArguments: true` so Node forwards argv to CreateProcess unchanged, without re-applying CommandLineToArgvW escaping.

This is the only shape that survives both layers.

## Changes

- **`packages/platform/src/index.ts`** — extend `CommandInvocation` with optional `windowsVerbatimArguments`; extract `buildCmdShimInvocation` helper that applies the outer wrap + verbatim flag in both `createCommandInvocation` and `createPackageManagerInvocation`; forward the flag through `spawnBackgroundProcess` / `spawnLoggedProcess`.
- **`apps/daemon/src/server.ts`** — agent spawn forwards `invocation.windowsVerbatimArguments`. This is the call site that hit #315 in the wild (Codex CLI `.CMD` shim, user dir with space).
- **`tools/pack/src/win.ts`** — `runPnpm` and `runNpmInstall` forward the flag through `execFileAsync`. Affects the Windows packaged-build pipeline when run from a path with spaces.
- **`tools/dev/src/index.ts`** — `runLoggedCommand` accepts and forwards the flag; `buildDesktop` propagates it. Affects local dev on Windows.

## Tests

Added 9 unit tests in `packages/platform/src/index.test.ts` that stub `process.platform` so both Windows and POSIX branches run on every CI runner:

- POSIX pass-through (no quoting changes)
- Windows non-shim binary pass-through
- `.CMD` shim with spaces in the binary path (the #315 repro)
- `.bat` shim parity
- Argv elements with spaces alongside the shim path
- Argv elements without whitespace stay unquoted
- `process.env.ComSpec` fallback
- `npm_execpath` short-circuit (cross-platform)
- POSIX pnpm pass-through
- Windows pnpm wrapped through cmd.exe

## Test plan

- [x] \`pnpm --filter @open-design/platform test\` — 12/12 passing (3 existing + 9 new)
- [x] \`pnpm --filter @open-design/platform typecheck\` — clean
- [x] \`pnpm --filter @open-design/daemon build\` — clean (TS strict)
- [x] \`pnpm --filter @open-design/daemon test\` — 282/282 passing
- [x] \`pnpm typecheck\` — full repo clean
- [x] \`pnpm test\` — all packages pass (~452 tests total)
- [ ] Manual Windows verification — I don't have a Windows host. The unit tests pin the exact byte sequence Node sends to CreateProcess; reviewers with Windows access can sanity-check by running Codex from a path containing a space.

## Notes

The fix is intentionally narrow to the `.cmd` / `.bat` shim path — it does not touch non-Windows or non-shim invocations, so there's no risk of regressing POSIX or direct-`.exe` spawn behavior. All four production call sites (`spawnBackgroundProcess`, `spawnLoggedProcess`, `apps/daemon` agent spawn, `tools/pack` + `tools/dev` build pipelines) were updated in this PR — leaving any of them unflipped would silently break on Windows whenever the path contains spaces.

Closes #315.