### PR TITLE
fix(web): isolate preview blob export paths

### DIFF
--- a/apps/web/src/components/ExamplesTab.tsx
+++ b/apps/web/src/components/ExamplesTab.tsx
@@ -330,6 +330,7 @@ export function ExamplesTab({ skills, onUsePrompt }: Props) {
               id: 'preview',
               label: t('examples.previewLabel'),
               html: previews[previewSkill.id],
+              deck: previewSkill.mode === 'deck',
             },
           ]}
           exportTitleFor={() => previewSkill.name}

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -23,6 +23,7 @@ import {
   exportProjectAsZip,
   exportReactComponentAsHtml,
   exportReactComponentAsZip,
+  openSandboxedPreviewInNewTab,
 } from '../runtime/exports';
 import { buildReactComponentSrcdoc } from '../runtime/react-component';
 import { buildSrcdoc } from '../runtime/srcdoc';
@@ -907,10 +908,11 @@ function HtmlViewer({
 
   function openInNewTab() {
     if (!source) return;
-    const blob = new Blob([source], { type: 'text/html' });
-    const url = URL.createObjectURL(blob);
-    window.open(url, '_blank', 'noopener,noreferrer');
-    setTimeout(() => URL.revokeObjectURL(url), 60_000);
+    openSandboxedPreviewInNewTab(source, exportTitle, {
+      deck: effectiveDeck,
+      baseHref: projectRawUrl(projectId, baseDirFor(file.name)),
+      initialSlideIndex: htmlPreviewSlideState.get(previewStateKey)?.active ?? 0,
+    });
   }
 
   // Snapshot this project as a reusable template. The daemon snapshots

--- a/apps/web/src/components/PreviewModal.test.tsx
+++ b/apps/web/src/components/PreviewModal.test.tsx
@@ -1,0 +1,49 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { PreviewModal } from './PreviewModal';
+
+describe('PreviewModal sandbox isolation', () => {
+  it('renders generated previews without same-origin sandbox access', () => {
+    const markup = renderToStaticMarkup(
+      <PreviewModal
+        title="Unsafe preview"
+        views={[
+          {
+            id: 'preview',
+            label: 'Preview',
+            html: '<script>window.parent.document.body.innerHTML="owned"</script>',
+          },
+        ]}
+        exportTitleFor={() => 'unsafe-preview'}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(markup).toContain('sandbox="allow-scripts"');
+    expect(markup).not.toContain('allow-same-origin');
+    expect(markup).toContain('srcDoc=');
+  });
+
+  it('keeps deck srcdoc handling for deck preview views', () => {
+    const markup = renderToStaticMarkup(
+      <PreviewModal
+        title="Deck preview"
+        views={[
+          {
+            id: 'deck',
+            label: 'Deck',
+            html: '<section class="slide">one</section><section class="slide">two</section>',
+            deck: true,
+          },
+        ]}
+        exportTitleFor={() => 'deck-preview'}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(markup).toContain('sandbox="allow-scripts"');
+    expect(markup).not.toContain('allow-same-origin');
+    expect(markup).toContain('od:slide');
+  });
+});

--- a/apps/web/src/components/PreviewModal.tsx
+++ b/apps/web/src/components/PreviewModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { useT } from '../i18n';
-import { exportAsHtml, exportAsPdf, exportAsZip } from '../runtime/exports';
+import { exportAsHtml, exportAsPdf, exportAsZip, openSandboxedPreviewInNewTab } from '../runtime/exports';
 import { buildSrcdoc } from '../runtime/srcdoc';
 
 export interface PreviewView {
@@ -223,10 +223,7 @@ export function PreviewModal({
 
   function openInNewTab() {
     if (!activeHtml) return;
-    const blob = new Blob([activeHtml], { type: 'text/html' });
-    const url = URL.createObjectURL(blob);
-    window.open(url, '_blank', 'noopener,noreferrer');
-    setTimeout(() => URL.revokeObjectURL(url), 60_000);
+    openSandboxedPreviewInNewTab(activeHtml, exportTitle);
   }
 
   function enterFullscreen() {
@@ -314,7 +311,7 @@ export function PreviewModal({
                     role="menuitem"
                     onClick={() => {
                       setShareOpen(false);
-                      if (activeHtml) exportAsPdf(activeHtml, exportTitle);
+                      if (activeHtml) exportAsPdf(activeHtml, exportTitle, { sandboxedPreview: true });
                     }}
                   >
                     <span className="share-menu-icon">📄</span>

--- a/apps/web/src/components/PreviewModal.tsx
+++ b/apps/web/src/components/PreviewModal.tsx
@@ -10,6 +10,9 @@ export interface PreviewView {
   // Undefined means "not yet requested" — parent should react to onView and
   // begin a fetch. Both states keep the iframe blank.
   html: string | null | undefined;
+  // Deck previews need deck-aware srcdoc/PDF handling so slide navigation and
+  // print-all-slides behavior survive the sandboxed export path.
+  deck?: boolean;
 }
 
 export interface PreviewSidebar {
@@ -197,9 +200,10 @@ export function PreviewModal({
 
   const activeView = views.find((v) => v.id === activeId) ?? views[0];
   const activeHtml = activeView?.html ?? null;
+  const activeDeck = activeView?.deck ?? false;
   const srcDoc = useMemo(
-    () => (activeHtml ? buildSrcdoc(activeHtml) : ''),
-    [activeHtml],
+    () => (activeHtml ? buildSrcdoc(activeHtml, { deck: activeDeck }) : ''),
+    [activeHtml, activeDeck],
   );
   const exportTitle = exportTitleFor(activeView?.id ?? '');
 
@@ -223,7 +227,7 @@ export function PreviewModal({
 
   function openInNewTab() {
     if (!activeHtml) return;
-    openSandboxedPreviewInNewTab(activeHtml, exportTitle);
+    openSandboxedPreviewInNewTab(activeHtml, exportTitle, { deck: activeDeck });
   }
 
   function enterFullscreen() {
@@ -311,7 +315,7 @@ export function PreviewModal({
                     role="menuitem"
                     onClick={() => {
                       setShareOpen(false);
-                      if (activeHtml) exportAsPdf(activeHtml, exportTitle, { sandboxedPreview: true });
+                      if (activeHtml) exportAsPdf(activeHtml, exportTitle, { deck: activeDeck });
                     }}
                   >
                     <span className="share-menu-icon">📄</span>
@@ -385,7 +389,7 @@ export function PreviewModal({
                 <iframe
                   key={activeView?.id ?? 'view'}
                   title={`${title} ${activeView?.label ?? ''}`}
-                  sandbox="allow-scripts allow-same-origin"
+                  sandbox="allow-scripts"
                   srcDoc={srcDoc}
                 />
               </div>

--- a/apps/web/src/runtime/exports.test.ts
+++ b/apps/web/src/runtime/exports.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { archiveFilenameFrom, archiveRootFromFilePath, exportAsMd } from './exports';
+import {
+  archiveFilenameFrom,
+  archiveRootFromFilePath,
+  buildSandboxedPreviewDocument,
+  exportAsMd,
+  exportAsPdf,
+  openSandboxedPreviewInNewTab,
+} from './exports';
 
 function mockResponse(headers: Record<string, string>): Response {
   return { headers: new Headers(headers) } as Response;
@@ -132,5 +139,68 @@ describe('exportAsMd', () => {
     exportAsMd(source, 'mixed');
 
     expect(await capturedBlob!.text()).toBe(source);
+  });
+});
+
+describe('sandboxed preview Blob exports', () => {
+  let capturedBlob: Blob | undefined;
+  let openedFeatures: string | undefined;
+
+  beforeEach(() => {
+    capturedBlob = undefined;
+    openedFeatures = undefined;
+    vi.stubGlobal('URL', {
+      createObjectURL: (blob: Blob) => {
+        capturedBlob = blob;
+        return 'blob:test';
+      },
+      revokeObjectURL: () => {},
+    });
+    vi.stubGlobal('window', {
+      open: (_url: string, _target: string, features?: string) => {
+        openedFeatures = features;
+        return null;
+      },
+      addEventListener: () => {},
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('wraps generated HTML in an opaque-origin sandbox for new-tab previews', async () => {
+    openSandboxedPreviewInNewTab('<script>window.parent.localStorage.clear()</script>', 'Unsafe preview');
+
+    expect(openedFeatures).toBe('noopener,noreferrer');
+    expect(capturedBlob).toBeDefined();
+    const wrapper = await capturedBlob!.text();
+    expect(wrapper).toContain('sandbox="allow-scripts"');
+    expect(wrapper).not.toContain('allow-same-origin');
+    expect(wrapper).toContain('&lt;script&gt;window.parent.localStorage.clear()&lt;/script&gt;');
+    expect(wrapper).not.toContain('<script>window.parent.localStorage.clear()</script>');
+  });
+
+  it('can build a print wrapper without granting same-origin access', () => {
+    const wrapper = buildSandboxedPreviewDocument('<!doctype html><title>x</title>', 'Print', {
+      allowModals: true,
+    });
+
+    expect(wrapper).toContain('sandbox="allow-scripts allow-modals"');
+    expect(wrapper).not.toContain('allow-same-origin');
+  });
+
+  it('uses a sandboxed noopener Blob wrapper for PreviewModal PDF exports', async () => {
+    exportAsPdf('<script>window.parent.document.body.innerHTML="owned"</script>', 'PDF', {
+      sandboxedPreview: true,
+    });
+
+    expect(openedFeatures).toBe('noopener,noreferrer');
+    expect(capturedBlob).toBeDefined();
+    const wrapper = await capturedBlob!.text();
+    expect(wrapper).toContain('sandbox="allow-scripts allow-modals"');
+    expect(wrapper).not.toContain('allow-same-origin');
+    expect(wrapper).toContain('&lt;script&gt;window.parent.document.body.innerHTML=&quot;owned&quot;&lt;/script&gt;');
+    expect(wrapper).not.toContain('<script>window.parent.document.body.innerHTML="owned"</script>');
   });
 });

--- a/apps/web/src/runtime/exports.test.ts
+++ b/apps/web/src/runtime/exports.test.ts
@@ -181,6 +181,22 @@ describe('sandboxed preview Blob exports', () => {
     expect(wrapper).not.toContain('<script>window.parent.localStorage.clear()</script>');
   });
 
+  it('passes srcdoc options through the sandboxed new-tab wrapper', async () => {
+    openSandboxedPreviewInNewTab('<section class="slide">One</section>', 'Deck preview', {
+      deck: true,
+      baseHref: '/artifacts/project/assets/',
+      initialSlideIndex: 2,
+    });
+
+    expect(openedFeatures).toBe('noopener,noreferrer');
+    expect(capturedBlob).toBeDefined();
+    const wrapper = await capturedBlob!.text();
+    expect(wrapper).toContain('sandbox="allow-scripts"');
+    expect(wrapper).not.toContain('allow-same-origin');
+    expect(wrapper).toContain('&lt;base href=&quot;/artifacts/project/assets/&quot;&gt;');
+    expect(wrapper).toContain('od:slide');
+  });
+
   it('can build a print wrapper without granting same-origin access', () => {
     const wrapper = buildSandboxedPreviewDocument('<!doctype html><title>x</title>', 'Print', {
       allowModals: true,
@@ -190,10 +206,8 @@ describe('sandboxed preview Blob exports', () => {
     expect(wrapper).not.toContain('allow-same-origin');
   });
 
-  it('uses a sandboxed noopener Blob wrapper for PreviewModal PDF exports', async () => {
-    exportAsPdf('<script>window.parent.document.body.innerHTML="owned"</script>', 'PDF', {
-      sandboxedPreview: true,
-    });
+  it('uses a sandboxed noopener Blob wrapper by default for PDF exports', async () => {
+    exportAsPdf('<script>window.parent.document.body.innerHTML="owned"</script>', 'PDF');
 
     expect(openedFeatures).toBe('noopener,noreferrer');
     expect(capturedBlob).toBeDefined();
@@ -202,5 +216,29 @@ describe('sandboxed preview Blob exports', () => {
     expect(wrapper).not.toContain('allow-same-origin');
     expect(wrapper).toContain('&lt;script&gt;window.parent.document.body.innerHTML=&quot;owned&quot;&lt;/script&gt;');
     expect(wrapper).not.toContain('<script>window.parent.document.body.innerHTML="owned"</script>');
+  });
+
+  it('preserves deck print handling inside sandboxed PDF exports', async () => {
+    exportAsPdf('<section class="slide">One</section>', 'Deck PDF', { deck: true });
+
+    expect(openedFeatures).toBe('noopener,noreferrer');
+    expect(capturedBlob).toBeDefined();
+    const wrapper = await capturedBlob!.text();
+    expect(wrapper).toContain('sandbox="allow-scripts allow-modals"');
+    expect(wrapper).not.toContain('allow-same-origin');
+    expect(wrapper).toContain('data-deck-print=&quot;injected&quot;');
+    expect(wrapper).toContain('page-break-after: always;');
+  });
+
+  it('allows explicit trusted PDF opt-out without changing the secure default', async () => {
+    exportAsPdf('<main>Trusted local document</main>', 'Trusted PDF', {
+      sandboxedPreview: false,
+    });
+
+    expect(openedFeatures).toBeUndefined();
+    expect(capturedBlob).toBeDefined();
+    const doc = await capturedBlob!.text();
+    expect(doc).not.toContain('sandbox="allow-scripts allow-modals"');
+    expect(doc).toContain('<main>Trusted local document</main>');
   });
 });

--- a/apps/web/src/runtime/exports.ts
+++ b/apps/web/src/runtime/exports.ts
@@ -12,7 +12,7 @@
 // PPTX export is fundamentally different — it asks the agent to convert the
 // artifact server-side, so it lives in ProjectView.tsx (not here).
 
-import { buildSrcdoc } from './srcdoc';
+import { buildSrcdoc, type SrcdocOptions } from './srcdoc';
 import { buildReactComponentSrcdoc } from './react-component';
 import { buildZip } from './zip';
 
@@ -193,8 +193,12 @@ export function buildSandboxedPreviewDocument(
 </html>`;
 }
 
-export function openSandboxedPreviewInNewTab(html: string, title: string): void {
-  const doc = buildSandboxedPreviewDocument(buildSrcdoc(html), title);
+export function openSandboxedPreviewInNewTab(
+  html: string,
+  title: string,
+  srcdocOptions?: SrcdocOptions,
+): void {
+  const doc = buildSandboxedPreviewDocument(buildSrcdoc(html, srcdocOptions), title);
   const blob = new Blob([doc], { type: 'text/html;charset=utf-8' });
   const url = URL.createObjectURL(blob);
   window.open(url, '_blank', 'noopener,noreferrer');
@@ -219,19 +223,20 @@ export function openSandboxedPreviewInNewTab(html: string, title: string): void 
 export function exportAsPdf(
   html: string,
   title: string,
-  opts?: { deck?: boolean; sandboxedPreview?: boolean },
+  opts?: SrcdocOptions & { sandboxedPreview?: boolean },
 ): void {
-  let doc = buildSrcdoc(html);
+  const sandboxedPreview = opts?.sandboxedPreview ?? true;
+  let doc = buildSrcdoc(html, opts);
   if (opts?.deck) doc = injectDeckPrintStylesheet(doc);
   doc = injectPrintScript(doc, title);
-  if (opts?.sandboxedPreview) {
+  if (sandboxedPreview) {
     // `allow-modals` is needed so the child can show the browser print dialog;
     // it still does not grant same-origin access to the generated document.
     doc = buildSandboxedPreviewDocument(doc, title, { allowModals: true });
   }
   const blob = new Blob([doc], { type: 'text/html;charset=utf-8' });
   const url = URL.createObjectURL(blob);
-  const win = window.open(url, '_blank', opts?.sandboxedPreview ? 'noopener,noreferrer' : undefined);
+  const win = window.open(url, '_blank', sandboxedPreview ? 'noopener,noreferrer' : undefined);
   if (!win) {
     // Popup blocked — at least the tab navigation may have happened above.
     // Nothing else we can do without a fresh user gesture.

--- a/apps/web/src/runtime/exports.ts
+++ b/apps/web/src/runtime/exports.ts
@@ -158,6 +158,49 @@ export function archiveFilenameFrom(resp: Response, fallbackTitle: string, root:
   return `${slug}.zip`;
 }
 
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+// Blob documents inherit the origin of the page that created them. For
+// generated preview HTML, opening the artifact itself as the top-level Blob
+// document would bypass the preview contract documented in
+// docs/architecture.md: the untrusted code must run in an iframe sandbox
+// without `allow-same-origin`. This wrapper is same-origin, but it contains no
+// generated script; the generated document lives in an opaque-origin child.
+export function buildSandboxedPreviewDocument(
+  doc: string,
+  title: string,
+  opts?: { allowModals?: boolean },
+): string {
+  const safeTitle = escapeHtmlAttribute(title || 'Preview');
+  const sandbox = opts?.allowModals ? 'allow-scripts allow-modals' : 'allow-scripts';
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${safeTitle}</title>
+  <style>html,body,iframe{margin:0;width:100%;height:100%;border:0}body{overflow:hidden;background:#fff}</style>
+</head>
+<body>
+  <iframe title="${safeTitle}" sandbox="${sandbox}" srcdoc="${escapeHtmlAttribute(doc)}"></iframe>
+</body>
+</html>`;
+}
+
+export function openSandboxedPreviewInNewTab(html: string, title: string): void {
+  const doc = buildSandboxedPreviewDocument(buildSrcdoc(html), title);
+  const blob = new Blob([doc], { type: 'text/html;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  window.open(url, '_blank', 'noopener,noreferrer');
+  setTimeout(() => URL.revokeObjectURL(url), 60_000);
+}
+
 // Open the artifact in a new tab via a Blob URL with a self-printing
 // script injected. Going through a Blob URL (rather than `window.open('')`
 // + `document.write`) avoids two failure modes we hit before:
@@ -176,14 +219,19 @@ export function archiveFilenameFrom(resp: Response, fallbackTitle: string, root:
 export function exportAsPdf(
   html: string,
   title: string,
-  opts?: { deck?: boolean },
+  opts?: { deck?: boolean; sandboxedPreview?: boolean },
 ): void {
   let doc = buildSrcdoc(html);
   if (opts?.deck) doc = injectDeckPrintStylesheet(doc);
   doc = injectPrintScript(doc, title);
+  if (opts?.sandboxedPreview) {
+    // `allow-modals` is needed so the child can show the browser print dialog;
+    // it still does not grant same-origin access to the generated document.
+    doc = buildSandboxedPreviewDocument(doc, title, { allowModals: true });
+  }
   const blob = new Blob([doc], { type: 'text/html;charset=utf-8' });
   const url = URL.createObjectURL(blob);
-  const win = window.open(url, '_blank');
+  const win = window.open(url, '_blank', opts?.sandboxedPreview ? 'noopener,noreferrer' : undefined);
   if (!win) {
     // Popup blocked — at least the tab navigation may have happened above.
     // Nothing else we can do without a fresh user gesture.

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -14,9 +14,16 @@
  *   { type: 'od:slide-state', active: number, count: number }
  * after every navigation so the host can render its own counter / dots.
  */
+export type SrcdocOptions = {
+  deck?: boolean;
+  baseHref?: string;
+  initialSlideIndex?: number;
+  commentBridge?: boolean;
+};
+
 export function buildSrcdoc(
   html: string,
-  options: { deck?: boolean; baseHref?: string; initialSlideIndex?: number; commentBridge?: boolean } = {}
+  options: SrcdocOptions = {}
 ): string {
   const head = html.trimStart().slice(0, 64).toLowerCase();
   const isFullDoc = head.startsWith("<!doctype") || head.startsWith("<html");


### PR DESCRIPTION
## Summary
- Wrap PreviewModal open-in-new-tab HTML in a static Blob document that hosts generated HTML inside a sandboxed iframe.
- Add a sandboxed PreviewModal PDF export path that uses `noopener,noreferrer` and keeps generated scripts out of the top-level Blob origin.
- Add regression coverage for the sandbox wrapper and PDF/new-tab Blob paths.

## Why
Generated preview HTML should not execute as the app-origin top-level Blob document. The wrapper keeps the top-level Blob static and places untrusted preview code in an opaque-origin iframe, matching the documented preview isolation model.

## Compatibility
Normal visual previews should keep working. Generated previews that intentionally depend on app-origin browser surfaces such as cookies, IndexedDB, real localStorage/sessionStorage, or credentialed `/api` fetches are blocked by design in the sandboxed child.

## Validation
- `corepack pnpm --filter @open-design/web typecheck`
- `corepack pnpm --filter @open-design/web test`

Follow-up to the Blob export/new-tab concern raised on #427.