### PR TITLE
fix: truncate long template names to keep task status visible

### DIFF
--- a/apps/web/src/components/DesignsTab.tsx
+++ b/apps/web/src/components/DesignsTab.tsx
@@ -371,7 +371,14 @@ export function DesignsTab({
 										) : (
 											<span>{t("designs.cardFreeform")}</span>
 										)}
-										{skill ? ` · ${skill}` : ""}
+										{skill ? (
+											<>
+												{" · "}
+												<span className="design-card-skill" title={skill}>
+													{skill}
+												</span>
+											</>
+										) : null}
 										{" · "}
 										<span
 											className={`design-card-status design-card-status-${status}`}
@@ -458,7 +465,14 @@ export function DesignsTab({
 														) : (
 															<span>{t("designs.cardFreeform")}</span>
 														)}
-														{skill ? ` · ${skill}` : ""}
+														{skill ? (
+															<>
+																{" · "}
+																<span className="design-card-skill" title={skill}>
+																	{skill}
+																</span>
+															</>
+														) : null}
 														{sub === "recent"
 															? ` · ${relativeTime(p.updatedAt, t)}`
 															: sub === "yours"

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6470,6 +6470,14 @@ button.connector-action.is-loading {
 .design-card-meta .ds {
   color: var(--accent);
 }
+.design-card-skill {
+  display: inline-block;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: bottom;
+}
 .design-card-status {
   font-weight: 500;
 }


### PR DESCRIPTION
## Summary

This PR fixes issue #1220 where overly long template names on project cards push the task execution status out of view.

## Problem

On project cards:
- Long template names take up too much horizontal space
- Task execution status (Running, Failed, Completed) gets truncated or hidden
- Users cannot easily see the current task state

## Solution

Truncate long template names with CSS ellipsis to ensure status information remains visible.

### Implementation

**Wrap template names:**
```tsx
<span className="design-card-skill" title={skill.name}>
  {skill.name}
</span>
```

**CSS truncation:**
```css
.design-card-skill {
  max-width: 120px;
  overflow: hidden;
  text-overflow: ellipsis;
  white-space: nowrap;
}
```

## Changes

- ✅ Wrap skill/template names in `.design-card-skill` span
- ✅ Add `title` attribute for full name on hover
- ✅ Apply to both grid and kanban views
- ✅ Add CSS rule to truncate at 120px with ellipsis

## User Experience

**Before:**
```
Design System · Very Very Very Long Template Name · Run...
```

**After:**
```
Design System · Very Very Very Lo... · Running · 2 hours ago
```

- Closes #1220