### PR TITLE
fix: include empty env for ACP MCP servers

### DIFF
--- a/apps/daemon/src/agents.ts
+++ b/apps/daemon/src/agents.ts
@@ -940,6 +940,12 @@ export function buildLiveArtifactsMcpServersForAgent(def, { enabled = true, comm
       name: 'open-design-live-artifacts',
       command,
       args: [...argsPrefix, 'mcp', 'live-artifacts'],
+      // Hermes ACP validates stdio MCP env as a list, not an object. Passing no
+      // env is fine here because the child process inherits OD_* values from
+      // the agent runtime environment (see buildAgentEnv in server.ts). Without
+      // this field Hermes rejects session/new with "Invalid params" whenever a
+      // project run enables live-artifacts MCP.
+      env: [],
     },
   ];
 }

--- a/apps/daemon/tests/agents.test.ts
+++ b/apps/daemon/tests/agents.test.ts
@@ -169,20 +169,14 @@ test('codex args do not include the literal `-` stdin sentinel (regression of #2
 });
 
 test('live artifact MCP discovery is limited to mature ACP agents', () => {
-  assert.deepEqual(buildLiveArtifactsMcpServersForAgent(hermes), [
-    {
-      name: 'open-design-live-artifacts',
-      command: 'od',
-      args: ['mcp', 'live-artifacts'],
-    },
-  ]);
-  assert.deepEqual(buildLiveArtifactsMcpServersForAgent(kimi), [
-    {
-      name: 'open-design-live-artifacts',
-      command: 'od',
-      args: ['mcp', 'live-artifacts'],
-    },
-  ]);
+  const expectedServer = {
+    name: 'open-design-live-artifacts',
+    command: 'od',
+    args: ['mcp', 'live-artifacts'],
+    env: [],
+  };
+  assert.deepEqual(buildLiveArtifactsMcpServersForAgent(hermes), [expectedServer]);
+  assert.deepEqual(buildLiveArtifactsMcpServersForAgent(kimi), [expectedServer]);
 
   for (const agent of AGENT_DEFS) {
     if (agent.id === 'hermes' || agent.id === 'kimi') continue;
@@ -205,6 +199,7 @@ test('live artifact MCP discovery can use daemon-resolved CLI command', () => {
         name: 'open-design-live-artifacts',
         command: process.execPath,
         args: ['/workspace/apps/daemon/dist/cli.js', 'mcp', 'live-artifacts'],
+        env: [],
       },
     ],
   );


### PR DESCRIPTION
## Summary
- Add an explicit empty `env` array to live-artifacts MCP server definitions
- Update daemon agent tests to expect the ACP-compatible MCP server shape

## Why
Hermes ACP validates stdio MCP server definitions with `env` as a list. Without an explicit `env: []`, `session/new` rejects Open Design runs that enable live-artifacts MCP with `Invalid params`.

## Test Plan
- `corepack pnpm --filter @open-design/daemon test -- tests/agents.test.ts`
- `corepack pnpm --filter @open-design/daemon test -- tests/acp.test.ts tests/agents.test.ts`

Note: local verification ran on Node v22.22.0, while the repo currently warns that it wants Node ~24.
