### PR TITLE
fix(web): expand design file row click target

### DIFF
--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -497,17 +497,24 @@ export function DesignFilesPanel({
                                 {selected.has(f.name) ? '\u2611' : '\u2610'}
                               </span>
                             </td>
-                            <td className="df-cell-icon">
+                            <td
+                              className="df-cell-icon df-cell-openable"
+                              onClick={() => setPreview(f.name)}
+                              onDoubleClick={() => onOpenFile(f.name)}
+                            >
                               <span className="df-row-icon" data-kind={f.kind} aria-hidden>
                                 {kindGlyph(f.kind)}
                               </span>
                             </td>
-                            <td className="df-cell-name">
+                            <td
+                              className="df-cell-name df-cell-openable"
+                              onClick={() => setPreview(f.name)}
+                              onDoubleClick={() => onOpenFile(f.name)}
+                            >
                               <button
                                 type="button"
                                 className="df-row-name-btn"
                                 onClick={() => setPreview(f.name)}
-                                onDoubleClick={() => onOpenFile(f.name)}
                                 onKeyDown={(e) => {
                                   if (e.key === 'Enter' || e.key === ' ') {
                                     e.preventDefault();
@@ -529,10 +536,20 @@ export function DesignFilesPanel({
                                 </span>
                               </button>
                             </td>
-                            <td className="df-cell-kind">
+                            <td
+                              className="df-cell-kind df-cell-openable"
+                              onClick={() => setPreview(f.name)}
+                              onDoubleClick={() => onOpenFile(f.name)}
+                            >
                               <span className="df-kind-label">{kindLabel(f.kind, t)}</span>
                             </td>
-                            <td className="df-cell-time">{relativeTime(f.mtime, t)}</td>
+                            <td
+                              className="df-cell-time df-cell-openable"
+                              onClick={() => setPreview(f.name)}
+                              onDoubleClick={() => onOpenFile(f.name)}
+                            >
+                              {relativeTime(f.mtime, t)}
+                            </td>
                             <td className="df-cell-menu">
                               <span
                                 data-testid={`design-file-menu-${f.name}`}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -7090,7 +7090,8 @@ button.connector-action.is-loading {
   transition: background 120ms ease;
 }
 .df-file-row:hover { background: var(--bg-subtle); }
-.df-file-row.active { background: var(--blue-bg); }
+.df-file-row.active:not(.selected) { background: var(--bg-subtle); }
+.df-file-row.active.selected { background: var(--blue-bg); }
 .df-file-row.active .df-row-name { color: var(--text-strong); }
 .df-file-row.selected { background: var(--blue-bg); }
 
@@ -7106,6 +7107,9 @@ button.connector-action.is-loading {
   padding: 10px 12px 10px 0;
   vertical-align: middle;
 }
+.df-cell-openable {
+  cursor: pointer;
+}
 .df-row-name-btn {
   all: unset;
   cursor: pointer;
@@ -7113,6 +7117,10 @@ button.connector-action.is-loading {
   flex-direction: column;
   gap: 2px;
   min-width: 0;
+}
+.df-row-name-btn:hover:not(:disabled) {
+  background: transparent;
+  border-color: transparent;
 }
 .df-row-name-btn:focus-visible {
   outline: 2px solid var(--accent);

--- a/apps/web/tests/components/DesignFilesPanel.test.tsx
+++ b/apps/web/tests/components/DesignFilesPanel.test.tsx
@@ -32,22 +32,25 @@ function generateFiles(count: number): ProjectFile[] {
 }
 
 function renderPanel(files: ProjectFile[]) {
-  return render(
+  const onOpenFile = vi.fn();
+  const onDeleteFiles = vi.fn();
+  const result = render(
     <DesignFilesPanel
       projectId="test-project"
       files={files}
       liveArtifacts={[]}
       onRefreshFiles={vi.fn()}
-      onOpenFile={vi.fn()}
+      onOpenFile={onOpenFile}
       onOpenLiveArtifact={vi.fn()}
       onDeleteFile={vi.fn()}
-      onDeleteFiles={vi.fn()}
+      onDeleteFiles={onDeleteFiles}
       onUpload={vi.fn()}
       onUploadFiles={vi.fn()}
       onPaste={vi.fn()}
       onNewSketch={vi.fn()}
     />,
   );
+  return { ...result, onDeleteFiles, onOpenFile };
 }
 
 function getPageInfo(container: HTMLElement): string {
@@ -142,6 +145,60 @@ describe('DesignFilesPanel large-list regression', () => {
     fireEvent.click(btns[1]!);
 
     expect(getPageInfo(container)).toContain('31–60 of 500');
+  });
+
+  it('uses non-control table cells as file row click targets', () => {
+    const files = generateFiles(1);
+    const { container, onOpenFile } = renderPanel(files);
+    const row = container.querySelector('.df-file-row')!;
+
+    fireEvent.click(row.querySelector('.df-cell-icon')!);
+    expect(container.querySelector('[data-testid="design-file-preview"]')?.textContent).toContain(
+      'file-1.html',
+    );
+
+    fireEvent.click(row.querySelector('.df-cell-kind')!);
+    expect(container.querySelector('[data-testid="design-file-preview"]')?.textContent).toContain(
+      'file-1.html',
+    );
+
+    fireEvent.click(row.querySelector('.df-cell-name')!);
+    expect(container.querySelector('[data-testid="design-file-preview"]')?.textContent).toContain(
+      'file-1.html',
+    );
+
+    fireEvent.doubleClick(row.querySelector('.df-cell-name')!);
+    expect(onOpenFile).toHaveBeenCalledWith('file-1.html');
+    onOpenFile.mockClear();
+
+    fireEvent.doubleClick(row.querySelector('.df-cell-time')!);
+    expect(onOpenFile).toHaveBeenCalledWith('file-1.html');
+  });
+
+  it('does not preview or open files from row controls', () => {
+    const files = generateFiles(1);
+    const { container, onOpenFile } = renderPanel(files);
+    const row = container.querySelector('.df-file-row')!;
+
+    fireEvent.click(row.querySelector('.df-row-check')!);
+    expect(container.querySelector('[data-testid="design-file-preview"]')).toBeNull();
+    expect(onOpenFile).not.toHaveBeenCalled();
+
+    fireEvent.click(row.querySelector('.df-row-menu')!);
+    expect(container.querySelector('[data-testid="design-file-preview"]')).toBeNull();
+    expect(onOpenFile).not.toHaveBeenCalled();
+  });
+
+  it('passes every selected file to batch delete', () => {
+    const files = generateFiles(3);
+    const { container, onDeleteFiles } = renderPanel(files);
+    const rows = Array.from(container.querySelectorAll('.df-file-row'));
+
+    fireEvent.click(rows[0]!.querySelector('.df-row-check')!);
+    fireEvent.click(rows[1]!.querySelector('.df-row-check')!);
+    fireEvent.click(container.querySelector('[data-testid="design-files-batch-delete"]')!);
+
+    expect(onDeleteFiles).toHaveBeenCalledWith(['file-1.html', 'file-2.png']);
   });
 
   it('renders 500 files within a reasonable time', () => {


### PR DESCRIPTION
## Summary
- make Design Files table rows clickable across non-control cells, not just the file name block
- keep checkbox and row menu interactions independent
- prevent the inner file-name button hover behavior from painting a mismatched patch over the selected row without suppressing normal focus behavior
- distinguish preview/active rows from checkbox-selected rows so blue fill only represents files included in batch actions

## Validation
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/DesignFilesPanel.test.tsx tests/components/FileWorkspace.test.tsx`
- `pnpm --filter @open-design/web typecheck`

Note: local Node is `v22.22.0`, so pnpm prints the existing engine warning for the repo's `~24` target.