### PR TITLE
fix: remove redundant Connect GitHub placeholder from import menu

### DIFF
--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -1066,7 +1066,6 @@ function ToolsImportPanel({
   return (
     <div className="composer-tools-list">
       <ImportItem icon="upload" label={t('chat.importFig')} t={t} />
-      <ImportItem icon="link" label={t('chat.importGitHub')} t={t} />
       <ImportItem icon="grid" label={t('chat.importWeb')} t={t} />
       <ImportItem
         icon="folder"


### PR DESCRIPTION
## Summary

Removes the redundant "Connect GitHub" placeholder from the chat composer import menu.

## Problem

GitHub connection is already available through the Connectors tab. The disabled "Connect GitHub" item in the chat composer import menu was a redundant placeholder that created confusion about duplicate entry points.

## Solution

Removed the `<ImportItem icon="link" label={t("chat.importGitHub")} t={t} />` line from `ChatComposer.tsx` (line 1069).

This streamlines the UI and directs users to the primary GitHub connection flow via Connectors.

## Changes

- **File modified**: `apps/web/src/components/ChatComposer.tsx`
- **Lines changed**: 1 deletion
- **Type**: UI cleanup

## Testing

- ✅ Verified the import menu no longer shows the disabled "Connect GitHub" item
- ✅ Confirmed GitHub connection still works via Connectors tab
- ✅ No breaking changes to existing functionality

## Related

Fixes #777