### PR TITLE
fix(packaged): include nvm/fnm/mise agent CLI bins in packaged PATH

### DIFF
--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync, readdirSync } from "node:fs";
 import { mkdir, open, type FileHandle } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { homedir } from "node:os";
@@ -22,7 +23,7 @@ import {
   resolveAppIpcPath,
   type SidecarRuntimeContext,
 } from "@open-design/sidecar";
-import { collectNvmFnmBins, createProcessStampArgs, stopProcesses, waitForProcessExit } from "@open-design/platform";
+import { createProcessStampArgs, stopProcesses, waitForProcessExit } from "@open-design/platform";
 
 import type { PackagedNamespacePaths } from "./paths.js";
 
@@ -92,6 +93,29 @@ async function waitForStatus<T>(
 function extractPort(url: string): string {
   const parsed = new URL(url);
   return parsed.port || (parsed.protocol === "https:" ? "443" : "80");
+}
+
+function existingDirsUnder(root: string, segments: string[] = []): string[] {
+  const dirs: string[] = [];
+  try {
+    const entries = readdirSync(root, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const full = join(root, entry.name, ...segments);
+      if (existsSync(full)) dirs.push(full);
+    }
+  } catch {
+    // best-effort: directory may not exist or be unreadable
+  }
+  return dirs;
+}
+
+function collectNvmFnmBins(home: string): string[] {
+  return [
+    ...existingDirsUnder(join(home, ".nvm", "versions", "node"), ["bin"]),
+    ...existingDirsUnder(join(home, ".local", "share", "fnm", "node-versions"), ["installation", "bin"]),
+    ...existingDirsUnder(join(home, ".local", "share", "mise", "installs", "node"), ["bin"]),
+  ];
 }
 
 function resolvePackagedPathEnv(basePath = process.env.PATH ?? ""): string {

--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -22,7 +22,7 @@ import {
   resolveAppIpcPath,
   type SidecarRuntimeContext,
 } from "@open-design/sidecar";
-import { createProcessStampArgs, stopProcesses, waitForProcessExit } from "@open-design/platform";
+import { collectNvmFnmBins, createProcessStampArgs, stopProcesses, waitForProcessExit } from "@open-design/platform";
 
 import type { PackagedNamespacePaths } from "./paths.js";
 
@@ -102,6 +102,8 @@ function resolvePackagedPathEnv(basePath = process.env.PATH ?? ""): string {
     join(home, ".opencode", "bin"),
     join(home, ".cargo", "bin"),
     join(home, ".bun", "bin"),
+    join(home, ".volta", "bin"),
+    ...collectNvmFnmBins(home),
     "/opt/homebrew/bin",
     "/usr/local/bin",
     "/usr/bin",

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -1,5 +1,8 @@
 import { execFile, spawn, type ChildProcess, type StdioOptions } from "node:child_process";
+import { existsSync, readdirSync } from "node:fs";
 import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 
 export type CommandInvocation = {
@@ -393,4 +396,30 @@ export async function readLogTail(filePath: string, maxLines = 80): Promise<stri
   } catch {
     return [];
   }
+}
+
+function existingDirsUnder(root: string, segments: string[] = []): string[] {
+  const dirs: string[] = [];
+  try {
+    const entries = readdirSync(root, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const full = join(root, entry.name, ...segments);
+      if (existsSync(full)) dirs.push(full);
+    }
+  } catch {
+    // ignore
+  }
+  return dirs;
+}
+
+// Scan per-user Node version-manager bin directories so packaged builds
+// (DMG / AppImage / NSIS) can discover npm-global agent CLIs installed
+// under nvm / fnm / mise even though GUI apps don't inherit shell PATH.
+export function collectNvmFnmBins(home: string = homedir()): string[] {
+  return [
+    ...existingDirsUnder(join(home, ".nvm", "versions", "node"), ["bin"]),
+    ...existingDirsUnder(join(home, ".local", "share", "fnm", "node-versions"), ["installation", "bin"]),
+    ...existingDirsUnder(join(home, ".local", "share", "mise", "installs", "node"), ["bin"]),
+  ];
 }

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -1,8 +1,5 @@
 import { execFile, spawn, type ChildProcess, type StdioOptions } from "node:child_process";
-import { existsSync, readdirSync } from "node:fs";
 import { readFile } from "node:fs/promises";
-import { homedir } from "node:os";
-import { join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 
 export type CommandInvocation = {
@@ -396,30 +393,4 @@ export async function readLogTail(filePath: string, maxLines = 80): Promise<stri
   } catch {
     return [];
   }
-}
-
-function existingDirsUnder(root: string, segments: string[] = []): string[] {
-  const dirs: string[] = [];
-  try {
-    const entries = readdirSync(root, { withFileTypes: true });
-    for (const entry of entries) {
-      if (!entry.isDirectory()) continue;
-      const full = join(root, entry.name, ...segments);
-      if (existsSync(full)) dirs.push(full);
-    }
-  } catch {
-    // ignore
-  }
-  return dirs;
-}
-
-// Scan per-user Node version-manager bin directories so packaged builds
-// (DMG / AppImage / NSIS) can discover npm-global agent CLIs installed
-// under nvm / fnm / mise even though GUI apps don't inherit shell PATH.
-export function collectNvmFnmBins(home: string = homedir()): string[] {
-  return [
-    ...existingDirsUnder(join(home, ".nvm", "versions", "node"), ["bin"]),
-    ...existingDirsUnder(join(home, ".local", "share", "fnm", "node-versions"), ["installation", "bin"]),
-    ...existingDirsUnder(join(home, ".local", "share", "mise", "installs", "node"), ["bin"]),
-  ];
 }


### PR DESCRIPTION
## 背景

#346 已在 `agents.ts` 中修复了 dev 模式下跨 nvm/fnm Node 版本的 agent CLI 发现（`userToolchainDirs`）。但打包构建（DMG/AppImage/NSIS）的 PATH 构造路径 `resolvePackagedPathEnv` 仍然只包含硬编码目录（`.local/bin`、homebrew 等），缺失 nvm/fnm/mise 的 npm 全局 bin 目录。

对于 macOS GUI 应用（Dock/Finder 启动），PATH 来自 launchd 而非 shell profile，这个问题尤为突出。

## 改动

- `packages/platform/src/index.ts` — 新增 `collectNvmFnmBins()` 和 `existingDirsUnder()` 辅助函数，动态扫描：
  - `~/.nvm/versions/node/*/bin`
  - `~/.local/share/fnm/node-versions/*/installation/bin`
  - `~/.local/share/mise/installs/node/*/bin`
- `apps/packaged/src/sidecars.ts` — `resolvePackagedPathEnv` 追加调用 `collectNvmFnmBins(home)`

## 设计决策

- **运行时扫描而非 shell wrapper**：`bash -l -c` 引入 1-3s 延迟且可能 hang；配置文件需要用户知道路径；symlink 约定不是开箱即用
- **PATH 优先**：原有 PATH 目录在 `Set` 中排在前面，fallback 目录追加，不改变查找优先级
- **碰撞确定性**：`readdirSync` 返回字母序（v20 先于 v22），行为可预测
- **best-effort 安全模型**：目录扫描仅发现路径，信任用户自身 Node 环境

## 影响范围

仅影响打包构建的 daemon 启动 PATH，不影响 dev 模式（`tools-dev`）。