### PR TITLE
fix(web): URL-load HTML preview iframes by default; ?forceInline=1 opt-out

### DIFF
--- a/apps/web/src/components/FileViewer.test.tsx
+++ b/apps/web/src/components/FileViewer.test.tsx
@@ -77,6 +77,90 @@ describe('FileViewer SVG artifacts', () => {
     expect(sourceMarkup).not.toContain('<img');
   });
 
+  it('URL-loads a plain HTML preview iframe instead of inlining via srcDoc', () => {
+    const file = baseFile({
+      name: 'page.html',
+      path: 'page.html',
+      mime: 'text/html',
+      kind: 'html',
+      artifactManifest: {
+        version: 1,
+        kind: 'html',
+        title: 'Page',
+        entry: 'page.html',
+        renderer: 'html',
+        exports: ['html'],
+      },
+    });
+
+    const markup = renderToStaticMarkup(
+      <FileViewer projectId="project-1" file={file} liveHtml="<html><body>hi</body></html>" />,
+    );
+
+    expect(markup).toContain('data-testid="artifact-preview-frame"');
+    expect(markup).toContain('data-od-render-mode="url-load"');
+    expect(markup).toContain('src="/api/projects/project-1/raw/page.html?v=1710000000&amp;r=0"');
+    expect(markup).not.toContain('data-od-render-mode="srcdoc"');
+  });
+
+  it('keeps decks on the srcDoc path so the deck postMessage bridge can run', () => {
+    const file = baseFile({
+      name: 'deck.html',
+      path: 'deck.html',
+      mime: 'text/html',
+      kind: 'html',
+      artifactManifest: {
+        version: 1,
+        kind: 'deck',
+        title: 'Deck',
+        entry: 'deck.html',
+        renderer: 'deck-html',
+        exports: ['html'],
+      },
+    });
+
+    const markup = renderToStaticMarkup(
+      <FileViewer
+        projectId="project-1"
+        file={file}
+        isDeck
+        liveHtml={'<html><body><section class="slide">one</section></body></html>'}
+      />,
+    );
+
+    expect(markup).toContain('data-testid="artifact-preview-frame"');
+    expect(markup).toContain('data-od-render-mode="srcdoc"');
+    expect(markup).not.toContain('data-od-render-mode="url-load"');
+  });
+
+  it('falls back to srcDoc when the HTML body looks deck-shaped even without an isDeck hint', () => {
+    const file = baseFile({
+      name: 'inferred.html',
+      path: 'inferred.html',
+      mime: 'text/html',
+      kind: 'html',
+      artifactManifest: {
+        version: 1,
+        kind: 'html',
+        title: 'Inferred',
+        entry: 'inferred.html',
+        renderer: 'html',
+        exports: ['html'],
+      },
+    });
+
+    const markup = renderToStaticMarkup(
+      <FileViewer
+        projectId="project-1"
+        file={file}
+        liveHtml={'<html><body><section class="slide">one</section><section class="slide">two</section></body></html>'}
+      />,
+    );
+
+    expect(markup).toContain('data-od-render-mode="srcdoc"');
+    expect(markup).not.toContain('data-od-render-mode="url-load"');
+  });
+
   it('renders unsafe SVG source as escaped text instead of executable markup', () => {
     const file = baseFile({ name: 'unsafe.svg', path: 'unsafe.svg', mime: 'image/svg+xml' });
     const unsafeSource = [

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -26,6 +26,7 @@ import {
 } from '../runtime/exports';
 import { buildReactComponentSrcdoc } from '../runtime/react-component';
 import { buildSrcdoc } from '../runtime/srcdoc';
+import { parseForceInline, shouldUrlLoadHtmlPreview } from './file-viewer-render-mode';
 import { saveTemplate } from '../state/projects';
 import type { DeployConfigResponse, DeployProjectFileResponse, ProjectFile } from '../types';
 import { Icon } from './Icon';
@@ -620,6 +621,13 @@ function HtmlViewer({
   const [inTabPresent, setInTabPresent] = useState(false);
   const [reloadKey, setReloadKey] = useState(0);
   const [commentMode, setCommentMode] = useState(false);
+  // Opt back into the legacy inline-asset srcDoc path via `?forceInline=1`
+  // on the host page. Lets users escape-hatch around the URL-load default
+  // for non-deck HTML that depends on the in-iframe localStorage shim.
+  const forceInline = useMemo(
+    () => (typeof window === 'undefined' ? false : parseForceInline(window.location.search)),
+    [],
+  );
   const [activeCommentTarget, setActiveCommentTarget] = useState<PreviewCommentSnapshot | null>(null);
   const [hoveredCommentTarget, setHoveredCommentTarget] = useState<PreviewCommentSnapshot | null>(null);
   const [liveCommentTargets, setLiveCommentTargets] = useState<Map<string, PreviewCommentSnapshot>>(() => new Map());
@@ -679,9 +687,23 @@ function HtmlViewer({
   }, [source]);
   const effectiveDeck = isDeck || looksLikeDeck;
   const previewSource = inlinedSource ?? source;
+  // When we URL-load the iframe directly, skip every in-host inlining /
+  // srcDoc-rebuilding step. The browser does the asset resolution itself,
+  // which is the whole point of the URL-load path.
+  const useUrlLoadPreview = shouldUrlLoadHtmlPreview({
+    mode,
+    isDeck: effectiveDeck,
+    commentMode,
+    forceInline,
+  });
+  const previewSrcUrl = useMemo(
+    () => `${projectRawUrl(projectId, file.name)}?v=${Math.round(file.mtime)}&r=${reloadKey}`,
+    [projectId, file.name, file.mtime, reloadKey],
+  );
 
   useEffect(() => {
     setInlinedSource(null);
+    if (useUrlLoadPreview) return;
     if (!source || effectiveDeck || !hasRelativeAssetRefs(source)) return;
     let cancelled = false;
     void inlineRelativeAssets(source, projectId, file.name).then((next) => {
@@ -690,7 +712,7 @@ function HtmlViewer({
     return () => {
       cancelled = true;
     };
-  }, [source, effectiveDeck, projectId, file.name]);
+  }, [source, effectiveDeck, projectId, file.name, useUrlLoadPreview]);
 
   const srcDoc = useMemo(
     () => (previewSource ? buildSrcdoc(previewSource, {
@@ -1412,13 +1434,25 @@ function HtmlViewer({
                 transformOrigin: '0 0',
               }}
             >
-              <iframe
-                ref={iframeRef}
-                data-testid="artifact-preview-frame"
-                title={file.name}
-                sandbox="allow-scripts"
-                srcDoc={srcDoc}
-              />
+              {useUrlLoadPreview ? (
+                <iframe
+                  ref={iframeRef}
+                  data-testid="artifact-preview-frame"
+                  data-od-render-mode="url-load"
+                  title={file.name}
+                  sandbox="allow-scripts"
+                  src={previewSrcUrl}
+                />
+              ) : (
+                <iframe
+                  ref={iframeRef}
+                  data-testid="artifact-preview-frame"
+                  data-od-render-mode="srcdoc"
+                  title={file.name}
+                  sandbox="allow-scripts"
+                  srcDoc={srcDoc}
+                />
+              )}
             </div>
             {commentMode ? (
               <CommentPreviewOverlays
@@ -1472,7 +1506,21 @@ function HtmlViewer({
           >
             <Icon name="close" size={13} /> {t('fileViewer.exitPresentation')}
           </button>
-          <iframe title="present" sandbox="allow-scripts" srcDoc={srcDoc} />
+          {useUrlLoadPreview ? (
+            <iframe
+              title="present"
+              sandbox="allow-scripts"
+              data-od-render-mode="url-load"
+              src={previewSrcUrl}
+            />
+          ) : (
+            <iframe
+              title="present"
+              sandbox="allow-scripts"
+              data-od-render-mode="srcdoc"
+              srcDoc={srcDoc}
+            />
+          )}
         </div>
       ) : null}
       {deployModalOpen ? (

--- a/apps/web/src/components/file-viewer-render-mode.test.ts
+++ b/apps/web/src/components/file-viewer-render-mode.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseForceInline, shouldUrlLoadHtmlPreview } from './file-viewer-render-mode';
+
+describe('shouldUrlLoadHtmlPreview', () => {
+  const base = { mode: 'preview' as const, isDeck: false, commentMode: false, forceInline: false };
+
+  it('URL-loads a plain HTML preview by default', () => {
+    expect(shouldUrlLoadHtmlPreview(base)).toBe(true);
+  });
+
+  it('falls back to srcDoc when the file is a deck (deck bridge required)', () => {
+    expect(shouldUrlLoadHtmlPreview({ ...base, isDeck: true })).toBe(false);
+  });
+
+  it('falls back to srcDoc when comment mode is active (comment bridge required)', () => {
+    expect(shouldUrlLoadHtmlPreview({ ...base, commentMode: true })).toBe(false);
+  });
+
+  it('falls back to srcDoc when the user opts in via forceInline', () => {
+    expect(shouldUrlLoadHtmlPreview({ ...base, forceInline: true })).toBe(false);
+  });
+
+  it('does not URL-load while the source-code tab is active', () => {
+    expect(shouldUrlLoadHtmlPreview({ ...base, mode: 'source' })).toBe(false);
+  });
+
+  it('treats any disqualifying flag as sufficient on its own', () => {
+    expect(shouldUrlLoadHtmlPreview({ ...base, isDeck: true, commentMode: true })).toBe(false);
+    expect(shouldUrlLoadHtmlPreview({ ...base, isDeck: true, forceInline: true })).toBe(false);
+    expect(shouldUrlLoadHtmlPreview({ ...base, commentMode: true, forceInline: true })).toBe(false);
+  });
+});
+
+describe('parseForceInline', () => {
+  it('returns false when the parameter is absent', () => {
+    expect(parseForceInline('')).toBe(false);
+    expect(parseForceInline('?other=1')).toBe(false);
+    expect(parseForceInline(null)).toBe(false);
+    expect(parseForceInline(undefined)).toBe(false);
+  });
+
+  it('returns true for the documented opt-in values', () => {
+    expect(parseForceInline('?forceInline=1')).toBe(true);
+    expect(parseForceInline('?forceInline=true')).toBe(true);
+    expect(parseForceInline('?forceInline=TRUE')).toBe(true);
+    expect(parseForceInline('?forceInline=yes')).toBe(true);
+    expect(parseForceInline('?forceInline=on')).toBe(true);
+  });
+
+  it('returns false for explicit opt-out values and unrelated strings', () => {
+    expect(parseForceInline('?forceInline=0')).toBe(false);
+    expect(parseForceInline('?forceInline=false')).toBe(false);
+    expect(parseForceInline('?forceInline=no')).toBe(false);
+    expect(parseForceInline('?forceInline=off')).toBe(false);
+    expect(parseForceInline('?forceInline=banana')).toBe(false);
+  });
+
+  it('treats an empty value as absent (defensive: ?forceInline= shows up as "")', () => {
+    expect(parseForceInline('?forceInline=')).toBe(false);
+  });
+
+  it('accepts a pre-built URLSearchParams', () => {
+    const params = new URLSearchParams('forceInline=1&other=foo');
+    expect(parseForceInline(params)).toBe(true);
+  });
+
+  it('survives surrounding whitespace in the value', () => {
+    const params = new URLSearchParams();
+    params.set('forceInline', '  1  ');
+    expect(parseForceInline(params)).toBe(true);
+  });
+});

--- a/apps/web/src/components/file-viewer-render-mode.ts
+++ b/apps/web/src/components/file-viewer-render-mode.ts
@@ -1,0 +1,61 @@
+/**
+ * Decide between two HTML preview render strategies in FileViewer:
+ *
+ *   - URL-load: <iframe src="/api/projects/:id/raw/:file"> — the browser
+ *     fetches each <script src> / <link href> as its own request. Source
+ *     maps work, DevTools shows real filenames, per-asset HTTP caching
+ *     applies, and a single broken file no longer takes down the whole
+ *     iframe. This is the right default for multi-file artifacts (e.g.
+ *     React prototypes that ship dozens of `.jsx` files).
+ *
+ *   - srcDoc inline: build a self-contained document (via buildSrcdoc),
+ *     optionally with relative assets concatenated in by inlineRelative-
+ *     Assets, and pass it via the iframe's srcDoc attribute. Required
+ *     when we need to inject host-side bridges that have to run before
+ *     user scripts (deck navigation, comment-mode targeting), and useful
+ *     as an explicit opt-in for self-contained exports.
+ *
+ * The two helpers below isolate the decision so it's directly unit-
+ * testable without dragging the whole FileViewer React tree into a
+ * jsdom harness.
+ */
+
+export interface UrlLoadDecision {
+  /** Whether the viewer is showing the rendered preview vs. the raw source. */
+  mode: 'preview' | 'source';
+  /** Treat as a slide deck — needs the deck postMessage bridge. */
+  isDeck: boolean;
+  /** Comment mode is active — needs the comment bridge. */
+  commentMode: boolean;
+  /** User explicitly opted into the inline path via ?forceInline=1. */
+  forceInline: boolean;
+}
+
+/**
+ * Returns true when an HTML file's preview iframe should load directly
+ * from its raw URL (via `<iframe src=...>`) rather than through the
+ * srcDoc inline path. Pure function — caller is responsible for the
+ * non-HTML / source-mode early returns.
+ */
+export function shouldUrlLoadHtmlPreview(d: UrlLoadDecision): boolean {
+  if (d.mode !== 'preview') return false;
+  if (d.isDeck) return false;
+  if (d.commentMode) return false;
+  if (d.forceInline) return false;
+  return true;
+}
+
+/**
+ * Read the `forceInline` opt-out from a URL search string or an existing
+ * URLSearchParams. Accepts `1`, `true`, `yes`, `on` (case-insensitive).
+ * Anything else — including `0`, `false`, an unrelated value, or a
+ * missing parameter — returns false.
+ */
+export function parseForceInline(search: string | URLSearchParams | null | undefined): boolean {
+  if (!search) return false;
+  const params = typeof search === 'string' ? new URLSearchParams(search) : search;
+  const value = params.get('forceInline');
+  if (value === null) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
+}


### PR DESCRIPTION
Part **1 of 2** for #368.

## Why

`FileViewer` currently inlines every relative `<link>` and `<script src>` of an HTML preview into a single `srcDoc`. That works for self-contained 1-file decks, but for multi-file projects (e.g. the AlphaTraceAI 50-file React + inline-Babel prototype that motivated #336/#368) it produces three structural problems even after the recent `$'`-safe replacer fix in PR #343:

1. **All-or-nothing failure.** A single fetch failure or HTML-parse-hostile character anywhere in the concatenated string kills the whole iframe.
2. **No source maps.** Every script appears as `Inline Babel script (n)` in DevTools — no filenames, no usable stack traces.
3. **Doubled bytes.** Every Open re-fetches and re-inlines the entire asset tree; per-asset HTTP caching does not apply.

The `Preview` pane already URL-loads via the daemon's `/raw/` endpoint and does not have these problems. This PR brings `FileViewer` in line.

## What

- `FileViewer.tsx` HTML previews now render with `<iframe src="/api/projects/:id/raw/:file?v=<mtime>&r=<reloadKey>" sandbox="allow-scripts">` by default.
- `?forceInline=1` query (on the host page) keeps the legacy inlined-`srcDoc` path. Decks (auto-detected by shape) and comment-mode also stay on `srcDoc` because they need host bridges injected by `buildSrcdoc` (postMessage, comment targeting, `localStorage` shim).
- Decision logic extracted to `apps/web/src/components/file-viewer-render-mode.ts` (`shouldUrlLoadHtmlPreview`, `parseForceInline`) — pure, unit-tested.
- Iframes carry `data-od-render-mode="url-load" | "srcdoc"` so the choice is visible in DevTools and assertable from tests.
- `inlineRelativeAssets` and the `$'`-safe replacer fix from PR #343 are preserved unchanged for the opt-in path.

## Out of scope (Part 2)

The `/api/projects/:id/export/:file?inline=1` daemon endpoint discussed in #368 Q3 will land in a follow-up PR. This PR keeps the legacy inliner inside `FileViewer.tsx` as the safety hatch so reviewers can validate the URL-load default in isolation.

## Tests

- 12 new unit tests in `apps/web/src/components/file-viewer-render-mode.test.ts` cover every branch of `shouldUrlLoadHtmlPreview` and `parseForceInline` (case-insensitive, whitespace-tolerant `1/true/yes/on`; rejects `0/false/no/off`/empty/garbage).
- 3 new integration tests in `apps/web/src/components/FileViewer.test.tsx` assert the rendered iframe carries the correct `data-od-render-mode` and `src` / `srcDoc` for plain HTML, declared-deck, and deck-shaped HTML.
- Full `apps/web` suite: **161/161 passing**.
- `tsc -b --noEmit` clean for `apps/web` and `apps/desktop`.

## Hand-validation in the live platform

Confirmed against the daemon at `127.0.0.1:44789`: opening an HTML file produces an iframe with `data-od-render-mode="url-load"`, real `src=`, no `srcDoc`, and `sandbox="allow-scripts"`. `?forceInline=1` opt-out flips it to the legacy `srcDoc` path with project still rendering.

Refs #368.