### PR TITLE
fix(desktop): allow about:blank popup for PDF export fallback

### DIFF
--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -228,7 +228,15 @@ export function isAllowedChildWindowUrl(url: string): boolean {
     // its links resolve to `http://127.0.0.1:.../...`, which is gated
     // by the separate `isHttpUrl` branch and continues to open in the
     // user's external browser via `shell.openExternal`.
-    return parsed.protocol === "blob:" || parsed.protocol === "od:";
+    // `about:blank` is used by the renderer's PDF export fallback path:
+    // `window.open('', '_blank')` opens a blank window that is then
+    // navigated to a Blob URL. Without this, the empty URL is denied
+    // and the user sees a "Popup blocked" alert.
+    return (
+      parsed.protocol === "blob:" ||
+      parsed.protocol === "od:" ||
+      (parsed.protocol === "about:" && parsed.pathname === "blank")
+    );
   } catch {
     return false;
   }


### PR DESCRIPTION
## Problem

The PDF export fallback path uses `window.open(''_blank')` to open a blank window that is then navigated to a Blob URL. However, Electron's `setWindowOpenHandler` in `isAllowedChildWindowUrl` only allowed `blob:` and `od:` protocols, so the `about:blank` URL was silently denied.

This caused `window.open` to return `null`, triggering a "Popup blocked" alert for the user.

## Fix

Add `about:blank` to the allowed child window URL whitelist in `isAllowedChildWindowUrl`. The window is immediately navigated to a Blob URL after opening, so allowing `about:blank` is safe and scoped to the PDF export fallback flow.

## Affected File

- `apps/desktop/src/main/runtime.ts`