### PR TITLE
fix(i18n): default id locale to English for untranslated keys

### DIFF
--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -1,6 +1,17 @@
 import type { Dict } from '../types';
+import { en } from './en';
 
 export const id: Dict = {
+  // Default to English for any key not yet translated. This protects
+  // the locale against typecheck regressions when a feature lands new
+  // strings in a separate PR (the Cloudflare Pages deploy keys
+  // shipped before this locale was fully populated, leaving 18
+  // properties unset on `Dict` and turning `tsc -b` red on every
+  // other open PR's CI). Existing Indonesian translations below
+  // override these fallbacks; new translators can replace English
+  // fallbacks one key at a time. Mirrors the `...en` pattern already
+  // used by de / es-ES / fr / hu / ja / ko / pl / tr.
+  ...en,
   'common.cancel': 'Batal',
   'common.save': 'Simpan',
   'common.close': 'Tutup',


### PR DESCRIPTION
## Summary

- The Indonesian locale was added in [fcc37c6](https://github.com/nexu-io/open-design/commit/fcc37c6) right around the same time the Cloudflare Pages artifact deployment feature landed in [09eb88f](https://github.com/nexu-io/open-design/commit/09eb88f). The Cloudflare PR added 18 new keys to the `Dict` interface and translated them in every existing locale, but `id.ts` was populated against the previous shape.
- Once both commits sat on main, every workspace `tsc -b --noEmit` started failing with:

  ```
  src/i18n/locales/id.ts(3,14): error TS2740: Type ... is missing the following properties from type 'Dict':
  'fileViewer.deployProviderLabel', 'fileViewer.vercelProvider',
  'fileViewer.cloudflarePagesProvider', 'fileViewer.deployToProvider',
  and 14 more.
  ```

- That turns the `Validate workspace` CI check red on **every open PR** until someone manually adds the missing keys. The same race will happen the next time a feature lands new strings unless the locale defaults to English fallbacks the way `de` / `es-ES` / `fr` / `hu` / `ja` / `ko` / `pl` / `tr` already do.
- Apply the `import { en } from './en'; ...en, ...overrides` pattern to `id.ts`. Existing Indonesian translations stay as overrides — no regression on what users see — and any new key landed by a future feature inherits an English fallback automatically. Translators can replace fallbacks one key at a time without breaking the build in between.

## What's verified

| Check | Result |
|---|---|
| `pnpm --filter @open-design/web typecheck` (`tsc -b --noEmit`) | clean (was red on `id.ts(3,14)`) |
| `tsx scripts/i18n-check.ts` | passes |

## Test plan

- [x] `tsc -b --noEmit` passes on the web workspace.
- [x] `i18n-check` passes.
- [ ] Manual smoke: Indonesian-locale users see the existing translated strings unchanged for keys they already had, and English text for the newly-landed Cloudflare Pages deploy keys until those get translated.

## Notes

- This is a **broader-project unblock** rather than a feature change. Every other open PR's CI is currently red on the same `id.ts` typecheck, so getting this in first lets unrelated PRs (mine and others') turn green again. I noticed this while diagnosing why CI failed on #818.
- Mirrors the existing `...en` pattern in 8 other locale files — no new convention introduced.