### PR TITLE
fix(web): hide the Save comment button on Pods (issue #792)

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -1419,14 +1419,16 @@ function BoardComposerPopover({
         >
           Add note
         </button>
-        <button
-          type="button"
-          className="ghost"
-          disabled={target.selectionKind === 'pod' || !draft.trim()}
-          onClick={() => void onSaveComment()}
-        >
-          Save comment
-        </button>
+        {target.selectionKind === 'pod' ? null : (
+          <button
+            type="button"
+            className="ghost"
+            disabled={!draft.trim()}
+            onClick={() => void onSaveComment()}
+          >
+            Save comment
+          </button>
+        )}
         <button
           type="button"
           className="primary"


### PR DESCRIPTION
Closes #792.

The board comment popover already gated `Save comment` behind `disabled={target.selectionKind === 'pod' || !draft.trim()}`, which meant on a Pods selection the button was visible but greyed out. That reads like a normal "needs input" disabled state and gives users no signal that the operation is unsupported here, which is exactly the misleading-affordance pattern #792 asked us to clean up.

Now we drop rendering the button when `selectionKind === 'pod'` so the popover footer collapses to `Add note` + `Send to chat`, which are the affordances Pods actually uses. The disabled prop on the remaining call site only carries the draft-empty constraint, since the pod check is no longer needed.

Source: https://github.com/nexu-io/open-design/blob/main/apps/web/src/components/FileViewer.tsx

### What I checked
- `pnpm guard` clean.
- `pnpm --filter @open-design/web typecheck` clean.
- `pnpm --filter @open-design/web test` (568 passed).
- Visual check that an Inspect comment popover still shows Save comment, and a Pods popover only shows Add note + Send to chat with the same layout rhythm as before.