### PR TITLE
fix(pack): harden mac portable runtime bundling

### DIFF
--- a/apps/daemon/src/agents.ts
+++ b/apps/daemon/src/agents.ts
@@ -277,6 +277,8 @@ export const AGENT_DEFS = [
       { id: 'sonnet', label: 'Sonnet (alias)' },
       { id: 'opus', label: 'Opus (alias)' },
       { id: 'haiku', label: 'Haiku (alias)' },
+      { id: 'claude-opus-4-7', label: 'claude-opus-4-7' },
+      { id: 'claude-sonnet-4-6', label: 'claude-sonnet-4-6' },
       { id: 'claude-opus-4-5', label: 'claude-opus-4-5' },
       { id: 'claude-sonnet-4-5', label: 'claude-sonnet-4-5' },
       { id: 'claude-haiku-4-5', label: 'claude-haiku-4-5' },
@@ -444,6 +446,7 @@ export const AGENT_DEFS = [
       DEFAULT_MODEL_OPTION,
       // Gemini 3 (May 2026): top-tier reasoning + fast frontier-class.
       // Both currently ship as previews via the Gemini CLI. Issue #981.
+      { id: 'gemini-3.1-pro-preview', label: 'gemini-3.1-pro-preview' },
       { id: 'gemini-3-pro-preview', label: 'gemini-3-pro-preview' },
       { id: 'gemini-3-flash-preview', label: 'gemini-3-flash-preview' },
       { id: 'gemini-2.5-pro', label: 'gemini-2.5-pro' },

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -133,6 +133,8 @@ export interface AgentRefreshOptions {
 
 const SUGGESTED_MODELS_BY_PROTOCOL = {
   anthropic: [
+    'claude-opus-4-7',
+    'claude-sonnet-4-6',
     'claude-opus-4-5',
     'claude-sonnet-4-5',
     'claude-haiku-4-5',
@@ -150,6 +152,9 @@ const SUGGESTED_MODELS_BY_PROTOCOL = {
     'mimo-v2.5-pro',
   ],
   openai: [
+    'gpt-5.5',
+    'gpt-5-codex',
+    'gpt-5',
     'gpt-4o',
     'gpt-4o-mini',
     'o3',
@@ -213,6 +218,9 @@ const SUGGESTED_MODELS_BY_PROTOCOL = {
     'gpt-4o-mini',
   ],
   google: [
+    'gemini-3.1-pro-preview',
+    'gemini-2.5-pro',
+    'gemini-2.5-flash',
     'gemini-2.0-flash',
     'gemini-2.0-flash-lite',
     'gemini-1.5-pro',

--- a/tools/pack/resources/web-standalone-after-pack.cjs
+++ b/tools/pack/resources/web-standalone-after-pack.cjs
@@ -574,9 +574,19 @@ async function collectMacAdhocSignTargets(appPath) {
   return targets;
 }
 
+async function clearMacCodeSignMetadata(target) {
+  await execFileAsync("xattr", ["-cr", target], {
+    maxBuffer: 20 * 1024 * 1024,
+  });
+  await execFileAsync("xattr", ["-c", target], {
+    maxBuffer: 20 * 1024 * 1024,
+  });
+}
+
 async function signMacAdhocBundle(appPath) {
   const targets = await collectMacAdhocSignTargets(appPath);
   for (const target of targets) {
+    await clearMacCodeSignMetadata(target);
     await execFileAsync("codesign", ["--force", "--sign", "-", "--timestamp=none", target], {
       maxBuffer: 20 * 1024 * 1024,
     });

--- a/tools/pack/src/mac/app.ts
+++ b/tools/pack/src/mac/app.ts
@@ -120,6 +120,26 @@ async function buildPrebundledStandaloneRuntime(
   });
 }
 
+async function copyBundledNodeRuntime(paths: MacPaths): Promise<void> {
+  const bundledNodePath = join(paths.resourceRoot, "bin", "node");
+  await mkdir(join(paths.resourceRoot, "bin"), { recursive: true });
+  await cp(process.execPath, bundledNodePath);
+  await chmod(bundledNodePath, 0o755);
+
+  const hostNodeLibRoot = join(dirname(process.execPath), "..", "lib");
+  const hostNodeLibEntries = await readdir(hostNodeLibRoot).catch(() => []);
+  const libnodeEntries = hostNodeLibEntries.filter((entry) =>
+    /^libnode(?:\.\d+)?\.dylib$/.test(entry)
+  );
+  if (libnodeEntries.length === 0) return;
+
+  const bundledLibRoot = join(paths.resourceRoot, "lib");
+  await mkdir(bundledLibRoot, { recursive: true });
+  for (const entry of libnodeEntries) {
+    await cp(join(hostNodeLibRoot, entry), join(bundledLibRoot, entry));
+  }
+}
+
 export async function copyResourceTree(config: ToolPackConfig, paths: MacPaths): Promise<void> {
   await rm(paths.resourceRoot, { force: true, recursive: true });
   await mkdir(paths.resourceRoot, { recursive: true });
@@ -128,9 +148,7 @@ export async function copyResourceTree(config: ToolPackConfig, paths: MacPaths):
     workspaceRoot: config.workspaceRoot,
     resourceRoot: paths.resourceRoot,
   });
-  await mkdir(join(paths.resourceRoot, "bin"), { recursive: true });
-  await cp(process.execPath, join(paths.resourceRoot, "bin", "node"));
-  await chmod(join(paths.resourceRoot, "bin", "node"), 0o755);
+  await copyBundledNodeRuntime(paths);
 }
 
 export async function collectWorkspaceTarballs(


### PR DESCRIPTION
## Summary\n- preserve the local model picker additions on top of current main\n- clear macOS metadata before ad-hoc codesigning portable mac bundles\n- bundle Homebrew-style libnode dylibs alongside the packaged Node runtime\n\n## Validation\n- pnpm guard\n- pnpm --filter @open-design/daemon typecheck\n- pnpm --filter @open-design/web typecheck\n- pnpm --filter @open-design/tools-pack build\n- pnpm --filter @open-design/tools-pack test\n- pnpm tools-pack mac build --to app --portable --dir ~/open-design-tools-pack-build\n- codesign --verify --deep --strict --verbose=2 /Applications/Open Design.app\n- packaged desktop/daemon/web IPC status + /api/health\n\n## Data preservation\n- did not modify ~/Library/Application Support/Open Design or repo .od data\n- verified existing default namespace SQLite has 4 projects after update