### PR TITLE
Fix: windows inspect overlay

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -2883,7 +2883,7 @@ function HtmlViewer({
   const [boardTool, setBoardTool] = useState<BoardTool>('inspect');
   const [inspectMode, setInspectMode] = useState(false);
   // for hint managing hint box state
-  const [openHintBox, setOpenHintBox] = useState(false);
+  const [openHintBox, setOpenHintBox] = useState(true);
   const [manualEditMode, setManualEditMode] = useState(false);
   const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([]);
   const [selectedManualEditTarget, setSelectedManualEditTarget] = useState<ManualEditTarget | null>(null);

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -4627,6 +4627,8 @@ function HtmlViewer({
               </div>
                <button
                 type="button"
+                title="Close Inspect Hint"
+                aria-label="Close Inspect Hint"
                 onClick={() => setOpenHintBox(false)}
                 className="orbit-artifact-ghost">
                  <Icon className='' name='close' size={12} />

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -2882,6 +2882,8 @@ function HtmlViewer({
   const [boardMode, setBoardMode] = useState(false);
   const [boardTool, setBoardTool] = useState<BoardTool>('inspect');
   const [inspectMode, setInspectMode] = useState(false);
+  // for hint managing hint box state
+  const [openHintBox, setOpenHintBox] = useState(false);
   const [manualEditMode, setManualEditMode] = useState(false);
   const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([]);
   const [selectedManualEditTarget, setSelectedManualEditTarget] = useState<ManualEditTarget | null>(null);
@@ -4232,6 +4234,7 @@ function HtmlViewer({
                   setBoardMode(false);
                   clearBoardComposer();
                   setManualEditMode(false);
+                  setOpenHintBox(true);
                 }
                 return next;
               });
@@ -4617,9 +4620,17 @@ function HtmlViewer({
                 error={inspectError}
               />
             ) : null}
-            {inspectMode && !activeInspectTarget ? (
-              <div className="inspect-empty-hint" data-testid="inspect-empty-hint">
+            {inspectMode && openHintBox && !activeInspectTarget ? (
+              <div className="inspect-empty-hint-container">
+                <div className="inspect-empty-hint" data-testid="inspect-empty-hint">
                 Click any element with <code>data-od-id</code> to tune its style.
+              </div>
+               <button
+                type="button"
+                onClick={() => setOpenHintBox(false)}
+                className="orbit-artifact-ghost">
+                 <Icon className='' name='close' size={12} />
+               </button>
               </div>
             ) : null}
           </div>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -8281,6 +8281,12 @@ button.ghost.mcp-copy-btn:hover:not(:disabled) {
   align-items: center;
   justify-content: center;
   gap: 5px;
+  pointer-events: none;
+}
+
+.inspect-empty-hint-container button,
+.inspect-empty-hint-container .close-button {
+  pointer-events: auto;
 }
 
 .inspect-empty-hint code {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -8283,19 +8283,6 @@ button.ghost.mcp-copy-btn:hover:not(:disabled) {
   gap: 5px;
 }
 
-.inspect-empty-hint {
-  /* position: absolute;
-  top: 14px;
-  right: 14px;
-  z-index: 5;
-  padding: 8px 12px;
-  border: 1px dashed var(--border);
-  border-radius: var(--radius);
-  background: var(--bg-panel);
-  color: var(--text-muted);
-  font-size: 12px;
-  pointer-events: none; */
-}
 .inspect-empty-hint code {
   padding: 1px 5px;
   border-radius: 3px;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -8265,7 +8265,8 @@ button.ghost.mcp-copy-btn:hover:not(:disabled) {
   color: var(--red);
   font-size: 11px;
 }
-.inspect-empty-hint {
+
+.inspect-empty-hint-container {
   position: absolute;
   top: 14px;
   right: 14px;
@@ -8276,7 +8277,24 @@ button.ghost.mcp-copy-btn:hover:not(:disabled) {
   background: var(--bg-panel);
   color: var(--text-muted);
   font-size: 12px;
-  pointer-events: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+}
+
+.inspect-empty-hint {
+  /* position: absolute;
+  top: 14px;
+  right: 14px;
+  z-index: 5;
+  padding: 8px 12px;
+  border: 1px dashed var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-panel);
+  color: var(--text-muted);
+  font-size: 12px;
+  pointer-events: none; */
 }
 .inspect-empty-hint code {
   padding: 1px 5px;


### PR DESCRIPTION
Closes #904

## What this PR does

Improves the inspect mode hint overlay behavior on Windows.

## Changes

* Wrapped the inspect hint inside a dedicated container
* Added a dismiss button for the inspect hint overlay
* Added a new `openHintBox` state to control hint visibility
* Improved overlay positioning and layout behavior
* Prevents the hint from obscuring design content while inspecting

## Notes

UI-only change. No runtime logic or API changes.

## Tested

* Tested inspect mode behavior locally on Windows
* Verified the hint renders correctly and can be dismissed
* Verified inspect interactions continue working as expected

## Screenshots


https://github.com/user-attachments/assets/9816fad2-cf38-47a4-b9f2-a78ba2e3f7e6

