### PR TITLE
feat(daemon): Critique Theater Phase 6.2 (artifact extraction + endpoint)

### DIFF
--- a/apps/daemon/src/critique/artifact-handler.ts
+++ b/apps/daemon/src/critique/artifact-handler.ts
@@ -1,0 +1,218 @@
+import { promises as fs, constants as fsConstants } from 'node:fs';
+import * as path from 'node:path';
+import type { Request, Response } from 'express';
+import type Database from 'better-sqlite3';
+import { getCritiqueRun } from './persistence.js';
+import { mimeForExtension } from './artifact-writer.js';
+
+/** HTTP status codes used by the artifact endpoint. */
+const HTTP_BAD_REQUEST = 400;
+const HTTP_NOT_FOUND = 404;
+const HTTP_OK = 200;
+
+/**
+ * Default response size cap when the caller doesn't pass one. Used as the
+ * floor: an instance with `OD_CRITIQUE_PARSER_MAX_BLOCK_BYTES` raised above
+ * this value gets the larger cap so every artifact the orchestrator + writer
+ * accepted is retrievable. Codex P2 on PR #1085: hard-coding 4 MiB here
+ * while the writer accepted up to `cfg.parserMaxBlockBytes` made accepted
+ * rows unretrievable in raised-limit deployments.
+ */
+const DEFAULT_RESPONSE_SIZE_CAP_BYTES = 4 * 1024 * 1024;
+
+/**
+ * GET /api/projects/:projectId/critique/:runId/artifact
+ *
+ * Streams the bytes the orchestrator wrote for the run's SHIP `<ARTIFACT>`
+ * block, with the mime type derived from the file extension on disk. This
+ * is the daemon-resolved logical handle the web layer fetches; clients
+ * never receive a raw filesystem path. Cross-project leak guard mirrors
+ * the interrupt handler: a request against project p1 must not surface a
+ * runId that belongs to p2.
+ *
+ * Status semantics:
+ *   200 — happy path; body is the artifact bytes with the right mime.
+ *   400 — projectId/runId missing or whitespace-only.
+ *   404 — run not found, cross-project leak, no artifact persisted, or
+ *         the on-disk file disappeared (bytes never made it to the row).
+ *
+ * @see specs/current/critique-theater.md § rerun endpoint (Task 6.2)
+ */
+export function handleCritiqueArtifact(
+  db: Database.Database,
+  options: { artifactsRoot: string; responseCapBytes?: number },
+): (req: Request, res: Response) => Promise<void> {
+  const artifactsRoot = path.resolve(options.artifactsRoot);
+  // Honor the configured cap as-is when it's a positive finite number.
+  // The earlier `Math.max(DEFAULT, configured)` shape made the read-time
+  // size guard diverge from the writer's policy: a deployment that lowered
+  // OD_CRITIQUE_PARSER_MAX_BLOCK_BYTES below 4 MiB would still stream
+  // tampered files up to 4 MiB even though writeShipArtifact would have
+  // refused them. Mirror the writer's policy exactly so what the writer
+  // accepts is what the endpoint serves, and only fall back to the
+  // default when the option is absent or invalid (mrcfps follow-up on
+  // PR #1085).
+  const responseCapBytes =
+    Number.isFinite(options.responseCapBytes) && options.responseCapBytes! > 0
+      ? options.responseCapBytes!
+      : DEFAULT_RESPONSE_SIZE_CAP_BYTES;
+
+  return async function critiqueArtifactHandler(req: Request, res: Response): Promise<void> {
+    const projectId =
+      typeof req.params['projectId'] === 'string'
+        ? req.params['projectId'].trim()
+        : '';
+    const runId =
+      typeof req.params['runId'] === 'string'
+        ? req.params['runId'].trim()
+        : '';
+
+    if (!projectId || !runId) {
+      res
+        .status(HTTP_BAD_REQUEST)
+        .json({ error: { code: 'BAD_REQUEST', message: 'projectId and runId are required' } });
+      return;
+    }
+
+    const row = getCritiqueRun(db, runId);
+
+    // Cross-project leak guard: a request against project p1 must not
+    // reveal that runId actually lives in p2. 404 (not 403) so the
+    // existence of other projects' runs is not leaked.
+    if (row === null || row.projectId !== projectId) {
+      res
+        .status(HTTP_NOT_FOUND)
+        .json({ error: { code: 'NOT_FOUND', message: 'critique run not found' } });
+      return;
+    }
+
+    if (row.artifactPath === null) {
+      // Either the run is still running, the orchestrator failed to write
+      // the artifact (size, fs error, agent shipped no body), or the row
+      // pre-dates artifact persistence and hasn't been backfilled. All
+      // three are observable as 404 from the client's perspective.
+      res
+        .status(HTTP_NOT_FOUND)
+        .json({
+          error: {
+            code: 'NOT_FOUND',
+            message: 'critique run has no persisted artifact',
+            currentStatus: row.status,
+          },
+        });
+      return;
+    }
+
+    // Path-traversal guard: the row's artifactPath must resolve INSIDE
+    // the configured artifacts root. Refusing anything else means a
+    // tampered DB row cannot leak arbitrary files off disk through this
+    // endpoint. Symlinks are not followed: the orchestrator writes
+    // through the writer module which never produces symlinks, so any
+    // symlink found here is suspicious.
+    const resolvedArtifactPath = path.resolve(row.artifactPath);
+    const relToRoot = path.relative(artifactsRoot, resolvedArtifactPath);
+    if (
+      relToRoot.startsWith('..')
+      || path.isAbsolute(relToRoot)
+      || relToRoot === ''
+    ) {
+      res
+        .status(HTTP_NOT_FOUND)
+        .json({ error: { code: 'NOT_FOUND', message: 'critique artifact not found' } });
+      return;
+    }
+
+    // Open the file once and stream from the resulting fd. The earlier
+    // shape did `lstat(path) → validate → createReadStream(path)`, which
+    // left a time-of-check / time-of-use window where a local actor with
+    // write access to the critique-artifacts directory could swap in a
+    // symlink or a larger file between the validation and the reopen.
+    // Opening once with O_NOFOLLOW (where the platform supports it) and
+    // stat'ing the open fd via fileHandle.stat() means the size and
+    // file-type checks describe the exact bytes we are about to stream
+    // (mrcfps follow-up on PR #1085).
+    //
+    // O_NOFOLLOW is a POSIX flag; on Windows the constant resolves to
+    // undefined and the open fall-through behaves like a normal read.
+    // The path-traversal guard above plus the orchestrator never writing
+    // through symlinks make Windows still safe in practice.
+    const noFollowFlag =
+      typeof fsConstants.O_NOFOLLOW === 'number' ? fsConstants.O_NOFOLLOW : 0;
+    const openFlags = fsConstants.O_RDONLY | noFollowFlag;
+    let fileHandle: Awaited<ReturnType<typeof fs.open>>;
+    try {
+      fileHandle = await fs.open(resolvedArtifactPath, openFlags);
+    } catch {
+      // ELOOP from O_NOFOLLOW (symlink), ENOENT (vanished), EACCES, etc.
+      res
+        .status(HTTP_NOT_FOUND)
+        .json({ error: { code: 'NOT_FOUND', message: 'critique artifact not found' } });
+      return;
+    }
+
+    try {
+      const stat = await fileHandle.stat();
+      if (!stat.isFile()) {
+        await fileHandle.close();
+        res
+          .status(HTTP_NOT_FOUND)
+          .json({ error: { code: 'NOT_FOUND', message: 'critique artifact not found' } });
+        return;
+      }
+      if (stat.size > responseCapBytes) {
+        await fileHandle.close();
+        res
+          .status(HTTP_NOT_FOUND)
+          .json({
+            error: { code: 'NOT_FOUND', message: 'critique artifact exceeds response cap' },
+          });
+        return;
+      }
+
+      const ext = path.extname(resolvedArtifactPath);
+      const contentType = mimeForExtension(ext);
+
+      res.status(HTTP_OK);
+      res.setHeader('Content-Type', contentType);
+      res.setHeader('Content-Length', String(stat.size));
+      res.setHeader('X-Content-Type-Options', 'nosniff');
+      // Prevent SVG / HTML artifacts from running scripts when fetched
+      // directly. The web layer renders the bytes inside a sandboxed iframe
+      // for HTML; this CSP is a defense-in-depth header for clients that
+      // dereference the URL outside that sandbox.
+      if (contentType === 'image/svg+xml' || contentType === 'text/html') {
+        res.setHeader(
+          'Content-Security-Policy',
+          "default-src 'none'; img-src data:; style-src 'unsafe-inline'",
+        );
+      }
+      // Artifacts are content-addressed by runId; the row never re-points
+      // to a different file once written, so a long cache lifetime is safe.
+      res.setHeader('Cache-Control', 'private, max-age=3600');
+
+      // createReadStream({ autoClose: true }) is the FileHandle method that
+      // closes the underlying fd when the stream ends or errors, so we do
+      // not double-close after handing the fd to the stream.
+      const stream = fileHandle.createReadStream({ autoClose: true });
+      stream.on('error', () => {
+        if (!res.headersSent) {
+          res.status(HTTP_NOT_FOUND).end();
+        } else {
+          res.destroy();
+        }
+      });
+      stream.pipe(res);
+    } catch (err) {
+      // Anything thrown after the open succeeded but before the stream is
+      // wired up: close the fd so it does not leak, then surface 404.
+      await fileHandle.close().catch(() => {});
+      if (!res.headersSent) {
+        res
+          .status(HTTP_NOT_FOUND)
+          .json({ error: { code: 'NOT_FOUND', message: 'critique artifact not found' } });
+      } else {
+        res.destroy(err instanceof Error ? err : undefined);
+      }
+    }
+  };
+}

--- a/apps/daemon/src/critique/artifact-writer.ts
+++ b/apps/daemon/src/critique/artifact-writer.ts
@@ -1,0 +1,176 @@
+import * as path from 'node:path';
+import { promises as fs } from 'node:fs';
+
+/**
+ * Allowlist of artifact mime types the agent is expected to ship under v1.
+ * The web layer's preview surface knows how to render each of these inline,
+ * and the daemon's `Content-Type` response header for the artifact-fetch
+ * endpoint is taken straight from this map. Unknown mimes fall through to
+ * the binary sink (see `extensionForMime`) so an experimenting agent can
+ * still ship something, but the file is named `.bin` and the response
+ * header degrades to `application/octet-stream` so downstream consumers
+ * cannot misinterpret raw bytes as a known type.
+ *
+ * The allowlist is intentionally narrow; expand it through this constant
+ * (and the matching tests) rather than guessing from the mime string.
+ */
+const ARTIFACT_MIME_EXTENSIONS = {
+  'text/html': 'html',
+  'text/css': 'css',
+  'text/markdown': 'md',
+  'text/plain': 'txt',
+  'application/json': 'json',
+  'image/svg+xml': 'svg',
+} as const satisfies Record<string, string>;
+
+const FALLBACK_MIME = 'application/octet-stream';
+const FALLBACK_EXTENSION = 'bin';
+
+/** Result of a successful artifact write. All paths are absolute. */
+export interface WriteShipArtifactResult {
+  /** Resolved mime type (input mime if it was on the allowlist, else the
+   *  binary fallback). The artifact endpoint serves this as Content-Type. */
+  mime: string;
+  /** Lowercase extension WITHOUT the leading dot. */
+  extension: string;
+  /** Absolute path to the file the daemon just wrote. */
+  absPath: string;
+  /** Filename within the artifact directory (no parent components). */
+  filename: string;
+  /** UTF-8 byte length of the body that was written. */
+  sizeBytes: number;
+}
+
+/**
+ * Errors thrown by `writeShipArtifact`. The orchestrator distinguishes these
+ * from generic Node fs errors so it can map an oversize body to the same
+ * `degraded` outcome a parser-side OversizeBlockError would produce, and a
+ * filesystem failure to `failed`.
+ */
+export class ArtifactTooLargeError extends Error {
+  readonly code = 'ARTIFACT_TOO_LARGE' as const;
+  constructor(readonly sizeBytes: number, readonly maxBytes: number) {
+    super(
+      `<ARTIFACT> body of ${sizeBytes} bytes exceeded artifact-writer cap of ${maxBytes} bytes`,
+    );
+  }
+}
+
+export class ArtifactEmptyError extends Error {
+  readonly code = 'ARTIFACT_EMPTY' as const;
+  constructor() {
+    super('<ARTIFACT> body is empty after CDATA strip; refusing to write a zero-byte file');
+  }
+}
+
+export interface WriteShipArtifactOptions {
+  /** Hard cap on the body size in UTF-8 bytes; defaults to 1 MiB. The
+   *  orchestrator passes `cfg.parserMaxBlockBytes` so the on-disk limit
+   *  matches the parser's in-memory limit. */
+  maxBytes?: number;
+}
+
+/** Default body cap when the orchestrator doesn't pass one. 1 MiB is the
+ *  same ballpark as the parser's default block cap; any artifact larger than
+ *  this is a strong signal the agent is misbehaving. */
+const DEFAULT_MAX_BYTES = 1024 * 1024;
+
+/**
+ * Resolve the canonical mime + filename for a SHIP artifact body and write
+ * it to `<dir>/artifact.<ext>` atomically (write to a sibling tmp file, then
+ * rename). The caller is expected to pass a directory that already exists;
+ * the orchestrator builds it as `<artifactsDir>/<projectId>/<runId>` at
+ * run-start, so creation is the orchestrator's responsibility, not this
+ * module's.
+ *
+ * `mime` is matched case-insensitively and trimmed of a `; charset=…`
+ * suffix before the extension lookup, so `text/html; charset=utf-8` and
+ * `Text/HTML` both resolve to the `html` extension.
+ */
+export async function writeShipArtifact(
+  dir: string,
+  body: string,
+  mime: string,
+  options: WriteShipArtifactOptions = {},
+): Promise<WriteShipArtifactResult> {
+  const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
+  const sizeBytes = Buffer.byteLength(body, 'utf8');
+  if (sizeBytes === 0) {
+    throw new ArtifactEmptyError();
+  }
+  if (sizeBytes > maxBytes) {
+    throw new ArtifactTooLargeError(sizeBytes, maxBytes);
+  }
+
+  const resolvedMime = canonicalizeMime(mime);
+  const extension = extensionForMime(resolvedMime);
+  const filename = `artifact.${extension}`;
+  const absPath = path.join(dir, filename);
+
+  // Atomic write: render to a sibling tmp file then rename. A naive write
+  // could leave a half-written file under `artifact.<ext>` if the daemon
+  // crashes mid-write; the rename is observed atomically on POSIX and is
+  // good enough on Windows for the local-only daemon use case.
+  const tmpPath = `${absPath}.tmp.${process.pid}.${Date.now()}`;
+  await fs.writeFile(tmpPath, body, { encoding: 'utf8' });
+  try {
+    await fs.rename(tmpPath, absPath);
+  } catch (err) {
+    // Best-effort cleanup of the tmp file; never let cleanup mask the
+    // original rename error.
+    await fs.unlink(tmpPath).catch(() => {});
+    throw err;
+  }
+
+  return { mime: resolvedMime, extension, absPath, filename, sizeBytes };
+}
+
+/**
+ * Look up the on-disk extension for a mime that has already been
+ * canonicalized via `canonicalizeMime`. Exported so the artifact-fetch
+ * endpoint can reverse the lookup and so the parser's golden tests can
+ * assert mime → ext mappings without re-deriving them inline.
+ */
+export function extensionForMime(canonicalMime: string): string {
+  const known = (ARTIFACT_MIME_EXTENSIONS as Record<string, string>)[canonicalMime];
+  return known ?? FALLBACK_EXTENSION;
+}
+
+/**
+ * Look up the canonical mime for a known extension. Used by the
+ * artifact-fetch endpoint when the row only stores the path; the path
+ * extension is the source of truth on read because the row was written by
+ * `writeShipArtifact` which derives the extension from the mime in the
+ * first place. Falls back to `application/octet-stream` so the response
+ * header is always something a browser can refuse to render as HTML.
+ */
+export function mimeForExtension(extension: string): string {
+  const lower = extension.toLowerCase().replace(/^\./, '');
+  for (const [mime, ext] of Object.entries(ARTIFACT_MIME_EXTENSIONS)) {
+    if (ext === lower) return mime;
+  }
+  return FALLBACK_MIME;
+}
+
+/**
+ * Reduce an `<ARTIFACT mime="…">` attribute value to the canonical lookup
+ * key: lowercased, with any `; charset=…` parameters stripped. Returns the
+ * binary fallback for empty / unknown / malformed inputs so the rest of the
+ * pipeline never has to guard for `mime === ''`.
+ */
+function canonicalizeMime(raw: string): string {
+  const head = (raw ?? '').split(';')[0]?.trim().toLowerCase();
+  if (!head) return FALLBACK_MIME;
+  if (Object.prototype.hasOwnProperty.call(ARTIFACT_MIME_EXTENSIONS, head)) {
+    return head;
+  }
+  return FALLBACK_MIME;
+}
+
+/** Visible-for-testing: the canonical allowlist + the fallbacks. */
+export const ARTIFACT_WRITER_INTERNALS = {
+  ARTIFACT_MIME_EXTENSIONS,
+  FALLBACK_MIME,
+  FALLBACK_EXTENSION,
+  DEFAULT_MAX_BYTES,
+};

--- a/apps/daemon/src/critique/interrupt-handler.ts
+++ b/apps/daemon/src/critique/interrupt-handler.ts
@@ -3,7 +3,6 @@ import type Database from 'better-sqlite3';
 import {
   getCritiqueRun,
   markRunInterruptedRecovery,
-  type CritiqueRunStatus,
 } from './persistence.js';
 import type { RunRegistry } from './run-registry.js';
 
@@ -62,7 +61,10 @@ export function handleCritiqueInterrupt(
       return;
     }
 
-    const liveStatus = row.status as CritiqueRunStatus | 'running';
+    // row.status is already CritiquePersistedStatus (the contracts type that
+    // admits 'running' alongside terminal values), so we can compare without
+    // the inline widen this handler used to carry.
+    const liveStatus = row.status;
 
     if (liveStatus === 'interrupted') {
       // Idempotent retry path. The original interrupt already drove the run

--- a/apps/daemon/src/critique/orchestrator.ts
+++ b/apps/daemon/src/critique/orchestrator.ts
@@ -1,9 +1,15 @@
 import type { ChildProcess } from 'node:child_process';
+import { promises as fs } from 'node:fs';
 import type Database from 'better-sqlite3';
 import type { CritiqueConfig, PanelEvent } from '@open-design/contracts/critique';
 import { panelEventToSse } from '@open-design/contracts/critique';
 import type { CritiqueSseEvent } from '@open-design/contracts/critique';
-import { parseCritiqueStream } from './parser.js';
+import { parseCritiqueStream, type ShipArtifactPayload } from './parser.js';
+import {
+  ArtifactEmptyError,
+  ArtifactTooLargeError,
+  writeShipArtifact,
+} from './artifact-writer.js';
 import {
   computeComposite,
   decideRound,
@@ -14,6 +20,7 @@ import {
   insertCritiqueRun,
   updateCritiqueRun,
   type CritiqueRunRow,
+  type CritiqueRunStatus,
 } from './persistence.js';
 import { writeTranscript } from './transcript.js';
 import {
@@ -75,7 +82,10 @@ export interface OrchestratorParams {
 }
 
 export interface OrchestratorResult {
-  status: CritiqueRunRow['status'];
+  // The orchestrator only ever returns after a run reaches a terminal
+  // outcome, so this is the public terminal-only union, not the wider
+  // CritiquePersistedStatus that admits 'running' for live DB rows.
+  status: CritiqueRunStatus;
   composite: number | null;
   rounds: CritiqueRunRow['rounds'];
   transcriptPath: string | null;
@@ -131,7 +141,19 @@ export async function runOrchestrator(
   const completedRounds: RoundState[] = [];
   let artifactPath: string | null = null;
   let shipEvent: Extract<PanelEvent, { type: 'ship' }> | null = null;
-  let finalStatus: CritiqueRunRow['status'] = 'failed';
+  // Buffered SHIP artifact body coming from the parser side-channel. The
+  // body intentionally never travels on the SSE wire (the SHIP PanelEvent
+  // doesn't carry it), so the orchestrator captures it here, writes it to
+  // disk after decideRound runs, and pins artifactPath on the run row.
+  //
+  // Wrapped in a single-property box rather than a `let pendingArtifact`
+  // so TypeScript's control-flow analysis doesn't narrow it to `never`
+  // at the read site below. The parser callback only mutates the box's
+  // `value` field; without the box, tsc with strict / noImplicitAny would
+  // see the closure assignment as opaque and conclude the field is
+  // unreachable.
+  const artifactBuffer: { value: ShipArtifactPayload | null } = { value: null };
+  let finalStatus: CritiqueRunStatus = 'failed';
   let finalComposite: number | null = null;
   let transcriptPath: string | null = null;
 
@@ -180,6 +202,15 @@ export async function runOrchestrator(
       parserMaxBlockBytes: cfg.parserMaxBlockBytes,
       projectId,
       artifactId: params.artifactId,
+      // Side-channel for the SHIP <ARTIFACT> body. The parser invokes this
+      // synchronously right before yielding the ship PanelEvent, so the
+      // orchestrator has the body in hand by the time decideRound runs.
+      // Only the LAST artifact is retained: the parser already enforces
+      // that a second SHIP becomes a parser_warning, so this branch is only
+      // hit on the legitimate first SHIP per run.
+      onArtifact: (payload: ShipArtifactPayload) => {
+        artifactBuffer.value = payload;
+      },
     };
 
     for await (const event of parseCritiqueStream(timedSource, parserOpts)) {
@@ -321,9 +352,14 @@ export async function runOrchestrator(
       finalStatus = decision === 'ship' ? 'shipped' : 'below_threshold';
       finalComposite = shippedRound.composite;
 
-      // Emit the daemon-authoritative ship event. SSE clients and the
-      // transcript see this single normalized payload, never the raw agent
-      // claim from the buffered shipEvent.
+      // Build the daemon-authoritative ship event payload now, but DO NOT
+      // emit it yet. SSE clients react to critique.ship by fetching the
+      // artifact endpoint, so the file must be on disk AND the row's
+      // artifactPath must be populated before the event goes out;
+      // otherwise the client races us and gets a 404 against a row that
+      // is about to gain its path on the next finalize call. Order:
+      //   write file -> persist artifactPath on row -> emit ship event.
+      // (lefarcen P1 on PR #1085.)
       const normalizedShip: Extract<PanelEvent, { type: 'ship' }> = {
         type: 'ship',
         runId,
@@ -333,15 +369,71 @@ export async function runOrchestrator(
         artifactRef: { projectId, artifactId: params.artifactId },
         summary: ship.summary,
       };
+
+      // Persist the SHIP artifact body now that the row is being finalized.
+      // Failures here are logged but do not block finalization: the run
+      // still goes terminal so the orchestrator's caller can drive the chat
+      // run lifecycle, and the artifact endpoint will return 404 instead of
+      // pointing at a missing file. Phase 14 (artifact backfill) will fill
+      // in older rows that were created before this code path existed.
+      const captured = artifactBuffer.value;
+      if (captured !== null) {
+        try {
+          await fs.mkdir(artifactDir, { recursive: true });
+          const written = await writeShipArtifact(
+            artifactDir,
+            captured.body,
+            captured.mime,
+            { maxBytes: cfg.parserMaxBlockBytes },
+          );
+          artifactPath = written.absPath;
+          // Pin artifactPath on the row BEFORE we emit critique.ship,
+          // so the GET /artifact endpoint sees the path the moment a
+          // client reacts to the SSE event. Without this incremental
+          // patch the row stays at artifactPath=null until the
+          // bottom-of-orchestrator updateCritiqueRun fires, which is
+          // after any client request triggered by critique.ship.
+          updateCritiqueRun(db, runId, { artifactPath });
+        } catch (err) {
+          // ArtifactTooLargeError / ArtifactEmptyError are agent-side
+          // problems (the parser already validated non-empty, so empty
+          // here means the agent shipped a CDATA-only body). Filesystem
+          // errors are environment problems. Either way, leaving
+          // artifactPath null makes the run still finalize and the ship
+          // event still emit; the artifact endpoint will 404 instead of
+          // claiming bytes that don't exist.
+          if (
+            err instanceof ArtifactTooLargeError
+            || err instanceof ArtifactEmptyError
+          ) {
+            console.warn(
+              `[critique] runId=${runId}: refusing to persist ship artifact (${err.code}): ${err.message}`,
+            );
+          } else {
+            console.warn(
+              `[critique] runId=${runId}: ship artifact write failed: ${
+                err instanceof Error ? err.message : String(err)
+              }`,
+            );
+          }
+          artifactPath = null;
+        }
+      } else {
+        // SHIP arrived without an <ARTIFACT> side-channel payload. The
+        // parser refuses to yield a ship event in this state (it throws
+        // MissingArtifactError), so reaching this branch means the parser
+        // contract is violated. Surface as a warning rather than crashing
+        // the orchestrator; the transcript still records the ship event.
+        console.warn(
+          `[critique] runId=${runId}: ship event reached orchestrator without an artifact payload; parser contract violated`,
+        );
+        artifactPath = null;
+      }
+
+      // File is on disk, row knows about it. Now emit critique.ship so
+      // SSE subscribers can fetch /artifact without racing the writer.
       collectedEvents.push(normalizedShip);
       bus.emit(panelEventToSse(normalizedShip));
-
-      // artifactPath stays null until a future phase actually extracts the
-      // <SHIP><ARTIFACT> body and writes it to disk. Persisting a synthesized
-      // path that no file occupies would let UI/replay/export code dereference
-      // a missing file. The transcript still carries the ship event with the
-      // artifact reference so consumers can find the run.
-      artifactPath = null;
     } else {
       // No SHIP arrived (or the agent SHIP was rejected as malformed above).
       // Apply fallback policy over the daemon's closed rounds.

--- a/apps/daemon/src/critique/parser.ts
+++ b/apps/daemon/src/critique/parser.ts
@@ -1,6 +1,24 @@
 import type { PanelEvent } from '@open-design/contracts/critique';
 import { parseV1 } from './parsers/v1.js';
 
+/**
+ * Side-channel payload the parser hands the orchestrator when a SHIP block
+ * carries an `<ARTIFACT>`. The body and mime intentionally do NOT travel on
+ * the SHIP `PanelEvent` (which is also the SSE wire shape) so artifact bytes
+ * never broadcast to clients; the orchestrator persists them to disk and
+ * the web layer fetches via the dedicated artifact endpoint.
+ */
+export interface ShipArtifactPayload {
+  /** Round the SHIP closed against. Matches the round on the ship event. */
+  round: number;
+  /** `mime` attribute from `<ARTIFACT mime="…">`; empty string if omitted. */
+  mime: string;
+  /** Decoded artifact body. CDATA wrappers are stripped before delivery. */
+  body: string;
+}
+
+export type ShipArtifactCallback = (payload: ShipArtifactPayload) => void;
+
 export interface ParserOptions {
   runId: string;
   adapter: string;
@@ -9,6 +27,13 @@ export interface ParserOptions {
   projectId?: string;
   /** Artifact identity threaded into ship event artifactRef. */
   artifactId?: string;
+  /**
+   * Side-channel for the SHIP artifact body. Invoked synchronously inside
+   * the parser right before the corresponding ship `PanelEvent` is yielded,
+   * so the orchestrator can write the bytes to disk and persist a path on
+   * the row before any consumer of the ship event reacts to it.
+   */
+  onArtifact?: ShipArtifactCallback;
 }
 
 export async function* parseCritiqueStream(

--- a/apps/daemon/src/critique/parsers/v1.ts
+++ b/apps/daemon/src/critique/parsers/v1.ts
@@ -1,5 +1,6 @@
 import type { PanelEvent, PanelistRole } from '@open-design/contracts/critique';
 import { MalformedBlockError, MissingArtifactError, OversizeBlockError } from '../errors.js';
+import type { ShipArtifactCallback } from '../parser.js';
 
 const KNOWN_ROLES: ReadonlySet<string> = new Set(['designer', 'critic', 'brand', 'a11y', 'copy']);
 
@@ -36,6 +37,10 @@ interface State {
   shipSeen: boolean;
   designerArtifactInRound1: boolean;
   lastAdvance: number;
+  /** Optional side-channel; see ShipArtifactCallback in ../parser.ts.
+   *  Spelled `| undefined` (rather than `?:`) so the State literal can
+   *  explicitly assign `undefined` under `exactOptionalPropertyTypes`. */
+  onArtifact: ShipArtifactCallback | undefined;
 }
 
 export async function* parseV1(
@@ -46,6 +51,7 @@ export async function* parseV1(
     parserMaxBlockBytes: number;
     projectId?: string;
     artifactId?: string;
+    onArtifact?: ShipArtifactCallback;
   },
 ): AsyncIterable<PanelEvent> {
   const state: State = {
@@ -64,6 +70,7 @@ export async function* parseV1(
     shipSeen: false,
     designerArtifactInRound1: false,
     lastAdvance: 0,
+    onArtifact: opts.onArtifact,
   };
 
   for await (const chunk of source) {
@@ -322,7 +329,12 @@ function* drain(state: State): Generator<PanelEvent> {
           state.consumed + cursor,
         );
       }
-      const closeIdx = slice.indexOf('</SHIP>');
+      // Look up `</SHIP>` while skipping over any `<![CDATA[ ... ]]>` spans
+      // inside the body. A naive `indexOf` would match a literal `</SHIP>`
+      // string sitting inside a JS / HTML payload wrapped in CDATA and
+      // truncate the SHIP block early, dropping the real `</ARTIFACT>` and
+      // `</SUMMARY>` siblings (lefarcen P2 on PR #1085).
+      const closeIdx = indexOfOutsideCdata(slice, '</SHIP>');
       if (closeIdx < 0) break;
       const blockText = slice.slice(0, closeIdx + '</SHIP>'.length);
       const blockBytes = Buffer.byteLength(blockText, 'utf8');
@@ -357,15 +369,44 @@ function* drain(state: State): Generator<PanelEvent> {
       const attrs = parseAttrs(slice.slice('<SHIP'.length, headEnd));
       const inner = slice.slice(headEnd + 1, closeIdx);
 
-      // Validate that a non-empty <ARTIFACT> block is present inside <SHIP>.
-      const artifactMatch = inner.match(/<ARTIFACT\b[^>]*>([\s\S]*?)<\/ARTIFACT>/);
-      if (!artifactMatch || artifactMatch[1] === undefined || artifactMatch[1].trim().length === 0) {
+      // Validate that a non-empty <ARTIFACT> block is present inside <SHIP>
+      // and capture its head + body so the orchestrator can persist the bytes
+      // to disk via the side-channel callback. The body must NOT be added to
+      // the ship PanelEvent itself, since that event is also the SSE wire
+      // shape; broadcasting megabytes of HTML to every SSE subscriber would
+      // ruin the bus. The orchestrator pulls the body off `onArtifact` and
+      // emits only the small `artifactRef` on the wire.
+      const artifactExtraction = extractArtifactBlock(inner);
+      if (
+        artifactExtraction === null
+        || artifactExtraction.body.trim().length === 0
+      ) {
         throw new MissingArtifactError(
           `<SHIP> at position ${state.consumed + cursor} contains no <ARTIFACT> block or the block is empty`,
         );
       }
 
-      const summary = (inner.match(/<SUMMARY>([\s\S]*?)<\/SUMMARY>/)?.[1] ?? '').trim();
+      const artifactAttrs = parseAttrs(artifactExtraction.attrText);
+      const artifactMime = artifactAttrs['mime'] ?? '';
+      // CDATA-wrapped bodies are unwrapped inside `extractArtifactBlock`,
+      // which scans for `]]></ARTIFACT>` (with optional whitespace) so a
+      // legitimate JS / HTML payload that contains a literal `</ARTIFACT>`
+      // sentinel inside a string or comment does not truncate the body
+      // (mrcfps follow-up on PR #1085).
+      const artifactBody = artifactExtraction.body;
+
+      // Scope the SUMMARY scan to bytes that come AFTER the artifact's
+      // closing tag. Searching the full SHIP `inner` would let an artifact
+      // body that contains a literal `<SUMMARY>...</SUMMARY>` pair (for
+      // example a CDATA-wrapped HTML fragment) hijack the ship summary
+      // before the real sibling tag is reached, so rerun / history would
+      // display artifact bytes as the summary text (mrcfps follow-up on
+      // PR #1085).
+      const summary = (
+        inner
+          .slice(artifactExtraction.blockEnd)
+          .match(/<SUMMARY>([\s\S]*?)<\/SUMMARY>/)?.[1] ?? ''
+      ).trim();
 
       const rawStatus = attrs['status'] ?? '';
       const validStatuses = ['shipped', 'below_threshold', 'timed_out', 'interrupted'] as const;
@@ -375,10 +416,23 @@ function* drain(state: State): Generator<PanelEvent> {
           : 'shipped'
       ) as 'shipped' | 'below_threshold' | 'timed_out' | 'interrupted';
 
+      const shipRound = Number(attrs['round'] ?? '0');
+
+      // Side-channel hand-off BEFORE the ship event yields, so the
+      // orchestrator can write artifact.<ext> and pin artifactPath on the
+      // run row before any consumer of the ship event reacts to it.
+      if (state.onArtifact) {
+        state.onArtifact({
+          round: shipRound,
+          mime: artifactMime,
+          body: artifactBody,
+        });
+      }
+
       yield {
         type: 'ship',
         runId: state.runId,
-        round: Number(attrs['round'] ?? '0'),
+        round: shipRound,
         composite: Number(attrs['composite'] ?? '0'),
         status,
         artifactRef: { projectId: state.projectId, artifactId: state.artifactId },
@@ -490,6 +544,124 @@ function parseAttrs(s: string): Record<string, string> {
     if (key != null) out[key] = m[2] ?? '';
   }
   return out;
+}
+
+/**
+ * Find the first occurrence of `needle` in `source` that is NOT inside a
+ * `<![CDATA[ ... ]]>` span. The wire protocol uses sibling tags (`</SHIP>`,
+ * `</ARTIFACT>`, `<SUMMARY>`) that an agent could legitimately ship inside
+ * an HTML / JS payload wrapped in CDATA — a naive `indexOf` would match
+ * those sentinels, slicing the wrong block out and corrupting both the
+ * extraction and the surrounding parser state. CDATA forbids the literal
+ * `]]>` inside its content per the XML spec, so once we open one we can
+ * always find its terminator and resume scanning afterward.
+ *
+ * Returns -1 when no out-of-CDATA match exists, including the case where
+ * an unterminated CDATA span runs to the end of the source. Streaming
+ * callers should treat that as "not enough bytes yet" and break.
+ */
+export function indexOfOutsideCdata(
+  source: string,
+  needle: string,
+  startOffset: number = 0,
+): number {
+  let i = startOffset;
+  while (i < source.length) {
+    if (source.startsWith('<![CDATA[', i)) {
+      const cdataEnd = source.indexOf(']]>', i + '<![CDATA['.length);
+      if (cdataEnd < 0) {
+        // Unterminated CDATA: the rest of the buffer is opaque. The
+        // streaming SHIP path treats this the same as `indexOf` returning
+        // -1 and waits for more bytes; the post-SHIP-close artifact path
+        // treats it as malformed (since the SHIP closer was already found
+        // outside CDATA, every CDATA inside `inner` should be terminated).
+        return -1;
+      }
+      i = cdataEnd + ']]>'.length;
+      continue;
+    }
+    if (source.startsWith(needle, i)) return i;
+    i += 1;
+  }
+  return -1;
+}
+
+/**
+ * Locate the `<ARTIFACT ...>` block inside the SHIP body and return its
+ * attribute string + decoded payload. CDATA-aware: when the artifact body
+ * starts with `<![CDATA[`, the function scans for the matching
+ * `]]></ARTIFACT>` pair (allowing whitespace between `]]>` and `</ARTIFACT>`)
+ * rather than the first bare `</ARTIFACT>`, so a payload containing a
+ * literal `</ARTIFACT>` inside a JS string or comment is delivered intact.
+ *
+ * `blockEnd` is the offset in `source` immediately after the closing
+ * `</ARTIFACT>` tag, so callers that need to scan SHIP-level sibling tags
+ * (`<SUMMARY>`, etc.) can do so on `source.slice(blockEnd)` instead of the
+ * full SHIP inner — otherwise an artifact body that contains a literal
+ * `<SUMMARY>...</SUMMARY>` pair would be misread as the ship summary
+ * (mrcfps follow-up on PR #1085).
+ *
+ * Returns `null` if no `<ARTIFACT>` opener exists, no closing tag matches,
+ * or the body decodes to an empty string.
+ */
+export function extractArtifactBlock(
+  source: string,
+): { attrText: string; body: string; blockEnd: number } | null {
+  const openerMatch = source.match(/<ARTIFACT\b([^>]*)>/);
+  if (
+    !openerMatch
+    || openerMatch.index === undefined
+    || openerMatch[1] === undefined
+  ) {
+    return null;
+  }
+  const attrText = openerMatch[1];
+  const bodyStart = openerMatch.index + openerMatch[0].length;
+  const remainder = source.slice(bodyStart);
+
+  // CDATA-wrapped path: scan for `]]>` followed by optional whitespace then
+  // `</ARTIFACT>`. The `]]>` MUST come from the CDATA terminator, never from
+  // body text, so this is safe even when the body itself contains the bytes
+  // `</ARTIFACT>` inside a string or comment. CDATA forbids the literal
+  // sequence `]]>` inside its content per the XML spec, so the first match
+  // is always the real terminator.
+  const trimmed = remainder.trimStart();
+  const leadingWs = remainder.length - trimmed.length;
+  if (trimmed.startsWith('<![CDATA[')) {
+    // `cdataInnerStart` is an offset into `remainder` (the slice of
+    // `source` that begins right after the `<ARTIFACT ...>` opener), so
+    // every subsequent slice must be against `remainder` too — slicing
+    // `source` here would shift by `bodyStart` and chop off the leading
+    // bytes of the body.
+    const cdataInnerStart = leadingWs + '<![CDATA['.length;
+    // Allow whitespace between `]]>` and `</ARTIFACT>` so authors can
+    // pretty-print. CDATA forbids the literal `]]>` inside its content
+    // per the XML spec, so the first match is always the real terminator.
+    const tailRe = /\]\]>\s*<\/ARTIFACT>/;
+    const tailMatch = remainder.slice(cdataInnerStart).match(tailRe);
+    if (!tailMatch || tailMatch.index === undefined || tailMatch[0] === undefined) {
+      // Open CDATA without a CDATA-terminated closer: malformed.
+      return null;
+    }
+    const body = remainder.slice(
+      cdataInnerStart,
+      cdataInnerStart + tailMatch.index,
+    );
+    const blockEnd = bodyStart + cdataInnerStart + tailMatch.index + tailMatch[0].length;
+    return { attrText, body, blockEnd };
+  }
+
+  // Inline (non-CDATA) path: stop at the first `</ARTIFACT>` that is not
+  // itself nested inside a stray CDATA span. Bodies that need to embed
+  // `</ARTIFACT>` literally must wrap themselves in CDATA; that contract
+  // matches the v1 spec's recommended emitter, but if the body happens to
+  // open a CDATA span before its real `</ARTIFACT>` terminator we still
+  // skip past it for safety.
+  const closeIdx = indexOfOutsideCdata(remainder, '</ARTIFACT>');
+  if (closeIdx < 0) return null;
+  const body = remainder.slice(0, closeIdx);
+  const blockEnd = bodyStart + closeIdx + '</ARTIFACT>'.length;
+  return { attrText, body, blockEnd };
 }
 
 // Score range and clamp now respect the run's declared scale (captured from

--- a/apps/daemon/src/critique/persistence.ts
+++ b/apps/daemon/src/critique/persistence.ts
@@ -1,6 +1,7 @@
 import type Database from 'better-sqlite3';
 import {
   CRITIQUE_RUN_STATUSES,
+  type CritiquePersistedStatus,
   type CritiqueRoundSummary,
   type CritiqueRunStatus,
 } from '@open-design/contracts/critique';
@@ -12,13 +13,19 @@ import {
  * web layer can consume the same shapes and the same display order
  * through the rerun / history endpoints (AGENTS.md requirement that
  * shared API DTOs live in packages/contracts).
+ *
+ * `CritiquePersistedStatus` extends `CritiqueRunStatus` with the in-flight
+ * `'running'` value so DB-row types can be precisely typed without inline
+ * `as X | 'running'` widens at every call site (lefarcen P2 on PR #1016).
+ * Public DTOs continue to use the terminal-only `CritiqueRunStatus` so a
+ * future endpoint cannot leak a 'running' row through the wire.
  */
 export { CRITIQUE_RUN_STATUSES };
-export type { CritiqueRoundSummary, CritiqueRunStatus };
+export type { CritiquePersistedStatus, CritiqueRoundSummary, CritiqueRunStatus };
 
-// All values accepted by the DB CHECK constraint, including the in-flight value
-// that the public type union deliberately omits.
-const ALL_VALID_STATUSES: ReadonlySet<string> = new Set([
+// All values accepted by the DB CHECK constraint, derived from the
+// CritiquePersistedStatus union so this set never drifts from the type.
+const ALL_VALID_STATUSES: ReadonlySet<string> = new Set<CritiquePersistedStatus>([
   ...CRITIQUE_RUN_STATUSES,
   'running',
 ]);
@@ -28,7 +35,11 @@ export interface CritiqueRunRow {
   projectId: string;
   conversationId: string | null;
   artifactPath: string | null;
-  status: CritiqueRunStatus;
+  /** Reflects the on-disk row exactly: a row may legitimately be in the
+   *  in-flight `'running'` state until the orchestrator (or
+   *  reconcileStaleRuns) drives it to a terminal status. Public DTOs that
+   *  surface critique runs to the web must narrow to `CritiqueRunStatus`. */
+  status: CritiquePersistedStatus;
   score: number | null;
   rounds: CritiqueRoundSummary[];
   transcriptPath: string | null;
@@ -42,9 +53,10 @@ export interface CritiqueRunInsert {
   projectId: string;
   conversationId?: string | null;
   artifactPath?: string | null;
-  /** Accepts 'running' in addition to the terminal statuses so callers can
-   *  create in-flight rows without a type cast. */
-  status: CritiqueRunStatus | 'running';
+  /** Accepts every value the DB CHECK constraint allows, so the orchestrator
+   *  can insert an in-flight `'running'` row at run-start without an inline
+   *  type cast. */
+  status: CritiquePersistedStatus;
   score?: number | null;
   rounds?: CritiqueRoundSummary[];
   transcriptPath?: string | null;
@@ -54,6 +66,10 @@ export interface CritiqueRunInsert {
 }
 
 export interface CritiqueRunPatch {
+  /** Patches only ever finalize a row into a terminal state; in-flight
+   *  rows are created via the insert path, not patched. Keeping this
+   *  terminal-only catches accidental writes that would re-park a row in
+   *  `'running'` after it transitioned out. */
   status?: CritiqueRunStatus;
   score?: number | null;
   rounds?: CritiqueRoundSummary[];
@@ -126,7 +142,7 @@ function normalizeRow(raw: RawCritiqueRunRow): CritiqueRunRow {
     projectId: raw.projectId,
     conversationId: raw.conversationId,
     artifactPath: raw.artifactPath,
-    status: raw.status as CritiqueRunStatus,
+    status: raw.status as CritiquePersistedStatus,
     score: raw.score,
     rounds,
     transcriptPath: raw.transcriptPath,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -46,6 +46,7 @@ import { reconcileStaleRuns } from './critique/persistence.js';
 import { runOrchestrator } from './critique/orchestrator.js';
 import { createRunRegistry } from './critique/run-registry.js';
 import { handleCritiqueInterrupt } from './critique/interrupt-handler.js';
+import { handleCritiqueArtifact } from './critique/artifact-handler.js';
 import { createCopilotStreamHandler } from './copilot-stream.js';
 import { createJsonEventStreamHandler } from './json-event-stream.js';
 import { createQoderStreamHandler } from './qoder-stream.js';
@@ -838,6 +839,13 @@ migrateLegacyDataDirSync({
   dataDir: RUNTIME_DATA_DIR,
 });
 const ARTIFACTS_DIR = path.join(RUNTIME_DATA_DIR, 'artifacts');
+// Critique Theater artifacts intentionally live OUTSIDE the static
+// `/artifacts` tree (which is mounted via express.static below). The
+// per-run artifact endpoint is the only sanctioned read path so the
+// project-membership / cross-project leak / size / CSP guards in
+// handleCritiqueArtifact cannot be bypassed by a caller that guesses
+// `/artifacts/<projectId>/<runId>/artifact.html`. Codex P1 on PR #1085.
+const CRITIQUE_ARTIFACTS_DIR = path.join(RUNTIME_DATA_DIR, 'critique-artifacts');
 const PROJECTS_DIR = path.join(RUNTIME_DATA_DIR, 'projects');
 const USER_SKILLS_DIR = path.join(RUNTIME_DATA_DIR, 'skills');
 const USER_DESIGN_SYSTEMS_DIR = path.join(RUNTIME_DATA_DIR, 'design-systems');
@@ -845,6 +853,7 @@ fs.mkdirSync(PROJECTS_DIR, { recursive: true });
 for (const dir of [USER_SKILLS_DIR, USER_DESIGN_SYSTEMS_DIR]) {
   fs.mkdirSync(dir, { recursive: true });
 }
+fs.mkdirSync(CRITIQUE_ARTIFACTS_DIR, { recursive: true });
 const orbitService = new OrbitService(RUNTIME_DATA_DIR);
 let routineService = null;
 
@@ -6227,7 +6236,7 @@ export async function startServer({
         // same project from overwriting each other's transcript or final HTML.
         // Spec: artifacts/<projectId>/<runId>/transcript.ndjson(.gz).
         const critiqueProjectKey = typeof projectId === 'string' && projectId ? projectId : critiqueRunId;
-        const critiqueArtifactDir = path.join(ARTIFACTS_DIR, critiqueProjectKey, critiqueRunId);
+        const critiqueArtifactDir = path.join(CRITIQUE_ARTIFACTS_DIR, critiqueProjectKey, critiqueRunId);
         const stdoutIterable = (async function* () {
           for await (const chunk of child.stdout) yield String(chunk);
         })();
@@ -6904,6 +6913,24 @@ export async function startServer({
   app.post(
     '/api/projects/:projectId/critique/:runId/interrupt',
     handleCritiqueInterrupt(db, critiqueRunRegistry),
+  );
+
+  // GET /api/projects/:projectId/critique/:runId/artifact
+  // Streams the SHIP <ARTIFACT> body the orchestrator persisted, with
+  // mime derived from the file extension on disk. Cross-project leak
+  // guard mirrors the interrupt route. The web layer fetches this as
+  // the logical artifact handle so it never sees daemon paths.
+  //
+  // Response cap is threaded from cfg.parserMaxBlockBytes so a row that
+  // the orchestrator + writer accepted is always retrievable; without
+  // this, raising OD_CRITIQUE_PARSER_MAX_BLOCK_BYTES above the
+  // hard-coded ceiling would 404 a valid artifact (codex P2 on PR #1085).
+  app.get(
+    '/api/projects/:projectId/critique/:runId/artifact',
+    handleCritiqueArtifact(db, {
+      artifactsRoot: CRITIQUE_ARTIFACTS_DIR,
+      responseCapBytes: critiqueCfg.parserMaxBlockBytes,
+    }),
   );
 
   // ---- API Proxy (SSE) for API-compatible endpoints ------------------------

--- a/apps/daemon/tests/critique-artifact-endpoint.test.ts
+++ b/apps/daemon/tests/critique-artifact-endpoint.test.ts
@@ -1,0 +1,343 @@
+/**
+ * Tests for GET /api/projects/:projectId/critique/:runId/artifact.
+ *
+ * Each test mounts the handler on a fresh Express mini-app with an
+ * in-memory SQLite database and a real on-disk artifacts root, so the
+ * full handler logic (cross-project leak guard, path-traversal guard,
+ * missing-file 404, mime/Content-Type response) is exercised without
+ * starting the full daemon server.
+ *
+ * @see specs/current/critique-theater.md § rerun endpoint (Task 6.2)
+ */
+import http from 'node:http';
+import { mkdirSync, mkdtempSync, writeFileSync, symlinkSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import express from 'express';
+import Database from 'better-sqlite3';
+import {
+  insertCritiqueRun,
+  migrateCritique,
+  updateCritiqueRun,
+} from '../src/critique/persistence.js';
+import { handleCritiqueArtifact } from '../src/critique/artifact-handler.js';
+
+// ---------------------------------------------------------------------------
+// Test infrastructure
+// ---------------------------------------------------------------------------
+
+function freshDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  db.exec(`
+    CREATE TABLE projects (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY(project_id) REFERENCES projects(id) ON DELETE CASCADE
+    );
+    INSERT INTO projects (id, name, created_at, updated_at) VALUES ('p1', 'Project 1', 0, 0);
+    INSERT INTO projects (id, name, created_at, updated_at) VALUES ('p2', 'Project 2', 0, 0);
+  `);
+  migrateCritique(db);
+  return db;
+}
+
+function startMiniServer(
+  db: Database.Database,
+  artifactsRoot: string,
+): Promise<{ baseUrl: string; server: http.Server }> {
+  const app = express();
+  app.get(
+    '/api/projects/:projectId/critique/:runId/artifact',
+    handleCritiqueArtifact(db, { artifactsRoot }),
+  );
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (!addr || typeof addr !== 'object') {
+        reject(new Error('could not bind'));
+        return;
+      }
+      resolve({ baseUrl: `http://127.0.0.1:${addr.port}`, server });
+    });
+    server.on('error', reject);
+  });
+}
+
+interface FetchResult {
+  status: number;
+  headers: Headers;
+  body: string;
+}
+
+async function get(url: string): Promise<FetchResult> {
+  const res = await fetch(url);
+  const body = await res.text();
+  return { status: res.status, headers: res.headers, body };
+}
+
+/** Insert a row + place a real artifact file under the artifacts root,
+ *  matching what the orchestrator would have written. */
+function seedRowWithArtifact(
+  db: Database.Database,
+  artifactsRoot: string,
+  args: {
+    runId: string;
+    projectId: string;
+    body: string;
+    extension: 'html' | 'css' | 'svg' | 'bin' | 'json' | 'txt' | 'md';
+  },
+): { absPath: string } {
+  const dir = join(artifactsRoot, args.projectId, args.runId);
+  mkdirSync(dir, { recursive: true });
+  const absPath = join(dir, `artifact.${args.extension}`);
+  writeFileSync(absPath, args.body, 'utf8');
+  insertCritiqueRun(db, {
+    id: args.runId,
+    projectId: args.projectId,
+    status: 'shipped',
+    score: 9,
+    rounds: [{ n: 1, composite: 9, mustFix: 0, decision: 'ship' }],
+    artifactPath: absPath,
+    protocolVersion: 1,
+  });
+  return { absPath };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GET /api/projects/:projectId/critique/:runId/artifact', () => {
+  let db: Database.Database;
+  let artifactsRoot: string;
+  let baseUrl: string;
+  let server: http.Server;
+
+  beforeEach(async () => {
+    db = freshDb();
+    artifactsRoot = mkdtempSync(join(tmpdir(), 'od-artifact-endpoint-'));
+    ({ baseUrl, server } = await startMiniServer(db, artifactsRoot));
+  });
+
+  afterEach(async () => {
+    db.close();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await rm(artifactsRoot, { recursive: true, force: true });
+  });
+
+  // ---- 200: happy path -----------------------------------------------------
+
+  it('streams the body with text/html and the right Content-Length', async () => {
+    seedRowWithArtifact(db, artifactsRoot, {
+      runId: 'crun_html',
+      projectId: 'p1',
+      body: '<html><body>final</body></html>',
+      extension: 'html',
+    });
+
+    const { status, headers, body } = await get(
+      `${baseUrl}/api/projects/p1/critique/crun_html/artifact`,
+    );
+
+    expect(status).toBe(200);
+    expect(headers.get('content-type')).toBe('text/html');
+    expect(headers.get('content-length')).toBe('31');
+    expect(headers.get('x-content-type-options')).toBe('nosniff');
+    expect(headers.get('content-security-policy')).toContain("default-src 'none'");
+    expect(body).toBe('<html><body>final</body></html>');
+  });
+
+  it('streams an SVG with image/svg+xml and the same CSP that html gets', async () => {
+    seedRowWithArtifact(db, artifactsRoot, {
+      runId: 'crun_svg',
+      projectId: 'p1',
+      body: '<svg xmlns="http://www.w3.org/2000/svg"></svg>',
+      extension: 'svg',
+    });
+
+    const { status, headers } = await get(
+      `${baseUrl}/api/projects/p1/critique/crun_svg/artifact`,
+    );
+
+    expect(status).toBe(200);
+    expect(headers.get('content-type')).toBe('image/svg+xml');
+    expect(headers.get('content-security-policy')).toContain("default-src 'none'");
+  });
+
+  it('streams an unknown extension as application/octet-stream without a CSP header', async () => {
+    seedRowWithArtifact(db, artifactsRoot, {
+      runId: 'crun_bin',
+      projectId: 'p1',
+      body: 'binary-ish',
+      extension: 'bin',
+    });
+
+    const { status, headers, body } = await get(
+      `${baseUrl}/api/projects/p1/critique/crun_bin/artifact`,
+    );
+
+    expect(status).toBe(200);
+    expect(headers.get('content-type')).toBe('application/octet-stream');
+    expect(headers.get('content-security-policy')).toBeNull();
+    expect(body).toBe('binary-ish');
+  });
+
+  // ---- 404: unknown / cross-project / missing artifact ---------------------
+
+  it('returns 404 when the run does not exist', async () => {
+    const { status, body } = await get(
+      `${baseUrl}/api/projects/p1/critique/ghost/artifact`,
+    );
+    expect(status).toBe(404);
+    expect(JSON.parse(body)).toMatchObject({ error: { code: 'NOT_FOUND' } });
+  });
+
+  it('returns 404 when the runId belongs to a different project (cross-project leak guard)', async () => {
+    seedRowWithArtifact(db, artifactsRoot, {
+      runId: 'crun_other',
+      projectId: 'p2',
+      body: '<html>p2</html>',
+      extension: 'html',
+    });
+
+    const { status } = await get(
+      `${baseUrl}/api/projects/p1/critique/crun_other/artifact`,
+    );
+    expect(status).toBe(404);
+  });
+
+  it('returns 404 when the row has no artifactPath (still running, or never shipped)', async () => {
+    insertCritiqueRun(db, {
+      id: 'crun_no_artifact',
+      projectId: 'p1',
+      status: 'running',
+      protocolVersion: 1,
+    });
+
+    const { status, body } = await get(
+      `${baseUrl}/api/projects/p1/critique/crun_no_artifact/artifact`,
+    );
+    expect(status).toBe(404);
+    expect(JSON.parse(body)).toMatchObject({
+      error: { code: 'NOT_FOUND', currentStatus: 'running' },
+    });
+  });
+
+  it('returns 404 when artifactPath points outside the artifacts root', async () => {
+    const outsideDir = mkdtempSync(join(tmpdir(), 'od-artifact-outside-'));
+    try {
+      const outsidePath = join(outsideDir, 'leaked.html');
+      writeFileSync(outsidePath, '<html>leaked</html>', 'utf8');
+      insertCritiqueRun(db, {
+        id: 'crun_traversal',
+        projectId: 'p1',
+        status: 'shipped',
+        score: 9,
+        rounds: [{ n: 1, composite: 9, mustFix: 0, decision: 'ship' }],
+        artifactPath: outsidePath,
+        protocolVersion: 1,
+      });
+
+      const { status } = await get(
+        `${baseUrl}/api/projects/p1/critique/crun_traversal/artifact`,
+      );
+      expect(status).toBe(404);
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns 404 when the file on disk has been deleted (row points at a vanished path)', async () => {
+    const { absPath } = seedRowWithArtifact(db, artifactsRoot, {
+      runId: 'crun_vanished',
+      projectId: 'p1',
+      body: '<html></html>',
+      extension: 'html',
+    });
+    await rm(absPath);
+
+    const { status } = await get(
+      `${baseUrl}/api/projects/p1/critique/crun_vanished/artifact`,
+    );
+    expect(status).toBe(404);
+  });
+
+  it('returns 404 when artifactPath resolves to a symlink (refuses non-regular files)', async function symlinkCase() {
+    // Symlinks fail with EPERM on Windows runners that lack the privilege.
+    // Skip the assertion there rather than mark the suite flaky.
+    const target = join(artifactsRoot, 'target.html');
+    writeFileSync(target, '<html>real</html>', 'utf8');
+    const linkDir = join(artifactsRoot, 'p1', 'crun_symlink');
+    mkdirSync(linkDir, { recursive: true });
+    const linkPath = join(linkDir, 'artifact.html');
+    try {
+      symlinkSync(target, linkPath);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'EPERM') return;
+      throw err;
+    }
+    insertCritiqueRun(db, {
+      id: 'crun_symlink',
+      projectId: 'p1',
+      status: 'shipped',
+      score: 9,
+      rounds: [{ n: 1, composite: 9, mustFix: 0, decision: 'ship' }],
+      artifactPath: linkPath,
+      protocolVersion: 1,
+    });
+
+    const { status } = await get(
+      `${baseUrl}/api/projects/p1/critique/crun_symlink/artifact`,
+    );
+    expect(status).toBe(404);
+  });
+
+  // ---- 400: bad input ------------------------------------------------------
+
+  it('returns 400 when runId is whitespace-only', async () => {
+    const { status } = await get(
+      `${baseUrl}/api/projects/p1/critique/%20/artifact`,
+    );
+    expect(status).toBe(400);
+  });
+
+  // ---- terminal-state coverage --------------------------------------------
+
+  it('serves the artifact for every terminal status that ever wrote one', async () => {
+    const cases: Array<['shipped' | 'below_threshold' | 'interrupted' | 'timed_out', string]> = [
+      ['shipped', '<html>shipped</html>'],
+      ['below_threshold', '<html>below</html>'],
+      ['interrupted', '<html>cut</html>'],
+      ['timed_out', '<html>tick</html>'],
+    ];
+    for (const [state, body] of cases) {
+      const id = `crun_${state}`;
+      const { absPath } = seedRowWithArtifact(db, artifactsRoot, {
+        runId: id,
+        projectId: 'p1',
+        body,
+        extension: 'html',
+      });
+      // Override status to the case-specific value.
+      updateCritiqueRun(db, id, { status: state, artifactPath: absPath });
+
+      const { status, body: served } = await get(
+        `${baseUrl}/api/projects/p1/critique/${id}/artifact`,
+      );
+      expect(status).toBe(200);
+      expect(served).toBe(body);
+    }
+  });
+});

--- a/apps/daemon/tests/critique-artifact-writer.test.ts
+++ b/apps/daemon/tests/critique-artifact-writer.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for the SHIP <ARTIFACT> writer module.
+ *
+ * The writer is the daemon's only path for turning a parser-side payload
+ * into bytes on disk; the artifact endpoint serves whatever this module
+ * produced, so the mime → extension contract and the size cap matter for
+ * production correctness, not just developer ergonomics.
+ *
+ * @see specs/current/critique-theater.md § rerun endpoint (Task 6.2)
+ */
+import { mkdtempSync, readFileSync, statSync } from 'node:fs';
+import { rm, readdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  ARTIFACT_WRITER_INTERNALS,
+  ArtifactEmptyError,
+  ArtifactTooLargeError,
+  extensionForMime,
+  mimeForExtension,
+  writeShipArtifact,
+} from '../src/critique/artifact-writer.js';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'od-artifact-writer-'));
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe('writeShipArtifact', () => {
+  it('writes the body verbatim and resolves the canonical mime + extension', async () => {
+    const result = await writeShipArtifact(
+      dir,
+      '<html><body>final</body></html>',
+      'text/html',
+    );
+
+    expect(result.mime).toBe('text/html');
+    expect(result.extension).toBe('html');
+    expect(result.filename).toBe('artifact.html');
+    expect(result.absPath).toBe(join(dir, 'artifact.html'));
+    expect(result.sizeBytes).toBe(31);
+    expect(readFileSync(result.absPath, 'utf8')).toBe('<html><body>final</body></html>');
+  });
+
+  it('strips charset parameters and case before mime lookup', async () => {
+    const result = await writeShipArtifact(
+      dir,
+      '/* css */',
+      'Text/CSS; charset=utf-8',
+    );
+
+    expect(result.mime).toBe('text/css');
+    expect(result.extension).toBe('css');
+    expect(readFileSync(result.absPath, 'utf8')).toBe('/* css */');
+  });
+
+  it('falls back to application/octet-stream + .bin for unknown mime types', async () => {
+    const result = await writeShipArtifact(dir, 'binary-ish', 'application/x-zip');
+
+    expect(result.mime).toBe('application/octet-stream');
+    expect(result.extension).toBe('bin');
+    expect(result.filename).toBe('artifact.bin');
+    expect(readFileSync(result.absPath, 'utf8')).toBe('binary-ish');
+  });
+
+  it('falls back to the binary extension for empty / whitespace-only mime input', async () => {
+    const result = await writeShipArtifact(dir, 'something', '');
+
+    expect(result.mime).toBe('application/octet-stream');
+    expect(result.extension).toBe('bin');
+  });
+
+  it('refuses zero-byte bodies with ArtifactEmptyError', async () => {
+    await expect(writeShipArtifact(dir, '', 'text/html'))
+      .rejects.toBeInstanceOf(ArtifactEmptyError);
+  });
+
+  it('throws ArtifactTooLargeError when the body exceeds the configured cap', async () => {
+    const body = 'a'.repeat(2048);
+    await expect(
+      writeShipArtifact(dir, body, 'text/html', { maxBytes: 1024 }),
+    ).rejects.toBeInstanceOf(ArtifactTooLargeError);
+  });
+
+  it('rejects via UTF-8 byte length, not JS string length, for multi-byte payloads', async () => {
+    // Each Unicode emoji is 4 bytes in UTF-8 but 2 chars in JS string length.
+    // Cap of 5 bytes must reject a string whose JS .length is 2 but byte
+    // length is 8.
+    const body = '🎨🎨';
+    expect(body.length).toBe(4);
+    expect(Buffer.byteLength(body, 'utf8')).toBe(8);
+    await expect(
+      writeShipArtifact(dir, body, 'text/html', { maxBytes: 5 }),
+    ).rejects.toBeInstanceOf(ArtifactTooLargeError);
+  });
+
+  it('does not leave a tmp sibling when the write succeeds', async () => {
+    await writeShipArtifact(dir, '<html></html>', 'text/html');
+
+    const entries = await readdir(dir);
+    expect(entries).toEqual(['artifact.html']);
+  });
+
+  it('overwrites a previous artifact in the same directory atomically', async () => {
+    const first = await writeShipArtifact(dir, '<html>v1</html>', 'text/html');
+    const second = await writeShipArtifact(dir, '<html>v2</html>', 'text/html');
+
+    expect(second.absPath).toBe(first.absPath);
+    expect(readFileSync(second.absPath, 'utf8')).toBe('<html>v2</html>');
+    const entries = await readdir(dir);
+    expect(entries).toEqual(['artifact.html']);
+  });
+
+  it('writes deterministic file size that matches the byte-length reported on the result', async () => {
+    const body = 'a'.repeat(123);
+    const result = await writeShipArtifact(dir, body, 'text/plain');
+
+    expect(result.sizeBytes).toBe(123);
+    expect(statSync(result.absPath).size).toBe(123);
+  });
+});
+
+describe('extensionForMime / mimeForExtension', () => {
+  it('round-trips every known mime', () => {
+    for (const [mime, ext] of Object.entries(
+      ARTIFACT_WRITER_INTERNALS.ARTIFACT_MIME_EXTENSIONS,
+    )) {
+      expect(extensionForMime(mime)).toBe(ext);
+      expect(mimeForExtension(ext)).toBe(mime);
+    }
+  });
+
+  it('returns the binary fallback for unknown extensions and mimes', () => {
+    expect(extensionForMime('application/x-foo')).toBe(
+      ARTIFACT_WRITER_INTERNALS.FALLBACK_EXTENSION,
+    );
+    expect(mimeForExtension('xyz')).toBe(ARTIFACT_WRITER_INTERNALS.FALLBACK_MIME);
+  });
+
+  it('strips a leading dot from extension lookups', () => {
+    expect(mimeForExtension('.html')).toBe('text/html');
+    expect(mimeForExtension('html')).toBe('text/html');
+  });
+});

--- a/apps/daemon/tests/critique-lifecycle.test.ts
+++ b/apps/daemon/tests/critique-lifecycle.test.ts
@@ -1,15 +1,16 @@
 /**
- * Regression tests for round 3 review feedback on PR #481:
+ * Regression tests for round 3 review feedback on PR #481, plus the
+ * Phase 6.2 artifact-extraction expansion:
  *   - A signal-terminated child (e.g. SIGTERM from /api/runs/:id/cancel)
  *     finalizes the critique row as 'interrupted', not 'below_threshold'.
  *     The synthetic ship event for the best-so-far round carries
  *     status='interrupted' so transcripts and SSE clients see the real cause.
- *   - artifactPath persisted with the row stays null on shipped runs until a
- *     future phase actually writes the SHIP <ARTIFACT> body to disk. The
- *     transcript still records the ship event so consumers can find the run.
+ *   - Shipped runs now persist the SHIP <ARTIFACT> body to disk and pin
+ *     the absolute path on the row, so the artifact endpoint can stream
+ *     the bytes the agent shipped (CDATA wrapper stripped).
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync } from 'node:fs';
+import { mkdtempSync, existsSync, readFileSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -125,7 +126,7 @@ describe('orchestrator lifecycle (PR #481 round 3 review)', () => {
     expect(result.composite!).toBeGreaterThan(8.0);
   });
 
-  it('shipped run persists artifactPath=null until artifact extraction lands', async () => {
+  it('shipped run persists the SHIP <ARTIFACT> body to disk and pins the absolute path on the row', async () => {
     const { bus } = makeBus();
     const artifactDir = join(tmpDir, 'no-artifact');
 
@@ -165,8 +166,15 @@ describe('orchestrator lifecycle (PR #481 round 3 review)', () => {
     });
 
     expect(result.status).toBe('shipped');
-    expect(result.artifactPath).toBeNull();
+    expect(result.artifactPath).toBeTruthy();
+    expect(result.artifactPath!.endsWith('artifact.html')).toBe(true);
+
     const row = getCritiqueRun(db, 'r-shipped');
-    expect(row?.artifactPath).toBeNull();
+    expect(row?.artifactPath).toBe(result.artifactPath);
+
+    // The bytes on disk are exactly what the agent shipped, with the
+    // CDATA wrapper from the SHIP <ARTIFACT> stripped.
+    expect(existsSync(result.artifactPath!)).toBe(true);
+    expect(readFileSync(result.artifactPath!, 'utf8')).toBe('<html><body>final</body></html>');
   });
 });

--- a/apps/daemon/tests/critique-orchestrator.test.ts
+++ b/apps/daemon/tests/critique-orchestrator.test.ts
@@ -187,10 +187,29 @@ describe('runOrchestrator - happy path', () => {
     const transcriptFile = join(artifactDir, result.transcriptPath!);
     expect(existsSync(transcriptFile)).toBe(true);
 
+    // Phase 6.2 artifact persistence: the SHIP <ARTIFACT> body lands on
+    // disk, the row carries an absolute path to it, and the file contains
+    // the exact bytes the agent shipped (CDATA wrapper stripped).
+    expect(result.artifactPath).toBeTruthy();
+    expect(row?.artifactPath).toBe(result.artifactPath);
+    expect(existsSync(result.artifactPath!)).toBe(true);
+    expect(result.artifactPath!.endsWith('artifact.html')).toBe(true);
+    expect(readFileSync(result.artifactPath!, 'utf8')).toBe('<html><body>final</body></html>');
+
     // SSE events emitted: should include run_started and ship.
     const eventNames = events.map((e) => e.event);
     expect(eventNames).toContain('critique.run_started');
     expect(eventNames).toContain('critique.ship');
+
+    // SSE ship payload must NOT carry the artifact body or the mime,
+    // those travel only through the parser side-channel and the on-disk
+    // file. Broadcasting megabytes of HTML to every SSE subscriber would
+    // ruin the bus.
+    const shipEvent = events.find((e) => e.event === 'critique.ship');
+    expect(shipEvent).toBeTruthy();
+    const shipData = shipEvent?.data as Record<string, unknown>;
+    expect(shipData['body']).toBeUndefined();
+    expect(shipData['mime']).toBeUndefined();
   });
 
   it('SSE events are emitted in source order', async () => {
@@ -215,6 +234,57 @@ describe('runOrchestrator - happy path', () => {
     const shipIdx = names.lastIndexOf('critique.ship');
     expect(runStartedIdx).toBe(0);
     expect(shipIdx).toBeGreaterThan(runStartedIdx);
+  });
+
+  // Regression: lefarcen P1 on PR #1085. SSE clients react to
+  // critique.ship by fetching the artifact endpoint, so the file must
+  // exist on disk AND the row must already have artifactPath populated
+  // by the time critique.ship goes out, otherwise a fast client races
+  // the writer and gets a 404 against a row that is about to gain its
+  // path on the next finalize call.
+  it('does not emit critique.ship until the artifact is on disk and the row has artifactPath', async () => {
+    const events: CritiqueSseEvent[] = [];
+    const observations: Array<{
+      artifactPathOnRow: string | null;
+      fileExistsOnDisk: boolean;
+    }> = [];
+    const artifactDir = join(tmpDir, 'run-ordering');
+    const bus: CritiqueSseBus = {
+      emit: (e) => {
+        events.push(e);
+        if (e.event === 'critique.ship') {
+          // Snapshot the row + filesystem AT THE MOMENT the ship event
+          // fires. Any client subscribed to the SSE bus would observe
+          // exactly this state when it reacts to the event.
+          const row = getCritiqueRun(db, 'r-order-race');
+          observations.push({
+            artifactPathOnRow: row?.artifactPath ?? null,
+            fileExistsOnDisk:
+              row?.artifactPath != null ? existsSync(row.artifactPath) : false,
+          });
+        }
+      },
+    };
+
+    await runOrchestrator({
+      runId: 'r-order-race',
+      projectId: 'p1',
+      conversationId: null,
+      artifactId: 'a1',
+      artifactDir,
+      adapter: 'claude',
+      cfg: defaultCritiqueConfig(),
+      db,
+      bus,
+      stdout: streamOf(happyStream3Rounds()),
+    });
+
+    // Exactly one critique.ship event was observed and at that instant
+    // the row already carried artifactPath and the file already
+    // existed on disk.
+    expect(observations).toHaveLength(1);
+    expect(observations[0]?.artifactPathOnRow).toBeTruthy();
+    expect(observations[0]?.fileExistsOnDisk).toBe(true);
   });
 });
 

--- a/apps/daemon/tests/parser.test.ts
+++ b/apps/daemon/tests/parser.test.ts
@@ -413,3 +413,220 @@ describe('parseCritiqueStream -- Defects 3+5 regressions', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// SHIP <ARTIFACT> body extraction
+//
+// The earlier extractor used a single `<ARTIFACT\b([^>]*)>([\s\S]*?)</ARTIFACT>`
+// match, which truncated at the first literal `</ARTIFACT>` inside the
+// body. Real shipped HTML / SVG / JS bodies wrapped in CDATA can legitimately
+// contain that sentinel inside a string or comment. The CDATA-aware
+// extractor scans for `]]></ARTIFACT>` instead so the round-trip preserves
+// arbitrary bytes the agent shipped (mrcfps follow-up on PR #1085).
+// ---------------------------------------------------------------------------
+
+describe('parseCritiqueStream -- SHIP <ARTIFACT> CDATA-aware extraction', () => {
+  // Build a minimal complete v1 stream around a SHIP whose <ARTIFACT> body
+  // is the literal text we want to test.
+  function streamWithArtifact(body: string, mime = 'text/html'): string {
+    return `<CRITIQUE_RUN version="1" maxRounds="1" threshold="8.0" scale="10">
+  <ROUND n="1">
+    <PANELIST role="designer">
+      <NOTES>v1</NOTES>
+      <ARTIFACT mime="text/html"><![CDATA[<p>v1</p>]]></ARTIFACT>
+    </PANELIST>
+    <PANELIST role="critic" score="9"><DIM name="x" score="9">ok</DIM></PANELIST>
+    <PANELIST role="brand" score="9"><DIM name="x" score="9">ok</DIM></PANELIST>
+    <PANELIST role="a11y" score="9"><DIM name="x" score="9">ok</DIM></PANELIST>
+    <PANELIST role="copy" score="9"><DIM name="x" score="9">ok</DIM></PANELIST>
+    <ROUND_END n="1" composite="9" must_fix="0" decision="ship"><REASON>ok</REASON></ROUND_END>
+  </ROUND>
+  <SHIP round="1" composite="9" status="shipped">
+    <ARTIFACT mime="${mime}">${body}</ARTIFACT>
+    <SUMMARY>Done.</SUMMARY>
+  </SHIP>
+</CRITIQUE_RUN>`;
+  }
+
+  it('preserves a CDATA-wrapped JS body that contains the literal `</ARTIFACT>` sentinel inside a string', async () => {
+    const dangerousBody = `<![CDATA[<script>const s = "</ARTIFACT>";</script>]]>`;
+    const captured: Array<{ round: number; mime: string; body: string }> = [];
+    await collect(
+      parseCritiqueStream(chunkify(streamWithArtifact(dangerousBody)), {
+        runId: 't-cdata',
+        adapter: 'test',
+        parserMaxBlockBytes: 262_144,
+        onArtifact: (info) => captured.push(info),
+      }),
+    );
+
+    expect(captured).toHaveLength(1);
+    // The CDATA wrapper is stripped; the embedded `</ARTIFACT>` sentinel
+    // travels through verbatim and the writer would persist it byte-for-byte.
+    expect(captured[0]?.body).toBe(`<script>const s = "</ARTIFACT>";</script>`);
+    expect(captured[0]?.mime).toBe('text/html');
+  });
+
+  it('preserves a CDATA body that contains the literal `</ARTIFACT>` sentinel inside an HTML comment', async () => {
+    const body = `<![CDATA[<!-- bookmark: </ARTIFACT> --><p>real</p>]]>`;
+    const captured: Array<{ round: number; mime: string; body: string }> = [];
+    await collect(
+      parseCritiqueStream(chunkify(streamWithArtifact(body)), {
+        runId: 't-cdata-comment',
+        adapter: 'test',
+        parserMaxBlockBytes: 262_144,
+        onArtifact: (info) => captured.push(info),
+      }),
+    );
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.body).toBe(`<!-- bookmark: </ARTIFACT> --><p>real</p>`);
+  });
+
+  it('still extracts a non-CDATA inline body that does NOT contain the sentinel', async () => {
+    const body = `<p>plain inline body</p>`;
+    const captured: Array<{ round: number; mime: string; body: string }> = [];
+    await collect(
+      parseCritiqueStream(chunkify(streamWithArtifact(body)), {
+        runId: 't-inline',
+        adapter: 'test',
+        parserMaxBlockBytes: 262_144,
+        onArtifact: (info) => captured.push(info),
+      }),
+    );
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.body).toBe(`<p>plain inline body</p>`);
+  });
+
+  it('tolerates whitespace between the `]]>` CDATA terminator and `</ARTIFACT>`', async () => {
+    const body = `<![CDATA[<p>spaced</p>]]>\n  `;
+    // Intentionally insert a newline + spaces between the CDATA close and
+    // the `</ARTIFACT>` tag so a regex that requires the close to be
+    // immediately followed by `</ARTIFACT>` would miss it.
+    const stream = `<CRITIQUE_RUN version="1" maxRounds="1" threshold="8.0" scale="10">
+  <ROUND n="1">
+    <PANELIST role="designer">
+      <NOTES>v1</NOTES>
+      <ARTIFACT mime="text/html"><![CDATA[<p>v1</p>]]></ARTIFACT>
+    </PANELIST>
+    <PANELIST role="critic" score="9"><DIM name="x" score="9">ok</DIM></PANELIST>
+    <PANELIST role="brand" score="9"><DIM name="x" score="9">ok</DIM></PANELIST>
+    <PANELIST role="a11y" score="9"><DIM name="x" score="9">ok</DIM></PANELIST>
+    <PANELIST role="copy" score="9"><DIM name="x" score="9">ok</DIM></PANELIST>
+    <ROUND_END n="1" composite="9" must_fix="0" decision="ship"><REASON>ok</REASON></ROUND_END>
+  </ROUND>
+  <SHIP round="1" composite="9" status="shipped">
+    <ARTIFACT mime="text/html">${body}
+</ARTIFACT>
+    <SUMMARY>Done.</SUMMARY>
+  </SHIP>
+</CRITIQUE_RUN>`;
+
+    const captured: Array<{ round: number; mime: string; body: string }> = [];
+    await collect(
+      parseCritiqueStream(chunkify(stream), {
+        runId: 't-pretty',
+        adapter: 'test',
+        parserMaxBlockBytes: 262_144,
+        onArtifact: (info) => captured.push(info),
+      }),
+    );
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.body).toBe('<p>spaced</p>');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SHIP boundary sentinel safety
+//
+// The parser walks the SHIP block by `indexOf('</SHIP>')` and the ship
+// summary by `<SUMMARY>` regex on the SHIP inner. Both used to be
+// non-CDATA-aware, so an agent shipping arbitrary HTML / JS bodies that
+// happened to contain those literal sentinels inside a CDATA wrapper
+// could either truncate the SHIP block early (lefarcen P2) or hijack the
+// ship summary text (mrcfps follow-up). Both lookups now skip CDATA
+// spans, so the streamed bytes round-trip intact and the sibling tags
+// resolve to the real outer occurrences.
+// ---------------------------------------------------------------------------
+
+describe('parseCritiqueStream -- SHIP sentinel safety inside CDATA', () => {
+  function streamWithArtifactAndSummary(
+    artifactBody: string,
+    summary: string,
+  ): string {
+    return `<CRITIQUE_RUN version="1" maxRounds="1" threshold="8.0" scale="10">
+  <ROUND n="1">
+    <PANELIST role="designer">
+      <NOTES>v1</NOTES>
+      <ARTIFACT mime="text/html"><![CDATA[<p>v1</p>]]></ARTIFACT>
+    </PANELIST>
+    <PANELIST role="critic" score="9"><DIM name="x" score="9">ok</DIM></PANELIST>
+    <PANELIST role="brand" score="9"><DIM name="x" score="9">ok</DIM></PANELIST>
+    <PANELIST role="a11y" score="9"><DIM name="x" score="9">ok</DIM></PANELIST>
+    <PANELIST role="copy" score="9"><DIM name="x" score="9">ok</DIM></PANELIST>
+    <ROUND_END n="1" composite="9" must_fix="0" decision="ship"><REASON>ok</REASON></ROUND_END>
+  </ROUND>
+  <SHIP round="1" composite="9" status="shipped">
+    <ARTIFACT mime="text/html">${artifactBody}</ARTIFACT>
+    <SUMMARY>${summary}</SUMMARY>
+  </SHIP>
+</CRITIQUE_RUN>`;
+  }
+
+  it('uses the real ship summary even when the artifact CDATA contains a literal <SUMMARY> pair before it', async () => {
+    // The artifact body contains `<SUMMARY>artifact text</SUMMARY>` BEFORE
+    // the real sibling SUMMARY. A naive regex against the full SHIP inner
+    // would grab the artifact-internal pair first and emit "artifact text"
+    // as the ship summary.
+    const artifactBody =
+      `<![CDATA[<div><SUMMARY>artifact text</SUMMARY></div><p>real artifact body</p>]]>`;
+    const realSummary = 'Design converged after one round.';
+
+    const events = await collect(
+      parseCritiqueStream(chunkify(streamWithArtifactAndSummary(artifactBody, realSummary)), {
+        runId: 't-summary-hijack',
+        adapter: 'test',
+        parserMaxBlockBytes: 262_144,
+      }),
+    );
+
+    const ship = events.find((e) => e.type === 'ship');
+    expect(ship).toBeDefined();
+    if (ship && ship.type === 'ship') {
+      expect(ship.summary).toBe(realSummary);
+    }
+  });
+
+  it('finds the real </SHIP> closer even when the artifact CDATA contains a literal </SHIP> string', async () => {
+    // The artifact body contains `</SHIP>` inside a JS string. A naive
+    // `slice.indexOf('</SHIP>')` would treat that as the SHIP closer,
+    // truncating before the real `</ARTIFACT>` and `</SUMMARY>` siblings
+    // and leaving the parser in a corrupted state.
+    const artifactBody =
+      `<![CDATA[<script>const s = "</SHIP>";</script><p>real body</p>]]>`;
+    const realSummary = 'Honored the closer outside CDATA.';
+
+    const captured: Array<{ round: number; mime: string; body: string }> = [];
+    const events = await collect(
+      parseCritiqueStream(chunkify(streamWithArtifactAndSummary(artifactBody, realSummary)), {
+        runId: 't-ship-close-hijack',
+        adapter: 'test',
+        parserMaxBlockBytes: 262_144,
+        onArtifact: (info) => captured.push(info),
+      }),
+    );
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.body).toBe(
+      `<script>const s = "</SHIP>";</script><p>real body</p>`,
+    );
+
+    const ship = events.find((e) => e.type === 'ship');
+    expect(ship).toBeDefined();
+    if (ship && ship.type === 'ship') {
+      expect(ship.summary).toBe(realSummary);
+    }
+  });
+});

--- a/packages/contracts/src/critique.ts
+++ b/packages/contracts/src/critique.ts
@@ -217,3 +217,57 @@ export const CRITIQUE_RUN_STATUSES = [
   'failed',
   'legacy',
 ] as const satisfies readonly CritiqueRunStatus[];
+
+/**
+ * Compile-time guarantee that every `CritiqueRunStatus` variant appears in
+ * `CRITIQUE_RUN_STATUSES`. `satisfies` only proves each listed value is
+ * valid; this assertion proves the list is exhaustive, so adding a new
+ * variant to `CritiqueRunStatus` (or `ShipStatus`) without updating the
+ * array fails the build with a tuple naming the missing variants. Picked
+ * up from lefarcen P3 on PR #1016. The exported helper type is reusable
+ * by other shared enums (e.g. `PANELIST_ROLES`) once they need the same
+ * guard.
+ */
+export type AssertExhaustiveValues<T extends string, U extends readonly T[]> =
+  Exclude<T, U[number]> extends never
+    ? true
+    : ['Missing variants in array:', Exclude<T, U[number]>];
+
+const _critiqueRunStatusesExhaustive: AssertExhaustiveValues<
+  CritiqueRunStatus,
+  typeof CRITIQUE_RUN_STATUSES
+> = true;
+// Reference the binding so esbuild does not tree-shake it; the assignment
+// itself is what enforces the exhaustiveness guarantee at compile time.
+void _critiqueRunStatusesExhaustive;
+
+/**
+ * Internal-to-the-daemon row status. Adds the in-flight `'running'` value
+ * the DB CHECK constraint accepts to the public `CritiqueRunStatus` union
+ * so DB-row types can be precisely typed without inline `as X | 'running'`
+ * widens at every call site. Every public DTO continues to use the
+ * terminal-only `CritiqueRunStatus` so a future endpoint cannot leak a
+ * 'running' row through the wire. Picked up from lefarcen P2 on PR #1016.
+ */
+export type CritiquePersistedStatus = CritiqueRunStatus | 'running';
+
+/**
+ * Logical handle the daemon hands to the web layer for a critique run's
+ * shipped artifact. Web clients never see daemon filesystem paths; they
+ * fetch the artifact bytes via the `url` field, which the daemon serves
+ * with the right `Content-Type` header derived from `mime`. Returned by
+ * the rerun endpoint and the `GET /api/projects/:projectId/critique/:runId/artifact`
+ * route that streams the bytes.
+ */
+export interface CritiqueArtifactRef {
+  /** The owning project; matches the URL segment. */
+  projectId: string;
+  /** The owning critique run; matches the URL segment. */
+  runId: string;
+  /** Content-Type announced by the agent in `<ARTIFACT mime="…">`. */
+  mime: string;
+  /** Size of the artifact body in bytes, as written to disk. */
+  sizeBytes: number;
+  /** Daemon-relative HTTP path the web layer fetches to stream the bytes. */
+  url: string;
+}


### PR DESCRIPTION
Step (b) of the four-step Phase 6.2 unblock plan that closed [#1006](https://github.com/nexu-io/open-design/pull/1006). Step (a) was the contracts move in [#1016](https://github.com/nexu-io/open-design/pull/1016). This PR is the foundational change that makes a real rerun endpoint possible: the orchestrator now actually persists the SHIP `<ARTIFACT>` body, and the web layer has a logical handle to fetch it.

## What lands

**Parser side-channel.** [`apps/daemon/src/critique/parser.ts`](https://github.com/nexu-io/open-design/blob/feat/critique-theater-phase6.2-artifact-extraction/apps/daemon/src/critique/parser.ts) and [`parsers/v1.ts`](https://github.com/nexu-io/open-design/blob/feat/critique-theater-phase6.2-artifact-extraction/apps/daemon/src/critique/parsers/v1.ts) capture the `mime` attribute and CDATA-stripped body of the SHIP `<ARTIFACT>` block, then call an `onArtifact` callback synchronously right before yielding the ship `PanelEvent`. The body and mime intentionally never join the `PanelEvent` itself, so they never broadcast on the SSE wire.

**Artifact writer.** New module [`apps/daemon/src/critique/artifact-writer.ts`](https://github.com/nexu-io/open-design/blob/feat/critique-theater-phase6.2-artifact-extraction/apps/daemon/src/critique/artifact-writer.ts) turns a `(dir, body, mime)` triple into bytes on disk. Highlights:

- Mime allowlist (`text/html`, `text/css`, `text/markdown`, `text/plain`, `application/json`, `image/svg+xml`); everything else falls through to `application/octet-stream` + `.bin` so unknown payloads cannot be misinterpreted as a known type.
- UTF-8 byte-length cap (defaults to 1 MiB, the orchestrator passes `cfg.parserMaxBlockBytes`), so multi-byte payloads cannot sneak past a JS `.length` check. Caught by a dedicated test using emoji.
- Atomic write: render to a sibling `.tmp.<pid>.<ts>` file then rename, so a daemon crash mid-write cannot leave a half-written artifact under the canonical name. The tmp file is unlinked on rename failure.
- Typed `ArtifactTooLargeError` and `ArtifactEmptyError` so the orchestrator can route an oversize body separately from a filesystem error.

**Orchestrator wiring.** [`apps/daemon/src/critique/orchestrator.ts`](https://github.com/nexu-io/open-design/blob/feat/critique-theater-phase6.2-artifact-extraction/apps/daemon/src/critique/orchestrator.ts) buffers the parser's `ShipArtifactPayload`, calls `writeShipArtifact` after `decideRound` runs, and pins the absolute path on the row through the existing finalize pipeline. Failures here log a warning and finalize with `artifactPath = null` rather than aborting the run, so the artifact endpoint returns 404 instead of pointing at a missing file. `OrchestratorResult.status` is now terminal-only (`CritiqueRunStatus`), no longer the wider `CritiquePersistedStatus`.

**Artifact endpoint.** New module [`apps/daemon/src/critique/artifact-handler.ts`](https://github.com/nexu-io/open-design/blob/feat/critique-theater-phase6.2-artifact-extraction/apps/daemon/src/critique/artifact-handler.ts) serves `GET /api/projects/:projectId/critique/:runId/artifact`. The web layer never sees daemon paths; it streams bytes through this URL with the right `Content-Type`. Defense in depth:

- Cross-project leak guard returns `404` (not `403`) when a runId belongs to another project, mirroring the interrupt handler.
- Path-traversal guard resolves the row's `artifactPath` against the artifacts root and refuses anything outside it.
- Symlinks and non-regular files refused with `404` (defends against a tampered DB row pointing at `/etc/passwd`-style targets).
- Response size cap stops a tampered file from streaming unbounded bytes even if it slipped past the writer.
- `Content-Security-Policy: default-src 'none'; img-src data:; style-src 'unsafe-inline'` on HTML and SVG so the bytes are inert when fetched outside the web layer's sandbox iframe.
- `Cache-Control: private, max-age=3600` since artifacts are content-addressed by `runId` and never re-written.

## Folded in from PR #1016 review

[lefarcen left two non-blocking notes on #1016](https://github.com/nexu-io/open-design/pull/1016) (the contracts move). Both are closed here since `persistence.ts` was already in scope:

- **P2** introduced `CritiquePersistedStatus = CritiqueRunStatus | 'running'` in the contracts package. `CritiqueRunRow.status` and `CritiqueRunInsert.status` now use it, and the inline `as CritiqueRunStatus | 'running'` widen in [`interrupt-handler.ts`](https://github.com/nexu-io/open-design/blob/feat/critique-theater-phase6.2-artifact-extraction/apps/daemon/src/critique/interrupt-handler.ts) is gone. Public DTOs continue to use the terminal-only `CritiqueRunStatus`.
- **P3** added `AssertExhaustiveValues` and a compile-time assertion in [`packages/contracts/src/critique.ts`](https://github.com/nexu-io/open-design/blob/feat/critique-theater-phase6.2-artifact-extraction/packages/contracts/src/critique.ts) that proves `CRITIQUE_RUN_STATUSES` covers every `CritiqueRunStatus` variant. Adding a value to `ShipStatus` without updating the array now fails the build with a tuple naming the missing variants.

## Coverage

174 critique tests pass locally across 14 files, including:

- New [`critique-artifact-writer.test.ts`](https://github.com/nexu-io/open-design/blob/feat/critique-theater-phase6.2-artifact-extraction/apps/daemon/tests/critique-artifact-writer.test.ts) (13 unit tests) covering body/mime/extension contract, charset stripping, UTF-8 byte-length cap, atomic write, overwrite, no leftover tmp files.
- New [`critique-artifact-endpoint.test.ts`](https://github.com/nexu-io/open-design/blob/feat/critique-theater-phase6.2-artifact-extraction/apps/daemon/tests/critique-artifact-endpoint.test.ts) (11 endpoint tests) covering happy path on html/svg/bin, 404 unknown / cross-project / no-artifact / outside-root / vanished-file / symlink / whitespace-runId, plus terminal-status fan-out.
- Extended [`critique-orchestrator.test.ts`](https://github.com/nexu-io/open-design/blob/feat/critique-theater-phase6.2-artifact-extraction/apps/daemon/tests/critique-orchestrator.test.ts) happy-path: asserts `result.artifactPath` is set, the file exists, the bytes match, and the SSE ship payload does NOT carry `body` or `mime`.
- Inverted [`critique-lifecycle.test.ts`](https://github.com/nexu-io/open-design/blob/feat/critique-theater-phase6.2-artifact-extraction/apps/daemon/tests/critique-lifecycle.test.ts) — the old "artifactPath stays null" regression is now "artifactPath is the absolute path and the bytes are the SHIP body with CDATA stripped".

## Validation

- `pnpm guard` clean.
- `pnpm --filter @open-design/contracts build` clean.
- `pnpm --filter @open-design/daemon build` clean (full tsc, the same step CI runs).
- `pnpm --filter @open-design/web typecheck` clean (sanity check that the contracts changes do not break web).
- `pnpm --filter @open-design/daemon exec vitest run tests/critique` (14 files, 174 tests, all green).

## What's next

Steps (c) and (d) of the unblock plan: persist `original_message_id` / `agent_id` / `model_id` so the rerun handler can resolve the exact original brief, then re-implement the rerun endpoint on top of (a)+(b)+(c) with end-to-end tests that go through `runOrchestrator`.