### PR TITLE
fix(web): normalize daemon proxy origins

### DIFF
--- a/apps/web/sidecar/server.ts
+++ b/apps/web/sidecar/server.ts
@@ -111,13 +111,40 @@ export function resolveDaemonProxyTarget(
   return new URL(`${parsedRequestUrl.pathname}${parsedRequestUrl.search}`, daemonOrigin);
 }
 
+export function normalizeDaemonProxyOriginHeader(options: {
+  daemonOrigin: string;
+  origin: string | undefined;
+  webPort: number;
+}): string | undefined {
+  if (options.origin == null || options.origin.length === 0) return options.origin;
+
+  const schemes = ["http", "https"];
+  const loopbackHosts = ["127.0.0.1", "localhost", "[::1]", HOST];
+  const allowedWebOrigins = new Set(
+    schemes.flatMap((scheme) => loopbackHosts.map((host) => `${scheme}://${host}:${options.webPort}`)),
+  );
+
+  return allowedWebOrigins.has(options.origin) ? options.daemonOrigin : options.origin;
+}
+
 async function proxyToDaemon(
   target: URL,
   request: IncomingMessage,
   response: ServerResponse,
+  webPort: number,
 ): Promise<void> {
   const proxyRequestFactory = target.protocol === "https:" ? createHttpsRequest : createHttpRequest;
   const headers = { ...request.headers, host: target.host };
+  const origin = normalizeDaemonProxyOriginHeader({
+    daemonOrigin: target.origin,
+    origin: typeof request.headers.origin === "string" ? request.headers.origin : undefined,
+    webPort,
+  });
+  if (origin == null || origin.length === 0) {
+    delete headers.origin;
+  } else {
+    headers.origin = origin;
+  }
 
   await new Promise<void>((resolveProxy) => {
     const proxyRequest = proxyRequestFactory(
@@ -233,10 +260,11 @@ export async function startWebSidecar(runtime: SidecarRuntimeContext<SidecarStam
 
   const daemonOrigin = resolveDaemonOrigin();
   const handleRequest = app.getRequestHandler();
+  let webPort = 0;
   const httpServer = createHttpServer((request, response) => {
     const daemonProxyTarget = daemonOrigin == null ? null : resolveDaemonProxyTarget(daemonOrigin, request.url);
     if (daemonProxyTarget != null) {
-      void proxyToDaemon(daemonProxyTarget, request, response).catch((error: unknown) => {
+      void proxyToDaemon(daemonProxyTarget, request, response, webPort).catch((error: unknown) => {
         response.statusCode = 502;
         response.end(error instanceof Error ? error.message : String(error));
       });
@@ -249,6 +277,7 @@ export async function startWebSidecar(runtime: SidecarRuntimeContext<SidecarStam
     });
   });
   const port = await listen(httpServer, parsePort(process.env[WEB_PORT_ENV]));
+  webPort = port;
   const state: WebStatusSnapshot = {
     pid: process.pid,
     state: "running",

--- a/apps/web/src/sidecar-proxy.test.ts
+++ b/apps/web/src/sidecar-proxy.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveDaemonProxyTarget } from '../sidecar/server';
+import {
+  normalizeDaemonProxyOriginHeader,
+  resolveDaemonProxyTarget,
+} from '../sidecar/server';
 
 describe('resolveDaemonProxyTarget', () => {
   it('proxies allowlisted relative paths to the daemon origin', () => {
@@ -20,5 +23,54 @@ describe('resolveDaemonProxyTarget', () => {
 
   it('rejects non-daemon paths', () => {
     expect(resolveDaemonProxyTarget('http://127.0.0.1:7456', '/settings')).toBeNull();
+  });
+});
+
+describe('normalizeDaemonProxyOriginHeader', () => {
+  it('normalizes the current web origin to the daemon origin', () => {
+    expect(
+      normalizeDaemonProxyOriginHeader({
+        daemonOrigin: 'http://127.0.0.1:7456',
+        origin: 'http://127.0.0.1:3000',
+        webPort: 3000,
+      }),
+    ).toBe('http://127.0.0.1:7456');
+  });
+
+  it('accepts localhost as an equivalent loopback web origin', () => {
+    expect(
+      normalizeDaemonProxyOriginHeader({
+        daemonOrigin: 'http://127.0.0.1:7456',
+        origin: 'http://localhost:3000',
+        webPort: 3000,
+      }),
+    ).toBe('http://127.0.0.1:7456');
+  });
+
+  it('does not rewrite unrelated browser origins', () => {
+    expect(
+      normalizeDaemonProxyOriginHeader({
+        daemonOrigin: 'http://127.0.0.1:7456',
+        origin: 'https://example.com',
+        webPort: 3000,
+      }),
+    ).toBe('https://example.com');
+  });
+
+  it('preserves absent and null origins for daemon policy to handle', () => {
+    expect(
+      normalizeDaemonProxyOriginHeader({
+        daemonOrigin: 'http://127.0.0.1:7456',
+        origin: undefined,
+        webPort: 3000,
+      }),
+    ).toBeUndefined();
+    expect(
+      normalizeDaemonProxyOriginHeader({
+        daemonOrigin: 'http://127.0.0.1:7456',
+        origin: 'null',
+        webPort: 3000,
+      }),
+    ).toBe('null');
   });
 });

--- a/tools/dev/src/index.ts
+++ b/tools/dev/src/index.ts
@@ -404,15 +404,18 @@ async function spawnSidecarRuntime(request: {
 
 async function spawnDaemonRuntime(config: ToolDevConfig, options: CliOptions): Promise<{ pid: number }> {
   const daemonPort = parsePortOption(options.daemonPort, "--daemon-port");
+  const webPort = parsePortOption(options.webPort, "--web-port");
   const logHandle = await openAppLog(config, APP_KEYS.DAEMON);
 
   try {
     await logHandle.write(`\n[tools-dev] launching daemon at ${new Date().toISOString()}\n`);
+    if (webPort != null) await logHandle.write(`[tools-dev] trusting web origin port ${webPort}\n`);
     return await spawnSidecarRuntime({
       appName: APP_KEYS.DAEMON,
       config,
       env: {
         [SIDECAR_ENV.DAEMON_PORT]: String(daemonPort ?? 0),
+        ...(webPort == null ? {} : { [SIDECAR_ENV.WEB_PORT]: String(webPort) }),
         ...(options.parentPid == null ? {} : { [TOOLS_DEV_PARENT_PID_ENV]: String(options.parentPid) }),
       },
       logHandle,


### PR DESCRIPTION
## Summary
- remove the auto web-port preallocation path called out in review, avoiding TOCTOU and idempotent start/restart regressions
- normalize same-origin web sidecar proxy requests so daemon receives its own origin while unrelated browser origins are still forwarded and rejected by daemon policy
- keep explicit --web-port support by passing OD_WEB_PORT to daemon when the user pins a web port
- add web sidecar proxy origin normalization tests

Fixes #388

## Verification
- pnpm --filter @open-design/tools-dev typecheck
- pnpm --filter @open-design/tools-dev test
- pnpm --filter @open-design/tools-dev build
- pnpm --filter @open-design/web typecheck
- pnpm --filter @open-design/web test
- pnpm --filter @open-design/packaged typecheck
- pnpm --filter @open-design/packaged build
- pnpm tools-dev start web --namespace issue-388-review --daemon-port 17459 --json
- repeated pnpm tools-dev start web --namespace issue-388-review --daemon-port 17459 --json returned created:false for daemon/web
- curl POST via web origin http://127.0.0.1:64944/api/projects with Origin http://127.0.0.1:64944 returned 200
- curl POST via same web URL with Origin https://example.com returned 403
- pnpm tools-dev run web --namespace issue-388-run-review --daemon-port 17460
- curl POST via run web origin http://127.0.0.1:65101/api/projects with Origin http://127.0.0.1:65101 returned 200
- curl POST via same run web URL with Origin https://example.com returned 403
- pnpm test
- pnpm typecheck

Note: validation ran under Node v22.22.0 in this shell, so pnpm emitted engine warnings for packages that declare node ~24.