### PR TITLE
fix(web): allow pod-to-chat comment text to wrap instead of truncating (#793)

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -872,7 +872,7 @@ function UserMessage({
             <span key={a.id} className="user-attachment staged-comment">
               <span className="staged-name">
                 <strong>{a.elementId}</strong>
-                <span>{a.comment}</span>
+                <span title={a.comment}>{a.comment}</span>
               </span>
             </span>
           ))}

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -870,9 +870,9 @@ function UserMessage({
         <div className="user-attachments comment-history-attachments">
           {commentAttachments.map((a) => (
             <span key={a.id} className="user-attachment staged-comment">
-              <span className="staged-name">
+              <span className="staged-name" title={`${a.elementId}: ${a.comment}`}>
                 <strong>{a.elementId}</strong>
-                <span title={a.comment}>{a.comment}</span>
+                <span>{a.comment}</span>
               </span>
             </span>
           ))}

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -1428,6 +1428,7 @@ function BoardComposerPopover({
   onDraft,
   onAddDraft,
   onRemoveQueuedNote,
+  onRemovePodMember,
   onClose,
   onSaveComment,
   onSendBatch,
@@ -1442,6 +1443,7 @@ function BoardComposerPopover({
   onDraft: (value: string) => void;
   onAddDraft: () => void;
   onRemoveQueuedNote: (index: number) => void;
+  onRemovePodMember: (elementId: string) => void;
   onClose: () => void;
   onSaveComment: () => void | Promise<void>;
   onSendBatch: () => void | Promise<void>;
@@ -1480,9 +1482,17 @@ function BoardComposerPopover({
         <div className="board-pod-summary">
           <strong>{target.memberCount || podMembers.length} captured items</strong>
           <div className="board-pod-members">
-            {podMembers.slice(0, 6).map((member) => (
+            {podMembers.map((member) => (
               <span key={member.elementId} className="board-pod-chip">
                 {summarizeMember(member)}
+                <button
+                  type="button"
+                  className="board-pod-chip-remove"
+                  title={t('chat.comments.removePodMember')}
+                  onClick={() => onRemovePodMember(member.elementId)}
+                >
+                  <Icon name="close" size={10} />
+                </button>
               </span>
             ))}
           </div>
@@ -4793,6 +4803,16 @@ function HtmlViewer({
                 onRemoveQueuedNote={(index) =>
                   setQueuedBoardNotes((current) => current.filter((_, currentIndex) => currentIndex !== index))
                 }
+                onRemovePodMember={(elementId) => {
+                  const current = activeCommentTarget;
+                  if (!current) return;
+                  const nextMembers = (current.podMembers ?? []).filter((m) => m.elementId !== elementId);
+                  if (nextMembers.length === 0) {
+                    clearBoardComposer();
+                  } else {
+                    setActiveCommentTarget({ ...current, podMembers: nextMembers, memberCount: nextMembers.length });
+                  }
+                }}
                 onClose={clearBoardComposer}
                 onSaveComment={savePersistentComment}
                 onSendBatch={sendBoardBatch}

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -1489,6 +1489,7 @@ function BoardComposerPopover({
                   type="button"
                   className="board-pod-chip-remove"
                   title={t('chat.comments.removePodMember')}
+                  aria-label={t('chat.comments.removePodMember')}
                   onClick={() => onRemovePodMember(member.elementId)}
                 >
                   <Icon name="close" size={10} />
@@ -3021,6 +3022,8 @@ function HtmlViewer({
     [],
   );
   const [activeCommentTarget, setActiveCommentTarget] = useState<PreviewCommentSnapshot | null>(null);
+  const activeCommentTargetRef = useRef(activeCommentTarget);
+  activeCommentTargetRef.current = activeCommentTarget;
   const [hoveredCommentTarget, setHoveredCommentTarget] = useState<PreviewCommentSnapshot | null>(null);
   const [liveCommentTargets, setLiveCommentTargets] = useState<Map<string, PreviewCommentSnapshot>>(() => new Map());
   const liveCommentTargetsRef = useRef(liveCommentTargets);
@@ -4804,7 +4807,7 @@ function HtmlViewer({
                   setQueuedBoardNotes((current) => current.filter((_, currentIndex) => currentIndex !== index))
                 }
                 onRemovePodMember={(elementId) => {
-                  const current = activeCommentTarget;
+                  const current = activeCommentTargetRef.current;
                   if (!current) return;
                   const nextMembers = (current.podMembers ?? []).filter((m) => m.elementId !== elementId);
                   if (nextMembers.length === 0) {

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -607,6 +607,7 @@ export const en: Dict = {
   'chat.comments.updateSend': 'Update & send',
   'chat.comments.removeAttachment': 'Remove comment attachment',
   'chat.comments.removeAttachmentAria': 'Remove comment attachment for {name}',
+  'chat.comments.removePodMember': 'Remove captured component',
   'chat.conversationsTitle': 'Conversations',
   'chat.conversationsAria': 'Conversation history',
   'chat.newConversation': 'New conversation',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -599,6 +599,7 @@ export const zhCN: Dict = {
   'chat.comments.placeholder': 'Comment on this element…',
   'chat.comments.addSend': 'Add & send',
   'chat.comments.updateSend': 'Update & send',
+  'chat.comments.removePodMember': 'Remove captured component',
   'chat.comments.removeAttachment': 'Remove comment attachment',
   'chat.comments.removeAttachmentAria': 'Remove comment attachment for {name}',
   'chat.conversationsTitle': '对话历史',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -759,6 +759,7 @@ export interface Dict {
   'chat.comments.updateSend': string;
   'chat.comments.removeAttachment': string;
   'chat.comments.removeAttachmentAria': string;
+  'chat.comments.removePodMember': string;
   'chat.conversationsTitle': string;
   'chat.conversationsAria': string;
   'chat.newConversation': string;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -838,6 +838,7 @@ code {
 .chat-log {
   flex: 1;
   overflow-y: auto;
+  overflow-x: hidden;
   padding: 16px;
   display: flex;
   flex-direction: column;
@@ -852,6 +853,8 @@ code {
   border: none;
   white-space: normal;
   word-wrap: break-word;
+  min-width: 0;
+  max-width: 100%;
 }
 .msg .role {
   display: flex;
@@ -9316,6 +9319,7 @@ button.ghost.mcp-copy-btn:hover:not(:disabled) {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  min-width: 0;
 }
 .prose-block { line-height: 1.6; color: var(--text); }
 .prose-block .md-p { margin: 0; }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -8509,6 +8509,8 @@ button.connector-action.is-loading {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
+  max-height: 120px;
+  overflow-y: auto;
 }
 .board-pod-chip {
   display: inline-flex;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1046,15 +1046,20 @@ code {
   object-fit: cover;
 }
 .staged-comment {
-  max-width: 100%;
   border-radius: var(--radius-pill);
   padding: 4px 6px 4px 10px;
+}
+.user-attachment.staged-comment {
+  max-width: 100%;
+  max-height: 200px;
+  overflow-y: auto;
 }
 .staged-comment .staged-name {
   display: inline-flex;
   align-items: center;
   gap: 6px;
   min-width: 0;
+  flex-wrap: wrap;
 }
 .staged-comment .staged-name strong {
   color: var(--accent-strong);

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -8511,12 +8511,34 @@ button.connector-action.is-loading {
   gap: 6px;
 }
 .board-pod-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   padding: 3px 7px;
   border: 1px solid var(--border-soft);
   border-radius: var(--radius-pill);
   background: var(--bg-panel);
   color: var(--text-muted);
   font-size: 11px;
+}
+.board-pod-chip-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  padding: 0;
+  margin: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-faint);
+  cursor: pointer;
+  line-height: 1;
+}
+.board-pod-chip-remove:hover {
+  background: var(--red-bg);
+  color: var(--red);
 }
 .board-note-list {
   display: grid;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1046,7 +1046,7 @@ code {
   object-fit: cover;
 }
 .staged-comment {
-  max-width: 280px;
+  max-width: 100%;
   border-radius: var(--radius-pill);
   padding: 4px 6px 4px 10px;
 }
@@ -1062,9 +1062,8 @@ code {
   flex: 0 0 auto;
 }
 .staged-comment .staged-name span {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  white-space: normal;
+  word-break: break-word;
 }
 .staged-comment button {
   width: 20px;


### PR DESCRIPTION
Fixes #793

## Problem

When sending content from Pods to Chat, the resulting comment attachment chips had a hard `max-width: 280px` and `white-space: nowrap`, causing long comments to be silently clipped with ellipsis. Users could not read the full transferred content.

## Changes

- `index.css`: increase `.staged-comment` max-width from `280px` to `100%` so chips use available space
- `index.css`: replace `white-space: nowrap` with `white-space: normal` and `word-break: break-word` on `.staged-comment .staged-name span`
- `ChatPane.tsx`: add `title={a.comment}` tooltip on the comment text span as a fallback

## Result

Long pod comments sent to chat now wrap across multiple lines instead of being truncated, making the full transferred content readable.