### PR TITLE
release: Open Design 0.4.0 — Live artifacts + Composio, MCP server, Critique Theater, Linux desktop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,122 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-05
+
+A multi-platform, multi-protocol leap: Open Design now ships as an MCP server, lands on Linux desktops, ships Critique Theater (Design Jury) Phase 4, gains live-reload + Tweaks mode + live artifacts in the preview pane, and adds five new agent / runtime adapters. 71 merged PRs from 40+ contributors over two days.
+
+### Added
+
+#### MCP & agent integration
+- **`od mcp` — expose Open Design as a stdio MCP server.** Coding agents in other repos (Claude Code, Codex, Cursor, VS Code, Antigravity, Zed, Windsurf) can read files from local Open Design projects directly, including the project the user has open in the Open Design app right now. ([#399])
+- **Link code folder support for agent context** — point agents at any local code folder alongside the design project. ([#455])
+- Kilo CLI (ACP) agent adapter. ([#480])
+- DeepSeek TUI agent adapter. ([#439])
+
+#### Critique workflow
+- **Critique Theater Phase 4** — persistence, transcript, and orchestrator. The "Design Jury" multi-panelist scoring pipeline is now end-to-end. ([#481])
+- Critique Theater foundation — shared contracts and streaming v1 parser (Phases 0–2). ([#387])
+
+#### Preview pane
+- **Live-reload preview iframes** when project files change on disk. ([#409])
+- **Tweaks mode for HTML previews** — element picker, pod selection, batched chat attachments. ([#513])
+- URL-load HTML preview iframes by default (`?forceInline=1` opt-out). ([#384])
+- **Live artifacts and Composio connector catalog.** ([#381])
+
+#### Packaging & deployment
+- **Linux x64 AppImage** in `tools-pack` and the release workflows. ([#369])
+- Optimize packaged mac artifact size. ([#424])
+
+#### Daemon
+- `OD_MEDIA_CONFIG_DIR` to relocate `media-config.json` (Nix store, immutable images, sandboxes). ([#411])
+- Modernized multi-provider API proxy routing (Anthropic, OpenAI-compatible, Azure OpenAI, Google Gemini). ([#385])
+- Seed daemon with pre-baked decks and web prototypes. ([#457])
+
+#### Skills, design systems & prompt templates
+- **Atelier Zero** editorial collage landing-page design system. ([#366])
+- `open-design-landing` rename, **kami skill bundle**, and landing OG assets. ([#428])
+- Craft `animation-discipline` module + opt-ins on mobile-app, mobile-onboarding, gamified-app. ([#515])
+- Craft `state-coverage` module + opt-ins on dashboard, mobile-app, kanban-board. ([#502])
+
+#### Web / UI
+- Skills & design systems management page in Settings. ([#535])
+
+#### Design Files
+- Batch ZIP download with multi-select. ([#405])
+
+#### Internationalization
+- Complete **French** localization, README, and Quickstart. ([#326], [#397], [#434])
+- **Ukrainian** UI localization. ([#395])
+- **Russian** UI locale refresh + README + gallery metadata. ([#393], [#396])
+- Brazilian Portuguese README translation. ([#460])
+- Arabic README translation. ([#458])
+
+### Changed
+
+- Refactor `RUNTIME_DATA_DIR` resolution logic. ([#391])
+- Update Codex sandbox invocation. ([#477])
+
+### Fixed
+
+#### Security
+- Bind daemon to localhost by default + origin validation. ([#365])
+- Strip `ANTHROPIC_API_KEY` when spawning Claude Code. ([#400])
+- Preserve `ANTHROPIC_API_KEY` when `ANTHROPIC_BASE_URL` is set. ([#514])
+- Preserve `*_API_KEY` env vars for CLI agents in packaged builds. ([#404])
+- Normalize daemon proxy origins. ([#392])
+
+#### Daemon
+- Resolve daemon `package.json` from any compiled layout so the packaged app reports the correct version. ([#537])
+- Correct Claude Code `--add-dir` capability detection. ([#440])
+- Handle ACP `-32603` errors gracefully in `session/set_model`. ([#492])
+- Expose skill resources via cwd-relative aliases. ([#435])
+- Support nested paths in project file serve route. ([#401])
+- Respect baseUrl path verbatim in OpenAI-compat proxy. ([#410])
+
+#### Web UI
+- Prevent vertical scrollbar on artifact preview frame. ([#453])
+- Prevent vertical scrollbar on `ws-tabs-bar`. ([#448])
+- Language option button height truncation in Settings. ([#447])
+- Aspect-ratio cards no longer overflow into siblings. ([#476])
+- Add copy buttons for FileViewer code blocks. ([#471])
+- Lowercase `todowrite` compatibility in ToolCard. ([#523])
+- Cap `htmlPreviewSlideState` Map to prevent memory leak. ([#488])
+- Isolate preview blob export paths. ([#429])
+- Split execution-mode tabs and align active chip visuals. ([#418])
+- Tighten entry-tab layout and design-system showcase color picker. ([#412])
+- Lift coming-soon tip above sticky tabs and make it readable in dark theme. ([#382])
+- Fix file tab wheel scrolling. ([#549])
+
+#### Design Files
+- Clear selection on project switch. ([#465])
+
+#### Agents
+- Copilot prompt processing with correct command format. ([#466])
+- Codex Gemini CLI trust handling. ([#352])
+
+#### Desktop
+- Show window on macOS dock activate. ([#270])
+
+#### Packaging
+- Bundle prompt templates in packaged desktop resources. ([#417])
+
+#### Landing page
+- Deploy with `npm wrangler`. ([#421])
+
+### Documentation
+
+- Discord invite badge in README. ([#504])
+- Surface desktop downloads in README. ([#522])
+- "Running the Project" section in README. ([#468])
+- First-PR link points to /contribute page. ([#494])
+- Defer README template-driven generation; capture #195 discussion. ([#403])
+- Fix typo in zh-TW README. ([#548])
+- Auto-generated metrics SVG and contributors wall refresh. ([#406], [#407], [#489], [#490])
+
+### Internal
+
+- Enforce test directory conventions. ([#496])
+
 ## [0.3.0] - 2026-05-03
 
 A fast follow-up to 0.2.0 focused on richer design workflows, packaged-agent reliability, export/deploy flows, and broader internationalization. 39 merged PRs from 25 contributors.
@@ -249,7 +365,8 @@ First public release of Open Design — a local-first, open-source alternative t
 - Beta release workflow placeholder. ([#36])
 - Git commit co-author policy. ([#131])
 
-[Unreleased]: https://github.com/nexu-io/open-design/compare/open-design-v0.3.0...HEAD
+[Unreleased]: https://github.com/nexu-io/open-design/compare/open-design-v0.4.0...HEAD
+[0.4.0]: https://github.com/nexu-io/open-design/releases/tag/open-design-v0.4.0
 [0.3.0]: https://github.com/nexu-io/open-design/releases/tag/open-design-v0.3.0
 [0.2.0]: https://github.com/nexu-io/open-design/releases/tag/open-design-v0.2.0
 [0.1.0]: https://github.com/nexu-io/open-design/releases/tag/open-design-v0.1.0
@@ -421,3 +538,74 @@ First public release of Open Design — a local-first, open-source alternative t
 [#296]: https://github.com/nexu-io/open-design/pull/296
 [#300]: https://github.com/nexu-io/open-design/pull/300
 [#309]: https://github.com/nexu-io/open-design/pull/309
+[#270]: https://github.com/nexu-io/open-design/pull/270
+[#326]: https://github.com/nexu-io/open-design/pull/326
+[#352]: https://github.com/nexu-io/open-design/pull/352
+[#365]: https://github.com/nexu-io/open-design/pull/365
+[#366]: https://github.com/nexu-io/open-design/pull/366
+[#369]: https://github.com/nexu-io/open-design/pull/369
+[#381]: https://github.com/nexu-io/open-design/pull/381
+[#382]: https://github.com/nexu-io/open-design/pull/382
+[#384]: https://github.com/nexu-io/open-design/pull/384
+[#385]: https://github.com/nexu-io/open-design/pull/385
+[#387]: https://github.com/nexu-io/open-design/pull/387
+[#391]: https://github.com/nexu-io/open-design/pull/391
+[#392]: https://github.com/nexu-io/open-design/pull/392
+[#393]: https://github.com/nexu-io/open-design/pull/393
+[#395]: https://github.com/nexu-io/open-design/pull/395
+[#396]: https://github.com/nexu-io/open-design/pull/396
+[#397]: https://github.com/nexu-io/open-design/pull/397
+[#399]: https://github.com/nexu-io/open-design/pull/399
+[#400]: https://github.com/nexu-io/open-design/pull/400
+[#401]: https://github.com/nexu-io/open-design/pull/401
+[#403]: https://github.com/nexu-io/open-design/pull/403
+[#404]: https://github.com/nexu-io/open-design/pull/404
+[#405]: https://github.com/nexu-io/open-design/pull/405
+[#406]: https://github.com/nexu-io/open-design/pull/406
+[#407]: https://github.com/nexu-io/open-design/pull/407
+[#409]: https://github.com/nexu-io/open-design/pull/409
+[#410]: https://github.com/nexu-io/open-design/pull/410
+[#411]: https://github.com/nexu-io/open-design/pull/411
+[#412]: https://github.com/nexu-io/open-design/pull/412
+[#417]: https://github.com/nexu-io/open-design/pull/417
+[#418]: https://github.com/nexu-io/open-design/pull/418
+[#421]: https://github.com/nexu-io/open-design/pull/421
+[#424]: https://github.com/nexu-io/open-design/pull/424
+[#428]: https://github.com/nexu-io/open-design/pull/428
+[#429]: https://github.com/nexu-io/open-design/pull/429
+[#434]: https://github.com/nexu-io/open-design/pull/434
+[#435]: https://github.com/nexu-io/open-design/pull/435
+[#439]: https://github.com/nexu-io/open-design/pull/439
+[#440]: https://github.com/nexu-io/open-design/pull/440
+[#447]: https://github.com/nexu-io/open-design/pull/447
+[#448]: https://github.com/nexu-io/open-design/pull/448
+[#453]: https://github.com/nexu-io/open-design/pull/453
+[#455]: https://github.com/nexu-io/open-design/pull/455
+[#457]: https://github.com/nexu-io/open-design/pull/457
+[#458]: https://github.com/nexu-io/open-design/pull/458
+[#460]: https://github.com/nexu-io/open-design/pull/460
+[#465]: https://github.com/nexu-io/open-design/pull/465
+[#466]: https://github.com/nexu-io/open-design/pull/466
+[#468]: https://github.com/nexu-io/open-design/pull/468
+[#471]: https://github.com/nexu-io/open-design/pull/471
+[#476]: https://github.com/nexu-io/open-design/pull/476
+[#477]: https://github.com/nexu-io/open-design/pull/477
+[#480]: https://github.com/nexu-io/open-design/pull/480
+[#481]: https://github.com/nexu-io/open-design/pull/481
+[#488]: https://github.com/nexu-io/open-design/pull/488
+[#489]: https://github.com/nexu-io/open-design/pull/489
+[#490]: https://github.com/nexu-io/open-design/pull/490
+[#492]: https://github.com/nexu-io/open-design/pull/492
+[#494]: https://github.com/nexu-io/open-design/pull/494
+[#496]: https://github.com/nexu-io/open-design/pull/496
+[#502]: https://github.com/nexu-io/open-design/pull/502
+[#504]: https://github.com/nexu-io/open-design/pull/504
+[#513]: https://github.com/nexu-io/open-design/pull/513
+[#514]: https://github.com/nexu-io/open-design/pull/514
+[#515]: https://github.com/nexu-io/open-design/pull/515
+[#522]: https://github.com/nexu-io/open-design/pull/522
+[#523]: https://github.com/nexu-io/open-design/pull/523
+[#537]: https://github.com/nexu-io/open-design/pull/537
+[#535]: https://github.com/nexu-io/open-design/pull/535
+[#548]: https://github.com/nexu-io/open-design/pull/548
+[#549]: https://github.com/nexu-io/open-design/pull/549

--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/daemon",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "main": "./dist/cli.js",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/desktop",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "main": "./dist/main/index.js",

--- a/apps/landing-page/package.json
+++ b/apps/landing-page/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/landing-page",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/packaged/package.json
+++ b/apps/packaged/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/packaged",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/web",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/e2e",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-design",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "packageManager": "pnpm@10.33.2",
   "type": "module",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/contracts",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "description": "Shared pure TypeScript contracts for the Open Design web/daemon boundary.",

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/platform",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/sidecar-proto/package.json
+++ b/packages/sidecar-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/sidecar-proto",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/sidecar/package.json
+++ b/packages/sidecar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/sidecar",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/tools/dev/package.json
+++ b/tools/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-dev",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-pack",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "bin": {


### PR DESCRIPTION

🎉 **`71 PRs` · `100+ contributors` · `2 days`** — Open Design 0.4.0 levels up across the board: a brand-new **live artifacts** platform with a Composio connector catalog, **MCP** integration with every major AI editor, the **first Linux desktop** release, **Critique Theater (Design Jury)** scoring drafts before they ship, plus a wave of preview / agent / i18n / security work. 🚀

## 🔥 Highlights

- ✨ **Live artifacts + Composio connector catalog.** Designs that don't go stale: artifacts react to live data, and the new catalog plugs into hundreds of SaaS tools through Composio. (#381) Thanks @mrcfps.
- 🤖 **MCP server (`od mcp`).** Stop screenshotting your designs into Cursor — Claude Code, Cursor, VS Code, Zed, Windsurf and any MCP-aware tool now read your Open Design files directly. (#399) Thanks @emilneander.
- 🎭 **Critique Theater (Design Jury) ships end-to-end.** No more "good enough" drafts: every artifact gets graded by five panelists on accessibility, brand fit, and craft, and only ships above 8/10. (#387, #481) Thanks @Nagendhra-web.
- 🐧 **Linux x64 AppImage.** Linux desktops finally get Open Design as a one-file installer — and it now runs cleanly in Nix, sandboxes, and other locked-down boxes. (#369, #411) Thanks @iuliandita and @GodTamIt.
- ⚡ **Live-reload + Tweaks-mode HTML previews.** Stop hitting reload — save a file and the preview refreshes itself; click any element to drop a tweak straight into the agent's context. (#384, #409, #513) Thanks @bankielewicz and @Martin-Atrin.
- 🪢 **Link code folder for agent context.** Your agent can finally see your design and your code repo at the same time — point it at a folder, no copy-paste. (#455) Thanks @encyc.
- 🤖 **Kilo CLI + DeepSeek TUI agent adapters.** Two more AI agents to pick from — Open Design now drives 13+ coding CLIs out of the box. (#439, #480) Thanks @Ajay-Satish-01 and @pftom.
- 🌍 **Five new locale pushes.** Open Design speaks more of your team's languages — Ukrainian and full French UIs, refreshed Russian, plus Brazilian Portuguese and Arabic READMEs. (#326, #393, #395, #396, #397, #434, #458, #460) Thanks @davezfr, @DrMaks22, @devcodex2025, @qiongyu1999, and @oscarnogueira.
- 🔒 **Daemon localhost binding + API key hygiene.** Self-hosters can sleep better — Open Design no longer exposes itself to your LAN by default, and your API keys stay sealed when agents spawn. (#365, #392, #400, #404, #514) Thanks @JasonOA888, @sebastianwestberg, @aitonic, @VioletCoding, and @lefarcen.

> 📥 **Download:** the table below points at the final asset URLs — links go live once this PR is merged and the `release-stable` workflow finishes. Tag: `open-design-v0.4.0`.
>
> | Platform | Architecture | Asset |
> |---|---|---|
> | macOS | Apple Silicon (arm64) | [open-design-0.4.0-mac-arm64.dmg](https://github.com/nexu-io/open-design/releases/download/open-design-v0.4.0/open-design-0.4.0-mac-arm64.dmg) |
> | macOS (auto-update feed) | Apple Silicon (arm64) | [open-design-0.4.0-mac-arm64.zip](https://github.com/nexu-io/open-design/releases/download/open-design-v0.4.0/open-design-0.4.0-mac-arm64.zip) |
> | Windows | x64 (unsigned) | [open-design-0.4.0-win-x64-setup.exe](https://github.com/nexu-io/open-design/releases/download/open-design-v0.4.0/open-design-0.4.0-win-x64-setup.exe) |
> | **Linux** 🆕 | **x64 AppImage** | [**open-design-0.4.0-linux-x86_64.AppImage**](https://github.com/nexu-io/open-design/releases/download/open-design-v0.4.0/open-design-0.4.0-linux-x86_64.AppImage) |

## ✨ What's New

### 🤖 MCP & agent integration

- **`od mcp` — stdio MCP server.** Drop into Claude Code / Cursor / VS Code / Zed / Windsurf via standard MCP config. (#399) Thanks @emilneander.
- **Link code folder support for agent context.** (#455) Thanks @encyc.
- **Kilo CLI (ACP)** agent adapter. (#480) Thanks @Ajay-Satish-01.
- **DeepSeek TUI** agent adapter. (#439) Thanks @pftom.

### 🎭 Critique workflow

- **Critique Theater Phase 4** — persistence, transcript, orchestrator. (#481) Thanks @Nagendhra-web.
- Critique Theater foundation — shared contracts and streaming v1 parser. (#387) Thanks @Nagendhra-web.

### 🖼️ Preview pane

- **Live-reload preview iframes.** (#409) Thanks @bankielewicz.
- **Tweaks mode for HTML previews** — element picker, pod selection, batched chat attachments. (#513) Thanks @Martin-Atrin.
- URL-load HTML preview iframes by default. (#384) Thanks @bankielewicz.
- **Live artifacts and Composio connector catalog.** (#381) Thanks @mrcfps.

### 📦 Packaging & deployment

- **Linux x64 AppImage.** (#369) Thanks @iuliandita.
- Optimize packaged mac artifact size. (#424) Thanks @PerishCode.

### 🤖 Daemon

- `OD_MEDIA_CONFIG_DIR` for read-only / immutable installs. (#411) Thanks @GodTamIt.
- Modernized multi-provider API proxy routing (Anthropic, OpenAI-compatible, Azure OpenAI, Google Gemini). (#385) Thanks @lefarcen.
- Seed daemon with pre-baked decks and web prototypes. (#457) Thanks @pftom.

### 🎨 Skills, design systems & prompt templates

- **Atelier Zero** editorial collage landing-page design system. (#366) Thanks @pftom.
- `open-design-landing` rename + **kami skill bundle** + landing OG assets. (#428) Thanks @pftom.
- Craft `animation-discipline` module + opt-ins on mobile-app, mobile-onboarding, gamified-app. (#515) Thanks @MohamedAbdallah-14.
- Craft `state-coverage` module + opt-ins on dashboard, mobile-app, kanban-board. (#502) Thanks @MohamedAbdallah-14.

### 📁 Design Files

- Batch ZIP download with multi-select. (#405) Thanks @dabing1022.

### 🌍 Internationalization

- 🇫🇷 Complete **French** localization, README, and Quickstart. (#326, #397, #434) Thanks @davezfr.
- 🇺🇦 **Ukrainian** UI localization. (#395) Thanks @devcodex2025.
- 🇷🇺 **Russian** UI refresh + README + gallery metadata. (#393, #396) Thanks @DrMaks22.
- 🇧🇷 Brazilian Portuguese README. (#460) Thanks @oscarnogueira.
- 🇸🇦 Arabic README translation. (#458) Thanks @qiongyu1999.

## 🛡️ Stability & Reliability

- 🔒 **Bind daemon to localhost by default with origin validation.** (#365) Thanks @JasonOA888.
- 🔑 **Strip `ANTHROPIC_API_KEY` when spawning Claude Code** + preserve when `ANTHROPIC_BASE_URL` is set. (#400, #514) Thanks @sebastianwestberg and @VioletCoding.
- 📦 **Preserve `*_API_KEY` env vars for CLI agents in packaged builds.** (#404) Thanks @aitonic.
- 🌐 **Normalize daemon proxy origins.** (#392) Thanks @lefarcen.
- 🆔 **Daemon `package.json` resolves from any compiled layout** so the packaged app reports the correct version. (#537) Thanks @jinmeihong0201-gif.
- 🛂 **Correct Claude Code `--add-dir` capability detection.** (#440) Thanks @1119302165.
- 🔧 **Handle ACP `-32603` errors gracefully** in `session/set_model`. (#492) Thanks @goemonwanwan.
- 📂 **Skill resources via cwd-relative aliases** + nested project file paths. (#401, #435) Thanks @nikshh and @fancyboi999.
- 🔌 **Respect `baseUrl` path verbatim in OpenAI-compat proxy.** (#410) Thanks @GodTamIt.

## 🐛 Bug Fixes

- 📜 Prevent vertical scrollbar on artifact preview frame and `ws-tabs-bar`. (#448, #453) Thanks @nmsn.
- 🔠 Language option button height truncation in Settings. (#447) Thanks @nmsn.
- 🃏 Aspect-ratio cards no longer overflow into siblings. (#476) Thanks @dabing1022.
- 📋 Copy buttons on FileViewer code blocks. (#471) Thanks @jiakeboge.
- ⚙️ Lowercase `todowrite` compatibility in ToolCard. (#523) Thanks @1119302165.
- 💧 Cap `htmlPreviewSlideState` Map to prevent memory leak. (#488) Thanks @hobostay.
- 🖼️ Isolate preview blob export paths. (#429) Thanks @Aresdgi.
- 🗂️ Split execution-mode tabs and align active chip visuals. (#418) Thanks @monshunter.
- 🎨 Tighten entry-tab layout and design-system showcase color picker. (#412) Thanks @pftom.
- 🌒 Lift coming-soon tip above sticky tabs and make it readable in dark theme. (#382) Thanks @emilneander.
- 📁 Clear Design Files selection on project switch. (#465) Thanks @dabing1022.
- 🤖 Copilot prompt processing with correct command format. (#466) Thanks @albertasaftei.
- 🤖 Codex Gemini CLI trust handling + sandbox invocation. (#352, #477) Thanks @danduma and @irixzafra.
- 🍎 Show window on macOS dock activate. (#270) Thanks @StotheC90.
- 📦 Bundle prompt templates in packaged desktop resources. (#417) Thanks @Romantin.
- 🚀 Deploy landing-page with `npm wrangler`. (#421) Thanks @mrcfps.
- 🔄 Refactor `RUNTIME_DATA_DIR` resolution. (#391) Thanks @vistar.

## 📚 Documentation

- 💬 Discord invite badge in README. (#504) Thanks @joeylee12629-star.
- 📥 Surface desktop downloads in README. (#522) Thanks @qiongyu1999.
- 🚦 "Running the Project" section in README. (#468) Thanks @sinamashini.
- 🤝 First-PR link points to /contribute. (#494) Thanks @lefarcen.
- 🌐 Defer README template-driven generation. (#403) Thanks @laihenyi.

## 🔨 For Developers

<details>
<summary>Click to expand</summary>

- 📊 Auto-generated metrics SVG and contributors wall refresh. (#406, #407, #489, #490)
- 🧪 Enforce test directory conventions. (#496) Thanks @PerishCode.

</details>

## ✅ System Requirements

- **macOS** — Apple Silicon (arm64) only, macOS 11 Big Sur or newer. Intel macs are not supported.
- **Windows** — x64, Windows 10 / 11. Installer is **unsigned** (SmartScreen will warn on first launch — choose "More info → Run anyway").
- **Linux** 🆕 — x64 AppImage. `chmod +x open-design-0.4.0-linux-x86_64.AppImage && ./open-design-0.4.0-linux-x86_64.AppImage`. AppImage is unsigned; some distros may prompt the first time.
- **From source** — Node.js 24.x and pnpm 10.33.2+ (per `engines` in `package.json`).

## ⚠️ Known Issues

- 🪟 **Windows installer is unsigned** — SmartScreen / antivirus warnings on first launch. Code signing tracked for a follow-up release.
- 🐧 **Linux AppImage is also unsigned** — first-launch trust prompts on some distros.
- 🍎 **No macOS Intel (x64) build** — Apple Silicon only.
- 🐚 **`od` CLI shadows the POSIX `od` (octal dump) when installed globally.** Use `/usr/bin/od` or `command od` for the system tool.
- 🌐 **i18n metadata drift on new prompt templates** — A handful of templates still don't have display titles in every UI locale; the i18n coverage test step is still skipped in `release-stable`.

---

## 🚀 Releasing this PR

This PR ships:

1. **All 13 monorepo `package.json` files bumped to `0.4.0`** (apps/{web,daemon,desktop,packaged,landing-page}, packages/{contracts,platform,sidecar,sidecar-proto}, tools/{dev,pack}, e2e, root). Internal `workspace:0.3.x` specifiers updated to `workspace:0.4.0`. `pnpm-lock.yaml` refreshed.
2. **`CHANGELOG.md`** — new `[0.4.0] - 2026-05-05` entry covering 64 merged PRs.

The release-stable workflow already lives on `main`; no infrastructure changes here. After merge, dispatch `release-stable` with `mac_signed=true` to publish.

Local verify dry-run already passed: `pnpm install` → daemon/desktop/web `build:sidecar` builds → `pnpm -r run typecheck` (exit 0) → `pnpm guard` (residual-JS + test-layout checks). CI verify job should be green on first try.

**Full Changelog:** https://github.com/nexu-io/open-design/compare/open-design-v0.3.0...release/v0.4.0
