### PR TITLE
Fix file tab wheel scrolling

### DIFF
--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -66,6 +66,7 @@ export function FileWorkspace({
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [sketches, setSketches] = useState<Record<string, SketchState>>({});
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const tabsBarRef = useRef<HTMLDivElement | null>(null);
 
   // Pull the persisted active tab in when the parent's hydration completes
   // (or on project switch). Fall back to the Design Files browser so a
@@ -202,6 +203,17 @@ export function FileWorkspace({
     };
   }, []);
 
+  useEffect(() => {
+    const tabBar = tabsBarRef.current;
+    if (!tabBar) return;
+
+    const onWheel = (event: globalThis.WheelEvent) => {
+      scrollWorkspaceTabsWithWheel(tabBar, event);
+    };
+    tabBar.addEventListener('wheel', onWheel, { passive: false });
+    return () => tabBar.removeEventListener('wheel', onWheel);
+  }, []);
+
   async function handleDelete(name: string) {
     if (!confirm(t('workspace.deleteFileConfirm', { name }))) return;
     const ok = await deleteProjectFile(projectId, name);
@@ -336,7 +348,12 @@ export function FileWorkspace({
 
   return (
     <div className="workspace" data-testid="file-workspace">
-      <div className="ws-tabs-bar" role="tablist" aria-label={t('workspace.designFiles')}>
+      <div
+        ref={tabsBarRef}
+        className="ws-tabs-bar"
+        role="tablist"
+        aria-label={t('workspace.designFiles')}
+      >
         <button
           type="button"
           className={`ws-tab design-files-tab ${activeTab === DESIGN_FILES_TAB ? 'active' : ''}`}
@@ -507,6 +524,30 @@ function Tab({
       ) : null}
     </div>
   );
+}
+
+export function scrollWorkspaceTabsWithWheel(
+  tabBar: Pick<HTMLDivElement, 'clientWidth' | 'scrollLeft' | 'scrollWidth'>,
+  event: Pick<globalThis.WheelEvent, 'ctrlKey' | 'deltaMode' | 'deltaX' | 'deltaY' | 'preventDefault'>,
+) {
+  if (event.ctrlKey) return;
+  if (Math.abs(event.deltaY) <= Math.abs(event.deltaX)) return;
+  if (tabBar.scrollWidth <= tabBar.clientWidth) return;
+
+  const before = tabBar.scrollLeft;
+  tabBar.scrollLeft += wheelDeltaToPixels(event.deltaY, event.deltaMode);
+  if (tabBar.scrollLeft === before) return;
+
+  event.preventDefault();
+}
+
+function wheelDeltaToPixels(delta: number, deltaMode: number): number {
+  const WHEEL_DELTA_LINE = 1;
+  const WHEEL_DELTA_PAGE = 2;
+
+  if (deltaMode === WHEEL_DELTA_LINE) return delta * 16;
+  if (deltaMode === WHEEL_DELTA_PAGE) return delta * 160;
+  return delta;
 }
 
 function kindIconName(

--- a/apps/web/tests/components/FileWorkspace.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.test.tsx
@@ -1,7 +1,7 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it, vi } from 'vitest';
 
-import { FileWorkspace } from '../../src/components/FileWorkspace';
+import { FileWorkspace, scrollWorkspaceTabsWithWheel } from '../../src/components/FileWorkspace';
 
 describe('FileWorkspace upload input', () => {
   it('keeps the Design Files picker aligned with drag-and-drop file support', () => {
@@ -18,5 +18,161 @@ describe('FileWorkspace upload input', () => {
 
     expect(markup).toContain('data-testid="design-files-upload-input"');
     expect(markup).not.toContain('accept=');
+  });
+});
+
+describe('scrollWorkspaceTabsWithWheel', () => {
+  function makeTabBar(scrollLeft: number, scrollWidth = 400, clientWidth = 200) {
+    return { scrollLeft, scrollWidth, clientWidth } as HTMLDivElement;
+  }
+
+  function makeClampedTabBar(scrollLeft: number, scrollWidth = 400, clientWidth = 200) {
+    let value = scrollLeft;
+    return {
+      scrollWidth,
+      clientWidth,
+      get scrollLeft() {
+        return value;
+      },
+      set scrollLeft(next: number) {
+        value = Math.min(Math.max(next, 0), scrollWidth - clientWidth);
+      },
+    } as HTMLDivElement;
+  }
+
+  it('maps vertical mouse wheel movement to horizontal tab scrolling', () => {
+    const preventDefault = vi.fn();
+    const currentTarget = makeTabBar(12);
+    const event = {
+      ctrlKey: false,
+      deltaMode: 0,
+      deltaX: 0,
+      deltaY: 40,
+      preventDefault,
+    } as unknown as WheelEvent;
+
+    scrollWorkspaceTabsWithWheel(currentTarget, event);
+
+    expect(currentTarget.scrollLeft).toBe(52);
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports reverse vertical wheel movement', () => {
+    const preventDefault = vi.fn();
+    const currentTarget = makeTabBar(52);
+    const event = {
+      ctrlKey: false,
+      deltaMode: 0,
+      deltaX: 0,
+      deltaY: -40,
+      preventDefault,
+    } as unknown as WheelEvent;
+
+    scrollWorkspaceTabsWithWheel(currentTarget, event);
+
+    expect(currentTarget.scrollLeft).toBe(12);
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  it('normalizes line-based wheel deltas to useful pixel movement', () => {
+    const preventDefault = vi.fn();
+    const currentTarget = makeTabBar(12);
+    const event = {
+      ctrlKey: false,
+      deltaMode: 1,
+      deltaX: 0,
+      deltaY: 3,
+      preventDefault,
+    } as unknown as WheelEvent;
+
+    scrollWorkspaceTabsWithWheel(currentTarget, event);
+
+    expect(currentTarget.scrollLeft).toBe(60);
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  it('normalizes page-based wheel deltas to useful pixel movement', () => {
+    const preventDefault = vi.fn();
+    const currentTarget = makeTabBar(12, 600, 200);
+    const event = {
+      ctrlKey: false,
+      deltaMode: 2,
+      deltaX: 0,
+      deltaY: 1,
+      preventDefault,
+    } as unknown as WheelEvent;
+
+    scrollWorkspaceTabsWithWheel(currentTarget, event);
+
+    expect(currentTarget.scrollLeft).toBe(172);
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves native horizontal wheel gestures alone', () => {
+    const preventDefault = vi.fn();
+    const currentTarget = makeTabBar(12);
+    const event = {
+      ctrlKey: false,
+      deltaMode: 0,
+      deltaX: 50,
+      deltaY: 10,
+      preventDefault,
+    } as unknown as WheelEvent;
+
+    scrollWorkspaceTabsWithWheel(currentTarget, event);
+
+    expect(currentTarget.scrollLeft).toBe(12);
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('leaves ctrl-wheel zoom gestures alone', () => {
+    const preventDefault = vi.fn();
+    const currentTarget = makeTabBar(12);
+    const event = {
+      ctrlKey: true,
+      deltaMode: 0,
+      deltaX: 0,
+      deltaY: 40,
+      preventDefault,
+    } as unknown as WheelEvent;
+
+    scrollWorkspaceTabsWithWheel(currentTarget, event);
+
+    expect(currentTarget.scrollLeft).toBe(12);
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('does not intercept vertical wheel movement when tabs do not overflow', () => {
+    const preventDefault = vi.fn();
+    const currentTarget = makeTabBar(12, 200, 200);
+    const event = {
+      ctrlKey: false,
+      deltaMode: 0,
+      deltaX: 0,
+      deltaY: 40,
+      preventDefault,
+    } as unknown as WheelEvent;
+
+    scrollWorkspaceTabsWithWheel(currentTarget, event);
+
+    expect(currentTarget.scrollLeft).toBe(12);
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('lets page scrolling continue when the tab bar is already at the wheel boundary', () => {
+    const preventDefault = vi.fn();
+    const currentTarget = makeClampedTabBar(200, 400, 200);
+    const event = {
+      ctrlKey: false,
+      deltaMode: 0,
+      deltaX: 0,
+      deltaY: 40,
+      preventDefault,
+    } as unknown as WheelEvent;
+
+    scrollWorkspaceTabsWithWheel(currentTarget, event);
+
+    expect(currentTarget.scrollLeft).toBe(200);
+    expect(preventDefault).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Add wheel handling to the file workspace tab bar so vertical mouse wheel input scrolls overflowing tabs horizontally.
- Register the wheel listener with `{ passive: false }` so `preventDefault()` works when the tab bar actually scrolls.
- Keep native horizontal gestures, non-overflowing tab bars, and scroll-boundary cases from being intercepted.
- Cover the behavior with FileWorkspace unit tests, including reverse scroll, line/page delta modes, native horizontal gestures, no overflow, and boundary pass-through.

## Why
When many file tabs are open, the tab bar is a horizontal navigation surface. Using the mouse wheel over that area should move the tabs left/right, not make the tab strip or page feel like it is scrolling vertically. This keeps the tab bar height stable and makes hidden tabs easier to reach.

## Validation
- `pnpm --filter @open-design/web test -- tests/components/FileWorkspace.test.tsx`
- `pnpm --filter @open-design/web test`
- `pnpm --filter @open-design/web typecheck`
- `git diff --check`
- Claude Code review via `$cc:review` passed on the final working tree diff.