### PR TITLE
fix(desktop): cleanly quit macOS packaged app

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -103,6 +103,12 @@ export async function runDesktopMain(
 
   attachParentMonitor(shutdown);
 
+  app.on("before-quit", (event) => {
+    if (shuttingDown) return;
+    event.preventDefault();
+    void shutdown().finally(() => process.exit(0));
+  });
+
   ipcServer = await createJsonIpcServer({
     socketPath: runtime.ipc,
     handler: async (message: unknown) => {


### PR DESCRIPTION
## Problem

PR #270 intentionally makes the macOS red close button hide the window instead of destroying the app, which is the right Dock re-open behavior.

However, the same close handler can also intercept the real app quit path. In a packaged macOS app, using Quit / Cmd-Q can leave the Electron main process plus daemon/web sidecars alive, so the Dock still shows Open Design as running.

## Fix

- Handle Electron `before-quit` in desktop main.
- On the first real app quit, prevent the default quit and route through the existing unified `shutdown()` path.
- Once `shutdown()` calls `desktop.close()`, the runtime `stopped` flag allows the BrowserWindow close to proceed, and the existing `app.quit()` completes normally.

This keeps the PR #270 red-X behavior intact while making real Quit / Cmd-Q clean up the app.

## Test

- `pnpm install --frozen-lockfile`
- `pnpm --filter @open-design/desktop typecheck`

Local packaged verification in our macOS build:

- Build and install packaged app.
- Launch Open Design.
- Run `osascript -e 'tell application "Open Design" to quit'`.
- Verify `pgrep -fl 'Open Design|--od-stamp-namespace=release-stable'` returns no Open Design main/helper/sidecar processes.