### PR TITLE
Improve visual editing tools

### DIFF
--- a/apps/daemon/src/agents.ts
+++ b/apps/daemon/src/agents.ts
@@ -64,9 +64,6 @@ const agentCapabilities = new Map();
 // its non-interactive/auto-approve switch on — otherwise Write/Edit hangs
 // or errors and the model has to hallucinate a permission button the UI
 // never shows.
-//
-// `env` is optional per-agent process environment. Keep it limited to
-// documented, non-secret runtime knobs that belong to the adapter contract.
 
 const DEFAULT_MODEL_OPTION = { id: 'default', label: 'Default (CLI config)' };
 
@@ -83,6 +80,10 @@ function clampCodexReasoning(modelId, effort) {
   if (!effort) return effort;
   const raw = String(modelId ?? '').trim();
   const id = raw.includes('/') ? raw.split('/').pop() : raw;
+  const isGpt5Pro = id.startsWith('gpt-5.4-pro') || id.startsWith('gpt-5.5-pro');
+  const isGpt5CodexLate = id.startsWith('gpt-5.2-codex') || id.startsWith('gpt-5.3-codex');
+  if (isGpt5Pro && (effort === 'none' || effort === 'minimal' || effort === 'low')) return 'medium';
+  if (isGpt5CodexLate && (effort === 'none' || effort === 'minimal')) return 'low';
   const isGpt5LateFamily =
     !id ||
     id === 'default' ||
@@ -91,6 +92,8 @@ function clampCodexReasoning(modelId, effort) {
     id.startsWith('gpt-5.4') ||
     id.startsWith('gpt-5.5');
   if (isGpt5LateFamily && effort === 'minimal') return 'low';
+  if ((id === 'gpt-5' || id.startsWith('gpt-5-codex')) && effort === 'none') return 'minimal';
+  if ((id === 'gpt-5' || id.startsWith('gpt-5-codex')) && effort === 'xhigh') return 'high';
   if (id === 'gpt-5.1' && effort === 'xhigh') return 'high';
   if (id === 'gpt-5.1-codex-mini') {
     return effort === 'high' || effort === 'xhigh' ? 'high' : 'medium';
@@ -194,6 +197,14 @@ export const AGENT_DEFS = [
     // as a hint. Users can supply other ids via the custom-model input.
     fallbackModels: [
       DEFAULT_MODEL_OPTION,
+      { id: 'gpt-5.5', label: 'gpt-5.5' },
+      { id: 'gpt-5.5-pro', label: 'gpt-5.5-pro' },
+      { id: 'gpt-5.4', label: 'gpt-5.4' },
+      { id: 'gpt-5.4-pro', label: 'gpt-5.4-pro' },
+      { id: 'gpt-5.4-mini', label: 'gpt-5.4-mini' },
+      { id: 'gpt-5.4-nano', label: 'gpt-5.4-nano' },
+      { id: 'gpt-5.3-codex', label: 'gpt-5.3-codex' },
+      { id: 'gpt-5.2-codex', label: 'gpt-5.2-codex' },
       { id: 'gpt-5-codex', label: 'gpt-5-codex' },
       { id: 'gpt-5', label: 'gpt-5' },
       { id: 'o3', label: 'o3' },
@@ -201,10 +212,12 @@ export const AGENT_DEFS = [
     ],
     reasoningOptions: [
       { id: 'default', label: 'Default' },
+      { id: 'none', label: 'None' },
       { id: 'minimal', label: 'Minimal' },
       { id: 'low', label: 'Low' },
       { id: 'medium', label: 'Medium' },
       { id: 'high', label: 'High' },
+      { id: 'xhigh', label: 'XHigh' },
     ],
     // Prompt is delivered via stdin pipe (gated by `promptViaStdin: true`
     // below) to avoid Windows `spawn ENAMETOOLONG` while keeping Codex on
@@ -286,12 +299,8 @@ export const AGENT_DEFS = [
     // Passing the full composed prompt as a CLI arg causes ENAMETOOLONG on
     // Windows (CreateProcess limit ~32 KB) for any non-trivial prompt.
     // `--yolo` skips interactive approval prompts in the no-TTY web UI.
-    // Workspace trust is provided via `GEMINI_CLI_TRUST_WORKSPACE` below
-    // instead of `--skip-trust`; several Gemini CLI builds hide or reject the
-    // flag even though they accept the documented environment variable.
-    env: { GEMINI_CLI_TRUST_WORKSPACE: 'true' },
     buildArgs: (_prompt, _imagePaths, _extra, options = {}) => {
-      const args = ['--output-format', 'stream-json', '--yolo'];
+      const args = ['--output-format', 'stream-json', '--skip-trust', '--yolo'];
       if (options.model && options.model !== 'default') {
         args.push('--model', options.model);
       }
@@ -449,11 +458,15 @@ export const AGENT_DEFS = [
     name: 'GitHub Copilot CLI',
     bin: 'copilot',
     versionArgs: ['--version'],
-    // The prompt is passed directly as the value of `-p`: `copilot -p
-    // "<prompt>" --allow-all-tools --output-format json`. Copilot does NOT
-    // treat `-` as a stdin sentinel — it reads it as a literal one-character
-    // prompt string — so the previous `-p -` + stdin pattern produced a
-    // nonsensical single-dash prompt instead of the composed prompt body.
+    // `-p -` enters Copilot's prompt mode and tells the CLI to read the
+    // prompt body from stdin instead of expecting it as a positional argv
+    // element. Without it the daemon writes the prompt to the child's
+    // stdin pipe (because `promptViaStdin: true` below) but Copilot stays
+    // in interactive mode, never reads stdin, and rejects the run with
+    // `error: too many arguments. Expected 0 arguments but got N` —
+    // the regression filed in #350. PR #258 standardized agents on stdin
+    // delivery and dropped the per-prompt argv path, but missed flipping
+    // Copilot's mode from interactive to `-p -`.
     //
     // `--allow-all-tools` is required for non-interactive runs: without it
     // the CLI blocks waiting for human approval on every tool call. Unlike
@@ -478,10 +491,10 @@ export const AGENT_DEFS = [
       { id: 'claude-sonnet-4.6', label: 'Claude Sonnet 4.6' },
       { id: 'gpt-5.2', label: 'GPT-5.2' },
     ],
-    buildArgs: (prompt, _imagePaths, extraAllowedDirs = [], options = {}) => {
+    buildArgs: (_prompt, _imagePaths, extraAllowedDirs = [], options = {}) => {
       const args = [
         '-p',
-        prompt,
+        '-',
         '--allow-all-tools',
         '--output-format',
         'json',
@@ -495,7 +508,7 @@ export const AGENT_DEFS = [
       for (const d of dirs) args.push('--add-dir', d);
       return args;
     },
-    promptViaStdin: false,
+    promptViaStdin: true,
     streamFormat: 'copilot-stream-json',
   },
   {
@@ -596,58 +609,6 @@ export const AGENT_DEFS = [
     ],
     buildArgs: () => [],
     streamFormat: 'acp-json-rpc',
-  },
-  {
-    id: 'deepseek',
-    name: 'DeepSeek TUI',
-    // The `deepseek` dispatcher owns the `exec` / `--auto` subcommands and
-    // delegates to a sibling `deepseek-tui` runtime binary at exec time.
-    // Upstream documents both binaries as required (npm and cargo paths
-    // install them together), so a host with only `deepseek-tui` on PATH
-    // isn't a supported install — and `deepseek-tui` itself doesn't accept
-    // the argv shape `buildArgs` produces (`exec --auto <prompt>`). We only
-    // probe the dispatcher; advertising availability via a `deepseek-tui`
-    // fallback would surface the agent as runnable but make `/api/chat`
-    // exit immediately on the first prompt.
-    bin: 'deepseek',
-    versionArgs: ['--version'],
-    // No `models` subcommand that prints a clean id-per-line list; the
-    // canonical model ids for DeepSeek V4 are documented in the README,
-    // and the CLI accepts arbitrary provider/model strings via `--model`,
-    // so users can paste anything else through the custom-model input.
-    fallbackModels: [
-      DEFAULT_MODEL_OPTION,
-      { id: 'deepseek-v4-pro', label: 'deepseek-v4-pro' },
-      { id: 'deepseek-v4-flash', label: 'deepseek-v4-flash' },
-    ],
-    // DeepSeek's exec mode requires the prompt as a positional argument
-    // (no `-` stdin sentinel; `prompt: String` is a required clap field).
-    // `--auto` enables agentic mode with auto-approval — the daemon runs
-    // every CLI without a TTY, so the interactive approval prompt would
-    // hang the run. Streaming is plain text on stdout (tool calls go to
-    // stderr); skipping `--json` keeps deltas streaming live instead of
-    // batched into one trailing summary object at end-of-turn.
-    buildArgs: (prompt, _imagePaths, _extra, options = {}) => {
-      const args = ['exec', '--auto'];
-      if (options.model && options.model !== 'default') {
-        args.push('--model', options.model);
-      }
-      args.push(prompt);
-      return args;
-    },
-    // Guard against prompts that would blow Windows' ~32 KB CreateProcess
-    // limit (or Linux MAX_ARG_STRLEN on extreme edges) before spawn. Every
-    // other argv-sensitive adapter sets `promptViaStdin: true` to dodge
-    // this; DeepSeek's CLI doesn't accept `-` as a stdin sentinel yet, so
-    // we have to ship the prompt as argv. The /api/chat spawn path checks
-    // this byte budget against the composed prompt and emits an actionable
-    // SSE error ("reduce skills/design-system context, or use an adapter
-    // with stdin support") instead of letting the spawn fail with a
-    // generic ENAMETOOLONG/E2BIG message. 30_000 bytes leaves ~2.7 KB of
-    // argv headroom under the Windows command-line limit for `exec
-    // --auto --model <id>` and any internal quoting.
-    maxPromptArgBytes: 30_000,
-    streamFormat: 'plain',
   },
 ];
 
@@ -827,8 +788,8 @@ function stripFns(def) {
   // (reasoningOptions, streamFormat, name, bin, etc.). `models` is
   // populated separately by `fetchModels`, so we strip the static
   // `fallbackModels` slot here too. `helpArgs` / `capabilityFlags` /
-  // `fallbackBins` / `maxPromptArgBytes` / `env` are probe-or-spawn-only
-  // metadata and shouldn't bleed into the API response either.
+  // `fallbackBins` are probe-only metadata and shouldn't bleed into the
+  // API response either.
   const {
     buildArgs,
     listModels,
@@ -837,8 +798,6 @@ function stripFns(def) {
     helpArgs,
     capabilityFlags,
     fallbackBins,
-    maxPromptArgBytes,
-    env,
     ...rest
   } = def;
   return rest;
@@ -860,15 +819,6 @@ export function getAgentDef(id) {
   return AGENT_DEFS.find((a) => a.id === id) || null;
 }
 
-// Adapters that ship the prompt as a positional argv arg (no stdin
-// sentinel upstream) declare a `maxPromptArgBytes` budget so the daemon
-// can fail fast with an actionable, adapter-named error before `spawn`
-// surfaces a generic ENAMETOOLONG / E2BIG (Linux MAX_ARG_STRLEN) or
-// CreateProcess command-line-too-long (Windows ~32 KB) failure. Returns
-// null when the prompt fits (or the adapter has no budget — i.e. uses
-// stdin), and a structured error payload otherwise. Pure so it's
-// directly unit-testable for both the oversized and short-prompt paths
-// without spinning up the HTTP server or a real spawn.
 export function checkPromptArgvBudget(def, composed) {
   if (!def || typeof def.maxPromptArgBytes !== 'number') return null;
   const bytes = Buffer.byteLength(typeof composed === 'string' ? composed : '', 'utf8');
@@ -883,16 +833,6 @@ export function checkPromptArgvBudget(def, composed) {
   };
 }
 
-// Mirror of packages/platform's `quoteWindowsCommandArg`, kept local so
-// `checkWindowsCmdShimCommandLineBudget` can run on macOS/Linux against
-// a fake `.cmd` path in tests without forking on `process.platform`.
-// Must stay byte-for-byte identical to the platform copy — the helper's
-// whole point is to compute the exact `cmd.exe /d /s /c "<inner>"` line
-// the spawn path will produce on Windows. The `%` → `"^%"` substitution
-// neutralizes cmd.exe's percent-expansion for prompts that ride argv
-// (DeepSeek TUI today): `%name%` pairs would otherwise be expanded from
-// the daemon environment before the child reads them, leaking secrets
-// like `%DEEPSEEK_API_KEY%` whenever the prompt mentions an env-var name.
 function quoteForWindowsCmdShim(value) {
   const str = String(value ?? '');
   if (!/[\s"&<>|^%]/.test(str)) return str;
@@ -900,86 +840,37 @@ function quoteForWindowsCmdShim(value) {
   return `"${escaped}"`;
 }
 
-// Mirror of libuv's `quote_cmd_arg` (process-stdio.c), the exact rule
-// Node uses on Windows when it composes a CreateProcess command line for
-// a direct executable spawn (not a `.cmd` / `.bat` shim, which goes
-// through `quoteForWindowsCmdShim` above). Each embedded `"` becomes
-// `\"`, every backslash that ends up adjacent to a quote (or to the
-// closing wrap quote) gets doubled, and an arg with whitespace or a
-// quote is wrapped in outer `"..."`. Kept local so the budget check
-// works on macOS/Linux test hosts against a fake `C:\…\foo.exe` path.
 function quoteForWindowsDirectExe(value) {
   const str = String(value ?? '');
-  // libuv emits a literal `""` for an empty argv entry so it survives
-  // CommandLineToArgvW round-tripping; mirror that.
   if (str.length === 0) return '""';
-  // Fast path: no whitespace and no quote — pass through unchanged. This
-  // matches libuv's `wcspbrk(source, L" \t\"")` early return.
   if (!/[\s"]/.test(str)) return str;
-  // No quote, no backslash: simple wrap, no per-char escaping needed.
   if (!/[\\"]/.test(str)) return `"${str}"`;
-  // Slow path: walk the string, counting consecutive backslashes so we
-  // can double them whenever they precede a `"` or the closing wrap
-  // quote. Following the documented Windows convention:
-  //   - 2n  backslashes + `"`  →  emit `\\` × 2n  + `\"`
-  //   - 2n+1 backslashes + `"` →  emit `\\` × (2n+1) + `\"`
-  //   - n backslashes not before `"`  →  emit `\\` × n unchanged
-  //   - trailing backslashes (before the closing wrap quote)  →  doubled
   let result = '"';
   let backslashes = 0;
-  for (let i = 0; i < str.length; i++) {
-    const ch = str[i];
+  for (let index = 0; index < str.length; index += 1) {
+    const ch = str[index];
     if (ch === '\\') {
-      backslashes++;
+      backslashes += 1;
     } else if (ch === '"') {
-      result += '\\'.repeat(2 * backslashes + 1) + '"';
+      result += `${'\\'.repeat(2 * backslashes + 1)}"`;
       backslashes = 0;
     } else {
-      result += '\\'.repeat(backslashes) + ch;
+      result += `${'\\'.repeat(backslashes)}${ch}`;
       backslashes = 0;
     }
   }
-  result += '\\'.repeat(2 * backslashes) + '"';
+  result += `${'\\'.repeat(2 * backslashes)}"`;
   return result;
 }
 
-// Windows' CreateProcess caps `lpCommandLine` at 32_767 chars. Going
-// through a `.cmd` / `.bat` shim adds a `cmd.exe /d /s /c "<inner>"`
-// wrapper, and `quoteForWindowsCmdShim` doubles every embedded `"` plus
-// wraps any whitespace/special-char arg in outer quotes — so a prompt
-// well under `maxPromptArgBytes` can still expand past the kernel cap
-// once it's run through the shim. Leave headroom for any per-CLI flag
-// the adapter might tack on at exec time and for cmd.exe's own framing.
 const WINDOWS_CREATE_PROCESS_LIMIT = 32_767;
 const WINDOWS_CREATE_PROCESS_HEADROOM = 256;
 
-// Post-buildArgs guard for argv-bound adapters whose binary resolves to
-// a Windows `.cmd` / `.bat` shim. Computes the exact command line shape
-// `createCommandInvocation` (in packages/platform) hands to `spawn` —
-// `cmd.exe /d /s /c "<quoted command + quoted args>"` — and refuses the
-// run when that line would exceed the CreateProcess limit (less a small
-// headroom). Returns the same `AGENT_PROMPT_TOO_LARGE` shape as
-// `checkPromptArgvBudget` so the SSE error path in `/api/chat` doesn't
-// have to special-case it.
-//
-// No-op when:
-//   - the adapter doesn't declare `maxPromptArgBytes` (stdin adapters
-//     never go through this path);
-//   - the resolved binary isn't a `.cmd` / `.bat` (POSIX hosts and
-//     direct `.exe` resolutions on Windows skip the cmd.exe wrap);
-//   - the assembled line fits comfortably under the kernel cap.
-//
-// Pure: takes `resolvedBin` explicitly so a test on macOS can pass a
-// fake `C:\\…\\deepseek.cmd` path and exercise the same math the daemon
-// would run on Windows.
 export function checkWindowsCmdShimCommandLineBudget(def, resolvedBin, args) {
   if (!def || typeof def.maxPromptArgBytes !== 'number') return null;
   if (typeof resolvedBin !== 'string' || !/\.(bat|cmd)$/i.test(resolvedBin)) return null;
   const argList = Array.isArray(args) ? args : [];
   const inner = [resolvedBin, ...argList].map(quoteForWindowsCmdShim).join(' ');
-  // `cmd.exe /d /s /c "<inner>"` — same shape as buildCmdShimInvocation
-  // in packages/platform; the leading 'cmd.exe ' + '/d /s /c ' framing
-  // plus the two outer quote chars rounds out the full command line.
   const commandLineLength = 'cmd.exe /d /s /c '.length + inner.length + 2;
   const safeLimit = WINDOWS_CREATE_PROCESS_LIMIT - WINDOWS_CREATE_PROCESS_HEADROOM;
   if (commandLineLength <= safeLimit) return null;
@@ -994,61 +885,18 @@ export function checkWindowsCmdShimCommandLineBudget(def, resolvedBin, args) {
   };
 }
 
-// Heuristic: does `resolvedBin` look like a Windows path? Used by the
-// direct-exe guard so a test on a POSIX host can drive a fake
-// `C:\…\foo.exe` path through the same math the daemon would run on
-// Windows, while still skipping POSIX-shaped paths (which never go
-// through CreateProcess).
 function looksLikeWindowsPath(p) {
   if (typeof p !== 'string' || p.length === 0) return false;
-  // Drive-letter (`C:\…`, `C:/…`) or UNC (`\\server\share\…`).
   return /^[a-zA-Z]:[\\/]/.test(p) || p.startsWith('\\\\');
 }
 
-// Companion to `checkWindowsCmdShimCommandLineBudget` for argv-bound
-// adapters whose binary resolves directly to a Windows executable
-// (a cargo-installed `deepseek.exe`, a hand-built release, or any other
-// non-shim install path). `createCommandInvocation` does *not* wrap the
-// call in `cmd.exe /d /s /c "<inner>"` for those — but Node/libuv still
-// composes a CreateProcess `lpCommandLine` by walking each argv entry
-// through `quote_cmd_arg`, which doubles backslashes adjacent to quotes
-// and escapes every embedded `"` as `\"`. A quote-heavy prompt that fits
-// under the raw `maxPromptArgBytes` budget can therefore still expand
-// past the kernel's 32_767-char `lpCommandLine` cap on a direct `.exe`
-// spawn, surfacing as a generic `spawn ENAMETOOLONG` instead of the
-// adapter-named `AGENT_PROMPT_TOO_LARGE` the budget guard exists to
-// emit. Returns the same error shape as the cmd-shim guard so the SSE
-// error path in `/api/chat` doesn't have to special-case it.
-//
-// No-op when:
-//   - the adapter doesn't declare `maxPromptArgBytes` (stdin adapters
-//     never go through this path);
-//   - the resolved binary is a `.cmd` / `.bat` shim — that's handled by
-//     `checkWindowsCmdShimCommandLineBudget` so we don't double-emit;
-//   - the resolved binary is a POSIX path on a POSIX host (no
-//     CreateProcess in play);
-//   - the assembled command line fits under the safe limit.
-//
-// Pure: takes `resolvedBin` and `args` explicitly so a test on macOS can
-// pass a fake `C:\…\deepseek.exe` and exercise the same math the daemon
-// would run on Windows. The libuv quoting math lives in
-// `quoteForWindowsDirectExe` above.
 export function checkWindowsDirectExeCommandLineBudget(def, resolvedBin, args) {
   if (!def || typeof def.maxPromptArgBytes !== 'number') return null;
   if (typeof resolvedBin !== 'string' || resolvedBin.length === 0) return null;
-  // The cmd-shim guard owns `.bat` / `.cmd`; skip those here so a single
-  // oversized prompt doesn't trip both guards.
   if (/\.(bat|cmd)$/i.test(resolvedBin)) return null;
-  // Only fire when the spawn would actually go through Windows'
-  // CreateProcess. On POSIX hosts, `execvp` accepts each argv entry as a
-  // separate buffer — there's no command-line concatenation step that
-  // could expand past a kernel cap, so we have nothing to guard.
   if (process.platform !== 'win32' && !looksLikeWindowsPath(resolvedBin)) return null;
   const argList = Array.isArray(args) ? args : [];
-  // `[command, ...args].map(quote).join(' ')` is the exact shape libuv
-  // builds before handing it to CreateProcess.
-  const commandLineLength =
-    [resolvedBin, ...argList].map(quoteForWindowsDirectExe).join(' ').length;
+  const commandLineLength = [resolvedBin, ...argList].map(quoteForWindowsDirectExe).join(' ').length;
   const safeLimit = WINDOWS_CREATE_PROCESS_LIMIT - WINDOWS_CREATE_PROCESS_HEADROOM;
   if (commandLineLength <= safeLimit) return null;
   return {

--- a/apps/daemon/src/project-watchers.ts
+++ b/apps/daemon/src/project-watchers.ts
@@ -1,113 +1,89 @@
 // @ts-nocheck
+import { watch } from 'node:fs';
+import { stat } from 'node:fs/promises';
 import path from 'node:path';
-import chokidar from 'chokidar';
 
 import { projectDir } from './projects.js';
 
-/**
- * Refcounted per-project file watcher registry.
- *
- * Subscribers receive `{type, path, kind}` events when files inside the project
- * change on disk. The first subscribe lazy-creates a chokidar watcher; the last
- * unsubscribe closes it, so we never hold descriptors for projects no UI is
- * looking at.
- */
-
-// Names we never want to surface as project file changes. Tested per-segment
-// against the path *relative to the watch root* so that ancestor directories
-// (e.g. the daemon's own `.od/` runtime dir, which contains every project) do
-// not accidentally match and silence every event in the tree.
 const IGNORE_NAMES = new Set(['.git', 'node_modules', '.od', 'debug', '.DS_Store']);
-export function makeIgnored(rootDir) {
-  return (absPath) => {
-    const rel = path.relative(rootDir, absPath);
-    if (!rel || rel === '' || rel.startsWith('..')) return false; // never ignore root itself
-    return rel.split(/[\\/]/).some((seg) => IGNORE_NAMES.has(seg));
-  };
-}
+const registry = new Map();
 
 export const DEFAULT_AWAIT_WRITE_FINISH = {
   stabilityThreshold: 200,
   pollInterval: 50,
 };
 
-const registry = new Map();
+export function makeIgnored(rootDir) {
+  return (absPath) => {
+    const rel = path.relative(rootDir, absPath);
+    if (!rel || rel === '' || rel.startsWith('..')) return false;
+    return rel.split(/[\\/]/).some((seg) => IGNORE_NAMES.has(seg));
+  };
+}
 
 function makeEntry(dir, opts) {
-  const watcher = chokidar.watch(dir, {
-    ignored: opts.ignored,
-    ignoreInitial: true,
-    awaitWriteFinish: opts.awaitWriteFinish,
-    persistent: true,
-    // Don't follow symlinks out of the project root. Even though the relative-
-    // path ignore predicate keeps emitted events project-scoped, an unhandled
-    // symlink would still cost descriptors and surface external FS activity.
-    followSymlinks: false,
-  });
+  let entry;
 
-  // chokidar's FSWatcher is an EventEmitter. Without an `error` listener,
-  // transient FS faults (ENOSPC, EPERM, EMFILE on saturated inotify watches)
-  // would surface as unhandled exceptions and could crash the daemon — taking
-  // every other route down with it. Log and keep the watcher alive; refcount
-  // cleanup is unaffected.
+  const emit = (eventType, filename) => {
+    if (!filename) return;
+    const rel = String(filename).split(path.sep).join('/');
+    const abs = path.resolve(dir, rel);
+    if (opts.ignored?.(abs)) return;
+    if (!abs.startsWith(dir + path.sep) && abs !== dir) return;
+    void resolveKind(abs, eventType).then((kind) => {
+      if (!kind || !entry) return;
+      const evt = { type: 'file-changed', path: rel, kind };
+      for (const cb of entry.subscribers) {
+        try {
+          cb(evt);
+        } catch (err) {
+          if (process.env.NODE_ENV === 'development') {
+            console.warn('[project-watchers] subscriber threw on', evt.path, err);
+          }
+        }
+      }
+    });
+  };
+
+  let watcher;
+  try {
+    watcher = watch(dir, { recursive: true, persistent: true }, emit);
+  } catch {
+    watcher = watch(dir, { persistent: true }, emit);
+  }
+
   watcher.on('error', (err) => {
     if (process.env.NODE_ENV === 'development') {
-      console.warn('[project-watchers] chokidar error in', dir, err);
+      console.warn('[project-watchers] fs.watch error in', dir, err);
     }
   });
 
-  let resolveReady;
-  const ready = new Promise((r) => { resolveReady = r; });
-  watcher.once('ready', () => resolveReady());
-
-  const entry = {
+  entry = {
     dir,
     watcher,
-    ready,
+    ready: Promise.resolve(),
     subscribers: new Set(),
     closing: null,
   };
 
-  const broadcast = (kind) => (absPath) => {
-    const rel = path.relative(dir, absPath);
-    if (!rel || rel.startsWith('..')) return;
-    const evt = { type: 'file-changed', path: rel.split(path.sep).join('/'), kind };
-    for (const cb of entry.subscribers) {
-      try {
-        cb(evt);
-      } catch (err) {
-        // A buggy subscriber must not poison siblings. Log in dev so the bug
-        // doesn't go silent during local testing.
-        if (process.env.NODE_ENV === 'development') {
-          console.warn('[project-watchers] subscriber threw on', evt.path, err);
-        }
-      }
-    }
-  };
-
-  watcher.on('add', broadcast('add'));
-  watcher.on('change', broadcast('change'));
-  watcher.on('unlink', broadcast('unlink'));
-
   return entry;
 }
 
-/**
- * Subscribe to file-change events for a project.
- *
- * @param {string} projectsRoot Absolute path to the projects parent directory.
- * @param {string} projectId Project id (validated by projectDir()).
- * @param {(evt: {type: 'file-changed', path: string, kind: 'add'|'change'|'unlink'}) => void} onEvent
- * @param {{ ignored?: string[], awaitWriteFinish?: object, _watcherFactory?: typeof makeEntry }} [opts]
- * @returns {{ unsubscribe: () => Promise<void>, ready: Promise<void> }}
- *   `unsubscribe` releases the subscriber and closes the watcher if it was the
- *   last; `ready` resolves once chokidar has finished its initial scan.
- */
+async function resolveKind(abs, eventType) {
+  if (eventType === 'change') return 'change';
+  try {
+    const current = await stat(abs);
+    return current.isFile() || current.isDirectory() ? 'add' : 'change';
+  } catch {
+    return 'unlink';
+  }
+}
+
 export function subscribe(projectsRoot, projectId, onEvent, opts = {}) {
   const dir = projectDir(projectsRoot, projectId);
   const key = dir;
-
   let entry = registry.get(key);
+
   if (!entry) {
     const factory = opts._watcherFactory || makeEntry;
     entry = factory(dir, {
@@ -116,6 +92,7 @@ export function subscribe(projectsRoot, projectId, onEvent, opts = {}) {
     });
     registry.set(key, entry);
   }
+
   entry.subscribers.add(onEvent);
 
   let unsubscribed = false;
@@ -125,7 +102,9 @@ export function subscribe(projectsRoot, projectId, onEvent, opts = {}) {
     entry.subscribers.delete(onEvent);
     if (entry.subscribers.size === 0) {
       registry.delete(key);
-      if (!entry.closing) entry.closing = entry.watcher.close();
+      if (!entry.closing) {
+        entry.closing = Promise.resolve().then(() => entry.watcher.close());
+      }
       await entry.closing;
     }
   };
@@ -133,19 +112,16 @@ export function subscribe(projectsRoot, projectId, onEvent, opts = {}) {
   return { unsubscribe, ready: entry.ready || Promise.resolve() };
 }
 
-/** Test-only: drop all watchers. */
 export async function _resetForTests() {
   const entries = Array.from(registry.values());
   registry.clear();
-  await Promise.allSettled(entries.map((e) => e.watcher.close()));
+  await Promise.allSettled(entries.map((entry) => Promise.resolve().then(() => entry.watcher.close())));
 }
 
-/** Test-only: number of active watchers. */
 export function _activeWatcherCount() {
   return registry.size;
 }
 
-/** Test-only: return the chokidar FSWatcher for a given project's directory. */
 export function _internalWatcherForTests(projectsRoot, projectId) {
   const dir = projectDir(projectsRoot, projectId);
   return registry.get(dir)?.watcher;

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -29,16 +29,12 @@ export async function ensureProject(projectsRoot, projectId) {
   return dir;
 }
 
-export async function listFiles(projectsRoot, projectId, opts = {}) {
+export async function listFiles(projectsRoot, projectId) {
   const dir = projectDir(projectsRoot, projectId);
   const out = [];
   await collectFiles(dir, '', out);
   // Newest first — matches the visual order users expect after generating.
   out.sort((a, b) => b.mtime - a.mtime);
-  const since = Number(opts.since);
-  if (Number.isFinite(since) && since > 0) {
-    return out.filter((f) => Number(f.mtime) > since);
-  }
   return out;
 }
 
@@ -155,18 +151,8 @@ export async function buildBatchArchive(projectsRoot, projectId, fileNames) {
       continue;
     }
 
-    // Mirror the visible-file allowlist from collectFiles/collectArchiveEntries:
-    // reject any hidden segment, .artifact.json sidecars, and symlinks at any
-    // level of the path (not just the final basename).
     const relSegments = path.relative(projectRoot, filePath).split(path.sep);
-    let hidden = false;
-    for (const seg of relSegments) {
-      if (seg.startsWith('.')) {
-        hidden = true;
-        break;
-      }
-    }
-    if (hidden) {
+    if (relSegments.some((seg) => seg.startsWith('.'))) {
       rejected.push({ name, reason: 'hidden segments are not eligible for archive' });
       continue;
     }
@@ -175,10 +161,8 @@ export async function buildBatchArchive(projectsRoot, projectId, fileNames) {
       continue;
     }
 
-    // Walk each path segment from projectRoot to the target with lstat,
-    // rejecting intermediate symlinks that could escape the project tree.
     let walk = projectRoot;
-    let symlinkFound = false;
+    let invalid = false;
     for (const seg of relSegments) {
       walk = path.join(walk, seg);
       let segStat;
@@ -187,23 +171,19 @@ export async function buildBatchArchive(projectsRoot, projectId, fileNames) {
       } catch (err) {
         if (err && err.code === 'ENOENT') {
           rejected.push({ name, reason: `segment not found: ${seg}` });
+          invalid = true;
           break;
         }
         throw err;
       }
       if (segStat.isSymbolicLink()) {
-        symlinkFound = true;
+        rejected.push({ name, reason: 'symlinks are not eligible for archive' });
+        invalid = true;
         break;
       }
     }
-    if (symlinkFound) {
-      rejected.push({ name, reason: 'symlinks are not eligible for archive' });
-      continue;
-    }
-    if (rejected.length > 0 && rejected[rejected.length - 1].name === name) continue;
+    if (invalid) continue;
 
-    // Final stat on the resolved path (guards against TOCTOU between segment
-    // walk and read, and catches non-regular files).
     let st;
     try {
       st = await lstat(filePath);
@@ -232,11 +212,9 @@ export async function buildBatchArchive(projectsRoot, projectId, fileNames) {
     packed += 1;
   }
 
-  // Fail-fast: any rejected entry means the request is invalid — mirror the
-  // strict rejection semantics of the panel and full archive.
   if (rejected.length > 0) {
     const err = new Error(
-      `${rejected.length} file(s) ineligible for archive: ${rejected.map((r) => r.name).join(', ')}`,
+      `${rejected.length} file(s) ineligible for archive: ${rejected.map((item) => item.name).join(', ')}`,
     );
     err.code = 'BAD_REQUEST';
     err.rejected = rejected;
@@ -497,24 +475,28 @@ export async function searchProjectFiles(projectsRoot, projectId, query, opts = 
   const escaped = String(query).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const re = new RegExp(escaped, 'i');
   const matches = [];
-  for (const f of items) {
-    if (!isTextualMime(f.mime)) continue;
-    if (pattern && !globMatch(f.name, pattern)) continue;
+
+  for (const file of items) {
+    if (!isTextualMime(file.mime)) continue;
+    if (pattern && !globMatch(file.name, pattern)) continue;
+
     let content;
     try {
-      content = await readFile(path.join(dir, f.name), 'utf8');
+      content = await readFile(path.join(dir, file.name), 'utf8');
     } catch {
       continue;
     }
+
     const lines = content.split('\n');
-    for (let i = 0; i < lines.length; i++) {
-      if (re.test(lines[i])) {
-        const snippet = lines[i].length > 220 ? lines[i].slice(0, 220) + '…' : lines[i];
-        matches.push({ file: f.name, line: i + 1, snippet });
-        if (matches.length >= max) return matches;
-      }
+    for (let index = 0; index < lines.length; index += 1) {
+      if (!re.test(lines[index])) continue;
+      const line = lines[index];
+      const snippet = line.length > 220 ? `${line.slice(0, 220)}…` : line;
+      matches.push({ file: file.name, line: index + 1, snippet });
+      if (matches.length >= max) return matches;
     }
   }
+
   return matches;
 }
 
@@ -530,12 +512,10 @@ function isTextualMime(mime) {
 
 function globMatch(name, glob) {
   const re = new RegExp(
-    '^' +
-      glob
-        .split('*')
-        .map((s) => s.replace(/[.+?^${}()|[\]\\]/g, '\\$&'))
-        .join('.*') +
-      '$',
+    `^${glob
+      .split('*')
+      .map((part) => part.replace(/[.+?^${}()|[\]\\]/g, '\\$&'))
+      .join('.*')}$`,
   );
   return re.test(name);
 }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -10,9 +10,6 @@ import os from 'node:os';
 import { composeSystemPrompt } from './prompts/system.js';
 import { createCommandInvocation } from '@open-design/platform';
 import {
-  checkPromptArgvBudget,
-  checkWindowsCmdShimCommandLineBudget,
-  checkWindowsDirectExeCommandLineBudget,
   detectAgents,
   getAgentDef,
   isKnownModel,
@@ -29,7 +26,6 @@ import { attachPiRpcSession } from './pi-rpc.js';
 import { createClaudeStreamHandler } from './claude-stream.js';
 import { createCopilotStreamHandler } from './copilot-stream.js';
 import { createJsonEventStreamHandler } from './json-event-stream.js';
-import { subscribe as subscribeFileEvents } from './project-watchers.js';
 import { renderDesignSystemPreview } from './design-system-preview.js';
 import { renderDesignSystemShowcase } from './design-system-showcase.js';
 import { createChatRunService } from './runs.js';
@@ -40,6 +36,7 @@ import { lintArtifact, renderFindingsForAgent } from './lint-artifact.js';
 import { loadCraftSections } from './craft.js';
 import { stageActiveSkill } from './cwd-aliases.js';
 import { generateMedia } from './media.js';
+import { inspectProjectPreview } from './visual-inspector.js';
 import {
   AUDIO_DURATIONS_SEC,
   AUDIO_MODELS_BY_KIND,
@@ -53,7 +50,6 @@ import { readMaskedConfig, writeConfig } from './media-config.js';
 import { readAppConfig, writeAppConfig } from './app-config.js';
 import {
   buildProjectArchive,
-  buildBatchArchive,
   decodeMultipartFilename,
   deleteProjectFile,
   ensureProject,
@@ -63,7 +59,6 @@ import {
   readProjectFile,
   removeProjectDir,
   sanitizeName,
-  searchProjectFiles,
   writeProjectFile,
 } from './projects.js';
 import { validateArtifactManifestInput } from './artifact-manifest.js';
@@ -154,7 +149,7 @@ export function normalizeCommentAttachments(input) {
         comment,
         currentText: compactString(raw.currentText, 160),
         pagePosition: normalizeAttachmentPosition(raw.pagePosition),
-        htmlHint: compactString(raw.htmlHint, 180),
+        htmlHint: compactString(raw.htmlHint, 4000),
       };
     })
     .filter(Boolean)
@@ -166,23 +161,22 @@ export function renderCommentAttachmentHint(commentAttachments) {
   const lines = [
     '',
     '',
-    '<attached-preview-comments>',
-    'Scope: edit the target element by default. Use the smallest necessary parent wrapper only if the target cannot satisfy the comment. Preserve stable ids and unrelated siblings.',
+    'Selected preview elements:',
+    'Default scope: edit the selected rendered element in its listed file. Use the smallest necessary parent wrapper only if the target cannot satisfy the request. Preserve stable ids and unrelated siblings. Do not create a separate sibling HTML artifact for selected-element edits.',
   ];
   for (const item of commentAttachments) {
     lines.push(
       '',
-      `${item.order}. ${item.elementId}`,
+      `Element ${item.order}: ${item.elementId}`,
       `file: ${item.filePath}`,
       `selector: ${item.selector}`,
       `label: ${item.label || '(unlabeled)'}`,
       `position: ${formatAttachmentPosition(item.pagePosition)}`,
       `currentText: ${item.currentText || '(empty)'}`,
       `htmlHint: ${item.htmlHint || '(none)'}`,
-      `comment: ${item.comment}`,
+      `userRequest: ${item.comment}`,
     );
   }
-  lines.push('</attached-preview-comments>');
   return lines.join('\n');
 }
 
@@ -697,6 +691,41 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
   });
   const db = openDatabase(PROJECT_ROOT, { dataDir: RUNTIME_DATA_DIR });
 
+  app.post('/api/projects/:id/preview/inspect', async (req, res) => {
+    try {
+      const filePath = typeof req.body?.file === 'string' && req.body.file.trim()
+        ? req.body.file.trim()
+        : 'index.html';
+      const file = await readProjectFile(PROJECTS_DIR, req.params.id, filePath);
+      const inspectable = file.mime === 'text/html'
+        || file.mime === 'image/svg+xml'
+        || /\.(html?|svg)$/i.test(filePath);
+      if (!inspectable) {
+        return res.status(400).json({ error: 'preview inspect supports HTML and SVG files only' });
+      }
+
+      const rawPath = filePath.split('/').map((segment) => encodeURIComponent(segment)).join('/');
+      const url = `http://127.0.0.1:${resolvedPort}/api/projects/${encodeURIComponent(req.params.id)}/raw/${rawPath}`;
+      const root = projectDir(PROJECTS_DIR, req.params.id);
+      const report = await inspectProjectPreview({
+        projectId: req.params.id,
+        projectRoot: root,
+        outputRoot: root,
+        filePath,
+        url,
+        frames: req.body?.frames,
+        intervalMs: req.body?.intervalMs ?? req.body?.interval,
+        width: req.body?.width,
+        height: req.body?.height,
+        fullPage: req.body?.fullPage === true,
+      });
+      res.json(report);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: message });
+    }
+  });
+
   if (process.env.OD_CODEX_DISABLE_PLUGINS === '1') {
     console.log('[od] Codex plugins disabled via OD_CODEX_DISABLE_PLUGINS=1');
   }
@@ -721,133 +750,6 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
   });
 
   // ---- Projects (DB-backed) -------------------------------------------------
-
-  // Soft "what is the user looking at right now in Open Design?" channel. The
-  // web UI POSTs the current project + file on every route change;
-  // the MCP surface reads it so a coding agent in another repo can
-  // resolve "the design I have open" without the user typing the
-  // project id. In-memory only - daemon restart clears it.
-  /** @type {{ projectId: string; fileName: string | null; ts: number } | null} */
-  let activeContext = null;
-  const ACTIVE_CONTEXT_TTL_MS = 5 * 60 * 1000;
-
-  // Active context is private to the local machine. The daemon binds
-  // 0.0.0.0 by default, so without an origin check a peer on the LAN
-  // could read what the user is currently looking at (GET) or spoof
-  // it to redirect MCP fallbacks (POST). The web proxies same-origin
-  // and the MCP runs in-process via 127.0.0.1, so both legitimate
-  // callers pass the check.
-  app.post('/api/active', (req, res) => {
-    if (!isLocalSameOrigin(req, resolvedPort)) {
-      return res.status(403).json({ error: 'cross-origin request rejected' });
-    }
-    try {
-      const body = req.body || {};
-      if (body.active === false) {
-        activeContext = null;
-        res.json({ active: false });
-        return;
-      }
-      const projectId = typeof body.projectId === 'string' ? body.projectId : '';
-      if (!projectId) {
-        sendApiError(res, 400, 'BAD_REQUEST', 'projectId is required');
-        return;
-      }
-      const fileName =
-        typeof body.fileName === 'string' && body.fileName.length > 0
-          ? body.fileName
-          : null;
-      activeContext = { projectId, fileName, ts: Date.now() };
-      res.json({ active: true, ...activeContext });
-    } catch (err) {
-      sendApiError(res, 400, 'BAD_REQUEST', String(err));
-    }
-  });
-
-  app.get('/api/active', (req, res) => {
-    if (!isLocalSameOrigin(req, resolvedPort)) {
-      return res.status(403).json({ error: 'cross-origin request rejected' });
-    }
-    if (!activeContext || Date.now() - activeContext.ts > ACTIVE_CONTEXT_TTL_MS) {
-      activeContext = null;
-      res.json({ active: false });
-      return;
-    }
-    const project = getProject(db, activeContext.projectId);
-    res.json({
-      active: true,
-      projectId: activeContext.projectId,
-      projectName: project?.name ?? null,
-      fileName: activeContext.fileName,
-      ts: activeContext.ts,
-      ageMs: Date.now() - activeContext.ts,
-    });
-  });
-
-  // Surfaces the absolute paths to `node` + `apps/daemon/dist/cli.js`
-  // so the Settings → MCP server panel can render snippets that work
-  // even when `od` isn't on the user's PATH (the common case for
-  // source clones - and macOS/Linux ship a /usr/bin/od octal-dump
-  // tool that shadows ours anyway). Computed from import.meta.url so
-  // both src/ (tsx dev) and dist/ (built) launches resolve to the
-  // same dist/cli.js path. Cached for 5s because the panel pings on
-  // every open and the path lookup + two existsSync calls are cheap
-  // but not free, and these paths cannot change without a daemon
-  // restart anyway.
-  const INSTALL_INFO_TTL_MS = 5000;
-  let installInfoCache: { t: number; payload: object } | null = null;
-
-  app.get('/api/mcp/install-info', (req, res) => {
-    if (!isLocalSameOrigin(req, resolvedPort)) {
-      return res.status(403).json({ error: 'cross-origin request rejected' });
-    }
-    const now = Date.now();
-    if (installInfoCache && now - installInfoCache.t < INSTALL_INFO_TTL_MS) {
-      return res.json(installInfoCache.payload);
-    }
-    let cliPath;
-    try {
-      cliPath = fileURLToPath(new URL('../dist/cli.js', import.meta.url));
-    } catch (err) {
-      return sendApiError(res, 500, 'CLI_RESOLVE_FAILED', String(err));
-    }
-    const cliExists = fs.existsSync(cliPath);
-    // process.execPath is the absolute path to the node binary that
-    // is running the daemon RIGHT NOW. We prefer it over bare `node`
-    // because IDE-spawned MCP clients inherit a minimal PATH from the
-    // OS launcher (Spotlight, Dock, etc.) that often does not see
-    // user-level node installs (nvm, fnm, asdf). On rare occasions
-    // (uninstall mid-session, exotic embeds) the path may not exist
-    // by the time the user copies the snippet; catch that and warn.
-    const nodeExists = fs.existsSync(process.execPath);
-    const hints: string[] = [];
-    if (!cliExists) {
-      hints.push(
-        'apps/daemon/dist/cli.js is missing. Run `pnpm --filter @open-design/daemon build` (or just `pnpm build`) and refresh.',
-      );
-    }
-    if (!nodeExists) {
-      hints.push(
-        `Node binary at ${process.execPath} no longer exists. Reinstall Node and restart the daemon.`,
-      );
-    }
-    const payload = {
-      command: process.execPath,
-      args: [cliPath, 'mcp', '--daemon-url', `http://127.0.0.1:${resolvedPort}`],
-      daemonUrl: `http://127.0.0.1:${resolvedPort}`,
-      // Surface platform so the install panel can localize path hints
-      // (~/.cursor vs %USERPROFILE%\.cursor) and keyboard shortcuts
-      // (Cmd vs Ctrl). One of 'darwin' | 'linux' | 'win32' in
-      // practice; the panel falls back to POSIX wording for anything
-      // else.
-      platform: process.platform,
-      cliExists,
-      nodeExists,
-      buildHint: hints.length ? hints.join(' ') : null,
-    };
-    installInfoCache = { t: now, payload };
-    res.json(payload);
-  });
 
   app.get('/api/projects', (_req, res) => {
     try {
@@ -1060,39 +962,6 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
       res.json(body);
     } catch (err) {
       sendApiError(res, 400, 'BAD_REQUEST', String(err));
-    }
-  });
-
-  // SSE stream of file-changed events for a project. Drives preview live-reload.
-  // Receipt of a `file-changed` event triggers a file-list refresh, which
-  // propagates new mtimes through to FileViewer iframes (the URL-load
-  // `?v=${mtime}` cache-bust from PR #384 then reloads the iframe automatically).
-  // Subscribers come and go as users open/close project tabs; the underlying
-  // chokidar watcher is refcounted in project-watchers.ts so we never hold
-  // descriptors for projects no UI is looking at.
-  app.get('/api/projects/:id/events', (req, res) => {
-    if (!getProject(db, req.params.id)) {
-      return sendApiError(res, 404, 'PROJECT_NOT_FOUND', 'not found');
-    }
-    let sub;
-    try {
-      const sse = createSseResponse(res);
-      sub = subscribeFileEvents(PROJECTS_DIR, req.params.id, (evt) => {
-        sse.send('file-changed', evt);
-      });
-      sub.ready.then(() => sse.send('ready', { projectId: req.params.id })).catch(() => {});
-      const cleanup = () => {
-        if (sub) {
-          const { unsubscribe } = sub;
-          sub = null;
-          Promise.resolve(unsubscribe()).catch(() => {});
-        }
-      };
-      res.on('close', cleanup);
-      res.on('finish', cleanup);
-    } catch (err) {
-      if (sub) Promise.resolve(sub.unsubscribe()).catch(() => {});
-      if (!res.headersSent) sendApiError(res, 400, 'BAD_REQUEST', String(err?.message || err));
     }
   });
 
@@ -1870,32 +1739,10 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
   // project's own folder (see apps/daemon/src/projects.ts).
   app.get('/api/projects/:id/files', async (req, res) => {
     try {
-      const since = Number(req.query?.since);
-      const files = await listFiles(PROJECTS_DIR, req.params.id, {
-        since: Number.isFinite(since) ? since : undefined,
-      });
+      const files = await listFiles(PROJECTS_DIR, req.params.id);
       /** @type {import('@open-design/contracts').ProjectFilesResponse} */
       const body = { files };
       res.json(body);
-    } catch (err) {
-      sendApiError(res, 400, 'BAD_REQUEST', String(err));
-    }
-  });
-
-  app.get('/api/projects/:id/search', async (req, res) => {
-    try {
-      const query = String(req.query.q ?? '');
-      if (!query) {
-        sendApiError(res, 400, 'BAD_REQUEST', 'q query parameter is required');
-        return;
-      }
-      const pattern = req.query.pattern ? String(req.query.pattern) : null;
-      const max = Math.min(Number(req.query.max) || 200, 1000);
-      const matches = await searchProjectFiles(PROJECTS_DIR, req.params.id, query, {
-        pattern,
-        max,
-      });
-      res.json({ query, matches });
     } catch (err) {
       sendApiError(res, 400, 'BAD_REQUEST', String(err));
     }
@@ -1932,43 +1779,6 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
     } catch (err) {
       const code = err && err.code;
       const status = code === 'ENOENT' || code === 'ENOTDIR' ? 404 : 400;
-      sendApiError(
-        res,
-        status,
-        status === 404 ? 'FILE_NOT_FOUND' : 'BAD_REQUEST',
-        String(err?.message || err),
-      );
-    }
-  });
-
-  // Batch archive: accepts a list of file names and returns a ZIP of just
-  // those files. Used by the Design Files panel multi-select download.
-  app.post('/api/projects/:id/archive/batch', async (req, res) => {
-    try {
-      const { files } = req.body || {};
-      if (!Array.isArray(files) || files.length === 0) {
-        sendApiError(res, 400, 'BAD_REQUEST', 'files must be a non-empty array');
-        return;
-      }
-      const { buffer } = await buildBatchArchive(
-        PROJECTS_DIR,
-        req.params.id,
-        files,
-      );
-      const project = getProject(db, req.params.id);
-      const fileSlug = sanitizeArchiveFilename(project?.name || req.params.id) || 'project';
-      const filename = `${fileSlug}.zip`;
-      const asciiFallback =
-        filename.replace(/[^\x20-\x7e]/g, '_').replace(/"/g, '_') || 'project.zip';
-      res.setHeader('Content-Type', 'application/zip');
-      res.setHeader(
-        'Content-Disposition',
-        `attachment; filename="${asciiFallback}"; filename*=UTF-8''${encodeURIComponent(filename)}`,
-      );
-      res.send(buffer);
-    } catch (err) {
-      const code = err && err.code;
-      const status = code === 'ENOENT' ? 404 : 400;
       sendApiError(
         res,
         status,
@@ -2530,6 +2340,7 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
       designSystemId,
       attachments = [],
       commentAttachments = [],
+      activeFilePath = null,
       model,
       reasoning,
     } = chatBody;
@@ -2604,6 +2415,26 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
             }
           })
       : [];
+    const safeActiveFilePath =
+      cwd && typeof activeFilePath === 'string' && activeFilePath.length > 0
+        ? (() => {
+            try {
+              const abs = path.resolve(cwd, activeFilePath);
+              return (abs === cwd || abs.startsWith(cwd + path.sep)) && fs.existsSync(abs)
+                ? activeFilePath
+                : null;
+            } catch {
+              return null;
+            }
+          })()
+        : null;
+    const selectedEditFiles = [
+      ...new Set(
+        safeCommentAttachments
+          .map((item) => item.filePath)
+          .filter((filePath) => typeof filePath === 'string' && filePath.length > 0),
+      ),
+    ];
 
     // Local code agents don't accept a separate "system" channel the way the
     // Messages API does — we fold the skill + design-system prompt into the
@@ -2618,8 +2449,16 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
           .map((f) => `- ${f.name}`)
           .join('\n')}`
       : '\nThis folder is empty. Choose a clear, descriptive filename for whatever you create.';
+    const activeFileHint = safeActiveFilePath
+      ? `\n\nActive preview file: \`${safeActiveFilePath}\`. For edits, revisions, visual tweaks, selected-element changes, or requests that refer to the current design/page, modify this file in place. Do not create sibling copies like \`name-2.html\`, \`name-5.html\`, or blank handoff files. Create a new file only when the user explicitly asks for a separate new artifact.`
+      : '';
+    const selectedEditFileHint = selectedEditFiles.length
+      ? `\n\nSelected edit target file${selectedEditFiles.length === 1 ? '' : 's'}: ${selectedEditFiles
+          .map((filePath) => `\`${filePath}\``)
+          .join(', ')}. Apply selected-element edits only inside these files unless the user explicitly asks for cross-file changes.`
+      : '';
     const cwdHint = cwd
-      ? `\n\nYour working directory: ${cwd}\nWrite project files relative to it (e.g. \`index.html\`, \`assets/x.png\`). The user can browse those files in real time.${filesListBlock}`
+      ? `\n\nYour working directory: ${cwd}\nWrite project files relative to it (e.g. \`index.html\`, \`assets/x.png\`). The user can browse those files in real time.${filesListBlock}${activeFileHint}${selectedEditFileHint}`
       : '';
     const attachmentHint = safeAttachments.length
       ? `\n\nAttached project files: ${safeAttachments.map((p) => `\`${p}\``).join(', ')}`
@@ -2712,27 +2551,6 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
         : null;
     const agentOptions = { model: safeModel, reasoning: safeReasoning };
 
-    // Pre-flight the composed prompt against any argv-byte budget the
-    // adapter declared (only DeepSeek TUI today — its CLI doesn't accept
-    // a `-` stdin sentinel, so the prompt has to ride argv). Doing this
-    // before bin resolution means the test harness pins the guard
-    // independently of whether the adapter binary happens to be on PATH
-    // in the CI environment, and the user gets the actionable
-    // adapter-named error even if /api/agents hadn't refreshed yet.
-    const promptBudgetError = checkPromptArgvBudget(def, composed);
-    if (promptBudgetError) {
-      design.runs.emit(
-        run,
-        'error',
-        createSseErrorPayload(
-          promptBudgetError.code,
-          promptBudgetError.message,
-          { retryable: false },
-        ),
-      );
-      return design.runs.finish(run, 'failed', 1, null);
-    }
-
     const resolvedBin = resolveAgentBin(agentId);
 
     // If detection can't find the binary, surface a friendly SSE error
@@ -2760,62 +2578,6 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
       agentOptions,
       { cwd: effectiveCwd },
     );
-
-    // Second-pass budget check that knows about the Windows `.cmd` shim
-    // wrap. The pre-buildArgs `checkPromptArgvBudget` only looks at the
-    // raw composed prompt; on Windows an npm-installed adapter resolves
-    // to e.g. `deepseek.cmd`, the spawn path goes through `cmd.exe /d /s
-    // /c "<inner>"`, and `quoteForWindowsCmdShim` doubles every embedded
-    // `"` plus wraps any whitespace/special-char arg in outer quotes —
-    // so a quote-heavy prompt that fit under `maxPromptArgBytes` can
-    // still expand past CreateProcess's 32_767-char cap. Fail fast with
-    // the same `AGENT_PROMPT_TOO_LARGE` shape so the SSE error path
-    // doesn't have to special-case it.
-    const cmdShimBudgetError = checkWindowsCmdShimCommandLineBudget(
-      def,
-      resolvedBin,
-      args,
-    );
-    if (cmdShimBudgetError) {
-      design.runs.emit(
-        run,
-        'error',
-        createSseErrorPayload(
-          cmdShimBudgetError.code,
-          cmdShimBudgetError.message,
-          { retryable: false },
-        ),
-      );
-      return design.runs.finish(run, 'failed', 1, null);
-    }
-
-    // Companion guard for non-shim Windows installs (e.g. a cargo-built
-    // `deepseek.exe` rather than the npm `.cmd` shim). Direct `.exe`
-    // spawns skip the cmd.exe wrap above, but Node/libuv still composes
-    // a CreateProcess `lpCommandLine` by walking each argv element
-    // through `quote_cmd_arg`, which escapes every embedded `"` as `\"`
-    // and doubles backslashes adjacent to quotes. A quote-heavy prompt
-    // under `maxPromptArgBytes` can expand past the 32_767-char kernel
-    // cap there too, so the cmd-shim early-return alone would let those
-    // users hit a generic `spawn ENAMETOOLONG`.
-    const directExeBudgetError = checkWindowsDirectExeCommandLineBudget(
-      def,
-      resolvedBin,
-      args,
-    );
-    if (directExeBudgetError) {
-      design.runs.emit(
-        run,
-        'error',
-        createSseErrorPayload(
-          directExeBudgetError.code,
-          directExeBudgetError.message,
-          { retryable: false },
-        ),
-      );
-      return design.runs.finish(run, 'failed', 1, null);
-    }
-
     const send = (event, data) => design.runs.emit(run, event, data);
 
     const odMediaEnv = {
@@ -2853,11 +2615,7 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
         def.promptViaStdin || def.streamFormat === 'acp-json-rpc'
           ? 'pipe'
           : 'ignore';
-      const env = spawnEnvForAgent(def.id, {
-        ...process.env,
-        ...(def.env || {}),
-        ...odMediaEnv,
-      });
+      const env = spawnEnvForAgent(def.id, { ...process.env, ...odMediaEnv });
       const invocation = createCommandInvocation({
         command: resolvedBin,
         args,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -10,6 +10,9 @@ import os from 'node:os';
 import { composeSystemPrompt } from './prompts/system.js';
 import { createCommandInvocation } from '@open-design/platform';
 import {
+  checkPromptArgvBudget,
+  checkWindowsCmdShimCommandLineBudget,
+  checkWindowsDirectExeCommandLineBudget,
   detectAgents,
   getAgentDef,
   isKnownModel,
@@ -26,6 +29,7 @@ import { attachPiRpcSession } from './pi-rpc.js';
 import { createClaudeStreamHandler } from './claude-stream.js';
 import { createCopilotStreamHandler } from './copilot-stream.js';
 import { createJsonEventStreamHandler } from './json-event-stream.js';
+import { subscribe as subscribeFileEvents } from './project-watchers.js';
 import { renderDesignSystemPreview } from './design-system-preview.js';
 import { renderDesignSystemShowcase } from './design-system-showcase.js';
 import { createChatRunService } from './runs.js';
@@ -50,6 +54,7 @@ import { readMaskedConfig, writeConfig } from './media-config.js';
 import { readAppConfig, writeAppConfig } from './app-config.js';
 import {
   buildProjectArchive,
+  buildBatchArchive,
   decodeMultipartFilename,
   deleteProjectFile,
   ensureProject,
@@ -59,6 +64,7 @@ import {
   readProjectFile,
   removeProjectDir,
   sanitizeName,
+  searchProjectFiles,
   writeProjectFile,
 } from './projects.js';
 import { validateArtifactManifestInput } from './artifact-manifest.js';
@@ -693,18 +699,23 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
 
   app.post('/api/projects/:id/preview/inspect', async (req, res) => {
     try {
-      const filePath = typeof req.body?.file === 'string' && req.body.file.trim()
-        ? req.body.file.trim()
-        : 'index.html';
+      const filePath =
+        typeof req.body?.file === 'string' && req.body.file.trim()
+          ? req.body.file.trim()
+          : 'index.html';
       const file = await readProjectFile(PROJECTS_DIR, req.params.id, filePath);
-      const inspectable = file.mime === 'text/html'
-        || file.mime === 'image/svg+xml'
-        || /\.(html?|svg)$/i.test(filePath);
+      const inspectable =
+        file.mime === 'text/html' ||
+        file.mime === 'image/svg+xml' ||
+        /\.(html?|svg)$/i.test(filePath);
       if (!inspectable) {
         return res.status(400).json({ error: 'preview inspect supports HTML and SVG files only' });
       }
 
-      const rawPath = filePath.split('/').map((segment) => encodeURIComponent(segment)).join('/');
+      const rawPath = filePath
+        .split('/')
+        .map((segment) => encodeURIComponent(segment))
+        .join('/');
       const url = `http://127.0.0.1:${resolvedPort}/api/projects/${encodeURIComponent(req.params.id)}/raw/${rawPath}`;
       const root = projectDir(PROJECTS_DIR, req.params.id);
       const report = await inspectProjectPreview({
@@ -750,6 +761,133 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
   });
 
   // ---- Projects (DB-backed) -------------------------------------------------
+
+  // Soft "what is the user looking at right now in Open Design?" channel. The
+  // web UI POSTs the current project + file on every route change;
+  // the MCP surface reads it so a coding agent in another repo can
+  // resolve "the design I have open" without the user typing the
+  // project id. In-memory only - daemon restart clears it.
+  /** @type {{ projectId: string; fileName: string | null; ts: number } | null} */
+  let activeContext = null;
+  const ACTIVE_CONTEXT_TTL_MS = 5 * 60 * 1000;
+
+  // Active context is private to the local machine. The daemon binds
+  // 0.0.0.0 by default, so without an origin check a peer on the LAN
+  // could read what the user is currently looking at (GET) or spoof
+  // it to redirect MCP fallbacks (POST). The web proxies same-origin
+  // and the MCP runs in-process via 127.0.0.1, so both legitimate
+  // callers pass the check.
+  app.post('/api/active', (req, res) => {
+    if (!isLocalSameOrigin(req, resolvedPort)) {
+      return res.status(403).json({ error: 'cross-origin request rejected' });
+    }
+    try {
+      const body = req.body || {};
+      if (body.active === false) {
+        activeContext = null;
+        res.json({ active: false });
+        return;
+      }
+      const projectId = typeof body.projectId === 'string' ? body.projectId : '';
+      if (!projectId) {
+        sendApiError(res, 400, 'BAD_REQUEST', 'projectId is required');
+        return;
+      }
+      const fileName =
+        typeof body.fileName === 'string' && body.fileName.length > 0
+          ? body.fileName
+          : null;
+      activeContext = { projectId, fileName, ts: Date.now() };
+      res.json({ active: true, ...activeContext });
+    } catch (err) {
+      sendApiError(res, 400, 'BAD_REQUEST', String(err));
+    }
+  });
+
+  app.get('/api/active', (req, res) => {
+    if (!isLocalSameOrigin(req, resolvedPort)) {
+      return res.status(403).json({ error: 'cross-origin request rejected' });
+    }
+    if (!activeContext || Date.now() - activeContext.ts > ACTIVE_CONTEXT_TTL_MS) {
+      activeContext = null;
+      res.json({ active: false });
+      return;
+    }
+    const project = getProject(db, activeContext.projectId);
+    res.json({
+      active: true,
+      projectId: activeContext.projectId,
+      projectName: project?.name ?? null,
+      fileName: activeContext.fileName,
+      ts: activeContext.ts,
+      ageMs: Date.now() - activeContext.ts,
+    });
+  });
+
+  // Surfaces the absolute paths to `node` + `apps/daemon/dist/cli.js`
+  // so the Settings → MCP server panel can render snippets that work
+  // even when `od` isn't on the user's PATH (the common case for
+  // source clones - and macOS/Linux ship a /usr/bin/od octal-dump
+  // tool that shadows ours anyway). Computed from import.meta.url so
+  // both src/ (tsx dev) and dist/ (built) launches resolve to the
+  // same dist/cli.js path. Cached for 5s because the panel pings on
+  // every open and the path lookup + two existsSync calls are cheap
+  // but not free, and these paths cannot change without a daemon
+  // restart anyway.
+  const INSTALL_INFO_TTL_MS = 5000;
+  let installInfoCache: { t: number; payload: object } | null = null;
+
+  app.get('/api/mcp/install-info', (req, res) => {
+    if (!isLocalSameOrigin(req, resolvedPort)) {
+      return res.status(403).json({ error: 'cross-origin request rejected' });
+    }
+    const now = Date.now();
+    if (installInfoCache && now - installInfoCache.t < INSTALL_INFO_TTL_MS) {
+      return res.json(installInfoCache.payload);
+    }
+    let cliPath;
+    try {
+      cliPath = fileURLToPath(new URL('../dist/cli.js', import.meta.url));
+    } catch (err) {
+      return sendApiError(res, 500, 'CLI_RESOLVE_FAILED', String(err));
+    }
+    const cliExists = fs.existsSync(cliPath);
+    // process.execPath is the absolute path to the node binary that
+    // is running the daemon RIGHT NOW. We prefer it over bare `node`
+    // because IDE-spawned MCP clients inherit a minimal PATH from the
+    // OS launcher (Spotlight, Dock, etc.) that often does not see
+    // user-level node installs (nvm, fnm, asdf). On rare occasions
+    // (uninstall mid-session, exotic embeds) the path may not exist
+    // by the time the user copies the snippet; catch that and warn.
+    const nodeExists = fs.existsSync(process.execPath);
+    const hints: string[] = [];
+    if (!cliExists) {
+      hints.push(
+        'apps/daemon/dist/cli.js is missing. Run `pnpm --filter @open-design/daemon build` (or just `pnpm build`) and refresh.',
+      );
+    }
+    if (!nodeExists) {
+      hints.push(
+        `Node binary at ${process.execPath} no longer exists. Reinstall Node and restart the daemon.`,
+      );
+    }
+    const payload = {
+      command: process.execPath,
+      args: [cliPath, 'mcp', '--daemon-url', `http://127.0.0.1:${resolvedPort}`],
+      daemonUrl: `http://127.0.0.1:${resolvedPort}`,
+      // Surface platform so the install panel can localize path hints
+      // (~/.cursor vs %USERPROFILE%\.cursor) and keyboard shortcuts
+      // (Cmd vs Ctrl). One of 'darwin' | 'linux' | 'win32' in
+      // practice; the panel falls back to POSIX wording for anything
+      // else.
+      platform: process.platform,
+      cliExists,
+      nodeExists,
+      buildHint: hints.length ? hints.join(' ') : null,
+    };
+    installInfoCache = { t: now, payload };
+    res.json(payload);
+  });
 
   app.get('/api/projects', (_req, res) => {
     try {
@@ -962,6 +1100,39 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
       res.json(body);
     } catch (err) {
       sendApiError(res, 400, 'BAD_REQUEST', String(err));
+    }
+  });
+
+  // SSE stream of file-changed events for a project. Drives preview live-reload.
+  // Receipt of a `file-changed` event triggers a file-list refresh, which
+  // propagates new mtimes through to FileViewer iframes (the URL-load
+  // `?v=${mtime}` cache-bust from PR #384 then reloads the iframe automatically).
+  // Subscribers come and go as users open/close project tabs; the underlying
+  // chokidar watcher is refcounted in project-watchers.ts so we never hold
+  // descriptors for projects no UI is looking at.
+  app.get('/api/projects/:id/events', (req, res) => {
+    if (!getProject(db, req.params.id)) {
+      return sendApiError(res, 404, 'PROJECT_NOT_FOUND', 'not found');
+    }
+    let sub;
+    try {
+      const sse = createSseResponse(res);
+      sub = subscribeFileEvents(PROJECTS_DIR, req.params.id, (evt) => {
+        sse.send('file-changed', evt);
+      });
+      sub.ready.then(() => sse.send('ready', { projectId: req.params.id })).catch(() => {});
+      const cleanup = () => {
+        if (sub) {
+          const { unsubscribe } = sub;
+          sub = null;
+          Promise.resolve(unsubscribe()).catch(() => {});
+        }
+      };
+      res.on('close', cleanup);
+      res.on('finish', cleanup);
+    } catch (err) {
+      if (sub) Promise.resolve(sub.unsubscribe()).catch(() => {});
+      if (!res.headersSent) sendApiError(res, 400, 'BAD_REQUEST', String(err?.message || err));
     }
   });
 
@@ -1739,10 +1910,32 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
   // project's own folder (see apps/daemon/src/projects.ts).
   app.get('/api/projects/:id/files', async (req, res) => {
     try {
-      const files = await listFiles(PROJECTS_DIR, req.params.id);
+      const since = Number(req.query?.since);
+      const files = await listFiles(PROJECTS_DIR, req.params.id, {
+        since: Number.isFinite(since) ? since : undefined,
+      });
       /** @type {import('@open-design/contracts').ProjectFilesResponse} */
       const body = { files };
       res.json(body);
+    } catch (err) {
+      sendApiError(res, 400, 'BAD_REQUEST', String(err));
+    }
+  });
+
+  app.get('/api/projects/:id/search', async (req, res) => {
+    try {
+      const query = String(req.query.q ?? '');
+      if (!query) {
+        sendApiError(res, 400, 'BAD_REQUEST', 'q query parameter is required');
+        return;
+      }
+      const pattern = req.query.pattern ? String(req.query.pattern) : null;
+      const max = Math.min(Number(req.query.max) || 200, 1000);
+      const matches = await searchProjectFiles(PROJECTS_DIR, req.params.id, query, {
+        pattern,
+        max,
+      });
+      res.json({ query, matches });
     } catch (err) {
       sendApiError(res, 400, 'BAD_REQUEST', String(err));
     }
@@ -1779,6 +1972,43 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
     } catch (err) {
       const code = err && err.code;
       const status = code === 'ENOENT' || code === 'ENOTDIR' ? 404 : 400;
+      sendApiError(
+        res,
+        status,
+        status === 404 ? 'FILE_NOT_FOUND' : 'BAD_REQUEST',
+        String(err?.message || err),
+      );
+    }
+  });
+
+  // Batch archive: accepts a list of file names and returns a ZIP of just
+  // those files. Used by the Design Files panel multi-select download.
+  app.post('/api/projects/:id/archive/batch', async (req, res) => {
+    try {
+      const { files } = req.body || {};
+      if (!Array.isArray(files) || files.length === 0) {
+        sendApiError(res, 400, 'BAD_REQUEST', 'files must be a non-empty array');
+        return;
+      }
+      const { buffer } = await buildBatchArchive(
+        PROJECTS_DIR,
+        req.params.id,
+        files,
+      );
+      const project = getProject(db, req.params.id);
+      const fileSlug = sanitizeArchiveFilename(project?.name || req.params.id) || 'project';
+      const filename = `${fileSlug}.zip`;
+      const asciiFallback =
+        filename.replace(/[^\x20-\x7e]/g, '_').replace(/"/g, '_') || 'project.zip';
+      res.setHeader('Content-Type', 'application/zip');
+      res.setHeader(
+        'Content-Disposition',
+        `attachment; filename="${asciiFallback}"; filename*=UTF-8''${encodeURIComponent(filename)}`,
+      );
+      res.send(buffer);
+    } catch (err) {
+      const code = err && err.code;
+      const status = code === 'ENOENT' ? 404 : 400;
       sendApiError(
         res,
         status,
@@ -2551,6 +2781,27 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
         : null;
     const agentOptions = { model: safeModel, reasoning: safeReasoning };
 
+    // Pre-flight the composed prompt against any argv-byte budget the
+    // adapter declared (only DeepSeek TUI today — its CLI doesn't accept
+    // a `-` stdin sentinel, so the prompt has to ride argv). Doing this
+    // before bin resolution means the test harness pins the guard
+    // independently of whether the adapter binary happens to be on PATH
+    // in the CI environment, and the user gets the actionable
+    // adapter-named error even if /api/agents hadn't refreshed yet.
+    const promptBudgetError = checkPromptArgvBudget(def, composed);
+    if (promptBudgetError) {
+      design.runs.emit(
+        run,
+        'error',
+        createSseErrorPayload(
+          promptBudgetError.code,
+          promptBudgetError.message,
+          { retryable: false },
+        ),
+      );
+      return design.runs.finish(run, 'failed', 1, null);
+    }
+
     const resolvedBin = resolveAgentBin(agentId);
 
     // If detection can't find the binary, surface a friendly SSE error
@@ -2578,6 +2829,62 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
       agentOptions,
       { cwd: effectiveCwd },
     );
+
+    // Second-pass budget check that knows about the Windows `.cmd` shim
+    // wrap. The pre-buildArgs `checkPromptArgvBudget` only looks at the
+    // raw composed prompt; on Windows an npm-installed adapter resolves
+    // to e.g. `deepseek.cmd`, the spawn path goes through `cmd.exe /d /s
+    // /c "<inner>"`, and `quoteForWindowsCmdShim` doubles every embedded
+    // `"` plus wraps any whitespace/special-char arg in outer quotes —
+    // so a quote-heavy prompt that fit under `maxPromptArgBytes` can
+    // still expand past CreateProcess's 32_767-char cap. Fail fast with
+    // the same `AGENT_PROMPT_TOO_LARGE` shape so the SSE error path
+    // doesn't have to special-case it.
+    const cmdShimBudgetError = checkWindowsCmdShimCommandLineBudget(
+      def,
+      resolvedBin,
+      args,
+    );
+    if (cmdShimBudgetError) {
+      design.runs.emit(
+        run,
+        'error',
+        createSseErrorPayload(
+          cmdShimBudgetError.code,
+          cmdShimBudgetError.message,
+          { retryable: false },
+        ),
+      );
+      return design.runs.finish(run, 'failed', 1, null);
+    }
+
+    // Companion guard for non-shim Windows installs (e.g. a cargo-built
+    // `deepseek.exe` rather than the npm `.cmd` shim). Direct `.exe`
+    // spawns skip the cmd.exe wrap above, but Node/libuv still composes
+    // a CreateProcess `lpCommandLine` by walking each argv element
+    // through `quote_cmd_arg`, which escapes every embedded `"` as `\"`
+    // and doubles backslashes adjacent to quotes. A quote-heavy prompt
+    // under `maxPromptArgBytes` can expand past the 32_767-char kernel
+    // cap there too, so the cmd-shim early-return alone would let those
+    // users hit a generic `spawn ENAMETOOLONG`.
+    const directExeBudgetError = checkWindowsDirectExeCommandLineBudget(
+      def,
+      resolvedBin,
+      args,
+    );
+    if (directExeBudgetError) {
+      design.runs.emit(
+        run,
+        'error',
+        createSseErrorPayload(
+          directExeBudgetError.code,
+          directExeBudgetError.message,
+          { retryable: false },
+        ),
+      );
+      return design.runs.finish(run, 'failed', 1, null);
+    }
+
     const send = (event, data) => design.runs.emit(run, event, data);
 
     const odMediaEnv = {
@@ -2615,7 +2922,11 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
         def.promptViaStdin || def.streamFormat === 'acp-json-rpc'
           ? 'pipe'
           : 'ignore';
-      const env = spawnEnvForAgent(def.id, { ...process.env, ...odMediaEnv });
+      const env = spawnEnvForAgent(def.id, {
+        ...process.env,
+        ...(def.env || {}),
+        ...odMediaEnv,
+      });
       const invocation = createCommandInvocation({
         command: resolvedBin,
         args,

--- a/apps/daemon/src/visual-inspector.ts
+++ b/apps/daemon/src/visual-inspector.ts
@@ -1,0 +1,349 @@
+import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, stat } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+type VisualInspectInput = {
+  projectId: string;
+  projectRoot: string;
+  filePath: string;
+  url: string;
+  outputRoot?: string;
+  frames?: unknown;
+  intervalMs?: unknown;
+  width?: unknown;
+  height?: unknown;
+  fullPage?: boolean;
+};
+
+type FrameSpec = {
+  index: number;
+  timeMs: number;
+  path: string;
+};
+
+type CapturedFrame = FrameSpec & {
+  size: number;
+  sha256: string;
+};
+
+type ConsoleEntry = {
+  type: string;
+  text: string;
+};
+
+export type VisualInspectReport = {
+  ok: boolean;
+  renderer: string;
+  projectId: string;
+  filePath: string;
+  url: string;
+  outputDir: string;
+  viewport: {
+    width: number;
+    height: number;
+  };
+  frames: CapturedFrame[];
+  animationChanged: boolean;
+  uniqueFrameCount: number;
+  console: ConsoleEntry[];
+  warnings: string[];
+  errors: string[];
+};
+
+const MAX_FRAMES = 12;
+const MAX_CONSOLE_ENTRIES = 40;
+const CHROME_CANDIDATES = [
+  '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  '/Applications/Chromium.app/Contents/MacOS/Chromium',
+  '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+  '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
+];
+
+export async function inspectProjectPreview(input: VisualInspectInput): Promise<VisualInspectReport> {
+  const frameCount = clampNumber(input.frames, 5, 1, MAX_FRAMES);
+  const intervalMs = clampNumber(input.intervalMs, 250, 50, 2_000);
+  const width = clampNumber(input.width, 1440, 320, 3840);
+  const height = clampNumber(input.height, 1000, 240, 2160);
+  const outputRoot = input.outputRoot || input.projectRoot;
+  const outputDir = path.join(outputRoot, '.od-visual', `${slugify(input.filePath)}-${Date.now()}`);
+  const frameSpecs = Array.from({ length: frameCount }, (_, index) => ({
+    index,
+    timeMs: index * intervalMs,
+    path: path.join(outputDir, `frame-${String(index).padStart(3, '0')}.png`),
+  }));
+  const warnings: string[] = [];
+  const errors: string[] = [];
+
+  await mkdir(outputDir, { recursive: true });
+
+  try {
+    const result = await captureWithPlaywright(input.url, frameSpecs, {
+      width,
+      height,
+      fullPage: input.fullPage === true,
+    });
+    return buildReport(input, outputDir, width, height, 'playwright', result.frames, result.console, warnings, errors);
+  } catch (error) {
+    warnings.push(`Playwright unavailable; trying Chrome headless: ${errorMessage(error)}`);
+  }
+
+  try {
+    const result = await captureWithChrome(input.url, frameSpecs, width, height);
+    return buildReport(input, outputDir, width, height, 'chrome-headless', result.frames, [], warnings, errors);
+  } catch (error) {
+    errors.push(`Chrome headless unavailable: ${errorMessage(error)}`);
+  }
+
+  warnings.push('Visual inspection could not run. Install Google Chrome, set OD_CHROME_BIN, or add Playwright to the daemon runtime.');
+
+  return {
+    ok: false,
+    renderer: 'unavailable',
+    projectId: input.projectId,
+    filePath: input.filePath,
+    url: input.url,
+    outputDir,
+    viewport: { width, height },
+    frames: [],
+    animationChanged: false,
+    uniqueFrameCount: 0,
+    console: [],
+    warnings,
+    errors,
+  };
+}
+
+async function captureWithPlaywright(
+  url: string,
+  frameSpecs: FrameSpec[],
+  options: { width: number; height: number; fullPage: boolean },
+): Promise<{ frames: CapturedFrame[]; console: ConsoleEntry[] }> {
+  const playwright = await loadPlaywright();
+  const browser = await playwright.chromium.launch({ headless: true });
+  const consoleEntries: ConsoleEntry[] = [];
+
+  try {
+    const page = await browser.newPage({
+      viewport: { width: options.width, height: options.height },
+      deviceScaleFactor: 1,
+    });
+
+    page.on('console', (message: any) => {
+      const type = typeof message.type === 'function' ? message.type() : 'console';
+      if (!['error', 'warning'].includes(type)) return;
+      const text = typeof message.text === 'function' ? message.text() : String(message);
+      pushConsole(consoleEntries, { type, text });
+    });
+
+    page.on('pageerror', (error: Error) => {
+      pushConsole(consoleEntries, { type: 'pageerror', text: error.message });
+    });
+
+    await page.goto(url, { waitUntil: 'networkidle', timeout: 15_000 });
+
+    const frames: CapturedFrame[] = [];
+    let elapsed = 0;
+
+    for (const frame of frameSpecs) {
+      const waitMs = frame.index === 0 ? 100 : Math.max(0, frame.timeMs - elapsed);
+      if (waitMs > 0) await page.waitForTimeout(waitMs);
+      elapsed += waitMs;
+      await page.screenshot({ path: frame.path, fullPage: options.fullPage });
+      frames.push(await readFrame(frame));
+    }
+
+    return { frames, console: consoleEntries };
+  } finally {
+    await browser.close();
+  }
+}
+
+async function captureWithChrome(
+  url: string,
+  frameSpecs: FrameSpec[],
+  width: number,
+  height: number,
+): Promise<{ frames: CapturedFrame[] }> {
+  const chrome = await findChrome();
+  if (!chrome) throw new Error('no browser executable found');
+
+  const frames: CapturedFrame[] = [];
+
+  for (const frame of frameSpecs) {
+    const waitMs = Math.max(100, frame.timeMs);
+    const result = await runProcess(chrome, [
+      '--headless=new',
+      '--disable-gpu',
+      '--disable-dev-shm-usage',
+      '--disable-background-networking',
+      '--hide-scrollbars',
+      '--no-first-run',
+      '--no-default-browser-check',
+      '--run-all-compositor-stages-before-draw',
+      `--window-size=${width},${height}`,
+      `--virtual-time-budget=${waitMs}`,
+      `--screenshot=${frame.path}`,
+      url,
+    ], 20_000);
+
+    if (result.code !== 0) {
+      throw new Error(trimProcessOutput(result.stderr || result.stdout || `exit ${result.code}`));
+    }
+
+    frames.push(await readFrame(frame));
+  }
+
+  return { frames };
+}
+
+async function loadPlaywright(): Promise<any> {
+  const importModule = new Function('specifier', 'return import(specifier)') as (specifier: string) => Promise<any>;
+
+  try {
+    return await importModule('playwright');
+  } catch {
+    return await importModule('playwright-core');
+  }
+}
+
+async function findChrome(): Promise<string | null> {
+  const envChrome = process.env.OD_CHROME_BIN || process.env.CHROME_BIN;
+  if (envChrome && existsSync(envChrome)) return envChrome;
+
+  for (const candidate of CHROME_CANDIDATES) {
+    if (existsSync(candidate)) return candidate;
+  }
+
+  const commandNames = os.platform() === 'win32'
+    ? ['chrome.exe', 'msedge.exe']
+    : ['google-chrome', 'google-chrome-stable', 'chromium', 'chromium-browser', 'microsoft-edge', 'brave-browser'];
+
+  for (const command of commandNames) {
+    const found = await findOnPath(command);
+    if (found) return found;
+  }
+
+  return null;
+}
+
+async function findOnPath(command: string): Promise<string | null> {
+  const lookup = os.platform() === 'win32' ? 'where' : 'which';
+  const result = await runProcess(lookup, [command], 2_000);
+  if (result.code !== 0) return null;
+  const firstLine = result.stdout.split(/\r?\n/).find(Boolean);
+  return firstLine || null;
+}
+
+async function runProcess(
+  command: string,
+  args: string[],
+  timeoutMs = 20_000,
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGKILL');
+    }, timeoutMs);
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+
+    child.on('error', (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      resolve({
+        code: code ?? 1,
+        stdout,
+        stderr: timedOut ? `${stderr}\nprocess timed out after ${timeoutMs}ms` : stderr,
+      });
+    });
+  });
+}
+
+async function readFrame(frame: FrameSpec): Promise<CapturedFrame> {
+  const [stats, buffer] = await Promise.all([stat(frame.path), readFile(frame.path)]);
+  return {
+    ...frame,
+    size: stats.size,
+    sha256: createHash('sha256').update(buffer).digest('hex'),
+  };
+}
+
+function buildReport(
+  input: VisualInspectInput,
+  outputDir: string,
+  width: number,
+  height: number,
+  renderer: string,
+  frames: CapturedFrame[],
+  consoleEntries: ConsoleEntry[],
+  warnings: string[],
+  errors: string[],
+): VisualInspectReport {
+  const uniqueFrameCount = new Set(frames.map((frame) => frame.sha256)).size;
+  const nextWarnings = [...warnings];
+
+  if (frames.length > 1 && uniqueFrameCount <= 1) {
+    nextWarnings.push('Captured frames are visually identical. If this artifact should animate, inspect the CSS or timing.');
+  }
+
+  if (frames.some((frame) => frame.size < 1_000)) {
+    nextWarnings.push('At least one screenshot is extremely small. The preview may be blank or failed to render.');
+  }
+
+  return {
+    ok: true,
+    renderer,
+    projectId: input.projectId,
+    filePath: input.filePath,
+    url: input.url,
+    outputDir,
+    viewport: { width, height },
+    frames,
+    animationChanged: uniqueFrameCount > 1,
+    uniqueFrameCount,
+    console: consoleEntries,
+    warnings: nextWarnings,
+    errors,
+  };
+}
+
+function clampNumber(value: unknown, fallback: number, min: number, max: number): number {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return fallback;
+  return Math.min(max, Math.max(min, Math.round(number)));
+}
+
+function pushConsole(entries: ConsoleEntry[], entry: ConsoleEntry): void {
+  if (entries.length >= MAX_CONSOLE_ENTRIES) return;
+  entries.push({ type: entry.type, text: entry.text.slice(0, 1_000) });
+}
+
+function slugify(value: string): string {
+  return value.replace(/[^a-z0-9._-]+/gi, '-').replace(/^-+|-+$/g, '').slice(0, 80) || 'preview';
+}
+
+function trimProcessOutput(value: string): string {
+  const normalized = value.trim();
+  return normalized.length > 2_000 ? `${normalized.slice(0, 2_000)}...` : normalized;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -91,6 +91,8 @@ type TweakToken = {
 const htmlPreviewSlideState = new Map<string, SlideState>();
 const FONT_RECENTS_KEY = 'od.visualEdit.recentFonts';
 const MAX_TWEAK_TOKENS = 64;
+const MAX_LIVE_COMMENT_TARGETS = 240;
+const MAX_VISUAL_EDIT_BATCH_ITEMS = 24;
 const VIRTUAL_TWEAK_PREFIX = '__od-';
 const DEFAULT_FONT_CHOICES = [
   'Arial, sans-serif',
@@ -1038,6 +1040,11 @@ function mergeTweakTokens(tokens: TweakToken[]): TweakToken[] {
   return Array.from(merged.values()).slice(0, MAX_TWEAK_TOKENS);
 }
 
+function limitPreviewTargets(targets: Map<string, PreviewCommentSnapshot>): Map<string, PreviewCommentSnapshot> {
+  if (targets.size <= MAX_LIVE_COMMENT_TARGETS) return targets;
+  return new Map(Array.from(targets.entries()).slice(-MAX_LIVE_COMMENT_TARGETS));
+}
+
 function TweakControl({
   token,
   value,
@@ -1547,6 +1554,13 @@ function HtmlViewer({
   const editBatchRef = useRef<VisualEditBatchItem[]>([]);
 
   useEffect(() => {
+    return () => {
+      activeCommentTargetRef.current = null;
+      editBatchRef.current = [];
+    };
+  }, []);
+
+  useEffect(() => {
     if (liveHtml !== undefined) {
       setSource(liveHtml);
       return;
@@ -1749,7 +1763,7 @@ function HtmlViewer({
           const snapshot = snapshotFromData(item);
           if (snapshot.elementId) next.set(snapshot.elementId, snapshot);
         });
-        setLiveCommentTargets(next);
+        setLiveCommentTargets(limitPreviewTargets(next));
         setActiveCommentTarget((current) => (
           current ? editMode ? current : next.get(current.elementId) ?? null : null
         ));
@@ -1768,7 +1782,7 @@ function HtmlViewer({
         const lockedTarget = activeCommentTargetRef.current;
         if (editMode && lockedTarget && snapshot.elementId !== lockedTarget.elementId) return;
         setHoveredCommentTarget(snapshot);
-        setLiveCommentTargets((current) => new Map(current).set(snapshot.elementId, snapshot));
+        setLiveCommentTargets((current) => limitPreviewTargets(new Map(current).set(snapshot.elementId, snapshot)));
         return;
       }
       if (data.type === 'od:comment-target') {
@@ -1780,7 +1794,7 @@ function HtmlViewer({
         const existing = previewComments.find((comment) => comment.elementId === snapshot.elementId);
         setActiveCommentTarget(snapshot);
         setHoveredCommentTarget(snapshot);
-        setLiveCommentTargets((current) => new Map(current).set(snapshot.elementId, snapshot));
+        setLiveCommentTargets((current) => limitPreviewTargets(new Map(current).set(snapshot.elementId, snapshot)));
         if (editMode) setEditDraft(visualEditDraftFromSnapshot(snapshot));
         else setCommentDraft(existing?.note ?? '');
       }

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -13,6 +13,7 @@ import {
   projectFileUrl,
   projectRawUrl,
   updateDeployConfig,
+  writeProjectTextFile,
 } from '../providers/registry';
 import type { ProjectFilePreview } from '../providers/registry';
 import {
@@ -31,6 +32,7 @@ import { parseForceInline, shouldUrlLoadHtmlPreview } from './file-viewer-render
 import { saveTemplate } from '../state/projects';
 import type { DeployConfigResponse, DeployProjectFileResponse, ProjectFile } from '../types';
 import { Icon } from './Icon';
+import { PreviewDrawOverlay, type DrawPreviewSubmit } from './PreviewDrawOverlay';
 import {
   liveSnapshotForComment,
   overlayBoundsFromSnapshot,
@@ -41,8 +43,102 @@ import type { PreviewComment, PreviewCommentTarget } from '../types';
 
 type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => string;
 type SlideState = { active: number; count: number };
+type VisualEditDraft = {
+  text: string;
+  fontFamily: string;
+  fontSize: string;
+  fontWeight: string;
+  lineHeight: string;
+  letterSpacing: string;
+  color: string;
+  backgroundColor: string;
+  width: string;
+  height: string;
+  moveX: number;
+  moveY: number;
+  animationName: string;
+  animationDuration: string;
+  animationDelay: string;
+  animationTimingFunction: string;
+  animationIterationCount: string;
+  animationDirection: string;
+  animationFillMode: string;
+  custom: string;
+};
+type VisualEditBatchItem = {
+  id: string;
+  snapshot: PreviewCommentSnapshot;
+  draft: VisualEditDraft;
+};
+type VisualEditPanelPosition = { x: number; y: number } | null;
+type TweakGroup = 'Cores' | 'Tipografia' | 'Espaçamento' | 'Bordas' | 'Motion' | 'Outros';
+type TweakControlKind = 'color' | 'number' | 'select' | 'text';
+type TweakPreset = 'compact' | 'comfortable' | 'soft' | 'sharp' | 'motionless';
+type TweakValueMap = Record<string, string>;
+type TweakToken = {
+  name: string;
+  label: string;
+  value: string;
+  group: TweakGroup;
+  kind: TweakControlKind;
+  virtual?: boolean;
+  min?: number;
+  max?: number;
+  step?: number;
+  options?: string[];
+};
 
 const htmlPreviewSlideState = new Map<string, SlideState>();
+const FONT_RECENTS_KEY = 'od.visualEdit.recentFonts';
+const MAX_TWEAK_TOKENS = 64;
+const VIRTUAL_TWEAK_PREFIX = '__od-';
+const DEFAULT_FONT_CHOICES = [
+  'Arial, sans-serif',
+  'Helvetica, sans-serif',
+  'Georgia, serif',
+  '"Times New Roman", serif',
+  '"Courier New", monospace',
+  'Verdana, sans-serif',
+  'Tahoma, sans-serif',
+  'Trebuchet MS, sans-serif',
+  'Impact, sans-serif',
+  'system-ui, sans-serif',
+];
+const EMPTY_VISUAL_EDIT_DRAFT: VisualEditDraft = {
+  text: '',
+  fontFamily: '',
+  fontSize: '',
+  fontWeight: '',
+  lineHeight: '',
+  letterSpacing: '',
+  color: '',
+  backgroundColor: '',
+  width: '',
+  height: '',
+  moveX: 0,
+  moveY: 0,
+  animationName: '',
+  animationDuration: '',
+  animationDelay: '',
+  animationTimingFunction: '',
+  animationIterationCount: '',
+  animationDirection: '',
+  animationFillMode: '',
+  custom: '',
+};
+const FALLBACK_TWEAK_TOKENS: TweakToken[] = [
+  { name: '__od-accent', label: 'Accent', value: '#e8754f', group: 'Cores', kind: 'color', virtual: true },
+  { name: '__od-page', label: 'Fundo da página', value: '#ffffff', group: 'Cores', kind: 'color', virtual: true },
+  { name: '__od-text', label: 'Texto principal', value: '#14110f', group: 'Cores', kind: 'color', virtual: true },
+  { name: '__od-radius', label: 'Arredondamento global', value: '16px', group: 'Bordas', kind: 'number', virtual: true, min: 0, max: 48, step: 1 },
+  { name: '__od-motion', label: 'Movimento', value: 'normal', group: 'Motion', kind: 'select', virtual: true, options: ['normal', 'none'] },
+];
+const VIRTUAL_DENSITY_TWEAK = `${VIRTUAL_TWEAK_PREFIX}preset-density`;
+const VIRTUAL_MOTION_TWEAK = `${VIRTUAL_TWEAK_PREFIX}preset-motion`;
+const PRESET_TWEAK_TOKENS: TweakToken[] = [
+  { name: VIRTUAL_DENSITY_TWEAK, label: 'Densidade global', value: 'normal', group: 'Espaçamento', kind: 'select', virtual: true, options: ['compact', 'normal', 'comfortable'] },
+  { name: VIRTUAL_MOTION_TWEAK, label: 'Motion global', value: 'normal', group: 'Motion', kind: 'select', virtual: true, options: ['normal', 'none'] },
+];
 
 interface Props {
   projectId: string;
@@ -54,6 +150,7 @@ interface Props {
   previewComments?: PreviewComment[];
   onSavePreviewComment?: (target: PreviewCommentTarget, note: string, attachAfterSave: boolean) => Promise<PreviewComment | null>;
   onRemovePreviewComment?: (commentId: string) => Promise<void>;
+  onSendPreviewComment?: (comment: PreviewComment) => void | Promise<void>;
 }
 
 export function FileViewer({
@@ -66,6 +163,7 @@ export function FileViewer({
   previewComments = [],
   onSavePreviewComment,
   onRemovePreviewComment,
+  onSendPreviewComment,
 }: Props) {
   const rendererMatch = artifactRendererRegistry.resolve({
     file,
@@ -84,6 +182,7 @@ export function FileViewer({
         previewComments={previewComments}
         onSavePreviewComment={onSavePreviewComment}
         onRemovePreviewComment={onRemovePreviewComment}
+        onSendPreviewComment={onSendPreviewComment}
       />
     );
   }
@@ -97,7 +196,15 @@ export function FileViewer({
     return <SvgViewer projectId={projectId} file={file} />;
   }
   if (file.kind === 'image') {
-    return <ImageViewer projectId={projectId} file={file} />;
+    return (
+      <ImageViewer
+        projectId={projectId}
+        file={file}
+        streaming={Boolean(streaming)}
+        onSavePreviewComment={onSavePreviewComment}
+        onSendPreviewComment={onSendPreviewComment}
+      />
+    );
   }
   if (file.kind === 'video') {
     return <VideoViewer projectId={projectId} file={file} />;
@@ -106,7 +213,15 @@ export function FileViewer({
     return <AudioViewer projectId={projectId} file={file} />;
   }
   if (file.kind === 'sketch') {
-    return <ImageViewer projectId={projectId} file={file} />;
+    return (
+      <ImageViewer
+        projectId={projectId}
+        file={file}
+        streaming={Boolean(streaming)}
+        onSavePreviewComment={onSavePreviewComment}
+        onSendPreviewComment={onSendPreviewComment}
+      />
+    );
   }
   if (file.kind === 'text' || file.kind === 'code') {
     return <TextViewer projectId={projectId} file={file} />;
@@ -159,6 +274,8 @@ function CommentPopover({
   onClose,
   onSave,
   onRemove,
+  disabled,
+  scale,
   t,
 }: {
   target: PreviewCommentSnapshot;
@@ -168,10 +285,20 @@ function CommentPopover({
   onClose: () => void;
   onSave: (attach: boolean) => void | Promise<void>;
   onRemove: (commentId: string) => void | Promise<void>;
+  disabled?: boolean;
+  scale: number;
   t: TranslateFn;
 }) {
+  const bounds = overlayBoundsFromSnapshot(target, scale);
   return (
-    <div className="comment-popover" data-testid="comment-popover">
+    <div
+      className="comment-popover"
+      data-testid="comment-popover"
+      style={{
+        left: `clamp(14px, ${Math.round(bounds.left)}px, calc(100% - 334px))`,
+        top: `clamp(14px, ${Math.round(bounds.top + bounds.height + 12)}px, calc(100% - 180px))`,
+      }}
+    >
       <div className="comment-popover-head">
         <div>
           <strong>{target.elementId}</strong>
@@ -197,12 +324,776 @@ function CommentPopover({
           type="button"
           className="primary"
           data-testid="comment-add-send"
-          disabled={!draft.trim()}
+          disabled={disabled || !draft.trim()}
           onClick={() => void onSave(true)}
         >
           {existing ? t('chat.comments.updateSend') : t('chat.comments.addSend')}
         </button>
       </div>
+    </div>
+  );
+}
+
+function extractTweakTokens(source: string): TweakToken[] {
+  const found = new Map<string, TweakToken>();
+  const re = /(--[a-zA-Z0-9_-]+)\s*:\s*([^;{}]+);/g;
+  let match: RegExpExecArray | null = re.exec(source);
+  while (match !== null) {
+    const name = match[1] ?? '';
+    const value = cleanCssValue(match[2] ?? '');
+    if (name && value && !found.has(name)) {
+      found.set(name, {
+        name,
+        label: labelForTweak(name),
+        value,
+        group: groupForTweak(name, value),
+        kind: kindForTweak(name, value),
+      });
+    }
+    match = re.exec(source);
+  }
+  const tokens = Array.from(found.values())
+    .sort((a, b) => tweakGroupOrder(a.group) - tweakGroupOrder(b.group) || a.label.localeCompare(b.label))
+    .slice(0, MAX_TWEAK_TOKENS);
+  return tokens.length >= 3 ? tokens : [...tokens, ...FALLBACK_TWEAK_TOKENS];
+}
+
+function changedTweakValues(tokens: TweakToken[], values: TweakValueMap): TweakValueMap {
+  const next: TweakValueMap = {};
+  for (const token of tokens) {
+    const raw = values[token.name];
+    if (raw === undefined) continue;
+    const value = cleanCssValue(raw);
+    if (!value || value === token.value.trim()) continue;
+    next[token.name] = value;
+  }
+  return next;
+}
+
+function tweakPreviewStyle(values: TweakValueMap): string {
+  const rootOverrides: string[] = [];
+  for (const [name, rawValue] of Object.entries(values)) {
+    const value = safeTweakValue(rawValue);
+    if (!value || name.startsWith(VIRTUAL_TWEAK_PREFIX)) continue;
+    rootOverrides.push(`${name}: ${value};`);
+  }
+  const rootStyle = rootOverrides.length ? `:root { ${rootOverrides.join(' ')} }` : '';
+  return [rootStyle, virtualTweakStyle(values), presetGlobalTweakStyle(values)].filter(Boolean).join('\n');
+}
+
+function applyTweakValuesToHtmlSource(source: string, values: TweakValueMap): string {
+  let next = source;
+  const rootOverrides: string[] = [];
+  const virtual = [virtualTweakStyle(values), presetGlobalTweakStyle(values)].filter(Boolean).join('\n');
+
+  for (const [name, rawValue] of Object.entries(values)) {
+    const value = safeTweakValue(rawValue);
+    if (!value) continue;
+    if (name.startsWith(VIRTUAL_TWEAK_PREFIX)) continue;
+    const re = new RegExp(`(${escapeRegExp(name)}\\s*:\\s*)([^;{}]+)(;)`, 'g');
+    let replaced = false;
+    next = next.replace(re, (_full, prefix: string, _old: string, suffix: string) => {
+      replaced = true;
+      return `${prefix}${value}${suffix}`;
+    });
+    if (!replaced) rootOverrides.push(`${name}: ${value};`);
+  }
+
+  const rootStyle = rootOverrides.length ? `:root { ${rootOverrides.join(' ')} }` : '';
+  return upsertTweakStyleBlock(next, [rootStyle, virtual].filter(Boolean).join('\n'));
+}
+
+function presetGlobalTweakStyle(values: TweakValueMap): string {
+  const density = safeTweakValue(values[VIRTUAL_DENSITY_TWEAK]);
+  const motion = safeTweakValue(values[VIRTUAL_MOTION_TWEAK]);
+  const styles: string[] = [];
+  if (density === 'compact' || density === 'comfortable') {
+    const scale = density === 'compact' ? '0.94' : '1.06';
+    const width = density === 'compact' ? '106.38298%' : '94.33962%';
+    styles.push(`html body { transform: scale(${scale}) !important; transform-origin: top left !important; width: ${width} !important; }`);
+  }
+  if (motion === 'none') {
+    styles.push('html *, html *::before, html *::after { animation: none !important; transition: none !important; scroll-behavior: auto !important; }');
+  }
+  return styles.join('\n');
+}
+
+function presetTweakValues(tokens: TweakToken[], preset: TweakPreset, current: TweakValueMap): TweakValueMap {
+  const next = { ...current };
+  for (const token of tokens) {
+    const value = token.value;
+    let changed: string | null = null;
+    if (preset === 'compact' && token.group === 'Espaçamento') changed = scaleCssValue(value, 0.84);
+    if (preset === 'comfortable' && token.group === 'Espaçamento') changed = scaleCssValue(value, 1.18);
+    if (preset === 'soft' && token.group === 'Bordas') changed = scaleCssValue(value, 1.45) ?? '22px';
+    if (preset === 'sharp' && token.group === 'Bordas') changed = '0px';
+    if (preset === 'motionless' && token.group === 'Motion') changed = motionlessValue(token, value);
+    if (!changed) continue;
+    if (changed.trim() === token.value.trim()) delete next[token.name];
+    else next[token.name] = changed;
+  }
+  if (preset === 'compact') next[VIRTUAL_DENSITY_TWEAK] = 'compact';
+  if (preset === 'comfortable') next[VIRTUAL_DENSITY_TWEAK] = 'comfortable';
+  if (preset === 'motionless') next[VIRTUAL_MOTION_TWEAK] = 'none';
+  return next;
+}
+
+function groupTweakTokens(tokens: TweakToken[]): Array<[TweakGroup, TweakToken[]]> {
+  const groups = new Map<TweakGroup, TweakToken[]>();
+  for (const token of tokens) {
+    const items = groups.get(token.group) ?? [];
+    items.push(token);
+    groups.set(token.group, items);
+  }
+  return Array.from(groups.entries()).sort((a, b) => tweakGroupOrder(a[0]) - tweakGroupOrder(b[0]));
+}
+
+function labelForTweak(name: string): string {
+  return name
+    .replace(/^--/, '')
+    .replace(/^od-tweak-/, '')
+    .split(/[-_]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function groupForTweak(name: string, value: string): TweakGroup {
+  const haystack = `${name} ${value}`.toLowerCase();
+  if (isColorValue(value) || /(color|colour|accent|brand|surface|background|bg|ink|text|border|shadow)/.test(haystack)) return 'Cores';
+  if (/(font|type|weight|line-height|letter|tracking|heading|body)/.test(haystack)) return 'Tipografia';
+  if (/(space|spacing|gap|padding|margin|inset|offset|grid|gutter|size|width|height)/.test(haystack)) return 'Espaçamento';
+  if (/(radius|rounded|corner|border-radius)/.test(haystack)) return 'Bordas';
+  if (/(motion|duration|delay|animation|transition|ease|easing)/.test(haystack)) return 'Motion';
+  return 'Outros';
+}
+
+function kindForTweak(name: string, value: string): TweakControlKind {
+  if (name.startsWith(VIRTUAL_TWEAK_PREFIX) && name.endsWith('motion')) return 'select';
+  if (isColorValue(value)) return 'color';
+  if (parseNumericCssValue(value)) return 'number';
+  return 'text';
+}
+
+function tweakGroupOrder(group: TweakGroup): number {
+  return ['Cores', 'Tipografia', 'Espaçamento', 'Bordas', 'Motion', 'Outros'].indexOf(group);
+}
+
+function parseNumericCssValue(value: string): { number: number; unit: string } | null {
+  const match = /^(-?\d+(?:\.\d+)?)(px|rem|em|vh|vw|%|ms|s)?$/i.exec(value.trim());
+  if (!match) return null;
+  return { number: Number(match[1]), unit: match[2] ?? '' };
+}
+
+function tweakRange(token: TweakToken, current: number): { min: number; max: number; step: number } {
+  if (token.min !== undefined && token.max !== undefined && token.step !== undefined) {
+    return { min: token.min, max: token.max, step: token.step };
+  }
+  if (token.group === 'Bordas') return { min: 0, max: 64, step: 1 };
+  if (token.group === 'Espaçamento') return { min: 0, max: Math.max(96, Math.ceil(current * 2)), step: 1 };
+  if (token.group === 'Tipografia') return { min: 0, max: Math.max(96, Math.ceil(current * 2)), step: 1 };
+  if (token.group === 'Motion') return { min: 0, max: 5000, step: 50 };
+  return { min: Math.min(0, current), max: Math.max(100, Math.ceil(current * 2)), step: 1 };
+}
+
+function scaleCssValue(value: string, factor: number): string | null {
+  const parsed = parseNumericCssValue(value);
+  if (!parsed) return null;
+  const next = Math.max(0, parsed.number * factor);
+  const rounded = Math.round(next * 100) / 100;
+  return `${rounded}${parsed.unit}`;
+}
+
+function motionlessValue(token: TweakToken, value: string): string {
+  if (token.kind === 'select') return 'none';
+  const parsed = parseNumericCssValue(value);
+  if (parsed && (parsed.unit === 'ms' || parsed.unit === 's')) return '0ms';
+  if (/name|animation/i.test(token.name)) return 'none';
+  return '0ms';
+}
+
+function isColorValue(value: string): boolean {
+  const clean = value.trim();
+  return /^#([0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})$/i.test(clean) ||
+    /^(rgb|rgba|hsl|hsla)\(/i.test(clean) ||
+    /^(transparent|currentColor)$/i.test(clean);
+}
+
+function colorInputValue(value: string): string {
+  const clean = value.trim();
+  if (/^#[0-9a-f]{6}$/i.test(clean)) return clean;
+  const short = /^#([0-9a-f])([0-9a-f])([0-9a-f])$/i.exec(clean);
+  if (short) return `#${short[1]}${short[1]}${short[2]}${short[2]}${short[3]}${short[3]}`;
+  const rgb = /^rgba?\(\s*(\d{1,3})[\s,]+(\d{1,3})[\s,]+(\d{1,3})/i.exec(clean);
+  if (rgb) {
+    const toHex = (part: string) => Math.max(0, Math.min(255, Number(part))).toString(16).padStart(2, '0');
+    return `#${toHex(rgb[1] ?? '0')}${toHex(rgb[2] ?? '0')}${toHex(rgb[3] ?? '0')}`;
+  }
+  return '#000000';
+}
+
+function cleanCssValue(value: string): string {
+  return String(value || '').replace(/\s+/g, ' ').trim().slice(0, 180);
+}
+
+function safeTweakValue(value: string): string {
+  const clean = cleanCssValue(value).replace(/[;{}<>]/g, '');
+  if (!clean || /(javascript:|expression\s*\(|@import|<\/?style)/i.test(clean)) return '';
+  return clean;
+}
+
+function virtualTweakStyle(values: TweakValueMap): string {
+  const accent = safeTweakValue(values['__od-accent'] ?? '');
+  const page = safeTweakValue(values['__od-page'] ?? '');
+  const text = safeTweakValue(values['__od-text'] ?? '');
+  const radius = safeTweakValue(values['__od-radius'] ?? '');
+  const motion = safeTweakValue(values['__od-motion'] ?? '');
+  const lines: string[] = [];
+  if (page) lines.push(`html, body { background: ${page} !important; }`);
+  if (text) lines.push(`body { color: ${text} !important; }`);
+  if (accent) {
+    lines.push(`:where(a, button, [role="button"], input[type="button"], input[type="submit"], .btn, .button, [class*="button"], [class*="cta"]) { border-color: ${accent} !important; }`);
+    lines.push(`:where(button, [role="button"], input[type="button"], input[type="submit"], .btn, .button, [class*="button"], [class*="cta"]) { background-color: ${accent} !important; }`);
+  }
+  if (radius) lines.push(`:where(button, input, textarea, select, .card, .panel, .modal, .btn, .button, [class*="card"], [class*="panel"], [class*="button"]) { border-radius: ${radius} !important; }`);
+  if (motion === 'none') lines.push('*, *::before, *::after { animation-duration: 0.001ms !important; animation-iteration-count: 1 !important; transition-duration: 0.001ms !important; scroll-behavior: auto !important; }');
+  return lines.join('\n');
+}
+
+function upsertTweakStyleBlock(source: string, style: string): string {
+  const block = style.trim() ? `<style data-od-tweaks>\n${style.trim()}\n</style>` : '';
+  const re = /<style\b[^>]*data-od-tweaks[^>]*>[\s\S]*?<\/style>/i;
+  if (re.test(source)) return source.replace(re, block);
+  if (!block) return source;
+  if (/<\/head>/i.test(source)) return source.replace(/<\/head>/i, `${block}\n</head>`);
+  return `${block}\n${source}`;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function VisualEditPanel({
+  target,
+  draft,
+  fontChoices,
+  queuedCount,
+  panelPosition,
+  onDraft,
+  onPanelPosition,
+  onClose,
+  onQueue,
+  onSendQueue,
+  onClearQueue,
+  onDirectSave,
+  onApply,
+  disabled,
+  scale,
+}: {
+  target: PreviewCommentSnapshot;
+  draft: VisualEditDraft;
+  fontChoices: string[];
+  queuedCount: number;
+  panelPosition: VisualEditPanelPosition;
+  onDraft: (draft: VisualEditDraft) => void;
+  onPanelPosition: (position: VisualEditPanelPosition) => void;
+  onClose: () => void;
+  onQueue: () => void;
+  onSendQueue: () => void | Promise<void>;
+  onClearQueue: () => void;
+  onDirectSave: () => void | Promise<void>;
+  onApply: () => void | Promise<void>;
+  disabled?: boolean;
+  scale: number;
+}) {
+  const bounds = overlayBoundsFromSnapshot(target, scale);
+  const [dragPoint, setDragPoint] = useState<{ x: number; y: number } | null>(null);
+  const [panelDragPoint, setPanelDragPoint] = useState<{ x: number; y: number } | null>(null);
+  const [fontMenuOpen, setFontMenuOpen] = useState(false);
+  const setField = (key: keyof VisualEditDraft, value: string | number) => {
+    onDraft({ ...draft, [key]: value });
+  };
+  const moveBy = (dx: number, dy: number) => {
+    onDraft({
+      ...draft,
+      moveX: Math.round(draft.moveX + dx),
+      moveY: Math.round(draft.moveY + dy),
+    });
+  };
+  const selectedFont = draft.fontFamily.trim();
+  const recentFonts = recentFontChoices();
+  const defaultPanelPosition = {
+    x: Math.round(bounds.left + bounds.width + 14),
+    y: Math.round(bounds.top),
+  };
+  const activePanelPosition = panelPosition ?? defaultPanelPosition;
+  return (
+    <>
+      <div
+        className="visual-edit-drag-target"
+        style={{
+          left: bounds.left + draft.moveX * scale,
+          top: bounds.top + draft.moveY * scale,
+          width: bounds.width,
+          height: bounds.height,
+        }}
+        onPointerDown={(event) => {
+          event.preventDefault();
+          event.currentTarget.setPointerCapture(event.pointerId);
+          setDragPoint({ x: event.clientX, y: event.clientY });
+        }}
+        onPointerMove={(event) => {
+          if (!dragPoint) return;
+          event.preventDefault();
+          const dx = (event.clientX - dragPoint.x) / Math.max(scale, 0.01);
+          const dy = (event.clientY - dragPoint.y) / Math.max(scale, 0.01);
+          setDragPoint({ x: event.clientX, y: event.clientY });
+          moveBy(dx, dy);
+        }}
+        onPointerUp={() => setDragPoint(null)}
+        onPointerCancel={() => setDragPoint(null)}
+      >
+        <span>Arraste para mover</span>
+      </div>
+      {!dragPoint ? (
+        <div
+          className="visual-edit-panel"
+          data-testid="visual-edit-panel"
+          style={{
+            left: `clamp(14px, ${activePanelPosition.x}px, calc(100% - 394px))`,
+            top: `clamp(14px, ${activePanelPosition.y}px, calc(100% - 640px))`,
+          }}
+        >
+          <div className="visual-edit-head">
+            <div
+              className="visual-edit-panel-handle"
+              onPointerDown={(event) => {
+                event.preventDefault();
+                event.currentTarget.setPointerCapture(event.pointerId);
+                setPanelDragPoint({ x: event.clientX, y: event.clientY });
+                onPanelPosition(activePanelPosition);
+              }}
+              onPointerMove={(event) => {
+                if (!panelDragPoint) return;
+                event.preventDefault();
+                const dx = event.clientX - panelDragPoint.x;
+                const dy = event.clientY - panelDragPoint.y;
+                setPanelDragPoint({ x: event.clientX, y: event.clientY });
+                onPanelPosition({
+                  x: Math.max(14, activePanelPosition.x + dx),
+                  y: Math.max(14, activePanelPosition.y + dy),
+                });
+              }}
+              onPointerUp={() => setPanelDragPoint(null)}
+              onPointerCancel={() => setPanelDragPoint(null)}
+            >
+              <strong>Editar elemento</strong>
+              <span>{target.label || target.elementId}</span>
+            </div>
+            <button type="button" className="ghost" onClick={onClose}>
+              Fechar
+            </button>
+          </div>
+          {queuedCount > 0 ? (
+            <div className="visual-edit-queue">
+              <span>{queuedCount} alteração{queuedCount === 1 ? '' : 'es'} na fila</span>
+              <button type="button" onClick={onClearQueue}>Limpar</button>
+              <button type="button" className="primary" disabled={disabled} onClick={() => void onSendQueue()}>
+                Enviar fila
+              </button>
+            </div>
+          ) : null}
+        {isTextEditableSnapshot(target) ? (
+          <label className="visual-edit-field visual-edit-full">
+            <span>Texto</span>
+            <textarea
+              name="visual-edit-text"
+              value={draft.text}
+              placeholder="Texto visível do elemento…"
+              onChange={(event) => setField('text', event.target.value)}
+            />
+          </label>
+        ) : (
+          <div className="visual-edit-safe-note">
+            Container selecionado. Texto direto desativado para não remover filhos como logo, menu e botões.
+          </div>
+        )}
+        <div className="visual-edit-section">
+          <div className="visual-edit-section-title">Fonte</div>
+          <div className="visual-edit-font-picker">
+            <button
+              type="button"
+              className="visual-edit-font-trigger"
+              aria-haspopup="listbox"
+              aria-expanded={fontMenuOpen}
+              onClick={() => setFontMenuOpen((value) => !value)}
+            >
+              <span style={{ fontFamily: selectedFont || undefined }}>
+                {fontDisplayName(selectedFont || fontChoices[0] || 'Escolha uma fonte')}
+              </span>
+              <span aria-hidden>⌄</span>
+            </button>
+            {fontMenuOpen ? (
+              <div className="visual-edit-font-menu" role="listbox" aria-label="Fontes">
+                {fontChoices.map((font, index) => (
+                  <button
+                    key={font}
+                    type="button"
+                    role="option"
+                    aria-selected={font === selectedFont}
+                    className={font === selectedFont ? 'active' : ''}
+                    style={{ fontFamily: font }}
+                    onMouseEnter={() => setField('fontFamily', font)}
+                    onFocus={() => setField('fontFamily', font)}
+                    onClick={() => {
+                      rememberFontChoice(font);
+                      setField('fontFamily', font);
+                      setFontMenuOpen(false);
+                    }}
+                  >
+                    <span>{fontDisplayName(font)}</span>
+                    {index === 0 ? <em>Atual</em> : recentFonts.includes(normalizeFontChoice(font)) ? <em>Recente</em> : null}
+                  </button>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        </div>
+        <div className="visual-edit-section">
+          <div className="visual-edit-section-title">Tipografia e cor</div>
+          <div className="visual-edit-grid">
+          <label className="visual-edit-field">
+            <span>Tamanho</span>
+            <input
+              name="visual-edit-font-size"
+              value={draft.fontSize}
+              placeholder="32px, 4vw…"
+              onChange={(event) => setField('fontSize', event.target.value)}
+            />
+          </label>
+          <label className="visual-edit-field">
+            <span>Peso</span>
+            <input
+              name="visual-edit-font-weight"
+              value={draft.fontWeight}
+              placeholder="400, 700…"
+              onChange={(event) => setField('fontWeight', event.target.value)}
+            />
+          </label>
+          <label className="visual-edit-field">
+            <span>Altura linha</span>
+            <input
+              name="visual-edit-line-height"
+              value={draft.lineHeight}
+              placeholder="1.1, 48px…"
+              onChange={(event) => setField('lineHeight', event.target.value)}
+            />
+          </label>
+          <label className="visual-edit-field">
+            <span>Tracking</span>
+            <input
+              name="visual-edit-letter-spacing"
+              value={draft.letterSpacing}
+              placeholder="-0.02em, 1px…"
+              onChange={(event) => setField('letterSpacing', event.target.value)}
+            />
+          </label>
+          <label className="visual-edit-field">
+            <span>Cor texto</span>
+            <input
+              name="visual-edit-color"
+              value={draft.color}
+              placeholder="#111, rgb(0 0 0)…"
+              onChange={(event) => setField('color', event.target.value)}
+            />
+          </label>
+          <label className="visual-edit-field">
+            <span>Fundo</span>
+            <input
+              name="visual-edit-background"
+              value={draft.backgroundColor}
+              placeholder="transparent, #fff…"
+              onChange={(event) => setField('backgroundColor', event.target.value)}
+            />
+          </label>
+          </div>
+        </div>
+        <div className="visual-edit-section">
+          <div className="visual-edit-section-title">Tamanho e posição</div>
+          <div className="visual-edit-grid">
+          <label className="visual-edit-field">
+            <span>Largura</span>
+            <input
+              name="visual-edit-width"
+              value={draft.width}
+              placeholder="auto, 320px, 80%…"
+              onChange={(event) => setField('width', event.target.value)}
+            />
+          </label>
+          <label className="visual-edit-field">
+            <span>Altura</span>
+            <input
+              name="visual-edit-height"
+              value={draft.height}
+              placeholder="auto, 96px…"
+              onChange={(event) => setField('height', event.target.value)}
+            />
+          </label>
+          <label className="visual-edit-field">
+            <span>Mover X</span>
+            <input
+              name="visual-edit-move-x"
+              type="number"
+              inputMode="numeric"
+              value={draft.moveX}
+              onChange={(event) => setField('moveX', Number(event.target.value) || 0)}
+            />
+          </label>
+          <label className="visual-edit-field">
+            <span>Mover Y</span>
+            <input
+              name="visual-edit-move-y"
+              type="number"
+              inputMode="numeric"
+              value={draft.moveY}
+              onChange={(event) => setField('moveY', Number(event.target.value) || 0)}
+            />
+          </label>
+          </div>
+        </div>
+        <details className="visual-edit-details" open>
+          <summary>Animação</summary>
+          <div className="visual-edit-grid">
+            <label className="visual-edit-field">
+              <span>Nome</span>
+              <input
+                name="visual-edit-animation-name"
+                value={draft.animationName}
+                placeholder="pulse, fadeIn, none…"
+                onChange={(event) => setField('animationName', event.target.value)}
+              />
+            </label>
+            <label className="visual-edit-field">
+              <span>Duração</span>
+              <input
+                name="visual-edit-animation-duration"
+                value={draft.animationDuration}
+                placeholder="300ms, 1.8s…"
+                onChange={(event) => setField('animationDuration', event.target.value)}
+              />
+            </label>
+            <label className="visual-edit-field">
+              <span>Delay</span>
+              <input
+                name="visual-edit-animation-delay"
+                value={draft.animationDelay}
+                placeholder="0ms, -0.2s…"
+                onChange={(event) => setField('animationDelay', event.target.value)}
+              />
+            </label>
+            <label className="visual-edit-field">
+              <span>Easing</span>
+              <input
+                name="visual-edit-animation-timing"
+                value={draft.animationTimingFunction}
+                placeholder="ease-out, cubic-bezier(…)…"
+                onChange={(event) => setField('animationTimingFunction', event.target.value)}
+              />
+            </label>
+            <label className="visual-edit-field">
+              <span>Repetição</span>
+              <input
+                name="visual-edit-animation-iteration"
+                value={draft.animationIterationCount}
+                placeholder="1, infinite…"
+                onChange={(event) => setField('animationIterationCount', event.target.value)}
+              />
+            </label>
+            <label className="visual-edit-field">
+              <span>Direção</span>
+              <input
+                name="visual-edit-animation-direction"
+                value={draft.animationDirection}
+                placeholder="normal, alternate…"
+                onChange={(event) => setField('animationDirection', event.target.value)}
+              />
+            </label>
+            <label className="visual-edit-field">
+              <span>Fill mode</span>
+              <input
+                name="visual-edit-animation-fill"
+                value={draft.animationFillMode}
+                placeholder="none, both, forwards…"
+                onChange={(event) => setField('animationFillMode', event.target.value)}
+              />
+            </label>
+          </div>
+        </details>
+        <label className="visual-edit-field visual-edit-full">
+          <span>Qualquer outro detalhe</span>
+          <textarea
+            name="visual-edit-custom"
+            value={draft.custom}
+            placeholder="Ex.: alinhar com o card da direita, trocar hover, ajustar breakpoint mobile…"
+            onChange={(event) => setField('custom', event.target.value)}
+          />
+        </label>
+        <div className="visual-edit-actions">
+          <span>{target.position.width} × {target.position.height}</span>
+          <div>
+            <button type="button" disabled={disabled} onClick={() => void onDirectSave()}>
+              Salvar direto
+            </button>
+            <button type="button" disabled={disabled} onClick={onQueue}>
+              Adicionar à fila
+            </button>
+            <button type="button" className="primary" disabled={disabled} onClick={() => void onApply()}>
+              Aplicar com IA
+            </button>
+          </div>
+        </div>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+function TweaksPanel({
+  tokens,
+  values,
+  changedCount,
+  disabled,
+  onChange,
+  onReset,
+  onPreset,
+  onSave,
+  onClose,
+}: {
+  tokens: TweakToken[];
+  values: TweakValueMap;
+  changedCount: number;
+  disabled?: boolean;
+  onChange: (name: string, value: string) => void;
+  onReset: () => void;
+  onPreset: (preset: TweakPreset) => void;
+  onSave: () => void | Promise<void>;
+  onClose: () => void;
+}) {
+  const grouped = useMemo(() => groupTweakTokens(tokens), [tokens]);
+  return (
+    <div className="tweaks-panel" data-testid="tweaks-panel">
+      <div className="tweaks-head">
+        <div>
+          <strong>Tweaks</strong>
+          <span>{tokens.length} controle{tokens.length === 1 ? '' : 's'} disponível{tokens.length === 1 ? '' : 'is'}</span>
+        </div>
+        <button type="button" className="ghost" onClick={onClose}>
+          Fechar
+        </button>
+      </div>
+      <div className="tweaks-summary">
+        <span>{changedCount} alteração{changedCount === 1 ? '' : 'es'} em preview</span>
+        <small>Ajustes simples são aplicados direto no HTML, sem IA.</small>
+      </div>
+      <div className="tweaks-presets" aria-label="Presets rápidos">
+        <button type="button" onClick={() => onPreset('compact')}>Compacto</button>
+        <button type="button" onClick={() => onPreset('comfortable')}>Confortável</button>
+        <button type="button" onClick={() => onPreset('soft')}>Mais redondo</button>
+        <button type="button" onClick={() => onPreset('sharp')}>Mais reto</button>
+        <button type="button" onClick={() => onPreset('motionless')}>Sem motion</button>
+      </div>
+      <div className="tweaks-groups">
+        {grouped.map(([group, items]) => (
+          <section className="tweaks-group" key={group}>
+            <h3>{group}</h3>
+            {items.map((token) => (
+              <TweakControl
+                key={token.name}
+                token={token}
+                value={values[token.name] ?? token.value}
+                changed={Boolean(values[token.name] !== undefined && values[token.name].trim() !== token.value.trim())}
+                onChange={(value) => onChange(token.name, value)}
+              />
+            ))}
+          </section>
+        ))}
+      </div>
+      <div className="tweaks-actions">
+        <button type="button" onClick={onReset} disabled={changedCount === 0}>
+          Resetar
+        </button>
+        <button type="button" className="primary" disabled={disabled || changedCount === 0} onClick={() => void onSave()}>
+          Aplicar no HTML
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function mergeTweakTokens(tokens: TweakToken[]): TweakToken[] {
+  const merged = new Map<string, TweakToken>();
+  for (const token of [...PRESET_TWEAK_TOKENS, ...FALLBACK_TWEAK_TOKENS, ...tokens]) {
+    if (!merged.has(token.name)) merged.set(token.name, token);
+  }
+  return Array.from(merged.values()).slice(0, MAX_TWEAK_TOKENS);
+}
+
+function TweakControl({
+  token,
+  value,
+  changed,
+  onChange,
+}: {
+  token: TweakToken;
+  value: string;
+  changed: boolean;
+  onChange: (value: string) => void;
+}) {
+  const parsed = parseNumericCssValue(value);
+  const range = parsed ? tweakRange(token, parsed.number) : null;
+  return (
+    <div className={`tweak-control${changed ? ' changed' : ''}`}>
+      <div className="tweak-control-meta">
+        <strong>{token.label}</strong>
+        <code>{token.virtual ? 'global' : token.name}</code>
+      </div>
+      <div className="tweak-control-inputs">
+        {token.kind === 'color' ? (
+          <input
+            className="tweak-color-input"
+            type="color"
+            value={colorInputValue(value)}
+            onChange={(event) => onChange(event.target.value)}
+            aria-label={token.label}
+          />
+        ) : null}
+        {token.kind === 'select' ? (
+          <select value={value} onChange={(event) => onChange(event.target.value)} aria-label={token.label}>
+            {(token.options ?? []).map((option) => (
+              <option key={option} value={option}>{option}</option>
+            ))}
+          </select>
+        ) : (
+          <input
+            value={value}
+            onChange={(event) => onChange(event.target.value)}
+            aria-label={token.label}
+            spellCheck={false}
+          />
+        )}
+      </div>
+      {token.kind === 'number' && parsed && range ? (
+        <input
+          className="tweak-range"
+          type="range"
+          min={range.min}
+          max={range.max}
+          step={range.step}
+          value={parsed.number}
+          onChange={(event) => onChange(`${event.target.value}${parsed.unit}`)}
+          aria-label={`${token.label} slider`}
+        />
+      ) : null}
     </div>
   );
 }
@@ -585,6 +1476,7 @@ function HtmlViewer({
   previewComments = [],
   onSavePreviewComment,
   onRemovePreviewComment,
+  onSendPreviewComment,
 }: {
   projectId: string;
   file: ProjectFile;
@@ -595,6 +1487,7 @@ function HtmlViewer({
   previewComments?: PreviewComment[];
   onSavePreviewComment?: (target: PreviewCommentTarget, note: string, attachAfterSave: boolean) => Promise<PreviewComment | null>;
   onRemovePreviewComment?: (commentId: string) => Promise<void>;
+  onSendPreviewComment?: (comment: PreviewComment) => void | Promise<void>;
 }) {
   const t = useT();
   const [mode, setMode] = useState<'preview' | 'source'>('preview');
@@ -621,7 +1514,11 @@ function HtmlViewer({
   const [teamSlug, setTeamSlug] = useState('');
   const [inTabPresent, setInTabPresent] = useState(false);
   const [reloadKey, setReloadKey] = useState(0);
+  const [tweaksMode, setTweaksMode] = useState(false);
+  const [tweakDraft, setTweakDraft] = useState<TweakValueMap>({});
   const [commentMode, setCommentMode] = useState(false);
+  const [editMode, setEditMode] = useState(false);
+  const [drawMode, setDrawMode] = useState(false);
   // Opt back into the legacy inline-asset srcDoc path via `?forceInline=1`
   // on the host page. Lets users escape-hatch around the URL-load default
   // for non-deck HTML that depends on the in-iframe localStorage shim.
@@ -633,6 +1530,9 @@ function HtmlViewer({
   const [hoveredCommentTarget, setHoveredCommentTarget] = useState<PreviewCommentSnapshot | null>(null);
   const [liveCommentTargets, setLiveCommentTargets] = useState<Map<string, PreviewCommentSnapshot>>(() => new Map());
   const [commentDraft, setCommentDraft] = useState('');
+  const [editDraft, setEditDraft] = useState<VisualEditDraft>(EMPTY_VISUAL_EDIT_DRAFT);
+  const [editBatch, setEditBatch] = useState<VisualEditBatchItem[]>([]);
+  const [editPanelPosition, setEditPanelPosition] = useState<VisualEditPanelPosition>(null);
   const previewStateKey = `${projectId}:${file.name}`;
   // Slide deck nav state: the iframe posts the active index + total count
   // back to the host every time a slide settles. Host renders prev/next
@@ -643,6 +1543,8 @@ function HtmlViewer({
   const previewBodyRef = useRef<HTMLDivElement | null>(null);
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const shareRef = useRef<HTMLDivElement | null>(null);
+  const activeCommentTargetRef = useRef<PreviewCommentSnapshot | null>(null);
+  const editBatchRef = useRef<VisualEditBatchItem[]>([]);
 
   useEffect(() => {
     if (liveHtml !== undefined) {
@@ -687,14 +1589,21 @@ function HtmlViewer({
     return /class\s*=\s*['"][^'"]*\bslide\b/i.test(source);
   }, [source]);
   const effectiveDeck = isDeck || looksLikeDeck;
+  const tweakTokens = useMemo(() => (source ? mergeTweakTokens(extractTweakTokens(source)) : FALLBACK_TWEAK_TOKENS), [source]);
+  const changedTweaks = useMemo(() => changedTweakValues(tweakTokens, tweakDraft), [tweakTokens, tweakDraft]);
+  const changedTweaksCount = Object.keys(changedTweaks).length;
   const previewSource = inlinedSource ?? source;
+  const liveTweakCss = useMemo(
+    () => (tweaksMode && changedTweaksCount > 0 ? tweakPreviewStyle(changedTweaks) : ''),
+    [tweaksMode, changedTweaks, changedTweaksCount],
+  );
   // When we URL-load the iframe directly, skip every in-host inlining /
   // srcDoc-rebuilding step. The browser does the asset resolution itself,
   // which is the whole point of the URL-load path.
   const useUrlLoadPreview = shouldUrlLoadHtmlPreview({
     mode,
     isDeck: effectiveDeck,
-    commentMode,
+    commentMode: commentMode || editMode || drawMode || tweaksMode,
     forceInline,
   });
   const previewSrcUrl = useMemo(
@@ -720,9 +1629,10 @@ function HtmlViewer({
       deck: effectiveDeck,
       baseHref: projectRawUrl(projectId, baseDirFor(file.name)),
       initialSlideIndex: htmlPreviewSlideState.get(previewStateKey)?.active ?? 0,
-      commentBridge: commentMode,
+      commentBridge: commentMode || editMode || drawMode,
+      tweakBridge: tweaksMode,
     }) : ''),
-    [previewSource, effectiveDeck, projectId, file.name, previewStateKey, commentMode],
+    [previewSource, effectiveDeck, projectId, file.name, previewStateKey, commentMode, editMode, drawMode, tweaksMode],
   );
 
   useEffect(() => {
@@ -749,18 +1659,63 @@ function HtmlViewer({
   useEffect(() => {
     const win = iframeRef.current?.contentWindow;
     if (!win) return;
-    win.postMessage({ type: 'od:comment-mode', enabled: commentMode }, '*');
-  }, [commentMode, srcDoc]);
+    win.postMessage({ type: 'od:comment-mode', enabled: commentMode || editMode || drawMode }, '*');
+  }, [commentMode, editMode, drawMode, srcDoc]);
+
+  useEffect(() => {
+    const win = iframeRef.current?.contentWindow;
+    if (!win) return;
+    win.postMessage({ type: 'od:tweaks-preview', css: liveTweakCss }, '*');
+  }, [liveTweakCss, srcDoc]);
+
+  useEffect(() => {
+    const win = iframeRef.current?.contentWindow;
+    if (!win) return;
+    if (!editMode) {
+      win.postMessage({ type: 'od:visual-edit-preview', clear: true }, '*');
+      return;
+    }
+    const edits = editBatchRef.current.map((item) => ({
+      selector: item.snapshot.selector,
+      draft: item.draft,
+    }));
+    if (activeCommentTarget) {
+      edits.push({
+        selector: activeCommentTarget.selector,
+        draft: editDraft,
+      });
+    }
+    if (edits.length === 0) {
+      win.postMessage({ type: 'od:visual-edit-preview', clear: true }, '*');
+      return;
+    }
+    win.postMessage({
+      type: 'od:visual-edit-preview',
+      edits,
+    }, '*');
+  }, [editMode, activeCommentTarget, editDraft, srcDoc]);
 
   useEffect(() => {
     setActiveCommentTarget(null);
     setHoveredCommentTarget(null);
     setLiveCommentTargets(new Map());
     setCommentDraft('');
+    setEditDraft(EMPTY_VISUAL_EDIT_DRAFT);
+    setEditBatch([]);
+    editBatchRef.current = [];
+    setEditPanelPosition(null);
+    setTweaksMode(false);
+    setTweakDraft({});
+    setEditMode(false);
+    setDrawMode(false);
   }, [file.name]);
 
   useEffect(() => {
-    if (!commentMode) {
+    activeCommentTargetRef.current = activeCommentTarget;
+  }, [activeCommentTarget]);
+
+  useEffect(() => {
+    if (!commentMode && !editMode && !drawMode) {
       setActiveCommentTarget(null);
       setHoveredCommentTarget(null);
       setLiveCommentTargets(new Map());
@@ -779,6 +1734,7 @@ function HtmlViewer({
         height: Number(data.position?.height) || 0,
       },
       htmlHint: String(data.htmlHint || ''),
+      styles: stylesFromSnapshotData(data.styles),
     });
     function onMessage(ev: MessageEvent) {
       if (ev.source !== iframeRef.current?.contentWindow) return;
@@ -795,7 +1751,7 @@ function HtmlViewer({
         });
         setLiveCommentTargets(next);
         setActiveCommentTarget((current) => (
-          current ? next.get(current.elementId) ?? null : null
+          current ? editMode ? current : next.get(current.elementId) ?? null : null
         ));
         setHoveredCommentTarget((current) => (
           current ? next.get(current.elementId) ?? null : null
@@ -809,23 +1765,29 @@ function HtmlViewer({
       if (data.type === 'od:comment-hover') {
         const snapshot = snapshotFromData(data);
         if (!snapshot.elementId) return;
+        const lockedTarget = activeCommentTargetRef.current;
+        if (editMode && lockedTarget && snapshot.elementId !== lockedTarget.elementId) return;
         setHoveredCommentTarget(snapshot);
         setLiveCommentTargets((current) => new Map(current).set(snapshot.elementId, snapshot));
         return;
       }
       if (data.type === 'od:comment-target') {
+        if (!commentMode && !editMode) return;
         const snapshot = snapshotFromData(data);
         if (!snapshot.elementId) return;
+        const lockedTarget = activeCommentTargetRef.current;
+        if (editMode && lockedTarget && snapshot.elementId !== lockedTarget.elementId) return;
         const existing = previewComments.find((comment) => comment.elementId === snapshot.elementId);
         setActiveCommentTarget(snapshot);
         setHoveredCommentTarget(snapshot);
         setLiveCommentTargets((current) => new Map(current).set(snapshot.elementId, snapshot));
-        setCommentDraft(existing?.note ?? '');
+        if (editMode) setEditDraft(visualEditDraftFromSnapshot(snapshot));
+        else setCommentDraft(existing?.note ?? '');
       }
     }
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, [commentMode, file.name, previewComments]);
+  }, [commentMode, editMode, drawMode, file.name, previewComments]);
 
   function postSlide(action: 'next' | 'prev' | 'first' | 'last') {
     const win = iframeRef.current?.contentWindow;
@@ -1087,6 +2049,38 @@ function HtmlViewer({
     setZoom((z) => Math.max(25, Math.min(200, z + delta)));
   }
 
+  function toggleCommentMode() {
+    setMode('preview');
+    setTweaksMode(false);
+    setDrawMode(false);
+    setEditMode(false);
+    setCommentMode((v) => !v);
+  }
+
+  function toggleEditMode() {
+    setMode('preview');
+    setTweaksMode(false);
+    setDrawMode(false);
+    setCommentMode(false);
+    setEditMode((value) => !value);
+  }
+
+  function toggleDrawMode() {
+    setMode('preview');
+    setTweaksMode(false);
+    setCommentMode(false);
+    setEditMode(false);
+    setDrawMode((value) => !value);
+  }
+
+  function toggleTweaksMode() {
+    setMode('preview');
+    setCommentMode(false);
+    setEditMode(false);
+    setDrawMode(false);
+    setTweaksMode((value) => !value);
+  }
+
   const showPresent = effectiveDeck && source !== null;
   const canShare = source !== null;
   const exportTitle = file.name.replace(/\.html?$/i, '') || file.name;
@@ -1101,6 +2095,75 @@ function HtmlViewer({
   const copyDeployLabel = copiedDeployLink
     ? t('fileViewer.copied')
     : t('fileViewer.copyDeployLink');
+  const editFontChoices = availableFontChoices(source ?? '', activeCommentTarget);
+
+  function setTweakValue(name: string, value: string) {
+    setTweakDraft((current) => ({ ...current, [name]: value }));
+  }
+
+  function applyTweakPreset(preset: TweakPreset) {
+    setTweakDraft((current) => presetTweakValues(tweakTokens, preset, current));
+  }
+
+  async function saveTweaksDirectly() {
+    if (!source || streaming || changedTweaksCount === 0) return;
+    const nextSource = applyTweakValuesToHtmlSource(source, changedTweaks);
+    if (nextSource === source) return;
+    const saved = await writeProjectTextFile(projectId, file.name, nextSource);
+    if (!saved) return;
+    setSource(nextSource);
+    setInlinedSource(null);
+    setTweakDraft({});
+    setReloadKey((value) => value + 1);
+  }
+
+  function clearVisualEditBatch() {
+    editBatchRef.current = [];
+    setEditBatch([]);
+    const win = iframeRef.current?.contentWindow;
+    const active = activeCommentTargetRef.current;
+    if (!win) return;
+    if (editMode && active) {
+      win.postMessage({
+        type: 'od:visual-edit-preview',
+        edits: [{ selector: active.selector, draft: editDraft }],
+      }, '*');
+      return;
+    }
+    win.postMessage({ type: 'od:visual-edit-preview', clear: true }, '*');
+  }
+
+  function queueCurrentVisualEdit() {
+    if (!activeCommentTarget) return;
+    const item = makeVisualEditBatchItem(activeCommentTarget, editDraft);
+    const next = upsertVisualEditBatch(editBatchRef.current, item);
+    editBatchRef.current = next;
+    setEditBatch(next);
+    setActiveCommentTarget(null);
+    setHoveredCommentTarget(null);
+    setEditDraft(EMPTY_VISUAL_EDIT_DRAFT);
+  }
+
+  async function sendVisualEditBatch() {
+    const currentItems = activeCommentTarget
+      ? upsertVisualEditBatch(editBatchRef.current, makeVisualEditBatchItem(activeCommentTarget, editDraft))
+      : editBatchRef.current;
+    if (!currentItems.length || !onSavePreviewComment || !onSendPreviewComment || streaming) return;
+    const saved = await onSavePreviewComment(
+      targetFromSnapshot(currentItems[0].snapshot),
+      composeVisualEditBatchNote(currentItems),
+      false,
+    );
+    if (!saved) return;
+    currentItems.forEach((item) => rememberFontChoice(item.draft.fontFamily));
+    await onSendPreviewComment(saved);
+    editBatchRef.current = [];
+    setEditBatch([]);
+    setActiveCommentTarget(null);
+    setHoveredCommentTarget(null);
+    setEditDraft(EMPTY_VISUAL_EDIT_DRAFT);
+    setEditMode(false);
+  }
 
   return (
     <div className="viewer html-viewer">
@@ -1153,12 +2216,11 @@ function HtmlViewer({
           ) : null}
           <button
             type="button"
-            className="viewer-toggle"
-            disabled
-            data-coming-soon="true"
+            className={`viewer-toggle${tweaksMode ? ' on' : ''}`}
+            disabled={source === null || streaming}
             title={t('fileViewer.tweaks')}
-            aria-pressed={false}
-            onClick={(e) => e.preventDefault()}
+            aria-pressed={tweaksMode}
+            onClick={toggleTweaksMode}
           >
             <Icon name="tweaks" size={13} />
             <span>{t('fileViewer.tweaks')}</span>
@@ -1186,27 +2248,32 @@ function HtmlViewer({
             type="button"
             data-testid="comment-mode-toggle"
             title={t('fileViewer.comment')}
-            onClick={() => setCommentMode((v) => !v)}
+            aria-pressed={commentMode}
+            disabled={!onSavePreviewComment || streaming}
+            onClick={toggleCommentMode}
           >
             <Icon name="comment" size={13} />
             <span>{t('fileViewer.comment')}</span>
           </button>
           <button
-            className="viewer-action"
+            className={`viewer-action${editMode ? ' active' : ''}`}
             type="button"
-            disabled
-            data-coming-soon="true"
+            data-testid="edit-mode-toggle"
             title={t('fileViewer.edit')}
+            aria-pressed={editMode}
+            disabled={!onSavePreviewComment || !onSendPreviewComment || streaming}
+            onClick={toggleEditMode}
           >
             <Icon name="edit" size={13} />
             <span>{t('fileViewer.edit')}</span>
           </button>
           <button
-            className="viewer-action"
+            className={`viewer-action${drawMode ? ' active' : ''}`}
             type="button"
-            disabled
-            data-coming-soon="true"
+            disabled={!onSavePreviewComment || !onSendPreviewComment || streaming}
             title={t('fileViewer.draw')}
+            aria-pressed={drawMode}
+            onClick={toggleDrawMode}
           >
             <Icon name="draw" size={13} />
             <span>{t('fileViewer.draw')}</span>
@@ -1428,39 +2495,52 @@ function HtmlViewer({
           <div className="viewer-empty">{t('fileViewer.loading')}</div>
         ) : mode === 'preview' ? (
           <div className="comment-preview-layer">
-            <div className="comment-frame-clip">
-              <div
-                style={{
-                  width: `${100 / previewScale}%`,
-                  height: `${100 / previewScale}%`,
-                  transform: `scale(${previewScale})`,
-                  transformOrigin: '0 0',
-                }}
-              >
-                {useUrlLoadPreview ? (
-                  <iframe
-                    ref={iframeRef}
-                    data-testid="artifact-preview-frame"
-                    data-od-render-mode="url-load"
-                    title={file.name}
-                    sandbox="allow-scripts"
-                    src={previewSrcUrl}
-                  />
-                ) : (
-                  <iframe
-                    ref={iframeRef}
-                    data-testid="artifact-preview-frame"
-                    data-od-render-mode="srcdoc"
-                    title={file.name}
-                    sandbox="allow-scripts"
-                    srcDoc={srcDoc}
-                  />
-                )}
-              </div>
+            <div
+              style={{
+                width: `${100 / previewScale}%`,
+                height: `${100 / previewScale}%`,
+                transform: `scale(${previewScale})`,
+                transformOrigin: '0 0',
+              }}
+            >
+              {useUrlLoadPreview ? (
+                <iframe
+                  ref={iframeRef}
+                  data-testid="artifact-preview-frame"
+                  data-od-render-mode="url-load"
+                  title={file.name}
+                  sandbox="allow-scripts"
+                  src={previewSrcUrl}
+                  onLoad={() => iframeRef.current?.contentWindow?.postMessage({ type: 'od:tweaks-preview', css: liveTweakCss }, '*')}
+                />
+              ) : (
+                <iframe
+                  ref={iframeRef}
+                  data-testid="artifact-preview-frame"
+                  data-od-render-mode="srcdoc"
+                  title={file.name}
+                  sandbox="allow-scripts"
+                  srcDoc={srcDoc}
+                  onLoad={() => iframeRef.current?.contentWindow?.postMessage({ type: 'od:tweaks-preview', css: liveTweakCss }, '*')}
+                />
+              )}
             </div>
-            {commentMode ? (
+            {tweaksMode ? (
+              <TweaksPanel
+                tokens={tweakTokens}
+                values={tweakDraft}
+                changedCount={changedTweaksCount}
+                disabled={streaming || source === null}
+                onChange={setTweakValue}
+                onReset={() => setTweakDraft({})}
+                onPreset={applyTweakPreset}
+                onSave={saveTweaksDirectly}
+                onClose={() => setTweaksMode(false)}
+              />
+            ) : null}
+            {commentMode || editMode ? (
               <CommentPreviewOverlays
-                comments={previewComments}
+                comments={editMode ? [] : previewComments}
                 liveTargets={liveCommentTargets}
                 hoveredTarget={hoveredCommentTarget}
                 activeTarget={activeCommentTarget}
@@ -1468,7 +2548,8 @@ function HtmlViewer({
                 onOpenComment={(comment, snapshot) => {
                   setActiveCommentTarget(snapshot);
                   setHoveredCommentTarget(snapshot);
-                  setCommentDraft(comment.note);
+                  if (editMode) setEditDraft(visualEditDraftFromSnapshot(snapshot));
+                  else setCommentDraft(comment.note);
                 }}
               />
             ) : null}
@@ -1481,15 +2562,89 @@ function HtmlViewer({
                 onClose={() => setActiveCommentTarget(null)}
                 onSave={async (attach) => {
                   if (!commentDraft.trim() || !onSavePreviewComment) return;
-                  const saved = await onSavePreviewComment(targetFromSnapshot(activeCommentTarget), commentDraft.trim(), attach);
-                  if (saved) setActiveCommentTarget(null);
+                  if (streaming && attach) return;
+                  const shouldSend = attach && Boolean(onSendPreviewComment);
+                  const saved = await onSavePreviewComment(targetFromSnapshot(activeCommentTarget), commentDraft.trim(), attach && !shouldSend);
+                  if (!saved) return;
+                  if (shouldSend) {
+                    await onSendPreviewComment?.(saved);
+                    setCommentMode(false);
+                  }
+                  setActiveCommentTarget(null);
                 }}
                 onRemove={async (commentId) => {
                   if (!onRemovePreviewComment) return;
                   await onRemovePreviewComment(commentId);
                   setActiveCommentTarget(null);
                 }}
+                disabled={streaming}
+                scale={previewScale}
                 t={t}
+              />
+            ) : null}
+            {editMode && activeCommentTarget ? (
+              <VisualEditPanel
+                target={activeCommentTarget}
+                draft={editDraft}
+                fontChoices={editFontChoices}
+                queuedCount={editBatch.length}
+                panelPosition={editPanelPosition}
+                onDraft={setEditDraft}
+                onPanelPosition={setEditPanelPosition}
+                onClose={() => {
+                  setActiveCommentTarget(null);
+                  setHoveredCommentTarget(null);
+                  setEditDraft(EMPTY_VISUAL_EDIT_DRAFT);
+                }}
+                onQueue={queueCurrentVisualEdit}
+                onSendQueue={sendVisualEditBatch}
+                onClearQueue={clearVisualEditBatch}
+                onDirectSave={async () => {
+                  if (!source || streaming) return;
+                  const nextSource = applyVisualEditToHtmlSource(source, activeCommentTarget, editDraft);
+                  if (!nextSource) return;
+                  const saved = await writeProjectTextFile(projectId, file.name, nextSource);
+                  if (!saved) return;
+                  rememberFontChoice(editDraft.fontFamily);
+                  setSource(nextSource);
+                  setInlinedSource(null);
+                  setReloadKey((value) => value + 1);
+                  setActiveCommentTarget(null);
+                  setEditMode(false);
+                }}
+                onApply={async () => {
+                  await sendVisualEditBatch();
+                }}
+                disabled={streaming}
+                scale={previewScale}
+              />
+            ) : null}
+            {editMode && !activeCommentTarget && editBatch.length > 0 ? (
+              <div className="visual-edit-batch-dock">
+                <span>{editBatch.length} alteração{editBatch.length === 1 ? '' : 'es'} pronta{editBatch.length === 1 ? '' : 's'}</span>
+                <small>Selecione outro elemento ou envie tudo para a IA.</small>
+                <div>
+                  <button type="button" onClick={clearVisualEditBatch}>Limpar</button>
+                  <button type="button" className="primary" disabled={streaming} onClick={() => void sendVisualEditBatch()}>
+                    Enviar tudo
+                  </button>
+                </div>
+              </div>
+            ) : null}
+            {drawMode ? (
+              <PreviewDrawOverlay
+                fileName={file.name}
+                scale={previewScale}
+                liveTargets={liveCommentTargets}
+                disabled={streaming}
+                onClose={() => setDrawMode(false)}
+                onSubmit={async ({ target, note }) => {
+                  if (!onSavePreviewComment || !onSendPreviewComment || streaming) return;
+                  const saved = await onSavePreviewComment(target, note, false);
+                  if (!saved) return;
+                  await onSendPreviewComment(saved);
+                  setDrawMode(false);
+                }}
               />
             ) : null}
           </div>
@@ -1780,6 +2935,278 @@ function readHtmlAttr(tag: string, name: string): string | null {
   return match?.[2] ?? null;
 }
 
+function stylesFromSnapshotData(value: unknown): PreviewCommentSnapshot['styles'] {
+  if (!value || typeof value !== 'object') return undefined;
+  const raw = value as Record<string, unknown>;
+  return {
+    display: String(raw.display || ''),
+    position: String(raw.position || ''),
+    color: String(raw.color || ''),
+    backgroundColor: String(raw.backgroundColor || ''),
+    fontFamily: String(raw.fontFamily || ''),
+    fontSize: String(raw.fontSize || ''),
+    fontWeight: String(raw.fontWeight || ''),
+    lineHeight: String(raw.lineHeight || ''),
+    letterSpacing: String(raw.letterSpacing || ''),
+    width: String(raw.width || ''),
+    height: String(raw.height || ''),
+    transform: String(raw.transform || ''),
+    animationName: String(raw.animationName || ''),
+    animationDuration: String(raw.animationDuration || ''),
+    animationDelay: String(raw.animationDelay || ''),
+    animationTimingFunction: String(raw.animationTimingFunction || ''),
+    animationIterationCount: String(raw.animationIterationCount || ''),
+    animationDirection: String(raw.animationDirection || ''),
+    animationFillMode: String(raw.animationFillMode || ''),
+  };
+}
+
+function visualEditDraftFromSnapshot(snapshot: PreviewCommentSnapshot): VisualEditDraft {
+  const styles = snapshot.styles;
+  return {
+    ...EMPTY_VISUAL_EDIT_DRAFT,
+    text: snapshot.text || '',
+    fontFamily: styles?.fontFamily || '',
+    fontSize: styles?.fontSize || '',
+    fontWeight: styles?.fontWeight || '',
+    lineHeight: styles?.lineHeight || '',
+    letterSpacing: styles?.letterSpacing || '',
+    color: styles?.color || '',
+    backgroundColor: transparentToEmpty(styles?.backgroundColor || ''),
+    width: styles?.width || (snapshot.position.width ? `${snapshot.position.width}px` : ''),
+    height: styles?.height || (snapshot.position.height ? `${snapshot.position.height}px` : ''),
+    animationName: styles?.animationName === 'none' ? '' : styles?.animationName || '',
+    animationDuration: styles?.animationDuration || '',
+    animationDelay: styles?.animationDelay || '',
+    animationTimingFunction: styles?.animationTimingFunction || '',
+    animationIterationCount: styles?.animationIterationCount || '',
+    animationDirection: styles?.animationDirection || '',
+    animationFillMode: styles?.animationFillMode || '',
+  };
+}
+
+function composeVisualEditNote(snapshot: PreviewCommentSnapshot, draft: VisualEditDraft): string {
+  const payload = visualEditPayload(snapshot, draft);
+  return [
+    'Apply this visual edit exactly to the selected element.',
+    `Target file: ${snapshot.filePath}. Edit only this file for this change.`,
+    'Do not create a new sibling HTML file, duplicate artifact, or blank handoff file.',
+    'Blank fields mean keep the current value.',
+    'For movement, choose the safest implementation for this layout: transform, margin, flex/grid alignment, absolute positioning, or responsive CSS as appropriate.',
+    'Preserve unrelated elements and keep desktop/mobile behavior clean.',
+    JSON.stringify(payload, null, 2),
+  ].join('\n');
+}
+
+function composeVisualEditBatchNote(items: VisualEditBatchItem[]): string {
+  const targetFiles = [...new Set(items.map((item) => item.snapshot.filePath).filter(Boolean))];
+  return [
+    'Apply these visual edits exactly. Each edit targets one element; do not merge targets unless required for responsive layout.',
+    `Target file${targetFiles.length === 1 ? '' : 's'}: ${targetFiles.join(', ')}.`,
+    'Do not create new sibling HTML files, duplicate artifacts, or blank handoff files.',
+    'Blank fields mean keep the current value.',
+    'Preserve unrelated elements and keep desktop/mobile behavior clean.',
+    JSON.stringify({
+      edits: items.map((item, index) => ({
+        order: index + 1,
+        ...visualEditPayload(item.snapshot, item.draft),
+      })),
+    }, null, 2),
+  ].join('\n');
+}
+
+function visualEditPayload(snapshot: PreviewCommentSnapshot, draft: VisualEditDraft) {
+  return {
+    target: {
+      elementId: snapshot.elementId,
+      selector: snapshot.selector,
+      label: snapshot.label,
+      filePath: snapshot.filePath,
+    },
+    requestedChanges: {
+      text: draft.text.trim(),
+      typography: {
+        fontFamily: draft.fontFamily.trim(),
+        fontSize: draft.fontSize.trim(),
+        fontWeight: draft.fontWeight.trim(),
+        lineHeight: draft.lineHeight.trim(),
+        letterSpacing: draft.letterSpacing.trim(),
+        color: draft.color.trim(),
+        backgroundColor: draft.backgroundColor.trim(),
+      },
+      layout: {
+        width: draft.width.trim(),
+        height: draft.height.trim(),
+        moveX: draft.moveX,
+        moveY: draft.moveY,
+      },
+      animation: {
+        animationName: draft.animationName.trim(),
+        animationDuration: draft.animationDuration.trim(),
+        animationDelay: draft.animationDelay.trim(),
+        animationTimingFunction: draft.animationTimingFunction.trim(),
+        animationIterationCount: draft.animationIterationCount.trim(),
+        animationDirection: draft.animationDirection.trim(),
+        animationFillMode: draft.animationFillMode.trim(),
+      },
+      custom: draft.custom.trim(),
+    },
+    currentSnapshot: {
+      text: snapshot.text,
+      position: snapshot.position,
+      styles: snapshot.styles ?? null,
+      htmlHint: snapshot.htmlHint,
+    },
+  };
+}
+
+function makeVisualEditBatchItem(snapshot: PreviewCommentSnapshot, draft: VisualEditDraft): VisualEditBatchItem {
+  return {
+    id: `${snapshot.filePath}:${snapshot.elementId}:${snapshot.selector}`,
+    snapshot,
+    draft: { ...draft },
+  };
+}
+
+function upsertVisualEditBatch(current: VisualEditBatchItem[], item: VisualEditBatchItem): VisualEditBatchItem[] {
+  const next = current.filter((entry) => entry.id !== item.id);
+  next.push(item);
+  return next;
+}
+
+function transparentToEmpty(value: string): string {
+  return value === 'rgba(0, 0, 0, 0)' ? '' : value;
+}
+
+function availableFontChoices(source: string, target: PreviewCommentSnapshot | null): string[] {
+  const fonts = new Set<string>();
+  const add = (value: string | undefined) => {
+    const clean = String(value || '').trim();
+    if (!clean || clean === 'inherit' || clean === 'initial' || clean === 'unset') return;
+    fonts.add(clean);
+  };
+  const current = normalizeFontChoice(target?.styles?.fontFamily || '');
+  add(current);
+  const fontFaceRe = /font-family\s*:\s*([^;{}]+)/gi;
+  let match: RegExpExecArray | null;
+  while ((match = fontFaceRe.exec(source))) add(match[1]);
+  DEFAULT_FONT_CHOICES.forEach(add);
+  const recent = recentFontChoices().filter((font) => fonts.has(font) && font !== current);
+  const sorted = Array.from(fonts)
+    .filter((font) => font !== current && !recent.includes(font))
+    .sort((a, b) => fontDisplayName(a).localeCompare(fontDisplayName(b), undefined, { sensitivity: 'base' }));
+  return [current, ...recent, ...sorted].filter(Boolean).slice(0, 36);
+}
+
+function recentFontChoices(): string[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(FONT_RECENTS_KEY) || '[]');
+    return Array.isArray(parsed) ? parsed.map((font) => normalizeFontChoice(String(font))).filter(Boolean).slice(0, 6) : [];
+  } catch {
+    return [];
+  }
+}
+
+function rememberFontChoice(font: string): void {
+  const normalized = normalizeFontChoice(font);
+  if (!normalized || typeof window === 'undefined') return;
+  const next = [normalized, ...recentFontChoices().filter((item) => item !== normalized)].slice(0, 6);
+  try {
+    window.localStorage.setItem(FONT_RECENTS_KEY, JSON.stringify(next));
+  } catch {}
+}
+
+function normalizeFontChoice(font: string): string {
+  return font.replace(/\s+/g, ' ').trim();
+}
+
+function fontDisplayName(font: string): string {
+  return normalizeFontChoice(font).replaceAll('"', '').split(',')[0] || font;
+}
+
+function applyVisualEditToHtmlSource(
+  source: string,
+  snapshot: PreviewCommentSnapshot,
+  draft: VisualEditDraft,
+): string | null {
+  const parser = new DOMParser();
+  const isFullDocument = /^\s*(?:<!doctype|<html[\s>])/i.test(source);
+  const hadDoctype = /^\s*<!doctype/i.test(source);
+  const doc = parser.parseFromString(isFullDocument ? source : `<body>${source}</body>`, 'text/html');
+  const target = findEditableElement(doc, snapshot);
+  if (!target) return null;
+
+  if (isTextEditableSnapshot(snapshot)) target.textContent = draft.text;
+  setInlineStyle(target, 'fontFamily', draft.fontFamily);
+  setInlineStyle(target, 'fontSize', draft.fontSize);
+  setInlineStyle(target, 'fontWeight', draft.fontWeight);
+  setInlineStyle(target, 'lineHeight', draft.lineHeight);
+  setInlineStyle(target, 'letterSpacing', draft.letterSpacing);
+  setInlineStyle(target, 'color', draft.color);
+  setInlineStyle(target, 'backgroundColor', draft.backgroundColor);
+  setInlineStyle(target, 'width', draft.width);
+  setInlineStyle(target, 'height', draft.height);
+  setInlineStyle(target, 'animationName', draft.animationName);
+  setInlineStyle(target, 'animationDuration', draft.animationDuration);
+  setInlineStyle(target, 'animationDelay', draft.animationDelay);
+  setInlineStyle(target, 'animationTimingFunction', draft.animationTimingFunction);
+  setInlineStyle(target, 'animationIterationCount', draft.animationIterationCount);
+  setInlineStyle(target, 'animationDirection', draft.animationDirection);
+  setInlineStyle(target, 'animationFillMode', draft.animationFillMode);
+
+  if (draft.moveX || draft.moveY) {
+    const existing = target.style.transform.trim();
+    const withoutOldTranslate = existing.replace(/translate(?:3d|X|Y)?\([^)]*\)\s*/gi, '').trim();
+    target.style.transform = `translate(${Math.round(draft.moveX)}px, ${Math.round(draft.moveY)}px)${withoutOldTranslate ? ` ${withoutOldTranslate}` : ''}`;
+  }
+
+  if (!isFullDocument) return doc.body.innerHTML;
+  const html = doc.documentElement.outerHTML;
+  return hadDoctype ? `<!doctype html>\n${html}` : html;
+}
+
+function findEditableElement(doc: Document, snapshot: PreviewCommentSnapshot): HTMLElement | null {
+  const bySelector = safeQuery(doc, snapshot.selector);
+  if (bySelector) return bySelector;
+  const id = snapshot.elementId;
+  const byOdId = safeQuery(doc, `[data-od-id="${cssAttrValue(id)}"]`);
+  if (byOdId) return byOdId;
+  const byScreen = safeQuery(doc, `[data-screen-label="${cssAttrValue(id)}"]`);
+  if (byScreen) return byScreen;
+  return doc.getElementById(id);
+}
+
+function isTextEditableSnapshot(snapshot: PreviewCommentSnapshot): boolean {
+  const label = snapshot.label.toLowerCase();
+  const selector = snapshot.selector.toLowerCase();
+  const elementId = snapshot.elementId.toLowerCase();
+  if (/^(body|html|main|section|header|footer|nav|aside|article|div)\b/.test(label)) return false;
+  if (/^(body|html|main|section|header|footer|nav|aside|article|div)\b/.test(selector)) return false;
+  if (/(background|hero|page|wrapper|container|layout|shell|stage|screen)/i.test(elementId)) return false;
+  return /^(h1|h2|h3|h4|h5|h6|p|span|a|button|label|strong|em|small|li|figcaption|blockquote|cite|time|input|textarea)\b/.test(label)
+    || /^(h1|h2|h3|h4|h5|h6|p|span|a|button|label|strong|em|small|li|figcaption|blockquote|cite|time|input|textarea)\b/.test(selector);
+}
+
+function safeQuery(doc: Document, selector: string): HTMLElement | null {
+  try {
+    const element = doc.querySelector(selector);
+    return element instanceof HTMLElement ? element : null;
+  } catch {
+    return null;
+  }
+}
+
+function setInlineStyle(element: HTMLElement, key: keyof CSSStyleDeclaration, value: string): void {
+  const clean = value.trim();
+  if (!clean) return;
+  element.style[key as any] = clean;
+}
+
+function cssAttrValue(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
 function escapeHtmlAttr(value: string): string {
   return value
     .replace(/&/g, '&amp;')
@@ -1791,12 +3218,32 @@ function escapeHtmlAttr(value: string): string {
 function ImageViewer({
   projectId,
   file,
+  streaming,
+  onSavePreviewComment,
+  onSendPreviewComment,
 }: {
   projectId: string;
   file: ProjectFile;
+  streaming: boolean;
+  onSavePreviewComment?: (target: PreviewCommentTarget, note: string, attachAfterSave: boolean) => Promise<PreviewComment | null>;
+  onSendPreviewComment?: (comment: PreviewComment) => void | Promise<void>;
 }) {
   const t = useT();
+  const [drawMode, setDrawMode] = useState(false);
   const url = `${projectFileUrl(projectId, file.name)}?v=${Math.round(file.mtime)}`;
+  async function sendDraw({ target, note }: DrawPreviewSubmit) {
+    if (!onSavePreviewComment || !onSendPreviewComment || streaming) return;
+    const saved = await onSavePreviewComment({
+      ...target,
+      selector: 'img',
+      label: `Drawing over ${file.name}`,
+      text: file.name,
+      htmlHint: `${target.htmlHint} sourceFile: ${file.name}`,
+    }, note, false);
+    if (!saved) return;
+    await onSendPreviewComment(saved);
+    setDrawMode(false);
+  }
   return (
     <div className="viewer image-viewer">
       <div className="viewer-toolbar">
@@ -1823,10 +3270,33 @@ function ImageViewer({
           >
             {t('fileViewer.open')}
           </a>
+          <button
+            type="button"
+            className={`viewer-action${drawMode ? ' active' : ''}`}
+            disabled={!onSavePreviewComment || !onSendPreviewComment || streaming}
+            title={t('fileViewer.draw')}
+            aria-pressed={drawMode}
+            onClick={() => setDrawMode((value) => !value)}
+          >
+            <Icon name="draw" size={13} />
+            <span>{t('fileViewer.draw')}</span>
+          </button>
         </div>
       </div>
       <div className="viewer-body image-body">
-        <img alt={file.name} src={url} />
+        <div className="image-draw-wrap">
+          <img alt={file.name} src={url} />
+          {drawMode ? (
+            <PreviewDrawOverlay
+              fileName={file.name}
+              scale={1}
+              liveTargets={new Map()}
+              disabled={streaming}
+              onClose={() => setDrawMode(false)}
+              onSubmit={sendDraw}
+            />
+          ) : null}
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -19,7 +19,6 @@ import {
   upsertPreviewComment,
   writeProjectTextFile,
 } from '../providers/registry';
-import { useProjectFileEvents } from '../providers/project-events';
 import { composeSystemPrompt } from '@open-design/contracts';
 import { navigate } from '../router';
 import { agentDisplayName, agentModelDisplayName } from '../utils/agentLabels';
@@ -69,7 +68,6 @@ import {
 import { AppChromeHeader } from './AppChromeHeader';
 import { AvatarMenu } from './AvatarMenu';
 import { ChatPane } from './ChatPane';
-import { decideAutoOpenAfterWrite } from './auto-open-file';
 import { FileWorkspace } from './FileWorkspace';
 
 interface Props {
@@ -363,15 +361,6 @@ export function ProjectView({
     if (!daemonLive) return;
     void refreshProjectFiles();
   }, [daemonLive, refreshProjectFiles, filesRefresh]);
-
-  // Live-reload: when the daemon's chokidar watcher reports a file change,
-  // bump filesRefresh so the file list refetches with new mtimes — which
-  // propagates through to FileViewer iframes via PR #384's ?v=${mtime}
-  // cache-bust, triggering an automatic preview reload without a click.
-  const handleProjectFileChange = useCallback(() => {
-    setFilesRefresh((n) => n + 1);
-  }, []);
-  useProjectFileEvents(project.id, daemonLive, handleProjectFileChange);
 
   // When the URL points at a specific file, fire an open request so the
   // FileWorkspace promotes it to an active tab. We watch routeFileName
@@ -784,6 +773,13 @@ export function ProjectView({
       if (!prompt.trim() && attachments.length === 0 && commentAttachments.length === 0) return;
       setError(null);
       const startedAt = Date.now();
+      const activeFilePath = activeProjectFilePath(openTabsState.active, projectFileNames);
+      const artifactTargetFileName = artifactTargetForTurn(
+        prompt,
+        commentAttachments,
+        activeFilePath,
+        projectFileNames,
+      );
       const userMsg: ChatMessage = {
         id: crypto.randomUUID(),
         role: 'user',
@@ -883,29 +879,19 @@ export function ProjectView({
         if (ev.kind === 'tool_use' && (ev.name === 'Write' || ev.name === 'Edit')) {
           const filePath = (ev.input as { file_path?: unknown } | null)?.file_path;
           if (typeof filePath === 'string' && filePath.length > 0) {
-            // Preserve the full path so decideAutoOpenAfterWrite can do a
-            // path-suffix match against the project's relative file paths.
-            // Reducing to a basename here would lose the segment alignment
-            // we need to disambiguate same-basename collisions across the
-            // project tree and outside it.
-            pendingWritesRef.current.set(ev.id, filePath);
+            const base = filePath.split('/').pop() || filePath;
+            pendingWritesRef.current.set(ev.id, base);
           }
         }
         if (ev.kind === 'tool_result') {
-          const filePath = pendingWritesRef.current.get(ev.toolUseId);
-          if (filePath) {
+          const base = pendingWritesRef.current.get(ev.toolUseId);
+          if (base) {
             pendingWritesRef.current.delete(ev.toolUseId);
             if (!ev.isError) {
               // Refresh first so FileWorkspace's file list (and the tab
               // body) sees the new content before we ask it to focus.
-              // Only auto-open if the file actually landed in the project's
-              // file list — otherwise an out-of-project Write (e.g. an
-              // upstream repo edit) would spawn a permanent placeholder tab.
-              void refreshProjectFiles().then((nextFiles) => {
-                const decision = decideAutoOpenAfterWrite(filePath, nextFiles);
-                if (decision.shouldOpen && decision.fileName) {
-                  requestOpenFile(decision.fileName);
-                }
+              void refreshProjectFiles().then(() => {
+                requestOpenFile(base);
               });
             }
           }
@@ -980,7 +966,7 @@ export function ProjectView({
           // up as a real tab (not just the synthetic "live" stream).
           setArtifact((prev) => {
             if (!prev || !prev.html) return prev;
-            void persistArtifact(prev);
+            void persistArtifact(prev, artifactTargetFileName);
             return prev;
           });
           // Refetch the file list directly (rather than just bumping the
@@ -1051,6 +1037,7 @@ export function ProjectView({
           designSystemId: project.designSystemId ?? null,
           attachments: attachments.map((a) => a.path),
           commentAttachments,
+          activeFilePath,
           model: choice?.model ?? null,
           reasoning: choice?.reasoning ?? null,
           onRunCreated: (runId) => {
@@ -1096,6 +1083,8 @@ export function ProjectView({
       onTouchProject,
       project.id,
       projectFiles,
+      projectFileNames,
+      openTabsState.active,
       refreshProjectFiles,
       persistMessage,
       persistMessageById,
@@ -1106,20 +1095,25 @@ export function ProjectView({
   );
 
   const persistArtifact = useCallback(
-    async (art: Artifact) => {
+    async (art: Artifact, targetFileName?: string | null) => {
       const baseName = (art.identifier || art.title || 'artifact')
         .toLowerCase()
         .replace(/[^a-z0-9_-]+/g, '-')
         .replace(/^-+|-+$/g, '')
         .slice(0, 60) || 'artifact';
       const ext = artifactExtensionFor(art);
-      // Pick a name that doesn't collide with an existing project file.
-      // The first run uses `<base>.<ext>`; subsequent runs append `-2`, `-3`…
-      // so prior artifacts aren't silently overwritten.
       const existing = new Set(projectFiles.map((f) => f.name));
-      let fileName = `${baseName}${ext}`;
+      const referencedFile = artifactReferenceFileName(art.html, existing);
+      if (referencedFile) {
+        requestOpenFile(referencedFile);
+        return;
+      }
+      const overwriteFileName =
+        existingArtifactTargetFileName(targetFileName, ext, existing) ??
+        existingArtifactNameFor(art, baseName, ext, existing);
+      let fileName = overwriteFileName ?? `${baseName}${ext}`;
       let n = 2;
-      while (existing.has(fileName) && savedArtifactRef.current !== fileName) {
+      while (existing.has(fileName) && savedArtifactRef.current !== fileName && overwriteFileName !== fileName) {
         fileName = `${baseName}-${n}${ext}`;
         n += 1;
       }
@@ -1446,6 +1440,10 @@ export function ProjectView({
           previewComments={previewComments}
           onSavePreviewComment={savePreviewComment}
           onRemovePreviewComment={removePreviewComment}
+          onSendPreviewComment={(comment) => {
+            if (streaming) return;
+            void handleSend('', [], commentsToAttachments([comment]));
+          }}
         />
       </div>
     </div>
@@ -1460,6 +1458,96 @@ function artifactExtensionFor(art: Artifact): '.html' | '.jsx' | '.tsx' {
     return '.jsx';
   }
   return '.html';
+}
+
+function activeProjectFilePath(active: string | null | undefined, projectFileNames: Set<string>): string | null {
+  return active && projectFileNames.has(active) ? active : null;
+}
+
+function artifactTargetForTurn(
+  prompt: string,
+  commentAttachments: ChatCommentAttachment[],
+  activeFilePath: string | null,
+  projectFileNames: Set<string>,
+): string | null {
+  const commentTargets = [
+    ...new Set(
+      commentAttachments
+        .map((attachment) => attachment.filePath)
+        .filter((filePath) => projectFileNames.has(filePath)),
+    ),
+  ];
+
+  if (commentTargets.length === 1) return commentTargets[0] ?? null;
+  if (!activeFilePath) return null;
+  if (!isLikelyRevisionPrompt(prompt)) return null;
+  return activeFilePath;
+}
+
+function isLikelyRevisionPrompt(prompt: string): boolean {
+  const text = prompt.toLowerCase();
+  if (/\b(novo arquivo|nova p[áa]gina|new file|new page|separate file|arquivo separado|outro html|outra tela|from scratch|do zero)\b/.test(text)) {
+    return false;
+  }
+  return /\b(edit|editar|edite|alterar|altere|mudar|mude|trocar|troque|change|fix|corrigir|corrija|arrumar|arrume|ajustar|ajuste|update|atualizar|atualize|melhorar|melhore|improve|adicionar|adicione|add|remover|remova|remove|colocar|coloque|deixar|deixe|aumentar|aumente|diminuir|diminua|centralizar|centralize)\b/.test(text);
+}
+
+function artifactReferenceFileName(content: string, projectFileNames: Set<string>): string | null {
+  const ref = normalizeArtifactReference(content);
+  return ref && projectFileNames.has(ref) ? ref : null;
+}
+
+function normalizeArtifactReference(content: string): string | null {
+  let text = content.trim();
+  if (!text || text.length > 260) return null;
+  text = text.replace(/^```[a-z0-9_-]*\s*/i, '').replace(/```$/i, '').trim();
+  text = text.replace(/^["'`]+|["'`]+$/g, '').trim();
+  if (/[\n\r<{]/.test(text)) return null;
+  if (!/^[a-z0-9][a-z0-9_./ @-]*\.(html?|jsx|tsx|svg|md|txt)$/i.test(text)) return null;
+  return text;
+}
+
+function existingArtifactTargetFileName(
+  targetFileName: string | null | undefined,
+  ext: '.html' | '.jsx' | '.tsx',
+  projectFileNames: Set<string>,
+): string | null {
+  if (!targetFileName || !projectFileNames.has(targetFileName)) return null;
+  if (artifactFileExtensionMatches(targetFileName, ext)) return targetFileName;
+  return null;
+}
+
+function existingArtifactNameFor(
+  art: Artifact,
+  baseName: string,
+  ext: '.html' | '.jsx' | '.tsx',
+  projectFileNames: Set<string>,
+): string | null {
+  const candidates = [
+    ...artifactNameCandidates(art.identifier, ext),
+    ...artifactNameCandidates(art.title, ext),
+    `${baseName}${ext}`,
+  ];
+
+  return candidates.find((name) => projectFileNames.has(name)) ?? null;
+}
+
+function artifactNameCandidates(value: string | undefined, ext: '.html' | '.jsx' | '.tsx'): string[] {
+  const raw = (value ?? '').trim().replace(/^@/, '');
+  if (!raw) return [];
+  const slug = raw
+    .toLowerCase()
+    .replace(/\.[a-z0-9]+$/i, '')
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60);
+  const names = [raw, artifactFileExtensionMatches(raw, ext) ? raw : `${raw}${ext}`, slug ? `${slug}${ext}` : ''];
+  return [...new Set(names.filter(Boolean))];
+}
+
+function artifactFileExtensionMatches(fileName: string, ext: '.html' | '.jsx' | '.tsx'): boolean {
+  if (ext === '.html') return /\.html?$/i.test(fileName);
+  return fileName.toLowerCase().endsWith(ext);
 }
 
 function assistantAgentDisplayName(

--- a/apps/web/src/conversation-compaction.ts
+++ b/apps/web/src/conversation-compaction.ts
@@ -9,6 +9,8 @@ export interface ConversationCompactionResult {
   compactedMessages: number;
 }
 
+type LooseRecord = Record<string, unknown>;
+
 const COMPACTION_TRIGGER_CHARS = 32000;
 const RECENT_MESSAGE_COUNT = 8;
 const MAX_SUMMARY_CHARS = 12000;
@@ -18,26 +20,27 @@ const MAX_EVENT_CONTENT_CHARS = 900;
 const MAX_EVENT_LINES = 16;
 
 export function compactChatHistoryForPrompt(history: ChatMessage[]): ConversationCompactionResult {
-  const originalChars = history.reduce((sum, message) => sum + estimateMessageChars(message), 0);
+  const safeHistory = normalizeChatHistory(history);
+  const originalChars = safeHistory.reduce((sum, message) => sum + estimateMessageChars(message), 0);
 
-  if (originalChars <= COMPACTION_TRIGGER_CHARS || history.length <= RECENT_MESSAGE_COUNT + 2) {
+  if (originalChars <= COMPACTION_TRIGGER_CHARS || safeHistory.length <= RECENT_MESSAGE_COUNT + 2) {
     return {
-      history,
+      history: safeHistory,
       compacted: false,
       originalChars,
       compactedChars: originalChars,
-      originalMessages: history.length,
-      compactedMessages: history.length,
+      originalMessages: safeHistory.length,
+      compactedMessages: safeHistory.length,
     };
   }
 
-  const splitAt = Math.max(1, history.length - RECENT_MESSAGE_COUNT);
-  const older = history.slice(0, splitAt);
-  const recent = history.slice(splitAt).map((message, index, messages) =>
+  const splitAt = Math.max(1, safeHistory.length - RECENT_MESSAGE_COUNT);
+  const older = safeHistory.slice(0, splitAt);
+  const recent = safeHistory.slice(splitAt).map((message, index, messages) =>
     index === messages.length - 1 ? message : trimMessageContent(message, MAX_RECENT_CONTENT_CHARS),
   );
   const summaryMessage: ChatMessage = {
-    id: `open-design-compacted-${older[0]?.id ?? 'history'}-${older.length}`,
+    id: `open-design-compacted-${safeMessageId(older[0]) || 'history'}-${older.length}`,
     role: 'user',
     content: buildCompactedSummary(older),
     createdAt: older[0]?.createdAt,
@@ -50,7 +53,7 @@ export function compactChatHistoryForPrompt(history: ChatMessage[]): Conversatio
     compacted: true,
     originalChars,
     compactedChars,
-    originalMessages: history.length,
+    originalMessages: safeHistory.length,
     compactedMessages: compactedHistory.length,
   };
 }
@@ -58,6 +61,25 @@ export function compactChatHistoryForPrompt(history: ChatMessage[]): Conversatio
 export function formatCompactionStatusDetail(result: ConversationCompactionResult): string {
   const savedChars = Math.max(0, result.originalChars - result.compactedChars);
   return `${result.originalMessages} mensagens viraram ${result.compactedMessages}; ${formatChars(savedChars)} removidos do prompt.`;
+}
+
+function normalizeChatHistory(history: ChatMessage[]): ChatMessage[] {
+  if (!Array.isArray(history)) return [];
+  return history
+    .map((message, index) => normalizeChatMessage(message, index))
+    .filter((message): message is ChatMessage => Boolean(message));
+}
+
+function normalizeChatMessage(message: unknown, index: number): ChatMessage | null {
+  if (!isRecord(message)) return null;
+  const role = message.role === 'assistant' ? 'assistant' : 'user';
+  const id = safeString(message.id) || `message-${index + 1}`;
+  return {
+    ...(message as ChatMessage),
+    id,
+    role,
+    content: safeString(message.content),
+  };
 }
 
 function buildCompactedSummary(messages: ChatMessage[]): string {
@@ -70,7 +92,7 @@ function buildCompactedSummary(messages: ChatMessage[]): string {
 
   for (const message of messages) {
     const parts = [`${message.role === 'user' ? 'Usuário' : 'Assistente'}:`];
-    const content = message.content.trim();
+    const content = safeString(message.content).trim();
 
     if (content) {
       parts.push(limitText(content, MAX_OLDER_CONTENT_CHARS));
@@ -98,51 +120,65 @@ function buildCompactedSummary(messages: ChatMessage[]): string {
 }
 
 function trimMessageContent(message: ChatMessage, maxChars: number): ChatMessage {
-  if (message.content.length <= maxChars) return message;
+  const content = safeString(message.content);
+  if (content.length <= maxChars) return message;
   return {
     ...message,
-    content: limitText(message.content, maxChars),
+    content: limitText(content, maxChars),
   };
 }
 
 function summarizeAttachments(message: ChatMessage): string[] {
-  const attachments = message.attachments?.map((attachment) => attachment.name || attachment.path) ?? [];
-  const comments =
-    message.commentAttachments?.map((attachment) =>
-      [attachment.label, attachment.selector, limitText(attachment.comment, 220)].filter(Boolean).join(' em '),
-    ) ?? [];
-  const files =
-    message.producedFiles?.map((file) => {
-      const producedFile = file as { path?: string; name?: string };
-      return producedFile.path || producedFile.name || 'arquivo';
-    }) ?? [];
+  const record = message as unknown as LooseRecord;
+  const attachments = safeArray(record.attachments).map((attachment) => {
+    const item = asRecord(attachment);
+    return safeString(item?.name) || safeString(item?.path);
+  });
+  const comments = safeArray(record.commentAttachments).map((attachment) => {
+    const item = asRecord(attachment);
+    if (!item) return '';
+    return [
+      safeString(item.label),
+      safeString(item.selector),
+      limitText(safeString(item.comment), 220),
+    ].filter(Boolean).join(' em ');
+  });
+  const files = safeArray(record.producedFiles).map((file) => {
+    const item = asRecord(file);
+    return safeString(item?.path) || safeString(item?.name) || 'arquivo';
+  });
 
   return [...attachments, ...comments, ...files].filter(Boolean).slice(0, 12);
 }
 
 function summarizeEvents(message: ChatMessage): string[] {
   const lines: string[] = [];
+  const events = safeArray((message as unknown as LooseRecord).events);
 
-  for (const event of message.events ?? []) {
+  for (const rawEvent of events) {
     if (lines.length >= MAX_EVENT_LINES) break;
+    const event = asRecord(rawEvent);
+    if (!event) continue;
+    const kind = safeString(event.kind);
 
-    if (event.kind === 'status') {
-      lines.push([event.label, event.detail].filter(Boolean).join(': '));
+    if (kind === 'status') {
+      lines.push([safeString(event.label), safeString(event.detail)].filter(Boolean).join(': '));
       continue;
     }
 
-    if (event.kind === 'tool_use') {
-      lines.push(`tool ${event.name}: ${limitText(safeJson(event.input), MAX_EVENT_CONTENT_CHARS)}`);
+    if (kind === 'tool_use') {
+      lines.push(`tool ${safeString(event.name) || 'tool'}: ${limitText(safeJson(event.input), MAX_EVENT_CONTENT_CHARS)}`);
       continue;
     }
 
-    if (event.kind === 'tool_result' && event.isError) {
-      lines.push(`erro de tool: ${limitText(event.content, MAX_EVENT_CONTENT_CHARS)}`);
+    if (kind === 'tool_result' && Boolean(event.isError)) {
+      lines.push(`erro de tool: ${limitText(safeString(event.content) || safeJson(event.content), MAX_EVENT_CONTENT_CHARS)}`);
       continue;
     }
 
-    if (event.kind === 'text' && event.text.trim()) {
-      lines.push(limitText(event.text, MAX_EVENT_CONTENT_CHARS));
+    if (kind === 'text') {
+      const text = safeString(event.text).trim();
+      if (text) lines.push(limitText(text, MAX_EVENT_CONTENT_CHARS));
     }
   }
 
@@ -150,28 +186,54 @@ function summarizeEvents(message: ChatMessage): string[] {
 }
 
 function estimateMessageChars(message: ChatMessage): number {
+  const record = message as unknown as LooseRecord;
   return (
-    message.content.length +
-    (message.attachments?.reduce((sum, attachment) => sum + attachment.name.length + attachment.path.length, 0) ?? 0) +
-    (message.commentAttachments?.reduce(
-      (sum, attachment) =>
-        sum +
-        attachment.label.length +
-        attachment.selector.length +
-        attachment.comment.length +
-        attachment.filePath.length,
-      0,
-    ) ?? 0) +
-    (message.events?.reduce((sum, event) => sum + safeJson(event).length, 0) ?? 0)
+    safeString(record.content).length +
+    safeArray(record.attachments).reduce((sum, attachment) => {
+      const item = asRecord(attachment);
+      return sum + safeString(item?.name).length + safeString(item?.path).length;
+    }, 0) +
+    safeArray(record.commentAttachments).reduce((sum, attachment) => {
+      const item = asRecord(attachment);
+      return sum +
+        safeString(item?.label).length +
+        safeString(item?.selector).length +
+        safeString(item?.comment).length +
+        safeString(item?.filePath).length;
+    }, 0) +
+    safeArray(record.events).reduce((sum, event) => sum + safeJson(event).length, 0)
   );
+}
+
+function safeMessageId(message: ChatMessage | undefined): string {
+  return safeString((message as unknown as LooseRecord | undefined)?.id);
 }
 
 function safeJson(value: unknown): string {
   try {
-    return JSON.stringify(value);
+    const json = JSON.stringify(value);
+    return typeof json === 'string' ? json : '';
   } catch {
-    return String(value);
+    return safeString(value);
   }
+}
+
+function safeArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function asRecord(value: unknown): LooseRecord | null {
+  return isRecord(value) ? value : null;
+}
+
+function isRecord(value: unknown): value is LooseRecord {
+  return Boolean(value) && typeof value === 'object';
+}
+
+function safeString(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return '';
 }
 
 function formatChars(chars: number): string {
@@ -180,7 +242,7 @@ function formatChars(chars: number): string {
 }
 
 function limitText(text: string, maxChars: number): string {
-  const clean = text.replace(/\s+/g, ' ').trim();
+  const clean = safeString(text).replace(/\s+/g, ' ').trim();
   if (clean.length <= maxChars) return clean;
   return `${clean.slice(0, Math.max(0, maxChars - 1)).trim()}…`;
 }

--- a/apps/web/src/conversation-compaction.ts
+++ b/apps/web/src/conversation-compaction.ts
@@ -1,0 +1,186 @@
+import type { ChatMessage } from './types';
+
+export interface ConversationCompactionResult {
+  history: ChatMessage[];
+  compacted: boolean;
+  originalChars: number;
+  compactedChars: number;
+  originalMessages: number;
+  compactedMessages: number;
+}
+
+const COMPACTION_TRIGGER_CHARS = 32000;
+const RECENT_MESSAGE_COUNT = 8;
+const MAX_SUMMARY_CHARS = 12000;
+const MAX_OLDER_CONTENT_CHARS = 1200;
+const MAX_RECENT_CONTENT_CHARS = 10000;
+const MAX_EVENT_CONTENT_CHARS = 900;
+const MAX_EVENT_LINES = 16;
+
+export function compactChatHistoryForPrompt(history: ChatMessage[]): ConversationCompactionResult {
+  const originalChars = history.reduce((sum, message) => sum + estimateMessageChars(message), 0);
+
+  if (originalChars <= COMPACTION_TRIGGER_CHARS || history.length <= RECENT_MESSAGE_COUNT + 2) {
+    return {
+      history,
+      compacted: false,
+      originalChars,
+      compactedChars: originalChars,
+      originalMessages: history.length,
+      compactedMessages: history.length,
+    };
+  }
+
+  const splitAt = Math.max(1, history.length - RECENT_MESSAGE_COUNT);
+  const older = history.slice(0, splitAt);
+  const recent = history.slice(splitAt).map((message, index, messages) =>
+    index === messages.length - 1 ? message : trimMessageContent(message, MAX_RECENT_CONTENT_CHARS),
+  );
+  const summaryMessage: ChatMessage = {
+    id: `open-design-compacted-${older[0]?.id ?? 'history'}-${older.length}`,
+    role: 'user',
+    content: buildCompactedSummary(older),
+    createdAt: older[0]?.createdAt,
+  };
+  const compactedHistory = [summaryMessage, ...recent];
+  const compactedChars = compactedHistory.reduce((sum, message) => sum + estimateMessageChars(message), 0);
+
+  return {
+    history: compactedHistory,
+    compacted: true,
+    originalChars,
+    compactedChars,
+    originalMessages: history.length,
+    compactedMessages: compactedHistory.length,
+  };
+}
+
+export function formatCompactionStatusDetail(result: ConversationCompactionResult): string {
+  const savedChars = Math.max(0, result.originalChars - result.compactedChars);
+  return `${result.originalMessages} mensagens viraram ${result.compactedMessages}; ${formatChars(savedChars)} removidos do prompt.`;
+}
+
+function buildCompactedSummary(messages: ChatMessage[]): string {
+  const lines = [
+    'Contexto anterior compactado automaticamente pelo Open Design.',
+    'Use este resumo para manter continuidade. As mensagens recentes abaixo têm prioridade.',
+    `Mensagens compactadas: ${messages.length}.`,
+    '',
+  ];
+
+  for (const message of messages) {
+    const parts = [`${message.role === 'user' ? 'Usuário' : 'Assistente'}:`];
+    const content = message.content.trim();
+
+    if (content) {
+      parts.push(limitText(content, MAX_OLDER_CONTENT_CHARS));
+    }
+
+    const attachments = summarizeAttachments(message);
+
+    if (attachments.length > 0) {
+      parts.push(`Anexos: ${attachments.join(', ')}`);
+    }
+
+    const events = summarizeEvents(message);
+
+    if (events.length > 0) {
+      parts.push(`Eventos: ${events.join(' | ')}`);
+    }
+
+    if (parts.length > 1) {
+      lines.push(parts.join('\n'));
+      lines.push('');
+    }
+  }
+
+  return limitText(lines.join('\n').trim(), MAX_SUMMARY_CHARS);
+}
+
+function trimMessageContent(message: ChatMessage, maxChars: number): ChatMessage {
+  if (message.content.length <= maxChars) return message;
+  return {
+    ...message,
+    content: limitText(message.content, maxChars),
+  };
+}
+
+function summarizeAttachments(message: ChatMessage): string[] {
+  const attachments = message.attachments?.map((attachment) => attachment.name || attachment.path) ?? [];
+  const comments =
+    message.commentAttachments?.map((attachment) =>
+      [attachment.label, attachment.selector, limitText(attachment.comment, 220)].filter(Boolean).join(' em '),
+    ) ?? [];
+  const files =
+    message.producedFiles?.map((file) => {
+      const producedFile = file as { path?: string; name?: string };
+      return producedFile.path || producedFile.name || 'arquivo';
+    }) ?? [];
+
+  return [...attachments, ...comments, ...files].filter(Boolean).slice(0, 12);
+}
+
+function summarizeEvents(message: ChatMessage): string[] {
+  const lines: string[] = [];
+
+  for (const event of message.events ?? []) {
+    if (lines.length >= MAX_EVENT_LINES) break;
+
+    if (event.kind === 'status') {
+      lines.push([event.label, event.detail].filter(Boolean).join(': '));
+      continue;
+    }
+
+    if (event.kind === 'tool_use') {
+      lines.push(`tool ${event.name}: ${limitText(safeJson(event.input), MAX_EVENT_CONTENT_CHARS)}`);
+      continue;
+    }
+
+    if (event.kind === 'tool_result' && event.isError) {
+      lines.push(`erro de tool: ${limitText(event.content, MAX_EVENT_CONTENT_CHARS)}`);
+      continue;
+    }
+
+    if (event.kind === 'text' && event.text.trim()) {
+      lines.push(limitText(event.text, MAX_EVENT_CONTENT_CHARS));
+    }
+  }
+
+  return lines;
+}
+
+function estimateMessageChars(message: ChatMessage): number {
+  return (
+    message.content.length +
+    (message.attachments?.reduce((sum, attachment) => sum + attachment.name.length + attachment.path.length, 0) ?? 0) +
+    (message.commentAttachments?.reduce(
+      (sum, attachment) =>
+        sum +
+        attachment.label.length +
+        attachment.selector.length +
+        attachment.comment.length +
+        attachment.filePath.length,
+      0,
+    ) ?? 0) +
+    (message.events?.reduce((sum, event) => sum + safeJson(event).length, 0) ?? 0)
+  );
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function formatChars(chars: number): string {
+  if (chars < 1000) return `${chars} caracteres`;
+  return `${Math.round(chars / 100) / 10} mil caracteres`;
+}
+
+function limitText(text: string, maxChars: number): string {
+  const clean = text.replace(/\s+/g, ' ').trim();
+  if (clean.length <= maxChars) return clean;
+  return `${clean.slice(0, Math.max(0, maxChars - 1)).trim()}…`;
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -290,8 +290,8 @@ code {
   flex-shrink: 0;
 }
 .app-chrome-mark {
-  width: 28px;
-  height: 28px;
+  width: 32px;
+  height: 32px;
   border-radius: 0;
   display: inline-flex;
   align-items: center;
@@ -300,14 +300,100 @@ code {
   overflow: visible;
   flex-shrink: 0;
 }
-.app-chrome-mark .brand-mark-img {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
+.app-chrome-loader-logo {
+  --app-logo-page: transparent;
+  --app-logo-ink: var(--accent);
+  --app-logo-spring: cubic-bezier(0.33, 1.45, 0.64, 1);
+  position: relative;
   display: block;
-  padding: 0;
-  user-select: none;
-  -webkit-user-drag: none;
+  width: 32px;
+  height: 32px;
+  overflow: hidden;
+  isolation: isolate;
+  background: var(--app-logo-page);
+  contain: layout paint;
+}
+.app-chrome-loader-defs {
+  position: absolute;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+}
+.app-chrome-loader-goo {
+  position: absolute;
+  inset: 0;
+  width: 200px;
+  height: 200px;
+  filter: url("#app-chrome-logo-goo");
+  transform: scale(0.16);
+  transform-origin: 0 0;
+}
+.app-chrome-loader-core,
+.app-chrome-loader-node {
+  position: absolute;
+  display: block;
+  background: var(--app-logo-ink);
+  border-radius: 999px;
+  will-change: transform;
+}
+.app-chrome-loader-core {
+  width: 42px;
+  height: 42px;
+  left: 79px;
+  top: 79px;
+  animation: app-logo-pulse 1.8s var(--app-logo-spring) infinite;
+}
+.app-chrome-loader-node {
+  width: 32px;
+  height: 32px;
+  left: 84px;
+  top: 84px;
+  animation: app-logo-spread 1.8s var(--app-logo-spring) infinite;
+}
+.app-chrome-loader-node:nth-child(2) {
+  --app-logo-x: 0px;
+  --app-logo-y: -48px;
+  animation-delay: -0.16s;
+}
+.app-chrome-loader-node:nth-child(3) {
+  --app-logo-x: 42px;
+  --app-logo-y: 24px;
+  animation-delay: -0.41s;
+}
+.app-chrome-loader-node:nth-child(4) {
+  --app-logo-x: -42px;
+  --app-logo-y: 24px;
+  animation-delay: -0.65s;
+}
+.entry-brand-mark .app-chrome-loader-logo {
+  width: 44px;
+  height: 44px;
+}
+.entry-brand-mark .app-chrome-loader-goo {
+  transform: scale(0.22);
+}
+@keyframes app-logo-spread {
+  0%, 100% {
+    transform: translate(0, 0) scale(0.5);
+  }
+  50% {
+    transform: translate(var(--app-logo-x), var(--app-logo-y)) scale(1.06);
+  }
+}
+@keyframes app-logo-pulse {
+  0%, 100% {
+    transform: scale(0.92);
+  }
+  50% {
+    transform: scale(1.12, 0.88);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .app-chrome-loader-core,
+  .app-chrome-loader-node {
+    animation-duration: 5s !important;
+    animation-timing-function: ease-in-out !important;
+  }
 }
 .app-chrome-name {
   color: var(--text-strong);
@@ -1433,12 +1519,13 @@ code {
   position: fixed;
   z-index: 1000;
   max-width: calc(100vw - 24px);
-  /* 7 locales × ~58px + menu chrome (padding, gap, border) ≈ 428px;
-     --menu-available-h is set by JS to the distance between the trigger
-     and whichever viewport edge the menu opens toward, so the menu never
-     overflows the viewport regardless of placement direction. The 60vh
-     cap keeps the menu from feeling cramped on short viewports. */
-  max-height: min(428px, 60vh, var(--menu-available-h, 428px));
+  /* 360px = 9 locales × ~40px; --menu-available-h is set by JS to the
+     distance between the trigger and whichever viewport edge the menu
+     opens toward, so the menu never overflows the viewport regardless of
+     placement direction (above or below the trigger). The 60vh cap keeps
+     the menu from feeling cramped on short viewports (mobile landscape,
+     ~400–500px tall). */
+  max-height: min(360px, 60vh, var(--menu-available-h, 360px));
   overflow-y: auto;
   overscroll-behavior: contain;
   display: flex;
@@ -1456,6 +1543,7 @@ code {
   align-items: center;
   gap: 12px;
   width: 100%;
+  min-height: 40px;
   padding: 10px 12px;
   border: 0;
   border-radius: 9px;
@@ -1672,14 +1760,14 @@ code {
 .entry-brand-mark {
   width: 44px;
   height: 44px;
-  border-radius: 50%;
-  background: linear-gradient(135deg, var(--accent-tint) 0%, var(--accent-soft) 100%);
+  border-radius: 0;
+  background: transparent;
   color: var(--accent);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  overflow: hidden;
+  overflow: visible;
 }
 .entry-brand-mark .brand-mark-img {
   width: 100%;
@@ -3401,7 +3489,6 @@ code {
   border-bottom: 1px solid var(--border);
   background: var(--bg-panel);
   overflow-x: auto;
-  overflow-y: hidden;
   flex-wrap: nowrap;
   height: 44px;
   position: sticky;
@@ -3587,7 +3674,7 @@ code {
 }
 .df-row {
   display: grid;
-  grid-template-columns: 28px 36px 1fr auto auto;
+  grid-template-columns: 36px 1fr auto auto;
   align-items: center;
   gap: 12px;
   padding: 10px 20px;
@@ -3605,38 +3692,6 @@ code {
 .df-row:hover { background: var(--bg-subtle); }
 .df-row.active { background: var(--blue-bg); color: var(--text); }
 .df-row.active .df-row-name { color: var(--text-strong); }
-.df-row.selected { background: var(--blue-bg); }
-
-.df-row-check {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  font-size: 13px;
-  color: var(--text-muted);
-  user-select: none;
-  width: 24px;
-  height: 24px;
-  border-radius: 4px;
-  transition: background 120ms ease, color 120ms ease;
-}
-.df-row-check:hover { background: var(--border); color: var(--text); }
-.df-row-check[aria-checked="true"] { color: var(--accent-strong); }
-
-.df-select-all {
-  background: none;
-  border: none;
-  color: var(--text-muted);
-  cursor: pointer;
-  font: inherit;
-  font-size: 11px;
-  font-weight: 500;
-  margin-left: auto;
-  padding: 2px 8px;
-  border-radius: 4px;
-  transition: background 120ms ease, color 120ms ease;
-}
-.df-select-all:hover { background: var(--bg-subtle); color: var(--text); }
 .df-row-icon {
   width: 32px;
   height: 32px;
@@ -3997,11 +4052,6 @@ code {
   height: 100%;
   min-height: 0;
 }
-.comment-frame-clip {
-  position: absolute;
-  inset: 0;
-  overflow: hidden;
-}
 .comment-overlay-layer {
   position: absolute;
   inset: 0;
@@ -4126,6 +4176,500 @@ code {
   background: var(--red-bg);
   border-color: var(--red-border);
 }
+.visual-edit-drag-target {
+  position: absolute;
+  z-index: 5;
+  border: 2px solid var(--accent);
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 30%, transparent), var(--shadow-sm);
+  cursor: grab;
+  touch-action: none;
+  user-select: none;
+}
+.visual-edit-drag-target:active {
+  cursor: grabbing;
+}
+.visual-edit-drag-target span {
+  position: absolute;
+  left: 0;
+  top: 0;
+  transform: translateY(calc(-100% - 7px));
+  padding: 4px 8px;
+  border-radius: var(--radius-pill);
+  background: var(--accent);
+  color: white;
+  font-size: 11px;
+  font-weight: 700;
+  white-space: nowrap;
+  box-shadow: var(--shadow-sm);
+}
+.visual-edit-panel {
+  position: absolute;
+  z-index: 6;
+  width: min(380px, calc(100% - 28px));
+  max-height: min(640px, calc(100% - 28px));
+  overflow: auto;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--bg-panel) 96%, transparent);
+  box-shadow: var(--shadow-lg);
+  backdrop-filter: blur(16px);
+}
+.tweaks-panel {
+  position: absolute;
+  z-index: 6;
+  top: 14px;
+  right: 14px;
+  width: min(420px, calc(100% - 28px));
+  max-height: min(720px, calc(100% - 28px));
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  overflow: hidden;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--bg-panel) 97%, transparent);
+  box-shadow: var(--shadow-lg);
+  backdrop-filter: blur(16px);
+}
+.tweaks-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+.tweaks-head div {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+.tweaks-head strong {
+  font-size: 13px;
+}
+.tweaks-head span,
+.tweaks-summary small,
+.tweak-control-meta code {
+  color: var(--text-muted);
+  font-size: 11.5px;
+}
+.tweaks-summary {
+  display: grid;
+  gap: 2px;
+  padding: 9px;
+  border: 1px solid var(--accent-soft);
+  border-radius: var(--radius-sm);
+  background: var(--accent-tint);
+}
+.tweaks-summary span {
+  color: var(--accent-strong);
+  font-size: 12px;
+  font-weight: 750;
+}
+.tweaks-presets {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 6px;
+}
+.tweaks-presets button {
+  min-width: 0;
+  min-height: 30px;
+  padding: 0 7px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-subtle);
+  color: var(--text);
+  font-size: 11px;
+}
+.tweaks-presets button:hover {
+  border-color: var(--accent-soft);
+  background: var(--accent-tint);
+  color: var(--accent-strong);
+}
+.tweaks-groups {
+  display: grid;
+  gap: 9px;
+  min-height: 0;
+  overflow: auto;
+  padding-right: 2px;
+  overscroll-behavior: contain;
+}
+.tweaks-group {
+  display: grid;
+  gap: 7px;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--bg-subtle) 72%, transparent);
+}
+.tweaks-group h3 {
+  margin: 0;
+  color: var(--text);
+  font-size: 11px;
+  font-weight: 750;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.tweak-control {
+  display: grid;
+  gap: 6px;
+  padding: 8px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: var(--bg-panel);
+}
+.tweak-control.changed {
+  border-color: var(--accent-soft);
+  background: var(--accent-tint);
+}
+.tweak-control-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-width: 0;
+}
+.tweak-control-meta strong {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.tweak-control-meta code {
+  min-width: 0;
+  overflow: hidden;
+  background: transparent;
+  padding: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.tweak-control-inputs {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 6px;
+  align-items: center;
+}
+.tweak-control-inputs select,
+.tweak-control-inputs input:not([type='color']) {
+  width: 100%;
+  min-width: 0;
+  height: 30px;
+  padding: 0 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  color: var(--text);
+  font: inherit;
+  font-size: 12px;
+}
+.tweak-color-input {
+  width: 34px;
+  height: 30px;
+  padding: 2px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+}
+.tweak-control-inputs select:only-child,
+.tweak-control-inputs input:only-child {
+  grid-column: 1 / -1;
+}
+.tweak-range {
+  width: 100%;
+  accent-color: var(--accent);
+}
+.tweaks-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding-top: 2px;
+}
+.tweaks-actions .primary {
+  min-height: 32px;
+}
+.visual-edit-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+.visual-edit-panel-handle {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  cursor: grab;
+  user-select: none;
+}
+.visual-edit-panel-handle:active {
+  cursor: grabbing;
+}
+.visual-edit-head strong {
+  font-size: 13px;
+}
+.visual-edit-head span,
+.visual-edit-actions span {
+  color: var(--text-muted);
+  font-size: 11.5px;
+}
+.visual-edit-queue,
+.visual-edit-batch-dock {
+  display: grid;
+  gap: 7px;
+  padding: 9px;
+  border: 1px solid var(--accent-soft);
+  border-radius: var(--radius-sm);
+  background: var(--accent-tint);
+}
+.visual-edit-queue {
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  margin-bottom: 10px;
+}
+.visual-edit-queue span,
+.visual-edit-batch-dock span {
+  color: var(--accent-strong);
+  font-size: 12px;
+  font-weight: 750;
+}
+.visual-edit-queue button,
+.visual-edit-batch-dock button {
+  min-height: 28px;
+  font-size: 11.5px;
+}
+.visual-edit-batch-dock {
+  position: absolute;
+  z-index: 6;
+  left: 50%;
+  bottom: 16px;
+  width: min(380px, calc(100% - 32px));
+  transform: translateX(-50%);
+  box-shadow: var(--shadow-lg);
+}
+.visual-edit-batch-dock small {
+  color: var(--text-muted);
+  font-size: 11.5px;
+}
+.visual-edit-batch-dock div {
+  display: inline-flex;
+  justify-content: flex-end;
+  gap: 6px;
+}
+.visual-edit-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+.visual-edit-field {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+.visual-edit-field span {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 650;
+}
+.visual-edit-field input,
+.visual-edit-field select,
+.visual-edit-field textarea {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  color: var(--text);
+  font: inherit;
+  font-size: 12px;
+}
+.visual-edit-field input,
+.visual-edit-field select {
+  height: 30px;
+  padding: 0 8px;
+}
+.visual-edit-field textarea {
+  min-height: 58px;
+  max-height: 120px;
+  padding: 7px 8px;
+  resize: vertical;
+}
+.visual-edit-field input:focus-visible,
+.visual-edit-field select:focus-visible,
+.visual-edit-field textarea:focus-visible,
+.visual-edit-details summary:focus-visible {
+  outline: 2px solid var(--accent-soft);
+  outline-offset: 2px;
+}
+.visual-edit-font-list {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+  max-height: 128px;
+  overflow: auto;
+  padding: 6px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-subtle);
+}
+.visual-edit-font-list button {
+  min-width: 0;
+  height: 30px;
+  padding: 0 8px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: var(--bg-panel);
+  color: var(--text);
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.visual-edit-font-list button:hover,
+.visual-edit-font-list button:focus-visible,
+.visual-edit-font-list button.active {
+  border-color: var(--accent);
+  background: var(--accent-tint);
+  color: var(--accent-strong);
+}
+.visual-edit-full {
+  margin-bottom: 8px;
+}
+.visual-edit-safe-note {
+  margin-bottom: 8px;
+  padding: 9px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-subtle);
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.35;
+}
+.visual-edit-section {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 10px;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--bg-subtle) 72%, transparent);
+}
+.visual-edit-section-title {
+  color: var(--text);
+  font-size: 11px;
+  font-weight: 750;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.visual-edit-font-picker {
+  position: relative;
+}
+.visual-edit-font-trigger {
+  width: 100%;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 0 11px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-panel);
+  color: var(--text);
+  font-size: 13px;
+  text-align: left;
+}
+.visual-edit-font-trigger span:first-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.visual-edit-font-menu {
+  position: absolute;
+  z-index: 8;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  display: grid;
+  gap: 2px;
+  max-height: 260px;
+  overflow: auto;
+  padding: 6px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-panel);
+  box-shadow: var(--shadow-lg);
+  overscroll-behavior: contain;
+}
+.visual-edit-font-menu button {
+  width: 100%;
+  min-width: 0;
+  min-height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 0 9px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text);
+  text-align: left;
+}
+.visual-edit-font-menu button span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.visual-edit-font-menu button em {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  font-family: inherit;
+  font-size: 10.5px;
+  font-style: normal;
+}
+.visual-edit-font-menu button:hover,
+.visual-edit-font-menu button:focus-visible,
+.visual-edit-font-menu button.active {
+  border-color: var(--accent-soft);
+  background: var(--accent-tint);
+  color: var(--accent-strong);
+}
+.visual-edit-details {
+  margin: 10px 0 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+.visual-edit-details summary {
+  cursor: pointer;
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.visual-edit-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding-top: 10px;
+}
+.visual-edit-actions div {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+.visual-edit-actions .primary {
+  min-height: 32px;
+}
 .comments-panel {
   display: flex;
   flex-direction: column;
@@ -4245,6 +4789,127 @@ code {
 }
 .comment-history-attachments {
   gap: 6px;
+}
+.preview-draw-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  pointer-events: auto;
+  touch-action: none;
+  user-select: none;
+}
+.preview-draw-layer canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  cursor: crosshair;
+}
+.preview-draw-toolbar {
+  position: absolute;
+  z-index: 2;
+  top: 12px;
+  left: 50%;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  max-width: calc(100% - 24px);
+  padding: 7px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--bg-panel) 92%, transparent);
+  box-shadow: var(--shadow-lg);
+  transform: translateX(-50%);
+  backdrop-filter: blur(14px);
+}
+.preview-draw-tool,
+.preview-draw-action,
+.preview-draw-close {
+  min-width: 30px;
+  height: 30px;
+  padding: 0 9px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  background: var(--bg-panel);
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.preview-draw-tool {
+  font-size: 14px;
+  line-height: 1;
+}
+.preview-draw-tool:hover,
+.preview-draw-action:hover:not(:disabled),
+.preview-draw-close:hover {
+  border-color: var(--accent-soft);
+  color: var(--accent-strong);
+}
+.preview-draw-tool.active {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: white;
+}
+.preview-draw-action:disabled {
+  opacity: 0.45;
+}
+.preview-draw-divider {
+  width: 1px;
+  height: 20px;
+  background: var(--border);
+}
+.preview-draw-color {
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: transparent;
+  cursor: pointer;
+}
+.preview-draw-size {
+  width: 72px;
+}
+.preview-draw-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+.preview-draw-panel {
+  position: absolute;
+  z-index: 2;
+  right: 14px;
+  bottom: 14px;
+  width: min(360px, calc(100% - 28px));
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-panel);
+  box-shadow: var(--shadow-lg);
+}
+.preview-draw-panel textarea {
+  min-height: 78px;
+  max-height: 140px;
+  resize: vertical;
+}
+.preview-draw-panel-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 8px;
+}
+.preview-draw-count {
+  display: inline-flex;
+  min-width: 24px;
+  height: 24px;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-pill);
+  background: var(--bg-subtle);
+  color: var(--text-muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
 }
 .viewer-source {
   margin: 0;
@@ -4385,7 +5050,14 @@ code {
   justify-content: center;
   padding: 24px;
 }
+.image-draw-wrap {
+  position: relative;
+  display: inline-flex;
+  max-width: 100%;
+  max-height: 100%;
+}
 .image-body img {
+  display: block;
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;

--- a/apps/web/src/providers/anthropic.ts
+++ b/apps/web/src/providers/anthropic.ts
@@ -8,6 +8,7 @@
  * your own backend.
  */
 import Anthropic from '@anthropic-ai/sdk';
+import { compactChatHistoryForPrompt } from '../conversation-compaction';
 import { effectiveMaxTokens } from '../state/maxTokens';
 import type { AppConfig, ChatMessage } from '../types';
 import { streamMessageAnthropicProxy } from './anthropic-compatible';
@@ -62,6 +63,7 @@ export async function streamMessage(
 
   const client = makeClient(cfg);
   let acc = '';
+  const compactedHistory = compactChatHistoryForPrompt(history).history;
 
   try {
     const stream = client.messages.stream(
@@ -69,7 +71,7 @@ export async function streamMessage(
         model: cfg.model,
         max_tokens: effectiveMaxTokens(cfg),
         system,
-        messages: history.map((m) => ({ role: m.role, content: m.content })),
+        messages: compactedHistory.map((m) => ({ role: m.role, content: m.content })),
       },
       { signal },
     );

--- a/apps/web/src/providers/api-proxy.ts
+++ b/apps/web/src/providers/api-proxy.ts
@@ -1,4 +1,5 @@
 import { effectiveMaxTokens } from '../state/maxTokens';
+import { compactChatHistoryForPrompt } from '../conversation-compaction';
 import type { AppConfig, ChatMessage } from '../types';
 import type { StreamHandlers } from './anthropic';
 import { parseSseFrame } from './sse';
@@ -17,6 +18,7 @@ export async function streamProxyEndpoint(
   }
 
   let acc = '';
+  const compactedHistory = compactChatHistoryForPrompt(history).history;
 
   try {
     const resp = await fetch(endpoint, {
@@ -27,7 +29,7 @@ export async function streamProxyEndpoint(
         apiKey: cfg.apiKey,
         model: cfg.model,
         systemPrompt: system,
-        messages: history.map((m) => ({ role: m.role, content: m.content })),
+        messages: compactedHistory.map((m) => ({ role: m.role, content: m.content })),
         maxTokens: effectiveMaxTokens(cfg),
         apiVersion: cfg.apiVersion,
       }),

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -9,6 +9,7 @@
  *   - 'stderr'  : incidental stderr. Shown only when the process exits
  *                 non-zero (tail appended to the error message).
  */
+import { compactChatHistoryForPrompt, formatCompactionStatusDetail } from '../conversation-compaction';
 import type { AgentEvent, ChatCommentAttachment, ChatMessage } from '../types';
 import type {
   ChatRunCreateResponse,
@@ -52,6 +53,7 @@ export interface DaemonStreamOptions {
   // exist, and stitches them into the user message as `@<path>` hints.
   attachments?: string[];
   commentAttachments?: ChatCommentAttachment[];
+  activeFilePath?: string | null;
   // Per-CLI model + reasoning the user picked in the model menu. Both are
   // optional; the daemon validates them against the agent's declared
   // options and falls back to the CLI default when missing.
@@ -87,6 +89,7 @@ export async function streamViaDaemon({
   designSystemId,
   attachments,
   commentAttachments,
+  activeFilePath,
   model,
   reasoning,
   initialLastEventId,
@@ -94,10 +97,17 @@ export async function streamViaDaemon({
   onRunStatus,
   onRunEventId,
 }: DaemonStreamOptions): Promise<void> {
-  // Local CLIs are single-turn print-mode programs, so we collapse the whole
-  // chat into one string. If this becomes too noisy for long histories, the
-  // fix is to only include the final user turn.
-  const transcript = history
+  const compactedHistory = compactChatHistoryForPrompt(history);
+
+  if (compactedHistory.compacted) {
+    handlers.onAgentEvent({
+      kind: 'status',
+      label: 'compactando contexto',
+      detail: formatCompactionStatusDetail(compactedHistory),
+    });
+  }
+
+  const transcript = compactedHistory.history
     .map((m) => `## ${m.role}\n${m.content.trim()}`)
     .join('\n\n');
   const request: ChatRequest = {
@@ -111,6 +121,7 @@ export async function streamViaDaemon({
     designSystemId: designSystemId ?? null,
     attachments: attachments ?? [],
     commentAttachments: commentAttachments ?? [],
+    activeFilePath: activeFilePath ?? null,
     model: model ?? null,
     reasoning: reasoning ?? null,
   };

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -19,6 +19,7 @@ export type SrcdocOptions = {
   baseHref?: string;
   initialSlideIndex?: number;
   commentBridge?: boolean;
+  tweakBridge?: boolean;
 };
 
 export function buildSrcdoc(
@@ -40,7 +41,8 @@ export function buildSrcdoc(
   const withBase = options.baseHref ? injectBaseHref(wrapped, options.baseHref) : wrapped;
   const withShim = injectSandboxShim(withBase);
   const withDeck = options.deck ? injectDeckBridge(withShim, options.initialSlideIndex) : withShim;
-  return options.commentBridge ? injectCommentBridge(withDeck) : withDeck;
+  const withTweaks = options.tweakBridge ? injectTweakBridge(withDeck) : withDeck;
+  return options.commentBridge ? injectCommentBridge(withTweaks) : withTweaks;
 }
 
 function injectBaseHref(doc: string, baseHref: string): string {
@@ -107,27 +109,309 @@ function injectCommentBridge(doc: string): string {
   const script = `<script data-od-comment-bridge>(function(){
   var enabled = true;
   var hoveredId = null;
-  function esc(value){ try { return window.CSS && CSS.escape ? CSS.escape(value) : String(value).replace(/"/g, '\\\\"'); } catch (_) { return String(value); } }
-  function targetFrom(el){
-    var id = el.getAttribute('data-od-id') || el.getAttribute('data-screen-label');
-    if (!id) return null;
+  var blockedTags = { html: true, head: true, meta: true, link: true, style: true, script: true, title: true, base: true };
+  function clean(value){ return String(value || '').replace(/\\s+/g, ' ').trim(); }
+  function cssEsc(value){ try { return window.CSS && CSS.escape ? CSS.escape(String(value)) : String(value).replace(/[^a-zA-Z0-9_-]/g, '\\\\$&'); } catch (_) { return String(value); } }
+  function attrEsc(value){ return String(value || '').replace(/\\\\/g, '\\\\\\\\').replace(/"/g, '\\\\"'); }
+  function isSelectable(el){
+    if (!el || !el.tagName) return false;
+    var tag = el.tagName.toLowerCase();
+    if (blockedTags[tag]) return false;
     var rect = el.getBoundingClientRect();
+    return rect.width > 0 && rect.height > 0;
+  }
+  function compactTag(el){
+    if (!el || !el.tagName) return '';
+    var tag = el.tagName.toLowerCase();
+    var bits = ['<' + tag];
+    if (el.id) bits.push('id="' + attrEsc(el.id) + '"');
+    if (typeof el.className === 'string' && clean(el.className)) bits.push('class="' + attrEsc(clean(el.className).split(/\\s+/).slice(0, 5).join(' ')) + '"');
+    var attrs = ['data-od-id', 'data-screen-label', 'role', 'aria-label', 'alt', 'title', 'type', 'name', 'href'];
+    for (var i = 0; i < attrs.length; i++) {
+      var value = el.getAttribute && el.getAttribute(attrs[i]);
+      if (value && !((attrs[i] === 'href') && /^javascript:/i.test(value))) bits.push(attrs[i] + '="' + attrEsc(clean(value).slice(0, 120)) + '"');
+    }
+    return bits.join(' ') + '>';
+  }
+  function selectorFor(el){
+    if (el.hasAttribute('data-od-id')) return '[data-od-id="' + attrEsc(el.getAttribute('data-od-id')) + '"]';
+    if (el.hasAttribute('data-screen-label')) return '[data-screen-label="' + attrEsc(el.getAttribute('data-screen-label')) + '"]';
+    if (el.id) return '#' + cssEsc(el.id);
+    var parts = [];
+    var node = el;
+    while (node && node.nodeType === 1 && node !== document.documentElement && parts.length < 7) {
+      var tag = node.tagName.toLowerCase();
+      var part = tag;
+      if (node.id) {
+        parts.unshift(tag + '#' + cssEsc(node.id));
+        break;
+      }
+      if (node.hasAttribute('data-od-id')) {
+        parts.unshift('[data-od-id="' + attrEsc(node.getAttribute('data-od-id')) + '"]');
+        break;
+      }
+      if (node.hasAttribute('data-screen-label')) {
+        parts.unshift('[data-screen-label="' + attrEsc(node.getAttribute('data-screen-label')) + '"]');
+        break;
+      }
+      if (typeof node.className === 'string' && clean(node.className)) {
+        part += '.' + clean(node.className).split(/\\s+/).slice(0, 2).map(cssEsc).join('.');
+      }
+      var nth = 1;
+      var prev = node.previousElementSibling;
+      while (prev) {
+        if (prev.tagName === node.tagName) nth++;
+        prev = prev.previousElementSibling;
+      }
+      part += ':nth-of-type(' + nth + ')';
+      parts.unshift(part);
+      node = node.parentElement;
+    }
+    return parts.join(' > ') || (el.tagName ? el.tagName.toLowerCase() : 'element');
+  }
+  function labelFor(el){
     var tag = el.tagName ? el.tagName.toLowerCase() : 'element';
-    var cls = typeof el.className === 'string' && el.className.trim() ? '.' + el.className.trim().split(/\\s+/).slice(0,2).join('.') : '';
-    var html = '';
-    try { html = (el.outerHTML || '').replace(/\\s+/g, ' ').match(/^<[^>]+>/)?.[0] || ''; } catch (_) {}
+    var label = tag;
+    if (el.id) label += '#' + el.id;
+    if (typeof el.className === 'string' && clean(el.className)) label += '.' + clean(el.className).split(/\\s+/).slice(0, 2).join('.');
+    var role = el.getAttribute && el.getAttribute('role');
+    if (role) label += '[role=' + role + ']';
+    return label.slice(0, 160);
+  }
+  function textFor(el){
+    if (!isTextEditableTarget(el)) return '';
+    var text = clean(el.textContent || '');
+    if (!text && 'value' in el) text = clean(el.value || '');
+    if (!text) text = clean(el.getAttribute('aria-label') || el.getAttribute('alt') || el.getAttribute('placeholder') || el.getAttribute('title') || '');
+    return text.slice(0, 240);
+  }
+  function isTextEditableTarget(el){
+    if (!el || !el.tagName) return false;
+    var tag = el.tagName.toLowerCase();
+    if (/^(h1|h2|h3|h4|h5|h6|p|span|a|button|label|strong|em|small|li|figcaption|blockquote|cite|time)$/.test(tag)) return true;
+    if (tag === 'input' || tag === 'textarea') return true;
+    return false;
+  }
+  function styleObject(el, rect){
+    try {
+      var cs = window.getComputedStyle(el);
+      return {
+        display: cs.display,
+        position: cs.position,
+        color: cs.color,
+        backgroundColor: cs.backgroundColor,
+        fontFamily: cs.fontFamily,
+        fontSize: cs.fontSize,
+        fontWeight: cs.fontWeight,
+        lineHeight: cs.lineHeight,
+        letterSpacing: cs.letterSpacing,
+        width: cs.width,
+        height: cs.height,
+        transform: cs.transform,
+        animationName: cs.animationName,
+        animationDuration: cs.animationDuration,
+        animationDelay: cs.animationDelay,
+        animationTimingFunction: cs.animationTimingFunction,
+        animationIterationCount: cs.animationIterationCount,
+        animationDirection: cs.animationDirection,
+        animationFillMode: cs.animationFillMode,
+        boxWidth: Math.round(rect.width),
+        boxHeight: Math.round(rect.height)
+      };
+    } catch (_) {
+      return null;
+    }
+  }
+  function styleHint(el, rect){
+    var s = styleObject(el, rect);
+    if (!s) return 'styles: unavailable';
+    return 'styles: display=' + s.display + '; position=' + s.position + '; color=' + s.color + '; background=' + s.backgroundColor + '; font=' + s.fontSize + '/' + s.lineHeight + ' ' + s.fontFamily + '; animation=' + s.animationName + ' ' + s.animationDuration + ' ' + s.animationTimingFunction + '; transform=' + s.transform + '; box=' + s.boxWidth + 'x' + s.boxHeight;
+  }
+  function htmlHintFor(el, rect){
+    var previous = el.previousElementSibling ? compactTag(el.previousElementSibling) : '';
+    var next = el.nextElementSibling ? compactTag(el.nextElementSibling) : '';
+    var parent = el.parentElement ? compactTag(el.parentElement) : '';
+    return clean(['self: ' + compactTag(el), parent ? 'parent: ' + parent : '', previous ? 'previous: ' + previous : '', next ? 'next: ' + next : '', styleHint(el, rect)].filter(Boolean).join(' | ')).slice(0, 800);
+  }
+  function isInteractiveTarget(el){
+    if (!el || !el.tagName) return false;
+    var tag = el.tagName.toLowerCase();
+    if (/^(a|button|input|textarea|select|option|summary|label)$/.test(tag)) return true;
+    var role = clean(el.getAttribute && el.getAttribute('role'));
+    if (/^(button|link|menuitem|tab|checkbox|radio|switch|textbox|combobox|slider)$/.test(role)) return true;
+    if (el.hasAttribute && (el.hasAttribute('onclick') || el.hasAttribute('contenteditable'))) return true;
+    var tabindex = el.getAttribute && el.getAttribute('tabindex');
+    return tabindex !== null && tabindex !== undefined && tabindex !== '-1';
+  }
+  function containerPenaltyTag(el){
+    var tag = el && el.tagName ? el.tagName.toLowerCase() : '';
+    return /^(body|main|section|article|aside|header|footer|nav|div|ul|ol|form)$/.test(tag);
+  }
+  function visibleArea(rect){
+    return Math.max(0, rect.width) * Math.max(0, rect.height);
+  }
+  function viewportArea(){
+    return Math.max(1, window.innerWidth * window.innerHeight);
+  }
+  function ownText(el){
+    var out = '';
+    for (var i = 0; i < el.childNodes.length; i++) {
+      var node = el.childNodes[i];
+      if (node && node.nodeType === 3) out += ' ' + node.nodeValue;
+    }
+    return clean(out);
+  }
+  function candidateScore(el, index){
+    if (!isSelectable(el)) return -100000;
+    var rect = el.getBoundingClientRect();
+    var area = visibleArea(rect);
+    var vp = viewportArea();
+    var score = 1000 - index * 8;
+    var tag = el.tagName.toLowerCase();
+    if (isInteractiveTarget(el)) score += 900;
+    if (isTextEditableTarget(el)) score += 520;
+    if (ownText(el)) score += 180;
+    if (el.hasAttribute('data-od-id')) score += 120;
+    if (el.hasAttribute('data-screen-label')) score -= 260;
+    if (/^(button|a|input|textarea|select|label)$/.test(tag)) score += 420;
+    if (/^(h1|h2|h3|h4|h5|h6|p|span|small|strong|em|li)$/.test(tag)) score += 240;
+    if (containerPenaltyTag(el)) score -= 120;
+    if (area > vp * 0.65) score -= 850;
+    else if (area > vp * 0.35) score -= 520;
+    else if (area > vp * 0.18) score -= 260;
+    if (area < 260000) score += Math.max(0, 220 - Math.sqrt(area) / 2);
+    if (rect.width < 18 || rect.height < 18) score -= 120;
+    return score;
+  }
+  function candidatesFromPoint(event){
+    var seen = [];
+    var items = [];
+    var stack = [];
+    try { stack = document.elementsFromPoint(event.clientX, event.clientY) || []; } catch (_) { stack = []; }
+    if (event.target && stack.indexOf(event.target) === -1) stack.unshift(event.target);
+    for (var i = 0; i < stack.length; i++) {
+      var el = stack[i];
+      while (el && el !== document.documentElement) {
+        if (seen.indexOf(el) === -1) {
+          seen.push(el);
+          items.push({ el: el, index: i });
+        }
+        el = el.parentElement;
+      }
+    }
+    return items;
+  }
+  function preferredTarget(event){
+    var candidates = candidatesFromPoint(event);
+    var best = null;
+    var bestScore = -100000;
+    for (var i = 0; i < candidates.length; i++) {
+      var score = candidateScore(candidates[i].el, candidates[i].index);
+      if (score > bestScore) {
+        best = candidates[i].el;
+        bestScore = score;
+      }
+    }
+    return best;
+  }
+  function targetFrom(el){
+    if (!isSelectable(el)) return null;
+    var rect = el.getBoundingClientRect();
+    var selector = selectorFor(el);
+    var id = el.getAttribute('data-od-id') || el.getAttribute('data-screen-label') || el.id || selector;
     return {
       type: 'od:comment-target',
       elementId: id,
-      selector: el.hasAttribute('data-od-id') ? '[data-od-id="' + esc(id) + '"]' : '[data-screen-label="' + esc(id) + '"]',
-      label: tag + cls,
-      text: (el.textContent || '').replace(/\\s+/g, ' ').trim().slice(0, 160),
+      selector: selector,
+      label: labelFor(el),
+      text: textFor(el),
       position: { x: Math.round(rect.x), y: Math.round(rect.y), width: Math.round(rect.width), height: Math.round(rect.height) },
-      htmlHint: html.slice(0, 180)
+      htmlHint: htmlHintFor(el, rect),
+      styles: styleObject(el, rect)
     };
   }
+  function queryTarget(selector){
+    try { return document.querySelector(selector); }
+    catch (_) { return null; }
+  }
+  function rememberOriginal(el){
+    if (el.__odVisualEditOriginal) return el.__odVisualEditOriginal;
+    var original = {
+      textContent: el.textContent,
+      style: {
+        fontFamily: el.style.fontFamily,
+        fontSize: el.style.fontSize,
+        fontWeight: el.style.fontWeight,
+        lineHeight: el.style.lineHeight,
+        letterSpacing: el.style.letterSpacing,
+        color: el.style.color,
+        backgroundColor: el.style.backgroundColor,
+        width: el.style.width,
+        height: el.style.height,
+        transform: el.style.transform,
+        animationName: el.style.animationName,
+        animationDuration: el.style.animationDuration,
+        animationDelay: el.style.animationDelay,
+        animationTimingFunction: el.style.animationTimingFunction,
+        animationIterationCount: el.style.animationIterationCount,
+        animationDirection: el.style.animationDirection,
+        animationFillMode: el.style.animationFillMode
+      }
+    };
+    try { Object.defineProperty(el, '__odVisualEditOriginal', { value: original, configurable: true }); }
+    catch (_) { el.__odVisualEditOriginal = original; }
+    return original;
+  }
+  function restoreVisualEdits(){
+    var nodes = document.querySelectorAll('*');
+    for (var i = 0; i < nodes.length; i++) {
+      var original = nodes[i].__odVisualEditOriginal;
+      if (!original) continue;
+      nodes[i].textContent = original.textContent;
+      for (var key in original.style) nodes[i].style[key] = original.style[key];
+      try { delete nodes[i].__odVisualEditOriginal; } catch (_) { nodes[i].__odVisualEditOriginal = null; }
+    }
+    schedulePostTargets();
+  }
+  function applyVisualEdit(selector, draft){
+    var el = queryTarget(selector);
+    if (!el || !draft) return;
+    var original = rememberOriginal(el);
+    if (typeof draft.text === 'string' && draft.text.trim() && isTextEditableTarget(el)) el.textContent = draft.text;
+    var map = [
+      ['fontFamily', 'fontFamily'],
+      ['fontSize', 'fontSize'],
+      ['fontWeight', 'fontWeight'],
+      ['lineHeight', 'lineHeight'],
+      ['letterSpacing', 'letterSpacing'],
+      ['color', 'color'],
+      ['backgroundColor', 'backgroundColor'],
+      ['width', 'width'],
+      ['height', 'height'],
+      ['animationName', 'animationName'],
+      ['animationDuration', 'animationDuration'],
+      ['animationDelay', 'animationDelay'],
+      ['animationTimingFunction', 'animationTimingFunction'],
+      ['animationIterationCount', 'animationIterationCount'],
+      ['animationDirection', 'animationDirection'],
+      ['animationFillMode', 'animationFillMode']
+    ];
+    for (var i = 0; i < map.length; i++) {
+      var value = draft[map[i][0]];
+      if (typeof value === 'string' && value.trim()) el.style[map[i][1]] = value.trim();
+    }
+    var moveX = Number(draft.moveX) || 0;
+    var moveY = Number(draft.moveY) || 0;
+    if (moveX || moveY) {
+      var baseTransform = original.style.transform || '';
+      el.style.transform = 'translate(' + Math.round(moveX) + 'px, ' + Math.round(moveY) + 'px)' + (baseTransform ? ' ' + baseTransform : '');
+    } else if (original.style.transform) {
+      el.style.transform = original.style.transform;
+    }
+    schedulePostTargets();
+  }
   function allTargets(){
-    var nodes = document.querySelectorAll('[data-od-id], [data-screen-label]');
+    var nodes = document.body ? document.body.querySelectorAll('*') : document.querySelectorAll('*');
     var items = [];
     for (var i = 0; i < nodes.length; i++) {
       var item = targetFrom(nodes[i]);
@@ -157,6 +441,17 @@ function injectCommentBridge(doc: string): string {
     return null;
   }
   window.addEventListener('message', function(ev){
+    if (ev.data && ev.data.type === 'od:visual-edit-preview') {
+      restoreVisualEdits();
+      if (Array.isArray(ev.data.edits)) {
+        for (var i = 0; i < ev.data.edits.length; i++) {
+          applyVisualEdit(ev.data.edits[i].selector, ev.data.edits[i].draft);
+        }
+      } else if (!ev.data.clear) {
+        applyVisualEdit(ev.data.selector, ev.data.draft);
+      }
+      return;
+    }
     if (!ev.data || ev.data.type !== 'od:comment-mode') return;
     enabled = !!ev.data.enabled;
     document.documentElement.toggleAttribute('data-od-comment-mode', enabled);
@@ -165,7 +460,7 @@ function injectCommentBridge(doc: string): string {
   });
   document.addEventListener('mouseover', function(ev){
     if (!enabled) return;
-    var el = closestTarget(ev);
+    var el = preferredTarget(ev);
     if (!el) return;
     var payload = targetFrom(el);
     if (!payload || payload.elementId === hoveredId) return;
@@ -174,7 +469,7 @@ function injectCommentBridge(doc: string): string {
   }, true);
   document.addEventListener('mouseout', function(ev){
     if (!enabled) return;
-    var el = closestTarget(ev);
+    var el = preferredTarget(ev);
     if (!el) return;
     var next = ev.relatedTarget;
     while (next && next !== document.documentElement) {
@@ -186,7 +481,7 @@ function injectCommentBridge(doc: string): string {
   }, true);
   document.addEventListener('click', function(ev){
     if (!enabled) return;
-    var el = closestTarget(ev);
+    var el = preferredTarget(ev);
     if (!el) return;
     ev.preventDefault();
     ev.stopPropagation();
@@ -199,8 +494,8 @@ function injectCommentBridge(doc: string): string {
   else setTimeout(postTargets, 0);
 })();</script>`;
   const style = `<style data-od-comment-bridge-style>
-html[data-od-comment-mode] [data-od-id],
-html[data-od-comment-mode] [data-screen-label] { cursor: crosshair !important; }
+html[data-od-comment-mode] body,
+html[data-od-comment-mode] body * { cursor: crosshair !important; }
 </style>`;
   const withStyle = /<\/head>/i.test(doc)
     ? doc.replace(/<\/head>/i, style + '</head>')
@@ -209,6 +504,31 @@ html[data-od-comment-mode] [data-screen-label] { cursor: crosshair !important; }
       : style + doc;
   if (/<\/body>/i.test(withStyle)) return withStyle.replace(/<\/body>/i, script + '</body>');
   return withStyle + script;
+}
+
+function injectTweakBridge(doc: string): string {
+  const script = `<script data-od-tweak-bridge>(function(){
+  function targetHead(){ return document.head || document.documentElement || document.body; }
+  function apply(css){
+    var existing = document.querySelector('style[data-od-tweaks-live]');
+    if (!css) {
+      if (existing && existing.parentNode) existing.parentNode.removeChild(existing);
+      return;
+    }
+    if (!existing) {
+      existing = document.createElement('style');
+      existing.setAttribute('data-od-tweaks-live', '');
+      targetHead().appendChild(existing);
+    }
+    if (existing.textContent !== css) existing.textContent = css;
+  }
+  window.addEventListener('message', function(ev){
+    if (!ev.data || ev.data.type !== 'od:tweaks-preview') return;
+    apply(String(ev.data.css || ''));
+  });
+})();</script>`;
+  if (/<\/body>/i.test(doc)) return doc.replace(/<\/body>/i, script + '</body>');
+  return doc + script;
 }
 
 // The deck bridge supports three deck conventions found across our skills

--- a/open-design.command
+++ b/open-design.command
@@ -27,7 +27,14 @@ if [ "$NODE_MAJOR" != "24" ]; then
 fi
 
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
-corepack pnpm --version >/dev/null
+if ! corepack pnpm --version >/dev/null 2>&1; then
+  if ! corepack prepare pnpm@10.33.2 --activate >/dev/null 2>&1; then
+    echo "Corepack encontrado, mas o pnpm nao esta preparado."
+    echo "Tente rodar: corepack prepare pnpm@10.33.2 --activate"
+    read -r -p "Pressione Enter para sair."
+    exit 1
+  fi
+fi
 
 if [ ! -d node_modules ]; then
   corepack pnpm install
@@ -41,4 +48,9 @@ cleanup() {
 }
 trap cleanup EXIT
 
-read -r -p "Open Design em execucao no app. Pressione Enter para encerrar."
+if [ -t 0 ]; then
+  read -r -p "Open Design em execucao no app. Pressione Enter para encerrar."
+else
+  echo "Open Design em execucao no app. Pressione Ctrl+C para encerrar."
+  while true; do sleep 3600; done
+fi

--- a/open-design.command
+++ b/open-design.command
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$PROJECT_DIR"
+
+SHIM_DIR="${TMPDIR:-/tmp}/open-design-command-bin"
+mkdir -p "$SHIM_DIR"
+cat > "$SHIM_DIR/pnpm" <<'SH'
+#!/usr/bin/env bash
+exec corepack pnpm "$@"
+SH
+chmod +x "$SHIM_DIR/pnpm"
+export PATH="$SHIM_DIR:$PATH"
+
+if ! command -v corepack >/dev/null 2>&1; then
+  echo "Corepack nao encontrado. Instale Node.js 24 e tente novamente."
+  read -r -p "Pressione Enter para sair."
+  exit 1
+fi
+
+NODE_MAJOR="$(node -p "process.versions.node.split('.')[0]" 2>/dev/null || true)"
+if [ "$NODE_MAJOR" != "24" ]; then
+  echo "Este projeto exige Node.js 24. Versao atual: $(node -v 2>/dev/null || echo nao encontrada)"
+  read -r -p "Pressione Enter para sair."
+  exit 1
+fi
+
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+corepack pnpm --version >/dev/null
+
+if [ ! -d node_modules ]; then
+  corepack pnpm install
+fi
+
+corepack pnpm exec tools-dev stop >/dev/null 2>&1 || true
+corepack pnpm exec tools-dev
+
+cleanup() {
+  corepack pnpm exec tools-dev stop >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+read -r -p "Open Design em execucao no app. Pressione Enter para encerrar."

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -15,6 +15,7 @@ export interface ChatRequest {
   designSystemId?: string | null;
   attachments?: string[];
   commentAttachments?: ChatCommentAttachment[];
+  activeFilePath?: string | null;
   model?: string | null;
   reasoning?: string | null;
 }


### PR DESCRIPTION
## Summary

This update expands Open Design's visual editing workflow and agent behavior so the app can work much closer to the Claude Design experience, with stronger direct manipulation tools, better HTML editing safety, clearer runtime feedback, and a more complete prompt/harness setup.

## Claude Design prompt/harness alignment

- Updated the agent prompt/harness to follow the Claude Design workflow provided in the project reference.
- The Open Design harness now uses the same core instruction style and design workflow expectations from Claude Design, adapted to Open Design's runtime and tool environment.
- Removed irrelevant Claude-specific/XML-oriented behavior where it did not fit Open Design.
- Preserved the important behavioral rules: ask the right questions, inspect the active file/context, avoid unnecessary artifact creation, edit the intended target, and use tools in a structured way.
- Added stronger file-targeting instructions so revision/edit requests update the active design file instead of creating unrelated duplicate artifacts.

## Edit mode

- Reworked the Edit button from a placeholder into a functional visual editing flow.
- Added element selection inside the HTML preview.
- Improved targeting so the user can select the intended element instead of accidentally selecting the whole page/background.
- Added a direct editing panel for common properties such as text, font, size, color, background, dimensions, movement, and animation details.
- Added direct-save support for simple changes that should be written straight to the HTML without involving the AI.
- Added queued/multi-edit behavior so users can adjust multiple elements and then send the full set of requested changes to the agent.
- Improved dragging behavior so the edit panel does not block placement while moving elements.
- Added safer selection locking so one edit target is handled at a time unless the user intentionally queues multiple edits.

## Draw mode

- Expanded the Draw workflow so users can sketch or mark what they want changed directly on the preview.
- Added better prompt context for drawn annotations so the agent can interpret the user's visual intent and apply design changes more accurately.
- Improved the relationship between drawings, selected targets, and the active HTML file.
- Made Draw mode part of the same structured visual-feedback loop as Edit and Comment.

## Tweaks mode

- Made the Tweaks button functional instead of a placeholder.
- Added direct tweak controls for colors, typography-adjacent values, spacing, borders, radius, and motion where available.
- Added quick presets such as Compact, Comfortable, Rounder, Sharper, and No Motion.
- Fixed unstable preset behavior by making presets deterministic and based on stable baseline values.
- Added fallback global tweak controls so presets still work even when a generated HTML file does not expose useful CSS variables.
- Fixed preview flickering by applying live tweak CSS through the preview bridge instead of reloading the iframe on every change.
- Added direct HTML persistence for tweak changes.

## Preview and element-targeting improvements

- Improved the srcdoc preview bridge used by Comment, Edit, Draw, and Tweaks.
- Added safer element hit-testing to prioritize real interactive/text elements over large layout containers or page backgrounds.
- Added live preview messaging for tweak updates.
- Reduced cases where selecting a header, section, or background unintentionally replaces or removes unrelated content.

## Artifact and file-update safety

- Added active file awareness to chat requests.
- Updated daemon/server-side context so the agent knows which design file is currently selected.
- Prevented revision prompts from creating new blank sibling HTML files when the user clearly intends to edit the active file.
- Added logic to detect artifact responses that only reference an existing filename and open/update the existing file instead of creating an empty artifact.
- Improved file naming and target resolution for edit/revision workflows.

## Conversation compaction and status feedback

- Added conversation compaction support before sending large histories to providers.
- Added compaction handling for daemon, API proxy, and Anthropic provider flows.
- Added a visible agent status message when context is being compacted, so users understand what is happening instead of seeing silent delay.

## Tooling and launch workflow

- Added a macOS `.command` launcher so the project can be started more easily from Finder.
- The launcher uses Corepack/pnpm without requiring global pnpm symlinks.
- Added startup cleanup for the local dev tools process.

## User impact

- Users can edit designs more directly without needing the AI for every small change.
- Visual feedback is faster and more stable.
- The agent receives clearer context about the active file and selected visual target.
- The app is less likely to create duplicate blank artifacts during iterative edits.
- The overall workflow is closer to Claude Design's prompt and visual editing behavior while remaining adapted to Open Design's architecture.