### PR TITLE
fix(web): aspect ratio cards no longer overflow into siblings

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1931,6 +1931,7 @@ code {
 }
 .newproj-option-card {
   min-height: 62px;
+  min-width: 0;
   padding: 10px;
   display: flex;
   align-items: center;
@@ -1945,21 +1946,31 @@ code {
   color: var(--text-muted);
   font-size: 11px;
 }
+.aspect-grid .newproj-option-card {
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 6px;
+}
 .aspect-copy {
   display: flex;
   flex-direction: column;
   gap: 2px;
   align-items: center;
   line-height: 1.15;
+  min-width: 0;
+  max-width: 100%;
 }
 .aspect-copy strong {
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: 12.5px;
   font-weight: 650;
+  letter-spacing: -0.005em;
+  max-width: 100%;
+  overflow-wrap: anywhere;
 }
 .aspect-copy small {
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: 11.5px;
 }
 .aspect-glyph {
   flex: none;
@@ -1969,11 +1980,11 @@ code {
   background: var(--bg-subtle);
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--border) 80%, transparent);
 }
-.aspect-1-1 { width: 26px; height: 26px; }
-.aspect-16-9 { width: 36px; height: 20px; }
-.aspect-9-16 { width: 20px; height: 36px; }
-.aspect-4-3 { width: 32px; height: 24px; }
-.aspect-3-4 { width: 24px; height: 32px; }
+.aspect-1-1 { width: 22px; height: 22px; }
+.aspect-16-9 { width: 32px; height: 18px; }
+.aspect-9-16 { width: 18px; height: 32px; }
+.aspect-4-3 { width: 28px; height: 21px; }
+.aspect-3-4 { width: 21px; height: 28px; }
 @media (max-width: 560px) {
   .newproj-model-grid,
   .newproj-option-grid,


### PR DESCRIPTION
## Summary

Fixes #242 — in the **Image** tab of the New Project panel, the aspect ratio cards rendered with overlapping glyphs and labels.

### Root cause

The 380px `.entry-side` gives the 3-column `.aspect-grid` only ~92px per cell. The previous flex-row card layout reserved 34px for the glyph plus 7px gap, leaving ~31px for the label — but `<strong>Landscape</strong>` / `<strong>Portrait</strong>` at 13px / weight 650 are ~75px wide. Without `min-width: 0` on the flex/grid items, the strong text refused to shrink and overflowed the card; each card's label visually covered the next card's glyph.

The `@media (max-width: 560px)` breakpoint that drops the grid to 2 columns never fires because the sidebar is fixed at 380px while the **viewport** is usually well above 560px.

### Fix

- Switch `.aspect-grid .newproj-option-card` to a column layout (glyph above, label+ratio below) so the label has the full card width.
- Add the missing `min-width: 0` on `.newproj-option-card` and `.aspect-copy` as a defense against future long-text regressions.
- Rebalance glyph dimensions and font sizes (`.aspect-copy strong` 13 → 12.5, `small` 12 → 11.5) to match the tighter cards.

No TypeScript or markup changes — pure CSS.

## Before / after

| Before (from #242) | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/ce056110-a084-44ba-a8b0-96bd2cf9282f" width="360"> | <img src="https://github.com/user-attachments/assets/2a751ebb-fac9-475d-b740-d5481ddacff4" width="360"> |

## Test plan

- [x] Visually verified in Chrome via `pnpm tools-dev` (web at `127.0.0.1:62748`) — aspect cards now render as 3+2 grid with glyph on top and `Square / Landscape / Portrait / Wide / Tall` labels intact.
- [x] `pnpm --filter @open-design/web typecheck` — passes.
- [ ] Reviewer to spot-check on Windows / Linux Chrome at default zoom.
