### PR TITLE
docs+web: surface @nexudotio X account in README + entry sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
   <a href="#design-systems"><img alt="Design systems" src="https://img.shields.io/badge/design%20systems-72-orange?style=flat-square" /></a>
   <a href="#skills"><img alt="Skills" src="https://img.shields.io/badge/skills-31-teal?style=flat-square" /></a>
   <a href="https://discord.gg/qhbcCH8Am4"><img alt="Discord" src="https://img.shields.io/badge/discord-join-5865F2?style=flat-square&logo=discord&logoColor=white" /></a>
+  <a href="https://x.com/nexudotio"><img alt="Follow @nexudotio on X" src="https://img.shields.io/badge/follow-%40nexudotio-1DA1F2?style=flat-square&logo=x&logoColor=white" /></a>
   <a href="QUICKSTART.md"><img alt="Quickstart" src="https://img.shields.io/badge/quickstart-3%20commands-green?style=flat-square" /></a>
 </p>
 
@@ -823,6 +824,10 @@ Phased delivery → [`docs/roadmap.md`](docs/roadmap.md).
 ## Status
 
 This is an early implementation — the closed loop (detect → pick skill + design system → chat → parse `<artifact>` → preview → save) runs end-to-end. The prompt stack and skill library are where most of the value lives, and they're stable. The component-level UI is shipping daily.
+
+## Stay in the loop
+
+Follow **[@nexudotio](https://x.com/nexudotio)** on X for release notes, new skills, new design systems, and the occasional behind-the-scenes thread on what's shipping next. Discord is for chat, X is for the milestones — both links are in the badges above.
 
 ## Star us
 

--- a/apps/web/src/components/EntryView.tsx
+++ b/apps/web/src/components/EntryView.tsx
@@ -558,6 +558,17 @@ export function EntryView({
               {envMetaLine}
             </span>
           </button>
+          <a
+            className="foot-pill"
+            href="https://x.com/nexudotio"
+            target="_blank"
+            rel="noreferrer noopener"
+            title="Follow @nexudotio on X for releases and milestones"
+            aria-label="Follow @nexudotio on X"
+          >
+            <Icon name="external-link" size={12} />
+            <span>Follow @nexudotio</span>
+          </a>
           <LanguageMenu />
         </div>
         <button


### PR DESCRIPTION
## What this PR does

Surfaces the official X account [`@nexudotio`](https://x.com/nexudotio) in **three** places so visitors can subscribe to release notes and milestone threads in one click:

1. **README header badge** — adds an X follow badge next to Discord (same `flat-square` style).
2. **README "Stay in the loop" section** — a 2-sentence section right above `Star us` distinguishing the channels: *Discord is for chat, X is for the milestones.*
3. **Web app entry sidebar** — adds a `Follow @nexudotio` pill to `entry-side-foot` (same `.foot-pill` style as the existing Pet / Settings / Language pills). Opens X in a new tab with `rel="noreferrer noopener"`.

## Why now

- We're approaching 30K stars and posting milestone threads + release notes on X (`@nexudotio`). Currently neither the README nor the desktop client links to that channel — people who star the repo or install the app have no easy way to follow the project on socials.
- Discord is great for live conversation but doesn't surface release-style updates well. Having both channels discoverable lets each one do what it's good at.

## Implementation notes

- **README**: 5 lines added, 0 removed.
- **Web app**: reuses the existing `.foot-pill` CSS (already supports `<a>` with `text-decoration: none`) and the existing `external-link` Icon — no new CSS, no new icon, no new i18n key required (single short English label, consistent with how the other foot pills are minimalist).
- 2 commits, 16 lines added total, only `README.md` and `apps/web/src/components/EntryView.tsx` touched.

## What is *not* changed

- No content removed or reordered.
- No copy edits to other sections.
- No new images or assets — README badge uses [shields.io](https://shields.io) like the rest of the header.