### PR TITLE
fix(release): defer Linux artifact from 0.4.0 stable

### DIFF
--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -297,6 +297,10 @@ jobs:
   build_linux:
     name: Build stable linux x64
     needs: [metadata, verify]
+    # Linux AppImage packaging is temporarily excluded from stable releases.
+    # Keep the job definition in place so the Linux lane can be re-enabled once
+    # the containerized pnpm bootstrap is fixed and reviewed.
+    if: ${{ false }}
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
@@ -372,7 +376,6 @@ jobs:
       - verify
       - build_mac
       - build_win
-      - build_linux
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
@@ -406,12 +409,6 @@ jobs:
           name: open-design-stable-win-release-assets
           path: ${{ runner.temp }}/release-assets/win
 
-      - name: Download linux release bundle
-        uses: actions/download-artifact@v8
-        with:
-          name: open-design-stable-linux-release-assets
-          path: ${{ runner.temp }}/release-assets/linux
-
       - name: Write release notes shell
         id: notes
         run: |
@@ -428,7 +425,7 @@ jobs:
 
           See [CHANGELOG.md](https://github.com/${GITHUB_REPOSITORY}/blob/${{ needs.metadata.outputs.version_tag }}/CHANGELOG.md) for the full release notes.
 
-          This stable release ships mac arm64 DMG/update ZIP, Windows x64 NSIS installer assets, Linux x64 AppImage (no auto-update yet), checksums, and updater feed files.
+          This stable release ships mac arm64 DMG/update ZIP, Windows x64 NSIS installer assets, checksums, and updater feed files. Linux AppImage packaging is temporarily deferred from the stable release lane.
           EOF
           echo "notes_file=$notes_file" >> "$GITHUB_OUTPUT"
 
@@ -452,7 +449,6 @@ jobs:
           mkdir -p "$all_release_dir"
           cp "$RUNNER_TEMP/release-assets/mac"/* "$all_release_dir/"
           cp "$RUNNER_TEMP/release-assets/win"/* "$all_release_dir/"
-          cp "$RUNNER_TEMP/release-assets/linux"/* "$all_release_dir/"
           gh release upload "${{ needs.metadata.outputs.version_tag }}" "$all_release_dir"/*
 
       - name: Promote draft to published latest
@@ -482,6 +478,6 @@ jobs:
             echo "- windows signed: false"
             echo "- mac assets: open-design-${{ needs.metadata.outputs.stable_version }}-mac-arm64.dmg, open-design-${{ needs.metadata.outputs.stable_version }}-mac-arm64.zip"
             echo "- win assets: open-design-${{ needs.metadata.outputs.stable_version }}-win-x64-setup.exe, open-design-${{ needs.metadata.outputs.stable_version }}-win-x64-setup.exe.blockmap"
-            echo "- linux assets: open-design-${{ needs.metadata.outputs.stable_version }}-linux-x64.AppImage"
-            echo "- Feeds: latest-mac.yml, latest.yml (no latest-linux.yml; AppImage updater not yet wired)"
+            echo "- linux assets: deferred from this stable release"
+            echo "- Feeds: latest-mac.yml, latest.yml"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.0] - 2026-05-05
 
-A multi-platform, multi-protocol leap: Open Design now ships as an MCP server, lands on Linux desktops, ships Critique Theater (Design Jury) Phase 4, gains live-reload + Tweaks mode + live artifacts in the preview pane, and adds five new agent / runtime adapters. 71 merged PRs from 40+ contributors over two days.
+A multi-protocol leap: Open Design now ships as an MCP server, ships Critique Theater (Design Jury) Phase 4, gains live-reload + Tweaks mode + live artifacts in the preview pane, and adds five new agent / runtime adapters. 71 merged PRs from 40+ contributors over two days. Linux AppImage packaging landed in tooling, but the stable Linux artifact is deferred from 0.4.0 while containerized release packaging is hardened.
 
 ### Added
 
@@ -30,7 +30,7 @@ A multi-platform, multi-protocol leap: Open Design now ships as an MCP server, l
 - **Live artifacts and Composio connector catalog.** ([#381])
 
 #### Packaging & deployment
-- **Linux x64 AppImage** in `tools-pack` and the release workflows. ([#369])
+- **Linux x64 AppImage tooling** in `tools-pack`; stable release artifact deferred from 0.4.0 while the containerized packaging lane is hardened. ([#369])
 - Optimize packaged mac artifact size. ([#424])
 
 #### Daemon


### PR DESCRIPTION
## Summary

Temporarily defer the Linux AppImage from the 0.4.0 stable release so we can publish the macOS and Windows artifacts while the Linux containerized packaging bootstrap is still under review in #560.

## Changes

- Keep the `build_linux` job definition, but skip it in `release-stable` for now.
- Remove `build_linux` from the publish job dependencies.
- Stop downloading/uploading Linux release assets in `publish`.
- Update release workflow notes and summary to say Linux is deferred.
- Update the 0.4.0 changelog wording so release notes do not promise a Linux desktop artifact.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-stable.yml")'`
- `pnpm guard`
- `GITHUB_REPOSITORY=nexu-io/open-design GITHUB_REF_NAME=fix/release-stable-defer-linux GITHUB_SHA=$(git rev-parse HEAD) node --experimental-strip-types scripts/release-stable.ts`

Local Node is 22.22.0, so pnpm prints the repo's expected `~24` engine warning.

## Release Plan

After this merges, dispatch `release-stable` from `main` with `mac_signed=true`. Expected output: mac arm64 DMG/update ZIP, Windows x64 NSIS installer, checksums, and updater feed files. No Linux AppImage in 0.4.0 stable.
