### PR TITLE
fix: prevent comment popover header overflow when label is too long

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -1313,12 +1313,12 @@ function BoardComposerPopover({
       }}
     >
       <div className="comment-popover-head">
-        <div>
+        <div title={target.elementId}>
           <strong id={titleId}>{target.elementId}</strong>
           <span>{target.label}</span>
           <span>{selectionKindLabel(target.selectionKind, target.memberCount)}</span>
         </div>
-        <button type="button" className="ghost" onClick={onClose}>
+        <button type="button" className="ghost" onClick={onClose} title={t('common.close')}>
           {t('common.close')}
         </button>
       </div>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5817,11 +5817,25 @@ button.connector-action.is-loading {
 .comment-popover-head div {
   display: grid;
   gap: 1px;
+  min-width: 0;
+  overflow: hidden;
 }
-.comment-popover-head strong { font-size: 13px; }
+.comment-popover-head strong {
+  font-size: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .comment-popover-head span {
   color: var(--text-muted);
   font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.comment-popover-head button.ghost {
+  flex: 0 0 auto;
+  white-space: nowrap;
 }
 .board-pod-summary {
   display: grid;


### PR DESCRIPTION
## Summary
When the comment popover header contains a long label, the layout breaks and the close button may be pushed out of view.

## Changes
- Add `min-width: 0` and `overflow: hidden` to `.comment-popover-head div`
- Add `text-overflow: ellipsis` and `white-space: nowrap` to `strong` and `span` elements
- Add `flex: 0 0 auto` to close button to keep it fixed width
- Add `title` attribute to header div and close button for hover tooltip

## Files
- `apps/web/src/index.css`
- `apps/web/src/components/FileViewer.tsx`