### PR TITLE
fix(web): prevent vertical scrollbar on ws-tabs-bar

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -3403,6 +3403,7 @@ code {
   border-bottom: 1px solid var(--border);
   background: var(--bg-panel);
   overflow-x: auto;
+  overflow-y: hidden;
   flex-wrap: nowrap;
   height: 44px;
   position: sticky;


### PR DESCRIPTION
## Summary

- Add `overflow-y: hidden` to `.ws-tabs-bar` to prevent an unintended vertical scrollbar.

## Background

Setting `overflow-x: auto` on `.ws-tabs-bar` implicitly sets `overflow-y` to `auto` per CSS spec. Combined with the fixed `height: 44px`, any vertical overflow (even 1px) triggers a vertical scrollbar.

## Changes

| File | Change |
|------|--------|
| `apps/web/src/index.css` | Add `overflow-y: hidden` to `.ws-tabs-bar` |

## Test plan

- [ ] Open a workspace with enough tabs to overflow horizontally
- [ ] Verify only a horizontal scrollbar appears, no vertical scrollbar
- [ ] Verify horizontal scrolling still works correctly