### PR TITLE
release: Open Design 0.4.1 — packaged startup hotfix + release gating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-05-06
+
+0.4.1 is the startup hotfix for the broken 0.4.0 desktop packages. It restores packaged app startup on macOS and Windows, adds release validation so the failure mode is caught before publication, and includes the small UI, agent, documentation, i18n, and craft updates that landed while the hotfix was being verified.
+
+### Added
+
+#### Web / UI
+- **Manual edit mode** for direct artifact edits. ([#620])
+- **Cmd/Ctrl+P quick file switcher** for faster project navigation. ([#556])
+- Resizable chat panel. ([#563])
+
+#### Daemon and agents
+- Added model name to PI initial status and RPC abort on cancel. ([#618])
+
+#### Craft and i18n
+- Craft `accessibility-baseline` module with opt-ins for dashboard, HR onboarding, and mobile onboarding. ([#587])
+- Craft `rtl-and-bidi` module so artifacts handle Arabic, Hebrew, and Persian content more reliably. ([#595])
+- Added i18n structure checks. ([#608])
+
+### Changed
+
+- Updated README first-PR links so `help-wanted` issues are surfaced alongside `good-first-issue`. ([#605])
+
+### Fixed
+
+#### Packaging
+- Fixed packaged desktop startup by building `@open-design/contracts` to `dist/*.mjs` + `.d.ts`, pointing its exports at compiled JavaScript, and building contracts before all packaged lanes pack workspace tarballs. ([#577])
+- Added packaged runtime beta gating so release candidates install, start, inspect `/api/health`, collect logs, stop, and uninstall before promotion. ([#637])
+
+#### Daemon and agents
+- Added the required stdio MCP server env field and recover from `-32602` on `session/set_model`. ([#627])
+- Normalized ACP `mcpServers` to the stdio shape for Kimi/Hermes ACP. ([#612])
+- Fixed agent CLI configuration and workspace focus mode. ([#604])
+
+#### Web and desktop
+- Preserved error messages across conversation reloads. ([#623])
+- Kept chat recoverable after conversation load failures. ([#637])
+- Honored native macOS quit behavior in the packaged desktop shell. ([#637])
+
+### Documentation
+
+- Documented `OD_DATA_DIR` and migration from `.od/` to the Desktop app. ([#570])
+- Added Chinese (Simplified) QUICKSTART. ([#578])
+- Backported missing zh-TW README sections from the English README. ([#586])
+- Synced and improved the Korean README. ([#619])
+
+### Internal
+
+- Refined release workflows, CI scope, e2e layout, and packaged runtime smoke coverage for beta validation. ([#637])
+- Refreshed generated GitHub metrics. ([#592])
+
 ## [0.4.0] - 2026-05-05
 
 A multi-protocol leap: Open Design now ships as an MCP server, ships Critique Theater (Design Jury) Phase 4, gains live-reload + Tweaks mode + live artifacts in the preview pane, and adds five new agent / runtime adapters. 71 merged PRs from 40+ contributors over two days. Linux AppImage packaging landed in tooling, but the stable Linux artifact is deferred from 0.4.0 while containerized release packaging is hardened.
@@ -365,7 +416,8 @@ First public release of Open Design — a local-first, open-source alternative t
 - Beta release workflow placeholder. ([#36])
 - Git commit co-author policy. ([#131])
 
-[Unreleased]: https://github.com/nexu-io/open-design/compare/open-design-v0.4.0...HEAD
+[Unreleased]: https://github.com/nexu-io/open-design/compare/open-design-v0.4.1...HEAD
+[0.4.1]: https://github.com/nexu-io/open-design/releases/tag/open-design-v0.4.1
 [0.4.0]: https://github.com/nexu-io/open-design/releases/tag/open-design-v0.4.0
 [0.3.0]: https://github.com/nexu-io/open-design/releases/tag/open-design-v0.3.0
 [0.2.0]: https://github.com/nexu-io/open-design/releases/tag/open-design-v0.2.0
@@ -609,3 +661,22 @@ First public release of Open Design — a local-first, open-source alternative t
 [#535]: https://github.com/nexu-io/open-design/pull/535
 [#548]: https://github.com/nexu-io/open-design/pull/548
 [#549]: https://github.com/nexu-io/open-design/pull/549
+[#556]: https://github.com/nexu-io/open-design/pull/556
+[#563]: https://github.com/nexu-io/open-design/pull/563
+[#570]: https://github.com/nexu-io/open-design/pull/570
+[#577]: https://github.com/nexu-io/open-design/pull/577
+[#578]: https://github.com/nexu-io/open-design/pull/578
+[#586]: https://github.com/nexu-io/open-design/pull/586
+[#587]: https://github.com/nexu-io/open-design/pull/587
+[#592]: https://github.com/nexu-io/open-design/pull/592
+[#595]: https://github.com/nexu-io/open-design/pull/595
+[#604]: https://github.com/nexu-io/open-design/pull/604
+[#605]: https://github.com/nexu-io/open-design/pull/605
+[#608]: https://github.com/nexu-io/open-design/pull/608
+[#612]: https://github.com/nexu-io/open-design/pull/612
+[#618]: https://github.com/nexu-io/open-design/pull/618
+[#619]: https://github.com/nexu-io/open-design/pull/619
+[#620]: https://github.com/nexu-io/open-design/pull/620
+[#623]: https://github.com/nexu-io/open-design/pull/623
+[#627]: https://github.com/nexu-io/open-design/pull/627
+[#637]: https://github.com/nexu-io/open-design/pull/637

--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/daemon",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "main": "./dist/cli.js",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/desktop",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "main": "./dist/main/index.js",

--- a/apps/landing-page/package.json
+++ b/apps/landing-page/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/landing-page",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/web",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/e2e",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-design",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "packageManager": "pnpm@10.33.2",
   "type": "module",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/contracts",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "description": "Shared pure TypeScript contracts for the Open Design web/daemon boundary.",

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/platform",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/sidecar-proto/package.json
+++ b/packages/sidecar-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/sidecar-proto",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/sidecar/package.json
+++ b/packages/sidecar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/sidecar",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/tools/dev/package.json
+++ b/tools/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-dev",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "bin": {

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-pack",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "bin": {


### PR DESCRIPTION
🎉 **`19 PRs` · startup hotfix · same-day recovery** — Open Design 0.4.1 gets desktop users unstuck after the broken 0.4.0 packages: macOS and Windows launch again, release candidates now get real packaged-runtime smoke coverage before promotion, and the hotfix also brings manual edits, faster file switching, sharper agent recovery, and better docs / craft support. 🚀

## 🔥 Highlights

- 🧯 **0.4.0 startup blocker fixed.** The packaged app no longer crashes before the window appears: `@open-design/contracts` now ships compiled JS, exports `dist/*.mjs`, and builds before every packaged lane packs workspace tarballs. (#577) Thanks @iuliandita.
- 🛡️ **Release candidates now prove they can boot.** Beta validation installs the packaged app, starts it, inspects `/api/health`, captures logs, stops it, and uninstalls cleanly before we promote another build. (#637) Thanks @PerishCode.
- ✍️ **Manual edit mode lands.** When the agent gets close but you want the final say, you can now directly edit artifacts instead of starting another round trip. (#620) Thanks @alchemistklk.
- ⚡ **Cmd/Ctrl+P quick file switching.** Jump across project files without hunting through the sidebar — faster reviews, faster fixes, less context loss. (#556) Thanks @whatiskadudoing.
- 🧱 **Resizable chat panel.** Give the conversation or the preview more room depending on what you are doing right now. (#563) Thanks @ferasbusiness666.
- 🤖 **Agent recovery got less brittle.** ACP / MCP server shapes, workspace focus mode, and `session/set_model` error recovery are tighter, so agent sessions survive more real-world provider quirks. (#604, #612, #627) Thanks @Sid-Qin, @Embracex1998, and @goemonwanwan.
- 🌍 **Artifacts behave better across languages.** New accessibility and RTL/Bidi craft modules help dashboards and onboarding flows stay usable for Arabic, Hebrew, Persian, and assistive-tech-heavy contexts. (#587, #595) Thanks @MohamedAbdallah-14.

> 📥 **Download:** final asset URLs are below — links go live once this PR is merged and the `release-stable` workflow finishes. Tag: `open-design-v0.4.1`.
>
> | Platform | Architecture | Asset |
> |---|---|---|
> | macOS | Apple Silicon (arm64) | [open-design-0.4.1-mac-arm64.dmg](https://github.com/nexu-io/open-design/releases/download/open-design-v0.4.1/open-design-0.4.1-mac-arm64.dmg) |
> | macOS (auto-update feed) | Apple Silicon (arm64) | [open-design-0.4.1-mac-arm64.zip](https://github.com/nexu-io/open-design/releases/download/open-design-v0.4.1/open-design-0.4.1-mac-arm64.zip) |
> | Windows | x64 (unsigned) | [open-design-0.4.1-win-x64-setup.exe](https://github.com/nexu-io/open-design/releases/download/open-design-v0.4.1/open-design-0.4.1-win-x64-setup.exe) |

## ✨ What's New

### ✍️ Editing & navigation

- ✍️ **Manual edit mode.** Make direct artifact changes when you want precise control after generation. (#620) Thanks @alchemistklk.
- ⚡ **Quick file switcher.** Cmd/Ctrl+P gets you to the right project file without breaking flow. (#556) Thanks @whatiskadudoing.
- 🧱 **Resizable chat panel.** Tune the workspace for writing, reviewing, or previewing. (#563) Thanks @ferasbusiness666.

### 🤖 Agents & daemon

- 🧭 **Agent CLI config + workspace focus mode fixes.** Fewer dead ends when agents need the right tool and the right project context. (#604) Thanks @Sid-Qin.
- 🔧 **Kimi / Hermes ACP MCP-server normalization.** Provider-specific config now lands in the shape the runtime expects. (#612) Thanks @Embracex1998.
- 🛠️ **MCP stdio env + `session/set_model` recovery.** The daemon is more forgiving when providers return strict `-32602` errors. (#627) Thanks @goemonwanwan.
- 📡 **PI initial status includes model name and cancel aborts RPC.** Better feedback and cleaner cancellation for active runs. (#618) Thanks @monotykamary.

### 🎨 Craft, i18n & docs

- ♿ **Accessibility baseline craft module.** Dashboard, HR onboarding, and mobile onboarding artifacts get stronger accessibility defaults. (#587) Thanks @MohamedAbdallah-14.
- 🔤 **RTL and Bidi craft module.** Arabic, Hebrew, and Persian content is much less likely to break layout or reading order. (#595) Thanks @MohamedAbdallah-14.
- 🧪 **i18n structure checks.** Locale drift gets caught earlier instead of leaking into release prep. (#608) Thanks @nettee.
- 📚 **Data-dir migration docs.** `OD_DATA_DIR` and `.od/` to Desktop app migration are now documented for users moving between source and packaged runs. (#570) Thanks @StotheC90.
- 🌏 **Chinese QUICKSTART + zh-TW / Korean README sync.** More onboarding docs are complete and current across locales. (#578, #586, #619) Thanks @YUHAO-corn, @laihenyi, and @Charlesswoo.
- 🤝 **Better contributor entry links.** First-time contributors now see `help-wanted` issues alongside `good-first-issue`. (#605) Thanks @lefarcen.

## 🛡️ Stability & Reliability

- 🧯 **Packaged startup no longer dies on raw TypeScript exports.** The 0.4.0 `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING` crash is fixed at the package boundary. (#577) Thanks @iuliandita.
- 🧪 **Packaged runtime smoke coverage protects the release lane.** A build that cannot start the desktop and answer `/api/health` should fail before users see it. (#637) Thanks @PerishCode.
- 💬 **Conversation errors stay recoverable.** Loading failures preserve useful error messages instead of leaving the chat in a confusing state. (#623) Thanks @nhancdt2602.
- 🍎 **Native macOS quit is respected.** Packaged desktop shutdown now matches platform expectations. (#637) Thanks @PerishCode.

## 🐛 Bug Fixes

- 📦 **Contracts package exports point at built JS.** Internal package tarballs no longer ask packaged Node to execute `.ts` files from `node_modules`. (#577) Thanks @iuliandita.
- 🧰 **Build order now matches packaged runtime needs.** Contracts build before macOS / Windows / Linux packaging lanes assemble internal package tarballs. (#577) Thanks @iuliandita.
- 🧭 **Agent workspace focus is less surprising.** CLI config and focused workspace behavior are aligned for agent startup. (#604) Thanks @Sid-Qin.
- 🔌 **ACP server config is normalized.** Kimi / Hermes MCP server definitions now use the stdio contract shape. (#612) Thanks @Embracex1998.
- 🧠 **Model switching recovers from strict provider validation.** `session/set_model` handles `-32602` more gracefully. (#627) Thanks @goemonwanwan.

## 📚 Documentation

- 📁 **`OD_DATA_DIR` migration path is documented.** Users can move between source and Desktop app data layouts with less guesswork. (#570) Thanks @StotheC90.
- 🇨🇳 **Chinese (Simplified) QUICKSTART.** Faster first run for Simplified Chinese readers. (#578) Thanks @YUHAO-corn.
- 🇹🇼 **Traditional Chinese README catches up.** Missing English H2 sections were backported. (#586) Thanks @laihenyi.
- 🇰🇷 **Korean README refresh.** The Korean landing docs are synced and improved. (#619) Thanks @Charlesswoo.
- 🤝 **Contributor links show more starter work.** The first-PR path now surfaces `help-wanted` issues too. (#605) Thanks @lefarcen.

## 🔨 For Developers

<details>
<summary>Click to expand</summary>

- 🧪 **Beta packaged runtime gate.** `release-beta` now has a mac packaged smoke path that installs, starts, inspects, logs, stops, and uninstalls. (#637)
- 🧹 **E2E lanes are cleaner.** UI Playwright files, Vitest integration tests, resources, libs, and scripts are split into clearer lanes. (#637)
- 📊 **Generated GitHub metrics refreshed.** Contributor/activity visuals are up to date for the release window. (#592)
- 📦 **All workspace package versions are aligned to `0.4.1`.** `apps/packaged` was bumped in #637; this PR aligns the remaining root/apps/packages/tools/e2e manifests.
- 🚀 **Release workflow owns final validation.** After merge, dispatch `release-stable` from `main` with `mac_signed=true` to publish.

</details>

## ✅ System Requirements

- 🍎 **macOS** — Apple Silicon (arm64) only, macOS 11 Big Sur or newer. Intel macs are not supported.
- 🪟 **Windows** — x64, Windows 10 / 11. Installer is **unsigned** (SmartScreen will warn on first launch — choose "More info → Run anyway").
- 🐧 **Linux** — no stable desktop artifact in 0.4.1; run from source while the Linux release lane is hardened.
- 🧑‍💻 **From source** — Node.js 24.x and pnpm 10.33.2+ (per `engines` in `package.json`).

## ⚠️ Known Issues

- 🚫 **Do not install v0.4.0.** It has a confirmed startup blocker; 0.4.1 is the replacement release.
- 🪟 **Windows installer is unsigned.** SmartScreen / antivirus warnings are expected on first launch. Code signing remains follow-up work.
- 🍎 **No macOS Intel (x64) build.** Apple Silicon only.
- 🐧 **No Linux desktop package in 0.4.1 stable.** AppImage packaging exists in tooling, but the stable artifact is still deferred while release packaging is hardened.
- 🐚 **`od` CLI shadows POSIX `od`** when installed globally. Use `/usr/bin/od` or `command od` for the system tool.

---

## 🚀 Releasing this PR

This PR ships:

1. 📦 **All 13 monorepo `package.json` files at `0.4.1`.** `apps/packaged` was bumped in #637; this PR aligns the remaining root/apps/packages/tools/e2e manifests.
2. 📝 **`CHANGELOG.md`** — new `[0.4.1] - 2026-05-06` entry covering the hotfix and 19 merged PRs since 0.4.0.

After merge, dispatch `release-stable` with `mac_signed=true` to publish `open-design-v0.4.1`.

**Full Changelog:** https://github.com/nexu-io/open-design/compare/open-design-v0.4.0...release/v0.4.1