### PR TITLE
Add OpenAI media OAuth fallback

### DIFF
--- a/apps/daemon/src/media-config.ts
+++ b/apps/daemon/src/media-config.ts
@@ -14,6 +14,7 @@
 // echo secrets back into the DOM.
 
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
 import path from 'node:path';
 import { MEDIA_PROVIDERS } from './media-models.js';
 
@@ -84,16 +85,96 @@ function readEnvKey(providerId) {
   return null;
 }
 
+function readNestedString(obj, keys) {
+  let cur = obj;
+  for (const key of keys) {
+    if (!cur || typeof cur !== 'object') return '';
+    cur = cur[key];
+  }
+  return typeof cur === 'string' && cur.trim() ? cur.trim() : '';
+}
+
+async function readJsonIfPresent(file) {
+  try {
+    const raw = await readFile(file, 'utf8');
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return null;
+    // Auth files are best-effort fallbacks. A malformed local auth cache
+    // should not break the Settings page or hide stored provider config.
+    return null;
+  }
+}
+
+function tokenFromHermesAuth(data) {
+  const providerToken = readNestedString(data, [
+    'providers',
+    'openai-codex',
+    'tokens',
+    'access_token',
+  ]);
+  if (providerToken) return providerToken;
+
+  const pool =
+    data && typeof data === 'object'
+      ? data.credential_pool && data.credential_pool['openai-codex']
+      : null;
+  if (Array.isArray(pool)) {
+    for (const item of pool) {
+      const token = readNestedString(item, ['access_token']);
+      if (token) return token;
+    }
+  }
+  return '';
+}
+
+function tokenFromCodexAuth(data) {
+  const oauthToken = readNestedString(data, ['tokens', 'access_token']);
+  if (oauthToken) return { token: oauthToken, source: 'oauth-codex' };
+
+  const apiKey = readNestedString(data, ['OPENAI_API_KEY']);
+  if (apiKey) return { token: apiKey, source: 'codex-auth' };
+
+  return null;
+}
+
+async function resolveOpenAIOAuthCredential() {
+  const home = homedir();
+  const hermesAuth = await readJsonIfPresent(
+    path.join(home, '.hermes', 'auth.json'),
+  );
+  const hermesToken = tokenFromHermesAuth(hermesAuth);
+  if (hermesToken) {
+    return { apiKey: hermesToken, source: 'oauth-hermes' };
+  }
+
+  const codexAuth = await readJsonIfPresent(
+    path.join(home, '.codex', 'auth.json'),
+  );
+  const codexToken = tokenFromCodexAuth(codexAuth);
+  if (codexToken) {
+    return { apiKey: codexToken.token, source: codexToken.source };
+  }
+
+  return null;
+}
+
 /**
- * Resolve credentials for a provider. Env vars win, then stored config.
+ * Resolve credentials for a provider. Env vars win, then stored config,
+ * then OpenAI/Codex OAuth for the OpenAI media provider.
  * Returns { apiKey, baseUrl } where either may be empty string.
  */
 export async function resolveProviderConfig(projectRoot, providerId) {
   const stored = await readStored(projectRoot);
   const entry = stored[providerId] || {};
   const envKey = readEnvKey(providerId);
+  const oauth =
+    providerId === 'openai' && !envKey && !entry.apiKey
+      ? await resolveOpenAIOAuthCredential()
+      : null;
   return {
-    apiKey: envKey || entry.apiKey || '',
+    apiKey: envKey || entry.apiKey || oauth?.apiKey || '',
     baseUrl: entry.baseUrl || '',
   };
 }
@@ -110,12 +191,16 @@ export async function readMaskedConfig(projectRoot) {
     const entry = stored[id] || {};
     const envKey = readEnvKey(id);
     const hasStoredKey = typeof entry.apiKey === 'string' && entry.apiKey.length > 0;
+    const oauth =
+      id === 'openai' && !envKey && !hasStoredKey
+        ? await resolveOpenAIOAuthCredential()
+        : null;
     providers[id] = {
-      configured: Boolean(envKey || hasStoredKey),
-      source: envKey ? 'env' : hasStoredKey ? 'stored' : 'unset',
+      configured: Boolean(envKey || hasStoredKey || oauth?.apiKey),
+      source: envKey ? 'env' : hasStoredKey ? 'stored' : oauth?.source || 'unset',
       // Show last 4 chars only when stored locally; never echo env-var
-      // secrets so power users who only export ENV don't accidentally
-      // see them in the DOM.
+      // or OAuth secrets so power users don't accidentally see them in
+      // the DOM.
       apiKeyTail: hasStoredKey ? entry.apiKey.slice(-4) : '',
       baseUrl: entry.baseUrl || '',
     };

--- a/apps/daemon/src/media.ts
+++ b/apps/daemon/src/media.ts
@@ -509,7 +509,7 @@ const AZURE_DEFAULT_API_VERSION = '2024-02-01';
 
 async function renderOpenAIImage(ctx, credentials) {
   if (!credentials.apiKey) {
-    throw new Error('no OpenAI API key — configure it in Settings or set OPENAI_API_KEY');
+    throw new Error('no OpenAI credential — configure an API key in Settings, set OPENAI_API_KEY, or refresh Codex/Hermes OAuth');
   }
   const rawBase = credentials.baseUrl || 'https://api.openai.com/v1';
   const azure = detectAzureEndpoint(rawBase);
@@ -688,7 +688,7 @@ function openaiSpeechFormatFor(fileName) {
 
 async function renderOpenAISpeech(ctx, credentials, fileName) {
   if (!credentials.apiKey) {
-    throw new Error('no OpenAI API key — configure it in Settings or set OPENAI_API_KEY');
+    throw new Error('no OpenAI credential — configure an API key in Settings, set OPENAI_API_KEY, or refresh Codex/Hermes OAuth');
   }
   const rawBase = credentials.baseUrl || 'https://api.openai.com/v1';
   const azure = detectAzureEndpoint(rawBase);

--- a/apps/daemon/tests/media-config.test.ts
+++ b/apps/daemon/tests/media-config.test.ts
@@ -1,0 +1,132 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { readMaskedConfig, resolveProviderConfig } from '../src/media-config.js';
+
+const OPENAI_ENV_KEYS = [
+  'OD_OPENAI_API_KEY',
+  'OPENAI_API_KEY',
+  'AZURE_API_KEY',
+  'AZURE_OPENAI_API_KEY',
+];
+
+describe('media-config OpenAI OAuth fallback', () => {
+  let homeDir: string;
+  let projectRoot: string;
+  const originalHome = process.env.HOME;
+  const originalEnv = Object.fromEntries(
+    OPENAI_ENV_KEYS.map((key) => [key, process.env[key]]),
+  );
+
+  beforeEach(async () => {
+    homeDir = await mkdtemp(path.join(tmpdir(), 'od-media-home-'));
+    projectRoot = await mkdtemp(path.join(tmpdir(), 'od-media-project-'));
+    process.env.HOME = homeDir;
+    for (const key of OPENAI_ENV_KEYS) {
+      delete process.env[key];
+    }
+  });
+
+  afterEach(async () => {
+    if (originalHome == null) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+    for (const key of OPENAI_ENV_KEYS) {
+      if (originalEnv[key] == null) {
+        delete process.env[key];
+      } else {
+        process.env[key] = originalEnv[key];
+      }
+    }
+    await rm(homeDir, { recursive: true, force: true });
+    await rm(projectRoot, { recursive: true, force: true });
+  });
+
+  async function writeHomeJson(relPath: string, data: unknown) {
+    const file = path.join(homeDir, relPath);
+    await mkdir(path.dirname(file), { recursive: true });
+    await writeFile(file, JSON.stringify(data), 'utf8');
+  }
+
+  async function writeStoredMediaConfig(data: unknown) {
+    const file = path.join(projectRoot, '.od', 'media-config.json');
+    await mkdir(path.dirname(file), { recursive: true });
+    await writeFile(file, JSON.stringify(data), 'utf8');
+  }
+
+  function openaiProvider(masked: { providers: unknown }) {
+    return (masked.providers as Record<string, unknown>).openai;
+  }
+
+  it('uses Hermes openai-codex OAuth when no API key is configured', async () => {
+    await writeHomeJson('.hermes/auth.json', {
+      providers: {
+        'openai-codex': {
+          tokens: { access_token: 'hermes-oauth-token' },
+        },
+      },
+    });
+
+    const resolved = await resolveProviderConfig(projectRoot, 'openai');
+    const masked = await readMaskedConfig(projectRoot);
+
+    expect(resolved.apiKey).toBe('hermes-oauth-token');
+    expect(openaiProvider(masked)).toMatchObject({
+      configured: true,
+      source: 'oauth-hermes',
+      apiKeyTail: '',
+    });
+  });
+
+  it('uses Codex OAuth when Hermes has no OpenAI Codex credential', async () => {
+    await writeHomeJson('.codex/auth.json', {
+      tokens: { access_token: 'codex-oauth-token' },
+    });
+
+    const resolved = await resolveProviderConfig(projectRoot, 'openai');
+    const masked = await readMaskedConfig(projectRoot);
+
+    expect(resolved.apiKey).toBe('codex-oauth-token');
+    expect(openaiProvider(masked)).toMatchObject({
+      configured: true,
+      source: 'oauth-codex',
+      apiKeyTail: '',
+    });
+  });
+
+  it('keeps stored provider config ahead of OAuth fallbacks', async () => {
+    await writeHomeJson('.hermes/auth.json', {
+      providers: {
+        'openai-codex': {
+          tokens: { access_token: 'hermes-oauth-token' },
+        },
+      },
+    });
+    await writeStoredMediaConfig({
+      providers: {
+        openai: {
+          apiKey: 'stored-openai-key',
+          baseUrl: 'https://example.test/v1',
+        },
+      },
+    });
+
+    const resolved = await resolveProviderConfig(projectRoot, 'openai');
+    const masked = await readMaskedConfig(projectRoot);
+
+    expect(resolved).toEqual({
+      apiKey: 'stored-openai-key',
+      baseUrl: 'https://example.test/v1',
+    });
+    expect(openaiProvider(masked)).toMatchObject({
+      configured: true,
+      source: 'stored',
+      apiKeyTail: '-key',
+      baseUrl: 'https://example.test/v1',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a best-effort OAuth credential fallback for the OpenAI media provider when no explicit OpenAI API key is configured.

Resolution order remains conservative:

1. provider env vars such as `OD_OPENAI_API_KEY` / `OPENAI_API_KEY`
2. stored project media config
3. local OAuth credentials from known CLI auth caches

The masked config endpoint only reports coarse sources such as `oauth-hermes` / `oauth-codex` and never returns OAuth token tails. Malformed or absent local auth files are ignored so Settings and stored config continue to work.

Closes #374.

## Testing

- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/daemon test -- media-config.test.ts`
