### PR TITLE
fix(web): keep saved Composio API key indicator visible while typing a replacement (#741)

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -1690,6 +1690,34 @@ export function SettingsDialog({
   );
 }
 
+/**
+ * The four UI states the Composio API key field can be in.
+ *
+ * `saved-pending` exists so the saved-key indicator stays visible while
+ * the user types a draft replacement. Previously the badge was tied to
+ * `!hasPendingEdit`, which made it vanish on the first keystroke and
+ * trained users to think the original key had already been overwritten
+ * (issue #741). Treating "saved key plus draft" as its own state lets
+ * the badge stay anchored while the hint text differentiates the
+ * unsaved replacement from a fully-saved value.
+ */
+export type ComposioCredentialState =
+  | 'empty'
+  | 'pending-new'
+  | 'saved'
+  | 'saved-pending';
+
+export function deriveComposioCredentialState(
+  composio: { apiKey?: string; apiKeyConfigured?: boolean } | null | undefined,
+): ComposioCredentialState {
+  const hasPendingEdit = Boolean(composio?.apiKey?.trim());
+  const hasSavedKey = Boolean(composio?.apiKeyConfigured);
+  if (hasSavedKey && hasPendingEdit) return 'saved-pending';
+  if (hasSavedKey) return 'saved';
+  if (hasPendingEdit) return 'pending-new';
+  return 'empty';
+}
+
 function ComposioSection({
   cfg,
   setCfg,
@@ -1702,9 +1730,9 @@ function ComposioSection({
   const updateComposio = (patch: NonNullable<AppConfig['composio']>) => {
     setCfg((curr) => ({ ...curr, composio: { ...(curr.composio ?? {}), ...patch } }));
   };
-  const hasPendingEdit = Boolean(composio.apiKey?.trim());
-  const apiKeyConfigured = Boolean(hasPendingEdit || composio.apiKeyConfigured);
-  const isSavedState = apiKeyConfigured && !hasPendingEdit;
+  const credentialState = deriveComposioCredentialState(composio);
+  const hasSavedKey = credentialState === 'saved' || credentialState === 'saved-pending';
+  const apiKeyConfigured = credentialState !== 'empty';
   const tail = composio.apiKeyTail?.trim();
 
   return (
@@ -1719,7 +1747,7 @@ function ComposioSection({
         <span className="field-label-row">
           <span className="field-label-group">
             <span className="field-label">Composio API Key</span>
-            {isSavedState ? (
+            {hasSavedKey ? (
               <span className="field-status-badge" title="Saved to local daemon">
                 {tail ? `Saved · ••••${tail}` : 'Saved'}
               </span>
@@ -1739,7 +1767,7 @@ function ComposioSection({
           <input
             type="password"
             value={composio.apiKey ?? ''}
-            placeholder={isSavedState ? 'Paste a new key to replace the saved one' : 'Paste Composio API key'}
+            placeholder={hasSavedKey ? 'Paste a new key to replace the saved one' : 'Paste Composio API key'}
             onChange={(e) => updateComposio({ apiKey: e.target.value })}
             aria-describedby="composio-api-key-help"
           />
@@ -1753,11 +1781,13 @@ function ComposioSection({
           </button>
         </div>
         <span id="composio-api-key-help" className="hint">
-          {isSavedState
-            ? 'Your key stays in the local daemon. Paste a new key above to replace it, or Clear to remove.'
-            : apiKeyConfigured
-              ? 'Unsaved changes — click Save to store this key in the local daemon.'
-              : 'Keys are stored locally in the daemon and never sent through environment variables.'}
+          {credentialState === 'saved-pending'
+            ? 'Unsaved replacement. Click Save to overwrite the saved key, or Clear to discard the draft and the saved key.'
+            : credentialState === 'saved'
+              ? 'Your key stays in the local daemon. Paste a new key above to replace it, or Clear to remove.'
+              : credentialState === 'pending-new'
+                ? 'Unsaved changes. Click Save to store this key in the local daemon.'
+                : 'Keys are stored locally in the daemon and never sent through environment variables.'}
         </span>
       </label>
     </section>

--- a/apps/web/tests/components/SettingsDialog.test.ts
+++ b/apps/web/tests/components/SettingsDialog.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   agentRefreshOptionsForConfig,
   canRunProviderConnectionTest,
+  deriveComposioCredentialState,
   isValidApiBaseUrl,
   shouldShowCustomModelInput,
   switchApiProtocolConfig,
@@ -303,5 +304,53 @@ describe('SettingsDialog agent CLI env settings', () => {
       throwOnError: true,
       agentCliEnv: {},
     });
+  });
+});
+
+describe('deriveComposioCredentialState', () => {
+  // Issue #741: when a Composio API key is already saved and the user
+  // starts typing a draft replacement, the saved-key indicator must
+  // stay visible. The previous code conflated `saved + draft` with
+  // `draft only` and made the badge vanish on the first keystroke.
+
+  it('returns "empty" when nothing is configured and the field is empty', () => {
+    expect(deriveComposioCredentialState({})).toBe('empty');
+    expect(deriveComposioCredentialState(null)).toBe('empty');
+    expect(deriveComposioCredentialState(undefined)).toBe('empty');
+    expect(deriveComposioCredentialState({ apiKey: '' })).toBe('empty');
+    expect(deriveComposioCredentialState({ apiKey: '   ' })).toBe('empty');
+  });
+
+  it('returns "saved" when a key is configured and no draft is being typed', () => {
+    expect(
+      deriveComposioCredentialState({ apiKeyConfigured: true }),
+    ).toBe('saved');
+    expect(
+      deriveComposioCredentialState({ apiKey: '', apiKeyConfigured: true }),
+    ).toBe('saved');
+    expect(
+      deriveComposioCredentialState({ apiKey: '   ', apiKeyConfigured: true }),
+    ).toBe('saved');
+  });
+
+  it('returns "pending-new" when only a draft is being typed (no saved key)', () => {
+    expect(deriveComposioCredentialState({ apiKey: 'sk-draft' })).toBe('pending-new');
+    expect(
+      deriveComposioCredentialState({ apiKey: 'sk-draft', apiKeyConfigured: false }),
+    ).toBe('pending-new');
+  });
+
+  it('returns "saved-pending" when a key is saved AND a draft is being typed', () => {
+    // Regression: this is the state that previously masqueraded as
+    // "pending-new" and made the saved-key badge disappear.
+    expect(
+      deriveComposioCredentialState({ apiKey: 'sk-replacement', apiKeyConfigured: true }),
+    ).toBe('saved-pending');
+  });
+
+  it('treats whitespace-only drafts as no draft so the badge is anchored on "saved"', () => {
+    expect(
+      deriveComposioCredentialState({ apiKey: '   \t\n', apiKeyConfigured: true }),
+    ).toBe('saved');
   });
 });


### PR DESCRIPTION
Closes #741.

## Problem

The Composio API Key field's saved-state badge (`Saved · ••••qEg`) was wired to `isSavedState = apiKeyConfigured && !hasPendingEdit`, which made it disappear the moment the user typed the first character of a replacement draft. Users reading the settings panel saw the saved-key indicator vanish before clicking Save and reasonably assumed the stored credential had already been overwritten or removed.

Credential editing is a high-trust workflow. A UI that fakes a state change before the durable write is the wrong default. @shangxinyu1's screenshots make the issue obvious.

## Fix

Replaced the boolean derivation in [apps/web/src/components/SettingsDialog.tsx](https://github.com/nexu-io/open-design/blob/main/apps/web/src/components/SettingsDialog.tsx) with a single helper `deriveComposioCredentialState` that returns one of four states:

- `empty`: no saved key, no draft
- `pending-new`: no saved key, draft typed
- `saved`: saved key, no draft
- `saved-pending`: saved key AND draft typed (the fix)

The component now shows the saved-key badge for **both** `saved` and `saved-pending`, so the indicator stays anchored while the user types. The hint text differentiates all four states so the unsaved-replacement case is still clearly called out:

| State | Hint |
| --- | --- |
| `saved-pending` | Unsaved replacement. Click Save to overwrite the saved key, or Clear to discard the draft and the saved key. |
| `saved` | Your key stays in the local daemon. Paste a new key above to replace it, or Clear to remove. |
| `pending-new` | Unsaved changes. Click Save to store this key in the local daemon. |
| `empty` | Keys are stored locally in the daemon and never sent through environment variables. |

Local: SettingsDialog tests 23/23 including the 5 new helper cases (empty, pending-new, saved, saved-pending, plus whitespace-only-draft edge case), web typecheck and `pnpm guard` clean.