### PR TITLE
fix(daemon): make the connector Close window button always give feedback

### DIFF
--- a/apps/daemon/src/connectors/routes.ts
+++ b/apps/daemon/src/connectors/routes.ts
@@ -476,17 +476,34 @@ function renderConnectorConnectedHtml(connectorId: string): string {
           closeButton.textContent = 'Close this tab manually';
           hint.textContent = 'Your browser blocked automatic closing. You can close this tab and return to Open Design.';
         }
+        function hasLiveOpener() {
+          try {
+            return Boolean(window.opener) && !window.opener.closed;
+          } catch {
+            return false;
+          }
+        }
         function requestClose() {
+          // window.close() is silently rejected by browsers when the tab
+          // was not opened by a script (no opener), so trying it from a
+          // direct navigation always looks like the button "did nothing".
+          // Skip the no-op call and surface the manual-close instructions
+          // immediately so the click visibly produces feedback. Issue #669.
+          if (!hasLiveOpener()) {
+            showManualCloseHint();
+            return;
+          }
           try {
             window.close();
           } finally {
-            window.setTimeout(() => {
-              if (document.visibilityState === 'visible') showManualCloseHint();
-            }, 250);
+            // If the page is still alive after the close attempt, the
+            // browser blocked it. Update the hint unconditionally; if
+            // close did succeed the page is unloading and this never runs.
+            window.setTimeout(showManualCloseHint, 400);
           }
         }
         try {
-          if (window.opener && !window.opener.closed) {
+          if (hasLiveOpener()) {
             window.opener.postMessage(message, '*');
             window.setTimeout(requestClose, 900);
           } else {


### PR DESCRIPTION
Closes #669.

When the connector callback page is reached via direct navigation rather than the daemon's popup-driven flow (linked from a different tab, opened in a new window by the OAuth provider, etc.) there is no `window.opener` and any `window.close()` call is silently rejected by the browser. The previous handler called close anyway and only flipped the manual-close hint after a 250ms timer gated on `visibilityState === 'visible'`. If the visibility check ever read `'hidden'` (the popup losing focus during the close attempt is enough), the hint never updated and the button looked completely dead.

The new code detects the no-opener case up front. With no live opener, the click skips the no-op close call and shows the manual-close instructions immediately, so the user sees instant feedback. When there is an opener, the hint update is scheduled unconditionally after the close attempt: if close actually worked the page is unloading and the timer never runs, otherwise the hint reliably surfaces.

Source: https://github.com/nexu-io/open-design/blob/main/apps/daemon/src/connectors/routes.ts

### What I checked
- `pnpm guard` and `pnpm --filter @open-design/daemon typecheck` clean.
- `pnpm --filter @open-design/daemon exec vitest run tests/connectors` (75 passed).
- Walked the script logic by hand for the three observable states: popup with live opener (auto + manual close attempt), popup whose opener has been closed (manual hint immediately), direct tab nav (manual hint immediately).