### PR TITLE
fix(daemon): make ACP stage timeout configurable + raise default to 10min (#646)

### DIFF
--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -4,7 +4,12 @@ import path from 'node:path';
 
 const ACP_PROTOCOL_VERSION = 1;
 const DEFAULT_TIMEOUT_MS = 15_000;
-const DEFAULT_STAGE_TIMEOUT_MS = 180_000;
+// Allow user-configurable stage timeout via OD_ACP_TIMEOUT_MS env var.
+// Default increased from 180s to 600s (10 minutes) to support complex tasks
+// like repo analysis + multi-page document generation (issue #646).
+const DEFAULT_STAGE_TIMEOUT_MS = process.env.OD_ACP_TIMEOUT_MS 
+  ? parseInt(process.env.OD_ACP_TIMEOUT_MS, 10) 
+  : 600_000;
 
 export function buildAcpSessionNewParams(cwd, { mcpServers } = {}) {
   const servers = Array.isArray(mcpServers) ? mcpServers : [];


### PR DESCRIPTION
Fixes #646

## Background
Issue #646 reported `ACP response timed out after 180000ms` when running complex tasks (Hermes analyzing the open-design repo + generating multi-page slide deck). The 3-minute default was too short for tasks requiring large-context Codex/Claude Code calls.

## Change
- Add env var `OD_ACP_TIMEOUT_MS` (milliseconds) to override the stage timeout at runtime
- Raise default from 180000 (3 min) to 600000 (10 min) — covers most repo analysis + multi-page document generation flows
- Code comment now references issue #646 + the user-configurable path

## Test plan
- [ ] Repro from #646: launch "分析 open-design 仓库 + 生成杂志风格 PPT" — confirm no 180s timeout
- [ ] Set `OD_ACP_TIMEOUT_MS=900000` env, launch a task — confirm 15-min budget honored
- [ ] Default behavior: tasks under 10 min should be unchanged

---
🤖 Authored by LooperBot per #646 maintainer request (feishu group, 2026-05-07).