### PR TITLE
fix(packaged): build desktop before typecheck

### DIFF
--- a/apps/packaged/package.json
+++ b/apps/packaged/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "node ./esbuild.config.mjs && tsc -p tsconfig.json --emitDeclarationOnly",
     "test": "vitest run -c vitest.config.ts",
-    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.tests.json --noEmit"
+    "typecheck": "pnpm --filter @open-design/desktop build && tsc -p tsconfig.json --noEmit && tsc -p tsconfig.tests.json --noEmit"
   },
   "dependencies": {
     "@open-design/daemon": "workspace:*",


### PR DESCRIPTION
## Summary
- build `@open-design/desktop` before running the packaged app typecheck so its exported declarations stay in sync with source
- prevent packaged tests from reading stale desktop `dist` types during workspace `pnpm typecheck`
- verified with `pnpm --filter @open-design/packaged typecheck`, `pnpm guard`, and `pnpm typecheck`