### PR TITLE
fix(web): truncate long inspect-panel labels so they cannot spill past the panel edge (#780)

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -1507,7 +1507,7 @@ function InspectPanel({
     <aside className="inspect-panel" data-testid="inspect-panel">
       <header className="inspect-panel-head">
         <div className="inspect-panel-title">
-          <strong>{target.label || target.elementId}</strong>
+          <strong title={target.label || target.elementId}>{target.label || target.elementId}</strong>
           <code title={target.selector}>{target.elementId}</code>
         </div>
         <button type="button" className="ghost" onClick={onClose} aria-label="Close inspect">

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5957,8 +5957,8 @@ button.connector-action.is-loading {
   /* Long target.label values (deeply-nested component selectors) used
      to spill past the title container and out of the panel because
      this rule had no overflow constraint. Truncate with ellipsis;
-     the full string remains accessible via the title attribute on
-     the sibling <code>. Issue #780. */
+     the <strong> carries title={label} so the full string is still
+     visible on hover. Issue #780. */
   font-size: 13px;
   white-space: nowrap;
   overflow: hidden;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5954,7 +5954,15 @@ button.connector-action.is-loading {
   min-width: 0;
 }
 .inspect-panel-title strong {
+  /* Long target.label values (deeply-nested component selectors) used
+     to spill past the title container and out of the panel because
+     this rule had no overflow constraint. Truncate with ellipsis;
+     the full string remains accessible via the title attribute on
+     the sibling <code>. Issue #780. */
   font-size: 13px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .inspect-panel-title code {
   color: var(--text-muted);


### PR DESCRIPTION
Closes #780.

## Problem

The inspect panel renders the selected component's label as a `<strong>` inside `.inspect-panel-title`. The grid container had `min-width: 0` (allowing it to shrink) but the inner `<strong>` rule in [apps/web/src/index.css](https://github.com/nexu-io/open-design/blob/main/apps/web/src/index.css) only set `font-size` with no overflow constraints. A deeply-nested component with a long generated selector path produced a label longer than the 296px panel width, and the text spilled out past the panel's right edge instead of clipping inside the title's background frame.

## Fix

Three properties on `.inspect-panel-title strong`:

```css
white-space: nowrap;
overflow: hidden;
text-overflow: ellipsis;
```

The label now truncates with ellipsis within the panel boundary. The full string remains accessible to users via the `title` attribute already present on the sibling `<code>` element that renders the same selector context.

Local: web typecheck and `pnpm guard` clean. Pure CSS change with no runtime test surface.