### PR TITLE
fix: use ACP config options for model selection

### DIFF
--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -29,6 +29,14 @@ export interface ModelOption {
   label: string;
 }
 
+interface AcpModelConfigOption {
+  configId: string;
+  currentValue: string | null;
+  values: unknown[];
+}
+
+const MODEL_CONFIG_OPTION_IDS = new Set(['model', 'models', 'modelid', 'modelids']);
+
 interface DetectAcpModelsOptions {
   bin: string;
   args: string[];
@@ -143,7 +151,81 @@ function choosePermissionOutcome(options: unknown): string | null {
   return null;
 }
 
-function normalizeModels(models: unknown, defaultModelOption: ModelOption): ModelOption[] {
+function normalizeConfigOptionToken(value: unknown): string {
+  return typeof value === 'string'
+    ? value.trim().toLowerCase().replace(/[\s_-]+/g, '')
+    : '';
+}
+
+function isModelConfigOption(option: JsonObject, configId: string): boolean {
+  const category = normalizeConfigOptionToken(option.category);
+  if (category === 'model') return true;
+  const id = normalizeConfigOptionToken(configId);
+  if (id === 'model') return true;
+  if (category) return false;
+  const name = normalizeConfigOptionToken(option.name);
+  return MODEL_CONFIG_OPTION_IDS.has(id) || name === 'model';
+}
+
+function findModelConfigOption(configOptions: unknown): AcpModelConfigOption | null {
+  const options = Array.isArray(configOptions) ? configOptions : [];
+  for (const rawOption of options) {
+    const option = asObject(rawOption);
+    if (!option) continue;
+    const configId = typeof option.id === 'string' ? option.id.trim() : '';
+    if (!configId) continue;
+    const type = typeof option.type === 'string' ? option.type.trim() : '';
+    if (type && type !== 'select') continue;
+    if (!isModelConfigOption(option, configId)) continue;
+    const currentValue =
+      typeof option.currentValue === 'string' && option.currentValue.trim()
+        ? option.currentValue.trim()
+        : null;
+    return {
+      configId,
+      currentValue,
+      values: Array.isArray(option.options) ? option.options : [],
+    };
+  }
+  return null;
+}
+
+function normalizeModelConfigOptions(
+  configOptions: unknown,
+  defaultModelOption: ModelOption,
+): { currentModelId: string | null; models: ModelOption[] } | null {
+  const modelConfig = findModelConfigOption(configOptions);
+  if (!modelConfig) return null;
+  const seen = new Set([defaultModelOption.id]);
+  const out = [defaultModelOption];
+  for (const rawValue of modelConfig.values) {
+    const value = asObject(rawValue);
+    if (!value) continue;
+    const id =
+      typeof value.value === 'string' && value.value.trim()
+        ? value.value.trim()
+        : typeof value.id === 'string'
+          ? value.id.trim()
+          : '';
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    const name = typeof value.name === 'string' ? value.name.trim() : '';
+    const isCurrent = id === modelConfig.currentValue;
+    const labelBase = name && name !== id ? `${name} (${id})` : id;
+    out.push({ id, label: isCurrent ? `${labelBase} • current` : labelBase });
+  }
+  return { currentModelId: modelConfig.currentValue, models: out };
+}
+
+export function normalizeModels(
+  models: unknown,
+  defaultModelOption: ModelOption,
+  configOptions?: unknown,
+): ModelOption[] {
+  const configModels = normalizeModelConfigOptions(configOptions, defaultModelOption);
+  if (configModels && configModels.models.length > 1) {
+    return configModels.models;
+  }
   const modelsObj = asObject(models);
   const available = Array.isArray(modelsObj?.availableModels) ? modelsObj.availableModels : [];
   const currentModelId =
@@ -159,7 +241,20 @@ function normalizeModels(models: unknown, defaultModelOption: ModelOption): Mode
     const labelBase = name && name !== id ? `${name} (${id})` : id;
     out.push({ id, label: isCurrent ? `${labelBase} • current` : labelBase });
   }
-  return out;
+  return out.length > 1 || !configModels ? out : configModels.models;
+}
+
+function modelSelectionErrorIsRecoverable(code: unknown): boolean {
+  return code === -32603 || code === -32602 || code === -32601 || code === -32002;
+}
+
+function currentModelFromSessionResult(result: JsonObject): string | null {
+  const configCurrent = findModelConfigOption(result.configOptions)?.currentValue;
+  if (configCurrent) return configCurrent;
+  const models = asObject(result.models);
+  return typeof models?.currentModelId === 'string' && models.currentModelId.trim()
+    ? models.currentModelId.trim()
+    : null;
 }
 
 export function createJsonLineStream(onMessage: (message: unknown, rawLine: string) => void) {
@@ -266,7 +361,7 @@ export async function detectAcpModels({
         return;
       }
       if (expectedId === 2) {
-        const models = normalizeModels(result.models, defaultModelOption);
+        const models = normalizeModels(result.models, defaultModelOption, result.configOptions);
         finish(resolve, models);
         if (!child.killed) child.kill('SIGTERM');
       }
@@ -324,6 +419,7 @@ export function attachAcpSession({
   let setModelRequestId: JsonRpcId | null = null;
   let sessionId: string | null = null;
   let activeModel: string | null = null;
+  let modelConfigId: string | null = null;
   let emittedThinkingStart = false;
   let emittedFirstTokenStatus = false;
   let finished = false;
@@ -393,6 +489,13 @@ export function attachAcpSession({
     }
   };
 
+  const recoverFromModelSelectionError = () => {
+    setModelRequestId = null;
+    activeModel = activeModel || 'default';
+    send('agent', { type: 'status', label: 'model', model: activeModel });
+    sendPrompt();
+  };
+
   const parser = createJsonLineStream((raw, rawLine) => {
     if (aborted) return;
     resetStageTimer('response');
@@ -407,32 +510,22 @@ export function attachAcpSession({
       // (pipe-broken, cleanup race conditions, etc.) are safe to ignore.
       if (finished) return;
       // JSON-RPC error handling:
-      // -32603 "Internal error": unexpected-id errors are cleanup noise — suppress.
-      //   Expected-id errors for session/set_model fall through to the recovery
-      //   block. All others (initialize, session/new, session/prompt) are real
-      //   failures — call fail().
-      // -32602 "Invalid params": these are real validation failures. Only
-      //   suppress when they match setModelRequestId so the recovery block handles
-      //   them. Any other -32602 (unexpected-id or non-set_model expected-id) is
-      //   a genuine protocol error — call fail().
+      // -32603 unexpected-id errors are cleanup noise. Expected-id model
+      // selection failures are recoverable; all other RPC errors are real
+      // protocol failures for initialize/session/new/session/prompt.
+      if (
+        obj.id === setModelRequestId &&
+        modelSelectionErrorIsRecoverable(error?.code) &&
+        promptRequestId === null
+      ) {
+        recoverFromModelSelectionError();
+        return;
+      }
       if (error?.code === -32603 && obj.id !== expectedId) {
         return;
       }
-      if (error?.code === -32602 && obj.id !== setModelRequestId) {
-        fail(rpcErr);
-        return;
-      }
-      if (error?.code === -32603 && obj.id === expectedId) {
-        if (obj.id === setModelRequestId) {
-          // Fall through — the recovery block will handle this
-        } else {
-          fail(rpcErr);
-          return;
-        }
-      }
-      if (error?.code === -32602 && obj.id === setModelRequestId) {
-        // Fall through — the recovery block will handle this
-      }
+      fail(rpcErr);
+      return;
     }
     if (obj.method === 'session/request_permission') {
       replyPermission(obj);
@@ -468,23 +561,6 @@ export function attachAcpSession({
       }
       return;
     }
-    // Recovery: if session/set_model failed with -32603 or -32602, fall back to
-    // sending the prompt with the default (already-active) model.
-    // -32603: agent doesn't support set_model at all (internal error).
-    // -32602: agent rejects the model ID or set_model params (invalid params).
-    // This is scoped to the exact set_model request id to avoid
-    // triggering on prompt or other request failures.
-    if (
-      (error?.code === -32603 || error?.code === -32602) &&
-      obj.id === setModelRequestId &&
-      promptRequestId === null
-    ) {
-      setModelRequestId = null;
-      activeModel = activeModel || 'default';
-      send('agent', { type: 'status', label: 'model', model: activeModel });
-      sendPrompt();
-      return;
-    }
     if (obj.id !== expectedId || !result) {
       return;
     }
@@ -504,25 +580,24 @@ export function attachAcpSession({
     }
     if (expectedId === 2) {
       sessionId = typeof result.sessionId === 'string' ? result.sessionId : null;
-      const models = asObject(result.models);
-      activeModel =
-        typeof models?.currentModelId === 'string'
-          ? models.currentModelId
-          : null;
+      const modelConfig = findModelConfigOption(result.configOptions);
+      modelConfigId = modelConfig?.configId ?? null;
+      activeModel = currentModelFromSessionResult(result);
       if (sessionId && activeModel) {
         send('agent', { type: 'status', label: 'model', model: activeModel });
       }
       if (sessionId && model && model !== 'default') {
         setModelRequestId = nextId;
         expectedId = nextId;
+        const setModelMethod = modelConfigId ? 'session/set_config_option' : 'session/set_model';
+        const setModelParams = modelConfigId
+          ? { sessionId, configId: modelConfigId, value: model }
+          : { sessionId, modelId: model };
         writeRpc(
           nextId,
-          'session/set_model',
-          {
-            sessionId,
-            modelId: model,
-          },
-          'session/set_model',
+          setModelMethod,
+          setModelParams,
+          setModelMethod,
         );
         nextId += 1;
         return;
@@ -549,7 +624,7 @@ export function attachAcpSession({
       return;
     }
     if (sessionId && model && model !== 'default' && obj.id === expectedId) {
-      activeModel = model;
+      activeModel = currentModelFromSessionResult(result) ?? model;
       send('agent', { type: 'status', label: 'model', model: activeModel });
       sendPrompt();
     }

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -3,7 +3,9 @@ import { EventEmitter } from 'node:events';
 import { PassThrough } from 'node:stream';
 import path from 'node:path';
 import { test } from 'vitest';
-import { attachAcpSession, buildAcpSessionNewParams } from '../src/acp.js';
+import { attachAcpSession, buildAcpSessionNewParams, normalizeModels } from '../src/acp.js';
+
+const DEFAULT_MODEL_OPTION = { id: 'default', label: 'Default (CLI config)' };
 
 test('ACP session params do not require MCP servers by default', () => {
   assert.deepEqual(buildAcpSessionNewParams('/tmp/od-project'), {
@@ -50,6 +52,156 @@ test('ACP session params preserve caller-provided type and env fields', () => {
   assert.deepEqual(server.env, [{ key: 'TOKEN', value: 'secret' }]);
 });
 
+test('ACP model normalization prefers session configOptions models', () => {
+  const models = normalizeModels(
+    {
+      currentModelId: 'legacy-model',
+      availableModels: [{ modelId: 'legacy-model', name: 'Legacy Model' }],
+    },
+    DEFAULT_MODEL_OPTION,
+    [
+      {
+        id: 'model',
+        type: 'select',
+        category: 'model',
+        currentValue: 'swe-1-6-fast',
+        options: [
+          { value: 'claude-opus-4-6-thinking', name: 'Claude Opus 4.6 Thinking' },
+          { id: 'swe-1-6-fast', name: 'SWE-1.6 Fast' },
+        ],
+      },
+    ],
+  );
+
+  assert.deepEqual(models, [
+    DEFAULT_MODEL_OPTION,
+    {
+      id: 'claude-opus-4-6-thinking',
+      label: 'Claude Opus 4.6 Thinking (claude-opus-4-6-thinking)',
+    },
+    {
+      id: 'swe-1-6-fast',
+      label: 'SWE-1.6 Fast (swe-1-6-fast) • current',
+    },
+  ]);
+});
+
+test('ACP model normalization accepts category-less model configOptions', () => {
+  const models = normalizeModels(null, DEFAULT_MODEL_OPTION, [
+    {
+      id: 'models',
+      type: 'select',
+      name: 'Model',
+      currentValue: 'swe-1-6-fast',
+      options: [
+        { value: 'claude-opus-4-6-thinking', name: 'Claude Opus 4.6 Thinking' },
+        { value: 'swe-1-6-fast', name: 'SWE-1.6 Fast' },
+      ],
+    },
+  ]);
+
+  assert.deepEqual(models, [
+    DEFAULT_MODEL_OPTION,
+    {
+      id: 'claude-opus-4-6-thinking',
+      label: 'Claude Opus 4.6 Thinking (claude-opus-4-6-thinking)',
+    },
+    {
+      id: 'swe-1-6-fast',
+      label: 'SWE-1.6 Fast (swe-1-6-fast) • current',
+    },
+  ]);
+});
+
+test('attachAcpSession sets selected models through ACP config options', () => {
+  const child = new FakeAcpChild();
+  const writes: string[] = [];
+  const events: Array<{ event: string; payload: unknown }> = [];
+  child.stdin.on('data', (chunk) => writes.push(String(chunk)));
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'hello',
+    cwd: '/tmp/od-project',
+    model: 'claude-opus-4-6-thinking',
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, {
+    sessionId: 'session-1',
+    configOptions: [
+      {
+        id: 'models',
+        type: 'select',
+        name: 'Model',
+        currentValue: 'swe-1-6-fast',
+        options: [
+          { value: 'claude-opus-4-6-thinking', name: 'Claude Opus 4.6 Thinking' },
+          { value: 'swe-1-6-fast', name: 'SWE-1.6 Fast' },
+        ],
+      },
+    ],
+  });
+  writeAcpResult(child, 3, {
+    configOptions: [
+      {
+        id: 'models',
+        type: 'select',
+        name: 'Model',
+        currentValue: 'claude-opus-4-6-thinking',
+        options: [],
+      },
+    ],
+  });
+  writeAcpResult(child, 4, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const requests = parseRpcWrites(writes);
+  const configRequest = requests.find((entry) => entry.method === 'session/set_config_option');
+  assert.deepEqual(configRequest?.params, {
+    sessionId: 'session-1',
+    configId: 'models',
+    value: 'claude-opus-4-6-thinking',
+  });
+  assert.equal(requests.some((entry) => entry.method === 'session/set_model'), false);
+  assert.deepEqual(agentModelStatuses(events), [
+    'swe-1-6-fast',
+    'claude-opus-4-6-thinking',
+  ]);
+});
+
+test('attachAcpSession keeps legacy session/set_model when no model config option exists', () => {
+  const child = new FakeAcpChild();
+  const writes: string[] = [];
+  child.stdin.on('data', (chunk) => writes.push(String(chunk)));
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'hello',
+    cwd: '/tmp/od-project',
+    model: 'legacy-model',
+    mcpServers: [],
+    send: () => {},
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, {
+    sessionId: 'session-1',
+    models: { currentModelId: 'default' },
+  });
+  writeAcpResult(child, 3, { models: { currentModelId: 'legacy-model' } });
+  writeAcpResult(child, 4, {});
+
+  const requests = parseRpcWrites(writes);
+  const setModelRequest = requests.find((entry) => entry.method === 'session/set_model');
+  assert.deepEqual(setModelRequest?.params, {
+    sessionId: 'session-1',
+    modelId: 'legacy-model',
+  });
+  assert.equal(requests.some((entry) => entry.method === 'session/set_config_option'), false);
+});
+
 test('attachAcpSession exposes abort and sends session cancel after session creation', () => {
   const child = new FakeAcpChild();
   const writes: string[] = [];
@@ -71,16 +223,35 @@ test('attachAcpSession exposes abort and sends session cancel after session crea
   session.abort();
   session.abort();
 
-  const parsed = writes
+  const parsed = parseRpcWrites(writes);
+  const cancelRequests = parsed.filter((entry) => entry.method === 'session/cancel');
+  assert.equal(cancelRequests.length, 1);
+  const cancelRequest = cancelRequests[0];
+  assert.ok(cancelRequest);
+  assert.deepEqual(cancelRequest.params, { sessionId: 'session-1' });
+});
+
+function parseRpcWrites(writes: string[]): Array<Record<string, unknown>> {
+  return writes
     .join('')
     .trim()
     .split('\n')
     .filter(Boolean)
-    .map((line) => JSON.parse(line));
-  const cancelRequests = parsed.filter((entry) => entry.method === 'session/cancel');
-  assert.equal(cancelRequests.length, 1);
-  assert.deepEqual(cancelRequests[0].params, { sessionId: 'session-1' });
-});
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+function writeAcpResult(child: FakeAcpChild, id: number, result: unknown): void {
+  child.stdout.write(`${JSON.stringify({ id, result })}\n`);
+}
+
+function agentModelStatuses(events: Array<{ event: string; payload: unknown }>): unknown[] {
+  return events
+    .filter((entry) => {
+      const payload = entry.payload as { type?: unknown; label?: unknown };
+      return entry.event === 'agent' && payload.type === 'status' && payload.label === 'model';
+    })
+    .map((entry) => (entry.payload as { model?: unknown }).model);
+}
 
 class FakeAcpChild extends EventEmitter {
   stdin = new PassThrough();


### PR DESCRIPTION
﻿## Summary
- Parse ACP session `configOptions` for model selectors when `result.models` is empty or legacy-only
- Use stable `session/set_config_option` for selected ACP models when a model config option is advertised
- Keep legacy `session/set_model` fallback for older ACP agents and cover both paths in daemon tests

Fixes #1200

## Validation
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/acp.test.ts`
