### PR TITLE
fix(daemon, packaged): unbreak GUI-launched agent detection on minimal PATHs (#442)

### DIFF
--- a/apps/daemon/src/agents.ts
+++ b/apps/daemon/src/agents.ts
@@ -1,10 +1,11 @@
 // @ts-nocheck
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { existsSync, readdirSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { delimiter } from 'node:path';
 import path from 'node:path';
 import { homedir } from 'node:os';
+import { wellKnownUserToolchainBins } from '@open-design/platform';
 import { detectAcpModels } from './acp.js';
 import { parsePiModels } from './pi-rpc.js';
 
@@ -712,22 +713,11 @@ export const AGENT_DEFS = [
   },
 ];
 
-function existingDirsUnder(root, segments = []) {
-  const dirs = [];
-  let entries = [];
-  try {
-    entries = readdirSync(root, { withFileTypes: true });
-  } catch {
-    return dirs;
-  }
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    const full = path.join(root, entry.name, ...segments);
-    if (existsSync(full)) dirs.push(full);
-  }
-  return dirs;
-}
-
+// Toolchain dir computation lives in @open-design/platform so the daemon
+// resolver and the packaged sidecar PATH builder can never drift again
+// (issue #442). The wrapper here just preserves the OD_AGENT_HOME test
+// hook and the per-home cache that reduces filesystem scans on every
+// resolveOnPath() call.
 const TOOLCHAIN_DIR_CACHE_TTL_MS = 5000;
 let cachedToolchainHome = null;
 let cachedToolchainDirs = null;
@@ -746,27 +736,13 @@ function userToolchainDirs() {
   }
   cachedToolchainHome = home;
   cachedToolchainDirsAt = now;
-  cachedToolchainDirs = [
-    path.join(home, '.local', 'bin'),
-    path.join(home, '.opencode', 'bin'),
-    path.join(home, '.bun', 'bin'),
-    path.join(home, '.volta', 'bin'),
-    path.join(home, '.asdf', 'shims'),
-    path.join(home, 'Library', 'pnpm'),
-    path.join(home, '.cargo', 'bin'),
-    ...(process.platform !== 'win32' && !homeOverride
-      ? ['/opt/homebrew/bin', '/usr/local/bin']
-      : []),
-    ...existingDirsUnder(
-      path.join(home, '.local', 'share', 'mise', 'installs', 'node'),
-      ['bin'],
-    ),
-    ...existingDirsUnder(path.join(home, '.nvm', 'versions', 'node'), ['bin']),
-    ...existingDirsUnder(
-      path.join(home, '.local', 'share', 'fnm', 'node-versions'),
-      ['installation', 'bin'],
-    ),
-  ];
+  // Skip Homebrew / /usr/local bins when running under OD_AGENT_HOME so
+  // tests that scope detection to a temp home don't pick up the real
+  // machine's CLIs.
+  cachedToolchainDirs = wellKnownUserToolchainBins({
+    home,
+    includeSystemBins: process.platform !== 'win32' && !homeOverride,
+  });
   return cachedToolchainDirs;
 }
 

--- a/apps/daemon/src/agents.ts
+++ b/apps/daemon/src/agents.ts
@@ -715,9 +715,10 @@ export const AGENT_DEFS = [
 
 // Toolchain dir computation lives in @open-design/platform so the daemon
 // resolver and the packaged sidecar PATH builder can never drift again
-// (issue #442). The wrapper here just preserves the OD_AGENT_HOME test
-// hook and the per-home cache that reduces filesystem scans on every
-// resolveOnPath() call.
+// (issue #442). See @open-design/platform's wellKnownUserToolchainBins
+// for the canonical search list. The wrapper here just preserves the
+// OD_AGENT_HOME test hook and the per-home cache that reduces
+// filesystem scans on every resolveOnPath() call.
 const TOOLCHAIN_DIR_CACHE_TTL_MS = 5000;
 let cachedToolchainHome = null;
 let cachedToolchainDirs = null;
@@ -736,12 +737,16 @@ function userToolchainDirs() {
   }
   cachedToolchainHome = home;
   cachedToolchainDirsAt = now;
-  // Skip Homebrew / /usr/local bins when running under OD_AGENT_HOME so
-  // tests that scope detection to a temp home don't pick up the real
-  // machine's CLIs.
+  // When OD_AGENT_HOME is set, scope the search strictly to the override
+  // home: skip Homebrew / /usr/local *and* pass an empty env so that a
+  // developer or CI runner with NPM_CONFIG_PREFIX / npm_config_prefix
+  // exported can't leak the real machine's <prefix>/bin into a sandboxed
+  // detection run. Without this the agents.test.ts cases that build a
+  // tmp home would be machine-environment-dependent.
   cachedToolchainDirs = wellKnownUserToolchainBins({
     home,
     includeSystemBins: process.platform !== 'win32' && !homeOverride,
+    env: homeOverride ? {} : process.env,
   });
   return cachedToolchainDirs;
 }

--- a/apps/daemon/tests/agents.test.ts
+++ b/apps/daemon/tests/agents.test.ts
@@ -41,6 +41,7 @@ const originalHome = process.env.HOME;
 const originalAgentHome = process.env.OD_AGENT_HOME;
 const originalDaemonUrl = process.env.OD_DAEMON_URL;
 const originalToolToken = process.env.OD_TOOL_TOKEN;
+const originalNpmConfigPrefix = process.env.NPM_CONFIG_PREFIX;
 const originalFetch = globalThis.fetch;
 
 afterEach(() => {
@@ -69,6 +70,11 @@ afterEach(() => {
     delete process.env.OD_TOOL_TOKEN;
   } else {
     process.env.OD_TOOL_TOKEN = originalToolToken;
+  }
+  if (originalNpmConfigPrefix == null) {
+    delete process.env.NPM_CONFIG_PREFIX;
+  } else {
+    process.env.NPM_CONFIG_PREFIX = originalNpmConfigPrefix;
   }
   globalThis.fetch = originalFetch;
 });
@@ -845,7 +851,11 @@ fsTest(
           `got ${resolved}`,
       );
     } finally {
-      delete process.env.NPM_CONFIG_PREFIX;
+      // afterEach restores NPM_CONFIG_PREFIX to its pre-test value (or
+      // deletes it when it was unset), so do not unconditionally
+      // `delete` it here — that would clobber an export the developer
+      // / CI runner had already set, leaking into the next test in the
+      // same Vitest worker.
       rmSync(sandbox, { recursive: true, force: true });
       rmSync(realPrefix, { recursive: true, force: true });
     }

--- a/apps/daemon/tests/agents.test.ts
+++ b/apps/daemon/tests/agents.test.ts
@@ -812,6 +812,46 @@ fsTest(
   },
 );
 
+// Test isolation: when OD_AGENT_HOME points at a sandbox, an exported
+// $NPM_CONFIG_PREFIX / $npm_config_prefix on the developer's or CI
+// runner's environment must not leak a real <prefix>/bin into the
+// sandboxed search list. Otherwise an agent installed by the host
+// machine could satisfy a "not on PATH" assertion in the sandbox and
+// make detection tests environment-dependent. Raised in PR review on
+// #442 (review comment by @mrcfps on apps/daemon/src/agents.ts:742).
+fsTest(
+  'OD_AGENT_HOME isolates resolution from $NPM_CONFIG_PREFIX leakage',
+  () => {
+    const sandbox = mkdtempSync(join(tmpdir(), 'od-agents-sandbox-'));
+    const realPrefix = mkdtempSync(join(tmpdir(), 'od-agents-real-prefix-'));
+    const realPrefixBin = join(realPrefix, 'bin');
+    try {
+      // Sandbox is empty — gemini does not exist under OD_AGENT_HOME.
+      // Real prefix has a gemini, simulating the developer's /opt/...
+      // or ~/.npm-global install. NPM_CONFIG_PREFIX points at it.
+      mkdirSync(realPrefixBin, { recursive: true });
+      writeFileSync(join(realPrefixBin, 'gemini'), '');
+      chmodSync(join(realPrefixBin, 'gemini'), 0o755);
+
+      process.env.OD_AGENT_HOME = sandbox;
+      process.env.PATH = '/usr/bin:/bin';
+      process.env.NPM_CONFIG_PREFIX = realPrefix;
+
+      const resolved = resolveAgentExecutable({ bin: 'gemini' });
+      assert.equal(
+        resolved,
+        null,
+        `OD_AGENT_HOME sandbox must not see the real $NPM_CONFIG_PREFIX bin; ` +
+          `got ${resolved}`,
+      );
+    } finally {
+      delete process.env.NPM_CONFIG_PREFIX;
+      rmSync(sandbox, { recursive: true, force: true });
+      rmSync(realPrefix, { recursive: true, force: true });
+    }
+  },
+);
+
 // DeepSeek TUI's exec subcommand requires the prompt as a positional
 // argument (no `-` stdin sentinel; clap declares `prompt: String` as a
 // required field). `--auto` enables agentic mode with auto-approval —

--- a/apps/daemon/tests/agents.test.ts
+++ b/apps/daemon/tests/agents.test.ts
@@ -762,6 +762,56 @@ fsTest(
   },
 );
 
+// Issue #442: GUI-launched daemons (Finder/Dock on macOS, .desktop on Linux)
+// inherit a stripped PATH that doesn't include the user's npm global prefix.
+// Most third-party "fix npm EACCES without sudo" tutorials configure
+// `~/.npm-global` as the prefix, so any CLI installed via `npm i -g <cli>`
+// lives at `~/.npm-global/bin/<cli>`. The daemon must search there even when
+// the inherited PATH only carries `/usr/bin:/bin:...`.
+fsTest(
+  'resolveAgentExecutable searches ~/.npm-global/bin under a minimal GUI-launched PATH (issue #442)',
+  () => {
+    const home = mkdtempSync(join(tmpdir(), 'od-agents-npm-global-'));
+    try {
+      const dir = join(home, '.npm-global', 'bin');
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'gemini'), '');
+      chmodSync(join(dir, 'gemini'), 0o755);
+      process.env.OD_AGENT_HOME = home;
+      // Mirror the launchd default a `.app` actually inherits — no
+      // `~/.npm-global/bin`, no `/opt/homebrew/bin`, nothing user-side.
+      process.env.PATH = '/usr/bin:/bin';
+
+      const resolved = resolveAgentExecutable({ bin: 'gemini' });
+      assert.equal(resolved, join(dir, 'gemini'));
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  },
+);
+
+// Same root cause as #442 but for the second-most-common alternative
+// non-canonical npm prefix shipped in older "fix sudo-free npm" guides.
+fsTest(
+  'resolveAgentExecutable also searches ~/.npm-packages/bin (alt npm prefix)',
+  () => {
+    const home = mkdtempSync(join(tmpdir(), 'od-agents-npm-packages-'));
+    try {
+      const dir = join(home, '.npm-packages', 'bin');
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'gemini'), '');
+      chmodSync(join(dir, 'gemini'), 0o755);
+      process.env.OD_AGENT_HOME = home;
+      process.env.PATH = '/usr/bin:/bin';
+
+      const resolved = resolveAgentExecutable({ bin: 'gemini' });
+      assert.equal(resolved, join(dir, 'gemini'));
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  },
+);
+
 // DeepSeek TUI's exec subcommand requires the prompt as a positional
 // argument (no `-` stdin sentinel; clap declares `prompt: String` as a
 // required field). `--auto` enables agentic mode with auto-approval —

--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -1,8 +1,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
-import { existsSync, readdirSync } from "node:fs";
 import { mkdir, open, type FileHandle } from "node:fs/promises";
 import { createRequire } from "node:module";
-import { homedir } from "node:os";
 import { delimiter, dirname, join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 
@@ -23,7 +21,12 @@ import {
   resolveAppIpcPath,
   type SidecarRuntimeContext,
 } from "@open-design/sidecar";
-import { createProcessStampArgs, stopProcesses, waitForProcessExit } from "@open-design/platform";
+import {
+  createProcessStampArgs,
+  stopProcesses,
+  waitForProcessExit,
+  wellKnownUserToolchainBins,
+} from "@open-design/platform";
 
 import type { PackagedWebOutputMode } from "./config.js";
 import type { PackagedNamespacePaths } from "./paths.js";
@@ -105,45 +108,19 @@ function extractPort(url: string): string {
   return parsed.port || (parsed.protocol === "https:" ? "443" : "80");
 }
 
-function existingDirsUnder(root: string, segments: string[] = []): string[] {
-  const dirs: string[] = [];
-  try {
-    const entries = readdirSync(root, { withFileTypes: true });
-    for (const entry of entries) {
-      if (!entry.isDirectory()) continue;
-      const full = join(root, entry.name, ...segments);
-      if (existsSync(full)) dirs.push(full);
-    }
-  } catch {
-    // best-effort: directory may not exist or be unreadable
-  }
-  return dirs;
-}
-
-function collectNvmFnmBins(home: string): string[] {
-  return [
-    ...existingDirsUnder(join(home, ".nvm", "versions", "node"), ["bin"]),
-    ...existingDirsUnder(join(home, ".local", "share", "fnm", "node-versions"), ["installation", "bin"]),
-    ...existingDirsUnder(join(home, ".local", "share", "mise", "installs", "node"), ["bin"]),
-  ];
-}
+// Hardcoded POSIX system bins the packaged daemon must always be able to
+// reach even when the inherited PATH from launchd / a desktop launcher is
+// stripped down to nothing. The user-toolchain portion of the search list
+// (Homebrew, npm globals, nvm/fnm/mise, cargo, ...) lives in
+// @open-design/platform's wellKnownUserToolchainBins so the daemon
+// resolver and this PATH builder cannot drift again. See issue #442.
+const PACKAGED_POSIX_SYSTEM_BINS = ["/usr/bin", "/bin", "/usr/sbin", "/sbin"] as const;
 
 function resolvePackagedPathEnv(basePath = process.env.PATH ?? ""): string {
-  const home = homedir();
   const candidates = [
     ...basePath.split(delimiter),
-    join(home, ".local", "bin"),
-    join(home, ".opencode", "bin"),
-    join(home, ".cargo", "bin"),
-    join(home, ".bun", "bin"),
-    join(home, ".volta", "bin"),
-    ...collectNvmFnmBins(home),
-    "/opt/homebrew/bin",
-    "/usr/local/bin",
-    "/usr/bin",
-    "/bin",
-    "/usr/sbin",
-    "/sbin",
+    ...wellKnownUserToolchainBins(),
+    ...PACKAGED_POSIX_SYSTEM_BINS,
   ];
   return [...new Set(candidates.filter((entry) => entry.length > 0))].join(delimiter);
 }

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -7,7 +7,7 @@ Follow the root `AGENTS.md` first. This file only records module-level boundarie
 - `packages/contracts`: web/daemon app contract layer. Keep it pure TypeScript; it must not depend on Next.js, Express, Node filesystem/process APIs, browser APIs, SQLite, daemon internals, or the sidecar control-plane protocol.
 - `packages/sidecar-proto`: Open Design sidecar business protocol. Owns app/mode/source constants, namespace validation, stamp descriptor/fields/flags, IPC message schema, status shapes, error semantics, and default product path constants.
 - `packages/sidecar`: generic sidecar runtime primitives. Includes bootstrap, IPC transport, path/runtime resolution, launch env, and JSON runtime file helpers; it must not hard-code Open Design app keys or IPC business messages.
-- `packages/platform`: generic OS process primitives. Includes stamp serialization, command parsing, and process matching/search; it must consume the `sidecar-proto` descriptor and must not hard-code `--od-stamp-*` details.
+- `packages/platform`: generic OS process primitives. Includes stamp serialization, command parsing, process matching/search, and well-known user-toolchain bin discovery; it must consume the `sidecar-proto` descriptor and must not hard-code `--od-stamp-*` details. The toolchain helper is the single source of truth shared by the daemon agent resolver (`apps/daemon/src/agents.ts`) and the packaged sidecar PATH builder (`apps/packaged/src/sidecars.ts`) so neither layer can drift the search list.
 
 ## Removed directories
 

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -465,9 +465,15 @@ export function wellKnownUserToolchainBins(
   // Honour an explicit npm prefix override regardless of where the user
   // pointed it. Covers setups that don't match either of the conventions
   // above (e.g. corporate provisioning that exports a custom prefix).
-  const npmPrefix = env.NPM_CONFIG_PREFIX ?? env.npm_config_prefix;
-  if (typeof npmPrefix === "string" && npmPrefix.length > 0) {
-    dirs.push(join(npmPrefix, "bin"));
+  // Trim before length-checking so accidental whitespace-only values
+  // (`NPM_CONFIG_PREFIX=" "`) do not produce a `/bin`-suffixed garbage
+  // entry.
+  const npmPrefixRaw = env.NPM_CONFIG_PREFIX ?? env.npm_config_prefix;
+  if (typeof npmPrefixRaw === "string") {
+    const npmPrefix = npmPrefixRaw.trim();
+    if (npmPrefix.length > 0) {
+      dirs.push(join(npmPrefix, "bin"));
+    }
   }
   if (includeSystemBins) {
     dirs.push("/opt/homebrew/bin", "/usr/local/bin");

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -444,23 +444,19 @@ export function wellKnownUserToolchainBins(
   const home = options.home ?? homedir();
   const includeSystemBins = options.includeSystemBins ?? process.platform !== "win32";
   const env = options.env ?? process.env;
-  const dirs: string[] = [
-    join(home, ".local", "bin"),
-    join(home, ".opencode", "bin"),
-    join(home, ".bun", "bin"),
-    join(home, ".volta", "bin"),
-    join(home, ".asdf", "shims"),
-    join(home, "Library", "pnpm"),
-    join(home, ".cargo", "bin"),
-  ];
-  // Honour an explicit npm prefix override before the conventional
-  // guesses below: `$NPM_CONFIG_PREFIX` / `$npm_config_prefix` is the
-  // user's *current* npm configuration, so a binary installed via
-  // `npm i -g` today lives at `<prefix>/bin`. The conventional guesses
-  // (`~/.npm-global`, `~/.npm-packages`) often hold *stale* installs
-  // from an older prefix the user has since rewritten — searching the
-  // env-driven prefix first gives "explicit beats convention" semantics
-  // and matches npm's own resolution order (env > .npmrc > default).
+  const dirs: string[] = [];
+  // The user's *explicit* npm prefix outranks every conventional
+  // location below — including `~/.local/bin`. The env var is the
+  // user's current npm configuration, so a binary installed via
+  // `npm i -g` today lives at `<prefix>/bin`. Conventional locations
+  // (`~/.local/bin`, `~/.npm-global`, `~/.npm-packages`) routinely
+  // hold *stale* installs from an older prefix the user has since
+  // rewritten, and `~/.local/bin` in particular is also a shared
+  // dumping ground for pip --user / cargo install / hand-built
+  // binaries that may collide with old npm artefacts. Putting the
+  // env-driven prefix first matches npm's own resolution order
+  // (env > .npmrc > default) and gives "explicit beats convention"
+  // semantics across the whole list, not just the npm-prefix block.
   // Trim before length-checking so accidental whitespace-only values
   // (`NPM_CONFIG_PREFIX=" "`) do not produce a `/bin`-suffixed garbage
   // entry.
@@ -471,14 +467,21 @@ export function wellKnownUserToolchainBins(
       dirs.push(join(npmPrefix, "bin"));
     }
   }
-  // Common user-level npm prefixes for sudo-free global installs. The
-  // npm docs canonical example uses ~/.local (already covered above);
-  // ~/.npm-global is the dominant non-canonical convention shipped in
-  // most third-party "fix npm EACCES" tutorials, and ~/.npm-packages
-  // is the second-most common variant. Without these, GUI-launched
-  // daemons miss `npm i -g`'d CLIs even though they resolve cleanly
-  // from the user's shell. See open-design issue #442.
   dirs.push(
+    join(home, ".local", "bin"),
+    join(home, ".opencode", "bin"),
+    join(home, ".bun", "bin"),
+    join(home, ".volta", "bin"),
+    join(home, ".asdf", "shims"),
+    join(home, "Library", "pnpm"),
+    join(home, ".cargo", "bin"),
+    // Common user-level npm prefixes for sudo-free global installs.
+    // ~/.npm-global is the dominant non-canonical convention shipped
+    // in most third-party "fix npm EACCES" tutorials, and
+    // ~/.npm-packages is the second-most common variant. Without
+    // these, GUI-launched daemons miss `npm i -g`'d CLIs even though
+    // they resolve cleanly from the user's shell. See open-design
+    // issue #442.
     join(home, ".npm-global", "bin"),
     join(home, ".npm-packages", "bin"),
   );

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -1,5 +1,8 @@
 import { execFile, spawn, type ChildProcess, type StdioOptions } from "node:child_process";
+import { existsSync, readdirSync } from "node:fs";
 import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 
 export type CommandInvocation = {
@@ -408,4 +411,103 @@ export async function readLogTail(filePath: string, maxLines = 80): Promise<stri
   } catch {
     return [];
   }
+}
+
+export type WellKnownUserToolchainOptions = {
+  // Override homedir() so callers in sandboxed tests or namespaced launches
+  // can substitute a fixture directory. Falls back to os.homedir().
+  home?: string;
+  // Include /opt/homebrew/bin and /usr/local/bin in the result. Defaults to
+  // true on POSIX so GUI-launched processes (which inherit a minimal PATH
+  // from launchd / desktop launchers) still see Homebrew-installed CLIs;
+  // defaults to false on Windows because those paths are POSIX-only.
+  includeSystemBins?: boolean;
+  // Read $NPM_CONFIG_PREFIX / $npm_config_prefix from this map and append
+  // `<prefix>/bin` if defined. Defaults to process.env so user-customised
+  // npm prefixes are picked up automatically. Pass an empty object to
+  // suppress lookup (useful in tests).
+  env?: NodeJS.ProcessEnv;
+};
+
+// Single source of truth for "user-level CLI install locations the daemon
+// must search even when launched with a minimal PATH". GUI launchers
+// (macOS .app bundles, Linux .desktop files) typically inherit a stripped
+// PATH from launchd / the desktop session and do not read interactive
+// shell rc files, so without this list any CLI installed under the user's
+// own toolchain (`npm i -g`, `pnpm self-install`, `cargo install`, asdf,
+// nvm, fnm, mise, ...) is silently undetected. Both the daemon resolver
+// and the packaged sidecar PATH builder consume this so the two layers
+// can never drift again.
+export function wellKnownUserToolchainBins(
+  options: WellKnownUserToolchainOptions = {},
+): string[] {
+  const home = options.home ?? homedir();
+  const includeSystemBins = options.includeSystemBins ?? process.platform !== "win32";
+  const env = options.env ?? process.env;
+  const dirs: string[] = [
+    join(home, ".local", "bin"),
+    join(home, ".opencode", "bin"),
+    join(home, ".bun", "bin"),
+    join(home, ".volta", "bin"),
+    join(home, ".asdf", "shims"),
+    join(home, "Library", "pnpm"),
+    join(home, ".cargo", "bin"),
+    // Common user-level npm prefixes for sudo-free global installs. The
+    // npm docs canonical example uses ~/.local (already covered above);
+    // ~/.npm-global is the dominant non-canonical convention shipped in
+    // most third-party "fix npm EACCES" tutorials, and ~/.npm-packages
+    // is the second-most common variant. Without these, GUI-launched
+    // daemons miss `npm i -g`'d CLIs even though they resolve cleanly
+    // from the user's shell. See open-design issue #442.
+    join(home, ".npm-global", "bin"),
+    join(home, ".npm-packages", "bin"),
+  ];
+  // Honour an explicit npm prefix override regardless of where the user
+  // pointed it. Covers setups that don't match either of the conventions
+  // above (e.g. corporate provisioning that exports a custom prefix).
+  const npmPrefix = env.NPM_CONFIG_PREFIX ?? env.npm_config_prefix;
+  if (typeof npmPrefix === "string" && npmPrefix.length > 0) {
+    dirs.push(join(npmPrefix, "bin"));
+  }
+  if (includeSystemBins) {
+    dirs.push("/opt/homebrew/bin", "/usr/local/bin");
+  }
+  // Per-version Node toolchains: scan the install root and surface every
+  // version directory's bin folder. Best-effort — missing roots simply
+  // contribute nothing.
+  for (const installRoot of [
+    {
+      root: join(home, ".local", "share", "mise", "installs", "node"),
+      segments: ["bin"],
+    },
+    {
+      root: join(home, ".nvm", "versions", "node"),
+      segments: ["bin"],
+    },
+    {
+      root: join(home, ".local", "share", "fnm", "node-versions"),
+      segments: ["installation", "bin"],
+    },
+  ]) {
+    for (const dir of existingChildBinDirs(installRoot.root, installRoot.segments)) {
+      dirs.push(dir);
+    }
+  }
+  return dirs;
+}
+
+function existingChildBinDirs(root: string, segments: string[]): string[] {
+  const out: string[] = [];
+  let entries: import("node:fs").Dirent<string>[];
+  try {
+    entries = readdirSync(root, { encoding: "utf8", withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const candidate = join(root, entry.name, ...segments);
+    if (existsSync(candidate)) out.push(candidate);
+  }
+  return out;
 }

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -452,19 +452,15 @@ export function wellKnownUserToolchainBins(
     join(home, ".asdf", "shims"),
     join(home, "Library", "pnpm"),
     join(home, ".cargo", "bin"),
-    // Common user-level npm prefixes for sudo-free global installs. The
-    // npm docs canonical example uses ~/.local (already covered above);
-    // ~/.npm-global is the dominant non-canonical convention shipped in
-    // most third-party "fix npm EACCES" tutorials, and ~/.npm-packages
-    // is the second-most common variant. Without these, GUI-launched
-    // daemons miss `npm i -g`'d CLIs even though they resolve cleanly
-    // from the user's shell. See open-design issue #442.
-    join(home, ".npm-global", "bin"),
-    join(home, ".npm-packages", "bin"),
   ];
-  // Honour an explicit npm prefix override regardless of where the user
-  // pointed it. Covers setups that don't match either of the conventions
-  // above (e.g. corporate provisioning that exports a custom prefix).
+  // Honour an explicit npm prefix override before the conventional
+  // guesses below: `$NPM_CONFIG_PREFIX` / `$npm_config_prefix` is the
+  // user's *current* npm configuration, so a binary installed via
+  // `npm i -g` today lives at `<prefix>/bin`. The conventional guesses
+  // (`~/.npm-global`, `~/.npm-packages`) often hold *stale* installs
+  // from an older prefix the user has since rewritten — searching the
+  // env-driven prefix first gives "explicit beats convention" semantics
+  // and matches npm's own resolution order (env > .npmrc > default).
   // Trim before length-checking so accidental whitespace-only values
   // (`NPM_CONFIG_PREFIX=" "`) do not produce a `/bin`-suffixed garbage
   // entry.
@@ -475,6 +471,17 @@ export function wellKnownUserToolchainBins(
       dirs.push(join(npmPrefix, "bin"));
     }
   }
+  // Common user-level npm prefixes for sudo-free global installs. The
+  // npm docs canonical example uses ~/.local (already covered above);
+  // ~/.npm-global is the dominant non-canonical convention shipped in
+  // most third-party "fix npm EACCES" tutorials, and ~/.npm-packages
+  // is the second-most common variant. Without these, GUI-launched
+  // daemons miss `npm i -g`'d CLIs even though they resolve cleanly
+  // from the user's shell. See open-design issue #442.
+  dirs.push(
+    join(home, ".npm-global", "bin"),
+    join(home, ".npm-packages", "bin"),
+  );
   if (includeSystemBins) {
     dirs.push("/opt/homebrew/bin", "/usr/local/bin");
   }

--- a/packages/platform/tests/index.test.ts
+++ b/packages/platform/tests/index.test.ts
@@ -383,6 +383,35 @@ describe("wellKnownUserToolchainBins", () => {
     }
   });
 
+  // PR #614 review (mrcfps): npm's own resolution order is env > .npmrc
+  // > default, so when the user has explicitly configured a prefix via
+  // $NPM_CONFIG_PREFIX, that location holds the *current* `npm i -g`
+  // installs and should outrank the conventional guesses. Conventional
+  // ~/.npm-global / ~/.npm-packages frequently retain *stale* binaries
+  // from an older prefix.
+  it("places $NPM_CONFIG_PREFIX/bin before the conventional ~/.npm-global and ~/.npm-packages guesses", () => {
+    const home = mkdtempSync(join(tmpdir(), "wkutb-prefix-order-"));
+    const customPrefix = mkdtempSync(join(tmpdir(), "wkutb-custom-order-"));
+    try {
+      const dirs = wellKnownUserToolchainBins({
+        home,
+        env: { NPM_CONFIG_PREFIX: customPrefix },
+        includeSystemBins: false,
+      });
+      const explicitIdx = dirs.indexOf(join(customPrefix, "bin"));
+      const npmGlobalIdx = dirs.indexOf(join(home, ".npm-global", "bin"));
+      const npmPackagesIdx = dirs.indexOf(join(home, ".npm-packages", "bin"));
+      expect(explicitIdx).toBeGreaterThanOrEqual(0);
+      expect(npmGlobalIdx).toBeGreaterThanOrEqual(0);
+      expect(npmPackagesIdx).toBeGreaterThanOrEqual(0);
+      expect(explicitIdx).toBeLessThan(npmGlobalIdx);
+      expect(explicitIdx).toBeLessThan(npmPackagesIdx);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(customPrefix, { recursive: true, force: true });
+    }
+  });
+
   it("ignores whitespace-only npm prefix values rather than emitting a `/bin` entry", () => {
     const home = mkdtempSync(join(tmpdir(), "wkutb-whitespace-prefix-"));
     try {

--- a/packages/platform/tests/index.test.ts
+++ b/packages/platform/tests/index.test.ts
@@ -386,10 +386,11 @@ describe("wellKnownUserToolchainBins", () => {
   // PR #614 review (mrcfps): npm's own resolution order is env > .npmrc
   // > default, so when the user has explicitly configured a prefix via
   // $NPM_CONFIG_PREFIX, that location holds the *current* `npm i -g`
-  // installs and should outrank the conventional guesses. Conventional
-  // ~/.npm-global / ~/.npm-packages frequently retain *stale* binaries
-  // from an older prefix.
-  it("places $NPM_CONFIG_PREFIX/bin before the conventional ~/.npm-global and ~/.npm-packages guesses", () => {
+  // installs and should outrank every conventional location below —
+  // including ~/.local/bin (which is also a shared pip --user / cargo
+  // install dumping ground). Conventional locations frequently retain
+  // *stale* binaries from an older prefix.
+  it("places $NPM_CONFIG_PREFIX/bin before every conventional location, including ~/.local/bin", () => {
     const home = mkdtempSync(join(tmpdir(), "wkutb-prefix-order-"));
     const customPrefix = mkdtempSync(join(tmpdir(), "wkutb-custom-order-"));
     try {
@@ -399,13 +400,16 @@ describe("wellKnownUserToolchainBins", () => {
         includeSystemBins: false,
       });
       const explicitIdx = dirs.indexOf(join(customPrefix, "bin"));
+      const localBinIdx = dirs.indexOf(join(home, ".local", "bin"));
       const npmGlobalIdx = dirs.indexOf(join(home, ".npm-global", "bin"));
       const npmPackagesIdx = dirs.indexOf(join(home, ".npm-packages", "bin"));
-      expect(explicitIdx).toBeGreaterThanOrEqual(0);
-      expect(npmGlobalIdx).toBeGreaterThanOrEqual(0);
-      expect(npmPackagesIdx).toBeGreaterThanOrEqual(0);
-      expect(explicitIdx).toBeLessThan(npmGlobalIdx);
-      expect(explicitIdx).toBeLessThan(npmPackagesIdx);
+      // Explicit prefix must be present and ahead of every conventional
+      // sibling. The first hit wins inside resolveOnPath() and the
+      // packaged PATH builder, so this ordering propagates verbatim.
+      expect(explicitIdx).toBe(0);
+      expect(localBinIdx).toBeGreaterThan(explicitIdx);
+      expect(npmGlobalIdx).toBeGreaterThan(explicitIdx);
+      expect(npmPackagesIdx).toBeGreaterThan(explicitIdx);
     } finally {
       rmSync(home, { recursive: true, force: true });
       rmSync(customPrefix, { recursive: true, force: true });

--- a/packages/platform/tests/index.test.ts
+++ b/packages/platform/tests/index.test.ts
@@ -1,3 +1,7 @@
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
@@ -6,6 +10,7 @@ import {
   createProcessStampArgs,
   matchesStampedProcess,
   readProcessStampFromCommand,
+  wellKnownUserToolchainBins,
   type ProcessStampContract,
 } from "../src/index.js";
 
@@ -296,5 +301,146 @@ describe("createPackageManagerInvocation", () => {
       "/c",
       '"pnpm --filter @open-design/desktop build"',
     ]);
+  });
+});
+
+describe("wellKnownUserToolchainBins", () => {
+  // Filesystem-backed cases use a sandboxed home so we don't depend on the
+  // real machine's toolchain layout. PATHEXT-style Windows quirks aren't
+  // relevant here — the helper returns directories, not resolved binaries.
+  it("returns the documented user-level CLI install locations under home", () => {
+    const home = mkdtempSync(join(tmpdir(), "wkutb-home-"));
+    try {
+      const dirs = wellKnownUserToolchainBins({ home, env: {}, includeSystemBins: false });
+      expect(dirs).toContain(join(home, ".local", "bin"));
+      expect(dirs).toContain(join(home, ".opencode", "bin"));
+      expect(dirs).toContain(join(home, ".bun", "bin"));
+      expect(dirs).toContain(join(home, ".volta", "bin"));
+      expect(dirs).toContain(join(home, ".asdf", "shims"));
+      expect(dirs).toContain(join(home, "Library", "pnpm"));
+      expect(dirs).toContain(join(home, ".cargo", "bin"));
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  // Regression for #442. The two dominant non-canonical npm prefixes used
+  // by sudo-free tutorials (~/.npm-global, ~/.npm-packages) must always
+  // appear, otherwise GUI-launched daemons miss `npm i -g`'d CLIs.
+  it("includes both ~/.npm-global/bin and ~/.npm-packages/bin (issue #442)", () => {
+    const home = mkdtempSync(join(tmpdir(), "wkutb-npm-"));
+    try {
+      const dirs = wellKnownUserToolchainBins({ home, env: {}, includeSystemBins: false });
+      expect(dirs).toContain(join(home, ".npm-global", "bin"));
+      expect(dirs).toContain(join(home, ".npm-packages", "bin"));
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("appends $NPM_CONFIG_PREFIX/bin when set so corporate prefixes resolve", () => {
+    const home = mkdtempSync(join(tmpdir(), "wkutb-prefix-"));
+    const customPrefix = mkdtempSync(join(tmpdir(), "wkutb-custom-"));
+    try {
+      const dirs = wellKnownUserToolchainBins({
+        home,
+        env: { NPM_CONFIG_PREFIX: customPrefix },
+        includeSystemBins: false,
+      });
+      expect(dirs).toContain(join(customPrefix, "bin"));
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(customPrefix, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to lower-case npm_config_prefix when NPM_CONFIG_PREFIX is absent", () => {
+    const home = mkdtempSync(join(tmpdir(), "wkutb-prefix-lc-"));
+    const customPrefix = mkdtempSync(join(tmpdir(), "wkutb-custom-lc-"));
+    try {
+      const dirs = wellKnownUserToolchainBins({
+        home,
+        env: { npm_config_prefix: customPrefix },
+        includeSystemBins: false,
+      });
+      expect(dirs).toContain(join(customPrefix, "bin"));
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(customPrefix, { recursive: true, force: true });
+    }
+  });
+
+  it("does not append a prefix entry when neither env var is set", () => {
+    const home = mkdtempSync(join(tmpdir(), "wkutb-noprefix-"));
+    try {
+      const dirs = wellKnownUserToolchainBins({ home, env: {}, includeSystemBins: false });
+      // The bare `/bin` suffix would be ambiguous, but we can at least
+      // confirm nothing equal to "/bin" leaked in from a `join(undefined,
+      // "bin")`-style bug.
+      expect(dirs).not.toContain("/bin");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("includes /opt/homebrew/bin and /usr/local/bin when includeSystemBins is true", () => {
+    const home = mkdtempSync(join(tmpdir(), "wkutb-sys-"));
+    try {
+      const dirs = wellKnownUserToolchainBins({ home, env: {}, includeSystemBins: true });
+      expect(dirs).toContain("/opt/homebrew/bin");
+      expect(dirs).toContain("/usr/local/bin");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("omits /opt/homebrew/bin and /usr/local/bin when includeSystemBins is false", () => {
+    const home = mkdtempSync(join(tmpdir(), "wkutb-nosys-"));
+    try {
+      const dirs = wellKnownUserToolchainBins({ home, env: {}, includeSystemBins: false });
+      expect(dirs).not.toContain("/opt/homebrew/bin");
+      expect(dirs).not.toContain("/usr/local/bin");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("expands per-version Node toolchains for mise / nvm / fnm", () => {
+    const home = mkdtempSync(join(tmpdir(), "wkutb-versioned-"));
+    try {
+      const miseBin = join(home, ".local", "share", "mise", "installs", "node", "24.14.1", "bin");
+      const nvmBin = join(home, ".nvm", "versions", "node", "v22.10.0", "bin");
+      const fnmBin = join(home, ".local", "share", "fnm", "node-versions", "v20.11.1", "installation", "bin");
+      mkdirSync(miseBin, { recursive: true });
+      mkdirSync(nvmBin, { recursive: true });
+      mkdirSync(fnmBin, { recursive: true });
+      writeFileSync(join(miseBin, "marker"), "");
+      writeFileSync(join(nvmBin, "marker"), "");
+      writeFileSync(join(fnmBin, "marker"), "");
+      chmodSync(join(miseBin, "marker"), 0o644);
+      chmodSync(join(nvmBin, "marker"), 0o644);
+      chmodSync(join(fnmBin, "marker"), 0o644);
+
+      const dirs = wellKnownUserToolchainBins({ home, env: {}, includeSystemBins: false });
+      expect(dirs).toContain(miseBin);
+      expect(dirs).toContain(nvmBin);
+      expect(dirs).toContain(fnmBin);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("returns an empty version slice when toolchain root is absent", () => {
+    const home = mkdtempSync(join(tmpdir(), "wkutb-empty-"));
+    try {
+      const dirs = wellKnownUserToolchainBins({ home, env: {}, includeSystemBins: false });
+      // No mise/nvm/fnm directories were created — none of the per-version
+      // bins should appear.
+      expect(dirs.some((dir) => dir.includes(join(".nvm", "versions", "node")))).toBe(false);
+      expect(dirs.some((dir) => dir.includes(join("fnm", "node-versions")))).toBe(false);
+      expect(dirs.some((dir) => dir.includes(join("mise", "installs", "node")))).toBe(false);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/platform/tests/index.test.ts
+++ b/packages/platform/tests/index.test.ts
@@ -383,6 +383,25 @@ describe("wellKnownUserToolchainBins", () => {
     }
   });
 
+  it("ignores whitespace-only npm prefix values rather than emitting a `/bin` entry", () => {
+    const home = mkdtempSync(join(tmpdir(), "wkutb-whitespace-prefix-"));
+    try {
+      const dirs = wellKnownUserToolchainBins({
+        home,
+        env: { NPM_CONFIG_PREFIX: "   " },
+        includeSystemBins: false,
+      });
+      // Whitespace-only must not produce a bogus `<whitespace>/bin` entry
+      // nor a bare `/bin` (the join("   ", "bin") shape).
+      for (const dir of dirs) {
+        expect(dir.trim()).not.toBe("/bin");
+        expect(dir).not.toMatch(/^\s+\/bin$/);
+      }
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   it("includes /opt/homebrew/bin and /usr/local/bin when includeSystemBins is true", () => {
     const home = mkdtempSync(join(tmpdir(), "wkutb-sys-"));
     try {


### PR DESCRIPTION
## Summary

Fixes #442. GUI-launched daemons (Finder/Dock on macOS, `.desktop` on Linux) inherit a stripped PATH from launchd / the desktop session and don't read interactive shell rc files, so any CLI installed via `npm i -g <cli>` under a sudo-free prefix like `~/.npm-global` was silently undetected. Surface fix is "add `~/.npm-global/bin` to the search list", but the search list lives in *two* places that have already drifted, so the fix needs to share a single source of truth.

## Root cause (verified end-to-end against current `main`)

Two independent copies of the user-toolchain bin list:

- `apps/daemon/src/agents.ts` `userToolchainDirs()` — drives `resolveOnPath` → `detectAgents`
- `apps/packaged/src/sidecars.ts` `resolvePackagedPathEnv()` — rebuilds the daemon child's `PATH` in packaged mode

Both lists are missing `~/.npm-global/bin`. They had also already drifted: `~/.asdf/shims` and `~/Library/pnpm` exist in the daemon copy but not in the packaged copy, so asdf and `pnpm self-install`-ed CLIs are silently undetected in packaged builds today even though `pnpm tools-dev` sees them.

Reproduction script (against `main`, before this PR):

```js
process.env.PATH = '/usr/bin:/bin:/usr/sbin:/sbin'; // launchd default
process.env.OD_AGENT_HOME = FAKE_HOME; // ~/.npm-global/bin/gemini exists
const { resolveAgentExecutable } = await import('apps/daemon/dist/agents.js');
console.log(resolveAgentExecutable({ bin: 'gemini' })); // → null
```

`launchctl getenv PATH` returns empty on a stock macOS, confirming GUI launches do not inherit shell PATH.

## Solution

Extract `wellKnownUserToolchainBins(options)` into `@open-design/platform` as the single source of truth. Both layers consume it. The list now also covers:

- `~/.npm-global/bin` and `~/.npm-packages/bin` — the two dominant non-canonical npm prefixes shipped in third-party "fix npm EACCES without sudo" tutorials
- `$NPM_CONFIG_PREFIX/bin` and `$npm_config_prefix/bin` — npm's own config env var, so corporate/CI provisioning that exports a custom prefix resolves automatically

Adopting a shared helper also drags the `~/.asdf/shims` and `~/Library/pnpm` entries into the packaged path, fixing the pre-existing silent drift for free.

## Files

- `packages/platform/src/index.ts` — adds `wellKnownUserToolchainBins({ home, includeSystemBins, env })`
- `packages/platform/tests/index.test.ts` — 9 new vitest cases covering the documented dirs, both npm-prefix conventions, env-var override (uppercase + lowercase), `includeSystemBins` flag, and per-version mise/nvm/fnm expansion
- `apps/daemon/src/agents.ts` — `userToolchainDirs()` is now a thin caching wrapper that calls the platform helper; `OD_AGENT_HOME` test hook preserved
- `apps/daemon/tests/agents.test.ts` — adds two regression cases under the existing minimal-PATH harness: `~/.npm-global/bin/gemini` and `~/.npm-packages/bin/gemini` resolve when `PATH=/usr/bin:/bin`
- `apps/packaged/src/sidecars.ts` — `resolvePackagedPathEnv()` now consumes the shared helper and only keeps the POSIX system bins (`/usr/bin`, `/bin`, `/usr/sbin`, `/sbin`) at this layer
- `packages/AGENTS.md` — records that the platform helper is the shared source of truth so the two layers can never drift again

No new dependencies. Both apps already depend on `@open-design/platform`.

## Validation

```bash
$ pnpm --filter @open-design/platform test
 Test Files  1 passed (1)
      Tests  23 passed (23)

$ pnpm --filter @open-design/daemon exec vitest run tests/agents.test.ts
 Test Files  1 passed (1)
      Tests  64 passed (64)

$ pnpm typecheck
- 0 errors

$ pnpm guard
Residual JavaScript check passed: project-owned code is TypeScript-only.
Test layout check passed: apps/packages/tools tests live in sibling tests directories.

$ pnpm --filter @open-design/platform build
$ pnpm --filter @open-design/daemon build
$ pnpm --filter @open-design/packaged build
# all succeeded
```

End-to-end reproduction script run against the patched `dist`:

```json
{
  "fakeHome": "/var/folders/.../verify-442-JDdByP",
  "fakeGeminiExists": true,
  "pathUsed": "/usr/bin:/bin:/usr/sbin:/sbin",
  "resolved": "/var/folders/.../.npm-global/bin/gemini",
  "bug_present": false,
  "fix_works": true
}
```

Some unrelated tests (project-status, project-watchers, web build) fail on this machine due to local `better-sqlite3` / `turbopack` / `rollup` native-binary signing issues that exist on `main` before any of these changes. CI will run on a clean Linux runner.

## Test plan

- [x] `pnpm --filter @open-design/platform test` — green
- [x] `pnpm --filter @open-design/daemon exec vitest run tests/agents.test.ts` — green
- [x] `pnpm typecheck` — clean
- [x] `pnpm guard` — clean
- [x] `pnpm --filter @open-design/{platform,daemon,packaged} build` — all succeed
- [x] End-to-end repro: `resolveAgentExecutable({ bin: 'gemini' })` resolves under launchd-default PATH when binary lives in `~/.npm-global/bin`
- [ ] CI on Linux runner
- [ ] Optional manual sanity check on a packaged macOS build (out of scope here, but the same shared helper now drives that path)

Closes #442.
