### PR TITLE
fix(daemon): allow portless Origin for UI-needed POST endpoints

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1545,13 +1545,15 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
 
   // POST endpoints that the Open Design UI needs with a portless Origin.
   // Kept narrow to avoid opening state-changing endpoints beyond the UI's
-  // actual usage. All listed endpoints require Content-Type: application/json,
-  // which is NOT a CORS-safelisted type, so the browser always sends a
-  // preflight OPTIONS request — meaning this fallback does not bypass CORS
-  // for those routes.  The /upload endpoint is deliberately excluded because
-  // it accepts multipart/form-data (a safelisted type that skips preflight),
-  // which would allow CSRF from a page on the default port (80).
-  // See _PORTLESS_SAFE_POST_RE usage in the origin middleware.
+  // actual usage.  The middleware also enforces Content-Type: application/json
+  // for these portless POSTs (see isPortlessSafe below), which is critical
+  // because some routes normalize a missing body and still perform side
+  // effects.  application/json is NOT a CORS-safelisted type, so the browser
+  // always sends a preflight OPTIONS request — meaning this fallback does
+  // not bypass CORS for these routes.  The /upload endpoint is deliberately
+  // excluded because it accepts multipart/form-data (a safelisted type that
+  // skips preflight), which would allow CSRF from a page on the default
+  // port (80).
   const _PORTLESS_SAFE_POST_RE =
     /^\/(test\/connection|projects|chat|runs|artifacts\/(save|lint)|templates|codex-pets\/sync|tools\/live-artifacts\/(create|update|refresh)|projects\/[^/]+\/(conversations|deploy|archive|media)|live-artifacts\/[^/]+\/refresh)$/;
 
@@ -1592,15 +1594,24 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
       // for GET (idempotent) and for a small set of POST endpoints
       // that the Open Design UI needs (test connection, create project,
       // chat, conversations, templates, artifacts, runs).
-      // All whitelisted POST endpoints require Content-Type: application/json,
-      // which forces a CORS preflight — so this is not vulnerable to CSRF
-      // from simple form submissions. Endpoints accepting multipart/form-data
-      // (e.g. /upload) are excluded because that content type is safelisted
-      // and skips preflight. Other mutating methods (PUT/PATCH/DELETE) and
-      // POST endpoints not in this list always require an exact port-match.
+      //
+      // POST endpoints additionally require Content-Type: application/json
+      // at the middleware level. This is critical because:
+      //   1. application/json is NOT a CORS-safelisted content type, so the
+      //      browser always sends a preflight OPTIONS request for it.
+      //   2. Some whitelisted routes normalize a missing/non-JSON body and
+      //      still perform side effects, so relying on route-level validation
+      //      is not enough — the middleware must reject safelisted content
+      //      types (multipart/form-data, text/plain, application/x-www-form-urlencoded)
+      //      that skip preflight and could be sent by a page on localhost:80.
+      //
+      // Other mutating methods (PUT/PATCH/DELETE) and POST endpoints not in
+      // this list always require an exact port-match.
       const isPortlessSafe =
         isPortlessLoopbackOrigin(String(origin)) &&
-        (req.method === 'GET' || _PORTLESS_SAFE_POST_RE.test(req.path));
+        (req.method === 'GET' ||
+          (_PORTLESS_SAFE_POST_RE.test(req.path) &&
+            /^application\/json\b/i.test(String(req.headers['content-type'] ?? ''))));
       if (!isPortlessSafe) {
         return res.status(403).json({ error: 'Cross-origin requests are not allowed' });
       }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1555,7 +1555,7 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
   // skips preflight), which would allow CSRF from a page on the default
   // port (80).
   const _PORTLESS_SAFE_POST_RE =
-    /^\/(test\/connection|projects|chat|runs|artifacts\/(save|lint)|templates|codex-pets\/sync|tools\/live-artifacts\/(create|update|refresh)|projects\/[^/]+\/(conversations|deploy|archive|media)|live-artifacts\/[^/]+\/refresh)$/;
+    /^\/(test\/connection|projects|chat|runs|artifacts\/(save|lint)|templates|codex-pets\/sync|tools\/live-artifacts\/(create|update|refresh)|projects\/[^/]+\/(conversations|deploy|archive(\/batch)?|media)|live-artifacts\/[^/]+\/refresh)$/;
 
   // Reject cross-origin requests to API endpoints.
   // Health/version remain open for monitoring probes.

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1574,7 +1574,7 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
 
     const ports = allowedBrowserPorts(resolvedPort);
     if (!isAllowedBrowserOrigin(origin, req.headers.host, ports, host, extraAllowedOrigins)) {
-      if (req.method !== 'GET' || !isPortlessLoopbackOrigin(String(origin))) {
+      if (!isPortlessLoopbackOrigin(String(origin))) {
         return res.status(403).json({ error: 'Cross-origin requests are not allowed' });
       }
     }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1543,6 +1543,18 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
   const _NULL_ORIGIN_SAFE_GET_RE =
     /^\/projects\/[^/]+\/raw\/|^\/codex-pets\/[^/]+\/spritesheet$/;
 
+  // POST endpoints that the Open Design UI needs with a portless Origin.
+  // Kept narrow to avoid opening state-changing endpoints beyond the UI's
+  // actual usage. All listed endpoints require Content-Type: application/json,
+  // which is NOT a CORS-safelisted type, so the browser always sends a
+  // preflight OPTIONS request — meaning this fallback does not bypass CORS
+  // for those routes.  The /upload endpoint is deliberately excluded because
+  // it accepts multipart/form-data (a safelisted type that skips preflight),
+  // which would allow CSRF from a page on the default port (80).
+  // See _PORTLESS_SAFE_POST_RE usage in the origin middleware.
+  const _PORTLESS_SAFE_POST_RE =
+    /^\/(test\/connection|projects|chat|runs|artifacts\/(save|lint)|templates|codex-pets\/sync|tools\/live-artifacts\/(create|update|refresh)|projects\/[^/]+\/(conversations|deploy|archive|media)|live-artifacts\/[^/]+\/refresh)$/;
+
   // Reject cross-origin requests to API endpoints.
   // Health/version remain open for monitoring probes.
   // Non-browser clients (no Origin header) are always allowed.
@@ -1574,7 +1586,22 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
 
     const ports = allowedBrowserPorts(resolvedPort);
     if (!isAllowedBrowserOrigin(origin, req.headers.host, ports, host, extraAllowedOrigins)) {
-      if (!isPortlessLoopbackOrigin(String(origin))) {
+      // Chrome strips the port from the Origin header on same-origin
+      // requests to localhost (e.g. http://127.0.0.1 instead of
+      // http://127.0.0.1:4353). Allow portless loopback origins only
+      // for GET (idempotent) and for a small set of POST endpoints
+      // that the Open Design UI needs (test connection, create project,
+      // chat, conversations, templates, artifacts, runs).
+      // All whitelisted POST endpoints require Content-Type: application/json,
+      // which forces a CORS preflight — so this is not vulnerable to CSRF
+      // from simple form submissions. Endpoints accepting multipart/form-data
+      // (e.g. /upload) are excluded because that content type is safelisted
+      // and skips preflight. Other mutating methods (PUT/PATCH/DELETE) and
+      // POST endpoints not in this list always require an exact port-match.
+      const isPortlessSafe =
+        isPortlessLoopbackOrigin(String(origin)) &&
+        (req.method === 'GET' || _PORTLESS_SAFE_POST_RE.test(req.path));
+      if (!isPortlessSafe) {
         return res.status(403).json({ error: 'Cross-origin requests are not allowed' });
       }
     }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1555,7 +1555,7 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
   // skips preflight), which would allow CSRF from a page on the default
   // port (80).
   const _PORTLESS_SAFE_POST_RE =
-    /^\/(test\/connection|projects|chat|runs|artifacts\/(save|lint)|templates|codex-pets\/sync|tools\/live-artifacts\/(create|update|refresh)|projects\/[^/]+\/(conversations|deploy|archive(\/batch)?|media)|live-artifacts\/[^/]+\/refresh)$/;
+    /^\/(test\/connection|projects|chat|runs|runs\/[^/]+\/cancel|artifacts\/(save|lint)|templates|codex-pets\/sync|tools\/live-artifacts\/(create|update|refresh)|projects\/[^/]+\/(conversations|deploy|archive(\/batch)?|media)|live-artifacts\/[^/]+\/refresh)$/;
 
   // Reject cross-origin requests to API endpoints.
   // Health/version remain open for monitoring probes.

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -202,7 +202,11 @@ async function consumeDaemonRun({
   const cancelRun = () => {
     if (canceled) return;
     canceled = true;
-    void fetch(`/api/runs/${encodeURIComponent(runId)}/cancel`, { method: 'POST' }).catch(() => {});
+    void fetch(`/api/runs/${encodeURIComponent(runId)}/cancel`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    }).catch(() => {});
   };
 
   cancelSignal?.addEventListener('abort', cancelRun, { once: true });


### PR DESCRIPTION
## Summary

Chrome strips the port from the `Origin` header on same-origin requests to localhost with non-standard ports (sends `Origin: http://127.0.0.1` instead of `http://127.0.0.1:4353`). PR #735 added a portless loopback origin fallback for GET requests only, which fixed agent scanning but left the test-connection button and project creation broken (both use POST).

This PR extends the portless origin fallback to a targeted whitelist of POST endpoints that the UI needs, while maintaining security:

- **Allowed:** `/test/connection`, `/projects`, `/chat`, `/runs`, `/templates`, `/artifacts/save`, `/artifacts/lint`, and other UI-needed endpoints — all require `Content-Type: application/json` which forces CORS preflight.
- **Blocked:** `/upload` (accepts `multipart/form-data`, a safelisted type that skips preflight — CSRF risk from localhost:80).
- **Blocked:** All `PUT`/`PATCH`/`DELETE` requests with portless origins.

## Security rationale

`application/json` is NOT a CORS-safelisted content type, so the browser always sends a preflight `OPTIONS` request for these POST endpoints. This means a malicious page on `localhost:80` cannot reach them via simple form submissions or `fetch()` with `mode: 'no-cors'`.

The `/upload` endpoint is deliberately excluded because it accepts `multipart/form-data` (safelisted), which would allow CSRF from a page on the default port.

## Test plan

- [x] `POST /api/test/connection` with `Origin: http://127.0.0.1` → 200/400 (reaches route, not blocked by CORS)
- [x] `POST /api/upload` with `Origin: http://127.0.0.1` → 403 (correctly blocked)
- [x] `GET /api/agents` with `Origin: http://127.0.0.1` → 200 (allowed)
- [x] `PUT /api/app-config` with `Origin: http://127.0.0.1` → 403 (blocked)
- [x] All endpoints with `Origin: http://127.0.0.1:<port>` → normal behavior