### PR TITLE
fix(web): treat inlined script content as literal in FileViewer

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -1669,7 +1669,7 @@ async function inlineRelativeAssets(
   const resolved = (await Promise.all(replacements)).filter(
     (item): item is { from: string; to: string } => item !== null,
   );
-  return resolved.reduce((next, { from, to }) => next.replace(from, to), html);
+  return resolved.reduce((next, { from, to }) => next.replace(from, () => to), html);
 }
 
 async function fetchProjectRelativeText(


### PR DESCRIPTION
Fixes #336.

## Summary

`FileViewer.tsx`'s `inlineRelativeAssets` was passing fetched script/CSS content as the `to` argument of `String.prototype.replace`. When that content contained `$'`, `$&`, `` $` ``, `$1`–`$9`, or `$<name>` — all valid in JavaScript code — those sequences were interpreted as replacement-pattern back-references, mangling or truncating the inlined output.

This broke the **Open** view for any HTML project whose inlined `.jsx`/`.js` files contained those characters. Repro from the linked issue: a multi-file React+Babel prototype where a JSX file held `'-$'` / `'+$'` literals — the inliner produced `Unterminated string constant` Babel errors and `ReferenceError: SpineProvider is not defined` because the script bodies were truncated at `$'`.

The fix is one line: pass a function replacer to `replace`, which causes the replacement string to be inserted verbatim with no special-pattern interpretation.

## Test plan

- [x] Reload an affected project (multi-file React+Babel prototype with `$'` in JSX) via Open — no longer shows raw source / Babel parse errors; React tree mounts as in browser-direct view
- [ ] Decks and single-file HTML continue to render unchanged
- [ ] Source view still shows raw HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)