### PR TITLE
fix: deck PDF export shows all slides, not just current page

### DIFF
--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -228,7 +228,9 @@ export function isAllowedChildWindowUrl(url: string): boolean {
     // its links resolve to `http://127.0.0.1:.../...`, which is gated
     // by the separate `isHttpUrl` branch and continues to open in the
     // user's external browser via `shell.openExternal`.
-    return parsed.protocol === "blob:" || parsed.protocol === "od:";
+    // `about:blank` is used by the PDF export fallback (window.open('', '_blank'))
+    // before navigating to a blob: URL. Without this, the popup is silently blocked.
+    return parsed.protocol === "blob:" || parsed.protocol === "od:" || url === "about:blank";
   } catch {
     return false;
   }

--- a/apps/web/src/runtime/exports.ts
+++ b/apps/web/src/runtime/exports.ts
@@ -323,6 +323,8 @@ const DECK_PRINT_CSS = `
     transform: none !important;
   }
   .slide, [data-screen-label], section.slide, .deck-slide, .ppt-slide {
+    display: block !important;
+    visibility: visible !important;
     flex: none !important;
     width: 1920px !important;
     height: 1080px !important;
@@ -334,6 +336,10 @@ const DECK_PRINT_CSS = `
     transform: none !important;
     position: relative !important;
     overflow: hidden !important;
+  }
+  .slide[hidden], [data-screen-label][hidden],
+  section.slide[hidden], .deck-slide[hidden], .ppt-slide[hidden] {
+    display: block !important;
   }
   .slide:last-child, [data-screen-label]:last-child { page-break-after: auto; break-after: auto; }
   .deck-counter, .deck-hint, .deck-nav,


### PR DESCRIPTION
## Problem

When exporting a deck (slideshow) artifact as PDF, only the currently visible slide is captured. All other slides are missing from the exported PDF.

## Root Cause

Deck navigation hides inactive slides using one of three mechanisms:
- **Inline `style="display:none"`** (class-toggle decks — the deck bridge JS sets `list[k].style.display = "none"` for inactive slides)
- **Inline `style="visibility:hidden"`** (visibility-only decks)
- **HTML `hidden` attribute**

The `DECK_PRINT_CSS` `@media print` rules had `page-break-after` and sizing overrides but **no `display` or `visibility` overrides**, so hidden slides stayed hidden during print — only the active slide appeared in the PDF.

Additionally, in the Electron desktop app, the browser fallback path (`window.open("", "_blank")`) was silently blocked by `setWindowOpenHandler` because `about:blank` was not in the `isAllowedChildWindowUrl` whitelist.

## Changes

### 1. `apps/web/src/runtime/exports.ts` — Fix slide visibility for print
- Add `display: block !important` and `visibility: visible !important` to the `.slide` / `[data-screen-label]` selectors in `DECK_PRINT_CSS`
- Add a rule for `[hidden]` slides to override the HTML `hidden` attribute
- This ensures **all slides become visible** when the browser renders the print layout, then `page-break-after: always` splits them into separate pages

### 2. `apps/desktop/src/main/runtime.ts` — Unblock PDF export popup in Electron
- Add `about:blank` to the `isAllowedChildWindowUrl` whitelist
- The PDF export fallback opens `window.open("", "_blank")` (which resolves to `about:blank`) before navigating to a `blob:` URL — without this, the popup is silently denied

## Testing

- Create a deck artifact with multiple slides in Open Design
- Click "Export as PDF"
- **Before fix**: PDF contains only the currently visible slide (1 page)
- **After fix**: PDF contains all slides, each on its own page