### PR TITLE
fix(pack/win): close detection gaps that let Open Design.exe stay locked at install time (#821)

### DIFF
--- a/tools/pack/src/win/custom-installer.ts
+++ b/tools/pack/src/win/custom-installer.ts
@@ -258,7 +258,13 @@ FunctionEnd
 Function DetectRunningInstances
   Push $0
   Push $1
-  nsExec::ExecToStack 'powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "& { param($$install, $$registered); $$roots = @($$install, $$registered) | Where-Object { $$_ } | ForEach-Object { $$root = $$_.TrimEnd([char]92).ToLowerInvariant(); [pscustomobject]@{ Exact = $$root; Prefix = ($$root + [char]92) } } | Select-Object -Unique Exact, Prefix; $$matches = Get-CimInstance Win32_Process | Where-Object { $$matched = $$false; $$exe = $$_.ExecutablePath; if ($$null -ne $$exe) { $$exe = $$exe.ToLowerInvariant(); foreach ($$root in $$roots) { if ($$root.Exact -and (($$exe -eq $$root.Exact) -or $$exe.StartsWith($$root.Prefix))) { $$matched = $$true; break } } }; $$matched }; if ($$matches) { $$matches | ForEach-Object { [string]$$_.ProcessId + [char]32 + $$_.Name } } }" "$INSTDIR" "$ExistingInstallLocation"'
+  ; Match by ExecutablePath under the install root when available. WMI returns
+  ; null ExecutablePath for processes the caller cannot fully introspect
+  ; (insufficient access, processes mid-spawn). For those rows, fall back to
+  ; CommandLine containing the install-root prefix, which is OD-specific
+  ; enough to avoid false positives without resorting to global Name matching.
+  ; Issue #821.
+  nsExec::ExecToStack 'powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "& { param($$install, $$registered); $$roots = @($$install, $$registered) | Where-Object { $$_ } | ForEach-Object { $$root = $$_.TrimEnd([char]92).ToLowerInvariant(); [pscustomobject]@{ Exact = $$root; Prefix = ($$root + [char]92) } } | Select-Object -Unique Exact, Prefix; $$matches = Get-CimInstance Win32_Process | Where-Object { $$matched = $$false; $$exe = $$_.ExecutablePath; if ($$null -ne $$exe) { $$exe = $$exe.ToLowerInvariant(); foreach ($$root in $$roots) { if ($$root.Exact -and (($$exe -eq $$root.Exact) -or $$exe.StartsWith($$root.Prefix))) { $$matched = $$true; break } } } else { $$cmd = $$_.CommandLine; if ($$null -ne $$cmd) { $$cmdLc = $$cmd.ToLowerInvariant(); foreach ($$root in $$roots) { if ($$root.Prefix -and $$cmdLc.Contains($$root.Prefix)) { $$matched = $$true; break } } } }; $$matched }; if ($$matches) { $$matches | ForEach-Object { [string]$$_.ProcessId + [char]32 + $$_.Name } } }" "$INSTDIR" "$ExistingInstallLocation"'
   Pop $0
   Pop $1
   \${If} $0 == "0"
@@ -275,7 +281,14 @@ FunctionEnd
 Function CloseRunningInstances
   Push $0
   Push $1
-  nsExec::ExecToStack 'powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "& { param($$install, $$registered); $$roots = @($$install, $$registered) | Where-Object { $$_ } | ForEach-Object { $$root = $$_.TrimEnd([char]92).ToLowerInvariant(); [pscustomobject]@{ Exact = $$root; Prefix = ($$root + [char]92) } } | Select-Object -Unique Exact, Prefix; $$matches = Get-CimInstance Win32_Process | Where-Object { $$matched = $$false; $$exe = $$_.ExecutablePath; if ($$null -ne $$exe) { $$exe = $$exe.ToLowerInvariant(); foreach ($$root in $$roots) { if ($$root.Exact -and (($$exe -eq $$root.Exact) -or $$exe.StartsWith($$root.Prefix))) { $$matched = $$true; break } } }; $$matched }; $$ids = @($$matches | ForEach-Object { $$_.ProcessId }); foreach ($$id in $$ids) { try { [void][System.Diagnostics.Process]::GetProcessById($$id).CloseMainWindow() } catch {} }; Start-Sleep -Milliseconds 1500; foreach ($$id in $$ids) { try { $$p = [System.Diagnostics.Process]::GetProcessById($$id); if (-not $$p.HasExited) { Stop-Process -Id $$id -Force -ErrorAction SilentlyContinue } } catch {} }; if ($$ids) { $$ids -join ([char]32) } }" "$INSTDIR" "$ExistingInstallLocation"'
+  ; Same matching as DetectRunningInstances (ExecutablePath path-prefix +
+  ; CommandLine fallback for null ExecutablePath rows). After Stop-Process
+  ; -Force we now WaitForExit on each PID (5s per process) before returning,
+  ; so the OS file-handle GC has time to release the lock on $INSTDIR\$exeName
+  ; before the installer proceeds into MUI_PAGE_INSTFILES. Without this wait
+  ; the next overwrite can race the kill and trigger NSIS's native "file in
+  ; use" Retry/Cancel dialog. Issue #821.
+  nsExec::ExecToStack 'powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "& { param($$install, $$registered); $$roots = @($$install, $$registered) | Where-Object { $$_ } | ForEach-Object { $$root = $$_.TrimEnd([char]92).ToLowerInvariant(); [pscustomobject]@{ Exact = $$root; Prefix = ($$root + [char]92) } } | Select-Object -Unique Exact, Prefix; $$matches = Get-CimInstance Win32_Process | Where-Object { $$matched = $$false; $$exe = $$_.ExecutablePath; if ($$null -ne $$exe) { $$exe = $$exe.ToLowerInvariant(); foreach ($$root in $$roots) { if ($$root.Exact -and (($$exe -eq $$root.Exact) -or $$exe.StartsWith($$root.Prefix))) { $$matched = $$true; break } } } else { $$cmd = $$_.CommandLine; if ($$null -ne $$cmd) { $$cmdLc = $$cmd.ToLowerInvariant(); foreach ($$root in $$roots) { if ($$root.Prefix -and $$cmdLc.Contains($$root.Prefix)) { $$matched = $$true; break } } } }; $$matched }; $$ids = @($$matches | ForEach-Object { $$_.ProcessId }); foreach ($$id in $$ids) { try { [void][System.Diagnostics.Process]::GetProcessById($$id).CloseMainWindow() } catch {} }; Start-Sleep -Milliseconds 1500; foreach ($$id in $$ids) { try { $$p = [System.Diagnostics.Process]::GetProcessById($$id); if (-not $$p.HasExited) { Stop-Process -Id $$id -Force -ErrorAction SilentlyContinue } } catch {} }; foreach ($$id in $$ids) { try { $$p = [System.Diagnostics.Process]::GetProcessById($$id); if (-not $$p.HasExited) { [void]$$p.WaitForExit(5000) } } catch {} }; if ($$ids) { $$ids -join ([char]32) } }" "$INSTDIR" "$ExistingInstallLocation"'
   Pop $0
   Pop $1
   Push "running instances close exit=$0 output=$1"


### PR DESCRIPTION
Closes part of #821. Addresses the two installer-side gaps @lefarcen confirmed in [the issue thread](https://github.com/nexu-io/open-design/issues/821#issuecomment-4397357213) after their own code review.

## Background

The custom NSIS pre-install flow in [tools/pack/src/win/custom-installer.ts](https://github.com/nexu-io/open-design/blob/main/tools/pack/src/win/custom-installer.ts) detects and closes running OD processes before extraction. But the dialog kutzki sees ("Open Design cannot be closed. Please close it manually and click Retry to continue.") is **not** the custom `RunningInstancesCloseFailed` text. It's NSIS's native file-in-use Retry/Cancel prompt fired during `MUI_PAGE_INSTFILES`. That means detection and close ran cleanly but extraction still hit a locked `$INSTDIR\Open Design.exe`.

## Gap 1: WMI null `ExecutablePath`

`DetectRunningInstances` and `CloseRunningInstances` matched only on `Win32_Process.ExecutablePath` under the install root. WMI returns null `ExecutablePath` for processes the caller cannot fully introspect (insufficient access tokens, protected-process states, processes mid-spawn). A child process spawned right as the installer launched can hit this and slip past the filter.

**Fix:** added a fallback that, for null-`ExecutablePath` rows, matches against `CommandLine` containing the install-root prefix. The install path is OD-specific enough to avoid false positives without resorting to a broad `Name` match against arbitrary apps.

## Gap 2: race between `Stop-Process -Force` and NSIS extraction

`CloseRunningInstances` previously called `Stop-Process -Force` and returned. On Windows the kernel finalizes file-handle release asynchronously after process exit, so an overwrite right after the kill can race the handle GC. NSIS hits the file-in-use prompt even though the kill technically succeeded.

**Fix:** added `WaitForExit(5000)` per PID after the force-stop loop. Each killed process gets up to 5s to actually exit before the function returns and `RunningInstancesPageLeave` proceeds. By the time NSIS reaches extraction the OS handles are released.

## What's not in this PR

The third part of @lefarcen's proposed fix is the cross-platform `before-quit` cleanup in the Electron app so that real app-quit (and electron-updater's `quitAndInstall`) reliably tears down sidecars before the installer ever runs. That belongs with [#422](https://github.com/nexu-io/open-design/pull/422)'s direction and is intentionally out of scope here. This PR addresses only the installer-side gaps that fire when, for any reason, an OD process is still alive when the installer launches.

## Honest caveat

I do not have a Windows packaged-build environment to run `pnpm tools-pack win build --to nsis` and reproduce the locked-file dialog end-to-end. The PowerShell edits are textual and follow the patterns already in the template; the file does not have any workspace test surface. A verifying install pass on a real Windows host (previous OD installed and running, then run new installer over it) is recommended before merge. Happy to iterate on whatever the maintainer's local repro reveals.

`pnpm guard` clean. The `tools-pack typecheck` fails on a pre-existing missing `@electron/rebuild` devDep in `src/win/app.ts` on current main (reproducible by checking out main directly without my edit), unrelated to this change.