### PR TITLE
fix: add gpt-5.1 Codex picker options

### DIFF
--- a/apps/daemon/src/agents.ts
+++ b/apps/daemon/src/agents.ts
@@ -234,6 +234,8 @@ export const AGENT_DEFS = [
       { id: 'gpt-5.4', label: 'gpt-5.4' },
       { id: 'gpt-5.4-mini', label: 'gpt-5.4-mini' },
       { id: 'gpt-5.3-codex', label: 'gpt-5.3-codex' },
+      { id: 'gpt-5.1', label: 'gpt-5.1' },
+      { id: 'gpt-5.1-codex-mini', label: 'gpt-5.1-codex-mini' },
       { id: 'gpt-5-codex', label: 'gpt-5-codex' },
       { id: 'gpt-5', label: 'gpt-5' },
       { id: 'o3', label: 'o3' },

--- a/apps/daemon/tests/agents.test.ts
+++ b/apps/daemon/tests/agents.test.ts
@@ -169,6 +169,8 @@ test('codex model picker includes current OpenAI choices in priority order', asy
     'gpt-5.4',
     'gpt-5.4-mini',
     'gpt-5.3-codex',
+    'gpt-5.1',
+    'gpt-5.1-codex-mini',
     'gpt-5-codex',
     'gpt-5',
     'o3',
@@ -218,6 +220,13 @@ test('codex model picker includes current OpenAI choices in priority order', asy
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+test('codex picker includes models with special reasoning clamps', () => {
+  const pickerModels = new Set(codex.fallbackModels.map((model) => model.id));
+
+  assert.equal(pickerModels.has('gpt-5.1'), true);
+  assert.equal(pickerModels.has('gpt-5.1-codex-mini'), true);
 });
 
 // Recent Codex CLI versions reject a bare `-` argv sentinel; passing it

--- a/apps/daemon/tests/agents.test.ts
+++ b/apps/daemon/tests/agents.test.ts
@@ -222,7 +222,7 @@ test('codex model picker includes current OpenAI choices in priority order', asy
   }
 });
 
-test('codex picker includes models with special reasoning clamps', () => {
+test('codex picker includes gpt-5.1 model family', () => {
   const pickerModels = new Set(codex.fallbackModels.map((model) => model.id));
 
   assert.equal(pickerModels.has('gpt-5.1'), true);


### PR DESCRIPTION
## Summary
- Add `gpt-5.1` and `gpt-5.1-codex-mini` to the Codex fallback picker list
- Update the Codex picker priority-order regression test
- Add coverage to keep models with reasoning clamps visible in the picker

## Why
`agents.ts` already has reasoning clamp handling for these models, but they were not exposed through the Codex fallback picker. This keeps the picker aligned with the runtime model handling.

## Testing
- `corepack pnpm install`
- `corepack pnpm --filter @open-design/daemon test -- agents.test.ts`
- `corepack pnpm --filter @open-design/daemon typecheck`

Note: local environment is Node v20.19.2 while the repo declares Node ~24, but the targeted test suite and typecheck passed.
