### PR TITLE
fix(daemon): lead copilot spawn with `-p -` so prompt-via-stdin is consumed

### DIFF
--- a/apps/daemon/src/agents.ts
+++ b/apps/daemon/src/agents.ts
@@ -441,6 +441,16 @@ export const AGENT_DEFS = [
     name: 'GitHub Copilot CLI',
     bin: 'copilot',
     versionArgs: ['--version'],
+    // `-p -` enters Copilot's prompt mode and tells the CLI to read the
+    // prompt body from stdin instead of expecting it as a positional argv
+    // element. Without it the daemon writes the prompt to the child's
+    // stdin pipe (because `promptViaStdin: true` below) but Copilot stays
+    // in interactive mode, never reads stdin, and rejects the run with
+    // `error: too many arguments. Expected 0 arguments but got N` —
+    // the regression filed in #350. PR #258 standardized agents on stdin
+    // delivery and dropped the per-prompt argv path, but missed flipping
+    // Copilot's mode from interactive to `-p -`.
+    //
     // `--allow-all-tools` is required for non-interactive runs: without it
     // the CLI blocks waiting for human approval on every tool call. Unlike
     // Codex (where `exec` is a dedicated headless subcommand with
@@ -466,6 +476,8 @@ export const AGENT_DEFS = [
     ],
     buildArgs: (_prompt, _imagePaths, extraAllowedDirs = [], options = {}) => {
       const args = [
+        '-p',
+        '-',
         '--allow-all-tools',
         '--output-format',
         'json',

--- a/apps/daemon/tests/agents.test.ts
+++ b/apps/daemon/tests/agents.test.ts
@@ -7,6 +7,7 @@ import { join } from 'node:path';
 import { AGENT_DEFS, resolveAgentExecutable } from '../src/agents.js';
 
 const codex = AGENT_DEFS.find((agent) => agent.id === 'codex');
+const copilot = AGENT_DEFS.find((agent) => agent.id === 'copilot');
 const cursorAgent = AGENT_DEFS.find((agent) => agent.id === 'cursor-agent');
 const kiro = AGENT_DEFS.find((agent) => agent.id === 'kiro');
 const claude = AGENT_DEFS.find((agent) => agent.id === 'claude');
@@ -92,6 +93,61 @@ test('cursor-agent args deliver prompts via stdin without passing a literal dash
     '--workspace',
     '/tmp/od-project',
   ]);
+});
+
+// `-p -` puts Copilot in prompt mode and tells it to read the body from
+// stdin. Without this pair the daemon writes the prompt to the child's
+// stdin pipe (because `promptViaStdin: true`) but Copilot stays
+// interactive, ignores stdin, and rejects the run with
+// `error: too many arguments. Expected 0 arguments but got N`. Pin the
+// pair as the leading argv elements so the regression in #350 can't
+// drift back. Also pin the order — Copilot expects `-p` before any other
+// flag, including model / add-dir extensions.
+test('copilot args lead with `-p -` so the stdin prompt is actually consumed (regression of #350)', () => {
+  const baseArgs = copilot.buildArgs('', [], [], {});
+  assert.equal(baseArgs[0], '-p');
+  assert.equal(baseArgs[1], '-');
+  assert.deepEqual(baseArgs, [
+    '-p',
+    '-',
+    '--allow-all-tools',
+    '--output-format',
+    'json',
+  ]);
+});
+
+test('copilot args keep `-p -` at the front when model and extra dirs are added', () => {
+  const args = copilot.buildArgs(
+    '',
+    [],
+    ['/tmp/od-skills', '/tmp/od-design-systems'],
+    { model: 'claude-sonnet-4.6' },
+  );
+  assert.equal(args[0], '-p');
+  assert.equal(args[1], '-');
+  assert.deepEqual(args, [
+    '-p',
+    '-',
+    '--allow-all-tools',
+    '--output-format',
+    'json',
+    '--model',
+    'claude-sonnet-4.6',
+    '--add-dir',
+    '/tmp/od-skills',
+    '--add-dir',
+    '/tmp/od-design-systems',
+  ]);
+});
+
+test('copilot drops empty / non-string entries from extraAllowedDirs without breaking the `-p -` lead', () => {
+  const args = copilot.buildArgs('', [], ['', null, '/tmp/od-skills', undefined], {});
+  assert.equal(args[0], '-p');
+  assert.equal(args[1], '-');
+  // Only the one valid path survives.
+  const addDirIndex = args.indexOf('--add-dir');
+  assert.equal(args[addDirIndex + 1], '/tmp/od-skills');
+  assert.equal(args.filter((a) => a === '--add-dir').length, 1);
 });
 
 test('kiro args use acp subcommand for json-rpc streaming', () => {


### PR DESCRIPTION
## Summary

Closes [#350](https://github.com/nexu-io/open-design/issues/350). GitHub Copilot CLI rejects every Open Design run with \`error: too many arguments. Expected 0 arguments but got N\` and exits code 1, leaving the agent unusable on \`main\` / 0.2.0.

Same regression family as [#237](https://github.com/nexu-io/open-design/issues/237) (codex) and the original [#315](https://github.com/nexu-io/open-design/issues/315) motivation behind PR [#258](https://github.com/nexu-io/open-design/pull/258) (\"Standardize agent communication via stdin\"). PR #258 moved every adapter onto a shared stdin pipe and dropped the per-prompt argv path, but missed flipping Copilot from interactive mode (where the prompt body is a positional argv element) to \`-p -\` mode (where Copilot reads the body from stdin).

cc @lefarcen — your diagnosis on [#350](https://github.com/nexu-io/open-design/issues/350#issuecomment-) was the spec; this PR implements it.

## Root cause

Without \`-p -\`:
1. The daemon writes the prompt to the child's stdin pipe (because \`promptViaStdin: true\`).
2. Copilot stays in **interactive mode**, doesn't read stdin.
3. The leftover daemon argv (\`--allow-all-tools\`, \`--output-format\`, \`json\`, …) becomes \"too many arguments\" from Copilot's perspective.
4. Copilot exits code 1 before reading anything.

With \`-p -\` as the leading argv pair:
1. Copilot enters **prompt mode** with stdin as the body source.
2. The daemon's stdin pipe is consumed correctly.
3. Trailing flags (\`--allow-all-tools\`, etc.) are interpreted as flags, not as positional excess.

## Changes

- \`apps/daemon/src/agents.ts\` — prepend \`-p\` and \`-\` to the copilot \`buildArgs\` output. Inline comment expanded to document the regression and why \`-p -\` is load-bearing, so the next refactor doesn't re-break it.
- \`apps/daemon/tests/agents.test.ts\` — three new regression cases:
  1. **Base shape** — \`-p -\` lead + the unchanged tail of \`--allow-all-tools --output-format json\`.
  2. **Order under model + add-dir extension** — \`-p -\` stays first even when \`--model\` and repeated \`--add-dir\` flags get appended.
  3. **Sanitization** — empty / non-string entries in \`extraAllowedDirs\` still drop out (existing behavior) without disturbing the \`-p -\` lead.

Surgical update to the agent's buildArgs only — no daemon-side plumbing changes. Mirrors the codex post-#258 cleanup in [#342](https://github.com/nexu-io/open-design/pull/342).

## Test plan

- [x] \`pnpm --filter @open-design/daemon test\` — 19 files / 317 tests green (3 new copilot cases included)
- [x] \`pnpm --filter @open-design/daemon typecheck\` — clean
- [x] Manual run against a current GitHub Copilot CLI install — I don't have one wired up locally; reviewers with one can confirm by sending any prompt against an Open Design build that contains this commit.

## Out of scope

Doesn't audit the other agents that flipped to \`promptViaStdin: true\` in #258 for similar stdin-mode mismatches:

- **OpenCode** ([\`agents.ts:320\`](https://github.com/nexu-io/open-design/blob/main/apps/daemon/src/agents.ts#L320)) — still pushes a bare \`-\` at the end. Possibly related to [#163](https://github.com/nexu-io/open-design/issues/163).
- **Qwen Code** ([\`agents.ts:433\`](https://github.com/nexu-io/open-design/blob/main/apps/daemon/src/agents.ts#L433)) — same shape, behavior with current Qwen versions unverified.

Calling out for maintainer assessment alongside [#163](https://github.com/nexu-io/open-design/issues/163) / [#218](https://github.com/nexu-io/open-design/issues/218). Each CLI uses a different stdin sentinel convention so a per-agent fix is the right granularity, not a daemon-side abstraction.

### Verification path for the next person auditing OpenCode / Qwen Code

Per @lefarcen's review suggestion, here's the concrete check sequence so the next contributor doesn't have to re-derive it:

1. **Confirm whether the CLI accepts a bare \`-\` as a stdin sentinel.** Run from a terminal:
   \`\`\`bash
   echo "say hi" | opencode run --format json --dangerously-skip-permissions -
   echo "say hi" | qwen --yolo -
   \`\`\`
   If the CLI consumes stdin and produces output → the current bare \`-\` shape is correct, no change needed.
2. **If \`-\` is rejected with an "unexpected argument" / "too many arguments" / "argument required" error,** the CLI doesn't auto-recognise \`-\` as the stdin sentinel. Check \`opencode run --help\` / \`qwen --help\` for the actual stdin-mode flag — common shapes are \`-p -\` (this PR / Codex-style), \`--input -\`, or just consuming stdin when the positional prompt arg is absent.
3. **Pattern to apply** is identical to this PR: prepend the correct stdin-sentinel pair at the front of the agent's \`buildArgs\` output and pin it with a regression test mirroring the three cases here (base shape, model + add-dir extension, sanitization).

If the CLI's behavior has changed between versions (which is what bit Codex in [#237](https://github.com/nexu-io/open-design/issues/237) and Copilot here), a new issue per agent is probably worth filing rather than rolling everything into one PR — different upstreams move on different cadences.
