### PR TITLE
fix(daemon): drop literal `-` argv from codex spawn so prompts deliver via stdin pipe alone

### DIFF
--- a/apps/daemon/src/agents.ts
+++ b/apps/daemon/src/agents.ts
@@ -202,8 +202,13 @@ export const AGENT_DEFS = [
       { id: 'medium', label: 'Medium' },
       { id: 'high', label: 'High' },
     ],
-    // Prompt delivered via stdin (`codex exec -`) to avoid Windows
-    // `spawn ENAMETOOLONG` while keeping Codex on its structured JSON stream.
+    // Prompt is delivered via stdin pipe (gated by `promptViaStdin: true`
+    // below) to avoid Windows `spawn ENAMETOOLONG` while keeping Codex on
+    // its structured JSON stream. Recent Codex CLI versions reject a bare
+    // `-` argv sentinel — passing both the pipe and `-` produces
+    // `error: unexpected argument '-' found` and the agent exits with
+    // code 2 before any prompt is read (see issue #237). The pipe alone
+    // is sufficient for stdin delivery.
     buildArgs: (_prompt, _imagePaths, _extra, options = {}, runtimeContext = {}) => {
       const args = [
         'exec',
@@ -228,7 +233,6 @@ export const AGENT_DEFS = [
         // is exposed as `model_reasoning_effort`.
         args.push('-c', `model_reasoning_effort="${effort}"`);
       }
-      args.push('-');
       return args;
     },
     promptViaStdin: true,

--- a/apps/daemon/tests/agents.test.ts
+++ b/apps/daemon/tests/agents.test.ts
@@ -38,7 +38,6 @@ test('codex args disable plugins when OD_CODEX_DISABLE_PLUGINS is 1', () => {
     '--disable',
     'plugins',
   ]);
-  assert.equal(args.at(-1), '-');
 });
 
 test('codex args keep plugins enabled when OD_CODEX_DISABLE_PLUGINS is unset', () => {
@@ -48,7 +47,6 @@ test('codex args keep plugins enabled when OD_CODEX_DISABLE_PLUGINS is unset', (
 
   assert.equal(args.includes('--disable'), false);
   assert.equal(args.includes('plugins'), false);
-  assert.equal(args.at(-1), '-');
 });
 
 test('codex args keep plugins enabled when OD_CODEX_DISABLE_PLUGINS is not 1', () => {
@@ -58,7 +56,27 @@ test('codex args keep plugins enabled when OD_CODEX_DISABLE_PLUGINS is not 1', (
 
   assert.equal(args.includes('--disable'), false);
   assert.equal(args.includes('plugins'), false);
-  assert.equal(args.at(-1), '-');
+});
+
+// Recent Codex CLI versions reject a bare `-` argv sentinel; passing it
+// alongside the stdin pipe causes `error: unexpected argument '-' found`
+// and exit code 2 before any prompt is read. We deliver the prompt via
+// stdin pipe alone (gated by `promptViaStdin: true`). Regression of #237.
+test('codex args do not include the literal `-` stdin sentinel (regression of #237)', () => {
+  delete process.env.OD_CODEX_DISABLE_PLUGINS;
+
+  const baseArgs = codex.buildArgs('', [], [], {}, { cwd: '/tmp/od-project' });
+  assert.equal(baseArgs.includes('-'), false);
+
+  const withModel = codex.buildArgs('', [], [], { model: 'gpt-5-codex' }, { cwd: '/tmp/od-project' });
+  assert.equal(withModel.includes('-'), false);
+
+  const withReasoning = codex.buildArgs('', [], [], { reasoning: 'high' }, { cwd: '/tmp/od-project' });
+  assert.equal(withReasoning.includes('-'), false);
+
+  process.env.OD_CODEX_DISABLE_PLUGINS = '1';
+  const withDisablePlugins = codex.buildArgs('', [], [], {}, { cwd: '/tmp/od-project' });
+  assert.equal(withDisablePlugins.includes('-'), false);
 });
 
 test('cursor-agent args deliver prompts via stdin without passing a literal dash prompt', () => {


### PR DESCRIPTION
## Summary

Closes [#237](https://github.com/nexu-io/open-design/issues/237). Recent Codex CLI versions (≥ 0.122 per the issue thread) reject a bare \`-\` argv element with \`error: unexpected argument '-' found\` and exit code 2 before any prompt is read. The daemon currently passes both the stdin pipe (\`promptViaStdin: true\`) and a trailing \`-\` argv, which was redundant after PR [#258](https://github.com/nexu-io/open-design/pull/258) standardized stdin delivery — only the codex \`args.push('-')\` was missed in that refactor.

This matches the maintainer's diagnosis (cc @lefarcen) — see [#237 thread](https://github.com/nexu-io/open-design/issues/237#issuecomment-) where \`@lefarcen\` confirmed:

> PR #258 (\"Standardize agent communication via stdin\") set \`promptViaStdin: true\` for codex, which makes the daemon deliver the prompt via stdin. BUT it didn't remove the \`args.push('-')\` from the buildArgs function… The fix is trivial (literally removing 2 lines).

The fix mirrors the pattern that was already applied to \`cursor-agent\` (see the inline comment at the top of its buildArgs in [\`apps/daemon/src/agents.ts\`](https://github.com/nexu-io/open-design/blob/main/apps/daemon/src/agents.ts#L392-L396)), where the same \`-\` sentinel was found to surface as a literal user prompt.

## Scope (deliberately minimal)

- \`apps/daemon/src/agents.ts\` — drop the trailing \`args.push('-')\` from codex \`buildArgs\` and update the inline comment so it documents the post-#258 contract (stdin pipe alone) instead of the broken \`codex exec -\` form.
- \`apps/daemon/tests/agents.test.ts\` — three existing tests asserted \`args.at(-1) === '-'\`, which encoded the broken contract. Replace them with a single regression test that pins \`args.includes('-') === false\` across the plugin, model, reasoning, and disable-plugins permutations, so the sentinel can't sneak back in via a future buildArgs branch.

## Out of scope (calling out for maintainer assessment)

1. **\`--full-auto\` deprecation warning**: current Codex versions print
   > warning: \`--full-auto\` is deprecated; use \`--sandbox workspace-write\` instead
   It's a warning, not an error — Codex still runs. The right replacement isn't a 1:1 swap (\`--full-auto\` also implies an auto-approval policy that plain \`--sandbox workspace-write\` doesn't enable), so cleaning this up deserves its own PR after confirming the modern equivalent. Tracking separately from #237.

2. **OpenCode + Qwen follow the same \`args.push('-')\` + \`promptViaStdin: true\` shape** at [\`apps/daemon/src/agents.ts:320\`](https://github.com/nexu-io/open-design/blob/main/apps/daemon/src/agents.ts#L320) and [\`apps/daemon/src/agents.ts:433\`](https://github.com/nexu-io/open-design/blob/main/apps/daemon/src/agents.ts#L433). Whether their current CLIs also reject a bare \`-\` is unverified — but if they do, the same minimal fix applies there. Worth a look alongside [#163](https://github.com/nexu-io/open-design/issues/163) (OpenCode exits code 1) and [#218](https://github.com/nexu-io/open-design/issues/218) (Kimi/npm-distributed Copilot).

## Test plan

- [x] \`pnpm --filter @open-design/daemon test\` — 283/283 passing (16 in agents.test.ts, including the new regression)
- [x] \`pnpm --filter @open-design/daemon typecheck\` — clean
- [ ] Manual Codex run on Windows / 0.128.0+ — I don't have a current Codex CLI install to verify the live path; reviewers with one can confirm by running any prompt against an Open Design build that contains this commit.

Closes #237.