### PR TITLE
fix: skip symlinks in file listing and archive generation

### DIFF
--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -7,7 +7,7 @@
 // All paths flowing in from HTTP handlers are validated against the project
 // directory to prevent path traversal — see resolveSafe().
 
-import { lstat, mkdir, readdir, readFile, rm, stat, unlink, writeFile } from 'node:fs/promises';
+import { lstat, mkdir, readdir, readFile, realpath, rm, stat, unlink, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import JSZip from 'jszip';
 import {
@@ -56,8 +56,9 @@ async function collectFiles(dir, relDir, out) {
     try {
       const ls = await lstat(full);
       if (ls.isSymbolicLink()) continue;
-    } catch {
-      continue;
+    } catch (err) {
+      if (err && err.code === 'ENOENT') continue;
+      throw err;
     }
     const rel = relDir ? `${relDir}/${e.name}` : e.name;
     if (e.isDirectory()) {
@@ -93,7 +94,7 @@ export async function buildProjectArchive(projectsRoot, projectId, root) {
   let archiveRoot = projectRoot;
   let archiveBaseName = '';
   if (typeof root === 'string' && root.trim().length > 0) {
-    archiveRoot = resolveSafe(projectRoot, root);
+    archiveRoot = await resolveSafeReal(projectRoot, root);
     archiveBaseName = path.basename(archiveRoot);
   }
 
@@ -278,8 +279,9 @@ async function collectArchiveEntries(dir, relDir, out) {
     try {
       const ls = await lstat(full);
       if (ls.isSymbolicLink()) continue;
-    } catch {
-      continue;
+    } catch (err) {
+      if (err && err.code === 'ENOENT') continue;
+      throw err;
     }
     const rel = relDir ? `${relDir}/${e.name}` : e.name;
     if (e.isDirectory()) {
@@ -294,10 +296,11 @@ async function collectArchiveEntries(dir, relDir, out) {
 
 export async function readProjectFile(projectsRoot, projectId, name) {
   const dir = projectDir(projectsRoot, projectId);
-  const file = resolveSafe(dir, name);
+  const rootReal = await realpath(dir).catch(() => dir);
+  const file = await resolveSafeReal(dir, name);
   const buf = await readFile(file);
   const st = await stat(file);
-  const rel = toProjectPath(path.relative(dir, file));
+  const rel = toProjectPath(path.relative(rootReal, file));
   const manifest = await readManifestForPath(dir, rel);
   return {
     buffer: buf,
@@ -395,6 +398,22 @@ function resolveSafe(dir, name) {
     throw new Error('path escapes project dir');
   }
   return target;
+}
+
+async function resolveSafeReal(dir, name) {
+  const target = resolveSafe(dir, name);
+  const rootReal = await realpath(dir).catch(() => dir);
+  let targetReal;
+  try {
+    targetReal = await realpath(target);
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return target;
+    throw err;
+  }
+  if (!targetReal.startsWith(rootReal + path.sep) && targetReal !== rootReal) {
+    throw new Error('path escapes project dir via symlink');
+  }
+  return targetReal;
 }
 
 export function sanitizePath(raw) {

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -7,7 +7,8 @@
 // All paths flowing in from HTTP handlers are validated against the project
 // directory to prevent path traversal — see resolveSafe().
 
-import { lstat, mkdir, readdir, readFile, realpath, rm, stat, unlink, writeFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import { lstat, mkdir, open, readdir, readFile, realpath, rm, stat, unlink, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import JSZip from 'jszip';
 import {
@@ -129,9 +130,9 @@ export async function buildProjectArchive(projectsRoot, projectId, root) {
 
   const zip = new JSZip();
   for (const entry of entries) {
-    const buf = await readFile(entry.fullPath);
+    const { buffer: buf, mtime } = await readArchiveEntry(entry.fullPath);
     zip.file(entry.relPath, buf, {
-      date: new Date(entry.mtime),
+      date: new Date(mtime),
       binary: true,
     });
   }
@@ -291,6 +292,27 @@ async function collectArchiveEntries(dir, relDir, out) {
     if (e.name.endsWith('.artifact.json')) continue;
     const st = await stat(full);
     out.push({ relPath: rel, fullPath: full, mtime: st.mtimeMs });
+  }
+}
+
+async function readArchiveEntry(filePath) {
+  const beforeOpen = await lstat(filePath);
+  if (beforeOpen.isSymbolicLink()) {
+    throw new Error('archive entry is a symlink');
+  }
+  if (!beforeOpen.isFile()) {
+    throw new Error('archive entry is not a regular file');
+  }
+  const noFollow = typeof constants.O_NOFOLLOW === 'number' ? constants.O_NOFOLLOW : 0;
+  const handle = await open(filePath, constants.O_RDONLY | noFollow);
+  try {
+    const opened = await handle.stat();
+    if (!opened.isFile()) {
+      throw new Error('archive entry is not a regular file');
+    }
+    return { buffer: await handle.readFile(), mtime: opened.mtimeMs };
+  } finally {
+    await handle.close();
   }
 }
 

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -52,8 +52,14 @@ async function collectFiles(dir, relDir, out) {
   }
   for (const e of entries) {
     if (e.name.startsWith('.')) continue;
-    const rel = relDir ? `${relDir}/${e.name}` : e.name;
     const full = path.join(dir, e.name);
+    try {
+      const ls = await lstat(full);
+      if (ls.isSymbolicLink()) continue;
+    } catch {
+      continue;
+    }
+    const rel = relDir ? `${relDir}/${e.name}` : e.name;
     if (e.isDirectory()) {
       await collectFiles(full, rel, out);
       continue;
@@ -268,8 +274,14 @@ async function collectArchiveEntries(dir, relDir, out) {
   for (const e of entries) {
     if (e.name.startsWith('.')) continue;
     if (!e.isDirectory() && !e.isFile()) continue;
-    const rel = relDir ? `${relDir}/${e.name}` : e.name;
     const full = path.join(dir, e.name);
+    try {
+      const ls = await lstat(full);
+      if (ls.isSymbolicLink()) continue;
+    } catch {
+      continue;
+    }
+    const rel = relDir ? `${relDir}/${e.name}` : e.name;
     if (e.isDirectory()) {
       await collectArchiveEntries(full, rel, out);
       continue;

--- a/apps/daemon/tests/project-archive.test.ts
+++ b/apps/daemon/tests/project-archive.test.ts
@@ -1,11 +1,11 @@
 import { mkdtempSync, rmSync } from 'node:fs';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import JSZip from 'jszip';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { buildProjectArchive } from '../src/projects.js';
+import { buildProjectArchive, readProjectFile } from '../src/projects.js';
 
 describe('buildProjectArchive', () => {
   let projectsRoot = '';
@@ -85,5 +85,53 @@ describe('buildProjectArchive', () => {
     expect(baseName).toBe(dirName);
     const zip = await JSZip.loadAsync(buffer);
     expect(Object.keys(zip.files)).toContain('index.html');
+  });
+
+  it('omits symlinks from full project archives', async () => {
+    const outside = path.join(projectsRoot, 'outside');
+    await mkdir(outside);
+    await writeFile(path.join(outside, 'secret.txt'), 'secret');
+    try {
+      await symlink(outside, path.join(projectsRoot, projectId, 'leak'), 'dir');
+    } catch {
+      return;
+    }
+
+    const { buffer } = await buildProjectArchive(projectsRoot, projectId, '');
+    const zip = await JSZip.loadAsync(buffer);
+    const fileEntries = Object.values(zip.files)
+      .filter((entry) => !entry.dir)
+      .map((entry) => entry.name);
+
+    expect(fileEntries.some((name) => name.includes('secret.txt'))).toBe(false);
+  });
+
+  it('rejects an archive root that escapes through a symlink', async () => {
+    const outside = path.join(projectsRoot, 'outside-root');
+    await mkdir(outside);
+    await writeFile(path.join(outside, 'secret.txt'), 'secret');
+    try {
+      await symlink(outside, path.join(projectsRoot, projectId, 'root-link'), 'dir');
+    } catch {
+      return;
+    }
+
+    await expect(buildProjectArchive(projectsRoot, projectId, 'root-link')).rejects.toThrow(
+      /symlink/,
+    );
+  });
+
+  it('rejects direct file reads that escape through a symlink', async () => {
+    const outside = path.join(projectsRoot, 'outside-file.txt');
+    await writeFile(outside, 'secret');
+    try {
+      await symlink(outside, path.join(projectsRoot, projectId, 'leak.txt'));
+    } catch {
+      return;
+    }
+
+    await expect(readProjectFile(projectsRoot, projectId, 'leak.txt')).rejects.toThrow(
+      /symlink/,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Adds `lstat` checks to skip symbolic links in `collectFiles()` and `collectArchiveEntries()`

## Problem
Both `collectFiles` (used by `GET /api/projects/:id/files`) and `collectArchiveEntries` (used by project archive ZIP downloads) use `Dirent.isDirectory()` which follows symlinks. A symlink placed inside a project directory that points to an arbitrary location (e.g. `/etc`) would be followed, leaking files outside the project tree in file listings and archive downloads.

## Fix
Use `lstat` to detect symbolic links before recursing or including entries. Symlinks are silently skipped.

## Test plan
- [ ] Create a symlink inside a project directory: `ln -s /etc/project-secrets .od/projects/<id>/leak`
- [ ] `GET /api/projects/<id>/files` should NOT include files from the symlink target
- [ ] Archive download should NOT include files from the symlink target

🤖 Generated with [Claude Code](https://claude.com/claude-code)