### PR TITLE
docs(i18n): defer README template-driven generation, capture #195 discussion

### DIFF
--- a/TRANSLATIONS.md
+++ b/TRANSLATIONS.md
@@ -211,6 +211,17 @@ on them now, with rough triggers for revisiting:
 - **Translation memory tooling** (Crowdin / Weblate / Lingui). Re-evaluate
   once the project hits ~12-15 active locales **or** when contributors
   start visibly duplicating effort across PRs.
+- **README template-driven generation** (e.g. [NRG](https://github.com/nanolaba/readme-generator),
+  custom `.src.md` build scripts, All Contributors-style tooling).
+  Re-evaluate once the project hits ≥15 locales **or** README structural
+  edits become more frequent than monthly. Discussion in
+  [#195](https://github.com/nexu-io/open-design/issues/195): template-driven
+  generation solves the "update line 27 in 10 README variants" brittleness,
+  but forces a shared structure that today's locale variants intentionally
+  diverge from (e.g. `README.zh-TW.md`'s "上手體驗" section, the pt-BR /
+  pt-PT precedent for content-level — not just translation-level —
+  differences). Worth revisiting once locale voice is more settled or
+  the manual-update cost grows.
 
 ## Open questions
 


### PR DESCRIPTION
Follow-up to #196 / discussion in #195. After PR #196 landed, @andriishin pointed out [NRG](https://github.com/nanolaba/readme-generator) (single `.src.md` template → multi-locale `README.<lang>.md`) as a fix for the atomic-update brittleness called out in TRANSLATIONS.md step 7. @lefarcen analyzed the fit and we agreed the right move is **document-and-defer** rather than fold tooling into the docs RFC.

This PR captures that decision in `TRANSLATIONS.md` so future contributors don't relitigate it from scratch.

## What changes

A single bullet under **Deferred decisions** — parallel in shape to the existing Translation memory tooling entry:

- Lists multiple options (NRG, custom `.src.md` scripts, All Contributors-style) so we don't lock into one tool prematurely.
- Trigger conditions: **≥15 locales** OR **README structural edits more frequent than monthly**.
- Records the core trade-off from the #195 thread: template-driven generation solves the "update line 27 in 10 README variants" brittleness but forces a shared structure that today's locale variants intentionally diverge from (e.g. `README.zh-TW.md`'s "上手體驗" section, the pt-BR / pt-PT content-level precedent).

## Why "Deferred" not "Open question"

The existing **Open questions** section is for genuinely undecided items. NRG-class tooling has been actively discussed in #195 and the team agreed to defer with explicit triggers — that's the same shape as the TM-tooling entry already living under **Deferred decisions**.

## Out of scope

A separate tracking issue (\"Evaluate template-driven README generation\") will collect NRG + alternatives and link back here. That's a separate, smaller change that doesn't need to ride with this docs update.

## Test plan

- [ ] Render `TRANSLATIONS.md` on GitHub; confirm the new bullet renders alongside the TM-tooling bullet under Deferred decisions.
- [ ] Confirm the #195 link resolves to the NRG discussion thread.