### PR TITLE
fix(web): give the deploy modal primary action a bit more breathing room

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -4737,7 +4737,7 @@ function HtmlViewer({
       ) : null}
       {deployModalOpen ? (
         <div className="modal-backdrop" role="presentation">
-          <div className="modal deploy-modal" role="dialog" aria-modal="true">
+          <div className="modal deploy-modal deploy-flow-modal" role="dialog" aria-modal="true">
             <div className="modal-head">
               <div className="kicker">{deployProviderLabel}</div>
               <h2>{t('fileViewer.deployToProvider', { provider: deployProviderLabel })}</h2>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -9368,6 +9368,19 @@ button.ghost.mcp-copy-btn:hover:not(:disabled) {
   max-height: calc(100vh - 32px);
   overflow: auto;
 }
+/* Add a few extra pixels above the deploy dialog's primary action so
+   it does not crowd the divider. The shared .modal-foot uses 12px
+   vertical padding which is fine for shorter dialogs but reads as
+   cramped here because the deploy form ends in dense token / domain
+   config rows that push content right up to the border. Scoped to the
+   deploy dialog only (the template-save dialog also carries the
+   .deploy-modal class on its root, which is why we key off the
+   purpose-specific .deploy-flow-modal hook instead). 16px matches the
+   bump proposed for the global rule in #957 so the rhythm stays close
+   to the rest of the app. Issue #913. */
+.deploy-flow-modal .modal-foot {
+  padding-top: 16px;
+}
 .deploy-form {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Closes #913.

The deploy modal's primary action button (Cloudflare Pages, etc.) was sitting flush against the divider that separates the dialog body from the footer. The shared `.modal-foot` rule uses 12px vertical padding, which feels fine in the shorter dialogs that share it (sketch close confirm, template save) but reads as cramped in deploy because the form above ends in dense token / domain config rows that push content right up to the divider.

Added a deploy-modal-scoped override at https://github.com/nexu-io/open-design/blob/main/apps/web/src/index.css to nudge the footer top padding to 18px. Bottom padding stays on the shared 12px so the overall dialog height does not jump and we are not making any global change to other modals' rhythm.

### What I checked
- `pnpm guard` and `pnpm --filter @open-design/web typecheck` clean.
- `pnpm --filter @open-design/web test` (567 passed).
- Visual check that the deploy modal primary button no longer crowds the divider while the cancel button alignment, modal height, and surrounding spacing are unchanged.