### PR TITLE
fix(daemon): correct Claude Code --add-dir capability detection (fix …

### DIFF
--- a/apps/daemon/src/agents.ts
+++ b/apps/daemon/src/agents.ts
@@ -124,10 +124,13 @@ export const AGENT_DEFS = [
     // — issue #235) get auto-detected without writing wrapper scripts.
     fallbackBins: ['openclaude'],
     versionArgs: ['--version'],
-    helpArgs: ['--help'],
+    helpArgs: ['-p', '--help'],
     capabilityFlags: {
       // Flag string -> capability key. After probing `--help`, we set
       // `agentCapabilities[id][key] = true` for each substring that matches.
+      // `--add-dir` and `--include-partial-messages` live under `claude -p`
+      // subcommand, so we probe `claude -p --help` instead of `claude --help`.
+      // Fixes issue #430: --add-dir never detected because it wasn't in global help.
       '--include-partial-messages': 'partialMessages',
       '--add-dir': 'addDir',
     },

--- a/apps/daemon/tests/agents.test.ts
+++ b/apps/daemon/tests/agents.test.ts
@@ -272,6 +272,61 @@ test('claude flags promptViaStdin and never embeds the prompt in argv', () => {
   assert.ok(args.includes('-p'), 'claude argv must include -p');
 });
 
+// ---- Claude Code --add-dir capability (issue #430) -------------------------
+// Skill seeds (`skills/<id>/assets/template.html`) and design-system specs
+// (`design-systems/<id>/DESIGN.md`) live outside the project cwd. Without
+// `--add-dir`, Claude Code's directory access policy blocks reads on any
+// path outside the working directory. Bug was that we probed global `claude
+// --help` for `--add-dir` but that flag only appears in `claude -p --help`.
+
+test('claude buildArgs passes --add-dir when dirs are supplied (issue #430, probing-failed baseline)', () => {
+  // This is the default state before any capability probe runs: agentCapabilities
+  // has no entry -> buildArgs gets `caps = {}` -> caps.addDir is undefined ->
+  // undefined !== false -> true. This is also the "probing threw" case: timeout,
+  // binary not found, non-zero exit code from --help. Dirs are always passed
+  // unless capability probing explicitly detected --help and found no --add-dir.
+  const args = claude.buildArgs(
+    '',
+    [],
+    ['/repo/skills', '/repo/design-systems'],
+    {},
+  );
+
+  const addDirIndex = args.indexOf('--add-dir');
+  assert.ok(addDirIndex >= 0, '--add-dir must be present by default (safe baseline)');
+  assert.equal(args[addDirIndex + 1], '/repo/skills');
+  assert.equal(args[addDirIndex + 2], '/repo/design-systems');
+  // Check flag ordering: --add-dir comes before --permission-mode
+  const permModeIndex = args.indexOf('--permission-mode');
+  assert.ok(
+    addDirIndex < permModeIndex,
+    `--add-dir (index ${addDirIndex}) should appear before --permission-mode (index ${permModeIndex})`,
+  );
+});
+
+test('claude buildArgs drops empty / null dirs but keeps valid ones (issue #430 edge case)', () => {
+  const args = claude.buildArgs('', [], ['', null, '/repo/skills', undefined], {});
+
+  const addDirIndex = args.indexOf('--add-dir');
+  assert.ok(addDirIndex >= 0, '--add-dir should survive filter');
+  // Only the one valid path survives after --add-dir.
+  assert.equal(args[addDirIndex + 1], '/repo/skills');
+  // Should NOT have multiple --add-dir flags (one flag, N arguments).
+  assert.equal(args.filter((a) => a === '--add-dir').length, 1);
+  // Should NOT have null / undefined / '' sneaking into argv.
+  assert.equal(args.includes(''), false);
+  assert.equal(args.includes(null), false);
+  assert.equal(args.includes(undefined), false);
+});
+
+test('claude helpArgs probes the -p subcommand where --add-dir lives (issue #430 root cause)', () => {
+  assert.deepEqual(
+    claude.helpArgs,
+    ['-p', '--help'],
+    `claude.helpArgs must be ['-p', '--help'], not just ['--help'], because --add-dir lives under the -p subcommand. Probing global help never finds it! Got: ${JSON.stringify(claude.helpArgs)}`,
+  );
+});
+
 // ---- OpenClaude fallback (issue #235) -------------------------------------
 // OpenClaude (https://github.com/Gitlawb/openclaude) is a Claude Code fork
 // that ships under a different binary name but speaks an argv-compatible


### PR DESCRIPTION
## Description

This PR fixes issue #430 where Claude Code failed to read skill files due to incorrect directory access policy enforcement.

### Root Cause

The Claude Code agent definition was probing **global** `claude --help` output for capability flags, but `--add-dir` and `--include-partial-messages` are **subcommand-specific flags** that only appear under `claude -p --help`, not in the global help output.

This caused:
1. Capability detection to incorrectly set `caps.addDir = false` for users with working Claude Code installations
2. The `--add-dir` flag was therefore never passed on agent spawn
3. Claude Code's sandbox enforcement blocked all absolute-path reads outside the project cwd
4. Skill files, skill assets, and design-system specs could not be read by the agent

> **Note:** The "probing failed / timeout" path already worked correctly, as it fell back to an empty capabilities object `{}` which defaulted to passing `--add-dir`. The failure mode only manifested when the help probe actually succeeded.

---

## Impact Analysis

### Scope
| Aspect | Impact |
|---|---|
| **Agents affected** | Claude Code ONLY. All 12+ other agents (Codex, Cursor, Devin, Gemini, etc.) are completely untouched. |
| **Code change surface** | 1 line changed in `helpArgs` + comment. No logic changes to any other agent. |
| **API compatibility** | No external API changes. `helpArgs` is stripped before serialization. |
| **Backward compatibility** | Fully backward compatible. Older Claude Code versions continue to work via fallback mechanism. |

### Execution Paths Affected

| Path | Before | After |
|---|---|---|
| Daemon agent detection | `execFile('claude', ['--help'])` | `execFile('claude', ['-p', '--help'])` |
| Agent spawn `buildArgs` | `--add-dir` never passed when probe succeeded | `--add-dir` correctly passed when detected |
| `/api/agents` endpoint | `helpArgs` internal-only field stripped | No change — still stripped |

---

## Changes Made

| File | Change |
|---|---|
| `apps/daemon/src/agents.ts` | Updated Claude Code `helpArgs` to probe subcommand help |
| `apps/daemon/tests/agents.test.ts` | Added 3 regression tests for issue #430 |

---

## Regression Protection

Tests added:
1. ✅ Default `--add-dir` propagation when directories are supplied
2. ✅ Correct filtering of empty/null directory entries
3. ✅ Explicit assertion that `['-p', '--help']` is used for probing (prevents regression)

---

## Testing

1. **Before this fix:** Running `claude --help | grep --add-dir` returns no matches
2. **After this fix:** Running `claude -p --help | grep --add-dir` correctly finds the flag
3. All existing agent tests continue to pass
4. New regression tests prevent this specific failure mode from recurring
 