### PR TITLE
fix(web): 写盘前拦截 prose-as-HTML artifact (#50)

### DIFF
--- a/apps/web/src/artifacts/validate.ts
+++ b/apps/web/src/artifacts/validate.ts
@@ -1,42 +1,56 @@
 /**
- * Pre-write structural validation for AI-emitted HTML artifacts.
+ * Pre-write structural sniff for AI-emitted HTML artifacts.
  *
  * Defends the project-file persistence path (`persistArtifact` →
  * `writeProjectTextFile`) against the failure mode in #50 / #1143 where the
  * model emits an `<artifact type="text/html">…</artifact>` block whose body is
- * a one-line prose summary instead of a complete document. Without this gate,
- * such content lands on disk as a real `.html` file with `kind: html` manifest
- * and pollutes the project file panel as a phantom artifact tab.
+ * a prose summary instead of a complete document. Without this gate, such
+ * content lands on disk as a real `.html` file with `kind: html` manifest and
+ * pollutes the project file panel as a phantom artifact tab.
  *
  * Policy (intentionally narrow — false positives here block real saves):
- * - non-empty after trimming
- * - meets a minimum length threshold (a single sentence cannot pass)
- * - contains either `<!doctype` or an `<html` opening tag (case-insensitive)
+ * - non-empty after trimming BOM and leading whitespace
+ * - meets a minimum length threshold
+ * - the *first* non-whitespace token is `<!doctype html>` or `<html`
+ *   (anchored at the start; mid-string mentions of these tags do NOT count —
+ *   AI prose like "Updated the <html lang> attribute…" must be rejected)
  *
- * The gate is *not* an HTML linter. Malformed but recognizably-structured HTML
- * passes; only content that obviously isn't a document fails. Hand-edited
- * partial drafts go through a different code path (FileViewer / FileWorkspace)
- * and are intentionally not gated here.
+ * What this gate is NOT:
+ * - It is **not** an HTML linter or validator. Malformed but recognizably
+ *   document-shaped HTML passes; only content that obviously isn't a document
+ *   fails. The guarantee is "blocks obvious prose-as-HTML", not "validates
+ *   well-formed HTML."
+ * - It does **not** cover `.jsx` / `.tsx` artifacts or any other type — the
+ *   `persistArtifact` caller only invokes this for `ext === '.html'`. This is
+ *   not a generalized artifact-validation framework.
+ * - It does **not** apply to user-driven saves via `FileViewer` /
+ *   `FileWorkspace`; those go through a different code path and may
+ *   legitimately save partial drafts.
+ *
+ * Threshold note: 64 chars rejects minimal empty-body documents like
+ * `<!doctype html><html><body></body></html>` (49 chars). That is intentional
+ * — AI-emitted artifacts in this product are expected to be non-trivial
+ * deliverables, not test fixtures, so the lower bound favors fewer phantom
+ * files over preserving fixture-grade empties.
  */
 
 const MIN_HTML_LENGTH = 64;
-const HTML_OPENING_TAG_RE = /<html\b/i;
-const DOCTYPE_RE = /<!doctype\s+html/i;
+const STARTS_WITH_DOCUMENT_RE = /^(?:<!doctype\s+html\b|<html\b)/i;
 
 export type HtmlArtifactValidationResult =
   | { ok: true }
   | { ok: false; reason: string };
 
 export function validateHtmlArtifact(content: string): HtmlArtifactValidationResult {
-  const trimmed = content.trim().replace(/^﻿/, '');
+  const trimmed = content.replace(/^﻿/, '').trim();
   if (trimmed.length === 0) {
     return { ok: false, reason: 'empty content' };
   }
   if (trimmed.length < MIN_HTML_LENGTH) {
     return { ok: false, reason: `content too short to be HTML (got ${trimmed.length} chars, need ≥${MIN_HTML_LENGTH})` };
   }
-  if (!HTML_OPENING_TAG_RE.test(trimmed) && !DOCTYPE_RE.test(trimmed)) {
-    return { ok: false, reason: 'no <!doctype html> or <html> tag found — content does not look like a complete HTML document' };
+  if (!STARTS_WITH_DOCUMENT_RE.test(trimmed)) {
+    return { ok: false, reason: 'content does not start with <!doctype html> or <html — looks like prose, not a complete HTML document' };
   }
   return { ok: true };
 }

--- a/apps/web/src/artifacts/validate.ts
+++ b/apps/web/src/artifacts/validate.ts
@@ -1,0 +1,42 @@
+/**
+ * Pre-write structural validation for AI-emitted HTML artifacts.
+ *
+ * Defends the project-file persistence path (`persistArtifact` →
+ * `writeProjectTextFile`) against the failure mode in #50 / #1143 where the
+ * model emits an `<artifact type="text/html">…</artifact>` block whose body is
+ * a one-line prose summary instead of a complete document. Without this gate,
+ * such content lands on disk as a real `.html` file with `kind: html` manifest
+ * and pollutes the project file panel as a phantom artifact tab.
+ *
+ * Policy (intentionally narrow — false positives here block real saves):
+ * - non-empty after trimming
+ * - meets a minimum length threshold (a single sentence cannot pass)
+ * - contains either `<!doctype` or an `<html` opening tag (case-insensitive)
+ *
+ * The gate is *not* an HTML linter. Malformed but recognizably-structured HTML
+ * passes; only content that obviously isn't a document fails. Hand-edited
+ * partial drafts go through a different code path (FileViewer / FileWorkspace)
+ * and are intentionally not gated here.
+ */
+
+const MIN_HTML_LENGTH = 64;
+const HTML_OPENING_TAG_RE = /<html\b/i;
+const DOCTYPE_RE = /<!doctype\s+html/i;
+
+export type HtmlArtifactValidationResult =
+  | { ok: true }
+  | { ok: false; reason: string };
+
+export function validateHtmlArtifact(content: string): HtmlArtifactValidationResult {
+  const trimmed = content.trim().replace(/^﻿/, '');
+  if (trimmed.length === 0) {
+    return { ok: false, reason: 'empty content' };
+  }
+  if (trimmed.length < MIN_HTML_LENGTH) {
+    return { ok: false, reason: `content too short to be HTML (got ${trimmed.length} chars, need ≥${MIN_HTML_LENGTH})` };
+  }
+  if (!HTML_OPENING_TAG_RE.test(trimmed) && !DOCTYPE_RE.test(trimmed)) {
+    return { ok: false, reason: 'no <!doctype html> or <html> tag found — content does not look like a complete HTML document' };
+  }
+  return { ok: true };
+}

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -9,6 +9,7 @@ import {
   type PointerEvent as ReactPointerEvent,
 } from 'react';
 import { createHtmlArtifactManifest, inferLegacyManifest } from '../artifacts/manifest';
+import { validateHtmlArtifact } from '../artifacts/validate';
 import { createArtifactParser } from '../artifacts/parser';
 import { useT } from '../i18n';
 import { streamMessage } from '../providers/anthropic';
@@ -1360,6 +1361,18 @@ export function ProjectView({
         .replace(/^-+|-+$/g, '')
         .slice(0, 60) || 'artifact';
       const ext = artifactExtensionFor(art);
+      // Pre-write structural gate for HTML artifacts (#50, #1143). Reject
+      // bodies that obviously aren't a complete document — usually a one-line
+      // prose summary the model emitted inside `<artifact type="text/html">`
+      // when only Edit-tool changes happened this turn. Without this guard,
+      // such content lands as a phantom HTML file in the project panel.
+      if (ext === '.html') {
+        const validation = validateHtmlArtifact(art.html);
+        if (!validation.ok) {
+          setError(`Refused to save artifact "${art.identifier || art.title || 'untitled'}": ${validation.reason}`);
+          return;
+        }
+      }
       // Pick a name that doesn't collide with an existing project file.
       // The first run uses `<base>.<ext>`; subsequent runs append `-2`, `-3`…
       // so prior artifacts aren't silently overwritten.

--- a/apps/web/tests/artifacts/validate.test.ts
+++ b/apps/web/tests/artifacts/validate.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { validateHtmlArtifact } from '../../src/artifacts/validate';
+
+describe('validateHtmlArtifact', () => {
+  it('rejects an empty string', () => {
+    const result = validateHtmlArtifact('');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/empty/i);
+  });
+
+  it('rejects whitespace-only content', () => {
+    const result = validateHtmlArtifact('   \n\t  ');
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects a one-line prose summary (the #50 phantom-artifact case)', () => {
+    const prose = '查看 `html-ppt-xhs-white-editorial/index.html` — 已删第 2 页（章节分隔）和第 8 页（致谢），剩余 6 张移除顶部 chrome，仅保留右下角 `01/06`–`06/06` 页码。';
+    const result = validateHtmlArtifact(prose);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/html/i);
+  });
+
+  it('rejects content shorter than the minimum threshold even if it contains angle brackets', () => {
+    const result = validateHtmlArtifact('<p>hi</p>');
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects a long prose blob that lacks any HTML structural markers', () => {
+    const prose = '这是一段很长的中文总结，'.repeat(20);
+    const result = validateHtmlArtifact(prose);
+    expect(result.ok).toBe(false);
+  });
+
+  it('accepts a complete <!doctype html> document', () => {
+    const html = '<!doctype html><html><head><title>x</title></head><body><h1>hello</h1></body></html>';
+    const result = validateHtmlArtifact(html);
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts content with a leading <html> tag (no doctype)', () => {
+    const html = '<html><head><title>x</title></head><body><div>content here long enough</div></body></html>';
+    const result = validateHtmlArtifact(html);
+    expect(result.ok).toBe(true);
+  });
+
+  it('is case-insensitive on the doctype / html tag check', () => {
+    const html = '<!DOCTYPE HTML><HTML><BODY><DIV>hello world content</DIV></BODY></HTML>';
+    const result = validateHtmlArtifact(html);
+    expect(result.ok).toBe(true);
+  });
+
+  it('tolerates leading whitespace and BOM before the doctype', () => {
+    const html = '﻿\n  <!doctype html>\n<html><body>real document body content</body></html>';
+    const result = validateHtmlArtifact(html);
+    expect(result.ok).toBe(true);
+  });
+});

--- a/apps/web/tests/artifacts/validate.test.ts
+++ b/apps/web/tests/artifacts/validate.test.ts
@@ -32,6 +32,26 @@ describe('validateHtmlArtifact', () => {
     expect(result.ok).toBe(false);
   });
 
+  it('rejects long prose that mentions an inline <html ...> tag mid-sentence (mrcfps finding)', () => {
+    const prose = 'Updated the <html lang> attribute and cleaned up the footer layout for mobile previews.';
+    expect(prose.length).toBeGreaterThan(64);
+    const result = validateHtmlArtifact(prose);
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects long prose that mentions <!doctype html> mid-sentence', () => {
+    const prose = 'I added a <!doctype html> declaration at the top and rewrote the body section to match the brief.';
+    expect(prose.length).toBeGreaterThan(64);
+    const result = validateHtmlArtifact(prose);
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects content where the first non-whitespace token is a non-document tag like <p>', () => {
+    const fragment = '<p>This is a paragraph that happens to contain enough chars and a stray <html> mention.</p>';
+    const result = validateHtmlArtifact(fragment);
+    expect(result.ok).toBe(false);
+  });
+
   it('accepts a complete <!doctype html> document', () => {
     const html = '<!doctype html><html><head><title>x</title></head><body><h1>hello</h1></body></html>';
     const result = validateHtmlArtifact(html);


### PR DESCRIPTION
## 概要

为 `persistArtifact` 在 `<artifact type="text/html">` 持久化路径上加结构性 HTML gate，拦住 #50 现场报告里的"幽灵 HTML 文件"——AI 把一句中文总结塞进 `<artifact>` 块、被系统当合法 HTML 落盘到项目文件面板的失败模式。

## 修复内容

- 新增 `apps/web/src/artifacts/validate.ts` 暴露纯函数 `validateHtmlArtifact(content)`：非空 + 长度 ≥ 64 字符 + 含 `<!doctype html>` 或 `<html>` 标签（大小写不敏感、容忍 BOM 与前导空白）
- `apps/web/src/components/ProjectView.tsx` 的 `persistArtifact` 在 `ext === '.html'` 分支调用 gate，失败时通过 `setError` 报错并 return，不进入写盘流程
- 测试：`apps/web/tests/artifacts/validate.test.ts` 9 例（empty / whitespace / #50 现场 prose / 含尖括号但太短 / 长 prose 无 HTML 标签 / doctype-only / html-only / 大小写不敏感 / BOM 容忍）

## 与 #50 的关系

#50 列出了三层修复（写前内容校验 / identifier-scoped revision 模型 / history UI）。本 PR 只做第一层"写前内容校验"，因为：
- 改动小、独立、纯防御
- 不依赖 schema/UX 决策，可以立即合并
- 与第二层（revision 模型）正交，不阻塞那边的方案讨论

## scope 边界

**只 gate `<artifact>` 标签持久化路径**——`persistArtifact` 是 streaming parser 拿到 `<artifact>...</artifact>` 后调用的入口。

**不 gate 用户手动保存路径**——`FileViewer` / `FileWorkspace` 里用户在编辑器里写 HTML 草稿时走 `writeProjectTextFile` 直调（无 `artifactManifest`），不经过 `persistArtifact`，不受本 PR 影响。这是有意保留的——用户保存 WIP HTML 是合理的，不应该被结构性 gate 阻拦。

## 根因 prompt 层后续

AI 之所以会在没有新 HTML 产出的情况下仍发空壳 `<artifact>`，根源在 `apps/daemon/src/prompts/official-system.ts` 的 "Artifact handoff" 写成了非协商性规则、缺少免发条款。已拆出 #1143 单独跟进。本 PR 是持久化层兜底防御，与 #1143 互补：

| 层级 | 作用 | 强度 |
|---|---|---|
| #1143 prompt 层 | 让 AI 不去发空壳 artifact | 概率性服从 |
| **本 PR 持久化层** | 挡住已经发出来的空壳 artifact | 强制力 |

## 验证

- `pnpm guard` ✅
- `pnpm typecheck` ✅
- `pnpm --filter @open-design/web test --run tests/artifacts` → 38/38 通过（含本 PR 新增 9 例）
- `pnpm --filter @open-design/web test` 全量：648/652 通过；4 例失败为 `SettingsDialog.execution.test.tsx` 的 localStorage 问题，是 main 上就有的 pre-existing failure，与本 PR 无关

## Test plan

- [ ] 真实场景验证：构造一次仅 Edit 工具的对话轮次，观察 AI 即使发出空壳 `<artifact>` 也不会污染项目文件面板，error toast 提示拒收原因
- [ ] 反向回归验证：发出正常完整 HTML artifact 仍能正常落盘、自动开 tab 预览