### PR TITLE
fix(daemon): version-aware Gemini binary resolution (#978)

### DIFF
--- a/apps/daemon/src/agents.ts
+++ b/apps/daemon/src/agents.ts
@@ -1160,21 +1160,29 @@ export function enumerateOnPath(bin) {
 // otherwise-valid Gemini CLI versions just because the upstream tags
 // shipped that way.
 //
-// Returns 0 (equal) when either side is unparseable — the caller
-// already has a fall-through path to "use first found", so an
-// unparseable version shouldn't accidentally read as "lower than
-// minVersion" and disqualify a fine binary.
+// Returns `null` when either side is unparseable. The caller MUST
+// distinguish that from `0` (equal) — folding both into "passes the
+// floor" let an old `gemini` that prints a banner like
+// `gemini version 0.1.12` (instead of bare `0.1.12`) sneak past the
+// minVersion check and re-introduce #978. Only callers that have
+// their own fall-through path can safely treat null as "skip this
+// candidate".
 export function compareSemver(a, b) {
   const parse = (raw) => {
     if (typeof raw !== 'string') return null;
     const trimmed = raw.trim().replace(/^v/i, '');
+    // Anchor `^` so a banner like `gemini version 0.1.12` no longer
+    // reads as the bare semver `0.1.12` — that misread was the P1 in
+    // mrcfps + lefarcen's review of #1007: an old Gemini whose
+    // `--version` prints prose with embedded numbers would otherwise
+    // pass the minVersion floor and shadow a modern install.
     const match = trimmed.match(/^(\d+)\.(\d+)\.(\d+)/);
     if (!match) return null;
     return [Number(match[1]), Number(match[2]), Number(match[3])];
   };
   const aParts = parse(a);
   const bParts = parse(b);
-  if (!aParts || !bParts) return 0;
+  if (!aParts || !bParts) return null;
   for (let i = 0; i < 3; i++) {
     if (aParts[i] !== bParts[i]) return aParts[i] > bParts[i] ? 1 : -1;
   }
@@ -1244,7 +1252,15 @@ export async function chooseExecutableByMinVersion(def, configuredEnv, env) {
   );
   for (const result of probes) {
     if (!result.version) continue;
-    if (compareSemver(result.version, def.minVersion) >= 0) {
+    // `compareSemver` returns `null` for unparseable inputs (see
+    // its comment). Treat that as "this candidate's version is not
+    // confidently comparable with the floor" — skip it so a banner
+    // like `gemini version 0.1.12` doesn't accidentally pass the
+    // floor and re-introduce #978. The fall-through below still
+    // runs the spawn against the first candidate so the existing
+    // detection error path stays visible.
+    const cmp = compareSemver(result.version, def.minVersion);
+    if (cmp !== null && cmp >= 0) {
       return { resolved: result.path, version: result.version };
     }
   }
@@ -1320,6 +1336,16 @@ async function probe(def, configuredEnv = {}) {
       // would re-resolve via the first-match `resolveAgentExecutable`
       // and pick the stale binary even though detection skipped it.
       resolvedAgentBinCache.set(def.id, { resolved, version });
+    } else {
+      // Detection couldn't resolve a binary this pass — clear the
+      // cache so a previously-cached path doesn't survive an
+      // uninstall / PATH change / override clear. Without this,
+      // `detectAgents()` would correctly report Gemini unavailable
+      // while `resolveAgentBin()` still returned the stale cached
+      // path, and chat / connection-test would keep spawning the
+      // binary that no longer exists. mrcfps + codex review of
+      // #1007.
+      resolvedAgentBinCache.delete(def.id);
     }
   } else {
     resolved = resolveAgentExecutable(def, configuredEnv);
@@ -1644,10 +1670,19 @@ export function checkWindowsDirectExeCommandLineBudget(def, resolvedBin, args) {
 // first-match `resolveAgentExecutable` and pick the same stale binary
 // detection skipped, putting the user back into the cryptic
 // `Unknown arguments: output-format, outputFormat` failure.
+//
+// IMPORTANT: an explicit `<AGENT>_BIN` configured override (passed
+// per-request from `/api/chat` and `/api/test/connection`) always
+// wins over the cache. Without this guard, a cached auto-pick from
+// an earlier detect would shadow a request-scoped override the user
+// changed afterwards — re-introducing the problem #978's escape
+// hatch is supposed to solve. mrcfps + lefarcen review of #1007.
 export function resolveAgentBin(id, configuredEnv = {}) {
   const def = getAgentDef(id);
   if (!def?.bin) return null;
   if (def.minVersion) {
+    const configured = configuredExecutableOverride(def, configuredEnv);
+    if (configured) return configured;
     const cached = resolvedAgentBinCache.get(id);
     if (cached?.resolved) return cached.resolved;
   }

--- a/apps/daemon/src/agents.ts
+++ b/apps/daemon/src/agents.ts
@@ -440,6 +440,19 @@ export const AGENT_DEFS = [
     name: 'Gemini CLI',
     bin: 'gemini',
     versionArgs: ['--version'],
+    // Issue #978: Gemini CLI builds before the `--output-format
+    // stream-json` flag stabilized (~0.30) reject our buildArgs with
+    // a yargs `Unknown arguments: output-format, outputFormat` error.
+    // On macOS the GUI app's PATH order means a stale
+    // `/usr/local/bin/gemini` (left over from an old `npm i -g
+    // @google/gemini-cli`) wins over a modern Homebrew/nvm install,
+    // and the spawn fails with cryptic help-output. Setting
+    // `minVersion` opts this entry into the version-aware resolver
+    // (`chooseExecutableByMinVersion`) which walks every `gemini` on
+    // PATH + toolchain dirs, picks the first that meets this floor,
+    // and caches the choice so the chat-time spawn lands on the same
+    // binary detection chose.
+    minVersion: '0.30.0',
     fallbackModels: [
       DEFAULT_MODEL_OPTION,
       // Gemini 3 (May 2026): top-tier reasoning + fast frontier-class.
@@ -1109,6 +1122,144 @@ export function resolveAgentExecutable(def, configuredEnv = {}) {
   return inspectAgentExecutableResolution(def, configuredEnv).selectedPath;
 }
 
+// Enumerate every absolute path on PATH + user toolchain dirs where
+// `bin` resolves. Used by the version-aware resolver to skip stale
+// installs (#978): a user with both `/usr/local/bin/gemini=0.1.12`
+// (legacy `npm i -g`) and `/opt/homebrew/bin/gemini=0.40.1` (current)
+// would otherwise have the GUI app pick the older one because the
+// system PATH segment runs ahead of the toolchain segment, even
+// though the modern binary is also resolvable.
+//
+// Mirrors `resolveOnPath` semantics — same dir order, same Windows
+// PATHEXT walk, same de-dupe — but returns every match rather than
+// the first.
+export function enumerateOnPath(bin) {
+  if (!bin) return [];
+  const exts =
+    process.platform === 'win32'
+      ? (process.env.PATHEXT || '.EXE;.CMD;.BAT').split(';')
+      : [''];
+  const dirs = resolvePathDirs();
+  const out = [];
+  const seen = new Set();
+  for (const dir of dirs) {
+    for (const ext of exts) {
+      const full = path.join(dir, bin + ext);
+      if (!full || seen.has(full)) continue;
+      seen.add(full);
+      if (existsSync(full)) out.push(full);
+    }
+  }
+  return out;
+}
+
+// Compare two version strings by their leading `major.minor.patch`
+// tuple. Returns -1 / 0 / 1 in the usual semver-compare convention.
+// Tolerates pre-release / build / `v`-prefix noise (`'v0.40.1'`,
+// `'0.40.1-rc.2'`, `'0.40.1+meta'`) so the resolver doesn't reject
+// otherwise-valid Gemini CLI versions just because the upstream tags
+// shipped that way.
+//
+// Returns 0 (equal) when either side is unparseable — the caller
+// already has a fall-through path to "use first found", so an
+// unparseable version shouldn't accidentally read as "lower than
+// minVersion" and disqualify a fine binary.
+export function compareSemver(a, b) {
+  const parse = (raw) => {
+    if (typeof raw !== 'string') return null;
+    const trimmed = raw.trim().replace(/^v/i, '');
+    const match = trimmed.match(/^(\d+)\.(\d+)\.(\d+)/);
+    if (!match) return null;
+    return [Number(match[1]), Number(match[2]), Number(match[3])];
+  };
+  const aParts = parse(a);
+  const bParts = parse(b);
+  if (!aParts || !bParts) return 0;
+  for (let i = 0; i < 3; i++) {
+    if (aParts[i] !== bParts[i]) return aParts[i] > bParts[i] ? 1 : -1;
+  }
+  return 0;
+}
+
+// Module-level cache keyed by agent id. Populated by `probe()` when
+// the def opts into version-aware resolution; consulted by
+// `resolveAgentBin()` so the synchronous chat-time spawn picks the
+// same binary the async detection chose.
+const resolvedAgentBinCache = new Map();
+
+// Strip the cache for a given agent id (or all when called bare).
+// Exposed so tests don't have to fight cross-test bleed when they
+// shadow PATH for `chooseExecutableByMinVersion` runs.
+export function clearResolvedAgentBinCache(id) {
+  if (id) resolvedAgentBinCache.delete(id);
+  else resolvedAgentBinCache.clear();
+}
+
+// Walk every candidate binary on PATH + toolchain dirs, run
+// `--version` on each in parallel, and return the first absolute
+// path whose version is at or above `def.minVersion`. Falls through
+// to the first-found path when no candidate meets the minimum so the
+// existing detection error path (cryptic, but visible) still fires
+// instead of silently swallowing the spawn intent. When the explicit
+// `<AGENT>_BIN` override is configured, the override wins
+// unconditionally — the user has already opted out of auto-pick.
+//
+// Returns `{ resolved: string|null, version: string|null }` so the
+// caller can short-circuit the second `--version` exec in `probe()`
+// — the version we just probed here is exactly the one the API
+// response should ship.
+export async function chooseExecutableByMinVersion(def, configuredEnv, env) {
+  const configured = configuredExecutableOverride(def, configuredEnv);
+  if (configured) return { resolved: configured, version: null };
+  const bins = [
+    def.bin,
+    ...(Array.isArray(def.fallbackBins) ? def.fallbackBins : []),
+  ].filter((bin) => typeof bin === 'string' && bin.length > 0);
+  const candidates = [];
+  const seen = new Set();
+  for (const bin of bins) {
+    for (const found of enumerateOnPath(bin)) {
+      if (seen.has(found)) continue;
+      seen.add(found);
+      candidates.push(found);
+    }
+  }
+  if (candidates.length === 0) return { resolved: null, version: null };
+  // Probe versions in parallel with a short timeout so a hung old
+  // binary doesn't block detection. 1500ms is generous for a
+  // local CLI's `--version` path which is typically <50ms.
+  const probes = await Promise.all(
+    candidates.map(async (candidate) => {
+      try {
+        const { stdout } = await execAgentFile(candidate, def.versionArgs, {
+          env,
+          timeout: 1500,
+        });
+        const version = String(stdout || '').trim().split('\n')[0] || '';
+        return { path: candidate, version };
+      } catch {
+        return { path: candidate, version: null };
+      }
+    }),
+  );
+  for (const result of probes) {
+    if (!result.version) continue;
+    if (compareSemver(result.version, def.minVersion) >= 0) {
+      return { resolved: result.path, version: result.version };
+    }
+  }
+  // No candidate met the minimum — fall through to the first-found
+  // path so the spawn still happens (and the existing yargs/argv
+  // mismatch error surfaces). Returning null here would silently
+  // drop the agent from detection even though a binary IS present;
+  // worse UX than the cryptic-but-visible failure.
+  const fallback = probes[0];
+  return {
+    resolved: fallback?.path ?? candidates[0],
+    version: fallback?.version ?? null,
+  };
+}
+
 async function fetchModels(def, resolvedBin, env) {
   if (typeof def.fetchModels === 'function') {
     try {
@@ -1141,15 +1292,6 @@ async function fetchModels(def, resolvedBin, env) {
 }
 
 async function probe(def, configuredEnv = {}) {
-  const resolved = resolveAgentExecutable(def, configuredEnv);
-  if (!resolved) {
-    return {
-      ...stripFns(def),
-      models: def.fallbackModels ?? [DEFAULT_MODEL_OPTION],
-      available: false,
-      ...installMetaForAgent(def.id),
-    };
-  }
   const probeEnv = spawnEnvForAgent(
     def.id,
     {
@@ -1158,15 +1300,48 @@ async function probe(def, configuredEnv = {}) {
     },
     configuredEnv,
   );
+  let resolved = null;
+  // Versions get probed twice without this fast-path: once to pick
+  // the best candidate, once for the API response. When
+  // `chooseExecutableByMinVersion` runs `--version` itself, its
+  // result is the answer — reuse it instead of re-execing.
   let version = null;
-  try {
-    const { stdout } = await execAgentFile(resolved, def.versionArgs, {
-      env: probeEnv,
-      timeout: 3000,
-    });
-    version = stdout.trim().split('\n')[0];
-  } catch {
-    // binary exists but --version failed; still mark available
+  if (def.minVersion) {
+    // Version-aware resolution: walk all candidates, skip ones too
+    // old to support the args buildArgs ships. See #978 for the
+    // canonical scenario (stale `/usr/local/bin/gemini=0.1.12`
+    // shadowing a modern Homebrew/nvm install on macOS GUI launches).
+    const picked = await chooseExecutableByMinVersion(def, configuredEnv, probeEnv);
+    resolved = picked.resolved;
+    version = picked.version;
+    if (resolved) {
+      // Cache so the synchronous chat-time `resolveAgentBin` returns
+      // the same path the async detection chose. Without this, chat
+      // would re-resolve via the first-match `resolveAgentExecutable`
+      // and pick the stale binary even though detection skipped it.
+      resolvedAgentBinCache.set(def.id, { resolved, version });
+    }
+  } else {
+    resolved = resolveAgentExecutable(def, configuredEnv);
+  }
+  if (!resolved) {
+    return {
+      ...stripFns(def),
+      models: def.fallbackModels ?? [DEFAULT_MODEL_OPTION],
+      available: false,
+      ...installMetaForAgent(def.id),
+    };
+  }
+  if (version == null) {
+    try {
+      const { stdout } = await execAgentFile(resolved, def.versionArgs, {
+        env: probeEnv,
+        timeout: 3000,
+      });
+      version = stdout.trim().split('\n')[0];
+    } catch {
+      // binary exists but --version failed; still mark available
+    }
   }
   // Probe `--help` once per agent and record which flags the installed CLI
   // advertises. Cached on `agentCapabilities` for buildArgs to consult.
@@ -1462,9 +1637,20 @@ export function checkWindowsDirectExeCommandLineBudget(def, resolvedBin, args) {
 // Used by the chat handler so spawn() gets the same executable that
 // detection reported as available — fixes Windows ENOENT when the bare
 // bin name isn't on the child process's PATH (issue #10).
+//
+// For agents that opted into version-aware resolution via `def.minVersion`
+// (currently just gemini, see #978), prefer the path the async detection
+// already chose. Without this, chat would re-resolve via the
+// first-match `resolveAgentExecutable` and pick the same stale binary
+// detection skipped, putting the user back into the cryptic
+// `Unknown arguments: output-format, outputFormat` failure.
 export function resolveAgentBin(id, configuredEnv = {}) {
   const def = getAgentDef(id);
   if (!def?.bin) return null;
+  if (def.minVersion) {
+    const cached = resolvedAgentBinCache.get(id);
+    if (cached?.resolved) return cached.resolved;
+  }
   return resolveAgentExecutable(def, configuredEnv);
 }
 

--- a/apps/daemon/src/agents.ts
+++ b/apps/daemon/src/agents.ts
@@ -1212,13 +1212,16 @@ export function clearResolvedAgentBinCache(id) {
 // `<AGENT>_BIN` override is configured, the override wins
 // unconditionally — the user has already opted out of auto-pick.
 //
-// Returns `{ resolved: string|null, version: string|null }` so the
-// caller can short-circuit the second `--version` exec in `probe()`
-// — the version we just probed here is exactly the one the API
-// response should ship.
+// Returns `{ resolved: string|null, version: string|null,
+// fromOverride: boolean }` so the caller can (a) short-circuit the
+// second `--version` exec in `probe()` (the version we just probed
+// here is exactly the one the API response should ship) and (b)
+// know whether the result is a request-scoped override path — those
+// must not be cached, otherwise clearing the override leaves a stale
+// pin pointing at a path the user explicitly opted out of.
 export async function chooseExecutableByMinVersion(def, configuredEnv, env) {
   const configured = configuredExecutableOverride(def, configuredEnv);
-  if (configured) return { resolved: configured, version: null };
+  if (configured) return { resolved: configured, version: null, fromOverride: true };
   const bins = [
     def.bin,
     ...(Array.isArray(def.fallbackBins) ? def.fallbackBins : []),
@@ -1232,7 +1235,7 @@ export async function chooseExecutableByMinVersion(def, configuredEnv, env) {
       candidates.push(found);
     }
   }
-  if (candidates.length === 0) return { resolved: null, version: null };
+  if (candidates.length === 0) return { resolved: null, version: null, fromOverride: false };
   // Probe versions in parallel with a short timeout so a hung old
   // binary doesn't block detection. 1500ms is generous for a
   // local CLI's `--version` path which is typically <50ms.
@@ -1261,7 +1264,7 @@ export async function chooseExecutableByMinVersion(def, configuredEnv, env) {
     // detection error path stays visible.
     const cmp = compareSemver(result.version, def.minVersion);
     if (cmp !== null && cmp >= 0) {
-      return { resolved: result.path, version: result.version };
+      return { resolved: result.path, version: result.version, fromOverride: false };
     }
   }
   // No candidate met the minimum — fall through to the first-found
@@ -1273,6 +1276,7 @@ export async function chooseExecutableByMinVersion(def, configuredEnv, env) {
   return {
     resolved: fallback?.path ?? candidates[0],
     version: fallback?.version ?? null,
+    fromOverride: false,
   };
 }
 
@@ -1330,13 +1334,13 @@ async function probe(def, configuredEnv = {}) {
     const picked = await chooseExecutableByMinVersion(def, configuredEnv, probeEnv);
     resolved = picked.resolved;
     version = picked.version;
-    if (resolved) {
+    if (resolved && !picked.fromOverride) {
       // Cache so the synchronous chat-time `resolveAgentBin` returns
       // the same path the async detection chose. Without this, chat
       // would re-resolve via the first-match `resolveAgentExecutable`
       // and pick the stale binary even though detection skipped it.
       resolvedAgentBinCache.set(def.id, { resolved, version });
-    } else {
+    } else if (!resolved) {
       // Detection couldn't resolve a binary this pass — clear the
       // cache so a previously-cached path doesn't survive an
       // uninstall / PATH change / override clear. Without this,
@@ -1347,6 +1351,15 @@ async function probe(def, configuredEnv = {}) {
       // #1007.
       resolvedAgentBinCache.delete(def.id);
     }
+    // When `picked.fromOverride` is true the cache is intentionally
+    // left as-is: the result is a request-scoped <AGENT>_BIN path
+    // the user can clear at any time, so writing it to the cache
+    // turns the escape hatch one-way (clear the env and chat still
+    // spawns the override path, even though the env that opted in
+    // is gone). Preserving the previous auto-pick instead keeps the
+    // override reversible — clearing it falls back to the last
+    // version-aware pick the resolver actually walked candidates
+    // for. lefarcen review of #1007.
   } else {
     resolved = resolveAgentExecutable(def, configuredEnv);
   }

--- a/apps/daemon/tests/agents.test.ts
+++ b/apps/daemon/tests/agents.test.ts
@@ -2639,6 +2639,56 @@ fsTest(
   },
 );
 
+test(
+  'detectAgents with GEMINI_BIN does not poison the cache; clearing the override returns to the auto-pick (#1007 P2 lefarcen)',
+  async () => {
+    // Without this guard, `chooseExecutableByMinVersion` would
+    // return the override path AND `probe()`'s cache write would
+    // record it. A subsequent `resolveAgentBin('gemini', {})`
+    // (request without the env var) would then read the override
+    // back out of the cache — turning the escape hatch one-way:
+    // the user cleared GEMINI_BIN but chat still spawns the
+    // override binary. After the fix, `probe()` skips the cache
+    // write when the resolver returns `fromOverride: true`, so
+    // the cache stays pinned to the last version-aware auto-pick
+    // and the override is reversible.
+    const home = isolateAgentHome();
+    const autoDir = mkdtempSync(join(tmpdir(), 'od-gemini-poison-auto-'));
+    const pinDir = mkdtempSync(join(tmpdir(), 'od-gemini-poison-pin-'));
+    try {
+      const autoPath = writeFakeVersionCli(autoDir, 'gemini', '0.40.1');
+      const pinPath = writeFakeVersionCli(pinDir, 'gemini', '0.40.2');
+      // Step 1: detect without override → cache = autoPath.
+      process.env.PATH = autoDir;
+      clearResolvedAgentBinCache('gemini');
+      await detectAgents({});
+      assert.equal(resolveAgentBin('gemini', {}), autoPath);
+
+      // Step 2: detect WITH override → resolves to pinPath for
+      // the settings/UI response, but must NOT overwrite the
+      // cache the auto-pick populated above.
+      const overrideResults = await detectAgents({
+        gemini: { GEMINI_BIN: pinPath },
+      });
+      const overrideGemini = overrideResults.find(
+        (agent) => agent.id === 'gemini',
+      );
+      assert.equal(overrideGemini?.path, pinPath);
+
+      // Step 3: a later request without the override clears its
+      // env. resolveAgentBin reads the cache; with the poisoning
+      // fix the cache is still autoPath, so the result is the
+      // last-known auto-pick, not the pinned override.
+      assert.equal(resolveAgentBin('gemini', {}), autoPath);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(autoDir, { recursive: true, force: true });
+      rmSync(pinDir, { recursive: true, force: true });
+      clearResolvedAgentBinCache('gemini');
+    }
+  },
+);
+
 test('Gemini AGENT_DEF declares minVersion so the version-aware resolver kicks in (#978)', () => {
   // Pinned here as a regression guard so a future cleanup that
   // strips the field doesn't silently put the GUI app back into the

--- a/apps/daemon/tests/agents.test.ts
+++ b/apps/daemon/tests/agents.test.ts
@@ -15,8 +15,13 @@ import {
   checkPromptArgvBudget,
   checkWindowsCmdShimCommandLineBudget,
   checkWindowsDirectExeCommandLineBudget,
+  chooseExecutableByMinVersion,
+  clearResolvedAgentBinCache,
+  compareSemver,
   detectAgents,
+  enumerateOnPath,
   inspectAgentExecutableResolution,
+  resolveAgentBin,
   resolveAgentExecutable,
   spawnEnvForAgent,
 } from '../src/agents.js';
@@ -2212,4 +2217,275 @@ test('spawnEnvForAgent does not mutate the input env', () => {
 
   assert.equal(original.ANTHROPIC_API_KEY, 'sk-leak');
   assert.notEqual(env, original);
+});
+
+// ---- Issue #978: Gemini binary version-aware resolution -------------------
+// Older `gemini-cli` builds (notably 0.1.12 from a long-ago `npm i -g
+// @google/gemini-cli`) reject the daemon's `--output-format stream-json`
+// args with a yargs `Unknown arguments: output-format, outputFormat`
+// error. On macOS GUI launches, system PATH (`/usr/bin:/bin:/usr/sbin:
+// /sbin:/usr/local/bin`) runs ahead of the toolchain dirs we prepend
+// for #346/#614 — so a stale `/usr/local/bin/gemini` shadows the
+// modern Homebrew/nvm install and the spawn lands on cryptic help
+// output. The version-aware resolver walks every candidate, picks the
+// first that meets `def.minVersion`, and caches the choice so the
+// chat-time spawn lands on the same binary detection chose.
+
+test('compareSemver returns -1 / 0 / 1 by leading major.minor.patch', () => {
+  assert.equal(compareSemver('0.40.1', '0.30.0'), 1);
+  assert.equal(compareSemver('0.30.0', '0.40.1'), -1);
+  assert.equal(compareSemver('1.0.0', '0.99.99'), 1);
+  assert.equal(compareSemver('0.40.1', '0.40.1'), 0);
+});
+
+test('compareSemver tolerates v-prefix and pre-release / build noise', () => {
+  // gemini-cli has shipped tags like `v0.40.1` and `0.40.1-rc.2` in
+  // the wild — the resolver shouldn't disqualify either of those.
+  assert.equal(compareSemver('v0.40.1', '0.30.0'), 1);
+  assert.equal(compareSemver('0.40.1-rc.2', '0.30.0'), 1);
+  assert.equal(compareSemver('0.40.1+meta', '0.40.1'), 0);
+});
+
+test('compareSemver returns 0 (equal) for unparseable versions so the caller still falls through', () => {
+  // The caller has its own "no candidate met minVersion → use
+  // first-found" fallback, but only when compareSemver does NOT
+  // declare a candidate satisfactory. Returning 0 keeps an
+  // unparseable version from accidentally clearing the bar — the
+  // resolver moves on and the fall-through fires.
+  assert.equal(compareSemver('not-a-version', '0.30.0'), 0);
+  assert.equal(compareSemver('0.30.0', null), 0);
+  assert.equal(compareSemver(undefined, '0.30.0'), 0);
+});
+
+fsTest(
+  'enumerateOnPath returns every directory containing the binary, in PATH order',
+  () => {
+    const dirA = mkdtempSync(join(tmpdir(), 'od-enumerate-a-'));
+    const dirB = mkdtempSync(join(tmpdir(), 'od-enumerate-b-'));
+    try {
+      writeFileSync(join(dirA, 'gemini'), '');
+      writeFileSync(join(dirB, 'gemini'), '');
+      chmodSync(join(dirA, 'gemini'), 0o755);
+      chmodSync(join(dirB, 'gemini'), 0o755);
+      process.env.PATH = `${dirA}:${dirB}`;
+
+      const found = enumerateOnPath('gemini');
+      // Order matters — the resolver picks the first entry that
+      // meets minVersion, so PATH precedence has to come through
+      // unchanged (this is what gives the user-installed modern
+      // binary a chance to win when it sits later in the order).
+      assert.deepEqual(found, [join(dirA, 'gemini'), join(dirB, 'gemini')]);
+    } finally {
+      rmSync(dirA, { recursive: true, force: true });
+      rmSync(dirB, { recursive: true, force: true });
+    }
+  },
+);
+
+fsTest(
+  'enumerateOnPath returns an empty list when the binary is missing',
+  () => {
+    const dir = mkdtempSync(join(tmpdir(), 'od-enumerate-empty-'));
+    try {
+      process.env.PATH = dir;
+      assert.deepEqual(enumerateOnPath('gemini'), []);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);
+
+// Helper: write an executable shell script that prints `version` when
+// invoked with `--version`. Lets us simulate the multi-install
+// scenario from #978 without depending on a real gemini binary.
+function writeFakeVersionCli(dir: string, name: string, version: string): string {
+  const filePath = join(dir, name);
+  const script = `#!/bin/sh
+case "$1" in
+  --version) echo "${version}";;
+  *) echo "noop";;
+esac
+`;
+  writeFileSync(filePath, script);
+  chmodSync(filePath, 0o755);
+  return filePath;
+}
+
+fsTest(
+  'chooseExecutableByMinVersion picks the newer candidate even when an older one is on PATH first (#978)',
+  async () => {
+    const oldDir = mkdtempSync(join(tmpdir(), 'od-gemini-old-'));
+    const newDir = mkdtempSync(join(tmpdir(), 'od-gemini-new-'));
+    try {
+      const oldPath = writeFakeVersionCli(oldDir, 'gemini', '0.1.12');
+      const newPath = writeFakeVersionCli(newDir, 'gemini', '0.40.1');
+      // Mirror the issue's PATH order: stale `/usr/local/bin` style
+      // entry first, modern toolchain entry second.
+      process.env.PATH = `${oldDir}:${newDir}`;
+
+      const def = minimalAgentDef({
+        id: 'gemini',
+        bin: 'gemini',
+        minVersion: '0.30.0',
+        versionArgs: ['--version'],
+      });
+      const picked = await chooseExecutableByMinVersion(def, {}, process.env);
+
+      assert.equal(picked.resolved, newPath);
+      assert.equal(picked.version, '0.40.1');
+      // Defensive: don't accept the stale binary just because it
+      // happens to come first in PATH order.
+      assert.notEqual(picked.resolved, oldPath);
+    } finally {
+      rmSync(oldDir, { recursive: true, force: true });
+      rmSync(newDir, { recursive: true, force: true });
+    }
+  },
+);
+
+fsTest(
+  'chooseExecutableByMinVersion falls back to first-found when no candidate meets minVersion',
+  async () => {
+    // No modern install anywhere — the resolver must NOT silently
+    // drop the agent. Returning the first-found candidate keeps the
+    // existing detection-error path firing (cryptic, but visible)
+    // and gives the user a path to surface the failure in the UI.
+    const dir = mkdtempSync(join(tmpdir(), 'od-gemini-stale-only-'));
+    try {
+      const stalePath = writeFakeVersionCli(dir, 'gemini', '0.1.12');
+      process.env.PATH = dir;
+
+      const def = minimalAgentDef({
+        id: 'gemini',
+        bin: 'gemini',
+        minVersion: '0.30.0',
+        versionArgs: ['--version'],
+      });
+      const picked = await chooseExecutableByMinVersion(def, {}, process.env);
+
+      assert.equal(picked.resolved, stalePath);
+      assert.equal(picked.version, '0.1.12');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);
+
+fsTest(
+  'chooseExecutableByMinVersion honors a configured GEMINI_BIN override without running version probes',
+  async () => {
+    // The explicit override is the user's escape hatch — they've
+    // already opted out of auto-pick, so the resolver must respect
+    // their choice even if the pinned binary fails the version
+    // floor (e.g. they're knowingly testing an old build).
+    const newDir = mkdtempSync(join(tmpdir(), 'od-gemini-override-new-'));
+    const pinDir = mkdtempSync(join(tmpdir(), 'od-gemini-override-pin-'));
+    try {
+      writeFakeVersionCli(newDir, 'gemini', '0.40.1');
+      const pinPath = writeFakeVersionCli(pinDir, 'gemini', '0.1.12');
+      // PATH includes the modern install — the override has to win
+      // anyway since the user pinned the old one explicitly.
+      process.env.PATH = newDir;
+
+      const def = minimalAgentDef({
+        id: 'gemini',
+        bin: 'gemini',
+        minVersion: '0.30.0',
+        versionArgs: ['--version'],
+      });
+      const picked = await chooseExecutableByMinVersion(
+        def,
+        { GEMINI_BIN: pinPath },
+        process.env,
+      );
+
+      assert.equal(picked.resolved, pinPath);
+      // The override path skips `--version` entirely (we trust the
+      // user) — the version slot should come back null so the
+      // caller knows to probe separately if it needs the version.
+      assert.equal(picked.version, null);
+    } finally {
+      rmSync(newDir, { recursive: true, force: true });
+      rmSync(pinDir, { recursive: true, force: true });
+    }
+  },
+);
+
+fsTest(
+  'chooseExecutableByMinVersion returns null resolved when no candidate exists',
+  async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'od-gemini-empty-'));
+    try {
+      process.env.PATH = dir;
+
+      const def = minimalAgentDef({
+        id: 'gemini',
+        bin: 'gemini',
+        minVersion: '0.30.0',
+        versionArgs: ['--version'],
+      });
+      const picked = await chooseExecutableByMinVersion(def, {}, process.env);
+
+      assert.equal(picked.resolved, null);
+      assert.equal(picked.version, null);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);
+
+fsTest(
+  'detectAgents + resolveAgentBin returns the modern gemini even when an older one shadows it on PATH (#978)',
+  async () => {
+    // End-to-end pin: probe runs the smart resolver, caches the
+    // pick, and the chat-time `resolveAgentBin` call returns the
+    // same path. Without the cache, chat would re-resolve via the
+    // first-match `resolveAgentExecutable` and pick the stale
+    // binary again.
+    const oldDir = mkdtempSync(join(tmpdir(), 'od-gemini-e2e-old-'));
+    const newDir = mkdtempSync(join(tmpdir(), 'od-gemini-e2e-new-'));
+    try {
+      const oldPath = writeFakeVersionCli(oldDir, 'gemini', '0.1.12');
+      const newPath = writeFakeVersionCli(newDir, 'gemini', '0.40.1');
+      process.env.PATH = `${oldDir}:${newDir}`;
+      // Strip the toolchain home so the test isn't sensitive to
+      // whatever `gemini` happens to live under the dev's real $HOME.
+      process.env.OD_AGENT_HOME = mkdtempSync(join(tmpdir(), 'od-gemini-e2e-home-'));
+      clearResolvedAgentBinCache('gemini');
+
+      const agents = await detectAgents({});
+      const gemini = agents.find((agent: { id: string }) => agent.id === 'gemini');
+      assert.ok(gemini, 'detectAgents must surface gemini');
+      assert.equal(gemini.available, true);
+      assert.equal(gemini.path, newPath);
+      assert.equal(gemini.version, '0.40.1');
+
+      // Chat-time spawn resolution consults the cache so it lands on
+      // the same binary — without this, the chat would re-resolve
+      // via first-match and pick the stale 0.1.12 again.
+      const spawnPath = resolveAgentBin('gemini', {});
+      assert.equal(spawnPath, newPath);
+      assert.notEqual(spawnPath, oldPath);
+    } finally {
+      rmSync(oldDir, { recursive: true, force: true });
+      rmSync(newDir, { recursive: true, force: true });
+      clearResolvedAgentBinCache('gemini');
+    }
+  },
+);
+
+test('Gemini AGENT_DEF declares minVersion so the version-aware resolver kicks in (#978)', () => {
+  // Pinned here as a regression guard so a future cleanup that
+  // strips the field doesn't silently put the GUI app back into the
+  // "stale `/usr/local/bin/gemini` shadows modern install" failure
+  // mode.
+  assert.equal(typeof gemini.minVersion, 'string');
+  assert.ok(gemini.minVersion.length > 0, 'gemini.minVersion must be set');
+  // Sanity: the floor must read as ≥ 0.30 — that's the cited
+  // baseline in #978 where `--output-format stream-json` shipped in
+  // a stable form. Lowering it would re-admit the broken builds.
+  assert.ok(
+    compareSemver(gemini.minVersion, '0.30.0') >= 0,
+    `gemini.minVersion (${gemini.minVersion}) must be ≥ 0.30.0`,
+  );
 });

--- a/apps/daemon/tests/agents.test.ts
+++ b/apps/daemon/tests/agents.test.ts
@@ -2246,20 +2246,33 @@ test('compareSemver tolerates v-prefix and pre-release / build noise', () => {
   assert.equal(compareSemver('0.40.1+meta', '0.40.1'), 0);
 });
 
-test('compareSemver returns 0 (equal) for unparseable versions so the caller still falls through', () => {
-  // The caller has its own "no candidate met minVersion → use
-  // first-found" fallback, but only when compareSemver does NOT
-  // declare a candidate satisfactory. Returning 0 keeps an
-  // unparseable version from accidentally clearing the bar — the
-  // resolver moves on and the fall-through fires.
-  assert.equal(compareSemver('not-a-version', '0.30.0'), 0);
-  assert.equal(compareSemver('0.30.0', null), 0);
-  assert.equal(compareSemver(undefined, '0.30.0'), 0);
+test('compareSemver returns null for unparseable input so the resolver can skip the candidate', () => {
+  // P1 from mrcfps + lefarcen review of #1007: returning 0 (equal)
+  // for unparseable strings let a banner-style version like
+  // `gemini version 0.1.12` pass the >= 0 floor in
+  // `chooseExecutableByMinVersion` and shadow a modern install.
+  // Switching to null forces the resolver to distinguish parse
+  // failure from genuine equality; the gate becomes
+  // `cmp !== null && cmp >= 0`.
+  assert.equal(compareSemver('not-a-version', '0.30.0'), null);
+  assert.equal(compareSemver('0.30.0', null), null);
+  assert.equal(compareSemver(undefined, '0.30.0'), null);
+});
+
+test('compareSemver only matches a leading bare semver (no banner-prose pass-through)', () => {
+  // The exact failure shape that re-introduced #978 in the original
+  // implementation. The fix anchors the regex to `^` so prose
+  // wrapping the numbers no longer reads as a clean version. Any
+  // future change that loosens that anchor would re-admit the
+  // shadowing scenario.
+  assert.equal(compareSemver('gemini version 0.1.12', '0.30.0'), null);
+  assert.equal(compareSemver('Gemini CLI 0.40.1 (build x)', '0.30.0'), null);
 });
 
 fsTest(
   'enumerateOnPath returns every directory containing the binary, in PATH order',
   () => {
+    const home = isolateAgentHome();
     const dirA = mkdtempSync(join(tmpdir(), 'od-enumerate-a-'));
     const dirB = mkdtempSync(join(tmpdir(), 'od-enumerate-b-'));
     try {
@@ -2276,6 +2289,7 @@ fsTest(
       // binary a chance to win when it sits later in the order).
       assert.deepEqual(found, [join(dirA, 'gemini'), join(dirB, 'gemini')]);
     } finally {
+      rmSync(home, { recursive: true, force: true });
       rmSync(dirA, { recursive: true, force: true });
       rmSync(dirB, { recursive: true, force: true });
     }
@@ -2285,24 +2299,31 @@ fsTest(
 fsTest(
   'enumerateOnPath returns an empty list when the binary is missing',
   () => {
+    const home = isolateAgentHome();
     const dir = mkdtempSync(join(tmpdir(), 'od-enumerate-empty-'));
     try {
       process.env.PATH = dir;
       assert.deepEqual(enumerateOnPath('gemini'), []);
     } finally {
+      rmSync(home, { recursive: true, force: true });
       rmSync(dir, { recursive: true, force: true });
     }
   },
 );
 
-// Helper: write an executable shell script that prints `version` when
-// invoked with `--version`. Lets us simulate the multi-install
-// scenario from #978 without depending on a real gemini binary.
-function writeFakeVersionCli(dir: string, name: string, version: string): string {
+// Helper: write an executable shell script that prints `versionOutput`
+// when invoked with `--version`. Lets us simulate the multi-install
+// scenario from #978 (and the banner-style version regression
+// flagged by #1007 reviewers) without depending on a real gemini
+// binary. `versionOutput` is the *full* line printed — pass a clean
+// semver to mimic modern Gemini, or wrap it in prose
+// (`'gemini version 0.1.12'`) to mimic the banner pattern that the
+// resolver must skip.
+function writeFakeVersionCli(dir: string, name: string, versionOutput: string): string {
   const filePath = join(dir, name);
   const script = `#!/bin/sh
 case "$1" in
-  --version) echo "${version}";;
+  --version) echo "${versionOutput}";;
   *) echo "noop";;
 esac
 `;
@@ -2311,9 +2332,23 @@ esac
   return filePath;
 }
 
+// Pin OD_AGENT_HOME to an empty temp directory for the duration of
+// a resolver test so `userToolchainDirs()` resolves to nothing and
+// PATH is the only source of agent binaries. Without this, on a
+// developer/CI machine that has a real `gemini` under Homebrew /
+// nvm / asdf / npm-global, "missing binary" assertions can fail and
+// "exact list" assertions can pick up the extra real candidates.
+// lefarcen review of #1007.
+function isolateAgentHome(): string {
+  const home = mkdtempSync(join(tmpdir(), 'od-agent-home-'));
+  process.env.OD_AGENT_HOME = home;
+  return home;
+}
+
 fsTest(
   'chooseExecutableByMinVersion picks the newer candidate even when an older one is on PATH first (#978)',
   async () => {
+    const home = isolateAgentHome();
     const oldDir = mkdtempSync(join(tmpdir(), 'od-gemini-old-'));
     const newDir = mkdtempSync(join(tmpdir(), 'od-gemini-new-'));
     try {
@@ -2337,6 +2372,46 @@ fsTest(
       // happens to come first in PATH order.
       assert.notEqual(picked.resolved, oldPath);
     } finally {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(oldDir, { recursive: true, force: true });
+      rmSync(newDir, { recursive: true, force: true });
+    }
+  },
+);
+
+fsTest(
+  'chooseExecutableByMinVersion skips a banner-style version output and accepts the next candidate (#1007 P1)',
+  async () => {
+    // P1 from the #1007 review: an old `gemini` whose `--version`
+    // prints prose like `gemini version 0.1.12` (rather than bare
+    // semver) used to slip past `compareSemver === 0` and shadow a
+    // modern install. After switching the helper to return null on
+    // unparseable input, this candidate must be skipped.
+    const home = isolateAgentHome();
+    const oldDir = mkdtempSync(join(tmpdir(), 'od-gemini-banner-'));
+    const newDir = mkdtempSync(join(tmpdir(), 'od-gemini-modern-'));
+    try {
+      const bannerPath = writeFakeVersionCli(
+        oldDir,
+        'gemini',
+        'gemini version 0.1.12',
+      );
+      const modernPath = writeFakeVersionCli(newDir, 'gemini', '0.40.1');
+      process.env.PATH = `${oldDir}:${newDir}`;
+
+      const def = minimalAgentDef({
+        id: 'gemini',
+        bin: 'gemini',
+        minVersion: '0.30.0',
+        versionArgs: ['--version'],
+      });
+      const picked = await chooseExecutableByMinVersion(def, {}, process.env);
+
+      assert.equal(picked.resolved, modernPath);
+      assert.equal(picked.version, '0.40.1');
+      assert.notEqual(picked.resolved, bannerPath);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
       rmSync(oldDir, { recursive: true, force: true });
       rmSync(newDir, { recursive: true, force: true });
     }
@@ -2350,6 +2425,7 @@ fsTest(
     // drop the agent. Returning the first-found candidate keeps the
     // existing detection-error path firing (cryptic, but visible)
     // and gives the user a path to surface the failure in the UI.
+    const home = isolateAgentHome();
     const dir = mkdtempSync(join(tmpdir(), 'od-gemini-stale-only-'));
     try {
       const stalePath = writeFakeVersionCli(dir, 'gemini', '0.1.12');
@@ -2366,6 +2442,7 @@ fsTest(
       assert.equal(picked.resolved, stalePath);
       assert.equal(picked.version, '0.1.12');
     } finally {
+      rmSync(home, { recursive: true, force: true });
       rmSync(dir, { recursive: true, force: true });
     }
   },
@@ -2378,6 +2455,7 @@ fsTest(
     // already opted out of auto-pick, so the resolver must respect
     // their choice even if the pinned binary fails the version
     // floor (e.g. they're knowingly testing an old build).
+    const home = isolateAgentHome();
     const newDir = mkdtempSync(join(tmpdir(), 'od-gemini-override-new-'));
     const pinDir = mkdtempSync(join(tmpdir(), 'od-gemini-override-pin-'));
     try {
@@ -2405,6 +2483,7 @@ fsTest(
       // caller knows to probe separately if it needs the version.
       assert.equal(picked.version, null);
     } finally {
+      rmSync(home, { recursive: true, force: true });
       rmSync(newDir, { recursive: true, force: true });
       rmSync(pinDir, { recursive: true, force: true });
     }
@@ -2414,6 +2493,7 @@ fsTest(
 fsTest(
   'chooseExecutableByMinVersion returns null resolved when no candidate exists',
   async () => {
+    const home = isolateAgentHome();
     const dir = mkdtempSync(join(tmpdir(), 'od-gemini-empty-'));
     try {
       process.env.PATH = dir;
@@ -2429,6 +2509,7 @@ fsTest(
       assert.equal(picked.resolved, null);
       assert.equal(picked.version, null);
     } finally {
+      rmSync(home, { recursive: true, force: true });
       rmSync(dir, { recursive: true, force: true });
     }
   },
@@ -2442,15 +2523,13 @@ fsTest(
     // same path. Without the cache, chat would re-resolve via the
     // first-match `resolveAgentExecutable` and pick the stale
     // binary again.
+    const home = isolateAgentHome();
     const oldDir = mkdtempSync(join(tmpdir(), 'od-gemini-e2e-old-'));
     const newDir = mkdtempSync(join(tmpdir(), 'od-gemini-e2e-new-'));
     try {
       const oldPath = writeFakeVersionCli(oldDir, 'gemini', '0.1.12');
       const newPath = writeFakeVersionCli(newDir, 'gemini', '0.40.1');
       process.env.PATH = `${oldDir}:${newDir}`;
-      // Strip the toolchain home so the test isn't sensitive to
-      // whatever `gemini` happens to live under the dev's real $HOME.
-      process.env.OD_AGENT_HOME = mkdtempSync(join(tmpdir(), 'od-gemini-e2e-home-'));
       clearResolvedAgentBinCache('gemini');
 
       const agents = await detectAgents({});
@@ -2467,8 +2546,94 @@ fsTest(
       assert.equal(spawnPath, newPath);
       assert.notEqual(spawnPath, oldPath);
     } finally {
+      rmSync(home, { recursive: true, force: true });
       rmSync(oldDir, { recursive: true, force: true });
       rmSync(newDir, { recursive: true, force: true });
+      clearResolvedAgentBinCache('gemini');
+    }
+  },
+);
+
+fsTest(
+  'detectAgents clears the cache when no candidate resolves so resolveAgentBin no longer returns a stale path (#1007 P2)',
+  async () => {
+    // P2 from mrcfps + codex review of #1007: the cache was only
+    // populated on success and never cleared, so a previously
+    // cached Gemini path could survive an uninstall / PATH change.
+    // After this fix, a probe pass that finds no binary clears the
+    // cache, and `resolveAgentBin` falls back to the sync
+    // first-match resolver — which also returns null for an empty
+    // PATH, keeping detection and chat in sync.
+    const home = isolateAgentHome();
+    const installDir = mkdtempSync(join(tmpdir(), 'od-gemini-cache-install-'));
+    const emptyDir = mkdtempSync(join(tmpdir(), 'od-gemini-cache-empty-'));
+    try {
+      const installedPath = writeFakeVersionCli(installDir, 'gemini', '0.40.1');
+      // First detect: gemini is on PATH and modern → cached.
+      process.env.PATH = installDir;
+      clearResolvedAgentBinCache('gemini');
+      let agents = await detectAgents({});
+      let gemini = agents.find((a: { id: string }) => a.id === 'gemini');
+      assert.equal(gemini.available, true);
+      assert.equal(gemini.path, installedPath);
+      assert.equal(resolveAgentBin('gemini', {}), installedPath);
+
+      // Simulate the user uninstalling / cleaning up: PATH no
+      // longer contains gemini.
+      process.env.PATH = emptyDir;
+      agents = await detectAgents({});
+      gemini = agents.find((a: { id: string }) => a.id === 'gemini');
+      assert.equal(gemini.available, false);
+      // Without the cache-clear, resolveAgentBin would still
+      // return `installedPath` here even though detection just
+      // reported the agent unavailable — chat / connection-test
+      // would keep spawning a binary that no longer exists.
+      assert.equal(resolveAgentBin('gemini', {}), null);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(installDir, { recursive: true, force: true });
+      rmSync(emptyDir, { recursive: true, force: true });
+      clearResolvedAgentBinCache('gemini');
+    }
+  },
+);
+
+fsTest(
+  'resolveAgentBin honors a request-scoped GEMINI_BIN override even when the cache is populated (#1007 P2)',
+  async () => {
+    // P2 from mrcfps + lefarcen review of #1007: the cache was
+    // consulted before `configuredEnv`, so a request-scoped
+    // override (passed by `/api/chat` and `/api/test/connection`)
+    // got ignored once detection had populated the cache. After
+    // this fix, `configuredExecutableOverride` is checked first
+    // and the explicit override always wins.
+    const home = isolateAgentHome();
+    const autoDir = mkdtempSync(join(tmpdir(), 'od-gemini-override-auto-'));
+    const pinDir = mkdtempSync(join(tmpdir(), 'od-gemini-override-pin-'));
+    try {
+      const autoPath = writeFakeVersionCli(autoDir, 'gemini', '0.40.1');
+      const pinPath = writeFakeVersionCli(pinDir, 'gemini', '0.40.2');
+      // Detection auto-picks the autoDir install and caches it.
+      process.env.PATH = autoDir;
+      clearResolvedAgentBinCache('gemini');
+      await detectAgents({});
+      assert.equal(resolveAgentBin('gemini', {}), autoPath);
+
+      // The user later pins GEMINI_BIN at a different binary via
+      // request-scoped env. Without checking the override before
+      // the cache, resolveAgentBin would keep returning autoPath.
+      assert.equal(
+        resolveAgentBin('gemini', { GEMINI_BIN: pinPath }),
+        pinPath,
+      );
+      // Defensive: the cache is left untouched — the next request
+      // without the override still returns the auto-picked path,
+      // so the override stays scoped to whatever caller set it.
+      assert.equal(resolveAgentBin('gemini', {}), autoPath);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(autoDir, { recursive: true, force: true });
+      rmSync(pinDir, { recursive: true, force: true });
       clearResolvedAgentBinCache('gemini');
     }
   },
@@ -2479,13 +2644,17 @@ test('Gemini AGENT_DEF declares minVersion so the version-aware resolver kicks i
   // strips the field doesn't silently put the GUI app back into the
   // "stale `/usr/local/bin/gemini` shadows modern install" failure
   // mode.
-  assert.equal(typeof gemini.minVersion, 'string');
-  assert.ok(gemini.minVersion.length > 0, 'gemini.minVersion must be set');
+  const minVersion = gemini.minVersion;
+  assert.ok(
+    typeof minVersion === 'string' && minVersion.length > 0,
+    'gemini.minVersion must be a non-empty string',
+  );
   // Sanity: the floor must read as ≥ 0.30 — that's the cited
   // baseline in #978 where `--output-format stream-json` shipped in
   // a stable form. Lowering it would re-admit the broken builds.
+  const cmp = compareSemver(minVersion, '0.30.0');
   assert.ok(
-    compareSemver(gemini.minVersion, '0.30.0') >= 0,
-    `gemini.minVersion (${gemini.minVersion}) must be ≥ 0.30.0`,
+    cmp !== null && cmp >= 0,
+    `gemini.minVersion (${minVersion}) must be ≥ 0.30.0`,
   );
 });


### PR DESCRIPTION
## Summary

Closes #978. \`resolveAgentExecutable\` walks PATH then \`userToolchainDirs()\` and returns the first match. On macOS GUI launches, system PATH runs first (\`/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin\`), toolchain dirs come second. A stale \`/usr/local/bin/gemini=0.1.12\` left over from an old \`npm i -g @google/gemini-cli\` shadows a modern Homebrew/nvm install, and the daemon spawn lands on yargs \`Unknown arguments: output-format, outputFormat\` because \`--output-format stream-json\` didn't exist in that vintage. Documented \`GEMINI_BIN\` is the existing escape hatch but the user has to know to set it.

## What changed

Opt-in version-aware resolution via a new \`def.minVersion\` field. Currently set only on Gemini (\`'0.30.0'\` — the cited baseline in #978 where \`--output-format stream-json\` shipped stable). Other agents skip the version walk and keep first-match resolution unchanged.

When \`def.minVersion\` is set, \`chooseExecutableByMinVersion\`:

1. Honors the explicit \`<AGENT>_BIN\` configured override (Gemini's \`GEMINI_BIN\`) without running version probes — the user opted out of auto-pick.
2. Enumerates every path on PATH + toolchain dirs where \`def.bin\` resolves.
3. Runs \`--version\` on each in parallel with a 1.5s timeout.
4. Picks the first whose version meets \`minVersion\`.
5. Falls through to first-found when nothing meets the floor — existing detection error path still fires (cryptic, but visible) instead of silently dropping the agent.

\`probe()\` runs the smart resolver and caches the chosen path. The synchronous chat-time \`resolveAgentBin\` (used by the chat handler so spawn() lands on the same executable detection chose, fix for #10) consults the cache first.

## Why this cut

The user's diagnosis was correct: it IS PATH resolution. Just enriching PATH (already partially done in #614) doesn't help when the stale binary is on the system PATH that runs first. Just clearer error messaging (option 1 alone in the issue) leaves the user to manually \`sudo rm /usr/local/bin/gemini\`. The smart resolver actually fixes the multi-install scenario without user action while keeping the explicit override as the escape hatch. \`minVersion\` is opt-in per agent so nothing changes for claude / codex / opencode / etc.

## Test plan

- [x] \`pnpm i18n:check\` — passes.
- [x] \`pnpm typecheck\` (daemon) — my touched files contribute zero new errors (5 pre-existing errors on \`origin/main\` from the \`DesktopExportPdfInput\` sidecar drift, unrelated to this PR).
- [x] \`pnpm test\` (daemon) — 1074 / 1074 of the runnable tests pass; 5 pre-existing failures on origin/main (vp-cli-probe scenarios, resolveCurrentArtifact) unchanged. New tests:
  - \`compareSemver\` (3 cases): basic compare, v-prefix / pre-release / build tolerance, returns 0-on-unparseable so the fall-through fires correctly.
  - \`enumerateOnPath\` (2 cases): PATH order preserved across multiple matches, empty list when bin missing.
  - \`chooseExecutableByMinVersion\` (4 cases): picks newer when older is on PATH first, falls through to first-found when nothing meets the floor (so the existing error surface still fires), honors \`GEMINI_BIN\` override without running version probes, returns null resolved when no candidate exists.
  - \`detectAgents + resolveAgentBin\` end-to-end: pins the cache wiring — without it, chat-time spawn would re-resolve via first-match \`resolveAgentExecutable\` and land on the stale binary detection skipped.
  - Regression guard pinning \`gemini.minVersion\` (so a future cleanup that strips the field can't silently put the GUI app back into the failure mode).

## Manual repro

The issue's setup, simulated locally with two fake \`gemini\` shell scripts:

\`\`\`bash
mkdir -p /tmp/old/bin /tmp/new/bin
cat > /tmp/old/bin/gemini <<'EOSH'
#!/bin/sh
[ \"\$1\" = \"--version\" ] && echo \"0.1.12\"
EOSH
cat > /tmp/new/bin/gemini <<'EOSH'
#!/bin/sh
[ \"\$1\" = \"--version\" ] && echo \"0.40.1\"
EOSH
chmod +x /tmp/old/bin/gemini /tmp/new/bin/gemini

PATH=\"/tmp/old/bin:/tmp/new/bin\" pnpm --filter @open-design/daemon dev
\`\`\`

Before: \`/api/agents\` reports \`gemini\` at \`/tmp/old/bin/gemini\` with version \`0.1.12\`. Sending a chat → \`agent exited with code 1\` + yargs help.

After: \`/api/agents\` reports \`gemini\` at \`/tmp/new/bin/gemini\` with version \`0.40.1\`. Chat lands on the modern binary and the spawn succeeds.

Setting \`GEMINI_BIN=/tmp/old/bin/gemini\` in the daemon's env still wins (escape hatch preserved) — the user has explicitly opted out of auto-pick.

## Out of scope (flagged for follow-ups)

- Surfacing a structured \`disabledReason\` to the API contract / Settings UI when no candidate met \`minVersion\`. Useful for the \"no modern install anywhere\" case (the existing error stays cryptic) but layers over the contract.
- Documenting the minimum Gemini CLI version in agent docs (option 4 in the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)