### PR TITLE
feat(daemon): load user design systems from ~/.open-design/design-systems

### DIFF
--- a/apps/daemon/src/design-systems.ts
+++ b/apps/daemon/src/design-systems.ts
@@ -4,6 +4,7 @@
 // paragraph between the H1 and the next heading (Category line stripped).
 
 import { readdir, readFile, stat } from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 
 export type DesignSystemSurface = 'web' | 'image' | 'video' | 'audio';
@@ -19,6 +20,14 @@ export type DesignSystemSummary = {
 };
 
 type ColorToken = { name: string; value: string };
+
+// Mirrors the convention already used by deployConfigPath() — user-writable
+// state lives under ~/.open-design (OD_USER_STATE_DIR overrides the base).
+// Keeping it in this module so resource resolution stays alongside the loader.
+export function userDesignSystemsDir(): string {
+  const base = process.env.OD_USER_STATE_DIR || path.join(os.homedir(), '.open-design');
+  return path.join(base, 'design-systems');
+}
 
 export async function listDesignSystems(root: string): Promise<DesignSystemSummary[]> {
   const out: DesignSystemSummary[] = [];
@@ -53,6 +62,28 @@ export async function listDesignSystems(root: string): Promise<DesignSystemSumma
   return out;
 }
 
+// User entries override bundled entries with the same id. The user list is
+// surfaced first so that picker iteration order is stable when a user
+// override shadows a bundled system.
+export function mergeDesignSystemLists(
+  user: DesignSystemSummary[],
+  bundled: DesignSystemSummary[],
+): DesignSystemSummary[] {
+  const userIds = new Set(user.map((d) => d.id));
+  return [...user, ...bundled.filter((d) => !userIds.has(d.id))];
+}
+
+export async function listAllDesignSystems(
+  bundledRoot: string,
+  userRoot: string,
+): Promise<DesignSystemSummary[]> {
+  const [bundled, user] = await Promise.all([
+    listDesignSystems(bundledRoot),
+    listDesignSystems(userRoot),
+  ]);
+  return mergeDesignSystemLists(user, bundled);
+}
+
 export async function readDesignSystem(root: string, id: string): Promise<string | null> {
   const file = path.join(root, id, 'DESIGN.md');
   try {
@@ -60,6 +91,18 @@ export async function readDesignSystem(root: string, id: string): Promise<string
   } catch {
     return null;
   }
+}
+
+// User folder takes precedence so a user-authored override of a bundled id
+// returns the user copy. Returns null if neither root has the design system.
+export async function readDesignSystemFromAny(
+  bundledRoot: string,
+  userRoot: string,
+  id: string,
+): Promise<string | null> {
+  const fromUser = await readDesignSystem(userRoot, id);
+  if (fromUser !== null) return fromUser;
+  return readDesignSystem(bundledRoot, id);
 }
 
 function summarize(raw: string): string {

--- a/apps/daemon/src/finalize-design.ts
+++ b/apps/daemon/src/finalize-design.ts
@@ -33,7 +33,7 @@ import type {
   FinalizeArtifactRef,
 } from '@open-design/contracts/api/finalize';
 import { getProject } from './db.js';
-import { readDesignSystem } from './design-systems.js';
+import { readDesignSystemFromAny, userDesignSystemsDir } from './design-systems.js';
 import {
   listFiles,
   readProjectFile,
@@ -271,7 +271,11 @@ export async function finalizeDesignPackage(
         ? ((project as { designSystemId: string }).designSystemId)
         : null;
     const designSystemBody = designSystemId
-      ? await readDesignSystem(designSystemsRoot, designSystemId)
+      ? await readDesignSystemFromAny(
+          designSystemsRoot,
+          userDesignSystemsDir(),
+          designSystemId,
+        )
       : null;
 
     // Phase 5: current artifact (active tab → newest .artifact.json → null).

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -36,7 +36,11 @@ import { validateLinkedDirs } from './linked-dirs.js';
 import { buildWindowsFolderDialogCommand, parseFolderDialogStdout } from './native-folder-dialog.js';
 import { listCodexPets, readCodexPetSpritesheet } from './codex-pets.js';
 import { syncCommunityPets } from './community-pets-sync.js';
-import { listDesignSystems, readDesignSystem } from './design-systems.js';
+import {
+  listAllDesignSystems,
+  readDesignSystemFromAny,
+  userDesignSystemsDir,
+} from './design-systems.js';
 import { attachAcpSession } from './acp.js';
 import { attachPiRpcSession } from './pi-rpc.js';
 import { createClaudeStreamHandler } from './claude-stream.js';
@@ -733,6 +737,11 @@ const DESIGN_SYSTEMS_DIR = resolveDaemonResourceDir(
   'design-systems',
   path.join(PROJECT_ROOT, 'design-systems'),
 );
+// User-writable overlay so users can drop custom design systems somewhere
+// that survives app updates (the bundled DESIGN_SYSTEMS_DIR is overwritten
+// every release in packaged builds). Same convention as deployConfigPath():
+// OD_USER_STATE_DIR overrides ~/.open-design.
+const USER_DESIGN_SYSTEMS_DIR = userDesignSystemsDir();
 const CRAFT_DIR = resolveDaemonResourceDir(
   DAEMON_RESOURCE_ROOT,
   'craft',
@@ -3095,7 +3104,10 @@ export async function startServer({
 
   app.get('/api/design-systems', async (_req, res) => {
     try {
-      const systems = await listDesignSystems(DESIGN_SYSTEMS_DIR);
+      const systems = await listAllDesignSystems(
+        DESIGN_SYSTEMS_DIR,
+        USER_DESIGN_SYSTEMS_DIR,
+      );
       res.json({
         designSystems: systems.map(({ body, ...rest }) => rest),
       });
@@ -3106,7 +3118,11 @@ export async function startServer({
 
   app.get('/api/design-systems/:id', async (req, res) => {
     try {
-      const body = await readDesignSystem(DESIGN_SYSTEMS_DIR, req.params.id);
+      const body = await readDesignSystemFromAny(
+        DESIGN_SYSTEMS_DIR,
+        USER_DESIGN_SYSTEMS_DIR,
+        req.params.id,
+      );
       if (body === null)
         return res.status(404).json({ error: 'design system not found' });
       res.json({ id: req.params.id, body });
@@ -3147,7 +3163,11 @@ export async function startServer({
   // file shows up on the next view, no rebuild needed.
   app.get('/api/design-systems/:id/preview', async (req, res) => {
     try {
-      const body = await readDesignSystem(DESIGN_SYSTEMS_DIR, req.params.id);
+      const body = await readDesignSystemFromAny(
+        DESIGN_SYSTEMS_DIR,
+        USER_DESIGN_SYSTEMS_DIR,
+        req.params.id,
+      );
       if (body === null)
         return res.status(404).type('text/plain').send('not found');
       const html = renderDesignSystemPreview(req.params.id, body);
@@ -3162,7 +3182,11 @@ export async function startServer({
   // /preview: built at request time, no caching.
   app.get('/api/design-systems/:id/showcase', async (req, res) => {
     try {
-      const body = await readDesignSystem(DESIGN_SYSTEMS_DIR, req.params.id);
+      const body = await readDesignSystemFromAny(
+        DESIGN_SYSTEMS_DIR,
+        USER_DESIGN_SYSTEMS_DIR,
+        req.params.id,
+      );
       if (body === null)
         return res.status(404).type('text/plain').send('not found');
       const html = renderDesignSystemShowcase(req.params.id, body);
@@ -4790,12 +4814,18 @@ export async function startServer({
     let designSystemBody;
     let designSystemTitle;
     if (effectiveDesignSystemId) {
-      const systems = await listDesignSystems(DESIGN_SYSTEMS_DIR);
+      const systems = await listAllDesignSystems(
+        DESIGN_SYSTEMS_DIR,
+        USER_DESIGN_SYSTEMS_DIR,
+      );
       const summary = systems.find((s) => s.id === effectiveDesignSystemId);
       designSystemTitle = summary?.title;
       designSystemBody =
-        (await readDesignSystem(DESIGN_SYSTEMS_DIR, effectiveDesignSystemId)) ??
-        undefined;
+        (await readDesignSystemFromAny(
+          DESIGN_SYSTEMS_DIR,
+          USER_DESIGN_SYSTEMS_DIR,
+          effectiveDesignSystemId,
+        )) ?? undefined;
     }
 
     const template =
@@ -5157,7 +5187,12 @@ export async function startServer({
       codexGeneratedImagesDir = validateCodexGeneratedImagesDir(
         codexGeneratedImagesDir,
         {
-          protectedDirs: [SKILLS_DIR, DESIGN_SYSTEMS_DIR, ...linkedDirs],
+          protectedDirs: [
+            SKILLS_DIR,
+            DESIGN_SYSTEMS_DIR,
+            USER_DESIGN_SYSTEMS_DIR,
+            ...linkedDirs,
+          ],
         },
       );
     }
@@ -5165,7 +5200,9 @@ export async function startServer({
       agentId,
       skillsDir: SKILLS_DIR,
       designSystemsDir: DESIGN_SYSTEMS_DIR,
-      linkedDirs,
+      // Piped through `linkedDirs` so the user overlay is allowlisted
+      // without changing resolveChatExtraAllowedDirs's signature.
+      linkedDirs: [USER_DESIGN_SYSTEMS_DIR, ...linkedDirs],
       codexGeneratedImagesDir,
     });
     const codexImagegenOverride = resolveGrantedCodexImagegenOverride({

--- a/apps/daemon/tests/design-systems.test.ts
+++ b/apps/daemon/tests/design-systems.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, beforeAll, afterAll } from 'vitest';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import {
+  listAllDesignSystems,
+  listDesignSystems,
+  mergeDesignSystemLists,
+  readDesignSystem,
+  readDesignSystemFromAny,
+} from '../src/design-systems.js';
+
+let bundledDir: string;
+let userDir: string;
+
+beforeAll(async () => {
+  bundledDir = await mkdtemp(path.join(tmpdir(), 'od-ds-bundled-'));
+  userDir = await mkdtemp(path.join(tmpdir(), 'od-ds-user-'));
+
+  await mkdir(path.join(bundledDir, 'alpha'), { recursive: true });
+  await writeFile(
+    path.join(bundledDir, 'alpha', 'DESIGN.md'),
+    '# Alpha\n\n> Category: Bundled\n\nBundled alpha body.\n',
+    'utf8',
+  );
+  await mkdir(path.join(bundledDir, 'beta'), { recursive: true });
+  await writeFile(
+    path.join(bundledDir, 'beta', 'DESIGN.md'),
+    '# Beta\n\n> Category: Bundled\n\nBundled beta body.\n',
+    'utf8',
+  );
+
+  // `alpha` collides with a bundled id so we can verify user-wins. `gamma`
+  // is user-only and should appear in the merged list.
+  await mkdir(path.join(userDir, 'alpha'), { recursive: true });
+  await writeFile(
+    path.join(userDir, 'alpha', 'DESIGN.md'),
+    '# Alpha (user)\n\n> Category: Custom\n\nUser alpha override.\n',
+    'utf8',
+  );
+  await mkdir(path.join(userDir, 'gamma'), { recursive: true });
+  await writeFile(
+    path.join(userDir, 'gamma', 'DESIGN.md'),
+    '# Gamma\n\n> Category: Custom\n\nUser-only gamma.\n',
+    'utf8',
+  );
+});
+
+afterAll(async () => {
+  await rm(bundledDir, { recursive: true, force: true });
+  await rm(userDir, { recursive: true, force: true });
+});
+
+describe('listAllDesignSystems', () => {
+  it('merges user and bundled, with user winning on id collision', async () => {
+    const merged = await listAllDesignSystems(bundledDir, userDir);
+    const ids = merged.map((d) => d.id).sort();
+    expect(ids).toEqual(['alpha', 'beta', 'gamma']);
+    const alpha = merged.find((d) => d.id === 'alpha')!;
+    expect(alpha.title).toBe('Alpha (user)');
+    expect(alpha.category).toBe('Custom');
+  });
+
+  it('still returns bundled list when the user folder does not exist', async () => {
+    const missingUserDir = path.join(userDir, '__does_not_exist__');
+    const merged = await listAllDesignSystems(bundledDir, missingUserDir);
+    expect(merged.map((d) => d.id).sort()).toEqual(['alpha', 'beta']);
+  });
+});
+
+describe('mergeDesignSystemLists', () => {
+  it('keeps user entries first and drops bundled duplicates', async () => {
+    const bundled = await listDesignSystems(bundledDir);
+    const user = await listDesignSystems(userDir);
+    const merged = mergeDesignSystemLists(user, bundled);
+    expect(merged[0]?.id).toBe('alpha');
+    expect(merged.find((d) => d.id === 'alpha')?.title).toBe('Alpha (user)');
+    expect(merged.filter((d) => d.id === 'alpha')).toHaveLength(1);
+  });
+});
+
+describe('readDesignSystemFromAny', () => {
+  it('returns the user copy when the id exists in both', async () => {
+    const body = await readDesignSystemFromAny(bundledDir, userDir, 'alpha');
+    expect(body).toContain('User alpha override.');
+  });
+
+  it('falls back to bundled when the user folder lacks the id', async () => {
+    const body = await readDesignSystemFromAny(bundledDir, userDir, 'beta');
+    expect(body).toContain('Bundled beta body.');
+  });
+
+  it('returns null when neither root has the id', async () => {
+    const body = await readDesignSystemFromAny(bundledDir, userDir, 'nope');
+    expect(body).toBeNull();
+  });
+
+  it('matches readDesignSystem output for a bundled-only id', async () => {
+    const direct = await readDesignSystem(bundledDir, 'beta');
+    const merged = await readDesignSystemFromAny(bundledDir, userDir, 'beta');
+    expect(merged).toBe(direct);
+  });
+});

--- a/design-systems/README.md
+++ b/design-systems/README.md
@@ -68,6 +68,19 @@ Drop a new folder containing a `DESIGN.md` and it shows up on next refresh.
 Add a `> Category: <Group>` line to slot it under an existing group, or use
 any new label and it lands at the bottom of the dropdown.
 
+For packaged installs, prefer a user-writable folder so your templates
+survive app updates (the bundled `design-systems/` folder is overwritten on
+upgrade in packaged builds):
+
+```
+~/.open-design/design-systems/<your-template>/DESIGN.md
+```
+
+The daemon scans this folder in addition to the bundled one. If a user
+folder uses the same id as a bundled system, the user copy wins. Override
+the base path with the `OD_USER_STATE_DIR` env var (the same convention used
+by deploy credentials).
+
 ## Refreshing the bundled set
 
 The 70 product systems are pulled from the upstream npm package. To re-sync


### PR DESCRIPTION
## Summary

- Packaged installs ship design systems under `<app resources>/open-design/design-systems/`, which is overwritten on every update — any design system added there is lost on upgrade.
- This change adds a user-writable overlay at `~/.open-design/design-systems/` that the daemon scans in addition to the bundled folder.
- User entries win on id collision, so a user-authored override of a bundled system is preserved across upgrades.

## Design notes

- Path convention: `OD_USER_STATE_DIR || ~/.open-design`, the same one already used by `deployConfigPath()` for Vercel/Cloudflare credentials. New helper `userDesignSystemsDir()` lives next to the loader.
- New helpers in `apps/daemon/src/design-systems.ts`:
  - `mergeDesignSystemLists(user, bundled)` — user-first, dedupe by id.
  - `listAllDesignSystems(bundledRoot, userRoot)` — parallel scan + merge.
  - `readDesignSystemFromAny(bundledRoot, userRoot, id)` — user copy wins; falls back to bundled.
- Existing `listDesignSystems` / `readDesignSystem` signatures are unchanged so callers (incl. tests) keep working with no fan-out.
- `finalizeDesignPackage` keeps its existing signature and derives the user dir internally via `userDesignSystemsDir()` — avoids touching the 11 existing test call sites.
- Server endpoints rewired to consult both folders: `GET /api/design-systems`, `GET /api/design-systems/:id`, `/preview`, `/showcase`, plus the chat-time active-system lookup.
- `protectedDirs` and `extraAllowedDirs` include the user folder too, so agents can read user templates symmetrically with bundled ones (piped via `linkedDirs` to keep `resolveChatExtraAllowedDirs`'s signature unchanged).
- MCP `od://design-systems/...` resources inherit the merge for free since the MCP layer goes through `/api/design-systems`.

## What this PR does *not* change

- No web UI changes. The picker doesn't visually distinguish user vs bundled (intentionally kept out of this PR to keep the surface small; can be added in a follow-up if desired).
- No contracts changes. `DesignSystemSummary` shape unchanged.
- No packager changes. Bundled folder location is untouched.

## Test plan

- [x] New `apps/daemon/tests/design-systems.test.ts` covers: merge, user-wins on id collision, fallback when the user folder is missing, and read precedence (`readDesignSystemFromAny`).
- [x] `pnpm --filter @open-design/daemon test` — 1380/1380 pass.
- [x] `pnpm --filter @open-design/daemon typecheck` — clean.
- [x] `pnpm --filter @open-design/contracts typecheck` — clean.
- [x] `pnpm guard` — passes.
- [ ] Manual: drop a `DESIGN.md` under `~/.open-design/design-systems/<my-template>/` in a packaged install and confirm it appears in the picker after restart.