### PR TITLE
fix(web): unbreak Create button on plain HTTP / LAN-IP deployments (#849)

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -38,6 +38,7 @@ import {
   apiProtocolModelLabel,
 } from '../utils/apiProtocol';
 import { playSound, showCompletionNotification } from '../utils/notifications';
+import { randomUUID } from '../utils/uuid';
 import { DEFAULT_NOTIFICATIONS } from '../state/config';
 import type { TodoItem } from '../runtime/todos';
 import { appendErrorStatusEvent } from '../runtime/chat-events';
@@ -983,7 +984,7 @@ export function ProjectView({
       setError(null);
       const startedAt = Date.now();
       const userMsg: ChatMessage = {
-        id: crypto.randomUUID(),
+        id: randomUUID(),
         role: 'user',
         content: prompt,
         createdAt: startedAt,
@@ -1010,7 +1011,7 @@ export function ProjectView({
               selectedAgentChoice?.model,
             )
           : apiProtocolModelLabel(config.apiProtocol, config.model);
-      const assistantId = crypto.randomUUID();
+      const assistantId = randomUUID();
       const assistantMsg: ChatMessage = {
         id: assistantId,
         role: 'assistant',
@@ -1260,7 +1261,7 @@ export function ProjectView({
           projectId: project.id,
           conversationId: activeConversationId,
           assistantMessageId: assistantId,
-          clientRequestId: crypto.randomUUID(),
+          clientRequestId: randomUUID(),
           skillId: project.skillId ?? null,
           designSystemId: project.designSystemId ?? null,
           attachments: attachments.map((a) => a.path),

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -6,6 +6,7 @@
 // the UI can stay rendered when the daemon is briefly unreachable.
 
 import type { ImportFolderRequest, ImportFolderResponse } from '@open-design/contracts';
+import { randomUUID } from '../utils/uuid';
 import type {
   ChatMessage,
   Conversation,
@@ -45,7 +46,13 @@ export async function createProject(input: {
   metadata?: ProjectMetadata;
 }): Promise<{ project: Project; conversationId: string } | null> {
   try {
-    const id = crypto.randomUUID();
+    // `randomUUID` falls back to `crypto.getRandomValues` / `Math.random`
+    // when `crypto.randomUUID` is unavailable. Open Design served over
+    // plain HTTP on a LAN IP (Docker / unRAID self-hosting) is a
+    // non-secure context, where `crypto.randomUUID` is undefined and
+    // calling it directly throws — the surrounding try/catch then turns
+    // the Create button into a silent no-op (issue #849).
+    const id = randomUUID();
     const resp = await fetch('/api/projects', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/apps/web/src/utils/uuid.ts
+++ b/apps/web/src/utils/uuid.ts
@@ -1,0 +1,56 @@
+// Tiered v4-UUID generator that survives non-secure contexts.
+//
+// `crypto.randomUUID()` is restricted to secure contexts — HTTPS or
+// `localhost`. When Open Design is served over plain HTTP on a LAN
+// IP (the standard Docker / unRAID / NAS self-hosted setup, e.g.
+// `http://192.168.1.10:17573`), Chromium silently makes
+// `crypto.randomUUID` undefined. Calls then throw
+// `TypeError: crypto.randomUUID is not a function`, which the surrounding
+// try/catch in `state/projects.ts` swallows — the Create button
+// effectively becomes a no-op for every LAN-IP user (issue #849, also
+// reported as #394).
+//
+// Three-tier fallback, preferred in order:
+//
+//   1. `crypto.randomUUID()` — secure-context happy path. Native, fast,
+//      cryptographically random.
+//   2. `crypto.getRandomValues()` — available in non-secure contexts
+//      too (it's a separate API not gated by isSecureContext). Gives
+//      us a real RFC 4122 v4 UUID with crypto-quality entropy.
+//   3. `Math.random()` — last resort, only for environments without
+//      either Web Crypto API. The IDs we generate (project ids, message
+//      ids, client request ids) are scoped to a single user's local
+//      browser session, so cryptographic uniqueness isn't required —
+//      we just need enough entropy to avoid collisions in normal use.
+export function randomUUID(): string {
+  // Tier 1: native randomUUID where the spec lets us.
+  if (
+    typeof crypto !== 'undefined'
+    && typeof crypto.randomUUID === 'function'
+  ) {
+    return crypto.randomUUID();
+  }
+
+  // Tier 2: build a v4 UUID from `crypto.getRandomValues`. The byte
+  // layout follows RFC 4122 §4.4 — set the version (high nibble of
+  // byte 6) to 4 and the variant (high two bits of byte 8) to `10`.
+  if (
+    typeof crypto !== 'undefined'
+    && typeof crypto.getRandomValues === 'function'
+  ) {
+    const bytes = new Uint8Array(16);
+    crypto.getRandomValues(bytes);
+    bytes[6] = (bytes[6]! & 0x0f) | 0x40;
+    bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+    const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+  }
+
+  // Tier 3: Math.random fallback. Same template as the de-facto
+  // browser polyfill — replace `x` with a random hex nibble and `y`
+  // with one of `8`/`9`/`a`/`b` to satisfy the variant bits.
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16);
+  });
+}

--- a/apps/web/tests/utils/uuid.test.ts
+++ b/apps/web/tests/utils/uuid.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { randomUUID } from '../../src/utils/uuid';
+
+// RFC 4122 v4 format: 8-4-4-4-12 hex with version `4` (third group) and
+// variant `10xx` (first nibble of fourth group is 8/9/a/b).
+const V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe('randomUUID (issue #849)', () => {
+  const originalCrypto = globalThis.crypto;
+
+  afterEach(() => {
+    // vitest's jsdom env supplies a real `crypto` object — restore it
+    // after every test so later runs don't inherit the mocks.
+    Object.defineProperty(globalThis, 'crypto', {
+      value: originalCrypto,
+      configurable: true,
+      writable: true,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it('returns a v4 UUID under the secure-context happy path (tier 1)', () => {
+    // jsdom's crypto already has randomUUID — exercise the live path.
+    const uuid = randomUUID();
+    expect(uuid).toMatch(V4_RE);
+  });
+
+  it('delegates to crypto.randomUUID when available (tier 1)', () => {
+    const sentinel = '11111111-1111-4111-8111-111111111111';
+    Object.defineProperty(globalThis, 'crypto', {
+      value: {
+        randomUUID: () => sentinel,
+        // getRandomValues still present so a regression that flipped
+        // tier order would silently pass — the equality check below
+        // is what catches it.
+        getRandomValues: originalCrypto.getRandomValues.bind(originalCrypto),
+      },
+      configurable: true,
+      writable: true,
+    });
+    expect(randomUUID()).toBe(sentinel);
+  });
+
+  it('falls back to crypto.getRandomValues when randomUUID is missing (tier 2)', () => {
+    // Non-secure context shape: `crypto.randomUUID` is undefined but
+    // `crypto.getRandomValues` is still around. This is the exact LAN-IP
+    // / Docker self-hosting scenario the bug report describes.
+    Object.defineProperty(globalThis, 'crypto', {
+      value: {
+        randomUUID: undefined,
+        getRandomValues: originalCrypto.getRandomValues.bind(originalCrypto),
+      },
+      configurable: true,
+      writable: true,
+    });
+
+    const uuid = randomUUID();
+    expect(uuid).toMatch(V4_RE);
+    // A real RFC 4122 v4 UUID has the version nibble fixed at `4`
+    // (first char of group 3) and variant bits 10xx in the first
+    // nibble of group 4 (one of 8/9/a/b). The regex above checks
+    // both, but assert them explicitly so a future refactor that
+    // accidentally returns a v1/v3/v5 UUID under tier 2 fails with
+    // a more pointed error.
+    const [, , versionGroup, variantGroup] = uuid.split('-');
+    expect(versionGroup![0]).toBe('4');
+    expect(['8', '9', 'a', 'b']).toContain(variantGroup![0]!.toLowerCase());
+  });
+
+  it('falls back to Math.random when neither crypto API is available (tier 3)', () => {
+    // Strip crypto entirely. Real environments without Web Crypto are
+    // rare in 2026 (it's been baseline for years), but the helper has
+    // to keep behaving rather than throw — the IDs we produce are
+    // session-scoped and don't need crypto-quality entropy for that
+    // narrow fallback.
+    Object.defineProperty(globalThis, 'crypto', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+
+    const uuid = randomUUID();
+    expect(uuid).toMatch(V4_RE);
+  });
+
+  it('does not throw when crypto.randomUUID is missing (the #849 root cause)', () => {
+    // The original bug: calling `crypto.randomUUID()` directly in a
+    // non-secure context throws TypeError, the surrounding try/catch
+    // returns null, and the Create button silently no-ops. Pin that
+    // the helper never throws even when the native call would.
+    Object.defineProperty(globalThis, 'crypto', {
+      value: {
+        randomUUID: undefined,
+        getRandomValues: originalCrypto.getRandomValues.bind(originalCrypto),
+      },
+      configurable: true,
+      writable: true,
+    });
+    expect(() => randomUUID()).not.toThrow();
+  });
+
+  it('produces unique values across many calls under tier 2', () => {
+    Object.defineProperty(globalThis, 'crypto', {
+      value: {
+        randomUUID: undefined,
+        getRandomValues: originalCrypto.getRandomValues.bind(originalCrypto),
+      },
+      configurable: true,
+      writable: true,
+    });
+    const seen = new Set<string>();
+    for (let i = 0; i < 1000; i += 1) seen.add(randomUUID());
+    expect(seen.size).toBe(1000);
+  });
+});


### PR DESCRIPTION
## Summary

- `crypto.randomUUID()` is restricted to [secure contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) (HTTPS or `localhost`). When Open Design is served over plain HTTP on a LAN IP — the standard Docker / unRAID / NAS self-hosted setup, e.g. `http://192.168.1.10:17573` — Chromium silently makes the function undefined. Calls throw `TypeError: crypto.randomUUID is not a function`, which the `try/catch` around `createProject()` swallows by returning `null`, which the click handler reads as "no project, do nothing".
- Net effect: the **Create button is a silent no-op for every LAN-IP user**. Same root cause shows up across [#849](https://github.com/nexu-io/open-design/issues/849) (this PR) and [#394](https://github.com/nexu-io/open-design/issues/394).
- Fix: centralize UUID generation into a new `apps/web/src/utils/uuid.ts` helper with a 3-tier fallback (per @lefarcen's [review suggestion](https://github.com/nexu-io/open-design/issues/849#issuecomment-4404371657)), and route all four affected callsites through it.

Fixes #849. Same root cause as #394 — landing this should close that one too.

Big credit to @socratestherefore for the gold-standard root-cause writeup and proposed polyfill, and @lefarcen for the `getRandomValues` upgrade path that keeps the non-secure tier crypto-random.

## Three-tier fallback

| Tier | Path | When it fires |
|---|---|---|
| 1 | `crypto.randomUUID()` | Secure context (HTTPS or `localhost`). Native, fast, crypto-random. |
| 2 | `crypto.getRandomValues()` + RFC 4122 §4.4 byte layout | Non-secure context (the issue #849 LAN-IP case). The Web Crypto API itself isn't gated by `isSecureContext`, so `getRandomValues` is still there — gives us a real v4 UUID with crypto-quality entropy. |
| 3 | `Math.random()` | Environments missing both. Project / message / client-request ids are scoped to a single user's browser session — collision avoidance is enough; cryptographic uniqueness isn't required. |

## Diff shape

| File | What changes |
|---|---|
| `apps/web/src/utils/uuid.ts` | New helper. ~60 lines, standalone — no other imports beyond `globalThis.crypto`. |
| `apps/web/src/state/projects.ts` | Import the helper; replace `crypto.randomUUID()` at line 48 with `randomUUID()`. |
| `apps/web/src/components/ProjectView.tsx` | Import the helper; replace 3 `crypto.randomUUID()` callsites (user msg id, assistant msg id, client request id). |
| `apps/web/tests/utils/uuid.test.ts` | New: 6 tests covering tier 1 / tier 2 / tier 3 / format / "doesn't throw on missing randomUUID" / 1000-iteration uniqueness on tier 2. |

4 files, +184 / −4.

## Why a single helper instead of just polyfilling each callsite

Centralizing means:
- One place to evolve the fallback strategy if a new tier becomes preferred.
- Future callsites can `import { randomUUID } from '../utils/uuid'` and not re-litigate the secure-context question.
- Sweep test: `grep -rn "crypto.randomUUID" apps/web/src/` returns zero hits in app code after this PR (only the helper file's own implementation), which is the regression guard for "did anyone reintroduce a direct call".

## What's verified

| Check | Result |
|---|---|
| `pnpm --filter @open-design/web vitest` | **522/522** (was 516, +6) |
| `pnpm --filter @open-design/web typecheck` (`tsc -b --noEmit`) | clean |
| `tsx scripts/i18n-check.ts` | passes |
| `grep -rn "crypto.randomUUID" apps/web/src/` | only the helper's own implementation; zero direct callsites in app code |

## What's NOT verified

I don't have a Docker / LAN-IP self-hosted setup locally, so I haven't reproduced the original symptom end-to-end. The structural argument:

1. The 6 new unit tests stub `globalThis.crypto = { randomUUID: undefined, getRandomValues }` — the exact shape Chromium presents in non-secure contexts — and assert the helper still returns a valid v4 UUID without throwing. That's the literal #849 root cause being pinned.
2. Format validation uses an RFC 4122 v4 regex (`8-4-4-4-12` hex with version `4` and variant `10xx`) plus explicit version/variant nibble checks, so a future refactor that accidentally returns a v1/v3/v5 UUID under tier 2 fails with a pointed error.
3. 1000-iteration uniqueness check on tier 2 catches any entropy regression.

If @socratestherefore can pull this branch onto their unRAID Docker setup and confirm Create works over `http://<LAN-IP>`, that closes the loop end-to-end.

## Test plan

- [x] 6 new helper unit tests pass (tier 1 / tier 2 / tier 3 / format / no-throw / uniqueness).
- [x] Existing web test suite (522 tests) stays green.
- [x] Web typecheck + i18n-check clean.
- [x] No residual direct `crypto.randomUUID()` callsite in `apps/web/src/`.
- [ ] Manual smoke on plain-HTTP LAN-IP (e.g. Docker self-hosted): Create button creates a project and navigates, no silent failure.
- [ ] Manual smoke on localhost / HTTPS: no regression on the secure-context path (tier 1 still wins).

## Notes

- Cross-link: #394 reports the same root cause and was confirmed in that thread by multiple users. This fix should close it.
- Considered the alternative @socratestherefore mentioned (server-side UUID generation by making the daemon's POST id field optional). Stuck with the client-side polyfill because it's smaller scope, doesn't change the wire contract, and doesn't require backward-compat handling for clients that still send their own ids. Trade-off noted at the issue level — happy to iterate if a maintainer prefers the server-side approach.