### PR TITLE
fix(runtime): auto-annotate imported HTML elements for Tweaks selection (#892)

### DIFF
--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -254,12 +254,29 @@ function annotateMissingOdIds(doc: string): string {
   if (typeof DOMParser === 'undefined') return doc;
   try {
     const parsed = new DOMParser().parseFromString(doc, 'text/html');
-    const selector = 'section, article, header, footer, nav, main, aside, h1, h2, h3, h4, h5, h6, button, a, [id], div[class], div[id]';
+    // Only target divs that are direct children of semantic containers or body;
+    // deeply nested layout divs (e.g. flex/grid wrappers) create noise in the
+    // selection bridge without adding meaningful pickable targets.
+    const selector = [
+      'section', 'article', 'header', 'footer', 'nav', 'main', 'aside',
+      'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+      'button', 'a', '[id]',
+      'body > div[class]', 'body > div[id]',
+      'section > div[class]', 'section > div[id]',
+      'article > div[class]', 'article > div[id]',
+      'main > div[class]', 'main > div[id]',
+      'header > div[class]', 'header > div[id]',
+      'footer > div[class]', 'footer > div[id]',
+      'nav > div[class]', 'nav > div[id]',
+      'aside > div[class]', 'aside > div[id]',
+      '[id] > div[class]', '[id] > div[id]',
+    ].join(', ');
+    const skipTags = new Set(['script', 'style', 'template', 'noscript', 'iframe', 'object', 'embed']);
     let fallbackIndex = 0;
     parsed.body.querySelectorAll(selector).forEach((el) => {
       if (el.hasAttribute('data-od-id') || el.hasAttribute('data-screen-label')) return;
       const tag = el.tagName.toLowerCase();
-      if (tag === 'script' || tag === 'style' || tag === 'template' || tag === 'noscript') return;
+      if (skipTags.has(tag)) return;
       const path = sourcePathForElement(el);
       el.setAttribute('data-od-id', path || `od-${tag}-${fallbackIndex++}`);
     });

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -48,7 +48,9 @@ export function buildSrcdoc(
   </head>
   <body>${html}</body>
 </html>`;
-  const withSourcePaths = options.editBridge ? annotateManualEditSourcePaths(wrapped) : wrapped;
+  const needsOdIds = options.commentBridge || options.inspectBridge;
+  const withOdIds = needsOdIds ? annotateMissingOdIds(wrapped) : wrapped;
+  const withSourcePaths = options.editBridge ? annotateManualEditSourcePaths(withOdIds) : withOdIds;
   const withBase = options.baseHref ? injectBaseHref(withSourcePaths, options.baseHref) : withSourcePaths;
   const withShim = injectSandboxShim(withBase);
   const withDeck = options.deck ? injectDeckBridge(withShim, options.initialSlideIndex) : withShim;
@@ -240,6 +242,32 @@ function sourcePathForElement(el: Element): string {
 function serializeHtmlDocument(doc: Document): string {
   const doctype = doc.doctype ? '<!doctype html>\n' : '';
   return `${doctype}${doc.documentElement.outerHTML}`;
+}
+
+/**
+ * Auto-annotate structural HTML elements that lack `data-od-id` or
+ * `data-screen-label` so that the selection bridge (Picker / Pods /
+ * Tweaks) can target them. This fixes imported designs whose HTML was
+ * generated outside of Open Design and therefore carries no OD-specific
+ * annotations.
+ */
+function annotateMissingOdIds(doc: string): string {
+  if (typeof DOMParser === 'undefined') return doc;
+  try {
+    const parsed = new DOMParser().parseFromString(doc, 'text/html');
+    const selector = 'section, article, header, footer, nav, main, aside, [id]';
+    let fallbackIndex = 0;
+    parsed.body.querySelectorAll(selector).forEach((el) => {
+      if (el.hasAttribute('data-od-id') || el.hasAttribute('data-screen-label')) return;
+      const tag = el.tagName.toLowerCase();
+      if (tag === 'script' || tag === 'style' || tag === 'template' || tag === 'noscript') return;
+      const path = sourcePathForElement(el);
+      el.setAttribute('data-od-id', path || `od-${tag}-${fallbackIndex++}`);
+    });
+    return serializeHtmlDocument(parsed);
+  } catch {
+    return doc;
+  }
 }
 
 function injectManualEditBridge(doc: string): string {

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -48,8 +48,7 @@ export function buildSrcdoc(
   </head>
   <body>${html}</body>
 </html>`;
-  const needsOdIds = options.commentBridge || options.inspectBridge;
-  const withOdIds = needsOdIds ? annotateMissingOdIds(wrapped) : wrapped;
+  const withOdIds = annotateMissingOdIds(wrapped);
   const withSourcePaths = options.editBridge ? annotateManualEditSourcePaths(withOdIds) : withOdIds;
   const withBase = options.baseHref ? injectBaseHref(withSourcePaths, options.baseHref) : withSourcePaths;
   const withShim = injectSandboxShim(withBase);
@@ -255,7 +254,7 @@ function annotateMissingOdIds(doc: string): string {
   if (typeof DOMParser === 'undefined') return doc;
   try {
     const parsed = new DOMParser().parseFromString(doc, 'text/html');
-    const selector = 'section, article, header, footer, nav, main, aside, [id]';
+    const selector = 'section, article, header, footer, nav, main, aside, h1, h2, h3, h4, h5, h6, button, a, [id], div[class], div[id]';
     let fallbackIndex = 0;
     parsed.body.querySelectorAll(selector).forEach((el) => {
       if (el.hasAttribute('data-od-id') || el.hasAttribute('data-screen-label')) return;

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -216,7 +216,7 @@ function annotateManualEditSourcePaths(doc: string): string {
   try {
     const parsed = new DOMParser().parseFromString(doc, 'text/html');
     parsed.body.querySelectorAll(MANUAL_EDIT_DISCOVERY_SELECTOR).forEach((el) => {
-      if (el.hasAttribute('data-od-id')) return;
+      if (el.hasAttribute(MANUAL_EDIT_SOURCE_PATH_ATTR)) return;
       const path = sourcePathForElement(el);
       if (path) el.setAttribute(MANUAL_EDIT_SOURCE_PATH_ATTR, path);
     });

--- a/apps/web/tests/runtime/srcdoc.test.ts
+++ b/apps/web/tests/runtime/srcdoc.test.ts
@@ -254,39 +254,79 @@ describe('buildSrcdoc', () => {
     expect(srcdoc).not.toContain('<div data-od-id=');
   });
 
-  it('annotates direct-child divs under semantic containers and skips iframe/object/embed', () => {
+  it('auto-annotates direct-child divs with class or id under semantic containers', () => {
     const dom = new JSDOM('');
     globalThis.DOMParser = dom.window.DOMParser;
     const srcdoc = buildSrcdoc(
-      '<main><div class="card">A</div><iframe src="x"></iframe></main>',
-      { commentBridge: true },
+      '<section><div class="wrapper">Wrapper</div><div id="named">Named</div></section>',
+      {},
     );
     Reflect.deleteProperty(globalThis, 'DOMParser');
 
-    expect(srcdoc).toContain('<div class="card" data-od-id=');
+    // Direct-child divs under section get data-od-id
+    expect(srcdoc).toContain('<div class="wrapper" data-od-id=');
+    expect(srcdoc).toContain('<div id="named" data-od-id=');
+  });
+
+  it('skips deeply nested divs to avoid layout-noise in the selection bridge', () => {
+    const dom = new JSDOM('');
+    globalThis.DOMParser = dom.window.DOMParser;
+    const srcdoc = buildSrcdoc(
+      '<section><div class="outer"><div class="inner">Deep</div></div></section>',
+      {},
+    );
+    Reflect.deleteProperty(globalThis, 'DOMParser');
+
+    // The outer div is a direct child of section, so it gets annotated
+    expect(srcdoc).toContain('<div class="outer" data-od-id=');
+    // The inner div is nested two levels deep; it must NOT get annotated
+    expect(srcdoc).not.toContain('<div class="inner" data-od-id=');
+  });
+
+  it('auto-annotates even when no bridge flags are set (always-on for persistence)', () => {
+    const dom = new JSDOM('');
+    globalThis.DOMParser = dom.window.DOMParser;
+    const srcdoc = buildSrcdoc(
+      '<article><h1>Title</h1></article>',
+      {},
+    );
+    Reflect.deleteProperty(globalThis, 'DOMParser');
+
+    // Without commentBridge or inspectBridge, annotation still runs so that
+    // saved inspect tweaks (which reference data-od-id selectors) survive
+    // when the user later leaves inspect mode.
+    expect(srcdoc).toContain('<article data-od-id=');
+    expect(srcdoc).toContain('<h1 data-od-id=');
+  });
+
+  it('skips iframe, object, and embed tags from auto-annotation even when they have id', () => {
+    const dom = new JSDOM('');
+    globalThis.DOMParser = dom.window.DOMParser;
+    const srcdoc = buildSrcdoc(
+      '<section><iframe src="x"></iframe><object data="x"></object><embed src="x"></embed><iframe id="framed" src="y"></iframe></section>',
+      {},
+    );
+    Reflect.deleteProperty(globalThis, 'DOMParser');
+
     expect(srcdoc).not.toContain('<iframe data-od-id=');
+    expect(srcdoc).not.toContain('<object data-od-id=');
+    expect(srcdoc).not.toContain('<embed data-od-id=');
+    expect(srcdoc).not.toContain('<iframe id="framed" data-od-id=');
   });
 
-  it('always annotates missing od-ids even when no selection bridge is requested', () => {
-    const dom = new JSDOM('');
-    globalThis.DOMParser = dom.window.DOMParser;
-    const srcdoc = buildSrcdoc('<section><h1>Title</h1></section>', {});
-    Reflect.deleteProperty(globalThis, 'DOMParser');
-
-    expect(srcdoc).toContain('data-od-id=');
-    expect(srcdoc).not.toContain('data-od-selection-bridge');
-  });
-
-  it('annotates div children of [id] elements but not nested anonymous divs', () => {
+  it('annotates div children of elements with id', () => {
     const dom = new JSDOM('');
     globalThis.DOMParser = dom.window.DOMParser;
     const srcdoc = buildSrcdoc(
-      '<div id="root"><div class="child">A</div><div><div class="nested">B</div></div></div>',
-      { commentBridge: true },
+      '<div id="wrapper"><div class="content">Content</div><div id="named">Named</div></div>',
+      {},
     );
     Reflect.deleteProperty(globalThis, 'DOMParser');
 
-    expect(srcdoc).toContain('<div class="child" data-od-id=');
-    expect(srcdoc).not.toContain('<div class="nested" data-od-id=');
+    // The wrapper div itself is matched by [id] and gets annotated
+    expect(srcdoc).toContain('<div id="wrapper" data-od-id=');
+    // Its direct-child divs are matched by [id] > div[class] / [id] > div[id]
+    expect(srcdoc).toContain('<div class="content" data-od-id=');
+    expect(srcdoc).toContain('<div id="named" data-od-id=');
   });
 });

--- a/apps/web/tests/runtime/srcdoc.test.ts
+++ b/apps/web/tests/runtime/srcdoc.test.ts
@@ -217,4 +217,76 @@ describe('buildSrcdoc', () => {
     expect(srcdoc).not.toContain("type: 'od:comment-target'");
     expect(srcdoc).not.toContain("type: 'od:inspect-overrides'");
   });
+
+  // Regression for nexu-io/open-design#892: imported designs (e.g. Claude
+  // Design ZIP) may not carry data-od-id annotations. The selection bridge
+  // depends on these attributes to identify clickable targets, so we
+  // auto-annotate structural elements when they are missing.
+  it('auto-annotates imported HTML that lacks data-od-id or data-screen-label', () => {
+    const dom = new JSDOM('');
+    globalThis.DOMParser = dom.window.DOMParser;
+    const srcdoc = buildSrcdoc(
+      '<section><h1>Title</h1></div></section><article>Body</article>',
+      { commentBridge: true },
+    );
+    Reflect.deleteProperty(globalThis, 'DOMParser');
+
+    // Structural elements get path-based data-od-id
+    expect(srcdoc).toContain('data-od-id="');
+    // Script / style elements are skipped
+    expect(srcdoc).not.toContain('<script data-od-id=');
+  });
+
+  it('does not overwrite existing data-od-id or data-screen-label annotations', () => {
+    const dom = new JSDOM('');
+    globalThis.DOMParser = dom.window.DOMParser;
+    const srcdoc = buildSrcdoc(
+      '<section data-od-id="hero">Hero</section><div data-screen-label="cta">CTA</div>',
+      { commentBridge: true },
+    );
+    Reflect.deleteProperty(globalThis, 'DOMParser');
+
+    // Existing annotations must be preserved intact on their elements.
+    expect(srcdoc).toContain('<section data-od-id="hero">');
+    expect(srcdoc).toContain('<div data-screen-label="cta">');
+    // The div already has data-screen-label, so it must not get a fallback
+    // data-od-id injected by auto-annotation.
+    expect(srcdoc).not.toContain('<div data-od-id=');
+  });
+
+  it('annotates direct-child divs under semantic containers and skips iframe/object/embed', () => {
+    const dom = new JSDOM('');
+    globalThis.DOMParser = dom.window.DOMParser;
+    const srcdoc = buildSrcdoc(
+      '<main><div class="card">A</div><iframe src="x"></iframe></main>',
+      { commentBridge: true },
+    );
+    Reflect.deleteProperty(globalThis, 'DOMParser');
+
+    expect(srcdoc).toContain('<div class="card" data-od-id=');
+    expect(srcdoc).not.toContain('<iframe data-od-id=');
+  });
+
+  it('always annotates missing od-ids even when no selection bridge is requested', () => {
+    const dom = new JSDOM('');
+    globalThis.DOMParser = dom.window.DOMParser;
+    const srcdoc = buildSrcdoc('<section><h1>Title</h1></section>', {});
+    Reflect.deleteProperty(globalThis, 'DOMParser');
+
+    expect(srcdoc).toContain('data-od-id=');
+    expect(srcdoc).not.toContain('data-od-selection-bridge');
+  });
+
+  it('annotates div children of [id] elements but not nested anonymous divs', () => {
+    const dom = new JSDOM('');
+    globalThis.DOMParser = dom.window.DOMParser;
+    const srcdoc = buildSrcdoc(
+      '<div id="root"><div class="child">A</div><div><div class="nested">B</div></div></div>',
+      { commentBridge: true },
+    );
+    Reflect.deleteProperty(globalThis, 'DOMParser');
+
+    expect(srcdoc).toContain('<div class="child" data-od-id=');
+    expect(srcdoc).not.toContain('<div class="nested" data-od-id=');
+  });
 });


### PR DESCRIPTION
Fixes #892

## Problem

Designs imported from external sources do not always carry stable Open Design target annotations. Without a usable `data-od-id` / screen label target, Picker, Pods, and Tweaks selection can silently fail on common imported HTML.

## Changes

- Add fallback `data-od-id` annotation for imported markup that lacks existing Open Design target attributes.
- Run the fallback annotation consistently across render modes so saved Inspect/Tweaks selectors keep matching after users leave Inspect mode.
- Keep manual-edit source-path markers intact by allowing source-path annotation even when fallback `data-od-id` values are present.
- Expand selector coverage for common imported HTML shapes such as headings, buttons, links, and direct-child div wrappers while preserving existing annotations.
- Add regression coverage for imported annotation, selector persistence, and manual-edit source mapping.

## Result

Imported designs can be selected in Picker / Pods / Tweaks more reliably, and saved tweaks no longer disappear when the preview switches out of the bridge mode that first created the fallback ids.

## Surface area
- [x] UI
- [ ] Keyboard shortcut
- [ ] CLI
- [ ] env var
- [ ] API
- [x] Default behavior change
- [ ] i18n keys
- [ ] Extension point
- [ ] New top-level dependency
- [ ] None

## Validation
- GitHub CI on the rebased head is green: `build` and `Validate workspace` passed.
- Reviewer re-check confirmed the persistence gap, selector coverage, and manual-edit source-path pipeline issue are addressed on the current head.