### PR TITLE
fix(web): truncate entry footer pet label

### DIFF
--- a/apps/web/src/components/EntryView.tsx
+++ b/apps/web/src/components/EntryView.tsx
@@ -504,7 +504,7 @@ export function EntryView({
                     : '🐾'
                   : '🐾'}
               </span>
-              <span>
+              <span className="foot-pill-pet-label">
                 {config.pet?.adopted
                   ? t('pet.changePet')
                   : t('pet.adoptCallout')}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4701,6 +4701,7 @@ code {
 .entry-side-foot-row .foot-pill-follow {
   flex: 0 1 auto;
 }
+.entry-side-foot-row .foot-pill-pet-label,
 .entry-side-foot-row .foot-pill-follow-label {
   flex: 1 1 auto;
   min-width: 0;


### PR DESCRIPTION
## Summary
- make the entry footer pet label shrinkable with the same ellipsis behavior as the Follow label
- prevents long localized pet labels from forcing the compact footer row to overflow after #1045

## Validation
- `pnpm --filter @open-design/contracts build`
- `pnpm --filter @open-design/web typecheck`

Note: local Node is `v22.22.0`, so pnpm prints the existing engine warning for the repo's `~24` target.