### PR TITLE
fix(web): prevent chat messages from overflowing into workspace area (#662)

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -838,6 +838,7 @@ code {
 .chat-log {
   flex: 1;
   overflow-y: auto;
+  overflow-x: hidden;
   padding: 16px;
   display: flex;
   flex-direction: column;
@@ -852,6 +853,8 @@ code {
   border: none;
   white-space: normal;
   word-wrap: break-word;
+  min-width: 0;
+  max-width: 100%;
 }
 .msg .role {
   display: flex;
@@ -9316,6 +9319,7 @@ button.ghost.mcp-copy-btn:hover:not(:disabled) {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  min-width: 0;
 }
 .prose-block { line-height: 1.6; color: var(--text); }
 .prose-block .md-p { margin: 0; }


### PR DESCRIPTION
## Problem

Chat panel content (thinking blocks, status pills, form cards) can visually extend past the left pane boundary and overlap the workspace area on the right, breaking the split-view layout.

## Root cause

While  and  already have  (from #740), the intermediate flex items in the layout chain can still propagate intrinsic content width:

-  only had , leaving horizontal overflow as 
-  lacked , so flex items in the chat log column could expand beyond the panel width when nested content (tool cards, form elements) is wider than the container

## Fix

- Add  to  to clip any horizontally overflowing content
- Add  to  to prevent flex items from expanding beyond the chat panel width

## Verification

These are purely CSS layout constraints with zero behavioral changes. The fix ensures:
1. Chat messages stay clipped within the chat pane boundary
2. Flex items respect the panel width even when nested content is intrinsically wider
3. Existing  on  and  works correctly with the full constraint chain

Closes #662