### PR TITLE
fix(packaged): swallow harmless setTypeOfService EINVAL from undici (#895)

### DIFF
--- a/apps/packaged/src/logging.ts
+++ b/apps/packaged/src/logging.ts
@@ -38,27 +38,80 @@ function normalizeError(error: unknown): unknown {
  * still connects and serves traffic — so the right behaviour is to
  * log + ignore, not to crash.
  *
- * Match strategy is intentionally narrow: name the syscall (the
- * `setTypeOfService` literal), and verify the error code is the
- * expected `EINVAL`. We avoid swallowing every `EINVAL` because that
- * code is also raised by genuine bugs (bad config values, malformed
- * arguments to other syscalls). Exported so a unit test can pin the
- * exact shape this branch matches.
+ * Match strategy is intentionally narrow:
+ *   1. The error message must name the `setTypeOfService` syscall.
+ *   2. The structured `code` property is **authoritative** when
+ *      present: it must equal `EINVAL` for the error to qualify.
+ *      A `code` of anything else (e.g. `EACCES`) is treated as a
+ *      contradicting signal and the filter rejects the match —
+ *      otherwise an `EACCES` permission failure with a stale or
+ *      copy-pasted `EINVAL` substring in the message would slip
+ *      through.
+ *   3. Only when `code` is absent (some libuv builds don't populate
+ *      it on raw thrown Errors) do we fall back to looking for the
+ *      `EINVAL` token in the message.
+ *
+ * We never swallow every `EINVAL`: that code is raised by plenty of
+ * real bugs (bad config values, malformed arguments to other
+ * syscalls). Exported so a unit test can pin the exact shape this
+ * branch matches.
  */
 export function isHarmlessSocketOptionError(value: unknown): boolean {
   if (!(value instanceof Error)) return false;
   const message = typeof value.message === "string" ? value.message : "";
   if (!message) return false;
-  const code =
-    typeof (value as NodeJS.ErrnoException).code === "string"
-      ? (value as NodeJS.ErrnoException).code
-      : "";
-  // Primary shape: undici / Node socket initialiser. The error message
-  // string is constructed by libuv as `<syscall> <errcode>`.
-  if (message.includes("setTypeOfService") && (code === "EINVAL" || message.includes("EINVAL"))) {
-    return true;
+  if (!message.includes("setTypeOfService")) return false;
+  const code = (value as NodeJS.ErrnoException).code;
+  if (typeof code === "string" && code.length > 0) {
+    // Structured code present — it has to be EINVAL. Anything else
+    // (EACCES, EPERM, ECONNRESET, …) is a contradicting signal and
+    // we let it crash so real bugs don't get hidden.
+    return code === "EINVAL";
   }
-  return false;
+  // No structured code: fall back to message-based detection. The
+  // libuv error string is `<syscall> <errcode>` so the EINVAL token
+  // appears alongside the syscall name.
+  return message.includes("EINVAL");
+}
+
+/**
+ * Build the named `uncaughtException` handler used by
+ * `attachPackagedDesktopProcessLogging`. Exposed as its own factory
+ * so a unit test can drive it without bringing up the full logging
+ * pipeline.
+ *
+ * Behaviour contract (issue #906 review):
+ *   - Harmless `setTypeOfService EINVAL` shapes from undici socket
+ *     internals are logged at warn level and the function returns
+ *     silently. The process continues running.
+ *   - Anything else is logged at error level, then the handler
+ *     **removes itself from `process.uncaughtException` listeners**
+ *     and re-throws via `setImmediate`. Removing the listener first
+ *     is critical: without it, the re-throw re-enters the same
+ *     handler, schedules another setImmediate, and the packaged
+ *     main process spins forever instead of terminating —
+ *     reproduced and called out by mrcfps + lefarcen on the first
+ *     #906 review pass. With the listener gone the next throw has
+ *     no `uncaughtException` listener to land in, Node's default
+ *     crash path takes over, and Electron's native "JavaScript
+ *     error in main process" dialog renders as it did before this
+ *     code existed.
+ */
+export function createFatalUncaughtExceptionHandler(
+  logger: PackagedDesktopLogger,
+): (error: unknown) => void {
+  const handler = (error: unknown): void => {
+    if (isHarmlessSocketOptionError(error)) {
+      logger.warn("packaged desktop swallowed harmless socket option error", { error });
+      return;
+    }
+    logger.error("packaged desktop fatal uncaught exception", { error });
+    process.removeListener("uncaughtException", handler);
+    setImmediate(() => {
+      throw error;
+    });
+  };
+  return handler;
 }
 
 function normalizeMeta(meta: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
@@ -168,20 +221,15 @@ export function attachPackagedDesktopProcessLogging(options: {
   // error in main process" dialog the next time anything in the
   // renderer does a fetch (e.g. opening Settings → Pets → Community).
   //
-  // For unknown errors we re-throw via `setImmediate` so Node's
-  // default uncaughtException behaviour (process death + crash dialog)
-  // is preserved end-to-end. Adding the handler at all does not
-  // suppress that path — it only short-circuits the specific harmless
-  // shapes we recognise.
-  process.on("uncaughtException", (error) => {
-    if (isHarmlessSocketOptionError(error)) {
-      logger.warn("packaged desktop swallowed harmless socket option error", { error });
-      return;
-    }
-    setImmediate(() => {
-      throw error;
-    });
-  });
+  // For non-harmless errors the handler restores Node's default
+  // uncaughtException behaviour: it removes itself from the listener
+  // list and re-throws via `setImmediate`. With no `uncaughtException`
+  // handlers registered, Node's default crash path takes over (stack
+  // trace + non-zero exit) and Electron's own "JavaScript error in
+  // main process" dialog renders as it would have before this code
+  // existed. See `createFatalUncaughtExceptionHandler` for the
+  // unit-tested factory.
+  process.on("uncaughtException", createFatalUncaughtExceptionHandler(logger));
   process.on("unhandledRejection", (reason) => {
     if (isHarmlessSocketOptionError(reason)) {
       logger.warn("packaged desktop swallowed harmless socket option rejection", { reason });

--- a/apps/packaged/src/logging.ts
+++ b/apps/packaged/src/logging.ts
@@ -26,6 +26,41 @@ function normalizeError(error: unknown): unknown {
   return error;
 }
 
+/**
+ * Recognise known-harmless socket option errors so the packaged main
+ * process can swallow them instead of surfacing Electron's "JavaScript
+ * error in main process" dialog (issue #895).
+ *
+ * The flagship case is undici throwing `setTypeOfService EINVAL` from
+ * its socket setup path: certain macOS / VPN configurations refuse to
+ * let the kernel set the IP_TOS byte on outbound sockets. The QoS
+ * marking failing has no functional impact on the request — the socket
+ * still connects and serves traffic — so the right behaviour is to
+ * log + ignore, not to crash.
+ *
+ * Match strategy is intentionally narrow: name the syscall (the
+ * `setTypeOfService` literal), and verify the error code is the
+ * expected `EINVAL`. We avoid swallowing every `EINVAL` because that
+ * code is also raised by genuine bugs (bad config values, malformed
+ * arguments to other syscalls). Exported so a unit test can pin the
+ * exact shape this branch matches.
+ */
+export function isHarmlessSocketOptionError(value: unknown): boolean {
+  if (!(value instanceof Error)) return false;
+  const message = typeof value.message === "string" ? value.message : "";
+  if (!message) return false;
+  const code =
+    typeof (value as NodeJS.ErrnoException).code === "string"
+      ? (value as NodeJS.ErrnoException).code
+      : "";
+  // Primary shape: undici / Node socket initialiser. The error message
+  // string is constructed by libuv as `<syscall> <errcode>`.
+  if (message.includes("setTypeOfService") && (code === "EINVAL" || message.includes("EINVAL"))) {
+    return true;
+  }
+  return false;
+}
+
 function normalizeMeta(meta: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
   if (meta == null) return undefined;
   return Object.fromEntries(
@@ -123,7 +158,35 @@ export function attachPackagedDesktopProcessLogging(options: {
   process.on("uncaughtExceptionMonitor", (error) => {
     logger.error("packaged desktop uncaught exception", { error });
   });
+  // Defensive filter for known-harmless network errors. undici can throw
+  // `setTypeOfService EINVAL` from socket internals on certain macOS /
+  // VPN configurations (issue #895): the kernel rejects setting the
+  // IP_TOS byte on the outbound socket, but the connection itself is
+  // healthy — we just don't get the QoS / DSCP marking, which the app
+  // doesn't depend on. Without this filter the rejection bubbles to
+  // Electron's default handler and surfaces as a native "JavaScript
+  // error in main process" dialog the next time anything in the
+  // renderer does a fetch (e.g. opening Settings → Pets → Community).
+  //
+  // For unknown errors we re-throw via `setImmediate` so Node's
+  // default uncaughtException behaviour (process death + crash dialog)
+  // is preserved end-to-end. Adding the handler at all does not
+  // suppress that path — it only short-circuits the specific harmless
+  // shapes we recognise.
+  process.on("uncaughtException", (error) => {
+    if (isHarmlessSocketOptionError(error)) {
+      logger.warn("packaged desktop swallowed harmless socket option error", { error });
+      return;
+    }
+    setImmediate(() => {
+      throw error;
+    });
+  });
   process.on("unhandledRejection", (reason) => {
+    if (isHarmlessSocketOptionError(reason)) {
+      logger.warn("packaged desktop swallowed harmless socket option rejection", { reason });
+      return;
+    }
     logger.error("packaged desktop unhandled rejection", { reason });
   });
   process.on("beforeExit", (code) => {

--- a/apps/packaged/src/protocol.ts
+++ b/apps/packaged/src/protocol.ts
@@ -25,13 +25,63 @@ function toWebRuntimeUrl(webRuntimeUrl: string, requestUrl: string): string {
   return target.toString();
 }
 
+function buildProxyErrorResponse(error: unknown, target: string): Response {
+  const message = error instanceof Error ? error.message : String(error);
+  const code =
+    error instanceof Error && typeof (error as NodeJS.ErrnoException).code === "string"
+      ? (error as NodeJS.ErrnoException).code
+      : null;
+  return new Response(
+    JSON.stringify({
+      error: "OD_PROTOCOL_PROXY_FAILED",
+      message,
+      ...(code === null ? {} : { code }),
+      target,
+    }),
+    {
+      status: 502,
+      headers: { "content-type": "application/json" },
+    },
+  );
+}
+
+/**
+ * Inner request handler for the `od://` Electron protocol — every
+ * renderer fetch flows through here and gets proxied to the local web
+ * sidecar via Node's global `fetch` (which is undici under the hood).
+ *
+ * Pulled out as a named export so unit tests can drive it with a stub
+ * `fetchImpl` without spinning up Electron, and so the try/catch
+ * stays auditable from one place.
+ *
+ * Why the try/catch matters: undici can throw `setTypeOfService
+ * EINVAL` from socket internals on certain macOS / VPN configurations
+ * (issue #895). Without the catch, the rejection bubbles all the way
+ * up to the Electron main process and surfaces as a native
+ * "JavaScript error in main process" dialog the next time the user
+ * does anything that triggers a renderer-to-sidecar fetch (e.g.
+ * Settings → Pets → Community). Returning a 502 instead lets the
+ * renderer see a normal failure and keeps the process alive.
+ */
+export async function handleOdRequest(
+  request: Request,
+  webRuntimeUrl: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Response> {
+  const target = toWebRuntimeUrl(webRuntimeUrl, request.url);
+  try {
+    return await fetchImpl(new Request(target, request));
+  } catch (error) {
+    return buildProxyErrorResponse(error, target);
+  }
+}
+
 export function packagedEntryUrl(): string {
   return OD_ENTRY_URL;
 }
 
 export function registerOdProtocol(webRuntimeUrl: string): void {
   protocol.handle(OD_SCHEME, async (request) => {
-    const target = toWebRuntimeUrl(webRuntimeUrl, request.url);
-    return await fetch(new Request(target, request));
+    return await handleOdRequest(request, webRuntimeUrl);
   });
 }

--- a/apps/packaged/tests/logging.test.ts
+++ b/apps/packaged/tests/logging.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Regression coverage for the harmless-socket-option filter the
+ * packaged Electron entry uses to swallow `setTypeOfService EINVAL`
+ * undici crashes (issue #895). Without the filter, those errors
+ * surface as native "JavaScript error in main process" dialogs the
+ * moment a renderer fetch hits the affected socket option setter on
+ * macOS / VPN configurations that don't allow IP_TOS marking.
+ *
+ * Match strategy is intentionally narrow — name the syscall AND
+ * verify the EINVAL code — so a future regression that broadens the
+ * filter to "every EINVAL" (which would silently swallow real bugs)
+ * trips a test.
+ *
+ * @see https://github.com/nexu-io/open-design/issues/895
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { isHarmlessSocketOptionError } from '../src/logging.js';
+
+describe('isHarmlessSocketOptionError (issue #895)', () => {
+  it('matches the canonical undici setTypeOfService EINVAL shape', () => {
+    const error = new Error('setTypeOfService EINVAL') as NodeJS.ErrnoException;
+    error.code = 'EINVAL';
+    error.syscall = 'setTypeOfService';
+    expect(isHarmlessSocketOptionError(error)).toBe(true);
+  });
+
+  it('matches when only the message has both tokens (no code property set)', () => {
+    // Some libuv builds surface the error without populating the
+    // `code` property — the message string itself is the sole signal.
+    const error = new Error('setTypeOfService EINVAL');
+    expect(isHarmlessSocketOptionError(error)).toBe(true);
+  });
+
+  it('matches when code is EINVAL and message references setTypeOfService', () => {
+    const error = new Error('Error: setTypeOfService failed') as NodeJS.ErrnoException;
+    error.code = 'EINVAL';
+    expect(isHarmlessSocketOptionError(error)).toBe(true);
+  });
+
+  it('does NOT match a generic EINVAL — that code is also raised by real bugs', () => {
+    // Guard against a future refactor that broadens the filter to
+    // "every EINVAL" and silently swallows configuration errors.
+    const error = new Error('write EINVAL') as NodeJS.ErrnoException;
+    error.code = 'EINVAL';
+    expect(isHarmlessSocketOptionError(error)).toBe(false);
+  });
+
+  it('does NOT match a setTypeOfService error with a different errno (e.g. EACCES)', () => {
+    const error = new Error('setTypeOfService EACCES') as NodeJS.ErrnoException;
+    error.code = 'EACCES';
+    expect(isHarmlessSocketOptionError(error)).toBe(false);
+  });
+
+  it('does NOT match unrelated errors with similar shape', () => {
+    const error = new Error('something happened');
+    expect(isHarmlessSocketOptionError(error)).toBe(false);
+  });
+
+  it('does NOT match non-Error rejection values (preserves fail-fast for primitives)', () => {
+    expect(isHarmlessSocketOptionError('setTypeOfService EINVAL')).toBe(false);
+    expect(isHarmlessSocketOptionError(null)).toBe(false);
+    expect(isHarmlessSocketOptionError(undefined)).toBe(false);
+    expect(isHarmlessSocketOptionError({ message: 'setTypeOfService EINVAL' })).toBe(false);
+  });
+
+  it('does NOT match Error with empty message even if code is EINVAL', () => {
+    const error = new Error('') as NodeJS.ErrnoException;
+    error.code = 'EINVAL';
+    expect(isHarmlessSocketOptionError(error)).toBe(false);
+  });
+});

--- a/apps/packaged/tests/logging.test.ts
+++ b/apps/packaged/tests/logging.test.ts
@@ -14,9 +14,25 @@
  * @see https://github.com/nexu-io/open-design/issues/895
  */
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { isHarmlessSocketOptionError } from '../src/logging.js';
+import {
+  createFatalUncaughtExceptionHandler,
+  isHarmlessSocketOptionError,
+  type PackagedDesktopLogger,
+} from '../src/logging.js';
+
+function stubLogger(): PackagedDesktopLogger {
+  return {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('isHarmlessSocketOptionError (issue #895)', () => {
   it('matches the canonical undici setTypeOfService EINVAL shape', () => {
@@ -53,6 +69,24 @@ describe('isHarmlessSocketOptionError (issue #895)', () => {
     expect(isHarmlessSocketOptionError(error)).toBe(false);
   });
 
+  // #906 review (lefarcen P2): the structured `code` property must be
+  // authoritative when present. Without this guard a contradicting
+  // EACCES code paired with a message containing both `setTypeOfService`
+  // and `EINVAL` (a stale token, copy-pasted shape, or future libuv
+  // formatting change) would slip through and silently swallow a real
+  // permissions failure.
+  it('does NOT match when code contradicts the message — code is authoritative (#906 review)', () => {
+    const error = new Error('setTypeOfService EINVAL') as NodeJS.ErrnoException;
+    error.code = 'EACCES';
+    expect(isHarmlessSocketOptionError(error)).toBe(false);
+  });
+
+  it('does NOT match when code is a different errno but message has both tokens (defence-in-depth)', () => {
+    const error = new Error('setTypeOfService EINVAL — extra context') as NodeJS.ErrnoException;
+    error.code = 'EPERM';
+    expect(isHarmlessSocketOptionError(error)).toBe(false);
+  });
+
   it('does NOT match unrelated errors with similar shape', () => {
     const error = new Error('something happened');
     expect(isHarmlessSocketOptionError(error)).toBe(false);
@@ -69,5 +103,93 @@ describe('isHarmlessSocketOptionError (issue #895)', () => {
     const error = new Error('') as NodeJS.ErrnoException;
     error.code = 'EINVAL';
     expect(isHarmlessSocketOptionError(error)).toBe(false);
+  });
+});
+
+// Regression coverage for the #906 review (mrcfps + lefarcen):
+// the non-harmless branch must NOT re-enter itself when it re-throws.
+// Without the explicit `process.removeListener` call, the rethrown
+// error landed back in this same listener, scheduled another
+// `setImmediate`, and the packaged main process span forever instead
+// of terminating. The factory exposes the named handler so we can
+// assert the listener-removal step in isolation.
+describe('createFatalUncaughtExceptionHandler (issue #906)', () => {
+  it('logs harmless socket option errors at warn level and returns silently', () => {
+    const logger = stubLogger();
+    const handler = createFatalUncaughtExceptionHandler(logger);
+    const harmless = new Error('setTypeOfService EINVAL') as NodeJS.ErrnoException;
+    harmless.code = 'EINVAL';
+
+    const removeListenerSpy = vi.spyOn(process, 'removeListener');
+    const setImmediateSpy = vi.spyOn(globalThis, 'setImmediate');
+
+    handler(harmless);
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.error).not.toHaveBeenCalled();
+    // Critical: the harmless branch must not deregister or schedule
+    // anything — the process must keep running normally.
+    expect(removeListenerSpy).not.toHaveBeenCalled();
+    expect(setImmediateSpy).not.toHaveBeenCalled();
+  });
+
+  it('removes itself from uncaughtException listeners before scheduling the rethrow (#906 P1)', () => {
+    const logger = stubLogger();
+    const handler = createFatalUncaughtExceptionHandler(logger);
+
+    const removeListenerSpy = vi.spyOn(process, 'removeListener');
+    // Stub setImmediate to capture the scheduled callback without
+    // actually firing it (which would dump the rethrown error onto
+    // vitest's own uncaughtException path).
+    const scheduled: Array<() => void> = [];
+    const setImmediateSpy = vi
+      .spyOn(globalThis, 'setImmediate')
+      .mockImplementation(((fn: () => void) => {
+        scheduled.push(fn);
+        return 0 as unknown as NodeJS.Immediate;
+      }) as typeof setImmediate);
+
+    const realBug = new Error('something genuinely broke');
+    handler(realBug);
+
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    // The actual #906 P1 fix: handler unregisters itself BEFORE the
+    // rethrow is scheduled. Mirrors mrcfps's reproduction script.
+    expect(removeListenerSpy).toHaveBeenCalledWith('uncaughtException', handler);
+    const removeListenerOrder = removeListenerSpy.mock.invocationCallOrder[0]!;
+    const setImmediateOrder = setImmediateSpy.mock.invocationCallOrder[0]!;
+    expect(removeListenerOrder).toBeLessThan(setImmediateOrder);
+
+    // The scheduled callback rethrows the original error so Node's
+    // default uncaughtException path picks it up after the listener
+    // is gone.
+    expect(scheduled).toHaveLength(1);
+    expect(() => scheduled[0]!()).toThrow(realBug);
+  });
+
+  it('does NOT re-enter itself when invoked twice with non-harmless errors (loop guard)', () => {
+    // Belt-and-suspenders: even if a future refactor accidentally
+    // forgot the removeListener call, this test would catch the
+    // recursion the original review reproduced.
+    const logger = stubLogger();
+    const handler = createFatalUncaughtExceptionHandler(logger);
+
+    const setImmediateCallCount: number[] = [];
+    vi.spyOn(globalThis, 'setImmediate').mockImplementation(((fn: () => void) => {
+      setImmediateCallCount.push(setImmediateCallCount.length);
+      // Crucially do NOT actually call fn() — that would test the
+      // recursion path through Node's process.emit, which is what
+      // we're trying to break out of.
+      void fn;
+      return 0 as unknown as NodeJS.Immediate;
+    }) as typeof setImmediate);
+
+    handler(new Error('first'));
+    handler(new Error('second'));
+
+    // Each invocation schedules exactly one rethrow. If the handler
+    // re-entered itself we'd see runaway scheduling.
+    expect(setImmediateCallCount).toHaveLength(2);
+    expect(logger.error).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/packaged/tests/protocol.test.ts
+++ b/apps/packaged/tests/protocol.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Regression coverage for the `od://` protocol proxy in
+ * apps/packaged/src/protocol.ts.
+ *
+ * The packaged Electron entry registers `od://` as the loader for the
+ * web runtime and forwards every renderer request to the local web
+ * sidecar through Node's global `fetch` (which is undici under the
+ * hood). Without a try/catch in the handler, undici throwing
+ * `setTypeOfService EINVAL` from socket internals on certain macOS /
+ * VPN configurations bubbled up to Electron's default uncaught
+ * exception handler — surfacing as a native "JavaScript error in
+ * main process" dialog the moment the user did anything that
+ * triggered a fetch (e.g. Settings → Pets → Community).
+ *
+ * @see https://github.com/nexu-io/open-design/issues/895
+ */
+
+// `protocol.handle` from the `electron` module is invoked at import
+// time inside `apps/packaged/src/protocol.ts`. Stub the module before
+// importing so the test environment doesn't need a real Electron
+// runtime.
+import { vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  protocol: {
+    registerSchemesAsPrivileged: vi.fn(),
+    handle: vi.fn(),
+  },
+}));
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { handleOdRequest } from '../src/protocol.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('od:// protocol proxy', () => {
+  it('proxies the request through fetchImpl with the rewritten target URL', async () => {
+    const captured: Request[] = [];
+    const fetchImpl: typeof fetch = async (input) => {
+      captured.push(input as Request);
+      return new Response('ok', { status: 200 });
+    };
+
+    const request = new Request('od://app/api/codex-pets/sync', { method: 'POST' });
+    const response = await handleOdRequest(request, 'http://127.0.0.1:17579/', fetchImpl);
+
+    expect(response.status).toBe(200);
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.url).toBe('http://127.0.0.1:17579/api/codex-pets/sync');
+    expect(captured[0]!.method).toBe('POST');
+  });
+
+  it('preserves the request path, search, and hash when rewriting to the web sidecar', async () => {
+    const captured: Request[] = [];
+    const fetchImpl: typeof fetch = async (input) => {
+      captured.push(input as Request);
+      return new Response('', { status: 204 });
+    };
+
+    const request = new Request('od://app/api/projects?limit=5#section', { method: 'GET' });
+    await handleOdRequest(request, 'http://127.0.0.1:42424/', fetchImpl);
+
+    const target = new URL(captured[0]!.url);
+    expect(target.host).toBe('127.0.0.1:42424');
+    expect(target.pathname).toBe('/api/projects');
+    expect(target.search).toBe('?limit=5');
+    // `Request` strips the hash fragment per the Fetch spec, but the
+    // pathname + search above are the values the proxy is responsible
+    // for getting right. Pin those.
+  });
+
+  // The flagship #895 regression: undici can throw `setTypeOfService
+  // EINVAL` mid-fetch from socket internals. Without the try/catch
+  // wrapper around the handler's fetch call, that rejection propagates
+  // up to Electron's default uncaught exception handler and surfaces
+  // as a native "JavaScript error in main process" dialog. The
+  // handler must instead return a 502 Response so the renderer sees
+  // a normal failure and the process keeps running.
+  it('returns a 502 Response when the underlying fetch rejects (issue #895)', async () => {
+    const fetchImpl: typeof fetch = async () => {
+      const error = new Error('setTypeOfService EINVAL') as NodeJS.ErrnoException;
+      error.code = 'EINVAL';
+      error.syscall = 'setTypeOfService';
+      throw error;
+    };
+
+    const request = new Request('od://app/api/codex-pets/sync', { method: 'POST' });
+    const response = await handleOdRequest(request, 'http://127.0.0.1:17579/', fetchImpl);
+
+    expect(response.status).toBe(502);
+    const body = (await response.json()) as {
+      error: string;
+      message: string;
+      code?: string;
+      target: string;
+    };
+    expect(body.error).toBe('OD_PROTOCOL_PROXY_FAILED');
+    expect(body.message).toContain('setTypeOfService');
+    expect(body.code).toBe('EINVAL');
+    expect(body.target).toBe('http://127.0.0.1:17579/api/codex-pets/sync');
+  });
+
+  it('does not throw when fetch rejects (the actual #895 root-cause guard)', async () => {
+    const fetchImpl: typeof fetch = async () => {
+      throw new Error('socket hang up');
+    };
+
+    // The promise must resolve with a Response, never reject.
+    await expect(
+      handleOdRequest(new Request('od://app/'), 'http://127.0.0.1:1/', fetchImpl),
+    ).resolves.toBeInstanceOf(Response);
+  });
+
+  it('handles non-Error rejection values without throwing', async () => {
+    const fetchImpl: typeof fetch = async () => {
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
+      throw 'sync timeout';
+    };
+
+    const response = await handleOdRequest(
+      new Request('od://app/api/probe'),
+      'http://127.0.0.1:1/',
+      fetchImpl,
+    );
+    expect(response.status).toBe(502);
+    const body = (await response.json()) as { message: string };
+    expect(body.message).toBe('sync timeout');
+  });
+});


### PR DESCRIPTION
## Summary

- Opening Settings → Pets → Community in the packaged desktop app surfaces a native **"JavaScript error in main process"** dialog with `Uncaught Exception: Error: setTypeOfService EINVAL`. Root cause: undici's socket setup tries to set the IP_TOS byte (QoS / DSCP marking) on outbound sockets, and the macOS kernel refuses with `EINVAL` on some configurations (VPNs, IPv6-only sockets, certain firewall postures). The byte is purely advisory — the socket itself is healthy — so the rejection should not crash the app.
- The flow that triggers it isn't actually Pets-specific. Every renderer page load and API call in the packaged build flows through the `od://` Electron protocol handler in [`apps/packaged/src/protocol.ts`](https://github.com/nexu-io/open-design/blob/main/apps/packaged/src/protocol.ts), which forwards via Node's global `fetch` (undici under the hood). Pets > Community happens to be the page that surfaces it for #895's reporter, but anything that fetches could trip it.
- Two cooperating defensive layers:
  - **Layer 1 — `protocol.ts`**: extract the inner handler as `handleOdRequest()` (testable) and wrap the `await fetch()` in a try/catch that returns a 502 Response on failure. Without this, every undici rejection — not just `setTypeOfService` — escapes to Electron's default uncaught-exception path. Now the renderer sees a normal error response and the main process keeps running.
  - **Layer 2 — `logging.ts`**: add a `process.on('uncaughtException')` handler with a narrow `isHarmlessSocketOptionError()` filter that matches the canonical undici shape only (message contains `setTypeOfService` AND code is `EINVAL` or message contains `EINVAL`). Anything unrecognised re-throws via `setImmediate` so Node's default crash + Electron's crash dialog still fire end-to-end for real bugs.

Fixes #895.

## Why two layers

| Layer | Catches | Why we need it |
|---|---|---|
| `protocol.ts` try/catch | undici rejections that propagate as a rejected `fetch()` promise | The common case — once the socket setup throws, the promise rejects, `await` re-throws, our catch converts to a 502. Already enough to fix the reported scenario. |
| `logging.ts` uncaughtException filter | undici/socket errors that escape promise rejection (e.g. errors fired from socket-level callbacks that don't have a Promise to wire into) | Defence in depth. Without it, any future undici code path that emits the error out-of-band would still crash the main process. The filter is intentionally narrow — see negative tests below. |

## Negative guard against over-broad swallowing

The filter at `logging.ts:isHarmlessSocketOptionError` matches **only** the canonical undici shape. Tests explicitly assert it does NOT match:

- `write EINVAL` (a generic EINVAL — also raised by real bugs)
- `setTypeOfService EACCES` (a setTypeOfService failure with a different errno — could indicate a real permissions issue worth investigating)
- Non-`Error` rejection values (preserves fail-fast for primitive rejections)
- An `Error` with empty message even when `code === 'EINVAL'`

A future regression that broadens the filter to "every EINVAL" would trip these tests.

## Diff shape

| File | What changes |
|---|---|
| `apps/packaged/src/protocol.ts` | Pull inner handler out as `handleOdRequest()`, accept an optional `fetchImpl` for tests, wrap fetch in try/catch, build a 502 Response with structured error body on failure. |
| `apps/packaged/src/logging.ts` | Add `isHarmlessSocketOptionError()` (exported for tests) and a `process.on('uncaughtException')` handler that uses it. Existing `uncaughtExceptionMonitor` log call kept intact. `unhandledRejection` also gains the filter for symmetry. |
| `apps/packaged/tests/protocol.test.ts` | New: 5 tests — happy path proxy, URL rewriting preserves path/search, **fetch rejecting with the canonical EINVAL shape returns a 502 (the #895 regression guard)**, never-throw guarantee, non-Error rejection handling. |
| `apps/packaged/tests/logging.test.ts` | New: 8 tests — canonical match, message-only / code-only variants, **negative guard against generic EINVAL**, negative guard against setTypeOfService with a non-EINVAL errno, primitive rejections, empty-message Errors. |

4 files, +320 / −2.

## What's verified

| Check | Result |
|---|---|
| `pnpm --filter @open-design/packaged vitest tests/protocol.test.ts tests/logging.test.ts` | **13/13** |
| packaged `tsc -p tsconfig.json --noEmit` | clean |
| packaged `tsc -p tsconfig.tests.json --noEmit` (the CI killer) | clean |

There is one pre-existing failure in `tests/sidecars.test.ts` (`adds custom VP_HOME/bin to the packaged PATH builder`) that is unrelated to this PR — confirmed by stashing the change and re-running on the bare branch base. Not in scope to fix here.

## What's NOT verified

I don't have a macOS / VPN configuration locally that reproduces the original `setTypeOfService EINVAL`. The structural argument:

1. The handler-side test stubs the exact undici error shape (`Error('setTypeOfService EINVAL')` with `code: 'EINVAL'`, `syscall: 'setTypeOfService'`) and asserts the protocol handler returns a 502 Response instead of throwing.
2. The filter-side tests pin both the positive match (canonical shape) and the negative guards (generic EINVAL, different syscall, non-Error rejections), so a future contributor can't accidentally regress either direction.
3. If the affected user (cc the #895 reporter) can pull this branch in a packaged build and confirm the dialog no longer appears, that closes the loop end-to-end.

## Test plan

- [x] 13 new tests pass (5 protocol + 8 logging).
- [x] Both packaged typecheck configs clean.
- [x] No new failures introduced (pre-existing `sidecars.test.ts` flake noted but out of scope).
- [ ] Manual smoke on packaged build with the affected configuration: open Settings → Pets → Community and observe no native error dialog. Renderer should see a normal "Pets community feed unavailable" error if the underlying network actually is broken — never a main-process crash.
- [ ] Manual smoke on a healthy macOS / Linux: no regression on the `od://` proxy happy path; the web app continues to load and API calls flow normally.

## Notes

- `od://` scheme handler is the central network-proxy hop in the packaged build. Hardening it has the side benefit of making *every* renderer fetch failure gracefully degrade — not just the `setTypeOfService EINVAL` case the issue reports. Future undici / socket / DNS errors that would have crashed main now surface as 502s the renderer can handle.
- Did not bump up to a global per-process Electron crash handler; the targeted filter is enough for the reported scenario and keeps fail-fast for unknown errors.