### PR TITLE
Fix Ukrainian prompt template translations

### DIFF
--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -162,6 +162,8 @@ export const uk: Dict = {
   'promptTemplates.openSource': 'Переглянути оригінал',
   'promptTemplates.openFullscreen': 'Відкрити попередній перегляд у повноекранному режимі',
   'promptTemplates.closeFullscreen': 'Закрити попередній перегляд у повноекранному режимі',
+  'promptTemplates.allSources': 'Усі джерела',
+  'promptTemplates.sourceFilterAria': 'Фільтрувати за джерелом',
   'promptTemplates.retry': 'Повторити',
 
   'connectors.title': 'Конектори',


### PR DESCRIPTION
## Summary
- Add missing Ukrainian translations for prompt template source filtering labels.

## Tests
- git diff --check
- Not run: pnpm i18n:check / typecheck because node_modules are not installed in this worktree (`tsx` and workspace dependencies are missing).
