### PR TITLE
Fix packaged contracts runtime exports

### DIFF
--- a/packages/contracts/esbuild.config.mjs
+++ b/packages/contracts/esbuild.config.mjs
@@ -1,0 +1,13 @@
+import { build } from "esbuild";
+
+await build({
+  bundle: true,
+  entryNames: "[name]",
+  entryPoints: ["./src/index.ts", "./src/critique.ts"],
+  format: "esm",
+  outdir: "./dist",
+  outExtension: { ".js": ".mjs" },
+  packages: "external",
+  platform: "node",
+  target: "node24",
+});

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -4,18 +4,23 @@
   "private": true,
   "type": "module",
   "description": "Shared pure TypeScript contracts for the Open Design web/daemon boundary.",
+  "main": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "exports": {
     ".": {
-      "types": "./src/index.ts",
-      "default": "./src/index.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.mjs"
     },
     "./critique": {
-      "types": "./src/critique.ts",
-      "default": "./src/critique.ts"
+      "types": "./dist/critique.d.ts",
+      "default": "./dist/critique.mjs"
     }
   },
-  "types": "./src/index.ts",
   "scripts": {
+    "build": "node ./esbuild.config.mjs && tsc -p tsconfig.json --emitDeclarationOnly",
     "test": "vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.tests.json --noEmit"
   },
@@ -23,6 +28,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "esbuild": "0.27.7",
     "typescript": "^5.6.3",
     "vitest": "^2.1.8"
   }

--- a/packages/contracts/tests/package-runtime.test.ts
+++ b/packages/contracts/tests/package-runtime.test.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs';
+import { access } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -26,5 +27,24 @@ describe('@open-design/contracts package runtime shape', () => {
     expect(pkg.exports?.['.']?.types).toBe('./dist/index.d.ts');
     expect(pkg.exports?.['./critique']?.default).toBe('./dist/critique.mjs');
     expect(pkg.exports?.['./critique']?.types).toBe('./dist/critique.d.ts');
+  });
+
+  it('points every runtime export at generated files', async () => {
+    await expect(access(join(packageRoot, 'dist/index.mjs'))).resolves.toBeUndefined();
+    await expect(access(join(packageRoot, 'dist/index.d.ts'))).resolves.toBeUndefined();
+    await expect(access(join(packageRoot, 'dist/critique.mjs'))).resolves.toBeUndefined();
+    await expect(access(join(packageRoot, 'dist/critique.d.ts'))).resolves.toBeUndefined();
+  });
+
+  it('makes runtime exports importable through package exports', async () => {
+    const contracts = await import('@open-design/contracts');
+    const critique = await import('@open-design/contracts/critique');
+
+    expect(contracts.composeSystemPrompt).toEqual(expect.any(Function));
+    expect(contracts.exampleHealthResponse).toEqual({ ok: true, service: 'daemon' });
+    expect(critique.defaultCritiqueConfig()).toMatchObject({
+      enabled: false,
+      protocolVersion: critique.CRITIQUE_PROTOCOL_VERSION,
+    });
   });
 });

--- a/packages/contracts/tests/package-runtime.test.ts
+++ b/packages/contracts/tests/package-runtime.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+function readPackageJson(): {
+  exports?: Record<string, { default?: string; types?: string }>;
+  files?: string[];
+  main?: string;
+  types?: string;
+} {
+  return JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8'));
+}
+
+describe('@open-design/contracts package runtime shape', () => {
+  it('exports built JavaScript instead of TypeScript source files', () => {
+    const pkg = readPackageJson();
+
+    expect(pkg.main).toBe('./dist/index.mjs');
+    expect(pkg.types).toBe('./dist/index.d.ts');
+    expect(pkg.files).toEqual(['dist']);
+    expect(pkg.exports?.['.']?.default).toBe('./dist/index.mjs');
+    expect(pkg.exports?.['.']?.types).toBe('./dist/index.d.ts');
+    expect(pkg.exports?.['./critique']?.default).toBe('./dist/critique.mjs');
+    expect(pkg.exports?.['./critique']?.types).toBe('./dist/critique.d.ts');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,6 +242,9 @@ importers:
         specifier: ^3.23.8
         version: 3.25.76
     devDependencies:
+      esbuild:
+        specifier: 0.27.7
+        version: 0.27.7
       typescript:
         specifier: ^5.6.3
         version: 5.9.3

--- a/scripts/guard.ts
+++ b/scripts/guard.ts
@@ -34,6 +34,9 @@ const residualSkippedDirectories = new Set([
 ]);
 
 const residualAllowedExactPaths = new Set([
+  // esbuild config entrypoints are executed directly by Node before package
+  // dist output exists.
+  "packages/contracts/esbuild.config.mjs",
   "packages/platform/esbuild.config.mjs",
   "packages/sidecar/esbuild.config.mjs",
   "packages/sidecar-proto/esbuild.config.mjs",

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -6,6 +6,7 @@ const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, "..");
 
 const buildTargets = [
+  "packages/contracts",
   "packages/sidecar-proto",
   "packages/sidecar",
   "packages/platform",

--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -277,6 +277,7 @@ async function buildWorkspaceArtifacts(config: ToolPackConfig): Promise<void> {
   const webNextEnvPath = join(config.workspaceRoot, "apps", "web", "next-env.d.ts");
   const previousWebNextEnv = await readFile(webNextEnvPath, "utf8").catch(() => null);
 
+  await runPnpm(config, ["--filter", "@open-design/contracts", "build"]);
   await runPnpm(config, ["--filter", "@open-design/sidecar-proto", "build"]);
   await runPnpm(config, ["--filter", "@open-design/sidecar", "build"]);
   await runPnpm(config, ["--filter", "@open-design/platform", "build"]);

--- a/tools/pack/src/mac.ts
+++ b/tools/pack/src/mac.ts
@@ -388,6 +388,7 @@ async function buildWorkspaceArtifacts(config: ToolPackConfig): Promise<void> {
   const webNextEnvPath = join(config.workspaceRoot, "apps", "web", "next-env.d.ts");
   const previousWebNextEnv = await readFile(webNextEnvPath, "utf8").catch(() => null);
 
+  await runPnpm(config, ["--filter", "@open-design/contracts", "build"]);
   await runPnpm(config, ["--filter", "@open-design/sidecar-proto", "build"]);
   await runPnpm(config, ["--filter", "@open-design/sidecar", "build"]);
   await runPnpm(config, ["--filter", "@open-design/platform", "build"]);

--- a/tools/pack/src/win.ts
+++ b/tools/pack/src/win.ts
@@ -609,6 +609,7 @@ async function buildWorkspaceArtifacts(config: ToolPackConfig): Promise<void> {
   const webNextEnvPath = join(config.workspaceRoot, "apps", "web", "next-env.d.ts");
   const previousWebNextEnv = await readFile(webNextEnvPath, "utf8").catch(() => null);
 
+  await runPnpm(config, ["--filter", "@open-design/contracts", "build"]);
   await runPnpm(config, ["--filter", "@open-design/sidecar-proto", "build"]);
   await runPnpm(config, ["--filter", "@open-design/sidecar", "build"]);
   await runPnpm(config, ["--filter", "@open-design/platform", "build"]);


### PR DESCRIPTION
## Summary
- Build @open-design/contracts into dist/*.mjs and dist/*.d.ts for package runtime exports.
- Point package exports at built artifacts so packaged Node runtimes do not import TypeScript from node_modules.
- Build contracts before packaged linux/mac/win assembly and during the shared postinstall bootstrap.
- Add runtime package-shape coverage that checks generated files and imports both package export paths.

## Verification
- pnpm install
- pnpm --filter @open-design/contracts test -- package-runtime.test.ts
- pnpm --filter @open-design/contracts build
- pnpm -C packages/contracts typecheck
- pnpm guard
- rm -rf packages/contracts/dist && node scripts/postinstall.mjs
- pnpm --filter @open-design/daemon build
- pnpm --filter @open-design/tools-pack test
- pnpm --filter @open-design/tools-pack build
- pnpm -C tools/pack typecheck
- Linux AppImage smoke downstream: packaged daemon/web reached running state

## Follow-up from Linux/AUR smoke
The AUR package now pre-extracts the AppImage into an AppDir at install time, which avoids repeated AppImage extraction on launch and materially improves startup. That is useful upstream packaging work, but it changes tools-pack linux install/start/uninstall process matching and AppDir permission handling, so it should be a separate focused PR instead of being bundled into this contracts runtime export fix.