### PR TITLE
fix(web): scroll workspace tabs in place instead of the window

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -580,7 +580,7 @@ code {
 /* -------- Split / panes -------------------------------------------- */
 .split {
   display: grid;
-  grid-template-columns: minmax(380px, 460px) 1fr;
+  grid-template-columns: minmax(380px, 460px) minmax(0, 1fr);
   min-height: 0;
 }
 .pane {


### PR DESCRIPTION
## What

Change the right column of the project `.split` grid from `1fr` to `minmax(0, 1fr)` so the workspace tab bar's `overflow-x: auto` actually scrolls the tabs row instead of letting the column blow out and scrolling the entire window.

## Why

`grid-template-columns: ... 1fr` resolves to `minmax(auto, 1fr)`. The `auto` minimum equals the column's intrinsic content width, and `.ws-tabs-bar` uses `flex-wrap: nowrap` — so once enough tabs are open, the column expands past the viewport. The page scrolls horizontally; the toolbar action group (Preview / Source / Comment / Edit) drifts off-screen.

`minmax(0, 1fr)` lets the column shrink below its content's intrinsic width, which is what the existing `overflow-x: auto` on `.ws-tabs-bar` already expects. Net result: tabs scroll within their own row, the window doesn't scroll, and the right-side toolbar stays pinned via `justify-content: space-between`.

## Repro

Window ~1500px wide (e.g. browser on a 15" laptop), 6+ tabs open in the workspace.

1. Two-finger horizontal scroll over the tabs row.
2. **Before:** the entire window scrolls; Preview / Source / Comment / Edit slide off the right edge.
3. **After:** only the tabs row scrolls; the toolbar stays in place.

Browser-agnostic — `1fr` defaulting to `minmax(auto, 1fr)` is CSS spec behavior.

## Risk

Theoretical only — any inner component that was relying on the right column being wider than the viewport would now get squeezed. Spot-checked the file viewer, sketch editor, and Design Files panel; all manage their own overflow.