### PR TITLE
fix(web): todo card dark mode styling

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6535,7 +6535,7 @@ button.connector-action.is-loading {
   gap: 10px;
   padding: 5px 8px;
   line-height: 1.45;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   border: 1px solid transparent;
   transition: background-color 120ms ease, border-color 120ms ease;
 }
@@ -6566,7 +6566,7 @@ button.connector-action.is-loading {
 .todo-completed .todo-text {
   text-decoration: line-through;
   text-decoration-color: color-mix(in srgb, var(--text-muted) 60%, transparent);
-  color: var(--text-soft);
+  color: var(--text-muted);
 }
 
 /* Composer extras */
@@ -7148,13 +7148,13 @@ button.connector-action.is-loading {
   letter-spacing: 0.02em;
   text-transform: uppercase;
   font-size: 11px;
-  color: var(--accent);
+  color: var(--text-strong);
 }
 .op-todo .op-meta {
   margin-left: auto;
   font-variant-numeric: tabular-nums;
   font-size: 11px;
-  color: var(--accent);
+  color: var(--text-strong);
 }
 
 /* Question form — interactive form a planning agent can post into chat */

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6523,31 +6523,51 @@ button.connector-action.is-loading {
 .op-todo .todo-list {
   list-style: none;
   margin: 0;
-  padding: 4px 12px 10px;
+  padding: 6px 8px 10px;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 1px;
   font-size: 12px;
 }
 .todo-item {
   display: flex;
   align-items: flex-start;
-  gap: 8px;
-  padding: 2px 0;
-  line-height: 1.4;
+  gap: 10px;
+  padding: 5px 8px;
+  line-height: 1.45;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  transition: background-color 120ms ease, border-color 120ms ease;
 }
 .todo-check {
   width: 16px;
   flex-shrink: 0;
-  color: var(--text-muted);
+  color: var(--text-soft);
   font-family: var(--mono);
   text-align: center;
+  line-height: 1.45;
 }
+.todo-text { color: var(--text); }
+
+/* Pending — quietly waiting */
+.todo-pending .todo-check { color: var(--text-faint); }
 .todo-pending .todo-text { color: var(--text-muted); }
+
+/* In progress — the only row that should pop */
+.todo-in_progress {
+  background: color-mix(in srgb, var(--accent) 10%, var(--bg-panel));
+  border-color: color-mix(in srgb, var(--accent) 28%, transparent);
+}
 .todo-in_progress .todo-check { color: var(--accent); }
-.todo-in_progress .todo-text { color: var(--text); font-weight: 500; }
+.todo-in_progress .todo-text { color: var(--text-strong); font-weight: 600; }
+
+/* Completed — settled, but still readable */
 .todo-completed .todo-check { color: var(--green); }
-.todo-completed .todo-text { text-decoration: line-through; color: var(--text-muted); }
+.todo-completed .todo-text {
+  text-decoration: line-through;
+  text-decoration-color: color-mix(in srgb, var(--text-muted) 60%, transparent);
+  color: var(--text-soft);
+}
 
 /* Composer extras */
 .composer.drag-active {
@@ -7114,27 +7134,27 @@ button.connector-action.is-loading {
 /* op-todo card variant (the .op-todo .todo-list rule already exists above) */
 .op-todo {
   border-color: var(--accent-soft);
-  background: linear-gradient(180deg, #fff8f3 0%, var(--bg-panel) 60%);
+  background: linear-gradient(180deg, var(--accent-tint) 0%, var(--bg-panel) 60%);
 }
 .op-todo .op-card-head {
-  border-bottom: 1px solid var(--accent-soft);
+  border-bottom: 1px solid color-mix(in srgb, var(--accent-soft) 70%, transparent);
   background: transparent;
 }
 .op-todo .op-icon {
   background: var(--accent-soft);
-  color: var(--accent-hover);
+  color: var(--accent);
 }
 .op-todo .op-title {
   letter-spacing: 0.02em;
   text-transform: uppercase;
   font-size: 11px;
-  color: var(--accent-hover);
+  color: var(--accent);
 }
 .op-todo .op-meta {
   margin-left: auto;
   font-variant-numeric: tabular-nums;
   font-size: 11px;
-  color: var(--accent-hover);
+  color: var(--accent);
 }
 
 /* Question form — interactive form a planning agent can post into chat */


### PR DESCRIPTION
## Summary
- Replace the todo card's hardcoded light surface with theme-aware accent/background tokens.
- Improve todo row hierarchy and readability for pending, active, and completed states in dark mode.

## Validation
- pnpm guard
- pnpm --filter @open-design/web typecheck

## Screenshot

Before:
<img width="916" height="658" alt="image" src="https://github.com/user-attachments/assets/1a3fca25-ba68-4ad8-a31d-22c678db6c1e" />

After:
<img width="954" height="798" alt="image" src="https://github.com/user-attachments/assets/ab947145-43bf-4efe-82a1-fe76286fb7c6" />
