### PR TITLE
fix(daemon): make MCP install snippet survive daemon port changes

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -516,8 +516,8 @@ async function runMcp(args) {
     return;
   }
 
-  const daemonUrl =
-    flags['daemon-url'] || process.env.OD_DAEMON_URL || 'http://127.0.0.1:7456';
+  const { resolveMcpDaemonUrl } = await import('./mcp-daemon-url.js');
+  const daemonUrl = await resolveMcpDaemonUrl({ flagUrl: flags['daemon-url'] });
 
   const { runMcpStdio } = await import('./mcp.js');
   await runMcpStdio({ daemonUrl });
@@ -532,8 +532,15 @@ in another repo so the agent can pull files from a local Open Design
 project without exporting a zip every iteration.
 
 Options:
-  --daemon-url <url>   Open Design daemon HTTP base URL (default: env
-                       OD_DAEMON_URL, falling back to http://127.0.0.1:7456).
+  --daemon-url <url>   Open Design daemon HTTP base URL. Resolution
+                       order: this flag, OD_DAEMON_URL, the running
+                       daemon's sidecar IPC status socket
+                       (/tmp/open-design/ipc/<namespace>/daemon.sock),
+                       then http://127.0.0.1:7456. With IPC discovery
+                       the spawned MCP server tracks the live daemon
+                       URL across restarts even when the daemon binds
+                       an ephemeral port, so MCP client configs do not
+                       need to be re-pasted on each port change.
 
 Tools exposed:
   list_projects                  list every Open Design project

--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -536,11 +536,13 @@ Options:
                        order: this flag, OD_DAEMON_URL, the running
                        daemon's sidecar IPC status socket
                        (/tmp/open-design/ipc/<namespace>/daemon.sock),
-                       then http://127.0.0.1:7456. With IPC discovery
-                       the spawned MCP server tracks the live daemon
-                       URL across restarts even when the daemon binds
-                       an ephemeral port, so MCP client configs do not
-                       need to be re-pasted on each port change.
+                       then http://127.0.0.1:7456. Each new MCP spawn
+                       discovers the live daemon URL at startup, so
+                       MCP client configs stay valid across daemon
+                       restarts even when the port is ephemeral. A
+                       running MCP server caches the URL; restart the
+                       MCP client after a daemon restart to pick up a
+                       new port.
 
 Tools exposed:
   list_projects                  list every Open Design project

--- a/apps/daemon/src/mcp-daemon-url.ts
+++ b/apps/daemon/src/mcp-daemon-url.ts
@@ -1,0 +1,67 @@
+import {
+  APP_KEYS,
+  OPEN_DESIGN_SIDECAR_CONTRACT,
+  SIDECAR_DEFAULTS,
+  SIDECAR_ENV,
+  SIDECAR_MESSAGES,
+  type DaemonStatusSnapshot,
+} from "@open-design/sidecar-proto";
+import { requestJsonIpc, resolveAppIpcPath } from "@open-design/sidecar";
+
+export const MCP_DEFAULT_DAEMON_URL = "http://127.0.0.1:7456";
+
+export interface ResolveMcpDaemonUrlOptions {
+  /** Value passed via `--daemon-url`. Empty string is treated as unset. */
+  flagUrl?: string | null;
+  /** Defaults to `process.env`; injected for tests. */
+  env?: NodeJS.ProcessEnv;
+  /** IPC discovery timeout. Short by default so an absent daemon does not stall MCP startup. */
+  timeoutMs?: number;
+}
+
+/**
+ * Resolve the daemon HTTP base URL for `od mcp`.
+ *
+ * Spawn order: explicit `--daemon-url` flag, `OD_DAEMON_URL` env, then
+ * a STATUS roundtrip to the sidecar IPC socket the running daemon
+ * already publishes (`/tmp/open-design/ipc/<namespace>/daemon.sock`).
+ * Falls back to the legacy default for direct `od` launches that do
+ * not run as a sidecar. Discovery means the install snippet never has
+ * to bake a port: every spawn rediscovers the live URL, so an
+ * ephemeral daemon port (tools-dev, packaged) cannot invalidate a
+ * previously-installed MCP client config.
+ */
+export async function resolveMcpDaemonUrl(
+  options: ResolveMcpDaemonUrlOptions = {},
+): Promise<string> {
+  const env = options.env ?? process.env;
+  const flagUrl = options.flagUrl ?? null;
+  if (flagUrl != null && flagUrl.length > 0) return flagUrl;
+  const envUrl = env.OD_DAEMON_URL;
+  if (envUrl != null && envUrl.length > 0) return envUrl;
+  const discovered = await discoverDaemonUrlFromIpc(env, options.timeoutMs ?? 800);
+  if (discovered != null) return discovered;
+  return MCP_DEFAULT_DAEMON_URL;
+}
+
+async function discoverDaemonUrlFromIpc(
+  env: NodeJS.ProcessEnv,
+  timeoutMs: number,
+): Promise<string | null> {
+  try {
+    const socketPath = resolveAppIpcPath({
+      app: APP_KEYS.DAEMON,
+      contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+      env,
+      namespace: env[SIDECAR_ENV.NAMESPACE] ?? SIDECAR_DEFAULTS.namespace,
+    });
+    const status = await requestJsonIpc<DaemonStatusSnapshot>(
+      socketPath,
+      { type: SIDECAR_MESSAGES.STATUS },
+      { timeoutMs },
+    );
+    return status?.url ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1667,9 +1667,15 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
     const commandEnv = process.env.ELECTRON_RUN_AS_NODE === '1'
       ? { ELECTRON_RUN_AS_NODE: '1' }
       : null;
+    // The snippet intentionally omits --daemon-url. `od mcp` discovers
+    // the live daemon URL via the sidecar IPC status socket on every
+    // spawn, so the client config stays valid across restarts even
+    // when the daemon binds an ephemeral port (tools-dev, packaged).
+    // OD_DAEMON_URL or --daemon-url remain available as escape hatches
+    // for users who run the daemon outside the sidecar runtime.
     const payload = {
       command: process.execPath,
-      args: [cliPath, 'mcp', '--daemon-url', `http://127.0.0.1:${resolvedPort}`],
+      args: [cliPath, 'mcp'],
       ...(commandEnv == null ? {} : { env: commandEnv }),
       daemonUrl: `http://127.0.0.1:${resolvedPort}`,
       // Surface platform so the install panel can localize path hints

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -16,6 +16,7 @@ import {
 } from './prompts/system.js';
 import { expandHomePrefix, resolveProjectRelativePath } from './home-expansion.js';
 import { createCommandInvocation } from '@open-design/platform';
+import { SIDECAR_DEFAULTS, SIDECAR_ENV } from '@open-design/sidecar-proto';
 import {
   buildLiveArtifactsMcpServersForAgent,
   checkPromptArgvBudget,
@@ -1664,19 +1665,43 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
         `Node-compatible runtime at ${process.execPath} no longer exists. Reinstall Open Design or Node and restart the daemon.`,
       );
     }
-    const commandEnv = process.env.ELECTRON_RUN_AS_NODE === '1'
+    // The daemon was bootstrapped as a sidecar (tools-dev, packaged) iff
+    // bootstrapSidecarRuntime stamped OD_SIDECAR_IPC_PATH into the env.
+    // In sidecar mode the snippet omits --daemon-url and the spawned
+    // `od mcp` discovers the live URL via the IPC status socket on
+    // every spawn, so the client config survives ephemeral-port
+    // restarts. We also propagate OD_SIDECAR_NAMESPACE (and IPC_BASE
+    // when overridden) so a non-default namespace daemon stays
+    // reachable - the MCP client does not inherit the daemon's env,
+    // so without this the spawned `od mcp` would probe the default
+    // namespace socket and miss.
+    //
+    // For direct `od` / `od --port X` launches there is no IPC
+    // socket; bake --daemon-url so custom ports keep working.
+    const sidecarIpcPath = process.env[SIDECAR_ENV.IPC_PATH];
+    const isSidecarMode = sidecarIpcPath != null && sidecarIpcPath.length > 0;
+    const sidecarEnv = {};
+    if (isSidecarMode) {
+      const ns = process.env[SIDECAR_ENV.NAMESPACE];
+      if (ns != null && ns !== SIDECAR_DEFAULTS.namespace) {
+        sidecarEnv[SIDECAR_ENV.NAMESPACE] = ns;
+      }
+      const ipcBase = process.env[SIDECAR_ENV.IPC_BASE];
+      if (ipcBase != null && ipcBase.length > 0) {
+        sidecarEnv[SIDECAR_ENV.IPC_BASE] = ipcBase;
+      }
+    }
+    const electronEnv = process.env.ELECTRON_RUN_AS_NODE === '1'
       ? { ELECTRON_RUN_AS_NODE: '1' }
       : null;
-    // The snippet intentionally omits --daemon-url. `od mcp` discovers
-    // the live daemon URL via the sidecar IPC status socket on every
-    // spawn, so the client config stays valid across restarts even
-    // when the daemon binds an ephemeral port (tools-dev, packaged).
-    // OD_DAEMON_URL or --daemon-url remain available as escape hatches
-    // for users who run the daemon outside the sidecar runtime.
+    const env = { ...sidecarEnv, ...(electronEnv ?? {}) };
+    const args = isSidecarMode
+      ? [cliPath, 'mcp']
+      : [cliPath, 'mcp', '--daemon-url', `http://127.0.0.1:${resolvedPort}`];
     const payload = {
       command: process.execPath,
-      args: [cliPath, 'mcp'],
-      ...(commandEnv == null ? {} : { env: commandEnv }),
+      args,
+      ...(Object.keys(env).length > 0 ? { env } : {}),
       daemonUrl: `http://127.0.0.1:${resolvedPort}`,
       // Surface platform so the install panel can localize path hints
       // (~/.cursor vs %USERPROFILE%\.cursor) and keyboard shortcuts

--- a/apps/daemon/tests/mcp-daemon-url.test.ts
+++ b/apps/daemon/tests/mcp-daemon-url.test.ts
@@ -1,0 +1,102 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it, test } from "vitest";
+import { createJsonIpcServer, type JsonIpcServerHandle } from "@open-design/sidecar";
+import { SIDECAR_ENV, SIDECAR_MESSAGES } from "@open-design/sidecar-proto";
+import { resolveMcpDaemonUrl, MCP_DEFAULT_DAEMON_URL } from "../src/mcp-daemon-url.js";
+
+// On Windows the sidecar IPC contract switches to named pipes whose
+// names are not relocatable via OD_SIDECAR_IPC_BASE, so the discovery
+// case cannot use a per-test temp socket; skip just that case there.
+const ipcTest = process.platform === "win32" ? test.skip : test;
+
+// Verifies the resolution chain: --daemon-url > OD_DAEMON_URL > sidecar
+// IPC status discovery > legacy default. Each layer must short-circuit
+// the next so the spawned `od mcp` follows the live daemon across
+// restarts without re-pasting the install snippet.
+
+describe("resolveMcpDaemonUrl", () => {
+  let ipcBaseDir: string;
+
+  beforeAll(() => {
+    ipcBaseDir = fs.mkdtempSync(path.join(os.tmpdir(), "od-mcp-resolve-"));
+  });
+
+  afterAll(() => {
+    fs.rmSync(ipcBaseDir, { recursive: true, force: true });
+  });
+
+  it("prefers the explicit --daemon-url flag", async () => {
+    const url = await resolveMcpDaemonUrl({
+      flagUrl: "http://flag.example:1111",
+      env: {
+        OD_DAEMON_URL: "http://env.example:2222",
+        [SIDECAR_ENV.IPC_BASE]: ipcBaseDir,
+      },
+    });
+    expect(url).toBe("http://flag.example:1111");
+  });
+
+  it("falls back to OD_DAEMON_URL when no flag given", async () => {
+    const url = await resolveMcpDaemonUrl({
+      env: {
+        OD_DAEMON_URL: "http://env.example:2222",
+        [SIDECAR_ENV.IPC_BASE]: ipcBaseDir,
+      },
+    });
+    expect(url).toBe("http://env.example:2222");
+  });
+
+  it("returns the legacy default when no flag/env/socket is available", async () => {
+    const url = await resolveMcpDaemonUrl({
+      env: {
+        // Point IPC discovery at a directory with no socket; discovery
+        // should fail silently and we fall back to the default.
+        [SIDECAR_ENV.IPC_BASE]: ipcBaseDir,
+        [SIDECAR_ENV.NAMESPACE]: "missing-ns",
+      },
+      timeoutMs: 200,
+    });
+    expect(url).toBe(MCP_DEFAULT_DAEMON_URL);
+  });
+
+  ipcTest("discovers the live daemon URL via the sidecar IPC status socket", async () => {
+    const namespace = "discover-test";
+    const namespaceDir = path.join(ipcBaseDir, namespace);
+    fs.mkdirSync(namespaceDir, { recursive: true });
+    const socketPath = path.join(namespaceDir, "daemon.sock");
+    let ipc: JsonIpcServerHandle | null = null;
+    try {
+      ipc = await createJsonIpcServer({
+        socketPath,
+        handler: (message) => {
+          if (
+            message != null &&
+            typeof message === "object" &&
+            (message as { type?: unknown }).type === SIDECAR_MESSAGES.STATUS
+          ) {
+            return {
+              pid: 4242,
+              state: "running",
+              updatedAt: new Date().toISOString(),
+              url: "http://127.0.0.1:54321",
+            };
+          }
+          throw new Error("unexpected message");
+        },
+      });
+
+      const url = await resolveMcpDaemonUrl({
+        env: {
+          [SIDECAR_ENV.IPC_BASE]: ipcBaseDir,
+          [SIDECAR_ENV.NAMESPACE]: namespace,
+        },
+        timeoutMs: 1000,
+      });
+      expect(url).toBe("http://127.0.0.1:54321");
+    } finally {
+      await ipc?.close();
+    }
+  });
+});

--- a/apps/daemon/tests/mcp-install-info.test.ts
+++ b/apps/daemon/tests/mcp-install-info.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import os from 'node:os';
 import express from 'express';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { SIDECAR_DEFAULTS, SIDECAR_ENV } from '@open-design/sidecar-proto';
 import { isLocalSameOrigin } from '../src/server.js';
 
 // The install-info endpoint is a self-contained handler that resolves
@@ -16,9 +17,13 @@ import { isLocalSameOrigin } from '../src/server.js';
 interface InstallInfoOpts {
   cliPath: string;
   port: number;
+  /** Stand-in for `process.env`. Lets each test simulate sidecar vs
+   *  non-sidecar daemon launches and custom namespaces without
+   *  mutating the real process env. */
+  env?: NodeJS.ProcessEnv;
 }
 
-function makeInstallInfoApp({ cliPath, port }: InstallInfoOpts) {
+function makeInstallInfoApp({ cliPath, port, env = {} }: InstallInfoOpts) {
   const app = express();
 
   const TTL_MS = 5000;
@@ -39,9 +44,35 @@ function makeInstallInfoApp({ cliPath, port }: InstallInfoOpts) {
     const hints: string[] = [];
     if (!cliExists) hints.push('cli missing');
     if (!nodeExists) hints.push('node missing');
+
+    // Mirror the production handler in apps/daemon/src/server.ts:
+    // sidecar-bootstrapped daemons rely on IPC discovery in `od mcp`
+    // and propagate namespace / IPC base through the snippet env;
+    // non-sidecar (direct `od --port X`) launches bake the URL.
+    const sidecarIpcPath = env[SIDECAR_ENV.IPC_PATH];
+    const isSidecarMode = sidecarIpcPath != null && sidecarIpcPath.length > 0;
+    const sidecarEnv: Record<string, string> = {};
+    if (isSidecarMode) {
+      const ns = env[SIDECAR_ENV.NAMESPACE];
+      if (ns != null && ns !== SIDECAR_DEFAULTS.namespace) {
+        sidecarEnv[SIDECAR_ENV.NAMESPACE] = ns;
+      }
+      const ipcBase = env[SIDECAR_ENV.IPC_BASE];
+      if (ipcBase != null && ipcBase.length > 0) {
+        sidecarEnv[SIDECAR_ENV.IPC_BASE] = ipcBase;
+      }
+    }
+    const electronEnv = env.ELECTRON_RUN_AS_NODE === '1'
+      ? { ELECTRON_RUN_AS_NODE: '1' }
+      : null;
+    const snippetEnv = { ...sidecarEnv, ...(electronEnv ?? {}) };
+    const args = isSidecarMode
+      ? [cliPath, 'mcp']
+      : [cliPath, 'mcp', '--daemon-url', `http://127.0.0.1:${port}`];
     const payload = {
       command: process.execPath,
-      args: [cliPath, 'mcp'],
+      args,
+      ...(Object.keys(snippetEnv).length > 0 ? { env: snippetEnv } : {}),
       daemonUrl: `http://127.0.0.1:${port}`,
       platform: process.platform,
       cliExists,
@@ -57,28 +88,52 @@ function makeInstallInfoApp({ cliPath, port }: InstallInfoOpts) {
   return app;
 }
 
+interface Harness {
+  app: express.Express;
+  server: http.Server;
+  port: number;
+  baseUrl: string;
+}
+
+async function startHarness(cliPath: string, env: NodeJS.ProcessEnv): Promise<Harness> {
+  // Pick a free port first so the handler can compare against it for
+  // isLocalSameOrigin.
+  const port: number = await new Promise((resolveListen) => {
+    const tmp = http.createServer();
+    tmp.listen(0, '127.0.0.1', () => {
+      const p = (tmp.address() as { port: number }).port;
+      tmp.close(() => resolveListen(p));
+    });
+  });
+  const app = makeInstallInfoApp({ cliPath, port, env });
+  const server: http.Server = await new Promise((resolveStart) => {
+    const handle = app.listen(port, '127.0.0.1', () => resolveStart(handle));
+  });
+  return { app, server, port, baseUrl: `http://127.0.0.1:${port}` };
+}
+
 describe('GET /api/mcp/install-info', () => {
-  let server: http.Server;
-  let baseUrl: string;
-  let port: number;
   let tmpDir: string;
   let cliPath: string;
-  let app: express.Express;
+  // Tests share the tmpDir but each top-level case spins its own
+  // app instance so different env configurations stay isolated.
+  let nonSidecar: { server: http.Server; port: number; app: express.Express };
 
   beforeAll(
     () =>
-      new Promise<void>((resolve) => {
+      new Promise<void>((resolveBoot) => {
         tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'od-mcp-info-'));
         cliPath = path.join(tmpDir, 'cli.js');
         fs.writeFileSync(cliPath, '// stub\n', 'utf8');
-        // listen on a random free port; capture so isLocalSameOrigin
-        // can compare the Host header
         const tmp = http.createServer();
         tmp.listen(0, '127.0.0.1', () => {
-          port = (tmp.address() as { port: number }).port;
+          const port = (tmp.address() as { port: number }).port;
           tmp.close(() => {
-            app = makeInstallInfoApp({ cliPath, port });
-            server = app.listen(port, '127.0.0.1', () => resolve());
+            const app = makeInstallInfoApp({ cliPath, port, env: {} });
+            const server = app.listen(port, '127.0.0.1', () => {
+              nonSidecar = { server, port, app };
+              resolveBoot();
+            });
           });
         });
       }),
@@ -87,22 +142,24 @@ describe('GET /api/mcp/install-info', () => {
   afterAll(
     () =>
       new Promise<void>((resolve) => {
-        server.close(() => {
+        nonSidecar.server.close(() => {
           fs.rmSync(tmpDir, { recursive: true, force: true });
           resolve();
         });
       }),
   );
 
-  it('returns command, args, platform, daemonUrl', async () => {
-    const res = await fetch(`${baseUrl ?? `http://127.0.0.1:${port}`}/api/mcp/install-info`);
+  it('non-sidecar launch bakes --daemon-url so custom ports keep working', async () => {
+    const { port } = nonSidecar;
+    const res = await fetch(`http://127.0.0.1:${port}/api/mcp/install-info`);
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.command).toBe(process.execPath);
-    // No --daemon-url: the spawned `od mcp` discovers the live daemon URL via
-    // the sidecar IPC status socket, so the snippet stays valid across daemon
-    // restarts even when the port is ephemeral.
-    expect(body.args).toEqual([cliPath, 'mcp']);
+    // Direct `od` launches have no IPC socket; the snippet bakes the
+    // URL so the spawned `od mcp` reaches the right port without any
+    // discovery.
+    expect(body.args).toEqual([cliPath, 'mcp', '--daemon-url', `http://127.0.0.1:${port}`]);
+    expect(body.env).toBeUndefined();
     expect(body.daemonUrl).toBe(`http://127.0.0.1:${port}`);
     expect(body.platform).toBe(process.platform);
     expect(body.cliExists).toBe(true);
@@ -111,6 +168,7 @@ describe('GET /api/mcp/install-info', () => {
   });
 
   it('rejects cross-origin requests with 403', async () => {
+    const { port } = nonSidecar;
     const res = await fetch(`http://127.0.0.1:${port}/api/mcp/install-info`, {
       headers: { Origin: 'https://evil.com' },
     });
@@ -118,11 +176,13 @@ describe('GET /api/mcp/install-info', () => {
   });
 
   it('accepts requests with no Origin header (loopback fetch)', async () => {
+    const { port } = nonSidecar;
     const res = await fetch(`http://127.0.0.1:${port}/api/mcp/install-info`);
     expect(res.status).toBe(200);
   });
 
   it('accepts requests with matching localhost Origin', async () => {
+    const { port } = nonSidecar;
     const res = await fetch(`http://127.0.0.1:${port}/api/mcp/install-info`, {
       headers: { Origin: `http://127.0.0.1:${port}` },
     });
@@ -130,14 +190,66 @@ describe('GET /api/mcp/install-info', () => {
   });
 
   it('caches the payload across rapid calls', async () => {
+    const { port, app } = nonSidecar;
     const before = (app as any)._resolveCalls();
     await fetch(`http://127.0.0.1:${port}/api/mcp/install-info`);
     await fetch(`http://127.0.0.1:${port}/api/mcp/install-info`);
     await fetch(`http://127.0.0.1:${port}/api/mcp/install-info`);
     const after = (app as any)._resolveCalls();
-    // The first call may go through or may hit the cache from earlier
-    // tests; what matters is that 3 rapid calls add at most 1 fresh
-    // resolve, not 3.
+    // 3 rapid calls add at most 1 fresh resolve, not 3.
     expect(after - before).toBeLessThanOrEqual(1);
+  });
+
+  it('sidecar default namespace omits --daemon-url and emits no env block', async () => {
+    const { port, server } = await startHarness(cliPath, {
+      [SIDECAR_ENV.IPC_PATH]: '/tmp/open-design/ipc/default/daemon.sock',
+      [SIDECAR_ENV.NAMESPACE]: SIDECAR_DEFAULTS.namespace,
+    });
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/api/mcp/install-info`);
+      const body = await res.json();
+      expect(body.args).toEqual([cliPath, 'mcp']);
+      // Default namespace + default IPC base means the spawned `od mcp`
+      // can derive the right socket without any env hints.
+      expect(body.env).toBeUndefined();
+    } finally {
+      await new Promise<void>((done) => server?.close(() => done()));
+    }
+  });
+
+  it('sidecar non-default namespace propagates OD_SIDECAR_NAMESPACE', async () => {
+    const { port, server } = await startHarness(cliPath, {
+      [SIDECAR_ENV.IPC_PATH]: '/tmp/open-design/ipc/foo/daemon.sock',
+      [SIDECAR_ENV.NAMESPACE]: 'foo',
+    });
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/api/mcp/install-info`);
+      const body = await res.json();
+      expect(body.args).toEqual([cliPath, 'mcp']);
+      // Without this propagation the MCP client would launch `od mcp`
+      // with no namespace env, fall back to "default", and miss the
+      // foo daemon entirely.
+      expect(body.env).toEqual({ [SIDECAR_ENV.NAMESPACE]: 'foo' });
+    } finally {
+      await new Promise<void>((done) => server?.close(() => done()));
+    }
+  });
+
+  it('sidecar with custom IPC base propagates OD_SIDECAR_IPC_BASE', async () => {
+    const { port, server } = await startHarness(cliPath, {
+      [SIDECAR_ENV.IPC_PATH]: '/var/run/open-design/foo/daemon.sock',
+      [SIDECAR_ENV.NAMESPACE]: 'foo',
+      [SIDECAR_ENV.IPC_BASE]: '/var/run/open-design',
+    });
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/api/mcp/install-info`);
+      const body = await res.json();
+      expect(body.env).toEqual({
+        [SIDECAR_ENV.NAMESPACE]: 'foo',
+        [SIDECAR_ENV.IPC_BASE]: '/var/run/open-design',
+      });
+    } finally {
+      await new Promise<void>((done) => server?.close(() => done()));
+    }
   });
 });

--- a/apps/daemon/tests/mcp-install-info.test.ts
+++ b/apps/daemon/tests/mcp-install-info.test.ts
@@ -41,7 +41,7 @@ function makeInstallInfoApp({ cliPath, port }: InstallInfoOpts) {
     if (!nodeExists) hints.push('node missing');
     const payload = {
       command: process.execPath,
-      args: [cliPath, 'mcp', '--daemon-url', `http://127.0.0.1:${port}`],
+      args: [cliPath, 'mcp'],
       daemonUrl: `http://127.0.0.1:${port}`,
       platform: process.platform,
       cliExists,
@@ -99,7 +99,10 @@ describe('GET /api/mcp/install-info', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.command).toBe(process.execPath);
-    expect(body.args).toEqual([cliPath, 'mcp', '--daemon-url', `http://127.0.0.1:${port}`]);
+    // No --daemon-url: the spawned `od mcp` discovers the live daemon URL via
+    // the sidecar IPC status socket, so the snippet stays valid across daemon
+    // restarts even when the port is ephemeral.
+    expect(body.args).toEqual([cliPath, 'mcp']);
     expect(body.daemonUrl).toBe(`http://127.0.0.1:${port}`);
     expect(body.platform).toBe(process.platform);
     expect(body.cliExists).toBe(true);


### PR DESCRIPTION
**Why:** Install snippet bakes `--daemon-url http://127.0.0.1:<port>`,
but tools-dev and packaged both pass DAEMON_PORT=0 so the daemon
picks a fresh port every restart. Pasted client configs break until
edited.

**How:** `od mcp` now discovers the live URL via the daemon's sidecar
IPC status socket on each spawn. Resolution order: `--daemon-url`,
`OD_DAEMON_URL`, IPC discovery, default `http://127.0.0.1:7456`.
Snippet drops `--daemon-url`.

**To test:**
- Open Settings → MCP server: snippet args have no `--daemon-url`.
- Update your client's MCP config (Claude Code, Cursor, etc.) with
  the new snippet, restart the client, run a tool call.
- Restart Open Design (port changes), open a new chat in your
  client, tool calls still work.

**Notes:**
- An already-spawned `od mcp` caches the discovered URL for its
  lifetime; if the daemon restarts mid-session, restart the MCP
  client too.
- Direct `od --port <X>` launches do not open an IPC socket; set
  `OD_DAEMON_URL` or pass `--daemon-url` for non-default ports.