### PR TITLE
feat: add validation and error feedback for invalid file paths

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -603,7 +603,9 @@ export function App() {
 
   const handleImportFolder = useCallback(async (baseDir: string) => {
     const result = await importFolderProject({ baseDir });
-    if (!result) return;
+    if (!result) {
+      throw new Error('Could not import folder. The path may be invalid or inaccessible.');
+    }
     setProjects((curr) => [result.project, ...curr.filter((p) => p.id !== result.project.id)]);
     navigate({
       kind: 'project',

--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -468,9 +468,25 @@ export function NewProjectPanel({
     if (!onImportFolder) return;
     const trimmed = baseDir.trim();
     if (!trimmed) return;
+    
+    // Validate path before attempting import
+    if (!trimmed.startsWith('/')) {
+      setImportFolderError({
+        message: 'Invalid path',
+        details: 'Path must be an absolute path starting with /',
+      });
+      return;
+    }
+    
+    setImportFolderError(null);
     setImportingFolder(true);
     try {
       await onImportFolder(trimmed);
+    } catch (err) {
+      setImportFolderError({
+        message: 'Failed to import folder',
+        details: err instanceof Error ? err.message : 'Unknown error',
+      });
     } finally {
       setImportingFolder(false);
     }


### PR DESCRIPTION
Fixes #1186

## Problem
When the user enters an invalid file path in the project creation panel, the app proceeds without validation or error feedback. This creates confusion and potentially empty projects.

## Solution
Add path validation and error handling:
1. Validate that path is absolute (starts with /)
2. Show clear error message for invalid paths
3. Catch API failures and display error details
4. Prevent project creation until path is valid

## Changes
1. **NewProjectPanel.tsx**:
   - Add path validation before import
   - Check if path starts with '/'
   - Set importFolderError for invalid paths
   - Wrap onImportFolder in try-catch
   - Display error message to user
   - Clear error on valid path

2. **App.tsx**:
   - Modify handleImportFolder to throw error when API returns null
   - Provide clear error message about invalid/inaccessible path
   - Error propagates to NewProjectPanel for display

## User Experience
**Before:**
Invalid path → [no feedback] → empty project created

**After:**
Invalid path → [error message displayed] → project creation blocked

## Error Messages
- "Invalid path" - Path must be absolute (start with /)
- "Failed to import folder" - API error or inaccessible path
- "Could not import folder. The path may be invalid or inaccessible."

## Testing
1. Open project creation panel
2. Enter invalid paths:
   - Relative path: "folder/path"
   - Just "/"
   - Non-existent path: "/invalid/path"
3. Click "Open folder"
4. Verify error messages appear
5. Enter valid path and verify it works