### PR TITLE
fix(web): hide unsupported save comment button and refine pod spacing

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -1360,31 +1360,35 @@ function BoardComposerPopover({
             {t('chat.comments.remove')}
           </button>
         ) : <span />}
-        <button
-          type="button"
-          className="ghost"
-          disabled={!draft.trim()}
-          onClick={onAddDraft}
-        >
-          Add note
-        </button>
-        <button
-          type="button"
-          className="ghost"
-          disabled={target.selectionKind === 'pod' || !draft.trim()}
-          onClick={() => void onSaveComment()}
-        >
-          Save comment
-        </button>
-        <button
-          type="button"
-          className="primary"
-          data-testid="comment-add-send"
-          disabled={pendingCount === 0 || sending}
-          onClick={() => void onSendBatch()}
-        >
-          {sending ? 'Sending...' : 'Send to chat'}
-        </button>
+        <div className="comment-popover-right-actions">
+          <button
+            type="button"
+            className="ghost"
+            disabled={!draft.trim()}
+            onClick={onAddDraft}
+          >
+            Add note
+          </button>
+          {target.selectionKind !== 'pod' && (
+            <button
+              type="button"
+              className="ghost"
+              disabled={!draft.trim()}
+              onClick={() => void onSaveComment()}
+            >
+              Save comment
+            </button>
+          )}
+          <button
+            type="button"
+            className="primary"
+            data-testid="comment-add-send"
+            disabled={pendingCount === 0 || sending}
+            onClick={() => void onSendBatch()}
+          >
+            {sending ? 'Sending...' : 'Send to chat'}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5879,6 +5879,10 @@ button.connector-action.is-loading {
   gap: 8px;
   margin-top: 8px;
 }
+.comment-popover-right-actions {
+  display: flex;
+  gap: 6px;
+}
 .comment-popover-remove {
   color: var(--red);
   background: transparent;


### PR DESCRIPTION
# Summary
Refines the comment popover layout by grouping primary action buttons and hiding the unsupported "Save comment" button.

# Changes
- **Button Grouping**: Wrapped action buttons in a flex `div` with a `6px` gap in `FileViewer.tsx`.
- **Layout Persistence**: The new wrapper ensures the layout remains stable and professional regardless of whether the "Save comment" button is enabled.
- **Future Proofing**: This structure prevents the "Add note" and "Send to chat" buttons from drifting apart (due to the parent's `space-between` style) and allows for a seamless, styling-consistent restoration of the "Save comment" feature in the future.

# Before
<img width="428" height="468" alt="image" src="https://github.com/user-attachments/assets/e75bf121-803c-45d9-af5b-75da19400f94" />

# After 
<img width="466" height="497" alt="image" src="https://github.com/user-attachments/assets/12480129-247e-4c14-a320-d0e1323b17d9" />

# References
Closes #792