### PR TITLE
fix(web): add clear success feedback after saving API keys in Setting…

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -244,10 +244,13 @@ export function App() {
     setTemplates(list);
   }, []);
 
-  const handleConfigSave = useCallback((next: AppConfig) => {
-    // Saving from any settings dialog (welcome or regular) counts as
-    // having completed onboarding — the user has actively chosen a
-    // configuration, so future page loads can skip the auto-popup.
+  const handleConfigSave = useCallback(async (next: AppConfig) => {
+    // Persist the raw Composio key to the daemon first. If the write fails,
+    // bail without touching local state so we never report a false positive.
+    const composioSuccess = await syncComposioConfigToDaemon(next.composio);
+    if (!composioSuccess) {
+      return { success: false };
+    }
     const withOnboarding: AppConfig = {
       ...next,
       composio: normalizeSavedComposioConfig(next.composio),
@@ -258,11 +261,8 @@ export function App() {
       force: true,
     });
     void syncConfigToDaemon(withOnboarding);
-    // Keep the Composio secret out of localStorage, but send the raw pending
-    // edit to the daemon before it is normalized away for local persistence.
-    void syncComposioConfigToDaemon(next.composio);
     setConfig(withOnboarding);
-    setSettingsOpen(false);
+    return { success: true };
   }, []);
 
   const handleModeChange = useCallback(

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -49,7 +49,7 @@ interface Props {
   appVersionInfo: AppVersionInfo | null;
   welcome?: boolean;
   initialSection?: SettingsSection;
-  onSave: (cfg: AppConfig) => void;
+  onSave: (cfg: AppConfig) => Promise<{ success: boolean }> | void;
   onClose: () => void;
   onRefreshAgents: (
     options?: AgentRefreshOptions,
@@ -326,6 +326,8 @@ export function SettingsDialog({
   const [agentRescanRunning, setAgentRescanRunning] = useState(false);
   const [agentRescanNotice, setAgentRescanNotice] =
     useState<RescanNotice | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveSuccess, setSaveSuccess] = useState(false);
   const languageRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -1014,7 +1016,7 @@ export function SettingsDialog({
           {activeSection === 'media' ? <MediaProvidersSection cfg={cfg} setCfg={setCfg} /> : null}
           {activeSection === 'integrations' ? <IntegrationsSection /> : null}
 
-          {activeSection === 'composio' ? <ComposioSection cfg={cfg} setCfg={setCfg} /> : null}
+          {activeSection === 'composio' ? <ComposioSection cfg={cfg} setCfg={setCfg} saveSuccess={saveSuccess} setSaveSuccess={setSaveSuccess} /> : null}
 
           {activeSection === 'language' ? (
           <section className="settings-section">
@@ -1161,10 +1163,34 @@ export function SettingsDialog({
           <button
             type="button"
             className="primary"
-            disabled={!canSave}
-            onClick={() => onSave(cfg)}
+            disabled={!canSave || isSaving}
+            onClick={async () => {
+              setIsSaving(true);
+              setSaveSuccess(false);
+              const result = await onSave(cfg);
+              setIsSaving(false);
+              if (!result?.success) return;
+              if (activeSection === 'composio' && !welcome) {
+                setSaveSuccess(true);
+                setCfg((curr) => {
+                  const apiKey = curr.composio?.apiKey?.trim();
+                  if (!apiKey) return curr;
+                  return {
+                    ...curr,
+                    composio: {
+                      ...curr.composio,
+                      apiKey: '',
+                      apiKeyConfigured: true,
+                      apiKeyTail: apiKey.slice(-4),
+                    },
+                  };
+                });
+              } else {
+                onClose();
+              }
+            }}
           >
-            {welcome ? t('settings.getStarted') : t('common.save')}
+            {isSaving ? 'Saving...' : (welcome ? t('settings.getStarted') : t('common.save'))}
           </button>
         </footer>
       </div>
@@ -1175,9 +1201,13 @@ export function SettingsDialog({
 function ComposioSection({
   cfg,
   setCfg,
+  saveSuccess,
+  setSaveSuccess,
 }: {
   cfg: AppConfig;
   setCfg: Dispatch<SetStateAction<AppConfig>>;
+  saveSuccess: boolean;
+  setSaveSuccess: (v: boolean) => void;
 }) {
   const composio = cfg.composio ?? {};
 
@@ -1222,24 +1252,34 @@ function ComposioSection({
             type="password"
             value={composio.apiKey ?? ''}
             placeholder={isSavedState ? 'Paste a new key to replace the saved one' : 'Paste Composio API key'}
-            onChange={(e) => updateComposio({ apiKey: e.target.value })}
+            onChange={(e) => {
+              setSaveSuccess(false);
+              updateComposio({ apiKey: e.target.value });
+            }}
             aria-describedby="composio-api-key-help"
           />
           <button
             type="button"
             className="ghost"
             disabled={!apiKeyConfigured}
-            onClick={() => updateComposio({ apiKey: '', apiKeyConfigured: false, apiKeyTail: '' })}
+            onClick={() => {
+              setSaveSuccess(false);
+              updateComposio({ apiKey: '', apiKeyConfigured: false, apiKeyTail: '' });
+            }}
           >
             Clear
           </button>
         </div>
         <span id="composio-api-key-help" className="hint">
-          {isSavedState
-            ? 'Your key stays in the local daemon. Paste a new key above to replace it, or Clear to remove.'
-            : apiKeyConfigured
-              ? 'Unsaved changes — click Save to store this key in the local daemon.'
-              : 'Keys are stored locally in the daemon and never sent through environment variables.'}
+          {saveSuccess ? (
+            <span role="status" className="success-hint">✓ API key saved successfully</span>
+          ) : hasPendingEdit ? (
+            'Unsaved changes — click Save to store this key in the local daemon.'
+          ) : isSavedState ? (
+            'Your key stays in the local daemon. Paste a new key above to replace it, or Clear to remove.'
+          ) : (
+            'Keys are stored locally in the daemon and never sent through environment variables.'
+          )}
         </span>
       </label>
     </section>

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -292,19 +292,21 @@ export async function fetchComposioConfigFromDaemon(): Promise<AppConfig['compos
 
 export async function syncComposioConfigToDaemon(
   config: AppConfig['composio'] | undefined,
-): Promise<void> {
+): Promise<boolean> {
   const apiKey = config?.apiKey ?? '';
   const payload = {
     ...(apiKey.trim() || !config?.apiKeyConfigured ? { apiKey } : {}),
   };
   try {
-    await fetch('/api/connectors/composio/config', {
+    const response = await fetch('/api/connectors/composio/config', {
       method: 'PUT',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(payload),
     });
+    return response.ok;
   } catch {
     // Daemon offline; localStorage keeps the user's copy for the next save.
+    return false;
   }
 }
 


### PR DESCRIPTION
## Summary
This PR addresses issue #654, which highlighted a critical usability friction point: when saving an API key under **Settings > Connectors**, the modal closed immediately without providing any confirmation signal. This lack of feedback left users guessing whether their credentials had been written successfully to the background daemon.

To resolve this, we have refactored the save process to be fully asynchronous. The settings modal now remains open during the save operation, displays a loading state on the save button, and renders a clear inline success status once the configuration has been safely persisted.

---

## Before vs. After Comparison

| UX Behavior | Before This PR | After This PR |
| :--- | :--- | :--- |
| **Save Mechanism** | Fire-and-forget sync function. | Awaited async Promise. |
| **Modal Behavior** | Closes instantly upon clicking "Save". | Remains open to display transition states. |
| **Button State** | Remains static during save. | Disables and shows "Saving..." during write. |
| **User Feedback** | Zero inline or toast confirmation. | Explicit message: "API key saved successfully" (role="status"). |
| **Dirty State Handling**| Only resets badge on reload. | Resets immediately on success; clears message if edited. |

---

## Root Cause & Architectural Changes

In the previous implementation, the save action handled by `handleConfigSave` in `App.tsx` kicked off background synchronization tasks (like `syncComposioConfigToDaemon`) but instantly closed the modal synchronously:

```typescript
// Previous implementation in App.tsx (synchronous auto-close)
saveConfig(withOnboarding);
void syncComposioConfigToDaemon(next.composio);
setSettingsOpen(false); // Closed before daemon write completed