### PR TITLE
feat(web): add "Export as Markdown" pass-through download to share menu

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -18,6 +18,7 @@ import type { ProjectFilePreview } from '../providers/registry';
 import {
   exportAsHtml,
   exportAsJsx,
+  exportAsMd,
   exportAsPdf,
   exportProjectAsZip,
   exportReactComponentAsHtml,
@@ -1323,6 +1324,24 @@ function HtmlViewer({
                   >
                     <span className="share-menu-icon"><Icon name="file-code" size={14} /></span>
                     <span>{t('fileViewer.exportHtml')}</span>
+                  </button>
+                  {/* Export as Markdown — pass-through download of the
+                      artifact source with a `.md` extension. No conversion
+                      runs; the file body is identical to the Source view.
+                      Useful for piping the artifact into markdown-aware
+                      tooling (LLM context windows, vault apps). See
+                      issue #279. */}
+                  <button
+                    type="button"
+                    className="share-menu-item"
+                    role="menuitem"
+                    onClick={() => {
+                      setShareMenuOpen(false);
+                      exportAsMd(source ?? '', exportTitle);
+                    }}
+                  >
+                    <span className="share-menu-icon"><Icon name="file" size={14} /></span>
+                    <span>{t('fileViewer.exportMd')}</span>
                   </button>
                   <div className="share-menu-divider" />
                   <button

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -534,6 +534,7 @@ export const ar: Dict = {
   'fileViewer.exportPptxNa': 'تصدير PPTX غير متوفر هنا.',
   'fileViewer.exportZip': 'تحميل كـ zip.',
   'fileViewer.exportHtml': 'تصدير كـ HTML مستقل',
+  'fileViewer.exportMd': 'تصدير كـ Markdown',
   'fileViewer.exportJsx': 'تصدير كـ JSX',
   'fileViewer.exportReactHtml': 'تصدير المعاينة كـ HTML',
   'fileViewer.saveAsTemplate': 'حفظ كقالب...',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -534,6 +534,7 @@ export const de: Dict = {
   'fileViewer.exportPptxNa': 'PPTX-Export ist hier nicht verfügbar.',
   'fileViewer.exportZip': 'Als .zip herunterladen',
   'fileViewer.exportHtml': 'Als eigenständiges HTML exportieren',
+  'fileViewer.exportMd': 'Als Markdown exportieren',
   'fileViewer.exportJsx': 'Als JSX exportieren',
   'fileViewer.exportReactHtml': 'Vorschau als HTML exportieren',
   'fileViewer.saveAsTemplate': 'Als Template speichern…',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -534,6 +534,7 @@ export const en: Dict = {
   'fileViewer.exportPptxNa': 'PPTX export is not available here.',
   'fileViewer.exportZip': 'Download as .zip',
   'fileViewer.exportHtml': 'Export as standalone HTML',
+  'fileViewer.exportMd': 'Export as Markdown',
   'fileViewer.exportJsx': 'Export as JSX',
   'fileViewer.exportReactHtml': 'Export preview as HTML',
   'fileViewer.saveAsTemplate': 'Save as template…',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -535,6 +535,7 @@ export const esES: Dict = {
   'fileViewer.exportPptxNa': 'La exportación a PPTX no está disponible aquí.',
   'fileViewer.exportZip': 'Descargar como .zip',
   'fileViewer.exportHtml': 'Exportar como HTML independiente',
+  'fileViewer.exportMd': 'Exportar como Markdown',
   'fileViewer.exportJsx': 'Exportar como JSX',
   'fileViewer.exportReactHtml': 'Exportar vista previa como HTML',
   'fileViewer.saveAsTemplate': 'Guardar como plantilla…',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -534,6 +534,7 @@ export const fa: Dict = {
   'fileViewer.exportPptxNa': 'صادرکردن PPTX اینجا در دسترس نیست.',
   'fileViewer.exportZip': 'دانلود به صورت .zip',
   'fileViewer.exportHtml': 'صادرکردن به HTML مستقل',
+  'fileViewer.exportMd': 'صادرکردن به صورت Markdown',
   'fileViewer.exportJsx': 'صادرکردن به JSX',
   'fileViewer.exportReactHtml': 'صادرکردن پیش‌نمایش به HTML',
   'fileViewer.saveAsTemplate': 'ذخیره به عنوان قالب…',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -534,6 +534,7 @@ export const hu: Dict = {
   'fileViewer.exportPptxNa': 'A PPTX export itt nem elérhető.',
   'fileViewer.exportZip': 'Letöltés .zip-ként',
   'fileViewer.exportHtml': 'Exportálás önálló HTML-ként',
+  'fileViewer.exportMd': 'Exportálás Markdown-ként',
   'fileViewer.exportJsx': 'Exportálás JSX-ként',
   'fileViewer.exportReactHtml': 'Előnézet exportálása HTML-ként',
   'fileViewer.saveAsTemplate': 'Mentés sablonként…',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -533,6 +533,7 @@ export const ja: Dict = {
   'fileViewer.exportPptxNa': 'ここでは PPTX エクスポートは利用できません。',
   'fileViewer.exportZip': '.zip としてダウンロード',
   'fileViewer.exportHtml': 'スタンドアロン HTML としてエクスポート',
+  'fileViewer.exportMd': 'Markdown としてエクスポート',
   'fileViewer.exportJsx': 'JSX としてエクスポート',
   'fileViewer.exportReactHtml': 'プレビューを HTML としてエクスポート',
   'fileViewer.saveAsTemplate': 'テンプレートとして保存…',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -534,6 +534,7 @@ export const ko: Dict = {
   'fileViewer.exportPptxNa': '이곳에서는 PPTX 내보내기를 할 수 없습니다.',
   'fileViewer.exportZip': '.zip으로 다운로드',
   'fileViewer.exportHtml': '독립 실행형 HTML로 내보내기',
+  'fileViewer.exportMd': 'Markdown으로 내보내기',
   'fileViewer.exportJsx': 'JSX로 내보내기',
   'fileViewer.exportReactHtml': '미리보기를 HTML로 내보내기',
   'fileViewer.saveAsTemplate': '템플릿으로 저장…',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -534,6 +534,7 @@ export const pl: Dict = {
   'fileViewer.exportPptxNa': 'Eksport do PPTX nie jest tutaj dostępny.',
   'fileViewer.exportZip': 'Pobierz jako .zip',
   'fileViewer.exportHtml': 'Eksportuj jako samodzielny HTML',
+  'fileViewer.exportMd': 'Eksportuj jako Markdown',
   'fileViewer.exportJsx': 'Eksportuj jako JSX',
   'fileViewer.exportReactHtml': 'Eksportuj podgląd jako HTML',
   'fileViewer.saveAsTemplate': 'Zapisz jako szablon…',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -533,6 +533,7 @@ export const ptBR: Dict = {
   'fileViewer.exportPptxNa': 'Exportação PPTX não está disponível aqui.',
   'fileViewer.exportZip': 'Baixar como .zip',
   'fileViewer.exportHtml': 'Exportar como HTML independente',
+  'fileViewer.exportMd': 'Exportar como Markdown',
   'fileViewer.exportJsx': 'Exportar como JSX',
   'fileViewer.exportReactHtml': 'Exportar prévia como HTML',
   'fileViewer.saveAsTemplate': 'Salvar como template…',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -533,6 +533,7 @@ export const ru: Dict = {
   'fileViewer.exportPptxNa': 'Экспорт PPTX здесь недоступен.',
   'fileViewer.exportZip': 'Скачать как .zip',
   'fileViewer.exportHtml': 'Экспорт как HTML',
+  'fileViewer.exportMd': 'Экспорт в Markdown',
   'fileViewer.exportJsx': 'Экспорт как JSX',
   'fileViewer.exportReactHtml': 'Экспорт предпросмотра как HTML',
   'fileViewer.saveAsTemplate': 'Сохранить как шаблон…',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -533,6 +533,7 @@ export const tr: Dict = {
   'fileViewer.exportPptxNa': 'PPTX dışa aktarma burada mevcut değil.',
   'fileViewer.exportZip': 'ZIP olarak indir',
   'fileViewer.exportHtml': 'Tekil HTML olarak dışa aktar',
+  'fileViewer.exportMd': 'Markdown olarak dışa aktar',
   'fileViewer.exportJsx': 'JSX olarak dışa aktar',
   'fileViewer.exportReactHtml': 'Önizlemeyi HTML olarak dışa aktar',
   'fileViewer.saveAsTemplate': 'Şablon olarak kaydet…',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -522,6 +522,7 @@ export const zhCN: Dict = {
   'fileViewer.exportPptxNa': '此处暂不支持导出 PPTX。',
   'fileViewer.exportZip': '下载为 .zip',
   'fileViewer.exportHtml': '导出为独立 HTML',
+  'fileViewer.exportMd': '导出为 Markdown',
   'fileViewer.exportJsx': '导出为 JSX',
   'fileViewer.exportReactHtml': '导出预览 HTML',
   'fileViewer.saveAsTemplate': '保存为模板…',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -522,6 +522,7 @@ export const zhTW: Dict = {
   'fileViewer.exportPptxNa': '此處暫不支援匯出 PPTX。',
   'fileViewer.exportZip': '下載為 .zip',
   'fileViewer.exportHtml': '匯出為獨立 HTML',
+  'fileViewer.exportMd': '匯出為 Markdown',
   'fileViewer.exportJsx': '匯出為 JSX',
   'fileViewer.exportReactHtml': '匯出預覽 HTML',
   'fileViewer.saveAsTemplate': '儲存為範本…',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -548,6 +548,7 @@ export interface Dict {
   'fileViewer.exportPptxNa': string;
   'fileViewer.exportZip': string;
   'fileViewer.exportHtml': string;
+  'fileViewer.exportMd': string;
   'fileViewer.exportJsx': string;
   'fileViewer.exportReactHtml': string;
   'fileViewer.saveAsTemplate': string;

--- a/apps/web/src/runtime/exports.test.ts
+++ b/apps/web/src/runtime/exports.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { archiveFilenameFrom, archiveRootFromFilePath } from './exports';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { archiveFilenameFrom, archiveRootFromFilePath, exportAsMd } from './exports';
 
 function mockResponse(headers: Record<string, string>): Response {
   return { headers: new Headers(headers) } as Response;
@@ -62,5 +62,75 @@ describe('archiveFilenameFrom', () => {
       'content-disposition': "attachment; filename*=UTF-8''%E9%9D",
     });
     expect(archiveFilenameFrom(resp, 'fallback', 'ui-design')).toBe('ui-design.zip');
+  });
+});
+
+// `exportAsMd` is a pass-through (the file body is the artifact source
+// verbatim, only the extension and Content-Type flip). Tests exercise it
+// end-to-end by stubbing the few DOM globals `triggerDownload` touches —
+// we run under `environment: 'node'`, so `document` and `URL` aren't
+// available by default. See issue #279.
+describe('exportAsMd', () => {
+  let capturedBlob: Blob | undefined;
+  let capturedFilename: string | undefined;
+
+  beforeEach(() => {
+    capturedBlob = undefined;
+    capturedFilename = undefined;
+    vi.stubGlobal('URL', {
+      createObjectURL: (blob: Blob) => {
+        capturedBlob = blob;
+        return 'blob:test';
+      },
+      revokeObjectURL: () => {},
+    });
+    vi.stubGlobal('document', {
+      createElement: () => {
+        const anchor = { href: '', click: () => {} } as { href: string; download?: string; click: () => void };
+        Object.defineProperty(anchor, 'download', {
+          set(value: string) {
+            capturedFilename = value;
+          },
+          get() {
+            return capturedFilename ?? '';
+          },
+        });
+        return anchor;
+      },
+      body: { appendChild: () => {}, removeChild: () => {} },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('downloads the source bytes verbatim under a `.md` extension', async () => {
+    const source = '<!doctype html>\n<html lang="en"><body>hi</body></html>\n';
+
+    exportAsMd(source, 'TTC — Seed Round · 2026');
+
+    expect(capturedBlob).toBeDefined();
+    expect(capturedBlob!.type).toBe('text/markdown;charset=utf-8');
+    // Critical: no transformation, no normalization, no trimming. Whatever
+    // the Source view shows is what lands in the .md.
+    expect(await capturedBlob!.text()).toBe(source);
+    expect(capturedFilename).toBe('TTC-Seed-Round-2026.md');
+  });
+
+  it('falls back to "artifact.md" when the title is empty or unsafe', () => {
+    exportAsMd('hello', '');
+    expect(capturedFilename).toBe('artifact.md');
+
+    exportAsMd('hello', '???');
+    expect(capturedFilename).toBe('artifact.md');
+  });
+
+  it('keeps multi-byte content (UTF-8) intact end-to-end', async () => {
+    const source = '# 中文标题\n\n这是 markdown 文件 — でも本当は HTML 源代码 (مرحبا)。\n';
+
+    exportAsMd(source, 'mixed');
+
+    expect(await capturedBlob!.text()).toBe(source);
   });
 });

--- a/apps/web/src/runtime/exports.ts
+++ b/apps/web/src/runtime/exports.ts
@@ -1,9 +1,14 @@
 // Client-side export helpers used by the Share menu in the HTML viewer.
-// Three of the four formats run entirely in the browser:
+// Four of the five formats run entirely in the browser:
 //   - PDF  : open the artifact in a popup window and trigger window.print().
 //            The user picks "Save as PDF" from the system print dialog.
 //   - HTML : download the artifact as a single .html file via a Blob URL.
 //   - ZIP  : pack the artifact into a stored-mode ZIP (see ./zip.ts).
+//   - MD   : download the artifact's source verbatim with a `.md` extension
+//            so it can be ingested by markdown-aware tooling (LLM context
+//            windows, vault apps, etc.). No conversion is performed — the
+//            file content is the same source the Source view shows. See
+//            issue #279.
 // PPTX export is fundamentally different — it asks the agent to convert the
 // artifact server-side, so it lives in ProjectView.tsx (not here).
 
@@ -49,6 +54,16 @@ export function exportAsZip(html: string, title: string): void {
     },
   ]);
   triggerDownload(blob, `${slug}.zip`);
+}
+
+export function exportAsMd(source: string, title: string): void {
+  // Pass-through download: the file body is the artifact source verbatim,
+  // only the extension and Content-Type are flipped to markdown. No
+  // HTML→markdown conversion happens here — users who pipe the file into
+  // markdown-aware tooling (LLM context windows, vault apps) get the same
+  // bytes the Source view displays.
+  const blob = new Blob([source], { type: 'text/markdown;charset=utf-8' });
+  triggerDownload(blob, `${safeFilename(title, 'artifact')}.md`);
 }
 
 type ReactSourceExtension = '.jsx' | '.tsx';


### PR DESCRIPTION
## Summary

Closes [#279](https://github.com/nexu-io/open-design/issues/279). Adds an **Export as Markdown** entry to the HTML / deck artifact share menu. The entry downloads the artifact source **verbatim** with a \`.md\` extension and \`text/markdown; charset=utf-8\` Content-Type — no HTML→markdown conversion runs. The file body is byte-for-byte identical to what the Source view shows.

## Why pass-through, not conversion

The first iteration used \`turndown\` to do a real HTML→CommonMark conversion. The issue author rejected that path: lossy text-extraction strips out the embedded styles + scripts that make the deck reproducible. They want the **source** under a \`.md\` filename so it slots into markdown-aware tooling (LLM context windows, vault apps) that key off the extension.

Keeping the implementation byte-exact also leaves room for a future *Convert to Markdown* entry to live alongside this one without overlap, if a lossy-conversion use case comes up later.

## Changes

| File | What |
|---|---|
| \`apps/web/src/runtime/exports.ts\` | New \`exportAsMd(source, title)\` helper. Module-level comment updated to include MD in the export-family description. |
| \`apps/web/src/components/FileViewer.tsx\` | New share menu entry, positioned right after *Export as standalone HTML* and before the *Save as template* divider so the file-format exports stay grouped. |
| \`apps/web/src/i18n/types.ts\` + 14 locale files (\`en\`, \`de\`, \`ja\`, \`ko\`, \`zh-CN\`, \`zh-TW\`, \`es-ES\`, \`fa\`, \`pt-BR\`, \`ru\`, \`ar\`, \`pl\`, \`tr\`, \`hu\`) | \`fileViewer.exportMd\` key, mirroring the structure of the existing \`exportHtml\` / \`exportZip\` entries. |
| \`apps/web/src/runtime/exports.test.ts\` | Three new cases under \`exportAsMd\`: bytes-verbatim with the markdown content type, title fallback when sanitization yields nothing, and UTF-8 round-trip. Tests stub \`URL.createObjectURL\` + a minimal \`document\` so the download path works under \`environment: 'node'\`. |

**No new dependencies.** **No daemon-side changes** — all client-side.

## Test plan

- [x] \`pnpm --filter @open-design/web test\` — 23 files / 143 tests green (12 in \`exports.test.ts\`, including 3 new)
- [x] \`pnpm --filter @open-design/web typecheck\` — clean
- [x] \`pnpm typecheck\` (full repo, including \`check:residual-js\`) — clean
- [x] Manual browser test via \`pnpm tools-dev run web\`: clicked the new menu entry on a 10-slide deck artifact; the download blob was \`text/markdown; charset=utf-8\`, 36,990 bytes, started with \`<!doctype html>...\` and matched the Source view byte-for-byte.

## UI placement

The share menu now reads, top to bottom:

\`\`\`
Export as PDF (all slides)
Export as PPTX...
─
Download as .zip
Export as standalone HTML
Export as Markdown          ← new
─
Save as template...
Deploy to Vercel
Copy link
\`\`\`