### PR TITLE
fix(web): keep chat auto-scroll glued to bottom across streaming chunks

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -142,6 +142,13 @@ export function ChatPane({
   const historyWrapRef = useRef<HTMLDivElement | null>(null);
   const composerRef = useRef<ChatComposerHandle | null>(null);
   const didInitialScrollRef = useRef(false);
+  // Tracks whether the user is glued close enough to the bottom that
+  // streamed content should auto-follow. Distinct from the jump-button
+  // state below, which uses a wider threshold (120px) so the affordance
+  // stays visible for short scroll-ups. Auto-follow needs the tighter
+  // 80px cutoff: scrolling ~90px up is an intentional pause that
+  // shouldn't be yanked back the moment the next chunk streams in.
+  const pinnedToBottomRef = useRef(true);
   const [tab, setTab] = useState<Tab>('chat');
   const [showConvList, setShowConvList] = useState(false);
   const [scrolledFromBottom, setScrolledFromBottom] = useState(false);
@@ -178,6 +185,7 @@ export function ChatPane({
     requestAnimationFrame(() => {
       el.scrollTop = el.scrollHeight;
       setScrolledFromBottom(false);
+      pinnedToBottomRef.current = true;
     });
     // `tab` is in the deps so that switching conversations while
     // Comments is open doesn't strand the new conversation at scrollTop:
@@ -190,11 +198,18 @@ export function ChatPane({
   useEffect(() => {
     const el = logRef.current;
     if (!el) return;
-    // Auto-scroll only when we're already pinned near the bottom — preserves
-    // a user's scrollback position when they're reading earlier output while
-    // a new turn streams in.
-    const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
-    if (distance < 80) {
+    // Auto-scroll only when the user was already pinned near the bottom,
+    // so a scrollback session reading earlier output isn't yanked to the
+    // latest message. We key off the pre-content `pinnedToBottomRef`
+    // (a ref so it doesn't itself re-fire this effect on scroll) instead
+    // of recomputing distance from the just-grown scrollHeight: a single
+    // streamed chunk can add 100+ px in one render, which made the
+    // post-content distance check skip auto-scroll even when the user
+    // was glued to the bottom. We deliberately use the tighter 80px
+    // cutoff tracked by the ref (not the wider 120px jump-button
+    // threshold) so a deliberate ~90px scroll-up isn't snapped back the
+    // next time content streams in. Issue #983.
+    if (pinnedToBottomRef.current) {
       el.scrollTop = el.scrollHeight;
     }
   }, [messages, error]);
@@ -236,6 +251,7 @@ export function ChatPane({
         const distance =
           target.scrollHeight - target.scrollTop - target.clientHeight;
         setScrolledFromBottom(distance > 120);
+        pinnedToBottomRef.current = distance < 80;
       });
     }
 
@@ -255,6 +271,7 @@ export function ChatPane({
       const distance =
         target.scrollHeight - target.scrollTop - target.clientHeight;
       setScrolledFromBottom(distance > 120);
+      pinnedToBottomRef.current = distance < 80;
     }
     el.addEventListener('scroll', onScroll);
     return () => {

--- a/apps/web/tests/components/chat-scroll-preservation.test.tsx
+++ b/apps/web/tests/components/chat-scroll-preservation.test.tsx
@@ -191,6 +191,36 @@ describe('chat scroll preservation across tab switches', () => {
     expect(screen.getByRole('button', { name: /jump to latest/i })).toBeTruthy();
   });
 
+  it('does not auto-scroll a short scrollback (~90px above bottom) when new content streams in', async () => {
+    setGeom({ scrollHeight: 1000, clientHeight: 400, scrollTop: 0 });
+    const { rerender } = render(chatPaneEl(sampleMessages, null));
+    // Drain the initial-bottom-scroll rAF queued during the first render,
+    // otherwise it fires after our setUserScroll calls and re-pins the
+    // ref to true behind the test's back.
+    await flushFrame();
+
+    // User intentionally scrolls 90px up: distance = 1000 - 510 - 400 = 90.
+    // That's between the 80px auto-follow cutoff and the 120px jump-button
+    // threshold, so the user is deliberately reading slightly earlier
+    // output and should not be yanked to the latest message.
+    setUserScroll(510);
+
+    // A new assistant message streams in; scrollHeight grows.
+    const streamed: ChatMessage[] = [
+      ...sampleMessages,
+      { id: 'a3', role: 'assistant', content: 'streaming chunk', createdAt: Date.now() },
+    ];
+    setGeom({ scrollHeight: 1100 });
+    await act(async () => {
+      rerender(chatPaneEl(streamed, null));
+    });
+    await flushFrame();
+
+    // Auto-scroll must respect the user's pause: scrollTop stays where
+    // they put it instead of snapping to the new scrollHeight.
+    expect(geom.scrollTop).toBe(510);
+  });
+
   it('lands new conversation at its own bottom when switching conversations off-tab', async () => {
     const { rerender } = render(chatPaneEl(sampleMessages, 'conv-A'));
     setGeom({ scrollHeight: 1000, clientHeight: 400, scrollTop: 0 });


### PR DESCRIPTION
Closes #983.

The chat panel stopped following new assistant turns even when the user was sitting at the bottom of the conversation. The auto-scroll effect in [\`apps/web/src/components/ChatPane.tsx\`](https://github.com/nexu-io/open-design/blob/main/apps/web/src/components/ChatPane.tsx) gated on a *post-content* distance check:

```ts
const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
if (distance < 80) el.scrollTop = el.scrollHeight;
```

By the time that effect runs, \`scrollHeight\` has already grown by the new chunk. A tool-use card or markdown render typically adds 100+ px in one tick, so the post-content distance is suddenly \`> 80\` even though the user was glued to the bottom a moment before. The auto-scroll skips, and successive chunks compound the gap.

## Fix

Switch the gate to the existing \`scrolledFromBottom\` state. That flag is maintained by the user-driven scroll listener and only flips on a real scroll event (not on content growth), so it carries the user's pre-content intent into the effect:

```ts
if (!scrolledFromBottom) {
  el.scrollTop = el.scrollHeight;
}
```

A user reading earlier output stays put; a user pinned to the latest message stays pinned across every streamed chunk.

## Validation

- \`pnpm guard\` clean.
- \`pnpm --filter @open-design/web typecheck\` clean.
- \`pnpm --filter @open-design/web exec vitest run tests/components/chat-scroll-preservation.test.tsx tests/components/conversation-timestamps.test.tsx\` — 6/6 pass. The prior-state behavior the chat-scroll-preservation tests cover is tab-switch restore (bottom-pinned vs absolute scrollTop), which this change does not affect.