### PR TITLE
feat: add success feedback after saving API keys

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -2492,7 +2492,7 @@ function ConnectorSection({
   // completes, the daemon returns a tail-only echo, and we land in
   // the saved state with the same UI as a key loaded from disk.
   const [keySaveStatus, setKeySaveStatus] =
-    useState<'idle' | 'saving' | 'error'>('idle');
+    useState<'idle' | 'saving' | 'success' | 'error'>('idle');
   const [catalogRefreshNonce, setCatalogRefreshNonce] = useState(0);
   const handleSaveKey = async () => {
     if (keySaveStatus === 'saving') return;
@@ -2513,7 +2513,11 @@ function ConnectorSection({
         apiKeyTail: pendingKey.trim().slice(-4),
       });
       setCatalogRefreshNonce((nonce) => nonce + 1);
-      setKeySaveStatus('idle');
+      // Show success state for 2 seconds before returning to idle
+      setKeySaveStatus('success');
+      setTimeout(() => {
+        setKeySaveStatus('idle');
+      }, 2000);
     } catch {
       setKeySaveStatus('error');
     }
@@ -2693,7 +2697,7 @@ function ConnectorSection({
           </span>
           <button
             type="button"
-            className={'primary settings-connectors-save' + (keySaveStatus === 'saving' ? ' is-busy' : '')}
+            className={'primary settings-connectors-save' + (keySaveStatus === 'saving' ? ' is-busy' : '') + (keySaveStatus === 'success' ? ' is-success' : '')}
             disabled={saveDisabled}
             onClick={() => void handleSaveKey()}
             title={
@@ -2706,6 +2710,11 @@ function ConnectorSection({
               <>
                 <Icon name="spinner" size={12} className="icon-spin" />
                 <span>{t('settings.connectorsKeySaving')}</span>
+              </>
+            ) : keySaveStatus === 'success' ? (
+              <>
+                <Icon name="check" size={12} />
+                <span>{t('settings.connectorsKeySaved')}</span>
               </>
             ) : (
               t('settings.connectorsSaveKey')

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1252,6 +1252,7 @@ export const en: Dict = {
   'settings.connectorsSaveKey': 'Save key',
   'settings.connectorsSaveKeyTitle': 'Send this key to the local daemon',
   'settings.connectorsKeySaving': 'Saving\u2026',
+  'settings.connectorsKeySaved': 'Saved',
   'settings.connectorsKeyError': 'Couldn\u2019t save the key. Check that the local daemon is running and try again.',
   'settings.connectorsHelpSaved': 'Your key is saved in the local daemon. Paste a new key to replace it, or Clear to remove.',
   'settings.connectorsHelpUnsaved': 'Unsaved changes \u2014 click Save key to store this credential in the local daemon and refresh the catalog below.',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -258,6 +258,7 @@ export interface Dict {
   'settings.connectorsSaveKey': string;
   'settings.connectorsSaveKeyTitle': string;
   'settings.connectorsKeySaving': string;
+  'settings.connectorsKeySaved': string;
   'settings.connectorsKeyError': string;
   'settings.connectorsHelpSaved': string;
   'settings.connectorsHelpUnsaved': string;


### PR DESCRIPTION
Fixes #654

## Problem
After clicking "Save key" in the Composio section of Settings, the button immediately returns to its default state without providing clear confirmation that the key was saved successfully. Users have to reopen Settings or look for indirect signals to verify the save worked.

## Solution
Add explicit success feedback to the "Save key" button:
- Show "Saved ✓" state for 2 seconds after successful save
- Display check icon alongside success message
- Add 'success' to keySaveStatus state machine
- Button automatically returns to idle state after 2s

## Changes
1. **SettingsDialog.tsx**:
   - Update keySaveStatus type: 'idle' | 'saving' | 'success' | 'error'
   - Modify handleSaveKey to set 'success' state with 2s timeout
   - Add success state rendering in button UI with check icon
   - Add 'is-success' CSS class for styling

2. **i18n/locales/en.ts**:
   - Add 'settings.connectorsKeySaved': 'Saved' translation

3. **i18n/types.ts**:
   - Add 'settings.connectorsKeySaved' to Dict type

## User Experience
**Before:** Save key → [button returns to "Save key"] → user unsure

**After:** Save key → ["Saving..."] → ["Saved ✓" for 2s] → ["Save key"]

This matches the pattern used in the Media Providers reload button and provides clear, immediate feedback that the save succeeded.

## Testing
1. Open Settings → Composio
2. Enter a Composio API key
3. Click "Save key"
4. Observe:
   - Button shows "Saving..." with spinner
   - Button changes to "Saved" with check icon
   - After 2 seconds, button returns to "Save key"
5. Verify the key is actually saved (check the "Saved · ••••XXXX" badge appears)