### PR TITLE
feat(daemon): support OD_EXTRA_ORIGINS for reverse-proxy deploys

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1058,15 +1058,23 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
     if (webPort && webPort !== resolvedPort) ports.push(webPort);
     const schemes = ['http', 'https'];
     const loopbackHosts = ['127.0.0.1', 'localhost', '[::1]'];
-    return new Set(
-      ports.flatMap((p) => [
+    // OD_EXTRA_ORIGINS: comma-separated extra browser origins to allow.
+    // Use case: serving the web UI through a local reverse proxy that
+    // rewrites the Host (e.g. portless at <name>.localhost:1355).
+    const extraOrigins = (process.env.OD_EXTRA_ORIGINS || '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    return new Set([
+      ...ports.flatMap((p) => [
         ...schemes.flatMap((s) => loopbackHosts.map((h) => `${s}://${h}:${p}`)),
         // When bound to a specific non-loopback address (e.g. Tailscale,
         // LAN IP, or 0.0.0.0), allow browser requests from that address
         // too so the documented --host escape hatch remains usable.
         ...schemes.map((s) => `${s}://${host}:${p}`),
       ]),
-    );
+      ...extraOrigins,
+    ]);
   }
 
   // Routes that serve content to sandboxed iframes (Origin: null) for
@@ -4609,12 +4617,32 @@ export function isLocalSameOrigin(req, port) {
   if (webPort && webPort !== port) ports.push(webPort);
   const bindHost = process.env.OD_BIND_HOST || '127.0.0.1';
   const loopbackHosts = ['127.0.0.1', 'localhost', '[::1]'];
-  const allowedHosts = new Set(
-    ports.flatMap((p) => [
+  // OD_EXTRA_ORIGINS: same env var honored by buildAllowedOrigins().
+  // Comma-separated browser origins allowed when serving through a
+  // reverse proxy that rewrites Host/Origin (e.g. portless).
+  const extraOrigins = (process.env.OD_EXTRA_ORIGINS || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  // Derive `host:port` from each extra origin so DNS-rebind protection
+  // stays intact while the proxy's Host passes through.
+  const extraHosts = extraOrigins
+    .map((o) => {
+      try {
+        const u = new URL(o);
+        return u.host;
+      } catch {
+        return '';
+      }
+    })
+    .filter(Boolean);
+  const allowedHosts = new Set([
+    ...ports.flatMap((p) => [
       ...loopbackHosts.map((h) => `${h}:${p}`),
       `${bindHost}:${p}`,
     ]),
-  );
+    ...extraHosts,
+  ]);
 
   // Reject unknown Host first (DNS rebinding / Host header attack)
   if (!allowedHosts.has(host)) return false;
@@ -4623,11 +4651,12 @@ export function isLocalSameOrigin(req, port) {
   if (origin == null || origin === '') return true;
 
   const schemes = ['http', 'https'];
-  const allowedOrigins = new Set(
-    ports.flatMap((p) => [
+  const allowedOrigins = new Set([
+    ...ports.flatMap((p) => [
       ...schemes.flatMap((s) => loopbackHosts.map((h) => `${s}://${h}:${p}`)),
       ...schemes.map((s) => `${s}://${bindHost}:${p}`),
     ]),
-  );
+    ...extraOrigins,
+  ]);
   return allowedOrigins.has(String(origin));
 }

--- a/apps/daemon/tests/origin-validation.test.ts
+++ b/apps/daemon/tests/origin-validation.test.ts
@@ -32,12 +32,20 @@ function createOriginMiddleware(resolvedPort, host = '127.0.0.1') {
     if (webPort && webPort !== resolvedPort) ports.push(webPort);
     const schemes = ['http', 'https'];
     const loopbackHosts = ['127.0.0.1', 'localhost', '[::1]'];
-    const allowedOrigins = new Set(
-      ports.flatMap((p) => [
+    // OD_EXTRA_ORIGINS: comma-separated extra browser origins to allow.
+    // Use case: serving the web UI through a local reverse proxy that
+    // rewrites the Host (e.g. portless at <name>.localhost:1355).
+    const extraOrigins = (process.env.OD_EXTRA_ORIGINS || '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const allowedOrigins = new Set([
+      ...ports.flatMap((p) => [
         ...schemes.flatMap((s) => loopbackHosts.map((h) => `${s}://${h}:${p}`)),
         ...schemes.map((s) => `${s}://${host}:${p}`),
       ]),
-    );
+      ...extraOrigins,
+    ]);
     if (!allowedOrigins.has(String(origin))) {
       return res.status(403).json({ error: 'Cross-origin requests are not allowed' });
     }
@@ -232,6 +240,48 @@ describe('daemon origin validation middleware', () => {
       origin: `http://127.0.0.1:${port + 2000}`,
     });
     delete process.env.OD_WEB_PORT;
+    expect(res.status).toBe(403);
+  });
+
+  // --- OD_EXTRA_ORIGINS (reverse-proxy / portless support) ---
+
+  it('allows origins listed in OD_EXTRA_ORIGINS', async () => {
+    process.env.OD_EXTRA_ORIGINS = 'http://design.localhost:1355';
+    const res = await request(port, 'GET', '/api/projects', {
+      origin: 'http://design.localhost:1355',
+    });
+    delete process.env.OD_EXTRA_ORIGINS;
+    expect(res.status).toBe(200);
+  });
+
+  it('supports multiple comma-separated origins in OD_EXTRA_ORIGINS', async () => {
+    process.env.OD_EXTRA_ORIGINS = 'http://design.localhost:1355, https://od.example.com';
+    const r1 = await request(port, 'GET', '/api/projects', {
+      origin: 'http://design.localhost:1355',
+    });
+    const r2 = await request(port, 'GET', '/api/projects', {
+      origin: 'https://od.example.com',
+    });
+    delete process.env.OD_EXTRA_ORIGINS;
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+  });
+
+  it('still blocks origins NOT listed in OD_EXTRA_ORIGINS', async () => {
+    process.env.OD_EXTRA_ORIGINS = 'http://design.localhost:1355';
+    const res = await request(port, 'GET', '/api/projects', {
+      origin: 'http://evil.com',
+    });
+    delete process.env.OD_EXTRA_ORIGINS;
+    expect(res.status).toBe(403);
+  });
+
+  it('treats empty/blank OD_EXTRA_ORIGINS entries as no-op', async () => {
+    process.env.OD_EXTRA_ORIGINS = ',  , ';
+    const res = await request(port, 'GET', '/api/projects', {
+      origin: 'http://design.localhost:1355',
+    });
+    delete process.env.OD_EXTRA_ORIGINS;
     expect(res.status).toBe(403);
   });
 


### PR DESCRIPTION
## Why

Operators today can only expose the OD web UI on **loopback** or on the **explicit `--host` bind address**. Any local reverse proxy that fronts the daemon at a different origin (Caddy, [Vercel Portless](https://github.com/vercel-labs/portless), an organisation-wide nginx, a Tailscale Funnel-style egress, …) gets a `403 {"error":"Cross-origin requests are not allowed"}` on every `/api` call, because the browser's `Origin` header doesn't match anything in the allowlist.

Concrete repro from my setup: I run OD behind portless at `http://design.localhost:1355` so it shares a single proxy port with the rest of my dev tools. Chat works for the first turn (no `Origin` because the request comes from `tools-dev`'s spawned agent), but the second user message from the browser fails with the 403 above.

## What

Add an opt-in `OD_EXTRA_ORIGINS` env var: comma-separated list of extra browser origins the daemon trusts. Patched in both places that build the allowlist:

1. The global `/api` origin middleware in `startServer()` — fixes the chat flow.
2. The inline `isLocalSameOrigin()` helper used by media-generation routes (image / video / audio / HyperFrames) — fixes the rest of the surface that lives behind the same proxy. `allowedHosts` is also extended with the `URL.host` of each entry so DNS-rebind protection stays intact when the proxy passes the original `Host` header through.

Behaviour when the env var is unset is **unchanged** — the existing loopback + bind-host policy still applies on its own. Empty / blank entries are ignored so `OD_EXTRA_ORIGINS=,,,` is the same as no env var.

## Example

```bash
OD_EXTRA_ORIGINS=http://design.localhost:1355 \
  pnpm tools-dev run web --web-port 5176 --daemon-port 7458
```

Or with multiple proxy origins:

```bash
OD_EXTRA_ORIGINS=http://design.localhost:1355,https://od.example.com \
  pnpm tools-dev run web ...
```

## Tests

`apps/daemon/tests/origin-validation.test.ts` already mirrors the middleware inline; I extended the mirror and added 4 cases that follow the same shape as the existing `OD_WEB_PORT` block:

- ✅ allows an origin listed in `OD_EXTRA_ORIGINS`
- ✅ supports multiple comma-separated origins
- ✅ still blocks origins **not** listed (security guard intact)
- ✅ treats blank / empty entries as no-op

```
✓ tests/origin-validation.test.ts (23 tests) 112ms
  Test Files  1 passed (1)
       Tests  23 passed (23)
```

`pnpm --filter @open-design/daemon typecheck` — clean.

## Notes

- I marked this **draft** so maintainers can decide on naming (`OD_EXTRA_ORIGINS` vs e.g. `OD_TRUSTED_ORIGINS` / `OD_ALLOWED_ORIGINS`) before I polish docs.
- Happy to add a one-liner to `QUICKSTART.md` / the `OD_*` env vars section in the README architecture table once the name is settled.
- Conscious that adding *any* origin escape hatch is a security-sensitive change; the design choice here is to keep it **fully opt-in**, **per-process**, **per-origin** (no wildcards), and **purely additive** to the existing allowlist — same shape as `OD_WEB_PORT` and `OD_BIND_HOST`. Open to feedback if you'd prefer a stricter shape (e.g. require a corresponding `OD_BIND_HOST` entry, or require an explicit allowlist file rather than env var).