### PR TITLE
fix: reset inactivity watchdog on raw stdout bytes, not just parsed events (#918)

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -5550,6 +5550,12 @@ export async function startServer({
     child.stdout.setEncoding('utf8');
     child.stderr.setEncoding('utf8');
 
+    // Reset the inactivity watchdog on every raw stdout byte so that
+    // structured adapters that buffer partial lines (Codex item.completed,
+    // pi-rpc session/prompt, ACP agent messages) and models that spend a
+    // long time in non-streamed reasoning still keep the run alive.
+    child.stdout.on('data', () => noteAgentActivity());
+
     // Critique Theater branch (M0 dark launch, default disabled).
     // Only plain-stream adapters are routed through runOrchestrator in v1.
     // Adapters that emit structured wrappers (claude-stream-json,


### PR DESCRIPTION
Summary
---
Add a universal raw stdout activity listener so the agent inactivity watchdog resets on every byte written to the pipe, not just on complete parsed JSON events. Fixes false "Agent stalled without emitting any new output for 120s" errors across all seven structured stream formats.

Changes
---
apps/daemon/src/server.ts (1 file, +6 lines)
- Added child.stdout.on('data', () => noteAgentActivity()) at server.ts:5557, registered immediately after child.stdout.setEncoding('utf8') and before any format-specific stream dispatch
- Comment documents the affected adapters: Codex item.completed batching, pi-rpc session/prompt, ACP agent messages, and models with long non-streamed reasoning phases

Context
---
Structured stream handlers (Claude, Qoder, Copilot, Codex, OpenCode, pi-rpc, ACP) all use createJsonLineStream-style buffering — they accumulate bytes, split on newlines, and only emit events when a complete JSON line is parsed. noteAgentActivity() was only called on those parsed events.
During long model reasoning or buffered artifact generation — notably Codex 5.5 writing a full landing page HTML as a single item.completed event, or DeepSeek V4 / Kimi 2.6 spending >120s in non-streamed reasoning — the stdout pipe stays silent even though the agent is working. The watchdog fires and kills the run with a false stall error.
The fix adds a raw 'data' listener before any format-specific wiring. Node.js supports multiple 'data' listeners on readable streams — the raw listener fires first and resets the timer, then the format parser processes the chunk as before. Stderr was already covered (line 5805); stdout was the gap.