### PR TITLE
Add Tweaks mode for HTML previews with picker, pod selection, and batched chat attachments

### DIFF
--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -9,7 +9,6 @@ import Database from 'better-sqlite3';
 import path from 'node:path';
 import fs from 'node:fs';
 import { randomUUID } from 'node:crypto';
-import { migrateCritique } from './critique/persistence.js';
 
 let dbInstance = null;
 let dbFile = null;
@@ -171,6 +170,17 @@ function migrate(db) {
   if (!messageCols.some((c) => c.name === 'comment_attachments_json')) {
     db.exec(`ALTER TABLE messages ADD COLUMN comment_attachments_json TEXT`);
   }
+
+  const previewCommentCols = db.prepare(`PRAGMA table_info(preview_comments)`).all();
+  if (!previewCommentCols.some((c) => c.name === 'selection_kind')) {
+    db.exec(`ALTER TABLE preview_comments ADD COLUMN selection_kind TEXT`);
+  }
+  if (!previewCommentCols.some((c) => c.name === 'member_count')) {
+    db.exec(`ALTER TABLE preview_comments ADD COLUMN member_count INTEGER`);
+  }
+  if (!previewCommentCols.some((c) => c.name === 'pod_members_json')) {
+    db.exec(`ALTER TABLE preview_comments ADD COLUMN pod_members_json TEXT`);
+  }
   const deploymentCols = db.prepare(`PRAGMA table_info(deployments)`).all();
   if (!deploymentCols.some((c) => c.name === 'status')) {
     db.exec(`ALTER TABLE deployments ADD COLUMN status TEXT NOT NULL DEFAULT 'ready'`);
@@ -181,7 +191,6 @@ function migrate(db) {
   if (!deploymentCols.some((c) => c.name === 'reachable_at')) {
     db.exec(`ALTER TABLE deployments ADD COLUMN reachable_at INTEGER`);
   }
-  migrateCritique(db);
 }
 
 // ---------- deployments ----------
@@ -738,6 +747,8 @@ export function listPreviewComments(db, projectId, conversationId) {
       `SELECT id, project_id AS projectId, conversation_id AS conversationId,
               file_path AS filePath, element_id AS elementId, selector, label,
               text, position_json AS positionJson, html_hint AS htmlHint,
+              selection_kind AS selectionKind, member_count AS memberCount,
+              pod_members_json AS podMembersJson,
               note, status, created_at AS createdAt, updated_at AS updatedAt
          FROM preview_comments
         WHERE project_id = ? AND conversation_id = ?
@@ -758,6 +769,11 @@ export function upsertPreviewComment(db, projectId, conversationId, input) {
   const text = typeof target.text === 'string' ? compactWhitespace(target.text).slice(0, 160) : '';
   const htmlHint = typeof target.htmlHint === 'string' ? compactWhitespace(target.htmlHint).slice(0, 180) : '';
   const position = normalizePosition(target.position);
+  const selectionKind = target.selectionKind === 'pod' ? 'pod' : 'element';
+  const podMembers = selectionKind === 'pod' ? normalizePodMembers(target.podMembers) : [];
+  const memberCount = selectionKind === 'pod'
+    ? Math.max(podMembers.length, Number.isFinite(target.memberCount) ? Math.round(target.memberCount) : 0)
+    : 0;
   const now = Date.now();
   const existing = db
     .prepare(
@@ -771,14 +787,18 @@ export function upsertPreviewComment(db, projectId, conversationId, input) {
   db.prepare(
     `INSERT INTO preview_comments
        (id, project_id, conversation_id, file_path, element_id, selector, label,
-        text, position_json, html_hint, note, status, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        text, position_json, html_hint, selection_kind, member_count, pod_members_json,
+        note, status, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(project_id, conversation_id, file_path, element_id) DO UPDATE SET
        selector = excluded.selector,
        label = excluded.label,
        text = excluded.text,
        position_json = excluded.position_json,
        html_hint = excluded.html_hint,
+       selection_kind = excluded.selection_kind,
+       member_count = excluded.member_count,
+       pod_members_json = excluded.pod_members_json,
        note = excluded.note,
        status = 'open',
        updated_at = excluded.updated_at`,
@@ -793,6 +813,9 @@ export function upsertPreviewComment(db, projectId, conversationId, input) {
     text,
     JSON.stringify(position),
     htmlHint,
+    selectionKind,
+    selectionKind === 'pod' ? memberCount : null,
+    selectionKind === 'pod' ? JSON.stringify(podMembers) : null,
     note,
     'open',
     createdAt,
@@ -828,6 +851,8 @@ function getPreviewComment(db, projectId, conversationId, id) {
       `SELECT id, project_id AS projectId, conversation_id AS conversationId,
               file_path AS filePath, element_id AS elementId, selector, label,
               text, position_json AS positionJson, html_hint AS htmlHint,
+              selection_kind AS selectionKind, member_count AS memberCount,
+              pod_members_json AS podMembersJson,
               note, status, created_at AS createdAt, updated_at AS updatedAt
          FROM preview_comments
         WHERE id = ? AND project_id = ? AND conversation_id = ?`,
@@ -837,6 +862,7 @@ function getPreviewComment(db, projectId, conversationId, id) {
 }
 
 function normalizePreviewComment(row) {
+  const podMembers = parseJsonOrUndef(row.podMembersJson);
   return {
     id: row.id,
     projectId: row.projectId,
@@ -848,6 +874,9 @@ function normalizePreviewComment(row) {
     text: row.text,
     position: parseJsonOrUndef(row.positionJson) ?? { x: 0, y: 0, width: 0, height: 0 },
     htmlHint: row.htmlHint,
+    selectionKind: row.selectionKind === 'pod' ? 'pod' : 'element',
+    memberCount: Number.isFinite(row.memberCount) ? row.memberCount : undefined,
+    podMembers: Array.isArray(podMembers) ? podMembers : undefined,
     note: row.note,
     status: row.status,
     createdAt: row.createdAt,
@@ -858,6 +887,32 @@ function normalizePreviewComment(row) {
 function cleanRequiredString(value, name) {
   if (typeof value !== 'string' || !value.trim()) throw new Error(`${name} required`);
   return value.trim();
+}
+
+function normalizePodMembers(input) {
+  if (!Array.isArray(input)) return [];
+  return input
+    .map((member) => {
+      if (!member || typeof member !== 'object') return null;
+      const elementId = cleanRequiredString(member.elementId, 'podMember.elementId');
+      const selector = cleanRequiredString(member.selector, 'podMember.selector');
+      const label = cleanRequiredString(member.label, 'podMember.label');
+      return {
+        elementId,
+        selector,
+        label,
+        text:
+          typeof member.text === 'string'
+            ? compactWhitespace(member.text).slice(0, 160)
+            : '',
+        position: normalizePosition(member.position),
+        htmlHint:
+          typeof member.htmlHint === 'string'
+            ? compactWhitespace(member.htmlHint).slice(0, 180)
+            : '',
+      };
+    })
+    .filter(Boolean);
 }
 
 function compactWhitespace(value) {

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -9,6 +9,7 @@ import Database from 'better-sqlite3';
 import path from 'node:path';
 import fs from 'node:fs';
 import { randomUUID } from 'node:crypto';
+import { migrateCritique } from './critique/persistence.js';
 
 let dbInstance = null;
 let dbFile = null;
@@ -191,6 +192,7 @@ function migrate(db) {
   if (!deploymentCols.some((c) => c.name === 'reachable_at')) {
     db.exec(`ALTER TABLE deployments ADD COLUMN reachable_at INTEGER`);
   }
+  migrateCritique(db);
 }
 
 // ---------- deployments ----------
@@ -772,7 +774,11 @@ export function upsertPreviewComment(db, projectId, conversationId, input) {
   const selectionKind = target.selectionKind === 'pod' ? 'pod' : 'element';
   const podMembers = selectionKind === 'pod' ? normalizePodMembers(target.podMembers) : [];
   const memberCount = selectionKind === 'pod'
-    ? Math.max(podMembers.length, Number.isFinite(target.memberCount) ? Math.round(target.memberCount) : 0)
+    ? (podMembers.length > 0
+        ? podMembers.length
+        : Number.isFinite(target.memberCount)
+          ? Math.max(0, Math.round(target.memberCount))
+          : 0)
     : 0;
   const now = Date.now();
   const existing = db
@@ -863,6 +869,7 @@ function getPreviewComment(db, projectId, conversationId, id) {
 
 function normalizePreviewComment(row) {
   const podMembers = parseJsonOrUndef(row.podMembersJson);
+  const normalizedPodMembers = Array.isArray(podMembers) ? podMembers : undefined;
   return {
     id: row.id,
     projectId: row.projectId,
@@ -875,8 +882,13 @@ function normalizePreviewComment(row) {
     position: parseJsonOrUndef(row.positionJson) ?? { x: 0, y: 0, width: 0, height: 0 },
     htmlHint: row.htmlHint,
     selectionKind: row.selectionKind === 'pod' ? 'pod' : 'element',
-    memberCount: Number.isFinite(row.memberCount) ? row.memberCount : undefined,
-    podMembers: Array.isArray(podMembers) ? podMembers : undefined,
+    memberCount:
+      normalizedPodMembers && normalizedPodMembers.length > 0
+        ? normalizedPodMembers.length
+        : Number.isFinite(row.memberCount)
+          ? row.memberCount
+          : undefined,
+    podMembers: normalizedPodMembers,
     note: row.note,
     status: row.status,
     createdAt: row.createdAt,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -175,6 +175,15 @@ export function normalizeCommentAttachments(input) {
       const label = cleanString(raw.label);
       const comment = cleanString(raw.comment);
       if (!filePath || !elementId || !selector || !comment) return null;
+      const selectionKind = raw.selectionKind === 'pod' ? 'pod' : 'element';
+      const podMembers = selectionKind === 'pod' ? normalizeAttachmentPodMembers(raw.podMembers) : [];
+      const memberCount =
+        selectionKind === 'pod'
+          ? Math.max(
+              podMembers.length,
+              Number.isFinite(raw.memberCount) ? Math.max(0, Math.round(raw.memberCount)) : 0,
+            )
+          : 0;
       return {
         id: cleanString(raw.id) || `comment-${index + 1}`,
         order: Number.isFinite(raw.order)
@@ -188,6 +197,10 @@ export function normalizeCommentAttachments(input) {
         currentText: compactString(raw.currentText, 160),
         pagePosition: normalizeAttachmentPosition(raw.pagePosition),
         htmlHint: compactString(raw.htmlHint, 180),
+        selectionKind,
+        memberCount,
+        podMembers,
+        source: raw.source === 'board-batch' ? 'board-batch' : 'saved-comment',
       };
     })
     .filter(Boolean)
@@ -200,12 +213,14 @@ export function renderCommentAttachmentHint(commentAttachments) {
     '',
     '',
     '<attached-preview-comments>',
-    'Scope: edit the target element by default. Use the smallest necessary parent wrapper only if the target cannot satisfy the comment. Preserve stable ids and unrelated siblings.',
+    'Scope: treat each attachment as the default refinement target. For single elements, edit the target element first. For pods, coordinate the captured group as one design region and preserve unrelated areas.',
   ];
   for (const item of commentAttachments) {
+    const targetKind = item.selectionKind === 'pod' ? 'pod' : 'element';
     lines.push(
       '',
       `${item.order}. ${item.elementId}`,
+      `targetKind: ${targetKind}`,
       `file: ${item.filePath}`,
       `selector: ${item.selector}`,
       `label: ${item.label || '(unlabeled)'}`,
@@ -214,6 +229,14 @@ export function renderCommentAttachmentHint(commentAttachments) {
       `htmlHint: ${item.htmlHint || '(none)'}`,
       `comment: ${item.comment}`,
     );
+    if (targetKind === 'pod') {
+      lines.push(`memberCount: ${item.memberCount || item.podMembers.length || 0}`);
+      item.podMembers.slice(0, 8).forEach((member, memberIndex) => {
+        lines.push(
+          `member.${memberIndex + 1}: ${member.elementId} | ${member.label || '(unlabeled)'} | ${member.selector}`,
+        );
+      });
+    }
   }
   lines.push('</attached-preview-comments>');
   return lines.join('\n');
@@ -236,6 +259,27 @@ function normalizeAttachmentPosition(input) {
     width: finiteAttachmentNumber(value.width),
     height: finiteAttachmentNumber(value.height),
   };
+}
+
+function normalizeAttachmentPodMembers(input) {
+  if (!Array.isArray(input)) return [];
+  return input
+    .map((member) => {
+      if (!member || typeof member !== 'object') return null;
+      const elementId = cleanString(member.elementId);
+      const selector = cleanString(member.selector);
+      const label = cleanString(member.label);
+      if (!elementId || !selector) return null;
+      return {
+        elementId,
+        selector,
+        label,
+        text: compactString(member.text, 160),
+        position: normalizeAttachmentPosition(member.position),
+        htmlHint: compactString(member.htmlHint, 180),
+      };
+    })
+    .filter(Boolean);
 }
 
 function finiteAttachmentNumber(value) {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -179,10 +179,11 @@ export function normalizeCommentAttachments(input) {
       const podMembers = selectionKind === 'pod' ? normalizeAttachmentPodMembers(raw.podMembers) : [];
       const memberCount =
         selectionKind === 'pod'
-          ? Math.max(
-              podMembers.length,
-              Number.isFinite(raw.memberCount) ? Math.max(0, Math.round(raw.memberCount)) : 0,
-            )
+          ? (podMembers.length > 0
+              ? podMembers.length
+              : Number.isFinite(raw.memberCount)
+                ? Math.max(0, Math.round(raw.memberCount))
+                : 0)
           : 0;
       return {
         id: cleanString(raw.id) || `comment-${index + 1}`,

--- a/apps/daemon/tests/comment-attachments.test.ts
+++ b/apps/daemon/tests/comment-attachments.test.ts
@@ -125,6 +125,42 @@ describe('preview comment agent payload', () => {
     expect(hint).toContain('selector: [data-od-id="hero-title"]');
     expect(hint).toContain('comment: Make the headline shorter');
   });
+
+  it('renders pod attachments with grouped member context', () => {
+    const normalized = normalizeCommentAttachments([
+      commentAttachment({
+        id: 'pod-1',
+        selectionKind: 'pod',
+        memberCount: 2,
+        selector: '[data-od-id="hero"], [data-od-id="chart"]',
+        label: 'Hero and chart',
+        podMembers: [
+          {
+            elementId: 'hero',
+            selector: '[data-od-id="hero"]',
+            label: 'section.hero',
+            text: 'Hero title',
+            position: { x: 10, y: 20, width: 200, height: 100 },
+            htmlHint: '<section data-od-id="hero">',
+          },
+          {
+            elementId: 'chart',
+            selector: '[data-od-id="chart"]',
+            label: 'section.chart',
+            text: 'Chart value',
+            position: { x: 120, y: 80, width: 190, height: 120 },
+            htmlHint: '<section data-od-id="chart">',
+          },
+        ],
+      }),
+    ]);
+
+    const hint = renderCommentAttachmentHint(normalized);
+
+    expect(hint).toContain('targetKind: pod');
+    expect(hint).toContain('memberCount: 2');
+    expect(hint).toContain('member.1: hero | section.hero | [data-od-id="hero"]');
+  });
 });
 
 function seededDb() {

--- a/apps/daemon/tests/comment-attachments.test.ts
+++ b/apps/daemon/tests/comment-attachments.test.ts
@@ -30,6 +30,24 @@ afterEach(() => {
 });
 
 describe('preview comment persistence', () => {
+  it('keeps critique migration wired while adding pod columns on a fresh database', () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'od-comments-'));
+    const db = openDatabase(tempDir);
+
+    const previewColumns = db
+      .prepare(`PRAGMA table_info(preview_comments)`)
+      .all()
+      .map((column: { name: string }) => column.name);
+    const critiqueTable = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='critique_runs'`)
+      .get() as { name?: string } | undefined;
+
+    expect(previewColumns).toEqual(
+      expect.arrayContaining(['selection_kind', 'member_count', 'pod_members_json']),
+    );
+    expect(critiqueTable?.name).toBe('critique_runs');
+  });
+
   it('upserts the latest comment by conversation, file, and element', () => {
     const db = seededDb();
     const first = upsertPreviewComment(db, 'project-1', 'conversation-1', {
@@ -131,7 +149,7 @@ describe('preview comment agent payload', () => {
       commentAttachment({
         id: 'pod-1',
         selectionKind: 'pod',
-        memberCount: 2,
+        memberCount: 99,
         selector: '[data-od-id="hero"], [data-od-id="chart"]',
         label: 'Hero and chart',
         podMembers: [
@@ -159,6 +177,7 @@ describe('preview comment agent payload', () => {
 
     expect(hint).toContain('targetKind: pod');
     expect(hint).toContain('memberCount: 2');
+    expect(normalized[0]?.memberCount).toBe(2);
     expect(hint).toContain('member.1: hero | section.hero | [data-od-id="hero"]');
   });
 });

--- a/apps/web/src/comments.ts
+++ b/apps/web/src/comments.ts
@@ -1,7 +1,9 @@
 import type {
   ChatCommentAttachment,
   ChatMessage,
+  PreviewCommentMember,
   PreviewComment,
+  PreviewCommentSelectionKind,
   PreviewCommentTarget,
 } from './types';
 
@@ -13,6 +15,9 @@ export interface PreviewCommentSnapshot {
   text: string;
   position: { x: number; y: number; width: number; height: number };
   htmlHint: string;
+  selectionKind?: PreviewCommentSelectionKind;
+  memberCount?: number;
+  podMembers?: PreviewCommentMember[];
 }
 
 export interface CommentOverlayBounds {
@@ -23,6 +28,7 @@ export interface CommentOverlayBounds {
 }
 
 export function targetFromSnapshot(snapshot: PreviewCommentSnapshot): PreviewCommentTarget {
+  const podMembers = normalizeMembers(snapshot.podMembers);
   return {
     filePath: snapshot.filePath,
     elementId: snapshot.elementId,
@@ -31,6 +37,15 @@ export function targetFromSnapshot(snapshot: PreviewCommentSnapshot): PreviewCom
     text: trimContextText(snapshot.text),
     position: normalizePosition(snapshot.position),
     htmlHint: trimHtmlHint(snapshot.htmlHint),
+    selectionKind: snapshot.selectionKind === 'pod' ? 'pod' : 'element',
+    memberCount:
+      snapshot.selectionKind === 'pod'
+        ? Math.max(
+            podMembers.length,
+            Number.isFinite(snapshot.memberCount) ? Math.round(snapshot.memberCount as number) : 0,
+          )
+        : undefined,
+    podMembers: podMembers.length > 0 ? podMembers : undefined,
   };
 }
 
@@ -61,6 +76,7 @@ export function commentToAttachment(
   comment: PreviewComment,
   order: number,
 ): ChatCommentAttachment {
+  const podMembers = normalizeMembers(comment.podMembers);
   return {
     id: comment.id,
     order,
@@ -72,11 +88,57 @@ export function commentToAttachment(
     currentText: trimContextText(comment.text),
     pagePosition: normalizePosition(comment.position),
     htmlHint: trimHtmlHint(comment.htmlHint),
+    selectionKind: comment.selectionKind === 'pod' ? 'pod' : 'element',
+    memberCount:
+      comment.selectionKind === 'pod'
+        ? Math.max(
+            podMembers.length,
+            typeof comment.memberCount === 'number' ? Math.round(comment.memberCount) : 0,
+          )
+        : undefined,
+    podMembers: podMembers.length > 0 ? podMembers : undefined,
+    source: 'saved-comment',
   };
 }
 
 export function commentsToAttachments(comments: PreviewComment[]): ChatCommentAttachment[] {
   return comments.map((comment, index) => commentToAttachment(comment, index + 1));
+}
+
+export function buildBoardCommentAttachments(input: {
+  target: PreviewCommentTarget;
+  notes: string[];
+}): ChatCommentAttachment[] {
+  const podMembers = normalizeMembers(input.target.podMembers);
+  const selectionKind = input.target.selectionKind === 'pod' ? 'pod' : 'element';
+  const memberCount =
+    selectionKind === 'pod'
+      ? Math.max(
+          podMembers.length,
+          typeof input.target.memberCount === 'number'
+            ? Math.round(input.target.memberCount)
+            : 0,
+        )
+      : undefined;
+  return input.notes
+    .map((note) => note.trim())
+    .filter(Boolean)
+    .map((note, index) => ({
+      id: `${input.target.elementId}-board-${index + 1}`,
+      order: index + 1,
+      filePath: input.target.filePath,
+      elementId: input.target.elementId,
+      selector: input.target.selector,
+      label: input.target.label,
+      comment: note,
+      currentText: trimContextText(input.target.text),
+      pagePosition: normalizePosition(input.target.position),
+      htmlHint: trimHtmlHint(input.target.htmlHint),
+      selectionKind,
+      memberCount,
+      podMembers: podMembers.length > 0 ? podMembers : undefined,
+      source: 'board-batch',
+    }));
 }
 
 export function messageContentWithCommentAttachments(
@@ -123,6 +185,16 @@ export function simplePositionLabel(position: PreviewComment['position']): strin
   return `x${normalized.x} y${normalized.y}`;
 }
 
+export function selectionKindLabel(
+  selectionKind: PreviewCommentSelectionKind | undefined,
+  memberCount?: number,
+): string {
+  if (selectionKind === 'pod') {
+    return memberCount && memberCount > 0 ? `Pod · ${memberCount} items` : 'Pod';
+  }
+  return 'Element';
+}
+
 export function trimContextText(value: string): string {
   const text = String(value || '').replace(/\s+/g, ' ').trim();
   return text.length > 160 ? `${text.slice(0, 157)}...` : text;
@@ -142,9 +214,11 @@ function renderCommentAttachmentContext(commentAttachments: ChatCommentAttachmen
   ];
   commentAttachments.forEach((item) => {
     const position = normalizePosition(item.pagePosition);
+    const selectionKind = item.selectionKind === 'pod' ? 'pod' : 'element';
     lines.push(
       '',
       `${item.order}. ${item.elementId}`,
+      `targetKind: ${selectionKind}`,
       `file: ${item.filePath}`,
       `selector: ${item.selector}`,
       `label: ${item.label || '(unlabeled)'}`,
@@ -153,6 +227,14 @@ function renderCommentAttachmentContext(commentAttachments: ChatCommentAttachmen
       `htmlHint: ${trimHtmlHint(item.htmlHint || '') || '(none)'}`,
       `comment: ${item.comment}`,
     );
+    if (selectionKind === 'pod') {
+      lines.push(`memberCount: ${item.memberCount || item.podMembers?.length || 0}`);
+      (item.podMembers ?? []).slice(0, 8).forEach((member, memberIndex) => {
+        lines.push(
+          `member.${memberIndex + 1}: ${member.elementId} | ${member.label || '(unlabeled)'} | ${member.selector}`,
+        );
+      });
+    }
   });
   lines.push('</attached-preview-comments>');
   return lines.join('\n');
@@ -169,4 +251,18 @@ function normalizePosition(input: PreviewComment['position']): PreviewComment['p
 
 function finite(value: number | undefined): number {
   return Number.isFinite(value) ? Math.round(value as number) : 0;
+}
+
+function normalizeMembers(input: PreviewCommentMember[] | undefined): PreviewCommentMember[] {
+  if (!Array.isArray(input)) return [];
+  return input
+    .map((member) => ({
+      elementId: String(member.elementId || '').trim(),
+      selector: String(member.selector || '').trim(),
+      label: String(member.label || '').trim(),
+      text: trimContextText(String(member.text || '')),
+      position: normalizePosition(member.position),
+      htmlHint: trimHtmlHint(String(member.htmlHint || '')),
+    }))
+    .filter((member) => member.elementId && member.selector);
 }

--- a/apps/web/src/comments.ts
+++ b/apps/web/src/comments.ts
@@ -40,10 +40,11 @@ export function targetFromSnapshot(snapshot: PreviewCommentSnapshot): PreviewCom
     selectionKind: snapshot.selectionKind === 'pod' ? 'pod' : 'element',
     memberCount:
       snapshot.selectionKind === 'pod'
-        ? Math.max(
-            podMembers.length,
-            Number.isFinite(snapshot.memberCount) ? Math.round(snapshot.memberCount as number) : 0,
-          )
+        ? (podMembers.length > 0
+            ? podMembers.length
+            : Number.isFinite(snapshot.memberCount)
+              ? Math.round(snapshot.memberCount as number)
+              : 0)
         : undefined,
     podMembers: podMembers.length > 0 ? podMembers : undefined,
   };
@@ -91,10 +92,11 @@ export function commentToAttachment(
     selectionKind: comment.selectionKind === 'pod' ? 'pod' : 'element',
     memberCount:
       comment.selectionKind === 'pod'
-        ? Math.max(
-            podMembers.length,
-            typeof comment.memberCount === 'number' ? Math.round(comment.memberCount) : 0,
-          )
+        ? (podMembers.length > 0
+            ? podMembers.length
+            : typeof comment.memberCount === 'number'
+              ? Math.round(comment.memberCount)
+              : 0)
         : undefined,
     podMembers: podMembers.length > 0 ? podMembers : undefined,
     source: 'saved-comment',
@@ -113,12 +115,11 @@ export function buildBoardCommentAttachments(input: {
   const selectionKind = input.target.selectionKind === 'pod' ? 'pod' : 'element';
   const memberCount =
     selectionKind === 'pod'
-      ? Math.max(
-          podMembers.length,
-          typeof input.target.memberCount === 'number'
+      ? (podMembers.length > 0
+          ? podMembers.length
+          : typeof input.target.memberCount === 'number'
             ? Math.round(input.target.memberCount)
-            : 0,
-        )
+            : 0)
       : undefined;
   return input.notes
     .map((note) => note.trim())

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from 'react';
+import { useEffect, useMemo, useRef, useState, type CSSProperties, type MouseEvent as ReactMouseEvent } from 'react';
 import { MarkdownRenderer, artifactRendererRegistry } from '../artifacts/renderer-registry';
 import { renderMarkdownToSafeHtml } from '../artifacts/markdown';
 import { useT } from '../i18n';
@@ -47,15 +47,24 @@ import type {
 } from '../types';
 import { Icon } from './Icon';
 import {
+  buildBoardCommentAttachments,
   liveSnapshotForComment,
   overlayBoundsFromSnapshot,
+  selectionKindLabel,
   targetFromSnapshot,
   type PreviewCommentSnapshot,
 } from '../comments';
-import type { PreviewComment, PreviewCommentTarget } from '../types';
+import type {
+  ChatCommentAttachment,
+  PreviewComment,
+  PreviewCommentMember,
+  PreviewCommentTarget,
+} from '../types';
 
 type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => string;
 type SlideState = { active: number; count: number };
+type BoardTool = 'inspect' | 'pod';
+type StrokePoint = { x: number; y: number };
 
 const MAX_CACHED_SLIDE_STATES = 64;
 const htmlPreviewSlideState = new Map<string, SlideState>();
@@ -160,6 +169,7 @@ interface Props {
   previewComments?: PreviewComment[];
   onSavePreviewComment?: (target: PreviewCommentTarget, note: string, attachAfterSave: boolean) => Promise<PreviewComment | null>;
   onRemovePreviewComment?: (commentId: string) => Promise<void>;
+  onSendBoardCommentAttachments?: (attachments: ChatCommentAttachment[]) => Promise<void> | void;
 }
 
 export function FileViewer({
@@ -172,6 +182,7 @@ export function FileViewer({
   previewComments = [],
   onSavePreviewComment,
   onRemovePreviewComment,
+  onSendBoardCommentAttachments,
 }: Props) {
   const rendererMatch = artifactRendererRegistry.resolve({
     file,
@@ -190,6 +201,7 @@ export function FileViewer({
         previewComments={previewComments}
         onSavePreviewComment={onSavePreviewComment}
         onRemovePreviewComment={onRemovePreviewComment}
+        onSendBoardCommentAttachments={onSendBoardCommentAttachments}
       />
     );
   }
@@ -1160,36 +1172,73 @@ function FileActions({
   );
 }
 
-function CommentPopover({
+function BoardComposerPopover({
   target,
   existing,
   draft,
+  notes,
   onDraft,
+  onAddDraft,
+  onRemoveQueuedNote,
   onClose,
-  onSave,
+  onSaveComment,
+  onSendBatch,
   onRemove,
+  sending,
   t,
 }: {
   target: PreviewCommentSnapshot;
   existing: PreviewComment | null;
   draft: string;
+  notes: string[];
   onDraft: (value: string) => void;
+  onAddDraft: () => void;
+  onRemoveQueuedNote: (index: number) => void;
   onClose: () => void;
-  onSave: (attach: boolean) => void | Promise<void>;
+  onSaveComment: () => void | Promise<void>;
+  onSendBatch: () => void | Promise<void>;
   onRemove: (commentId: string) => void | Promise<void>;
+  sending: boolean;
   t: TranslateFn;
 }) {
+  const pendingCount = notes.length + (draft.trim() ? 1 : 0);
+  const podMembers = target.podMembers ?? [];
   return (
     <div className="comment-popover" data-testid="comment-popover">
       <div className="comment-popover-head">
         <div>
           <strong>{target.elementId}</strong>
           <span>{target.label}</span>
+          <span>{selectionKindLabel(target.selectionKind, target.memberCount)}</span>
         </div>
         <button type="button" className="ghost" onClick={onClose}>
           {t('common.close')}
         </button>
       </div>
+      {podMembers.length > 0 ? (
+        <div className="board-pod-summary">
+          <strong>{target.memberCount || podMembers.length} captured items</strong>
+          <div className="board-pod-members">
+            {podMembers.slice(0, 6).map((member) => (
+              <span key={member.elementId} className="board-pod-chip">
+                {summarizeMember(member)}
+              </span>
+            ))}
+          </div>
+        </div>
+      ) : null}
+      {notes.length > 0 ? (
+        <div className="board-note-list">
+          {notes.map((note, index) => (
+            <div key={`${target.elementId}-${index}`} className="board-note-item">
+              <span>{note}</span>
+              <button type="button" className="ghost" onClick={() => onRemoveQueuedNote(index)}>
+                Remove
+              </button>
+            </div>
+          ))}
+        </div>
+      ) : null}
       <textarea
         data-testid="comment-popover-input"
         value={draft}
@@ -1204,16 +1253,41 @@ function CommentPopover({
         ) : <span />}
         <button
           type="button"
+          className="ghost"
+          disabled={!draft.trim()}
+          onClick={onAddDraft}
+        >
+          Add note
+        </button>
+        <button
+          type="button"
+          className="ghost"
+          disabled={target.selectionKind === 'pod' || !draft.trim()}
+          onClick={() => void onSaveComment()}
+        >
+          Save comment
+        </button>
+        <button
+          type="button"
           className="primary"
           data-testid="comment-add-send"
-          disabled={!draft.trim()}
-          onClick={() => void onSave(true)}
+          disabled={pendingCount === 0 || sending}
+          onClick={() => void onSendBatch()}
         >
-          {existing ? t('chat.comments.updateSend') : t('chat.comments.addSend')}
+          {sending ? 'Sending...' : 'Send to chat'}
         </button>
       </div>
     </div>
   );
+}
+
+function summarizeMember(member: PreviewCommentMember): string {
+  const text = String(member.text || '').trim();
+  if (text) {
+    const trimmed = text.length > 24 ? `${text.slice(0, 21)}...` : text;
+    return `${member.label || member.elementId} · ${trimmed}`;
+  }
+  return member.label || member.elementId;
 }
 
 function CommentPreviewOverlays({
@@ -1221,14 +1295,18 @@ function CommentPreviewOverlays({
   liveTargets,
   hoveredTarget,
   activeTarget,
+  boardTool,
   scale,
+  strokePoints,
   onOpenComment,
 }: {
   comments: PreviewComment[];
   liveTargets: Map<string, PreviewCommentSnapshot>;
   hoveredTarget: PreviewCommentSnapshot | null;
   activeTarget: PreviewCommentSnapshot | null;
+  boardTool: BoardTool;
   scale: number;
+  strokePoints: StrokePoint[];
   onOpenComment: (comment: PreviewComment, snapshot: PreviewCommentSnapshot) => void;
 }) {
   const visibleComments = comments
@@ -1277,6 +1355,13 @@ function CommentPreviewOverlays({
           selected={Boolean(activeTarget)}
         />
       ) : null}
+      {boardTool === 'pod' && strokePoints.length > 1 ? (
+        <svg className="board-pod-stroke">
+          <polyline
+            points={strokePoints.map((point) => `${point.x},${point.y}`).join(' ')}
+          />
+        </svg>
+      ) : null}
     </div>
   );
 }
@@ -1290,6 +1375,50 @@ function CommentTargetOverlay({
   scale: number;
   selected: boolean;
 }) {
+  const displayMembers = podDisplayMembers(snapshot);
+  if (displayMembers.length > 0) {
+    const overlayWeights = podOverlayWeights(displayMembers);
+    return (
+      <>
+        {displayMembers.map((member, index) => {
+          const bounds = overlayBoundsFromSnapshot(member, scale);
+          const width = Math.round(member.position.width);
+          const height = Math.round(member.position.height);
+          const overlayWeight = overlayWeights[index] ?? {
+            backgroundOpacity: 0.24,
+            outlineOpacity: 0.72,
+            ringOpacity: 0.18,
+          };
+          const overlayStyle: CSSProperties & Record<string, string | number> = {
+            left: bounds.left,
+            top: bounds.top,
+            width: bounds.width,
+            height: bounds.height,
+            '--comment-overlay-bg': `rgba(22, 119, 255, ${overlayWeight.backgroundOpacity})`,
+            '--comment-overlay-ring': `rgba(22, 119, 255, ${overlayWeight.ringOpacity})`,
+            '--comment-overlay-border': `rgba(22, 119, 255, ${overlayWeight.outlineOpacity})`,
+          };
+          return (
+            <div
+              key={`${member.elementId}-${index}`}
+              className={`comment-target-overlay comment-target-overlay--member${selected ? ' selected' : ''}`}
+              style={overlayStyle}
+              data-testid="comment-target-overlay"
+            >
+              {index === 0 ? (
+                <div className="comment-target-tooltip">
+                  <strong>{snapshot.elementId}</strong>
+                  <span>{selectionKindLabel(snapshot.selectionKind, snapshot.memberCount)}</span>
+                  <span>{displayMembers.length} visible</span>
+                  <span>{width} × {height}</span>
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
+      </>
+    );
+  }
   const bounds = overlayBoundsFromSnapshot(snapshot, scale);
   const width = Math.round(snapshot.position.width);
   const height = Math.round(snapshot.position.height);
@@ -1307,10 +1436,267 @@ function CommentTargetOverlay({
       <div className="comment-target-tooltip">
         <strong>{snapshot.elementId}</strong>
         <span>{snapshot.label}</span>
+        <span>{selectionKindLabel(snapshot.selectionKind, snapshot.memberCount)}</span>
         <span>{width} × {height}</span>
       </div>
     </div>
   );
+}
+
+function podDisplayMembers(snapshot: PreviewCommentSnapshot): PreviewCommentSnapshot[] {
+  if (snapshot.selectionKind !== 'pod' || !Array.isArray(snapshot.podMembers)) return [];
+  const memberSnapshots = snapshot.podMembers.map((member) => ({
+    filePath: snapshot.filePath,
+    elementId: member.elementId,
+    selector: member.selector,
+    label: member.label,
+    text: member.text,
+    position: member.position,
+    htmlHint: member.htmlHint,
+    selectionKind: 'element' as const,
+  }));
+  const refined = pruneContainerSelections(memberSnapshots);
+  return refined.length > 0 ? refined : memberSnapshots;
+}
+
+function podOverlayWeights(
+  members: PreviewCommentSnapshot[],
+): Array<{ backgroundOpacity: number; outlineOpacity: number; ringOpacity: number }> {
+  const areas = members.map((member) =>
+    Math.max(1, member.position.width * member.position.height),
+  );
+  const maxArea = Math.max(...areas);
+  const minArea = Math.min(...areas);
+  return areas.map((area) => {
+    const normalized =
+      maxArea === minArea ? 1 : 1 - (area - minArea) / (maxArea - minArea);
+    const emphasis = Math.pow(normalized, 0.9);
+    return {
+      backgroundOpacity: roundOverlayOpacity(0.1 + emphasis * 0.6),
+      outlineOpacity: roundOverlayOpacity(0.34 + emphasis * 0.36),
+      ringOpacity: roundOverlayOpacity(0.08 + emphasis * 0.18),
+    };
+  });
+}
+
+function roundOverlayOpacity(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function buildPodSnapshot(input: {
+  filePath: string;
+  scale: number;
+  strokePoints: StrokePoint[];
+  liveTargets: Map<string, PreviewCommentSnapshot>;
+}): PreviewCommentSnapshot | null {
+  if (input.strokePoints.length < 2) return null;
+  const closedLoop = isClosedLoop(input.strokePoints);
+  const intersected = Array.from(input.liveTargets.values()).filter((snapshot) =>
+    selectionHitsSnapshot({
+      points: input.strokePoints,
+      snapshot,
+      scale: input.scale,
+      closedLoop,
+    }),
+  );
+  const refined = pruneContainerSelections(intersected);
+  const selected = refined.length > 0 ? refined : intersected;
+  if (selected.length === 0) return null;
+  const bounds = selected.reduce(
+    (acc, snapshot) => {
+      const rect = snapshot.position;
+      return {
+        left: Math.min(acc.left, rect.x),
+        top: Math.min(acc.top, rect.y),
+        right: Math.max(acc.right, rect.x + rect.width),
+        bottom: Math.max(acc.bottom, rect.y + rect.height),
+      };
+    },
+    {
+      left: Number.POSITIVE_INFINITY,
+      top: Number.POSITIVE_INFINITY,
+      right: Number.NEGATIVE_INFINITY,
+      bottom: Number.NEGATIVE_INFINITY,
+    },
+  );
+  const podMembers: PreviewCommentMember[] = selected.map((snapshot) => ({
+    elementId: snapshot.elementId,
+    selector: snapshot.selector,
+    label: snapshot.label,
+    text: snapshot.text,
+    position: snapshot.position,
+    htmlHint: snapshot.htmlHint,
+  }));
+  const summary = selected
+    .slice(0, 3)
+    .map((snapshot) => summarizeSnapshot(snapshot))
+    .join(' · ');
+  const htmlHint = selected
+    .slice(0, 4)
+    .map((snapshot) => snapshot.htmlHint)
+    .filter(Boolean)
+    .join(' ');
+  const combinedSelector = selected
+    .slice(0, 8)
+    .map((snapshot) => snapshot.selector)
+    .filter(Boolean)
+    .join(', ');
+  return {
+    filePath: input.filePath,
+    elementId: `pod-${Date.now()}`,
+    selector: combinedSelector || 'body *',
+    label: summary || `Pod of ${intersected.length} items`,
+    text: intersected
+      .slice(0, 4)
+      .map((snapshot) => snapshot.text)
+      .filter(Boolean)
+      .join(' · '),
+    position: {
+      x: Math.round(bounds.left),
+      y: Math.round(bounds.top),
+      width: Math.max(1, Math.round(bounds.right - bounds.left)),
+      height: Math.max(1, Math.round(bounds.bottom - bounds.top)),
+    },
+    htmlHint: htmlHint.slice(0, 180),
+    selectionKind: 'pod',
+    memberCount: selected.length,
+    podMembers,
+  };
+}
+
+function pruneContainerSelections(
+  snapshots: PreviewCommentSnapshot[],
+): PreviewCommentSnapshot[] {
+  if (snapshots.length < 2) return snapshots;
+  return snapshots.filter((candidate) => {
+    const candidateArea = Math.max(1, candidate.position.width * candidate.position.height);
+    const contained = snapshots.filter(
+      (other) =>
+        other.elementId !== candidate.elementId &&
+        rectContains(candidate.position, other.position),
+    );
+    if (contained.length === 0) return true;
+    const union = contained.reduce(
+      (acc, other) => ({
+        left: Math.min(acc.left, other.position.x),
+        top: Math.min(acc.top, other.position.y),
+        right: Math.max(acc.right, other.position.x + other.position.width),
+        bottom: Math.max(acc.bottom, other.position.y + other.position.height),
+      }),
+      {
+        left: Number.POSITIVE_INFINITY,
+        top: Number.POSITIVE_INFINITY,
+        right: Number.NEGATIVE_INFINITY,
+        bottom: Number.NEGATIVE_INFINITY,
+      },
+    );
+    const unionArea = Math.max(1, (union.right - union.left) * (union.bottom - union.top));
+    return !(contained.length >= 2 && candidateArea > unionArea * 2.4);
+  });
+}
+
+function summarizeSnapshot(snapshot: PreviewCommentSnapshot): string {
+  const text = snapshot.text.trim();
+  if (text) {
+    const trimmed = text.length > 28 ? `${text.slice(0, 25)}...` : text;
+    return `${snapshot.label || snapshot.elementId} · ${trimmed}`;
+  }
+  return snapshot.label || snapshot.elementId;
+}
+
+function selectionHitsSnapshot(input: {
+  points: StrokePoint[];
+  snapshot: PreviewCommentSnapshot;
+  scale: number;
+  closedLoop: boolean;
+}): boolean {
+  const bounds = overlayBoundsFromSnapshot(input.snapshot, input.scale);
+  if (pathIntersectsRect(input.points, bounds)) return true;
+  if (!input.closedLoop) return false;
+  const center = {
+    x: bounds.left + bounds.width / 2,
+    y: bounds.top + bounds.height / 2,
+  };
+  if (pointInPolygon(center, input.points)) return true;
+  const corners = [
+    { x: bounds.left, y: bounds.top },
+    { x: bounds.left + bounds.width, y: bounds.top },
+    { x: bounds.left + bounds.width, y: bounds.top + bounds.height },
+    { x: bounds.left, y: bounds.top + bounds.height },
+  ];
+  return corners.some((corner) => pointInPolygon(corner, input.points));
+}
+
+function isClosedLoop(points: StrokePoint[]): boolean {
+  if (points.length < 4) return false;
+  const first = points[0]!;
+  const last = points[points.length - 1]!;
+  return Math.hypot(first.x - last.x, first.y - last.y) <= 28;
+}
+
+function rectContains(
+  outer: { x: number; y: number; width: number; height: number },
+  inner: { x: number; y: number; width: number; height: number },
+): boolean {
+  return (
+    outer.x <= inner.x &&
+    outer.y <= inner.y &&
+    outer.x + outer.width >= inner.x + inner.width &&
+    outer.y + outer.height >= inner.y + inner.height
+  );
+}
+
+function pathIntersectsRect(
+  points: StrokePoint[],
+  rect: { left: number; top: number; width: number; height: number },
+): boolean {
+  if (points.length === 0) return false;
+  const x1 = rect.left;
+  const y1 = rect.top;
+  const x2 = rect.left + rect.width;
+  const y2 = rect.top + rect.height;
+  for (let index = 0; index < points.length; index += 1) {
+    const point = points[index]!;
+    if (point.x >= x1 && point.x <= x2 && point.y >= y1 && point.y <= y2) {
+      return true;
+    }
+    const next = points[index + 1];
+    if (!next) continue;
+    if (
+      lineIntersectsLine(point, next, { x: x1, y: y1 }, { x: x2, y: y1 }) ||
+      lineIntersectsLine(point, next, { x: x2, y: y1 }, { x: x2, y: y2 }) ||
+      lineIntersectsLine(point, next, { x: x2, y: y2 }, { x: x1, y: y2 }) ||
+      lineIntersectsLine(point, next, { x: x1, y: y2 }, { x: x1, y: y1 })
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function pointInPolygon(point: StrokePoint, polygon: StrokePoint[]): boolean {
+  let inside = false;
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const pi = polygon[i]!;
+    const pj = polygon[j]!;
+    const intersects =
+      pi.y > point.y !== pj.y > point.y &&
+      point.x <
+        ((pj.x - pi.x) * (point.y - pi.y)) / ((pj.y - pi.y) || Number.EPSILON) + pi.x;
+    if (intersects) inside = !inside;
+  }
+  return inside;
+}
+
+function lineIntersectsLine(a1: StrokePoint, a2: StrokePoint, b1: StrokePoint, b2: StrokePoint): boolean {
+  const denominator =
+    (a2.x - a1.x) * (b2.y - b1.y) - (a2.y - a1.y) * (b2.x - b1.x);
+  if (denominator === 0) return false;
+  const ua =
+    ((b2.x - b1.x) * (a1.y - b1.y) - (b2.y - b1.y) * (a1.x - b1.x)) / denominator;
+  const ub =
+    ((a2.x - a1.x) * (a1.y - b1.y) - (a2.y - a1.y) * (a1.x - b1.x)) / denominator;
+  return ua >= 0 && ua <= 1 && ub >= 0 && ub <= 1;
 }
 
 function ReactComponentViewer({
@@ -1594,6 +1980,7 @@ function HtmlViewer({
   previewComments = [],
   onSavePreviewComment,
   onRemovePreviewComment,
+  onSendBoardCommentAttachments,
 }: {
   projectId: string;
   file: ProjectFile;
@@ -1604,6 +1991,7 @@ function HtmlViewer({
   previewComments?: PreviewComment[];
   onSavePreviewComment?: (target: PreviewCommentTarget, note: string, attachAfterSave: boolean) => Promise<PreviewComment | null>;
   onRemovePreviewComment?: (commentId: string) => Promise<void>;
+  onSendBoardCommentAttachments?: (attachments: ChatCommentAttachment[]) => Promise<void> | void;
 }) {
   const t = useT();
   const [mode, setMode] = useState<'preview' | 'source'>('preview');
@@ -1630,7 +2018,8 @@ function HtmlViewer({
   const [teamSlug, setTeamSlug] = useState('');
   const [inTabPresent, setInTabPresent] = useState(false);
   const [reloadKey, setReloadKey] = useState(0);
-  const [commentMode, setCommentMode] = useState(false);
+  const [boardMode, setBoardMode] = useState(false);
+  const [boardTool, setBoardTool] = useState<BoardTool>('inspect');
   // Opt back into the legacy inline-asset srcDoc path via `?forceInline=1`
   // on the host page. Lets users escape-hatch around the URL-load default
   // for non-deck HTML that depends on the in-iframe localStorage shim.
@@ -1641,8 +2030,13 @@ function HtmlViewer({
   const [activeCommentTarget, setActiveCommentTarget] = useState<PreviewCommentSnapshot | null>(null);
   const [hoveredCommentTarget, setHoveredCommentTarget] = useState<PreviewCommentSnapshot | null>(null);
   const [liveCommentTargets, setLiveCommentTargets] = useState<Map<string, PreviewCommentSnapshot>>(() => new Map());
+  const liveCommentTargetsRef = useRef(liveCommentTargets);
   const [commentDraft, setCommentDraft] = useState('');
+  const [queuedBoardNotes, setQueuedBoardNotes] = useState<string[]>([]);
+  const [sendingBoardBatch, setSendingBoardBatch] = useState(false);
+  const [strokePoints, setStrokePoints] = useState<StrokePoint[]>([]);
   const previewStateKey = `${projectId}:${file.name}`;
+  const previewScale = zoom / 100;
   // Slide deck nav state: the iframe posts the active index + total count
   // back to the host every time a slide settles. Host renders prev/next
   // controls in the toolbar and reflects the count beside them.
@@ -1652,6 +2046,10 @@ function HtmlViewer({
   const previewBodyRef = useRef<HTMLDivElement | null>(null);
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const shareRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    liveCommentTargetsRef.current = liveCommentTargets;
+  }, [liveCommentTargets]);
 
   useEffect(() => {
     if (liveHtml !== undefined) {
@@ -1703,7 +2101,7 @@ function HtmlViewer({
   const useUrlLoadPreview = shouldUrlLoadHtmlPreview({
     mode,
     isDeck: effectiveDeck,
-    commentMode,
+    commentMode: boardMode,
     forceInline,
   });
   const previewSrcUrl = useMemo(
@@ -1729,9 +2127,9 @@ function HtmlViewer({
       deck: effectiveDeck,
       baseHref: projectRawUrl(projectId, baseDirFor(file.name)),
       initialSlideIndex: htmlPreviewSlideState.get(previewStateKey)?.active ?? 0,
-      commentBridge: commentMode,
+      commentBridge: boardMode,
     }) : ''),
-    [previewSource, effectiveDeck, projectId, file.name, previewStateKey, commentMode],
+    [previewSource, effectiveDeck, projectId, file.name, previewStateKey, boardMode],
   );
 
   useEffect(() => {
@@ -1758,21 +2156,25 @@ function HtmlViewer({
   useEffect(() => {
     const win = iframeRef.current?.contentWindow;
     if (!win) return;
-    win.postMessage({ type: 'od:comment-mode', enabled: commentMode }, '*');
-  }, [commentMode, srcDoc]);
+    win.postMessage({ type: 'od:comment-mode', enabled: boardMode, mode: boardTool }, '*');
+  }, [boardMode, boardTool, srcDoc]);
 
   useEffect(() => {
     setActiveCommentTarget(null);
     setHoveredCommentTarget(null);
     setLiveCommentTargets(new Map());
     setCommentDraft('');
+    setQueuedBoardNotes([]);
+    setStrokePoints([]);
   }, [file.name]);
 
   useEffect(() => {
-    if (!commentMode) {
-      setActiveCommentTarget(null);
-      setHoveredCommentTarget(null);
-      setLiveCommentTargets(new Map());
+    if (!boardMode) {
+      setActiveCommentTarget((current) => (current ? null : current));
+      setHoveredCommentTarget((current) => (current ? null : current));
+      setLiveCommentTargets((current) => (current.size > 0 ? new Map() : current));
+      setQueuedBoardNotes((current) => (current.length > 0 ? [] : current));
+      setStrokePoints((current) => (current.length > 0 ? [] : current));
       return;
     }
     const snapshotFromData = (data: Partial<PreviewCommentSnapshot>): PreviewCommentSnapshot => ({
@@ -1788,12 +2190,16 @@ function HtmlViewer({
         height: Number(data.position?.height) || 0,
       },
       htmlHint: String(data.htmlHint || ''),
+      selectionKind: data.selectionKind === 'pod' ? 'pod' : 'element',
+      memberCount: typeof data.memberCount === 'number' ? data.memberCount : undefined,
+      podMembers: Array.isArray(data.podMembers) ? data.podMembers : undefined,
     });
     function onMessage(ev: MessageEvent) {
       if (ev.source !== iframeRef.current?.contentWindow) return;
       const data = ev.data as (Partial<PreviewCommentSnapshot> & {
         type?: string;
         targets?: Array<Partial<PreviewCommentSnapshot>>;
+        points?: StrokePoint[];
       }) | null;
       if (!data?.type) return;
       if (data.type === 'od:comment-targets' && Array.isArray(data.targets)) {
@@ -1804,10 +2210,18 @@ function HtmlViewer({
         });
         setLiveCommentTargets(next);
         setActiveCommentTarget((current) => (
-          current ? next.get(current.elementId) ?? null : null
+          current
+            ? current.selectionKind === 'pod'
+              ? current
+              : next.get(current.elementId) ?? null
+            : null
         ));
         setHoveredCommentTarget((current) => (
-          current ? next.get(current.elementId) ?? null : null
+          current
+            ? current.selectionKind === 'pod'
+              ? current
+              : next.get(current.elementId) ?? null
+            : null
         ));
         return;
       }
@@ -1830,11 +2244,48 @@ function HtmlViewer({
         setHoveredCommentTarget(snapshot);
         setLiveCommentTargets((current) => new Map(current).set(snapshot.elementId, snapshot));
         setCommentDraft(existing?.note ?? '');
+        setQueuedBoardNotes([]);
+        return;
+      }
+      if (data.type === 'od:pod-clear') {
+        setStrokePoints([]);
+        return;
+      }
+      if (data.type === 'od:pod-stroke' && Array.isArray(data.points)) {
+        setStrokePoints(
+          data.points.map((point) => ({
+            x: Number(point.x) || 0,
+            y: Number(point.y) || 0,
+          })),
+        );
+        return;
+      }
+      if (data.type === 'od:pod-select' && Array.isArray(data.points)) {
+        const points = data.points.map((point) => ({
+          x: Number(point.x) || 0,
+          y: Number(point.y) || 0,
+        }));
+        setStrokePoints(points);
+        const nextTarget = buildPodSnapshot({
+          filePath: file.name,
+          scale: previewScale,
+          strokePoints: points,
+          liveTargets: liveCommentTargetsRef.current,
+        });
+        if (!nextTarget) {
+          setStrokePoints([]);
+          return;
+        }
+        setActiveCommentTarget(nextTarget);
+        setHoveredCommentTarget(nextTarget);
+        setQueuedBoardNotes([]);
+        setCommentDraft('');
+        setStrokePoints([]);
       }
     }
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, [commentMode, file.name, previewComments]);
+  }, [boardMode, file.name, previewComments, previewScale]);
 
   function postSlide(action: 'next' | 'prev' | 'first' | 'last') {
     const win = iframeRef.current?.contentWindow;
@@ -2096,11 +2547,65 @@ function HtmlViewer({
     setZoom((z) => Math.max(25, Math.min(200, z + delta)));
   }
 
+  function clearBoardComposer() {
+    setActiveCommentTarget(null);
+    setHoveredCommentTarget(null);
+    setCommentDraft('');
+    setQueuedBoardNotes([]);
+    setStrokePoints([]);
+  }
+
+  function activateBoard(nextTool?: BoardTool) {
+    setMode('preview');
+    setBoardMode(true);
+    if (nextTool) {
+      setBoardTool(nextTool);
+    }
+  }
+
+  function queueCurrentDraft() {
+    const note = commentDraft.trim();
+    if (!note) return;
+    setQueuedBoardNotes((current) => [...current, note]);
+    setCommentDraft('');
+  }
+
+  async function sendBoardBatch() {
+    if (!activeCommentTarget || !onSendBoardCommentAttachments) return;
+    const nextNotes = [...queuedBoardNotes];
+    if (commentDraft.trim()) nextNotes.push(commentDraft.trim());
+    if (nextNotes.length === 0) return;
+    setSendingBoardBatch(true);
+    try {
+      await onSendBoardCommentAttachments(
+        buildBoardCommentAttachments({
+          target: targetFromSnapshot(activeCommentTarget),
+          notes: nextNotes,
+        }),
+      );
+      clearBoardComposer();
+    } finally {
+      setSendingBoardBatch(false);
+    }
+  }
+
+  async function savePersistentComment() {
+    if (!activeCommentTarget || !commentDraft.trim() || !onSavePreviewComment) return;
+    const saved = await onSavePreviewComment(
+      targetFromSnapshot(activeCommentTarget),
+      commentDraft.trim(),
+      false,
+    );
+    if (saved) {
+      setCommentDraft('');
+    }
+  }
+
   const showPresent = effectiveDeck && source !== null;
   const canShare = source !== null;
   const exportTitle = file.name.replace(/\.html?$/i, '') || file.name;
   const canPptx = canShare && Boolean(onExportAsPptx) && !streaming;
-  const previewScale = zoom / 100;
+  const boardAvailable = source !== null;
   const activeDeployment = deployResult || deployment;
   const activeDeployedUrl = activeDeployment?.url?.trim() || '';
   const activeDeploymentReady = activeDeployment?.status === 'ready';
@@ -2162,12 +2667,18 @@ function HtmlViewer({
           ) : null}
           <button
             type="button"
-            className="viewer-toggle"
-            disabled
-            data-coming-soon="true"
+            className={`viewer-toggle${boardMode ? ' active' : ''}`}
             title={t('fileViewer.tweaks')}
-            aria-pressed={false}
-            onClick={(e) => e.preventDefault()}
+            aria-pressed={boardMode}
+            disabled={!boardAvailable}
+            onClick={() => {
+              if (boardMode) {
+                setBoardMode(false);
+                clearBoardComposer();
+                return;
+              }
+              activateBoard(boardTool);
+            }}
           >
             <Icon name="tweaks" size={13} />
             <span>{t('fileViewer.tweaks')}</span>
@@ -2190,36 +2701,31 @@ function HtmlViewer({
             </button>
           </div>
           <span className="viewer-divider" aria-hidden />
-          <button
-            className={`viewer-action${commentMode ? ' active' : ''}`}
-            type="button"
-            data-testid="comment-mode-toggle"
-            title={t('fileViewer.comment')}
-            onClick={() => setCommentMode((v) => !v)}
-          >
-            <Icon name="comment" size={13} />
-            <span>{t('fileViewer.comment')}</span>
-          </button>
-          <button
-            className="viewer-action"
-            type="button"
-            disabled
-            data-coming-soon="true"
-            title={t('fileViewer.edit')}
-          >
-            <Icon name="edit" size={13} />
-            <span>{t('fileViewer.edit')}</span>
-          </button>
-          <button
-            className="viewer-action"
-            type="button"
-            disabled
-            data-coming-soon="true"
-            title={t('fileViewer.draw')}
-          >
-            <Icon name="draw" size={13} />
-            <span>{t('fileViewer.draw')}</span>
-          </button>
+          {boardMode ? (
+            <>
+              <button
+                className={`viewer-action${boardTool === 'inspect' ? ' active' : ''}`}
+                type="button"
+                data-testid="comment-mode-toggle"
+                disabled={!boardAvailable}
+                title="Pick one element"
+                onClick={() => activateBoard('inspect')}
+              >
+                <Icon name="edit" size={13} />
+                <span>Picker</span>
+              </button>
+              <button
+                className={`viewer-action${boardTool === 'pod' ? ' active' : ''}`}
+                type="button"
+                disabled={!boardAvailable}
+                title="Draw a pod selection"
+                onClick={() => activateBoard('pod')}
+              >
+                <Icon name="draw" size={13} />
+                <span>Pods</span>
+              </button>
+            </>
+          ) : null}
           <span className="viewer-divider" aria-hidden />
           <button
             type="button"
@@ -2467,37 +2973,43 @@ function HtmlViewer({
                 )}
               </div>
             </div>
-            {commentMode ? (
+            {boardMode ? (
               <CommentPreviewOverlays
                 comments={previewComments}
                 liveTargets={liveCommentTargets}
                 hoveredTarget={hoveredCommentTarget}
                 activeTarget={activeCommentTarget}
+                boardTool={boardTool}
                 scale={previewScale}
+                strokePoints={strokePoints}
                 onOpenComment={(comment, snapshot) => {
                   setActiveCommentTarget(snapshot);
                   setHoveredCommentTarget(snapshot);
                   setCommentDraft(comment.note);
+                  setQueuedBoardNotes([]);
                 }}
               />
             ) : null}
-            {commentMode && activeCommentTarget ? (
-              <CommentPopover
+            {boardMode && activeCommentTarget ? (
+              <BoardComposerPopover
                 target={activeCommentTarget}
                 existing={previewComments.find((comment) => comment.elementId === activeCommentTarget.elementId) ?? null}
                 draft={commentDraft}
+                notes={queuedBoardNotes}
                 onDraft={setCommentDraft}
-                onClose={() => setActiveCommentTarget(null)}
-                onSave={async (attach) => {
-                  if (!commentDraft.trim() || !onSavePreviewComment) return;
-                  const saved = await onSavePreviewComment(targetFromSnapshot(activeCommentTarget), commentDraft.trim(), attach);
-                  if (saved) setActiveCommentTarget(null);
-                }}
+                onAddDraft={queueCurrentDraft}
+                onRemoveQueuedNote={(index) =>
+                  setQueuedBoardNotes((current) => current.filter((_, currentIndex) => currentIndex !== index))
+                }
+                onClose={clearBoardComposer}
+                onSaveComment={savePersistentComment}
+                onSendBatch={sendBoardBatch}
                 onRemove={async (commentId) => {
                   if (!onRemovePreviewComment) return;
                   await onRemovePreviewComment(commentId);
-                  setActiveCommentTarget(null);
+                  clearBoardComposer();
                 }}
+                sending={sendingBoardBatch}
                 t={t}
               />
             ) : null}

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -65,6 +65,7 @@ type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => 
 type SlideState = { active: number; count: number };
 type BoardTool = 'inspect' | 'pod';
 type StrokePoint = { x: number; y: number };
+const MAX_BRIDGE_COORDINATE = 1_000_000;
 
 const MAX_CACHED_SLIDE_STATES = 64;
 const htmlPreviewSlideState = new Map<string, SlideState>();
@@ -1204,10 +1205,22 @@ function BoardComposerPopover({
   const pendingCount = notes.length + (draft.trim() ? 1 : 0);
   const podMembers = target.podMembers ?? [];
   return (
-    <div className="comment-popover" data-testid="comment-popover">
+    <div
+      className="comment-popover"
+      data-testid="comment-popover"
+      role="dialog"
+      aria-modal="false"
+      aria-labelledby={`board-composer-title-${target.elementId}`}
+      onKeyDown={(event) => {
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          onClose();
+        }
+      }}
+    >
       <div className="comment-popover-head">
         <div>
-          <strong>{target.elementId}</strong>
+          <strong id={`board-composer-title-${target.elementId}`}>{target.elementId}</strong>
           <span>{target.label}</span>
           <span>{selectionKindLabel(target.selectionKind, target.memberCount)}</span>
         </div>
@@ -1242,6 +1255,8 @@ function BoardComposerPopover({
       <textarea
         data-testid="comment-popover-input"
         value={draft}
+        autoFocus
+        aria-label={t('chat.comments.placeholder')}
         placeholder={t('chat.comments.placeholder')}
         onChange={(event) => onDraft(event.target.value)}
       />
@@ -1358,7 +1373,7 @@ function CommentPreviewOverlays({
       {boardTool === 'pod' && strokePoints.length > 1 ? (
         <svg className="board-pod-stroke">
           <polyline
-            points={strokePoints.map((point) => `${point.x},${point.y}`).join(' ')}
+            points={strokePoints.map((point) => `${point.x * scale},${point.y * scale}`).join(' ')}
           />
         </svg>
       ) : null}
@@ -1485,7 +1500,6 @@ function roundOverlayOpacity(value: number): number {
 
 function buildPodSnapshot(input: {
   filePath: string;
-  scale: number;
   strokePoints: StrokePoint[];
   liveTargets: Map<string, PreviewCommentSnapshot>;
 }): PreviewCommentSnapshot | null {
@@ -1495,7 +1509,6 @@ function buildPodSnapshot(input: {
     selectionHitsSnapshot({
       points: input.strokePoints,
       snapshot,
-      scale: input.scale,
       closedLoop,
     }),
   );
@@ -1607,10 +1620,14 @@ function summarizeSnapshot(snapshot: PreviewCommentSnapshot): string {
 function selectionHitsSnapshot(input: {
   points: StrokePoint[];
   snapshot: PreviewCommentSnapshot;
-  scale: number;
   closedLoop: boolean;
 }): boolean {
-  const bounds = overlayBoundsFromSnapshot(input.snapshot, input.scale);
+  const bounds = {
+    left: input.snapshot.position.x,
+    top: input.snapshot.position.y,
+    width: input.snapshot.position.width,
+    height: input.snapshot.position.height,
+  };
   if (pathIntersectsRect(input.points, bounds)) return true;
   if (!input.closedLoop) return false;
   const center = {
@@ -1697,6 +1714,17 @@ function lineIntersectsLine(a1: StrokePoint, a2: StrokePoint, b1: StrokePoint, b
   const ub =
     ((a2.x - a1.x) * (a1.y - b1.y) - (a2.y - a1.y) * (a1.x - b1.x)) / denominator;
   return ua >= 0 && ua <= 1 && ub >= 0 && ub <= 1;
+}
+
+function finiteBridgeInteger(value: unknown): number | undefined {
+  if (!Number.isFinite(value)) return undefined;
+  return clampBridgeCoordinate(value);
+}
+
+function clampBridgeCoordinate(value: unknown): number {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return 0;
+  return Math.max(-MAX_BRIDGE_COORDINATE, Math.min(MAX_BRIDGE_COORDINATE, Math.round(numeric)));
 }
 
 function ReactComponentViewer({
@@ -2184,14 +2212,14 @@ function HtmlViewer({
       label: String(data.label || ''),
       text: String(data.text || ''),
       position: {
-        x: Number(data.position?.x) || 0,
-        y: Number(data.position?.y) || 0,
-        width: Number(data.position?.width) || 0,
-        height: Number(data.position?.height) || 0,
+        x: clampBridgeCoordinate(data.position?.x),
+        y: clampBridgeCoordinate(data.position?.y),
+        width: clampBridgeCoordinate(data.position?.width),
+        height: clampBridgeCoordinate(data.position?.height),
       },
       htmlHint: String(data.htmlHint || ''),
       selectionKind: data.selectionKind === 'pod' ? 'pod' : 'element',
-      memberCount: typeof data.memberCount === 'number' ? data.memberCount : undefined,
+      memberCount: finiteBridgeInteger(data.memberCount),
       podMembers: Array.isArray(data.podMembers) ? data.podMembers : undefined,
     });
     function onMessage(ev: MessageEvent) {
@@ -2254,21 +2282,20 @@ function HtmlViewer({
       if (data.type === 'od:pod-stroke' && Array.isArray(data.points)) {
         setStrokePoints(
           data.points.map((point) => ({
-            x: Number(point.x) || 0,
-            y: Number(point.y) || 0,
+            x: clampBridgeCoordinate(point.x),
+            y: clampBridgeCoordinate(point.y),
           })),
         );
         return;
       }
       if (data.type === 'od:pod-select' && Array.isArray(data.points)) {
         const points = data.points.map((point) => ({
-          x: Number(point.x) || 0,
-          y: Number(point.y) || 0,
+          x: clampBridgeCoordinate(point.x),
+          y: clampBridgeCoordinate(point.y),
         }));
         setStrokePoints(points);
         const nextTarget = buildPodSnapshot({
           filePath: file.name,
-          scale: previewScale,
           strokePoints: points,
           liveTargets: liveCommentTargetsRef.current,
         });
@@ -2285,7 +2312,7 @@ function HtmlViewer({
     }
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, [boardMode, file.name, previewComments, previewScale]);
+  }, [boardMode, file.name, previewComments]);
 
   function postSlide(action: 'next' | 'prev' | 'first' | 'last') {
     const win = iframeRef.current?.contentWindow;
@@ -2709,6 +2736,8 @@ function HtmlViewer({
                 data-testid="comment-mode-toggle"
                 disabled={!boardAvailable}
                 title="Pick one element"
+                aria-label="Picker"
+                aria-pressed={boardTool === 'inspect'}
                 onClick={() => activateBoard('inspect')}
               >
                 <Icon name="edit" size={13} />
@@ -2719,6 +2748,8 @@ function HtmlViewer({
                 type="button"
                 disabled={!boardAvailable}
                 title="Draw a pod selection"
+                aria-label="Pods"
+                aria-pressed={boardTool === 'pod'}
                 onClick={() => activateBoard('pod')}
               >
                 <Icon name="draw" size={13} />

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -3049,7 +3049,7 @@ function HtmlViewer({
                   await onRemovePreviewComment(commentId);
                   clearBoardComposer();
                 }}
-                sending={sendingBoardBatch}
+                sending={sendingBoardBatch || streaming}
                 t={t}
               />
             ) : null}

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type CSSProperties, type MouseEvent as ReactMouseEvent } from 'react';
+import { useEffect, useId, useMemo, useRef, useState, type CSSProperties, type MouseEvent as ReactMouseEvent } from 'react';
 import { MarkdownRenderer, artifactRendererRegistry } from '../artifacts/renderer-registry';
 import { renderMarkdownToSafeHtml } from '../artifacts/markdown';
 import { useT } from '../i18n';
@@ -1204,13 +1204,14 @@ function BoardComposerPopover({
 }) {
   const pendingCount = notes.length + (draft.trim() ? 1 : 0);
   const podMembers = target.podMembers ?? [];
+  const titleId = useId();
   return (
     <div
       className="comment-popover"
       data-testid="comment-popover"
       role="dialog"
       aria-modal="false"
-      aria-labelledby={`board-composer-title-${target.elementId}`}
+      aria-labelledby={titleId}
       onKeyDown={(event) => {
         if (event.key === 'Escape') {
           event.preventDefault();
@@ -1220,7 +1221,7 @@ function BoardComposerPopover({
     >
       <div className="comment-popover-head">
         <div>
-          <strong id={`board-composer-title-${target.elementId}`}>{target.elementId}</strong>
+          <strong id={titleId}>{target.elementId}</strong>
           <span>{target.label}</span>
           <span>{selectionKindLabel(target.selectionKind, target.memberCount)}</span>
         </div>
@@ -2187,6 +2188,12 @@ function HtmlViewer({
     win.postMessage({ type: 'od:comment-mode', enabled: boardMode, mode: boardTool }, '*');
   }, [boardMode, boardTool, srcDoc]);
 
+  function syncCommentMode() {
+    const win = iframeRef.current?.contentWindow;
+    if (!win) return;
+    win.postMessage({ type: 'od:comment-mode', enabled: boardMode, mode: boardTool }, '*');
+  }
+
   useEffect(() => {
     setActiveCommentTarget(null);
     setHoveredCommentTarget(null);
@@ -2991,6 +2998,7 @@ function HtmlViewer({
                     title={file.name}
                     sandbox="allow-scripts"
                     src={previewSrcUrl}
+                    onLoad={syncCommentMode}
                   />
                 ) : (
                   <iframe
@@ -3000,6 +3008,7 @@ function HtmlViewer({
                     title={file.name}
                     sandbox="allow-scripts"
                     srcDoc={srcDoc}
+                    onLoad={syncCommentMode}
                   />
                 )}
               </div>

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -7,6 +7,7 @@ import {
   writeProjectTextFile,
 } from '../providers/registry';
 import {
+  type ChatCommentAttachment,
   liveArtifactSummaryToWorkspaceEntry,
   type LiveArtifactSummary,
   type LiveArtifactEventItem,
@@ -40,6 +41,7 @@ interface Props {
   previewComments?: PreviewComment[];
   onSavePreviewComment?: (target: PreviewCommentTarget, note: string, attachAfterSave: boolean) => Promise<PreviewComment | null>;
   onRemovePreviewComment?: (commentId: string) => Promise<void>;
+  onSendBoardCommentAttachments?: (attachments: ChatCommentAttachment[]) => Promise<void> | void;
 }
 
 interface SketchState {
@@ -67,6 +69,7 @@ export function FileWorkspace({
   previewComments = [],
   onSavePreviewComment,
   onRemovePreviewComment,
+  onSendBoardCommentAttachments,
 }: Props) {
   const t = useT();
   // Persisted tabs come from the parent. Active tab can transiently point
@@ -452,6 +455,7 @@ export function FileWorkspace({
             previewComments={previewComments.filter((comment) => comment.filePath === activeFile.name)}
             onSavePreviewComment={onSavePreviewComment}
             onRemovePreviewComment={onRemovePreviewComment}
+            onSendBoardCommentAttachments={onSendBoardCommentAttachments}
           />
         ) : (
           <div className="viewer-empty">

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -847,6 +847,7 @@ export function ProjectView({
       commentAttachments: ChatCommentAttachment[] = commentsToAttachments(attachedComments),
     ) => {
       if (!activeConversationId) return;
+      if (streaming) return;
       if (!prompt.trim() && attachments.length === 0 && commentAttachments.length === 0) return;
       setError(null);
       const startedAt = Date.now();
@@ -1170,6 +1171,7 @@ export function ProjectView({
     [
       attachedComments,
       activeConversationId,
+      streaming,
       messages,
       config,
       agentsById,
@@ -1190,10 +1192,10 @@ export function ProjectView({
 
   const handleSendBoardCommentAttachments = useCallback(
     async (commentAttachments: ChatCommentAttachment[]) => {
-      if (commentAttachments.length === 0) return;
+      if (streaming || commentAttachments.length === 0) return;
       await handleSend('', [], commentAttachments);
     },
-    [handleSend],
+    [handleSend, streaming],
   );
 
   const persistArtifact = useCallback(

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -619,15 +619,19 @@ export function ProjectView({
   const patchAttachedStatuses = useCallback(
     async (attachments: ChatCommentAttachment[], status: PreviewComment['status']) => {
       if (!activeConversationId || attachments.length === 0) return;
+      const persistedAttachments = attachments.filter(
+        (attachment) => attachment.source !== 'board-batch',
+      );
+      if (persistedAttachments.length === 0) return;
       setPreviewComments((current) =>
         current.map((comment) =>
-          attachments.some((attachment) => attachment.id === comment.id)
+          persistedAttachments.some((attachment) => attachment.id === comment.id)
             ? { ...comment, status }
             : comment,
         ),
       );
       await Promise.all(
-        attachments.map((attachment) =>
+        persistedAttachments.map((attachment) =>
           patchPreviewCommentStatus(project.id, activeConversationId, attachment.id, status),
         ),
       );
@@ -1184,6 +1188,14 @@ export function ProjectView({
     ],
   );
 
+  const handleSendBoardCommentAttachments = useCallback(
+    async (commentAttachments: ChatCommentAttachment[]) => {
+      if (commentAttachments.length === 0) return;
+      await handleSend('', [], commentAttachments);
+    },
+    [handleSend],
+  );
+
   const persistArtifact = useCallback(
     async (art: Artifact) => {
       const baseName = (art.identifier || art.title || 'artifact')
@@ -1531,6 +1543,7 @@ export function ProjectView({
           previewComments={previewComments}
           onSavePreviewComment={savePreviewComment}
           onRemovePreviewComment={removePreviewComment}
+          onSendBoardCommentAttachments={handleSendBoardCommentAttachments}
         />
       </div>
     </div>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4989,8 +4989,10 @@ button.connector-action.is-loading {
   transition: transform 120ms ease;
   box-shadow: var(--shadow-xs);
 }
-.viewer-toggle.on .switch { background: var(--text); border-color: var(--text); }
-.viewer-toggle.on .switch::after { transform: translateX(12px); }
+.viewer-toggle.on .switch,
+.viewer-toggle.active .switch { background: var(--text); border-color: var(--text); }
+.viewer-toggle.on .switch::after,
+.viewer-toggle.active .switch::after { transform: translateX(12px); }
 .viewer-tabs { display: inline-flex; gap: 2px; }
 .viewer-tab {
   background: transparent;
@@ -5539,16 +5541,31 @@ button.connector-action.is-loading {
   z-index: 3;
   pointer-events: none;
 }
+.board-pod-stroke {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+  pointer-events: none;
+}
+.board-pod-stroke polyline {
+  fill: none;
+  stroke: rgba(22, 119, 255, 0.95);
+  stroke-width: 3;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  filter: drop-shadow(0 0 4px rgba(22, 119, 255, 0.28));
+}
 .comment-target-overlay {
   position: absolute;
   pointer-events: none;
-  border: 1px solid #1677ff;
-  background: rgba(22, 119, 255, 0.24);
-  box-shadow: 0 0 0 1px rgba(22, 119, 255, 0.18);
+  border: 1px solid var(--comment-overlay-border, #1677ff);
+  background: var(--comment-overlay-bg, rgba(22, 119, 255, 0.24));
+  box-shadow: 0 0 0 1px var(--comment-overlay-ring, rgba(22, 119, 255, 0.18));
 }
 .comment-target-overlay.selected {
   border-width: 2px;
-  background: rgba(22, 119, 255, 0.3);
 }
 .comment-target-tooltip {
   position: absolute;
@@ -5635,6 +5652,50 @@ button.connector-action.is-loading {
 .comment-popover-head span {
   color: var(--text-muted);
   font-size: 12px;
+}
+.board-pod-summary {
+  display: grid;
+  gap: 6px;
+  margin-bottom: 8px;
+  padding: 8px;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-sm);
+  background: var(--bg-subtle);
+}
+.board-pod-summary strong {
+  font-size: 12px;
+}
+.board-pod-members {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.board-pod-chip {
+  padding: 3px 7px;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-pill);
+  background: var(--bg-panel);
+  color: var(--text-muted);
+  font-size: 11px;
+}
+.board-note-list {
+  display: grid;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+.board-note-item {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 8px 9px;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-sm);
+  background: var(--bg-subtle);
+  font-size: 12px;
+}
+.board-note-item span {
+  color: var(--text);
 }
 .comment-popover textarea {
   min-height: 78px;

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -111,6 +111,8 @@ function injectCommentBridge(doc: string): string {
   var selectableCache = null;
   var drawing = false;
   var stroke = [];
+  var postTargetsTimer = null;
+  var MAX_TARGETS = 400;
   function esc(value){ try { return window.CSS && CSS.escape ? CSS.escape(value) : String(value).replace(/"/g, '\\\\"'); } catch (_) { return String(value); } }
   function isSelectableElement(el){
     if (!el || !el.tagName) return false;
@@ -141,7 +143,12 @@ function injectCommentBridge(doc: string): string {
     while (node && node.nodeType === 1 && node !== document.body && parts.length < 6) {
       var part = node.tagName.toLowerCase();
       var cls = typeof node.className === 'string' && node.className.trim()
-        ? node.className.trim().split(/\\s+/).slice(0, 2).join('.')
+        ? node.className
+            .trim()
+            .split(/\\s+/)
+            .slice(0, 2)
+            .map(function(token){ return esc(token); })
+            .join('.')
         : '';
       if (cls) part += '.' + cls;
       var index = 1;
@@ -195,6 +202,7 @@ function injectCommentBridge(doc: string): string {
     for (var i = 0; i < nodes.length; i++) {
       var item = targetFrom(nodes[i]);
       if (item) items.push(item);
+      if (items.length >= MAX_TARGETS) break;
     }
     selectableCache = items;
     return selectableCache;
@@ -208,10 +216,14 @@ function injectCommentBridge(doc: string): string {
   function schedulePostTargets(){
     if (!enabled || postTargetsPending) return;
     postTargetsPending = true;
-    window.requestAnimationFrame(function(){
-      postTargetsPending = false;
-      postTargets();
-    });
+    if (postTargetsTimer) window.clearTimeout(postTargetsTimer);
+    postTargetsTimer = window.setTimeout(function(){
+      window.requestAnimationFrame(function(){
+        postTargetsPending = false;
+        postTargetsTimer = null;
+        postTargets();
+      });
+    }, 120);
   }
   function closestTarget(event){
     var el = event.target && event.target.nodeType === 3 ? event.target.parentElement : event.target;

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -106,38 +106,103 @@ function injectSandboxShim(doc: string): string {
 function injectCommentBridge(doc: string): string {
   const script = `<script data-od-comment-bridge>(function(){
   var enabled = true;
+  var mode = 'picker';
   var hoveredId = null;
+  var selectableCache = null;
+  var drawing = false;
+  var stroke = [];
   function esc(value){ try { return window.CSS && CSS.escape ? CSS.escape(value) : String(value).replace(/"/g, '\\\\"'); } catch (_) { return String(value); } }
-  function targetFrom(el){
-    var id = el.getAttribute('data-od-id') || el.getAttribute('data-screen-label');
-    if (!id) return null;
+  function isSelectableElement(el){
+    if (!el || !el.tagName) return false;
+    var tag = el.tagName.toLowerCase();
+    if (tag === 'html' || tag === 'body' || tag === 'head' || tag === 'script' || tag === 'style' || tag === 'meta' || tag === 'link' || tag === 'title') return false;
     var rect = el.getBoundingClientRect();
+    if (!rect || rect.width < 2 || rect.height < 2) return false;
+    var style = window.getComputedStyle ? window.getComputedStyle(el) : null;
+    if (style && (style.display === 'none' || style.visibility === 'hidden' || style.pointerEvents === 'none')) return false;
+    return true;
+  }
+  function meaningfulText(el){
+    return (el.textContent || '').replace(/\\s+/g, ' ').trim().slice(0, 160);
+  }
+  function shortLabel(el){
     var tag = el.tagName ? el.tagName.toLowerCase() : 'element';
+    var id = typeof el.id === 'string' && el.id.trim() ? '#' + el.id.trim() : '';
     var cls = typeof el.className === 'string' && el.className.trim() ? '.' + el.className.trim().split(/\\s+/).slice(0,2).join('.') : '';
+    return tag + id + cls;
+  }
+  function cssPath(el){
+    if (el.hasAttribute && el.hasAttribute('data-od-id')) {
+      return '[data-od-id="' + esc(el.getAttribute('data-od-id')) + '"]';
+    }
+    if (el.id) return '#' + esc(el.id);
+    var parts = [];
+    var node = el;
+    while (node && node.nodeType === 1 && node !== document.body && parts.length < 6) {
+      var part = node.tagName.toLowerCase();
+      var cls = typeof node.className === 'string' && node.className.trim()
+        ? node.className.trim().split(/\\s+/).slice(0, 2).join('.')
+        : '';
+      if (cls) part += '.' + cls;
+      var index = 1;
+      var sib = node;
+      while ((sib = sib.previousElementSibling)) {
+        if (sib.tagName === node.tagName) index++;
+      }
+      part += ':nth-of-type(' + index + ')';
+      parts.unshift(part);
+      node = node.parentElement;
+      if (node && node.id) {
+        parts.unshift('#' + esc(node.id));
+        break;
+      }
+    }
+    return parts.join(' > ') || shortLabel(el);
+  }
+  function stableElementId(el){
+    if (el.hasAttribute && el.hasAttribute('data-od-id')) {
+      return el.getAttribute('data-od-id');
+    }
+    if (el.id) return el.id;
+    return cssPath(el);
+  }
+  function targetFrom(el){
+    if (!isSelectableElement(el)) return null;
+    var id = stableElementId(el);
+    var rect = el.getBoundingClientRect();
     var html = '';
     try { html = (el.outerHTML || '').replace(/\\s+/g, ' ').match(/^<[^>]+>/)?.[0] || ''; } catch (_) {}
     return {
       type: 'od:comment-target',
       elementId: id,
-      selector: el.hasAttribute('data-od-id') ? '[data-od-id="' + esc(id) + '"]' : '[data-screen-label="' + esc(id) + '"]',
-      label: tag + cls,
-      text: (el.textContent || '').replace(/\\s+/g, ' ').trim().slice(0, 160),
+      selector: cssPath(el),
+      label: shortLabel(el),
+      text: meaningfulText(el),
       position: { x: Math.round(rect.x), y: Math.round(rect.y), width: Math.round(rect.width), height: Math.round(rect.height) },
       htmlHint: html.slice(0, 180)
     };
   }
+  function relativePoint(ev){
+    return { x: Math.round(ev.clientX), y: Math.round(ev.clientY) };
+  }
+  function postStroke(type){
+    window.parent.postMessage({ type: type, points: stroke.slice() }, '*');
+  }
   function allTargets(){
-    var nodes = document.querySelectorAll('[data-od-id], [data-screen-label]');
+    if (selectableCache) return selectableCache;
+    var nodes = document.body ? document.body.querySelectorAll('*') : [];
     var items = [];
     for (var i = 0; i < nodes.length; i++) {
       var item = targetFrom(nodes[i]);
       if (item) items.push(item);
     }
-    return items;
+    selectableCache = items;
+    return selectableCache;
   }
   var postTargetsPending = false;
   function postTargets(){
     if (!enabled) return;
+    selectableCache = null;
     window.parent.postMessage({ type: 'od:comment-targets', targets: allTargets() }, '*');
   }
   function schedulePostTargets(){
@@ -149,9 +214,9 @@ function injectCommentBridge(doc: string): string {
     });
   }
   function closestTarget(event){
-    var el = event.target;
+    var el = event.target && event.target.nodeType === 3 ? event.target.parentElement : event.target;
     while (el && el !== document.documentElement) {
-      if (el.getAttribute && (el.hasAttribute('data-od-id') || el.hasAttribute('data-screen-label'))) return el;
+      if (isSelectableElement(el)) return el;
       el = el.parentElement;
     }
     return null;
@@ -159,12 +224,19 @@ function injectCommentBridge(doc: string): string {
   window.addEventListener('message', function(ev){
     if (!ev.data || ev.data.type !== 'od:comment-mode') return;
     enabled = !!ev.data.enabled;
+    mode = ev.data.mode === 'pod' ? 'pod' : 'picker';
     document.documentElement.toggleAttribute('data-od-comment-mode', enabled);
+    document.documentElement.setAttribute('data-od-comment-mode-kind', mode);
     if (enabled) setTimeout(postTargets, 0);
     else hoveredId = null;
+    if (!enabled || mode !== 'pod') {
+      drawing = false;
+      stroke = [];
+      window.parent.postMessage({ type: 'od:pod-clear' }, '*');
+    }
   });
   document.addEventListener('mouseover', function(ev){
-    if (!enabled) return;
+    if (!enabled || mode !== 'picker') return;
     var el = closestTarget(ev);
     if (!el) return;
     var payload = targetFrom(el);
@@ -173,7 +245,7 @@ function injectCommentBridge(doc: string): string {
     window.parent.postMessage(Object.assign({}, payload, { type: 'od:comment-hover' }), '*');
   }, true);
   document.addEventListener('mouseout', function(ev){
-    if (!enabled) return;
+    if (!enabled || mode !== 'picker') return;
     var el = closestTarget(ev);
     if (!el) return;
     var next = ev.relatedTarget;
@@ -185,7 +257,7 @@ function injectCommentBridge(doc: string): string {
     window.parent.postMessage({ type: 'od:comment-leave' }, '*');
   }, true);
   document.addEventListener('click', function(ev){
-    if (!enabled) return;
+    if (!enabled || mode !== 'picker') return;
     var el = closestTarget(ev);
     if (!el) return;
     ev.preventDefault();
@@ -193,14 +265,45 @@ function injectCommentBridge(doc: string): string {
     var payload = targetFrom(el);
     if (payload) window.parent.postMessage(payload, '*');
   }, true);
+  document.addEventListener('pointerdown', function(ev){
+    if (!enabled || mode !== 'pod' || ev.button !== 0) return;
+    drawing = true;
+    stroke = [relativePoint(ev)];
+    ev.preventDefault();
+    ev.stopPropagation();
+    postStroke('od:pod-stroke');
+  }, true);
+  document.addEventListener('pointermove', function(ev){
+    if (!drawing || mode !== 'pod') return;
+    var point = relativePoint(ev);
+    var last = stroke[stroke.length - 1];
+    if (last && Math.hypot(last.x - point.x, last.y - point.y) < 4) return;
+    stroke.push(point);
+    ev.preventDefault();
+    ev.stopPropagation();
+    postStroke('od:pod-stroke');
+  }, true);
+  function finishStroke(ev){
+    if (!drawing || mode !== 'pod') return;
+    drawing = false;
+    if (ev) {
+      ev.preventDefault();
+      ev.stopPropagation();
+    }
+    postStroke('od:pod-select');
+  }
+  document.addEventListener('pointerup', finishStroke, true);
+  document.addEventListener('pointercancel', finishStroke, true);
   window.addEventListener('resize', schedulePostTargets);
   document.addEventListener('scroll', schedulePostTargets, true);
+  var mo = new MutationObserver(schedulePostTargets);
+  mo.observe(document.documentElement, { subtree: true, childList: true, attributes: true, characterData: true });
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', postTargets);
   else setTimeout(postTargets, 0);
 })();</script>`;
   const style = `<style data-od-comment-bridge-style>
-html[data-od-comment-mode] [data-od-id],
-html[data-od-comment-mode] [data-screen-label] { cursor: crosshair !important; }
+html[data-od-comment-mode] body * { cursor: crosshair !important; }
+html[data-od-comment-mode][data-od-comment-mode-kind="pod"] body * { cursor: cell !important; }
 </style>`;
   const withStyle = /<\/head>/i.test(doc)
     ? doc.replace(/<\/head>/i, style + '</head>')

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -24,6 +24,8 @@ import type {
   ProjectDeploymentsResponse,
   PersistedAgentEvent,
   Project,
+  PreviewCommentMember,
+  PreviewCommentSelectionKind,
   PreviewComment,
   PreviewCommentStatus,
   PreviewCommentTarget,
@@ -42,6 +44,8 @@ import type {
   SkillSummary,
   UpdateDeployConfigRequest,
 } from '@open-design/contracts';
+
+export type { PreviewCommentMember, PreviewCommentSelectionKind } from '@open-design/contracts';
 
 export type ExecMode = 'daemon' | 'api';
 export type ApiProtocol = 'anthropic' | 'openai' | 'azure' | 'google';

--- a/apps/web/tests/comments.test.ts
+++ b/apps/web/tests/comments.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  buildBoardCommentAttachments,
   commentsToAttachments,
   historyWithCommentAttachmentContext,
   liveSnapshotForComment,
@@ -38,6 +39,99 @@ describe('preview comment attachment helpers', () => {
       { id: 'c1', order: 1, elementId: 'hero-title', comment: 'Shorten this title' },
       { id: 'c2', order: 2, elementId: 'chart', comment: 'Make it feel real' },
     ]);
+  });
+
+  it('builds grouped board payloads for pod selections', () => {
+    const attachments = buildBoardCommentAttachments({
+      target: {
+        filePath: 'atlas.html',
+        elementId: 'pod-1',
+        selector: '[data-od-id="hero"], [data-od-id="chart"]',
+        label: 'Hero and chart',
+        text: 'Hero title Chart value',
+        position: { x: 10, y: 20, width: 300, height: 200 },
+        htmlHint: '<section data-od-id="hero">',
+        selectionKind: 'pod',
+        memberCount: 2,
+        podMembers: [
+          {
+            elementId: 'hero',
+            selector: '[data-od-id="hero"]',
+            label: 'section.hero',
+            text: 'Hero title',
+            position: { x: 10, y: 20, width: 200, height: 100 },
+            htmlHint: '<section data-od-id="hero">',
+          },
+          {
+            elementId: 'chart',
+            selector: '[data-od-id="chart"]',
+            label: 'section.chart',
+            text: 'Chart value',
+            position: { x: 120, y: 80, width: 190, height: 120 },
+            htmlHint: '<section data-od-id="chart">',
+          },
+        ],
+      },
+      notes: ['Tighten the hierarchy', 'Make the chart feel premium'],
+    });
+
+    expect(attachments).toHaveLength(2);
+    expect(attachments[0]).toMatchObject({
+      selectionKind: 'pod',
+      memberCount: 2,
+      source: 'board-batch',
+      comment: 'Tighten the hierarchy',
+    });
+    expect(messageContentWithCommentAttachments('', attachments)).toContain('memberCount: 2');
+  });
+
+  it('keeps large queued board-note batches ordered in one send payload', () => {
+    const notes = Array.from({ length: 8 }, (_, index) => `Note ${index + 1}`);
+    const attachments = buildBoardCommentAttachments({
+      target: {
+        filePath: 'atlas.html',
+        elementId: 'pod-2',
+        selector: '[data-od-id="card"]',
+        label: 'Card pod',
+        text: 'Heading Body CTA',
+        position: { x: 20, y: 30, width: 240, height: 160 },
+        htmlHint: '<section data-od-id="card">',
+        selectionKind: 'pod',
+        memberCount: 3,
+        podMembers: [
+          {
+            elementId: 'card-heading',
+            selector: '[data-od-id="card-heading"]',
+            label: 'h2.card-heading',
+            text: 'Heading',
+            position: { x: 24, y: 34, width: 100, height: 32 },
+            htmlHint: '<h2 data-od-id="card-heading">',
+          },
+          {
+            elementId: 'card-body',
+            selector: '[data-od-id="card-body"]',
+            label: 'p.card-body',
+            text: 'Body',
+            position: { x: 24, y: 72, width: 180, height: 48 },
+            htmlHint: '<p data-od-id="card-body">',
+          },
+          {
+            elementId: 'card-cta',
+            selector: '[data-od-id="card-cta"]',
+            label: 'button.card-cta',
+            text: 'CTA',
+            position: { x: 24, y: 128, width: 96, height: 32 },
+            htmlHint: '<button data-od-id="card-cta">',
+          },
+        ],
+      },
+      notes,
+    });
+
+    expect(attachments).toHaveLength(8);
+    expect(attachments.map((attachment) => attachment.order)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+    expect(attachments.map((attachment) => attachment.comment)).toEqual(notes);
+    expect(messageContentWithCommentAttachments('', attachments)).toContain('8. pod-2');
   });
 
   it('updates and removes attached comments by saved comment id', () => {

--- a/apps/web/tests/runtime/srcdoc.test.ts
+++ b/apps/web/tests/runtime/srcdoc.test.ts
@@ -48,10 +48,16 @@ describe('buildSrcdoc', () => {
 
     expect(srcdoc).toContain('data-od-comment-bridge');
     expect(srcdoc).toContain('var enabled = true;');
+    expect(srcdoc).toContain("var mode = 'picker';");
     expect(srcdoc).toContain("type: 'od:comment-target'");
     expect(srcdoc).toContain("type: 'od:comment-hover'");
     expect(srcdoc).toContain("type: 'od:comment-leave'");
     expect(srcdoc).toContain("type: 'od:comment-targets'");
+    expect(srcdoc).toContain("postStroke('od:pod-stroke')");
+    expect(srcdoc).toContain("postStroke('od:pod-select')");
+    expect(srcdoc).toContain('data-od-comment-mode-kind');
+    expect(srcdoc).toContain("body * { cursor: crosshair !important; }");
+    expect(srcdoc).toContain('MutationObserver(schedulePostTargets)');
     expect(srcdoc).toContain("document.addEventListener('scroll', schedulePostTargets, true);");
     expect(srcdoc).toContain('data-od-comment-bridge-style');
   });

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -1,5 +1,9 @@
 import type { ProjectFile } from './files';
-import type { PreviewCommentPosition } from './comments';
+import type {
+  PreviewCommentMember,
+  PreviewCommentPosition,
+  PreviewCommentSelectionKind,
+} from './comments';
 
 export type ChatRole = 'user' | 'assistant';
 
@@ -71,6 +75,10 @@ export interface ChatCommentAttachment {
   currentText: string;
   pagePosition: PreviewCommentPosition;
   htmlHint: string;
+  selectionKind?: PreviewCommentSelectionKind;
+  memberCount?: number;
+  podMembers?: PreviewCommentMember[];
+  source?: 'saved-comment' | 'board-batch';
 }
 
 export type PersistedAgentEvent =

--- a/packages/contracts/src/api/comments.ts
+++ b/packages/contracts/src/api/comments.ts
@@ -15,6 +15,17 @@ export interface PreviewCommentPosition {
   height: number;
 }
 
+export type PreviewCommentSelectionKind = 'element' | 'pod';
+
+export interface PreviewCommentMember {
+  elementId: string;
+  selector: string;
+  label: string;
+  text: string;
+  position: PreviewCommentPosition;
+  htmlHint: string;
+}
+
 export interface PreviewCommentTarget {
   filePath: string;
   elementId: string;
@@ -23,6 +34,9 @@ export interface PreviewCommentTarget {
   text: string;
   position: PreviewCommentPosition;
   htmlHint: string;
+  selectionKind?: PreviewCommentSelectionKind;
+  memberCount?: number;
+  podMembers?: PreviewCommentMember[];
 }
 
 export interface PreviewComment {
@@ -36,6 +50,9 @@ export interface PreviewComment {
   text: string;
   position: PreviewCommentPosition;
   htmlHint: string;
+  selectionKind?: PreviewCommentSelectionKind;
+  memberCount?: number;
+  podMembers?: PreviewCommentMember[];
   note: string;
   status: PreviewCommentStatus;
   createdAt: number;
@@ -60,4 +77,3 @@ export interface PreviewCommentsResponse {
 }
 
 export interface PreviewCommentDeleteResponse extends OkResponse {}
-


### PR DESCRIPTION
## Summary
- add a `Tweaks` workflow for rendered HTML previews
- support precise DOM-backed picking and freehand pod selection inside the preview iframe
- let users queue multiple notes and send them to chat as one structured attachment batch

## What changed
- extend preview comment contracts and persistence so pod selections can carry grouped member context
- upgrade the HTML preview bridge to expose nested DOM targets plus pod-stroke events
- replace the old single comment toggle with `Tweaks`, `Picker`, and `Pods` in the HTML viewer
- add helper/runtime/daemon tests for batched board attachments and the richer iframe bridge

## Validation
- `npm exec pnpm -- --filter @open-design/web typecheck`
- `npm exec pnpm -- --filter @open-design/web exec vitest run tests/comments.test.ts tests/runtime/srcdoc.test.ts`
- `npm exec pnpm -- --filter @open-design/daemon exec vitest run tests/comment-attachments.test.ts`
- `npm exec pnpm -- --filter @open-design/web build`
