### PR TITLE
fix(daemon): write SSE events atomically in createSseResponse.send

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1790,9 +1790,13 @@ export function createSseResponse(
     /** @param {ChatSseEvent['event'] | ProxySseEvent['event'] | string} event */
     send(event, data, id: string | number | null | undefined = null) {
       if (!canWrite()) return false;
-      if (id !== null && id !== undefined) res.write(`id: ${id}\n`);
-      res.write(`event: ${event}\n`);
-      res.write(`data: ${JSON.stringify(data)}\n\n`);
+      // Assemble the full SSE event into a single write so id/event/data land
+      // in one TCP chunk. Three separate writes would let `event: <type>` flush
+      // ahead of the `data:` payload, which produces partial events for
+      // consumers that read chunk-by-chunk (e.g. tests using a Response body
+      // reader with a substring marker).
+      const idLine = id !== null && id !== undefined ? `id: ${id}\n` : '';
+      res.write(`${idLine}event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
       return true;
     },
     writeKeepAlive,


### PR DESCRIPTION
## Summary
- Combine the three `res.write()` calls in `createSseResponse.send` into one atomic write so each SSE event lands as a single TCP frame for sub-MTU events.
- Fixes four chat-route SSE tests in `apps/daemon/tests/chat-route.test.ts` (`surfaces Qoder assistant error records...`, `fails Qoder runs when the result reports is_error...`, `fails stalled json-stream runs after the inactivity timeout elapses`, `marks stalled runs failed even when the child ignores SIGTERM`) which were racing against the multi-write chunk split inside the `readSseUntil` helper.

## Why this is a real bug, not just a test fix
The three separate writes (`id:`, `event:`, `data:`) get flushed as three TCP chunks on a fast localhost connection. Any consumer that reads chunks and looks for the `event: <type>` marker can return between writes — the test helper hits that exact race, but production consumers that don't fully buffer events are vulnerable to the same partial-event read. Atomic-per-event writes match how other SSE implementations (rxjs/SSE, EventSource polyfills, Express SSE middlewares) emit events.

## Test plan
- [x] `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/chat-route.test.ts -t "surfaces Qoder|is_error with exit code 0|fails stalled json-stream|marks stalled runs failed even when"` — 4/4 pass (was 0/4)
- [x] `pnpm --filter @open-design/daemon test` — 86/86 test files pass
- [x] `pnpm typecheck` — clean across all 12 workspaces
- [x] Public API of `createSseResponse` unchanged; no callers needed updating

## Diff

```diff
     send(event, data, id: string | number | null | undefined = null) {
       if (!canWrite()) return false;
-      if (id !== null && id !== undefined) res.write(`id: ${id}\n`);
-      res.write(`event: ${event}\n`);
-      res.write(`data: ${JSON.stringify(data)}\n\n`);
+      // Assemble the full SSE event into a single write so id/event/data land
+      // in one TCP chunk. Three separate writes would let `event: <type>` flush
+      // ahead of the `data:` payload, which produces partial events for
+      // consumers that read chunk-by-chunk (e.g. tests using a Response body
+      // reader with a substring marker).
+      const idLine = id !== null && id !== undefined ? `id: ${id}\n` : '';
+      res.write(`${idLine}event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
       return true;
     },
```
