### PR TITLE
fix: fix link handling in example preview iframe sandbox

### DIFF
--- a/apps/web/src/components/PreviewModal.tsx
+++ b/apps/web/src/components/PreviewModal.tsx
@@ -389,7 +389,7 @@ export function PreviewModal({
                 <iframe
                   key={activeView?.id ?? 'view'}
                   title={`${title} ${activeView?.label ?? ''}`}
-                  sandbox="allow-scripts"
+                  sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
                   srcDoc={srcDoc}
                 />
               </div>

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -166,20 +166,28 @@ function injectSandboxShim(doc: string): string {
     var isAnchor = href.startsWith('#') || href === '';
     if (isAnchor) {
       e.preventDefault();
-      var targetId = href.slice(1);
-      var target = targetId ? document.getElementById(targetId) : null;
-      if (target) {
-        target.scrollIntoView();
-        location.hash === href && history.replaceState(null, '', ' ');
-        location.hash = href;
+      if (href === '' || href === '#') {
+        window.scrollTo({ top: 0 });
+        history.replaceState(null, '', ' ');
+      } else {
+        var targetId = href.slice(1);
+        var target = targetId ? document.getElementById(targetId) : null;
+        if (target) {
+          target.scrollIntoView();
+          location.hash === href && history.replaceState(null, '', ' ');
+          location.hash = href;
+        }
       }
     } else if (link.getAttribute('target') === '_blank') {
       e.preventDefault();
       let safe = false;
       try {
         var url = new URL(href, location.href);
-        safe = url.protocol === 'http:' || url.protocol === 'https:' || url.protocol === 'mailto:';
-      } catch(_) {}
+        safe =
+          url.protocol === 'http:' ||
+          url.protocol === 'https:' ||
+          url.protocol === 'mailto:';
+      } catch (_) {}
       safe && window.open(href, '_blank', 'noopener,noreferrer');
     }
   });

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -159,16 +159,28 @@ function injectSandboxShim(doc: string): string {
   tryShim('sessionStorage');
   document.addEventListener('click', (e) => {
     if (!e.target || !(e.target instanceof Element)) return;
-    const link = e.target.closest('a[href]');
+    var link = e.target.closest('a[href]');
     if (!link) return;
-    const href = link.getAttribute('href');
-    const isAnchor = href.startsWith('#') || href === '';
+    var href = link.getAttribute('href');
+    if (href === null) return;
+    var isAnchor = href.startsWith('#') || href === '';
     if (isAnchor) {
       e.preventDefault();
-      location.hash = href;
-    } else if (link.target === '_blank') {
+      var targetId = href.slice(1);
+      var target = targetId ? document.getElementById(targetId) : null;
+      if (target) {
+        target.scrollIntoView();
+        location.hash === href && history.replaceState(null, '', ' ');
+        location.hash = href;
+      }
+    } else if (link.getAttribute('target') === '_blank') {
       e.preventDefault();
-      window.open(href, '_blank', 'noopener,noreferrer');
+      let safe = false;
+      try {
+        var url = new URL(href, location.href);
+        safe = url.protocol === 'http:' || url.protocol === 'https:' || url.protocol === 'mailto:';
+      } catch(_) {}
+      safe && window.open(href, '_blank', 'noopener,noreferrer');
     }
   });
 })();</script>`;

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -129,6 +129,10 @@ function escapeAttr(value: string): string {
 // becomes a static, unnavigable preview. We install a same-origin
 // in-memory shim BEFORE any user script runs so those decks degrade
 // gracefully (position just doesn't persist across reloads).
+// allow-popups and allow-popups-to-escape-sandbox are needed for 
+// links with target="_blank" to work in the sandboxed preview.
+// Empty hrefs and hash only hrefs will be intercepted and ignored.
+// hrefs leading to an id on the page will be scrolled into view.
 function injectSandboxShim(doc: string): string {
   const shim = `<script data-od-sandbox-shim>(function(){
   function makeStore(){
@@ -153,6 +157,26 @@ function injectSandboxShim(doc: string): string {
   }
   tryShim('localStorage');
   tryShim('sessionStorage');
+  document.addEventListener('click', (e) => {
+    const link = e.target.closest('a[href]');
+    if (!link) return;
+    const href = link.getAttribute('href');
+    const rel = link.getAttribute('rel');
+    const isAnchor = href.startsWith('#') || href === ';
+    if (isAnchor) {
+      e.preventDefault();
+      document
+        .getElementById(href.slice(1))
+        ?.scrollIntoView();
+    } else if (link.target === '_blank') {
+      e.preventDefault();
+      if (rel === 'noopener noreferrer') {
+        window.open(href, '_blank');
+      } else {
+          window.open(href, '_blank', 'noopener,noreferrer');
+      }
+    }
+  });
 })();</script>`;
   if (/<head[^>]*>/i.test(doc))
     return doc.replace(/<head[^>]*>/i, (m) => `${m}${shim}`);

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -158,23 +158,17 @@ function injectSandboxShim(doc: string): string {
   tryShim('localStorage');
   tryShim('sessionStorage');
   document.addEventListener('click', (e) => {
+    if (!e.target || !(e.target instanceof Element)) return;
     const link = e.target.closest('a[href]');
     if (!link) return;
     const href = link.getAttribute('href');
-    const rel = link.getAttribute('rel');
     const isAnchor = href.startsWith('#') || href === '';
     if (isAnchor) {
       e.preventDefault();
-      document
-        .getElementById(href.slice(1))
-        ?.scrollIntoView();
+      location.hash = href;
     } else if (link.target === '_blank') {
       e.preventDefault();
-      if (rel === 'noopener noreferrer') {
-        window.open(href, '_blank');
-      } else {
-          window.open(href, '_blank', 'noopener,noreferrer');
-      }
+      window.open(href, '_blank', 'noopener,noreferrer');
     }
   });
 })();</script>`;

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -162,7 +162,7 @@ function injectSandboxShim(doc: string): string {
     if (!link) return;
     const href = link.getAttribute('href');
     const rel = link.getAttribute('rel');
-    const isAnchor = href.startsWith('#') || href === ';
+    const isAnchor = href.startsWith('#') || href === '';
     if (isAnchor) {
       e.preventDefault();
       document

--- a/apps/web/tests/components/PreviewModal.test.tsx
+++ b/apps/web/tests/components/PreviewModal.test.tsx
@@ -20,7 +20,7 @@ describe('PreviewModal sandbox isolation', () => {
       />,
     );
 
-    expect(markup).toContain('sandbox="allow-scripts"');
+    expect(markup).toContain('sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"');
     expect(markup).not.toContain('allow-same-origin');
     expect(markup).toContain('srcDoc=');
   });
@@ -42,8 +42,28 @@ describe('PreviewModal sandbox isolation', () => {
       />,
     );
 
-    expect(markup).toContain('sandbox="allow-scripts"');
+    expect(markup).toContain('sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"');
     expect(markup).not.toContain('allow-same-origin');
     expect(markup).toContain('od:slide');
+  });
+
+  it('includes popup flags in the sandbox attribute', () => {
+    const markup = renderToStaticMarkup(
+      <PreviewModal
+        title="Popup preview"
+        views={[
+          {
+            id: 'popup',
+            label: 'Popup',
+            html: '<button onclick="window.open(\'https://example.com\')">Open Popup</button>',
+          },
+        ]}
+        exportTitleFor={() => 'popup-preview'}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(markup).toContain('allow-popups');
+    expect(markup).toContain('allow-popups-to-escape-sandbox');
   });
 });


### PR DESCRIPTION
## Fix #660 Examples preview iframe link navigation bug

### Fixes

- Added a click interceptor inside the preview iframe
- Anchor links (`href="#"`, `href="#section"`) scroll correctly within the preview, smooth scrolling works if enabled
- Links with `target="_blank"` are safely opened in a new tab, aided by adding the following iframe sandbox options:
	-  ` allow-popups allow-popups-to-escape-sandbox` 	 