### PR TITLE
fix(web): preserve Chat scroll position across Chat/Comments tab switches (#790)

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -156,6 +156,9 @@ export function ChatPane({
 
   useEffect(() => {
     didInitialScrollRef.current = false;
+    // A new conversation should land at the bottom (its own initial
+    // scroll), not inherit the previous conversation's saved position.
+    savedChatScrollRef.current = null;
   }, [activeConversationId]);
 
   useEffect(() => {

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -169,7 +169,13 @@ export function ChatPane({
       el.scrollTop = el.scrollHeight;
       setScrolledFromBottom(false);
     });
-  }, [activeConversationId, messages.length]);
+    // `tab` is in the deps so that switching conversations while
+    // Comments is open doesn't strand the new conversation at scrollTop:
+    // 0. The activeConversationId-reset effect above clears
+    // didInitialScrollRef while the chat-log is unmounted; this effect
+    // then re-runs when the user returns to Chat and the element is
+    // available, scrolling the new conversation to its initial bottom.
+  }, [activeConversationId, messages.length, tab]);
 
   useEffect(() => {
     const el = logRef.current;

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -180,19 +180,42 @@ export function ChatPane({
     }
   }, [messages, error]);
 
+  // Saved chat-log scrollTop, preserved across tab switches.
+  // The chat-log <div> is conditionally rendered (line 331:
+  // `{tab === 'chat' ? ... : null}`) so it unmounts when the user
+  // switches to Comments. On remount it would default to scrollTop: 0
+  // (top of conversation), and the initial-bottom-scroll effect skips
+  // because didInitialScrollRef is already true. Save scrollTop while
+  // Chat is visible and restore it on remount so reading position
+  // survives tab toggles. Issue #790.
+  const savedChatScrollTopRef = useRef<number | null>(null);
   useEffect(() => {
+    if (tab !== 'chat') return;
     const el = logRef.current;
     if (!el) return;
+
+    // Restore previously-saved position on remount. Defer to the next
+    // frame so the conditional <> contents finish layout before the
+    // scrollTop write lands.
+    const saved = savedChatScrollTopRef.current;
+    if (saved !== null) {
+      requestAnimationFrame(() => {
+        const target = logRef.current;
+        if (target) target.scrollTop = saved;
+      });
+    }
+
     function onScroll() {
       const target = logRef.current;
       if (!target) return;
+      savedChatScrollTopRef.current = target.scrollTop;
       const distance =
         target.scrollHeight - target.scrollTop - target.clientHeight;
       setScrolledFromBottom(distance > 120);
     }
     el.addEventListener('scroll', onScroll);
     return () => el.removeEventListener('scroll', onScroll);
-  }, []);
+  }, [tab]);
 
   // Close the conversation history dropdown on outside click / Escape.
   useEffect(() => {

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -218,6 +218,14 @@ export function ChatPane({
         } else {
           target.scrollTop = saved.scrollTop;
         }
+        // Resync the jump-to-latest affordance with the restored
+        // position. Without this, a user who left Chat ~60px from the
+        // bottom and returns to find new messages stacked underneath
+        // would land hundreds of pixels above the latest turn while
+        // scrolledFromBottom remained false until they scrolled.
+        const distance =
+          target.scrollHeight - target.scrollTop - target.clientHeight;
+        setScrolledFromBottom(distance > 120);
       });
     }
 

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -180,15 +180,17 @@ export function ChatPane({
     }
   }, [messages, error]);
 
-  // Saved chat-log scrollTop, preserved across tab switches.
-  // The chat-log <div> is conditionally rendered (line 331:
-  // `{tab === 'chat' ? ... : null}`) so it unmounts when the user
-  // switches to Comments. On remount it would default to scrollTop: 0
-  // (top of conversation), and the initial-bottom-scroll effect skips
-  // because didInitialScrollRef is already true. Save scrollTop while
-  // Chat is visible and restore it on remount so reading position
-  // survives tab toggles. Issue #790.
-  const savedChatScrollTopRef = useRef<number | null>(null);
+  // Saved chat-log scroll state, preserved across tab switches. The
+  // chat-log <div> is conditionally rendered so it unmounts when the
+  // user switches to Comments. On remount it would default to
+  // scrollTop: 0 and the initial-bottom-scroll effect skips because
+  // didInitialScrollRef is already true. We capture either the absolute
+  // scrollTop or a "pinned to bottom" flag while Chat is visible, so
+  // bottom-followers stay pinned even when new messages stream in
+  // off-tab. Issue #790.
+  const savedChatScrollRef = useRef<
+    { pinnedToBottom: true } | { pinnedToBottom: false; scrollTop: number } | null
+  >(null);
   useEffect(() => {
     if (tab !== 'chat') return;
     const el = logRef.current;
@@ -197,24 +199,44 @@ export function ChatPane({
     // Restore previously-saved position on remount. Defer to the next
     // frame so the conditional <> contents finish layout before the
     // scrollTop write lands.
-    const saved = savedChatScrollTopRef.current;
+    const saved = savedChatScrollRef.current;
     if (saved !== null) {
       requestAnimationFrame(() => {
         const target = logRef.current;
-        if (target) target.scrollTop = saved;
+        if (!target) return;
+        if (saved.pinnedToBottom) {
+          target.scrollTop = target.scrollHeight;
+        } else {
+          target.scrollTop = saved.scrollTop;
+        }
       });
+    }
+
+    function snapshot(target: HTMLDivElement) {
+      const distance =
+        target.scrollHeight - target.scrollTop - target.clientHeight;
+      savedChatScrollRef.current =
+        distance < 50
+          ? { pinnedToBottom: true }
+          : { pinnedToBottom: false, scrollTop: target.scrollTop };
     }
 
     function onScroll() {
       const target = logRef.current;
       if (!target) return;
-      savedChatScrollTopRef.current = target.scrollTop;
+      snapshot(target);
       const distance =
         target.scrollHeight - target.scrollTop - target.clientHeight;
       setScrolledFromBottom(distance > 120);
     }
     el.addEventListener('scroll', onScroll);
-    return () => el.removeEventListener('scroll', onScroll);
+    return () => {
+      // Capture final scroll state before unmount; the ref normally
+      // tracks via onScroll, but programmatic scrolls or layout shifts
+      // right before unmount can leave it stale.
+      snapshot(el);
+      el.removeEventListener('scroll', onScroll);
+    };
   }, [tab]);
 
   // Close the conversation history dropdown on outside click / Escape.

--- a/apps/web/tests/components/chat-scroll-preservation.test.tsx
+++ b/apps/web/tests/components/chat-scroll-preservation.test.tsx
@@ -46,8 +46,8 @@ function mockScrollGeometry(
   };
 }
 
-function renderChatPane(messages: ChatMessage[]) {
-  return render(
+function chatPaneEl(messages: ChatMessage[], activeConversationId: string | null) {
+  return (
     <ChatPane
       messages={messages}
       streaming={false}
@@ -58,11 +58,15 @@ function renderChatPane(messages: ChatMessage[]) {
       onSend={() => {}}
       onStop={() => {}}
       conversations={[]}
-      activeConversationId={null}
+      activeConversationId={activeConversationId}
       onSelectConversation={() => {}}
       onDeleteConversation={() => {}}
-    />,
+    />
   );
+}
+
+function renderChatPane(messages: ChatMessage[], activeConversationId: string | null = null) {
+  return render(chatPaneEl(messages, activeConversationId));
 }
 
 const sampleMessages: ChatMessage[] = [
@@ -117,7 +121,7 @@ describe('chat scroll preservation across tab switches', () => {
   });
 
   it('snaps to new scrollHeight when user was pinned to bottom and new content arrived off-tab', async () => {
-    const { rerender } = renderChatPane(sampleMessages);
+    renderChatPane(sampleMessages);
     const log = getChatLog();
     const ctl = mockScrollGeometry(log, {
       scrollHeight: 1000,
@@ -160,23 +164,49 @@ describe('chat scroll preservation across tab switches', () => {
 
     // Bottom-pinned user lands at scrollHeight, not at the old offset.
     expect(remountedTop).toBe(1500);
+  });
 
-    // Sanity: also exercise that a non-pinned user does not snap.
-    rerender(
-      <ChatPane
-        messages={sampleMessages}
-        streaming={false}
-        error={null}
-        projectId="project-1"
-        projectFiles={[]}
-        onEnsureProject={async () => 'project-1'}
-        onSend={() => {}}
-        onStop={() => {}}
-        conversations={[]}
-        activeConversationId={null}
-        onSelectConversation={() => {}}
-        onDeleteConversation={() => {}}
-      />,
-    );
+  it('does not restore previous conversation scroll when activeConversationId changes', async () => {
+    const { rerender } = render(chatPaneEl(sampleMessages, 'conv-A'));
+    const log = getChatLog();
+    const ctl = mockScrollGeometry(log, {
+      scrollHeight: 1000,
+      clientHeight: 400,
+      scrollTop: 0,
+    });
+
+    // User scrolls up in conversation A and switches to Comments.
+    ctl.setScrollTop(150);
+    await switchTab('Comments');
+
+    // While off-tab, the active conversation changes to B. Returning to
+    // Chat should land at conversation B's own initial position, not
+    // restore conversation A's scrollTop.
+    rerender(chatPaneEl(sampleMessages, 'conv-B'));
+    await switchTab('Chat');
+
+    const remounted = getChatLog();
+    let remountedTop = 0;
+    Object.defineProperty(remounted, 'scrollHeight', {
+      configurable: true,
+      get: () => 1000,
+    });
+    Object.defineProperty(remounted, 'clientHeight', {
+      configurable: true,
+      get: () => 400,
+    });
+    Object.defineProperty(remounted, 'scrollTop', {
+      configurable: true,
+      get: () => remountedTop,
+      set: (v: number) => {
+        remountedTop = v;
+      },
+    });
+
+    await flushFrame();
+
+    // Saved state was cleared on the conversation switch, so the rAF
+    // restore branch is skipped and scrollTop stays at its initial 0.
+    expect(remountedTop).toBe(0);
   });
 });

--- a/apps/web/tests/components/chat-scroll-preservation.test.tsx
+++ b/apps/web/tests/components/chat-scroll-preservation.test.tsx
@@ -1,0 +1,182 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ChatPane } from '../../src/components/ChatPane';
+import type { ChatMessage } from '../../src/types';
+
+// jsdom does not run a layout engine, so scrollHeight, clientHeight, and
+// scrollTop are zero by default. The scroll-preservation effect derives
+// "near bottom" from those, so we drive them explicitly per test.
+function mockScrollGeometry(
+  el: HTMLElement,
+  geom: { scrollHeight: number; clientHeight: number; scrollTop: number },
+) {
+  Object.defineProperty(el, 'scrollHeight', {
+    configurable: true,
+    get: () => geom.scrollHeight,
+  });
+  Object.defineProperty(el, 'clientHeight', {
+    configurable: true,
+    get: () => geom.clientHeight,
+  });
+  let scrollTop = geom.scrollTop;
+  Object.defineProperty(el, 'scrollTop', {
+    configurable: true,
+    get: () => scrollTop,
+    set: (v: number) => {
+      scrollTop = v;
+    },
+  });
+  return {
+    setScrollTop(v: number) {
+      scrollTop = v;
+      fireEvent.scroll(el);
+    },
+    setScrollHeight(v: number) {
+      Object.defineProperty(el, 'scrollHeight', {
+        configurable: true,
+        get: () => v,
+      });
+      geom.scrollHeight = v;
+    },
+    getScrollTop() {
+      return scrollTop;
+    },
+  };
+}
+
+function renderChatPane(messages: ChatMessage[]) {
+  return render(
+    <ChatPane
+      messages={messages}
+      streaming={false}
+      error={null}
+      projectId="project-1"
+      projectFiles={[]}
+      onEnsureProject={async () => 'project-1'}
+      onSend={() => {}}
+      onStop={() => {}}
+      conversations={[]}
+      activeConversationId={null}
+      onSelectConversation={() => {}}
+      onDeleteConversation={() => {}}
+    />,
+  );
+}
+
+const sampleMessages: ChatMessage[] = [
+  { id: 'u1', role: 'user', content: 'first request', createdAt: Date.now() },
+  { id: 'a1', role: 'assistant', content: 'first reply', createdAt: Date.now() },
+  { id: 'u2', role: 'user', content: 'second request', createdAt: Date.now() },
+  { id: 'a2', role: 'assistant', content: 'second reply', createdAt: Date.now() },
+];
+
+function getChatLog(): HTMLElement {
+  const el = document.querySelector('.chat-log');
+  if (!el) throw new Error('chat-log not found');
+  return el as HTMLElement;
+}
+
+function flushFrame() {
+  return act(async () => {
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+  });
+}
+
+async function switchTab(name: 'Chat' | 'Comments') {
+  const tab = screen.getByRole('tab', { name });
+  await act(async () => {
+    fireEvent.click(tab);
+  });
+}
+
+describe('chat scroll preservation across tab switches', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('restores absolute scrollTop when user was scrolled up', async () => {
+    renderChatPane(sampleMessages);
+    const log = getChatLog();
+    const ctl = mockScrollGeometry(log, {
+      scrollHeight: 1000,
+      clientHeight: 400,
+      scrollTop: 0,
+    });
+
+    // User scrolls up to 200 (well above bottom: distance=400).
+    ctl.setScrollTop(200);
+
+    await switchTab('Comments');
+    await switchTab('Chat');
+    await flushFrame();
+
+    const restored = getChatLog();
+    expect(restored.scrollTop).toBe(200);
+  });
+
+  it('snaps to new scrollHeight when user was pinned to bottom and new content arrived off-tab', async () => {
+    const { rerender } = renderChatPane(sampleMessages);
+    const log = getChatLog();
+    const ctl = mockScrollGeometry(log, {
+      scrollHeight: 1000,
+      clientHeight: 400,
+      scrollTop: 600,
+    });
+
+    // User is pinned at bottom (distance = 1000 - 600 - 400 = 0 < 50).
+    ctl.setScrollTop(600);
+
+    await switchTab('Comments');
+
+    // While off-tab, new messages would normally grow scrollHeight. We
+    // simulate that, then re-render so the chat-log remounts at the new
+    // size.
+    ctl.setScrollHeight(1500);
+
+    await switchTab('Chat');
+
+    // Re-mount picks up a fresh element; carry the new geometry into it.
+    const remounted = getChatLog();
+    Object.defineProperty(remounted, 'scrollHeight', {
+      configurable: true,
+      get: () => 1500,
+    });
+    Object.defineProperty(remounted, 'clientHeight', {
+      configurable: true,
+      get: () => 400,
+    });
+    let remountedTop = 0;
+    Object.defineProperty(remounted, 'scrollTop', {
+      configurable: true,
+      get: () => remountedTop,
+      set: (v: number) => {
+        remountedTop = v;
+      },
+    });
+
+    await flushFrame();
+
+    // Bottom-pinned user lands at scrollHeight, not at the old offset.
+    expect(remountedTop).toBe(1500);
+
+    // Sanity: also exercise that a non-pinned user does not snap.
+    rerender(
+      <ChatPane
+        messages={sampleMessages}
+        streaming={false}
+        error={null}
+        projectId="project-1"
+        projectFiles={[]}
+        onEnsureProject={async () => 'project-1'}
+        onSend={() => {}}
+        onStop={() => {}}
+        conversations={[]}
+        activeConversationId={null}
+        onSelectConversation={() => {}}
+        onDeleteConversation={() => {}}
+      />,
+    );
+  });
+});

--- a/apps/web/tests/components/chat-scroll-preservation.test.tsx
+++ b/apps/web/tests/components/chat-scroll-preservation.test.tsx
@@ -166,6 +166,56 @@ describe('chat scroll preservation across tab switches', () => {
     expect(remountedTop).toBe(1500);
   });
 
+  it('reveals the jump-to-latest button when restored position is no longer near bottom', async () => {
+    renderChatPane(sampleMessages);
+    const log = getChatLog();
+    const ctl = mockScrollGeometry(log, {
+      scrollHeight: 1000,
+      clientHeight: 400,
+      scrollTop: 0,
+    });
+
+    // User leaves Chat ~60px from the bottom (distance = 1000 - 540 - 400 = 60).
+    ctl.setScrollTop(540);
+
+    await switchTab('Comments');
+
+    // While off-tab, new messages stack underneath. scrollHeight grows
+    // dramatically; the saved absolute scrollTop is now hundreds of
+    // pixels above the latest turn.
+    ctl.setScrollHeight(2000);
+
+    await switchTab('Chat');
+
+    // Carry the new geometry into the remounted element so the
+    // distance-from-bottom calc inside the rAF restore can see it.
+    const remounted = getChatLog();
+    let remountedTop = 0;
+    Object.defineProperty(remounted, 'scrollHeight', {
+      configurable: true,
+      get: () => 2000,
+    });
+    Object.defineProperty(remounted, 'clientHeight', {
+      configurable: true,
+      get: () => 400,
+    });
+    Object.defineProperty(remounted, 'scrollTop', {
+      configurable: true,
+      get: () => remountedTop,
+      set: (v: number) => {
+        remountedTop = v;
+      },
+    });
+
+    await flushFrame();
+
+    // Restored to old offset (540), but distance = 2000 - 540 - 400 = 1060
+    // is well past the 120px threshold, so the jump-to-latest button
+    // must be visible immediately, not hidden until the user scrolls.
+    expect(remountedTop).toBe(540);
+    expect(screen.getByRole('button', { name: /jump to latest/i })).toBeTruthy();
+  });
+
   it('lands new conversation at its own bottom when switching conversations off-tab', async () => {
     const { rerender } = render(chatPaneEl(sampleMessages, 'conv-A'));
     const log = getChatLog();

--- a/apps/web/tests/components/chat-scroll-preservation.test.tsx
+++ b/apps/web/tests/components/chat-scroll-preservation.test.tsx
@@ -166,7 +166,7 @@ describe('chat scroll preservation across tab switches', () => {
     expect(remountedTop).toBe(1500);
   });
 
-  it('does not restore previous conversation scroll when activeConversationId changes', async () => {
+  it('lands new conversation at its own bottom when switching conversations off-tab', async () => {
     const { rerender } = render(chatPaneEl(sampleMessages, 'conv-A'));
     const log = getChatLog();
     const ctl = mockScrollGeometry(log, {
@@ -179,9 +179,9 @@ describe('chat scroll preservation across tab switches', () => {
     ctl.setScrollTop(150);
     await switchTab('Comments');
 
-    // While off-tab, the active conversation changes to B. Returning to
-    // Chat should land at conversation B's own initial position, not
-    // restore conversation A's scrollTop.
+    // While off-tab the active conversation changes to B. Returning to
+    // Chat must land at conversation B's own initial bottom, not at
+    // scrollTop: 0 and not at conversation A's saved offset.
     rerender(chatPaneEl(sampleMessages, 'conv-B'));
     await switchTab('Chat');
 
@@ -205,8 +205,9 @@ describe('chat scroll preservation across tab switches', () => {
 
     await flushFrame();
 
-    // Saved state was cleared on the conversation switch, so the rAF
-    // restore branch is skipped and scrollTop stays at its initial 0.
-    expect(remountedTop).toBe(0);
+    // Saved state was cleared and the initial-bottom-scroll effect
+    // re-runs with `tab` in its deps, so the new conversation lands at
+    // its own scrollHeight rather than the browser default 0.
+    expect(remountedTop).toBe(1000);
   });
 });


### PR DESCRIPTION
Closes #790.

## Problem

In [apps/web/src/components/ChatPane.tsx](https://github.com/nexu-io/open-design/blob/main/apps/web/src/components/ChatPane.tsx) the chat-log container is conditionally rendered (`{tab === 'chat' ? <>...</> : null}`). When the user switches to Comments and back, the chat-log is unmounted and remounted; the remounted element starts at `scrollTop: 0`, and the initial-bottom-scroll effect skips because `didInitialScrollRef.current` is already `true` from the original mount. The conversation view jumps to the top of the long conversation instead of preserving the user's reading position.

## Fix

Replaced the empty-deps scroll listener with a tab-keyed effect that:

1. Captures `scrollTop` inside the existing `onScroll` handler so the saved position is always current.
2. On every chat-log mount (when `tab` becomes `'chat'`), restores the saved `scrollTop` on the next animation frame so layout finishes before the scroll write lands.

```ts
const savedChatScrollTopRef = useRef<number | null>(null);
useEffect(() => {
  if (tab !== 'chat') return;
  const el = logRef.current;
  if (!el) return;
  const saved = savedChatScrollTopRef.current;
  if (saved !== null) {
    requestAnimationFrame(() => {
      const target = logRef.current;
      if (target) target.scrollTop = saved;
    });
  }
  function onScroll() {
    const target = logRef.current;
    if (!target) return;
    savedChatScrollTopRef.current = target.scrollTop;
    const distance = target.scrollHeight - target.scrollTop - target.clientHeight;
    setScrolledFromBottom(distance > 120);
  }
  el.addEventListener('scroll', onScroll);
  return () => el.removeEventListener('scroll', onScroll);
}, [tab]);
```

The existing `scrolledFromBottom` signal that drives the jump-to-bottom button is folded into the same handler and now correctly re-attaches on every chat-log remount, incidentally fixing a secondary issue where that listener silently stopped firing after a tab toggle.

Local: web typecheck and `pnpm guard` clean.