### PR TITLE
fix(daemon): improve connector close button behavior when opener is unavailable (#669)

### DIFF
--- a/apps/daemon/src/connectors/composio.ts
+++ b/apps/daemon/src/connectors/composio.ts
@@ -387,6 +387,7 @@ export interface ComposioPendingConnection {
   connectorId: string;
   state: string;
   providerConnectionId?: string;
+  webOrigin?: string;
   expiresAtMs: number;
 }
 
@@ -394,6 +395,7 @@ export interface ComposioConnectionCompletion {
   connectorId: string;
   accountLabel: string;
   credentials: ConnectorCredentialMaterial;
+  webOrigin?: string;
 }
 
 export class ComposioConnectorProvider {
@@ -480,7 +482,7 @@ export class ComposioConnectorProvider {
     return undefined;
   }
 
-  async connect(definition: ConnectorCatalogDefinition, callbackUrl: string, signal?: AbortSignal): Promise<ComposioConnectionStart> {
+  async connect(definition: ConnectorCatalogDefinition, callbackUrl: string, webOrigin: string | undefined, signal?: AbortSignal): Promise<ComposioConnectionStart> {
     this.pruneExpiredPendingConnections();
 
     const authConfigId = await this.getOrCreateManagedAuthConfigId(definition, signal);
@@ -508,7 +510,7 @@ export class ComposioConnectorProvider {
     const providerConnectionId = getComposioConnectionId(response);
     const redirectUrl = getString(response.redirect_url) ?? getString(response.redirectUrl);
     const status = getString(response.status)?.toUpperCase();
-    this.pendingConnections.set(state, { connectorId: definition.id, state, ...(providerConnectionId ? { providerConnectionId } : {}), expiresAtMs });
+    this.pendingConnections.set(state, { connectorId: definition.id, state, ...(providerConnectionId ? { providerConnectionId } : {}), ...(webOrigin ? { webOrigin } : {}), expiresAtMs });
 
     const validatedConnection = status === 'ACTIVE' && providerConnectionId
       ? await this.getValidatedConnectedAccount(definition, providerConnectionId, authConfigId, signal)
@@ -545,7 +547,7 @@ export class ComposioConnectorProvider {
     }
     const expectedAuthConfigId = await this.getAuthConfigId(input.definition, input.signal);
     const response = await this.getValidatedConnectedAccount(input.definition, providerConnectionId, expectedAuthConfigId, input.signal);
-    return this.connectionToCredentials(input.definition, providerConnectionId, response);
+    return { ...this.connectionToCredentials(input.definition, providerConnectionId, response), ...(pending.webOrigin ? { webOrigin: pending.webOrigin } : {}) };
   }
 
   private pruneExpiredPendingConnections(now = Date.now()): void {

--- a/apps/daemon/src/connectors/routes.ts
+++ b/apps/daemon/src/connectors/routes.ts
@@ -89,7 +89,7 @@ function escapeHtml(value: string): string {
   });
 }
 
-function renderConnectorConnectedHtml(connectorId: string): string {
+function renderConnectorConnectedHtml(connectorId: string, appBaseUrl: string): string {
   const knownConnectorLabels: Record<string, string> = {
     github: 'GitHub',
     google_drive: 'Google Drive',
@@ -105,6 +105,7 @@ function renderConnectorConnectedHtml(connectorId: string): string {
   const connectorLabelHtml = escapeHtml(connectorLabel);
   const connectorIdJson = JSON.stringify(connectorId);
   const connectorLabelJson = JSON.stringify(connectorLabel);
+  const appBaseUrlJson = JSON.stringify(appBaseUrl);
 
   return `<!doctype html>
 <html lang="en">
@@ -293,18 +294,31 @@ function renderConnectorConnectedHtml(connectorId: string): string {
       (() => {
         const connectorId = ${connectorIdJson};
         const connectorLabel = ${connectorLabelJson};
+        const appBaseUrl = ${appBaseUrlJson};
+        const hasOpener = window.opener && !window.opener.closed;
         const message = { type: 'open-design:connector-connected', connectorId, connectorLabel };
         try {
-          if (window.opener && !window.opener.closed) {
+          if (hasOpener) {
             window.opener.postMessage(message, '*');
             window.setTimeout(() => window.close(), 900);
+            document.getElementById('auto-close-hint').textContent = 'This popup will close automatically if your browser allows it.';
           } else {
-            document.getElementById('auto-close-hint').textContent = 'You can close this tab and return to Open Design.';
+            document.getElementById('auto-close-hint').textContent = 'You can return to Open Design using the button below.';
           }
         } catch {
-          document.getElementById('auto-close-hint').textContent = 'You can close this tab and return to Open Design.';
+          if (!hasOpener) {
+            document.getElementById('auto-close-hint').textContent = 'You can return to Open Design using the button below.';
+          }
         }
-        document.getElementById('close-window').addEventListener('click', () => window.close());
+        const btn = document.getElementById('close-window');
+        if (hasOpener) {
+          btn.addEventListener('click', () => window.close());
+        } else {
+          btn.textContent = 'Return to Open Design';
+          btn.addEventListener('click', () => {
+            window.location.href = appBaseUrl;
+          });
+        }
       })();
     </script>
   </body>
@@ -368,11 +382,24 @@ export function registerConnectorRoutes(app: Express, options: RegisterConnector
         options.sendApiError(res, 400, 'VALIDATION_FAILED', 'Composio connector credentials can only be stored through OAuth callback completion');
         return;
       }
+      const origin = req.headers.origin;
+      let webOrigin: string | undefined;
+      if (origin) {
+        try {
+          const url = new URL(origin);
+          if (isLoopbackHostname(url.hostname)) {
+            webOrigin = origin;
+          }
+        } catch {
+          // invalid origin, ignore
+        }
+      }
       res.json({
         ...(await service.connect(connectorId, {
           ...(accountLabel === undefined ? {} : { accountLabel }),
           ...(credentials === undefined ? {} : { credentials }),
           callbackUrl: `${connectorCallbackUrl(req)}/${encodeURIComponent(connectorId)}`,
+          ...(webOrigin === undefined ? {} : { webOrigin }),
         })),
       });
     } catch (err) {
@@ -394,8 +421,20 @@ export function registerConnectorRoutes(app: Express, options: RegisterConnector
             ? req.query.account_id
             : undefined;
       const status = typeof req.query.status === 'string' ? req.query.status : undefined;
-      await service.completeComposioConnection({ connectorId, state, ...(providerConnectionId === undefined ? {} : { providerConnectionId }), ...(status === undefined ? {} : { status }) });
-      res.type('html').send(renderConnectorConnectedHtml(connectorId));
+      const result = await service.completeComposioConnection({ connectorId, state, ...(providerConnectionId === undefined ? {} : { providerConnectionId }), ...(status === undefined ? {} : { status }) });
+      const host = req.get('host') ?? 'localhost';
+      let appBaseUrl = `${req.protocol}://${host}`;
+      if (result.webOrigin) {
+        try {
+          const url = new URL(result.webOrigin);
+          if (isLoopbackHostname(url.hostname)) {
+            appBaseUrl = result.webOrigin;
+          }
+        } catch {
+          // invalid webOrigin, use daemon host
+        }
+      }
+      res.type('html').send(renderConnectorConnectedHtml(connectorId, appBaseUrl));
     } catch (err) {
       sendConnectorRouteError(res, err, options.sendApiError);
     }

--- a/apps/daemon/src/connectors/routes.ts
+++ b/apps/daemon/src/connectors/routes.ts
@@ -89,7 +89,11 @@ function escapeHtml(value: string): string {
   });
 }
 
-function renderConnectorConnectedHtml(connectorId: string, appBaseUrl: string): string {
+function escapeForScript(value: string): string {
+  return JSON.stringify(value).replace(/</g, '\\u003c');
+}
+
+function renderConnectorConnectedHtml(connectorId: string, appBaseUrl?: string): string {
   const knownConnectorLabels: Record<string, string> = {
     github: 'GitHub',
     google_drive: 'Google Drive',
@@ -105,7 +109,7 @@ function renderConnectorConnectedHtml(connectorId: string, appBaseUrl: string): 
   const connectorLabelHtml = escapeHtml(connectorLabel);
   const connectorIdJson = JSON.stringify(connectorId);
   const connectorLabelJson = JSON.stringify(connectorLabel);
-  const appBaseUrlJson = JSON.stringify(appBaseUrl);
+  const appBaseUrlJson = escapeForScript(appBaseUrl ?? '');
 
   return `<!doctype html>
 <html lang="en">
@@ -303,21 +307,26 @@ function renderConnectorConnectedHtml(connectorId: string, appBaseUrl: string): 
             window.setTimeout(() => window.close(), 900);
             document.getElementById('auto-close-hint').textContent = 'This popup will close automatically if your browser allows it.';
           } else {
-            document.getElementById('auto-close-hint').textContent = 'You can return to Open Design using the button below.';
+            document.getElementById('auto-close-hint').textContent = appBaseUrl
+              ? 'You can return to Open Design using the button below.'
+              : 'You can close this tab.';
           }
         } catch {
-          if (!hasOpener) {
-            document.getElementById('auto-close-hint').textContent = 'You can return to Open Design using the button below.';
-          }
+          document.getElementById('auto-close-hint').textContent = appBaseUrl
+            ? 'You can return to Open Design using the button below.'
+            : 'You can close this tab.';
         }
         const btn = document.getElementById('close-window');
         if (hasOpener) {
           btn.addEventListener('click', () => window.close());
-        } else {
+        } else if (appBaseUrl) {
           btn.textContent = 'Return to Open Design';
           btn.addEventListener('click', () => {
             window.location.href = appBaseUrl;
           });
+        } else {
+          btn.textContent = 'Close tab';
+          btn.addEventListener('click', () => window.close());
         }
       })();
     </script>
@@ -422,16 +431,26 @@ export function registerConnectorRoutes(app: Express, options: RegisterConnector
             : undefined;
       const status = typeof req.query.status === 'string' ? req.query.status : undefined;
       const result = await service.completeComposioConnection({ connectorId, state, ...(providerConnectionId === undefined ? {} : { providerConnectionId }), ...(status === undefined ? {} : { status }) });
-      const host = req.get('host') ?? 'localhost';
-      let appBaseUrl = `${req.protocol}://${host}`;
+      let appBaseUrl: string | undefined;
       if (result.webOrigin) {
         try {
           const url = new URL(result.webOrigin);
           if (isLoopbackHostname(url.hostname)) {
-            appBaseUrl = result.webOrigin;
+            appBaseUrl = url.origin;
           }
         } catch {
-          // invalid webOrigin, use daemon host
+          // invalid webOrigin, fall through to host fallback
+        }
+      }
+      if (!appBaseUrl) {
+        const host = req.get('host') ?? 'localhost';
+        try {
+          const url = new URL(`http://${host}`);
+          if (isLoopbackHostname(url.hostname)) {
+            appBaseUrl = url.origin;
+          }
+        } catch {
+          // invalid host, render without navigation
         }
       }
       res.type('html').send(renderConnectorConnectedHtml(connectorId, appBaseUrl));

--- a/apps/daemon/src/connectors/service.ts
+++ b/apps/daemon/src/connectors/service.ts
@@ -570,7 +570,7 @@ export class ConnectorService {
     return this.toDetail(definition);
   }
 
-  async connect(connectorId: string, options: { accountLabel?: string; credentials?: ConnectorCredentialMaterial; callbackUrl?: string; signal?: AbortSignal } = {}): Promise<ConnectorConnectResult> {
+  async connect(connectorId: string, options: { accountLabel?: string; credentials?: ConnectorCredentialMaterial; callbackUrl?: string; webOrigin?: string; signal?: AbortSignal } = {}): Promise<ConnectorConnectResult> {
     const definition = await this.getDefinition(connectorId, options.signal);
     if (!definition) {
       throw new ConnectorServiceError('CONNECTOR_NOT_FOUND', 'connector not found', 404);
@@ -582,7 +582,7 @@ export class ConnectorService {
       if (!options.callbackUrl) {
         throw new ConnectorServiceError('CONNECTOR_EXECUTION_FAILED', 'callbackUrl is required for Composio connectors', 400, { connectorId });
       }
-      auth = await composioConnectorProvider.connect(definition, options.callbackUrl, options.signal);
+      auth = await composioConnectorProvider.connect(definition, options.callbackUrl, options.webOrigin, options.signal);
       detailDefinition = await this.getDefinition(connectorId, options.signal) ?? definition;
       if (auth.kind === 'redirect_required' || auth.kind === 'pending') {
         return { connector: this.toDetail(detailDefinition), auth: publicComposioAuthStart(auth) };
@@ -611,7 +611,7 @@ export class ConnectorService {
     return this.toDetail(definition);
   }
 
-  async completeComposioConnection(input: { connectorId: string; state: string; providerConnectionId?: string; status?: string; signal?: AbortSignal }): Promise<ConnectorDetail> {
+  async completeComposioConnection(input: { connectorId: string; state: string; providerConnectionId?: string; status?: string; signal?: AbortSignal }): Promise<ConnectorDetail & { webOrigin?: string }> {
     const definition = await this.getDefinition(input.connectorId, input.signal);
     if (!definition) {
       throw new ConnectorServiceError('CONNECTOR_NOT_FOUND', 'connector not found', 404);
@@ -621,7 +621,7 @@ export class ConnectorService {
     }
     const completed = await composioConnectorProvider.completeConnection({ definition, state: input.state, ...(input.providerConnectionId === undefined ? {} : { providerConnectionId: input.providerConnectionId }), ...(input.status === undefined ? {} : { status: input.status }), ...(input.signal === undefined ? {} : { signal: input.signal }) });
     this.statusService.connect(definition, completed.accountLabel, completed.credentials);
-    return this.toDetail(definition);
+    return { ...this.toDetail(definition), ...(completed.webOrigin ? { webOrigin: completed.webOrigin } : {}) };
   }
 
   async execute(request: ConnectorExecuteRequest, context: ConnectorExecutionContext): Promise<ConnectorExecuteResponse> {


### PR DESCRIPTION
Fixes #669

修复 connector 成功页面关闭按钮在 opener 不可用时无效的问题：

- 提取 hasOpener 变量，消除重复的 window.opener && !window.opener.closed 判断
- 有 opener 时：提示文案改为 "This popup will close automatically if your browser allows it."
- 无 opener 时：提示文案改为 "You can return to Open Design using the button below."
- catch 块中增加 hasOpener 判断，避免显示误导性错误文案