### PR TITLE
feat(daemon): make connection-test timeouts configurable

### DIFF
--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -46,11 +46,45 @@ import {
 export { validateBaseUrl } from '@open-design/contracts/api/connectionTest';
 
 // Aggressive but not punitive — happy paths usually return in under 2 s.
-const PROVIDER_TIMEOUT_MS = 12_000;
+// Override with OD_CONNECTION_TEST_PROVIDER_TIMEOUT_MS for slow networks
+// or distant providers; invalid values fall back to the default.
+const DEFAULT_PROVIDER_TIMEOUT_MS = 12_000;
 // CLI boot time is dominated by adapter auth/session restore; the heavy
 // adapters (Codex, Cursor Agent) regularly take 5–10 s on a cold first
 // run, so 45 s leaves headroom without making a hung child invisible.
-const AGENT_TIMEOUT_MS = 45_000;
+// Override with OD_CONNECTION_TEST_AGENT_TIMEOUT_MS.
+const DEFAULT_AGENT_TIMEOUT_MS = 45_000;
+
+export function resolveConnectionTestTimeoutMs(
+  key: 'OD_CONNECTION_TEST_PROVIDER_TIMEOUT_MS' | 'OD_CONNECTION_TEST_AGENT_TIMEOUT_MS',
+  fallback: number,
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const raw = env[key];
+  if (raw === undefined || raw === '') return fallback;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 1) {
+    console.warn(
+      `connection-test: ignoring ${key}=${JSON.stringify(raw)} (must be a positive integer ms); using ${fallback}ms`,
+    );
+    return fallback;
+  }
+  return n;
+}
+
+function providerTimeoutMs(): number {
+  return resolveConnectionTestTimeoutMs(
+    'OD_CONNECTION_TEST_PROVIDER_TIMEOUT_MS',
+    DEFAULT_PROVIDER_TIMEOUT_MS,
+  );
+}
+
+function agentTimeoutMs(): number {
+  return resolveConnectionTestTimeoutMs(
+    'OD_CONNECTION_TEST_AGENT_TIMEOUT_MS',
+    DEFAULT_AGENT_TIMEOUT_MS,
+  );
+}
 const AGENT_COMPLETION_DEBOUNCE_MS = 500;
 const AGENT_KILL_GRACE_MS = 2_000;
 // Truncates the assistant reply we surface in the success copy so a
@@ -492,7 +526,7 @@ export async function testProviderConnection(
   } else {
     input.signal?.addEventListener('abort', abortFromParent, { once: true });
   }
-  const timer = setTimeout(() => controller.abort(), PROVIDER_TIMEOUT_MS);
+  const timer = setTimeout(() => controller.abort(), providerTimeoutMs());
 
   try {
     const modelError = await validateLocalOpenAiModel(
@@ -1114,7 +1148,7 @@ export async function testAgentConnection(
       child.stdin.end(SMOKE_PROMPT, 'utf8');
     }
     const cancellationPromise = new Promise<{ kind: 'timeout' } | { kind: 'aborted' }>((resolve) => {
-      timer = setTimeout(() => resolve({ kind: 'timeout' }), AGENT_TIMEOUT_MS);
+      timer = setTimeout(() => resolve({ kind: 'timeout' }), agentTimeoutMs());
       abortHandler = () => resolve({ kind: 'aborted' });
       if (input.signal?.aborted) {
         abortHandler();

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -54,6 +54,13 @@ const DEFAULT_PROVIDER_TIMEOUT_MS = 12_000;
 // run, so 45 s leaves headroom without making a hung child invisible.
 // Override with OD_CONNECTION_TEST_AGENT_TIMEOUT_MS.
 const DEFAULT_AGENT_TIMEOUT_MS = 45_000;
+// Node's `setTimeout` silently clamps any delay above this to ~1 ms
+// (with a TimeoutOverflowWarning), so an override meant to *extend*
+// the budget — e.g. `OD_CONNECTION_TEST_AGENT_TIMEOUT_MS=3000000000` —
+// would actually make every connection test fail almost immediately.
+// Reject above the cap so the safety timeout cannot be accidentally
+// disarmed by an oversized env value.
+const MAX_CONNECTION_TEST_TIMEOUT_MS = 2_147_483_647;
 
 export function resolveConnectionTestTimeoutMs(
   key: 'OD_CONNECTION_TEST_PROVIDER_TIMEOUT_MS' | 'OD_CONNECTION_TEST_AGENT_TIMEOUT_MS',
@@ -63,9 +70,9 @@ export function resolveConnectionTestTimeoutMs(
   const raw = env[key];
   if (raw === undefined || raw === '') return fallback;
   const n = Number(raw);
-  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 1) {
+  if (!Number.isSafeInteger(n) || n < 1 || n > MAX_CONNECTION_TEST_TIMEOUT_MS) {
     console.warn(
-      `connection-test: ignoring ${key}=${JSON.stringify(raw)} (must be a positive integer ms); using ${fallback}ms`,
+      `connection-test: ignoring ${key}=${JSON.stringify(raw)} (must be a positive integer between 1 and ${MAX_CONNECTION_TEST_TIMEOUT_MS} ms); using ${fallback}ms`,
     );
     return fallback;
   }

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -10,6 +10,7 @@ import {
   createAgentSink,
   isSmokeOkReply,
   redactSecrets,
+  resolveConnectionTestTimeoutMs,
   testAgentConnection,
   testProviderConnection,
 } from '../src/connectionTest.js';
@@ -1229,5 +1230,47 @@ describe('connection test helpers', () => {
         "There's an issue with the selected model (abcde). It may not exist.",
       ),
     ).toBe(false);
+  });
+});
+
+describe('connection test timeout overrides', () => {
+  it('returns the fallback when the override is missing or empty', () => {
+    expect(
+      resolveConnectionTestTimeoutMs('OD_CONNECTION_TEST_PROVIDER_TIMEOUT_MS', 12_000, {}),
+    ).toBe(12_000);
+    expect(
+      resolveConnectionTestTimeoutMs('OD_CONNECTION_TEST_AGENT_TIMEOUT_MS', 45_000, {
+        OD_CONNECTION_TEST_AGENT_TIMEOUT_MS: '',
+      }),
+    ).toBe(45_000);
+  });
+
+  it('honors a positive integer override', () => {
+    expect(
+      resolveConnectionTestTimeoutMs('OD_CONNECTION_TEST_PROVIDER_TIMEOUT_MS', 12_000, {
+        OD_CONNECTION_TEST_PROVIDER_TIMEOUT_MS: '30000',
+      }),
+    ).toBe(30_000);
+    expect(
+      resolveConnectionTestTimeoutMs('OD_CONNECTION_TEST_AGENT_TIMEOUT_MS', 45_000, {
+        OD_CONNECTION_TEST_AGENT_TIMEOUT_MS: '120000',
+      }),
+    ).toBe(120_000);
+  });
+
+  it('warns and falls back on non-numeric, zero, negative, or non-integer overrides', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      for (const bad of ['fast', '0', '-1', '1.5', 'NaN']) {
+        expect(
+          resolveConnectionTestTimeoutMs('OD_CONNECTION_TEST_PROVIDER_TIMEOUT_MS', 12_000, {
+            OD_CONNECTION_TEST_PROVIDER_TIMEOUT_MS: bad,
+          }),
+        ).toBe(12_000);
+      }
+      expect(warn).toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -1273,4 +1273,36 @@ describe('connection test timeout overrides', () => {
       warn.mockRestore();
     }
   });
+
+  // Regression: a previous version of resolveConnectionTestTimeoutMs
+  // accepted any positive integer, but Node's setTimeout silently
+  // clamps delays above 2^31-1 to ~1 ms (with a TimeoutOverflowWarning).
+  // An override that meant to extend the budget would instead make
+  // every connection test fail almost immediately — the safety
+  // timeout would be effectively disarmed.
+  it('rejects values above the Node setTimeout maximum (2^31-1)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const tooLarge = '3000000000'; // ~50 minutes; exceeds 2_147_483_647 ms
+      expect(
+        resolveConnectionTestTimeoutMs('OD_CONNECTION_TEST_AGENT_TIMEOUT_MS', 45_000, {
+          OD_CONNECTION_TEST_AGENT_TIMEOUT_MS: tooLarge,
+        }),
+      ).toBe(45_000);
+      // The exact maximum is still accepted; anything past it is not.
+      expect(
+        resolveConnectionTestTimeoutMs('OD_CONNECTION_TEST_AGENT_TIMEOUT_MS', 45_000, {
+          OD_CONNECTION_TEST_AGENT_TIMEOUT_MS: '2147483647',
+        }),
+      ).toBe(2_147_483_647);
+      expect(
+        resolveConnectionTestTimeoutMs('OD_CONNECTION_TEST_AGENT_TIMEOUT_MS', 45_000, {
+          OD_CONNECTION_TEST_AGENT_TIMEOUT_MS: '2147483648',
+        }),
+      ).toBe(45_000);
+      expect(warn).toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
 });


### PR DESCRIPTION
## Motivation

The Settings → Connection Test flow has two hardcoded budgets:

- **Provider** connection test: `PROVIDER_TIMEOUT_MS = 12_000`
- **Agent** connection test: `AGENT_TIMEOUT_MS = 45_000`

These are tuned for happy-path latencies, but on slow networks, distant providers, or constrained CLI adapter cold-starts they time out with no user-facing way to extend the budget. The user only sees "timeout" with no recourse.

## Change

`apps/daemon/src/connectionTest.ts`:

- Rename the constants to `DEFAULT_PROVIDER_TIMEOUT_MS` / `DEFAULT_AGENT_TIMEOUT_MS` (same default values, no behavior change for users who set nothing).
- Add two env-var overrides:
  - `OD_CONNECTION_TEST_PROVIDER_TIMEOUT_MS`
  - `OD_CONNECTION_TEST_AGENT_TIMEOUT_MS`
- Defensive parsing: non-numeric / zero / negative / fractional values are rejected with a `console.warn` and the default is used. A typo in the env cannot silently disable the safety timeout.
- Export `resolveConnectionTestTimeoutMs(key, fallback, env)` so the resolution logic is unit-testable.

`apps/daemon/tests/connection-test.test.ts`:

- 3 new tests covering the three resolution paths: empty env → fallback, honored numeric override, invalid value → warn + fallback.

## Compatibility

- No public API change in the daemon.
- Defaults (12s / 45s) are preserved — existing deployments and CI run unchanged unless the new env vars are explicitly set.
- Constant-name change is internal-only (no external imports of the old names).

## Verification (to confirm in CI / by reviewer)

- [ ] `apps/daemon` vitest suite green (3 new cases pass; nothing else regresses)
- [ ] `resolveConnectionTestTimeoutMs` behavior matches the parse-rules table in the source comments