### PR TITLE
fix(web): add copy buttons for FileViewer code blocks

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -43,7 +43,10 @@ type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => 
 type SlideState = { active: number; count: number };
 
 const htmlPreviewSlideState = new Map<string, SlideState>();
+const MARKDOWN_CODE_BLOCK_ATTR = 'data-markdown-code-block';
 const MARKDOWN_COPY_BLOCK_ATTR = 'data-copy-code-block';
+const MARKDOWN_COPY_BUTTON_CLASS = 'markdown-code-copy';
+const MARKDOWN_COPY_TOAST_CLASS = 'markdown-code-toast';
 
 async function copyTextToClipboard(text: string): Promise<boolean> {
   try {
@@ -58,28 +61,61 @@ async function copyTextToClipboard(text: string): Promise<boolean> {
     ta.select();
     try {
       return document.execCommand('copy');
+    } catch {
+      return false;
     } finally {
       document.body.removeChild(ta);
     }
   }
 }
 
-function decorateMarkdownCodeBlocks(html: string, t: TranslateFn, copiedBlockId: string | null): string {
+function decorateMarkdownCodeBlocks(html: string): string {
   let blockIndex = 0;
   return html.replace(/<pre\b([^>]*)>([\s\S]*?)<\/pre>/g, (_match, attrs: string, content: string) => {
     const blockId = String(blockIndex++);
-    const copied = copiedBlockId === blockId;
-    const label = copied ? t('fileViewer.copied') : t('fileViewer.copy');
-    const toast = copied
-      ? `<span class="markdown-code-toast" role="status" aria-live="polite">${t('fileViewer.copied')}</span>`
-      : '';
-    return (
-      `<div class="markdown-code-block">` +
-      `<button type="button" class="markdown-code-copy" ${MARKDOWN_COPY_BLOCK_ATTR}="${blockId}" title="${t('fileViewer.copyTitle')}" aria-label="${label}">` +
-      `${label}</button>` +
-      `${toast}<pre${attrs}>${content}</pre></div>`
-    );
+    return `<div class="markdown-code-block" ${MARKDOWN_CODE_BLOCK_ATTR}="${blockId}"><pre${attrs}>${content}</pre></div>`;
   });
+}
+
+function setMarkdownCodeBlockCopiedState(block: HTMLElement, copied: boolean, t: TranslateFn) {
+  const button = block.querySelector<HTMLButtonElement>(`.${MARKDOWN_COPY_BUTTON_CLASS}`);
+  if (!button) return;
+  const label = copied ? t('fileViewer.copied') : t('fileViewer.copy');
+  button.textContent = label;
+  button.setAttribute('aria-label', label);
+  button.title = t('fileViewer.copyTitle');
+
+  const existingToast = block.querySelector(`.${MARKDOWN_COPY_TOAST_CLASS}`);
+  if (copied) {
+    if (existingToast instanceof HTMLElement) {
+      existingToast.textContent = t('fileViewer.copied');
+      return;
+    }
+    const toast = document.createElement('span');
+    toast.className = MARKDOWN_COPY_TOAST_CLASS;
+    toast.setAttribute('role', 'status');
+    toast.setAttribute('aria-live', 'polite');
+    toast.textContent = t('fileViewer.copied');
+    button.insertAdjacentElement('afterend', toast);
+    return;
+  }
+
+  existingToast?.remove();
+}
+
+function ensureMarkdownCodeBlockControls(root: HTMLElement, t: TranslateFn) {
+  for (const block of root.querySelectorAll<HTMLElement>(`[${MARKDOWN_CODE_BLOCK_ATTR}]`)) {
+    let button = block.querySelector<HTMLButtonElement>(`.${MARKDOWN_COPY_BUTTON_CLASS}`);
+    if (!button) {
+      button = document.createElement('button');
+      button.type = 'button';
+      button.className = MARKDOWN_COPY_BUTTON_CLASS;
+      const blockId = block.getAttribute(MARKDOWN_CODE_BLOCK_ATTR) ?? '';
+      button.setAttribute(MARKDOWN_COPY_BLOCK_ATTR, blockId);
+      block.prepend(button);
+    }
+    setMarkdownCodeBlockCopiedState(block, false, t);
+  }
 }
 
 interface Props {
@@ -2148,15 +2184,20 @@ function MarkdownViewer({
   const [text, setText] = useState<string | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
   const [copied, setCopied] = useState(false);
-  const [copiedBlockId, setCopiedBlockId] = useState<string | null>(null);
+  const markdownArticleRef = useRef<HTMLElement | null>(null);
   const copyBlockTimerRef = useRef<number | null>(null);
+  const copiedMarkdownBlockRef = useRef<HTMLElement | null>(null);
   const status = file.artifactManifest?.status ?? 'complete';
   const isStreaming = status === 'streaming';
   const isError = status === 'error';
 
   useEffect(() => {
     setText(null);
-    setCopiedBlockId(null);
+    copiedMarkdownBlockRef.current = null;
+    if (copyBlockTimerRef.current) {
+      window.clearTimeout(copyBlockTimerRef.current);
+      copyBlockTimerRef.current = null;
+    }
     let cancelled = false;
     void fetchProjectFileText(projectId, file.name).then((next) => {
       if (!cancelled) setText(next ?? '');
@@ -2168,6 +2209,7 @@ function MarkdownViewer({
 
   useEffect(() => {
     return () => {
+      copiedMarkdownBlockRef.current = null;
       if (copyBlockTimerRef.current) {
         window.clearTimeout(copyBlockTimerRef.current);
       }
@@ -2186,8 +2228,17 @@ function MarkdownViewer({
   const html = useMemo(() => {
     if (text === null) return null;
     const renderPartial = MarkdownRenderer.renderPartial ?? renderMarkdownToSafeHtml;
-    return decorateMarkdownCodeBlocks(renderPartial(text), t, copiedBlockId);
-  }, [copiedBlockId, t, text]);
+    return decorateMarkdownCodeBlocks(renderPartial(text));
+  }, [text]);
+
+  useEffect(() => {
+    const article = markdownArticleRef.current;
+    if (!article) return;
+    ensureMarkdownCodeBlockControls(article, t);
+    if (copiedMarkdownBlockRef.current?.isConnected) {
+      setMarkdownCodeBlockCopiedState(copiedMarkdownBlockRef.current, true, t);
+    }
+  }, [html, t]);
 
   async function handleMarkdownBodyClick(event: ReactMouseEvent<HTMLElement>) {
     const target = event.target;
@@ -2195,18 +2246,24 @@ function MarkdownViewer({
     const button = target.closest<HTMLButtonElement>(`button[${MARKDOWN_COPY_BLOCK_ATTR}]`);
     if (!button) return;
     const block = button.closest('.markdown-code-block');
-    const codeText = block?.querySelector('pre')?.textContent ?? '';
-    if (!codeText) return;
-    const didCopy = await copyTextToClipboard(codeText);
+    if (!(block instanceof HTMLElement)) return;
+    const pre = block.querySelector('pre');
+    if (!pre) return;
+    const didCopy = await copyTextToClipboard(pre.textContent ?? '');
     if (!didCopy) return;
-    const blockId = button.getAttribute(MARKDOWN_COPY_BLOCK_ATTR);
-    if (!blockId) return;
-    setCopiedBlockId(blockId);
+    if (copiedMarkdownBlockRef.current && copiedMarkdownBlockRef.current !== block) {
+      setMarkdownCodeBlockCopiedState(copiedMarkdownBlockRef.current, false, t);
+    }
+    copiedMarkdownBlockRef.current = block;
+    setMarkdownCodeBlockCopiedState(block, true, t);
     if (copyBlockTimerRef.current) {
       window.clearTimeout(copyBlockTimerRef.current);
     }
     copyBlockTimerRef.current = window.setTimeout(() => {
-      setCopiedBlockId(null);
+      if (copiedMarkdownBlockRef.current) {
+        setMarkdownCodeBlockCopiedState(copiedMarkdownBlockRef.current, false, t);
+      }
+      copiedMarkdownBlockRef.current = null;
       copyBlockTimerRef.current = null;
     }, 1800);
   }
@@ -2248,6 +2305,7 @@ function MarkdownViewer({
             {isError ? <div className="markdown-status markdown-status-error">{t('fileViewer.markdownErrorStatus')}</div> : null}
             {/* Safe by contract: renderMarkdownToSafeHtml escapes raw HTML and rejects unsafe link protocols. */}
             <article
+              ref={markdownArticleRef}
               className="markdown-rendered"
               onClick={(event) => void handleMarkdownBodyClick(event)}
               dangerouslySetInnerHTML={{ __html: html }}

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from 'react';
 import { MarkdownRenderer, artifactRendererRegistry } from '../artifacts/renderer-registry';
 import { renderMarkdownToSafeHtml } from '../artifacts/markdown';
 import { useT } from '../i18n';
@@ -43,6 +43,44 @@ type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => 
 type SlideState = { active: number; count: number };
 
 const htmlPreviewSlideState = new Map<string, SlideState>();
+const MARKDOWN_COPY_BLOCK_ATTR = 'data-copy-code-block';
+
+async function copyTextToClipboard(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    ta.style.position = 'fixed';
+    ta.style.opacity = '0';
+    document.body.appendChild(ta);
+    ta.select();
+    try {
+      return document.execCommand('copy');
+    } finally {
+      document.body.removeChild(ta);
+    }
+  }
+}
+
+function decorateMarkdownCodeBlocks(html: string, t: TranslateFn, copiedBlockId: string | null): string {
+  let blockIndex = 0;
+  return html.replace(/<pre\b([^>]*)>([\s\S]*?)<\/pre>/g, (_match, attrs: string, content: string) => {
+    const blockId = String(blockIndex++);
+    const copied = copiedBlockId === blockId;
+    const label = copied ? t('fileViewer.copied') : t('fileViewer.copy');
+    const toast = copied
+      ? `<span class="markdown-code-toast" role="status" aria-live="polite">${t('fileViewer.copied')}</span>`
+      : '';
+    return (
+      `<div class="markdown-code-block">` +
+      `<button type="button" class="markdown-code-copy" ${MARKDOWN_COPY_BLOCK_ATTR}="${blockId}" title="${t('fileViewer.copyTitle')}" aria-label="${label}">` +
+      `${label}</button>` +
+      `${toast}<pre${attrs}>${content}</pre></div>`
+    );
+  });
+}
 
 interface Props {
   projectId: string;
@@ -2110,12 +2148,15 @@ function MarkdownViewer({
   const [text, setText] = useState<string | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
   const [copied, setCopied] = useState(false);
+  const [copiedBlockId, setCopiedBlockId] = useState<string | null>(null);
+  const copyBlockTimerRef = useRef<number | null>(null);
   const status = file.artifactManifest?.status ?? 'complete';
   const isStreaming = status === 'streaming';
   const isError = status === 'error';
 
   useEffect(() => {
     setText(null);
+    setCopiedBlockId(null);
     let cancelled = false;
     void fetchProjectFileText(projectId, file.name).then((next) => {
       if (!cancelled) setText(next ?? '');
@@ -2125,34 +2166,50 @@ function MarkdownViewer({
     };
   }, [projectId, file.name, file.mtime, reloadKey]);
 
+  useEffect(() => {
+    return () => {
+      if (copyBlockTimerRef.current) {
+        window.clearTimeout(copyBlockTimerRef.current);
+      }
+    };
+  }, []);
+
   async function copy() {
     if (text == null) return;
-    try {
-      await navigator.clipboard.writeText(text);
+    const didCopy = await copyTextToClipboard(text);
+    if (didCopy) {
       setCopied(true);
       window.setTimeout(() => setCopied(false), 1500);
-    } catch {
-      const ta = document.createElement('textarea');
-      ta.value = text;
-      ta.style.position = 'fixed';
-      ta.style.opacity = '0';
-      document.body.appendChild(ta);
-      ta.select();
-      try {
-        document.execCommand('copy');
-        setCopied(true);
-        window.setTimeout(() => setCopied(false), 1500);
-      } finally {
-        document.body.removeChild(ta);
-      }
     }
   }
 
   const html = useMemo(() => {
     if (text === null) return null;
     const renderPartial = MarkdownRenderer.renderPartial ?? renderMarkdownToSafeHtml;
-    return renderPartial(text);
-  }, [text]);
+    return decorateMarkdownCodeBlocks(renderPartial(text), t, copiedBlockId);
+  }, [copiedBlockId, t, text]);
+
+  async function handleMarkdownBodyClick(event: ReactMouseEvent<HTMLElement>) {
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    const button = target.closest<HTMLButtonElement>(`button[${MARKDOWN_COPY_BLOCK_ATTR}]`);
+    if (!button) return;
+    const block = button.closest('.markdown-code-block');
+    const codeText = block?.querySelector('pre')?.textContent ?? '';
+    if (!codeText) return;
+    const didCopy = await copyTextToClipboard(codeText);
+    if (!didCopy) return;
+    const blockId = button.getAttribute(MARKDOWN_COPY_BLOCK_ATTR);
+    if (!blockId) return;
+    setCopiedBlockId(blockId);
+    if (copyBlockTimerRef.current) {
+      window.clearTimeout(copyBlockTimerRef.current);
+    }
+    copyBlockTimerRef.current = window.setTimeout(() => {
+      setCopiedBlockId(null);
+      copyBlockTimerRef.current = null;
+    }, 1800);
+  }
 
   return (
     <div className="viewer text-viewer">
@@ -2192,6 +2249,7 @@ function MarkdownViewer({
             {/* Safe by contract: renderMarkdownToSafeHtml escapes raw HTML and rejects unsafe link protocols. */}
             <article
               className="markdown-rendered"
+              onClick={(event) => void handleMarkdownBodyClick(event)}
               dangerouslySetInnerHTML={{ __html: html }}
             />
           </>

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -53,6 +53,7 @@ async function copyTextToClipboard(text: string): Promise<boolean> {
     await navigator.clipboard.writeText(text);
     return true;
   } catch {
+    const priorFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
     const ta = document.createElement('textarea');
     ta.value = text;
     ta.style.position = 'fixed';
@@ -65,6 +66,13 @@ async function copyTextToClipboard(text: string): Promise<boolean> {
       return false;
     } finally {
       document.body.removeChild(ta);
+      if (priorFocus?.isConnected) {
+        try {
+          priorFocus.focus({ preventScroll: true });
+        } catch {
+          priorFocus.focus();
+        }
+      }
     }
   }
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4366,12 +4366,64 @@ code {
   color: var(--text-muted);
   background: var(--bg-panel);
 }
+.markdown-code-block {
+  position: relative;
+}
+.markdown-code-copy {
+  position: absolute;
+  top: 18px;
+  right: 18px;
+  z-index: 1;
+  border: 1px solid var(--border-soft);
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--bg-panel) 92%, black 8%);
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  padding: 7px 10px;
+  cursor: pointer;
+  opacity: 0;
+  transform: translateY(-2px);
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease,
+    color 120ms ease,
+    border-color 120ms ease,
+    background 120ms ease;
+}
+.markdown-code-block:hover .markdown-code-copy,
+.markdown-code-block:focus-within .markdown-code-copy {
+  opacity: 1;
+  transform: translateY(0);
+}
+.markdown-code-copy:hover,
+.markdown-code-copy:focus-visible {
+  color: var(--text);
+  border-color: var(--border);
+  background: var(--bg-elevated, var(--bg));
+}
+.markdown-code-toast {
+  position: absolute;
+  top: 18px;
+  right: 82px;
+  z-index: 1;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--accent) 18%, var(--bg-panel));
+  color: var(--text);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  padding: 7px 10px;
+  box-shadow: 0 10px 26px color-mix(in oklab, var(--accent) 18%, transparent);
+}
 .markdown-rendered pre {
   margin: 12px 0;
   background: var(--bg-panel);
   border: 1px solid var(--border-soft);
   border-radius: 8px;
-  padding: 12px;
+  padding: 40px 12px 12px;
   overflow: auto;
 }
 .markdown-rendered code {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4398,6 +4398,12 @@ code {
   opacity: 1;
   transform: translateY(0);
 }
+@media (hover: none) {
+  .markdown-code-copy {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
 .markdown-code-copy:hover,
 .markdown-code-copy:focus-visible {
   color: var(--text);

--- a/e2e/tests/file-viewer-markdown-copy.test.tsx
+++ b/e2e/tests/file-viewer-markdown-copy.test.tsx
@@ -18,6 +18,7 @@ vi.mock('../../apps/web/src/providers/registry', async () => {
 const mockedFetchProjectFileText = vi.mocked(fetchProjectFileText);
 let writeTextMock: ReturnType<typeof vi.fn>;
 let originalClipboard: PropertyDescriptor | undefined;
+let originalExecCommand: PropertyDescriptor | undefined;
 
 function baseFile(overrides: Partial<ProjectFile> = {}): ProjectFile {
   return {
@@ -43,6 +44,7 @@ function baseFile(overrides: Partial<ProjectFile> = {}): ProjectFile {
 describe('FileViewer markdown code block copy', () => {
   beforeEach(() => {
     originalClipboard = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+    originalExecCommand = Object.getOwnPropertyDescriptor(document, 'execCommand');
     mockedFetchProjectFileText.mockResolvedValue('```ts\nconsole.log("copied")\n```');
     writeTextMock = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, 'clipboard', {
@@ -58,6 +60,11 @@ describe('FileViewer markdown code block copy', () => {
       Object.defineProperty(navigator, 'clipboard', originalClipboard);
     } else {
       delete (navigator as { clipboard?: Clipboard }).clipboard;
+    }
+    if (originalExecCommand) {
+      Object.defineProperty(document, 'execCommand', originalExecCommand);
+    } else {
+      delete (document as Document & { execCommand?: typeof document.execCommand }).execCommand;
     }
     cleanup();
     vi.clearAllMocks();

--- a/e2e/tests/file-viewer-markdown-copy.test.tsx
+++ b/e2e/tests/file-viewer-markdown-copy.test.tsx
@@ -1,0 +1,79 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FileViewer } from '../../apps/web/src/components/FileViewer';
+import type { ProjectFile } from '../../apps/web/src/types';
+import { fetchProjectFileText } from '../../apps/web/src/providers/registry';
+
+vi.mock('../../apps/web/src/providers/registry', async () => {
+  const actual = await vi.importActual<typeof import('../../apps/web/src/providers/registry')>(
+    '../../apps/web/src/providers/registry',
+  );
+  return {
+    ...actual,
+    fetchProjectFileText: vi.fn(),
+  };
+});
+
+const mockedFetchProjectFileText = vi.mocked(fetchProjectFileText);
+let writeTextMock: ReturnType<typeof vi.fn>;
+
+function baseFile(overrides: Partial<ProjectFile> = {}): ProjectFile {
+  return {
+    name: 'notes.md',
+    path: 'notes.md',
+    type: 'file',
+    size: 256,
+    mtime: 1710000000,
+    kind: 'text',
+    mime: 'text/markdown',
+    artifactManifest: {
+      version: 1,
+      kind: 'markdown-document',
+      title: 'Notes',
+      entry: 'notes.md',
+      renderer: 'markdown',
+      exports: ['md'],
+    },
+    ...overrides,
+  };
+}
+
+describe('FileViewer markdown code block copy', () => {
+  beforeEach(() => {
+    mockedFetchProjectFileText.mockResolvedValue('```ts\nconsole.log("copied")\n```');
+    writeTextMock = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: writeTextMock,
+      },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('copies fenced code blocks from the markdown preview', async () => {
+    const { container } = render(<FileViewer projectId="project-1" file={baseFile()} />);
+
+    await waitFor(() => {
+      expect(container.querySelector('.markdown-code-copy')).toBeTruthy();
+    });
+    const copyButton = container.querySelector('.markdown-code-copy') as HTMLButtonElement;
+    expect(copyButton.tagName).toBe('BUTTON');
+
+    fireEvent.click(copyButton);
+
+    await waitFor(() => {
+      expect(writeTextMock).toHaveBeenCalledWith('console.log("copied")');
+    });
+    await waitFor(() => {
+      const updatedButton = container.querySelector('.markdown-code-copy');
+      expect(updatedButton?.getAttribute('aria-label')).toBe('Copied!');
+    });
+    expect(screen.getByRole('status').textContent).toBe('Copied!');
+  });
+});

--- a/e2e/tests/file-viewer-markdown-copy.test.tsx
+++ b/e2e/tests/file-viewer-markdown-copy.test.tsx
@@ -17,6 +17,7 @@ vi.mock('../../apps/web/src/providers/registry', async () => {
 
 const mockedFetchProjectFileText = vi.mocked(fetchProjectFileText);
 let writeTextMock: ReturnType<typeof vi.fn>;
+let originalClipboard: PropertyDescriptor | undefined;
 
 function baseFile(overrides: Partial<ProjectFile> = {}): ProjectFile {
   return {
@@ -41,6 +42,7 @@ function baseFile(overrides: Partial<ProjectFile> = {}): ProjectFile {
 
 describe('FileViewer markdown code block copy', () => {
   beforeEach(() => {
+    originalClipboard = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
     mockedFetchProjectFileText.mockResolvedValue('```ts\nconsole.log("copied")\n```');
     writeTextMock = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, 'clipboard', {
@@ -52,6 +54,11 @@ describe('FileViewer markdown code block copy', () => {
   });
 
   afterEach(() => {
+    if (originalClipboard) {
+      Object.defineProperty(navigator, 'clipboard', originalClipboard);
+    } else {
+      delete (navigator as { clipboard?: Clipboard }).clipboard;
+    }
     cleanup();
     vi.clearAllMocks();
   });
@@ -65,15 +72,32 @@ describe('FileViewer markdown code block copy', () => {
     const copyButton = container.querySelector('.markdown-code-copy') as HTMLButtonElement;
     expect(copyButton.tagName).toBe('BUTTON');
 
+    copyButton.focus();
+    expect(copyButton).toBe(document.activeElement);
     fireEvent.click(copyButton);
 
     await waitFor(() => {
       expect(writeTextMock).toHaveBeenCalledWith('console.log("copied")');
     });
+    expect(copyButton).toBe(document.activeElement);
     await waitFor(() => {
-      const updatedButton = container.querySelector('.markdown-code-copy');
-      expect(updatedButton?.getAttribute('aria-label')).toBe('Copied!');
+      expect(copyButton.getAttribute('aria-label')).toBe('Copied!');
     });
     expect(screen.getByRole('status').textContent).toBe('Copied!');
+  });
+
+  it('copies empty fenced code blocks instead of treating the button as broken', async () => {
+    mockedFetchProjectFileText.mockResolvedValue('```ts\n```');
+    const { container } = render(<FileViewer projectId="project-1" file={baseFile()} />);
+
+    await waitFor(() => {
+      expect(container.querySelector('.markdown-code-copy')).toBeTruthy();
+    });
+    const copyButton = container.querySelector('.markdown-code-copy') as HTMLButtonElement;
+    fireEvent.click(copyButton);
+
+    await waitFor(() => {
+      expect(writeTextMock).toHaveBeenCalledWith('');
+    });
   });
 });

--- a/e2e/tests/file-viewer-markdown-copy.test.tsx
+++ b/e2e/tests/file-viewer-markdown-copy.test.tsx
@@ -100,4 +100,28 @@ describe('FileViewer markdown code block copy', () => {
       expect(writeTextMock).toHaveBeenCalledWith('');
     });
   });
+
+  it('restores focus when the Clipboard API fails and the execCommand fallback succeeds', async () => {
+    writeTextMock.mockRejectedValueOnce(new Error('clipboard unavailable'));
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      value: vi.fn().mockReturnValue(true),
+    });
+    const execCommandSpy = vi.mocked(document.execCommand);
+    const { container } = render(<FileViewer projectId="project-1" file={baseFile()} />);
+
+    await waitFor(() => {
+      expect(container.querySelector('.markdown-code-copy')).toBeTruthy();
+    });
+    const copyButton = container.querySelector('.markdown-code-copy') as HTMLButtonElement;
+    copyButton.focus();
+    expect(copyButton).toBe(document.activeElement);
+
+    fireEvent.click(copyButton);
+
+    await waitFor(() => {
+      expect(execCommandSpy).toHaveBeenCalledWith('copy');
+    });
+    expect(copyButton).toBe(document.activeElement);
+  });
 });


### PR DESCRIPTION
## Summary
- add a copy button to each markdown code block rendered in `FileViewer`
- reuse the existing clipboard fallback path and show inline copied feedback per block
- add regression coverage for copying fenced code blocks from the markdown preview

## Testing
- `pnpm --filter @open-design/e2e test -- file-viewer-markdown-copy.test.tsx`
- `pnpm --filter @open-design/web test -- FileViewer.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/daemon build`
- `pnpm --filter @open-design/e2e typecheck`

## Notes
- Root `pnpm typecheck` is currently blocked by an existing `apps/packaged` typecheck failure: `Cannot find module @open-design/desktop/main`.
- Root `pnpm test` is currently blocked by existing daemon test timeouts in `apps/daemon/tests/project-watchers.test.ts` and `apps/daemon/tests/deploy.test.ts`.

Closes #463