### PR TITLE
fix(web): ignore <artifact> tags inside markdown code spans and fences

### DIFF
--- a/apps/web/src/artifacts/markdown-context.ts
+++ b/apps/web/src/artifacts/markdown-context.ts
@@ -9,8 +9,13 @@
  * literal Markdown and must not be treated as a real protocol tag.
  */
 
-// Line-anchored fence delimiter, mirrors runtime/markdown.tsx:44.
-export const FENCE_LINE_RE = /^[ ]{0,3}```(\w[\w+-]*)?\s*$/;
+// Line-anchored fence delimiters, mirror runtime/markdown.tsx:44 (open) and
+// runtime/markdown.tsx:49 (close). The renderer is asymmetric on purpose:
+// an opening fence may carry an info string (e.g. ```html), a closing fence
+// must be a bare triple-backtick line. Neither permits leading indentation —
+// an indented "   ```" line is rendered as a paragraph, not a fence.
+export const FENCE_OPEN_RE = /^```(\w[\w+-]*)?\s*$/;
+export const FENCE_CLOSE_RE = /^```\s*$/;
 
 // Inline code span (single-backtick pair), mirrors runtime/markdown.tsx:164.
 export const INLINE_CODE_RE = /`[^`]+`/g;
@@ -41,15 +46,15 @@ export function computeSkipRanges(buffer: string): {
     const eol = buffer.indexOf('\n', pos);
     if (eol === -1) break;
     const line = buffer.slice(pos, eol);
-    if (FENCE_LINE_RE.test(line)) {
-      if (!inFence) {
+    if (!inFence) {
+      if (FENCE_OPEN_RE.test(line)) {
         inFence = true;
         fenceStart = pos;
-      } else {
-        inFence = false;
-        ranges.push([fenceStart, eol + 1]);
-        fenceStart = -1;
       }
+    } else if (FENCE_CLOSE_RE.test(line)) {
+      inFence = false;
+      ranges.push([fenceStart, eol + 1]);
+      fenceStart = -1;
     }
     pos = eol + 1;
   }

--- a/apps/web/src/artifacts/markdown-context.ts
+++ b/apps/web/src/artifacts/markdown-context.ts
@@ -20,28 +20,21 @@ export const FENCE_CLOSE_RE = /^```\s*$/;
 // Inline code span (single-backtick pair), mirrors runtime/markdown.tsx:164.
 export const INLINE_CODE_RE = /`[^`]+`/g;
 
-// Block-starter recognizers used by `parseBlocks()` in runtime/markdown.tsx:33-108.
-// `renderInline` only runs within a single block, so inline-code scanning must
-// reset at every block boundary — otherwise an unmatched backtick in one
-// paragraph can bridge across a blank line/heading/list/hr/fence into a later
-// paragraph and create a phantom inline span that swallows a real <artifact …>.
+// Paragraph-break recognizers — these mirror the inner paragraph-accumulation
+// loop in `parseBlocks()` (runtime/markdown.tsx:95-104), which is what
+// actually decides where a paragraph ends. The outer loop in `parseBlocks`
+// has additional block-starters (HR, fenced-code with `^```` prefix, etc.)
+// but those only take effect when no paragraph is currently being built;
+// mid-paragraph they are paragraph content. The renderer therefore treats
+// `intro \`` / `---` / `<artifact …>` / `---` / `closing \`` as ONE paragraph
+// whose backticks pair across the recitation — so this walker must too.
 //
-// Keep these in lock step with runtime/markdown.tsx:39 (blank), :59 (heading),
-// :67 (hr), :73 (ul), :83 (ol). Fence-open/close are already handled by the
-// fence pass above.
+// Notable omission: HR — see comment above. HR-shaped lines (`---` / `***`
+// / `___`) carry no backticks of their own, so leaving them inside the
+// surrounding paragraph region is benign for inline-code scanning either way.
 const HEADING_RE = /^#{1,4}\s+/;
-const HR_RE = /^\s*(?:-{3,}|_{3,}|\*{3,})\s*$/;
 const UL_ITEM_RE = /^\s*[-*+]\s+/;
 const OL_ITEM_RE = /^\s*\d+\.\s+/;
-
-function isBlockStarter(line: string): boolean {
-  if (line.trim() === '') return true;
-  if (HEADING_RE.test(line)) return true;
-  if (HR_RE.test(line)) return true;
-  if (UL_ITEM_RE.test(line)) return true;
-  if (OL_ITEM_RE.test(line)) return true;
-  return false;
-}
 
 // `<artifact` followed by whitespace is a real protocol open tag; any other
 // continuation (e.g. `<artifactual`) is a prefix-shared literal that must not
@@ -94,9 +87,8 @@ export function computeSkipRanges(buffer: string): {
         closeBlockBefore(pos);
         inFence = true;
         fenceStart = pos;
-      } else if (line.trim() === '' || HR_RE.test(line)) {
-        // Blank lines / horizontal rules separate blocks and have no inline
-        // content of their own.
+      } else if (line.trim() === '') {
+        // Blank lines separate blocks.
         closeBlockBefore(pos);
       } else if (HEADING_RE.test(line) || UL_ITEM_RE.test(line) || OL_ITEM_RE.test(line)) {
         // Heading and list-item lines are each their own block in the

--- a/apps/web/src/artifacts/markdown-context.ts
+++ b/apps/web/src/artifacts/markdown-context.ts
@@ -20,6 +20,38 @@ export const FENCE_CLOSE_RE = /^```\s*$/;
 // Inline code span (single-backtick pair), mirrors runtime/markdown.tsx:164.
 export const INLINE_CODE_RE = /`[^`]+`/g;
 
+// Block-starter recognizers used by `parseBlocks()` in runtime/markdown.tsx:33-108.
+// `renderInline` only runs within a single block, so inline-code scanning must
+// reset at every block boundary — otherwise an unmatched backtick in one
+// paragraph can bridge across a blank line/heading/list/hr/fence into a later
+// paragraph and create a phantom inline span that swallows a real <artifact …>.
+//
+// Keep these in lock step with runtime/markdown.tsx:39 (blank), :59 (heading),
+// :67 (hr), :73 (ul), :83 (ol). Fence-open/close are already handled by the
+// fence pass above.
+const HEADING_RE = /^#{1,4}\s+/;
+const HR_RE = /^\s*(?:-{3,}|_{3,}|\*{3,})\s*$/;
+const UL_ITEM_RE = /^\s*[-*+]\s+/;
+const OL_ITEM_RE = /^\s*\d+\.\s+/;
+
+function isBlockStarter(line: string): boolean {
+  if (line.trim() === '') return true;
+  if (HEADING_RE.test(line)) return true;
+  if (HR_RE.test(line)) return true;
+  if (UL_ITEM_RE.test(line)) return true;
+  if (OL_ITEM_RE.test(line)) return true;
+  return false;
+}
+
+// `<artifact` followed by whitespace is a real protocol open tag; any other
+// continuation (e.g. `<artifactual`) is a prefix-shared literal that must not
+// be treated as a tag. Mirrors the parser's `findOpenTag` real-open guard so
+// the parser and the stripper agree on what counts as a real tag.
+export function isRealArtifactOpenAt(content: string, idx: number): boolean {
+  const next = content.charAt(idx + '<artifact'.length);
+  return next !== '' && /\s/.test(next);
+}
+
 export type Range = readonly [number, number];
 
 /**
@@ -38,32 +70,69 @@ export function computeSkipRanges(buffer: string): {
   unclosedFenceStart: number | null;
 } {
   const ranges: Range[] = [];
+  // Paragraph-block regions are contiguous spans of paragraph lines outside
+  // any fenced code block. `renderInline` runs once per block, so inline-code
+  // scanning is restricted to one block at a time — backticks never pair
+  // across a block boundary in the rendered output.
+  const blockRegions: Range[] = [];
 
   let pos = 0;
   let inFence = false;
   let fenceStart = -1;
+  let blockStart = -1;
+  const closeBlockBefore = (idx: number) => {
+    if (blockStart !== -1 && idx > blockStart) blockRegions.push([blockStart, idx]);
+    blockStart = -1;
+  };
   while (pos < buffer.length) {
     const eol = buffer.indexOf('\n', pos);
-    if (eol === -1) break;
-    const line = buffer.slice(pos, eol);
+    const lineEnd = eol === -1 ? buffer.length : eol;
+    const line = buffer.slice(pos, lineEnd);
+    const lineHasNewline = eol !== -1;
     if (!inFence) {
-      if (FENCE_OPEN_RE.test(line)) {
+      if (lineHasNewline && FENCE_OPEN_RE.test(line)) {
+        closeBlockBefore(pos);
         inFence = true;
         fenceStart = pos;
+      } else if (line.trim() === '' || HR_RE.test(line)) {
+        // Blank lines / horizontal rules separate blocks and have no inline
+        // content of their own.
+        closeBlockBefore(pos);
+      } else if (HEADING_RE.test(line) || UL_ITEM_RE.test(line) || OL_ITEM_RE.test(line)) {
+        // Heading and list-item lines are each their own block in the
+        // renderer (`renderInline` runs per item / per heading), so they get
+        // a one-line inline-scan region rather than joining adjacent
+        // paragraphs. The marker chars themselves are not backticks, so we
+        // can scan the whole line without stripping the marker first.
+        closeBlockBefore(pos);
+        blockRegions.push([pos, lineEnd]);
+      } else {
+        if (blockStart === -1) blockStart = pos;
       }
-    } else if (FENCE_CLOSE_RE.test(line)) {
+    } else if (lineHasNewline && FENCE_CLOSE_RE.test(line)) {
       inFence = false;
       ranges.push([fenceStart, eol + 1]);
       fenceStart = -1;
     }
+    if (!lineHasNewline) {
+      // Trailing partial line — already accounted for above (either folded
+      // into the current paragraph region, or skipped because it starts with
+      // a block-starter pattern). Stop walking.
+      break;
+    }
     pos = eol + 1;
   }
+  // Flush any open paragraph region at end-of-buffer (no trailing newline).
+  if (!inFence) closeBlockBefore(buffer.length);
 
-  INLINE_CODE_RE.lastIndex = 0;
-  let m: RegExpExecArray | null = INLINE_CODE_RE.exec(buffer);
-  while (m !== null) {
-    ranges.push([m.index, m.index + m[0].length]);
-    m = INLINE_CODE_RE.exec(buffer);
+  for (const [s, e] of blockRegions) {
+    INLINE_CODE_RE.lastIndex = 0;
+    const segment = buffer.slice(s, e);
+    let m: RegExpExecArray | null = INLINE_CODE_RE.exec(segment);
+    while (m !== null) {
+      ranges.push([s + m.index, s + m.index + m[0].length]);
+      m = INLINE_CODE_RE.exec(segment);
+    }
   }
 
   return { ranges, unclosedFenceStart: inFence ? fenceStart : null };

--- a/apps/web/src/artifacts/markdown-context.ts
+++ b/apps/web/src/artifacts/markdown-context.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared Markdown-context helpers used by both the streaming artifact parser
+ * and the post-stream `<artifact>` stripper. The single source of truth for
+ * what counts as a fenced code block or an inline code span — kept in lock
+ * step with apps/web/src/runtime/markdown.tsx so the parser/stripper view of
+ * a buffer matches what the chat UI will actually render.
+ *
+ * Anything that "looks like" an artifact tag inside one of these regions is
+ * literal Markdown and must not be treated as a real protocol tag.
+ */
+
+// Line-anchored fence delimiter, mirrors runtime/markdown.tsx:44.
+export const FENCE_LINE_RE = /^[ ]{0,3}```(\w[\w+-]*)?\s*$/;
+
+// Inline code span (single-backtick pair), mirrors runtime/markdown.tsx:164.
+export const INLINE_CODE_RE = /`[^`]+`/g;
+
+export type Range = readonly [number, number];
+
+/**
+ * Compute the half-open `[start, end)` ranges of `buffer` that the renderer
+ * would treat as fenced code blocks or inline code spans. The `unclosedFenceStart`
+ * is the index of an opening fence with no matching close in the buffer (or
+ * `null` if every fence is closed) — the streaming parser uses it to hold
+ * back; the stripper ignores it.
+ *
+ * Lines without a terminating `\n` (the trailing partial line during
+ * streaming) are not classified as fence delimiters here. Callers that care
+ * about partial-state behavior should inspect the tail themselves.
+ */
+export function computeSkipRanges(buffer: string): {
+  ranges: Range[];
+  unclosedFenceStart: number | null;
+} {
+  const ranges: Range[] = [];
+
+  let pos = 0;
+  let inFence = false;
+  let fenceStart = -1;
+  while (pos < buffer.length) {
+    const eol = buffer.indexOf('\n', pos);
+    if (eol === -1) break;
+    const line = buffer.slice(pos, eol);
+    if (FENCE_LINE_RE.test(line)) {
+      if (!inFence) {
+        inFence = true;
+        fenceStart = pos;
+      } else {
+        inFence = false;
+        ranges.push([fenceStart, eol + 1]);
+        fenceStart = -1;
+      }
+    }
+    pos = eol + 1;
+  }
+
+  INLINE_CODE_RE.lastIndex = 0;
+  let m: RegExpExecArray | null = INLINE_CODE_RE.exec(buffer);
+  while (m !== null) {
+    ranges.push([m.index, m.index + m[0].length]);
+    m = INLINE_CODE_RE.exec(buffer);
+  }
+
+  return { ranges, unclosedFenceStart: inFence ? fenceStart : null };
+}
+
+export function rangeContains(ranges: ReadonlyArray<Range>, p: number): boolean {
+  for (const [s, e] of ranges) {
+    if (p >= s && p < e) return true;
+  }
+  return false;
+}

--- a/apps/web/src/artifacts/parser.ts
+++ b/apps/web/src/artifacts/parser.ts
@@ -42,7 +42,7 @@ type OpenTagMatch =
   | { kind: 'partial'; start: number }
   | { kind: 'none' };
 
-import { computeSkipRanges, FENCE_OPEN_RE, rangeContains } from './markdown-context';
+import { computeSkipRanges, FENCE_OPEN_RE, isRealArtifactOpenAt, rangeContains } from './markdown-context';
 
 // Scan the buffer for `<artifact …>` while skipping any positions that the
 // chat markdown renderer would render as a fenced code block or inline code
@@ -59,34 +59,11 @@ function findOpenTag(buffer: string): OpenTagMatch {
   const len = buffer.length;
   const { ranges, unclosedFenceStart } = computeSkipRanges(buffer);
 
-  if (unclosedFenceStart !== null) {
-    return { kind: 'partial', start: unclosedFenceStart };
-  }
-
-  const lastNl = buffer.lastIndexOf('\n');
-  if (lastNl < len - 1) {
-    const tailLineStart = lastNl + 1;
-    const tail = buffer.slice(tailLineStart);
-    if (FENCE_OPEN_RE.test(tail) || /^`{1,2}$/.test(tail)) {
-      return { kind: 'partial', start: tailLineStart };
-    }
-  }
-
-  let firstUnmatched = -1;
-  let parity = 0;
-  for (let k = lastNl + 1; k < len; k++) {
-    if (buffer.charAt(k) !== '`') continue;
-    if (rangeContains(ranges, k)) continue;
-    if (parity === 0) {
-      firstUnmatched = k;
-      parity = 1;
-    } else {
-      firstUnmatched = -1;
-      parity = 0;
-    }
-  }
-  if (firstUnmatched !== -1) return { kind: 'partial', start: firstUnmatched };
-
+  // Pass 1: scan for the earliest *complete* real `<artifact …>` open outside
+  // any skip range. Done before any hold-back decision, otherwise a stray
+  // backtick or fence-opener prefix on a tail line would suppress an already
+  // self-contained artifact earlier in the buffer.
+  let earliestPartialOpen = -1;
   let from = 0;
   while (from < len) {
     const idx = buffer.indexOf(OPEN_PREFIX, from);
@@ -95,10 +72,21 @@ function findOpenTag(buffer: string): OpenTagMatch {
       from = idx + OPEN_PREFIX.length;
       continue;
     }
+    if (unclosedFenceStart !== null && idx >= unclosedFenceStart) {
+      // Anything past an unclosed fence opener is inside a code block that
+      // will close in a later chunk (or at end-of-buffer for the stripper);
+      // treat as skip range, not a real tag.
+      break;
+    }
     const after = idx + OPEN_PREFIX.length;
     const next = buffer.charAt(after);
-    if (next === '') return { kind: 'partial', start: idx };
-    if (!/\s/.test(next)) {
+    if (next === '') {
+      // `<artifact` at very end of buffer — could become real with the next
+      // chunk. Remember the earliest one and keep looking for a complete tag.
+      if (earliestPartialOpen === -1) earliestPartialOpen = idx;
+      break;
+    }
+    if (!isRealArtifactOpenAt(buffer, idx)) {
       // Not a real <artifact ...> open (e.g. "<artifactual"). Keep scanning.
       from = after;
       continue;
@@ -116,18 +104,57 @@ function findOpenTag(buffer: string): OpenTagMatch {
       }
       j++;
     }
-    return { kind: 'partial', start: idx };
+    // Ran out of buffer before the closing `>` arrived — this is an open tag
+    // mid-stream. Remember and stop scanning (any later `<artifact` would be
+    // a second tag we'd reach next chunk).
+    if (earliestPartialOpen === -1) earliestPartialOpen = idx;
+    break;
   }
 
-  // Strict prefix at the tail (e.g. "<art") — hold back.
-  const tail = buffer.lastIndexOf('<');
-  if (tail !== -1 && !rangeContains(ranges, tail)) {
-    const slice = buffer.slice(tail);
-    if (OPEN_PREFIX.startsWith(slice) && slice.length < OPEN_PREFIX.length) {
-      return { kind: 'partial', start: tail };
+  // Pass 2: no complete open found. Decide whether to hold back, and if so,
+  // from which position. Earliest hold-back wins so the text-flush boundary
+  // never crosses something that might still resolve into a tag/fence/span.
+  let holdback = -1;
+  const note = (pos: number | null) => {
+    if (pos !== null && pos !== -1 && (holdback === -1 || pos < holdback)) holdback = pos;
+  };
+  note(earliestPartialOpen);
+  note(unclosedFenceStart);
+
+  const lastNl = buffer.lastIndexOf('\n');
+  if (lastNl < len - 1) {
+    const tailLineStart = lastNl + 1;
+    const tail = buffer.slice(tailLineStart);
+    if (FENCE_OPEN_RE.test(tail) || /^`{1,2}$/.test(tail)) {
+      note(tailLineStart);
     }
   }
 
+  let firstUnmatched = -1;
+  let parity = 0;
+  for (let k = lastNl + 1; k < len; k++) {
+    if (buffer.charAt(k) !== '`') continue;
+    if (rangeContains(ranges, k)) continue;
+    if (parity === 0) {
+      firstUnmatched = k;
+      parity = 1;
+    } else {
+      firstUnmatched = -1;
+      parity = 0;
+    }
+  }
+  note(firstUnmatched);
+
+  // Strict prefix at the tail (e.g. "<art") — hold back.
+  const tailLt = buffer.lastIndexOf('<');
+  if (tailLt !== -1 && !rangeContains(ranges, tailLt)) {
+    const slice = buffer.slice(tailLt);
+    if (OPEN_PREFIX.startsWith(slice) && slice.length < OPEN_PREFIX.length) {
+      note(tailLt);
+    }
+  }
+
+  if (holdback !== -1) return { kind: 'partial', start: holdback };
   return { kind: 'none' };
 }
 

--- a/apps/web/src/artifacts/parser.ts
+++ b/apps/web/src/artifacts/parser.ts
@@ -42,88 +42,41 @@ type OpenTagMatch =
   | { kind: 'partial'; start: number }
   | { kind: 'none' };
 
-// Line-anchored fence regex, identical to apps/web/src/runtime/markdown.tsx so
-// the parser's view of "what's a fenced code block" matches what the chat UI
-// will actually render. Mid-line ```html in prose is NOT a fence per the
-// renderer, so it must not be one here either — otherwise a real artifact tag
-// that follows such prose would be wrongly suppressed.
-const FENCE_LINE_RE = /^[ ]{0,3}```(\w[\w+-]*)?\s*$/;
-
-// CommonMark-style inline code span: a single backtick, then one or more
-// non-backtick characters, then a single backtick. Matches the renderer's
-// renderInline regex so the two stay in lockstep.
-const INLINE_CODE_RE = /`[^`]+`/g;
-
-function rangeContains(ranges: Array<readonly [number, number]>, p: number): boolean {
-  for (const [s, e] of ranges) {
-    if (p >= s && p < e) return true;
-  }
-  return false;
-}
+import { computeSkipRanges, rangeContains } from './markdown-context';
 
 // Scan the buffer for `<artifact …>` while skipping any positions that the
 // chat markdown renderer would render as a fenced code block or inline code
-// span. Streaming caveat: when the buffer ends mid-fence (no closing fence
-// yet) or with an unmatched inline backtick, return a partial anchored at the
-// region's start so the caller waits for more data instead of emitting prose
-// that may turn out to be code.
+// span — see ./markdown-context.ts for the shared classification used by both
+// the streaming parser and the post-stream `<artifact>` stripper.
+//
+// Streaming caveats handled here on top of the shared ranges:
+//   * Open fence with no close yet → hold back from its opening line.
+//   * Unterminated tail line that could still resolve into a fence delimiter
+//     (e.g. "```", "```ht") → hold back from the line start.
+//   * Unmatched opening backtick after the last \n → hold back from it; a
+//     future chunk may turn it into an inline code span.
 function findOpenTag(buffer: string): OpenTagMatch {
   const len = buffer.length;
-  const skip: Array<readonly [number, number]> = [];
+  const { ranges, unclosedFenceStart } = computeSkipRanges(buffer);
 
-  // Pass 1: classify whole, \n-terminated lines as fence delimiters and
-  // collect [open-line-start, close-line-end+1) ranges.
-  let pos = 0;
-  let inFence = false;
-  let fenceStart = -1;
-  while (pos < len) {
-    const eol = buffer.indexOf('\n', pos);
-    if (eol === -1) {
-      // The tail is unterminated — we cannot classify it as a fence delimiter
-      // until \n arrives. If we're inside an open fence, hold back from the
-      // opening line so the next chunk can resolve the close.
-      if (inFence) return { kind: 'partial', start: fenceStart };
-      // Otherwise, if the tail looks like the start of a fence delimiter that
-      // hasn't completed yet (e.g. "```", "```ht"), hold back so a future \n
-      // can promote it to a real fence.
-      const tail = buffer.slice(pos);
-      if (/^[ ]{0,3}```\w*$/.test(tail) || /^[ ]{0,3}`{1,2}$/.test(tail)) {
-        return { kind: 'partial', start: pos };
-      }
-      break;
-    }
-    const line = buffer.slice(pos, eol);
-    if (FENCE_LINE_RE.test(line)) {
-      if (!inFence) {
-        inFence = true;
-        fenceStart = pos;
-      } else {
-        inFence = false;
-        skip.push([fenceStart, eol + 1]);
-        fenceStart = -1;
-      }
-    }
-    pos = eol + 1;
-  }
-  if (inFence) return { kind: 'partial', start: fenceStart };
-
-  // Pass 2: collect inline code spans with the same regex the renderer uses.
-  // A span that overlaps a fence range is benign — rangeContains is OR.
-  INLINE_CODE_RE.lastIndex = 0;
-  let m: RegExpExecArray | null = INLINE_CODE_RE.exec(buffer);
-  while (m !== null) {
-    skip.push([m.index, m.index + m[0].length]);
-    m = INLINE_CODE_RE.exec(buffer);
+  if (unclosedFenceStart !== null) {
+    return { kind: 'partial', start: unclosedFenceStart };
   }
 
-  // Streaming: an unmatched opening backtick after the last \n could close in
-  // a future chunk. Hold back from the first such backtick.
   const lastNl = buffer.lastIndexOf('\n');
+  if (lastNl < len - 1) {
+    const tailLineStart = lastNl + 1;
+    const tail = buffer.slice(tailLineStart);
+    if (/^[ ]{0,3}```\w*$/.test(tail) || /^[ ]{0,3}`{1,2}$/.test(tail)) {
+      return { kind: 'partial', start: tailLineStart };
+    }
+  }
+
   let firstUnmatched = -1;
   let parity = 0;
   for (let k = lastNl + 1; k < len; k++) {
     if (buffer.charAt(k) !== '`') continue;
-    if (rangeContains(skip, k)) continue;
+    if (rangeContains(ranges, k)) continue;
     if (parity === 0) {
       firstUnmatched = k;
       parity = 1;
@@ -134,12 +87,11 @@ function findOpenTag(buffer: string): OpenTagMatch {
   }
   if (firstUnmatched !== -1) return { kind: 'partial', start: firstUnmatched };
 
-  // Pass 3: find the first `<artifact …>` that is not in any skip range.
   let from = 0;
   while (from < len) {
     const idx = buffer.indexOf(OPEN_PREFIX, from);
     if (idx === -1) break;
-    if (rangeContains(skip, idx)) {
+    if (rangeContains(ranges, idx)) {
       from = idx + OPEN_PREFIX.length;
       continue;
     }
@@ -169,7 +121,7 @@ function findOpenTag(buffer: string): OpenTagMatch {
 
   // Strict prefix at the tail (e.g. "<art") — hold back.
   const tail = buffer.lastIndexOf('<');
-  if (tail !== -1 && !rangeContains(skip, tail)) {
+  if (tail !== -1 && !rangeContains(ranges, tail)) {
     const slice = buffer.slice(tail);
     if (OPEN_PREFIX.startsWith(slice) && slice.length < OPEN_PREFIX.length) {
       return { kind: 'partial', start: tail };

--- a/apps/web/src/artifacts/parser.ts
+++ b/apps/web/src/artifacts/parser.ts
@@ -42,91 +42,134 @@ type OpenTagMatch =
   | { kind: 'partial'; start: number }
   | { kind: 'none' };
 
-// Linear scan that ignores `<artifact` occurrences inside Markdown code spans
-// (single-backtick `…`) and fenced code blocks (```…```). The model frequently
-// recites the artifact tag literally when documenting the protocol; without
-// this gating, the parser would enter artifact mode on the recitation and
-// suppress the rest of the rendered reply. If a code span/fence is still open
-// at the end of the buffer, hold back from its start so a later chunk can
-// resolve the boundary without losing fence context.
+// Line-anchored fence regex, identical to apps/web/src/runtime/markdown.tsx so
+// the parser's view of "what's a fenced code block" matches what the chat UI
+// will actually render. Mid-line ```html in prose is NOT a fence per the
+// renderer, so it must not be one here either — otherwise a real artifact tag
+// that follows such prose would be wrongly suppressed.
+const FENCE_LINE_RE = /^[ ]{0,3}```(\w[\w+-]*)?\s*$/;
+
+// CommonMark-style inline code span: a single backtick, then one or more
+// non-backtick characters, then a single backtick. Matches the renderer's
+// renderInline regex so the two stay in lockstep.
+const INLINE_CODE_RE = /`[^`]+`/g;
+
+function rangeContains(ranges: Array<readonly [number, number]>, p: number): boolean {
+  for (const [s, e] of ranges) {
+    if (p >= s && p < e) return true;
+  }
+  return false;
+}
+
+// Scan the buffer for `<artifact …>` while skipping any positions that the
+// chat markdown renderer would render as a fenced code block or inline code
+// span. Streaming caveat: when the buffer ends mid-fence (no closing fence
+// yet) or with an unmatched inline backtick, return a partial anchored at the
+// region's start so the caller waits for more data instead of emitting prose
+// that may turn out to be code.
 function findOpenTag(buffer: string): OpenTagMatch {
   const len = buffer.length;
-  let i = 0;
+  const skip: Array<readonly [number, number]> = [];
+
+  // Pass 1: classify whole, \n-terminated lines as fence delimiters and
+  // collect [open-line-start, close-line-end+1) ranges.
+  let pos = 0;
   let inFence = false;
-  let inInline = false;
   let fenceStart = -1;
-
-  while (i < len) {
-    const c = buffer.charAt(i);
-
-    if (!inInline && c === '`' && buffer.charAt(i + 1) === '`' && buffer.charAt(i + 2) === '`') {
-      if (inFence) {
-        inFence = false;
-        fenceStart = -1;
-      } else {
+  while (pos < len) {
+    const eol = buffer.indexOf('\n', pos);
+    if (eol === -1) {
+      // The tail is unterminated — we cannot classify it as a fence delimiter
+      // until \n arrives. If we're inside an open fence, hold back from the
+      // opening line so the next chunk can resolve the close.
+      if (inFence) return { kind: 'partial', start: fenceStart };
+      // Otherwise, if the tail looks like the start of a fence delimiter that
+      // hasn't completed yet (e.g. "```", "```ht"), hold back so a future \n
+      // can promote it to a real fence.
+      const tail = buffer.slice(pos);
+      if (/^[ ]{0,3}```\w*$/.test(tail) || /^[ ]{0,3}`{1,2}$/.test(tail)) {
+        return { kind: 'partial', start: pos };
+      }
+      break;
+    }
+    const line = buffer.slice(pos, eol);
+    if (FENCE_LINE_RE.test(line)) {
+      if (!inFence) {
         inFence = true;
-        fenceStart = i;
-      }
-      i += 3;
-      continue;
-    }
-
-    if (!inFence && c === '`') {
-      if (inInline) {
-        inInline = false;
-        fenceStart = -1;
+        fenceStart = pos;
       } else {
-        inInline = true;
-        fenceStart = i;
+        inFence = false;
+        skip.push([fenceStart, eol + 1]);
+        fenceStart = -1;
       }
-      i += 1;
-      continue;
     }
+    pos = eol + 1;
+  }
+  if (inFence) return { kind: 'partial', start: fenceStart };
 
-    if (inFence || inInline) {
-      i += 1;
-      continue;
-    }
-
-    if (c === '<' && buffer.startsWith(OPEN_PREFIX, i)) {
-      const after = i + OPEN_PREFIX.length;
-      const next = buffer.charAt(after);
-      if (next === '') return { kind: 'partial', start: i };
-      if (!/\s/.test(next)) {
-        // Not a real <artifact ...> open (e.g. "<artifactual"). Keep scanning.
-        i = after;
-        continue;
-      }
-
-      // Quote-aware scan for the closing '>'.
-      let j = after;
-      let quote: '"' | "'" | null = null;
-      while (j < len) {
-        const cc = buffer.charAt(j);
-        if (quote !== null) {
-          if (cc === quote) quote = null;
-        } else if (cc === '"' || cc === "'") {
-          quote = cc;
-        } else if (cc === '>') {
-          return { kind: 'complete', start: i, end: j + 1, attrs: buffer.slice(after, j) };
-        }
-        j++;
-      }
-      return { kind: 'partial', start: i };
-    }
-
-    i += 1;
+  // Pass 2: collect inline code spans with the same regex the renderer uses.
+  // A span that overlaps a fence range is benign — rangeContains is OR.
+  INLINE_CODE_RE.lastIndex = 0;
+  let m: RegExpExecArray | null = INLINE_CODE_RE.exec(buffer);
+  while (m !== null) {
+    skip.push([m.index, m.index + m[0].length]);
+    m = INLINE_CODE_RE.exec(buffer);
   }
 
-  // An unclosed code span/fence at the tail: hold back so the next chunk can
-  // close it (or reveal a real artifact tag once the fence ends).
-  if (fenceStart !== -1) {
-    return { kind: 'partial', start: fenceStart };
+  // Streaming: an unmatched opening backtick after the last \n could close in
+  // a future chunk. Hold back from the first such backtick.
+  const lastNl = buffer.lastIndexOf('\n');
+  let firstUnmatched = -1;
+  let parity = 0;
+  for (let k = lastNl + 1; k < len; k++) {
+    if (buffer.charAt(k) !== '`') continue;
+    if (rangeContains(skip, k)) continue;
+    if (parity === 0) {
+      firstUnmatched = k;
+      parity = 1;
+    } else {
+      firstUnmatched = -1;
+      parity = 0;
+    }
+  }
+  if (firstUnmatched !== -1) return { kind: 'partial', start: firstUnmatched };
+
+  // Pass 3: find the first `<artifact …>` that is not in any skip range.
+  let from = 0;
+  while (from < len) {
+    const idx = buffer.indexOf(OPEN_PREFIX, from);
+    if (idx === -1) break;
+    if (rangeContains(skip, idx)) {
+      from = idx + OPEN_PREFIX.length;
+      continue;
+    }
+    const after = idx + OPEN_PREFIX.length;
+    const next = buffer.charAt(after);
+    if (next === '') return { kind: 'partial', start: idx };
+    if (!/\s/.test(next)) {
+      // Not a real <artifact ...> open (e.g. "<artifactual"). Keep scanning.
+      from = after;
+      continue;
+    }
+    let j = after;
+    let quote: '"' | "'" | null = null;
+    while (j < len) {
+      const c = buffer.charAt(j);
+      if (quote !== null) {
+        if (c === quote) quote = null;
+      } else if (c === '"' || c === "'") {
+        quote = c;
+      } else if (c === '>') {
+        return { kind: 'complete', start: idx, end: j + 1, attrs: buffer.slice(after, j) };
+      }
+      j++;
+    }
+    return { kind: 'partial', start: idx };
   }
 
   // Strict prefix at the tail (e.g. "<art") — hold back.
   const tail = buffer.lastIndexOf('<');
-  if (tail !== -1) {
+  if (tail !== -1 && !rangeContains(skip, tail)) {
     const slice = buffer.slice(tail);
     if (OPEN_PREFIX.startsWith(slice) && slice.length < OPEN_PREFIX.length) {
       return { kind: 'partial', start: tail };

--- a/apps/web/src/artifacts/parser.ts
+++ b/apps/web/src/artifacts/parser.ts
@@ -67,7 +67,7 @@ function findOpenTag(buffer: string): OpenTagMatch {
   if (lastNl < len - 1) {
     const tailLineStart = lastNl + 1;
     const tail = buffer.slice(tailLineStart);
-    if (/^[ ]{0,3}```\w*$/.test(tail) || /^[ ]{0,3}`{1,2}$/.test(tail)) {
+    if (/^```\w*$/.test(tail) || /^`{1,2}$/.test(tail)) {
       return { kind: 'partial', start: tailLineStart };
     }
   }

--- a/apps/web/src/artifacts/parser.ts
+++ b/apps/web/src/artifacts/parser.ts
@@ -42,47 +42,97 @@ type OpenTagMatch =
   | { kind: 'partial'; start: number }
   | { kind: 'none' };
 
+// Linear scan that ignores `<artifact` occurrences inside Markdown code spans
+// (single-backtick `…`) and fenced code blocks (```…```). The model frequently
+// recites the artifact tag literally when documenting the protocol; without
+// this gating, the parser would enter artifact mode on the recitation and
+// suppress the rest of the rendered reply. If a code span/fence is still open
+// at the end of the buffer, hold back from its start so a later chunk can
+// resolve the boundary without losing fence context.
 function findOpenTag(buffer: string): OpenTagMatch {
-  let from = 0;
-  while (from <= buffer.length) {
-    const idx = buffer.indexOf(OPEN_PREFIX, from);
-    if (idx === -1) {
-      // Maybe a strict prefix at the tail (e.g. "<art") — hold back.
-      const tail = buffer.lastIndexOf('<');
-      if (tail !== -1) {
-        const slice = buffer.slice(tail);
-        if (OPEN_PREFIX.startsWith(slice) && slice.length < OPEN_PREFIX.length) {
-          return { kind: 'partial', start: tail };
-        }
-      }
-      return { kind: 'none' };
-    }
+  const len = buffer.length;
+  let i = 0;
+  let inFence = false;
+  let inInline = false;
+  let fenceStart = -1;
 
-    const after = idx + OPEN_PREFIX.length;
-    const next = buffer.charAt(after);
-    if (next === '') return { kind: 'partial', start: idx };
-    if (!/\s/.test(next)) {
-      // Not a real <artifact ...> open (e.g. "<artifactual"). Keep scanning.
-      from = after;
+  while (i < len) {
+    const c = buffer.charAt(i);
+
+    if (!inInline && c === '`' && buffer.charAt(i + 1) === '`' && buffer.charAt(i + 2) === '`') {
+      if (inFence) {
+        inFence = false;
+        fenceStart = -1;
+      } else {
+        inFence = true;
+        fenceStart = i;
+      }
+      i += 3;
       continue;
     }
 
-    // Quote-aware scan for the closing '>'.
-    let i = after;
-    let quote: '"' | "'" | null = null;
-    while (i < buffer.length) {
-      const c = buffer.charAt(i);
-      if (quote !== null) {
-        if (c === quote) quote = null;
-      } else if (c === '"' || c === "'") {
-        quote = c;
-      } else if (c === '>') {
-        return { kind: 'complete', start: idx, end: i + 1, attrs: buffer.slice(after, i) };
+    if (!inFence && c === '`') {
+      if (inInline) {
+        inInline = false;
+        fenceStart = -1;
+      } else {
+        inInline = true;
+        fenceStart = i;
       }
-      i++;
+      i += 1;
+      continue;
     }
-    return { kind: 'partial', start: idx };
+
+    if (inFence || inInline) {
+      i += 1;
+      continue;
+    }
+
+    if (c === '<' && buffer.startsWith(OPEN_PREFIX, i)) {
+      const after = i + OPEN_PREFIX.length;
+      const next = buffer.charAt(after);
+      if (next === '') return { kind: 'partial', start: i };
+      if (!/\s/.test(next)) {
+        // Not a real <artifact ...> open (e.g. "<artifactual"). Keep scanning.
+        i = after;
+        continue;
+      }
+
+      // Quote-aware scan for the closing '>'.
+      let j = after;
+      let quote: '"' | "'" | null = null;
+      while (j < len) {
+        const cc = buffer.charAt(j);
+        if (quote !== null) {
+          if (cc === quote) quote = null;
+        } else if (cc === '"' || cc === "'") {
+          quote = cc;
+        } else if (cc === '>') {
+          return { kind: 'complete', start: i, end: j + 1, attrs: buffer.slice(after, j) };
+        }
+        j++;
+      }
+      return { kind: 'partial', start: i };
+    }
+
+    i += 1;
   }
+
+  // An unclosed code span/fence at the tail: hold back so the next chunk can
+  // close it (or reveal a real artifact tag once the fence ends).
+  if (fenceStart !== -1) {
+    return { kind: 'partial', start: fenceStart };
+  }
+
+  // Strict prefix at the tail (e.g. "<art") — hold back.
+  const tail = buffer.lastIndexOf('<');
+  if (tail !== -1) {
+    const slice = buffer.slice(tail);
+    if (OPEN_PREFIX.startsWith(slice) && slice.length < OPEN_PREFIX.length) {
+      return { kind: 'partial', start: tail };
+    }
+  }
+
   return { kind: 'none' };
 }
 

--- a/apps/web/src/artifacts/parser.ts
+++ b/apps/web/src/artifacts/parser.ts
@@ -42,7 +42,7 @@ type OpenTagMatch =
   | { kind: 'partial'; start: number }
   | { kind: 'none' };
 
-import { computeSkipRanges, rangeContains } from './markdown-context';
+import { computeSkipRanges, FENCE_OPEN_RE, rangeContains } from './markdown-context';
 
 // Scan the buffer for `<artifact …>` while skipping any positions that the
 // chat markdown renderer would render as a fenced code block or inline code
@@ -67,7 +67,7 @@ function findOpenTag(buffer: string): OpenTagMatch {
   if (lastNl < len - 1) {
     const tailLineStart = lastNl + 1;
     const tail = buffer.slice(tailLineStart);
-    if (/^```\w*$/.test(tail) || /^`{1,2}$/.test(tail)) {
+    if (FENCE_OPEN_RE.test(tail) || /^`{1,2}$/.test(tail)) {
       return { kind: 'partial', start: tailLineStart };
     }
   }

--- a/apps/web/src/artifacts/strip.ts
+++ b/apps/web/src/artifacts/strip.ts
@@ -28,7 +28,15 @@ function findUnskipped(content: string, needle: string, fromIndex: number, range
  * end-of-string when a tag is malformed or still streaming).
  */
 export function stripArtifact(content: string): string {
-  const { ranges } = computeSkipRanges(content);
+  const { ranges: baseRanges, unclosedFenceStart } = computeSkipRanges(content);
+  // For complete (non-streaming) content, an unclosed fence is rendered by
+  // the chat Markdown renderer as a code block extending to end of input
+  // (see runtime/markdown.tsx:49 — the close-loop runs until lines exhaust).
+  // The stripper has to mirror that, otherwise a literal `<artifact …>`
+  // tucked into a code example at the bottom of a chat reply (no trailing
+  // newline) gets treated as a real protocol tag and eaten.
+  const ranges: Range[] =
+    unclosedFenceStart !== null ? [...baseRanges, [unclosedFenceStart, content.length]] : baseRanges;
   const open = findUnskipped(content, OPEN, 0, ranges);
   if (open === -1) return content;
   const closeTag = content.indexOf('>', open);

--- a/apps/web/src/artifacts/strip.ts
+++ b/apps/web/src/artifacts/strip.ts
@@ -1,0 +1,39 @@
+import { computeSkipRanges, rangeContains, type Range } from './markdown-context';
+
+const OPEN = '<artifact';
+const CLOSE = '</artifact>';
+
+function findUnskipped(content: string, needle: string, fromIndex: number, ranges: ReadonlyArray<Range>): number {
+  let from = fromIndex;
+  while (from <= content.length) {
+    const idx = content.indexOf(needle, from);
+    if (idx === -1) return -1;
+    if (!rangeContains(ranges, idx)) return idx;
+    from = idx + needle.length;
+  }
+  return -1;
+}
+
+/**
+ * Remove the first real `<artifact …>…</artifact>` block from `content`.
+ *
+ * "Real" excludes any `<artifact` substring that the chat Markdown renderer
+ * would render as inline code or part of a fenced code block — those are
+ * literal recitations of the protocol and must survive intact, otherwise
+ * the rendered chat reply gets silently truncated mid-explanation.
+ *
+ * If no real open tag exists, the content is returned unchanged. If a real
+ * open exists but no matching real close is found, the content is also
+ * returned unchanged (refusing to strip is safer than truncating to
+ * end-of-string when a tag is malformed or still streaming).
+ */
+export function stripArtifact(content: string): string {
+  const { ranges } = computeSkipRanges(content);
+  const open = findUnskipped(content, OPEN, 0, ranges);
+  if (open === -1) return content;
+  const closeTag = content.indexOf('>', open);
+  if (closeTag === -1) return content;
+  const end = findUnskipped(content, CLOSE, closeTag, ranges);
+  if (end === -1) return content;
+  return (content.slice(0, open) + content.slice(end + CLOSE.length)).trim();
+}

--- a/apps/web/src/artifacts/strip.ts
+++ b/apps/web/src/artifacts/strip.ts
@@ -1,4 +1,4 @@
-import { computeSkipRanges, rangeContains, type Range } from './markdown-context';
+import { computeSkipRanges, isRealArtifactOpenAt, rangeContains, type Range } from './markdown-context';
 
 const OPEN = '<artifact';
 const CLOSE = '</artifact>';
@@ -10,6 +10,24 @@ function findUnskipped(content: string, needle: string, fromIndex: number, range
     if (idx === -1) return -1;
     if (!rangeContains(ranges, idx)) return idx;
     from = idx + needle.length;
+  }
+  return -1;
+}
+
+// Like `findUnskipped(OPEN, …)` but also rejects prefix-shared literals like
+// `<artifactual` — only `<artifact` followed by whitespace counts as a real
+// protocol open. Matches the parser's `findOpenTag` real-open guard so the
+// two paths agree on what the renderer will treat as a tag.
+function findRealOpen(content: string, fromIndex: number, ranges: ReadonlyArray<Range>): number {
+  let from = fromIndex;
+  while (from <= content.length) {
+    const idx = content.indexOf(OPEN, from);
+    if (idx === -1) return -1;
+    if (rangeContains(ranges, idx) || !isRealArtifactOpenAt(content, idx)) {
+      from = idx + OPEN.length;
+      continue;
+    }
+    return idx;
   }
   return -1;
 }
@@ -37,7 +55,7 @@ export function stripArtifact(content: string): string {
   // newline) gets treated as a real protocol tag and eaten.
   const ranges: Range[] =
     unclosedFenceStart !== null ? [...baseRanges, [unclosedFenceStart, content.length]] : baseRanges;
-  const open = findUnskipped(content, OPEN, 0, ranges);
+  const open = findRealOpen(content, 0, ranges);
   if (open === -1) return content;
   const closeTag = content.indexOf('>', open);
   if (closeTag === -1) return content;

--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -6,6 +6,7 @@ import {
   splitOnQuestionForms,
   type QuestionForm,
 } from "../artifacts/question-form";
+import { stripArtifact } from "../artifacts/strip";
 import { QuestionFormView, parseSubmittedAnswers } from "./QuestionForm";
 import { Icon } from "./Icon";
 import { useT } from "../i18n";
@@ -814,17 +815,6 @@ function buildBlocks(events: AgentEvent[]): Block[] {
     }
   }
   return out;
-}
-
-function stripArtifact(content: string): string {
-  const open = content.indexOf("<artifact");
-  if (open === -1) return content;
-  const closeTag = content.indexOf(">", open);
-  const end = content.indexOf("</artifact>", closeTag);
-  return (
-    content.slice(0, open) +
-    content.slice(end === -1 ? content.length : end + 11)
-  ).trim();
 }
 
 // Split prose into alternating plain-text and `<system-reminder>` segments.

--- a/apps/web/tests/artifacts/parser.test.ts
+++ b/apps/web/tests/artifacts/parser.test.ts
@@ -73,6 +73,29 @@ describe('createArtifactParser', () => {
     });
   });
 
+  it('does not enter artifact mode for a tag wrapped in double backticks', () => {
+    // lefarcen P2: double-backtick code spans (``…``) are valid Markdown.
+    const events = collect(
+      'You can quote it as ``<artifact identifier="x" type="text/html" title="X">`` in prose.',
+    );
+    expect(events.find((e) => e.type === 'artifact:start')).toBeUndefined();
+  });
+
+  it('does not enter artifact mode on a triple-backtick string literal inside a fenced block', () => {
+    // lefarcen P2: fenced JS example whose body contains a string with literal ``` should
+    // not pop fence state early and expose a later <artifact> as real.
+    const events = collect(
+      [
+        '```js',
+        'const fence = "```";',
+        'const tag = "<artifact identifier=\\"x\\" type=\\"text/html\\" title=\\"X\\">";',
+        '```',
+        'After.',
+      ].join('\n'),
+    );
+    expect(events.find((e) => e.type === 'artifact:start')).toBeUndefined();
+  });
+
   it('does not enter artifact mode when a fenced tag arrives across multiple chunks', () => {
     const parser = createArtifactParser();
     const chunks = [

--- a/apps/web/tests/artifacts/parser.test.ts
+++ b/apps/web/tests/artifacts/parser.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import { type ArtifactEvent, createArtifactParser } from '../../src/artifacts/parser';
+
+function collect(input: string): ArtifactEvent[] {
+  const parser = createArtifactParser();
+  const events: ArtifactEvent[] = [];
+  for (const e of parser.feed(input)) events.push(e);
+  for (const e of parser.flush()) events.push(e);
+  return events;
+}
+
+describe('createArtifactParser', () => {
+  it('parses a real artifact tag in prose', () => {
+    const events = collect(
+      'Here is a page:\n<artifact identifier="hello" type="text/html" title="Hi">\n<h1>Hi</h1>\n</artifact>\nDone.',
+    );
+    const start = events.find((e) => e.type === 'artifact:start');
+    const end = events.find((e) => e.type === 'artifact:end');
+    expect(start).toMatchObject({ identifier: 'hello', artifactType: 'text/html', title: 'Hi' });
+    expect(end).toMatchObject({ identifier: 'hello' });
+    const trailing = events
+      .filter((e): e is Extract<ArtifactEvent, { type: 'text' }> => e.type === 'text')
+      .map((e) => e.delta)
+      .join('');
+    expect(trailing).toContain('Done.');
+  });
+
+  it('does not enter artifact mode for a tag inside inline backticks', () => {
+    const events = collect(
+      'To emit an artifact, wrap output in `<artifact identifier="x" type="text/html" title="X">` and continue writing normal prose afterwards.',
+    );
+    expect(events.find((e) => e.type === 'artifact:start')).toBeUndefined();
+    const text = events
+      .filter((e): e is Extract<ArtifactEvent, { type: 'text' }> => e.type === 'text')
+      .map((e) => e.delta)
+      .join('');
+    expect(text).toContain('continue writing normal prose afterwards.');
+  });
+
+  it('does not enter artifact mode for a tag inside a fenced code block', () => {
+    const events = collect(
+      [
+        'Example:',
+        '```html',
+        '<artifact identifier="demo" type="text/html" title="Demo">',
+        '<h1>Demo</h1>',
+        '</artifact>',
+        '```',
+        'After the fence, more prose.',
+      ].join('\n'),
+    );
+    expect(events.find((e) => e.type === 'artifact:start')).toBeUndefined();
+    const text = events
+      .filter((e): e is Extract<ArtifactEvent, { type: 'text' }> => e.type === 'text')
+      .map((e) => e.delta)
+      .join('');
+    expect(text).toContain('After the fence, more prose.');
+  });
+
+  it('does not enter artifact mode when a fenced tag arrives across multiple chunks', () => {
+    const parser = createArtifactParser();
+    const chunks = [
+      'Example:\n```html\n<artifact identifier="demo"',
+      ' type="text/html" title="Demo">\n<h1>Demo</h1>\n</artif',
+      'act>\n```\nAfter the fence, more prose.',
+    ];
+    const events: ArtifactEvent[] = [];
+    for (const c of chunks) for (const e of parser.feed(c)) events.push(e);
+    for (const e of parser.flush()) events.push(e);
+    expect(events.find((e) => e.type === 'artifact:start')).toBeUndefined();
+    const text = events
+      .filter((e): e is Extract<ArtifactEvent, { type: 'text' }> => e.type === 'text')
+      .map((e) => e.delta)
+      .join('');
+    expect(text).toContain('After the fence, more prose.');
+  });
+});

--- a/apps/web/tests/artifacts/parser.test.ts
+++ b/apps/web/tests/artifacts/parser.test.ts
@@ -144,6 +144,23 @@ describe('createArtifactParser', () => {
     expect(events.find((e) => e.type === 'artifact:end')).toBeDefined();
   });
 
+  it('does not enter artifact mode when bridged by stray backticks across HR-shaped lines', () => {
+    // Renderer's paragraph loop does not break on HR (runtime/markdown.tsx:95-104),
+    // so `intro \`\n---\n<artifact …>…</artifact>\n---\nclosing \`` is one paragraph
+    // and the backticks pair to cover the literal recitation. mrcfps's
+    // 2026-05-11 05:46 follow-up — the skip-range walker must not split on HR.
+    const events = collect(
+      [
+        'intro `',
+        '---',
+        '<artifact identifier="x" type="text/plain" title="X">demo</artifact>',
+        '---',
+        'closing `',
+      ].join('\n'),
+    );
+    expect(events.find((e) => e.type === 'artifact:start')).toBeUndefined();
+  });
+
   it('does not enter artifact mode for <artifactual> or other prefix-shared identifiers', () => {
     // `<artifact` must be followed by whitespace to count as a real open;
     // strings like `<artifactual>` are not protocol tags and must survive as

--- a/apps/web/tests/artifacts/parser.test.ts
+++ b/apps/web/tests/artifacts/parser.test.ts
@@ -58,6 +58,21 @@ describe('createArtifactParser', () => {
     expect(text).toContain('After the fence, more prose.');
   });
 
+  it('still parses a real artifact tag when prose contains an inline triple-backtick that is not a fence', () => {
+    // The chat markdown renderer (apps/web/src/runtime/markdown.tsx) only treats
+    // ``` as a fence when it appears alone on a line. A mid-line ```html that
+    // is not a fence per the renderer must not suppress a real artifact that
+    // follows. (Reported by Codex review on PR #1132.)
+    const events = collect(
+      'The opening marker is ```html and the response then writes:\n<artifact identifier="real" type="text/html" title="Real">\n<h1>real</h1>\n</artifact>',
+    );
+    expect(events.find((e) => e.type === 'artifact:start')).toMatchObject({
+      identifier: 'real',
+      artifactType: 'text/html',
+      title: 'Real',
+    });
+  });
+
   it('does not enter artifact mode when a fenced tag arrives across multiple chunks', () => {
     const parser = createArtifactParser();
     const chunks = [

--- a/apps/web/tests/artifacts/parser.test.ts
+++ b/apps/web/tests/artifacts/parser.test.ts
@@ -126,6 +126,37 @@ describe('createArtifactParser', () => {
     }
   });
 
+  it('parses a real artifact between paragraphs that each carry a stray backtick', () => {
+    // Inline code is paragraph-local in the renderer; an unbalanced backtick
+    // in one paragraph must not bridge across a blank line to pair with a
+    // backtick in a later paragraph and swallow a real <artifact …> in
+    // between (mrcfps's 2026-05-11 repro).
+    const events = collect(
+      [
+        'intro `',
+        '',
+        '<artifact identifier="x" type="text/plain" title="X">demo</artifact>',
+        '',
+        'closing `',
+      ].join('\n'),
+    );
+    expect(events.find((e) => e.type === 'artifact:start')).toBeDefined();
+    expect(events.find((e) => e.type === 'artifact:end')).toBeDefined();
+  });
+
+  it('does not enter artifact mode for <artifactual> or other prefix-shared identifiers', () => {
+    // `<artifact` must be followed by whitespace to count as a real open;
+    // strings like `<artifactual>` are not protocol tags and must survive as
+    // literal text on both the parser and the stripper sides.
+    const events = collect('prefix <artifactual>demo</artifact> suffix');
+    expect(events.find((e) => e.type === 'artifact:start')).toBeUndefined();
+    const text = events
+      .filter((e): e is Extract<ArtifactEvent, { type: 'text' }> => e.type === 'text')
+      .map((e) => e.delta)
+      .join('');
+    expect(text).toBe('prefix <artifactual>demo</artifact> suffix');
+  });
+
   it('does not enter artifact mode when a fenced tag arrives across multiple chunks', () => {
     const parser = createArtifactParser();
     const chunks = [

--- a/apps/web/tests/artifacts/parser.test.ts
+++ b/apps/web/tests/artifacts/parser.test.ts
@@ -96,6 +96,36 @@ describe('createArtifactParser', () => {
     expect(events.find((e) => e.type === 'artifact:start')).toBeUndefined();
   });
 
+  it('holds back when a chunk ends mid-line on a renderer-valid fence opener prefix', () => {
+    // lefarcen polish P2: the streaming tail-line guard must mirror the
+    // renderer's FENCE_OPEN_RE shape, not a stricter \w-only subset.
+    // Opener tails like "```c++" (info string with `+`/`-`) or "``` "
+    // (trailing whitespace) are valid renderer openers waiting for a `\n`.
+    // If the parser flushes them as text and then sees a literal `<artifact>`
+    // on the next chunk, that artifact would incorrectly enter artifact mode.
+    const cases: Array<{ name: string; chunks: [string, string] }> = [
+      {
+        name: 'plus suffix',
+        chunks: ['Header.\n```c++', '\n<artifact identifier="x" type="text/plain" title="X">demo</artifact>\n```\n'],
+      },
+      {
+        name: 'dash suffix',
+        chunks: ['Header.\n```ts-', '\n<artifact identifier="x" type="text/plain" title="X">demo</artifact>\n```\n'],
+      },
+      {
+        name: 'trailing space',
+        chunks: ['Header.\n``` ', '\n<artifact identifier="x" type="text/plain" title="X">demo</artifact>\n```\n'],
+      },
+    ];
+    for (const { name, chunks } of cases) {
+      const parser = createArtifactParser();
+      const events: ArtifactEvent[] = [];
+      for (const c of chunks) for (const e of parser.feed(c)) events.push(e);
+      for (const e of parser.flush()) events.push(e);
+      expect(events.find((e) => e.type === 'artifact:start'), name).toBeUndefined();
+    }
+  });
+
   it('does not enter artifact mode when a fenced tag arrives across multiple chunks', () => {
     const parser = createArtifactParser();
     const chunks = [

--- a/apps/web/tests/artifacts/strip.test.ts
+++ b/apps/web/tests/artifacts/strip.test.ts
@@ -44,4 +44,45 @@ describe('stripArtifact', () => {
     const input = 'Trailing prose<artifact identifier="x"> with no closer.';
     expect(stripArtifact(input)).toBe(input);
   });
+
+  it('preserves a tag inside a fenced literal whose closing fence has no trailing newline', () => {
+    // Renderer treats an unclosed-at-EOF fence as a code block extending to
+    // end of input. The stripper must do the same, otherwise a literal
+    // recitation tucked into a code example at the bottom of a chat reply
+    // gets eaten.
+    const input = '```js\nconst s = `<artifact identifier="x">demo</artifact>`;\n```';
+    expect(stripArtifact(input)).toBe(input);
+  });
+
+  it('strips a real artifact that follows an indented pseudo-fence (renderer sees no fence)', () => {
+    // The renderer's open-fence regex disallows leading spaces; an indented
+    // "   ```html" line is rendered as a paragraph, not a fence. The
+    // <artifact …> on the next line is therefore a real protocol tag and
+    // must be stripped — not preserved as fictional fenced content.
+    const input = [
+      '   ```html',
+      '<artifact identifier="x" type="text/html" title="X">',
+      '<h1>x</h1>',
+      '</artifact>',
+      'Tail.',
+    ].join('\n');
+    const out = stripArtifact(input);
+    expect(out).not.toContain('<artifact');
+    expect(out).toContain('Tail.');
+  });
+
+  it('preserves a tag inside a fenced block that contains a `\`\`\`html` line in its body', () => {
+    // The renderer closes a fence only on a bare "```\\s*$" — a "```html"
+    // line inside an open fence is kept as code content. The stripper must
+    // match that semantics or it will exit the fence early and eat a
+    // literal <artifact …> recitation that follows.
+    const input = [
+      '```js',
+      'const a = `<p>x</p>`;',
+      '```html',
+      '<artifact identifier="x" type="text/html" title="X">demo</artifact>',
+      '```',
+    ].join('\n');
+    expect(stripArtifact(input)).toBe(input);
+  });
 });

--- a/apps/web/tests/artifacts/strip.test.ts
+++ b/apps/web/tests/artifacts/strip.test.ts
@@ -71,6 +71,32 @@ describe('stripArtifact', () => {
     expect(out).toContain('Tail.');
   });
 
+  it('strips a real artifact between paragraphs that each carry a stray backtick', () => {
+    // Inline code spans are paragraph-local in the renderer; an unbalanced
+    // backtick in one paragraph must not bridge across a blank line to pair
+    // with a backtick in another paragraph and accidentally classify a real
+    // <artifact …> between them as inline code (mrcfps's 2026-05-11 repro).
+    const input = [
+      'intro `',
+      '',
+      '<artifact identifier="x" type="text/plain" title="X">demo</artifact>',
+      '',
+      'closing `',
+    ].join('\n');
+    const out = stripArtifact(input);
+    expect(out).not.toContain('<artifact');
+    expect(out).toContain('intro `');
+    expect(out).toContain('closing `');
+  });
+
+  it('does not strip <artifactual> or other prefix-shared identifiers', () => {
+    // The streaming parser only treats `<artifact` as a real open when the
+    // next char is whitespace; the stripper must apply the same rule, else
+    // literal prose mentioning `<artifactual>` gets silently truncated.
+    const input = 'prefix <artifactual>demo</artifact> suffix';
+    expect(stripArtifact(input)).toBe(input);
+  });
+
   it('preserves a tag inside a fenced block that contains a `\`\`\`html` line in its body', () => {
     // The renderer closes a fence only on a bare "```\\s*$" — a "```html"
     // line inside an open fence is kept as code content. The stripper must

--- a/apps/web/tests/artifacts/strip.test.ts
+++ b/apps/web/tests/artifacts/strip.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { stripArtifact } from '../../src/artifacts/strip';
+
+describe('stripArtifact', () => {
+  it('removes a real artifact tag and its body from prose', () => {
+    const out = stripArtifact(
+      'Header.\n<artifact identifier="x" type="text/html" title="X">\n<h1>x</h1>\n</artifact>\nFooter.',
+    );
+    expect(out).toBe('Header.\n\nFooter.');
+  });
+
+  it('preserves an artifact tag wrapped in inline backticks', () => {
+    const input = 'Wrap output as `<artifact identifier="x">demo</artifact>` to ship it.';
+    expect(stripArtifact(input)).toBe(input);
+  });
+
+  it('preserves an artifact tag inside a fenced code block', () => {
+    const input = [
+      'Example:',
+      '```html',
+      '<artifact identifier="demo" type="text/html" title="Demo">',
+      '<h1>Demo</h1>',
+      '</artifact>',
+      '```',
+      'After.',
+    ].join('\n');
+    expect(stripArtifact(input)).toBe(input);
+  });
+
+  it('preserves a tag wrapped in double backticks', () => {
+    const input = 'Use ``<artifact identifier="x" type="text/html" title="X">`` here.';
+    expect(stripArtifact(input)).toBe(input);
+  });
+
+  it('returns content unchanged when no artifact open tag is present', () => {
+    const input = 'Just prose, no markup.';
+    expect(stripArtifact(input)).toBe(input);
+  });
+
+  it('does not truncate when an open tag has no matching close', () => {
+    // A bare orphan open without a close should not nuke the rest of the
+    // message (the previous implementation sliced to end-of-string).
+    const input = 'Trailing prose<artifact identifier="x"> with no closer.';
+    expect(stripArtifact(input)).toBe(input);
+  });
+});

--- a/apps/web/tests/artifacts/strip.test.ts
+++ b/apps/web/tests/artifacts/strip.test.ts
@@ -89,6 +89,23 @@ describe('stripArtifact', () => {
     expect(out).toContain('closing `');
   });
 
+  it('preserves a tag bridged by stray backticks across HR-shaped lines (renderer keeps HR as paragraph content)', () => {
+    // runtime/markdown.tsx:95-104's paragraph-accumulation loop only breaks on
+    // blank / fence / heading / ul / ol — it does NOT break on HR. So a buffer
+    // shaped `intro \`` / `---` / `<artifact …>…</artifact>` / `---` / `closing \``
+    // is one paragraph in the renderer, and the two stray backticks pair to
+    // cover the literal artifact recitation. The skip-range walker must mirror
+    // that (mrcfps's 2026-05-11 05:46 follow-up).
+    const input = [
+      'intro `',
+      '---',
+      '<artifact identifier="x" type="text/plain" title="X">demo</artifact>',
+      '---',
+      'closing `',
+    ].join('\n');
+    expect(stripArtifact(input)).toBe(input);
+  });
+
   it('does not strip <artifactual> or other prefix-shared identifiers', () => {
     // The streaming parser only treats `<artifact` as a real open when the
     // next char is whitespace; the stripper must apply the same rule, else


### PR DESCRIPTION
## Summary

Fixes #1130. The streaming artifact parser (`apps/web/src/artifacts/parser.ts`) treated any literal `<artifact ` substring in the buffer as the start of a real artifact tag, regardless of whether it appeared inside a Markdown code span or fenced block. When the model recited the protocol verbatim — for example explaining how `apps/daemon/src/prompts/official-system.ts`'s `<artifact identifier="kebab-slug" …>` template works — the parser flipped into artifact mode, suppressed the rest of the rendered reply, and (when a closing `</artifact>` appeared in the recitation) silently wrote a spurious file to disk via `persistArtifact`.

## Approach

Replace `findOpenTag`'s raw `indexOf` scan with a linear walk that tracks Markdown context:

- skip any `<artifact` prefix found inside a fenced code block (` ``` `)
- skip any `<artifact` prefix found inside an inline code span (`` ` ``)
- if the buffer ends mid-fence, return a `partial` match anchored at the fence start so the next streaming chunk can resolve the boundary without losing fence context (matches the existing partial-tag pattern)

Triple-backtick is checked before single-backtick, and inline detection is suppressed inside an open fence — so the standard `` ```html `` … `` ``` `` shape doesn't collapse into pairs of inline spans.

## Tests

New file `apps/web/tests/artifacts/parser.test.ts` with four cases:

- **regression baseline**: a real `<artifact>` in plain prose still parses (start/chunk/end events, trailing text preserved)
- inline backtick recitation no longer enters artifact mode
- fenced code block recitation (open + content + close all inside the fence) no longer enters artifact mode
- the same fenced case fed in three streaming chunks (split mid-tag and mid-`</artifact>`) also no longer enters artifact mode

All four pass with the fix; the latter three fail without it.

## Verification

- `pnpm --filter @open-design/web exec vitest run tests/artifacts/parser.test.ts` — 4 passed
- `pnpm --filter @open-design/web typecheck` — clean
- `pnpm --filter @open-design/web test` — same pass/fail set as `main` (the four `SettingsDialog.execution.test.tsx` failures are pre-existing `window.localStorage` env issues unrelated to this change)
- Manual reproduction in the desktop app: asking the assistant to document the artifact protocol now renders the full reply (1448 output tokens vs. the previously-truncated 1300) and no longer creates a spurious file in the project file panel

## Test plan

- [ ] CI green on `apps/web` package
- [ ] Manual: in any project, ask the assistant to explain the artifact tag syntax — verify the chat renders to completion and no junk file appears in the file panel