### PR TITLE
chore(i18n): backfill de/ru/fr fallbacks for social-media-dashboard + totality-festival

### DIFF
--- a/apps/web/src/i18n/content.fr.ts
+++ b/apps/web/src/i18n/content.fr.ts
@@ -320,6 +320,7 @@ export const FR_SKILL_IDS_WITH_EN_FALLBACK = [
   'orbit-gmail',
   'orbit-linear',
   'orbit-notion',
+  'social-media-dashboard',
   'web-prototype-taste-brutalist',
   'web-prototype-taste-editorial',
   'web-prototype-taste-soft',
@@ -388,6 +389,7 @@ export const FR_DESIGN_SYSTEM_IDS_WITH_EN_FALLBACK = [
   'spacious',
   'storytelling',
   'tetris',
+  'totality-festival',
   'vibrant',
   'vintage',
 ] as const;

--- a/apps/web/src/i18n/content.ru.ts
+++ b/apps/web/src/i18n/content.ru.ts
@@ -320,6 +320,7 @@ export const RU_SKILL_IDS_WITH_EN_FALLBACK = [
   'orbit-gmail',
   'orbit-linear',
   'orbit-notion',
+  'social-media-dashboard',
   'web-prototype-taste-brutalist',
   'web-prototype-taste-editorial',
   'web-prototype-taste-soft',
@@ -388,6 +389,7 @@ export const RU_DESIGN_SYSTEM_IDS_WITH_EN_FALLBACK = [
   'spacious',
   'storytelling',
   'tetris',
+  'totality-festival',
   'vibrant',
   'vintage',
 ] as const;

--- a/apps/web/src/i18n/content.ts
+++ b/apps/web/src/i18n/content.ts
@@ -369,6 +369,7 @@ const DE_SKILL_IDS_WITH_EN_FALLBACK = [
   'orbit-gmail',
   'orbit-linear',
   'orbit-notion',
+  'social-media-dashboard',
   'web-prototype-taste-brutalist',
   'web-prototype-taste-editorial',
   'web-prototype-taste-soft',
@@ -437,6 +438,7 @@ const DE_DESIGN_SYSTEM_IDS_WITH_EN_FALLBACK = [
   'spacious',
   'storytelling',
   'tetris',
+  'totality-festival',
   'vibrant',
   'vintage',
 ] as const;


### PR DESCRIPTION
## Summary

[PR #678](https://github.com/nexu-io/open-design/pull/678) added the \`social-media-dashboard\` skill and the \`totality-festival\` design system to \`skills/\` and \`design-systems/\`, but didn't register them in any of the three localized content files. \`main\` has been red since the #678 merge — \`e2e/tests/localized-content.test.ts\` fails for \`de\` / \`ru\` / \`fr\` with:

\`\`\`
AssertionError: skills display copy: expected
  [ 'audio-jingle', 'blog-post', …(67) ]
  to deeply equal
  [ 'audio-jingle', 'blog-post', …(68) ]
\`\`\`

This blocks CI on every open PR — for example [PR #700](https://github.com/nexu-io/open-design/pull/700) (the #691 OpenCode error-frame fix), which is daemon-only and has nothing to do with i18n. @lefarcen called this out [in #700's review](https://github.com/nexu-io/open-design/pull/700#issuecomment-) and suggested either backfilling the locale files or temporarily skipping the failing test. This PR takes the backfill path so main goes green for everyone.

## Changes

Six entries across three files, all in the same shape as the existing pattern:

| File | Skill fallback | Design-system fallback |
|---|---|---|
| \`apps/web/src/i18n/content.ts\` (DE) | + \`'social-media-dashboard'\` | + \`'totality-festival'\` |
| \`apps/web/src/i18n/content.ru.ts\` | + \`'social-media-dashboard'\` | + \`'totality-festival'\` |
| \`apps/web/src/i18n/content.fr.ts\` | + \`'social-media-dashboard'\` | + \`'totality-festival'\` |

## Why fallback rather than full localization

The codebase already has a documented \"registered but not yet translated\" pattern: the \`*_SKILL_IDS_WITH_EN_FALLBACK\` / \`*_DESIGN_SYSTEM_IDS_WITH_EN_FALLBACK\` arrays. 7 existing skills (the \`orbit-*\` Orbit briefing templates, \`html-ppt-taste-*\`, \`web-prototype-taste-*\`) and the bulk of the design systems are already handled this way in de/ru/fr. The picker falls back to the English title + summary at render time, so users still see something coherent.

Translations are deliberately left as a follow-up for whichever native speakers triage this surface — the EN fallback isn't \"missing state,\" it's the documented contract for \"registered, English-only for now.\" If maintainers want full de/ru/fr copy for these two entries, that's a separate PR with native review.

## Test plan

- [x] \`pnpm --filter @open-design/e2e exec vitest run tests/localized-content.test.ts\` — **6/6 pass** (was 3/6 before).
- [x] \`pnpm --filter @open-design/web typecheck\` — clean.
- [x] \`pnpm --filter @open-design/web test\` — 42 files / 309 tests pass.

After merge, [PR #700](https://github.com/nexu-io/open-design/pull/700)'s CI should auto-go-green on rebase and unblock its review.