### PR TITLE
fix: remove dead ternary in WORKSPACE_ROOT resolution

### DIFF
--- a/tools/dev/src/config.ts
+++ b/tools/dev/src/config.ts
@@ -20,7 +20,7 @@ import {
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-export const WORKSPACE_ROOT = path.resolve(__dirname, "../..");
+export const WORKSPACE_ROOT = path.resolve(__dirname, "../../..");
 
 export const ALL_APPS = [APP_KEYS.DAEMON, APP_KEYS.WEB, APP_KEYS.DESKTOP] as const;
 export const DEFAULT_START_APPS = [APP_KEYS.DAEMON, APP_KEYS.WEB, APP_KEYS.DESKTOP] as const;

--- a/tools/dev/src/config.ts
+++ b/tools/dev/src/config.ts
@@ -19,9 +19,8 @@ import {
 } from "@open-design/sidecar";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const ENTRY_DIR_NAME = path.basename(__dirname);
 
-export const WORKSPACE_ROOT = path.resolve(__dirname, ENTRY_DIR_NAME === "dist" ? "../../.." : "../../..");
+export const WORKSPACE_ROOT = path.resolve(__dirname, "../..");
 
 export const ALL_APPS = [APP_KEYS.DAEMON, APP_KEYS.WEB, APP_KEYS.DESKTOP] as const;
 export const DEFAULT_START_APPS = [APP_KEYS.DAEMON, APP_KEYS.WEB, APP_KEYS.DESKTOP] as const;

--- a/tools/pack/src/config.ts
+++ b/tools/pack/src/config.ts
@@ -11,7 +11,7 @@ import { resolveNamespace } from "@open-design/sidecar";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-export const WORKSPACE_ROOT = resolve(__dirname, "../..");
+export const WORKSPACE_ROOT = resolve(__dirname, "../../..");
 
 export type ToolPackPlatform = "mac" | "win" | "linux";
 export type ToolPackBuildOutput = "all" | "app" | "appimage" | "dir" | "dmg" | "nsis" | "zip";

--- a/tools/pack/src/config.ts
+++ b/tools/pack/src/config.ts
@@ -10,9 +10,8 @@ import {
 import { resolveNamespace } from "@open-design/sidecar";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const ENTRY_DIR_NAME = path.basename(__dirname);
 
-export const WORKSPACE_ROOT = resolve(__dirname, ENTRY_DIR_NAME === "dist" ? "../../.." : "../../..");
+export const WORKSPACE_ROOT = resolve(__dirname, "../..");
 
 export type ToolPackPlatform = "mac" | "win" | "linux";
 export type ToolPackBuildOutput = "all" | "app" | "appimage" | "dir" | "dmg" | "nsis" | "zip";


### PR DESCRIPTION
## Summary
- Simplifies `WORKSPACE_ROOT` in `tools/dev/src/config.ts` and `tools/pack/src/config.ts` from a ternary with identical branches to a single `"../.."`
- Removes unused `ENTRY_DIR_NAME` constant from both files

## Problem
Both files contained:
```ts
ENTRY_DIR_NAME === "dist" ? "../../.." : "../../.."
```
The ternary condition checks whether the entry directory is `dist` (built) or `src` (source), but since `src/` and `dist/` are siblings at the same depth under `tools/{dev,pack}/`, both branches resolve to the same path — three levels up reaches the repo root from either. The conditional and the `ENTRY_DIR_NAME` constant were dead code that suggested a distinction where none existed.

## Test plan
- [ ] `pnpm tools-dev start` still resolves workspace root correctly
- [ ] `pnpm tools-pack` still resolves workspace root correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)