### PR TITLE
add OpenRouter provider preset

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -141,7 +141,7 @@ Both modes feed the **same** `<artifact>` parser and the **same** sandboxed ifra
 
 ### OpenRouter API mode
 
-OpenRouter uses the OpenAI-compatible API path. In **Settings -> Execution -> API mode**, choose **OpenAI**, pick **OpenRouter** from quick-fill providers, paste an OpenRouter API key, and select a model such as `openai/gpt-5.2` or `openrouter/auto`.
+OpenRouter uses the OpenAI-compatible API path. Create an API key from [OpenRouter Keys](https://openrouter.ai/settings/keys), then in **Settings -> Execution -> API mode**, choose **OpenAI**, pick **OpenRouter** from quick-fill providers, paste the key, and select a model such as `openai/gpt-5.2` or `openrouter/auto`.
 
 The preset fills:
 
@@ -149,6 +149,8 @@ The preset fills:
 Base URL: https://openrouter.ai/api/v1
 Model: openai/gpt-5.2
 ```
+
+If you configure OpenRouter manually instead of using the preset, make sure the protocol tab is **OpenAI** before pasting `https://openrouter.ai/api/v1`; the Anthropic and Gemini protocol tabs use different upstream request shapes. OpenRouter 401, 402, or 429 responses usually mean the API key, account credits, free-model availability, or rate limits need attention on the OpenRouter side rather than in Open Design.
 
 ## Prompt composition
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -139,6 +139,17 @@ location /api/ {
 
 Both modes feed the **same** `<artifact>` parser and the **same** sandboxed iframe. The only thing that differs is the transport and the system-prompt delivery (local CLIs have no separate system channel, so the composed prompt is folded into the user message).
 
+### OpenRouter API mode
+
+OpenRouter uses the OpenAI-compatible API path. In **Settings -> Execution -> API mode**, choose **OpenAI**, pick **OpenRouter** from quick-fill providers, paste an OpenRouter API key, and select a model such as `openai/gpt-5.2` or `openrouter/auto`.
+
+The preset fills:
+
+```text
+Base URL: https://openrouter.ai/api/v1
+Model: openai/gpt-5.2
+```
+
 ## Prompt composition
 
 For every send, the app builds a system prompt from three layers and sends it to the provider:

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -140,7 +140,7 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
       'openrouter/auto',
       'anthropic/claude-sonnet-4.5',
       'google/gemini-3-flash-preview',
-      'x-ai/grok-4.1-fast',
+      'x-ai/grok-4',
     ],
   },
   {

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -131,6 +131,19 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
     models: ['gpt-4o', 'gpt-4o-mini', 'o3', 'o4-mini'],
   },
   {
+    label: 'OpenRouter',
+    protocol: 'openai',
+    baseUrl: 'https://openrouter.ai/api/v1',
+    model: 'openai/gpt-5.2',
+    models: [
+      'openai/gpt-5.2',
+      'openrouter/auto',
+      'anthropic/claude-sonnet-4.5',
+      'google/gemini-3-flash-preview',
+      'x-ai/grok-4.1-fast',
+    ],
+  },
+  {
     label: 'Azure OpenAI',
     protocol: 'azure',
     baseUrl: '',

--- a/apps/web/src/state/maxTokens.ts
+++ b/apps/web/src/state/maxTokens.ts
@@ -28,8 +28,12 @@ const OVERRIDES: Record<string, number> = {
   'mimo-v2.5-pro': 32768,
 };
 
+function litellmMaxTokens(model: string): number | undefined {
+  return LITELLM_MODELS[model] ?? LITELLM_MODELS[`openrouter/${model}`];
+}
+
 export function modelMaxTokensDefault(model: string): number {
-  return OVERRIDES[model] ?? LITELLM_MODELS[model] ?? FALLBACK_MAX_TOKENS;
+  return OVERRIDES[model] ?? litellmMaxTokens(model) ?? FALLBACK_MAX_TOKENS;
 }
 
 function isValidOverride(value: number | undefined): value is number {

--- a/apps/web/tests/components/SettingsDialog.test.ts
+++ b/apps/web/tests/components/SettingsDialog.test.ts
@@ -6,6 +6,7 @@ import {
   updateAgentCliEnvValue,
   updateCurrentApiProtocolConfig,
 } from '../../src/components/SettingsDialog';
+import { KNOWN_PROVIDERS } from '../../src/state/config';
 import type { AppConfig } from '../../src/types';
 
 const baseConfig: AppConfig = {
@@ -94,6 +95,17 @@ describe('SettingsDialog API protocol switching', () => {
   });
 
   it('keeps OpenRouter as a selectable OpenAI-compatible provider preset', () => {
+    expect(KNOWN_PROVIDERS).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: 'OpenRouter',
+          protocol: 'openai',
+          baseUrl: 'https://openrouter.ai/api/v1',
+          model: 'openai/gpt-5.2',
+        }),
+      ]),
+    );
+
     const openai = switchApiProtocolConfig(baseConfig, 'openai');
     const next = updateCurrentApiProtocolConfig(openai, {
       baseUrl: 'https://openrouter.ai/api/v1',

--- a/apps/web/tests/components/SettingsDialog.test.ts
+++ b/apps/web/tests/components/SettingsDialog.test.ts
@@ -93,6 +93,22 @@ describe('SettingsDialog API protocol switching', () => {
     });
   });
 
+  it('keeps OpenRouter as a selectable OpenAI-compatible provider preset', () => {
+    const openai = switchApiProtocolConfig(baseConfig, 'openai');
+    const next = updateCurrentApiProtocolConfig(openai, {
+      baseUrl: 'https://openrouter.ai/api/v1',
+      model: 'openai/gpt-5.2',
+      apiProviderBaseUrl: 'https://openrouter.ai/api/v1',
+    });
+
+    expect(next).toMatchObject({
+      apiProtocol: 'openai',
+      baseUrl: 'https://openrouter.ai/api/v1',
+      model: 'openai/gpt-5.2',
+      apiProviderBaseUrl: 'https://openrouter.ai/api/v1',
+    });
+  });
+
   it('auto-fills Google defaults when switching from a selected known provider', () => {
     expect(switchApiProtocolConfig(baseConfig, 'google')).toMatchObject({
       mode: 'api',

--- a/apps/web/tests/providers/openai-compatible.test.ts
+++ b/apps/web/tests/providers/openai-compatible.test.ts
@@ -16,6 +16,11 @@ describe('isOpenAICompatible', () => {
     expect(isOpenAICompatible('mimo-v2.5-pro', 'https://token-plan-cn.xiaomimimo.com/v1')).toBe(true);
   });
 
+  it('routes OpenRouter through the OpenAI-compatible chat completions proxy', () => {
+    expect(isOpenAICompatible('openai/gpt-5.2', 'https://openrouter.ai/api/v1')).toBe(true);
+    expect(isOpenAICompatible('openrouter/auto', 'https://openrouter.ai/api/v1')).toBe(true);
+  });
+
   it('routes MiniMax Anthropic endpoint paths away from OpenAI-compatible chat completions', () => {
     expect(isOpenAICompatible('MiniMax-M2.7-highspeed', 'https://api.minimaxi.com/v1/anthropic')).toBe(false);
     expect(isOpenAICompatible('MiniMax-M2.7-highspeed', 'https://api.minimaxi.com/anthropic/v1')).toBe(false);

--- a/apps/web/tests/providers/sse.test.ts
+++ b/apps/web/tests/providers/sse.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { reattachDaemonRun, streamViaDaemon } from '../../src/providers/daemon';
 import { streamMessageOpenAI } from '../../src/providers/openai-compatible';
 import { parseSseFrame } from '../../src/providers/sse';
+import { KNOWN_PROVIDERS } from '../../src/state/config';
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -548,6 +549,47 @@ describe('streamMessageOpenAI', () => {
     expect(fetchMock).toHaveBeenCalledWith('/api/proxy/openai/stream', expect.any(Object));
     expect(handlers.onDelta).toHaveBeenCalledWith('hi');
     expect(handlers.onDone).toHaveBeenCalledWith('hi');
+  });
+
+  it('sends the OpenRouter preset through the OpenAI proxy with its token default', async () => {
+    const openRouter = KNOWN_PROVIDERS.find((provider) => provider.label === 'OpenRouter');
+    if (!openRouter) throw new Error('OpenRouter provider preset missing');
+    const handlers = createStreamHandlers();
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      sseResponse('event: end\ndata: {}\n\n'),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await streamMessageOpenAI(
+      {
+        mode: 'api',
+        apiKey: 'test-key',
+        apiProtocol: 'openai',
+        apiProviderBaseUrl: openRouter.baseUrl,
+        baseUrl: openRouter.baseUrl,
+        model: openRouter.model,
+        agentId: null,
+        skillId: null,
+        designSystemId: null,
+      },
+      '',
+      [{ id: '1', role: 'user', content: 'hello' }],
+      new AbortController().signal,
+      handlers,
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/proxy/openai/stream', expect.objectContaining({
+      body: expect.any(String),
+      method: 'POST',
+    }));
+    const [, init] = fetchMock.mock.calls[0]!;
+    const body = JSON.parse(String((init as RequestInit).body));
+    expect(body).toMatchObject({
+      baseUrl: 'https://openrouter.ai/api/v1',
+      model: 'openai/gpt-5.2',
+      maxTokens: 128000,
+    });
+    expect(handlers.onError).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/tests/state/maxTokens.test.ts
+++ b/apps/web/tests/state/maxTokens.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import litellmData from '../../src/state/litellm-models.json';
+import { KNOWN_PROVIDERS } from '../../src/state/config';
 import {
   effectiveMaxTokens,
   FALLBACK_MAX_TOKENS,
@@ -28,6 +29,16 @@ describe('modelMaxTokensDefault', () => {
   it('returns FALLBACK_MAX_TOKENS for unknown ids', () => {
     expect(modelMaxTokensDefault('definitely-not-a-real-model-x9z')).toBe(FALLBACK_MAX_TOKENS);
     expect(FALLBACK_MAX_TOKENS).toBe(8192);
+  });
+
+  it('normalizes OpenRouter provider model ids to LiteLLM OpenRouter aliases', () => {
+    const openRouter = KNOWN_PROVIDERS.find((provider) => provider.label === 'OpenRouter');
+    expect(openRouter?.models?.length).toBeGreaterThan(0);
+
+    for (const model of openRouter?.models ?? []) {
+      expect((litellmData.models as Record<string, number>)[model]).toBeUndefined();
+      expect(modelMaxTokensDefault(model)).not.toBe(FALLBACK_MAX_TOKENS);
+    }
   });
 });
 


### PR DESCRIPTION
## Why

OpenRouter already works through Open Design's OpenAI-compatible proxy when users know the custom base URL, but it was not available as a quick-fill provider in Settings. Adding a preset makes the existing BYOK path discoverable without introducing a new adapter or dependency.

## What changed

- Added OpenRouter to the known OpenAI-compatible provider presets with `https://openrouter.ai/api/v1` and current model suggestions.
- Documented the OpenRouter API-mode setup in `QUICKSTART.md`.
- Added focused coverage for the OpenRouter preset and OpenAI-compatible routing.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/web test -- apps/web/tests/components/SettingsDialog.test.ts apps/web/tests/providers/openai-compatible.test.ts`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm --filter @open-design/desktop build`
- `pnpm typecheck`