### PR TITLE
fix: prevent infinite re-render loop in reattach effect

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -123,6 +123,8 @@ export function ProjectView({
     null,
   );
   const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const messagesRef = useRef(messages);
+  messagesRef.current = messages;
   const [previewComments, setPreviewComments] = useState<PreviewComment[]>([]);
   const [attachedComments, setAttachedComments] = useState<PreviewComment[]>([]);
   const [streaming, setStreaming] = useState(false);
@@ -565,7 +567,8 @@ export function ProjectView({
     let cancelled = false;
 
     const attachRecoverableRuns = async () => {
-      const activeRuns = messages.some(
+      const currentMessages = messagesRef.current;
+      const activeRuns = currentMessages.some(
         (m) => m.role === 'assistant' && isActiveRunStatus(m.runStatus) && !m.runId,
       )
         ? await listActiveChatRuns(project.id, activeConversationId)
@@ -577,7 +580,7 @@ export function ProjectView({
           .map((run) => [run.assistantMessageId!, run]),
       );
 
-      for (const message of messages) {
+      for (const message of currentMessages) {
         if (cancelled) return;
         if (message.role !== 'assistant') continue;
         if (!isActiveRunStatus(message.runStatus)) continue;
@@ -752,7 +755,6 @@ export function ProjectView({
     daemonLive,
     activeConversationId,
     streaming,
-    messages,
     project.id,
     updateMessageById,
     persistMessageById,


### PR DESCRIPTION
## Summary

- Fixed "Maximum update depth exceeded" error caused by the `attachRecoverableRuns` useEffect in `ProjectView.tsx`
- The effect had `messages` in its dependency array while also calling `updateMessageById` inside the effect body, creating a state update → re-render → effect re-fire loop
- Replaced direct `messages` dependency with a `messagesRef` pattern so the effect reads current messages without re-triggering on every state change

## Root Cause

The useEffect (line ~563) that reattaches recoverable daemon runs depended on `messages`. Inside the effect, `updateMessageById` is called to patch message run status (e.g., setting `runId`, marking as `failed`). Each call updates `messages` state → triggers re-render → effect re-fires → calls `updateMessageById` again → infinite loop.

While ref-based guards (`reattachControllersRef`, `completedReattachRunsRef`) prevent duplicate reattach operations, they cannot prevent the effect function itself from being re-invoked and re-executing `updateMessageById` for messages that match the initial conditions before the async guards take effect.

## Fix

1. Added `messagesRef` (`useRef`) that always holds the latest `messages` value
2. The effect reads `messagesRef.current` instead of closing over `messages`
3. Removed `messages` from the dependency array

The effect now only re-runs when `daemonLive`, `activeConversationId`, or `streaming` state changes — which are the actual conditions that should trigger reattachment logic.

## Test plan

- [x] Verified no TypeScript errors
- [ ] Open a project with an active/recoverable agent run → no console error, no infinite loop
- [ ] Send a new message → streaming works normally, no "Maximum update depth exceeded"