### PR TITLE
fix(daemon): support nested paths in project file serve route

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1781,12 +1781,12 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
     }
   });
 
-  app.get('/api/projects/:id/files/:name', async (req, res) => {
+  app.get('/api/projects/:id/files/*', async (req, res) => {
     try {
       const file = await readProjectFile(
         PROJECTS_DIR,
         req.params.id,
-        req.params.name,
+        req.params[0],
       );
       res.type(file.mime).send(file.buffer);
     } catch (err) {


### PR DESCRIPTION
## Problem

When opening an HTML project file as a standalone preview (via `/api/projects/:id/files/<name>`), assets stored in subdirectories — such as `assets/logo-mark.svg` or `fonts/Aeroport.woff2` — failed to load with 404 errors.

The root cause: the Express route `/api/projects/:id/files/:name` uses a named parameter that does not match path separators (`/`), so any file with a subdirectory prefix was never matched.

## Fix

Change the route from a named param to a wildcard and read `req.params[0]` to capture the full relative path including subdirectories.

```diff
- app.get('/api/projects/:id/files/:name', async (req, res) => {
+ app.get('/api/projects/:id/files/*', async (req, res) => {
     const file = await readProjectFile(
       PROJECTS_DIR,
       req.params.id,
-      req.params.name,
+      req.params[0],
     );
```

The more-specific `/preview` sub-route registered above is unaffected.

## Test

1. Upload an HTML file that references assets in subdirectories (`assets/`, `fonts/`, etc.)
2. Open `GET /api/projects/:id/files/<file>.html` directly in a browser
3. Assets and fonts now load correctly (previously 404)