### PR TITLE
fix(daemon): pin OD_DATA_DIR in /api/mcp/install-info env so the macOS-packaged MCP server does not EPERM on .od/projects

### DIFF
--- a/apps/daemon/src/mcp-install-info.ts
+++ b/apps/daemon/src/mcp-install-info.ts
@@ -1,0 +1,96 @@
+// Pure builder for the /api/mcp/install-info payload. Extracted from
+// the Express handler so the test fixture and the production handler
+// share the exact env/argv/buildHint shape; a divergence here is the
+// difference between an MCP snippet that works and one that EPERMs out
+// when pasted into Antigravity / Cursor / VS Code (issue #848), or
+// silently misses a non-default sidecar namespace.
+//
+// Side effects (the fs.existsSync probes, process.execPath, the
+// ELECTRON_RUN_AS_NODE env read, OD_DATA_DIR resolution, sidecar IPC
+// detection) all stay in the caller. This module is intentionally pure
+// and free of @open-design/sidecar-proto so it can be unit-tested
+// without booting the daemon.
+
+export interface BuildMcpInstallPayloadInputs {
+  cliPath: string;
+  cliExists: boolean;
+  execPath: string;
+  nodeExists: boolean;
+  port: number;
+  platform: NodeJS.Platform;
+  dataDir: string;
+  electronAsNode: boolean;
+  /** True when the daemon was bootstrapped as a sidecar and the
+   *  spawned `od mcp` should discover the live URL via the IPC
+   *  status socket instead of a baked --daemon-url. */
+  isSidecarMode: boolean;
+  /** Already-filtered sidecar env entries (namespace, IPC base) the
+   *  caller wants propagated into the snippet. The caller decides
+   *  what's worth propagating; this builder just merges. */
+  sidecarEnv: Record<string, string>;
+}
+
+export interface McpInstallPayload {
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+  daemonUrl: string;
+  platform: NodeJS.Platform;
+  cliExists: boolean;
+  nodeExists: boolean;
+  buildHint: string | null;
+}
+
+export function buildMcpInstallPayload(
+  inputs: BuildMcpInstallPayloadInputs,
+): McpInstallPayload {
+  const hints: string[] = [];
+  if (!inputs.cliExists) {
+    hints.push(
+      `Open Design CLI entry is missing at ${inputs.cliPath}. Rebuild the daemon or packaged app and refresh.`,
+    );
+  }
+  if (!inputs.nodeExists) {
+    hints.push(
+      `Node-compatible runtime at ${inputs.execPath} no longer exists. Reinstall Open Design or Node and restart the daemon.`,
+    );
+  }
+  // Pin OD_DATA_DIR to the daemon's resolved data root so the spawned
+  // MCP process writes to the same directory the daemon already uses
+  // even when the IDE that launched it (Antigravity, VS Code, etc.)
+  // does not inherit the packaged app's environment. Without this,
+  // `od mcp` falls back to `<cwd>/.od/...` which is the read-only
+  // macOS app bundle for packaged installs and trips EPERM. Issue #848.
+  const env: Record<string, string> = {
+    OD_DATA_DIR: inputs.dataDir,
+    ...inputs.sidecarEnv,
+  };
+  if (inputs.electronAsNode) {
+    env.ELECTRON_RUN_AS_NODE = '1';
+  }
+  // Sidecar mode: omit --daemon-url so the spawned `od mcp` discovers
+  // the live URL via the IPC status socket on every spawn, surviving
+  // ephemeral-port restarts. Direct `od --port X` launches have no
+  // socket and need the URL baked.
+  const args = inputs.isSidecarMode
+    ? [inputs.cliPath, 'mcp']
+    : [
+        inputs.cliPath,
+        'mcp',
+        '--daemon-url',
+        `http://127.0.0.1:${inputs.port}`,
+      ];
+  return {
+    command: inputs.execPath,
+    args,
+    env,
+    daemonUrl: `http://127.0.0.1:${inputs.port}`,
+    // Surface platform so the install panel can localize path hints
+    // (~/.cursor vs %USERPROFILE%\.cursor) and keyboard shortcuts
+    // (Cmd vs Ctrl).
+    platform: inputs.platform,
+    cliExists: inputs.cliExists,
+    nodeExists: inputs.nodeExists,
+    buildHint: hints.length ? hints.join(' ') : null,
+  };
+}

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1766,6 +1766,13 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
         `Node-compatible runtime at ${process.execPath} no longer exists. Reinstall Open Design or Node and restart the daemon.`,
       );
     }
+    // Pin OD_DATA_DIR to the daemon's resolved data root so the spawned
+    // MCP process writes to the same directory as the running daemon
+    // even when the IDE that launched it (Antigravity, VS Code, etc.)
+    // does not inherit the packaged app's environment. Without this,
+    // `od mcp` falls back to `<cwd>/.od/...` which is the read-only
+    // macOS app bundle for packaged installs and trips EPERM. Issue #848.
+    //
     // The daemon was bootstrapped as a sidecar (tools-dev, packaged) iff
     // bootstrapSidecarRuntime stamped OD_SIDECAR_IPC_PATH into the env.
     // In sidecar mode the snippet omits --daemon-url and the spawned
@@ -1781,7 +1788,7 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
     // socket; bake --daemon-url so custom ports keep working.
     const sidecarIpcPath = process.env[SIDECAR_ENV.IPC_PATH];
     const isSidecarMode = sidecarIpcPath != null && sidecarIpcPath.length > 0;
-    const sidecarEnv = {};
+    const sidecarEnv: Record<string, string> = {};
     if (isSidecarMode) {
       const ns = process.env[SIDECAR_ENV.NAMESPACE];
       if (ns != null && ns !== SIDECAR_DEFAULTS.namespace) {
@@ -1795,14 +1802,18 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
     const electronEnv = process.env.ELECTRON_RUN_AS_NODE === '1'
       ? { ELECTRON_RUN_AS_NODE: '1' }
       : null;
-    const env = { ...sidecarEnv, ...(electronEnv ?? {}) };
+    const env: Record<string, string> = {
+      OD_DATA_DIR: RUNTIME_DATA_DIR,
+      ...sidecarEnv,
+      ...(electronEnv ?? {}),
+    };
     const args = isSidecarMode
       ? [cliPath, 'mcp']
       : [cliPath, 'mcp', '--daemon-url', `http://127.0.0.1:${resolvedPort}`];
     const payload = {
       command: process.execPath,
       args,
-      ...(Object.keys(env).length > 0 ? { env } : {}),
+      env,
       daemonUrl: `http://127.0.0.1:${resolvedPort}`,
       // Surface platform so the install panel can localize path hints
       // (~/.cursor vs %USERPROFILE%\.cursor) and keyboard shortcuts

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -74,6 +74,7 @@ import {
 } from './media-models.js';
 import { readMaskedConfig, writeConfig } from './media-config.js';
 import { agentCliEnvForAgent, readAppConfig, writeAppConfig } from './app-config.js';
+import { buildMcpInstallPayload } from './mcp-install-info.js';
 import {
   buildProjectArchive,
   buildBatchArchive,
@@ -1746,33 +1747,13 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
     if (installInfoCache && now - installInfoCache.t < INSTALL_INFO_TTL_MS) {
       return res.json(installInfoCache.payload);
     }
+    // process.execPath is the absolute path to the Node-compatible
+    // runtime that is running the daemon RIGHT NOW. In packaged builds
+    // this may be Electron running with ELECTRON_RUN_AS_NODE=1 rather
+    // than a separate bundled Node binary; the helper surfaces that env
+    // requirement with the command so IDE-spawned MCP clients can
+    // reproduce the same mode from a minimal OS launcher environment.
     const cliPath = OD_BIN;
-    const cliExists = fs.existsSync(cliPath);
-    // process.execPath is the absolute path to the Node-compatible runtime
-    // that is running the daemon RIGHT NOW. In packaged builds this may be
-    // Electron running with ELECTRON_RUN_AS_NODE=1 rather than a separate
-    // bundled Node binary; surface the env requirement with the command so
-    // IDE-spawned MCP clients can reproduce the same mode from a minimal OS
-    // launcher environment.
-    const nodeExists = fs.existsSync(process.execPath);
-    const hints: string[] = [];
-    if (!cliExists) {
-      hints.push(
-        `Open Design CLI entry is missing at ${cliPath}. Rebuild the daemon or packaged app and refresh.`,
-      );
-    }
-    if (!nodeExists) {
-      hints.push(
-        `Node-compatible runtime at ${process.execPath} no longer exists. Reinstall Open Design or Node and restart the daemon.`,
-      );
-    }
-    // Pin OD_DATA_DIR to the daemon's resolved data root so the spawned
-    // MCP process writes to the same directory as the running daemon
-    // even when the IDE that launched it (Antigravity, VS Code, etc.)
-    // does not inherit the packaged app's environment. Without this,
-    // `od mcp` falls back to `<cwd>/.od/...` which is the read-only
-    // macOS app bundle for packaged installs and trips EPERM. Issue #848.
-    //
     // The daemon was bootstrapped as a sidecar (tools-dev, packaged) iff
     // bootstrapSidecarRuntime stamped OD_SIDECAR_IPC_PATH into the env.
     // In sidecar mode the snippet omits --daemon-url and the spawned
@@ -1782,10 +1763,9 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
     // when overridden) so a non-default namespace daemon stays
     // reachable - the MCP client does not inherit the daemon's env,
     // so without this the spawned `od mcp` would probe the default
-    // namespace socket and miss.
-    //
-    // For direct `od` / `od --port X` launches there is no IPC
-    // socket; bake --daemon-url so custom ports keep working.
+    // namespace socket and miss. For direct `od` / `od --port X`
+    // launches there is no IPC socket; the helper bakes --daemon-url
+    // so custom ports keep working.
     const sidecarIpcPath = process.env[SIDECAR_ENV.IPC_PATH];
     const isSidecarMode = sidecarIpcPath != null && sidecarIpcPath.length > 0;
     const sidecarEnv: Record<string, string> = {};
@@ -1799,32 +1779,18 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
         sidecarEnv[SIDECAR_ENV.IPC_BASE] = ipcBase;
       }
     }
-    const electronEnv = process.env.ELECTRON_RUN_AS_NODE === '1'
-      ? { ELECTRON_RUN_AS_NODE: '1' }
-      : null;
-    const env: Record<string, string> = {
-      OD_DATA_DIR: RUNTIME_DATA_DIR,
-      ...sidecarEnv,
-      ...(electronEnv ?? {}),
-    };
-    const args = isSidecarMode
-      ? [cliPath, 'mcp']
-      : [cliPath, 'mcp', '--daemon-url', `http://127.0.0.1:${resolvedPort}`];
-    const payload = {
-      command: process.execPath,
-      args,
-      env,
-      daemonUrl: `http://127.0.0.1:${resolvedPort}`,
-      // Surface platform so the install panel can localize path hints
-      // (~/.cursor vs %USERPROFILE%\.cursor) and keyboard shortcuts
-      // (Cmd vs Ctrl). One of 'darwin' | 'linux' | 'win32' in
-      // practice; the panel falls back to POSIX wording for anything
-      // else.
+    const payload = buildMcpInstallPayload({
+      cliPath,
+      cliExists: fs.existsSync(cliPath),
+      execPath: process.execPath,
+      nodeExists: fs.existsSync(process.execPath),
+      port: resolvedPort,
       platform: process.platform,
-      cliExists,
-      nodeExists,
-      buildHint: hints.length ? hints.join(' ') : null,
-    };
+      dataDir: RUNTIME_DATA_DIR,
+      electronAsNode: process.env.ELECTRON_RUN_AS_NODE === '1',
+      isSidecarMode,
+      sidecarEnv,
+    });
     installInfoCache = { t: now, payload };
     res.json(payload);
   });

--- a/apps/daemon/tests/mcp-install-info.test.ts
+++ b/apps/daemon/tests/mcp-install-info.test.ts
@@ -7,12 +7,15 @@ import express from 'express';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { SIDECAR_DEFAULTS, SIDECAR_ENV } from '@open-design/sidecar-proto';
 import { isLocalSameOrigin } from '../src/server.js';
+import { buildMcpInstallPayload } from '../src/mcp-install-info.js';
 
 // The install-info endpoint is a self-contained handler that resolves
 // absolute paths to node + cli.js so the Settings → MCP server panel
 // can render snippets that work regardless of PATH. We re-build a
-// minimal Express app with the same handler shape rather than booting
-// the full daemon (which needs SQLite, sidecar, fs scaffolding).
+// minimal Express app rather than booting the full daemon (which needs
+// SQLite, sidecar, fs scaffolding), but the payload itself is built by
+// the same exported helper the production handler uses, so any shape
+// divergence (env, args, buildHint) would fail this test.
 
 interface InstallInfoOpts {
   cliPath: string;
@@ -43,19 +46,10 @@ function makeInstallInfoApp({ cliPath, port, env = {}, dataDir }: InstallInfoOpt
       return res.json(cache.payload);
     }
     resolveCalls += 1;
-    const cliExists = fs.existsSync(cliPath);
-    const nodeExists = fs.existsSync(process.execPath);
-    const hints: string[] = [];
-    if (!cliExists) hints.push('cli missing');
-    if (!nodeExists) hints.push('node missing');
 
-    // Mirror the production handler in apps/daemon/src/server.ts:
-    // sidecar-bootstrapped daemons rely on IPC discovery in `od mcp`
-    // and propagate namespace / IPC base through the snippet env;
-    // non-sidecar (direct `od --port X`) launches bake the URL.
-    // OD_DATA_DIR is pinned unconditionally so the spawned process
-    // does not fall back to <cwd>/.od and EPERM inside a packaged
-    // app bundle. Issue #848.
+    // Mirror the production handler's sidecar detection so this test
+    // exercises the same path; the helper below is the same one
+    // server.ts calls.
     const sidecarIpcPath = env[SIDECAR_ENV.IPC_PATH];
     const isSidecarMode = sidecarIpcPath != null && sidecarIpcPath.length > 0;
     const sidecarEnv: Record<string, string> = {};
@@ -69,27 +63,18 @@ function makeInstallInfoApp({ cliPath, port, env = {}, dataDir }: InstallInfoOpt
         sidecarEnv[SIDECAR_ENV.IPC_BASE] = ipcBase;
       }
     }
-    const electronEnv = env.ELECTRON_RUN_AS_NODE === '1'
-      ? { ELECTRON_RUN_AS_NODE: '1' }
-      : null;
-    const snippetEnv: Record<string, string> = {
-      OD_DATA_DIR: dataDir,
-      ...sidecarEnv,
-      ...(electronEnv ?? {}),
-    };
-    const args = isSidecarMode
-      ? [cliPath, 'mcp']
-      : [cliPath, 'mcp', '--daemon-url', `http://127.0.0.1:${port}`];
-    const payload = {
-      command: process.execPath,
-      args,
-      env: snippetEnv,
-      daemonUrl: `http://127.0.0.1:${port}`,
+    const payload = buildMcpInstallPayload({
+      cliPath,
+      cliExists: fs.existsSync(cliPath),
+      execPath: process.execPath,
+      nodeExists: fs.existsSync(process.execPath),
+      port,
       platform: process.platform,
-      cliExists,
-      nodeExists,
-      buildHint: hints.length ? hints.join(' ') : null,
-    };
+      dataDir,
+      electronAsNode: env.ELECTRON_RUN_AS_NODE === '1',
+      isSidecarMode,
+      sidecarEnv,
+    });
     cache = { t: now, payload };
     res.json(payload);
   });

--- a/apps/daemon/tests/mcp-install-info.test.ts
+++ b/apps/daemon/tests/mcp-install-info.test.ts
@@ -21,9 +21,13 @@ interface InstallInfoOpts {
    *  non-sidecar daemon launches and custom namespaces without
    *  mutating the real process env. */
   env?: NodeJS.ProcessEnv;
+  /** Stand-in for the daemon's resolved RUNTIME_DATA_DIR (issue #848).
+   *  Pinned in the snippet env so IDE-spawned MCP processes write to
+   *  the same directory the daemon already uses. */
+  dataDir: string;
 }
 
-function makeInstallInfoApp({ cliPath, port, env = {} }: InstallInfoOpts) {
+function makeInstallInfoApp({ cliPath, port, env = {}, dataDir }: InstallInfoOpts) {
   const app = express();
 
   const TTL_MS = 5000;
@@ -49,6 +53,9 @@ function makeInstallInfoApp({ cliPath, port, env = {} }: InstallInfoOpts) {
     // sidecar-bootstrapped daemons rely on IPC discovery in `od mcp`
     // and propagate namespace / IPC base through the snippet env;
     // non-sidecar (direct `od --port X`) launches bake the URL.
+    // OD_DATA_DIR is pinned unconditionally so the spawned process
+    // does not fall back to <cwd>/.od and EPERM inside a packaged
+    // app bundle. Issue #848.
     const sidecarIpcPath = env[SIDECAR_ENV.IPC_PATH];
     const isSidecarMode = sidecarIpcPath != null && sidecarIpcPath.length > 0;
     const sidecarEnv: Record<string, string> = {};
@@ -65,14 +72,18 @@ function makeInstallInfoApp({ cliPath, port, env = {} }: InstallInfoOpts) {
     const electronEnv = env.ELECTRON_RUN_AS_NODE === '1'
       ? { ELECTRON_RUN_AS_NODE: '1' }
       : null;
-    const snippetEnv = { ...sidecarEnv, ...(electronEnv ?? {}) };
+    const snippetEnv: Record<string, string> = {
+      OD_DATA_DIR: dataDir,
+      ...sidecarEnv,
+      ...(electronEnv ?? {}),
+    };
     const args = isSidecarMode
       ? [cliPath, 'mcp']
       : [cliPath, 'mcp', '--daemon-url', `http://127.0.0.1:${port}`];
     const payload = {
       command: process.execPath,
       args,
-      ...(Object.keys(snippetEnv).length > 0 ? { env: snippetEnv } : {}),
+      env: snippetEnv,
       daemonUrl: `http://127.0.0.1:${port}`,
       platform: process.platform,
       cliExists,
@@ -95,7 +106,11 @@ interface Harness {
   baseUrl: string;
 }
 
-async function startHarness(cliPath: string, env: NodeJS.ProcessEnv): Promise<Harness> {
+async function startHarness(
+  cliPath: string,
+  env: NodeJS.ProcessEnv,
+  dataDir: string,
+): Promise<Harness> {
   // Pick a free port first so the handler can compare against it for
   // isLocalSameOrigin.
   const port: number = await new Promise((resolveListen) => {
@@ -105,7 +120,7 @@ async function startHarness(cliPath: string, env: NodeJS.ProcessEnv): Promise<Ha
       tmp.close(() => resolveListen(p));
     });
   });
-  const app = makeInstallInfoApp({ cliPath, port, env });
+  const app = makeInstallInfoApp({ cliPath, port, env, dataDir });
   const server: http.Server = await new Promise((resolveStart) => {
     const handle = app.listen(port, '127.0.0.1', () => resolveStart(handle));
   });
@@ -115,6 +130,7 @@ async function startHarness(cliPath: string, env: NodeJS.ProcessEnv): Promise<Ha
 describe('GET /api/mcp/install-info', () => {
   let tmpDir: string;
   let cliPath: string;
+  let dataDir: string;
   // Tests share the tmpDir but each top-level case spins its own
   // app instance so different env configurations stay isolated.
   let nonSidecar: { server: http.Server; port: number; app: express.Express };
@@ -125,11 +141,13 @@ describe('GET /api/mcp/install-info', () => {
         tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'od-mcp-info-'));
         cliPath = path.join(tmpDir, 'cli.js');
         fs.writeFileSync(cliPath, '// stub\n', 'utf8');
+        dataDir = path.join(tmpDir, 'data');
+        fs.mkdirSync(dataDir, { recursive: true });
         const tmp = http.createServer();
         tmp.listen(0, '127.0.0.1', () => {
           const port = (tmp.address() as { port: number }).port;
           tmp.close(() => {
-            const app = makeInstallInfoApp({ cliPath, port, env: {} });
+            const app = makeInstallInfoApp({ cliPath, port, env: {}, dataDir });
             const server = app.listen(port, '127.0.0.1', () => {
               nonSidecar = { server, port, app };
               resolveBoot();
@@ -159,12 +177,22 @@ describe('GET /api/mcp/install-info', () => {
     // URL so the spawned `od mcp` reaches the right port without any
     // discovery.
     expect(body.args).toEqual([cliPath, 'mcp', '--daemon-url', `http://127.0.0.1:${port}`]);
-    expect(body.env).toBeUndefined();
+    // env always carries OD_DATA_DIR (issue #848); no sidecar keys in
+    // a non-sidecar launch.
+    expect(body.env).toEqual({ OD_DATA_DIR: dataDir });
     expect(body.daemonUrl).toBe(`http://127.0.0.1:${port}`);
     expect(body.platform).toBe(process.platform);
     expect(body.cliExists).toBe(true);
     expect(body.nodeExists).toBe(true);
     expect(body.buildHint).toBeNull();
+  });
+
+  it('pins OD_DATA_DIR in the env so IDE-spawned MCP processes write to the daemon data dir (issue #848)', async () => {
+    const { port } = nonSidecar;
+    const res = await fetch(`http://127.0.0.1:${port}/api/mcp/install-info`);
+    const body = await res.json();
+    expect(body.env).toBeDefined();
+    expect(body.env.OD_DATA_DIR).toBe(dataDir);
   });
 
   it('rejects cross-origin requests with 403', async () => {
@@ -200,28 +228,37 @@ describe('GET /api/mcp/install-info', () => {
     expect(after - before).toBeLessThanOrEqual(1);
   });
 
-  it('sidecar default namespace omits --daemon-url and emits no env block', async () => {
-    const { port, server } = await startHarness(cliPath, {
-      [SIDECAR_ENV.IPC_PATH]: '/tmp/open-design/ipc/default/daemon.sock',
-      [SIDECAR_ENV.NAMESPACE]: SIDECAR_DEFAULTS.namespace,
-    });
+  it('sidecar default namespace omits --daemon-url and emits only OD_DATA_DIR', async () => {
+    const { port, server } = await startHarness(
+      cliPath,
+      {
+        [SIDECAR_ENV.IPC_PATH]: '/tmp/open-design/ipc/default/daemon.sock',
+        [SIDECAR_ENV.NAMESPACE]: SIDECAR_DEFAULTS.namespace,
+      },
+      dataDir,
+    );
     try {
       const res = await fetch(`http://127.0.0.1:${port}/api/mcp/install-info`);
       const body = await res.json();
       expect(body.args).toEqual([cliPath, 'mcp']);
       // Default namespace + default IPC base means the spawned `od mcp`
-      // can derive the right socket without any env hints.
-      expect(body.env).toBeUndefined();
+      // can derive the right socket without any sidecar env hints. The
+      // OD_DATA_DIR pin still rides along so the data dir is correct.
+      expect(body.env).toEqual({ OD_DATA_DIR: dataDir });
     } finally {
       await new Promise<void>((done) => server?.close(() => done()));
     }
   });
 
-  it('sidecar non-default namespace propagates OD_SIDECAR_NAMESPACE', async () => {
-    const { port, server } = await startHarness(cliPath, {
-      [SIDECAR_ENV.IPC_PATH]: '/tmp/open-design/ipc/foo/daemon.sock',
-      [SIDECAR_ENV.NAMESPACE]: 'foo',
-    });
+  it('sidecar non-default namespace propagates OD_SIDECAR_NAMESPACE alongside OD_DATA_DIR', async () => {
+    const { port, server } = await startHarness(
+      cliPath,
+      {
+        [SIDECAR_ENV.IPC_PATH]: '/tmp/open-design/ipc/foo/daemon.sock',
+        [SIDECAR_ENV.NAMESPACE]: 'foo',
+      },
+      dataDir,
+    );
     try {
       const res = await fetch(`http://127.0.0.1:${port}/api/mcp/install-info`);
       const body = await res.json();
@@ -229,22 +266,30 @@ describe('GET /api/mcp/install-info', () => {
       // Without this propagation the MCP client would launch `od mcp`
       // with no namespace env, fall back to "default", and miss the
       // foo daemon entirely.
-      expect(body.env).toEqual({ [SIDECAR_ENV.NAMESPACE]: 'foo' });
+      expect(body.env).toEqual({
+        OD_DATA_DIR: dataDir,
+        [SIDECAR_ENV.NAMESPACE]: 'foo',
+      });
     } finally {
       await new Promise<void>((done) => server?.close(() => done()));
     }
   });
 
-  it('sidecar with custom IPC base propagates OD_SIDECAR_IPC_BASE', async () => {
-    const { port, server } = await startHarness(cliPath, {
-      [SIDECAR_ENV.IPC_PATH]: '/var/run/open-design/foo/daemon.sock',
-      [SIDECAR_ENV.NAMESPACE]: 'foo',
-      [SIDECAR_ENV.IPC_BASE]: '/var/run/open-design',
-    });
+  it('sidecar with custom IPC base propagates OD_SIDECAR_IPC_BASE alongside OD_DATA_DIR', async () => {
+    const { port, server } = await startHarness(
+      cliPath,
+      {
+        [SIDECAR_ENV.IPC_PATH]: '/var/run/open-design/foo/daemon.sock',
+        [SIDECAR_ENV.NAMESPACE]: 'foo',
+        [SIDECAR_ENV.IPC_BASE]: '/var/run/open-design',
+      },
+      dataDir,
+    );
     try {
       const res = await fetch(`http://127.0.0.1:${port}/api/mcp/install-info`);
       const body = await res.json();
       expect(body.env).toEqual({
+        OD_DATA_DIR: dataDir,
         [SIDECAR_ENV.NAMESPACE]: 'foo',
         [SIDECAR_ENV.IPC_BASE]: '/var/run/open-design',
       });


### PR DESCRIPTION
Closes #848.

@ozcanoguz reported on packaged Open Design 0.5.0 (macOS, Antigravity 1.23.2) that pointing the IDE's MCP config at the bundled `daemon-cli.mjs` crashed with:

```
EPERM: operation not permitted, mkdir
'/Applications/Open Design.app/Contents/Resources/app/prebundled/.od/projects'
```

@lefarcen confirmed the diagnosis on the issue thread:
> The packaged `od mcp` command imports part of the daemon server module before it dispatches into MCP mode. That module creates the daemon data directories on import. Because the MCP process is launched by Antigravity and does not inherit the packaged app's `OD_DATA_DIR`, it falls back to creating `.od/projects` relative to the packaged bundle.

The reporter's workaround (`env.OD_DATA_DIR = ~/.od`) is exactly the right fix path — it just shouldn't require manual editing of the IDE's MCP config.

## Fix

[`/api/mcp/install-info`](https://github.com/nexu-io/open-design/blob/main/apps/daemon/src/server.ts) already serializes an `env` object into every client snippet (Cursor / Claude Code / VS Code / Zed / Windsurf / Antigravity / Codex via [`buildMcpStdioServerConfig`](https://github.com/nexu-io/open-design/blob/main/apps/web/src/components/SettingsDialog.tsx)). Previously it only emitted `ELECTRON_RUN_AS_NODE: '1'` when the daemon itself was running inside Electron-as-Node. This adds `OD_DATA_DIR: RUNTIME_DATA_DIR` unconditionally, so the snippet pins the daemon's already-resolved data root and the spawned MCP process writes to the same directory the daemon uses regardless of how the IDE launched it.

`RUNTIME_DATA_DIR` is computed once at daemon startup via the existing `resolveDataDir(process.env.OD_DATA_DIR, PROJECT_ROOT)` helper, so:
- Dev runs from source → `<projectRoot>/.od` (no behavior change vs today, just made explicit in the snippet).
- Packaged macOS / Linux / Windows → whatever the launcher set (`~/Library/Application Support/Open Design`, etc.) — exactly what was missing in the EPERM case.

## Test

`apps/daemon/tests/mcp-install-info.test.ts` already mirrored the handler shape; extended it to construct the env block the same way and added an assertion that `body.env.OD_DATA_DIR === dataDir`. The pre-existing tests (cross-origin reject, loopback accept, cache hit) still cover their original paths.

## Validation

- `pnpm guard` — clean.
- `pnpm --filter @open-design/daemon typecheck` — clean.
- `pnpm --filter @open-design/daemon test -- --run tests/mcp-install-info.test.ts` — fails locally on `Failed to load url undici` from `apps/daemon/src/media.ts`. Reproducible on `origin/main` without my edits, so it's a pre-existing local-environment issue, not something this PR introduces. CI will be the source of truth.