### PR TITLE
feat: add success feedback when saving templates

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -2959,6 +2959,7 @@ function HtmlViewer({
   // Template save UX. We surface a transient "Saved" pill in the share
   // menu so the user gets feedback without a noisy toast layer.
   const [savingTemplate, setSavingTemplate] = useState(false);
+  const [templateSaveSuccess, setTemplateSaveSuccess] = useState(false);
   const [templateNote, setTemplateNote] = useState<string | null>(null);
   const [templateModalOpen, setTemplateModalOpen] = useState(false);
   const [templateName, setTemplateName] = useState('');
@@ -3932,6 +3933,7 @@ function HtmlViewer({
     setSavingTemplate(true);
     setTemplateNote(null);
     setTemplateSaveError(null);
+    setTemplateSaveSuccess(false);
     let savedName: string | null = null;
     try {
       const tpl = await saveTemplate({
@@ -3944,9 +3946,14 @@ function HtmlViewer({
         return;
       }
       savedName = tpl.name;
-      setTemplateModalOpen(false);
-      setTemplateName('');
-      setTemplateDescription('');
+      // Show success state for 1.5 seconds before closing
+      setTemplateSaveSuccess(true);
+      setTimeout(() => {
+        setTemplateModalOpen(false);
+        setTemplateName('');
+        setTemplateDescription('');
+        setTemplateSaveSuccess(false);
+      }, 1500);
       setTemplateNote(t('fileViewer.savedTemplate', { name: tpl.name }));
     } finally {
       setSavingTemplate(false);
@@ -4957,6 +4964,7 @@ function HtmlViewer({
                 />
               </label>
               {templateSaveError ? <p className="deploy-error">{templateSaveError}</p> : null}
+              {templateSaveSuccess ? <p className="deploy-success">{t('fileViewer.templateSaveSuccess')}</p> : null}
             </div>
             <div className="modal-foot">
               <button
@@ -4973,12 +4981,12 @@ function HtmlViewer({
               <button
                 type="button"
                 className="viewer-action primary"
-                disabled={savingTemplate || !templateName.trim()}
+                disabled={savingTemplate || templateSaveSuccess || !templateName.trim()}
                 onClick={() => {
                   void handleSaveAsTemplate();
                 }}
               >
-                {savingTemplate ? t('fileViewer.savingTemplate') : t('common.save')}
+                {savingTemplate ? t('fileViewer.savingTemplate') : templateSaveSuccess ? t('fileViewer.templateSaved') : t('common.save')}
               </button>
             </div>
           </div>

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -885,6 +885,8 @@ export const en: Dict = {
   'fileViewer.saveAsTemplate': 'Save as template…',
   'fileViewer.savingTemplate': 'Saving template…',
   'fileViewer.savedTemplate': 'Saved as "{name}"',
+  'fileViewer.templateSaved': 'Saved',
+  'fileViewer.templateSaveSuccess': 'Template saved successfully',
   'fileViewer.savedTemplateFail': 'Could not save template — try again.',
   'fileViewer.templateNamePrompt': 'Template name',
   'fileViewer.templateNameDefault': 'Untitled template',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -1034,6 +1034,8 @@ export interface Dict {
   'fileViewer.saveAsTemplate': string;
   'fileViewer.savingTemplate': string;
   'fileViewer.savedTemplate': string;
+  'fileViewer.templateSaved': string;
+  'fileViewer.templateSaveSuccess': string;
   'fileViewer.savedTemplateFail': string;
   'fileViewer.templateNamePrompt': string;
   'fileViewer.templateNameDefault': string;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -10102,6 +10102,10 @@ button.ghost.mcp-copy-btn:hover:not(:disabled) {
   margin: 0;
   color: var(--red);
 }
+.deploy-success {
+  margin: 0;
+  color: var(--green);
+}
 .deploy-result-block {
   overflow: hidden;
   border: 1px solid var(--border);


### PR DESCRIPTION
Fixes #1190

## Problem
When saving an artifact as a template, clicking "Save" provides no visible feedback about whether the action succeeded or failed. The dialog closes immediately, leaving users uncertain whether the template was actually saved.

## Solution
Add explicit success feedback in the "Save as template" dialog:
- Show success message in the dialog for 1.5 seconds
- Update Save button to show "Saved" state
- Delay dialog close to let users see the confirmation
- Add green success message below the form

## Changes
1. **FileViewer.tsx**:
   - Add templateSaveSuccess state
   - Modify handleSaveAsTemplate to show success state
   - Delay dialog close by 1.5s after successful save
   - Update Save button to show "Saved" when success
   - Add success message display in dialog
   - Disable button during success state

2. **i18n/locales/en.ts**:
   - Add 'fileViewer.templateSaved': 'Saved'
   - Add 'fileViewer.templateSaveSuccess': 'Template saved successfully'

3. **i18n/types.ts**:
   - Add templateSaved and templateSaveSuccess to Dict type

4. **index.css**:
   - Add .deploy-success style (green color)

## User Experience
**Before:**
Save → [dialog closes immediately] → user unsure if saved

**After:**
Save → ["Saving template..."] → ["Saved" + success message for 1.5s] → [dialog closes]

## Testing
1. Open an artifact
2. Click "Save as template"
3. Enter template name
4. Click "Save"
5. Observe:
   - Button shows "Saving template..."
   - Button changes to "Saved"
   - Green success message appears
   - Dialog closes after 1.5 seconds
6. Verify template appears in template list