### PR TITLE
Fix macOS entry view drag region

### DIFF
--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -95,6 +95,21 @@ const MAC_WINDOW_CHROME_CSS = `
   .app-chrome-drag {
     -webkit-app-region: drag;
   }
+  .entry-brand,
+  .entry-header {
+    -webkit-app-region: drag;
+  }
+  .entry-brand button,
+  .entry-brand [role="button"],
+  .entry-header button,
+  .entry-header [role="button"],
+  .entry-tabs,
+  .entry-tabs *,
+  .entry-side-resizer,
+  .avatar-popover,
+  .avatar-popover * {
+    -webkit-app-region: no-drag;
+  }
 `;
 
 function createPendingHtml(): string {


### PR DESCRIPTION
## Summary

Fixes the packaged macOS desktop entry view so the window can be dragged from the entry header/brand chrome.

The project view already gets macOS drag regions through `AppChromeHeader`, but the entry view has its own `.entry-brand` and `.entry-header` elements. Those areas were not included in the desktop runtime CSS injection, so the window could not be moved before opening a project.

This extends `MAC_WINDOW_CHROME_CSS` with:

- `drag` on `.entry-brand` and `.entry-header`
- `no-drag` on interactive controls such as buttons, tabs, the sidebar resizer, and avatar popover content

Closes #371.

## Testing

- `pnpm --filter @open-design/desktop typecheck`
- Locally packaged macOS app: verified entry view can be dragged while tabs/avatar controls remain clickable
