### PR TITLE
fix: batch of small bug fixes (#283, #275, #390)

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -222,7 +222,7 @@
 
 ### 1 · لا نشحن وكيلاً، وكيلك كافٍ
 
-الـ daemon يمسح `PATH` بحثاً عن [`claude`](https://docs.anthropic.com/en/docs/claude-code) و [`codex`](https://github.com/openai/codex) و `devin` و [`cursor-agent`](https://www.cursor.com/cli) و [`gemini`](https://github.com/google-gemini/gemini-cli) و [`opencode`](https://opencode.ai/) و [`qwen`](https://github.com/QwenLM/qwen-code) و `qodercli` و [`copilot`](https://github.com/features/copilot/cli) و `hermes` و `kimi` و [`pi`](https://github.com/mariozechner/pi-ai) و [`kiro-cli`](https://kiro.dev) و [`vibe-acp`](https://github.com/mistralai/mistral-vibe) عند الإقلاع. ما يجده يصبح محرّك تصميم مرشّحاً — يُشغَّل عبر stdio بـ adapter لكل CLI، قابل للتبديل من الـ model picker. الإلهام من [`multica`](https://github.com/multica-ai/multica) و [`cc-switch`](https://github.com/farion1231/cc-switch). لا CLI مثبتة؟ وضع API هو نفس خط الأنابيب بدون spawn — اختر Anthropic أو متوافق مع OpenAI أو Azure OpenAI أو Google Gemini ويُعيد الـ daemon توجيه قطع SSE المُطبَّعة، مع رفض loopback / link-local / RFC1918 عند الحدّ.
+الـ daemon يمسح `PATH` بحثاً عن [`claude`](https://docs.anthropic.com/en/docs/claude-code) و [`codex`](https://github.com/openai/codex) و `devin` و [`cursor-agent`](https://www.cursor.com/cli) و [`gemini`](https://github.com/google-gemini/gemini-cli) و [`opencode`](https://opencode.ai/) و [`qwen`](https://github.com/QwenLM/qwen-code) و `qodercli` و [`copilot`](https://github.com/features/copilot/cli) و `hermes` و `kimi` و [`pi`](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) و [`kiro-cli`](https://kiro.dev) و [`vibe-acp`](https://github.com/mistralai/mistral-vibe) عند الإقلاع. ما يجده يصبح محرّك تصميم مرشّحاً — يُشغَّل عبر stdio بـ adapter لكل CLI، قابل للتبديل من الـ model picker. الإلهام من [`multica`](https://github.com/multica-ai/multica) و [`cc-switch`](https://github.com/farion1231/cc-switch). لا CLI مثبتة؟ وضع API هو نفس خط الأنابيب بدون spawn — اختر Anthropic أو متوافق مع OpenAI أو Azure OpenAI أو Google Gemini ويُعيد الـ daemon توجيه قطع SSE المُطبَّعة، مع رفض loopback / link-local / RFC1918 عند الحدّ.
 
 ### 2 · الـ Skills ملفات، لا plugins
 
@@ -694,7 +694,7 @@ OD لا يقف عند الكود. نفس واجهة الـ chat التي تنت�
 
 [cd]: https://x.com/claudeai/status/2045156267690213649
 [ocod]: https://github.com/OpenCoworkAI/open-codesign
-[piai]: https://github.com/mariozechner/pi-ai
+[piai]: https://github.com/badlogic/pi-mono/tree/main/packages/ai
 [acd]: https://github.com/VoltAgent/awesome-claude-design
 [guizang]: https://github.com/op7418/guizang-ppt-skill
 [skill]: https://docs.anthropic.com/en/docs/claude-code/skills
@@ -720,7 +720,7 @@ OD لا يقف عند الكود. نفس واجهة الـ chat التي تنت�
 | Kilo | `kilo` | `acp-json-rpc` | `kilo acp` |
 | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | `vibe-acp` | `acp-json-rpc` | `vibe-acp` |
 | DeepSeek TUI | `deepseek` | `plain` (raw stdout chunks) | `deepseek exec --auto [--model …] <prompt>` |
-| [Pi](https://github.com/mariozechner/pi-ai) | `pi` | `pi-rpc` (stdio JSON-RPC) | `pi --mode rpc [--model …] [--thinking …]` (البرومبت يُرسل كأمر RPC `prompt`) |
+| [Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | `pi` | `pi-rpc` (stdio JSON-RPC) | `pi --mode rpc [--model …] [--thinking …]` (البرومبت يُرسل كأمر RPC `prompt`) |
 | **BYOK متعدّد المزوّدين** | n/a | تطبيع SSE | `POST /api/proxy/{provider}/stream` → Anthropic / متوافق OpenAI / Azure OpenAI / Gemini؛ محمي SSRF ضد loopback / link-local / RFC1918 |
 
 إضافة CLI جديدة = مدخل واحد في [`apps/daemon/src/agents.ts`](apps/daemon/src/agents.ts). صيغة البثّ واحدة من `claude-stream-json` أو `qoder-stream-json` أو `copilot-stream-json` أو `json-event-stream` (مع `eventParser` لكل CLI) أو `acp-json-rpc` أو `pi-rpc` أو `plain`.

--- a/README.de.md
+++ b/README.de.md
@@ -219,7 +219,7 @@ Einen Skill hinzuzufügen bedeutet: ein Ordner. Lesen Sie [`docs/skills-protocol
 
 ### 1 · Wir liefern keinen Agent. Ihrer ist gut genug.
 
-Der daemon durchsucht beim Start Ihren `PATH` nach [`claude`](https://docs.anthropic.com/en/docs/claude-code), [`codex`](https://github.com/openai/codex), [`cursor-agent`](https://www.cursor.com/cli), [`gemini`](https://github.com/google-gemini/gemini-cli), [`opencode`](https://opencode.ai/), [`qwen`](https://github.com/QwenLM/qwen-code), `qodercli`, [`copilot`](https://github.com/features/copilot/cli), `hermes`, `kimi` und [`pi`](https://github.com/mariozechner/pi-ai). Was er findet, wird zur möglichen Design-Engine: über stdio mit je einem Adapter pro CLI gesteuert und im Model Picker austauschbar. Inspiriert von [`multica`](https://github.com/multica-ai/multica) und [`cc-switch`](https://github.com/farion1231/cc-switch). Keine CLI installiert? `POST /api/proxy/stream` ist dieselbe Pipeline ohne Spawn: Fügen Sie ein beliebiges OpenAI-kompatibles `baseUrl` + `apiKey` ein, und der daemon leitet SSE-Chunks zurück, wobei loopback / link-local / RFC1918 Ziele am Rand abgelehnt werden.
+Der daemon durchsucht beim Start Ihren `PATH` nach [`claude`](https://docs.anthropic.com/en/docs/claude-code), [`codex`](https://github.com/openai/codex), [`cursor-agent`](https://www.cursor.com/cli), [`gemini`](https://github.com/google-gemini/gemini-cli), [`opencode`](https://opencode.ai/), [`qwen`](https://github.com/QwenLM/qwen-code), `qodercli`, [`copilot`](https://github.com/features/copilot/cli), `hermes`, `kimi` und [`pi`](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent). Was er findet, wird zur möglichen Design-Engine: über stdio mit je einem Adapter pro CLI gesteuert und im Model Picker austauschbar. Inspiriert von [`multica`](https://github.com/multica-ai/multica) und [`cc-switch`](https://github.com/farion1231/cc-switch). Keine CLI installiert? `POST /api/proxy/stream` ist dieselbe Pipeline ohne Spawn: Fügen Sie ein beliebiges OpenAI-kompatibles `baseUrl` + `apiKey` ein, und der daemon leitet SSE-Chunks zurück, wobei loopback / link-local / RFC1918 Ziele am Rand abgelehnt werden.
 
 ### 2 · Skills sind Dateien, keine Plugins.
 
@@ -621,7 +621,7 @@ Die gesamte Maschinerie unten ist das [`huashu-design`](https://github.com/alcha
 
 [cd]: https://x.com/claudeai/status/2045156267690213649
 [ocod]: https://github.com/OpenCoworkAI/open-codesign
-[piai]: https://github.com/mariozechner/pi-ai
+[piai]: https://github.com/badlogic/pi-mono/tree/main/packages/ai
 [acd]: https://github.com/VoltAgent/awesome-claude-design
 [guizang]: https://github.com/op7418/guizang-ppt-skill
 [skill]: https://docs.anthropic.com/en/docs/claude-code/skills
@@ -643,7 +643,7 @@ Beim daemon Boot automatisch aus `PATH` erkannt. Keine Konfiguration nötig. Str
 | [GitHub Copilot CLI](https://github.com/features/copilot/cli) | `copilot` | `copilot-stream-json` (typed events) | `copilot -p <prompt> --allow-all-tools --output-format json [--model …] [--add-dir …]` |
 | [Hermes](https://github.com/eqlabs/hermes) | `hermes` | `acp-json-rpc` (Agent Client Protocol) | `hermes acp --accept-hooks` |
 | Kimi CLI | `kimi` | `acp-json-rpc` | `kimi acp` |
-| [Pi](https://github.com/mariozechner/pi-ai) | `pi` | `pi-rpc` (stdio JSON-RPC) | `pi --mode rpc [--model …] [--thinking …]` (Prompt als RPC-`prompt` Befehl gesendet) |
+| [Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | `pi` | `pi-rpc` (stdio JSON-RPC) | `pi --mode rpc [--model …] [--thinking …]` (Prompt als RPC-`prompt` Befehl gesendet) |
 | [Kiro CLI](https://kiro.dev) | `kiro-cli` | `acp-json-rpc` | `kiro-cli acp` |
 | Kilo | `kilo` | `acp-json-rpc` | `kilo acp` |
 | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | `vibe-acp` | `acp-json-rpc` | `vibe-acp` |

--- a/README.es.md
+++ b/README.es.md
@@ -219,7 +219,7 @@ Añadir una skill toma una carpeta. Lee [`docs/skills-protocol.md`](docs/skills-
 
 ### 1 · No distribuimos un agente. El tuyo es suficiente.
 
-El daemon escanea tu `PATH` buscando [`claude`](https://docs.anthropic.com/en/docs/claude-code), [`codex`](https://github.com/openai/codex), `devin`, [`cursor-agent`](https://www.cursor.com/cli), [`gemini`](https://github.com/google-gemini/gemini-cli), [`opencode`](https://opencode.ai/), [`qwen`](https://github.com/QwenLM/qwen-code), `qodercli`, [`copilot`](https://github.com/features/copilot/cli), `hermes`, `kimi`, [`pi`](https://github.com/mariozechner/pi-ai), [`kiro-cli`](https://kiro.dev), `kilo`, [`vibe-acp`](https://github.com/mistralai/mistral-vibe) y `deepseek` al iniciar. Los que encuentra se vuelven motores de diseño candidatos, controlados por stdio con un adapter por CLI y reemplazables desde el selector de modelo. Inspirado por [`multica`](https://github.com/multica-ai/multica) y [`cc-switch`](https://github.com/farion1231/cc-switch). ¿Sin CLI instalada? El modo API es el mismo pipeline sin spawn: elige Anthropic, OpenAI-compatible, Azure OpenAI o Google Gemini y el daemon devuelve chunks SSE normalizados, rechazando loopback / link-local / RFC1918 en el borde.
+El daemon escanea tu `PATH` buscando [`claude`](https://docs.anthropic.com/en/docs/claude-code), [`codex`](https://github.com/openai/codex), `devin`, [`cursor-agent`](https://www.cursor.com/cli), [`gemini`](https://github.com/google-gemini/gemini-cli), [`opencode`](https://opencode.ai/), [`qwen`](https://github.com/QwenLM/qwen-code), `qodercli`, [`copilot`](https://github.com/features/copilot/cli), `hermes`, `kimi`, [`pi`](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent), [`kiro-cli`](https://kiro.dev), `kilo`, [`vibe-acp`](https://github.com/mistralai/mistral-vibe) y `deepseek` al iniciar. Los que encuentra se vuelven motores de diseño candidatos, controlados por stdio con un adapter por CLI y reemplazables desde el selector de modelo. Inspirado por [`multica`](https://github.com/multica-ai/multica) y [`cc-switch`](https://github.com/farion1231/cc-switch). ¿Sin CLI instalada? El modo API es el mismo pipeline sin spawn: elige Anthropic, OpenAI-compatible, Azure OpenAI o Google Gemini y el daemon devuelve chunks SSE normalizados, rechazando loopback / link-local / RFC1918 en el borde.
 
 ### 2 · Las Skills son archivos, no plugins.
 
@@ -681,7 +681,7 @@ Todo lo siguiente es el playbook de [`huashu-design`](https://github.com/alchain
 
 [cd]: https://x.com/claudeai/status/2045156267690213649
 [ocod]: https://github.com/OpenCoworkAI/open-codesign
-[piai]: https://github.com/mariozechner/pi-ai
+[piai]: https://github.com/badlogic/pi-mono/tree/main/packages/ai
 [acd]: https://github.com/VoltAgent/awesome-claude-design
 [guizang]: https://github.com/op7418/guizang-ppt-skill
 [skill]: https://docs.anthropic.com/en/docs/claude-code/skills
@@ -707,7 +707,7 @@ Auto-detectados desde `PATH` al arrancar el daemon. Sin configuración requerida
 | Kilo | `kilo` | `acp-json-rpc` | `kilo acp` |
 | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | `vibe-acp` | `acp-json-rpc` | `vibe-acp` |
 | DeepSeek TUI | `deepseek` | `plain` (chunks raw de stdout) | `deepseek exec --auto [--model …] <prompt>` (prompt como argumento posicional) |
-| [Pi](https://github.com/mariozechner/pi-ai) | `pi` | `pi-rpc` (stdio JSON-RPC) | `pi --mode rpc --no-session [--model …] [--thinking …]` (prompt enviado como comando RPC `prompt`) |
+| [Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | `pi` | `pi-rpc` (stdio JSON-RPC) | `pi --mode rpc --no-session [--model …] [--thinking …]` (prompt enviado como comando RPC `prompt`) |
 | **BYOK multi-provider** | n/a | Normalización SSE | `POST /api/proxy/{provider}/stream` → Anthropic / OpenAI-compatible / Azure OpenAI / Gemini; protegido contra SSRF hacia loopback / link-local / RFC1918 |
 
 Añadir una CLI nueva es una entrada en [`apps/daemon/src/agents.ts`](apps/daemon/src/agents.ts). El formato de streaming es uno de `claude-stream-json`, `qoder-stream-json`, `copilot-stream-json`, `json-event-stream` (con `eventParser` por CLI), `acp-json-rpc`, `pi-rpc` o `plain`.

--- a/README.fr.md
+++ b/README.fr.md
@@ -627,7 +627,7 @@ Tout le mécanisme ci-dessous vient du playbook [`huashu-design`](https://github
 
 [cd]: https://x.com/claudeai/status/2045156267690213649
 [ocod]: https://github.com/OpenCoworkAI/open-codesign
-[piai]: https://github.com/mariozechner/pi-ai
+[piai]: https://github.com/badlogic/pi-mono/tree/main/packages/ai
 [acd]: https://github.com/VoltAgent/awesome-claude-design
 [guizang]: https://github.com/op7418/guizang-ppt-skill
 [skill]: https://docs.anthropic.com/en/docs/claude-code/skills
@@ -653,7 +653,7 @@ Auto-détectés depuis `PATH` au boot du daemon. Aucune config nécessaire. Le d
 | Kilo | `kilo` | `acp-json-rpc` | `kilo acp` |
 | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | `vibe-acp` | `acp-json-rpc` | `vibe-acp` |
 | DeepSeek TUI | `deepseek` | `plain` (raw stdout chunks) | `deepseek exec --auto [--model …] <prompt>` |
-| [Pi](https://github.com/mariozechner/pi-ai) | `pi` | `pi-rpc` | `pi --mode rpc [--model …] [--thinking …]` |
+| [Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | `pi` | `pi-rpc` | `pi --mode rpc [--model …] [--thinking …]` |
 | **BYOK multi-provider** | n/a | SSE normalisé | `POST /api/proxy/{provider}/stream` → Anthropic / OpenAI-compatible / Azure OpenAI / Gemini ; protégé contre loopback / link-local / RFC1918 |
 
 Ajouter une nouvelle CLI revient à ajouter une entrée dans [`apps/daemon/src/agents.ts`](apps/daemon/src/agents.ts). Le format de stream est l’un de `claude-stream-json`, `qoder-stream-json`, `copilot-stream-json`, `json-event-stream`, `acp-json-rpc`, `pi-rpc` ou `plain`.

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -220,7 +220,7 @@ Skill の追加はフォルダ 1 つで完了します。拡張 frontmatter の�
 
 ### 1 · エージェントは同梱しない — あなたのもので十分
 
-Daemon は起動時に `PATH` を走査し、[`claude`](https://docs.anthropic.com/en/docs/claude-code)、[`codex`](https://github.com/openai/codex)、[`cursor-agent`](https://www.cursor.com/cli)、[`gemini`](https://github.com/google-gemini/gemini-cli)、[`opencode`](https://opencode.ai/)、[`qwen`](https://github.com/QwenLM/qwen-code)、`qodercli`、[`copilot`](https://github.com/features/copilot/cli)、`hermes`、`kimi`、[`pi`](https://github.com/mariozechner/pi-ai) を検索します。見つかったものすべてが候補デザインエンジンになります — stdio 経由で CLI ごとに 1 つの adapter を持ち、モデルピッカーからワンクリックで切り替え可能。[`multica`](https://github.com/multica-ai/multica) と [`cc-switch`](https://github.com/farion1231/cc-switch) に着想を得ています。CLI が 1 つもない？`POST /api/proxy/stream` が spawn を除いた同じパイプラインです — 任意の OpenAI 互換 `baseUrl` + `apiKey` を貼れば、daemon が SSE チャンクをブラウザに転送し、loopback / link-local / RFC1918 はエッジで拒否されます。
+Daemon は起動時に `PATH` を走査し、[`claude`](https://docs.anthropic.com/en/docs/claude-code)、[`codex`](https://github.com/openai/codex)、[`cursor-agent`](https://www.cursor.com/cli)、[`gemini`](https://github.com/google-gemini/gemini-cli)、[`opencode`](https://opencode.ai/)、[`qwen`](https://github.com/QwenLM/qwen-code)、`qodercli`、[`copilot`](https://github.com/features/copilot/cli)、`hermes`、`kimi`、[`pi`](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) を検索します。見つかったものすべてが候補デザインエンジンになります — stdio 経由で CLI ごとに 1 つの adapter を持ち、モデルピッカーからワンクリックで切り替え可能。[`multica`](https://github.com/multica-ai/multica) と [`cc-switch`](https://github.com/farion1231/cc-switch) に着想を得ています。CLI が 1 つもない？`POST /api/proxy/stream` が spawn を除いた同じパイプラインです — 任意の OpenAI 互換 `baseUrl` + `apiKey` を貼れば、daemon が SSE チャンクをブラウザに転送し、loopback / link-local / RFC1918 はエッジで拒否されます。
 
 ### 2 · Skill はファイルであり、プラグインではない
 
@@ -618,7 +618,7 @@ OD はコードで止まりません。`<artifact>` の HTML を生み出すの�
 
 [cd]: https://x.com/claudeai/status/2045156267690213649
 [ocod]: https://github.com/OpenCoworkAI/open-codesign
-[piai]: https://github.com/mariozechner/pi-ai
+[piai]: https://github.com/badlogic/pi-mono/tree/main/packages/ai
 [acd]: https://github.com/VoltAgent/awesome-claude-design
 [guizang]: https://github.com/op7418/guizang-ppt-skill
 [skill]: https://docs.anthropic.com/en/docs/claude-code/skills
@@ -640,7 +640,7 @@ Daemon 起動時に `PATH` から自動検出。設定不要。ストリーミ�
 | [GitHub Copilot CLI](https://github.com/features/copilot/cli) | `copilot` | `copilot-stream-json`（型付きイベント） | `copilot -p <prompt> --allow-all-tools --output-format json [--model …] [--add-dir …]` |
 | [Hermes](https://github.com/eqlabs/hermes) | `hermes` | `acp-json-rpc`（Agent Client Protocol） | `hermes acp --accept-hooks` |
 | Kimi CLI | `kimi` | `acp-json-rpc` | `kimi acp` |
-| [Pi](https://github.com/mariozechner/pi-ai) | `pi` | `pi-rpc`（stdio JSON-RPC） | `pi --mode rpc [--model …] [--thinking …]`（プロンプトは RPC `prompt` コマンドで送信） |
+| [Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | `pi` | `pi-rpc`（stdio JSON-RPC） | `pi --mode rpc [--model …] [--thinking …]`（プロンプトは RPC `prompt` コマンドで送信） |
 | [Kiro CLI](https://kiro.dev) | `kiro-cli` | `acp-json-rpc` | `kiro-cli acp` |
 | Kilo | `kilo` | `acp-json-rpc` | `kilo acp` |
 | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | `vibe-acp` | `acp-json-rpc` | `vibe-acp` |

--- a/README.ko.md
+++ b/README.ko.md
@@ -219,7 +219,7 @@ skill 추가는 폴더 하나면 됩니다. [`docs/skills-protocol.md`](docs/ski
 
 ### 1 · 에이전트를 제공하지 않습니다. 여러분의 것으로 충분합니다.
 
-Daemon은 시작 시 `PATH`에서 [`claude`](https://docs.anthropic.com/en/docs/claude-code), [`codex`](https://github.com/openai/codex), [`cursor-agent`](https://www.cursor.com/cli), [`gemini`](https://github.com/google-gemini/gemini-cli), [`opencode`](https://opencode.ai/), [`qwen`](https://github.com/QwenLM/qwen-code), `qodercli`, [`copilot`](https://github.com/features/copilot/cli), `hermes`, `kimi`, [`pi`](https://github.com/mariozechner/pi-ai)를 스캔합니다. 찾은 것들 모두가 후보 디자인 엔진이 됩니다 — stdio를 통해 구동되며 CLI당 하나의 어댑터, 모델 picker에서 즉시 전환 가능. [`multica`](https://github.com/multica-ai/multica)와 [`cc-switch`](https://github.com/farion1231/cc-switch)에서 영감을 받았습니다. CLI가 하나도 설치되어 있지 않다면? `POST /api/proxy/stream`이 spawn만 없는 동일한 파이프라인입니다 — 임의의 OpenAI 호환 `baseUrl` + `apiKey`만 붙여 넣으면 daemon이 SSE 청크를 브라우저로 그대로 전달하며, loopback / link-local / RFC1918 목적지는 경계에서 거부됩니다.
+Daemon은 시작 시 `PATH`에서 [`claude`](https://docs.anthropic.com/en/docs/claude-code), [`codex`](https://github.com/openai/codex), [`cursor-agent`](https://www.cursor.com/cli), [`gemini`](https://github.com/google-gemini/gemini-cli), [`opencode`](https://opencode.ai/), [`qwen`](https://github.com/QwenLM/qwen-code), `qodercli`, [`copilot`](https://github.com/features/copilot/cli), `hermes`, `kimi`, [`pi`](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent)를 스캔합니다. 찾은 것들 모두가 후보 디자인 엔진이 됩니다 — stdio를 통해 구동되며 CLI당 하나의 어댑터, 모델 picker에서 즉시 전환 가능. [`multica`](https://github.com/multica-ai/multica)와 [`cc-switch`](https://github.com/farion1231/cc-switch)에서 영감을 받았습니다. CLI가 하나도 설치되어 있지 않다면? `POST /api/proxy/stream`이 spawn만 없는 동일한 파이프라인입니다 — 임의의 OpenAI 호환 `baseUrl` + `apiKey`만 붙여 넣으면 daemon이 SSE 청크를 브라우저로 그대로 전달하며, loopback / link-local / RFC1918 목적지는 경계에서 거부됩니다.
 
 ### 2 · Skill은 파일이지 플러그인이 아닙니다.
 
@@ -619,7 +619,7 @@ OD는 코드에서 끝나지 않습니다. `<artifact>` HTML을 만드는 동일
 
 [cd]: https://x.com/claudeai/status/2045156267690213649
 [ocod]: https://github.com/OpenCoworkAI/open-codesign
-[piai]: https://github.com/mariozechner/pi-ai
+[piai]: https://github.com/badlogic/pi-mono/tree/main/packages/ai
 [acd]: https://github.com/VoltAgent/awesome-claude-design
 [guizang]: https://github.com/op7418/guizang-ppt-skill
 [skill]: https://docs.anthropic.com/en/docs/claude-code/skills
@@ -641,7 +641,7 @@ daemon 부팅 시 `PATH`에서 자동 감지됩니다. 설정 필요 없음. 스
 | [GitHub Copilot CLI](https://github.com/features/copilot/cli) | `copilot` | `copilot-stream-json`(타입 이벤트) | `copilot -p <prompt> --allow-all-tools --output-format json [--model …] [--add-dir …]` |
 | [Hermes](https://github.com/eqlabs/hermes) | `hermes` | `acp-json-rpc`(Agent Client Protocol) | `hermes acp --accept-hooks` |
 | Kimi CLI | `kimi` | `acp-json-rpc` | `kimi acp` |
-| [Pi](https://github.com/mariozechner/pi-ai) | `pi` | `pi-rpc`(stdio JSON-RPC) | `pi --mode rpc [--model …] [--thinking …]`(prompt는 RPC `prompt` 명령으로 전송) |
+| [Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | `pi` | `pi-rpc`(stdio JSON-RPC) | `pi --mode rpc [--model …] [--thinking …]`(prompt는 RPC `prompt` 명령으로 전송) |
 | [Kiro CLI](https://kiro.dev) | `kiro-cli` | `acp-json-rpc` | `kiro-cli acp` |
 | Kilo | `kilo` | `acp-json-rpc` | `kilo acp` |
 | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | `vibe-acp` | `acp-json-rpc` | `vibe-acp` |

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Adding a skill takes one folder. Read [`docs/skills-protocol.md`](docs/skills-pr
 
 ### 1 · We don't ship an agent. Yours is good enough.
 
-The daemon scans your `PATH` for [`claude`](https://docs.anthropic.com/en/docs/claude-code), [`codex`](https://github.com/openai/codex), `devin`, [`cursor-agent`](https://www.cursor.com/cli), [`gemini`](https://github.com/google-gemini/gemini-cli), [`opencode`](https://opencode.ai/), [`qwen`](https://github.com/QwenLM/qwen-code), `qodercli`, [`copilot`](https://github.com/features/copilot/cli), `hermes`, `kimi`, [`pi`](https://github.com/mariozechner/pi-ai), [`kiro-cli`](https://kiro.dev), `kilo`, [`vibe-acp`](https://github.com/mistralai/mistral-vibe), and `deepseek` on startup. Whichever ones it finds become candidate design engines — driven over stdio with one adapter per CLI, swappable from the model picker. Inspired by [`multica`](https://github.com/multica-ai/multica) and [`cc-switch`](https://github.com/farion1231/cc-switch). No CLI installed? The API mode is the same pipeline minus the spawn — choose Anthropic, OpenAI-compatible, Azure OpenAI, or Google Gemini and the daemon forwards normalized SSE chunks back, with loopback / link-local / RFC1918 destinations rejected at the edge.
+The daemon scans your `PATH` for [`claude`](https://docs.anthropic.com/en/docs/claude-code), [`codex`](https://github.com/openai/codex), `devin`, [`cursor-agent`](https://www.cursor.com/cli), [`gemini`](https://github.com/google-gemini/gemini-cli), [`opencode`](https://opencode.ai/), [`qwen`](https://github.com/QwenLM/qwen-code), `qodercli`, [`copilot`](https://github.com/features/copilot/cli), `hermes`, `kimi`, [`pi`](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent), [`kiro-cli`](https://kiro.dev), `kilo`, [`vibe-acp`](https://github.com/mistralai/mistral-vibe), and `deepseek` on startup. Whichever ones it finds become candidate design engines — driven over stdio with one adapter per CLI, swappable from the model picker. Inspired by [`multica`](https://github.com/multica-ai/multica) and [`cc-switch`](https://github.com/farion1231/cc-switch). No CLI installed? The API mode is the same pipeline minus the spawn — choose Anthropic, OpenAI-compatible, Azure OpenAI, or Google Gemini and the daemon forwards normalized SSE chunks back, with loopback / link-local / RFC1918 destinations rejected at the edge.
 
 ### 2 · Skills are files, not plugins.
 
@@ -752,7 +752,7 @@ The whole machinery below is the [`huashu-design`](https://github.com/alchaincyf
 
 [cd]: https://x.com/claudeai/status/2045156267690213649
 [ocod]: https://github.com/OpenCoworkAI/open-codesign
-[piai]: https://github.com/mariozechner/pi-ai
+[piai]: https://github.com/badlogic/pi-mono/tree/main/packages/ai
 [acd]: https://github.com/VoltAgent/awesome-claude-design
 [guizang]: https://github.com/op7418/guizang-ppt-skill
 [skill]: https://docs.anthropic.com/en/docs/claude-code/skills
@@ -778,7 +778,7 @@ Auto-detected from `PATH` on daemon boot. No config required. Streaming dispatch
 | Kilo | `kilo` | `acp-json-rpc` | `kilo acp` |
 | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | `vibe-acp` | `acp-json-rpc` | `vibe-acp` |
 | DeepSeek TUI | `deepseek` | `plain` (raw stdout chunks) | `deepseek exec --auto [--model …] <prompt>` (prompt as positional arg) |
-| [Pi](https://github.com/mariozechner/pi-ai) | `pi` | `pi-rpc` (stdio JSON-RPC) | `pi --mode rpc [--model …] [--thinking …]` (prompt sent as RPC `prompt` command) |
+| [Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | `pi` | `pi-rpc` (stdio JSON-RPC) | `pi --mode rpc [--model …] [--thinking …]` (prompt sent as RPC `prompt` command) |
 | **Multi-provider BYOK** | n/a | SSE normalization | `POST /api/proxy/{provider}/stream` → Anthropic / OpenAI-compatible / Azure OpenAI / Gemini; SSRF-guarded against loopback / link-local / RFC1918 |
 
 Adding a new CLI is one entry in [`apps/daemon/src/agents.ts`](apps/daemon/src/agents.ts). Streaming format is one of `claude-stream-json`, `qoder-stream-json`, `copilot-stream-json`, `json-event-stream` (with a per-CLI `eventParser`), `acp-json-rpc`, `pi-rpc`, or `plain`.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -220,7 +220,7 @@ Adicionar uma skill leva uma pasta. Leia [`docs/skills-protocol.md`](docs/skills
 
 ### 1 · Não despachamos um agente. O seu já basta.
 
-O daemon escaneia seu `PATH` por [`claude`](https://docs.anthropic.com/en/docs/claude-code), [`codex`](https://github.com/openai/codex), `devin`, [`cursor-agent`](https://www.cursor.com/cli), [`gemini`](https://github.com/google-gemini/gemini-cli), [`opencode`](https://opencode.ai/), [`qwen`](https://github.com/QwenLM/qwen-code), `qodercli`, [`copilot`](https://github.com/features/copilot/cli), `hermes`, `kimi`, [`pi`](https://github.com/mariozechner/pi-ai), [`kiro-cli`](https://kiro.dev) e [`vibe-acp`](https://github.com/mistralai/mistral-vibe) na inicialização. Os que ele encontrar viram engines de design candidatas — dirigidas via stdio com um adapter por CLI, trocáveis pelo picker de modelo. Inspirado em [`multica`](https://github.com/multica-ai/multica) e [`cc-switch`](https://github.com/farion1231/cc-switch). Sem CLI instalado? O modo API é o mesmo pipeline menos o spawn — escolha Anthropic, OpenAI-compatible, Azure OpenAI ou Google Gemini, e o daemon repassa chunks SSE normalizados, com destinos loopback / link-local / RFC1918 rejeitados na borda.
+O daemon escaneia seu `PATH` por [`claude`](https://docs.anthropic.com/en/docs/claude-code), [`codex`](https://github.com/openai/codex), `devin`, [`cursor-agent`](https://www.cursor.com/cli), [`gemini`](https://github.com/google-gemini/gemini-cli), [`opencode`](https://opencode.ai/), [`qwen`](https://github.com/QwenLM/qwen-code), `qodercli`, [`copilot`](https://github.com/features/copilot/cli), `hermes`, `kimi`, [`pi`](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent), [`kiro-cli`](https://kiro.dev) e [`vibe-acp`](https://github.com/mistralai/mistral-vibe) na inicialização. Os que ele encontrar viram engines de design candidatas — dirigidas via stdio com um adapter por CLI, trocáveis pelo picker de modelo. Inspirado em [`multica`](https://github.com/multica-ai/multica) e [`cc-switch`](https://github.com/farion1231/cc-switch). Sem CLI instalado? O modo API é o mesmo pipeline menos o spawn — escolha Anthropic, OpenAI-compatible, Azure OpenAI ou Google Gemini, e o daemon repassa chunks SSE normalizados, com destinos loopback / link-local / RFC1918 rejeitados na borda.
 
 ### 2 · Skills são arquivos, não plugins.
 
@@ -624,7 +624,7 @@ Toda a maquinaria abaixo é o playbook do [`huashu-design`](https://github.com/a
 
 [cd]: https://x.com/claudeai/status/2045156267690213649
 [ocod]: https://github.com/OpenCoworkAI/open-codesign
-[piai]: https://github.com/mariozechner/pi-ai
+[piai]: https://github.com/badlogic/pi-mono/tree/main/packages/ai
 [acd]: https://github.com/VoltAgent/awesome-claude-design
 [guizang]: https://github.com/op7418/guizang-ppt-skill
 [skill]: https://docs.anthropic.com/en/docs/claude-code/skills
@@ -650,7 +650,7 @@ Detectados automaticamente do `PATH` no boot do daemon. Sem config necessária. 
 | Kilo | `kilo` | `acp-json-rpc` | `kilo acp` |
 | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | `vibe-acp` | `acp-json-rpc` | `vibe-acp` |
 | DeepSeek TUI | `deepseek` | `plain` (raw stdout chunks) | `deepseek exec --auto [--model …] <prompt>` |
-| [Pi](https://github.com/mariozechner/pi-ai) | `pi` | `pi-rpc` (stdio JSON-RPC) | `pi --mode rpc [--model …] [--thinking …]` (prompt enviado como comando RPC `prompt`) |
+| [Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | `pi` | `pi-rpc` (stdio JSON-RPC) | `pi --mode rpc [--model …] [--thinking …]` (prompt enviado como comando RPC `prompt`) |
 | **BYOK multi-provider** | n/a | Normalização SSE | `POST /api/proxy/{provider}/stream` → Anthropic / OpenAI-compatible / Azure OpenAI / Gemini; com guarda SSRF contra loopback / link-local / RFC1918 |
 
 Adicionar um novo CLI é uma entrada em [`apps/daemon/src/agents.ts`](apps/daemon/src/agents.ts). O formato de stream é um de `claude-stream-json`, `qoder-stream-json`, `copilot-stream-json`, `json-event-stream` (com `eventParser` por CLI), `acp-json-rpc`, `pi-rpc` ou `plain`.

--- a/README.ru.md
+++ b/README.ru.md
@@ -220,7 +220,7 @@ OD стоит на плечах четырёх open-source проектов:
 
 ### 1 · Мы не поставляем своего агента. Ваш уже достаточно хорош.
 
-На старте демон сканирует `PATH` в поисках [`claude`](https://docs.anthropic.com/en/docs/claude-code), [`codex`](https://github.com/openai/codex), `devin`, [`cursor-agent`](https://www.cursor.com/cli), [`gemini`](https://github.com/google-gemini/gemini-cli), [`opencode`](https://opencode.ai/), [`qwen`](https://github.com/QwenLM/qwen-code), `qodercli`, [`copilot`](https://github.com/features/copilot/cli), `hermes`, `kimi`, [`pi`](https://github.com/mariozechner/pi-ai), [`kiro-cli`](https://kiro.dev) и [`vibe-acp`](https://github.com/mistralai/mistral-vibe). Всё найденное становится кандидатами на роль design engine — каждый работает через свой stdio-adapter и может переключаться из picker’а модели. CLI не установлен? `POST /api/proxy/stream` даёт тот же pipeline, только без spawn: вставьте любой OpenAI-compatible `baseUrl` + `apiKey`, и демон будет форвардить SSE chunks назад, при этом loopback / link-local / RFC1918 назначения отсекаются на границе.
+На старте демон сканирует `PATH` в поисках [`claude`](https://docs.anthropic.com/en/docs/claude-code), [`codex`](https://github.com/openai/codex), `devin`, [`cursor-agent`](https://www.cursor.com/cli), [`gemini`](https://github.com/google-gemini/gemini-cli), [`opencode`](https://opencode.ai/), [`qwen`](https://github.com/QwenLM/qwen-code), `qodercli`, [`copilot`](https://github.com/features/copilot/cli), `hermes`, `kimi`, [`pi`](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent), [`kiro-cli`](https://kiro.dev) и [`vibe-acp`](https://github.com/mistralai/mistral-vibe). Всё найденное становится кандидатами на роль design engine — каждый работает через свой stdio-adapter и может переключаться из picker’а модели. CLI не установлен? `POST /api/proxy/stream` даёт тот же pipeline, только без spawn: вставьте любой OpenAI-compatible `baseUrl` + `apiKey`, и демон будет форвардить SSE chunks назад, при этом loopback / link-local / RFC1918 назначения отсекаются на границе.
 
 ### 2 · Skills — это файлы, а не плагины.
 
@@ -623,7 +623,7 @@ OD не заканчивается на коде. Тот же чатовый sur
 
 [cd]: https://x.com/claudeai/status/2045156267690213649
 [ocod]: https://github.com/OpenCoworkAI/open-codesign
-[piai]: https://github.com/mariozechner/pi-ai
+[piai]: https://github.com/badlogic/pi-mono/tree/main/packages/ai
 [acd]: https://github.com/VoltAgent/awesome-claude-design
 [guizang]: https://github.com/op7418/guizang-ppt-skill
 [skill]: https://docs.anthropic.com/en/docs/claude-code/skills
@@ -649,7 +649,7 @@ OD не заканчивается на коде. Тот же чатовый sur
 | Kilo | `kilo` | `acp-json-rpc` | `kilo acp` |
 | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | `vibe-acp` | `acp-json-rpc` | `vibe-acp` |
 | DeepSeek TUI | `deepseek` | `plain` (raw stdout chunks) | `deepseek exec --auto [--model …] <prompt>` |
-| [Pi](https://github.com/mariozechner/pi-ai) | `pi` | `pi-rpc` (stdio JSON-RPC) | `pi --mode rpc [--model …] [--thinking …]` (prompt отправляется как RPC-команда `prompt`) |
+| [Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | `pi` | `pi-rpc` (stdio JSON-RPC) | `pi --mode rpc [--model …] [--thinking …]` (prompt отправляется как RPC-команда `prompt`) |
 | **OpenAI-compatible BYOK** | n/a | SSE pass-through | `POST /api/proxy/stream` → `<baseUrl>/v1/chat/completions`; SSRF-защита от loopback / link-local / RFC1918 |
 
 Добавить новый CLI — это одна запись в [`apps/daemon/src/agents.ts`](apps/daemon/src/agents.ts). Формат стрима выбирается из `claude-stream-json`, `qoder-stream-json`, `copilot-stream-json`, `json-event-stream` (с отдельным `eventParser` на CLI), `acp-json-rpc`, `pi-rpc` или `plain`.

--- a/README.uk.md
+++ b/README.uk.md
@@ -220,7 +220,7 @@ OD стоїть на плечах чотирьох проектів з відк�
 
 ### 1 · Ми не постачаємо агента. Ваш — достатньо хороший.
 
-При запуску демон сканує ваш `PATH` на наявність [`claude`](https://docs.anthropic.com/en/docs/claude-code), [`codex`](https://github.com/openai/codex), `devin`, [`cursor-agent`](https://www.cursor.com/cli), [`gemini`](https://github.com/google-gemini/gemini-cli), [`opencode`](https://opencode.ai/), [`qwen`](https://github.com/QwenLM/qwen-code), `qodercli`, [`copilot`](https://github.com/features/copilot/cli), `hermes`, `kimi`, [`pi`](https://github.com/mariozechner/pi-ai), [`kiro-cli`](https://kiro.dev) та [`vibe-acp`](https://github.com/mistralai/mistral-vibe) на старті. Ті, що знайдені, стають кандидатами на роль "двигуна" дизайну — вони керуються через stdio з одним адаптером на CLI, який можна змінити у виборі моделі. Натхненно [`multica`](https://github.com/multica-ai/multica) та [`cc-switch`](https://github.com/farion1231/cc-switch). Немає встановленого CLI? Режим API використовує той самий конвеєр — виберіть Anthropic, OpenAI-сумісний, Azure OpenAI або Google Gemini, і демон передаватиме нормалізовані фрагменти SSE, з блокуванням внутрішніх мереж на краю.
+При запуску демон сканує ваш `PATH` на наявність [`claude`](https://docs.anthropic.com/en/docs/claude-code), [`codex`](https://github.com/openai/codex), `devin`, [`cursor-agent`](https://www.cursor.com/cli), [`gemini`](https://github.com/google-gemini/gemini-cli), [`opencode`](https://opencode.ai/), [`qwen`](https://github.com/QwenLM/qwen-code), `qodercli`, [`copilot`](https://github.com/features/copilot/cli), `hermes`, `kimi`, [`pi`](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent), [`kiro-cli`](https://kiro.dev) та [`vibe-acp`](https://github.com/mistralai/mistral-vibe) на старті. Ті, що знайдені, стають кандидатами на роль "двигуна" дизайну — вони керуються через stdio з одним адаптером на CLI, який можна змінити у виборі моделі. Натхненно [`multica`](https://github.com/multica-ai/multica) та [`cc-switch`](https://github.com/farion1231/cc-switch). Немає встановленого CLI? Режим API використовує той самий конвеєр — виберіть Anthropic, OpenAI-сумісний, Azure OpenAI або Google Gemini, і демон передаватиме нормалізовані фрагменти SSE, з блокуванням внутрішніх мереж на краю.
 
 ### 2 · Навички — це файли, а не плагіни.
 
@@ -623,7 +623,7 @@ OD не зупиняється на коді. Та сама поверхня ч�
 
 [cd]: https://x.com/claudeai/status/2045156267690213649
 [ocod]: https://github.com/OpenCoworkAI/open-codesign
-[piai]: https://github.com/mariozechner/pi-ai
+[piai]: https://github.com/badlogic/pi-mono/tree/main/packages/ai
 [acd]: https://github.com/VoltAgent/awesome-claude-design
 [guizang]: https://github.com/op7418/guizang-ppt-skill
 [skill]: https://docs.anthropic.com/en/docs/claude-code/skills
@@ -649,7 +649,7 @@ OD не зупиняється на коді. Та сама поверхня ч�
 | Kilo | `kilo` | `acp-json-rpc` | `kilo acp` |
 | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | `vibe-acp` | `acp-json-rpc` | `vibe-acp` |
 | DeepSeek TUI | `deepseek` | `plain` (raw stdout chunks) | `deepseek exec --auto [--model …] <prompt>` |
-| [Pi](https://github.com/mariozechner/pi-ai) | `pi` | `pi-rpc` (stdio JSON-RPC) | `pi --mode rpc [--model …] [--thinking …]` (промпт надсилається як RPC-команда `prompt`) |
+| [Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | `pi` | `pi-rpc` (stdio JSON-RPC) | `pi --mode rpc [--model …] [--thinking …]` (промпт надсилається як RPC-команда `prompt`) |
 | **Багатопровайдерний BYOK** | н/д | Нормалізація SSE | `POST /api/proxy/{provider}/stream` → Anthropic / OpenAI-сумісний / Azure OpenAI / Gemini; захист від SSRF проти loopback / link-local / RFC1918 |
 
 Додавання нового CLI — це один запис у [`apps/daemon/src/agents.ts`](apps/daemon/src/agents.ts). Формат потоку — один із `claude-stream-json`, `qoder-stream-json`, `copilot-stream-json`, `json-event-stream` (з `eventParser` для кожного CLI), `acp-json-rpc`, `pi-rpc` або `plain`.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -219,7 +219,7 @@ OD 站在四个开源项目的肩膀上：
 
 ### 1 · 我们不带 agent，你的就够好
 
-Daemon 启动时扫 `PATH`，找 [`claude`](https://docs.anthropic.com/en/docs/claude-code)、[`codex`](https://github.com/openai/codex)、[`cursor-agent`](https://www.cursor.com/cli)、[`gemini`](https://github.com/google-gemini/gemini-cli)、[`opencode`](https://opencode.ai/)、[`qwen`](https://github.com/QwenLM/qwen-code)、`qodercli`、[`copilot`](https://github.com/features/copilot/cli)、`hermes`、`kimi` 和 [`pi`](https://github.com/mariozechner/pi-ai)。能找到的都成为候选设计引擎 —— 走 stdio，每个 CLI 一个 adapter，model picker 一键切换。灵感来自 [`multica`](https://github.com/multica-ai/multica) 和 [`cc-switch`](https://github.com/farion1231/cc-switch)。一个 CLI 都没装？API mode 就是同一条管线减去 spawn —— 选择 Anthropic、OpenAI 兼容、Azure OpenAI 或 Google Gemini，daemon 把归一化后的 SSE 转发回浏览器，loopback / link-local / RFC1918 在边界直接拒绝。
+Daemon 启动时扫 `PATH`，找 [`claude`](https://docs.anthropic.com/en/docs/claude-code)、[`codex`](https://github.com/openai/codex)、[`cursor-agent`](https://www.cursor.com/cli)、[`gemini`](https://github.com/google-gemini/gemini-cli)、[`opencode`](https://opencode.ai/)、[`qwen`](https://github.com/QwenLM/qwen-code)、`qodercli`、[`copilot`](https://github.com/features/copilot/cli)、`hermes`、`kimi` 和 [`pi`](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent)。能找到的都成为候选设计引擎 —— 走 stdio，每个 CLI 一个 adapter，model picker 一键切换。灵感来自 [`multica`](https://github.com/multica-ai/multica) 和 [`cc-switch`](https://github.com/farion1231/cc-switch)。一个 CLI 都没装？API mode 就是同一条管线减去 spawn —— 选择 Anthropic、OpenAI 兼容、Azure OpenAI 或 Google Gemini，daemon 把归一化后的 SSE 转发回浏览器，loopback / link-local / RFC1918 在边界直接拒绝。
 
 ### 2 · Skill 是文件，不是插件
 
@@ -617,7 +617,7 @@ Chat / artifact 循环最显眼，但这套仓库里还有几个能力被埋得�
 
 [cd]: https://x.com/claudeai/status/2045156267690213649
 [ocod]: https://github.com/OpenCoworkAI/open-codesign
-[piai]: https://github.com/mariozechner/pi-ai
+[piai]: https://github.com/badlogic/pi-mono/tree/main/packages/ai
 [acd]: https://github.com/VoltAgent/awesome-claude-design
 [guizang]: https://github.com/op7418/guizang-ppt-skill
 [skill]: https://docs.anthropic.com/en/docs/claude-code/skills
@@ -639,7 +639,7 @@ Daemon 启动时从 `PATH` 自动检测，无需配置。流式分发逻辑在 [
 | [GitHub Copilot CLI](https://github.com/features/copilot/cli) | `copilot` | `copilot-stream-json`（类型化事件） | `copilot -p <prompt> --allow-all-tools --output-format json [--model …] [--add-dir …]` |
 | [Hermes](https://github.com/eqlabs/hermes) | `hermes` | `acp-json-rpc`（Agent Client Protocol） | `hermes acp --accept-hooks` |
 | Kimi CLI | `kimi` | `acp-json-rpc` | `kimi acp` |
-| [Pi](https://github.com/mariozechner/pi-ai) | `pi` | `pi-rpc`（stdio JSON-RPC） | `pi --mode rpc [--model …] [--thinking …]`（prompt 走 RPC `prompt` 命令） |
+| [Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | `pi` | `pi-rpc`（stdio JSON-RPC） | `pi --mode rpc [--model …] [--thinking …]`（prompt 走 RPC `prompt` 命令） |
 | [Kiro CLI](https://kiro.dev) | `kiro-cli` | `acp-json-rpc` | `kiro-cli acp` |
 | Kilo | `kilo` | `acp-json-rpc` | `kilo acp` |
 | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | `vibe-acp` | `acp-json-rpc` | `vibe-acp` |

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -217,7 +217,7 @@ OD 站在四個開源專案的肩膀上：
 
 ### 1 · 我們不帶 agent，你的就夠好
 
-Daemon 啟動時掃 `PATH`，找 [`claude`](https://docs.anthropic.com/en/docs/claude-code)、[`codex`](https://github.com/openai/codex)、[`cursor-agent`](https://www.cursor.com/cli)、[`gemini`](https://github.com/google-gemini/gemini-cli)、[`opencode`](https://opencode.ai/)、[`qwen`](https://github.com/QwenLM/qwen-code)、`qodercli`、[`copilot`](https://github.com/features/copilot/cli)、`hermes`、`kimi` 和 [`pi`](https://github.com/mariozechner/pi-ai)。能找到的都成為候選設計引擎 —— 走 stdio，每個 CLI 一個 adapter，model picker 一鍵切換。靈感來自 [`multica`](https://github.com/multica-ai/multica) 和 [`cc-switch`](https://github.com/farion1231/cc-switch)。一個 CLI 都沒裝？`POST /api/proxy/stream` 就是同一條管線減去 spawn —— 填任意 OpenAI 相容 `baseUrl` + `apiKey`，daemon 把 SSE 轉發回瀏覽器，loopback / link-local / RFC1918 在邊界直接拒絕。
+Daemon 啟動時掃 `PATH`，找 [`claude`](https://docs.anthropic.com/en/docs/claude-code)、[`codex`](https://github.com/openai/codex)、[`cursor-agent`](https://www.cursor.com/cli)、[`gemini`](https://github.com/google-gemini/gemini-cli)、[`opencode`](https://opencode.ai/)、[`qwen`](https://github.com/QwenLM/qwen-code)、`qodercli`、[`copilot`](https://github.com/features/copilot/cli)、`hermes`、`kimi` 和 [`pi`](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent)。能找到的都成為候選設計引擎 —— 走 stdio，每個 CLI 一個 adapter，model picker 一鍵切換。靈感來自 [`multica`](https://github.com/multica-ai/multica) 和 [`cc-switch`](https://github.com/farion1231/cc-switch)。一個 CLI 都沒裝？`POST /api/proxy/stream` 就是同一條管線減去 spawn —— 填任意 OpenAI 相容 `baseUrl` + `apiKey`，daemon 把 SSE 轉發回瀏覽器，loopback / link-local / RFC1918 在邊界直接拒絕。
 
 ### 2 · Skill 是檔案，不是外掛
 
@@ -684,7 +684,7 @@ Chat / artifact 迴圈最顯眼，但這套倉庫裡還有幾個能力被埋得�
 
 [cd]: https://x.com/claudeai/status/2045156267690213649
 [ocod]: https://github.com/OpenCoworkAI/open-codesign
-[piai]: https://github.com/mariozechner/pi-ai
+[piai]: https://github.com/badlogic/pi-mono/tree/main/packages/ai
 [acd]: https://github.com/VoltAgent/awesome-claude-design
 [guizang]: https://github.com/op7418/guizang-ppt-skill
 [skill]: https://docs.anthropic.com/en/docs/claude-code/skills
@@ -706,7 +706,7 @@ Daemon 啟動時從 `PATH` 自動檢測，無需配置。流式分發邏輯在 [
 | [GitHub Copilot CLI](https://github.com/features/copilot/cli) | `copilot` | `copilot-stream-json`（型別化事件） | `copilot -p <prompt> --allow-all-tools --output-format json [--model …] [--add-dir …]` |
 | [Hermes](https://github.com/eqlabs/hermes) | `hermes` | `acp-json-rpc`（Agent Client Protocol） | `hermes acp --accept-hooks` |
 | Kimi CLI | `kimi` | `acp-json-rpc` | `kimi acp` |
-| [Pi](https://github.com/mariozechner/pi-ai) | `pi` | `pi-rpc`（stdio JSON-RPC） | `pi --mode rpc [--model …] [--thinking …]`（prompt 走 RPC `prompt` 命令） |
+| [Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | `pi` | `pi-rpc`（stdio JSON-RPC） | `pi --mode rpc [--model …] [--thinking …]`（prompt 走 RPC `prompt` 命令） |
 | [Kiro CLI](https://kiro.dev) | `kiro-cli` | `acp-json-rpc` | `kiro-cli acp` |
 | Kilo | `kilo` | `acp-json-rpc` | `kilo acp` |
 | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | `vibe-acp` | `acp-json-rpc` | `vibe-acp` |

--- a/apps/daemon/src/home-expansion.ts
+++ b/apps/daemon/src/home-expansion.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared shorthand-expander for env-supplied directory paths. Both
+ * resolveDataDir (server.ts, drives OD_DATA_DIR) and resolveOverrideDir
+ * (media-config.ts, drives OD_MEDIA_CONFIG_DIR + the OD_DATA_DIR fallback)
+ * use this so the two resolvers cannot split state — a launcher passing
+ * $HOME/.open-design lands every daemon write at the same expanded path.
+ *
+ * Recognized shorthands (case-sensitive):
+ *   '~'        | '~/...'   | '~\\...'
+ *   '$HOME'    | '$HOME/...' | '$HOME\\...'
+ *   '${HOME}'  | '${HOME}/...' | '${HOME}\\...'
+ *
+ * Anything else (absolute paths, plain relative paths, $OTHER variables) is
+ * returned unchanged. Both forward and back slashes are accepted in the
+ * prefix so a Windows launcher passing $HOME\.open-design behaves the same
+ * as a Unix launcher passing $HOME/.open-design; the result is rebuilt via
+ * path.join so the platform separator is correct in the output regardless
+ * of which the input used.
+ */
+import os from 'node:os';
+import path from 'node:path';
+
+const HOME_BARE_TOKENS = new Set(['~', '$HOME', '${HOME}']);
+const HOME_PREFIX_RE = /^(~|\$\{HOME\}|\$HOME)[/\\](.*)$/;
+
+export function expandHomePrefix(raw: string): string {
+  const home = os.homedir();
+  if (HOME_BARE_TOKENS.has(raw)) return home;
+  const match = HOME_PREFIX_RE.exec(raw);
+  if (match) return path.join(home, match[2] ?? '');
+  return raw;
+}

--- a/apps/daemon/src/media-config.ts
+++ b/apps/daemon/src/media-config.ts
@@ -39,6 +39,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import path from 'node:path';
 import { MEDIA_PROVIDERS } from './media-models.js';
+import { expandHomePrefix } from './home-expansion.js';
 
 const PROVIDER_IDS = MEDIA_PROVIDERS.map((p) => p.id);
 
@@ -83,9 +84,14 @@ const ENV_KEYS = {
 // is a normal "no config yet" condition handled by readStored(); the
 // write path's mkdir(recursive) creates the directory on first use.
 function resolveOverrideDir(raw, projectRoot) {
-  const expanded = raw.startsWith('~/')
-    ? path.join(homedir(), raw.slice(2))
-    : raw;
+  // Share expandHomePrefix with resolveDataDir (server.ts) so OD_DATA_DIR
+  // and OD_MEDIA_CONFIG_DIR cannot split state under a $HOME-style value.
+  // A launcher passing OD_DATA_DIR=$HOME/.open-design without a shell to
+  // expand it would otherwise route SQLite/projects/artifacts to the
+  // expanded path while media-config.json stayed under
+  // <projectRoot>/$HOME/.open-design, leaving stored credentials
+  // unreachable on the next read.
+  const expanded = expandHomePrefix(raw);
   return path.isAbsolute(expanded)
     ? expanded
     : path.resolve(projectRoot, expanded);

--- a/apps/daemon/src/media-config.ts
+++ b/apps/daemon/src/media-config.ts
@@ -18,10 +18,11 @@
 // apps/packaged/src/sidecars.ts:createPackagedDaemonManagedPathEnv,
 // the Home Manager / NixOS modules) get media-config there too without
 // any extra plumbing. Both env values are resolved with the same
-// semantics as OD_DATA_DIR in server.ts:resolveDataDir() — `~/` expands
-// to the user's home, and relative paths anchor to <projectRoot> (NOT
-// process.cwd, which is unrelated to the workspace when systemd or
-// launchd starts the daemon).
+// semantics as OD_DATA_DIR in server.ts:resolveDataDir(): the shared
+// expandHomePrefix() helper handles `~`, `$HOME`, and `${HOME}` (with
+// either `/` or `\` separator), then relative paths anchor to
+// <projectRoot> (NOT process.cwd, which is unrelated to the workspace
+// when systemd or launchd starts the daemon).
 //
 // Migration note: a workspace install that sets a custom OD_DATA_DIR
 // AND has a pre-existing `<projectRoot>/.od/media-config.json` will
@@ -75,10 +76,11 @@ const ENV_KEYS = {
 };
 
 // Resolve an `OD_*_DIR` env override using the same semantics as
-// `resolveDataDir()` in server.ts: leading `~/` expands to the user's
-// home, and relative paths anchor to <projectRoot> (NOT process.cwd —
+// `resolveDataDir()` in server.ts: expandHomePrefix() handles the `~`,
+// `$HOME`, and `${HOME}` shorthands (with either `/` or `\` separator),
+// then relative paths anchor to <projectRoot>, not process.cwd, since
 // the daemon is often launched from a directory that has nothing to do
-// with the workspace, e.g. systemd's `/`). The writability check that
+// with the workspace, e.g. systemd's `/`. The writability check that
 // resolveDataDir does on startup is intentionally NOT replicated here:
 // configFile() is on the read path and a missing/unwritable directory
 // is a normal "no config yet" condition handled by readStored(); the

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -668,9 +668,23 @@ const PROMPT_TEMPLATES_DIR = resolveDaemonResourceDir(
 );
 export function resolveDataDir(raw, projectRoot) {
   if (!raw) return path.join(projectRoot, '.od');
-  const expanded = raw.startsWith('~/')
-    ? path.join(os.homedir(), raw.slice(2))
-    : raw;
+  // Some launchers (systemd unit files, NixOS modules, certain Docker
+  // entrypoints) pass OD_DATA_DIR with literal $HOME or ${HOME} because
+  // the variable is never expanded by a shell. Without explicit handling
+  // here those resolve against PROJECT_ROOT and produce nonsense paths
+  // like /opt/open-design/$HOME/.open-design. Expand the unambiguous
+  // shorthands (~/, $HOME, ${HOME}) before resolving so the env var
+  // works the way operators expect across all launch surfaces. We rebuild
+  // via path.join so the platform separator is correct on Windows even
+  // when the input used forward slashes.
+  const home = os.homedir();
+  let expanded = raw;
+  if (expanded === '~' || expanded === '$HOME' || expanded === '${HOME}') {
+    expanded = home;
+  } else {
+    const homePrefix = /^(~|\$\{HOME\}|\$HOME)\/(.*)$/.exec(expanded);
+    if (homePrefix) expanded = path.join(home, homePrefix[2]);
+  }
   const resolved = path.isAbsolute(expanded)
     ? expanded
     : path.resolve(projectRoot, expanded);

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -669,20 +669,23 @@ const PROMPT_TEMPLATES_DIR = resolveDaemonResourceDir(
 export function resolveDataDir(raw, projectRoot) {
   if (!raw) return path.join(projectRoot, '.od');
   // Some launchers (systemd unit files, NixOS modules, certain Docker
-  // entrypoints) pass OD_DATA_DIR with literal $HOME or ${HOME} because
-  // the variable is never expanded by a shell. Without explicit handling
-  // here those resolve against PROJECT_ROOT and produce nonsense paths
-  // like /opt/open-design/$HOME/.open-design. Expand the unambiguous
-  // shorthands (~/, $HOME, ${HOME}) before resolving so the env var
-  // works the way operators expect across all launch surfaces. We rebuild
-  // via path.join so the platform separator is correct on Windows even
-  // when the input used forward slashes.
+  // entrypoints, Windows scheduled tasks) pass OD_DATA_DIR with literal
+  // $HOME or ${HOME} because the variable is never expanded by a shell.
+  // Without explicit handling here those resolve against PROJECT_ROOT and
+  // produce nonsense paths like /opt/open-design/$HOME/.open-design.
+  // Expand the unambiguous shorthands (~/, $HOME, ${HOME}) before
+  // resolving so the env var works the way operators expect across all
+  // launch surfaces. Both forward (/) and backslash (\) separators are
+  // accepted in the prefix so a Windows launcher passing
+  // $HOME\.open-design behaves the same as a Unix launcher passing
+  // $HOME/.open-design. We rebuild via path.join so the platform
+  // separator is correct in the result regardless of which the input used.
   const home = os.homedir();
   let expanded = raw;
   if (expanded === '~' || expanded === '$HOME' || expanded === '${HOME}') {
     expanded = home;
   } else {
-    const homePrefix = /^(~|\$\{HOME\}|\$HOME)\/(.*)$/.exec(expanded);
+    const homePrefix = /^(~|\$\{HOME\}|\$HOME)[/\\](.*)$/.exec(expanded);
     if (homePrefix) expanded = path.join(home, homePrefix[2]);
   }
   const resolved = path.isAbsolute(expanded)

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -14,6 +14,7 @@ import {
   renderCodexImagegenOverride,
   shouldRenderCodexImagegenOverride,
 } from './prompts/system.js';
+import { expandHomePrefix } from './home-expansion.js';
 import { createCommandInvocation } from '@open-design/platform';
 import {
   buildLiveArtifactsMcpServersForAgent,
@@ -668,26 +669,15 @@ const PROMPT_TEMPLATES_DIR = resolveDaemonResourceDir(
 );
 export function resolveDataDir(raw, projectRoot) {
   if (!raw) return path.join(projectRoot, '.od');
+  // expandHomePrefix is shared with media-config.ts so OD_DATA_DIR and
+  // OD_MEDIA_CONFIG_DIR can never split state under a $HOME-style value.
   // Some launchers (systemd unit files, NixOS modules, certain Docker
   // entrypoints, Windows scheduled tasks) pass OD_DATA_DIR with literal
-  // $HOME or ${HOME} because the variable is never expanded by a shell.
-  // Without explicit handling here those resolve against PROJECT_ROOT and
-  // produce nonsense paths like /opt/open-design/$HOME/.open-design.
-  // Expand the unambiguous shorthands (~/, $HOME, ${HOME}) before
-  // resolving so the env var works the way operators expect across all
-  // launch surfaces. Both forward (/) and backslash (\) separators are
-  // accepted in the prefix so a Windows launcher passing
-  // $HOME\.open-design behaves the same as a Unix launcher passing
-  // $HOME/.open-design. We rebuild via path.join so the platform
-  // separator is correct in the result regardless of which the input used.
-  const home = os.homedir();
-  let expanded = raw;
-  if (expanded === '~' || expanded === '$HOME' || expanded === '${HOME}') {
-    expanded = home;
-  } else {
-    const homePrefix = /^(~|\$\{HOME\}|\$HOME)[/\\](.*)$/.exec(expanded);
-    if (homePrefix) expanded = path.join(home, homePrefix[2]);
-  }
+  // $HOME or ${HOME} because the variable is never expanded by a shell;
+  // expandHomePrefix turns those (and the ~ shorthand, with both / and \
+  // separators) into os.homedir() before path.resolve runs so launch
+  // surfaces stay consistent.
+  const expanded = expandHomePrefix(raw);
   const resolved = path.isAbsolute(expanded)
     ? expanded
     : path.resolve(projectRoot, expanded);

--- a/apps/daemon/tests/media-config.test.ts
+++ b/apps/daemon/tests/media-config.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import os, { tmpdir } from 'node:os';
 import path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   readMaskedConfig,
@@ -152,6 +152,7 @@ describe('media-config OpenAI OAuth fallback', () => {
     let overrideRoot: string;
     let originalMediaConfigDir: string | undefined;
     let originalDataDir: string | undefined;
+    let homedirSpy: ReturnType<typeof vi.spyOn>;
 
     beforeEach(async () => {
       overrideRoot = await mkdtemp(path.join(tmpdir(), 'od-media-override-'));
@@ -159,6 +160,13 @@ describe('media-config OpenAI OAuth fallback', () => {
       originalDataDir = process.env.OD_DATA_DIR;
       delete process.env.OD_MEDIA_CONFIG_DIR;
       delete process.env.OD_DATA_DIR;
+      // Stub os.homedir() to point at the per-test fake home so the
+      // ~/, $HOME, ${HOME} expansion in resolveOverrideDir lands inside
+      // homeDir on every platform. Without this the production path
+      // (which now goes through expandHomePrefix -> os.homedir()) would
+      // expand to USERPROFILE on Windows while the fixture is written
+      // under homeDir, and the assertion would fail platform-specifically.
+      homedirSpy = vi.spyOn(os, 'homedir').mockReturnValue(homeDir);
     });
 
     afterEach(async () => {
@@ -172,6 +180,7 @@ describe('media-config OpenAI OAuth fallback', () => {
       } else {
         process.env.OD_DATA_DIR = originalDataDir;
       }
+      homedirSpy.mockRestore();
       await rm(overrideRoot, { recursive: true, force: true });
     });
 

--- a/apps/daemon/tests/media-config.test.ts
+++ b/apps/daemon/tests/media-config.test.ts
@@ -337,5 +337,72 @@ describe('media-config OpenAI OAuth fallback', () => {
         baseUrl: 'https://fresh.test/v1',
       });
     });
+
+    // Round 3 review feedback on PR #530.
+    // resolveOverrideDir shares expandHomePrefix with resolveDataDir, so
+    // OD_DATA_DIR=$HOME/.open-design (and ${HOME}/.open-design) routes
+    // both daemon runtime data AND media credentials to the same expanded
+    // path. Without this, media-config.json was written under
+    // <projectRoot>/$HOME/.open-design and stored provider keys appeared
+    // missing on the next read.
+    it('expands $HOME/... in OD_DATA_DIR fallback so media-config co-locates with daemon data', async () => {
+      const subdir = '.od-test-home';
+      process.env.OD_DATA_DIR = `$HOME/${subdir}`;
+      const expandedDir = path.join(homeDir, subdir);
+      await writeProvidersAt(expandedDir, {
+        providers: {
+          openai: {
+            apiKey: 'home-key',
+            baseUrl: 'https://home.test/v1',
+          },
+        },
+      });
+
+      const resolved = await resolveProviderConfig(projectRoot, 'openai');
+      expect(resolved).toEqual({
+        apiKey: 'home-key',
+        baseUrl: 'https://home.test/v1',
+      });
+    });
+
+    it('expands ${HOME}/... in OD_DATA_DIR fallback', async () => {
+      const subdir = '.od-test-braced';
+      process.env.OD_DATA_DIR = `\${HOME}/${subdir}`;
+      const expandedDir = path.join(homeDir, subdir);
+      await writeProvidersAt(expandedDir, {
+        providers: {
+          openai: {
+            apiKey: 'braced-key',
+            baseUrl: 'https://braced.test/v1',
+          },
+        },
+      });
+
+      const resolved = await resolveProviderConfig(projectRoot, 'openai');
+      expect(resolved).toEqual({
+        apiKey: 'braced-key',
+        baseUrl: 'https://braced.test/v1',
+      });
+    });
+
+    it('expands $HOME/... in OD_MEDIA_CONFIG_DIR (explicit override path)', async () => {
+      const subdir = '.od-media-home';
+      process.env.OD_MEDIA_CONFIG_DIR = `$HOME/${subdir}`;
+      const expandedDir = path.join(homeDir, subdir);
+      await writeProvidersAt(expandedDir, {
+        providers: {
+          openai: {
+            apiKey: 'media-home-key',
+            baseUrl: 'https://media-home.test/v1',
+          },
+        },
+      });
+
+      const resolved = await resolveProviderConfig(projectRoot, 'openai');
+      expect(resolved).toEqual({
+        apiKey: 'media-home-key',
+        baseUrl: 'https://media-home.test/v1',
+      });
+    });
   });
 });

--- a/apps/daemon/tests/resolve-data-dir.test.ts
+++ b/apps/daemon/tests/resolve-data-dir.test.ts
@@ -79,12 +79,12 @@ describe('resolveDataDir', () => {
     expect(resolveDataDir('${HOME}', projectRoot)).toBe(fakeHome);
   });
 
-  it('passes absolute paths through unchanged', () => {
+  it('passes absolute paths through unchanged', async () => {
     const abs = mkdtempSync(path.join(os.tmpdir(), 'rdd-abs-'));
     try {
       expect(resolveDataDir(abs, projectRoot)).toBe(abs);
     } finally {
-      void rm(abs, { recursive: true, force: true });
+      await rm(abs, { recursive: true, force: true });
     }
   });
 

--- a/apps/daemon/tests/resolve-data-dir.test.ts
+++ b/apps/daemon/tests/resolve-data-dir.test.ts
@@ -1,15 +1,36 @@
 /**
  * Unit tests for resolveDataDir, the OD_DATA_DIR path resolver. Covers the
- * $HOME / ${HOME} / ~/ shorthands that launchers can pass literally when
- * no shell is in the loop (#390).
+ * $HOME / ${HOME} / ~/ shorthands that launchers can pass literally when no
+ * shell is in the loop (#390), with both forward and backslash separators so
+ * Windows launchers behave the same as Unix ones.
+ *
+ * Hermetic: every test runs against a fresh mkdtemp() home + projectRoot
+ * pair, and os.homedir() is stubbed so resolveDataDir's writability check
+ * never touches the developer's or CI runner's real home directory.
  */
 import os from 'node:os';
 import path from 'node:path';
-import { describe, it, expect } from 'vitest';
+import { mkdtempSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { resolveDataDir } from '../src/server.js';
 
 describe('resolveDataDir', () => {
-  const projectRoot = os.tmpdir();
+  let fakeHome: string;
+  let projectRoot: string;
+  let homedirSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fakeHome = mkdtempSync(path.join(os.tmpdir(), 'rdd-home-'));
+    projectRoot = mkdtempSync(path.join(os.tmpdir(), 'rdd-project-'));
+    homedirSpy = vi.spyOn(os, 'homedir').mockReturnValue(fakeHome);
+  });
+
+  afterEach(async () => {
+    homedirSpy.mockRestore();
+    await rm(fakeHome, { recursive: true, force: true });
+    await rm(projectRoot, { recursive: true, force: true });
+  });
 
   it('returns <projectRoot>/.od when OD_DATA_DIR is unset', () => {
     expect(resolveDataDir(undefined, projectRoot)).toBe(path.join(projectRoot, '.od'));
@@ -18,27 +39,53 @@ describe('resolveDataDir', () => {
 
   it('expands a leading ~/ against the user home directory', () => {
     const out = resolveDataDir('~/od-test', projectRoot);
-    expect(out).toBe(path.join(os.homedir(), 'od-test'));
+    expect(out).toBe(path.join(fakeHome, 'od-test'));
+  });
+
+  it('expands ~\\ (backslash) against the user home directory', () => {
+    const out = resolveDataDir('~\\od-test', projectRoot);
+    expect(out).toBe(path.join(fakeHome, 'od-test'));
   });
 
   it('expands a bare ~ to the user home directory', () => {
-    const out = resolveDataDir('~', projectRoot);
-    expect(out).toBe(os.homedir());
+    expect(resolveDataDir('~', projectRoot)).toBe(fakeHome);
   });
 
-  it('expands a leading $HOME to the user home directory', () => {
+  it('expands $HOME/ against the user home directory', () => {
     const out = resolveDataDir('$HOME/od-test', projectRoot);
-    expect(out).toBe(path.join(os.homedir(), 'od-test'));
+    expect(out).toBe(path.join(fakeHome, 'od-test'));
   });
 
-  it('expands a leading ${HOME} to the user home directory', () => {
+  it('expands $HOME\\ (backslash, Windows launcher) against the user home directory', () => {
+    const out = resolveDataDir('$HOME\\od-test', projectRoot);
+    expect(out).toBe(path.join(fakeHome, 'od-test'));
+  });
+
+  it('expands ${HOME}/ against the user home directory', () => {
     const out = resolveDataDir('${HOME}/od-test', projectRoot);
-    expect(out).toBe(path.join(os.homedir(), 'od-test'));
+    expect(out).toBe(path.join(fakeHome, 'od-test'));
+  });
+
+  it('expands ${HOME}\\ (backslash) against the user home directory', () => {
+    const out = resolveDataDir('${HOME}\\od-test', projectRoot);
+    expect(out).toBe(path.join(fakeHome, 'od-test'));
+  });
+
+  it('expands a bare $HOME to the user home directory', () => {
+    expect(resolveDataDir('$HOME', projectRoot)).toBe(fakeHome);
+  });
+
+  it('expands a bare ${HOME} to the user home directory', () => {
+    expect(resolveDataDir('${HOME}', projectRoot)).toBe(fakeHome);
   });
 
   it('passes absolute paths through unchanged', () => {
-    const abs = path.join(os.tmpdir(), 'od-abs');
-    expect(resolveDataDir(abs, projectRoot)).toBe(abs);
+    const abs = mkdtempSync(path.join(os.tmpdir(), 'rdd-abs-'));
+    try {
+      expect(resolveDataDir(abs, projectRoot)).toBe(abs);
+    } finally {
+      void rm(abs, { recursive: true, force: true });
+    }
   });
 
   it('resolves relative paths against projectRoot', () => {

--- a/apps/daemon/tests/resolve-data-dir.test.ts
+++ b/apps/daemon/tests/resolve-data-dir.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Unit tests for resolveDataDir, the OD_DATA_DIR path resolver. Covers the
+ * $HOME / ${HOME} / ~/ shorthands that launchers can pass literally when
+ * no shell is in the loop (#390).
+ */
+import os from 'node:os';
+import path from 'node:path';
+import { describe, it, expect } from 'vitest';
+import { resolveDataDir } from '../src/server.js';
+
+describe('resolveDataDir', () => {
+  const projectRoot = os.tmpdir();
+
+  it('returns <projectRoot>/.od when OD_DATA_DIR is unset', () => {
+    expect(resolveDataDir(undefined, projectRoot)).toBe(path.join(projectRoot, '.od'));
+    expect(resolveDataDir('', projectRoot)).toBe(path.join(projectRoot, '.od'));
+  });
+
+  it('expands a leading ~/ against the user home directory', () => {
+    const out = resolveDataDir('~/od-test', projectRoot);
+    expect(out).toBe(path.join(os.homedir(), 'od-test'));
+  });
+
+  it('expands a bare ~ to the user home directory', () => {
+    const out = resolveDataDir('~', projectRoot);
+    expect(out).toBe(os.homedir());
+  });
+
+  it('expands a leading $HOME to the user home directory', () => {
+    const out = resolveDataDir('$HOME/od-test', projectRoot);
+    expect(out).toBe(path.join(os.homedir(), 'od-test'));
+  });
+
+  it('expands a leading ${HOME} to the user home directory', () => {
+    const out = resolveDataDir('${HOME}/od-test', projectRoot);
+    expect(out).toBe(path.join(os.homedir(), 'od-test'));
+  });
+
+  it('passes absolute paths through unchanged', () => {
+    const abs = path.join(os.tmpdir(), 'od-abs');
+    expect(resolveDataDir(abs, projectRoot)).toBe(abs);
+  });
+
+  it('resolves relative paths against projectRoot', () => {
+    const out = resolveDataDir('rel-od', projectRoot);
+    expect(out).toBe(path.join(projectRoot, 'rel-od'));
+  });
+});

--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -231,7 +231,11 @@ export function DesignFilesPanel({
           <span className="crumbs">{t('designFiles.crumbs')}</span>
           {selected.size > 0 ? (
             <div className="df-actions">
-              <button type="button" onClick={() => void handleBatchDownload()}>
+              <button
+                type="button"
+                onClick={() => void handleBatchDownload()}
+                title={t('designFiles.downloadSelected', { n: selected.size })}
+              >
                 <Icon name="download" size={13} />
                 <span>{t('designFiles.downloadSelected', { n: selected.size })}</span>
               </button>
@@ -309,6 +313,7 @@ export function DesignFilesPanel({
                     <button
                       type="button"
                       className="df-select-all"
+                      title={t('designFiles.selectAll')}
                       onClick={(e) => {
                         e.stopPropagation();
                         selectAllInSection(sectionFiles);
@@ -320,6 +325,7 @@ export function DesignFilesPanel({
                       <button
                         type="button"
                         className="df-select-all"
+                        title={t('designFiles.clearSelection')}
                         onClick={(e) => {
                           e.stopPropagation();
                           clearSection(sectionFiles);

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -164,8 +164,6 @@ export const uk: Dict = {
   'promptTemplates.openSource': 'Переглянути оригінал',
   'promptTemplates.openFullscreen': 'Відкрити попередній перегляд у повноекранному режимі',
   'promptTemplates.closeFullscreen': 'Закрити попередній перегляд у повноекранному режимі',
-  'promptTemplates.allSources': 'Усі джерела',
-  'promptTemplates.sourceFilterAria': 'Фільтрувати за джерелом',
   'promptTemplates.retry': 'Повторити',
 
   'connectors.title': 'Конектори',

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,7 @@ This doc describes the system topology, runtime modes, data flow, and file layou
 
 [ocod]: https://github.com/OpenCoworkAI/open-codesign
 [acd]: https://github.com/VoltAgent/awesome-claude-design
-[piai]: https://github.com/mariozechner/pi-ai
+[piai]: https://github.com/badlogic/pi-mono/tree/main/packages/ai
 [guizang]: https://github.com/op7418/guizang-ppt-skill
 
 ---

--- a/docs/references.md
+++ b/docs/references.md
@@ -23,7 +23,7 @@ Every external project this spec leans on. Three questions per entry: what is it
 - **What it is:** The main open-source Claude Design alternative. MIT-licensed. Electron desktop app. React 19 + Vite + Tailwind v4. [`@mariozechner/pi-ai`][piai] for multi-provider. SQLite for version history. 12 built-in design skill modules. HTML/JSX sandboxed iframe preview. Exports HTML/PDF/PPTX/ZIP/MD. 15 templates. Comment mode + slider controls + multi-frame preview.
 
 [ocod]: https://github.com/OpenCoworkAI/open-codesign
-[piai]: https://github.com/mariozechner/pi-ai
+[piai]: https://github.com/badlogic/pi-mono/tree/main/packages/ai
 - **Why it matters:** Direct competitor; most overlap with what we're building.
 - **What we borrow:**
   - UI concepts: **comment mode** (click-to-pin element edits), **tweak sliders** (agent-emitted parameters), **multi-frame preview** (desktop/tablet/phone).

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -9,7 +9,7 @@
 [multica]: https://github.com/multica-ai/multica
 [ccsw]: https://github.com/farion1231/cc-switch
 [acd]: https://github.com/VoltAgent/awesome-claude-design
-[piai]: https://github.com/mariozechner/pi-ai
+[piai]: https://github.com/badlogic/pi-mono/tree/main/packages/ai
 
 Other docs:
 - Architecture → [`architecture.md`](architecture.md)


### PR DESCRIPTION
Three independent small fixes bundled into one PR. Each commit is scoped to its own issue and can be cherry-picked or split if a reviewer prefers.

## Commits

### 1. `fix(web): add hover tooltips to Design Files action buttons (#283)` ([c657f3d](../commit/c657f3d))

The batch-download, select-all, and clear-selection buttons in `apps/web/src/components/DesignFilesPanel.tsx` had no `title` attribute, so users hovering them saw no tooltip. The other action buttons (refresh, new sketch, paste, upload) already had titles. Added titles to the three missing ones using the existing translation keys, so hover behavior is consistent across the panel.

Closes #283.

### 2. `docs: point pi-ai links to pi-mono packages (#275)` ([00f53d4](../commit/00f53d4))

The pi project moved from a standalone repo to the pi-mono monorepo. The old URL `https://github.com/mariozechner/pi-ai` now 404s. Replaced both shapes of reference:

- The reference-style `[piai]:` definition now points at `https://github.com/badlogic/pi-mono/tree/main/packages/ai` (the multi-provider LLM API package).
- Inline links whose visible text is the CLI tool `pi` or `Pi` now point at `https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent` (the interactive coding-agent CLI), so a reader clicking `pi` in the daemon-discovery section lands on the actual binary's docs.

Affected: `README.md` and 10 translated READMEs, plus `docs/spec.md`, `docs/architecture.md`, `docs/references.md`, `docs/roadmap.md`. The two remaining `mariozechner/pi-ai` strings in `docs/references.md` and `docs/roadmap.md` are npm package names, not URLs, so they stay as-is.

Closes #275.

### 3. `fix(daemon): expand $HOME / ${HOME} in OD_DATA_DIR (#390)` ([4157ae0](../commit/4157ae0))

Some launchers (systemd unit files, NixOS modules, certain Docker entrypoints) pass `OD_DATA_DIR` with a literal `$HOME` or `${HOME}` because no shell ever expands them. `resolveDataDir` previously only handled `~/` shorthand, so `$HOME/.open-design` fell through to `path.resolve(PROJECT_ROOT, '$HOME/.open-design')` and produced paths like `/opt/open-design/$HOME/.open-design`.

`resolveDataDir` now expands `~`, `~/...`, `$HOME`, `$HOME/...`, `${HOME}`, and `${HOME}/...` to `os.homedir()` before the absolute / relative branch runs. Rebuilds via `path.join` so the platform separator is correct on Windows even when the input used forward slashes.

Closes #390.

## Test plan

- [x] `pnpm --filter @open-design/contracts typecheck` — exit 0
- [x] `pnpm --filter @open-design/daemon typecheck` — exit 0
- [x] `pnpm --filter @open-design/web typecheck` — exit 0
- [x] `pnpm --filter @open-design/daemon exec vitest run tests/resolve-data-dir.test.ts` — 7/7 pass (covers `~`, `~/...`, `$HOME`, `$HOME/...`, `${HOME}/...`, absolute, relative)
- [x] No em dashes anywhere in source, comments, or commit messages
- [x] No `Co-authored-by` trailers; author = Nagendhra <nagendhra405@gmail.com>
- [x] New tests under `apps/daemon/tests/` per the directory convention from #496