### PR TITLE
fix(desktop): allow od:// URLs in setWindowOpenHandler so live artifact previews open in child window (#911)

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -27,6 +27,13 @@ import { readProcessStamp } from "@open-design/platform";
 
 import { createDesktopRuntime } from "./runtime.js";
 
+// Re-export pure URL-policy helpers so the packaged workspace's
+// vitest can pin their behaviour without spinning up a full Electron
+// runtime. They are part of the security boundary for child-window
+// navigation (see `setWindowOpenHandler` in `runtime.ts`), so
+// pinning them is worth the small extra surface.
+export { isAllowedChildWindowUrl, isHttpUrl } from "./runtime.js";
+
 const TOOLS_DEV_PARENT_PID_ENV = SIDECAR_ENV.TOOLS_DEV_PARENT_PID;
 
 export type DesktopMainOptions = {

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -182,7 +182,11 @@ async function applyWindowChromeCss(window: BrowserWindow): Promise<void> {
   await window.webContents.insertCSS(MAC_WINDOW_CHROME_CSS, { cssOrigin: "user" });
 }
 
-function isHttpUrl(url: string): boolean {
+// Exported for unit tests in `apps/packaged/tests/desktop-url-allowlist.test.ts`
+// — these are pure URL-policy helpers and `apps/desktop` itself has no
+// vitest setup, so the packaged workspace hosts the coverage. Keep them
+// pure and side-effect-free.
+export function isHttpUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
     return parsed.protocol === "http:" || parsed.protocol === "https:";
@@ -191,10 +195,24 @@ function isHttpUrl(url: string): boolean {
   }
 }
 
-function isAllowedChildWindowUrl(url: string): boolean {
+export function isAllowedChildWindowUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
-    return parsed.protocol === "blob:";
+    // `blob:` covers in-renderer generated downloads / object URLs.
+    // `od:` is the packaged Electron entry's privileged scheme
+    // registered by `apps/packaged/src/protocol.ts` and proxied to the
+    // local web sidecar. Without this branch, any in-app
+    // `<a target="_blank" href="/api/...">` resolves to `od://app/...`
+    // in packaged builds, falls through `setWindowOpenHandler` to
+    // `{ action: "deny" }`, and the click is silently dropped — that
+    // was the Orbit "Open artifact" no-op reported in #911. Allowing
+    // `od:` here lets Electron open the link in a child BrowserWindow
+    // that inherits the same protocol registration + preload, so the
+    // live artifact preview renders normally. Dev mode is unaffected:
+    // its links resolve to `http://127.0.0.1:.../...`, which is gated
+    // by the separate `isHttpUrl` branch and continues to open in the
+    // user's external browser via `shell.openExternal`.
+    return parsed.protocol === "blob:" || parsed.protocol === "od:";
   } catch {
     return false;
   }

--- a/apps/packaged/tests/desktop-url-allowlist.test.ts
+++ b/apps/packaged/tests/desktop-url-allowlist.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Regression coverage for the URL-policy helpers re-exported from
+ * `@open-design/desktop/main`. The helpers are part of the security
+ * boundary for child-window navigation (see `setWindowOpenHandler`
+ * in `apps/desktop/src/main/runtime.ts`); the packaged workspace
+ * hosts the test because `apps/desktop` itself has no vitest setup
+ * yet — adding one is more scope than #911 needs.
+ *
+ * @see https://github.com/nexu-io/open-design/issues/911
+ */
+
+// Mock electron at import time — `runtime.ts` pulls `BrowserWindow`,
+// `dialog`, `ipcMain`, and `shell` from it at top level. None of those
+// surfaces are exercised by the pure URL helpers we want to test, so a
+// minimal stub is enough to keep the import clean in a non-Electron
+// vitest environment.
+import { vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  BrowserWindow: class {},
+  dialog: { showOpenDialog: vi.fn() },
+  ipcMain: { handle: vi.fn(), removeHandler: vi.fn() },
+  shell: { openExternal: vi.fn() },
+  app: { whenReady: vi.fn() },
+}));
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  isAllowedChildWindowUrl,
+  isHttpUrl,
+} from '@open-design/desktop/main';
+
+describe('isHttpUrl', () => {
+  it('matches http and https protocols', () => {
+    expect(isHttpUrl('http://127.0.0.1:1234/api/x')).toBe(true);
+    expect(isHttpUrl('https://example.com')).toBe(true);
+  });
+
+  it('rejects non-http schemes', () => {
+    expect(isHttpUrl('od://app/foo')).toBe(false);
+    expect(isHttpUrl('file:///etc/passwd')).toBe(false);
+    expect(isHttpUrl('blob:http://x/abc')).toBe(false);
+    expect(isHttpUrl('javascript:alert(1)')).toBe(false);
+    expect(isHttpUrl('data:text/html,foo')).toBe(false);
+  });
+
+  it('rejects malformed URLs', () => {
+    expect(isHttpUrl('not a url')).toBe(false);
+    expect(isHttpUrl('')).toBe(false);
+  });
+});
+
+describe('isAllowedChildWindowUrl (issue #911)', () => {
+  it('allows the packaged od:// scheme so live artifact previews open in a child BrowserWindow', () => {
+    // The flagship #911 case: the Orbit panel's "Open artifact"
+    // button is an `<a target="_blank" href="/api/live-artifacts/.../preview?projectId=...">`.
+    // In packaged builds the renderer lives at `od://app/`, so that
+    // relative href resolves to `od://app/api/live-artifacts/.../preview?projectId=...`
+    // by the time `setWindowOpenHandler` sees it.
+    expect(isAllowedChildWindowUrl('od://app/api/live-artifacts/abc/preview?projectId=p1')).toBe(true);
+    expect(isAllowedChildWindowUrl('od://app/')).toBe(true);
+  });
+
+  it('continues to allow blob: URLs (existing behaviour)', () => {
+    // In-renderer generated downloads / object URLs need a child
+    // window so the user can land on the file. Pinned to guard
+    // against an accidental regression that drops this case.
+    expect(isAllowedChildWindowUrl('blob:http://127.0.0.1:1234/abc-uuid')).toBe(true);
+  });
+
+  it('does NOT allow http(s) URLs — those route to shell.openExternal in the same handler', () => {
+    // The `setWindowOpenHandler` body checks `isHttpUrl` separately
+    // and opens those in the user's default browser instead of a
+    // child window. Routing http:// through the child-window allow
+    // path would pop a stripped-down BrowserWindow with no app
+    // chrome, which is worse than `shell.openExternal`.
+    expect(isAllowedChildWindowUrl('http://example.com')).toBe(false);
+    expect(isAllowedChildWindowUrl('https://example.com')).toBe(false);
+    expect(isAllowedChildWindowUrl('http://127.0.0.1:17579/api/foo')).toBe(false);
+  });
+
+  it('does NOT allow potentially dangerous schemes', () => {
+    // Security boundary: keep the allowlist narrow. `file://` could
+    // be used to pop OS-level files, `javascript:` is an execution
+    // vector, `data:` lets attackers craft inline pages.
+    expect(isAllowedChildWindowUrl('file:///etc/passwd')).toBe(false);
+    expect(isAllowedChildWindowUrl('javascript:alert(1)')).toBe(false);
+    expect(isAllowedChildWindowUrl('data:text/html,<script>alert(1)</script>')).toBe(false);
+  });
+
+  it('returns false for malformed URLs without throwing', () => {
+    expect(isAllowedChildWindowUrl('not a url')).toBe(false);
+    expect(isAllowedChildWindowUrl('')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- The Orbit panel's "Open artifact" button is an `<a target="_blank" href="/api/live-artifacts/.../preview?projectId=...">` rendered by [`apps/web/src/components/SettingsDialog.tsx:3274`](https://github.com/nexu-io/open-design/blob/main/apps/web/src/components/SettingsDialog.tsx#L3274). In **packaged Electron builds** the renderer lives at `od://app/`, so that relative `href` resolves to `od://app/api/live-artifacts/.../preview?projectId=...` by the time `setWindowOpenHandler` sees it.
- The existing handler in [`apps/desktop/src/main/runtime.ts:300`](https://github.com/nexu-io/open-design/blob/main/apps/desktop/src/main/runtime.ts#L300) ran three checks: `isAllowedChildWindowUrl(url)` (only `blob:`), `isHttpUrl(url)` (only `http(s):`), then fall through to `{ action: "deny" }`. The packaged `od://` scheme matched neither, so the click was silently dropped — Orbit's "Open artifact" became a no-op for every desktop user.
- Dev mode (`http://127.0.0.1:port/`) was unaffected: its links resolved through the http branch and opened in the user's external browser via `shell.openExternal`.

Fix: extend `isAllowedChildWindowUrl` to also accept the packaged `od:` scheme. Electron then opens a child BrowserWindow that inherits the same protocol registration + preload, so the live artifact preview HTML (served via the `od://` proxy in `apps/packaged/src/protocol.ts`) renders in the new window. 1-line core change in `runtime.ts`, plus a re-export and test.

Fixes #911.

## Behaviour delta

| Mode | Before | After |
|---|---|---|
| Packaged (Electron, `od://app/` renderer) | click → `od://app/api/.../preview` → silently denied | click → child BrowserWindow renders the artifact preview |
| Dev mode (`http://127.0.0.1:port/`) | link → `http://127.0.0.1:.../api/.../preview` → `shell.openExternal` opens in user's default browser | unchanged |
| Other links (github.com, external docs, etc.) inside packaged | open in user's default browser via `shell.openExternal` | unchanged — `od:` is not a wildcard, only the packaged scheme passes the allowlist |

## Why a child window is the right target (not `shell.openExternal`)

Routing `od://` through `shell.openExternal` would fail because `od:` is a privileged Electron protocol, not an OS-level URL handler — the OS doesn't know what to do with it. The only way to render the preview is inside the same Electron runtime that registered the scheme, which means a child BrowserWindow. The child inherits the parent's `webPreferences` (sandbox, contextIsolation, preload), so it lands at the same security posture as the main window.

## Diff shape

| File | What changes |
|---|---|
| `apps/desktop/src/main/runtime.ts` | Extend `isAllowedChildWindowUrl` to accept `od:` alongside `blob:`. Mark `isHttpUrl` and `isAllowedChildWindowUrl` `export` so the packaged workspace's vitest can pin them. Heavy doc comment on the new branch citing the Orbit no-op. |
| `apps/desktop/src/main/index.ts` | Re-export the two helpers through `@open-design/desktop/main` so cross-package tests can import them via the package boundary (avoids `rootDir` violation in `tsc -p tsconfig.tests.json`). |
| `apps/packaged/tests/desktop-url-allowlist.test.ts` | New: 8 tests pinning both helpers — `od:` allowed (the #911 regression guard), `blob:` still allowed (existing), `http(s):` NOT allowed by this branch (handled by sibling `isHttpUrl` path), `file:` / `javascript:` / `data:` explicitly NOT allowed (security boundary). |

3 files, +124 / −3.

## What's verified

| Check | Result |
|---|---|
| `pnpm --filter @open-design/packaged vitest tests/desktop-url-allowlist.test.ts` | **8/8** |
| `pnpm --filter @open-design/desktop typecheck` | clean |
| packaged `tsc -p tsconfig.json --noEmit` | clean |
| packaged `tsc -p tsconfig.tests.json --noEmit` (the CI killer) | clean |

The pre-existing `apps/packaged/tests/sidecars.test.ts > adds custom VP_HOME/bin to the packaged PATH builder` failure is unrelated to this PR — confirmed by stashing the change and re-running on the bare branch base. Out of scope here.

## What's NOT verified

I don't have a packaged build pipeline locally, so the actual click-through ("press Open artifact → child window pops with live artifact preview") needs a desktop tester. The structural argument:

1. The new test asserts `isAllowedChildWindowUrl('od://app/api/live-artifacts/abc/preview?projectId=p1') === true` — the exact URL shape that the orbit panel produces in packaged builds.
2. `setWindowOpenHandler` returning `{ action: "allow" }` is Electron's documented "open a child BrowserWindow" path — same mechanism `blob:` already uses for in-renderer download URLs.
3. The child window inherits the parent's `webPreferences` and the app-level `od://` protocol registration, so loading `od://app/api/.../preview` in the child runs through the same proxy in `apps/packaged/src/protocol.ts` that already serves the main window's API calls.

If @shangxinyu1 or any desktop user can pull `Sid-Qin:fix/orbit-open-artifact-desktop-911` against a packaged build and confirm Settings → Orbit → Open artifact now opens the preview, that closes the loop.

## Test plan

- [x] 8 new tests covering the URL allowlist surface.
- [x] Both packaged typecheck configs clean.
- [x] Desktop typecheck clean.
- [ ] Manual smoke on packaged build: open Settings → Orbit, click **Open artifact**, expect a child window with the live artifact preview rendered.
- [ ] Verify other `target="_blank"` links inside the packaged app still route to `shell.openExternal` (e.g. clicking a github.com link in the readme/credits panel should still open the user's default browser, not pop a child window).

## Notes

- This is the third desktop-side fix in a row that turns out to be an Electron-policy gap (#738 `window.prompt` disabled, #895 undici socket option, now #911 child-window allowlist). The pattern is consistent: web code that works fine in a browser quietly stops working in the packaged Electron host because of a default-deny policy that nobody has noticed yet. Worth flagging in case the team wants to invest in a packaged-mode QA sweep.
- The exported helpers are pure functions; making them part of `@open-design/desktop/main`'s public API doesn't add runtime coupling — only test reachability.