### PR TITLE
fix(daemon): deliver Copilot prompt via stdin to avoid Windows ENAMETOOLONG (#705)

### DIFF
--- a/apps/daemon/src/agents.ts
+++ b/apps/daemon/src/agents.ts
@@ -557,39 +557,52 @@ export const AGENT_DEFS = [
     name: 'GitHub Copilot CLI',
     bin: 'copilot',
     versionArgs: ['--version'],
-    // The prompt is passed directly as the value of `-p`: `copilot -p
-    // "<prompt>" --allow-all-tools --output-format json`. Copilot does NOT
-    // treat `-` as a stdin sentinel — it reads it as a literal one-character
-    // prompt string — so the previous `-p -` + stdin pattern produced a
-    // nonsensical single-dash prompt instead of the composed prompt body.
+    // Prompt is delivered via stdin (gated by `promptViaStdin: true`
+    // below) to avoid Windows `spawn ENAMETOOLONG` (issue #705):
+    // `copilot -p <body>` ships the full composed prompt as a single
+    // argv entry, and CreateProcess caps `lpCommandLine` at ~32 KB
+    // direct or ~8 KB through a `.cmd` shim. Any non-trivial Open
+    // Design prompt blows past that — even a "Hi" expands to several
+    // thousand chars after skills + design-system context are composed
+    // in.
     //
-    // `--allow-all-tools` is required for non-interactive runs: without it
-    // the CLI blocks waiting for human approval on every tool call. Unlike
-    // Codex (where `exec` is a dedicated headless subcommand with
-    // auto-approve baked in) or Claude Code (which inherits its permission
-    // policy from the user's settings.json), Copilot's `-p` mode always
-    // prompts unless this flag is passed explicitly.
+    // The transport is "omit `-p` entirely, pipe the prompt to stdin"
+    // per upstream copilot-cli issue #1046 (closed as already supported,
+    // confirmed working on Copilot CLI for `echo "..." | copilot
+    // --model <id>` and `cat prompt.txt | copilot --model <id>`). The
+    // earlier `-p -` attempt (PR #351) and the argv-bound revert
+    // (PR #466) both pre-dated that confirmation: `-p -` made Copilot
+    // interpret `-` as a literal one-character prompt, but omitting
+    // `-p` entirely is a separate code path that does delegate to
+    // stdin under a non-TTY pipe — which is exactly how the daemon
+    // spawns the child (`stdio: ['pipe', 'pipe', 'pipe']`).
     //
-    // `--output-format json` produces JSONL that copilot-stream.js parses
-    // into the same typed events as claude-stream.js.
+    // `--allow-all-tools` is still required for non-interactive runs:
+    // without it the CLI blocks waiting for human approval on every
+    // tool call. Unlike Codex (where `exec` is a dedicated headless
+    // subcommand with auto-approve baked in) or Claude Code (which
+    // inherits its permission policy from the user's settings.json),
+    // Copilot always prompts unless this flag is passed explicitly.
     //
-    // `--add-dir` (repeatable, same flag as Claude Code's) widens Copilot's
-    // path-level sandbox to skill seeds + design-system specs outside the
-    // project cwd.
+    // `--output-format json` produces JSONL that copilot-stream.js
+    // parses into the same typed events as claude-stream.js.
     //
-    // No `models` subcommand; the CLI accepts whatever the user's Copilot
-    // subscription exposes. Ship a small evidence-based hint list — the
-    // default we observed in the JSON stream and the example from
-    // `copilot --help`. Users can paste any other id via Settings.
+    // `--add-dir` (repeatable, same flag as Claude Code's) widens
+    // Copilot's path-level sandbox to skill seeds + design-system
+    // specs outside the project cwd.
+    //
+    // No `models` subcommand; the CLI accepts whatever the user's
+    // Copilot subscription exposes. Ship a small evidence-based hint
+    // list — the default we observed in the JSON stream and the
+    // example from `copilot --help`. Users can paste any other id via
+    // Settings.
     fallbackModels: [
       DEFAULT_MODEL_OPTION,
       { id: 'claude-sonnet-4.6', label: 'Claude Sonnet 4.6' },
       { id: 'gpt-5.2', label: 'GPT-5.2' },
     ],
-    buildArgs: (prompt, _imagePaths, extraAllowedDirs = [], options = {}) => {
+    buildArgs: (_prompt, _imagePaths, extraAllowedDirs = [], options = {}) => {
       const args = [
-        '-p',
-        prompt,
         '--allow-all-tools',
         '--output-format',
         'json',
@@ -603,7 +616,7 @@ export const AGENT_DEFS = [
       for (const d of dirs) args.push('--add-dir', d);
       return args;
     },
-    promptViaStdin: false,
+    promptViaStdin: true,
     streamFormat: 'copilot-stream-json',
   },
   {

--- a/apps/daemon/tests/agents.test.ts
+++ b/apps/daemon/tests/agents.test.ts
@@ -342,26 +342,35 @@ test('cursor-agent args deliver prompts via stdin without passing a literal dash
   ]);
 });
 
-// Copilot does NOT treat `-` as a stdin sentinel — it reads it as a
-// literal one-character prompt. The prompt must be passed directly as the
-// value of `-p`. Pin the argv shape so the regression can't drift back.
-// Also pin the order — Copilot expects `-p <prompt>` before any other
-// flag, including model / add-dir extensions.
-test('copilot args pass the prompt directly as the -p value (not via stdin sentinel)', () => {
+// Copilot reads the prompt from stdin when `-p` is omitted entirely
+// (upstream copilot-cli issue #1046, confirmed working as
+// `echo "..." | copilot --model <id>`). The earlier `-p -` attempt
+// was a dead end because Copilot takes `-` as a literal one-character
+// prompt; omitting `-p` is a separate code path that does delegate to
+// stdin under a non-TTY pipe. Pin `promptViaStdin: true` and the
+// stdin-only argv shape so a future refactor can't silently bring
+// `-p <prompt>` back and reintroduce the Windows ENAMETOOLONG
+// regression (issue #705).
+test('copilot delivers the prompt via stdin (no -p, no prompt body in argv)', () => {
   const prompt = 'design a landing page';
   const baseArgs = copilot.buildArgs(prompt, [], [], {});
-  assert.equal(baseArgs[0], '-p');
-  assert.equal(baseArgs[1], prompt);
+  assert.equal(copilot.promptViaStdin, true);
+  assert.ok(
+    !baseArgs.includes('-p'),
+    'copilot argv must not include -p; the prompt rides stdin',
+  );
+  assert.ok(
+    !baseArgs.includes(prompt),
+    'copilot argv must not include the prompt body; it rides stdin',
+  );
   assert.deepEqual(baseArgs, [
-    '-p',
-    prompt,
     '--allow-all-tools',
     '--output-format',
     'json',
   ]);
 });
 
-test('copilot args keep `-p <prompt>` at the front when model and extra dirs are added', () => {
+test('copilot args append model and extra dirs after the base flags without reintroducing -p', () => {
   const prompt = 'design a landing page';
   const args = copilot.buildArgs(
     prompt,
@@ -369,11 +378,9 @@ test('copilot args keep `-p <prompt>` at the front when model and extra dirs are
     ['/tmp/od-skills', '/tmp/od-design-systems'],
     { model: 'claude-sonnet-4.6' },
   );
-  assert.equal(args[0], '-p');
-  assert.equal(args[1], prompt);
+  assert.ok(!args.includes('-p'));
+  assert.ok(!args.includes(prompt));
   assert.deepEqual(args, [
-    '-p',
-    prompt,
     '--allow-all-tools',
     '--output-format',
     'json',
@@ -386,7 +393,7 @@ test('copilot args keep `-p <prompt>` at the front when model and extra dirs are
   ]);
 });
 
-test('copilot drops empty / non-string entries from extraAllowedDirs without breaking the `-p <prompt>` lead', () => {
+test('copilot drops empty / non-string entries from extraAllowedDirs without reintroducing -p', () => {
   const prompt = 'design a landing page';
   const args = copilot.buildArgs(
     prompt,
@@ -394,12 +401,36 @@ test('copilot drops empty / non-string entries from extraAllowedDirs without bre
     ['', null, '/tmp/od-skills', undefined],
     {},
   );
-  assert.equal(args[0], '-p');
-  assert.equal(args[1], prompt);
+  assert.ok(!args.includes('-p'));
   // Only the one valid path survives.
   const addDirIndex = args.indexOf('--add-dir');
   assert.equal(args[addDirIndex + 1], '/tmp/od-skills');
   assert.equal(args.filter((a) => a === '--add-dir').length, 1);
+});
+
+// Mirror of the Claude Code 200_000-char synthetic-prompt guard: even
+// when the composed prompt is large enough to blow the Windows
+// CreateProcess command-line cap (~32 KB direct, ~8 KB through a `.cmd`
+// shim), no argv entry must ever carry the prompt body. This is the
+// structural assertion that the issue #705 fix can't quietly regress.
+test('copilot flags promptViaStdin and never embeds the prompt in argv', () => {
+  assert.equal(copilot.promptViaStdin, true);
+
+  const longPrompt = 'x'.repeat(200_000);
+  const args = copilot.buildArgs(longPrompt, [], [], {});
+
+  assert.ok(Array.isArray(args), 'copilot.buildArgs must return argv');
+  assert.equal(
+    args.includes(longPrompt),
+    false,
+    'prompt must not appear in argv',
+  );
+  for (const arg of args) {
+    assert.ok(
+      typeof arg === 'string' && arg.length < 1000,
+      `no argv entry should carry the prompt body (saw length ${arg.length})`,
+    );
+  }
 });
 
 test('kiro args use acp subcommand for json-rpc streaming', () => {


### PR DESCRIPTION
## Summary

- Drops `-p <prompt>` from the GitHub Copilot CLI adapter and sets `promptViaStdin: true`, so the composed prompt rides the existing stdin pipe instead of CreateProcess's `lpCommandLine` (capped at ~32 KB direct, ~8 KB through a `.cmd` shim).
- This unblocks every Windows + Copilot CLI run, which today fails with `spawn ENAMETOOLONG` on any non-trivial prompt — even `"Hi"` expands to several thousand chars after Open Design composes in skills + design-system context (issue #705).
- Tests rewritten to assert the new stdin-only argv shape, plus a mirror of the Claude Code 200_000-char synthetic-prompt guard so no argv entry can ever carry the prompt body again.

Fixes #705.

## Why this transport is correct

The earlier `-p -` attempt (#351) and the argv-bound revert (#466) both pre-dated the upstream confirmation in [github/copilot-cli#1046](https://github.com/github/copilot-cli/issues/1046) (closed January 2026). That issue confirms two stdin-driven invocations work in Copilot CLI:

```bash
echo "1+1" | copilot --model gpt-4.1
cat prompt.txt | copilot --model gpt-4.1
```

The semantics are different from `-p -`:

| Pattern | Behavior |
|---|---|
| `copilot -p <body>` | argv prompt, **fails on Windows for non-trivial prompts** (issue #705) |
| `copilot -p -` | takes `-` as a literal one-character prompt — the dead end PR #466 documented |
| `copilot ...` (no `-p`) + stdin pipe | reads composed prompt from stdin, runs non-interactively — **what this PR uses** |

The daemon already spawns the child with `stdio: ['pipe', 'pipe', 'pipe']` and ends stdin with the composed prompt body when `promptViaStdin: true` (see [`apps/daemon/src/server.ts:4041`](https://github.com/nexu-io/open-design/blob/main/apps/daemon/src/server.ts#L4041)) — exactly the non-TTY pipe shape Copilot's stdin code path expects. `--allow-all-tools`, `--output-format json`, `--model`, and `--add-dir` are all unaffected and continue to ride argv.

## What's verified

| Check | Result |
|---|---|
| `vitest run tests/agents.test.ts` | 78/78 passing |
| `vitest run tests/critique-spawn-wiring.test.ts tests/structured-streams.test.ts` | 14/14 passing |
| `tsc -p apps/daemon/tsconfig.json --noEmit` | clean |

## What's NOT verified

I don't have a Windows host with Copilot CLI to exercise the actual ENAMETOOLONG path end-to-end. The fix relies on the structural argument that:

1. The previous failure was `-p <body>` blowing CreateProcess — the new transport never puts the body on argv.
2. Upstream issue #1046 is the maintainers acknowledging the omit-`-p`-pipe-stdin transport works.
3. The 200_000-char guard test proves no argv entry can carry the prompt body even at synthetic worst-case size.

If a Windows + Copilot CLI tester (e.g. @josemaria-ccr from #705) can run the desktop build with this branch, that closes the loop. Failing that, the inverse signal is also useful — if it doesn't work, I want to know before this lands.

## Test plan

- [x] Existing daemon test suite stays green (agents, spawn-wiring, structured-streams).
- [x] New regression test: 200_000-char synthetic prompt → no argv entry > 1000 chars + `promptViaStdin: true`.
- [ ] Manual smoke on Windows + Copilot CLI 1.0.42: send `"Hi"` and a multi-thousand-char design brief, confirm no ENAMETOOLONG and the JSON stream parses normally.
- [ ] Manual smoke on macOS or Linux + Copilot CLI: confirm no regression in the previously-working argv path.

## Notes on history

- PR #258 standardized stdin delivery, missed Copilot.
- PR #351 tried `-p -` to opt back into stdin — Copilot took `-` literally.
- PR #466 reverted to `-p <body>` argv, which is the state issue #705 surfaces.
- This PR is the third attempt, anchored on the upstream confirmation that omitting `-p` entirely is the working transport.