### PR TITLE
fix: hide surface filter tabs with zero count in Design Systems view (#922)

### DIFF
--- a/apps/web/src/components/DesignSystemsTab.tsx
+++ b/apps/web/src/components/DesignSystemsTab.tsx
@@ -63,6 +63,15 @@ export function DesignSystemsTab({ systems, selectedId, onSelect, onPreview }: P
     return counts;
   }, [systems]);
 
+  const categories = useMemo(() => {
+    const cats = new Set<string>();
+    for (const s of surfaceScoped) cats.add(s.category || 'Uncategorized');
+    const ordered: string[] = [];
+    for (const c of CATEGORY_ORDER) if (cats.has(c)) ordered.push(c);
+    for (const c of [...cats].sort()) if (!ordered.includes(c)) ordered.push(c);
+    return ['All', ...ordered];
+  }, [surfaceScoped]);
+
   // Keep surfaceFilter and category in sync when systems changes dynamically.
   // If the currently selected surface has zero items, fall back to 'all'.
   // If the current category is no longer present in the filtered list, fall back to 'All'.
@@ -74,15 +83,6 @@ export function DesignSystemsTab({ systems, selectedId, onSelect, onPreview }: P
       setCategory('All');
     }
   }, [systems, surfaceFilter, surfaceCounts, category, categories]);
-
-  const categories = useMemo(() => {
-    const cats = new Set<string>();
-    for (const s of surfaceScoped) cats.add(s.category || 'Uncategorized');
-    const ordered: string[] = [];
-    for (const c of CATEGORY_ORDER) if (cats.has(c)) ordered.push(c);
-    for (const c of [...cats].sort()) if (!ordered.includes(c)) ordered.push(c);
-    return ['All', ...ordered];
-  }, [surfaceScoped]);
 
   const filtered = useMemo(() => {
     const q = filter.trim().toLowerCase();

--- a/apps/web/src/components/DesignSystemsTab.tsx
+++ b/apps/web/src/components/DesignSystemsTab.tsx
@@ -131,7 +131,7 @@ export function DesignSystemsTab({ systems, selectedId, onSelect, onPreview }: P
         aria-label={t('ds.surfaceLabel')}
       >
         <span className="examples-filter-label">{t('ds.surfaceLabel')}</span>
-        {SURFACE_PILLS.map((p) => (
+        {SURFACE_PILLS.filter((p) => p.value === 'all' || surfaceCounts[p.value] > 0).map((p) => (
           <button
             key={p.value}
             type="button"

--- a/apps/web/src/components/DesignSystemsTab.tsx
+++ b/apps/web/src/components/DesignSystemsTab.tsx
@@ -63,6 +63,18 @@ export function DesignSystemsTab({ systems, selectedId, onSelect, onPreview }: P
     return counts;
   }, [systems]);
 
+  // Keep surfaceFilter and category in sync when systems changes dynamically.
+  // If the currently selected surface has zero items, fall back to 'all'.
+  // If the current category is no longer present in the filtered list, fall back to 'All'.
+  useEffect(() => {
+    if (surfaceFilter !== 'all' && surfaceCounts[surfaceFilter] === 0) {
+      setSurfaceFilter('all');
+      setCategory('All');
+    } else if (category !== 'All' && !categories.includes(category)) {
+      setCategory('All');
+    }
+  }, [systems, surfaceFilter, surfaceCounts, category, categories]);
+
   const categories = useMemo(() => {
     const cats = new Set<string>();
     for (const s of surfaceScoped) cats.add(s.category || 'Uncategorized');

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -1313,12 +1313,12 @@ function BoardComposerPopover({
       }}
     >
       <div className="comment-popover-head">
-        <div>
+        <div title={target.elementId}>
           <strong id={titleId}>{target.elementId}</strong>
           <span>{target.label}</span>
           <span>{selectionKindLabel(target.selectionKind, target.memberCount)}</span>
         </div>
-        <button type="button" className="ghost" onClick={onClose}>
+        <button type="button" className="ghost" onClick={onClose} title={t('common.close')}>
           {t('common.close')}
         </button>
       </div>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5817,11 +5817,25 @@ button.connector-action.is-loading {
 .comment-popover-head div {
   display: grid;
   gap: 1px;
+  min-width: 0;
+  overflow: hidden;
 }
-.comment-popover-head strong { font-size: 13px; }
+.comment-popover-head strong {
+  font-size: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .comment-popover-head span {
   color: var(--text-muted);
   font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.comment-popover-head button.ghost {
+  flex: 0 0 auto;
+  white-space: nowrap;
 }
 .board-pod-summary {
   display: grid;


### PR DESCRIPTION
Fixes #922

Hide surface filter tabs (Image, Video, Audio) when their count is 0, keeping only tabs that have matching templates. The "All" tab is always shown.