### PR TITLE
Fix/error message persistence

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -31,6 +31,7 @@ import {
 import { playSound, showCompletionNotification } from '../utils/notifications';
 import { DEFAULT_NOTIFICATIONS } from '../state/config';
 import type { TodoItem } from '../runtime/todos';
+import { appendErrorStatusEvent } from '../runtime/chat-events';
 import { isLiveArtifactTabId, liveArtifactTabId } from '../types';
 import {
   createConversation,
@@ -569,6 +570,18 @@ export function ProjectView({
     [project.id, activeConversationId],
   );
 
+  const appendAssistantErrorEvent = useCallback(
+    (messageId: string, message: string) => {
+      if (!message) return;
+      updateMessageById(
+        messageId,
+        (prev) => appendErrorStatusEvent(prev, message),
+        true,
+      );
+    },
+    [updateMessageById],
+  );
+
   const refreshPreviewComments = useCallback(async () => {
     if (!activeConversationId) return;
     const next = await fetchPreviewComments(project.id, activeConversationId);
@@ -763,6 +776,7 @@ export function ProjectView({
               textBuffer.cancel();
               unregisterTextBuffer();
               setError(err.message);
+              appendAssistantErrorEvent(message.id, err.message);
               updateMessageById(
                 message.id,
                 (prev) => ({ ...prev, runStatus: 'failed', endedAt: prev.endedAt ?? Date.now() }),
@@ -808,7 +822,14 @@ export function ProjectView({
         })
           .catch((err) => {
             if ((err as Error).name !== 'AbortError') {
-              setError(err instanceof Error ? err.message : String(err));
+              const msg = err instanceof Error ? err.message : String(err);
+              setError(msg);
+              appendAssistantErrorEvent(message.id, msg);
+              updateMessageById(
+                message.id,
+                (prev) => ({ ...prev, runStatus: 'failed', endedAt: prev.endedAt ?? Date.now() }),
+                true,
+              );
             }
           })
           .finally(() => {
@@ -1091,6 +1112,7 @@ export function ProjectView({
           textBuffer.cancel();
           cancelSendTextBuffer();
           setError(err.message);
+          appendAssistantErrorEvent(assistantId, err.message);
           updateAssistant((prev) => ({
             ...prev,
             endedAt: Date.now(),

--- a/apps/web/src/runtime/chat-events.ts
+++ b/apps/web/src/runtime/chat-events.ts
@@ -7,6 +7,9 @@ export function appendErrorStatusEvent(message: ChatMessage, detail: string): Ch
   if (last?.kind === 'status' && last.label === 'error' && last.detail === detail) {
     return message;
   }
+  if (!detail?.trim()) {
+    return message;
+  }
   return {
     ...message,
     events: [...events, { kind: 'status', label: 'error', detail }],

--- a/apps/web/src/runtime/chat-events.ts
+++ b/apps/web/src/runtime/chat-events.ts
@@ -1,0 +1,15 @@
+import type { ChatMessage } from '../types';
+
+export function appendErrorStatusEvent(message: ChatMessage, detail: string): ChatMessage {
+  if (!detail) return message;
+  const events = message.events ?? [];
+  const last = events[events.length - 1];
+  if (last?.kind === 'status' && last.label === 'error' && last.detail === detail) {
+    return message;
+  }
+  return {
+    ...message,
+    events: [...events, { kind: 'status', label: 'error', detail }],
+  };
+}
+

--- a/e2e/tests/project-view-error-persistence.test.tsx
+++ b/e2e/tests/project-view-error-persistence.test.tsx
@@ -1,0 +1,165 @@
+import { cleanup, render, waitFor } from '@testing-library/react';
+import React, { act } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+let lastChatPaneProps: any | null = null;
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('../../apps/web/src/i18n', () => ({
+  useT: () => ((key: string) => key) as any,
+}));
+
+vi.mock('../../apps/web/src/components/ChatPane', async () => {
+  const mod = await vi.importActual<any>('../../apps/web/src/components/ChatPane');
+  return {
+    ...mod,
+    ChatPane: (props: any) => {
+      lastChatPaneProps = props;
+      return null;
+    },
+  };
+});
+
+vi.mock('../../apps/web/src/components/AppChromeHeader', () => ({
+  AppChromeHeader: () => null,
+}));
+
+vi.mock('../../apps/web/src/components/AvatarMenu', () => ({
+  AvatarMenu: () => null,
+}));
+
+vi.mock('../../apps/web/src/components/FileWorkspace', () => ({
+  FileWorkspace: () => null,
+}));
+
+vi.mock('../../apps/web/src/router', () => ({
+  navigate: () => {},
+}));
+
+vi.mock('../../apps/web/src/utils/notifications', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../apps/web/src/utils/notifications')>();
+  return {
+    ...actual,
+    playSound: () => {},
+    showCompletionNotification: async () => {},
+  };
+});
+
+vi.mock('../../apps/web/src/providers/registry', () => ({
+  fetchPreviewComments: async () => [],
+  fetchDesignSystem: async () => null,
+  fetchLiveArtifacts: async () => [],
+  fetchProjectFiles: async () => [],
+  fetchSkill: async () => null,
+  patchPreviewCommentStatus: async () => true,
+  upsertPreviewComment: async () => null,
+  deletePreviewComment: async () => true,
+  writeProjectTextFile: async () => null,
+}));
+
+vi.mock('../../apps/web/src/providers/project-events', () => ({
+  useProjectFileEvents: () => ({ events: [] }),
+}));
+
+vi.mock('../../apps/web/src/state/projects', () => ({
+  listConversations: async () => [{ id: 'conv-1', title: 'Conversation', createdAt: 0 }],
+  createConversation: async () => ({ id: 'conv-1', title: 'Conversation', createdAt: 0 }),
+  listMessages: async () => [],
+  loadTabs: async () => ({ tabs: [], active: null }),
+  saveTabs: async () => {},
+  saveMessage: async () => {},
+  patchConversation: async () => null,
+  deleteConversation: async () => true,
+  patchProject: async () => null,
+  getTemplate: async () => null,
+}));
+
+vi.mock('../../apps/web/src/providers/daemon', () => ({
+  fetchChatRunStatus: async () => null,
+  listActiveChatRuns: async () => [],
+  reattachDaemonRun: async () => {},
+  streamViaDaemon: async ({ handlers, onRunCreated, onRunStatus }: any) => {
+    onRunCreated?.('run-1');
+    onRunStatus?.('running');
+    handlers.onError(new Error('connection refused'));
+  },
+}));
+
+async function loadProjectView() {
+  const { ProjectView } = await import('../../apps/web/src/components/ProjectView');
+  return ProjectView;
+}
+
+function baseProject() {
+  return {
+    id: 'proj-1',
+    name: 'Project',
+    createdAt: 0,
+    updatedAt: 0,
+    skillId: null,
+    designSystemId: null,
+    metadata: {} as any,
+  };
+}
+
+describe('ProjectView daemon error persistence', () => {
+  afterEach(() => cleanup());
+
+  it('stores daemon failure details on the assistant message events', async () => {
+    lastChatPaneProps = null;
+    const ProjectView = await loadProjectView();
+
+    render(
+      <ProjectView
+        project={baseProject()}
+        routeFileName={null}
+        config={
+          {
+            mode: 'daemon',
+            agentId: 'claude',
+            skillId: null,
+            designSystemId: null,
+            disabledSkills: [],
+            disabledDesignSystems: [],
+          } as any
+        }
+        agents={[{ id: 'claude', name: 'Claude', detected: true, version: '1.0.0', models: [] }] as any}
+        skills={[]}
+        designSystems={[]}
+        daemonLive
+        onModeChange={() => {}}
+        onAgentChange={() => {}}
+        onAgentModelChange={() => {}}
+        onRefreshAgents={() => {}}
+        onOpenSettings={() => {}}
+        onBack={() => {}}
+        onClearPendingPrompt={() => {}}
+        onTouchProject={() => {}}
+        onProjectChange={() => {}}
+        onProjectsRefresh={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(lastChatPaneProps).not.toBeNull();
+      expect(lastChatPaneProps!.messages).toHaveLength(0);
+    });
+
+    await act(async () => {
+      await lastChatPaneProps!.onSend('hi', []);
+    });
+
+    await waitFor(() => {
+      const assistant = (lastChatPaneProps!.messages as any[]).find((m: any) => m.role === 'assistant');
+      expect(assistant).toBeTruthy();
+      const events = assistant!.events ?? [];
+      expect(
+        events.some(
+          (e: any) => e.kind === 'status' && e.label === 'error' && e.detail === 'connection refused',
+        ),
+      ).toBe(true);
+    });
+  });
+});

--- a/e2e/tests/project-view-error-persistence.test.tsx
+++ b/e2e/tests/project-view-error-persistence.test.tsx
@@ -3,6 +3,7 @@ import React, { act } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 let lastChatPaneProps: any | null = null;
+const saveMessageSpy = vi.fn(async () => {});
 
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -69,7 +70,7 @@ vi.mock('../../apps/web/src/state/projects', () => ({
   listMessages: async () => [],
   loadTabs: async () => ({ tabs: [], active: null }),
   saveTabs: async () => {},
-  saveMessage: async () => {},
+  saveMessage: saveMessageSpy,
   patchConversation: async () => null,
   deleteConversation: async () => true,
   patchProject: async () => null,
@@ -105,7 +106,10 @@ function baseProject() {
 }
 
 describe('ProjectView daemon error persistence', () => {
-  afterEach(() => cleanup());
+  afterEach(() => {
+    cleanup();
+    saveMessageSpy.mockClear();
+  });
 
   it('stores daemon failure details on the assistant message events', async () => {
     lastChatPaneProps = null;
@@ -144,7 +148,7 @@ describe('ProjectView daemon error persistence', () => {
 
     await waitFor(() => {
       expect(lastChatPaneProps).not.toBeNull();
-      expect(lastChatPaneProps!.messages).toHaveLength(0);
+      expect(lastChatPaneProps!.activeConversationId).toBe('conv-1');
     });
 
     await act(async () => {
@@ -158,6 +162,144 @@ describe('ProjectView daemon error persistence', () => {
       expect(
         events.some(
           (e: any) => e.kind === 'status' && e.label === 'error' && e.detail === 'connection refused',
+        ),
+      ).toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(saveMessageSpy).toHaveBeenCalled();
+    });
+  });
+
+  it('keeps prior error details after switching agents and sending again', async () => {
+    lastChatPaneProps = null;
+    const ProjectView = await loadProjectView();
+
+    const view = render(
+      <ProjectView
+        project={baseProject()}
+        routeFileName={null}
+        config={
+          {
+            mode: 'daemon',
+            agentId: 'claude',
+            skillId: null,
+            designSystemId: null,
+            disabledSkills: [],
+            disabledDesignSystems: [],
+          } as any
+        }
+        agents={
+          [
+            { id: 'claude', name: 'Claude', detected: true, version: '1.0.0', models: [] },
+            { id: 'opencode', name: 'OpenCode', detected: true, version: '1.0.0', models: [] },
+          ] as any
+        }
+        skills={[]}
+        designSystems={[]}
+        daemonLive
+        onModeChange={() => {}}
+        onAgentChange={() => {}}
+        onAgentModelChange={() => {}}
+        onRefreshAgents={() => {}}
+        onOpenSettings={() => {}}
+        onBack={() => {}}
+        onClearPendingPrompt={() => {}}
+        onTouchProject={() => {}}
+        onProjectChange={() => {}}
+        onProjectsRefresh={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(lastChatPaneProps).not.toBeNull();
+      expect(lastChatPaneProps!.activeConversationId).toBe('conv-1');
+    });
+
+    await act(async () => {
+      await lastChatPaneProps!.onSend('first', []);
+    });
+
+    let firstAssistantId = '';
+    await waitFor(() => {
+      const assistants = (lastChatPaneProps!.messages as any[]).filter(
+        (m: any) => m.role === 'assistant',
+      );
+      expect(assistants.length).toBe(1);
+      const first = assistants[0]!;
+      firstAssistantId = first.id;
+      const events = first.events ?? [];
+      expect(
+        events.some(
+          (e: any) =>
+            e.kind === 'status' && e.label === 'error' && e.detail === 'connection refused',
+        ),
+      ).toBe(true);
+    });
+
+    // Switch agent (simulates picking a different CLI), then send again.
+    view.rerender(
+      <ProjectView
+        project={baseProject()}
+        routeFileName={null}
+        config={
+          {
+            mode: 'daemon',
+            agentId: 'opencode',
+            skillId: null,
+            designSystemId: null,
+            disabledSkills: [],
+            disabledDesignSystems: [],
+          } as any
+        }
+        agents={
+          [
+            { id: 'claude', name: 'Claude', detected: true, version: '1.0.0', models: [] },
+            { id: 'opencode', name: 'OpenCode', detected: true, version: '1.0.0', models: [] },
+          ] as any
+        }
+        skills={[]}
+        designSystems={[]}
+        daemonLive
+        onModeChange={() => {}}
+        onAgentChange={() => {}}
+        onAgentModelChange={() => {}}
+        onRefreshAgents={() => {}}
+        onOpenSettings={() => {}}
+        onBack={() => {}}
+        onClearPendingPrompt={() => {}}
+        onTouchProject={() => {}}
+        onProjectChange={() => {}}
+        onProjectsRefresh={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(lastChatPaneProps!.activeConversationId).toBe('conv-1');
+    });
+
+    await act(async () => {
+      await lastChatPaneProps!.onSend('second', []);
+    });
+
+    await waitFor(() => {
+      const messages = lastChatPaneProps!.messages as any[];
+      const firstAssistant = messages.find((m: any) => m.id === firstAssistantId);
+      expect(firstAssistant).toBeTruthy();
+      expect(
+        (firstAssistant!.events ?? []).some(
+          (e: any) =>
+            e.kind === 'status' && e.label === 'error' && e.detail === 'connection refused',
+        ),
+      ).toBe(true);
+
+      const assistants = messages.filter((m: any) => m.role === 'assistant');
+      expect(assistants.length).toBe(2);
+      const secondAssistant = assistants[1]!;
+      expect(
+        (secondAssistant.events ?? []).some(
+          (e: any) =>
+            e.kind === 'status' && e.label === 'error' && e.detail === 'connection refused',
         ),
       ).toBe(true);
     });


### PR DESCRIPTION
Close #165

## Root Cause
Daemon/API failures were only surfaced via ephemeral chat error state, so switching agents could hide the prior run’s details

## Fix

The fix appends a durable status event with the error text onto the assistant ChatMessage (and uses a small `appendErrorStatusEvent` helper). I also added e2e test to cover this issue