### PR TITLE
fix(design-files): clear batch selection when switching projects

### DIFF
--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -60,6 +60,7 @@ export function DesignFilesPanel({
   const [sectionLimits, setSectionLimits] = useState<Partial<Record<Section, number>>>({});
   const [isSectionExpansionPending, startSectionExpansion] = useTransition();
   const [selected, setSelected] = useState<Set<string>>(new Set());
+  const prevProjectIdRef = useRef(projectId);
 
   const grouped = useMemo(() => {
     const groups: Record<Section, ProjectFile[]> = {
@@ -76,8 +77,16 @@ export function DesignFilesPanel({
     return groups;
   }, [files]);
 
-  // Prune stale selections when the file list or project changes.
+  // Selections are project-scoped: clear them outright on project switch so
+  // common filenames (e.g. index.html in both projects) don't carry over.
+  // For same-project file changes (refresh, delete, replace), intersect with
+  // the current file list to drop stale names.
   useEffect(() => {
+    if (prevProjectIdRef.current !== projectId) {
+      prevProjectIdRef.current = projectId;
+      setSelected((prev) => (prev.size === 0 ? prev : new Set()));
+      return;
+    }
     setSelected((prev) => {
       if (prev.size === 0) return prev;
       const names = new Set(files.map((f) => f.name));


### PR DESCRIPTION
## Summary

Follow-up to #405. mrcfps' [post-merge review](https://github.com/nexu-io/open-design/pull/405#discussion_r3182849399) flagged a P1: switching projects keeps the batch-download selection alive when both projects share a filename.

The prune effect introduced in #405 only intersects `selected` with the *new* files list. Common names like `index.html`, `README.md`, or `style.css` exist in many projects, so on project switch the panel stayed in ZIP-download mode and `handleBatchDownload()` would POST the same-name selection against the new project's archive endpoint — even though the user never checked anything in the new project.

## Fix

- Track the previous `projectId` in a `useRef`.
- When `projectId` changes: reset `selected` to an empty `Set`, regardless of name overlap.
- When `projectId` is unchanged but `files` changes (refresh / delete / replace): keep the existing intersection-prune so stale names within the same project still get dropped.

Single change in `apps/web/src/components/DesignFilesPanel.tsx`. Matches mrcfps' suggested approach (ref-based projectId tracking + same-project intersection retained).

## Test plan

Vitest in `apps/web` runs in `node` env (no jsdom) and existing component tests use SSR `renderToStaticMarkup` which doesn't run effects, so the cross-project case isn't expressible there without new test infra. Verified manually:

- [x] `pnpm --filter @open-design/web typecheck` passes
- [x] `pnpm --filter @open-design/web test` — 30 files, 206 tests pass
- [ ] Manual: in project A, check `index.html`, header switches to "Download N as ZIP"
- [ ] Manual: switch to project B (which also has `index.html`) — header reverts to upload/paste/sketch actions, `index.html` row checkbox is unchecked
- [ ] Manual: in project A, check `index.html` then refresh — selection survives
- [ ] Manual: in project A, check `index.html` then delete it — selection drops the stale name