### PR TITLE
fix(acp): normalize mcpServers to stdio shape for Kimi/Hermes ACP

### DIFF
--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -7,13 +7,21 @@ const DEFAULT_TIMEOUT_MS = 15_000;
 const DEFAULT_STAGE_TIMEOUT_MS = 180_000;
 
 export function buildAcpSessionNewParams(cwd, { mcpServers } = {}) {
+  const servers = Array.isArray(mcpServers) ? mcpServers : [];
   return {
     cwd: path.resolve(cwd),
     // MCP is an optional compatibility layer. Default to no MCP servers so ACP
     // agents can run through the skill + CLI path without MCP support. Do not
     // auto-install or mutate user/global MCP config; callers must pass an
     // explicit per-session MCP descriptor when a compatible agent supports it.
-    mcpServers: Array.isArray(mcpServers) ? mcpServers : [],
+    // Normalize to the ACP stdio server shape expected by Kimi/Hermes.
+    mcpServers: servers.map((s) => ({
+      type: typeof s?.type === 'string' ? s.type : 'stdio',
+      name: typeof s?.name === 'string' ? s.name : '',
+      command: typeof s?.command === 'string' ? s.command : '',
+      args: Array.isArray(s?.args) ? s.args : [],
+      env: Array.isArray(s?.env) ? s.env : [],
+    })),
   };
 }
 

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -19,11 +19,30 @@ test('ACP session params do not request global MCP config mutation', () => {
   assert.equal('installMcpServers' in params, false);
 });
 
-test('ACP session params accept explicit MCP servers as optional configuration', () => {
+test('ACP session params normalize explicit MCP servers to ACP stdio shape', () => {
   const mcpServers = [{ name: 'open-design-live-artifacts', command: 'od', args: ['mcp', 'live-artifacts'] }];
 
   assert.deepEqual(buildAcpSessionNewParams('/tmp/od-project', { mcpServers }), {
     cwd: path.resolve('/tmp/od-project'),
-    mcpServers,
+    mcpServers: [
+      {
+        type: 'stdio',
+        name: 'open-design-live-artifacts',
+        command: 'od',
+        args: ['mcp', 'live-artifacts'],
+        env: [],
+      },
+    ],
   });
+});
+
+test('ACP session params preserve caller-provided type and env fields', () => {
+  const mcpServers = [
+    { type: 'http', name: 'http-server', url: 'http://localhost:3000', headers: {}, env: [{ key: 'TOKEN', value: 'secret' }] },
+  ];
+
+  const result = buildAcpSessionNewParams('/tmp/od-project', { mcpServers });
+  assert.equal(result.mcpServers[0].type, 'http');
+  assert.equal(result.mcpServers[0].name, 'http-server');
+  assert.deepEqual(result.mcpServers[0].env, [{ key: 'TOKEN', value: 'secret' }]);
 });


### PR DESCRIPTION
## Problem

When using Kimi CLI (ACP JSON-RPC agent), Open Design's daemon sends a session/new request with MCP server descriptors in the shape { name, command, args }. Kimi CLI 1.35.0 expects the full ACP stdio server shape { type: 'stdio', name, command, args, env: [] }, and rejects the request with **JSON-RPC -32602 Invalid params**.

This happens when mcpDiscovery is enabled for an ACP agent (Kimi and Hermes both declare mcpDiscovery: 'mature-acp').

## Reproduction

1. Install Kimi CLI 1.35.0 and ensure it is on PATH.
2. Start Open Design (pnpm tools-dev run web).
3. Open the web UI and start a new chat with the Kimi agent.
4. The daemon calls ttachAcpSession → session/new with mcpServers populated by uildLiveArtifactsMcpServersForAgent.
5. Kimi CLI returns json-rpc id 2: Invalid params and the chat fails immediately.

## Fix

uildAcpSessionNewParams now maps every MCP server descriptor to the complete stdio shape expected by ACP-compliant agents:

`	s
{
  type: 'stdio',
  name: typeof s?.name === 'string' ? s.name : '',
  command: typeof s?.command === 'string' ? s.command : '',
  args: Array.isArray(s?.args) ? s.args : [],
  env: [],
}
`

This keeps the change scoped to the ACP adapter without affecting other agents (Claude Code, Codex, etc.) that use different transport formats.

## Verification

- Manually tested the full ACP handshake against kimi acp:
  - initialize → success
  - session/new with normalized mcpServers → returns valid sessionId
  - session/prompt → streams correctly

Fixes the json-rpc id 2: Invalid params error reported when running Open Design with Kimi CLI.