### PR TITLE
feat(daemon): expose gemini-3 preview models and 2.5-flash-lite in the Gemini picker

### DIFF
--- a/apps/daemon/src/agents.ts
+++ b/apps/daemon/src/agents.ts
@@ -349,8 +349,14 @@ export const AGENT_DEFS = [
     versionArgs: ['--version'],
     fallbackModels: [
       DEFAULT_MODEL_OPTION,
+      // Gemini 3 (May 2026): top-tier reasoning + fast frontier-class.
+      // Both currently ship as previews via the Gemini CLI. Issue #981.
+      { id: 'gemini-3-pro-preview', label: 'gemini-3-pro-preview' },
+      { id: 'gemini-3-flash-preview', label: 'gemini-3-flash-preview' },
       { id: 'gemini-2.5-pro', label: 'gemini-2.5-pro' },
       { id: 'gemini-2.5-flash', label: 'gemini-2.5-flash' },
+      // Cheapest 2.5 multimodal variant; useful for high-volume / low-latency work.
+      { id: 'gemini-2.5-flash-lite', label: 'gemini-2.5-flash-lite' },
     ],
     // Gemini reads from stdin when `-p` is omitted and stdin is a pipe.
     // Passing the full composed prompt as a CLI arg causes ENAMETOOLONG on

--- a/apps/daemon/tests/agents.test.ts
+++ b/apps/daemon/tests/agents.test.ts
@@ -709,6 +709,21 @@ test('gemini args preserve custom model selection', () => {
   ]);
 });
 
+test('gemini picker exposes the Gemini 3 previews and 2.5 family in priority order', () => {
+  // Pin the picker contents and ordering so the Settings UI cannot be
+  // silently reshaped by a future edit to AGENT_DEFS. Gemini also accepts
+  // arbitrary custom ids, which makes it especially easy for a regression
+  // here to slip through manual QA. Issue #981.
+  assert.deepEqual(gemini.fallbackModels.map((m) => m.id), [
+    'default',
+    'gemini-3-pro-preview',
+    'gemini-3-flash-preview',
+    'gemini-2.5-pro',
+    'gemini-2.5-flash',
+    'gemini-2.5-flash-lite',
+  ]);
+});
+
 test('qoder entry uses qodercli with stream-json stdin delivery and tier model hints', () => {
   assert.equal(qoder.name, 'Qoder CLI');
   assert.equal(qoder.bin, 'qodercli');


### PR DESCRIPTION
Closes #981.

The Gemini agent's `fallbackModels` registry in [`apps/daemon/src/agents.ts`](https://github.com/nexu-io/open-design/blob/main/apps/daemon/src/agents.ts) only listed `gemini-2.5-pro` and `gemini-2.5-flash`. The Gemini CLI itself supports the newer Gemini 3 generation (`gemini-3-pro-preview`, `gemini-3-flash-preview`) and `gemini-2.5-flash-lite` for low-latency multimodal work, so users were forced to either use \`Default\` or type the id by hand.

This adds the three ids to the fallback list with the same shape as the existing entries. No other behavior changes; \`Default\` and any custom id the user types still work as before.

Validated locally: \`pnpm guard\` and \`pnpm --filter @open-design/daemon typecheck\` clean.