### PR TITLE
fix(web): keep inspect-panel close button on a stable single-line layout (#785)

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5948,6 +5948,15 @@ button.connector-action.is-loading {
   justify-content: space-between;
   gap: 10px;
 }
+.inspect-panel-head > button {
+  /* Without an explicit shrink-floor, a long selected-component label
+     in the title can squeeze the Close button so narrowly that the
+     "x" glyph stacks into a vertical layout on some font/zoom
+     combinations. Pinning flex-shrink: 0 keeps the close affordance
+     on a stable single-line size regardless of label length. Issue
+     #785. */
+  flex-shrink: 0;
+}
 .inspect-panel-title {
   display: grid;
   gap: 2px;


### PR DESCRIPTION
Closes #785.

## Problem

`.inspect-panel-head` in [apps/web/src/index.css](https://github.com/nexu-io/open-design/blob/main/apps/web/src/index.css) laid out a flexible title block next to the Close button with `display: flex` and `gap: 10px`, but no `flex-shrink` ceiling on the button. When the selected component had a long generated selector, the title block consumed almost all available width and the close button shrank below its natural glyph width. On some font/zoom combinations the single-character `×` label rendered stacked vertically rather than as a normal horizontal control, exactly the symptom @shangxinyu1 reported.

## Fix

```css
.inspect-panel-head > button {
  flex-shrink: 0;
}
```

The close control now reserves its natural size regardless of how much the title block expands. The button stays on a single horizontal line for any selector length the panel can render.

Local: web typecheck and `pnpm guard` clean. Pure CSS change with no runtime test surface.