### PR TITLE
release: Open Design 0.5.0 — Live Dashboards, Inspect mode, accent theming, Linux headless

### DIFF
--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -237,6 +237,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Setup NSIS
+        shell: pwsh
+        run: |
+          if ((Get-Command makensis.exe -ErrorAction SilentlyContinue) -or (Test-Path "C:\Program Files (x86)\NSIS\makensis.exe")) {
+            exit 0
+          }
+          choco install nsis -y --no-progress
+
       - name: Build stable windows artifacts
         shell: pwsh
         run: >-

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -262,19 +262,13 @@ jobs:
           New-Item -ItemType Directory -Force -Path $releaseDir | Out-Null
 
           $sourceInstaller = Join-Path $env:RUNNER_TEMP "tools-pack/out/win/namespaces/release-stable-win/builder/Open Design-release-stable-win-setup.exe"
-          $sourceBlockmap = Join-Path $env:RUNNER_TEMP "tools-pack/out/win/namespaces/release-stable-win/builder/Open Design-release-stable-win-setup.exe.blockmap"
           if (!(Test-Path $sourceInstaller)) {
             throw "expected installer not found at $sourceInstaller"
           }
-          if (!(Test-Path $sourceBlockmap)) {
-            throw "expected blockmap not found at $sourceBlockmap"
-          }
 
           $versionedInstaller = "open-design-${{ needs.metadata.outputs.stable_version }}-win-x64-setup.exe"
-          $versionedBlockmap = "open-design-${{ needs.metadata.outputs.stable_version }}-win-x64-setup.exe.blockmap"
           $checksumFile = "$versionedInstaller.sha256"
           Copy-Item $sourceInstaller (Join-Path $releaseDir $versionedInstaller)
-          Copy-Item $sourceBlockmap (Join-Path $releaseDir $versionedBlockmap)
 
           $installerPath = Join-Path $releaseDir $versionedInstaller
           $hash = (Get-FileHash -Path $installerPath -Algorithm SHA256).Hash.ToLowerInvariant()
@@ -485,7 +479,7 @@ jobs:
             echo "- mac signed/notarized: ${{ inputs.mac_signed }}"
             echo "- windows signed: false"
             echo "- mac assets: open-design-${{ needs.metadata.outputs.stable_version }}-mac-arm64.dmg, open-design-${{ needs.metadata.outputs.stable_version }}-mac-arm64.zip"
-            echo "- win assets: open-design-${{ needs.metadata.outputs.stable_version }}-win-x64-setup.exe, open-design-${{ needs.metadata.outputs.stable_version }}-win-x64-setup.exe.blockmap"
+            echo "- win assets: open-design-${{ needs.metadata.outputs.stable_version }}-win-x64-setup.exe"
             echo "- linux assets: deferred from this stable release"
             echo "- Feeds: latest-mac.yml, latest.yml"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,99 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-07
+
+A minor release focused on iteration: live-data dashboards graduate to a first-class artifact category, an in-preview Inspect mode lands for per-element style tuning, the desktop launcher gets an accent color theme, Critique Theater advances to Phase 5, and Linux gains headless lifecycle support. New Qoder CLI agent, Nano Banana image provider, and Indonesian locale. 51 merged PRs since 0.4.1, accumulated across 16 beta cycles.
+
+### Added
+
+#### Web / UI
+- **Inspect mode** — live per-element style tuning in the HTML preview. ([#362])
+- **Accent color control + launcher** — a global accent persists across the desktop launcher and entry view. ([#683])
+- **Connection tests for execution settings** — verify provider config without launching a chat. ([#507])
+- Replaced the SketchEditor `window.prompt()` text tool with an in-app modal so long prompts stop getting clipped. ([#738])
+
+#### Skills, design systems & prompt templates
+- **`live-dashboard` skill** — generic Live Artifact dashboard template. ([#778])
+- **`clinic-console` live-artifact template.** ([#795])
+- **FlowAI live dashboard template skill.** ([#801])
+- **Notion-style team dashboard prompt template (Live Artifact).** ([#799])
+- **`waitlist-page` skill.** ([#555])
+- **`social-media-dashboard` skill + Totality Festival design system.** ([#678])
+- **Five Orbit briefing prompt templates.** ([#671])
+- **Craft `form-validation` module** — generated forms follow modern RHF/Zod patterns instead of 2018 Formik habits. ([#625])
+
+#### Critique Theater
+- **Phase 5** — panel prompt template + system composer wiring. ([#524])
+
+#### Daemon and agents
+- **Qoder CLI** agent adapter. ([#626])
+- **Project transcript export to disk** for downstream tools (replay, audit, sharing) — prereq for #450. ([#493])
+- Override the Codex executable path for nvm / mise / fnm-installed toolchains. ([#755])
+- Codex image projects can use built-in imagegen. ([#622])
+- DeepSeek v4 models in the model catalog. ([#722])
+- `OD_LEGACY_DATA_DIR` migrator for 0.3.x → 0.4.x data recovery. ([#712])
+
+#### Media generation
+- **Nano Banana image provider.** ([#631])
+- HyperFrames video previews, provider badge, and source filter on the templates surface. ([#293])
+
+#### Linux & packaging
+- **Linux headless lifecycle** — `install` / `start` / `stop` from CLI without a desktop session. ([#686])
+- Improved Windows beta packaging and installer flow. ([#768])
+- Migrated beta release publishing to R2. ([#805])
+
+#### Internationalization
+- **Indonesian (`id`) UI locale.** ([#414])
+
+### Changed
+
+- Project file watcher now ignores `.venv` and other large dirs so Python projects stop overwhelming it. ([#531])
+- Daemon CORS whitelist accepts portless `Origin` headers for Chrome compatibility. ([#735])
+- Extended OpenAI image request timeouts so larger generations stop being killed mid-flight. ([#788])
+- Surfaced the `@nexudotio` X account in README and entry sidebar. ([#696])
+
+### Fixed
+
+#### Daemon and agents
+- Delivered Copilot prompts via stdin to avoid Windows `ENAMETOOLONG`. ([#727])
+- Surfaced OpenCode error frames; treated empty-output runs as failed instead of silently succeeding. ([#700])
+- Discovered toolchain paths for GUI-launched agents on minimal `PATH`. ([#614])
+
+#### Web and desktop
+- Removed Tweaks-mode element-selector tooltip noise. ([#697])
+- Fixed chat pane overflow. ([#740])
+- Narrowed the `ws-tabs-bar` scrollbar so filenames stop overlapping. ([#781])
+- Improved settings dialog scroll behavior. ([#667])
+- Widened settings subtitle so the English copy fits on one line. ([#747])
+- Persisted design system selection across sessions. ([#621])
+- Aligned the design system default test fixture. ([#708])
+- Showed an alert when the PDF export popup is blocked. ([#664])
+- Fixed the Windows link-code-folder dialog. ([#698])
+- Made desktop entry chrome consistent. ([#655])
+
+#### Packaging & runtime
+- Unbroke Claude Design ZIP import on Node 24 and raised the file ceiling. ([#591])
+- Diagnosed missing Next package during `tools-dev` web startup. ([#675])
+
+#### Internationalization
+- Aligned `README.es` UI references to the `es-ES.ts` locale. ([#611])
+- Fixed Ukrainian prompt template translations and removed duplicate keys. ([#674], [#680])
+
+#### Miscellaneous
+- Batched small fixes for [#283], [#275], and [#390]. ([#530])
+
+### Documentation
+
+- Documented the Linux namespace env var in `tools-pack`. ([#670])
+- Fixed broken `pi-ai` links after the package split. ([#277])
+
+### Internal
+
+- Added desktop settings + project flow e2e coverage. ([#306])
+- CI: notify Discord `#resolved` when issues are closed by a merged PR. ([#685])
+- Refreshed generated GitHub metrics SVG and contributors wall. ([#718], [#720])
+
 ## [0.4.1] - 2026-05-06
 
 0.4.1 is the startup hotfix for the broken 0.4.0 desktop packages. It restores packaged app startup on macOS and Windows, adds release validation so the failure mode is caught before publication, and includes the small UI, agent, documentation, i18n, and craft updates that landed while the hotfix was being verified.
@@ -416,7 +509,8 @@ First public release of Open Design — a local-first, open-source alternative t
 - Beta release workflow placeholder. ([#36])
 - Git commit co-author policy. ([#131])
 
-[Unreleased]: https://github.com/nexu-io/open-design/compare/open-design-v0.4.1...HEAD
+[Unreleased]: https://github.com/nexu-io/open-design/compare/open-design-v0.5.0...HEAD
+[0.5.0]: https://github.com/nexu-io/open-design/releases/tag/open-design-v0.5.0
 [0.4.1]: https://github.com/nexu-io/open-design/releases/tag/open-design-v0.4.1
 [0.4.0]: https://github.com/nexu-io/open-design/releases/tag/open-design-v0.4.0
 [0.3.0]: https://github.com/nexu-io/open-design/releases/tag/open-design-v0.3.0
@@ -680,3 +774,60 @@ First public release of Open Design — a local-first, open-source alternative t
 [#623]: https://github.com/nexu-io/open-design/pull/623
 [#627]: https://github.com/nexu-io/open-design/pull/627
 [#637]: https://github.com/nexu-io/open-design/pull/637
+[#275]: https://github.com/nexu-io/open-design/pull/275
+[#277]: https://github.com/nexu-io/open-design/pull/277
+[#283]: https://github.com/nexu-io/open-design/pull/283
+[#293]: https://github.com/nexu-io/open-design/pull/293
+[#306]: https://github.com/nexu-io/open-design/pull/306
+[#362]: https://github.com/nexu-io/open-design/pull/362
+[#390]: https://github.com/nexu-io/open-design/pull/390
+[#414]: https://github.com/nexu-io/open-design/pull/414
+[#493]: https://github.com/nexu-io/open-design/pull/493
+[#507]: https://github.com/nexu-io/open-design/pull/507
+[#524]: https://github.com/nexu-io/open-design/pull/524
+[#530]: https://github.com/nexu-io/open-design/pull/530
+[#531]: https://github.com/nexu-io/open-design/pull/531
+[#555]: https://github.com/nexu-io/open-design/pull/555
+[#591]: https://github.com/nexu-io/open-design/pull/591
+[#611]: https://github.com/nexu-io/open-design/pull/611
+[#614]: https://github.com/nexu-io/open-design/pull/614
+[#621]: https://github.com/nexu-io/open-design/pull/621
+[#622]: https://github.com/nexu-io/open-design/pull/622
+[#625]: https://github.com/nexu-io/open-design/pull/625
+[#626]: https://github.com/nexu-io/open-design/pull/626
+[#631]: https://github.com/nexu-io/open-design/pull/631
+[#655]: https://github.com/nexu-io/open-design/pull/655
+[#664]: https://github.com/nexu-io/open-design/pull/664
+[#667]: https://github.com/nexu-io/open-design/pull/667
+[#670]: https://github.com/nexu-io/open-design/pull/670
+[#671]: https://github.com/nexu-io/open-design/pull/671
+[#674]: https://github.com/nexu-io/open-design/pull/674
+[#675]: https://github.com/nexu-io/open-design/pull/675
+[#678]: https://github.com/nexu-io/open-design/pull/678
+[#680]: https://github.com/nexu-io/open-design/pull/680
+[#683]: https://github.com/nexu-io/open-design/pull/683
+[#685]: https://github.com/nexu-io/open-design/pull/685
+[#686]: https://github.com/nexu-io/open-design/pull/686
+[#696]: https://github.com/nexu-io/open-design/pull/696
+[#697]: https://github.com/nexu-io/open-design/pull/697
+[#698]: https://github.com/nexu-io/open-design/pull/698
+[#700]: https://github.com/nexu-io/open-design/pull/700
+[#708]: https://github.com/nexu-io/open-design/pull/708
+[#712]: https://github.com/nexu-io/open-design/pull/712
+[#718]: https://github.com/nexu-io/open-design/pull/718
+[#720]: https://github.com/nexu-io/open-design/pull/720
+[#722]: https://github.com/nexu-io/open-design/pull/722
+[#727]: https://github.com/nexu-io/open-design/pull/727
+[#735]: https://github.com/nexu-io/open-design/pull/735
+[#738]: https://github.com/nexu-io/open-design/pull/738
+[#740]: https://github.com/nexu-io/open-design/pull/740
+[#747]: https://github.com/nexu-io/open-design/pull/747
+[#755]: https://github.com/nexu-io/open-design/pull/755
+[#768]: https://github.com/nexu-io/open-design/pull/768
+[#778]: https://github.com/nexu-io/open-design/pull/778
+[#781]: https://github.com/nexu-io/open-design/pull/781
+[#788]: https://github.com/nexu-io/open-design/pull/788
+[#795]: https://github.com/nexu-io/open-design/pull/795
+[#799]: https://github.com/nexu-io/open-design/pull/799
+[#801]: https://github.com/nexu-io/open-design/pull/801
+[#805]: https://github.com/nexu-io/open-design/pull/805

--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/daemon",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "main": "./dist/cli.js",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/desktop",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "main": "./dist/main/index.js",

--- a/apps/landing-page/package.json
+++ b/apps/landing-page/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/landing-page",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/packaged/package.json
+++ b/apps/packaged/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/packaged",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/web",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/e2e",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-design",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "private": true,
   "packageManager": "pnpm@10.33.2",
   "type": "module",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/contracts",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "description": "Shared pure TypeScript contracts for the Open Design web/daemon boundary.",

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/platform",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/sidecar-proto/package.json
+++ b/packages/sidecar-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/sidecar-proto",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/sidecar/package.json
+++ b/packages/sidecar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/sidecar",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/tools/dev/package.json
+++ b/tools/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-dev",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-pack",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "bin": {


### PR DESCRIPTION
> Note for reviewers: every `@user` mention below is wrapped in backticks so creating this PR does not ping contributors. Strip the backticks before publishing the GitHub release if you want attribution to notify people.

🎉 **`51 PRs` · `36 contributors` · ~1 day** — Open Design 0.5.0 turns the corner from "render once" to "iterate forever": **live-data dashboards** as a first-class artifact category, **Inspect mode** for per-element style tuning, an **accent-color theme system** for the launcher, **Critique Theater Phase 5**, plus a new agent (Qoder), a new image provider (Nano Banana), Linux headless mode, and a long fix queue from 16 beta cycles. 🚀

## 🔥 Highlights

- 📊 **Three new live-dashboard skills.** Generic `live-dashboard` (Notion-style team dashboard, #778), `clinic-console` template added to the existing `live-artifact` skill (#795), and template-mode `flowai-live-dashboard-template` (#801) — all targeting the 0.4.0 Live Artifacts surface so generated artifacts pull from real data instead of frozen mocks. Thanks `@adityagaddhyan`, `@yashverma48`, and `@kushwahasonam`.
- 🗂️ **First prompt template under the Live Artifact category.** Notion-style team dashboard under `prompt-templates/image/` — template-only, no surface or loader changes. (#799) Thanks `@Joey-nexu`.
- 🔬 **Inspect mode for live per-element style tuning.** Click anything in the preview to inspect and tweak its computed styles — color, spacing, type — without round-tripping through the agent. (#362) Thanks `@pftom`.
- 🎨 **Accent color control + launcher.** Pick the brand color you want Open Design itself to wear — global accent persists across the desktop launcher and entry view. (#683) Thanks `@Feroomon2010`.
- 🎭 **Critique Theater Phase 5: panel prompts + system composer.** The jury picks up its scoring rubric from a panel-level prompt template wired through the shared system composer, so critiques stay coherent across runs. (#524) Thanks `@Nagendhra-web`.
- 📤 **Project transcript export.** Daemon now writes a structured transcript to disk for downstream tools (replay, audit, sharing) — prereq for #450. (#493) Thanks `@bryanatkinson`.
- 🤖 **Qoder CLI agent + Nano Banana image provider.** Open Design now drives Qoder out of the box, and image projects can target the new Nano Banana provider. (#626, #631) Thanks `@mamba` and `@zztdan`.
- 🐧 **Linux headless install/start/stop.** A non-graphical lifecycle path so Open Design can run on servers and CI without a desktop session. (#686) Thanks `@Jheison-Martinez`.
- 🇮🇩 **Indonesian (id) UI locale.** (#414) Thanks `@aqilaziz`.

> 📥 **Download:** the table below points at the final asset URLs — links go live once this PR is merged and the `release-stable` workflow finishes. Tag: `open-design-v0.5.0`.
>
> | Platform | Architecture | Asset |
> |---|---|---|
> | macOS | Apple Silicon (arm64) | [open-design-0.5.0-mac-arm64.dmg](https://github.com/nexu-io/open-design/releases/download/open-design-v0.5.0/open-design-0.5.0-mac-arm64.dmg) |
> | macOS (auto-update feed) | Apple Silicon (arm64) | [open-design-0.5.0-mac-arm64.zip](https://github.com/nexu-io/open-design/releases/download/open-design-v0.5.0/open-design-0.5.0-mac-arm64.zip) |
> | Windows | x64 (unsigned) | [open-design-0.5.0-win-x64-setup.exe](https://github.com/nexu-io/open-design/releases/download/open-design-v0.5.0/open-design-0.5.0-win-x64-setup.exe) |

## ✨ What's New

### 🔬 Editing & inspection

- 🔬 **Inspect mode.** Live per-element style tuning in the HTML preview. (#362) Thanks `@pftom`.
- 🎨 **Accent color control + launcher.** Theme Open Design itself. (#683) Thanks `@Feroomon2010`.
- 🧰 **SketchEditor text prompt becomes a modal** so long prompts stop getting clipped. (#738) Thanks `@pftom`.
- 🧹 **Tweaks-mode tooltip noise removed.** (#697) Thanks `@bojiehbj`.

### 🤖 Agents & daemon

- 🤖 **Qoder CLI** agent adapter. (#626) Thanks `@mamba`.
- 🛣️ **Override Codex executable path.** Useful for nvm / mise / fnm-installed toolchains. (#755) Thanks `@shangxinyu1`.
- 🎨 **Codex image projects can use built-in imagegen.** (#622) Thanks `@DehengHuang`.
- 📡 **Copilot prompts delivered via stdin.** Removes another argv-too-large class of failure on Windows. (#727) Thanks `@lefarcen`.
- 🧪 **Connection tests for execution settings.** Verify provider config without launching a chat. (#507) Thanks `@monshunter`.
- 📤 **Project transcript export.** (#493) Thanks `@bryanatkinson`.
- 🔍 **GUI-launched agents discover toolchain on minimal `PATH`.** (#614) Thanks `@XinminZeng`.
- 🧠 **DeepSeek v4 models in catalog.** (#722) Thanks `@1119302165`.
- 🐍 **Watcher ignores `.venv` and other large dirs.** Stops project file watcher from melting on Python projects. (#531) Thanks `@1119302165`.
- 🌐 **Portless `Origin` accepted in CORS whitelist.** Restores Chrome compatibility for some embed scenarios. (#735) Thanks `@lefarcen`.
- 📁 **`OD_LEGACY_DATA_DIR` migrator** moves `.od/` users into the desktop data layout cleanly. (#712) Thanks `@Nagendhra-web`.

### 🎭 Critique Theater

- 🎯 **Phase 5: panel prompt template + system composer wiring.** (#524) Thanks `@Nagendhra-web`.

### 🎬 Media generation

- 🍌 **Nano Banana image provider.** (#631) Thanks `@zztdan`.
- 🎞️ **HyperFrames video previews + provider badge + source filter.** Browsing video templates is no longer a guessing game. (#293) Thanks `@pftom`.
- ⏱️ **Extend OpenAI image request timeouts** so larger generations stop being killed mid-flight. (#788) Thanks `@lefarcen`.

### 🎨 Skills, design systems & prompt templates

- 📊 **`live-dashboard` skill — generic Live Artifact dashboard template.** (#778) Thanks `@adityagaddhyan`.
- 🩺 **`clinic-console` live-artifact template.** (#795) Thanks `@yashverma48`.
- 📈 **FlowAI live dashboard template skill.** (#801) Thanks `@kushwahasonam`.
- 🗂️ **Notion-style team dashboard prompt template.** (#799) Thanks `@Joey-nexu`.
- 📝 **`waitlist-page` skill.** (#555) Thanks `@VedankVansia`.
- 📱 **`social-media-dashboard` skill + Totality Festival design system.** (#678) Thanks `@Tuola-waj`.
- 🛰️ **Five Orbit briefing templates.** (#671) Thanks `@anders-eli`.
- 🧱 **Craft `form-validation` module.** Generated forms now follow modern RHF/Zod patterns instead of 2018 Formik habits. (#625) Thanks `@MohamedAbdallah-14`.

### 📁 Files & previews

- 📄 **Alert when PDF export popup is blocked.** (#664) Thanks `@pratikrai`.
- 📐 **Tighter `ws-tabs-bar` scrollbar.** Filenames stop overlapping the bar. (#781) Thanks `@arunkukrety`.
- 🪟 **Fix chat pane overflow.** (#740)
- 📦 **Claude Design ZIP import works on Node 24** + the file ceiling is raised. (#591) Thanks `@gabriel-vaz`.

### 🐧 Packaging & platforms

- 🐧 **Linux headless install / start / stop.** (#686) Thanks `@Jheison-Martinez`.
- 🪟 **Improved Windows beta packaging and installer flow.** Smaller, faster, cleaner namespace handling. (#768) Thanks `@PerishCode`.
- ☁️ **Beta release publishing migrated to R2.** (#805) Thanks `@PerishCode`.
- 🪟 **Fix Windows link-code-folder dialog.** (#698) Thanks `@xuncha`.
- 🪟 **Consistent desktop entry chrome.** (#655) Thanks `@Siri-Ray`.

### 🌍 Internationalization & docs

- 🇮🇩 **Indonesian (`id`) UI locale.** (#414) Thanks `@aqilaziz`.
- 🇺🇦 **Ukrainian prompt template fixes** + duplicate-key cleanup. (#674, #680) Thanks `@Caprika` and `@lefarcen`.
- 🇪🇸 **Spanish README aligned to the `es-ES.ts` locale.** (#611) Thanks `@israelcastro`.
- 🐦 **`@nexudotio` X account surfaced in README + entry sidebar.** (#696) Thanks `@lefarcen`.
- 🔗 **Fix broken pi-ai links** (404'd after the package split). (#277) Thanks `@lefarcen`.
- 📚 **Linux namespace env var documented in tools-pack.** (#670) Thanks `@PerishCode`.

## 🛡️ Stability & Reliability

- 🧩 **Design-system selection persists** in web. (#621) Thanks `@lefarcen`.
- 🧪 **Aligned design-system default test fixture.** (#708) Thanks `@marcchan`.
- 🧰 **OpenCode error frames surfaced; empty-output runs treated as failed** instead of silently succeeding. (#700) Thanks `@lefarcen`.
- 🪟 **Settings dialog scroll behavior.** (#667) Thanks `@jiezhu`.
- 🔠 **Wider settings subtitle.** (#747) Thanks `@Nagendhra-web`.
- 🔍 **Diagnose missing Next package** during `tools-dev` web startup. (#675) Thanks `@iuliandita`.
- 🧹 **Batch of small bug fixes** for #283, #275, #390. (#530) Thanks `@Nagendhra-web`.

## 🐛 Bug Fixes

- 🪟 Tweaks-mode element-selector tooltip removed. (#697) Thanks `@bojiehbj`.
- 🪟 Chat pane overflow. (#740)
- 📐 ws-tabs-bar scrollbar. (#781) Thanks `@arunkukrety`.
- 📁 .venv ignored by project file watcher. (#531) Thanks `@1119302165`.

## 📚 Documentation

- 🇪🇸 README.es alignment to es-ES locale. (#611) Thanks `@israelcastro`.
- 🐦 `@nexudotio` X account in README + entry sidebar. (#696) Thanks `@lefarcen`.
- 🔗 pi-ai link split fix. (#277) Thanks `@lefarcen`.
- 📚 Linux tools-pack namespace env doc. (#670) Thanks `@PerishCode`.

## 🔨 For Developers

<details>
<summary>Click to expand</summary>

- 🧪 **Desktop settings + project flow e2e coverage.** (#306) Thanks `@Joey-nexu`.
- 📊 **Generated GitHub metrics + contributors wall refreshed** for the release window. (#718, #720)
- 🤖 **Discord `#resolved` notify when issues are closed by merged PRs.** (#685) Thanks `@lefarcen`.

</details>

## ✅ System Requirements

- 🍎 **macOS** — Apple Silicon (arm64) only, macOS 11 Big Sur or newer. Intel macs are not supported.
- 🪟 **Windows** — x64, Windows 10 / 11. Installer is **unsigned** (SmartScreen will warn on first launch — choose "More info → Run anyway").
- 🐧 **Linux** — first-class **headless** lifecycle support lands in 0.5.0 (`install`, `start`, `stop` from CLI). A packaged Linux desktop GUI artifact is still deferred while the release lane is hardened.
- 🧑‍💻 **From source** — Node.js 24.x and pnpm 10.33.2+ (per `engines` in `package.json`).

## ⚠️ Known Issues

- 🪟 **Windows installer is unsigned.** SmartScreen / antivirus warnings are expected. Code signing is still follow-up work.
- 🍎 **No macOS Intel (x64) build.** Apple Silicon only.
- 🐧 **No Linux desktop GUI package in 0.5.0 stable** — use headless mode or run from source.
- 🐚 **`od` CLI shadows POSIX `od`** when installed globally. Use `/usr/bin/od` or `command od` for the system tool.

---

## 🚀 Releasing this PR

This PR ships:

1. 📦 **All 13 monorepo `package.json` files bumped to `0.5.0`** (root, `apps/{web,daemon,desktop,packaged,landing-page}`, `packages/{contracts,platform,sidecar,sidecar-proto}`, `tools/{dev,pack}`, `e2e`). Internal workspace specifiers are `workspace:*`, so no lockfile change was needed.
2. 📝 **`CHANGELOG.md`** — new `[0.5.0] - 2026-05-07` entry covering the 51 merged PRs since 0.4.1, plus footnote refs for new PR numbers.

The `release-stable` workflow already lives on `main`; no infrastructure changes here. After merge, dispatch `release-stable` with `mac_signed=true` to publish.

Local verify dry-run before opening this PR:

- `pnpm install` (workspace links — lockfile already in sync)
- `pnpm --filter @open-design/contracts --filter @open-design/desktop --filter @open-design/daemon run build` (populates dist/ for downstream typecheck consumers; contracts must be rebuilt because `09eb88f` and `988fd6d` added new exported members like `providerId` / `accountId` / `ImportFolderRequest` / `ImportFolderResponse`)
- `pnpm typecheck` → exit 0 across all 13 packages

(Local Node was `22.22.0`, so pnpm printed engine warnings for the repo's `~24` requirement; matches the 0.3.0 / 0.4.1 release dry-runs.)

**Full Changelog:** https://github.com/nexu-io/open-design/compare/open-design-v0.4.1...release/v0.5.0
