### PR TITLE
fix: cap htmlPreviewSlideState Map to prevent memory leak

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -42,7 +42,16 @@ import type { PreviewComment, PreviewCommentTarget } from '../types';
 type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => string;
 type SlideState = { active: number; count: number };
 
+const MAX_CACHED_SLIDE_STATES = 64;
 const htmlPreviewSlideState = new Map<string, SlideState>();
+
+function setSlideStateCached(key: string, state: SlideState) {
+  htmlPreviewSlideState.set(key, state);
+  if (htmlPreviewSlideState.size > MAX_CACHED_SLIDE_STATES) {
+    const oldest = htmlPreviewSlideState.keys().next().value;
+    if (oldest != null) htmlPreviewSlideState.delete(oldest);
+  }
+}
 
 interface Props {
   projectId: string;
@@ -739,7 +748,7 @@ function HtmlViewer({
       if (!data || data.type !== 'od:slide-state') return;
       if (typeof data.active !== 'number' || typeof data.count !== 'number') return;
       const next = { active: data.active, count: data.count };
-      htmlPreviewSlideState.set(previewStateKey, next);
+      setSlideStateCached(previewStateKey, next);
       setSlideState(next);
     }
     window.addEventListener('message', onMessage);


### PR DESCRIPTION
## Summary
- Adds a 64-entry cap with FIFO eviction to the `htmlPreviewSlideState` module-level Map

## Problem
`htmlPreviewSlideState` in `apps/web/src/components/FileViewer.tsx` (line 45) is a module-level `Map<string, SlideState>` keyed by `${projectId}:${fileName}`. Entries are set but never deleted. In long-lived sessions where the user opens many projects and files, this Map grows without bound, leaking memory.

## Fix
Wrap the `.set()` call in a `setSlideStateCached()` function that evicts the oldest entry when the Map exceeds 64 entries. The `.get()` calls remain unchanged — they just return `undefined` for evicted keys, which is handled gracefully (falls back to slide 0).

## Test plan
- [ ] Open many files with deck previews — slide state should still be preserved for recent files
- [ ] Verify old entries are evicted after opening >64 unique files

🤖 Generated with [Claude Code](https://claude.com/claude-code)