### PR TITLE
fix(daemon): accept portless loopback Origin headers in CORS allowlist (#733)

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1336,15 +1336,26 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
     if (webPort && webPort !== resolvedPort) ports.push(webPort);
     const schemes = ['http', 'https'];
     const loopbackHosts = ['127.0.0.1', 'localhost', '[::1]'];
-    return new Set(
-      ports.flatMap((p) => [
+    return new Set([
+      ...ports.flatMap((p) => [
         ...schemes.flatMap((s) => loopbackHosts.map((h) => `${s}://${h}:${p}`)),
         // When bound to a specific non-loopback address (e.g. Tailscale,
         // LAN IP, or 0.0.0.0), allow browser requests from that address
         // too so the documented --host escape hatch remains usable.
         ...schemes.map((s) => `${s}://${host}:${p}`),
       ]),
-    );
+      // Some browser builds (observed on Chrome on Windows under certain
+      // localhost-with-non-standard-port profiles, issue #733) serialize
+      // the Origin header without the port, e.g. `http://127.0.0.1`
+      // instead of `http://127.0.0.1:6313`. The cross-origin policy is
+      // still loopback-only — port-less means "the same origin's host
+      // without a port" — so accepting these portless variants doesn't
+      // widen the trust boundary, just makes the matcher tolerant of
+      // how individual browsers serialize the header. Without this,
+      // every /api request from such a browser dies with 403.
+      ...schemes.flatMap((s) => loopbackHosts.map((h) => `${s}://${h}`)),
+      ...schemes.map((s) => `${s}://${host}`),
+    ]);
   }
 
   // Routes that serve content to sandboxed iframes (Origin: null) for
@@ -5128,11 +5139,16 @@ export function isLocalSameOrigin(req, port) {
   if (origin == null || origin === '') return true;
 
   const schemes = ['http', 'https'];
-  const allowedOrigins = new Set(
-    ports.flatMap((p) => [
+  const allowedOrigins = new Set([
+    ...ports.flatMap((p) => [
       ...schemes.flatMap((s) => loopbackHosts.map((h) => `${s}://${h}:${p}`)),
       ...schemes.map((s) => `${s}://${bindHost}:${p}`),
     ]),
-  );
+    // Match `buildAllowedOrigins()`: accept the portless serializations
+    // some browsers emit on localhost (issue #733). Loopback-only, so
+    // the trust boundary doesn't change.
+    ...schemes.flatMap((s) => loopbackHosts.map((h) => `${s}://${h}`)),
+    ...schemes.map((s) => `${s}://${bindHost}`),
+  ]);
   return allowedOrigins.has(String(origin));
 }

--- a/apps/daemon/tests/origin-validation.test.ts
+++ b/apps/daemon/tests/origin-validation.test.ts
@@ -32,12 +32,16 @@ function createOriginMiddleware(resolvedPort, host = '127.0.0.1') {
     if (webPort && webPort !== resolvedPort) ports.push(webPort);
     const schemes = ['http', 'https'];
     const loopbackHosts = ['127.0.0.1', 'localhost', '[::1]'];
-    const allowedOrigins = new Set(
-      ports.flatMap((p) => [
+    const allowedOrigins = new Set([
+      ...ports.flatMap((p) => [
         ...schemes.flatMap((s) => loopbackHosts.map((h) => `${s}://${h}:${p}`)),
         ...schemes.map((s) => `${s}://${host}:${p}`),
       ]),
-    );
+      // Mirror buildAllowedOrigins(): accept the portless serializations
+      // some browsers emit on localhost (issue #733).
+      ...schemes.flatMap((s) => loopbackHosts.map((h) => `${s}://${h}`)),
+      ...schemes.map((s) => `${s}://${host}`),
+    ]);
     if (!allowedOrigins.has(String(origin))) {
       return res.status(403).json({ error: 'Cross-origin requests are not allowed' });
     }
@@ -145,6 +149,48 @@ describe('daemon origin validation middleware', () => {
       origin: `https://127.0.0.1:${port}`,
     });
     expect(res.status).toBe(200);
+  });
+
+  // --- Portless Origin (issue #733) ---
+  // Some browser builds (observed on Chrome under Windows when serving
+  // localhost on a non-standard port) send the Origin header without
+  // the port — `http://127.0.0.1` instead of `http://127.0.0.1:6313`.
+  // The middleware must accept these portless loopback variants so
+  // every /api request from such a browser doesn't 403.
+
+  it('allows portless Origin: http://127.0.0.1 (loopback, no port)', async () => {
+    const res = await request(port, 'GET', '/api/projects', {
+      origin: 'http://127.0.0.1',
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('allows portless Origin: http://localhost (loopback, no port)', async () => {
+    const res = await request(port, 'GET', '/api/projects', {
+      origin: 'http://localhost',
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('allows portless Origin: http://[::1] (IPv6 loopback, no port)', async () => {
+    const res = await request(port, 'GET', '/api/projects', {
+      origin: 'http://[::1]',
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('allows portless Origin via HTTPS', async () => {
+    const res = await request(port, 'GET', '/api/projects', {
+      origin: 'https://127.0.0.1',
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('still blocks non-loopback portless Origins (security boundary preserved)', async () => {
+    const res = await request(port, 'GET', '/api/projects', {
+      origin: 'http://evil.com',
+    });
+    expect(res.status).toBe(403);
   });
 
   // --- Origin: null (sandboxed iframe previews) ---
@@ -320,5 +366,12 @@ describe('origin validation: non-loopback bind host', () => {
       origin: `http://evil.com:${port}`,
     });
     expect(res.status).toBe(403);
+  });
+
+  it('allows portless Origin from the non-loopback bind host (issue #733)', async () => {
+    const res = await request(port, 'GET', '/api/projects', {
+      origin: `http://${nonLoopbackHost}`,
+    });
+    expect(res.status).toBe(200);
   });
 });


### PR DESCRIPTION
## Summary

- Some browser builds (observed on Chrome under Windows when serving localhost on a non-standard port) serialize the `Origin` request header **without the port** — `http://127.0.0.1` instead of `http://127.0.0.1:6313`. The daemon's allowlist only constructs port-bearing origins (`buildAllowedOrigins()` and `isLocalSameOrigin()` in [`apps/daemon/src/server.ts`](https://github.com/nexu-io/open-design/blob/main/apps/daemon/src/server.ts)), so portless variants miss every entry and every `/api/*` request dies with `403 Cross-origin requests are not allowed`. Incognito mode dodges it because it serializes the port the way the spec says to (issue #733 has the full repro).
- Adds the portless serializations (`http://127.0.0.1`, `http://localhost`, `http://[::1]`, https variants, and the explicit bind host) to both functions. **Trust boundary unchanged**: still loopback-only, plus the documented non-loopback `--host` escape hatch the existing port-bearing entries already allow. `http://evil.com` and other non-loopback portless origins remain blocked.
- Mirrors the patch in [`origin-validation.test.ts`'s `createOriginMiddleware()` helper](https://github.com/nexu-io/open-design/blob/main/apps/daemon/tests/origin-validation.test.ts#L11) so tests exercise the real shape, and adds 6 new tests covering the portless cases — including a negative test confirming `http://evil.com` still 403s.

Fixes #733. Reported with full diagnosis and a candidate patch by @JHR-deve — this PR is essentially landing their proposal verbatim with tests.

## Why the trust boundary doesn't widen

The allowlist construction is keyed on **host**, not host-plus-port. Adding portless variants of hosts that are already in the loopback set is just being tolerant of how individual browsers serialize the `Origin` header — it doesn't admit any host that wasn't already accepted with a port. Verified by the `still blocks non-loopback portless Origins (security boundary preserved)` test.

The non-loopback bind host (`OD_BIND_HOST`, e.g. Tailscale or LAN IP under `--host`) is already accepted with a port; adding its portless form is consistent with that policy.

## Diff shape

| File | What changes |
|---|---|
| `apps/daemon/src/server.ts` | `buildAllowedOrigins()` (line 1333) and `isLocalSameOrigin()` (line 5103) each gain 4 portless allowlist entries: `http`/`https` × `127.0.0.1`/`localhost`/`[::1]` plus `http`/`https` × bind host. Comments cite issue #733 for archaeology. |
| `apps/daemon/tests/origin-validation.test.ts` | `createOriginMiddleware()` helper updated to mirror the real middleware. 6 new test cases covering the portless code paths. |

2 files, +78 / −9.

## What's verified

| Check | Result |
|---|---|
| `vitest run tests/origin-validation.test.ts` | **25/25** (was 19, added 6) |
| `vitest run` (full daemon suite) | **923/923** across 63 test files |
| `tsc -p apps/daemon/tsconfig.json --noEmit` | clean |

## What's NOT verified

I don't have a Windows + Chrome 147 setup to exercise the actual portless-Origin browser path end-to-end. The structural argument is:

1. The reporter's repro is concrete (`Origin: http://127.0.0.1` reaching the middleware → 403). Their fix proposal is exactly what this PR lands.
2. The new positive tests exercise that exact `Origin` shape against the same allowlist function the daemon uses at runtime.
3. The new negative test confirms `http://evil.com` (non-loopback, no port) still 403s, so the trust boundary is preserved.

If @JHR-deve can pull this branch and rerun the rescan in Chrome normal mode, that closes the loop end-to-end.

## Test plan

- [x] Existing 19 origin-validation tests still pass.
- [x] 6 new tests covering portless loopback variants.
- [x] Full daemon test suite (923 tests) green.
- [x] Daemon typecheck clean.
- [ ] Manual smoke on Windows + Chrome normal mode: `pnpm tools-dev start web`, click Settings → Rescan, confirm no 403 on `/api/connectors/status`.
- [ ] Same smoke on Firefox / Safari / Chrome incognito to confirm no regression in the previously-working port-bearing path.