### PR TITLE
fix linux test path

### DIFF
--- a/tools/pack/tests/linux.test.ts
+++ b/tools/pack/tests/linux.test.ts
@@ -65,10 +65,10 @@ describe("buildDockerArgs", () => {
 
   it("mounts docker home and electron caches under .tmp/tools-pack/.docker-*", () => {
     const args = buildDockerArgs(makeConfig(), { uid: 1000, gid: 1000 });
-    expect(args).toContain("/work/.tmp/tools-pack/.docker-home:/home/builder");
-    expect(args).toContain("/work/.tmp/tools-pack/.docker-cache/electron:/home/builder/.cache/electron");
+    expect(args).toContain(`${join("/work/.tmp/tools-pack", ".docker-home")}:/home/builder`);
+    expect(args).toContain(`${join("/work/.tmp/tools-pack", ".docker-cache", "electron")}:/home/builder/.cache/electron`);
     expect(args).toContain(
-      "/work/.tmp/tools-pack/.docker-cache/electron-builder:/home/builder/.cache/electron-builder",
+      `${join("/work/.tmp/tools-pack", ".docker-cache", "electron-builder")}:/home/builder/.cache/electron-builder`,
     );
   });
 


### PR DESCRIPTION
## Summary

- Update the tools-pack Linux Docker mount path assertions to build expected host paths with `join(...)`.
- Keep the test expectations aligned with `buildDockerArgs`, which uses platform-native `path.join()` internally.

## Why

The test hardcoded POSIX-style host paths. On Windows, `path.join()` produces Windows-style separators, so the assertion fails even though the implementation is behaving consistently with the platform.

## Validation

- `pnpm --filter @open-design/tools-pack test`
