### PR TITLE
fix: serve python files as text

### DIFF
--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -566,6 +566,7 @@ const EXT_MIME = {
   '.cjs': 'text/javascript; charset=utf-8',
   '.jsx': 'text/javascript; charset=utf-8',
   '.ts': 'text/typescript; charset=utf-8',
+  '.py': 'text/x-python; charset=utf-8',
   // `.tsx` previously served as `text/typescript`, which browser module
   // loaders and strict CSPs do not accept as a JavaScript MIME. Multi-file
   // React prototypes that load `.tsx` via Babel-standalone (`<script

--- a/apps/daemon/tests/project-classifiers.test.ts
+++ b/apps/daemon/tests/project-classifiers.test.ts
@@ -105,6 +105,7 @@ describe('mimeFor', () => {
     expect(mimeFor('a.jsx')).toBe('text/javascript; charset=utf-8');
     expect(mimeFor('a.tsx')).toBe('text/javascript; charset=utf-8');
     expect(mimeFor('a.ts')).toBe('text/typescript; charset=utf-8');
+    expect(mimeFor('a.py')).toBe('text/x-python; charset=utf-8');
     expect(mimeFor('a.json')).toBe('application/json; charset=utf-8');
     expect(mimeFor('a.md')).toBe('text/markdown; charset=utf-8');
     expect(mimeFor('a.txt')).toBe('text/plain; charset=utf-8');
@@ -151,6 +152,7 @@ describe('mimeFor', () => {
   it('is case-insensitive on the extension', () => {
     expect(mimeFor('IMG.PNG')).toBe('image/png');
     expect(mimeFor('PAGE.HTML')).toBe('text/html; charset=utf-8');
+    expect(mimeFor('SCRIPT.PY')).toBe('text/x-python; charset=utf-8');
     expect(mimeFor('FOO.JSON')).toBe('application/json; charset=utf-8');
   });
 });


### PR DESCRIPTION
## Summary
- Serve `.py` files as text from the daemon MIME map
- Add regression coverage for lowercase and uppercase Python extensions

## Why
Python files are classified as code elsewhere in the project, but `mimeFor()` fell back to `application/octet-stream`. Serving them as text keeps previews and direct file responses consistent with code-file handling.

## Testing
- `corepack pnpm install`
- `corepack pnpm --filter @open-design/daemon test -- project-classifiers`
- `corepack pnpm --filter @open-design/daemon typecheck`

Note: local environment is Node v20.19.2 while the repo declares Node ~24, but the targeted suite and typecheck passed.
