### PR TITLE
[codex] Handle empty API responses as no output

### DIFF
--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -72,6 +72,9 @@ export function AssistantMessage({
     | undefined;
   const produced = message.producedFiles ?? [];
   const roleLabel = assistantRoleLabel(message, t);
+  const hasEmptyResponse = events.some(
+    (e) => e.kind === "status" && e.label === "empty_response"
+  );
   const unfinishedTodos = streaming ? [] : unfinishedTodosFromEvents(events);
   const canContinueTodos =
     !streaming &&
@@ -154,6 +157,7 @@ export function AssistantMessage({
           endedAt={message.endedAt}
           usage={usage}
           hasUnfinishedTodos={unfinishedTodos.length > 0}
+          hasEmptyResponse={hasEmptyResponse}
         />
       </div>
     </div>
@@ -219,16 +223,18 @@ function AssistantFooter({
   endedAt,
   usage,
   hasUnfinishedTodos,
+  hasEmptyResponse,
 }: {
   streaming: boolean;
   startedAt: number | undefined;
   endedAt: number | undefined;
   usage: Extract<AgentEvent, { kind: "usage" }> | undefined;
   hasUnfinishedTodos: boolean;
+  hasEmptyResponse: boolean;
 }) {
   const t = useT();
   const elapsed = useLiveElapsed(streaming, startedAt, endedAt);
-  if (!streaming && !elapsed && !usage && !hasUnfinishedTodos) return null;
+  if (!streaming && !elapsed && !usage && !hasUnfinishedTodos && !hasEmptyResponse) return null;
   return (
     <div
       className="assistant-footer"
@@ -238,6 +244,8 @@ function AssistantFooter({
       <span className="assistant-label">
         {streaming
           ? t("assistant.workingLabel")
+          : hasEmptyResponse
+          ? t("assistant.emptyResponseLabel")
           : hasUnfinishedTodos
           ? t("assistant.unfinishedLabel")
           : t("assistant.doneLabel")}
@@ -804,7 +812,8 @@ function buildBlocks(events: AgentEvent[]): Block[] {
         ev.label === "streaming" ||
         ev.label === "starting" ||
         ev.label === "requesting" ||
-        ev.label === "thinking"
+        ev.label === "thinking" ||
+        ev.label === "empty_response"
       )
         continue;
       const last = out[out.length - 1];

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1133,6 +1133,7 @@ export function ProjectView({
 
       const parser = createArtifactParser();
       let liveHtml = '';
+      let streamedText = '';
 
       const updateAssistant = (updater: (prev: ChatMessage) => ChatMessage) => {
         setMessages((curr) =>
@@ -1242,7 +1243,10 @@ export function ProjectView({
       abortRef.current = controller;
       cancelRef.current = cancelController;
       const handlers = {
-        onDelta: textBuffer.appendContent,
+        onDelta: (delta: string) => {
+          streamedText += delta;
+          textBuffer.appendContent(delta);
+        },
         onAgentEvent: (ev: AgentEvent) => {
           if (ev.kind === 'text') textBuffer.appendTextEvent(ev.text);
           else pushEvent(ev);
@@ -1259,6 +1263,7 @@ export function ProjectView({
           const emptyApiResponse =
             config.mode === 'api' &&
             !fullText.trim() &&
+            !streamedText.trim() &&
             !liveHtml.trim();
           if (emptyApiResponse) {
             const diagnostic = t('assistant.emptyResponseMessage');

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1276,6 +1276,9 @@ export function ProjectView({
               true,
               { telemetryFinalized: true },
             );
+            if (commentAttachments.length > 0) {
+              void patchAttachedStatuses(commentAttachments, 'failed');
+            }
             setStreaming(false);
             abortRef.current = null;
             cancelRef.current = null;

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1247,7 +1247,7 @@ export function ProjectView({
           if (ev.kind === 'text') textBuffer.appendTextEvent(ev.text);
           else pushEvent(ev);
         },
-        onDone: () => {
+        onDone: (fullText = '') => {
           textBuffer.flush();
           textBuffer.cancel();
           cancelSendTextBuffer();
@@ -1255,6 +1255,33 @@ export function ProjectView({
             if (ev.type === 'artifact:end') {
               setArtifact((prev) => (prev ? { ...prev, html: ev.fullContent } : null));
             }
+          }
+          const emptyApiResponse =
+            config.mode === 'api' &&
+            !fullText.trim() &&
+            !liveHtml.trim();
+          if (emptyApiResponse) {
+            const diagnostic = t('assistant.emptyResponseMessage');
+            updateMessageById(
+              assistantId,
+              (prev) => ({
+                ...prev,
+                endedAt: Date.now(),
+                events: [
+                  ...(prev.events ?? []),
+                  { kind: 'status', label: 'empty_response', detail: config.model },
+                  { kind: 'text', text: diagnostic },
+                ],
+              }),
+              true,
+              { telemetryFinalized: true },
+            );
+            setStreaming(false);
+            abortRef.current = null;
+            cancelRef.current = null;
+            void refreshProjectFiles();
+            onProjectsRefresh();
+            return;
           }
           updateAssistant((prev) => ({
             ...prev,

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -929,6 +929,8 @@ export const ar: Dict = {
   'assistant.role': 'المساعد',
   'assistant.workingLabel': 'جاري العمل',
   'assistant.doneLabel': 'تم',
+  'assistant.emptyResponseLabel': 'No output',
+  'assistant.emptyResponseMessage': 'The provider ended the request without returning text or an artifact. Try another model or provider, check quota, or retry.',
   'assistant.unfinishedLabel': 'توقف مع عمل غير مكتمل',
   'assistant.unfinishedSummary': 'تبقى {n} مهمة/مهام',
   'assistant.unfinishedMore': '+{n} أكثر',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -817,6 +817,8 @@ export const de: Dict = {
   'assistant.role': 'Assistent',
   'assistant.workingLabel': 'Arbeitet',
   'assistant.doneLabel': 'Fertig',
+  'assistant.emptyResponseLabel': 'No output',
+  'assistant.emptyResponseMessage': 'The provider ended the request without returning text or an artifact. Try another model or provider, check quota, or retry.',
   'assistant.unfinishedLabel': 'Mit unerledigter Arbeit gestoppt',
   'assistant.unfinishedSummary': '{n} Aufgabe(n) offen',
   'assistant.unfinishedMore': '+{n} weitere',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1031,6 +1031,8 @@ export const en: Dict = {
   'assistant.role': 'Assistant',
   'assistant.workingLabel': 'Working',
   'assistant.doneLabel': 'Done',
+  'assistant.emptyResponseLabel': 'No output',
+  'assistant.emptyResponseMessage': 'The provider ended the request without returning text or an artifact. Try another model or provider, check quota, or retry.',
   'assistant.unfinishedLabel': 'Stopped with unfinished work',
   'assistant.unfinishedSummary': '{n} task(s) remain',
   'assistant.unfinishedMore': '+{n} more',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -818,6 +818,8 @@ export const esES: Dict = {
   'assistant.role': 'Asistente',
   'assistant.workingLabel': 'Trabajando',
   'assistant.doneLabel': 'Listo',
+  'assistant.emptyResponseLabel': 'No output',
+  'assistant.emptyResponseMessage': 'The provider ended the request without returning text or an artifact. Try another model or provider, check quota, or retry.',
   'assistant.unfinishedLabel': 'Detenido con tareas pendientes',
   'assistant.unfinishedSummary': 'quedan {n} tarea(s)',
   'assistant.unfinishedMore': '+{n} más',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -903,6 +903,8 @@ export const fa: Dict = {
   'assistant.role': 'دستیار',
   'assistant.workingLabel': 'در حال کار',
   'assistant.doneLabel': 'انجام شد',
+  'assistant.emptyResponseLabel': 'No output',
+  'assistant.emptyResponseMessage': 'The provider ended the request without returning text or an artifact. Try another model or provider, check quota, or retry.',
   'assistant.unfinishedLabel': 'با کار ناتمام متوقف شد',
   'assistant.unfinishedSummary': '{n} وظیفه باقی مانده',
   'assistant.unfinishedMore': '+{n} بیشتر',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -929,6 +929,8 @@ export const fr: Dict = {
   'assistant.role': 'Assistant',
   'assistant.workingLabel': 'En cours',
   'assistant.doneLabel': 'Terminé',
+  'assistant.emptyResponseLabel': 'No output',
+  'assistant.emptyResponseMessage': 'The provider ended the request without returning text or an artifact. Try another model or provider, check quota, or retry.',
   'assistant.unfinishedLabel': 'Arrêté avec du travail non terminé',
   'assistant.unfinishedSummary': '{n} tâche(s) restante(s)',
   'assistant.unfinishedMore': '+{n} de plus',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -929,6 +929,8 @@ export const hu: Dict = {
   'assistant.role': 'Asszisztens',
   'assistant.workingLabel': 'Dolgozik',
   'assistant.doneLabel': 'Kész',
+  'assistant.emptyResponseLabel': 'No output',
+  'assistant.emptyResponseMessage': 'The provider ended the request without returning text or an artifact. Try another model or provider, check quota, or retry.',
   'assistant.unfinishedLabel': 'Befejezetlen munkával állt le',
   'assistant.unfinishedSummary': '{n} feladat hátravan',
   'assistant.unfinishedMore': '+{n} további',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -1068,6 +1068,8 @@ export const id: Dict = {
   'assistant.role': 'Asisten',
   'assistant.workingLabel': 'Sedang bekerja',
   'assistant.doneLabel': 'Selesai',
+  'assistant.emptyResponseLabel': 'No output',
+  'assistant.emptyResponseMessage': 'The provider ended the request without returning text or an artifact. Try another model or provider, check quota, or retry.',
   'assistant.unfinishedLabel': 'Belum selesai',
   'assistant.unfinishedSummary': '{n} tugas tersisa',
   'assistant.unfinishedMore': '+{n} lagi',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -816,6 +816,8 @@ export const ja: Dict = {
   'assistant.role': 'アシスタント',
   'assistant.workingLabel': '作業中',
   'assistant.doneLabel': '完了',
+  'assistant.emptyResponseLabel': 'No output',
+  'assistant.emptyResponseMessage': 'The provider ended the request without returning text or an artifact. Try another model or provider, check quota, or retry.',
   'assistant.unfinishedLabel': '未完了の作業があります',
   'assistant.unfinishedSummary': '{n} 件のタスクが残っています',
   'assistant.unfinishedMore': '+{n} 件',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -929,6 +929,8 @@ export const ko: Dict = {
   'assistant.role': '어시스턴트 (Assistant)',
   'assistant.workingLabel': '작업 중',
   'assistant.doneLabel': '완료됨',
+  'assistant.emptyResponseLabel': 'No output',
+  'assistant.emptyResponseMessage': 'The provider ended the request without returning text or an artifact. Try another model or provider, check quota, or retry.',
   'assistant.unfinishedLabel': '작업을 마치지 못하고 중지됨',
   'assistant.unfinishedSummary': '{n}개 작업 남음',
   'assistant.unfinishedMore': '+{n}개 추가',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -929,6 +929,8 @@ export const pl: Dict = {
   'assistant.role': 'Asystent',
   'assistant.workingLabel': 'Pracuję',
   'assistant.doneLabel': 'Gotowe',
+  'assistant.emptyResponseLabel': 'No output',
+  'assistant.emptyResponseMessage': 'The provider ended the request without returning text or an artifact. Try another model or provider, check quota, or retry.',
   'assistant.unfinishedLabel': 'Zatrzymano z niedokończonymi zadaniami',
   'assistant.unfinishedSummary': 'pozostało {n} zadań',
   'assistant.unfinishedMore': '+{n} więcej',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -961,6 +961,8 @@ export const ptBR: Dict = {
   'assistant.role': 'Assistente',
   'assistant.workingLabel': 'Trabalhando',
   'assistant.doneLabel': 'Concluído',
+  'assistant.emptyResponseLabel': 'No output',
+  'assistant.emptyResponseMessage': 'The provider ended the request without returning text or an artifact. Try another model or provider, check quota, or retry.',
   'assistant.unfinishedLabel': 'Interrompido com trabalho pendente',
   'assistant.unfinishedSummary': '{n} tarefa(s) restante(s)',
   'assistant.unfinishedMore': '+{n} mais',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -961,6 +961,8 @@ export const ru: Dict = {
   'assistant.role': 'Ассистент',
   'assistant.workingLabel': 'Работает',
   'assistant.doneLabel': 'Готово',
+  'assistant.emptyResponseLabel': 'No output',
+  'assistant.emptyResponseMessage': 'The provider ended the request without returning text or an artifact. Try another model or provider, check quota, or retry.',
   'assistant.unfinishedLabel': 'Остановлено с незавершенной работой',
   'assistant.unfinishedSummary': 'Осталось задач: {n}',
   'assistant.unfinishedMore': '+{n} еще',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -932,6 +932,8 @@ export const th: Dict = {
   'assistant.role': 'หน่วยผู้ช่วยเหลือส่วนตัว',
   'assistant.workingLabel': 'ดำเนินระบบรับทำงานอยู่',
   'assistant.doneLabel': 'บรรลุสู่ระดับพร้อมแล้ว',
+  'assistant.emptyResponseLabel': 'No output',
+  'assistant.emptyResponseMessage': 'The provider ended the request without returning text or an artifact. Try another model or provider, check quota, or retry.',
   'assistant.unfinishedLabel': 'พ้นจากโหมดเพราะงานตกค้าง',
   'assistant.unfinishedSummary': 'งาน {n} ขั้นลืมอยู่ข้างหลัง',
   'assistant.unfinishedMore': 'ทิ้งเพิ่มมาอีก +{n}',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -920,6 +920,8 @@ export const tr: Dict = {
   'assistant.role': 'Asistan',
   'assistant.workingLabel': 'Çalışıyor',
   'assistant.doneLabel': 'Bitti',
+  'assistant.emptyResponseLabel': 'No output',
+  'assistant.emptyResponseMessage': 'The provider ended the request without returning text or an artifact. Try another model or provider, check quota, or retry.',
   'assistant.unfinishedLabel': 'Bitmemiş işlerle durduruldu',
   'assistant.unfinishedSummary': '{n} görev kaldı',
   'assistant.unfinishedMore': '+{n} daha',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -962,6 +962,8 @@ export const uk: Dict = {
   'assistant.role': 'Асистент',
   'assistant.workingLabel': 'Роботи',
   'assistant.doneLabel': 'Готово',
+  'assistant.emptyResponseLabel': 'No output',
+  'assistant.emptyResponseMessage': 'The provider ended the request without returning text or an artifact. Try another model or provider, check quota, or retry.',
   'assistant.unfinishedLabel': 'Зупинено з незавершеною роботою',
   'assistant.unfinishedSummary': 'залишилось {n} завдання(нь)',
   'assistant.unfinishedMore': '+ще {n}',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1002,6 +1002,8 @@ export const zhCN: Dict = {
   'assistant.role': '助手',
   'assistant.workingLabel': '执行中',
   'assistant.doneLabel': '已完成',
+  'assistant.emptyResponseLabel': '无输出',
+  'assistant.emptyResponseMessage': '服务商结束了请求，但没有返回文本或设计产物。请尝试更换模型或服务商、检查额度，或重试。',
   'assistant.unfinishedLabel': '已停止，仍有未完成任务',
   'assistant.unfinishedSummary': '剩余 {n} 个任务',
   'assistant.unfinishedMore': '还有 {n} 个',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -995,6 +995,8 @@ export const zhTW: Dict = {
   'assistant.role': '助手',
   'assistant.workingLabel': '執行中',
   'assistant.doneLabel': '已完成',
+  'assistant.emptyResponseLabel': '無輸出',
+  'assistant.emptyResponseMessage': '服務商結束了請求，但沒有返回文字或設計產物。請嘗試更換模型或服務商、檢查額度，或重試。',
   'assistant.outTokens': '{n} 輸出',
   'assistant.producedFiles': '本輪產出的檔案',
   'assistant.openFile': '開啟',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -1184,6 +1184,8 @@ export interface Dict {
   'assistant.role': string;
   'assistant.workingLabel': string;
   'assistant.doneLabel': string;
+  'assistant.emptyResponseLabel': string;
+  'assistant.emptyResponseMessage': string;
   'assistant.unfinishedLabel': string;
   'assistant.unfinishedSummary': string;
   'assistant.unfinishedMore': string;

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -1,0 +1,279 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ProjectView } from '../../src/components/ProjectView';
+import { streamMessage } from '../../src/providers/anthropic';
+import type { StreamHandlers } from '../../src/providers/anthropic';
+import { writeProjectTextFile } from '../../src/providers/registry';
+import { saveMessage } from '../../src/state/projects';
+import type {
+  AgentEvent,
+  AgentInfo,
+  AppConfig,
+  ChatAttachment,
+  ChatCommentAttachment,
+  ChatMessage,
+  Conversation,
+  DesignSystemSummary,
+  Project,
+  SkillSummary,
+} from '../../src/types';
+
+vi.mock('../../src/router', () => ({
+  navigate: vi.fn(),
+}));
+
+vi.mock('../../src/providers/anthropic', () => ({
+  streamMessage: vi.fn(),
+}));
+
+vi.mock('../../src/providers/daemon', () => ({
+  fetchChatRunStatus: vi.fn(),
+  listActiveChatRuns: vi.fn().mockResolvedValue([]),
+  reattachDaemonRun: vi.fn(),
+  streamViaDaemon: vi.fn(),
+}));
+
+vi.mock('../../src/providers/project-events', () => ({
+  useProjectFileEvents: vi.fn(),
+}));
+
+vi.mock('../../src/providers/registry', async () => {
+  const actual = await vi.importActual<typeof import('../../src/providers/registry')>(
+    '../../src/providers/registry',
+  );
+  return {
+    ...actual,
+    deletePreviewComment: vi.fn(),
+    fetchDesignSystem: vi.fn().mockResolvedValue(null),
+    fetchLiveArtifacts: vi.fn().mockResolvedValue([]),
+    fetchPreviewComments: vi.fn().mockResolvedValue([]),
+    fetchProjectFiles: vi.fn().mockResolvedValue([]),
+    fetchSkill: vi.fn().mockResolvedValue(null),
+    patchPreviewCommentStatus: vi.fn(),
+    upsertPreviewComment: vi.fn(),
+    writeProjectTextFile: vi.fn(),
+  };
+});
+
+vi.mock('../../src/state/projects', async () => {
+  const actual = await vi.importActual<typeof import('../../src/state/projects')>(
+    '../../src/state/projects',
+  );
+  const mockConversation = (projectId: string): Conversation => ({
+    id: `conv-${projectId}`,
+    projectId,
+    title: null,
+    createdAt: 1,
+    updatedAt: 1,
+  });
+  return {
+    ...actual,
+    createConversation: vi.fn().mockImplementation(async (projectId: string) => mockConversation(projectId)),
+    deleteConversation: vi.fn(),
+    getTemplate: vi.fn().mockResolvedValue(null),
+    listConversations: vi.fn().mockImplementation(async (projectId: string) => [mockConversation(projectId)]),
+    listMessages: vi.fn().mockResolvedValue([]),
+    loadTabs: vi.fn().mockResolvedValue({ tabs: [], active: null }),
+    patchConversation: vi.fn(),
+    patchProject: vi.fn(),
+    saveMessage: vi.fn(),
+    saveTabs: vi.fn(),
+  };
+});
+
+vi.mock('../../src/components/AppChromeHeader', () => ({
+  AppChromeHeader: ({ children }: { children: ReactNode }) => <header>{children}</header>,
+}));
+
+vi.mock('../../src/components/AvatarMenu', () => ({
+  AvatarMenu: () => null,
+}));
+
+vi.mock('../../src/components/FileWorkspace', () => ({
+  FileWorkspace: () => <div data-testid="file-workspace" />,
+}));
+
+vi.mock('../../src/components/Loading', () => ({
+  CenteredLoader: () => <div data-testid="loader" />,
+}));
+
+vi.mock('../../src/components/ChatPane', () => ({
+  ChatPane: ({
+    messages,
+    onSend,
+  }: {
+    messages: ChatMessage[];
+    onSend: (
+      prompt: string,
+      attachments: ChatAttachment[],
+      commentAttachments: ChatCommentAttachment[],
+    ) => void;
+  }) => (
+    <div>
+      <button type="button" onClick={() => onSend('Create a login page', [], [])}>
+        send
+      </button>
+      {messages.map((message) => (
+        <article key={message.id} data-testid={`message-${message.role}`}>
+          <span>{message.content}</span>
+          <span>{message.runStatus ?? 'no-run-status'}</span>
+          {(message.events ?? []).map((event, index) => (
+            <span key={index}>
+              {event.kind === 'status' ? `${event.label}:${event.detail ?? ''}` : ''}
+              {event.kind === 'text' ? event.text : ''}
+            </span>
+          ))}
+        </article>
+      ))}
+    </div>
+  ),
+}));
+
+const mockedStreamMessage = vi.mocked(streamMessage);
+const mockedSaveMessage = vi.mocked(saveMessage);
+const mockedWriteProjectTextFile = vi.mocked(writeProjectTextFile);
+
+const config: AppConfig = {
+  mode: 'api',
+  apiProtocol: 'openai',
+  apiKey: 'sk-test',
+  baseUrl: 'https://api.deepseek.com',
+  model: 'deepseek-chat',
+  agentId: null,
+  skillId: null,
+  designSystemId: null,
+};
+
+const project: Project = {
+  id: 'project-1',
+  name: 'Project',
+  skillId: null,
+  designSystemId: null,
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+function renderProjectView() {
+  return render(
+    <ProjectView
+      project={project}
+      routeFileName={null}
+      config={config}
+      agents={[] as AgentInfo[]}
+      skills={[] as SkillSummary[]}
+      designSystems={[] as DesignSystemSummary[]}
+      daemonLive
+      onModeChange={vi.fn()}
+      onAgentChange={vi.fn()}
+      onAgentModelChange={vi.fn()}
+      onRefreshAgents={vi.fn()}
+      onOpenSettings={vi.fn()}
+      onBack={vi.fn()}
+      onClearPendingPrompt={vi.fn()}
+      onTouchProject={vi.fn()}
+      onProjectChange={vi.fn()}
+      onProjectsRefresh={vi.fn()}
+    />,
+  );
+}
+
+describe('ProjectView API empty response handling', () => {
+  beforeEach(() => {
+    mockedStreamMessage.mockReset();
+    mockedSaveMessage.mockClear();
+    mockedWriteProjectTextFile.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('marks an empty API completion as a soft no-output state instead of succeeded', async () => {
+    mockedStreamMessage.mockImplementation(async (
+      _cfg: AppConfig,
+      _system: string,
+      _history: ChatMessage[],
+      _signal: AbortSignal,
+      handlers: StreamHandlers,
+    ) => {
+      handlers.onDone('');
+    });
+    renderProjectView();
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'send' })).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: 'send' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('empty_response:deepseek-chat')).toBeTruthy();
+    });
+    expect(screen.getByText(/provider ended the request/i)).toBeTruthy();
+    expect(screen.queryByText('succeeded')).toBeNull();
+
+    await waitFor(() => {
+      expect(
+        mockedSaveMessage.mock.calls.some((call) => {
+          const message = call[2] as ChatMessage;
+          return (
+            message.role === 'assistant' &&
+            message.runStatus === undefined &&
+            message.events?.some(
+              (event: AgentEvent) => event.kind === 'status' && event.label === 'empty_response',
+            )
+          );
+        }),
+      ).toBe(true);
+    });
+  });
+
+  it('keeps normal API text completions on the succeeded path', async () => {
+    mockedStreamMessage.mockImplementation(async (
+      _cfg: AppConfig,
+      _system: string,
+      _history: ChatMessage[],
+      _signal: AbortSignal,
+      handlers: StreamHandlers,
+    ) => {
+      handlers.onDelta('hello');
+      handlers.onDone('hello');
+    });
+    renderProjectView();
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'send' })).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: 'send' }));
+
+    await waitFor(() => expect(screen.getAllByText('hello').length).toBeGreaterThan(0));
+    await waitFor(() => expect(screen.getByText('succeeded')).toBeTruthy());
+    expect(screen.queryByText(/provider ended the request/i)).toBeNull();
+  });
+
+  it('keeps API artifact completions on the succeeded path even when done text is empty', async () => {
+    const artifact =
+      '<artifact identifier="landing-page" type="text/html" title="Landing Page">' +
+      '<!doctype html><html><head><title>Landing</title></head><body><main><h1>Landing page</h1><p>Generated design artifact with enough structure to persist.</p></main></body></html>' +
+      '</artifact>';
+    mockedStreamMessage.mockImplementation(async (
+      _cfg: AppConfig,
+      _system: string,
+      _history: ChatMessage[],
+      _signal: AbortSignal,
+      handlers: StreamHandlers,
+    ) => {
+      handlers.onDelta(artifact);
+      handlers.onDone('');
+    });
+    renderProjectView();
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'send' })).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: 'send' }));
+
+    await waitFor(() => expect(screen.getByText('succeeded')).toBeTruthy());
+    await waitFor(() => expect(mockedWriteProjectTextFile).toHaveBeenCalled());
+    expect(screen.queryByText(/provider ended the request/i)).toBeNull();
+    expect(screen.queryByText('empty_response:deepseek-chat')).toBeNull();
+  });
+});

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ProjectView } from '../../src/components/ProjectView';
 import { streamMessage } from '../../src/providers/anthropic';
 import type { StreamHandlers } from '../../src/providers/anthropic';
-import { writeProjectTextFile } from '../../src/providers/registry';
+import { patchPreviewCommentStatus, writeProjectTextFile } from '../../src/providers/registry';
 import { saveMessage } from '../../src/state/projects';
 import type {
   AgentEvent,
@@ -21,6 +21,10 @@ import type {
   Project,
   SkillSummary,
 } from '../../src/types';
+
+const chatPaneMockState = vi.hoisted(() => ({
+  commentAttachments: [] as ChatCommentAttachment[],
+}));
 
 vi.mock('../../src/router', () => ({
   navigate: vi.fn(),
@@ -114,7 +118,7 @@ vi.mock('../../src/components/ChatPane', () => ({
     ) => void;
   }) => (
     <div>
-      <button type="button" onClick={() => onSend('Create a login page', [], [])}>
+      <button type="button" onClick={() => onSend('Create a login page', [], chatPaneMockState.commentAttachments)}>
         send
       </button>
       {messages.map((message) => (
@@ -136,6 +140,7 @@ vi.mock('../../src/components/ChatPane', () => ({
 const mockedStreamMessage = vi.mocked(streamMessage);
 const mockedSaveMessage = vi.mocked(saveMessage);
 const mockedWriteProjectTextFile = vi.mocked(writeProjectTextFile);
+const mockedPatchPreviewCommentStatus = vi.mocked(patchPreviewCommentStatus);
 
 const config: AppConfig = {
   mode: 'api',
@@ -183,9 +188,11 @@ function renderProjectView() {
 
 describe('ProjectView API empty response handling', () => {
   beforeEach(() => {
+    chatPaneMockState.commentAttachments = [];
     mockedStreamMessage.mockReset();
     mockedSaveMessage.mockClear();
     mockedWriteProjectTextFile.mockClear();
+    mockedPatchPreviewCommentStatus.mockClear();
   });
 
   afterEach(() => {
@@ -230,6 +237,52 @@ describe('ProjectView API empty response handling', () => {
     });
   });
 
+  it('marks attached saved comments as failed when an API completion has no output', async () => {
+    chatPaneMockState.commentAttachments = [
+      {
+        id: 'comment-1',
+        order: 1,
+        filePath: 'index.html',
+        elementId: 'hero-title',
+        selector: '#hero-title',
+        label: 'Hero title',
+        comment: 'Make this clearer',
+        currentText: 'Old title',
+        pagePosition: { x: 0, y: 0, width: 100, height: 24 },
+        htmlHint: '<h1 id="hero-title">Old title</h1>',
+        source: 'saved-comment',
+      },
+    ];
+    mockedStreamMessage.mockImplementation(async (
+      _cfg: AppConfig,
+      _system: string,
+      _history: ChatMessage[],
+      _signal: AbortSignal,
+      handlers: StreamHandlers,
+    ) => {
+      handlers.onDone('');
+    });
+    renderProjectView();
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'send' })).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: 'send' }));
+
+    await waitFor(() => {
+      expect(mockedPatchPreviewCommentStatus).toHaveBeenCalledWith(
+        project.id,
+        'conv-project-1',
+        'comment-1',
+        'failed',
+      );
+    });
+    await waitFor(() => {
+      expect(hasSavedAssistantMessage((message) => (
+        message.runStatus === undefined &&
+        message.events?.some((event) => event.kind === 'status' && event.label === 'empty_response') === true
+      ))).toBe(true);
+    });
+  });
+
   it('keeps normal API text completions on the succeeded path', async () => {
     mockedStreamMessage.mockImplementation(async (
       _cfg: AppConfig,
@@ -247,7 +300,9 @@ describe('ProjectView API empty response handling', () => {
     fireEvent.click(screen.getByRole('button', { name: 'send' }));
 
     await waitFor(() => expect(screen.getAllByText('hello').length).toBeGreaterThan(0));
-    await waitFor(() => expect(screen.getByText('succeeded')).toBeTruthy());
+    await waitFor(() => {
+      expect(hasSavedAssistantMessage((message) => message.runStatus === 'succeeded')).toBe(true);
+    });
     expect(screen.queryByText(/provider ended the request/i)).toBeNull();
   });
 
@@ -271,9 +326,18 @@ describe('ProjectView API empty response handling', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: 'send' })).toBeTruthy());
     fireEvent.click(screen.getByRole('button', { name: 'send' }));
 
-    await waitFor(() => expect(screen.getByText('succeeded')).toBeTruthy());
+    await waitFor(() => {
+      expect(hasSavedAssistantMessage((message) => message.runStatus === 'succeeded')).toBe(true);
+    });
     await waitFor(() => expect(mockedWriteProjectTextFile).toHaveBeenCalled());
     expect(screen.queryByText(/provider ended the request/i)).toBeNull();
     expect(screen.queryByText('empty_response:deepseek-chat')).toBeNull();
   });
 });
+
+function hasSavedAssistantMessage(predicate: (message: ChatMessage) => boolean): boolean {
+  return mockedSaveMessage.mock.calls.some((call) => {
+    const message = call[2] as ChatMessage;
+    return message.role === 'assistant' && predicate(message);
+  });
+}

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -8,7 +8,7 @@ import { ProjectView } from '../../src/components/ProjectView';
 import { streamMessage } from '../../src/providers/anthropic';
 import type { StreamHandlers } from '../../src/providers/anthropic';
 import { patchPreviewCommentStatus, writeProjectTextFile } from '../../src/providers/registry';
-import { saveMessage } from '../../src/state/projects';
+import { listMessages, saveMessage } from '../../src/state/projects';
 import type {
   AgentEvent,
   AgentInfo,
@@ -138,6 +138,7 @@ vi.mock('../../src/components/ChatPane', () => ({
 }));
 
 const mockedStreamMessage = vi.mocked(streamMessage);
+const mockedListMessages = vi.mocked(listMessages);
 const mockedSaveMessage = vi.mocked(saveMessage);
 const mockedWriteProjectTextFile = vi.mocked(writeProjectTextFile);
 const mockedPatchPreviewCommentStatus = vi.mocked(patchPreviewCommentStatus);
@@ -190,6 +191,7 @@ describe('ProjectView API empty response handling', () => {
   beforeEach(() => {
     chatPaneMockState.commentAttachments = [];
     mockedStreamMessage.mockReset();
+    mockedListMessages.mockClear();
     mockedSaveMessage.mockClear();
     mockedWriteProjectTextFile.mockClear();
     mockedPatchPreviewCommentStatus.mockClear();
@@ -212,8 +214,7 @@ describe('ProjectView API empty response handling', () => {
     });
     renderProjectView();
 
-    await waitFor(() => expect(screen.getByRole('button', { name: 'send' })).toBeTruthy());
-    fireEvent.click(screen.getByRole('button', { name: 'send' }));
+    await sendTestPrompt();
 
     await waitFor(() => {
       expect(screen.getByText('empty_response:deepseek-chat')).toBeTruthy();
@@ -264,8 +265,7 @@ describe('ProjectView API empty response handling', () => {
     });
     renderProjectView();
 
-    await waitFor(() => expect(screen.getByRole('button', { name: 'send' })).toBeTruthy());
-    fireEvent.click(screen.getByRole('button', { name: 'send' }));
+    await sendTestPrompt();
 
     await waitFor(() => {
       expect(mockedPatchPreviewCommentStatus).toHaveBeenCalledWith(
@@ -296,8 +296,7 @@ describe('ProjectView API empty response handling', () => {
     });
     renderProjectView();
 
-    await waitFor(() => expect(screen.getByRole('button', { name: 'send' })).toBeTruthy());
-    fireEvent.click(screen.getByRole('button', { name: 'send' }));
+    await sendTestPrompt();
 
     await waitFor(() => expect(screen.getAllByText('hello').length).toBeGreaterThan(0));
     await waitFor(() => {
@@ -323,8 +322,7 @@ describe('ProjectView API empty response handling', () => {
     });
     renderProjectView();
 
-    await waitFor(() => expect(screen.getByRole('button', { name: 'send' })).toBeTruthy());
-    fireEvent.click(screen.getByRole('button', { name: 'send' }));
+    await sendTestPrompt();
 
     await waitFor(() => {
       expect(hasSavedAssistantMessage((message) => message.runStatus === 'succeeded')).toBe(true);
@@ -334,6 +332,15 @@ describe('ProjectView API empty response handling', () => {
     expect(screen.queryByText('empty_response:deepseek-chat')).toBeNull();
   });
 });
+
+async function sendTestPrompt() {
+  await waitFor(() => {
+    expect(mockedListMessages).toHaveBeenCalledWith(project.id, 'conv-project-1');
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await waitFor(() => expect(screen.getByRole('button', { name: 'send' })).toBeTruthy());
+  fireEvent.click(screen.getByRole('button', { name: 'send' }));
+}
 
 function hasSavedAssistantMessage(predicate: (message: ChatMessage) => boolean): boolean {
   return mockedSaveMessage.mock.calls.some((call) => {

--- a/apps/web/tests/components/assistant-message-unfinished-todos.test.tsx
+++ b/apps/web/tests/components/assistant-message-unfinished-todos.test.tsx
@@ -19,6 +19,28 @@ function messageWithEvents(events: AgentEvent[]): ChatMessage {
 describe('AssistantMessage unfinished todo state', () => {
   afterEach(() => cleanup());
 
+  it('shows a soft no-output state instead of Done for empty API responses', () => {
+    render(
+      <AssistantMessage
+        message={messageWithEvents([
+          { kind: 'status', label: 'empty_response', detail: 'deepseek-chat' },
+          {
+            kind: 'text',
+            text: 'The provider ended the request without returning text or an artifact. Try another model or provider, check quota, or retry.',
+          },
+        ])}
+        streaming={false}
+        projectId="project-1"
+        isLast
+      />,
+    );
+
+    expect(screen.getByText('No output')).toBeTruthy();
+    expect(screen.getByText(/provider ended the request/i)).toBeTruthy();
+    expect(screen.queryByText('Done')).toBeNull();
+    expect(screen.queryByText('empty_response')).toBeNull();
+  });
+
   it('keeps Done for a completed latest TodoWrite fixture', () => {
     render(
       <AssistantMessage

--- a/e2e/ui/api-empty-response.test.ts
+++ b/e2e/ui/api-empty-response.test.ts
@@ -1,0 +1,76 @@
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+const STORAGE_KEY = 'open-design:config';
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript((key) => {
+    window.localStorage.setItem(
+      key,
+      JSON.stringify({
+        mode: 'api',
+        apiProtocol: 'openai',
+        apiKey: 'sk-test',
+        baseUrl: 'https://api.deepseek.com',
+        model: 'deepseek-chat',
+        agentId: null,
+        skillId: null,
+        designSystemId: null,
+        onboardingCompleted: true,
+        agentModels: {},
+      }),
+    );
+  }, STORAGE_KEY);
+});
+
+test('API empty stream shows No output instead of Done', async ({ page }) => {
+  await page.route('**/api/proxy/openai/stream', async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: {
+        'content-type': 'text/event-stream',
+        'cache-control': 'no-cache',
+      },
+      body: ['event: end', 'data: {}', '', ''].join('\n'),
+    });
+  });
+
+  await page.goto('/');
+  await createProject(page, 'API empty response smoke');
+  await expectWorkspaceReady(page);
+  await sendPrompt(page, 'Create a login page');
+
+  await expect(page.locator('.assistant-label', { hasText: 'No output' })).toBeVisible();
+  await expect(page.getByText(/provider ended the request/i)).toBeVisible();
+  await expect(page.locator('.assistant-label', { hasText: 'Done' })).toHaveCount(0);
+});
+
+async function createProject(page: Page, name: string) {
+  await expect(page.getByTestId('new-project-panel')).toBeVisible();
+  await page.getByTestId('new-project-tab-prototype').click();
+  await page.getByTestId('new-project-name').fill(name);
+  await page.getByTestId('create-project').click();
+}
+
+async function expectWorkspaceReady(page: Page) {
+  await expect(page).toHaveURL(/\/projects\//);
+  await expect(page.getByTestId('chat-composer')).toBeVisible();
+  await expect(page.getByTestId('file-workspace')).toBeVisible();
+}
+
+async function sendPrompt(page: Page, prompt: string) {
+  const input = page.getByTestId('chat-composer-input');
+  const sendButton = page.getByTestId('chat-send');
+  const streamResponse = page.waitForResponse(
+    (response) => {
+      const url = new URL(response.url());
+      return url.pathname === '/api/proxy/openai/stream' && response.request().method() === 'POST';
+    },
+    { timeout: 5_000 },
+  );
+
+  await input.fill(prompt);
+  await expect(sendButton).toBeEnabled();
+  await sendButton.click();
+  await streamResponse;
+}


### PR DESCRIPTION
## Summary

Fixes the misleading completed state for API-mode streams that end cleanly without returning text or an artifact.

The root cause was that `ProjectView` treated `onDone('')` as a successful assistant turn after flushing the stream buffers. In API mode, the proxy can legitimately emit a clean `end` event with no deltas, so the UI showed `Done` / `已完成` even though no useful output was produced.

## Changes

- Detect empty API completions after text/artifact parser flushing.
- Persist a soft `empty_response` assistant status event plus a diagnostic text message.
- Keep `ChatRunStatus` unchanged and avoid marking the turn as `succeeded` or `failed` for this soft state.
- Teach the assistant footer to render `No output` / `无输出` / `無輸出` for the soft state.
- Keep normal success behavior unchanged for API text responses and streamed artifact responses.
- Add component coverage and a Playwright UI smoke test for the real API proxy stream path.

## Validation

- `pnpm --filter @open-design/web exec vitest run tests/components/ProjectView.api-empty-response.test.tsx tests/components/assistant-message-unfinished-todos.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`
- `PATH=/Users/alche/.nvm/versions/node/v24.0.0/bin:$PATH OD_PORT=18457 OD_WEB_PORT=18574 OD_E2E_NAMESPACE=api-empty-response-smoke-node24 pnpm exec playwright test -c playwright.config.ts ui/api-empty-response.test.ts` from `e2e/`
