### PR TITLE
chore(web): #475 retry follow-ups — extract shouldShowRetryButton + attachment tests

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -60,6 +60,9 @@ interface Props {
   onDeleteComment?: (commentId: string) => void;
   onSend: (prompt: string, attachments: ChatAttachment[], commentAttachments: ChatCommentAttachment[]) => void;
   onStop: () => void;
+  // Retry a failed assistant turn. Reuses the preceding user message
+  // verbatim — does NOT append a duplicate to history. See issue #475.
+  onRetry?: (failedAssistantId: string) => void;
   // Click-to-open chain: passes a basename up to ProjectView, which sets
   // FileWorkspace's openRequest. Tool cards, attachment chips, and
   // produced-file chips all call this.
@@ -109,6 +112,7 @@ export function ChatPane({
   onDeleteComment,
   onSend,
   onStop,
+  onRetry,
   onRequestOpenFile,
   initialDraft,
   onSubmitForm,
@@ -412,7 +416,29 @@ export function ChatPane({
                   </Fragment>
                 );
               })}
-              {error ? <div className="msg error">{error}</div> : null}
+              {error ? (
+                <div className="msg error">
+                  <span>{error}</span>
+                  {onRetry && lastAssistantId
+                    ? (() => {
+                        const last = messages[messages.length - 1];
+                        if (!last || last.id !== lastAssistantId) return null;
+                        if (last.runStatus !== 'failed') return null;
+                        return (
+                          <button
+                            type="button"
+                            className="ghost chat-error-retry"
+                            data-testid="chat-error-retry"
+                            onClick={() => onRetry(lastAssistantId)}
+                            disabled={streaming}
+                          >
+                            {t('promptTemplates.retry')}
+                          </button>
+                        );
+                      })()
+                    : null}
+                </div>
+              ) : null}
             </div>
             {scrolledFromBottom ? (
               <button

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -12,6 +12,20 @@ import { Icon } from './Icon';
 
 type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => string;
 
+// Retry is only offered when the most recent message is the failed
+// assistant turn the error banner refers to. If the user has sent
+// further messages since, or the run is no longer marked failed,
+// retrying would target stale state.
+export function shouldShowRetryButton(
+  messages: ChatMessage[],
+  lastAssistantId: string | null,
+): boolean {
+  if (!lastAssistantId) return false;
+  const last = messages[messages.length - 1];
+  if (!last || last.id !== lastAssistantId) return false;
+  return last.runStatus === 'failed';
+}
+
 // Featured starter prompts shown on the empty chat. Clicking one fills
 // the composer (does not auto-send) so users can tweak before sending.
 // Each prompt is intentionally dense — it should showcase ambitious
@@ -419,24 +433,17 @@ export function ChatPane({
               {error ? (
                 <div className="msg error">
                   <span>{error}</span>
-                  {onRetry && lastAssistantId
-                    ? (() => {
-                        const last = messages[messages.length - 1];
-                        if (!last || last.id !== lastAssistantId) return null;
-                        if (last.runStatus !== 'failed') return null;
-                        return (
-                          <button
-                            type="button"
-                            className="ghost chat-error-retry"
-                            data-testid="chat-error-retry"
-                            onClick={() => onRetry(lastAssistantId)}
-                            disabled={streaming}
-                          >
-                            {t('promptTemplates.retry')}
-                          </button>
-                        );
-                      })()
-                    : null}
+                  {onRetry && lastAssistantId && shouldShowRetryButton(messages, lastAssistantId) ? (
+                    <button
+                      type="button"
+                      className="ghost chat-error-retry"
+                      data-testid="chat-error-retry"
+                      onClick={() => onRetry(lastAssistantId)}
+                      disabled={streaming}
+                    >
+                      {t('promptTemplates.retry')}
+                    </button>
+                  ) : null}
                 </div>
               ) : null}
             </div>

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -779,19 +779,33 @@ export function ProjectView({
       prompt: string,
       attachments: ChatAttachment[],
       commentAttachments: ChatCommentAttachment[] = commentsToAttachments(attachedComments),
+      // When set, this call replays a previously-sent user turn after its
+      // assistant turn failed. We reuse the existing user message verbatim
+      // instead of appending a duplicate to history. See issue #475.
+      options: { retryOfAssistantId?: string } = {},
     ) => {
       if (!activeConversationId) return;
-      if (!prompt.trim() && attachments.length === 0 && commentAttachments.length === 0) return;
-      setError(null);
       const startedAt = Date.now();
-      const userMsg: ChatMessage = {
-        id: crypto.randomUUID(),
-        role: 'user',
-        content: prompt,
-        createdAt: startedAt,
-        attachments: attachments.length > 0 ? attachments : undefined,
-        commentAttachments: commentAttachments.length > 0 ? commentAttachments : undefined,
-      };
+      let userMsg: ChatMessage;
+      let priorMessages: ChatMessage[];
+      if (options.retryOfAssistantId) {
+        const target = resolveRetryTarget(messages, options.retryOfAssistantId);
+        if (!target) return;
+        userMsg = target.userMsg;
+        priorMessages = target.priorMessages;
+      } else {
+        if (!prompt.trim() && attachments.length === 0 && commentAttachments.length === 0) return;
+        userMsg = {
+          id: crypto.randomUUID(),
+          role: 'user',
+          content: prompt,
+          createdAt: startedAt,
+          attachments: attachments.length > 0 ? attachments : undefined,
+          commentAttachments: commentAttachments.length > 0 ? commentAttachments : undefined,
+        };
+        priorMessages = messages;
+      }
+      setError(null);
       const selectedAgent =
         config.mode === 'daemon' && config.agentId
           ? agentsById.get(config.agentId)
@@ -824,22 +838,29 @@ export function ProjectView({
         runStatus: config.mode === 'daemon' ? 'running' : undefined,
         startedAt,
       };
-      const nextHistory = [...messages, userMsg];
+      const nextHistory = [...priorMessages, userMsg];
       setMessages([...nextHistory, assistantMsg]);
       setStreaming(true);
       setArtifact(null);
       savedArtifactRef.current = null;
       onTouchProject();
-      persistMessage(userMsg);
+      // On retry, the user message is already on disk; only the new
+      // assistant placeholder needs persisting. Skipping persistMessage(userMsg)
+      // also keeps the original timestamp/id stable.
+      if (!options.retryOfAssistantId) persistMessage(userMsg);
       persistMessage(assistantMsg);
-      if (commentAttachments.length > 0) {
+      const effectiveCommentAttachments = options.retryOfAssistantId
+        ? userMsg.commentAttachments ?? []
+        : commentAttachments;
+      if (!options.retryOfAssistantId && commentAttachments.length > 0) {
         void patchAttachedStatuses(commentAttachments, 'applying');
         setAttachedComments([]);
       }
       // If this is the first turn, derive a working title from the prompt
       // so the conversation is identifiable in the dropdown without a
-      // round-trip through the agent.
-      if (messages.length === 0) {
+      // round-trip through the agent. Skip on retry (title already set, and
+      // priorMessages excludes the user turn so length===0 would mis-fire).
+      if (!options.retryOfAssistantId && messages.length === 0) {
         const title = prompt.slice(0, 60).trim();
         if (title) {
           setConversations((curr) =>
@@ -970,8 +991,8 @@ export function ProjectView({
             endedAt: Date.now(),
             runStatus: config.mode === 'api' || prev.runId ? 'succeeded' : prev.runStatus,
           }));
-          if (commentAttachments.length > 0) {
-            void patchAttachedStatuses(commentAttachments, 'needs_review');
+          if (effectiveCommentAttachments.length > 0) {
+            void patchAttachedStatuses(effectiveCommentAttachments, 'needs_review');
           }
           setStreaming(false);
           abortRef.current = null;
@@ -1016,8 +1037,8 @@ export function ProjectView({
               ? 'failed'
               : prev.runStatus,
           }));
-          if (commentAttachments.length > 0) {
-            void patchAttachedStatuses(commentAttachments, 'failed');
+          if (effectiveCommentAttachments.length > 0) {
+            void patchAttachedStatuses(effectiveCommentAttachments, 'failed');
           }
           setStreaming(false);
           abortRef.current = null;
@@ -1049,8 +1070,11 @@ export function ProjectView({
           clientRequestId: crypto.randomUUID(),
           skillId: project.skillId ?? null,
           designSystemId: project.designSystemId ?? null,
-          attachments: attachments.map((a) => a.path),
-          commentAttachments,
+          attachments: (options.retryOfAssistantId
+            ? userMsg.attachments ?? []
+            : attachments
+          ).map((a) => a.path),
+          commentAttachments: effectiveCommentAttachments,
           model: choice?.model ?? null,
           reasoning: choice?.reasoning ?? null,
           onRunCreated: (runId) => {
@@ -1103,6 +1127,18 @@ export function ProjectView({
       updateMessageById,
       onProjectsRefresh,
     ],
+  );
+
+  // Retry a failed assistant turn without appending a duplicate user
+  // message. The previous user turn is reused verbatim; the failed
+  // assistant turn (and anything after it) is dropped from history
+  // before re-streaming. See issue #475.
+  const handleRetry = useCallback(
+    (failedAssistantId: string) => {
+      if (streaming) return;
+      void handleSend('', [], [], { retryOfAssistantId: failedAssistantId });
+    },
+    [streaming, handleSend],
   );
 
   const persistArtifact = useCallback(
@@ -1412,6 +1448,7 @@ export function ProjectView({
           onDeleteComment={(commentId) => void removePreviewComment(commentId)}
           onSend={handleSend}
           onStop={handleStop}
+          onRetry={handleRetry}
           onRequestOpenFile={requestOpenFile}
           initialDraft={initialDraft}
           onSubmitForm={(text) => {
@@ -1475,6 +1512,27 @@ function assistantAgentDisplayName(
 
 function isTerminalRunStatus(status: ChatMessage['runStatus']): boolean {
   return status === 'succeeded' || status === 'failed' || status === 'canceled';
+}
+
+/**
+ * Locate the user turn that should be re-sent when retrying a failed
+ * assistant turn. Returns the original user message verbatim plus the
+ * conversation history that precedes it. Callers must NOT append a new
+ * user message — that would duplicate the prompt in the LLM context
+ * (issue #475).
+ *
+ * Returns null when the failed assistant id is not found, is the first
+ * message, or is not preceded by a user message.
+ */
+export function resolveRetryTarget(
+  messages: ChatMessage[],
+  failedAssistantId: string,
+): { userMsg: ChatMessage; priorMessages: ChatMessage[] } | null {
+  const failedIdx = messages.findIndex((m) => m.id === failedAssistantId);
+  if (failedIdx <= 0) return null;
+  const prior = messages[failedIdx - 1];
+  if (!prior || prior.role !== 'user') return null;
+  return { userMsg: prior, priorMessages: messages.slice(0, failedIdx - 1) };
 }
 
 function isActiveRunStatus(status: ChatMessage['runStatus']): boolean {

--- a/apps/web/tests/components/retry-target.test.ts
+++ b/apps/web/tests/components/retry-target.test.ts
@@ -60,4 +60,34 @@ describe('resolveRetryTarget — issue #475', () => {
     ];
     expect(resolveRetryTarget(messages, 'a2')).toBeNull();
   });
+
+  it('preserves attachments on the reused user turn so retry can replay them', () => {
+    const messages: ChatMessage[] = [
+      {
+        id: 'u1',
+        role: 'user',
+        content: 'render this',
+        attachments: [{ path: '/p/img.png', name: 'img.png', kind: 'image' }],
+      },
+      assistant('a1', 'failed'),
+    ];
+
+    const target = resolveRetryTarget(messages, 'a1');
+    expect(target).not.toBeNull();
+    expect(target!.userMsg.attachments).toEqual([
+      { path: '/p/img.png', name: 'img.png', kind: 'image' },
+    ]);
+    // Mirrors the daemon-stream call site: `(userMsg.attachments ?? []).map(...)`
+    // must not throw whether attachments is present, undefined, or empty.
+    const paths = (target!.userMsg.attachments ?? []).map((a) => a.path);
+    expect(paths).toEqual(['/p/img.png']);
+  });
+
+  it('tolerates a reused user turn with no attachments without throwing', () => {
+    const messages = [user('u1', 'plain'), assistant('a1', 'failed')];
+    const target = resolveRetryTarget(messages, 'a1');
+    expect(target).not.toBeNull();
+    expect(target!.userMsg.attachments).toBeUndefined();
+    expect(() => (target!.userMsg.attachments ?? []).map((a) => a.path)).not.toThrow();
+  });
 });

--- a/apps/web/tests/components/retry-target.test.ts
+++ b/apps/web/tests/components/retry-target.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { resolveRetryTarget } from '../../src/components/ProjectView';
+import type { ChatMessage } from '../../src/types';
+
+function user(id: string, content: string): ChatMessage {
+  return { id, role: 'user', content };
+}
+
+function assistant(id: string, runStatus?: ChatMessage['runStatus']): ChatMessage {
+  return { id, role: 'assistant', content: '', runStatus };
+}
+
+describe('resolveRetryTarget — issue #475', () => {
+  it('returns the preceding user turn and history-before-it for a failed assistant', () => {
+    const messages = [
+      user('u1', 'first prompt'),
+      assistant('a1'),
+      user('u2', 'second prompt'),
+      assistant('a2', 'failed'),
+    ];
+
+    const target = resolveRetryTarget(messages, 'a2');
+
+    expect(target).not.toBeNull();
+    expect(target!.userMsg.id).toBe('u2');
+    expect(target!.userMsg.content).toBe('second prompt');
+    expect(target!.priorMessages.map((m) => m.id)).toEqual(['u1', 'a1']);
+  });
+
+  it('does not duplicate the user message when reconstructing the next history', () => {
+    const messages = [
+      user('u1', 'one prompt'),
+      assistant('a1', 'failed'),
+    ];
+
+    const target = resolveRetryTarget(messages, 'a1');
+    expect(target).not.toBeNull();
+    const nextHistory = [...target!.priorMessages, target!.userMsg];
+
+    const userTurns = nextHistory.filter((m) => m.role === 'user');
+    expect(userTurns).toHaveLength(1);
+    expect(userTurns[0]!.content).toBe('one prompt');
+  });
+
+  it('returns null when the failed assistant id is not found', () => {
+    const messages = [user('u1', 'x'), assistant('a1', 'failed')];
+    expect(resolveRetryTarget(messages, 'missing')).toBeNull();
+  });
+
+  it('returns null when the failed assistant has no preceding user turn', () => {
+    const messages = [assistant('a1', 'failed')];
+    expect(resolveRetryTarget(messages, 'a1')).toBeNull();
+  });
+
+  it('returns null when the message before the failed assistant is not a user turn', () => {
+    const messages = [
+      user('u1', 'x'),
+      assistant('a1'),
+      assistant('a2', 'failed'),
+    ];
+    expect(resolveRetryTarget(messages, 'a2')).toBeNull();
+  });
+});

--- a/apps/web/tests/components/should-show-retry-button.test.ts
+++ b/apps/web/tests/components/should-show-retry-button.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { shouldShowRetryButton } from '../../src/components/ChatPane';
+import type { ChatMessage } from '../../src/types';
+
+function user(id: string): ChatMessage {
+  return { id, role: 'user', content: '' };
+}
+function assistant(id: string, runStatus?: ChatMessage['runStatus']): ChatMessage {
+  return { id, role: 'assistant', content: '', runStatus };
+}
+
+describe('shouldShowRetryButton — issue #475', () => {
+  it('shows when the last message is the failed assistant', () => {
+    const messages = [user('u1'), assistant('a1', 'failed')];
+    expect(shouldShowRetryButton(messages, 'a1')).toBe(true);
+  });
+
+  it('hides when there is no last assistant id', () => {
+    expect(shouldShowRetryButton([user('u1')], null)).toBe(false);
+  });
+
+  it('hides when the last message is not the referenced assistant', () => {
+    const messages = [user('u1'), assistant('a1', 'failed'), user('u2')];
+    expect(shouldShowRetryButton(messages, 'a1')).toBe(false);
+  });
+
+  it('hides when the assistant run is not failed', () => {
+    const messages = [user('u1'), assistant('a1', 'succeeded')];
+    expect(shouldShowRetryButton(messages, 'a1')).toBe(false);
+  });
+
+  it('hides on an empty message list', () => {
+    expect(shouldShowRetryButton([], 'a1')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Addresses review feedback on #475 (retry should not duplicate the previous user message). Stacked on top of that PR — review/merge #475 first.

- **P3 — Retry button readability:** Extracted the dense IIFE in `ChatPane.tsx` (error banner) into a named `shouldShowRetryButton(messages, lastAssistantId)` helper. Same gating logic, easier to read and now directly unit-testable.
- **P2 — Attachments edge case:** The daemon-stream call site already guards with `userMsg.attachments ?? []`, but there was no test exercising attachments on the retried turn. Added two unit tests confirming attachments are preserved on the reused user turn and that the `?? []` guard keeps the path safe when `attachments` is undefined.
- **P2 — End-to-end verification:** Local environment is on Node 22; cannot satisfy the repo's Node ~24 engines pin for the Playwright e2e flow. Flagging for a maintainer with a Node 24 environment.

## Changes
- `apps/web/src/components/ChatPane.tsx` — export `shouldShowRetryButton`; replace the IIFE with a single conditional.
- `apps/web/tests/components/should-show-retry-button.test.ts` — new, 5 tests covering each gating branch.
- `apps/web/tests/components/retry-target.test.ts` — +2 tests for the attachments path.

## Test plan
- [x] `pnpm --filter @open-design/web test` — 223 tests pass (12 across the two retry test files).
- [x] `pnpm --filter @open-design/web typecheck` — clean.
- [x] `pnpm guard` — clean.
- [ ] Maintainer e2e on Node 24: open a project, force a failed assistant run, click Retry, confirm only one user turn is sent in the network payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)