### PR TITLE
fix(tools-pack): fetch pnpm standalone binary in linux container (#558 follow-up)

### DIFF
--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -96,20 +96,45 @@ export function buildDockerArgs(
   // None of these values can contain shell metacharacters, so direct
   // interpolation into the inner command string is safe.
   //
-  // We can't rely on `corepack pnpm` here: although Node 16.10+ ships corepack,
-  // the `electronuserland/builder:base` image strips the corepack binary, so
-  // the inner `bash -lc` fails with `corepack: command not found`. We also
-  // can't `corepack enable` ourselves — the container runs as the host's
-  // non-root uid (--user above) and corepack would try to write shims next
-  // to the system Node binary, which is owned by root in this image.
+  // The `electronuserland/builder:base` image is intentionally minimal: it
+  // ships a Node binary but strips npm, npx, *and* corepack from PATH. So
+  // every "ask the image to invoke pnpm" path fails with `command not found`.
   //
-  // Use `npx --yes pnpm@<version>` instead: `npx` ships with npm (always
-  // present in the image), `--yes` skips the install confirmation, and the
-  // package gets cached under `$HOME/.npm/_npx`, which is writable by the
-  // unprivileged user. The pinned version matches the `packageManager`
-  // field in the root package.json so reproducibility is preserved.
+  // Fix: download the official pnpm `linuxstatic-<arch>` standalone binary
+  // at container start, picking the asset by `uname -m` so the same workflow
+  // works on amd64 (GitHub Actions ubuntu-latest) and arm64 (Apple Silicon
+  // hosts pulling an arm64 builder image). The binary is self-contained
+  // (bundles its own Node runtime), so it doesn't depend on the image's
+  // npm tooling at all. Stage it under `/tmp/pnpm` for this container
+  // invocation, which is writable by the unprivileged container user.
+  // We rely on `curl`, which electron-builder itself uses for downloads and
+  // is consistently present in this image; the shell guard keeps failures
+  // explicit if that image contract changes.
+  //
+  // The pinned version matches the `packageManager` field in the root
+  // package.json so reproducibility is preserved (a guard test in
+  // tools/pack/tests/linux.test.ts asserts the lockstep).
   const PNPM_VERSION = "10.33.2";
-  const pnpmCmd = `npx --yes pnpm@${PNPM_VERSION}`;
+  const pnpmLinuxStaticX64Sha256 = "a47be715939bafa420fbdc5e34f7f9d8292c032402162c89ccb611e944e526d6";
+  const pnpmLinuxStaticArm64Sha256 = "4d402d0ef12cdc4d81ca339904e68638d841f4e27c73e460534d06e6b56048a9";
+  // Pick the right pnpm binary based on the container's CPU. Docker may run
+  // either an amd64 or arm64 `electronuserland/builder:base` (Apple Silicon
+  // hosts pull arm64 by default), so a hardcoded `-x64` asset would fail
+  // with "Exec format error" on ARM. Detect inside the container with
+  // `uname -m` and fall back to a clear error for unsupported arches.
+  const pnpmReleaseUrl = `https://github.com/pnpm/pnpm/releases/download/v${PNPM_VERSION}`;
+  const setupPnpm =
+    `command -v curl >/dev/null || { echo "curl not found in container image" >&2; exit 127; } && ` +
+    `case "$(uname -m)" in ` +
+    `x86_64) PNPM_ASSET=pnpm-linuxstatic-x64; PNPM_SHA256=${pnpmLinuxStaticX64Sha256} ;; ` +
+    `aarch64) PNPM_ASSET=pnpm-linuxstatic-arm64; PNPM_SHA256=${pnpmLinuxStaticArm64Sha256} ;; ` +
+    `*) echo "unsupported container arch: $(uname -m)" >&2; exit 1 ;; ` +
+    `esac && ` +
+    `curl --retry 3 --retry-all-errors --connect-timeout 10 --max-time 60 -fsSL "${pnpmReleaseUrl}/$PNPM_ASSET" -o /tmp/pnpm.tmp && ` +
+    `echo "$PNPM_SHA256  /tmp/pnpm.tmp" | sha256sum -c - && ` +
+    `mv /tmp/pnpm.tmp /tmp/pnpm && ` +
+    `chmod +x /tmp/pnpm`;
+  const pnpmCmd = "/tmp/pnpm";
   const innerArgs = [
     `${pnpmCmd} tools-pack linux build`,
     `--to ${config.to}`,
@@ -119,7 +144,7 @@ export function buildDockerArgs(
   if (config.portable) {
     innerArgs.push("--portable");
   }
-  const innerCommand = `${pnpmCmd} install --frozen-lockfile && ` + innerArgs.join(" ");
+  const innerCommand = `${setupPnpm} && ${pnpmCmd} install --frozen-lockfile && ` + innerArgs.join(" ");
 
   return [
     "run",

--- a/tools/pack/tests/linux.test.ts
+++ b/tools/pack/tests/linux.test.ts
@@ -87,22 +87,58 @@ describe("buildDockerArgs", () => {
   it("re-invokes pnpm tools-pack linux build inside the container without --containerized", () => {
     const args = buildDockerArgs(makeConfig(), { uid: 1000, gid: 1000 });
     const last = args[args.length - 1];
-    expect(last).toMatch(/npx --yes pnpm@\d+\.\d+\.\d+ install --frozen-lockfile/);
-    expect(last).toMatch(/npx --yes pnpm@\d+\.\d+\.\d+ tools-pack linux build --to all --namespace default/);
+    expect(last).toMatch(/command -v curl >\/dev\/null/);
+    expect(last).toMatch(/case "\$\(uname -m\)" in/);
+    expect(last).toMatch(/x86_64\) PNPM_ASSET=pnpm-linuxstatic-x64; PNPM_SHA256=[a-f0-9]{64}/);
+    expect(last).toMatch(/aarch64\) PNPM_ASSET=pnpm-linuxstatic-arm64; PNPM_SHA256=[a-f0-9]{64}/);
+    expect(last).toMatch(
+      /curl --retry 3 --retry-all-errors --connect-timeout 10 --max-time 60 -fsSL "https:\/\/github\.com\/pnpm\/pnpm\/releases\/download\/v\d+\.\d+\.\d+\/\$PNPM_ASSET" -o \/tmp\/pnpm\.tmp/,
+    );
+    expect(last).toMatch(/echo "\$PNPM_SHA256  \/tmp\/pnpm\.tmp" \| sha256sum -c -/);
+    expect(last).toMatch(/mv \/tmp\/pnpm\.tmp \/tmp\/pnpm/);
+    expect(last).toMatch(/chmod \+x \/tmp\/pnpm/);
+    expect(last).toMatch(/\/tmp\/pnpm install --frozen-lockfile/);
+    expect(last).toMatch(/\/tmp\/pnpm tools-pack linux build --to all --namespace default/);
     expect(last).not.toMatch(/--containerized/);
   });
 
-  it("invokes pnpm via `npx --yes pnpm@<version>` (electronuserland/builder:base strips corepack, and the non-root container can't write Node shim dir)", () => {
+  it("fetches pnpm standalone binary instead of relying on image npm tooling (electronuserland/builder:base ships a minimal Node without npm/npx/corepack)", () => {
     const args = buildDockerArgs(makeConfig(), { uid: 1000, gid: 1000 });
     const last = args[args.length - 1];
     expect(last).not.toMatch(/corepack/);
-    expect(last).toMatch(/npx --yes pnpm@/);
+    expect(last).not.toMatch(/\bnpx\b/);
+    expect(last).not.toMatch(/(^|[;&|]\s*)npm(\s|$)/);
+    expect(last).toMatch(/pnpm-linuxstatic-x64/);
+    expect(last).toMatch(/pnpm-linuxstatic-arm64/);
+  });
+
+  it("picks the pnpm asset by container CPU so amd64 and arm64 hosts both work", () => {
+    // Hardcoding `pnpm-linuxstatic-x64` would `Exec format error` on ARM64
+    // hosts (e.g. Apple Silicon developers running `tools-pack linux build
+    // --containerized` locally, where Docker pulls an arm64 builder image
+    // by default). Detect inside the container with `uname -m`.
+    const args = buildDockerArgs(makeConfig(), { uid: 1000, gid: 1000 });
+    const last = args[args.length - 1];
+    expect(last).toContain('case "$(uname -m)" in');
+    expect(last).toContain("x86_64) PNPM_ASSET=pnpm-linuxstatic-x64");
+    expect(last).toContain("aarch64) PNPM_ASSET=pnpm-linuxstatic-arm64");
+    expect(last).toMatch(/unsupported container arch/);
+  });
+
+  it("verifies the downloaded standalone pnpm binary before executing it", () => {
+    const args = buildDockerArgs(makeConfig(), { uid: 1000, gid: 1000 });
+    const last = args[args.length - 1];
+    expect(last).toMatch(/PNPM_SHA256=[a-f0-9]{64}/);
+    expect(last).toMatch(/sha256sum -c -/);
+    expect(last).toMatch(/\/tmp\/pnpm\.tmp/);
+    expect(last.indexOf("sha256sum -c -")).toBeLessThan(last.indexOf("mv /tmp/pnpm.tmp /tmp/pnpm"));
+    expect(last.indexOf("mv /tmp/pnpm.tmp /tmp/pnpm")).toBeLessThan(last.indexOf("chmod +x /tmp/pnpm"));
   });
 
   it("hardcoded pnpm version stays in lockstep with root package.json `packageManager`", () => {
     // Guard against silent drift: if someone bumps packageManager in the
     // root package.json but forgets to update PNPM_VERSION in linux.ts,
-    // the Linux container build would silently keep using the old pnpm.
+    // the Linux container build would silently keep downloading the old pnpm.
     const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
     const rootPkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf-8")) as {
       packageManager?: string;
@@ -113,7 +149,7 @@ describe("buildDockerArgs", () => {
 
     const args = buildDockerArgs(makeConfig(), { uid: 1000, gid: 1000 });
     const last = args[args.length - 1];
-    expect(last).toContain(`npx --yes pnpm@${expectedVersion}`);
+    expect(last).toContain(`pnpm/releases/download/v${expectedVersion}/$PNPM_ASSET`);
   });
 
   it("forwards --dir /tools-pack so inner build output lands under the mounted host dir", () => {


### PR DESCRIPTION
## Why

Follow-up to #558. After replacing \`corepack pnpm\` with \`npx --yes pnpm@<version>\`, the next release-stable dispatch ([25387708738](https://github.com/nexu-io/open-design/actions/runs/25387708738)) revealed:

\`\`\`
bash: line 1: npx: command not found
Error: docker build exited with code 127
\`\`\`

\`electronuserland/builder:base\` is even more minimal than expected — it ships a Node binary but strips **npm, npx, AND corepack** from PATH. Every "ask the image to invoke pnpm" path fails the same way.

## What this changes

Skip the image's npm tooling entirely. Download the official **pnpm-linuxstatic-x64** standalone binary at container start:

- Self-contained: bundles its own Node runtime, doesn't depend on anything in the image
- Writes to \`/tmp/pnpm\` (tmpfs, writable by the unprivileged container user)
- Pinned version matches root \`packageManager\` (guard test enforces lockstep)

\`\`\`diff
- const pnpmCmd = \`npx --yes pnpm@\${PNPM_VERSION}\`;
- const innerCommand = \`\${pnpmCmd} install --frozen-lockfile && \` + innerArgs.join(" ");
+ const pnpmDownloadUrl = \`https://github.com/pnpm/pnpm/releases/download/v\${PNPM_VERSION}/pnpm-linuxstatic-x64\`;
+ const setupPnpm = \`curl -fsSL "\${pnpmDownloadUrl}" -o /tmp/pnpm && chmod +x /tmp/pnpm\`;
+ const pnpmCmd = "/tmp/pnpm";
+ const innerCommand = \`\${setupPnpm} && \${pnpmCmd} install --frozen-lockfile && \` + innerArgs.join(" ");
\`\`\`

Inner command shape inside the container:
\`\`\`
curl -fsSL https://github.com/pnpm/pnpm/releases/download/v10.33.2/pnpm-linuxstatic-x64 -o /tmp/pnpm \\
  && chmod +x /tmp/pnpm \\
  && /tmp/pnpm install --frozen-lockfile \\
  && /tmp/pnpm tools-pack linux build --to all --namespace ... --dir /tools-pack
\`\`\`

\`curl\` is one of the few tooling utilities consistently present in \`electronuserland/builder:base\` (used by electron-builder itself for downloads).

## Tests updated

\`tools/pack/tests/linux.test.ts\`:
- "re-invokes pnpm tools-pack linux build" — assert curl + chmod + /tmp/pnpm
- "fetches pnpm standalone binary instead of npm tooling" — assert no \`corepack\`, \`npx\`, or \`npm \` appears in the inner command (sentinel for image regressions)
- "PNPM_VERSION lockstep with root packageManager" — guard test asserts the download URL embeds the same version as \`packageManager\` in the root \`package.json\`

Local: \`pnpm --filter @open-design/tools-pack run test\` → 25 passed.

## After merge

Re-dispatch \`release-stable\` with \`mac_signed=true\`. The 0.4.0 release commit (#454) is already on main; only the workflow needs another run. Atomic publish guarantees no orphan tag/release if Linux still misbehaves.

## Test plan

- [ ] CI \`Validate workspace\` goes green
- [ ] After merge, \`release-stable\` dispatch finishes all four build jobs (verify + mac + win + **linux**) and publishes \`open-design-v0.4.0\`