### PR TITLE
Fix agent CLI config and workspace focus mode

### DIFF
--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -122,6 +122,7 @@ export async function detectAcpModels({
   bin,
   args,
   cwd = process.cwd(),
+  env = process.env,
   timeoutMs = DEFAULT_TIMEOUT_MS,
   clientName = 'open-design-detect',
   clientVersion = 'runtime-adapter',
@@ -131,7 +132,7 @@ export async function detectAcpModels({
     const child = spawn(bin, args, {
       cwd,
       stdio: ['pipe', 'pipe', 'pipe'],
-      env: { ...process.env },
+      env: { ...env },
     });
     child.stdout.setEncoding('utf8');
     child.stderr.setEncoding('utf8');

--- a/apps/daemon/src/agents.ts
+++ b/apps/daemon/src/agents.ts
@@ -253,7 +253,7 @@ export const AGENT_DEFS = [
     name: 'Devin for Terminal',
     bin: 'devin',
     versionArgs: ['--version'],
-    fetchModels: async (resolvedBin) =>
+    fetchModels: async (resolvedBin, env) =>
       detectAcpModels({
         bin: resolvedBin,
         args: [
@@ -263,6 +263,7 @@ export const AGENT_DEFS = [
           'false',
           'acp',
         ],
+        env,
         timeoutMs: 15_000,
         defaultModelOption: DEFAULT_MODEL_OPTION,
       }),
@@ -362,10 +363,11 @@ export const AGENT_DEFS = [
     name: 'Hermes',
     bin: 'hermes',
     versionArgs: ['--version'],
-    fetchModels: async (resolvedBin) =>
+    fetchModels: async (resolvedBin, env) =>
       detectAcpModels({
         bin: resolvedBin,
         args: ['acp', '--accept-hooks'],
+        env,
         timeoutMs: 15_000,
         defaultModelOption: DEFAULT_MODEL_OPTION,
       }),
@@ -387,10 +389,11 @@ export const AGENT_DEFS = [
     name: 'Kimi CLI',
     bin: 'kimi',
     versionArgs: ['--version'],
-    fetchModels: async (resolvedBin) =>
+    fetchModels: async (resolvedBin, env) =>
       detectAcpModels({
         bin: resolvedBin,
         args: ['acp'],
+        env,
         timeoutMs: 15_000,
         defaultModelOption: DEFAULT_MODEL_OPTION,
       }),
@@ -545,9 +548,10 @@ export const AGENT_DEFS = [
     versionArgs: ['--version'],
     // `pi --list-models` prints a TSV table to stderr (not stdout),
     // so we use a custom fetchModels that reads stderr.
-    fetchModels: async (resolvedBin) => {
+    fetchModels: async (resolvedBin, env) => {
       try {
         const { stderr } = await execFileP(resolvedBin, ['--list-models'], {
+          env,
           timeout: 20_000,
           maxBuffer: 8 * 1024 * 1024,
         });
@@ -615,10 +619,11 @@ export const AGENT_DEFS = [
     name: 'Kiro CLI',
     bin: 'kiro-cli',
     versionArgs: ['--version'],
-    fetchModels: async (resolvedBin) =>
+    fetchModels: async (resolvedBin, env) =>
       detectAcpModels({
         bin: resolvedBin,
         args: ['acp'],
+        env,
         timeoutMs: 15_000,
         defaultModelOption: DEFAULT_MODEL_OPTION,
       }),
@@ -631,10 +636,11 @@ export const AGENT_DEFS = [
     name: 'Kilo',
     bin: 'kilo',
     versionArgs: ['--version'],
-    fetchModels: async (resolvedBin) =>
+    fetchModels: async (resolvedBin, env) =>
       detectAcpModels({
         bin: resolvedBin,
         args: ['acp'],
+        env,
         timeoutMs: 15_000,
         defaultModelOption: DEFAULT_MODEL_OPTION,
       }),
@@ -647,10 +653,11 @@ export const AGENT_DEFS = [
     name: 'Mistral Vibe CLI',
     bin: 'vibe-acp',
     versionArgs: ['--version'],
-    fetchModels: async (resolvedBin) =>
+    fetchModels: async (resolvedBin, env) =>
       detectAcpModels({
         bin: resolvedBin,
         args: [],
+        env,
         timeoutMs: 15_000,
         defaultModelOption: DEFAULT_MODEL_OPTION,
       }),
@@ -820,10 +827,10 @@ export function resolveAgentExecutable(def) {
   return null;
 }
 
-async function fetchModels(def, resolvedBin) {
+async function fetchModels(def, resolvedBin, env) {
   if (typeof def.fetchModels === 'function') {
     try {
-      const parsed = await def.fetchModels(resolvedBin);
+      const parsed = await def.fetchModels(resolvedBin, env);
       if (!parsed || parsed.length === 0) return def.fallbackModels;
       return parsed;
     } catch {
@@ -833,6 +840,7 @@ async function fetchModels(def, resolvedBin) {
   if (!def.listModels) return def.fallbackModels;
   try {
     const { stdout } = await execFileP(resolvedBin, def.listModels.args, {
+      env,
       timeout: def.listModels.timeoutMs ?? 5000,
       // Models lists from popular CLIs (e.g. opencode) easily exceed the
       // default 1MB buffer once you include every openrouter model. Bump
@@ -850,7 +858,7 @@ async function fetchModels(def, resolvedBin) {
   }
 }
 
-async function probe(def) {
+async function probe(def, configuredEnv = {}) {
   const resolved = resolveAgentExecutable(def);
   if (!resolved) {
     return {
@@ -859,9 +867,18 @@ async function probe(def) {
       available: false,
     };
   }
+  const probeEnv = spawnEnvForAgent(
+    def.id,
+    {
+      ...process.env,
+      ...(def.env || {}),
+    },
+    configuredEnv,
+  );
   let version = null;
   try {
     const { stdout } = await execFileP(resolved, def.versionArgs, {
+      env: probeEnv,
       timeout: 3000,
     });
     version = stdout.trim().split('\n')[0];
@@ -874,6 +891,7 @@ async function probe(def) {
     const caps = {};
     try {
       const { stdout } = await execFileP(resolved, def.helpArgs, {
+        env: probeEnv,
         timeout: 5000,
         maxBuffer: 4 * 1024 * 1024,
       });
@@ -886,7 +904,7 @@ async function probe(def) {
     }
     agentCapabilities.set(def.id, caps);
   }
-  const models = await fetchModels(def, resolved);
+  const models = await fetchModels(def, resolved, probeEnv);
   return {
     ...stripFns(def),
     models,
@@ -918,8 +936,10 @@ function stripFns(def) {
   return rest;
 }
 
-export async function detectAgents() {
-  const results = await Promise.all(AGENT_DEFS.map(probe));
+export async function detectAgents(configuredEnvByAgent = {}) {
+  const results = await Promise.all(
+    AGENT_DEFS.map((def) => probe(def, configuredEnvByAgent?.[def.id] ?? {})),
+  );
   // Refresh the validation cache from whatever we just surfaced to the UI
   // so /api/chat can accept any model the user could have just picked,
   // including ones that only showed up after a CLI re-auth.
@@ -1182,8 +1202,8 @@ export function resolveAgentBin(id) {
 // object loses Node's case-insensitive accessor — `Anthropic_Api_Key`
 // would survive a literal `delete env.ANTHROPIC_API_KEY` and still reach
 // the child. Iterate keys and compare case-insensitively to close that.
-export function spawnEnvForAgent(agentId, baseEnv) {
-  const env = { ...baseEnv };
+export function spawnEnvForAgent(agentId, baseEnv, configuredEnv = {}) {
+  const env = { ...baseEnv, ...expandConfiguredEnv(configuredEnv) };
   if (agentId !== 'claude') return env;
   const hasCustomBaseUrl = Object.keys(env).some(
     (k) =>
@@ -1196,6 +1216,24 @@ export function spawnEnvForAgent(agentId, baseEnv) {
     if (key.toUpperCase() === 'ANTHROPIC_API_KEY') delete env[key];
   }
   return env;
+}
+
+function expandConfiguredEnv(configuredEnv) {
+  const out = {};
+  if (!configuredEnv || typeof configuredEnv !== 'object') return out;
+  for (const [key, value] of Object.entries(configuredEnv)) {
+    if (typeof value !== 'string') continue;
+    out[key] = expandHomePath(value);
+  }
+  return out;
+}
+
+function expandHomePath(value) {
+  if (value === '~') return homedir();
+  if (value.startsWith('~/') || value.startsWith('~\\')) {
+    return path.join(homedir(), value.slice(2));
+  }
+  return value;
 }
 
 // Daemon's /api/chat needs to validate the user's model pick against the

--- a/apps/daemon/src/app-config.ts
+++ b/apps/daemon/src/app-config.ts
@@ -46,10 +46,10 @@ function configFile(dataDir: string): string {
 
 const AGENT_MODEL_KEYS: ReadonlySet<string> = new Set(['model', 'reasoning']);
 
-const AGENT_CLI_ENV_KEYS: Readonly<Record<string, ReadonlySet<string>>> = {
-  claude: new Set(['CLAUDE_CONFIG_DIR']),
-  codex: new Set(['CODEX_HOME']),
-};
+const AGENT_CLI_ENV_KEYS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
+  ['claude', new Set(['CLAUDE_CONFIG_DIR'])],
+  ['codex', new Set(['CODEX_HOME'])],
+]);
 
 function isValidAgentModelEntry(v: unknown): v is AgentModelPrefs {
   if (!v || typeof v !== 'object' || Array.isArray(v)) return false;
@@ -82,7 +82,7 @@ function validateAgentCliEnv(raw: unknown): AgentCliEnvPrefs | undefined {
   const result: AgentCliEnvPrefs = Object.create(null);
   for (const [agentId, value] of Object.entries(raw as Record<string, unknown>)) {
     if (agentId === '__proto__' || agentId === 'constructor') continue;
-    const allowed = AGENT_CLI_ENV_KEYS[agentId];
+    const allowed = AGENT_CLI_ENV_KEYS.get(agentId);
     if (!allowed || typeof value !== 'object' || value === null || Array.isArray(value)) {
       continue;
     }

--- a/apps/daemon/src/app-config.ts
+++ b/apps/daemon/src/app-config.ts
@@ -16,10 +16,13 @@ export interface AgentModelPrefs {
   reasoning?: string;
 }
 
+export type AgentCliEnvPrefs = Record<string, Record<string, string>>;
+
 export interface AppConfigPrefs {
   onboardingCompleted?: boolean;
   agentId?: string | null;
   agentModels?: Record<string, AgentModelPrefs>;
+  agentCliEnv?: AgentCliEnvPrefs;
   skillId?: string | null;
   designSystemId?: string | null;
   disabledSkills?: string[];
@@ -30,6 +33,7 @@ const ALLOWED_KEYS: ReadonlySet<keyof AppConfigPrefs> = new Set([
   'onboardingCompleted',
   'agentId',
   'agentModels',
+  'agentCliEnv',
   'skillId',
   'designSystemId',
   'disabledSkills',
@@ -41,6 +45,11 @@ function configFile(dataDir: string): string {
 }
 
 const AGENT_MODEL_KEYS: ReadonlySet<string> = new Set(['model', 'reasoning']);
+
+const AGENT_CLI_ENV_KEYS: Readonly<Record<string, ReadonlySet<string>>> = {
+  claude: new Set(['CLAUDE_CONFIG_DIR']),
+  codex: new Set(['CODEX_HOME']),
+};
 
 function isValidAgentModelEntry(v: unknown): v is AgentModelPrefs {
   if (!v || typeof v !== 'object' || Array.isArray(v)) return false;
@@ -67,6 +76,39 @@ function validateAgentModels(
   return Object.keys(result).length > 0 ? result : undefined;
 }
 
+function validateAgentCliEnv(raw: unknown): AgentCliEnvPrefs | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  if (typeof raw !== 'object' || Array.isArray(raw)) return undefined;
+  const result: AgentCliEnvPrefs = Object.create(null);
+  for (const [agentId, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (agentId === '__proto__' || agentId === 'constructor') continue;
+    const allowed = AGENT_CLI_ENV_KEYS[agentId];
+    if (!allowed || typeof value !== 'object' || value === null || Array.isArray(value)) {
+      continue;
+    }
+    const env: Record<string, string> = Object.create(null);
+    for (const [envKey, envValue] of Object.entries(value as Record<string, unknown>)) {
+      if (!allowed.has(envKey)) continue;
+      if (typeof envValue !== 'string') continue;
+      const trimmed = envValue.trim();
+      if (!trimmed) continue;
+      env[envKey] = trimmed;
+    }
+    if (Object.keys(env).length > 0) result[agentId] = env;
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+export function agentCliEnvForAgent(
+  prefs: AgentCliEnvPrefs | undefined,
+  agentId: string,
+): Record<string, string> {
+  if (!prefs || typeof agentId !== 'string') return {};
+  const env = prefs[agentId];
+  if (!env || typeof env !== 'object' || Array.isArray(env)) return {};
+  return { ...env };
+}
+
 function applyConfigValue(
   target: Record<string, unknown>,
   key: keyof AppConfigPrefs,
@@ -82,6 +124,14 @@ function applyConfigValue(
   }
   if (key === 'agentModels') {
     const validated = validateAgentModels(value);
+    if (validated !== undefined) {
+      target[key] = validated;
+    } else {
+      delete target[key];
+    }
+  }
+  if (key === 'agentCliEnv') {
+    const validated = validateAgentCliEnv(value);
     if (validated !== undefined) {
       target[key] = validated;
     } else {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -57,7 +57,7 @@ import {
   VIDEO_MODELS,
 } from './media-models.js';
 import { readMaskedConfig, writeConfig } from './media-config.js';
-import { readAppConfig, writeAppConfig } from './app-config.js';
+import { agentCliEnvForAgent, readAppConfig, writeAppConfig } from './app-config.js';
 import {
   buildProjectArchive,
   buildBatchArchive,
@@ -1130,7 +1130,9 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
   // Warm agent-capability probes (e.g. whether the installed Claude Code
   // build advertises --include-partial-messages) so the first /api/chat
   // hits a populated cache even if /api/agents hasn't been called yet.
-  void detectAgents().catch(() => {});
+  void readAppConfig(RUNTIME_DATA_DIR)
+    .then((config) => detectAgents(config.agentCliEnv ?? {}))
+    .catch(() => detectAgents().catch(() => {}));
 
   await recoverStaleLiveArtifactRefreshes({ projectsRoot: PROJECTS_DIR }).catch((error) => {
     console.warn('[od] Failed to recover stale live artifact refreshes:', error);
@@ -1823,7 +1825,8 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
 
   app.get('/api/agents', async (_req, res) => {
     try {
-      const list = await detectAgents();
+      const config = await readAppConfig(RUNTIME_DATA_DIR);
+      const list = await detectAgents(config.agentCliEnv ?? {});
       res.json({ agents: list });
     } catch (err) {
       res.status(500).json({ error: String(err) });
@@ -3676,6 +3679,13 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
           }
         : {}),
     };
+    let configuredAgentEnv = {};
+    try {
+      const appConfig = await readAppConfig(RUNTIME_DATA_DIR);
+      configuredAgentEnv = agentCliEnvForAgent(appConfig.agentCliEnv, def.id);
+    } catch {
+      configuredAgentEnv = {};
+    }
 
     if (run.cancelRequested || design.runs.isTerminal(run.status)) {
       revokeToolToken('child_exit');
@@ -3713,6 +3723,7 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
             ...createAgentRuntimeEnv(process.env, daemonUrl, toolTokenGrant),
             ...(def.env || {}),
           },
+          configuredAgentEnv,
         ),
         ...odMediaEnv,
       };

--- a/apps/daemon/tests/agents.test.ts
+++ b/apps/daemon/tests/agents.test.ts
@@ -16,6 +16,7 @@ import {
   checkPromptArgvBudget,
   checkWindowsCmdShimCommandLineBudget,
   checkWindowsDirectExeCommandLineBudget,
+  detectAgents,
   resolveAgentExecutable,
   spawnEnvForAgent,
 } from '../src/agents.js';
@@ -1216,6 +1217,58 @@ test('spawnEnvForAgent strips ANTHROPIC_API_KEY for the claude adapter', () => {
   assert.equal('ANTHROPIC_API_KEY' in env, false);
   assert.equal(env.PATH, '/usr/bin');
   assert.equal(env.OD_DAEMON_URL, 'http://127.0.0.1:7456');
+});
+
+test('spawnEnvForAgent applies configured Claude Code env before auth stripping', () => {
+  const env = spawnEnvForAgent(
+    'claude',
+    {
+      ANTHROPIC_API_KEY: 'sk-leak',
+      PATH: '/usr/bin',
+    },
+    {
+      CLAUDE_CONFIG_DIR: '/Users/test/.claude-2',
+    },
+  );
+
+  assert.equal(env.CLAUDE_CONFIG_DIR, '/Users/test/.claude-2');
+  assert.equal('ANTHROPIC_API_KEY' in env, false);
+  assert.equal(env.PATH, '/usr/bin');
+});
+
+test('spawnEnvForAgent applies configured Codex env without mutating the base env', () => {
+  const base = { PATH: '/usr/bin' };
+  const env = spawnEnvForAgent('codex', base, {
+    CODEX_HOME: '/Users/test/.codex-alt',
+  });
+
+  assert.equal(env.CODEX_HOME, '/Users/test/.codex-alt');
+  assert.equal(env.PATH, '/usr/bin');
+  assert.equal('CODEX_HOME' in base, false);
+});
+
+test('detectAgents applies configured env while probing the CLI', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'od-agent-env-'));
+  try {
+    const bin = join(dir, 'claude');
+    writeFileSync(
+      bin,
+      '#!/bin/sh\nif [ "$1" = "--version" ]; then echo "$CLAUDE_CONFIG_DIR"; exit 0; fi\nif [ "$1" = "-p" ]; then echo "--add-dir --include-partial-messages"; exit 0; fi\nexit 0\n',
+    );
+    chmodSync(bin, 0o755);
+    process.env.PATH = dir;
+    process.env.OD_AGENT_HOME = dir;
+
+    const agents = await detectAgents({
+      claude: { CLAUDE_CONFIG_DIR: '/tmp/claude-config-probe' },
+    });
+
+    const detected = agents.find((agent) => agent.id === 'claude');
+    assert.equal(detected?.available, true);
+    assert.equal(detected?.version, '/tmp/claude-config-probe');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 // Windows env-var names are case-insensitive at the kernel level, but

--- a/apps/daemon/tests/app-config.test.ts
+++ b/apps/daemon/tests/app-config.test.ts
@@ -177,6 +177,58 @@ describe('app-config', () => {
       expect(cfg.agentModels).toBeUndefined();
     });
 
+    it('persists supported per-agent CLI env keys and drops everything else', async () => {
+      await writeAppConfig(dataDir, {
+        agentCliEnv: {
+          claude: {
+            CLAUDE_CONFIG_DIR: '  ~/.claude-2  ',
+            ANTHROPIC_API_KEY: 'sk-should-not-persist',
+          },
+          codex: {
+            CODEX_HOME: '~/.codex-alt',
+            OPENAI_API_KEY: 'sk-should-not-persist',
+          },
+          gemini: {
+            GEMINI_API_KEY: 'should-not-persist',
+          },
+          __proto__: {
+            CLAUDE_CONFIG_DIR: 'bad',
+          },
+        },
+      });
+
+      const cfg = await readAppConfig(dataDir);
+
+      expect(cfg.agentCliEnv).toEqual({
+        claude: { CLAUDE_CONFIG_DIR: '~/.claude-2' },
+        codex: { CODEX_HOME: '~/.codex-alt' },
+      });
+    });
+
+    it('clears agentCliEnv when null or an empty object is sent', async () => {
+      await writeAppConfig(dataDir, {
+        agentCliEnv: {
+          claude: { CLAUDE_CONFIG_DIR: '~/.claude-2' },
+        },
+        onboardingCompleted: true,
+      });
+      expect((await readAppConfig(dataDir)).agentCliEnv).toBeDefined();
+
+      await writeAppConfig(dataDir, { agentCliEnv: null });
+      let cfg = await readAppConfig(dataDir);
+      expect(cfg.agentCliEnv).toBeUndefined();
+      expect(cfg.onboardingCompleted).toBe(true);
+
+      await writeAppConfig(dataDir, {
+        agentCliEnv: {
+          codex: { CODEX_HOME: '~/.codex-alt' },
+        },
+      });
+      await writeAppConfig(dataDir, { agentCliEnv: {} });
+      cfg = await readAppConfig(dataDir);
+      expect(cfg.agentCliEnv).toBeUndefined();
+    });
+
     it('handles corrupted existing file gracefully on write', async () => {
       await writeFile(path.join(dataDir, 'app-config.json'), 'CORRUPT');
       await writeAppConfig(dataDir, { agentId: 'test' });

--- a/apps/daemon/tests/app-config.test.ts
+++ b/apps/daemon/tests/app-config.test.ts
@@ -205,6 +205,28 @@ describe('app-config', () => {
       });
     });
 
+    it('drops agentCliEnv entries that collide with Object.prototype keys', async () => {
+      await writeAppConfig(dataDir, {
+        agentCliEnv: {
+          toString: {
+            CODEX_HOME: '~/.codex-prototype',
+          },
+          hasOwnProperty: {
+            CLAUDE_CONFIG_DIR: '~/.claude-prototype',
+          },
+          claude: {
+            CLAUDE_CONFIG_DIR: '~/.claude-2',
+          },
+        },
+      });
+
+      const cfg = await readAppConfig(dataDir);
+
+      expect(cfg.agentCliEnv).toEqual({
+        claude: { CLAUDE_CONFIG_DIR: '~/.claude-2' },
+      });
+    });
+
     it('clears agentCliEnv when null or an empty object is sent', async () => {
       await writeAppConfig(dataDir, {
         agentCliEnv: {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -182,6 +182,12 @@ export function App() {
               ...daemonConfig.agentModels,
             };
           }
+          if (daemonConfig.agentCliEnv) {
+            next.agentCliEnv = {
+              ...(next.agentCliEnv ?? {}),
+              ...daemonConfig.agentCliEnv,
+            };
+          }
           if (daemonConfig.disabledSkills !== undefined) {
             next.disabledSkills = daemonConfig.disabledSkills;
           }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -23,6 +23,7 @@ import {
   hasAnyConfiguredProvider,
   fetchComposioConfigFromDaemon,
   loadConfig,
+  mergeDaemonConfig,
   saveConfig,
   syncComposioConfigToDaemon,
   syncConfigToDaemon,
@@ -159,42 +160,9 @@ export function App() {
       setAppVersionInfo(versionInfo);
 
       setConfig((prev) => {
-        const next = { ...prev };
-
         // Merge daemon-persisted config — daemon values win for the fields
         // it tracks so that the choice survives origin/storage resets.
-        if (daemonConfig) {
-          if (daemonConfig.onboardingCompleted != null) {
-            next.onboardingCompleted = daemonConfig.onboardingCompleted;
-          }
-          if (daemonConfig.agentId !== undefined) {
-            next.agentId = daemonConfig.agentId;
-          }
-          if (daemonConfig.skillId !== undefined) {
-            next.skillId = daemonConfig.skillId;
-          }
-          if (daemonConfig.designSystemId !== undefined) {
-            next.designSystemId = daemonConfig.designSystemId;
-          }
-          if (daemonConfig.agentModels) {
-            next.agentModels = {
-              ...(next.agentModels ?? {}),
-              ...daemonConfig.agentModels,
-            };
-          }
-          if (daemonConfig.agentCliEnv) {
-            next.agentCliEnv = {
-              ...(next.agentCliEnv ?? {}),
-              ...daemonConfig.agentCliEnv,
-            };
-          }
-          if (daemonConfig.disabledSkills !== undefined) {
-            next.disabledSkills = daemonConfig.disabledSkills;
-          }
-          if (daemonConfig.disabledDesignSystems !== undefined) {
-            next.disabledDesignSystems = daemonConfig.disabledDesignSystems;
-          }
-        }
+        const next = mergeDaemonConfig(prev, daemonConfig);
 
         if (alive) {
           const hasLocalComposioKey = Boolean(next.composio?.apiKey?.trim());
@@ -343,12 +311,18 @@ export function App() {
   );
 
   const refreshAgents = useCallback(
-    async (options?: { throwOnError?: boolean }) => {
-      const next = await fetchAgents(options);
+    async (options?: { throwOnError?: boolean; agentCliEnv?: AppConfig['agentCliEnv'] }) => {
+      if (options && Object.prototype.hasOwnProperty.call(options, 'agentCliEnv')) {
+        const nextConfig = { ...config, agentCliEnv: options.agentCliEnv ?? {} };
+        saveConfig(nextConfig);
+        await syncConfigToDaemon(nextConfig);
+        setConfig(nextConfig);
+      }
+      const next = await fetchAgents({ throwOnError: options?.throwOnError });
       setAgents(next);
       return next;
     },
-    [],
+    [config],
   );
 
   const handleCreateProject = useCallback(

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -43,6 +43,8 @@ interface Props {
   onSavePreviewComment?: (target: PreviewCommentTarget, note: string, attachAfterSave: boolean) => Promise<PreviewComment | null>;
   onRemovePreviewComment?: (commentId: string) => Promise<void>;
   onSendBoardCommentAttachments?: (attachments: ChatCommentAttachment[]) => Promise<void> | void;
+  focusMode?: boolean;
+  onFocusModeChange?: (next: boolean) => void;
 }
 
 interface SketchState {
@@ -71,6 +73,8 @@ export function FileWorkspace({
   onSavePreviewComment,
   onRemovePreviewComment,
   onSendBoardCommentAttachments,
+  focusMode = false,
+  onFocusModeChange,
 }: Props) {
   const t = useT();
   // Persisted tabs come from the parent. Active tab can transiently point
@@ -406,49 +410,66 @@ export function FileWorkspace({
 
   return (
     <div className="workspace" data-testid="file-workspace">
-      <div
-        ref={tabsBarRef}
-        className="ws-tabs-bar"
-        role="tablist"
-        aria-label={t('workspace.designFiles')}
-      >
-        <button
-          type="button"
-          className={`ws-tab design-files-tab ${activeTab === DESIGN_FILES_TAB ? 'active' : ''}`}
-          role="tab"
-          aria-selected={activeTab === DESIGN_FILES_TAB}
-          tabIndex={0}
-          data-testid="design-files-tab"
-          onClick={() => setActiveTab(DESIGN_FILES_TAB)}
-          title={t('workspace.designFiles')}
+      <div className="ws-tabs-shell">
+        <div
+          ref={tabsBarRef}
+          className="ws-tabs-bar"
+          role="tablist"
+          aria-label={t('workspace.designFiles')}
         >
-          <span className="tab-icon" aria-hidden>
-            <Icon name="grid" size={13} />
-          </span>
-          <span className="ws-tab-label">{t('workspace.designFiles')}</span>
-        </button>
-        {tabNames.map((name) => {
-          const sketchEntry = sketches[name];
-          const dirtyMark =
-            sketchEntry && (sketchEntry.dirty || !sketchEntry.persisted) ? ' •' : '';
-          const isPending = sketchEntry && !sketchEntry.persisted;
-          const onDisk = visibleFiles.find((f) => f.name === name);
-          const liveArtifact = liveArtifactEntries.find((entry) => entry.tabId === name);
-          const kind = liveArtifact ? 'live-artifact' : onDisk?.kind ?? (isSketchName(name) ? 'sketch' : 'text');
-          return (
-            <Tab
-              key={name}
-              label={`${liveArtifact?.title ?? name}${dirtyMark}`}
-              active={activeTab === name}
-              onActivate={() =>
-                isPending ? activatePending(name) : setPersistedActive(name)
-              }
-              onClose={() => closeTab(name)}
-              kind={kind}
-              liveArtifact={liveArtifact}
-            />
-          );
-        })}
+          <button
+            type="button"
+            className={`ws-tab design-files-tab ${activeTab === DESIGN_FILES_TAB ? 'active' : ''}`}
+            role="tab"
+            aria-selected={activeTab === DESIGN_FILES_TAB}
+            tabIndex={0}
+            data-testid="design-files-tab"
+            onClick={() => setActiveTab(DESIGN_FILES_TAB)}
+            title={t('workspace.designFiles')}
+          >
+            <span className="tab-icon" aria-hidden>
+              <Icon name="grid" size={13} />
+            </span>
+            <span className="ws-tab-label">{t('workspace.designFiles')}</span>
+          </button>
+          {tabNames.map((name) => {
+            const sketchEntry = sketches[name];
+            const dirtyMark =
+              sketchEntry && (sketchEntry.dirty || !sketchEntry.persisted) ? ' •' : '';
+            const isPending = sketchEntry && !sketchEntry.persisted;
+            const onDisk = visibleFiles.find((f) => f.name === name);
+            const liveArtifact = liveArtifactEntries.find((entry) => entry.tabId === name);
+            const kind = liveArtifact ? 'live-artifact' : onDisk?.kind ?? (isSketchName(name) ? 'sketch' : 'text');
+            return (
+              <Tab
+                key={name}
+                label={`${liveArtifact?.title ?? name}${dirtyMark}`}
+                active={activeTab === name}
+                onActivate={() =>
+                  isPending ? activatePending(name) : setPersistedActive(name)
+                }
+                onClose={() => closeTab(name)}
+                kind={kind}
+                liveArtifact={liveArtifact}
+              />
+            );
+          })}
+        </div>
+        {onFocusModeChange ? (
+          <div className="ws-tabs-actions">
+            <button
+              type="button"
+              className="ws-focus-toggle"
+              data-testid="workspace-focus-toggle"
+              aria-pressed={focusMode}
+              title={focusMode ? t('workspace.showChat') : t('workspace.focusMode')}
+              onClick={() => onFocusModeChange(!focusMode)}
+            >
+              <Icon name={focusMode ? 'comment' : 'zoom-in'} size={13} />
+              <span>{focusMode ? t('workspace.showChat') : t('workspace.focusMode')}</span>
+            </button>
+          </div>
+        ) : null}
       </div>
       <div className="ws-body">
         {uploadError ? <div className="viewer-empty">{uploadError}</div> : null}

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -180,6 +180,10 @@ function appendLiveArtifactEventItem(
   return next.length > 50 ? next.slice(next.length - 50) : next;
 }
 
+export function projectSplitClassName(workspaceFocused: boolean): string {
+  return workspaceFocused ? 'split split-focus' : 'split';
+}
+
 function projectEventToAgentEvent(evt: ProjectEvent): LiveArtifactEventItem['event'] | null {
   if (evt.type === 'file-changed') return null;
   if (evt.type === 'live_artifact') {
@@ -241,6 +245,7 @@ export function ProjectView({
   const [projectFiles, setProjectFiles] = useState<ProjectFile[]>([]);
   const [liveArtifacts, setLiveArtifacts] = useState<LiveArtifactSummary[]>([]);
   const [liveArtifactEvents, setLiveArtifactEvents] = useState<LiveArtifactEventItem[]>([]);
+  const [workspaceFocused, setWorkspaceFocused] = useState(false);
   const [chatPanelWidth, setChatPanelWidth] = useState(readSavedChatPanelWidth);
   const [chatPanelMaxWidth, setChatPanelMaxWidth] = useState(MAX_CHAT_PANEL_WIDTH);
   const [workspacePanelMinWidth, setWorkspacePanelMinWidth] = useState(MIN_WORKSPACE_PANEL_WIDTH);
@@ -316,6 +321,10 @@ export function ProjectView({
     return () => {
       cancelled = true;
     };
+  }, [project.id]);
+
+  useEffect(() => {
+    setWorkspaceFocused(false);
   }, [project.id]);
 
   // Load messages whenever the active conversation changes. This happens
@@ -1740,67 +1749,76 @@ export function ProjectView({
       </AppChromeHeader>
       <div
         ref={splitRef}
-        className={`split${resizingChatPanel ? ' is-resizing-chat' : ''}`}
-        style={{
-          gridTemplateColumns:
-            `${chatPanelWidth}px ${SPLIT_RESIZE_HANDLE_WIDTH}px ${workspacePanelTrack}`,
-        }}
+        className={[
+          projectSplitClassName(workspaceFocused),
+          resizingChatPanel && !workspaceFocused ? 'is-resizing-chat' : '',
+        ].filter(Boolean).join(' ')}
+        style={workspaceFocused
+          ? undefined
+          : {
+              gridTemplateColumns:
+                `${chatPanelWidth}px ${SPLIT_RESIZE_HANDLE_WIDTH}px ${workspacePanelTrack}`,
+            }}
       >
-        <ChatPane
-          // The conversation id is part of the key so switching conversations
-          // resets internal scroll/draft state inside ChatPane and ChatComposer.
-          key={activeConversationId ?? 'no-conv'}
-          messages={messages}
-          streaming={streaming}
-          error={error}
-          projectId={project.id}
-          projectFiles={projectFiles}
-          projectFileNames={projectFileNames}
-          onEnsureProject={handleEnsureProject}
-          previewComments={previewComments}
-          attachedComments={attachedComments}
-          onAttachComment={attachPreviewComment}
-          onDetachComment={detachPreviewComment}
-          onDeleteComment={(commentId) => void removePreviewComment(commentId)}
-          onSend={handleSend}
-          onStop={handleStop}
-          onRequestOpenFile={requestOpenFile}
-          initialDraft={initialDraft}
-          onSubmitForm={(text) => {
-            if (streaming) return;
-            void handleSend(text, [], []);
-          }}
-          onContinueRemainingTasks={handleContinueRemainingTasks}
-          onNewConversation={handleNewConversation}
-          conversations={conversations}
-          activeConversationId={activeConversationId}
-          onSelectConversation={handleSelectConversation}
-          onDeleteConversation={handleDeleteConversation}
-          onRenameConversation={handleRenameConversation}
-          onOpenSettings={onOpenSettings}
-          petConfig={config.pet}
-          onAdoptPet={onAdoptPetInline}
-          onTogglePet={onTogglePet}
-          onOpenPetSettings={onOpenPetSettings}
-          projectMetadata={project.metadata}
-          onProjectMetadataChange={(metadata) => {
-            onProjectChange({ ...project, metadata });
-          }}
-        />
-        <div
-          className="split-resize-handle"
-          role="separator"
-          aria-orientation="vertical"
-          aria-label={chatResizeLabel}
-          aria-valuemin={chatPanelAriaMinWidth}
-          aria-valuemax={chatPanelMaxWidth}
-          aria-valuenow={chatPanelWidth}
-          tabIndex={0}
-          title={chatResizeLabel}
-          onPointerDown={handleChatResizePointerDown}
-          onKeyDown={handleChatResizeKeyDown}
-          onBlur={handleChatResizeBlur}
-        />
+        <div className="split-chat-slot" hidden={workspaceFocused}>
+          <ChatPane
+            // The conversation id is part of the key so switching conversations
+            // resets internal scroll/draft state inside ChatPane and ChatComposer.
+            key={activeConversationId ?? 'no-conv'}
+            messages={messages}
+            streaming={streaming}
+            error={error}
+            projectId={project.id}
+            projectFiles={projectFiles}
+            projectFileNames={projectFileNames}
+            onEnsureProject={handleEnsureProject}
+            previewComments={previewComments}
+            attachedComments={attachedComments}
+            onAttachComment={attachPreviewComment}
+            onDetachComment={detachPreviewComment}
+            onDeleteComment={(commentId) => void removePreviewComment(commentId)}
+            onSend={handleSend}
+            onStop={handleStop}
+            onRequestOpenFile={requestOpenFile}
+            initialDraft={initialDraft}
+            onSubmitForm={(text) => {
+              if (streaming) return;
+              void handleSend(text, [], []);
+            }}
+            onContinueRemainingTasks={handleContinueRemainingTasks}
+            onNewConversation={handleNewConversation}
+            conversations={conversations}
+            activeConversationId={activeConversationId}
+            onSelectConversation={handleSelectConversation}
+            onDeleteConversation={handleDeleteConversation}
+            onRenameConversation={handleRenameConversation}
+            onOpenSettings={onOpenSettings}
+            petConfig={config.pet}
+            onAdoptPet={onAdoptPetInline}
+            onTogglePet={onTogglePet}
+            onOpenPetSettings={onOpenPetSettings}
+            projectMetadata={project.metadata}
+            onProjectMetadataChange={(metadata) => {
+              onProjectChange({ ...project, metadata });
+            }}
+          />
+        </div>
+        {!workspaceFocused ? (
+          <div
+            className="split-resize-handle"
+            role="separator"
+            aria-orientation="vertical"
+            aria-label={chatResizeLabel}
+            aria-valuemin={chatPanelAriaMinWidth}
+            aria-valuemax={chatPanelMaxWidth}
+            aria-valuenow={chatPanelWidth}
+            tabIndex={0}
+            title={chatResizeLabel}
+            onPointerDown={handleChatResizePointerDown}
+            onKeyDown={handleChatResizeKeyDown}
+            onBlur={handleChatResizeBlur}
+          />
+        ) : null}
         <FileWorkspace
           projectId={project.id}
           files={projectFiles}
@@ -1819,6 +1837,8 @@ export function ProjectView({
           onSavePreviewComment={savePreviewComment}
           onRemovePreviewComment={removePreviewComment}
           onSendBoardCommentAttachments={handleSendBoardCommentAttachments}
+          focusMode={workspaceFocused}
+          onFocusModeChange={setWorkspaceFocused}
         />
       </div>
     </div>

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -52,8 +52,13 @@ interface Props {
   onSave: (cfg: AppConfig) => void;
   onClose: () => void;
   onRefreshAgents: (
-    options?: { throwOnError?: boolean },
+    options?: AgentRefreshOptions,
   ) => AgentInfo[] | Promise<AgentInfo[] | void> | void;
+}
+
+export interface AgentRefreshOptions {
+  throwOnError?: boolean;
+  agentCliEnv?: AppConfig['agentCliEnv'];
 }
 
 const SUGGESTED_MODELS_BY_PROTOCOL = {
@@ -258,6 +263,13 @@ export function updateAgentCliEnvValue(
   };
 }
 
+export function agentRefreshOptionsForConfig(cfg: AppConfig): AgentRefreshOptions {
+  return {
+    throwOnError: true,
+    agentCliEnv: cfg.agentCliEnv ?? {},
+  };
+}
+
 export function switchApiProtocolConfig(
   config: AppConfig,
   protocol: ApiProtocol,
@@ -370,7 +382,7 @@ export function SettingsDialog({
     setAgentRescanRunning(true);
     setAgentRescanNotice(null);
     try {
-      const refreshed = await onRefreshAgents({ throwOnError: true });
+      const refreshed = await onRefreshAgents(agentRefreshOptionsForConfig(cfg));
       const nextAgents = Array.isArray(refreshed) ? refreshed : agents;
       setAgentRescanNotice({
         kind: 'success',

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -132,6 +132,21 @@ type RescanNotice =
   | { kind: 'success'; count: number }
   | { kind: 'error' };
 
+const AGENT_CLI_ENV_FIELDS = [
+  {
+    agentId: 'claude',
+    envKey: 'CLAUDE_CONFIG_DIR',
+    labelKey: 'settings.cliEnvClaudeConfigDir',
+    placeholder: '~/.claude-2',
+  },
+  {
+    agentId: 'codex',
+    envKey: 'CODEX_HOME',
+    labelKey: 'settings.cliEnvCodexHome',
+    placeholder: '~/.codex-alt',
+  },
+] as const;
+
 function defaultApiProtocolConfig(protocol: ApiProtocol): ApiProtocolConfig {
   const provider = KNOWN_PROVIDERS.find((p) => p.protocol === protocol);
   return {
@@ -214,6 +229,33 @@ export function updateCurrentApiProtocolConfig(
     protocol,
     nextApiConfig,
   );
+}
+
+export function updateAgentCliEnvValue(
+  config: AppConfig,
+  agentId: string,
+  envKey: string,
+  rawValue: string,
+): AppConfig {
+  const value = rawValue.trim();
+  const agentCliEnv = { ...(config.agentCliEnv ?? {}) };
+  const nextAgentEnv = { ...(agentCliEnv[agentId] ?? {}) };
+  if (value) {
+    nextAgentEnv[envKey] = value;
+  } else {
+    delete nextAgentEnv[envKey];
+  }
+
+  if (Object.keys(nextAgentEnv).length > 0) {
+    agentCliEnv[agentId] = nextAgentEnv;
+  } else {
+    delete agentCliEnv[agentId];
+  }
+
+  return {
+    ...config,
+    agentCliEnv: Object.keys(agentCliEnv).length > 0 ? agentCliEnv : {},
+  };
 }
 
 export function switchApiProtocolConfig(
@@ -790,6 +832,35 @@ export function SettingsDialog({
                   </div>
                 );
               })()}
+              <div className="agent-cli-env">
+                <div className="agent-cli-env-head">
+                  <h4>{t('settings.cliEnvTitle')}</h4>
+                  <p className="hint">{t('settings.cliEnvHint')}</p>
+                </div>
+                <div className="agent-cli-env-grid">
+                  {AGENT_CLI_ENV_FIELDS.map((field) => (
+                    <label className="field" key={`${field.agentId}:${field.envKey}`}>
+                      <span className="field-label">{t(field.labelKey)}</span>
+                      <input
+                        type="text"
+                        value={cfg.agentCliEnv?.[field.agentId]?.[field.envKey] ?? ''}
+                        placeholder={field.placeholder}
+                        spellCheck={false}
+                        onChange={(e) =>
+                          setCfg((c) =>
+                            updateAgentCliEnvValue(
+                              c,
+                              field.agentId,
+                              field.envKey,
+                              e.target.value,
+                            ),
+                          )
+                        }
+                      />
+                    </label>
+                  ))}
+                </div>
+              </div>
             </section>
           ) : (
             <section className="settings-section">

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -108,6 +108,11 @@ export const ar: Dict = {
   'settings.reasoningPicker': 'جهد التفكير',
   'settings.modelPickerHint':
     'يتم جلبه من CLI عندما يعرض أمر `models`. "الافتراضي" يترك الخيار لإعدادات CLI؛ "مخصص..." يسمح لك بكتابة أي معرف نموذج يقبله CLI.',
+  'settings.cliEnvTitle': 'CLI config locations',
+  'settings.cliEnvHint':
+    'Set non-secret config directories for packaged app runs and agent detection.',
+  'settings.cliEnvClaudeConfigDir': 'Claude Code config dir',
+  'settings.cliEnvCodexHome': 'Codex home',
   'settings.modelCustom': 'مخصص (اكتب أدناه)...',
   'settings.modelCustomLabel': 'معرف النموذج المخصص',
   'settings.modelCustomPlaceholder': 'مثلاً: anthropic/claude-sonnet-4-6',
@@ -481,6 +486,8 @@ export const ar: Dict = {
   'misc.designSystem': 'نظام تصميم',
 
   'workspace.designFiles': 'ملفات التصميم',
+  'workspace.focusMode': 'Focus workspace',
+  'workspace.showChat': 'Show chat',
   'workspace.closeTab': 'إغلاق علامة التبويب',
   'workspace.deleteFileConfirm': 'حذف "{name}" من مجلد المشروع؟',
   'workspace.openFromDesignFiles': 'فتح ملف من',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -108,6 +108,11 @@ export const de: Dict = {
   'settings.reasoningPicker': 'Reasoning-Aufwand',
   'settings.modelPickerHint':
     'Wird aus der CLI geladen, wenn sie einen `models`-Befehl anbietet. „Standard“ überlässt die Auswahl der CLI-Konfiguration; mit „Benutzerdefiniert…“ können Sie jede von der CLI akzeptierte Modell-ID eingeben.',
+  'settings.cliEnvTitle': 'CLI config locations',
+  'settings.cliEnvHint':
+    'Set non-secret config directories for packaged app runs and agent detection.',
+  'settings.cliEnvClaudeConfigDir': 'Claude Code config dir',
+  'settings.cliEnvCodexHome': 'Codex home',
   'settings.modelCustom': 'Benutzerdefiniert (unten eingeben)…',
   'settings.modelCustomLabel': 'Benutzerdefinierte Modell-ID',
   'settings.modelCustomPlaceholder': 'z. B. anthropic/claude-sonnet-4-6',
@@ -435,6 +440,8 @@ export const de: Dict = {
   'misc.designSystem': 'Designsystem',
 
   'workspace.designFiles': 'Design-Dateien',
+  'workspace.focusMode': 'Focus workspace',
+  'workspace.showChat': 'Show chat',
   'workspace.closeTab': 'Tab schließen',
   'workspace.deleteFileConfirm': '„{name}“ aus dem Projektordner löschen?',
   'workspace.openFromDesignFiles': 'Datei öffnen aus',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -106,6 +106,11 @@ export const en: Dict = {
   'settings.reasoningPicker': 'Reasoning effort',
   'settings.modelPickerHint':
     'Fetched from the CLI when it exposes a `models` command. "Default" leaves the choice to the CLI’s own config; "Custom…" lets you type any model id the CLI accepts.',
+  'settings.cliEnvTitle': 'CLI config locations',
+  'settings.cliEnvHint':
+    'Set non-secret config directories for packaged app runs and agent detection.',
+  'settings.cliEnvClaudeConfigDir': 'Claude Code config dir',
+  'settings.cliEnvCodexHome': 'Codex home',
   'settings.modelCustom': 'Custom (type below)…',
   'settings.modelCustomLabel': 'Custom model id',
   'settings.modelCustomPlaceholder': 'e.g. anthropic/claude-sonnet-4-6',
@@ -492,6 +497,8 @@ export const en: Dict = {
   'misc.designSystem': 'Design system',
 
   'workspace.designFiles': 'Design Files',
+  'workspace.focusMode': 'Focus workspace',
+  'workspace.showChat': 'Show chat',
   'workspace.closeTab': 'Close tab',
   'workspace.deleteFileConfirm': 'Delete "{name}" from the project folder?',
   'workspace.openFromDesignFiles': 'Open a file from',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -108,6 +108,11 @@ export const esES: Dict = {
   'settings.reasoningPicker': 'Esfuerzo de razonamiento',
   'settings.modelPickerHint':
     'Se obtiene de la CLI cuando expone un comando `models`. «Predeterminado» deja la elección a la propia configuración de la CLI; «Personalizado…» permite escribir cualquier id de modelo aceptado por la CLI.',
+  'settings.cliEnvTitle': 'CLI config locations',
+  'settings.cliEnvHint':
+    'Set non-secret config directories for packaged app runs and agent detection.',
+  'settings.cliEnvClaudeConfigDir': 'Claude Code config dir',
+  'settings.cliEnvCodexHome': 'Codex home',
   'settings.modelCustom': 'Personalizado (escribe abajo)…',
   'settings.modelCustomLabel': 'Id de modelo personalizado',
   'settings.modelCustomPlaceholder': 'p. ej., anthropic/claude-sonnet-4-6',
@@ -436,6 +441,8 @@ export const esES: Dict = {
   'misc.designSystem': 'Sistema de diseño',
 
   'workspace.designFiles': 'Archivos de diseño',
+  'workspace.focusMode': 'Focus workspace',
+  'workspace.showChat': 'Show chat',
   'workspace.closeTab': 'Cerrar pestaña',
   'workspace.deleteFileConfirm': '¿Eliminar «{name}» de la carpeta del proyecto?',
   'workspace.openFromDesignFiles': 'Abre un archivo desde',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -106,6 +106,11 @@ export const fa: Dict = {
   'settings.reasoningPicker': 'سطح استدلال',
   'settings.modelPickerHint':
     'هنگامی که CLI یک دستور `models` را ارائه می‌دهد از آن دریافت می‌شود. «پیش‌فرض» انتخاب را به پیکربندی خود CLI واگذار می‌کند؛ «سفارشی…» به شما امکان می‌دهد هر شناسه مدلی را که CLI می‌پذیرد تایپ کنید.',
+  'settings.cliEnvTitle': 'CLI config locations',
+  'settings.cliEnvHint':
+    'Set non-secret config directories for packaged app runs and agent detection.',
+  'settings.cliEnvClaudeConfigDir': 'Claude Code config dir',
+  'settings.cliEnvCodexHome': 'Codex home',
   'settings.modelCustom': 'سفارشی (در زیر تایپ کنید)…',
   'settings.modelCustomLabel': 'شناسه مدل سفارشی',
   'settings.modelCustomPlaceholder': 'مثلاً anthropic/claude-sonnet-4-6',
@@ -492,6 +497,8 @@ export const fa: Dict = {
   'misc.designSystem': 'سیستم طراحی',
 
   'workspace.designFiles': 'فایل‌های طراحی',
+  'workspace.focusMode': 'Focus workspace',
+  'workspace.showChat': 'Show chat',
   'workspace.closeTab': 'بستن تب',
   'workspace.deleteFileConfirm': 'آیا «{name}» از پوشه پروژه حذف شود؟',
   'workspace.openFromDesignFiles': 'باز کردن یک فایل از',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -108,6 +108,11 @@ export const fr: Dict = {
   'settings.reasoningPicker': 'Effort de raisonnement',
   'settings.modelPickerHint':
     'Récupéré depuis le CLI lorsqu\'il expose une commande `models`. « Par défaut » laisse le choix à la configuration du CLI ; « Personnalisé… » vous permet de saisir n\'importe quel identifiant de modèle accepté par le CLI.',
+  'settings.cliEnvTitle': 'CLI config locations',
+  'settings.cliEnvHint':
+    'Set non-secret config directories for packaged app runs and agent detection.',
+  'settings.cliEnvClaudeConfigDir': 'Claude Code config dir',
+  'settings.cliEnvCodexHome': 'Codex home',
   'settings.modelCustom': 'Personnalisé (saisir ci-dessous)…',
   'settings.modelCustomLabel': 'Identifiant du modèle personnalisé',
   'settings.modelCustomPlaceholder': 'ex. anthropic/claude-sonnet-4-6',
@@ -481,6 +486,8 @@ export const fr: Dict = {
   'misc.designSystem': 'Design system',
 
   'workspace.designFiles': 'Fichiers de design',
+  'workspace.focusMode': 'Focus workspace',
+  'workspace.showChat': 'Show chat',
   'workspace.closeTab': 'Fermer l\'onglet',
   'workspace.deleteFileConfirm': 'Supprimer « {name} » du dossier du projet ?',
   'workspace.openFromDesignFiles': 'Ouvrir un fichier depuis',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -108,6 +108,11 @@ export const hu: Dict = {
   'settings.reasoningPicker': 'Gondolkodási erőfeszítés',
   'settings.modelPickerHint':
     'A CLI-tól kérdezi le, ha az közzéteszi a `models` parancsot. Az „Alapértelmezett" a CLI saját konfigjára bízza a választást; az „Egyedi…" tetszőleges, a CLI által elfogadott modell-id-t enged megadni.',
+  'settings.cliEnvTitle': 'CLI config locations',
+  'settings.cliEnvHint':
+    'Set non-secret config directories for packaged app runs and agent detection.',
+  'settings.cliEnvClaudeConfigDir': 'Claude Code config dir',
+  'settings.cliEnvCodexHome': 'Codex home',
   'settings.modelCustom': 'Egyedi (gépeld be alább)…',
   'settings.modelCustomLabel': 'Egyedi modell-id',
   'settings.modelCustomPlaceholder': 'pl. anthropic/claude-sonnet-4-6',
@@ -481,6 +486,8 @@ export const hu: Dict = {
   'misc.designSystem': 'Designrendszer',
 
   'workspace.designFiles': 'Designfájlok',
+  'workspace.focusMode': 'Focus workspace',
+  'workspace.showChat': 'Show chat',
   'workspace.closeTab': 'Lap bezárása',
   'workspace.deleteFileConfirm': 'Törlöd a(z) „{name}" fájlt a projektmappából?',
   'workspace.openFromDesignFiles': 'Nyiss meg egy fájlt innen:',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -108,6 +108,11 @@ export const ja: Dict = {
   'settings.reasoningPicker': '推論の強さ',
   'settings.modelPickerHint':
     'CLI が `models` コマンドを公開している場合に取得されます。「デフォルト」は CLI 自身の設定に委ね、「カスタム…」は CLI が受け付ける任意のモデル ID を入力できます。',
+  'settings.cliEnvTitle': 'CLI config locations',
+  'settings.cliEnvHint':
+    'Set non-secret config directories for packaged app runs and agent detection.',
+  'settings.cliEnvClaudeConfigDir': 'Claude Code config dir',
+  'settings.cliEnvCodexHome': 'Codex home',
   'settings.modelCustom': 'カスタム（下に入力）…',
   'settings.modelCustomLabel': 'カスタムモデル ID',
   'settings.modelCustomPlaceholder': '例: anthropic/claude-sonnet-4-6',
@@ -434,6 +439,8 @@ export const ja: Dict = {
   'misc.designSystem': 'デザインシステム',
 
   'workspace.designFiles': 'デザインファイル',
+  'workspace.focusMode': 'Focus workspace',
+  'workspace.showChat': 'Show chat',
   'workspace.closeTab': 'タブを閉じる',
   'workspace.deleteFileConfirm': 'プロジェクトフォルダーから "{name}" を削除しますか？',
   'workspace.openFromDesignFiles': 'ファイルを開く: ',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -108,6 +108,11 @@ export const ko: Dict = {
   'settings.reasoningPicker': '추론 (Reasoning)',
   'settings.modelPickerHint':
     'CLI가 `models` 명령어를 지원할 때 가져옵니다. "Default"는 CLI 자체 설정을 따르며, "직접 입력…"을 선택하면 CLI가 허용하는 모델 ID를 입력할 수 있습니다.',
+  'settings.cliEnvTitle': 'CLI config locations',
+  'settings.cliEnvHint':
+    'Set non-secret config directories for packaged app runs and agent detection.',
+  'settings.cliEnvClaudeConfigDir': 'Claude Code config dir',
+  'settings.cliEnvCodexHome': 'Codex home',
   'settings.modelCustom': '직접 입력…',
   'settings.modelCustomLabel': '사용자 지정 모델 ID',
   'settings.modelCustomPlaceholder': '예: anthropic/claude-sonnet-4-6',
@@ -481,6 +486,8 @@ export const ko: Dict = {
   'misc.designSystem': '디자인 시스템',
 
   'workspace.designFiles': '디자인 파일',
+  'workspace.focusMode': 'Focus workspace',
+  'workspace.showChat': 'Show chat',
   'workspace.closeTab': '탭 닫기',
   'workspace.deleteFileConfirm': '프로젝트 폴더에서 "{name}" 파일을 삭제하시겠습니까?',
   'workspace.openFromDesignFiles': '디자인 파일 열기',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -108,6 +108,11 @@ export const pl: Dict = {
   'settings.reasoningPicker': 'Poziom rozumowania',
   'settings.modelPickerHint':
       'Pobierane z CLI, gdy obsługuje ono polecenie `models`. „Domyślne” pozostawia wybór konfiguracji CLI; „Własne…” pozwala wpisać dowolne ID modelu akceptowane przez CLI.',
+  'settings.cliEnvTitle': 'CLI config locations',
+  'settings.cliEnvHint':
+    'Set non-secret config directories for packaged app runs and agent detection.',
+  'settings.cliEnvClaudeConfigDir': 'Claude Code config dir',
+  'settings.cliEnvCodexHome': 'Codex home',
   'settings.modelCustom': 'Własny (wpisz poniżej)…',
   'settings.modelCustomLabel': 'Własne ID modelu',
   'settings.modelCustomPlaceholder': 'np. anthropic/claude-sonnet-4-6',
@@ -481,6 +486,8 @@ export const pl: Dict = {
   'misc.designSystem': 'System projektowania',
 
   'workspace.designFiles': 'Pliki projektu',
+  'workspace.focusMode': 'Focus workspace',
+  'workspace.showChat': 'Show chat',
   'workspace.closeTab': 'Zamknij kartę',
   'workspace.deleteFileConfirm': 'Usunąć „{name}” z folderu projektu?',
   'workspace.openFromDesignFiles': 'Otwórz plik z',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -106,6 +106,11 @@ export const ptBR: Dict = {
   'settings.reasoningPicker': 'Esforço de raciocínio',
   'settings.modelPickerHint':
     'Buscado na CLI quando ela expõe um comando `models`. "Padrão" deixa a escolha para a configuração da própria CLI; "Personalizado…" permite digitar qualquer id de modelo aceito pela CLI.',
+  'settings.cliEnvTitle': 'CLI config locations',
+  'settings.cliEnvHint':
+    'Set non-secret config directories for packaged app runs and agent detection.',
+  'settings.cliEnvClaudeConfigDir': 'Claude Code config dir',
+  'settings.cliEnvCodexHome': 'Codex home',
   'settings.modelCustom': 'Personalizado (digite abaixo)…',
   'settings.modelCustomLabel': 'Id do modelo personalizado',
   'settings.modelCustomPlaceholder': 'ex.: anthropic/claude-sonnet-4-6',
@@ -491,6 +496,8 @@ export const ptBR: Dict = {
   'misc.designSystem': 'Sistema de design',
 
   'workspace.designFiles': 'Arquivos de design',
+  'workspace.focusMode': 'Focus workspace',
+  'workspace.showChat': 'Show chat',
   'workspace.closeTab': 'Fechar aba',
   'workspace.deleteFileConfirm': 'Excluir "{name}" da pasta do projeto?',
   'workspace.openFromDesignFiles': 'Abra um arquivo em',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -106,6 +106,11 @@ export const ru: Dict = {
   'settings.reasoningPicker': 'Сложность рассуждений',
   'settings.modelPickerHint':
     'Получается из CLI, если он поддерживает команду `models`. «По умолчанию» оставляет выбор конфигурации CLI, а «Пользовательская…» позволяет ввести любой ID модели, который CLI принимает.',
+  'settings.cliEnvTitle': 'CLI config locations',
+  'settings.cliEnvHint':
+    'Set non-secret config directories for packaged app runs and agent detection.',
+  'settings.cliEnvClaudeConfigDir': 'Claude Code config dir',
+  'settings.cliEnvCodexHome': 'Codex home',
   'settings.modelCustom': 'Пользовательская (введите ниже)…',
   'settings.modelCustomLabel': 'Пользовательский ID модели',
   'settings.modelCustomPlaceholder': 'например, anthropic/claude-sonnet-4-6',
@@ -491,6 +496,8 @@ export const ru: Dict = {
   'misc.designSystem': 'Дизайн-система',
 
   'workspace.designFiles': 'Файлы дизайна',
+  'workspace.focusMode': 'Focus workspace',
+  'workspace.showChat': 'Show chat',
   'workspace.closeTab': 'Закрыть вкладку',
   'workspace.deleteFileConfirm': 'Удалить «{name}» из папки проекта?',
   'workspace.openFromDesignFiles': 'Открыть файл из',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -107,6 +107,11 @@ export const uk: Dict = {
   'settings.reasoningPicker': 'Інтенсивність міркувань',
   'settings.modelPickerHint':
     'Отримується з CLI, коли він виявляє команду `models`. «За замовчуванням» залишає вибір конфігурації CLI; «Власна…» дозволяє ввести будь-яке ID моделі, яке приймає CLI.',
+  'settings.cliEnvTitle': 'CLI config locations',
+  'settings.cliEnvHint':
+    'Set non-secret config directories for packaged app runs and agent detection.',
+  'settings.cliEnvClaudeConfigDir': 'Claude Code config dir',
+  'settings.cliEnvCodexHome': 'Codex home',
   'settings.modelCustom': 'Власна (введіть нижче)…',
   'settings.modelCustomLabel': 'Власне ID моделі',
   'settings.modelCustomPlaceholder': 'напр. anthropic/claude-sonnet-4-6',
@@ -492,6 +497,8 @@ export const uk: Dict = {
   'misc.designSystem': 'Система дизайну',
 
   'workspace.designFiles': 'Файли дизайну',
+  'workspace.focusMode': 'Focus workspace',
+  'workspace.showChat': 'Show chat',
   'workspace.closeTab': 'Закрити вкладку',
   'workspace.deleteFileConfirm': 'Видалити "{name}" з папки проекту?',
   'workspace.openFromDesignFiles': 'Відкрити файл з',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -105,6 +105,11 @@ export const zhCN: Dict = {
   'settings.reasoningPicker': '推理强度',
   'settings.modelPickerHint':
     '当 CLI 提供 `models` 命令时会自动拉取。选择「默认」则沿用 CLI 自身的配置；选择「自定义」可手动输入任何 CLI 支持的模型 id。',
+  'settings.cliEnvTitle': 'CLI 配置位置',
+  'settings.cliEnvHint':
+    '为打包版应用运行和 agent 检测设置非敏感配置目录。',
+  'settings.cliEnvClaudeConfigDir': 'Claude Code 配置目录',
+  'settings.cliEnvCodexHome': 'Codex home',
   'settings.modelCustom': '自定义（在下方填写）…',
   'settings.modelCustomLabel': '自定义模型 id',
   'settings.modelCustomPlaceholder': '例如 anthropic/claude-sonnet-4-6',
@@ -483,6 +488,8 @@ export const zhCN: Dict = {
   'misc.designSystem': '设计体系',
 
   'workspace.designFiles': '设计文件',
+  'workspace.focusMode': '专注工作区',
+  'workspace.showChat': '显示聊天',
   'workspace.closeTab': '关闭标签页',
   'workspace.deleteFileConfirm': '从项目文件夹中删除「{name}」？',
   'workspace.openFromDesignFiles': '请从',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -105,6 +105,11 @@ export const zhTW: Dict = {
   'settings.reasoningPicker': '推理強度',
   'settings.modelPickerHint':
     '當 CLI 提供 `models` 命令時會自動拉取。選擇「預設」則沿用 CLI 自身的設定；選擇「自訂」可手動輸入任何 CLI 支援的模型 id。',
+  'settings.cliEnvTitle': 'CLI 設定位置',
+  'settings.cliEnvHint':
+    '為打包版應用執行和 agent 偵測設定非敏感設定目錄。',
+  'settings.cliEnvClaudeConfigDir': 'Claude Code 設定目錄',
+  'settings.cliEnvCodexHome': 'Codex home',
   'settings.modelCustom': '自訂（在下方填寫）…',
   'settings.modelCustomLabel': '自訂模型 id',
   'settings.modelCustomPlaceholder': '例如 anthropic/claude-sonnet-4-6',
@@ -483,6 +488,8 @@ export const zhTW: Dict = {
   'misc.designSystem': '設計系統',
 
   'workspace.designFiles': '設計檔案',
+  'workspace.focusMode': '專注工作區',
+  'workspace.showChat': '顯示聊天',
   'workspace.closeTab': '關閉分頁',
   'workspace.deleteFileConfirm': '從專案資料夾中刪除「{name}」？',
   'workspace.openFromDesignFiles': '請從',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -127,6 +127,10 @@ export interface Dict {
   'settings.modelPicker': string;
   'settings.reasoningPicker': string;
   'settings.modelPickerHint': string;
+  'settings.cliEnvTitle': string;
+  'settings.cliEnvHint': string;
+  'settings.cliEnvClaudeConfigDir': string;
+  'settings.cliEnvCodexHome': string;
   'settings.modelCustom': string;
   'settings.modelCustomLabel': string;
   'settings.modelCustomPlaceholder': string;
@@ -551,6 +555,8 @@ export interface Dict {
 
   // Workspace / file viewer / design files panel
   'workspace.designFiles': string;
+  'workspace.focusMode': string;
+  'workspace.showChat': string;
   'workspace.closeTab': string;
   'workspace.deleteFileConfirm': string;
   'workspace.openFromDesignFiles': string;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -591,6 +591,19 @@ code {
 .split.is-resizing-chat iframe {
   pointer-events: none;
 }
+.split.split-focus {
+  grid-template-columns: minmax(0, 1fr);
+}
+.split-chat-slot {
+  display: flex;
+  min-height: 0;
+}
+.split-chat-slot[hidden] {
+  display: none;
+}
+.split-chat-slot > .pane {
+  flex: 1 1 auto;
+}
 .pane {
   display: flex;
   flex-direction: column;
@@ -1609,6 +1622,32 @@ code {
   color: var(--text-muted);
 }
 .agent-model-row .hint { margin: 0; font-size: 11.5px; }
+.agent-cli-env {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-sm);
+  background: var(--bg-panel);
+}
+.agent-cli-env-head {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.agent-cli-env-head h4 {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+}
+.agent-cli-env-head .hint { margin: 0; font-size: 11.5px; }
+.agent-cli-env-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
 .status-dot {
   width: 8px; height: 8px;
   border-radius: 50%;
@@ -4439,20 +4478,28 @@ button.connector-action.is-loading {
   background: var(--bg);
   flex: 1;
 }
-.ws-tabs-bar {
+.ws-tabs-shell {
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: 8px;
   padding: 6px 10px;
   border-bottom: 1px solid var(--border);
   background: var(--bg-panel);
-  overflow-x: auto;
-  overflow-y: hidden;
-  flex-wrap: nowrap;
   height: 44px;
   position: sticky;
   top: 0;
   z-index: 4;
+}
+.ws-tabs-bar {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  flex-wrap: nowrap;
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 100%;
 }
 
 .ws-tab {
@@ -4523,8 +4570,30 @@ button.connector-action.is-loading {
   color: var(--text);
 }
 
-.ws-tabs-spacer { flex: 1; }
 .ws-tabs-actions { display: inline-flex; gap: 4px; align-items: center; }
+.ws-focus-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 28px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  color: var(--text-muted);
+  font-size: 12px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.ws-focus-toggle:hover {
+  background: var(--bg-subtle);
+  color: var(--text);
+  border-color: var(--border-strong);
+}
+.ws-focus-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 .ws-tab-action {
   padding: 4px 12px;
   font-size: 12.5px;

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -61,6 +61,7 @@ export const DEFAULT_CONFIG: AppConfig = {
   mediaProviders: {},
   composio: {},
   agentModels: {},
+  agentCliEnv: {},
   pet: DEFAULT_PET,
   notifications: DEFAULT_NOTIFICATIONS,
 };
@@ -235,6 +236,7 @@ export function loadConfig(): AppConfig {
       mediaProviders: { ...(parsed.mediaProviders ?? {}) },
       composio: { ...(parsed.composio ?? {}) },
       agentModels: { ...(parsed.agentModels ?? {}) },
+      agentCliEnv: { ...(parsed.agentCliEnv ?? {}) },
       pet: normalizePet(parsed.pet),
       notifications: normalizeNotifications(parsed.notifications),
     };
@@ -351,6 +353,7 @@ export async function syncConfigToDaemon(config: AppConfig): Promise<void> {
     onboardingCompleted: config.onboardingCompleted,
     agentId: config.agentId,
     agentModels: config.agentModels,
+    agentCliEnv: config.agentCliEnv,
     skillId: config.skillId,
     designSystemId: config.designSystemId,
     disabledSkills: config.disabledSkills,

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -312,6 +312,41 @@ export function saveConfig(config: AppConfig): void {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(config));
 }
 
+export function mergeDaemonConfig(
+  localConfig: AppConfig,
+  daemonConfig: AppConfigPrefs | null,
+): AppConfig {
+  const next = { ...localConfig };
+  if (!daemonConfig) return next;
+
+  if (daemonConfig.onboardingCompleted != null) {
+    next.onboardingCompleted = daemonConfig.onboardingCompleted;
+  }
+  if (daemonConfig.agentId !== undefined) {
+    next.agentId = daemonConfig.agentId;
+  }
+  if (daemonConfig.skillId !== undefined) {
+    next.skillId = daemonConfig.skillId;
+  }
+  if (daemonConfig.designSystemId !== undefined) {
+    next.designSystemId = daemonConfig.designSystemId;
+  }
+  if (daemonConfig.agentModels) {
+    next.agentModels = {
+      ...(next.agentModels ?? {}),
+      ...daemonConfig.agentModels,
+    };
+  }
+  next.agentCliEnv = daemonConfig.agentCliEnv ?? {};
+  if (daemonConfig.disabledSkills !== undefined) {
+    next.disabledSkills = daemonConfig.disabledSkills;
+  }
+  if (daemonConfig.disabledDesignSystems !== undefined) {
+    next.disabledDesignSystems = daemonConfig.disabledDesignSystems;
+  }
+  return next;
+}
+
 export function hasAnyConfiguredProvider(
   providers: Record<string, MediaProviderCredentials> | undefined,
 ): boolean {

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -1,5 +1,6 @@
 import type {
   AgentInfo,
+  AgentCliEnvPrefs,
   AgentModelPrefs,
   AppVersionInfo,
   AppVersionResponse,
@@ -141,6 +142,7 @@ export interface ApiProtocolConfig {
 // other one's choice. Missing entries fall back to the agent's first
 // declared model (`'default'` — let the CLI pick).
 export type AgentModelChoice = AgentModelPrefs;
+export type AgentCliEnvConfig = AgentCliEnvPrefs;
 
 export type AppTheme = 'system' | 'light' | 'dark';
 
@@ -258,6 +260,8 @@ export interface AppConfig {
   // Pre-existing configs without this field fall through to the agent's
   // declared default.
   agentModels?: Record<string, AgentModelChoice>;
+  // Per-agent non-secret CLI config locations injected into detection and runs.
+  agentCliEnv?: AgentCliEnvConfig;
   // Caps the upstream completion length in API mode. Defaults to 8192 when
   // unset; raise it for providers (e.g. MiMo) that allow longer responses.
   maxTokens?: number;

--- a/apps/web/tests/components/FileWorkspace.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.test.tsx
@@ -2,6 +2,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it, vi } from 'vitest';
 
 import { FileWorkspace, scrollWorkspaceTabsWithWheel } from '../../src/components/FileWorkspace';
+import { projectSplitClassName } from '../../src/components/ProjectView';
 
 describe('FileWorkspace upload input', () => {
   it('keeps the Design Files picker aligned with drag-and-drop file support', () => {
@@ -19,6 +20,72 @@ describe('FileWorkspace upload input', () => {
 
     expect(markup).toContain('data-testid="design-files-upload-input"');
     expect(markup).not.toContain('accept=');
+  });
+
+  it('keeps focus mode controls in the workspace tab bar', () => {
+    const markup = renderToStaticMarkup(
+      <FileWorkspace
+        projectId="project-1"
+        files={[]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        tabsState={{ tabs: [], active: null }}
+        onTabsStateChange={vi.fn()}
+        focusMode={false}
+        onFocusModeChange={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain('data-testid="workspace-focus-toggle"');
+    expect(markup).toContain('Focus workspace');
+  });
+
+  it('keeps the focus mode action outside the horizontally scrollable tablist', () => {
+    const markup = renderToStaticMarkup(
+      <FileWorkspace
+        projectId="project-1"
+        files={[]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        tabsState={{ tabs: [], active: null }}
+        onTabsStateChange={vi.fn()}
+        focusMode={false}
+        onFocusModeChange={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain('class="ws-tabs-shell"');
+    expect(markup).toContain('class="ws-tabs-actions"');
+    expect(markup).toMatch(
+      /<div class="ws-tabs-bar" role="tablist"[^>]*>[\s\S]*?<\/div><div class="ws-tabs-actions">/,
+    );
+  });
+
+  it('labels the same workspace control as chat restore while focused', () => {
+    const markup = renderToStaticMarkup(
+      <FileWorkspace
+        projectId="project-1"
+        files={[]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        tabsState={{ tabs: [], active: null }}
+        onTabsStateChange={vi.fn()}
+        focusMode
+        onFocusModeChange={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain('Show chat');
+  });
+});
+
+describe('projectSplitClassName', () => {
+  it('marks the project split as focused so the chat pane can collapse globally', () => {
+    expect(projectSplitClassName(false)).toBe('split');
+    expect(projectSplitClassName(true)).toBe('split split-focus');
   });
 });
 

--- a/apps/web/tests/components/SettingsDialog.test.ts
+++ b/apps/web/tests/components/SettingsDialog.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  agentRefreshOptionsForConfig,
   isValidApiBaseUrl,
   switchApiProtocolConfig,
   updateAgentCliEnvValue,
@@ -188,6 +189,36 @@ describe('SettingsDialog agent CLI env settings', () => {
 
     expect(next.agentCliEnv).toEqual({
       codex: { CODEX_HOME: '~/.codex-alt' },
+    });
+  });
+
+  it('passes pending CLI env prefs through agent rescan options', () => {
+    const config: AppConfig = {
+      ...baseConfig,
+      mode: 'daemon',
+      agentCliEnv: {
+        claude: { CLAUDE_CONFIG_DIR: '~/.claude-pending' },
+      },
+    };
+
+    expect(agentRefreshOptionsForConfig(config)).toEqual({
+      throwOnError: true,
+      agentCliEnv: {
+        claude: { CLAUDE_CONFIG_DIR: '~/.claude-pending' },
+      },
+    });
+  });
+
+  it('passes an empty CLI env object through agent rescan after fields are cleared', () => {
+    const config: AppConfig = {
+      ...baseConfig,
+      mode: 'daemon',
+      agentCliEnv: {},
+    };
+
+    expect(agentRefreshOptionsForConfig(config)).toEqual({
+      throwOnError: true,
+      agentCliEnv: {},
     });
   });
 });

--- a/apps/web/tests/components/SettingsDialog.test.ts
+++ b/apps/web/tests/components/SettingsDialog.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   isValidApiBaseUrl,
   switchApiProtocolConfig,
+  updateAgentCliEnvValue,
   updateCurrentApiProtocolConfig,
 } from '../../src/components/SettingsDialog';
 import type { AppConfig } from '../../src/types';
@@ -142,5 +143,51 @@ describe('SettingsDialog API Base URL validation', () => {
     expect(isValidApiBaseUrl('http://169.254.1.5:11434/v1')).toBe(false);
     expect(isValidApiBaseUrl('http://172.16.0.5:11434/v1')).toBe(false);
     expect(isValidApiBaseUrl('http://192.168.1.5:11434/v1')).toBe(false);
+  });
+});
+
+describe('SettingsDialog agent CLI env settings', () => {
+  it('updates supported per-agent CLI env values without dropping sibling agents', () => {
+    const config: AppConfig = {
+      ...baseConfig,
+      mode: 'daemon',
+      agentCliEnv: {
+        codex: { CODEX_HOME: '~/.codex-alt' },
+      },
+    };
+
+    const next = updateAgentCliEnvValue(
+      config,
+      'claude',
+      'CLAUDE_CONFIG_DIR',
+      '  ~/.claude-2  ',
+    );
+
+    expect(next.agentCliEnv).toEqual({
+      claude: { CLAUDE_CONFIG_DIR: '~/.claude-2' },
+      codex: { CODEX_HOME: '~/.codex-alt' },
+    });
+  });
+
+  it('removes empty per-agent CLI env entries', () => {
+    const config: AppConfig = {
+      ...baseConfig,
+      mode: 'daemon',
+      agentCliEnv: {
+        claude: { CLAUDE_CONFIG_DIR: '~/.claude-2' },
+        codex: { CODEX_HOME: '~/.codex-alt' },
+      },
+    };
+
+    const next = updateAgentCliEnvValue(
+      config,
+      'claude',
+      'CLAUDE_CONFIG_DIR',
+      '',
+    );
+
+    expect(next.agentCliEnv).toEqual({
+      codex: { CODEX_HOME: '~/.codex-alt' },
+    });
   });
 });

--- a/apps/web/tests/state/config.test.ts
+++ b/apps/web/tests/state/config.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   DEFAULT_CONFIG,
   loadConfig,
+  mergeDaemonConfig,
   syncComposioConfigToDaemon,
   syncConfigToDaemon,
 } from '../../src/state/config';
@@ -92,6 +93,45 @@ describe('syncConfigToDaemon', () => {
         claude: { CLAUDE_CONFIG_DIR: '~/.claude-2' },
         codex: { CODEX_HOME: '~/.codex-alt' },
       },
+    });
+  });
+});
+
+describe('mergeDaemonConfig', () => {
+  it('clears stale local CLI env prefs when the daemon has none', () => {
+    const merged = mergeDaemonConfig(
+      {
+        ...DEFAULT_CONFIG,
+        agentCliEnv: {
+          claude: { CLAUDE_CONFIG_DIR: '~/.claude-old' },
+        },
+      },
+      {
+        agentId: 'codex',
+      },
+    );
+
+    expect(merged.agentId).toBe('codex');
+    expect(merged.agentCliEnv).toEqual({});
+  });
+
+  it('uses daemon CLI env prefs instead of merging with stale local entries', () => {
+    const merged = mergeDaemonConfig(
+      {
+        ...DEFAULT_CONFIG,
+        agentCliEnv: {
+          claude: { CLAUDE_CONFIG_DIR: '~/.claude-old' },
+        },
+      },
+      {
+        agentCliEnv: {
+          codex: { CODEX_HOME: '~/.codex-new' },
+        },
+      },
+    );
+
+    expect(merged.agentCliEnv).toEqual({
+      codex: { CODEX_HOME: '~/.codex-new' },
     });
   });
 });

--- a/apps/web/tests/state/config.test.ts
+++ b/apps/web/tests/state/config.test.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_CONFIG,
   loadConfig,
   syncComposioConfigToDaemon,
+  syncConfigToDaemon,
 } from '../../src/state/config';
 import type { AppConfig } from '../../src/types';
 
@@ -51,6 +52,46 @@ describe('syncComposioConfigToDaemon', () => {
       method: 'PUT',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({}),
+    });
+  });
+});
+
+describe('syncConfigToDaemon', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.stubGlobal('fetch', originalFetch);
+  });
+
+  it('syncs per-agent CLI env prefs to the daemon app config', async () => {
+    const fetchMock = vi.fn(async () => new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await syncConfigToDaemon({
+      ...DEFAULT_CONFIG,
+      agentCliEnv: {
+        claude: { CLAUDE_CONFIG_DIR: '~/.claude-2' },
+        codex: { CODEX_HOME: '~/.codex-alt' },
+      },
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toBe('/api/app-config');
+    expect(init.method).toBe('PUT');
+    expect(init.headers).toEqual({ 'content-type': 'application/json' });
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      onboardingCompleted: DEFAULT_CONFIG.onboardingCompleted,
+      agentId: DEFAULT_CONFIG.agentId,
+      agentModels: DEFAULT_CONFIG.agentModels,
+      skillId: DEFAULT_CONFIG.skillId,
+      designSystemId: DEFAULT_CONFIG.designSystemId,
+      agentCliEnv: {
+        claude: { CLAUDE_CONFIG_DIR: '~/.claude-2' },
+        codex: { CODEX_HOME: '~/.codex-alt' },
+      },
     });
   });
 });

--- a/packages/contracts/src/api/app-config.ts
+++ b/packages/contracts/src/api/app-config.ts
@@ -3,10 +3,13 @@ export interface AgentModelPrefs {
   reasoning?: string;
 }
 
+export type AgentCliEnvPrefs = Record<string, Record<string, string>>;
+
 export interface AppConfigPrefs {
   onboardingCompleted?: boolean;
   agentId?: string | null;
   agentModels?: Record<string, AgentModelPrefs>;
+  agentCliEnv?: AgentCliEnvPrefs;
   skillId?: string | null;
   designSystemId?: string | null;
   disabledSkills?: string[];


### PR DESCRIPTION
## Summary
- Add daemon-backed per-agent CLI config locations for Claude Code and Codex.
- Inject configured CLI env into agent detection, model probing, and chat runtime spawns.
- Add workspace focus mode that collapses chat and expands the workspace preview while keeping tabs and controls available.
- Keep the focus/restore action pinned outside the horizontally scrollable tab strip so chat can always be restored.

## Issues
Closes #571
Closes #550

## Root Cause
The packaged app did not inherit terminal-only CLI config env, so authenticated Claude/Codex installs using custom config locations could not be discovered or launched reliably. The workspace layout also kept chat and preview side by side with no full-width review mode.

## Implementation
- Add `agentCliEnv` to shared app config contracts and web config sync.
- Persist only supported non-secret env keys: `CLAUDE_CONFIG_DIR` for Claude and `CODEX_HOME` for Codex.
- Apply those env values consistently to daemon detection, ACP/model probing, and agent spawn.
- Add Settings UI for CLI config locations.
- Add focus-mode state to ProjectView and a workspace tab-bar toggle.
- Hide chat during focus mode without unmounting it, so draft/internal state is preserved.
- Split the workspace header into a scrollable tablist plus pinned actions so `Show chat` remains visible when many tabs are open.

## UI / UX
```text
Normal
+----------------+--------------------------------+
| Chat           | Tabs scroll  ...   Focus button |
|                | Workspace preview               |
+----------------+--------------------------------+

Focus mode
+-------------------------------------------------+
| Tabs scroll  ...                       Show chat |
| Workspace preview                               |
+-------------------------------------------------+
```

## Testing
- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/daemon test -- tests/app-config.test.ts tests/agents.test.ts` (56 files / 766 tests)
- `pnpm --filter @open-design/web test -- tests/state/config.test.ts tests/components/SettingsDialog.test.ts tests/components/FileWorkspace.test.tsx` (33 files / 265 tests)
- `pnpm --filter @open-design/contracts build`
- `pnpm --filter @open-design/daemon build`
- `pnpm --filter @open-design/desktop build`
- `pnpm --filter @open-design/web build`
- `git diff --check`

## Notes
- Local verification ran with Node `v22.16.0`; this repository declares Node `~24`, so pnpm emitted engine warnings while the commands above still completed successfully.