### PR TITLE
[codex] Fix packaged contracts runtime exports

### DIFF
--- a/packages/contracts/esbuild.config.mjs
+++ b/packages/contracts/esbuild.config.mjs
@@ -1,0 +1,13 @@
+import { build } from "esbuild";
+
+await build({
+  bundle: true,
+  entryPoints: ["./src/index.ts", "./src/critique.ts"],
+  format: "esm",
+  outbase: "./src",
+  outdir: "./dist",
+  outExtension: { ".js": ".mjs" },
+  packages: "external",
+  platform: "node",
+  target: "node24",
+});

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -4,18 +4,24 @@
   "private": true,
   "type": "module",
   "description": "Shared pure TypeScript contracts for the Open Design web/daemon boundary.",
+  "main": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "package.json"
+  ],
   "exports": {
     ".": {
-      "types": "./src/index.ts",
-      "default": "./src/index.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.mjs"
     },
     "./critique": {
-      "types": "./src/critique.ts",
-      "default": "./src/critique.ts"
+      "types": "./dist/critique.d.ts",
+      "default": "./dist/critique.mjs"
     }
   },
-  "types": "./src/index.ts",
   "scripts": {
+    "build": "node ./esbuild.config.mjs && tsc -p tsconfig.json",
     "test": "vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.tests.json --noEmit"
   },
@@ -23,6 +29,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "esbuild": "0.27.7",
     "typescript": "^5.6.3",
     "vitest": "^2.1.8"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,6 +242,9 @@ importers:
         specifier: ^3.23.8
         version: 3.25.76
     devDependencies:
+      esbuild:
+        specifier: 0.27.7
+        version: 0.27.7
       typescript:
         specifier: ^5.6.3
         version: 5.9.3

--- a/scripts/guard.ts
+++ b/scripts/guard.ts
@@ -34,6 +34,7 @@ const residualSkippedDirectories = new Set([
 ]);
 
 const residualAllowedExactPaths = new Set([
+  "packages/contracts/esbuild.config.mjs",
   "packages/platform/esbuild.config.mjs",
   "packages/sidecar/esbuild.config.mjs",
   "packages/sidecar-proto/esbuild.config.mjs",

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -6,6 +6,7 @@ const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, "..");
 
 const buildTargets = [
+  "packages/contracts",
   "packages/sidecar-proto",
   "packages/sidecar",
   "packages/platform",

--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -277,6 +277,7 @@ async function buildWorkspaceArtifacts(config: ToolPackConfig): Promise<void> {
   const webNextEnvPath = join(config.workspaceRoot, "apps", "web", "next-env.d.ts");
   const previousWebNextEnv = await readFile(webNextEnvPath, "utf8").catch(() => null);
 
+  await runPnpm(config, ["--filter", "@open-design/contracts", "build"]);
   await runPnpm(config, ["--filter", "@open-design/sidecar-proto", "build"]);
   await runPnpm(config, ["--filter", "@open-design/sidecar", "build"]);
   await runPnpm(config, ["--filter", "@open-design/platform", "build"]);

--- a/tools/pack/src/mac.ts
+++ b/tools/pack/src/mac.ts
@@ -388,6 +388,7 @@ async function buildWorkspaceArtifacts(config: ToolPackConfig): Promise<void> {
   const webNextEnvPath = join(config.workspaceRoot, "apps", "web", "next-env.d.ts");
   const previousWebNextEnv = await readFile(webNextEnvPath, "utf8").catch(() => null);
 
+  await runPnpm(config, ["--filter", "@open-design/contracts", "build"]);
   await runPnpm(config, ["--filter", "@open-design/sidecar-proto", "build"]);
   await runPnpm(config, ["--filter", "@open-design/sidecar", "build"]);
   await runPnpm(config, ["--filter", "@open-design/platform", "build"]);

--- a/tools/pack/src/win.ts
+++ b/tools/pack/src/win.ts
@@ -609,6 +609,7 @@ async function buildWorkspaceArtifacts(config: ToolPackConfig): Promise<void> {
   const webNextEnvPath = join(config.workspaceRoot, "apps", "web", "next-env.d.ts");
   const previousWebNextEnv = await readFile(webNextEnvPath, "utf8").catch(() => null);
 
+  await runPnpm(config, ["--filter", "@open-design/contracts", "build"]);
   await runPnpm(config, ["--filter", "@open-design/sidecar-proto", "build"]);
   await runPnpm(config, ["--filter", "@open-design/sidecar", "build"]);
   await runPnpm(config, ["--filter", "@open-design/platform", "build"]);

--- a/tools/pack/tests/linux.test.ts
+++ b/tools/pack/tests/linux.test.ts
@@ -65,10 +65,10 @@ describe("buildDockerArgs", () => {
 
   it("mounts docker home and electron caches under .tmp/tools-pack/.docker-*", () => {
     const args = buildDockerArgs(makeConfig(), { uid: 1000, gid: 1000 });
-    expect(args).toContain("/work/.tmp/tools-pack/.docker-home:/home/builder");
-    expect(args).toContain("/work/.tmp/tools-pack/.docker-cache/electron:/home/builder/.cache/electron");
+    expect(args).toContain(`${join("/work/.tmp/tools-pack", ".docker-home")}:/home/builder`);
+    expect(args).toContain(`${join("/work/.tmp/tools-pack", ".docker-cache", "electron")}:/home/builder/.cache/electron`);
     expect(args).toContain(
-      "/work/.tmp/tools-pack/.docker-cache/electron-builder:/home/builder/.cache/electron-builder",
+      `${join("/work/.tmp/tools-pack", ".docker-cache", "electron-builder")}:/home/builder/.cache/electron-builder`,
     );
   });
 


### PR DESCRIPTION
## Summary

- Build `@open-design/contracts` into runtime JS and declaration files before packaging.
- Point the contracts package exports at `dist/*.mjs` / `dist/*.d.ts` instead of TypeScript source files.
- Include the contracts build in postinstall and all packaged build lanes so Windows/macOS/Linux packaged apps install runtime-safe contracts tarballs.
- Make the tools-pack Linux Docker mount test work on Windows path separators.

## Root Cause

The packaged app installed `@open-design/contracts` with exports such as `@open-design/contracts/critique` pointing to `src/critique.ts`. The daemon sidecar imports runtime values from that subpath, so the packaged Windows Node runtime attempted to load a TypeScript file from `node_modules`, which fails with `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING` and prevents the daemon IPC pipe from coming up.

## Validation

- `pnpm -C packages/contracts pack --dry-run` confirms the tarball contains `dist/**` and `package.json`, not `src/*.ts`.
- `node -e "import('@open-design/contracts/critique')..."` from `apps/daemon` loads runtime functions successfully.
- `pnpm --filter @open-design/contracts build`
- `pnpm --filter @open-design/contracts typecheck`
- `pnpm --filter @open-design/contracts test`
- `pnpm --filter @open-design/daemon build`
- `pnpm --filter @open-design/tools-pack build`
- `pnpm --filter @open-design/tools-pack test`
- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/packaged build`

Note: local verification ran on Node v22.18.0, so pnpm emitted engine warnings because the repo targets Node ~24.