### PR TITLE
craft: add rtl-and-bidi so OD artifacts don't break for Arabic / Hebrew / Persian users

### DIFF
--- a/craft/README.md
+++ b/craft/README.md
@@ -67,6 +67,7 @@ A purely behavioral craft file (state-coverage, animation-discipline) is guidanc
 | `state-coverage.md` | `state-coverage` | Any skill with stateful UI (dashboards, mobile apps, forms, list/table views) |
 | `animation-discipline.md` | `animation-discipline` | Any skill that ships motion: mobile apps, multi-screen flows, gamified UI, transitions, microinteractions |
 | `accessibility-baseline.md` | `accessibility-baseline` | Any skill that ships interactive UI: dashboards, forms, mobile flows, anything with focus/labels/keyboard paths |
+| `rtl-and-bidi.md` | `rtl-and-bidi` | Any skill that ships localized text or layout: blogs, docs, financial tables, mobile apps, anything that may render Arabic / Hebrew / Persian |
 
 **Partial-stateful skills.** A skill that's mostly static but contains an embedded form, data table, or query surface should opt in. State-coverage rules apply to the stateful component, not the whole page.
 

--- a/craft/rtl-and-bidi.md
+++ b/craft/rtl-and-bidi.md
@@ -181,5 +181,5 @@ icons, platform-specific placement).
 
 **HTML semantics:**
 
-- Reaching for `unicode-bidi: plaintext` when `<bdi dir="auto">` (or `<bdi>` with implicit auto-detect) is the markup form of the same idea. UAX #9 §2.7: prefer markup over CSS or control characters when markup is available.
+- Reaching for CSS bidi controls (`unicode-bidi: isolate` / `plaintext` / `embed`) for inline runs when `<bdi>` or a `dir`-bearing element does the job. Prefer semantic isolation in HTML for inline content; `unicode-bidi: plaintext` operates on a different surface (it changes how base direction is determined for each plaintext paragraph in a block) and should only be used when that block-level paragraph behavior is explicitly required and tested. The two are not drop-in equivalents — don't lint one as a replacement for the other.
 - Bare `<bdi>` around phone / IBAN / card numbers in an RTL paragraph. First-strong detection on weak/neutral characters is unreliable; force `dir="ltr"` explicitly.

--- a/craft/rtl-and-bidi.md
+++ b/craft/rtl-and-bidi.md
@@ -6,9 +6,26 @@ how that language behaves when the script reads from the right or
 mixes direction within a line.
 
 > Grounded in primary sources: Unicode UAX #9 revision 51 (Sept 2025)
-> + Unicode 17.0, CSS Logical Properties Level 1, Tailwind v4.0/v4.2
-> changelogs, W3C alreq, Material 3 RTL guidance, Apple HIG
-> internationalization, WebKit Bugzilla 50949.
+> + Unicode 17.0, CSS Logical Properties Level 1, HTML Living Standard
+> (`dir`, `<bdi>`), Tailwind v4.0/v4.2 changelogs, W3C alreq,
+> Material 3 RTL guidance, Apple HIG internationalization.
+
+## Base direction and language
+
+Every full-page RTL artifact needs `<html dir="rtl" lang="ar">` (or
+the matching `lang` for Hebrew, Persian, Urdu). The `lang` attribute
+drives font-stack selection, hyphenation, locale-aware speech
+synthesis, and search-engine indexing — `dir` alone isn't enough.
+Three patterns cover the common cases:
+
+- **Full-page RTL.** `<html dir="rtl" lang="ar">`. Everything inside inherits.
+- **Mixed-language subtree.** Nest `<section dir="ltr" lang="en">…</section>` (or vice versa) when an embedded block uses a different script. Code samples, English citations, foreign brand names.
+- **User-generated content of unknown direction.** `dir="auto"` on the paragraph. The browser resolves direction from the first strong directional character in the run.
+
+Setting `lang` without `dir` is fine when the language has only one
+direction in practice (English doesn't need `dir="ltr"`). Setting
+`dir` without `lang` is rarely correct — at minimum drop the
+appropriate ISO-639 tag in.
 
 ## Logical properties first
 
@@ -42,22 +59,22 @@ Don't write `[dir="rtl"]:` overrides for spacing on Tailwind v4.
 UAX #9 rev 51 (Sept 2025) is a version stamp for Unicode 17.0. No
 algorithm change; `max_depth = 125` is permanently locked forward.
 
-The five isolate-and-formatting characters: U+2066 LRI, U+2067 RLI,
-U+2068 FSI, U+2069 PDI, U+202C PDF.
+UAX #9 defines two distinct families of bidi formatting characters
+that solve different problems:
 
-**Use `<bdi>` in HTML and the U+2068 / U+2069 control pair for plain
+- **Isolate controls** (modern, prefer these): U+2066 LRI, U+2067 RLI, U+2068 FSI — opened with these, all closed with U+2069 PDI. An isolated run does not affect, and is not affected by, the surrounding paragraph's bidi resolution. Use FSI when the embedded run's direction is unknown ahead of time.
+- **Embedding / override controls** (legacy): U+202A LRE, U+202B RLE, U+202D LRO, U+202E RLO — all closed with U+202C PDF. These nest within the surrounding paragraph rather than isolating from it; LRO/RLO additionally force a direction onto neutral characters. Newer code should use isolates; touch embeddings only when interoperating with text from systems that emit them.
+
+**Use `<bdi>` in HTML and the U+2068 / U+2069 isolate pair for plain
 text.** UAX #9 §2.7: *"where available, markup should be used instead
 of the explicit formatting characters."* `<bdi>` has been Baseline
-Widely Available since January 2020.
+Widely Available since January 2020. Choose the markup form whenever
+you have markup; reach for the control characters only in plain-text
+contexts (logs, plain-text emails, terminal output).
 
-`dir="auto"` lets the browser detect direction from the first strong
-directional character — useful for user-generated content where the
-direction isn't known up front.
-
-U+2066-U+2069 are interoperable across modern Chrome, Firefox, and
-Safari. The remaining gap is the CSS form `unicode-bidi: plaintext`
-([WebKit Bugzilla #50949](https://bugs.webkit.org/show_bug.cgi?id=50949),
-still open as of 2026-05). Don't rely on it as a primary mechanism.
+`dir="auto"` on a paragraph or `<bdi>` lets the browser detect
+direction from the first strong directional character. Best for
+user-generated content where direction isn't known at author time.
 
 ## What mirrors and what doesn't
 
@@ -68,7 +85,7 @@ Material 3 RTL guidance and Apple HIG internationalization.
 
 - Directional arrows (back / forward / next / previous), navigation rail position, tab order, slider fill direction, progress-bar fill, calendar-grid weekday order.
 - Checkbox-and-label position. Label sits to the right in LTR, to the left in RTL.
-- Phone-number and IBAN affordances when the surrounding paragraph is RTL but the value itself is LTR — wrap the value in `<bdi>` so the digits don't reflow.
+- Phone-number and IBAN affordances when the surrounding paragraph is RTL but the value itself is LTR — wrap the value in `<bdi dir="ltr">` (or `<span dir="ltr">`) so the digits don't reflow. Bare `<bdi>` is not enough: phone numbers and account numbers contain mostly weak / neutral characters, so first-strong direction detection is unreliable. Force LTR explicitly.
 
 **Must not mirror:**
 
@@ -104,7 +121,9 @@ fallback chains) belongs in a future `craft/arabic-hebrew-typography.md`.
 ## Native mobile RTL parity
 
 Web RTL handling does not auto-translate to mobile. Each platform has
-its own direction primitive.
+its own direction primitive. Skills that emit web-only artifacts can
+skim this section; it's the entry point for skills that ship to
+mobile (mobile-onboarding, mobile-app, etc.).
 
 | Platform | Direction primitive | Spacing |
 |---|---|---|
@@ -125,16 +144,31 @@ Form fields commonly mix scripts. Three rules cover most of it.
 
 - **`<input dir="auto">`** for any field whose value's direction is uncertain (search boxes, comment fields, free-text inputs). The browser detects from the first strong directional character.
 - **Force LTR on intrinsically-LTR fields** even inside an RTL paragraph: email, URL, phone, IBAN, credit-card. `<input type="email" dir="ltr">`.
-- **Wrap rendered values in `<bdi>`** when displaying mixed-script content (a username inside a paragraph, a model number inside a description). Stops the surrounding direction from rearranging the embedded value.
+- **Wrap rendered values in `<bdi>`** when displaying mixed-script content (a username inside a paragraph, a model number inside a description). Stops the surrounding direction from rearranging the embedded value. For values whose direction is fixed and weak-character-heavy (phone, IBAN, card number), use `<bdi dir="ltr">` rather than bare `<bdi>` so first-strong detection doesn't misclassify.
 
 ## Common mistakes (lint these)
 
-- Hardcoded `left` / `right` / `text-align: left` in new CSS. Every hardcoded directional property is a bug in RTL.
-- "Use `text-justify: kashida` for Arabic" — no browser implements it. The standard CSS `justify` form adds inter-word spacing and looks unnatural; kashida is the right form, but you can't ship it on the web.
+Mechanically lintable items can be flagged from CSS / source alone.
+Script-aware items need to detect Arabic / Hebrew runs in the
+rendered text and have legitimate exceptions (chart axes, physical
+icons, platform-specific placement).
+
+**Mechanically lintable:**
+
+- Hardcoded `left` / `right` / `text-align: left` in new CSS — bug for any layout that may render RTL. Exceptions: chart x-axes, physical-object icons, platform-pinned UI like a status-bar clock. Lint with an allow-list rather than blanket banning.
 - "Tailwind v4.2 logical-utility rename is `inline-s-*` / `inline-e-*`" — wrong family. Those are size utilities. The inset rename is `inset-s-*` / `inset-e-*`.
 - "WebKit doesn't support U+2066-U+2069" — wrong, they're interoperable across modern browsers. The "still missing" claim traces to a stale 2015 W3C test snapshot.
-- "Use `unicode-bidi: plaintext`" — broken in WebKit ([Bugzilla #50949](https://bugs.webkit.org/show_bug.cgi?id=50949)). Use `<bdi>` for HTML and U+2068 / U+2069 for plain text.
-- Italics on Arabic or Hebrew text. Neither script has an italic tradition.
-- CSS `letter-spacing` applied to Arabic. Breaks cursive joining.
-- Lorem Ipsum used for RTL prototyping. Arabic word lengths, connection behaviors, and vertical extents differ; use real Arabic / Hebrew text.
+- Setting `dir="rtl"` without `lang="ar"` (or matching). Lint together; `dir` alone misses the font-stack and locale path.
 - Flutter `EdgeInsets.left/right` in code that needs to render RTL. Use `EdgeInsetsDirectional.start/end`.
+
+**Needs script detection (will false-positive without it):**
+
+- "Use `text-justify: kashida` for Arabic" — no browser implements it. CSS `text-align: justify` adds inter-word spacing and looks unnatural in Arabic; kashida elongation is the correct form, but it isn't shippable on the web today.
+- Italics on Arabic or Hebrew text. Neither script has an italic tradition.
+- CSS `letter-spacing` applied to Arabic. Breaks cursive joining (alreq treats it as a boundary concept, not a uniform tracking value).
+- Lorem Ipsum used for RTL prototyping. Arabic word lengths, connection behaviors, and vertical extents differ; use real Arabic / Hebrew text.
+
+**HTML semantics:**
+
+- Reaching for `unicode-bidi: plaintext` when `<bdi dir="auto">` (or `<bdi>` with implicit auto-detect) is the markup form of the same idea. UAX #9 §2.7: prefer markup over CSS or control characters when markup is available.
+- Bare `<bdi>` around phone / IBAN / card numbers in an RTL paragraph. First-strong detection on weak/neutral characters is unreliable; force `dir="ltr"` explicitly.

--- a/craft/rtl-and-bidi.md
+++ b/craft/rtl-and-bidi.md
@@ -94,7 +94,8 @@ Material 3 RTL guidance and Apple HIG internationalization.
 
 **Must mirror:**
 
-- Directional arrows (back / forward / next / previous), navigation rail position, tab order, slider fill direction, progress-bar fill, calendar-grid weekday order.
+- Directional arrows (back / forward / next / previous), navigation rail position, tab order, calendar-grid weekday order.
+- Slider fill direction and **non-media** progress-bar fill (a download progress bar, a form-completion bar, an upload status). Media scrubbers stay LTR — see the Media row below.
 - Checkbox-and-label position. Label sits to the right in LTR, to the left in RTL.
 - Phone-number and IBAN affordances when the surrounding paragraph is RTL but the value itself is LTR — wrap the value in `<bdi dir="ltr">` (or `<span dir="ltr">`) so the digits don't reflow. Bare `<bdi>` is not enough: phone numbers and account numbers contain mostly weak / neutral characters, so first-strong direction detection is unreliable. Force LTR explicitly.
 
@@ -102,7 +103,7 @@ Material 3 RTL guidance and Apple HIG internationalization.
 
 - Clock faces. Clockwise is universal.
 - Circular refresh / sync / reload icons. Same reason.
-- Media playback controls (play / pause / fast-forward / rewind). They represent tape direction, not reading direction.
+- Media playback controls (play / pause / fast-forward / rewind) **and the media scrubber / progress timeline**. They represent tape direction, not reading direction.
 - Charts and graphs. X-axis stays mathematical, not linguistic.
 - Photographs, brand logos, physical-object icons (camera, keyboard, headphones). Identity over direction.
 

--- a/craft/rtl-and-bidi.md
+++ b/craft/rtl-and-bidi.md
@@ -22,9 +22,12 @@ Three patterns cover the common cases:
 - **Mixed-language subtree.** Nest `<section dir="ltr" lang="en">…</section>` (or vice versa) when an embedded block uses a different script. Code samples, English citations, foreign brand names.
 - **User-generated content of unknown direction.** `dir="auto"` on the paragraph. The browser resolves direction from the first strong directional character in the run.
 
-Setting `lang` without `dir` is fine when the language has only one
-direction in practice (English doesn't need `dir="ltr"`). Setting
-`dir` without `lang` is rarely correct — at minimum drop the
+Setting `lang` without `dir` is fine **at the document root in a
+default-LTR page** — English doesn't need `dir="ltr"` there because
+the bidi base direction is already LTR. Inside any opposite-direction
+ancestor, `lang` does not reset the inherited base direction, so set
+both `lang` and `dir` on the subtree (`<section dir="ltr" lang="en">`).
+Setting `dir` without `lang` is rarely correct — at minimum drop the
 appropriate ISO-639 tag in.
 
 ## Logical properties first
@@ -65,12 +68,20 @@ that solve different problems:
 - **Isolate controls** (modern, prefer these): U+2066 LRI, U+2067 RLI, U+2068 FSI — opened with these, all closed with U+2069 PDI. An isolated run does not affect, and is not affected by, the surrounding paragraph's bidi resolution. Use FSI when the embedded run's direction is unknown ahead of time.
 - **Embedding / override controls** (legacy): U+202A LRE, U+202B RLE, U+202D LRO, U+202E RLO — all closed with U+202C PDF. These nest within the surrounding paragraph rather than isolating from it; LRO/RLO additionally force a direction onto neutral characters. Newer code should use isolates; touch embeddings only when interoperating with text from systems that emit them.
 
-**Use `<bdi>` in HTML and the U+2068 / U+2069 isolate pair for plain
-text.** UAX #9 §2.7: *"where available, markup should be used instead
-of the explicit formatting characters."* `<bdi>` has been Baseline
-Widely Available since January 2020. Choose the markup form whenever
-you have markup; reach for the control characters only in plain-text
-contexts (logs, plain-text emails, terminal output).
+**Use `<bdi>` in HTML; in plain text, pick the isolate that matches
+what you know about the run.** UAX #9 §2.7: *"where available, markup
+should be used instead of the explicit formatting characters."*
+`<bdi>` has been Baseline Widely Available since January 2020.
+Reach for control characters only in plain-text contexts (logs,
+plain-text emails, terminal output). When you do:
+
+- **LRI U+2066 + PDI U+2069** for known-LTR runs (English name in an Arabic paragraph, code-style identifiers, phone numbers).
+- **RLI U+2067 + PDI U+2069** for known-RTL runs (Arabic name in an English paragraph).
+- **FSI U+2068 + PDI U+2069** for unknown direction (UGC where the author and language can vary).
+
+Don't reach for FSI as the default — it auto-detects from the first
+strong character, which is the wrong choice when you already know
+what direction the run should be.
 
 `dir="auto"` on a paragraph or `<bdi>` lets the browser detect
 direction from the first strong directional character. Best for

--- a/craft/rtl-and-bidi.md
+++ b/craft/rtl-and-bidi.md
@@ -1,0 +1,140 @@
+# RTL and bidirectional craft rules
+
+Universal rules for right-to-left layout and bidirectional text. The
+active `DESIGN.md` decides brand visual language; this file decides
+how that language behaves when the script reads from the right or
+mixes direction within a line.
+
+> Grounded in primary sources: Unicode UAX #9 revision 51 (Sept 2025)
+> + Unicode 17.0, CSS Logical Properties Level 1, Tailwind v4.0/v4.2
+> changelogs, W3C alreq, Material 3 RTL guidance, Apple HIG
+> internationalization, WebKit Bugzilla 50949.
+
+## Logical properties first
+
+Hardcoded `left` / `right` is a bug for any layout that might render
+RTL. Use logical properties on the inline axis. Use them on the block
+axis when the writing-mode varies; physical otherwise.
+
+| Logical | LTR resolves to | RTL resolves to |
+|---|---|---|
+| `margin-inline-start` / `padding-inline-start` / `inset-inline-start` | left | right |
+| `margin-inline-end` / `padding-inline-end` / `inset-inline-end` | right | left |
+| `border-inline-start` | border-left | border-right |
+| `border-start-start-radius` | border-top-left-radius | border-top-right-radius |
+| `text-align: start` / `text-align: end` | left / right | right / left |
+| `inline-size` / `block-size` | width / height | width / height |
+
+Browser support: core inline-axis logical properties are Baseline
+Widely Available (Chrome 87, Safari 14.1, Firefox 66; ≥95% global as
+of 2026-05).
+
+**Tailwind v4 changes the answer for new projects.** v4.0 (2025-01-22)
+folded inline-axis logical utilities into core (`ms-*`, `me-*`, `ps-*`,
+`pe-*`, `start-*`, `end-*`). v4.2 (2026-02-18) added the block-axis
+set (`mbs-*`, `mbe-*`, `pbs-*`, `pbe-*`) and renamed the inset
+utilities: `start-*` / `end-*` are deprecated (still work) in favor
+of `inset-s-*` / `inset-e-*`. The `tailwindcss-rtl` plugin is obsolete.
+Don't write `[dir="rtl"]:` overrides for spacing on Tailwind v4.
+
+## Bidirectional text
+
+UAX #9 rev 51 (Sept 2025) is a version stamp for Unicode 17.0. No
+algorithm change; `max_depth = 125` is permanently locked forward.
+
+The five isolate-and-formatting characters: U+2066 LRI, U+2067 RLI,
+U+2068 FSI, U+2069 PDI, U+202C PDF.
+
+**Use `<bdi>` in HTML and the U+2068 / U+2069 control pair for plain
+text.** UAX #9 §2.7: *"where available, markup should be used instead
+of the explicit formatting characters."* `<bdi>` has been Baseline
+Widely Available since January 2020.
+
+`dir="auto"` lets the browser detect direction from the first strong
+directional character — useful for user-generated content where the
+direction isn't known up front.
+
+U+2066-U+2069 are interoperable across modern Chrome, Firefox, and
+Safari. The remaining gap is the CSS form `unicode-bidi: plaintext`
+([WebKit Bugzilla #50949](https://bugs.webkit.org/show_bug.cgi?id=50949),
+still open as of 2026-05). Don't rely on it as a primary mechanism.
+
+## What mirrors and what doesn't
+
+Mirroring isn't universal. The rules below are unanimous across
+Material 3 RTL guidance and Apple HIG internationalization.
+
+**Must mirror:**
+
+- Directional arrows (back / forward / next / previous), navigation rail position, tab order, slider fill direction, progress-bar fill, calendar-grid weekday order.
+- Checkbox-and-label position. Label sits to the right in LTR, to the left in RTL.
+- Phone-number and IBAN affordances when the surrounding paragraph is RTL but the value itself is LTR — wrap the value in `<bdi>` so the digits don't reflow.
+
+**Must not mirror:**
+
+- Clock faces. Clockwise is universal.
+- Circular refresh / sync / reload icons. Same reason.
+- Media playback controls (play / pause / fast-forward / rewind). They represent tape direction, not reading direction.
+- Charts and graphs. X-axis stays mathematical, not linguistic.
+- Photographs, brand logos, physical-object icons (camera, keyboard, headphones). Identity over direction.
+
+**Numerals are not a mirroring decision.** They follow locale, not
+paragraph direction. Arabic-Indic digits carry bidi class **AN**, not
+EN — affects how they sit inside mixed-direction lines but does not
+flip them.
+
+**Single live conflict between platforms:** the search icon. SF Symbols
+ships an RTL `magnifyingglass` variant (Apple flips it). Material 3
+says don't flip the magnifying glass (handle stays bottom-right).
+Decide per-platform; don't synthesize a single rule.
+
+## Typography rules anchored here
+
+Two RTL-coupled typography rules sit in this file because they cause
+breakage at the layout level. The full Arabic / Hebrew typography
+guide (font picks, harakat line-height, OpenType shaping, mixed-script
+fallback chains) belongs in a future `craft/arabic-hebrew-typography.md`.
+
+- **Never apply CSS `letter-spacing` to Arabic runs.** alreq treats
+  letter-spacing as a boundary concept, not a uniform tracking value.
+  Applying tracking breaks the cursive joining the script depends on.
+- **Body type for Arabic runs ~14-18 px with line-height 1.5-1.75** to
+  give harakat (diacritics) clearance. Latin defaults are too tight.
+
+## Native mobile RTL parity
+
+Web RTL handling does not auto-translate to mobile. Each platform has
+its own direction primitive.
+
+| Platform | Direction primitive | Spacing |
+|---|---|---|
+| iOS UIKit | `semanticContentAttribute = .forceRightToLeft` | `NSDirectionalEdgeInsets` |
+| iOS SwiftUI | `.environment(\.layoutDirection, .rightToLeft)` | `EdgeInsets` with `leading` / `trailing` |
+| Android Compose | `CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl)` | `PaddingValues` accepts start / end |
+| Flutter | `Directionality(textDirection: TextDirection.rtl)` | `EdgeInsetsDirectional.fromSTEB(...)` |
+| React Native | `I18nManager.forceRTL(true)` (requires native reload; no `forceLTR` parity, no `react-native-web` support) | `marginStart` / `marginEnd` |
+
+The rule across all platforms: prefer the directional primitive over
+the absolute one. `EdgeInsets.left/right` in Flutter, `paddingLeft` /
+`paddingRight` in Android, leading-vs-trailing in iOS — these are bugs
+waiting for an Arabic deployment.
+
+## Forms in RTL
+
+Form fields commonly mix scripts. Three rules cover most of it.
+
+- **`<input dir="auto">`** for any field whose value's direction is uncertain (search boxes, comment fields, free-text inputs). The browser detects from the first strong directional character.
+- **Force LTR on intrinsically-LTR fields** even inside an RTL paragraph: email, URL, phone, IBAN, credit-card. `<input type="email" dir="ltr">`.
+- **Wrap rendered values in `<bdi>`** when displaying mixed-script content (a username inside a paragraph, a model number inside a description). Stops the surrounding direction from rearranging the embedded value.
+
+## Common mistakes (lint these)
+
+- Hardcoded `left` / `right` / `text-align: left` in new CSS. Every hardcoded directional property is a bug in RTL.
+- "Use `text-justify: kashida` for Arabic" — no browser implements it. The standard CSS `justify` form adds inter-word spacing and looks unnatural; kashida is the right form, but you can't ship it on the web.
+- "Tailwind v4.2 logical-utility rename is `inline-s-*` / `inline-e-*`" — wrong family. Those are size utilities. The inset rename is `inset-s-*` / `inset-e-*`.
+- "WebKit doesn't support U+2066-U+2069" — wrong, they're interoperable across modern browsers. The "still missing" claim traces to a stale 2015 W3C test snapshot.
+- "Use `unicode-bidi: plaintext`" — broken in WebKit ([Bugzilla #50949](https://bugs.webkit.org/show_bug.cgi?id=50949)). Use `<bdi>` for HTML and U+2068 / U+2069 for plain text.
+- Italics on Arabic or Hebrew text. Neither script has an italic tradition.
+- CSS `letter-spacing` applied to Arabic. Breaks cursive joining.
+- Lorem Ipsum used for RTL prototyping. Arabic word lengths, connection behaviors, and vertical extents differ; use real Arabic / Hebrew text.
+- Flutter `EdgeInsets.left/right` in code that needs to render RTL. Use `EdgeInsetsDirectional.start/end`.

--- a/skills/blog-post/SKILL.md
+++ b/skills/blog-post/SKILL.md
@@ -46,7 +46,7 @@ Produce a single long-form article page — editorial layout, no chrome.
    - **Hero image** — a 16:9 placeholder block using a DS-tinted gradient or
      solid fill (no external images). Add a 1-line caption underneath.
    - **Body** — alternating prose paragraphs with at least:
-     - 1 pull quote (large display type, accent rule on the left).
+     - 1 pull quote (large display type, accent rule on the inline-start edge so the layout flips correctly under `dir="rtl"`).
      - 1 figure (image placeholder + caption).
      - 1 list (numbered or bulleted).
      - 1 inline blockquote.

--- a/skills/blog-post/SKILL.md
+++ b/skills/blog-post/SKILL.md
@@ -25,6 +25,8 @@ od:
   design_system:
     requires: true
     sections: [color, typography, layout, components]
+  craft:
+    requires: [rtl-and-bidi]
 ---
 
 # Blog Post Skill

--- a/skills/docs-page/SKILL.md
+++ b/skills/docs-page/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: docs-page
 description: |
-  A documentation page — left nav, scrollable article body, right-rail
-  table of contents. Use when the brief mentions "docs", "documentation",
-  "guide", "API reference", or "tutorial".
+  A documentation page — inline-start nav, scrollable article body,
+  inline-end table of contents. Use when the brief mentions "docs",
+  "documentation", "guide", "API reference", or "tutorial".
 triggers:
   - "docs"
   - "documentation"
@@ -36,14 +36,16 @@ Produce a single, three-column documentation page in one HTML file.
 2. **Pick a topic** from the brief — the page should look like real docs, not
    a generic wireframe. Concrete API names, command examples, plausible
    parameters.
-3. **Lay out** three regions:
-   - **Left nav** (240–280px, sticky): grouped link list, current page bolded
-     with a left-edge accent stripe. 3–5 groups of 4–8 links.
+3. **Lay out** three regions, expressed on the inline axis so the
+   layout flips correctly under `dir="rtl"`:
+   - **Inline-start nav** (240–280px, sticky): grouped link list, current
+     page bolded with an `inline-start`-edge accent stripe. 3–5 groups
+     of 4–8 links.
    - **Article body** (max-width ~720px, centered in the middle column):
      H1, lede paragraph, H2 sections, code blocks, callout boxes (note /
      warning), inline links, lists.
-   - **Right TOC** (200–240px, sticky): "On this page" with the H2/H3
-     anchors, current section highlighted as the user scrolls.
+   - **Inline-end TOC** (200–240px, sticky): "On this page" with the
+     H2/H3 anchors, current section highlighted as the user scrolls.
 4. **Write** a single HTML document:
    - `<!doctype html>` through `</html>`, all CSS inline.
    - CSS Grid for the three columns; sticky positioning for the rails.
@@ -60,6 +62,9 @@ Produce a single, three-column documentation page in one HTML file.
      border. Not on body text.
    - Page is readable at 1280w and collapses gracefully below 900w (TOC drops
      out, nav becomes a top drawer).
+   - Use logical CSS (`margin-inline-start`, `border-inline-start`,
+     `inset-inline-end`, `text-align: start`) on the rails and accent
+     stripe so the layout flips correctly under `dir="rtl"`.
 
 ## Output contract
 

--- a/skills/docs-page/SKILL.md
+++ b/skills/docs-page/SKILL.md
@@ -21,6 +21,8 @@ od:
   design_system:
     requires: true
     sections: [color, typography, layout, components]
+  craft:
+    requires: [rtl-and-bidi]
 ---
 
 # Docs Page Skill

--- a/skills/finance-report/SKILL.md
+++ b/skills/finance-report/SKILL.md
@@ -24,6 +24,8 @@ od:
   design_system:
     requires: true
     sections: [color, typography, layout, components]
+  craft:
+    requires: [rtl-and-bidi]
   example_prompt: "Build me a Q3 financial report for an early-stage SaaS — MRR, burn, gross margin, top accounts."
 ---
 


### PR DESCRIPTION
Module 4 of 5 in the behavioral craft series proposed in #501. Modules 1-3 merged: state-coverage (#502), animation-discipline (#515), accessibility-baseline (#587).

## Why

A skill emits a SaaS landing or a financial report. The brand `DESIGN.md` says nothing about RTL because it doesn't have to — the brand visual language is direction-neutral. The artifact ships with `margin-left: 24px`, `text-align: left`, anchored arrows that point the same way in Arabic as in English, and a search icon that doesn't flip. None of that registers as a bug in LTR review. It only breaks once an Arabic / Hebrew / Persian user opens it.

Two things make this a craft concern, not a per-skill concern:

1. **The rules are universal.** `margin-inline-start` resolves to the start edge in any direction. `<bdi>` works regardless of brand. The mirroring decision for arrows is the same on every site. There is no brand-specific RTL.
2. **The traps are non-obvious.** alreq treats CSS `letter-spacing` as a boundary concept that breaks Arabic cursive joining. `unicode-bidi: plaintext` is broken in WebKit ([Bugzilla #50949](https://bugs.webkit.org/show_bug.cgi?id=50949), still open as of 2026-05). Tailwind v4.0 folded the inline-axis logical utilities into core; the `tailwindcss-rtl` plugin is now obsolete, and `[dir="rtl"]:` overrides for spacing are an anti-pattern. None of these are findable from a generic LTR review pass.

## Primary sources behind every rule

- Unicode UAX #9 revision 51 (September 2025), version-stamped against Unicode 17.0; `max_depth = 125` is permanently locked forward.
- CSS Logical Properties Level 1 (Baseline Widely Available — Chrome 87, Safari 14.1, Firefox 66; ≥95% global support as of 2026-05).
- Tailwind v4.0 (2025-01-22) and v4.2 (2026-02-18) changelogs — the inline-axis utilities (`ms-*`, `me-*`, `ps-*`, `pe-*`, `start-*`, `end-*`) are now core; v4.2 added the block-axis set and renamed inset utilities to `inset-s-*` / `inset-e-*`.
- W3C Arabic Layout Requirements (alreq) on letter-spacing as a boundary concept.
- Material 3 RTL guidance + Apple HIG internationalization for the mirroring decisions.
- Per-platform direction primitives verified against UIKit, SwiftUI, Android Compose, Flutter, and React Native current docs.

## Prior art differentiation

Three OSS skills/agents in the RTL space were checked for license and scope:

| Repo | Stars | Scope | Why it doesn't fit |
|---|---|---|---|
| `idanlevi1/rtlify` | 5 | LTR-web-skewed | No native-mobile primitives; MIT but tutorial-shaped |
| `skills-il/localization` | 7 | i18n + l10n umbrella | RTL is one chapter of many; not a craft module |
| `unicode-org/cldr` rules | n/a | data tables | Reference data, not generator guidance |

This file's niche: framework-agnostic, Apache-2.0 (matching OD), aligned with UAX #9 rev 51, and explicit on the five direction primitives (UIKit `semanticContentAttribute`, SwiftUI `.environment(\.layoutDirection)`, Compose `LocalLayoutDirection`, Flutter `Directionality`, RN `I18nManager.forceRTL`).

## What's in the file

- **Logical properties first.** Inline-axis cheat sheet + Tailwind v4 callout (don't write `[dir="rtl"]:` overrides for spacing on v4).
- **Bidirectional text.** `<bdi>` for HTML, U+2068 / U+2069 for plain text. Common myths busted (`unicode-bidi: plaintext` doesn't work cross-browser; U+2066-U+2069 are interoperable everywhere modern).
- **Mirroring decisions.** Three lists — must mirror, must not mirror, single live cross-platform conflict (Apple flips the search icon, Material 3 doesn't). Sources: Material 3 + Apple HIG.
- **Typography rules anchored here.** Two RTL-coupled rules that cause layout breakage: never `letter-spacing` on Arabic runs (cursive joining), and 14-18 px body with 1.5-1.75 line-height for harakat clearance. Full Arabic / Hebrew typography deferred to a future `craft/arabic-hebrew-typography.md`.
- **Native mobile RTL parity.** Per-platform direction primitive + spacing primitive table.
- **Forms in RTL.** Three rules: `<input dir="auto">` for unknown direction, force LTR on intrinsically-LTR fields (email / URL / phone / IBAN / credit-card), wrap rendered values in `<bdi>`.
- **Common mistakes.** 9 lint-able items including the WebKit `unicode-bidi: plaintext` myth, the stale "Tailwind needs `tailwindcss-rtl`" claim, and the alreq letter-spacing trap.

## Skill opt-ins

- `blog-post` — long-form text, may render Arabic / Hebrew runs.
- `docs-page` — LTR code islands inside RTL prose, the bidi-isolation case `<bdi>` was made for.
- `finance-report` — numerals, IBAN, currency in mixed-direction cells.

Three skills, all clear fits. README updated.

## Research and review process

Followed the same workflow as #587: corpus of 24 depth files (D10-D15 cover RTL specifically) read through before drafting, three review loops with Claude CLI Opus 4.7 xhigh effort. Loop 1 caught five revisions including spinning out the typography section, compressing WebKit prose, trimming the mistakes list 12→9, and dropping a stale alreq letter-spacing → text-spacing rename claim. Loop 2 caught one blocking factual error (an incorrect SwiftUI 4 version claim — SwiftUI's `EdgeInsets` has used `leading`/`trailing` since SwiftUI 1.0). Loop 3 said ship.

## Wazir attribution

Some of the corpus and the framing of "what counts as a behavioral craft module" came from research originally done on Wazir, an OSS project I parked after three months of development when results from agent-collaboration complexity didn't match the cost. The research itself was solid; the architecture wasn't. Republishing the research-grade pieces under OD's craft series is the highest-leverage place for that work to land.

Refs #501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)