### PR TITLE
fix(actions): map pull_request_target to contributor bot event

### DIFF
--- a/.github/workflows/contributor-card-bot.yml
+++ b/.github/workflows/contributor-card-bot.yml
@@ -50,4 +50,9 @@ jobs:
           BOT_APP_ID: ${{ secrets.BOT_APP_ID }}
           BOT_APP_INSTALLATION_ID: ${{ secrets.BOT_APP_INSTALLATION_ID }}
           BOT_APP_PRIVATE_KEY: ${{ secrets.BOT_APP_PRIVATE_KEY }}
-        run: pnpm exec tsx scripts/action-handler.ts
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "pull_request_target" ]; then
+            GITHUB_EVENT_NAME=pull_request pnpm exec tsx scripts/action-handler.ts
+          else
+            pnpm exec tsx scripts/action-handler.ts
+          fi


### PR DESCRIPTION
## Summary
- make the contributor bot run under `pull_request_target` by remapping the child process event name to `pull_request`
- keep `pull_request_target` so the workflow can continue using repo secrets for merged PRs from forks
- verified the existing failed run succeeds once secrets are present; `pnpm guard` passes, and `pnpm typecheck` currently fails on an unrelated packaged test export error in `apps/packaged/tests/desktop-url-allowlist.test.ts`