### PR TITLE
fix(daemon): expose skill resources via cwd-relative aliases

### DIFF
--- a/apps/daemon/src/cwd-aliases.ts
+++ b/apps/daemon/src/cwd-aliases.ts
@@ -1,139 +1,150 @@
-// @ts-nocheck
-// CWD-relative aliases for resource roots that live outside the agent's
-// working directory.
+// Stage the active skill into the agent's project cwd so its side files
+// (assets/, references/) are reachable through a cwd-relative path
+// (`.od-skills/<folder>/...`). The chat handler invokes
+// `stageActiveSkill()` once per turn before spawning the agent; the
+// skill preamble emitted by `withSkillRootPreamble()` advertises both
+// the cwd-relative alias path (primary) and the absolute repo path
+// (fallback) so agents work whether or not staging succeeds.
 //
-// Background. The daemon spawns each code-agent CLI with `cwd` pinned to
-// `.od/projects/<id>/`, but skill bodies and design-system specs live in
-// repository-level folders (`<repo>/skills/`, `<repo>/design-systems/`).
-// The legacy approach was to inject absolute paths into the skill body and
-// rely on every agent CLI exposing an "extra allowed directory" flag
-// (Claude Code's / Copilot's `--add-dir`). That contract is fragile:
+// Why a per-project copy and not a symlink/junction
+// -------------------------------------------------
+// An earlier draft of this fix (PR #435 round 1) created a directory
+// link pointing at the repository's live `skills/` tree. Reviewers
+// flagged that as a write-amplification vulnerability: agents have
+// write access to their cwd, and a `Write`/`Edit`/`Bash` call against
+// `.od-skills/<id>/SKILL.md` resolves through the symlink and mutates
+// the shipped resource itself. Per-project copies eliminate that
+// channel — every byte under `.od-skills/` is a private working copy,
+// and corrupting it has no effect on other projects or on the source.
 //
-//   1. Most agents (codex, gemini, opencode, cursor-agent, qwen, pi,
-//      hermes, kimi) have no equivalent flag, so absolute paths simply
-//      fail with a directory-access policy error (issue #430).
-//   2. Claude Code itself can refuse the path under specific permission
-//      / trust configurations even with `--add-dir` set.
+// Cost. We only stage the *active* skill, not the entire SKILLS_DIR;
+// individual skills are typically 1–3 MB. On APFS / btrfs / ReFS
+// `fs.cp` uses copy-on-write where available, so the steady-state cost
+// is a few syscalls.
 //
-// Fix. Before composing the prompt, the daemon stages a directory link
-// inside the project cwd for every resource root the prompt references.
-// On POSIX we use a symbolic link; on Windows a directory junction (which
-// does not require the SeCreateSymbolicLinkPrivilege). The skill preamble
-// then refers to resources via the alias (`.od-skills/<id>/...`), which
-// is a path inside the agent's cwd and therefore works for every CLI.
-// `--add-dir` is still passed for Claude/Copilot as a belt-and-suspenders
-// fallback in case junction/symlink creation fails.
-//
-// The function is idempotent: running it on every chat turn is cheap, and
-// it self-heals when the alias is missing or repoints if the target
-// moved. It refuses to overwrite a pre-existing non-symlink entry under
-// the same name to avoid clobbering user data.
+// Source symlinks. We `dereference: true` so the staged copy is fully
+// self-contained — nothing inside it can write back to a real file
+// outside the project. We also call `stat()` (not `lstat()`) on the
+// source root so an environment that puts `skills/` itself behind a
+// symlink (e.g. a content-addressable mount) is followed correctly.
 
-import { lstat, readlink, realpath, symlink, unlink } from 'node:fs/promises';
+import { cp, lstat, rm, stat } from 'node:fs/promises';
 import path from 'node:path';
 
 export const SKILLS_CWD_ALIAS = '.od-skills';
-export const DESIGN_SYSTEMS_CWD_ALIAS = '.od-design-systems';
 
-export interface CwdAliasSpec {
-  name: string;
-  target: string;
+export type SkillStagingLogger = (message: string) => void;
+
+export interface SkillStagingResult {
+  /** True when a usable copy of the source is sitting at `stagedPath`. */
+  staged: boolean;
+  /** Absolute path of the staged directory if staging succeeded. */
+  stagedPath?: string;
+  /** Populated when staging was skipped or failed; never thrown. */
+  reason?: string;
 }
 
-export type CwdAliasLogger = (message: string) => void;
+/**
+ * Copy `<sourceDir>` to `<cwd>/.od-skills/<folderName>/` so an agent can
+ * reach skill side files via a cwd-relative path. Idempotent and
+ * non-throwing — failures are logged and surfaced via the result so the
+ * caller falls back to absolute-path delivery (`--add-dir` for
+ * Claude/Copilot, embedded absolute path in the preamble for others).
+ *
+ * The previous-turn copy is replaced wholesale on every call, which is
+ * the simplest correct way to handle skill-source updates (e.g. the
+ * user just edited a `references/*.md` mid-session).
+ */
+export async function stageActiveSkill(
+  cwd: string | null | undefined,
+  folderName: string,
+  sourceDir: string,
+  log: SkillStagingLogger = () => {},
+): Promise<SkillStagingResult> {
+  if (!cwd) {
+    return { staged: false, reason: 'no project cwd' };
+  }
+  if (!isSafeAliasSegment(folderName)) {
+    return { staged: false, reason: `unsafe folder name "${folderName}"` };
+  }
 
-export async function ensureCwdAliases(
-  cwd: string,
-  specs: CwdAliasSpec[],
-  log: CwdAliasLogger = () => {},
-): Promise<void> {
-  if (!cwd || !Array.isArray(specs)) return;
-  for (const spec of specs) {
-    if (!spec || typeof spec.name !== 'string' || typeof spec.target !== 'string') {
-      continue;
-    }
-    try {
-      await ensureOne(cwd, spec, log);
-    } catch (err) {
+  // `stat()` follows symlinks so a symlinked SKILLS_DIR or a symlinked
+  // skill folder is treated as the directory it points at, not skipped.
+  let sourceStat;
+  try {
+    sourceStat = await stat(sourceDir);
+  } catch (err) {
+    return {
+      staged: false,
+      reason: `source missing: ${(err as Error).message}`,
+    };
+  }
+  if (!sourceStat.isDirectory()) {
+    return { staged: false, reason: 'source is not a directory' };
+  }
+
+  const aliasRoot = path.join(cwd, SKILLS_CWD_ALIAS);
+  const stagedPath = path.join(aliasRoot, folderName);
+
+  // The alias root is OD-reserved. If the user (or some unrelated tool)
+  // has put a real file under that name, refuse to clobber it. A
+  // legacy symlink left by an earlier daemon version is replaced with
+  // a real directory so we own the writable namespace.
+  try {
+    const aliasStat = await lstat(aliasRoot);
+    if (aliasStat.isSymbolicLink()) {
       log(
-        `[od] cwd-alias failed: ${spec.name} -> ${spec.target}: ${
-          (err && err.message) || String(err)
-        }`,
+        `[od] skill-stage: replacing legacy symlink at ${aliasRoot} with a real directory`,
       );
+      await rm(aliasRoot, { recursive: true, force: true });
+    } else if (!aliasStat.isDirectory()) {
+      log(
+        `[od] skill-stage: ${aliasRoot} exists and is not a directory; refusing to stage`,
+      );
+      return {
+        staged: false,
+        reason: 'alias root taken by a non-directory entry',
+      };
     }
-  }
-}
-
-async function ensureOne(cwd, spec, log) {
-  const linkPath = path.join(cwd, spec.name);
-  const targetAbs = path.resolve(spec.target);
-
-  // The source must exist as a directory; otherwise the alias would point
-  // at nothing. Skip silently — this matches how the chat handler already
-  // filters `extraAllowedDirs` with `fs.existsSync`.
-  try {
-    const targetStat = await lstat(targetAbs);
-    if (!targetStat.isDirectory()) return;
   } catch {
-    return;
+    // does not exist — created by `cp` below
   }
 
-  let linkStat;
   try {
-    linkStat = await lstat(linkPath);
-  } catch {
-    await createDirLink(linkPath, targetAbs);
-    return;
-  }
-
-  // On Windows, fs.symlink('junction') still reports isSymbolicLink() === true
-  // through Node's lstat (see node/fs docs), so a single branch covers both
-  // POSIX symlinks and Windows directory junctions.
-  if (linkStat.isSymbolicLink()) {
-    if (await pointsAt(linkPath, targetAbs)) return;
-    try {
-      await unlink(linkPath);
-    } catch (err) {
-      log(`[od] cwd-alias: failed to refresh ${linkPath}: ${err.message}`);
-      return;
-    }
-    await createDirLink(linkPath, targetAbs);
-    return;
-  }
-
-  // A real file or directory is sitting under the reserved alias name.
-  // Refuse to overwrite — that would destroy user data we did not create.
-  log(
-    `[od] cwd-alias: ${linkPath} exists and is not a symlink; leaving it alone (skill resources will fall back to --add-dir paths)`,
-  );
-}
-
-async function createDirLink(linkPath, target) {
-  const type = process.platform === 'win32' ? 'junction' : 'dir';
-  await symlink(target, linkPath, type);
-}
-
-async function pointsAt(linkPath, target) {
-  try {
-    const resolved = await realpath(linkPath);
-    return pathsEqual(resolved, target);
-  } catch {
-    // Dangling link — let the caller refresh it.
-    try {
-      const raw = await readlink(linkPath);
-      const abs = path.isAbsolute(raw)
-        ? raw
-        : path.resolve(path.dirname(linkPath), raw);
-      return pathsEqual(abs, target);
-    } catch {
-      return false;
-    }
+    // Wipe a stale per-skill copy first so a removed source file is
+    // reflected and a partially-failed previous run cannot leave junk
+    // behind.
+    await rm(stagedPath, { recursive: true, force: true });
+    await cp(sourceDir, stagedPath, {
+      recursive: true,
+      // Resolve every symlink we find inside the skill so the staged
+      // copy is a fully self-contained set of regular files. This is
+      // what makes the copy a true write barrier — no entry under
+      // `.od-skills/...` can resolve back to a real file outside the
+      // project cwd.
+      dereference: true,
+      preserveTimestamps: true,
+    });
+    return { staged: true, stagedPath };
+  } catch (err) {
+    log(`[od] skill-stage failed: ${(err as Error).message}`);
+    return { staged: false, reason: (err as Error).message };
   }
 }
 
-function pathsEqual(a, b) {
-  const la = path.resolve(a);
-  const lb = path.resolve(b);
-  if (process.platform === 'win32') return la.toLowerCase() === lb.toLowerCase();
-  return la === lb;
+const UNSAFE_ALIAS_RE = /[\\/]|\0/;
+
+/**
+ * Returns true if `name` is safe to use as a single path segment under
+ * the alias root. Rejects empty strings, dot-segments (`.`/`..`), path
+ * separators (`/`, `\`), null bytes, and absolute paths so a malformed
+ * caller cannot escape the alias root.
+ */
+function isSafeAliasSegment(name: unknown): name is string {
+  if (typeof name !== 'string') return false;
+  if (name.length === 0) return false;
+  if (name === '.' || name === '..') return false;
+  if (UNSAFE_ALIAS_RE.test(name)) return false;
+  if (path.isAbsolute(name)) return false;
+  return true;
 }

--- a/apps/daemon/src/cwd-aliases.ts
+++ b/apps/daemon/src/cwd-aliases.ts
@@ -1,0 +1,139 @@
+// @ts-nocheck
+// CWD-relative aliases for resource roots that live outside the agent's
+// working directory.
+//
+// Background. The daemon spawns each code-agent CLI with `cwd` pinned to
+// `.od/projects/<id>/`, but skill bodies and design-system specs live in
+// repository-level folders (`<repo>/skills/`, `<repo>/design-systems/`).
+// The legacy approach was to inject absolute paths into the skill body and
+// rely on every agent CLI exposing an "extra allowed directory" flag
+// (Claude Code's / Copilot's `--add-dir`). That contract is fragile:
+//
+//   1. Most agents (codex, gemini, opencode, cursor-agent, qwen, pi,
+//      hermes, kimi) have no equivalent flag, so absolute paths simply
+//      fail with a directory-access policy error (issue #430).
+//   2. Claude Code itself can refuse the path under specific permission
+//      / trust configurations even with `--add-dir` set.
+//
+// Fix. Before composing the prompt, the daemon stages a directory link
+// inside the project cwd for every resource root the prompt references.
+// On POSIX we use a symbolic link; on Windows a directory junction (which
+// does not require the SeCreateSymbolicLinkPrivilege). The skill preamble
+// then refers to resources via the alias (`.od-skills/<id>/...`), which
+// is a path inside the agent's cwd and therefore works for every CLI.
+// `--add-dir` is still passed for Claude/Copilot as a belt-and-suspenders
+// fallback in case junction/symlink creation fails.
+//
+// The function is idempotent: running it on every chat turn is cheap, and
+// it self-heals when the alias is missing or repoints if the target
+// moved. It refuses to overwrite a pre-existing non-symlink entry under
+// the same name to avoid clobbering user data.
+
+import { lstat, readlink, realpath, symlink, unlink } from 'node:fs/promises';
+import path from 'node:path';
+
+export const SKILLS_CWD_ALIAS = '.od-skills';
+export const DESIGN_SYSTEMS_CWD_ALIAS = '.od-design-systems';
+
+export interface CwdAliasSpec {
+  name: string;
+  target: string;
+}
+
+export type CwdAliasLogger = (message: string) => void;
+
+export async function ensureCwdAliases(
+  cwd: string,
+  specs: CwdAliasSpec[],
+  log: CwdAliasLogger = () => {},
+): Promise<void> {
+  if (!cwd || !Array.isArray(specs)) return;
+  for (const spec of specs) {
+    if (!spec || typeof spec.name !== 'string' || typeof spec.target !== 'string') {
+      continue;
+    }
+    try {
+      await ensureOne(cwd, spec, log);
+    } catch (err) {
+      log(
+        `[od] cwd-alias failed: ${spec.name} -> ${spec.target}: ${
+          (err && err.message) || String(err)
+        }`,
+      );
+    }
+  }
+}
+
+async function ensureOne(cwd, spec, log) {
+  const linkPath = path.join(cwd, spec.name);
+  const targetAbs = path.resolve(spec.target);
+
+  // The source must exist as a directory; otherwise the alias would point
+  // at nothing. Skip silently — this matches how the chat handler already
+  // filters `extraAllowedDirs` with `fs.existsSync`.
+  try {
+    const targetStat = await lstat(targetAbs);
+    if (!targetStat.isDirectory()) return;
+  } catch {
+    return;
+  }
+
+  let linkStat;
+  try {
+    linkStat = await lstat(linkPath);
+  } catch {
+    await createDirLink(linkPath, targetAbs);
+    return;
+  }
+
+  // On Windows, fs.symlink('junction') still reports isSymbolicLink() === true
+  // through Node's lstat (see node/fs docs), so a single branch covers both
+  // POSIX symlinks and Windows directory junctions.
+  if (linkStat.isSymbolicLink()) {
+    if (await pointsAt(linkPath, targetAbs)) return;
+    try {
+      await unlink(linkPath);
+    } catch (err) {
+      log(`[od] cwd-alias: failed to refresh ${linkPath}: ${err.message}`);
+      return;
+    }
+    await createDirLink(linkPath, targetAbs);
+    return;
+  }
+
+  // A real file or directory is sitting under the reserved alias name.
+  // Refuse to overwrite — that would destroy user data we did not create.
+  log(
+    `[od] cwd-alias: ${linkPath} exists and is not a symlink; leaving it alone (skill resources will fall back to --add-dir paths)`,
+  );
+}
+
+async function createDirLink(linkPath, target) {
+  const type = process.platform === 'win32' ? 'junction' : 'dir';
+  await symlink(target, linkPath, type);
+}
+
+async function pointsAt(linkPath, target) {
+  try {
+    const resolved = await realpath(linkPath);
+    return pathsEqual(resolved, target);
+  } catch {
+    // Dangling link — let the caller refresh it.
+    try {
+      const raw = await readlink(linkPath);
+      const abs = path.isAbsolute(raw)
+        ? raw
+        : path.resolve(path.dirname(linkPath), raw);
+      return pathsEqual(abs, target);
+    } catch {
+      return false;
+    }
+  }
+}
+
+function pathsEqual(a, b) {
+  const la = path.resolve(a);
+  const lb = path.resolve(b);
+  if (process.platform === 'win32') return la.toLowerCase() === lb.toLowerCase();
+  return la === lb;
+}

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -34,11 +34,7 @@ import { listPromptTemplates, readPromptTemplate } from './prompt-templates.js';
 import { buildDocumentPreview } from './document-preview.js';
 import { lintArtifact, renderFindingsForAgent } from './lint-artifact.js';
 import { loadCraftSections } from './craft.js';
-import {
-  ensureCwdAliases,
-  SKILLS_CWD_ALIAS,
-  DESIGN_SYSTEMS_CWD_ALIAS,
-} from './cwd-aliases.js';
+import { stageActiveSkill } from './cwd-aliases.js';
 import { generateMedia } from './media.js';
 import {
   AUDIO_DURATIONS_SEC,
@@ -2233,6 +2229,7 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
     let skillName;
     let skillMode;
     let skillCraftRequires = [];
+    let activeSkillDir = null;
     if (effectiveSkillId) {
       const skill = (await listSkills(SKILLS_DIR)).find(
         (s) => s.id === effectiveSkillId,
@@ -2241,6 +2238,7 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
         skillBody = skill.body;
         skillName = skill.name;
         skillMode = skill.mode;
+        activeSkillDir = skill.dir;
         if (Array.isArray(skill.craftRequires))
           skillCraftRequires = skill.craftRequires;
       }
@@ -2272,7 +2270,7 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
         ? (getTemplate(db, metadata.templateId) ?? undefined)
         : undefined;
 
-    return composeSystemPrompt({
+    const prompt = composeSystemPrompt({
       skillBody,
       skillName,
       skillMode,
@@ -2283,6 +2281,11 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
       metadata,
       template,
     });
+    // The chat handler also needs to know where the active skill lives
+    // on disk so it can stage a per-project copy of its side files
+    // before spawning the agent. Returning that here avoids a second
+    // `listSkills()` scan in `startChatRun`.
+    return { prompt, activeSkillDir };
   };
 
   const startChatRun = async (chatBody, run) => {
@@ -2396,11 +2399,12 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
       ? `\n\nAttached project files: ${safeAttachments.map((p) => `\`${p}\``).join(', ')}`
       : '';
     const commentHint = renderCommentAttachmentHint(safeCommentAttachments);
-    const daemonSystemPrompt = await composeDaemonSystemPrompt({
-      projectId,
-      skillId,
-      designSystemId,
-    });
+    const { prompt: daemonSystemPrompt, activeSkillDir } =
+      await composeDaemonSystemPrompt({
+        projectId,
+        skillId,
+        designSystemId,
+      });
     const instructionPrompt = [daemonSystemPrompt, systemPrompt]
       .map((part) => (typeof part === 'string' ? part.trim() : ''))
       .filter(Boolean)
@@ -2417,31 +2421,42 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
         : '',
     ].join('');
 
-    // Skill seeds (`skills/<id>/assets/template.html`) and design-system
-    // specs (`design-systems/<id>/DESIGN.md`) live outside the project cwd.
-    // We expose them through two complementary mechanisms:
+    // Make skill side files reachable through three layers, in order of
+    // preference. The skill preamble emitted by `withSkillRootPreamble()`
+    // advertises both the cwd-relative path (1) and the absolute path
+    // (2/3) so the agent can pick whichever works.
     //
-    //   1. Stage cwd-relative aliases (`.od-skills`, `.od-design-systems`)
-    //      pointing at the resource roots, so any agent CLI — not just
-    //      those that honour `--add-dir` — can reach those files via a
-    //      path inside its own working directory. This is what the skill
-    //      preamble emitted by `withSkillRootPreamble()` references, and
-    //      it is the load-bearing fix for issue #430 (Claude Code blocked
-    //      reads of absolute skill paths despite `--add-dir`, and every
-    //      non-Claude agent had no equivalent flag at all).
-    //   2. Keep `extraAllowedDirs` so Claude/Copilot still get
-    //      `--add-dir` for the absolute paths, as a belt-and-suspenders
-    //      fallback if the alias cannot be created (e.g. the user has a
-    //      pre-existing real entry under one of the reserved alias names).
-    if (cwd) {
-      await ensureCwdAliases(
+    //   1. CWD-relative copy. Stage the *active* skill into
+    //      `<cwd>/.od-skills/<folder>/` so any agent CLI — not just the
+    //      ones that honour `--add-dir` — can reach those files via a
+    //      path inside its working directory. We copy (not symlink) so
+    //      the staged directory is a true write barrier — agents cannot
+    //      mutate the shipped repo resource through their cwd.
+    //   2. `--add-dir` allowlist. Pass `SKILLS_DIR` and
+    //      `DESIGN_SYSTEMS_DIR` to Claude/Copilot so the absolute fallback
+    //      path in the preamble is reachable when staging fails (e.g. the
+    //      project has no on-disk cwd, or fs.cp errored).
+    //   3. PROJECT_ROOT cwd. When `cwd` is null, the agent runs with
+    //      `cwd: PROJECT_ROOT` — there the absolute path is already an
+    //      in-cwd path, so neither (1) nor (2) is required for it to
+    //      resolve.
+    //
+    // Design systems are *not* staged here. Their bodies are read by the
+    // daemon and folded into the system prompt directly (see
+    // `readDesignSystem`), so an agent never has to open them via the
+    // filesystem.
+    if (cwd && activeSkillDir) {
+      const result = await stageActiveSkill(
         cwd,
-        [
-          { name: SKILLS_CWD_ALIAS, target: SKILLS_DIR },
-          { name: DESIGN_SYSTEMS_CWD_ALIAS, target: DESIGN_SYSTEMS_DIR },
-        ],
+        path.basename(activeSkillDir),
+        activeSkillDir,
         (msg) => console.warn(msg),
       );
+      if (!result.staged) {
+        console.warn(
+          `[od] skill-stage skipped: ${result.reason ?? 'unknown reason'}; falling back to absolute paths`,
+        );
+      }
     }
     const extraAllowedDirs = [SKILLS_DIR, DESIGN_SYSTEMS_DIR].filter((d) =>
       fs.existsSync(d),

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -34,6 +34,11 @@ import { listPromptTemplates, readPromptTemplate } from './prompt-templates.js';
 import { buildDocumentPreview } from './document-preview.js';
 import { lintArtifact, renderFindingsForAgent } from './lint-artifact.js';
 import { loadCraftSections } from './craft.js';
+import {
+  ensureCwdAliases,
+  SKILLS_CWD_ALIAS,
+  DESIGN_SYSTEMS_CWD_ALIAS,
+} from './cwd-aliases.js';
 import { generateMedia } from './media.js';
 import {
   AUDIO_DURATIONS_SEC,
@@ -2414,11 +2419,30 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
 
     // Skill seeds (`skills/<id>/assets/template.html`) and design-system
     // specs (`design-systems/<id>/DESIGN.md`) live outside the project cwd.
-    // The composed system prompt asks the agent to Read them via absolute
-    // paths in the skill-root preamble — without an explicit allowlist,
-    // Claude Code blocks those reads (issue #6: "no permission to read
-    // skills template"). We surface both roots so any agent that honours
-    // `--add-dir` can resolve those side files.
+    // We expose them through two complementary mechanisms:
+    //
+    //   1. Stage cwd-relative aliases (`.od-skills`, `.od-design-systems`)
+    //      pointing at the resource roots, so any agent CLI — not just
+    //      those that honour `--add-dir` — can reach those files via a
+    //      path inside its own working directory. This is what the skill
+    //      preamble emitted by `withSkillRootPreamble()` references, and
+    //      it is the load-bearing fix for issue #430 (Claude Code blocked
+    //      reads of absolute skill paths despite `--add-dir`, and every
+    //      non-Claude agent had no equivalent flag at all).
+    //   2. Keep `extraAllowedDirs` so Claude/Copilot still get
+    //      `--add-dir` for the absolute paths, as a belt-and-suspenders
+    //      fallback if the alias cannot be created (e.g. the user has a
+    //      pre-existing real entry under one of the reserved alias names).
+    if (cwd) {
+      await ensureCwdAliases(
+        cwd,
+        [
+          { name: SKILLS_CWD_ALIAS, target: SKILLS_DIR },
+          { name: DESIGN_SYSTEMS_CWD_ALIAS, target: DESIGN_SYSTEMS_DIR },
+        ],
+        (msg) => console.warn(msg),
+      );
+    }
     const extraAllowedDirs = [SKILLS_DIR, DESIGN_SYSTEMS_DIR].filter((d) =>
       fs.existsSync(d),
     );

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -2458,6 +2458,14 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
         );
       }
     }
+    // Resolve the agent's effective working directory once and use it
+    // everywhere the agent could read it (buildArgs runtimeContext, spawn
+    // cwd, ACP session new). Falling back to PROJECT_ROOT — rather than
+    // letting `spawn` inherit the daemon process cwd — is what makes the
+    // absolute-path fallback in the skill preamble actually in-cwd for
+    // no-project runs (packaged daemons / service launches do not start
+    // their working directory from the workspace root).
+    const effectiveCwd = cwd ?? PROJECT_ROOT;
     const extraAllowedDirs = [SKILLS_DIR, DESIGN_SYSTEMS_DIR].filter((d) =>
       fs.existsSync(d),
     );
@@ -2503,7 +2511,7 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
       safeImages,
       extraAllowedDirs,
       agentOptions,
-      { cwd },
+      { cwd: effectiveCwd },
     );
     const send = (event, data) => design.runs.emit(run, event, data);
 
@@ -2551,7 +2559,7 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
       child = spawn(invocation.command, invocation.args, {
         env,
         stdio: [stdinMode, 'pipe', 'pipe'],
-        cwd: cwd || undefined,
+        cwd: effectiveCwd,
         shell: false,
         // Required when invocation wraps a Windows .cmd/.bat shim through
         // cmd.exe; without this, Node re-escapes the inner command line and
@@ -2608,7 +2616,7 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
       acpSession = attachPiRpcSession({
         child,
         prompt: composed,
-        cwd: cwd || PROJECT_ROOT,
+        cwd: effectiveCwd,
         model: safeModel,
         send,
       });
@@ -2616,7 +2624,7 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
       acpSession = attachAcpSession({
         child,
         prompt: composed,
-        cwd: cwd || PROJECT_ROOT,
+        cwd: effectiveCwd,
         model: safeModel,
         send,
       });

--- a/apps/daemon/src/skills.ts
+++ b/apps/daemon/src/skills.ts
@@ -6,6 +6,7 @@
 import { readdir, readFile, stat } from "node:fs/promises";
 import path from "node:path";
 import { parseFrontmatter } from "./frontmatter.js";
+import { SKILLS_CWD_ALIAS } from "./cwd-aliases.js";
 
 export async function listSkills(skillsRoot) {
   const out = [];
@@ -68,17 +69,26 @@ export async function listSkills(skillsRoot) {
 
 // Skills that ship side files (e.g. `assets/template.html`, `references/*.md`)
 // need the agent to know where the skill lives on disk — relative paths in the
-// SKILL.md body resolve against the agent's CWD, which is the daemon root, not
-// the skill folder. We prepend a short preamble so any capable code agent can
-// open those files via absolute paths.
+// SKILL.md body would otherwise resolve against the agent's CWD, which is the
+// project folder (`.od/projects/<id>/`), not the skill folder.
+//
+// We prepend a short preamble pointing at a CWD-relative alias
+// (`.od-skills/<folder>/`). The chat handler stages a directory link at that
+// alias name before spawning the agent (see `cwd-aliases.ts`), so the path is
+// reachable from inside the agent's working directory on every CLI — not just
+// the ones that honour `--add-dir`. The agent never needs to escape its CWD,
+// so directory-access policies (issue #430) cannot block these reads.
 function withSkillRootPreamble(body, dir) {
+  const folder = path.basename(dir);
+  const skillRootRel = `${SKILLS_CWD_ALIAS}/${folder}`;
   const preamble = [
-    "> **Skill root (absolute):** `" + dir + "`",
+    "> **Skill root (relative to project):** `" + skillRootRel + "/`",
     ">",
     "> This skill ships side files alongside `SKILL.md`. When the workflow",
     "> below references relative paths such as `assets/template.html` or",
-    "> `references/layouts.md`, resolve them against the skill root above and",
-    "> open them via their full absolute path.",
+    "> `references/layouts.md`, resolve them against the skill root above —",
+    "> e.g. open `" + skillRootRel + "/assets/template.html`. Stay inside the",
+    "> project working directory; do not use absolute paths from outside it.",
     "",
     "",
   ].join("\n");

--- a/apps/daemon/src/skills.ts
+++ b/apps/daemon/src/skills.ts
@@ -72,23 +72,37 @@ export async function listSkills(skillsRoot) {
 // SKILL.md body would otherwise resolve against the agent's CWD, which is the
 // project folder (`.od/projects/<id>/`), not the skill folder.
 //
-// We prepend a short preamble pointing at a CWD-relative alias
-// (`.od-skills/<folder>/`). The chat handler stages a directory link at that
-// alias name before spawning the agent (see `cwd-aliases.ts`), so the path is
-// reachable from inside the agent's working directory on every CLI — not just
-// the ones that honour `--add-dir`. The agent never needs to escape its CWD,
-// so directory-access policies (issue #430) cannot block these reads.
+// We prepend a short preamble that advertises two paths:
+//
+//   1. A CWD-relative alias path (`.od-skills/<folder>/`) — the primary one.
+//      Before spawning the agent the chat handler copies the active skill
+//      into `<cwd>/.od-skills/<folder>/` (see `cwd-aliases.ts`), so this
+//      path is inside the agent's working directory on every CLI and is
+//      not blocked by directory-access policies (issue #430).
+//   2. The absolute repo path — a fallback for the cases the staged copy
+//      cannot exist for: `/api/runs` calls without a project (cwd falls
+//      back to the repo root, where the absolute path *is* an in-cwd
+//      path), or environments where staging fails. Claude/Copilot are
+//      additionally given `--add-dir` for that absolute path, so the
+//      fallback round-trips even under their permission policy.
+//
+// Authoring guidance lives in the preamble itself so an agent can pick
+// the right form on its own without daemon-side feature detection.
 function withSkillRootPreamble(body, dir) {
   const folder = path.basename(dir);
   const skillRootRel = `${SKILLS_CWD_ALIAS}/${folder}`;
   const preamble = [
     "> **Skill root (relative to project):** `" + skillRootRel + "/`",
+    "> **Skill root (absolute fallback):** `" + dir + "`",
     ">",
     "> This skill ships side files alongside `SKILL.md`. When the workflow",
     "> below references relative paths such as `assets/template.html` or",
-    "> `references/layouts.md`, resolve them against the skill root above —",
-    "> e.g. open `" + skillRootRel + "/assets/template.html`. Stay inside the",
-    "> project working directory; do not use absolute paths from outside it.",
+    "> `references/layouts.md`, prefer the relative form rooted at the",
+    "> first path above — e.g. open `" + skillRootRel + "/assets/template.html`.",
+    "> If that path is not reachable from your working directory, fall",
+    "> back to the absolute path: `" + dir + "/assets/template.html`.",
+    "> Either form resolves to the same file; the relative form keeps you",
+    "> inside the project working directory, which is preferred.",
     "",
     "",
   ].join("\n");

--- a/apps/daemon/tests/cwd-aliases.test.ts
+++ b/apps/daemon/tests/cwd-aliases.test.ts
@@ -1,147 +1,246 @@
-import { lstatSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import {
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { realpath } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
-import {
-  DESIGN_SYSTEMS_CWD_ALIAS,
-  SKILLS_CWD_ALIAS,
-  ensureCwdAliases,
-} from '../src/cwd-aliases.js';
+import { SKILLS_CWD_ALIAS, stageActiveSkill } from '../src/cwd-aliases.js';
 
 function fresh(): string {
-  return mkdtempSync(path.join(tmpdir(), 'od-cwd-alias-'));
+  return mkdtempSync(path.join(tmpdir(), 'od-skill-stage-'));
 }
 
-describe('ensureCwdAliases', () => {
-  it('exposes documented alias names so the skill preamble stays in sync', () => {
+function writeSampleSkill(root: string, folder: string): string {
+  const dir = path.join(root, folder);
+  mkdirSync(path.join(dir, 'assets'), { recursive: true });
+  mkdirSync(path.join(dir, 'references'), { recursive: true });
+  writeFileSync(path.join(dir, 'SKILL.md'), '# original SKILL\n');
+  writeFileSync(
+    path.join(dir, 'assets', 'template.html'),
+    '<html>original</html>',
+  );
+  writeFileSync(path.join(dir, 'references', 'checklist.md'), '- original');
+  return dir;
+}
+
+describe('stageActiveSkill', () => {
+  it('exposes the documented alias name so the skill preamble stays in sync', () => {
     expect(SKILLS_CWD_ALIAS).toBe('.od-skills');
-    expect(DESIGN_SYSTEMS_CWD_ALIAS).toBe('.od-design-systems');
   });
 
-  it('creates a symlink/junction from cwd to the source root', async () => {
-    const root = fresh();
-    const cwd = path.join(root, 'project');
-    const src = path.join(root, 'skills');
+  it('stages a per-project copy under <cwd>/.od-skills/<folder>/', async () => {
+    const fs = fresh();
+    const cwd = path.join(fs, 'project');
+    const sourceRoot = path.join(fs, 'skills');
+    const sourceDir = writeSampleSkill(sourceRoot, 'blog-post');
     mkdirSync(cwd);
-    mkdirSync(src);
-    writeFileSync(path.join(src, 'a.txt'), 'hello');
 
-    await ensureCwdAliases(cwd, [
-      { name: SKILLS_CWD_ALIAS, target: src },
-    ]);
+    const result = await stageActiveSkill(cwd, 'blog-post', sourceDir);
 
-    const linkPath = path.join(cwd, SKILLS_CWD_ALIAS);
-    expect(lstatSync(linkPath).isSymbolicLink()).toBe(true);
-    expect(await realpath(linkPath)).toBe(await realpath(src));
+    expect(result.staged).toBe(true);
+    expect(result.stagedPath).toBe(
+      path.join(cwd, SKILLS_CWD_ALIAS, 'blog-post'),
+    );
+    expect(
+      readFileSync(
+        path.join(result.stagedPath!, 'SKILL.md'),
+        'utf8',
+      ),
+    ).toContain('original SKILL');
+    expect(
+      readFileSync(
+        path.join(result.stagedPath!, 'assets', 'template.html'),
+        'utf8',
+      ),
+    ).toContain('original');
   });
 
-  it('is idempotent when the alias already points at the same target', async () => {
-    const root = fresh();
-    const cwd = path.join(root, 'project');
-    const src = path.join(root, 'skills');
+  it('produces a real directory entry, not a symlink (write barrier)', async () => {
+    const fs = fresh();
+    const cwd = path.join(fs, 'project');
+    const sourceDir = writeSampleSkill(path.join(fs, 'skills'), 'blog-post');
     mkdirSync(cwd);
-    mkdirSync(src);
 
-    await ensureCwdAliases(cwd, [{ name: SKILLS_CWD_ALIAS, target: src }]);
-    const before = await realpath(path.join(cwd, SKILLS_CWD_ALIAS));
-    await ensureCwdAliases(cwd, [{ name: SKILLS_CWD_ALIAS, target: src }]);
-    const after = await realpath(path.join(cwd, SKILLS_CWD_ALIAS));
+    await stageActiveSkill(cwd, 'blog-post', sourceDir);
 
-    expect(after).toBe(before);
+    const stagedSkill = path.join(cwd, SKILLS_CWD_ALIAS, 'blog-post');
+    expect(lstatSync(stagedSkill).isSymbolicLink()).toBe(false);
+    expect(lstatSync(stagedSkill).isDirectory()).toBe(true);
+
+    const stagedFile = path.join(stagedSkill, 'SKILL.md');
+    expect(lstatSync(stagedFile).isSymbolicLink()).toBe(false);
+    expect(lstatSync(stagedFile).isFile()).toBe(true);
   });
 
-  it('repoints the alias when the target moves', async () => {
-    const root = fresh();
-    const cwd = path.join(root, 'project');
-    const src1 = path.join(root, 'skills-old');
-    const src2 = path.join(root, 'skills-new');
-    mkdirSync(cwd);
-    mkdirSync(src1);
-    mkdirSync(src2);
-
-    await ensureCwdAliases(cwd, [{ name: SKILLS_CWD_ALIAS, target: src1 }]);
-    await ensureCwdAliases(cwd, [{ name: SKILLS_CWD_ALIAS, target: src2 }]);
-
-    const real = await realpath(path.join(cwd, SKILLS_CWD_ALIAS));
-    expect(real).toBe(await realpath(src2));
-  });
-
-  it('skips silently when the source does not exist', async () => {
-    const root = fresh();
-    const cwd = path.join(root, 'project');
+  it('REGRESSION: writes through the staged copy do not mutate the source', async () => {
+    // This is the P1 vulnerability lefarcen flagged on PR #435 round 1:
+    // when `.od-skills` was a directory junction, an agent could
+    // `Edit`/`Write` through the alias and overwrite the shipped repo
+    // resource. The per-project copy is the structural fix; this test
+    // pins it down so a future "optimisation" that re-introduces a
+    // symlink would fail loud.
+    const fs = fresh();
+    const cwd = path.join(fs, 'project');
+    const sourceDir = writeSampleSkill(path.join(fs, 'skills'), 'blog-post');
     mkdirSync(cwd);
 
-    const messages: string[] = [];
-    await ensureCwdAliases(
+    await stageActiveSkill(cwd, 'blog-post', sourceDir);
+
+    const stagedSkillMd = path.join(
       cwd,
-      [{ name: SKILLS_CWD_ALIAS, target: path.join(root, 'absent') }],
-      (msg) => messages.push(msg),
+      SKILLS_CWD_ALIAS,
+      'blog-post',
+      'SKILL.md',
+    );
+    writeFileSync(stagedSkillMd, '# AGENT MUTATED');
+
+    expect(readFileSync(path.join(sourceDir, 'SKILL.md'), 'utf8')).toContain(
+      'original SKILL',
+    );
+    expect(readFileSync(stagedSkillMd, 'utf8')).toContain('AGENT MUTATED');
+  });
+
+  it('replaces a previous stage so removed files are not left behind', async () => {
+    const fs = fresh();
+    const cwd = path.join(fs, 'project');
+    const sourceDir = writeSampleSkill(path.join(fs, 'skills'), 'blog-post');
+    mkdirSync(cwd);
+    await stageActiveSkill(cwd, 'blog-post', sourceDir);
+    const stale = path.join(cwd, SKILLS_CWD_ALIAS, 'blog-post', 'stale.md');
+    writeFileSync(stale, 'should be wiped on next stage');
+
+    await stageActiveSkill(cwd, 'blog-post', sourceDir);
+
+    expect(() => readFileSync(stale)).toThrow();
+  });
+
+  it('follows a symlinked source root via stat() instead of skipping it', async () => {
+    const fs = fresh();
+    const cwd = path.join(fs, 'project');
+    const realRoot = path.join(fs, 'skills-real');
+    const linkedRoot = path.join(fs, 'skills');
+    const realSkill = writeSampleSkill(realRoot, 'blog-post');
+    symlinkSync(realRoot, linkedRoot, 'dir');
+    mkdirSync(cwd);
+
+    const result = await stageActiveSkill(
+      cwd,
+      'blog-post',
+      // simulate the daemon resolving SKILLS_DIR through a symlinked
+      // mount.
+      path.join(linkedRoot, 'blog-post'),
     );
 
-    expect(() => lstatSync(path.join(cwd, SKILLS_CWD_ALIAS))).toThrow();
-    expect(messages).toEqual([]);
+    expect(result.staged).toBe(true);
+    expect(
+      readFileSync(
+        path.join(result.stagedPath!, 'SKILL.md'),
+        'utf8',
+      ),
+    ).toContain('original SKILL');
+    void realSkill;
   });
 
-  it('refuses to clobber a pre-existing real entry under the alias name', async () => {
-    const root = fresh();
-    const cwd = path.join(root, 'project');
-    const src = path.join(root, 'skills');
+  it('upgrades a legacy symlink left by an earlier daemon to a real directory', async () => {
+    const fs = fresh();
+    const cwd = path.join(fs, 'project');
+    const sourceDir = writeSampleSkill(path.join(fs, 'skills'), 'blog-post');
     mkdirSync(cwd);
-    mkdirSync(src);
-    // The user happens to have a regular file at the alias name.
+    // Earlier daemon versions staged the alias root as a directory link
+    // that pointed at SKILLS_DIR. Make sure the new staging logic
+    // detects and replaces that without panicking.
+    symlinkSync(path.dirname(sourceDir), path.join(cwd, SKILLS_CWD_ALIAS), 'dir');
+
+    const messages: string[] = [];
+    const result = await stageActiveSkill(
+      cwd,
+      'blog-post',
+      sourceDir,
+      (m) => messages.push(m),
+    );
+
+    expect(result.staged).toBe(true);
+    expect(
+      lstatSync(path.join(cwd, SKILLS_CWD_ALIAS)).isSymbolicLink(),
+    ).toBe(false);
+    expect(messages.some((m) => m.includes('replacing legacy symlink'))).toBe(
+      true,
+    );
+  });
+
+  it('refuses to stage when the alias root is a regular file', async () => {
+    const fs = fresh();
+    const cwd = path.join(fs, 'project');
+    const sourceDir = writeSampleSkill(path.join(fs, 'skills'), 'blog-post');
+    mkdirSync(cwd);
     writeFileSync(path.join(cwd, SKILLS_CWD_ALIAS), 'user-content');
 
     const messages: string[] = [];
-    await ensureCwdAliases(
+    const result = await stageActiveSkill(
       cwd,
-      [{ name: SKILLS_CWD_ALIAS, target: src }],
-      (msg) => messages.push(msg),
+      'blog-post',
+      sourceDir,
+      (m) => messages.push(m),
     );
 
-    expect(lstatSync(path.join(cwd, SKILLS_CWD_ALIAS)).isFile()).toBe(true);
-    expect(messages.some((m) => m.includes('not a symlink'))).toBe(true);
+    expect(result.staged).toBe(false);
+    expect(result.reason).toMatch(/non-directory/);
+    expect(
+      readFileSync(path.join(cwd, SKILLS_CWD_ALIAS), 'utf8'),
+    ).toBe('user-content');
+    expect(messages.some((m) => m.includes('refusing to stage'))).toBe(true);
   });
 
-  it('processes each spec independently when one fails', async () => {
-    const root = fresh();
-    const cwd = path.join(root, 'project');
-    const goodSrc = path.join(root, 'design-systems');
+  it('skips silently when the source directory does not exist', async () => {
+    const fs = fresh();
+    const cwd = path.join(fs, 'project');
     mkdirSync(cwd);
-    mkdirSync(goodSrc);
-    // Block the first alias by occupying its name with a regular file.
-    writeFileSync(path.join(cwd, SKILLS_CWD_ALIAS), 'user-content');
 
-    const messages: string[] = [];
-    await ensureCwdAliases(
+    const result = await stageActiveSkill(
       cwd,
-      [
-        { name: SKILLS_CWD_ALIAS, target: path.join(root, 'absent') },
-        { name: DESIGN_SYSTEMS_CWD_ALIAS, target: goodSrc },
-      ],
-      (msg) => messages.push(msg),
+      'blog-post',
+      path.join(fs, 'skills', 'missing'),
     );
 
-    // Second alias still created.
-    const goodLink = path.join(cwd, DESIGN_SYSTEMS_CWD_ALIAS);
-    expect(lstatSync(goodLink).isSymbolicLink()).toBe(true);
-    expect(await realpath(goodLink)).toBe(await realpath(goodSrc));
+    expect(result.staged).toBe(false);
+    expect(result.reason).toMatch(/source missing/);
   });
 
-  it('ignores malformed specs without crashing', async () => {
-    const root = fresh();
-    const cwd = path.join(root, 'project');
-    mkdirSync(cwd);
-
-    await ensureCwdAliases(cwd, [
-      // @ts-expect-error intentionally malformed
+  it('returns false without throwing when cwd is null', async () => {
+    const result = await stageActiveSkill(
       null,
-      // @ts-expect-error intentionally malformed
-      { name: 123, target: '/tmp' },
-      // @ts-expect-error intentionally malformed
-      { name: '.od-skills' },
-    ]);
-
-    expect(() => lstatSync(path.join(cwd, SKILLS_CWD_ALIAS))).toThrow();
+      'blog-post',
+      '/does/not/matter',
+    );
+    expect(result.staged).toBe(false);
+    expect(result.reason).toBe('no project cwd');
   });
+
+  it.each([
+    ['', 'unsafe folder name'],
+    ['.', 'unsafe folder name'],
+    ['..', 'unsafe folder name'],
+    ['../escape', 'unsafe folder name'],
+    ['nested/path', 'unsafe folder name'],
+    ['back\\slash', 'unsafe folder name'],
+    ['/abs/path', 'unsafe folder name'],
+  ])(
+    'rejects unsafe folder name %j to keep the alias root sealed',
+    async (folder, expectedReason) => {
+      const fs = fresh();
+      const cwd = path.join(fs, 'project');
+      mkdirSync(cwd);
+
+      const result = await stageActiveSkill(cwd, folder, '/anywhere');
+
+      expect(result.staged).toBe(false);
+      expect(result.reason).toContain(expectedReason);
+    },
+  );
 });

--- a/apps/daemon/tests/cwd-aliases.test.ts
+++ b/apps/daemon/tests/cwd-aliases.test.ts
@@ -1,0 +1,147 @@
+import { lstatSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { realpath } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  DESIGN_SYSTEMS_CWD_ALIAS,
+  SKILLS_CWD_ALIAS,
+  ensureCwdAliases,
+} from '../src/cwd-aliases.js';
+
+function fresh(): string {
+  return mkdtempSync(path.join(tmpdir(), 'od-cwd-alias-'));
+}
+
+describe('ensureCwdAliases', () => {
+  it('exposes documented alias names so the skill preamble stays in sync', () => {
+    expect(SKILLS_CWD_ALIAS).toBe('.od-skills');
+    expect(DESIGN_SYSTEMS_CWD_ALIAS).toBe('.od-design-systems');
+  });
+
+  it('creates a symlink/junction from cwd to the source root', async () => {
+    const root = fresh();
+    const cwd = path.join(root, 'project');
+    const src = path.join(root, 'skills');
+    mkdirSync(cwd);
+    mkdirSync(src);
+    writeFileSync(path.join(src, 'a.txt'), 'hello');
+
+    await ensureCwdAliases(cwd, [
+      { name: SKILLS_CWD_ALIAS, target: src },
+    ]);
+
+    const linkPath = path.join(cwd, SKILLS_CWD_ALIAS);
+    expect(lstatSync(linkPath).isSymbolicLink()).toBe(true);
+    expect(await realpath(linkPath)).toBe(await realpath(src));
+  });
+
+  it('is idempotent when the alias already points at the same target', async () => {
+    const root = fresh();
+    const cwd = path.join(root, 'project');
+    const src = path.join(root, 'skills');
+    mkdirSync(cwd);
+    mkdirSync(src);
+
+    await ensureCwdAliases(cwd, [{ name: SKILLS_CWD_ALIAS, target: src }]);
+    const before = await realpath(path.join(cwd, SKILLS_CWD_ALIAS));
+    await ensureCwdAliases(cwd, [{ name: SKILLS_CWD_ALIAS, target: src }]);
+    const after = await realpath(path.join(cwd, SKILLS_CWD_ALIAS));
+
+    expect(after).toBe(before);
+  });
+
+  it('repoints the alias when the target moves', async () => {
+    const root = fresh();
+    const cwd = path.join(root, 'project');
+    const src1 = path.join(root, 'skills-old');
+    const src2 = path.join(root, 'skills-new');
+    mkdirSync(cwd);
+    mkdirSync(src1);
+    mkdirSync(src2);
+
+    await ensureCwdAliases(cwd, [{ name: SKILLS_CWD_ALIAS, target: src1 }]);
+    await ensureCwdAliases(cwd, [{ name: SKILLS_CWD_ALIAS, target: src2 }]);
+
+    const real = await realpath(path.join(cwd, SKILLS_CWD_ALIAS));
+    expect(real).toBe(await realpath(src2));
+  });
+
+  it('skips silently when the source does not exist', async () => {
+    const root = fresh();
+    const cwd = path.join(root, 'project');
+    mkdirSync(cwd);
+
+    const messages: string[] = [];
+    await ensureCwdAliases(
+      cwd,
+      [{ name: SKILLS_CWD_ALIAS, target: path.join(root, 'absent') }],
+      (msg) => messages.push(msg),
+    );
+
+    expect(() => lstatSync(path.join(cwd, SKILLS_CWD_ALIAS))).toThrow();
+    expect(messages).toEqual([]);
+  });
+
+  it('refuses to clobber a pre-existing real entry under the alias name', async () => {
+    const root = fresh();
+    const cwd = path.join(root, 'project');
+    const src = path.join(root, 'skills');
+    mkdirSync(cwd);
+    mkdirSync(src);
+    // The user happens to have a regular file at the alias name.
+    writeFileSync(path.join(cwd, SKILLS_CWD_ALIAS), 'user-content');
+
+    const messages: string[] = [];
+    await ensureCwdAliases(
+      cwd,
+      [{ name: SKILLS_CWD_ALIAS, target: src }],
+      (msg) => messages.push(msg),
+    );
+
+    expect(lstatSync(path.join(cwd, SKILLS_CWD_ALIAS)).isFile()).toBe(true);
+    expect(messages.some((m) => m.includes('not a symlink'))).toBe(true);
+  });
+
+  it('processes each spec independently when one fails', async () => {
+    const root = fresh();
+    const cwd = path.join(root, 'project');
+    const goodSrc = path.join(root, 'design-systems');
+    mkdirSync(cwd);
+    mkdirSync(goodSrc);
+    // Block the first alias by occupying its name with a regular file.
+    writeFileSync(path.join(cwd, SKILLS_CWD_ALIAS), 'user-content');
+
+    const messages: string[] = [];
+    await ensureCwdAliases(
+      cwd,
+      [
+        { name: SKILLS_CWD_ALIAS, target: path.join(root, 'absent') },
+        { name: DESIGN_SYSTEMS_CWD_ALIAS, target: goodSrc },
+      ],
+      (msg) => messages.push(msg),
+    );
+
+    // Second alias still created.
+    const goodLink = path.join(cwd, DESIGN_SYSTEMS_CWD_ALIAS);
+    expect(lstatSync(goodLink).isSymbolicLink()).toBe(true);
+    expect(await realpath(goodLink)).toBe(await realpath(goodSrc));
+  });
+
+  it('ignores malformed specs without crashing', async () => {
+    const root = fresh();
+    const cwd = path.join(root, 'project');
+    mkdirSync(cwd);
+
+    await ensureCwdAliases(cwd, [
+      // @ts-expect-error intentionally malformed
+      null,
+      // @ts-expect-error intentionally malformed
+      { name: 123, target: '/tmp' },
+      // @ts-expect-error intentionally malformed
+      { name: '.od-skills' },
+    ]);
+
+    expect(() => lstatSync(path.join(cwd, SKILLS_CWD_ALIAS))).toThrow();
+  });
+});

--- a/apps/daemon/tests/cwd-aliases.test.ts
+++ b/apps/daemon/tests/cwd-aliases.test.ts
@@ -16,6 +16,14 @@ function fresh(): string {
   return mkdtempSync(path.join(tmpdir(), 'od-skill-stage-'));
 }
 
+// On Windows, `fs.symlink(target, link, 'dir')` requires
+// SeCreateSymbolicLinkPrivilege / Developer Mode and fails on most CI
+// images. `'junction'` is the directory-only equivalent that does not
+// require elevated privileges, so we use it for fixtures so the daemon
+// suite stays green on Windows runners.
+const dirLinkType: 'dir' | 'junction' =
+  process.platform === 'win32' ? 'junction' : 'dir';
+
 function writeSampleSkill(root: string, folder: string): string {
   const dir = path.join(root, folder);
   mkdirSync(path.join(dir, 'assets'), { recursive: true });
@@ -126,7 +134,7 @@ describe('stageActiveSkill', () => {
     const realRoot = path.join(fs, 'skills-real');
     const linkedRoot = path.join(fs, 'skills');
     const realSkill = writeSampleSkill(realRoot, 'blog-post');
-    symlinkSync(realRoot, linkedRoot, 'dir');
+    symlinkSync(realRoot, linkedRoot, dirLinkType);
     mkdirSync(cwd);
 
     const result = await stageActiveSkill(
@@ -155,7 +163,7 @@ describe('stageActiveSkill', () => {
     // Earlier daemon versions staged the alias root as a directory link
     // that pointed at SKILLS_DIR. Make sure the new staging logic
     // detects and replaces that without panicking.
-    symlinkSync(path.dirname(sourceDir), path.join(cwd, SKILLS_CWD_ALIAS), 'dir');
+    symlinkSync(path.dirname(sourceDir), path.join(cwd, SKILLS_CWD_ALIAS), dirLinkType);
 
     const messages: string[] = [];
     const result = await stageActiveSkill(

--- a/apps/daemon/tests/skills.test.ts
+++ b/apps/daemon/tests/skills.test.ts
@@ -1,0 +1,104 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { listSkills } from '../src/skills.js';
+import { SKILLS_CWD_ALIAS } from '../src/cwd-aliases.js';
+
+function fresh(): string {
+  return mkdtempSync(path.join(tmpdir(), 'od-skills-'));
+}
+
+function writeSkill(
+  root: string,
+  folder: string,
+  options: {
+    name?: string;
+    description?: string;
+    body?: string;
+    withAttachments?: boolean;
+  } = {},
+) {
+  const dir = path.join(root, folder);
+  mkdirSync(dir, { recursive: true });
+  const fm = [
+    '---',
+    `name: ${options.name ?? folder}`,
+    `description: ${options.description ?? 'A test skill.'}`,
+    '---',
+    '',
+    options.body ?? '# Test skill body',
+    '',
+  ].join('\n');
+  writeFileSync(path.join(dir, 'SKILL.md'), fm);
+  if (options.withAttachments) {
+    mkdirSync(path.join(dir, 'assets'), { recursive: true });
+    writeFileSync(
+      path.join(dir, 'assets', 'template.html'),
+      '<html><body>seed</body></html>',
+    );
+  }
+}
+
+describe('listSkills preamble', () => {
+  it('emits a CWD-relative skill root for skills that ship side files', async () => {
+    const root = fresh();
+    writeSkill(root, 'demo-skill', {
+      withAttachments: true,
+      body: 'Use `assets/template.html` to bootstrap.',
+    });
+
+    const skills = await listSkills(root);
+    expect(skills).toHaveLength(1);
+    const [skill] = skills;
+
+    // The preamble must reference the CWD-relative alias, not an absolute
+    // path, so agents stay inside their working directory when reading
+    // skill side files.
+    expect(skill.body).toContain(`${SKILLS_CWD_ALIAS}/demo-skill/`);
+    expect(skill.body).toContain(
+      `${SKILLS_CWD_ALIAS}/demo-skill/assets/template.html`,
+    );
+
+    // The skill folder absolute path must NOT leak into the body — that's
+    // the regression that triggered issue #430 (Claude Code blocked reads
+    // outside the agent's CWD even with `--add-dir`).
+    expect(skill.body).not.toContain(skill.dir);
+    expect(skill.body).not.toMatch(/Skill root \(absolute\)/);
+  });
+
+  it('uses the on-disk folder name in the alias path even when `name` differs', async () => {
+    const root = fresh();
+    writeSkill(root, 'guizang-ppt', {
+      name: 'magazine-web-ppt',
+      withAttachments: true,
+    });
+
+    const skills = await listSkills(root);
+    expect(skills).toHaveLength(1);
+    const [skill] = skills;
+
+    // `id`/`name` reflect the frontmatter value (used elsewhere as a stable
+    // public id), but the on-disk alias path must use the actual folder
+    // name — that is what the daemon-staged junction maps to.
+    expect(skill.id).toBe('magazine-web-ppt');
+    expect(skill.body).toContain(`${SKILLS_CWD_ALIAS}/guizang-ppt/`);
+    expect(skill.body).not.toContain(`${SKILLS_CWD_ALIAS}/magazine-web-ppt/`);
+  });
+
+  it('does not emit a preamble for skills without side files', async () => {
+    const root = fresh();
+    writeSkill(root, 'lone-skill', {
+      withAttachments: false,
+      body: 'Body without external files.',
+    });
+
+    const skills = await listSkills(root);
+    expect(skills).toHaveLength(1);
+    const [skill] = skills;
+
+    expect(skill.body).not.toContain(SKILLS_CWD_ALIAS);
+    expect(skill.body).not.toContain('Skill root');
+    expect(skill.body).toContain('Body without external files.');
+  });
+});

--- a/apps/daemon/tests/skills.test.ts
+++ b/apps/daemon/tests/skills.test.ts
@@ -41,7 +41,7 @@ function writeSkill(
 }
 
 describe('listSkills preamble', () => {
-  it('emits a CWD-relative skill root for skills that ship side files', async () => {
+  it('emits both a cwd-relative skill root and an absolute fallback', async () => {
     const root = fresh();
     writeSkill(root, 'demo-skill', {
       withAttachments: true,
@@ -52,19 +52,23 @@ describe('listSkills preamble', () => {
     expect(skills).toHaveLength(1);
     const [skill] = skills;
 
-    // The preamble must reference the CWD-relative alias, not an absolute
-    // path, so agents stay inside their working directory when reading
-    // skill side files.
+    // The cwd-relative alias path is the primary one — that's what makes
+    // the agent stay inside its working directory when reading skill
+    // side files (issue #430).
     expect(skill.body).toContain(`${SKILLS_CWD_ALIAS}/demo-skill/`);
     expect(skill.body).toContain(
       `${SKILLS_CWD_ALIAS}/demo-skill/assets/template.html`,
     );
 
-    // The skill folder absolute path must NOT leak into the body — that's
-    // the regression that triggered issue #430 (Claude Code blocked reads
-    // outside the agent's CWD even with `--add-dir`).
-    expect(skill.body).not.toContain(skill.dir);
-    expect(skill.body).not.toMatch(/Skill root \(absolute\)/);
+    // The absolute fallback is required for two cases the relative path
+    // cannot serve:
+    //   - calls without a project (cwd defaults to PROJECT_ROOT, where
+    //     the absolute path is in fact an in-cwd path);
+    //   - environments where `stageActiveSkill()` failed.
+    // Claude/Copilot are additionally given `--add-dir` for that path.
+    expect(skill.body).toContain(skill.dir);
+    expect(skill.body).toMatch(/Skill root \(absolute fallback\)/);
+    expect(skill.body).toMatch(/Skill root \(relative to project\)/);
   });
 
   it('uses the on-disk folder name in the alias path even when `name` differs', async () => {


### PR DESCRIPTION
Closes #430.

## Problem

When the daemon spawns a code-agent CLI, `cwd` is pinned to the project
folder (`.od/projects/<id>/`) but skill side-files live under
`<repo>/skills/<id>/...`. The previous fix (#6) emitted absolute paths
inside the skill preamble and relied on `--add-dir` to widen Claude's
allowlist.

That contract is fragile in two ways:

1. **Most agents have no `--add-dir`-equivalent.** `codex`, `gemini`,
   `opencode`, `cursor-agent`, `qwen`, `pi`, `hermes`, and `kimi` all
   ignore the absolute paths in the preamble — every skill that ships
   side files (e.g. `assets/template.html`) is a designed-in failure
   on those agents.
2. **Claude Code itself can still refuse them.** Under specific
   permission / trust configurations the directory-access policy
   blocks reads outside `cwd` even with `--add-dir` and
   `--permission-mode bypassPermissions`. This is what issue #430
   reproduces in the wild.

## Root cause

The architecture coupled skill resource visibility to a per-CLI
"extra allowed directories" flag — a contract no agent universally
honours and Claude Code itself does not honour in every config.

## Fix

Expose skill (and design-system) resources from inside the agent's
own working directory:

1. **`apps/daemon/src/cwd-aliases.ts` (new).** `ensureCwdAliases(cwd, specs)`
   stages a directory link at `<cwd>/.od-skills -> <SKILLS_DIR>` and
   `<cwd>/.od-design-systems -> <DESIGN_SYSTEMS_DIR>`. POSIX uses a
   symbolic link, Windows uses a directory junction (no admin
   privilege required). The function is idempotent, repoints when the
   target moves, and refuses to clobber a non-symlink entry under the
   reserved name to avoid destroying user data.
2. **`apps/daemon/src/skills.ts`.** `withSkillRootPreamble` is
   rewritten to point at `.od-skills/<folder>/` instead of an
   absolute path — every reference now resolves inside the agent's
   cwd, so directory-access policies cannot block it on any CLI.
3. **`apps/daemon/src/server.ts`.** The chat handler calls
   `ensureCwdAliases` before composing the prompt. `extraAllowedDirs`
   (and the `--add-dir` flags it feeds) are kept as a
   belt-and-suspenders fallback for Claude/Copilot.

## Why this design

- **Universal.** Works on every agent CLI without per-CLI flag wiring.
- **Zero copy.** Junction/symlink — no skill data duplicated per
  project.
- **Self-healing.** Idempotent on every chat turn; recovers from
  manual edits, target moves, dangling links.
- **Conservative.** Refuses to overwrite a real entry the user
  created under the reserved alias name. If the alias cannot be
  staged, the absolute-path `--add-dir` path still serves Claude /
  Copilot.

## Validation

```bash
PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm typecheck   # passes
PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm test        # daemon 378 / web 169 / tools-pack 24 pass
PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm check:residual-js   # passes
```

New tests:

- `apps/daemon/tests/cwd-aliases.test.ts` (8 cases): create, idempotent
  re-run, repoint when target moves, skip when source absent, refuse to
  clobber a real entry, isolation between specs, malformed-spec safety.
- `apps/daemon/tests/skills.test.ts` (3 cases): preamble emits the
  cwd-relative alias, uses the on-disk folder name (not the
  frontmatter `name` which can differ), and skips the preamble when
  the skill ships no side files.

## Compatibility / risk

- Skills that already work under Claude Code with `--add-dir` continue
  to work — they simply pick up the alias path first.
- No public API change in `/api/skills` (only the body preamble text
  changed).
- Windows uses `fs.symlink(target, linkPath, 'junction')`, which Node
  documents as not requiring `SeCreateSymbolicLinkPrivilege`.
- If `OD_RESOURCE_ROOT` or `OD_DATA_DIR` puts the resource roots and
  the project cwd on different volumes, junction creation fails — the
  warning is logged and Claude/Copilot fall back to the existing
  `--add-dir` path; other agents on that exotic configuration would
  not have worked before this PR either.
