### PR TITLE
feat: ship Knowhub design artifact

### DIFF
--- a/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/.design-canvas.state.json
+++ b/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/.design-canvas.state.json
@@ -1,0 +1,1 @@
+{"sections":{"states":{"title":"States"},"source":{"title":"Source detail · annotated"},"video":{"title":"Video detail · annotated"}}}

--- a/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/Detail page.html
+++ b/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/Detail page.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Knowledge Hub · detail page</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" />
+  <link rel="stylesheet" href="design-system/tokens.css" />
+  <style>
+    html, body { margin: 0; padding: 0; background: #f0eee9; }
+    @keyframes khBlink { 50% { opacity: 0; } }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+  <script type="text/babel" src="lib/design-canvas.jsx"></script>
+  <script type="text/babel" src="lib/kh-screens.jsx"></script>
+  <script type="text/babel" src="lib/kh-annotated.jsx"></script>
+  <script type="text/babel" src="lib/kh-detail-screens.jsx"></script>
+  <script type="text/babel" src="lib/kh-detail-annotated.jsx"></script>
+
+  <script type="text/babel">
+    const { DesignCanvas, DCSection, DCArtboard,
+            AnnotatedDetail, PlainDetailDevice } = window;
+
+    function App() {
+      return (
+        <DesignCanvas>
+          <DCSection id="video" title="Video detail · annotated"
+                     subtitle="Single-column, skim-first. Hero → meta → actions → TOC chips → sections.">
+            <DCArtboard id="video-anno-dark" label="A · Annotated (dark)" width={900} height={900}>
+              <AnnotatedDetail mode="dark" kind="video" />
+            </DCArtboard>
+            <DCArtboard id="video-anno-light" label="B · Annotated (light)" width={900} height={900}>
+              <AnnotatedDetail mode="light" kind="video" />
+            </DCArtboard>
+          </DCSection>
+
+          <DCSection id="source" title="Source detail · annotated"
+                     subtitle="Articles, repos, sites. Lighter hero, KV block, markdown analysis.">
+            <DCArtboard id="source-anno-dark" label="C · Annotated (dark)" width={900} height={900}>
+              <AnnotatedDetail mode="dark" kind="source" />
+            </DCArtboard>
+            <DCArtboard id="source-anno-light" label="D · Annotated (light)" width={900} height={900}>
+              <AnnotatedDetail mode="light" kind="source" />
+            </DCArtboard>
+          </DCSection>
+
+          <DCSection id="clean" title="Clean states"
+                     subtitle="No callouts — the actual detail experience.">
+            <DCArtboard id="video-dark" label="E · Video, dark" width={390} height={760}>
+              <PlainDetailDevice mode="dark" kind="video" />
+            </DCArtboard>
+            <DCArtboard id="video-light" label="F · Video, light" width={390} height={760}>
+              <PlainDetailDevice mode="light" kind="video" />
+            </DCArtboard>
+            <DCArtboard id="source-dark" label="G · Source, dark" width={390} height={760}>
+              <PlainDetailDevice mode="dark" kind="source" />
+            </DCArtboard>
+            <DCArtboard id="source-light" label="H · Source, light" width={390} height={760}>
+              <PlainDetailDevice mode="light" kind="source" />
+            </DCArtboard>
+          </DCSection>
+        </DesignCanvas>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+  </script>
+</body>
+</html>

--- a/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/Mobile redesign.html
+++ b/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/Mobile redesign.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Knowledge Hub · mobile redesign</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" />
+  <link rel="stylesheet" href="design-system/tokens.css" />
+  <style>
+    html, body { margin: 0; padding: 0; background: #f0eee9; }
+    @keyframes khBlink { 50% { opacity: 0; } }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+  <script type="text/babel" src="lib/design-canvas.jsx"></script>
+  <script type="text/babel" src="lib/kh-screens.jsx"></script>
+  <script type="text/babel" src="lib/kh-annotated.jsx"></script>
+
+  <script type="text/babel">
+    const { DesignCanvas, DCSection, DCArtboard, AnnotatedLibrary, PlainDevice } = window;
+
+    function App() {
+      return (
+        <DesignCanvas>
+          <DCSection id="spec" title="Library · annotated spec"
+                     subtitle="Mobile redesign for screens ≤ 640px. Dark is primary; light shown side-by-side.">
+            <DCArtboard id="annotated-dark" label="A · Annotated (dark)" width={900} height={900}>
+              <AnnotatedLibrary mode="dark" />
+            </DCArtboard>
+            <DCArtboard id="annotated-light" label="B · Annotated (light)" width={900} height={900}>
+              <AnnotatedLibrary mode="light" />
+            </DCArtboard>
+          </DCSection>
+
+          <DCSection id="states" title="States"
+                     subtitle="Clean screens without callouts — the actual mobile experience.">
+            <DCArtboard id="dark" label="C · Dark, home" width={390} height={760}>
+              <PlainDevice mode="dark" active="home" />
+            </DCArtboard>
+            <DCArtboard id="light" label="D · Light, home" width={390} height={760}>
+              <PlainDevice mode="light" active="home" />
+            </DCArtboard>
+            <DCArtboard id="search" label="E · Inline search" width={390} height={760}>
+              <PlainDevice mode="dark" active="search" searchOpen={true} />
+            </DCArtboard>
+            <DCArtboard id="library-tab" label="F · Library tab active" width={390} height={760}>
+              <PlainDevice mode="dark" active="library" />
+            </DCArtboard>
+          </DCSection>
+        </DesignCanvas>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+  </script>
+</body>
+</html>

--- a/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/Quick add.html
+++ b/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/Quick add.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Knowledge Hub · quick add</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" />
+  <link rel="stylesheet" href="design-system/tokens.css" />
+  <style>
+    html, body { margin: 0; padding: 0; background: #f0eee9; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+  <script type="text/babel" src="lib/design-canvas.jsx"></script>
+  <script type="text/babel" src="lib/kh-screens.jsx"></script>
+  <script type="text/babel" src="lib/kh-quickadd.jsx"></script>
+  <script type="text/babel" src="lib/kh-history.jsx"></script>
+  <script type="text/babel" src="lib/kh-quickadd-annotated.jsx"></script>
+
+  <script type="text/babel">
+    const { DesignCanvas, DCSection, DCArtboard,
+            AnnotatedQuickAdd, ScreenLibraryFab, ScreenLibrarySheet,
+            ScreenImportHistory } = window;
+
+    function App() {
+      return (
+        <DesignCanvas>
+          <DCSection id="flow" title="Quick add · annotated flow"
+                     subtitle="Paste a link you just found. Two taps: FAB → Add to library.">
+            <DCArtboard id="qa-annotated" label="A · Flow walkthrough" width={1500} height={880}>
+              <AnnotatedQuickAdd />
+            </DCArtboard>
+          </DCSection>
+
+          <DCSection id="states" title="States"
+                     subtitle="Every variant of the paste sheet, dark & light.">
+            <DCArtboard id="fab-dark" label="B · Library + FAB (dark)" width={390} height={780}>
+              <div data-theme="dark" style={{ width: '100%', height: '100%' }}>
+                <ScreenLibraryFab />
+              </div>
+            </DCArtboard>
+            <DCArtboard id="fab-light" label="C · Library + FAB (light)" width={390} height={780}>
+              <div data-theme="light" style={{ width: '100%', height: '100%' }}>
+                <ScreenLibraryFab />
+              </div>
+            </DCArtboard>
+            <DCArtboard id="pasted-dark" label="D · Pasted (dark)" width={390} height={780}>
+              <div data-theme="dark" style={{ width: '100%', height: '100%' }}>
+                <ScreenLibrarySheet state="pasted" />
+              </div>
+            </DCArtboard>
+            <DCArtboard id="pasted-light" label="E · Pasted (light)" width={390} height={780}>
+              <div data-theme="light" style={{ width: '100%', height: '100%' }}>
+                <ScreenLibrarySheet state="pasted" />
+              </div>
+            </DCArtboard>
+            <DCArtboard id="empty-dark" label="F · Empty (dark)" width={390} height={780}>
+              <div data-theme="dark" style={{ width: '100%', height: '100%' }}>
+                <ScreenLibrarySheet state="empty" />
+              </div>
+            </DCArtboard>
+            <DCArtboard id="done-dark" label="G · Done (dark)" width={390} height={780}>
+              <div data-theme="dark" style={{ width: '100%', height: '100%' }}>
+                <ScreenLibrarySheet state="done" />
+              </div>
+            </DCArtboard>
+          </DCSection>
+
+          <DCSection id="history" title="Import history"
+                     subtitle="Every link added via Quick Add, with processing status. Accessed from sheet's 'Done' state or Library overflow.">
+            <DCArtboard id="history-dark" label="H · History (dark)" width={390} height={780}>
+              <div data-theme="dark" style={{ width: '100%', height: '100%' }}>
+                <ScreenImportHistory />
+              </div>
+            </DCArtboard>
+            <DCArtboard id="history-light" label="I · History (light)" width={390} height={780}>
+              <div data-theme="light" style={{ width: '100%', height: '100%' }}>
+                <ScreenImportHistory />
+              </div>
+            </DCArtboard>
+          </DCSection>
+        </DesignCanvas>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+  </script>
+</body>
+</html>

--- a/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/design-system/README.md
+++ b/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/design-system/README.md
@@ -1,0 +1,113 @@
+# Knowledge Hub — Design System
+
+Dark-first, quiet operational UI. Compact information density, restrained
+indigo primary, no marketing-style hero/card-heavy layouts.
+
+This folder is the **source of truth** for tokens and component primitives.
+Drop it into the Next.js app at `app/design-system/` (or `src/design-system/`)
+and import from it.
+
+## Structure
+
+```
+design-system/
+├── tokens.css            ← CSS variables (shadcn-style names)
+├── tokens.ts             ← Typed tokens for runtime use
+├── globals.css           ← Imports tokens.css + base styles + reset
+├── components/
+│   ├── ThemeProvider.tsx
+│   ├── Button.tsx        ← Button, IconButton
+│   ├── Pill.tsx          ← Pill, Tag
+│   ├── Card.tsx
+│   ├── Section.tsx       ← SectionLabel, DetailSection
+│   ├── Header.tsx        ← PageHeader, DetailHeader
+│   ├── BottomNav.tsx
+│   ├── ChipStrip.tsx
+│   ├── Display.tsx       ← KVGrid, Quote, Callout
+│   └── index.ts          ← barrel
+├── spec.html             ← live docs page (sidebar nav)
+└── README.md             ← this file
+```
+
+## Install (Next.js app router)
+
+1. Copy `design-system/` into your app, e.g. `src/design-system/`.
+2. Add to `app/layout.tsx`:
+
+   ```tsx
+   import "@/design-system/globals.css";
+   import { Inter } from "next/font/google";
+   import { GeistMono } from "geist/font/mono";
+   import { ThemeProvider } from "@/design-system/components";
+
+   const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
+
+   export default function RootLayout({ children }: { children: React.ReactNode }) {
+     return (
+       <html lang="en" suppressHydrationWarning>
+         <body className={`${inter.variable} ${GeistMono.variable}`}>
+           <ThemeProvider>{children}</ThemeProvider>
+         </body>
+       </html>
+     );
+   }
+   ```
+
+3. Override the sans/mono families in `tokens.css` if you wire `next/font`
+   variables instead of bare family names:
+
+   ```css
+   :root {
+     --font-sans: var(--font-inter), -apple-system, system-ui, sans-serif;
+     --font-mono: var(--font-geist-mono), ui-monospace, Menlo, monospace;
+   }
+   ```
+
+4. Install runtime dep: `pnpm add lucide-react`.
+
+## Themes
+
+- Default = **system preference** (`prefers-color-scheme`).
+- Manual override = `data-theme="dark" | "light"` on `<html>` (set by
+  `ThemeProvider`).
+- Persisted in `localStorage` under `kh-theme`. Clear it to fall back to system.
+
+## Token contract
+
+Names follow shadcn conventions so component APIs stay portable:
+
+| Token                   | Purpose                                    |
+| ----------------------- | ------------------------------------------ |
+| `--background`          | page surface                               |
+| `--background-elev`     | sticky bars, sheets                        |
+| `--card` / `--popover`  | content surfaces                           |
+| `--foreground`          | primary text                               |
+| `--foreground-dim`      | body / secondary text                      |
+| `--muted`               | meta / labels                              |
+| `--muted-dim`           | tertiary / timestamps                      |
+| `--border`              | hairline                                   |
+| `--border-strong`       | divider / handle                           |
+| `--primary`             | brand action color (indigo)                |
+| `--primary-tint`        | primary at low opacity (chips, callouts)   |
+| `--ring`                | focus ring                                 |
+| `--success/info/warning/danger` | status                             |
+
+See `tokens.css` for the full list incl. type, spacing, radius, shadows,
+z-layers, motion.
+
+## Usage rules
+
+- Prefer CSS variables in components (`color: var(--foreground)`); reach for
+  the TS module only when you need a value at runtime.
+- Density is intentional: `--row-default = 56px`, `--hit-min = 44px`. Don't
+  invent looser variants without a reason.
+- One indigo only. Status colors carry meaning; never use them for emphasis.
+- Mono is reserved for IDs, timestamps, code, and ops surfaces — apply via
+  `.kh-mono` or `font-family: var(--font-mono)`.
+- Borders, not shadows. Shadows are for the FAB and modal layers only.
+
+## Live spec
+
+Open `design-system/spec.html` to browse every token + component with
+copyable values. The page reads tokens from `tokens.css` so switching theme
+re-renders all swatches.

--- a/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/design-system/components/BottomNav.tsx
+++ b/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/design-system/components/BottomNav.tsx
@@ -1,0 +1,73 @@
+/**
+ * <BottomNav> — fixed 4-item nav, 64px tall, blurred bg.
+ */
+"use client";
+
+import * as React from "react";
+import type { LucideIcon } from "lucide-react";
+
+export interface BottomNavItem {
+  id: string;
+  label: string;
+  icon: LucideIcon;
+}
+
+export function BottomNav({
+  items,
+  active,
+  onSelect,
+}: {
+  items: BottomNavItem[];
+  active: string;
+  onSelect?: (id: string) => void;
+}) {
+  return (
+    <nav
+      style={{
+        position: "absolute",
+        left: 0,
+        right: 0,
+        bottom: 0,
+        height: 64,
+        paddingBottom: "env(safe-area-inset-bottom, 0)",
+        borderTop: "1px solid var(--border)",
+        background: "var(--nav-bg)",
+        backdropFilter: "blur(var(--blur-lg))",
+        WebkitBackdropFilter: "blur(var(--blur-lg))",
+        display: "flex",
+        zIndex: 30,
+      }}
+    >
+      {items.map(({ id, label, icon: Icon }) => {
+        const on = id === active;
+        return (
+          <button
+            key={id}
+            onClick={() => onSelect?.(id)}
+            style={{
+              flex: 1,
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 3,
+              color: on ? "var(--primary)" : "var(--muted)",
+            }}
+          >
+            <Icon size={20} strokeWidth={on ? 2 : 1.6} />
+            <span
+              style={{
+                fontSize: 11,
+                fontWeight: on ? 600 : 500,
+                letterSpacing: 0.1,
+                lineHeight: 1,
+              }}
+            >
+              {label}
+            </span>
+          </button>
+        );
+      })}
+    </nav>
+  );
+}

--- a/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/design-system/components/Button.tsx
+++ b/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/design-system/components/Button.tsx
@@ -1,0 +1,124 @@
+/**
+ * <Button>, <IconButton>
+ *
+ * Variants: primary | ghost | outline | danger
+ * Sizes:    sm (28) | md (32, default) | lg (44)
+ *
+ * Uses lucide-react for icons by convention. Pass any LucideIcon as `icon`.
+ */
+"use client";
+
+import * as React from "react";
+import type { LucideIcon } from "lucide-react";
+
+type Variant = "primary" | "ghost" | "outline" | "danger";
+type Size = "sm" | "md" | "lg";
+
+const SIZES: Record<Size, { h: number; px: number; fs: number; gap: number }> = {
+  sm: { h: 28, px: 10, fs: 12, gap: 5 },
+  md: { h: 32, px: 12, fs: 13, gap: 6 },
+  lg: { h: 44, px: 16, fs: 14, gap: 8 },
+};
+
+function variantStyle(v: Variant): React.CSSProperties {
+  switch (v) {
+    case "primary":
+      return { background: "var(--primary)", color: "var(--primary-foreground)", border: "1px solid transparent" };
+    case "ghost":
+      return { background: "transparent", color: "var(--foreground)", border: "1px solid transparent" };
+    case "outline":
+      return { background: "transparent", color: "var(--foreground)", border: "1px solid var(--border)" };
+    case "danger":
+      return { background: "var(--danger)", color: "#fff", border: "1px solid transparent" };
+  }
+}
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: Variant;
+  size?: Size;
+  icon?: LucideIcon;
+  iconRight?: LucideIcon;
+  fullWidth?: boolean;
+}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  function Button(
+    {
+      variant = "ghost",
+      size = "md",
+      icon: Icon,
+      iconRight: IconRight,
+      fullWidth,
+      style,
+      children,
+      ...rest
+    },
+    ref,
+  ) {
+    const s = SIZES[size];
+    return (
+      <button
+        ref={ref}
+        {...rest}
+        style={{
+          height: s.h,
+          padding: `0 ${s.px}px`,
+          borderRadius: "var(--radius-md)",
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: s.gap,
+          fontFamily: "inherit",
+          fontSize: s.fs,
+          fontWeight: 500,
+          letterSpacing: "var(--tracking-flat)",
+          whiteSpace: "nowrap",
+          cursor: "pointer",
+          transition: "background var(--duration-2) var(--ease-out)",
+          width: fullWidth ? "100%" : undefined,
+          ...variantStyle(variant),
+          ...style,
+        }}
+      >
+        {Icon && <Icon size={s.fs} strokeWidth={1.6} />}
+        {children}
+        {IconRight && <IconRight size={s.fs} strokeWidth={1.6} />}
+      </button>
+    );
+  },
+);
+
+export interface IconButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  icon: LucideIcon;
+  size?: Size;
+  label: string; // a11y
+}
+
+export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
+  function IconButton({ icon: Icon, size = "md", label, style, ...rest }, ref) {
+    const dim = size === "sm" ? 28 : size === "lg" ? 44 : 36;
+    const ic = size === "sm" ? 14 : size === "lg" ? 20 : 17;
+    return (
+      <button
+        ref={ref}
+        aria-label={label}
+        {...rest}
+        style={{
+          width: dim,
+          height: dim,
+          borderRadius: "var(--radius-md)",
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: "var(--foreground)",
+          background: "transparent",
+          ...style,
+        }}
+      >
+        <Icon size={ic} strokeWidth={1.6} />
+      </button>
+    );
+  },
+);

--- a/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/design-system/components/Card.tsx
+++ b/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/design-system/components/Card.tsx
@@ -1,0 +1,50 @@
+/**
+ * <Card>  — neutral surface (border + radius)
+ * <CardRow> — flex row variant for list items
+ */
+"use client";
+
+import * as React from "react";
+
+export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
+  padded?: boolean;
+  interactive?: boolean;
+}
+
+export function Card({
+  padded = true,
+  interactive,
+  style,
+  children,
+  ...rest
+}: CardProps) {
+  return (
+    <div
+      {...rest}
+      style={{
+        background: "var(--card)",
+        border: "1px solid var(--border)",
+        borderRadius: "var(--radius-xl)",
+        padding: padded ? 12 : 0,
+        cursor: interactive ? "pointer" : undefined,
+        transition: interactive
+          ? "background var(--duration-2) var(--ease-out)"
+          : undefined,
+        ...style,
+      }}
+      onMouseEnter={(e) => {
+        if (interactive)
+          (e.currentTarget as HTMLDivElement).style.background =
+            "var(--card-hover)";
+        rest.onMouseEnter?.(e);
+      }}
+      onMouseLeave={(e) => {
+        if (interactive)
+          (e.currentTarget as HTMLDivElement).style.background = "var(--card)";
+        rest.onMouseLeave?.(e);
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/design-system/components/ChipStrip.tsx
+++ b/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/design-system/components/ChipStrip.tsx
@@ -1,0 +1,54 @@
+/**
+ * <ChipStrip> — horizontal scrollable chips (TOC, filters).
+ *               Uses `.kh-scroll-x` from globals.css to hide scrollbars.
+ */
+"use client";
+
+import * as React from "react";
+
+export interface ChipItem {
+  id: string;
+  label: string;
+}
+
+export function ChipStrip({
+  items,
+  active,
+  onSelect,
+}: {
+  items: ChipItem[];
+  active?: string;
+  onSelect?: (id: string) => void;
+}) {
+  return (
+    <div className="kh-scroll-x" style={{ position: "relative" }}>
+      <div style={{ display: "flex", gap: 6, padding: "0 16px" }}>
+        {items.map(({ id, label }) => {
+          const on = id === active;
+          return (
+            <button
+              key={id}
+              onClick={() => onSelect?.(id)}
+              style={{
+                flexShrink: 0,
+                height: 28,
+                padding: "0 12px",
+                borderRadius: 14,
+                display: "inline-flex",
+                alignItems: "center",
+                fontSize: 12,
+                fontWeight: 500,
+                letterSpacing: "var(--tracking-flat)",
+                background: on ? "var(--primary-tint)" : "var(--pill-bg)",
+                color: on ? "var(--primary)" : "var(--muted)",
+                border: `1px solid ${on ? "transparent" : "var(--border)"}`,
+              }}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/design-system/components/Display.tsx
+++ b/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/design-system/components/Display.tsx
@@ -1,0 +1,125 @@
+/**
+ * <KVGrid> — two-column key/value grid used in detail metadata blocks.
+ * <Quote>  — left-rule blockquote, optionally tinted with primary.
+ * <Callout> — info / warning / danger soft surface.
+ */
+"use client";
+
+import * as React from "react";
+
+export function KVGrid({
+  items,
+  columns = 2,
+}: {
+  items: ReadonlyArray<readonly [string, React.ReactNode]>;
+  columns?: 1 | 2 | 3;
+}) {
+  return (
+    <div
+      style={{
+        padding: 12,
+        background: "var(--card)",
+        border: "1px solid var(--border)",
+        borderRadius: "var(--radius-xl)",
+        display: "grid",
+        gridTemplateColumns: `repeat(${columns}, 1fr)`,
+        gap: "10px 16px",
+      }}
+    >
+      {items.map(([k, v]) => (
+        <div key={k}>
+          <div
+            style={{
+              fontSize: 10,
+              color: "var(--muted-dim)",
+              letterSpacing: "var(--tracking-caps)",
+              textTransform: "uppercase",
+              fontWeight: 600,
+            }}
+          >
+            {k}
+          </div>
+          <div
+            style={{
+              fontSize: 13,
+              color: "var(--foreground-dim)",
+              marginTop: 2,
+              letterSpacing: "var(--tracking-flat)",
+            }}
+          >
+            {v}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function Quote({ children }: { children: React.ReactNode }) {
+  return (
+    <blockquote
+      style={{
+        margin: 0,
+        padding: "10px 14px",
+        borderLeft: "2px solid var(--primary)",
+        background: "var(--card)",
+        borderRadius: "0 var(--radius-xl) var(--radius-xl) 0",
+        fontSize: 14,
+        fontStyle: "italic",
+        lineHeight: "var(--leading-normal)",
+        color: "var(--foreground-dim)",
+        letterSpacing: "var(--tracking-flat)",
+      }}
+    >
+      {children}
+    </blockquote>
+  );
+}
+
+type CalloutTone = "info" | "success" | "warning" | "danger" | "primary";
+
+export function Callout({
+  tone = "info",
+  title,
+  children,
+}: {
+  tone?: CalloutTone;
+  title?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  const accent =
+    tone === "success" ? "var(--success)" :
+    tone === "warning" ? "var(--warning)" :
+    tone === "danger"  ? "var(--danger)" :
+    tone === "primary" ? "var(--primary)" :
+    "var(--info)";
+  return (
+    <div
+      style={{
+        padding: 12,
+        background: "var(--card)",
+        border: "1px solid var(--border)",
+        borderLeft: `2px solid ${accent}`,
+        borderRadius: "var(--radius-xl)",
+        fontSize: 13,
+        lineHeight: "var(--leading-normal)",
+        color: "var(--foreground-dim)",
+        letterSpacing: "var(--tracking-flat)",
+      }}
+    >
+      {title && (
+        <div
+          style={{
+            fontSize: 13,
+            fontWeight: 600,
+            color: "var(--foreground)",
+            marginBottom: 4,
+          }}
+        >
+          {title}
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}

--- a/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/design-system/components/Header.tsx
+++ b/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/design-system/components/Header.tsx
@@ -1,0 +1,112 @@
+/**
+ * <PageHeader>   — top-level app header (logo + title + actions, 56px sticky)
+ * <DetailHeader> — back-arrow header used on inner pages
+ */
+"use client";
+
+import * as React from "react";
+import { ChevronLeft, MoreHorizontal } from "lucide-react";
+import { IconButton } from "./Button";
+
+export function PageHeader({
+  title,
+  leading,
+  actions,
+}: {
+  title: React.ReactNode;
+  leading?: React.ReactNode;
+  actions?: React.ReactNode;
+}) {
+  return (
+    <header
+      style={{
+        position: "sticky",
+        top: 0,
+        zIndex: 30,
+        height: 56,
+        padding: "0 16px",
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        background: "var(--header-bg)",
+        backdropFilter: "blur(var(--blur-md))",
+        WebkitBackdropFilter: "blur(var(--blur-md))",
+        borderBottom: "1px solid var(--border)",
+      }}
+    >
+      {leading ?? (
+        <div
+          style={{
+            width: 24,
+            height: 24,
+            borderRadius: 6,
+            background: "var(--primary)",
+            color: "#fff",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: -0.3,
+          }}
+        >
+          KH
+        </div>
+      )}
+      <div
+        style={{
+          fontSize: 15,
+          fontWeight: 600,
+          color: "var(--foreground)",
+          letterSpacing: -0.2,
+        }}
+      >
+        {title}
+      </div>
+      <div style={{ flex: 1 }} />
+      {actions}
+    </header>
+  );
+}
+
+export function DetailHeader({
+  back = "Back",
+  actions,
+}: {
+  back?: React.ReactNode;
+  actions?: React.ReactNode;
+}) {
+  return (
+    <header
+      style={{
+        position: "sticky",
+        top: 0,
+        zIndex: 30,
+        height: 56,
+        padding: "0 8px 0 4px",
+        display: "flex",
+        alignItems: "center",
+        gap: 4,
+        background: "var(--header-bg)",
+        backdropFilter: "blur(var(--blur-md))",
+        WebkitBackdropFilter: "blur(var(--blur-md))",
+        borderBottom: "1px solid var(--border)",
+      }}
+    >
+      <IconButton icon={ChevronLeft} label="Back" />
+      <div
+        style={{
+          fontSize: 13,
+          fontWeight: 500,
+          color: "var(--muted)",
+          letterSpacing: -0.1,
+        }}
+      >
+        {back}
+      </div>
+      <div style={{ flex: 1 }} />
+      {actions}
+      <IconButton icon={MoreHorizontal} label="More" />
+    </header>
+  );
+}

--- a/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/design-system/components/Pill.tsx
+++ b/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/design-system/components/Pill.tsx
@@ -1,0 +1,62 @@
+/**
+ * <Pill> — small chip for tags, kinds, status.
+ * <Tag>  — # prefix, used for topics.
+ */
+"use client";
+
+import * as React from "react";
+
+export interface PillProps extends React.HTMLAttributes<HTMLSpanElement> {
+  tone?: "neutral" | "primary" | "success" | "info" | "warning" | "danger";
+  size?: "xs" | "sm";
+  active?: boolean;
+}
+
+export function Pill({
+  tone = "neutral",
+  size = "sm",
+  active,
+  style,
+  children,
+  ...rest
+}: PillProps) {
+  const h = size === "xs" ? 20 : 22;
+  const fs = size === "xs" ? 10 : 11;
+  const bg =
+    active ? "var(--primary-tint)" :
+    tone === "primary" ? "var(--primary-tint)" :
+    "var(--pill-bg)";
+  const color =
+    active ? "var(--primary)" :
+    tone === "primary" ? "var(--primary)" :
+    tone === "success" ? "var(--success)" :
+    tone === "info"    ? "var(--info)" :
+    tone === "warning" ? "var(--warning)" :
+    tone === "danger"  ? "var(--danger)" :
+    "var(--foreground-dim)";
+  return (
+    <span
+      {...rest}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        height: h,
+        padding: "0 8px",
+        borderRadius: "var(--radius-full)",
+        fontSize: fs,
+        fontWeight: 500,
+        letterSpacing: "var(--tracking-wide)",
+        background: bg,
+        color,
+        border: `1px solid ${active ? "transparent" : "var(--border)"}`,
+        ...style,
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+export function Tag({ children, ...rest }: PillProps) {
+  return <Pill {...rest}>#{children}</Pill>;
+}

--- a/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/design-system/components/Section.tsx
+++ b/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/design-system/components/Section.tsx
@@ -1,0 +1,92 @@
+/**
+ * <SectionLabel>   — uppercase eyebrow above content groups (lists, sections)
+ * <DetailSection>  — labelled section block used inside detail pages
+ */
+"use client";
+
+import * as React from "react";
+
+export function SectionLabel({
+  label,
+  count,
+  trailing,
+  inset = true,
+}: {
+  label: string;
+  count?: string | number;
+  trailing?: React.ReactNode;
+  inset?: boolean;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "baseline",
+        justifyContent: "space-between",
+        padding: inset ? "0 16px" : 0,
+        marginTop: 20,
+        marginBottom: 8,
+      }}
+    >
+      <div
+        style={{
+          fontSize: "var(--text-xs)",
+          fontWeight: 600,
+          letterSpacing: "var(--tracking-caps)",
+          textTransform: "uppercase",
+          color: "var(--muted)",
+        }}
+      >
+        {label}
+      </div>
+      {(count !== undefined || trailing) && (
+        <div
+          style={{
+            fontSize: "var(--text-xs)",
+            color: "var(--muted-dim)",
+            fontVariantNumeric: "tabular-nums",
+          }}
+        >
+          {trailing ?? count}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function DetailSection({
+  label,
+  trailing,
+  children,
+}: {
+  label: string;
+  trailing?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <section style={{ marginTop: 28, padding: "0 16px" }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "baseline",
+          justifyContent: "space-between",
+          marginBottom: 10,
+        }}
+      >
+        <div
+          style={{
+            fontSize: "var(--text-xs)",
+            fontWeight: 600,
+            letterSpacing: "var(--tracking-caps)",
+            textTransform: "uppercase",
+            color: "var(--muted)",
+          }}
+        >
+          {label}
+        </div>
+        {trailing}
+      </div>
+      {children}
+    </section>
+  );
+}

--- a/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/design-system/components/ThemeProvider.tsx
+++ b/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/design-system/components/ThemeProvider.tsx
@@ -1,0 +1,73 @@
+/**
+ * <ThemeProvider> — Manages dark/light theme.
+ *
+ * Sets `data-theme` on <html>. Default is "system" (no attribute, lets media
+ * query take over). Manual toggle persists to localStorage and overrides.
+ *
+ * Mount once in app/layout.tsx (client boundary required).
+ */
+"use client";
+
+import * as React from "react";
+
+type Theme = "system" | "dark" | "light";
+type Resolved = "dark" | "light";
+
+interface Ctx {
+  theme: Theme;
+  resolved: Resolved;
+  setTheme: (t: Theme) => void;
+  toggle: () => void;
+}
+
+const ThemeCtx = React.createContext<Ctx | null>(null);
+const STORAGE_KEY = "kh-theme";
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = React.useState<Theme>("system");
+  const [systemPref, setSystemPref] = React.useState<Resolved>("dark");
+
+  // hydrate from storage + system pref
+  React.useEffect(() => {
+    const stored = (typeof window !== "undefined" &&
+      (localStorage.getItem(STORAGE_KEY) as Theme)) || "system";
+    setThemeState(stored);
+
+    const mq = window.matchMedia("(prefers-color-scheme: light)");
+    const upd = () => setSystemPref(mq.matches ? "light" : "dark");
+    upd();
+    mq.addEventListener("change", upd);
+    return () => mq.removeEventListener("change", upd);
+  }, []);
+
+  const resolved: Resolved = theme === "system" ? systemPref : theme;
+
+  // reflect to <html data-theme>
+  React.useEffect(() => {
+    const root = document.documentElement;
+    if (theme === "system") root.removeAttribute("data-theme");
+    else root.setAttribute("data-theme", theme);
+  }, [theme]);
+
+  const setTheme = React.useCallback((t: Theme) => {
+    setThemeState(t);
+    if (t === "system") localStorage.removeItem(STORAGE_KEY);
+    else localStorage.setItem(STORAGE_KEY, t);
+  }, []);
+
+  const toggle = React.useCallback(() => {
+    setTheme(resolved === "dark" ? "light" : "dark");
+  }, [resolved, setTheme]);
+
+  return (
+    <ThemeCtx.Provider value={{ theme, resolved, setTheme, toggle }}>
+      {children}
+    </ThemeCtx.Provider>
+  );
+}
+
+export function useTheme() {
+  const ctx = React.useContext(ThemeCtx);
+  if (!ctx) throw new Error("useTheme must be used within <ThemeProvider>");
+  return ctx;
+}

--- a/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/design-system/components/index.ts
+++ b/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/design-system/components/index.ts
@@ -1,0 +1,13 @@
+// Barrel export — import from "@/design-system/components"
+export { ThemeProvider, useTheme } from "./ThemeProvider";
+export { Button, IconButton } from "./Button";
+export type { ButtonProps, IconButtonProps } from "./Button";
+export { Pill, Tag } from "./Pill";
+export { Card } from "./Card";
+export { SectionLabel, DetailSection } from "./Section";
+export { PageHeader, DetailHeader } from "./Header";
+export { BottomNav } from "./BottomNav";
+export type { BottomNavItem } from "./BottomNav";
+export { KVGrid, Quote, Callout } from "./Display";
+export { ChipStrip } from "./ChipStrip";
+export type { ChipItem } from "./ChipStrip";

--- a/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/design-system/globals.css
+++ b/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/design-system/globals.css
@@ -1,0 +1,69 @@
+/* ============================================================
+   Knowledge Hub — Global styles
+   Import in app/layout.tsx AFTER tokens.css.
+   ============================================================ */
+
+@import "./tokens.css";
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--background);
+  color: var(--foreground);
+  font-family: var(--font-sans);
+  font-feature-settings: var(--font-feature-settings);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+body { min-height: 100dvh; }
+
+/* Selection */
+::selection {
+  background: var(--selection-bg);
+  color: var(--selection-fg);
+}
+
+/* Focus — single source of truth */
+:where(button, a, input, textarea, select, [tabindex]):focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+/* Reset native button look */
+button {
+  font: inherit;
+  color: inherit;
+  background: none;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+}
+
+/* Tabular numbers for IDs / timestamps / counts */
+.kh-num,
+[data-num] { font-variant-numeric: tabular-nums; }
+
+/* Mono surface */
+.kh-mono { font-family: var(--font-mono); font-feature-settings: normal; }
+
+/* Hide scrollbars on horizontal chip strips */
+.kh-scroll-x {
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.kh-scroll-x::-webkit-scrollbar { display: none; }
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/design-system/spec.html
+++ b/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/design-system/spec.html
@@ -1,0 +1,990 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Knowledge Hub — Design System</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600&display=swap" />
+  <link rel="stylesheet" href="globals.css" />
+  <style>
+    /* ── Spec layout (not part of the kit; this page only) ── */
+    body { display: flex; min-height: 100dvh; }
+
+    .ds-sidebar {
+      flex-shrink: 0;
+      width: 240px;
+      height: 100dvh;
+      position: sticky; top: 0;
+      border-right: 1px solid var(--border);
+      background: var(--background-elev);
+      padding: 24px 0;
+      overflow-y: auto;
+    }
+    .ds-sidebar-brand {
+      display: flex; align-items: center; gap: 8px;
+      padding: 0 20px 20px;
+      border-bottom: 1px solid var(--border);
+      margin-bottom: 12px;
+    }
+    .ds-sidebar-brand .mark {
+      width: 22px; height: 22px; border-radius: 5px;
+      background: var(--primary); color: #fff;
+      display: flex; align-items: center; justify-content: center;
+      font-size: 10px; font-weight: 700; letter-spacing: -0.3px;
+    }
+    .ds-sidebar-brand .name { font-size: 13px; font-weight: 600; letter-spacing: -0.1px; }
+    .ds-sidebar-brand .ver {
+      font-family: var(--font-mono); font-size: 10px;
+      color: var(--muted-dim); margin-left: auto;
+    }
+    .ds-sidebar-section {
+      font-size: 10px; font-weight: 600; letter-spacing: 0.8px;
+      text-transform: uppercase; color: var(--muted);
+      padding: 14px 20px 6px;
+    }
+    .ds-sidebar a {
+      display: block; padding: 6px 20px;
+      font-size: 13px; color: var(--foreground-dim);
+      text-decoration: none;
+      border-left: 2px solid transparent;
+      letter-spacing: -0.1px;
+    }
+    .ds-sidebar a:hover { color: var(--foreground); background: var(--card-hover); }
+    .ds-sidebar a.active {
+      color: var(--primary);
+      border-left-color: var(--primary);
+      background: var(--primary-tint);
+    }
+
+    .ds-main { flex: 1; min-width: 0; max-width: 1100px; padding: 32px 48px 96px; }
+    .ds-topbar {
+      display: flex; align-items: center; gap: 8px;
+      margin-bottom: 32px; padding-bottom: 16px;
+      border-bottom: 1px solid var(--border);
+    }
+    .ds-topbar .crumb {
+      font-size: 12px; color: var(--muted); letter-spacing: 0.1px;
+    }
+    .ds-topbar .crumb b { color: var(--foreground); font-weight: 600; }
+    .ds-topbar .spacer { flex: 1; }
+    .ds-theme-switch {
+      display: inline-flex; padding: 2px;
+      background: var(--pill-bg);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+    }
+    .ds-theme-switch button {
+      height: 26px; padding: 0 10px; border-radius: 6px;
+      font-size: 12px; font-weight: 500; color: var(--muted);
+      letter-spacing: -0.1px;
+    }
+    .ds-theme-switch button.on {
+      background: var(--card); color: var(--foreground);
+      box-shadow: var(--shadow-xs);
+    }
+
+    section.ds-section { margin-bottom: 64px; scroll-margin-top: 24px; }
+    section.ds-section > h1 {
+      margin: 0 0 4px; font-size: 28px; font-weight: 600;
+      letter-spacing: -0.6px; color: var(--foreground);
+    }
+    section.ds-section > .ds-lede {
+      margin: 0 0 24px; font-size: 14px; color: var(--muted);
+      max-width: 64ch; line-height: 1.55;
+    }
+
+    h2.ds-h2 {
+      margin: 32px 0 12px; font-size: 16px; font-weight: 600;
+      letter-spacing: -0.2px; color: var(--foreground);
+    }
+    h3.ds-h3 {
+      margin: 20px 0 8px; font-size: 13px; font-weight: 600;
+      letter-spacing: -0.1px; color: var(--foreground-dim);
+    }
+
+    .ds-grid { display: grid; gap: 12px; }
+    .ds-grid-3 { grid-template-columns: repeat(3, 1fr); }
+    .ds-grid-4 { grid-template-columns: repeat(4, 1fr); }
+    .ds-grid-auto { grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); }
+
+    /* swatch card */
+    .ds-swatch {
+      background: var(--card); border: 1px solid var(--border);
+      border-radius: 12px; overflow: hidden;
+    }
+    .ds-swatch .chip { height: 64px; }
+    .ds-swatch .meta { padding: 10px 12px; }
+    .ds-swatch .meta .name {
+      font-size: 12px; font-weight: 600; color: var(--foreground);
+      letter-spacing: -0.1px;
+    }
+    .ds-swatch .meta .var {
+      margin-top: 2px; font-family: var(--font-mono); font-size: 10px;
+      color: var(--muted-dim); letter-spacing: 0;
+    }
+
+    /* token row (text/spacing/radius) */
+    .ds-row {
+      display: grid;
+      grid-template-columns: 180px 80px 1fr;
+      align-items: center;
+      padding: 10px 12px;
+      border-top: 1px solid var(--border);
+      font-size: 13px;
+    }
+    .ds-row:first-child { border-top: 0; }
+    .ds-row .var { font-family: var(--font-mono); color: var(--muted); font-size: 11px; }
+    .ds-row .val { font-family: var(--font-mono); color: var(--foreground-dim); font-size: 11px; }
+    .ds-row .preview { color: var(--foreground-dim); }
+
+    .ds-card {
+      background: var(--card); border: 1px solid var(--border);
+      border-radius: 12px;
+    }
+
+    /* component preview frame */
+    .ds-preview {
+      background:
+        repeating-linear-gradient(45deg, transparent 0 9px, var(--border) 9px 10px),
+        var(--background);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 32px;
+      display: flex; flex-wrap: wrap; gap: 16px; align-items: center;
+    }
+    .ds-preview.col { flex-direction: column; align-items: stretch; }
+    .ds-preview-label {
+      display: flex; align-items: center; gap: 8px;
+      margin: 16px 0 8px;
+    }
+    .ds-preview-label .dot {
+      width: 6px; height: 6px; border-radius: 3px; background: var(--muted-dim);
+    }
+    .ds-preview-label .name {
+      font-family: var(--font-mono); font-size: 11px; color: var(--muted);
+      letter-spacing: 0;
+    }
+
+    code.ds-code {
+      font-family: var(--font-mono); font-size: 12px;
+      background: var(--pill-bg); border: 1px solid var(--border);
+      padding: 1px 6px; border-radius: 4px; color: var(--foreground-dim);
+    }
+    pre.ds-pre {
+      margin: 8px 0 0;
+      padding: 14px 16px;
+      background: var(--card); border: 1px solid var(--border);
+      border-radius: 10px;
+      font-family: var(--font-mono); font-size: 12px;
+      line-height: 1.55; color: var(--foreground-dim);
+      overflow-x: auto;
+    }
+
+    /* spacing visual */
+    .ds-spacer-row { display: flex; align-items: center; gap: 12px; padding: 8px 0; }
+    .ds-spacer-row .bar {
+      background: var(--primary-tint); border-radius: 2px;
+      height: 12px;
+    }
+    .ds-spacer-row .label {
+      font-family: var(--font-mono); font-size: 11px; color: var(--muted);
+      width: 80px; flex-shrink: 0;
+    }
+    .ds-spacer-row .px {
+      font-family: var(--font-mono); font-size: 11px; color: var(--muted-dim);
+    }
+
+    /* radius visual */
+    .ds-radius-tile {
+      width: 88px; height: 64px;
+      background: var(--primary-tint);
+      border: 1px solid var(--primary); border-color: rgba(94,106,210,0.4);
+    }
+    .ds-radius-cell {
+      display: flex; flex-direction: column; align-items: center; gap: 8px;
+      padding: 16px;
+    }
+    .ds-radius-cell .label {
+      font-family: var(--font-mono); font-size: 11px; color: var(--muted);
+    }
+
+    /* Phone frame for component composition demo */
+    .ds-phone {
+      width: 360px; height: 720px;
+      background: var(--background);
+      border: 1px solid var(--border);
+      border-radius: 28px;
+      overflow: hidden;
+      position: relative;
+      box-shadow: var(--shadow-md);
+    }
+  </style>
+</head>
+<body>
+  <aside class="ds-sidebar">
+    <div class="ds-sidebar-brand">
+      <div class="mark">KH</div>
+      <div class="name">Design System</div>
+      <div class="ver">v0.1</div>
+    </div>
+
+    <div class="ds-sidebar-section">Foundations</div>
+    <a href="#overview" class="active">Overview</a>
+    <a href="#colors">Colors</a>
+    <a href="#typography">Typography</a>
+    <a href="#spacing">Spacing</a>
+    <a href="#radius">Radius</a>
+    <a href="#shadows">Shadows &amp; layers</a>
+    <a href="#motion">Motion</a>
+
+    <div class="ds-sidebar-section">Components</div>
+    <a href="#buttons">Button &amp; IconButton</a>
+    <a href="#pills">Pill &amp; Tag</a>
+    <a href="#chipstrip">ChipStrip</a>
+    <a href="#cards">Card</a>
+    <a href="#sections">SectionLabel &amp; DetailSection</a>
+    <a href="#headers">PageHeader &amp; DetailHeader</a>
+    <a href="#bottomnav">BottomNav</a>
+    <a href="#display">KVGrid · Quote · Callout</a>
+
+    <div class="ds-sidebar-section">Patterns</div>
+    <a href="#composition">List → detail</a>
+    <a href="#install">Install</a>
+  </aside>
+
+  <main class="ds-main">
+    <div class="ds-topbar">
+      <div class="crumb"><b>Knowledge Hub</b> · Design System</div>
+      <div class="spacer"></div>
+      <div class="ds-theme-switch" id="themeSwitch">
+        <button data-theme="dark" class="on">Dark</button>
+        <button data-theme="light">Light</button>
+      </div>
+    </div>
+
+    <div id="root"></div>
+  </main>
+
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+  <script type="text/babel">
+    /* eslint-disable */
+    const { useState, useEffect } = React;
+
+    /* ── Theme switcher ─────────────────────────────── */
+    const sw = document.getElementById('themeSwitch');
+    sw.addEventListener('click', (e) => {
+      const btn = e.target.closest('button[data-theme]');
+      if (!btn) return;
+      const theme = btn.dataset.theme;
+      document.documentElement.setAttribute('data-theme', theme);
+      sw.querySelectorAll('button').forEach(b => b.classList.toggle('on', b === btn));
+    });
+
+    /* ── Sidebar active section ─────────────────────── */
+    const links = document.querySelectorAll('.ds-sidebar a');
+    function syncActive() {
+      const y = window.scrollY + 80;
+      let active = links[0];
+      links.forEach(a => {
+        const id = a.getAttribute('href').slice(1);
+        const el = document.getElementById(id);
+        if (el && el.offsetTop <= y) active = a;
+      });
+      links.forEach(a => a.classList.toggle('active', a === active));
+    }
+    window.addEventListener('scroll', syncActive, { passive: true });
+
+    /* ── Inline icons (mirror lucide visually) ─────── */
+    const I = ({ d, s = 16, sw = 1.6 }) => (
+      <svg width={s} height={s} viewBox="0 0 24 24" fill="none"
+           stroke="currentColor" strokeWidth={sw} strokeLinecap="round" strokeLinejoin="round">
+        {typeof d === 'string' ? <path d={d} /> : d}
+      </svg>
+    );
+    const Search = (p) => <I {...p} d={<><circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/></>} />;
+    const Sun    = (p) => <I {...p} d={<><circle cx="12" cy="12" r="3.5"/><path d="M12 3v2M12 19v2M3 12h2M19 12h2M5.6 5.6l1.4 1.4M17 17l1.4 1.4M5.6 18.4 7 17M17 7l1.4-1.4"/></>} />;
+    const Sparkle= (p) => <I {...p} d="M12 3v4M12 17v4M3 12h4M17 12h4M5.5 5.5l2.8 2.8M15.7 15.7l2.8 2.8M5.5 18.5l2.8-2.8M15.7 8.3l2.8-2.8" />;
+    const Ext    = (p) => <I {...p} d={<><path d="M14 4h6v6"/><path d="M20 4l-8 8"/><path d="M18 14v4a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4"/></>} />;
+    const Back   = (p) => <I {...p} d="M15 6l-6 6 6 6" />;
+    const More   = (p) => <I {...p} d={<><circle cx="5" cy="12" r="1.4" fill="currentColor"/><circle cx="12" cy="12" r="1.4" fill="currentColor"/><circle cx="19" cy="12" r="1.4" fill="currentColor"/></>} sw={0} />;
+    const Home   = (p) => <I {...p} d={<><path d="M3.5 11 12 4l8.5 7"/><path d="M5 10v9h14v-9"/></>} />;
+    const Lib    = (p) => <I {...p} d={<><rect x="3.5" y="4.5" width="17" height="15" rx="2"/><path d="M8 4v15M3.5 9h4.5"/></>} />;
+    const Ops    = (p) => <I {...p} d={<><circle cx="12" cy="12" r="3"/><path d="M12 2v3M12 19v3M4.2 4.2l2.1 2.1M17.7 17.7l2.1 2.1M2 12h3M19 12h3M4.2 19.8l2.1-2.1M17.7 6.3l2.1-2.1"/></>} />;
+
+    /* ── Tokens (mirrors tokens.ts; declared inline so spec is self-contained) ─ */
+    const COLOR_TOKENS = [
+      { group: 'Surfaces', items: [
+        ['--background', 'page bg'],
+        ['--background-elev', 'elevated bg'],
+        ['--card', 'card surface'],
+        ['--card-hover', 'card hover'],
+        ['--popover', 'popover/sheet'],
+      ]},
+      { group: 'Foreground', items: [
+        ['--foreground', 'primary text'],
+        ['--foreground-dim', 'body / secondary'],
+        ['--muted', 'meta / labels'],
+        ['--muted-dim', 'tertiary / timestamps'],
+      ]},
+      { group: 'Borders & Ring', items: [
+        ['--border', 'hairline'],
+        ['--border-strong', 'divider'],
+        ['--ring', 'focus ring'],
+      ]},
+      { group: 'Brand', items: [
+        ['--primary', 'indigo · actions'],
+        ['--primary-foreground', 'on-primary text'],
+        ['--primary-tint', 'soft primary'],
+        ['--primary-tint-strong', 'strong primary tint'],
+      ]},
+      { group: 'Status', items: [
+        ['--success', 'completed / OK'],
+        ['--info', 'processing'],
+        ['--warning', 'queued / wait'],
+        ['--danger', 'error / destructive'],
+      ]},
+      { group: 'Component-specific', items: [
+        ['--pill-bg', 'pill / chip surface'],
+        ['--header-bg', 'sticky header w/ blur'],
+        ['--nav-bg', 'bottom nav w/ blur'],
+        ['--thumb', 'placeholder gradient A'],
+        ['--thumb-accent', 'placeholder gradient B'],
+        ['--scrim', 'modal scrim'],
+      ]},
+    ];
+
+    function Swatch({ name, desc }) {
+      const [v, setV] = useState('');
+      useEffect(() => {
+        const c = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+        setV(c);
+      });
+      return (
+        <div className="ds-swatch">
+          <div className="chip" style={{ background: `var(${name})`, borderBottom: '1px solid var(--border)' }} />
+          <div className="meta">
+            <div className="name">{desc}</div>
+            <div className="var">{name}</div>
+            <div className="var" style={{ color: 'var(--muted)' }}>{v}</div>
+          </div>
+        </div>
+      );
+    }
+
+    /* ── Re-implementations of the kit components for previews ──
+       Mirrors design-system/components/* using only CSS vars.    */
+
+    const Button = ({ variant = 'ghost', size = 'md', icon: Icon, children, fullWidth, style, ...rest }) => {
+      const sz = { sm:{h:28,px:10,fs:12,gap:5}, md:{h:32,px:12,fs:13,gap:6}, lg:{h:44,px:16,fs:14,gap:8} }[size];
+      const vstyle = {
+        primary:{background:'var(--primary)',color:'var(--primary-foreground)',border:'1px solid transparent'},
+        ghost:  {background:'transparent',color:'var(--foreground)',border:'1px solid transparent'},
+        outline:{background:'transparent',color:'var(--foreground)',border:'1px solid var(--border)'},
+        danger: {background:'var(--danger)',color:'#fff',border:'1px solid transparent'},
+      }[variant];
+      return (
+        <button {...rest} style={{
+          height: sz.h, padding: `0 ${sz.px}px`, borderRadius: 'var(--radius-md)',
+          display:'inline-flex', alignItems:'center', justifyContent:'center', gap: sz.gap,
+          fontFamily:'inherit', fontSize: sz.fs, fontWeight: 500, letterSpacing:'-0.1px',
+          whiteSpace:'nowrap', cursor:'pointer', width: fullWidth?'100%':undefined,
+          ...vstyle, ...style,
+        }}>
+          {Icon && <Icon s={sz.fs} />} {children}
+        </button>
+      );
+    };
+
+    const IconBtn = ({ icon: Icon, size = 'md' }) => {
+      const dim = size === 'sm' ? 28 : size === 'lg' ? 44 : 36;
+      const ic  = size === 'sm' ? 14 : size === 'lg' ? 20 : 17;
+      return (
+        <button style={{
+          width: dim, height: dim, borderRadius: 'var(--radius-md)',
+          display:'inline-flex', alignItems:'center', justifyContent:'center',
+          color: 'var(--foreground)', background:'transparent', cursor:'pointer',
+        }}><Icon s={ic} /></button>
+      );
+    };
+
+    const Pill = ({ children, tone='neutral', active }) => {
+      const color = active||tone==='primary' ? 'var(--primary)'
+        : tone==='success' ? 'var(--success)'
+        : tone==='info' ? 'var(--info)'
+        : tone==='warning' ? 'var(--warning)'
+        : tone==='danger' ? 'var(--danger)'
+        : 'var(--foreground-dim)';
+      const bg = active||tone==='primary' ? 'var(--primary-tint)' : 'var(--pill-bg)';
+      return (
+        <span style={{
+          display:'inline-flex',alignItems:'center',height:22,padding:'0 8px',
+          borderRadius:9999,fontSize:11,fontWeight:500,letterSpacing:'0.1px',
+          background:bg,color,border:`1px solid ${active?'transparent':'var(--border)'}`,
+        }}>{children}</span>
+      );
+    };
+
+    const Card = ({ children, padded=true, style }) => (
+      <div style={{
+        background:'var(--card)', border:'1px solid var(--border)',
+        borderRadius:'var(--radius-xl)', padding: padded?12:0, ...style,
+      }}>{children}</div>
+    );
+
+    const SectionLabel = ({ label, count }) => (
+      <div style={{display:'flex',alignItems:'baseline',justifyContent:'space-between',
+                   padding:'0 16px',marginTop:20,marginBottom:8}}>
+        <div style={{fontSize:11,fontWeight:600,letterSpacing:'0.8px',
+                     textTransform:'uppercase',color:'var(--muted)'}}>{label}</div>
+        {count != null && <div style={{fontSize:11,color:'var(--muted-dim)',
+                     fontVariantNumeric:'tabular-nums'}}>{count}</div>}
+      </div>
+    );
+
+    const DetailSection = ({ label, trailing, children }) => (
+      <section style={{marginTop:28,padding:'0 16px'}}>
+        <div style={{display:'flex',alignItems:'baseline',justifyContent:'space-between',marginBottom:10}}>
+          <div style={{fontSize:11,fontWeight:600,letterSpacing:'0.8px',
+                       textTransform:'uppercase',color:'var(--muted)'}}>{label}</div>
+          {trailing}
+        </div>
+        {children}
+      </section>
+    );
+
+    const PageHeader = ({ title }) => (
+      <div style={{
+        position:'sticky',top:0,zIndex:30,height:56,padding:'0 16px',
+        display:'flex',alignItems:'center',gap:10,
+        background:'var(--header-bg)',backdropFilter:'blur(18px)',
+        WebkitBackdropFilter:'blur(18px)',borderBottom:'1px solid var(--border)',
+      }}>
+        <div style={{
+          width:24,height:24,borderRadius:6,background:'var(--primary)',color:'#fff',
+          display:'flex',alignItems:'center',justifyContent:'center',
+          fontSize:11,fontWeight:700,letterSpacing:-0.3,
+        }}>KH</div>
+        <div style={{fontSize:15,fontWeight:600,color:'var(--foreground)',letterSpacing:-0.2}}>{title}</div>
+        <div style={{flex:1}}/>
+        <IconBtn icon={Search} />
+        <IconBtn icon={Sun} />
+      </div>
+    );
+
+    const DetailHeader = () => (
+      <div style={{
+        position:'sticky',top:0,zIndex:30,height:56,padding:'0 8px 0 4px',
+        display:'flex',alignItems:'center',gap:4,
+        background:'var(--header-bg)',backdropFilter:'blur(18px)',
+        WebkitBackdropFilter:'blur(18px)',borderBottom:'1px solid var(--border)',
+      }}>
+        <IconBtn icon={Back} />
+        <div style={{fontSize:13,fontWeight:500,color:'var(--muted)',letterSpacing:-0.1}}>Library</div>
+        <div style={{flex:1}}/>
+        <IconBtn icon={More} />
+      </div>
+    );
+
+    const BottomNav = () => {
+      const items = [['home','Home',Home],['search','Search',Search],['library','Library',Lib],['ops','Ops',Ops]];
+      return (
+        <div style={{
+          position:'absolute',left:0,right:0,bottom:0,height:64,
+          borderTop:'1px solid var(--border)',background:'var(--nav-bg)',
+          backdropFilter:'blur(20px)',WebkitBackdropFilter:'blur(20px)',
+          display:'flex',zIndex:30,
+        }}>
+          {items.map(([id,label,Ic],i)=>{
+            const on = i===0;
+            return (
+              <button key={id} style={{
+                flex:1,display:'flex',flexDirection:'column',alignItems:'center',
+                justifyContent:'center',gap:3,
+                color: on?'var(--primary)':'var(--muted)',
+              }}>
+                <Ic s={20} sw={on?2:1.6} />
+                <span style={{fontSize:11,fontWeight:on?600:500,letterSpacing:0.1,lineHeight:1}}>{label}</span>
+              </button>
+            );
+          })}
+        </div>
+      );
+    };
+
+    const ChipStrip = ({ items, active }) => (
+      <div className="kh-scroll-x">
+        <div style={{display:'flex',gap:6,padding:'0 16px'}}>
+          {items.map((label, i) => {
+            const on = label === active;
+            return (
+              <span key={label} style={{
+                flexShrink:0,height:28,padding:'0 12px',borderRadius:14,
+                display:'inline-flex',alignItems:'center',
+                fontSize:12,fontWeight:500,letterSpacing:'-0.1px',
+                background: on?'var(--primary-tint)':'var(--pill-bg)',
+                color: on?'var(--primary)':'var(--muted)',
+                border:`1px solid ${on?'transparent':'var(--border)'}`,
+              }}>{label}</span>
+            );
+          })}
+        </div>
+      </div>
+    );
+
+    const KVGrid = ({ items }) => (
+      <div style={{
+        padding:12,background:'var(--card)',border:'1px solid var(--border)',
+        borderRadius:12,display:'grid',gridTemplateColumns:'1fr 1fr',gap:'10px 16px',
+      }}>
+        {items.map(([k,v]) => (
+          <div key={k}>
+            <div style={{fontSize:10,color:'var(--muted-dim)',letterSpacing:'0.6px',
+                         textTransform:'uppercase',fontWeight:600}}>{k}</div>
+            <div style={{fontSize:13,color:'var(--foreground-dim)',marginTop:2,letterSpacing:-0.1}}>{v}</div>
+          </div>
+        ))}
+      </div>
+    );
+
+    const Quote = ({ children }) => (
+      <blockquote style={{
+        margin:0,padding:'10px 14px',borderLeft:'2px solid var(--primary)',
+        background:'var(--card)',borderRadius:'0 12px 12px 0',
+        fontSize:14,fontStyle:'italic',lineHeight:1.55,
+        color:'var(--foreground-dim)',letterSpacing:-0.1,
+      }}>{children}</blockquote>
+    );
+
+    const Callout = ({ tone='info', title, children }) => {
+      const accent = { info:'var(--info)', success:'var(--success)',
+        warning:'var(--warning)', danger:'var(--danger)', primary:'var(--primary)' }[tone];
+      return (
+        <div style={{
+          padding:12,background:'var(--card)',border:'1px solid var(--border)',
+          borderLeft:`2px solid ${accent}`,borderRadius:12,
+          fontSize:13,lineHeight:1.55,color:'var(--foreground-dim)',letterSpacing:-0.1,
+        }}>
+          {title && <div style={{fontSize:13,fontWeight:600,color:'var(--foreground)',marginBottom:4}}>{title}</div>}
+          {children}
+        </div>
+      );
+    };
+
+    /* ── Sections ──────────────────────────────────── */
+    function Spec() {
+      return (
+        <>
+          {/* Overview */}
+          <section id="overview" className="ds-section">
+            <h1>Knowledge Hub Design System</h1>
+            <p className="ds-lede">
+              Dark-first, quiet operational UI. Compact information density, restrained
+              indigo primary, no marketing-style hero/card-heavy layouts. Tokens cover
+              surfaces, text hierarchy, borders, focus rings, status colors, spacing,
+              radius, shadows, and density. Components work in both list and detail
+              views without creating a second visual language.
+            </p>
+            <div className="ds-grid ds-grid-3">
+              <Card><div style={{fontSize:12,color:'var(--muted)',marginBottom:6,letterSpacing:0.8,textTransform:'uppercase',fontWeight:600}}>Stack</div>
+                <div style={{fontSize:13,color:'var(--foreground-dim)',lineHeight:1.55}}>
+                  Next.js (app router) · plain CSS variables · CSS modules · lucide-react · Inter + Geist Mono
+                </div></Card>
+              <Card><div style={{fontSize:12,color:'var(--muted)',marginBottom:6,letterSpacing:0.8,textTransform:'uppercase',fontWeight:600}}>Themes</div>
+                <div style={{fontSize:13,color:'var(--foreground-dim)',lineHeight:1.55}}>
+                  Default = system preference. Manual toggle persists to localStorage and overrides via <code className="ds-code">data-theme</code>.
+                </div></Card>
+              <Card><div style={{fontSize:12,color:'var(--muted)',marginBottom:6,letterSpacing:0.8,textTransform:'uppercase',fontWeight:600}}>Naming</div>
+                <div style={{fontSize:13,color:'var(--foreground-dim)',lineHeight:1.55}}>
+                  shadcn-style: <code className="ds-code">--background</code>, <code className="ds-code">--foreground</code>, <code className="ds-code">--primary</code>, <code className="ds-code">--muted</code>.
+                </div></Card>
+            </div>
+          </section>
+
+          {/* Colors */}
+          <section id="colors" className="ds-section">
+            <h1>Colors</h1>
+            <p className="ds-lede">Toggle the theme up top to see all swatches re-render. Values come live from <code className="ds-code">tokens.css</code>.</p>
+            {COLOR_TOKENS.map(({ group, items }) => (
+              <div key={group}>
+                <h2 className="ds-h2">{group}</h2>
+                <div className="ds-grid ds-grid-auto">
+                  {items.map(([n, d]) => <Swatch key={n} name={n} desc={d} />)}
+                </div>
+              </div>
+            ))}
+          </section>
+
+          {/* Typography */}
+          <section id="typography" className="ds-section">
+            <h1>Typography</h1>
+            <p className="ds-lede">Inter for everything; Geist Mono reserved for IDs, timestamps, code, and ops surfaces. Dial-down letter spacing on titles.</p>
+
+            <h2 className="ds-h2">Type scale</h2>
+            <div className="ds-card">
+              {[
+                ['--text-4xl', 32, 'tight', 'Knowledge Hub'],
+                ['--text-3xl', 24, 'tight', 'Building agent orchestration'],
+                ['--text-2xl', 20, 'snug', 'Section header'],
+                ['--text-xl', 17, 'snug', 'Card title'],
+                ['--text-lg', 15, 'snug', 'Header title'],
+                ['--text-md', 14, 'normal', 'Body — long-form analysis paragraph.'],
+                ['--text-base', 13, 'normal', 'Default UI text · button label'],
+                ['--text-sm', 12, 'normal', 'Meta · timestamps · authors'],
+                ['--text-xs', 11, 'wide', 'EYEBROW · UPPERCASE LABEL'],
+                ['--text-2xs', 10, 'wide', 'KV KEY · MICRO-LABEL'],
+              ].map(([n, px, lh, sample]) => (
+                <div className="ds-row" key={n}>
+                  <span className="var">{n}</span>
+                  <span className="val">{px}px</span>
+                  <span className="preview" style={{
+                    fontSize: px,
+                    letterSpacing: px>=20?-0.4:px>=15?-0.2:px>=13?-0.1:0.1,
+                    fontWeight: px>=20?650:px>=15?600:500,
+                    color: px<=11 ? 'var(--muted)' : 'var(--foreground-dim)',
+                    textTransform: px<=11 ? 'uppercase' : 'none',
+                  }}>{sample}</span>
+                </div>
+              ))}
+            </div>
+
+            <h2 className="ds-h2">Mono surface</h2>
+            <div className="ds-preview">
+              <div style={{fontFamily:'var(--font-mono)',fontSize:13,color:'var(--foreground-dim)'}}>
+                42:08 · 8,240 words · processed 2026-04-15
+              </div>
+            </div>
+          </section>
+
+          {/* Spacing */}
+          <section id="spacing" className="ds-section">
+            <h1>Spacing</h1>
+            <p className="ds-lede">4px base. Stay on this scale for everything — gaps, padding, margins.</p>
+            <div className="ds-card" style={{padding:16}}>
+              {[
+                ['--space-1',4],['--space-2',8],['--space-3',10],['--space-4',12],
+                ['--space-5',14],['--space-6',16],['--space-7',20],['--space-8',24],
+                ['--space-9',28],['--space-10',32],['--space-12',40],['--space-14',48],
+                ['--space-16',64],
+              ].map(([n,v]) => (
+                <div className="ds-spacer-row" key={n}>
+                  <div className="label">{n}</div>
+                  <div className="bar" style={{ width: v }} />
+                  <div className="px">{v}px</div>
+                </div>
+              ))}
+            </div>
+
+            <h2 className="ds-h2">Density</h2>
+            <p style={{fontSize:13,color:'var(--muted)',margin:'0 0 8px'}}>
+              List rows and hit targets. <code className="ds-code">--hit-min</code> is the floor for any tap target on mobile.
+            </p>
+            <div className="ds-grid ds-grid-3">
+              <Card><div style={{fontSize:11,color:'var(--muted)',letterSpacing:0.8,textTransform:'uppercase',fontWeight:600,marginBottom:8}}>Compact</div>
+                <div style={{fontFamily:'var(--font-mono)',fontSize:12,color:'var(--foreground-dim)'}}>--row-compact · 44px</div>
+                <div style={{height:44,marginTop:8,background:'var(--pill-bg)',borderRadius:6}}/></Card>
+              <Card><div style={{fontSize:11,color:'var(--muted)',letterSpacing:0.8,textTransform:'uppercase',fontWeight:600,marginBottom:8}}>Default</div>
+                <div style={{fontFamily:'var(--font-mono)',fontSize:12,color:'var(--foreground-dim)'}}>--row-default · 56px</div>
+                <div style={{height:56,marginTop:8,background:'var(--pill-bg)',borderRadius:6}}/></Card>
+              <Card><div style={{fontSize:11,color:'var(--muted)',letterSpacing:0.8,textTransform:'uppercase',fontWeight:600,marginBottom:8}}>Loose</div>
+                <div style={{fontFamily:'var(--font-mono)',fontSize:12,color:'var(--foreground-dim)'}}>--row-loose · 72px</div>
+                <div style={{height:72,marginTop:8,background:'var(--pill-bg)',borderRadius:6}}/></Card>
+            </div>
+          </section>
+
+          {/* Radius */}
+          <section id="radius" className="ds-section">
+            <h1>Radius</h1>
+            <p className="ds-lede">Cards & sheets at <code className="ds-code">12</code>. Buttons at <code className="ds-code">8–10</code>. Pills full-round.</p>
+            <div className="ds-card" style={{display:'flex',flexWrap:'wrap',padding:8}}>
+              {[['xs',4],['sm',6],['md',8],['lg',10],['xl',12],['2xl',16],['full',9999]].map(([k,v]) => (
+                <div className="ds-radius-cell" key={k}>
+                  <div className="ds-radius-tile" style={{borderRadius: v === 9999 ? 9999 : v}} />
+                  <div className="label">--radius-{k} · {v}px</div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* Shadows & layers */}
+          <section id="shadows" className="ds-section">
+            <h1>Shadows &amp; layers</h1>
+            <p className="ds-lede">Borders carry weight; shadows are reserved for the FAB and modal layer.</p>
+            <div className="ds-grid ds-grid-3">
+              {[['xs','--shadow-xs'],['sm','--shadow-sm'],['md','--shadow-md'],['lg','--shadow-lg'],['fab','--shadow-fab']].map(([k,n])=>(
+                <div key={k} style={{padding:24,background:'var(--card)',border:'1px solid var(--border)',borderRadius:12,
+                  display:'flex',flexDirection:'column',alignItems:'center',gap:12}}>
+                  <div style={{width:96,height:48,background:'var(--card)',border:'1px solid var(--border)',borderRadius:10,boxShadow:`var(${n})`}}/>
+                  <div style={{fontFamily:'var(--font-mono)',fontSize:11,color:'var(--muted)'}}>{n}</div>
+                </div>
+              ))}
+            </div>
+            <h2 className="ds-h2">Z-layers</h2>
+            <div className="ds-card">
+              {[['--z-base',0],['--z-sticky',30],['--z-fab',40],['--z-overlay',60],['--z-modal',70],['--z-toast',80]].map(([n,v])=>(
+                <div className="ds-row" key={n} style={{gridTemplateColumns:'200px 80px 1fr'}}>
+                  <span className="var">{n}</span><span className="val">{v}</span>
+                  <span style={{fontSize:13,color:'var(--foreground-dim)'}}>{
+                    {0:'page content',30:'sticky headers / bottom nav',40:'FAB',60:'sheets / dropdowns',70:'modals',80:'toasts'}[v]
+                  }</span>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* Motion */}
+          <section id="motion" className="ds-section">
+            <h1>Motion</h1>
+            <p className="ds-lede">Two easings, four durations. Respect <code className="ds-code">prefers-reduced-motion</code> (handled in globals.css).</p>
+            <div className="ds-card">
+              {[
+                ['--duration-1','80ms','tap feedback, color flicks'],
+                ['--duration-2','140ms','hover, button press'],
+                ['--duration-3','220ms','sheet open, popover'],
+                ['--duration-4','320ms','page transitions'],
+              ].map(([n,v,d])=>(
+                <div className="ds-row" key={n}><span className="var">{n}</span><span className="val">{v}</span><span style={{fontSize:13,color:'var(--foreground-dim)'}}>{d}</span></div>
+              ))}
+            </div>
+          </section>
+
+          {/* Buttons */}
+          <section id="buttons" className="ds-section">
+            <h1>Button &amp; IconButton</h1>
+            <p className="ds-lede">Primary for the single most-important action per surface. Outline for secondary; ghost for utility/header chrome.</p>
+            <div className="ds-preview">
+              <Button variant="primary" icon={Sparkle}>Create skill</Button>
+              <Button variant="outline" icon={Ext}>YouTube</Button>
+              <Button variant="ghost">Cancel</Button>
+              <Button variant="danger">Delete</Button>
+            </div>
+            <div className="ds-preview-label"><div className="dot"/><div className="name">sizes</div></div>
+            <div className="ds-preview">
+              <Button variant="primary" size="sm">sm · 28</Button>
+              <Button variant="primary" size="md">md · 32</Button>
+              <Button variant="primary" size="lg">lg · 44</Button>
+            </div>
+            <div className="ds-preview-label"><div className="dot"/><div className="name">icon-only</div></div>
+            <div className="ds-preview">
+              <IconBtn icon={Search}/><IconBtn icon={Sun}/><IconBtn icon={More}/><IconBtn icon={Back}/>
+            </div>
+            <pre className="ds-pre">{`<Button variant="primary" icon={Sparkle}>Create skill</Button>
+<IconButton icon={Search} label="Search" />`}</pre>
+          </section>
+
+          {/* Pills */}
+          <section id="pills" className="ds-section">
+            <h1>Pill &amp; Tag</h1>
+            <p className="ds-lede">Status, kind, count chips. <code className="ds-code">Tag</code> is a Pill with a # prefix for topics.</p>
+            <div className="ds-preview">
+              <Pill>neutral</Pill>
+              <Pill tone="primary" active>active</Pill>
+              <Pill tone="success">done</Pill>
+              <Pill tone="info">processing</Pill>
+              <Pill tone="warning">queued</Pill>
+              <Pill tone="danger">failed</Pill>
+            </div>
+            <div className="ds-preview">
+              <Pill>#agents</Pill>
+              <Pill>#langgraph</Pill>
+              <Pill>#orchestration</Pill>
+              <Pill>#tooling</Pill>
+            </div>
+          </section>
+
+          {/* ChipStrip */}
+          <section id="chipstrip" className="ds-section">
+            <h1>ChipStrip</h1>
+            <p className="ds-lede">Horizontal scrollable. Single-active. Used for in-page TOC and filter rows.</p>
+            <div className="ds-preview col" style={{padding:16}}>
+              <ChipStrip
+                items={['Summary','Takeaways','Things','Quotes','Tools','Screenshots','Transcript']}
+                active="Summary"/>
+            </div>
+          </section>
+
+          {/* Cards */}
+          <section id="cards" className="ds-section">
+            <h1>Card</h1>
+            <p className="ds-lede">Neutral surface. Compose cards with internal sections — don't nest cards inside cards.</p>
+            <div className="ds-preview">
+              <Card style={{width:320}}>
+                <div style={{fontSize:11,color:'var(--muted)',fontWeight:500,letterSpacing:0.1,marginBottom:8}}>
+                  Article · <span style={{color:'var(--success)'}}>done</span>
+                </div>
+                <div style={{fontSize:15,fontWeight:600,color:'var(--foreground)',letterSpacing:-0.2,marginBottom:6}}>
+                  Context engineering is the new prompt engineering
+                </div>
+                <div style={{fontSize:13,lineHeight:1.45,color:'var(--muted)'}}>
+                  A tour through why the “prompt” abstraction is dissolving into long-form context curation.
+                </div>
+              </Card>
+            </div>
+          </section>
+
+          {/* Sections */}
+          <section id="sections" className="ds-section">
+            <h1>SectionLabel &amp; DetailSection</h1>
+            <p className="ds-lede">Eyebrow labels above content groups. <code className="ds-code">SectionLabel</code> for list pages, <code className="ds-code">DetailSection</code> for inner detail pages.</p>
+            <div className="ds-preview col" style={{padding:0}}>
+              <div style={{padding:'16px 0'}}>
+                <SectionLabel label="Videos" count="24 total" />
+                <Card style={{margin:'0 16px'}}>Card 1</Card>
+                <SectionLabel label="Other knowledge" count="12 sources" />
+                <Card style={{margin:'0 16px'}}>Card 2</Card>
+              </div>
+            </div>
+            <div className="ds-preview-label"><div className="dot"/><div className="name">DetailSection</div></div>
+            <div className="ds-preview col" style={{padding:0}}>
+              <div style={{padding:'4px 0 24px'}}>
+                <DetailSection label="Key takeaways" trailing={<span style={{fontSize:11,color:'var(--muted-dim)'}}>3 items</span>}>
+                  <ul style={{margin:0,padding:0,listStyle:'none',display:'flex',flexDirection:'column',gap:10}}>
+                    {['State graphs beat prompt chains.','Checkpoint the entire graph state.','Prefer typed handoffs over ReAct loops.'].map((s,i)=>(
+                      <li key={i} style={{display:'flex',gap:10,fontSize:14,lineHeight:1.55,color:'var(--foreground-dim)'}}>
+                        <span style={{color:'var(--primary)',fontWeight:600}}>→</span><span>{s}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </DetailSection>
+              </div>
+            </div>
+          </section>
+
+          {/* Headers */}
+          <section id="headers" className="ds-section">
+            <h1>PageHeader &amp; DetailHeader</h1>
+            <p className="ds-lede">Both are 56px sticky bars with backdrop blur.</p>
+            <div className="ds-preview col" style={{padding:0}}>
+              <PageHeader title="Library" />
+              <div style={{padding:24,fontSize:13,color:'var(--muted)'}}>Page content scrolls beneath…</div>
+            </div>
+            <div className="ds-preview-label"><div className="dot"/><div className="name">DetailHeader</div></div>
+            <div className="ds-preview col" style={{padding:0}}>
+              <DetailHeader />
+              <div style={{padding:24,fontSize:13,color:'var(--muted)'}}>Detail content scrolls beneath…</div>
+            </div>
+          </section>
+
+          {/* BottomNav */}
+          <section id="bottomnav" className="ds-section">
+            <h1>BottomNav</h1>
+            <p className="ds-lede">Fixed 4-item nav. Active item uses <code className="ds-code">--primary</code>.</p>
+            <div className="ds-preview col" style={{padding:0,minHeight:120,position:'relative'}}>
+              <BottomNav />
+            </div>
+          </section>
+
+          {/* Display */}
+          <section id="display" className="ds-section">
+            <h1>KVGrid · Quote · Callout</h1>
+            <p className="ds-lede">Display primitives for detail pages.</p>
+            <h2 className="ds-h2">KVGrid</h2>
+            <div className="ds-preview col">
+              <KVGrid items={[['Type','article'],['Status','done'],['Created','Apr 12, 2026'],['Processed','Apr 12, 2026']]}/>
+            </div>
+            <h2 className="ds-h2">Quote</h2>
+            <div className="ds-preview col">
+              <Quote>“The mistake people make is treating the agent as the program. The graph is the program. The model is just one of the functions you call.”</Quote>
+            </div>
+            <h2 className="ds-h2">Callout</h2>
+            <div className="ds-preview col">
+              <Callout tone="info" title="Heads up">Processing usually takes under a minute. You'll see this row turn green when it's done.</Callout>
+              <Callout tone="success" title="Queued">Will queue for processing — you'll see it in Library instantly.</Callout>
+              <Callout tone="warning" title="Slow source">This site frequently rate-limits scrapers. Expect ~3 minutes.</Callout>
+              <Callout tone="danger" title="Failed">Couldn't fetch this URL. Open it manually and try paste-as-text.</Callout>
+            </div>
+          </section>
+
+          {/* Composition */}
+          <section id="composition" className="ds-section">
+            <h1>List → detail composition</h1>
+            <p className="ds-lede">A whole detail page should feel like a single thoughtful document — header, hero, meta, action bar, TOC, then sections separated by eyebrow labels.</p>
+            <div className="ds-preview" style={{padding:24,justifyContent:'center'}}>
+              <div className="ds-phone">
+                <DetailHeader />
+                <div style={{height:'calc(100% - 56px - 64px)',overflow:'hidden',padding:'8px 0 16px'}}>
+                  <div style={{padding:'8px 16px 0'}}>
+                    <div style={{aspectRatio:'16 / 9',borderRadius:12,
+                      background:'linear-gradient(135deg, var(--thumb), var(--thumb-accent))',
+                      position:'relative',overflow:'hidden'}}>
+                      <div style={{position:'absolute',inset:0,
+                        backgroundImage:'repeating-linear-gradient(135deg, transparent 0 11px, var(--border) 11px 12px)',
+                        opacity:0.6}}/>
+                    </div>
+                  </div>
+                  <div style={{padding:'14px 16px 0'}}>
+                    <h1 style={{margin:0,fontSize:18,fontWeight:650,letterSpacing:-0.4,
+                                color:'var(--foreground)',lineHeight:1.25}}>
+                      Building agent orchestration with LangGraph
+                    </h1>
+                    <div style={{marginTop:8,fontSize:12,color:'var(--muted)'}}>Latent Space · Apr 14</div>
+                  </div>
+                  <div style={{padding:'14px 16px 0',display:'flex',gap:8}}>
+                    <Button variant="primary" size="md" icon={Sparkle}>Create skill</Button>
+                    <Button variant="outline" size="md" icon={Ext}>YouTube</Button>
+                  </div>
+                  <div style={{marginTop:18}}>
+                    <ChipStrip items={['Summary','Takeaways','Tools','Quotes']} active="Summary"/>
+                  </div>
+                  <DetailSection label="Summary">
+                    <p style={{margin:0,fontSize:13,lineHeight:1.6,color:'var(--foreground-dim)',letterSpacing:-0.1}}>
+                      A ground-up walkthrough of stateful agent graphs — how to design nodes, edges, and checkpoints so workflows remain debuggable when tools start failing.
+                    </p>
+                  </DetailSection>
+                </div>
+                <BottomNav />
+              </div>
+            </div>
+          </section>
+
+          {/* Install */}
+          <section id="install" className="ds-section">
+            <h1>Install</h1>
+            <p className="ds-lede">Drop the folder into your Next.js app and import from it.</p>
+            <pre className="ds-pre">{`# 1. Copy the folder
+cp -R design-system src/
+
+# 2. Install runtime deps
+pnpm add lucide-react geist
+
+# 3. In app/layout.tsx
+import "@/design-system/globals.css";
+import { Inter } from "next/font/google";
+import { GeistMono } from "geist/font/mono";
+import { ThemeProvider } from "@/design-system/components";
+
+const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body className={\`\${inter.variable} \${GeistMono.variable}\`}>
+        <ThemeProvider>{children}</ThemeProvider>
+      </body>
+    </html>
+  );
+}`}</pre>
+            <h2 className="ds-h2">Wire next/font into the tokens</h2>
+            <p style={{fontSize:13,color:'var(--muted)',margin:'0 0 8px'}}>
+              In <code className="ds-code">tokens.css</code>, swap the bare family names for next/font CSS variables:
+            </p>
+            <pre className="ds-pre">{`:root {
+  --font-sans: var(--font-inter), -apple-system, system-ui, sans-serif;
+  --font-mono: var(--font-geist-mono), ui-monospace, Menlo, monospace;
+}`}</pre>
+          </section>
+
+          <div style={{height:120}}/>
+        </>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<Spec/>);
+  </script>
+</body>
+</html>

--- a/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/design-system/tokens.css
+++ b/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/design-system/tokens.css
@@ -1,0 +1,224 @@
+/* ============================================================
+   Knowledge Hub — Design Tokens
+   Plain CSS variables, shadcn-style naming.
+   Dark-first; light theme via [data-theme="light"] override.
+   System preference is the default; manual toggle wins.
+   ============================================================ */
+
+:root,
+[data-theme="dark"] {
+  /* ── Surfaces ──────────────────────────────────────── */
+  --background:        #08090a;   /* page bg */
+  --background-elev:   #0c0d0f;   /* elevated bg (sheets, sticky bars) */
+  --card:              #0f1011;   /* card / list-row surface */
+  --card-hover:        #131417;
+  --popover:           #0c0d0f;
+
+  /* ── Foreground / text ────────────────────────────── */
+  --foreground:        #f7f8f8;   /* primary text */
+  --foreground-dim:    #c7c9cd;   /* body / secondary */
+  --muted:             #8a8f98;   /* meta, labels */
+  --muted-dim:         #5b5f66;   /* tertiary, timestamps */
+
+  /* ── Borders & rings ─────────────────────────────── */
+  --border:            rgba(255,255,255,0.08);
+  --border-strong:     rgba(255,255,255,0.14);
+  --ring:              rgba(94,106,210,0.55);
+
+  /* ── Brand / primary ─────────────────────────────── */
+  --primary:           #5e6ad2;
+  --primary-foreground:#ffffff;
+  --primary-tint:      rgba(94,106,210,0.14);
+  --primary-tint-strong: rgba(94,106,210,0.22);
+
+  /* ── Status ──────────────────────────────────────── */
+  --success:           #7dd3a0;
+  --info:              #82c7ff;
+  --warning:           #f0c674;
+  --danger:            #e5736e;
+
+  /* ── Component-specific surfaces ─────────────────── */
+  --pill-bg:           rgba(255,255,255,0.04);
+  --nav-bg:            rgba(8,9,10,0.72);
+  --header-bg:         rgba(8,9,10,0.78);
+  --thumb:             #16181c;
+  --thumb-accent:      #1c1f26;
+  --scrim:             rgba(0,0,0,0.4);
+
+  /* ── Selection ──────────────────────────────────── */
+  --selection-bg:      rgba(94,106,210,0.35);
+  --selection-fg:      #ffffff;
+
+  color-scheme: dark;
+}
+
+[data-theme="light"] {
+  --background:        #f7f8f8;
+  --background-elev:   #ffffff;
+  --card:              #ffffff;
+  --card-hover:        #fafafa;
+  --popover:           #ffffff;
+
+  --foreground:        #1a1a1e;
+  --foreground-dim:    #3a3a40;
+  --muted:             #62666d;
+  --muted-dim:         #8f9399;
+
+  --border:            #e6e6e6;
+  --border-strong:     #d1d1d1;
+  --ring:              rgba(94,106,210,0.45);
+
+  --primary:           #5e6ad2;
+  --primary-foreground:#ffffff;
+  --primary-tint:      rgba(94,106,210,0.10);
+  --primary-tint-strong: rgba(94,106,210,0.18);
+
+  --success:           #2e9b65;
+  --info:              #2563c9;
+  --warning:           #b97f12;
+  --danger:            #c0382f;
+
+  --pill-bg:           #f1f2f3;
+  --nav-bg:            rgba(247,248,248,0.82);
+  --header-bg:         rgba(247,248,248,0.85);
+  --thumb:             #e9eaec;
+  --thumb-accent:      #dfe1e4;
+  --scrim:             rgba(20,22,28,0.32);
+
+  --selection-bg:      rgba(94,106,210,0.22);
+  --selection-fg:      #1a1a1e;
+
+  color-scheme: light;
+}
+
+/* System-preference fallback (only when no explicit data-theme) */
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme]) {
+    --background:        #f7f8f8;
+    --background-elev:   #ffffff;
+    --card:              #ffffff;
+    --card-hover:        #fafafa;
+    --popover:           #ffffff;
+
+    --foreground:        #1a1a1e;
+    --foreground-dim:    #3a3a40;
+    --muted:             #62666d;
+    --muted-dim:         #8f9399;
+
+    --border:            #e6e6e6;
+    --border-strong:     #d1d1d1;
+    --ring:              rgba(94,106,210,0.45);
+
+    --primary-tint:      rgba(94,106,210,0.10);
+    --primary-tint-strong: rgba(94,106,210,0.18);
+
+    --success:           #2e9b65;
+    --info:              #2563c9;
+    --warning:           #b97f12;
+    --danger:            #c0382f;
+
+    --pill-bg:           #f1f2f3;
+    --nav-bg:            rgba(247,248,248,0.82);
+    --header-bg:         rgba(247,248,248,0.85);
+    --thumb:             #e9eaec;
+    --thumb-accent:      #dfe1e4;
+    --scrim:             rgba(20,22,28,0.32);
+
+    --selection-bg:      rgba(94,106,210,0.22);
+    --selection-fg:      #1a1a1e;
+
+    color-scheme: light;
+  }
+}
+
+:root {
+  /* ── Type ────────────────────────────────────────── */
+  --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI",
+               system-ui, sans-serif;
+  --font-mono: "Geist Mono", "JetBrains Mono", ui-monospace, SFMono-Regular,
+               Menlo, Consolas, monospace;
+  --font-feature-settings: "cv01", "ss03";
+
+  /* type scale (px values; pair with line-heights below) */
+  --text-2xs: 10px;
+  --text-xs:  11px;
+  --text-sm:  12px;
+  --text-base:13px;
+  --text-md:  14px;
+  --text-lg:  15px;
+  --text-xl:  17px;
+  --text-2xl: 20px;
+  --text-3xl: 24px;
+  --text-4xl: 32px;
+
+  --leading-tight:   1.25;
+  --leading-snug:    1.4;
+  --leading-normal:  1.55;
+  --leading-relaxed: 1.65;
+
+  --tracking-tight: -0.4px;   /* h1 */
+  --tracking-snug:  -0.2px;   /* titles */
+  --tracking-flat:  -0.1px;   /* body */
+  --tracking-wide:   0.1px;   /* meta */
+  --tracking-caps:   0.8px;   /* uppercase labels */
+
+  /* ── Spacing (4px base) ─────────────────────────── */
+  --space-0:  0;
+  --space-1:  4px;
+  --space-2:  8px;
+  --space-3:  10px;
+  --space-4:  12px;
+  --space-5:  14px;
+  --space-6:  16px;
+  --space-7:  20px;
+  --space-8:  24px;
+  --space-9:  28px;
+  --space-10: 32px;
+  --space-12: 40px;
+  --space-14: 48px;
+  --space-16: 64px;
+
+  /* ── Radius ─────────────────────────────────────── */
+  --radius-xs:    4px;
+  --radius-sm:    6px;
+  --radius-md:    8px;
+  --radius-lg:    10px;
+  --radius-xl:    12px;
+  --radius-2xl:   16px;
+  --radius-full:  9999px;
+
+  /* ── Density (list rows, hit targets) ───────────── */
+  --row-compact:  44px;
+  --row-default:  56px;
+  --row-loose:    72px;
+  --hit-min:      44px;   /* mobile hit-target floor */
+
+  /* ── Shadows (used sparingly) ───────────────────── */
+  --shadow-xs:    0 1px 2px rgba(0,0,0,0.18);
+  --shadow-sm:    0 2px 6px rgba(0,0,0,0.22);
+  --shadow-md:    0 8px 20px rgba(0,0,0,0.30);
+  --shadow-lg:    0 18px 40px rgba(0,0,0,0.40);
+  --shadow-fab:   0 8px 20px rgba(94,106,210,0.35), 0 2px 4px rgba(0,0,0,0.20);
+  --shadow-fab-pressed: 0 2px 8px rgba(94,106,210,0.45), 0 0 0 6px rgba(94,106,210,0.18);
+
+  /* ── Layers ─────────────────────────────────────── */
+  --z-base:      0;
+  --z-sticky:    30;
+  --z-fab:       40;
+  --z-overlay:   60;
+  --z-modal:     70;
+  --z-toast:     80;
+
+  /* ── Motion ─────────────────────────────────────── */
+  --ease-out:     cubic-bezier(0.2, 0.7, 0.2, 1);
+  --ease-in-out:  cubic-bezier(0.65, 0, 0.35, 1);
+  --duration-1:   80ms;
+  --duration-2:   140ms;
+  --duration-3:   220ms;
+  --duration-4:   320ms;
+
+  /* ── Backdrop blur ──────────────────────────────── */
+  --blur-sm: 12px;
+  --blur-md: 18px;
+  --blur-lg: 24px;
+}

--- a/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/design-system/tokens.ts
+++ b/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/design-system/tokens.ts
@@ -1,0 +1,155 @@
+/**
+ * Knowledge Hub — Typed token module
+ *
+ * Mirrors `tokens.css`. Use these from TypeScript when you need
+ * tokens at runtime (animation values, inline styles, canvas, etc.).
+ *
+ * In CSS / className contexts prefer the variables directly:
+ *   color: var(--foreground)
+ *
+ * To read a token at runtime against the active theme:
+ *   getComputedStyle(document.documentElement).getPropertyValue('--primary')
+ */
+
+export const palette = {
+  // Brand
+  primary:        "#5e6ad2",
+  primaryFg:      "#ffffff",
+
+  // Status (dark-theme values; light overrides via CSS vars)
+  success:        "#7dd3a0",
+  info:           "#82c7ff",
+  warning:        "#f0c674",
+  danger:         "#e5736e",
+} as const;
+
+export const themes = {
+  dark: {
+    background:       "#08090a",
+    backgroundElev:   "#0c0d0f",
+    card:             "#0f1011",
+    cardHover:        "#131417",
+    foreground:       "#f7f8f8",
+    foregroundDim:    "#c7c9cd",
+    muted:            "#8a8f98",
+    mutedDim:         "#5b5f66",
+    border:           "rgba(255,255,255,0.08)",
+    borderStrong:     "rgba(255,255,255,0.14)",
+    pillBg:           "rgba(255,255,255,0.04)",
+    navBg:            "rgba(8,9,10,0.72)",
+    headerBg:         "rgba(8,9,10,0.78)",
+    thumb:            "#16181c",
+    thumbAccent:      "#1c1f26",
+    scrim:            "rgba(0,0,0,0.4)",
+  },
+  light: {
+    background:       "#f7f8f8",
+    backgroundElev:   "#ffffff",
+    card:             "#ffffff",
+    cardHover:        "#fafafa",
+    foreground:       "#1a1a1e",
+    foregroundDim:    "#3a3a40",
+    muted:            "#62666d",
+    mutedDim:         "#8f9399",
+    border:           "#e6e6e6",
+    borderStrong:     "#d1d1d1",
+    pillBg:           "#f1f2f3",
+    navBg:            "rgba(247,248,248,0.82)",
+    headerBg:         "rgba(247,248,248,0.85)",
+    thumb:            "#e9eaec",
+    thumbAccent:      "#dfe1e4",
+    scrim:            "rgba(20,22,28,0.32)",
+  },
+} as const;
+
+export type ThemeName = keyof typeof themes;
+export type ThemeTokens = typeof themes.dark;
+
+export const fonts = {
+  sans: '"Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+  mono: '"Geist Mono", "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+  featureSettings: '"cv01", "ss03"',
+} as const;
+
+export const text = {
+  size: {
+    "2xs": 10, xs: 11, sm: 12, base: 13, md: 14,
+    lg: 15, xl: 17, "2xl": 20, "3xl": 24, "4xl": 32,
+  },
+  leading: { tight: 1.25, snug: 1.4, normal: 1.55, relaxed: 1.65 },
+  tracking: { tight: -0.4, snug: -0.2, flat: -0.1, wide: 0.1, caps: 0.8 },
+} as const;
+
+export const space = {
+  0: 0, 1: 4, 2: 8, 3: 10, 4: 12, 5: 14, 6: 16,
+  7: 20, 8: 24, 9: 28, 10: 32, 12: 40, 14: 48, 16: 64,
+} as const;
+
+export const radius = {
+  xs: 4, sm: 6, md: 8, lg: 10, xl: 12, "2xl": 16, full: 9999,
+} as const;
+
+export const density = {
+  rowCompact: 44,
+  rowDefault: 56,
+  rowLoose: 72,
+  hitMin: 44,
+} as const;
+
+export const shadows = {
+  xs:  "0 1px 2px rgba(0,0,0,0.18)",
+  sm:  "0 2px 6px rgba(0,0,0,0.22)",
+  md:  "0 8px 20px rgba(0,0,0,0.30)",
+  lg:  "0 18px 40px rgba(0,0,0,0.40)",
+  fab: "0 8px 20px rgba(94,106,210,0.35), 0 2px 4px rgba(0,0,0,0.2)",
+  fabPressed: "0 2px 8px rgba(94,106,210,0.45), 0 0 0 6px rgba(94,106,210,0.18)",
+} as const;
+
+export const z = {
+  base: 0, sticky: 30, fab: 40, overlay: 60, modal: 70, toast: 80,
+} as const;
+
+export const motion = {
+  ease: {
+    out: "cubic-bezier(0.2, 0.7, 0.2, 1)",
+    inOut: "cubic-bezier(0.65, 0, 0.35, 1)",
+  },
+  duration: { 1: 80, 2: 140, 3: 220, 4: 320 },
+} as const;
+
+export const blur = { sm: 12, md: 18, lg: 24 } as const;
+
+/** CSS variable names — use with `var(NAME)` in styles. */
+export const cssVar = {
+  background:        "--background",
+  backgroundElev:    "--background-elev",
+  card:              "--card",
+  cardHover:         "--card-hover",
+  popover:           "--popover",
+  foreground:        "--foreground",
+  foregroundDim:     "--foreground-dim",
+  muted:             "--muted",
+  mutedDim:          "--muted-dim",
+  border:            "--border",
+  borderStrong:      "--border-strong",
+  ring:              "--ring",
+  primary:           "--primary",
+  primaryForeground: "--primary-foreground",
+  primaryTint:       "--primary-tint",
+  primaryTintStrong: "--primary-tint-strong",
+  success:           "--success",
+  info:              "--info",
+  warning:           "--warning",
+  danger:            "--danger",
+  pillBg:            "--pill-bg",
+  navBg:             "--nav-bg",
+  headerBg:          "--header-bg",
+  thumb:             "--thumb",
+  thumbAccent:       "--thumb-accent",
+  scrim:             "--scrim",
+} as const;
+
+export type CssVarKey = keyof typeof cssVar;
+
+/** Helper: `v("primary")` → `"var(--primary)"` */
+export const v = (key: CssVarKey): string => `var(${cssVar[key]})`;

--- a/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/lib/design-canvas.jsx
+++ b/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/lib/design-canvas.jsx
@@ -1,0 +1,626 @@
+
+// DesignCanvas.jsx — Figma-ish design canvas wrapper
+// Warm gray grid bg + Sections + Artboards + PostIt notes.
+// Artboards are reorderable (grip-drag), labels/titles are inline-editable,
+// and any artboard can be opened in a fullscreen focus overlay (←/→/Esc).
+// State persists to a .design-canvas.state.json sidecar via the host
+// bridge. No assets, no deps.
+//
+// Usage:
+//   <DesignCanvas>
+//     <DCSection id="onboarding" title="Onboarding" subtitle="First-run variants">
+//       <DCArtboard id="a" label="A · Dusk" width={260} height={480}>…</DCArtboard>
+//       <DCArtboard id="b" label="B · Minimal" width={260} height={480}>…</DCArtboard>
+//     </DCSection>
+//   </DesignCanvas>
+
+const DC = {
+  bg: '#f0eee9',
+  grid: 'rgba(0,0,0,0.06)',
+  label: 'rgba(60,50,40,0.7)',
+  title: 'rgba(40,30,20,0.85)',
+  subtitle: 'rgba(60,50,40,0.6)',
+  postitBg: '#fef4a8',
+  postitText: '#5a4a2a',
+  font: '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+};
+
+// One-time CSS injection (classes are dc-prefixed so they don't collide with
+// the hosted design's own styles).
+if (typeof document !== 'undefined' && !document.getElementById('dc-styles')) {
+  const s = document.createElement('style');
+  s.id = 'dc-styles';
+  s.textContent = [
+    '.dc-editable{cursor:text;outline:none;white-space:nowrap;border-radius:3px;padding:0 2px;margin:0 -2px}',
+    '.dc-editable:focus{background:#fff;box-shadow:0 0 0 1.5px #c96442}',
+    '[data-dc-slot]{transition:transform .18s cubic-bezier(.2,.7,.3,1)}',
+    '[data-dc-slot].dc-dragging{transition:none;z-index:10;pointer-events:none}',
+    '[data-dc-slot].dc-dragging .dc-card{box-shadow:0 12px 40px rgba(0,0,0,.25),0 0 0 2px #c96442;transform:scale(1.02)}',
+    '.dc-card{transition:box-shadow .15s,transform .15s}',
+    '.dc-card *{scrollbar-width:none}',
+    '.dc-card *::-webkit-scrollbar{display:none}',
+    '.dc-labelrow{display:flex;align-items:center;gap:4px;height:24px}',
+    '.dc-grip{cursor:grab;display:flex;align-items:center;padding:5px 4px;border-radius:4px;transition:background .12s}',
+    '.dc-grip:hover{background:rgba(0,0,0,.08)}',
+    '.dc-grip:active{cursor:grabbing}',
+    '.dc-labeltext{cursor:pointer;border-radius:4px;padding:3px 6px;display:flex;align-items:center;transition:background .12s}',
+    '.dc-labeltext:hover{background:rgba(0,0,0,.05)}',
+    '.dc-expand{position:absolute;bottom:100%;right:0;margin-bottom:5px;z-index:2;opacity:0;transition:opacity .12s,background .12s;',
+    '  width:22px;height:22px;border-radius:5px;border:none;cursor:pointer;padding:0;',
+    '  background:transparent;color:rgba(60,50,40,.7);display:flex;align-items:center;justify-content:center}',
+    '.dc-expand:hover{background:rgba(0,0,0,.06);color:#2a251f}',
+    '[data-dc-slot]:hover .dc-expand{opacity:1}',
+  ].join('\n');
+  document.head.appendChild(s);
+}
+
+const DCCtx = React.createContext(null);
+
+// ─────────────────────────────────────────────────────────────
+// DesignCanvas — stateful wrapper around the pan/zoom viewport.
+// Owns runtime state (per-section order, renamed titles/labels, focused
+// artboard). Order/titles/labels persist to a .design-canvas.state.json
+// sidecar next to the HTML. Reads go via plain fetch() so the saved
+// arrangement is visible anywhere the HTML + sidecar are served together
+// (omelette preview, direct link, downloaded zip). Writes go through the
+// host's window.omelette bridge — editing requires the omelette runtime.
+// Focus is ephemeral.
+// ─────────────────────────────────────────────────────────────
+const DC_STATE_FILE = '.design-canvas.state.json';
+
+function DesignCanvas({ children, minScale, maxScale, style }) {
+  const [state, setState] = React.useState({ sections: {}, focus: null });
+  const [themeMode, setThemeMode] = React.useState('dark');
+  // Hold rendering until the sidecar read settles so the saved order/titles
+  // appear on first paint (no source-order flash). didRead gates writes until
+  // the read settles so the empty initial state can't clobber a slow read;
+  // skipNextWrite suppresses the one echo-write that would otherwise follow
+  // hydration.
+  const [ready, setReady] = React.useState(false);
+  const didRead = React.useRef(false);
+  const skipNextWrite = React.useRef(false);
+
+  React.useEffect(() => {
+    let off = false;
+    fetch('./' + DC_STATE_FILE)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((saved) => {
+        if (off || !saved || !saved.sections) return;
+        skipNextWrite.current = true;
+        setState((s) => ({ ...s, sections: saved.sections }));
+      })
+      .catch(() => {})
+      .finally(() => { didRead.current = true; if (!off) setReady(true); });
+    const t = setTimeout(() => { if (!off) setReady(true); }, 150);
+    return () => { off = true; clearTimeout(t); };
+  }, []);
+
+  React.useEffect(() => {
+    if (!didRead.current) return;
+    if (skipNextWrite.current) { skipNextWrite.current = false; return; }
+    const t = setTimeout(() => {
+      window.omelette?.writeFile(DC_STATE_FILE, JSON.stringify({ sections: state.sections })).catch(() => {});
+    }, 250);
+    return () => clearTimeout(t);
+  }, [state.sections]);
+
+  // Build registries synchronously from children so FocusOverlay can read
+  // them in the same render. Only direct DCSection > DCArtboard children are
+  // walked — wrapping them in other elements opts out of focus/reorder.
+  const registry = {};     // slotId -> { sectionId, artboard }
+  const sectionMeta = {};  // sectionId -> { title, subtitle, slotIds[] }
+  const sectionOrder = [];
+  React.Children.forEach(children, (sec) => {
+    if (!sec || sec.type !== DCSection) return;
+    const sid = sec.props.id ?? sec.props.title;
+    if (!sid) return;
+    sectionOrder.push(sid);
+    const persisted = state.sections[sid] || {};
+    const srcIds = [];
+    React.Children.forEach(sec.props.children, (ab) => {
+      if (!ab || ab.type !== DCArtboard) return;
+      const aid = ab.props.id ?? ab.props.label;
+      if (!aid) return;
+      registry[`${sid}/${aid}`] = { sectionId: sid, artboard: ab };
+      srcIds.push(aid);
+    });
+    const kept = (persisted.order || []).filter((k) => srcIds.includes(k));
+    sectionMeta[sid] = {
+      title: persisted.title ?? sec.props.title,
+      subtitle: sec.props.subtitle,
+      slotIds: [...kept, ...srcIds.filter((k) => !kept.includes(k))],
+    };
+  });
+
+  const api = React.useMemo(() => ({
+    state,
+    section: (id) => state.sections[id] || {},
+    patchSection: (id, p) => setState((s) => ({
+      ...s,
+      sections: { ...s.sections, [id]: { ...s.sections[id], ...(typeof p === 'function' ? p(s.sections[id] || {}) : p) } },
+    })),
+    setFocus: (slotId) => setState((s) => ({ ...s, focus: slotId })),
+    themeMode,
+    setThemeMode,
+    toggleTheme: () => setThemeMode((m) => (m === 'dark' ? 'light' : 'dark')),
+  }), [state, themeMode]);
+
+  // Esc exits focus; any outside pointerdown commits an in-progress rename.
+  React.useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') api.setFocus(null); };
+    const onPd = (e) => {
+      const ae = document.activeElement;
+      if (ae && ae.isContentEditable && !ae.contains(e.target)) ae.blur();
+    };
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('pointerdown', onPd, true);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('pointerdown', onPd, true);
+    };
+  }, [api]);
+
+  return (
+    <DCCtx.Provider value={api}>
+      <DCViewport minScale={minScale} maxScale={maxScale} dataMode={themeMode} style={style}>{ready && children}</DCViewport>
+      {state.focus && registry[state.focus] && (
+        <DCFocusOverlay entry={registry[state.focus]} sectionMeta={sectionMeta} sectionOrder={sectionOrder} />
+      )}
+    </DCCtx.Provider>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCViewport — transform-based pan/zoom (internal)
+//
+// Input mapping (Figma-style):
+//   • trackpad pinch  → zoom   (ctrlKey wheel; Safari gesture* events)
+//   • trackpad scroll → pan    (two-finger)
+//   • mouse wheel     → zoom   (notched; distinguished from trackpad scroll)
+//   • middle-drag / primary-drag-on-bg → pan
+//
+// Transform state lives in a ref and is written straight to the DOM
+// (translate3d + will-change) so wheel ticks don't go through React —
+// keeps pans at 60fps on dense canvases.
+// ─────────────────────────────────────────────────────────────
+function DCViewport({ children, minScale = 0.1, maxScale = 8, dataMode = 'dark', style = {} }) {
+  const vpRef = React.useRef(null);
+  const worldRef = React.useRef(null);
+  const tf = React.useRef({ x: 0, y: 0, scale: 1 });
+
+  const apply = React.useCallback(() => {
+    const { x, y, scale } = tf.current;
+    const el = worldRef.current;
+    if (el) el.style.transform = `translate3d(${x}px, ${y}px, 0) scale(${scale})`;
+  }, []);
+
+  React.useEffect(() => {
+    const vp = vpRef.current;
+    if (!vp) return;
+
+    const zoomAt = (cx, cy, factor) => {
+      const r = vp.getBoundingClientRect();
+      const px = cx - r.left, py = cy - r.top;
+      const t = tf.current;
+      const next = Math.min(maxScale, Math.max(minScale, t.scale * factor));
+      const k = next / t.scale;
+      // keep the world point under the cursor fixed
+      t.x = px - (px - t.x) * k;
+      t.y = py - (py - t.y) * k;
+      t.scale = next;
+      apply();
+    };
+
+    // Mouse-wheel vs trackpad-scroll heuristic. A physical wheel sends
+    // line-mode deltas (Firefox) or large integer pixel deltas with no X
+    // component (Chrome/Safari, typically multiples of 100/120). Trackpad
+    // two-finger scroll sends small/fractional pixel deltas, often with
+    // non-zero deltaX. ctrlKey is set by the browser for trackpad pinch.
+    const isMouseWheel = (e) =>
+      e.deltaMode !== 0 ||
+      (e.deltaX === 0 && Number.isInteger(e.deltaY) && Math.abs(e.deltaY) >= 40);
+
+    const onWheel = (e) => {
+      e.preventDefault();
+      if (isGesturing) return; // Safari: gesture* owns the pinch — discard concurrent wheels
+      if (e.ctrlKey) {
+        // trackpad pinch (or explicit ctrl+wheel)
+        zoomAt(e.clientX, e.clientY, Math.exp(-e.deltaY * 0.01));
+      } else if (isMouseWheel(e)) {
+        // notched mouse wheel — fixed-ratio step per click
+        zoomAt(e.clientX, e.clientY, Math.exp(-Math.sign(e.deltaY) * 0.18));
+      } else {
+        // trackpad two-finger scroll — pan
+        tf.current.x -= e.deltaX;
+        tf.current.y -= e.deltaY;
+        apply();
+      }
+    };
+
+    // Safari sends native gesture* events for trackpad pinch with a smooth
+    // e.scale; preferring these over the ctrl+wheel fallback gives a much
+    // better feel there. No-ops on other browsers. Safari also fires
+    // ctrlKey wheel events during the same pinch — isGesturing makes
+    // onWheel drop those entirely so they neither zoom nor pan.
+    let gsBase = 1;
+    let isGesturing = false;
+    const onGestureStart = (e) => { e.preventDefault(); isGesturing = true; gsBase = tf.current.scale; };
+    const onGestureChange = (e) => {
+      e.preventDefault();
+      zoomAt(e.clientX, e.clientY, (gsBase * e.scale) / tf.current.scale);
+    };
+    const onGestureEnd = (e) => { e.preventDefault(); isGesturing = false; };
+
+    // Drag-pan: middle button anywhere, or primary button on canvas
+    // background (anything that isn't an artboard or an inline editor).
+    let drag = null;
+    const onPointerDown = (e) => {
+      const onBg = !e.target.closest('[data-dc-slot], .dc-editable');
+      if (!(e.button === 1 || (e.button === 0 && onBg))) return;
+      e.preventDefault();
+      vp.setPointerCapture(e.pointerId);
+      drag = { id: e.pointerId, lx: e.clientX, ly: e.clientY };
+      vp.style.cursor = 'grabbing';
+    };
+    const onPointerMove = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      tf.current.x += e.clientX - drag.lx;
+      tf.current.y += e.clientY - drag.ly;
+      drag.lx = e.clientX; drag.ly = e.clientY;
+      apply();
+    };
+    const onPointerUp = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      vp.releasePointerCapture(e.pointerId);
+      drag = null;
+      vp.style.cursor = '';
+    };
+
+    vp.addEventListener('wheel', onWheel, { passive: false });
+    vp.addEventListener('gesturestart', onGestureStart, { passive: false });
+    vp.addEventListener('gesturechange', onGestureChange, { passive: false });
+    vp.addEventListener('gestureend', onGestureEnd, { passive: false });
+    vp.addEventListener('pointerdown', onPointerDown);
+    vp.addEventListener('pointermove', onPointerMove);
+    vp.addEventListener('pointerup', onPointerUp);
+    vp.addEventListener('pointercancel', onPointerUp);
+    return () => {
+      vp.removeEventListener('wheel', onWheel);
+      vp.removeEventListener('gesturestart', onGestureStart);
+      vp.removeEventListener('gesturechange', onGestureChange);
+      vp.removeEventListener('gestureend', onGestureEnd);
+      vp.removeEventListener('pointerdown', onPointerDown);
+      vp.removeEventListener('pointermove', onPointerMove);
+      vp.removeEventListener('pointerup', onPointerUp);
+      vp.removeEventListener('pointercancel', onPointerUp);
+    };
+  }, [apply, minScale, maxScale]);
+
+  const gridSvg = `url("data:image/svg+xml,%3Csvg width='120' height='120' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M120 0H0v120' fill='none' stroke='${encodeURIComponent(DC.grid)}' stroke-width='1'/%3E%3C/svg%3E")`;
+  return (
+    <div
+      ref={vpRef}
+      className="design-canvas"
+      data-theme={dataMode}
+      style={{
+        height: '100vh', width: '100vw',
+        background: DC.bg,
+        overflow: 'hidden',
+        overscrollBehavior: 'none',
+        touchAction: 'none',
+        position: 'relative',
+        fontFamily: DC.font,
+        boxSizing: 'border-box',
+        ...style,
+      }}
+    >
+      <div
+        ref={worldRef}
+        style={{
+          position: 'absolute', top: 0, left: 0,
+          transformOrigin: '0 0',
+          willChange: 'transform',
+          width: 'max-content', minWidth: '100%',
+          minHeight: '100%',
+          padding: '60px 0 80px',
+        }}
+      >
+        <div style={{ position: 'absolute', inset: -6000, backgroundImage: gridSvg, backgroundSize: '120px 120px', pointerEvents: 'none', zIndex: -1 }} />
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCSection — editable title + h-row of artboards in persisted order
+// ─────────────────────────────────────────────────────────────
+function DCSection({ id, title, subtitle, children, gap = 48 }) {
+  const ctx = React.useContext(DCCtx);
+  const sid = id ?? title;
+  const all = React.Children.toArray(children);
+  const artboards = all.filter((c) => c && c.type === DCArtboard);
+  const rest = all.filter((c) => !(c && c.type === DCArtboard));
+  const srcOrder = artboards.map((a) => a.props.id ?? a.props.label);
+  const sec = (ctx && sid && ctx.section(sid)) || {};
+
+  const order = React.useMemo(() => {
+    const kept = (sec.order || []).filter((k) => srcOrder.includes(k));
+    return [...kept, ...srcOrder.filter((k) => !kept.includes(k))];
+  }, [sec.order, srcOrder.join('|')]);
+
+  const byId = Object.fromEntries(artboards.map((a) => [a.props.id ?? a.props.label, a]));
+
+  return (
+    <div data-dc-section={sid} style={{ marginBottom: 80, position: 'relative' }}>
+      <div style={{ padding: '0 60px 56px' }}>
+        <DCEditable tag="div" value={sec.title ?? title}
+          onChange={(v) => ctx && sid && ctx.patchSection(sid, { title: v })}
+          style={{ fontSize: 28, fontWeight: 600, color: DC.title, letterSpacing: -0.4, marginBottom: 6, display: 'inline-block' }} />
+        {subtitle && <div style={{ fontSize: 16, color: DC.subtitle }}>{subtitle}</div>}
+      </div>
+      <div style={{ display: 'flex', gap, padding: '0 60px', alignItems: 'flex-start', width: 'max-content' }}>
+        {order.map((k) => (
+          <DCArtboardFrame key={k} sectionId={sid} artboard={byId[k]} order={order}
+            label={(sec.labels || {})[k] ?? byId[k].props.label}
+            onRename={(v) => ctx && ctx.patchSection(sid, (x) => ({ labels: { ...x.labels, [k]: v } }))}
+            onReorder={(next) => ctx && ctx.patchSection(sid, { order: next })}
+            onFocus={() => ctx && ctx.setFocus(`${sid}/${k}`)} />
+        ))}
+      </div>
+      {rest}
+    </div>
+  );
+}
+
+// DCArtboard — marker; rendered by DCArtboardFrame via DCSection.
+function DCArtboard() { return null; }
+
+function DCArtboardFrame({ sectionId, artboard, label, order, onRename, onReorder, onFocus }) {
+  const { id: rawId, label: rawLabel, width = 260, height = 480, children, style = {} } = artboard.props;
+  const id = rawId ?? rawLabel;
+  const ref = React.useRef(null);
+
+  // Live drag-reorder: dragged card sticks to cursor; siblings slide into
+  // their would-be slots in real time via transforms. DOM order only
+  // changes on drop.
+  const onGripDown = (e) => {
+    e.preventDefault(); e.stopPropagation();
+    const me = ref.current;
+    // translateX is applied in local (pre-scale) space but pointer deltas and
+    // getBoundingClientRect().left are screen-space — divide by the viewport's
+    // current scale so the dragged card tracks the cursor at any zoom level.
+    const scale = me.getBoundingClientRect().width / me.offsetWidth || 1;
+    const peers = Array.from(document.querySelectorAll(`[data-dc-section="${sectionId}"] [data-dc-slot]`));
+    const homes = peers.map((el) => ({ el, id: el.dataset.dcSlot, x: el.getBoundingClientRect().left }));
+    const slotXs = homes.map((h) => h.x);
+    const startIdx = order.indexOf(id);
+    const startX = e.clientX;
+    let liveOrder = order.slice();
+    me.classList.add('dc-dragging');
+
+    const layout = () => {
+      for (const h of homes) {
+        if (h.id === id) continue;
+        const slot = liveOrder.indexOf(h.id);
+        h.el.style.transform = `translateX(${(slotXs[slot] - h.x) / scale}px)`;
+      }
+    };
+
+    const move = (ev) => {
+      const dx = ev.clientX - startX;
+      me.style.transform = `translateX(${dx / scale}px)`;
+      const cur = homes[startIdx].x + dx;
+      let nearest = 0, best = Infinity;
+      for (let i = 0; i < slotXs.length; i++) {
+        const d = Math.abs(slotXs[i] - cur);
+        if (d < best) { best = d; nearest = i; }
+      }
+      if (liveOrder.indexOf(id) !== nearest) {
+        liveOrder = order.filter((k) => k !== id);
+        liveOrder.splice(nearest, 0, id);
+        layout();
+      }
+    };
+
+    const up = () => {
+      document.removeEventListener('pointermove', move);
+      document.removeEventListener('pointerup', up);
+      const finalSlot = liveOrder.indexOf(id);
+      me.classList.remove('dc-dragging');
+      me.style.transform = `translateX(${(slotXs[finalSlot] - homes[startIdx].x) / scale}px)`;
+      // After the settle transition, kill transitions + clear transforms +
+      // commit the reorder in the same frame so there's no visual snap-back.
+      setTimeout(() => {
+        for (const h of homes) { h.el.style.transition = 'none'; h.el.style.transform = ''; }
+        if (liveOrder.join('|') !== order.join('|')) onReorder(liveOrder);
+        requestAnimationFrame(() => requestAnimationFrame(() => {
+          for (const h of homes) h.el.style.transition = '';
+        }));
+      }, 180);
+    };
+    document.addEventListener('pointermove', move);
+    document.addEventListener('pointerup', up);
+  };
+
+  return (
+    <div ref={ref} data-dc-slot={id} style={{ position: 'relative', flexShrink: 0 }}>
+      <div className="dc-labelrow" style={{ position: 'absolute', bottom: '100%', left: -4, marginBottom: 4, color: DC.label }}>
+        <div className="dc-grip" onPointerDown={onGripDown} title="Drag to reorder">
+          <svg width="9" height="13" viewBox="0 0 9 13" fill="currentColor"><circle cx="2" cy="2" r="1.1"/><circle cx="7" cy="2" r="1.1"/><circle cx="2" cy="6.5" r="1.1"/><circle cx="7" cy="6.5" r="1.1"/><circle cx="2" cy="11" r="1.1"/><circle cx="7" cy="11" r="1.1"/></svg>
+        </div>
+        <div className="dc-labeltext" onClick={onFocus} title="Click to focus">
+          <DCEditable value={label} onChange={onRename} onClick={(e) => e.stopPropagation()}
+            style={{ fontSize: 15, fontWeight: 500, color: DC.label, lineHeight: 1 }} />
+        </div>
+      </div>
+      <button className="dc-expand" onClick={onFocus} onPointerDown={(e) => e.stopPropagation()} title="Focus">
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"><path d="M7 1h4v4M5 11H1V7M11 1L7.5 4.5M1 11l3.5-3.5"/></svg>
+      </button>
+      <div className="dc-card"
+        style={{ borderRadius: 2, boxShadow: '0 1px 3px rgba(0,0,0,.08),0 4px 16px rgba(0,0,0,.06)', overflow: 'hidden', width, height, background: '#fff', ...style }}>
+        {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb', fontSize: 13, fontFamily: DC.font }}>{id}</div>}
+      </div>
+    </div>
+  );
+}
+
+// Inline rename — commits on blur or Enter.
+function DCEditable({ value, onChange, style, tag = 'span', onClick }) {
+  const T = tag;
+  return (
+    <T className="dc-editable" contentEditable suppressContentEditableWarning
+      onClick={onClick}
+      onPointerDown={(e) => e.stopPropagation()}
+      onBlur={(e) => onChange && onChange(e.currentTarget.textContent)}
+      onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); e.currentTarget.blur(); } }}
+      style={style}>{value}</T>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Focus mode — overlay one artboard; ←/→ within section, ↑/↓ across
+// sections, Esc or backdrop click to exit.
+// ─────────────────────────────────────────────────────────────
+function DCFocusOverlay({ entry, sectionMeta, sectionOrder }) {
+  const ctx = React.useContext(DCCtx);
+  const { sectionId, artboard } = entry;
+  const sec = ctx.section(sectionId);
+  const meta = sectionMeta[sectionId];
+  const peers = meta.slotIds;
+  const aid = artboard.props.id ?? artboard.props.label;
+  const idx = peers.indexOf(aid);
+  const secIdx = sectionOrder.indexOf(sectionId);
+
+  const go = (d) => { const n = peers[(idx + d + peers.length) % peers.length]; if (n) ctx.setFocus(`${sectionId}/${n}`); };
+  const goSection = (d) => {
+    const ns = sectionOrder[(secIdx + d + sectionOrder.length) % sectionOrder.length];
+    const first = sectionMeta[ns] && sectionMeta[ns].slotIds[0];
+    if (first) ctx.setFocus(`${ns}/${first}`);
+  };
+
+  React.useEffect(() => {
+    const k = (e) => {
+      if (e.key === 'ArrowLeft') { e.preventDefault(); go(-1); }
+      if (e.key === 'ArrowRight') { e.preventDefault(); go(1); }
+      if (e.key === 'ArrowUp') { e.preventDefault(); goSection(-1); }
+      if (e.key === 'ArrowDown') { e.preventDefault(); goSection(1); }
+    };
+    document.addEventListener('keydown', k);
+    return () => document.removeEventListener('keydown', k);
+  });
+
+  const { width = 260, height = 480, children } = artboard.props;
+  const [vp, setVp] = React.useState({ w: window.innerWidth, h: window.innerHeight });
+  React.useEffect(() => { const r = () => setVp({ w: window.innerWidth, h: window.innerHeight }); window.addEventListener('resize', r); return () => window.removeEventListener('resize', r); }, []);
+  const scale = Math.max(0.1, Math.min((vp.w - 200) / width, (vp.h - 260) / height, 2));
+
+  const [ddOpen, setDd] = React.useState(false);
+  const Arrow = ({ dir, onClick }) => (
+    <button onClick={(e) => { e.stopPropagation(); onClick(); }}
+      style={{ position: 'absolute', top: '50%', [dir]: 28, transform: 'translateY(-50%)',
+        border: 'none', background: 'rgba(255,255,255,.08)', color: 'rgba(255,255,255,.9)',
+        width: 44, height: 44, borderRadius: 22, fontSize: 18, cursor: 'pointer',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'background .15s' }}
+      onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.18)')}
+      onMouseLeave={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.08)')}>
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+        <path d={dir === 'left' ? 'M11 3L5 9l6 6' : 'M7 3l6 6-6 6'} /></svg>
+    </button>
+  );
+
+  // Portal to body so position:fixed is the real viewport regardless of any
+  // transform on DesignCanvas's ancestors (including the canvas zoom itself).
+  return ReactDOM.createPortal(
+    <div onClick={() => ctx.setFocus(null)}
+      onWheel={(e) => e.preventDefault()}
+      style={{ position: 'fixed', inset: 0, zIndex: 100, background: 'rgba(24,20,16,.6)', backdropFilter: 'blur(14px)',
+        fontFamily: DC.font, color: '#fff' }}>
+
+      {/* top bar: section dropdown (left) · close (right) */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', top: 0, left: 0, right: 0, height: 72, display: 'flex', alignItems: 'flex-start', padding: '16px 20px 0', gap: 16 }}>
+        <div style={{ position: 'relative' }}>
+          <button onClick={() => setDd((o) => !o)}
+            style={{ border: 'none', background: 'transparent', color: '#fff', cursor: 'pointer', padding: '6px 8px',
+              borderRadius: 6, textAlign: 'left', fontFamily: 'inherit' }}>
+            <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span style={{ fontSize: 18, fontWeight: 600, letterSpacing: -0.3 }}>{meta.title}</span>
+              <svg width="11" height="11" viewBox="0 0 11 11" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" style={{ opacity: .7 }}><path d="M2 4l3.5 3.5L9 4"/></svg>
+            </span>
+            {meta.subtitle && <span style={{ display: 'block', fontSize: 13, opacity: .6, fontWeight: 400, marginTop: 2 }}>{meta.subtitle}</span>}
+          </button>
+          {ddOpen && (
+            <div style={{ position: 'absolute', top: '100%', left: 0, marginTop: 4, background: '#2a251f', borderRadius: 8,
+              boxShadow: '0 8px 32px rgba(0,0,0,.4)', padding: 4, minWidth: 200, zIndex: 10 }}>
+              {sectionOrder.map((sid) => (
+                <button key={sid} onClick={() => { setDd(false); const f = sectionMeta[sid].slotIds[0]; if (f) ctx.setFocus(`${sid}/${f}`); }}
+                  style={{ display: 'block', width: '100%', textAlign: 'left', border: 'none', cursor: 'pointer',
+                    background: sid === sectionId ? 'rgba(255,255,255,.1)' : 'transparent', color: '#fff',
+                    padding: '8px 12px', borderRadius: 5, fontSize: 14, fontWeight: sid === sectionId ? 600 : 400, fontFamily: 'inherit' }}>
+                  {sectionMeta[sid].title}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        <div style={{ flex: 1 }} />
+        <button onClick={() => ctx.setFocus(null)}
+          onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.12)')}
+          onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+          style={{ border: 'none', background: 'transparent', color: 'rgba(255,255,255,.7)', width: 32, height: 32,
+            borderRadius: 16, fontSize: 20, cursor: 'pointer', lineHeight: 1, transition: 'background .12s' }}>×</button>
+      </div>
+
+      {/* card centered, label + index below — only the card itself stops
+          propagation so any backdrop click (including the margins around
+          the card) exits focus */}
+      <div
+        style={{ position: 'absolute', top: 64, bottom: 56, left: 100, right: 100, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 16 }}>
+        <div onClick={(e) => e.stopPropagation()} style={{ width: width * scale, height: height * scale, position: 'relative' }}>
+          <div style={{ width, height, transform: `scale(${scale})`, transformOrigin: 'top left', background: '#fff', borderRadius: 2, overflow: 'hidden',
+            boxShadow: '0 20px 80px rgba(0,0,0,.4)' }}>
+            {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb' }}>{aid}</div>}
+          </div>
+        </div>
+        <div onClick={(e) => e.stopPropagation()} style={{ fontSize: 14, fontWeight: 500, opacity: .85, textAlign: 'center' }}>
+          {(sec.labels || {})[aid] ?? artboard.props.label}
+          <span style={{ opacity: .5, marginLeft: 10, fontVariantNumeric: 'tabular-nums' }}>{idx + 1} / {peers.length}</span>
+        </div>
+      </div>
+
+      <Arrow dir="left" onClick={() => go(-1)} />
+      <Arrow dir="right" onClick={() => go(1)} />
+
+      {/* dots */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', bottom: 20, left: '50%', transform: 'translateX(-50%)', display: 'flex', gap: 8 }}>
+        {peers.map((p, i) => (
+          <button key={p} onClick={() => ctx.setFocus(`${sectionId}/${p}`)}
+            style={{ border: 'none', padding: 0, cursor: 'pointer', width: 6, height: 6, borderRadius: 3,
+              background: i === idx ? '#fff' : 'rgba(255,255,255,.3)' }} />
+        ))}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Post-it — absolute-positioned sticky note
+// ─────────────────────────────────────────────────────────────
+function DCPostIt({ children, top, left, right, bottom, rotate = -2, width = 180 }) {
+  return (
+    <div style={{
+      position: 'absolute', top, left, right, bottom, width,
+      background: DC.postitBg, padding: '14px 16px',
+      fontFamily: '"Comic Sans MS", "Marker Felt", "Segoe Print", cursive',
+      fontSize: 14, lineHeight: 1.4, color: DC.postitText,
+      boxShadow: '0 2px 8px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.08)',
+      transform: `rotate(${rotate}deg)`,
+      zIndex: 5,
+    }}>{children}</div>
+  );
+}
+
+Object.assign(window, { DesignCanvas, DCSection, DCArtboard, DCPostIt, DCCtx });

--- a/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/lib/ios-frame.jsx
+++ b/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/lib/ios-frame.jsx
@@ -1,0 +1,338 @@
+
+// iOS.jsx — Simplified iOS 26 (Liquid Glass) device frame
+// Based on the iOS 26 UI Kit + Figma status bar spec. No assets, no deps.
+// Exports: IOSDevice, IOSStatusBar, IOSNavBar, IOSGlassPill, IOSList, IOSListRow, IOSKeyboard
+
+// ─────────────────────────────────────────────────────────────
+// Status bar
+// ─────────────────────────────────────────────────────────────
+function IOSStatusBar({ dark = false, time = '9:41' }) {
+  const c = dark ? '#fff' : '#000';
+  return (
+    <div style={{
+      display: 'flex', gap: 154, alignItems: 'center', justifyContent: 'center',
+      padding: '21px 24px 19px', boxSizing: 'border-box',
+      position: 'relative', zIndex: 20, width: '100%',
+    }}>
+      <div style={{ flex: 1, height: 22, display: 'flex', alignItems: 'center', justifyContent: 'center', paddingTop: 1.5 }}>
+        <span style={{
+          fontFamily: '-apple-system, "SF Pro", system-ui', fontWeight: 590,
+          fontSize: 17, lineHeight: '22px', color: c,
+        }}>{time}</span>
+      </div>
+      <div style={{ flex: 1, height: 22, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7, paddingTop: 1, paddingRight: 1 }}>
+        <svg width="19" height="12" viewBox="0 0 19 12">
+          <rect x="0" y="7.5" width="3.2" height="4.5" rx="0.7" fill={c}/>
+          <rect x="4.8" y="5" width="3.2" height="7" rx="0.7" fill={c}/>
+          <rect x="9.6" y="2.5" width="3.2" height="9.5" rx="0.7" fill={c}/>
+          <rect x="14.4" y="0" width="3.2" height="12" rx="0.7" fill={c}/>
+        </svg>
+        <svg width="17" height="12" viewBox="0 0 17 12">
+          <path d="M8.5 3.2C10.8 3.2 12.9 4.1 14.4 5.6L15.5 4.5C13.7 2.7 11.2 1.5 8.5 1.5C5.8 1.5 3.3 2.7 1.5 4.5L2.6 5.6C4.1 4.1 6.2 3.2 8.5 3.2Z" fill={c}/>
+          <path d="M8.5 6.8C9.9 6.8 11.1 7.3 12 8.2L13.1 7.1C11.8 5.9 10.2 5.1 8.5 5.1C6.8 5.1 5.2 5.9 3.9 7.1L5 8.2C5.9 7.3 7.1 6.8 8.5 6.8Z" fill={c}/>
+          <circle cx="8.5" cy="10.5" r="1.5" fill={c}/>
+        </svg>
+        <svg width="27" height="13" viewBox="0 0 27 13">
+          <rect x="0.5" y="0.5" width="23" height="12" rx="3.5" stroke={c} strokeOpacity="0.35" fill="none"/>
+          <rect x="2" y="2" width="20" height="9" rx="2" fill={c}/>
+          <path d="M25 4.5V8.5C25.8 8.2 26.5 7.2 26.5 6.5C26.5 5.8 25.8 4.8 25 4.5Z" fill={c} fillOpacity="0.4"/>
+        </svg>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Liquid glass pill — blur + tint + shine
+// ─────────────────────────────────────────────────────────────
+function IOSGlassPill({ children, dark = false, style = {} }) {
+  return (
+    <div style={{
+      height: 44, minWidth: 44, borderRadius: 9999,
+      position: 'relative', overflow: 'hidden',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      boxShadow: dark
+        ? '0 2px 6px rgba(0,0,0,0.35), 0 6px 16px rgba(0,0,0,0.2)'
+        : '0 1px 3px rgba(0,0,0,0.07), 0 3px 10px rgba(0,0,0,0.06)',
+      ...style,
+    }}>
+      {/* blur + tint */}
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 9999,
+        backdropFilter: 'blur(12px) saturate(180%)',
+        WebkitBackdropFilter: 'blur(12px) saturate(180%)',
+        background: dark ? 'rgba(120,120,128,0.28)' : 'rgba(255,255,255,0.5)',
+      }} />
+      {/* shine */}
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 9999,
+        boxShadow: dark
+          ? 'inset 1.5px 1.5px 1px rgba(255,255,255,0.15), inset -1px -1px 1px rgba(255,255,255,0.08)'
+          : 'inset 1.5px 1.5px 1px rgba(255,255,255,0.7), inset -1px -1px 1px rgba(255,255,255,0.4)',
+        border: dark ? '0.5px solid rgba(255,255,255,0.15)' : '0.5px solid rgba(0,0,0,0.06)',
+      }} />
+      <div style={{ position: 'relative', zIndex: 1, display: 'flex', alignItems: 'center', padding: '0 4px' }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Navigation bar — glass pills + large title
+// ─────────────────────────────────────────────────────────────
+function IOSNavBar({ title = 'Title', dark = false, trailingIcon = true }) {
+  const muted = dark ? 'rgba(255,255,255,0.6)' : '#404040';
+  const text = dark ? '#fff' : '#000';
+  const pillIcon = (content) => (
+    <IOSGlassPill dark={dark}>
+      <div style={{ width: 36, height: 36, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        {content}
+      </div>
+    </IOSGlassPill>
+  );
+  return (
+    <div style={{
+      display: 'flex', flexDirection: 'column', gap: 10,
+      paddingTop: 62, paddingBottom: 10, position: 'relative', zIndex: 5,
+    }}>
+      <div style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        padding: '0 16px',
+      }}>
+        {/* back chevron */}
+        {pillIcon(
+          <svg width="12" height="20" viewBox="0 0 12 20" fill="none" style={{ marginLeft: -1 }}>
+            <path d="M10 2L2 10l8 8" stroke={muted} strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+        )}
+        {/* trailing ellipsis */}
+        {trailingIcon && pillIcon(
+          <svg width="22" height="6" viewBox="0 0 22 6">
+            <circle cx="3" cy="3" r="2.5" fill={muted}/>
+            <circle cx="11" cy="3" r="2.5" fill={muted}/>
+            <circle cx="19" cy="3" r="2.5" fill={muted}/>
+          </svg>
+        )}
+      </div>
+      {/* large title */}
+      <div style={{
+        padding: '0 16px',
+        fontFamily: '-apple-system, system-ui',
+        fontSize: 34, fontWeight: 700, lineHeight: '41px',
+        color: text, letterSpacing: 0.4,
+      }}>{title}</div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Grouped list (inset card, r:26) + row (52px)
+// ─────────────────────────────────────────────────────────────
+function IOSListRow({ title, detail, icon, chevron = true, isLast = false, dark = false }) {
+  const text = dark ? '#fff' : '#000';
+  const sec = dark ? 'rgba(235,235,245,0.6)' : 'rgba(60,60,67,0.6)';
+  const ter = dark ? 'rgba(235,235,245,0.3)' : 'rgba(60,60,67,0.3)';
+  const sep = dark ? 'rgba(84,84,88,0.65)' : 'rgba(60,60,67,0.12)';
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', minHeight: 52,
+      padding: '0 16px', position: 'relative',
+      fontFamily: '-apple-system, system-ui', fontSize: 17,
+      letterSpacing: -0.43,
+    }}>
+      {icon && (
+        <div style={{
+          width: 30, height: 30, borderRadius: 7, background: icon,
+          marginRight: 12, flexShrink: 0,
+        }} />
+      )}
+      <div style={{ flex: 1, color: text }}>{title}</div>
+      {detail && <span style={{ color: sec, marginRight: 6 }}>{detail}</span>}
+      {chevron && (
+        <svg width="8" height="14" viewBox="0 0 8 14" style={{ flexShrink: 0 }}>
+          <path d="M1 1l6 6-6 6" stroke={ter} strokeWidth="2" fill="none" strokeLinecap="round" strokeLinejoin="round"/>
+        </svg>
+      )}
+      {!isLast && (
+        <div style={{
+          position: 'absolute', bottom: 0, right: 0,
+          left: icon ? 58 : 16, height: 0.5, background: sep,
+        }} />
+      )}
+    </div>
+  );
+}
+
+function IOSList({ header, children, dark = false }) {
+  const hc = dark ? 'rgba(235,235,245,0.6)' : 'rgba(60,60,67,0.6)';
+  const bg = dark ? '#1C1C1E' : '#fff';
+  return (
+    <div>
+      {header && (
+        <div style={{
+          fontFamily: '-apple-system, system-ui', fontSize: 13,
+          color: hc, textTransform: 'uppercase',
+          padding: '8px 36px 6px', letterSpacing: -0.08,
+        }}>{header}</div>
+      )}
+      <div style={{
+        background: bg, borderRadius: 26,
+        margin: '0 16px', overflow: 'hidden',
+      }}>{children}</div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Device frame
+// ─────────────────────────────────────────────────────────────
+function IOSDevice({
+  children, width = 402, height = 874, dark = false,
+  title, keyboard = false,
+}) {
+  return (
+    <div style={{
+      width, height, borderRadius: 48, overflow: 'hidden',
+      position: 'relative', background: dark ? '#000' : '#F2F2F7',
+      boxShadow: '0 40px 80px rgba(0,0,0,0.18), 0 0 0 1px rgba(0,0,0,0.12)',
+      fontFamily: '-apple-system, system-ui, sans-serif',
+      WebkitFontSmoothing: 'antialiased',
+    }}>
+      {/* dynamic island */}
+      <div style={{
+        position: 'absolute', top: 11, left: '50%', transform: 'translateX(-50%)',
+        width: 126, height: 37, borderRadius: 24, background: '#000', zIndex: 50,
+      }} />
+      {/* status bar (absolute) */}
+      <div style={{ position: 'absolute', top: 0, left: 0, right: 0, zIndex: 10 }}>
+        <IOSStatusBar dark={dark} />
+      </div>
+      {/* nav + content */}
+      <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+        {title !== undefined && <IOSNavBar title={title} dark={dark} />}
+        <div style={{ flex: 1, overflow: 'auto' }}>{children}</div>
+        {keyboard && <IOSKeyboard dark={dark} />}
+      </div>
+      {/* home indicator — always on top */}
+      <div style={{
+        position: 'absolute', bottom: 0, left: 0, right: 0, zIndex: 60,
+        height: 34, display: 'flex', justifyContent: 'center', alignItems: 'flex-end',
+        paddingBottom: 8, pointerEvents: 'none',
+      }}>
+        <div style={{
+          width: 139, height: 5, borderRadius: 100,
+          background: dark ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.25)',
+        }} />
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Keyboard — iOS 26 liquid glass
+// ─────────────────────────────────────────────────────────────
+function IOSKeyboard({ dark = false }) {
+  const glyph = dark ? 'rgba(255,255,255,0.7)' : '#595959';
+  const sugg = dark ? 'rgba(255,255,255,0.6)' : '#333';
+  const keyBg = dark ? 'rgba(255,255,255,0.22)' : 'rgba(255,255,255,0.85)';
+
+  // special-key icons
+  const icons = {
+    shift: <svg width="19" height="17" viewBox="0 0 19 17"><path d="M9.5 1L1 9.5h4.5V16h8V9.5H18L9.5 1z" fill={glyph}/></svg>,
+    del: <svg width="23" height="17" viewBox="0 0 23 17"><path d="M7 1h13a2 2 0 012 2v11a2 2 0 01-2 2H7l-6-7.5L7 1z" fill="none" stroke={glyph} strokeWidth="1.6" strokeLinejoin="round"/><path d="M10 5l7 7M17 5l-7 7" stroke={glyph} strokeWidth="1.6" strokeLinecap="round"/></svg>,
+    ret: <svg width="20" height="14" viewBox="0 0 20 14"><path d="M18 1v6H4m0 0l4-4M4 7l4 4" fill="none" stroke="#fff" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/></svg>,
+  };
+
+  const key = (content, { w, flex, ret, fs = 25, k } = {}) => (
+    <div key={k} style={{
+      height: 42, borderRadius: 8.5,
+      flex: flex ? 1 : undefined, width: w, minWidth: 0,
+      background: ret ? '#08f' : keyBg,
+      boxShadow: '0 1px 0 rgba(0,0,0,0.075)',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      fontFamily: '-apple-system, "SF Compact", system-ui',
+      fontSize: fs, fontWeight: 458, color: ret ? '#fff' : glyph,
+    }}>{content}</div>
+  );
+
+  const row = (keys, pad = 0) => (
+    <div style={{ display: 'flex', gap: 6.5, justifyContent: 'center', padding: `0 ${pad}px` }}>
+      {keys.map(l => key(l, { flex: true, k: l }))}
+    </div>
+  );
+
+  return (
+    <div style={{
+      position: 'relative', zIndex: 15, borderRadius: 27, overflow: 'hidden',
+      padding: '11px 0 2px',
+      display: 'flex', flexDirection: 'column', alignItems: 'center',
+      boxShadow: dark
+        ? '0 -2px 20px rgba(0,0,0,0.09)'
+        : '0 -1px 6px rgba(0,0,0,0.018), 0 -3px 20px rgba(0,0,0,0.012)',
+    }}>
+      {/* liquid glass bg — same recipe as nav pills */}
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 27,
+        backdropFilter: 'blur(12px) saturate(180%)',
+        WebkitBackdropFilter: 'blur(12px) saturate(180%)',
+        background: dark ? 'rgba(120,120,128,0.14)' : 'rgba(255,255,255,0.25)',
+      }} />
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 27,
+        boxShadow: dark
+          ? 'inset 1.5px 1.5px 1px rgba(255,255,255,0.15)'
+          : 'inset 1.5px 1.5px 1px rgba(255,255,255,0.7), inset -1px -1px 1px rgba(255,255,255,0.4)',
+        border: dark ? '0.5px solid rgba(255,255,255,0.15)' : '0.5px solid rgba(0,0,0,0.06)',
+        pointerEvents: 'none',
+      }} />
+
+      {/* autocorrect bar */}
+      <div style={{
+        display: 'flex', gap: 20, alignItems: 'center',
+        padding: '8px 22px 13px', width: '100%', boxSizing: 'border-box',
+        position: 'relative',
+      }}>
+        {['"The"', 'the', 'to'].map((w, i) => (
+          <React.Fragment key={i}>
+            {i > 0 && <div style={{ width: 1, height: 25, background: '#ccc', opacity: 0.3 }} />}
+            <div style={{
+              flex: 1, textAlign: 'center',
+              fontFamily: '-apple-system, system-ui', fontSize: 17,
+              color: sugg, letterSpacing: -0.43, lineHeight: '22px',
+            }}>{w}</div>
+          </React.Fragment>
+        ))}
+      </div>
+
+      {/* key layout */}
+      <div style={{
+        display: 'flex', flexDirection: 'column', gap: 13,
+        padding: '0 6.5px', width: '100%', boxSizing: 'border-box',
+        position: 'relative',
+      }}>
+        {row(['q','w','e','r','t','y','u','i','o','p'])}
+        {row(['a','s','d','f','g','h','j','k','l'], 20)}
+        <div style={{ display: 'flex', gap: 14.25, alignItems: 'center' }}>
+          {key(icons.shift, { w: 45, k: 'shift' })}
+          <div style={{ display: 'flex', gap: 6.5, flex: 1 }}>
+            {['z','x','c','v','b','n','m'].map(l => key(l, { flex: true, k: l }))}
+          </div>
+          {key(icons.del, { w: 45, k: 'del' })}
+        </div>
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          {key('ABC', { w: 92.25, fs: 18, k: 'abc' })}
+          {key('', { flex: true, k: 'space' })}
+          {key(icons.ret, { w: 92.25, ret: true, k: 'ret' })}
+        </div>
+      </div>
+
+      {/* bottom spacer (emoji+mic area, icons omitted) */}
+      <div style={{ height: 56, width: '100%', position: 'relative' }} />
+    </div>
+  );
+}
+
+Object.assign(window, {
+  IOSDevice, IOSStatusBar, IOSNavBar, IOSGlassPill, IOSList, IOSListRow, IOSKeyboard,
+});

--- a/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/lib/kh-annotated.jsx
+++ b/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/lib/kh-annotated.jsx
@@ -1,0 +1,164 @@
+// kh-annotated.jsx — annotated version of the library screen with callouts
+
+function AnnoLine({ from, to, stroke = '#c96442' }) {
+  // draw a line between two absolute coords in the parent SVG
+  return <line x1={from.x} y1={from.y} x2={to.x} y2={to.y} stroke={stroke} strokeWidth="1" strokeDasharray="3 3" />;
+}
+
+function Callout({ top, left, right, title, body, color = '#c96442' }) {
+  return (
+    <div style={{
+      position: 'absolute', top, left, right, width: 200,
+      fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+    }}>
+      <div style={{
+        fontSize: 11, fontWeight: 700, letterSpacing: 0.6, textTransform: 'uppercase',
+        color, marginBottom: 4,
+      }}>{title}</div>
+      <div style={{ fontSize: 12, lineHeight: 1.45, color: 'rgba(40,30,20,0.78)' }}>{body}</div>
+    </div>
+  );
+}
+
+// A single artboard: iOS frame with the Library screen + callouts around it
+function AnnotatedLibrary({ mode = 'dark' }) {
+  const deviceW = 390;
+  const deviceH = 760;
+  const totalW = 900;
+  const totalH = 900;
+  const devLeft = (totalW - deviceW) / 2;
+  const devTop = 60;
+
+  const dot = (x, y) => (
+    <div style={{
+      position: 'absolute', left: x - 4, top: y - 4,
+      width: 8, height: 8, borderRadius: 4,
+      background: '#c96442', boxShadow: '0 0 0 3px rgba(201,100,66,0.18)',
+    }} />
+  );
+
+  return (
+    <div style={{
+      width: totalW, height: totalH, position: 'relative',
+      background: '#f0eee9',
+      fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+    }}>
+      {/* connector lines behind everything */}
+      <svg width={totalW} height={totalH} style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}>
+        {/* Header → left callout */}
+        <path d={`M 260 98 L ${devLeft + 12} 98`} stroke="#c96442" strokeWidth="1" strokeDasharray="3 3" fill="none" />
+        {/* Section label → left */}
+        <path d={`M 260 200 L ${devLeft + 20} 200`} stroke="#c96442" strokeWidth="1" strokeDasharray="3 3" fill="none" />
+        {/* Section spacing → left */}
+        <path d={`M 260 340 L ${devLeft + 12} 340`} stroke="#c96442" strokeWidth="1" strokeDasharray="3 3" fill="none" />
+        {/* Card → right */}
+        <path d={`M ${devLeft + deviceW - 16} 250 L 720 250`} stroke="#c96442" strokeWidth="1" strokeDasharray="3 3" fill="none" />
+        {/* Tags → right */}
+        <path d={`M ${devLeft + deviceW - 100} 310 L 720 420`} stroke="#c96442" strokeWidth="1" strokeDasharray="3 3" fill="none" />
+        {/* Bottom nav → right */}
+        <path d={`M ${devLeft + deviceW - 16} 770 L 720 770`} stroke="#c96442" strokeWidth="1" strokeDasharray="3 3" fill="none" />
+        {/* Gutter → left bottom */}
+        <path d={`M 260 560 L ${devLeft + 8} 560`} stroke="#c96442" strokeWidth="1" strokeDasharray="3 3" fill="none" />
+      </svg>
+
+      {/* LEFT callouts */}
+      <Callout top={72} left={50} title="01 · Header, 56px fixed" body="Single row: KH mark + title left, search + theme-toggle right. Search icon expands inline into a full-width input — never wraps to a second row." />
+      <Callout top={178} left={50} title="02 · Section label" body="12px uppercase, 0.8px tracking, muted. 20px top margin, 8px below. Small count on the right, tabular numerals." />
+      <Callout top={316} left={50} title="03 · Section rhythm" body="24–28px between sections visually — labels carry the weight, not divider lines or heavy card chrome." />
+      <Callout top={540} left={50} title="04 · 16px gutter, always" body="Cards float inside a consistent 16px horizontal margin. Never collapses to 12px at 480px — the breathing room is the design." />
+
+      {/* RIGHT callouts */}
+      <Callout top={220} right={50} title="05 · Card as list row" body="Full-width row, 12px internal padding. 72×72 thumb left, text right. Title 15px/600, 2-line summary 13px/muted, tag pills, then channel · date footer." />
+      <Callout top={402} right={50} title="06 · Pills, subtle" body="22px tall, 11px label, 1px border. Background is 4% white tint — informational, never demanding attention." />
+      <Callout top={748} right={50} title="07 · 4-item labelled nav" body="Home · Search · Library · Ops. 64px tall, icon + 11px label. Active = indigo fill on both. Subtle top border, background blur for depth." />
+
+      {/* dots */}
+      {dot(devLeft + 12, 98)}
+      {dot(devLeft + 20, 200)}
+      {dot(devLeft + 12, 340)}
+      {dot(devLeft + 8, 560)}
+      {dot(devLeft + deviceW - 16, 250)}
+      {dot(devLeft + deviceW - 100, 310)}
+      {dot(devLeft + deviceW - 16, 770)}
+
+      {/* Device */}
+      <div style={{ position: 'absolute', left: devLeft, top: devTop, width: deviceW, height: deviceH,
+                    borderRadius: 42, overflow: 'hidden',
+                    boxShadow: '0 30px 60px rgba(0,0,0,0.12), 0 0 0 1px rgba(0,0,0,0.08)',
+                    background: '#000' }}>
+        {/* status bar — minimal */}
+        <div style={{
+          position: 'absolute', top: 0, left: 0, right: 0, height: 44, zIndex: 40,
+          display: 'flex', alignItems: 'center', padding: '0 28px',
+          color: mode === 'dark' ? '#fff' : '#000',
+          fontSize: 14, fontWeight: 600, letterSpacing: -0.2,
+        }}>
+          <div>9:41</div>
+          <div style={{ flex: 1 }} />
+          <div style={{ fontSize: 11, opacity: 0.9 }}>● ● ●</div>
+        </div>
+        {/* notch */}
+        <div style={{
+          position: 'absolute', top: 10, left: '50%', transform: 'translateX(-50%)',
+          width: 118, height: 34, borderRadius: 22, background: '#000', zIndex: 50,
+        }} />
+        {/* content, offset for status bar */}
+        <div data-theme={mode} style={{ paddingTop: 44, height: '100%', boxSizing: 'border-box' }}>
+          <ScreenLibrary active="home" />
+        </div>
+        {/* home indicator */}
+        <div style={{
+          position: 'absolute', bottom: 8, left: '50%', transform: 'translateX(-50%)',
+          width: 128, height: 4, borderRadius: 3,
+          background: mode === 'dark' ? 'rgba(255,255,255,0.65)' : 'rgba(0,0,0,0.28)',
+          zIndex: 60,
+        }} />
+      </div>
+
+      {/* caption below */}
+      <div style={{
+        position: 'absolute', bottom: 28, left: 0, right: 0, textAlign: 'center',
+        fontSize: 12, color: 'rgba(40,30,20,0.5)', letterSpacing: 0.2,
+      }}>
+        Library · mobile (≤ 640px) · {mode === 'dark' ? 'dark mode' : 'light mode'}
+      </div>
+    </div>
+  );
+}
+
+// Plain device (no annotations) — for the other artboards
+function PlainDevice({ mode = 'dark', searchOpen = false, active = 'home', width = 390, height = 760 }) {
+  return (
+    <div style={{
+      width, height, borderRadius: 42, overflow: 'hidden', position: 'relative',
+      boxShadow: '0 30px 60px rgba(0,0,0,0.12), 0 0 0 1px rgba(0,0,0,0.08)',
+      background: '#000',
+    }}>
+      <div style={{
+        position: 'absolute', top: 0, left: 0, right: 0, height: 44, zIndex: 40,
+        display: 'flex', alignItems: 'center', padding: '0 28px',
+        color: mode === 'dark' ? '#fff' : '#000',
+        fontSize: 14, fontWeight: 600, letterSpacing: -0.2,
+      }}>
+        <div>9:41</div>
+        <div style={{ flex: 1 }} />
+        <div style={{ fontSize: 11, opacity: 0.9 }}>● ● ●</div>
+      </div>
+      <div style={{
+        position: 'absolute', top: 10, left: '50%', transform: 'translateX(-50%)',
+        width: 118, height: 34, borderRadius: 22, background: '#000', zIndex: 50,
+      }} />
+      <div data-theme={mode} style={{ paddingTop: 44, height: '100%', boxSizing: 'border-box' }}>
+        <ScreenLibrary active={active} searchOpen={searchOpen} />
+      </div>
+      <div style={{
+        position: 'absolute', bottom: 8, left: '50%', transform: 'translateX(-50%)',
+        width: 128, height: 4, borderRadius: 3,
+        background: mode === 'dark' ? 'rgba(255,255,255,0.65)' : 'rgba(0,0,0,0.28)',
+        zIndex: 60,
+      }} />
+    </div>
+  );
+}
+
+Object.assign(window, { AnnotatedLibrary, PlainDevice, Callout });

--- a/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/lib/kh-detail-annotated.jsx
+++ b/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/lib/kh-detail-annotated.jsx
@@ -1,0 +1,143 @@
+// kh-detail-annotated.jsx — annotated versions of detail screens
+
+function AnnotatedDetail({ mode = 'dark', kind = 'video' }) {
+  const deviceW = 390;
+  const deviceH = 760;
+  const totalW = 900;
+  const totalH = 900;
+  const devLeft = (totalW - deviceW) / 2;
+  const devTop = 60;
+
+  const dot = (x, y) => (
+    <div style={{
+      position: 'absolute', left: x - 4, top: y - 4,
+      width: 8, height: 8, borderRadius: 4,
+      background: '#c96442', boxShadow: '0 0 0 3px rgba(201,100,66,0.18)',
+    }} />
+  );
+
+  const Screen = kind === 'video' ? ScreenVideoDetail : ScreenSourceDetail;
+  const isVid = kind === 'video';
+
+  return (
+    <div style={{
+      width: totalW, height: totalH, position: 'relative', background: '#f0eee9',
+      fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+    }}>
+      <svg width={totalW} height={totalH} style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}>
+        <path d={`M 260 98 L ${devLeft + 10} 98`} stroke="#c96442" strokeWidth="1" strokeDasharray="3 3" fill="none" />
+        <path d={`M 260 ${isVid ? 230 : 180} L ${devLeft + deviceW - 100} ${isVid ? 230 : 180}`} stroke="#c96442" strokeWidth="1" strokeDasharray="3 3" fill="none" />
+        <path d={`M 260 ${isVid ? 380 : 340} L ${devLeft + 20} ${isVid ? 380 : 340}`} stroke="#c96442" strokeWidth="1" strokeDasharray="3 3" fill="none" />
+        <path d={`M ${devLeft + deviceW - 16} ${isVid ? 300 : 300} L 720 ${isVid ? 300 : 300}`} stroke="#c96442" strokeWidth="1" strokeDasharray="3 3" fill="none" />
+        <path d={`M ${devLeft + deviceW - 16} ${isVid ? 500 : 560} L 720 ${isVid ? 500 : 560}`} stroke="#c96442" strokeWidth="1" strokeDasharray="3 3" fill="none" />
+        <path d={`M 260 560 L ${devLeft + 20} 560`} stroke="#c96442" strokeWidth="1" strokeDasharray="3 3" fill="none" />
+        <path d={`M ${devLeft + deviceW - 16} 770 L 720 770`} stroke="#c96442" strokeWidth="1" strokeDasharray="3 3" fill="none" />
+      </svg>
+
+      {isVid ? (
+        <>
+          <Callout top={72} left={50} title="01 · Context header" body="Back arrow + breadcrumb label + overflow. No duplicated title — that's in the hero below. 56px fixed, blurred." />
+          <Callout top={208} left={50} title="02 · Hero thumb" body="16:9 with center play button and a duration chip. Taps through to YouTube. The only non-text affordance above the fold." />
+          <Callout top={360} left={50} title="03 · Section labels" body="Same uppercase 11px label as the Library feed — vertical rhythm is consistent with the list view." />
+          <Callout top={540} left={50} title="04 · Skim-first order" body="Summary → takeaways → things → quote → tools → topics → transcript. The cheapest-to-read items come first." />
+
+          <Callout top={270} right={50} title="05 · Title + meta" body="20px/650 title, 2-line max by content. Meta line below: channel · posted · processed, separated by mid-dots. Tabular numerals." />
+          <Callout top={470} right={50} title="06 · Action bar" body="Primary (Create skill, indigo fill) + secondary (YouTube, outline). 32px pills. Scrolls with the page — always reachable, never sticky-chrome." />
+          <Callout top={750} right={50} title="07 · Bottom nav, always" body="Same 4-item nav everywhere in the app. Home stays active on detail pages — context is clear from the back breadcrumb, not the tab." />
+        </>
+      ) : (
+        <>
+          <Callout top={72} left={50} title="01 · Context header" body="Same back + breadcrumb + overflow pattern as video detail. Reusing the pattern keeps the product coherent across source types." />
+          <Callout top={148} left={50} title="02 · Kind + status strip" body="Icon chip + 'Article · done' line. Replaces the heavy badge-in-hero from desktop — here it's a single muted line." />
+          <Callout top={316} left={50} title="03 · Compact KV block" body="Type, status, created, processed in a 2-column grid inside one card. Desktop used a long inline kv-row — this packs the same info into ~72px." />
+          <Callout top={540} left={50} title="04 · Analysis as prose" body="Rendered markdown flows at 14px/1.65 with inline h3 at 13/600. Full reading measure inside 16px gutter — no nested card chrome." />
+
+          <Callout top={270} right={50} title="05 · Title + host" body="20/650 title with a single muted host line below. No subtitle wrapping; host truncates with an ellipsis." />
+          <Callout top={530} right={50} title="06 · Notes card" body="Personal notes get their own tinted card so they're visually distinct from extracted analysis above — a cheap way to signal authorship." />
+          <Callout top={750} right={50} title="07 · Bottom nav" body="Shared across all detail pages. No action rail, no sidebar — the phone has one column." />
+        </>
+      )}
+
+      {dot(devLeft + 10, 98)}
+      {dot(devLeft + deviceW - 100, isVid ? 230 : 180)}
+      {dot(devLeft + 20, isVid ? 380 : 340)}
+      {dot(devLeft + deviceW - 16, 300)}
+      {dot(devLeft + deviceW - 16, isVid ? 500 : 560)}
+      {dot(devLeft + 20, 560)}
+      {dot(devLeft + deviceW - 16, 770)}
+
+      <div style={{ position: 'absolute', left: devLeft, top: devTop, width: deviceW, height: deviceH,
+                    borderRadius: 42, overflow: 'hidden',
+                    boxShadow: '0 30px 60px rgba(0,0,0,0.12), 0 0 0 1px rgba(0,0,0,0.08)',
+                    background: '#000' }}>
+        <div style={{
+          position: 'absolute', top: 0, left: 0, right: 0, height: 44, zIndex: 40,
+          display: 'flex', alignItems: 'center', padding: '0 28px',
+          color: mode === 'dark' ? '#fff' : '#000',
+          fontSize: 14, fontWeight: 600, letterSpacing: -0.2,
+        }}>
+          <div>9:41</div>
+          <div style={{ flex: 1 }} />
+          <div style={{ fontSize: 11, opacity: 0.9 }}>● ● ●</div>
+        </div>
+        <div style={{
+          position: 'absolute', top: 10, left: '50%', transform: 'translateX(-50%)',
+          width: 118, height: 34, borderRadius: 22, background: '#000', zIndex: 50,
+        }} />
+        <div data-theme={mode} style={{ paddingTop: 44, height: '100%', boxSizing: 'border-box' }}>
+          <Screen />
+        </div>
+        <div style={{
+          position: 'absolute', bottom: 8, left: '50%', transform: 'translateX(-50%)',
+          width: 128, height: 4, borderRadius: 3,
+          background: mode === 'dark' ? 'rgba(255,255,255,0.65)' : 'rgba(0,0,0,0.28)',
+          zIndex: 60,
+        }} />
+      </div>
+
+      <div style={{
+        position: 'absolute', bottom: 28, left: 0, right: 0, textAlign: 'center',
+        fontSize: 12, color: 'rgba(40,30,20,0.5)', letterSpacing: 0.2,
+      }}>
+        {isVid ? 'Video' : 'Source'} detail · mobile · {mode}
+      </div>
+    </div>
+  );
+}
+
+function PlainDetailDevice({ mode = 'dark', kind = 'video', width = 390, height = 760 }) {
+  const Screen = kind === 'video' ? ScreenVideoDetail : ScreenSourceDetail;
+  return (
+    <div style={{
+      width, height, borderRadius: 42, overflow: 'hidden', position: 'relative',
+      boxShadow: '0 30px 60px rgba(0,0,0,0.12), 0 0 0 1px rgba(0,0,0,0.08)',
+      background: '#000',
+    }}>
+      <div style={{
+        position: 'absolute', top: 0, left: 0, right: 0, height: 44, zIndex: 40,
+        display: 'flex', alignItems: 'center', padding: '0 28px',
+        color: mode === 'dark' ? '#fff' : '#000',
+        fontSize: 14, fontWeight: 600, letterSpacing: -0.2,
+      }}>
+        <div>9:41</div>
+        <div style={{ flex: 1 }} />
+        <div style={{ fontSize: 11, opacity: 0.9 }}>● ● ●</div>
+      </div>
+      <div style={{
+        position: 'absolute', top: 10, left: '50%', transform: 'translateX(-50%)',
+        width: 118, height: 34, borderRadius: 22, background: '#000', zIndex: 50,
+      }} />
+      <div data-theme={mode} style={{ paddingTop: 44, height: '100%', boxSizing: 'border-box' }}>
+        <Screen />
+      </div>
+      <div style={{
+        position: 'absolute', bottom: 8, left: '50%', transform: 'translateX(-50%)',
+        width: 128, height: 4, borderRadius: 3,
+        background: mode === 'dark' ? 'rgba(255,255,255,0.65)' : 'rgba(0,0,0,0.28)',
+        zIndex: 60,
+      }} />
+    </div>
+  );
+}
+
+Object.assign(window, { AnnotatedDetail, PlainDetailDevice });

--- a/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/lib/kh-detail-screens.jsx
+++ b/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/lib/kh-detail-screens.jsx
@@ -1,0 +1,412 @@
+// kh-detail-screens.jsx — video detail + source detail, mobile
+// Reuses shared primitives, icons, Pill, BottomNav from kh-screens.jsx.
+
+// ─── Local icons (detail-specific) ────────────────────────
+const Icon2 = ({ d, size = 20, stroke = 'currentColor', fill = 'none', sw = 1.6 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill={fill} stroke={stroke}
+       strokeWidth={sw} strokeLinecap="round" strokeLinejoin="round">
+    {typeof d === 'string' ? <path d={d} /> : d}
+  </svg>
+);
+const IconBack = (p) => <Icon2 {...p} d="M15 6l-6 6 6 6" />;
+const IconMore = (p) => <Icon2 {...p} d={<><circle cx="5" cy="12" r="1.4" fill="currentColor"/><circle cx="12" cy="12" r="1.4" fill="currentColor"/><circle cx="19" cy="12" r="1.4" fill="currentColor"/></>} stroke="none" />;
+const IconExt  = (p) => <Icon2 {...p} d={<><path d="M14 4h6v6"/><path d="M20 4l-8 8"/><path d="M18 14v4a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4"/></>} />;
+const IconSparkle = (p) => <Icon2 {...p} d="M12 3v4M12 17v4M3 12h4M17 12h4M5.5 5.5l2.8 2.8M15.7 15.7l2.8 2.8M5.5 18.5l2.8-2.8M15.7 8.3l2.8-2.8" />;
+const IconChev = (p) => <Icon2 {...p} d="M9 18l6-6-6-6" />;
+const IconPlay2 = (p) => <Icon2 {...p} d="M8 5v14l11-7z" fill="currentColor" stroke="none" />;
+
+// ─── Mobile detail header (56px, back + title + actions) ─
+function DetailHeader({ back = 'Back', actions }) {
+  return window.DetailHeaderBase
+    ? <window.DetailHeaderBase back={back} actions={actions} />
+    : (
+      <header style={{
+        position: 'sticky', top: 0, zIndex: 30,
+        height: 56, padding: '0 8px 0 4px',
+        display: 'flex', alignItems: 'center', gap: 4,
+        background: 'var(--header-bg)', backdropFilter: 'blur(var(--blur-md))', WebkitBackdropFilter: 'blur(var(--blur-md))',
+        borderBottom: '1px solid var(--border)',
+      }}>
+        <IconButton icon={IconBack} label="Back" />
+        <div style={{
+          fontSize: 13, fontWeight: 500, color: 'var(--muted)', letterSpacing: -0.1,
+        }}>{back}</div>
+        <div style={{ flex: 1 }} />
+        {actions}
+        <IconButton icon={IconMore} label="More" />
+      </header>
+    );
+}
+
+function ActionButton({ children, icon, primary }) {
+  return <Button variant={primary ? 'primary' : 'outline'} size="md" icon={icon}>{children}</Button>;
+}
+
+// ─── Section in detail body ──────────────────────────────
+function DetailSection({ label, children, trailing }) {
+  return (
+    <section style={{ marginTop: 28, padding: '0 16px' }}>
+      <div style={{
+        display: 'flex', alignItems: 'baseline', justifyContent: 'space-between',
+        marginBottom: 10,
+      }}>
+        <div style={{
+          fontSize: 11, fontWeight: 600, letterSpacing: 0.8, textTransform: 'uppercase',
+          color: 'var(--muted)',
+        }}>{label}</div>
+        {trailing}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+// ─── Video detail screen ────────────────────────────────
+function ScreenVideoDetail() {
+  return (
+    <div style={{
+      width: '100%', height: '100%', background: 'var(--background)', color: 'var(--foreground)', fontFamily: 'var(--font-sans)',
+      display: 'flex', flexDirection: 'column', position: 'relative', overflow: 'hidden',
+      fontFeatureSettings: 'var(--font-feature-settings)',
+    }}>
+      <DetailHeader back="Library" />
+      <div style={{ flex: 1, overflowY: 'auto', paddingBottom: 96 }}>
+        {/* Hero thumb */}
+        <div style={{ padding: '8px 16px 0' }}>
+          <div style={{
+            position: 'relative', width: '100%', aspectRatio: '16 / 9',
+            borderRadius: 12, overflow: 'hidden',
+            background: 'linear-gradient(135deg, var(--thumb), var(--thumb-accent))',
+          }}>
+            <div style={{
+              position: 'absolute', inset: 0,
+              backgroundImage: 'repeating-linear-gradient(135deg, transparent 0 11px, var(--border) 11px 12px)',
+              opacity: 0.6,
+            }} />
+            <div style={{
+              position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center',
+            }}>
+              <div style={{
+                width: 52, height: 52, borderRadius: 26,
+                background: 'var(--scrim)', backdropFilter: 'blur(4px)',
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                color: 'var(--primary-foreground)', paddingLeft: 3,
+              }}><IconPlay2 size={18} /></div>
+            </div>
+            <div style={{
+              position: 'absolute', right: 8, bottom: 8,
+              padding: '2px 6px', borderRadius: 4, background: 'var(--scrim)',
+              color: 'var(--primary-foreground)', fontSize: 11, fontWeight: 600,
+              fontVariantNumeric: 'tabular-nums',
+            }}>42:08</div>
+          </div>
+        </div>
+
+        {/* Title + meta */}
+        <div style={{ padding: '16px 16px 0' }}>
+          <h1 style={{
+            margin: 0, fontSize: 20, fontWeight: 650, lineHeight: 1.25,
+            color: "var(--foreground)", letterSpacing: -0.4,
+          }}>Building agent orchestration with LangGraph from first principles</h1>
+          <div style={{
+            marginTop: 10, display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '4px 10px',
+            fontSize: 12, color: "var(--muted)", fontVariantNumeric: 'tabular-nums',
+          }}>
+            <span style={{ color: "var(--foreground-dim)", fontWeight: 500 }}>Latent Space</span>
+            <span style={{ color: "var(--muted-dim)" }}>·</span>
+            <span>Posted Apr 14</span>
+            <span style={{ color: "var(--muted-dim)" }}>·</span>
+            <span>Processed 2026-04-15</span>
+          </div>
+        </div>
+
+        {/* Action bar */}
+        <div style={{ padding: '14px 16px 0', display: 'flex', gap: 8 }}>
+          <ActionButton primary icon={IconSparkle}>Create skill</ActionButton>
+          <ActionButton icon={IconExt}>YouTube</ActionButton>
+        </div>
+
+        {/* TOC pills (horizontal scroll) */}
+        <div style={{ marginTop: 20, position: 'relative' }}>
+          <div style={{
+            display: 'flex', gap: 6, padding: '0 16px',
+            overflowX: 'auto', scrollbarWidth: 'none',
+          }}>
+            {['Summary', 'Takeaways', 'Things', 'Quotes', 'Tools', 'Screenshots', 'Transcript'].map((s, i) => (
+              <span key={s} style={{
+                flexShrink: 0, height: 28, padding: '0 12px', borderRadius: 14,
+                display: 'inline-flex', alignItems: 'center',
+                fontSize: 12, fontWeight: 500, letterSpacing: -0.1,
+                background: i === 0 ? "var(--primary-tint)" : "var(--pill-bg)",
+                color: i === 0 ? "var(--primary)" : "var(--muted)",
+                border: `1px solid ${i === 0 ? 'transparent' : "var(--border)"}`,
+              }}>{s}</span>
+            ))}
+          </div>
+        </div>
+
+        {/* Summary */}
+        <DetailSection label="Summary">
+          <p style={{
+            margin: 0, fontSize: 14, lineHeight: 1.6, color: "var(--foreground-dim)",
+            letterSpacing: -0.1,
+          }}>
+            A ground-up walkthrough of stateful agent graphs — how to design nodes, edges, and checkpoints so that tool-heavy workflows remain debuggable when things inevitably start failing. The host spends the first half on the mental model and the second half walking through a real orchestration for a customer-support triage bot.
+          </p>
+        </DetailSection>
+
+        {/* Takeaways */}
+        <DetailSection label="Key takeaways">
+          <ul style={{ margin: 0, padding: 0, listStyle: 'none', display: 'flex', flexDirection: 'column', gap: 10 }}>
+            {[
+              'State graphs beat prompt chains once you have more than two fallible tools in the loop.',
+              'Checkpoint the entire graph state, not just the message history — tool outputs are the expensive part.',
+              'The ReAct loop is a tarpit; prefer explicit edges with typed handoffs.',
+            ].map((s, i) => (
+              <li key={i} style={{
+                display: 'flex', gap: 10, alignItems: 'flex-start',
+                fontSize: 14, lineHeight: 1.55, color: "var(--foreground-dim)",
+              }}>
+                <span style={{
+                  flexShrink: 0, color: "var(--primary)", marginTop: 2, fontSize: 14, fontWeight: 600,
+                }}>→</span>
+                <span>{s}</span>
+              </li>
+            ))}
+          </ul>
+        </DetailSection>
+
+        {/* Things They Do — with timestamp + screenshot */}
+        <DetailSection label="Things they do" trailing={
+          <span style={{ fontSize: 11, color: "var(--muted-dim)", fontVariantNumeric: 'tabular-nums' }}>4 moments</span>
+        }>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            {[
+              { n: 1, text: 'Sketch the graph on paper before opening an editor.', ts: '04:12', hasSs: false },
+              { n: 2, text: 'Define a typed State object that every node both reads from and writes to.', ts: '11:38', hasSs: true },
+              { n: 3, text: 'Make the router node stateless and deterministic.', ts: '22:07', hasSs: false },
+            ].map((th) => (
+              <div key={th.n} style={{
+                background: "var(--card)", border: '1px solid var(--border)', borderRadius: 12, overflow: 'hidden',
+              }}>
+                <div style={{ padding: 12, display: 'flex', gap: 10 }}>
+                  <span style={{
+                    flexShrink: 0, width: 22, height: 22, borderRadius: 11,
+                    background: "var(--pill-bg)", color: "var(--muted)",
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    fontSize: 11, fontWeight: 600, fontVariantNumeric: 'tabular-nums',
+                  }}>{th.n}</span>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontSize: 14, lineHeight: 1.5, color: "var(--foreground-dim)", letterSpacing: -0.1 }}>
+                      {th.text}{' '}
+                      <span style={{
+                        display: 'inline-flex', alignItems: 'center', gap: 3,
+                        height: 20, padding: '0 7px', borderRadius: 10,
+                        background: 'var(--primary-tint)', color: 'var(--primary)',
+                        fontSize: 11, fontWeight: 600, fontVariantNumeric: 'tabular-nums',
+                        verticalAlign: '2px',
+                      }}>
+                        <IconPlay2 size={8} />{th.ts}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                {th.hasSs && (
+                  <div style={{
+                    borderTop: '1px solid var(--border)',
+                    aspectRatio: '16 / 7',
+                    background: 'linear-gradient(135deg, var(--thumb), var(--thumb-accent))',
+                    position: 'relative', overflow: 'hidden',
+                  }}>
+                    <div style={{
+                      position: 'absolute', inset: 0,
+                      backgroundImage: 'repeating-linear-gradient(135deg, transparent 0 11px, var(--border) 11px 12px)',
+                      opacity: 0.55,
+                    }} />
+                    <div style={{
+                      position: 'absolute', left: 8, bottom: 8,
+                      display: 'inline-flex', alignItems: 'center', gap: 3,
+                      height: 20, padding: '0 7px', borderRadius: 10,
+                      background: 'var(--scrim)', color: 'var(--primary-foreground)',
+                      fontSize: 11, fontWeight: 600, fontVariantNumeric: 'tabular-nums',
+                    }}>
+                      <IconPlay2 size={8} /> {th.ts}
+                    </div>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </DetailSection>
+
+        {/* Quote */}
+        <DetailSection label="Notable quote">
+          <blockquote style={{
+            margin: 0, padding: '10px 14px',
+            borderLeft: '2px solid var(--primary)',
+            background: "var(--card)", borderRadius: '0 12px 12px 0',
+            fontSize: 14, fontStyle: 'italic', lineHeight: 1.55,
+            color: "var(--foreground-dim)", letterSpacing: -0.1,
+          }}>
+            “The mistake people make is treating the agent as the program. The graph is the program. The model is just one of the functions you call.”
+          </blockquote>
+        </DetailSection>
+
+        {/* Tools */}
+        <DetailSection label="Tools mentioned">
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+            {['LangGraph', 'Pydantic', 'Postgres', 'Weights & Biases', 'tmux'].map((x) => (
+              <span key={x} style={{
+                height: 26, padding: '0 10px', borderRadius: 8,
+                display: 'inline-flex', alignItems: 'center',
+                fontSize: 12, fontWeight: 500,
+                background: "var(--pill-bg)", color: "var(--foreground-dim)", border: '1px solid var(--border)',
+              }}>{x}</span>
+            ))}
+          </div>
+        </DetailSection>
+
+        {/* Topics */}
+        <DetailSection label="Topics">
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+            {['agents', 'langgraph', 'orchestration', 'tooling', 'state-machines'].map((x) => (
+              <span key={x} style={{
+                height: 22, padding: '0 8px', borderRadius: 999,
+                display: 'inline-flex', alignItems: 'center',
+                fontSize: 11, fontWeight: 500,
+                background: "var(--pill-bg)", color: "var(--muted)", border: '1px solid var(--border)',
+              }}>#{x}</span>
+            ))}
+          </div>
+        </DetailSection>
+
+        {/* Transcript preview row */}
+        <DetailSection label="Transcript">
+          <button style={{
+            width: '100%', padding: 14, background: "var(--card)", border: '1px solid var(--border)',
+            borderRadius: 12, textAlign: 'left', cursor: 'pointer',
+            display: 'flex', alignItems: 'center', gap: 10, fontFamily: 'inherit',
+          }}>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 13, fontWeight: 500, color: "var(--foreground)", letterSpacing: -0.1 }}>
+                Full transcript
+              </div>
+              <div style={{ fontSize: 11, color: "var(--muted-dim)", marginTop: 2, fontVariantNumeric: 'tabular-nums' }}>
+                42:08 · 8,240 words
+              </div>
+            </div>
+            <IconChev size={16} stroke="var(--muted)" />
+          </button>
+        </DetailSection>
+      </div>
+
+      <BottomNav active="home" />
+    </div>
+  );
+}
+
+// ─── Source detail screen ───────────────────────────────
+function ScreenSourceDetail() {
+  return (
+    <div style={{
+      width: '100%', height: '100%', background: "var(--background)", color: "var(--foreground)", fontFamily: "var(--font-sans)",
+      display: 'flex', flexDirection: 'column', position: 'relative', overflow: 'hidden',
+      fontFeatureSettings: '"cv01","ss03"',
+    }}>
+      <DetailHeader back="Library" />
+      <div style={{ flex: 1, overflowY: 'auto', paddingBottom: 96 }}>
+        {/* Kind + status strip */}
+        <div style={{ padding: '14px 16px 0', display: 'flex', alignItems: 'center', gap: 8 }}>
+          <div style={{
+            width: 32, height: 32, borderRadius: 8, background: "var(--pill-bg)",
+            border: '1px solid var(--border)', color: "var(--muted)",
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+          }}><IconExt size={15} stroke="var(--muted)" /></div>
+          <div style={{ fontSize: 11, color: "var(--muted)", fontWeight: 500, letterSpacing: 0.1 }}>
+            Article · <span style={{ color: 'var(--success)' }}>done</span>
+          </div>
+        </div>
+
+        {/* Title + host */}
+        <div style={{ padding: '10px 16px 0' }}>
+          <h1 style={{
+            margin: 0, fontSize: 20, fontWeight: 650, lineHeight: 1.25,
+            color: "var(--foreground)", letterSpacing: -0.4,
+          }}>Context engineering is the new prompt engineering</h1>
+          <div style={{
+            marginTop: 6, fontSize: 12, color: "var(--muted)",
+            overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+          }}>simonwillison.net</div>
+        </div>
+
+        {/* Actions */}
+        <div style={{ padding: '14px 16px 0', display: 'flex', gap: 8 }}>
+          <ActionButton primary icon={IconSparkle}>Create skill</ActionButton>
+          <ActionButton icon={IconExt}>Open source</ActionButton>
+        </div>
+
+        {/* KV row */}
+        <div style={{
+          margin: '18px 16px 0', padding: 12,
+          background: "var(--card)", border: '1px solid var(--border)', borderRadius: 12,
+          display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '10px 16px',
+        }}>
+          {[
+            ['Type', 'article'],
+            ['Status', 'done'],
+            ['Created', 'Apr 12, 2026'],
+            ['Processed', 'Apr 12, 2026'],
+          ].map(([k, v]) => (
+            <div key={k}>
+              <div style={{ fontSize: 10, color: "var(--muted-dim)", letterSpacing: 0.6, textTransform: 'uppercase', fontWeight: 600 }}>{k}</div>
+              <div style={{ fontSize: 13, color: "var(--foreground-dim)", marginTop: 2, letterSpacing: -0.1 }}>{v}</div>
+            </div>
+          ))}
+        </div>
+
+        {/* Analysis */}
+        <DetailSection label="Analysis">
+          <div style={{ fontSize: 14, lineHeight: 1.65, color: "var(--foreground-dim)", letterSpacing: -0.1 }}>
+            <p style={{ margin: '0 0 12px' }}>
+              The author walks through a progression most practitioners are living: the “prompt” as a unit of authorship is dissolving into something closer to long-form context curation — and the tooling is trailing the practice.
+            </p>
+            <h3 style={{
+              margin: '16px 0 8px', fontSize: 13, fontWeight: 600,
+              color: "var(--foreground)", letterSpacing: -0.1,
+            }}>Three shifts worth noting</h3>
+            <ul style={{ margin: 0, paddingLeft: 18, display: 'flex', flexDirection: 'column', gap: 6 }}>
+              <li>Retrieval is now a first-class product surface, not a hidden subroutine.</li>
+              <li>Evaluation moved from prompts to rollouts — you grade the trajectory, not the turn.</li>
+              <li>The interesting abstractions live at the context-assembly layer.</li>
+            </ul>
+          </div>
+        </DetailSection>
+
+        {/* Notes */}
+        <DetailSection label="Notes">
+          <div style={{
+            padding: 12, background: "var(--card)", border: '1px solid var(--border)', borderRadius: 12,
+            fontSize: 13, lineHeight: 1.55, color: "var(--foreground-dim)", letterSpacing: -0.1,
+          }}>
+            Worth mining for the “grade the trajectory” framing — fits the orchestration notes from last week.
+          </div>
+        </DetailSection>
+
+        {/* Topic */}
+        <DetailSection label="Topic">
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+            <span style={{
+              height: 22, padding: '0 8px', borderRadius: 999,
+              display: 'inline-flex', alignItems: 'center',
+              fontSize: 11, fontWeight: 500,
+              background: "var(--pill-bg)", color: "var(--muted)", border: '1px solid var(--border)',
+            }}>#context</span>
+          </div>
+        </DetailSection>
+      </div>
+      <BottomNav active="home" />
+    </div>
+  );
+}
+
+Object.assign(window, { ScreenVideoDetail, ScreenSourceDetail, DetailHeader });

--- a/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/lib/kh-history.jsx
+++ b/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/lib/kh-history.jsx
@@ -1,0 +1,226 @@
+// kh-history.jsx — Import History screen.
+// Shows all items added via Quick Add with their processing status.
+
+const IconH_Q = ({ d, size = 20, stroke = 'currentColor', fill = 'none', sw = 1.6 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill={fill} stroke={stroke}
+       strokeWidth={sw} strokeLinecap="round" strokeLinejoin="round">
+    {typeof d === 'string' ? <path d={d} /> : d}
+  </svg>
+);
+const IconBack = (p) => <IconH_Q {...p} d="M15 6l-6 6 6 6" sw={2} />;
+const IconMore = (p) => <IconH_Q {...p} d={<><circle cx="5" cy="12" r="1.3" fill="currentColor"/><circle cx="12" cy="12" r="1.3" fill="currentColor"/><circle cx="19" cy="12" r="1.3" fill="currentColor"/></>} stroke="none" />;
+const IconRetry = (p) => <IconH_Q {...p} d="M4 4v6h6M20 20v-6h-6M4 10a8 8 0 0 1 14-3M20 14a8 8 0 0 1-14 3" />;
+const IconVidH = (p) => <IconH_Q {...p} d={<><rect x="3" y="5" width="18" height="14" rx="2"/><path d="M10 9l5 3-5 3z" fill="currentColor"/></>} />;
+const IconArtH = (p) => <IconH_Q {...p} d={<><path d="M5 4h11l3 3v13H5z"/><path d="M8 10h8M8 14h8M8 18h5"/></>} />;
+const IconRepoH = (p) => <IconH_Q {...p} d={<><circle cx="6" cy="6" r="2.5"/><circle cx="6" cy="18" r="2.5"/><circle cx="18" cy="8" r="2.5"/><path d="M6 8.5v7M8.5 6H14a3 3 0 0 1 3 3v1"/></>} />;
+const IconSiteH = (p) => <IconH_Q {...p} d={<><circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3c2.5 3 2.5 15 0 18M12 3c-2.5 3-2.5 15 0 18"/></>} />;
+
+const KIND_ICON = { video: IconVidH, article: IconArtH, repo: IconRepoH, site: IconSiteH };
+const KIND_LABEL = { video: 'Video', article: 'Article', repo: 'Repo', site: 'Site' };
+
+// Status dot + label
+function StatusTag({ status }) {
+  const map = {
+    ready:      { color: 'var(--success)', label: 'Ready' },
+    processing: { color: "var(--primary)", label: 'Processing' },
+    queued:     { color: "var(--muted)",    label: 'Queued' },
+    failed:     { color: 'var(--danger)', label: 'Failed' },
+  };
+  const { color, label } = map[status];
+  const pulse = status === 'processing';
+
+  return (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center', gap: 5,
+      fontSize: 11, fontWeight: 500, letterSpacing: -0.05,
+      color: status === 'ready' ? "var(--muted)" : color,
+    }}>
+      <span style={{
+        width: 6, height: 6, borderRadius: 3, background: color,
+        animation: pulse ? 'khPulse 1.4s ease-in-out infinite' : 'none',
+      }} />
+      {label}
+    </span>
+  );
+}
+
+// Sample history data — recent to old
+const HISTORY = [
+  { id: 1, kind: 'article', title: 'Context engineering for AI agents',
+    domain: 'simonwillison.net', status: 'processing', when: 'Just now' },
+  { id: 2, kind: 'video', title: 'Building reliable LLM systems at scale',
+    domain: 'youtube.com', status: 'queued', when: '2 min ago' },
+  { id: 3, kind: 'repo', title: 'anthropics/anthropic-cookbook',
+    domain: 'github.com', status: 'ready', when: '8 min ago' },
+  { id: 4, kind: 'article', title: 'Why retrieval is the bottleneck',
+    domain: 'eugeneyan.com', status: 'ready', when: '34 min ago' },
+  { id: 5, kind: 'site', title: 'Linear changelog',
+    domain: 'linear.app', status: 'failed', when: '1 hr ago' },
+  { id: 6, kind: 'video', title: 'The shape of AI-native products',
+    domain: 'youtube.com', status: 'ready', when: '2 hr ago' },
+  { id: 7, kind: 'article', title: 'Evals are all you need',
+    domain: 'hamel.dev', status: 'ready', when: 'Yesterday' },
+  { id: 8, kind: 'repo', title: 'vercel/ai',
+    domain: 'github.com', status: 'ready', when: 'Yesterday' },
+];
+
+// Group by day bucket for section labels
+const GROUPS = [
+  { label: 'Today', items: HISTORY.slice(0, 6) },
+  { label: 'Yesterday', items: HISTORY.slice(6) },
+];
+
+function HistoryRow({ item, showDivider = true }) {
+  const Icon = KIND_ICON[item.kind];
+  const failed = item.status === 'failed';
+
+  return (
+    <div style={{
+      padding: '12px 16px',
+      borderBottom: showDivider ? '1px solid var(--border)' : 'none',
+      display: 'flex', alignItems: 'center', gap: 12,
+      opacity: failed ? 0.75 : 1,
+    }}>
+      {/* Kind glyph */}
+      <div style={{
+        flexShrink: 0, width: 36, height: 36, borderRadius: 8,
+        background: failed ? 'var(--primary-tint)' : "var(--pill-bg)",
+        color: failed ? 'var(--danger)' : "var(--muted)",
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+      }}><Icon size={16} stroke={failed ? 'var(--danger)' : "var(--muted)"} /></div>
+
+      {/* Title + meta */}
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{
+          fontSize: 14, fontWeight: 500, color: "var(--foreground)", letterSpacing: -0.1,
+          overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+          marginBottom: 3,
+        }}>{item.title}</div>
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: 8,
+          fontSize: 11, color: "var(--muted)", letterSpacing: -0.05,
+        }}>
+          <span style={{
+            overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+            maxWidth: 120,
+          }}>{item.domain}</span>
+          <span style={{ color: "var(--muted-dim)" }}>·</span>
+          <StatusTag status={item.status} />
+          <span style={{ color: "var(--muted-dim)" }}>·</span>
+          <span>{item.when}</span>
+        </div>
+      </div>
+
+      {/* Action: retry for failed, overflow menu otherwise */}
+      {failed ? (
+        <button style={{
+          flexShrink: 0, height: 28, padding: '0 10px', borderRadius: 14,
+          background: 'transparent', color: 'var(--danger)',
+          border: '1px solid var(--danger)', cursor: 'pointer',
+          fontFamily: 'inherit', fontSize: 12, fontWeight: 500, letterSpacing: -0.05,
+          display: 'inline-flex', alignItems: 'center', gap: 4,
+        }}>
+          <IconRetry size={12} stroke="var(--danger)" sw={1.8} /> Retry
+        </button>
+      ) : (
+        <button style={{
+          flexShrink: 0, width: 28, height: 28, borderRadius: 6,
+          background: 'transparent', border: 'none', cursor: 'pointer',
+          color: "var(--muted)",
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+        }}><IconMore size={16} stroke="var(--muted)" /></button>
+      )}
+    </div>
+  );
+}
+
+// Mini header specific to History (has a back button + title)
+function HistoryHeader() {
+  return (
+    <DetailHeader
+      back="Import history"
+      actions={<Button variant="ghost" size="md">Clear</Button>}
+    />
+  );
+}
+
+// Section label, mirrors the Library pattern
+function HistorySection({ label }) {
+  return (
+    <div style={{
+      padding: '20px 16px 8px',
+      fontSize: 11, fontWeight: 600, letterSpacing: 0.8, textTransform: 'uppercase',
+      color: "var(--muted)",
+    }}>{label}</div>
+  );
+}
+
+// Counter summary bar at very top (subtle)
+function HistorySummary() {
+  const processing = HISTORY.filter(h => h.status === 'processing' || h.status === 'queued').length;
+  const failed = HISTORY.filter(h => h.status === 'failed').length;
+
+  return (
+    <div style={{
+      margin: '12px 16px 0', padding: '10px 12px', borderRadius: 10,
+      background: "var(--card)", border: '1px solid var(--border)',
+      display: 'flex', alignItems: 'center', gap: 16,
+      fontSize: 12, color: "var(--foreground-dim)", letterSpacing: -0.05,
+    }}>
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+        <span style={{
+          width: 6, height: 6, borderRadius: 3, background: "var(--primary)",
+          animation: 'khPulse 1.4s ease-in-out infinite',
+        }} />
+        <strong style={{ fontWeight: 600, color: "var(--foreground)" }}>{processing}</strong> processing
+      </span>
+      {failed > 0 && (
+        <>
+          <span style={{ color: "var(--muted-dim)" }}>·</span>
+          <span style={{ color: 'var(--danger)' }}>
+            <strong style={{ fontWeight: 600 }}>{failed}</strong> failed
+          </span>
+        </>
+      )}
+      <span style={{ marginLeft: 'auto', color: "var(--muted-dim)" }}>
+        {HISTORY.length} total
+      </span>
+    </div>
+  );
+}
+
+function ScreenImportHistory() {
+  return (
+    <div style={{
+      width: '100%', height: '100%',
+      background: "var(--background)", color: "var(--foreground)",
+      fontFamily: "var(--font-sans)",
+      display: 'flex', flexDirection: 'column',
+      overflow: 'hidden',
+    }}>
+      <style>{`@keyframes khPulse { 0%,100%{opacity:1} 50%{opacity:.35} }`}</style>
+      <HistoryHeader />
+      <div style={{ flex: 1, overflow: 'auto' }}>
+        <HistorySummary />
+        {GROUPS.map((g, gi) => (
+          <div key={g.label}>
+            <HistorySection label={g.label} />
+            <div style={{
+              margin: '0 16px',
+              background: "var(--card)", border: '1px solid var(--border)',
+              borderRadius: 12, overflow: 'hidden',
+            }}>
+              {g.items.map((item, i) => (
+                <HistoryRow key={item.id} item={item}
+                            showDivider={i < g.items.length - 1} />
+              ))}
+            </div>
+          </div>
+        ))}
+        <div style={{ height: 24 }} />
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { ScreenImportHistory, HistoryRow, StatusTag, HISTORY });

--- a/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/lib/kh-quickadd-annotated.jsx
+++ b/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/lib/kh-quickadd-annotated.jsx
@@ -1,0 +1,177 @@
+// kh-quickadd-annotated.jsx — annotated Quick Add flow
+// Assumes kh-screens.jsx + kh-quickadd.jsx loaded first.
+
+// Reuse Callout pattern from existing annotated files
+function QACallout({ x, y, w = 200, title, body, anchor }) {
+  return (
+    <div style={{
+      position: 'absolute', left: x, top: y, width: w,
+      fontFamily: 'var(--font-sans)', fontSize: 11, lineHeight: 1.5,
+      color: '#3a3a40',
+    }}>
+      <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: 0.8,
+                    textTransform: 'uppercase', color: '#5e6ad2', marginBottom: 4 }}>
+        {title}
+      </div>
+      <div style={{ color: '#1a1a1e', letterSpacing: -0.05 }}>{body}</div>
+      {anchor && (
+        <svg style={{
+          position: 'absolute', left: anchor.sx, top: anchor.sy,
+          width: anchor.w, height: anchor.h, overflow: 'visible',
+          pointerEvents: 'none',
+        }}>
+          <path d={anchor.d} fill="none" stroke="#5e6ad2" strokeWidth={1}
+                strokeDasharray="3 3" />
+          <circle cx={anchor.ex} cy={anchor.ey} r={2.5} fill="#5e6ad2" />
+        </svg>
+      )}
+    </div>
+  );
+}
+
+// Device frame consistent with other annotated screens
+function QADevice({ children, x, y, w = 300, h = 600, label }) {
+  return (
+    <div style={{ position: 'absolute', left: x, top: y }}>
+      <div style={{
+        width: w, height: h, borderRadius: 28, overflow: 'hidden',
+        border: '1px solid rgba(0,0,0,0.12)',
+        boxShadow: '0 20px 40px -12px rgba(0,0,0,0.15), 0 4px 10px -2px rgba(0,0,0,0.08)',
+        background: '#000',
+      }}>
+        {children}
+      </div>
+      {label && (
+        <div style={{
+          marginTop: 10, fontFamily: 'var(--font-sans)', fontSize: 11, fontWeight: 600,
+          letterSpacing: 0.4, textTransform: 'uppercase', color: '#5e6ad2',
+        }}>{label}</div>
+      )}
+    </div>
+  );
+}
+
+function AnnotatedQuickAdd() {
+  // Canvas layout: 3 devices in a row with callouts around them
+  const deviceW = 280, deviceH = 560;
+  const row1Y = 80;
+
+  return (
+    <div style={{
+      width: 1500, height: 880, position: 'relative',
+      background: '#fafafa', fontFamily: 'var(--font-sans)',
+    }}>
+      {/* Title */}
+      <div style={{ position: 'absolute', top: 30, left: 40, right: 40 }}>
+        <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: 1.2,
+                      textTransform: 'uppercase', color: '#5e6ad2' }}>
+          Flow · Quick add
+        </div>
+        <div style={{ fontSize: 18, fontWeight: 600, color: '#1a1a1e',
+                      letterSpacing: -0.3, marginTop: 2 }}>
+          Two taps from clipboard to library
+        </div>
+      </div>
+
+      {/* ─ Step 1: Library + FAB ─────────────────────────── */}
+      <QADevice x={60} y={row1Y} w={deviceW} h={deviceH} label="1 · Tap FAB">
+        <div data-theme="dark" style={{ transform: 'scale(0.718)', transformOrigin: 'top left',
+                      width: 390, height: 780 }}>
+          <ScreenLibraryFab />
+        </div>
+      </QADevice>
+
+      <QACallout
+        x={60 + deviceW + 24} y={row1Y + 380} w={220}
+        title="① Floating action button"
+        body="Pinned above nav at 16px inset. Always reachable by thumb. Primary indigo signals the system's single most-used write action."
+        anchor={{ sx: -30, sy: -240, w: 30, h: 260,
+                  d: 'M 30 260 Q 10 250 5 140',
+                  ex: 5, ey: 140 }}
+      />
+
+      {/* ─ Step 2: Paste sheet ────────────────────────────── */}
+      <QADevice x={520} y={row1Y} w={deviceW} h={deviceH} label="2 · Confirm">
+        <div data-theme="dark" style={{ transform: 'scale(0.718)', transformOrigin: 'top left',
+                      width: 390, height: 780 }}>
+          <ScreenLibrarySheet state="pasted" />
+        </div>
+      </QADevice>
+
+      <QACallout
+        x={520 - 200} y={row1Y + 180} w={180}
+        title="Auto-paste"
+        body="Sheet opens with clipboard URL already staged. If no URL: falls back to empty state with paste button + manual entry."
+        anchor={{ sx: 180, sy: 10, w: 50, h: 40,
+                  d: 'M 0 10 Q 30 5 50 20',
+                  ex: 50, ey: 20 }}
+      />
+
+      <QACallout
+        x={520 + deviceW + 24} y={row1Y + 230} w={220}
+        title="② One-tap add"
+        body="Kind is auto-detected from URL (YouTube → video, github.com → repo, etc.). User can override via chips. Topic auto-tagged from history."
+        anchor={{ sx: -30, sy: -60, w: 30, h: 240,
+                  d: 'M 30 80 Q 10 100 5 180',
+                  ex: 5, ey: 180 }}
+      />
+
+      <QACallout
+        x={520 + deviceW + 24} y={row1Y + 470} w={220}
+        title="Commit"
+        body="48px primary button · full width. Text confirms what happens next — queued, already visible in Library."
+        anchor={{ sx: -30, sy: -20, w: 30, h: 40,
+                  d: 'M 30 20 L 5 30',
+                  ex: 5, ey: 30 }}
+      />
+
+      {/* ─ Step 3: Done flash ─────────────────────────────── */}
+      <QADevice x={980} y={row1Y} w={deviceW} h={deviceH} label="3 · Continue or dismiss">
+        <div data-theme="dark" style={{ transform: 'scale(0.718)', transformOrigin: 'top left',
+                      width: 390, height: 780 }}>
+          <ScreenLibrarySheet state="done" />
+        </div>
+      </QADevice>
+
+      <QACallout
+        x={980 + deviceW + 24} y={row1Y + 380} w={200}
+        title="Two forward paths"
+        body="View: jumps to Library where item is already visible (processing). Add another: keeps sheet open, clears fields — for pasting a batch."
+        anchor={{ sx: -30, sy: -30, w: 30, h: 40,
+                  d: 'M 30 30 L 5 40',
+                  ex: 5, ey: 40 }}
+      />
+
+      {/* Tap-count badge at top */}
+      <div style={{
+        position: 'absolute', top: 88, left: 60 + deviceW + 24 + 240,
+        display: 'flex', alignItems: 'center', gap: 10,
+        padding: '8px 14px', borderRadius: 20,
+        background: 'rgba(94,106,210,0.10)', color: '#5e6ad2',
+        fontSize: 12, fontWeight: 600, letterSpacing: -0.1,
+      }}>
+        Tap 1 <span style={{ opacity: 0.5 }}>→</span> Tap 2 <span style={{ opacity: 0.5 }}>→</span> Done
+      </div>
+
+      {/* Bottom bar: alt path (empty state) */}
+      <div style={{
+        position: 'absolute', left: 40, right: 40, bottom: 30,
+        padding: '14px 18px', borderRadius: 12,
+        background: '#fff', border: '1px solid #e6e6e6',
+        display: 'flex', alignItems: 'center', gap: 16,
+        fontSize: 12, color: '#3a3a40', lineHeight: 1.5, letterSpacing: -0.05,
+      }}>
+        <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: 0.8,
+                      textTransform: 'uppercase', color: '#5e6ad2' }}>
+          Edge case
+        </div>
+        <div>
+          <strong style={{ color: '#1a1a1e' }}>No clipboard URL:</strong> sheet opens with a dashed
+          paste target and a "Type a URL instead" escape. Still two taps — FAB, then paste button.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { AnnotatedQuickAdd, QADevice, QACallout });

--- a/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/lib/kh-quickadd.jsx
+++ b/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/lib/kh-quickadd.jsx
@@ -1,0 +1,241 @@
+// kh-quickadd.jsx — two-tap link capture flow.
+
+const IconQ = ({ d, size = 20, stroke = 'currentColor', fill = 'none', sw = 1.6 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill={fill} stroke={stroke}
+       strokeWidth={sw} strokeLinecap="round" strokeLinejoin="round">
+    {typeof d === 'string' ? <path d={d} /> : d}
+  </svg>
+);
+const IconPlus = (p) => <IconQ {...p} d="M12 5v14M5 12h14" sw={2} />;
+const IconClipboard = (p) => <IconQ {...p} d={<><rect x="7" y="4" width="10" height="16" rx="2"/><path d="M9 3h6v3H9z"/></>} />;
+const IconClose = (p) => <IconQ {...p} d="M6 6l12 12M18 6L6 18" />;
+const IconCheck = (p) => <IconQ {...p} d="M5 12.5l4.5 4.5L19 7" sw={2.2} />;
+const IconLink = (p) => <IconQ {...p} d="M10 14a4 4 0 0 0 5.7 0l3-3a4 4 0 0 0-5.7-5.7L11.5 7M14 10a4 4 0 0 0-5.7 0l-3 3a4 4 0 1 0 5.7 5.7L12.5 17" />;
+const IconRepo = (p) => <IconQ {...p} d={<><circle cx="6" cy="6" r="2.5"/><circle cx="6" cy="18" r="2.5"/><circle cx="18" cy="8" r="2.5"/><path d="M6 8.5v7M8.5 6H14a3 3 0 0 1 3 3v1"/></>} />;
+const IconVid = (p) => <IconQ {...p} d={<><rect x="3" y="5" width="18" height="14" rx="2"/><path d="M10 9l5 3-5 3z" fill="currentColor"/></>} />;
+const IconArt = (p) => <IconQ {...p} d={<><path d="M5 4h11l3 3v13H5z"/><path d="M8 10h8M8 14h8M8 18h5"/></>} />;
+
+// Floating action button — sits above the bottom nav, pulls up slightly
+function FAB({ onClick, pressed = false }) {
+  return (
+    <button onClick={onClick} style={{
+      position: 'absolute', right: 16, bottom: 80, zIndex: 40,
+      width: 52, height: 52, borderRadius: 26,
+      background: "var(--primary)", border: 'none', cursor: 'pointer',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      color: 'var(--primary-foreground)',
+      boxShadow: pressed
+        ? 'var(--shadow-fab-pressed)'
+        : 'var(--shadow-fab)',
+      transition: 'box-shadow .14s ease',
+    }}>
+      <IconPlus size={22} stroke="var(--primary-foreground)" sw={2.2} />
+    </button>
+  );
+}
+
+// The paste sheet (state = 'empty' | 'pasted' | 'done')
+function PasteSheet({ state = 'pasted' }) {
+  const url = 'https://simonwillison.net/2026/apr/context-engineering';
+  const domain = 'simonwillison.net';
+
+  return (
+    <div style={{
+      position: 'absolute', inset: 0, zIndex: 60,
+      display: 'flex', flexDirection: 'column',
+      background: 'var(--scrim)', backdropFilter: 'blur(2px)',
+    }}>
+      {/* scrim click target */}
+      <div style={{ flex: 1 }} />
+
+      {/* sheet */}
+      <div style={{
+        background: "var(--background-elev)",
+        borderTopLeftRadius: 20, borderTopRightRadius: 20,
+        borderTop: '1px solid var(--border)',
+        paddingBottom: 'env(safe-area-inset-bottom, 0)',
+      }}>
+        {/* grab handle */}
+        <div style={{ padding: '8px 0 4px', display: 'flex', justifyContent: 'center' }}>
+          <div style={{
+            width: 36, height: 4, borderRadius: 2,
+            background: "var(--border-strong)",
+          }} />
+        </div>
+
+        {/* header */}
+        <div style={{
+          display: 'flex', alignItems: 'center', padding: '4px 8px 4px 16px', height: 44,
+        }}>
+          <div style={{ fontSize: 15, fontWeight: 600, color: "var(--foreground)", letterSpacing: -0.2 }}>
+            Quick add
+          </div>
+          <div style={{ flex: 1 }} />
+          <button style={{
+            width: 32, height: 32, border: 'none', background: 'transparent',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            color: "var(--muted)", borderRadius: 8, cursor: 'pointer',
+          }}><IconClose size={18} stroke="var(--muted)" /></button>
+        </div>
+
+        {state === 'empty' && <EmptyState />}
+        {state === 'pasted' && <PastedState url={url} domain={domain} />}
+        {state === 'done' && <DoneState domain={domain} />}
+      </div>
+    </div>
+  );
+}
+
+// Empty — no clipboard URL; show paste target + manual hint
+function EmptyState() {
+  return (
+    <div style={{ padding: '12px 16px 20px' }}>
+      <div style={{
+        padding: 20, borderRadius: 12,
+        border: '1px dashed var(--border-strong)', background: "var(--card)",
+        display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10,
+      }}>
+        <div style={{
+          width: 40, height: 40, borderRadius: 20, background: "var(--pill-bg)",
+          color: "var(--muted)",
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+        }}><IconClipboard size={18} stroke="var(--muted)" /></div>
+        <div style={{ fontSize: 14, fontWeight: 500, color: "var(--foreground)", letterSpacing: -0.1 }}>
+          Paste a link from your clipboard
+        </div>
+        <div style={{ fontSize: 12, color: "var(--muted)", textAlign: 'center', lineHeight: 1.5 }}>
+          YouTube, articles, repos, sites.<br/>We'll figure out the rest.
+        </div>
+      </div>
+      <button style={{
+        marginTop: 12, width: '100%', height: 44, borderRadius: 10,
+        background: "var(--primary)", color: 'var(--primary-foreground)', border: 'none', cursor: 'pointer',
+        fontFamily: 'inherit', fontSize: 14, fontWeight: 600, letterSpacing: -0.1,
+        display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
+      }}>
+        <IconClipboard size={15} stroke="var(--primary-foreground)" /> Paste from clipboard
+      </button>
+      <button style={{
+        marginTop: 8, width: '100%', height: 40, borderRadius: 10,
+        background: 'transparent', color: "var(--foreground-dim)", border: 'none', cursor: 'pointer',
+        fontFamily: 'inherit', fontSize: 13, fontWeight: 500,
+      }}>Type a URL instead</button>
+    </div>
+  );
+}
+
+// Pasted — URL detected; preview + kind detection + one-tap Add
+function PastedState({ url, domain }) {
+  return (
+    <div style={{ padding: '4px 16px 16px' }}>
+      {/* URL preview card — auto-detected */}
+      <div style={{
+        padding: 12, borderRadius: 12, background: "var(--card)", border: '1px solid var(--border)',
+        display: 'flex', alignItems: 'center', gap: 10,
+      }}>
+        <div style={{
+          flexShrink: 0, width: 36, height: 36, borderRadius: 8,
+          background: "var(--primary-tint)", color: "var(--primary)",
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+        }}><IconArt size={18} stroke="var(--primary)" /></div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 11, color: "var(--muted)", fontWeight: 500, letterSpacing: 0.1 }}>
+            Detected · Article
+          </div>
+          <div style={{
+            fontSize: 13, fontWeight: 500, color: "var(--foreground)", letterSpacing: -0.1, marginTop: 2,
+            overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+          }}>{domain}</div>
+        </div>
+        <button style={{
+          width: 28, height: 28, border: 'none', background: 'transparent',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          color: "var(--muted)", borderRadius: 6, cursor: 'pointer',
+        }}><IconClose size={14} stroke="var(--muted)" /></button>
+      </div>
+
+      {/* Topic (optional) */}
+      <div style={{ marginTop: 14 }}>
+        <div style={{
+          fontSize: 11, fontWeight: 600, letterSpacing: 0.8, textTransform: 'uppercase',
+          color: "var(--muted)", marginBottom: 6,
+        }}>Topic</div>
+        <div style={{
+          height: 40, padding: '0 12px', borderRadius: 10,
+          background: "var(--pill-bg)", border: '1px solid var(--border)',
+          display: 'flex', alignItems: 'center',
+          fontSize: 13, color: "var(--muted-dim)", letterSpacing: -0.1,
+        }}>
+          # context <span style={{ marginLeft: 'auto', color: "var(--muted-dim)", fontSize: 11 }}>Auto-tag</span>
+        </div>
+      </div>
+
+      {/* CTAs */}
+      <button style={{
+        marginTop: 16, width: '100%', height: 48, borderRadius: 12,
+        background: "var(--primary)", color: 'var(--primary-foreground)', border: 'none', cursor: 'pointer',
+        fontFamily: 'inherit', fontSize: 15, fontWeight: 600, letterSpacing: -0.1,
+      }}>Add to library</button>
+      <div style={{
+        marginTop: 10, fontSize: 11, color: "var(--muted-dim)", textAlign: 'center',
+      }}>
+        Will queue for processing · you'll see it in Library instantly
+      </div>
+    </div>
+  );
+}
+
+// Done — success flash
+function DoneState({ domain }) {
+  return (
+    <div style={{ padding: '20px 16px 24px', display: 'flex', flexDirection: 'column', alignItems: 'center', textAlign: 'center' }}>
+      <div style={{
+        width: 56, height: 56, borderRadius: 28,
+        background: "var(--primary-tint)", color: "var(--primary)",
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        marginBottom: 12,
+      }}><IconCheck size={24} stroke="var(--primary)" /></div>
+      <div style={{ fontSize: 16, fontWeight: 600, color: "var(--foreground)", letterSpacing: -0.2 }}>
+        Queued for processing
+      </div>
+      <div style={{ fontSize: 13, color: "var(--muted)", marginTop: 4, letterSpacing: -0.1 }}>
+        {domain}
+      </div>
+      <div style={{ marginTop: 18, display: 'flex', gap: 8, width: '100%' }}>
+        <button style={{
+          flex: 1, height: 44, borderRadius: 10,
+          background: 'transparent', color: "var(--foreground)", border: '1px solid var(--border)', cursor: 'pointer',
+          fontFamily: 'inherit', fontSize: 14, fontWeight: 500,
+        }}>View in Library</button>
+        <button style={{
+          flex: 1, height: 44, borderRadius: 10,
+          background: "var(--primary)", color: 'var(--primary-foreground)', border: 'none', cursor: 'pointer',
+          fontFamily: 'inherit', fontSize: 14, fontWeight: 600,
+        }}>Add another</button>
+      </div>
+    </div>
+  );
+}
+
+// Screen wrappers — Library-with-FAB, and Library-with-sheet-open (dimmed bg)
+function ScreenLibraryFab() {
+  return (
+    <div style={{ width: '100%', height: '100%', position: 'relative' }}>
+      <ScreenLibrary active="home" />
+      <FAB />
+    </div>
+  );
+}
+
+function ScreenLibrarySheet({ state = 'pasted' }) {
+  return (
+    <div style={{ width: '100%', height: '100%', position: 'relative' }}>
+      <ScreenLibrary active="home" />
+      <PasteSheet state={state} />
+    </div>
+  );
+}
+
+Object.assign(window, {
+  FAB, PasteSheet, ScreenLibraryFab, ScreenLibrarySheet,
+});

--- a/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/lib/kh-screens.jsx
+++ b/.od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/lib/kh-screens.jsx
@@ -1,0 +1,413 @@
+// kh-screens.jsx — redesigned Knowledge Hub mobile screens
+// Shared component set that consumes project/design-system/tokens.css.
+
+// ─── Icons (stroke-only, 20px) ─────────────────────────────
+const Icon = ({ d, size = 20, stroke = 'currentColor', fill = 'none', sw = 1.6 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill={fill} stroke={stroke}
+       strokeWidth={sw} strokeLinecap="round" strokeLinejoin="round">
+    {typeof d === 'string' ? <path d={d} /> : d}
+  </svg>
+);
+const IconSearch = (p) => <Icon {...p} d={<><circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/></>} />;
+const IconMoon   = (p) => <Icon {...p} d="M20.5 13.5A8.5 8.5 0 1 1 10.5 3.5a6.5 6.5 0 0 0 10 10Z" />;
+const IconSun    = (p) => <Icon {...p} d={<><circle cx="12" cy="12" r="3.5"/><path d="M12 3v2M12 19v2M3 12h2M19 12h2M5.6 5.6l1.4 1.4M17 17l1.4 1.4M5.6 18.4 7 17M17 7l1.4-1.4"/></>} />;
+const IconHome   = (p) => <Icon {...p} d={<><path d="M3.5 11 12 4l8.5 7"/><path d="M5 10v9h14v-9"/></>} />;
+const IconLibrary= (p) => <Icon {...p} d={<><rect x="3.5" y="4.5" width="17" height="15" rx="2"/><path d="M8 4v15M3.5 9h4.5"/></>} />;
+const IconOps    = (p) => <Icon {...p} d={<><circle cx="12" cy="12" r="3"/><path d="M12 2v3M12 19v3M4.2 4.2l2.1 2.1M17.7 17.7l2.1 2.1M2 12h3M19 12h3M4.2 19.8l2.1-2.1M17.7 6.3l2.1-2.1"/></>} />;
+const IconPlay   = (p) => <Icon {...p} d="M8 5v14l11-7z" fill="currentColor" stroke="none" />;
+const IconImage  = (p) => <Icon {...p} d={<><rect x="3" y="4" width="18" height="16" rx="2"/><circle cx="9" cy="10" r="1.5"/><path d="m3 16 5-4 6 5 3-2 4 3"/></>} />;
+const IconLink   = (p) => <Icon {...p} d="M10 14a4 4 0 0 0 5.7 0l3-3a4 4 0 0 0-5.7-5.7L11.5 7M14 10a4 4 0 0 0-5.7 0l-3 3a4 4 0 1 0 5.7 5.7L12.5 17" />;
+const IconGit    = (p) => <Icon {...p} d={<><circle cx="6" cy="6" r="2.5"/><circle cx="6" cy="18" r="2.5"/><circle cx="18" cy="8" r="2.5"/><path d="M6 8.5v7M8.5 6H14a3 3 0 0 1 3 3v1"/></>} />;
+const IconClock  = (p) => <Icon {...p} d={<><circle cx="12" cy="12" r="8.5"/><path d="M12 7v5.5l3.5 2"/></>} />;
+const IconChevronLeft = (p) => <Icon {...p} d="M15 6l-6 6 6 6" />;
+const IconMoreHorizontal = (p) => <Icon {...p} d={<><circle cx="5" cy="12" r="1.4" fill="currentColor"/><circle cx="12" cy="12" r="1.4" fill="currentColor"/><circle cx="19" cy="12" r="1.4" fill="currentColor"/></>} stroke="none" />;
+
+// ─── Tiny primitives ───────────────────────────────────────
+const BOTTOM_NAV_ITEMS = [
+  { id: 'home', label: 'Home', icon: IconHome },
+  { id: 'search', label: 'Search', icon: IconSearch },
+  { id: 'library', label: 'Library', icon: IconLibrary },
+  { id: 'ops', label: 'Ops', icon: IconOps },
+];
+
+function useCanvasTheme() {
+  const ctx = window.DCCtx ? React.useContext(window.DCCtx) : null;
+  return ctx || {};
+}
+
+const pillColorForTone = (tone, active) => {
+  if (active || tone === 'primary') return 'var(--primary)';
+  if (tone === 'success') return 'var(--success)';
+  if (tone === 'info') return 'var(--info)';
+  if (tone === 'warning') return 'var(--warning)';
+  if (tone === 'danger') return 'var(--danger)';
+  return 'var(--foreground-dim)';
+};
+
+const Pill = ({ tone = 'neutral', size = 'sm', active, style, children, ...rest }) => {
+  const h = size === 'xs' ? 20 : 22;
+  const fs = size === 'xs' ? 10 : 11;
+  return (
+    <span {...rest} style={{
+      display: 'inline-flex', alignItems: 'center', height: h, padding: '0 8px',
+      borderRadius: 'var(--radius-full)', fontSize: fs, fontWeight: 500,
+      letterSpacing: 'var(--tracking-wide)',
+      background: active || tone === 'primary' ? 'var(--primary-tint)' : 'var(--pill-bg)',
+      color: pillColorForTone(tone, active),
+      border: `1px solid ${active ? 'transparent' : 'var(--border)'}`,
+      ...style,
+    }}>{children}</span>
+  );
+};
+
+// ─── Header (56px, single row) ─────────────────────────────
+function SearchBar() {
+  return (
+    <div style={{
+      flex: 1, display: 'flex', alignItems: 'center', gap: 8,
+      height: 36, padding: '0 12px',
+      background: 'var(--pill-bg)', border: '1px solid var(--border-strong)',
+      borderRadius: 'var(--radius-lg)', color: 'var(--foreground)',
+    }}>
+      <IconSearch size={14} stroke="var(--muted)" />
+      <div style={{ flex: 1, fontSize: 13, color: 'var(--foreground)' }}>
+        agent orchestration
+        <span style={{ display: 'inline-block', width: 1, height: 13, marginLeft: 1,
+                       background: 'var(--primary)', verticalAlign: '-2px',
+                       animation: 'khBlink 1s steps(2) infinite' }} />
+      </div>
+      <span style={{ fontSize: 11, color: 'var(--muted)' }}>Cancel</span>
+    </div>
+  );
+}
+
+function PageHeader({ title, leading, actions }) {
+  return (
+    <header style={{
+      position: 'sticky', top: 0, zIndex: 30,
+      height: 56, padding: '0 16px',
+      display: 'flex', alignItems: 'center', gap: 10,
+      background: 'var(--header-bg)', backdropFilter: 'blur(var(--blur-md))', WebkitBackdropFilter: 'blur(var(--blur-md))',
+      borderBottom: '1px solid var(--border)',
+    }}>
+      {leading ?? (
+        <div style={{
+          width: 24, height: 24, borderRadius: 6,
+          background: 'var(--primary)', color: 'var(--primary-foreground)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          fontSize: 11, fontWeight: 700, letterSpacing: -0.3,
+        }}>KH</div>
+      )}
+      <div style={{ fontSize: 15, fontWeight: 600, color: 'var(--foreground)', letterSpacing: -0.2 }}>{title}</div>
+      <div style={{ flex: 1 }} />
+      {actions}
+    </header>
+  );
+}
+
+function DetailHeader({ back = 'Back', actions }) {
+  return (
+    <header style={{
+      position: 'sticky', top: 0, zIndex: 30,
+      height: 56, padding: '0 8px 0 4px',
+      display: 'flex', alignItems: 'center', gap: 4,
+      background: 'var(--header-bg)', backdropFilter: 'blur(var(--blur-md))', WebkitBackdropFilter: 'blur(var(--blur-md))',
+      borderBottom: '1px solid var(--border)',
+    }}>
+      <IconButton icon={IconChevronLeft} label="Back" />
+      <div style={{
+        fontSize: 13, fontWeight: 500, color: 'var(--muted)', letterSpacing: -0.1,
+      }}>{back}</div>
+      <div style={{ flex: 1 }} />
+      {actions}
+      <IconButton icon={IconMoreHorizontal} label="More" />
+    </header>
+  );
+}
+
+function Header({ searchOpen, title = 'Library' }) {
+  const { themeMode = 'dark', toggleTheme } = useCanvasTheme();
+  const ThemeIcon = themeMode === 'dark' ? IconSun : IconMoon;
+  return searchOpen ? (
+    <PageHeader title="" leading={<SearchBar />} />
+  ) : (
+    <PageHeader
+      title={title}
+      actions={
+        <>
+          <IconButton icon={IconSearch} label="Search" />
+          <IconButton icon={ThemeIcon} label="Toggle theme" onClick={toggleTheme} />
+        </>
+      }
+    />
+  );
+}
+
+function Button({ variant = 'ghost', size = 'md', icon: IconEl, iconRight: IconRight, fullWidth, style, children, ...rest }) {
+  const sizes = {
+    sm: { h: 28, px: 10, fs: 12, gap: 5 },
+    md: { h: 32, px: 12, fs: 13, gap: 6 },
+    lg: { h: 44, px: 16, fs: 14, gap: 8 },
+  };
+  const variants = {
+    primary: { background: 'var(--primary)', color: 'var(--primary-foreground)', border: '1px solid transparent' },
+    ghost: { background: 'transparent', color: 'var(--foreground)', border: '1px solid transparent' },
+    outline: { background: 'transparent', color: 'var(--foreground)', border: '1px solid var(--border)' },
+    danger: { background: 'var(--danger)', color: 'var(--primary-foreground)', border: '1px solid transparent' },
+  };
+  const s = sizes[size];
+  return (
+    <button {...rest} style={{
+      height: s.h, padding: `0 ${s.px}px`,
+      borderRadius: 'var(--radius-md)',
+      display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: s.gap,
+      fontFamily: 'inherit', fontSize: s.fs, fontWeight: 500,
+      letterSpacing: 'var(--tracking-flat)', whiteSpace: 'nowrap', cursor: 'pointer',
+      transition: 'background var(--duration-2) var(--ease-out)',
+      width: fullWidth ? '100%' : undefined,
+      ...variants[variant],
+      ...style,
+    }}>
+      {IconEl && <IconEl size={s.fs} sw={1.6} strokeWidth={1.6} />}
+      {children}
+      {IconRight && <IconRight size={s.fs} sw={1.6} strokeWidth={1.6} />}
+    </button>
+  );
+}
+
+function IconButton({ icon: IconEl, size = 'md', label, style, ...rest }) {
+  const dim = size === 'sm' ? 28 : size === 'lg' ? 44 : 36;
+  const ic = size === 'sm' ? 14 : size === 'lg' ? 20 : 17;
+  return (
+    <button aria-label={label} {...rest} style={{
+      width: dim, height: dim, border: 'none', background: 'transparent',
+      borderRadius: 'var(--radius-md)', cursor: 'pointer',
+      display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+      color: 'var(--foreground)',
+      ...style,
+    }}><IconEl size={ic} sw={1.6} strokeWidth={1.6} /></button>
+  );
+}
+
+// ─── Section header ────────────────────────────────────────
+function SectionLabel({ label, count }) {
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'baseline', justifyContent: 'space-between',
+      padding: '0 16px', marginTop: 20, marginBottom: 8,
+    }}>
+      <div style={{
+        fontSize: 11, fontWeight: 600, letterSpacing: 0.8, textTransform: 'uppercase',
+        color: 'var(--muted)',
+      }}>{label}</div>
+      {count != null && (
+        <div style={{ fontSize: 11, color: 'var(--muted-dim)', fontVariantNumeric: 'tabular-nums' }}>{count}</div>
+      )}
+    </div>
+  );
+}
+
+// ─── Video card (list row) ────────────────────────────────
+function VideoCard({ data }) {
+  return (
+    <article style={{
+      margin: '0 16px 8px', padding: 12,
+      background: 'var(--card)', border: '1px solid var(--border)',
+      borderRadius: 12, display: 'flex', gap: 12,
+    }}>
+      <div style={{
+        flexShrink: 0, width: 72, height: 72, borderRadius: 8,
+        background: 'linear-gradient(135deg, var(--thumb), var(--thumb-accent))',
+        position: 'relative', overflow: 'hidden',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+      }}>
+        <div style={{
+          position: 'absolute', inset: 0,
+          backgroundImage: 'repeating-linear-gradient(135deg, transparent 0 9px, var(--border) 9px 10px)',
+          opacity: 0.7,
+        }} />
+        <div style={{
+          width: 28, height: 28, borderRadius: 14, background: 'var(--scrim)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          color: 'var(--primary-foreground)', position: 'relative', backdropFilter: 'blur(4px)',
+        }}>
+          <IconPlay size={12} />
+        </div>
+        <div style={{
+          position: 'absolute', right: 4, bottom: 4,
+          padding: '1px 5px', borderRadius: 4,
+          background: 'var(--scrim)', color: 'var(--primary-foreground)',
+          fontSize: 9, fontWeight: 600, letterSpacing: 0.2,
+          fontVariantNumeric: 'tabular-nums',
+        }}>{data.duration}</div>
+      </div>
+      <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 6 }}>
+        <div style={{
+          fontSize: 15, fontWeight: 600, lineHeight: 1.3, color: 'var(--foreground)',
+          letterSpacing: -0.2,
+          display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical',
+          overflow: 'hidden',
+        }}>{data.title}</div>
+        <div style={{
+          fontSize: 13, lineHeight: 1.4, color: 'var(--muted)',
+          display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical',
+          overflow: 'hidden',
+        }}>{data.summary}</div>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginTop: 2 }}>
+          {data.tags.map((tg) => <Pill key={tg}>#{tg}</Pill>)}
+        </div>
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: 8, marginTop: 2,
+          fontSize: 11, color: 'var(--muted-dim)', fontVariantNumeric: 'tabular-nums',
+        }}>
+          <span style={{ color: 'var(--muted)', fontWeight: 500 }}>{data.channel}</span>
+          <span>·</span>
+          <span>{data.date}</span>
+          {data.ss && (<><span>·</span><span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
+            <IconImage size={11} stroke="var(--muted-dim)" sw={1.8} />{data.ss}
+          </span></>)}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+// ─── Source card (article/repo/link) ──────────────────────
+function SourceCard({ data }) {
+  const iconFor = { Article: IconLink, Repo: IconGit, Site: IconLink }[data.kind] || IconLink;
+  const IconEl = iconFor;
+  return (
+    <article style={{
+      margin: '0 16px 8px', padding: 12,
+      background: 'var(--card)', border: '1px solid var(--border)',
+      borderRadius: 12,
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+        <div style={{
+          width: 24, height: 24, borderRadius: 6,
+          background: 'var(--pill-bg)', color: 'var(--muted)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          border: '1px solid var(--border)',
+        }}>
+          <IconEl size={13} stroke="var(--muted)" />
+        </div>
+        <div style={{ fontSize: 11, color: 'var(--muted)', fontWeight: 500, letterSpacing: 0.1 }}>
+          {data.kind} · <span style={{ color: data.status === 'done' ? 'var(--success)' : data.status === 'processing' ? 'var(--info)' : 'var(--muted)' }}>{data.status}</span>
+        </div>
+      </div>
+      <div style={{
+        fontSize: 15, fontWeight: 600, lineHeight: 1.3, color: 'var(--foreground)',
+        letterSpacing: -0.2, marginBottom: 6,
+        display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden',
+      }}>{data.title}</div>
+      <div style={{
+        fontSize: 13, lineHeight: 1.45, color: 'var(--muted)', marginBottom: 8,
+        display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden',
+      }}>{data.summary}</div>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginBottom: 6 }}>
+        {data.tags.map((tg) => <Pill key={tg}>#{tg}</Pill>)}
+      </div>
+      <div style={{
+        fontSize: 11, color: 'var(--muted-dim)', fontVariantNumeric: 'tabular-nums',
+        overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+      }}>{data.url}</div>
+    </article>
+  );
+}
+
+// ─── Bottom nav (4 items, 64px, labelled) ─────────────────
+function BottomNav({ items = BOTTOM_NAV_ITEMS, active, onSelect }) {
+  return (
+    <div style={{
+      position: 'absolute', left: 0, right: 0, bottom: 0,
+      height: 64, paddingBottom: 'env(safe-area-inset-bottom, 0)',
+      borderTop: '1px solid var(--border)',
+      background: 'var(--nav-bg)', backdropFilter: 'blur(var(--blur-lg))', WebkitBackdropFilter: 'blur(var(--blur-lg))',
+      display: 'flex', zIndex: 30,
+    }}>
+      {items.map(({ id, label, icon: I }) => {
+        const on = id === active;
+        return (
+          <button key={id} onClick={() => onSelect?.(id)} style={{
+            flex: 1, border: 'none', background: 'transparent', cursor: 'pointer',
+            display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
+            gap: 3, padding: 0,
+            color: on ? 'var(--primary)' : 'var(--muted)',
+          }}>
+            <I size={20} stroke="currentColor" sw={on ? 2 : 1.6} />
+            <span style={{ fontSize: 11, fontWeight: on ? 600 : 500, letterSpacing: 0.1, lineHeight: 1 }}>{label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── Sample data ──────────────────────────────────────────
+const VIDEOS = [
+  { title: 'Building agent orchestration with LangGraph from first principles',
+    summary: 'A ground-up walkthrough of stateful graphs, checkpointing, and how to escape the ReAct-loop tarpit when tools start failing.',
+    tags: ['agents', 'langgraph', 'tooling'], channel: 'Latent Space', date: 'Apr 14', duration: '42:08', ss: 18 },
+  { title: 'The case against micro-RAG: when retrieval actually hurts',
+    summary: 'Why naïve chunked vector search falls apart on long-form reasoning — and three patterns that replace it.',
+    tags: ['rag', 'evals'], channel: 'Anthropic', date: 'Apr 10', duration: '28:41', ss: 9 },
+  { title: 'Designing a knowledge hub for a team of one',
+    summary: 'Solo-dev notes on keeping transcripts, sources, and skills from turning into a graveyard of half-read PDFs.',
+    tags: ['knowledge', 'workflow'], channel: 'Notes from work', date: 'Apr 6', duration: '14:22', ss: 5 },
+];
+
+const SOURCES = [
+  { kind: 'Article', title: 'Context engineering is the new prompt engineering',
+    summary: 'A tour through why the "prompt" abstraction is dissolving into something closer to long-form context curation.',
+    tags: ['context', 'prompting'], status: 'done', url: 'simonwillison.net/2026/apr/context' },
+  { kind: 'Repo', title: 'stanford-crfm/levanter',
+    summary: 'JAX-based training framework with a clean separation between model code, optimizer state, and checkpointing.',
+    tags: ['training', 'jax'], status: 'processing', url: 'github.com/stanford-crfm/levanter' },
+];
+
+// ─── Full screen: Library ─────────────────────────────────
+function ScreenLibrary({ searchOpen = false, active = 'home' }) {
+  return (
+    <div style={{
+      width: '100%', height: '100%', background: 'var(--background)',
+      color: 'var(--foreground)', fontFamily: 'var(--font-sans)',
+      display: 'flex', flexDirection: 'column',
+      position: 'relative', overflow: 'hidden',
+      fontFeatureSettings: 'var(--font-feature-settings)',
+    }}>
+      <Header searchOpen={searchOpen} />
+      <div style={{ flex: 1, overflowY: 'auto', paddingBottom: 80 }}>
+        <SectionLabel label="Videos" count="24 total" />
+        {VIDEOS.map((v, i) => <VideoCard key={i} data={v} />)}
+        <SectionLabel label="Other knowledge" count="12 sources" />
+        {SOURCES.map((s, i) => <SourceCard key={i} data={s} />)}
+        <SectionLabel label="Recent activity" />
+        <div style={{
+          margin: '0 16px', padding: 12,
+          background: 'var(--card)', border: '1px solid var(--border)', borderRadius: 12,
+          display: 'flex', alignItems: 'center', gap: 10,
+        }}>
+          <div style={{
+            width: 28, height: 28, borderRadius: 8, background: 'var(--primary-tint)',
+            color: 'var(--primary)', display: 'flex', alignItems: 'center', justifyContent: 'center',
+          }}><IconClock size={15} /></div>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--foreground)', letterSpacing: -0.1 }}>
+              Poll completed · 3 new videos
+            </div>
+            <div style={{ fontSize: 11, color: 'var(--muted-dim)', marginTop: 2 }}>
+              kolejain · 4 min ago
+            </div>
+          </div>
+        </div>
+      </div>
+      <BottomNav active={active} />
+    </div>
+  );
+}
+
+Object.assign(window, {
+  ScreenLibrary, Header, PageHeader, DetailHeader, SearchBar, SectionLabel, VideoCard, SourceCard,
+  BottomNav, Button, IconButton, Pill, VIDEOS, SOURCES,
+  IconSearch, IconMoon, IconSun, IconHome, IconLibrary, IconOps, IconPlay,
+});

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Track the Knowhub Open Design artifact bundle with design-system-token-backed standalone screens.
+
 ## [0.4.0] - 2026-05-05
 
 A multi-protocol leap: Open Design now ships as an MCP server, ships Critique Theater (Design Jury) Phase 4, gains live-reload + Tweaks mode + live artifacts in the preview pane, and adds five new agent / runtime adapters. 71 merged PRs from 40+ contributors over two days. Linux AppImage packaging landed in tooling, but the stable Linux artifact is deferred from 0.4.0 while containerized release packaging is hardened.


### PR DESCRIPTION
## Summary
- Track the Knowhub Open Design artifact bundle so the design-system compliance refactor can be reviewed and shipped.
- Refactor Knowhub standalone JSX screens to consume `design-system/tokens.css` via `var(--...)` values instead of `KH_TOKENS`, `KH_FONT`, and `t` prop threading.
- Align inline standalone component APIs with the design-system TSX component props for `Pill`, `PageHeader` / `DetailHeader`, `BottomNav`, `Button`, and `IconButton`.
- Load `design-system/tokens.css` from all three standalone HTML artifacts and use scoped `data-theme` wrappers for dark/light canvases.

## Verification
- `grep -rE "(KH_TOKENS|KH_FONT)" .od/projects/b8171267-18a9-457e-9157-01307f6f277f/knowhub/project/lib/` returned zero matches.
- Product UI hardcoded color grep returned zero matches for `kh-screens.jsx`, `kh-detail-screens.jsx`, `kh-quickadd.jsx`, and `kh-history.jsx`.
- All `var(--...)` references in Knowhub `project/lib` resolve against `project/design-system/tokens.css`.
- Playwright local artifact smoke passed for `Mobile redesign.html`, `Quick add.html`, and `Detail page.html` with no runtime errors.
- Theme toggle changed the canvas root `data-theme` from `dark` to `light`.
- `corepack pnpm guard` passed.
- `PATH=/tmp/pnpm-shim:$PATH corepack pnpm typecheck` passed after building `@open-design/desktop` locally so `apps/packaged` could resolve `@open-design/desktop/main` generated types.

## Review Status
- No GitHub status checks have appeared yet for this fork PR.
- No automated bot review comments are present.
- Required human review is pending; the open-design team commented that they will run a deep review within 24h.

Generated with [Claude Code](https://claude.com/claude-code)
