### PR TITLE
fix(web): disable Design Files Up button when no preview is open

### DIFF
--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -232,6 +232,7 @@ export function DesignFilesPanel({
             type="button"
             className="icon-only"
             onClick={() => setPreview(null)}
+            disabled={!preview}
             title={t('designFiles.up')}
             aria-label={t('designFiles.back')}
           >


### PR DESCRIPTION
Closes #772.

The upward-arrow button at the top of DesignFilesPanel exists to back out of an open preview (it calls `setPreview(null)`). When no preview is active, clicking it is a silent no-op, which is exactly what #772 reported: a control that visually looks like it could be a "sort up" affordance but produces no visible effect. Adding `disabled={!preview}` lights it up only when there is an active preview to leave, so the dead-button confusion goes away without changing what the button does in its actual role.

Source: https://github.com/nexu-io/open-design/blob/main/apps/web/src/components/DesignFilesPanel.tsx

### What I checked
- `pnpm guard` and `pnpm --filter @open-design/web typecheck` clean.
- `pnpm --filter @open-design/web test` (568 passed).
- Visual check: with no preview, the Up button renders as disabled and clicking it does nothing visible. After opening a file preview, the button is enabled again and dismisses the preview as before.