### PR TITLE
fix(web): refresh home projects after deleting a conversation (#1202)

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1615,6 +1615,13 @@ export function ProjectView({
     async (id: string) => {
       const ok = await deleteConversationApi(project.id, id);
       if (!ok) return;
+      // The deleted conversation may have owned an unanswered
+      // `<question-form>`, which the daemon counts toward the project's
+      // `needsInput` flag in `/api/projects`. Home cards render that
+      // flag from the cached projects payload, so without refreshing
+      // it here the `Needs input` badge survives the deletion until
+      // the next manual reload.
+      onProjectsRefresh();
       setConversations((curr) => {
         const next = curr.filter((c) => c.id !== id);
         if (next.length === 0) {
@@ -1632,7 +1639,7 @@ export function ProjectView({
         return next;
       });
     },
-    [project.id, activeConversationId],
+    [project.id, activeConversationId, onProjectsRefresh],
   );
 
   const handleRenameConversation = useCallback(

--- a/apps/web/tests/components/ProjectView.deleteConversation.test.tsx
+++ b/apps/web/tests/components/ProjectView.deleteConversation.test.tsx
@@ -1,0 +1,206 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ProjectView } from '../../src/components/ProjectView';
+
+const listConversations = vi.fn();
+const listMessages = vi.fn();
+const fetchPreviewComments = vi.fn();
+const loadTabs = vi.fn();
+const fetchProjectFiles = vi.fn();
+const fetchLiveArtifacts = vi.fn();
+const fetchSkill = vi.fn();
+const fetchDesignSystem = vi.fn();
+const getTemplate = vi.fn();
+const fetchChatRunStatus = vi.fn();
+const listActiveChatRuns = vi.fn();
+const reattachDaemonRun = vi.fn();
+const deleteConversation = vi.fn();
+const createConversation = vi.fn();
+const patchConversation = vi.fn();
+const patchProject = vi.fn();
+const saveMessage = vi.fn();
+const saveTabs = vi.fn();
+
+// Capture the props ChatPane receives so the test can drive
+// `onDeleteConversation` directly — ChatPane itself is mocked to a
+// no-op renderer (the real component pulls in markdown + chat
+// streaming machinery that isn't relevant to the projects-refresh
+// regression we want to pin).
+const chatPaneProps: { onDeleteConversation?: (id: string) => Promise<void> | void } = {};
+
+vi.mock('../../src/i18n', () => ({
+  useT: () => ((value: string) => value),
+}));
+
+vi.mock('../../src/providers/anthropic', () => ({
+  streamMessage: vi.fn(),
+}));
+
+vi.mock('../../src/providers/daemon', () => ({
+  fetchChatRunStatus: (...args: unknown[]) => fetchChatRunStatus(...args),
+  listActiveChatRuns: (...args: unknown[]) => listActiveChatRuns(...args),
+  reattachDaemonRun: (...args: unknown[]) => reattachDaemonRun(...args),
+  streamViaDaemon: vi.fn(),
+}));
+
+vi.mock('../../src/providers/registry', () => ({
+  deletePreviewComment: vi.fn(),
+  fetchPreviewComments: (...args: unknown[]) => fetchPreviewComments(...args),
+  fetchDesignSystem: (...args: unknown[]) => fetchDesignSystem(...args),
+  fetchLiveArtifacts: (...args: unknown[]) => fetchLiveArtifacts(...args),
+  fetchProjectFiles: (...args: unknown[]) => fetchProjectFiles(...args),
+  fetchSkill: (...args: unknown[]) => fetchSkill(...args),
+  patchPreviewCommentStatus: vi.fn(),
+  upsertPreviewComment: vi.fn(),
+  writeProjectTextFile: vi.fn(),
+}));
+
+vi.mock('../../src/router', () => ({
+  navigate: vi.fn(),
+}));
+
+vi.mock('../../src/state/projects', () => ({
+  createConversation: (...args: unknown[]) => createConversation(...args),
+  deleteConversation: (...args: unknown[]) => deleteConversation(...args),
+  getTemplate: (...args: unknown[]) => getTemplate(...args),
+  listConversations: (...args: unknown[]) => listConversations(...args),
+  listMessages: (...args: unknown[]) => listMessages(...args),
+  loadTabs: (...args: unknown[]) => loadTabs(...args),
+  patchConversation: (...args: unknown[]) => patchConversation(...args),
+  patchProject: (...args: unknown[]) => patchProject(...args),
+  saveMessage: (...args: unknown[]) => saveMessage(...args),
+  saveTabs: (...args: unknown[]) => saveTabs(...args),
+}));
+
+vi.mock('../../src/components/AppChromeHeader', () => ({
+  AppChromeHeader: () => null,
+}));
+
+vi.mock('../../src/components/AvatarMenu', () => ({
+  AvatarMenu: () => null,
+}));
+
+vi.mock('../../src/components/ChatPane', () => ({
+  ChatPane: (props: { onDeleteConversation?: (id: string) => Promise<void> | void }) => {
+    chatPaneProps.onDeleteConversation = props.onDeleteConversation;
+    return null;
+  },
+}));
+
+vi.mock('../../src/components/FileWorkspace', () => ({
+  FileWorkspace: () => null,
+}));
+
+vi.mock('../../src/components/Loading', () => ({
+  CenteredLoader: () => null,
+}));
+
+function renderProjectView(onProjectsRefresh: () => void) {
+  return render(
+    <ProjectView
+      project={{ id: 'project-1', name: 'Project', skillId: null, designSystemId: null } as never}
+      routeFileName={null}
+      config={{ mode: 'daemon', agentId: 'agent-1', notifications: undefined, agentModels: {} } as never}
+      agents={[{ id: 'agent-1', name: 'OpenCode', models: [] } as never]}
+      skills={[]}
+      designSystems={[]}
+      daemonLive
+      onModeChange={() => {}}
+      onAgentChange={() => {}}
+      onAgentModelChange={() => {}}
+      onRefreshAgents={() => {}}
+      onOpenSettings={() => {}}
+      onBack={() => {}}
+      onClearPendingPrompt={() => {}}
+      onTouchProject={() => {}}
+      onProjectChange={() => {}}
+      onProjectsRefresh={onProjectsRefresh}
+    />,
+  );
+}
+
+describe('ProjectView conversation delete', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    chatPaneProps.onDeleteConversation = undefined;
+  });
+
+  // Issue #1202: the home `Needs input` badge is rendered from the
+  // cached `/api/projects` payload (App.tsx owns the `projects` state).
+  // Deleting a conversation that owned an unanswered question-form
+  // flips the daemon-side flag, but without calling onProjectsRefresh
+  // here the home view keeps the stale flag until the next manual
+  // reload. All the other state-changing branches in ProjectView
+  // already call onProjectsRefresh (run end, live artifact events,
+  // etc.) — this pins that the delete-conversation branch joins them.
+  it('triggers onProjectsRefresh after deleting a conversation', async () => {
+    listConversations.mockResolvedValue([
+      { id: 'conv-1', title: 'Conversation 1' },
+      { id: 'conv-2', title: 'Conversation 2' },
+    ]);
+    listMessages.mockResolvedValue([]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    fetchChatRunStatus.mockResolvedValue(null);
+    listActiveChatRuns.mockResolvedValue([]);
+    reattachDaemonRun.mockResolvedValue(undefined);
+    deleteConversation.mockResolvedValue(true);
+
+    const onProjectsRefresh = vi.fn();
+
+    renderProjectView(onProjectsRefresh);
+
+    // ChatPane mount is async (ProjectView loads conversations in an
+    // effect, then renders chat). Wait for the mocked ChatPane to
+    // surface its `onDeleteConversation` prop.
+    await waitFor(() => expect(chatPaneProps.onDeleteConversation).toBeDefined());
+
+    await act(async () => {
+      await chatPaneProps.onDeleteConversation!('conv-1');
+    });
+
+    expect(deleteConversation).toHaveBeenCalledWith('project-1', 'conv-1');
+    expect(onProjectsRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  // Defensive complement: if the daemon delete fails, we must not
+  // pretend it succeeded — onProjectsRefresh would feed the home view
+  // a "deleted" state that isn't actually true on disk, putting the
+  // cache MORE out of sync than the bug we're fixing.
+  it('does not trigger onProjectsRefresh when the delete request fails', async () => {
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation 1' }]);
+    listMessages.mockResolvedValue([]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    fetchChatRunStatus.mockResolvedValue(null);
+    listActiveChatRuns.mockResolvedValue([]);
+    reattachDaemonRun.mockResolvedValue(undefined);
+    deleteConversation.mockResolvedValue(false);
+
+    const onProjectsRefresh = vi.fn();
+
+    renderProjectView(onProjectsRefresh);
+
+    await waitFor(() => expect(chatPaneProps.onDeleteConversation).toBeDefined());
+
+    await act(async () => {
+      await chatPaneProps.onDeleteConversation!('conv-1');
+    });
+
+    expect(deleteConversation).toHaveBeenCalledWith('project-1', 'conv-1');
+    expect(onProjectsRefresh).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1202. The home design cards render their `Needs input` badge from the cached `/api/projects` payload — App.tsx owns the `projects` state and threads a `refreshProjects` callback down to ProjectView as the `onProjectsRefresh` prop. ProjectView already fires it from every other state-changing branch (run end, live-artifact events, project rename, …), but the conversation-delete branch silently skipped it. Result: deleting a conversation that owned an unanswered `<question-form>` flips the daemon-side `needsInput` flag, yet the home card keeps showing the stale `Needs input` badge until the next manual reload.

## Approach

Call `onProjectsRefresh()` immediately after a successful `deleteConversation` API response inside `handleDeleteConversation`, gated on the `!ok` early-return so a failed delete cannot drag the home cache out of sync in the opposite direction. Adds `onProjectsRefresh` to the `useCallback` deps for exhaustive-deps correctness; behavior matches the four existing `onProjectsRefresh()` call sites in this file (`apps/web/src/components/ProjectView.tsx`).

```diff
   const handleDeleteConversation = useCallback(
     async (id: string) => {
       const ok = await deleteConversationApi(project.id, id);
       if (!ok) return;
+      // The deleted conversation may have owned an unanswered
+      // `<question-form>`, which the daemon counts toward the project's
+      // `needsInput` flag in `/api/projects`. Home cards render that
+      // flag from the cached projects payload, so without refreshing
+      // it here the `Needs input` badge survives the deletion until
+      // the next manual reload.
+      onProjectsRefresh();
       setConversations((curr) => {
         // …
       });
     },
-    [project.id, activeConversationId],
+    [project.id, activeConversationId, onProjectsRefresh],
   );
```

This is the tighter of the two directions @lefarcen suggested in the issue thread (refresh on delete-success vs refresh on home-return). Refresh-on-delete is preferred because:
- It matches the existing pattern at the other four call sites in this file (run end, live-artifact created, live-artifact refresh, file-events handler).
- It works regardless of how the user navigates back to home (router push, tab switch, window focus from a packaged build, etc.) — a refresh-on-home-return path would be limited to the explicit back button.
- It keeps cache invalidation co-located with the action that invalidated the data.

## Reproduce

1. Open Design (any build).
2. From the home, open or create a project.
3. Have the assistant emit a `<question-form>` so the project picks up the `Needs input` state (or use any conversation the daemon currently flags as needing input).
4. Delete that conversation from the chat conversations list.
5. Navigate back to home and look at the project card.

**Before this PR:** the `Needs input` badge is still visible on the card even though the conversation is gone.
**After this PR:** the card reflects the post-delete state immediately.

## Verification

- `pnpm --filter @open-design/web typecheck` — clean (`tsc -b --noEmit` exit 0)
- `pnpm --filter @open-design/web test` — **84 files, 745/745 passed** (full suite, including the 2 new regression tests below)
- `pnpm guard` — 5/5 invariant checks pass
- Direct test verification (sanity check that the regression test isn't a tautology):
  1. `git stash push apps/web/src/components/ProjectView.tsx` (drop the source fix)
  2. `pnpm exec vitest run tests/components/ProjectView.deleteConversation.test.tsx` → "triggers onProjectsRefresh after deleting a conversation" **fails** with `expected "spy" to be called 1 times, but got 0 times`
  3. `git stash pop` (restore the fix) → both tests **pass**

## New regression tests

`apps/web/tests/components/ProjectView.deleteConversation.test.tsx`:

- **triggers onProjectsRefresh after deleting a conversation** — pins the main #1202 invariant: a successful `deleteConversationApi` response must fire `onProjectsRefresh` exactly once. Captures the `onDeleteConversation` prop that ProjectView passes down to ChatPane (ChatPane itself is mocked to a no-op so the test doesn't have to drag in the markdown/chat-streaming machinery) and invokes it directly.
- **does not trigger onProjectsRefresh when the delete request fails** — defensive complement so a future "just always refresh" refactor doesn't paper over a real failure with a stale-but-confident home UI.

The test follows the existing setup pattern in `ProjectView.run-cleanup.test.tsx` (same provider/router/state mocks plus targeted child-component stubs).

## Test plan

- [ ] CI green on the `apps/web` package
- [ ] Manual: reproduce the issue per the steps above (before / after on a real daemon + project)

## Not in scope

- Other places that may suffer from the same "home `projects` cache vs project-page action" mismatch (e.g. message deletion within a conversation, or anything else that could flip `needsInput`). Those are not what #1202 reports; they can be addressed separately if they surface.
- Refresh-on-home-return as a second safety net. Not needed for the reported reproduction, and the current refresh is the right anchor for the action that invalidated the data.