### PR TITLE
fix(settings): suppress autosave flicker on Composio key drafts

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -1220,12 +1220,22 @@ export function SettingsDialog({
   const mediaProvidersChangeVersionRef = useRef(0);
   const lastSyncedMediaProvidersVersionRef = useRef(0);
   const [autosaveRetryTick, setAutosaveRetryTick] = useState(0);
+  // Snapshot of the last cfg that triggered a real autosave cycle. Used
+  // to distinguish a meaningful edit from a Composio-draft-only diff so
+  // the indicator does not flash "All changes saved" while the user is
+  // still typing a replacement key that the daemon has not received.
+  const lastAutosavedCfgRef = useRef<AppConfig | null>(null);
   autosaveLatestRef.current = cfg;
   useEffect(() => {
     if (autosaveSkipFirstRef.current) {
       autosaveSkipFirstRef.current = false;
+      lastAutosavedCfgRef.current = cfg;
       return;
     }
+    if (!autosaveDiffIsMeaningful(lastAutosavedCfgRef.current, cfg)) {
+      return;
+    }
+    lastAutosavedCfgRef.current = cfg;
     setAutosaveStatus('pending');
     if (autosaveSavedTimerRef.current != null) {
       window.clearTimeout(autosaveSavedTimerRef.current);
@@ -2579,6 +2589,46 @@ export function deriveComposioCredentialState(
   if (hasSavedKey) return 'saved';
   if (hasPendingEdit) return 'pending-new';
   return 'empty';
+}
+
+/**
+ * Compare two configs ignoring the in-flight Composio API key draft.
+ *
+ * The autosave loop fires on every committed edit to `cfg`, including
+ * keystrokes in the Composio API key field. That field is intentionally
+ * stripped before anything reaches localStorage or the daemon (see
+ * `buildPersistedConfig` in `App.tsx` and the "Save key" gesture in
+ * `ConnectorSection`), so a draft-only diff is a non-event for the
+ * persistence layer.
+ *
+ * Returning `false` from this helper lets the autosave effect skip the
+ * pending -> saving -> saved status flicker for that case so the global
+ * "All changes saved" indicator never reports a write the daemon never
+ * received. Returns `true` for any other diff (including
+ * apiKeyConfigured / apiKeyTail changes, which DO come from the daemon
+ * after a real save).
+ */
+export function autosaveDiffIsMeaningful(
+  prev: AppConfig | null,
+  next: AppConfig,
+): boolean {
+  if (prev === null) return true;
+  if (prev === next) return false;
+  const stripDraftKey = (cfg: AppConfig): AppConfig => {
+    if (!cfg.composio) return cfg;
+    const { apiKey: _draft, ...rest } = cfg.composio;
+    // A composio block with no persistent state (just the draft apiKey)
+    // is functionally equivalent to no composio block at all -- nothing
+    // would be written to localStorage or the daemon. Collapse it so the
+    // "I added a draft" transition does not register as a meaningful
+    // diff.
+    if (Object.keys(rest).length === 0) {
+      const { composio: _composio, ...withoutComposio } = cfg;
+      return withoutComposio as AppConfig;
+    }
+    return { ...cfg, composio: rest };
+  };
+  return JSON.stringify(stripDraftKey(prev)) !== JSON.stringify(stripDraftKey(next));
 }
 
 function ConnectorSection({

--- a/apps/web/tests/components/SettingsDialog.test.ts
+++ b/apps/web/tests/components/SettingsDialog.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   agentRefreshOptionsForConfig,
+  autosaveDiffIsMeaningful,
   canFetchProviderModels,
   canRunProviderConnectionTest,
   deriveComposioCredentialState,
@@ -443,6 +444,86 @@ describe('deriveComposioCredentialState', () => {
     expect(
       deriveComposioCredentialState({ apiKey: '   \t\n', apiKeyConfigured: true }),
     ).toBe('saved');
+  });
+});
+
+describe('autosaveDiffIsMeaningful', () => {
+  // Issue #1187: typing a Composio API key draft fired the autosave loop
+  // and made the global "All changes saved" indicator flash for every
+  // keystroke even though the draft is intentionally stripped before
+  // anything reaches the daemon. The helper now suppresses that flicker
+  // by reporting draft-only diffs as non-events.
+
+  it('treats the initial (null) snapshot as meaningful so first edits still fire', () => {
+    expect(autosaveDiffIsMeaningful(null, baseConfig)).toBe(true);
+  });
+
+  it('treats the identical reference as a no-op', () => {
+    expect(autosaveDiffIsMeaningful(baseConfig, baseConfig)).toBe(false);
+  });
+
+  it('returns true when a non-composio field changes (e.g. model)', () => {
+    const next: AppConfig = { ...baseConfig, model: 'claude-opus-4-7' };
+    expect(autosaveDiffIsMeaningful(baseConfig, next)).toBe(true);
+  });
+
+  it('returns false when only the Composio apiKey draft changes', () => {
+    const prev: AppConfig = {
+      ...baseConfig,
+      composio: { apiKey: '', apiKeyConfigured: true, apiKeyTail: 'abcd' },
+    };
+    const next: AppConfig = {
+      ...prev,
+      composio: { ...prev.composio, apiKey: '111' },
+    };
+    expect(autosaveDiffIsMeaningful(prev, next)).toBe(false);
+  });
+
+  it('returns true when apiKeyConfigured changes (real save coming back from the daemon)', () => {
+    const prev: AppConfig = {
+      ...baseConfig,
+      composio: { apiKey: '', apiKeyConfigured: false },
+    };
+    const next: AppConfig = {
+      ...baseConfig,
+      composio: { apiKey: '', apiKeyConfigured: true, apiKeyTail: 'abcd' },
+    };
+    expect(autosaveDiffIsMeaningful(prev, next)).toBe(true);
+  });
+
+  it('returns true when apiKeyTail changes (daemon echoed back a new tail)', () => {
+    const prev: AppConfig = {
+      ...baseConfig,
+      composio: { apiKey: '', apiKeyConfigured: true, apiKeyTail: 'abcd' },
+    };
+    const next: AppConfig = {
+      ...baseConfig,
+      composio: { apiKey: '', apiKeyConfigured: true, apiKeyTail: 'wxyz' },
+    };
+    expect(autosaveDiffIsMeaningful(prev, next)).toBe(true);
+  });
+
+  it('handles the "previously no composio block, now drafting" transition without flicker', () => {
+    const next: AppConfig = {
+      ...baseConfig,
+      composio: { apiKey: '111' },
+    };
+    // The prev cfg has no composio block; next has a draft-only composio block.
+    // This is a draft-only change for autosave purposes.
+    expect(autosaveDiffIsMeaningful(baseConfig, next)).toBe(false);
+  });
+
+  it('still returns true when a draft AND a real field both change', () => {
+    const prev: AppConfig = {
+      ...baseConfig,
+      composio: { apiKey: '', apiKeyConfigured: true },
+    };
+    const next: AppConfig = {
+      ...prev,
+      model: 'claude-opus-4-7',
+      composio: { ...prev.composio, apiKey: '111' },
+    };
+    expect(autosaveDiffIsMeaningful(prev, next)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Typing a new Composio API key into the Connectors settings caused the global "All changes saved" indicator to flash for every keystroke even though the draft is intentionally stripped before anything reaches localStorage or the daemon. The contradiction the issue describes - the saved-key badge still showing the old key, the user typing a replacement, and the top-right pill claiming the new value is already saved - lands directly on this autosave loop.

Closes #1187

## Why this matters

The save semantics for an API key need to be unambiguous. The explicit "Save key" gesture in `ConnectorSection` is the only path that actually persists a Composio key (see also `buildPersistedConfig` in `App.tsx`, which drops the secret before localStorage), so the global autosave indicator firing on each keystroke is straightforwardly wrong for that field. With the indicator flicker gone the existing `saved-pending` state already does the right thing on the credentials surface: the saved-key badge stays anchored while the input shows the unsaved draft, and "Save key" is the only thing that flips the badge to a new value.

## Change

`apps/web/src/components/SettingsDialog.tsx`

Adds `autosaveDiffIsMeaningful(prev, next)`. It strips the in-flight `composio.apiKey` from both sides before comparing, and also collapses a `composio` block whose only field is that draft. The autosave effect now compares the freshly committed `cfg` against the last snapshot that actually fired and skips the `pending -> saving -> saved` cycle when the only diff is a draft key. The helper is exported so the existing test suite can pin its behaviour.

Real changes still fire as before: `apiKeyConfigured` flipping to `true` or `apiKeyTail` echoing back from the daemon after a successful "Save key" call both count as meaningful diffs, so the "just saved" confirmation still appears for genuine writes - just not for typing.

The `saved-pending` credential state and the `Save key` button are unchanged. The behaviour the issue asks for ("Saving a replacement key should require an explicit confirmation action such as a dedicated Save key button") was already in place; this PR removes the false signal that conflicted with it.

## Tests

`apps/web/tests/components/SettingsDialog.test.ts` gets a new `autosaveDiffIsMeaningful` describe block with 8 unit tests covering the initial null snapshot, identity, non-composio field changes, the draft-key-only diff that motivates the fix, the `apiKeyConfigured` and `apiKeyTail` paths (daemon-echoed changes that MUST still fire), the "no composio block -> draft-only block" transition, and the mixed draft + real-field case. All 52 tests in the file pass on the new code. `pnpm --filter @open-design/web typecheck` exits clean.

## What I did not change

- `deriveComposioCredentialState` and the `saved-pending` UI state are kept as-is; they already render the right thing once the global indicator stops contradicting them.
- The `Save key` button, the two-stage destructive Clear confirmation, and the daemon round-trip in `persistComposioConfigChange` are untouched.
- No copy or i18n changes; the original `settings.autosaveSaved` string is correct - it just should not fire for draft keys.

## Risk

Low. The helper is a pure comparison function with explicit unit tests for every edge case. The autosave effect's other deps (`onPersist`, `autosaveRetryTick`) and the unmount-flush path are unchanged.
