### PR TITLE
feat: add resizable chat panel

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -242,7 +242,12 @@ export function ProjectView({
   const preferredChatPanelWidthRef = useRef(chatPanelWidth);
   const resizeStartPreferredWidthRef = useRef(chatPanelWidth);
   const chatPanelMaxWidthRef = useRef(chatPanelMaxWidth);
-  const resizeStateRef = useRef<{ rect: DOMRect; isRtl: boolean } | null>(null);
+  const resizeStateRef = useRef<{
+    startClientX: number;
+    startWidth: number;
+    isRtl: boolean;
+    hasMoved: boolean;
+  } | null>(null);
   const pointerCleanupRef = useRef<(() => void) | null>(null);
   const pointerFrameRef = useRef<number | null>(null);
   const pendingPointerClientXRef = useRef<number | null>(null);
@@ -1481,6 +1486,7 @@ export function ProjectView({
     () => skills.find((s) => s.id === project.skillId)?.mode === 'deck',
     [skills, project.skillId],
   );
+  const chatResizeLabel = t('project.resizeChatPanel');
 
   const renderPreferredChatPanelWidth = useCallback((
     preferredWidth: number,
@@ -1558,9 +1564,10 @@ export function ProjectView({
     const updateWidthFromClientX = (clientX: number) => {
       const state = resizeStateRef.current;
       if (!state) return;
-      const rawWidth = state.isRtl
-        ? state.rect.right - clientX
-        : clientX - state.rect.left;
+      const delta = clientX - state.startClientX;
+      if (delta === 0 && !state.hasMoved) return;
+      state.hasMoved = true;
+      const rawWidth = state.startWidth + (state.isRtl ? -delta : delta);
       applyChatPanelWidth(rawWidth);
     };
 
@@ -1575,10 +1582,11 @@ export function ProjectView({
     };
 
     resizeStateRef.current = {
-      rect: split.getBoundingClientRect(),
+      startClientX: event.clientX,
+      startWidth: chatPanelWidthRef.current,
       isRtl: window.getComputedStyle(split).direction === 'rtl',
+      hasMoved: false,
     };
-    updateWidthFromClientX(event.clientX);
 
     const handlePointerMove = (moveEvent: PointerEvent) => {
       pendingPointerClientXRef.current = moveEvent.clientX;
@@ -1751,12 +1759,12 @@ export function ProjectView({
           className="split-resize-handle"
           role="separator"
           aria-orientation="vertical"
-          aria-label="Resize chat panel"
+          aria-label={chatResizeLabel}
           aria-valuemin={MIN_CHAT_PANEL_WIDTH}
           aria-valuemax={chatPanelMaxWidth}
           aria-valuenow={chatPanelWidth}
           tabIndex={0}
-          title="Resize chat panel"
+          title={chatResizeLabel}
           onPointerDown={handleChatResizePointerDown}
           onKeyDown={handleChatResizeKeyDown}
           onBlur={handleChatResizeBlur}

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -121,22 +121,29 @@ const MAX_CHAT_PANEL_WIDTH = 720;
 const MIN_WORKSPACE_PANEL_WIDTH = 400;
 const SPLIT_RESIZE_HANDLE_WIDTH = 8;
 const CHAT_PANEL_KEYBOARD_STEP = 16;
+const MIN_NORMAL_SPLIT_WIDTH =
+  MIN_CHAT_PANEL_WIDTH + SPLIT_RESIZE_HANDLE_WIDTH + MIN_WORKSPACE_PANEL_WIDTH;
+
+function workspacePanelMinWidthForSplit(splitWidth: number): number {
+  if (!Number.isFinite(splitWidth) || splitWidth <= 0) return MIN_WORKSPACE_PANEL_WIDTH;
+  return splitWidth < MIN_NORMAL_SPLIT_WIDTH ? 0 : MIN_WORKSPACE_PANEL_WIDTH;
+}
 
 function maxChatPanelWidthForSplit(splitWidth: number): number {
   if (!Number.isFinite(splitWidth) || splitWidth <= 0) return MAX_CHAT_PANEL_WIDTH;
-  const viewportAwareMax = splitWidth - SPLIT_RESIZE_HANDLE_WIDTH - MIN_WORKSPACE_PANEL_WIDTH;
-  return Math.max(
-    MIN_CHAT_PANEL_WIDTH,
-    Math.min(MAX_CHAT_PANEL_WIDTH, Math.floor(viewportAwareMax)),
-  );
+  const workspaceMinWidth = workspacePanelMinWidthForSplit(splitWidth);
+  const viewportAwareMax = splitWidth - SPLIT_RESIZE_HANDLE_WIDTH - workspaceMinWidth;
+  return Math.max(0, Math.min(MAX_CHAT_PANEL_WIDTH, Math.floor(viewportAwareMax)));
+}
+
+function clampPreferredChatPanelWidth(width: number): number {
+  return Math.min(MAX_CHAT_PANEL_WIDTH, Math.max(MIN_CHAT_PANEL_WIDTH, Math.round(width)));
 }
 
 function clampChatPanelWidth(width: number, maxWidth = MAX_CHAT_PANEL_WIDTH): number {
-  const effectiveMax = Math.max(
-    MIN_CHAT_PANEL_WIDTH,
-    Math.min(MAX_CHAT_PANEL_WIDTH, Math.floor(maxWidth)),
-  );
-  return Math.min(effectiveMax, Math.max(MIN_CHAT_PANEL_WIDTH, Math.round(width)));
+  const effectiveMax = Math.max(0, Math.min(MAX_CHAT_PANEL_WIDTH, Math.floor(maxWidth)));
+  const effectiveMin = Math.min(MIN_CHAT_PANEL_WIDTH, effectiveMax);
+  return Math.min(effectiveMax, Math.max(effectiveMin, Math.round(width)));
 }
 
 function readSavedChatPanelWidth(): number {
@@ -145,7 +152,7 @@ function readSavedChatPanelWidth(): number {
     const raw = window.localStorage.getItem(CHAT_PANEL_WIDTH_STORAGE_KEY);
     const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
     return Number.isFinite(parsed)
-      ? clampChatPanelWidth(parsed, MAX_CHAT_PANEL_WIDTH)
+      ? clampPreferredChatPanelWidth(parsed)
       : DEFAULT_CHAT_PANEL_WIDTH;
   } catch {
     return DEFAULT_CHAT_PANEL_WIDTH;
@@ -157,7 +164,7 @@ function saveChatPanelWidth(width: number): void {
   try {
     window.localStorage.setItem(
       CHAT_PANEL_WIDTH_STORAGE_KEY,
-      String(clampChatPanelWidth(width, MAX_CHAT_PANEL_WIDTH)),
+      String(clampPreferredChatPanelWidth(width)),
     );
   } catch {
     // localStorage can be unavailable in hardened browser contexts.
@@ -236,6 +243,7 @@ export function ProjectView({
   const [liveArtifactEvents, setLiveArtifactEvents] = useState<LiveArtifactEventItem[]>([]);
   const [chatPanelWidth, setChatPanelWidth] = useState(readSavedChatPanelWidth);
   const [chatPanelMaxWidth, setChatPanelMaxWidth] = useState(MAX_CHAT_PANEL_WIDTH);
+  const [workspacePanelMinWidth, setWorkspacePanelMinWidth] = useState(MIN_WORKSPACE_PANEL_WIDTH);
   const [resizingChatPanel, setResizingChatPanel] = useState(false);
   const splitRef = useRef<HTMLDivElement | null>(null);
   const chatPanelWidthRef = useRef(chatPanelWidth);
@@ -1487,6 +1495,11 @@ export function ProjectView({
     [skills, project.skillId],
   );
   const chatResizeLabel = t('project.resizeChatPanel');
+  const workspacePanelTrack =
+    workspacePanelMinWidth === 0
+      ? 'minmax(0, 1fr)'
+      : `minmax(${workspacePanelMinWidth}px, 1fr)`;
+  const chatPanelAriaMinWidth = Math.min(MIN_CHAT_PANEL_WIDTH, chatPanelMaxWidth);
 
   const renderPreferredChatPanelWidth = useCallback((
     preferredWidth: number,
@@ -1499,7 +1512,9 @@ export function ProjectView({
   }, []);
 
   const applyChatPanelWidth = useCallback((width: number): number => {
-    const nextPreferred = clampChatPanelWidth(width, chatPanelMaxWidthRef.current);
+    const nextPreferred = clampPreferredChatPanelWidth(
+      clampChatPanelWidth(width, chatPanelMaxWidthRef.current),
+    );
     preferredChatPanelWidthRef.current = nextPreferred;
     return renderPreferredChatPanelWidth(nextPreferred);
   }, [renderPreferredChatPanelWidth]);
@@ -1530,8 +1545,11 @@ export function ProjectView({
     if (!split) return undefined;
 
     const updateAllowedWidth = () => {
-      const nextMax = maxChatPanelWidthForSplit(split.clientWidth);
+      const splitWidth = split.clientWidth;
+      const nextWorkspaceMin = workspacePanelMinWidthForSplit(splitWidth);
+      const nextMax = maxChatPanelWidthForSplit(splitWidth);
       chatPanelMaxWidthRef.current = nextMax;
+      setWorkspacePanelMinWidth(nextWorkspaceMin);
       setChatPanelMaxWidth(nextMax);
       renderPreferredChatPanelWidth(preferredChatPanelWidthRef.current, nextMax);
     };
@@ -1711,7 +1729,7 @@ export function ProjectView({
         className={`split${resizingChatPanel ? ' is-resizing-chat' : ''}`}
         style={{
           gridTemplateColumns:
-            `${chatPanelWidth}px ${SPLIT_RESIZE_HANDLE_WIDTH}px minmax(${MIN_WORKSPACE_PANEL_WIDTH}px, 1fr)`,
+            `${chatPanelWidth}px ${SPLIT_RESIZE_HANDLE_WIDTH}px ${workspacePanelTrack}`,
         }}
       >
         <ChatPane
@@ -1760,7 +1778,7 @@ export function ProjectView({
           role="separator"
           aria-orientation="vertical"
           aria-label={chatResizeLabel}
-          aria-valuemin={MIN_CHAT_PANEL_WIDTH}
+          aria-valuemin={chatPanelAriaMinWidth}
           aria-valuemax={chatPanelMaxWidth}
           aria-valuenow={chatPanelWidth}
           tabIndex={0}

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -239,8 +239,9 @@ export function ProjectView({
   const [resizingChatPanel, setResizingChatPanel] = useState(false);
   const splitRef = useRef<HTMLDivElement | null>(null);
   const chatPanelWidthRef = useRef(chatPanelWidth);
+  const preferredChatPanelWidthRef = useRef(chatPanelWidth);
+  const resizeStartPreferredWidthRef = useRef(chatPanelWidth);
   const chatPanelMaxWidthRef = useRef(chatPanelMaxWidth);
-  const resizeFinalWidthRef = useRef(chatPanelWidth);
   const resizeStateRef = useRef<{ rect: DOMRect; isRtl: boolean } | null>(null);
   const pointerCleanupRef = useRef<(() => void) | null>(null);
   const pointerFrameRef = useRef<number | null>(null);
@@ -1481,13 +1482,21 @@ export function ProjectView({
     [skills, project.skillId],
   );
 
-  const applyChatPanelWidth = useCallback((width: number): number => {
-    const next = clampChatPanelWidth(width, chatPanelMaxWidthRef.current);
+  const renderPreferredChatPanelWidth = useCallback((
+    preferredWidth: number,
+    maxWidth = chatPanelMaxWidthRef.current,
+  ): number => {
+    const next = clampChatPanelWidth(preferredWidth, maxWidth);
     chatPanelWidthRef.current = next;
-    resizeFinalWidthRef.current = next;
     setChatPanelWidth(next);
     return next;
   }, []);
+
+  const applyChatPanelWidth = useCallback((width: number): number => {
+    const nextPreferred = clampChatPanelWidth(width, chatPanelMaxWidthRef.current);
+    preferredChatPanelWidthRef.current = nextPreferred;
+    return renderPreferredChatPanelWidth(nextPreferred);
+  }, [renderPreferredChatPanelWidth]);
 
   const finishChatPanelResize = useCallback((saveFinalWidth = true) => {
     pointerCleanupRef.current?.();
@@ -1499,12 +1508,11 @@ export function ProjectView({
     pendingPointerClientXRef.current = null;
     resizeStateRef.current = null;
     setResizingChatPanel(false);
-    if (saveFinalWidth) saveChatPanelWidth(resizeFinalWidthRef.current);
+    if (saveFinalWidth) saveChatPanelWidth(preferredChatPanelWidthRef.current);
   }, []);
 
   useEffect(() => {
     chatPanelWidthRef.current = chatPanelWidth;
-    resizeFinalWidthRef.current = chatPanelWidth;
   }, [chatPanelWidth]);
 
   useEffect(() => {
@@ -1519,14 +1527,7 @@ export function ProjectView({
       const nextMax = maxChatPanelWidthForSplit(split.clientWidth);
       chatPanelMaxWidthRef.current = nextMax;
       setChatPanelMaxWidth(nextMax);
-      const currentWidth = chatPanelWidthRef.current;
-      const next = clampChatPanelWidth(currentWidth, nextMax);
-      if (next !== currentWidth) {
-        chatPanelWidthRef.current = next;
-        resizeFinalWidthRef.current = next;
-        setChatPanelWidth(next);
-        saveChatPanelWidth(next);
-      }
+      renderPreferredChatPanelWidth(preferredChatPanelWidthRef.current, nextMax);
     };
 
     updateAllowedWidth();
@@ -1539,9 +1540,9 @@ export function ProjectView({
 
     window.addEventListener('resize', updateAllowedWidth);
     return () => window.removeEventListener('resize', updateAllowedWidth);
-  }, []);
+  }, [renderPreferredChatPanelWidth]);
 
-  useEffect(() => () => finishChatPanelResize(true), [finishChatPanelResize]);
+  useEffect(() => () => finishChatPanelResize(false), [finishChatPanelResize]);
 
   const handleChatResizePointerDown = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
     if (event.button !== 0) return;
@@ -1552,6 +1553,7 @@ export function ProjectView({
     event.currentTarget.setPointerCapture(event.pointerId);
     pointerCleanupRef.current?.();
     setResizingChatPanel(true);
+    resizeStartPreferredWidthRef.current = preferredChatPanelWidthRef.current;
 
     const updateWidthFromClientX = (clientX: number) => {
       const state = resizeStateRef.current;
@@ -1590,23 +1592,32 @@ export function ProjectView({
       flushPendingPointerMove();
       finishChatPanelResize(true);
     };
+    const handlePointerCancel = () => {
+      flushPendingPointerMove();
+      preferredChatPanelWidthRef.current = resizeStartPreferredWidthRef.current;
+      renderPreferredChatPanelWidth(resizeStartPreferredWidthRef.current);
+      finishChatPanelResize(false);
+    };
     const cleanup = () => {
       window.removeEventListener('pointermove', handlePointerMove);
       window.removeEventListener('pointerup', handlePointerEnd);
-      window.removeEventListener('pointercancel', handlePointerEnd);
-      window.removeEventListener('blur', handlePointerEnd);
+      window.removeEventListener('pointercancel', handlePointerCancel);
+      window.removeEventListener('blur', handlePointerCancel);
     };
 
     pointerCleanupRef.current = cleanup;
     window.addEventListener('pointermove', handlePointerMove);
     window.addEventListener('pointerup', handlePointerEnd);
-    window.addEventListener('pointercancel', handlePointerEnd);
-    window.addEventListener('blur', handlePointerEnd);
-  }, [applyChatPanelWidth, finishChatPanelResize]);
+    window.addEventListener('pointercancel', handlePointerCancel);
+    window.addEventListener('blur', handlePointerCancel);
+  }, [applyChatPanelWidth, finishChatPanelResize, renderPreferredChatPanelWidth]);
 
   const handleChatResizeBlur = useCallback(() => {
-    if (pointerCleanupRef.current) finishChatPanelResize(true);
-  }, [finishChatPanelResize]);
+    if (!pointerCleanupRef.current) return;
+    preferredChatPanelWidthRef.current = resizeStartPreferredWidthRef.current;
+    renderPreferredChatPanelWidth(resizeStartPreferredWidthRef.current);
+    finishChatPanelResize(false);
+  }, [finishChatPanelResize, renderPreferredChatPanelWidth]);
 
   const handleChatResizeKeyDown = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
     let nextWidth: number | null = null;

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -4,6 +4,8 @@ import {
   useMemo,
   useRef,
   useState,
+  useLayoutEffect,
+  type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
 } from 'react';
 import { createHtmlArtifactManifest, inferLegacyManifest } from '../artifacts/manifest';
@@ -116,9 +118,25 @@ const CHAT_PANEL_WIDTH_STORAGE_KEY = 'open-design.project.chatPanelWidth';
 const DEFAULT_CHAT_PANEL_WIDTH = 460;
 const MIN_CHAT_PANEL_WIDTH = 320;
 const MAX_CHAT_PANEL_WIDTH = 720;
+const MIN_WORKSPACE_PANEL_WIDTH = 400;
+const SPLIT_RESIZE_HANDLE_WIDTH = 8;
+const CHAT_PANEL_KEYBOARD_STEP = 16;
 
-function clampChatPanelWidth(width: number): number {
-  return Math.min(MAX_CHAT_PANEL_WIDTH, Math.max(MIN_CHAT_PANEL_WIDTH, Math.round(width)));
+function maxChatPanelWidthForSplit(splitWidth: number): number {
+  if (!Number.isFinite(splitWidth) || splitWidth <= 0) return MAX_CHAT_PANEL_WIDTH;
+  const viewportAwareMax = splitWidth - SPLIT_RESIZE_HANDLE_WIDTH - MIN_WORKSPACE_PANEL_WIDTH;
+  return Math.max(
+    MIN_CHAT_PANEL_WIDTH,
+    Math.min(MAX_CHAT_PANEL_WIDTH, Math.floor(viewportAwareMax)),
+  );
+}
+
+function clampChatPanelWidth(width: number, maxWidth = MAX_CHAT_PANEL_WIDTH): number {
+  const effectiveMax = Math.max(
+    MIN_CHAT_PANEL_WIDTH,
+    Math.min(MAX_CHAT_PANEL_WIDTH, Math.floor(maxWidth)),
+  );
+  return Math.min(effectiveMax, Math.max(MIN_CHAT_PANEL_WIDTH, Math.round(width)));
 }
 
 function readSavedChatPanelWidth(): number {
@@ -127,7 +145,7 @@ function readSavedChatPanelWidth(): number {
     const raw = window.localStorage.getItem(CHAT_PANEL_WIDTH_STORAGE_KEY);
     const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
     return Number.isFinite(parsed)
-      ? clampChatPanelWidth(parsed)
+      ? clampChatPanelWidth(parsed, MAX_CHAT_PANEL_WIDTH)
       : DEFAULT_CHAT_PANEL_WIDTH;
   } catch {
     return DEFAULT_CHAT_PANEL_WIDTH;
@@ -139,7 +157,7 @@ function saveChatPanelWidth(width: number): void {
   try {
     window.localStorage.setItem(
       CHAT_PANEL_WIDTH_STORAGE_KEY,
-      String(clampChatPanelWidth(width)),
+      String(clampChatPanelWidth(width, MAX_CHAT_PANEL_WIDTH)),
     );
   } catch {
     // localStorage can be unavailable in hardened browser contexts.
@@ -217,8 +235,16 @@ export function ProjectView({
   const [liveArtifacts, setLiveArtifacts] = useState<LiveArtifactSummary[]>([]);
   const [liveArtifactEvents, setLiveArtifactEvents] = useState<LiveArtifactEventItem[]>([]);
   const [chatPanelWidth, setChatPanelWidth] = useState(readSavedChatPanelWidth);
+  const [chatPanelMaxWidth, setChatPanelMaxWidth] = useState(MAX_CHAT_PANEL_WIDTH);
   const [resizingChatPanel, setResizingChatPanel] = useState(false);
   const splitRef = useRef<HTMLDivElement | null>(null);
+  const chatPanelWidthRef = useRef(chatPanelWidth);
+  const chatPanelMaxWidthRef = useRef(chatPanelMaxWidth);
+  const resizeFinalWidthRef = useRef(chatPanelWidth);
+  const resizeStateRef = useRef<{ rect: DOMRect; isRtl: boolean } | null>(null);
+  const pointerCleanupRef = useRef<(() => void) | null>(null);
+  const pointerFrameRef = useRef<number | null>(null);
+  const pendingPointerClientXRef = useRef<number | null>(null);
   // The persisted set of open tabs + active tab. Persisted via PUT on every
   // change; loaded once when the project mounts.
   const [openTabsState, setOpenTabsState] = useState<OpenTabsState>({
@@ -1455,37 +1481,149 @@ export function ProjectView({
     [skills, project.skillId],
   );
 
+  const applyChatPanelWidth = useCallback((width: number): number => {
+    const next = clampChatPanelWidth(width, chatPanelMaxWidthRef.current);
+    chatPanelWidthRef.current = next;
+    resizeFinalWidthRef.current = next;
+    setChatPanelWidth(next);
+    return next;
+  }, []);
+
+  const finishChatPanelResize = useCallback((saveFinalWidth = true) => {
+    pointerCleanupRef.current?.();
+    pointerCleanupRef.current = null;
+    if (pointerFrameRef.current !== null) {
+      cancelAnimationFrame(pointerFrameRef.current);
+      pointerFrameRef.current = null;
+    }
+    pendingPointerClientXRef.current = null;
+    resizeStateRef.current = null;
+    setResizingChatPanel(false);
+    if (saveFinalWidth) saveChatPanelWidth(resizeFinalWidthRef.current);
+  }, []);
+
+  useEffect(() => {
+    chatPanelWidthRef.current = chatPanelWidth;
+    resizeFinalWidthRef.current = chatPanelWidth;
+  }, [chatPanelWidth]);
+
+  useEffect(() => {
+    chatPanelMaxWidthRef.current = chatPanelMaxWidth;
+  }, [chatPanelMaxWidth]);
+
+  useLayoutEffect(() => {
+    const split = splitRef.current;
+    if (!split) return undefined;
+
+    const updateAllowedWidth = () => {
+      const nextMax = maxChatPanelWidthForSplit(split.clientWidth);
+      chatPanelMaxWidthRef.current = nextMax;
+      setChatPanelMaxWidth(nextMax);
+      const currentWidth = chatPanelWidthRef.current;
+      const next = clampChatPanelWidth(currentWidth, nextMax);
+      if (next !== currentWidth) {
+        chatPanelWidthRef.current = next;
+        resizeFinalWidthRef.current = next;
+        setChatPanelWidth(next);
+        saveChatPanelWidth(next);
+      }
+    };
+
+    updateAllowedWidth();
+
+    if (typeof ResizeObserver !== 'undefined') {
+      const observer = new ResizeObserver(updateAllowedWidth);
+      observer.observe(split);
+      return () => observer.disconnect();
+    }
+
+    window.addEventListener('resize', updateAllowedWidth);
+    return () => window.removeEventListener('resize', updateAllowedWidth);
+  }, []);
+
+  useEffect(() => () => finishChatPanelResize(true), [finishChatPanelResize]);
+
   const handleChatResizePointerDown = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
     if (event.button !== 0) return;
     const split = splitRef.current;
     if (!split) return;
     event.preventDefault();
+    event.currentTarget.focus();
     event.currentTarget.setPointerCapture(event.pointerId);
+    pointerCleanupRef.current?.();
     setResizingChatPanel(true);
 
-    const splitLeft = split.getBoundingClientRect().left;
-    let finalWidth = chatPanelWidth;
-    const updateWidth = (clientX: number) => {
-      finalWidth = clampChatPanelWidth(clientX - splitLeft);
-      setChatPanelWidth(finalWidth);
+    const updateWidthFromClientX = (clientX: number) => {
+      const state = resizeStateRef.current;
+      if (!state) return;
+      const rawWidth = state.isRtl
+        ? state.rect.right - clientX
+        : clientX - state.rect.left;
+      applyChatPanelWidth(rawWidth);
     };
-    updateWidth(event.clientX);
+
+    const flushPendingPointerMove = () => {
+      if (pointerFrameRef.current !== null) {
+        cancelAnimationFrame(pointerFrameRef.current);
+        pointerFrameRef.current = null;
+      }
+      const clientX = pendingPointerClientXRef.current;
+      pendingPointerClientXRef.current = null;
+      if (clientX !== null) updateWidthFromClientX(clientX);
+    };
+
+    resizeStateRef.current = {
+      rect: split.getBoundingClientRect(),
+      isRtl: window.getComputedStyle(split).direction === 'rtl',
+    };
+    updateWidthFromClientX(event.clientX);
 
     const handlePointerMove = (moveEvent: PointerEvent) => {
-      updateWidth(moveEvent.clientX);
+      pendingPointerClientXRef.current = moveEvent.clientX;
+      if (pointerFrameRef.current !== null) return;
+      pointerFrameRef.current = requestAnimationFrame(() => {
+        pointerFrameRef.current = null;
+        flushPendingPointerMove();
+      });
     };
-    const handlePointerUp = () => {
+    const handlePointerEnd = () => {
+      flushPendingPointerMove();
+      finishChatPanelResize(true);
+    };
+    const cleanup = () => {
       window.removeEventListener('pointermove', handlePointerMove);
-      window.removeEventListener('pointerup', handlePointerUp);
-      window.removeEventListener('pointercancel', handlePointerUp);
-      setResizingChatPanel(false);
-      saveChatPanelWidth(finalWidth);
+      window.removeEventListener('pointerup', handlePointerEnd);
+      window.removeEventListener('pointercancel', handlePointerEnd);
+      window.removeEventListener('blur', handlePointerEnd);
     };
 
+    pointerCleanupRef.current = cleanup;
     window.addEventListener('pointermove', handlePointerMove);
-    window.addEventListener('pointerup', handlePointerUp, { once: true });
-    window.addEventListener('pointercancel', handlePointerUp, { once: true });
-  }, [chatPanelWidth]);
+    window.addEventListener('pointerup', handlePointerEnd);
+    window.addEventListener('pointercancel', handlePointerEnd);
+    window.addEventListener('blur', handlePointerEnd);
+  }, [applyChatPanelWidth, finishChatPanelResize]);
+
+  const handleChatResizeBlur = useCallback(() => {
+    if (pointerCleanupRef.current) finishChatPanelResize(true);
+  }, [finishChatPanelResize]);
+
+  const handleChatResizeKeyDown = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
+    let nextWidth: number | null = null;
+    if (event.key === 'ArrowLeft') {
+      nextWidth = chatPanelWidthRef.current - CHAT_PANEL_KEYBOARD_STEP;
+    } else if (event.key === 'ArrowRight') {
+      nextWidth = chatPanelWidthRef.current + CHAT_PANEL_KEYBOARD_STEP;
+    } else if (event.key === 'Home') {
+      nextWidth = MIN_CHAT_PANEL_WIDTH;
+    } else if (event.key === 'End') {
+      nextWidth = chatPanelMaxWidthRef.current;
+    }
+    if (nextWidth === null) return;
+    event.preventDefault();
+    const next = applyChatPanelWidth(nextWidth);
+    saveChatPanelWidth(next);
+  }, [applyChatPanelWidth]);
 
   // Hand the pending prompt to ChatPane exactly once. We snapshot the value
   // into local state on mount so it survives the ChatPane remount triggered
@@ -1550,7 +1688,10 @@ export function ProjectView({
       <div
         ref={splitRef}
         className={`split${resizingChatPanel ? ' is-resizing-chat' : ''}`}
-        style={{ gridTemplateColumns: `${chatPanelWidth}px 8px minmax(0, 1fr)` }}
+        style={{
+          gridTemplateColumns:
+            `${chatPanelWidth}px ${SPLIT_RESIZE_HANDLE_WIDTH}px minmax(${MIN_WORKSPACE_PANEL_WIDTH}px, 1fr)`,
+        }}
       >
         <ChatPane
           // The conversation id is part of the key so switching conversations
@@ -1598,8 +1739,14 @@ export function ProjectView({
           role="separator"
           aria-orientation="vertical"
           aria-label="Resize chat panel"
+          aria-valuemin={MIN_CHAT_PANEL_WIDTH}
+          aria-valuemax={chatPanelMaxWidth}
+          aria-valuenow={chatPanelWidth}
+          tabIndex={0}
           title="Resize chat panel"
           onPointerDown={handleChatResizePointerDown}
+          onKeyDown={handleChatResizeKeyDown}
+          onBlur={handleChatResizeBlur}
         />
         <FileWorkspace
           projectId={project.id}

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from 'react';
 import { createHtmlArtifactManifest, inferLegacyManifest } from '../artifacts/manifest';
 import { createArtifactParser } from '../artifacts/parser';
 import { useT } from '../i18n';
@@ -105,6 +112,39 @@ interface Props {
 }
 
 let liveArtifactEventSequence = 0;
+const CHAT_PANEL_WIDTH_STORAGE_KEY = 'open-design.project.chatPanelWidth';
+const DEFAULT_CHAT_PANEL_WIDTH = 460;
+const MIN_CHAT_PANEL_WIDTH = 320;
+const MAX_CHAT_PANEL_WIDTH = 720;
+
+function clampChatPanelWidth(width: number): number {
+  return Math.min(MAX_CHAT_PANEL_WIDTH, Math.max(MIN_CHAT_PANEL_WIDTH, Math.round(width)));
+}
+
+function readSavedChatPanelWidth(): number {
+  if (typeof window === 'undefined') return DEFAULT_CHAT_PANEL_WIDTH;
+  try {
+    const raw = window.localStorage.getItem(CHAT_PANEL_WIDTH_STORAGE_KEY);
+    const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
+    return Number.isFinite(parsed)
+      ? clampChatPanelWidth(parsed)
+      : DEFAULT_CHAT_PANEL_WIDTH;
+  } catch {
+    return DEFAULT_CHAT_PANEL_WIDTH;
+  }
+}
+
+function saveChatPanelWidth(width: number): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(
+      CHAT_PANEL_WIDTH_STORAGE_KEY,
+      String(clampChatPanelWidth(width)),
+    );
+  } catch {
+    // localStorage can be unavailable in hardened browser contexts.
+  }
+}
 
 function appendLiveArtifactEventItem(
   prev: LiveArtifactEventItem[],
@@ -176,6 +216,9 @@ export function ProjectView({
   const [projectFiles, setProjectFiles] = useState<ProjectFile[]>([]);
   const [liveArtifacts, setLiveArtifacts] = useState<LiveArtifactSummary[]>([]);
   const [liveArtifactEvents, setLiveArtifactEvents] = useState<LiveArtifactEventItem[]>([]);
+  const [chatPanelWidth, setChatPanelWidth] = useState(readSavedChatPanelWidth);
+  const [resizingChatPanel, setResizingChatPanel] = useState(false);
+  const splitRef = useRef<HTMLDivElement | null>(null);
   // The persisted set of open tabs + active tab. Persisted via PUT on every
   // change; loaded once when the project mounts.
   const [openTabsState, setOpenTabsState] = useState<OpenTabsState>({
@@ -1412,6 +1455,38 @@ export function ProjectView({
     [skills, project.skillId],
   );
 
+  const handleChatResizePointerDown = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    const split = splitRef.current;
+    if (!split) return;
+    event.preventDefault();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    setResizingChatPanel(true);
+
+    const splitLeft = split.getBoundingClientRect().left;
+    let finalWidth = chatPanelWidth;
+    const updateWidth = (clientX: number) => {
+      finalWidth = clampChatPanelWidth(clientX - splitLeft);
+      setChatPanelWidth(finalWidth);
+    };
+    updateWidth(event.clientX);
+
+    const handlePointerMove = (moveEvent: PointerEvent) => {
+      updateWidth(moveEvent.clientX);
+    };
+    const handlePointerUp = () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerUp);
+      window.removeEventListener('pointercancel', handlePointerUp);
+      setResizingChatPanel(false);
+      saveChatPanelWidth(finalWidth);
+    };
+
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp, { once: true });
+    window.addEventListener('pointercancel', handlePointerUp, { once: true });
+  }, [chatPanelWidth]);
+
   // Hand the pending prompt to ChatPane exactly once. We snapshot the value
   // into local state on mount so it survives the ChatPane remount triggered
   // when `activeConversationId` resolves from `null` to a real id (the
@@ -1472,7 +1547,11 @@ export function ProjectView({
             <span className="meta" data-testid="project-meta">{projectMeta}</span>
         </div>
       </AppChromeHeader>
-      <div className="split">
+      <div
+        ref={splitRef}
+        className={`split${resizingChatPanel ? ' is-resizing-chat' : ''}`}
+        style={{ gridTemplateColumns: `${chatPanelWidth}px 8px minmax(0, 1fr)` }}
+      >
         <ChatPane
           // The conversation id is part of the key so switching conversations
           // resets internal scroll/draft state inside ChatPane and ChatComposer.
@@ -1513,6 +1592,14 @@ export function ProjectView({
           onProjectMetadataChange={(metadata) => {
             onProjectChange({ ...project, metadata });
           }}
+        />
+        <div
+          className="split-resize-handle"
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize chat panel"
+          title="Resize chat panel"
+          onPointerDown={handleChatResizePointerDown}
         />
         <FileWorkspace
           projectId={project.id}

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1610,10 +1610,12 @@ export function ProjectView({
 
   const handleChatResizeKeyDown = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
     let nextWidth: number | null = null;
+    const split = splitRef.current;
+    const isRtl = split ? window.getComputedStyle(split).direction === 'rtl' : false;
     if (event.key === 'ArrowLeft') {
-      nextWidth = chatPanelWidthRef.current - CHAT_PANEL_KEYBOARD_STEP;
+      nextWidth = chatPanelWidthRef.current + (isRtl ? 1 : -1) * CHAT_PANEL_KEYBOARD_STEP;
     } else if (event.key === 'ArrowRight') {
-      nextWidth = chatPanelWidthRef.current + CHAT_PANEL_KEYBOARD_STEP;
+      nextWidth = chatPanelWidthRef.current + (isRtl ? -1 : 1) * CHAT_PANEL_KEYBOARD_STEP;
     } else if (event.key === 'Home') {
       nextWidth = MIN_CHAT_PANEL_WIDTH;
     } else if (event.key === 'End') {

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -394,6 +394,7 @@ export const ar: Dict = {
 
   'project.backToProjects': 'العودة للمشاريع',
   'project.metaFreeform': 'شكل حر',
+  'project.resizeChatPanel': 'تغيير حجم لوحة الدردشة',
   'chat.tabChat': 'دردشة',
   'chat.tabComments': 'تعليقات',
   'chat.commentsSoon': 'التعليقات - قريباً',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -348,6 +348,7 @@ export const de: Dict = {
 
   'project.backToProjects': 'Zurück zu Projekten',
   'project.metaFreeform': 'frei',
+  'project.resizeChatPanel': 'Größe des Chat-Bereichs ändern',
   'chat.tabChat': 'Chat',
   'chat.tabComments': 'Kommentare',
   'chat.commentsSoon': 'Kommentare — demnächst',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -405,6 +405,7 @@ export const en: Dict = {
 
   'project.backToProjects': 'Back to projects',
   'project.metaFreeform': 'freeform',
+  'project.resizeChatPanel': 'Resize chat panel',
   'chat.tabChat': 'Chat',
   'chat.tabComments': 'Comments',
   'chat.commentsSoon': 'Comments — coming soon',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -349,6 +349,7 @@ export const esES: Dict = {
 
   'project.backToProjects': 'Volver a los proyectos',
   'project.metaFreeform': 'estilo libre',
+  'project.resizeChatPanel': 'Redimensionar panel de chat',
   'chat.tabChat': 'Chat',
   'chat.tabComments': 'Comentarios',
   'chat.commentsSoon': 'Comentarios — próximamente',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -405,6 +405,7 @@ export const fa: Dict = {
 
   'project.backToProjects': 'بازگشت به پروژه‌ها',
   'project.metaFreeform': 'آزاد',
+  'project.resizeChatPanel': 'تغییر اندازه پنل چت',
   'chat.tabChat': 'چت',
   'chat.tabComments': 'نظرات',
   'chat.commentsSoon': 'نظرات — به زودی',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -394,6 +394,7 @@ export const fr: Dict = {
 
   'project.backToProjects': 'Retour aux projets',
   'project.metaFreeform': 'libre',
+  'project.resizeChatPanel': 'Redimensionner le panneau de chat',
   'chat.tabChat': 'Chat',
   'chat.tabComments': 'Commentaires',
   'chat.commentsSoon': 'Commentaires — bientôt disponible',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -394,6 +394,7 @@ export const hu: Dict = {
 
   'project.backToProjects': 'Vissza a projektekhez',
   'project.metaFreeform': 'szabad formátum',
+  'project.resizeChatPanel': 'Csevegőpanel átméretezése',
   'chat.tabChat': 'Csevegés',
   'chat.tabComments': 'Megjegyzések',
   'chat.commentsSoon': 'Megjegyzések — hamarosan',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -347,6 +347,7 @@ export const ja: Dict = {
 
   'project.backToProjects': 'プロジェクトに戻る',
   'project.metaFreeform': 'フリーフォーム',
+  'project.resizeChatPanel': 'チャットパネルのサイズを変更',
   'chat.tabChat': 'チャット',
   'chat.tabComments': 'コメント',
   'chat.commentsSoon': 'コメント — 近日公開',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -394,6 +394,7 @@ export const ko: Dict = {
 
   'project.backToProjects': '프로젝트 목록으로 돌아가기',
   'project.metaFreeform': '자유 양식',
+  'project.resizeChatPanel': '채팅 패널 크기 조절',
   'chat.tabChat': '채팅',
   'chat.tabComments': '댓글',
   'chat.commentsSoon': '댓글 — 곧 지원될 예정입니다.',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -394,6 +394,7 @@ export const pl: Dict = {
 
   'project.backToProjects': 'Wróć do projektów',
   'project.metaFreeform': 'styl dowolny',
+  'project.resizeChatPanel': 'Zmień rozmiar panelu czatu',
   'chat.tabChat': 'Czat',
   'chat.tabComments': 'Komentarze',
   'chat.commentsSoon': 'Komentarze — wkrótce',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -404,6 +404,7 @@ export const ptBR: Dict = {
 
   'project.backToProjects': 'Voltar aos projetos',
   'project.metaFreeform': 'livre',
+  'project.resizeChatPanel': 'Redimensionar painel de chat',
   'chat.tabChat': 'Chat',
   'chat.tabComments': 'Comentários',
   'chat.commentsSoon': 'Comentários — em breve',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -404,6 +404,7 @@ export const ru: Dict = {
 
   'project.backToProjects': 'Назад к проектам',
   'project.metaFreeform': 'произвольная форма',
+  'project.resizeChatPanel': 'Изменить размер панели чата',
   'chat.tabChat': 'Чат',
   'chat.tabComments': 'Комментарии',
   'chat.commentsSoon': 'Комментарии — скоро',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -393,6 +393,7 @@ export const tr: Dict = {
 
   'project.backToProjects': 'Projelere dön',
   'project.metaFreeform': 'serbest stil',
+  'project.resizeChatPanel': 'Sohbet panelini yeniden boyutlandır',
   'chat.tabChat': 'Sohbet',
   'chat.tabComments': 'Yorumlar',
   'chat.commentsSoon': 'Yorumlar — yakında',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -405,6 +405,7 @@ export const uk: Dict = {
 
   'project.backToProjects': 'Назад до проектів',
   'project.metaFreeform': 'вільна форма',
+  'project.resizeChatPanel': 'Змінити розмір панелі чату',
   'chat.tabChat': 'Чат',
   'chat.tabComments': 'Коментарі',
   'chat.commentsSoon': 'Коментарі — скоро',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -399,6 +399,7 @@ export const zhCN: Dict = {
 
   'project.backToProjects': '返回项目列表',
   'project.metaFreeform': '自由设计',
+  'project.resizeChatPanel': '调整聊天面板大小',
   'chat.tabChat': '对话',
   'chat.tabComments': '评论',
   'chat.commentsSoon': '评论 — 即将上线',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -399,6 +399,7 @@ export const zhTW: Dict = {
 
   'project.backToProjects': '返回專案列表',
   'project.metaFreeform': '自由設計',
+  'project.resizeChatPanel': '調整聊天面板大小',
   'chat.tabChat': '對話',
   'chat.tabComments': '評論',
   'chat.commentsSoon': '評論 — 即將上線',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -455,6 +455,7 @@ export interface Dict {
   // Project view / chat pane / composer
   'project.backToProjects': string;
   'project.metaFreeform': string;
+  'project.resizeChatPanel': string;
   'chat.tabChat': string;
   'chat.tabComments': string;
   'chat.commentsSoon': string;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -580,17 +580,51 @@ code {
 /* -------- Split / panes -------------------------------------------- */
 .split {
   display: grid;
-  grid-template-columns: minmax(380px, 460px) minmax(0, 1fr);
+  grid-template-columns: 460px 8px minmax(0, 1fr);
   min-height: 0;
+}
+.split.is-resizing-chat {
+  cursor: col-resize;
+  user-select: none;
+}
+.split.is-resizing-chat iframe {
+  pointer-events: none;
 }
 .pane {
   display: flex;
   flex-direction: column;
   min-height: 0;
-  border-right: 1px solid var(--border);
   background: var(--bg-panel);
 }
-.pane:last-child { border-right: none; }
+.split-resize-handle {
+  width: 8px;
+  min-width: 8px;
+  height: 100%;
+  cursor: col-resize;
+  background:
+    linear-gradient(
+      90deg,
+      transparent 0,
+      transparent 3px,
+      var(--border) 3px,
+      var(--border) 5px,
+      transparent 5px
+    );
+  transition: background 120ms ease;
+  touch-action: none;
+}
+.split-resize-handle:hover,
+.split.is-resizing-chat .split-resize-handle {
+  background:
+    linear-gradient(
+      90deg,
+      color-mix(in srgb, var(--accent) 16%, transparent) 0,
+      color-mix(in srgb, var(--accent) 16%, transparent) 3px,
+      var(--accent) 3px,
+      var(--accent) 5px,
+      color-mix(in srgb, var(--accent) 16%, transparent) 5px
+    );
+}
 
 /* -------- Chat sticky header --------------------------------------- */
 .chat-header {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -580,7 +580,7 @@ code {
 /* -------- Split / panes -------------------------------------------- */
 .split {
   display: grid;
-  grid-template-columns: 460px 8px minmax(0, 1fr);
+  grid-template-columns: 460px 8px minmax(400px, 1fr);
   min-height: 0;
 }
 .split.is-resizing-chat {
@@ -614,6 +614,7 @@ code {
   touch-action: none;
 }
 .split-resize-handle:hover,
+.split-resize-handle:focus-visible,
 .split.is-resizing-chat .split-resize-handle {
   background:
     linear-gradient(
@@ -624,6 +625,10 @@ code {
       var(--accent) 5px,
       color-mix(in srgb, var(--accent) 16%, transparent) 5px
     );
+}
+.split-resize-handle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
 }
 
 /* -------- Chat sticky header --------------------------------------- */

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -582,6 +582,7 @@ code {
   display: grid;
   grid-template-columns: 460px 8px minmax(400px, 1fr);
   min-height: 0;
+  min-width: 0;
 }
 .split.is-resizing-chat {
   cursor: col-resize;


### PR DESCRIPTION
Adds a draggable resize divider between the chat panel and the preview/files workspace.

Changes:
- Added resizable chat panel width
- Saves chat width to localStorage
- Clamps width between 320px and 720px
- Adds an 8px vertical resize handle
- Keeps layout resize instant while dragging

Tested locally and confirmed the resize behavior works as expected.