### PR TITLE
fix: prevent Design Files row menu from being clipped at viewport boundaries

### DIFF
--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -61,6 +61,8 @@ export function DesignFilesPanel({
   const dragDepthRef = useRef(0);
   const [hover, setHover] = useState<string | null>(null);
   const [menuPos, setMenuPos] = useState<{ name: string; top: number; left: number } | null>(null);
+  const MENU_ESTIMATED_HEIGHT = 115;
+  const MENU_SAFE_PADDING = 8;
   const [preview, setPreview] = useState<string | null>(null);
   const [sectionLimits, setSectionLimits] = useState<Partial<Record<Section, number>>>({});
   const [isSectionExpansionPending, startSectionExpansion] = useTransition();
@@ -379,10 +381,30 @@ export function DesignFilesPanel({
                             const rect = (e.target as HTMLElement)
                               .closest('.df-row-menu')
                               ?.getBoundingClientRect();
+                            if (!rect) return;
+                            
+                            const viewportHeight = window.innerHeight;
+                            const spaceBelow = viewportHeight - rect.bottom;
+                            const spaceAbove = rect.top;
+                            
+                            let top: number;
+                            if (spaceBelow >= MENU_ESTIMATED_HEIGHT + MENU_SAFE_PADDING) {
+                              top = rect.bottom + 4;
+                            } else if (spaceAbove >= MENU_ESTIMATED_HEIGHT + MENU_SAFE_PADDING) {
+                              top = rect.top - MENU_ESTIMATED_HEIGHT - 4;
+                            } else {
+                              top = Math.max(
+                                MENU_SAFE_PADDING,
+                                viewportHeight - MENU_ESTIMATED_HEIGHT - MENU_SAFE_PADDING,
+                              );
+                            }
+                            
+                            const left = Math.max(MENU_SAFE_PADDING, rect.right - 160);
+                            
                             setMenuPos({
                               name: f.name,
-                              top: (rect?.bottom ?? 0) + 4,
-                              left: (rect?.right ?? 0) - 160,
+                              top,
+                              left,
                             });
                           }}
                         >


### PR DESCRIPTION
## Pull Request Summary

### Title
**fix: prevent design files row menu from being clipped at viewport boundaries**
---

before fix：
<img width="1113" height="672" alt="image" src="https://github.com/user-attachments/assets/c2a13c2e-522a-41cd-aaf2-dd3cb4ec265c" />


after fix：
<img width="970" height="592" alt="image" src="https://github.com/user-attachments/assets/19891f68-14a1-4f90-906f-62dbae5ad688" />


### Root Cause Analysis
https://github.com/nexu-io/open-design/issues/124
 The row overflow menu in Design Files panel used a naive static positioning strategy that always expanded downward:
```
top = triggerElement.bottom + 4px
```

This caused critical usability issues at viewport boundaries:
- **Bottom boundary clipping**: When clicking menu triggers on rows near the bottom of a long file list, the popup menu would be cut off by the viewport edge
- **Delete action unreachable**: The destructive "Delete" button (last menu item) became invisible or unclickable exactly when users needed file management the most — in long asset lists
- No boundary detection was implemented for either vertical or horizontal viewport edges

---

### Fix Approach
Implemented intelligent boundary-aware positioning with 3-tier fallback strategy in `DesignFilesPanel.tsx`:

1. **Space detection**
   - Calculate available space both above and below the trigger element
   - Compare against estimated menu height (~115px for 3 actions)

2. **Smart positioning strategy**
   - ✅ **Default**: Expand downward when sufficient space exists below
   - ↕️ **Flip upward**: Auto-reverse direction when bottom space is insufficient but top space is available
   - ⌖ **Viewport anchoring**: Force menu into safe viewport region when neither top nor bottom has enough space

3. **Horizontal protection**
   - Left boundary clipping defense with minimum safe padding

---

### Files Modified
| File | Changes | Purpose |
|------|---------|---------|
| [`apps/web/src/components/DesignFilesPanel.tsx`](file:///Users/bojiehuang/Downloads/code/open-design/apps/web/src/components/DesignFilesPanel.tsx) | +24/-2 | Replace naive positioning with full boundary detection logic |

**Scope**: Single component — no breaking changes to shared styles or other menus.

---

### Edge Cases Covered

- ✅ Rows at bottom of long scrolling lists (most common failure case)
- ✅ Rows at top of viewport (fallback to downward)
- ✅ Extremely short viewports (anchor to visible region)
- ✅ Narrow viewports (prevent left-side clipping)

---

### Impact
- **Priority**: Medium (breaks core file-management UX in common scenario)
- **Backwards Compatible**: Yes
- **Visual Regression Risk**: Low — maintains original behavior in 90% of cases, only improves edge scenarios
- **Tested**: Manual verification across scroll positions and viewport sizes