### PR TITLE
Fix pending prompt clearing for templates

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -410,7 +410,7 @@ export function App() {
         p.id === projectId ? { ...p, pendingPrompt: undefined } : p,
       ),
     );
-    void patchProject(projectId, { pendingPrompt: undefined });
+    void patchProject(projectId, { pendingPrompt: null });
   }, [route]);
 
   const handleTouchProject = useCallback(() => {

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -306,7 +306,17 @@ export function ProjectView({
   // dropped), create one on the fly.
   useEffect(() => {
     let cancelled = false;
+    setConversations([]);
+    setActiveConversationId(null);
     setConversationLoadError(null);
+    setMessages([]);
+    setPreviewComments([]);
+    setAttachedComments([]);
+    setStreaming(false);
+    setError(null);
+    setArtifact(null);
+    savedArtifactRef.current = null;
+    pendingWritesRef.current.clear();
     (async () => {
       try {
         const list = await listConversations(project.id);
@@ -1733,25 +1743,29 @@ export function ProjectView({
     saveChatPanelWidth(next);
   }, [applyChatPanelWidth]);
 
-  // Hand the pending prompt to ChatPane exactly once. We snapshot the value
-  // into local state on mount so it survives the ChatPane remount triggered
-  // when `activeConversationId` resolves from `null` to a real id (the
-  // `key={activeConversationId}` on ChatPane otherwise wipes the freshly
-  // seeded composer draft). Once the conversation id is in place — meaning
-  // ChatPane has remounted with the seed still available — we clear both
-  // the local snapshot and the persisted pendingPrompt so future
-  // conversation switches don't keep re-seeding the composer.
-  const [initialDraft, setInitialDraft] = useState<string | undefined>(
-    project.pendingPrompt,
+  // Hand the pending prompt to ChatPane exactly once per project. The local
+  // project-scoped snapshot survives the conversation-id remount, while the
+  // persisted pendingPrompt is cleared so refreshes and later entries do not
+  // re-seed the composer.
+  const [initialDraft, setInitialDraft] = useState<
+    { projectId: string; value: string } | undefined
+  >(
+    project.pendingPrompt
+      ? { projectId: project.id, value: project.pendingPrompt }
+      : undefined,
   );
   useEffect(() => {
-    if (initialDraft && activeConversationId) {
-      setInitialDraft(undefined);
-    }
-  }, [initialDraft, activeConversationId]);
-  useEffect(() => {
-    if (project.pendingPrompt) onClearPendingPrompt();
-  }, [project.pendingPrompt, onClearPendingPrompt]);
+    const pendingPrompt = project.pendingPrompt;
+    if (!pendingPrompt) return;
+    setInitialDraft((current) =>
+      current?.projectId === project.id
+        ? current
+        : { projectId: project.id, value: pendingPrompt },
+    );
+    onClearPendingPrompt();
+  }, [project.id, project.pendingPrompt, onClearPendingPrompt]);
+  const chatInitialDraft =
+    initialDraft?.projectId === project.id ? initialDraft.value : undefined;
 
   return (
     <div className="app">
@@ -1811,7 +1825,7 @@ export function ProjectView({
             <ChatPane
               // The conversation id is part of the key so switching conversations
               // resets internal scroll/draft state inside ChatPane and ChatComposer.
-              key={activeConversationId ?? 'conversation-unavailable'}
+              key={`${project.id}:${activeConversationId ?? 'conversation-unavailable'}`}
               messages={messages}
               streaming={streaming}
               error={conversationLoadError ?? error}
@@ -1827,7 +1841,7 @@ export function ProjectView({
               onSend={handleSend}
               onStop={handleStop}
               onRequestOpenFile={requestOpenFile}
-              initialDraft={initialDraft}
+              initialDraft={chatInitialDraft}
               onSubmitForm={(text) => {
                 if (streaming) return;
                 void handleSend(text, [], []);

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -149,9 +149,13 @@ export async function deleteTemplate(id: string): Promise<boolean> {
   }
 }
 
+type ProjectPatch = Omit<Partial<Project>, 'pendingPrompt'> & {
+  pendingPrompt?: Project['pendingPrompt'] | null;
+};
+
 export async function patchProject(
   id: string,
-  patch: Partial<Project>,
+  patch: ProjectPatch,
 ): Promise<Project | null> {
   try {
     const resp = await fetch(`/api/projects/${encodeURIComponent(id)}`, {

--- a/apps/web/tests/components/NewProjectPanel.test.tsx
+++ b/apps/web/tests/components/NewProjectPanel.test.tsx
@@ -329,6 +329,7 @@ describe('NewProjectPanel design system defaults', () => {
         }),
       }),
     );
+    expect(templateOnCreate.mock.calls[0]?.[0]).not.toHaveProperty('pendingPrompt');
   });
 
   it('saves image creation with the selected aspect and trimmed style notes metadata', () => {

--- a/apps/web/tests/components/ProjectView.pendingPrompt.test.tsx
+++ b/apps/web/tests/components/ProjectView.pendingPrompt.test.tsx
@@ -1,0 +1,248 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ProjectView } from '../../src/components/ProjectView';
+import type {
+  AgentInfo,
+  AppConfig,
+  Conversation,
+  DesignSystemSummary,
+  Project,
+  SkillSummary,
+} from '../../src/types';
+import {
+  createConversation,
+  listConversations,
+  listMessages,
+} from '../../src/state/projects';
+import { fetchPreviewComments } from '../../src/providers/registry';
+
+vi.mock('../../src/i18n', () => ({
+  useT: () => (key: string) => key,
+}));
+
+vi.mock('../../src/router', () => ({
+  navigate: vi.fn(),
+}));
+
+vi.mock('../../src/providers/anthropic', () => ({
+  streamMessage: vi.fn(),
+}));
+
+vi.mock('../../src/providers/daemon', () => ({
+  fetchChatRunStatus: vi.fn(),
+  listActiveChatRuns: vi.fn().mockResolvedValue([]),
+  reattachDaemonRun: vi.fn(),
+  streamViaDaemon: vi.fn(),
+}));
+
+vi.mock('../../src/providers/project-events', () => ({
+  useProjectFileEvents: vi.fn(),
+}));
+
+vi.mock('../../src/providers/registry', async () => {
+  const actual = await vi.importActual<typeof import('../../src/providers/registry')>(
+    '../../src/providers/registry',
+  );
+  return {
+    ...actual,
+    deletePreviewComment: vi.fn(),
+    fetchDesignSystem: vi.fn(),
+    fetchLiveArtifacts: vi.fn().mockResolvedValue([]),
+    fetchPreviewComments: vi.fn(),
+    fetchProjectFiles: vi.fn().mockResolvedValue([]),
+    fetchSkill: vi.fn(),
+    getTemplate: vi.fn(),
+    patchPreviewCommentStatus: vi.fn(),
+    upsertPreviewComment: vi.fn(),
+    writeProjectTextFile: vi.fn(),
+  };
+});
+
+vi.mock('../../src/state/projects', async () => {
+  const actual = await vi.importActual<typeof import('../../src/state/projects')>(
+    '../../src/state/projects',
+  );
+  return {
+    ...actual,
+    createConversation: vi.fn(),
+    listConversations: vi.fn(),
+    listMessages: vi.fn(),
+    loadTabs: vi.fn().mockResolvedValue({ tabs: [], active: null }),
+    patchConversation: vi.fn(),
+    patchProject: vi.fn(),
+    saveMessage: vi.fn(),
+    saveTabs: vi.fn(),
+  };
+});
+
+vi.mock('../../src/components/AppChromeHeader', () => ({
+  AppChromeHeader: ({ children }: { children: ReactNode }) => (
+    <header>{children}</header>
+  ),
+}));
+
+vi.mock('../../src/components/AvatarMenu', () => ({
+  AvatarMenu: () => null,
+}));
+
+vi.mock('../../src/components/FileWorkspace', () => ({
+  FileWorkspace: () => <div data-testid="file-workspace" />,
+}));
+
+vi.mock('../../src/components/Loading', () => ({
+  CenteredLoader: () => <div data-testid="loader" />,
+}));
+
+vi.mock('../../src/components/ChatPane', () => ({
+  ChatPane: ({ initialDraft }: { initialDraft?: string }) => (
+    <textarea
+      data-testid="chat-composer-input"
+      readOnly
+      value={initialDraft ?? ''}
+    />
+  ),
+}));
+
+const mockedListConversations = vi.mocked(listConversations);
+const mockedCreateConversation = vi.mocked(createConversation);
+const mockedListMessages = vi.mocked(listMessages);
+const mockedFetchPreviewComments = vi.mocked(fetchPreviewComments);
+
+const config: AppConfig = {
+  mode: 'api',
+  apiKey: '',
+  baseUrl: '',
+  model: '',
+  agentId: null,
+  skillId: null,
+  designSystemId: null,
+};
+
+const project = (id: string, pendingPrompt?: string): Project => ({
+  id,
+  name: `Project ${id}`,
+  skillId: null,
+  designSystemId: null,
+  createdAt: 1,
+  updatedAt: 1,
+  ...(pendingPrompt ? { pendingPrompt } : {}),
+});
+
+const conversation = (projectId: string): Conversation => ({
+  id: `conv-${projectId}`,
+  projectId,
+  title: null,
+  createdAt: 1,
+  updatedAt: 1,
+});
+
+function renderProjectView(
+  currentProject: Project,
+  onClearPendingPrompt = vi.fn(),
+) {
+  return render(
+    <ProjectView
+      project={currentProject}
+      routeFileName={null}
+      config={config}
+      agents={[] as AgentInfo[]}
+      skills={[] as SkillSummary[]}
+      designSystems={[] as DesignSystemSummary[]}
+      daemonLive
+      onModeChange={vi.fn()}
+      onAgentChange={vi.fn()}
+      onAgentModelChange={vi.fn()}
+      onRefreshAgents={vi.fn()}
+      onOpenSettings={vi.fn()}
+      onBack={vi.fn()}
+      onClearPendingPrompt={onClearPendingPrompt}
+      onTouchProject={vi.fn()}
+      onProjectChange={vi.fn()}
+      onProjectsRefresh={vi.fn()}
+    />,
+  );
+}
+
+describe('ProjectView pending prompt seeding', () => {
+  beforeEach(() => {
+    mockedListConversations.mockImplementation(async (projectId) => [
+      conversation(projectId),
+    ]);
+    mockedCreateConversation.mockImplementation(async (projectId) =>
+      conversation(projectId),
+    );
+    mockedListMessages.mockResolvedValue([]);
+    mockedFetchPreviewComments.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('prefills chat once when the project has a pending prompt and requests persistence clear', async () => {
+    const onClearPendingPrompt = vi.fn();
+    renderProjectView(project('with-prompt', 'Use this prompt'), onClearPendingPrompt);
+
+    await waitFor(() => {
+      expect(composerValue()).toBe('Use this prompt');
+    });
+    expect(onClearPendingPrompt).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not prefill when re-entering a project after the pending prompt was cleared', async () => {
+    renderProjectView(project('cleared'));
+
+    await waitFor(() => {
+      expect(composerValue()).toBe('');
+    });
+  });
+
+  it('does not leak a prior project prompt into a template project without one', async () => {
+    const first = project('source', 'Old seed');
+    const second = {
+      ...project('template'),
+      metadata: { kind: 'template' as const, templateId: 'tmpl-1' },
+    };
+    const view = renderProjectView(first);
+
+    await waitFor(() => {
+      expect(composerValue()).toBe('Old seed');
+    });
+
+    view.rerender(
+      <ProjectView
+        project={second}
+        routeFileName={null}
+        config={config}
+        agents={[]}
+        skills={[]}
+        designSystems={[]}
+        daemonLive
+        onModeChange={vi.fn()}
+        onAgentChange={vi.fn()}
+        onAgentModelChange={vi.fn()}
+        onRefreshAgents={vi.fn()}
+        onOpenSettings={vi.fn()}
+        onBack={vi.fn()}
+        onClearPendingPrompt={vi.fn()}
+        onTouchProject={vi.fn()}
+        onProjectChange={vi.fn()}
+        onProjectsRefresh={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(composerValue()).toBe('');
+    });
+  });
+});
+
+function composerValue(): string {
+  return (screen.getByTestId('chat-composer-input') as HTMLTextAreaElement)
+    .value;
+}

--- a/apps/web/tests/state/projects.test.ts
+++ b/apps/web/tests/state/projects.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { patchProject } from '../../src/state/projects';
+
+describe('project persistence helpers', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('serializes pendingPrompt null so the daemon can clear it', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        project: {
+          id: 'project-1',
+          name: 'Project',
+          skillId: null,
+          designSystemId: null,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await patchProject('project-1', { pendingPrompt: null });
+
+    expect(JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string)).toEqual({
+      pendingPrompt: null,
+    });
+  });
+});


### PR DESCRIPTION
  Fixes #909

  ## Summary
  - Clear persisted `pendingPrompt` with `null` so the daemon
removes it instead of JSON dropping `undefined`.
  - Scope the initial composer draft snapshot by project id and
remount chat state by project + conversation.
  - Reset old conversation UI state immediately when switching
projects.
  - Ensure From template creation does not include
`pendingPrompt`.

  ## Tests
  - pnpm --filter @open-design/web test
  - pnpm --filter @open-design/web typecheck
  - pnpm guard
  - pnpm typecheck