### PR TITLE
fix(tools-pack): replace corepack with npx in linux container build (unblocks 0.4.0)

### DIFF
--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -96,14 +96,22 @@ export function buildDockerArgs(
   // None of these values can contain shell metacharacters, so direct
   // interpolation into the inner command string is safe.
   //
-  // We invoke pnpm via `corepack pnpm` instead of `corepack enable && pnpm ...`
-  // because the container runs as the host's non-root uid (--user above) and
-  // `corepack enable` writes shims next to the system Node binary, which is
-  // owned by root in electronuserland/builder:base and not writable by the
-  // unprivileged container user. `corepack pnpm` resolves and executes the
-  // pinned packageManager from package.json directly, no shims required.
+  // We can't rely on `corepack pnpm` here: although Node 16.10+ ships corepack,
+  // the `electronuserland/builder:base` image strips the corepack binary, so
+  // the inner `bash -lc` fails with `corepack: command not found`. We also
+  // can't `corepack enable` ourselves — the container runs as the host's
+  // non-root uid (--user above) and corepack would try to write shims next
+  // to the system Node binary, which is owned by root in this image.
+  //
+  // Use `npx --yes pnpm@<version>` instead: `npx` ships with npm (always
+  // present in the image), `--yes` skips the install confirmation, and the
+  // package gets cached under `$HOME/.npm/_npx`, which is writable by the
+  // unprivileged user. The pinned version matches the `packageManager`
+  // field in the root package.json so reproducibility is preserved.
+  const PNPM_VERSION = "10.33.2";
+  const pnpmCmd = `npx --yes pnpm@${PNPM_VERSION}`;
   const innerArgs = [
-    "corepack pnpm tools-pack linux build",
+    `${pnpmCmd} tools-pack linux build`,
     `--to ${config.to}`,
     `--namespace ${config.namespace}`,
     "--dir /tools-pack",
@@ -111,7 +119,7 @@ export function buildDockerArgs(
   if (config.portable) {
     innerArgs.push("--portable");
   }
-  const innerCommand = "corepack pnpm install --frozen-lockfile && " + innerArgs.join(" ");
+  const innerCommand = `${pnpmCmd} install --frozen-lockfile && ` + innerArgs.join(" ");
 
   return [
     "run",

--- a/tools/pack/tests/linux.test.ts
+++ b/tools/pack/tests/linux.test.ts
@@ -1,3 +1,7 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { describe, expect, it } from "vitest";
 
 import type { ToolPackConfig } from "../src/config.js";
@@ -83,16 +87,33 @@ describe("buildDockerArgs", () => {
   it("re-invokes pnpm tools-pack linux build inside the container without --containerized", () => {
     const args = buildDockerArgs(makeConfig(), { uid: 1000, gid: 1000 });
     const last = args[args.length - 1];
-    expect(last).toMatch(/corepack pnpm install --frozen-lockfile/);
-    expect(last).toMatch(/corepack pnpm tools-pack linux build --to all --namespace default/);
+    expect(last).toMatch(/npx --yes pnpm@\d+\.\d+\.\d+ install --frozen-lockfile/);
+    expect(last).toMatch(/npx --yes pnpm@\d+\.\d+\.\d+ tools-pack linux build --to all --namespace default/);
     expect(last).not.toMatch(/--containerized/);
   });
 
-  it("invokes pnpm via `corepack pnpm` rather than `corepack enable` (non-root container can't write Node shim dir)", () => {
+  it("invokes pnpm via `npx --yes pnpm@<version>` (electronuserland/builder:base strips corepack, and the non-root container can't write Node shim dir)", () => {
     const args = buildDockerArgs(makeConfig(), { uid: 1000, gid: 1000 });
     const last = args[args.length - 1];
-    expect(last).not.toMatch(/corepack enable/);
-    expect(last).toMatch(/corepack pnpm/);
+    expect(last).not.toMatch(/corepack/);
+    expect(last).toMatch(/npx --yes pnpm@/);
+  });
+
+  it("hardcoded pnpm version stays in lockstep with root package.json `packageManager`", () => {
+    // Guard against silent drift: if someone bumps packageManager in the
+    // root package.json but forgets to update PNPM_VERSION in linux.ts,
+    // the Linux container build would silently keep using the old pnpm.
+    const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+    const rootPkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf-8")) as {
+      packageManager?: string;
+    };
+    const match = String(rootPkg.packageManager ?? "").match(/^pnpm@(\d+\.\d+\.\d+)$/);
+    expect(match, `expected root packageManager "pnpm@x.y.z", got ${rootPkg.packageManager}`).not.toBeNull();
+    const expectedVersion = match![1];
+
+    const args = buildDockerArgs(makeConfig(), { uid: 1000, gid: 1000 });
+    const last = args[args.length - 1];
+    expect(last).toContain(`npx --yes pnpm@${expectedVersion}`);
   });
 
   it("forwards --dir /tools-pack so inner build output lands under the mounted host dir", () => {


### PR DESCRIPTION
## Why

0.4.0 release-stable run [25386360556](https://github.com/nexu-io/open-design/actions/runs/25386360556) failed at the new `build_linux` job:

\`\`\`
bash: line 1: corepack: command not found
Error: docker build exited with code 127
\`\`\`

\`tools/pack/src/linux.ts\` invokes \`corepack pnpm ...\` inside the \`electronuserland/builder:base\` container. Although Node 16.10+ ships corepack, this image strips the corepack binary, so \`docker exec\`'s inner \`bash -lc\` fails before pnpm install ever starts. We also can't \`corepack enable\` ourselves — the container runs as the host's non-root uid and corepack would try to write shims next to the root-owned system Node binary.

The Linux build path was added in #369 and worked against an earlier electronuserland image; the corepack stripping appears to be a recent change in that base image.

## What this changes

Swap \`corepack pnpm\` for \`npx --yes pnpm@10.33.2\` in \`buildDockerArgs\` (the only place corepack is invoked inside the container):

\`\`\`diff
- "corepack pnpm tools-pack linux build"
+ \`\${pnpmCmd} tools-pack linux build\`
- "corepack pnpm install --frozen-lockfile && ..."
+ \`\${pnpmCmd} install --frozen-lockfile && ...\`
\`\`\`

Why \`npx --yes pnpm@<version>\`:
- \`npx\` ships with npm and is always present in the base image
- \`--yes\` skips the install confirmation prompt
- packages cache under \`\$HOME/.npm/_npx\`, which is writable by the unprivileged container user (no root required)
- the pinned version matches \`packageManager\` in the root \`package.json\`, preserving reproducibility

Net diff: **+16 / -8 lines** in a single file.

## Local verification

\`\`\`
pnpm install --frozen-lockfile  # ✅
pnpm --filter @open-design/daemon build  # ✅
pnpm --filter @open-design/desktop build  # ✅
pnpm --filter @open-design/web build:sidecar  # ✅
pnpm -r run typecheck  # ✅ exit 0
pnpm guard  # ✅ residual-JS + test-layout
\`\`\`

The actual fix (running pnpm via npx inside the container) can only be exercised by the docker run on a Linux GitHub Actions runner — the next \`release-stable\` dispatch validates it end-to-end. Atomic publish in release-stable.yml means a second failure here still leaves no orphan tag/release behind.

## After merge

Re-dispatch \`release-stable\` with \`mac_signed=true\` to publish 0.4.0. The 0.4.0 \`release: ...\` commit (#454) is already on main — only the workflow needs another run.

## Test plan

- [ ] CI \`Validate workspace\` goes green on this PR
- [ ] After merge, \`release-stable\` dispatch finishes all four build jobs (verify + mac + win + **linux**) and publishes \`open-design-v0.4.0\`