### PR TITLE
Add local custom CLI agent profiles

### DIFF
--- a/apps/daemon/src/agents.ts
+++ b/apps/daemon/src/agents.ts
@@ -1,5 +1,9 @@
 // @ts-nocheck
-export { AGENT_DEFS, getAgentDef } from './runtimes/registry.js';
+export {
+  AGENT_DEFS,
+  getAgentDef,
+  readLocalAgentProfileDefs,
+} from './runtimes/registry.js';
 export { detectAgents } from './runtimes/detection.js';
 export {
   resolveOnPath,

--- a/apps/daemon/src/runtimes/local-profiles.ts
+++ b/apps/daemon/src/runtimes/local-profiles.ts
@@ -1,0 +1,177 @@
+import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+import { DEFAULT_MODEL_OPTION, sanitizeCustomModel } from './models.js';
+import type {
+  RuntimeAgentDef,
+  RuntimeBuildOptions,
+  RuntimeModelOption,
+} from './types.js';
+
+function localAgentProfilesFile(): string {
+  const explicit = process.env.OD_AGENT_PROFILES_CONFIG;
+  if (typeof explicit === 'string' && explicit.trim()) {
+    return explicit.trim();
+  }
+  return path.join(homedir(), '.open-design', 'agents.local.json');
+}
+
+function normalizeStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (item): item is string =>
+      typeof item === 'string' &&
+      item.length > 0 &&
+      !item.includes('\0'),
+  );
+}
+
+function normalizeEnvMap(value: unknown): Record<string, string> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  const out: Record<string, string> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    if (
+      typeof raw === 'string' ||
+      typeof raw === 'number' ||
+      typeof raw === 'boolean'
+    ) {
+      out[key] = String(raw);
+    }
+  }
+  return out;
+}
+
+function normalizeModelOptions(value: unknown): RuntimeModelOption[] | null {
+  if (!Array.isArray(value)) return null;
+  const out = [DEFAULT_MODEL_OPTION];
+  const seen = new Set(['default']);
+  for (const item of value) {
+    const id =
+      typeof item === 'string'
+        ? item.trim()
+        : item && typeof item === 'object' && typeof item.id === 'string'
+          ? item.id.trim()
+          : '';
+    if (!sanitizeCustomModel(id) || seen.has(id)) continue;
+    seen.add(id);
+    const label =
+      item && typeof item === 'object' && typeof item.label === 'string'
+        ? item.label.trim()
+        : '';
+    out.push({ id, label: label || id });
+  }
+  return out.length > 1 ? out : null;
+}
+
+function normalizeDefaultModel(value: unknown): string | null {
+  return typeof value === 'string' ? sanitizeCustomModel(value) : null;
+}
+
+function optionsWithDefaultModel(
+  options: RuntimeBuildOptions | undefined,
+  defaultModel: string | null,
+): RuntimeBuildOptions | undefined {
+  if (
+    defaultModel == null ||
+    (options?.model != null && options.model !== 'default')
+  ) {
+    return options;
+  }
+  return { ...options, model: defaultModel };
+}
+
+function createLocalAgentDef(
+  raw: unknown,
+  baseDefs: RuntimeAgentDef[],
+): RuntimeAgentDef | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const profile = raw as Record<string, unknown>;
+  const id = typeof profile.id === 'string' ? profile.id.trim() : '';
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$/.test(id)) return null;
+  if (baseDefs.some((def) => def.id === id)) return null;
+
+  const hasExplicitBaseAgent =
+    typeof profile.baseAgent === 'string' &&
+    profile.baseAgent.trim().length > 0;
+  const baseId = hasExplicitBaseAgent
+    ? (profile.baseAgent as string).trim()
+    : 'claude';
+  const base = baseDefs.find((def) => def.id === baseId);
+  if (!base) {
+    if (hasExplicitBaseAgent) {
+      console.warn(
+        `[agents] skipping local profile "${id}": unknown baseAgent "${baseId}"`,
+      );
+    }
+    return null;
+  }
+
+  const bin =
+    typeof profile.bin === 'string' &&
+    profile.bin.trim() &&
+    !profile.bin.includes('\0')
+      ? profile.bin.trim()
+      : base.bin;
+  const name =
+    typeof profile.name === 'string' && profile.name.trim()
+      ? profile.name.trim()
+      : id;
+  const prefixArgs = normalizeStringList(profile.args ?? profile.prefixArgs);
+  const env = normalizeEnvMap(profile.env);
+  const fallbackModels =
+    normalizeModelOptions(profile.models ?? profile.fallbackModels) ??
+    base.fallbackModels;
+  const versionArgs = normalizeStringList(profile.versionArgs);
+  const helpArgs = normalizeStringList(profile.helpArgs);
+  const defaultModel = normalizeDefaultModel(profile.defaultModel);
+
+  return {
+    ...base,
+    id,
+    name,
+    bin,
+    versionArgs: versionArgs.length > 0 ? versionArgs : base.versionArgs,
+    ...(helpArgs.length > 0 ? { helpArgs } : {}),
+    fallbackModels,
+    env,
+    buildArgs: (prompt, imagePaths, extraAllowedDirs, options, runtimeContext) => [
+      ...prefixArgs,
+      ...base.buildArgs(
+        prompt,
+        imagePaths,
+        extraAllowedDirs,
+        optionsWithDefaultModel(options, defaultModel),
+        runtimeContext,
+      ),
+    ],
+  };
+}
+
+export function readLocalAgentProfileDefs(
+  baseDefs: RuntimeAgentDef[],
+): RuntimeAgentDef[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(localAgentProfilesFile(), 'utf8'));
+  } catch {
+    return [];
+  }
+  const profiles = Array.isArray(parsed)
+    ? parsed
+    : parsed &&
+        typeof parsed === 'object' &&
+        Array.isArray((parsed as { agents?: unknown }).agents)
+      ? (parsed as { agents: unknown[] }).agents
+      : [];
+  const defs: RuntimeAgentDef[] = [];
+  const seen = new Set(baseDefs.map((def) => def.id));
+  for (const profile of profiles) {
+    const def = createLocalAgentDef(profile, baseDefs);
+    if (!def || seen.has(def.id)) continue;
+    seen.add(def.id);
+    defs.push(def);
+  }
+  return defs;
+}

--- a/apps/daemon/src/runtimes/registry.ts
+++ b/apps/daemon/src/runtimes/registry.ts
@@ -14,9 +14,10 @@ import { kiroAgentDef } from './defs/kiro.js';
 import { kiloAgentDef } from './defs/kilo.js';
 import { vibeAgentDef } from './defs/vibe.js';
 import { deepseekAgentDef } from './defs/deepseek.js';
+import { readLocalAgentProfileDefs as readLocalAgentProfileDefsFromFile } from './local-profiles.js';
 import type { RuntimeAgentDef } from './types.js';
 
-export const AGENT_DEFS: RuntimeAgentDef[] = [
+const BASE_AGENT_DEFS: RuntimeAgentDef[] = [
   claudeAgentDef,
   codexAgentDef,
   devinAgentDef,
@@ -33,6 +34,17 @@ export const AGENT_DEFS: RuntimeAgentDef[] = [
   kiloAgentDef,
   vibeAgentDef,
   deepseekAgentDef,
+];
+
+export function readLocalAgentProfileDefs(
+  baseDefs: RuntimeAgentDef[] = BASE_AGENT_DEFS,
+): RuntimeAgentDef[] {
+  return readLocalAgentProfileDefsFromFile(baseDefs);
+}
+
+export const AGENT_DEFS: RuntimeAgentDef[] = [
+  ...BASE_AGENT_DEFS,
+  ...readLocalAgentProfileDefs(BASE_AGENT_DEFS),
 ];
 
 const ids = new Set();

--- a/apps/daemon/tests/runtimes/registry-and-args.test.ts
+++ b/apps/daemon/tests/runtimes/registry-and-args.test.ts
@@ -2,11 +2,103 @@ import { test } from 'vitest';
 import {
   AGENT_DEFS, assert, chmodSync, codex, detectAgents, join, mkdtempSync, rmSync, tmpdir, withEnvSnapshot, withPlatform, writeFileSync,
 } from './helpers/test-helpers.js';
+import { readLocalAgentProfileDefs } from '../../src/runtimes/registry.js';
 
 test('AGENT_DEFS ids are unique', () => {
   const ids = AGENT_DEFS.map((a) => a.id);
   const dupes = ids.filter((id, i) => ids.indexOf(id) !== i);
   assert.deepEqual(dupes, [], `duplicate agent ids: ${JSON.stringify(dupes)}`);
+});
+
+test('local agent profiles inherit a base adapter and can pin the default model', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'od-local-agent-profiles-'));
+  try {
+    await withEnvSnapshot(['OD_AGENT_PROFILES_CONFIG'], async () => {
+      const config = join(dir, 'agents.local.json');
+      writeFileSync(
+        config,
+        JSON.stringify({
+          agents: [
+            {
+              id: 'zcode',
+              name: 'ZCode',
+              baseAgent: 'claude',
+              bin: 'zcode',
+              args: ['run'],
+              defaultModel: 'zyb-claude',
+              models: [
+                { id: 'zyb-claude', label: 'zyb-claude' },
+                { id: 'zyb-gpt', label: 'zyb-gpt' },
+              ],
+              env: {
+                ZCODE_ROUTE: 'design',
+                RETRIES: 2,
+                'BAD-NAME': 'ignored',
+              },
+            },
+          ],
+        }),
+      );
+      process.env.OD_AGENT_PROFILES_CONFIG = config;
+
+      const profiles = readLocalAgentProfileDefs();
+      assert.equal(profiles.length, 1);
+      const [profile] = profiles;
+      assert.ok(profile);
+      assert.equal(profile.id, 'zcode');
+      assert.equal(profile.name, 'ZCode');
+      assert.equal(profile.bin, 'zcode');
+      assert.equal(profile.promptViaStdin, true);
+      assert.equal(profile.streamFormat, 'claude-stream-json');
+      assert.deepEqual(profile.fallbackModels.map((model) => model.id), [
+        'default',
+        'zyb-claude',
+        'zyb-gpt',
+      ]);
+      assert.deepEqual(profile.env, {
+        ZCODE_ROUTE: 'design',
+        RETRIES: '2',
+      });
+
+      const defaultArgs = profile.buildArgs('', [], [], {});
+      assert.deepEqual(defaultArgs.slice(0, 2), ['run', '-p']);
+      assert.ok(defaultArgs.includes('--model'));
+      assert.equal(defaultArgs[defaultArgs.indexOf('--model') + 1], 'zyb-claude');
+
+      const explicitArgs = profile.buildArgs('', [], [], { model: 'zyb-gpt' });
+      assert.equal(explicitArgs[explicitArgs.indexOf('--model') + 1], 'zyb-gpt');
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('local agent profiles skip explicit unknown baseAgent without falling back', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'od-local-agent-profiles-invalid-'));
+  try {
+    await withEnvSnapshot(['OD_AGENT_PROFILES_CONFIG'], async () => {
+      const config = join(dir, 'agents.local.json');
+      writeFileSync(
+        config,
+        JSON.stringify({
+          agents: [
+            { id: 'claude', bin: 'duplicate' },
+            { id: 'bad id with spaces', bin: 'bad' },
+            { id: 'unknown-base', baseAgent: 'does-not-exist', bin: 'bad' },
+            { id: 'ok-wrapper', bin: 'ok-wrapper' },
+          ],
+        }),
+      );
+      process.env.OD_AGENT_PROFILES_CONFIG = config;
+
+      const profiles = readLocalAgentProfileDefs();
+
+      assert.deepEqual(profiles.map((profile) => profile.id), ['ok-wrapper']);
+      assert.equal(profiles[0]?.bin, 'ok-wrapper');
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test('codex args disable plugins when OD_CODEX_DISABLE_PLUGINS is 1', () => {


### PR DESCRIPTION
Fixes #375.

## Why

Custom agent CLI wrappers are useful when a developer needs Open Design to launch an existing local agent command with local routing, environment, or wrapper arguments. Today that requires hardcoding a new adapter in the daemon, which does not scale and is not appropriate for vendor- or company-specific routes.

This PR adds an opt-in local profile file so those wrappers can live on the user's machine while the upstream daemon only owns the generic loader and validation behavior.

## What users will see

By default, existing users will see no change.

Users who create `~/.open-design/agents.local.json` or set `OD_AGENT_PROFILES_CONFIG` can add local agent entries that appear in the existing agent picker. Those entries inherit an existing built-in adapter such as Claude and can override the displayed name, executable, prefix args, environment, version/help args, model hints, and optional `defaultModel` behavior.

Example config:

```json
{
  "agents": [
    {
      "id": "local-claude-wrapper",
      "name": "Local Claude Wrapper",
      "baseAgent": "claude",
      "bin": "local-claude",
      "args": ["--profile", "demo"],
      "env": { "LOCAL_AGENT_ROUTE": "demo" },
      "defaultModel": "custom-model",
      "models": [{ "id": "custom-model", "label": "Custom Model" }]
    }
  ]
}
```

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable. This is an opt-in daemon configuration path and uses the existing agent picker once a local profile is configured.

## Bug fix verification

Not applicable. This is an opt-in feature for local custom agent wrappers.

## Validation

- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/daemon test -- agents.test.ts`
- Focused refresh validation after rebasing onto the split runtime registry:
  - `vitest tests/runtimes/registry-and-args.test.ts`
  - `vitest tests/runtimes/env-and-detection.test.ts`
- GitHub checks on latest head are green:
  - Detect PR change scopes
  - Validate workspace
  - build