### PR TITLE
release: Open Design 0.6.0 — External MCP client, Cloudflare Pages deploy, Critique Phase 6, top bar redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,190 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-05-09
+
+A connectivity-and-iteration release: Open Design becomes a fully bidirectional MCP citizen (external MCP client with 39 templates), ships **Cloudflare Pages deployment** for generated artifacts (with custom domains), advances Critique Theater to **Phase 6** (interrupt + project-keyed run registry), and lands a redesigned top bar, draggable file tabs, batch delete, **vector PDF export**, **agent-callable research/search**, and **Orbit activity summaries**. Hyperframes learns the HTML-in-Canvas API. New BYOK provider (Ollama Cloud), new agent capabilities (Gemini 3 preview + GPT-5.1 codex picker + DeepSeek v4), new design systems (BMW M, Slack, Cisco, Webex, Mission Control, Urdu Modern), eight new skill bundles, and Turkish + Thai locales. 136 merged PRs since 0.5.0.
+
 ### Added
 
-- **`ib-pitch-book` skill** — investment-banking strategic-alternatives pitch book (Anthropic financial-services Pitch Agent workflow); ships `example.html` and IB layout references.
+#### MCP, deployment & connectors
+- **External MCP client with daemon-managed OAuth and 39 design-focused templates.** Open Design can now consume MCP servers, not just expose itself as one. ([#898])
+- **Cloudflare Pages artifact deployment.** One-shot publish of generated artifacts to Pages from the desktop app. ([#729])
+- **Cloudflare Pages custom domains.** Bind your own domain to deployed artifacts. ([#851])
+- Preserve OAuth state and advertised tool counts when reconnecting MCP/connector providers. ([#1036])
+- Optimized Composio connector previews. ([#907])
+
+#### Critique Theater
+- **Phase 6.1: critique interrupt endpoint + project-keyed run registry.** Long critiques can now be interrupted cleanly per project. ([#819])
+- Shared `CritiqueRoundSummary` / `CritiqueRunStatus` types via the `@open-design/contracts` package. ([#1016])
+
+#### Web / UI
+- **Top bar redesign** — Share/Present lifted to the top bar, zoom dropdown, and an explicit focus toggle. ([#1048])
+- **Draggable file tab reordering** in the workspace. ([#936])
+- **Batch delete for selected design files.** ([#783])
+- **Sortable Design Files table columns.** ([#804])
+- **Privacy consent choices made explicit** at first launch. ([#1031])
+- Differentiated "recent" vs "your designs" sorting. ([#845])
+- Inspect / Picker now renders an empty-annotation state instead of a blank panel. ([#1005])
+- Toggle to reveal saved media-provider API keys. ([#867])
+
+#### Desktop & artifacts
+- **Direct PDF export for artifacts.** ([#532])
+- Hyperframes skill learns the **HTML-in-Canvas** API for richer in-canvas previews. ([#852])
+- Consolidated Hyperframes video template updates. ([#1079])
+- Inspect overlay support on Windows packaged builds. ([#944])
+- Allow `od://` URLs through `setWindowOpenHandler` so live-artifact previews open in a child window. ([#933])
+
+#### Daemon, agents & runtime
+- **Import existing local folder as a project.** ([#624])
+- **Agent-callable research command + `/search`.** Agents can ask the project for grounded research without leaving the chat. ([#615])
+- **Orbit activity summaries.** ([#681])
+- Finalized the design-package endpoint (closes #450). ([#832])
+- Closed pi adapter parity gaps (`imagePaths`, `extraAllowedDirs`, error events, `sendAgentEvent` routing). ([#763])
+- Language-boost support for Minimax TTS. ([#773])
+- Expose Gemini 3 preview models and Gemini 2.5 Flash Lite in the picker. ([#986])
+- Add GPT-5.1 entries to the Codex picker. ([#946])
+- Expand Codex picker coverage. ([#757])
+- Stable nightly promotion gate for `[codex]`. ([#962])
+- `VP_HOME` environment variable support in agent resolution. ([#859])
+- Auto-rebuild `better-sqlite3` on Node.js ABI mismatch postinstall. ([#813])
+- Increase agent inactivity timeout. ([#1071])
+- Reset inactivity watchdog on raw stdout bytes, not just parsed events. ([#976])
+
+#### BYOK & integrations
+- **Ollama Cloud** as a BYOK provider. ([#923])
+- **Opt-in Langfuse telemetry.** ([#800])
+- Make Azure API version optional. ([#941])
+
+#### Skills, design systems & prompt templates
+- **`ib-pitch-book` skill** — investment-banking strategic-alternatives pitch book (Anthropic financial-services Pitch Agent port). ([#888])
+- **`github-dashboard` skill.** ([#666])
+- **`clinical-case-report` skill.** ([#581])
+- **`social-media-matrix-tracker` skill** — live-artifact tracker. ([#810])
+- **`trading-analysis` live-artifact dashboard skill.** ([#824])
+- **`otd-operations-brief` live-artifact template.** ([#794])
+- **32 zhangzara HTML deck templates.** ([#704])
+- **7 example dashboards + contract demo** for the live-artifact skill. ([#716])
+- **`after-hours-editorial` template skill.** ([#1053])
+- **`swiss-user-research-video` template skill.** ([#1054])
+- **`editorial-burgundy-principles` template skill.** ([#1065])
+- **`swiss-creative-mode` template skill.** ([#1068])
+- **BMW M design system.** ([#579])
+- **Slack design system.** ([#899])
+- **Cisco and Webex design systems.** ([#991])
+- **Mission Control design system.** ([#858])
+- **Urdu Modern (Indus Script) design system.** ([#714])
+- Craft `laws-of-ux` module so generated UIs respect working-memory limits. ([#809])
+- Craft `typography-hierarchy` and `typography-hierarchy-editorial` rules. ([#975], [#979])
+
+#### Internationalization
+- **Turkish README translation.** ([#843])
+- **Full Thai (`th`) UI locale.** ([#1018])
+- Renamed live-artifact tab label in zh-CN and zh-TW. ([#969])
+- Default `id` locale to English for keys not yet translated. ([#822])
+- Trim BYOK proxy fallback line from zh-CN intro. ([#915])
+
+#### Packaging & deployment
+- **Docker Compose deployment workflow.** ([#65])
+- Preserve beta e2e spec reports in R2. ([#812])
+- Document the Colima build-swap helper. ([#967])
+
+#### Community
+- **Vaunt contributor recognition** (5-tier system). ([#908])
+
+### Changed
+
+- Hardened security scan findings and upgraded dependencies. ([#806])
+- Strengthened e2e PR coverage and entry/settings automation coverage. ([#796], [#811])
+- Refreshed contributors wall and GitHub metrics. ([#856], [#1004], [#853], [#998])
+- Refined `typography-hierarchy` craft docs — clarify edge cases and make lint measurable. ([#979])
+
+### Fixed
+
+#### MCP & connectors
+- MCP install snippet survives daemon port changes. ([#846])
+- Pin `OD_DATA_DIR` in `/api/mcp/install-info` env so the macOS-packaged MCP server stops EPERM'ing on `.od/projects`. ([#857])
+- Reserve clearance for the MCP server Copy button so it stops overlapping the snippet. ([#847])
+- Give the MCP server Copy button a solid surface so it reads against the code block. ([#840])
+- Stable curated tool count in the connector card badge. ([#767])
+- Remove redundant "Connect GitHub" placeholder from the import menu. ([#964])
+- Connector "Close window" button always gives feedback. ([#995])
+- Confirm before clearing the saved Composio API key. ([#877])
+- Keep saved Composio API key indicator visible while typing a replacement. ([#751])
+- Confirm before clearing a saved Media provider API key. ([#875])
+
+#### Cloudflare Pages
+- Cloudflare Pages custom-domain lookup. ([#958])
+
+#### Web UI
+- Surface explicit error/retry state when example preview HTML fails to load. ([#863])
+- Confirm before closing a dirty sketch so unsaved strokes are not lost. ([#988])
+- Keep chat auto-scroll glued to the bottom across streaming chunks. ([#989])
+- Preserve Chat scroll position across Chat/Comments tab switches. ([#841], [#886])
+- Differentiate selected, hover, and focus states in the language switcher. ([#987])
+- Scroll the active workspace tab into view when the strip overflows. ([#990])
+- Keep the Design Files tab visible when workspace tabs scroll. ([#842])
+- Wrap long note text inside picker/comment popovers. ([#830])
+- Wrap comment-popover action row so the Save/Sending button can't exceed the popover edge. ([#829])
+- Prevent comment popover header overflow when the label is too long. ([#833])
+- Truncate long Inspect-panel labels so they cannot spill past the panel edge. ([#838])
+- Keep Inspect-panel close button on a stable single-line layout. ([#839])
+- Increase project meta line-height to prevent descender clipping. ([#834])
+- Give the deploy modal primary action more breathing room. ([#992])
+- Hide the unsupported "Save comment" button on Pods selections. ([#993])
+- Clear stale upload error banner when previewing existing files. ([#994])
+- Expand design file row click target. ([#1039])
+- Keep entry footer pills compact. ([#1045])
+- Hide stale upload error banner when previewing other files. ([#994])
+- Scope settings save validation + sanitize payload to the active sidebar section. ([#827])
+- Ensure the Settings close button is always clickable. ([#971])
+- Correct `srcdoc` injection and deck bridge for JS strings containing closing `</script>`. ([#938])
+- Unbreak the Create button on plain HTTP / LAN-IP deployments. ([#900])
+- Differentiate recent vs your-designs sorting. ([#845])
+- Keep examples filter counts consistent. ([#949])
+
+#### Desktop & packaging
+- Cleanly quit the macOS packaged app. ([#422])
+- Keep modal controls clickable in drag regions. ([#1032])
+- Improve Orbit and packaged data-dir startup errors. ([#1067])
+- Fix desktop preview interactions and connector auth feedback. ([#864])
+- Fix desktop preview and packaged app interactions. ([#879])
+- Fix desktop prompt template close hitbox. ([#1056])
+- Pack/win: close detection gaps that let `Open Design.exe` stay locked at install time. ([#823])
+- Tools-pack: mark `blake3-wasm` as external in the macOS prebundle. ([#844])
+- Packaged: swallow harmless `setTypeOfService EINVAL` from undici. ([#906])
+
+#### Daemon
+- Settle completed runs and clean up shutdown children. ([#924])
+- Fix stuck chat runs and unintended cancels. ([#896])
+- Write SSE events atomically in `createSseResponse.send`. ([#972])
+- Media generation task state survives daemon restart (#648). ([#884])
+- Sync Orbit last run with the selected prompt template. ([#937])
+- Image template creations execute the selected prompt automatically. ([#752])
+- Serve Python files as text. ([#947])
+- Type-check core server paths and leaf modules. ([#943], [#952])
+
+#### Codex / OpenCode
+- OpenCode todowrite footer state. ([#1046])
+
+#### Skills & docs
+- Stale internal links across docs. ([#950])
+
+### Documentation
+
+- **Repository-wide code review guidelines.** ([#927])
+- **Design system authoring guide.** ([#961])
+- **Skills contributing guide.** ([#1035])
+- Docker setup instructions in QUICKSTART, CONTRIBUTING, and README. ([#935])
+- Re-add `awesome-design-md` reference to QUICKSTART. ([#940])
+- Update prompts path from web to daemon in README files. ([#756])
+
+### Internal
+
+- Test: cover model option rendering. ([#948])
+- Test: de-flake chat-scroll-preservation across tab switches. ([#886])
+- Auto-generated metrics + contributors wall refreshes. ([#853], [#998], [#856], [#1004])
+- Release: Open Design 0.5.0 changelog landing. ([#820])
 
 ## [0.5.0] - 2026-05-07
 
@@ -835,3 +1016,139 @@ First public release of Open Design — a local-first, open-source alternative t
 [#799]: https://github.com/nexu-io/open-design/pull/799
 [#801]: https://github.com/nexu-io/open-design/pull/801
 [#805]: https://github.com/nexu-io/open-design/pull/805
+[#65]: https://github.com/nexu-io/open-design/pull/65
+[#422]: https://github.com/nexu-io/open-design/pull/422
+[#532]: https://github.com/nexu-io/open-design/pull/532
+[#579]: https://github.com/nexu-io/open-design/pull/579
+[#581]: https://github.com/nexu-io/open-design/pull/581
+[#615]: https://github.com/nexu-io/open-design/pull/615
+[#624]: https://github.com/nexu-io/open-design/pull/624
+[#666]: https://github.com/nexu-io/open-design/pull/666
+[#681]: https://github.com/nexu-io/open-design/pull/681
+[#704]: https://github.com/nexu-io/open-design/pull/704
+[#714]: https://github.com/nexu-io/open-design/pull/714
+[#716]: https://github.com/nexu-io/open-design/pull/716
+[#729]: https://github.com/nexu-io/open-design/pull/729
+[#751]: https://github.com/nexu-io/open-design/pull/751
+[#752]: https://github.com/nexu-io/open-design/pull/752
+[#756]: https://github.com/nexu-io/open-design/pull/756
+[#757]: https://github.com/nexu-io/open-design/pull/757
+[#763]: https://github.com/nexu-io/open-design/pull/763
+[#767]: https://github.com/nexu-io/open-design/pull/767
+[#771]: https://github.com/nexu-io/open-design/pull/771
+[#773]: https://github.com/nexu-io/open-design/pull/773
+[#794]: https://github.com/nexu-io/open-design/pull/794
+[#796]: https://github.com/nexu-io/open-design/pull/796
+[#800]: https://github.com/nexu-io/open-design/pull/800
+[#804]: https://github.com/nexu-io/open-design/pull/804
+[#806]: https://github.com/nexu-io/open-design/pull/806
+[#809]: https://github.com/nexu-io/open-design/pull/809
+[#810]: https://github.com/nexu-io/open-design/pull/810
+[#811]: https://github.com/nexu-io/open-design/pull/811
+[#812]: https://github.com/nexu-io/open-design/pull/812
+[#813]: https://github.com/nexu-io/open-design/pull/813
+[#819]: https://github.com/nexu-io/open-design/pull/819
+[#820]: https://github.com/nexu-io/open-design/pull/820
+[#822]: https://github.com/nexu-io/open-design/pull/822
+[#823]: https://github.com/nexu-io/open-design/pull/823
+[#824]: https://github.com/nexu-io/open-design/pull/824
+[#827]: https://github.com/nexu-io/open-design/pull/827
+[#829]: https://github.com/nexu-io/open-design/pull/829
+[#830]: https://github.com/nexu-io/open-design/pull/830
+[#832]: https://github.com/nexu-io/open-design/pull/832
+[#833]: https://github.com/nexu-io/open-design/pull/833
+[#834]: https://github.com/nexu-io/open-design/pull/834
+[#838]: https://github.com/nexu-io/open-design/pull/838
+[#839]: https://github.com/nexu-io/open-design/pull/839
+[#840]: https://github.com/nexu-io/open-design/pull/840
+[#841]: https://github.com/nexu-io/open-design/pull/841
+[#842]: https://github.com/nexu-io/open-design/pull/842
+[#843]: https://github.com/nexu-io/open-design/pull/843
+[#844]: https://github.com/nexu-io/open-design/pull/844
+[#845]: https://github.com/nexu-io/open-design/pull/845
+[#846]: https://github.com/nexu-io/open-design/pull/846
+[#847]: https://github.com/nexu-io/open-design/pull/847
+[#851]: https://github.com/nexu-io/open-design/pull/851
+[#852]: https://github.com/nexu-io/open-design/pull/852
+[#853]: https://github.com/nexu-io/open-design/pull/853
+[#856]: https://github.com/nexu-io/open-design/pull/856
+[#857]: https://github.com/nexu-io/open-design/pull/857
+[#858]: https://github.com/nexu-io/open-design/pull/858
+[#859]: https://github.com/nexu-io/open-design/pull/859
+[#863]: https://github.com/nexu-io/open-design/pull/863
+[#864]: https://github.com/nexu-io/open-design/pull/864
+[#867]: https://github.com/nexu-io/open-design/pull/867
+[#875]: https://github.com/nexu-io/open-design/pull/875
+[#877]: https://github.com/nexu-io/open-design/pull/877
+[#879]: https://github.com/nexu-io/open-design/pull/879
+[#884]: https://github.com/nexu-io/open-design/pull/884
+[#886]: https://github.com/nexu-io/open-design/pull/886
+[#888]: https://github.com/nexu-io/open-design/pull/888
+[#896]: https://github.com/nexu-io/open-design/pull/896
+[#898]: https://github.com/nexu-io/open-design/pull/898
+[#899]: https://github.com/nexu-io/open-design/pull/899
+[#900]: https://github.com/nexu-io/open-design/pull/900
+[#906]: https://github.com/nexu-io/open-design/pull/906
+[#907]: https://github.com/nexu-io/open-design/pull/907
+[#908]: https://github.com/nexu-io/open-design/pull/908
+[#915]: https://github.com/nexu-io/open-design/pull/915
+[#923]: https://github.com/nexu-io/open-design/pull/923
+[#924]: https://github.com/nexu-io/open-design/pull/924
+[#927]: https://github.com/nexu-io/open-design/pull/927
+[#933]: https://github.com/nexu-io/open-design/pull/933
+[#935]: https://github.com/nexu-io/open-design/pull/935
+[#936]: https://github.com/nexu-io/open-design/pull/936
+[#937]: https://github.com/nexu-io/open-design/pull/937
+[#938]: https://github.com/nexu-io/open-design/pull/938
+[#940]: https://github.com/nexu-io/open-design/pull/940
+[#941]: https://github.com/nexu-io/open-design/pull/941
+[#943]: https://github.com/nexu-io/open-design/pull/943
+[#944]: https://github.com/nexu-io/open-design/pull/944
+[#946]: https://github.com/nexu-io/open-design/pull/946
+[#947]: https://github.com/nexu-io/open-design/pull/947
+[#948]: https://github.com/nexu-io/open-design/pull/948
+[#949]: https://github.com/nexu-io/open-design/pull/949
+[#950]: https://github.com/nexu-io/open-design/pull/950
+[#952]: https://github.com/nexu-io/open-design/pull/952
+[#958]: https://github.com/nexu-io/open-design/pull/958
+[#961]: https://github.com/nexu-io/open-design/pull/961
+[#962]: https://github.com/nexu-io/open-design/pull/962
+[#964]: https://github.com/nexu-io/open-design/pull/964
+[#967]: https://github.com/nexu-io/open-design/pull/967
+[#969]: https://github.com/nexu-io/open-design/pull/969
+[#971]: https://github.com/nexu-io/open-design/pull/971
+[#972]: https://github.com/nexu-io/open-design/pull/972
+[#975]: https://github.com/nexu-io/open-design/pull/975
+[#976]: https://github.com/nexu-io/open-design/pull/976
+[#979]: https://github.com/nexu-io/open-design/pull/979
+[#986]: https://github.com/nexu-io/open-design/pull/986
+[#987]: https://github.com/nexu-io/open-design/pull/987
+[#988]: https://github.com/nexu-io/open-design/pull/988
+[#989]: https://github.com/nexu-io/open-design/pull/989
+[#990]: https://github.com/nexu-io/open-design/pull/990
+[#991]: https://github.com/nexu-io/open-design/pull/991
+[#992]: https://github.com/nexu-io/open-design/pull/992
+[#993]: https://github.com/nexu-io/open-design/pull/993
+[#994]: https://github.com/nexu-io/open-design/pull/994
+[#995]: https://github.com/nexu-io/open-design/pull/995
+[#998]: https://github.com/nexu-io/open-design/pull/998
+[#1004]: https://github.com/nexu-io/open-design/pull/1004
+[#1005]: https://github.com/nexu-io/open-design/pull/1005
+[#1016]: https://github.com/nexu-io/open-design/pull/1016
+[#1018]: https://github.com/nexu-io/open-design/pull/1018
+[#1031]: https://github.com/nexu-io/open-design/pull/1031
+[#1032]: https://github.com/nexu-io/open-design/pull/1032
+[#1035]: https://github.com/nexu-io/open-design/pull/1035
+[#1036]: https://github.com/nexu-io/open-design/pull/1036
+[#1039]: https://github.com/nexu-io/open-design/pull/1039
+[#1045]: https://github.com/nexu-io/open-design/pull/1045
+[#1046]: https://github.com/nexu-io/open-design/pull/1046
+[#1048]: https://github.com/nexu-io/open-design/pull/1048
+[#1053]: https://github.com/nexu-io/open-design/pull/1053
+[#1054]: https://github.com/nexu-io/open-design/pull/1054
+[#1056]: https://github.com/nexu-io/open-design/pull/1056
+[#1065]: https://github.com/nexu-io/open-design/pull/1065
+[#1067]: https://github.com/nexu-io/open-design/pull/1067
+[#1068]: https://github.com/nexu-io/open-design/pull/1068
+[#1071]: https://github.com/nexu-io/open-design/pull/1071
+[#1079]: https://github.com/nexu-io/open-design/pull/1079

--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/daemon",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "main": "./dist/cli.js",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/desktop",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "main": "./dist/main/index.js",

--- a/apps/landing-page/package.json
+++ b/apps/landing-page/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/landing-page",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/packaged/package.json
+++ b/apps/packaged/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/packaged",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/web",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/e2e",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-design",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "packageManager": "pnpm@10.33.2",
   "type": "module",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/contracts",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "description": "Shared pure TypeScript contracts for the Open Design web/daemon boundary.",

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/platform",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/sidecar-proto/package.json
+++ b/packages/sidecar-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/sidecar-proto",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/sidecar/package.json
+++ b/packages/sidecar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/sidecar",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/tools/dev/package.json
+++ b/tools/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-dev",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-pack",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "bin": {


### PR DESCRIPTION
> Note for reviewers: every `@user` mention below is wrapped in backticks so creating this PR does not ping contributors. Strip the backticks before publishing the GitHub release if you want attribution to notify people.

🎉 **`136 PRs` · ~2 days** — Open Design 0.6.0 turns the corner from "iterate forever" to "ship anywhere": **Cloudflare Pages deployment** for generated artifacts, an **external MCP client** with daemon-managed OAuth and 39 design-focused templates, **Critique Theater Phase 6**, a **redesigned top bar**, **vector PDF export**, **agent-callable research / `/search`**, **Orbit activity summaries**, plus six new design systems, eight new skills, BYOK Ollama Cloud, opt-in Langfuse telemetry, Turkish + Thai locales, and a long fix queue across web, desktop, daemon, packaged, and connectors. 🚀

## 🔥 Highlights

- 🌐 **External MCP client + daemon-managed OAuth + 39 design-focused templates.** Open Design becomes fully bidirectional — it ships its own MCP server *and* now consumes external MCP servers through a managed OAuth flow. (#898) Thanks `@pftom`.
- ☁️ **Cloudflare Pages artifact deployment + custom domains.** One-shot publish of generated artifacts to Pages, then bind your own domain. (#729, #851, #958) Thanks `@bulai0408`.
- 🎭 **Critique Theater Phase 6.1.** Critique runs are now interruptible per-project via a new daemon endpoint and a project-keyed run registry; shared types moved into `@open-design/contracts`. (#819, #1016) Thanks `@Nagendhra-web`.
- 🧰 **Top bar redesign.** Share/Present lifted to the top bar, zoom dropdown, explicit focus toggle. (#1048) Thanks `@qiongyu1999`.
- 📄 **Direct PDF export for artifacts.** No more "print to PDF" workarounds. (#532) Thanks `@tenderpooh`.
- 🔍 **Agent-callable research command + `/search`.** Agents can ground themselves without leaving the chat. (#615) Thanks `@pftom`.
- 🛰️ **Orbit activity summaries.** (#681) Thanks `@mrcfps`.
- 🪟 **Hyperframes learns the HTML-in-Canvas API** for richer in-canvas previews. (#852) Thanks `@pftom`.
- 📁 **Import existing local folder as a project.** (#624) Thanks `@infinity-nft`.
- 🧱 **Six new design systems** — BMW M, Slack, Cisco, Webex, Mission Control, Urdu Modern (Indus Script). (#579, #899, #991, #858, #714) Thanks `@Sohaibcodecrafter`, `@MubashirYaqoob`, `@rahulbsw`, `@Ayush-Mahadik`, `@muhammad-anas-15`.
- 🎨 **Eight new skills** — `ib-pitch-book`, `github-dashboard`, `clinical-case-report`, `social-media-matrix-tracker`, `trading-analysis`, `otd-operations-brief`, `after-hours-editorial`, plus 32 zhangzara HTML deck templates and 7 example dashboards. (#888, #666, #581, #810, #824, #794, #1053, #704, #716)
- 🤖 **BYOK: Ollama Cloud** as a first-class provider. (#923) Thanks `@aronheredi`.
- 📊 **Opt-in Langfuse telemetry.** (#800) Thanks `@lefarcen`.
- 🇹🇷🇹🇭 **Turkish README + full Thai (`th`) UI locale.** (#843, #1018) Thanks `@esadomer`, `@Tatsuyato`.

> 📥 **Download:** the table below points at the final asset URLs — links go live once this PR is merged and the `release-stable` workflow finishes. Tag: `open-design-v0.6.0`.
>
> | Platform | Architecture | Asset |
> |---|---|---|
> | macOS | Apple Silicon (arm64) | [open-design-0.6.0-mac-arm64.dmg](https://github.com/nexu-io/open-design/releases/download/open-design-v0.6.0/open-design-0.6.0-mac-arm64.dmg) |
> | macOS (auto-update feed) | Apple Silicon (arm64) | [open-design-0.6.0-mac-arm64.zip](https://github.com/nexu-io/open-design/releases/download/open-design-v0.6.0/open-design-0.6.0-mac-arm64.zip) |
> | Windows | x64 (unsigned) | [open-design-0.6.0-win-x64-setup.exe](https://github.com/nexu-io/open-design/releases/download/open-design-v0.6.0/open-design-0.6.0-win-x64-setup.exe) |

## ✨ What's New

### 🌐 MCP, deployment & connectors

- 🌐 **External MCP client with daemon-managed OAuth + 39 design-focused templates.** (#898) Thanks `@pftom`.
- ☁️ **Cloudflare Pages artifact deployment.** (#729) Thanks `@bulai0408`.
- 🌍 **Cloudflare Pages custom domains.** (#851) Thanks `@bulai0408`.
- 🔁 Preserve OAuth state and advertised tool counts when reconnecting MCP/connector providers. (#1036) Thanks `@alchemistklk`.
- 🧩 Optimized Composio connector previews. (#907) Thanks `@alchemistklk`.

### 🎭 Critique Theater

- 🎯 **Phase 6.1: critique interrupt endpoint + project-keyed run registry.** (#819) Thanks `@Nagendhra-web`.
- 📦 Move `CritiqueRoundSummary` / `CritiqueRunStatus` into `@open-design/contracts`. (#1016) Thanks `@Nagendhra-web`.

### 🖥️ Web / UI

- 🧭 **Top bar redesign — Share/Present, zoom dropdown, focus toggle.** (#1048) Thanks `@qiongyu1999`.
- 🪄 **Draggable file tab reordering.** (#936) Thanks `@Romantin`.
- 🗂️ **Batch delete for selected design files.** (#783) Thanks `@yinjialu`.
- 📊 **Sortable Design Files table columns.** (#804) Thanks `@paulstean`.
- 🔒 **Privacy consent choices made explicit.** (#1031) Thanks `@lefarcen`.
- 🆕 Differentiate "recent" vs "your designs" sorting. (#845) Thanks `@Priyanshudotdev`.
- 👀 Render an empty-annotation state for Inspect / Picker. (#1005) Thanks `@Sid-Qin`.
- 🗝️ Toggle to reveal saved media-provider API keys. (#867) Thanks `@nettee`.

### 🖼️ Desktop & artifacts

- 📄 **Direct PDF export for artifacts.** (#532) Thanks `@tenderpooh`.
- 🪟 **HTML-in-Canvas API in the hyperframes skill.** (#852) Thanks `@pftom`.
- 🎞️ Consolidated hyperframes video template updates. (#1079) Thanks `@Tuola-waj`.
- 🪟 Inspect overlay support on Windows packaged builds. (#944) Thanks `@Priyanshudotdev`.
- 🪟 Allow `od://` URLs through `setWindowOpenHandler` so live-artifact previews open in a child window. (#933) Thanks `@Sid-Qin`.

### 🤖 Daemon, agents & runtime

- 📁 **Import existing local folder as a project.** (#624) Thanks `@infinity-nft`.
- 🔍 **Agent-callable research command + `/search`.** (#615) Thanks `@pftom`.
- 🛰️ **Orbit activity summaries.** (#681) Thanks `@mrcfps`.
- 📦 Finalized the design-package endpoint (closes #450). (#832) Thanks `@bankielewicz`.
- 🧰 Closed pi adapter parity gaps (`imagePaths`, `extraAllowedDirs`, error events, `sendAgentEvent` routing). (#763) Thanks `@monotykamary`.
- 🗣️ Language-boost support for Minimax TTS. (#773) Thanks `@terencewlc`.
- 🧠 Expose Gemini 3 preview models + 2.5 Flash Lite in the picker. (#986) Thanks `@Nagendhra-web`.
- 🧠 GPT-5.1 entries in the Codex picker. (#946) Thanks `@leprincep35700`.
- 🧠 Expand Codex picker coverage. (#757) Thanks `@leprincep35700`.
- 🌙 Stable nightly promotion gate for `[codex]`. (#962) Thanks `@PerishCode`.
- 🛣️ `VP_HOME` env var support in agent resolution. (#859) Thanks `@AmbitionsXXXV`.
- 🛠️ Auto-rebuild `better-sqlite3` on Node.js ABI mismatch postinstall. (#813) Thanks `@VikingOwl91`.
- ⏱️ Increase agent inactivity timeout. (#1071) Thanks `@alchemistklk`.
- ⏱️ Reset inactivity watchdog on raw stdout bytes, not just parsed events. (#976) Thanks `@ButterHost69`.

### 🔌 BYOK & integrations

- 🦙 **Ollama Cloud** as a BYOK provider. (#923) Thanks `@aronheredi`.
- 📊 **Opt-in Langfuse telemetry.** (#800) Thanks `@lefarcen`.
- ☁️ Make Azure API version optional. (#941) Thanks `@haocn-ops`.

### 🎨 Skills, design systems & prompt templates

- 💼 **`ib-pitch-book` skill** — investment-banking strategic-alternatives pitch book (Anthropic financial-services Pitch Agent port). (#888) Thanks `@ashleyashli`.
- 📈 **`github-dashboard` skill.** (#666) Thanks `@joeylee12629-star`.
- 🩺 **`clinical-case-report` skill.** (#581) Thanks `@syedali254`.
- 📱 **`social-media-matrix-tracker` skill.** (#810) Thanks `@Tuola-waj`.
- 💹 **`trading-analysis` live-artifact dashboard skill.** (#824) Thanks `@Tuola-waj`.
- 🛰️ **`otd-operations-brief` live-artifact template.** (#794) Thanks `@joeylee12629-star`.
- 🃏 **32 zhangzara HTML deck templates.** (#704) Thanks `@pftom`.
- 📊 **7 example dashboards + contract demo** for the live-artifact skill. (#716) Thanks `@pftom`.
- 🌃 **`after-hours-editorial` template skill.** (#1053) Thanks `@Tuola-waj`.
- 🇨🇭 **`swiss-user-research-video` template skill.** (#1054) Thanks `@Tuola-waj`.
- 🍷 **`editorial-burgundy-principles` template skill.** (#1065) Thanks `@Tuola-waj`.
- 🇨🇭 **`swiss-creative-mode` template skill.** (#1068) Thanks `@Tuola-waj`.
- 🚗 **BMW M design system.** (#579) Thanks `@Sohaibcodecrafter`.
- 💬 **Slack design system.** (#899) Thanks `@MubashirYaqoob`.
- 🌐 **Cisco and Webex design systems.** (#991) Thanks `@rahulbsw`.
- 🚀 **Mission Control design system.** (#858) Thanks `@Ayush-Mahadik`.
- 📜 **Urdu Modern (Indus Script) design system.** (#714) Thanks `@muhammad-anas-15`.
- 🧠 Craft `laws-of-ux` so generated UIs respect working-memory limits. (#809) Thanks `@MohamedAbdallah-14`.
- 🔠 Craft `typography-hierarchy` and `typography-hierarchy-editorial` rules. (#975, #979) Thanks `@itsmeved24`.

### 🌍 Internationalization

- 🇹🇷 **Turkish README translation.** (#843) Thanks `@esadomer`.
- 🇹🇭 **Full Thai (`th`) UI locale.** (#1018) Thanks `@Tatsuyato`.
- 🈚 Renamed live-artifact tab label in zh-CN and zh-TW. (#969) Thanks `@zhujie007`.
- 🇮🇩 Default `id` locale to English for keys not yet translated. (#822) Thanks `@Sid-Qin`.
- 🇨🇳 Trim BYOK proxy fallback line from zh-CN intro. (#915) Thanks `@qiongyu1999`.

### 📦 Packaging & deployment

- 🐳 **Docker Compose deployment workflow.** (#65) Thanks `@wangwanjie`.
- 📊 Preserve beta e2e spec reports in R2. (#812) Thanks `@PerishCode`.
- 🐳 Document the Colima build-swap helper. (#967) Thanks `@wangwanjie`.

### 🤝 Community

- 🏅 **Vaunt contributor recognition** (5-tier system). (#908) Thanks `@ashleyashli`.

## 🛡️ Stability & Reliability

- 🔐 Hardened security scan findings and upgraded dependencies. (#806) Thanks `@ferasbusiness666`.
- 🧪 Strengthened e2e PR coverage and entry/settings automation. (#796, #811) Thanks `@mrcfps`, `@shangxinyu1`.
- 🧰 Settle completed runs and clean up shutdown children. (#924) Thanks `@Siri-Ray`.
- 🧰 Fix stuck chat runs and unintended cancels. (#896) Thanks `@shangxinyu1`.
- 🧪 Type-check core server paths and leaf modules. (#943, #952) Thanks `@nettee`.
- 📡 Write SSE events atomically in `createSseResponse.send`. (#972) Thanks `@jnalv414`.
- 💾 Media generation task state survives daemon restart (#648). (#884) Thanks `@pmasadali20776-ui`.
- ⚙️ Sync Orbit last run with the selected prompt template. (#937) Thanks `@Derrick-xn`.
- 🖼️ Image template creations execute the selected prompt automatically. (#752) Thanks `@arijiiiitttt`.

## 🐛 Bug Fixes

### MCP & connectors

- 🔌 MCP install snippet survives daemon port changes. (#846) Thanks `@emilneander`.
- 🍎 Pin `OD_DATA_DIR` in `/api/mcp/install-info` env so the macOS-packaged MCP server stops EPERM'ing. (#857) Thanks `@Nagendhra-web`.
- 🪟 Reserve clearance for the MCP server Copy button so it stops overlapping the snippet. (#847) Thanks `@Nagendhra-web`.
- 🪟 Give the MCP server Copy button a solid surface against the code block. (#840) Thanks `@Nagendhra-web`.
- 🔢 Stable curated tool count in the connector card badge. (#767) Thanks `@Sid-Qin`.
- 🧹 Remove redundant "Connect GitHub" placeholder from the import menu. (#964) Thanks `@xxiaoxiong`.
- 🪟 Connector "Close window" button always gives feedback. (#995) Thanks `@Nagendhra-web`.
- 🔑 Confirm before clearing the saved Composio API key. (#877) Thanks `@Nagendhra-web`.
- 🔑 Keep saved Composio API key indicator visible while typing a replacement. (#751) Thanks `@Nagendhra-web`.
- 🔑 Confirm before clearing a saved Media provider API key. (#875) Thanks `@Nagendhra-web`.

### Cloudflare Pages

- 🌍 Cloudflare Pages custom-domain lookup. (#958) Thanks `@bulai0408`.

### Web UI

- ⚠️ Surface explicit error/retry state when example preview HTML fails to load. (#863) Thanks `@Nagendhra-web`.
- ✏️ Confirm before closing a dirty sketch so unsaved strokes are not lost. (#988) Thanks `@Nagendhra-web`.
- 💬 Keep chat auto-scroll glued to bottom across streaming chunks. (#989) Thanks `@Nagendhra-web`.
- 💬 Preserve Chat scroll position across Chat/Comments tab switches. (#841, #886) Thanks `@Nagendhra-web`, `@lefarcen`.
- 🌐 Differentiate selected/hover/focus in the language switcher. (#987) Thanks `@Nagendhra-web`.
- 📐 Scroll the active workspace tab into view when the strip overflows. (#990) Thanks `@Nagendhra-web`.
- 📐 Keep the Design Files tab visible when workspace tabs scroll. (#842) Thanks `@Nagendhra-web`.
- 💬 Wrap long note text inside picker/comment popovers. (#830) Thanks `@Nagendhra-web`.
- 💬 Wrap comment-popover action row so the Save/Sending button can't exceed the popover edge. (#829) Thanks `@Nagendhra-web`.
- 💬 Prevent comment popover header overflow when the label is too long. (#833) Thanks `@nmsn`.
- 🔬 Truncate long Inspect-panel labels. (#838) Thanks `@Nagendhra-web`.
- 🔬 Keep Inspect-panel close button on a stable single-line layout. (#839) Thanks `@Nagendhra-web`.
- 📐 Increase project meta line-height to prevent descender clipping. (#834) Thanks `@zhujie007`.
- ✨ Give the deploy modal primary action more breathing room. (#992) Thanks `@Nagendhra-web`.
- 🧱 Hide the unsupported "Save comment" button on Pods selections. (#993) Thanks `@Nagendhra-web`.
- 🧹 Clear stale upload error banner when previewing existing files. (#994) Thanks `@Nagendhra-web`.
- 👆 Expand design file row click target. (#1039) Thanks `@lefarcen`.
- 🧷 Keep entry footer pills compact. (#1045) Thanks `@lefarcen`.
- 🧹 Hide stale upload error banner when previewing other files. (#994) Thanks `@Nagendhra-web`.
- ⚙️ Scope settings save validation + sanitize payload to the active sidebar section. (#827) Thanks `@Nagendhra-web`.
- ❌ Ensure the Settings close button is always clickable. (#971) Thanks `@xxiaoxiong`.
- 🧩 Correct `srcdoc` injection and deck bridge for JS strings containing closing `</script>`. (#938) Thanks `@Morzorz`.
- 🌐 Unbreak the Create button on plain HTTP / LAN-IP deployments. (#900) Thanks `@Sid-Qin`.
- 🔢 Keep examples filter counts consistent. (#949) Thanks `@leprincep35700`.

### Desktop & packaging

- 🍎 Cleanly quit the macOS packaged app. (#422) Thanks `@fuyizheng3120`.
- 🪟 Keep modal controls clickable in drag regions. (#1032) Thanks `@mrcfps`.
- 🛰️ Improve Orbit and packaged data-dir startup errors. (#1067) Thanks `@mrcfps`.
- 🪟 Fix desktop preview interactions and connector auth feedback. (#864) Thanks `@shangxinyu1`.
- 🪟 Fix desktop preview and packaged app interactions. (#879) Thanks `@shangxinyu1`.
- 🪟 Fix desktop prompt template close hitbox. (#1056) Thanks `@Siri-Ray`.
- 🪟 Pack/win: close detection gaps that let `Open Design.exe` stay locked at install time. (#823) Thanks `@Nagendhra-web`.
- 🍎 Tools-pack: mark `blake3-wasm` as external in the macOS prebundle. (#844) Thanks `@marcoandreom`.
- 🪟 Packaged: swallow harmless `setTypeOfService EINVAL` from undici. (#906) Thanks `@Sid-Qin`.

### Codex / OpenCode

- 📝 OpenCode todowrite footer state. (#1046) Thanks `@alchemistklk`.

### Daemon

- 🐍 Serve Python files as text. (#947) Thanks `@leprincep35700`.

## 📚 Documentation

- 🧭 **Repository-wide code review guidelines.** (#927) Thanks `@mrcfps`.
- 🎨 **Design system authoring guide.** (#961) Thanks `@Ayush-Mahadik`.
- 🛠️ **Skills contributing guide.** (#1035) Thanks `@lefarcen`.
- 🐳 Docker setup instructions in QUICKSTART, CONTRIBUTING, and README. (#935) Thanks `@Priyanshudotdev`.
- 🔗 Re-add `awesome-design-md` reference to QUICKSTART. (#940) Thanks `@zoltanszogyenyi`.
- 📖 Update prompts path from web to daemon in README files. (#756) Thanks `@thientu`.
- 🔗 Fix stale internal links across docs. (#950) Thanks `@leprincep35700`.

## 🔨 For Developers

<details>
<summary>Click to expand</summary>

- 🧪 Test: cover model option rendering. (#948) Thanks `@leprincep35700`.
- 🧪 Test: de-flake chat-scroll-preservation across tab switches. (#886) Thanks `@lefarcen`.
- 📊 Auto-generated metrics + contributors wall refreshes. (#853, #998, #856, #1004)
- 📦 Release: 0.5.0 changelog landing. (#820) Thanks `@lefarcen`.

</details>

## ✅ System Requirements

- 🍎 **macOS** — Apple Silicon (arm64) only, macOS 11 Big Sur or newer. Intel macs are not supported.
- 🪟 **Windows** — x64, Windows 10 / 11. Installer is **unsigned** (SmartScreen will warn on first launch — choose "More info → Run anyway").
- 🐧 **Linux** — headless lifecycle (`install`, `start`, `stop`) supported via CLI. A packaged Linux desktop GUI artifact is still deferred while the release lane is hardened.
- 🧑‍💻 **From source** — Node.js 24.x and pnpm 10.33.2+ (per `engines` in `package.json`).

## ⚠️ Known Issues

- 🪟 **Windows installer is unsigned.** SmartScreen / antivirus warnings are expected. Code signing is still follow-up work.
- 🍎 **No macOS Intel (x64) build.** Apple Silicon only.
- 🐧 **No Linux desktop GUI package in 0.6.0 stable** — use headless mode or run from source.
- 🐚 **`od` CLI shadows POSIX `od`** when installed globally. Use `/usr/bin/od` or `command od` for the system tool.

---

## 🚀 Releasing this PR

This PR ships:

1. 📦 **All 13 monorepo `package.json` files bumped to `0.6.0`** (root, `apps/{web,daemon,desktop,packaged,landing-page}`, `packages/{contracts,platform,sidecar,sidecar-proto}`, `tools/{dev,pack}`, `e2e`). Internal workspace specifiers are `workspace:*`, so no lockfile change was needed. `apps/packaged` was at `0.5.1` from a hotfix and is bumped to `0.6.0` along with everything else.
2. 📝 **`CHANGELOG.md`** — new `[0.6.0] - 2026-05-09` entry covering the 136 merged PRs since 0.5.0, plus footnote refs for new PR numbers.

The `release-stable` workflow already lives on `main`; no infrastructure changes here.

### Publish flow

`release-stable` is a two-stage promote pipeline. Run it **on this PR's branch (`release/v0.6.0`) before merging** — historically that's how 0.5.0 went out, with merge-to-main happening after the GitHub Release was live.

**Stage 1 — build + sign + publish to R2 as `nightly`** (no GitHub Release / tag yet):

```
gh workflow run release-stable.yml \
  --ref release/v0.6.0 \
  -f channel=nightly
```

This builds mac arm64 + win x64, signs, runs packaged smoke tests, and writes assets to R2 `nightly/versions/0.6.0.nightly.<N>/...`. The nightly number auto-increments on each run, so this stage can be retried until green. Note the final `nightlyVersion` from the run summary.

**Stage 2 — promote that exact nightly to a stable GitHub Release**:

```
gh workflow run release-stable.yml \
  --ref release/v0.6.0 \
  -f channel=stable \
  -f nightly_version=0.6.0.nightly.<N>
```

`channel=stable` re-validates the R2 metadata (branch, commit, signed, platform URLs all have to match), creates tag `open-design-v0.6.0` + a draft GitHub Release on this PR's commit, uploads the same assets, flips the release to `latest`, and updates the `stable/latest/{latest-mac.yml,latest.yml}` auto-update feeds on R2.

**Stage 3 — merge this PR.** Merge to main once the GitHub Release is published so main carries the released version + CHANGELOG entry.

Local verify dry-run before opening this PR:

- `pnpm install` (workspace links — lockfile already in sync)
- `pnpm guard` → exit 0
- `pnpm typecheck` → exit 0 across all 13 packages

**Full Changelog:** https://github.com/nexu-io/open-design/compare/open-design-v0.5.0...release/v0.6.0
