### PR TITLE
feat: add macOS Intel (x64) build support to release workflows

### DIFF
--- a/.github/scripts/release/assets/mac-intel.sh
+++ b/.github/scripts/release/assets/mac-intel.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+for name in RELEASE_VERSION RUNNER_TEMP TOOLS_PACK_NAMESPACE; do
+  if [ -z "${!name:-}" ]; then
+    echo "$name is required" >&2
+    exit 1
+  fi
+done
+
+asset_suffix="${ASSET_VERSION_SUFFIX:-}"
+release_dir="$RUNNER_TEMP/release-assets"
+mkdir -p "$release_dir"
+
+source_dmg="$RUNNER_TEMP/tools-pack/out/mac/namespaces/$TOOLS_PACK_NAMESPACE/dmg/Open Design-$TOOLS_PACK_NAMESPACE.dmg"
+source_zip="$RUNNER_TEMP/tools-pack/out/mac/namespaces/$TOOLS_PACK_NAMESPACE/zip/Open Design-$TOOLS_PACK_NAMESPACE.zip"
+if [ ! -f "$source_dmg" ]; then
+  echo "expected dmg not found at $source_dmg" >&2
+  exit 1
+fi
+if [ ! -f "$source_zip" ]; then
+  echo "expected zip not found at $source_zip" >&2
+  exit 1
+fi
+
+versioned_dmg="open-design-${RELEASE_VERSION}${asset_suffix}-mac-x64.dmg"
+versioned_zip="open-design-${RELEASE_VERSION}${asset_suffix}-mac-x64.zip"
+dmg_checksum_file="$versioned_dmg.sha256"
+zip_checksum_file="$versioned_zip.sha256"
+
+cp "$source_dmg" "$release_dir/$versioned_dmg"
+cp "$source_zip" "$release_dir/$versioned_zip"
+(
+  cd "$release_dir"
+  shasum -a 256 "$versioned_dmg" > "$dmg_checksum_file"
+  shasum -a 256 "$versioned_zip" > "$zip_checksum_file"
+)

--- a/.github/scripts/release/r2/publish.sh
+++ b/.github/scripts/release/r2/publish.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-for name in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY BASE_VERSION BRANCH_NAME CLOUDFLARE_R2_RELEASES_BUCKET CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN CLOUDFLARE_R2_RELEASES_URL ENABLE_LINUX ENABLE_MAC ENABLE_WIN GITHUB_OUTPUT RELEASE_CHANNEL RELEASE_SIGNED RELEASE_VERSION RUNNER_TEMP STATE_SOURCE; do
+for name in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY BASE_VERSION BRANCH_NAME CLOUDFLARE_R2_RELEASES_BUCKET CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN CLOUDFLARE_R2_RELEASES_URL ENABLE_LINUX ENABLE_MAC ENABLE_MAC_INTEL ENABLE_WIN GITHUB_OUTPUT RELEASE_CHANNEL RELEASE_SIGNED RELEASE_VERSION RUNNER_TEMP STATE_SOURCE; do
   if [ -z "${!name:-}" ]; then
     echo "$name is required" >&2
     exit 1
@@ -105,6 +105,8 @@ upload_report_zip() {
 
 mac_dmg="open-design-$RELEASE_VERSION$asset_version_suffix-mac-arm64.dmg"
 mac_zip="open-design-$RELEASE_VERSION$asset_version_suffix-mac-arm64.zip"
+mac_intel_dmg="open-design-$RELEASE_VERSION$asset_version_suffix-mac-x64.dmg"
+mac_intel_zip="open-design-$RELEASE_VERSION$asset_version_suffix-mac-x64.zip"
 win_installer="open-design-$RELEASE_VERSION$win_asset_suffix-win-x64-setup.exe"
 linux_appimage="open-design-$RELEASE_VERSION$linux_asset_suffix-linux-x64.AppImage"
 metadata_path="$release_root/metadata.json"
@@ -138,6 +140,17 @@ if [ "$ENABLE_WIN" = "true" ]; then
   } >> "$GITHUB_OUTPUT"
 fi
 
+if [ "$ENABLE_MAC_INTEL" = "true" ]; then
+  upload "$release_root/mac-intel/$mac_intel_dmg" "$version_prefix/$mac_intel_dmg" "application/x-apple-diskimage" "public, max-age=31536000, immutable"
+  upload "$release_root/mac-intel/$mac_intel_zip" "$version_prefix/$mac_intel_zip" "application/zip" "public, max-age=31536000, immutable"
+  upload "$release_root/mac-intel/$mac_intel_dmg.sha256" "$version_prefix/$mac_intel_dmg.sha256" "text/plain; charset=utf-8" "public, max-age=31536000, immutable"
+  upload "$release_root/mac-intel/$mac_intel_zip.sha256" "$version_prefix/$mac_intel_zip.sha256" "text/plain; charset=utf-8" "public, max-age=31536000, immutable"
+  {
+    echo "mac_intel_dmg_url=$public_origin/$version_prefix/$mac_intel_dmg"
+    echo "mac_intel_zip_url=$public_origin/$version_prefix/$mac_intel_zip"
+  } >> "$GITHUB_OUTPUT"
+fi
+
 if [ "$ENABLE_LINUX" = "true" ]; then
   upload "$release_root/linux/$linux_appimage" "$version_prefix/$linux_appimage" "application/octet-stream" "public, max-age=31536000, immutable"
   upload "$release_root/linux/$linux_appimage.sha256" "$version_prefix/$linux_appimage.sha256" "text/plain; charset=utf-8" "public, max-age=31536000, immutable"
@@ -160,6 +173,8 @@ REPORT_MODE="$report_mode" \
 REPORT_ZIP_PATH="$report_zip_path" \
 MAC_DMG="$mac_dmg" \
 MAC_ZIP="$mac_zip" \
+MAC_INTEL_DMG="$mac_intel_dmg" \
+MAC_INTEL_ZIP="$mac_intel_zip" \
 WIN_INSTALLER="$win_installer" \
 LINUX_APPIMAGE="$linux_appimage" \
 MAC_ARTIFACT_MODE="$mac_artifact_mode" \
@@ -242,6 +257,18 @@ if (enabled("ENABLE_LINUX")) {
     signed: false,
     artifacts: {
       appImage: fileEntry("linux", env.LINUX_APPIMAGE, "application/octet-stream"),
+    },
+  };
+}
+if (enabled("ENABLE_MAC_INTEL")) {
+  platforms.macIntel = {
+    arch: "x64",
+    enabled: true,
+    feed: null,
+    signed: false,
+    artifacts: {
+      dmg: fileEntry("mac-intel", env.MAC_INTEL_DMG, "application/x-apple-diskimage"),
+      zip: fileEntry("mac-intel", env.MAC_INTEL_ZIP, "application/zip"),
     },
   };
 }

--- a/.github/scripts/release/r2/publish.sh
+++ b/.github/scripts/release/r2/publish.sh
@@ -9,6 +9,7 @@ for name in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY BASE_VERSION BRANCH_NAME CLO
 done
 
 asset_version_suffix="${ASSET_VERSION_SUFFIX:-}"
+mac_intel_asset_suffix="${MAC_INTEL_ASSET_SUFFIX:-$asset_version_suffix}"
 win_asset_suffix="${WIN_ASSET_SUFFIX:-$asset_version_suffix}"
 linux_asset_suffix="${LINUX_ASSET_SUFFIX:-$asset_version_suffix}"
 mac_artifact_mode="${MAC_ARTIFACT_MODE:-dmg-and-zip}"
@@ -105,8 +106,8 @@ upload_report_zip() {
 
 mac_dmg="open-design-$RELEASE_VERSION$asset_version_suffix-mac-arm64.dmg"
 mac_zip="open-design-$RELEASE_VERSION$asset_version_suffix-mac-arm64.zip"
-mac_intel_dmg="open-design-$RELEASE_VERSION$asset_version_suffix-mac-x64.dmg"
-mac_intel_zip="open-design-$RELEASE_VERSION$asset_version_suffix-mac-x64.zip"
+mac_intel_dmg="open-design-$RELEASE_VERSION$mac_intel_asset_suffix-mac-x64.dmg"
+mac_intel_zip="open-design-$RELEASE_VERSION$mac_intel_asset_suffix-mac-x64.zip"
 win_installer="open-design-$RELEASE_VERSION$win_asset_suffix-win-x64-setup.exe"
 linux_appimage="open-design-$RELEASE_VERSION$linux_asset_suffix-linux-x64.AppImage"
 metadata_path="$release_root/metadata.json"

--- a/.github/scripts/release/r2/summary.sh
+++ b/.github/scripts/release/r2/summary.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-for name in BASE_VERSION ENABLE_LINUX ENABLE_MAC ENABLE_WIN GITHUB_STEP_SUMMARY RELEASE_CHANNEL RELEASE_SIGNED RELEASE_VERSION STATE_SOURCE; do
+for name in BASE_VERSION ENABLE_LINUX ENABLE_MAC ENABLE_MAC_INTEL ENABLE_WIN GITHUB_STEP_SUMMARY RELEASE_CHANNEL RELEASE_SIGNED RELEASE_VERSION STATE_SOURCE; do
   if [ -z "${!name:-}" ]; then
     echo "$name is required" >&2
     exit 1
@@ -46,6 +46,10 @@ const platforms = {
     enabled: enabled("ENABLE_LINUX"),
     signed: false,
   },
+  macIntel: {
+    enabled: enabled("ENABLE_MAC_INTEL"),
+    signed: false,
+  },
 };
 
 if (platforms.mac.enabled) {
@@ -70,6 +74,13 @@ if (platforms.linux.enabled) {
     appImage: optional("R2_LINUX_APPIMAGE_URL"),
   };
   platforms.linux.feed = null;
+}
+if (platforms.macIntel.enabled) {
+  platforms.macIntel.artifacts = {
+    dmg: optional("R2_MAC_INTEL_DMG_URL"),
+    zip: optional("R2_MAC_INTEL_ZIP_URL"),
+  };
+  platforms.macIntel.feed = null;
 }
 
 const githubReleaseEnabled = env.GITHUB_RELEASE_ENABLED === "true";
@@ -140,6 +151,15 @@ const platformRows = [
     linkList([{ label: "AppImage", url: platforms.linux.artifacts?.appImage }]),
     "-",
   ],
+  [
+    "macOS x64 (Intel)",
+    platformStatus(platforms.macIntel, "Published"),
+    linkList([
+      { label: "DMG", url: platforms.macIntel.artifacts?.dmg },
+      { label: "ZIP", url: platforms.macIntel.artifacts?.zip },
+    ]),
+    "-",
+  ],
 ];
 
 const platformTable = [
@@ -169,6 +189,11 @@ const reportRows = reportZipUrl == null
         ]),
       ],
       ["Linux x64", platforms.linux.enabled ? "Not collected" : "Skipped", "-"],
+      [
+        "macOS x64 (Intel)",
+        platforms.macIntel.enabled ? "Published" : "Skipped",
+        "-",
+      ],
     ]
   : [["report.zip", "Published", link("download", reportZipUrl)]];
 

--- a/.github/scripts/release/r2/verify.sh
+++ b/.github/scripts/release/r2/verify.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-for name in ENABLE_LINUX ENABLE_MAC ENABLE_WIN R2_METADATA_URL RELEASE_CHANNEL RELEASE_VERSION RUNNER_TEMP; do
+for name in ENABLE_LINUX ENABLE_MAC ENABLE_MAC_INTEL ENABLE_WIN R2_METADATA_URL RELEASE_CHANNEL RELEASE_VERSION RUNNER_TEMP; do
   if [ -z "${!name:-}" ]; then
     echo "$name is required" >&2
     exit 1
@@ -119,6 +119,17 @@ if [ "$ENABLE_WIN" = "true" ]; then
   require_report_file "win/screenshots/open-design-win-smoke.png"
   require_report_file "win/tools-pack.json"
   require_report_file "win/vitest.log"
+fi
+
+if [ "$ENABLE_MAC_INTEL" = "true" ]; then
+  for name in R2_MAC_INTEL_DMG_URL R2_MAC_INTEL_ZIP_URL; do
+    if [ -z "${!name:-}" ]; then
+      echo "$name is required when ENABLE_MAC_INTEL=true" >&2
+      exit 1
+    fi
+  done
+  curl -fsSI "$R2_MAC_INTEL_DMG_URL" >/dev/null
+  curl -fsSI "$R2_MAC_INTEL_ZIP_URL" >/dev/null
 fi
 
 if [ "$ENABLE_LINUX" = "true" ]; then

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -13,6 +13,11 @@ on:
         required: true
         type: boolean
         default: true
+      enable_mac_intel:
+        description: "Build and publish macOS Intel x64 (unsigned) beta artifacts."
+        required: true
+        type: boolean
+        default: false
       enable_linux:
         description: "Build and publish Linux x64 AppImage/checksum to R2 only; no updater feed is published yet."
         required: true
@@ -55,7 +60,7 @@ jobs:
       - name: Validate beta publish inputs
         run: |
           set -euo pipefail
-          if [ "${{ inputs.enable_mac }}" != "true" ] && [ "${{ inputs.enable_win }}" != "true" ] && [ "${{ inputs.enable_linux }}" != "true" ]; then
+          if [ "${{ inputs.enable_mac }}" != "true" ] && [ "${{ inputs.enable_win }}" != "true" ] && [ "${{ inputs.enable_mac_intel }}" != "true" ] && [ "${{ inputs.enable_linux }}" != "true" ]; then
             echo "release-beta requires at least one platform to be enabled" >&2
             exit 1
           fi
@@ -295,6 +300,59 @@ jobs:
           name: open-design-beta-mac-release-assets
           path: ${{ runner.temp }}/release-assets
 
+  build_mac_intel:
+    name: Build beta mac x64
+    needs: metadata
+    if: ${{ inputs.enable_mac_intel }}
+    runs-on: macos-13
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 10.33.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Apply beta package version
+        run: npm pkg set "version=${{ needs.metadata.outputs.beta_version }}" --prefix apps/packaged
+
+      - name: Build beta mac intel artifacts
+        run: |
+          set -euo pipefail
+          pnpm exec tools-pack mac build \
+            --dir "$RUNNER_TEMP/tools-pack" \
+            --namespace release-beta-intel \
+            --portable \
+            --mac-compression maximum \
+            --to all \
+            --json
+
+      - name: Prepare beta mac intel assets
+        id: assets
+        env:
+          ASSET_VERSION_SUFFIX: .unsigned
+          RELEASE_CHANNEL: beta
+          RELEASE_VERSION: ${{ needs.metadata.outputs.beta_version }}
+          TOOLS_PACK_NAMESPACE: release-beta-intel
+        run: bash .github/scripts/release/assets/mac-intel.sh
+
+      - name: Upload mac intel release bundle
+        uses: actions/upload-artifact@v7
+        with:
+          name: open-design-beta-mac-intel-release-assets
+          path: ${{ runner.temp }}/release-assets
+
   build_win:
     name: Build beta win x64
     needs: metadata
@@ -515,6 +573,7 @@ jobs:
     needs:
       - metadata
       - build_mac
+      - build_mac_intel
       - build_win
       - build_linux
     if: >-
@@ -522,8 +581,9 @@ jobs:
         always() &&
         !cancelled() &&
         needs.metadata.result == 'success' &&
-        (inputs.enable_mac || inputs.enable_win || inputs.enable_linux) &&
+        (inputs.enable_mac || inputs.enable_win || inputs.enable_mac_intel || inputs.enable_linux) &&
         (!inputs.enable_mac || needs.build_mac.result == 'success') &&
+        (!inputs.enable_mac_intel || needs.build_mac_intel.result == 'success') &&
         (!inputs.enable_win || needs.build_win.result == 'success') &&
         (!inputs.enable_linux || needs.build_linux.result == 'success')
       }}
@@ -543,6 +603,7 @@ jobs:
       BRANCH_NAME: ${{ needs.metadata.outputs.branch }}
       ENABLE_LINUX: ${{ inputs.enable_linux }}
       ENABLE_MAC: ${{ inputs.enable_mac }}
+      ENABLE_MAC_INTEL: ${{ inputs.enable_mac_intel }}
       ENABLE_WIN: ${{ inputs.enable_win }}
       GITHUB_RELEASE_ENABLED: "false"
       LINUX_ASSET_SUFFIX: .unsigned
@@ -565,6 +626,13 @@ jobs:
         with:
           name: open-design-beta-mac-release-assets
           path: ${{ runner.temp }}/release-assets/mac
+
+      - name: Download mac intel release bundle
+        if: ${{ inputs.enable_mac_intel }}
+        uses: actions/download-artifact@v8
+        with:
+          name: open-design-beta-mac-intel-release-assets
+          path: ${{ runner.temp }}/release-assets/mac-intel
 
       - name: Download windows release bundle
         if: ${{ inputs.enable_win }}
@@ -608,6 +676,8 @@ jobs:
           R2_LINUX_APPIMAGE_URL: ${{ steps.r2.outputs.linux_appimage_url }}
           R2_MAC_DMG_URL: ${{ steps.r2.outputs.mac_dmg_url }}
           R2_MAC_FEED_URL: ${{ steps.r2.outputs.mac_feed_url }}
+          R2_MAC_INTEL_DMG_URL: ${{ steps.r2.outputs.mac_intel_dmg_url }}
+          R2_MAC_INTEL_ZIP_URL: ${{ steps.r2.outputs.mac_intel_zip_url }}
           R2_MAC_ZIP_URL: ${{ steps.r2.outputs.mac_zip_url }}
           R2_METADATA_URL: ${{ steps.r2.outputs.metadata_url }}
           R2_REPORT_ZIP_URL: ${{ steps.r2.outputs.report_zip_url }}
@@ -620,6 +690,8 @@ jobs:
           R2_LINUX_APPIMAGE_URL: ${{ steps.r2.outputs.linux_appimage_url }}
           R2_MAC_DMG_URL: ${{ steps.r2.outputs.mac_dmg_url }}
           R2_MAC_FEED_URL: ${{ steps.r2.outputs.mac_feed_url }}
+          R2_MAC_INTEL_DMG_URL: ${{ steps.r2.outputs.mac_intel_dmg_url }}
+          R2_MAC_INTEL_ZIP_URL: ${{ steps.r2.outputs.mac_intel_zip_url }}
           R2_MAC_ZIP_URL: ${{ steps.r2.outputs.mac_zip_url }}
           R2_METADATA_URL: ${{ steps.r2.outputs.metadata_url }}
           R2_REPORT_ZIP_URL: ${{ steps.r2.outputs.report_zip_url }}

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -608,6 +608,7 @@ jobs:
       GITHUB_RELEASE_ENABLED: "false"
       LINUX_ASSET_SUFFIX: .unsigned
       MAC_ARTIFACT_MODE: dmg-only
+      MAC_INTEL_ASSET_SUFFIX: .unsigned
       RELEASE_CHANNEL: beta
       RELEASE_VERSION: ${{ needs.metadata.outputs.beta_version }}
       RELEASE_SIGNED: "true"

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -346,6 +346,59 @@ jobs:
           name: open-design-release-mac-release-assets
           path: ${{ runner.temp }}/release-assets
 
+  build_mac_intel:
+    name: Build release mac intel x64
+    needs: [metadata, verify]
+    runs-on: macos-13
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 10.33.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Apply release package version
+        run: npm pkg set "version=${{ needs.metadata.outputs.stable_version }}" --prefix apps/packaged
+
+      - name: Build release mac intel artifacts
+        run: |
+          set -euo pipefail
+          pnpm exec tools-pack mac build \
+            --dir "$RUNNER_TEMP/tools-pack" \
+            --namespace release-stable-intel \
+            --portable \
+            --mac-compression maximum \
+            --to all \
+            --json
+
+      - name: Prepare mac intel release assets
+        id: assets
+        env:
+          RELEASE_CHANNEL: ${{ needs.metadata.outputs.channel }}
+          RELEASE_VERSION: ${{ needs.metadata.outputs.release_version }}
+          TOOLS_PACK_NAMESPACE: release-stable-intel
+        run: bash .github/scripts/release/assets/mac-intel.sh
+
+      - name: Upload mac intel release bundle
+        uses: actions/upload-artifact@v7
+        with:
+          name: open-design-release-mac-intel-release-assets
+          path: ${{ runner.temp }}/release-assets
+
   build_win:
     name: Build release win x64
     needs: [metadata, verify]
@@ -518,6 +571,7 @@ jobs:
       - metadata
       - verify
       - build_mac
+      - build_mac_intel
       - build_win
       - build_linux
     if: >-
@@ -527,6 +581,7 @@ jobs:
         needs.metadata.result == 'success' &&
         needs.verify.result == 'success' &&
         needs.build_mac.result == 'success' &&
+        needs.build_mac_intel.result == 'success' &&
         needs.build_win.result == 'success' &&
         (needs.build_linux.result == 'success' || needs.build_linux.result == 'skipped')
       }}
@@ -544,6 +599,7 @@ jobs:
       BRANCH_NAME: ${{ needs.metadata.outputs.branch }}
       ENABLE_LINUX: ${{ needs.build_linux.result == 'success' }}
       ENABLE_MAC: "true"
+      ENABLE_MAC_INTEL: "true"
       ENABLE_WIN: "true"
       GITHUB_RELEASE_ENABLED: ${{ needs.metadata.outputs.github_release_enabled }}
       NIGHTLY_NUMBER: ${{ needs.metadata.outputs.nightly_number }}
@@ -583,6 +639,12 @@ jobs:
         with:
           name: open-design-release-mac-release-assets
           path: ${{ runner.temp }}/release-assets/mac
+
+      - name: Download mac intel release bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: open-design-release-mac-intel-release-assets
+          path: ${{ runner.temp }}/release-assets/mac-intel
 
       - name: Download windows release bundle
         uses: actions/download-artifact@v8
@@ -634,6 +696,7 @@ jobs:
           all_release_dir="$RUNNER_TEMP/release-assets/all"
           mkdir -p "$all_release_dir"
           cp "$RUNNER_TEMP/release-assets/mac"/* "$all_release_dir/"
+          cp "$RUNNER_TEMP/release-assets/mac-intel"/* "$all_release_dir/"
           cp "$RUNNER_TEMP/release-assets/win"/* "$all_release_dir/"
           if [ "$ENABLE_LINUX" = "true" ]; then
             cp "$RUNNER_TEMP/release-assets/linux"/* "$all_release_dir/"
@@ -649,6 +712,8 @@ jobs:
           R2_LINUX_APPIMAGE_URL: ${{ steps.r2.outputs.linux_appimage_url }}
           R2_MAC_DMG_URL: ${{ steps.r2.outputs.mac_dmg_url }}
           R2_MAC_FEED_URL: ${{ steps.r2.outputs.mac_feed_url }}
+          R2_MAC_INTEL_DMG_URL: ${{ steps.r2.outputs.mac_intel_dmg_url }}
+          R2_MAC_INTEL_ZIP_URL: ${{ steps.r2.outputs.mac_intel_zip_url }}
           R2_MAC_ZIP_URL: ${{ steps.r2.outputs.mac_zip_url }}
           R2_METADATA_URL: ${{ steps.r2.outputs.metadata_url }}
           R2_REPORT_ZIP_URL: ${{ steps.r2.outputs.report_zip_url }}
@@ -678,6 +743,8 @@ jobs:
           R2_LINUX_APPIMAGE_URL: ${{ steps.r2.outputs.linux_appimage_url }}
           R2_MAC_DMG_URL: ${{ steps.r2.outputs.mac_dmg_url }}
           R2_MAC_FEED_URL: ${{ steps.r2.outputs.mac_feed_url }}
+          R2_MAC_INTEL_DMG_URL: ${{ steps.r2.outputs.mac_intel_dmg_url }}
+          R2_MAC_INTEL_ZIP_URL: ${{ steps.r2.outputs.mac_intel_zip_url }}
           R2_MAC_ZIP_URL: ${{ steps.r2.outputs.mac_zip_url }}
           R2_METADATA_URL: ${{ steps.r2.outputs.metadata_url }}
           R2_REPORT_ZIP_URL: ${{ steps.r2.outputs.report_zip_url }}


### PR DESCRIPTION
## Summary

Add macOS Intel (x64) build jobs to both `release-beta.yml` and `release-stable.yml` workflows, using `macos-13` runners (Intel x64).

Closes #746

## What changed

### `release-beta.yml`
- Added `enable_mac_intel` workflow input (boolean, default: `false`)
- Added `build_mac_intel` job: runs on `macos-13`, produces unsigned DMG + ZIP with `-mac-x64` suffix
- Updated `publish` job: downloads, collects, and uploads Intel artifacts alongside existing arm64 assets

### `release-stable.yml`
- Added `build_mac_intel` job: runs on `macos-13`, produces unsigned DMG + ZIP with `-mac-x64` suffix
- Updated `publish` job: downloads, collects, and uploads Intel artifacts alongside existing arm64 assets

## Why `macos-13`

GitHub Actions `macos-14` and `macos-15` runners are Apple Silicon (arm64). `macos-13` is the last Intel-based runner. The project's build system (`tools/pack/src/mac.ts`) uses `process.arch` for architecture detection, so building on an Intel runner naturally produces x64 artifacts — no source code changes needed.

## Local build verification

Successfully built macOS Intel x64 artifacts on a local Intel Mac (macOS 26.3.1, x86_64):

```
$ file "Open Design.app/Contents/MacOS/Open Design"
Mach-O 64-bit executable x86_64
```

Output:
- DMG: 227 MB
- ZIP: 225 MB

## Design decisions

- **Intel builds are unsigned** — Apple signing/notarization is only applied to arm64 builds (requires Apple Developer certificate). Intel builds follow the same pattern as Windows (unsigned).
- **Beta toggle defaults to `false`** — the `enable_mac_intel` input in the beta workflow defaults to `false` so existing workflow runs are unaffected. It can be enabled per-release as needed.
- **No auto-update feed for Intel** — the `latest-mac.yml` auto-update feed is generated by the arm64 build. Intel builds only produce the installable artifacts (DMG, ZIP, checksums).
- **No `enable_mac_intel` toggle in stable** — stable releases always build Intel alongside arm64.

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/release-beta.yml` | +99 lines (new job + publish updates) |
| `.github/workflows/release-stable.yml` | +85 lines (new job + publish updates) |
