### PR TITLE
fix(web): replace window.prompt() Save-as-template flow with in-app modal (#723)

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -2031,9 +2031,17 @@ function HtmlViewer({
   const [presentMenuOpen, setPresentMenuOpen] = useState(false);
   const [shareMenuOpen, setShareMenuOpen] = useState(false);
   // Template save UX. We surface a transient "Saved" pill in the share
-  // menu so the user gets feedback without a noisy toast layer.
+  // menu so the user gets feedback without a noisy toast layer. The
+  // modal carries the name + description input because the desktop app
+  // runs in Electron, where `window.prompt()` is disabled by default
+  // and silently returns null — making the previous prompt-based flow
+  // a no-op for every desktop user (issue #723).
   const [savingTemplate, setSavingTemplate] = useState(false);
   const [templateNote, setTemplateNote] = useState<string | null>(null);
+  const [templateModalOpen, setTemplateModalOpen] = useState(false);
+  const [templateName, setTemplateName] = useState('');
+  const [templateDescription, setTemplateDescription] = useState('');
+  const [templateError, setTemplateError] = useState<string | null>(null);
   const [deployment, setDeployment] = useState<DeployProjectFileResponse | null>(null);
   const [deployModalOpen, setDeployModalOpen] = useState(false);
   const [deployConfig, setDeployConfig] = useState<DeployConfigResponse | null>(null);
@@ -2607,33 +2615,48 @@ function HtmlViewer({
   // the viewer), so the template captures the whole design, not a single
   // page. Surfaced here in the Share menu because that's where the user's
   // share / export mental model already lives.
-  async function handleSaveAsTemplate() {
+  function openSaveAsTemplateModal() {
     setShareMenuOpen(false);
     const defaultName =
       file.name.replace(/\.html?$/i, '') || t('fileViewer.templateNameDefault');
-    const name = window.prompt(t('fileViewer.templateNamePrompt'), defaultName);
-    if (!name || !name.trim()) return;
-    const description = window.prompt(
-      t('fileViewer.templateDescPrompt'),
-      '',
-    );
+    setTemplateName(defaultName);
+    setTemplateDescription('');
+    setTemplateError(null);
+    setTemplateNote(null);
+    setTemplateModalOpen(true);
+  }
+
+  async function submitSaveAsTemplate() {
+    const trimmedName = templateName.trim();
+    if (!trimmedName) {
+      // The Save button is also disabled when the name is empty so this
+      // path is normally unreachable, but guard the network call anyway
+      // in case Enter-to-submit fires before the disabled state catches up.
+      return;
+    }
     setSavingTemplate(true);
+    setTemplateError(null);
     setTemplateNote(null);
     try {
       const tpl = await saveTemplate({
-        name: name.trim(),
-        description: description?.trim() || undefined,
+        name: trimmedName,
+        description: templateDescription.trim() || undefined,
         sourceProjectId: projectId,
       });
-      setTemplateNote(
-        tpl
-          ? t('fileViewer.savedTemplate', { name: tpl.name })
-          : t('fileViewer.savedTemplateFail'),
+      if (tpl) {
+        setTemplateModalOpen(false);
+        setTemplateNote(t('fileViewer.savedTemplate', { name: tpl.name }));
+        // Auto-clear the note so the menu doesn't keep stale state next open.
+        setTimeout(() => setTemplateNote(null), 4000);
+      } else {
+        setTemplateError(t('fileViewer.savedTemplateFail'));
+      }
+    } catch (err) {
+      setTemplateError(
+        err instanceof Error ? err.message : t('fileViewer.savedTemplateFail'),
       );
     } finally {
       setSavingTemplate(false);
-      // Auto-clear the note so the menu doesn't keep stale state next open.
-      setTimeout(() => setTemplateNote(null), 4000);
     }
   }
 
@@ -3140,7 +3163,7 @@ function HtmlViewer({
                     role="menuitem"
                     disabled={savingTemplate}
                     onClick={() => {
-                      void handleSaveAsTemplate();
+                      openSaveAsTemplateModal();
                     }}
                   >
                     <span className="share-menu-icon"><Icon name="copy" size={14} /></span>
@@ -3472,6 +3495,71 @@ function HtmlViewer({
                   : deployPhase === 'preparing-link'
                     ? t('fileViewer.preparingPublicLink')
                     : t('fileViewer.deployToVercel')}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+      {templateModalOpen ? (
+        <div className="modal-backdrop" role="presentation">
+          <div className="modal template-modal" role="dialog" aria-modal="true">
+            <div className="modal-head">
+              <h2>{t('fileViewer.templateModalTitle')}</h2>
+            </div>
+            <div className="template-form">
+              <label className="template-field">
+                <span>{t('fileViewer.templateNamePrompt')}</span>
+                <input
+                  type="text"
+                  value={templateName}
+                  placeholder={t('fileViewer.templateNameDefault')}
+                  disabled={savingTemplate}
+                  autoFocus
+                  onChange={(e) => setTemplateName(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && templateName.trim() && !savingTemplate) {
+                      e.preventDefault();
+                      void submitSaveAsTemplate();
+                    }
+                  }}
+                />
+              </label>
+              <label className="template-field">
+                <span>{t('fileViewer.templateDescPrompt')}</span>
+                <textarea
+                  value={templateDescription}
+                  disabled={savingTemplate}
+                  rows={3}
+                  onChange={(e) => setTemplateDescription(e.target.value)}
+                />
+              </label>
+              {templateError ? (
+                <p className="deploy-error">{templateError}</p>
+              ) : null}
+            </div>
+            <div className="modal-foot">
+              <button
+                type="button"
+                className="ghost-link button-like"
+                disabled={savingTemplate}
+                onClick={() => {
+                  setTemplateModalOpen(false);
+                  setTemplateError(null);
+                }}
+              >
+                {t('common.cancel')}
+              </button>
+              <button
+                type="button"
+                className="viewer-action primary"
+                disabled={savingTemplate || !templateName.trim()}
+                onClick={() => {
+                  void submitSaveAsTemplate();
+                }}
+              >
+                {savingTemplate
+                  ? t('fileViewer.savingTemplate')
+                  : t('common.save')}
               </button>
             </div>
           </div>

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -662,6 +662,7 @@ export const ar: Dict = {
   'fileViewer.exportJsx': 'تصدير كـ JSX',
   'fileViewer.exportReactHtml': 'تصدير المعاينة كـ HTML',
   'fileViewer.saveAsTemplate': 'حفظ كقالب...',
+  'fileViewer.templateModalTitle': 'حفظ كقالب',
   'fileViewer.savingTemplate': 'جاري حفظ القالب...',
   'fileViewer.savedTemplate': 'تم الحفظ باسم "{name}"',
   'fileViewer.savedTemplateFail': 'تعذر حفظ القالب - حاول مرة أخرى.',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -618,6 +618,7 @@ export const de: Dict = {
   'fileViewer.exportJsx': 'Als JSX exportieren',
   'fileViewer.exportReactHtml': 'Vorschau als HTML exportieren',
   'fileViewer.saveAsTemplate': 'Als Template speichern…',
+  'fileViewer.templateModalTitle': 'Als Template speichern',
   'fileViewer.savingTemplate': 'Template wird gespeichert…',
   'fileViewer.savedTemplate': 'Als „{name}“ gespeichert',
   'fileViewer.savedTemplateFail': 'Template konnte nicht gespeichert werden — bitte erneut versuchen.',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -677,6 +677,7 @@ export const en: Dict = {
   'fileViewer.exportJsx': 'Export as JSX',
   'fileViewer.exportReactHtml': 'Export preview as HTML',
   'fileViewer.saveAsTemplate': 'Save as template…',
+  'fileViewer.templateModalTitle': 'Save as template',
   'fileViewer.savingTemplate': 'Saving template…',
   'fileViewer.savedTemplate': 'Saved as "{name}"',
   'fileViewer.savedTemplateFail': 'Could not save template — try again.',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -619,6 +619,7 @@ export const esES: Dict = {
   'fileViewer.exportJsx': 'Exportar como JSX',
   'fileViewer.exportReactHtml': 'Exportar vista previa como HTML',
   'fileViewer.saveAsTemplate': 'Guardar como plantilla…',
+  'fileViewer.templateModalTitle': 'Guardar como plantilla',
   'fileViewer.savingTemplate': 'Guardando plantilla…',
   'fileViewer.savedTemplate': 'Guardado como «{name}»',
   'fileViewer.savedTemplateFail': 'No se pudo guardar la plantilla. Inténtalo de nuevo.',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -677,6 +677,7 @@ export const fa: Dict = {
   'fileViewer.exportJsx': 'صادرکردن به JSX',
   'fileViewer.exportReactHtml': 'صادرکردن پیش‌نمایش به HTML',
   'fileViewer.saveAsTemplate': 'ذخیره به عنوان قالب…',
+  'fileViewer.templateModalTitle': 'ذخیره به عنوان قالب',
   'fileViewer.savingTemplate': 'در حال ذخیره قالب…',
   'fileViewer.savedTemplate': 'به عنوان «{name}» ذخیره شد',
   'fileViewer.savedTemplateFail': 'ذخیره قالب ناموفق بود — دوباره امتحان کنید.',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -662,6 +662,7 @@ export const fr: Dict = {
   'fileViewer.exportJsx': 'Exporter en JSX',
   'fileViewer.exportReactHtml': 'Exporter l\'aperçu en HTML',
   'fileViewer.saveAsTemplate': 'Enregistrer comme modèle…',
+  'fileViewer.templateModalTitle': 'Enregistrer comme modèle',
   'fileViewer.savingTemplate': 'Enregistrement du modèle…',
   'fileViewer.savedTemplate': 'Enregistré comme « {name} »',
   'fileViewer.savedTemplateFail': 'Impossible d\'enregistrer le modèle — réessayez.',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -664,6 +664,7 @@ export const hu: Dict = {
   'fileViewer.exportJsx': 'Exportálás JSX-ként',
   'fileViewer.exportReactHtml': 'Előnézet exportálása HTML-ként',
   'fileViewer.saveAsTemplate': 'Mentés sablonként…',
+  'fileViewer.templateModalTitle': 'Mentés sablonként',
   'fileViewer.savingTemplate': 'Sablon mentése…',
   'fileViewer.savedTemplate': 'Mentve „{name}" néven',
   'fileViewer.savedTemplateFail': 'A sablon mentése nem sikerült — próbáld újra.',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -617,6 +617,7 @@ export const ja: Dict = {
   'fileViewer.exportJsx': 'JSX としてエクスポート',
   'fileViewer.exportReactHtml': 'プレビューを HTML としてエクスポート',
   'fileViewer.saveAsTemplate': 'テンプレートとして保存…',
+  'fileViewer.templateModalTitle': 'テンプレートとして保存',
   'fileViewer.savingTemplate': 'テンプレートを保存中…',
   'fileViewer.savedTemplate': '"{name}" として保存しました',
   'fileViewer.savedTemplateFail': 'テンプレートを保存できませんでした — もう一度試してください。',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -664,6 +664,7 @@ export const ko: Dict = {
   'fileViewer.exportJsx': 'JSX로 내보내기',
   'fileViewer.exportReactHtml': '미리보기를 HTML로 내보내기',
   'fileViewer.saveAsTemplate': '템플릿으로 저장…',
+  'fileViewer.templateModalTitle': '템플릿으로 저장',
   'fileViewer.savingTemplate': '템플릿 저장 중…',
   'fileViewer.savedTemplate': '"{name}"(으)로 저장됨',
   'fileViewer.savedTemplateFail': '템플릿 저장에 실패했습니다. 다시 시도해 주세요.',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -664,6 +664,7 @@ export const pl: Dict = {
   'fileViewer.exportJsx': 'Eksportuj jako JSX',
   'fileViewer.exportReactHtml': 'Eksportuj podgląd jako HTML',
   'fileViewer.saveAsTemplate': 'Zapisz jako szablon…',
+  'fileViewer.templateModalTitle': 'Zapisz jako szablon',
   'fileViewer.savingTemplate': 'Zapisywanie szablonu…',
   'fileViewer.savedTemplate': 'Zapisano jako „{name}”',
   'fileViewer.savedTemplateFail': 'Nie udało się zapisać szablonu — spróbuj ponownie.',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -676,6 +676,7 @@ export const ptBR: Dict = {
   'fileViewer.exportJsx': 'Exportar como JSX',
   'fileViewer.exportReactHtml': 'Exportar prévia como HTML',
   'fileViewer.saveAsTemplate': 'Salvar como template…',
+  'fileViewer.templateModalTitle': 'Salvar como template',
   'fileViewer.savingTemplate': 'Salvando template…',
   'fileViewer.savedTemplate': 'Salvo como "{name}"',
   'fileViewer.savedTemplateFail': 'Não foi possível salvar o template — tente novamente.',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -676,6 +676,7 @@ export const ru: Dict = {
   'fileViewer.exportJsx': 'Экспорт как JSX',
   'fileViewer.exportReactHtml': 'Экспорт предпросмотра как HTML',
   'fileViewer.saveAsTemplate': 'Сохранить как шаблон…',
+  'fileViewer.templateModalTitle': 'Сохранить как шаблон',
   'fileViewer.savingTemplate': 'Сохранение шаблона…',
   'fileViewer.savedTemplate': 'Сохранено как «{name}»',
   'fileViewer.savedTemplateFail': 'Не удалось сохранить шаблон — попробуйте снова.',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -656,6 +656,7 @@ export const tr: Dict = {
   'fileViewer.exportJsx': 'JSX olarak dışa aktar',
   'fileViewer.exportReactHtml': 'Önizlemeyi HTML olarak dışa aktar',
   'fileViewer.saveAsTemplate': 'Şablon olarak kaydet…',
+  'fileViewer.templateModalTitle': 'Şablon olarak kaydet',
   'fileViewer.savingTemplate': 'Şablon kaydediliyor…',
   'fileViewer.savedTemplate': '"{name}" olarak kaydedildi',
   'fileViewer.savedTemplateFail': 'Şablon olarak kaydedilemedi — yeniden deneyin.',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -695,6 +695,7 @@ export const uk: Dict = {
   'fileViewer.exportJsx': 'Експортувати як JSX',
   'fileViewer.exportReactHtml': 'Експортувати попередній перегляд як HTML',
   'fileViewer.saveAsTemplate': 'Зберегти як шаблон…',
+  'fileViewer.templateModalTitle': 'Зберегти як шаблон',
   'fileViewer.savingTemplate': 'Збереження шаблону…',
   'fileViewer.savedTemplate': 'Збережено як "{name}"',
   'fileViewer.savedTemplateFail': 'Не вдалося зберегти шаблон — спробуйте ще раз.',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -664,6 +664,7 @@ export const zhCN: Dict = {
   'fileViewer.exportJsx': '导出为 JSX',
   'fileViewer.exportReactHtml': '导出预览 HTML',
   'fileViewer.saveAsTemplate': '保存为模板…',
+  'fileViewer.templateModalTitle': '保存为模板',
   'fileViewer.savingTemplate': '正在保存模板…',
   'fileViewer.savedTemplate': '已保存为「{name}」',
   'fileViewer.savedTemplateFail': '保存模板失败，请重试。',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -664,6 +664,7 @@ export const zhTW: Dict = {
   'fileViewer.exportJsx': '匯出為 JSX',
   'fileViewer.exportReactHtml': '匯出預覽 HTML',
   'fileViewer.saveAsTemplate': '儲存為範本…',
+  'fileViewer.templateModalTitle': '儲存為範本',
   'fileViewer.savingTemplate': '正在儲存範本…',
   'fileViewer.savedTemplate': '已儲存為「{name}」',
   'fileViewer.savedTemplateFail': '儲存範本失敗，請重試。',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -732,6 +732,7 @@ export interface Dict {
   'fileViewer.exportJsx': string;
   'fileViewer.exportReactHtml': string;
   'fileViewer.saveAsTemplate': string;
+  'fileViewer.templateModalTitle': string;
   'fileViewer.savingTemplate': string;
   'fileViewer.savedTemplate': string;
   'fileViewer.savedTemplateFail': string;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6849,6 +6849,37 @@ button.connector-action.is-loading {
   max-height: calc(100vh - 32px);
   overflow: auto;
 }
+/* Template-save modal — replaces the previous window.prompt() flow that
+   silently no-op'd in Electron (issue #723). Tighter width than the
+   deploy modal because there's only two fields. */
+.template-modal {
+  width: min(520px, calc(100vw - 32px));
+}
+.template-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-top: 18px;
+}
+.template-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.template-field input,
+.template-field textarea {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 8px 12px;
+  background: var(--bg-panel);
+  color: var(--text);
+  font: inherit;
+}
+.template-field input { min-height: 36px; }
+.template-field textarea { resize: vertical; min-height: 64px; }
 .deploy-form {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

- The Share menu's `Save as template…` action silently no-op'd in the desktop app. The handler at [`apps/web/src/components/FileViewer.tsx:2610`](https://github.com/nexu-io/open-design/blob/main/apps/web/src/components/FileViewer.tsx#L2610) called `window.prompt()` twice (name then description), but Electron disables `window.prompt()` by default — both calls return `null` synchronously and the handler's `if (!name) return` exits before any visible UI happens. Reporter saw no modal, no loading state, no error: total silence.
- Replace the prompt-driven flow with an in-app modal that mirrors the existing `.deploy-modal` pattern in the same file. The same handler wiring around `saveTemplate()` and the transient "Saved" pill in the share menu is preserved — only the input collection step changes.
- Adds 1 new i18n key (`fileViewer.templateModalTitle`) across all 16 locales; reuses existing `templateNamePrompt` / `templateNameDefault` / `templateDescPrompt` strings as the field labels and default value, so no translator churn beyond the new title.

Fixes #723.

## Why `window.prompt()` is the wrong primitive here

| | Browser dev | Electron desktop (shipped app) |
|---|---|---|
| `window.prompt()` returns | a string or null | **always null** (silently disabled) |
| Visible to user | yes | nothing |

Electron disables `window.prompt()` by default with no documented opt-in (Chromium upstream removed the dialog and Electron has not re-added it). The result for any handler that does `const x = window.prompt(...); if (!x) return;` is a guaranteed silent no-op for every desktop user — exactly what #723 reports.

## Scope of the change

| File | What changes |
|---|---|
| `apps/web/src/components/FileViewer.tsx` | Add modal state (`templateModalOpen`, `templateName`, `templateDescription`, `templateError`); split `handleSaveAsTemplate` into `openSaveAsTemplateModal()` (opens the modal, seeds defaults) and `submitSaveAsTemplate()` (the previous async save call, now driven by modal state); add modal JSX after the deploy modal. |
| `apps/web/src/i18n/types.ts` | Declare `'fileViewer.templateModalTitle': string` on `Dict`. |
| `apps/web/src/i18n/locales/*.ts` (16 files) | Add per-locale translation, derived from the existing `saveAsTemplate` value minus the trailing ellipsis. |
| `apps/web/src/index.css` | Add minimal `.template-modal` / `.template-form` / `.template-field` rules — reuses the shared `.modal-backdrop` / `.modal` / `.modal-head` / `.modal-foot` shell. |

19 files changed, +153 / −17.

## What's verified

| Check | Result |
|---|---|
| `pnpm --filter @open-design/web typecheck` | clean |
| `pnpm --filter @open-design/web test tests/components/FileViewer.test.tsx` | 9/9 passing |
| `tsx scripts/i18n-check.ts` | passes |
| Live `pnpm tools-dev run web` boot | clean (no console / build errors) |
| `.template-modal` / `.template-form` / `.template-field` rules in live stylesheet | yes (verified by reading `document.styleSheets`) |
| `fileViewer.templateModalTitle` key in compiled JS bundle | yes (verified by fetching script chunks) |
| Residual `window.prompt(t('fileViewer.templateNamePrompt'), …)` callsites in compiled JS | **0** (regex grep across all 32 emitted chunks) |

## What's NOT verified

The bug only reproduces in the **packaged Electron desktop app** (`window.prompt()` works fine in any normal browser, including the dev server). I don't have a desktop build pipeline set up, so I can't end-to-end exercise "click Save as template → see the modal → enter a name → see the saved pill" in a real Electron environment from here. The structural argument is:

1. The legacy callsite is gone from the compiled bundle (verified above).
2. The new modal renders from React state, with no `window.prompt()` / `window.confirm()` involvement at all.
3. The deploy modal in the same file uses the identical class shell and works in Electron today.

If a desktop tester (e.g. someone running a fresh build of #723's branch) can confirm the menu item now opens the modal, that closes the loop end-to-end.

## Out-of-scope follow-up

`apps/web/src/components/SketchEditor.tsx:129` has the same Electron `window.prompt()` regression for the sketch "add text" tool. That's the only other `window.prompt()` callsite in the web app. Tracking it separately so this PR stays focused on the FileViewer Share menu the issue reports — happy to follow up with a second PR using the same modal pattern.

## Test plan

- [x] Existing FileViewer test suite stays green.
- [x] Web typecheck + i18n-check pass.
- [x] Bundle/CSS verification: new rules and i18n key present in live build, legacy `window.prompt(…templateNamePrompt…)` callsite gone.
- [ ] Manual smoke on the desktop build: open a project → open a generated file → Share → `Save as template…` → expect the new modal (with name / description fields) instead of nothing.
- [ ] Visual check that the modal sizing + spacing matches the rest of the Open Design modal language across light + dark themes.