### PR TITLE
[codex] Increase agent inactivity timeout

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1836,10 +1836,19 @@ export interface StartServerOptions {
   returnServer?: boolean;
 }
 
+const DEFAULT_CHAT_RUN_INACTIVITY_TIMEOUT_MS = 10 * 60 * 1000;
+const MAX_CHAT_RUN_INACTIVITY_TIMEOUT_MS = 24 * 60 * 60 * 1000;
+
 function resolveChatRunInactivityTimeoutMs() {
   const raw = Number(process.env.OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS);
-  if (!Number.isFinite(raw)) return 2 * 60 * 1000;
-  return Math.max(0, Math.floor(raw));
+  // This watchdog observes child stdout/stderr/SSE activity, not real CPU or
+  // filesystem progress. Keep the default long enough for agents that spend
+  // several minutes silently writing large artifacts.
+  if (!Number.isFinite(raw)) return DEFAULT_CHAT_RUN_INACTIVITY_TIMEOUT_MS;
+  // Node clamps delays larger than a signed 32-bit integer down to 1ms, which
+  // makes an oversized override fail almost immediately while reporting a huge
+  // timeout. Keep explicit overrides bounded to a practical, timer-safe value.
+  return Math.min(MAX_CHAT_RUN_INACTIVITY_TIMEOUT_MS, Math.max(0, Math.floor(raw)));
 }
 
 function resolveChatRunShutdownGraceMs() {

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -342,6 +342,43 @@ const timer = setInterval(() => {
     }
   });
 
+  it('caps oversized inactivity overrides so Node does not fire the timer immediately', async () => {
+    const previous = process.env.OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS;
+    process.env.OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS = '10000000000';
+    try {
+      await withFakeAgent(
+        'opencode',
+        `
+setTimeout(() => {
+  console.log(JSON.stringify({ type: 'text', part: { text: 'done' } }));
+  process.exit(0);
+}, 50);
+`,
+        async () => {
+          const createResponse = await fetch(`${baseUrl}/api/runs`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              agentId: 'opencode',
+              message: 'hello',
+            }),
+          });
+          expect(createResponse.status).toBe(202);
+          const { runId } = await createResponse.json() as { runId: string };
+
+          const statusBody = await waitForRunStatus(baseUrl, runId);
+          expect(statusBody.status).toBe('succeeded');
+        },
+      );
+    } finally {
+      if (previous == null) {
+        delete process.env.OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS;
+      } else {
+        process.env.OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS = previous;
+      }
+    }
+  });
+
   it('marks stalled runs failed even when the child ignores SIGTERM', async () => {
     const previous = process.env.OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS;
     process.env.OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS = '500';


### PR DESCRIPTION
## Summary

- Increase the daemon chat-run inactivity watchdog default from 2 minutes to 10 minutes.
- Keep `OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS` as the override for tests and custom deployments.
- Cap oversized inactivity overrides to a timer-safe 24h maximum so Node cannot overflow the delay to 1ms.
- Document that the watchdog tracks child stdout/stderr/SSE silence, not CPU or filesystem progress.

## Why

The previous 120s default could fail valid long-running agent turns while the child process was still working silently, such as writing large artifacts or doing non-streamed reasoning. Codex CLI itself uses a 5-minute model stream idle timeout, so Open Design was timing out earlier than the underlying agent runtime.

The screenshot with `10000000s` is a separate but related overflow path: an oversized millisecond value such as `10000000000` exceeds Node setTimeout signed-32-bit limits. Node then clamps the actual timer to 1ms, making the run fail almost immediately while the UI reports a huge timeout.

## Validation

- PASS: `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/chat-route.test.ts` (19/19)
