### PR TITLE
docs: add Docker setup instructions to QUICKSTART.md and CONTRIBUTING.md and README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,64 @@ pnpm --filter @open-design/web build  # web package build when needed
 
 Node `~24` and pnpm `10.33.x` are required. `nvm` / `fnm` are optional; use `nvm install 24 && nvm use 24` or `fnm install 24 && fnm use 24` if you prefer managing Node that way. macOS, Linux, and WSL2 are the primary paths. Windows native should work but isn't a primary target — file an issue if it doesn't.
 
-You don't need any agent CLI on your `PATH` to develop OD itself — the daemon will tell you "no agents found" and fall back to the **Anthropic API · BYOK** path, which is the fastest dev loop anyway.
+## Docker Setup
+
+Run Open Design without installing Node.js or pnpm.
+
+### Prerequisites
+
+Make sure Docker Desktop with Compose v2 is installed:
+
+```bash
+docker compose version
+```
+
+### Start Open Design
+
+```bash
+cd deploy
+docker compose up -d
+```
+
+Open in your browser:
+
+```text
+http://localhost:7456
+```
+
+### Common Commands
+
+```bash
+# View logs
+docker compose logs -f
+
+# Restart containers
+docker compose restart
+
+# Stop containers
+docker compose down
+
+# Pull latest image
+docker compose pull
+docker compose up -d
+```
+
+### Optional Environment Overrides
+
+Create a `deploy/.env` file:
+
+```env
+OPEN_DESIGN_PORT=7456
+OPEN_DESIGN_MEM_LIMIT=384m
+OPEN_DESIGN_ALLOWED_ORIGINS=https://yourdomain.com
+OPEN_DESIGN_IMAGE=docker.io/vanjayak/open-design:latest
+```
+
+> Projects and database data are persisted automatically using Docker volumes.
+
+For the full Docker guide and advanced configuration, see `QUICKSTART.md`.
+
+
 
 ---
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -30,6 +30,129 @@ corepack enable
 corepack pnpm --version   # should print 10.33.2
 ```
 
+## Docker Setup
+
+Run Open Design in a fully containerised environment without installing Node.js or pnpm locally.
+
+### Requirements
+
+* Docker Desktop
+* Docker Compose v2
+
+Verify Docker is installed correctly:
+
+```bash
+docker compose version
+```
+
+---
+
+## Start Open Design
+
+From the repository root:
+
+```bash
+cd deploy
+docker compose up -d
+```
+
+Open the app in your browser:
+
+```text
+http://localhost:7456
+```
+
+The first startup may take a few seconds while Docker pulls the latest image.
+
+---
+
+## Common Docker Commands
+
+### View logs
+
+```bash
+docker compose logs -f
+```
+
+### Restart containers
+
+```bash
+docker compose restart
+```
+
+### Stop containers
+
+```bash
+docker compose down
+```
+
+### Pull the latest image
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+### Remove all local app data
+
+```bash
+docker compose down -v
+```
+
+---
+
+## Environment Configuration
+
+Create a `deploy/.env` file to override the default configuration:
+
+```env
+# Port exposed on the host
+OPEN_DESIGN_PORT=7456
+
+# Container memory limit
+OPEN_DESIGN_MEM_LIMIT=384m
+
+# Allowed CORS origins
+OPEN_DESIGN_ALLOWED_ORIGINS=https://yourdomain.com
+
+# Docker image tag
+OPEN_DESIGN_IMAGE=docker.io/vanjayak/open-design:latest
+```
+
+---
+
+## Persistent Storage
+
+Open Design stores projects and SQLite data inside a Docker volume:
+
+```text
+open_design_data
+```
+
+The volume is mounted to:
+
+```text
+/app/.od
+```
+
+Data persists across container restarts and image updates.
+
+Inspect the volume:
+
+```bash
+docker volume inspect open-design_open_design_data
+```
+
+---
+
+## Notes
+
+* Docker mode is ideal for contributors who do not want a local Node.js or pnpm setup.
+* The container exposes the production daemon build directly on port `7456`.
+* For development workflows and advanced local setup, see the rest of this Quickstart guide.
+
+---
+
 ## One-shot (dev mode)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -309,6 +309,57 @@ The fastest way to try Open Design is the prebuilt desktop app — no Node, no p
 - **[open-design.ai](https://open-design.ai/)** — official download page
 - **[GitHub releases](https://github.com/nexu-io/open-design/releases)**
 
+
+### Run with Docker
+
+Run Open Design without installing Node.js or pnpm locally.
+
+#### Requirements
+
+* Docker Desktop
+* Docker Compose v2
+
+Verify Docker:
+
+```bash id="70jv9o"
+docker compose version
+```
+
+#### Start Open Design
+
+```bash id="m9w43w"
+git clone https://github.com/nexu-io/open-design.git
+cd open-design/deploy
+docker compose up -d
+```
+
+Open in your browser:
+
+```text id="4s4xeh"
+http://localhost:7456
+```
+
+#### Common Commands
+
+```bash id="gl95kp"
+# View logs
+docker compose logs -f
+
+# Restart containers
+docker compose restart
+
+# Stop containers
+docker compose down
+
+# Pull latest image
+docker compose pull
+docker compose up -d
+```
+
+For advanced Docker configuration and environment variables, see [`QUICKSTART.md`](QUICKSTART.md).
+
+
+
 ### Run from source
 
 ```bash


### PR DESCRIPTION
Closes #902

## What this PR does

Adds Docker setup documentation to:

* `README.md`
* `QUICKSTART.md`
* `CONTRIBUTING.md`

## Changes

* Added a quick Docker start guide to `README.md`
* Added a detailed Docker setup section to `QUICKSTART.md`
* Added Docker instructions for contributors in `CONTRIBUTING.md`

## Notes

Docs only. No runtime or configuration changes.

## Tested

```bash id="3zb9b6"
cd deploy
docker compose up -d
```

Verified the app loads successfully at:

```text id="9gb5c6"
http://localhost:7456
```

---

## Screenshots

Docker container running

<img width="1399" height="117" alt="image" src="https://github.com/user-attachments/assets/4d5ebbdc-e32d-4c35-8194-4bb6f45b7096" />

----

Open Design running locally on port `7456`

<img width="1919" height="1038" alt="image" src="https://github.com/user-attachments/assets/e7893d48-24c2-49de-a78a-6b5291aae6f2" />
