### PR TITLE
fix(web): route chat file links to workspace preview instead of new window (#1239)

### DIFF
--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -1,6 +1,10 @@
 import { Fragment, useEffect, useMemo, useState } from "react";
 import { ToolCard } from "./ToolCard";
-import { renderMarkdown } from "../runtime/markdown";
+import {
+  renderMarkdown,
+  type MarkdownLinkClickHandler,
+} from "../runtime/markdown";
+import { asInProjectFilePath } from "../runtime/in-project-link";
 import { projectFileUrl } from "../providers/registry";
 import {
   splitOnQuestionForms,
@@ -118,6 +122,7 @@ export function AssistantMessage({
                   });
                   onSubmitForm?.(text);
                 }}
+                onRequestOpenFile={onRequestOpenFile}
               />
             );
           if (b.kind === "thinking")
@@ -435,6 +440,7 @@ function ProseBlock({
   nextUserContent,
   locallySubmitted,
   onSubmitForm,
+  onRequestOpenFile,
 }: {
   text: string;
   isLastAssistant: boolean;
@@ -442,9 +448,25 @@ function ProseBlock({
   nextUserContent?: string;
   locallySubmitted: Set<string>;
   onSubmitForm: (formId: string, text: string) => void;
+  onRequestOpenFile?: (name: string) => void;
 }) {
   const cleaned = useMemo(() => stripArtifact(text), [text]);
   const segments = useMemo(() => splitOnQuestionForms(cleaned), [cleaned]);
+  // Route chat-emitted file links (relative paths like `template.html`
+  // or `subdir/hero.html`) through the workspace tab opener instead of
+  // the default `target="_blank"`. Without this, Electron's window-open
+  // handler creates a new app window whose relative href can't resolve
+  // and the user lands on the home screen — the file they wanted to
+  // preview is never shown.
+  const onLinkClick = useMemo<MarkdownLinkClickHandler | undefined>(() => {
+    if (!onRequestOpenFile) return undefined;
+    return (href, event) => {
+      const path = asInProjectFilePath(href);
+      if (!path) return;
+      event.preventDefault();
+      onRequestOpenFile(path);
+    };
+  }, [onRequestOpenFile]);
   // Each text segment is further split on `<system-reminder>` blocks so
   // those render as their own collapsible chip instead of raw markup.
   const renderable = segments.flatMap(
@@ -476,7 +498,11 @@ function ProseBlock({
           return <SystemReminderBlock key={seg.key} text={seg.text} />;
         }
         if (seg.kind === "text") {
-          return <Fragment key={seg.key}>{renderMarkdown(seg.text)}</Fragment>;
+          return (
+            <Fragment key={seg.key}>
+              {renderMarkdown(seg.text, { onLinkClick })}
+            </Fragment>
+          );
         }
         return (
           <FormBlock

--- a/apps/web/src/runtime/in-project-link.ts
+++ b/apps/web/src/runtime/in-project-link.ts
@@ -1,0 +1,62 @@
+/**
+ * Decide whether a markdown link href in chat output should resolve to an
+ * in-project file (opened in the right-pane workspace) or fall through to
+ * the default browser link behavior (Electron `setWindowOpenHandler` →
+ * new window).
+ *
+ * Chat output from the assistant frequently contains references like
+ * `[template.html](template.html)` or `[hero](subdir/hero.html)`. Those
+ * are relative paths into the current project's file workspace; with
+ * default `target="_blank"` they instead open a new Electron window with
+ * no project context and land on the home screen. Routing them through
+ * the existing `requestOpenFile` callback keeps the user in the same
+ * project view and previews the file in the right pane.
+ *
+ * Returns the normalized file path to open when the href looks like an
+ * in-project link, or `null` to let the default link behavior win.
+ *
+ * Pass-through (returns null):
+ *   - http(s):// and any other URL scheme (mailto:, ftp:, …) — explicit
+ *     external link, default browser behavior is correct.
+ *   - `#anchor` — fragment within the current document.
+ *   - Absolute paths starting with `/` — could mean filesystem root in
+ *     Electron and is not what the assistant is referencing; better to
+ *     not silently rewrite into an in-project open.
+ *   - `..` traversal — refuses to leave the project root via relative
+ *     navigation. (Anchors any normalization in the consumer to project-
+ *     scoped files only.)
+ *   - Empty / whitespace.
+ *
+ * Intercept (returns normalized path):
+ *   - Bare filename:        `template.html`        → `template.html`
+ *   - Explicit relative:    `./template.html`      → `template.html`
+ *   - Nested in subdir:     `subdir/hero.html`     → `subdir/hero.html`
+ *   - With query / hash:    `template.html?x=1#a`  → `template.html`
+ *     (query and fragment are stripped — the workspace tab opener takes
+ *     a file path, not a URL.)
+ */
+export function asInProjectFilePath(href: string | null | undefined): string | null {
+  if (typeof href !== 'string') return null;
+  const trimmed = href.trim();
+  if (!trimmed) return null;
+  if (trimmed.startsWith('#')) return null;
+  // RFC 3986 scheme: ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ) followed
+  // by ":". Catches http:, https:, mailto:, file:, od:, blob:, etc.
+  if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return null;
+  if (trimmed.startsWith('/')) return null;
+  // Reject any segment that climbs out of the project root. Cheaper +
+  // safer than a full path normalization pass, and `..` segments are
+  // not something real assistant chat output emits for file references.
+  const segments = trimmed.split('/');
+  if (segments.some((segment) => segment === '..')) return null;
+  // Strip an explicit `./` prefix so the consumer sees the same shape
+  // it would have gotten from a bare filename.
+  const withoutDotSlash = trimmed.startsWith('./') ? trimmed.slice(2) : trimmed;
+  // Drop query and fragment — the workspace tab opener takes a file
+  // path, not a URL. Doing it in this order so `?` or `#` inside a
+  // filename (rare but legal) doesn't slip into the workspace key.
+  const beforeHash = withoutDotSlash.split('#')[0] ?? '';
+  const beforeQuery = beforeHash.split('?')[0] ?? '';
+  const normalized = beforeQuery.trim();
+  return normalized.length > 0 ? normalized : null;
+}

--- a/apps/web/src/runtime/markdown.tsx
+++ b/apps/web/src/runtime/markdown.tsx
@@ -11,13 +11,29 @@
  * Output is a React fragment of typed elements — no dangerouslySetInnerHTML,
  * so untrusted text can't smuggle markup through.
  */
-import { Fragment, type ReactNode } from 'react';
+import { Fragment, type MouseEvent, type ReactNode } from 'react';
 
-export function renderMarkdown(input: string): ReactNode {
+export type MarkdownLinkClickHandler = (
+  href: string,
+  event: MouseEvent<HTMLAnchorElement>,
+) => void;
+
+export interface RenderMarkdownOptions {
+  /**
+   * Fired on every rendered `<a>` click before the default link behavior.
+   * Callers that want to intercept (e.g. route in-project file links to
+   * a workspace tab opener instead of letting the browser/Electron open
+   * a new window) should call `event.preventDefault()` themselves. When
+   * not provided, links keep their default `target="_blank"` behavior.
+   */
+  onLinkClick?: MarkdownLinkClickHandler;
+}
+
+export function renderMarkdown(input: string, options?: RenderMarkdownOptions): ReactNode {
   const blocks = parseBlocks(input);
   return (
     <>
-      {blocks.map((b, i) => renderBlock(b, i))}
+      {blocks.map((b, i) => renderBlock(b, i, options))}
     </>
   );
 }
@@ -107,19 +123,19 @@ function parseBlocks(input: string): Block[] {
   return out;
 }
 
-function renderBlock(block: Block, key: number): ReactNode {
+function renderBlock(block: Block, key: number, options?: RenderMarkdownOptions): ReactNode {
   if (block.kind === 'p') {
-    return <p key={key} className="md-p">{renderInline(block.text)}</p>;
+    return <p key={key} className="md-p">{renderInline(block.text, options)}</p>;
   }
   if (block.kind === 'h') {
     const Tag = (`h${block.level}` as 'h1' | 'h2' | 'h3' | 'h4');
-    return <Tag key={key} className={`md-h md-h${block.level}`}>{renderInline(block.text)}</Tag>;
+    return <Tag key={key} className={`md-h md-h${block.level}`}>{renderInline(block.text, options)}</Tag>;
   }
   if (block.kind === 'ul') {
     return (
       <ul key={key} className="md-ul">
         {block.items.map((item, i) => (
-          <li key={i}>{renderInline(item)}</li>
+          <li key={i}>{renderInline(item, options)}</li>
         ))}
       </ul>
     );
@@ -128,7 +144,7 @@ function renderBlock(block: Block, key: number): ReactNode {
     return (
       <ol key={key} className="md-ol">
         {block.items.map((item, i) => (
-          <li key={i}>{renderInline(item)}</li>
+          <li key={i}>{renderInline(item, options)}</li>
         ))}
       </ol>
     );
@@ -150,7 +166,7 @@ function renderBlock(block: Block, key: number): ReactNode {
 // and plain text. We walk the string with a regex that matches whichever
 // delimiter shows up next; everything between delimiters becomes a text
 // span (which itself still gets autolink scanning).
-function renderInline(text: string): ReactNode {
+function renderInline(text: string, options?: RenderMarkdownOptions): ReactNode {
   const out: ReactNode[] = [];
   // Order matters:
   //  1. inline code first so its contents are not re-tokenized as bold/italic.
@@ -167,7 +183,7 @@ function renderInline(text: string): ReactNode {
   let key = 0;
   while ((m = re.exec(text))) {
     if (m.index > lastIndex) {
-      pushText(out, text.slice(lastIndex, m.index), key++);
+      pushText(out, text.slice(lastIndex, m.index), key++, options);
     }
     if (m[1]) {
       out.push(
@@ -176,13 +192,15 @@ function renderInline(text: string): ReactNode {
         </code>,
       );
     } else if (m[2] && m[3]) {
+      const href = m[3];
       out.push(
         <a
           key={key++}
           className="md-link"
-          href={m[3]}
+          href={href}
           target="_blank"
           rel="noreferrer noopener"
+          onClick={options?.onLinkClick ? (event) => options.onLinkClick!(href, event) : undefined}
         >
           {m[2]}
         </a>,
@@ -190,15 +208,17 @@ function renderInline(text: string): ReactNode {
     } else if (m[4]) {
       // Bare URL — autolink with the URL as both href and visible text,
       // matching the Markdown `<https://…>` autolink convention.
+      const href = m[4];
       out.push(
         <a
           key={key++}
           className="md-link md-link-bare"
-          href={m[4]}
+          href={href}
           target="_blank"
           rel="noreferrer noopener"
+          onClick={options?.onLinkClick ? (event) => options.onLinkClick!(href, event) : undefined}
         >
-          {m[4]}
+          {href}
         </a>,
       );
     } else if (m[5]) {
@@ -213,7 +233,7 @@ function renderInline(text: string): ReactNode {
     lastIndex = re.lastIndex;
   }
   if (lastIndex < text.length) {
-    pushText(out, text.slice(lastIndex), key++);
+    pushText(out, text.slice(lastIndex), key++, options);
   }
   return <Fragment>{out}</Fragment>;
 }
@@ -222,7 +242,12 @@ function renderInline(text: string): ReactNode {
 // text nodes. Newlines inside a paragraph become explicit <br />s — the
 // upstream parser has already left them in place because chat output
 // often relies on hard line breaks rather than blank-line separation.
-function pushText(out: ReactNode[], text: string, baseKey: number): void {
+function pushText(
+  out: ReactNode[],
+  text: string,
+  baseKey: number,
+  options?: RenderMarkdownOptions,
+): void {
   if (!text) return;
   const urlRe = /(https?:\/\/[^\s)]+)/g;
   const segments: ReactNode[] = [];
@@ -233,15 +258,20 @@ function pushText(out: ReactNode[], text: string, baseKey: number): void {
     if (m.index > lastIndex) {
       segments.push(...withBreaks(text.slice(lastIndex, m.index), `${baseKey}-${k++}`));
     }
+    // m[1] is the URL capture group; if the regex matched at all the
+    // group is populated, so the non-null assertion documents that
+    // invariant without forcing a runtime guard.
+    const href = m[1]!;
     segments.push(
       <a
         key={`${baseKey}-${k++}`}
         className="md-link"
-        href={m[1]}
+        href={href}
         target="_blank"
         rel="noreferrer noopener"
+        onClick={options?.onLinkClick ? (event) => options.onLinkClick!(href, event) : undefined}
       >
-        {m[1]}
+        {href}
       </a>,
     );
     lastIndex = urlRe.lastIndex;

--- a/apps/web/tests/components/AssistantMessage.linkClick.test.tsx
+++ b/apps/web/tests/components/AssistantMessage.linkClick.test.tsx
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AssistantMessage } from '../../src/components/AssistantMessage';
+import type { AgentEvent, ChatMessage } from '../../src/types';
+
+function messageWithText(text: string): ChatMessage {
+  const events: AgentEvent[] = [{ kind: 'text', text }];
+  return {
+    id: 'assistant-1',
+    role: 'assistant',
+    content: '',
+    events,
+    startedAt: 1_000,
+    endedAt: 3_000,
+    runStatus: 'succeeded',
+  };
+}
+
+describe('AssistantMessage — chat file-link routing (#1239)', () => {
+  afterEach(() => cleanup());
+
+  it('routes a relative file-link click through onRequestOpenFile and suppresses the default new-window behavior', () => {
+    // Before this fix, the rendered <a> kept its target="_blank" and
+    // Electron's setWindowOpenHandler created a new app window with a
+    // relative href it couldn't resolve, dumping the user on the home
+    // screen. The fix detects in-project file paths and routes them
+    // through the existing workspace tab opener instead.
+    const onRequestOpenFile = vi.fn();
+    const { container } = render(
+      <AssistantMessage
+        message={messageWithText('Open [template.html](template.html) to preview.')}
+        streaming={false}
+        projectId="project-1"
+        onRequestOpenFile={onRequestOpenFile}
+      />,
+    );
+
+    const anchor = container.querySelector('a.md-link');
+    expect(anchor).not.toBeNull();
+    expect(anchor?.getAttribute('href')).toBe('template.html');
+
+    // Dispatch a real DOM MouseEvent so we can check defaultPrevented
+    // on the underlying native event — that's the signal Electron's
+    // setWindowOpenHandler reads to decide whether to open a new
+    // window.
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+    anchor!.dispatchEvent(clickEvent);
+
+    expect(onRequestOpenFile).toHaveBeenCalledTimes(1);
+    expect(onRequestOpenFile).toHaveBeenCalledWith('template.html');
+    expect(clickEvent.defaultPrevented).toBe(true);
+  });
+
+  it('normalizes a ./ prefix and a nested subdirectory path before opening', () => {
+    const onRequestOpenFile = vi.fn();
+    const { container } = render(
+      <AssistantMessage
+        message={messageWithText('Inspect [hero](./subdir/hero.html) section.')}
+        streaming={false}
+        projectId="project-1"
+        onRequestOpenFile={onRequestOpenFile}
+      />,
+    );
+
+    const anchor = container.querySelector('a.md-link')!;
+    fireEvent.click(anchor);
+    expect(onRequestOpenFile).toHaveBeenCalledTimes(1);
+    expect(onRequestOpenFile).toHaveBeenCalledWith('subdir/hero.html');
+  });
+
+  it('does not intercept external https:// URLs — keeps default target="_blank"', () => {
+    // We must not regress on the original chat behavior for legitimate
+    // outbound URLs (documentation links, search results, etc.). The
+    // anchor still uses target="_blank" and onRequestOpenFile is not
+    // called for these.
+    const onRequestOpenFile = vi.fn();
+    const { container } = render(
+      <AssistantMessage
+        message={messageWithText('See [the docs](https://docs.example.com/guide) for context.')}
+        streaming={false}
+        projectId="project-1"
+        onRequestOpenFile={onRequestOpenFile}
+      />,
+    );
+
+    const anchor = container.querySelector('a.md-link')!;
+    expect(anchor.getAttribute('href')).toBe('https://docs.example.com/guide');
+    expect(anchor.getAttribute('target')).toBe('_blank');
+
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+    anchor.dispatchEvent(clickEvent);
+
+    expect(onRequestOpenFile).not.toHaveBeenCalled();
+    expect(clickEvent.defaultPrevented).toBe(false);
+  });
+
+  it('does not intercept bare-URL autolinks either', () => {
+    const onRequestOpenFile = vi.fn();
+    const { container } = render(
+      <AssistantMessage
+        message={messageWithText('Reference: https://example.com/page')}
+        streaming={false}
+        projectId="project-1"
+        onRequestOpenFile={onRequestOpenFile}
+      />,
+    );
+
+    const anchor = container.querySelector('a.md-link')!;
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+    anchor.dispatchEvent(clickEvent);
+
+    expect(onRequestOpenFile).not.toHaveBeenCalled();
+    expect(clickEvent.defaultPrevented).toBe(false);
+  });
+
+  it('does not intercept #fragment anchors', () => {
+    const onRequestOpenFile = vi.fn();
+    const { container } = render(
+      <AssistantMessage
+        message={messageWithText('Jump to [section](#section) above.')}
+        streaming={false}
+        projectId="project-1"
+        onRequestOpenFile={onRequestOpenFile}
+      />,
+    );
+
+    const anchor = container.querySelector('a.md-link')!;
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+    anchor.dispatchEvent(clickEvent);
+    expect(onRequestOpenFile).not.toHaveBeenCalled();
+    expect(clickEvent.defaultPrevented).toBe(false);
+  });
+
+  it('falls back to default behavior when no onRequestOpenFile is provided', () => {
+    // The component should remain usable in surfaces that have no
+    // project context (no workspace tabs). Clicks on file-shaped
+    // links must NOT silently no-op when there is no handler; they
+    // should hit the underlying default link behavior.
+    const { container } = render(
+      <AssistantMessage
+        message={messageWithText('Open [template.html](template.html) to preview.')}
+        streaming={false}
+        projectId="project-1"
+      />,
+    );
+
+    const anchor = container.querySelector('a.md-link')!;
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+    anchor.dispatchEvent(clickEvent);
+    expect(clickEvent.defaultPrevented).toBe(false);
+  });
+});

--- a/apps/web/tests/runtime/in-project-link.test.ts
+++ b/apps/web/tests/runtime/in-project-link.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import { asInProjectFilePath } from '../../src/runtime/in-project-link';
+
+describe('asInProjectFilePath', () => {
+  describe('intercepts (returns normalized path)', () => {
+    it('bare filename → unchanged', () => {
+      expect(asInProjectFilePath('template.html')).toBe('template.html');
+    });
+
+    it('strips a leading ./ prefix', () => {
+      expect(asInProjectFilePath('./template.html')).toBe('template.html');
+    });
+
+    it('keeps subdirectory paths intact', () => {
+      expect(asInProjectFilePath('subdir/hero.html')).toBe('subdir/hero.html');
+    });
+
+    it('strips ./ in front of a subdirectory path', () => {
+      expect(asInProjectFilePath('./subdir/hero.html')).toBe('subdir/hero.html');
+    });
+
+    it('drops a trailing query string', () => {
+      expect(asInProjectFilePath('template.html?v=2')).toBe('template.html');
+    });
+
+    it('drops a trailing fragment', () => {
+      expect(asInProjectFilePath('template.html#section')).toBe('template.html');
+    });
+
+    it('drops both query and fragment together', () => {
+      expect(asInProjectFilePath('template.html?v=2#section')).toBe('template.html');
+    });
+
+    it('trims surrounding whitespace from the href', () => {
+      expect(asInProjectFilePath('  template.html  ')).toBe('template.html');
+    });
+
+    it('handles long, real-world chat output filenames', () => {
+      // The exact shape shown in the issue screenshot.
+      expect(asInProjectFilePath('orbit-daily-digest-general-2026-05-11.html'))
+        .toBe('orbit-daily-digest-general-2026-05-11.html');
+    });
+  });
+
+  describe('passes through (returns null) — external schemes', () => {
+    it('http://', () => {
+      expect(asInProjectFilePath('http://example.com/x')).toBeNull();
+    });
+
+    it('https://', () => {
+      expect(asInProjectFilePath('https://example.com/x')).toBeNull();
+    });
+
+    it('mailto:', () => {
+      expect(asInProjectFilePath('mailto:foo@bar.com')).toBeNull();
+    });
+
+    it('the Electron od: protocol', () => {
+      expect(asInProjectFilePath('od://app/projects/123')).toBeNull();
+    });
+
+    it('blob: URLs', () => {
+      expect(asInProjectFilePath('blob:https://example.com/abc')).toBeNull();
+    });
+
+    it('file: URLs (these are NOT in-project relative paths)', () => {
+      expect(asInProjectFilePath('file:///etc/passwd')).toBeNull();
+    });
+
+    it('hyphen-and-digit schemes still match the RFC 3986 grammar', () => {
+      // e.g. some custom protocol like `web+tel:` — anything matching
+      // `^[a-z][a-z0-9+.-]*:` per the RFC. The point is to be safe,
+      // not to enumerate every scheme.
+      expect(asInProjectFilePath('web+tel:123')).toBeNull();
+    });
+  });
+
+  describe('passes through (returns null) — non-link or unsafe shapes', () => {
+    it('null / undefined / non-string', () => {
+      expect(asInProjectFilePath(null)).toBeNull();
+      expect(asInProjectFilePath(undefined)).toBeNull();
+      // @ts-expect-error — intentional bad input to verify runtime guard
+      expect(asInProjectFilePath(42)).toBeNull();
+    });
+
+    it('empty / whitespace-only', () => {
+      expect(asInProjectFilePath('')).toBeNull();
+      expect(asInProjectFilePath('   ')).toBeNull();
+    });
+
+    it('pure fragment (intra-page anchor)', () => {
+      expect(asInProjectFilePath('#section')).toBeNull();
+    });
+
+    it('absolute path starting with /', () => {
+      // Could mean filesystem root in Electron and is not what the
+      // assistant means when it writes a chat file link; default
+      // browser behavior is the safer fallback.
+      expect(asInProjectFilePath('/etc/passwd')).toBeNull();
+      expect(asInProjectFilePath('/some/file.html')).toBeNull();
+    });
+
+    it('a path with .. traversal anywhere', () => {
+      expect(asInProjectFilePath('..')).toBeNull();
+      expect(asInProjectFilePath('../sibling.html')).toBeNull();
+      expect(asInProjectFilePath('subdir/../escape.html')).toBeNull();
+      expect(asInProjectFilePath('a/b/../c.html')).toBeNull();
+    });
+
+    it('href that strips to empty after query/fragment removal', () => {
+      // Pathological but possible — a chat message with `[label](?foo)`.
+      expect(asInProjectFilePath('?foo')).toBeNull();
+      expect(asInProjectFilePath('#')).toBeNull();
+    });
+  });
+});

--- a/apps/web/tests/runtime/markdown.linkClick.test.tsx
+++ b/apps/web/tests/runtime/markdown.linkClick.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderMarkdown } from '../../src/runtime/markdown';
+
+describe('renderMarkdown — onLinkClick option', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('does not attach onClick when onLinkClick is not provided', () => {
+    // Backwards-compat: existing callers (file viewer, system reminders,
+    // anywhere that just wants markdown rendered with default behavior)
+    // must keep their previous behavior. The rendered <a> still uses
+    // target="_blank" and has no extra event listener overhead.
+    const { container } = render(
+      <div>{renderMarkdown('Click [here](https://example.com).')}</div>,
+    );
+    const anchor = container.querySelector('a');
+    expect(anchor).not.toBeNull();
+    expect(anchor?.getAttribute('href')).toBe('https://example.com');
+    // onClick attaches as a React synthetic listener; without it the DOM
+    // attribute also stays absent. We can't directly inspect React's
+    // listener map from a DOM query, but the absence-of-side-effects
+    // check below pins the contract: clicking does not invoke any
+    // intercept callback because none was registered.
+    expect(anchor?.hasAttribute('onclick')).toBe(false);
+  });
+
+  it('fires onLinkClick on every explicit [text](url) link click', () => {
+    const onLinkClick = vi.fn();
+    const { container } = render(
+      <div>
+        {renderMarkdown('Open [the file](template.html) to inspect.', { onLinkClick })}
+      </div>,
+    );
+    const anchor = container.querySelector('a');
+    expect(anchor).not.toBeNull();
+    expect(anchor?.getAttribute('href')).toBe('template.html');
+    fireEvent.click(anchor!);
+    expect(onLinkClick).toHaveBeenCalledTimes(1);
+    expect(onLinkClick.mock.calls[0]?.[0]).toBe('template.html');
+  });
+
+  it('fires onLinkClick on autolinked bare https URLs', () => {
+    // The bare-autolink branch runs through pushText; before this PR
+    // it had no onClick wiring at all, so the regression would be
+    // "in-project files are intercepted but bare URLs are not". The
+    // contract is the same in both paths: caller hears the click and
+    // decides whether to preventDefault.
+    const onLinkClick = vi.fn();
+    const { container } = render(
+      <div>{renderMarkdown('See https://example.com/page for context.', { onLinkClick })}</div>,
+    );
+    const anchor = container.querySelector('a');
+    expect(anchor).not.toBeNull();
+    fireEvent.click(anchor!);
+    expect(onLinkClick).toHaveBeenCalledTimes(1);
+    expect(onLinkClick.mock.calls[0]?.[0]).toBe('https://example.com/page');
+  });
+
+  it('passes the React MouseEvent so the caller can preventDefault', () => {
+    // The intercept contract is: the caller decides whether to
+    // suppress the default `target="_blank"` behavior. This test
+    // pins that the second argument is the React synthetic event,
+    // not just the raw DOM event or a stripped wrapper.
+    const onLinkClick = vi.fn((_href: string, event: { preventDefault: () => void }) => {
+      event.preventDefault();
+    });
+    const { container } = render(
+      <div>
+        {renderMarkdown('Open [the file](template.html).', { onLinkClick })}
+      </div>,
+    );
+    const anchor = container.querySelector('a')!;
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+    anchor.dispatchEvent(clickEvent);
+    // React routes the native event through its synthetic event
+    // system; the caller's preventDefault call propagates to the
+    // underlying native event so the browser would not follow the
+    // `target="_blank"` link.
+    expect(onLinkClick).toHaveBeenCalledTimes(1);
+    expect(clickEvent.defaultPrevented).toBe(true);
+  });
+
+  it('still respects markdown structure when intercepting clicks', () => {
+    // Sanity: the link in a paragraph alongside emphasis and inline
+    // code keeps the parent <p>'s other tokens intact; only the <a>
+    // gets the click wiring.
+    const onLinkClick = vi.fn();
+    const { container } = render(
+      <div>
+        {renderMarkdown(
+          'Look at [the file](template.html) and **note** the `index.html` reference.',
+          { onLinkClick },
+        )}
+      </div>,
+    );
+    expect(container.querySelector('strong')?.textContent).toBe('note');
+    expect(container.querySelector('code')?.textContent).toBe('index.html');
+    const anchor = container.querySelector('a')!;
+    fireEvent.click(anchor);
+    expect(onLinkClick).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1239 (P0). Chat-emitted markdown links like `[template.html](template.html)` or `[hero](subdir/hero.html)` rendered as `<a target=\"_blank\">` with no `onClick`. In Electron that hits `setWindowOpenHandler` and creates a new `od://` BrowserWindow; a relative href has no base so the new window can't resolve it and lands on the home screen — the file the assistant pointed at is never previewed. This PR routes those relative file links through the workspace tab opener that already lives in ProjectView, while leaving external `http(s)://` URLs (and other schemes / fragments / absolute paths) on their default browser-link behavior.

## Approach

ProjectView already exposes `requestOpenFile(name)` (apps/web/src/components/ProjectView.tsx:569) and threads it down to ChatPane → AssistantMessage as the `onRequestOpenFile` prop. Tool cards and produced-file chips have used it for a while. The PR plugs chat-markdown `<a>` clicks into the same path.

```diff
ProseBlock (apps/web/src/components/AssistantMessage.tsx)
+ const onLinkClick = useMemo<MarkdownLinkClickHandler | undefined>(() => {
+   if (!onRequestOpenFile) return undefined;
+   return (href, event) => {
+     const path = asInProjectFilePath(href);
+     if (!path) return;  // external / anchor / abs / traversal → default behavior
+     event.preventDefault();
+     onRequestOpenFile(path);
+   };
+ }, [onRequestOpenFile]);

- {renderMarkdown(seg.text)}
+ {renderMarkdown(seg.text, { onLinkClick })}
```

Three pieces:

1. **`apps/web/src/runtime/in-project-link.ts`** (new) — pure helper `asInProjectFilePath(href): string | null` documenting and gating the intercept-vs-pass-through decision in one place.
2. **`apps/web/src/runtime/markdown.tsx`** — `renderMarkdown(input, options?)` now takes `RenderMarkdownOptions` with an optional `onLinkClick` callback. Threaded through `renderBlock` / `renderInline` / `pushText` so **all three** `<a>` render sites get the same intercept hook (explicit `[text](url)` links, bare-URL autolinks inside inline scans, and the autolink branch in `pushText`). When the option is omitted, render output is byte-identical to before — every existing caller (file viewer, system reminders, …) keeps working without changes.
3. **`apps/web/src/components/AssistantMessage.tsx`** — wires the existing `onRequestOpenFile` prop into that hook via the helper.

### What gets intercepted

| href | Result |
|---|---|
| `template.html` | → `onRequestOpenFile('template.html')` + `preventDefault()` |
| `./template.html` | → `onRequestOpenFile('template.html')` |
| `subdir/hero.html` | → `onRequestOpenFile('subdir/hero.html')` |
| `template.html?v=2#section` | → `onRequestOpenFile('template.html')` |
| `https://docs.example.com` | pass-through, opens externally |
| `mailto:foo@bar` | pass-through |
| `#section` | pass-through |
| `/abs/path` | pass-through |
| `..` / `../sibling.html` / `a/b/../c.html` | pass-through (refuse to leave project root via relative navigation) |

The pass-through cases come from real-world chat content (doc links, OAuth flows, bare URLs) and from defensive checks (`..` traversal, absolute paths).

## Reproduce

1. Open a project with chat that includes file links — typical Orbit / artifact-generating sessions produce them automatically; the issue screenshot shows `template.html`, `index.html`, `orbit-daily-digest-general-2026-05-11.html`.
2. Click one of those links in the chat.

**Before this PR**: a new Electron app window opens and lands on the home screen. The file is never previewed.
**After this PR**: the file opens in the right-pane Design Files workspace and the user stays in the current project.

## Verification

- `pnpm --filter @open-design/contracts build && pnpm --filter @open-design/web typecheck` — clean (exit 0)
- `pnpm --filter @open-design/web test` — **87 files, 785/785 passed**, includes the 33 new tests below
- `pnpm guard` — 5/5 invariant checks pass
- Direct RED→GREEN sanity check: `git stash push apps/web/src/runtime/markdown.tsx apps/web/src/components/AssistantMessage.tsx` → re-run `AssistantMessage.linkClick.test.tsx` → the two `expect(onRequestOpenFile).toHaveBeenCalled…` cases fail, the four pass-through invariants still pass. `git stash pop` → all 6 pass again.

## New tests

| File | Cases | What it pins |
|---|---|---|
| `apps/web/tests/runtime/in-project-link.test.ts` | 22 | Every documented intercept / pass-through shape, including the exact filename pattern from the issue screenshot (`orbit-daily-digest-general-2026-05-11.html`). |
| `apps/web/tests/runtime/markdown.linkClick.test.tsx` | 5 | `onLinkClick` contract across all three `<a>` render sites; backwards-compat when `options` is omitted; `preventDefault()` propagation through the React synthetic event boundary. |
| `apps/web/tests/components/AssistantMessage.linkClick.test.tsx` | 6 | Integration: relative file link intercepts through `onRequestOpenFile` with normalized path (`./subdir/hero.html` → `subdir/hero.html`); https / bare URL / `#fragment` fall through; missing `onRequestOpenFile` keeps default behavior. |

## Test plan

- [ ] CI green on the `apps/web` package
- [ ] Manual: reproduce the issue per the steps above (chat with file links → click → file previews in-app instead of opening a new window)

## Not in scope

- Other paths that emit clickable file-shaped strings (tool cards, produced-file chips, file panel) — those already use `onRequestOpenFile` directly and were never broken by this issue.
- `target="_blank"` on the rendered `<a>` is preserved. If a future feature wants to fully suppress the underlying default (e.g. middle-click-to-open-in-tab semantics for in-project files), it can extend `onLinkClick` further; the intercept contract is already in place.