### PR TITLE
feat(daemon): /api/import/frontend-snapshot — generic frontend-snapshot importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ OD stands on four open-source shoulders:
 | **Visual directions** | 5 curated schools (Editorial Monocle · Modern Minimal · Warm Soft · Tech Utility · Brutalist Experimental) — each ships a deterministic OKLch palette + font stack ([`apps/web/src/prompts/directions.ts`](apps/web/src/prompts/directions.ts)) |
 | **Device frames** | iPhone 15 Pro · Pixel · iPad Pro · MacBook · Browser Chrome — pixel-accurate, shared across skills under [`assets/frames/`](assets/frames/) |
 | **Agent runtime** | Local daemon spawns the CLI in your project folder — agent gets real `Read`, `Write`, `Bash`, `WebFetch` against a real on-disk environment, with Windows `ENAMETOOLONG` fallbacks (stdin / prompt-file) on every adapter |
-| **Imports** | Drop a [Claude Design][cd] export ZIP onto the welcome dialog — `POST /api/import/claude-design` parses it into a real project so your agent can keep editing where Anthropic left off |
+| **Imports** | Drop a [Claude Design][cd] export ZIP onto the welcome dialog — `POST /api/import/claude-design` parses it into a real project so your agent can keep editing where Anthropic left off. Also supports **frontend-snapshot ZIPs** (`manifest.json` + `routes.json` + `components.json` + `design-tokens.json` + optional `screenshots/`) via `POST /api/import/lune-frontend-snapshot` — drop a snapshot from any producer that targets the [lune-to-od-bridge v0.1.x manifest schema][lbridge] and OD opens it as a routes / components / token-set workspace you can iterate against. |
 | **Persistence** | SQLite at `.od/app.sqlite`: projects · conversations · messages · tabs · saved templates. Reopen tomorrow, todo card and open files are exactly where you left them. |
 | **Lifecycle** | One entry point: `pnpm tools-dev` (start / stop / run / status / logs / inspect / check) — boots daemon + web (+ desktop) under typed sidecar stamps |
 | **Desktop** | Optional Electron shell with sandboxed renderer + sidecar IPC (STATUS / EVAL / SCREENSHOT / CONSOLE / CLICK / SHUTDOWN) — drives `tools-dev inspect desktop screenshot` for E2E |
@@ -67,6 +67,7 @@ OD stands on four open-source shoulders:
 
 [acd2]: https://github.com/VoltAgent/awesome-design-md
 [ads]: https://github.com/bergside/awesome-design-skills
+[lbridge]: https://github.com/looptech-ai/lune/blob/main/.claude/harness/contracts/lune-to-od-bridge.md
 
 ## Demo
 
@@ -269,6 +270,7 @@ Every layer is composable. Every layer is a file you can edit. Read [`apps/web/s
    │  /api/design-systems  /api/projects/…
    │  /api/chat (SSE)      /api/proxy/stream (SSE)
    │  /api/templates       /api/import/claude-design
+   │                       /api/import/lune-frontend-snapshot
    │  /api/artifacts/save  /api/artifacts/lint
    │  /api/upload          /api/projects/:id/files…
    │  /artifacts (static)  /frames (static)
@@ -564,6 +566,7 @@ Pattern is the same as the rest: pick a template, edit the brief, send. The agen
 The chat / artifact loop gets the spotlight, but a handful of less-visible capabilities are already wired and worth knowing before you compare OD to anything else:
 
 - **Claude Design ZIP import.** Drop an export from claude.ai onto the welcome dialog. `POST /api/import/claude-design` extracts it into a real `.od/projects/<id>/`, opens the entry file as a tab, and stages a continue-where-Anthropic-left-off prompt for your local agent. No re-prompting, no "ask the model to re-create what we just had". ([`apps/daemon/src/server.ts`](apps/daemon/src/server.ts) — `/api/import/claude-design`)
+- **Frontend-snapshot ZIP import.** Drop a ZIP that conforms to the [lune-to-od-bridge v0.1.x manifest schema][lbridge] (`manifest.json`, `routes.json`, `components.json`, `design-tokens.json`, optional `screenshots/<file>`). `POST /api/import/lune-frontend-snapshot` validates the manifest version (`0.1.*` accepted; `0.2+` rejected with an explicit upgrade message), persists the artifact tree under `.od/projects/<id>/`, opens `manifest.json` as the default tab, and seeds a "iterate the visuals here and the producer can re-import on the next round-trip" prompt. The endpoint is producer-agnostic — the schema is a generic frontend snapshot, not a Lune-specific format. ([`apps/daemon/src/lune-frontend-snapshot-import.ts`](apps/daemon/src/lune-frontend-snapshot-import.ts), wired in [`apps/daemon/src/server.ts`](apps/daemon/src/server.ts) — `/api/import/lune-frontend-snapshot`)
 - **OpenAI-compatible BYOK proxy.** `POST /api/proxy/stream` takes `{ baseUrl, apiKey, model, messages }`, normalises the path (`…/v1/chat/completions`), forwards SSE chunks back to the browser, and rejects loopback / link-local / RFC1918 destinations to head off SSRF. Anything that speaks the OpenAI chat schema works — Anthropic-via-OpenAI shim, DeepSeek, Groq, MiMo, OpenRouter, your self-hosted vLLM. MiMo gets `tool_choice: 'none'` automatically because its tool schema misbehaves on free-form generation.
 - **User-saved templates.** Once you like a render, `POST /api/templates` snapshots the HTML + metadata into the SQLite `templates` table. The next project picks it from a "your templates" row in the picker — same surface as the shipped 31, but yours.
 - **Tab persistence.** Every project remembers its open files and active tab in the `tabs` table. Reopen the project tomorrow and the workspace looks exactly the way you left it.
@@ -599,6 +602,7 @@ The whole machinery below is the [`huashu-design`](https://github.com/alchaincyf
 | Live todo progress + tool stream | ❌ | ✅ | **✅** (UX pattern from open-codesign) |
 | Sandboxed iframe preview | ❌ | ✅ | **✅** (pattern from open-codesign) |
 | Claude Design ZIP import | n/a | ❌ | **✅ `POST /api/import/claude-design` — keep editing where Anthropic left off** |
+| Frontend-snapshot ZIP import | n/a | ❌ | **✅ `POST /api/import/lune-frontend-snapshot` — round-trip with any [bridge-schema][lbridge] producer** |
 | Comment-mode surgical edits | ❌ | ✅ | 🟡 partial — preview element comments + chat attachments; surgical patch reliability still in progress |
 | AI-emitted tweaks panel | ❌ | ✅ | 🚧 roadmap — dedicated chat-side panel UX is not implemented yet |
 | Filesystem-grade workspace | ❌ | partial (Electron sandbox) | **✅ Real cwd, real tools, persisted SQLite (projects · conversations · messages · tabs · templates)** |
@@ -664,6 +668,7 @@ Long-form provenance write-up — what we take from each, what we deliberately d
 - [x] SQLite-backed projects · conversations · messages · tabs · templates
 - [x] OpenAI-compatible BYOK proxy (`/api/proxy/stream`) with SSRF guard
 - [x] Claude Design ZIP import (`/api/import/claude-design`)
+- [x] Frontend-snapshot ZIP import (`/api/import/lune-frontend-snapshot`) — accepts any [lune-to-od-bridge v0.1.x][lbridge] producer ZIP
 - [x] Sidecar protocol + Electron desktop with IPC automation (STATUS / EVAL / SCREENSHOT / CONSOLE / CLICK / SHUTDOWN)
 - [x] Artifact lint API + 5-dim self-critique pre-emit gate
 - [ ] Comment-mode surgical edits — partial shipped: preview element comments and chat attachments; reliable targeted patching remains in progress

--- a/apps/daemon/src/claude-design-import.ts
+++ b/apps/daemon/src/claude-design-import.ts
@@ -1,39 +1,11 @@
 // @ts-nocheck
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { inflateRawSync } from 'node:zlib';
-import { validateProjectPath } from './projects.js';
-
-const EOCD_SIG = 0x06054b50;
-const CENTRAL_SIG = 0x02014b50;
-const LOCAL_SIG = 0x04034b50;
-
-const MAX_FILES = 500;
-const MAX_TOTAL_BYTES = 100 * 1024 * 1024;
-const MAX_FILE_BYTES = 25 * 1024 * 1024;
+import { readZipEntries, safeJoin } from './zip-reader.js';
 
 export async function importClaudeDesignZip(zipPath, projectDir) {
   const zip = await readFile(zipPath);
-  const entries = readCentralDirectory(zip);
-  const files = [];
-  let totalBytes = 0;
-
-  for (const entry of entries) {
-    if (entry.isDirectory) continue;
-    if (files.length >= MAX_FILES) throw new Error('zip contains too many files');
-    const relPath = sanitizeZipPath(entry.name);
-    if (entry.uncompressedSize > MAX_FILE_BYTES) {
-      throw new Error(`zip file too large: ${relPath}`);
-    }
-    totalBytes += entry.uncompressedSize;
-    if (totalBytes > MAX_TOTAL_BYTES) throw new Error('zip is too large');
-
-    const body = readEntryBody(zip, entry);
-    if (body.length !== entry.uncompressedSize) {
-      throw new Error(`zip entry size mismatch: ${relPath}`);
-    }
-    files.push({ path: relPath, body });
-  }
+  const files = readZipEntries(zip);
 
   if (files.length === 0) throw new Error('zip contains no files');
   const entryFile = chooseEntryFile(files.map((f) => f.path));
@@ -52,78 +24,6 @@ export async function importClaudeDesignZip(zipPath, projectDir) {
   };
 }
 
-function readCentralDirectory(zip) {
-  const eocdOffset = findEndOfCentralDirectory(zip);
-  const entryCount = zip.readUInt16LE(eocdOffset + 10);
-  const centralSize = zip.readUInt32LE(eocdOffset + 12);
-  const centralOffset = zip.readUInt32LE(eocdOffset + 16);
-  if (centralOffset + centralSize > zip.length) {
-    throw new Error('invalid zip central directory');
-  }
-
-  const entries = [];
-  let offset = centralOffset;
-  for (let i = 0; i < entryCount; i += 1) {
-    if (zip.readUInt32LE(offset) !== CENTRAL_SIG) {
-      throw new Error('invalid zip central directory entry');
-    }
-    const flags = zip.readUInt16LE(offset + 8);
-    const method = zip.readUInt16LE(offset + 10);
-    const compressedSize = zip.readUInt32LE(offset + 20);
-    const uncompressedSize = zip.readUInt32LE(offset + 24);
-    const nameLen = zip.readUInt16LE(offset + 28);
-    const extraLen = zip.readUInt16LE(offset + 30);
-    const commentLen = zip.readUInt16LE(offset + 32);
-    const localOffset = zip.readUInt32LE(offset + 42);
-    const name = zip.slice(offset + 46, offset + 46 + nameLen).toString('utf8');
-    if ((flags & 1) !== 0) throw new Error('encrypted zip entries are not supported');
-    if (method !== 0 && method !== 8) {
-      throw new Error(`unsupported zip compression method: ${method}`);
-    }
-    entries.push({
-      name,
-      method,
-      compressedSize,
-      uncompressedSize,
-      localOffset,
-      isDirectory: name.endsWith('/'),
-    });
-    offset += 46 + nameLen + extraLen + commentLen;
-  }
-  return entries;
-}
-
-function findEndOfCentralDirectory(zip) {
-  const min = Math.max(0, zip.length - 0xffff - 22);
-  for (let i = zip.length - 22; i >= min; i -= 1) {
-    if (zip.readUInt32LE(i) === EOCD_SIG) return i;
-  }
-  throw new Error('invalid zip: missing central directory');
-}
-
-function readEntryBody(zip, entry) {
-  const offset = entry.localOffset;
-  if (zip.readUInt32LE(offset) !== LOCAL_SIG) {
-    throw new Error(`invalid zip local header: ${entry.name}`);
-  }
-  const nameLen = zip.readUInt16LE(offset + 26);
-  const extraLen = zip.readUInt16LE(offset + 28);
-  const bodyStart = offset + 30 + nameLen + extraLen;
-  const bodyEnd = bodyStart + entry.compressedSize;
-  if (bodyEnd > zip.length) throw new Error(`zip entry exceeds archive: ${entry.name}`);
-  const compressed = zip.slice(bodyStart, bodyEnd);
-  if (entry.method === 0) return Buffer.from(compressed);
-  return inflateRawSync(compressed, { maxOutputLength: entry.uncompressedSize });
-}
-
-function sanitizeZipPath(name) {
-  if (name.includes('\0')) throw new Error('invalid zip file name');
-  if (/^[A-Za-z]:/.test(name) || name.startsWith('/')) {
-    throw new Error('absolute zip paths are not allowed');
-  }
-  return validateProjectPath(name);
-}
-
 function chooseEntryFile(paths) {
   const html = paths.filter((p) => /\.html?$/i.test(p));
   if (html.length === 0) return null;
@@ -134,12 +34,4 @@ function chooseEntryFile(paths) {
     html[0] ??
     null
   );
-}
-
-function safeJoin(root, relPath) {
-  const target = path.resolve(root, relPath);
-  if (!target.startsWith(root + path.sep) && target !== root) {
-    throw new Error('path escapes project dir');
-  }
-  return target;
 }

--- a/apps/daemon/src/lune-frontend-snapshot-import.ts
+++ b/apps/daemon/src/lune-frontend-snapshot-import.ts
@@ -1,0 +1,132 @@
+// @ts-nocheck
+//
+// `/api/import/lune-frontend-snapshot` parser.
+//
+// Accepts a ZIP that conforms to the **lune-to-od-bridge v0.1.x manifest
+// schema** — produced today by Lune's `pnpm export-to-od` (looptech-ai/lune
+// `scripts/export-to-od.mjs`, contract `lune-to-od-bridge`) but specified
+// generically so any frontend snapshotter can target it. The contract
+// lives upstream at <https://github.com/looptech-ai/lune/blob/main/.claude/harness/contracts/lune-to-od-bridge.md>.
+//
+// ZIP contents (v0.1.x):
+//   manifest.json         — top-level metadata + counts + file pointers
+//   routes.json           — { routes: [{ path, file, group, dynamic, title }, ...] }
+//   components.json       — { components: [{ name, file, props?, ... }, ...] }
+//   design-tokens.json    — { cssVariables: { "--foo": "value", ... } }
+//   screenshots/<file>    — optional PNG/JPEG static frames (one per route)
+//   README.md             — human notes from the producer
+//
+// Per the contract's semver-major version gate, this importer accepts any
+// `0.1.*` manifestVersion and rejects `0.2+` with an explicit "schema
+// upgrade required" message. The version gate intentionally lives here
+// (not in the producer) so OD can advertise its supported range without
+// chasing every snapshotter's release cadence.
+
+import { readFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { readZipEntries, safeJoin } from './zip-reader.js';
+
+const SUPPORTED_MAJOR_MINOR = '0.1.';
+
+const REQUIRED_FILES = ['manifest.json', 'routes.json', 'components.json', 'design-tokens.json'];
+
+/**
+ * Parse + persist a Lune-style frontend-snapshot ZIP.
+ *
+ * @param {string} zipPath — disk path to an uploaded ZIP
+ * @param {string} projectDir — destination directory (created if absent)
+ * @returns {Promise<{
+ *   manifest: object,
+ *   routes: object,
+ *   components: object,
+ *   designTokens: object,
+ *   screenshots: { file: string }[],
+ *   files: string[],
+ * }>}
+ *
+ * Errors thrown here are user-facing (the route handler propagates the
+ * `.message` verbatim into the 400 response body), so they MUST be
+ * actionable: tell the operator what's wrong with the ZIP and what to
+ * do next.
+ */
+export async function importLuneFrontendSnapshotZip(zipPath, projectDir) {
+  const zip = await readFile(zipPath);
+  const files = readZipEntries(zip);
+  if (files.length === 0) throw new Error('zip contains no files');
+
+  const byPath = new Map(files.map((f) => [f.path, f]));
+
+  for (const required of REQUIRED_FILES) {
+    if (!byPath.has(required)) {
+      throw new Error(
+        `lune-frontend-snapshot ZIP missing required file: ${required}. ` +
+          `Expected v${SUPPORTED_MAJOR_MINOR}x layout (manifest.json + routes.json + components.json + design-tokens.json).`,
+      );
+    }
+  }
+
+  const manifest = parseJson(byPath.get('manifest.json').body, 'manifest.json');
+  validateManifest(manifest);
+
+  const routes = parseJson(byPath.get('routes.json').body, 'routes.json');
+  const components = parseJson(byPath.get('components.json').body, 'components.json');
+  const designTokens = parseJson(byPath.get('design-tokens.json').body, 'design-tokens.json');
+
+  const screenshots = files
+    .filter((f) => f.path.startsWith('screenshots/') && !f.path.endsWith('/.placeholder'))
+    .map((f) => ({ file: f.path }));
+
+  // Persist the raw artifact tree so OD's existing project-file viewers
+  // (sidemap / token-set / static-frame loaders) can read them straight
+  // off disk without any additional indirection. The same write loop the
+  // claude-design import uses.
+  await mkdir(projectDir, { recursive: true });
+  for (const f of files) {
+    const target = safeJoin(projectDir, f.path);
+    await mkdir(path.dirname(target), { recursive: true });
+    await writeFile(target, f.body);
+  }
+
+  return {
+    manifest,
+    routes,
+    components,
+    designTokens,
+    screenshots,
+    files: files.map((f) => f.path),
+  };
+}
+
+function parseJson(buffer, label) {
+  try {
+    return JSON.parse(buffer.toString('utf8'));
+  } catch (err) {
+    throw new Error(`${label} is not valid JSON: ${err.message}`);
+  }
+}
+
+/**
+ * Enforce the v0.1.x semver-major contract gate. Exported for direct
+ * unit-testing of the version policy without going through the full
+ * file-system-touching import path.
+ */
+export function validateManifest(manifest) {
+  if (!manifest || typeof manifest !== 'object') {
+    throw new Error('manifest.json must be a JSON object');
+  }
+  const version = manifest.manifestVersion;
+  if (typeof version !== 'string' || version.length === 0) {
+    throw new Error('manifest.json missing manifestVersion field');
+  }
+  if (!version.startsWith(SUPPORTED_MAJOR_MINOR)) {
+    throw new Error(
+      `unsupported manifestVersion ${version}: this OD build accepts ${SUPPORTED_MAJOR_MINOR}x. ` +
+        `Re-export from the producer with a compatible bridge schema, ` +
+        `or upgrade OD to a build that handles the newer schema.`,
+    );
+  }
+  if (typeof manifest.projectName !== 'string' || !manifest.projectName.trim()) {
+    throw new Error('manifest.json missing projectName field');
+  }
+}

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -29,6 +29,7 @@ import { renderDesignSystemPreview } from './design-system-preview.js';
 import { renderDesignSystemShowcase } from './design-system-showcase.js';
 import { createChatRunService } from './runs.js';
 import { importClaudeDesignZip } from './claude-design-import.js';
+import { importLuneFrontendSnapshotZip } from './lune-frontend-snapshot-import.js';
 import { listPromptTemplates, readPromptTemplate } from './prompt-templates.js';
 import { buildDocumentPreview } from './document-preview.js';
 import { lintArtifact, renderFindingsForAgent } from './lint-artifact.js';
@@ -815,6 +816,92 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
       } catch (err) {
         if (req.file?.path) fs.promises.unlink(req.file.path).catch(() => {});
         res.status(400).json({ error: String(err) });
+      }
+    },
+  );
+
+  // `/api/import/lune-frontend-snapshot` — accepts a ZIP that conforms to
+  // the lune-to-od-bridge v0.1.x manifest schema (any producer, not just
+  // Lune itself). The handler shape mirrors `/api/import/claude-design`
+  // above so the welcome-dialog drag-drop UI can switch importers based
+  // on file content without needing two upload paths. See
+  // `lune-frontend-snapshot-import.ts` for the manifest contract details.
+  app.post(
+    '/api/import/lune-frontend-snapshot',
+    importUpload.single('file'),
+    async (req, res) => {
+      try {
+        if (!req.file)
+          return res.status(400).json({ error: 'zip file required' });
+        const originalName =
+          req.file.originalname || 'frontend-snapshot.od.zip';
+        if (!/\.zip$/i.test(originalName)) {
+          fs.promises.unlink(req.file.path).catch(() => {});
+          return res.status(400).json({ error: 'expected a .zip file' });
+        }
+        const id = randomId();
+        const now = Date.now();
+        const imported = await importLuneFrontendSnapshotZip(
+          req.file.path,
+          projectDir(PROJECTS_DIR, id),
+        );
+        fs.promises.unlink(req.file.path).catch(() => {});
+
+        const projectName =
+          imported.manifest.projectName ||
+          originalName.replace(/\.zip$/i, '').trim() ||
+          'Frontend snapshot import';
+
+        const project = insertProject(db, {
+          id,
+          name: projectName,
+          skillId: null,
+          designSystemId: null,
+          pendingPrompt:
+            `Imported frontend snapshot "${projectName}" ` +
+            `(${imported.manifest.counts?.routes ?? 0} routes, ` +
+            `${imported.manifest.counts?.components ?? 0} components, ` +
+            `${imported.manifest.counts?.designTokens ?? 0} design tokens). ` +
+            `Iterate the visuals here and the producer can re-import on the next round-trip.`,
+          metadata: {
+            kind: 'frontend-snapshot',
+            importedFrom: 'lune-frontend-snapshot',
+            manifestVersion: imported.manifest.manifestVersion,
+            sourceFileName: originalName,
+            sourceRepoUrl: imported.manifest.sourceRepoUrl ?? null,
+            commitSha: imported.manifest.commitSha ?? null,
+            counts: imported.manifest.counts ?? null,
+          },
+          createdAt: now,
+          updatedAt: now,
+        });
+
+        const cid = randomId();
+        insertConversation(db, {
+          id: cid,
+          projectId: id,
+          title: `Imported ${projectName} snapshot`,
+          createdAt: now,
+          updatedAt: now,
+        });
+
+        // Open the manifest itself as the default tab so operators land on
+        // the metadata view first; the route + component inventories are a
+        // single click away in the file tree.
+        setTabs(db, id, ['manifest.json'], 'manifest.json');
+
+        res.json({
+          project,
+          conversationId: cid,
+          manifestVersion: imported.manifest.manifestVersion,
+          counts: imported.manifest.counts ?? null,
+          screenshots: imported.screenshots,
+          files: imported.files,
+          redirectUrl: `/projects/${id}`,
+        });
+      } catch (err) {
+        if (req.file?.path) fs.promises.unlink(req.file.path).catch(() => {});
+        res.status(400).json({ error: String(err?.message ?? err) });
       }
     },
   );

--- a/apps/daemon/src/zip-reader.ts
+++ b/apps/daemon/src/zip-reader.ts
@@ -1,0 +1,146 @@
+// @ts-nocheck
+//
+// Minimal in-memory ZIP reader shared by all `/api/import/*` endpoints
+// (currently `claude-design` and `lune-frontend-snapshot`). Lifted out of
+// `claude-design-import.ts` so multiple importers can reuse the same
+// streaming + safety logic without pulling a new dependency into the
+// daemon's tightly-controlled deps tree.
+//
+// The reader is deliberately spec-minimal: it understands STORE (method 0)
+// and DEFLATE (method 8) entries with up-front-known sizes, which is
+// what every modern ZIP writer (including Lune's `node:zlib`-based one)
+// emits by default. Encrypted entries are rejected. ZIP64 is not
+// supported; the per-archive caps below make ZIP64 unreachable in
+// practice.
+
+import { inflateRawSync } from 'node:zlib';
+import path from 'node:path';
+import { validateProjectPath } from './projects.js';
+
+const EOCD_SIG = 0x06054b50;
+const CENTRAL_SIG = 0x02014b50;
+const LOCAL_SIG = 0x04034b50;
+
+export const ZIP_DEFAULT_LIMITS = {
+  maxFiles: 500,
+  maxTotalBytes: 100 * 1024 * 1024,
+  maxFileBytes: 25 * 1024 * 1024,
+};
+
+/**
+ * Read every file entry out of a ZIP buffer. Caller is expected to
+ * supply size limits — the defaults above are the ones the
+ * claude-design import has shipped with since day one.
+ *
+ * @param {Buffer} zip
+ * @param {{ maxFiles?: number, maxTotalBytes?: number, maxFileBytes?: number }} [limits]
+ * @returns {{ path: string, body: Buffer }[]}
+ */
+export function readZipEntries(zip, limits = {}) {
+  const maxFiles = limits.maxFiles ?? ZIP_DEFAULT_LIMITS.maxFiles;
+  const maxTotalBytes = limits.maxTotalBytes ?? ZIP_DEFAULT_LIMITS.maxTotalBytes;
+  const maxFileBytes = limits.maxFileBytes ?? ZIP_DEFAULT_LIMITS.maxFileBytes;
+
+  const entries = readCentralDirectory(zip);
+  const files = [];
+  let totalBytes = 0;
+
+  for (const entry of entries) {
+    if (entry.isDirectory) continue;
+    if (files.length >= maxFiles) throw new Error('zip contains too many files');
+    const relPath = sanitizeZipPath(entry.name);
+    if (entry.uncompressedSize > maxFileBytes) {
+      throw new Error(`zip file too large: ${relPath}`);
+    }
+    totalBytes += entry.uncompressedSize;
+    if (totalBytes > maxTotalBytes) throw new Error('zip is too large');
+
+    const body = readEntryBody(zip, entry);
+    if (body.length !== entry.uncompressedSize) {
+      throw new Error(`zip entry size mismatch: ${relPath}`);
+    }
+    files.push({ path: relPath, body });
+  }
+
+  return files;
+}
+
+export function readCentralDirectory(zip) {
+  const eocdOffset = findEndOfCentralDirectory(zip);
+  const entryCount = zip.readUInt16LE(eocdOffset + 10);
+  const centralSize = zip.readUInt32LE(eocdOffset + 12);
+  const centralOffset = zip.readUInt32LE(eocdOffset + 16);
+  if (centralOffset + centralSize > zip.length) {
+    throw new Error('invalid zip central directory');
+  }
+
+  const entries = [];
+  let offset = centralOffset;
+  for (let i = 0; i < entryCount; i += 1) {
+    if (zip.readUInt32LE(offset) !== CENTRAL_SIG) {
+      throw new Error('invalid zip central directory entry');
+    }
+    const flags = zip.readUInt16LE(offset + 8);
+    const method = zip.readUInt16LE(offset + 10);
+    const compressedSize = zip.readUInt32LE(offset + 20);
+    const uncompressedSize = zip.readUInt32LE(offset + 24);
+    const nameLen = zip.readUInt16LE(offset + 28);
+    const extraLen = zip.readUInt16LE(offset + 30);
+    const commentLen = zip.readUInt16LE(offset + 32);
+    const localOffset = zip.readUInt32LE(offset + 42);
+    const name = zip.slice(offset + 46, offset + 46 + nameLen).toString('utf8');
+    if ((flags & 1) !== 0) throw new Error('encrypted zip entries are not supported');
+    if (method !== 0 && method !== 8) {
+      throw new Error(`unsupported zip compression method: ${method}`);
+    }
+    entries.push({
+      name,
+      method,
+      compressedSize,
+      uncompressedSize,
+      localOffset,
+      isDirectory: name.endsWith('/'),
+    });
+    offset += 46 + nameLen + extraLen + commentLen;
+  }
+  return entries;
+}
+
+export function findEndOfCentralDirectory(zip) {
+  const min = Math.max(0, zip.length - 0xffff - 22);
+  for (let i = zip.length - 22; i >= min; i -= 1) {
+    if (zip.readUInt32LE(i) === EOCD_SIG) return i;
+  }
+  throw new Error('invalid zip: missing central directory');
+}
+
+export function readEntryBody(zip, entry) {
+  const offset = entry.localOffset;
+  if (zip.readUInt32LE(offset) !== LOCAL_SIG) {
+    throw new Error(`invalid zip local header: ${entry.name}`);
+  }
+  const nameLen = zip.readUInt16LE(offset + 26);
+  const extraLen = zip.readUInt16LE(offset + 28);
+  const bodyStart = offset + 30 + nameLen + extraLen;
+  const bodyEnd = bodyStart + entry.compressedSize;
+  if (bodyEnd > zip.length) throw new Error(`zip entry exceeds archive: ${entry.name}`);
+  const compressed = zip.slice(bodyStart, bodyEnd);
+  if (entry.method === 0) return Buffer.from(compressed);
+  return inflateRawSync(compressed, { maxOutputLength: entry.uncompressedSize });
+}
+
+export function sanitizeZipPath(name) {
+  if (name.includes('\0')) throw new Error('invalid zip file name');
+  if (/^[A-Za-z]:/.test(name) || name.startsWith('/')) {
+    throw new Error('absolute zip paths are not allowed');
+  }
+  return validateProjectPath(name);
+}
+
+export function safeJoin(root, relPath) {
+  const target = path.resolve(root, relPath);
+  if (!target.startsWith(root + path.sep) && target !== root) {
+    throw new Error('path escapes project dir');
+  }
+  return target;
+}

--- a/apps/daemon/tests/lune-frontend-snapshot-import.test.ts
+++ b/apps/daemon/tests/lune-frontend-snapshot-import.test.ts
@@ -1,0 +1,387 @@
+// @ts-nocheck
+//
+// Tests for the lune-frontend-snapshot importer + its `/api/import/lune-frontend-snapshot`
+// route handler. Mirrors the layout of `tests/server-cors.test.ts` — small
+// in-process Express app exposing only the route under test, no daemon
+// boot, no SQLite. ZIPs are built in-memory with `node:zlib` (the same
+// approach Lune's producer uses) so we don't need to ship a binary
+// fixture in the OD repo.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+// Node 20 (the version OD pins to) does not expose `crc32` from `node:zlib`
+// (added in 22.2.0). The ZIP central directory requires a CRC32 of every
+// uncompressed entry; computing it by hand keeps the test fixture builder
+// independent of Node-version drift.
+const CRC32_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n += 1) {
+    let c = n;
+    for (let k = 0; k < 8; k += 1) {
+      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    }
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+function crc32(buf: Buffer): number {
+  let c = 0xffffffff;
+  for (let i = 0; i < buf.length; i += 1) {
+    c = CRC32_TABLE[(c ^ buf[i]) & 0xff] ^ (c >>> 8);
+  }
+  return (c ^ 0xffffffff) >>> 0;
+}
+import express from 'express';
+import multer from 'multer';
+import http from 'node:http';
+import {
+  importLuneFrontendSnapshotZip,
+  validateManifest,
+} from '../src/lune-frontend-snapshot-import.js';
+
+// ---------------------------------------------------------------------------
+// In-memory ZIP writer (STORE method — simplest valid ZIP that the
+// importer's reader accepts; sidesteps DEFLATE round-tripping in the
+// fixture builder so any failure here is unambiguously a reader bug, not
+// a writer bug).
+// ---------------------------------------------------------------------------
+
+function buildZip(entries) {
+  const localChunks = [];
+  const central = [];
+  let offset = 0;
+
+  for (const { name, body } of entries) {
+    const nameBuf = Buffer.from(name, 'utf8');
+    const data = body instanceof Buffer ? body : Buffer.from(body, 'utf8');
+    const crc = crc32(data);
+    const localHeader = Buffer.alloc(30);
+    localHeader.writeUInt32LE(0x04034b50, 0);
+    localHeader.writeUInt16LE(20, 4); // version needed
+    localHeader.writeUInt16LE(0, 6); // flags
+    localHeader.writeUInt16LE(0, 8); // method = store
+    localHeader.writeUInt16LE(0, 10); // mtime
+    localHeader.writeUInt16LE(0, 12); // mdate
+    localHeader.writeUInt32LE(crc, 14);
+    localHeader.writeUInt32LE(data.length, 18);
+    localHeader.writeUInt32LE(data.length, 22);
+    localHeader.writeUInt16LE(nameBuf.length, 26);
+    localHeader.writeUInt16LE(0, 28);
+    localChunks.push(localHeader, nameBuf, data);
+
+    const centralHeader = Buffer.alloc(46);
+    centralHeader.writeUInt32LE(0x02014b50, 0);
+    centralHeader.writeUInt16LE(20, 4);
+    centralHeader.writeUInt16LE(20, 6);
+    centralHeader.writeUInt16LE(0, 8);
+    centralHeader.writeUInt16LE(0, 10);
+    centralHeader.writeUInt16LE(0, 12);
+    centralHeader.writeUInt16LE(0, 14);
+    centralHeader.writeUInt32LE(crc, 16);
+    centralHeader.writeUInt32LE(data.length, 20);
+    centralHeader.writeUInt32LE(data.length, 24);
+    centralHeader.writeUInt16LE(nameBuf.length, 28);
+    centralHeader.writeUInt16LE(0, 30);
+    centralHeader.writeUInt16LE(0, 32);
+    centralHeader.writeUInt16LE(0, 34);
+    centralHeader.writeUInt16LE(0, 36);
+    centralHeader.writeUInt32LE(0, 38);
+    centralHeader.writeUInt32LE(offset, 42);
+    central.push(centralHeader, nameBuf);
+    offset += localHeader.length + nameBuf.length + data.length;
+  }
+
+  const centralBuf = Buffer.concat(central);
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(0, 4);
+  eocd.writeUInt16LE(0, 6);
+  eocd.writeUInt16LE(entries.length, 8);
+  eocd.writeUInt16LE(entries.length, 10);
+  eocd.writeUInt32LE(centralBuf.length, 12);
+  eocd.writeUInt32LE(offset, 16);
+  eocd.writeUInt16LE(0, 20);
+  return Buffer.concat([...localChunks, centralBuf, eocd]);
+}
+
+function buildLuneSnapshotZip(overrides = {}) {
+  const manifest = {
+    manifestVersion: '0.1.0',
+    projectName: 'Lune',
+    sourceRepoUrl: 'https://github.com/looptech-ai/lune',
+    commitSha: 'abc1234',
+    exportTimestamp: '2026-05-02T00:00:00Z',
+    counts: {
+      routes: 2,
+      components: 1,
+      designTokens: 1,
+      screenshotsCaptured: 0,
+      screenshotsSkipped: 2,
+    },
+    files: {
+      routes: 'routes.json',
+      components: 'components.json',
+      designTokens: 'design-tokens.json',
+      screenshots: 'screenshots/',
+    },
+    notes: ['fixture for OD round-trip test'],
+    ...(overrides.manifest ?? {}),
+  };
+  const routes = {
+    routes: [
+      { path: '/', file: 'apps/web/app/page.tsx', group: null, dynamic: false, title: 'Home' },
+      { path: '/dashboard', file: 'apps/web/app/dashboard/page.tsx', group: null, dynamic: false, title: 'Dashboard' },
+    ],
+  };
+  const components = {
+    components: [
+      { name: 'Button', file: 'apps/web/components/button.tsx' },
+    ],
+  };
+  const designTokens = { cssVariables: { '--lune-primary': '#0070f3' } };
+
+  const baseEntries = [
+    { name: 'manifest.json', body: JSON.stringify(manifest, null, 2) },
+    { name: 'routes.json', body: JSON.stringify(routes, null, 2) },
+    { name: 'components.json', body: JSON.stringify(components, null, 2) },
+    { name: 'design-tokens.json', body: JSON.stringify(designTokens, null, 2) },
+    { name: 'screenshots/.placeholder', body: 'no screenshots in this fixture' },
+    { name: 'README.md', body: '# Lune snapshot (fixture)\n' },
+  ];
+
+  const entries = overrides.entries ?? baseEntries;
+  return { zip: buildZip(entries), manifest, routes, components, designTokens };
+}
+
+// ---------------------------------------------------------------------------
+// Direct importer tests
+// ---------------------------------------------------------------------------
+
+describe('importLuneFrontendSnapshotZip', () => {
+  let workDir;
+  beforeEach(async () => {
+    workDir = await mkdtemp(path.join(tmpdir(), 'lune-snap-test-'));
+  });
+  afterEach(async () => {
+    await rm(workDir, { recursive: true, force: true });
+  });
+
+  it('round-trips a v0.1.0 fixture into a project dir', async () => {
+    const { zip, manifest } = buildLuneSnapshotZip();
+    const zipPath = path.join(workDir, 'snapshot.zip');
+    await writeFile(zipPath, zip);
+
+    const projectDir = path.join(workDir, 'project');
+    const result = await importLuneFrontendSnapshotZip(zipPath, projectDir);
+
+    expect(result.manifest.manifestVersion).toBe('0.1.0');
+    expect(result.manifest.projectName).toBe(manifest.projectName);
+    expect(result.routes.routes).toHaveLength(2);
+    expect(result.components.components[0].name).toBe('Button');
+    expect(result.designTokens.cssVariables['--lune-primary']).toBe('#0070f3');
+    expect(result.files).toContain('manifest.json');
+    expect(result.screenshots).toEqual([]);
+
+    const persistedManifest = await readFile(
+      path.join(projectDir, 'manifest.json'),
+      'utf8',
+    );
+    expect(JSON.parse(persistedManifest).projectName).toBe('Lune');
+  });
+
+  it('rejects manifestVersion 0.2.0 with a schema-upgrade message', async () => {
+    const { zip } = buildLuneSnapshotZip({
+      manifest: { manifestVersion: '0.2.0', projectName: 'Lune' },
+    });
+    const zipPath = path.join(workDir, 'snapshot.zip');
+    await writeFile(zipPath, zip);
+    await expect(
+      importLuneFrontendSnapshotZip(zipPath, path.join(workDir, 'project')),
+    ).rejects.toThrow(/unsupported manifestVersion 0\.2\.0/);
+  });
+
+  it('rejects ZIP without manifest.json', async () => {
+    const zip = buildZip([
+      { name: 'routes.json', body: '{"routes":[]}' },
+      { name: 'components.json', body: '{"components":[]}' },
+      { name: 'design-tokens.json', body: '{"cssVariables":{}}' },
+    ]);
+    const zipPath = path.join(workDir, 'snapshot.zip');
+    await writeFile(zipPath, zip);
+    await expect(
+      importLuneFrontendSnapshotZip(zipPath, path.join(workDir, 'project')),
+    ).rejects.toThrow(/missing required file: manifest\.json/);
+  });
+
+  it('rejects non-ZIP body', async () => {
+    const zipPath = path.join(workDir, 'not-a-zip.zip');
+    await writeFile(zipPath, Buffer.from('totally not a zip file just plain text'));
+    await expect(
+      importLuneFrontendSnapshotZip(zipPath, path.join(workDir, 'project')),
+    ).rejects.toThrow(/missing central directory/);
+  });
+
+  it('persists screenshots when present', async () => {
+    const fakePng = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const { zip } = buildLuneSnapshotZip({
+      entries: [
+        {
+          name: 'manifest.json',
+          body: JSON.stringify({
+            manifestVersion: '0.1.0',
+            projectName: 'Lune',
+            counts: { routes: 1, components: 0, designTokens: 0, screenshotsCaptured: 1, screenshotsSkipped: 0 },
+          }),
+        },
+        { name: 'routes.json', body: '{"routes":[{"path":"/","file":"a","group":null,"dynamic":false,"title":"Home"}]}' },
+        { name: 'components.json', body: '{"components":[]}' },
+        { name: 'design-tokens.json', body: '{"cssVariables":{}}' },
+        { name: 'screenshots/home.png', body: fakePng },
+      ],
+    });
+    const zipPath = path.join(workDir, 'snapshot.zip');
+    await writeFile(zipPath, zip);
+    const result = await importLuneFrontendSnapshotZip(zipPath, path.join(workDir, 'project'));
+    expect(result.screenshots).toEqual([{ file: 'screenshots/home.png' }]);
+    const written = await readFile(path.join(workDir, 'project', 'screenshots', 'home.png'));
+    expect(written.equals(fakePng)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateManifest unit tests
+// ---------------------------------------------------------------------------
+
+describe('validateManifest', () => {
+  it('accepts 0.1.0 and 0.1.99', () => {
+    expect(() => validateManifest({ manifestVersion: '0.1.0', projectName: 'X' })).not.toThrow();
+    expect(() => validateManifest({ manifestVersion: '0.1.99', projectName: 'X' })).not.toThrow();
+  });
+
+  it('rejects 0.2.0 and 1.0.0', () => {
+    expect(() => validateManifest({ manifestVersion: '0.2.0', projectName: 'X' })).toThrow(/unsupported manifestVersion/);
+    expect(() => validateManifest({ manifestVersion: '1.0.0', projectName: 'X' })).toThrow(/unsupported manifestVersion/);
+  });
+
+  it('rejects missing manifestVersion', () => {
+    expect(() => validateManifest({ projectName: 'X' })).toThrow(/missing manifestVersion/);
+  });
+
+  it('rejects missing projectName', () => {
+    expect(() => validateManifest({ manifestVersion: '0.1.0' })).toThrow(/missing projectName/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Route handler test — wires the importer through Express+multer the same
+// way server.ts does, hits it via fetch, and asserts the JSON response.
+// ---------------------------------------------------------------------------
+
+function makeTestApp(uploadDir, projectsDir) {
+  const app = express();
+  const upload = multer({ dest: uploadDir });
+  app.post(
+    '/api/import/lune-frontend-snapshot',
+    upload.single('file'),
+    async (req, res) => {
+      try {
+        if (!req.file) return res.status(400).json({ error: 'zip file required' });
+        if (!/\.zip$/i.test(req.file.originalname || '')) {
+          return res.status(400).json({ error: 'expected a .zip file' });
+        }
+        const id = 'test-project';
+        const imported = await importLuneFrontendSnapshotZip(
+          req.file.path,
+          path.join(projectsDir, id),
+        );
+        res.json({
+          project: { id, name: imported.manifest.projectName },
+          manifestVersion: imported.manifest.manifestVersion,
+          files: imported.files,
+          redirectUrl: `/projects/${id}`,
+        });
+      } catch (err) {
+        res.status(400).json({ error: String(err?.message ?? err) });
+      }
+    },
+  );
+  return app;
+}
+
+describe('POST /api/import/lune-frontend-snapshot', () => {
+  let server;
+  let baseUrl;
+  let workDir;
+
+  beforeEach(async () => {
+    workDir = await mkdtemp(path.join(tmpdir(), 'lune-snap-route-'));
+    const app = makeTestApp(path.join(workDir, 'uploads'), path.join(workDir, 'projects'));
+    await new Promise((resolve) => {
+      server = http.createServer(app).listen(0, '127.0.0.1', () => {
+        const addr = server.address();
+        baseUrl = `http://127.0.0.1:${addr.port}`;
+        resolve();
+      });
+    });
+  });
+
+  afterEach(async () => {
+    await new Promise((resolve) => server.close(() => resolve()));
+    await rm(workDir, { recursive: true, force: true });
+  });
+
+  it('returns 200 + project metadata for a valid v0.1.0 ZIP', async () => {
+    const { zip } = buildLuneSnapshotZip();
+    const form = new FormData();
+    form.append('file', new Blob([zip], { type: 'application/zip' }), 'lune-frontend.od.zip');
+    const res = await fetch(`${baseUrl}/api/import/lune-frontend-snapshot`, {
+      method: 'POST',
+      body: form,
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.manifestVersion).toBe('0.1.0');
+    expect(body.project.name).toBe('Lune');
+    expect(body.redirectUrl).toBe('/projects/test-project');
+    expect(body.files).toContain('manifest.json');
+  });
+
+  it('returns 400 with manifestVersion 0.2.0', async () => {
+    const { zip } = buildLuneSnapshotZip({
+      manifest: { manifestVersion: '0.2.0', projectName: 'Lune' },
+    });
+    const form = new FormData();
+    form.append('file', new Blob([zip], { type: 'application/zip' }), 'lune-frontend.od.zip');
+    const res = await fetch(`${baseUrl}/api/import/lune-frontend-snapshot`, {
+      method: 'POST',
+      body: form,
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/unsupported manifestVersion 0\.2\.0/);
+  });
+
+  it('returns 400 when file extension is not .zip', async () => {
+    const form = new FormData();
+    form.append('file', new Blob([Buffer.from('hi')], { type: 'text/plain' }), 'wrong.txt');
+    const res = await fetch(`${baseUrl}/api/import/lune-frontend-snapshot`, {
+      method: 'POST',
+      body: form,
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/expected a \.zip file/);
+  });
+
+  it('returns 400 when no file is supplied', async () => {
+    const res = await fetch(`${baseUrl}/api/import/lune-frontend-snapshot`, {
+      method: 'POST',
+      body: new FormData(),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/zip file required/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a second `/api/import/*` endpoint to the daemon: **`POST /api/import/lune-frontend-snapshot`**. Accepts a ZIP that conforms to a generic frontend-snapshot manifest schema (`manifest.json` + `routes.json` + `components.json` + `design-tokens.json` + optional `screenshots/<file>`) and persists it as an OD project the user can iterate against.

The use case is **round-trip with an upstream design source**. A producer snapshots its live frontend into a ZIP; the user drag-drops the ZIP onto OD's welcome dialog; OD opens the route + component + token inventories as workspace files; the user iterates the visuals inside OD; the producer can re-snapshot on the next round.

The endpoint is **producer-agnostic**. The schema is a generic frontend snapshot, not coupled to any specific producer. Any tool that targets the v0.1.x manifest works.

## Why this shape, not a fork of `claude-design`

`/api/import/claude-design` expects a static-HTML export with an entry-file picker. A frontend snapshot is structured artifacts (route table, component manifest, token set), not HTML. The two import modes diverge on:

- **Persistence target**: claude-design picks an `index.html` and opens it in the preview iframe; lune-frontend-snapshot opens `manifest.json` and presents the artifacts as workspace files for the agent to read.
- **Validation**: lune-frontend-snapshot enforces a semver-major version gate (`0.1.*` accepted, `0.2+` rejected) so the daemon advertises its supported range without chasing every snapshotter's release cadence.
- **Metadata**: project rows tag `metadata.kind = 'frontend-snapshot'` (vs `'prototype'`) so the welcome dialog can route imports to the right handler purely off file content.

ZIP-reading code that was previously inlined in `claude-design-import.ts` is extracted to `apps/daemon/src/zip-reader.ts` so both importers share the same size/safety limits (max 500 files / 100 MB total / 25 MB per entry) without duplicating the central-directory walker.

## Files

- `apps/daemon/src/lune-frontend-snapshot-import.ts` — manifest validation + ZIP parse + persist (~125 LoC)
- `apps/daemon/src/zip-reader.ts` — extracted from `claude-design-import.ts`; now shared (~140 LoC)
- `apps/daemon/src/claude-design-import.ts` — reduced to ~35 LoC (HTML entry-file picker + persist; ZIP plumbing now imported)
- `apps/daemon/src/server.ts` — adds the route handler right after `/api/import/claude-design`, mirrors its multer + project-insert + tab-set shape
- `apps/daemon/tests/lune-frontend-snapshot-import.test.ts` — 13 cases
- `README.md` — "Imports" row, "Beyond chat" section, comparison table, supported-features checklist updated

No new dependencies. The existing claude-design importer's raw-zlib approach is reused (rather than pulling in `jszip`) for consistency with the existing import path.

## Tests

13 cases — direct importer (5), `validateManifest` policy (4), HTTP route via Express+multer (4):

```
 ✓ tests/lune-frontend-snapshot-import.test.ts (13 tests) 58ms
 Test Files  20 passed (20)
      Tests  331 passed (331)
   Duration  2.35s
```

`pnpm typecheck` clean. The full pre-existing daemon suite (318 tests) remains green.

## Status

PR closed by author 2026-05-03. Body scrubbed retroactively to remove producer-specific repo URLs and ticket references. Maintainer feedback (reviewer requested adding `frontend-snapshot` to the shared `ProjectKind` contract in `packages/contracts/src/api/projects.ts`) was reasonable and would address the core blocker on a future re-submission.