### PR TITLE
fix(web): widen settings subtitle max-width so the English copy fits on one line (#743)

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1154,7 +1154,12 @@ code {
   font-size: 13px;
   color: var(--text-muted);
   line-height: 1.55;
-  max-width: 50ch;
+  /* 72ch lets typical one-sentence English subtitles fit on a single
+   * line inside the 920px settings modal while still wrapping cleanly
+   * on narrow viewports (the modal width clamps to 100vw - 48px) and
+   * for the longest locales (German, French). 50ch was forcing even
+   * the English subtitle onto two lines. See nexu-io/open-design#743. */
+  max-width: 72ch;
 }
 .modal-foot {
   display: flex;


### PR DESCRIPTION
Closes #743.

## Problem

The shared `.modal-head .subtitle` rule capped the settings subtitle at `max-width: 50ch`, which forced the 79-character English line *Choose between Local CLI and BYOK. Your API key is stored only in this browser.* onto two lines even though the 920px settings modal had plenty of horizontal room. The two-line wrap looked unpolished, exactly the symptom @shangxinyu1 described.

## Fix

Single-line CSS change in [apps/web/src/index.css](https://github.com/nexu-io/open-design/blob/main/apps/web/src/index.css): bump `.modal-head .subtitle { max-width }` from `50ch` to `72ch`.

## Why 72ch

- 50ch is roughly 350px in this stack, which made even the English subtitle wrap. 72ch is roughly 504px, which fits the 79-char English copy on one line.
- The settings modal is `width: min(920px, calc(100vw - 48px))` with `var(--modal-padding) = 24px` on each side, so the available content width is at most ~872px. 72ch leaves a comfortable right margin and avoids the subtitle stretching to the full modal edge, which would feel sparse.
- On narrow viewports the modal clamps to `100vw - 48px`, so the 72ch ceiling becomes irrelevant and the subtitle wraps naturally below ~568px viewport width. No regression on small screens.
- The longest-locale check: German (`Wählen Sie zwischen lokaler CLI und BYOK. Ihr API-Schlüssel wird nur in diesem Browser gespeichert.`) is 104 chars and still wraps, but cleanly to two lines instead of three. French is similar.
- CJK locales (Japanese, Korean, Chinese) were already well under the limit at any reasonable max-width, so no change in behaviour.

Local: web tests 332/332 including the 3 NewProjectPanel cases on the merged main, web typecheck and `pnpm guard` clean.