### PR TITLE
feat(web): add draggable resize handles in manual edit mode

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -4534,15 +4534,9 @@ function HtmlViewer({
     </div>
   );
 
-  // ARIA max widths — use current sibling panel widths, not their mins
-  const ariaWs = workspaceRef.current;
-  const ariaWsW = ariaWs ? ariaWs.clientWidth : 0;
-  const ariaLayersMax = ariaWsW
-    ? Math.max(LAYERS_MIN_WIDTH, Math.round(ariaWsW - MANUAL_EDIT_HANDLE_WIDTH * 2 - EDITOR_MIN_WIDTH - previewPanelWidth))
-    : 9999;
-  const ariaPreviewMax = ariaWsW
-    ? Math.max(PREVIEW_PANEL_MIN_WIDTH, Math.round(ariaWsW - MANUAL_EDIT_HANDLE_WIDTH * 2 - layersWidth - EDITOR_MIN_WIDTH))
-    : 9999;
+  // ARIA max widths — derived from redistributeWidths limits (no DOM measurement needed)
+  const ariaLayersMax = Math.max(LAYERS_MIN_WIDTH, layersWidth + editorWidth - EDITOR_MIN_WIDTH);
+  const ariaPreviewMax = Math.max(PREVIEW_PANEL_MIN_WIDTH, previewPanelWidth + editorWidth - EDITOR_MIN_WIDTH);
 
   return (
     <div className="viewer html-viewer">

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -3084,6 +3084,7 @@ function HtmlViewer({
   const [editorWidth, setEditorWidth] = useState(() => readSavedWidth(EDITOR_WIDTH_KEY, EDITOR_DEFAULT_WIDTH, EDITOR_MIN_WIDTH));
   const [previewPanelWidth, setPreviewPanelWidth] = useState(() => readSavedWidth(PREVIEW_WIDTH_KEY, PREVIEW_PANEL_DEFAULT_WIDTH, PREVIEW_PANEL_MIN_WIDTH));
   const [resizingPanel, setResizingPanel] = useState<'layers' | 'preview' | null>(null);
+  const hasNormalizedRef = useRef(false);
   const layersWidthRef = useRef(layersWidth);
   const editorWidthRef = useRef(editorWidth);
   const previewPanelWidthRef = useRef(previewPanelWidth);
@@ -4395,11 +4396,15 @@ function HtmlViewer({
     if (pointerFrameRef.current !== null) cancelAnimationFrame(pointerFrameRef.current);
   }, []);
 
-  // Re-clamp restored widths against the actual workspace width (not viewport)
+  // Re-clamp restored widths against the actual workspace width (not viewport).
+  // Runs once: after source loads and manualEditMode makes the workspace visible.
   useLayoutEffect(() => {
+    if (hasNormalizedRef.current) return;
     const ws = workspaceRef.current;
     if (!ws) return;
-    const available = ws.clientWidth - MANUAL_EDIT_HANDLE_WIDTH * 2 - 4 * MANUAL_EDIT_GAP;
+    const cs = window.getComputedStyle(ws);
+    const padH = Number.parseFloat(cs.paddingLeft) + Number.parseFloat(cs.paddingRight);
+    const available = ws.clientWidth - padH - MANUAL_EDIT_HANDLE_WIDTH * 2 - 4 * MANUAL_EDIT_GAP;
     if (available <= 0) return;
     const n = normalizePanelWidths(
       layersWidthRef.current,
@@ -4413,7 +4418,8 @@ function HtmlViewer({
     setEditorWidth(n.editor);
     previewPanelWidthRef.current = n.preview;
     setPreviewPanelWidth(n.preview);
-  }, []);
+    hasNormalizedRef.current = true;
+  }, [source, manualEditMode]);
 
   const handleResizePointerDown = useCallback((side: 'layers' | 'preview') => (event: React.PointerEvent<HTMLDivElement>) => {
     if (event.button !== 0) return;

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useId, useMemo, useRef, useState, type CSSProperties, type MouseEvent as ReactMouseEvent, type ReactNode } from 'react';
+import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState, type CSSProperties, type MouseEvent as ReactMouseEvent, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import { APP_CHROME_FILE_ACTIONS_ID } from './AppChromeHeader';
 import { MarkdownRenderer, artifactRendererRegistry } from '../artifacts/renderer-registry';
@@ -162,22 +162,45 @@ const MANUAL_EDIT_HANDLE_WIDTH = 8;
 const LAYERS_WIDTH_KEY = 'open-design.manualEdit.layersWidth';
 const EDITOR_WIDTH_KEY = 'open-design.manualEdit.editorWidth';
 const PREVIEW_WIDTH_KEY = 'open-design.manualEdit.previewWidth';
+const MANUAL_EDIT_GAP = 10;
 const MANUAL_EDIT_KEYBOARD_STEP = 16;
 
-function readSavedWidth(key: string, fallback: number, min: number, max: number): number {
+function readSavedWidth(key: string, fallback: number, min: number): number {
   if (typeof window === 'undefined') return fallback;
   try {
     const raw = window.localStorage.getItem(key);
     const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
-    if (!Number.isFinite(parsed)) return fallback;
-    const clampedMin = Math.max(min, Math.round(parsed));
-    return Math.min(clampedMin, max);
+    return Number.isFinite(parsed) ? Math.max(min, Math.round(parsed)) : fallback;
   } catch { return fallback; }
 }
 
-function panelMaxWidth(minOtherA: number, minOtherB: number): number {
-  if (typeof window === 'undefined') return 9999;
-  return Math.round(window.innerWidth - minOtherA - minOtherB - MANUAL_EDIT_HANDLE_WIDTH * 2);
+export function normalizePanelWidths(
+  layers: number,
+  editor: number,
+  preview: number,
+  available: number,
+): { layers: number; editor: number; preview: number } {
+  let l = Math.max(LAYERS_MIN_WIDTH, Math.round(layers));
+  let e = Math.max(EDITOR_MIN_WIDTH, Math.round(editor));
+  let p = Math.max(PREVIEW_PANEL_MIN_WIDTH, Math.round(preview));
+
+  let overflow = l + e + p - available;
+  if (overflow <= 0) return { layers: l, editor: e, preview: p };
+
+  // Squeeze editor first (flexible middle panel), then side panels if still overflowing
+  const squeezeE = Math.min(overflow, e - EDITOR_MIN_WIDTH);
+  e -= squeezeE;
+  overflow -= squeezeE;
+  if (overflow > 0) {
+    const squeezeL = Math.min(overflow, l - LAYERS_MIN_WIDTH);
+    l -= squeezeL;
+    overflow -= squeezeL;
+  }
+  if (overflow > 0) {
+    const squeezeP = Math.min(overflow, p - PREVIEW_PANEL_MIN_WIDTH);
+    p -= squeezeP;
+  }
+  return { layers: l, editor: e, preview: p };
 }
 
 function redistributeWidths(
@@ -3057,9 +3080,9 @@ function HtmlViewer({
   const manualEditSavingRef = useRef(false);
 
   // Manual edit panel resize state
-  const [layersWidth, setLayersWidth] = useState(() => readSavedWidth(LAYERS_WIDTH_KEY, LAYERS_DEFAULT_WIDTH, LAYERS_MIN_WIDTH, panelMaxWidth(EDITOR_MIN_WIDTH, PREVIEW_PANEL_MIN_WIDTH)));
-  const [editorWidth, setEditorWidth] = useState(() => readSavedWidth(EDITOR_WIDTH_KEY, EDITOR_DEFAULT_WIDTH, EDITOR_MIN_WIDTH, panelMaxWidth(LAYERS_MIN_WIDTH, PREVIEW_PANEL_MIN_WIDTH)));
-  const [previewPanelWidth, setPreviewPanelWidth] = useState(() => readSavedWidth(PREVIEW_WIDTH_KEY, PREVIEW_PANEL_DEFAULT_WIDTH, PREVIEW_PANEL_MIN_WIDTH, panelMaxWidth(LAYERS_MIN_WIDTH, EDITOR_MIN_WIDTH)));
+  const [layersWidth, setLayersWidth] = useState(() => readSavedWidth(LAYERS_WIDTH_KEY, LAYERS_DEFAULT_WIDTH, LAYERS_MIN_WIDTH));
+  const [editorWidth, setEditorWidth] = useState(() => readSavedWidth(EDITOR_WIDTH_KEY, EDITOR_DEFAULT_WIDTH, EDITOR_MIN_WIDTH));
+  const [previewPanelWidth, setPreviewPanelWidth] = useState(() => readSavedWidth(PREVIEW_WIDTH_KEY, PREVIEW_PANEL_DEFAULT_WIDTH, PREVIEW_PANEL_MIN_WIDTH));
   const [resizingPanel, setResizingPanel] = useState<'layers' | 'preview' | null>(null);
   const layersWidthRef = useRef(layersWidth);
   const editorWidthRef = useRef(editorWidth);
@@ -4370,6 +4393,26 @@ function HtmlViewer({
   useEffect(() => () => {
     pointerCleanupRef.current?.();
     if (pointerFrameRef.current !== null) cancelAnimationFrame(pointerFrameRef.current);
+  }, []);
+
+  // Re-clamp restored widths against the actual workspace width (not viewport)
+  useLayoutEffect(() => {
+    const ws = workspaceRef.current;
+    if (!ws) return;
+    const available = ws.clientWidth - MANUAL_EDIT_HANDLE_WIDTH * 2 - 4 * MANUAL_EDIT_GAP;
+    if (available <= 0) return;
+    const n = normalizePanelWidths(
+      layersWidthRef.current,
+      editorWidthRef.current,
+      previewPanelWidthRef.current,
+      available,
+    );
+    layersWidthRef.current = n.layers;
+    setLayersWidth(n.layers);
+    editorWidthRef.current = n.editor;
+    setEditorWidth(n.editor);
+    previewPanelWidthRef.current = n.preview;
+    setPreviewPanelWidth(n.preview);
   }, []);
 
   const handleResizePointerDown = useCallback((side: 'layers' | 'preview') => (event: React.PointerEvent<HTMLDivElement>) => {

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -4425,6 +4425,37 @@ function HtmlViewer({
     hasNormalizedRef.current = true;
   }, [source, manualEditMode]);
 
+  // Re-normalize when workspace width changes during an active manual-edit session
+  // (e.g., user drags the ProjectView chat/workspace split).
+  useEffect(() => {
+    if (!manualEditMode) return;
+    const ws = workspaceRef.current;
+    if (!ws) return;
+    const observer = new ResizeObserver(() => {
+      const cs = window.getComputedStyle(ws);
+      const padH = Number.parseFloat(cs.paddingLeft) + Number.parseFloat(cs.paddingRight);
+      const available = ws.clientWidth - padH - MANUAL_EDIT_HANDLE_WIDTH * 2 - 4 * MANUAL_EDIT_GAP;
+      if (available <= 0) return;
+      const n = normalizePanelWidths(
+        layersWidthRef.current,
+        editorWidthRef.current,
+        previewPanelWidthRef.current,
+        available,
+      );
+      if (n.layers === layersWidthRef.current
+        && n.editor === editorWidthRef.current
+        && n.preview === previewPanelWidthRef.current) return;
+      layersWidthRef.current = n.layers;
+      setLayersWidth(n.layers);
+      editorWidthRef.current = n.editor;
+      setEditorWidth(n.editor);
+      previewPanelWidthRef.current = n.preview;
+      setPreviewPanelWidth(n.preview);
+    });
+    observer.observe(ws);
+    return () => observer.disconnect();
+  }, [source, manualEditMode]);
+
   const handleResizePointerDown = useCallback((side: 'layers' | 'preview') => (event: React.PointerEvent<HTMLDivElement>) => {
     if (event.button !== 0) return;
     const workspace = workspaceRef.current;

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useMemo, useRef, useState, type CSSProperties, type MouseEvent as ReactMouseEvent, type ReactNode } from 'react';
+import { useCallback, useEffect, useId, useMemo, useRef, useState, type CSSProperties, type MouseEvent as ReactMouseEvent, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import { APP_CHROME_FILE_ACTIONS_ID } from './AppChromeHeader';
 import { MarkdownRenderer, artifactRendererRegistry } from '../artifacts/renderer-registry';
@@ -150,6 +150,53 @@ const MARKDOWN_CODE_BLOCK_ATTR = 'data-markdown-code-block';
 const MARKDOWN_COPY_BLOCK_ATTR = 'data-copy-code-block';
 const MARKDOWN_COPY_BUTTON_CLASS = 'markdown-code-copy';
 const MARKDOWN_COPY_TOAST_CLASS = 'markdown-code-toast';
+
+// Manual edit panel resize constants
+const LAYERS_MIN_WIDTH = 180;
+const LAYERS_DEFAULT_WIDTH = 240;
+const EDITOR_MIN_WIDTH = 280;
+const EDITOR_DEFAULT_WIDTH = 420;
+const PREVIEW_PANEL_MIN_WIDTH = 280;
+const PREVIEW_PANEL_DEFAULT_WIDTH = 344;
+const MANUAL_EDIT_HANDLE_WIDTH = 8;
+const LAYERS_WIDTH_KEY = 'open-design.manualEdit.layersWidth';
+const EDITOR_WIDTH_KEY = 'open-design.manualEdit.editorWidth';
+const PREVIEW_WIDTH_KEY = 'open-design.manualEdit.previewWidth';
+const MANUAL_EDIT_KEYBOARD_STEP = 16;
+
+function readSavedWidth(key: string, fallback: number): number {
+  if (typeof window === 'undefined') return fallback;
+  try {
+    const raw = window.localStorage.getItem(key);
+    const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
+    return Number.isFinite(parsed) ? Math.round(parsed) : fallback;
+  } catch { return fallback; }
+}
+
+function redistributeWidths(
+  side: 'layers' | 'preview',
+  delta: number,
+  layers: number,
+  editor: number,
+  preview: number,
+): { layers: number; editor: number; preview: number } {
+  if (side === 'layers') {
+    let newLayers = Math.max(LAYERS_MIN_WIDTH, Math.round(layers + delta));
+    let newEditor = editor - (newLayers - layers);
+    if (newEditor < EDITOR_MIN_WIDTH) {
+      newEditor = EDITOR_MIN_WIDTH;
+      newLayers = layers + editor - EDITOR_MIN_WIDTH;
+    }
+    return { layers: newLayers, editor: newEditor, preview };
+  }
+  let newPreview = Math.max(PREVIEW_PANEL_MIN_WIDTH, Math.round(preview - delta));
+  let newEditor = editor - (newPreview - preview);
+  if (newEditor < EDITOR_MIN_WIDTH) {
+    newEditor = EDITOR_MIN_WIDTH;
+    newPreview = preview + editor - EDITOR_MIN_WIDTH;
+  }
+  return { layers, editor: newEditor, preview: newPreview };
+}
 
 const DEPLOY_PROVIDER_OPTIONS: DeployProviderOption[] = [
   {
@@ -3001,6 +3048,28 @@ function HtmlViewer({
   const [manualEditError, setManualEditError] = useState<string | null>(null);
   const [manualEditSaving, setManualEditSaving] = useState(false);
   const manualEditSavingRef = useRef(false);
+
+  // Manual edit panel resize state
+  const [layersWidth, setLayersWidth] = useState(() => readSavedWidth(LAYERS_WIDTH_KEY, LAYERS_DEFAULT_WIDTH));
+  const [editorWidth, setEditorWidth] = useState(() => readSavedWidth(EDITOR_WIDTH_KEY, EDITOR_DEFAULT_WIDTH));
+  const [previewPanelWidth, setPreviewPanelWidth] = useState(() => readSavedWidth(PREVIEW_WIDTH_KEY, PREVIEW_PANEL_DEFAULT_WIDTH));
+  const [resizingPanel, setResizingPanel] = useState<'layers' | 'preview' | null>(null);
+  const layersWidthRef = useRef(layersWidth);
+  const editorWidthRef = useRef(editorWidth);
+  const previewPanelWidthRef = useRef(previewPanelWidth);
+  const workspaceRef = useRef<HTMLDivElement | null>(null);
+  const resizeStateRef = useRef<{
+    startClientX: number;
+    startLayers: number;
+    startEditor: number;
+    startPreview: number;
+    side: 'layers' | 'preview';
+    isRtl: boolean;
+  } | null>(null);
+  const pointerCleanupRef = useRef<(() => void) | null>(null);
+  const pointerFrameRef = useRef<number | null>(null);
+  const pendingPointerClientXRef = useRef<number | null>(null);
+
   const templateNameId = useId();
   const templateDescriptionId = useId();
   // Opt back into the legacy inline-asset srcDoc path via `?forceInline=1`
@@ -4287,6 +4356,178 @@ function HtmlViewer({
     return t('fileViewer.deployLinkPreparingLabel');
   };
 
+  // Manual edit panel resize handlers
+  useEffect(() => { layersWidthRef.current = layersWidth; }, [layersWidth]);
+  useEffect(() => { editorWidthRef.current = editorWidth; }, [editorWidth]);
+  useEffect(() => { previewPanelWidthRef.current = previewPanelWidth; }, [previewPanelWidth]);
+  useEffect(() => () => {
+    pointerCleanupRef.current?.();
+    if (pointerFrameRef.current !== null) cancelAnimationFrame(pointerFrameRef.current);
+  }, []);
+
+  const handleResizePointerDown = useCallback((side: 'layers' | 'preview') => (event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    const workspace = workspaceRef.current;
+    if (!workspace) return;
+    event.preventDefault();
+    event.currentTarget.focus();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    pointerCleanupRef.current?.();
+    setResizingPanel(side);
+
+    const startLayers = layersWidthRef.current;
+    const startEditor = editorWidthRef.current;
+    const startPreview = previewPanelWidthRef.current;
+
+    const applyWidths = (layers: number, editor: number, preview: number) => {
+      layersWidthRef.current = layers;
+      setLayersWidth(layers);
+      editorWidthRef.current = editor;
+      setEditorWidth(editor);
+      previewPanelWidthRef.current = preview;
+      setPreviewPanelWidth(preview);
+    };
+
+    const updateFromClientX = (clientX: number) => {
+      const st = resizeStateRef.current;
+      if (!st) return;
+      let delta = clientX - st.startClientX;
+      if (st.isRtl) delta = -delta;
+
+      const r = redistributeWidths(side, delta, startLayers, startEditor, startPreview);
+      applyWidths(r.layers, r.editor, r.preview);
+    };
+
+    const flushMove = () => {
+      if (pointerFrameRef.current !== null) {
+        cancelAnimationFrame(pointerFrameRef.current);
+        pointerFrameRef.current = null;
+      }
+      const cx = pendingPointerClientXRef.current;
+      pendingPointerClientXRef.current = null;
+      if (cx !== null) updateFromClientX(cx);
+    };
+
+    const saveWidths = () => {
+      try {
+        window.localStorage.setItem(LAYERS_WIDTH_KEY, String(layersWidthRef.current));
+        window.localStorage.setItem(EDITOR_WIDTH_KEY, String(editorWidthRef.current));
+        window.localStorage.setItem(PREVIEW_WIDTH_KEY, String(previewPanelWidthRef.current));
+      } catch { /* ignore */ }
+    };
+
+    resizeStateRef.current = {
+      startClientX: event.clientX,
+      startLayers,
+      startEditor,
+      startPreview,
+      side,
+      isRtl: window.getComputedStyle(workspace).direction === 'rtl',
+    };
+
+    const onMove = (e: PointerEvent) => {
+      pendingPointerClientXRef.current = e.clientX;
+      if (pointerFrameRef.current !== null) return;
+      pointerFrameRef.current = requestAnimationFrame(() => { pointerFrameRef.current = null; flushMove(); });
+    };
+    const onEnd = () => { flushMove(); saveWidths(); setResizingPanel(null); pointerCleanupRef.current?.(); pointerCleanupRef.current = null; };
+    const onCancel = () => { flushMove(); applyWidths(startLayers, startEditor, startPreview); setResizingPanel(null); pointerCleanupRef.current?.(); pointerCleanupRef.current = null; };
+    const cleanup = () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onEnd);
+      window.removeEventListener('pointercancel', onCancel);
+      window.removeEventListener('blur', onCancel);
+    };
+    pointerCleanupRef.current = cleanup;
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onEnd);
+    window.addEventListener('pointercancel', onCancel);
+    window.addEventListener('blur', onCancel);
+  }, []);
+
+  const handleLayersResizePointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    handleResizePointerDown('layers')(event);
+  }, [handleResizePointerDown]);
+
+  const handlePreviewResizePointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    handleResizePointerDown('preview')(event);
+  }, [handleResizePointerDown]);
+
+  const handleResizeKeyDown = useCallback((side: 'layers' | 'preview') => (event: React.KeyboardEvent<HTMLDivElement>) => {
+    let delta = 0;
+    const workspace = workspaceRef.current;
+    const isRtl = workspace ? window.getComputedStyle(workspace).direction === 'rtl' : false;
+
+    if (event.key === 'ArrowLeft') {
+      delta = -MANUAL_EDIT_KEYBOARD_STEP;
+    } else if (event.key === 'ArrowRight') {
+      delta = MANUAL_EDIT_KEYBOARD_STEP;
+    } else if (event.key === 'Home') {
+      delta = side === 'layers' ? LAYERS_MIN_WIDTH - layersWidthRef.current : PREVIEW_PANEL_MIN_WIDTH - previewPanelWidthRef.current;
+    } else {
+      return;
+    }
+    if (isRtl) delta = -delta;
+    event.preventDefault();
+
+    const r = redistributeWidths(side, delta, layersWidthRef.current, editorWidthRef.current, previewPanelWidthRef.current);
+    layersWidthRef.current = r.layers;
+    setLayersWidth(r.layers);
+    editorWidthRef.current = r.editor;
+    setEditorWidth(r.editor);
+    previewPanelWidthRef.current = r.preview;
+    setPreviewPanelWidth(r.preview);
+    try {
+      window.localStorage.setItem(LAYERS_WIDTH_KEY, String(layersWidthRef.current));
+      window.localStorage.setItem(EDITOR_WIDTH_KEY, String(editorWidthRef.current));
+      window.localStorage.setItem(PREVIEW_WIDTH_KEY, String(previewPanelWidthRef.current));
+    } catch { /* ignore */ }
+  }, []);
+
+  const handleLayersResizeKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    handleResizeKeyDown('layers')(event);
+  }, [handleResizeKeyDown]);
+
+  const handlePreviewResizeKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    handleResizeKeyDown('preview')(event);
+  }, [handleResizeKeyDown]);
+
+  const previewFrame = (
+    <div
+      style={{
+        width: `${100 / previewScale}%`,
+        height: `${100 / previewScale}%`,
+        transform: `scale(${previewScale})`,
+        transformOrigin: '0 0',
+      }}
+    >
+      {useUrlLoadPreview ? (
+        <iframe
+          ref={iframeRef}
+          data-testid="artifact-preview-frame"
+          data-od-render-mode="url-load"
+          title={file.name}
+          sandbox="allow-scripts"
+          src={previewSrcUrl}
+          onLoad={syncBridgeModes}
+        />
+      ) : (
+        <iframe
+          ref={iframeRef}
+          data-testid="artifact-preview-frame"
+          data-od-render-mode="srcdoc"
+          title={file.name}
+          sandbox="allow-scripts"
+          srcDoc={srcDoc}
+          onLoad={() => {
+            replayInspectOverridesToIframe();
+            syncBridgeModes();
+          }}
+        />
+      )}
+    </div>
+  );
+
   return (
     <div className="viewer html-viewer">
       <div className="viewer-toolbar">
@@ -4696,75 +4937,46 @@ function HtmlViewer({
         {source === null ? (
           <div className="viewer-empty">{t('fileViewer.loading')}</div>
         ) : mode === 'preview' ? (
-          <div className={manualEditMode ? 'manual-edit-workspace' : 'comment-preview-layer'}>
+          <div
+            className={manualEditMode ? `manual-edit-workspace${resizingPanel ? ' is-resizing' : ''}` : 'comment-preview-layer'}
+            ref={workspaceRef}
+            style={manualEditMode ? { gridTemplateColumns: `${layersWidth}px ${MANUAL_EDIT_HANDLE_WIDTH}px ${editorWidth}px ${MANUAL_EDIT_HANDLE_WIDTH}px ${previewPanelWidth}px` } : undefined}
+          >
             {manualEditMode ? (
-              <ManualEditPanel
-                targets={manualEditTargets}
-                selectedTarget={selectedManualEditTarget}
-                draft={manualEditDraft}
-                history={manualEditHistory}
-                error={manualEditError}
-                canUndo={manualEditHistory.length > 0}
-                canRedo={manualEditUndone.length > 0}
-                busy={manualEditSaving}
-                onSelectTarget={selectManualEditTarget}
-                onDraftChange={setManualEditDraft}
-                onApplyPatch={(patch, label) => {
-                  void applyManualEdit(patch, label);
-                }}
-                onError={setManualEditError}
-                onCancelDraft={() => {
-                  if (selectedManualEditTarget) selectManualEditTarget(selectedManualEditTarget);
-                }}
-                onUndo={() => {
-                  void undoManualEdit();
-                }}
-                onRedo={() => {
-                  void redoManualEdit();
-                }}
-              />
-            ) : null}
-            <div className={manualEditMode ? 'manual-edit-canvas' : 'comment-frame-clip'}>
-              <div
-                style={{
-                  width: `${100 / previewScale}%`,
-                  height: `${100 / previewScale}%`,
-                  transform: `scale(${previewScale})`,
-                  transformOrigin: '0 0',
-                }}
-              >
-                {useUrlLoadPreview ? (
-                  <iframe
-                    ref={iframeRef}
-                    data-testid="artifact-preview-frame"
-                    data-od-render-mode="url-load"
-                    title={file.name}
-                    sandbox="allow-scripts"
-                    src={previewSrcUrl}
-                    onLoad={syncBridgeModes}
-                  />
-                ) : (
-                  <iframe
-                    ref={iframeRef}
-                    data-testid="artifact-preview-frame"
-                    data-od-render-mode="srcdoc"
-                    title={file.name}
-                    sandbox="allow-scripts"
-                    srcDoc={srcDoc}
-                    // Re-seeds the iframe-side bridge with the host's
-                    // authoritative inspect override map after each srcdoc
-                    // rebuild, then syncs comment/edit bridge modes.
-                    // URL-loaded iframes have no inspect bridge, so the
-                    // replay handler is intentionally only on the srcDoc
-                    // branch.
-                    onLoad={() => {
-                      replayInspectOverridesToIframe();
-                      syncBridgeModes();
-                    }}
-                  />
-                )}
-              </div>
-            </div>
+              <>
+                <ManualEditPanel
+                  targets={manualEditTargets}
+                  selectedTarget={selectedManualEditTarget}
+                  draft={manualEditDraft}
+                  history={manualEditHistory}
+                  error={manualEditError}
+                  canUndo={manualEditHistory.length > 0}
+                  canRedo={manualEditUndone.length > 0}
+                  busy={manualEditSaving}
+                  onSelectTarget={selectManualEditTarget}
+                  onDraftChange={setManualEditDraft}
+                  onApplyPatch={(patch, label) => {
+                    void applyManualEdit(patch, label);
+                  }}
+                  onError={setManualEditError}
+                  onCancelDraft={() => {
+                    if (selectedManualEditTarget) selectManualEditTarget(selectedManualEditTarget);
+                  }}
+                  onUndo={() => {
+                    void undoManualEdit();
+                  }}
+                  onRedo={() => {
+                    void redoManualEdit();
+                  }}
+                  childrenAfter={<div className="manual-edit-resize-handle" role="separator" aria-orientation="vertical" aria-label={t('manualEdit.resizePreview')} tabIndex={0} onPointerDown={handlePreviewResizePointerDown} onKeyDown={handlePreviewResizeKeyDown} />}
+                >
+                  <div className="manual-edit-resize-handle" role="separator" aria-orientation="vertical" aria-label={t('manualEdit.resizeLayers')} tabIndex={0} onPointerDown={handleLayersResizePointerDown} onKeyDown={handleLayersResizeKeyDown} />
+                </ManualEditPanel>
+                <div className="manual-edit-canvas">{previewFrame}</div>
+              </>
+            ) : (
+              <div className="comment-frame-clip">{previewFrame}</div>
+            )}
             {boardMode ? (
               <CommentPreviewOverlays
                 comments={previewComments}

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -4400,6 +4400,7 @@ function HtmlViewer({
   // Runs once: after source loads and manualEditMode makes the workspace visible.
   useLayoutEffect(() => {
     if (hasNormalizedRef.current) return;
+    if (!manualEditMode) return;
     const ws = workspaceRef.current;
     if (!ws) return;
     const cs = window.getComputedStyle(ws);

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -185,7 +185,7 @@ export function normalizePanelWidths(
   let p = Math.max(PREVIEW_PANEL_MIN_WIDTH, Math.round(preview));
 
   let overflow = l + e + p - available;
-  if (overflow <= 0) return { layers: l, editor: e, preview: p };
+  if (overflow <= 0) return { layers: l, editor: e - overflow, preview: p };
 
   // Squeeze editor first (flexible middle panel), then side panels if still overflowing
   const squeezeE = Math.min(overflow, e - EDITOR_MIN_WIDTH);

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -5042,7 +5042,7 @@ function HtmlViewer({
           <div
             className={manualEditMode ? `manual-edit-workspace${resizingPanel ? ' is-resizing' : ''}` : 'comment-preview-layer'}
             ref={workspaceRef}
-            style={manualEditMode ? { gridTemplateColumns: `${layersWidth}px ${MANUAL_EDIT_HANDLE_WIDTH}px minmax(${editorWidth}px, 1fr) ${MANUAL_EDIT_HANDLE_WIDTH}px ${previewPanelWidth}px` } : undefined}
+            style={manualEditMode ? { gridTemplateColumns: `${layersWidth}px ${MANUAL_EDIT_HANDLE_WIDTH}px ${editorWidth}px ${MANUAL_EDIT_HANDLE_WIDTH}px ${previewPanelWidth}px` } : undefined}
           >
             {manualEditMode ? (
               <>

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -4463,7 +4463,7 @@ function HtmlViewer({
     } else if (event.key === 'ArrowRight') {
       delta = MANUAL_EDIT_KEYBOARD_STEP;
     } else if (event.key === 'Home') {
-      delta = side === 'layers' ? LAYERS_MIN_WIDTH - layersWidthRef.current : PREVIEW_PANEL_MIN_WIDTH - previewPanelWidthRef.current;
+      delta = side === 'layers' ? LAYERS_MIN_WIDTH - layersWidthRef.current : previewPanelWidthRef.current - PREVIEW_PANEL_MIN_WIDTH;
     } else {
       return;
     }

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -185,7 +185,7 @@ export function normalizePanelWidths(
   let p = Math.max(PREVIEW_PANEL_MIN_WIDTH, Math.round(preview));
 
   let overflow = l + e + p - available;
-  if (overflow <= 0) return { layers: l, editor: e - overflow, preview: p };
+  if (overflow <= 0) return { layers: l, editor: e, preview: p };
 
   // Squeeze editor first (flexible middle panel), then side panels if still overflowing
   const squeezeE = Math.min(overflow, e - EDITOR_MIN_WIDTH);
@@ -5042,7 +5042,7 @@ function HtmlViewer({
           <div
             className={manualEditMode ? `manual-edit-workspace${resizingPanel ? ' is-resizing' : ''}` : 'comment-preview-layer'}
             ref={workspaceRef}
-            style={manualEditMode ? { gridTemplateColumns: `${layersWidth}px ${MANUAL_EDIT_HANDLE_WIDTH}px ${editorWidth}px ${MANUAL_EDIT_HANDLE_WIDTH}px ${previewPanelWidth}px` } : undefined}
+            style={manualEditMode ? { gridTemplateColumns: `${layersWidth}px ${MANUAL_EDIT_HANDLE_WIDTH}px minmax(${editorWidth}px, 1fr) ${MANUAL_EDIT_HANDLE_WIDTH}px ${previewPanelWidth}px` } : undefined}
           >
             {manualEditMode ? (
               <>

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -4397,10 +4397,13 @@ function HtmlViewer({
   }, []);
 
   // Re-clamp restored widths against the actual workspace width (not viewport).
-  // Runs once: after source loads and manualEditMode makes the workspace visible.
+  // Re-runs each time manual edit mode activates so the current workspace size is measured.
   useLayoutEffect(() => {
+    if (!manualEditMode) {
+      hasNormalizedRef.current = false;
+      return;
+    }
     if (hasNormalizedRef.current) return;
-    if (!manualEditMode) return;
     const ws = workspaceRef.current;
     if (!ws) return;
     const cs = window.getComputedStyle(ws);

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -5042,7 +5042,7 @@ function HtmlViewer({
           <div
             className={manualEditMode ? `manual-edit-workspace${resizingPanel ? ' is-resizing' : ''}` : 'comment-preview-layer'}
             ref={workspaceRef}
-            style={manualEditMode ? { gridTemplateColumns: `${layersWidth}px ${MANUAL_EDIT_HANDLE_WIDTH}px ${editorWidth}px ${MANUAL_EDIT_HANDLE_WIDTH}px ${previewPanelWidth}px` } : undefined}
+            style={manualEditMode ? { gridTemplateColumns: `${layersWidth}px ${MANUAL_EDIT_HANDLE_WIDTH}px minmax(${editorWidth}px, 1fr) ${MANUAL_EDIT_HANDLE_WIDTH}px ${previewPanelWidth}px` } : undefined}
           >
             {manualEditMode ? (
               <>

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -164,13 +164,20 @@ const EDITOR_WIDTH_KEY = 'open-design.manualEdit.editorWidth';
 const PREVIEW_WIDTH_KEY = 'open-design.manualEdit.previewWidth';
 const MANUAL_EDIT_KEYBOARD_STEP = 16;
 
-function readSavedWidth(key: string, fallback: number, min: number): number {
+function readSavedWidth(key: string, fallback: number, min: number, max: number): number {
   if (typeof window === 'undefined') return fallback;
   try {
     const raw = window.localStorage.getItem(key);
     const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
-    return Number.isFinite(parsed) ? Math.max(min, Math.round(parsed)) : fallback;
+    if (!Number.isFinite(parsed)) return fallback;
+    const clampedMin = Math.max(min, Math.round(parsed));
+    return Math.min(clampedMin, max);
   } catch { return fallback; }
+}
+
+function panelMaxWidth(minOtherA: number, minOtherB: number): number {
+  if (typeof window === 'undefined') return 9999;
+  return Math.round(window.innerWidth - minOtherA - minOtherB - MANUAL_EDIT_HANDLE_WIDTH * 2);
 }
 
 function redistributeWidths(
@@ -3050,9 +3057,9 @@ function HtmlViewer({
   const manualEditSavingRef = useRef(false);
 
   // Manual edit panel resize state
-  const [layersWidth, setLayersWidth] = useState(() => readSavedWidth(LAYERS_WIDTH_KEY, LAYERS_DEFAULT_WIDTH, LAYERS_MIN_WIDTH));
-  const [editorWidth, setEditorWidth] = useState(() => readSavedWidth(EDITOR_WIDTH_KEY, EDITOR_DEFAULT_WIDTH, EDITOR_MIN_WIDTH));
-  const [previewPanelWidth, setPreviewPanelWidth] = useState(() => readSavedWidth(PREVIEW_WIDTH_KEY, PREVIEW_PANEL_DEFAULT_WIDTH, PREVIEW_PANEL_MIN_WIDTH));
+  const [layersWidth, setLayersWidth] = useState(() => readSavedWidth(LAYERS_WIDTH_KEY, LAYERS_DEFAULT_WIDTH, LAYERS_MIN_WIDTH, panelMaxWidth(EDITOR_MIN_WIDTH, PREVIEW_PANEL_MIN_WIDTH)));
+  const [editorWidth, setEditorWidth] = useState(() => readSavedWidth(EDITOR_WIDTH_KEY, EDITOR_DEFAULT_WIDTH, EDITOR_MIN_WIDTH, panelMaxWidth(LAYERS_MIN_WIDTH, PREVIEW_PANEL_MIN_WIDTH)));
+  const [previewPanelWidth, setPreviewPanelWidth] = useState(() => readSavedWidth(PREVIEW_WIDTH_KEY, PREVIEW_PANEL_DEFAULT_WIDTH, PREVIEW_PANEL_MIN_WIDTH, panelMaxWidth(LAYERS_MIN_WIDTH, EDITOR_MIN_WIDTH)));
   const [resizingPanel, setResizingPanel] = useState<'layers' | 'preview' | null>(null);
   const layersWidthRef = useRef(layersWidth);
   const editorWidthRef = useRef(editorWidth);

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -4431,7 +4431,8 @@ function HtmlViewer({
     if (!manualEditMode) return;
     const ws = workspaceRef.current;
     if (!ws) return;
-    const observer = new ResizeObserver(() => {
+
+    const reNormalize = () => {
       const cs = window.getComputedStyle(ws);
       const padH = Number.parseFloat(cs.paddingLeft) + Number.parseFloat(cs.paddingRight);
       const available = ws.clientWidth - padH - MANUAL_EDIT_HANDLE_WIDTH * 2 - 4 * MANUAL_EDIT_GAP;
@@ -4451,9 +4452,16 @@ function HtmlViewer({
       setEditorWidth(n.editor);
       previewPanelWidthRef.current = n.preview;
       setPreviewPanelWidth(n.preview);
-    });
-    observer.observe(ws);
-    return () => observer.disconnect();
+    };
+
+    if (typeof ResizeObserver !== 'undefined') {
+      const observer = new ResizeObserver(reNormalize);
+      observer.observe(ws);
+      return () => observer.disconnect();
+    }
+
+    window.addEventListener('resize', reNormalize);
+    return () => window.removeEventListener('resize', reNormalize);
   }, [source, manualEditMode]);
 
   const handleResizePointerDown = useCallback((side: 'layers' | 'preview') => (event: React.PointerEvent<HTMLDivElement>) => {

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -164,12 +164,12 @@ const EDITOR_WIDTH_KEY = 'open-design.manualEdit.editorWidth';
 const PREVIEW_WIDTH_KEY = 'open-design.manualEdit.previewWidth';
 const MANUAL_EDIT_KEYBOARD_STEP = 16;
 
-function readSavedWidth(key: string, fallback: number): number {
+function readSavedWidth(key: string, fallback: number, min: number): number {
   if (typeof window === 'undefined') return fallback;
   try {
     const raw = window.localStorage.getItem(key);
     const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
-    return Number.isFinite(parsed) ? Math.round(parsed) : fallback;
+    return Number.isFinite(parsed) ? Math.max(min, Math.round(parsed)) : fallback;
   } catch { return fallback; }
 }
 
@@ -3050,9 +3050,9 @@ function HtmlViewer({
   const manualEditSavingRef = useRef(false);
 
   // Manual edit panel resize state
-  const [layersWidth, setLayersWidth] = useState(() => readSavedWidth(LAYERS_WIDTH_KEY, LAYERS_DEFAULT_WIDTH));
-  const [editorWidth, setEditorWidth] = useState(() => readSavedWidth(EDITOR_WIDTH_KEY, EDITOR_DEFAULT_WIDTH));
-  const [previewPanelWidth, setPreviewPanelWidth] = useState(() => readSavedWidth(PREVIEW_WIDTH_KEY, PREVIEW_PANEL_DEFAULT_WIDTH));
+  const [layersWidth, setLayersWidth] = useState(() => readSavedWidth(LAYERS_WIDTH_KEY, LAYERS_DEFAULT_WIDTH, LAYERS_MIN_WIDTH));
+  const [editorWidth, setEditorWidth] = useState(() => readSavedWidth(EDITOR_WIDTH_KEY, EDITOR_DEFAULT_WIDTH, EDITOR_MIN_WIDTH));
+  const [previewPanelWidth, setPreviewPanelWidth] = useState(() => readSavedWidth(PREVIEW_WIDTH_KEY, PREVIEW_PANEL_DEFAULT_WIDTH, PREVIEW_PANEL_MIN_WIDTH));
   const [resizingPanel, setResizingPanel] = useState<'layers' | 'preview' | null>(null);
   const layersWidthRef = useRef(layersWidth);
   const editorWidthRef = useRef(editorWidth);
@@ -4459,15 +4459,14 @@ function HtmlViewer({
     const isRtl = workspace ? window.getComputedStyle(workspace).direction === 'rtl' : false;
 
     if (event.key === 'ArrowLeft') {
-      delta = -MANUAL_EDIT_KEYBOARD_STEP;
+      delta = isRtl ? MANUAL_EDIT_KEYBOARD_STEP : -MANUAL_EDIT_KEYBOARD_STEP;
     } else if (event.key === 'ArrowRight') {
-      delta = MANUAL_EDIT_KEYBOARD_STEP;
+      delta = isRtl ? -MANUAL_EDIT_KEYBOARD_STEP : MANUAL_EDIT_KEYBOARD_STEP;
     } else if (event.key === 'Home') {
       delta = side === 'layers' ? LAYERS_MIN_WIDTH - layersWidthRef.current : previewPanelWidthRef.current - PREVIEW_PANEL_MIN_WIDTH;
     } else {
       return;
     }
-    if (isRtl) delta = -delta;
     event.preventDefault();
 
     const r = redistributeWidths(side, delta, layersWidthRef.current, editorWidthRef.current, previewPanelWidthRef.current);
@@ -4527,6 +4526,16 @@ function HtmlViewer({
       )}
     </div>
   );
+
+  // ARIA max widths — use current sibling panel widths, not their mins
+  const ariaWs = workspaceRef.current;
+  const ariaWsW = ariaWs ? ariaWs.clientWidth : 0;
+  const ariaLayersMax = ariaWsW
+    ? Math.max(LAYERS_MIN_WIDTH, Math.round(ariaWsW - MANUAL_EDIT_HANDLE_WIDTH * 2 - EDITOR_MIN_WIDTH - previewPanelWidth))
+    : 9999;
+  const ariaPreviewMax = ariaWsW
+    ? Math.max(PREVIEW_PANEL_MIN_WIDTH, Math.round(ariaWsW - MANUAL_EDIT_HANDLE_WIDTH * 2 - layersWidth - EDITOR_MIN_WIDTH))
+    : 9999;
 
   return (
     <div className="viewer html-viewer">
@@ -4968,9 +4977,9 @@ function HtmlViewer({
                   onRedo={() => {
                     void redoManualEdit();
                   }}
-                  childrenAfter={<div className="manual-edit-resize-handle" role="separator" aria-orientation="vertical" aria-label={t('manualEdit.resizePreview')} tabIndex={0} onPointerDown={handlePreviewResizePointerDown} onKeyDown={handlePreviewResizeKeyDown} />}
+                  childrenAfter={<div className="manual-edit-resize-handle" role="separator" aria-orientation="vertical" aria-label={t('manualEdit.resizePreview')} aria-valuemin={PREVIEW_PANEL_MIN_WIDTH} aria-valuemax={ariaPreviewMax} aria-valuenow={previewPanelWidth} tabIndex={0} onPointerDown={handlePreviewResizePointerDown} onKeyDown={handlePreviewResizeKeyDown} />}
                 >
-                  <div className="manual-edit-resize-handle" role="separator" aria-orientation="vertical" aria-label={t('manualEdit.resizeLayers')} tabIndex={0} onPointerDown={handleLayersResizePointerDown} onKeyDown={handleLayersResizeKeyDown} />
+                  <div className="manual-edit-resize-handle" role="separator" aria-orientation="vertical" aria-label={t('manualEdit.resizeLayers')} aria-valuemin={LAYERS_MIN_WIDTH} aria-valuemax={ariaLayersMax} aria-valuenow={layersWidth} tabIndex={0} onPointerDown={handleLayersResizePointerDown} onKeyDown={handleLayersResizeKeyDown} />
                 </ManualEditPanel>
                 <div className="manual-edit-canvas">{previewFrame}</div>
               </>

--- a/apps/web/src/components/ManualEditPanel.tsx
+++ b/apps/web/src/components/ManualEditPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { type ReactNode, useEffect, useState } from 'react';
 import { useT } from '../i18n';
 import { emptyManualEditStyles, type ManualEditHistoryEntry, type ManualEditPatch, type ManualEditStyles, type ManualEditTarget } from '../edit-mode/types';
 
@@ -44,8 +44,12 @@ export function ManualEditPanel({
   onCancelDraft,
   onUndo,
   onRedo,
+  children,
+  childrenAfter,
 }: {
   targets: ManualEditTarget[];
+  children?: ReactNode;
+  childrenAfter?: ReactNode;
   selectedTarget: ManualEditTarget | null;
   draft: ManualEditDraft;
   history: ManualEditHistoryEntry[];
@@ -89,6 +93,8 @@ export function ManualEditPanel({
           ))}
         </div>
       </aside>
+
+      {children}
 
       <aside className="manual-edit-right">
         <section className="manual-edit-modal">
@@ -225,6 +231,8 @@ export function ManualEditPanel({
           )}
         </section>
       </aside>
+
+      {childrenAfter}
     </>
   );
 }

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -762,6 +762,8 @@ export const ar: Dict = {
   'manualEdit.border': "Border",
   'manualEdit.width': "Width",
   'manualEdit.minHeight': "Min height",
+  'manualEdit.resizeLayers': "Resize layers panel",
+  'manualEdit.resizePreview': "Resize preview panel",
   'fileViewer.zoomOut': 'تصغير',
   'fileViewer.zoomIn': 'تكبير',
   'fileViewer.resetZoom': 'إعادة تعيين الزوم',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -650,6 +650,8 @@ export const de: Dict = {
   'manualEdit.border': "Border",
   'manualEdit.width': "Width",
   'manualEdit.minHeight': "Min height",
+  'manualEdit.resizeLayers': "Resize layers panel",
+  'manualEdit.resizePreview': "Resize preview panel",
   'fileViewer.zoomOut': 'Verkleinern',
   'fileViewer.zoomIn': 'Vergrößern',
   'fileViewer.resetZoom': 'Zoom zurücksetzen',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -775,6 +775,8 @@ export const en: Dict = {
   'manualEdit.border': "Border",
   'manualEdit.width': "Width",
   'manualEdit.minHeight': "Min height",
+  'manualEdit.resizeLayers': "Resize layers panel",
+  'manualEdit.resizePreview': "Resize preview panel",
   'fileViewer.zoomOut': 'Zoom out',
   'fileViewer.zoomIn': 'Zoom in',
   'fileViewer.resetZoom': 'Reset zoom',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -651,6 +651,8 @@ export const esES: Dict = {
   'manualEdit.border': "Border",
   'manualEdit.width': "Width",
   'manualEdit.minHeight': "Min height",
+  'manualEdit.resizeLayers': "Resize layers panel",
+  'manualEdit.resizePreview': "Resize preview panel",
   'fileViewer.zoomOut': 'Reducir zoom',
   'fileViewer.zoomIn': 'Aumentar zoom',
   'fileViewer.resetZoom': 'Restablecer zoom',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -775,6 +775,8 @@ export const fa: Dict = {
   'manualEdit.border': "Border",
   'manualEdit.width': "Width",
   'manualEdit.minHeight': "Min height",
+  'manualEdit.resizeLayers': "Resize layers panel",
+  'manualEdit.resizePreview': "Resize preview panel",
   'fileViewer.zoomOut': 'کوچک‌نمایی',
   'fileViewer.zoomIn': 'بزرگ‌نمایی',
   'fileViewer.resetZoom': 'بازنشانی زوم',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -762,6 +762,8 @@ export const fr: Dict = {
   'manualEdit.border': "Border",
   'manualEdit.width': "Width",
   'manualEdit.minHeight': "Min height",
+  'manualEdit.resizeLayers': "Resize layers panel",
+  'manualEdit.resizePreview': "Resize preview panel",
   'fileViewer.zoomOut': 'Zoom arrière',
   'fileViewer.zoomIn': 'Zoom avant',
   'fileViewer.resetZoom': 'Réinitialiser le zoom',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -762,6 +762,8 @@ export const hu: Dict = {
   'manualEdit.border': "Border",
   'manualEdit.width': "Width",
   'manualEdit.minHeight': "Min height",
+  'manualEdit.resizeLayers': "Resize layers panel",
+  'manualEdit.resizePreview': "Resize preview panel",
   'fileViewer.zoomOut': 'Kicsinyítés',
   'fileViewer.zoomIn': 'Nagyítás',
   'fileViewer.resetZoom': 'Nagyítás visszaállítása',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -866,6 +866,8 @@ export const id: Dict = {
   'manualEdit.border': 'Border',
   'manualEdit.width': 'Lebar',
   'manualEdit.minHeight': 'Tinggi minimum',
+  'manualEdit.resizeLayers': "Resize layers panel",
+  'manualEdit.resizePreview': "Resize preview panel",
 
   'fileViewer.zoomOut': 'Perkecil',
   'fileViewer.zoomIn': 'Perbesar',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -649,6 +649,8 @@ export const ja: Dict = {
   'manualEdit.border': "Border",
   'manualEdit.width': "Width",
   'manualEdit.minHeight': "Min height",
+  'manualEdit.resizeLayers': "Resize layers panel",
+  'manualEdit.resizePreview': "Resize preview panel",
   'fileViewer.zoomOut': 'ズームアウト',
   'fileViewer.zoomIn': 'ズームイン',
   'fileViewer.resetZoom': 'ズームをリセット',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -762,6 +762,8 @@ export const ko: Dict = {
   'manualEdit.border': "Border",
   'manualEdit.width': "Width",
   'manualEdit.minHeight': "Min height",
+  'manualEdit.resizeLayers': "Resize layers panel",
+  'manualEdit.resizePreview': "Resize preview panel",
   'fileViewer.zoomOut': '축소',
   'fileViewer.zoomIn': '확대',
   'fileViewer.resetZoom': '배율 초기화',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -762,6 +762,8 @@ export const pl: Dict = {
   'manualEdit.border': "Border",
   'manualEdit.width': "Width",
   'manualEdit.minHeight': "Min height",
+  'manualEdit.resizeLayers': "Resize layers panel",
+  'manualEdit.resizePreview': "Resize preview panel",
   'fileViewer.zoomOut': 'Pomniejsz',
   'fileViewer.zoomIn': 'Powiększ',
   'fileViewer.resetZoom': 'Resetuj powiększenie',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -774,6 +774,8 @@ export const ptBR: Dict = {
   'manualEdit.border': "Border",
   'manualEdit.width': "Width",
   'manualEdit.minHeight': "Min height",
+  'manualEdit.resizeLayers': "Resize layers panel",
+  'manualEdit.resizePreview': "Resize preview panel",
   'fileViewer.zoomOut': 'Diminuir zoom',
   'fileViewer.zoomIn': 'Aumentar zoom',
   'fileViewer.resetZoom': 'Redefinir zoom',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -774,6 +774,8 @@ export const ru: Dict = {
   'manualEdit.border': "Border",
   'manualEdit.width': "Width",
   'manualEdit.minHeight': "Min height",
+  'manualEdit.resizeLayers': "Resize layers panel",
+  'manualEdit.resizePreview': "Resize preview panel",
   'fileViewer.zoomOut': 'Уменьшить',
   'fileViewer.zoomIn': 'Увеличить',
   'fileViewer.resetZoom': 'Сбросить масштаб',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -752,6 +752,8 @@ export const th: Dict = {
   'manualEdit.border': "ความหนาเส้น",
   'manualEdit.width': "ขนาดความกว้าง",
   'manualEdit.minHeight': "ส่วนเตี้ยที่สุด",
+  'manualEdit.resizeLayers': "Resize layers panel",
+  'manualEdit.resizePreview': "Resize preview panel",
   'fileViewer.zoomOut': 'หุบมุมมอง',
   'fileViewer.zoomIn': 'ซูมมองชัด',
   'fileViewer.resetZoom': 'ซูมรีเซ็ตหน้าจอ',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -753,6 +753,8 @@ export const tr: Dict = {
   'manualEdit.border': "Border",
   'manualEdit.width': "Width",
   'manualEdit.minHeight': "Min height",
+  'manualEdit.resizeLayers': "Resize layers panel",
+  'manualEdit.resizePreview': "Resize preview panel",
   'fileViewer.zoomOut': 'Yakınlaş',
   'fileViewer.zoomIn': 'Uzaklaş',
   'fileViewer.resetZoom': 'Uzaklığı sıfırla',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -793,6 +793,8 @@ export const uk: Dict = {
   'manualEdit.border': "Border",
   'manualEdit.width': "Width",
   'manualEdit.minHeight': "Min height",
+  'manualEdit.resizeLayers': "Resize layers panel",
+  'manualEdit.resizePreview': "Resize preview panel",
   'fileViewer.zoomOut': 'Зменшити',
   'fileViewer.zoomIn': 'Збільшити',
   'fileViewer.resetZoom': 'Скинути масштаб',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -763,6 +763,8 @@ export const zhCN: Dict = {
   'manualEdit.border': "Border",
   'manualEdit.width': "Width",
   'manualEdit.minHeight': "Min height",
+  'manualEdit.resizeLayers': "调整图层面板宽度",
+  'manualEdit.resizePreview': "调整预览面板宽度",
   'fileViewer.zoomOut': '缩小',
   'fileViewer.zoomIn': '放大',
   'fileViewer.resetZoom': '重置缩放',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -763,6 +763,8 @@ export const zhTW: Dict = {
   'manualEdit.border': "Border",
   'manualEdit.width': "Width",
   'manualEdit.minHeight': "Min height",
+  'manualEdit.resizeLayers': "Resize layers panel",
+  'manualEdit.resizePreview': "Resize preview panel",
   'fileViewer.zoomOut': '縮小',
   'fileViewer.zoomIn': '放大',
   'fileViewer.resetZoom': '重設縮放',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -924,6 +924,8 @@ export interface Dict {
   'manualEdit.border': string;
   'manualEdit.width': string;
   'manualEdit.minHeight': string;
+  'manualEdit.resizeLayers': string;
+  'manualEdit.resizePreview': string;
   'fileViewer.zoomOut': string;
   'fileViewer.zoomIn': string;
   'fileViewer.resetZoom': string;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -14096,12 +14096,57 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
 /* Manual edit mode */
 .manual-edit-workspace {
   display: grid;
-  grid-template-columns: 240px minmax(420px, 1fr) 344px;
   gap: 10px;
   height: 100%;
   min-height: 0;
   padding: 10px;
   background: var(--bg);
+}
+
+.manual-edit-workspace.is-resizing {
+  cursor: col-resize;
+  user-select: none;
+}
+
+.manual-edit-workspace.is-resizing iframe {
+  pointer-events: none;
+}
+
+.manual-edit-resize-handle {
+  width: 8px;
+  min-width: 8px;
+  height: 100%;
+  cursor: col-resize;
+  background:
+    linear-gradient(
+      90deg,
+      transparent 0,
+      transparent 3px,
+      var(--border) 3px,
+      var(--border) 5px,
+      transparent 5px
+    );
+  transition: background 120ms ease;
+  touch-action: none;
+}
+
+.manual-edit-resize-handle:hover,
+.manual-edit-resize-handle:focus-visible,
+.manual-edit-workspace.is-resizing .manual-edit-resize-handle {
+  background:
+    linear-gradient(
+      90deg,
+      color-mix(in srgb, var(--accent) 16%, transparent) 0,
+      color-mix(in srgb, var(--accent) 16%, transparent) 3px,
+      var(--accent) 3px,
+      var(--accent) 5px,
+      color-mix(in srgb, var(--accent) 16%, transparent) 5px
+    );
+}
+
+.manual-edit-resize-handle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
 }
 
 .manual-edit-canvas {

--- a/apps/web/tests/components/file-viewer-panel-normalize.test.ts
+++ b/apps/web/tests/components/file-viewer-panel-normalize.test.ts
@@ -8,6 +8,16 @@ const EDITOR_MIN = 280;
 const PREVIEW_MIN = 280;
 const SUM_OF_MINS = LAYERS_MIN + EDITOR_MIN + PREVIEW_MIN; // 740
 
+// Workspace CSS: padding 10px each side, gap 10px, handle 8px
+const HANDLE_W = 8;
+const GAP = 10;
+const PAD = 10;
+
+/** Simulates the useLayoutEffect available-width computation from clientWidth. */
+function availableFromClientWidth(clientWidth: number): number {
+  return clientWidth - PAD * 2 - HANDLE_W * 2 - 4 * GAP;
+}
+
 describe('normalizePanelWidths', () => {
   it('returns values unchanged when they fit within available width', () => {
     const r = normalizePanelWidths(240, 420, 344, 1200);
@@ -52,37 +62,39 @@ describe('normalizePanelWidths', () => {
     const r = normalizePanelWidths(300, 450, 400, SUM_OF_MINS + 10);
     expect(r.editor).toBe(EDITOR_MIN);
     expect(r.layers).toBe(LAYERS_MIN);
-    expect(r.preview).toBe(290); // absorbs remaining 110 overflow
+    expect(r.preview).toBe(290); // absorbs remaining overflow
     expect(r.layers + r.editor + r.preview).toBe(SUM_OF_MINS + 10);
   });
 
   it('handles large-monitor widths restored on a smaller split workspace', () => {
-    // Saved on a 2560px monitor: layers=400, editor=600, preview=500
-    // Opened on a split workspace: 850px clientWidth - 56 = 794 available
-    const available = 794;
+    // 850px clientWidth → available = 850 - 20 - 16 - 40 = 774
+    const available = availableFromClientWidth(850);
+    expect(available).toBe(774);
     const r = normalizePanelWidths(400, 600, 500, available);
 
-    // sum = 1500, overflow = 706
-    // editor squeezed: 600 -> 280 (320), overflow = 386
-    // layers squeezed: 400 -> 180 (220), overflow = 166
-    // preview squeezed: 500 -> 334 (166)
+    // sum = 1500, overflow = 726
+    // editor: 600 -> 280 (320), overflow = 406
+    // layers: 400 -> 180 (220), overflow = 186
+    // preview: 500 -> 314 (186)
     expect(r.editor).toBe(EDITOR_MIN);
     expect(r.layers).toBe(LAYERS_MIN);
-    expect(r.preview).toBe(334);
-    expect(r.layers + r.editor + r.preview).toBe(794);
+    expect(r.preview).toBe(314);
+    expect(r.layers + r.editor + r.preview).toBe(774);
   });
 
   it('handles a single oversized panel on an otherwise normal workspace', () => {
-    // layers=800 on a 900px clientWidth workspace: 900 - 56 = 844 available
-    const r = normalizePanelWidths(800, 420, 344, 844);
+    // 900px clientWidth → available = 900 - 76 = 824
+    const available = availableFromClientWidth(900);
+    expect(available).toBe(824);
+    const r = normalizePanelWidths(800, 420, 344, available);
 
-    // sum = 1564, overflow = 720
-    // editor: 420 -> 280 (140), overflow = 580
-    // layers: 800 -> 220 (580), overflow = 0
+    // sum = 1564, overflow = 740
+    // editor: 420 -> 280 (140), overflow = 600
+    // layers: 800 -> 200 (600), overflow = 0
     expect(r.editor).toBe(EDITOR_MIN);
     expect(r.preview).toBe(344);
-    expect(r.layers).toBe(220);
-    expect(r.layers + r.editor + r.preview).toBe(844);
+    expect(r.layers).toBe(200);
+    expect(r.layers + r.editor + r.preview).toBe(824);
   });
 
   it('rounds fractional panel widths', () => {
@@ -93,10 +105,89 @@ describe('normalizePanelWidths', () => {
   });
 
   it('returns minimums when available is less than sum of minimums', () => {
-    // Pathological: workspace too narrow even for minimums
     const r = normalizePanelWidths(200, 300, 300, SUM_OF_MINS - 1);
     expect(r.layers).toBe(LAYERS_MIN);
     expect(r.editor).toBe(EDITOR_MIN);
     expect(r.preview).toBe(PREVIEW_MIN);
+  });
+});
+
+describe('normalizePanelWidths — ARIA and minimum invariants', () => {
+  it('never returns a value below its declared minimum', () => {
+    const cases = [
+      [800, 600, 500, 400],
+      [100, 200, 100, 800],
+      [500, 600, 500, 300],
+      [240, 420, 344, 741],
+    ] as const;
+    for (const [l, e, p, a] of cases) {
+      const r = normalizePanelWidths(l, e, p, a);
+      expect(r.layers, `layers for (${l},${e},${p},${a})`).toBeGreaterThanOrEqual(LAYERS_MIN);
+      expect(r.editor, `editor for (${l},${e},${p},${a})`).toBeGreaterThanOrEqual(EDITOR_MIN);
+      expect(r.preview, `preview for (${l},${e},${p},${a})`).toBeGreaterThanOrEqual(PREVIEW_MIN);
+    }
+  });
+
+  it('returned widths satisfy ARIA bounds: valuenow <= valuemax', () => {
+    // After normalization, simulate the ARIA max computation that runs in the component:
+    //   ariaLayersMax = max(LAYERS_MIN, layers + editor - EDITOR_MIN)
+    //   ariaPreviewMax = max(PREVIEW_MIN, preview + editor - EDITOR_MIN)
+    // Verify valuenow (the actual width) <= valuemax.
+    const cases = [
+      [800, 600, 500, availableFromClientWidth(900)],
+      [400, 600, 500, availableFromClientWidth(850)],
+      [240, 420, 344, availableFromClientWidth(1200)],
+    ] as const;
+    for (const [l, e, p, a] of cases) {
+      const r = normalizePanelWidths(l, e, p, a);
+      const layersMax = Math.max(LAYERS_MIN, r.layers + r.editor - EDITOR_MIN);
+      const previewMax = Math.max(PREVIEW_MIN, r.preview + r.editor - EDITOR_MIN);
+      expect(r.layers, `layers <= max for (${l},${e},${p})`).toBeLessThanOrEqual(layersMax);
+      expect(r.preview, `preview <= max for (${l},${e},${p})`).toBeLessThanOrEqual(previewMax);
+      // Also valuemax >= valuemin (always true by construction, but verify)
+      expect(layersMax).toBeGreaterThanOrEqual(LAYERS_MIN);
+      expect(previewMax).toBeGreaterThanOrEqual(PREVIEW_MIN);
+    }
+  });
+
+  it('sum never exceeds available when available >= sum of minimums', () => {
+    const available = SUM_OF_MINS + 200;
+    const r = normalizePanelWidths(500, 600, 500, available);
+    expect(r.layers + r.editor + r.preview).toBeLessThanOrEqual(available);
+    expect(r.layers).toBeGreaterThanOrEqual(LAYERS_MIN);
+    expect(r.editor).toBeGreaterThanOrEqual(EDITOR_MIN);
+    expect(r.preview).toBeGreaterThanOrEqual(PREVIEW_MIN);
+  });
+});
+
+describe('normalizePanelWidths — content-box available width with real CSS budget', () => {
+  it('deducts padding, gaps, and handles from clientWidth correctly', () => {
+    // Simulates the real computation: clientWidth=1100 → available=1024
+    // 1100 - 2*10(pad) - 2*8(handle) - 4*10(gap) = 1024
+    expect(availableFromClientWidth(1100)).toBe(1024);
+    expect(availableFromClientWidth(850)).toBe(774);
+    expect(availableFromClientWidth(756)).toBe(680); // just above sum of mins
+  });
+
+  it('default widths (240+420+344=1004) fit in a 1100px clientWidth workspace', () => {
+    const available = availableFromClientWidth(1100);
+    const r = normalizePanelWidths(240, 420, 344, available);
+    expect(r).toEqual({ layers: 240, editor: 420, preview: 344 });
+    expect(r.layers + r.editor + r.preview).toBeLessThanOrEqual(available);
+  });
+
+  it('large persisted widths on a constrained 850px workspace are clamped', () => {
+    // clientWidth=850, available=774
+    // Saved: layers=500, editor=450, preview=400 → sum=1350
+    const available = availableFromClientWidth(850);
+    const r = normalizePanelWidths(500, 450, 400, available);
+    // overflow = 1350 - 774 = 576
+    // editor: 450 -> 280 (170), overflow = 406
+    // layers: 500 -> 180 (320), overflow = 86
+    // preview: 400 -> 314 (86)
+    expect(r.layers + r.editor + r.preview).toBe(available);
+    expect(r.layers).toBeGreaterThanOrEqual(LAYERS_MIN);
+    expect(r.editor).toBeGreaterThanOrEqual(EDITOR_MIN);
+    expect(r.preview).toBeGreaterThanOrEqual(PREVIEW_MIN);
   });
 });

--- a/apps/web/tests/components/file-viewer-panel-normalize.test.ts
+++ b/apps/web/tests/components/file-viewer-panel-normalize.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest';
+import { normalizePanelWidths } from '../../src/components/FileViewer';
+
+const LAYERS_MIN = 180;
+const EDITOR_MIN = 280;
+const PREVIEW_MIN = 280;
+const SUM_OF_MINS = LAYERS_MIN + EDITOR_MIN + PREVIEW_MIN; // 740
+
+describe('normalizePanelWidths', () => {
+  it('returns values unchanged when they fit within available width', () => {
+    const r = normalizePanelWidths(240, 420, 344, 1200);
+    expect(r).toEqual({ layers: 240, editor: 420, preview: 344 });
+  });
+
+  it('does nothing when values already equal available width exactly', () => {
+    const available = 240 + 420 + 344;
+    const r = normalizePanelWidths(240, 420, 344, available);
+    expect(r).toEqual({ layers: 240, editor: 420, preview: 344 });
+  });
+
+  it('lifts values below their minimums even without overflow', () => {
+    const r = normalizePanelWidths(100, 200, 100, 1200);
+    expect(r).toEqual({ layers: LAYERS_MIN, editor: EDITOR_MIN, preview: PREVIEW_MIN });
+  });
+
+  it('squeezes the editor first when panels overflow', () => {
+    // sum = 240 + 420 + 300 = 960, available = 900, overflow = 60
+    const r = normalizePanelWidths(240, 420, 300, 900);
+    expect(r.layers).toBe(240);
+    expect(r.preview).toBe(300);
+    expect(r.editor).toBe(360); // 420 - 60
+    expect(r.layers + r.editor + r.preview).toBe(900);
+  });
+
+  it('squeezes side panels after editor hits its minimum', () => {
+    // sum = 240 + 290 + 320 = 850, available = 750, overflow = 100
+    // editor can only give 10 (290->280), overflow = 90
+    // layers can give 60 (240->180), overflow = 30
+    // preview absorbs remaining 30 (320->290)
+    const r = normalizePanelWidths(240, 290, 320, 750);
+    expect(r.editor).toBe(EDITOR_MIN); // 280
+    expect(r.layers).toBe(LAYERS_MIN); // 180
+    expect(r.preview).toBe(290); // 320 - 30
+    expect(r.layers + r.editor + r.preview).toBe(750);
+  });
+
+  it('clamps editor and layers to minimums when available is barely above sum of minimums', () => {
+    // available = 750 (just 10 above sum of mins)
+    // editor 450→280 (170), layers 300→180 (120), preview 400→290 (110)
+    const r = normalizePanelWidths(300, 450, 400, SUM_OF_MINS + 10);
+    expect(r.editor).toBe(EDITOR_MIN);
+    expect(r.layers).toBe(LAYERS_MIN);
+    expect(r.preview).toBe(290); // absorbs remaining 110 overflow
+    expect(r.layers + r.editor + r.preview).toBe(SUM_OF_MINS + 10);
+  });
+
+  it('handles large-monitor widths restored on a smaller split workspace', () => {
+    // Saved on a 2560px monitor: layers=400, editor=600, preview=500
+    // Opened on a split workspace: 850px clientWidth - 56 = 794 available
+    const available = 794;
+    const r = normalizePanelWidths(400, 600, 500, available);
+
+    // sum = 1500, overflow = 706
+    // editor squeezed: 600 -> 280 (320), overflow = 386
+    // layers squeezed: 400 -> 180 (220), overflow = 166
+    // preview squeezed: 500 -> 334 (166)
+    expect(r.editor).toBe(EDITOR_MIN);
+    expect(r.layers).toBe(LAYERS_MIN);
+    expect(r.preview).toBe(334);
+    expect(r.layers + r.editor + r.preview).toBe(794);
+  });
+
+  it('handles a single oversized panel on an otherwise normal workspace', () => {
+    // layers=800 on a 900px clientWidth workspace: 900 - 56 = 844 available
+    const r = normalizePanelWidths(800, 420, 344, 844);
+
+    // sum = 1564, overflow = 720
+    // editor: 420 -> 280 (140), overflow = 580
+    // layers: 800 -> 220 (580), overflow = 0
+    expect(r.editor).toBe(EDITOR_MIN);
+    expect(r.preview).toBe(344);
+    expect(r.layers).toBe(220);
+    expect(r.layers + r.editor + r.preview).toBe(844);
+  });
+
+  it('rounds fractional panel widths', () => {
+    const r = normalizePanelWidths(240.7, 420.3, 344.5, 1200);
+    expect(r.layers).toBe(241);
+    expect(r.editor).toBe(420);
+    expect(r.preview).toBe(345);
+  });
+
+  it('returns minimums when available is less than sum of minimums', () => {
+    // Pathological: workspace too narrow even for minimums
+    const r = normalizePanelWidths(200, 300, 300, SUM_OF_MINS - 1);
+    expect(r.layers).toBe(LAYERS_MIN);
+    expect(r.editor).toBe(EDITOR_MIN);
+    expect(r.preview).toBe(PREVIEW_MIN);
+  });
+});

--- a/apps/web/tests/components/file-viewer-panel-normalize.test.ts
+++ b/apps/web/tests/components/file-viewer-panel-normalize.test.ts
@@ -19,13 +19,12 @@ function availableFromClientWidth(clientWidth: number): number {
 }
 
 describe('normalizePanelWidths', () => {
-  it('expands the editor to fill slack when panels fit within available width', () => {
-    // sum = 240 + 420 + 344 = 1004, available = 1200, slack = 196
+  it('returns values unchanged when they fit within available width', () => {
+    // sum = 240 + 420 + 344 = 1004, available = 1200, slack = 196 — no expansion
     const r = normalizePanelWidths(240, 420, 344, 1200);
     expect(r.layers).toBe(240);
+    expect(r.editor).toBe(420);
     expect(r.preview).toBe(344);
-    expect(r.editor).toBe(616); // 420 + 196
-    expect(r.layers + r.editor + r.preview).toBe(1200);
   });
 
   it('does nothing when values already equal available width exactly', () => {
@@ -34,14 +33,12 @@ describe('normalizePanelWidths', () => {
     expect(r).toEqual({ layers: 240, editor: 420, preview: 344 });
   });
 
-  it('lifts values below their minimums and expands editor to fill slack', () => {
+  it('lifts values below their minimums without expanding to fill', () => {
     const r = normalizePanelWidths(100, 200, 100, 1200);
-    // All three clamped to mins: 180 + 280 + 280 = 740
-    // slack = 1200 - 740 = 460, goes to editor
+    // All three clamped to mins: 180 + 280 + 280 = 740, no expansion
     expect(r.layers).toBe(LAYERS_MIN);
+    expect(r.editor).toBe(EDITOR_MIN);
     expect(r.preview).toBe(PREVIEW_MIN);
-    expect(r.editor).toBe(740); // 280 + 460
-    expect(r.layers + r.editor + r.preview).toBe(1200);
   });
 
   it('squeezes the editor first when panels overflow', () => {
@@ -106,13 +103,11 @@ describe('normalizePanelWidths', () => {
     expect(r.layers + r.editor + r.preview).toBe(824);
   });
 
-  it('rounds fractional panel widths and expands editor to fill available', () => {
+  it('rounds fractional panel widths', () => {
     const r = normalizePanelWidths(240.7, 420.3, 344.5, 1200);
     expect(r.layers).toBe(241);
+    expect(r.editor).toBe(420);
     expect(r.preview).toBe(345);
-    // sum = 241+420+345 = 1006, slack = 1200-1006 = 194, editor = 420+194 = 614
-    expect(r.editor).toBe(614);
-    expect(r.layers + r.editor + r.preview).toBe(1200);
   });
 
   it('returns minimums when available is less than sum of minimums', () => {
@@ -180,13 +175,12 @@ describe('normalizePanelWidths — content-box available width with real CSS bud
     expect(availableFromClientWidth(756)).toBe(680); // just above sum of mins
   });
 
-  it('default widths (240+420+344=1004) expand editor to fill 1100px workspace', () => {
+  it('default widths (240+420+344=1004) fit in a 1100px clientWidth workspace unchanged', () => {
     const available = availableFromClientWidth(1100); // = 1024
     const r = normalizePanelWidths(240, 420, 344, available);
     expect(r.layers).toBe(240);
+    expect(r.editor).toBe(420);
     expect(r.preview).toBe(344);
-    expect(r.editor).toBe(440); // 420 + 20 (slack)
-    expect(r.layers + r.editor + r.preview).toBe(available);
   });
 
   it('large persisted widths on a constrained 850px workspace are clamped', () => {
@@ -207,19 +201,18 @@ describe('normalizePanelWidths — content-box available width with real CSS bud
 
 describe('normalizePanelWidths — workspace resize during active session', () => {
   it('re-normalizes when workspace shrinks mid-session', () => {
-    // Initial: 1100px workspace → 1024 available, editor expands to 440
+    // Initial: 1100px workspace → 1024 available, values fit without expansion
     const available1 = availableFromClientWidth(1100); // = 1024
     const r1 = normalizePanelWidths(240, 420, 344, available1);
     expect(r1.layers).toBe(240);
+    expect(r1.editor).toBe(420);
     expect(r1.preview).toBe(344);
-    expect(r1.editor).toBe(440); // 420 + 20 slack
-    expect(r1.layers + r1.editor + r1.preview).toBe(available1);
 
     // User drags chat split wider → workspace shrinks to 850px → 774
     const available2 = availableFromClientWidth(850);
     const r2 = normalizePanelWidths(r1.layers, r1.editor, r1.preview, available2);
-    // sum = 240+440+344=1024, overflow = 1024-774=250
-    // editor: 440→280 (160), overflow=90
+    // sum = 240+420+344=1004, overflow = 1004-774=230
+    // editor: 420→280 (140), overflow=90
     // layers: 240→180 (60), overflow=30
     // preview: 344→314 (30)
     expect(r2.layers).toBe(LAYERS_MIN); // 180

--- a/apps/web/tests/components/file-viewer-panel-normalize.test.ts
+++ b/apps/web/tests/components/file-viewer-panel-normalize.test.ts
@@ -19,9 +19,13 @@ function availableFromClientWidth(clientWidth: number): number {
 }
 
 describe('normalizePanelWidths', () => {
-  it('returns values unchanged when they fit within available width', () => {
+  it('expands the editor to fill slack when panels fit within available width', () => {
+    // sum = 240 + 420 + 344 = 1004, available = 1200, slack = 196
     const r = normalizePanelWidths(240, 420, 344, 1200);
-    expect(r).toEqual({ layers: 240, editor: 420, preview: 344 });
+    expect(r.layers).toBe(240);
+    expect(r.preview).toBe(344);
+    expect(r.editor).toBe(616); // 420 + 196
+    expect(r.layers + r.editor + r.preview).toBe(1200);
   });
 
   it('does nothing when values already equal available width exactly', () => {
@@ -30,9 +34,14 @@ describe('normalizePanelWidths', () => {
     expect(r).toEqual({ layers: 240, editor: 420, preview: 344 });
   });
 
-  it('lifts values below their minimums even without overflow', () => {
+  it('lifts values below their minimums and expands editor to fill slack', () => {
     const r = normalizePanelWidths(100, 200, 100, 1200);
-    expect(r).toEqual({ layers: LAYERS_MIN, editor: EDITOR_MIN, preview: PREVIEW_MIN });
+    // All three clamped to mins: 180 + 280 + 280 = 740
+    // slack = 1200 - 740 = 460, goes to editor
+    expect(r.layers).toBe(LAYERS_MIN);
+    expect(r.preview).toBe(PREVIEW_MIN);
+    expect(r.editor).toBe(740); // 280 + 460
+    expect(r.layers + r.editor + r.preview).toBe(1200);
   });
 
   it('squeezes the editor first when panels overflow', () => {
@@ -97,11 +106,13 @@ describe('normalizePanelWidths', () => {
     expect(r.layers + r.editor + r.preview).toBe(824);
   });
 
-  it('rounds fractional panel widths', () => {
+  it('rounds fractional panel widths and expands editor to fill available', () => {
     const r = normalizePanelWidths(240.7, 420.3, 344.5, 1200);
     expect(r.layers).toBe(241);
-    expect(r.editor).toBe(420);
     expect(r.preview).toBe(345);
+    // sum = 241+420+345 = 1006, slack = 1200-1006 = 194, editor = 420+194 = 614
+    expect(r.editor).toBe(614);
+    expect(r.layers + r.editor + r.preview).toBe(1200);
   });
 
   it('returns minimums when available is less than sum of minimums', () => {
@@ -169,11 +180,13 @@ describe('normalizePanelWidths — content-box available width with real CSS bud
     expect(availableFromClientWidth(756)).toBe(680); // just above sum of mins
   });
 
-  it('default widths (240+420+344=1004) fit in a 1100px clientWidth workspace', () => {
-    const available = availableFromClientWidth(1100);
+  it('default widths (240+420+344=1004) expand editor to fill 1100px workspace', () => {
+    const available = availableFromClientWidth(1100); // = 1024
     const r = normalizePanelWidths(240, 420, 344, available);
-    expect(r).toEqual({ layers: 240, editor: 420, preview: 344 });
-    expect(r.layers + r.editor + r.preview).toBeLessThanOrEqual(available);
+    expect(r.layers).toBe(240);
+    expect(r.preview).toBe(344);
+    expect(r.editor).toBe(440); // 420 + 20 (slack)
+    expect(r.layers + r.editor + r.preview).toBe(available);
   });
 
   it('large persisted widths on a constrained 850px workspace are clamped', () => {
@@ -194,18 +207,25 @@ describe('normalizePanelWidths — content-box available width with real CSS bud
 
 describe('normalizePanelWidths — workspace resize during active session', () => {
   it('re-normalizes when workspace shrinks mid-session', () => {
-    // Initial: 1100px workspace → default widths (1004) fit in 1024
-    const available1 = availableFromClientWidth(1100);
+    // Initial: 1100px workspace → 1024 available, editor expands to 440
+    const available1 = availableFromClientWidth(1100); // = 1024
     const r1 = normalizePanelWidths(240, 420, 344, available1);
-    expect(r1).toEqual({ layers: 240, editor: 420, preview: 344 });
+    expect(r1.layers).toBe(240);
+    expect(r1.preview).toBe(344);
+    expect(r1.editor).toBe(440); // 420 + 20 slack
+    expect(r1.layers + r1.editor + r1.preview).toBe(available1);
 
     // User drags chat split wider → workspace shrinks to 850px → 774
     const available2 = availableFromClientWidth(850);
     const r2 = normalizePanelWidths(r1.layers, r1.editor, r1.preview, available2);
-    expect(r2.layers + r2.editor + r2.preview).toBeLessThanOrEqual(available2);
-    expect(r2.layers).toBeGreaterThanOrEqual(LAYERS_MIN);
-    expect(r2.editor).toBeGreaterThanOrEqual(EDITOR_MIN);
-    expect(r2.preview).toBeGreaterThanOrEqual(PREVIEW_MIN);
+    // sum = 240+440+344=1024, overflow = 1024-774=250
+    // editor: 440→280 (160), overflow=90
+    // layers: 240→180 (60), overflow=30
+    // preview: 344→314 (30)
+    expect(r2.layers).toBe(LAYERS_MIN); // 180
+    expect(r2.editor).toBe(EDITOR_MIN); // 280
+    expect(r2.preview).toBe(314);
+    expect(r2.layers + r2.editor + r2.preview).toBe(available2);
   });
 
   it('is idempotent when workspace width does not change', () => {

--- a/apps/web/tests/components/file-viewer-panel-normalize.test.ts
+++ b/apps/web/tests/components/file-viewer-panel-normalize.test.ts
@@ -191,3 +191,27 @@ describe('normalizePanelWidths — content-box available width with real CSS bud
     expect(r.preview).toBeGreaterThanOrEqual(PREVIEW_MIN);
   });
 });
+
+describe('normalizePanelWidths — workspace resize during active session', () => {
+  it('re-normalizes when workspace shrinks mid-session', () => {
+    // Initial: 1100px workspace → default widths (1004) fit in 1024
+    const available1 = availableFromClientWidth(1100);
+    const r1 = normalizePanelWidths(240, 420, 344, available1);
+    expect(r1).toEqual({ layers: 240, editor: 420, preview: 344 });
+
+    // User drags chat split wider → workspace shrinks to 850px → 774
+    const available2 = availableFromClientWidth(850);
+    const r2 = normalizePanelWidths(r1.layers, r1.editor, r1.preview, available2);
+    expect(r2.layers + r2.editor + r2.preview).toBeLessThanOrEqual(available2);
+    expect(r2.layers).toBeGreaterThanOrEqual(LAYERS_MIN);
+    expect(r2.editor).toBeGreaterThanOrEqual(EDITOR_MIN);
+    expect(r2.preview).toBeGreaterThanOrEqual(PREVIEW_MIN);
+  });
+
+  it('is idempotent when workspace width does not change', () => {
+    const available = availableFromClientWidth(1100);
+    const r1 = normalizePanelWidths(240, 420, 344, available);
+    const r2 = normalizePanelWidths(r1.layers, r1.editor, r1.preview, available);
+    expect(r2).toEqual(r1);
+  });
+});

--- a/e2e/ui/app.test.ts
+++ b/e2e/ui/app.test.ts
@@ -394,6 +394,11 @@ test('manual edit mode applies content, style, attribute, HTML, source, undo, an
   const frame = page.frameLocator('[data-testid="artifact-preview-frame"]');
   await expect(frame.getByRole('heading', { name: 'Original Hero' })).toBeVisible();
 
+  // Dismiss the privacy consent banner so it doesn't intercept clicks
+  // when the layout shifts due to 1fr editor column expansion.
+  const consentBanner = page.locator('.privacy-consent-banner');
+  await consentBanner.getByRole('button').last().click();
+
   await page.getByTestId('manual-edit-mode-toggle').click();
   await frame.getByRole('heading', { name: 'Original Hero' }).click();
   await expect(page.locator('.manual-edit-modal')).toContainText('Hero title');


### PR DESCRIPTION
Closes #1059 
Replace static CSS grid with adjustable three-column layout: Layers | Editor | Preview. Each column has explicit pixel width with min-width enforcement and no max-width. Drag handles redistribute space between adjacent panels only. Widths persist to localStorage. Keyboard accessible with ArrowLeft/Right/Home.