### PR TITLE
fix: resolve mobile frame screen paths as project files

### DIFF
--- a/apps/daemon/src/prompts/discovery.ts
+++ b/apps/daemon/src/prompts/discovery.ts
@@ -243,13 +243,15 @@ project/
 Then in \`index.html\` use:
 
 \`\`\`html
-<iframe src="/frames/iphone-15-pro.html?screen=screens/01-onboarding.html"
+<iframe src="/frames/iphone-15-pro.html?screen=screens/01-onboarding.html&project=PROJECT_ID"
         width="390" height="844" loading="lazy"></iframe>
-<iframe src="/frames/iphone-15-pro.html?screen=screens/02-paywall.html"
+<iframe src="/frames/iphone-15-pro.html?screen=screens/02-paywall.html&project=PROJECT_ID"
         width="390" height="844" loading="lazy"></iframe>
-<iframe src="/frames/iphone-15-pro.html?screen=screens/03-home.html"
+<iframe src="/frames/iphone-15-pro.html?screen=screens/03-home.html&project=PROJECT_ID"
         width="390" height="844" loading="lazy"></iframe>
 \`\`\`
+
+Replace \`PROJECT_ID\` with the actual project identifier. The \`project\` parameter tells the frame to resolve \`screen\` paths as project files via \`/api/projects/{project}/files/{screen}\` instead of treating them as relative URLs.
 
 The single-screen \`mobile-app\` skill already inlines the iPhone frame in its seed; you only need the shared frames for the multi-device / multi-screen case. Don't re-draw — use these.
 

--- a/assets/frames/android-pixel.html
+++ b/assets/frames/android-pixel.html
@@ -1,7 +1,12 @@
 <!doctype html>
 <!--
   Shared frame: Pixel 8 Pro (412 × 900).
-  Usage:  <iframe src="android-pixel.html?screen=path/to/screen.html"></iframe>
+  Usage:  <iframe src="android-pixel.html?screen=path/to/screen.html&project=PROJECT_ID"></iframe>
+  
+  Parameters:
+    - screen: Path to the screen HTML file
+    - project: Project ID to resolve screen as a project file via /api/projects/{project}/files/{screen}
+               (omit to treat screen as an absolute or relative URL for legacy compatibility)
 -->
 <html lang="en">
 <head>
@@ -149,9 +154,24 @@
   <script>
     (function () {
       var qs = new URLSearchParams(location.search);
-      var src = qs.get('screen');
+      var screen = qs.get('screen');
+      var project = qs.get('project');
       var iframe = document.getElementById('screen');
-      if (src) iframe.src = src;
+      
+      if (screen) {
+        // If project ID is provided, resolve screen path as a project file.
+        // Otherwise, treat screen as an absolute or relative URL (legacy behavior).
+        if (project) {
+          // Validate screen parameter to prevent path traversal
+          if (!/^[a-zA-Z0-9_\/-]+\.html$/.test(screen)) {
+            console.error('Invalid screen path:', screen);
+            return;
+          }
+          iframe.src = '/api/projects/' + encodeURIComponent(project) + '/files/' + screen;
+        } else {
+          iframe.src = screen;
+        }
+      }
     })();
   </script>
 </body>

--- a/assets/frames/ipad-pro.html
+++ b/assets/frames/ipad-pro.html
@@ -1,7 +1,12 @@
 <!doctype html>
 <!--
   Shared frame: iPad Pro 11" (834 × 1194 logical, displayed at 70% scale).
-  Usage:  <iframe src="ipad-pro.html?screen=path/to/screen.html"></iframe>
+  Usage:  <iframe src="ipad-pro.html?screen=path/to/screen.html&project=PROJECT_ID"></iframe>
+  
+  Parameters:
+    - screen: Path to the screen HTML file
+    - project: Project ID to resolve screen as a project file via /api/projects/{project}/files/{screen}
+               (omit to treat screen as an absolute or relative URL for legacy compatibility)
 -->
 <html lang="en">
 <head>
@@ -87,9 +92,24 @@
   <script>
     (function () {
       var qs = new URLSearchParams(location.search);
-      var src = qs.get('screen');
+      var screen = qs.get('screen');
+      var project = qs.get('project');
       var iframe = document.getElementById('screen');
-      if (src) iframe.src = src;
+      
+      if (screen) {
+        // If project ID is provided, resolve screen path as a project file.
+        // Otherwise, treat screen as an absolute or relative URL (legacy behavior).
+        if (project) {
+          // Validate screen parameter to prevent path traversal
+          if (!/^[a-zA-Z0-9_\/-]+\.html$/.test(screen)) {
+            console.error('Invalid screen path:', screen);
+            return;
+          }
+          iframe.src = '/api/projects/' + encodeURIComponent(project) + '/files/' + screen;
+        } else {
+          iframe.src = screen;
+        }
+      }
     })();
   </script>
 </body>

--- a/assets/frames/iphone-15-pro.html
+++ b/assets/frames/iphone-15-pro.html
@@ -1,9 +1,14 @@
 <!doctype html>
 <!--
   Shared frame: iPhone 15 Pro (390 × 844).
-  Usage:  <iframe src="iphone-15-pro.html?screen=path/to/screen.html"></iframe>
+  Usage:  <iframe src="iphone-15-pro.html?screen=path/to/screen.html&project=PROJECT_ID"></iframe>
   Renders: the bezel + Dynamic Island + status bar + home indicator,
            with the ?screen content embedded as an iframe in the screen area.
+  
+  Parameters:
+    - screen: Path to the screen HTML file
+    - project: Project ID to resolve screen as a project file via /api/projects/{project}/files/{screen}
+               (omit to treat screen as an absolute or relative URL for legacy compatibility)
 -->
 <html lang="en">
 <head>
@@ -166,9 +171,24 @@
   <script>
     (function () {
       var qs = new URLSearchParams(location.search);
-      var src = qs.get('screen');
+      var screen = qs.get('screen');
+      var project = qs.get('project');
       var iframe = document.getElementById('screen');
-      if (src) iframe.src = src;
+      
+      if (screen) {
+        // If project ID is provided, resolve screen path as a project file.
+        // Otherwise, treat screen as an absolute or relative URL (legacy behavior).
+        if (project) {
+          // Validate screen parameter to prevent path traversal
+          if (!/^[a-zA-Z0-9_\/-]+\.html$/.test(screen)) {
+            console.error('Invalid screen path:', screen);
+            return;
+          }
+          iframe.src = '/api/projects/' + encodeURIComponent(project) + '/files/' + screen;
+        } else {
+          iframe.src = screen;
+        }
+      }
     })();
   </script>
 </body>


### PR DESCRIPTION
Fixes #1087

## Problem
Mobile frame loaders (iPhone, Android Pixel, iPad) were treating the `screen` query parameter as a relative URL, causing the browser to resolve paths like `screens/start.html` relative to `/frames/`, resulting in 404 errors: `Cannot GET /frames/screens/start.html`.

## Root Cause
The frame HTML files used `iframe.src = src` directly, which made the browser resolve relative paths against the frame's own location (`/frames/iphone-15-pro.html`) instead of the project root.

## Solution
Add `project` parameter support to all mobile frame loaders:
- When `project` is provided, resolve `screen` as a project file via `/api/projects/{project}/files/{screen}`
- When `project` is omitted, treat `screen` as an absolute or relative URL (legacy behavior for backward compatibility)
- Add path validation to prevent traversal attacks

## Changes
1. **Frame loaders** (iphone-15-pro.html, android-pixel.html, ipad-pro.html):
   - Add `project` parameter parsing
   - Add screen path validation (alphanumeric, hyphens, underscores, slashes, .html)
   - Construct API path when project is provided
   - Update usage comments with parameter documentation

2. **Discovery prompt** (apps/daemon/src/prompts/discovery.ts):
   - Update iframe examples to include `&project=PROJECT_ID`
   - Add explanation of project parameter behavior

## Testing
Verified that:
- With `project` param: `screen=screens/start.html` resolves to `/api/projects/{id}/files/screens/start.html`
- Without `project` param: `screen=https://example.com/page.html` works (legacy)
- Invalid paths (e.g., `../../../etc/passwd`) are rejected

This matches the existing behavior in browser-chrome.html and other desktop frame loaders.