### PR TITLE
fix(desktop): keep modal controls clickable in drag regions

### DIFF
--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -101,6 +101,16 @@ const MAC_WINDOW_CHROME_CSS = `
   .app-chrome-drag {
     -webkit-app-region: drag;
   }
+  .modal-backdrop,
+  .modal-backdrop *,
+  .modal,
+  .modal *,
+  .ds-modal-backdrop,
+  .ds-modal-backdrop *,
+  .ds-modal,
+  .ds-modal * {
+    -webkit-app-region: no-drag;
+  }
   .entry-brand,
   .entry-header {
     -webkit-app-region: drag;
@@ -115,10 +125,6 @@ const MAC_WINDOW_CHROME_CSS = `
   .viewer-toolbar *,
   .deck-nav,
   .deck-nav *,
-  .ds-modal-header,
-  .ds-modal-header *,
-  .ds-modal-actions,
-  .ds-modal-actions *,
   .share-menu-popover,
   .share-menu-popover *,
   .entry-side-resizer,

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1082,6 +1082,7 @@ code {
   background: rgba(28, 27, 26, 0.42);
   backdrop-filter: blur(4px);
   -webkit-backdrop-filter: blur(4px);
+  -webkit-app-region: no-drag;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1090,6 +1091,7 @@ code {
 }
 .modal {
   background: var(--bg-elevated);
+  -webkit-app-region: no-drag;
   border-radius: var(--radius-lg);
   padding: 22px;
   width: 520px;
@@ -10565,6 +10567,7 @@ button.ghost.mcp-copy-btn:hover:not(:disabled) {
   z-index: 900;
   background: rgba(28, 27, 26, 0.42);
   backdrop-filter: blur(2px);
+  -webkit-app-region: no-drag;
   display: flex;
   align-items: stretch;
   justify-content: center;
@@ -10574,6 +10577,7 @@ button.ghost.mcp-copy-btn:hover:not(:disabled) {
   width: 100%;
   max-width: 1320px;
   background: var(--bg);
+  -webkit-app-region: no-drag;
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-lg);


### PR DESCRIPTION
## Summary
- Mark settings and design-system preview modals as `no-drag` so controls remain clickable when overlapping the Electron chrome drag strip.
- Broaden the macOS injected chrome CSS from individual DS modal controls to whole modal/backdrop surfaces.

## Validation
- `pnpm --filter @open-design/desktop typecheck`
- `pnpm --filter @open-design/web typecheck`