### PR TITLE
feat(contracts): share critique round / status types via the contracts package

### DIFF
--- a/apps/daemon/src/critique/persistence.ts
+++ b/apps/daemon/src/critique/persistence.ts
@@ -1,27 +1,20 @@
 import type Database from 'better-sqlite3';
-import type { ShipStatus } from '@open-design/contracts/critique';
+import {
+  CRITIQUE_RUN_STATUSES,
+  type CritiqueRoundSummary,
+  type CritiqueRunStatus,
+} from '@open-design/contracts/critique';
 
 /**
- * Final critique status persisted with each run. Mirrors the spec's CHECK
- * constraint on critique_status. 'failed' covers orchestrator-level errors,
- * 'legacy' marks rows produced before the feature shipped (reserved for the
- * artifacts-on-disk backfill in Phase 15).
+ * Re-export the public contract types and enumeration so existing
+ * daemon-side imports (`./persistence.js`) keep working unchanged. The
+ * canonical definitions live in `@open-design/contracts/critique` so the
+ * web layer can consume the same shapes and the same display order
+ * through the rerun / history endpoints (AGENTS.md requirement that
+ * shared API DTOs live in packages/contracts).
  */
-export type CritiqueRunStatus =
-  | ShipStatus
-  | 'degraded'
-  | 'failed'
-  | 'legacy';
-
-export const CRITIQUE_RUN_STATUSES: readonly CritiqueRunStatus[] = [
-  'shipped',
-  'below_threshold',
-  'timed_out',
-  'interrupted',
-  'degraded',
-  'failed',
-  'legacy',
-];
+export { CRITIQUE_RUN_STATUSES };
+export type { CritiqueRoundSummary, CritiqueRunStatus };
 
 // All values accepted by the DB CHECK constraint, including the in-flight value
 // that the public type union deliberately omits.
@@ -29,13 +22,6 @@ const ALL_VALID_STATUSES: ReadonlySet<string> = new Set([
   ...CRITIQUE_RUN_STATUSES,
   'running',
 ]);
-
-export interface CritiqueRoundSummary {
-  n: number;
-  composite: number;
-  mustFix: number;
-  decision: 'continue' | 'ship';
-}
 
 export interface CritiqueRunRow {
   id: string;

--- a/packages/contracts/src/critique.ts
+++ b/packages/contracts/src/critique.ts
@@ -173,3 +173,47 @@ export function panelEventToSse(e: PanelEvent): CritiqueSseEvent {
   // data. The cast is safe by construction.
   return { event: `critique.${type}`, data: payload } as CritiqueSseEvent;
 }
+
+/**
+ * Per-round summary persisted with each critique run. Mirrors the shape the
+ * orchestrator writes via decideRound; web clients consume it through the
+ * rerun and history endpoints, so it lives in the shared contract layer.
+ */
+export interface CritiqueRoundSummary {
+  n: number;
+  composite: number;
+  mustFix: number;
+  decision: RoundDecision;
+}
+
+/**
+ * Terminal critique status persisted with each run. Superset of ShipStatus
+ * that also covers degraded / failed / legacy outcomes. The daemon's CHECK
+ * constraint also accepts the in-flight 'running' value, but that is handled
+ * inline by daemon-side code; the public contract surface is terminal-only
+ * because every consumer of this type works against finished runs.
+ */
+export type CritiqueRunStatus =
+  | ShipStatus
+  | 'degraded'
+  | 'failed'
+  | 'legacy';
+
+/**
+ * Enumeration of every terminal CritiqueRunStatus value, in the order the
+ * UI / docs / status filters typically display them: SHIP outcomes first
+ * (shipped → below_threshold → timed_out → interrupted), then quality /
+ * lifecycle exits (degraded → failed), then the historical 'legacy' tag
+ * for runs created before the feature shipped. Web consumers (status
+ * filters, analytics dashboards) iterate this constant directly so the
+ * daemon stays the single source of truth on the order.
+ */
+export const CRITIQUE_RUN_STATUSES = [
+  'shipped',
+  'below_threshold',
+  'timed_out',
+  'interrupted',
+  'degraded',
+  'failed',
+  'legacy',
+] as const satisfies readonly CritiqueRunStatus[];


### PR DESCRIPTION
First step of the Phase 6.2 unblock plan we discussed on [#1006](https://github.com/nexu-io/open-design/pull/1006). This PR moves the three pieces of public critique state out of daemon-private source into the shared contracts package so the web layer can consume them without duplicating shapes or reaching across the apps/web → apps/daemon boundary.

### What moves

[\`packages/contracts/src/critique.ts\`](https://github.com/nexu-io/open-design/blob/feat/critique-contracts-shared-types/packages/contracts/src/critique.ts) gains:

- \`CritiqueRoundSummary\` (record persisted with each run; mirrors what the orchestrator writes in \`decideRound\`).
- \`CritiqueRunStatus\` (terminal-only union: \`ShipStatus | 'degraded' | 'failed' | 'legacy'\`).
- \`CRITIQUE_RUN_STATUSES\` (canonical display order: ship outcomes → quality / lifecycle exits → \`legacy\`).

### What stays daemon-side

[\`apps/daemon/src/critique/persistence.ts\`](https://github.com/nexu-io/open-design/blob/feat/critique-contracts-shared-types/apps/daemon/src/critique/persistence.ts) re-exports all three so every existing daemon import (orchestrator, server, run-registry, tests) keeps working unchanged.

The CHECK-constraint-aware \`ALL_VALID_STATUSES\` set that includes the in-flight \`'running'\` value stays daemon-private because it's strictly a DB invariant, not a public contract.

### Why now

This is the foundation step that codex-bot P2 and lefarcen P2 on [#1006](https://github.com/nexu-io/open-design/pull/1006) both asked for: the rerun and history endpoints will need a shared shape, and Phase 7 (web reducer) starts consuming them as soon as the artifact-extraction work lands. Splitting it out as its own no-behavior-change PR keeps it small and reviewable.

### Validation

- \`pnpm guard\` and \`pnpm --filter @open-design/contracts typecheck\` clean.
- \`pnpm --filter @open-design/daemon build\` clean (the same step CI runs for tsc).
- \`pnpm --filter @open-design/web typecheck\` clean (sanity check that web doesn't break on the contracts version bump).
- \`pnpm --filter @open-design/daemon exec vitest run tests/critique\` (12 files, 150 passed; existing \`critique-persistence.test.ts\` continues to import \`CRITIQUE_RUN_STATUSES\` through the daemon re-export and asserts the array still covers every status).