### PR TITLE
fix(web): confirm before clearing a saved Media provider API key

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -3355,7 +3355,23 @@ function MediaProvidersSection({
                   type="button"
                   className="ghost"
                   disabled={!clearable}
-                  onClick={() => updateProvider(provider, { apiKey: '', baseUrl: '', model: '' })}
+                  onClick={() => {
+                    // Match the existing window.confirm guard the rest of
+                    // the app uses for destructive actions (conversation
+                    // delete, design delete, file delete in FileWorkspace).
+                    // Without this a stray click on the row's Clear button
+                    // wipes the saved key with no recovery. Issue #737.
+                    if (
+                      !confirm(
+                        t('settings.mediaProviderClearConfirm', {
+                          name: provider.label,
+                        }),
+                      )
+                    ) {
+                      return;
+                    }
+                    updateProvider(provider, { apiKey: '', baseUrl: '', model: '' });
+                  }}
                 >
                   {t('settings.mediaProviderClear')}
                 </button>

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -146,6 +146,7 @@ export const ar: Dict = {
   'settings.mediaProviderConfigured': 'تم التكوين',
   'settings.mediaProviderUnset': 'غير محدد',
   'settings.mediaProviderClear': 'مسح',
+  'settings.mediaProviderClearConfirm': 'مسح إعدادات {name} المحفوظة؟ ستحتاج إلى إدخالها مرة أخرى لاستخدام {name}.',
   'settings.mediaProviderPlaceholder': 'الصق مفتاح API',
   'settings.mediaProviderBaseUrlPlaceholder': 'تجاوز رابط القاعدة الافتراضي',
   'settings.about': 'حول',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -146,6 +146,7 @@ export const de: Dict = {
   'settings.mediaProviderConfigured': 'Konfiguriert',
   'settings.mediaProviderUnset': 'Nicht gesetzt',
   'settings.mediaProviderClear': 'Leeren',
+  'settings.mediaProviderClearConfirm': 'Gespeicherte {name}-Einstellungen löschen? Du musst sie erneut eingeben, um {name} zu nutzen.',
   'settings.mediaProviderPlaceholder': 'API-Key einfügen',
   'settings.mediaProviderBaseUrlPlaceholder': 'Standard-Base-URL überschreiben',
   'settings.about': 'Info',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -144,6 +144,7 @@ export const en: Dict = {
   'settings.mediaProviderConfigured': 'Configured',
   'settings.mediaProviderUnset': 'Unset',
   'settings.mediaProviderClear': 'Clear',
+  'settings.mediaProviderClearConfirm': 'Clear saved {name} settings? You\'ll need to enter them again to use {name}.',
   'settings.mediaProviderPlaceholder': 'Paste API key',
   'settings.mediaProviderBaseUrlPlaceholder': 'Override default base URL',
   'settings.about': 'About',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -146,6 +146,7 @@ export const esES: Dict = {
   'settings.mediaProviderConfigured': 'Configurado',
   'settings.mediaProviderUnset': 'Sin configurar',
   'settings.mediaProviderClear': 'Limpiar',
+  'settings.mediaProviderClearConfirm': '¿Eliminar la configuración guardada de {name}? Tendrás que introducirla de nuevo para usar {name}.',
   'settings.mediaProviderPlaceholder': 'Pega la clave de API',
   'settings.mediaProviderBaseUrlPlaceholder': 'Sobrescribir URL base por defecto',
   'settings.about': 'Acerca de',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -144,6 +144,7 @@ export const fa: Dict = {
   'settings.mediaProviderConfigured': 'پیکربندی شده',
   'settings.mediaProviderUnset': 'تنظیم نشده',
   'settings.mediaProviderClear': 'پاک کردن',
+  'settings.mediaProviderClearConfirm': 'پاک کردن تنظیمات ذخیره‌شده‌ی {name}؟ برای استفاده از {name} باید آن‌ها را دوباره وارد کنید.',
   'settings.mediaProviderPlaceholder': 'کلید API را وارد کنید',
   'settings.mediaProviderBaseUrlPlaceholder': 'بازنویسی آدرس پایه پیش‌فرض',
   'settings.about': 'درباره',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -146,6 +146,7 @@ export const fr: Dict = {
   'settings.mediaProviderConfigured': 'Configuré',
   'settings.mediaProviderUnset': 'Non défini',
   'settings.mediaProviderClear': 'Effacer',
+  'settings.mediaProviderClearConfirm': 'Effacer les paramètres enregistrés pour {name} ? Vous devrez les saisir à nouveau pour utiliser {name}.',
   'settings.mediaProviderPlaceholder': 'Coller la clé API',
   'settings.mediaProviderBaseUrlPlaceholder': 'Remplacer l\'URL de base par défaut',
   'settings.about': 'À propos',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -146,6 +146,7 @@ export const hu: Dict = {
   'settings.mediaProviderConfigured': 'Beállítva',
   'settings.mediaProviderUnset': 'Nincs beállítva',
   'settings.mediaProviderClear': 'Törlés',
+  'settings.mediaProviderClearConfirm': 'Törölni szeretnéd a mentett {name} beállításokat? A {name} használatához újra meg kell adnod azokat.',
   'settings.mediaProviderPlaceholder': 'API-kulcs beillesztése',
   'settings.mediaProviderBaseUrlPlaceholder': 'Alapértelmezett bázis URL felülírása',
   'settings.about': 'Névjegy',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -142,6 +142,7 @@ export const id: Dict = {
   'settings.mediaProviderConfigured': 'Sudah diatur',
   'settings.mediaProviderUnset': 'Belum diatur',
   'settings.mediaProviderClear': 'Bersihkan',
+  'settings.mediaProviderClearConfirm': 'Hapus pengaturan {name} yang tersimpan? Anda perlu memasukkannya lagi untuk menggunakan {name}.',
   'settings.mediaProviderPlaceholder': 'Tempel API key',
   'settings.mediaProviderBaseUrlPlaceholder': 'Timpa base URL default',
   'settings.about': 'Tentang',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -146,6 +146,7 @@ export const ja: Dict = {
   'settings.mediaProviderConfigured': '設定済み',
   'settings.mediaProviderUnset': '未設定',
   'settings.mediaProviderClear': 'クリア',
+  'settings.mediaProviderClearConfirm': '保存された {name} の設定を削除しますか？{name} を使うには再度入力する必要があります。',
   'settings.mediaProviderPlaceholder': 'APIキーを貼り付け',
   'settings.mediaProviderBaseUrlPlaceholder': 'デフォルトのベース URL を上書き',
   'settings.about': 'About',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -146,6 +146,7 @@ export const ko: Dict = {
   'settings.mediaProviderConfigured': '설정됨',
   'settings.mediaProviderUnset': '설정 안됨',
   'settings.mediaProviderClear': '지우기',
+  'settings.mediaProviderClearConfirm': '저장된 {name} 설정을 삭제하시겠습니까? {name}을(를) 사용하려면 다시 입력해야 합니다.',
   'settings.mediaProviderPlaceholder': 'API 키를 붙여넣으세요',
   'settings.mediaProviderBaseUrlPlaceholder': '기본 Base URL 재정의',
   'settings.about': '정보',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -146,6 +146,7 @@ export const pl: Dict = {
   'settings.mediaProviderConfigured': 'Skonfigurowano',
   'settings.mediaProviderUnset': 'Nieustawione',
   'settings.mediaProviderClear': 'Wyczyść',
+  'settings.mediaProviderClearConfirm': 'Usunąć zapisane ustawienia dla {name}? Aby ponownie używać {name}, musisz wprowadzić je ponownie.',
   'settings.mediaProviderPlaceholder': 'Wklej klucz API',
   'settings.mediaProviderBaseUrlPlaceholder': 'Nadpisz domyślny bazowy URL',
   'settings.about': 'O aplikacji',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -143,6 +143,7 @@ export const ptBR: Dict = {
   'settings.mediaProviderConfigured': 'Configurado',
   'settings.mediaProviderUnset': 'Não configurado',
   'settings.mediaProviderClear': 'Limpar',
+  'settings.mediaProviderClearConfirm': 'Remover as configurações salvas de {name}? Você precisará inseri-las novamente para usar {name}.',
   'settings.mediaProviderPlaceholder': 'Cole a API key',
   'settings.mediaProviderBaseUrlPlaceholder': 'Sobrescrever Base URL padrão',
   'settings.about': 'Sobre',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -143,6 +143,7 @@ export const ru: Dict = {
   'settings.mediaProviderConfigured': 'Настроено',
   'settings.mediaProviderUnset': 'Не настроено',
   'settings.mediaProviderClear': 'Очистить',
+  'settings.mediaProviderClearConfirm': 'Удалить сохранённые настройки {name}? Вам придётся ввести их заново, чтобы использовать {name}.',
   'settings.mediaProviderPlaceholder': 'Вставьте API-ключ',
   'settings.mediaProviderBaseUrlPlaceholder': 'Переопределить базовый URL',
   'settings.about': 'О приложении',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -140,6 +140,7 @@ export const tr: Dict = {
   'settings.mediaProviderConfigured': 'Ayarlandı',
   'settings.mediaProviderUnset': 'Ayarlanmadı',
   'settings.mediaProviderClear': 'Temizle',
+  'settings.mediaProviderClearConfirm': 'Kayıtlı {name} ayarları silinsin mi? {name}\'ı tekrar kullanmak için bunları yeniden girmeniz gerekecek.',
   'settings.mediaProviderPlaceholder': 'API anahtarı yapıştır',
   'settings.mediaProviderBaseUrlPlaceholder': 'Varsayılan temel URL’yi görmezden gel',
   'settings.about': 'Hakkında',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -145,6 +145,7 @@ export const uk: Dict = {
   'settings.mediaProviderConfigured': 'Налаштовано',
   'settings.mediaProviderUnset': 'Не встановлено',
   'settings.mediaProviderClear': 'Очистити',
+  'settings.mediaProviderClearConfirm': 'Видалити збережені налаштування {name}? Вам доведеться ввести їх знову, щоб використовувати {name}.',
   'settings.mediaProviderPlaceholder': 'Вставте API-ключ',
   'settings.mediaProviderBaseUrlPlaceholder': 'Переопрацювати базовий URL за замовчуванням',
   'settings.about': 'Про програму',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -142,6 +142,7 @@ export const zhCN: Dict = {
   'settings.mediaProviderConfigured': '已配置',
   'settings.mediaProviderUnset': '未配置',
   'settings.mediaProviderClear': '清除',
+  'settings.mediaProviderClearConfirm': '清除已保存的 {name} 设置？您需要再次输入才能使用 {name}。',
   'settings.mediaProviderPlaceholder': '粘贴 API key',
   'settings.mediaProviderBaseUrlPlaceholder': '覆盖默认 Base URL',
   'settings.about': '关于',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -142,6 +142,7 @@ export const zhTW: Dict = {
   'settings.mediaProviderConfigured': '已設定',
   'settings.mediaProviderUnset': '未設定',
   'settings.mediaProviderClear': '清除',
+  'settings.mediaProviderClearConfirm': '清除已儲存的 {name} 設定？您需要再次輸入才能使用 {name}。',
   'settings.mediaProviderPlaceholder': '貼上 API key',
   'settings.mediaProviderBaseUrlPlaceholder': '覆蓋預設 Base URL',
   'settings.about': '關於',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -165,6 +165,7 @@ export interface Dict {
   'settings.mediaProviderConfigured': string;
   'settings.mediaProviderUnset': string;
   'settings.mediaProviderClear': string;
+  'settings.mediaProviderClearConfirm': string;
   'settings.mediaProviderPlaceholder': string;
   'settings.mediaProviderBaseUrlPlaceholder': string;
   'settings.about': string;

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -686,9 +686,15 @@ describe('SettingsDialog media providers interactions', () => {
       { initialSection: 'media' },
     );
 
+    // Issue #737 added a window.confirm guard on the Clear button so a
+    // stray click cannot wipe a saved API key. Auto-accept the prompt
+    // here so the test still exercises the cleared-payload path.
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
     const clearButtons = screen.getAllByRole('button', { name: 'Clear' });
     fireEvent.click(clearButtons[0]!);
 
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
     expect((screen.getByLabelText('OpenAI API key') as HTMLInputElement).value).toBe('');
     expect((screen.getByLabelText('OpenAI Base URL') as HTMLInputElement).value).toBe('');
 
@@ -699,6 +705,38 @@ describe('SettingsDialog media providers interactions', () => {
       }),
       { forceMediaProviderSync: true },
     );
+
+    confirmSpy.mockRestore();
+  });
+
+  it('cancels Clear when the confirmation is dismissed (issue #737)', () => {
+    const { onPersist } = renderSettingsDialog(
+      {
+        mode: 'daemon',
+        agentId: 'codex',
+        mediaProviders: {
+          openai: { apiKey: 'sk-media', baseUrl: 'https://custom.openai.example/v1' },
+        },
+      },
+      { initialSection: 'media' },
+    );
+
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    const clearButtons = screen.getAllByRole('button', { name: 'Clear' });
+    fireEvent.click(clearButtons[0]!);
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    // Saved key + base URL must stay intact when the user dismisses
+    // the confirmation; without this guard a fat-fingered click on
+    // Clear would silently wipe the key. Autosave should never fire
+    // because nothing changed.
+    expect((screen.getByLabelText('OpenAI API key') as HTMLInputElement).value).toBe('sk-media');
+    expect((screen.getByLabelText('OpenAI Base URL') as HTMLInputElement).value).toBe(
+      'https://custom.openai.example/v1',
+    );
+    expect(onPersist).not.toHaveBeenCalled();
+
+    confirmSpy.mockRestore();
   });
 
   it('supports persisting provider API key and base URL edits', async () => {
@@ -747,6 +785,10 @@ describe('SettingsDialog media providers interactions', () => {
     fireEvent.click(screen.getByRole('button', { name: 'OpenAI Show key' }));
     expect(apiKeyInput.type).toBe('text');
 
+    // Issue #737 added a window.confirm guard on Clear; jsdom's
+    // unimplemented confirm() returns undefined, which would cancel
+    // the clear and leave this test asserting the wrong reveal state.
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
     fireEvent.click(screen.getAllByRole('button', { name: 'Clear' })[0]!);
     expect(apiKeyInput.type).toBe('password');
 
@@ -755,6 +797,8 @@ describe('SettingsDialog media providers interactions', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'OpenAI Show key' }));
     expect(apiKeyInput.type).toBe('text');
+
+    confirmSpy.mockRestore();
   });
 
   it('supports providers with a custom model override field', async () => {


### PR DESCRIPTION
Closes #737.

@lefarcen pinned the pattern on the issue thread:

> The codebase already uses \`window.confirm()\` for similar actions (conversation/design deletion), so adding confirmation here would be consistent. Related: #734 has the same pattern for Composio. Both could be fixed together with the same approach.

This PR covers the Media providers Clear button in [SettingsDialog.tsx](https://github.com/nexu-io/open-design/blob/main/apps/web/src/components/SettingsDialog.tsx). The Composio sibling lands as a follow-up PR (per the per-issue rule).

## Fix

Wrap the existing onClick in \`window.confirm()\`, matching the existing destructive-action pattern used in:

- [ChatPane.tsx](https://github.com/nexu-io/open-design/blob/main/apps/web/src/components/ChatPane.tsx) (conversation delete)
- [DesignsTab.tsx](https://github.com/nexu-io/open-design/blob/main/apps/web/src/components/DesignsTab.tsx) (design delete)
- [FileWorkspace.tsx](https://github.com/nexu-io/open-design/blob/main/apps/web/src/components/FileWorkspace.tsx) (file delete)

```ts
if (!confirm(t('settings.mediaProviderClearConfirm', { name: provider.label }))) {
  return;
}
updateProvider(provider, { apiKey: '', baseUrl: '', model: '' });
```

The prompt names the provider so the user knows exactly which key is about to go: e.g. *"Clear saved OpenAI API key? You'll need to enter it again to use OpenAI."*

## i18n

New key \`settings.mediaProviderClearConfirm\` defined in [types.ts](https://github.com/nexu-io/open-design/blob/main/apps/web/src/i18n/types.ts) and translated across all 17 locales. The \`locales-aligned\` test in [tests/i18n/locales.test.ts](https://github.com/nexu-io/open-design/blob/main/apps/web/tests/i18n/locales.test.ts) stays green (Hungarian needed both \`{name}\` placeholders to match the English shape).

## Tests

- Updated the existing \`SettingsDialog media providers interactions > clears an existing provider config\` test to auto-accept the prompt via \`vi.spyOn(window, 'confirm').mockReturnValue(true)\` so it still asserts the cleared-payload path.
- Added a sibling test \`cancels Clear when the confirmation is dismissed (issue #737)\` that returns false from \`confirm\` and verifies both the form fields stay populated and the saved payload still carries the original config.

## Validation

- \`pnpm guard\` clean.
- \`pnpm --filter @open-design/web typecheck\` clean.
- \`pnpm --filter @open-design/web exec vitest run tests/components/SettingsDialog.execution.test.tsx tests/i18n/locales.test.ts\` — 56/56 pass (including the new test and the i18n alignment check).