### PR TITLE
fix(web): reserve clearance for MCP Copy button so it stops overlapping the snippet

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -2399,7 +2399,12 @@ function IntegrationsSection() {
             style={{
               background: 'var(--surface-2, #11141a)',
               color: 'var(--fg-1, #e6e6e6)',
-              padding: '12px 14px',
+              // Reserve top clearance for the absolutely-positioned
+              // Copy button so the first line of the snippet does not
+              // sit underneath it, and reserve right clearance so a
+              // wrapped bash one-liner stops short of the button rather
+              // than scrolling behind it. Issue #632.
+              padding: '40px 80px 12px 14px',
               borderRadius: 8,
               overflowX: 'auto',
               fontFamily:

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -2403,8 +2403,11 @@ function IntegrationsSection() {
               // Copy button so the first line of the snippet does not
               // sit underneath it, and reserve right clearance so a
               // wrapped bash one-liner stops short of the button rather
-              // than scrolling behind it. Issue #632.
-              padding: '40px 80px 12px 14px',
+              // than scrolling behind it. The right padding is sized
+              // for the wider "Copied" post-click state (icon + text +
+              // button padding + the 8px right offset) with a few px
+              // of buffer for elevated font sizes / zoom. Issue #632.
+              padding: '40px 104px 12px 14px',
               borderRadius: 8,
               overflowX: 'auto',
               fontFamily:


### PR DESCRIPTION
Closes #632.

The Copy button in **Settings > MCP server** is absolutely positioned at `top: 8 right: 8` over the snippet `<pre>` ([SettingsDialog.tsx](https://github.com/nexu-io/open-design/blob/main/apps/web/src/components/SettingsDialog.tsx)), but the `<pre>` only had `padding: '12px 14px'`. Result: the first line of the command sat directly under the button, and a wrapped bash one-liner kept growing right and slid behind the button. The reporter's screenshot shows exactly that overlap.

Rather than restructure the layout, this reserves the clearance inside the `<pre>`'s own padding:

```ts
padding: '40px 80px 12px 14px'
```

- 40px top → first line renders below the button.
- 80px right → wrapped bash content stops short of the button column.
- 12px bottom / 14px left unchanged.

Button stays anchored where it is, no JSX/structure changes, no new CSS rules.

Validated locally: `pnpm --filter @open-design/web typecheck`, `pnpm guard`, and the existing SettingsDialog vitest suite all clean.