### PR TITLE
fix: keep examples filter counts consistent

### DIFF
--- a/apps/web/src/components/ExamplesTab.tsx
+++ b/apps/web/src/components/ExamplesTab.tsx
@@ -275,6 +275,11 @@ export function ExamplesTab({ skills: rawSkills, onUsePrompt }: Props) {
     return ordered;
   }, [scenarioCounts]);
 
+  const scenarioAllCount = useMemo(
+    () => [...scenarioCounts.values()].reduce((total, count) => total + count, 0),
+    [scenarioCounts],
+  );
+
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase();
     const matched = skills.filter((s) => {
@@ -381,7 +386,7 @@ export function ExamplesTab({ skills: rawSkills, onUsePrompt }: Props) {
               onClick={() => setScenarioFilter('all')}
             >
               {t('examples.modeAll')}
-              <span className="filter-pill-count">{filtered.length}</span>
+              <span className="filter-pill-count">{scenarioAllCount}</span>
             </button>
             {scenarioOptions.map((tag) => (
               <button
@@ -670,6 +675,9 @@ function ExampleCard({
 }
 
 function tagForSkill(skill: SkillSummary, t: TranslateFn): string {
+  if (skill.mode === 'image' || skill.surface === 'image') return t('examples.tagImage');
+  if (skill.mode === 'video' || skill.surface === 'video') return t('examples.tagVideo');
+  if (skill.mode === 'audio' || skill.surface === 'audio') return t('examples.tagAudio');
   if (skill.mode === 'deck') return t('examples.tagSlideDeck');
   if (skill.mode === 'template') return t('examples.tagTemplate');
   if (skill.mode === 'design-system') return t('examples.tagDesignSystem');

--- a/apps/web/tests/components/examples-tab-filter-counts.test.tsx
+++ b/apps/web/tests/components/examples-tab-filter-counts.test.tsx
@@ -33,6 +33,7 @@ function skill(overrides: Partial<SkillSummary> & Pick<SkillSummary, 'id' | 'nam
     designSystemRequired: false,
     defaultFor: [],
     upstream: null,
+    aggregatesExamples: false,
     hasBody: true,
     examplePrompt: `Build ${name}`,
     ...rest,

--- a/apps/web/tests/components/examples-tab-filter-counts.test.tsx
+++ b/apps/web/tests/components/examples-tab-filter-counts.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ExamplesTab } from '../../src/components/ExamplesTab';
+import { fetchSkillExample } from '../../src/providers/registry';
+import type { SkillSummary } from '../../src/types';
+
+vi.mock('../../src/providers/registry', () => ({
+  fetchSkillExample: vi.fn(),
+}));
+
+const mockedFetch = fetchSkillExample as unknown as ReturnType<typeof vi.fn>;
+
+function skill(overrides: Partial<SkillSummary> & Pick<SkillSummary, 'id' | 'name'>): SkillSummary {
+  const { id, name, ...rest } = overrides;
+  return {
+    id,
+    name,
+    description: `${name} description`,
+    triggers: [id],
+    mode: 'prototype',
+    surface: 'web',
+    platform: 'desktop',
+    scenario: 'general',
+    previewType: 'web',
+    designSystemRequired: false,
+    defaultFor: [],
+    upstream: null,
+    hasBody: true,
+    examplePrompt: `Build ${name}`,
+    ...rest,
+  };
+}
+
+function renderExamples(skills: SkillSummary[]) {
+  render(<ExamplesTab skills={skills} onUsePrompt={() => {}} />);
+}
+
+describe('ExamplesTab filter counts', () => {
+  beforeEach(() => {
+    mockedFetch.mockResolvedValue({ html: '<main>preview</main>' });
+  });
+
+  afterEach(() => {
+    cleanup();
+    mockedFetch.mockReset();
+  });
+
+  it('keeps the Scenario All count scoped to surface and type, not the selected scenario', () => {
+    renderExamples([
+      skill({ id: 'eng-desktop', name: 'Engineering desktop', scenario: 'engineering' }),
+      skill({ id: 'eng-deck', name: 'Engineering deck', mode: 'deck', scenario: 'engineering' }),
+      skill({ id: 'product-desktop', name: 'Product desktop', scenario: 'product' }),
+      skill({ id: 'product-mobile', name: 'Product mobile', platform: 'mobile', scenario: 'product' }),
+    ]);
+
+    const scenarioFilters = screen.getByRole('tablist', { name: 'Scenario' });
+    expect(within(scenarioFilters).getByRole('button', { name: /^All\s*4$/ })).toBeTruthy();
+
+    fireEvent.click(within(scenarioFilters).getByRole('button', { name: /^Product\s*2$/ }));
+
+    expect(within(scenarioFilters).getByRole('button', { name: /^All\s*4$/ })).toBeTruthy();
+    expect(within(scenarioFilters).getByRole('button', { name: /^Product\s*2$/ })).toBeTruthy();
+  });
+
+  it('uses media tags for media examples so visible tags do not imply zero-count prototype types', () => {
+    renderExamples([
+      skill({ id: 'web-prototype', name: 'Web prototype' }),
+      skill({
+        id: 'image-example',
+        name: 'Image example',
+        mode: 'image',
+        surface: 'image',
+        platform: null,
+        previewType: 'image',
+      }),
+    ]);
+
+    const surfaceFilters = screen.getByRole('tablist', { name: 'Surface' });
+    fireEvent.click(within(surfaceFilters).getByRole('tab', { name: /^Image\s*1$/ }));
+
+    const typeFilters = screen.getByRole('tablist', { name: 'Type' });
+    expect(within(typeFilters).getByRole('tab', { name: /^All\s*1$/ })).toBeTruthy();
+    expect(within(typeFilters).getByRole('tab', { name: /^Prototypes · Desktop\s*0$/ })).toBeTruthy();
+    const imageCard = screen.getByTestId('example-card-image-example');
+    expect(within(imageCard).getByText('Image')).toBeTruthy();
+    expect(within(imageCard).queryByText('Desktop prototype')).toBeNull();
+  });
+});

--- a/apps/web/tests/components/examples-tab-filter-counts.test.tsx
+++ b/apps/web/tests/components/examples-tab-filter-counts.test.tsx
@@ -64,10 +64,17 @@ describe('ExamplesTab filter counts', () => {
     const scenarioFilters = screen.getByRole('tablist', { name: 'Scenario' });
     expect(within(scenarioFilters).getByRole('button', { name: /^All\s*4$/ })).toBeTruthy();
 
-    fireEvent.click(within(scenarioFilters).getByRole('button', { name: /^Product\s*2$/ }));
+    const typeFilters = screen.getByRole('tablist', { name: 'Type' });
+    fireEvent.click(within(typeFilters).getByRole('tab', { name: /^Prototypes · Desktop\s*2$/ }));
 
-    expect(within(scenarioFilters).getByRole('button', { name: /^All\s*4$/ })).toBeTruthy();
-    expect(within(scenarioFilters).getByRole('button', { name: /^Product\s*2$/ })).toBeTruthy();
+    expect(within(scenarioFilters).getByRole('button', { name: /^All\s*2$/ })).toBeTruthy();
+    expect(within(scenarioFilters).getByRole('button', { name: /^Engineering\s*1$/ })).toBeTruthy();
+    expect(within(scenarioFilters).getByRole('button', { name: /^Product\s*1$/ })).toBeTruthy();
+
+    fireEvent.click(within(scenarioFilters).getByRole('button', { name: /^Product\s*1$/ }));
+
+    expect(within(scenarioFilters).getByRole('button', { name: /^All\s*2$/ })).toBeTruthy();
+    expect(within(scenarioFilters).getByRole('button', { name: /^Product\s*1$/ })).toBeTruthy();
   });
 
   it('uses media tags for media examples so visible tags do not imply zero-count prototype types', () => {


### PR DESCRIPTION
## Summary
- Keep the Examples “All” scenario count stable when selecting a scenario filter
- Keep scenario counts scoped to the current surface/type filters
- Fix media example tag rendering so image/video/audio examples do not fall through to the prototype label
- Add regression coverage for the filter-count and visible-tag behavior

## Why
Fixes #914 and #917. The counts should describe the currently visible filter universe instead of changing because the selected chip filters itself, and visible media tags should match the available type counts.

## Testing
- `corepack pnpm install`
- `corepack pnpm --filter @open-design/web test -- examples-tab-filter-counts.test.tsx`
- `corepack pnpm --filter @open-design/web typecheck`
- `git diff --check`

Note: local environment is Node v20.19.2 while the repo declares Node ~24, but the targeted suite and typecheck passed.
