### PR TITLE
fix(web): replace native confirm with React dialog so Electron focus stays alive (#1129)

### DIFF
--- a/apps/web/src/components/ConfirmDialog.tsx
+++ b/apps/web/src/components/ConfirmDialog.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useId, useRef } from 'react';
+
+interface Props {
+  /** When false the dialog is unmounted entirely. */
+  open: boolean;
+  title: string;
+  message: string;
+  confirmLabel: string;
+  cancelLabel: string;
+  /** Visually marks the confirm button as a destructive action. */
+  destructive?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * Reusable confirmation dialog used in place of the native `confirm(...)`
+ * call. Native confirms in Electron leave the parent web contents
+ * without restored input focus on dismiss, so any input the user clicks
+ * after closing the dialog appears unfocusable until the window is
+ * refocused (#1129). A React-managed modal lives inside the same
+ * document and naturally restores focus to the previously-active
+ * element on close.
+ */
+export function ConfirmDialog({
+  open,
+  title,
+  message,
+  confirmLabel,
+  cancelLabel,
+  destructive,
+  onConfirm,
+  onCancel,
+}: Props): JSX.Element | null {
+  const titleId = useId();
+  const messageId = useId();
+  const confirmRef = useRef<HTMLButtonElement | null>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+  // Stash the latest cancel handler in a ref so the open-effect below can
+  // wire up Escape / focus-restore once per open transition without
+  // re-subscribing every render when the parent passes a fresh closure.
+  const onCancelRef = useRef(onCancel);
+  useEffect(() => {
+    onCancelRef.current = onCancel;
+  }, [onCancel]);
+
+  useEffect(() => {
+    if (!open) return;
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+    // Defer focus to after the modal has mounted into the DOM.
+    queueMicrotask(() => confirmRef.current?.focus());
+
+    function onKey(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        event.stopPropagation();
+        onCancelRef.current();
+      }
+    }
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      // Returning focus to the trigger keeps Electron's native focus
+      // tracking aligned with the React state, so the next click in the
+      // host inputs lands cleanly.
+      const previous = previousFocusRef.current;
+      previousFocusRef.current = null;
+      if (previous && typeof previous.focus === 'function') {
+        previous.focus();
+      }
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div className="modal-backdrop" onClick={onCancel} data-testid="confirm-dialog-backdrop">
+      <div
+        className="modal modal-confirm"
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={messageId}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <h2 id={titleId}>{title}</h2>
+        <p id={messageId} className="hint">{message}</p>
+        <div className="row">
+          <button
+            type="button"
+            onClick={onCancel}
+            data-testid="confirm-dialog-cancel"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            ref={confirmRef}
+            type="button"
+            className={destructive ? 'destructive' : undefined}
+            onClick={onConfirm}
+            data-testid="confirm-dialog-confirm"
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/ConfirmDialog.tsx
+++ b/apps/web/src/components/ConfirmDialog.tsx
@@ -34,6 +34,7 @@ export function ConfirmDialog({
 }: Props): JSX.Element | null {
   const titleId = useId();
   const messageId = useId();
+  const cancelRef = useRef<HTMLButtonElement | null>(null);
   const confirmRef = useRef<HTMLButtonElement | null>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
   // Stash the latest cancel handler in a ref so the open-effect below can
@@ -54,6 +55,25 @@ export function ConfirmDialog({
       if (event.key === 'Escape') {
         event.stopPropagation();
         onCancelRef.current();
+        return;
+      }
+      if (event.key === 'Tab') {
+        // Trap Tab inside the alertdialog. Native confirm(...) blocks all
+        // background interaction; an in-app modal that lets Tab walk out
+        // to the host page is a non-modal modal and lets keyboard users
+        // activate unrelated controls (e.g. another project card) before
+        // resolving the destructive prompt. Cycle between the two
+        // buttons in both directions.
+        const cancel = cancelRef.current;
+        const confirm = confirmRef.current;
+        if (!cancel || !confirm) return;
+        event.preventDefault();
+        const active = document.activeElement;
+        if (event.shiftKey) {
+          (active === cancel ? confirm : cancel).focus();
+        } else {
+          (active === confirm ? cancel : confirm).focus();
+        }
       }
     }
     document.addEventListener('keydown', onKey);
@@ -64,8 +84,17 @@ export function ConfirmDialog({
       // host inputs lands cleanly.
       const previous = previousFocusRef.current;
       previousFocusRef.current = null;
-      if (previous && typeof previous.focus === 'function') {
+      if (previous && previous.isConnected && typeof previous.focus === 'function') {
         previous.focus();
+      } else {
+        // Trigger was unmounted while the dialog was open — typical for
+        // destructive flows where confirming removes the host element
+        // (project card → its delete button) in the same React batch.
+        // Focusing a detached node is a no-op and leaves Electron's
+        // focus tracker stranded, which is the very regression this
+        // dialog exists to prevent. Park focus on the document body so
+        // the next user input has a valid focus owner to route from.
+        document.body.focus({ preventScroll: true });
       }
     };
   }, [open]);
@@ -86,6 +115,7 @@ export function ConfirmDialog({
         <p id={messageId} className="hint">{message}</p>
         <div className="row">
           <button
+            ref={cancelRef}
             type="button"
             onClick={onCancel}
             data-testid="confirm-dialog-cancel"

--- a/apps/web/src/components/DesignsTab.tsx
+++ b/apps/web/src/components/DesignsTab.tsx
@@ -8,8 +8,18 @@ import type {
 	ProjectDisplayStatus,
 	SkillSummary,
 } from "../types";
+import { ConfirmDialog } from "./ConfirmDialog";
 import { Icon } from "./Icon";
 import { LiveArtifactBadges } from "./LiveArtifactBadges";
+
+type PendingDelete =
+	| { kind: "project"; projectId: string; projectName: string }
+	| {
+			kind: "artifact";
+			projectId: string;
+			artifactId: string;
+			artifactTitle: string;
+	  };
 
 type SubTab = "recent" | "yours";
 type ViewMode = "grid" | "kanban";
@@ -71,6 +81,7 @@ export function DesignsTab({
 	const [liveArtifactsByProject, setLiveArtifactsByProject] = useState<
 		Record<string, LiveArtifactSummary[]>
 	>({});
+	const [pendingDelete, setPendingDelete] = useState<PendingDelete | null>(null);
 	const [view, setView] = useState<ViewMode>(() => {
 		if (typeof window === "undefined") return "grid";
 		try {
@@ -172,19 +183,40 @@ export function DesignsTab({
 		skills.find((s) => s.id === id)?.name ?? "";
 	const dsName = (id: string | null) =>
 		designSystems.find((d) => d.id === id)?.title ?? "";
-	const handleDeleteLiveArtifact = async (
+	const requestDeleteLiveArtifact = (
 		projectId: string,
 		artifact: LiveArtifactSummary,
 	) => {
-		if (!confirm(`${t("common.delete")} "${artifact.title}"?`)) return;
-		const ok = await deleteLiveArtifact(projectId, artifact.id);
-		if (!ok) return;
-		setLiveArtifactsByProject((current) => ({
-			...current,
-			[projectId]: (current[projectId] ?? []).filter(
-				(candidate) => candidate.id !== artifact.id,
-			),
-		}));
+		setPendingDelete({
+			kind: "artifact",
+			projectId,
+			artifactId: artifact.id,
+			artifactTitle: artifact.title,
+		});
+	};
+
+	const requestDeleteProject = (projectId: string, projectName: string) => {
+		setPendingDelete({ kind: "project", projectId, projectName });
+	};
+
+	const commitPendingDelete = async () => {
+		if (!pendingDelete) return;
+		if (pendingDelete.kind === "artifact") {
+			const { projectId, artifactId } = pendingDelete;
+			setPendingDelete(null);
+			const ok = await deleteLiveArtifact(projectId, artifactId);
+			if (!ok) return;
+			setLiveArtifactsByProject((current) => ({
+				...current,
+				[projectId]: (current[projectId] ?? []).filter(
+					(candidate) => candidate.id !== artifactId,
+				),
+			}));
+			return;
+		}
+		const projectId = pendingDelete.projectId;
+		setPendingDelete(null);
+		onDelete(projectId);
 	};
 
 	return (
@@ -288,7 +320,7 @@ export function DesignsTab({
 										aria-label={`${t("common.delete")} ${artifact.title}`}
 										onClick={(e) => {
 											e.stopPropagation();
-											void handleDeleteLiveArtifact(p.id, artifact);
+											requestDeleteLiveArtifact(p.id, artifact);
 										}}
 									>
 										<Icon name="close" size={12} />
@@ -348,8 +380,7 @@ export function DesignsTab({
 									aria-label={t("designs.deleteAria", { name: p.name })}
 									onClick={(e) => {
 										e.stopPropagation();
-										if (confirm(t("designs.deleteConfirm", { name: p.name })))
-											onDelete(p.id);
+										requestDeleteProject(p.id, p.name);
 									}}
 								>
 									<Icon name="close" size={12} />
@@ -436,12 +467,7 @@ export function DesignsTab({
 														})}
 														onClick={(e) => {
 															e.stopPropagation();
-															if (
-																confirm(
-																	t("designs.deleteConfirm", { name: p.name }),
-																)
-															)
-																onDelete(p.id);
+															requestDeleteProject(p.id, p.name);
 														}}
 													>
 														<Icon name="close" size={12} />
@@ -475,6 +501,26 @@ export function DesignsTab({
 					})}
 				</div>
 			)}
+			<ConfirmDialog
+				open={pendingDelete !== null}
+				title={
+					pendingDelete?.kind === "artifact"
+						? t("common.delete")
+						: t("designs.deleteTitle")
+				}
+				message={
+					pendingDelete?.kind === "artifact"
+						? `${t("common.delete")} "${pendingDelete.artifactTitle}"?`
+						: pendingDelete?.kind === "project"
+							? t("designs.deleteConfirm", { name: pendingDelete.projectName })
+							: ""
+				}
+				confirmLabel={t("common.delete")}
+				cancelLabel={t("common.cancel")}
+				destructive
+				onConfirm={() => void commitPendingDelete()}
+				onCancel={() => setPendingDelete(null)}
+			/>
 		</div>
 	);
 }

--- a/apps/web/tests/components/ConfirmDialog.test.tsx
+++ b/apps/web/tests/components/ConfirmDialog.test.tsx
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ConfirmDialog } from '../../src/components/ConfirmDialog';
+
+const baseProps = {
+  title: 'Delete project',
+  message: 'Delete "Test project"?',
+  confirmLabel: 'Delete',
+  cancelLabel: 'Cancel',
+};
+
+describe('ConfirmDialog', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders nothing when closed', () => {
+    const { container } = render(
+      <ConfirmDialog
+        {...baseProps}
+        open={false}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders title, message, and both action buttons when open', () => {
+    render(
+      <ConfirmDialog
+        {...baseProps}
+        open
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('alertdialog')).toBeTruthy();
+    expect(screen.getByText('Delete project')).toBeTruthy();
+    expect(screen.getByText('Delete "Test project"?')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeTruthy();
+  });
+
+  it('invokes onConfirm when the confirm button is clicked', () => {
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmDialog
+        {...baseProps}
+        open
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes onCancel when the cancel button is clicked', () => {
+    const onCancel = vi.fn();
+    render(
+      <ConfirmDialog
+        {...baseProps}
+        open
+        onConfirm={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes onCancel when the backdrop is clicked', () => {
+    const onCancel = vi.fn();
+    render(
+      <ConfirmDialog
+        {...baseProps}
+        open
+        onConfirm={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('confirm-dialog-backdrop'));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not invoke onCancel when the modal body is clicked', () => {
+    const onCancel = vi.fn();
+    render(
+      <ConfirmDialog
+        {...baseProps}
+        open
+        onConfirm={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('alertdialog'));
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it('invokes onCancel on Escape', () => {
+    const onCancel = vi.fn();
+    render(
+      <ConfirmDialog
+        {...baseProps}
+        open
+        onConfirm={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  // The whole point of this component (over native confirm) is that
+  // closing the dialog must restore focus to the trigger element so
+  // Electron's native focus tracker doesn't strand the host inputs in
+  // an unfocusable state — this is the regression in #1129.
+  it('restores focus to the previously focused element on close', () => {
+    const trigger = document.createElement('button');
+    trigger.textContent = 'Open';
+    document.body.appendChild(trigger);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    const { rerender } = render(
+      <ConfirmDialog
+        {...baseProps}
+        open
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    // Confirm button receives focus on open (via queueMicrotask in the
+    // component); flush microtasks before asserting.
+    return Promise.resolve().then(() => {
+      expect(document.activeElement).toBe(
+        screen.getByRole('button', { name: 'Delete' }),
+      );
+
+      rerender(
+        <ConfirmDialog
+          {...baseProps}
+          open={false}
+          onConfirm={vi.fn()}
+          onCancel={vi.fn()}
+        />,
+      );
+
+      expect(document.activeElement).toBe(trigger);
+
+      document.body.removeChild(trigger);
+    });
+  });
+});

--- a/apps/web/tests/components/ConfirmDialog.test.tsx
+++ b/apps/web/tests/components/ConfirmDialog.test.tsx
@@ -163,4 +163,88 @@ describe('ConfirmDialog', () => {
       document.body.removeChild(trigger);
     });
   });
+
+  // Trigger-detached path: destructive flows often unmount the trigger
+  // (e.g. the project card disappears the moment delete is confirmed).
+  // Focusing a detached node is a no-op, so the close path must fall
+  // back to a stable focus owner — otherwise Electron's focus tracker
+  // is stranded and we're back to the #1129 regression even with the
+  // React dialog in place.
+  it('falls back to document.body when the previously focused element has been detached', () => {
+    const trigger = document.createElement('button');
+    trigger.textContent = 'Open';
+    document.body.appendChild(trigger);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    const { rerender } = render(
+      <ConfirmDialog
+        {...baseProps}
+        open
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    return Promise.resolve().then(() => {
+      // Simulate the trigger unmounting while the dialog is open — the
+      // exact React batch a destructive confirm produces in DesignsTab.
+      document.body.removeChild(trigger);
+      expect(trigger.isConnected).toBe(false);
+
+      rerender(
+        <ConfirmDialog
+          {...baseProps}
+          open={false}
+          onConfirm={vi.fn()}
+          onCancel={vi.fn()}
+        />,
+      );
+
+      // Body is the neutral fallback owner — `document.activeElement`
+      // is body either because the parent code focused it or because
+      // jsdom defaulted there after the detached focus attempt was
+      // dropped. Either way, focus is NOT stranded on the detached
+      // trigger node.
+      expect(document.activeElement).toBe(document.body);
+    });
+  });
+
+  // Modal regression: keyboard users must not be able to Tab past the
+  // alertdialog into the host page. Native confirm(...) blocks all
+  // background interaction; without focus trapping the in-app dialog
+  // is a non-modal modal and an accidental Tab can land on (and Enter
+  // can activate) an unrelated background control while a destructive
+  // prompt is still open.
+  it('traps Tab inside the dialog, cycling between cancel and confirm', () => {
+    render(
+      <ConfirmDialog
+        {...baseProps}
+        open
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    return Promise.resolve().then(() => {
+      const cancel = screen.getByTestId('confirm-dialog-cancel');
+      const confirm = screen.getByTestId('confirm-dialog-confirm');
+
+      // queueMicrotask in the component lands focus on confirm.
+      expect(document.activeElement).toBe(confirm);
+
+      // Forward: confirm → cancel → confirm.
+      fireEvent.keyDown(document, { key: 'Tab' });
+      expect(document.activeElement).toBe(cancel);
+      fireEvent.keyDown(document, { key: 'Tab' });
+      expect(document.activeElement).toBe(confirm);
+
+      // Reverse: confirm → cancel (Shift+Tab from confirm).
+      fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+      expect(document.activeElement).toBe(cancel);
+      // And Shift+Tab from cancel cycles back to confirm.
+      fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+      expect(document.activeElement).toBe(confirm);
+    });
+  });
 });

--- a/apps/web/tests/components/DesignsTab.deleteFlow.test.tsx
+++ b/apps/web/tests/components/DesignsTab.deleteFlow.test.tsx
@@ -2,10 +2,10 @@
 
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { Project } from '@open-design/contracts';
+import type { LiveArtifactSummary, Project } from '@open-design/contracts';
 
 import { DesignsTab } from '../../src/components/DesignsTab';
-import { fetchLiveArtifacts } from '../../src/providers/registry';
+import { deleteLiveArtifact, fetchLiveArtifacts } from '../../src/providers/registry';
 
 vi.mock('../../src/providers/registry', () => ({
   deleteLiveArtifact: vi.fn(),
@@ -21,11 +21,35 @@ const sampleProject: Project = {
   updatedAt: Date.now(),
 };
 
+const sampleArtifact: LiveArtifactSummary = {
+  schemaVersion: 1,
+  id: 'artifact-1',
+  projectId: 'project-1',
+  title: 'Hero section',
+  slug: 'hero-section',
+  status: 'active',
+  pinned: false,
+  preview: { type: 'html', entry: 'index.html' },
+  refreshStatus: 'idle',
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  hasDocument: true,
+};
+
 describe('DesignsTab delete flow', () => {
   afterEach(() => {
     cleanup();
     vi.mocked(fetchLiveArtifacts).mockReset();
     vi.mocked(fetchLiveArtifacts).mockResolvedValue([]);
+    vi.mocked(deleteLiveArtifact).mockReset();
+    // DesignsTab persists its grid/kanban toggle to localStorage, so a
+    // test that flips it leaks the toggle into the next test's mount.
+    // Reset to default between tests.
+    try {
+      window.localStorage.clear();
+    } catch {
+      // ignore in environments without localStorage
+    }
   });
 
   it('opens the in-app confirm dialog when the project delete button is clicked', async () => {
@@ -107,5 +131,104 @@ describe('DesignsTab delete flow', () => {
 
     await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());
     expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  // Kanban view exposes its own delete affordance on each card. Same
+  // pendingDelete state ultimately drives the dialog, but the wiring is
+  // separate from grid view, so a kanban-side regression wouldn't be
+  // caught by the grid coverage alone.
+  it('routes kanban view project delete through the React dialog', async () => {
+    vi.mocked(fetchLiveArtifacts).mockResolvedValue([]);
+    const onDelete = vi.fn();
+
+    render(
+      <DesignsTab
+        projects={[sampleProject]}
+        skills={[]}
+        designSystems={[]}
+        onOpen={vi.fn()}
+        onOpenLiveArtifact={vi.fn()}
+        onDelete={onDelete}
+      />,
+    );
+
+    await screen.findByText('Marketing site');
+    fireEvent.click(screen.getByTestId('designs-view-kanban'));
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Delete project Marketing site' }),
+    );
+
+    expect(screen.getByRole('alertdialog')).toBeTruthy();
+    expect(onDelete).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('confirm-dialog-confirm'));
+    await waitFor(() => expect(onDelete).toHaveBeenCalledWith('project-1'));
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());
+  });
+
+  // Live-artifact delete is the third call site the PR replaced. Unlike
+  // project delete it goes through `deleteLiveArtifact` rather than the
+  // parent `onDelete` prop, so we assert that the provider was invoked
+  // with the right (projectId, artifactId) tuple only after confirm.
+  it('routes live-artifact delete through the React dialog and calls deleteLiveArtifact only on confirm', async () => {
+    vi.mocked(fetchLiveArtifacts).mockResolvedValue([sampleArtifact]);
+    vi.mocked(deleteLiveArtifact).mockResolvedValue(true);
+    const onDelete = vi.fn();
+
+    render(
+      <DesignsTab
+        projects={[sampleProject]}
+        skills={[]}
+        designSystems={[]}
+        onOpen={vi.fn()}
+        onOpenLiveArtifact={vi.fn()}
+        onDelete={onDelete}
+      />,
+    );
+
+    // Wait for the live-artifact card to surface — DesignsTab fetches
+    // artifacts in an effect after mount, so the delete affordance is
+    // not present synchronously.
+    const artifactDeleteButton = await screen.findByRole('button', {
+      name: 'Delete Hero section',
+    });
+
+    fireEvent.click(artifactDeleteButton);
+
+    expect(screen.getByRole('alertdialog')).toBeTruthy();
+    expect(deleteLiveArtifact).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('confirm-dialog-confirm'));
+    await waitFor(() =>
+      expect(deleteLiveArtifact).toHaveBeenCalledWith('project-1', 'artifact-1'),
+    );
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it('does not call deleteLiveArtifact when the live-artifact dialog is cancelled', async () => {
+    vi.mocked(fetchLiveArtifacts).mockResolvedValue([sampleArtifact]);
+    vi.mocked(deleteLiveArtifact).mockResolvedValue(true);
+
+    render(
+      <DesignsTab
+        projects={[sampleProject]}
+        skills={[]}
+        designSystems={[]}
+        onOpen={vi.fn()}
+        onOpenLiveArtifact={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    const artifactDeleteButton = await screen.findByRole('button', {
+      name: 'Delete Hero section',
+    });
+    fireEvent.click(artifactDeleteButton);
+    fireEvent.click(screen.getByTestId('confirm-dialog-cancel'));
+
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());
+    expect(deleteLiveArtifact).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/tests/components/DesignsTab.deleteFlow.test.tsx
+++ b/apps/web/tests/components/DesignsTab.deleteFlow.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Project } from '@open-design/contracts';
+
+import { DesignsTab } from '../../src/components/DesignsTab';
+import { fetchLiveArtifacts } from '../../src/providers/registry';
+
+vi.mock('../../src/providers/registry', () => ({
+  deleteLiveArtifact: vi.fn(),
+  fetchLiveArtifacts: vi.fn(),
+}));
+
+const sampleProject: Project = {
+  id: 'project-1',
+  name: 'Marketing site',
+  skillId: null,
+  designSystemId: null,
+  createdAt: Date.now() - 1000,
+  updatedAt: Date.now(),
+};
+
+describe('DesignsTab delete flow', () => {
+  afterEach(() => {
+    cleanup();
+    vi.mocked(fetchLiveArtifacts).mockReset();
+    vi.mocked(fetchLiveArtifacts).mockResolvedValue([]);
+  });
+
+  it('opens the in-app confirm dialog when the project delete button is clicked', async () => {
+    vi.mocked(fetchLiveArtifacts).mockResolvedValue([]);
+    const onDelete = vi.fn();
+
+    render(
+      <DesignsTab
+        projects={[sampleProject]}
+        skills={[]}
+        designSystems={[]}
+        onOpen={vi.fn()}
+        onOpenLiveArtifact={vi.fn()}
+        onDelete={onDelete}
+      />,
+    );
+
+    await screen.findByText('Marketing site');
+
+    // The grid view's delete button. It used to call native confirm()
+    // directly; now it should surface the React confirm dialog.
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Delete project Marketing site' }),
+    );
+
+    expect(screen.getByRole('alertdialog')).toBeTruthy();
+    expect(screen.getByText('Delete "Marketing site"?')).toBeTruthy();
+    // onDelete should NOT be called yet — only after the user confirms
+    // in the React dialog.
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it('calls onDelete with the project id only when the dialog is confirmed', async () => {
+    vi.mocked(fetchLiveArtifacts).mockResolvedValue([]);
+    const onDelete = vi.fn();
+
+    render(
+      <DesignsTab
+        projects={[sampleProject]}
+        skills={[]}
+        designSystems={[]}
+        onOpen={vi.fn()}
+        onOpenLiveArtifact={vi.fn()}
+        onDelete={onDelete}
+      />,
+    );
+
+    await screen.findByText('Marketing site');
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Delete project Marketing site' }),
+    );
+    fireEvent.click(screen.getByTestId('confirm-dialog-confirm'));
+
+    await waitFor(() => expect(onDelete).toHaveBeenCalledWith('project-1'));
+    // Dialog should close after the action commits.
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());
+  });
+
+  it('does not call onDelete when the dialog is cancelled', async () => {
+    vi.mocked(fetchLiveArtifacts).mockResolvedValue([]);
+    const onDelete = vi.fn();
+
+    render(
+      <DesignsTab
+        projects={[sampleProject]}
+        skills={[]}
+        designSystems={[]}
+        onOpen={vi.fn()}
+        onOpenLiveArtifact={vi.fn()}
+        onDelete={onDelete}
+      />,
+    );
+
+    await screen.findByText('Marketing site');
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Delete project Marketing site' }),
+    );
+    fireEvent.click(screen.getByTestId('confirm-dialog-cancel'));
+
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+});

--- a/e2e/ui/project-management-flows.test.ts
+++ b/e2e/ui/project-management-flows.test.ts
@@ -250,20 +250,28 @@ test('home design card deletion supports cancel and confirm flows', async ({ pag
   const designCard = homeDesignCard(page, projectName);
   await expect(designCard).toBeVisible();
 
-  page.once('dialog', async (dialog) => {
-    expect(dialog.message()).toContain(projectName);
-    await dialog.dismiss();
-  });
+  // Project delete now surfaces an in-app React confirm dialog instead
+  // of the native `window.confirm(...)` (the old `page.once('dialog')`
+  // handler will never fire for the React modal). Drive the new dialog
+  // by its alertdialog role and the cancel/confirm testids.
+
+  // Cancel flow: open the dialog, cancel, card remains.
   await designCard.hover();
   await designCard.getByRole('button', { name: new RegExp(`delete project ${escapeRegExp(projectName)}`, 'i') }).click();
+  const cancelFlowDialog = page.getByRole('alertdialog');
+  await expect(cancelFlowDialog).toBeVisible();
+  await expect(cancelFlowDialog).toContainText(projectName);
+  await page.getByTestId('confirm-dialog-cancel').click();
+  await expect(cancelFlowDialog).toHaveCount(0);
   await expect(designCard).toBeVisible();
 
-  page.once('dialog', async (dialog) => {
-    expect(dialog.message()).toContain(projectName);
-    await dialog.accept();
-  });
+  // Confirm flow: open the dialog, confirm, card removed.
   await designCard.hover();
   await designCard.getByRole('button', { name: new RegExp(`delete project ${escapeRegExp(projectName)}`, 'i') }).click();
+  const confirmFlowDialog = page.getByRole('alertdialog');
+  await expect(confirmFlowDialog).toBeVisible();
+  await expect(confirmFlowDialog).toContainText(projectName);
+  await page.getByTestId('confirm-dialog-confirm').click();
   await expect(homeDesignCard(page, projectName)).toHaveCount(0);
 
   const response = await page.request.get(`/api/projects/${projectId}`);


### PR DESCRIPTION
Fixes #1129

## Summary

Native browser/Electron \`confirm(...)\` leaves the parent web contents without restored input focus on dismiss. After the user clicks Delete on a project (or simply **cancels** the prompt), every input on the Designs page — Create project name, search, kanban filter — becomes unfocusable until the window is refocused.

The reproduction was nailed down in the issue thread:
- @Sakana-yuyu reproduced on desktop (PC)
- @Priyanshudotdev reproduced *even on cancel* (so it's not about deletion side effects), and observed it affecting both the search input and the Create panel input
- @lefarcen pointed at the three \`confirm(...)\` sites in \`DesignsTab.tsx\` and recommended replacing them with the \`SettingsDialog\` / \`PrivacyConsentModal\` pattern

## Changes

### New file: [\`apps/web/src/components/ConfirmDialog.tsx\`](apps/web/src/components/ConfirmDialog.tsx)

Reusable confirmation dialog. Reuses the existing \`.modal-backdrop\` / \`.modal\` / \`.hint\` / \`.row\` CSS so this PR ships **no new styling**.

The piece that actually fixes #1129:
\`\`\`tsx
useEffect(() => {
  if (!open) return;
  previousFocusRef.current = document.activeElement as HTMLElement | null;
  queueMicrotask(() => confirmRef.current?.focus());
  function onKey(event: KeyboardEvent) { /* Escape */ }
  document.addEventListener('keydown', onKey);
  return () => {
    document.removeEventListener('keydown', onKey);
    previousFocusRef.current?.focus?.();   // ← restore on close
  };
}, [open]);
\`\`\`

A latest-onCancel ref keeps the open-effect stable across renders so the focus-restore cleanup only runs on \`open: true → false\`, not on every parent re-render that hands in a fresh closure.

### [\`apps/web/src/components/DesignsTab.tsx\`](apps/web/src/components/DesignsTab.tsx)

Replace **all three** \`confirm(...)\` call sites with a single \`pendingDelete\` discriminated-union state that drives the new dialog:

| Old call site | What now |
|---|---|
| \`handleDeleteLiveArtifact\` (live-artifact card delete) | \`requestDeleteLiveArtifact\` sets \`pendingDelete = { kind: 'artifact', ... }\` |
| Project delete in grid view (line 351) | \`requestDeleteProject\` sets \`pendingDelete = { kind: 'project', ... }\` |
| Project delete in kanban view (line 440) | same \`requestDeleteProject\` |

Confirm → \`commitPendingDelete\` dispatches to the corresponding handler and clears state. Cancel just clears state.

> Side-note on the artifact delete: lefarcen's scope was the two project-delete confirms; I included the artifact-delete one too because it's the same root cause, the same site (DesignsTab), and the same one-line replacement. Happy to split it back out if you prefer keeping the PR strictly to the maintainer-confirmed scope.

## Tests

- [\`apps/web/tests/components/ConfirmDialog.test.tsx\`](apps/web/tests/components/ConfirmDialog.test.tsx) (8 tests): mount/unmount, all four close paths (confirm / cancel / Escape / backdrop), inner-modal click isolation, and **the focus-restore-on-close path that #1129 actually depends on** (asserts that focus returns to a previously-focused trigger button after the dialog closes).
- [\`apps/web/tests/components/DesignsTab.deleteFlow.test.tsx\`](apps/web/tests/components/DesignsTab.deleteFlow.test.tsx) (3 tests): clicking the project delete button now opens the in-app dialog instead of firing \`onDelete\`; confirm fires \`onDelete\` with the project id and dismisses the dialog; cancel closes the dialog without firing \`onDelete\`.

\`pnpm --filter @open-design/web typecheck\` ✅
\`pnpm exec vitest run tests/components\` → **354/354 pass** (40 test files), no regressions.

## Out of scope

- I did not audit the rest of the codebase for other \`confirm(...)\` usages. There's at least one in a chat composer / conversation flow; happy to follow up in a separate PR.
- Did not add destructive-button color styling. The \`destructive\` prop sets a class but the existing CSS doesn't define a \`.destructive\` rule on dialog buttons — kept as a structural hook for a follow-up theming pass.