### PR TITLE
fix: Support OpenCode Write tool display as card

### DIFF
--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -687,7 +687,7 @@ function summarizeGroup(
 
 function toolFamily(name: string): string {
   if (name === "Edit" || name === "str_replace_edit") return "edit";
-  if (name === "Write" || name === "create_file") return "write";
+  if (name === "Write" || name === "write" || name === "create_file") return "write";
   if (name === "Read" || name === "read_file") return "read";
   if (name === "Glob" || name === "list_files") return "glob";
   if (name === "Grep") return "grep";

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1115,8 +1115,9 @@ export function ProjectView({
         // file the moment the agent finishes writing it. The file-creating
         // tools we care about: Write (new file), Edit (existing file —
         // surfacing the freshly-modified file is also useful).
-        if (ev.kind === 'tool_use' && (ev.name === 'Write' || ev.name === 'Edit')) {
-          const filePath = (ev.input as { file_path?: unknown } | null)?.file_path;
+        if (ev.kind === 'tool_use' && ((ev.name === 'Write' || ev.name === 'write') || ev.name === 'Edit')) {
+          const input = ev.input as { file_path?: unknown; filePath?: unknown } | null;
+          const filePath = input?.file_path ?? input?.filePath;
           if (typeof filePath === 'string' && filePath.length > 0) {
             // Preserve the full path so decideAutoOpenAfterWrite can do a
             // path-suffix match against the project's relative file paths.

--- a/apps/web/src/components/ToolCard.tsx
+++ b/apps/web/src/components/ToolCard.tsx
@@ -54,7 +54,7 @@ export function ToolCard({
   }
   const ctx: FileToolCtx = { projectFileNames, onRequestOpenFile };
   if (name === 'TodoWrite' || name === 'todowrite') return <TodoCard input={use.input} />;
-  if (name === 'Write' || name === 'create_file')
+  if (name === 'Write' || name === 'write' || name === 'create_file')
     return <FileWriteCard input={use.input} result={result} ctx={ctx} />;
   if (name === 'Edit' || name === 'str_replace_edit')
     return <FileEditCard input={use.input} result={result} ctx={ctx} />;
@@ -134,8 +134,8 @@ function FileWriteCard({
   ctx: FileToolCtx;
 }) {
   const t = useT();
-  const obj = (input ?? {}) as { file_path?: string; path?: string; content?: string };
-  const file = obj.file_path ?? obj.path ?? '(unnamed)';
+  const obj = (input ?? {}) as { file_path?: string; filePath?: string; path?: string; content?: string };
+  const file = obj.file_path ?? obj.filePath ?? obj.path ?? '(unnamed)';
   const lines = typeof obj.content === 'string' ? obj.content.split('\n').length : null;
   return (
     <div className="op-card op-file">
@@ -165,12 +165,13 @@ function FileEditCard({
   const t = useT();
   const obj = (input ?? {}) as {
     file_path?: string;
+    filePath?: string;
     path?: string;
     old_string?: string;
     new_string?: string;
     edits?: { old_string?: string; new_string?: string }[];
   };
-  const file = obj.file_path ?? obj.path ?? '(unnamed)';
+  const file = obj.file_path ?? obj.filePath ?? obj.path ?? '(unnamed)';
   const editCount = Array.isArray(obj.edits) ? obj.edits.length : 1;
   return (
     <div className="op-card op-file">
@@ -198,8 +199,8 @@ function FileReadCard({
   ctx: FileToolCtx;
 }) {
   const t = useT();
-  const obj = (input ?? {}) as { file_path?: string; path?: string };
-  const file = obj.file_path ?? obj.path ?? '(unnamed)';
+  const obj = (input ?? {}) as { file_path?: string; filePath?: string; path?: string };
+  const file = obj.file_path ?? obj.filePath ?? obj.path ?? '(unnamed)';
   return (
     <div className="op-card op-file">
       <div className="op-card-head">

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -378,6 +378,15 @@ function isChatRunStatus(value: unknown): value is ChatRunStatus {
   return value === 'queued' || value === 'running' || value === 'succeeded' || value === 'failed' || value === 'canceled';
 }
 
+function normalizeToolInput(input: unknown): unknown {
+  if (input == null || typeof input !== 'object') return input;
+  const obj = input as Record<string, unknown>;
+  if ('filePath' in obj && typeof obj.filePath === 'string') {
+    return { ...obj, file_path: obj.filePath };
+  }
+  return input;
+}
+
 // Translate a raw `agent` SSE payload (what apps/daemon/src/claude-stream.ts emits)
 // into the UI's AgentEvent union. Keep this liberal — unknown types just
 // return null so the UI ignores them instead of rendering garbage.
@@ -429,7 +438,7 @@ function translateAgentEvent(data: DaemonAgentPayload): AgentEvent | null {
     };
   }
   if (t === 'tool_use' && typeof data.id === 'string' && typeof data.name === 'string') {
-    return { kind: 'tool_use', id: data.id, name: data.name, input: data.input ?? null };
+    return { kind: 'tool_use', id: data.id, name: data.name, input: normalizeToolInput(data.input) };
   }
   if (t === 'tool_result' && typeof data.toolUseId === 'string') {
     return {


### PR DESCRIPTION
**Problem:**
The Write tool from OpenCode AI wasn't being displayed correctly as a card in the UI. Two issues caused this:
1. OpenCode uses lowercase `write` as the tool name instead of `Write`
2. OpenCode uses camelCase `filePath` for file paths instead of snake_case `file_path` (which Claude uses)

**Solution:**
Implemented a two-layer fix:

1. **Root-level normalization** (`daemon.ts`): Added `normalizeToolInput()` function that automatically converts `filePath` to `file_path` when parsing tool use events

2. **Component-level compatibility** (fallback): Updated all relevant components to recognize both naming conventions

**Files Modified:**
- `apps/web/src/providers/daemon.ts` - Added root-level field normalization
- `apps/web/src/components/ToolCard.tsx` - Added tool name and field compatibility  
- `apps/web/src/components/AssistantMessage.tsx` - Added tool name recognition
- `apps/web/src/components/ProjectView.tsx` - Added field compatibility for auto-open

**Testing:**
All type checks pass successfully.