### PR TITLE
fix(daemon): surface OpenCode error frames + treat empty-output runs as failed

### DIFF
--- a/apps/daemon/src/json-event-stream.ts
+++ b/apps/daemon/src/json-event-stream.ts
@@ -83,11 +83,22 @@ function handleOpenCodeEvent(obj, onEvent, state) {
   }
 
   if (obj.type === 'error') {
+    // OpenCode emits structured error frames on stdout (e.g. provider auth
+    // failures, network errors, schema mismatches) and still exits 0. Surface
+    // them as proper `error` events so server.ts's `sendAgentEvent` wrapper
+    // can flip the run to `failed` and forward a visible SSE error to the
+    // chat UI. Previously we downgraded these to `type:'raw'`, which is not
+    // rendered as an assistant message — the run looked like a fast clean
+    // success while the user actually got nothing back. See issue #691.
+    //
+    // Shape mirrors the qoder-stream contract (`{type, message, raw}`) so
+    // the daemon's existing error-handling path (server.ts:4156-4168)
+    // recognises it without further wiring.
     const message =
       (obj.error && typeof obj.error === 'object' && obj.error.data?.message) ||
       (obj.error && typeof obj.error === 'object' && obj.error.name) ||
       'OpenCode error';
-    onEvent({ type: 'raw', line: stringifyContent({ type: 'error', message }) });
+    onEvent({ type: 'error', message, raw: stringifyContent(obj) });
     return true;
   }
 

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -4154,6 +4154,26 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
     // plain streams (most other CLIs) we forward raw chunks unchanged so
     // the browser can append them to the assistant's text buffer.
     let agentStreamError = null;
+    // Tracks whether any stream the run is using actually emitted user-
+    // visible content. Only the streams routed through `sendAgentEvent`
+    // contribute to this flag; ACP sessions and plain stdout streams are
+    // covered by their own success/failure paths and the empty-output
+    // guard below skips them via `trackingSubstantiveOutput`.
+    let agentProducedOutput = false;
+    let trackingSubstantiveOutput = false;
+    // Event types that count as "the agent actually produced something the
+    // user can see." Lifecycle markers (`status`) and meter readings
+    // (`usage`) deliberately do NOT count — a model can emit token-usage
+    // numbers for an empty completion (issue #691), and a `status:running`
+    // banner without any follow-up is exactly the silent-failure shape we
+    // want to surface as failed instead of succeeded.
+    const SUBSTANTIVE_AGENT_EVENT_TYPES = new Set([
+      'text_delta',
+      'thinking_delta',
+      'tool_use',
+      'tool_result',
+      'artifact',
+    ]);
     const sendAgentEvent = (ev) => {
       if (ev?.type === 'error') {
         if (agentStreamError) return;
@@ -4164,6 +4184,9 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
         }));
         return;
       }
+      if (ev?.type && SUBSTANTIVE_AGENT_EVENT_TYPES.has(ev.type)) {
+        agentProducedOutput = true;
+      }
       send('agent', ev);
     };
 
@@ -4172,6 +4195,7 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
       child.stdout.on('data', (chunk) => claude.feed(chunk));
       child.on('close', () => claude.flush());
     } else if (def.streamFormat === 'qoder-stream-json') {
+      trackingSubstantiveOutput = true;
       const qoder = createQoderStreamHandler(sendAgentEvent);
       child.stdout.on('data', (chunk) => qoder.feed(chunk));
       child.on('close', () => qoder.flush());
@@ -4197,9 +4221,15 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
         send,
       });
     } else if (def.streamFormat === 'json-event-stream') {
+      // Pipe through sendAgentEvent so the OpenCode `type:'error'` frame
+      // (now emitted as a real error event by json-event-stream.ts after
+      // #691) actually triggers `agentStreamError` instead of being
+      // forwarded as a no-op `agent` SSE event. This also wires the
+      // substantive-output tracking the close handler reads below.
+      trackingSubstantiveOutput = true;
       const handler = createJsonEventStreamHandler(
         def.eventParser || def.id,
-        (ev) => send('agent', ev),
+        sendAgentEvent,
       );
       child.stdout.on('data', (chunk) => handler.feed(chunk));
       child.on('close', () => handler.flush());
@@ -4225,6 +4255,28 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
       }
       if (agentStreamError) {
         return design.runs.finish(run, 'failed', code ?? 1, signal ?? null);
+      }
+      // Empty-output guard: a clean `code === 0` exit on a stream we are
+      // tracking, with no error frame and no substantive event, means the
+      // run silently finished without producing anything visible. That used
+      // to be marked `succeeded` and rendered as an empty assistant turn —
+      // see issue #691, where OpenCode runs were ending in ~3s with no
+      // chat content and no error banner. Surface an explicit failure
+      // instead so the chat shows a clear reason. ACP sessions and plain
+      // stdout streams are gated out via `trackingSubstantiveOutput`;
+      // their success/failure determination lives elsewhere.
+      if (
+        code === 0 &&
+        !run.cancelRequested &&
+        trackingSubstantiveOutput &&
+        !agentProducedOutput
+      ) {
+        send('error', createSseErrorPayload(
+          'AGENT_EXECUTION_FAILED',
+          'Agent completed without producing any output. The model or provider may have returned an empty response — check the agent logs for upstream errors.',
+          { retryable: true },
+        ));
+        return design.runs.finish(run, 'failed', code, signal);
       }
       const status = run.cancelRequested
         ? 'canceled'

--- a/apps/daemon/tests/json-event-stream.test.ts
+++ b/apps/daemon/tests/json-event-stream.test.ts
@@ -65,6 +65,70 @@ test('unknown json stream lines become raw events', () => {
   assert.deepEqual(events, [{ type: 'raw', line: 'not-json' }]);
 });
 
+// Regression coverage for #691: OpenCode emits structured error frames on
+// stdout while still exiting 0. The parser must surface them as proper
+// `error` events (matching the qoder-stream contract) so server.ts's
+// `sendAgentEvent` flips the run to `failed` and forwards a visible SSE
+// error to the chat. Previously these were downgraded to `type:'raw'`,
+// which the chat UI doesn't render — the run looked like a fast clean
+// success while the user actually got nothing back.
+test('opencode json stream surfaces error frames as proper error events (regression of #691)', () => {
+  const events = [];
+  const handler = createJsonEventStreamHandler('opencode', (event) => events.push(event));
+
+  const errorLine = JSON.stringify({
+    type: 'error',
+    error: {
+      name: 'ProviderError',
+      data: { message: 'Authentication expired — please re-login.' },
+    },
+  });
+  handler.feed(errorLine + '\n');
+
+  assert.deepEqual(events, [
+    {
+      type: 'error',
+      message: 'Authentication expired — please re-login.',
+      raw: errorLine,
+    },
+  ]);
+});
+
+test('opencode json stream falls back to error.name when error.data.message is absent', () => {
+  const events = [];
+  const handler = createJsonEventStreamHandler('opencode', (event) => events.push(event));
+
+  const errorLine = JSON.stringify({
+    type: 'error',
+    error: { name: 'NetworkError' },
+  });
+  handler.feed(errorLine + '\n');
+
+  assert.deepEqual(events, [
+    {
+      type: 'error',
+      message: 'NetworkError',
+      raw: errorLine,
+    },
+  ]);
+});
+
+test('opencode json stream falls back to a generic message when error has no usable detail', () => {
+  const events = [];
+  const handler = createJsonEventStreamHandler('opencode', (event) => events.push(event));
+
+  const errorLine = JSON.stringify({ type: 'error', error: {} });
+  handler.feed(errorLine + '\n');
+
+  assert.deepEqual(events, [
+    {
+      type: 'error',
+      message: 'OpenCode error',
+      raw: errorLine,
+    },
+  ]);
+});
+
 test('gemini stream emits init text and usage events', () => {
   const events = [];
   const handler = createJsonEventStreamHandler('gemini', (event) => events.push(event));


### PR DESCRIPTION
## Summary

Closes [#691](https://github.com/nexu-io/open-design/issues/691). OpenCode runs would silently complete in ~3 seconds without producing any visible chat output and still be rendered as a successful turn — three independent bugs along the structured-stream path conspired to produce this silent-failure shape. Fix lands all three at the right layer with full live-traffic validation.

PR description == post-mortem for whoever audits the next stream adapter that hits the same shape.

cc @lefarcen — your diagnosis on [#691](https://github.com/nexu-io/open-design/issues/691#issuecomment-) cited the exact file:line for two of the three bugs; this implements that plus the empty-output guard you flagged in the third bullet.

## Root cause (three independent bugs)

### Bug 1 — \`apps/daemon/src/json-event-stream.ts:85-91\`

OpenCode emits structured error frames on stdout (provider auth failures, network errors, schema mismatches) and still exits 0. The parser was downgrading these to \`{type: 'raw', line: ...}\`, which the chat UI does not render as an assistant message. The error string was effectively discarded.

**Fix:** emit a proper \`{type: 'error', message, raw}\` event matching the qoder-stream contract that the daemon's existing error-handling path already recognises (server.ts:4156-4168).

### Bug 2 — \`apps/daemon/src/server.ts:4199-4205\`

Even with Bug 1 fixed, the json-event-stream branch wired the parser to a bare \`(ev) => send('agent', ev)\` lambda — bypassing the \`sendAgentEvent\` wrapper that interprets \`type:'error'\` and sets the \`agentStreamError\` flag the close handler reads to flip the run to \`failed\`. So an emitted \`error\` event would just be forwarded as a no-op \`agent\` SSE event with no lifecycle effect.

**Fix:** route json-event-stream through \`sendAgentEvent\`, mirroring the qoder-stream-json wiring at line 4175.

### Bug 3 — \`apps/daemon/src/server.ts:4220-4234\` (the empty-output case)

Even with Bugs 1 and 2 fixed, there's still a class of runs where the upstream emits no error frame, no substantive event, and exits 0. Pre-fix this was marked \`succeeded\` and the user saw a blank chat with no diagnostic.

**Fix:** track \`agentProducedOutput\` inside \`sendAgentEvent\` (set on \`text_delta\`, \`thinking_delta\`, \`tool_use\`, \`tool_result\`, \`artifact\` — deliberately NOT on \`status\` / \`usage\`, since a model can emit token-usage numbers for an empty completion). When the close handler sees \`code === 0 && trackingSubstantiveOutput && !agentProducedOutput\`, the run is marked \`failed\` with an explicit \`AGENT_EXECUTION_FAILED\` SSE error so the chat shows a clear reason instead of an empty success.

The check is gated by \`trackingSubstantiveOutput\` so it only fires on streams that actually contribute to the output flag — currently \`qoder-stream-json\` and \`json-event-stream\`. ACP sessions and plain stdout streams keep their existing success/failure determination.

## Live verification

Verified end-to-end via a stub \`opencode\` binary against \`pnpm tools-dev run web\` for all three failure shapes:

| Scenario | Pre-fix | Post-fix |
|---|---|---|
| Stub emits \`{"type":"error",...}\` + exit 0 | \`succeeded\`, empty chat | \`failed\`, OpenCode error message surfaced as SSE \`error\` event |
| Stub emits nothing + exit 0 | \`succeeded\`, empty chat | \`failed\`, \"Agent completed without producing any output…\" diagnostic |
| Stub emits normal \`step_start\` / \`text\` / \`step_finish\` + exit 0 | \`succeeded\` | \`succeeded\` (regression check, no behaviour change) |

The exit code is propagated correctly in all three cases (the actual code from the child process, not a placeholder).

## Test plan

- [x] **Unit tests**: 3 new cases in \`apps/daemon/tests/json-event-stream.test.ts\` pin the OpenCode error event shape — full repro (\`error.data.message\`), \`error.name\` fallback, and the generic-fallback shape when \`error\` is empty.
- [x] \`pnpm --filter @open-design/daemon test\` — 60 files / 851 tests pass.
- [x] \`pnpm --filter @open-design/web test\` — 42 files / 309 tests pass.
- [x] \`pnpm typecheck\` (full repo) clean after \`pnpm --filter @open-design/daemon build\` + \`pnpm --filter @open-design/desktop build\` to seed the workspace dist outputs.
- [x] **Live e2e** as documented above.

## Out of scope (called out for the next person who audits this surface)

- **claude-stream-json / copilot-stream-json** still wire to a bare \`(ev) => send('agent', ev)\` and don't currently parse \`type:'error'\` frames. If their CLIs ever start emitting structured error events the same pattern (route through \`sendAgentEvent\` + emit proper \`type:'error'\`) applies. Not in scope here because we have no evidence those CLIs do this today, and changing the wiring without a confirmed failure mode risks regressing currently-working flows.
- **ACP sessions** (\`pi-rpc\`, \`acp-json-rpc\`) own their own success/failure determination via \`acpSession?.hasFatalError()\` and the empty-output guard explicitly skips them via \`trackingSubstantiveOutput\`.
- **Plain stdout streams** have no event-level tracking, so the empty-output guard skips them too. Diagnosing a no-output plain-stream agent is a separate problem that needs different signals (probably stderr inspection or stdout-byte-count tracking).