### PR TITLE
fix(web): align design system default test fixture

### DIFF
--- a/apps/web/tests/components/NewProjectPanel.test.tsx
+++ b/apps/web/tests/components/NewProjectPanel.test.tsx
@@ -16,7 +16,7 @@ const skills: SkillSummary[] = [
     mode: 'prototype',
     surface: 'web',
     previewType: 'html',
-    designSystemRequired: false,
+    designSystemRequired: true,
     defaultFor: ['prototype'],
     triggers: [],
     upstream: null,


### PR DESCRIPTION
## Summary
- Updates the NewProjectPanel default design system test fixture so the mocked prototype skill supports design systems.
- Keeps the test focused on default design system selection instead of the separate opt-out picker path.

## Validation
- pnpm --filter @open-design/web test -- tests/components/NewProjectPanel.test.tsx
- pnpm --filter @open-design/web typecheck
- pnpm guard
- pnpm typecheck

Fixes the CI failure from https://github.com/nexu-io/open-design/actions/runs/25453505130/job/74676719692.