### PR TITLE
feat(web): scroll question forms to top of viewport instead of pinning to bottom

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -566,7 +566,11 @@ export function ChatPane({
             onEnsureProject={onEnsureProject}
             commentAttachments={commentsToAttachments(attachedComments)}
             onRemoveCommentAttachment={onDetachComment}
-            onSend={onSend}
+            onSend={(prompt, attachments, commentAttachments, meta) => {
+              pinnedToBottomRef.current = true;
+              scrolledToFormRef.current = new Set();
+              onSend(prompt, attachments, commentAttachments, meta);
+            }}
             onStop={onStop}
             onOpenSettings={onOpenSettings}
             onOpenMcpSettings={onOpenMcpSettings}

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -194,7 +194,9 @@ export function ChatPane({
         const formEl = lastAssistantEl?.querySelector<HTMLElement>('[data-form-id]');
         if (formEl && !scrolledToFormRef.current.has(formEl.dataset.formId!)) {
           scrolledToFormRef.current.add(formEl.dataset.formId!);
-          el.scrollTop = formEl.offsetTop;
+          const formRect = formEl.getBoundingClientRect();
+          const containerRect = el.getBoundingClientRect();
+          el.scrollTop += formRect.top - containerRect.top;
           pinnedToBottomRef.current = false;
           setScrolledFromBottom(true);
           return;
@@ -246,11 +248,11 @@ export function ChatPane({
         // Form tag in content but the DOM element isn't ready yet (partial
         // stream) — skip bottom-scroll to avoid a jarring jump that gets
         // undone when the form finishes rendering.
-        return;
+        if (streaming) return;
       }
       el.scrollTop = el.scrollHeight;
     }
-  }, [messages, error]);
+  }, [messages, error, streaming]);
 
   // Saved chat-log scroll state, preserved across tab switches. The
   // chat-log <div> is conditionally rendered so it unmounts when the

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -194,9 +194,7 @@ export function ChatPane({
         const formEl = lastAssistantEl?.querySelector<HTMLElement>('[data-form-id]');
         if (formEl && !scrolledToFormRef.current.has(formEl.dataset.formId!)) {
           scrolledToFormRef.current.add(formEl.dataset.formId!);
-          const formRect = formEl.getBoundingClientRect();
-          const containerRect = el.getBoundingClientRect();
-          el.scrollTop += formRect.top - containerRect.top;
+          formEl.scrollIntoView({ block: 'start', behavior: 'smooth' });
           pinnedToBottomRef.current = false;
           setScrolledFromBottom(true);
           return;
@@ -204,7 +202,7 @@ export function ChatPane({
         // Already handled by the auto-scroll effect — don't bottom-scroll.
         if (formEl) return;
       }
-      el.scrollTop = el.scrollHeight;
+      el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
       setScrolledFromBottom(false);
       pinnedToBottomRef.current = true;
     });
@@ -250,7 +248,7 @@ export function ChatPane({
         // undone when the form finishes rendering.
         if (streaming) return;
       }
-      el.scrollTop = el.scrollHeight;
+      el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
     }
   }, [messages, error, streaming]);
 

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -149,6 +149,7 @@ export function ChatPane({
   // 80px cutoff: scrolling ~90px up is an intentional pause that
   // shouldn't be yanked back the moment the next chunk streams in.
   const pinnedToBottomRef = useRef(true);
+  const scrolledToFormRef = useRef<Set<string>>(new Set());
   const [tab, setTab] = useState<Tab>('chat');
   const [showConvList, setShowConvList] = useState(false);
   const [scrolledFromBottom, setScrolledFromBottom] = useState(false);
@@ -176,6 +177,7 @@ export function ChatPane({
     // A new conversation should land at the bottom (its own initial
     // scroll), not inherit the previous conversation's saved position.
     savedChatScrollRef.current = null;
+    scrolledToFormRef.current = new Set();
   }, [activeConversationId]);
 
   useEffect(() => {
@@ -183,6 +185,23 @@ export function ChatPane({
     if (!el || didInitialScrollRef.current || messages.length === 0) return;
     didInitialScrollRef.current = true;
     requestAnimationFrame(() => {
+      // If the last assistant message contains a question form, scroll to
+      // the form instead of the bottom, so the user sees the form first.
+      const lastAssistantMsg = [...messages].reverse().find((m) => m.role === 'assistant');
+      if (lastAssistantMsg?.content.includes('<question-form')) {
+        const assistantEls = el.querySelectorAll('.msg.assistant');
+        const lastAssistantEl = assistantEls[assistantEls.length - 1];
+        const formEl = lastAssistantEl?.querySelector<HTMLElement>('[data-form-id]');
+        if (formEl && !scrolledToFormRef.current.has(formEl.dataset.formId!)) {
+          scrolledToFormRef.current.add(formEl.dataset.formId!);
+          el.scrollTop = formEl.offsetTop;
+          pinnedToBottomRef.current = false;
+          setScrolledFromBottom(true);
+          return;
+        }
+        // Already handled by the auto-scroll effect — don't bottom-scroll.
+        if (formEl) return;
+      }
       el.scrollTop = el.scrollHeight;
       setScrolledFromBottom(false);
       pinnedToBottomRef.current = true;
@@ -210,6 +229,25 @@ export function ChatPane({
     // threshold) so a deliberate ~90px scroll-up isn't snapped back the
     // next time content streams in. Issue #983.
     if (pinnedToBottomRef.current) {
+      // If the last assistant message contains a question form, scroll to
+      // the form instead of the bottom, so the user lands on the form.
+      const lastAssistantMsg = [...messages].reverse().find((m) => m.role === 'assistant');
+      if (lastAssistantMsg?.content.includes('<question-form')) {
+        const assistantEls = el.querySelectorAll('.msg.assistant');
+        const lastAssistantEl = assistantEls[assistantEls.length - 1];
+        const formEl = lastAssistantEl?.querySelector<HTMLElement>('[data-form-id]');
+        if (formEl && !scrolledToFormRef.current.has(formEl.dataset.formId!)) {
+          scrolledToFormRef.current.add(formEl.dataset.formId!);
+          formEl.scrollIntoView({ block: 'start', behavior: 'smooth' });
+          pinnedToBottomRef.current = false;
+          setScrolledFromBottom(true);
+          return;
+        }
+        // Form tag in content but the DOM element isn't ready yet (partial
+        // stream) — skip bottom-scroll to avoid a jarring jump that gets
+        // undone when the form finishes rendering.
+        return;
+      }
       el.scrollTop = el.scrollHeight;
     }
   }, [messages, error]);
@@ -490,7 +528,11 @@ export function ChatPane({
                         onRequestOpenFile={onRequestOpenFile}
                         isLast={m.id === lastAssistantId}
                         nextUserContent={nextUserContentByAssistantId.get(m.id)}
-                        onSubmitForm={onSubmitForm}
+                        onSubmitForm={(text) => {
+                          pinnedToBottomRef.current = true;
+                          scrolledToFormRef.current = new Set();
+                          onSubmitForm?.(text);
+                        }}
                         onContinueRemainingTasks={
                           m.id === lastAssistantId && onContinueRemainingTasks
                             ? (todos) => onContinueRemainingTasks(m, todos)

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -248,7 +248,10 @@ export function ChatPane({
         // undone when the form finishes rendering.
         if (streaming) return;
       }
-      el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+      // Streaming bottom-pin must be instant — smooth scrollTo emits
+      // intermediate scroll events that flip pinnedToBottomRef to false,
+      // breaking auto-follow for subsequent chunks.
+      el.scrollTop = el.scrollHeight;
     }
   }, [messages, error, streaming]);
 

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -202,7 +202,9 @@ export function ChatPane({
         // Already handled by the auto-scroll effect — don't bottom-scroll.
         if (formEl) return;
       }
-      el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+      // Initial-load bottom-pin must be instant — smooth scrollTo emits
+      // intermediate scroll events that flip pinnedToBottomRef to false.
+      el.scrollTop = el.scrollHeight;
       setScrolledFromBottom(false);
       pinnedToBottomRef.current = true;
     });

--- a/apps/web/src/components/QuestionForm.tsx
+++ b/apps/web/src/components/QuestionForm.tsx
@@ -76,7 +76,7 @@ export function QuestionFormView({ form, interactive, submittedAnswers, onSubmit
   });
 
   return (
-    <div className={`question-form${locked ? ' question-form-locked' : ''}`}>
+    <div className={`question-form${locked ? ' question-form-locked' : ''}`} data-form-id={form.id}>
       <div className="question-form-head">
         <span className="question-form-icon" aria-hidden>?</span>
         <div className="question-form-titles">

--- a/apps/web/tests/components/chat-scroll-preservation.test.tsx
+++ b/apps/web/tests/components/chat-scroll-preservation.test.tsx
@@ -1,5 +1,18 @@
 // @vitest-environment jsdom
 
+// Polyfill scrollTo for jsdom (not available in jsdom's HTMLElement)
+if (typeof HTMLElement.prototype.scrollTo !== 'function') {
+  HTMLElement.prototype.scrollTo = function (
+    options?: ScrollToOptions | number,
+    _y?: number,
+  ) {
+    if (typeof options === 'object' && options !== null) {
+      if (options.top !== undefined) this.scrollTop = options.top;
+      if (options.left !== undefined) this.scrollLeft = options.left;
+    }
+  };
+}
+
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ChatPane } from '../../src/components/ChatPane';

--- a/apps/web/tests/components/conversation-timestamps.test.tsx
+++ b/apps/web/tests/components/conversation-timestamps.test.tsx
@@ -1,5 +1,18 @@
 // @vitest-environment jsdom
 
+// Polyfill scrollTo for jsdom (not available in jsdom's HTMLElement)
+if (typeof HTMLElement.prototype.scrollTo !== 'function') {
+  HTMLElement.prototype.scrollTo = function (
+    options?: ScrollToOptions | number,
+    _y?: number,
+  ) {
+    if (typeof options === 'object' && options !== null) {
+      if (options.top !== undefined) this.scrollTop = options.top;
+      if (options.left !== undefined) this.scrollLeft = options.left;
+    }
+  };
+}
+
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ChatPane } from '../../src/components/ChatPane';


### PR DESCRIPTION
## Summary

Changes the chat panel's auto-scroll behavior so that when an assistant response contains a `<question-form>`, the viewport scrolls to align the top of the form with the top of the visible chat area — instead of the current behavior which pins the latest response to the bottom.

### Key changes

- **`QuestionFormView`** (`apps/web/src/components/QuestionForm.tsx`): added `data-form-id={form.id}` attribute to the root element so it can be found by the scroll logic.
- **`ChatPane`** (`apps/web/src/components/ChatPane.tsx`):
  - Added `scrolledToFormRef` to track which form IDs have already been scrolled to, preventing re-scroll on subsequent streaming chunks.
  - **Initial scroll effect**: on conversation load, checks if the last assistant message contains a form and scrolls to it (instant) instead of bottom-scrolling.
  - **Auto-scroll effect**: during streaming, detects when a form appears in the last assistant message and smooth-scrolls to it. Sets `pinnedToBottomRef = false` immediately after so subsequent chunks don't abort the animation.
  - **Form submission**: resets `pinnedToBottomRef.current = true` and clears `scrolledToFormRef` so the next response reclaims scroll control.
  - Queries `[data-form-id]` only within the last `.msg.assistant` element to avoid targeting stale (answered) forms from earlier in the conversation.

### Behavior

| Scenario | Behavior |
|---|---|
| Normal text streaming | Bottom-scroll (unchanged) |
| Form appears during streaming | Smooth scroll to form top; subsequent text extends below viewport |
| Navigate to conversation ending in form | Instant scroll to form top |
| User scrolls away from form | No yank (`pinnedToBottomRef` is false) |
| Submit form → next response arrives | Scroll control reclaimed; next form/text scrolls into view |
| Tab switch away and back | Preserved via existing `savedChatScrollRef` mechanism |

### Verification

- `pnpm guard` — pass
- `pnpm typecheck` — all 12 workspace packages pass (1 pre-existing failure in `apps/packaged` unrelated)
- `pnpm --filter @open-design/web test` — 66 files, 596 tests, all pass