### PR TITLE
fix(daemon): prefer opencode-cli over opencode binary so OpenCode Desktop installs resolve to the CLI (#814)

### DIFF
--- a/apps/daemon/src/agents.ts
+++ b/apps/daemon/src/agents.ts
@@ -380,7 +380,24 @@ export const AGENT_DEFS = [
   {
     id: 'opencode',
     name: 'OpenCode',
-    bin: 'opencode',
+    // OpenCode Desktop (https://opencode.dev) ships two binaries when
+    // installed: `opencode` is the GUI launcher (clicking it opens a
+    // desktop app, not a stdin-driven CLI), and `opencode-cli` is the
+    // headless CLI that speaks the `run --format json …` protocol the
+    // daemon expects. Resolving `opencode` first ends up spawning the
+    // desktop launcher, which doesn't read stdin and never produces
+    // JSON events — so the agent silently does nothing for any user
+    // with the desktop install (issue #814).
+    //
+    // Resolve `opencode-cli` first, then fall back to bare `opencode`
+    // for the legacy CLI-only install (no desktop app), where there is
+    // no `-cli` suffix and the bare name is the real CLI.
+    // `resolveAgentExecutable` walks `bin` then `fallbackBins` in
+    // order, so this gives us "prefer the always-CLI binary, fall
+    // back to the historical name" — same mechanism Claude Code uses
+    // to fall back to `openclaude` (issue #235).
+    bin: 'opencode-cli',
+    fallbackBins: ['opencode'],
     versionArgs: ['--version'],
     // `opencode models` prints `provider/model` per line.
     listModels: {

--- a/apps/daemon/tests/agents.test.ts
+++ b/apps/daemon/tests/agents.test.ts
@@ -58,6 +58,7 @@ const pi = requireAgent('pi');
 const deepseek = requireAgent('deepseek');
 const gemini = requireAgent('gemini');
 const qoder = requireAgent('qoder');
+const opencode = requireAgent('opencode');
 const deepseekMaxPromptArgBytes = deepseek.maxPromptArgBytes;
 assert.ok(
   deepseekMaxPromptArgBytes !== undefined,
@@ -1147,6 +1148,80 @@ fsTest(
   },
 );
 
+// ---- OpenCode desktop-vs-CLI binary fallback (issue #814) -----------------
+// OpenCode Desktop installs two binaries on PATH: `opencode` (the GUI
+// launcher, opens a desktop window when invoked, never reads stdin) and
+// `opencode-cli` (the headless CLI the daemon needs). Resolving `opencode`
+// first means the daemon ends up spawning the GUI for every desktop user
+// and silently does nothing. The OpenCode AGENT_DEF declares the always-
+// CLI binary as primary and falls back to the historical `opencode` for
+// the legacy CLI-only install.
+
+test('opencode entry declares opencode-cli as primary and opencode as fallback (issue #814)', () => {
+  assert.equal(
+    opencode.bin,
+    'opencode-cli',
+    `opencode.bin must be 'opencode-cli' so OpenCode Desktop installs resolve to the headless CLI, not the GUI launcher; got ${JSON.stringify(opencode.bin)}`,
+  );
+  assert.ok(
+    Array.isArray(opencode.fallbackBins),
+    'opencode.fallbackBins must be an array',
+  );
+  assert.ok(
+    opencode.fallbackBins.includes('opencode'),
+    `opencode.fallbackBins must include 'opencode' so legacy CLI-only installs (no desktop, no -cli suffix) still resolve; got ${JSON.stringify(opencode.fallbackBins)}`,
+  );
+});
+
+fsTest(
+  'resolveAgentExecutable picks opencode-cli over opencode when both are on PATH (the OpenCode Desktop case from #814)',
+  () => {
+    const dir = mkdtempSync(join(tmpdir(), 'od-agents-resolve-'));
+    try {
+      // Simulate an OpenCode Desktop install: both binaries are on
+      // PATH. The bare `opencode` is the GUI launcher; `opencode-cli`
+      // is the real CLI the daemon needs.
+      writeFileSync(join(dir, 'opencode'), '');
+      writeFileSync(join(dir, 'opencode-cli'), '');
+      chmodSync(join(dir, 'opencode'), 0o755);
+      chmodSync(join(dir, 'opencode-cli'), 0o755);
+      process.env.OD_AGENT_HOME = dir;
+      process.env.PATH = dir;
+
+      const resolved = resolveAgentExecutable({
+        bin: 'opencode-cli',
+        fallbackBins: ['opencode'],
+      });
+      assert.equal(resolved, join(dir, 'opencode-cli'));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);
+
+fsTest(
+  'resolveAgentExecutable falls back to opencode when only the legacy CLI binary is installed (no desktop)',
+  () => {
+    const dir = mkdtempSync(join(tmpdir(), 'od-agents-resolve-'));
+    try {
+      // Pre-Desktop / npm-global install: only `opencode` is on PATH
+      // and it is the actual CLI. The daemon must still find it.
+      writeFileSync(join(dir, 'opencode'), '');
+      chmodSync(join(dir, 'opencode'), 0o755);
+      process.env.OD_AGENT_HOME = dir;
+      process.env.PATH = dir;
+
+      const resolved = resolveAgentExecutable({
+        bin: 'opencode-cli',
+        fallbackBins: ['opencode'],
+      });
+      assert.equal(resolved, join(dir, 'opencode'));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);
+
 fsTest(
   'resolveAgentExecutable searches mise node bins when PATH is minimal',
   () => {
@@ -1182,8 +1257,11 @@ fsTest(
   'resolveAgentExecutable still resolves agents without a fallbackBins field',
   () => {
     // Guard against a regression that would require every AGENT_DEF to
-    // declare fallbackBins. Most agents (codex / gemini / opencode / ...)
+    // declare fallbackBins. Most agents (codex / gemini / hermes / ...)
     // only have a single binary name and must keep working unchanged.
+    // (Note: opencode used to live in this list but now declares
+    // fallbackBins for its own desktop-vs-CLI binary case — see
+    // issue #814.)
     const dir = mkdtempSync(join(tmpdir(), 'od-agents-resolve-'));
     try {
       writeFileSync(join(dir, 'codex'), '');


### PR DESCRIPTION
## Summary

- OpenCode Desktop installs **two** binaries on PATH: `opencode` (the GUI launcher — clicking it opens a desktop window, never reads stdin) and `opencode-cli` (the headless CLI that speaks `run --format json --dangerously-skip-permissions -`).
- The OpenCode `AGENT_DEF` set `bin: 'opencode'`, so [`resolveAgentExecutable`](https://github.com/nexu-io/open-design/blob/main/apps/daemon/src/agents.ts#L875) resolved the GUI launcher for every user with the desktop install. The daemon happily spawned it, but the GUI launcher discards stdin and never emits the structured JSON stream `opencode-stream` parses — so the agent silently produced **no output** for the entire conversation. That's the symptom @giuliastro reports in #814.
- Fix: declare `bin: 'opencode-cli'` and `fallbackBins: ['opencode']` on the adapter. Same mechanism Claude Code already uses to fall back to `openclaude` (issue #235), so this is well-trodden ground in the codebase.

Fixes #814.

## Resolution semantics

| User shape | `bin` (`opencode-cli`) | `fallbackBins[0]` (`opencode`) | Resolved |
|---|---|---|---|
| OpenCode Desktop install (both on PATH) | ✓ | ✓ | `opencode-cli` (CLI) ← #814 fix path |
| Legacy CLI-only install (no desktop, no `-cli` suffix) | ✗ | ✓ | `opencode` (CLI in this shape) — no regression |
| Nothing installed | ✗ | ✗ | `null` — same as before |

## Diff shape

| File | What changes |
|---|---|
| `apps/daemon/src/agents.ts` | `bin: 'opencode'` → `bin: 'opencode-cli'`; add `fallbackBins: ['opencode']`; doc-comment block citing #814 + the #235 precedent. |
| `apps/daemon/tests/agents.test.ts` | One declarative test pins `opencode.bin === 'opencode-cli'` + `opencode.fallbackBins.includes('opencode')` (runs on every platform). Two filesystem-backed `fsTest`s pin the resolution priority: both-on-PATH picks `opencode-cli`; legacy-only falls back to `opencode`. Existing "most agents have a single binary" comment list updated to remove `opencode`. |

2 files, +97 / −2.

## What's verified

| Check | Result |
|---|---|
| Daemon vitest (full suite) | **993/993** |
| Daemon `tsc -p tsconfig.json --noEmit` | clean |
| Daemon `tsc -p tsconfig.tests.json --noEmit` (the CI killer that broke a previous PR) | clean |
| `tsx scripts/i18n-check.ts` | passes |

## What's NOT verified

I don't have OpenCode Desktop installed locally, so I can't end-to-end exercise "click → open project → confirm CLI binary spawns instead of GUI". The structural argument:

1. The fix is the same `fallbackBins` mechanism Claude Code uses for OpenClaude (#235), already battle-tested in production.
2. The new filesystem-backed tests construct both PATH layouts (desktop with both binaries; legacy with only the bare name) and assert which file path `resolveAgentExecutable` returns — that's the exact decision the daemon makes at spawn time.
3. `opencode-cli` is documented by OpenCode Desktop as the headless CLI binary; the assumption that it speaks the same `run --format json` protocol as the legacy `opencode` follows from the user report (#814) and the OpenCode docs the issue thread cites.

If `opencode-cli --version` / `opencode-cli run --help` reveals subcommand differences vs the legacy `opencode` binary that @lefarcen flagged in the issue, this PR can be narrowed (e.g. version-gated `buildArgs`) — but for now the symptom #814 reports is "spawning the wrong binary entirely," not "spawning the right binary with the wrong flags," so the fallbackBins flip is the minimum fix.

## Test plan

- [x] Existing daemon test suite stays green (993/993).
- [x] One declarative test asserts adapter shape on every platform.
- [x] Two `fsTest`s pin the resolution priority for both PATH layouts.
- [x] Daemon typecheck (both `tsconfig.json` and `tsconfig.tests.json`) clean.
- [ ] Manual smoke from @giuliastro (or any OpenCode Desktop user): with the desktop install on PATH, an OpenCode-agent run actually produces output instead of the GUI launching silently.
- [ ] Smoke from a legacy `opencode`-only install (no `-cli` suffix) to confirm the fallback resolves and runs unchanged.

## Notes

- This is related to #267 ("OpenCode is installed but it's not being detected") but addresses a different shape: in #267 the desktop install appeared to provide no spawnable CLI at all, while #814 confirms the CLI exists under a different binary name. With this PR landed, #267 might be re-testable too.
- @lefarcen — your diagnosis on the issue is exactly what shaped this PR. Tagging in case you want to confirm the binary-rename hypothesis before merge, or wait on @giuliastro's `opencode-cli --version` output you asked for.