### PR TITLE
feat: add scheduled routines for unattended agent runs

### DIFF
--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -158,6 +158,40 @@ function migrate(db: SqliteDb): void {
 
     CREATE INDEX IF NOT EXISTS idx_deployments_project
       ON deployments(project_id, updated_at DESC);
+
+    CREATE TABLE IF NOT EXISTS routines (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      prompt TEXT NOT NULL,
+      schedule_kind TEXT NOT NULL,
+      schedule_value TEXT NOT NULL,
+      schedule_json TEXT,
+      project_mode TEXT NOT NULL,
+      project_id TEXT,
+      skill_id TEXT,
+      agent_id TEXT,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS routine_runs (
+      id TEXT PRIMARY KEY,
+      routine_id TEXT NOT NULL,
+      trigger TEXT NOT NULL,
+      status TEXT NOT NULL,
+      project_id TEXT NOT NULL,
+      conversation_id TEXT NOT NULL,
+      agent_run_id TEXT NOT NULL,
+      started_at INTEGER NOT NULL,
+      completed_at INTEGER,
+      summary TEXT,
+      error TEXT,
+      FOREIGN KEY(routine_id) REFERENCES routines(id) ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_routine_runs_routine
+      ON routine_runs(routine_id, started_at DESC);
   `);
   // Forward-compatible column add for databases created before metadata_json.
   // SQLite has no IF NOT EXISTS for ALTER, so we check pragma_table_info.
@@ -207,6 +241,15 @@ function migrate(db: SqliteDb): void {
   }
   if (!deploymentCols.some((c: DbRow) => c.name === 'provider_metadata_json')) {
     db.exec(`ALTER TABLE deployments ADD COLUMN provider_metadata_json TEXT`);
+  }
+  // schedule_json holds the full RoutineSchedule object (kind discriminator
+  // plus kind-specific fields like time/timezone/weekday). The legacy
+  // schedule_kind/schedule_value columns are kept populated for query
+  // convenience and as a fallback when reading rows written before this
+  // column existed.
+  const routineCols = db.prepare(`PRAGMA table_info(routines)`).all() as DbRow[];
+  if (routineCols.length > 0 && !routineCols.some((c: DbRow) => c.name === 'schedule_json')) {
+    db.exec(`ALTER TABLE routines ADD COLUMN schedule_json TEXT`);
   }
   migrateCritique(db);
   migrateMediaTasks(db);
@@ -1028,6 +1071,207 @@ function parseJsonOrUndef(s: unknown): any {
   } catch {
     return undefined;
   }
+}
+
+// ---------- routines ----------
+
+const ROUTINE_COLS = `id, name, prompt,
+  schedule_kind AS scheduleKind, schedule_value AS scheduleValue,
+  schedule_json AS scheduleJson,
+  project_mode AS projectMode, project_id AS projectId,
+  skill_id AS skillId, agent_id AS agentId,
+  enabled, created_at AS createdAt, updated_at AS updatedAt`;
+
+const ROUTINE_RUN_COLS = `id, routine_id AS routineId, trigger, status,
+  project_id AS projectId, conversation_id AS conversationId,
+  agent_run_id AS agentRunId, started_at AS startedAt,
+  completed_at AS completedAt, summary, error`;
+
+export function listRoutines(db: SqliteDb) {
+  return (db
+    .prepare(`SELECT ${ROUTINE_COLS} FROM routines ORDER BY created_at ASC`)
+    .all() as DbRow[])
+    .map(normalizeRoutine);
+}
+
+export function getRoutine(db: SqliteDb, id: string) {
+  const r = db
+    .prepare(`SELECT ${ROUTINE_COLS} FROM routines WHERE id = ?`)
+    .get(id) as DbRow | undefined;
+  return r ? normalizeRoutine(r) : null;
+}
+
+export function insertRoutine(db: SqliteDb, r: DbRow) {
+  db.prepare(
+    `INSERT INTO routines
+       (id, name, prompt, schedule_kind, schedule_value, schedule_json,
+        project_mode, project_id, skill_id, agent_id, enabled,
+        created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    r.id,
+    r.name,
+    r.prompt,
+    r.scheduleKind,
+    r.scheduleValue,
+    r.scheduleJson ?? null,
+    r.projectMode,
+    r.projectId ?? null,
+    r.skillId ?? null,
+    r.agentId ?? null,
+    r.enabled ? 1 : 0,
+    r.createdAt,
+    r.updatedAt,
+  );
+  return getRoutine(db, r.id);
+}
+
+export function updateRoutine(db: SqliteDb, id: string, patch: DbRow) {
+  const existing = getRoutine(db, id);
+  if (!existing) return null;
+  const merged = {
+    ...existing,
+    ...patch,
+    updatedAt: typeof patch.updatedAt === 'number' ? patch.updatedAt : Date.now(),
+  };
+  db.prepare(
+    `UPDATE routines
+        SET name = ?, prompt = ?,
+            schedule_kind = ?, schedule_value = ?, schedule_json = ?,
+            project_mode = ?, project_id = ?,
+            skill_id = ?, agent_id = ?,
+            enabled = ?, updated_at = ?
+      WHERE id = ?`,
+  ).run(
+    merged.name,
+    merged.prompt,
+    merged.scheduleKind,
+    merged.scheduleValue,
+    merged.scheduleJson ?? null,
+    merged.projectMode,
+    merged.projectId ?? null,
+    merged.skillId ?? null,
+    merged.agentId ?? null,
+    merged.enabled ? 1 : 0,
+    merged.updatedAt,
+    id,
+  );
+  return getRoutine(db, id);
+}
+
+export function deleteRoutine(db: SqliteDb, id: string): boolean {
+  const result = db.prepare(`DELETE FROM routines WHERE id = ?`).run(id);
+  return result.changes > 0;
+}
+
+function normalizeRoutine(row: DbRow) {
+  return {
+    id: row.id,
+    name: row.name,
+    prompt: row.prompt,
+    scheduleKind: row.scheduleKind,
+    scheduleValue: row.scheduleValue,
+    scheduleJson: row.scheduleJson ?? null,
+    projectMode: row.projectMode,
+    projectId: row.projectId ?? null,
+    skillId: row.skillId ?? null,
+    agentId: row.agentId ?? null,
+    enabled: Number(row.enabled) === 1,
+    createdAt: Number(row.createdAt),
+    updatedAt: Number(row.updatedAt),
+  };
+}
+
+export function listRoutineRuns(db: SqliteDb, routineId: string, limit = 20) {
+  return (db
+    .prepare(
+      `SELECT ${ROUTINE_RUN_COLS}
+         FROM routine_runs
+        WHERE routine_id = ?
+        ORDER BY started_at DESC
+        LIMIT ?`,
+    )
+    .all(routineId, limit) as DbRow[])
+    .map(normalizeRoutineRun);
+}
+
+export function getLatestRoutineRun(db: SqliteDb, routineId: string) {
+  const r = db
+    .prepare(
+      `SELECT ${ROUTINE_RUN_COLS}
+         FROM routine_runs
+        WHERE routine_id = ?
+        ORDER BY started_at DESC
+        LIMIT 1`,
+    )
+    .get(routineId) as DbRow | undefined;
+  return r ? normalizeRoutineRun(r) : null;
+}
+
+export function getRoutineRun(db: SqliteDb, id: string) {
+  const r = db
+    .prepare(`SELECT ${ROUTINE_RUN_COLS} FROM routine_runs WHERE id = ?`)
+    .get(id) as DbRow | undefined;
+  return r ? normalizeRoutineRun(r) : null;
+}
+
+export function insertRoutineRun(db: SqliteDb, r: DbRow) {
+  db.prepare(
+    `INSERT INTO routine_runs
+       (id, routine_id, trigger, status, project_id, conversation_id,
+        agent_run_id, started_at, completed_at, summary, error)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    r.id,
+    r.routineId,
+    r.trigger,
+    r.status,
+    r.projectId,
+    r.conversationId,
+    r.agentRunId,
+    r.startedAt,
+    r.completedAt ?? null,
+    r.summary ?? null,
+    r.error ?? null,
+  );
+  return getRoutineRun(db, r.id);
+}
+
+export function updateRoutineRun(db: SqliteDb, id: string, patch: DbRow) {
+  const existing = getRoutineRun(db, id);
+  if (!existing) return null;
+  const merged = {
+    ...existing,
+    ...patch,
+  };
+  db.prepare(
+    `UPDATE routine_runs
+        SET status = ?, completed_at = ?, summary = ?, error = ?
+      WHERE id = ?`,
+  ).run(
+    merged.status,
+    merged.completedAt ?? null,
+    merged.summary ?? null,
+    merged.error ?? null,
+    id,
+  );
+  return getRoutineRun(db, id);
+}
+
+function normalizeRoutineRun(row: DbRow) {
+  return {
+    id: row.id,
+    routineId: row.routineId,
+    trigger: row.trigger,
+    status: row.status,
+    projectId: row.projectId,
+    conversationId: row.conversationId,
+    agentRunId: row.agentRunId,
+    startedAt: Number(row.startedAt),
+    completedAt: row.completedAt == null ? null : Number(row.completedAt),
+    summary: row.summary ?? null,
+    error: row.error ?? null,
+  };
 }
 
 // ---------- tabs ----------

--- a/apps/daemon/src/routines.ts
+++ b/apps/daemon/src/routines.ts
@@ -452,9 +452,16 @@ export class RoutineService {
       return handlerStart;
     })();
     this.inflight.set(routineId, promise);
-    promise.finally(() => {
-      this.inflight.delete(routineId);
-    });
+    // The trailing `finally(...)` returns a new promise that mirrors the
+    // original rejection; without `.catch` it would surface as an
+    // unhandled rejection (fatal in modern Node) when the handler rejects
+    // before producing a start handle. The original `promise` is still
+    // returned to callers, who handle the rejection there.
+    promise
+      .finally(() => {
+        this.inflight.delete(routineId);
+      })
+      .catch(() => {});
     return promise;
   }
 }

--- a/apps/daemon/src/routines.ts
+++ b/apps/daemon/src/routines.ts
@@ -1,0 +1,460 @@
+// RoutineService — multi-routine scheduler. Generalizes the single-routine
+// pattern in OrbitService: a list of user-defined routines, each with its
+// own schedule, that fires the registered run handler. Schedule kinds
+// covered: hourly (every hour at minute M), daily (HH:MM in timezone),
+// weekdays (Mon-Fri at HH:MM in timezone), weekly (one weekday at HH:MM in
+// timezone). The run handler (wired by server.ts) is responsible for
+// project/conversation creation and dispatch into startChatRun.
+
+import { randomUUID } from 'node:crypto';
+
+// Local mirror of the @open-design/contracts routine types. Kept here so
+// this service typechecks under NodeNext (the contracts dist re-exports are
+// extension-less, which only works under bundler-mode resolution). The
+// shapes must stay aligned with packages/contracts/src/api/routines.ts.
+
+export type RoutineRunStatus =
+  | 'queued'
+  | 'running'
+  | 'succeeded'
+  | 'failed'
+  | 'canceled';
+
+export type RoutineRunTrigger = 'manual' | 'scheduled';
+
+export type Weekday = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+export type RoutineSchedule =
+  | { kind: 'hourly'; minute: number }
+  | { kind: 'daily'; time: string; timezone: string }
+  | { kind: 'weekdays'; time: string; timezone: string }
+  | { kind: 'weekly'; time: string; timezone: string; weekday: Weekday };
+
+export type RoutineProjectTarget =
+  | { mode: 'create_each_run' }
+  | { mode: 'reuse'; projectId: string };
+
+export interface Routine {
+  id: string;
+  name: string;
+  prompt: string;
+  schedule: RoutineSchedule;
+  target: RoutineProjectTarget;
+  skillId: string | null;
+  agentId: string | null;
+  enabled: boolean;
+  nextRunAt: number | null;
+  lastRun: unknown;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface RoutineRun {
+  id: string;
+  routineId: string;
+  trigger: RoutineRunTrigger;
+  status: RoutineRunStatus;
+  projectId: string;
+  conversationId: string;
+  agentRunId: string;
+  startedAt: number;
+  completedAt: number | null;
+  summary: string | null;
+  error: string | null;
+}
+
+export interface RoutineRunHandlerStart {
+  projectId: string;
+  conversationId: string;
+  agentRunId: string;
+  completion: Promise<RoutineRunCompletion>;
+}
+
+export interface RoutineRunCompletion {
+  status: RoutineRunStatus;
+  summary?: string;
+  error?: string;
+}
+
+export type RoutineRunHandler = (input: {
+  routine: Routine;
+  trigger: RoutineRunTrigger;
+  startedAt: number;
+  runId: string;
+}) => Promise<RoutineRunHandlerStart>;
+
+export interface RoutinePersistence {
+  list(): Routine[];
+  insertRun(run: RoutineRun): void;
+  updateRun(id: string, patch: Partial<RoutineRun>): void;
+  getLatestRun(routineId: string): RoutineRun | null;
+}
+
+interface ScheduledTimer {
+  routineId: string;
+  timer: NodeJS.Timeout;
+  fireAt: Date;
+}
+
+// ---------- timezone math ----------
+
+// Returns the wall-clock parts of `atUtc` rendered in `timezone`. Uses
+// Intl.DateTimeFormat which Node ships with full-icu by default. If the
+// timezone is invalid the formatter throws — we catch upstream.
+function partsInTimezone(timezone: string, atUtc: Date): {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+  weekday: Weekday;
+} {
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    weekday: 'short',
+  });
+  const parts = dtf.formatToParts(atUtc);
+  const get = (type: string) =>
+    parts.find((p) => p.type === type)?.value ?? '0';
+  const weekdayStr = get('weekday');
+  const weekdayMap: Record<string, Weekday> = {
+    Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6,
+  };
+  let h = Number(get('hour'));
+  // Intl emits "24" at midnight in some locales/zones; normalize to 0.
+  if (h === 24) h = 0;
+  return {
+    year: Number(get('year')),
+    month: Number(get('month')),
+    day: Number(get('day')),
+    hour: h,
+    minute: Number(get('minute')),
+    second: Number(get('second')),
+    weekday: weekdayMap[weekdayStr] ?? 0,
+  };
+}
+
+// Convert wall-clock (Y-M-D h:m in `timezone`) to a UTC Date. Uses a
+// two-pass approach: build a tentative UTC stamp from the wall fields,
+// figure out the offset Intl reports for that instant in `timezone`, then
+// adjust. Two passes are enough across DST transitions because the offset
+// only depends on the instant, and the second pass uses the corrected
+// instant. Returns null if `timezone` is invalid.
+function tzWallToUtc(
+  timezone: string,
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+): Date | null {
+  try {
+    const tentative = Date.UTC(year, month - 1, day, hour, minute, 0);
+    const t1 = tzOffsetMinutes(timezone, new Date(tentative));
+    const adjusted = tentative - t1 * 60_000;
+    const t2 = tzOffsetMinutes(timezone, new Date(adjusted));
+    return new Date(tentative - t2 * 60_000);
+  } catch {
+    return null;
+  }
+}
+
+// Minutes east of UTC for `timezone` at instant `at`. e.g. Asia/Shanghai
+// returns 480.
+function tzOffsetMinutes(timezone: string, at: Date): number {
+  const p = partsInTimezone(timezone, at);
+  const asIfUtc = Date.UTC(p.year, p.month - 1, p.day, p.hour, p.minute, p.second);
+  return Math.round((asIfUtc - at.getTime()) / 60_000);
+}
+
+// ---------- next-fire calculation ----------
+
+export function nextHourlyRunAt(minute: number, now = new Date()): Date {
+  const next = new Date(now);
+  next.setSeconds(0, 0);
+  next.setMinutes(minute);
+  if (next.getTime() <= now.getTime()) {
+    next.setHours(next.getHours() + 1);
+  }
+  return next;
+}
+
+// Returns the next instant at which the wall-clock in `timezone` reads
+// "HH:MM" on a day where `predicate(weekday)` holds. Walks forward at most
+// 14 calendar days as a safety bound (covers any weekday-based pattern).
+function nextWallTimeMatching(
+  timezone: string,
+  time: string,
+  predicate: (weekday: Weekday) => boolean,
+  now: Date,
+): Date | null {
+  const m = /^(\d{2}):(\d{2})$/.exec(time);
+  if (!m) return null;
+  const hour = Number(m[1]);
+  const minute = Number(m[2]);
+  if (!Number.isFinite(hour) || hour < 0 || hour > 23) return null;
+  if (!Number.isFinite(minute) || minute < 0 || minute > 59) return null;
+
+  // Walk day by day in the target timezone.
+  for (let offset = 0; offset < 14; offset += 1) {
+    const probe = new Date(now.getTime() + offset * 24 * 60 * 60_000);
+    const parts = partsInTimezone(timezone, probe);
+    if (!predicate(parts.weekday)) continue;
+    const candidate = tzWallToUtc(timezone, parts.year, parts.month, parts.day, hour, minute);
+    if (!candidate) return null;
+    if (candidate.getTime() > now.getTime()) return candidate;
+  }
+  return null;
+}
+
+export function nextRunAtForSchedule(
+  schedule: RoutineSchedule,
+  now = new Date(),
+): Date | null {
+  if (schedule.kind === 'hourly') {
+    return nextHourlyRunAt(schedule.minute, now);
+  }
+  if (schedule.kind === 'daily') {
+    return nextWallTimeMatching(schedule.timezone, schedule.time, () => true, now);
+  }
+  if (schedule.kind === 'weekdays') {
+    // Mon=1 .. Fri=5
+    return nextWallTimeMatching(
+      schedule.timezone,
+      schedule.time,
+      (w) => w >= 1 && w <= 5,
+      now,
+    );
+  }
+  if (schedule.kind === 'weekly') {
+    return nextWallTimeMatching(
+      schedule.timezone,
+      schedule.time,
+      (w) => w === schedule.weekday,
+      now,
+    );
+  }
+  return null;
+}
+
+// ---------- validation ----------
+
+export function isValidWallTime(time: string): boolean {
+  const m = /^(\d{2}):(\d{2})$/.exec(time);
+  if (!m) return false;
+  const h = Number(m[1]);
+  const mm = Number(m[2]);
+  return h >= 0 && h <= 23 && mm >= 0 && mm <= 59;
+}
+
+export function isValidTimezone(tz: string): boolean {
+  if (!tz || typeof tz !== 'string') return false;
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function validateSchedule(schedule: RoutineSchedule): void {
+  if (!schedule || typeof schedule !== 'object') {
+    throw new Error('schedule is required');
+  }
+  if (schedule.kind === 'hourly') {
+    const m = schedule.minute;
+    if (!Number.isInteger(m) || m < 0 || m > 59) {
+      throw new Error('hourly.minute must be an integer 0-59');
+    }
+    return;
+  }
+  if (
+    schedule.kind === 'daily' ||
+    schedule.kind === 'weekdays' ||
+    schedule.kind === 'weekly'
+  ) {
+    if (!isValidWallTime(schedule.time)) {
+      throw new Error(`Invalid time: ${schedule.time}`);
+    }
+    if (!isValidTimezone(schedule.timezone)) {
+      throw new Error(`Invalid timezone: ${schedule.timezone}`);
+    }
+    if (schedule.kind === 'weekly') {
+      const w = schedule.weekday;
+      if (!Number.isInteger(w) || w < 0 || w > 6) {
+        throw new Error('weekly.weekday must be 0-6');
+      }
+    }
+    return;
+  }
+  throw new Error(`Unsupported schedule kind: ${(schedule as { kind: string }).kind}`);
+}
+
+export function validateTarget(target: RoutineProjectTarget): void {
+  if (!target || typeof target !== 'object') {
+    throw new Error('target is required');
+  }
+  if (target.mode === 'create_each_run') return;
+  if (target.mode === 'reuse') {
+    if (!target.projectId || typeof target.projectId !== 'string') {
+      throw new Error('Reuse target requires a projectId');
+    }
+    return;
+  }
+  throw new Error(
+    `Unsupported routine target mode: ${(target as { mode: string }).mode}`,
+  );
+}
+
+// ---------- service ----------
+
+export class RoutineService {
+  private timers = new Map<string, ScheduledTimer>();
+  private inflight = new Map<string, Promise<RoutineRunHandlerStart>>();
+  private runHandler: RoutineRunHandler | null = null;
+  private started = false;
+
+  constructor(private readonly persistence: RoutinePersistence) {}
+
+  setRunHandler(handler: RoutineRunHandler): void {
+    this.runHandler = handler;
+  }
+
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+    this.rescheduleAll();
+  }
+
+  stop(): void {
+    for (const entry of this.timers.values()) clearTimeout(entry.timer);
+    this.timers.clear();
+    this.started = false;
+  }
+
+  rescheduleAll(): void {
+    for (const entry of this.timers.values()) clearTimeout(entry.timer);
+    this.timers.clear();
+    if (!this.started) return;
+    for (const routine of this.persistence.list()) {
+      this.scheduleRoutine(routine);
+    }
+  }
+
+  rescheduleOne(routineId: string): void {
+    const existing = this.timers.get(routineId);
+    if (existing) {
+      clearTimeout(existing.timer);
+      this.timers.delete(routineId);
+    }
+    if (!this.started) return;
+    const routine = this.persistence.list().find((r) => r.id === routineId);
+    if (routine) this.scheduleRoutine(routine);
+  }
+
+  unschedule(routineId: string): void {
+    const existing = this.timers.get(routineId);
+    if (existing) {
+      clearTimeout(existing.timer);
+      this.timers.delete(routineId);
+    }
+  }
+
+  private scheduleRoutine(routine: Routine): void {
+    if (!routine.enabled) return;
+    const fireAt = nextRunAtForSchedule(routine.schedule);
+    if (!fireAt) return;
+    // setTimeout can't carry past 2^31 ms (~24.8 days); we cap and use
+    // a chained re-schedule. Routines fire within hours/days, but a
+    // misconfigured "next month" weekly value could otherwise overflow.
+    const delay = Math.max(1_000, Math.min(2_000_000_000, fireAt.getTime() - Date.now()));
+    const timer = setTimeout(() => {
+      this.timers.delete(routine.id);
+      this.start_(routine.id, 'scheduled')
+        .catch((error) => {
+          console.error(
+            `[od] routine ${routine.id} scheduled run failed:`,
+            error instanceof Error ? error.message : error,
+          );
+        })
+        .finally(() => {
+          // Always reschedule so a single fire keeps the cadence alive.
+          this.rescheduleOne(routine.id);
+        });
+    }, delay);
+    if (typeof timer.unref === 'function') timer.unref();
+    this.timers.set(routine.id, { routineId: routine.id, timer, fireAt });
+  }
+
+  nextRunAt(routineId: string): Date | null {
+    return this.timers.get(routineId)?.fireAt ?? null;
+  }
+
+  async runNow(routineId: string): Promise<RoutineRunHandlerStart> {
+    return this.start_(routineId, 'manual');
+  }
+
+  private async start_(
+    routineId: string,
+    trigger: RoutineRunTrigger,
+  ): Promise<RoutineRunHandlerStart> {
+    if (!this.runHandler) throw new Error('Routine run handler is not configured');
+    const inflight = this.inflight.get(routineId);
+    if (inflight) return inflight;
+
+    const routine = this.persistence.list().find((r) => r.id === routineId);
+    if (!routine) throw new Error(`Routine ${routineId} not found`);
+
+    const startedAt = Date.now();
+    const runId = `routine-run-${randomUUID()}`;
+    const promise = (async () => {
+      const handler = this.runHandler;
+      if (!handler) throw new Error('Routine run handler is not configured');
+      const handlerStart = await handler({ routine, trigger, startedAt, runId });
+      this.persistence.insertRun({
+        id: runId,
+        routineId: routine.id,
+        trigger,
+        status: 'running',
+        projectId: handlerStart.projectId,
+        conversationId: handlerStart.conversationId,
+        agentRunId: handlerStart.agentRunId,
+        startedAt,
+        completedAt: null,
+        summary: null,
+        error: null,
+      });
+      handlerStart.completion
+        .then((completion) => {
+          this.persistence.updateRun(runId, {
+            status: completion.status,
+            completedAt: Date.now(),
+            summary: completion.summary ?? null,
+            error: completion.error ?? null,
+          });
+        })
+        .catch((error) => {
+          this.persistence.updateRun(runId, {
+            status: 'failed',
+            completedAt: Date.now(),
+            summary: null,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
+      return handlerStart;
+    })();
+    this.inflight.set(routineId, promise);
+    promise.finally(() => {
+      this.inflight.delete(routineId);
+    });
+    return promise;
+  }
+}

--- a/apps/daemon/src/routines.ts
+++ b/apps/daemon/src/routines.ts
@@ -142,12 +142,17 @@ function partsInTimezone(timezone: string, atUtc: Date): {
   };
 }
 
-// Convert wall-clock (Y-M-D h:m in `timezone`) to a UTC Date. Uses a
-// two-pass approach: build a tentative UTC stamp from the wall fields,
-// figure out the offset Intl reports for that instant in `timezone`, then
-// adjust. Two passes are enough across DST transitions because the offset
-// only depends on the instant, and the second pass uses the corrected
-// instant. Returns null if `timezone` is invalid.
+// Convert wall-clock (Y-M-D h:m in `timezone`) to a UTC Date. Builds two
+// candidate instants from the wall fields — one using the offset Intl
+// reports at the tentative wall-as-UTC stamp, one using the offset at the
+// first candidate. On non-transition days both converge; on a fall-back
+// transition the second pass picks the post-transition instance; on a
+// spring-forward gap neither candidate round-trips because the requested
+// wall time does not exist that day. In the gap case we return the later
+// candidate, which has crossed the transition and renders as the first
+// valid post-gap wall time, so a routine still fires today instead of
+// firing an hour early before the gap. Returns null if `timezone` is
+// invalid.
 function tzWallToUtc(
   timezone: string,
   year: number,
@@ -159,12 +164,38 @@ function tzWallToUtc(
   try {
     const tentative = Date.UTC(year, month - 1, day, hour, minute, 0);
     const t1 = tzOffsetMinutes(timezone, new Date(tentative));
-    const adjusted = tentative - t1 * 60_000;
-    const t2 = tzOffsetMinutes(timezone, new Date(adjusted));
-    return new Date(tentative - t2 * 60_000);
+    const candidate1 = new Date(tentative - t1 * 60_000);
+    const t2 = tzOffsetMinutes(timezone, candidate1);
+    const candidate2 = new Date(tentative - t2 * 60_000);
+    if (matchesWallClock(timezone, candidate2, year, month, day, hour, minute)) {
+      return candidate2;
+    }
+    if (matchesWallClock(timezone, candidate1, year, month, day, hour, minute)) {
+      return candidate1;
+    }
+    return candidate1.getTime() > candidate2.getTime() ? candidate1 : candidate2;
   } catch {
     return null;
   }
+}
+
+function matchesWallClock(
+  timezone: string,
+  at: Date,
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+): boolean {
+  const p = partsInTimezone(timezone, at);
+  return (
+    p.year === year &&
+    p.month === month &&
+    p.day === day &&
+    p.hour === hour &&
+    p.minute === minute
+  );
 }
 
 // Minutes east of UTC for `timezone` at instant `at`. e.g. Asia/Shanghai

--- a/apps/daemon/src/routines.ts
+++ b/apps/daemon/src/routines.ts
@@ -142,18 +142,53 @@ function partsInTimezone(timezone: string, atUtc: Date): {
   };
 }
 
-// Convert wall-clock (Y-M-D h:m in `timezone`) to a UTC Date. Builds two
-// candidate instants from the wall fields — one using the offset Intl
-// reports at the tentative wall-as-UTC stamp, one using the offset at the
-// first candidate. On non-transition days both converge; on a fall-back
-// transition the second pass picks the post-transition instance; on a
-// spring-forward gap neither candidate round-trips because the requested
-// wall time does not exist that day. In the gap case we return the later
-// candidate, which has crossed the transition and renders as the first
-// valid post-gap wall time, so a routine still fires today instead of
-// firing an hour early before the gap. Returns null if `timezone` is
-// invalid.
-function tzWallToUtc(
+// Returns every UTC instant at which the wall clock in `timezone` reads
+// the requested Y-M-D h:m, sorted ascending. Most days have exactly one
+// match. On a fall-back transition day the requested time inside the
+// repeated hour has two matches (one before the transition, one after);
+// outside that hour it still has one. On a spring-forward gap the
+// requested time inside the gap has zero matches — callers fall back to
+// `tzWallToUtcGapFallback` to land on a post-gap instant the same day.
+// Probes offsets at three reference points across the day so that both
+// pre- and post-transition offsets are sampled regardless of which side
+// of the transition `tentative` happens to land on. Returns [] if
+// `timezone` is invalid.
+function tzWallToUtcCandidates(
+  timezone: string,
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+): Date[] {
+  try {
+    const tentative = Date.UTC(year, month - 1, day, hour, minute, 0);
+    const probeOffsetsMs = [-12, 0, 12].map((h) => h * 60 * 60_000);
+    const seen = new Set<number>();
+    const out: Date[] = [];
+    for (const dms of probeOffsetsMs) {
+      const off = tzOffsetMinutes(timezone, new Date(tentative + dms));
+      const cand = new Date(tentative - off * 60_000);
+      const t = cand.getTime();
+      if (seen.has(t)) continue;
+      if (matchesWallClock(timezone, cand, year, month, day, hour, minute)) {
+        seen.add(t);
+        out.push(cand);
+      }
+    }
+    return out.sort((a, b) => a.getTime() - b.getTime());
+  } catch {
+    return [];
+  }
+}
+
+// Spring-forward gap fallback: when the requested wall time doesn't
+// exist in `timezone` on this day (clocks jumped over it), return the
+// later of the two probe candidates. That instant has crossed the
+// transition and renders as the first valid post-gap wall time, so a
+// routine still fires today instead of firing an hour early before the
+// gap. Returns null if `timezone` is invalid.
+function tzWallToUtcGapFallback(
   timezone: string,
   year: number,
   month: number,
@@ -167,12 +202,6 @@ function tzWallToUtc(
     const candidate1 = new Date(tentative - t1 * 60_000);
     const t2 = tzOffsetMinutes(timezone, candidate1);
     const candidate2 = new Date(tentative - t2 * 60_000);
-    if (matchesWallClock(timezone, candidate2, year, month, day, hour, minute)) {
-      return candidate2;
-    }
-    if (matchesWallClock(timezone, candidate1, year, month, day, hour, minute)) {
-      return candidate1;
-    }
     return candidate1.getTime() > candidate2.getTime() ? candidate1 : candidate2;
   } catch {
     return null;
@@ -239,9 +268,25 @@ function nextWallTimeMatching(
     const probe = new Date(now.getTime() + offset * 24 * 60 * 60_000);
     const parts = partsInTimezone(timezone, probe);
     if (!predicate(parts.weekday)) continue;
-    const candidate = tzWallToUtc(timezone, parts.year, parts.month, parts.day, hour, minute);
-    if (!candidate) return null;
-    if (candidate.getTime() > now.getTime()) return candidate;
+    const candidates = tzWallToUtcCandidates(
+      timezone, parts.year, parts.month, parts.day, hour, minute,
+    );
+    if (candidates.length === 0) {
+      // Spring-forward gap: no valid wall instant exists today; pick the
+      // synthesized post-gap fallback so the routine still fires today.
+      const fallback = tzWallToUtcGapFallback(
+        timezone, parts.year, parts.month, parts.day, hour, minute,
+      );
+      if (!fallback) return null;
+      if (fallback.getTime() > now.getTime()) return fallback;
+      continue;
+    }
+    // Iterate candidates in ascending order so that on a fall-back overlap
+    // day, when `now` already passed the first occurrence (EDT), we still
+    // pick the second one (EST) before walking to the next day.
+    for (const candidate of candidates) {
+      if (candidate.getTime() > now.getTime()) return candidate;
+    }
   }
   return null;
 }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -116,6 +116,11 @@ import {
 } from './mcp-tokens.js';
 import { agentCliEnvForAgent, readAppConfig, writeAppConfig } from './app-config.js';
 import { OrbitService, formatLocalProjectTimestamp, renderOrbitTemplateSystemPrompt } from './orbit.js';
+import {
+  RoutineService,
+  validateSchedule as validateRoutineSchedule,
+  validateTarget as validateRoutineTarget,
+} from './routines.js';
 import { buildMcpInstallPayload } from './mcp-install-info.js';
 import {
   buildProjectArchive,
@@ -148,6 +153,8 @@ import {
   getTemplate,
   insertConversation,
   insertProject,
+  insertRoutine,
+  insertRoutineRun,
   insertTemplate,
   listProjectsAwaitingInput,
   listConversations,
@@ -156,13 +163,20 @@ import {
   listMessages,
   listPreviewComments,
   listProjects,
+  listRoutines,
+  listRoutineRuns,
   listTabs,
   listTemplates,
+  getLatestRoutineRun,
+  getRoutine,
+  deleteRoutine as dbDeleteRoutine,
   openDatabase,
   setTabs,
   updateConversation,
   updatePreviewCommentStatus,
   updateProject,
+  updateRoutine,
+  updateRoutineRun,
   upsertDeployment,
   upsertMessage,
   upsertPreviewComment,
@@ -807,6 +821,7 @@ const ARTIFACTS_DIR = path.join(RUNTIME_DATA_DIR, 'artifacts');
 const PROJECTS_DIR = path.join(RUNTIME_DATA_DIR, 'projects');
 fs.mkdirSync(PROJECTS_DIR, { recursive: true });
 const orbitService = new OrbitService(RUNTIME_DATA_DIR);
+let routineService = null;
 
 // In-memory OAuth state cache. Lives for the daemon process's lifetime.
 // Maps the OAuth `state` parameter we generated in /api/mcp/oauth/start
@@ -1919,6 +1934,32 @@ export async function startServer({
   configureComposioConfigStore(RUNTIME_DATA_DIR);
   composioConnectorProvider.configureCatalogCache(RUNTIME_DATA_DIR);
   composioConnectorProvider.startCatalogRefreshLoop();
+
+  // RoutineService persistence is a thin adapter over the SQLite helpers.
+  // Routines are stored as DB rows; the service holds in-memory timers and
+  // delegates "list me everything" / "record a run" back to SQLite.
+  routineService = new RoutineService({
+    list: () => listRoutines(db).map((row) => routineDbRowToContract(row, null)),
+    insertRun: (run) => {
+      insertRoutineRun(db, {
+        id: run.id,
+        routineId: run.routineId,
+        trigger: run.trigger,
+        status: run.status,
+        projectId: run.projectId,
+        conversationId: run.conversationId,
+        agentRunId: run.agentRunId,
+        startedAt: run.startedAt,
+        completedAt: run.completedAt,
+        summary: run.summary,
+        error: run.error,
+      });
+    },
+    updateRun: (id, patch) => {
+      updateRoutineRun(db, id, patch);
+    },
+    getLatestRun: (routineId) => getLatestRoutineRun(db, routineId),
+  });
   let daemonUrl = `http://127.0.0.1:${port}`;
 
   // Boot reconcile: any critique_runs row left in 'running' state by a prior
@@ -1957,6 +1998,8 @@ export async function startServer({
       return detectAgents(config.agentCliEnv ?? {});
     })
     .catch(() => detectAgents().catch(() => {}));
+
+  routineService.start();
 
   await recoverStaleLiveArtifactRefreshes({ projectsRoot: PROJECTS_DIR }).catch((error) => {
     console.warn('[od] Failed to recover stale live artifact refreshes:', error);
@@ -4539,6 +4582,356 @@ export async function startServer({
     }
   });
 
+  // ---------- routines ----------
+
+  // Map a DB row to the Routine contract shape. Schedule lives in
+  // schedule_json (the canonical form); when missing (rows written before
+  // that column existed) we fall back to the legacy daily-only kind/value
+  // pair with UTC as a safe default timezone.
+  function routineDbRowToContract(row, latestRun) {
+    let schedule;
+    if (row.scheduleJson) {
+      try {
+        schedule = JSON.parse(row.scheduleJson);
+      } catch {
+        schedule = null;
+      }
+    }
+    if (!schedule) {
+      // Legacy fallback: daily HH:MM in UTC.
+      schedule = {
+        kind: row.scheduleKind || 'daily',
+        time: row.scheduleValue || '09:00',
+        timezone: 'UTC',
+      };
+    }
+    const target = row.projectMode === 'reuse' && row.projectId
+      ? { mode: 'reuse', projectId: row.projectId }
+      : { mode: 'create_each_run' };
+    let lastRun = null;
+    if (latestRun) {
+      lastRun = {
+        runId: latestRun.id,
+        status: latestRun.status,
+        trigger: latestRun.trigger,
+        startedAt: latestRun.startedAt,
+        ...(latestRun.completedAt == null ? {} : { completedAt: latestRun.completedAt }),
+        projectId: latestRun.projectId,
+        conversationId: latestRun.conversationId,
+        agentRunId: latestRun.agentRunId,
+        ...(latestRun.summary ? { summary: latestRun.summary } : {}),
+      };
+    }
+    return {
+      id: row.id,
+      name: row.name,
+      prompt: row.prompt,
+      schedule,
+      target,
+      skillId: row.skillId ?? null,
+      agentId: row.agentId ?? null,
+      enabled: row.enabled === true || row.enabled === 1,
+      nextRunAt: null,
+      lastRun,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    };
+  }
+
+  // Serialize a schedule into the kind/value/json triple stored in SQLite.
+  // schedule_value carries a kind-specific stringified scalar (minute for
+  // hourly, "HH:MM" for time-of-day kinds) so existing simple queries keep
+  // working; schedule_json is the authoritative form.
+  function scheduleToDbCols(schedule) {
+    const json = JSON.stringify(schedule);
+    let value = '';
+    if (schedule.kind === 'hourly') value = String(schedule.minute);
+    else if (schedule.kind === 'weekly') value = `${schedule.weekday}:${schedule.time}`;
+    else value = schedule.time;
+    return { scheduleKind: schedule.kind, scheduleValue: value, scheduleJson: json };
+  }
+
+  function routineFromDb(id) {
+    const row = getRoutine(db, id);
+    if (!row) return null;
+    const latest = getLatestRoutineRun(db, id);
+    const contract = routineDbRowToContract(row, latest);
+    const nextDate = routineService?.nextRunAt(id) ?? null;
+    contract.nextRunAt = nextDate ? nextDate.getTime() : null;
+    return contract;
+  }
+
+  function validateRoutineInput(body, partial) {
+    if (!body || typeof body !== 'object') {
+      throw new Error('Request body must be an object');
+    }
+    if (!partial || body.name !== undefined) {
+      if (typeof body.name !== 'string' || !body.name.trim()) {
+        throw new Error('name is required');
+      }
+    }
+    if (!partial || body.prompt !== undefined) {
+      if (typeof body.prompt !== 'string' || !body.prompt.trim()) {
+        throw new Error('prompt is required');
+      }
+    }
+    if (!partial || body.schedule !== undefined) {
+      validateRoutineSchedule(body.schedule);
+    }
+    if (!partial || body.target !== undefined) {
+      validateRoutineTarget(body.target);
+      if (body.target.mode === 'reuse') {
+        const proj = getProject(db, body.target.projectId);
+        if (!proj) throw new Error(`target project ${body.target.projectId} not found`);
+      }
+    }
+  }
+
+  // Each routine fire: resolve agent, mint (or reuse) project + a fresh
+  // conversation, prime the user/assistant message pair, and dispatch into
+  // startChatRun. Returns the in-flight handles so the service can persist
+  // the routine_run row and observe completion.
+  routineService.setRunHandler(async ({ routine, trigger, startedAt, runId }) => {
+    const appConfig = await readAppConfig(RUNTIME_DATA_DIR);
+    let agentId = routine.agentId
+      || (typeof appConfig.agentId === 'string' && appConfig.agentId ? appConfig.agentId : null);
+    if (!agentId) {
+      const agents = await detectAgents(appConfig.agentCliEnv ?? {}).catch(() => []);
+      agentId = agents.find((agent) => agent.available)?.id ?? null;
+    }
+    if (!agentId) {
+      throw new Error('No available agent is configured. Choose an agent in Settings first.');
+    }
+
+    const now = startedAt;
+    const stamp = formatLocalProjectTimestamp(new Date(now).toISOString());
+
+    let projectId;
+    let projectName;
+    if (routine.target.mode === 'reuse') {
+      const proj = getProject(db, routine.target.projectId);
+      if (!proj) throw new Error(`Routine target project ${routine.target.projectId} not found`);
+      projectId = proj.id;
+      projectName = proj.name;
+    } else {
+      projectId = `routine-${randomUUID()}`;
+      projectName = `${routine.name} · ${stamp}`;
+      insertProject(db, {
+        id: projectId,
+        name: projectName,
+        skillId: routine.skillId ?? null,
+        designSystemId: appConfig.designSystemId ?? null,
+        pendingPrompt: null,
+        metadata: { kind: 'other', intent: 'routine', routineId: routine.id, trigger },
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+
+    const conversationId = `routine-conv-${randomUUID()}`;
+    const conversationTitle = routine.target.mode === 'reuse'
+      ? `${routine.name} · ${stamp}`
+      : projectName;
+    insertConversation(db, {
+      id: conversationId,
+      projectId,
+      title: conversationTitle,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const assistantMessageId = `routine-assistant-${randomUUID()}`;
+    const run = design.runs.create({
+      projectId,
+      conversationId,
+      assistantMessageId,
+      clientRequestId: `routine-${trigger}-${randomUUID()}`,
+      agentId,
+    });
+    upsertMessage(db, conversationId, {
+      id: `routine-user-${run.id}`,
+      role: 'user',
+      content: routine.prompt,
+    });
+    upsertMessage(db, conversationId, {
+      id: assistantMessageId,
+      role: 'assistant',
+      content: '',
+      agentId,
+      agentName: getAgentDef(agentId)?.name ?? agentId,
+      runId: run.id,
+      runStatus: 'queued',
+      startedAt: now,
+    });
+
+    const modelPrefs = appConfig.agentModels?.[agentId] ?? {};
+    design.runs.start(run, () => startChatRun({
+      agentId,
+      projectId,
+      conversationId: run.conversationId,
+      assistantMessageId: run.assistantMessageId,
+      clientRequestId: run.clientRequestId,
+      skillId: routine.skillId ?? null,
+      designSystemId: appConfig.designSystemId ?? null,
+      model: modelPrefs.model ?? null,
+      reasoning: modelPrefs.reasoning ?? null,
+      message: routine.prompt,
+      systemPrompt: [
+        `You are running an unattended scheduled routine named "${routine.name}".`,
+        'Do not ask follow-up questions, do not emit <question-form>, and do not wait for user input. Pick reasonable defaults and finish the task.',
+      ].join('\n'),
+    }, run));
+
+    const completion = (async () => {
+      const finalStatus = await design.runs.wait(run);
+      db.prepare(`UPDATE messages SET run_status = ?, ended_at = ? WHERE id = ?`)
+        .run(finalStatus.status, Date.now(), assistantMessageId);
+      return {
+        status: finalStatus.status,
+        summary: `Routine "${routine.name}" ${finalStatus.status}.`,
+      };
+    })();
+
+    return { projectId, conversationId, agentRunId: run.id, completion };
+  });
+
+  app.get('/api/routines', (req, res) => {
+    if (!isLocalSameOrigin(req, resolvedPort)) {
+      return res.status(403).json({ error: 'cross-origin request rejected' });
+    }
+    try {
+      const rows = listRoutines(db);
+      const routines = rows.map((row) => {
+        const latest = getLatestRoutineRun(db, row.id);
+        const contract = routineDbRowToContract(row, latest);
+        const nextDate = routineService?.nextRunAt(row.id) ?? null;
+        contract.nextRunAt = nextDate ? nextDate.getTime() : null;
+        return contract;
+      });
+      res.json({ routines });
+    } catch (err) {
+      res.status(500).json({ error: String(err?.message ?? err) });
+    }
+  });
+
+  app.post('/api/routines', (req, res) => {
+    if (!isLocalSameOrigin(req, resolvedPort)) {
+      return res.status(403).json({ error: 'cross-origin request rejected' });
+    }
+    try {
+      const body = req.body || {};
+      validateRoutineInput(body, false);
+      const id = `routine-${randomUUID()}`;
+      const now = Date.now();
+      const scheduleCols = scheduleToDbCols(body.schedule);
+      insertRoutine(db, {
+        id,
+        name: body.name.trim(),
+        prompt: body.prompt,
+        ...scheduleCols,
+        projectMode: body.target.mode,
+        projectId: body.target.mode === 'reuse' ? body.target.projectId : null,
+        skillId: body.skillId ?? null,
+        agentId: body.agentId ?? null,
+        enabled: body.enabled !== false,
+        createdAt: now,
+        updatedAt: now,
+      });
+      routineService?.rescheduleOne(id);
+      const routine = routineFromDb(id);
+      res.status(201).json({ routine });
+    } catch (err) {
+      res.status(400).json({ error: String(err?.message ?? err) });
+    }
+  });
+
+  app.get('/api/routines/:id', (req, res) => {
+    if (!isLocalSameOrigin(req, resolvedPort)) {
+      return res.status(403).json({ error: 'cross-origin request rejected' });
+    }
+    const routine = routineFromDb(req.params.id);
+    if (!routine) return res.status(404).json({ error: 'routine not found' });
+    res.json({ routine });
+  });
+
+  app.patch('/api/routines/:id', (req, res) => {
+    if (!isLocalSameOrigin(req, resolvedPort)) {
+      return res.status(403).json({ error: 'cross-origin request rejected' });
+    }
+    try {
+      const existing = getRoutine(db, req.params.id);
+      if (!existing) return res.status(404).json({ error: 'routine not found' });
+      const body = req.body || {};
+      validateRoutineInput(body, true);
+      const patch = {};
+      if (body.name !== undefined) patch.name = body.name.trim();
+      if (body.prompt !== undefined) patch.prompt = body.prompt;
+      if (body.schedule !== undefined) {
+        const cols = scheduleToDbCols(body.schedule);
+        patch.scheduleKind = cols.scheduleKind;
+        patch.scheduleValue = cols.scheduleValue;
+        patch.scheduleJson = cols.scheduleJson;
+      }
+      if (body.target !== undefined) {
+        patch.projectMode = body.target.mode;
+        patch.projectId = body.target.mode === 'reuse' ? body.target.projectId : null;
+      }
+      if (body.skillId !== undefined) patch.skillId = body.skillId ?? null;
+      if (body.agentId !== undefined) patch.agentId = body.agentId ?? null;
+      if (body.enabled !== undefined) patch.enabled = Boolean(body.enabled);
+      updateRoutine(db, req.params.id, patch);
+      routineService?.rescheduleOne(req.params.id);
+      const routine = routineFromDb(req.params.id);
+      res.json({ routine });
+    } catch (err) {
+      res.status(400).json({ error: String(err?.message ?? err) });
+    }
+  });
+
+  app.delete('/api/routines/:id', (req, res) => {
+    if (!isLocalSameOrigin(req, resolvedPort)) {
+      return res.status(403).json({ error: 'cross-origin request rejected' });
+    }
+    routineService?.unschedule(req.params.id);
+    const removed = dbDeleteRoutine(db, req.params.id);
+    if (!removed) return res.status(404).json({ error: 'routine not found' });
+    res.status(204).end();
+  });
+
+  app.post('/api/routines/:id/run', async (req, res) => {
+    if (!isLocalSameOrigin(req, resolvedPort)) {
+      return res.status(403).json({ error: 'cross-origin request rejected' });
+    }
+    try {
+      if (!routineService) throw new Error('routine service unavailable');
+      const existing = getRoutine(db, req.params.id);
+      if (!existing) return res.status(404).json({ error: 'routine not found' });
+      const start = await routineService.runNow(req.params.id);
+      const latest = getLatestRoutineRun(db, req.params.id);
+      const routine = routineFromDb(req.params.id);
+      res.status(202).json({
+        routine,
+        run: latest,
+        projectId: start.projectId,
+        conversationId: start.conversationId,
+        agentRunId: start.agentRunId,
+      });
+    } catch (err) {
+      res.status(500).json({ error: String(err?.message ?? err) });
+    }
+  });
+
+  app.get('/api/routines/:id/runs', (req, res) => {
+    if (!isLocalSameOrigin(req, resolvedPort)) {
+      return res.status(403).json({ error: 'cross-origin request rejected' });
+    }
+    const existing = getRoutine(db, req.params.id);
+    if (!existing) return res.status(404).json({ error: 'routine not found' });
+    const limit = Math.min(100, Math.max(1, Number(req.query.limit) || 20));
+    const runs = listRoutineRuns(db, req.params.id, limit);
+    res.json({ runs });
+  });
+
   // Native OS folder picker dialog. Returns { path: string | null }.
   app.post('/api/dialog/open-folder', async (req, res) => {
     if (!isLocalSameOrigin(req, resolvedPort)) {
@@ -6980,6 +7373,7 @@ export async function startServer({
     const cleanupDaemonBackgroundWork = () => {
       composioConnectorProvider.stopCatalogRefreshLoop();
       orbitService.stop();
+      routineService?.stop();
     };
     const shutdownDaemonRuns = async () => {
       if (daemonShutdownStarted) return;

--- a/apps/daemon/tests/routines.test.ts
+++ b/apps/daemon/tests/routines.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import { nextRunAtForSchedule } from '../src/routines.js';
+
+function partsIn(timezone: string, at: Date): Record<string, string> {
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+  const out: Record<string, string> = {};
+  for (const part of dtf.formatToParts(at)) {
+    if (part.type !== 'literal') out[part.type] = part.value;
+  }
+  if (out.hour === '24') out.hour = '00';
+  return out;
+}
+
+describe('nextRunAtForSchedule DST handling', () => {
+  it('does not fire before the requested wall time on a spring-forward gap day', () => {
+    // 2026-03-08 in America/New_York: clocks jump 02:00 EST → 03:00 EDT, so
+    // a daily routine scheduled at 02:30 has no valid wall clock that day.
+    // Prior to the fix, tzWallToUtc returned 06:30Z which renders back as
+    // 01:30 EST — an hour before the requested time. The fixed scheduler
+    // must instead advance to a valid post-gap instant on the same day.
+    const now = new Date('2026-03-08T05:00:00Z');
+    const next = nextRunAtForSchedule(
+      { kind: 'daily', time: '02:30', timezone: 'America/New_York' },
+      now,
+    );
+    expect(next).not.toBeNull();
+    if (!next) return;
+
+    const parts = partsIn('America/New_York', next);
+    expect(parts.year).toBe('2026');
+    expect(parts.month).toBe('03');
+    expect(parts.day).toBe('08');
+
+    const wallMinutes = Number(parts.hour) * 60 + Number(parts.minute);
+    expect(wallMinutes).toBeGreaterThanOrEqual(2 * 60 + 30);
+  });
+
+  it('selects the post-fall-back instance on a fall-back day with ambiguous wall times', () => {
+    // 2026-11-01 in America/New_York: 01:30 happens twice (EDT and EST).
+    // For a daily routine at 02:30, the only valid instance is 02:30 EST,
+    // which renders to 07:30Z. Make sure we pick that one regardless of
+    // candidate ordering inside tzWallToUtc.
+    const now = new Date('2026-11-01T05:00:00Z');
+    const next = nextRunAtForSchedule(
+      { kind: 'daily', time: '02:30', timezone: 'America/New_York' },
+      now,
+    );
+    expect(next).not.toBeNull();
+    if (!next) return;
+
+    const parts = partsIn('America/New_York', next);
+    expect(parts.year).toBe('2026');
+    expect(parts.month).toBe('11');
+    expect(parts.day).toBe('01');
+    expect(parts.hour).toBe('02');
+    expect(parts.minute).toBe('30');
+  });
+
+  it('returns the requested wall time on non-transition days', () => {
+    const now = new Date('2026-05-01T00:00:00Z');
+    const next = nextRunAtForSchedule(
+      { kind: 'daily', time: '02:30', timezone: 'America/New_York' },
+      now,
+    );
+    expect(next).not.toBeNull();
+    if (!next) return;
+
+    const parts = partsIn('America/New_York', next);
+    expect(parts.hour).toBe('02');
+    expect(parts.minute).toBe('30');
+  });
+});

--- a/apps/daemon/tests/routines.test.ts
+++ b/apps/daemon/tests/routines.test.ts
@@ -44,6 +44,42 @@ describe('nextRunAtForSchedule DST handling', () => {
     expect(wallMinutes).toBeGreaterThanOrEqual(2 * 60 + 30);
   });
 
+  it('still fires the second occurrence when the wall time itself is in the repeated hour', () => {
+    // 2026-11-01 in America/New_York: 01:30 happens twice — first at
+    // 05:30Z (EDT) and again at 06:30Z (EST) after clocks fall back.
+    // If the daemon checks at 05:45Z (between the two occurrences),
+    // a daily routine at 01:30 must still fire today at 06:30Z, not
+    // skip to 2026-11-02 because the EDT instance is already past.
+    const now = new Date('2026-11-01T05:45:00Z');
+    const next = nextRunAtForSchedule(
+      { kind: 'daily', time: '01:30', timezone: 'America/New_York' },
+      now,
+    );
+    expect(next).not.toBeNull();
+    if (!next) return;
+
+    expect(next.getTime()).toBe(Date.UTC(2026, 10, 1, 6, 30));
+    const parts = partsIn('America/New_York', next);
+    expect(parts.year).toBe('2026');
+    expect(parts.month).toBe('11');
+    expect(parts.day).toBe('01');
+    expect(parts.hour).toBe('01');
+    expect(parts.minute).toBe('30');
+  });
+
+  it('returns the first occurrence in the repeated hour when now is before either instance', () => {
+    // Before 05:30Z on the fall-back day, the next 01:30 NY is the
+    // first (EDT) occurrence at 05:30Z.
+    const now = new Date('2026-11-01T05:00:00Z');
+    const next = nextRunAtForSchedule(
+      { kind: 'daily', time: '01:30', timezone: 'America/New_York' },
+      now,
+    );
+    expect(next).not.toBeNull();
+    if (!next) return;
+    expect(next.getTime()).toBe(Date.UTC(2026, 10, 1, 5, 30));
+  });
+
   it('selects the post-fall-back instance on a fall-back day with ambiguous wall times', () => {
     // 2026-11-01 in America/New_York: 01:30 happens twice (EDT and EST).
     // For a daily routine at 02:30, the only valid instance is 02:30 EST,

--- a/apps/web/src/components/RoutinesSection.tsx
+++ b/apps/web/src/components/RoutinesSection.tsx
@@ -64,13 +64,19 @@ function detectLocalTimezone(): string {
 // Returns every IANA zone the platform recognizes, so the picker stays in
 // sync with the backend validator (which accepts any IANA timezone). Falls
 // back to a curated subset on older runtimes that lack `supportedValuesOf`.
+// `UTC` is always prepended because `Intl.supportedValuesOf('timeZone')`
+// returns only canonical region names on current runtimes (e.g. Node 24)
+// and would otherwise drop the most common non-local zone — which the
+// backend validator and contract examples still accept.
 function listSupportedTimezones(): string[] {
   try {
     const fn = (Intl as { supportedValuesOf?: (key: string) => string[] })
       .supportedValuesOf;
     if (typeof fn === 'function') {
       const list = fn('timeZone');
-      if (Array.isArray(list) && list.length > 0) return list;
+      if (Array.isArray(list) && list.length > 0) {
+        return list.includes('UTC') ? list : ['UTC', ...list];
+      }
     }
   } catch {
     // fall through

--- a/apps/web/src/components/RoutinesSection.tsx
+++ b/apps/web/src/components/RoutinesSection.tsx
@@ -33,9 +33,10 @@ const WEEKDAY_LABELS: { value: Weekday; short: string; long: string }[] = [
   { value: 6, short: 'Sat', long: 'Saturday' },
 ];
 
-// Curated common timezones. The browser's local zone is prepended at runtime
-// so the very first option always reflects "where the user actually is".
-const COMMON_TIMEZONES = [
+// Fallback list used only when the runtime doesn't expose
+// `Intl.supportedValuesOf('timeZone')`. The backend validator accepts any
+// IANA zone, so the picker should match — see `listSupportedTimezones`.
+const FALLBACK_TIMEZONES = [
   'UTC',
   'Asia/Shanghai',
   'Asia/Tokyo',
@@ -60,6 +61,23 @@ function detectLocalTimezone(): string {
   }
 }
 
+// Returns every IANA zone the platform recognizes, so the picker stays in
+// sync with the backend validator (which accepts any IANA timezone). Falls
+// back to a curated subset on older runtimes that lack `supportedValuesOf`.
+function listSupportedTimezones(): string[] {
+  try {
+    const fn = (Intl as { supportedValuesOf?: (key: string) => string[] })
+      .supportedValuesOf;
+    if (typeof fn === 'function') {
+      const list = fn('timeZone');
+      if (Array.isArray(list) && list.length > 0) return list;
+    }
+  } catch {
+    // fall through
+  }
+  return FALLBACK_TIMEZONES;
+}
+
 // "GMT+8", "GMT-5:30", "GMT" — short label that mirrors the screenshot's
 // "Shanghai (GMT+8)" pattern for legibility.
 function gmtLabel(timezone: string, at = new Date()): string {
@@ -82,7 +100,11 @@ function tzCityLabel(timezone: string): string {
 }
 
 function tzOptionLabel(timezone: string): string {
-  return `${tzCityLabel(timezone)} (${gmtLabel(timezone)})`;
+  // The GMT offset is intentionally omitted: it would drift seasonally for
+  // DST-observing zones (e.g. `America/New_York` is GMT-5 in winter and
+  // GMT-4 in summer) and a picker label that depends on `new Date()` is
+  // misleading. The IANA city stays stable year-round.
+  return tzCityLabel(timezone);
 }
 
 function formatTime12h(time: string): string {
@@ -95,12 +117,22 @@ function formatTime12h(time: string): string {
   return `${h12}:${mm} ${suffix}`;
 }
 
-function describeSchedule(schedule: RoutineSchedule): string {
+function describeSchedule(
+  schedule: RoutineSchedule,
+  nextRunAt?: number | null,
+): string {
   if (schedule.kind === 'hourly') {
     const mm = String(schedule.minute).padStart(2, '0');
     return `Runs every hour at :${mm}`;
   }
-  const tz = gmtLabel(schedule.timezone);
+  // Anchor the GMT offset to the next actual fire time so DST-observing
+  // zones don't drift seasonally — a New York routine created in winter
+  // would otherwise still render `GMT-5` after DST starts. When we don't
+  // know the next fire (e.g. the live preview while the form is open),
+  // fall back to the IANA city, which is stable year-round.
+  const tz = nextRunAt
+    ? gmtLabel(schedule.timezone, new Date(nextRunAt))
+    : tzCityLabel(schedule.timezone);
   if (schedule.kind === 'daily') {
     return `Runs daily at ${formatTime12h(schedule.time)} ${tz}`;
   }
@@ -335,7 +367,9 @@ export function RoutinesSection() {
 
   const timezones = useMemo(() => {
     const local = detectLocalTimezone();
-    const set = new Set<string>([local, ...COMMON_TIMEZONES]);
+    // Pin the user's local zone first, then expose every IANA zone the
+    // backend would accept so the picker matches the validator.
+    const set = new Set<string>([local, ...listSupportedTimezones()]);
     return Array.from(set);
   }, []);
 
@@ -613,7 +647,7 @@ export function RoutinesSection() {
                         <span className="routines-tag">paused</span>
                       ) : null}
                     </div>
-                    <div className="routines-item-line">{describeSchedule(r.schedule)}</div>
+                    <div className="routines-item-line">{describeSchedule(r.schedule, r.nextRunAt)}</div>
                     <div className="routines-item-meta">
                       <span>{targetLabel}</span>
                       <span aria-hidden>·</span>

--- a/apps/web/src/components/RoutinesSection.tsx
+++ b/apps/web/src/components/RoutinesSection.tsx
@@ -1,0 +1,680 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { FormEvent } from 'react';
+import type {
+  CreateRoutineRequest,
+  Routine,
+  RoutineProjectTarget,
+  RoutineRun,
+  RoutineSchedule,
+  Weekday,
+} from '@open-design/contracts';
+
+import { Icon } from './Icon';
+import { navigate } from '../router';
+
+type ProjectSummary = { id: string; name: string };
+
+type ScheduleKind = RoutineSchedule['kind'];
+
+const SCHEDULE_KINDS: { kind: ScheduleKind; label: string }[] = [
+  { kind: 'hourly', label: 'Hourly' },
+  { kind: 'daily', label: 'Daily' },
+  { kind: 'weekdays', label: 'Weekdays' },
+  { kind: 'weekly', label: 'Weekly' },
+];
+
+const WEEKDAY_LABELS: { value: Weekday; short: string; long: string }[] = [
+  { value: 0, short: 'Sun', long: 'Sunday' },
+  { value: 1, short: 'Mon', long: 'Monday' },
+  { value: 2, short: 'Tue', long: 'Tuesday' },
+  { value: 3, short: 'Wed', long: 'Wednesday' },
+  { value: 4, short: 'Thu', long: 'Thursday' },
+  { value: 5, short: 'Fri', long: 'Friday' },
+  { value: 6, short: 'Sat', long: 'Saturday' },
+];
+
+// Curated common timezones. The browser's local zone is prepended at runtime
+// so the very first option always reflects "where the user actually is".
+const COMMON_TIMEZONES = [
+  'UTC',
+  'Asia/Shanghai',
+  'Asia/Tokyo',
+  'Asia/Singapore',
+  'Asia/Kolkata',
+  'Europe/London',
+  'Europe/Berlin',
+  'Europe/Paris',
+  'America/New_York',
+  'America/Chicago',
+  'America/Denver',
+  'America/Los_Angeles',
+  'America/Sao_Paulo',
+  'Australia/Sydney',
+];
+
+function detectLocalTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+  } catch {
+    return 'UTC';
+  }
+}
+
+// "GMT+8", "GMT-5:30", "GMT" — short label that mirrors the screenshot's
+// "Shanghai (GMT+8)" pattern for legibility.
+function gmtLabel(timezone: string, at = new Date()): string {
+  try {
+    const dtf = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      timeZoneName: 'shortOffset',
+    });
+    const part = dtf.formatToParts(at).find((p) => p.type === 'timeZoneName');
+    return part?.value ?? 'GMT';
+  } catch {
+    return 'GMT';
+  }
+}
+
+function tzCityLabel(timezone: string): string {
+  if (timezone === 'UTC') return 'UTC';
+  const last = timezone.split('/').pop() ?? timezone;
+  return last.replace(/_/g, ' ');
+}
+
+function tzOptionLabel(timezone: string): string {
+  return `${tzCityLabel(timezone)} (${gmtLabel(timezone)})`;
+}
+
+function formatTime12h(time: string): string {
+  const m = /^(\d{2}):(\d{2})$/.exec(time);
+  if (!m) return time;
+  const h = Number(m[1]);
+  const mm = m[2];
+  const suffix = h >= 12 ? 'PM' : 'AM';
+  const h12 = h === 0 ? 12 : h > 12 ? h - 12 : h;
+  return `${h12}:${mm} ${suffix}`;
+}
+
+function describeSchedule(schedule: RoutineSchedule): string {
+  if (schedule.kind === 'hourly') {
+    const mm = String(schedule.minute).padStart(2, '0');
+    return `Runs every hour at :${mm}`;
+  }
+  const tz = gmtLabel(schedule.timezone);
+  if (schedule.kind === 'daily') {
+    return `Runs daily at ${formatTime12h(schedule.time)} ${tz}`;
+  }
+  if (schedule.kind === 'weekdays') {
+    return `Runs Mon–Fri at ${formatTime12h(schedule.time)} ${tz}`;
+  }
+  const day =
+    WEEKDAY_LABELS.find((w) => w.value === schedule.weekday)?.long ?? 'Sunday';
+  return `Runs every ${day} at ${formatTime12h(schedule.time)} ${tz}`;
+}
+
+function formatRelative(ts: number | null | undefined): string {
+  if (!ts) return '—';
+  const d = new Date(ts);
+  return d.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+}
+
+function formatRunTimestamp(ts: number): string {
+  return new Date(ts).toLocaleString(undefined, {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  });
+}
+
+type FormState = {
+  name: string;
+  prompt: string;
+  kind: ScheduleKind;
+  minute: number; // hourly
+  time: string; // daily/weekdays/weekly (HH:MM)
+  weekday: Weekday; // weekly
+  timezone: string;
+  mode: 'create_each_run' | 'reuse';
+  projectId: string;
+};
+
+function emptyForm(): FormState {
+  return {
+    name: '',
+    prompt: '',
+    kind: 'daily',
+    minute: 0,
+    time: '09:00',
+    weekday: 1,
+    timezone: detectLocalTimezone(),
+    mode: 'create_each_run',
+    projectId: '',
+  };
+}
+
+function buildSchedule(form: FormState): RoutineSchedule {
+  if (form.kind === 'hourly') {
+    return { kind: 'hourly', minute: form.minute };
+  }
+  if (form.kind === 'weekly') {
+    return {
+      kind: 'weekly',
+      weekday: form.weekday,
+      time: form.time,
+      timezone: form.timezone,
+    };
+  }
+  return {
+    kind: form.kind,
+    time: form.time,
+    timezone: form.timezone,
+  };
+}
+
+function StatusPill({ status }: { status: RoutineRun['status'] }) {
+  return <span className={`routines-status routines-status-${status}`}>{status}</span>;
+}
+
+function ScheduleEditor({
+  form,
+  setForm,
+  timezones,
+}: {
+  form: FormState;
+  setForm: (next: FormState) => void;
+  timezones: string[];
+}) {
+  return (
+    <div className="routines-schedule-editor">
+      <div className="routines-field-label">Schedule</div>
+      <div className="subtab-pill routines-kind-pills" role="tablist">
+        {SCHEDULE_KINDS.map((k) => (
+          <button
+            type="button"
+            key={k.kind}
+            role="tab"
+            aria-selected={form.kind === k.kind}
+            className={form.kind === k.kind ? 'active' : ''}
+            onClick={() => setForm({ ...form, kind: k.kind })}
+          >
+            {k.label}
+          </button>
+        ))}
+      </div>
+
+      {form.kind === 'hourly' ? (
+        <div className="routines-fieldrow">
+          <label className="routines-field">
+            <span>Minute of every hour</span>
+            <input
+              type="number"
+              min={0}
+              max={59}
+              step={1}
+              value={form.minute}
+              onChange={(e) =>
+                setForm({
+                  ...form,
+                  minute: Math.max(0, Math.min(59, Number(e.target.value) || 0)),
+                })
+              }
+            />
+          </label>
+        </div>
+      ) : null}
+
+      {form.kind === 'weekly' ? (
+        <div className="routines-weekday-row">
+          {WEEKDAY_LABELS.map((d) => (
+            <button
+              type="button"
+              key={d.value}
+              className={`routines-weekday${form.weekday === d.value ? ' active' : ''}`}
+              onClick={() => setForm({ ...form, weekday: d.value })}
+              aria-pressed={form.weekday === d.value}
+            >
+              {d.short}
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      {form.kind !== 'hourly' ? (
+        <div className="routines-fieldrow routines-fieldrow-2col">
+          <label className="routines-field">
+            <span>Time</span>
+            <input
+              type="time"
+              value={form.time}
+              onChange={(e) => setForm({ ...form, time: e.target.value })}
+            />
+          </label>
+          <label className="routines-field">
+            <span>Timezone</span>
+            <select
+              value={form.timezone}
+              onChange={(e) => setForm({ ...form, timezone: e.target.value })}
+            >
+              {timezones.map((tz) => (
+                <option key={tz} value={tz}>
+                  {tzOptionLabel(tz)}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      ) : null}
+
+      <p className="routines-schedule-hint">
+        {describeSchedule(buildSchedule(form))}
+      </p>
+    </div>
+  );
+}
+
+function RunHistory({ routineId, refreshKey }: { routineId: string; refreshKey: number }) {
+  const [runs, setRuns] = useState<RoutineRun[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch(`/api/routines/${routineId}/runs?limit=10`);
+        if (!res.ok) throw new Error(`runs: ${res.status}`);
+        const json = await res.json();
+        if (!cancelled) setRuns(json.runs ?? []);
+      } catch {
+        if (!cancelled) setRuns([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [routineId, refreshKey]);
+
+  if (runs === null) return <div className="routines-history-empty">Loading runs…</div>;
+  if (runs.length === 0)
+    return <div className="routines-history-empty">No runs yet.</div>;
+
+  return (
+    <ul className="routines-history">
+      {runs.map((r) => (
+        <li key={r.id} className="routines-history-row">
+          <StatusPill status={r.status} />
+          <span className="routines-history-time">{formatRunTimestamp(r.startedAt)}</span>
+          <span className="routines-history-trigger">
+            {r.trigger === 'manual' ? 'manual' : 'scheduled'}
+          </span>
+          <button
+            type="button"
+            className="routines-history-link"
+            onClick={() =>
+              navigate({ kind: 'project', projectId: r.projectId, fileName: null })
+            }
+            title="Open the project this run wrote to"
+          >
+            Open project
+            <Icon name="chevron-right" size={12} />
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function RoutinesSection() {
+  const [routines, setRoutines] = useState<Routine[]>([]);
+  const [projects, setProjects] = useState<ProjectSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showForm, setShowForm] = useState(false);
+  const [form, setForm] = useState<FormState>(emptyForm);
+  const [submitting, setSubmitting] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [historyTick, setHistoryTick] = useState(0);
+
+  const timezones = useMemo(() => {
+    const local = detectLocalTimezone();
+    const set = new Set<string>([local, ...COMMON_TIMEZONES]);
+    return Array.from(set);
+  }, []);
+
+  const refresh = async () => {
+    try {
+      const [rRes, pRes] = await Promise.all([
+        fetch('/api/routines'),
+        fetch('/api/projects'),
+      ]);
+      if (!rRes.ok) throw new Error(`routines: ${rRes.status}`);
+      const rJson = await rRes.json();
+      setRoutines(rJson.routines ?? []);
+      if (pRes.ok) {
+        const pJson = await pRes.json();
+        setProjects(
+          (pJson.projects ?? []).map((p: ProjectSummary) => ({
+            id: p.id,
+            name: p.name,
+          })),
+        );
+      }
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void refresh();
+  }, []);
+
+  const projectsById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const p of projects) map.set(p.id, p.name);
+    return map;
+  }, [projects]);
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      if (form.mode === 'reuse' && !form.projectId) {
+        throw new Error('Pick a project to reuse, or switch to "Create new each run"');
+      }
+      const target: RoutineProjectTarget =
+        form.mode === 'reuse' && form.projectId
+          ? { mode: 'reuse', projectId: form.projectId }
+          : { mode: 'create_each_run' };
+      const body: CreateRoutineRequest = {
+        name: form.name.trim(),
+        prompt: form.prompt,
+        schedule: buildSchedule(form),
+        target,
+        enabled: true,
+      };
+      const res = await fetch('/api/routines', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        throw new Error(j.error || `create failed: ${res.status}`);
+      }
+      setShowForm(false);
+      setForm(emptyForm());
+      void refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const runNow = async (id: string) => {
+    setBusyId(id);
+    setError(null);
+    try {
+      const res = await fetch(`/api/routines/${id}/run`, { method: 'POST' });
+      if (!res.ok && res.status !== 202) {
+        const j = await res.json().catch(() => ({}));
+        throw new Error(j.error || `run failed: ${res.status}`);
+      }
+      void refresh();
+      setExpandedId(id);
+      setHistoryTick((v) => v + 1);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const toggleEnabled = async (routine: Routine) => {
+    setBusyId(routine.id);
+    try {
+      const res = await fetch(`/api/routines/${routine.id}`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ enabled: !routine.enabled }),
+      });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        throw new Error(j.error || `update failed: ${res.status}`);
+      }
+      void refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const remove = async (id: string) => {
+    if (!window.confirm('Delete this routine? Past runs and their projects are kept.'))
+      return;
+    setBusyId(id);
+    try {
+      const res = await fetch(`/api/routines/${id}`, { method: 'DELETE' });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        throw new Error(j.error || `delete failed: ${res.status}`);
+      }
+      if (expandedId === id) setExpandedId(null);
+      void refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <section className="settings-section routines-section">
+      <div className="section-head">
+        <div>
+          <h3>Routines</h3>
+          <p className="hint">
+            Scheduled, unattended agent sessions. Each run starts a new
+            conversation — either inside an existing project, or in a fresh
+            project minted on the spot.
+          </p>
+        </div>
+        {!showForm ? (
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={() => {
+              setForm(emptyForm());
+              setShowForm(true);
+            }}
+          >
+            <Icon name="plus" size={14} />
+            <span>New routine</span>
+          </button>
+        ) : null}
+      </div>
+
+      {error ? (
+        <div className="settings-notice error" role="alert">
+          {error}
+        </div>
+      ) : null}
+
+      {showForm ? (
+        <form onSubmit={submit} className="routines-card routines-form">
+          <label className="routines-field">
+            <span>Name</span>
+            <input
+              required
+              value={form.name}
+              onChange={(e) => setForm({ ...form, name: e.target.value })}
+              placeholder="Morning briefing"
+              autoFocus
+            />
+          </label>
+          <label className="routines-field">
+            <span>Prompt</span>
+            <textarea
+              required
+              rows={4}
+              value={form.prompt}
+              onChange={(e) => setForm({ ...form, prompt: e.target.value })}
+              placeholder="Pull yesterday's GitHub + Linear activity and summarize what changed."
+            />
+          </label>
+
+          <ScheduleEditor form={form} setForm={setForm} timezones={timezones} />
+
+          <fieldset className="routines-fieldset">
+            <legend>Project</legend>
+            <label className="routines-radio">
+              <input
+                type="radio"
+                checked={form.mode === 'create_each_run'}
+                onChange={() => setForm({ ...form, mode: 'create_each_run' })}
+              />
+              <span>
+                <strong>Create a new project each run</strong>
+                <small>A fresh, isolated workspace per fire.</small>
+              </span>
+            </label>
+            <label className="routines-radio">
+              <input
+                type="radio"
+                checked={form.mode === 'reuse'}
+                onChange={() => setForm({ ...form, mode: 'reuse' })}
+              />
+              <span>
+                <strong>Reuse an existing project</strong>
+                <small>Each run lives as a new conversation inside the project.</small>
+              </span>
+            </label>
+            {form.mode === 'reuse' ? (
+              <select
+                className="routines-project-select"
+                value={form.projectId}
+                onChange={(e) => setForm({ ...form, projectId: e.target.value })}
+                required
+              >
+                <option value="">— Pick a project —</option>
+                {projects.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name}
+                  </option>
+                ))}
+              </select>
+            ) : null}
+          </fieldset>
+
+          <div className="routines-form-actions">
+            <button
+              type="button"
+              className="btn"
+              onClick={() => {
+                setShowForm(false);
+                setForm(emptyForm());
+              }}
+            >
+              Cancel
+            </button>
+            <button type="submit" className="btn btn-primary" disabled={submitting}>
+              {submitting ? 'Creating…' : 'Create'}
+            </button>
+          </div>
+        </form>
+      ) : null}
+
+      {loading ? (
+        <div className="routines-empty">Loading…</div>
+      ) : routines.length === 0 ? (
+        <div className="routines-empty">
+          <strong>No routines yet.</strong>
+          <p>Click <em>New routine</em> to schedule an unattended agent run.</p>
+        </div>
+      ) : (
+        <ul className="routines-list">
+          {routines.map((r) => {
+            const targetLabel =
+              r.target.mode === 'reuse'
+                ? `→ ${projectsById.get(r.target.projectId) ?? r.target.projectId}`
+                : '→ new project each run';
+            const isBusy = busyId === r.id;
+            const isExpanded = expandedId === r.id;
+            return (
+              <li key={r.id} className={`routines-card routines-item${r.enabled ? '' : ' is-disabled'}`}>
+                <div className="routines-item-head">
+                  <div className="routines-item-main">
+                    <div className="routines-item-title">
+                      <strong>{r.name}</strong>
+                      {!r.enabled ? (
+                        <span className="routines-tag">paused</span>
+                      ) : null}
+                    </div>
+                    <div className="routines-item-line">{describeSchedule(r.schedule)}</div>
+                    <div className="routines-item-meta">
+                      <span>{targetLabel}</span>
+                      <span aria-hidden>·</span>
+                      <span>next: {formatRelative(r.nextRunAt)}</span>
+                      {r.lastRun ? (
+                        <>
+                          <span aria-hidden>·</span>
+                          <span>
+                            last: <StatusPill status={r.lastRun.status} />{' '}
+                            {formatRelative(r.lastRun.startedAt)}
+                          </span>
+                        </>
+                      ) : null}
+                    </div>
+                  </div>
+                  <div className="routines-item-actions">
+                    <button
+                      type="button"
+                      className="btn btn-primary"
+                      onClick={() => runNow(r.id)}
+                      disabled={isBusy}
+                    >
+                      Run now
+                    </button>
+                    <button
+                      type="button"
+                      className="btn"
+                      onClick={() => toggleEnabled(r)}
+                      disabled={isBusy}
+                    >
+                      {r.enabled ? 'Pause' : 'Resume'}
+                    </button>
+                    <button
+                      type="button"
+                      className="btn btn-ghost"
+                      onClick={() => setExpandedId(isExpanded ? null : r.id)}
+                      aria-expanded={isExpanded}
+                    >
+                      {isExpanded ? 'Hide history' : 'History'}
+                    </button>
+                    <button
+                      type="button"
+                      className="btn btn-ghost btn-danger"
+                      onClick={() => remove(r.id)}
+                      disabled={isBusy}
+                      title="Delete this routine"
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </div>
+                {isExpanded ? (
+                  <div className="routines-item-history">
+                    <RunHistory routineId={r.id} refreshKey={historyTick} />
+                  </div>
+                ) : null}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -47,6 +47,7 @@ import { PetSettings } from './pet/PetSettings';
 import { McpClientSection } from './McpClientSection';
 import { LibrarySection } from './LibrarySection';
 import { PrivacySection } from './PrivacySection';
+import { RoutinesSection } from './RoutinesSection';
 import { ConnectorsBrowser } from './ConnectorsBrowser';
 import {
   applyAppearanceToDocument,
@@ -66,6 +67,7 @@ export type SettingsSection =
   | 'media'
   | 'composio'
   | 'orbit'
+  | 'routines'
   | 'integrations'
   | 'mcpClient'
   | 'language'
@@ -1050,6 +1052,10 @@ export function SettingsDialog({
     media: { title: t('settings.mediaProviders'), subtitle: t('settings.mediaProvidersHint') },
     composio: { title: t('connectors.title'), subtitle: t('connectors.subtitle') },
     orbit: { title: t('settings.orbit.title'), subtitle: t('settings.orbit.lede') },
+    routines: {
+      title: 'Routines',
+      subtitle: 'Scheduled, unattended agent sessions that run on their own.',
+    },
     integrations: { title: t('settings.mcpServerTitle'), subtitle: t('settings.mcpServerHint') },
     mcpClient: { title: t('settings.externalMcpTitle'), subtitle: t('settings.externalMcpHint') },
     language: { title: t('settings.language'), subtitle: t('settings.languageHint') },
@@ -1199,6 +1205,17 @@ export function SettingsDialog({
               <span>
                 <strong>{t('settings.orbit.title')}</strong>
                 <small>{t('settings.orbit.navHint')}</small>
+              </span>
+            </button>
+            <button
+              type="button"
+              className={`settings-nav-item${activeSection === 'routines' ? ' active' : ''}`}
+              onClick={() => setActiveSection('routines')}
+            >
+              <Icon name="history" size={18} />
+              <span>
+                <strong>Routines</strong>
+                <small>Schedule unattended agent runs</small>
               </span>
             </button>
             <button
@@ -1871,6 +1888,8 @@ export function SettingsDialog({
               onPersistComposioKey={onPersistComposioKey}
             />
           ) : null}
+
+          {activeSection === 'routines' ? <RoutinesSection /> : null}
 
           {activeSection === 'orbit' ? (
             <OrbitSection

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -14960,3 +14960,255 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
 .mcp-oauth-fallback .md-link:hover {
   text-decoration-thickness: 2px;
 }
+
+/* ---------------- Routines (Settings → Routines) ---------------- */
+
+.routines-section .section-head { align-items: flex-start; }
+
+.routines-card {
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.routines-form { margin-top: 4px; }
+
+.routines-empty {
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--radius-lg);
+  padding: 24px;
+  text-align: center;
+  color: var(--text-muted);
+  background: var(--bg-subtle);
+}
+.routines-empty strong { color: var(--text); display: block; margin-bottom: 4px; font-size: 14px; }
+.routines-empty p { margin: 0; font-size: 13px; }
+.routines-empty em { color: var(--text); font-style: normal; font-weight: 600; }
+
+.routines-field { display: flex; flex-direction: column; gap: 6px; }
+.routines-field > span {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+  letter-spacing: 0.01em;
+}
+.routines-field input[type="text"],
+.routines-field input[type="time"],
+.routines-field input[type="number"],
+.routines-field input:not([type]),
+.routines-field textarea,
+.routines-field select,
+.routines-project-select {
+  appearance: none;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  padding: 9px 12px;
+  font-size: 14px;
+  color: var(--text);
+  font-family: inherit;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+.routines-field input:focus,
+.routines-field textarea:focus,
+.routines-field select:focus,
+.routines-project-select:focus {
+  outline: none;
+  border-color: var(--text);
+  box-shadow: 0 0 0 3px rgba(26, 25, 22, 0.08);
+}
+.routines-field textarea { resize: vertical; min-height: 80px; }
+
+.routines-field-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+  letter-spacing: 0.01em;
+}
+
+.routines-fieldrow { display: flex; gap: 12px; flex-wrap: wrap; }
+.routines-fieldrow > .routines-field { flex: 1 1 180px; min-width: 0; }
+.routines-fieldrow-2col > .routines-field { flex: 1 1 240px; }
+
+.routines-schedule-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px;
+  background: var(--bg-subtle);
+  border-radius: var(--radius);
+}
+
+.routines-kind-pills { align-self: flex-start; }
+
+.routines-weekday-row {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.routines-weekday {
+  background: var(--bg-panel);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all 120ms ease;
+}
+.routines-weekday:hover { color: var(--text); border-color: var(--text-soft); }
+.routines-weekday.active {
+  background: var(--text);
+  color: var(--bg);
+  border-color: var(--text);
+}
+
+.routines-schedule-hint {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.routines-fieldset {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 12px 14px;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.routines-fieldset legend {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+  padding: 0 6px;
+}
+.routines-radio {
+  display: flex;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background 120ms ease;
+  align-items: flex-start;
+}
+.routines-radio:hover { background: var(--bg-subtle); }
+.routines-radio input { margin-top: 3px; }
+.routines-radio span { display: flex; flex-direction: column; gap: 2px; }
+.routines-radio strong { font-size: 14px; color: var(--text); font-weight: 600; }
+.routines-radio small { font-size: 12px; color: var(--text-muted); }
+
+.routines-form-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  border-top: 1px solid var(--border);
+  padding-top: 14px;
+}
+
+/* List of existing routines */
+.routines-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.routines-item.is-disabled { opacity: 0.7; }
+
+.routines-item-head {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+.routines-item-main { flex: 1 1 320px; min-width: 0; display: flex; flex-direction: column; gap: 4px; }
+.routines-item-title { display: flex; align-items: center; gap: 8px; }
+.routines-item-title strong { font-size: 15px; color: var(--text); font-weight: 600; }
+.routines-item-line { font-size: 13px; color: var(--text); }
+.routines-item-meta {
+  font-size: 12px;
+  color: var(--text-muted);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+.routines-tag {
+  font-size: 11px;
+  background: var(--bg-muted);
+  color: var(--text-muted);
+  padding: 2px 8px;
+  border-radius: var(--radius-pill);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+}
+
+.routines-item-actions { display: flex; gap: 6px; flex-wrap: wrap; align-items: center; }
+
+.routines-item-history {
+  border-top: 1px solid var(--border);
+  padding-top: 12px;
+  margin-top: 4px;
+}
+
+.routines-history { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 4px; }
+.routines-history-empty { font-size: 12px; color: var(--text-muted); padding: 6px 0; }
+.routines-history-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  gap: 10px;
+  align-items: center;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.routines-history-row:hover { background: var(--bg-subtle); }
+.routines-history-time { color: var(--text); }
+.routines-history-trigger {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.routines-history-link {
+  background: transparent;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  padding: 4px 8px;
+  font-size: 12px;
+  color: var(--text);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-weight: 500;
+}
+.routines-history-link:hover { background: var(--text); color: var(--bg); border-color: var(--text); }
+
+.routines-status {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: var(--radius-pill);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: var(--bg-muted);
+  color: var(--text-muted);
+}
+.routines-status-running { background: #f3eddc; color: #8a6a1a; }
+.routines-status-queued { background: #ece9e2; color: var(--text-muted); }
+.routines-status-succeeded { background: #e3efe6; color: #2e7d5b; }
+.routines-status-failed { background: #f6dfdc; color: #b3382b; }
+.routines-status-canceled { background: #ece9e2; color: var(--text-muted); }

--- a/packages/contracts/src/api/routines.ts
+++ b/packages/contracts/src/api/routines.ts
@@ -1,0 +1,150 @@
+// Routines: scheduled, unattended agent sessions. Each routine fires on a
+// schedule, mints a conversation (in either an existing project or a freshly
+// created one), and runs the configured prompt as an agent task.
+
+export type RoutineScheduleKind =
+  | 'hourly'
+  | 'daily'
+  | 'weekdays'
+  | 'weekly';
+
+// Sunday=0 .. Saturday=6, mirroring JS Date.getDay().
+export type Weekday = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+export interface RoutineHourlySchedule {
+  kind: 'hourly';
+  // 0-59. The minute of every hour at which the routine fires (UTC-equivalent
+  // since hour boundaries are universal — we don't take a timezone here).
+  minute: number;
+}
+
+export interface RoutineDailySchedule {
+  kind: 'daily';
+  // 24h "HH:MM" wall-clock time in `timezone`.
+  time: string;
+  // IANA timezone identifier (e.g. "Asia/Shanghai", "UTC").
+  timezone: string;
+}
+
+export interface RoutineWeekdaysSchedule {
+  kind: 'weekdays';
+  // 24h "HH:MM" wall-clock time in `timezone`. Fires Mon-Fri only.
+  time: string;
+  timezone: string;
+}
+
+export interface RoutineWeeklySchedule {
+  kind: 'weekly';
+  // 24h "HH:MM" wall-clock time in `timezone`. Fires once a week.
+  time: string;
+  timezone: string;
+  weekday: Weekday;
+}
+
+export type RoutineSchedule =
+  | RoutineHourlySchedule
+  | RoutineDailySchedule
+  | RoutineWeekdaysSchedule
+  | RoutineWeeklySchedule;
+
+export type RoutineProjectMode = 'create_each_run' | 'reuse';
+
+export interface RoutineCreateEachRunTarget {
+  mode: 'create_each_run';
+}
+
+export interface RoutineReuseProjectTarget {
+  mode: 'reuse';
+  projectId: string;
+}
+
+export type RoutineProjectTarget =
+  | RoutineCreateEachRunTarget
+  | RoutineReuseProjectTarget;
+
+export type RoutineRunStatus =
+  | 'queued'
+  | 'running'
+  | 'succeeded'
+  | 'failed'
+  | 'canceled';
+
+export type RoutineRunTrigger = 'manual' | 'scheduled';
+
+export interface RoutineLastRunSummary {
+  runId: string;
+  status: RoutineRunStatus;
+  trigger: RoutineRunTrigger;
+  startedAt: number;
+  completedAt?: number;
+  projectId: string;
+  conversationId: string;
+  agentRunId: string;
+  summary?: string;
+}
+
+export interface Routine {
+  id: string;
+  name: string;
+  prompt: string;
+  schedule: RoutineSchedule;
+  target: RoutineProjectTarget;
+  skillId: string | null;
+  agentId: string | null;
+  enabled: boolean;
+  nextRunAt: number | null;
+  lastRun: RoutineLastRunSummary | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface RoutineRun {
+  id: string;
+  routineId: string;
+  trigger: RoutineRunTrigger;
+  status: RoutineRunStatus;
+  projectId: string;
+  conversationId: string;
+  agentRunId: string;
+  startedAt: number;
+  completedAt: number | null;
+  summary: string | null;
+  error: string | null;
+}
+
+export interface CreateRoutineRequest {
+  name: string;
+  prompt: string;
+  schedule: RoutineSchedule;
+  target: RoutineProjectTarget;
+  skillId?: string | null;
+  agentId?: string | null;
+  enabled?: boolean;
+}
+
+export interface UpdateRoutineRequest {
+  name?: string;
+  prompt?: string;
+  schedule?: RoutineSchedule;
+  target?: RoutineProjectTarget;
+  skillId?: string | null;
+  agentId?: string | null;
+  enabled?: boolean;
+}
+
+export interface RoutinesResponse {
+  routines: Routine[];
+}
+
+export interface RoutineResponse {
+  routine: Routine;
+}
+
+export interface RoutineRunResponse {
+  routine: Routine;
+  run: RoutineRun;
+}
+
+export interface RoutineRunsResponse {
+  runs: RoutineRun[];
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -14,6 +14,7 @@ export * from './api/mcp';
 export * from './api/orbit';
 export * from './api/projects';
 export * from './api/proxy';
+export * from './api/routines';
 export * from './api/registry';
 export * from './api/research';
 export * from './api/version';


### PR DESCRIPTION
## Summary

Generalizes Orbit's single hard-coded daily-digest scheduler into user-defined **routines**: each one fires on a schedule (Hourly / Daily / Weekdays / Weekly with IANA timezone) and starts a fresh agent conversation, either inside an existing project or in a new project minted on the spot.

- **Backend (apps/daemon):** new `RoutineService` with timezone-aware `nextRunAt` computed via `Intl.DateTimeFormat` (no new dependency); two-pass `tzWallToUtc` so DST transitions stay correct. Each fire chains `rescheduleOne` in `finally()` so the cadence keeps going. New `routines` + `routine_runs` SQLite tables; `schedule_json` is the authoritative form, `schedule_kind`/`value` kept populated for query convenience. `/api/routines` CRUD + `/api/routines/:id/run` + `/api/routines/:id/runs`.
- **UI (Settings → Routines):** pill-chip schedule kind picker, time + timezone fields, weekday picker for Weekly, live preview line ("Runs daily at 9:00 AM GMT+8"). Routine list with status pill + next/last meta + expandable run history; each history row links into the project the run wrote to via the existing router primitive.
- **Custom cron** intentionally deferred — the discriminated union leaves room to add it later without breaking changes.

## Test plan

- [x] `pnpm guard`
- [x] `pnpm --filter @open-design/contracts build`
- [x] `pnpm --filter @open-design/daemon typecheck`
- [x] `pnpm --filter @open-design/web typecheck`
- [x] `pnpm --filter @open-design/web test` — 596/596 pass
- [x] Rebased cleanly onto latest `origin/main`
- [ ] Manual smoke: open Settings → Routines, create a `Hourly` and a `Daily` routine, verify the live preview line, "Run now" spawns a conversation in the right project, "History" lists the run with an "Open project" link that navigates correctly
- [ ] Manual smoke: create a `Weekly` routine for tomorrow's weekday at HH:MM in a non-UTC timezone, restart the daemon, confirm it still fires on schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)