### PR TITLE
feat(skills): teach hyperframes skill the HTML-in-Canvas API

### DIFF
--- a/skills/hyperframes/SKILL.md
+++ b/skills/hyperframes/SKILL.md
@@ -14,6 +14,7 @@ triggers:
   - "html shader"
   - "vfx-iphone-device"
   - "vfx-liquid-glass"
+  - "vfx-portal"
 od:
   mode: video
   surface: video

--- a/skills/hyperframes/SKILL.md
+++ b/skills/hyperframes/SKILL.md
@@ -9,6 +9,11 @@ triggers:
   - "captions"
   - "tts video"
   - "kinetic typography"
+  - "html in canvas"
+  - "drawElementImage"
+  - "html shader"
+  - "vfx-iphone-device"
+  - "vfx-liquid-glass"
 od:
   mode: video
   surface: video
@@ -489,5 +494,6 @@ Skip on small edits (fixing a color, adjusting one duration). Run on new composi
 - **[references/transitions.md](references/transitions.md)** — Scene transitions: crossfades, wipes, reveals, shader transitions. Energy/mood selection, CSS vs WebGL guidance. **Always read for multi-scene compositions** — scenes without transitions feel like jump cuts.
   - [transitions/catalog.md](references/transitions/catalog.md) — Hard rules, scene template, and routing to per-type implementation code.
   - Shader transitions are in `@hyperframes/shader-transitions` (`packages/shader-transitions/`) — read package source, not skill files.
+- **[references/html-in-canvas.md](references/html-in-canvas.md)** — HTML-in-Canvas (`drawElementImage`) for rendering live DOM as WebGL textures: 3D device mockups, shader-warped UIs, liquid glass, portals. Read when the user asks for `vfx-iphone-device`, `vfx-liquid-glass`, `vfx-portal`, or any "HTML mapped onto 3D / shader" effect. The render path auto-enables the Chrome flag, but the texture must be re-captured every frame for animated content — that's the most common cause of "the screen renders dead" output.
 
 GSAP patterns and effects are in the `/gsap` skill.

--- a/skills/hyperframes/references/html-in-canvas.md
+++ b/skills/hyperframes/references/html-in-canvas.md
@@ -18,8 +18,10 @@ When this skill runs inside Open Design, the daemon shells out to `npx hyperfram
 
 1. Place HTML content inside a `<canvas layoutsubtree>` element
 2. The browser renders the HTML children as normal DOM
-3. Call `ctx.drawElementImage(element, x, y, w, h)` to capture the rendered pixels into the canvas
+3. Wait for the canvas to paint, then call `ctx.drawElementImage(element, x, y, w, h)` to capture the rendered pixels
 4. Use the canvas as a Three.js texture, apply shaders, map to 3D geometry
+
+> **Always capture from a paint event.** The element snapshot the API draws from is only refreshed when the canvas paints. Calling `drawElementImage` during initial script evaluation can throw because the first snapshot does not exist yet; calling it outside `paint` after that point silently reads the *previous* snapshot. Drive both first-time capture and per-frame updates from `canvas.onpaint`, and use `canvas.requestPaint()` to ask for a fresh snapshot.
 
 ```html
 <!-- 1. HTML content lives inside the canvas -->
@@ -35,14 +37,24 @@ When this skill runs inside Open Design, the daemon shells out to `npx hyperfram
 ```
 
 ```javascript
-// 3. Capture HTML to canvas
+// 3. Capture HTML to canvas — wait for paint so the element snapshot exists
 var capCanvas = document.getElementById("capture");
 var ctx = capCanvas.getContext("2d");
-ctx.drawElementImage(capCanvas.querySelector(".my-dashboard"), 0, 0, 1920, 1080);
+var texture, material;
 
-// 4. Use as Three.js texture
-var texture = new THREE.CanvasTexture(capCanvas);
-var material = new THREE.MeshBasicMaterial({ map: texture });
+capCanvas.onpaint = function () {
+  ctx.drawElementImage(capCanvas.querySelector(".my-dashboard"), 0, 0, 1920, 1080);
+  if (!texture) {
+    // 4. Use as Three.js texture
+    texture = new THREE.CanvasTexture(capCanvas);
+    material = new THREE.MeshBasicMaterial({ map: texture });
+  } else {
+    texture.needsUpdate = true;
+  }
+};
+
+// Kick off the first paint; subsequent re-captures call requestPaint() again
+capCanvas.requestPaint();
 ```
 
 ## What makes this different
@@ -76,18 +88,23 @@ if (isSupported()) {
 
 ## Re-capturing every frame
 
-For animated content (scrolling, transitions, counters), call `drawElementImage` inside your render loop to update the texture every frame:
+For animated content (scrolling, transitions, counters), drive the capture from the canvas's `paint` event and ask for a fresh snapshot each frame with `requestPaint()`. Calling `drawElementImage` directly from the render loop reads the *previous* paint's snapshot, which on seek-driven HyperFrames renders shows up as a stale or frozen first texture.
 
 ```javascript
+// Capture runs whenever the canvas paints, so the snapshot is always fresh
+capCanvas.onpaint = function () {
+  ctx.clearRect(0, 0, W, H);
+  ctx.drawElementImage(htmlElement, 0, 0, W, H);
+  texture.needsUpdate = true;
+};
+
 function render() {
   // Update HTML state
   scrollContainer.style.transform = "translateY(-" + scrollOffset + "px)";
   counterEl.textContent = Math.round(currentValue);
 
-  // Re-capture
-  ctx.clearRect(0, 0, W, H);
-  ctx.drawElementImage(htmlElement, 0, 0, W, H);
-  texture.needsUpdate = true;
+  // Schedule a fresh snapshot; the onpaint handler above runs the capture
+  capCanvas.requestPaint();
 
   // Render 3D scene with updated texture
   renderer.render(scene, camera);

--- a/skills/hyperframes/references/html-in-canvas.md
+++ b/skills/hyperframes/references/html-in-canvas.md
@@ -1,0 +1,129 @@
+# HTML-in-Canvas
+
+Render live HTML as WebGL textures — GPU shaders, 3D geometry, and cinematic effects on any DOM content.
+
+The HTML-in-Canvas API (`drawElementImage`) lets you capture live, rendered DOM elements directly into a canvas at GPU speed. This means you can take any HTML — dashboards, forms, landing pages, app UIs — and render them as textures in WebGL scenes with shaders, 3D transformations, and post-processing effects.
+
+> **Chrome flag required for live preview only.** The `drawElementImage` API is experimental.
+>
+> 1. Open `chrome://flags/#canvas-draw-element` in Chrome or Brave
+> 2. Set **CanvasDrawElement** to **Enabled**
+> 3. Restart the browser
+>
+> HyperFrames enables this flag automatically during rendering (`--enable-features=CanvasDrawElement`), so rendered videos work without manual setup. The flag is only needed for live preview in the Studio.
+
+When this skill runs inside Open Design, the daemon shells out to `npx hyperframes render`, which inherits the auto-enable. You do **not** need to add browser flags or pass extra CLI args from the agent.
+
+## How it works
+
+1. Place HTML content inside a `<canvas layoutsubtree>` element
+2. The browser renders the HTML children as normal DOM
+3. Call `ctx.drawElementImage(element, x, y, w, h)` to capture the rendered pixels into the canvas
+4. Use the canvas as a Three.js texture, apply shaders, map to 3D geometry
+
+```html
+<!-- 1. HTML content lives inside the canvas -->
+<canvas id="capture" layoutsubtree width="1920" height="1080">
+  <div class="my-dashboard">
+    <h1>Revenue: $4.2M</h1>
+    <div class="chart">...</div>
+  </div>
+</canvas>
+
+<!-- 2. WebGL canvas for 3D rendering -->
+<canvas id="theater" width="1920" height="1080"></canvas>
+```
+
+```javascript
+// 3. Capture HTML to canvas
+var capCanvas = document.getElementById("capture");
+var ctx = capCanvas.getContext("2d");
+ctx.drawElementImage(capCanvas.querySelector(".my-dashboard"), 0, 0, 1920, 1080);
+
+// 4. Use as Three.js texture
+var texture = new THREE.CanvasTexture(capCanvas);
+var material = new THREE.MeshBasicMaterial({ map: texture });
+```
+
+## What makes this different
+
+Traditional approaches like `html2canvas` re-parse and re-render the DOM in JavaScript — they're slow, lossy, and miss CSS features like `backdrop-filter`, complex shadows, and web fonts. The `drawElementImage` API uses the browser's own compositor, so:
+
+- **Pixel-perfect** — every CSS feature is supported because the browser renders it natively
+- **GPU-accelerated** — captures at 60fps, fast enough for real-time animation
+- **Live content** — the HTML can animate, scroll, and change between captures
+- **Multiple captures simultaneously** — no nesting restrictions; multiple `<canvas layoutsubtree>` elements can capture different content in the same composition
+
+## Feature detection
+
+Always feature-detect before using the API. Compositions should fall back gracefully for browsers without the flag enabled. (Render path is always fine — the fallback only matters when a user opens the composition in a browser without `CanvasDrawElement`.)
+
+```javascript
+function isSupported() {
+  var tc = document.createElement("canvas");
+  if (!("layoutSubtree" in tc)) return false;
+  tc.setAttribute("layoutsubtree", "");
+  var ctx = tc.getContext("2d");
+  return ctx && typeof ctx.drawElementImage === "function";
+}
+
+if (isSupported()) {
+  ctx.drawElementImage(element, 0, 0, w, h);
+} else {
+  // Fallback: draw text directly on canvas, use static image, etc.
+}
+```
+
+## Re-capturing every frame
+
+For animated content (scrolling, transitions, counters), call `drawElementImage` inside your render loop to update the texture every frame:
+
+```javascript
+function render() {
+  // Update HTML state
+  scrollContainer.style.transform = "translateY(-" + scrollOffset + "px)";
+  counterEl.textContent = Math.round(currentValue);
+
+  // Re-capture
+  ctx.clearRect(0, 0, W, H);
+  ctx.drawElementImage(htmlElement, 0, 0, W, H);
+  texture.needsUpdate = true;
+
+  // Render 3D scene with updated texture
+  renderer.render(scene, camera);
+}
+```
+
+When a HyperFrames timeline drives the underlying HTML (counter ticks, scroll animation), the render loop must run on every frame the texture is visible — otherwise the WebGL surface freezes on the first capture and the user sees a static screen embedded in your 3D scene. This is the most common reason an HTML-in-Canvas composition "looks dead" after rendering.
+
+## Catalog blocks
+
+Install all HTML-in-Canvas blocks at once:
+
+```bash
+npx hyperframes add html-in-canvas
+```
+
+Or install individually:
+
+| Block | Description | Install |
+|-------|-------------|---------|
+| Liquid Glass | Voronoi glass fracture with parallax reveal | `npx hyperframes add vfx-liquid-glass` |
+| iPhone & MacBook | Real 3D GLTF devices with live HTML screens | `npx hyperframes add vfx-iphone-device` |
+| Text Cursor | Dramatic text reveal with chromatic shadows | `npx hyperframes add vfx-text-cursor` |
+| Portal | Dimension breach with volumetric light | `npx hyperframes add vfx-portal` |
+| Shatter | HTML shatters into glass fragments | `npx hyperframes add vfx-shatter` |
+| Magnetic | Magnetic field particle visualization | `npx hyperframes add vfx-magnetic` |
+| Liquid Background | Organic liquid simulation | `npx hyperframes add vfx-liquid-background` |
+
+Block reference pages live at `https://hyperframes.heygen.com/catalog/blocks/<name>`.
+
+## Rendering
+
+HyperFrames enables the Chrome flag automatically during rendering. No special configuration needed:
+
+```bash
+npx hyperframes render --output my-video.mp4
+```
+
+For Docker renders, the flag is also enabled automatically inside the container. Inside Open Design, the daemon's `npx hyperframes render` call (`apps/daemon/src/media.ts`) inherits the same default — you don't need to thread anything through.


### PR DESCRIPTION
## Summary

Vendored `skills/hyperframes/` predates upstream `v0.5.1`, which shipped the `drawElementImage` HTML-in-Canvas guide and the `vfx-iphone-device` / `vfx-liquid-glass` / `vfx-portal` family of catalog blocks. The skill that gets injected into every OD agent's system prompt has no mention of any of it, so when a user asks for "live HTML on a 3D phone screen" or "shader-warped dashboard", agents either skip the canvas integration entirely or invent the wrong API. The render itself succeeds — but the device screen comes out blank or frozen, which is the "no effect" symptom we kept seeing.

This PR closes the doc gap. No code changes, no version pin moves.

- Add `skills/hyperframes/references/html-in-canvas.md`, adapted from the upstream `docs/guides/html-in-canvas.mdx` guide. Includes feature detection, per-frame re-capture (the most common cause of dead-looking output), the catalog block table, and a short OD-specific note that our render path already auto-enables `--enable-features=CanvasDrawElement`.
- Surface the new reference from `SKILL.md` and add triggers (`html in canvas`, `drawElementImage`, `html shader`, `vfx-iphone-device`, `vfx-liquid-glass`).

## Why not bump a hyperframes version?

We don't pin one. `apps/daemon/src/media.ts` shells out to `npx hyperframes render`, which always pulls the latest published version (currently `v0.5.3`). The Chrome flag is already auto-enabled by the upstream CLI during render. The only reason the capability looked "missing" was that the agent didn't know how to author code that uses it.

## Test plan

- [x] `pnpm guard`
- [x] `pnpm --filter @open-design/e2e test -- tests/localized-content.test.ts` (skill discovery still aligns with localized copy)
- [ ] Spot-check on a real composition: ask an agent for a `vfx-iphone-device` clip and confirm the screen renders live HTML rather than going blank