### PR TITLE
fix(desktop): enforce minimum window size on main client (#1189)

### DIFF
--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -784,6 +784,12 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
   const consoleEntries: DesktopConsoleEntry[] = [];
   const window = new BrowserWindow({
     height: 900,
+    // Below this size the project page's left/right split (chat
+    // composer + designs panel + preview pane) overlaps and the top
+    // navigation clips, so prevent Electron from honoring user drags
+    // that would shrink the window past the usable breakpoint.
+    minHeight: 600,
+    minWidth: 900,
     show: true,
     title: "Open Design",
     ...MAC_WINDOW_CHROME,


### PR DESCRIPTION
## Summary

Closes #1189. The desktop main `BrowserWindow` in `apps/desktop/src/main/runtime.ts` shipped only `width: 1280, height: 900` with no `minWidth` / `minHeight`, so Electron honored arbitrary user drags. Past roughly 900×600 the project page's left/right split (chat composer + designs panel + preview pane) overlaps and the top navigation clips — the broken first impression the issue reports.

## Approach

Add `minWidth: 900, minHeight: 600` to the main window's `BrowserWindow` constructor. Values come from the maintainer's recommendation in the issue thread:

> 建议先加一个保守的最小尺寸，例如 `900x600`：这个宽度能覆盖当前项目页左右分栏的基本布局需求，同时不会影响常见小屏笔记本使用。

The print sub-window at `runtime.ts:809-818` is intentionally left untouched: it's created with `show: false`, populated programmatically, shown only during the print round-trip, then closed in `finally`. The user can't drag it to resize, so a min-size floor has no observable effect.

## Reproduce

Before this PR:

1. Build/run the desktop client.
2. Drag any window edge to make the window very narrow / short.
3. Observe top navigation clipping and the project-page layout overlapping (per the screenshot in #1189).

After this PR:

1. Same steps.
2. The window stops shrinking once any edge reaches the 900-wide / 600-tall floor; the chat + designs + preview split stays usable, top navigation stays visible.

## Verification

- `pnpm --filter @open-design/desktop typecheck` — clean (`tsc --noEmit` exit 0)
- `pnpm guard` — all 5 invariant checks pass (residual JS, test layout, e2e layout, web test layout, tools layout)
- Diff is 6 lines (4 lines of comment explaining the floor's rationale + the two new `min*` props); no other behavior touched

## Test plan

- [ ] Run the desktop client locally (`pnpm tools-dev` then the desktop dev launch path)
- [ ] Confirm the main window cannot be dragged below 900×600
- [ ] Confirm the print export flow (Cmd/Ctrl-P from a design) still works — print window is unaffected but worth a smoke-check
- [ ] If any specific page still looks visually cramped at exactly 900×600, capture a screenshot and we can iterate on that page's responsive layout separately (per @lefarcen's note in the issue thread)