### PR TITLE
Allow configured reverse proxy origins

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -3262,30 +3262,90 @@ export function isLocalSameOrigin(req, port) {
   return allowedOrigins.has(String(origin));
 }
 
-function readAllowedOriginsEnv() {
+let cachedAllowedOriginsRaw = null;
+let cachedAllowedOrigins = [];
+
+export function readAllowedOriginsEnv() {
   const raw = process.env.OD_ALLOWED_ORIGINS || '';
-  return raw
+  if (raw === cachedAllowedOriginsRaw) return cachedAllowedOrigins;
+
+  const origins = new Set();
+  for (const entry of raw
     .split(',')
-    .map((entry) => entry.trim())
-    .filter(Boolean)
-    .map((entry) => {
-      try {
-        return new URL(entry).origin;
-      } catch {
-        return null;
-      }
-    })
-    .filter(Boolean);
+    .map((part) => part.trim())
+    .filter(Boolean)) {
+    const parsed = parseAllowedOriginEntry(entry);
+    if (parsed.origin) {
+      origins.add(parsed.origin);
+    } else {
+      console.warn(
+        `OD_ALLOWED_ORIGINS: ignoring invalid entry ${JSON.stringify(parsed.displayEntry)}: ${parsed.reason}`,
+      );
+    }
+  }
+
+  cachedAllowedOriginsRaw = raw;
+  cachedAllowedOrigins = [...origins];
+  return cachedAllowedOrigins;
 }
 
-function readAllowedOriginHostsEnv() {
-  return readAllowedOriginsEnv()
-    .map((origin) => {
-      try {
-        return new URL(origin).host;
-      } catch {
-        return null;
-      }
-    })
-    .filter(Boolean);
+export function readAllowedOriginHostsEnv() {
+  return [
+    ...new Set(
+      readAllowedOriginsEnv()
+        .map((origin) => {
+          try {
+            return new URL(origin).host;
+          } catch {
+            return null;
+          }
+        })
+        .filter(Boolean),
+    ),
+  ];
+}
+
+function parseAllowedOriginEntry(entry) {
+  let url;
+  try {
+    url = new URL(entry);
+  } catch {
+    return {
+      origin: null,
+      displayEntry: entry,
+      reason: 'expected an absolute http:// or https:// origin',
+    };
+  }
+
+  const displayEntry = `${url.protocol}//${url.host}${url.pathname}${url.search}${url.hash}`;
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return {
+      origin: null,
+      displayEntry,
+      reason: 'scheme must be http or https',
+    };
+  }
+  if (url.username || url.password) {
+    return {
+      origin: null,
+      displayEntry,
+      reason: 'credentials are not allowed',
+    };
+  }
+  if (url.pathname !== '' && url.pathname !== '/') {
+    return {
+      origin: null,
+      displayEntry,
+      reason: 'origins cannot include a path',
+    };
+  }
+  if (url.search || url.hash) {
+    return {
+      origin: null,
+      displayEntry,
+      reason: 'origins cannot include query strings or fragments',
+    };
+  }
+
+  return { origin: url.origin, displayEntry, reason: null };
 }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -643,13 +643,16 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
     const schemes = ['http', 'https'];
     const loopbackHosts = ['127.0.0.1', 'localhost', '[::1]'];
     return new Set(
-      ports.flatMap((p) => [
-        ...schemes.flatMap((s) => loopbackHosts.map((h) => `${s}://${h}:${p}`)),
-        // When bound to a specific non-loopback address (e.g. Tailscale,
-        // LAN IP, or 0.0.0.0), allow browser requests from that address
-        // too so the documented --host escape hatch remains usable.
-        ...schemes.map((s) => `${s}://${host}:${p}`),
-      ]),
+      [
+        ...ports.flatMap((p) => [
+          ...schemes.flatMap((s) => loopbackHosts.map((h) => `${s}://${h}:${p}`)),
+          // When bound to a specific non-loopback address (e.g. Tailscale,
+          // LAN IP, or 0.0.0.0), allow browser requests from that address
+          // too so the documented --host escape hatch remains usable.
+          ...schemes.map((s) => `${s}://${host}:${p}`),
+        ]),
+        ...readAllowedOriginsEnv(),
+      ],
     );
   }
 
@@ -3231,10 +3234,13 @@ export function isLocalSameOrigin(req, port) {
   const bindHost = process.env.OD_BIND_HOST || '127.0.0.1';
   const loopbackHosts = ['127.0.0.1', 'localhost', '[::1]'];
   const allowedHosts = new Set(
-    ports.flatMap((p) => [
-      ...loopbackHosts.map((h) => `${h}:${p}`),
-      `${bindHost}:${p}`,
-    ]),
+    [
+      ...ports.flatMap((p) => [
+        ...loopbackHosts.map((h) => `${h}:${p}`),
+        `${bindHost}:${p}`,
+      ]),
+      ...readAllowedOriginHostsEnv(),
+    ],
   );
 
   // Reject unknown Host first (DNS rebinding / Host header attack)
@@ -3245,10 +3251,41 @@ export function isLocalSameOrigin(req, port) {
 
   const schemes = ['http', 'https'];
   const allowedOrigins = new Set(
-    ports.flatMap((p) => [
-      ...schemes.flatMap((s) => loopbackHosts.map((h) => `${s}://${h}:${p}`)),
-      ...schemes.map((s) => `${s}://${bindHost}:${p}`),
-    ]),
+    [
+      ...ports.flatMap((p) => [
+        ...schemes.flatMap((s) => loopbackHosts.map((h) => `${s}://${h}:${p}`)),
+        ...schemes.map((s) => `${s}://${bindHost}:${p}`),
+      ]),
+      ...readAllowedOriginsEnv(),
+    ],
   );
   return allowedOrigins.has(String(origin));
+}
+
+function readAllowedOriginsEnv() {
+  const raw = process.env.OD_ALLOWED_ORIGINS || '';
+  return raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      try {
+        return new URL(entry).origin;
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+function readAllowedOriginHostsEnv() {
+  return readAllowedOriginsEnv()
+    .map((origin) => {
+      try {
+        return new URL(origin).host;
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
 }

--- a/apps/daemon/tests/origin-validation.test.ts
+++ b/apps/daemon/tests/origin-validation.test.ts
@@ -1,7 +1,21 @@
 // @ts-nocheck
 import http from 'node:http';
 import express from 'express';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import {
+  isLocalSameOrigin,
+  readAllowedOriginHostsEnv,
+  readAllowedOriginsEnv,
+} from '../src/server.js';
 
 /**
  * Replicate the origin validation middleware from server.ts exactly
@@ -33,10 +47,13 @@ function createOriginMiddleware(resolvedPort, host = '127.0.0.1') {
     const schemes = ['http', 'https'];
     const loopbackHosts = ['127.0.0.1', 'localhost', '[::1]'];
     const allowedOrigins = new Set(
-      ports.flatMap((p) => [
-        ...schemes.flatMap((s) => loopbackHosts.map((h) => `${s}://${h}:${p}`)),
-        ...schemes.map((s) => `${s}://${host}:${p}`),
-      ]),
+      [
+        ...ports.flatMap((p) => [
+          ...schemes.flatMap((s) => loopbackHosts.map((h) => `${s}://${h}:${p}`)),
+          ...schemes.map((s) => `${s}://${host}:${p}`),
+        ]),
+        ...readAllowedOriginsEnv(),
+      ],
     );
     if (!allowedOrigins.has(String(origin))) {
       return res.status(403).json({ error: 'Cross-origin requests are not allowed' });
@@ -237,6 +254,146 @@ describe('daemon origin validation middleware', () => {
 
   // Note: fail-closed coverage when port=0 is tested in the dedicated
   // describe block below ("fail-closed before port resolution").
+});
+
+describe('OD_ALLOWED_ORIGINS parsing', () => {
+  let originalAllowedOrigins;
+  let warnSpy;
+
+  beforeEach(() => {
+    originalAllowedOrigins = process.env.OD_ALLOWED_ORIGINS;
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (originalAllowedOrigins === undefined) {
+      delete process.env.OD_ALLOWED_ORIGINS;
+    } else {
+      process.env.OD_ALLOWED_ORIGINS = originalAllowedOrigins;
+    }
+    warnSpy.mockRestore();
+  });
+
+  it('normalizes http and https origins, default ports, whitespace, and duplicates', () => {
+    process.env.OD_ALLOWED_ORIGINS =
+      ' https://proxy.example.com , http://proxy.example.com:80, https://proxy.example.com:443, https://proxy.example.com ';
+
+    expect(readAllowedOriginsEnv()).toEqual([
+      'https://proxy.example.com',
+      'http://proxy.example.com',
+    ]);
+    expect(readAllowedOriginHostsEnv()).toEqual(['proxy.example.com']);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed entries, unsupported schemes, credentials, paths, query strings, and fragments', () => {
+    process.env.OD_ALLOWED_ORIGINS = [
+      'not-a-url',
+      'ftp://proxy.example.com',
+      'https://user:pass@proxy.example.com',
+      'https://proxy.example.com/app',
+      'https://proxy.example.com?debug=1',
+      'https://proxy.example.com#section',
+      'https://ok.example.com/',
+    ].join(',');
+
+    expect(readAllowedOriginsEnv()).toEqual(['https://ok.example.com']);
+    expect(warnSpy).toHaveBeenCalledTimes(6);
+  });
+
+  it('caches parse warnings until the raw env value changes', () => {
+    process.env.OD_ALLOWED_ORIGINS = 'https://proxy.example.com/app';
+
+    expect(readAllowedOriginsEnv()).toEqual([]);
+    expect(readAllowedOriginsEnv()).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    process.env.OD_ALLOWED_ORIGINS = 'https://proxy.example.com?x=1';
+    expect(readAllowedOriginsEnv()).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('OD_ALLOWED_ORIGINS request validation', () => {
+  let server;
+  let port;
+  let originalAllowedOrigins;
+
+  beforeAll(
+    () =>
+      new Promise((resolve) => {
+        const tempApp = makeTestApp(0);
+        const tempServer = tempApp.listen(0, '127.0.0.1', () => {
+          port = tempServer.address().port;
+          tempServer.close(() => {
+            const realApp = makeTestApp(port);
+            server = realApp.listen(port, '127.0.0.1', () => resolve());
+          });
+        });
+      }),
+  );
+
+  beforeEach(() => {
+    originalAllowedOrigins = process.env.OD_ALLOWED_ORIGINS;
+  });
+
+  afterEach(() => {
+    if (originalAllowedOrigins === undefined) {
+      delete process.env.OD_ALLOWED_ORIGINS;
+    } else {
+      process.env.OD_ALLOWED_ORIGINS = originalAllowedOrigins;
+    }
+  });
+
+  afterAll(
+    () =>
+      new Promise((resolve) => {
+        server.close(() => resolve());
+      }),
+  );
+
+  it('allows browser requests from explicitly trusted origins', async () => {
+    process.env.OD_ALLOWED_ORIGINS = 'https://proxy.example.com';
+
+    const res = await request(port, 'POST', '/api/projects', {
+      origin: 'https://proxy.example.com',
+      headers: { 'content-type': 'application/json' },
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  it('includes trusted origin hosts in stricter same-origin checks', () => {
+    process.env.OD_ALLOWED_ORIGINS = 'https://proxy.example.com';
+
+    expect(
+      isLocalSameOrigin(
+        {
+          headers: {
+            host: 'proxy.example.com',
+            origin: 'https://proxy.example.com',
+          },
+        },
+        port,
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects configured origin hosts when the browser Origin does not match', () => {
+    process.env.OD_ALLOWED_ORIGINS = 'https://proxy.example.com';
+
+    expect(
+      isLocalSameOrigin(
+        {
+          headers: {
+            host: 'proxy.example.com',
+            origin: 'https://evil.example.com',
+          },
+        },
+        port,
+      ),
+    ).toBe(false);
+  });
 });
 
 describe('origin validation: fail-closed before port resolution', () => {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -281,6 +281,8 @@ pnpm tools-dev run web       # starts daemon + web foreground loop
 
 When a reverse proxy sits in front of the daemon, `/api/*` includes SSE streams and must stay unbuffered. The daemon sends `Cache-Control: no-cache, no-transform` and `X-Accel-Buffering: no`, and also emits SSE comment keepalives, but nginx can still break chunked streams if gzip is enabled. For nginx, set `proxy_buffering off;`, `gzip off;`, and long `proxy_read_timeout` / `proxy_send_timeout` values on the API location. Otherwise browsers can report `net::ERR_INCOMPLETE_CHUNKED_ENCODING 200 (OK)` on long generations.
 
+If the web UI is served from a reverse-proxy origin that differs from the daemon's loopback origin, set `OD_ALLOWED_ORIGINS` to a comma-separated list of explicit browser origins, for example `OD_ALLOWED_ORIGINS=https://open-design.internal.example.com`. This is an origin-wide trust decision: browser `Origin` headers do not include paths, so values must be bare `http://` or `https://` origins without credentials, paths, query strings, or fragments. Do not include public, shared, or multi-tenant origins unless every script on that origin is trusted to call the local daemon API. `OD_ALLOWED_ORIGINS` does not prove that a request actually passed through a proxy; it only extends the daemon's browser-origin allowlist.
+
 ### Docker
 ```yaml
 # docker-compose.yml


### PR DESCRIPTION
## Summary

Add `OD_ALLOWED_ORIGINS` support to the daemon so trusted reverse-proxy origins can call the local API without disabling the existing origin protections.

## Why

When Open Design is served behind a trusted reverse proxy, browser requests use the proxy origin instead of the daemon's loopback origin. The daemon currently rejects those requests with `403`, which blocks state-changing routes such as:

- `PUT /api/app-config`
- `POST /api/projects`

## Changes

- Add `OD_ALLOWED_ORIGINS` as a comma-separated list of trusted browser origins.
- Include configured origins in the daemon's global API origin validation.
- Include configured origin hosts in `isLocalSameOrigin`, which protects stricter local-only routes.
- Keep the existing defaults for loopback, bind host, and `OD_WEB_PORT`.

## Security

This does not add wildcard CORS. Unknown browser origins are still rejected with `403`. Deployments must explicitly opt in trusted origins through `OD_ALLOWED_ORIGINS`.

Invalid origin entries are ignored.

## Validation

- Built the Docker image successfully.
- Verified reverse-proxy requests succeed for:
  - `PUT /api/app-config`
  - `POST /api/projects`
- Verified no deployment-specific domain is included in source changes.