### PR TITLE
fix(web): reset Settings content scroll on section change

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -535,6 +535,12 @@ export function SettingsDialog({
   const [showApiKey, setShowApiKey] = useState(false);
   const [languageOpen, setLanguageOpen] = useState(false);
   const [activeSection, setActiveSection] = useState<SettingsSection>(initialSection);
+  // Scroll the right-hand content pane back to the top whenever the user
+  // picks a different settings section. Without this, switching from a
+  // long section the user had scrolled (e.g. Library) into a short one
+  // (About) keeps the previous scrollTop, so the new section's header
+  // can land out of view and the panel reads as half-loaded. Issue #634.
+  const settingsContentRef = useRef<HTMLDivElement | null>(null);
   const [languageMenuRect, setLanguageMenuRect] = useState<DOMRect | null>(null);
   const [agentRescanRunning, setAgentRescanRunning] = useState(false);
   const [agentRescanNotice, setAgentRescanNotice] =
@@ -560,6 +566,10 @@ export function SettingsDialog({
   useEffect(() => {
     setActiveSection(initialSection);
   }, [initialSection]);
+  useEffect(() => {
+    const el = settingsContentRef.current;
+    if (el) el.scrollTop = 0;
+  }, [activeSection]);
 
   // Tests pin a result against the unsaved draft. Once the user edits any
   // field that feeds into the test, the result is no longer trustworthy —
@@ -1241,7 +1251,7 @@ export function SettingsDialog({
               </span>
             </button>
           </aside>
-          <div className="settings-content">
+          <div className="settings-content" ref={settingsContentRef}>
           {activeSection === 'execution' ? (
             <>
               <div


### PR DESCRIPTION
Closes #634.

Switching settings sections (for example clicking About after scrolling around in Library or Pets) kept the previous `scrollTop` on the right-hand content panel, so the new section's header often landed below the fold and the panel read as half-loaded. The complaint in #634 was specifically about reaching About from a sidebar position near the bottom and finding the About content not fully visible.

Added a ref on `.settings-content` and a small `useEffect` that resets `scrollTop` to 0 whenever `activeSection` changes. The sidebar's own scroll position is left alone, so users who had to scroll the sidebar to reach a tab still see that tab in view after clicking it. Source: https://github.com/nexu-io/open-design/blob/main/apps/web/src/components/SettingsDialog.tsx

### What I checked
- `pnpm guard` and `pnpm --filter @open-design/web typecheck` clean.
- `pnpm --filter @open-design/web test` (568 passed; SettingsDialog suite covers section switching).
- Visual check: open Settings, scroll Library, click About, confirm About lands at the top of the content panel. Repeat with Pets and Notifications.