### PR TITLE
fix(desktop): exit fullscreen before hiding window on macOS close

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,7 @@ The following is a working playbook for routine bug follow-ups, distilled from r
 - **Hold the spec's scope.** Defects discovered outside the bug's described boundary belong in a follow-up — their own red spec, their own PR — not in this fix. List them in the PR body's "Adjacent issues" section with the rationale and move on.
 - **Let the fix read as an invariant.** Prefer a named helper whose docblock describes what must hold over a bolt-on `if` guard with apologetic history-comments. The call site should read as intent.
 - **Diff against the baseline.** When neighboring suites have pre-existing failures, stash or check out upstream before claiming "no new failures."
+- **Stage human verification for visible bugs.** When the symptom needs an eye to confirm — UI, platform-native behavior, animations, race conditions a unit test can't see — green specs alone aren't acceptance. Stand up a buggy-vs-fix comparison the reviewer can drive themselves (typical shape: two namespaced runtimes, one on `main`, one on the fix branch), and seed any required data only through production HTTP APIs; source-level test backdoors invalidate the verification because they prove a fake flow rather than the real one.
 
 For a worked example of one full loop (red e2e spec → fix → green), see `e2e/tests/dialog/stop-reconciles-message.test.ts` (issue #135).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,18 @@ This file is the single source of truth for agents entering this repository. Rea
 - Stamp/namespace changes must validate two concurrent namespaces and run desktop `inspect eval` plus `inspect screenshot` for each namespace.
 - Path/log changes must run `pnpm tools-dev logs --namespace <name> --json` and confirm log paths are under `.tmp/tools-dev/<namespace>/...`.
 
+## Bug follow-up workflow
+
+The following is a working playbook for routine bug follow-ups, distilled from recent practice. Treat it as a default action shape, not a contract — production reality always has edges these bullets can't anticipate, so use judgment when the situation doesn't fit cleanly.
+
+- **Lead with a red spec.** Default to encoding the bug as a falsifiable test that goes red before any source change, so the fix is anchored in observable behavior rather than source-code intuition. If a red spec can't be written cheaply, that's usually a signal to clarify scope rather than push forward on a guess.
+- **Try the cheapest layer first.** Reach for the lightest test layer that can still see the symptom (e2e Vitest at the daemon HTTP boundary → app-local Vitest → Playwright UI → platform-native harnesses), and drop down only when the cheaper layer can't.
+- **Hold the spec's scope.** Defects discovered outside the bug's described boundary belong in a follow-up — their own red spec, their own PR — not in this fix. List them in the PR body's "Adjacent issues" section with the rationale and move on.
+- **Let the fix read as an invariant.** Prefer a named helper whose docblock describes what must hold over a bolt-on `if` guard with apologetic history-comments. The call site should read as intent.
+- **Diff against the baseline.** When neighboring suites have pre-existing failures, stash or check out upstream before claiming "no new failures."
+
+For a worked example of one full loop (red e2e spec → fix → green), see `e2e/tests/dialog/stop-reconciles-message.test.ts` (issue #135).
+
 # Common commands
 
 ```bash

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -15,7 +15,8 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "test": "vitest run -c vitest.config.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.tests.json --noEmit"
   },
   "dependencies": {
     "@open-design/platform": "workspace:*",
@@ -25,7 +26,8 @@
   "devDependencies": {
     "@types/node": "24.12.2",
     "electron": "41.3.0",
-    "typescript": "6.0.3"
+    "typescript": "6.0.3",
+    "vitest": "^2.1.8"
   },
   "engines": {
     "node": "~24"

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -632,22 +632,31 @@ function ensureWindowVisible(window: BrowserWindow): void {
  * {@link hideWindowExitingFullscreen} — declared structurally so the
  * helper can be exercised with a plain mock in unit tests without
  * standing up an actual Electron window.
+ *
+ * `isEnteringFullscreen` covers the Electron-asynchronous gap between
+ * the renderer asking for fullscreen and the OS confirming via
+ * 'enter-full-screen': the caller is expected to track this from the
+ * window's enter/leave listeners (see the close handler in
+ * {@link configureWindow}) and surface it here.
  */
 export type WindowFullscreenSurface = {
   hide: () => void;
   isFullScreen: () => boolean;
   isSimpleFullScreen: () => boolean;
+  isEnteringFullscreen: () => boolean;
   setFullScreen: (flag: boolean) => void;
   setSimpleFullScreen: (flag: boolean) => void;
-  once: (event: 'leave-full-screen', listener: () => void) => unknown;
+  once: (event: 'enter-full-screen' | 'leave-full-screen', listener: () => void) => unknown;
 };
 
 /**
  * Hide the window, first leaving any active fullscreen so macOS doesn't
  * orphan the fullscreen Space as a black screen. The hide is deferred
- * until 'leave-full-screen' fires; otherwise hiding races the OS Space
- * teardown and the user is left staring at a black desktop until they
- * switch Spaces by hand.
+ * until 'leave-full-screen' fires; if the Space transition is still
+ * flipping in (`isEnteringFullscreen`), defer further until
+ * 'enter-full-screen' settles before starting the exit. Plain hides
+ * race the OS Space teardown and leave the user staring at a black
+ * desktop until they switch Spaces by hand.
  */
 export function hideWindowExitingFullscreen(window: WindowFullscreenSurface): void {
   if (window.isSimpleFullScreen()) {
@@ -658,6 +667,13 @@ export function hideWindowExitingFullscreen(window: WindowFullscreenSurface): vo
   if (window.isFullScreen()) {
     window.once('leave-full-screen', () => window.hide());
     window.setFullScreen(false);
+    return;
+  }
+  if (window.isEnteringFullscreen()) {
+    window.once('enter-full-screen', () => {
+      window.once('leave-full-screen', () => window.hide());
+      window.setFullScreen(false);
+    });
     return;
   }
   window.hide();
@@ -903,10 +919,43 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
   });
 
   if (process.platform === "darwin") {
+    // Track the in-flight fullscreen-enter window so the close handler can
+    // tell mid-transition apart from "definitely not fullscreen". HTML
+    // requestFullscreen() emits enter-html-full-screen on webContents
+    // before the OS Space transition completes; the BrowserWindow
+    // enter-full-screen event fires once the OS confirms.
+    let enteringFullscreen = false;
+    window.webContents.on("enter-html-full-screen", () => {
+      enteringFullscreen = true;
+    });
+    window.webContents.on("leave-html-full-screen", () => {
+      enteringFullscreen = false;
+    });
+    window.on("enter-full-screen", () => {
+      enteringFullscreen = false;
+    });
+    window.on("leave-full-screen", () => {
+      enteringFullscreen = false;
+    });
     window.on("close", (event) => {
       if (stopped) return;
       event.preventDefault();
-      hideWindowExitingFullscreen(window);
+      hideWindowExitingFullscreen({
+        hide: () => window.hide(),
+        isFullScreen: () => window.isFullScreen(),
+        isSimpleFullScreen: () => window.isSimpleFullScreen(),
+        isEnteringFullscreen: () => enteringFullscreen,
+        setFullScreen: (flag) => window.setFullScreen(flag),
+        setSimpleFullScreen: (flag) => window.setSimpleFullScreen(flag),
+        // BrowserWindow.once is heavily overloaded; both event names are
+        // valid (BrowserWindow emits enter-full-screen and
+        // leave-full-screen on macOS) but TypeScript can't pick a single
+        // overload for the union, so narrow at the call site.
+        once: (event, listener) =>
+          event === 'enter-full-screen'
+            ? window.once('enter-full-screen', listener)
+            : window.once('leave-full-screen', listener),
+      });
     });
   }
 

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -627,6 +627,42 @@ function ensureWindowVisible(window: BrowserWindow): void {
   window.focus();
 }
 
+/**
+ * Surface of {@link BrowserWindow} consumed by
+ * {@link hideWindowExitingFullscreen} — declared structurally so the
+ * helper can be exercised with a plain mock in unit tests without
+ * standing up an actual Electron window.
+ */
+export type WindowFullscreenSurface = {
+  hide: () => void;
+  isFullScreen: () => boolean;
+  isSimpleFullScreen: () => boolean;
+  setFullScreen: (flag: boolean) => void;
+  setSimpleFullScreen: (flag: boolean) => void;
+  once: (event: 'leave-full-screen', listener: () => void) => unknown;
+};
+
+/**
+ * Hide the window, first leaving any active fullscreen so macOS doesn't
+ * orphan the fullscreen Space as a black screen. The hide is deferred
+ * until 'leave-full-screen' fires; otherwise hiding races the OS Space
+ * teardown and the user is left staring at a black desktop until they
+ * switch Spaces by hand.
+ */
+export function hideWindowExitingFullscreen(window: WindowFullscreenSurface): void {
+  if (window.isSimpleFullScreen()) {
+    window.once('leave-full-screen', () => window.hide());
+    window.setSimpleFullScreen(false);
+    return;
+  }
+  if (window.isFullScreen()) {
+    window.once('leave-full-screen', () => window.hide());
+    window.setFullScreen(false);
+    return;
+  }
+  window.hide();
+}
+
 // PPTX is rendered by the agent into the project folder and reaches the
 // renderer through a normal `<a download>` link to /api/projects/:id/raw/*.
 // Without this hook Electron writes the bytes straight to the OS Downloads
@@ -868,10 +904,9 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
 
   if (process.platform === "darwin") {
     window.on("close", (event) => {
-      if (!stopped) {
-        event.preventDefault();
-        window.hide();
-      }
+      if (stopped) return;
+      event.preventDefault();
+      hideWindowExitingFullscreen(window);
     });
   }
 

--- a/apps/desktop/tests/main/hide-window-exiting-fullscreen.test.ts
+++ b/apps/desktop/tests/main/hide-window-exiting-fullscreen.test.ts
@@ -20,19 +20,24 @@ type MockCalls = string[];
 function createMockWindow(initial: {
   fullScreen?: boolean;
   simpleFullScreen?: boolean;
+  enteringFullscreen?: boolean;
 }): {
   window: WindowFullscreenSurface;
   calls: MockCalls;
+  emitEnterFullscreen: () => void;
   emitLeaveFullscreen: () => void;
 } {
   const calls: MockCalls = [];
+  let enterListener: (() => void) | null = null;
   let leaveListener: (() => void) | null = null;
   let fullScreen = initial.fullScreen ?? false;
   let simpleFullScreen = initial.simpleFullScreen ?? false;
+  const enteringFullscreen = initial.enteringFullscreen ?? false;
   const window: WindowFullscreenSurface = {
     hide: () => calls.push('hide'),
     isFullScreen: () => fullScreen,
     isSimpleFullScreen: () => simpleFullScreen,
+    isEnteringFullscreen: () => enteringFullscreen,
     setFullScreen: (flag) => {
       calls.push(`setFullScreen(${flag})`);
       fullScreen = flag;
@@ -43,12 +48,21 @@ function createMockWindow(initial: {
     },
     once: (event, listener) => {
       calls.push(`once(${event})`);
+      if (event === 'enter-full-screen') enterListener = listener;
       if (event === 'leave-full-screen') leaveListener = listener;
       return undefined;
     },
   };
   return {
     calls,
+    emitEnterFullscreen: () => {
+      const fn = enterListener;
+      enterListener = null;
+      // Real Electron flips isFullScreen() to true around the same moment
+      // 'enter-full-screen' fires, so model that here too.
+      fullScreen = true;
+      fn?.();
+    },
     emitLeaveFullscreen: () => {
       const fn = leaveListener;
       leaveListener = null;
@@ -91,6 +105,38 @@ describe('hideWindowExitingFullscreen', () => {
     expect(calls).toEqual([
       'once(leave-full-screen)',
       'setSimpleFullScreen(false)',
+      'hide',
+    ]);
+  });
+
+  // The macOS Space transition between requestFullscreen() and the
+  // 'enter-full-screen' event is asynchronous; isFullScreen() can still
+  // read false during that window. If we hide unconditionally in that gap
+  // the OS strands the still-transitioning Space as a black screen — the
+  // exact symptom #1215 reported. Wait for the enter to settle before
+  // pivoting to the exit-then-hide path.
+  test('waits out a fullscreen-enter transition before exiting and hiding', () => {
+    const { window, calls, emitEnterFullscreen, emitLeaveFullscreen } = createMockWindow({
+      enteringFullscreen: true,
+    });
+    hideWindowExitingFullscreen(window);
+
+    // While the Space is still flipping in, only an enter-listener is
+    // registered — no hide, no setFullScreen.
+    expect(calls).toEqual(['once(enter-full-screen)']);
+
+    emitEnterFullscreen();
+    expect(calls).toEqual([
+      'once(enter-full-screen)',
+      'once(leave-full-screen)',
+      'setFullScreen(false)',
+    ]);
+
+    emitLeaveFullscreen();
+    expect(calls).toEqual([
+      'once(enter-full-screen)',
+      'once(leave-full-screen)',
+      'setFullScreen(false)',
       'hide',
     ]);
   });

--- a/apps/desktop/tests/main/hide-window-exiting-fullscreen.test.ts
+++ b/apps/desktop/tests/main/hide-window-exiting-fullscreen.test.ts
@@ -1,0 +1,97 @@
+// Issue #1215 — clicking the macOS red X while the preview is in fullscreen
+// presentation mode hides the window but leaves the OS Space stuck as a
+// black screen. The close handler is allowed to call window.hide(), but it
+// must first arrange for the window to leave fullscreen so the Space tears
+// down with the window.
+//
+// This spec exercises the contract through hideWindowExitingFullscreen with
+// a structural mock — the bug shape is pure logic (sequence of calls), so
+// no real Electron window is required.
+
+import { describe, expect, test } from 'vitest';
+
+import {
+  hideWindowExitingFullscreen,
+  type WindowFullscreenSurface,
+} from '../../src/main/runtime.js';
+
+type MockCalls = string[];
+
+function createMockWindow(initial: {
+  fullScreen?: boolean;
+  simpleFullScreen?: boolean;
+}): {
+  window: WindowFullscreenSurface;
+  calls: MockCalls;
+  emitLeaveFullscreen: () => void;
+} {
+  const calls: MockCalls = [];
+  let leaveListener: (() => void) | null = null;
+  let fullScreen = initial.fullScreen ?? false;
+  let simpleFullScreen = initial.simpleFullScreen ?? false;
+  const window: WindowFullscreenSurface = {
+    hide: () => calls.push('hide'),
+    isFullScreen: () => fullScreen,
+    isSimpleFullScreen: () => simpleFullScreen,
+    setFullScreen: (flag) => {
+      calls.push(`setFullScreen(${flag})`);
+      fullScreen = flag;
+    },
+    setSimpleFullScreen: (flag) => {
+      calls.push(`setSimpleFullScreen(${flag})`);
+      simpleFullScreen = flag;
+    },
+    once: (event, listener) => {
+      calls.push(`once(${event})`);
+      if (event === 'leave-full-screen') leaveListener = listener;
+      return undefined;
+    },
+  };
+  return {
+    calls,
+    emitLeaveFullscreen: () => {
+      const fn = leaveListener;
+      leaveListener = null;
+      fn?.();
+    },
+    window,
+  };
+}
+
+describe('hideWindowExitingFullscreen', () => {
+  test('hides directly when the window is not in fullscreen', () => {
+    const { window, calls } = createMockWindow({});
+    hideWindowExitingFullscreen(window);
+    expect(calls).toEqual(['hide']);
+  });
+
+  test('exits native fullscreen first, defers hide until leave-full-screen fires', () => {
+    const { window, calls, emitLeaveFullscreen } = createMockWindow({ fullScreen: true });
+    hideWindowExitingFullscreen(window);
+
+    // Before the OS confirms the Space has torn down, the window must NOT
+    // be hidden — hiding mid-transition is what leaves the black Space.
+    expect(calls).toEqual(['once(leave-full-screen)', 'setFullScreen(false)']);
+
+    emitLeaveFullscreen();
+    expect(calls).toEqual([
+      'once(leave-full-screen)',
+      'setFullScreen(false)',
+      'hide',
+    ]);
+  });
+
+  test('exits simpleFullScreen first, defers hide until leave-full-screen fires', () => {
+    const { window, calls, emitLeaveFullscreen } = createMockWindow({ simpleFullScreen: true });
+    hideWindowExitingFullscreen(window);
+
+    expect(calls).toEqual(['once(leave-full-screen)', 'setSimpleFullScreen(false)']);
+
+    emitLeaveFullscreen();
+    expect(calls).toEqual([
+      'once(leave-full-screen)',
+      'setSimpleFullScreen(false)',
+      'hide',
+    ]);
+  });
+});

--- a/apps/desktop/tsconfig.tests.json
+++ b/apps/desktop/tsconfig.tests.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "tests/**/*.ts",
+    "tests/**/*.tsx",
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.test.{ts,tsx,js,mjs,cjs}'],
+    testTimeout: 10_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@24.12.2)(jsdom@29.1.1)
 
   apps/landing-page:
     dependencies:


### PR DESCRIPTION
## Summary
- darwin close handler now leaves any active fullscreen before hiding so macOS doesn't orphan the Space as a black screen (#1215)
- bootstrap Vitest on `apps/desktop` and add the first unit test covering the new `hideWindowExitingFullscreen` helper
- root `AGENTS.md` gains a soft-toned "Bug follow-up workflow" subsection codifying the spec-first / cheapest-layer / scope-discipline / invariant-shaped-fix / baseline-diff playbook used on #135 and this fix

## Details
- Bug path: in 演示 → 全屏 the renderer calls `requestFullscreen()`, which on Electron darwin transitions the BrowserWindow into a native fullscreen Space. Clicking the red ✕ fired the existing `'close'` handler, which `preventDefault()`'d and called `window.hide()` directly — but on macOS, hiding while the Space is still up leaves the Space sitting empty and black until the user switches Spaces by hand.
- Fix routes the close path through a named helper that, when the window is in `isSimpleFullScreen()` or `isFullScreen()`, registers a one-shot `'leave-full-screen'` listener and calls `setSimpleFullScreen(false)` / `setFullScreen(false)`. The hide is deferred until the OS confirms the Space teardown, so the window and the Space dismiss together.
- Helper is exported with a structural `WindowFullscreenSurface` type so the test exercises pure logic (sequence of calls) without spinning up a real Electron window.
- AGENTS.md addition is intentionally soft-toned: framed as a \"default action shape, not a contract\" with explicit room for case-by-case judgment — codification of recent practice, not a process rule.

## Validation
- \`pnpm --filter @open-design/desktop test\` — red against the bootstrap helper that just called \`hide()\`, green after the fullscreen-exit sequencing (3/3)
- \`pnpm --filter @open-design/desktop typecheck\` — clean
- \`pnpm --filter @open-design/e2e test specs\` — green (3 passed, 5 platform-skipped)
- \`pnpm --filter @open-design/e2e test tests\` — green (12/12, includes the #135 regression specs)
- \`pnpm typecheck\` / \`pnpm guard\` — clean

Fixes #1215