### PR TITLE
fix(i18n): remove duplicate Ukrainian prompt template keys

### DIFF
--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -165,8 +165,6 @@ export const uk: Dict = {
   'promptTemplates.openFullscreen': 'Відкрити попередній перегляд у повноекранному режимі',
   'promptTemplates.closeFullscreen': 'Закрити попередній перегляд у повноекранному режимі',
   'promptTemplates.retry': 'Повторити',
-  'promptTemplates.allSources': 'Усі джерела',
-  'promptTemplates.sourceFilterAria': 'Фільтр за джерелом',
 
   'connectors.title': 'Конектори',
   'connectors.subtitle': 'Локальні та майбутні джерела даних, які можуть живити live-артефакти.',


### PR DESCRIPTION
## Summary
- remove duplicate Ukrainian prompt-template translation keys from uk.ts
- keep the existing all-sources and source-filter translations in the prompt template group

## Validation
- pnpm --filter @open-design/web typecheck
- pnpm guard
- This fixes the TS1117 duplicate object key failure currently blocking PR #676 CI.