### PR TITLE
fix(web): keep entry footer pills compact

### DIFF
--- a/apps/web/src/components/EntryView.tsx
+++ b/apps/web/src/components/EntryView.tsx
@@ -483,30 +483,43 @@ export function EntryView({
           loading={skillsLoading || designSystemsLoading}
         />
         <div className="entry-side-foot">
-          <button
-            type="button"
-            className={`foot-pill pet-pill${config.pet?.adopted ? '' : ' pet-pill-fresh'}`}
-            onClick={onAdoptPet}
-            title={
-              config.pet?.adopted
-                ? t('pet.changePet')
-                : t('pet.adoptCallout')
-            }
-          >
-            <span className="pet-pill-glyph" aria-hidden>
-              {config.pet?.adopted
-                ? config.pet.petId === 'custom'
-                  ? config.pet.custom.glyph || '🦄'
-                  : '🐾'
-                : '🐾'}
-            </span>
-            <span>
-              {config.pet?.adopted
-                ? t('pet.changePet')
-                : t('pet.adoptCallout')}
-            </span>
-            {!config.pet?.adopted ? <span className="pet-pill-dot" aria-hidden /> : null}
-          </button>
+          <div className="entry-side-foot-row">
+            <button
+              type="button"
+              className={`foot-pill pet-pill${config.pet?.adopted ? '' : ' pet-pill-fresh'}`}
+              onClick={onAdoptPet}
+              title={
+                config.pet?.adopted
+                  ? t('pet.changePet')
+                  : t('pet.adoptCallout')
+              }
+            >
+              <span className="pet-pill-glyph" aria-hidden>
+                {config.pet?.adopted
+                  ? config.pet.petId === 'custom'
+                    ? config.pet.custom.glyph || '🦄'
+                    : '🐾'
+                  : '🐾'}
+              </span>
+              <span>
+                {config.pet?.adopted
+                  ? t('pet.changePet')
+                  : t('pet.adoptCallout')}
+              </span>
+              {!config.pet?.adopted ? <span className="pet-pill-dot" aria-hidden /> : null}
+            </button>
+            <a
+              className="foot-pill foot-pill-follow"
+              href="https://x.com/nexudotio"
+              target="_blank"
+              rel="noreferrer noopener"
+              title="Follow @nexudotio on X for releases and milestones"
+              aria-label="Follow @nexudotio on X"
+            >
+              <Icon name="external-link" size={12} />
+              <span className="foot-pill-follow-label">Follow @nexudotio</span>
+            </a>
+          </div>
           <button
             type="button"
             className="foot-pill"
@@ -525,17 +538,6 @@ export function EntryView({
               {envMetaLine}
             </span>
           </button>
-          <a
-            className="foot-pill"
-            href="https://x.com/nexudotio"
-            target="_blank"
-            rel="noreferrer noopener"
-            title="Follow @nexudotio on X for releases and milestones"
-            aria-label="Follow @nexudotio on X"
-          >
-            <Icon name="external-link" size={12} />
-            <span>Follow @nexudotio</span>
-          </a>
           <LanguageMenu />
         </div>
         <button

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4480,7 +4480,14 @@ code {
   display: flex;
   flex-direction: column;
   gap: 6px;
+  min-width: 0;
   padding-top: 16px;
+}
+.entry-side-foot-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
 }
 .entry-side-foot .foot-pill {
   display: inline-flex;
@@ -4495,6 +4502,19 @@ code {
   align-self: flex-start;
   cursor: pointer;
   text-decoration: none;
+}
+.entry-side-foot-row .foot-pill {
+  min-width: 0;
+}
+.entry-side-foot-row .foot-pill-follow {
+  flex: 0 1 auto;
+}
+.entry-side-foot-row .foot-pill-follow-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .entry-side-foot .foot-pill:hover { background: var(--bg-panel); border-color: var(--border-strong); color: var(--text); }
 .entry-side-foot .foot-pill .ico { font-size: 12px; opacity: 0.7; }


### PR DESCRIPTION
## Summary
- place the pet action and Follow @nexudotio pill on the same entry-sidebar footer row
- keep the Local CLI pill and language menu as the remaining footer rows to avoid making the sidebar scroll just because of the new follow link
- constrain the follow label with a shrinkable ellipsis label so narrow sidebar widths do not stretch the footer

## Validation
- `pnpm --filter @open-design/web typecheck`

Note: local Node is `v22.22.0`, so pnpm prints the existing engine warning for the repo's `~24` target.