### PR TITLE
fix(landing-page): deploy wrangler with npm

### DIFF
--- a/.github/workflows/landing-page-deploy.yml
+++ b/.github/workflows/landing-page-deploy.yml
@@ -86,10 +86,13 @@ jobs:
           NODE
 
       - name: Deploy to Cloudflare Pages
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: >
-          pnpm dlx wrangler@3.90.0 pages deploy apps/landing-page/out
-          --project-name=open-design-landing
-          --branch=${{ github.ref_name }}
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: apps/landing-page
+          packageManager: npm
+          command: >
+            pages deploy out
+            --project-name=open-design-landing
+            --branch=${{ github.ref_name }}

--- a/.github/workflows/landing-page-deploy.yml
+++ b/.github/workflows/landing-page-deploy.yml
@@ -86,12 +86,10 @@ jobs:
           NODE
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          packageManager: npm
-          command: >
-            pages deploy apps/landing-page/out
-            --project-name=open-design-landing
-            --branch=${{ github.ref_name }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: >
+          pnpm dlx wrangler@3.90.0 pages deploy apps/landing-page/out
+          --project-name=open-design-landing
+          --branch=${{ github.ref_name }}

--- a/.github/workflows/landing-page-deploy.yml
+++ b/.github/workflows/landing-page-deploy.yml
@@ -90,6 +90,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          packageManager: npm
           command: >
             pages deploy apps/landing-page/out
             --project-name=open-design-landing


### PR DESCRIPTION
## Summary
- Configure the landing page deploy workflow to let wrangler-action install Wrangler with npm instead of pnpm.
- Avoid pnpm workspace-root add failures during Cloudflare Pages deploys.

## Validation
- pnpm --filter @open-design/landing-page typecheck
- pnpm --filter @open-design/landing-page build
- git diff --check