### PR TITLE
fix(tools-pack): packaged mac daemon crashes from blake3-wasm __dirname in ESM

### DIFF
--- a/tools/pack/src/mac-prebundle.ts
+++ b/tools/pack/src/mac-prebundle.ts
@@ -15,6 +15,7 @@ export const MAC_PREBUNDLE_ENTRYPOINTS_DIR_NAME = "prebundle-entrypoints";
 
 export const MAC_PREBUNDLE_RUNTIME_DEPENDENCIES = {
   "better-sqlite3": "12.9.0",
+  "blake3-wasm": "2.1.5",
 } as const;
 
 export const MAC_STANDALONE_PREBUNDLE_EXCLUDED_INTERNAL_PACKAGES = [
@@ -42,10 +43,11 @@ export const MAC_PREBUNDLE_POLICIES = {
     label: "packaged main",
   },
   daemonCli: {
-    externals: ["better-sqlite3"],
+    externals: ["better-sqlite3", "blake3-wasm"],
     forbiddenInputs: [
       "/node_modules/@open-design/daemon/",
       "/node_modules/better-sqlite3/",
+      "/node_modules/blake3-wasm/",
       "/node_modules/electron/",
       "/node_modules/next/",
       "/node_modules/openai/",
@@ -55,10 +57,11 @@ export const MAC_PREBUNDLE_POLICIES = {
     label: "daemon cli",
   },
   daemonSidecar: {
-    externals: ["better-sqlite3"],
+    externals: ["better-sqlite3", "blake3-wasm"],
     forbiddenInputs: [
       "/node_modules/@open-design/daemon/",
       "/node_modules/better-sqlite3/",
+      "/node_modules/blake3-wasm/",
       "/node_modules/electron/",
       "/node_modules/next/",
       "/node_modules/openai/",

--- a/tools/pack/tests/mac-prebundle.test.ts
+++ b/tools/pack/tests/mac-prebundle.test.ts
@@ -63,11 +63,14 @@ describe("mac standalone prebundle policy", () => {
   it("documents the explicit code-level bundle boundaries", () => {
     expect(MAC_PREBUNDLE_ESBUILD_TARGET).toBe("node24");
     expect(MAC_PREBUNDLE_POLICIES.packagedMain.externals).toEqual(["electron"]);
-    expect(MAC_PREBUNDLE_POLICIES.daemonCli.externals).toEqual(["better-sqlite3"]);
-    expect(MAC_PREBUNDLE_POLICIES.daemonSidecar.externals).toEqual(["better-sqlite3"]);
+    expect(MAC_PREBUNDLE_POLICIES.daemonCli.externals).toEqual(["better-sqlite3", "blake3-wasm"]);
+    expect(MAC_PREBUNDLE_POLICIES.daemonSidecar.externals).toEqual(["better-sqlite3", "blake3-wasm"]);
     expect(MAC_PREBUNDLE_POLICIES.webSidecar.externals).toEqual([]);
     expect(MAC_DAEMON_PREBUNDLE_ESM_REQUIRE_BANNER).toContain("createRequire");
-    expect(MAC_PREBUNDLE_RUNTIME_DEPENDENCIES).toEqual({ "better-sqlite3": "12.9.0" });
+    expect(MAC_PREBUNDLE_RUNTIME_DEPENDENCIES).toEqual({
+      "better-sqlite3": "12.9.0",
+      "blake3-wasm": "2.1.5",
+    });
     expect(MAC_PREBUNDLED_DAEMON_CLI_RELATIVE_PATH).toBe("app/prebundled/daemon/daemon-cli.mjs");
     expect(MAC_PREBUNDLED_DAEMON_SIDECAR_RELATIVE_PATH).toBe("app/prebundled/daemon/daemon-sidecar.mjs");
     expect(MAC_PREBUNDLED_WEB_SIDECAR_RELATIVE_PATH).toBe("app/prebundled/web-sidecar.mjs");


### PR DESCRIPTION
## Summary

Packaged macOS app (\`pnpm tools-pack mac build\` + \`mac install\`) crashes on launch because the prebundled daemon throws:

\`\`\`
ReferenceError: __dirname is not defined in ES module scope
    at .../blake3-wasm/dist/wasm/nodejs/blake3_js.js
\`\`\`

\`blake3-wasm\` is a transitive dep imported from \`apps/daemon/src/deploy.ts\`. esbuild bundles it into the daemon ESM output, but the generated chunk uses \`__dirname\` without esbuild emitting a helper for it, and the \`.wasm\` asset (\`blake3_js_bg.wasm\`) is not copied alongside the bundle. The window appears for ~300ms then exits with code 1; no UI is reachable.

This change marks \`blake3-wasm\` as external in the \`daemonCli\` and \`daemonSidecar\` policies and adds it to \`MAC_PREBUNDLE_RUNTIME_DEPENDENCIES\` so it ships as a real \`node_modules\` entry in the packaged app, mirroring how \`better-sqlite3\` is handled.

## Reproduction (before fix)

\`\`\`
pnpm install
pnpm tools-pack mac build --to all
pnpm tools-pack mac install
open ".tmp/tools-pack/out/mac/namespaces/default/install/Applications/Open Design.default.app"
\`\`\`

\`.tmp/tools-pack/runtime/mac/namespaces/default/logs/daemon/latest.log\`:

\`\`\`
file:///.../prebundled/daemon/chunks/chunk-G4RLKWVC.mjs:63321
    var path30 = __require("path").join(__dirname, "blake3_js_bg.wasm");
                                        ^
ReferenceError: __dirname is not defined in ES module scope
    at ../../node_modules/.pnpm/blake3-wasm@2.1.5/.../blake3_js.js (...)
\`\`\`

\`logs/desktop/latest.log\`:

\`\`\`
"daemon exited before reporting status (code=1, signal=none)"
\`\`\`

Verified on macOS arm64 (Darwin 25.4.0), Node 24.15.0, pnpm 10.33.2.

## After fix

- \`pnpm --filter @open-design/tools-pack test\` → 53/53 pass
- \`pnpm --filter @open-design/tools-pack typecheck\` → clean
- \`pnpm tools-pack mac build --to all && pnpm tools-pack mac install\` → app launches, daemon reports \`{"state":"running","url":"http://127.0.0.1:<port>"}\` and \`/api/health\` returns \`{"ok":true}\`

## Test plan

- [x] Unit: tools-pack tests updated and green
- [x] Manual: rebuilt + reinstalled .app on darwin-arm64; daemon reaches \`running\` state and the desktop window stays open
- [ ] CI mac packaged build still passes