### PR TITLE
fix(web): scope settings save validation to the active sidebar section (#739)

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -452,6 +452,78 @@ export function agentRefreshOptionsForConfig(cfg: AppConfig): AgentRefreshOption
   };
 }
 
+/**
+ * Returns whether the modal's footer Save button should be enabled for the
+ * currently active sidebar section.
+ *
+ * The mode-completeness check (BYOK requires apiKey + model + valid baseUrl;
+ * Local CLI requires a selected available agent) is only meaningful on the
+ * execution-mode section, where the user is actively editing those fields.
+ * On every other sidebar section (language, appearance, composio, media,
+ * integrations, notifications, pet, library, about), partial state from a
+ * draft mode toggle (e.g. user clicked BYOK on the execution section without
+ * filling in fields, then navigated to language) must NOT block saving
+ * changes the user is making in those unrelated sections. Issue #739.
+ */
+export function shouldEnableSettingsSave(
+  cfg: AppConfig,
+  activeSection: SettingsSection,
+  agents: ReadonlyArray<{ id: string; available: boolean }>,
+  isBaseUrlValid: boolean,
+): boolean {
+  if (activeSection !== 'execution') return true;
+  if (cfg.mode === 'daemon') {
+    return Boolean(
+      cfg.agentId && agents.find((a) => a.id === cfg.agentId)?.available,
+    );
+  }
+  return Boolean(cfg.apiKey.trim() && cfg.model.trim() && isBaseUrlValid);
+}
+
+/**
+ * Returns the config that should actually be persisted by `onSave`.
+ *
+ * Counterpart to {@link shouldEnableSettingsSave}: when Save is enabled on a
+ * non-execution sidebar section but the user's draft execution config is
+ * incomplete (e.g. they toggled BYOK on the execution section, never filled
+ * in apiKey, then navigated to Language and clicked Save), the raw `cfg`
+ * still carries that broken draft. Persisting it would leave the app in an
+ * unusable execution state after the modal closes. This helper reverts the
+ * execution-related fields to their `initial` values in that case, so saving
+ * an unrelated section change never silently commits an incomplete execution
+ * mode.
+ *
+ * Within the execution section, or when execution is already valid, the
+ * config passes through unchanged. Issue #739.
+ */
+export function sanitizeSettingsSavePayload(
+  cfg: AppConfig,
+  initial: AppConfig,
+  activeSection: SettingsSection,
+  agents: ReadonlyArray<{ id: string; available: boolean }>,
+  isBaseUrlValid: boolean,
+): AppConfig {
+  if (activeSection === 'execution') return cfg;
+  // Reuse the existing execution-section validity gate so the two helpers
+  // share one source of truth for "execution config is complete enough."
+  const executionValid = shouldEnableSettingsSave(cfg, 'execution', agents, isBaseUrlValid);
+  if (executionValid) return cfg;
+  return {
+    ...cfg,
+    mode: initial.mode,
+    apiKey: initial.apiKey,
+    apiProtocol: initial.apiProtocol,
+    apiVersion: initial.apiVersion,
+    apiProtocolConfigs: initial.apiProtocolConfigs,
+    apiProviderBaseUrl: initial.apiProviderBaseUrl,
+    baseUrl: initial.baseUrl,
+    model: initial.model,
+    agentId: initial.agentId,
+    agentCliEnv: initial.agentCliEnv,
+    maxTokens: initial.maxTokens,
+  };
+}
+
 export function switchApiProtocolConfig(
   config: AppConfig,
   protocol: ApiProtocol,
@@ -791,14 +863,7 @@ export function SettingsDialog({
   const apiProtocol = cfg.apiProtocol ?? 'anthropic';
   const baseUrlValid = isValidApiBaseUrl(cfg.baseUrl);
   const baseUrlInvalid = Boolean(cfg.baseUrl.trim() && !baseUrlValid);
-  const canSave =
-    cfg.mode === 'daemon'
-      ? Boolean(cfg.agentId && agents.find((a) => a.id === cfg.agentId)?.available)
-      : Boolean(
-          cfg.apiKey.trim() &&
-          cfg.model.trim() &&
-          baseUrlValid,
-        );
+  const canSave = shouldEnableSettingsSave(cfg, activeSection, agents, baseUrlValid);
 
   const protocolProviders = useMemo(
     () => KNOWN_PROVIDERS.filter((p) => p.protocol === apiProtocol),
@@ -1686,7 +1751,17 @@ export function SettingsDialog({
             type="button"
             className="primary"
             disabled={!canSave}
-            onClick={() => onSave(cfg, activeSection !== 'composio')}
+            onClick={() =>
+              onSave(
+                // Sanitize before persist: when saving from a non-execution
+                // section with an incomplete BYOK draft, revert the
+                // execution-mode fields to `initial` so the unrelated section
+                // change is committed without leaving the app in a broken
+                // execution mode. Issue #739.
+                sanitizeSettingsSavePayload(cfg, initial, activeSection, agents, baseUrlValid),
+                activeSection !== 'composio',
+              )
+            }
           >
             {welcome ? t('settings.getStarted') : t('common.save')}
           </button>

--- a/apps/web/tests/components/SettingsDialog.test.ts
+++ b/apps/web/tests/components/SettingsDialog.test.ts
@@ -4,6 +4,8 @@ import {
   canRunProviderConnectionTest,
   deriveComposioCredentialState,
   isValidApiBaseUrl,
+  sanitizeSettingsSavePayload,
+  shouldEnableSettingsSave,
   shouldShowCustomModelInput,
   switchApiProtocolConfig,
   testStatusVariant,
@@ -373,5 +375,228 @@ describe('deriveComposioCredentialState', () => {
     expect(
       deriveComposioCredentialState({ apiKey: '   \t\n', apiKeyConfigured: true }),
     ).toBe('saved');
+  });
+});
+
+describe('shouldEnableSettingsSave', () => {
+  // Issue #739: when the user toggles BYOK on the execution section without
+  // filling required fields and then navigates to a different sidebar section
+  // (language, appearance, ...), the footer Save button must reflect the
+  // destination section's state, not the execution section's incomplete mode.
+
+  const validApiCfg: AppConfig = {
+    ...baseConfig,
+    mode: 'api',
+    apiKey: 'sk-x',
+    model: 'claude-sonnet-4-5',
+  };
+
+  const incompleteApiCfg: AppConfig = {
+    ...baseConfig,
+    mode: 'api',
+    apiKey: '', // user toggled BYOK but did not fill in fields
+    model: '',
+  };
+
+  const validDaemonCfg: AppConfig = {
+    ...baseConfig,
+    mode: 'daemon',
+    agentId: 'claude-code',
+  };
+
+  const availableAgent = { id: 'claude-code', available: true };
+  const unavailableAgent = { id: 'claude-code', available: false };
+
+  it('returns true on any non-execution section regardless of mode completeness (the fix for #739)', () => {
+    // The exact scenario from the issue: incomplete BYOK on execution must
+    // not block save on language, appearance, composio, etc.
+    expect(shouldEnableSettingsSave(incompleteApiCfg, 'language', [availableAgent], true)).toBe(true);
+    expect(shouldEnableSettingsSave(incompleteApiCfg, 'appearance', [availableAgent], true)).toBe(true);
+    expect(shouldEnableSettingsSave(incompleteApiCfg, 'composio', [availableAgent], true)).toBe(true);
+    expect(shouldEnableSettingsSave(incompleteApiCfg, 'media', [availableAgent], true)).toBe(true);
+    expect(shouldEnableSettingsSave(incompleteApiCfg, 'integrations', [availableAgent], true)).toBe(true);
+    expect(shouldEnableSettingsSave(incompleteApiCfg, 'notifications', [availableAgent], true)).toBe(true);
+    expect(shouldEnableSettingsSave(incompleteApiCfg, 'pet', [availableAgent], true)).toBe(true);
+    expect(shouldEnableSettingsSave(incompleteApiCfg, 'library', [availableAgent], true)).toBe(true);
+    expect(shouldEnableSettingsSave(incompleteApiCfg, 'about', [availableAgent], true)).toBe(true);
+  });
+
+  it('on execution + daemon: returns true only when an available agent is selected', () => {
+    expect(shouldEnableSettingsSave(validDaemonCfg, 'execution', [availableAgent], false)).toBe(true);
+    expect(
+      shouldEnableSettingsSave(
+        { ...validDaemonCfg, agentId: null },
+        'execution',
+        [availableAgent],
+        false,
+      ),
+    ).toBe(false);
+    expect(shouldEnableSettingsSave(validDaemonCfg, 'execution', [unavailableAgent], false)).toBe(false);
+    expect(shouldEnableSettingsSave(validDaemonCfg, 'execution', [], false)).toBe(false);
+  });
+
+  it('on execution + api: returns true only when apiKey, model, and baseUrl are all valid', () => {
+    expect(shouldEnableSettingsSave(validApiCfg, 'execution', [], true)).toBe(true);
+    expect(shouldEnableSettingsSave({ ...validApiCfg, apiKey: '' }, 'execution', [], true)).toBe(false);
+    expect(shouldEnableSettingsSave({ ...validApiCfg, apiKey: '   ' }, 'execution', [], true)).toBe(false);
+    expect(shouldEnableSettingsSave({ ...validApiCfg, model: '' }, 'execution', [], true)).toBe(false);
+    expect(shouldEnableSettingsSave(validApiCfg, 'execution', [], false)).toBe(false);
+  });
+
+  it('on execution: incomplete BYOK still disables save (existing behavior preserved)', () => {
+    // Regression guard so that #739's fix only changes the cross-section
+    // behavior, not the within-execution-section validity check.
+    expect(shouldEnableSettingsSave(incompleteApiCfg, 'execution', [availableAgent], true)).toBe(false);
+  });
+});
+
+describe('sanitizeSettingsSavePayload', () => {
+  // Round-2 review on PR #827 (lefarcen + chatgpt-codex + mrcfps): enabling
+  // Save on non-execution sections is the right UX, but the click still
+  // calls onSave(cfg, ...) which writes the entire draft to localStorage.
+  // If the user toggled BYOK without filling apiKey/model and then saved an
+  // unrelated Language change, the broken execution mode would persist and
+  // leave the app unable to run queries. The sanitize helper reverts the
+  // execution-mode fields to `initial` in that exact case.
+
+  const initialDaemon: AppConfig = {
+    ...baseConfig,
+    mode: 'daemon',
+    apiKey: 'pre-existing-key',
+    apiProtocol: 'anthropic',
+    apiVersion: '2024-01-01',
+    apiProviderBaseUrl: 'https://api.anthropic.com',
+    baseUrl: 'https://api.anthropic.com',
+    model: 'claude-sonnet-4-5',
+    agentId: 'claude-code',
+    agentCliEnv: { claude: { CLAUDE_CONFIG_DIR: '~/.claude' } },
+    maxTokens: 8000,
+  };
+
+  const draftWithIncompleteBYOK: AppConfig = {
+    ...initialDaemon,
+    mode: 'api',
+    apiKey: '',
+    model: '',
+    // Simulate the user's Appearance change carrying through cfg too.
+    theme: 'dark',
+  };
+
+  const availableAgent = { id: 'claude-code', available: true };
+
+  it('reverts execution-mode fields to initial when saving from a non-execution section with incomplete BYOK', () => {
+    // The exact P1 from lefarcen + chatgpt-codex + mrcfps: persisting
+    // mode='api' with empty credentials must NOT happen when the user
+    // saves from a non-execution section.
+    const sanitized = sanitizeSettingsSavePayload(
+      draftWithIncompleteBYOK,
+      initialDaemon,
+      'language',
+      [availableAgent],
+      true,
+    );
+
+    // Execution-mode fields are restored from initial:
+    expect(sanitized.mode).toBe('daemon');
+    expect(sanitized.apiKey).toBe('pre-existing-key');
+    expect(sanitized.apiProtocol).toBe('anthropic');
+    expect(sanitized.apiVersion).toBe('2024-01-01');
+    expect(sanitized.apiProviderBaseUrl).toBe('https://api.anthropic.com');
+    expect(sanitized.baseUrl).toBe('https://api.anthropic.com');
+    expect(sanitized.model).toBe('claude-sonnet-4-5');
+    expect(sanitized.agentId).toBe('claude-code');
+    expect(sanitized.agentCliEnv).toEqual({ claude: { CLAUDE_CONFIG_DIR: '~/.claude' } });
+    expect(sanitized.maxTokens).toBe(8000);
+
+    // The non-execution change (theme) is preserved:
+    expect(sanitized.theme).toBe('dark');
+  });
+
+  it('passes the cfg through unchanged when execution config is already valid', () => {
+    // A user with a valid BYOK setup who navigates to a non-execution
+    // section and saves expects their pre-existing valid execution config
+    // AND their non-execution change to land. No reversion.
+    const validApiInitial: AppConfig = {
+      ...baseConfig,
+      mode: 'api',
+      apiKey: 'sk-valid',
+      model: 'claude-sonnet-4-5',
+      baseUrl: 'https://api.anthropic.com',
+    };
+    const draftWithThemeChange: AppConfig = { ...validApiInitial, theme: 'light' };
+
+    const sanitized = sanitizeSettingsSavePayload(
+      draftWithThemeChange,
+      validApiInitial,
+      'appearance',
+      [availableAgent],
+      true,
+    );
+
+    expect(sanitized).toEqual(draftWithThemeChange);
+  });
+
+  it('passes the cfg through unchanged on the execution section itself', () => {
+    // Within the execution section, the canSave gate already blocks
+    // incomplete-BYOK saves, so we explicitly do NOT sanitize here:
+    // any draft the user CAN save from execution is one they intend to
+    // commit as a real execution-config change.
+    const sanitized = sanitizeSettingsSavePayload(
+      draftWithIncompleteBYOK,
+      initialDaemon,
+      'execution',
+      [availableAgent],
+      true,
+    );
+    expect(sanitized).toBe(draftWithIncompleteBYOK);
+  });
+
+  it('reverts on every non-execution section, not just language', () => {
+    // The fix must cover every sidebar section that does not own execution
+    // fields, otherwise a save from any one of them could leak the
+    // incomplete BYOK draft.
+    const sections: Array<Parameters<typeof sanitizeSettingsSavePayload>[2]> = [
+      'media',
+      'composio',
+      'integrations',
+      'language',
+      'appearance',
+      'notifications',
+      'pet',
+      'library',
+      'about',
+    ];
+    for (const section of sections) {
+      const sanitized = sanitizeSettingsSavePayload(
+        draftWithIncompleteBYOK,
+        initialDaemon,
+        section,
+        [availableAgent],
+        true,
+      );
+      expect(sanitized.mode).toBe('daemon');
+      expect(sanitized.apiKey).toBe('pre-existing-key');
+      expect(sanitized.agentId).toBe('claude-code');
+    }
+  });
+
+  it('preserves the non-execution change even when the daemon agent is unavailable in the registry passed in', () => {
+    // Edge case: user originally had a valid daemon mode with available
+    // agent. They didn't touch execution. The agent later went unavailable
+    // (e.g., daemon offline). Saving an Appearance change should still
+    // preserve the user's existing daemon selection because the revert
+    // path uses initial as the source of truth, not the live agent registry.
+    const sanitized = sanitizeSettingsSavePayload(
+      { ...initialDaemon, theme: 'system' },
+      initialDaemon,
+      'appearance',
+      [{ id: 'claude-code', available: false }],
+      true,
+    );
+    // Execution fields land equal to initial regardless of revert path,
+    // and the appearance change survives.
+    expect(sanitized.mode).toBe('daemon');
+    expect(sanitized.agentId).toBe('claude-code');
+    expect(sanitized.theme).toBe('system');
   });
 });


### PR DESCRIPTION
Closes #739.

## Problem

The footer Save button's enabled state was computed purely from execution-mode completeness (BYOK requires `apiKey` + `model` + valid `baseUrl`; Local CLI requires a selected available agent). That check ran regardless of which sidebar section the user was on, so a draft mode toggle on the execution section that left required fields empty would lock the Save button across every other section.

After clicking BYOK without filling fields and navigating to language or appearance, the user could not save unrelated changes in those sections even though they had nothing to do with execution mode. Exactly the symptom @shangxinyu1 described.

## Fix

Extracted the gating into a pure helper `shouldEnableSettingsSave(cfg, activeSection, agents, isBaseUrlValid)` in [apps/web/src/components/SettingsDialog.tsx](https://github.com/nexu-io/open-design/blob/main/apps/web/src/components/SettingsDialog.tsx).

- On any sidebar section other than `'execution'` (language, appearance, composio, media, integrations, notifications, pet, library, about): returns `true`. The mode-completeness check is meaningless on those sections.
- On `'execution'`: keeps the existing mode-completeness check unchanged. BYOK-incomplete still disables Save where the user is actually editing the mode fields.

The component's `canSave` is now a one-liner that delegates to the helper.

## Tests

`shouldEnableSettingsSave` has 4 new test groups in [apps/web/tests/components/SettingsDialog.test.ts](https://github.com/nexu-io/open-design/blob/main/apps/web/tests/components/SettingsDialog.test.ts):

- The fix itself: incomplete BYOK on execution does NOT block save when the user navigates to any other section.
- `'execution' + daemon`: returns true only when an available agent is selected.
- `'execution' + api`: returns true only when apiKey, model, and baseUrl are all valid.
- Regression guard: incomplete BYOK on `'execution'` still disables save (the within-section invariant the fix must NOT loosen).

Local: web tests 28/28, web typecheck, `pnpm guard` all clean.