### PR TITLE
fix(web): confirm before clearing the saved Composio API key

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -1856,7 +1856,19 @@ function ComposioSection({
             type="button"
             className="ghost"
             disabled={!apiKeyConfigured}
-            onClick={() => updateComposio({ apiKey: '', apiKeyConfigured: false, apiKeyTail: '' })}
+            onClick={() => {
+              // Match the existing window.confirm guard the rest of the
+              // app uses for destructive actions (conversation delete,
+              // design delete, file delete in FileWorkspace, and the
+              // Media providers Clear button). Without this a stray
+              // click wipes the daemon-stored Composio key and the
+              // user has to paste it back from their secrets manager.
+              // Issue #734.
+              if (!confirm('Clear the saved Composio API key? You\'ll need to paste it again to use Composio-backed connectors.')) {
+                return;
+              }
+              updateComposio({ apiKey: '', apiKeyConfigured: false, apiKeyTail: '' });
+            }}
           >
             Clear
           </button>

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -890,8 +890,15 @@ describe('SettingsDialog connectors interactions', () => {
       { initialSection: 'composio' },
     );
 
+    // Issue #734 added a window.confirm guard on the Clear button so a
+    // stray click cannot wipe a daemon-stored Composio key. Auto-accept
+    // the prompt here so the test still exercises the cleared-payload
+    // path.
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
     fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
 
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
     expect((screen.getByPlaceholderText('Paste Composio API key') as HTMLInputElement).value).toBe('');
     expect(screen.getByText(/Keys are stored locally in the daemon/i)).toBeTruthy();
 
@@ -906,6 +913,46 @@ describe('SettingsDialog connectors interactions', () => {
       }),
       false,
     );
+
+    confirmSpy.mockRestore();
+  });
+
+  it('cancels Clear when the Composio confirmation is dismissed (issue #734)', () => {
+    const { onSave } = renderSettingsDialog(
+      {
+        mode: 'daemon',
+        agentId: 'codex',
+        composio: {
+          apiKey: '',
+          apiKeyConfigured: true,
+          apiKeyTail: 'uQEg',
+        },
+      },
+      { initialSection: 'composio' },
+    );
+
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    // Saved badge survives because apiKeyConfigured is still true.
+    expect(screen.getByText(/Saved · ••••uQEg/)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    // Without a confirmation, the saved key must remain in the payload
+    // so the user does not silently lose their daemon-stored credential.
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        composio: expect.objectContaining({
+          apiKeyConfigured: true,
+          apiKeyTail: 'uQEg',
+        }),
+      }),
+      false,
+    );
+
+    confirmSpy.mockRestore();
   });
 
   it('does not save Composio edits when cancel is used or the backdrop is clicked', () => {


### PR DESCRIPTION
Closes #734.

Sibling to PR #875 (#737 — same pattern for the Media providers Clear button). @lefarcen flagged on #737 that *"Both could be fixed together with the same approach"*; per the per-issue rule these go in as separate PRs.

## Fix

Wrap the existing onClick on the Composio section's Clear button in [SettingsDialog.tsx](https://github.com/nexu-io/open-design/blob/main/apps/web/src/components/SettingsDialog.tsx) with \`window.confirm()\`, matching the existing destructive-action pattern used in [ChatPane.tsx](https://github.com/nexu-io/open-design/blob/main/apps/web/src/components/ChatPane.tsx) (conversation delete), [DesignsTab.tsx](https://github.com/nexu-io/open-design/blob/main/apps/web/src/components/DesignsTab.tsx) (design delete), [FileWorkspace.tsx](https://github.com/nexu-io/open-design/blob/main/apps/web/src/components/FileWorkspace.tsx) (file delete), and the Media providers Clear button covered by #737.

```ts
if (!confirm('Clear the saved Composio API key? You\'ll need to paste it again to use Composio-backed connectors.')) {
  return;
}
updateComposio({ apiKey: '', apiKeyConfigured: false, apiKeyTail: '' });
```

The prompt copy is intentionally in English to match the rest of the \`ComposioSection\` block, which is hardcoded English today (no \`t()\` calls in that section). Localizing the section is a separate scope; this PR keeps the same conventions.

## Tests

- Updated the existing \`clears a saved Composio key from the payload\` test to auto-accept the prompt via \`vi.spyOn(window, 'confirm').mockReturnValue(true)\` so it still asserts the cleared-payload path.
- Added a sibling test \`cancels Clear when the Composio confirmation is dismissed (issue #734)\` that returns false from \`confirm\` and verifies the saved badge stays visible and the daemon-stored key remains in the saved payload (\`apiKeyConfigured: true, apiKeyTail: 'uQEg'\`).

## Validation

- \`pnpm guard\` clean.
- \`pnpm --filter @open-design/web typecheck\` clean.
- \`pnpm --filter @open-design/web exec vitest run tests/components/SettingsDialog.execution.test.tsx\` — 55/55 pass.