### PR TITLE
fix(web): suppress autosave indicator for draft-only Connector key edits

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -104,6 +104,26 @@ export function buildPersistedConfig(next: AppConfig, current: AppConfig): AppCo
   };
 }
 
+/**
+ * True when `next` and `last` produce an identical persisted shape —
+ * i.e. the only diffs between them are fields that buildPersistedConfig
+ * intentionally strips before disk/daemon writes (the Composio API key
+ * draft today; any future save-on-explicit-confirm secrets later).
+ *
+ * The autosave loop in Settings uses this to skip the "All changes
+ * saved" indicator transition when the user has only typed an unsaved
+ * secret. Without it, autosave completes a no-op write and flashes
+ * "Saved" — misleading users into trusting that a sensitive key has
+ * been persisted when in fact only the section-local "Save key"
+ * gesture commits it.
+ */
+export function isAutosaveDraftOnlyChange(next: AppConfig, last: AppConfig): boolean {
+  return (
+    JSON.stringify(buildPersistedConfig(next, next))
+    === JSON.stringify(buildPersistedConfig(last, last))
+  );
+}
+
 export function resolveSettingsCloseConfig(
   rendered: AppConfig,
   latestPersisted: AppConfig,

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -59,6 +59,7 @@ import {
   applyAppearanceToDocument,
   normalizeAccentColor,
 } from '../state/appearance';
+import { isAutosaveDraftOnlyChange } from '../App';
 import {
   FAILURE_SOUNDS,
   SUCCESS_SOUNDS,
@@ -1217,6 +1218,13 @@ export function SettingsDialog({
   const autosaveRetryTimerRef = useRef<number | null>(null);
   const autosavePendingFlushRef = useRef(false);
   const autosaveLatestRef = useRef<AppConfig>(cfg);
+  // Baseline used by the draft-only detector: the snapshot at the most
+  // recent successful autosave (or the initial cfg on mount). Compared
+  // against the current snapshot to decide whether the only edits
+  // since last save are intentionally-stripped fields like the
+  // Composio API key — in which case we must NOT flash "All changes
+  // saved", because the draft has not actually been persisted.
+  const autosaveLastSavedRef = useRef<AppConfig>(cfg);
   const mediaProvidersChangeVersionRef = useRef(0);
   const lastSyncedMediaProvidersVersionRef = useRef(0);
   const [autosaveRetryTick, setAutosaveRetryTick] = useState(0);
@@ -1224,6 +1232,7 @@ export function SettingsDialog({
   useEffect(() => {
     if (autosaveSkipFirstRef.current) {
       autosaveSkipFirstRef.current = false;
+      autosaveLastSavedRef.current = cfg;
       return;
     }
     setAutosaveStatus('pending');
@@ -1247,10 +1256,27 @@ export function SettingsDialog({
       const persistOptions = {
         forceMediaProviderSync: mediaProvidersVersion > lastSyncedMediaProvidersVersionRef.current,
       };
+      // Draft-only edit (e.g. the user is mid-typing the Composio API
+      // key, which only commits via the explicit "Save key" gesture):
+      // the persisted shape would be identical to what is already on
+      // disk, so a save would be a no-op that mis-reports "Saved" and
+      // makes users trust that a sensitive key was persisted when it
+      // was not. Skip the persist and settle the indicator to idle.
+      // The forced media-provider sync path still runs because that
+      // is a real outbound effect even when the persisted shape
+      // hasn't changed.
+      if (
+        !persistOptions.forceMediaProviderSync
+        && isAutosaveDraftOnlyChange(snapshot, autosaveLastSavedRef.current)
+      ) {
+        setAutosaveStatus('idle');
+        return;
+      }
       setAutosaveStatus('saving');
       void (async () => {
         try {
           await onPersist(snapshot, persistOptions);
+          autosaveLastSavedRef.current = snapshot;
           if (persistOptions.forceMediaProviderSync) {
             lastSyncedMediaProvidersVersionRef.current = mediaProvidersVersion;
           }

--- a/apps/web/tests/App.test.ts
+++ b/apps/web/tests/App.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   buildPersistedConfig,
+  isAutosaveDraftOnlyChange,
   persistComposioConfigChange,
   resolveSettingsCloseConfig,
   shouldSyncMediaProvidersOnSave,
@@ -66,6 +67,38 @@ describe('buildPersistedConfig', () => {
         { ...baseConfig, onboardingCompleted: true },
       ),
     ).toMatchObject({ onboardingCompleted: true });
+  });
+});
+
+describe('isAutosaveDraftOnlyChange', () => {
+  const savedComposio: AppConfig = {
+    ...baseConfig,
+    composio: { apiKey: '', apiKeyConfigured: true, apiKeyTail: 'beef' },
+  };
+
+  it('treats an in-flight Composio API key edit as draft-only', () => {
+    const typing: AppConfig = {
+      ...savedComposio,
+      composio: { ...savedComposio.composio, apiKey: '111' },
+    };
+    expect(isAutosaveDraftOnlyChange(typing, savedComposio)).toBe(true);
+  });
+
+  it('flags a real change (non-draft field) as persist-worthy', () => {
+    const flipped: AppConfig = { ...savedComposio, model: 'claude-opus-4-7' };
+    expect(isAutosaveDraftOnlyChange(flipped, savedComposio)).toBe(false);
+  });
+
+  it('flags apiKeyConfigured / tail flips as persist-worthy', () => {
+    const cleared: AppConfig = {
+      ...savedComposio,
+      composio: { apiKey: '', apiKeyConfigured: false, apiKeyTail: '' },
+    };
+    expect(isAutosaveDraftOnlyChange(cleared, savedComposio)).toBe(false);
+  });
+
+  it('returns true for an identical snapshot (no-op autosave tick)', () => {
+    expect(isAutosaveDraftOnlyChange(savedComposio, savedComposio)).toBe(true);
   });
 });
 


### PR DESCRIPTION
Fixes #1187.

## Symptom

After typing a replacement value (e.g. `111`) into the Composio API key field:

- The middle section correctly keeps the saved-key badge (this was already fixed in #741 / PR #751).
- But the top-right global indicator advances through `pending → saving → saved` and shows **"All changes saved"** even though no replacement key has actually been persisted.

For sensitive credentials this is the worst possible signal: it tells users their key was saved when only a draft was typed, leaving them to discover the truth later when actions silently fail with the stale key.

## Root cause

`SettingsDialog`'s autosave effect persists `cfg` on every committed edit. `App.tsx`'s `handleConfigPersist` runs `buildPersistedConfig(cfg)` which **intentionally strips `composio.apiKey`** before disk and daemon writes (the secret is committed only through the section-local "Save key" gesture, see `App.tsx:93-105` and the comment at `SettingsDialog.tsx:1201-1206`). The strip works correctly — no secret leaks to disk — but the autosave indicator transitions on the basis of "did `onPersist` resolve?" rather than "did anything actually change?". A no-op save still resolves successfully, so the indicator flashes "Saved".

## Fix

Detect autosave ticks where the only delta since the last successful save is a field that `buildPersistedConfig` strips, and skip them.

1. **`apps/web/src/App.tsx`** — export `isAutosaveDraftOnlyChange(next, last)`. Returns `true` when `next` and `last` produce identical persisted shapes (i.e. `JSON.stringify(buildPersistedConfig(next, next)) === JSON.stringify(buildPersistedConfig(last, last))`). Built on top of the existing single source of truth for "what gets written" — no new strip list to drift out of sync.
2. **`apps/web/src/components/SettingsDialog.tsx`** — the autosave effect now tracks `autosaveLastSavedRef` (initial cfg on mount → updated on each successful persist). Inside the debounced callback, before calling `onPersist`, check `isAutosaveDraftOnlyChange(snapshot, autosaveLastSavedRef.current)`. When true and no forced media-provider sync is pending, settle the indicator to `'idle'` and return early — no daemon write, no "Saved" flash.

The forced media-provider sync path still runs unchanged, because that is a real outbound effect that must fire even when the persisted shape hasn't changed.

## What this preserves

- The section-local "Save key" button remains the only way to commit a new Composio key (unchanged).
- The saved-key badge / `apiKeyConfigured` / `apiKeyTail` state machine in `ConnectorSection` is untouched.
- Non-draft edits (model, mode, agent, baseUrl, mediaProviders, ...) still trigger the autosave indicator normally.
- Media-provider sync forced by version bumps still runs even on draft-only ticks.

The change generalizes: any future field that `buildPersistedConfig` adds to the strip list will inherit the same draft-only protection without further wiring.

## Tests

`apps/web/tests/App.test.ts` — 4 new cases for `isAutosaveDraftOnlyChange`:
- Typing a Composio API key → treated as draft-only ✓
- Changing a non-draft field (model) → persist-worthy ✓
- Flipping `apiKeyConfigured` / clearing `apiKeyTail` → persist-worthy ✓
- Identical snapshot → draft-only (no-op tick) ✓

10/10 tests pass in `apps/web/tests/App.test.ts` locally.

## Verification (to confirm in CI / by reviewer)

- [ ] `pnpm --filter @open-design/web test` green
- [ ] Manual: open Settings → Connectors → Composio, type a value, observe the top-right indicator stays idle (no "All changes saved" flash); clicking "Save key" still works and the indicator correctly updates after that explicit save.
- [ ] Manual: change a non-Composio field (e.g. switch model), confirm the indicator still flashes "Saved" as before.

## Out of scope (left to follow-ups)

- Surfacing a section-local "Unsaved key draft" badge on the Composio input (suggested in the issue) — the existing `ConnectorSection` already has its own draft state via the "Save key" button gating; a dedicated copy-string change is a separate UX iteration that should coordinate with #1101 / #1182 (#654 save-success feedback work referenced in the issue triage).

Refs #1187.