### PR TITLE
fix(web): localize MCP server settings panel for Chinese UI

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -1972,7 +1972,7 @@ interface McpClient {
   // Optional one-click install action. Currently only Cursor
   // supports deeplinks of this shape.
   buildDeeplink?: (info: McpInstallInfo) => string;
-  deeplinkLabel?: string;
+  deeplinkLabel?: () => string;
 }
 
 // Path hint per OS. Localizes the "where to paste" copy so a
@@ -2037,129 +2037,96 @@ function buildSharedMcpJson(info: McpInstallInfo): string {
 }`;
 }
 
-const MCP_CLIENTS: McpClient[] = [
-  {
-    id: 'claude',
-    label: 'Claude Code',
-    // `claude mcp add-json <name> '<json>'` takes ONLY the inner
-    // server-config object, not the full mcpServers wrapper. We
-    // inline the JSON into the command itself so the snippet is a
-    // real one-liner the user can copy and run, no template
-    // substitution. Single quotes around the JSON work in bash, zsh,
-    // PowerShell, and Git Bash; the only outlier is Windows cmd.exe,
-    // where users would need to swap to PowerShell.
-    buildMethod: () => 'CLI command',
-    buildInstruction: () => 'Run this in your terminal.',
-    buildSnippet: (info) => {
-      const inner = JSON.stringify(buildMcpStdioServerConfig(info));
-      return `claude mcp add-json --scope user open-design '${inner}'`;
-    },
-    buildSnippetLang: () => 'bash',
-  },
-  {
-    id: 'codex',
-    label: 'Codex',
-    // Codex CLI shares config between the terminal CLI and the IDE
-    // extension at ~/.codex/config.toml (TOML, not JSON, and a
-    // different table key from every other client - mcp_servers
-    // rather than mcpServers / servers / context_servers). Schema
-    // ref: https://developers.openai.com/codex/mcp.
-    //
-    // For our payload (just command + args, both strings/arrays of
-    // strings) JSON.stringify happens to produce valid TOML literal
-    // values, since TOML basic strings use the same double-quote
-    // escape rules and TOML inline arrays match JSON array syntax.
-    buildMethod: () => 'TOML config',
-    buildInstruction: (info) => {
-      const path = homeConfigPath(
-        info.platform,
-        '~/.codex/config.toml',
-        '%USERPROFILE%\\.codex\\config.toml',
-      );
-      return `Append this table to ${path}. The same config is shared between the Codex CLI and the Codex IDE extension.`;
-    },
-    buildSnippet: (info) => `[mcp_servers.open-design]
-command = ${JSON.stringify(info.command)}
-args = ${JSON.stringify(info.args)}${buildCodexEnvToml(info)}`,
-    buildSnippetLang: () => 'toml',
-  },
-  {
-    id: 'cursor',
-    label: 'Cursor',
-    buildMethod: () => 'One-click install',
-    buildInstruction: (info) =>
-      `Click "Install in Cursor" to install with an approval dialog, or merge this JSON into ${homeConfigPath(info.platform, '~/.cursor/mcp.json', '%USERPROFILE%\\.cursor\\mcp.json')}.`,
-    buildSnippet: buildSharedMcpJson,
-    buildSnippetLang: () => 'json',
-    buildDeeplink: (info) => {
-      const inner = buildMcpStdioServerConfig(info);
-      // Cursor expects the inner server-config object base64-encoded
-      // as ?config=...; the handler decodes it and pops an approval
-      // dialog before writing to mcp.json. We UTF-8-encode first so
-      // non-Latin1 chars in paths (e.g. an accented username) do not
-      // throw from btoa().
-      const encoded = utf8Btoa(JSON.stringify(inner));
-      return `cursor://anysphere.cursor-deeplink/mcp/install?name=open-design&config=${encoded}`;
-    },
-    deeplinkLabel: 'Install in Cursor',
-  },
-  {
-    id: 'vscode',
-    label: 'VS Code',
-    buildMethod: () => 'JSON config',
-    buildInstruction: (info) =>
-      `Open the Command Palette (${commandPaletteShortcut(info.platform)}), run "MCP: Open User Configuration", and merge this JSON. Copilot Chat must be in Agent mode for tools to show up.`,
-    buildSnippet: (info) => `{
-  "servers": {
-    "open-design": {
-      "type": "stdio",
-      "command": ${JSON.stringify(info.command)},
-      "args": ${JSON.stringify(info.args)}${info.env && Object.keys(info.env).length > 0 ? `,
-      "env": ${JSON.stringify(info.env)}` : ''}
-    }
-  }
-}`,
-    buildSnippetLang: () => 'json',
-  },
-  {
-    id: 'antigravity',
-    label: 'Antigravity',
-    buildMethod: () => 'JSON config',
-    buildInstruction: () =>
-      'In Antigravity: Agent panel "..." menu → MCP Servers → Manage MCP Servers → View raw config. Merge this JSON.',
-    buildSnippet: buildSharedMcpJson,
-    buildSnippetLang: () => 'json',
-  },
-  {
-    id: 'zed',
-    label: 'Zed',
-    buildMethod: () => 'JSON config',
-    buildInstruction: (info) =>
-      `Open Zed Settings (${settingsShortcut(info.platform)}) and merge this into the top-level object. Zed uses "context_servers", not "mcpServers".`,
-    buildSnippet: (info) => `{
-  "context_servers": {
-    "open-design": {
-      "source": "custom",
-      "command": ${JSON.stringify(info.command)},
-      "args": ${JSON.stringify(info.args)}${info.env && Object.keys(info.env).length > 0 ? `,
-      "env": ${JSON.stringify(info.env)}` : ''}
-    }
-  }
-}`,
-    buildSnippetLang: () => 'json',
-  },
-  {
-    id: 'windsurf',
-    label: 'Windsurf',
-    buildMethod: () => 'JSON config',
-    buildInstruction: (info) =>
-      `Open ${homeConfigPath(info.platform, '~/.codeium/windsurf/mcp_config.json', '%USERPROFILE%\\.codeium\\windsurf\\mcp_config.json')} (or use the MCPs icon in Cascade → Configure) and merge:`,
-    buildSnippet: buildSharedMcpJson,
-    buildSnippetLang: () => 'json',
-  },
-];
-
 function IntegrationsSection() {
+  const { t } = useI18n();
+
+  const MCP_CLIENTS: McpClient[] = [
+    {
+      id: 'claude',
+      label: 'Claude Code',
+      buildMethod: () => t('settings.mcpMethodCli'),
+      buildInstruction: () => t('settings.mcpInstructionCli'),
+      buildSnippet: (info) => {
+        const inner = JSON.stringify(buildMcpStdioServerConfig(info));
+        return `claude mcp add-json --scope user open-design '${inner}'`;
+      },
+      buildSnippetLang: () => 'bash',
+    },
+    {
+      id: 'codex',
+      label: 'Codex',
+      buildMethod: () => t('settings.mcpMethodToml'),
+      buildInstruction: (info) => {
+        const path = homeConfigPath(
+          info.platform,
+          '~/.codex/config.toml',
+          '%USERPROFILE%\\.codex\\config.toml',
+        );
+        return t('settings.mcpInstructionCodex', { path });
+      },
+      buildSnippet: (info) => `[mcp_servers.open-design]\ncommand = ${JSON.stringify(info.command)}\nargs = ${JSON.stringify(info.args)}${buildCodexEnvToml(info)}`,
+      buildSnippetLang: () => 'toml',
+    },
+    {
+      id: 'cursor',
+      label: 'Cursor',
+      buildMethod: () => t('settings.mcpMethodOneClick'),
+      buildInstruction: (info) =>
+        t('settings.mcpInstructionCursor', {
+          path: homeConfigPath(info.platform, '~/.cursor/mcp.json', '%USERPROFILE%\\.cursor\\mcp.json'),
+        }),
+      buildSnippet: buildSharedMcpJson,
+      buildSnippetLang: () => 'json',
+      buildDeeplink: (info) => {
+        const inner = buildMcpStdioServerConfig(info);
+        const encoded = utf8Btoa(JSON.stringify(inner));
+        return `cursor://anysphere.cursor-deeplink/mcp/install?name=open-design&config=${encoded}`;
+      },
+      deeplinkLabel: () => t('settings.mcpDeeplinkInstallCursor'),
+    },
+    {
+      id: 'vscode',
+      label: 'VS Code',
+      buildMethod: () => t('settings.mcpMethodJson'),
+      buildInstruction: (info) =>
+        t('settings.mcpInstructionCopilot', {
+          shortcut: commandPaletteShortcut(info.platform),
+        }),
+      buildSnippet: (info) => `{\n  "servers": {\n    "open-design": {\n      "type": "stdio",\n      "command": ${JSON.stringify(info.command)},\n      "args": ${JSON.stringify(info.args)}${info.env && Object.keys(info.env).length > 0 ? `,\n      "env": ${JSON.stringify(info.env)}` : ''}\n    }\n  }\n}`,
+      buildSnippetLang: () => 'json',
+    },
+    {
+      id: 'antigravity',
+      label: 'Antigravity',
+      buildMethod: () => t('settings.mcpMethodJson'),
+      buildInstruction: () => t('settings.mcpInstructionAntigravity'),
+      buildSnippet: buildSharedMcpJson,
+      buildSnippetLang: () => 'json',
+    },
+    {
+      id: 'zed',
+      label: 'Zed',
+      buildMethod: () => t('settings.mcpMethodJson'),
+      buildInstruction: (info) =>
+        t('settings.mcpInstructionZed', {
+          shortcut: settingsShortcut(info.platform),
+        }),
+      buildSnippet: (info) => `{\n  "context_servers": {\n    "open-design": {\n      "source": "custom",\n      "command": ${JSON.stringify(info.command)},\n      "args": ${JSON.stringify(info.args)}${info.env && Object.keys(info.env).length > 0 ? `,\n      "env": ${JSON.stringify(info.env)}` : ''}\n    }\n  }\n}`,
+      buildSnippetLang: () => 'json',
+    },
+    {
+      id: 'windsurf',
+      label: 'Windsurf',
+      buildMethod: () => t('settings.mcpMethodJson'),
+      buildInstruction: (info) =>
+        t('settings.mcpInstructionWindsurf', {
+          path: homeConfigPath(info.platform, '~/.codeium/windsurf/mcp_config.json', '%USERPROFILE%\\.codeium\\windsurf\\mcp_config.json'),
+        }),
+      buildSnippet: buildSharedMcpJson,
+      buildSnippetLang: () => 'json',
+    },
+  ];
+
   const [clientId, setClientId] = useState<McpClientId>('claude');
   const [pickerOpen, setPickerOpen] = useState(false);
   const [copied, setCopied] = useState(false);
@@ -2255,13 +2222,8 @@ function IntegrationsSection() {
     <section className="settings-section">
       <div className="section-head">
         <div>
-          <h3>MCP server</h3>
-          <p className="hint">
-            Lets a coding agent in another repo (Claude Code, Cursor,
-            VS Code, Antigravity, Zed, Windsurf) read your Open Design
-            projects. Use it to pull a design into your app without
-            exporting a zip first.
-          </p>
+          <h3>{t('settings.mcpTitle')}</h3>
+          <p className="hint">{t('settings.mcpHint')}</p>
         </div>
       </div>
 
@@ -2271,9 +2233,7 @@ function IntegrationsSection() {
             className="empty-card"
             style={{ marginBottom: 14, color: 'var(--danger-fg, #f88)' }}
           >
-            Couldn&rsquo;t reach the local daemon to resolve install paths
-            ({infoError}). Make sure Open Design is running, then reopen this
-            panel.
+            {t('settings.mcpDaemonError', { error: infoError! })}
           </div>
         ) : null}
 
@@ -2287,11 +2247,10 @@ function IntegrationsSection() {
           >
             <strong>
               {!info.cliExists
-                ? 'Build the daemon first.'
-                : 'Node binary is missing.'}
+                ? t('settings.mcpBuildDaemon')
+                : t('settings.mcpNodeMissing')}
             </strong>{' '}
-            {info.buildHint ??
-              'apps/daemon/dist/cli.js is missing. Run `pnpm --filter @open-design/daemon build` and refresh.'}
+            {info.buildHint ?? t('settings.mcpBuildHint')}
           </div>
         ) : null}
 
@@ -2380,7 +2339,7 @@ function IntegrationsSection() {
               style={{ padding: '6px 14px', fontSize: 13 }}
             >
               <Icon name="link" size={14} />
-              <span style={{ marginLeft: 6 }}>{client.deeplinkLabel}</span>
+              <span style={{ marginLeft: 6 }}>{client.deeplinkLabel ? client.deeplinkLabel() : ''}</span>
             </button>
             <span
               style={{
@@ -2389,7 +2348,7 @@ function IntegrationsSection() {
                 color: 'var(--fg-2, #9aa0a6)',
               }}
             >
-              Cursor pops an approval dialog before writing the config.
+              {t('settings.mcpCursorApproval')}
             </span>
           </div>
         ) : null}
@@ -2417,8 +2376,8 @@ function IntegrationsSection() {
             <code>
               {snippet ||
                 (infoError
-                  ? '# resolving paths failed, see the error above'
-                  : '# loading install paths from the local daemon…')}
+                  ? t('settings.mcpResolvingFailed')
+                  : t('settings.mcpLoadingPaths'))}
             </code>
           </pre>
           <button
@@ -2433,10 +2392,10 @@ function IntegrationsSection() {
               padding: '4px 10px',
               fontSize: 12,
             }}
-            aria-label="Copy MCP configuration snippet"
+            aria-label={t('settings.mcpCopyAria')}
           >
             <Icon name={copied ? 'check' : 'copy'} size={14} />
-            <span style={{ marginLeft: 6 }}>{copied ? 'Copied' : 'Copy'}</span>
+            <span style={{ marginLeft: 6 }}>{copied ? t('settings.mcpCopied') : t('settings.mcpCopy')}</span>
           </button>
         </div>
 
@@ -2452,13 +2411,9 @@ function IntegrationsSection() {
             lineHeight: 1.5,
           }}
         >
-          <strong>Restart your client to pick up the new server.</strong>{' '}
+          <strong>{t('settings.mcpRestartNote')}</strong>{' '}
           <span style={{ color: 'var(--text-muted)' }}>
-            Most editors only load MCP servers at startup. In Cursor / VS
-            Code / Antigravity / Windsurf you can run{' '}
-            <code>Developer: Reload Window</code> from the command palette
-            instead of a full restart. Zed and Claude Code need a quit and
-            reopen.
+            {t('settings.mcpRestartDetail')}
           </span>
         </div>
 
@@ -2473,7 +2428,7 @@ function IntegrationsSection() {
               fontWeight: 600,
             }}
           >
-            What your agent can do
+            {t('settings.mcpCapabilitiesTitle')}
           </p>
           <ul
             style={{
@@ -2483,19 +2438,9 @@ function IntegrationsSection() {
               color: 'var(--text)',
             }}
           >
-            <li>
-              Read or search any file in a project (HTML, JSX, CSS, JSON,
-              SVG, Markdown).
-            </li>
-            <li>
-              Pull a design bundle in one call: the entry file plus every
-              CSS variable, component, and font it references.
-            </li>
-            <li>
-              Default to the project and file you have open in Open Design,
-              so you can say &ldquo;build this in my app&rdquo; without
-              re-stating which design.
-            </li>
+            <li>{t('settings.mcpCapabilityRead')}</li>
+            <li>{t('settings.mcpCapabilityPull')}</li>
+            <li>{t('settings.mcpCapabilityDefault')}</li>
           </ul>
         </div>
 
@@ -2507,9 +2452,7 @@ function IntegrationsSection() {
             lineHeight: 1.5,
           }}
         >
-          Open Design must be running for MCP tool calls to succeed. If
-          you started your coding agent before opening Open Design,
-          restart the agent so it can reach the live daemon.
+          {t('settings.mcpRunningNote')}
         </p>
       </div>
     </section>

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -153,6 +153,53 @@ export const en: Dict = {
   'settings.runtimeDevelopment': 'Development',
   'settings.versionUnavailable': 'Version details are unavailable while the daemon is offline.',
 
+  // MCP server settings
+  'settings.mcpTitle': 'MCP server',
+  'settings.mcpHint':
+    'Lets a coding agent in another repo (Claude Code, Cursor, VS Code, Antigravity, Zed, Windsurf) read your Open Design projects. Use it to pull a design into your app without exporting a zip first.',
+  'settings.mcpDaemonError':
+    "Couldn't reach the local daemon to resolve install paths ({error}). Make sure Open Design is running, then reopen this panel.",
+  'settings.mcpBuildDaemon': 'Build the daemon first.',
+  'settings.mcpNodeMissing': 'Node binary is missing.',
+  'settings.mcpBuildHint':
+    'apps/daemon/dist/cli.js is missing. Run `pnpm --filter @open-design/daemon build` and refresh.',
+  'settings.mcpMethodCli': 'CLI command',
+  'settings.mcpInstructionCli': 'Run this in your terminal.',
+  'settings.mcpMethodToml': 'TOML config',
+  'settings.mcpInstructionCodex':
+    'Append this table to {path}. The same config is shared between the Codex CLI and the Codex IDE extension.',
+  'settings.mcpMethodOneClick': 'One-click install',
+  'settings.mcpInstructionCursor':
+    'Click "Install in Cursor" to install with an approval dialog, or merge this JSON into {path}.',
+  'settings.mcpDeeplinkInstallCursor': 'Install in Cursor',
+  'settings.mcpMethodJson': 'JSON config',
+  'settings.mcpInstructionCopilot':
+    'Open the Command Palette ({shortcut}), run "MCP: Open User Configuration", and merge this JSON. Copilot Chat must be in Agent mode for tools to show up.',
+  'settings.mcpInstructionAntigravity':
+    'In Antigravity: Agent panel "..." menu → MCP Servers → Manage MCP Servers → View raw config. Merge this JSON.',
+  'settings.mcpInstructionZed':
+    'Open Zed Settings ({shortcut}) and merge this into the top-level object. Zed uses "context_servers", not "mcpServers".',
+  'settings.mcpInstructionWindsurf':
+    'Open {path} (or use the MCPs icon in Cascade → Configure) and merge:',
+  'settings.mcpCopyAria': 'Copy MCP configuration snippet',
+  'settings.mcpResolvingFailed': '# resolving paths failed, see the error above',
+  'settings.mcpLoadingPaths': '# loading install paths from the local daemon…',
+  'settings.mcpCopied': 'Copied',
+  'settings.mcpCopy': 'Copy',
+  'settings.mcpCursorApproval': 'Cursor pops an approval dialog before writing the config.',
+  'settings.mcpRestartNote': 'Restart your client to pick up the new server.',
+  'settings.mcpRestartDetail':
+    'Most editors only load MCP servers at startup. In Cursor / VS Code / Antigravity / Windsurf you can run `Developer: Reload Window` from the command palette instead of a full restart. Zed and Claude Code need a quit and reopen.',
+  'settings.mcpCapabilitiesTitle': 'What your agent can do',
+  'settings.mcpCapabilityRead':
+    'Read or search any file in a project (HTML, JSX, CSS, JSON, SVG, Markdown).',
+  'settings.mcpCapabilityPull':
+    'Pull a design bundle in one call: the entry file plus every CSS variable, component, and font it references.',
+  'settings.mcpCapabilityDefault':
+    'Default to the project and file you have open in Open Design, so you can say "build this in my app" without re-stating which design.',
+  'settings.mcpRunningNote':
+    'Open Design must be running for MCP tool calls to succeed. If you started your coding agent before opening Open Design, restart the agent so it can reach the live daemon.',
+
   'entry.tabDesigns': 'Designs',
   'entry.tabExamples': 'Examples',
   'entry.tabDesignSystems': 'Design systems',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
+import { en } from './en';
 
 export const fa: Dict = {
+  ...en,
   'common.cancel': 'لغو',
   'common.save': 'ذخیره',
   'common.close': 'بستن',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
+import { en } from './en';
 
 export const id: Dict = {
+  ...en,
   'common.cancel': 'Batal',
   'common.save': 'Simpan',
   'common.close': 'Tutup',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
+import { en } from './en';
 
 export const ptBR: Dict = {
+  ...en,
   'common.cancel': 'Cancelar',
   'common.save': 'Salvar',
   'common.close': 'Fechar',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
+import { en } from './en';
 
 export const ru: Dict = {
+  ...en,
   'common.cancel': 'Отмена',
   'common.save': 'Сохранить',
   'common.close': 'Закрыть',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
+import { en } from './en';
 
 export const uk: Dict = {
+  ...en,
   'common.cancel': 'Скасувати',
   'common.save': 'Зберегти',
   'common.close': 'Закрити',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -151,6 +151,53 @@ export const zhCN: Dict = {
   'settings.runtimeDevelopment': '开发环境',
   'settings.versionUnavailable': '守护进程离线时无法获取版本详情。',
 
+  // MCP server settings
+  'settings.mcpTitle': 'MCP server',
+  'settings.mcpHint':
+    '让其他仓库中的编码助手（Claude Code、Cursor、VS Code、Antigravity、Zed、Windsurf）读取你的 Open Design 项目。无需先导出 zip，即可将设计拉取到你的应用中。',
+  'settings.mcpDaemonError':
+    '无法连接到本地守护进程以解析安装路径（{error}）。请确保 Open Design 正在运行，然后重新打开此面板。',
+  'settings.mcpBuildDaemon': '请先构建守护进程。',
+  'settings.mcpNodeMissing': 'Node 二进制文件缺失。',
+  'settings.mcpBuildHint':
+    'apps/daemon/dist/cli.js 缺失。请运行 `pnpm --filter @open-design/daemon build` 并刷新。',
+  'settings.mcpMethodCli': 'CLI 命令',
+  'settings.mcpInstructionCli': '在你的终端中运行此命令。',
+  'settings.mcpMethodToml': 'TOML 配置',
+  'settings.mcpInstructionCodex':
+    '将以下配置追加到 {path}。Codex CLI 与 Codex IDE 扩展共享同一配置。',
+  'settings.mcpMethodOneClick': '一键安装',
+  'settings.mcpInstructionCursor':
+    '点击"在 Cursor 中安装"以通过确认对话框安装，或将此 JSON 合并到 {path}。',
+  'settings.mcpDeeplinkInstallCursor': '在 Cursor 中安装',
+  'settings.mcpMethodJson': 'JSON 配置',
+  'settings.mcpInstructionCopilot':
+    '打开命令面板（{shortcut}），运行 "MCP: Open User Configuration"，然后合并此 JSON。Copilot Chat 必须处于 Agent 模式，工具才会显示。',
+  'settings.mcpInstructionAntigravity':
+    '在 Antigravity 中：Agent 面板 "..." 菜单 → MCP Servers → Manage MCP Servers → View raw config。合并此 JSON。',
+  'settings.mcpInstructionZed':
+    '打开 Zed Settings（{shortcut}），然后将此配置合并到顶层对象中。Zed 使用 "context_servers"，而非 "mcpServers"。',
+  'settings.mcpInstructionWindsurf':
+    '打开 {path}（或在 Cascade 中使用 MCPs 图标 → Configure）并合并：',
+  'settings.mcpCopyAria': '复制 MCP 配置片段',
+  'settings.mcpResolvingFailed': '# 解析路径失败，请查看上方错误',
+  'settings.mcpLoadingPaths': '# 正在从本地守护进程加载安装路径…',
+  'settings.mcpCopied': '已复制',
+  'settings.mcpCopy': '复制',
+  'settings.mcpCursorApproval': 'Cursor 会在写入配置前弹出确认对话框。',
+  'settings.mcpRestartNote': '重启客户端以加载新 server。',
+  'settings.mcpRestartDetail':
+    '大多数编辑器仅在启动时加载 MCP server。在 Cursor / VS Code / Antigravity / Windsurf 中，你可以在命令面板中运行 `Developer: Reload Window`，无需完全重启。Zed 和 Claude Code 需要退出并重新打开。',
+  'settings.mcpCapabilitiesTitle': '你的助手可以做什么',
+  'settings.mcpCapabilityRead':
+    '读取或搜索项目中的任意文件（HTML、JSX、CSS、JSON、SVG、Markdown）。',
+  'settings.mcpCapabilityPull':
+    '一次调用拉取设计包：入口文件及其引用的所有 CSS 变量、组件和字体。',
+  'settings.mcpCapabilityDefault':
+    '默认使用你在 Open Design 中打开的项目和文件，因此你可以直接说"在我的应用中构建这个"，无需重复说明是哪个设计。',
+  'settings.mcpRunningNote':
+    'Open Design 必须处于运行状态，MCP 工具调用才能成功。如果你在打开 Open Design 之前启动了编码助手，请重启助手以便它能连接到正在运行的守护进程。',
+
   'entry.tabDesigns': '我的设计',
   'entry.tabExamples': '示例',
   'entry.tabDesignSystems': '设计体系',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -151,6 +151,53 @@ export const zhTW: Dict = {
   'settings.runtimeDevelopment': '開發環境',
   'settings.versionUnavailable': '守護程式離線時無法取得版本詳情。',
 
+  // MCP server settings
+  'settings.mcpTitle': 'MCP server',
+  'settings.mcpHint':
+    '讓其他專案中的程式碼代理（Claude Code、Cursor、VS Code、Antigravity、Zed、Windsurf）讀取您的 Open Design 專案。您可以直接將設計匯入應用程式，無需先匯出 zip。',
+  'settings.mcpDaemonError':
+    '無法連線到本地守護程序以解析安裝路徑（{error}）。請確認 Open Design 正在執行，然後重新開啟此面板。',
+  'settings.mcpBuildDaemon': '請先建置守護行程。',
+  'settings.mcpNodeMissing': '缺少 Node 執行檔。',
+  'settings.mcpBuildHint':
+    '缺少 apps/daemon/dist/cli.js。請執行 `pnpm --filter @open-design/daemon build` 後重新整理。',
+  'settings.mcpMethodCli': 'CLI 指令',
+  'settings.mcpInstructionCli': '在您的終端機中執行此指令。',
+  'settings.mcpMethodToml': 'TOML 設定檔',
+  'settings.mcpInstructionCodex':
+    '將此表格附加到 {path}。Codex CLI 與 Codex IDE 擴充功能共用相同的設定。',
+  'settings.mcpMethodOneClick': '一鍵安裝',
+  'settings.mcpInstructionCursor':
+    '點擊「在 Cursor 中安裝」以透過核准對話框安裝，或將此 JSON 合併至 {path}。',
+  'settings.mcpDeeplinkInstallCursor': '在 Cursor 中安裝',
+  'settings.mcpMethodJson': 'JSON 設定檔',
+  'settings.mcpInstructionCopilot':
+    '開啟 Command Palette（{shortcut}），執行「MCP: Open User Configuration」，然後合併此 JSON。Copilot Chat 必須處於 Agent 模式，工具才會顯示。',
+  'settings.mcpInstructionAntigravity':
+    '在 Antigravity 中：Agent 面板「⋯」選單 → MCP Servers → Manage MCP Servers → View raw config。合併此 JSON。',
+  'settings.mcpInstructionZed':
+    '開啟 Zed Settings（{shortcut}），然後將此內容合併至最上層物件。Zed 使用「context_servers」，而非「mcpServers」。',
+  'settings.mcpInstructionWindsurf':
+    '開啟 {path}（或使用 Cascade 中的 MCPs 圖示 → Configure）並合併：',
+  'settings.mcpCopyAria': '複製 MCP 設定片段',
+  'settings.mcpResolvingFailed': '# 解析路徑失敗，請見上方錯誤',
+  'settings.mcpLoadingPaths': '# 正在從本地守護行程載入安裝路徑…',
+  'settings.mcpCopied': '已複製',
+  'settings.mcpCopy': '複製',
+  'settings.mcpCursorApproval': 'Cursor 會在寫入設定檔前彈出核准對話框。',
+  'settings.mcpRestartNote': '重新啟動您的客戶端以套用新的 server。',
+  'settings.mcpRestartDetail':
+    '大部分編輯器只在啟動時載入 MCP server。在 Cursor / VS Code / Antigravity / Windsurf 中，您可以從 Command Palette 執行「Developer: Reload Window」，無需完整重新啟動。Zed 與 Claude Code 則需要結束並重新開啟。',
+  'settings.mcpCapabilitiesTitle': '您的 agent 可以執行的操作',
+  'settings.mcpCapabilityRead':
+    '讀取或搜尋專案中的任何檔案（HTML、JSX、CSS、JSON、SVG、Markdown）。',
+  'settings.mcpCapabilityPull':
+    '透過單一呼叫拉取設計套件：包含進入點檔案以及所有引用的 CSS 變數、元件與字型。',
+  'settings.mcpCapabilityDefault':
+    '預設使用您在 Open Design 中開啟的專案與檔案，因此您可以說「在我的應用程式中建置這個」，無需重新說明是哪個設計。',
+  'settings.mcpRunningNote':
+    'Open Design 必須正在執行，MCP 工具呼叫才能成功。如果您在開啟 Open Design 之前就已啟動 coding agent，請重新啟動 agent，使其能夠連線到正在執行的守護行程。',
+
   'entry.tabDesigns': '我的設計',
   'entry.tabExamples': '範例',
   'entry.tabDesignSystems': '設計系統',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -187,6 +187,39 @@ export interface Dict {
   'settings.libraryDisabled': string;
   'settings.libraryToggleLabel': string;
 
+  // MCP server settings
+  'settings.mcpTitle': string;
+  'settings.mcpHint': string;
+  'settings.mcpDaemonError': string;
+  'settings.mcpBuildDaemon': string;
+  'settings.mcpNodeMissing': string;
+  'settings.mcpBuildHint': string;
+  'settings.mcpMethodCli': string;
+  'settings.mcpInstructionCli': string;
+  'settings.mcpMethodToml': string;
+  'settings.mcpInstructionCodex': string;
+  'settings.mcpMethodOneClick': string;
+  'settings.mcpInstructionCursor': string;
+  'settings.mcpDeeplinkInstallCursor': string;
+  'settings.mcpMethodJson': string;
+  'settings.mcpInstructionCopilot': string;
+  'settings.mcpInstructionAntigravity': string;
+  'settings.mcpInstructionZed': string;
+  'settings.mcpInstructionWindsurf': string;
+  'settings.mcpCopyAria': string;
+  'settings.mcpResolvingFailed': string;
+  'settings.mcpLoadingPaths': string;
+  'settings.mcpCopied': string;
+  'settings.mcpCopy': string;
+  'settings.mcpCursorApproval': string;
+  'settings.mcpRestartNote': string;
+  'settings.mcpRestartDetail': string;
+  'settings.mcpCapabilitiesTitle': string;
+  'settings.mcpCapabilityRead': string;
+  'settings.mcpCapabilityPull': string;
+  'settings.mcpCapabilityDefault': string;
+  'settings.mcpRunningNote': string;
+
   // Notifications (settings + system notifications)
   'settings.notifications': string;
   'settings.notificationsHint': string;


### PR DESCRIPTION
Fixes #745

## Summary

Localizes all user-facing strings in the MCP server settings panel that were previously hardcoded in English. When the UI language is set to Chinese (zh-CN or zh-TW), the MCP panel now displays localized text consistently with the rest of the settings surface.

## Changes

- **types.ts**: Added 31 typed `settings.mcp*` keys
- **en.ts**: Added English source values
- **zh-CN.ts / zh-TW.ts**: Added Simplified and Traditional Chinese translations
- **SettingsDialog.tsx**:
  - Moved `MCP_CLIENTS` from global const into `IntegrationsSection` so `buildMethod`/`buildInstruction`/`deeplinkLabel` can use `t()`
  - Wired all JSX strings through `useI18n`
  - Changed `deeplinkLabel` from `string` to `() => string` for dynamic translation

## What was NOT translated (per maintainer guidance)

- Code snippets / JSON config examples
- Product names (Claude Code, Cursor, VS Code, etc.)
- File paths and CLI commands
- Technical terms (MCP, JSON, TOML, CLI)

## Verification

- TypeScript types are consistent across all locale files
- Interpolation placeholders (`{error}`, `{path}`, `{shortcut}`) are preserved
- Terminology is consistent with existing settings UI in each locale