### PR TITLE
fix(postinstall): auto-rebuild better-sqlite3 on Node.js ABI mismatch

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -214,7 +214,7 @@ open-design/
 
 ## Troubleshooting
 
-- **`better-sqlite3` fails to load / ABI mismatch after a Node.js version change** — `pnpm install` re-runs `postinstall` automatically and rebuilds the native addon. If you have `ignore-scripts=true` in your `.npmrc` (or used `pnpm install --ignore-scripts`), run it manually: `node scripts/postinstall.mjs`
+- **`better-sqlite3` fails to load / ABI mismatch after a Node.js version change** — `pnpm install` re-runs `postinstall` automatically and rebuilds the native addon for the current Node.js. To rebuild manually or verify the fix: `pnpm --filter @open-design/daemon rebuild better-sqlite3` then `node -e "require('better-sqlite3')"`. Requires build tools: `python3`, `make`, `g++` (or `clang++`). If you have `ignore-scripts=true` in your `.npmrc`, run `node scripts/postinstall.mjs` after `pnpm install`.
 - **"no agents found on PATH"** — install one of: `claude`, `codex`, `devin`, `gemini`, `opencode`, `cursor-agent`, `qwen`, `qodercli`, `copilot`. Or switch to API mode in Settings and paste a provider key.
 - **daemon 500 on /api/chat** — check the daemon terminal for the stderr tail; usually the CLI rejected its args. Different CLIs take different argv shapes; see `apps/daemon/src/agents.ts` `buildArgs` if you need to tweak.
 - **media generation says `OD_BIN` is missing or daemon URL is `:0`** — run the media dispatcher checks above. Do not resume the old CLI session; reopen the project from the Open Design app so the daemon can inject fresh `OD_*` variables.

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -214,7 +214,7 @@ open-design/
 
 ## Troubleshooting
 
-- **`better-sqlite3` fails to load / ABI mismatch after a Node.js version change** — `pnpm install` re-runs `postinstall` automatically and rebuilds the native addon for the current Node.js. To rebuild manually or verify the fix: `pnpm --filter @open-design/daemon rebuild better-sqlite3` then `node -e "require('better-sqlite3')"`. Requires build tools: `python3`, `make`, `g++` (or `clang++`). If you have `ignore-scripts=true` in your `.npmrc`, run `node scripts/postinstall.mjs` after `pnpm install`.
+- **`better-sqlite3` fails to load / ABI mismatch after a Node.js version change** — `pnpm install` re-runs `postinstall` automatically and rebuilds the native addon for the current Node.js. To rebuild manually or verify the fix: `pnpm --filter @open-design/daemon rebuild better-sqlite3` then `pnpm --filter @open-design/daemon exec node -e "require('better-sqlite3')"`. Requires build tools: `python3`, `make`, `g++` (or `clang++`). If you have `ignore-scripts=true` in your `.npmrc`, run `node scripts/postinstall.mjs` after `pnpm install`.
 - **"no agents found on PATH"** — install one of: `claude`, `codex`, `devin`, `gemini`, `opencode`, `cursor-agent`, `qwen`, `qodercli`, `copilot`. Or switch to API mode in Settings and paste a provider key.
 - **daemon 500 on /api/chat** — check the daemon terminal for the stderr tail; usually the CLI rejected its args. Different CLIs take different argv shapes; see `apps/daemon/src/agents.ts` `buildArgs` if you need to tweak.
 - **media generation says `OD_BIN` is missing or daemon URL is `:0`** — run the media dispatcher checks above. Do not resume the old CLI session; reopen the project from the Open Design app so the daemon can inject fresh `OD_*` variables.

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -214,6 +214,7 @@ open-design/
 
 ## Troubleshooting
 
+- **`better-sqlite3` fails to load / ABI mismatch after a Node.js version change** — `pnpm install` re-runs `postinstall` automatically and rebuilds the native addon. If you have `ignore-scripts=true` in your `.npmrc` (or used `pnpm install --ignore-scripts`), run it manually: `node scripts/postinstall.mjs`
 - **"no agents found on PATH"** — install one of: `claude`, `codex`, `devin`, `gemini`, `opencode`, `cursor-agent`, `qwen`, `qodercli`, `copilot`. Or switch to API mode in Settings and paste a provider key.
 - **daemon 500 on /api/chat** — check the daemon terminal for the stderr tail; usually the CLI rejected its args. Different CLIs take different argv shapes; see `apps/daemon/src/agents.ts` `buildArgs` if you need to tweak.
 - **media generation says `OD_BIN` is missing or daemon URL is `:0`** — run the media dispatcher checks above. Do not resume the old CLI session; reopen the project from the Open Design app so the daemon can inject fresh `OD_*` variables.

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -1,5 +1,4 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, realpathSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, extname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -52,48 +51,38 @@ for (const target of buildTargets) {
 }
 
 // Verify the better-sqlite3 native addon loads under the current Node.js ABI.
-// prebuild-install may have fetched a prebuilt binary for a different ABI (e.g.
-// after switching between Node 22 / 24 / 25). When the addon fails to dlopen,
-// rebuild from source using the node-gyp bundled with better-sqlite3 in the
-// pnpm virtual store — no external tooling required beyond a C++ compiler.
-const b3Link = resolve(repoRoot, "node_modules", "better-sqlite3");
-if (existsSync(b3Link)) {
-  const req = createRequire(import.meta.url);
-  let b3Loads = false;
-  try {
-    req(b3Link);
-    b3Loads = true;
-  } catch {}
+// better-sqlite3 is a dep of apps/daemon (not the workspace root), so resolve
+// it from the daemon package context. prebuild-install may have fetched a
+// prebuilt binary for a different ABI (e.g. after switching between Node 22 /
+// 24 / 25). When the addon fails to dlopen, pnpm rebuild handles the rebuild
+// using its own node-gyp lifecycle — no assumptions about where node-gyp lives.
+const req = createRequire(resolve(repoRoot, "apps/daemon/package.json"));
+let needsRebuild = false;
+try {
+  req("better-sqlite3");
+} catch (e) {
+  // MODULE_NOT_FOUND means daemon deps aren't installed yet — not our problem.
+  // Any other error (ERR_DLOPEN_FAILED, ABI mismatch, etc.) warrants a rebuild.
+  if (e?.code !== "MODULE_NOT_FOUND") {
+    needsRebuild = true;
+  }
+}
 
-  if (!b3Loads) {
-    // realpathSync resolves the pnpm symlink to the actual store path, e.g.
-    // node_modules/.pnpm/better-sqlite3@X.Y.Z/node_modules/better-sqlite3
-    // node-gyp is a direct dep and lives one level up in the same subtree.
-    const b3Dir = realpathSync(b3Link);
-    const nodeGypScript = resolve(b3Dir, "..", "node-gyp", "bin", "node-gyp.js");
-
-    if (!existsSync(nodeGypScript)) {
-      process.stderr.write(
-        "postinstall: node-gyp not found in the pnpm store alongside better-sqlite3.\n" +
-          "Run `pnpm install` again, or install build tools and retry.\n",
-      );
-      process.exit(1);
-    }
-
-    process.stdout.write(
-      `postinstall: rebuilding better-sqlite3 for Node.js ${process.version}...\n`,
+if (needsRebuild) {
+  process.stdout.write(
+    `postinstall: rebuilding better-sqlite3 for Node.js ${process.version}...\n`,
+  );
+  const rebuild = spawnSync(
+    packageManager.command,
+    [...packageManager.argsPrefix, "--filter", "@open-design/daemon", "rebuild", "better-sqlite3"],
+    { cwd: repoRoot, stdio: "inherit" },
+  );
+  if (rebuild.error != null) throw rebuild.error;
+  if (rebuild.status !== 0) {
+    process.stderr.write(
+      "postinstall: better-sqlite3 rebuild failed.\n" +
+        "Install build tools (python3, make, g++ or clang++) then run: pnpm install\n",
     );
-    const rebuild = spawnSync(process.execPath, [nodeGypScript, "rebuild"], {
-      cwd: b3Dir,
-      stdio: "inherit",
-    });
-    if (rebuild.error != null) throw rebuild.error;
-    if (rebuild.status !== 0) {
-      process.stderr.write(
-        "postinstall: better-sqlite3 rebuild failed.\n" +
-          "Install build tools (python3, make, g++ or clang++) then run: pnpm install\n",
-      );
-      process.exit(rebuild.status ?? 1);
-    }
+    process.exit(rebuild.status ?? 1);
   }
 }

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -1,4 +1,6 @@
 import { spawnSync } from "node:child_process";
+import { existsSync, realpathSync } from "node:fs";
+import { createRequire } from "node:module";
 import { dirname, extname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -46,5 +48,52 @@ for (const target of buildTargets) {
 
   if (result.status !== 0) {
     process.exit(result.status ?? 1);
+  }
+}
+
+// Verify the better-sqlite3 native addon loads under the current Node.js ABI.
+// prebuild-install may have fetched a prebuilt binary for a different ABI (e.g.
+// after switching between Node 22 / 24 / 25). When the addon fails to dlopen,
+// rebuild from source using the node-gyp bundled with better-sqlite3 in the
+// pnpm virtual store — no external tooling required beyond a C++ compiler.
+const b3Link = resolve(repoRoot, "node_modules", "better-sqlite3");
+if (existsSync(b3Link)) {
+  const req = createRequire(import.meta.url);
+  let b3Loads = false;
+  try {
+    req(b3Link);
+    b3Loads = true;
+  } catch {}
+
+  if (!b3Loads) {
+    // realpathSync resolves the pnpm symlink to the actual store path, e.g.
+    // node_modules/.pnpm/better-sqlite3@X.Y.Z/node_modules/better-sqlite3
+    // node-gyp is a direct dep and lives one level up in the same subtree.
+    const b3Dir = realpathSync(b3Link);
+    const nodeGypScript = resolve(b3Dir, "..", "node-gyp", "bin", "node-gyp.js");
+
+    if (!existsSync(nodeGypScript)) {
+      process.stderr.write(
+        "postinstall: node-gyp not found in the pnpm store alongside better-sqlite3.\n" +
+          "Run `pnpm install` again, or install build tools and retry.\n",
+      );
+      process.exit(1);
+    }
+
+    process.stdout.write(
+      `postinstall: rebuilding better-sqlite3 for Node.js ${process.version}...\n`,
+    );
+    const rebuild = spawnSync(process.execPath, [nodeGypScript, "rebuild"], {
+      cwd: b3Dir,
+      stdio: "inherit",
+    });
+    if (rebuild.error != null) throw rebuild.error;
+    if (rebuild.status !== 0) {
+      process.stderr.write(
+        "postinstall: better-sqlite3 rebuild failed.\n" +
+          "Install build tools (python3, make, g++ or clang++) then run: pnpm install\n",
+      );
+      process.exit(rebuild.status ?? 1);
+    }
   }
 }


### PR DESCRIPTION
## Problem

`pnpm install` uses `prebuild-install` to fetch a prebuilt `better-sqlite3`
binary for the Node.js version active at install time. On systems where the
running Node ABI differs from Node 24 — Arch Linux system Node (currently 25),
`nodejs-lts-jod` (Node 22), or any environment where nvm/fnm isn't in use —
the addon silently installs but then fails to dlopen at daemon startup with an
ABI mismatch error. This also breaks AUR package builds under makepkg/fakeroot.

Related: #214

## Fix

`scripts/postinstall.mjs` now verifies the native addon loads after the
workspace builds complete. On failure it:

1. Resolves the pnpm symlink to the actual store path for `better-sqlite3`
2. Locates `node-gyp` from the pnpm virtual store (bundled as a direct dep of
   `better-sqlite3`, so no external tooling needed beyond a C++ compiler)
3. Runs `node-gyp rebuild` in the package directory against the current Node.js

`pnpm install` becomes self-healing across Node versions without requiring
nvm, fnm, or any other version manager.

A QUICKSTART troubleshooting entry is added for the edge case where
`ignore-scripts=true` prevents postinstall from running automatically.

## Changes

- `scripts/postinstall.mjs` — ABI check + conditional rebuild (~45 lines)
- `QUICKSTART.md` — one troubleshooting bullet for `ignore-scripts` users