### PR TITLE
update: add `awesome-design-md` reference back to QUICKSTART

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -47,7 +47,7 @@ pnpm tools-dev # starts daemon + web + desktop in the background
 
 On first load, the app detects your installed code-agent CLI (Claude Code / Codex / Devin for Terminal / Gemini / OpenCode / Cursor Agent / Qwen / Qoder CLI), picks it automatically, and defaults to `web-prototype` skill + `Neutral Modern` design system. Type a prompt and hit **Send**. The agent streams into the left pane; the `<artifact>` tag is parsed out and the HTML renders live on the right. When it finishes, click **Save to disk** to persist the artifact under `./.od/artifacts/<timestamp>-<slug>/index.html`.
 
-The **Design system** dropdown ships with **129 design systems** — 2 hand-authored starters (Neutral Modern, Warm Editorial), 70 bundled product systems, and 57 design skills sourced from [`awesome-design-skills`](https://github.com/bergside/awesome-design-skills). Pick one to skin every prototype in that brand's aesthetic.
+The **Design system** dropdown ships with 71 built-in systems — 2 hand-authored starters (Neutral Modern, Warm Editorial) and 69 product systems imported from [`awesome-design-md`](https://github.com/VoltAgent/awesome-design-md), grouped by category (AI & LLM, Developer Tools, Productivity, Backend, Design Tools, Fintech, E-Commerce, Media, Automotive). Pick one to skin every prototype in that brand's aesthetic, and another set of 57 design skills sourced from [`awesome-design-skills`](https://github.com/bergside/awesome-design-skills).
 
 The **Skill** dropdown groups by mode (Prototype / Deck / Template / Design system) and shows the default skill per mode with a `· default` suffix. Bundled skills:
 


### PR DESCRIPTION
Hey @pftom,

This PR adds back the `awesome-design-md` reference to QUICKSTART.

During my previous PR, although I instructed the AI to add `awesome-design-skills` as an additional resources, which it correctly did for the README.md file, it slip past for the QUICKSTART for some reason.

So what this PR does is it adds it back with the original text, and the `awesome-design-skills` as an additional resources.

Thanks!