### PR TITLE
security: harden daemon against prompt injection, credential leak, and supply chain risks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,15 +32,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288  # v5
         with:
           version: 10.33.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/landing-page-ci.yml
+++ b/.github/workflows/landing-page-ci.yml
@@ -36,15 +36,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288  # v5
         with:
           version: 10.33.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/landing-page-deploy.yml
+++ b/.github/workflows/landing-page-deploy.yml
@@ -29,15 +29,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288  # v5
         with:
           version: 10.33.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: 24
           cache: pnpm
@@ -86,7 +86,7 @@ jobs:
           NODE
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd  # v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub repository metrics
-        uses: lowlighter/metrics@latest
+        uses: lowlighter/metrics@65836723097537a54cd8eb90f61839426b4266b6  # v3.34
         with:
           # Output path; the action opens/updates a PR when this file changes.
           # Requires manual review to merge. If metrics unchanged, no PR is created.

--- a/.github/workflows/refresh-contributors-wall.yml
+++ b/.github/workflows/refresh-contributors-wall.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Refresh cache bust date
         run: |
@@ -38,7 +38,7 @@ jobs:
           perl -0pi -e "s/cache_bust=\d{4}-\d{2}-\d{2}/cache_bust=$DATE/g" README*.md
 
       - name: Create refresh pull request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8
         with:
           # Auth mirrors the metrics workflow: prefer a repository token that can
           # create pull requests, with GITHUB_TOKEN as a fallback for repos where

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -51,12 +51,12 @@ jobs:
       version_tag: ${{ steps.beta.outputs.version_tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: 24
 
@@ -73,17 +73,17 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288  # v5
         with:
           version: 10.33.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: 24
 
@@ -178,7 +178,7 @@ jobs:
           EOF
 
       - name: Upload mac release bundle
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: open-design-beta-mac-release-assets
           path: ${{ runner.temp }}/release-assets
@@ -192,17 +192,17 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288  # v5
         with:
           version: 10.33.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: 24
 
@@ -265,7 +265,7 @@ jobs:
           ) | Set-Content -Path (Join-Path $releaseDir "latest.yml")
 
       - name: Upload windows release bundle
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: open-design-beta-win-release-assets
           path: ${{ runner.temp }}/release-assets
@@ -279,17 +279,17 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288  # v5
         with:
           version: 10.33.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: 24
 
@@ -343,7 +343,7 @@ jobs:
           )
 
       - name: Upload linux release bundle
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: open-design-beta-linux-release-assets
           path: ${{ runner.temp }}/release-assets
@@ -373,27 +373,27 @@ jobs:
       ENABLE_LINUX: ${{ inputs.enable_linux }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Download mac release bundle
         if: ${{ inputs.enable_mac }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: open-design-beta-mac-release-assets
           path: ${{ runner.temp }}/release-assets/mac
 
       - name: Download windows release bundle
         if: ${{ inputs.enable_win }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: open-design-beta-win-release-assets
           path: ${{ runner.temp }}/release-assets/win
 
       - name: Download linux release bundle
         if: ${{ inputs.enable_linux }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: open-design-beta-linux-release-assets
           path: ${{ runner.temp }}/release-assets/linux

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -34,12 +34,12 @@ jobs:
       version_tag: ${{ steps.stable.outputs.version_tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: 24
 
@@ -53,17 +53,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288  # v5
         with:
           version: 10.33.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: 24
 
@@ -106,17 +106,17 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288  # v5
         with:
           version: 10.33.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: 24
 
@@ -207,7 +207,7 @@ jobs:
           EOF
 
       - name: Upload mac release bundle
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: open-design-stable-mac-release-assets
           path: ${{ runner.temp }}/release-assets
@@ -220,17 +220,17 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288  # v5
         with:
           version: 10.33.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: 24
 
@@ -289,7 +289,7 @@ jobs:
           ) | Set-Content -Path (Join-Path $releaseDir "latest.yml")
 
       - name: Upload windows release bundle
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: open-design-stable-win-release-assets
           path: ${{ runner.temp }}/release-assets
@@ -302,17 +302,17 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288  # v5
         with:
           version: 10.33.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: 24
 
@@ -360,7 +360,7 @@ jobs:
           )
 
       - name: Upload linux release bundle
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: open-design-stable-linux-release-assets
           path: ${{ runner.temp }}/release-assets
@@ -378,7 +378,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
@@ -395,19 +395,19 @@ jobs:
           fi
 
       - name: Download mac release bundle
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: open-design-stable-mac-release-assets
           path: ${{ runner.temp }}/release-assets/mac
 
       - name: Download windows release bundle
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: open-design-stable-win-release-assets
           path: ${{ runner.temp }}/release-assets/win
 
       - name: Download linux release bundle
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: open-design-stable-linux-release-assets
           path: ${{ runner.temp }}/release-assets/linux

--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -61,12 +61,12 @@ function formatUsage(usage) {
 
 function choosePermissionOutcome(options) {
   const list = Array.isArray(options) ? options : [];
-  const approveForSession = list.find((option) => option?.optionId === 'approve_for_session');
-  if (approveForSession) return 'approve_for_session';
-  const allowAlways = list.find((option) => option?.kind === 'allow_always');
-  if (allowAlways?.optionId) return allowAlways.optionId;
   const allowOnce = list.find((option) => option?.kind === 'allow_once');
   if (allowOnce?.optionId) return allowOnce.optionId;
+  const allowAlways = list.find((option) => option?.kind === 'allow_always');
+  if (allowAlways?.optionId) return allowAlways.optionId;
+  const approveForSession = list.find((option) => option?.optionId === 'approve_for_session');
+  if (approveForSession) return 'approve_for_session';
   return null;
 }
 
@@ -297,6 +297,11 @@ export function attachAcpSession({
       fail(`unhandled ACP permission request: ${JSON.stringify(raw)}`);
       return;
     }
+    send('agent', {
+      type: 'permission_request',
+      optionId,
+      options: raw.params?.options,
+    });
     resetStageTimer('session/request_permission');
     try {
       sendRpcResult(child.stdin, raw.id, {

--- a/apps/daemon/src/agents.ts
+++ b/apps/daemon/src/agents.ts
@@ -1182,18 +1182,46 @@ export function resolveAgentBin(id) {
 // object loses Node's case-insensitive accessor — `Anthropic_Api_Key`
 // would survive a literal `delete env.ANTHROPIC_API_KEY` and still reach
 // the child. Iterate keys and compare case-insensitively to close that.
+const SENSITIVE_ENV_PATTERNS = [
+  /^ANTHROPIC_API_KEY$/i,
+  /^OPENAI_API_KEY$/i,
+  /^AZURE_API_KEY$/i,
+  /^AZURE_OPENAI_API_KEY$/i,
+  /^GOOGLE_API_KEY$/i,
+  /^GEMINI_API_KEY$/i,
+  /^GH_TOKEN$/i,
+  /^GITHUB_TOKEN$/i,
+  /^GITLAB_TOKEN$/i,
+  /^AWS_SECRET_ACCESS_KEY$/i,
+  /^AWS_SESSION_TOKEN$/i,
+  /^AWS_ACCESS_KEY_ID$/i,
+  /^NPM_TOKEN$/i,
+  /^VERCEL_TOKEN$/i,
+  /^OD_[A-Z_]*_API_KEY$/i,
+  /^OD_[A-Z_]*_TOKEN$/i,
+];
+
 export function spawnEnvForAgent(agentId, baseEnv) {
   const env = { ...baseEnv };
-  if (agentId !== 'claude') return env;
-  const hasCustomBaseUrl = Object.keys(env).some(
-    (k) =>
-      k.toUpperCase() === 'ANTHROPIC_BASE_URL' &&
-      typeof env[k] === 'string' &&
-      env[k].trim() !== '',
-  );
-  if (hasCustomBaseUrl) return env;
+  // For Claude with a custom base URL, the user is routing to a non-Anthropic
+  // endpoint — preserve ANTHROPIC_API_KEY for authentication against it.
+  if (agentId === 'claude') {
+    const hasCustomBaseUrl = Object.keys(env).some(
+      (k) =>
+        k.toUpperCase() === 'ANTHROPIC_BASE_URL' &&
+        typeof env[k] === 'string' &&
+        env[k].trim() !== '',
+    );
+    if (hasCustomBaseUrl) {
+      for (const key of Object.keys(env)) {
+        if (key.toUpperCase() === 'ANTHROPIC_API_KEY') continue;
+        if (SENSITIVE_ENV_PATTERNS.some((re) => re.test(key))) delete env[key];
+      }
+      return env;
+    }
+  }
   for (const key of Object.keys(env)) {
-    if (key.toUpperCase() === 'ANTHROPIC_API_KEY') delete env[key];
+    if (SENSITIVE_ENV_PATTERNS.some((re) => re.test(key))) delete env[key];
   }
   return env;
 }

--- a/apps/daemon/src/claude-design-import.ts
+++ b/apps/daemon/src/claude-design-import.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { lstat, mkdir, readFile, unlink, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { inflateRawSync } from 'node:zlib';
 import { validateProjectPath } from './projects.js';
@@ -20,6 +20,10 @@ export async function importClaudeDesignZip(zipPath, projectDir) {
 
   for (const entry of entries) {
     if (entry.isDirectory) continue;
+    const unixType = (entry.externalFileAttributes >>> 16) & 0xF000;
+    if (unixType === 0xA000) {
+      throw new Error(`ZIP archive contains a symlink entry: ${entry.name}`);
+    }
     if (files.length >= MAX_FILES) throw new Error('zip contains too many files');
     const relPath = sanitizeZipPath(entry.name);
     if (entry.uncompressedSize > MAX_FILE_BYTES) {
@@ -40,10 +44,20 @@ export async function importClaudeDesignZip(zipPath, projectDir) {
   if (!entryFile) throw new Error('zip does not contain an HTML file');
 
   await mkdir(projectDir, { recursive: true });
+  const extractedPaths = [];
   for (const f of files) {
     const target = safeJoin(projectDir, f.path);
     await mkdir(path.dirname(target), { recursive: true });
     await writeFile(target, f.body);
+    extractedPaths.push(target);
+  }
+
+  for (const writtenPath of extractedPaths) {
+    const st = await lstat(writtenPath);
+    if (st.isSymbolicLink()) {
+      await unlink(writtenPath);
+      throw new Error(`Extracted path is a symlink: ${writtenPath}`);
+    }
   }
 
   return {
@@ -74,6 +88,7 @@ function readCentralDirectory(zip) {
     const nameLen = zip.readUInt16LE(offset + 28);
     const extraLen = zip.readUInt16LE(offset + 30);
     const commentLen = zip.readUInt16LE(offset + 32);
+    const externalFileAttributes = zip.readUInt32LE(offset + 38);
     const localOffset = zip.readUInt32LE(offset + 42);
     const name = zip.slice(offset + 46, offset + 46 + nameLen).toString('utf8');
     if ((flags & 1) !== 0) throw new Error('encrypted zip entries are not supported');
@@ -85,6 +100,7 @@ function readCentralDirectory(zip) {
       method,
       compressedSize,
       uncompressedSize,
+      externalFileAttributes,
       localOffset,
       isDirectory: name.endsWith('/'),
     });

--- a/apps/daemon/src/community-pets-sync.ts
+++ b/apps/daemon/src/community-pets-sync.ts
@@ -14,6 +14,7 @@ import { resolveCodexPetsRoot } from './codex-pets.js';
 
 const PETSHARE_BASE = 'https://ihzwckyzfcuktrljwpha.supabase.co/functions/v1/petshare';
 const HATCHERY_LIST = 'https://j20.nz/hatchery/api/pets.json';
+const MAX_SPRITESHEET_BYTES = 10 * 1024 * 1024; // 10 MiB
 
 export interface SyncOptions {
   // 'petshare' | 'hatchery' | 'all' — controls which catalogs we hit.
@@ -204,6 +205,9 @@ async function writePet(
   const bytes = await downloadBinary(task.spritesheetUrl);
   if (bytes.length < 16) {
     throw new Error(`${task.folder}: spritesheet too small (${bytes.length} bytes)`);
+  }
+  if (bytes.length > MAX_SPRITESHEET_BYTES) {
+    throw new Error(`${task.folder}: spritesheet too large (${bytes.length} bytes)`);
   }
   // Reject HTML error pages dressed as `.webp` so the UI doesn't end up
   // adopting a pet whose sprite is `<!doctype html>`.

--- a/apps/daemon/src/deploy.ts
+++ b/apps/daemon/src/deploy.ts
@@ -6,6 +6,8 @@ import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { readProjectFile, validateProjectPath } from './projects.js';
 
+const DEPLOY_HOOK_ALLOWED_HOSTS = new Set<string>([]);
+
 export const VERCEL_PROVIDER_ID = 'vercel-self';
 export const SAVED_TOKEN_MASK = 'saved-vercel-token';
 
@@ -92,7 +94,7 @@ export async function buildDeployFilePlan(projectsRoot, projectId, entryName, op
   const entryBase = path.posix.dirname(entryPath);
   const deployHtml = injectDeployHookScript(
     rewriteEntryHtmlReferences(html, entryBase),
-    options.hookScriptUrl ?? process.env.OD_DEPLOY_HOOK_SCRIPT_URL,
+    process.env.OD_DEPLOY_HOOK_SCRIPT_URL,
   );
   const files = new Map();
   files.set('index.html', {
@@ -570,6 +572,7 @@ export function normalizeDeployHookScriptUrl(raw) {
   try {
     const url = new URL(trimmed);
     if (url.protocol !== 'https:' && url.protocol !== 'http:') return '';
+    if (!DEPLOY_HOOK_ALLOWED_HOSTS.has(url.hostname)) return '';
     return url.toString();
   } catch {
     return '';

--- a/apps/daemon/src/design-systems.ts
+++ b/apps/daemon/src/design-systems.ts
@@ -7,6 +7,8 @@
 import { readdir, readFile, stat } from 'node:fs/promises';
 import path from 'node:path';
 
+const SAFE_ID_RE = /^[a-z0-9][a-z0-9._-]*$/;
+
 export async function listDesignSystems(root) {
   const out = [];
   let entries = [];
@@ -41,6 +43,7 @@ export async function listDesignSystems(root) {
 }
 
 export async function readDesignSystem(root, id) {
+  if (!id || typeof id !== 'string' || !SAFE_ID_RE.test(id)) return null;
   const file = path.join(root, id, 'DESIGN.md');
   try {
     return await readFile(file, 'utf8');

--- a/apps/daemon/src/media-config.ts
+++ b/apps/daemon/src/media-config.ts
@@ -35,6 +35,7 @@
 // We DO mask keys when reading via the GET endpoint so the UI doesn't
 // echo secrets back into the DOM.
 
+import fs from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import path from 'node:path';
@@ -111,6 +112,9 @@ async function readStored(projectRoot) {
   try {
     const raw = await readFile(configFile(projectRoot), 'utf8');
     const parsed = JSON.parse(raw);
+    // Silently tighten permissions on existing files — no-op on filesystems
+    // that don't support chmod.
+    try { fs.chmodSync(configFile(projectRoot), 0o600); } catch {}
     if (parsed && typeof parsed === 'object' && parsed.providers) {
       return parsed.providers;
     }
@@ -124,7 +128,8 @@ async function readStored(projectRoot) {
 async function writeStored(projectRoot, providers) {
   const file = configFile(projectRoot);
   await mkdir(path.dirname(file), { recursive: true });
-  await writeFile(file, JSON.stringify({ providers }, null, 2), 'utf8');
+  await writeFile(file, JSON.stringify({ providers }, null, 2), { encoding: 'utf8', mode: 0o600 });
+  try { fs.chmodSync(file, 0o600); } catch {}
 }
 
 function readEnvKey(providerId) {

--- a/apps/daemon/src/prompts/system.ts
+++ b/apps/daemon/src/prompts/system.ts
@@ -73,6 +73,15 @@ type ProjectMetadata = {
 };
 type ProjectTemplate = { name: string; description?: string | null; files: Array<{ name: string; content: string }> };
 
+function sanitizePromptField(value: unknown): string {
+  let s = String(value ?? '');
+  s = s.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, '');
+  s = s.replace(/---+/g, '- - -');
+  s = s.replace(/\n#/g, '\n＃');
+  s = s.replace(/`{3,}/g, '``');
+  return s.slice(0, 500);
+}
+
 export const BASE_SYSTEM_PROMPT = OFFICIAL_DESIGNER_PROMPT;
 
 export interface ComposeInput {
@@ -130,14 +139,14 @@ export function composeSystemPrompt({
 
   if (designSystemBody && designSystemBody.trim().length > 0) {
     parts.push(
-      `\n\n## Active design system${designSystemTitle ? ` — ${designSystemTitle}` : ''}\n\nTreat the following DESIGN.md as authoritative for color, typography, spacing, and component rules. Do not invent tokens outside this palette. When you copy the active skill's seed template, bind these tokens into its \`:root\` block before generating any layout.\n\n${designSystemBody.trim()}`,
+      `\n\n## Active design system${designSystemTitle ? ` — ${sanitizePromptField(designSystemTitle)}` : ''}\n\nTreat the following DESIGN.md as authoritative for color, typography, spacing, and component rules. Do not invent tokens outside this palette. When you copy the active skill's seed template, bind these tokens into its \`:root\` block before generating any layout.\n\n${designSystemBody.trim()}`,
     );
   }
 
   if (craftBody && craftBody.trim().length > 0) {
     const sectionLabel =
       Array.isArray(craftSections) && craftSections.length > 0
-        ? ` — ${craftSections.join(', ')}`
+        ? ` — ${sanitizePromptField(craftSections.join(', '))}`
         : '';
     parts.push(
       `\n\n## Active craft references${sectionLabel}\n\nThe following craft rules are universal — they apply on top of the active design system above, regardless of brand. The DESIGN.md decides *which* tokens to use; craft rules decide *how* to use them. On any conflict between a craft rule and a brand DESIGN.md, the brand wins for token values; craft rules still apply to anything the brand does not override (letter-spacing, accent overuse caps, anti-slop patterns).\n\n${craftBody.trim()}`,
@@ -147,7 +156,7 @@ export function composeSystemPrompt({
   if (skillBody && skillBody.trim().length > 0) {
     const preflight = derivePreflight(skillBody);
     parts.push(
-      `\n\n## Active skill${skillName ? ` — ${skillName}` : ''}\n\nFollow this skill's workflow exactly.${preflight}\n\n${skillBody.trim()}`,
+      `\n\n## Active skill${skillName ? ` — ${sanitizePromptField(skillName)}` : ''}\n\nFollow this skill's workflow exactly.${preflight}\n\n${skillBody.trim()}`,
     );
   }
 
@@ -202,7 +211,7 @@ function renderMetadataBlock(
     'These are the structured choices the user made (or skipped) when creating this project. Treat known fields as authoritative; for any field marked "(unknown — ask)" you MUST include a matching question in your turn-1 discovery form.',
   );
   lines.push('');
-  lines.push(`- **kind**: ${metadata.kind}`);
+  lines.push(`- **kind**: ${sanitizePromptField(metadata.kind)}`);
   if (metadata.intent === 'live-artifact') {
     lines.push(
       '- **intent**: live-artifact — the user chose New live artifact. The first output should be a live artifact/dashboard/report, not a one-off static mockup. Prefer the `live-artifact` skill workflow when available, keep source data compact, and register through the daemon live-artifact tool path once that wrapper/tooling is available.',
@@ -214,7 +223,7 @@ function renderMetadataBlock(
 
   if (metadata.kind === 'prototype') {
     lines.push(
-      `- **fidelity**: ${metadata.fidelity ?? '(unknown — ask: wireframe vs high-fidelity)'}`,
+      `- **fidelity**: ${metadata.fidelity != null ? sanitizePromptField(metadata.fidelity) : '(unknown — ask: wireframe vs high-fidelity)'}`,
     );
   }
   if (metadata.kind === 'deck') {
@@ -232,13 +241,13 @@ function renderMetadataBlock(
   }
   if (metadata.kind === 'image') {
     lines.push(
-      `- **imageModel**: ${metadata.imageModel ?? '(unknown — ask: which image model to use)'}`,
+      `- **imageModel**: ${metadata.imageModel != null ? sanitizePromptField(metadata.imageModel) : '(unknown — ask: which image model to use)'}`,
     );
     lines.push(
-      `- **aspectRatio**: ${metadata.imageAspect ?? '(unknown — ask: 1:1, 16:9, 9:16, 4:3, 3:4)'}`,
+      `- **aspectRatio**: ${metadata.imageAspect != null ? sanitizePromptField(metadata.imageAspect) : '(unknown — ask: 1:1, 16:9, 9:16, 4:3, 3:4)'}`,
     );
     if (metadata.imageStyle) {
-      lines.push(`- **styleNotes**: ${metadata.imageStyle}`);
+      lines.push(`- **styleNotes**: ${sanitizePromptField(metadata.imageStyle)}`);
     }
     if (
       metadata.promptTemplate?.title &&
@@ -254,13 +263,13 @@ function renderMetadataBlock(
   }
   if (metadata.kind === 'video') {
     lines.push(
-      `- **videoModel**: ${metadata.videoModel ?? '(unknown — ask: which video model to use)'}`,
+      `- **videoModel**: ${metadata.videoModel != null ? sanitizePromptField(metadata.videoModel) : '(unknown — ask: which video model to use)'}`,
     );
     lines.push(
       `- **lengthSeconds**: ${typeof metadata.videoLength === 'number' ? metadata.videoLength : '(unknown — ask: 3s / 5s / 10s)'}`,
     );
     lines.push(
-      `- **aspectRatio**: ${metadata.videoAspect ?? '(unknown — ask: 16:9, 9:16, 1:1)'}`,
+      `- **aspectRatio**: ${metadata.videoAspect != null ? sanitizePromptField(metadata.videoAspect) : '(unknown — ask: 16:9, 9:16, 1:1)'}`,
     );
     if (
       metadata.promptTemplate?.title &&
@@ -281,16 +290,16 @@ function renderMetadataBlock(
   }
   if (metadata.kind === 'audio') {
     lines.push(
-      `- **audioKind**: ${metadata.audioKind ?? '(unknown — ask: music / speech / sfx)'}`,
+      `- **audioKind**: ${metadata.audioKind != null ? sanitizePromptField(metadata.audioKind) : '(unknown — ask: music / speech / sfx)'}`,
     );
     lines.push(
-      `- **audioModel**: ${metadata.audioModel ?? '(unknown — ask: which audio model to use)'}`,
+      `- **audioModel**: ${metadata.audioModel != null ? sanitizePromptField(metadata.audioModel) : '(unknown — ask: which audio model to use)'}`,
     );
     lines.push(
       `- **durationSeconds**: ${typeof metadata.audioDuration === 'number' ? metadata.audioDuration : '(unknown — ask: target duration)'}`,
     );
     if (metadata.voice) {
-      lines.push(`- **voice**: ${metadata.voice}`);
+      lines.push(`- **voice**: ${sanitizePromptField(metadata.voice)}`);
     } else if (metadata.audioKind === 'speech') {
       lines.push('- **voice**: (unknown — ask: voice id / accent / pacing)');
     }
@@ -319,18 +328,18 @@ function renderMetadataBlock(
   ) {
     const tpl = metadata.promptTemplate;
     lines.push('');
-    lines.push(`### Reference prompt template — "${tpl.title ?? 'untitled'}"`);
+    lines.push(`### Reference prompt template — "${sanitizePromptField(tpl.title ?? 'untitled')}"`);
     const meta = [];
-    if (tpl.category) meta.push(`category: ${tpl.category}`);
-    if (tpl.model) meta.push(`suggested model: ${tpl.model}`);
-    if (tpl.aspect) meta.push(`aspect: ${tpl.aspect}`);
+    if (tpl.category) meta.push(`category: ${sanitizePromptField(tpl.category)}`);
+    if (tpl.model) meta.push(`suggested model: ${sanitizePromptField(tpl.model)}`);
+    if (tpl.aspect) meta.push(`aspect: ${sanitizePromptField(tpl.aspect)}`);
     if (Array.isArray(tpl.tags) && tpl.tags.length > 0) {
-      meta.push(`tags: ${tpl.tags.join(', ')}`);
+      meta.push(`tags: ${sanitizePromptField(tpl.tags.join(', '))}`);
     }
     if (meta.length > 0) lines.push(meta.join(' · '));
     if (tpl.summary) {
       lines.push('');
-      lines.push(tpl.summary);
+      lines.push(sanitizePromptField(tpl.summary));
     }
     lines.push('');
     lines.push(
@@ -349,10 +358,10 @@ function renderMetadataBlock(
     lines.push(truncated);
     lines.push('```');
     if (tpl.source) {
-      const author = tpl.source.author ? ` by ${tpl.source.author}` : '';
+      const author = tpl.source.author ? ` by ${sanitizePromptField(tpl.source.author)}` : '';
       lines.push('');
       lines.push(
-        `Source: ${tpl.source.repo}${author} — license ${tpl.source.license ?? 'unspecified'}. Preserve attribution if you echo the template language directly.`,
+        `Source: ${sanitizePromptField(tpl.source.repo)}${author} — license ${tpl.source.license != null ? sanitizePromptField(tpl.source.license) : 'unspecified'}. Preserve attribution if you echo the template language directly.`,
       );
     }
   }
@@ -360,7 +369,7 @@ function renderMetadataBlock(
   if (metadata.kind === 'template' && template && template.files.length > 0) {
     lines.push('');
     lines.push(
-      `### Template reference — "${template.name}"${template.description ? ` (${template.description})` : ''}`,
+      `### Template reference — "${sanitizePromptField(template.name)}"${template.description ? ` (${sanitizePromptField(template.description)})` : ''}`,
     );
     lines.push(
       'These HTML snapshots are what the user wants to start FROM. Read them as a stylistic + structural reference. You may copy structure, palette, typography, and component patterns; you may adapt them to the new brief; do NOT ship them verbatim. The agent should still produce its own artifact, just one that visibly inherits this template\'s design language.',
@@ -373,7 +382,7 @@ function renderMetadataBlock(
           ? `${f.content.slice(0, 12000)}\n<!-- … truncated (${f.content.length - 12000} chars omitted) -->`
           : f.content;
       lines.push('');
-      lines.push(`#### \`${f.name}\``);
+      lines.push(`#### \`${sanitizePromptField(f.name)}\``);
       lines.push('```html');
       lines.push(truncated);
       lines.push('```');

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -2,7 +2,7 @@
 import express from 'express';
 import multer from 'multer';
 import { execFile, spawn } from 'node:child_process';
-import { randomUUID } from 'node:crypto';
+import { randomBytes, randomUUID } from 'node:crypto';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
@@ -163,6 +163,9 @@ export function resolveDaemonCliPath(): string {
 
 const PROJECT_ROOT = resolveProjectRoot(__dirname);
 const RESOURCE_ROOT_ENV = 'OD_RESOURCE_ROOT';
+
+// Generate once per daemon process. Never persisted — restarts require re-auth.
+export const DAEMON_SESSION_TOKEN = randomBytes(32).toString('hex');
 
 export function normalizeCommentAttachments(input) {
   if (!Array.isArray(input)) return [];
@@ -727,6 +730,15 @@ function requireLocalDaemonRequest(req, res, next) {
   next();
 }
 
+function requireSessionToken(req, res, next) {
+  const token = req.headers['x-od-session-token'];
+  if (typeof token !== 'string' || token !== DAEMON_SESSION_TOKEN) {
+    res.status(401).json({ error: 'invalid session token' });
+    return;
+  }
+  next();
+}
+
 function setLiveArtifactPreviewHeaders(res) {
   res.setHeader('Content-Type', 'text/html; charset=utf-8');
   res.setHeader('Cache-Control', 'no-store');
@@ -1108,6 +1120,17 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
     }
     next();
   });
+
+  // Enforce the session token on all /api routes except the small set of
+  // unauthenticated bootstrap / health-check endpoints that the frontend
+  // needs to call before it has obtained the token.
+  const _SESSION_TOKEN_EXEMPT_RE =
+    /^\/health$|^\/version$|^\/daemon-token$|^\/live-artifacts\/[^/]+\/preview$/;
+  app.use('/api', (req, res, next) => {
+    if (_SESSION_TOKEN_EXEMPT_RE.test(req.path)) return next();
+    requireSessionToken(req, res, next);
+  });
+
   const db = openDatabase(PROJECT_ROOT, { dataDir: RUNTIME_DATA_DIR });
   configureConnectorCredentialStore(new FileConnectorCredentialStore(RUNTIME_DATA_DIR));
   configureComposioConfigStore(RUNTIME_DATA_DIR);
@@ -1148,6 +1171,14 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
   app.get('/api/version', async (_req, res) => {
     const version = await readCurrentAppVersionInfo();
     res.json({ version });
+  });
+
+  // Unauthenticated bootstrap endpoint: lets the web frontend retrieve the
+  // session token on first load. Still localhost-restricted via
+  // requireLocalDaemonRequest (IP check), but does not require the token
+  // itself (the frontend doesn't have it yet at this point).
+  app.get('/api/daemon-token', requireLocalDaemonRequest, (req, res) => {
+    res.json({ token: DAEMON_SESSION_TOKEN });
   });
 
   registerConnectorRoutes(app, { sendApiError, authorizeToolRequest, projectsRoot: PROJECTS_DIR, requireLocalDaemonRequest });


### PR DESCRIPTION
## Summary

Security hardening across 10 findings identified during a full review of the daemon, Electron shell, and CI/CD pipeline.

### Critical / High

- **Prompt injection** (`prompts/system.ts`): ~20 user-controlled metadata fields (`template title`, `category`, `voice`, `imageStyle`, etc.) are now run through `sanitizePromptField()` before being interpolated into the agent system prompt. Strips control characters, collapses markdown structural tokens (`---`, `#`, ` ``` `), and truncates to 500 chars. The existing backtick-escape on `tpl.prompt` is unchanged.
- **Credential leak to agent CLIs** (`agents.ts`): `spawnEnvForAgent()` previously only stripped `ANTHROPIC_API_KEY` from the Claude adapter. A new `SENSITIVE_ENV_PATTERNS` list (16 patterns: `OPENAI_API_KEY`, `GH_TOKEN`, `AWS_SECRET_ACCESS_KEY`, `GITHUB_TOKEN`, `NPM_TOKEN`, `VERCEL_TOKEN`, `OD_*_API_KEY`, etc.) is now applied to **all** agent child processes. The existing Claude + `ANTHROPIC_BASE_URL` exception is preserved.
- **Deploy hook script injection** (`deploy.ts`): `injectDeployHookScript()` accepted any `http(s)://` URL from `OD_DEPLOY_HOOK_SCRIPT_URL`, injecting a `<script>` into every Vercel deployment. Added an empty `DEPLOY_HOOK_ALLOWED_HOSTS` set — all hostnames blocked by default. Removed the `options.hookScriptUrl` programmatic override path from `buildDeployFilePlan()`.
- **ACP over-permissive auto-approval** (`acp.ts`): `choosePermissionOutcome()` previously preferred `approve_for_session` (session-wide grant). Reversed to prefer `allow_once` → `allow_always` → `approve_for_session`. Also emits a `permission_request` SSE event before replying so the UI can surface what was auto-approved.
- **API key file permissions** (`media-config.ts`): `media-config.json` is now written with `mode: 0o600` + `chmodSync`. Existing files have permissions tightened on first read (silent migration).

### Medium

- **Daemon session token** (`server.ts`): `DAEMON_SESSION_TOKEN` (32-byte random, never persisted) generated at startup. New `requireSessionToken` middleware applied to all `/api` routes except `/health`, `/version`, `/daemon-token`, and live-artifact preview routes. Bootstrap endpoint `GET /api/daemon-token` (localhost-restricted, unauthenticated) lets the web frontend fetch the token once on startup.
- **ZIP symlink extraction** (`claude-design-import.ts`): Reject ZIP entries whose Unix external attributes indicate a symlink (`externalFileAttributes >>> 16 & 0xF000 === 0xA000`) before extraction. Post-extraction `lstat()` scan unlinks any symlinks that slipped through (defense-in-depth).
- **Spritesheet download size cap** (`community-pets-sync.ts`): Added `MAX_SPRITESHEET_BYTES = 10 MiB` upper bound in `writePet()` to prevent disk exhaustion from oversized downloads.
- **CI action pinning** (`.github/workflows/*.yml`): All 8 third-party actions across 7 workflow files pinned to full 40-character commit SHAs. Version tag preserved in a comment. Covers `actions/checkout`, `actions/setup-node`, `pnpm/action-setup`, `actions/upload-artifact`, `actions/download-artifact`, `peter-evans/create-pull-request`, `cloudflare/wrangler-action`, and `lowlighter/metrics`.

### Low

- **Design system path traversal** (`design-systems.ts`): `readDesignSystem(root, id)` now validates `id` against `/^[a-z0-9][a-z0-9._-]*$/` before `path.join()`, blocking traversal attempts like `../../etc/passwd`.

## Test plan

- [ ] Verify `sanitizePromptField` strips `\n# OVERRIDE` and `---` from template titles in a local run
- [ ] Confirm agent child processes no longer inherit `OPENAI_API_KEY` / `GH_TOKEN` from the shell
- [ ] Confirm deploy hook injection is blocked with a test URL (should return empty artifact without the script tag)
- [ ] Verify `media-config.json` is created with `0o600` on a fresh install
- [ ] Confirm the web frontend can bootstrap via `GET /api/daemon-token` and subsequent API calls succeed with the `x-od-session-token` header
- [ ] Attempt to import a ZIP containing a symlink entry and confirm it is rejected
- [ ] Confirm all workflow SHAs resolve to the expected tags via `gh api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)