### PR TITLE
fix: set writable OD_DATA_DIR default for nix run

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -62,9 +62,14 @@
       # Wrap `od` with `--no-open` for `nix run`: the daemon package
       # builds the daemon workspace only, not `apps/web/out/`, so the
       # browser would otherwise auto-open onto an empty static dir.
+      #
+      # Set OD_DATA_DIR to a writable location when unset. The Nix store
+      # is read-only at runtime, so the daemon cannot write to its default
+      # `<projectRoot>/.od` location under `nix run`.
       apps.default = {
         type = "app";
         program = "${pkgs.writeShellScript "od-nix-run" ''
+          export OD_DATA_DIR="''${OD_DATA_DIR:-$HOME/.od}"
           exec ${daemon}/bin/od --no-open "$@"
         ''}";
         meta.description = "Open Design local daemon (`od`)";


### PR DESCRIPTION
Fixes #1157

## Problem

When running via `nix run github:nexu-io/open-design`, the daemon attempted to create runtime state under the Nix store package path:

```
/nix/store/.../lib/open-design/.od/projects
```

The Nix store is read-only at runtime, causing startup to fail with `ENOENT` when `mkdir()` tried to create the projects directory.

## Solution

Update the `nix run` wrapper to export `OD_DATA_DIR` with a writable default (`$HOME/.od`) when the variable is unset.

**Changes:**
- Modified `flake.nix` `apps.default` wrapper script
- Added `export OD_DATA_DIR="${OD_DATA_DIR:-$HOME/.od}"` before executing `od`
- Added explanatory comment documenting the Nix store read-only constraint

## Behavior

- **Default**: `nix run` now uses `$HOME/.od` for runtime state
- **Override**: Users can still set `OD_DATA_DIR` before running: `OD_DATA_DIR=/custom/path nix run ...`
- **Modules**: Home Manager and NixOS modules already set `OD_DATA_DIR`, so they are unaffected

## Testing

Verified the fix resolves the reported error. The daemon now starts successfully under `nix run` without requiring manual `OD_DATA_DIR` configuration.
