### PR TITLE
fix: format JSON preview with indentation

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -5579,8 +5579,21 @@ function TextViewer({
   useEffect(() => {
     setText(null);
     let cancelled = false;
-    void fetchProjectFileText(projectId, file.name).then((t) => {
-      if (!cancelled) setText(t ?? '');
+    void fetchProjectFileText(projectId, file.name).then((rawText) => {
+      if (cancelled) return;
+      let displayText = rawText ?? '';
+      
+      // Pretty-print JSON files for better readability (fixes #1199)
+      if (file.name.toLowerCase().endsWith('.json') && displayText.trim()) {
+        try {
+          const parsed = JSON.parse(displayText);
+          displayText = JSON.stringify(parsed, null, 2);
+        } catch {
+          // Not valid JSON or parse error — show raw text as-is
+        }
+      }
+      
+      setText(displayText);
     });
     return () => {
       cancelled = true;


### PR DESCRIPTION
Fixes #1199

## Summary

JSON files are now pretty-printed with 2-space indentation in the preview pane, making them much easier to read and inspect.

## Problem

Previously, JSON content was displayed as-is in the TextViewer component. When JSON files were minified (single line), they became extremely difficult to read, especially for large objects or nested structures.

## Solution

Added JSON detection and formatting in the `TextViewer` component:

1. **Detect JSON files** by `.json` file extension (case-insensitive)
2. **Parse and format** using `JSON.parse()` + `JSON.stringify(parsed, null, 2)`
3. **Graceful fallback** to raw text if parsing fails (invalid JSON)
4. **Preserve original behavior** for all non-JSON text files

## Changes

- Modified `TextViewer` component in `apps/web/src/components/FileViewer.tsx`
- Added JSON formatting logic in the `useEffect` that fetches file content
- No changes to data storage or file handling — purely display formatting

## Testing

### Before
```json
{"name":"example","nested":{"key":"value","array":[1,2,3]}}
```

### After
```json
{
  "name": "example",
  "nested": {
    "key": "value",
    "array": [
      1,
      2,
      3
    ]
  }
}
```

### Test cases
1. ✅ Valid JSON file → formatted with indentation
2. ✅ Invalid JSON file → shows raw text (no crash)
3. ✅ Non-JSON text file → unchanged behavior
4. ✅ Empty JSON file → handled gracefully

## Impact

- **Risk**: Very low — only affects display, no data modification
- **Scope**: JSON files in Design Files preview pane
- **Value**: High — significantly improves debugging and inspection workflow