### PR TITLE
fix(design-files): clear selection on project switch

### DIFF
--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -76,17 +76,10 @@ export function DesignFilesPanel({
     return groups;
   }, [files]);
 
-  // Clear selection on project switch to prevent cross-project leaks
-  // (e.g. index.html selected in project A persisting into project B).
-  const prevProjectRef = useRef<string | null>(null);
-  useEffect(() => {
-    if (prevProjectRef.current !== null && prevProjectRef.current !== projectId) {
-      setSelected(new Set());
-    }
-    prevProjectRef.current = projectId;
-  }, [projectId]);
-
-  // Prune selections that no longer exist in the current file list.
+  // Prune selections that no longer exist in the current file list
+  // (e.g. after a refresh or delete within the same project).
+  // Cross-project leaks are handled by the parent remounting this
+  // component via key={projectId}.
   useEffect(() => {
     setSelected((prev) => {
       if (prev.size === 0) return prev;

--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -76,7 +76,17 @@ export function DesignFilesPanel({
     return groups;
   }, [files]);
 
-  // Prune stale selections when the file list or project changes.
+  // Clear selection on project switch to prevent cross-project leaks
+  // (e.g. index.html selected in project A persisting into project B).
+  const prevProjectRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (prevProjectRef.current !== null && prevProjectRef.current !== projectId) {
+      setSelected(new Set());
+    }
+    prevProjectRef.current = projectId;
+  }, [projectId]);
+
+  // Prune selections that no longer exist in the current file list.
   useEffect(() => {
     setSelected((prev) => {
       if (prev.size === 0) return prev;
@@ -91,7 +101,7 @@ export function DesignFilesPanel({
       }
       return changed ? next : prev;
     });
-  }, [files, projectId]);
+  }, [files]);
 
   const previewFile = useMemo(
     () => files.find((f) => f.name === preview) ?? null,

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -377,6 +377,7 @@ export function FileWorkspace({
         {uploadError ? <div className="viewer-empty">{uploadError}</div> : null}
         {activeTab === DESIGN_FILES_TAB ? (
           <DesignFilesPanel
+            key={projectId}
             projectId={projectId}
             files={files}
             onRefreshFiles={onRefreshFiles}


### PR DESCRIPTION
## Summary

Fix post-merge P1 bug identified in [#405](https://github.com/nexu-io/open-design/pull/405),
tracked in [#464](https://github.com/nexu-io/open-design/issues/464).

**Bug**: Switching from project A to B, if both contain `index.html`,
the selection survives the intersection-prune. `handleBatchDownload()`
then posts against the new `projectId` — downloading project B's file
without the user selecting it.

**Fix**: Split the single `useEffect` into two:
- `projectId` change → clear `selected` entirely
- `files` change → prune stale entries only

## Test plan
- [ ] Select `index.html` in project A
- [ ] Switch to project B that also has `index.html`
- [ ] Verify selection is cleared, no batch download button shown

Closes #464.

🤖 Generated with [Claude Code](https://claude.com/claude-code)