### PR TITLE
fix(web): surface connector auth errors and stop silent popup close (#725)

### DIFF
--- a/apps/web/src/components/ConnectorsBrowser.tsx
+++ b/apps/web/src/components/ConnectorsBrowser.tsx
@@ -301,6 +301,21 @@ export function updateConnectorAuthorizationPendingFromStatuses(
   return pruneConnectorAuthorizationPending(next, nowMs);
 }
 
+export function clearConnectorAuthorizationErrorsForConnected(
+  errors: Record<string, string>,
+  statuses: ConnectorStatusResponse['statuses'],
+): Record<string, string> {
+  let mutated = false;
+  const next = { ...errors };
+  for (const [connectorId, status] of Object.entries(statuses)) {
+    if (status.status === 'connected' && next[connectorId] !== undefined) {
+      delete next[connectorId];
+      mutated = true;
+    }
+  }
+  return mutated ? next : errors;
+}
+
 export function clearConnectorAuthorizationPending(
   pending: ConnectorAuthorizationPendingState,
   connectorId: string,
@@ -555,6 +570,7 @@ export function ConnectorsBrowser({
     const statuses = await fetchConnectorStatuses();
     setConnectors((curr) => applyConnectorStatuses(curr, statuses));
     setConnectorAuthorizationPending((curr) => updateConnectorAuthorizationPendingFromStatuses(curr, statuses));
+    setConnectorAuthorizationError((curr) => clearConnectorAuthorizationErrorsForConnected(curr, statuses));
   }, []);
 
   useEffect(() => {

--- a/apps/web/src/components/ConnectorsBrowser.tsx
+++ b/apps/web/src/components/ConnectorsBrowser.tsx
@@ -540,6 +540,7 @@ export function ConnectorsBrowser({
   } | null>(null);
   const [connectorAuthorizationPending, setConnectorAuthorizationPending] = useState<ConnectorAuthorizationPendingState>(() => loadConnectorAuthorizationPending());
   const [connectorAuthorizationCancelFailed, setConnectorAuthorizationCancelFailed] = useState<Record<string, boolean>>({});
+  const [connectorAuthorizationError, setConnectorAuthorizationError] = useState<Record<string, string>>({});
   const [detailConnectorId, setDetailConnectorId] = useState<string | null>(null);
   const [toolPreviewLoadingIds, setToolPreviewLoadingIds] = useState<Record<string, boolean>>({});
   const [toolPreviewFetchedIds, setToolPreviewFetchedIds] = useState<Record<string, boolean>>({});
@@ -684,6 +685,12 @@ export function ConnectorsBrowser({
           delete next[connectorId];
           return next;
         });
+        setConnectorAuthorizationError((curr) => {
+          if (curr[connectorId] === undefined) return curr;
+          const next = { ...curr };
+          delete next[connectorId];
+          return next;
+        });
         const result = await connectConnector(connectorId);
         updateConnector(result.connector);
         if (result.connector && !result.error) {
@@ -693,9 +700,18 @@ export function ConnectorsBrowser({
           }));
         } else {
           setConnectorAuthorizationPending((curr) => clearConnectorAuthorizationPending(curr, connectorId));
+          if (result.error) {
+            setConnectorAuthorizationError((curr) => ({ ...curr, [connectorId]: result.error! }));
+          }
         }
       } else {
         setConnectorAuthorizationPending((curr) => clearConnectorAuthorizationPending(curr, connectorId));
+        setConnectorAuthorizationError((curr) => {
+          if (curr[connectorId] === undefined) return curr;
+          const next = { ...curr };
+          delete next[connectorId];
+          return next;
+        });
         updateConnector(await disconnectConnector(connectorId));
       }
     } finally {
@@ -764,6 +780,12 @@ export function ConnectorsBrowser({
     if (connector) {
       updateConnector(connector);
       setConnectorAuthorizationCancelFailed((curr) => {
+        if (curr[connectorId] === undefined) return curr;
+        const next = { ...curr };
+        delete next[connectorId];
+        return next;
+      });
+      setConnectorAuthorizationError((curr) => {
         if (curr[connectorId] === undefined) return curr;
         const next = { ...curr };
         delete next[connectorId];
@@ -891,6 +913,7 @@ export function ConnectorsBrowser({
                   }
                   authorizationPending={connectorAuthorizationPending[connector.id]}
                   authorizationCancelFailed={connectorAuthorizationCancelFailed[connector.id] === true}
+                  authorizationError={connectorAuthorizationError[connector.id] ?? null}
                   toolsLoading={toolsLoading}
                   toolsLoaded={toolsLoaded}
                   logoTheme={logoTheme}
@@ -931,6 +954,7 @@ export function ConnectorsBrowser({
           }
           authorizationPending={connectorAuthorizationPending[detailConnector.id]}
           authorizationCancelFailed={connectorAuthorizationCancelFailed[detailConnector.id] === true}
+          authorizationError={connectorAuthorizationError[detailConnector.id] ?? null}
           toolsLoading={toolsLoading}
           toolsPreviewLoading={Boolean(toolPreviewLoadingIds[detailConnector.id])}
           toolsLoaded={
@@ -956,6 +980,7 @@ function ConnectorCard({
   pendingAction,
   authorizationPending,
   authorizationCancelFailed,
+  authorizationError,
   toolsLoading: _toolsLoading,
   toolsLoaded,
   logoTheme,
@@ -969,6 +994,7 @@ function ConnectorCard({
   pendingAction: 'connect' | 'disconnect' | null;
   authorizationPending?: ConnectorAuthorizationPending;
   authorizationCancelFailed: boolean;
+  authorizationError: string | null;
   toolsLoading: boolean;
   toolsLoaded: boolean;
   logoTheme: 'light' | 'dark';
@@ -1131,6 +1157,11 @@ function ConnectorCard({
           ) : null}
         </div>
       </div>
+      {authorizationError ? (
+        <p className="connector-authorization-hint connector-authorization-error" role="alert">
+          {authorizationError}
+        </p>
+      ) : null}
       {authorizationCancelFailed ? (
         <p className="connector-authorization-hint connector-authorization-error" role="alert">
           {AUTHORIZATION_CANCEL_FAILED_MESSAGE}
@@ -1171,6 +1202,7 @@ function ConnectorDetailDrawer({
   pendingAction,
   authorizationPending,
   authorizationCancelFailed,
+  authorizationError,
   toolsLoading,
   toolsPreviewLoading,
   toolsLoaded,
@@ -1186,6 +1218,7 @@ function ConnectorDetailDrawer({
   pendingAction: 'connect' | 'disconnect' | null;
   authorizationPending?: ConnectorAuthorizationPending;
   authorizationCancelFailed: boolean;
+  authorizationError: string | null;
   toolsLoading: boolean;
   toolsPreviewLoading: boolean;
   toolsLoaded: boolean;
@@ -1293,6 +1326,11 @@ function ConnectorDetailDrawer({
                 </p>
               ) : null}
             </section>
+          ) : null}
+          {authorizationError ? (
+            <p className="connector-authorization-hint connector-authorization-error" role="alert">
+              {authorizationError}
+            </p>
           ) : null}
           {authorizationCancelFailed ? (
             <p className="connector-authorization-hint connector-authorization-error" role="alert">

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -365,8 +365,21 @@ export async function connectConnector(connectorId: string): Promise<ConnectorAc
           return { connector: json.connector ?? null, error: popupBlockedMessage() };
         }
       }
+    } else if (json.auth?.kind === 'connected') {
+      renderConnectorAuthInfo(authWindow, {
+        title: 'Already connected',
+        body: 'This connector is already authorized. You can close this window.',
+      });
+    } else if (json.auth?.kind === 'pending') {
+      renderConnectorAuthInfo(authWindow, {
+        title: 'Authorization pending',
+        body: 'Authorization is in progress but no redirect URL was returned. Watch for an email confirmation, or open the Composio dashboard to continue.',
+      });
     } else {
-      authWindow?.close();
+      renderConnectorAuthInfo(authWindow, {
+        title: 'No authorization URL returned',
+        body: 'The connector responded without a redirect URL. If this seems wrong, retry from Settings → Connectors, and confirm your Composio API key.',
+      });
     }
     return { connector: json.connector ?? null, ...(json.auth === undefined ? {} : { auth: json.auth }) };
   } catch (err) {
@@ -421,6 +434,23 @@ function renderConnectorAuthLoading(authWindow: Window | null, copy: { title: st
           <div style="max-width:300px;color:rgba(246,247,251,.72);font-size:13px;line-height:1.5;">${escapeHtmlText(copy.body)}</div>
         </div>
         <style>@keyframes od-spin{to{transform:rotate(360deg)}}</style>
+      </main>
+    `;
+  } catch {
+    /* Popup may be unavailable or already navigated; ignore. */
+  }
+}
+
+function renderConnectorAuthInfo(authWindow: Window | null, copy: { title: string; body: string }): void {
+  if (!authWindow) return;
+  try {
+    authWindow.document.title = copy.title;
+    authWindow.document.body.innerHTML = `
+      <main style="min-height:100vh;display:grid;place-items:center;margin:0;background:#0f1115;color:#f6f7fb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">
+        <div style="display:grid;gap:14px;justify-items:center;text-align:center;padding:32px;">
+          <div style="font-size:15px;font-weight:600;">${escapeHtmlText(copy.title)}</div>
+          <div style="max-width:360px;color:rgba(246,247,251,.72);font-size:13px;line-height:1.5;">${escapeHtmlText(copy.body)}</div>
+        </div>
       </main>
     `;
   } catch {

--- a/apps/web/tests/components/ConnectorsBrowser.test.tsx
+++ b/apps/web/tests/components/ConnectorsBrowser.test.tsx
@@ -418,6 +418,64 @@ describe('ConnectorsBrowser', () => {
     ).toHaveProperty('github');
   });
 
+  it('surfaces a connect error inline on the connector card', async () => {
+    const availableConnector: ConnectorDetail = {
+      ...configuredComposioConnector,
+      status: 'available',
+      auth: { provider: 'composio', configured: true },
+    };
+    vi.mocked(fetchConnectors).mockResolvedValue([availableConnector]);
+    vi.mocked(fetchConnectorDiscovery).mockResolvedValue([availableConnector]);
+    vi.mocked(fetchConnectorStatuses).mockResolvedValue({});
+    vi.mocked(connectConnector).mockResolvedValue({
+      connector: null,
+      error: 'Composio provider is not configured',
+    });
+
+    render(<ConnectorsBrowser composioConfigured />);
+
+    await screen.findByText('GitHub');
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }));
+
+    await waitFor(() => expect(connectConnector).toHaveBeenCalledWith('github'));
+    await waitFor(() => expect(
+      screen.getByRole('alert').textContent,
+    ).toContain('Composio provider is not configured'));
+  });
+
+  it('clears the inline connect error when the user retries and succeeds', async () => {
+    const availableConnector: ConnectorDetail = {
+      ...configuredComposioConnector,
+      status: 'available',
+      auth: { provider: 'composio', configured: true },
+    };
+    vi.mocked(fetchConnectors).mockResolvedValue([availableConnector]);
+    vi.mocked(fetchConnectorDiscovery).mockResolvedValue([availableConnector]);
+    vi.mocked(fetchConnectorStatuses).mockResolvedValue({});
+    vi.mocked(connectConnector)
+      .mockResolvedValueOnce({ connector: null, error: 'Composio provider is not configured' })
+      .mockResolvedValueOnce({
+        connector: availableConnector,
+        auth: {
+          kind: 'redirect_required',
+          redirectUrl: 'https://example.com/oauth',
+          expiresAt: '2026-05-08T10:00:00.000Z',
+        },
+      });
+
+    render(<ConnectorsBrowser composioConfigured />);
+
+    await screen.findByText('GitHub');
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }));
+    await waitFor(() => expect(
+      screen.getByRole('alert').textContent,
+    ).toContain('Composio provider is not configured'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }));
+    await waitFor(() => expect(connectConnector).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.queryByRole('alert')).toBeNull());
+  });
+
   it('does not mark failed OAuth launches as pending authorization', async () => {
     const availableConnector: ConnectorDetail = {
       ...configuredComposioConnector,

--- a/apps/web/tests/components/EntryView.test.ts
+++ b/apps/web/tests/components/EntryView.test.ts
@@ -6,6 +6,7 @@ import {
   sortConnectorsForSearch,
 } from '../../src/components/EntryView';
 import {
+  clearConnectorAuthorizationErrorsForConnected,
   clearConnectorAuthorizationPending,
   getConnectorDisplayToolCount,
   mergeConnectorActionResult,
@@ -303,6 +304,25 @@ describe('connector authorization pending state', () => {
     }, nowMs);
 
     expect(pending).toEqual({});
+  });
+
+  it('clears stored auth errors for connectors observed as connected', () => {
+    const errors = clearConnectorAuthorizationErrorsForConnected(
+      { exist: 'Composio provider is not configured', airtable: 'Connection failed' },
+      { exist: { status: 'connected' }, airtable: { status: 'available' } },
+    );
+
+    expect(errors).toEqual({ airtable: 'Connection failed' });
+  });
+
+  it('returns the same errors object when no connector transitions to connected', () => {
+    const original = { exist: 'Composio provider is not configured' };
+    const errors = clearConnectorAuthorizationErrorsForConnected(
+      original,
+      { exist: { status: 'available' } },
+    );
+
+    expect(errors).toBe(original);
   });
 
   it('cancels pending authorization without changing other pending connectors', () => {

--- a/apps/web/tests/providers/registry.test.ts
+++ b/apps/web/tests/providers/registry.test.ts
@@ -351,6 +351,42 @@ describe('connectConnector', () => {
     });
   });
 
+  it('renders an info notice in the popup when the connect response carries no redirect URL', async () => {
+    const authWindow = {
+      document: {
+        title: '',
+        body: { innerHTML: '' },
+      },
+      location: { replace: vi.fn() },
+      close: vi.fn(),
+    };
+    vi.stubGlobal('window', {
+      open: vi.fn(() => authWindow),
+      location: { assign: vi.fn() },
+    });
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === '/api/connectors/auth-configs/prepare') {
+        return new Response(JSON.stringify({
+          results: { twitter: { status: 'ready', authConfigId: 'ac_twitter' } },
+        }), { status: 200 });
+      }
+      return new Response(JSON.stringify({
+        connector: { id: 'twitter', name: 'Twitter', status: 'available', tools: [] },
+        auth: { kind: 'pending', expiresAt: '2026-05-08T10:00:00.000Z' },
+      }), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(connectConnector('twitter')).resolves.toMatchObject({
+      connector: { id: 'twitter' },
+      auth: { kind: 'pending' },
+    });
+
+    expect(authWindow.close).not.toHaveBeenCalled();
+    expect(authWindow.document.title).toBe('Authorization pending');
+    expect(authWindow.document.body.innerHTML).toContain('Authorization pending');
+  });
+
   it('opens connector auth in the system browser when Electron returns a success boolean', async () => {
     const open = vi.fn();
     const openExternal = vi.fn(async () => true);


### PR DESCRIPTION
Fixes #725

## Summary

The user-visible "Twitter Connect button does nothing" symptom is two layered bugs in the connector auth flow.

### Bug A (primary, affects desktop)

`ConnectorsBrowser.runConnectorAction` ignores `result.error` from `connectConnector`. Inside `connectConnector`, errors are surfaced via `renderConnectorAuthError(authWindow, ...)` — but on Electron desktop the `electronAPI.openExternal` path means `authWindow === null` and the helper returns immediately:

```ts
function renderConnectorAuthError(authWindow: Window | null, message: string): void {
  if (!authWindow) return;
  ...
}
```

So when (e.g.) the Composio API key is missing and the daemon throws `CONNECTOR_EXECUTION_FAILED`, the error reaches the web layer as `result.error` but is silently dropped. The user sees: click Connect → nothing happens.

### Bug B (secondary, affects web)

`registry.ts:connectConnector` calls `authWindow?.close()` whenever the connect response does not carry `{ kind: 'redirect_required', redirectUrl }`. For `kind: 'pending'` (no redirect URL) or `kind: 'connected'`, the popup vanishes without explanation.

## Changes

### `apps/web/src/components/ConnectorsBrowser.tsx`
- New `connectorAuthorizationError: Record<string, string>` state, mirroring the existing `connectorAuthorizationCancelFailed` pattern.
- `runConnectorAction` clears the error at the start of each attempt (both connect and disconnect) and sets it whenever `result.error` is non-empty.
- `cancelConnectorAuthorization` clears it on success.
- New `authorizationError: string \| null` prop on `ConnectorCard` and `ConnectorDetailDrawer`. Both render the message inline using the existing `.connector-authorization-error` class (no new CSS).

### `apps/web/src/providers/registry.ts`
- New `renderConnectorAuthInfo` helper (no spinner, no failure styling — matches `renderConnectorAuthLoading` shape).
- Replace `authWindow?.close()` with an explicit switch on `auth.kind`:
  - `'connected'` → "Already connected. You can close this window."
  - `'pending'` → "Authorization pending… Watch for an email confirmation, or open the Composio dashboard to continue."
  - other / undefined → "No authorization URL returned. Retry from Settings → Connectors, and confirm your Composio API key."

## Tests

- `apps/web/tests/providers/registry.test.ts`: new test asserts that when the connect response has `auth.kind === 'pending'` (no redirect URL), the popup is **not** closed and shows the "Authorization pending" notice.
- `apps/web/tests/components/ConnectorsBrowser.test.tsx`:
  - new test: `connectConnector` returning `{error: '…'}` causes the connector card to render the error inside `[role="alert"]`.
  - new test: a successful retry clears the inline error.

40/40 tests pass; `pnpm --filter @open-design/web typecheck` is clean.

## Out of scope

- I did not touch the daemon-side Composio detection (`getApiKey()` throw at `composio.ts:1117`). The error message it produces (`"Composio provider is not configured"`) is exactly the kind of thing this PR will now render verbatim — gating the Connect button before the request fires would be a sensible follow-up but is independent.
- Pod / cancel-pending flow is unchanged.