### PR TITLE
fix(daemon): add HTTP range request support for video/audio files

### DIFF
--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -337,6 +337,29 @@ async function collectArchiveEntries(dir, relDir, out) {
   }
 }
 
+/**
+ * Resolve the absolute file path for a project file without reading it into memory.
+ * Use this for streaming large files (video, audio) via HTTP range requests.
+ */
+export async function resolveProjectFilePath(projectsRoot, projectId, name, metadata?) {
+  const dir = resolveProjectDir(projectsRoot, projectId, metadata);
+  const file = await resolveSafeReal(dir, name);
+  const st = await stat(file);
+  const rel = toProjectPath(path.relative(dir, file));
+  const manifest = await readManifestForPath(dir, rel);
+  return {
+    absolutePath: file,
+    name: rel,
+    path: rel,
+    size: st.size,
+    mtime: st.mtimeMs,
+    mime: mimeFor(rel),
+    kind: kindFor(rel),
+    artifactKind: manifest?.kind,
+    artifactManifest: manifest,
+  };
+}
+
 export async function readProjectFile(projectsRoot, projectId, name, metadata?) {
   const dir = resolveProjectDir(projectsRoot, projectId, metadata);
   const file = await resolveSafeReal(dir, name);

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -138,6 +138,7 @@ import {
   readProjectFile,
   renameProjectFile,
   removeProjectDir,
+  resolveProjectFilePath,
   sanitizeName,
   searchProjectFiles,
   writeProjectFile,
@@ -4521,13 +4522,56 @@ export async function startServer({
   app.get('/api/projects/:id/files/*', async (req, res) => {
     try {
       const project = getProject(db, req.params.id);
-      const file = await readProjectFile(
+      const file = await resolveProjectFilePath(
         PROJECTS_DIR,
         req.params.id,
         req.params[0],
         project?.metadata,
       );
-      res.type(file.mime).send(file.buffer);
+
+      // For video and audio files, support HTTP range requests so browsers
+      // can seek/scrub. For other files, read into memory and send as before.
+      const isStreamable = file.mime.startsWith('video/') || file.mime.startsWith('audio/');
+
+      if (isStreamable) {
+        const range = req.headers.range;
+        if (range) {
+          // Parse range header (e.g., "bytes=0-1023")
+          const parts = range.replace(/bytes=/, '').split('-');
+          const start = parseInt(parts[0], 10);
+          const end = parts[1] ? parseInt(parts[1], 10) : file.size - 1;
+          const chunkSize = end - start + 1;
+
+          res.status(206); // Partial Content
+          res.set({
+            'Content-Range': `bytes ${start}-${end}/${file.size}`,
+            'Accept-Ranges': 'bytes',
+            'Content-Length': chunkSize,
+            'Content-Type': file.mime,
+          });
+
+          const stream = fs.createReadStream(file.absolutePath, { start, end });
+          stream.pipe(res);
+        } else {
+          // No range header — send the whole file
+          res.set({
+            'Accept-Ranges': 'bytes',
+            'Content-Length': file.size,
+            'Content-Type': file.mime,
+          });
+          const stream = fs.createReadStream(file.absolutePath);
+          stream.pipe(res);
+        }
+      } else {
+        // Non-streamable files: read into memory and send (existing behavior)
+        const fullFile = await readProjectFile(
+          PROJECTS_DIR,
+          req.params.id,
+          req.params[0],
+          project?.metadata,
+        );
+        res.type(fullFile.mime).send(fullFile.buffer);
+      }
     } catch (err) {
       const status = err && err.code === 'ENOENT' ? 404 : 400;
       sendApiError(


### PR DESCRIPTION
Fixes #784

## Problem

Video and audio artifacts could not be previewed inline in the file viewer. The `VideoViewer` and `AudioViewer` components already existed on the frontend, but the daemon was serving all files by reading the full buffer into memory with no `Accept-Ranges` header. Browsers require HTTP range request support to seek, scrub, or even begin playing video/audio — without it, playback silently fails.

## Solution

- Added `resolveProjectFilePath()` to `apps/daemon/src/projects.ts` to resolve a safe absolute file path without reading the file into memory
- Updated `GET /api/projects/:id/files/*` in `apps/daemon/src/server.ts` to:
  - Detect `video/*` and `audio/*` MIME types
  - Serve them via `fs.createReadStream` with `206 Partial Content` and `Accept-Ranges: bytes` headers when a Range header is present
  - Fall back to full-file streaming when no Range header is present
  - Keep existing buffer-based serving for non-media files (images, HTML, etc.)

## Benefits

- Video artifacts now preview inline with native browser controls
- Seeking/scrubbing works correctly
- Audio files also benefit from the same streaming support
- No memory overhead for large video files
- Non-media files unchanged (backward compatible)

## Test plan

- [ ] Generate a video artifact via an agent (e.g. image-to-video workflow)
- [ ] Click the video file in the file viewer — confirm inline `<video>` player renders with controls
- [ ] Verify seeking/scrubbing works in the player
- [ ] Repeat for an audio file (`.mp3`, `.wav`, `.m4a`)
- [ ] Confirm non-media files (HTML, images, text) are unaffected