### PR TITLE
fix: ensure Settings close button is always clickable

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1204,11 +1204,10 @@ code {
   position: absolute;
   top: 14px;
   right: 14px;
-  z-index: 3;
+  z-index: 10;
   display: flex;
   align-items: center;
   gap: 8px;
-  pointer-events: none; /* children opt back in */
 }
 .settings-chrome > * {
   pointer-events: auto;


### PR DESCRIPTION
## Summary

Fixes the Settings close button becoming unclickable after PR #681 introduced the new Settings layout with Orbit summaries.

## Root Cause

The issue was caused by a combination of:

1. **Low z-index**: `.settings-chrome` had `z-index: 3`, which could be overridden by modal content in certain stacking contexts
2. **Pointer events pattern**: The `pointer-events: none` on the container with `pointer-events: auto` on children may not work reliably in all scenarios

## Changes

- Increased `.settings-chrome` z-index from `3` to `10` to ensure the close button always stays above all modal content
- Removed `pointer-events: none` from `.settings-chrome` container to avoid potential click interception issues
- `.settings-autosave` already has `pointer-events: none`, so it won't block clicks

## Testing

- Verified the CSS changes are minimal and focused
- The close button should now be reliably clickable across all Settings tabs and window sizes
- No visual changes to the UI

## Notes

This is a conservative fix that addresses the z-index stacking and pointer-events issues without touching the layout or structure introduced in PR #681.

Fixes #905