### PR TITLE
fix(platform): add legacy ~/.fnm path to wellKnownUserToolchainBins

### DIFF
--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -24,7 +24,7 @@ export type ProcessStampContract<
   TCriteria extends Partial<TStamp> = Partial<TStamp>,
 > = {
   normalizeStamp(input: unknown): TStamp;
-  normalizeStampCriteria(input?: unknown): TCriteria;.fnm
+  normalizeStampCriteria(input?: unknown): TCriteria;
   stampFields: readonly ProcessStampField<TStamp>[];
   stampFlags: { readonly [K in ProcessStampField<TStamp>]: string };
 };

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -24,7 +24,7 @@ export type ProcessStampContract<
   TCriteria extends Partial<TStamp> = Partial<TStamp>,
 > = {
   normalizeStamp(input: unknown): TStamp;
-  normalizeStampCriteria(input?: unknown): TCriteria;
+  normalizeStampCriteria(input?: unknown): TCriteria;.fnm
   stampFields: readonly ProcessStampField<TStamp>[];
   stampFlags: { readonly [K in ProcessStampField<TStamp>]: string };
 };
@@ -522,6 +522,10 @@ export function wellKnownUserToolchainBins(
     },
     {
       root: join(home, ".local", "share", "fnm", "node-versions"),
+      segments: ["installation", "bin"],
+    },
+    {
+      root: join(home, ".fnm", "node-versions"),
       segments: ["installation", "bin"],
     },
   ]) {


### PR DESCRIPTION
fnm legacy installations use ~/.fnm/node-versions instead of 
~/.local/share/fnm/node-versions.

This adds the missing legacy path to wellKnownUserToolchainBins() scan list,
fixing Codex CLI detection on macOS when Node is managed by fnm legacy setups.

Closes #1102