### PR TITLE
Fix Image template creations not automatically executing the selected…

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -330,11 +330,15 @@ export function App() {
       // to "None" for every kind now, and the user expects that to land
       // as a no-design-system project rather than silently inheriting the
       // workspace default.
+      const derivedPendingPrompt =
+      input.pendingPrompt ??
+      (input.metadata?.promptTemplate?.prompt?.trim() || undefined);
+
       const result = await createProject({
         name: input.name,
         skillId: input.skillId,
         designSystemId: input.designSystemId,
-        pendingPrompt: input.pendingPrompt,
+        pendingPrompt: derivedPendingPrompt,
         metadata: input.metadata,
       });
       if (!result) return;


### PR DESCRIPTION
## What's the problem?

Closes #663

When a user picked an Image (or Video) template from the New Project panel, the prompt preview shown in the creation form was silently lost the moment they clicked **Create**. The new design opened to a completely empty chat — 
no generation, no indication anything went wrong. The user had to manually re-type the prompt themselves, defeating the entire purpose of the template gallery.

## Why was it happening?

The `handleCreateProject` function in `App.tsx` passes `input.pendingPrompt` to `createProject`. For prototype and deck flows this works fine because the caller always sets `pendingPrompt` explicitly.

For image and video flows, **the caller never sets it**. The selected template prompt lives inside `input.metadata.promptTemplate.prompt` and was never promoted into `pendingPrompt`. So `createProject` received `undefined`, the prompt was gone, and the design opened empty every time.

## What changed?

One variable added in `handleCreateProject` inside `apps/web/src/App.tsx`:

```ts
const derivedPendingPrompt =
  input.pendingPrompt ??
  (input.metadata?.promptTemplate?.prompt?.trim() || undefined);
```

When the caller supplies an explicit `pendingPrompt` (prototype, deck, skill cards) it is used as-is. When it is absent (image, video templates) we fall back to the template prompt from metadata. The rest of the pipeline — 
`pendingPrompt → initialDraft → ChatPane` — was already working correctly. This was the only missing link.

**1 file changed. 3 lines added. 1 line changed. Nothing else touched.**

## Before & After

| Scenario | Before | After |
|---|---|---|
| Image / Video tab → pick template → Create | Chat opens empty | Prompt fires automatically |
| Image / Video tab → no template selected | Idle | Idle (no change) |
| Open an existing image project | Idle | Idle (pendingPrompt clears after first fire) |
| Prototype / deck / skill card | Working | Still working (no change) |

## How to test

1. Run `pnpm tools-dev`
2. Click **New Project** → open the **Image** tab
3. Pick any template that has a prompt (any entry from the gallery)
4. Click **Create**
5. The prompt should fire automatically and image generation should begin
6. Navigate away and come back — the prompt should **not** re-fire