### PR TITLE
feat(provider-models): sort fetched models alphabetically

### DIFF
--- a/apps/daemon/src/providerModels.ts
+++ b/apps/daemon/src/providerModels.ts
@@ -76,7 +76,7 @@ function uniqueModels(models: ProviderModelOption[]): ProviderModelOption[] {
     seen.add(id);
     out.push({ id, label: model.label.trim() || id });
   }
-  return out;
+  return out.sort((a, b) => a.id.localeCompare(b.id));
 }
 
 function extractOpenAiModels(data: unknown): ProviderModelOption[] {

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -134,8 +134,8 @@ describe('POST /api/provider/models', () => {
       );
       return jsonResponse({
         data: [
-          { id: 'gpt-4o', object: 'model' },
           { id: 'gpt-4o-mini', object: 'model' },
+          { id: 'gpt-4o', object: 'model' },
           { id: 'gpt-4o', object: 'model' },
         ],
       });
@@ -179,6 +179,11 @@ describe('POST /api/provider/models', () => {
             display_name: 'Claude Sonnet 4.5',
             type: 'model',
           },
+          {
+            id: 'claude-haiku-4-5',
+            display_name: 'Claude Haiku 4.5',
+            type: 'model',
+          },
         ],
       });
     });
@@ -197,6 +202,7 @@ describe('POST /api/provider/models', () => {
     await expect(res.json()).resolves.toMatchObject({
       ok: true,
       models: [
+        { id: 'claude-haiku-4-5', label: 'Claude Haiku 4.5' },
         { id: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
       ],
     });
@@ -210,10 +216,9 @@ describe('POST /api/provider/models', () => {
       return jsonResponse({
         models: [
           {
-            name: 'models/gemini-2.0-flash-001',
-            baseModelId: 'gemini-2.0-flash',
-            displayName: 'Gemini 2.0 Flash',
-            supportedGenerationMethods: ['generateContent', 'countTokens'],
+            name: 'models/gemini-custom',
+            displayName: 'Gemini Custom',
+            supportedGenerationMethods: ['generateContent'],
           },
           {
             name: 'models/text-embedding-004',
@@ -221,9 +226,10 @@ describe('POST /api/provider/models', () => {
             supportedGenerationMethods: ['embedContent'],
           },
           {
-            name: 'models/gemini-custom',
-            displayName: 'Gemini Custom',
-            supportedGenerationMethods: ['generateContent'],
+            name: 'models/gemini-2.0-flash-001',
+            baseModelId: 'gemini-2.0-flash',
+            displayName: 'Gemini 2.0 Flash',
+            supportedGenerationMethods: ['generateContent', 'countTokens'],
           },
         ],
       });


### PR DESCRIPTION
## Motivation

After the fetch-models flow landed, providers return models in their own order, which can feel random from the user's perspective. For providers with many models, a stable alphabetical order makes the picker easier to scan.

## Summary

Sort fetched provider models by `id` ascending in the daemon after deduplication.

Static provider suggestions and the current model behavior are unchanged.

## Key Changes

- Sort fetched models in `apps/daemon/src/providerModels.ts` via `a.id.localeCompare(b.id)` after deduplication.
- Keep the frontend merge order unchanged: fetched models first, then provider preset / static suggestions, with the user's current model preserved.
- Update daemon model-listing tests so OpenAI, Anthropic, and Google mock responses prove sorted output.

## Out of Scope

- Semantic model ordering by tier, family, or version.
- Sorting static suggestions.
- Sorting the fully merged dropdown.

## Test Plan

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/connection-test.test.ts`
  - Passes: 48 tests.
