### PR TITLE
fix(web): wrap long note text inside picker/comment popover (#782)

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5865,7 +5865,15 @@ button.connector-action.is-loading {
   font-size: 12px;
 }
 .board-note-item span {
+  /* The note span sits next to a Remove button inside a fixed-width
+     ~300px popover. Without flex: 1 + min-width: 0 + overflow-wrap an
+     unbroken long string (URL, hash, base64) refuses to break and
+     pushes the popover layout sideways past its 320px boundary.
+     Issue #782. */
+  flex: 1;
+  min-width: 0;
   color: var(--text);
+  overflow-wrap: anywhere;
 }
 .comment-popover textarea {
   min-height: 78px;


### PR DESCRIPTION
Closes #782.

## Problem

`.board-note-item` is a flex row inside the comment popover holding a `<span>` with the note text and a `Remove` button. The span had no width hints. When the user added a note containing a very long unbroken string (URL, hash, base64), the span tried to fit it on one line, pushing the row wider than the popover's 320px boundary and distorting the overlay's right edge plus the surrounding picker UI.

## Fix

Three properties on `.board-note-item span`:

```css
flex: 1;            /* take remaining width next to the Remove button */
min-width: 0;       /* lift the default flex-item min-content floor so shrinking works */
overflow-wrap: anywhere; /* break long unbroken strings at any character when needed */
```

`flex: 1` and `min-width: 0` together let the span size to the available width. `overflow-wrap: anywhere` allows breaking at any character when natural word boundaries can't fit the string. No layout change for normal-length notes.

Local: web typecheck and `pnpm guard` clean. Pure CSS change with no runtime test surface.