### PR TITLE
fix(web): allow pod-to-chat comment text to wrap instead of truncating (#793)

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -870,7 +870,7 @@ function UserMessage({
         <div className="user-attachments comment-history-attachments">
           {commentAttachments.map((a) => (
             <span key={a.id} className="user-attachment staged-comment">
-              <span className="staged-name">
+              <span className="staged-name" title={`${a.elementId}: ${a.comment}`}>
                 <strong>{a.elementId}</strong>
                 <span>{a.comment}</span>
               </span>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1043,15 +1043,20 @@ code {
   object-fit: cover;
 }
 .staged-comment {
-  max-width: 280px;
   border-radius: var(--radius-pill);
   padding: 4px 6px 4px 10px;
+}
+.user-attachment.staged-comment {
+  max-width: 100%;
+  max-height: 200px;
+  overflow-y: auto;
 }
 .staged-comment .staged-name {
   display: inline-flex;
   align-items: center;
   gap: 6px;
   min-width: 0;
+  flex-wrap: wrap;
 }
 .staged-comment .staged-name strong {
   color: var(--accent-strong);
@@ -1059,9 +1064,8 @@ code {
   flex: 0 0 auto;
 }
 .staged-comment .staged-name span {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  white-space: normal;
+  word-break: break-word;
 }
 .staged-comment button {
   width: 20px;


### PR DESCRIPTION
Fixes #793

## Problem

When sending content from Pods to Chat, the resulting comment attachment chips had a hard `max-width: 280px` and `white-space: nowrap`, causing long comments to be silently clipped with ellipsis. Users could not read the full transferred content.

## Changes

- `index.css`: scope `.staged-comment` width expansion to `.user-attachment.staged-comment` only, add `max-height: 200px` with `overflow-y: auto` to prevent extreme height, and add `flex-wrap: wrap` to `.staged-name` so `elementId` and `comment` can wrap independently
- `index.css`: replace `white-space: nowrap` with `white-space: normal` and `word-break: break-word` on the comment text span
- `ChatPane.tsx`: add `title={\`\${a.elementId}: \${a.comment}\`}` tooltip on `.staged-name`, matching the existing pattern in `ChatComposer.tsx`

## Result

Long pod comments sent to chat now wrap across multiple lines within a bounded chip instead of being truncated, making the full transferred content readable.