### PR TITLE
fix(daemon): add required env field to McpServerStdio + recover from -32602 on set_model

### DIFF
--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -314,15 +314,17 @@ export function attachAcpSession({
       // After response completion, any late-arriving errors from the agent
       // (pipe-broken, cleanup race conditions, etc.) are safe to ignore.
       if (finished) return;
-      // JSON-RPC -32603 "Internal error" handling:
-      // Unexpected-id -32603 errors are cleanup noise — suppress them.
+      // JSON-RPC -32603 "Internal error" and -32602 "Invalid params" handling:
+      // Unexpected-id errors are cleanup noise — suppress them.
       // Expected-id -32603 errors for session/set_model fall through to the
       // recovery block below. All other expected-id -32603 errors (initialize,
       // session/new, session/prompt) are real failures — call fail().
-      if (raw.error?.code === -32603 && raw.id !== expectedId) {
+      // Expected-id -32602 errors for session/set_model are treated as "method
+      // not supported / params rejected" and also fall through to recovery.
+      if ((raw.error?.code === -32603 || raw.error?.code === -32602) && raw.id !== expectedId) {
         return;
       }
-      if (raw.error?.code === -32603 && raw.id === expectedId) {
+      if ((raw.error?.code === -32603 || raw.error?.code === -32602) && raw.id === expectedId) {
         if (raw.id === setModelRequestId) {
           // Fall through — the recovery block will handle this
         } else {
@@ -368,12 +370,12 @@ export function attachAcpSession({
       }
       return;
     }
-    // Recovery: if session/set_model failed with -32603, fall back to
+    // Recovery: if session/set_model failed with -32603 or -32602, fall back to
     // sending the prompt with the default (already-active) model.
     // This is scoped to the exact set_model request id to avoid
     // triggering on prompt or other request failures.
     if (
-      raw.error?.code === -32603 &&
+      (raw.error?.code === -32603 || raw.error?.code === -32602) &&
       raw.id === setModelRequestId &&
       promptRequestId === null
     ) {

--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -314,26 +314,32 @@ export function attachAcpSession({
       // After response completion, any late-arriving errors from the agent
       // (pipe-broken, cleanup race conditions, etc.) are safe to ignore.
       if (finished) return;
-      // JSON-RPC -32603 "Internal error" and -32602 "Invalid params" handling:
-      // Unexpected-id errors are cleanup noise — suppress them.
-      // Expected-id -32603 errors for session/set_model fall through to the
-      // recovery block below. All other expected-id -32603 errors (initialize,
-      // session/new, session/prompt) are real failures — call fail().
-      // Expected-id -32602 errors for session/set_model are treated as "method
-      // not supported / params rejected" and also fall through to recovery.
-      if ((raw.error?.code === -32603 || raw.error?.code === -32602) && raw.id !== expectedId) {
+      // JSON-RPC error handling:
+      // -32603 "Internal error": unexpected-id errors are cleanup noise — suppress.
+      //   Expected-id errors for session/set_model fall through to the recovery
+      //   block. All others (initialize, session/new, session/prompt) are real
+      //   failures — call fail().
+      // -32602 "Invalid params": these are real validation failures. Only
+      //   suppress when they match setModelRequestId so the recovery block handles
+      //   them. Any other -32602 (unexpected-id or non-set_model expected-id) is
+      //   a genuine protocol error — call fail().
+      if (raw.error?.code === -32603 && raw.id !== expectedId) {
         return;
       }
-      if ((raw.error?.code === -32603 || raw.error?.code === -32602) && raw.id === expectedId) {
+      if (raw.error?.code === -32602 && raw.id !== setModelRequestId) {
+        fail(rpcErr);
+        return;
+      }
+      if (raw.error?.code === -32603 && raw.id === expectedId) {
         if (raw.id === setModelRequestId) {
           // Fall through — the recovery block will handle this
         } else {
           fail(rpcErr);
           return;
         }
-      } else {
-        fail(rpcErr);
-        return;
+      }
+      if (raw.error?.code === -32602 && raw.id === setModelRequestId) {
+        // Fall through — the recovery block will handle this
       }
     }
     if (raw.method === 'session/request_permission') {
@@ -372,6 +378,8 @@ export function attachAcpSession({
     }
     // Recovery: if session/set_model failed with -32603 or -32602, fall back to
     // sending the prompt with the default (already-active) model.
+    // -32603: agent doesn't support set_model at all (internal error).
+    // -32602: agent rejects the model ID or set_model params (invalid params).
     // This is scoped to the exact set_model request id to avoid
     // triggering on prompt or other request failures.
     if (

--- a/apps/daemon/src/agents.ts
+++ b/apps/daemon/src/agents.ts
@@ -940,6 +940,7 @@ export function buildLiveArtifactsMcpServersForAgent(def, { enabled = true, comm
       name: 'open-design-live-artifacts',
       command,
       args: [...argsPrefix, 'mcp', 'live-artifacts'],
+      env: [],
     },
   ];
 }

--- a/apps/daemon/tests/agents.test.ts
+++ b/apps/daemon/tests/agents.test.ts
@@ -175,6 +175,7 @@ test('live artifact MCP discovery is limited to mature ACP agents', () => {
       name: 'open-design-live-artifacts',
       command: 'od',
       args: ['mcp', 'live-artifacts'],
+      env: [],
     },
   ]);
   assert.deepEqual(buildLiveArtifactsMcpServersForAgent(kimi), [
@@ -182,6 +183,7 @@ test('live artifact MCP discovery is limited to mature ACP agents', () => {
       name: 'open-design-live-artifacts',
       command: 'od',
       args: ['mcp', 'live-artifacts'],
+      env: [],
     },
   ]);
 
@@ -206,6 +208,7 @@ test('live artifact MCP discovery can use daemon-resolved CLI command', () => {
         name: 'open-design-live-artifacts',
         command: process.execPath,
         args: ['/workspace/apps/daemon/dist/cli.js', 'mcp', 'live-artifacts'],
+        env: [],
       },
     ],
   );


### PR DESCRIPTION
## Bug Fix

### 1. McpServerStdio `env` field missing (root cause of `-32602 Invalid params`)

`buildLiveArtifactsMcpServersForAgent()` generates MCP server descriptors without the `env` field. The ACP schema (`McpServerStdio`) marks `env` as `List[EnvVariable]` with **no default value** — it is required.

When the daemon sends `session/new` with a non-empty `mcpServers` array, Pydantic V2 Union-discriminated validation tries `HttpMcpServer`, `SseMcpServer`, and `McpServerStdio` in order. All three fail because:

- `HttpMcpServer` → missing `url`, `headers`, `type`
- `SseMcpServer` → missing `url`, `headers`, `type`  
- `McpServerStdio` → missing `env`

This cascades into a 7-error validation failure returned as `-32602 Invalid params`, which terminates the ACP session before it reaches `session/set_model` or `session/prompt`.

**This bug is invisible when `mcpServers` resolves to an empty array** (no live-artifacts token), so it only manifests when `mcpDiscovery: 'mature-acp'` agents (Hermes, Devin, Kimi) receive a non-empty MCP server list.

**Fix**: Add `env: []` to the descriptor object.

### 2. ACP recovery for `-32602 Invalid params` on `session/set_model`

Extends the existing `-32603 Internal error` recovery logic to also handle `-32602` when `session/set_model` fails. This allows the prompt to proceed with the default model instead of hanging or timing out, making the daemon more resilient when an ACP agent rejects the model ID.

## Testing

- Confirmed via direct ACP communication test (`hermes acp --accept-hooks`) that `initialize` → `session/new` → `session/set_model` all succeed when `env: []` is present
- Confirmed via Pydantic validation that omitting `env` produces 7 validation errors (reproducing the exact `-32602` reported in the wild)
- Full end-to-end test: Open Design → Hermes chat completed successfully after the fix