### PR TITLE
fix(pack): bundle prompt templates in packaged resources

### DIFF
--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -25,7 +25,7 @@ import {
 } from "@open-design/platform";
 
 import type { ToolPackConfig } from "./config.js";
-import { linuxResources } from "./resources.js";
+import { copyBundledResourceTrees, linuxResources } from "./resources.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -318,10 +318,10 @@ async function collectWorkspaceTarballs(
 async function copyResourceTree(config: ToolPackConfig, paths: LinuxPaths): Promise<void> {
   await rm(paths.resourceRoot, { force: true, recursive: true });
   await mkdir(paths.resourceRoot, { recursive: true });
-  await cp(join(config.workspaceRoot, "skills"), join(paths.resourceRoot, "skills"), { recursive: true });
-  await cp(join(config.workspaceRoot, "design-systems"), join(paths.resourceRoot, "design-systems"), { recursive: true });
-  await cp(join(config.workspaceRoot, "craft"), join(paths.resourceRoot, "craft"), { recursive: true });
-  await cp(join(config.workspaceRoot, "assets", "frames"), join(paths.resourceRoot, "frames"), { recursive: true });
+  await copyBundledResourceTrees({
+    workspaceRoot: config.workspaceRoot,
+    resourceRoot: paths.resourceRoot,
+  });
   await mkdir(join(paths.resourceRoot, "bin"), { recursive: true });
   await cp(process.execPath, join(paths.resourceRoot, "bin", "node"));
   await chmod(join(paths.resourceRoot, "bin", "node"), 0o755);

--- a/tools/pack/src/mac.ts
+++ b/tools/pack/src/mac.ts
@@ -27,7 +27,7 @@ import {
 } from "@open-design/platform";
 
 import type { ToolPackBuildOutput, ToolPackConfig } from "./config.js";
-import { macResources } from "./resources.js";
+import { copyBundledResourceTrees, macResources } from "./resources.js";
 
 const execFileAsync = promisify(execFile);
 const PRODUCT_NAME = "Open Design";
@@ -263,17 +263,9 @@ async function copyResourceTree(config: ToolPackConfig, paths: MacPaths): Promis
   await rm(paths.resourceRoot, { force: true, recursive: true });
   await mkdir(paths.resourceRoot, { recursive: true });
 
-  await cp(join(config.workspaceRoot, "skills"), join(paths.resourceRoot, "skills"), {
-    recursive: true,
-  });
-  await cp(join(config.workspaceRoot, "design-systems"), join(paths.resourceRoot, "design-systems"), {
-    recursive: true,
-  });
-  await cp(join(config.workspaceRoot, "craft"), join(paths.resourceRoot, "craft"), {
-    recursive: true,
-  });
-  await cp(join(config.workspaceRoot, "assets", "frames"), join(paths.resourceRoot, "frames"), {
-    recursive: true,
+  await copyBundledResourceTrees({
+    workspaceRoot: config.workspaceRoot,
+    resourceRoot: paths.resourceRoot,
   });
   await mkdir(join(paths.resourceRoot, "bin"), { recursive: true });
   await cp(process.execPath, join(paths.resourceRoot, "bin", "node"));

--- a/tools/pack/src/resources.test.ts
+++ b/tools/pack/src/resources.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp, readFile, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { copyBundledResourceTrees } from "./resources.js";
+
+describe("copyBundledResourceTrees", () => {
+  it("includes prompt templates", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-tools-pack-"));
+    const workspaceRoot = join(root, "workspace");
+    const resourceRoot = join(root, "resources");
+
+    try {
+      const promptTemplatePath = join(
+        workspaceRoot,
+        "prompt-templates",
+        "image",
+        "sample.json",
+      );
+      const communityPetPath = join(
+        workspaceRoot,
+        "assets",
+        "community-pets",
+        "sample",
+        "pet.json",
+      );
+      await mkdir(join(workspaceRoot, "skills", "sample"), { recursive: true });
+      await mkdir(join(workspaceRoot, "design-systems", "sample"), {
+        recursive: true,
+      });
+      await mkdir(join(workspaceRoot, "craft", "sample"), { recursive: true });
+      await mkdir(join(workspaceRoot, "assets", "frames"), { recursive: true });
+      await mkdir(join(workspaceRoot, "assets", "community-pets", "sample"), {
+        recursive: true,
+      });
+      await mkdir(join(workspaceRoot, "prompt-templates", "image"), {
+        recursive: true,
+      });
+      await writeFile(promptTemplatePath, "{\"id\":\"sample\"}\n", "utf8");
+      await writeFile(communityPetPath, "{\"name\":\"sample\"}\n", "utf8");
+
+      await copyBundledResourceTrees({ workspaceRoot, resourceRoot });
+
+      await expect(
+        readFile(
+          join(resourceRoot, "prompt-templates", "image", "sample.json"),
+          "utf8",
+        ),
+      ).resolves.toBe("{\"id\":\"sample\"}\n");
+      await expect(
+        readFile(
+          join(resourceRoot, "community-pets", "sample", "pet.json"),
+          "utf8",
+        ),
+      ).resolves.toBe("{\"name\":\"sample\"}\n");
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});

--- a/tools/pack/src/resources.ts
+++ b/tools/pack/src/resources.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import { cp } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -44,3 +45,26 @@ export const linuxResources = {
   icon: join(resourcesRoot, "linux", "icon.png"),
   desktopTemplate: join(resourcesRoot, "linux", "open-design.desktop.template"),
 } as const;
+
+const BUNDLED_RESOURCE_TREES = [
+  { from: "skills", to: "skills" },
+  { from: "design-systems", to: "design-systems" },
+  { from: "craft", to: "craft" },
+  { from: join("assets", "frames"), to: "frames" },
+  { from: join("assets", "community-pets"), to: "community-pets" },
+  { from: "prompt-templates", to: "prompt-templates" },
+] as const;
+
+export async function copyBundledResourceTrees({
+  workspaceRoot,
+  resourceRoot,
+}: {
+  workspaceRoot: string;
+  resourceRoot: string;
+}): Promise<void> {
+  for (const entry of BUNDLED_RESOURCE_TREES) {
+    await cp(join(workspaceRoot, entry.from), join(resourceRoot, entry.to), {
+      recursive: true,
+    });
+  }
+}

--- a/tools/pack/src/win.ts
+++ b/tools/pack/src/win.ts
@@ -30,7 +30,7 @@ import {
 } from "@open-design/platform";
 
 import type { ToolPackConfig } from "./config.js";
-import { winResources } from "./resources.js";
+import { copyBundledResourceTrees, winResources } from "./resources.js";
 
 const execFileAsync = promisify(execFile);
 const PRODUCT_NAME = "Open Design";
@@ -627,9 +627,10 @@ async function buildWorkspaceArtifacts(config: ToolPackConfig): Promise<void> {
 async function copyResourceTree(config: ToolPackConfig, paths: WinPaths): Promise<void> {
   await removeTree(paths.resourceRoot);
   await mkdir(paths.resourceRoot, { recursive: true });
-  await cp(join(config.workspaceRoot, "skills"), join(paths.resourceRoot, "skills"), { recursive: true });
-  await cp(join(config.workspaceRoot, "design-systems"), join(paths.resourceRoot, "design-systems"), { recursive: true });
-  await cp(join(config.workspaceRoot, "assets", "frames"), join(paths.resourceRoot, "frames"), { recursive: true });
+  await copyBundledResourceTrees({
+    workspaceRoot: config.workspaceRoot,
+    resourceRoot: paths.resourceRoot,
+  });
   await mkdir(join(paths.resourceRoot, "bin"), { recursive: true });
   await cp(process.execPath, join(paths.resourceRoot, "bin", "node.exe"));
   await chmod(join(paths.resourceRoot, "bin", "node.exe"), 0o755).catch(() => undefined);


### PR DESCRIPTION
## Summary

- add a shared tools-pack helper for copying bundled resource trees
- include `prompt-templates/` in packaged resources so image/video template tabs are populated
- use the shared resource copy path for Windows, macOS, and Linux packaged builds
- add a regression test that verifies prompt templates are copied

Fixes #416.

## Verification

- `pnpm install`
- `pnpm --filter @open-design/tools-pack exec vitest run src/resources.test.ts`
- `pnpm --filter @open-design/tools-pack typecheck`
- `pnpm --filter @open-design/tools-pack build`

Note: `pnpm --filter @open-design/tools-pack test` currently fails in the existing `src/linux.test.ts` Docker mount assertion on this Windows environment. The new `src/resources.test.ts` passes, and the failure is unrelated to this resource-copy change.