### PR TITLE
fix(web): scroll the active workspace tab into view when the strip overflows

### DIFF
--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -247,6 +247,36 @@ export function FileWorkspace({
     return () => tabBar.removeEventListener('wheel', onWheel);
   }, []);
 
+  // Browser-style tab bar: when the active tab changes (open from a chat
+  // file chip, switch via Cmd+P, etc.), scroll it into view so the user
+  // can always see what they have selected even when the strip overflows.
+  // The Design Files entry is already sticky-pinned, so we only scroll
+  // for real workspace tabs. Issue #775.
+  useEffect(() => {
+    if (activeTab === DESIGN_FILES_TAB) return;
+    const tabBar = tabsBarRef.current;
+    if (!tabBar) return;
+    const el = tabBar.querySelector<HTMLElement>('.ws-tab.active');
+    if (!el) return;
+    // The Design Files tab is sticky-pinned to the scrollport's left
+    // edge (index.css:.ws-tab.design-files-tab), so a naive scrollIntoView
+    // with inline: 'nearest' would slide a leftward-jumped active tab
+    // flush with that edge and leave it hidden underneath the sticky
+    // panel. Compute scrollLeft manually instead, treating the sticky
+    // tab's right edge as the effective visible-left boundary.
+    const tabRect = el.getBoundingClientRect();
+    const barRect = tabBar.getBoundingClientRect();
+    const stickyEl = tabBar.querySelector<HTMLElement>('.ws-tab.design-files-tab');
+    const stickyWidth = stickyEl ? stickyEl.getBoundingClientRect().width : 0;
+    const visibleLeft = barRect.left + stickyWidth;
+    const visibleRight = barRect.right;
+    if (tabRect.left < visibleLeft) {
+      tabBar.scrollLeft += tabRect.left - visibleLeft;
+    } else if (tabRect.right > visibleRight) {
+      tabBar.scrollLeft += tabRect.right - visibleRight;
+    }
+  }, [activeTab]);
+
   // Cmd+P (mac) / Ctrl+P (win/linux) opens the file palette. Capture phase
   // so we beat the browser's default print dialog. Platform-gated so on
   // macOS we don't steal Ctrl+P from native readline ("previous line") in


### PR DESCRIPTION
Closes #775.

PR #842 already pinned the Design Files entry to the left edge of the workspace tab strip. This handles the other half of the issue: keeping the **active** tab visible when the strip overflows.

Right now opening a tab via Cmd+P, clicking a chat file chip, or activating from the Design Files panel can leave the active tab parked entirely off-screen, and the user has to wheel the strip to find what they just opened.

## Fix

Add a small effect on \`activeTab\` change in [\`apps/web/src/components/FileWorkspace.tsx\`](https://github.com/nexu-io/open-design/blob/main/apps/web/src/components/FileWorkspace.tsx):

```ts
useEffect(() => {
  if (activeTab === DESIGN_FILES_TAB) return;
  const tabBar = tabsBarRef.current;
  if (!tabBar) return;
  const el = tabBar.querySelector<HTMLElement>('.ws-tab.active');
  if (!el) return;
  el.scrollIntoView({ behavior: 'auto', block: 'nearest', inline: 'nearest' });
}, [activeTab]);
```

\`inline: 'nearest'\` is the browser-tab-strip behavior the issue asks for: the strip only scrolls when the active tab isn't already in view, so it doesn't yank the user around when they're already looking at it. Design Files is excluded because the existing sticky CSS already keeps it visible.

## Validation

- \`pnpm guard\` clean.
- \`pnpm --filter @open-design/web typecheck\` clean.
- \`pnpm --filter @open-design/web exec vitest run tests/components/FileWorkspace.test.tsx\` — 13/13 pass.