### PR TITLE
fix(daemon): strip ANTHROPIC_API_KEY when spawning Claude Code

### DIFF
--- a/apps/daemon/src/agents.ts
+++ b/apps/daemon/src/agents.ts
@@ -813,6 +813,28 @@ export function resolveAgentBin(id) {
   return resolveAgentExecutable(def);
 }
 
+// Build the env passed to spawn() for a given agent adapter.
+//
+// The claude adapter strips ANTHROPIC_API_KEY so Claude Code's own auth
+// resolution (claude login / Pro/Max plan) wins instead of silently
+// falling back to API-key billing whenever the daemon happened to be
+// launched from a shell that exported the key for SDK or scripting use.
+// See issue #398.
+//
+// Windows env-var names are case-insensitive at the kernel level
+// (`GetEnvironmentVariable`), but spreading `process.env` into a plain
+// object loses Node's case-insensitive accessor — `Anthropic_Api_Key`
+// would survive a literal `delete env.ANTHROPIC_API_KEY` and still reach
+// the child. Iterate keys and compare case-insensitively to close that.
+export function spawnEnvForAgent(agentId, baseEnv) {
+  const env = { ...baseEnv };
+  if (agentId !== 'claude') return env;
+  for (const key of Object.keys(env)) {
+    if (key.toUpperCase() === 'ANTHROPIC_API_KEY') delete env[key];
+  }
+  return env;
+}
+
 // Daemon's /api/chat needs to validate the user's model pick against the
 // list we last surfaced to the UI. We keep a per-agent cache of the most
 // recent live list (refreshed every detectAgents() call) and additionally

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -2439,6 +2439,17 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
           ? 'pipe'
           : 'ignore';
       const env = { ...process.env, ...odMediaEnv };
+      // Claude Code prefers ANTHROPIC_API_KEY over the user's logged-in
+      // subscription auth when both are present, silently billing API
+      // usage even though the daemon's "Local CLI" mode implies the user
+      // wants their `claude login` credentials (Pro/Max plan) to win. If
+      // the launching shell exported ANTHROPIC_API_KEY for any other
+      // reason (SDK work, scripts), the spawn would inherit it. Strip it
+      // for the claude adapter so the CLI's own auth resolution applies.
+      // See https://github.com/nexu-io/open-design/issues/398
+      if (def.id === 'claude') {
+        delete env.ANTHROPIC_API_KEY;
+      }
       const invocation = createCommandInvocation({
         command: resolvedBin,
         args,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -15,6 +15,7 @@ import {
   isKnownModel,
   resolveAgentBin,
   sanitizeCustomModel,
+  spawnEnvForAgent,
 } from './agents.js';
 import { listSkills } from './skills.js';
 import { listCodexPets, readCodexPetSpritesheet } from './codex-pets.js';
@@ -2438,18 +2439,7 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
         def.promptViaStdin || def.streamFormat === 'acp-json-rpc'
           ? 'pipe'
           : 'ignore';
-      const env = { ...process.env, ...odMediaEnv };
-      // Claude Code prefers ANTHROPIC_API_KEY over the user's logged-in
-      // subscription auth when both are present, silently billing API
-      // usage even though the daemon's "Local CLI" mode implies the user
-      // wants their `claude login` credentials (Pro/Max plan) to win. If
-      // the launching shell exported ANTHROPIC_API_KEY for any other
-      // reason (SDK work, scripts), the spawn would inherit it. Strip it
-      // for the claude adapter so the CLI's own auth resolution applies.
-      // See https://github.com/nexu-io/open-design/issues/398
-      if (def.id === 'claude') {
-        delete env.ANTHROPIC_API_KEY;
-      }
+      const env = spawnEnvForAgent(def.id, { ...process.env, ...odMediaEnv });
       const invocation = createCommandInvocation({
         command: resolvedBin,
         args,

--- a/apps/daemon/tests/agents.test.ts
+++ b/apps/daemon/tests/agents.test.ts
@@ -4,7 +4,11 @@ import assert from 'node:assert/strict';
 import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { AGENT_DEFS, resolveAgentExecutable } from '../src/agents.js';
+import {
+  AGENT_DEFS,
+  resolveAgentExecutable,
+  spawnEnvForAgent,
+} from '../src/agents.js';
 
 const codex = AGENT_DEFS.find((agent) => agent.id === 'codex');
 const copilot = AGENT_DEFS.find((agent) => agent.id === 'copilot');
@@ -400,4 +404,59 @@ test('vibe fetchModels falls back to fallbackModels when detection fails', async
   assert.equal(result, null);
   assert.ok(Array.isArray(vibe.fallbackModels));
   assert.equal(vibe.fallbackModels[0].id, 'default');
+});
+
+// Issue #398: Claude Code prefers ANTHROPIC_API_KEY over `claude login`
+// credentials, silently billing API usage. Strip it for the claude
+// adapter so the user's subscription wins.
+test('spawnEnvForAgent strips ANTHROPIC_API_KEY for the claude adapter', () => {
+  const env = spawnEnvForAgent('claude', {
+    ANTHROPIC_API_KEY: 'sk-leak',
+    PATH: '/usr/bin',
+    OD_DAEMON_URL: 'http://127.0.0.1:7456',
+  });
+
+  assert.equal('ANTHROPIC_API_KEY' in env, false);
+  assert.equal(env.PATH, '/usr/bin');
+  assert.equal(env.OD_DAEMON_URL, 'http://127.0.0.1:7456');
+});
+
+// Windows env-var names are case-insensitive at the kernel level, but
+// spreading process.env into a plain object loses Node's case-insensitive
+// accessor — a `Anthropic_Api_Key` key would survive a literal
+// `delete env.ANTHROPIC_API_KEY` and still reach Claude Code on Windows.
+test('spawnEnvForAgent strips ANTHROPIC_API_KEY case-insensitively for the claude adapter', () => {
+  const env = spawnEnvForAgent('claude', {
+    Anthropic_Api_Key: 'sk-mixed-case',
+    anthropic_api_key: 'sk-lower-case',
+    PATH: '/usr/bin',
+  });
+
+  const remaining = Object.keys(env).filter(
+    (k) => k.toUpperCase() === 'ANTHROPIC_API_KEY',
+  );
+  assert.deepEqual(remaining, []);
+  assert.equal(env.PATH, '/usr/bin');
+});
+
+test('spawnEnvForAgent preserves ANTHROPIC_API_KEY for non-claude adapters', () => {
+  for (const agentId of ['codex', 'gemini', 'opencode', 'devin']) {
+    const env = spawnEnvForAgent(agentId, {
+      ANTHROPIC_API_KEY: 'sk-keep',
+      PATH: '/usr/bin',
+    });
+    assert.equal(
+      env.ANTHROPIC_API_KEY,
+      'sk-keep',
+      `expected ${agentId} to preserve ANTHROPIC_API_KEY`,
+    );
+  }
+});
+
+test('spawnEnvForAgent does not mutate the input env', () => {
+  const original = { ANTHROPIC_API_KEY: 'sk-leak', PATH: '/usr/bin' };
+  const env = spawnEnvForAgent('claude', original);
+
+  assert.equal(original.ANTHROPIC_API_KEY, 'sk-leak');
+  assert.notEqual(env, original);
 });


### PR DESCRIPTION
## Summary

- Fixes #398 — when the daemon spawns Claude Code, it inherits `ANTHROPIC_API_KEY` from the launching shell. Claude Code's [documented behavior](https://support.claude.com/en/articles/11145838-using-claude-code-with-your-pro-or-max-plan) is to prefer that env var over the user's `claude login` subscription credentials, so users on Pro/Max who selected "Local CLI" silently got billed against their API key instead.
- Strip `ANTHROPIC_API_KEY` from the env passed to `spawn` for the `claude` adapter only, so Claude Code's own auth resolution applies. Other adapters (which may legitimately use the var, e.g. when routing through Anthropic) are unaffected.

## Test plan

- [x] `pnpm --filter @open-design/daemon typecheck`
- [x] `pnpm --filter @open-design/daemon test` (342 tests pass)
- [x] `pnpm test` (full workspace) passes
- [x] `pnpm check:residual-js` passes
- [ ] Manual: with `ANTHROPIC_API_KEY` exported in the shell that launches the daemon, run a Claude Code chat and confirm the request hits the subscription rather than the API key (visible in Anthropic billing dashboard / `claude` debug logs)