### PR TITLE
fix: expand Codex picker coverage

### DIFF
--- a/apps/daemon/src/agents.ts
+++ b/apps/daemon/src/agents.ts
@@ -197,19 +197,23 @@ export const AGENT_DEFS = [
     // as a hint. Users can supply other ids via the custom-model input.
     fallbackModels: [
       DEFAULT_MODEL_OPTION,
-      { id: 'gpt-5-codex', label: 'gpt-5-codex' },
       { id: 'gpt-5.5', label: 'gpt-5.5' },
       { id: 'gpt-5.4', label: 'gpt-5.4' },
+      { id: 'gpt-5.4-mini', label: 'gpt-5.4-mini' },
+      { id: 'gpt-5.3-codex', label: 'gpt-5.3-codex' },
+      { id: 'gpt-5-codex', label: 'gpt-5-codex' },
       { id: 'gpt-5', label: 'gpt-5' },
       { id: 'o3', label: 'o3' },
       { id: 'o4-mini', label: 'o4-mini' },
     ],
     reasoningOptions: [
       { id: 'default', label: 'Default' },
+      { id: 'none', label: 'None' },
       { id: 'minimal', label: 'Minimal' },
       { id: 'low', label: 'Low' },
       { id: 'medium', label: 'Medium' },
       { id: 'high', label: 'High' },
+      { id: 'xhigh', label: 'XHigh' },
     ],
     // Prompt is delivered via stdin pipe (gated by `promptViaStdin: true`
     // below) to avoid Windows `spawn ENAMETOOLONG` while keeping Codex on

--- a/apps/daemon/src/agents.ts
+++ b/apps/daemon/src/agents.ts
@@ -198,6 +198,8 @@ export const AGENT_DEFS = [
     fallbackModels: [
       DEFAULT_MODEL_OPTION,
       { id: 'gpt-5-codex', label: 'gpt-5-codex' },
+      { id: 'gpt-5.5', label: 'gpt-5.5' },
+      { id: 'gpt-5.4', label: 'gpt-5.4' },
       { id: 'gpt-5', label: 'gpt-5' },
       { id: 'o3', label: 'o3' },
       { id: 'o4-mini', label: 'o4-mini' },

--- a/apps/daemon/tests/agents.test.ts
+++ b/apps/daemon/tests/agents.test.ts
@@ -138,16 +138,62 @@ test('codex args keep plugins enabled when OD_CODEX_DISABLE_PLUGINS is not 1', (
   assert.equal(args.includes('plugins'), false);
 });
 
-test('codex model picker includes explicit newer OpenAI choices', () => {
-  assert.deepEqual(codex.fallbackModels.map((m) => m.id), [
+test('codex model picker includes current OpenAI choices in priority order', async () => {
+  const expectedModels = [
     'default',
-    'gpt-5-codex',
     'gpt-5.5',
     'gpt-5.4',
+    'gpt-5.4-mini',
+    'gpt-5.3-codex',
+    'gpt-5-codex',
     'gpt-5',
     'o3',
     'o4-mini',
+  ];
+
+  assert.deepEqual(codex.fallbackModels.map((m) => m.id), expectedModels);
+  assert.deepEqual(codex.reasoningOptions.map((o) => o.id), [
+    'default',
+    'none',
+    'minimal',
+    'low',
+    'medium',
+    'high',
+    'xhigh',
   ]);
+
+  const args = codex.buildArgs(
+    '',
+    [],
+    [],
+    { model: 'gpt-5.5', reasoning: 'xhigh' },
+    { cwd: '/tmp/od-project' },
+  );
+  assert.ok(args.includes('--model'));
+  assert.ok(args.includes('gpt-5.5'));
+  assert.ok(args.includes('model_reasoning_effort="xhigh"'));
+
+  const dir = mkdtempSync(join(tmpdir(), 'od-agents-codex-models-'));
+  try {
+    const codexBin = join(dir, 'codex');
+    writeFileSync(
+      codexBin,
+      '#!/bin/sh\nif [ "$1" = "--version" ]; then echo "codex 1.0.0"; exit 0; fi\nexit 0\n',
+    );
+    chmodSync(codexBin, 0o755);
+    process.env.OD_AGENT_HOME = dir;
+    process.env.PATH = dir;
+
+    const agents = await detectAgents();
+    const detected = agents.find((agent) => agent.id === 'codex');
+
+    assert.ok(detected);
+    assert.equal(detected.available, true);
+    assert.equal(detected.version, 'codex 1.0.0');
+    assert.deepEqual(detected.models.map((m) => m.id), expectedModels);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 // Recent Codex CLI versions reject a bare `-` argv sentinel; passing it

--- a/apps/daemon/tests/agents.test.ts
+++ b/apps/daemon/tests/agents.test.ts
@@ -138,6 +138,18 @@ test('codex args keep plugins enabled when OD_CODEX_DISABLE_PLUGINS is not 1', (
   assert.equal(args.includes('plugins'), false);
 });
 
+test('codex model picker includes explicit newer OpenAI choices', () => {
+  assert.deepEqual(codex.fallbackModels.map((m) => m.id), [
+    'default',
+    'gpt-5-codex',
+    'gpt-5.5',
+    'gpt-5.4',
+    'gpt-5',
+    'o3',
+    'o4-mini',
+  ]);
+});
+
 // Recent Codex CLI versions reject a bare `-` argv sentinel; passing it
 // alongside the stdin pipe causes `error: unexpected argument '-' found`
 // and exit code 2 before any prompt is read. We deliver the prompt via


### PR DESCRIPTION
## Summary
- Expand the Codex CLI fallback model picker in recommended priority order: `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, then the existing older choices.
- Add `none` and `xhigh` to the Codex reasoning-effort picker options while keeping the existing options for compatibility.
- Strengthen regression coverage so the test verifies the static picker list, reasoning options, `buildArgs()` model/reasoning forwarding, and `detectAgents()` surfacing through a fake Codex binary.

## Why
Codex CLI does not expose a `models` command here, so Open Design relies on a static fallback list for the dropdown. Users who can run newer OpenAI models through their Codex account should be able to select those ids directly without using the custom-model input every time, and the picker should guide them toward current model choices.

## Testing
- `corepack pnpm --filter @open-design/daemon test -- apps/daemon/tests/agents.test.ts` (passes; daemon Vitest suite: 918 tests)
- `corepack pnpm guard` (passes)
- `corepack pnpm --filter @open-design/daemon typecheck` (passes)

## Notes
The local environment reports Node v20.19.2 while the repo requests Node ~24, so pnpm prints engine warnings during validation.
