### PR TITLE
fix(prompts): add "When NOT to emit" guardrail to artifact handoff (#1143)

### DIFF
--- a/apps/daemon/src/prompts/deck-framework.ts
+++ b/apps/daemon/src/prompts/deck-framework.ts
@@ -324,7 +324,7 @@ When the user asks for slides, your TodoWrite plan **must** start with "copy the
 4.  Add per-deck classes inside the second <style> block
 5.  Replace each <section class="slide"> SLOT with real content
 6.  Self-check (no rewriting framework chrome / @media print / nav script)
-7.  Emit single <artifact>
+7.  Emit single <artifact> if a new canonical deck HTML was written this turn; otherwise summarize the edits (see "Artifact emission is conditional" in the discovery layer)
 \`\`\`
 
 If you find yourself writing \`<style>\` rules for \`.deck-shell\`, \`.deck-stage\`, \`.slide\`, \`.canvas\`, \`fit()\`, \`@media print\`, or a keyboard handler — STOP. The framework already has them. Re-read this directive, then keep going from "fill SLOT content".

--- a/apps/daemon/src/prompts/discovery.ts
+++ b/apps/daemon/src/prompts/discovery.ts
@@ -14,7 +14,7 @@
  *                · "I have a brand spec / Match a reference site / screenshot"
  *                                              →  brand-spec extraction (Bash + Read), then TodoWrite
  *                · otherwise                   →  TodoWrite directly
- *   Turn 3+ →  work the plan, show progress live, build, self-check, emit <artifact>.
+ *   Turn 3+ →  work the plan, show progress live, build, self-check, emit <artifact> if a new canonical HTML was written this turn (skip on edits-only).
  *
  * Distilled from alchaincyf/huashu-design (Junior-Designer mode,
  * variations-not-answers, anti-AI-slop, embody-the-specialist) and
@@ -123,6 +123,12 @@ Skip directly to RULE 3.
 
 ---
 
+## Artifact emission is conditional (dominant-layer invariant)
+
+Emit \`<artifact>\` **only when this turn wrote a new canonical HTML file**. If this turn only edited an existing HTML file — or the body would be prose / summary / file-path / bash-output rather than a complete \`<!doctype html>\` document — do **not** emit \`<artifact>\`; summarize the changed file instead. This invariant overrides any \`emit <artifact>\` step that appears later in this prompt; see "Artifact handoff" in the base charter for the full no-emit rationale and rules.
+
+---
+
 ## RULE 3 — TodoWrite the plan, then live updates
 
 Once direction / brand-spec is locked, your **first tool call** is TodoWrite with a plan of 5–10 short imperative items in the order you'll do them. The chat renders this as a live "Todos" card — it is the user's primary way to see your plan and redirect cheaply.
@@ -140,7 +146,7 @@ The standard plan template (adapt the middle steps to the brief):
 - 6.  Replace [REPLACE] placeholders with real, specific copy from the brief
 - 7.  Self-check: run references/checklist.md (P0 must all pass)
 - 8.  Critique: 5-dim radar (philosophy / hierarchy / execution / specificity / restraint), fix any < 3/5
-- 9.  Emit single <artifact>
+- 9.  Emit single <artifact> if a new canonical HTML file was written this turn; otherwise summarize the edits
 \`\`\`
 
 **Decks especially — framework first, content second.** For \`kind=deck\` projects, step 4 is the load-bearing one: copy the deck framework HTML (the active skill's \`assets/template.html\`, or, if no skill is bound, the canonical skeleton in the deck-mode directive at the bottom of this prompt) **verbatim** before authoring any slide content. Do NOT write your own scale-to-fit logic, keyboard handler, slide visibility toggle, counter, or print stylesheet — every freeform attempt at this re-introduces the same iframe positioning / scaling bugs we have already fixed in the framework. Your job is to drop the framework in, bind the palette, then fill the \`<section class="slide">\` slots. That's it.
@@ -259,5 +265,5 @@ The single-screen \`mobile-app\` skill already inlines the iPhone frame in its s
   - "Pick a direction for me" → emit \`<question-form id="direction">\` + stop.
   - "I have a brand spec / Match a reference" → run brand-spec extraction, write \`brand-spec.md\`, then TodoWrite.
   - else → TodoWrite directly.
-- **Turn 3+** — work the plan; mark todos completed as each step lands; show the user something visible early; iterate; **run checklist + 5-dim critique** before emitting; emit a single \`<artifact>\`.
+- **Turn 3+** — work the plan; mark todos completed as each step lands; show the user something visible early; iterate; **run checklist + 5-dim critique** before emitting; emit a single \`<artifact>\` **only if a new canonical HTML file was written this turn** (skip on edits-only — see the "Artifact emission is conditional" invariant above).
 `;

--- a/apps/daemon/src/prompts/official-system.ts
+++ b/apps/daemon/src/prompts/official-system.ts
@@ -26,10 +26,10 @@ You can talk about your capabilities in non-technical, user-facing terms: HTML, 
 2. **Explore provided resources.** Read the active design system's full definition (it's stacked into this prompt below) and any user-attached files. Use file-listing and read tools liberally; concurrent reads are encouraged.
 3. **Plan with TodoWrite.** For anything beyond a one-shot tweak, lay out a todo list before you start writing files. Update it as you go — the user sees your progress live.
 4. **Build the project files.** Write your main HTML file (and any supporting CSS/JSX/JS) to the project root. Show the user something early — even a rough first pass is better than radio silence.
-5. **Finish.** Wrap up by emitting an \`<artifact>\` block referencing the canonical file (see "Artifact handoff" below). Verify it renders cleanly. Summarize **briefly**: what's there, what's still open, what you'd suggest next.
+5. **Finish.** If you wrote a new canonical HTML file this turn, wrap up by emitting an \`<artifact>\` block referencing it (see "Artifact handoff" below). If you only made in-place edits to an existing file, skip the artifact block — just summarize **briefly**: what file you changed, what changed, what's still open, what you'd suggest next.
 
-## Artifact handoff (non-negotiable output rule)
-At the end of every turn that produces a deliverable, the LAST thing in your response must be a single artifact block:
+## Artifact handoff
+When you ship a fresh deliverable in a turn, end the response with a single artifact block:
 
 \`\`\`
 <artifact identifier="kebab-slug" type="text/html" title="Human title">
@@ -43,6 +43,11 @@ Rules:
 - After \`</artifact>\`, stop. Do not narrate what you produced. Do not wrap the artifact in markdown code fences.
 - If you've written multiple files to the project, the artifact should be the **canonical entry point** (usually \`index.html\`). Reference supporting files by their project-relative paths in \`<link>\` / \`<script>\` tags only if you also intend the user to use them; otherwise inline.
 - For decks and multi-page work, you may write companion files; the artifact still wraps the entry HTML.
+
+**When NOT to emit \`<artifact>\`:**
+- **In-place edits only.** If this turn only modified an already-existing project HTML file via Edit (no new canonical HTML written this turn), do not emit \`<artifact>\`. Just say which file you changed and what you changed — the user already sees the file in their panel and the preview reflects the change automatically.
+- **Body must be a complete \`<!doctype html>\` document.** Never wrap a summary, prose, file path reference, bash output, or explanation inside \`<artifact>\`. If what you want to say isn't a complete standalone HTML document, write it as plain reply text — do not put it between \`<artifact>\` and \`</artifact>\`.
+- **When in doubt, skip it.** Re-emitting an unchanged artifact doesn't help the user; emitting an empty-shell one (artifact tag wrapping a one-line summary) actively misleads them and pollutes their project file panel with phantom files.
 
 ## Reading documents and images
 You can read Markdown, HTML, and other plaintext formats natively. You can read images attached by the user — they appear in the prompt with absolute paths or as project-relative paths inside your working directory. When the user pastes or drops an image, treat it as visual reference: lift palette, layout, tone — don't promise pixel-perfect recreation unless they ask for it.

--- a/apps/daemon/tests/prompts/system.test.ts
+++ b/apps/daemon/tests/prompts/system.test.ts
@@ -77,6 +77,26 @@ describe('composeSystemPrompt', () => {
       expect(prompt).toMatch(/complete `?<!doctype html>`?/i);
       expect(prompt).toMatch(/summar(y|ies)|prose|file path/i);
     });
+
+    it('does not carry unconditional "Emit single <artifact>" / "emit a single <artifact>" lines anywhere in the composed prompt', () => {
+      const prompt = composeSystemPrompt({});
+      // Discovery layer used to carry hard-rule unconditional emit instructions
+      // (plan template step 9, default arc Turn 3+ recap, deck workflow step 7).
+      // Those must be conditional now — otherwise the no-emit exception in the
+      // base prompt is overridden by the higher-priority discovery layer.
+      expect(prompt).not.toMatch(/^- 9\.\s+Emit single <artifact>\s*$/m);
+      expect(prompt).not.toMatch(/emit a single `?<artifact>`?\.\s*$/m);
+      expect(prompt).not.toMatch(/^7\.\s+Emit single <artifact>\s*$/m);
+    });
+
+    it('declares artifact-emission conditionality at the dominant discovery layer', () => {
+      const prompt = composeSystemPrompt({});
+      // The base prompt's "When NOT to emit" section is at lower precedence than
+      // DISCOVERY_AND_PHILOSOPHY, so the exception itself must be stated once at
+      // the dominant layer (near RULE 3) — not only back-pointed.
+      expect(prompt).toMatch(/only when this turn wrote a new canonical HTML/i);
+      expect(prompt).toMatch(/only edited an existing HTML file/i);
+    });
   });
 
   describe('connectedExternalMcp directive', () => {

--- a/apps/daemon/tests/prompts/system.test.ts
+++ b/apps/daemon/tests/prompts/system.test.ts
@@ -97,6 +97,18 @@ describe('composeSystemPrompt', () => {
       expect(prompt).toMatch(/only when this turn wrote a new canonical HTML/i);
       expect(prompt).toMatch(/only edited an existing HTML file/i);
     });
+
+    it('also keeps deck-mode prompts free of the unconditional emit line (DECK_FRAMEWORK_DIRECTIVE only stacks for deck projects)', () => {
+      // The plain composeSystemPrompt({}) call does NOT include
+      // DECK_FRAMEWORK_DIRECTIVE; that directive only stacks when
+      // `skillMode === 'deck'` or `metadata.kind === 'deck'`. So if
+      // deck-framework.ts:327 ever regresses back to "Emit single <artifact>",
+      // a no-args negative assertion is a false negative — exercise the deck
+      // path explicitly here.
+      const deckPrompt = composeSystemPrompt({ skillMode: 'deck' });
+      expect(deckPrompt).not.toMatch(/^7\.\s+Emit single <artifact>\s*$/m);
+      expect(deckPrompt).toMatch(/Emit single <artifact> if a new canonical deck HTML/i);
+    });
   });
 
   describe('connectedExternalMcp directive', () => {

--- a/apps/daemon/tests/prompts/system.test.ts
+++ b/apps/daemon/tests/prompts/system.test.ts
@@ -55,6 +55,30 @@ describe('composeSystemPrompt', () => {
     expect(prompt).toContain('The first output should be a live artifact/dashboard/report');
   });
 
+  describe('artifact handoff no-emit clauses (#1143)', () => {
+    it('drops the absolute "non-negotiable" framing in favor of conditional language', () => {
+      const prompt = composeSystemPrompt({});
+      expect(prompt).not.toContain('non-negotiable output rule');
+    });
+
+    it('includes the "When NOT to emit <artifact>" sub-section', () => {
+      const prompt = composeSystemPrompt({});
+      expect(prompt).toContain('When NOT to emit `<artifact>`');
+    });
+
+    it('forbids wrapping in-place-edit-only turns in an artifact block', () => {
+      const prompt = composeSystemPrompt({});
+      expect(prompt).toMatch(/in-place|Edit-only|already-existing/i);
+      expect(prompt).toMatch(/do not (emit|wrap|send) (a |an )?`?<artifact/i);
+    });
+
+    it('forbids putting prose / summaries / paths inside an artifact block', () => {
+      const prompt = composeSystemPrompt({});
+      expect(prompt).toMatch(/complete `?<!doctype html>`?/i);
+      expect(prompt).toMatch(/summar(y|ies)|prose|file path/i);
+    });
+  });
+
   describe('connectedExternalMcp directive', () => {
     it('omits the directive when no servers are passed', () => {
       const prompt = composeSystemPrompt({});


### PR DESCRIPTION
Fixes #1143

## 概要

修复 #1143：AI 偶尔在仅做 in-place 编辑（无新 canonical HTML 产出）时仍按 `non-negotiable output rule` 字面收尾，把一句总结塞进 `<artifact type="text/html">` 块，被下游当合法 HTML 落盘成幽灵文件。

根因在 prompt 缺少免发条款。本 PR 在 prompt 层让 AI 不去发空壳 artifact。

## 修复内容

`apps/daemon/src/prompts/official-system.ts`：

- **松动绝对化措辞**：`## Artifact handoff (non-negotiable output rule)` → `## Artifact handoff`，开篇 "At the end of every turn… the LAST thing in your response must be" → "When you ship a fresh deliverable in a turn, end the response with"
- **Workflow step 5 加分支**：原文一刀切要求 "Wrap up by emitting an `<artifact>` block"，改为：
  - 写了新 canonical HTML → 发 artifact（原行为）
  - 只做 in-place 编辑 → 跳过 artifact，直接简述改了哪个文件、改了什么
- **新增 "When NOT to emit `<artifact>`" 子段**，三条免发条件：
  1. **In-place edits only**：本轮无新 canonical HTML 写出 → 不发 artifact，用户已能在面板看到文件、preview 自动反映改动
  2. **Body must be a complete `<!doctype html>` document**：永远不要把总结、prose、文件路径、bash 输出、说明文字塞进 `<artifact>` 标签里——不是完整文档就用普通回复
  3. **When in doubt, skip it**：重发未变 artifact 没价值；发空壳 artifact（标签包一句话）反而误导用户、污染项目文件面板

## 与 #50 / #1144 的关系

| 层级 | 作用 | 强度 |
|---|---|---|
| **本 PR (prompt 层)** | 让 AI 不去发空壳 artifact | 概率性服从 |
| #1144 (持久化层) | 挡住已经发出来的空壳 artifact | 强制力 |
| #50 (versioning) | 修旧版本被覆盖丢失 | 独立设计讨论中 |

#1144 是兜底，本 PR 是治本。两者互补、独立合并。

## 测试

`apps/daemon/tests/prompts/system.test.ts` 新增 describe 块 \`artifact handoff no-emit clauses (#1143)\` 4 例：

- 断言 \`non-negotiable output rule\` 不再出现
- 断言 \`When NOT to emit \\\`<artifact>\\\`\` 子段存在
- 断言 in-place edit 免发条款短语
- 断言完整 doctype 要求 + 总结/prose/路径不应包标签的指令存在

## 验证

- \`pnpm guard\` ✅
- \`pnpm typecheck\` ✅
- \`pnpm --filter @open-design/daemon test --run tests/prompts\` → 10/10 通过（含本 PR 新增 4 例）
- \`pnpm --filter @open-design/daemon test\` 全量：1491/1497 通过；6 例失败为 \`chat-route\` / \`finalize-design\` / \`project-file-rename\` 的 pre-existing failures（已在 clean main 上 stash 验证一致），与本 PR 无关

## Test plan

- [ ] 真实场景 A（应免发）：构造一次仅 Edit 工具的对话轮次，观察 AI 不再发出 \`<artifact>\` 标签收尾，仅简述改动
- [ ] 真实场景 B（仍应发）：构造一次写新 HTML 文件的对话轮次，观察 artifact handoff 行为不变
- [ ] 真实场景 C（边界）：写了新 HTML 但同时也 Edit 了旧文件 → AI 应仍发新 HTML 的 artifact，不应被误导跳过