### PR TITLE
fix(web): keep Design Files tab visible when workspace tabs scroll

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4642,6 +4642,26 @@ button.connector-action.is-loading {
 .ws-tab.design-files-tab {
   font-weight: 500;
   color: var(--text);
+  /* Pin the Design Files entry to the left edge of the horizontally
+     scrollable tab strip so the user always has a way back to the file
+     list even when many tabs overflow. Without sticky positioning,
+     Design Files sits at flex index 0 and scrolls off the left edge
+     once the strip is wide enough to require horizontal scrolling.
+     Issue #775. */
+  position: sticky;
+  left: 0;
+  z-index: 1;
+  /* Solid panel surface so other tabs that scroll past underneath the
+     sticky element do not visibly bleed through. */
+  background: var(--bg-panel);
+  /* Subtle right-edge shadow signals the visual separation when other
+     tabs are scrolled beneath it. */
+  box-shadow: 4px 0 6px -4px rgba(0, 0, 0, 0.12);
+}
+.ws-tab.design-files-tab.active {
+  /* Active state should still read as selected; layer the active tint
+     over the sticky panel surface. */
+  background: var(--bg-subtle);
 }
 
 .ws-tabs-actions { display: inline-flex; gap: 4px; align-items: center; }


### PR DESCRIPTION
Closes #775.

When enough tabs are open, `.ws-tabs-bar` scrolls horizontally (`overflow-x: auto; flex-wrap: nowrap`) and the Design Files entry slides off the left edge with everything else, so there's no obvious way back to the file list.

This pins the Design Files button at the left with `position: sticky; left: 0` and a small right-side shadow so it stays anchored while the rest of the strip scrolls behind it. Active state gets the existing `--bg-subtle` so it still reads as selected.

Touches only [`apps/web/src/index.css`](https://github.com/nexu-io/open-design/blob/main/apps/web/src/index.css), no JSX changes.

Validated locally: `pnpm --filter @open-design/web typecheck` and `pnpm guard` both clean.