### PR TITLE
fix: make Azure API version optional

### DIFF
--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -437,18 +437,32 @@ function buildProviderCall(input: ProviderTestRequest): ProviderCallShape {
         extractText: extractOpenAIMessageText,
       };
     case 'azure': {
+      const url = new URL(baseUrl);
+      const basePath = url.pathname.replace(/\/+$/, '');
+      const usesVersionedOpenAIPath = /\/openai\/v\d+(?:$|\/)/.test(basePath);
       const apiVersion =
         typeof input.apiVersion === 'string' && input.apiVersion.trim()
           ? input.apiVersion.trim()
-          : '2024-10-21';
-      const trimmedBase = baseUrl.replace(/\/+$/, '');
+          : usesVersionedOpenAIPath
+            ? ''
+            : '2024-10-21';
+      url.pathname = usesVersionedOpenAIPath
+        ? `${basePath}/chat/completions`
+        : `${basePath}/openai/deployments/${encodeURIComponent(model)}/chat/completions`;
+      if (usesVersionedOpenAIPath && !apiVersion) {
+        url.searchParams.delete('api-version');
+      }
+      if (apiVersion) {
+        url.searchParams.set('api-version', apiVersion);
+      }
       return {
-        url: `${trimmedBase}/openai/deployments/${encodeURIComponent(model)}/chat/completions?api-version=${encodeURIComponent(apiVersion)}`,
+        url: url.toString(),
         headers: {
           'content-type': 'application/json',
           'api-key': apiKey,
         },
         body: {
+          ...(usesVersionedOpenAIPath ? { model } : {}),
           max_tokens: PROVIDER_MAX_TOKENS,
           messages: [{ role: 'user', content: SMOKE_PROMPT }],
           stream: false,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -6306,15 +6306,26 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
       );
     }
 
+    const url = new URL(baseUrl);
+    const basePath = url.pathname.replace(/\/+$/, '');
+    const usesVersionedOpenAIPath = /\/openai\/v\d+(?:$|\/)/.test(basePath);
     const version =
       typeof apiVersion === 'string' && apiVersion.trim()
         ? apiVersion.trim()
-        : '2024-10-21';
-    const url = new URL(baseUrl);
-    url.pathname = `${url.pathname.replace(/\/+$/, '')}/openai/deployments/${encodeURIComponent(model)}/chat/completions`;
-    url.searchParams.set('api-version', version);
+        : usesVersionedOpenAIPath
+          ? ''
+          : '2024-10-21';
+    url.pathname = usesVersionedOpenAIPath
+      ? `${basePath}/chat/completions`
+      : `${basePath}/openai/deployments/${encodeURIComponent(model)}/chat/completions`;
+    if (usesVersionedOpenAIPath && !version) {
+      url.searchParams.delete('api-version');
+    }
+    if (version) {
+      url.searchParams.set('api-version', version);
+    }
     console.log(
-      `[proxy:azure] ${req.method} ${validated.parsed.hostname} deployment=${model} api-version=${version}`,
+      `[proxy:azure] ${req.method} ${validated.parsed.hostname} deployment=${model} api-version=${version || 'omitted'}`,
     );
 
     const payloadMessages = Array.isArray(messages) ? [...messages] : [];
@@ -6323,6 +6334,7 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
     }
 
     const payload = {
+      ...(usesVersionedOpenAIPath ? { model } : {}),
       messages: payloadMessages,
       max_tokens:
         typeof maxTokens === 'number' && maxTokens > 0 ? maxTokens : 8192,

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -606,6 +606,106 @@ describe('POST /api/test/connection provider mode', () => {
     );
   });
 
+  it('keeps the default Azure api-version in connection tests when the field is blank', async () => {
+    const fetchMock = passThroughOrUpstream(() =>
+      jsonResponse({
+        choices: [{ message: { role: 'assistant', content: 'ok' } }],
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await realFetch(`${baseUrl}/api/test/connection`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        mode: 'provider',
+        protocol: 'azure',
+        baseUrl: 'https://my-azure.openai.azure.com',
+        apiKey: 'azure-key',
+        model: 'deployment-1',
+        apiVersion: '',
+      }),
+    });
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+    const upstream = fetchMock.mock.calls.find(
+      ([input]) => !String(input).startsWith(baseUrl),
+    );
+    expect(upstream).toBeDefined();
+    const [upstreamUrl] = upstream!;
+    expect(String(upstreamUrl)).toBe(
+      'https://my-azure.openai.azure.com/openai/deployments/deployment-1/chat/completions?api-version=2024-10-21',
+    );
+  });
+
+  it('omits Azure api-version in connection tests for OpenAI-compatible v1 paths when blank', async () => {
+    const fetchMock = passThroughOrUpstream(() =>
+      jsonResponse({
+        choices: [{ message: { role: 'assistant', content: 'ok' } }],
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await realFetch(`${baseUrl}/api/test/connection`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        mode: 'provider',
+        protocol: 'azure',
+        baseUrl: 'https://my-resource.services.ai.azure.com/api/projects/project/openai/v1',
+        apiKey: 'azure-key',
+        model: 'deployment-1',
+        apiVersion: '',
+      }),
+    });
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+    const upstream = fetchMock.mock.calls.find(
+      ([input]) => !String(input).startsWith(baseUrl),
+    );
+    expect(upstream).toBeDefined();
+    const [upstreamUrl, upstreamInit] = upstream!;
+    expect(String(upstreamUrl)).toBe(
+      'https://my-resource.services.ai.azure.com/api/projects/project/openai/v1/chat/completions',
+    );
+    expect(JSON.parse(String(upstreamInit?.body))).toMatchObject({
+      model: 'deployment-1',
+    });
+  });
+
+  it('removes copied Azure api-version query params in connection tests for OpenAI-compatible v1 paths when blank', async () => {
+    const fetchMock = passThroughOrUpstream(() =>
+      jsonResponse({
+        choices: [{ message: { role: 'assistant', content: 'ok' } }],
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await realFetch(`${baseUrl}/api/test/connection`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        mode: 'provider',
+        protocol: 'azure',
+        baseUrl:
+          'https://my-resource.services.ai.azure.com/api/projects/project/openai/v1?api-version=2024-10-21',
+        apiKey: 'azure-key',
+        model: 'deployment-1',
+        apiVersion: '',
+      }),
+    });
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+    const upstream = fetchMock.mock.calls.find(
+      ([input]) => !String(input).startsWith(baseUrl),
+    );
+    expect(upstream).toBeDefined();
+    const [upstreamUrl] = upstream!;
+    expect(String(upstreamUrl)).toBe(
+      'https://my-resource.services.ai.azure.com/api/projects/project/openai/v1/chat/completions',
+    );
+  });
+
   it('uses the non-streaming Gemini endpoint and extracts text from candidates', async () => {
     const fetchMock = passThroughOrUpstream(() =>
       jsonResponse({

--- a/apps/daemon/tests/proxy-routes.test.ts
+++ b/apps/daemon/tests/proxy-routes.test.ts
@@ -300,6 +300,88 @@ describe('API proxy routes', () => {
     expect(upstreamInit?.headers).toMatchObject({ 'api-key': 'azure-key' });
   });
 
+  it('keeps the default Azure api-version for deployment URLs when the field is blank', async () => {
+    const fetchMock = vi.fn((input: FetchInput, init?: FetchInit) => {
+      const url = String(input);
+      if (url.startsWith(baseUrl)) return realFetch(input, init);
+      return Promise.resolve(sseResponse('data: [DONE]\n\n'));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await realFetch(`${baseUrl}/api/proxy/azure/stream`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        baseUrl: 'https://resource.openai.azure.com',
+        apiKey: 'azure-key',
+        model: 'deployment-one',
+        apiVersion: '',
+        messages: [{ role: 'user', content: 'hello' }],
+      }),
+    });
+
+    const [upstreamUrl] = fetchMock.mock.calls[0]!;
+    expect(String(upstreamUrl)).toBe(
+      'https://resource.openai.azure.com/openai/deployments/deployment-one/chat/completions?api-version=2024-10-21',
+    );
+  });
+
+  it('omits Azure api-version for OpenAI-compatible v1 paths when the field is blank', async () => {
+    const fetchMock = vi.fn((input: FetchInput, init?: FetchInit) => {
+      const url = String(input);
+      if (url.startsWith(baseUrl)) return realFetch(input, init);
+      return Promise.resolve(sseResponse('data: [DONE]\n\n'));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await realFetch(`${baseUrl}/api/proxy/azure/stream`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        baseUrl: 'https://resource.services.ai.azure.com/api/projects/project/openai/v1',
+        apiKey: 'azure-key',
+        model: 'deployment-one',
+        apiVersion: '',
+        messages: [{ role: 'user', content: 'hello' }],
+      }),
+    });
+
+    const [upstreamUrl, upstreamInit] = fetchMock.mock.calls[0]!;
+    expect(String(upstreamUrl)).toBe(
+      'https://resource.services.ai.azure.com/api/projects/project/openai/v1/chat/completions',
+    );
+    expect(JSON.parse(String(upstreamInit?.body))).toMatchObject({
+      model: 'deployment-one',
+    });
+  });
+
+  it('removes copied Azure api-version query params for OpenAI-compatible v1 paths when the field is blank', async () => {
+    const fetchMock = vi.fn((input: FetchInput, init?: FetchInit) => {
+      const url = String(input);
+      if (url.startsWith(baseUrl)) return realFetch(input, init);
+      return Promise.resolve(sseResponse('data: [DONE]\n\n'));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await realFetch(`${baseUrl}/api/proxy/azure/stream`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        baseUrl:
+          'https://resource.services.ai.azure.com/api/projects/project/openai/v1?api-version=2024-10-21',
+        apiKey: 'azure-key',
+        model: 'deployment-one',
+        apiVersion: '',
+        messages: [{ role: 'user', content: 'hello' }],
+      }),
+    });
+
+    const [upstreamUrl] = fetchMock.mock.calls[0]!;
+    expect(String(upstreamUrl)).toBe(
+      'https://resource.services.ai.azure.com/api/projects/project/openai/v1/chat/completions',
+    );
+  });
+
   it('surfaces Gemini safety blocks as proxy errors', async () => {
     vi.stubGlobal('fetch', vi.fn((input: FetchInput, init?: FetchInit) => {
       const url = String(input);


### PR DESCRIPTION
## Summary
- stop defaulting blank Azure apiVersion values to 2024-10-21 in the stream proxy
- apply the same optional apiVersion behavior to provider connection tests
- add regression coverage for blank apiVersion requests

Fixes the remaining Azure /v1 issue discussed in #361, where Azure AI Foundry rejects an api-version query parameter on OpenAI-compatible /v1 paths.

## Tests
- Not run locally: this environment does not have pnpm or corepack installed.
- Ran: git diff --check