### PR TITLE
release: Open Design 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-03
+
+A fast follow-up to 0.2.0 focused on richer design workflows, packaged-agent reliability, export/deploy flows, and broader internationalization. 39 merged PRs from 25 contributors.
+
+### Added
+
+#### Web / UI
+- Pet companion with Codex hatch-pet integration. ([#296])
+- Brand design-system cards, thumbnails, and DESIGN.md side-by-side preview. ([#289])
+- Per-tool renderer registry for generative UI. ([#282])
+- Task completion sound and browser notification. ([#359])
+
+#### Agents & daemon
+- Persist code-agent startup state. ([#255])
+- Mistral Vibe CLI agent adapter. ([#354])
+- Devin for Terminal support. ([#301])
+- `OD_BIND_HOST` and `--host` for interface binding. ([#328])
+
+#### Skills & exports
+- Taste-skill-derived web prototype and HTML PPT examples. ([#358])
+- `pptx-html-fidelity-audit` skill wired into export prompts. ([#307])
+- Broader PPTX fidelity script coverage beyond CJK. ([#308])
+- Native desktop Save As dialog for `.pptx` downloads. ([#330])
+- Export as Markdown from the share menu. ([#345])
+
+#### Deployment
+- `/api/projects/:id/deploy/preflight` for pre-upload inspection. ([#320])
+
+#### Internationalization
+- Arabic (`ar`) UI locale with RTL layout. ([#316])
+- French (`fr`) UI locale. ([#376])
+
+### Fixed
+
+#### Agents, packaged runtime & Windows
+- Include `nvm` / `fnm` / `mise` agent CLI bins in packaged PATH. ([#364])
+- Detect Codex and Gemini CLIs from user toolchain paths. ([#346])
+- Upgrade `better-sqlite3` for Node 24 Windows prebuilt support. ([#357])
+- Lead Copilot spawn with `-p -` so prompt-via-stdin is consumed. ([#351])
+- Drop literal `-` argv from Codex spawn so prompts deliver via stdin pipe alone. ([#342])
+- Wrap `cmd.exe` shim invocations to survive `/s /c` quote stripping. ([#339])
+
+#### Web UI & files
+- Download as `.zip` now returns the actual project tree. ([#341])
+- Keep Design Files view active after deleting a file. ([#329])
+- Scroll workspace tabs in place instead of the window. ([#363])
+- Treat inlined script content as literal in FileViewer. ([#343])
+- Use response-order matching for bulk upload aggregation. ([#323])
+- Serve `.jsx` / `.tsx` with JS-family MIME types so browser loaders accept them. ([#340])
+- Fix macOS entry view drag region. ([#373])
+
+#### Daemon & deployment
+- Increase project upload limit from 20MB to 200MB. ([#319])
+- Bundle and rewrite assets referenced from inline `<style>` blocks and `style=""` attributes. ([#314])
+
+#### Internationalization
+- Update locale coverage after main merge. ([#251])
+- Add missing `designFiles.showMore` keys to `ar`, `hu`, `ko`, `pl`, and `tr`. ([#335])
+
+### Documentation
+
+- Japanese documentation update. ([#309])
+- README contributors wall refresh. ([#360])
+- Spelling fixes in CLI comments, spec, and video prompt docs. ([#300])
+
 ## [0.2.0] - 2026-05-02
 
 A feature-heavy follow-up to 0.1.0 — dark mode, xAI Grok Imagine media generation, headless deploy mode, OpenClaude fallback, four new locales, and a much richer skill / design-system / prompt-template catalog. 45 merged PRs from 27 contributors.
@@ -184,7 +249,8 @@ First public release of Open Design — a local-first, open-source alternative t
 - Beta release workflow placeholder. ([#36])
 - Git commit co-author policy. ([#131])
 
-[Unreleased]: https://github.com/nexu-io/open-design/compare/open-design-v0.2.0...HEAD
+[Unreleased]: https://github.com/nexu-io/open-design/compare/open-design-v0.3.0...HEAD
+[0.3.0]: https://github.com/nexu-io/open-design/releases/tag/open-design-v0.3.0
 [0.2.0]: https://github.com/nexu-io/open-design/releases/tag/open-design-v0.2.0
 [0.1.0]: https://github.com/nexu-io/open-design/releases/tag/open-design-v0.1.0
 
@@ -318,3 +384,40 @@ First public release of Open Design — a local-first, open-source alternative t
 [#284]: https://github.com/nexu-io/open-design/pull/284
 [#287]: https://github.com/nexu-io/open-design/pull/287
 [#288]: https://github.com/nexu-io/open-design/pull/288
+[#250]: https://github.com/nexu-io/open-design/pull/250
+[#251]: https://github.com/nexu-io/open-design/pull/251
+[#255]: https://github.com/nexu-io/open-design/pull/255
+[#301]: https://github.com/nexu-io/open-design/pull/301
+[#307]: https://github.com/nexu-io/open-design/pull/307
+[#308]: https://github.com/nexu-io/open-design/pull/308
+[#314]: https://github.com/nexu-io/open-design/pull/314
+[#316]: https://github.com/nexu-io/open-design/pull/316
+[#319]: https://github.com/nexu-io/open-design/pull/319
+[#320]: https://github.com/nexu-io/open-design/pull/320
+[#323]: https://github.com/nexu-io/open-design/pull/323
+[#328]: https://github.com/nexu-io/open-design/pull/328
+[#329]: https://github.com/nexu-io/open-design/pull/329
+[#330]: https://github.com/nexu-io/open-design/pull/330
+[#335]: https://github.com/nexu-io/open-design/pull/335
+[#339]: https://github.com/nexu-io/open-design/pull/339
+[#340]: https://github.com/nexu-io/open-design/pull/340
+[#341]: https://github.com/nexu-io/open-design/pull/341
+[#342]: https://github.com/nexu-io/open-design/pull/342
+[#343]: https://github.com/nexu-io/open-design/pull/343
+[#345]: https://github.com/nexu-io/open-design/pull/345
+[#346]: https://github.com/nexu-io/open-design/pull/346
+[#351]: https://github.com/nexu-io/open-design/pull/351
+[#354]: https://github.com/nexu-io/open-design/pull/354
+[#357]: https://github.com/nexu-io/open-design/pull/357
+[#358]: https://github.com/nexu-io/open-design/pull/358
+[#359]: https://github.com/nexu-io/open-design/pull/359
+[#360]: https://github.com/nexu-io/open-design/pull/360
+[#363]: https://github.com/nexu-io/open-design/pull/363
+[#364]: https://github.com/nexu-io/open-design/pull/364
+[#373]: https://github.com/nexu-io/open-design/pull/373
+[#376]: https://github.com/nexu-io/open-design/pull/376
+[#282]: https://github.com/nexu-io/open-design/pull/282
+[#289]: https://github.com/nexu-io/open-design/pull/289
+[#296]: https://github.com/nexu-io/open-design/pull/296
+[#300]: https://github.com/nexu-io/open-design/pull/300
+[#309]: https://github.com/nexu-io/open-design/pull/309

--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/daemon",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "main": "./dist/cli.js",
@@ -32,10 +32,10 @@
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.sidecar.json --noEmit && tsc -p tsconfig.tests.json --noEmit"
   },
   "dependencies": {
-    "@open-design/contracts": "workspace:0.2.0",
-    "@open-design/platform": "workspace:0.2.0",
-    "@open-design/sidecar": "workspace:0.2.0",
-    "@open-design/sidecar-proto": "workspace:0.2.0",
+    "@open-design/contracts": "workspace:0.3.0",
+    "@open-design/platform": "workspace:0.3.0",
+    "@open-design/sidecar": "workspace:0.3.0",
+    "@open-design/sidecar-proto": "workspace:0.3.0",
     "better-sqlite3": "^12.9.0",
     "express": "^4.19.2",
     "jszip": "^3.10.1",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/desktop",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "main": "./dist/main/index.js",
@@ -18,9 +18,9 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@open-design/platform": "workspace:0.2.0",
-    "@open-design/sidecar": "workspace:0.2.0",
-    "@open-design/sidecar-proto": "workspace:0.2.0"
+    "@open-design/platform": "workspace:0.3.0",
+    "@open-design/sidecar": "workspace:0.3.0",
+    "@open-design/sidecar-proto": "workspace:0.3.0"
   },
   "devDependencies": {
     "@types/node": "24.12.2",

--- a/apps/packaged/package.json
+++ b/apps/packaged/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/packaged",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",
@@ -20,12 +20,12 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@open-design/daemon": "workspace:0.2.0",
-    "@open-design/desktop": "workspace:0.2.0",
-    "@open-design/platform": "workspace:0.2.0",
-    "@open-design/sidecar": "workspace:0.2.0",
-    "@open-design/sidecar-proto": "workspace:0.2.0",
-    "@open-design/web": "workspace:0.2.0"
+    "@open-design/daemon": "workspace:0.3.0",
+    "@open-design/desktop": "workspace:0.3.0",
+    "@open-design/platform": "workspace:0.3.0",
+    "@open-design/sidecar": "workspace:0.3.0",
+    "@open-design/sidecar-proto": "workspace:0.3.0",
+    "@open-design/web": "workspace:0.3.0"
   },
   "devDependencies": {
     "@types/node": "24.12.2",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/web",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "exports": {
@@ -29,10 +29,10 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.32.1",
-    "@open-design/contracts": "workspace:0.2.0",
-    "@open-design/platform": "workspace:0.2.0",
-    "@open-design/sidecar": "workspace:0.2.0",
-    "@open-design/sidecar-proto": "workspace:0.2.0",
+    "@open-design/contracts": "workspace:0.3.0",
+    "@open-design/platform": "workspace:0.3.0",
+    "@open-design/sidecar": "workspace:0.3.0",
+    "@open-design/sidecar-proto": "workspace:0.3.0",
     "next": "^16.2.4",
     "openai": "^6.35.0",
     "react": "^18.3.1",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/e2e",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-design",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "packageManager": "pnpm@10.33.2",
   "type": "module",
@@ -25,8 +25,8 @@
     "typecheck": "pnpm -r --workspace-concurrency=1 --if-present run typecheck && pnpm --filter @open-design/daemon build && pnpm check:residual-js"
   },
   "devDependencies": {
-    "@open-design/tools-dev": "workspace:0.2.0",
-    "@open-design/tools-pack": "workspace:0.2.0"
+    "@open-design/tools-dev": "workspace:0.3.0",
+    "@open-design/tools-pack": "workspace:0.3.0"
   },
   "engines": {
     "node": "~24",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/contracts",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "description": "Shared pure TypeScript contracts for the Open Design web/daemon boundary.",

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/platform",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/sidecar-proto/package.json
+++ b/packages/sidecar-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/sidecar-proto",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/sidecar/package.json
+++ b/packages/sidecar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/sidecar",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,25 +9,25 @@ importers:
   .:
     devDependencies:
       '@open-design/tools-dev':
-        specifier: workspace:0.2.0
+        specifier: workspace:0.3.0
         version: link:tools/dev
       '@open-design/tools-pack':
-        specifier: workspace:0.2.0
+        specifier: workspace:0.3.0
         version: link:tools/pack
 
   apps/daemon:
     dependencies:
       '@open-design/contracts':
-        specifier: workspace:0.2.0
+        specifier: workspace:0.3.0
         version: link:../../packages/contracts
       '@open-design/platform':
-        specifier: workspace:0.2.0
+        specifier: workspace:0.3.0
         version: link:../../packages/platform
       '@open-design/sidecar':
-        specifier: workspace:0.2.0
+        specifier: workspace:0.3.0
         version: link:../../packages/sidecar
       '@open-design/sidecar-proto':
-        specifier: workspace:0.2.0
+        specifier: workspace:0.3.0
         version: link:../../packages/sidecar-proto
       better-sqlite3:
         specifier: ^12.9.0
@@ -64,13 +64,13 @@ importers:
   apps/desktop:
     dependencies:
       '@open-design/platform':
-        specifier: workspace:0.2.0
+        specifier: workspace:0.3.0
         version: link:../../packages/platform
       '@open-design/sidecar':
-        specifier: workspace:0.2.0
+        specifier: workspace:0.3.0
         version: link:../../packages/sidecar
       '@open-design/sidecar-proto':
-        specifier: workspace:0.2.0
+        specifier: workspace:0.3.0
         version: link:../../packages/sidecar-proto
     devDependencies:
       '@types/node':
@@ -86,22 +86,22 @@ importers:
   apps/packaged:
     dependencies:
       '@open-design/daemon':
-        specifier: workspace:0.2.0
+        specifier: workspace:0.3.0
         version: link:../daemon
       '@open-design/desktop':
-        specifier: workspace:0.2.0
+        specifier: workspace:0.3.0
         version: link:../desktop
       '@open-design/platform':
-        specifier: workspace:0.2.0
+        specifier: workspace:0.3.0
         version: link:../../packages/platform
       '@open-design/sidecar':
-        specifier: workspace:0.2.0
+        specifier: workspace:0.3.0
         version: link:../../packages/sidecar
       '@open-design/sidecar-proto':
-        specifier: workspace:0.2.0
+        specifier: workspace:0.3.0
         version: link:../../packages/sidecar-proto
       '@open-design/web':
-        specifier: workspace:0.2.0
+        specifier: workspace:0.3.0
         version: link:../web
     devDependencies:
       '@types/node':
@@ -123,16 +123,16 @@ importers:
         specifier: ^0.32.1
         version: 0.32.1
       '@open-design/contracts':
-        specifier: workspace:0.2.0
+        specifier: workspace:0.3.0
         version: link:../../packages/contracts
       '@open-design/platform':
-        specifier: workspace:0.2.0
+        specifier: workspace:0.3.0
         version: link:../../packages/platform
       '@open-design/sidecar':
-        specifier: workspace:0.2.0
+        specifier: workspace:0.3.0
         version: link:../../packages/sidecar
       '@open-design/sidecar-proto':
-        specifier: workspace:0.2.0
+        specifier: workspace:0.3.0
         version: link:../../packages/sidecar-proto
       next:
         specifier: ^16.2.4
@@ -244,13 +244,13 @@ importers:
   tools/dev:
     dependencies:
       '@open-design/platform':
-        specifier: workspace:0.2.0
+        specifier: workspace:0.3.0
         version: link:../../packages/platform
       '@open-design/sidecar':
-        specifier: workspace:0.2.0
+        specifier: workspace:0.3.0
         version: link:../../packages/sidecar
       '@open-design/sidecar-proto':
-        specifier: workspace:0.2.0
+        specifier: workspace:0.3.0
         version: link:../../packages/sidecar-proto
       cac:
         specifier: 6.7.14
@@ -275,13 +275,13 @@ importers:
         specifier: 3.1.0
         version: 3.1.0
       '@open-design/platform':
-        specifier: workspace:0.2.0
+        specifier: workspace:0.3.0
         version: link:../../packages/platform
       '@open-design/sidecar':
-        specifier: workspace:0.2.0
+        specifier: workspace:0.3.0
         version: link:../../packages/sidecar
       '@open-design/sidecar-proto':
-        specifier: workspace:0.2.0
+        specifier: workspace:0.3.0
         version: link:../../packages/sidecar-proto
       cac:
         specifier: 6.7.14

--- a/tools/dev/package.json
+++ b/tools/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-dev",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "bin": {
@@ -13,9 +13,9 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@open-design/platform": "workspace:0.2.0",
-    "@open-design/sidecar": "workspace:0.2.0",
-    "@open-design/sidecar-proto": "workspace:0.2.0",
+    "@open-design/platform": "workspace:0.3.0",
+    "@open-design/sidecar": "workspace:0.3.0",
+    "@open-design/sidecar-proto": "workspace:0.3.0",
     "cac": "6.7.14"
   },
   "devDependencies": {

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-pack",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "bin": {
@@ -12,9 +12,9 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@open-design/platform": "workspace:0.2.0",
-    "@open-design/sidecar": "workspace:0.2.0",
-    "@open-design/sidecar-proto": "workspace:0.2.0",
+    "@open-design/platform": "workspace:0.3.0",
+    "@open-design/sidecar": "workspace:0.3.0",
+    "@open-design/sidecar-proto": "workspace:0.3.0",
     "@electron/notarize": "3.1.0",
     "cac": "6.7.14",
     "electron-builder": "26.8.1"


### PR DESCRIPTION
> Note for reviewers: every `@user` mention below is wrapped in backticks so creating this PR does not ping contributors. Strip the backticks before publishing the GitHub release if you want attribution to notify people.

🎉 **`39 PRs` · `25 contributors` · one day after 0.2.0** — Open Design 0.3.0 keeps the momentum going: a pet companion, richer design-system browsing, stronger packaged-agent detection, better export/deploy flows, Arabic RTL + French, and a pile of Windows / CLI / preview reliability fixes.

## 🔥 Highlights

- 🐾 **Pet companion for Codex hatch-pet workflows.** Open Design now includes an in-app companion surface wired to hatch-pet and bundled community pet assets. (#296) Thanks `@pftom`.
- 🎨 **Richer design-system browsing.** Brand systems now get card thumbnails plus side-by-side DESIGN.md previews, powered by the new per-tool renderer registry. (#289, #282) Thanks `@pftom`.
- 🤖 **More agent coverage.** Added Devin for Terminal and Mistral Vibe CLI, plus persisted code-agent startup state. (#301, #354, #255) Thanks `@dabit3`, `@bezineb5`, and `@Ajay-Satish-01`.
- 📤 **Better export and download workflows.** Native Save As for `.pptx`, Export as Markdown, and ZIP downloads that return the actual project tree. (#330, #345, #341) Thanks `@laihenyi`, `@Sid-Qin`, and `@monshunter`.
- 🚀 **Deployment hardening.** Added deploy preflight inspection and fixed bundling / rewriting for assets referenced from inline styles. (#320, #314) Thanks `@Nagendhra-web`.
- 🌍 **Arabic RTL + French.** Open Design now ships full Arabic language support with RTL layout, plus a French locale. (#316, #376) Thanks `@Alihayder0` and `@rpalfray87`.

> 📥 **Download:** assets will be published once this PR is merged and the `release-stable` workflow finishes. Tag: `open-design-v0.3.0`.
>
> | Platform | Architecture | Asset |
> |---|---|---|
> | macOS | Apple Silicon (arm64) | [open-design-0.3.0-mac-arm64.dmg](https://github.com/nexu-io/open-design/releases/download/open-design-v0.3.0/open-design-0.3.0-mac-arm64.dmg) |
> | macOS (auto-update feed) | Apple Silicon (arm64) | [open-design-0.3.0-mac-arm64.zip](https://github.com/nexu-io/open-design/releases/download/open-design-v0.3.0/open-design-0.3.0-mac-arm64.zip) |
> | Windows | x64 (unsigned) | [open-design-0.3.0-win-x64-setup.exe](https://github.com/nexu-io/open-design/releases/download/open-design-v0.3.0/open-design-0.3.0-win-x64-setup.exe) |

## ✨ What's New

### 🐾 Pets, design systems & skills

- 🐾 **Pet companion with Codex hatch-pet integration.** (#296) Thanks `@pftom`.
- 🧩 **Brand design-system cards, thumbnails, and DESIGN.md side-by-side preview.** (#289) Thanks `@pftom`.
- 🛠️ **Per-tool renderer registry for generative UI.** (#282) Thanks `@pftom`.
- 🎞️ **Taste-skill-derived web prototype and HTML PPT examples.** (#358) Thanks `@pftom`.
- 📊 **PPTX HTML fidelity audit skill wired into export prompts.** (#307) Thanks `@laihenyi`.
- 🌐 **Broader PPTX fidelity script coverage beyond CJK.** (#308) Thanks `@laihenyi`.

### 🤖 Agents & packaged runtime

- 💾 **Persist code-agent startup state.** (#255) Thanks `@Ajay-Satish-01`.
- 🧠 **Mistral Vibe CLI agent adapter.** (#354) Thanks `@bezineb5`.
- 🖥️ **Devin for Terminal support.** (#301) Thanks `@dabit3`.
- 🧭 **Packaged app can find agent CLIs installed through nvm / fnm / mise.** (#364) Thanks `@dabing1022`.
- 🔎 **Codex and Gemini CLI detection now checks user toolchain paths.** (#346) Thanks `@maddada`.

### 📤 Export, deploy & sharing

- 💾 **Native desktop Save As dialog for `.pptx` downloads.** (#330) Thanks `@laihenyi`.
- 📝 **Export as Markdown from the share menu.** (#345) Thanks `@Sid-Qin`.
- 📦 **Download as `.zip` now returns the actual project tree.** (#341) Thanks `@monshunter`.
- 🧪 **Deploy preflight endpoint for inspecting projects before upload.** (#320) Thanks `@Nagendhra-web`.
- 🌐 **`OD_BIND_HOST` and `--host` for interface binding.** (#328) Thanks `@NickSeagullBot`.

## 🌍 Internationalization & Docs

- 🇸🇦 **Arabic (`ar`) with RTL layout.** (#316) Thanks `@Alihayder0`.
- 🇫🇷 **French (`fr`) locale.** (#376) Thanks `@rpalfray87`.
- 🇯🇵 Japanese documentation update. (#309) Thanks `@eltociear`.
- 🧱 Contributors wall refresh. (#360) Thanks `@nettee`.
- 📝 Spelling fixes in CLI comments, spec, and video prompt docs. (#300) Thanks `@luojiyin1987`.

## 🛡️ Stability & Reliability

- 🪟 **Node 24 Windows packaged builds are more reliable** after upgrading `better-sqlite3` for prebuilt support. (#357) Thanks `@louie42`.
- 📥 **Copilot and Codex prompt-via-stdin fixes** remove literal dash argv issues and make prompts consume correctly. (#351, #342) Thanks `@Sid-Qin`.
- 🪟 **cmd.exe shim invocations survive `/s /c` quote stripping.** (#339) Thanks `@Sid-Qin`.
- 🧩 **`.jsx` / `.tsx` files are served with JS-family MIME types** so browser loaders accept them. (#340) Thanks `@Sid-Qin`.
- 🧯 **Inline script content is treated as literal in FileViewer.** (#343) Thanks `@bankielewicz`.
- 📁 **Project upload limit increased from 20MB to 200MB.** (#319) Thanks `@lefarcen`.

## 🐛 Bug Fixes

- 📂 Keep Design Files view active after deleting a file. (#329) Thanks `@sak0a`.
- 📑 Scroll workspace tabs in place instead of scrolling the whole window. (#363) Thanks `@emilneander`.
- 🍎 Fix macOS entry view drag region. (#373) Thanks `@fuyizheng3120`.
- 📤 Use response-order matching for bulk upload aggregation. (#323) Thanks `@mvanhorn`.
- 🌍 Add missing `designFiles.showMore` locale keys for ar / hu / ko / pl / tr. (#335) Thanks `@lefarcen`.
- 🌍 Update locale coverage after main merge. (#251) Thanks `@ccfuncy`.

## ✅ System Requirements

- **macOS** — Apple Silicon (arm64) only, macOS 11 Big Sur or newer. Intel macs are not supported in 0.3.0.
- **Windows** — x64, Windows 10 / 11. Installer is **unsigned** (SmartScreen will warn on first launch; choose "More info → Run anyway").
- **Linux** — no packaged build; run from source or via headless mode.
- **From source** — Node.js 24.x and pnpm 10.33.2+.

## ⚠️ Known Issues

- 🪟 **Windows installer is unsigned** — SmartScreen / antivirus warnings on first launch. Code signing remains a follow-up.
- 🍎 **No macOS Intel (x64) build** — Apple Silicon only.
- 🐧 **No Linux desktop package** — run from source or deploy headlessly.

## 🔨 For Developers

<details>
<summary>Click to expand</summary>

- 🧪 `release-stable` metadata check recognizes `open-design-v0.3.0` as the next stable tag after `0.2.0`.
- 📦 All workspace package versions and internal workspace dependencies are bumped to `0.3.0`.
- ✅ Validation: `pnpm install`, `release-stable` metadata script, `pnpm typecheck`, and `pnpm test` passed locally. Local Node was `22.22.0`, so pnpm printed engine warnings for the repo's `~24` requirement.

</details>

---

**Full Changelog:** https://github.com/nexu-io/open-design/compare/open-design-v0.2.0...release/v0.3.0
