### PR TITLE
fix(daemon): preserve ANTHROPIC_API_KEY when ANTHROPIC_BASE_URL is set

### DIFF
--- a/apps/daemon/src/agents.ts
+++ b/apps/daemon/src/agents.ts
@@ -1173,7 +1173,10 @@ export function spawnEnvForAgent(agentId, baseEnv) {
   const env = { ...baseEnv };
   if (agentId !== 'claude') return env;
   const hasCustomBaseUrl = Object.keys(env).some(
-    (k) => k.toUpperCase() === 'ANTHROPIC_BASE_URL',
+    (k) =>
+      k.toUpperCase() === 'ANTHROPIC_BASE_URL' &&
+      typeof env[k] === 'string' &&
+      env[k].trim() !== '',
   );
   if (hasCustomBaseUrl) return env;
   for (const key of Object.keys(env)) {

--- a/apps/daemon/src/agents.ts
+++ b/apps/daemon/src/agents.ts
@@ -1159,6 +1159,11 @@ export function resolveAgentBin(id) {
 // launched from a shell that exported the key for SDK or scripting use.
 // See issue #398.
 //
+// However, when ANTHROPIC_BASE_URL is set the user is intentionally
+// routing Claude Code to a custom endpoint (e.g. a Kimi/Moonshot proxy).
+// In that case claude login is meaningless, so preserve the API key so
+// the child can authenticate against the custom base URL.
+//
 // Windows env-var names are case-insensitive at the kernel level
 // (`GetEnvironmentVariable`), but spreading `process.env` into a plain
 // object loses Node's case-insensitive accessor — `Anthropic_Api_Key`
@@ -1167,6 +1172,10 @@ export function resolveAgentBin(id) {
 export function spawnEnvForAgent(agentId, baseEnv) {
   const env = { ...baseEnv };
   if (agentId !== 'claude') return env;
+  const hasCustomBaseUrl = Object.keys(env).some(
+    (k) => k.toUpperCase() === 'ANTHROPIC_BASE_URL',
+  );
+  if (hasCustomBaseUrl) return env;
   for (const key of Object.keys(env)) {
     if (key.toUpperCase() === 'ANTHROPIC_API_KEY') delete env[key];
   }

--- a/apps/daemon/tests/agents.test.ts
+++ b/apps/daemon/tests/agents.test.ts
@@ -1093,6 +1093,28 @@ test('spawnEnvForAgent preserves ANTHROPIC_API_KEY when ANTHROPIC_BASE_URL is se
   assert.equal(env.PATH, '/usr/bin');
 });
 
+test('spawnEnvForAgent strips ANTHROPIC_API_KEY when ANTHROPIC_BASE_URL is empty', () => {
+  const env = spawnEnvForAgent('claude', {
+    ANTHROPIC_API_KEY: 'sk-leak',
+    ANTHROPIC_BASE_URL: '',
+    PATH: '/usr/bin',
+  });
+
+  assert.equal('ANTHROPIC_API_KEY' in env, false);
+  assert.equal(env.PATH, '/usr/bin');
+});
+
+test('spawnEnvForAgent strips ANTHROPIC_API_KEY when ANTHROPIC_BASE_URL is whitespace', () => {
+  const env = spawnEnvForAgent('claude', {
+    ANTHROPIC_API_KEY: 'sk-leak',
+    ANTHROPIC_BASE_URL: '   ',
+    PATH: '/usr/bin',
+  });
+
+  assert.equal('ANTHROPIC_API_KEY' in env, false);
+  assert.equal(env.PATH, '/usr/bin');
+});
+
 test('spawnEnvForAgent does not mutate the input env', () => {
   const original = { ANTHROPIC_API_KEY: 'sk-leak', PATH: '/usr/bin' };
   const env = spawnEnvForAgent('claude', original);

--- a/apps/daemon/tests/agents.test.ts
+++ b/apps/daemon/tests/agents.test.ts
@@ -1081,6 +1081,18 @@ test('spawnEnvForAgent preserves ANTHROPIC_API_KEY for non-claude adapters', () 
   }
 });
 
+test('spawnEnvForAgent preserves ANTHROPIC_API_KEY when ANTHROPIC_BASE_URL is set', () => {
+  const env = spawnEnvForAgent('claude', {
+    ANTHROPIC_API_KEY: 'sk-kimi',
+    ANTHROPIC_BASE_URL: 'https://api.moonshot.cn/v1',
+    PATH: '/usr/bin',
+  });
+
+  assert.equal(env.ANTHROPIC_API_KEY, 'sk-kimi');
+  assert.equal(env.ANTHROPIC_BASE_URL, 'https://api.moonshot.cn/v1');
+  assert.equal(env.PATH, '/usr/bin');
+});
+
 test('spawnEnvForAgent does not mutate the input env', () => {
   const original = { ANTHROPIC_API_KEY: 'sk-leak', PATH: '/usr/bin' };
   const env = spawnEnvForAgent('claude', original);


### PR DESCRIPTION
## Summary

  When `ANTHROPIC_BASE_URL` is set, the user is intentionally routing Claude Code to a custom endpoint (e.g. a Kimi/Moonshot
  proxy). In that case `claude login` is meaningless because the endpoint is not Anthropic's.

  Currently `spawnEnvForAgent` unconditionally strips `ANTHROPIC_API_KEY` for the claude adapter (issue #398). This makes sense
   for the default case — it prevents Claude Code from silently falling back to API-key billing when the daemon happens to be
  launched from a shell that exported the key for SDK use.

  However, it breaks users who rely on custom base URLs + API keys. This PR preserves `ANTHROPIC_API_KEY` when
  `ANTHROPIC_BASE_URL` is detected, while keeping the stripping behavior for the default (no custom base URL) case.

  ## Changes

  - `apps/daemon/src/agents.ts`: check for `ANTHROPIC_BASE_URL` before stripping `ANTHROPIC_API_KEY`
  - `apps/daemon/tests/agents.test.ts`: add test for the new behavior

  ## Test plan

  - [x] spawnEnvForAgent tests pass