### PR TITLE
fix(web): lift coming-soon tip above sticky tabs and make it readable in dark theme

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6378,6 +6378,7 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
    ============================================================ */
 .viewer-action[data-coming-soon='true'] {
   position: relative;
+  z-index: 5;
   opacity: 0.55;
   cursor: not-allowed;
 }
@@ -6388,7 +6389,7 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   bottom: calc(100% + 6px);
   left: 50%;
   transform: translateX(-50%);
-  background: var(--text-strong);
+  background: rgba(17, 24, 39, 0.95);
   color: white;
   font-size: 10.5px;
   padding: 4px 8px;
@@ -6405,6 +6406,7 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
 .viewer-action[data-coming-soon='true']:hover::after { opacity: 1; }
 .viewer-toggle[data-coming-soon='true'] {
   position: relative;
+  z-index: 5;
   opacity: 0.55;
   cursor: not-allowed;
 }
@@ -6415,7 +6417,7 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   bottom: calc(100% + 6px);
   left: 50%;
   transform: translateX(-50%);
-  background: var(--text-strong);
+  background: rgba(17, 24, 39, 0.95);
   color: white;
   font-size: 10.5px;
   padding: 4px 8px;


### PR DESCRIPTION
## Summary
The "Coming soon" pseudo-tip on the file-viewer toolbar (`Tweaks`, `Edit`, `Draw`) had two bugs:

- **Hidden behind `.ws-tabs-bar`.** The parent shell sets `opacity: 0.55`, which creates a new stacking context, so the `::after`'s `z-index: 10` was trapped locally and could not rise above the sticky workspace tabs (`z-index: 4`). Pin the parent to `z-index: 5` so its whole stacking context paints above the tabs.
- **Invisible in dark theme.** `background: var(--text-strong)` is `#f2ede4` in dark mode against `color: white` — white-on-white. Switch to the same fixed dark slate (`rgba(17, 24, 39, 0.95)`) already used by `.comment-target-tooltip`, so contrast holds in both themes.

Diff is 6 lines across the two symmetric `.viewer-action` / `.viewer-toggle` `[data-coming-soon='true']` rules.

## Test plan
- [ ] Open any file in a project, hover `Tweaks` / `Edit` / `Draw` in light theme — "COMING SOON" tip renders fully visible above the workspace tabs row.
- [ ] Switch to dark theme, repeat — tip is readable (white on dark slate), not white-on-white.
- [ ] No other layering regressions in the file viewer toolbar (popovers, share menu).