### PR TITLE
fix(i18n): add trading-terminal to localized design system coverage

### DIFF
--- a/apps/web/src/i18n/content.fr.ts
+++ b/apps/web/src/i18n/content.fr.ts
@@ -443,6 +443,7 @@ export const FR_DESIGN_SYSTEM_IDS_WITH_EN_FALLBACK = [
   'storytelling',
   'totality-festival',
   'tetris',
+  'trading-terminal',
   'urdu',
   'vibrant',
   'vintage',

--- a/apps/web/src/i18n/content.ru.ts
+++ b/apps/web/src/i18n/content.ru.ts
@@ -443,6 +443,7 @@ export const RU_DESIGN_SYSTEM_IDS_WITH_EN_FALLBACK = [
   'storytelling',
   'totality-festival',
   'tetris',
+  'trading-terminal',
   'urdu',
   'vibrant',
   'vintage',

--- a/apps/web/src/i18n/content.ts
+++ b/apps/web/src/i18n/content.ts
@@ -492,6 +492,7 @@ const DE_DESIGN_SYSTEM_IDS_WITH_EN_FALLBACK = [
   'storytelling',
   'totality-festival',
   'tetris',
+  'trading-terminal',
   'urdu',
   'vibrant',
   'vintage',


### PR DESCRIPTION
Adds `trading-terminal` to `DE_DESIGN_SYSTEM_IDS_WITH_EN_FALLBACK` (content.ts), `FR_DESIGN_SYSTEM_IDS_WITH_EN_FALLBACK` (content.fr.ts), and `RU_DESIGN_SYSTEM_IDS_WITH_EN_FALLBACK` (content.ru.ts).

Required for the `e2e/tests/localized-content.test.ts` coverage check to pass for the Trading Terminal design system (PR #883).