### PR TITLE
fix(version): resolve daemon package.json from any compiled layout

### DIFF
--- a/apps/daemon/src/app-version.ts
+++ b/apps/daemon/src/app-version.ts
@@ -1,4 +1,6 @@
-import { readFile } from 'node:fs/promises';
+import { readFile, stat } from 'node:fs/promises';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, join, parse as parsePath } from 'node:path';
 
 export const APP_VERSION_FALLBACK = '0.0.0';
 
@@ -31,8 +33,42 @@ export interface ReadAppVersionInfoOptions extends ResolveAppVersionInfoOptions 
   packageJsonUrl?: URL | undefined;
 }
 
-const DEFAULT_PACKAGE_JSON_URL = new URL('../package.json', import.meta.url);
 const processWithResources = process as NodeJS.Process & { resourcesPath?: string };
+
+// The compiled daemon ships in two layouts depending on which tsconfig produced
+// it: `dist/app-version.js` (rootDir=src, used by the `od` CLI) and
+// `dist/src/app-version.js` (rootDir=., used by the packaged sidecar entry).
+// A fixed relative path like `../package.json` only points at the daemon
+// `package.json` in the first layout — in the sidecar layout it resolves to
+// `dist/package.json`, which does not exist, so the version silently falls
+// back to `APP_VERSION_FALLBACK`. Walk up from `import.meta.url` until we find
+// a real `package.json` so both build outputs (and the TypeScript source
+// during `tools-dev`) read the daemon's actual version. Callers that already
+// inject the version via `OD_APP_VERSION` (packaged runtime) keep working
+// because that env still wins inside `resolveAppVersionInfo`.
+async function findNearestPackageJsonUrl(startUrl: URL): Promise<URL | null> {
+  let currentDir: string;
+  try {
+    currentDir = dirname(fileURLToPath(startUrl));
+  } catch {
+    return null;
+  }
+
+  const root = parsePath(currentDir).root;
+  while (true) {
+    const candidate = join(currentDir, 'package.json');
+    try {
+      const stats = await stat(candidate);
+      if (stats.isFile()) return pathToFileURL(candidate);
+    } catch {
+      // try the parent directory
+    }
+    if (currentDir === root) return null;
+    const parent = dirname(currentDir);
+    if (parent === currentDir) return null;
+    currentDir = parent;
+  }
+}
 
 function cleanString(value: unknown): string | null {
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
@@ -93,7 +129,7 @@ async function readPackageMetadata(packageJsonUrl: URL): Promise<PackageMetadata
 }
 
 export async function readCurrentAppVersionInfo({
-  packageJsonUrl = DEFAULT_PACKAGE_JSON_URL,
+  packageJsonUrl,
   packageMetadata,
   env,
   resourcesPath,
@@ -101,6 +137,8 @@ export async function readCurrentAppVersionInfo({
   platform,
   arch,
 }: ReadAppVersionInfoOptions = {}): Promise<AppVersionInfo> {
-  const metadata = packageMetadata ?? await readPackageMetadata(packageJsonUrl);
+  const resolvedUrl = packageJsonUrl ?? await findNearestPackageJsonUrl(new URL(import.meta.url));
+  const metadata = packageMetadata
+    ?? (resolvedUrl ? await readPackageMetadata(resolvedUrl) : null);
   return resolveAppVersionInfo({ env, packageMetadata: metadata, resourcesPath, execPath, platform, arch });
 }

--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -359,6 +359,7 @@ async function writeAssembledApp(
     paths.packagedConfigPath,
     `${JSON.stringify(
       {
+        appVersion: version,
         namespace: config.namespace,
         nodeCommandRelative: "open-design/bin/node",
         ...(config.portable ? {} : { namespaceBaseRoot: config.roots.runtime.namespaceBaseRoot }),


### PR DESCRIPTION
Fixes #534.

## Summary

Settings → About used to display `0.0.0` instead of the real daemon version in packaged builds. This PR makes the version lookup robust to the daemon's two compiled layouts and aligns the Linux packager with mac/win.

## Root cause

`apps/daemon` ships two compiled outputs and `app-version.ts` reads `package.json` via a fixed relative URL:

```ts
const DEFAULT_PACKAGE_JSON_URL = new URL('../package.json', import.meta.url);
```

| tsconfig | rootDir | output | `'../package.json'` resolves to |
| --- | --- | --- | --- |
| `tsconfig.json` (used by the `od` CLI) | `src` | `dist/app-version.js` | `apps/daemon/package.json` ✅ |
| `tsconfig.sidecar.json` (used by the packaged sidecar entry) | `.` | `dist/src/app-version.js` | `apps/daemon/dist/package.json` ❌ |

The packaged desktop app loads the daemon through `./sidecar`, which transitively imports `dist/src/app-version.js`. The lookup hits `ENOENT`, and `resolveAppVersionInfo` falls back to `APP_VERSION_FALLBACK = '0.0.0'`. The recently added `OD_APP_VERSION` env shortcut masks this on mac/win, but Linux's packager never wrote `appVersion` to `open-design-config.json`, so Linux packaged builds still show `0.0.0`.

## Changes

- `apps/daemon/src/app-version.ts`: walk up from `import.meta.url` until a real `package.json` is found. Uses only `node:url` + `node:path` primitives. `OD_APP_VERSION` env still wins inside `resolveAppVersionInfo`, so existing injection paths are unchanged.
- `tools/pack/src/linux.ts`: add `appVersion: version` to `open-design-config.json`, matching `mac.ts` / `win.ts`.

## Test plan

- [x] `pnpm --filter @open-design/daemon typecheck && build && test` — all pass (incl. the `OD_APP_VERSION` test added recently)
- [x] `pnpm --filter @open-design/tools-pack typecheck && test` — all pass
- [x] Loaded both compiled layouts directly with `OD_APP_VERSION` cleared — both report `0.3.0` after the fix (`dist/src/app-version.js` reported `0.0.0` before)
- [ ] `pnpm tools-pack mac build --to app && install && start` → Settings → About shows `0.3.0`
- [ ] `pnpm tools-pack win build --to nsis` → install → Settings → About shows `0.3.0`
- [ ] `pnpm tools-pack linux build --to appimage` → install → Settings → About shows `0.3.0` (previously broken)