### PR TITLE
fix(agents): copilot prompt processing with correct command format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ out/
 *.log
 .vite
 .astro/
+.vscode
 
 # Local runtime data — auto-created by the daemon on first start.
 # Holds app.sqlite (project metadata), projects/<id>/ (per-project artifacts,

--- a/apps/daemon/src/agents.ts
+++ b/apps/daemon/src/agents.ts
@@ -449,15 +449,11 @@ export const AGENT_DEFS = [
     name: 'GitHub Copilot CLI',
     bin: 'copilot',
     versionArgs: ['--version'],
-    // `-p -` enters Copilot's prompt mode and tells the CLI to read the
-    // prompt body from stdin instead of expecting it as a positional argv
-    // element. Without it the daemon writes the prompt to the child's
-    // stdin pipe (because `promptViaStdin: true` below) but Copilot stays
-    // in interactive mode, never reads stdin, and rejects the run with
-    // `error: too many arguments. Expected 0 arguments but got N` —
-    // the regression filed in #350. PR #258 standardized agents on stdin
-    // delivery and dropped the per-prompt argv path, but missed flipping
-    // Copilot's mode from interactive to `-p -`.
+    // The prompt is passed directly as the value of `-p`: `copilot -p
+    // "<prompt>" --allow-all-tools --output-format json`. Copilot does NOT
+    // treat `-` as a stdin sentinel — it reads it as a literal one-character
+    // prompt string — so the previous `-p -` + stdin pattern produced a
+    // nonsensical single-dash prompt instead of the composed prompt body.
     //
     // `--allow-all-tools` is required for non-interactive runs: without it
     // the CLI blocks waiting for human approval on every tool call. Unlike
@@ -482,10 +478,10 @@ export const AGENT_DEFS = [
       { id: 'claude-sonnet-4.6', label: 'Claude Sonnet 4.6' },
       { id: 'gpt-5.2', label: 'GPT-5.2' },
     ],
-    buildArgs: (_prompt, _imagePaths, extraAllowedDirs = [], options = {}) => {
+    buildArgs: (prompt, _imagePaths, extraAllowedDirs = [], options = {}) => {
       const args = [
         '-p',
-        '-',
+        prompt,
         '--allow-all-tools',
         '--output-format',
         'json',
@@ -499,7 +495,7 @@ export const AGENT_DEFS = [
       for (const d of dirs) args.push('--add-dir', d);
       return args;
     },
-    promptViaStdin: true,
+    promptViaStdin: false,
     streamFormat: 'copilot-stream-json',
   },
   {

--- a/apps/daemon/tests/agents.test.ts
+++ b/apps/daemon/tests/agents.test.ts
@@ -113,39 +113,38 @@ test('cursor-agent args deliver prompts via stdin without passing a literal dash
   ]);
 });
 
-// `-p -` puts Copilot in prompt mode and tells it to read the body from
-// stdin. Without this pair the daemon writes the prompt to the child's
-// stdin pipe (because `promptViaStdin: true`) but Copilot stays
-// interactive, ignores stdin, and rejects the run with
-// `error: too many arguments. Expected 0 arguments but got N`. Pin the
-// pair as the leading argv elements so the regression in #350 can't
-// drift back. Also pin the order — Copilot expects `-p` before any other
+// Copilot does NOT treat `-` as a stdin sentinel — it reads it as a
+// literal one-character prompt. The prompt must be passed directly as the
+// value of `-p`. Pin the argv shape so the regression can't drift back.
+// Also pin the order — Copilot expects `-p <prompt>` before any other
 // flag, including model / add-dir extensions.
-test('copilot args lead with `-p -` so the stdin prompt is actually consumed (regression of #350)', () => {
-  const baseArgs = copilot.buildArgs('', [], [], {});
+test('copilot args pass the prompt directly as the -p value (not via stdin sentinel)', () => {
+  const prompt = 'design a landing page';
+  const baseArgs = copilot.buildArgs(prompt, [], [], {});
   assert.equal(baseArgs[0], '-p');
-  assert.equal(baseArgs[1], '-');
+  assert.equal(baseArgs[1], prompt);
   assert.deepEqual(baseArgs, [
     '-p',
-    '-',
+    prompt,
     '--allow-all-tools',
     '--output-format',
     'json',
   ]);
 });
 
-test('copilot args keep `-p -` at the front when model and extra dirs are added', () => {
+test('copilot args keep `-p <prompt>` at the front when model and extra dirs are added', () => {
+  const prompt = 'design a landing page';
   const args = copilot.buildArgs(
-    '',
+    prompt,
     [],
     ['/tmp/od-skills', '/tmp/od-design-systems'],
     { model: 'claude-sonnet-4.6' },
   );
   assert.equal(args[0], '-p');
-  assert.equal(args[1], '-');
+  assert.equal(args[1], prompt);
   assert.deepEqual(args, [
     '-p',
-    '-',
+    prompt,
     '--allow-all-tools',
     '--output-format',
     'json',
@@ -158,10 +157,11 @@ test('copilot args keep `-p -` at the front when model and extra dirs are added'
   ]);
 });
 
-test('copilot drops empty / non-string entries from extraAllowedDirs without breaking the `-p -` lead', () => {
-  const args = copilot.buildArgs('', [], ['', null, '/tmp/od-skills', undefined], {});
+test('copilot drops empty / non-string entries from extraAllowedDirs without breaking the `-p <prompt>` lead', () => {
+  const prompt = 'design a landing page';
+  const args = copilot.buildArgs(prompt, [], ['', null, '/tmp/od-skills', undefined], {});
   assert.equal(args[0], '-p');
-  assert.equal(args[1], '-');
+  assert.equal(args[1], prompt);
   // Only the one valid path survives.
   const addDirIndex = args.indexOf('--add-dir');
   assert.equal(args[addDirIndex + 1], '/tmp/od-skills');


### PR DESCRIPTION
Fixed copilot prompt processing as saw earlier in issue [#437](https://github.com/nexu-io/open-design/issues/437) to use correct command format as tested:

`copilot -p "message" --allow-all-tools --output-format json`

This will likely fix the issue reported in [#367](https://github.com/nexu-io/open-design/issues/367) as well