### PR TITLE
feat(media): add Nano Banana image provider

### DIFF
--- a/apps/daemon/src/media-config.ts
+++ b/apps/daemon/src/media-config.ts
@@ -60,6 +60,7 @@ const ENV_KEYS = {
   // upstream env per docs.x.ai quickstart — so users who already export
   // it for the official SDK don't have to re-paste into Settings.
   grok: ['OD_GROK_API_KEY', 'XAI_API_KEY'],
+  nanobanana: ['OD_NANOBANANA_API_KEY', 'GOOGLE_API_KEY', 'GEMINI_API_KEY'],
   bfl: ['OD_BFL_API_KEY', 'BFL_API_KEY'],
   fal: ['OD_FAL_KEY', 'FAL_KEY'],
   replicate: ['OD_REPLICATE_API_TOKEN', 'REPLICATE_API_TOKEN'],
@@ -228,6 +229,9 @@ export async function resolveProviderConfig(projectRoot, providerId) {
   return {
     apiKey: envKey || entry.apiKey || oauth?.apiKey || '',
     baseUrl: entry.baseUrl || '',
+    ...(typeof entry.model === 'string' && entry.model.trim()
+      ? { model: entry.model.trim() }
+      : {}),
   };
 }
 
@@ -255,6 +259,9 @@ export async function readMaskedConfig(projectRoot) {
       // the DOM.
       apiKeyTail: hasStoredKey ? entry.apiKey.slice(-4) : '',
       baseUrl: entry.baseUrl || '',
+      ...(typeof entry.model === 'string' && entry.model.trim()
+        ? { model: entry.model.trim() }
+        : {}),
     };
   }
   return { providers };
@@ -287,8 +294,16 @@ export async function writeConfig(projectRoot, body) {
       typeof entry.baseUrl === 'string' && entry.baseUrl.trim()
         ? entry.baseUrl.trim()
         : '';
-    if (!apiKey && !baseUrl) continue;
-    next[id] = { apiKey, baseUrl };
+    const model =
+      typeof entry.model === 'string' && entry.model.trim()
+        ? entry.model.trim()
+        : '';
+    if (!apiKey && !baseUrl && !model) continue;
+    next[id] = {
+      apiKey,
+      baseUrl,
+      ...(model ? { model } : {}),
+    };
   }
   if (Object.keys(next).length === 0) {
     const prior = await readStored(projectRoot);

--- a/apps/daemon/src/media-models.ts
+++ b/apps/daemon/src/media-models.ts
@@ -13,6 +13,7 @@ export const MEDIA_PROVIDERS = [
   { id: 'volcengine', label: 'Volcengine Ark (Doubao)', hint: 'Seedance 2.0 / Seedream', integrated: true, defaultBaseUrl: 'https://ark.cn-beijing.volces.com/api/v3' },
   { id: 'grok', label: 'xAI Grok Imagine', hint: 'grok-imagine — image + video with native audio', integrated: true, defaultBaseUrl: 'https://api.x.ai/v1' },
   { id: 'hyperframes', label: 'HyperFrames', hint: 'Local HTML -> MP4 renderer', integrated: true, credentialsRequired: false, settingsVisible: false },
+  { id: 'nanobanana', label: 'Nano Banana', hint: 'Google official by default; custom gateway configurable', integrated: true, defaultBaseUrl: 'https://generativelanguage.googleapis.com' },
   { id: 'bfl', label: 'Black Forest Labs', hint: 'FLUX 1.1 Pro / FLUX Pro / Dev', integrated: false, defaultBaseUrl: 'https://api.bfl.ai' },
   { id: 'fal', label: 'Fal.ai', hint: 'Sora / Seedance / Veo / FLUX', integrated: false, defaultBaseUrl: 'https://fal.run' },
   { id: 'replicate', label: 'Replicate', hint: 'FLUX / SDXL / Ideogram', integrated: false, defaultBaseUrl: 'https://api.replicate.com/v1' },
@@ -39,6 +40,8 @@ export const IMAGE_MODELS = [
   { id: 'doubao-seededit-3-0-i2i-250628', label: 'seededit-3.0', hint: 'ByteDance · image edit', provider: 'volcengine', caps: ['i2i'] },
 
   { id: 'grok-imagine-image', label: 'grok-imagine-image', hint: 'xAI · 2K text-to-image', provider: 'grok', caps: ['t2i'] },
+
+  { id: 'gemini-3.1-flash-image-preview', label: 'nano-banana-2', hint: 'Nano Banana · text-to-image', provider: 'nanobanana', caps: ['t2i'] },
 
   { id: 'flux-1.1-pro', label: 'flux-1.1-pro', hint: 'BFL · flagship', provider: 'bfl', caps: ['t2i', 'i2i'] },
   { id: 'flux-pro', label: 'flux-pro', hint: 'BFL', provider: 'bfl', caps: ['t2i'] },

--- a/apps/daemon/src/media-models.ts
+++ b/apps/daemon/src/media-models.ts
@@ -13,7 +13,7 @@ export const MEDIA_PROVIDERS = [
   { id: 'volcengine', label: 'Volcengine Ark (Doubao)', hint: 'Seedance 2.0 / Seedream', integrated: true, defaultBaseUrl: 'https://ark.cn-beijing.volces.com/api/v3' },
   { id: 'grok', label: 'xAI Grok Imagine', hint: 'grok-imagine — image + video with native audio', integrated: true, defaultBaseUrl: 'https://api.x.ai/v1' },
   { id: 'hyperframes', label: 'HyperFrames', hint: 'Local HTML -> MP4 renderer', integrated: true, credentialsRequired: false, settingsVisible: false },
-  { id: 'nanobanana', label: 'Nano Banana', hint: 'Google official by default; custom gateway configurable', integrated: true, defaultBaseUrl: 'https://generativelanguage.googleapis.com' },
+  { id: 'nanobanana', label: 'Nano Banana', hint: 'Google official by default; custom gateway configurable', integrated: true, defaultBaseUrl: 'https://generativelanguage.googleapis.com', supportsCustomModel: true },
   { id: 'bfl', label: 'Black Forest Labs', hint: 'FLUX 1.1 Pro / FLUX Pro / Dev', integrated: false, defaultBaseUrl: 'https://api.bfl.ai' },
   { id: 'fal', label: 'Fal.ai', hint: 'Sora / Seedance / Veo / FLUX', integrated: false, defaultBaseUrl: 'https://fal.run' },
   { id: 'replicate', label: 'Replicate', hint: 'FLUX / SDXL / Ideogram', integrated: false, defaultBaseUrl: 'https://api.replicate.com/v1' },

--- a/apps/daemon/src/media.ts
+++ b/apps/daemon/src/media.ts
@@ -59,6 +59,8 @@ import {
 
 const execFile = promisify(execFileCb);
 const NANOBANANA_DEFAULT_BASE_URL = 'https://generativelanguage.googleapis.com';
+// Verify the current Nano Banana / Gemini image model name against:
+// https://ai.google.dev/gemini-api/docs/models
 const NANOBANANA_DEFAULT_MODEL = 'gemini-3.1-flash-image-preview';
 const NANOBANANA_DEFAULT_IMAGE_SIZE = '1K';
 

--- a/apps/daemon/src/media.ts
+++ b/apps/daemon/src/media.ts
@@ -58,6 +58,9 @@ import {
 } from './projects.js';
 
 const execFile = promisify(execFileCb);
+const NANOBANANA_DEFAULT_BASE_URL = 'https://generativelanguage.googleapis.com';
+const NANOBANANA_DEFAULT_MODEL = 'gemini-3.1-flash-image-preview';
+const NANOBANANA_DEFAULT_IMAGE_SIZE = '1K';
 
 const DEFAULT_OUTPUT_BY_SURFACE = {
   image: 'image.png',
@@ -361,6 +364,11 @@ export async function generateMedia(args) {
       suggestedExt = result.suggestedExt;
     } else if (def.provider === 'grok' && surface === 'video') {
       const result = await renderGrokVideo(ctx, credentials, args.onProgress);
+      bytes = result.bytes;
+      providerNote = result.providerNote;
+      suggestedExt = result.suggestedExt;
+    } else if (def.provider === 'nanobanana' && surface === 'image') {
+      const result = await renderNanoBananaImage(ctx, credentials);
       bytes = result.bytes;
       providerNote = result.providerNote;
       suggestedExt = result.suggestedExt;
@@ -1034,6 +1042,83 @@ async function renderGrokImage(ctx, credentials) {
     providerNote: `grok/${ctx.model} · ${aspectRatio} · ${bytes.length} bytes`,
     suggestedExt: sniffImageExt(bytes),
   };
+}
+
+async function renderNanoBananaImage(ctx, credentials) {
+  if (!credentials.apiKey) {
+    throw new Error(
+      'no Nano Banana API key — configure it in Settings or set OD_NANOBANANA_API_KEY',
+    );
+  }
+
+  const baseUrl = (credentials.baseUrl || NANOBANANA_DEFAULT_BASE_URL).replace(/\/$/, '');
+  const wireModel = (credentials.model || ctx.model || NANOBANANA_DEFAULT_MODEL).trim();
+  const body = {
+    contents: [{
+      parts: [{
+        text: ctx.prompt || 'A high-quality reference image.',
+      }],
+    }],
+    generationConfig: {
+      responseModalities: ['IMAGE'],
+      imageConfig: {
+        aspectRatio: nanoBananaAspectFor(ctx.aspect),
+        imageSize: NANOBANANA_DEFAULT_IMAGE_SIZE,
+      },
+    },
+  };
+
+  const resp = await fetch(`${baseUrl}/v1beta/models/${encodeURIComponent(wireModel)}:generateContent`, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${credentials.apiKey}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  const text = await resp.text();
+  if (!resp.ok) {
+    throw new Error(`nano-banana image ${resp.status}: ${truncate(text, 240)}`);
+  }
+  let data;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    throw new Error(`nano-banana image non-JSON: ${truncate(text, 200)}`);
+  }
+  const bytes = inlineImageBytesFromGenerateContent(data);
+  return {
+    bytes,
+    providerNote: `nano-banana/${wireModel} · ${nanoBananaAspectFor(ctx.aspect)} · ${NANOBANANA_DEFAULT_IMAGE_SIZE} · ${bytes.length} bytes`,
+    suggestedExt: sniffImageExt(bytes),
+  };
+}
+
+function nanoBananaAspectFor(aspect) {
+  if (
+    aspect === '1:1'
+    || aspect === '16:9'
+    || aspect === '9:16'
+    || aspect === '4:3'
+    || aspect === '3:4'
+  ) {
+    return aspect;
+  }
+  return '1:1';
+}
+
+function inlineImageBytesFromGenerateContent(data) {
+  const candidates = Array.isArray(data?.candidates) ? data.candidates : [];
+  for (const candidate of candidates) {
+    const parts = Array.isArray(candidate?.content?.parts) ? candidate.content.parts : [];
+    for (const part of parts) {
+      const inline = part?.inlineData;
+      if (typeof inline?.data === 'string' && inline.data) {
+        return Buffer.from(inline.data, 'base64');
+      }
+    }
+  }
+  throw new Error('nano-banana image response missing candidates[].content.parts[].inlineData.data');
 }
 
 function sniffImageExt(bytes) {

--- a/apps/daemon/src/media.ts
+++ b/apps/daemon/src/media.ts
@@ -1070,10 +1070,7 @@ async function renderNanoBananaImage(ctx, credentials) {
 
   const resp = await fetch(`${baseUrl}/v1beta/models/${encodeURIComponent(wireModel)}:generateContent`, {
     method: 'POST',
-    headers: {
-      authorization: `Bearer ${credentials.apiKey}`,
-      'content-type': 'application/json',
-    },
+    headers: nanoBananaHeaders(baseUrl, credentials.apiKey),
     body: JSON.stringify(body),
   });
   const text = await resp.text();
@@ -1092,6 +1089,27 @@ async function renderNanoBananaImage(ctx, credentials) {
     providerNote: `nano-banana/${wireModel} · ${nanoBananaAspectFor(ctx.aspect)} · ${NANOBANANA_DEFAULT_IMAGE_SIZE} · ${bytes.length} bytes`,
     suggestedExt: sniffImageExt(bytes),
   };
+}
+
+function nanoBananaHeaders(baseUrl, apiKey) {
+  const headers = {
+    'content-type': 'application/json',
+  };
+  if (usesOfficialGoogleApiKeyHeader(baseUrl)) {
+    headers['x-goog-api-key'] = apiKey;
+    return headers;
+  }
+  headers.authorization = `Bearer ${apiKey}`;
+  return headers;
+}
+
+function usesOfficialGoogleApiKeyHeader(baseUrl) {
+  try {
+    const url = new URL(baseUrl);
+    return url.hostname === 'generativelanguage.googleapis.com';
+  } catch {
+    return false;
+  }
 }
 
 function nanoBananaAspectFor(aspect) {

--- a/apps/daemon/tests/media-config.test.ts
+++ b/apps/daemon/tests/media-config.test.ts
@@ -9,6 +9,8 @@ import {
   writeConfig,
 } from '../src/media-config.js';
 
+const TEST_NANOBANANA_BASE_URL = 'https://nano-banana-gateway.example.test';
+
 const OPENAI_ENV_KEYS = [
   'OD_OPENAI_API_KEY',
   'OPENAI_API_KEY',
@@ -146,6 +148,38 @@ describe('media-config OpenAI OAuth fallback', () => {
       apiKeyTail: '-key',
       baseUrl: 'https://example.test/v1',
     });
+  });
+
+  it('resolves Nano Banana env and stored model overrides', async () => {
+    process.env.OD_NANOBANANA_API_KEY = 'env-nano-key';
+    await writeStoredMediaConfig({
+      providers: {
+        nanobanana: {
+          apiKey: 'stored-nano-key',
+          baseUrl: TEST_NANOBANANA_BASE_URL,
+          model: 'gemini-3.1-flash-image-preview-custom',
+        },
+      },
+    });
+
+    const resolved = await resolveProviderConfig(projectRoot, 'nanobanana');
+    const masked = await readMaskedConfig(projectRoot);
+    const provider = (masked.providers as Record<string, unknown>).nanobanana;
+
+    expect(resolved).toEqual({
+      apiKey: 'env-nano-key',
+      baseUrl: TEST_NANOBANANA_BASE_URL,
+      model: 'gemini-3.1-flash-image-preview-custom',
+    });
+    expect(provider).toMatchObject({
+      configured: true,
+      source: 'env',
+      apiKeyTail: '-key',
+      baseUrl: TEST_NANOBANANA_BASE_URL,
+      model: 'gemini-3.1-flash-image-preview-custom',
+    });
+
+    delete process.env.OD_NANOBANANA_API_KEY;
   });
 
   describe('OD_MEDIA_CONFIG_DIR / OD_DATA_DIR storage routing', () => {

--- a/apps/daemon/tests/media-nanobanana.test.ts
+++ b/apps/daemon/tests/media-nanobanana.test.ts
@@ -1,0 +1,143 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { generateMedia } from '../src/media.js';
+
+const PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2uoAAAAASUVORK5CYII=';
+const TEST_NANOBANANA_BASE_URL = 'https://nano-banana-gateway.example.test';
+
+describe('nano-banana media generation', () => {
+  let root: string;
+  let projectRoot: string;
+  let projectsRoot: string;
+  const realFetch = globalThis.fetch;
+  const originalMediaConfigDir = process.env.OD_MEDIA_CONFIG_DIR;
+  const originalDataDir = process.env.OD_DATA_DIR;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'od-nanobanana-'));
+    projectRoot = path.join(root, 'project-root');
+    projectsRoot = path.join(projectRoot, '.od', 'projects');
+    await mkdir(projectsRoot, { recursive: true });
+    delete process.env.OD_MEDIA_CONFIG_DIR;
+    delete process.env.OD_DATA_DIR;
+    process.env.OD_NANOBANANA_API_KEY = 'nano-test-key';
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = realFetch;
+    delete process.env.OD_NANOBANANA_API_KEY;
+    if (originalMediaConfigDir == null) {
+      delete process.env.OD_MEDIA_CONFIG_DIR;
+    } else {
+      process.env.OD_MEDIA_CONFIG_DIR = originalMediaConfigDir;
+    }
+    if (originalDataDir == null) {
+      delete process.env.OD_DATA_DIR;
+    } else {
+      process.env.OD_DATA_DIR = originalDataDir;
+    }
+    await rm(root, { recursive: true, force: true });
+  });
+
+  async function writeConfig(data: unknown) {
+    const file = path.join(projectRoot, '.od', 'media-config.json');
+    await mkdir(path.dirname(file), { recursive: true });
+    await writeFile(file, JSON.stringify(data), 'utf8');
+  }
+
+  it('renders Nano Banana images through generateContent', async () => {
+    await writeConfig({
+      providers: {
+        nanobanana: {
+          baseUrl: TEST_NANOBANANA_BASE_URL,
+          model: 'custom-nano-model',
+        },
+      },
+    });
+
+    const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
+      expect(String(input)).toBe(`${TEST_NANOBANANA_BASE_URL}/v1beta/models/custom-nano-model:generateContent`);
+      expect(init?.method).toBe('POST');
+      expect(init?.headers).toMatchObject({
+        authorization: 'Bearer nano-test-key',
+        'content-type': 'application/json',
+      });
+      expect(JSON.parse(String(init?.body))).toEqual({
+        contents: [{ parts: [{ text: 'A watercolor shiba inu under cherry blossoms' }] }],
+        generationConfig: {
+          responseModalities: ['IMAGE'],
+          imageConfig: {
+            aspectRatio: '16:9',
+            imageSize: '1K',
+          },
+        },
+      });
+      return new Response(JSON.stringify({
+        candidates: [{
+          content: {
+            parts: [{
+              inlineData: {
+                mimeType: 'image/png',
+                data: PNG_BASE64,
+              },
+            }],
+          },
+        }],
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'image',
+      model: 'gemini-3.1-flash-image-preview',
+      prompt: 'A watercolor shiba inu under cherry blossoms',
+      aspect: '16:9',
+      output: 'nano.png',
+    });
+
+    expect(result.name).toBe('nano.png');
+    expect(result.providerId).toBe('nanobanana');
+    expect(result.providerNote).toContain('nano-banana/custom-nano-model');
+    expect(result.providerNote).toContain('16:9');
+    expect(result.providerNote).toContain('1K');
+
+    const bytes = await readFile(path.join(projectsRoot, 'project-1', 'nano.png'));
+    expect(bytes.length).toBeGreaterThan(0);
+  });
+
+  it('surfaces upstream Nano Banana errors', async () => {
+    await writeConfig({
+      providers: {
+        nanobanana: {
+          baseUrl: TEST_NANOBANANA_BASE_URL,
+        },
+      },
+    });
+
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      error: { message: 'quota exceeded' },
+    }), {
+      status: 429,
+      headers: { 'content-type': 'application/json' },
+    })));
+
+    await expect(generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'image',
+      model: 'gemini-3.1-flash-image-preview',
+      prompt: 'A neon city skyline',
+      aspect: '1:1',
+    })).rejects.toThrow(/nano-banana image 429/);
+  });
+});

--- a/apps/daemon/tests/media-nanobanana.test.ts
+++ b/apps/daemon/tests/media-nanobanana.test.ts
@@ -65,6 +65,7 @@ describe('nano-banana media generation', () => {
         authorization: 'Bearer nano-test-key',
         'content-type': 'application/json',
       });
+      expect(init?.headers).not.toHaveProperty('x-goog-api-key');
       expect(JSON.parse(String(init?.body))).toEqual({
         contents: [{ parts: [{ text: 'A watercolor shiba inu under cherry blossoms' }] }],
         generationConfig: {
@@ -112,6 +113,47 @@ describe('nano-banana media generation', () => {
 
     const bytes = await readFile(path.join(projectsRoot, 'project-1', 'nano.png'));
     expect(bytes.length).toBeGreaterThan(0);
+  });
+
+  it('uses x-goog-api-key for the official Gemini endpoint', async () => {
+    const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
+      expect(String(input)).toBe('https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-image-preview:generateContent');
+      expect(init?.headers).toMatchObject({
+        'content-type': 'application/json',
+        'x-goog-api-key': 'nano-test-key',
+      });
+      expect(init?.headers).not.toHaveProperty('authorization');
+      return new Response(JSON.stringify({
+        candidates: [{
+          content: {
+            parts: [{
+              inlineData: {
+                mimeType: 'image/png',
+                data: PNG_BASE64,
+              },
+            }],
+          },
+        }],
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'image',
+      model: 'gemini-3.1-flash-image-preview',
+      prompt: 'A studio photo of a yellow banana on white seamless paper',
+      aspect: '1:1',
+      output: 'official.png',
+    });
+
+    expect(result.providerId).toBe('nanobanana');
+    expect(result.name).toBe('official.png');
   });
 
   it('surfaces upstream Nano Banana errors', async () => {

--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -1592,9 +1592,9 @@ function MediaProjectOptions(props:
   );
 }
 
-function supportedModels(surface: 'image' | 'video' | 'audio', models: MediaModel[]): MediaModel[] {
+export function supportedModels(surface: 'image' | 'video' | 'audio', models: MediaModel[]): MediaModel[] {
   const supportedProviders: Record<'image' | 'video' | 'audio', Set<string>> = {
-    image: new Set(['openai', 'volcengine', 'grok']),
+    image: new Set(['openai', 'volcengine', 'grok', 'nanobanana']),
     video: new Set(['volcengine', 'hyperframes', 'grok']),
     audio: new Set(['minimax', 'fishaudio']),
   };

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -1168,13 +1168,13 @@ function MediaProvidersSection({
     });
   const updateProvider = (
     provider: MediaProvider,
-    patch: { apiKey?: string; baseUrl?: string },
+    patch: { apiKey?: string; baseUrl?: string; model?: string },
   ) => {
     setCfg((curr) => {
-      const prev = curr.mediaProviders?.[provider.id] ?? { apiKey: '', baseUrl: '' };
+      const prev = curr.mediaProviders?.[provider.id] ?? { apiKey: '', baseUrl: '', model: '' };
       const next = { ...prev, ...patch };
       const map = { ...(curr.mediaProviders ?? {}) };
-      if (!next.apiKey.trim() && !next.baseUrl.trim()) {
+      if (!next.apiKey.trim() && !next.baseUrl.trim() && !next.model?.trim()) {
         delete map[provider.id];
       } else {
         map[provider.id] = next;
@@ -1193,9 +1193,11 @@ function MediaProvidersSection({
       </div>
       <div className="media-provider-list">
         {providers.map((provider) => {
-          const entry = cfg.mediaProviders?.[provider.id] ?? { apiKey: '', baseUrl: '' };
+          const entry = cfg.mediaProviders?.[provider.id] ?? { apiKey: '', baseUrl: '', model: '' };
           const configured = Boolean(entry.apiKey.trim() || entry.baseUrl.trim());
           const disabled = !provider.integrated;
+          const supportsCustomModel = provider.id === 'nanobanana';
+          const clearable = Boolean(entry.apiKey.trim() || entry.baseUrl.trim() || entry.model?.trim());
           return (
             <div key={provider.id} className={`media-provider-row${provider.integrated ? '' : ' pending'}`}>
               <div className="media-provider-head">
@@ -1230,11 +1232,20 @@ function MediaProvidersSection({
                   disabled={disabled}
                   onChange={(e) => updateProvider(provider, { baseUrl: e.target.value })}
                 />
+                {supportsCustomModel ? (
+                  <input
+                    value={entry.model ?? ''}
+                    placeholder="gemini-3.1-flash-image-preview"
+                    aria-label={`${provider.label} model`}
+                    disabled={disabled}
+                    onChange={(e) => updateProvider(provider, { model: e.target.value })}
+                  />
+                ) : null}
                 <button
                   type="button"
                   className="ghost"
-                  disabled={!configured}
-                  onClick={() => updateProvider(provider, { apiKey: '', baseUrl: '' })}
+                  disabled={!clearable}
+                  onClick={() => updateProvider(provider, { apiKey: '', baseUrl: '', model: '' })}
                 >
                   {t('settings.mediaProviderClear')}
                 </button>

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -1196,7 +1196,7 @@ function MediaProvidersSection({
           const entry = cfg.mediaProviders?.[provider.id] ?? { apiKey: '', baseUrl: '', model: '' };
           const configured = Boolean(entry.apiKey.trim() || entry.baseUrl.trim());
           const disabled = !provider.integrated;
-          const supportsCustomModel = provider.id === 'nanobanana';
+          const supportsCustomModel = provider.supportsCustomModel === true;
           const clearable = Boolean(entry.apiKey.trim() || entry.baseUrl.trim() || entry.model?.trim());
           return (
             <div key={provider.id} className={`media-provider-row${provider.integrated ? '' : ' pending'}`}>

--- a/apps/web/src/media/models.ts
+++ b/apps/web/src/media/models.ts
@@ -32,6 +32,7 @@ export type MediaProviderId =
   | 'volcengine'
   | 'grok'
   | 'hyperframes'
+  | 'nanobanana'
   | 'bfl'
   | 'fal'
   | 'replicate'
@@ -102,6 +103,14 @@ export const MEDIA_PROVIDERS: MediaProvider[] = [
     credentialsRequired: false,
     settingsVisible: false,
     docsUrl: 'https://hyperframes.heygen.com',
+  },
+  {
+    id: 'nanobanana',
+    label: 'Nano Banana',
+    hint: 'Google official by default; custom gateway configurable',
+    integrated: true,
+    defaultBaseUrl: 'https://generativelanguage.googleapis.com',
+    docsUrl: 'https://ai.google.dev/gemini-api/docs/api-key',
   },
   {
     id: 'bfl',
@@ -280,6 +289,15 @@ export const IMAGE_MODELS: MediaModel[] = [
     label: 'grok-imagine-image',
     hint: 'xAI · 2K text-to-image',
     provider: 'grok',
+    caps: ['t2i'],
+  },
+
+  // Nano Banana — Google-compatible generateContent image path.
+  {
+    id: 'gemini-3.1-flash-image-preview',
+    label: 'nano-banana-2',
+    hint: 'Nano Banana · text-to-image',
+    provider: 'nanobanana',
     caps: ['t2i'],
   },
 

--- a/apps/web/src/media/models.ts
+++ b/apps/web/src/media/models.ts
@@ -62,6 +62,8 @@ export interface MediaProvider {
   defaultBaseUrl?: string;
   /** Documentation URL for getting an API key. */
   docsUrl?: string;
+  /** Whether Settings should expose a custom model override field. */
+  supportsCustomModel?: boolean;
 }
 
 /**
@@ -111,6 +113,7 @@ export const MEDIA_PROVIDERS: MediaProvider[] = [
     integrated: true,
     defaultBaseUrl: 'https://generativelanguage.googleapis.com',
     docsUrl: 'https://ai.google.dev/gemini-api/docs/api-key',
+    supportsCustomModel: true,
   },
   {
     id: 'bfl',

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -126,6 +126,7 @@ export interface LiveArtifactPreviewRequest {
 export interface MediaProviderCredentials {
   apiKey: string;
   baseUrl: string;
+  model?: string;
 }
 
 export interface ApiProtocolConfig {

--- a/apps/web/tests/components/NewProjectPanel.test.ts
+++ b/apps/web/tests/components/NewProjectPanel.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+
+import { supportedModels } from '../../src/components/NewProjectPanel';
+import { IMAGE_MODELS } from '../../src/media/models';
+
+describe('NewProjectPanel image provider visibility', () => {
+  it('shows Nano Banana in supported image models', () => {
+    const models = supportedModels('image', IMAGE_MODELS);
+    expect(models.some((model) => model.provider === 'nanobanana')).toBe(true);
+    expect(models.some((model) => model.id === 'gemini-3.1-flash-image-preview')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated `nanobanana` media provider with Google-compatible `generateContent` image rendering, defaulting to the official Gemini endpoint while still allowing a custom gateway override
- expose Nano Banana provider settings and image-surface availability in the web UI, including an optional custom model override for the Nano Banana family
- add focused daemon and web coverage for config precedence, renderer behavior, and image picker visibility

## Scope
- this provider is for the Nano Banana image family only: Nano Banana, Nano Banana Pro, and Nano Banana 2
- the current implementation is limited to image generation (`text-to-image`) and does not add video, audio, or other non-image capabilities
- the default registered image model is `gemini-3.1-flash-image-preview`; other Nano Banana family variants can be selected through the provider's configurable model override

## Testing
- `node scripts/verify-media-models.mjs`
- `corepack pnpm guard`
- `corepack pnpm --filter @open-design/web test -- NewProjectPanel.test.ts`
- `corepack pnpm --filter @open-design/daemon test -- media-config.test.ts media-nanobanana.test.ts`
- `corepack pnpm --filter @open-design/web typecheck`
- `corepack pnpm --filter @open-design/daemon typecheck`
- `corepack pnpm --filter @open-design/web build`
- `corepack pnpm --filter @open-design/daemon build`
- private smoke test through the daemon Nano Banana renderer path against a compatible gateway

## Notes
- tracked tests were scrubbed of private gateway references before submission
- repo-wide package validation outside the touched surfaces still has a pre-existing `apps/packaged` typecheck issue unrelated to this change