### PR TITLE
fix(web): language option button height truncation in settings

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1433,13 +1433,13 @@ code {
   position: fixed;
   z-index: 1000;
   max-width: calc(100vw - 24px);
-  /* 360px = 9 locales × ~40px; --menu-available-h is set by JS to the
+  /* 7 locales × ~58px ≈ 406px; --menu-available-h is set by JS to the
      distance between the trigger and whichever viewport edge the menu
      opens toward, so the menu never overflows the viewport regardless of
      placement direction (above or below the trigger). The 60vh cap keeps
      the menu from feeling cramped on short viewports (mobile landscape,
      ~400–500px tall). */
-  max-height: min(360px, 60vh, var(--menu-available-h, 360px));
+  max-height: min(406px, 60vh, var(--menu-available-h, 406px));
   overflow-y: auto;
   overscroll-behavior: contain;
   display: flex;
@@ -1457,7 +1457,6 @@ code {
   align-items: center;
   gap: 12px;
   width: 100%;
-  min-height: 40px;
   padding: 10px 12px;
   border: 0;
   border-radius: 9px;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1433,13 +1433,12 @@ code {
   position: fixed;
   z-index: 1000;
   max-width: calc(100vw - 24px);
-  /* 7 locales × ~58px ≈ 406px; --menu-available-h is set by JS to the
-     distance between the trigger and whichever viewport edge the menu
-     opens toward, so the menu never overflows the viewport regardless of
-     placement direction (above or below the trigger). The 60vh cap keeps
-     the menu from feeling cramped on short viewports (mobile landscape,
-     ~400–500px tall). */
-  max-height: min(406px, 60vh, var(--menu-available-h, 406px));
+  /* 7 locales × ~58px + menu chrome (padding, gap, border) ≈ 428px;
+     --menu-available-h is set by JS to the distance between the trigger
+     and whichever viewport edge the menu opens toward, so the menu never
+     overflows the viewport regardless of placement direction. The 60vh
+     cap keeps the menu from feeling cramped on short viewports. */
+  max-height: min(428px, 60vh, var(--menu-available-h, 428px));
   overflow-y: auto;
   overscroll-behavior: contain;
   display: flex;


### PR DESCRIPTION
## Summary

- Remove `min-height: 40px` from `.settings-language-option` — the hardcoded minimum constrains button height when locale labels wrap to two lines, causing the second line to overflow outside the button.
- Update `.settings-language-menu` max-height budget from `360px` (9 × 40px) to `406px` (7 × 58px) to match the natural item height.

## Background

PR #287 added `min-height: 40px` to ensure consistent row height, with the menu `max-height` calculated as `9 locales × ~40px = 360px`. This assumption breaks when locale labels are long enough to wrap (e.g. Chinese or other multi-byte labels), where each item naturally sizes to ~58px instead of 40px.

## Changes

| File | Change |
|------|--------|
| `apps/web/src/index.css` | Remove `min-height: 40px` from `.settings-language-option`; update menu `max-height` from `360px` to `406px` |

## Test plan

- [ ] Open Settings → Language picker, verify all locale options display fully without text overflow
- [ ] Verify menu scrolls correctly when content exceeds viewport height
- [ ] Test on short viewport (mobile landscape) to confirm `60vh` cap still applies