### PR TITLE
fix(web): make privacy consent choices explicit

### DIFF
--- a/apps/web/src/components/PrivacyConsentModal.tsx
+++ b/apps/web/src/components/PrivacyConsentModal.tsx
@@ -1,4 +1,3 @@
-import type { CSSProperties } from 'react';
 import { useT } from '../i18n';
 
 interface Props {
@@ -14,9 +13,10 @@ interface Props {
  * Anchored to the bottom-right of the viewport (cookie-consent style)
  * so it's prominently visible without blocking the underlying app —
  * the user can move around and read while deciding. The two action
- * buttons share an equal-prominence seg-control so the reject path
- * is not visually de-emphasised, the EDPB equal-prominence requirement
- * under GDPR.
+ * buttons share equal visual prominence so the reject path is not
+ * de-emphasised, matching the EDPB equal-prominence requirement
+ * under GDPR. Neither button is rendered as selected before the user
+ * chooses.
  *
  * Stays mounted until the user picks Share or Don't share — there is
  * no dismiss-without-choice button on purpose. Telemetry decisions
@@ -48,16 +48,15 @@ export function PrivacyConsentModal({ onShare, onDecline }: Props): JSX.Element 
       <p className="hint privacy-consent-banner-footer">{t('settings.privacyConsentFooter')}</p>
 
       <div
-        className="seg-control"
+        className="privacy-consent-actions"
         role="group"
         aria-label={t('settings.privacyConsentKicker')}
-        style={{ ['--seg-cols' as string]: 2 } as CSSProperties}
       >
-        <button type="button" className="seg-btn active" onClick={onShare}>
-          <span className="seg-title">{t('settings.privacyConsentShare')}</span>
+        <button type="button" className="privacy-consent-action" onClick={onShare}>
+          {t('settings.privacyConsentShare')}
         </button>
-        <button type="button" className="seg-btn" onClick={onDecline}>
-          <span className="seg-title">{t('settings.privacyConsentDecline')}</span>
+        <button type="button" className="privacy-consent-action" onClick={onDecline}>
+          {t('settings.privacyConsentDecline')}
         </button>
       </div>
     </div>

--- a/apps/web/src/components/PrivacySection.tsx
+++ b/apps/web/src/components/PrivacySection.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties, Dispatch, SetStateAction } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
 import { useT } from '../i18n';
 import { Icon } from './Icon';
 import type { AppConfig, TelemetryConfig } from '../types';
@@ -189,22 +189,16 @@ function ConsentCard({ onShare, onDecline }: ConsentProps): JSX.Element {
 
       <p className="hint">{t('settings.privacyConsentFooter')}</p>
 
-      {/* Two-column seg-control gives both buttons identical visual weight,
-          which is what GDPR/EDPB asks for ("equal prominence" between
-          accept and reject). The accept side carries the active highlight
-          to mark it as the affirmative action without making the reject
-          side smaller or dimmer. */}
       <div
-        className="seg-control"
+        className="privacy-consent-actions"
         role="group"
         aria-label={t('settings.privacyConsentKicker')}
-        style={{ ['--seg-cols' as string]: 2 } as CSSProperties}
       >
-        <button type="button" className="seg-btn active" onClick={onShare}>
-          <span className="seg-title">{t('settings.privacyConsentShare')}</span>
+        <button type="button" className="privacy-consent-action" onClick={onShare}>
+          {t('settings.privacyConsentShare')}
         </button>
-        <button type="button" className="seg-btn" onClick={onDecline}>
-          <span className="seg-title">{t('settings.privacyConsentDecline')}</span>
+        <button type="button" className="privacy-consent-action" onClick={onDecline}>
+          {t('settings.privacyConsentDecline')}
         </button>
       </div>
     </div>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -14318,9 +14318,35 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   color: var(--text-muted);
 }
 
+.privacy-consent-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.privacy-consent-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  min-height: 38px;
+  padding: 8px 12px;
+  background: var(--bg-panel);
+  border-color: var(--border-strong);
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 600;
+  text-align: center;
+}
+
+.privacy-consent-action:hover:not(:disabled) {
+  background: var(--bg-subtle);
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--border-strong));
+}
+
 /* First-run privacy consent banner. Cookie-consent-style: anchored to the
-   bottom-right of the viewport, prominent but non-blocking, equal-weight
-   accept / decline pair via the existing 2-cell seg-control. Reuses the
+   bottom-right of the viewport, prominent but non-blocking. Reuses the
    same typography + radii + shadow as the rest of the panels. */
 .privacy-consent-banner {
   position: fixed;
@@ -14341,7 +14367,7 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   pointer-events: none;
 }
 
-.privacy-consent-banner .seg-control {
+.privacy-consent-banner .privacy-consent-actions {
   pointer-events: auto;
 }
 

--- a/apps/web/tests/components/App.connectors.test.tsx
+++ b/apps/web/tests/components/App.connectors.test.tsx
@@ -233,6 +233,12 @@ describe('App connectors settings flows', () => {
     await waitFor(() => {
       expect(container.querySelector('.privacy-consent-banner')).toBeTruthy();
     });
+    const banner = container.querySelector('.privacy-consent-banner');
+    expect(banner?.querySelector('.seg-control')).toBeNull();
+    expect(banner?.querySelector('.seg-btn.active')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Help improve' }).className).toContain(
+      'privacy-consent-action',
+    );
   });
 
   it('hides first-run privacy consent while settings is open', async () => {


### PR DESCRIPTION
## Summary

- Replace the privacy consent segmented control with two equal-weight plain buttons, so neither choice appears pre-selected.
- Apply the same explicit button treatment to the Settings -> Privacy consent card.
- Add a regression asserting the first-run banner no longer renders a selected segmented control.

## Test plan

- [x] `pnpm --filter @open-design/contracts build`
- [x] `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/App.connectors.test.tsx`
- [x] `pnpm --filter @open-design/web typecheck`

Note: local validation emitted Node engine warnings because this machine is on Node v22.22.0 while the repo targets Node ~24.