### PR TITLE
fix: use max_completion_tokens for Azure OpenAI endpoints

### DIFF
--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -344,7 +344,7 @@ function buildProviderCall(input: ProviderTestRequest): ProviderCallShape {
         },
         body: {
           model,
-          max_tokens: PROVIDER_MAX_TOKENS,
+          max_completion_tokens: PROVIDER_MAX_TOKENS,
           messages: [{ role: 'user', content: SMOKE_PROMPT }],
           stream: false,
         },
@@ -377,7 +377,7 @@ function buildProviderCall(input: ProviderTestRequest): ProviderCallShape {
         },
         body: {
           ...(usesVersionedOpenAIPath ? { model } : {}),
-          max_tokens: PROVIDER_MAX_TOKENS,
+          max_completion_tokens: PROVIDER_MAX_TOKENS,
           messages: [{ role: 'user', content: SMOKE_PROMPT }],
           stream: false,
         },

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -7023,7 +7023,7 @@ export async function startServer({
     const payload = {
       model,
       messages: payloadMessages,
-      max_tokens:
+      max_completion_tokens:
         typeof maxTokens === 'number' && maxTokens > 0 ? maxTokens : 8192,
       stream: true,
     };
@@ -7135,7 +7135,7 @@ export async function startServer({
     const payload = {
       ...(usesVersionedOpenAIPath ? { model } : {}),
       messages: payloadMessages,
-      max_tokens:
+      max_completion_tokens:
         typeof maxTokens === 'number' && maxTokens > 0 ? maxTokens : 8192,
       stream: true,
     };


### PR DESCRIPTION
Fixes #361

## Problem
Azure OpenAI API rejects `max_tokens` parameter and requires `max_completion_tokens` instead. Error:
```
Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.
```

## Solution
Updated OpenAI and Azure proxy endpoints to use `max_completion_tokens`:

**apps/daemon/src/connectionTest.ts** (lines 347, 380):
- OpenAI test case
- Azure test case

**apps/daemon/src/server.ts** (lines 7026, 7138):
- OpenAI proxy endpoint
- Azure proxy endpoint

Anthropic endpoints continue using `max_tokens` (per their API spec).

## Testing
@Adityagrao tested this fix locally and confirmed it works with Azure AI Foundry endpoints.

## Related
- PR #941 fixed the `api-version` query parameter issue
- This PR fixes the second Azure compatibility bug reported in the same issue