### PR TITLE
fix(web): wrap comment-popover action row so the Save/Sending button cannot exceed the popover edge (#779)

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5876,8 +5876,17 @@ button.connector-action.is-loading {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   margin-top: 8px;
+}
+.comment-popover-actions > * {
+  /* Buttons may carry labels longer than their natural fair-share of the
+     320px popover width (Save comment, Send to chat, Sending..., Add note,
+     Remove). Without an explicit shrink ceiling and wrap, the row pushes
+     past the popover's right edge instead of breaking onto a new line.
+     Issue #779. */
+  max-width: 100%;
 }
 .comment-popover-remove {
   color: var(--red);


### PR DESCRIPTION
Closes #779.

## Problem

`.comment-popover-actions` in [apps/web/src/index.css](https://github.com/nexu-io/open-design/blob/main/apps/web/src/index.css) lays out four buttons (Remove, Add note, Save comment, Send to chat / Sending...) with `display: flex`, `justify-content: space-between`, no `flex-wrap`, and no per-child shrink ceiling. The popover itself is `width: min(320px, calc(100% - 28px))` with 10px padding on each side, leaving roughly 300px of inner room.

The combined natural width of the labels (`Add note` + `Save comment` + `Send to chat`) exceeds 300px before the gaps are even counted. With nowrap and no shrink, the rightmost button visibly spills past the popover's right edge, exactly the symptom @shangxinyu1 reported. The `Sending...` text in the screenshot is just where the user happened to notice it; the underlying overflow is independent of the specific button label.

## Fix

Two single-property additions:

```css
.comment-popover-actions {
  /* existing */
  flex-wrap: wrap;
}
.comment-popover-actions > * {
  max-width: 100%;
}
```

`flex-wrap: wrap` lets the row break onto a second line when the labels do not fit. `max-width: 100%` on direct children stops a single oversized button from pushing the row out instead of wrapping. Wider screens where the buttons already fit see no layout change.

Local: web typecheck and `pnpm guard` clean. Pure CSS change with no runtime test surface.