### PR TITLE
fix: path traversal in readDesignSystem

### DIFF
--- a/apps/daemon/src/design-systems.ts
+++ b/apps/daemon/src/design-systems.ts
@@ -6,6 +6,7 @@
 
 import { readdir, readFile, stat } from 'node:fs/promises';
 import path from 'node:path';
+import { isSafeResourceId } from './resource-id.js';
 
 export async function listDesignSystems(root) {
   const out = [];
@@ -41,9 +42,7 @@ export async function listDesignSystems(root) {
 }
 
 export async function readDesignSystem(root, id) {
-  if (!id || typeof id !== 'string' || /[/\\]/.test(id) || id === '..' || id === '.') {
-    return null;
-  }
+  if (!isSafeResourceId(id)) return null;
   const file = path.join(root, id, 'DESIGN.md');
   try {
     return await readFile(file, 'utf8');

--- a/apps/daemon/src/design-systems.ts
+++ b/apps/daemon/src/design-systems.ts
@@ -41,6 +41,9 @@ export async function listDesignSystems(root) {
 }
 
 export async function readDesignSystem(root, id) {
+  if (!id || typeof id !== 'string' || /[/\\]/.test(id) || id === '..' || id === '.') {
+    return null;
+  }
   const file = path.join(root, id, 'DESIGN.md');
   try {
     return await readFile(file, 'utf8');

--- a/apps/daemon/src/prompt-templates.ts
+++ b/apps/daemon/src/prompt-templates.ts
@@ -10,6 +10,7 @@
 
 import { readdir, readFile, stat } from 'node:fs/promises';
 import path from 'node:path';
+import { isSafeResourceId } from './resource-id.js';
 
 const SUPPORTED_SURFACES = ['image', 'video'];
 
@@ -52,6 +53,7 @@ export async function listPromptTemplates(root) {
 
 export async function readPromptTemplate(root, surface, id) {
   if (!SUPPORTED_SURFACES.includes(surface)) return null;
+  if (!isSafeResourceId(id)) return null;
   const filePath = path.join(root, surface, `${id}.json`);
   try {
     const raw = await readFile(filePath, 'utf8');

--- a/apps/daemon/src/resource-id.ts
+++ b/apps/daemon/src/resource-id.ts
@@ -1,0 +1,6 @@
+export function isSafeResourceId(id: unknown): id is string {
+  if (typeof id !== 'string') return false;
+  if (id.length === 0 || id.length > 128) return false;
+  if (/^\.+$/.test(id)) return false;
+  return /^[A-Za-z0-9._-]+$/.test(id);
+}

--- a/apps/daemon/tests/static-resource-paths.test.ts
+++ b/apps/daemon/tests/static-resource-paths.test.ts
@@ -1,0 +1,63 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { readDesignSystem } from '../src/design-systems.js';
+import { readPromptTemplate } from '../src/prompt-templates.js';
+
+let tempRoot: string;
+
+beforeEach(async () => {
+  tempRoot = await mkdtemp(path.join(os.tmpdir(), 'od-static-resource-paths-'));
+});
+
+afterEach(async () => {
+  await rm(tempRoot, { recursive: true, force: true });
+});
+
+describe('static resource path guards', () => {
+  it('rejects design-system ids that are not single safe path segments', async () => {
+    const root = path.join(tempRoot, 'design-systems');
+    await mkdir(path.join(root, 'demo'), { recursive: true });
+    await writeFile(path.join(root, 'demo', 'DESIGN.md'), '# Demo\n');
+    await writeFile(path.join(tempRoot, 'DESIGN.md'), '# Outside\n');
+
+    await expect(readDesignSystem(root, 'demo')).resolves.toBe('# Demo\n');
+    await expect(readDesignSystem(root, '..')).resolves.toBeNull();
+    await expect(readDesignSystem(root, '...')).resolves.toBeNull();
+    await expect(readDesignSystem(root, '../outside')).resolves.toBeNull();
+    await expect(readDesignSystem(root, 'nested/demo')).resolves.toBeNull();
+  });
+
+  it('rejects prompt-template ids that can traverse out of their surface folder', async () => {
+    const root = path.join(tempRoot, 'prompt-templates');
+    await mkdir(path.join(root, 'image'), { recursive: true });
+    await writeFile(
+      path.join(root, 'image', 'demo.json'),
+      JSON.stringify({
+        id: 'demo',
+        surface: 'image',
+        title: 'Demo prompt',
+        prompt: 'A detailed prompt body long enough to be accepted.',
+        source: { repo: 'open-design/test', license: 'MIT' },
+      }),
+    );
+    await writeFile(
+      path.join(root, 'secret.json'),
+      JSON.stringify({
+        id: 'secret',
+        surface: 'image',
+        title: 'Secret prompt',
+        prompt: 'This template lives outside the image folder.',
+        source: { repo: 'open-design/test', license: 'MIT' },
+      }),
+    );
+
+    await expect(readPromptTemplate(root, 'image', 'demo')).resolves.toMatchObject({
+      id: 'demo',
+    });
+    await expect(readPromptTemplate(root, 'image', '../secret')).resolves.toBeNull();
+    await expect(readPromptTemplate(root, 'image', '..\\secret')).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Validates the `id` parameter in `readDesignSystem()` to reject path traversal attempts

## Problem
`readDesignSystem()` in `apps/daemon/src/design-systems.ts` passes the `id` parameter directly into `path.join(root, id, 'DESIGN.md')` without any validation. An attacker can supply `id = "../../etc"` to read arbitrary files on disk. Unlike `projects.ts` which uses `isSafeId()` validation, this function had no input sanitization.

## Fix
Add a guard that rejects ids containing `/` or `\` path separators, or dot segments (`..`, `.`).

## Test plan
- [ ] `GET /api/design-systems/..%2F..%2Fetc` should return null or error
- [ ] `GET /api/design-systems/valid-id` should still return DESIGN.md content

🤖 Generated with [Claude Code](https://claude.com/claude-code)