### PR TITLE
fix(daemon): serve .jsx / .tsx with JS-family MIME so browser loaders accept them

### DIFF
--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -245,8 +245,14 @@ const EXT_MIME = {
   '.js': 'text/javascript; charset=utf-8',
   '.mjs': 'text/javascript; charset=utf-8',
   '.cjs': 'text/javascript; charset=utf-8',
+  '.jsx': 'text/javascript; charset=utf-8',
   '.ts': 'text/typescript; charset=utf-8',
-  '.tsx': 'text/typescript; charset=utf-8',
+  // `.tsx` previously served as `text/typescript`, which browser module
+  // loaders and strict CSPs do not accept as a JavaScript MIME. Multi-file
+  // React prototypes that load `.tsx` via Babel-standalone (`<script
+  // type="text/babel" src="…">`) need a JS-family Content-Type for the
+  // browser fetch to succeed. Upstream of issue #336.
+  '.tsx': 'text/javascript; charset=utf-8',
   '.json': 'application/json; charset=utf-8',
   '.md': 'text/markdown; charset=utf-8',
   '.txt': 'text/plain; charset=utf-8',

--- a/apps/daemon/tests/project-classifiers.test.ts
+++ b/apps/daemon/tests/project-classifiers.test.ts
@@ -98,8 +98,13 @@ describe('mimeFor', () => {
     expect(mimeFor('a.js')).toBe('text/javascript; charset=utf-8');
     expect(mimeFor('a.mjs')).toBe('text/javascript; charset=utf-8');
     expect(mimeFor('a.cjs')).toBe('text/javascript; charset=utf-8');
+    // `.jsx` and `.tsx` are served to browsers running Babel-standalone
+    // (multi-file React prototypes), so they need a JS-family MIME — see
+    // issue #336. `.ts` stays as `text/typescript` because it has no
+    // browser-execution path; tooling reads it as TS source.
+    expect(mimeFor('a.jsx')).toBe('text/javascript; charset=utf-8');
+    expect(mimeFor('a.tsx')).toBe('text/javascript; charset=utf-8');
     expect(mimeFor('a.ts')).toBe('text/typescript; charset=utf-8');
-    expect(mimeFor('a.tsx')).toBe('text/typescript; charset=utf-8');
     expect(mimeFor('a.json')).toBe('application/json; charset=utf-8');
     expect(mimeFor('a.md')).toBe('text/markdown; charset=utf-8');
     expect(mimeFor('a.txt')).toBe('text/plain; charset=utf-8');


### PR DESCRIPTION
## Summary

Refs [#336](https://github.com/nexu-io/open-design/issues/336) — fixes the MIME hygiene bug @lefarcen flagged in that issue's first comment. Decoupled from the main #336 thread (Open-button render path), which still needs the reporter's DevTools log to fully diagnose.

## Problem

Multi-file React prototypes loaded via Babel-standalone (`<script type=\"text/babel\" src=\"…\">`) fetch each `.jsx` / `.tsx` over HTTP. The daemon's `EXT_MIME` map in [`apps/daemon/src/projects.ts:241`](https://github.com/nexu-io/open-design/blob/main/apps/daemon/src/projects.ts#L241) served:

- `.jsx` → no entry → fallback `application/octet-stream`
- `.tsx` → `text/typescript`

Neither is a JavaScript MIME. Strict CSPs and modern browser module loaders reject both — which is one of the failure modes #336 flagged for the Open-button render path.

## Fix

Map both `.jsx` and `.tsx` to `text/javascript; charset=utf-8`, matching `.js` / `.mjs` / `.cjs`.

`.ts` is intentionally left as `text/typescript` — it has no browser-execution path in this codebase; tooling that reads `.ts` as TypeScript source is the load-bearing consumer. If a future change makes `.ts` browser-served too, that's a separate decision.

## Changes

- `apps/daemon/src/projects.ts` — add `.jsx` entry, update `.tsx` entry, with an inline rationale comment pointing back to #336.
- `apps/daemon/tests/project-classifiers.test.ts` — pin the new mappings and document why `.ts` stays put.

## Test plan

- [x] \`pnpm --filter @open-design/daemon test\` — 282/282 passing
- [x] \`pnpm --filter @open-design/daemon typecheck\` — clean

## Notes

This does **not** close #336. The main render-path bug (multi-file prototype Open button) is still under investigation pending the reporter's DevTools log. This PR only addresses the hygiene issue @lefarcen confirmed in [the first comment thread](https://github.com/nexu-io/open-design/issues/336#issuecomment-) so it can ship independently.

Refs #336.