### PR TITLE
fix(web): correct srcdoc injection and deck bridge for JS strings con…

### DIFF
--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -105,13 +105,17 @@ function injectManualEditBridge(doc: string): string {
 }
 
 function injectBeforeHeadEnd(doc: string, payload: string): string {
-  if (/<\/head>/i.test(doc)) return doc.replace(/<\/head>/i, `${payload}</head>`);
+  const tag = '</head>';
+  const idx = doc.toLowerCase().indexOf(tag);
+  if (idx >= 0) return doc.slice(0, idx) + payload + doc.slice(idx);
   if (/<head[^>]*>/i.test(doc)) return doc.replace(/<head[^>]*>/i, (m) => `${m}${payload}`);
   return payload + doc;
 }
 
 function injectBeforeBodyEnd(doc: string, payload: string): string {
-  if (/<\/body>/i.test(doc)) return doc.replace(/<\/body>/i, `${payload}</body>`);
+  const tag = '</body>';
+  const idx = doc.toLowerCase().lastIndexOf(tag);
+  if (idx >= 0) return doc.slice(0, idx) + payload + doc.slice(idx);
   return doc + payload;
 }
 
@@ -631,12 +635,16 @@ html[data-od-comment-mode] body * { cursor: crosshair !important; }
 html[data-od-inspect-mode] body * { cursor: crosshair !important; }
 html[data-od-comment-mode][data-od-comment-mode-kind="pod"] body * { cursor: cell !important; }
 </style>`;
-  const withStyle = /<\/head>/i.test(doc)
-    ? doc.replace(/<\/head>/i, style + '</head>')
+  const headEndTag = '</head>';
+  const headEndIdx = doc.toLowerCase().indexOf(headEndTag);
+  const withStyle = headEndIdx >= 0
+    ? doc.slice(0, headEndIdx) + style + doc.slice(headEndIdx)
     : /<head[^>]*>/i.test(doc)
       ? doc.replace(/<head[^>]*>/i, (m) => m + style)
       : style + doc;
-  if (/<\/body>/i.test(withStyle)) return withStyle.replace(/<\/body>/i, script + '</body>');
+  const bodyEndTag = '</body>';
+  const bodyEndIdx = withStyle.toLowerCase().lastIndexOf(bodyEndTag);
+  if (bodyEndIdx >= 0) return withStyle.slice(0, bodyEndIdx) + script + withStyle.slice(bodyEndIdx);
   return withStyle + script;
 }
 
@@ -670,8 +678,10 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
   const styleFix = `<style data-od-deck-fix>
 .stage, .deck-stage, .deck-shell { place-content: center !important; }
 </style>`;
-  const docWithStyle = /<\/head>/i.test(doc)
-    ? doc.replace(/<\/head>/i, styleFix + "</head>")
+  const headEndTag = '</head>';
+  const headEndIdx = doc.toLowerCase().indexOf(headEndTag);
+  const docWithStyle = headEndIdx >= 0
+    ? doc.slice(0, headEndIdx) + styleFix + doc.slice(headEndIdx)
     : /<head[^>]*>/i.test(doc)
     ? doc.replace(/<head[^>]*>/i, (m) => m + styleFix)
     : styleFix + doc;
@@ -679,7 +689,7 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
   const script = `<script data-od-deck-bridge>(function(){
   var initialSlideIndex = ${safeInitialSlideIndex};
   var didRestoreInitialSlide = initialSlideIndex <= 0;
-  function slides(){ return document.querySelectorAll('.slide'); }
+  function slides(){ return document.querySelectorAll('.deck > .slide, .deck-stage > .slide, .deck-shell > .slide, body > .slide'); }
   function scroller(){
     if (document.body && document.body.scrollWidth > document.body.clientWidth + 1) return document.body;
     return document.scrollingElement || document.documentElement;
@@ -754,6 +764,12 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
     if (total) total.textContent = pad2(count);
     if (prev) prev.toggleAttribute('disabled', i <= 0);
     if (next) next.toggleAttribute('disabled', i >= count - 1);
+    document.querySelectorAll('.slide-number').forEach(function(el){
+      el.setAttribute('data-current',i+1); el.setAttribute('data-total',count);
+    });
+    document.querySelectorAll('.progress-bar>span').forEach(function(el){
+      el.style.width=(count?((i+1)/count*100)+'%':'0');
+    });
   }
   function setActive(i){
     var list = slides();
@@ -925,7 +941,9 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
   }
   observeSlides();
 })();</script>`;
-  if (/<\/body>/i.test(doc))
-    return doc.replace(/<\/body>/i, `${script}</body>`);
+  const bodyEndTag = '</body>';
+  const bodyEndIdx = doc.toLowerCase().lastIndexOf(bodyEndTag);
+  if (bodyEndIdx >= 0)
+    return doc.slice(0, bodyEndIdx) + script + doc.slice(bodyEndIdx);
   return doc + script;
 }

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -764,12 +764,6 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
     if (total) total.textContent = pad2(count);
     if (prev) prev.toggleAttribute('disabled', i <= 0);
     if (next) next.toggleAttribute('disabled', i >= count - 1);
-    document.querySelectorAll('.slide-number').forEach(function(el){
-      el.setAttribute('data-current',i+1); el.setAttribute('data-total',count);
-    });
-    document.querySelectorAll('.progress-bar>span').forEach(function(el){
-      el.style.width=(count?((i+1)/count*100)+'%':'0');
-    });
   }
   function setActive(i){
     var list = slides();
@@ -850,11 +844,19 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
   function report(){
     try {
       var list = slides();
+      var i = activeIndex(list);
+      var count = list.length;
       window.parent.postMessage({
         type: 'od:slide-state',
-        active: activeIndex(list),
-        count: list.length,
+        active: i,
+        count: count,
       }, '*');
+      document.querySelectorAll('.slide-number').forEach(function(el){
+        el.setAttribute('data-current',i+1); el.setAttribute('data-total',count);
+      });
+      document.querySelectorAll('.progress-bar>span').forEach(function(el){
+        el.style.width=(count?((i+1)/count*100)+'%':'0');
+      });
     } catch (e) {}
   }
   function restoreInitialSlide(){

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -104,19 +104,31 @@ function injectManualEditBridge(doc: string): string {
   return injectBeforeBodyEnd(withStyle, buildManualEditBridge(true));
 }
 
+// DOM-based HTML mutation: parse with DOMParser, apply mutations, serialize back.
+// Avoids string-matching pitfalls where </head>/<body> appear inside <script>
+// or <style> text — DOMParser correctly separates raw-text element content from
+// structural markup.
+function domMutate(doc: string, mutate: (parsed: Document) => void): string {
+  if (typeof DOMParser === 'undefined') return doc;
+  try {
+    const parsed = new DOMParser().parseFromString(doc, 'text/html');
+    mutate(parsed);
+    return serializeHtmlDocument(parsed);
+  } catch {
+    return doc;
+  }
+}
+
 function injectBeforeHeadEnd(doc: string, payload: string): string {
-  const tag = '</head>';
-  const idx = doc.toLowerCase().indexOf(tag);
-  if (idx >= 0) return doc.slice(0, idx) + payload + doc.slice(idx);
-  if (/<head[^>]*>/i.test(doc)) return doc.replace(/<head[^>]*>/i, (m) => `${m}${payload}`);
-  return payload + doc;
+  return domMutate(doc, (parsed) => {
+    if (parsed.head) parsed.head.insertAdjacentHTML('beforeend', payload);
+  });
 }
 
 function injectBeforeBodyEnd(doc: string, payload: string): string {
-  const tag = '</body>';
-  const idx = doc.toLowerCase().lastIndexOf(tag);
-  if (idx >= 0) return doc.slice(0, idx) + payload + doc.slice(idx);
-  return doc + payload;
+  return domMutate(doc, (parsed) => {
+    if (parsed.body) parsed.body.insertAdjacentHTML('beforeend', payload);
+  });
 }
 
 function injectBaseHref(doc: string, baseHref: string): string {
@@ -635,17 +647,10 @@ html[data-od-comment-mode] body * { cursor: crosshair !important; }
 html[data-od-inspect-mode] body * { cursor: crosshair !important; }
 html[data-od-comment-mode][data-od-comment-mode-kind="pod"] body * { cursor: cell !important; }
 </style>`;
-  const headEndTag = '</head>';
-  const headEndIdx = doc.toLowerCase().indexOf(headEndTag);
-  const withStyle = headEndIdx >= 0
-    ? doc.slice(0, headEndIdx) + style + doc.slice(headEndIdx)
-    : /<head[^>]*>/i.test(doc)
-      ? doc.replace(/<head[^>]*>/i, (m) => m + style)
-      : style + doc;
-  const bodyEndTag = '</body>';
-  const bodyEndIdx = withStyle.toLowerCase().lastIndexOf(bodyEndTag);
-  if (bodyEndIdx >= 0) return withStyle.slice(0, bodyEndIdx) + script + withStyle.slice(bodyEndIdx);
-  return withStyle + script;
+  return domMutate(doc, (parsed) => {
+    if (parsed.head) parsed.head.insertAdjacentHTML('beforeend', style);
+    if (parsed.body) parsed.body.insertAdjacentHTML('beforeend', script);
+  });
 }
 
 // The deck bridge supports three deck conventions found across our skills
@@ -678,14 +683,6 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
   const styleFix = `<style data-od-deck-fix>
 .stage, .deck-stage, .deck-shell { place-content: center !important; }
 </style>`;
-  const headEndTag = '</head>';
-  const headEndIdx = doc.toLowerCase().indexOf(headEndTag);
-  const docWithStyle = headEndIdx >= 0
-    ? doc.slice(0, headEndIdx) + styleFix + doc.slice(headEndIdx)
-    : /<head[^>]*>/i.test(doc)
-    ? doc.replace(/<head[^>]*>/i, (m) => m + styleFix)
-    : styleFix + doc;
-  doc = docWithStyle;
   const script = `<script data-od-deck-bridge>(function(){
   var initialSlideIndex = ${safeInitialSlideIndex};
   var didRestoreInitialSlide = initialSlideIndex <= 0;
@@ -943,9 +940,8 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
   }
   observeSlides();
 })();</script>`;
-  const bodyEndTag = '</body>';
-  const bodyEndIdx = doc.toLowerCase().lastIndexOf(bodyEndTag);
-  if (bodyEndIdx >= 0)
-    return doc.slice(0, bodyEndIdx) + script + doc.slice(bodyEndIdx);
-  return doc + script;
+  return domMutate(doc, (parsed) => {
+    if (parsed.head) parsed.head.insertAdjacentHTML('beforeend', styleFix);
+    if (parsed.body) parsed.body.insertAdjacentHTML('beforeend', script);
+  });
 }

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -104,31 +104,41 @@ function injectManualEditBridge(doc: string): string {
   return injectBeforeBodyEnd(withStyle, buildManualEditBridge(true));
 }
 
-// DOM-based HTML mutation: parse with DOMParser, apply mutations, serialize back.
-// Avoids string-matching pitfalls where </head>/<body> appear inside <script>
-// or <style> text — DOMParser correctly separates raw-text element content from
-// structural markup.
-function domMutate(doc: string, mutate: (parsed: Document) => void): string {
-  if (typeof DOMParser === 'undefined') return doc;
-  try {
-    const parsed = new DOMParser().parseFromString(doc, 'text/html');
-    mutate(parsed);
-    return serializeHtmlDocument(parsed);
-  } catch {
-    return doc;
-  }
-}
-
 function injectBeforeHeadEnd(doc: string, payload: string): string {
-  return domMutate(doc, (parsed) => {
-    if (parsed.head) parsed.head.insertAdjacentHTML('beforeend', payload);
-  });
+  if (typeof DOMParser !== 'undefined') {
+    try {
+      const parsed = new DOMParser().parseFromString(doc, 'text/html');
+      if (parsed.head) parsed.head.insertAdjacentHTML('beforeend', payload);
+      return serializeHtmlDocument(parsed);
+    } catch { /* DOMParser failed; fall through to string path */ }
+  }
+  // String fallback: find the real </head> (last one before <body>)
+  // to skip </head> literals inside <script>/<style> in <head>.
+  const lower = doc.toLowerCase();
+  const bodyStart = lower.indexOf('<body');
+  const limit = bodyStart >= 0 ? bodyStart : lower.length;
+  const idx = lower.lastIndexOf('</head>', limit - 1);
+  if (idx >= 0) return doc.slice(0, idx) + payload + doc.slice(idx);
+  if (/<head[^>]*>/i.test(doc)) return doc.replace(/<head[^>]*>/i, (m) => `${m}${payload}`);
+  return payload + doc;
 }
 
 function injectBeforeBodyEnd(doc: string, payload: string): string {
-  return domMutate(doc, (parsed) => {
-    if (parsed.body) parsed.body.insertAdjacentHTML('beforeend', payload);
-  });
+  if (typeof DOMParser !== 'undefined') {
+    try {
+      const parsed = new DOMParser().parseFromString(doc, 'text/html');
+      if (parsed.body) parsed.body.insertAdjacentHTML('beforeend', payload);
+      return serializeHtmlDocument(parsed);
+    } catch { /* DOMParser failed; fall through to string path */ }
+  }
+  // String fallback: find the real </body> (last one before </html>)
+  // to skip </body> literals inside <script>/<style> in <body>.
+  const lower = doc.toLowerCase();
+  const htmlEnd = lower.lastIndexOf('</html>');
+  const limit = htmlEnd >= 0 ? htmlEnd : lower.length;
+  const idx = lower.lastIndexOf('</body>', limit - 1);
+  if (idx >= 0) return doc.slice(0, idx) + payload + doc.slice(idx);
+  return doc + payload;
 }
 
 function injectBaseHref(doc: string, baseHref: string): string {
@@ -647,10 +657,7 @@ html[data-od-comment-mode] body * { cursor: crosshair !important; }
 html[data-od-inspect-mode] body * { cursor: crosshair !important; }
 html[data-od-comment-mode][data-od-comment-mode-kind="pod"] body * { cursor: cell !important; }
 </style>`;
-  return domMutate(doc, (parsed) => {
-    if (parsed.head) parsed.head.insertAdjacentHTML('beforeend', style);
-    if (parsed.body) parsed.body.insertAdjacentHTML('beforeend', script);
-  });
+  return injectBeforeBodyEnd(injectBeforeHeadEnd(doc, style), script);
 }
 
 // The deck bridge supports three deck conventions found across our skills
@@ -940,8 +947,5 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
   }
   observeSlides();
 })();</script>`;
-  return domMutate(doc, (parsed) => {
-    if (parsed.head) parsed.head.insertAdjacentHTML('beforeend', styleFix);
-    if (parsed.body) parsed.body.insertAdjacentHTML('beforeend', script);
-  });
+  return injectBeforeBodyEnd(injectBeforeHeadEnd(doc, styleFix), script);
 }


### PR DESCRIPTION
Closes #889 
<img width="953" height="891" alt="image" src="https://github.com/user-attachments/assets/dc373a7f-c071-4e5e-a9c1-39852fd55657" />

…taining HTML tags

- Use indexOf for </head> (real tag precedes JS string occurrences)
- Use lastIndexOf for </body> (real tag follows JS string occurrences)
- Scope deck bridge slide selector to direct children of deck containers to avoid counting cloned overview thumbnails
- Update .slide-number data attributes and .progress-bar width from deck bridge's updateDeckChrome so page counter and progress track with deck navigation