### PR TITLE
feat: add Docker support for daemon deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,9 +4,20 @@
 .github
 node_modules
 .od
-*.md
-*.png
-*.jpg
+.tmp
+.claude
+.codex
+.opencode
+.env*
+.npmrc
+reports
+
+# Exclude top-level docs and images only (runtime .md and .png/jpg under
+# skills/, design-systems/, craft/, assets/ must remain in the image)
+/*.md
+/*.png
+/*.jpg
+
 Dockerfile
 .dockerignore
 docker-compose.yml

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.gitignore
+.gitattributes
+.github
+node_modules
+.od
+*.md
+*.png
+*.jpg
+Dockerfile
+.dockerignore
+docker-compose.yml
+.edited_image.png
+e2e
+specs
+story

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,4 +57,7 @@ EXPOSE 7456
 
 ENV OD_BIND_HOST=0.0.0.0
 
-CMD ["node", "apps/daemon/dist/cli.js", "--no-open", "--host", "0.0.0.0"]
+# Bind host is controlled by OD_BIND_HOST env var (default 0.0.0.0).
+# Do NOT add --host here — the CLI flag overrides the env, preventing
+# Compose users from changing OD_BIND_HOST without also replacing CMD.
+CMD ["node", "apps/daemon/dist/cli.js", "--no-open"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:24-slim
+
+# Build deps needed for better-sqlite3 native module
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 make gcc g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN corepack enable && corepack prepare pnpm@10 --activate
+
+WORKDIR /app
+
+# Copy entire repo (use .dockerignore to skip .git, etc.)
+COPY . .
+
+# Install dependencies (postinstall builds workspace packages)
+RUN pnpm install --frozen-lockfile
+
+# Build the daemon CLI
+RUN pnpm -C apps/daemon run build
+
+EXPOSE 7456
+
+ENV OD_BIND_HOST=0.0.0.0
+
+CMD ["node", "apps/daemon/dist/cli.js", "--no-open", "--host", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,57 @@
-FROM node:24-slim
+# -- Build stage -------------------------------------------------------
+FROM node:24-slim AS builder
 
-# Build deps needed for better-sqlite3 native module
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 make gcc g++ \
     && rm -rf /var/lib/apt/lists/*
 
-RUN corepack enable && corepack prepare pnpm@10 --activate
+# Pin to the exact pnpm version declared in package.json
+RUN corepack enable && corepack prepare pnpm@10.33.2 --activate
 
 WORKDIR /app
 
-# Copy entire repo (use .dockerignore to skip .git, etc.)
 COPY . .
 
 # Install dependencies (postinstall builds workspace packages)
 RUN pnpm install --frozen-lockfile
 
-# Build the daemon CLI
-RUN pnpm -C apps/daemon run build
+# Build the daemon CLI and the static web UI
+RUN pnpm -C apps/daemon run build \
+    && pnpm --filter @open-design/web build
+
+# -- Runtime stage ------------------------------------------------------
+FROM node:24-slim
+
+RUN corepack enable && corepack prepare pnpm@10.33.2 --activate
+
+# Create unprivileged user
+RUN groupadd -r oduser && useradd -r -g oduser oduser \
+    && mkdir -p /app/.od && chown -R oduser:oduser /app
+
+WORKDIR /app
+
+# Runtime dependencies (pnpm workspace resolution)
+COPY --from=builder --chown=oduser:oduser /app/package.json /app/pnpm-lock.yaml /app/pnpm-workspace.yaml ./
+COPY --from=builder --chown=oduser:oduser /app/node_modules ./node_modules
+
+# Workspace package manifests (needed for module resolution)
+COPY --from=builder --chown=oduser:oduser /app/packages ./packages
+COPY --from=builder --chown=oduser:oduser /app/tools ./tools
+COPY --from=builder --chown=oduser:oduser /app/apps ./apps
+
+# Built artifacts
+COPY --from=builder --chown=oduser:oduser /app/apps/daemon/dist ./apps/daemon/dist
+COPY --from=builder --chown=oduser:oduser /app/apps/web/out ./apps/web/out
+
+# Runtime data directories
+COPY --from=builder --chown=oduser:oduser /app/skills ./skills
+COPY --from=builder --chown=oduser:oduser /app/design-systems ./design-systems
+COPY --from=builder --chown=oduser:oduser /app/prompt-templates ./prompt-templates
+COPY --from=builder --chown=oduser:oduser /app/templates ./templates
+COPY --from=builder --chown=oduser:oduser /app/craft ./craft
+COPY --from=builder --chown=oduser:oduser /app/assets ./assets
+
+USER oduser
 
 EXPOSE 7456
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,9 +55,9 @@ USER oduser
 
 EXPOSE 7456
 
-ENV OD_BIND_HOST=0.0.0.0
+# Default to loopback-only — the daemon is local-first with no auth.
+# To bind broadly, explicitly set OD_BIND_HOST=0.0.0.0 at runtime.
+ENV OD_BIND_HOST=127.0.0.1
 
-# Bind host is controlled by OD_BIND_HOST env var (default 0.0.0.0).
-# Do NOT add --host here — the CLI flag overrides the env, preventing
-# Compose users from changing OD_BIND_HOST without also replacing CMD.
+# Do NOT add --host here — the CLI flag overrides OD_BIND_HOST env.
 CMD ["node", "apps/daemon/dist/cli.js", "--no-open"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,9 @@ services:
     container_name: open-design
     ports:
       # Bind only to loopback by default — the daemon is local-first
-      # with no auth. To expose on a LAN, replace 127.0.0.1 with the
-      # desired interface IP and put a reverse proxy / auth layer in front.
+      # with no auth. To expose beyond localhost, you must use a
+      # reverse proxy (nginx, caddy) that rewrites the Origin header,
+      # set OD_BIND_HOST to the actual interface IP, and add auth.
       - "127.0.0.1:7456:7456"
     volumes:
       - od_data:/app/.od

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  open-design:
+    build: .
+    container_name: open-design
+    ports:
+      - "7456:7456"
+    volumes:
+      - od_data:/app/.od
+    restart: unless-stopped
+    environment:
+      - OD_PORT=7456
+      - OD_BIND_HOST=0.0.0.0
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:7456/api/health', (r) => { process.exit(r.statusCode === 200 ? 0 : 1) })"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+volumes:
+  od_data:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,10 @@ services:
       - OD_PORT=7456
       - OD_BIND_HOST=127.0.0.1
     healthcheck:
-      test: ["CMD", "node", "-e", "require('http').get('http://localhost:7456/api/health', (r) => { process.exit(r.statusCode === 200 ? 0 : 1) })"]
+      # Use 127.0.0.1 instead of localhost — on hosts where localhost
+      # resolves to ::1 first, the IPv6 connection would miss the IPv4
+      # listener and mark the container unhealthy.
+      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:7456/api/health', (r) => { process.exit(r.statusCode === 200 ? 0 : 1) })"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,10 @@ services:
     build: .
     container_name: open-design
     ports:
-      - "7456:7456"
+      # Bind only to loopback by default — the daemon is local-first
+      # with no auth. To expose on a LAN, replace 127.0.0.1 with the
+      # desired interface IP and put a reverse proxy / auth layer in front.
+      - "127.0.0.1:7456:7456"
     volumes:
       - od_data:/app/.od
     restart: unless-stopped
@@ -15,7 +18,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 30s
+      start_period: 60s
 
 volumes:
   od_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,18 +2,18 @@ services:
   open-design:
     build: .
     container_name: open-design
-    ports:
-      # Bind only to loopback by default — the daemon is local-first
-      # with no auth. To expose beyond localhost, you must use a
-      # reverse proxy (nginx, caddy) that rewrites the Origin header,
-      # set OD_BIND_HOST to the actual interface IP, and add auth.
-      - "127.0.0.1:7456:7456"
+    # Host networking preserves loopback for local-only daemon routes
+    # (live artifact preview, connectors) that reject non-loopback peer
+    # addresses. On Linux this works natively. On macOS, Docker Desktop
+    # 4.34+ supports host networking; older versions fall back to the
+    # VM's network which may break those routes.
+    network_mode: host
     volumes:
       - od_data:/app/.od
     restart: unless-stopped
     environment:
       - OD_PORT=7456
-      - OD_BIND_HOST=0.0.0.0
+      - OD_BIND_HOST=127.0.0.1
     healthcheck:
       test: ["CMD", "node", "-e", "require('http').get('http://localhost:7456/api/health', (r) => { process.exit(r.statusCode === 200 ? 0 : 1) })"]
       interval: 30s


### PR DESCRIPTION
## Summary
- Add `Dockerfile` to build and run the Open Design daemon in a container
- Add `.dockerignore` to keep the build context lean
- Add `docker-compose.yml` for easy management in Docker Desktop with one-click start/stop

## Motivation
Users who prefer containerized workflows can now run the Open Design daemon via Docker without installing Node.js and pnpm on their host. The Docker setup includes healthcheck monitoring and persistent storage for the `.od/` data directory.

## Test plan
- [x] `docker compose up -d --build` builds and starts successfully
- [x] `curl http://localhost:7456/api/health` returns `{"ok":true}`
- [x] `curl http://localhost:7456/api/skills` returns the full skills list
- [x] MCP server (`od mcp --daemon-url http://localhost:7456`) connects and serves tools
- [x] Container shows healthy in Docker Desktop

## Notes
The MCP stdio server still needs to run on the host (configured via `.mcp.json`) since Docker containers cannot expose stdio-based MCP servers to the host. This PR focuses on containerizing the daemon itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)