### PR TITLE
fix(daemon): handle 0-byte zip entries in claude-design import

### DIFF
--- a/apps/daemon/src/claude-design-import.ts
+++ b/apps/daemon/src/claude-design-import.ts
@@ -102,7 +102,6 @@ function findEndOfCentralDirectory(zip) {
 }
 
 function readEntryBody(zip, entry) {
-  if (entry.uncompressedSize === 0) return Buffer.alloc(0);
   const offset = entry.localOffset;
   if (zip.readUInt32LE(offset) !== LOCAL_SIG) {
     throw new Error(`invalid zip local header: ${entry.name}`);
@@ -112,6 +111,10 @@ function readEntryBody(zip, entry) {
   const bodyStart = offset + 30 + nameLen + extraLen;
   const bodyEnd = bodyStart + entry.compressedSize;
   if (bodyEnd > zip.length) throw new Error(`zip entry exceeds archive: ${entry.name}`);
+  // inflateRawSync throws RangeError when uncompressedSize is 0 (maxOutputLength:0
+  // is invalid) and on an empty deflate stream. Return early after header and bounds
+  // checks so the local-header signature and offset are still validated.
+  if (entry.uncompressedSize === 0) return Buffer.alloc(0);
   const compressed = zip.slice(bodyStart, bodyEnd);
   if (entry.method === 0) return Buffer.from(compressed);
   return inflateRawSync(compressed, { maxOutputLength: entry.uncompressedSize });

--- a/apps/daemon/src/claude-design-import.ts
+++ b/apps/daemon/src/claude-design-import.ts
@@ -102,6 +102,7 @@ function findEndOfCentralDirectory(zip) {
 }
 
 function readEntryBody(zip, entry) {
+  if (entry.uncompressedSize === 0) return Buffer.alloc(0);
   const offset = entry.localOffset;
   if (zip.readUInt32LE(offset) !== LOCAL_SIG) {
     throw new Error(`invalid zip local header: ${entry.name}`);

--- a/apps/daemon/tests/claude-design-import.test.ts
+++ b/apps/daemon/tests/claude-design-import.test.ts
@@ -154,4 +154,31 @@ describe('importClaudeDesignZip', () => {
       );
     });
   });
+
+  it('rejects a 0-byte entry whose local header has an invalid signature', async () => {
+    // Regression: the 0-byte early-return must NOT run before LOCAL_SIG validation.
+    // A malformed archive with a bad localOffset for a 0-byte entry must still be rejected.
+    await withTmpDir(async (dir) => {
+      const valid = buildZip([
+        { name: 'index.html', method: 0, data: Buffer.from('<html></html>', 'utf8') },
+        { name: 'empty.css', method: 8, data: Buffer.alloc(0) },
+      ]);
+      // Corrupt the local-file-header signature of the second entry (empty.css).
+      // The central directory says localOffset points to that header; overwrite
+      // the 4-byte signature with 0x00000000 so LOCAL_SIG check fails.
+      const corrupt = Buffer.from(valid);
+      // Find the second local header: first entry is at offset 0, its local header
+      // is 30 + len("index.html")=10 bytes + data bytes. Signature starts at that offset.
+      const firstLocalSize = 30 + 'index.html'.length + '<html></html>'.length;
+      corrupt.writeUInt32LE(0x00000000, firstLocalSize); // overwrite LOCAL_SIG of entry 2
+
+      const zipPath = path.join(dir, 'corrupt.zip');
+      const outDir = path.join(dir, 'out');
+      await writeFile(zipPath, corrupt);
+
+      await expect(importClaudeDesignZip(zipPath, outDir)).rejects.toThrow(
+        'invalid zip local header',
+      );
+    });
+  });
 });

--- a/apps/daemon/tests/claude-design-import.test.ts
+++ b/apps/daemon/tests/claude-design-import.test.ts
@@ -1,0 +1,157 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { importClaudeDesignZip } from '../src/claude-design-import.js';
+
+// Minimal CRC-32 matching the zip spec.
+function crc32(buf: Buffer): number {
+  const t: number[] = [];
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    t[n] = c >>> 0;
+  }
+  let c = 0xffffffff;
+  for (let i = 0; i < buf.length; i++) c = t[(c ^ buf[i]!) & 0xff]! ^ (c >>> 8);
+  return (c ^ 0xffffffff) >>> 0;
+}
+
+function buildZip(entries: Array<{ name: string; method: 0 | 8; data: Buffer }>): Buffer {
+  const localParts: Buffer[] = [];
+  const centralParts: Buffer[] = [];
+  let localOffset = 0;
+
+  for (const entry of entries) {
+    const name = Buffer.from(entry.name, 'utf8');
+    const { data } = entry;
+    const checksum = crc32(data);
+
+    const local = Buffer.alloc(30 + name.length);
+    local.writeUInt32LE(0x04034b50, 0);
+    local.writeUInt16LE(20, 4);
+    local.writeUInt16LE(0, 6);
+    local.writeUInt16LE(entry.method, 8);
+    local.writeUInt16LE(0, 10);
+    local.writeUInt16LE(0, 12);
+    local.writeUInt32LE(checksum, 14);
+    local.writeUInt32LE(data.length, 18);
+    local.writeUInt32LE(data.length, 22);
+    local.writeUInt16LE(name.length, 26);
+    local.writeUInt16LE(0, 28);
+    name.copy(local, 30);
+    localParts.push(local, data);
+
+    const central = Buffer.alloc(46 + name.length);
+    central.writeUInt32LE(0x02014b50, 0);
+    central.writeUInt16LE(20, 4);
+    central.writeUInt16LE(20, 6);
+    central.writeUInt16LE(0, 8);
+    central.writeUInt16LE(entry.method, 10);
+    central.writeUInt16LE(0, 12);
+    central.writeUInt16LE(0, 14);
+    central.writeUInt32LE(checksum, 16);
+    central.writeUInt32LE(data.length, 20);
+    central.writeUInt32LE(data.length, 24);
+    central.writeUInt16LE(name.length, 28);
+    central.writeUInt16LE(0, 30);
+    central.writeUInt16LE(0, 32);
+    central.writeUInt16LE(0, 34);
+    central.writeUInt16LE(0, 36);
+    central.writeUInt32LE(0, 38);
+    central.writeUInt32LE(localOffset, 42);
+    name.copy(central, 46);
+    centralParts.push(central);
+
+    localOffset += local.length + data.length;
+  }
+
+  const centralBuf = Buffer.concat(centralParts);
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(0, 4);
+  eocd.writeUInt16LE(0, 6);
+  eocd.writeUInt16LE(entries.length, 8);
+  eocd.writeUInt16LE(entries.length, 10);
+  eocd.writeUInt32LE(centralBuf.length, 12);
+  eocd.writeUInt32LE(localOffset, 16);
+  eocd.writeUInt16LE(0, 20);
+
+  return Buffer.concat([...localParts, centralBuf, eocd]);
+}
+
+async function withTmpDir(fn: (dir: string) => Promise<void>) {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'od-zip-test-'));
+  try {
+    await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe('importClaudeDesignZip', () => {
+  it('imports a zip containing a 0-byte entry with deflate method (method=8)', async () => {
+    // Regression: readEntryBody called inflateRawSync(emptyBuffer, { maxOutputLength: 0 })
+    // which throws RangeError. Fix: early-return Buffer.alloc(0) when uncompressedSize === 0.
+    await withTmpDir(async (dir) => {
+      const zip = buildZip([
+        { name: 'index.html', method: 0, data: Buffer.from('<html></html>', 'utf8') },
+        { name: 'empty.css', method: 8, data: Buffer.alloc(0) },
+      ]);
+      const zipPath = path.join(dir, 'test.zip');
+      const outDir = path.join(dir, 'out');
+      await writeFile(zipPath, zip);
+
+      const result = await importClaudeDesignZip(zipPath, outDir);
+      expect(result.entryFile).toBe('index.html');
+      expect(result.files).toContain('empty.css');
+    });
+  });
+
+  it('imports a zip containing a 0-byte stored entry (method=0)', async () => {
+    await withTmpDir(async (dir) => {
+      const zip = buildZip([
+        { name: 'index.html', method: 0, data: Buffer.from('<html></html>', 'utf8') },
+        { name: 'reset.css', method: 0, data: Buffer.alloc(0) },
+      ]);
+      const zipPath = path.join(dir, 'test.zip');
+      const outDir = path.join(dir, 'out');
+      await writeFile(zipPath, zip);
+
+      const result = await importClaudeDesignZip(zipPath, outDir);
+      expect(result.entryFile).toBe('index.html');
+      expect(result.files).toContain('reset.css');
+    });
+  });
+
+  it('resolves index.html as entry file', async () => {
+    await withTmpDir(async (dir) => {
+      const zip = buildZip([
+        { name: 'other.html', method: 0, data: Buffer.from('<html>other</html>', 'utf8') },
+        { name: 'index.html', method: 0, data: Buffer.from('<html>index</html>', 'utf8') },
+      ]);
+      const zipPath = path.join(dir, 'test.zip');
+      const outDir = path.join(dir, 'out');
+      await writeFile(zipPath, zip);
+
+      const result = await importClaudeDesignZip(zipPath, outDir);
+      expect(result.entryFile).toBe('index.html');
+    });
+  });
+
+  it('rejects a zip with no HTML file', async () => {
+    await withTmpDir(async (dir) => {
+      const zip = buildZip([
+        { name: 'styles.css', method: 0, data: Buffer.from('body{}', 'utf8') },
+      ]);
+      const zipPath = path.join(dir, 'test.zip');
+      const outDir = path.join(dir, 'out');
+      await writeFile(zipPath, zip);
+
+      await expect(importClaudeDesignZip(zipPath, outDir)).rejects.toThrow(
+        'zip does not contain an HTML file',
+      );
+    });
+  });
+});


### PR DESCRIPTION
Fixes #590

## Root cause

`readEntryBody` in `apps/daemon/src/claude-design-import.ts` calls `inflateRawSync` when a zip entry uses compression method 8 (deflate). When the entry has `uncompressedSize === 0` (a legitimately empty file), two things go wrong:

1. `inflateRawSync` receives an empty buffer — an invalid deflate stream — and throws.
2. The `maxOutputLength: 0` option passed to `inflateRawSync` is itself invalid and throws a `RangeError`.

ZIP files produced by macOS `zip`, Python's `zipfile`, and other tools include 0-byte entries with `method=8` for empty files. The import silently failed with an unhandled `RangeError` for any such archive.

## Fix

One line added to `readEntryBody`: early-return `Buffer.alloc(0)` when `entry.uncompressedSize === 0`, before touching the local header or calling inflate. The downstream size-mismatch check (`body.length !== entry.uncompressedSize` → `0 !== 0`) remains correct.

```diff
 function readEntryBody(zip, entry) {
+  if (entry.uncompressedSize === 0) return Buffer.alloc(0);
   const offset = entry.localOffset;
```

## Tests

Added `apps/daemon/tests/claude-design-import.test.ts` with a self-contained ZIP builder (no test dependencies added):

- **Regression case**: `method=8`, `uncompressedSize=0` — previously threw `RangeError`, now passes.
- **Stored zero-byte entry**: `method=0`, `uncompressedSize=0` — confirms stored path is unaffected.
- **Entry file selection**: `index.html` preferred over other HTML files.
- **No HTML file rejection**: throws the correct error message.

All 4 tests pass. `pnpm guard` passes. Pre-existing typecheck failures in `src/critique/` are unrelated to this change.