### PR TITLE
fix(web): differentiate selected, hover, and focus states in the language switcher

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -3151,9 +3151,20 @@ code {
   text-align: left;
   color: var(--text);
 }
-.settings-language-option:hover,
-.settings-language-option.active { background: var(--bg-subtle); }
-.settings-language-option.active { color: var(--accent); }
+/* Differentiate hover, selected, and keyboard-focus states so the
+   currently-selected language is visually distinct even when the
+   pointer is hovering a different row. Issue #628. */
+.settings-language-option:hover { background: var(--bg-subtle); }
+.settings-language-option.active {
+  background: var(--accent-tint);
+  color: var(--accent);
+  font-weight: 500;
+}
+.settings-language-option.active:hover { background: var(--accent-soft); }
+.settings-language-option:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
 .empty-card {
   padding: 16px;
   border: 1px dashed var(--border);


### PR DESCRIPTION
Closes #628.

The Settings → Language menu used \`--bg-subtle\` for both \`:hover\` and \`.active\`, so the currently-selected language was hard to tell apart from a row the pointer was over, and \`:focus-visible\` had no treatment at all. The reporter's screenshot shows exactly that: pick a language, hover another row, and the active state effectively disappears.

CSS-only change in [\`apps/web/src/index.css\`](https://github.com/nexu-io/open-design/blob/main/apps/web/src/index.css):

- Selected row → \`--accent-tint\` background + accent text + \`font-weight: 500\` so the active choice reads even when nothing is hovered.
- Selected + hover → lifts to \`--accent-soft\` so the cursor still gives feedback over the active row.
- \`:focus-visible\` → 2px accent outline (inset) for keyboard users.

The existing \`.active\` className wiring in the React picker already drives this; no JSX changes needed.

Validated locally: \`pnpm guard\` and \`pnpm --filter @open-design/web typecheck\` clean.