### PR TITLE
fix(daemon): persist runStatus/endedAt on chat run termination

### DIFF
--- a/apps/daemon/src/chat-routes.ts
+++ b/apps/daemon/src/chat-routes.ts
@@ -43,14 +43,14 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
     if (run.assistantMessageId) {
       void design.runs
         .wait(run)
-        .then((finalStatus) => {
+        .then((finalStatus: { status: string }) => {
           db.prepare(
             `UPDATE messages
                 SET run_status = ?, ended_at = COALESCE(ended_at, ?)
               WHERE id = ? AND run_status IN ('queued', 'running')`,
           ).run(finalStatus.status, Date.now(), run.assistantMessageId);
         })
-        .catch((err) => {
+        .catch((err: unknown) => {
           console.warn('[runs] message reconciliation failed', err);
         });
     }

--- a/apps/daemon/src/chat-routes.ts
+++ b/apps/daemon/src/chat-routes.ts
@@ -3,6 +3,32 @@ import type { RouteDeps } from './server-context.js';
 
 export interface RegisterChatRoutesDeps extends RouteDeps<'db' | 'design' | 'http' | 'chat' | 'agents' | 'critique' | 'validation' | 'lifecycle'> {}
 
+// Invariant: a chat assistant message row reflects its run's terminal state
+// even when the web client never persists the cancel/finish itself (refresh
+// or dropped PUT). Without this, a row stuck at run_status='running' /
+// ended_at=NULL makes the elapsed-time renderer fall back to now - startedAt
+// after reload. COALESCE preserves any endedAt the web already wrote; the
+// run_status guard skips rows the web has already finalized.
+function reconcileAssistantMessageOnRunEnd(
+  db: RegisterChatRoutesDeps['db'],
+  runs: RegisterChatRoutesDeps['design']['runs'],
+  run: { assistantMessageId: string | null },
+): void {
+  if (!run.assistantMessageId) return;
+  void runs
+    .wait(run)
+    .then((finalStatus: { status: string }) => {
+      db.prepare(
+        `UPDATE messages
+            SET run_status = ?, ended_at = COALESCE(ended_at, ?)
+          WHERE id = ? AND run_status IN ('queued', 'running')`,
+      ).run(finalStatus.status, Date.now(), run.assistantMessageId);
+    })
+    .catch((err: unknown) => {
+      console.warn('[runs] message reconciliation failed', err);
+    });
+}
+
 export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
   const { db, design } = ctx;
   const { sendApiError, createSseResponse } = ctx.http;
@@ -33,27 +59,7 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
     const body = { runId: run.id };
     res.status(202).json(body);
     design.runs.start(run, () => startChatRun(req.body || {}, run));
-    // Reconcile the assistant message row when the run reaches a terminal
-    // state. Without this, a Stop-then-refresh sequence leaves the row stuck
-    // at run_status='running' / ended_at=NULL — the web reattach effect then
-    // never freezes the elapsed timer and it keeps accumulating from the
-    // original startedAt (issue #135). The COALESCE preserves any endedAt the
-    // web client already persisted, and the run_status guard skips rows the
-    // web has already finalized.
-    if (run.assistantMessageId) {
-      void design.runs
-        .wait(run)
-        .then((finalStatus: { status: string }) => {
-          db.prepare(
-            `UPDATE messages
-                SET run_status = ?, ended_at = COALESCE(ended_at, ?)
-              WHERE id = ? AND run_status IN ('queued', 'running')`,
-          ).run(finalStatus.status, Date.now(), run.assistantMessageId);
-        })
-        .catch((err: unknown) => {
-          console.warn('[runs] message reconciliation failed', err);
-        });
-    }
+    reconcileAssistantMessageOnRunEnd(db, design.runs, run);
   });
 
   app.get('/api/runs', (req, res) => {

--- a/apps/daemon/src/chat-routes.ts
+++ b/apps/daemon/src/chat-routes.ts
@@ -33,6 +33,27 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
     const body = { runId: run.id };
     res.status(202).json(body);
     design.runs.start(run, () => startChatRun(req.body || {}, run));
+    // Reconcile the assistant message row when the run reaches a terminal
+    // state. Without this, a Stop-then-refresh sequence leaves the row stuck
+    // at run_status='running' / ended_at=NULL — the web reattach effect then
+    // never freezes the elapsed timer and it keeps accumulating from the
+    // original startedAt (issue #135). The COALESCE preserves any endedAt the
+    // web client already persisted, and the run_status guard skips rows the
+    // web has already finalized.
+    if (run.assistantMessageId) {
+      void design.runs
+        .wait(run)
+        .then((finalStatus) => {
+          db.prepare(
+            `UPDATE messages
+                SET run_status = ?, ended_at = COALESCE(ended_at, ?)
+              WHERE id = ? AND run_status IN ('queued', 'running')`,
+          ).run(finalStatus.status, Date.now(), run.assistantMessageId);
+        })
+        .catch((err) => {
+          console.warn('[runs] message reconciliation failed', err);
+        });
+    }
   });
 
   app.get('/api/runs', (req, res) => {

--- a/e2e/lib/vitest/runs.ts
+++ b/e2e/lib/vitest/runs.ts
@@ -46,6 +46,14 @@ export async function readRunEvents(baseUrl: string, runId: string): Promise<str
   return await requestText(baseUrl, `/api/runs/${encodeURIComponent(runId)}/events`);
 }
 
+export async function cancelRun(baseUrl: string, runId: string): Promise<{ ok: true }> {
+  return await requestJson<{ ok: true }>(
+    baseUrl,
+    `/api/runs/${encodeURIComponent(runId)}/cancel`,
+    { body: {}, method: 'POST' },
+  );
+}
+
 export async function waitForRunStatus(
   baseUrl: string,
   runId: string,

--- a/e2e/lib/vitest/runs.ts
+++ b/e2e/lib/vitest/runs.ts
@@ -77,6 +77,27 @@ export async function waitForRunStatus(
   throw new Error(`run ${runId} did not reach ${expected} within ${timeoutMs}ms; last=${last?.status ?? 'unknown'}`);
 }
 
+const TERMINAL_RUN_STATUSES = new Set<ChatRunStatus>(['succeeded', 'failed', 'canceled']);
+
+export async function waitForRunTerminal(
+  baseUrl: string,
+  runId: string,
+  options: { intervalMs?: number; timeoutMs?: number } = {},
+): Promise<ChatRunStatusBody> {
+  const timeoutMs = options.timeoutMs ?? 20_000;
+  const intervalMs = options.intervalMs ?? 250;
+  const startedAt = Date.now();
+  let last: ChatRunStatusBody | null = null;
+
+  while (Date.now() - startedAt < timeoutMs) {
+    last = await readRun(baseUrl, runId);
+    if (TERMINAL_RUN_STATUSES.has(last.status)) return last;
+    await delay(intervalMs);
+  }
+
+  throw new Error(`run ${runId} did not reach a terminal status within ${timeoutMs}ms; last=${last?.status ?? 'unknown'}`);
+}
+
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/e2e/tests/dialog/retry-after-stop.test.ts
+++ b/e2e/tests/dialog/retry-after-stop.test.ts
@@ -1,0 +1,190 @@
+// @vitest-environment node
+
+import { randomUUID } from 'node:crypto';
+import { join } from 'node:path';
+
+import { describe, expect, test } from 'vitest';
+
+import { createFakeAgentRuntimes } from '@/fake-agents';
+import { requestJson } from '@/vitest/http';
+import { listMessages, saveMessage } from '@/vitest/messages';
+import { cancelRun, startRun, waitForRunStatus } from '@/vitest/runs';
+import { createSmokeSuite } from '@/vitest/smoke-suite';
+
+type ProjectResponse = {
+  conversationId: string;
+  project: { id: string; metadata?: { kind?: string }; name: string };
+};
+
+const PROMPT_FIRST = 'Create a deterministic smoke artifact';
+const PROMPT_RETRY = 'Create a deterministic smoke artifact';
+
+describe('dialog retry after stop', () => {
+  test('retried turn keeps its own startedAt and does not merge with the previously stopped run', async () => {
+    const suite = await createSmokeSuite('dialog-retry-after-stop');
+
+    await suite.with.toolsDev(async ({ webUrl }) => {
+      const fakeAgents = await createFakeAgentRuntimes({
+        root: join(suite.scratchDir, 'fake-agents'),
+        runtimeIds: ['codex'],
+      });
+
+      await requestJson<{ config: Record<string, unknown> }>(webUrl, '/api/app-config', {
+        body: {
+          agentCliEnv: { codex: fakeAgents.codex.env },
+          agentId: 'codex',
+          agentModels: { codex: { model: 'default', reasoning: 'default' } },
+          designSystemId: null,
+          onboardingCompleted: true,
+          skillId: null,
+          telemetry: { artifactManifest: true, content: false, metrics: false },
+        },
+        method: 'PUT',
+      });
+
+      const project = await requestJson<ProjectResponse>(webUrl, '/api/projects', {
+        body: {
+          designSystemId: null,
+          id: randomUUID(),
+          metadata: { kind: 'prototype' },
+          name: 'Dialog retry-after-stop project',
+          pendingPrompt: null,
+          skillId: null,
+        },
+      });
+      const projectId = project.project.id;
+      const conversationId = project.conversationId;
+
+      // ---- Attempt 1: start, then user stops it ----
+      const t0 = Date.now();
+      const userMessageId1 = `user-stop-${t0}`;
+      const assistantMessageId1 = `assistant-stop-${t0}`;
+      await saveMessage(webUrl, projectId, conversationId, {
+        content: PROMPT_FIRST,
+        createdAt: t0,
+        id: userMessageId1,
+        role: 'user',
+      });
+      await saveMessage(webUrl, projectId, conversationId, {
+        agentId: 'codex',
+        agentName: 'Codex',
+        content: '',
+        createdAt: t0,
+        events: [],
+        id: assistantMessageId1,
+        role: 'assistant',
+        runStatus: 'running',
+        startedAt: t0,
+      });
+
+      const run1 = await startRun(webUrl, {
+        agentId: 'codex',
+        assistantMessageId: assistantMessageId1,
+        clientRequestId: `req-${t0}`,
+        conversationId,
+        designSystemId: null,
+        message: PROMPT_FIRST,
+        model: 'default',
+        projectId,
+        reasoning: 'default',
+        skillId: null,
+      });
+
+      // Mirror the UI handleStop path: cancel the run, then persist the
+      // assistant message with runStatus=canceled and a frozen endedAt.
+      await cancelRun(webUrl, run1.runId);
+      const stoppedAt = Date.now();
+      await saveMessage(webUrl, projectId, conversationId, {
+        agentId: 'codex',
+        agentName: 'Codex',
+        content: '',
+        createdAt: t0,
+        endedAt: stoppedAt,
+        events: [],
+        id: assistantMessageId1,
+        role: 'assistant',
+        runStatus: 'canceled',
+        startedAt: t0,
+      });
+
+      // ---- Attempt 2: retry by sending again ----
+      // Wait briefly so timestamps differ enough to be observable.
+      await delay(50);
+      const t1 = Date.now();
+      const userMessageId2 = `user-retry-${t1}`;
+      const assistantMessageId2 = `assistant-retry-${t1}`;
+      await saveMessage(webUrl, projectId, conversationId, {
+        content: PROMPT_RETRY,
+        createdAt: t1,
+        id: userMessageId2,
+        role: 'user',
+      });
+      await saveMessage(webUrl, projectId, conversationId, {
+        agentId: 'codex',
+        agentName: 'Codex',
+        content: '',
+        createdAt: t1,
+        events: [],
+        id: assistantMessageId2,
+        role: 'assistant',
+        runStatus: 'running',
+        startedAt: t1,
+      });
+
+      const run2 = await startRun(webUrl, {
+        agentId: 'codex',
+        assistantMessageId: assistantMessageId2,
+        clientRequestId: `req-${t1}`,
+        conversationId,
+        designSystemId: null,
+        message: PROMPT_RETRY,
+        model: 'default',
+        projectId,
+        reasoning: 'default',
+        skillId: null,
+      });
+
+      const finalRun2 = await waitForRunStatus(webUrl, run2.runId, 'succeeded', { timeoutMs: 30_000 });
+      expect(finalRun2.assistantMessageId).toBe(assistantMessageId2);
+
+      // Mirror the UI's onDone handler: persist the completion timestamp.
+      const finishedAt = Date.now();
+      await saveMessage(webUrl, projectId, conversationId, {
+        agentId: 'codex',
+        agentName: 'Codex',
+        content: '',
+        createdAt: t1,
+        endedAt: finishedAt,
+        events: [],
+        id: assistantMessageId2,
+        role: 'assistant',
+        runStatus: 'succeeded',
+        startedAt: t1,
+      });
+
+      // ---- Assert no merge ----
+      const allMessages = await listMessages(webUrl, projectId, conversationId);
+      const assistant1 = allMessages.find((m) => m.id === assistantMessageId1);
+      const assistant2 = allMessages.find((m) => m.id === assistantMessageId2);
+
+      expect(assistant1, 'first attempt persisted').toBeDefined();
+      expect(assistant2, 'retried attempt persisted').toBeDefined();
+
+      // Stopped attempt is preserved as historical state with a frozen timer.
+      expect(assistant1!.runStatus).toBe('canceled');
+      expect(assistant1!.startedAt).toBe(t0);
+      expect(assistant1!.endedAt).toBe(stoppedAt);
+
+      // Retried attempt has its own fresh startedAt — not merged with the
+      // previous attempt's startedAt — and its own endedAt.
+      expect(assistant2!.runStatus).toBe('succeeded');
+      expect(assistant2!.startedAt).toBe(t1);
+      expect(assistant2!.startedAt!).toBeGreaterThan(stoppedAt);
+      expect(assistant2!.endedAt).toBe(finishedAt);
+    });
+  }, 180_000);
+});
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/e2e/tests/dialog/stop-reconciles-message.test.ts
+++ b/e2e/tests/dialog/stop-reconciles-message.test.ts
@@ -24,7 +24,7 @@ import { describe, expect, test } from 'vitest';
 import { createFakeAgentRuntimes } from '@/fake-agents';
 import { requestJson } from '@/vitest/http';
 import { listMessages, saveMessage } from '@/vitest/messages';
-import { cancelRun, startRun, waitForRunStatus } from '@/vitest/runs';
+import { cancelRun, startRun, waitForRunTerminal } from '@/vitest/runs';
 import { createSmokeSuite } from '@/vitest/smoke-suite';
 
 type ProjectResponse = {
@@ -109,10 +109,11 @@ describe('dialog stop reconciles message endedAt', () => {
       await cancelRun(webUrl, run.runId);
 
       // Wait until the daemon reports the run as terminal so the reconciliation
-      // path has had a chance to run.
-      const finalRun = await waitForRunStatus(webUrl, run.runId, 'canceled', { timeoutMs: 10_000 })
-        .catch(() => waitForRunStatus(webUrl, run.runId, 'succeeded', { timeoutMs: 1_000 }));
-      expect(['canceled', 'succeeded', 'failed']).toContain(finalRun.status);
+      // path has had a chance to run. The exact terminal status (canceled vs
+      // failed vs succeeded) doesn't matter here — the assertion is about the
+      // resulting messages row, not which terminal the run landed in.
+      const finalRun = await waitForRunTerminal(webUrl, run.runId, { timeoutMs: 10_000 });
+      expect(TERMINAL_STATUSES).toContain(finalRun.status);
       const reconcileDeadline = Date.now();
 
       // Give the post-terminal reconciliation a brief moment to flush.
@@ -137,6 +138,8 @@ describe('dialog stop reconciles message endedAt', () => {
     });
   }, 180_000);
 });
+
+const TERMINAL_STATUSES = ['succeeded', 'failed', 'canceled'] as const;
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/e2e/tests/dialog/stop-reconciles-message.test.ts
+++ b/e2e/tests/dialog/stop-reconciles-message.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment node
+
+// Issue #135 scenario 1 — reattach after refresh.
+//
+// Symptom from the issue: after manually stopping a stuck run and starting it
+// again, the previous run's elapsed time keeps accumulating into the new
+// attempt. The web layer freezes the timer via `endedAt`, but if the user
+// refreshes (or the persist call races) before the canceled message is saved,
+// the message row in the daemon DB stays `run_status='running'` /
+// `ended_at=NULL`. On reload, the web reattach effect picks up the message,
+// sees the run is canceled, but never sets `endedAt` — so the renderer falls
+// back to `now - startedAt` and the timer keeps climbing forever.
+//
+// This spec exercises the daemon contract: after a chat run reaches a terminal
+// status, the corresponding assistant message row must carry both
+// `runStatus` and `endedAt` so any later reload sees a frozen timer, even when
+// the web client never managed to persist the cancel itself.
+
+import { randomUUID } from 'node:crypto';
+import { join } from 'node:path';
+
+import { describe, expect, test } from 'vitest';
+
+import { createFakeAgentRuntimes } from '@/fake-agents';
+import { requestJson } from '@/vitest/http';
+import { listMessages, saveMessage } from '@/vitest/messages';
+import { cancelRun, startRun, waitForRunStatus } from '@/vitest/runs';
+import { createSmokeSuite } from '@/vitest/smoke-suite';
+
+type ProjectResponse = {
+  conversationId: string;
+  project: { id: string; metadata?: { kind?: string }; name: string };
+};
+
+describe('dialog stop reconciles message endedAt', () => {
+  test('canceling a run sets the message endedAt even when the web client never saves the cancel', async () => {
+    const suite = await createSmokeSuite('dialog-stop-reconciles-message');
+
+    await suite.with.toolsDev(async ({ webUrl }) => {
+      const fakeAgents = await createFakeAgentRuntimes({
+        root: join(suite.scratchDir, 'fake-agents'),
+        runtimeIds: ['codex'],
+      });
+
+      await requestJson<{ config: Record<string, unknown> }>(webUrl, '/api/app-config', {
+        body: {
+          agentCliEnv: { codex: fakeAgents.codex.env },
+          agentId: 'codex',
+          agentModels: { codex: { model: 'default', reasoning: 'default' } },
+          designSystemId: null,
+          onboardingCompleted: true,
+          skillId: null,
+          telemetry: { artifactManifest: true, content: false, metrics: false },
+        },
+        method: 'PUT',
+      });
+
+      const project = await requestJson<ProjectResponse>(webUrl, '/api/projects', {
+        body: {
+          designSystemId: null,
+          id: randomUUID(),
+          metadata: { kind: 'prototype' },
+          name: 'Dialog stop reconciles project',
+          pendingPrompt: null,
+          skillId: null,
+        },
+      });
+      const projectId = project.project.id;
+      const conversationId = project.conversationId;
+
+      const startedAt = Date.now();
+      const userMessageId = `user-stop-reconcile-${startedAt}`;
+      const assistantMessageId = `assistant-stop-reconcile-${startedAt}`;
+      await saveMessage(webUrl, projectId, conversationId, {
+        content: 'Create a deterministic smoke artifact',
+        createdAt: startedAt,
+        id: userMessageId,
+        role: 'user',
+      });
+      await saveMessage(webUrl, projectId, conversationId, {
+        agentId: 'codex',
+        agentName: 'Codex',
+        content: '',
+        createdAt: startedAt,
+        events: [],
+        id: assistantMessageId,
+        role: 'assistant',
+        runStatus: 'running',
+        startedAt,
+      });
+
+      const run = await startRun(webUrl, {
+        agentId: 'codex',
+        assistantMessageId,
+        clientRequestId: `req-${startedAt}`,
+        conversationId,
+        designSystemId: null,
+        message: 'Create a deterministic smoke artifact',
+        model: 'default',
+        projectId,
+        reasoning: 'default',
+        skillId: null,
+      });
+
+      // Cancel the run. Crucially, do NOT call saveMessage afterwards — this
+      // models the user clicking Stop and then refreshing the page (or the
+      // browser dropping the in-flight PUT) before the web client persists the
+      // canceled state.
+      await cancelRun(webUrl, run.runId);
+
+      // Wait until the daemon reports the run as terminal so the reconciliation
+      // path has had a chance to run.
+      const finalRun = await waitForRunStatus(webUrl, run.runId, 'canceled', { timeoutMs: 10_000 })
+        .catch(() => waitForRunStatus(webUrl, run.runId, 'succeeded', { timeoutMs: 1_000 }));
+      expect(['canceled', 'succeeded', 'failed']).toContain(finalRun.status);
+      const reconcileDeadline = Date.now();
+
+      // Give the post-terminal reconciliation a brief moment to flush.
+      await delay(100);
+
+      const allMessages = await listMessages(webUrl, projectId, conversationId);
+      const assistant = allMessages.find((m) => m.id === assistantMessageId);
+      expect(assistant, 'assistant message present').toBeDefined();
+
+      // The DB row must reflect that the run is no longer active and must
+      // carry an endedAt that's close to the cancel/finish time. Without this,
+      // a later reload sees `endedAt=undefined`, the renderer falls back to
+      // `now - startedAt`, and the timer never freezes.
+      expect(assistant!.runStatus).not.toBe('running');
+      expect(assistant!.runStatus).not.toBe('queued');
+      expect(typeof assistant!.endedAt).toBe('number');
+      expect(assistant!.endedAt!).toBeGreaterThanOrEqual(startedAt);
+      // Allow a generous +5s window — the assertion is that endedAt was set
+      // around when the run terminated, not that the row sat with a NULL
+      // endedAt waiting for a later web write.
+      expect(assistant!.endedAt!).toBeLessThanOrEqual(reconcileDeadline + 5_000);
+    });
+  }, 180_000);
+});
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Summary
- daemon now reconciles `messages.run_status` and `messages.ended_at` when a chat run reaches a terminal state, so a stopped run's timer freezes even if the web client never managed to persist the cancel
- add `cancelRun` helper in `e2e/lib/vitest/runs.ts`
- add two regression specs under `e2e/tests/dialog/`: one for the cancel→retry no-merge contract, one for the message reconciliation gap

## Details
- Bug path: user clicks Stop, then refreshes (or the web's `saveMessage` PUT loses the race). The daemon transitions the run to `canceled` but never wrote back to the messages row, so on reload the web reattach effect sees `run_status='running'` and `ended_at=NULL`, the renderer falls back to `now - startedAt`, and the elapsed timer keeps climbing.
- Fix mirrors the existing routine (`server.ts:5406`) and orbit (`server.ts:7075`) reconciliation, scoped to the `POST /api/runs` chat path. `COALESCE(ended_at, ?)` preserves any web-persisted endedAt; the `run_status IN ('queued','running')` guard skips rows the web has already finalized.

## Validation
- `pnpm --filter @open-design/e2e test tests/dialog/stop-reconciles-message.test.ts` — red before fix, green after
- `pnpm --filter @open-design/e2e test tests/dialog/retry-after-stop.test.ts` — green (cancel→retry contract regression)
- `pnpm --filter @open-design/e2e test specs/dialog/main.spec.ts` — green (happy-path neighbor unaffected)
- `pnpm typecheck` — clean
- `pnpm guard` — clean
- `pnpm --filter @open-design/daemon test` — 10 pre-existing failures across `chat-route`, `connection-test`, `project-file-rename`, `mcp-spawn`, `finalize-design`, `desktop-import-token-gate`; confirmed via `git stash` that none are introduced by this change

## Adjacent issues found, not in scope
These are read-only source-code suspicions, not yet backed by a red e2e spec. If a follow-up spec confirms either, it will land as its own PR rather than expanding the scope of this #135 fix.

- `apps/web/src/components/ProjectView.tsx:1305`: the streaming `onError` handler can rewrite `runStatus` from `canceled` to `failed` after Stop because the `prev.runId` clause matches. Cosmetic (status badge), does not reintroduce the timer accumulation.
- API mode (`config.mode === 'api'`) bypasses `/api/runs` entirely and is structurally vulnerable to the same persist-then-refresh accumulation gap. The screenshot's Codex/ACP badges suggest the reporter hit this in daemon mode, so API mode is not in scope here.

Fixes #135