### PR TITLE
fix(daemon): upgrade better-sqlite3 for Node 24 Windows prebuilt support

### DIFF
--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -36,7 +36,7 @@
     "@open-design/platform": "workspace:0.2.0",
     "@open-design/sidecar": "workspace:0.2.0",
     "@open-design/sidecar-proto": "workspace:0.2.0",
-    "better-sqlite3": "^11.10.0",
+    "better-sqlite3": "^12.9.0",
     "express": "^4.19.2",
     "jszip": "^3.10.1",
     "multer": "^1.4.5-lts.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: workspace:0.2.0
         version: link:../../packages/sidecar-proto
       better-sqlite3:
-        specifier: ^11.10.0
-        version: 11.10.0
+        specifier: ^12.9.0
+        version: 12.9.0
       express:
         specifier: ^4.19.2
         version: 4.22.1
@@ -1366,8 +1366,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  better-sqlite3@11.10.0:
-    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
+  better-sqlite3@12.9.0:
+    resolution: {integrity: sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
@@ -3887,7 +3888,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.23: {}
 
-  better-sqlite3@11.10.0:
+  better-sqlite3@12.9.0:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3


### PR DESCRIPTION
This PR upgrades better-sqlite3 from ^11.10.0 to ^12.9.0 to resolve a common build failure encountered on Windows environments running Node 24.

The Problem: In the previous version, better-sqlite3 lacked compatible prebuilt binaries for Node 24 on Windows. This forced a local compilation (node-gyp rebuild) which frequently fails in environments without full Visual Studio C++ build tools installed, preventing the daemon from starting.

The Fix: Upgrading to ^12.9.0 provides the necessary prebuilt binaries for Node 24/Windows, allowing the project to be installed and run "out of the box" without requiring a local build environment for native dependencies.

Verification:

Successfully ran pnpm install on a Windows 10/Node 24 machine.
Verified that pnpm tools-dev start web correctly initializes the daemon and connects to the SQLite database.