### PR TITLE
fix(web): replace SketchEditor window.prompt() text tool with in-app modal

### DIFF
--- a/apps/web/src/components/SketchEditor.tsx
+++ b/apps/web/src/components/SketchEditor.tsx
@@ -73,6 +73,13 @@ export function SketchEditor({
   const [size, setSize] = useState(2);
   const drawingRef = useRef<SketchItem | null>(null);
   const [, force] = useState(0);
+  // Text-tool modal. Replaces window.prompt() because Electron 28+
+  // disables that API by default and silently returns null, making
+  // the text tool a no-op in the desktop app. Same root cause as
+  // issue #723 (FileViewer's Save-as-template flow).
+  const [textModalOpen, setTextModalOpen] = useState(false);
+  const [textModalValue, setTextModalValue] = useState('');
+  const textAnchorRef = useRef<{ x: number; y: number } | null>(null);
 
   // Resize canvas to its container while keeping a high DPR for crisp lines.
   useEffect(() => {
@@ -126,13 +133,11 @@ export function SketchEditor({
     const pos = pointerPos(e);
 
     if (tool === 'text') {
-      const text = window.prompt(t('sketch.textPrompt'));
-      if (text) {
-        onItemsChange([
-          ...items,
-          { kind: 'text', x: pos.x, y: pos.y, text, color, size: 16 + size * 4 },
-        ]);
-      }
+      // Stash the click position and open the modal. The actual TextItem is
+      // appended in submitTextModal, once the user confirms.
+      textAnchorRef.current = pos;
+      setTextModalValue('');
+      setTextModalOpen(true);
       return;
     }
 
@@ -187,6 +192,28 @@ export function SketchEditor({
   }
   function handleClear() {
     onItemsChange([]);
+  }
+
+  function submitTextModal() {
+    const text = textModalValue.trim();
+    const anchor = textAnchorRef.current;
+    if (!text || !anchor) {
+      cancelTextModal();
+      return;
+    }
+    onItemsChange([
+      ...items,
+      { kind: 'text', x: anchor.x, y: anchor.y, text, color, size: 16 + size * 4 },
+    ]);
+    setTextModalOpen(false);
+    setTextModalValue('');
+    textAnchorRef.current = null;
+  }
+
+  function cancelTextModal() {
+    setTextModalOpen(false);
+    setTextModalValue('');
+    textAnchorRef.current = null;
   }
 
   return (
@@ -250,6 +277,46 @@ export function SketchEditor({
           style={{ touchAction: 'none' }}
         />
       </div>
+      {textModalOpen ? (
+        <div className="modal-backdrop" role="presentation">
+          <div className="modal" role="dialog" aria-modal="true">
+            <div className="modal-head">
+              <h2>{t('sketch.textModalTitle')}</h2>
+            </div>
+            <label>
+              <span>{t('sketch.textPrompt')}</span>
+              <input
+                type="text"
+                value={textModalValue}
+                autoFocus
+                onChange={(e) => setTextModalValue(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && textModalValue.trim()) {
+                    e.preventDefault();
+                    submitTextModal();
+                  } else if (e.key === 'Escape') {
+                    e.preventDefault();
+                    cancelTextModal();
+                  }
+                }}
+              />
+            </label>
+            <div className="modal-foot">
+              <button type="button" className="ghost" onClick={cancelTextModal}>
+                {t('common.cancel')}
+              </button>
+              <button
+                type="button"
+                className="primary"
+                disabled={!textModalValue.trim()}
+                onClick={submitTextModal}
+              >
+                {t('common.save')}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -801,6 +801,7 @@ export const ar: Dict = {
   'sketch.clear': 'مسح',
   'sketch.close': 'إغلاق',
   'sketch.textPrompt': 'النص:',
+  'sketch.textModalTitle': 'إضافة نص',
 
   'pet.title': 'الحيوانات الأليفة',
   'pet.subtitle': 'تبنَّ رفيقاً صغيراً يطفو فوق مساحة عملك.',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -757,6 +757,7 @@ export const de: Dict = {
   'sketch.clear': 'Leeren',
   'sketch.close': 'Schließen',
   'sketch.textPrompt': 'Text:',
+  'sketch.textModalTitle': 'Text hinzufügen',
 
   'pet.title': 'Haustiere',
   'pet.tabBuiltIn': 'Vorgegeben',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -834,6 +834,7 @@ export const en: Dict = {
   'sketch.clear': 'Clear',
   'sketch.close': 'Close',
   'sketch.textPrompt': 'Text:',
+  'sketch.textModalTitle': 'Add text',
 
   'pet.title': 'Pets',
   'pet.subtitle': 'Adopt a tiny companion that floats over your workspace.',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -758,6 +758,7 @@ export const esES: Dict = {
   'sketch.clear': 'Limpiar',
   'sketch.close': 'Cerrar',
   'sketch.textPrompt': 'Texto:',
+  'sketch.textModalTitle': 'Añadir texto',
 
   'pet.title': 'Mascotas',
   'pet.tabBuiltIn': 'Integradas',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -835,6 +835,7 @@ export const fa: Dict = {
   'sketch.clear': 'پاک کردن',
   'sketch.close': 'بستن',
   'sketch.textPrompt': 'متن:',
+  'sketch.textModalTitle': 'افزودن متن',
 
   'pet.title': 'حیوان خانگی',
   'pet.tabBuiltIn': 'پیش‌فرض',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -801,6 +801,7 @@ export const fr: Dict = {
   'sketch.clear': 'Effacer',
   'sketch.close': 'Fermer',
   'sketch.textPrompt': 'Texte :',
+  'sketch.textModalTitle': 'Ajouter du texte',
 
   'pet.title': 'Compagnons',
   'pet.subtitle': 'Adoptez un petit compagnon qui flotte au-dessus de votre espace de travail.',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -803,6 +803,7 @@ export const hu: Dict = {
   'sketch.clear': 'Törlés',
   'sketch.close': 'Bezárás',
   'sketch.textPrompt': 'Szöveg:',
+  'sketch.textModalTitle': 'Szöveg hozzáadása',
 
   'pet.title': 'Háziállatok',
   'pet.subtitle': 'Fogadj be egy apró társat, aki a munkaterületed felett lebeg.',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -756,6 +756,7 @@ export const ja: Dict = {
   'sketch.clear': 'クリア',
   'sketch.close': '閉じる',
   'sketch.textPrompt': 'テキスト:',
+  'sketch.textModalTitle': 'テキストを追加',
 
   'pet.title': 'ペット',
   'pet.tabBuiltIn': '組み込み',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -803,6 +803,7 @@ export const ko: Dict = {
   'sketch.clear': '모두 지우기',
   'sketch.close': '닫기',
   'sketch.textPrompt': '텍스트:',
+  'sketch.textModalTitle': '텍스트 추가',
 
   'pet.title': '펫',
   'pet.tabBuiltIn': '내장',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -803,6 +803,7 @@ export const pl: Dict = {
   'sketch.clear': 'Wyczyść',
   'sketch.close': 'Zamknij',
   'sketch.textPrompt': 'Tekst:',
+  'sketch.textModalTitle': 'Dodaj tekst',
 
   'pet.title': 'Pupile',
   'pet.tabBuiltIn': 'Wbudowane',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -833,6 +833,7 @@ export const ptBR: Dict = {
   'sketch.clear': 'Limpar',
   'sketch.close': 'Fechar',
   'sketch.textPrompt': 'Texto:',
+  'sketch.textModalTitle': 'Adicionar texto',
 
   'pet.title': 'Bichinhos',
   'pet.tabBuiltIn': 'Inclusos',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -833,6 +833,7 @@ export const ru: Dict = {
   'sketch.clear': 'Очистить',
   'sketch.close': 'Закрыть',
   'sketch.textPrompt': 'Текст:',
+  'sketch.textModalTitle': 'Добавить текст',
 
   'pet.title': 'Питомцы',
   'pet.tabBuiltIn': 'Встроенные',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -795,6 +795,7 @@ export const tr: Dict = {
   'sketch.clear': 'Temizle',
   'sketch.close': 'Kapat',
   'sketch.textPrompt': 'Metin:',
+  'sketch.textModalTitle': 'Metin ekle',
 
   'pet.title': 'Evcil Dostlar',
   'pet.tabBuiltIn': 'Yerleşik',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -834,6 +834,7 @@ export const uk: Dict = {
   'sketch.clear': 'Очистити',
   'sketch.close': 'Закрити',
   'sketch.textPrompt': 'Текст:',
+  'sketch.textModalTitle': 'Додати текст',
 
   'pet.title': 'Маскоти',
   'pet.subtitle': 'Встановити крихітного супутника, який пливе над вашим робочим простором.',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -815,6 +815,7 @@ export const zhCN: Dict = {
   'sketch.clear': '清空',
   'sketch.close': '关闭',
   'sketch.textPrompt': '请输入文本：',
+  'sketch.textModalTitle': '添加文本',
 
   'pet.title': '宠物',
   'pet.tabBuiltIn': '内置',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -815,6 +815,7 @@ export const zhTW: Dict = {
   'sketch.clear': '清除',
   'sketch.close': '關閉',
   'sketch.textPrompt': '請輸入文字：',
+  'sketch.textModalTitle': '新增文字',
 
   'pet.title': '寵物',
   'pet.tabBuiltIn': '內建',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -1007,4 +1007,5 @@ export interface Dict {
   'sketch.clear': string;
   'sketch.close': string;
   'sketch.textPrompt': string;
+  'sketch.textModalTitle': string;
 }


### PR DESCRIPTION
## Summary

The sketch editor's `text` tool silently does nothing in the desktop app. Clicking the canvas with the text tool active calls `window.prompt()`, which Electron 28+ disables by default — the call returns null synchronously and the handler's `if (text)` guard exits before any UI appears.

This is the same root cause as the FileViewer Save-as-template regression fixed in [#723](https://github.com/nexu-io/open-design/issues/723) (precedent branch `fix/save-as-template-modal-723`). I'm not claiming to close #723 — that PR fixes the FileViewer side. This PR is the second of the two `window.prompt()` callsites in the web app (the third lives inside FileViewer and is part of the #723 fix). After both land, there are no remaining `window.prompt()` calls in `apps/web`.

## What changed

- `apps/web/src/components/SketchEditor.tsx:129` — replace the `window.prompt(t('sketch.textPrompt'))` call with an in-app modal:
  - Stash the click position in a ref when the user clicks the canvas with the text tool active.
  - Open a modal with a single text input (`autoFocus`, Enter-to-submit when non-empty, Escape-to-cancel).
  - Append the `TextItem` only on confirm using the stashed anchor; Cancel and Escape clear state.
- Reuses the existing `.modal-backdrop` / `.modal` / `.modal-head` / `.modal-foot` classes from `apps/web/src/index.css` — no new CSS.
- Adds one i18n key, `sketch.textModalTitle` ("Add text"), to the `Dict` interface and all 16 locale files. The existing `sketch.textPrompt` is reused as the field label so no other translator churn.

Strictly scoped to `SketchEditor.tsx` + i18n; `FileViewer.tsx` is intentionally untouched (#723's territory).

## Test plan

- [x] `pnpm --filter @open-design/web typecheck` — clean
- [x] `pnpm --filter @open-design/web test` — 320 tests across 44 files pass
- [x] `tsx scripts/i18n-check.ts` — passes (locale registration, README switchers, core doc links consistent)
- [ ] Manual: in the desktop app, open a sketch file, pick the text tool, click on the canvas — modal opens, Enter places the text at the click point, Cancel/Escape leave the canvas unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)