### PR TITLE
fix daemon browser opener on Windows

### DIFF
--- a/apps/daemon/src/browser-open.ts
+++ b/apps/daemon/src/browser-open.ts
@@ -1,0 +1,78 @@
+import { spawn as nodeSpawn } from 'node:child_process';
+import type { ChildProcess, SpawnOptions } from 'node:child_process';
+
+type SupportedPlatform = NodeJS.Platform;
+
+export type BrowserOpenInvocation = {
+  command: string;
+  args: string[];
+  options: SpawnOptions;
+};
+
+type OpenBrowserDeps = {
+  platform?: SupportedPlatform;
+  spawn?: (command: string, args: string[], options: SpawnOptions) => ChildProcess;
+  warn?: (message: string) => void;
+  env?: NodeJS.ProcessEnv;
+};
+
+function quoteWindowsCommandArg(value: string, { force = false }: { force?: boolean } = {}): string {
+  if (value.length === 0) return '""';
+  if (!force && !/[\s"&<>|^%]/.test(value)) return value;
+  const escaped = value.replace(/"/g, '""').replace(/%/g, '"^%"');
+  return `"${escaped}"`;
+}
+
+export function createBrowserOpenInvocation(
+  platform: SupportedPlatform,
+  url: string,
+  env: NodeJS.ProcessEnv = process.env,
+): BrowserOpenInvocation {
+  if (platform === 'win32') {
+    const comspec = env.ComSpec || env.COMSPEC || 'cmd.exe';
+    // `start` is a cmd.exe builtin on Windows, not a real executable. The empty
+    // title argument keeps cmd from treating the URL itself as the window title.
+    // Match @open-design/platform's cmd.exe shim shape: Node's default Windows
+    // argv quoting uses backslash escapes that cmd.exe does not understand, so
+    // the inner command must be wrapped for `/s /c` and passed verbatim.
+    const inner = [
+      'start',
+      quoteWindowsCommandArg(''),
+      quoteWindowsCommandArg(url, { force: true }),
+    ].join(' ');
+    return {
+      command: comspec,
+      args: ['/d', '/s', '/c', `"${inner}"`],
+      options: { detached: true, stdio: 'ignore', windowsHide: true, windowsVerbatimArguments: true },
+    };
+  }
+
+  return {
+    command: platform === 'darwin' ? 'open' : 'xdg-open',
+    args: [url],
+    options: { detached: true, stdio: 'ignore' },
+  };
+}
+
+export function openBrowser(url: string, deps: OpenBrowserDeps = {}): ChildProcess | null {
+  const platform = deps.platform ?? process.platform;
+  const spawn = deps.spawn ?? nodeSpawn;
+  const warn = deps.warn ?? ((message: string) => console.warn(message));
+  const invocation = createBrowserOpenInvocation(platform, url, deps.env);
+
+  try {
+    const child = spawn(invocation.command, invocation.args, invocation.options);
+    // Browser opening is best-effort. A missing opener must not crash the daemon
+    // after the server has already started and printed its URL.
+    child.on('error', (error) => {
+      const detail = error instanceof Error ? error.message : String(error);
+      warn(`[od] failed to open browser: ${detail}`);
+    });
+    child.unref();
+    return child;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    warn(`[od] failed to open browser: ${detail}`);
+    return null;
+  }
+}

--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -5,6 +5,7 @@ import { runLiveArtifactsMcpServer } from './mcp-live-artifacts-server.js';
 import { runConnectorsToolCli } from './tools-connectors-cli.js';
 import { runLiveArtifactsToolCli } from './tools-live-artifacts-cli.js';
 import { splitResearchSubcommand } from './research/cli-args.js';
+import { openBrowser } from './browser-open.js';
 
 const argv = process.argv.slice(2);
 
@@ -137,12 +138,7 @@ for (let i = 0; i < argv.length; i++) {
 startServer({ port, host }).then(url => {
   console.log(`[od] listening on ${url}`);
   if (open) {
-    const opener = process.platform === 'darwin' ? 'open'
-      : process.platform === 'win32' ? 'start'
-      : 'xdg-open';
-    import('node:child_process').then(({ spawn }) => {
-      spawn(opener, [url], { detached: true, stdio: 'ignore' }).unref();
-    });
+    openBrowser(url);
   }
 });
 }

--- a/apps/daemon/tests/browser-open.test.ts
+++ b/apps/daemon/tests/browser-open.test.ts
@@ -1,0 +1,40 @@
+import { EventEmitter } from 'node:events';
+import type { ChildProcess } from 'node:child_process';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createBrowserOpenInvocation, openBrowser } from '../src/browser-open.js';
+
+describe('browser open helper', () => {
+  it('opens URLs on Windows through cmd.exe instead of spawning the shell builtin directly', () => {
+    const invocation = createBrowserOpenInvocation('win32', 'http://127.0.0.1:7456/');
+
+    expect(invocation.command).toMatch(/cmd(?:\.exe)?$/i);
+    expect(invocation.args.slice(0, 3)).toEqual(['/d', '/s', '/c']);
+    expect(invocation.args[3]).toContain('start "" "http://127.0.0.1:7456/"');
+    expect(invocation.options).toMatchObject({ windowsVerbatimArguments: true });
+  });
+
+  it('escapes cmd.exe metacharacters before opening Windows URLs', () => {
+    const invocation = createBrowserOpenInvocation('win32', 'https://example.test/a b?q=%USERPROFILE%&name="A"');
+
+    expect(invocation.args[3]).toMatch(/^"start "" /);
+    expect(invocation.args[3]).toContain('"^%"USERPROFILE"^%"');
+    expect(invocation.args[3]).toContain('name=""A""');
+  });
+
+  it('handles opener spawn errors without crashing the daemon', () => {
+    const child = new EventEmitter() as ChildProcess;
+    child.unref = vi.fn() as ChildProcess['unref'];
+    const spawn = vi.fn(() => child);
+    const warn = vi.fn();
+
+    openBrowser('http://127.0.0.1:7456/', {
+      platform: 'linux',
+      spawn,
+      warn,
+    });
+
+    expect(() => child.emit('error', new Error('spawn xdg-open ENOENT'))).not.toThrow();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('failed to open browser'));
+  });
+});


### PR DESCRIPTION
## Summary

- Add a small daemon browser opener helper with platform-specific invocation details.
- Open Windows URLs through `cmd.exe /d /s /c start "" "<url>"` instead of spawning the `start` shell builtin directly.
- Attach an opener `error` handler so a missing platform opener warns instead of crashing the already-started daemon.

## Why

Refs #383.

The daemon CLI currently uses `spawn('start', [url])` on Windows. `start` is a `cmd.exe` builtin, not a standalone executable, so native Windows throws `spawn start ENOENT`. Because the detached child had no `error` listener, that best-effort browser-open failure could terminate the daemon after it had already started serving.

I updated my local checkout to latest `main` first. The Next.js dev-mode 404 described in #383 did not reproduce on latest `main` in my Windows native smoke (`/` returned 200 with only the Open Design title), so this PR is scoped to the still-relevant daemon browser opener crash.

## Validation

- `pnpm install`
- `pnpm tools-dev run web --daemon-port 17601 --web-port 17602`, then fetched `http://127.0.0.1:17602/`: HTTP 200, `<title>Open Design</title>`, no Next 404 title
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/browser-open.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/daemon build`
- `pnpm --filter @open-design/desktop build` followed by `pnpm typecheck`
- Production smoke on Windows native: `OD_WEB_PROD=1 node apps/daemon/dist/cli.js --port 17604` without `--no-open`; daemon stayed alive and `http://127.0.0.1:17604/` returned HTTP 200 with the Open Design title

## Known unrelated local test failures

`pnpm --filter @open-design/daemon test` still fails on latest `main` in this Windows native checkout outside this PR's opener path. The failures I saw are in existing agent executable override tests, Windows path normalization expectations in `server-paths.test.ts` / `mcp-config.test.ts`, two folder-import symlink status-code expectations, and one chat-route stalled-stream expectation. The focused opener regression test, daemon typecheck, daemon build, and root `pnpm typecheck` pass after building `@open-design/desktop`.
