### PR TITLE
Fix desktop prompt template close hitbox

### DIFF
--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -108,7 +108,13 @@ const MAC_WINDOW_CHROME_CSS = `
   .ds-modal-backdrop,
   .ds-modal-backdrop *,
   .ds-modal,
-  .ds-modal * {
+  .ds-modal *,
+  .prompt-template-modal-backdrop,
+  .prompt-template-modal-backdrop *,
+  .prompt-template-modal,
+  .prompt-template-modal *,
+  .prompt-template-lightbox-backdrop,
+  .prompt-template-lightbox-backdrop * {
     -webkit-app-region: no-drag;
   }
   .entry-brand,

--- a/apps/web/src/components/PromptTemplatePreviewModal.tsx
+++ b/apps/web/src/components/PromptTemplatePreviewModal.tsx
@@ -96,7 +96,7 @@ export function PromptTemplatePreviewModal({ summary, onClose }: Props) {
           </div>
           <button
             type="button"
-            className="ghost"
+            className="ghost prompt-template-modal-close"
             onClick={onClose}
             aria-label={t('common.close')}
           >

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -11670,23 +11670,40 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   padding: 24px;
 }
 .prompt-template-modal {
+  position: relative;
   background: var(--bg-panel);
   border-radius: 14px;
   width: min(820px, 100%);
   max-height: 90vh;
   display: flex;
   flex-direction: column;
+  min-height: 0;
   border: 1px solid var(--border);
   overflow: hidden;
   box-shadow: 0 32px 80px rgba(0, 0, 0, 0.25);
 }
 .prompt-template-modal-head {
+  flex: 0 0 auto;
   display: flex;
   gap: 12px;
   align-items: flex-start;
-  padding: 18px 18px 0;
+  padding: 18px 66px 0 18px;
+  background: var(--bg-panel);
 }
 .prompt-template-modal-titles { flex: 1; min-width: 0; }
+.prompt-template-modal-close {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  z-index: 20;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: auto;
+}
 .prompt-template-modal-titles h2 {
   font-size: 17px;
   margin: 0 0 6px 0;
@@ -11699,12 +11716,15 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   line-height: 1.45;
 }
 .prompt-template-modal-tags {
+  flex: 0 0 auto;
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
   padding: 10px 18px 0;
 }
 .prompt-template-modal-body {
+  flex: 1 1 auto;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -11859,6 +11879,7 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   overflow: auto;
 }
 .prompt-template-modal-foot {
+  flex: 0 0 auto;
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -11674,7 +11674,8 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   background: var(--bg-panel);
   border-radius: 14px;
   width: min(820px, 100%);
-  max-height: 90vh;
+  max-height: calc(100vh - 48px);
+  max-height: min(90vh, calc(100dvh - 48px));
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -11687,6 +11688,7 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   display: flex;
   gap: 12px;
   align-items: flex-start;
+  min-height: 56px;
   padding: 18px 66px 0 18px;
   background: var(--bg-panel);
 }


### PR DESCRIPTION
## Summary
- mark prompt template preview modal and lightbox as no-drag in the desktop chrome CSS injection
- give the prompt template modal close button a fixed top-layer hitbox
- constrain the modal flex layout so tall content scrolls inside the body

## Validation
- pnpm --filter @open-design/web typecheck
- pnpm --filter @open-design/web test
- pnpm --filter @open-design/desktop typecheck
- pnpm --filter @open-design/desktop build
- Manual packaged macOS smoke: open the prompt template preview modal and lightbox, then click both close buttons to verify neither is captured by the drag region.

<!-- looper:stamp v=1 -->
<sub>Generated by Looper 0.6.0 · runner=fixer · agent=codex</sub>