### PR TITLE
fix(web): remove same-origin from preview modal sandbox

### DIFF
--- a/apps/web/src/components/PreviewModal.test.tsx
+++ b/apps/web/src/components/PreviewModal.test.tsx
@@ -1,0 +1,20 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { PreviewModal } from './PreviewModal';
+
+describe('PreviewModal iframe sandbox', () => {
+  it('keeps srcDoc previews script-capable without same-origin access', () => {
+    const markup = renderToStaticMarkup(
+      <PreviewModal
+        title="Design system"
+        views={[{ id: 'showcase', label: 'Showcase', html: '<html><body>Preview</body></html>' }]}
+        exportTitleFor={() => 'showcase'}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(markup).toContain('sandbox="allow-scripts"');
+    expect(markup).not.toContain('allow-same-origin');
+  });
+});

--- a/apps/web/src/components/PreviewModal.tsx
+++ b/apps/web/src/components/PreviewModal.tsx
@@ -388,7 +388,7 @@ export function PreviewModal({
                 <iframe
                   key={activeView?.id ?? 'view'}
                   title={`${title} ${activeView?.label ?? ''}`}
-                  sandbox="allow-scripts allow-same-origin"
+                  sandbox="allow-scripts"
                   srcDoc={srcDoc}
                 />
               </div>


### PR DESCRIPTION
## Summary
- Remove `allow-same-origin` from the `PreviewModal` `srcDoc` iframe sandbox.
- Add a regression test that keeps the preview modal sandbox at `allow-scripts` only.

## Why
Generated preview HTML should not run as same-origin with the host app. This aligns `PreviewModal` with the documented preview isolation model and the other iframe previews in the web app.

## Validation
- [x] `corepack pnpm --filter @open-design/web typecheck`
- [x] `corepack pnpm --filter @open-design/web test`