### PR TITLE
[codex] fix OpenCode todowrite footer state

### DIFF
--- a/apps/web/src/runtime/todos.ts
+++ b/apps/web/src/runtime/todos.ts
@@ -35,7 +35,7 @@ export function latestTodosFromEvents(events: AgentEvent[] | undefined): TodoIte
   if (!events) return [];
   for (let i = events.length - 1; i >= 0; i -= 1) {
     const event = events[i];
-    if (event?.kind !== 'tool_use' || event.name !== 'TodoWrite') continue;
+    if (event?.kind !== 'tool_use' || !isTodoWriteToolName(event.name)) continue;
     return parseTodoWriteInput(event.input);
   }
   return [];
@@ -43,4 +43,8 @@ export function latestTodosFromEvents(events: AgentEvent[] | undefined): TodoIte
 
 export function unfinishedTodosFromEvents(events: AgentEvent[] | undefined): TodoItem[] {
   return latestTodosFromEvents(events).filter((todo) => todo.status !== 'completed');
+}
+
+function isTodoWriteToolName(name: string): boolean {
+  return name === 'TodoWrite' || name === 'todowrite';
 }

--- a/apps/web/tests/runtime/todos.test.ts
+++ b/apps/web/tests/runtime/todos.test.ts
@@ -53,6 +53,42 @@ describe('todo event helpers', () => {
     ]);
   });
 
+  it('recognizes lowercase OpenCode todowrite events', () => {
+    const events: AgentEvent[] = [
+      {
+        kind: 'tool_use',
+        id: 'todo-1',
+        name: 'todowrite',
+        input: {
+          todos: [
+            { content: 'Self-check template', status: 'completed' },
+            { content: 'Emit single artifact', status: 'pending' },
+          ],
+        },
+      },
+    ];
+
+    expect(unfinishedTodosFromEvents(events)).toEqual([
+      { content: 'Emit single artifact', status: 'pending', activeForm: undefined },
+    ]);
+  });
+
+  it('uses lowercase todowrite as the latest todo truth over older TodoWrite events', () => {
+    const events: AgentEvent[] = [
+      { kind: 'tool_use', id: 'todo-1', name: 'TodoWrite', input: firstTodoInput },
+      {
+        kind: 'tool_use',
+        id: 'todo-2',
+        name: 'todowrite',
+        input: { todos: [{ content: 'Emit single artifact', status: 'pending' }] },
+      },
+    ];
+
+    expect(latestTodosFromEvents(events)).toEqual([
+      { content: 'Emit single artifact', status: 'pending', activeForm: undefined },
+    ]);
+  });
+
   it('treats an empty latest TodoWrite event as authoritative', () => {
     const events: AgentEvent[] = [
       { kind: 'tool_use', id: 'todo-1', name: 'TodoWrite', input: firstTodoInput },


### PR DESCRIPTION
## Summary

- Fix OpenCode lowercase `todowrite` events being ignored by assistant unfinished-task detection.
- Keep the existing TODO card behavior unchanged while making the footer status use the same tool-name compatibility.
- Add regression coverage for lowercase `todowrite` and latest-event precedence.

## Root cause

OpenCode emits TODO tool events as `todowrite`. `ToolCard` already rendered both `TodoWrite` and `todowrite`, so the TODO card could show `6/7`, but `latestTodosFromEvents()` only scanned for `TodoWrite`. The assistant footer therefore saw no unfinished TODOs and displayed `Done`.

## Validation

- `pnpm --filter @open-design/web test -- apps/web/tests/runtime/todos.test.ts apps/web/tests/components/assistant-message-unfinished-todos.test.tsx`
