### PR TITLE
feat(linux): add headless mode for install/start/stop operations

### DIFF
--- a/apps/packaged/esbuild.config.mjs
+++ b/apps/packaged/esbuild.config.mjs
@@ -1,11 +1,21 @@
 import { build } from "esbuild";
 
-await build({
+const sharedOptions = {
   bundle: true,
-  entryPoints: ["./src/index.ts"],
   format: "esm",
-  outfile: "./dist/index.mjs",
   packages: "external",
   platform: "node",
   target: "node24",
+};
+
+await build({
+  ...sharedOptions,
+  entryPoints: ["./src/index.ts"],
+  outfile: "./dist/index.mjs",
+});
+
+await build({
+  ...sharedOptions,
+  entryPoints: ["./src/headless.ts"],
+  outfile: "./dist/headless.mjs",
 });

--- a/apps/packaged/package.json
+++ b/apps/packaged/package.json
@@ -10,6 +10,9 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.mjs"
     },
+    "./headless": {
+      "default": "./dist/headless.mjs"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/apps/packaged/src/headless.ts
+++ b/apps/packaged/src/headless.ts
@@ -104,7 +104,12 @@ async function main(): Promise<void> {
     webOutputMode: config.webOutputMode,
   });
 
-const webUrl = sidecars.web.url ?? "";
+const webUrl = sidecars.web.url;
+  if (!webUrl) {
+    await sidecars.close().catch(() => undefined);
+    await identity.close().catch(() => undefined);
+    throw new Error("web sidecar failed to produce URL — check logs/desktop/latest.log");
+  }
 
   await writePackagedWebIdentity({
     paths,

--- a/apps/packaged/src/headless.ts
+++ b/apps/packaged/src/headless.ts
@@ -14,7 +14,7 @@ import {
 import { bootstrapSidecarRuntime, resolveAppIpcPath } from "@open-design/sidecar";
 
 import type { PackagedConfig } from "./config.js";
-import { writePackagedDesktopIdentity } from "./identity.js";
+import { writePackagedDesktopIdentity, writePackagedWebIdentity } from "./identity.js";
 import { resolvePackagedNamespacePaths } from "./paths.js";
 import { startPackagedSidecars } from "./sidecars.js";
 
@@ -104,9 +104,15 @@ async function main(): Promise<void> {
     webOutputMode: config.webOutputMode,
   });
 
-  const webUrl = sidecars.web.url ?? "";
+const webUrl = sidecars.web.url ?? "";
 
-  process.stdout.write(`\n  Open Design is running\n\n`);
+  await writePackagedWebIdentity({
+    paths,
+    pid: process.pid,
+    url: webUrl,
+  });
+
+  process.stdout.write(`\n Open Design is running\n\n`);
   process.stdout.write(`  ➜  ${colorize(webUrl)}\n\n`);
   process.stdout.write(`  Press Ctrl+C to stop\n\n`);
 

--- a/apps/packaged/src/headless.ts
+++ b/apps/packaged/src/headless.ts
@@ -113,16 +113,6 @@ async function main(): Promise<void> {
     throw new Error("web sidecar failed to produce URL — check logs/desktop/latest.log");
   }
 
-  await writePackagedWebIdentity({
-    paths,
-    pid: process.pid,
-    url: webUrl,
-  });
-
-  process.stdout.write(`\n Open Design is running\n\n`);
-  process.stdout.write(` ➜ ${colorize(webUrl)}\n\n`);
-  process.stdout.write(` Press Ctrl+C to stop\n\n`);
-
   const shutdown = async (): Promise<void> => {
     process.stdout.write("\n Shutting down Open Design...\n");
     await ipcServer.close().catch(() => undefined);
@@ -146,6 +136,16 @@ async function main(): Promise<void> {
       }
     },
   });
+
+  await writePackagedWebIdentity({
+    paths,
+    pid: process.pid,
+    url: webUrl,
+  });
+
+  process.stdout.write(`\n Open Design is running\n\n`);
+  process.stdout.write(` ➜ ${colorize(webUrl)}\n\n`);
+  process.stdout.write(` Press Ctrl+C to stop\n\n`);
 
   process.on("SIGINT", () => {
     void shutdown();

--- a/apps/packaged/src/headless.ts
+++ b/apps/packaged/src/headless.ts
@@ -1,0 +1,133 @@
+import { mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  APP_KEYS,
+  OPEN_DESIGN_SIDECAR_CONTRACT,
+  SIDECAR_DEFAULTS,
+  SIDECAR_MODES,
+  SIDECAR_SOURCES,
+  type SidecarStamp,
+} from "@open-design/sidecar-proto";
+import { bootstrapSidecarRuntime, resolveAppIpcPath } from "@open-design/sidecar";
+
+import type { PackagedConfig } from "./config.js";
+import { writePackagedDesktopIdentity } from "./identity.js";
+import { resolvePackagedNamespacePaths } from "./paths.js";
+import { startPackagedSidecars } from "./sidecars.js";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+
+function resolveHeadlessNamespaceBaseRoot(): string {
+  const odDataDir = process.env.OD_DATA_DIR;
+  if (odDataDir != null && odDataDir.length > 0) {
+    return join(resolve(odDataDir.replace(/^~/, homedir())), "namespaces");
+  }
+  const xdgDataHome = process.env.XDG_DATA_HOME;
+  const dataBase =
+    xdgDataHome != null && xdgDataHome.length > 0
+      ? xdgDataHome
+      : join(homedir(), ".local", "share");
+  return join(dataBase, "open-design", "namespaces");
+}
+
+function resolveHeadlessConfig(): PackagedConfig {
+  const namespace =
+    OPEN_DESIGN_SIDECAR_CONTRACT.normalizeNamespace(
+      process.env.OD_NAMESPACE ??
+        process.env.OD_SIDECAR_NAMESPACE ??
+        SIDECAR_DEFAULTS.namespace,
+    );
+
+  const namespaceBaseRoot = resolveHeadlessNamespaceBaseRoot();
+
+  // OD_RESOURCE_ROOT may be set by a launcher script; otherwise default to a
+  // sibling open-design/ directory relative to the node_modules that contain
+  // this file — the layout written by tools-pack linux headless-install.
+  const resourceRoot =
+    process.env.OD_RESOURCE_ROOT ??
+    join(__dirname, "..", "..", "..", "open-design");
+
+  return {
+    appVersion: null,
+    namespace,
+    namespaceBaseRoot,
+    nodeCommand: null,
+    resourceRoot,
+    webStandaloneRoot: null,
+    webOutputMode: "server",
+  };
+}
+
+function createHeadlessStamp(namespace: string): SidecarStamp {
+  return {
+    app: APP_KEYS.DESKTOP,
+    ipc: resolveAppIpcPath({
+      app: APP_KEYS.DESKTOP,
+      contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+      namespace,
+    }),
+    mode: SIDECAR_MODES.RUNTIME,
+    namespace,
+    source: SIDECAR_SOURCES.PACKAGED,
+  };
+}
+
+function colorize(text: string): string {
+  if (process.stdout.isTTY !== true || process.env.NO_COLOR != null) return text;
+  return `\x1b[36m\x1b[4m${text}\x1b[0m`;
+}
+
+async function main(): Promise<void> {
+  const config = resolveHeadlessConfig();
+  const paths = resolvePackagedNamespacePaths(config);
+  const stamp = createHeadlessStamp(config.namespace);
+
+  await mkdir(paths.runtimeRoot, { recursive: true });
+
+  const runtime = bootstrapSidecarRuntime(stamp, process.env, {
+    app: APP_KEYS.DESKTOP,
+    base: paths.runtimeRoot,
+    contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+  });
+
+  // Write the identity marker so `tools-pack linux stop` can find and stop
+  // this process by PID via the same mechanism as the Electron packaged path.
+  const identity = await writePackagedDesktopIdentity({ paths, stamp });
+
+  const sidecars = await startPackagedSidecars(runtime, paths, {
+    appVersion: config.appVersion,
+    nodeCommand: config.nodeCommand,
+    webStandaloneRoot: config.webStandaloneRoot,
+    webOutputMode: config.webOutputMode,
+  });
+
+  const webUrl = sidecars.web.url ?? "";
+
+  process.stdout.write(`\n  Open Design is running\n\n`);
+  process.stdout.write(`  ➜  ${colorize(webUrl)}\n\n`);
+  process.stdout.write(`  Press Ctrl+C to stop\n\n`);
+
+  const shutdown = async (): Promise<void> => {
+    process.stdout.write("\n  Shutting down Open Design...\n");
+    await sidecars.close().catch(() => undefined);
+    await identity.close().catch(() => undefined);
+    process.exit(0);
+  };
+
+  process.on("SIGINT", () => {
+    void shutdown();
+  });
+  process.on("SIGTERM", () => {
+    void shutdown();
+  });
+}
+
+void main().catch((error: unknown) => {
+  process.stderr.write(
+    `open-design headless failed: ${error instanceof Error ? error.message : String(error)}\n`,
+  );
+  process.exit(1);
+});

--- a/apps/packaged/src/headless.ts
+++ b/apps/packaged/src/headless.ts
@@ -7,11 +7,13 @@ import {
   APP_KEYS,
   OPEN_DESIGN_SIDECAR_CONTRACT,
   SIDECAR_DEFAULTS,
+  SIDECAR_MESSAGES,
   SIDECAR_MODES,
   SIDECAR_SOURCES,
+  normalizeDesktopSidecarMessage,
   type SidecarStamp,
 } from "@open-design/sidecar-proto";
-import { bootstrapSidecarRuntime, resolveAppIpcPath } from "@open-design/sidecar";
+import { bootstrapSidecarRuntime, createJsonIpcServer, resolveAppIpcPath } from "@open-design/sidecar";
 
 import type { PackagedConfig } from "./config.js";
 import { writePackagedDesktopIdentity, writePackagedWebIdentity } from "./identity.js";
@@ -37,8 +39,8 @@ function resolveHeadlessConfig(): PackagedConfig {
   const namespace =
     OPEN_DESIGN_SIDECAR_CONTRACT.normalizeNamespace(
       process.env.OD_NAMESPACE ??
-        process.env.OD_SIDECAR_NAMESPACE ??
-        SIDECAR_DEFAULTS.namespace,
+      process.env.OD_SIDECAR_NAMESPACE ??
+      SIDECAR_DEFAULTS.namespace,
     );
 
   const namespaceBaseRoot = resolveHeadlessNamespaceBaseRoot();
@@ -104,7 +106,7 @@ async function main(): Promise<void> {
     webOutputMode: config.webOutputMode,
   });
 
-const webUrl = sidecars.web.url;
+  const webUrl = sidecars.web.url;
   if (!webUrl) {
     await sidecars.close().catch(() => undefined);
     await identity.close().catch(() => undefined);
@@ -118,15 +120,32 @@ const webUrl = sidecars.web.url;
   });
 
   process.stdout.write(`\n Open Design is running\n\n`);
-  process.stdout.write(`  ➜  ${colorize(webUrl)}\n\n`);
-  process.stdout.write(`  Press Ctrl+C to stop\n\n`);
+  process.stdout.write(` ➜ ${colorize(webUrl)}\n\n`);
+  process.stdout.write(` Press Ctrl+C to stop\n\n`);
 
   const shutdown = async (): Promise<void> => {
-    process.stdout.write("\n  Shutting down Open Design...\n");
+    process.stdout.write("\n Shutting down Open Design...\n");
+    await ipcServer.close().catch(() => undefined);
     await sidecars.close().catch(() => undefined);
     await identity.close().catch(() => undefined);
     process.exit(0);
   };
+
+  const ipcServer = await createJsonIpcServer({
+    socketPath: stamp.ipc,
+    handler: async (message: unknown) => {
+      const request = normalizeDesktopSidecarMessage(message);
+      switch (request.type) {
+        case SIDECAR_MESSAGES.STATUS:
+          return { pid: process.pid, state: "running", url: webUrl, updatedAt: new Date().toISOString() };
+        case SIDECAR_MESSAGES.SHUTDOWN:
+          setImmediate(() => {
+            void shutdown().finally(() => process.exit(0));
+          });
+          return { accepted: true };
+      }
+    },
+  });
 
   process.on("SIGINT", () => {
     void shutdown();

--- a/apps/packaged/src/identity.ts
+++ b/apps/packaged/src/identity.ts
@@ -18,6 +18,14 @@ export type PackagedDesktopRootIdentity = {
   version: 1;
 };
 
+export type PackagedWebRootIdentity = {
+  namespace: string;
+  pid: number;
+  url: string;
+  startedAt: string;
+  version: 1;
+};
+
 export type PackagedDesktopIdentityHandle = {
   close(): Promise<void>;
   identity: PackagedDesktopRootIdentity;
@@ -72,4 +80,19 @@ export async function writePackagedDesktopIdentity(options: {
     },
     identity,
   };
+}
+
+export async function writePackagedWebIdentity(options: {
+  paths: PackagedNamespacePaths;
+  pid: number;
+  url: string;
+}): Promise<void> {
+  const identity: PackagedWebRootIdentity = {
+    namespace: options.paths.namespaceRoot.split("/").pop() ?? "default",
+    pid: options.pid,
+    url: options.url,
+    startedAt: new Date().toISOString(),
+    version: 1,
+  };
+  await writeJsonFile(options.paths.webIdentityPath, identity);
 }

--- a/apps/packaged/src/paths.ts
+++ b/apps/packaged/src/paths.ts
@@ -16,6 +16,7 @@ export type PackagedNamespacePaths = {
   namespaceRoot: string;
   resourceRoot: string;
   runtimeRoot: string;
+  webIdentityPath: string;
 };
 
 export function resolvePackagedNamespacePaths(
@@ -36,5 +37,6 @@ export function resolvePackagedNamespacePaths(
     namespaceRoot,
     resourceRoot: config.resourceRoot,
     runtimeRoot: join(namespaceRoot, "runtime"),
+    webIdentityPath: join(namespaceRoot, "runtime", "web-root.json"),
   };
 }

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -42,5 +42,8 @@ pnpm tools-pack win inspect --expr "document.title"
 pnpm tools-pack win cleanup
 pnpm tools-pack linux build --to appimage
 pnpm tools-pack linux install
+pnpm tools-pack linux install --headless
+pnpm tools-pack linux start --headless
+pnpm tools-pack linux stop --headless
 pnpm tools-pack linux build --containerized
 ```

--- a/tools/pack/AGENTS.md
+++ b/tools/pack/AGENTS.md
@@ -10,6 +10,7 @@ Follow the root `AGENTS.md` and `tools/AGENTS.md` first. This tool owns the repo
 - Windows registry observation/cleanup must go through `reg.exe` and stay scoped to entries matching the namespace install/uninstaller paths.
 - Windows lifecycle logs must expose NSIS automation logs/markers/timings in addition to app runtime logs.
 - Linux AppImage build/install/start/stop/logs/uninstall/cleanup smoke commands.
+- Linux headless (no-Electron) install/start/stop via `--headless` flag on `install`, `start`, and `stop`.
 - Linux containerized builds via `electronuserland/builder` Docker image for distro-agnostic glibc compat.
 - Consuming sidecar/process/path primitives from `@open-design/sidecar-proto`, `@open-design/sidecar`, and `@open-design/platform`.
 

--- a/tools/pack/README.md
+++ b/tools/pack/README.md
@@ -69,8 +69,11 @@ Local lifecycle commands:
 - `tools-pack linux build --containerized` (run electron-builder inside `electronuserland/builder:base` Docker for distro-agnostic glibc compat — requires Docker)
 - `tools-pack linux build --to all --portable` (release artifacts that must not bake local tools-pack runtime paths)
 - `tools-pack linux install`
+- `tools-pack linux install --headless` (install the headless launcher script instead of the AppImage)
 - `tools-pack linux start`
+- `tools-pack linux start --headless` (start the headless entry — daemon + web, no Electron)
 - `tools-pack linux stop`
+- `tools-pack linux stop --headless` (stop a running headless process)
 - `tools-pack linux logs`
 - `tools-pack linux uninstall`
 - `tools-pack linux cleanup`
@@ -84,6 +87,16 @@ Local installs use XDG paths:
 - Icon: `~/.local/share/icons/hicolor/512x512/apps/open-design-<namespace>.png`
 
 The `<namespace>` suffix is unconditional so multiple developer namespaces can coexist on the same desktop. The `.desktop` file registers the `od://` scheme via `MimeType=x-scheme-handler/od;` and pre-sets `OD_NAMESPACE` on the `Exec=` line so menu launches identify the correct namespace.
+
+### Headless mode (`--headless`)
+
+`--headless` makes `install`, `start`, and `stop` operate on the headless entry (`@open-design/packaged/dist/headless.mjs`) instead of the AppImage. Headless mode runs daemon + web without Electron — useful on servers or in CI.
+
+- `install --headless` writes a self-contained shell script at `~/.local/bin/open-design-headless-<namespace>` that forwards to the bundled Node binary and headless entry.
+- `start --headless` spawns the headless process directly, redirects stdout/stderr to `logs/desktop/latest.log`, and waits up to 35 s for the identity marker before returning.
+- `stop --headless` reads the same `runtime/desktop-root.json` identity marker as the AppImage path, validates `stamp.source === PACKAGED`, sends a graceful SHUTDOWN over IPC, then terminates the process tree. It does not perform the AppImage-specific process-command check.
+
+`logs` always reads `logs/desktop/latest.log` regardless of mode, so headless output is visible via `tools-pack linux logs`.
 
 ### AppImage launch mode (FUSE caveat)
 

--- a/tools/pack/README.md
+++ b/tools/pack/README.md
@@ -90,10 +90,12 @@ The `<namespace>` suffix is unconditional so multiple developer namespaces can c
 
 ### Headless mode (`--headless`)
 
-`--headless` makes `install`, `start`, and `stop` operate on the headless entry (`@open-design/packaged/dist/headless.mjs`) instead of the AppImage. Headless mode runs daemon + web without Electron — useful on servers or in CI.
+Headless mode targets environments without a display (WSL2, headless servers, CI) where Electron can't run. If you have a desktop, use the AppImage; if you're SSH'd into a machine or in WSL, use headless.
 
-- `install --headless` writes a self-contained shell script at `~/.local/bin/open-design-headless-<namespace>` that forwards to the bundled Node binary and headless entry.
-- `start --headless` spawns the headless process directly, redirects stdout/stderr to `logs/desktop/latest.log`, and waits up to 35 s for the identity marker before returning.
+`--headless` makes `install`, `start`, and `stop` operate on the headless entry (`@open-design/packaged/dist/headless.mjs`) instead of the AppImage. Headless mode runs daemon + web without Electron.
+
+- `install --headless` writes a shell launcher at `~/.local/bin/open-design-headless-<namespace>` that bakes in the namespace and resource paths. The launcher is self-contained, but the assembled app directory at those paths must remain in place — don't move it after install.
+- `start --headless` spawns the headless process directly, redirects stdout/stderr to `logs/desktop/latest.log`, and waits up to 95s (35s for identity marker + 60s for web URL) before returning.
 - `stop --headless` reads the same `runtime/desktop-root.json` identity marker as the AppImage path, validates `stamp.source === PACKAGED`, sends a graceful SHUTDOWN over IPC, then terminates the process tree. It does not perform the AppImage-specific process-command check.
 
 `logs` always reads `logs/desktop/latest.log` regardless of mode, so headless output is visible via `tools-pack linux logs`.

--- a/tools/pack/src/config.ts
+++ b/tools/pack/src/config.ts
@@ -23,6 +23,7 @@ export type ToolPackCliOptions = {
   containerized?: boolean;
   dir?: string;
   expr?: string;
+  headless?: boolean;
   json?: boolean;
   macCompression?: string;
   namespace?: string;

--- a/tools/pack/src/index.ts
+++ b/tools/pack/src/index.ts
@@ -26,10 +26,13 @@ import {
 import {
   cleanupPackedLinuxNamespace,
   installPackedLinuxApp,
+  installPackedLinuxHeadless,
   packLinux,
   readPackedLinuxLogs,
   startPackedLinuxApp,
+  startPackedLinuxHeadless,
   stopPackedLinuxApp,
+  stopPackedLinuxHeadless,
   uninstallPackedLinuxApp,
 } from "./linux.js";
 
@@ -175,6 +178,7 @@ addWinLifecycleOptions(
 
 addBuildOptions(addSharedOptions(cli.command("linux <action>", "Linux packaging commands: build|install|start|stop|logs|uninstall|cleanup")), "linux")
   .option("--containerized", "build inside electronuserland/builder Docker for distro-agnostic glibc compat")
+  .option("--headless", "install/start/stop the headless (no-Electron) entry instead of the full desktop app")
   .action(async (action: string, options: CliOptions) => {
     const config = resolveToolPackConfig("linux", options);
     switch (action) {
@@ -182,13 +186,13 @@ addBuildOptions(addSharedOptions(cli.command("linux <action>", "Linux packaging 
         printJson(await packLinux(config));
         return;
       case "install":
-        printJson(await installPackedLinuxApp(config));
+        printJson(await (options.headless ? installPackedLinuxHeadless(config) : installPackedLinuxApp(config)));
         return;
       case "start":
-        printJson(await startPackedLinuxApp(config));
+        printJson(await (options.headless ? startPackedLinuxHeadless(config) : startPackedLinuxApp(config)));
         return;
       case "stop":
-        printJson(await stopPackedLinuxApp(config));
+        printJson(await (options.headless ? stopPackedLinuxHeadless(config) : stopPackedLinuxApp(config)));
         return;
       case "logs":
         printLogs(await readPackedLinuxLogs(config), options);

--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -1,5 +1,5 @@
 import { execFile, spawn } from "node:child_process";
-import { access, chmod, cp, mkdir, readFile, readdir, readlink, rename, rm, stat, writeFile } from "node:fs/promises";
+import { access, chmod, cp, mkdir, open, readFile, readdir, readlink, rename, rm, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { promisify } from "node:util";
@@ -1042,6 +1042,219 @@ export type LinuxCleanupResult = {
   skipped: boolean;
   stop: LinuxStopResult;
 };
+
+// --- Headless lifecycle ---
+
+// Paths resolved relative to the assembled app written during `tools-pack linux build`.
+// The headless entry lives at:
+//   <assembledAppRoot>/node_modules/@open-design/packaged/dist/headless.mjs
+// The bundled Node binary lives at:
+//   <namespaceRoot>/resources/open-design/bin/node  (populated by copyResourceTree)
+
+function resolveHeadlessEntryPath(paths: LinuxPaths): string {
+  return join(paths.assembledAppRoot, "node_modules", "@open-design", "packaged", "dist", "headless.mjs");
+}
+
+function resolveHeadlessBundledNodePath(paths: LinuxPaths): string {
+  return join(paths.resourceRoot, "bin", "node");
+}
+
+function headlessLauncherPath(config: ToolPackConfig): string {
+  return join(homedir(), ".local", "bin", `open-design-headless-${sanitizeNamespace(config.namespace)}`);
+}
+
+function headlessLogPath(config: ToolPackConfig): string {
+  return join(config.roots.runtime.namespaceRoot, "logs", APP_KEYS.DESKTOP, "latest.log");
+}
+
+export type LinuxHeadlessInstallResult = {
+  launcherPath: string;
+  namespace: string;
+};
+
+export type LinuxHeadlessStartResult = {
+  launcherPath: string;
+  logPath: string;
+  namespace: string;
+  pid: number;
+};
+
+export async function installPackedLinuxHeadless(config: ToolPackConfig): Promise<LinuxHeadlessInstallResult> {
+  const paths = resolveLinuxPaths(config);
+  const entryPath = resolveHeadlessEntryPath(paths);
+  const nodePath = resolveHeadlessBundledNodePath(paths);
+
+  if (!(await pathExists(entryPath))) {
+    throw new Error(
+      `headless entry not found at ${entryPath}; run \`tools-pack linux build\` first`,
+    );
+  }
+  if (!(await pathExists(nodePath))) {
+    throw new Error(
+      `bundled node binary not found at ${nodePath}; run \`tools-pack linux build\` first`,
+    );
+  }
+
+  const launcherPath = headlessLauncherPath(config);
+  await mkdir(dirname(launcherPath), { recursive: true });
+
+  // Write a self-contained launcher script. The namespace is baked in so the
+  // launcher name and the runtime namespace always agree. OD_DATA_DIR and
+  // OD_RESOURCE_ROOT may still be overridden by the caller's environment.
+  const script = [
+    "#!/bin/sh",
+    `# Open Design headless launcher — namespace: ${config.namespace}`,
+    `OD_NAMESPACE=${JSON.stringify(config.namespace)} OD_RESOURCE_ROOT=${JSON.stringify(paths.resourceRoot)} exec ${JSON.stringify(nodePath)} ${JSON.stringify(entryPath)} "$@"`,
+  ].join("\n") + "\n";
+
+  await writeFile(launcherPath, script, { encoding: "utf8", mode: 0o755 });
+
+  return { launcherPath, namespace: config.namespace };
+}
+
+export async function startPackedLinuxHeadless(config: ToolPackConfig): Promise<LinuxHeadlessStartResult> {
+  const paths = resolveLinuxPaths(config);
+  const entryPath = resolveHeadlessEntryPath(paths);
+  const nodePath = resolveHeadlessBundledNodePath(paths);
+
+  if (!(await pathExists(entryPath))) {
+    throw new Error(
+      `headless entry not found at ${entryPath}; run \`tools-pack linux build\` first`,
+    );
+  }
+
+  const nodeCommand = (await pathExists(nodePath)) ? nodePath : process.execPath;
+  const logPath = headlessLogPath(config);
+  await mkdir(dirname(logPath), { recursive: true });
+  await writeFile(logPath, "", "utf8");
+
+  // Remove stale identity marker from a previous run so waitForMarker below
+  // waits for the newly spawned process.
+  await rm(desktopIdentityPath(config), { force: true }).catch(() => undefined);
+
+  // Open the log file so stdout/stderr from the headless process are captured.
+  const logHandle = await open(logPath, "a");
+  let child: { pid: number };
+  try {
+    child = await spawnBackgroundProcess({
+      args: [entryPath],
+      command: nodeCommand,
+      cwd: dirname(entryPath),
+      env: {
+        ...process.env,
+        // Bake in the namespace so headless uses the same namespace as the
+        // tools-pack config regardless of the caller's environment.
+        OD_NAMESPACE: config.namespace,
+        // Point the headless data root at the tools-pack runtime directory so
+        // the identity marker is written to the path this function polls.
+        // headless.ts computes: join(OD_DATA_DIR, "namespaces") which must
+        // equal config.roots.runtime.namespaceBaseRoot.
+        OD_DATA_DIR: dirname(config.roots.runtime.namespaceBaseRoot),
+        OD_RESOURCE_ROOT: paths.resourceRoot,
+      },
+      logFd: logHandle.fd,
+    });
+  } finally {
+    // Close the parent-side handle; the child has already inherited the fd.
+    await logHandle.close().catch(() => undefined);
+  }
+
+  const markerPath = desktopIdentityPath(config);
+  const ready = await waitForMarker(markerPath, 35_000);
+  if (!ready) {
+    await teardownOrphanedStart(child.pid).catch(() => undefined);
+    throw new Error(`headless identity marker not written within 35s at ${markerPath}`);
+  }
+
+  return {
+    launcherPath: headlessLauncherPath(config),
+    logPath,
+    namespace: config.namespace,
+    pid: child.pid,
+  };
+}
+
+export async function stopPackedLinuxHeadless(config: ToolPackConfig): Promise<LinuxStopResult> {
+  const { fallback, marker } = await readDesktopRootIdentityMarker(config);
+
+  if (marker == null) {
+    return {
+      fallback,
+      gracefulRequested: false,
+      namespace: config.namespace,
+      remainingPids: [],
+      status: "not-running",
+      stoppedPids: [],
+    };
+  }
+
+  const snapshots = await listProcessSnapshots();
+  const candidate = snapshots.find((s) => s.pid === marker.pid);
+  if (candidate == null) {
+    return {
+      fallback: { ...fallback, reason: "marker-pid-not-running" },
+      gracefulRequested: false,
+      namespace: config.namespace,
+      remainingPids: [],
+      status: "not-running",
+      stoppedPids: [],
+    };
+  }
+
+  // Validate the stamp. Headless writes source=PACKAGED; skip the AppImage
+  // process-command check used by stopPackedLinuxApp since the headless entry
+  // is a plain Node process, not an AppImage.
+  const expectedIpc = resolveAppIpcPath({
+    app: APP_KEYS.DESKTOP,
+    contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+    namespace: config.namespace,
+  });
+  const stampOk =
+    marker.stamp.app === APP_KEYS.DESKTOP &&
+    marker.stamp.mode === SIDECAR_MODES.RUNTIME &&
+    marker.stamp.namespace === config.namespace &&
+    marker.stamp.ipc === expectedIpc &&
+    marker.stamp.source === SIDECAR_SOURCES.PACKAGED;
+
+  if (!stampOk || marker.namespaceRoot !== config.roots.runtime.namespaceRoot) {
+    return {
+      fallback: {
+        ...fallback,
+        marker: { pid: marker.pid, stamp: marker.stamp },
+        processCommand: candidate.command,
+        reason: "marker-validation-failed",
+      },
+      gracefulRequested: false,
+      namespace: config.namespace,
+      remainingPids: [marker.pid],
+      status: "unmanaged",
+      stoppedPids: [],
+    };
+  }
+
+  let gracefulRequested = false;
+  try {
+    await requestJsonIpc(marker.stamp.ipc, { type: SIDECAR_MESSAGES.SHUTDOWN }, { timeoutMs: 1500 });
+    gracefulRequested = true;
+  } catch {
+    gracefulRequested = false;
+  }
+
+  const treePids = collectProcessTreePids(snapshots, [marker.pid]);
+  const result = await stopProcesses(treePids);
+
+  if (result.remainingPids.length === 0) {
+    await rm(desktopIdentityPath(config), { force: true }).catch(() => undefined);
+  }
+
+  return {
+    gracefulRequested,
+    namespace: config.namespace,
+    remainingPids: result.remainingPids,
+    status: result.remainingPids.length === 0 ? "stopped" : "partial",
+    stoppedPids: result.stoppedPids,
+  };
+}
 
 export async function cleanupPackedLinuxNamespace(config: ToolPackConfig): Promise<LinuxCleanupResult> {
   const stop = await stopPackedLinuxApp(config);

--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -1092,16 +1092,32 @@ function webIdentityPath(config: ToolPackConfig): string {
   return join(config.roots.runtime.namespaceRoot, "runtime", "web-root.json");
 }
 
-async function waitForWebIdentity(config: ToolPackConfig, timeoutMs: number): Promise<WebRootIdentity | null> {
+function isValidWebIdentity(
+  identity: unknown,
+  namespace: string,
+  pid: number,
+): identity is WebRootIdentity {
+  if (typeof identity !== "object" || identity == null) return false;
+  const obj = identity as Record<string, unknown>;
+  return (
+    obj.version === 1 &&
+    obj.namespace === namespace &&
+    obj.pid === pid &&
+    typeof obj.url === "string" &&
+    obj.url.length > 0
+  );
+}
+
+async function waitForWebIdentity(config: ToolPackConfig, childPid: number, timeoutMs: number): Promise<WebRootIdentity | null> {
   const path = webIdentityPath(config);
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     try {
       const content = await readFile(path, "utf8");
-      const identity = JSON.parse(content) as WebRootIdentity;
-      if (identity.url != null) return identity;
+      const identity = JSON.parse(content);
+      if (isValidWebIdentity(identity, config.namespace, childPid)) return identity;
     } catch {
-      // File doesn't exist yet
+      // File doesn't exist yet or invalid JSON
     }
     await new Promise((r) => setTimeout(r, 100));
   }
@@ -1129,12 +1145,14 @@ export async function installPackedLinuxHeadless(config: ToolPackConfig): Promis
 
   // Write a self-contained launcher script. The namespace is baked in so the
   // launcher name and the runtime namespace always agree. namespace is
-  // pre-sanitized by sidecar-proto to [A-Za-z0-9._-]. OD_DATA_DIR and
-  // OD_RESOURCE_ROOT may still be overridden by the caller's environment.
+  // pre-sanitized by sidecar-proto to [A-Za-z0-9._-]. OD_DATA_DIR is baked
+  // so the headless process writes its runtime data under the same paths that
+  // tools-pack stop/logs expect.
+  const dataDir = dirname(config.roots.runtime.namespaceBaseRoot);
   const script = [
     "#!/bin/sh",
     `# Open Design headless launcher — namespace: ${config.namespace}`,
-    `OD_NAMESPACE=${JSON.stringify(config.namespace)} OD_RESOURCE_ROOT=${JSON.stringify(paths.resourceRoot)} exec ${JSON.stringify(nodePath)} ${JSON.stringify(entryPath)} "$@"`,
+    `OD_NAMESPACE=${JSON.stringify(config.namespace)} OD_DATA_DIR=${JSON.stringify(dataDir)} OD_RESOURCE_ROOT=${JSON.stringify(paths.resourceRoot)} exec ${JSON.stringify(nodePath)} ${JSON.stringify(entryPath)} "$@"`,
   ].join("\n") + "\n";
 
   await writeFile(launcherPath, script, { encoding: "utf8", mode: 0o755 });
@@ -1160,9 +1178,10 @@ export async function startPackedLinuxHeadless(config: ToolPackConfig): Promise<
   await mkdir(dirname(logPath), { recursive: true });
   await writeFile(logPath, "", "utf8");
 
-  // Remove stale identity marker from a previous run so waitForMarker below
-  // waits for the newly spawned process.
+  // Remove stale identity markers from a previous run so waitForMarker and
+  // waitForWebIdentity below wait for the newly spawned process.
   await rm(desktopIdentityPath(config), { force: true }).catch(() => undefined);
+  await rm(webIdentityPath(config), { force: true }).catch(() => undefined);
 
   // Open the log file so stdout/stderr from the headless process are captured.
   const logHandle = await open(logPath, "a");
@@ -1198,7 +1217,7 @@ export async function startPackedLinuxHeadless(config: ToolPackConfig): Promise<
     throw new Error(`headless identity marker not written within 35s at ${markerPath}`);
   }
 
-  const webIdentity = await waitForWebIdentity(config, 60_000);
+  const webIdentity = await waitForWebIdentity(config, child.pid, 60_000);
   if (webIdentity == null) {
     await teardownOrphanedStart(child.pid).catch(() => undefined);
     throw new Error(`web-root.json not written within 60s at ${webIdentityPath(config)}`);
@@ -1284,6 +1303,7 @@ export async function stopPackedLinuxHeadless(config: ToolPackConfig): Promise<L
 
   if (result.remainingPids.length === 0) {
     await rm(desktopIdentityPath(config), { force: true }).catch(() => undefined);
+    await rm(webIdentityPath(config), { force: true }).catch(() => undefined);
   }
 
   return {

--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -1077,7 +1077,36 @@ export type LinuxHeadlessStartResult = {
   logPath: string;
   namespace: string;
   pid: number;
+  status: WebRootIdentity | null;
 };
+
+type WebRootIdentity = {
+  namespace: string;
+  pid: number;
+  url: string;
+  startedAt: string;
+  version: 1;
+};
+
+function webIdentityPath(config: ToolPackConfig): string {
+  return join(config.roots.runtime.namespaceRoot, "runtime", "web-root.json");
+}
+
+async function waitForWebIdentity(config: ToolPackConfig, timeoutMs: number): Promise<WebRootIdentity | null> {
+  const path = webIdentityPath(config);
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const content = await readFile(path, "utf8");
+      const identity = JSON.parse(content) as WebRootIdentity;
+      if (identity.url != null) return identity;
+    } catch {
+      // File doesn't exist yet
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  return null;
+}
 
 export async function installPackedLinuxHeadless(config: ToolPackConfig): Promise<LinuxHeadlessInstallResult> {
   const paths = resolveLinuxPaths(config);
@@ -1166,11 +1195,14 @@ export async function startPackedLinuxHeadless(config: ToolPackConfig): Promise<
     throw new Error(`headless identity marker not written within 35s at ${markerPath}`);
   }
 
+  const webIdentity = await waitForWebIdentity(config, 60_000);
+
   return {
     launcherPath: headlessLauncherPath(config),
     logPath,
     namespace: config.namespace,
     pid: child.pid,
+    status: webIdentity,
   };
 }
 

--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -1077,7 +1077,7 @@ export type LinuxHeadlessStartResult = {
   logPath: string;
   namespace: string;
   pid: number;
-  status: WebRootIdentity | null;
+  status: WebRootIdentity;
 };
 
 type WebRootIdentity = {
@@ -1128,7 +1128,8 @@ export async function installPackedLinuxHeadless(config: ToolPackConfig): Promis
   await mkdir(dirname(launcherPath), { recursive: true });
 
   // Write a self-contained launcher script. The namespace is baked in so the
-  // launcher name and the runtime namespace always agree. OD_DATA_DIR and
+  // launcher name and the runtime namespace always agree. namespace is
+  // pre-sanitized by sidecar-proto to [A-Za-z0-9._-]. OD_DATA_DIR and
   // OD_RESOURCE_ROOT may still be overridden by the caller's environment.
   const script = [
     "#!/bin/sh",
@@ -1141,6 +1142,8 @@ export async function installPackedLinuxHeadless(config: ToolPackConfig): Promis
   return { launcherPath, namespace: config.namespace };
 }
 
+// Waits up to 35s for the desktop identity marker, then up to 60s for the
+// web identity (95s total).
 export async function startPackedLinuxHeadless(config: ToolPackConfig): Promise<LinuxHeadlessStartResult> {
   const paths = resolveLinuxPaths(config);
   const entryPath = resolveHeadlessEntryPath(paths);
@@ -1196,6 +1199,10 @@ export async function startPackedLinuxHeadless(config: ToolPackConfig): Promise<
   }
 
   const webIdentity = await waitForWebIdentity(config, 60_000);
+  if (webIdentity == null) {
+    await teardownOrphanedStart(child.pid).catch(() => undefined);
+    throw new Error(`web-root.json not written within 60s at ${webIdentityPath(config)}`);
+  }
 
   return {
     launcherPath: headlessLauncherPath(config),


### PR DESCRIPTION
## Summary

Adds headless mode for Linux packaging — allows running daemon + web without Electron for environments without desktop like WSL.

## Changes

- New `headless.mjs` entry point — Node-only runtime that spawns daemon and web sidecars without the Electron shell
- `--headless` flag on `tools-pack linux install/start/stop` to operate on the headless entry instead of the AppImage
- Shell launcher scripts installed to `~/.local/bin/open-design-headless-<namespace>` with baked-in namespace and resource paths
- `web-root.json` identity file written at startup with the web URL, replacing IPC polling for status — `tools-pack` reads the file directly instead of hammering the sidecar with ~200 status requests
- `start --headless` returns the web URL in the result payload so callers know where to connect
- `stop --headless` validates the packaged stamp and sends a graceful SHUTDOWN over IPC, then terminates the process tree

## Related Issue

- Fixes #503

## Testing

- [x] Built with `pnpm tools-pack linux build --to dir`
- [x] Installed headless with `pnpm tools-pack linux install --headless`
- [x] Started headless process with `pnpm tools-pack linux start --headless`
- [x] Verified web URL returned in start result
- [x] Verified `web-root.json` written to runtime directory
- [x] Stopped headless with `pnpm tools-pack linux stop --headless`
- [x] Verified logs accessible via `pnpm tools-pack linux logs`


<img width="1705" height="1029" alt="image" src="https://github.com/user-attachments/assets/f88a136e-2fcb-4268-a941-89fb70102027" />
