### PR TITLE
feat(daemon): Critique Theater Phase 6.2 (rerun endpoint)

### DIFF
--- a/apps/daemon/src/critique/rerun-handler.ts
+++ b/apps/daemon/src/critique/rerun-handler.ts
@@ -1,0 +1,119 @@
+import type { Request, Response } from 'express';
+import type Database from 'better-sqlite3';
+import { getCritiqueRun, type CritiqueRoundSummary, type CritiqueRunStatus } from './persistence.js';
+
+/** HTTP status codes used by the rerun endpoint. */
+const HTTP_BAD_REQUEST = 400;
+const HTTP_NOT_FOUND = 404;
+const HTTP_CONFLICT = 409;
+const HTTP_OK = 200;
+
+/**
+ * Payload returned to clients that asked to rerun a finished critique. The
+ * shape is intentionally a thin reference into the original run rather than a
+ * full new run row: the daemon does not start the next critique by itself,
+ * since the spawn path needs the agent / model / prompt context that lives in
+ * the chat layer. The web reducer (Phase 7) and Theater UI (Phase 8) consume
+ * this payload to drive a fresh chat send with `priorArtifactPath` attached
+ * so the new run can ground its critique against the previous artifact.
+ */
+export interface CritiqueRerunContext {
+  originalRunId: string;
+  projectId: string;
+  conversationId: string | null;
+  /** Path of the original artifact, surfaced as prior-art reference. */
+  priorArtifactPath: string | null;
+  protocolVersion: number;
+  /** Final status the original run terminated in (for UI labeling). */
+  originalStatus: CritiqueRunStatus;
+  /** Final composite score from the original run, if scored. */
+  originalScore: number | null;
+  /** Per-round summaries from the original, so UI can show "what we are improving on". */
+  originalRounds: CritiqueRoundSummary[];
+}
+
+/**
+ * POST /api/projects/:projectId/critique/:runId/rerun
+ *
+ * Resolves the original run and returns the reference payload the web layer
+ * needs to spawn a fresh critique with the original artifact attached as
+ * prior-art context. The endpoint itself is read-only: it does not mutate the
+ * critique_runs table or start a child process. That keeps the request
+ * idempotent and safe to retry, and it matches how Phase 6.1 (interrupt)
+ * exposes a thin verb on top of state the orchestrator owns.
+ *
+ * Status semantics:
+ *   200 — happy path; body is `CritiqueRerunContext`.
+ *   400 — projectId/runId missing in the URL.
+ *   404 — original run not found, or belongs to a different project.
+ *   409 — original is still 'running'; rerun while in flight is meaningless.
+ *
+ * @see specs/current/critique-theater.md § rerun endpoint (Task 6.2)
+ */
+export function handleCritiqueRerun(
+  db: Database.Database,
+): (req: Request, res: Response) => void {
+  return function critiqueRerunHandler(req: Request, res: Response): void {
+    const projectId =
+      typeof req.params['projectId'] === 'string'
+        ? req.params['projectId'].trim()
+        : '';
+    const runId =
+      typeof req.params['runId'] === 'string'
+        ? req.params['runId'].trim()
+        : '';
+
+    if (!projectId || !runId) {
+      res
+        .status(HTTP_BAD_REQUEST)
+        .json({ error: { code: 'BAD_REQUEST', message: 'projectId and runId are required' } });
+      return;
+    }
+
+    const row = getCritiqueRun(db, runId);
+
+    // Cross-project leak guard mirrors the interrupt endpoint: a request
+    // against project p1 must not reveal that runId actually lives in p2.
+    if (row === null || row.projectId !== projectId) {
+      res
+        .status(HTTP_NOT_FOUND)
+        .json({ error: { code: 'NOT_FOUND', message: 'critique run not found' } });
+      return;
+    }
+
+    // CritiqueRunStatus deliberately omits 'running' from its public union
+    // (only terminal states are exposed), but the DB CHECK constraint
+    // accepts it for in-flight rows. Widen here to match the runtime
+    // value before comparing, mirroring how the interrupt handler does it.
+    const liveStatus = row.status as CritiqueRunStatus | 'running';
+    if (liveStatus === 'running') {
+      // Reruning an in-flight run is meaningless: the original has not
+      // produced its final artifact yet, so the prior-art context the new
+      // run would attach is not stable. Clients should interrupt first
+      // (Task 6.1) and only ask for a rerun once the original is terminal.
+      res
+        .status(HTTP_CONFLICT)
+        .json({
+          error: {
+            code: 'CONFLICT',
+            message: 'cannot rerun a run that is still running; interrupt it first',
+            currentStatus: row.status,
+          },
+        });
+      return;
+    }
+
+    const payload: CritiqueRerunContext = {
+      originalRunId: row.id,
+      projectId: row.projectId,
+      conversationId: row.conversationId,
+      priorArtifactPath: row.artifactPath,
+      protocolVersion: row.protocolVersion,
+      originalStatus: row.status,
+      originalScore: row.score,
+      originalRounds: row.rounds,
+    };
+
+    res.status(HTTP_OK).json(payload);
+  };
+}

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -45,6 +45,7 @@ import { reconcileStaleRuns } from './critique/persistence.js';
 import { runOrchestrator } from './critique/orchestrator.js';
 import { createRunRegistry } from './critique/run-registry.js';
 import { handleCritiqueInterrupt } from './critique/interrupt-handler.js';
+import { handleCritiqueRerun } from './critique/rerun-handler.js';
 import { createCopilotStreamHandler } from './copilot-stream.js';
 import { createJsonEventStreamHandler } from './json-event-stream.js';
 import { createQoderStreamHandler } from './qoder-stream.js';
@@ -6199,6 +6200,17 @@ export async function startServer({
   app.post(
     '/api/projects/:projectId/critique/:runId/interrupt',
     handleCritiqueInterrupt(db, critiqueRunRegistry),
+  );
+
+  // POST /api/projects/:projectId/critique/:runId/rerun
+  // Returns the rerun-context payload (prior artifact path, original score,
+  // round summaries) the web layer needs to spawn a fresh critique with the
+  // original artifact attached as prior-art context. Read-only; the daemon
+  // does not start the new run itself, since the spawn path needs the agent /
+  // model / prompt context that lives in the chat layer (Task 6.2).
+  app.post(
+    '/api/projects/:projectId/critique/:runId/rerun',
+    handleCritiqueRerun(db),
   );
 
   // ---- API Proxy (SSE) for API-compatible endpoints ------------------------

--- a/apps/daemon/tests/critique-rerun-endpoint.test.ts
+++ b/apps/daemon/tests/critique-rerun-endpoint.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Tests for POST /api/projects/:projectId/critique/:runId/rerun
+ *
+ * Each test mounts the rerun handler on a fresh express mini-app with an
+ * in-memory SQLite database so the full handler logic is exercised without
+ * starting the full daemon server.
+ *
+ * @see specs/current/critique-theater.md § rerun endpoint (Task 6.2)
+ */
+import http from 'node:http';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import Database from 'better-sqlite3';
+import {
+  insertCritiqueRun,
+  migrateCritique,
+  type CritiqueRoundSummary,
+} from '../src/critique/persistence.js';
+import { handleCritiqueRerun } from '../src/critique/rerun-handler.js';
+
+// ---------------------------------------------------------------------------
+// Test infrastructure
+// ---------------------------------------------------------------------------
+
+function freshDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  db.exec(`
+    CREATE TABLE projects (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY(project_id) REFERENCES projects(id) ON DELETE CASCADE
+    );
+    INSERT INTO projects (id, name, created_at, updated_at) VALUES ('p1', 'Project 1', 0, 0);
+    INSERT INTO projects (id, name, created_at, updated_at) VALUES ('p2', 'Project 2', 0, 0);
+  `);
+  migrateCritique(db);
+  return db;
+}
+
+function startMiniServer(
+  db: Database.Database,
+): Promise<{ baseUrl: string; server: http.Server }> {
+  const app = express();
+  app.use(express.json());
+  app.post(
+    '/api/projects/:projectId/critique/:runId/rerun',
+    handleCritiqueRerun(db),
+  );
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (!addr || typeof addr !== 'object') {
+        reject(new Error('could not bind'));
+        return;
+      }
+      resolve({ baseUrl: `http://127.0.0.1:${addr.port}`, server });
+    });
+    server.on('error', reject);
+  });
+}
+
+async function post(url: string): Promise<{ status: number; json: unknown }> {
+  const res = await fetch(url, { method: 'POST' });
+  const json: unknown = await res.json().catch(() => null);
+  return { status: res.status, json };
+}
+
+const SAMPLE_ROUNDS: CritiqueRoundSummary[] = [
+  { n: 1, composite: 7.2, mustFix: 3, decision: 'continue' },
+  { n: 2, composite: 8.4, mustFix: 0, decision: 'ship' },
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('POST /api/projects/:projectId/critique/:runId/rerun', () => {
+  let db: Database.Database;
+  let baseUrl: string;
+  let server: http.Server;
+
+  beforeEach(async () => {
+    db = freshDb();
+    ({ baseUrl, server } = await startMiniServer(db));
+  });
+
+  afterEach(() => {
+    db.close();
+    return new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  // ---- 200: happy path -----------------------------------------------------
+
+  it('returns 200 with the rerun context for a shipped run', async () => {
+    insertCritiqueRun(db, {
+      id: 'crun_ok',
+      projectId: 'p1',
+      conversationId: null,
+      artifactPath: 'design/landing.html',
+      status: 'shipped',
+      score: 8.4,
+      rounds: SAMPLE_ROUNDS,
+      protocolVersion: 1,
+    });
+
+    const { status, json } = await post(`${baseUrl}/api/projects/p1/critique/crun_ok/rerun`);
+
+    expect(status).toBe(200);
+    expect(json).toMatchObject({
+      originalRunId: 'crun_ok',
+      projectId: 'p1',
+      conversationId: null,
+      priorArtifactPath: 'design/landing.html',
+      protocolVersion: 1,
+      originalStatus: 'shipped',
+      originalScore: 8.4,
+      originalRounds: SAMPLE_ROUNDS,
+    });
+  });
+
+  it('returns the rerun context for a below_threshold terminal run', async () => {
+    insertCritiqueRun(db, {
+      id: 'crun_low',
+      projectId: 'p1',
+      artifactPath: 'design/about.html',
+      status: 'below_threshold',
+      score: 6.1,
+      rounds: SAMPLE_ROUNDS.slice(0, 1),
+      protocolVersion: 1,
+    });
+
+    const { status, json } = await post(`${baseUrl}/api/projects/p1/critique/crun_low/rerun`);
+
+    expect(status).toBe(200);
+    expect(json).toMatchObject({
+      originalRunId: 'crun_low',
+      originalStatus: 'below_threshold',
+      originalScore: 6.1,
+      priorArtifactPath: 'design/about.html',
+    });
+  });
+
+  it('does not mutate the original row', async () => {
+    insertCritiqueRun(db, {
+      id: 'crun_immut',
+      projectId: 'p1',
+      artifactPath: 'design/x.html',
+      status: 'shipped',
+      score: 9,
+      rounds: SAMPLE_ROUNDS,
+      protocolVersion: 1,
+    });
+
+    const before = db.prepare('SELECT * FROM critique_runs WHERE id = ?').get('crun_immut');
+    await post(`${baseUrl}/api/projects/p1/critique/crun_immut/rerun`);
+    const after = db.prepare('SELECT * FROM critique_runs WHERE id = ?').get('crun_immut');
+
+    expect(after).toEqual(before);
+  });
+
+  // ---- 404: unknown run ----------------------------------------------------
+
+  it('returns 404 when the run does not exist', async () => {
+    const { status, json } = await post(`${baseUrl}/api/projects/p1/critique/ghost/rerun`);
+    expect(status).toBe(404);
+    expect(json).toMatchObject({ error: { code: 'NOT_FOUND' } });
+  });
+
+  it('returns 404 when the run belongs to a different project (cross-project leak guard)', async () => {
+    insertCritiqueRun(db, {
+      id: 'crun_other',
+      projectId: 'p2',
+      status: 'shipped',
+      score: 9,
+      rounds: SAMPLE_ROUNDS,
+      protocolVersion: 1,
+    });
+
+    const { status } = await post(`${baseUrl}/api/projects/p1/critique/crun_other/rerun`);
+    expect(status).toBe(404);
+  });
+
+  // ---- 409: still running --------------------------------------------------
+
+  it('returns 409 when the original run is still running', async () => {
+    insertCritiqueRun(db, {
+      id: 'crun_running',
+      projectId: 'p1',
+      status: 'running',
+      protocolVersion: 1,
+    });
+
+    const { status, json } = await post(
+      `${baseUrl}/api/projects/p1/critique/crun_running/rerun`,
+    );
+
+    expect(status).toBe(409);
+    expect(json).toMatchObject({
+      error: { code: 'CONFLICT', currentStatus: 'running' },
+    });
+  });
+
+  // ---- 400: bad input ------------------------------------------------------
+
+  it('returns 400 when runId is whitespace-only', async () => {
+    const { status } = await post(`${baseUrl}/api/projects/p1/critique/%20/rerun`);
+    expect(status).toBe(400);
+  });
+
+  // ---- terminal-state coverage --------------------------------------------
+
+  it('allows rerun from interrupted, timed_out, degraded, failed and legacy states', async () => {
+    const cases: Array<['interrupted' | 'timed_out' | 'degraded' | 'failed' | 'legacy']> = [
+      ['interrupted'],
+      ['timed_out'],
+      ['degraded'],
+      ['failed'],
+      ['legacy'],
+    ];
+    for (const [state] of cases) {
+      const id = `crun_${state}`;
+      insertCritiqueRun(db, {
+        id,
+        projectId: 'p1',
+        status: state,
+        protocolVersion: 1,
+      });
+      const { status, json } = await post(`${baseUrl}/api/projects/p1/critique/${id}/rerun`);
+      expect(status).toBe(200);
+      expect((json as { originalStatus: string }).originalStatus).toBe(state);
+    }
+  });
+});


### PR DESCRIPTION
Completes Phase 6 of the Critique Theater rollout by shipping the rerun endpoint that pairs with Phase 6.1's interrupt route ([#819](https://github.com/nexu-io/open-design/pull/819)).

`POST /api/projects/:projectId/critique/:runId/rerun` returns the reference payload the web layer needs to spawn a fresh critique with the original artifact attached as prior-art context: `originalRunId`, `projectId`, `conversationId`, `priorArtifactPath`, `protocolVersion`, `originalStatus`, `originalScore`, and the per-round summaries.

### Why read-only

Starting the new run itself lives in the chat spawn path because it needs the agent / model / prompt context that does not exist on the `critique_runs` row. Inserting a placeholder `'running'` row from this endpoint would just leave dangling state for the reconciler to clean up and would confuse the in-process run registry. Keeping rerun read-only also makes the request idempotent and safe to retry, which matched the design intent of the spec note in `specs/current/critique-theater-plan.md` § Task 6.2.

### Status semantics

- `200` — happy path; body is the rerun-context payload.
- `400` — `projectId`/`runId` missing or whitespace-only.
- `404` — original run not found, or belongs to a different project (cross-project leak guard mirrors the interrupt handler).
- `409` — original is still `'running'`; the prior-art reference is not stable yet, so clients should interrupt first and only ask for a rerun once the original is terminal.

### Coverage

8 vitest cases in [`apps/daemon/tests/critique-rerun-endpoint.test.ts`](https://github.com/nexu-io/open-design/blob/feat/critique-theater-phase6.2-rerun/apps/daemon/tests/critique-rerun-endpoint.test.ts):

- Happy path on `shipped` and `below_threshold`.
- Immutability of the original row (DB-row diff).
- 404 unknown id.
- 404 cross-project (runId belongs to a different project).
- 409 when original is still `'running'`.
- 400 on whitespace-only `runId`.
- Rerun allowed from every other terminal status: `interrupted`, `timed_out`, `degraded`, `failed`, `legacy`.

### Source files

- [`apps/daemon/src/critique/rerun-handler.ts`](https://github.com/nexu-io/open-design/blob/feat/critique-theater-phase6.2-rerun/apps/daemon/src/critique/rerun-handler.ts) — handler factory.
- [`apps/daemon/tests/critique-rerun-endpoint.test.ts`](https://github.com/nexu-io/open-design/blob/feat/critique-theater-phase6.2-rerun/apps/daemon/tests/critique-rerun-endpoint.test.ts) — endpoint tests.
- [`apps/daemon/src/server.ts`](https://github.com/nexu-io/open-design/blob/feat/critique-theater-phase6.2-rerun/apps/daemon/src/server.ts) — route wiring next to the interrupt route.

### Validation

- `pnpm guard` and `pnpm --filter @open-design/daemon typecheck` clean.
- `pnpm --filter @open-design/daemon exec vitest run tests/critique-rerun-endpoint.test.ts` (8/8 pass).