### PR TITLE
fix(web): refresh projects list on terminal run statuses

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -908,8 +908,17 @@ export function ProjectView({
     const agentEvent = projectEventToAgentEvent(evt);
     if (!agentEvent) return;
     setLiveArtifactEvents((prev) => appendLiveArtifactEventItem(prev, agentEvent));
-    void refreshLiveArtifacts();
-    onProjectsRefresh();
+    // Issue #731: await the detail view's live-artifact refetch before
+    // re-reading the Designs home cards so listProjects sees the same
+    // committed snapshot the detail view just observed. Without this the
+    // home card briefly shows "Completed" while the detail view still
+    // shows Working / error / timed out. The catch path still fires the
+    // refresh so a transient fetchLiveArtifacts failure doesn't strand
+    // the home card on a stale status.
+    void refreshLiveArtifacts().then(
+      () => onProjectsRefresh(),
+      () => onProjectsRefresh(),
+    );
     // Live artifact events come from chat-turn-emitted artifacts; they
     // also imply the conversation transcript changed.
     setDesignMdRefreshKey((n) => n + 1);

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1368,7 +1368,7 @@ export function ProjectView({
             true,
           );
           completedReattachRunsRef.current.add(runId);
-          void Promise.allSettled([saved]).then(() => onProjectsRefresh());
+          void saved.then(() => onProjectsRefresh());
           continue;
         }
         updateMessageById(

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1795,7 +1795,7 @@ export function ProjectView({
           if (emptyApiResponse) {
             const endedAt = Date.now();
             const diagnostic = t('assistant.emptyResponseMessage');
-            updateMessageById(
+            const persisted = updateMessageById(
               assistantId,
               (prev) => ({
                 ...prev,
@@ -1817,19 +1817,24 @@ export function ProjectView({
             clearStreamingMarker(runConversationId);
             updateConversationLatestRun('failed', endedAt);
             void refreshProjectFiles();
-            onProjectsRefresh();
+            void persisted.then(() => onProjectsRefresh());
             return;
           }
           const endedAt = Date.now();
           let finalRunStatus: ChatMessage['runStatus'] = 'succeeded';
-          updateAssistant((prev) => {
-            finalRunStatus = resolveSucceededRunStatus(prev.runStatus);
-            return {
-              ...prev,
-              endedAt,
-              runStatus: finalRunStatus,
-            };
-          });
+          const saved = updateMessageById(
+            assistantId,
+            (prev) => {
+              finalRunStatus = resolveSucceededRunStatus(prev.runStatus);
+              return {
+                ...prev,
+                endedAt,
+                runStatus: finalRunStatus,
+              };
+            },
+            true,
+            { telemetryFinalized: true },
+          );
           if (commentAttachments.length > 0) {
             void patchAttachedStatuses(commentAttachments, 'needs_review');
           }
@@ -1847,20 +1852,28 @@ export function ProjectView({
           // refresh signal) so we can diff against the pre-turn snapshot
           // and attach the new files to the assistant message as download
           // chips.
-          void refreshProjectFiles().then((nextFiles) => {
-            const produced = nextFiles.filter((f) => !beforeFileNames.has(f.name));
-            setMessages((curr) => {
-              const updated = curr.map((m) =>
-                m.id === assistantId
-                  ? { ...m, producedFiles: produced }
-                  : m,
-              );
-              const finalized = updated.find((m) => m.id === assistantId);
-              if (finalized) persistMessage(finalized, { telemetryFinalized: true });
-              return updated;
+          const produced = refreshProjectFiles().then((nextFiles) => {
+            const producedFiles = nextFiles.filter((f) => !beforeFileNames.has(f.name));
+            return new Promise<void>((resolve, reject) => {
+              setMessages((curr) => {
+                const updated = curr.map((m) =>
+                  m.id === assistantId
+                    ? { ...m, producedFiles }
+                    : m,
+                );
+                const finalized = updated.find((m) => m.id === assistantId);
+                if (finalized && !isPhantomDaemonRunMessage(finalized) && activeConversationId) {
+                  Promise.resolve(
+                    saveMessage(project.id, activeConversationId, finalized, { telemetryFinalized: true }),
+                  ).then(resolve, reject);
+                } else {
+                  resolve();
+                }
+                return updated;
+              });
             });
           });
-          onProjectsRefresh();
+          void Promise.allSettled([saved, produced]).then(() => onProjectsRefresh());
         },
         onError: (err: Error) => {
           const endedAt = Date.now();

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1347,6 +1347,7 @@ export function ProjectView({
             true,
           );
           completedReattachRunsRef.current.add(runId);
+          onProjectsRefresh();
           continue;
         }
         updateMessageById(
@@ -1437,6 +1438,7 @@ export function ProjectView({
               clearActiveRunRefs(reattachConversationId, controller, cancelController);
               clearStreamingMarker(reattachConversationId);
               persistNow({ telemetryFinalized: true });
+              onProjectsRefresh();
             },
           },
           onRunStatus: (runStatus) => {
@@ -1460,6 +1462,9 @@ export function ProjectView({
               clearStreamingMarker(reattachConversationId);
               persistNow({ telemetryFinalized: true });
             }
+            if (isTerminalRunStatus(runStatus)) {
+              onProjectsRefresh();
+            }
           },
           onRunEventId: (lastRunEventId) => {
             textBuffer.flush();
@@ -1478,6 +1483,7 @@ export function ProjectView({
                 true,
                 { telemetryFinalized: true },
               );
+              onProjectsRefresh();
             }
           })
           .finally(() => {
@@ -1860,6 +1866,7 @@ export function ProjectView({
             return curr;
           });
           void refreshProjectFiles();
+          onProjectsRefresh();
         },
       };
 

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1428,7 +1428,7 @@ export function ProjectView({
               reattachCancelControllersRef.current.delete(runId);
               clearActiveRunRefs(reattachConversationId, controller, cancelController);
               clearStreamingMarker(reattachConversationId);
-              persistNow({ telemetryFinalized: true });
+              const persisted = persistNow({ telemetryFinalized: true });
               void refreshProjectFiles();
               void Promise.allSettled([saved, persisted]).then(() => onProjectsRefresh());
             },
@@ -1448,8 +1448,8 @@ export function ProjectView({
               reattachCancelControllersRef.current.delete(runId);
               clearActiveRunRefs(reattachConversationId, controller, cancelController);
               clearStreamingMarker(reattachConversationId);
-              persistNow({ telemetryFinalized: true });
-              onProjectsRefresh();
+              const persisted = persistNow({ telemetryFinalized: true });
+              void Promise.allSettled([saved, persisted]).then(() => onProjectsRefresh());
             },
           },
           onRunStatus: (runStatus) => {
@@ -1872,11 +1872,9 @@ export function ProjectView({
           clearActiveRunRefs(runConversationId, controller, cancelController);
           clearStreamingMarker(runConversationId);
           updateConversationLatestRun('failed', endedAt);
-          setMessages((curr) => {
-            const finalized = curr.find((m) => m.id === assistantId);
-            if (finalized) persistMessage(finalized, { telemetryFinalized: true });
-            return curr;
-          });
+          let persisted: Promise<void> = Promise.resolve();
+          const finalized = messagesRef.current.find((m) => m.id === assistantId);
+          if (finalized) persisted = persistMessage(finalized, { telemetryFinalized: true });
           void refreshProjectFiles();
           void persisted.then(() => onProjectsRefresh());
         },
@@ -1911,7 +1909,7 @@ export function ProjectView({
           },
           onRunStatus: (runStatus) => {
             const endedAt = isTerminalRunStatus(runStatus) ? Date.now() : undefined;
-            updateMessageById(
+            const saved = updateMessageById(
               assistantId,
               (prev) => ({
                 ...prev,
@@ -1925,6 +1923,7 @@ export function ProjectView({
             if (isTerminalRunStatus(runStatus)) {
               clearActiveRunRefs(runConversationId, controller, cancelController);
               clearStreamingMarker(runConversationId);
+              void saved.then(() => onProjectsRefresh());
             }
           },
           onRunEventId: (lastRunEventId) => {

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1119,9 +1119,9 @@ export function ProjectView({
       updater: (message: ChatMessage) => ChatMessage,
       persist = false,
       persistOptions?: SaveMessageOptions,
-    ) => {
+    ): Promise<void> => {
+      let saved: ChatMessage | null = null;
       setMessages((curr) => {
-        let saved: ChatMessage | null = null;
         const next = curr.map((m) => {
           if (m.id !== messageId) return m;
           const updated = updater(m);
@@ -1137,6 +1137,10 @@ export function ProjectView({
         }
         return next;
       });
+      if (persist && saved && activeConversationId) {
+        return saveMessage(project.id, activeConversationId, saved, persistOptions);
+      }
+      return Promise.resolve();
     },
     [project.id, activeConversationId],
   );
@@ -1374,13 +1378,13 @@ export function ProjectView({
             persistMessageById(message.id);
           }, 500);
         };
-        const persistNow = (options?: SaveMessageOptions) => {
+        const persistNow = (options?: SaveMessageOptions): Promise<void> => {
           if (persistTimer) {
             clearTimeout(persistTimer);
             persistTimer = null;
           }
           textBuffer.flush();
-          persistMessageById(message.id, options);
+          return persistMessageById(message.id, options);
         };
         const textBuffer = createBufferedTextUpdates({
           updateMessage: (updater) => updateMessageById(message.id, updater),
@@ -1407,7 +1411,7 @@ export function ProjectView({
               textBuffer.flush();
               textBuffer.cancel();
               unregisterTextBuffer();
-              updateMessageById(
+              const saved = updateMessageById(
                 message.id,
                 (prev) => ({ ...prev, runStatus: 'succeeded', endedAt: prev.endedAt ?? Date.now() }),
                 true,
@@ -1419,7 +1423,7 @@ export function ProjectView({
               clearStreamingMarker(reattachConversationId);
               persistNow({ telemetryFinalized: true });
               void refreshProjectFiles();
-              onProjectsRefresh();
+              void Promise.allSettled([saved, persisted]).then(() => onProjectsRefresh());
             },
             onError: (err) => {
               textBuffer.flush();
@@ -1427,7 +1431,7 @@ export function ProjectView({
               unregisterTextBuffer();
               setError(err.message);
               appendAssistantErrorEvent(message.id, err.message);
-              updateMessageById(
+              const saved = updateMessageById(
                 message.id,
                 (prev) => ({ ...prev, runStatus: 'failed', endedAt: prev.endedAt ?? Date.now() }),
                 true,
@@ -1443,7 +1447,7 @@ export function ProjectView({
           },
           onRunStatus: (runStatus) => {
             textBuffer.flush();
-            updateMessageById(
+            const saved = updateMessageById(
               message.id,
               (prev) => ({
                 ...prev,
@@ -1452,6 +1456,7 @@ export function ProjectView({
               }),
               true,
             );
+            let persisted: Promise<void> = Promise.resolve();
             if (runStatus === 'canceled') {
               textBuffer.cancel();
               unregisterTextBuffer();
@@ -1463,7 +1468,7 @@ export function ProjectView({
               persistNow({ telemetryFinalized: true });
             }
             if (isTerminalRunStatus(runStatus)) {
-              onProjectsRefresh();
+              void Promise.allSettled([saved, persisted]).then(() => onProjectsRefresh());
             }
           },
           onRunEventId: (lastRunEventId) => {
@@ -1477,13 +1482,13 @@ export function ProjectView({
               const msg = err instanceof Error ? err.message : String(err);
               setError(msg);
               appendAssistantErrorEvent(message.id, msg);
-              updateMessageById(
+              const saved = updateMessageById(
                 message.id,
                 (prev) => ({ ...prev, runStatus: 'failed', endedAt: prev.endedAt ?? Date.now() }),
                 true,
                 { telemetryFinalized: true },
               );
-              onProjectsRefresh();
+              void saved.then(() => onProjectsRefresh());
             }
           })
           .finally(() => {
@@ -1866,7 +1871,7 @@ export function ProjectView({
             return curr;
           });
           void refreshProjectFiles();
-          onProjectsRefresh();
+          void persisted.then(() => onProjectsRefresh());
         },
       };
 

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1362,13 +1362,13 @@ export function ProjectView({
         const status = fallbackRun ?? await fetchChatRunStatus(runId);
         if (cancelled) return;
         if (!status) {
-          updateMessageById(
+          const saved = updateMessageById(
             message.id,
             (prev) => ({ ...prev, runStatus: 'failed', endedAt: prev.endedAt ?? Date.now() }),
             true,
           );
           completedReattachRunsRef.current.add(runId);
-          onProjectsRefresh();
+          void Promise.allSettled([saved]).then(() => onProjectsRefresh());
           continue;
         }
         updateMessageById(

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1107,14 +1107,18 @@ export function ProjectView({
   );
 
   const persistMessageById = useCallback(
-    (messageId: string, options?: SaveMessageOptions) => {
-      if (!activeConversationId) return;
-      setMessages((curr) => {
-        const found = curr.find((m) => m.id === messageId);
-        if (found && !isPhantomDaemonRunMessage(found)) {
-          void saveMessage(project.id, activeConversationId, found, options);
-        }
-        return curr;
+    (messageId: string, options?: SaveMessageOptions): Promise<void> => {
+      if (!activeConversationId) return Promise.resolve();
+      return new Promise<void>((resolve, reject) => {
+        setMessages((curr) => {
+          const found = curr.find((m) => m.id === messageId);
+          if (found && !isPhantomDaemonRunMessage(found)) {
+            Promise.resolve(saveMessage(project.id, activeConversationId, found, options)).then(resolve, reject);
+          } else {
+            resolve();
+          }
+          return curr;
+        });
       });
     },
     [project.id, activeConversationId],
@@ -1127,27 +1131,33 @@ export function ProjectView({
       persist = false,
       persistOptions?: SaveMessageOptions,
     ): Promise<void> => {
-      let saved: ChatMessage | null = null;
-      setMessages((curr) => {
-        const next = curr.map((m) => {
-          if (m.id !== messageId) return m;
-          const updated = updater(m);
-          saved = updated;
-          return updated;
-        });
-        // Same phantom guard as persistMessage: skip writes for a daemon
-        // assistant row that is still in-flight (active runStatus, no runId).
-        // The runId-arriving update from onRunCreated passes through because
-        // the updater sets runId before this check runs.
-        if (persist && saved && activeConversationId && !isPhantomDaemonRunMessage(saved)) {
-          void saveMessage(project.id, activeConversationId, saved, persistOptions);
-        }
-        return next;
-      });
-      if (persist && saved && activeConversationId) {
-        return saveMessage(project.id, activeConversationId, saved, persistOptions);
+      if (!persist) {
+        setMessages((curr) =>
+          curr.map((m) => (m.id === messageId ? updater(m) : m)),
+        );
+        return Promise.resolve();
       }
-      return Promise.resolve();
+      return new Promise<void>((resolve, reject) => {
+        setMessages((curr) => {
+          let saved: ChatMessage | null = null;
+          const next = curr.map((m) => {
+            if (m.id !== messageId) return m;
+            const updated = updater(m);
+            saved = updated;
+            return updated;
+          });
+          // Same phantom guard as persistMessage: skip writes for a daemon
+          // assistant row that is still in-flight (active runStatus, no runId).
+          // The runId-arriving update from onRunCreated passes through because
+          // the updater sets runId before this check runs.
+          if (saved && activeConversationId && !isPhantomDaemonRunMessage(saved)) {
+            Promise.resolve(saveMessage(project.id, activeConversationId, saved, persistOptions)).then(resolve, reject);
+          } else {
+            resolve();
+          }
+          return next;
+        });
+      });
     },
     [project.id, activeConversationId],
   );

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1472,7 +1472,7 @@ export function ProjectView({
               reattachCancelControllersRef.current.delete(runId);
               clearActiveRunRefs(reattachConversationId, controller, cancelController);
               clearStreamingMarker(reattachConversationId);
-              persistNow({ telemetryFinalized: true });
+              persisted = persistNow({ telemetryFinalized: true });
             }
             if (isTerminalRunStatus(runStatus)) {
               void Promise.allSettled([saved, persisted]).then(() => onProjectsRefresh());
@@ -1859,22 +1859,24 @@ export function ProjectView({
           cancelSendTextBuffer();
           setError(err.message);
           appendAssistantErrorEvent(assistantId, err.message);
-          updateAssistant((prev) => ({
-            ...prev,
-            endedAt,
-            runStatus: config.mode === 'api' || prev.runId || isActiveRunStatus(prev.runStatus)
-              ? 'failed'
-              : prev.runStatus,
-          }));
+          const persisted = updateMessageById(
+            assistantId,
+            (prev) => ({
+              ...prev,
+              endedAt,
+              runStatus: config.mode === 'api' || prev.runId || isActiveRunStatus(prev.runStatus)
+                ? 'failed'
+                : prev.runStatus,
+            }),
+            true,
+            { telemetryFinalized: true },
+          );
           if (commentAttachments.length > 0) {
             void patchAttachedStatuses(commentAttachments, 'failed');
           }
           clearActiveRunRefs(runConversationId, controller, cancelController);
           clearStreamingMarker(runConversationId);
           updateConversationLatestRun('failed', endedAt);
-          let persisted: Promise<void> = Promise.resolve();
-          const finalized = messagesRef.current.find((m) => m.id === assistantId);
-          if (finalized) persisted = persistMessage(finalized, { telemetryFinalized: true });
           void refreshProjectFiles();
           void persisted.then(() => onProjectsRefresh());
         },

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -350,6 +350,7 @@ export function ProjectView({
   const [activeConversationId, setActiveConversationId] = useState<string | null>(
     null,
   );
+  const messagesRef = useRef<ChatMessage[]>([]);
   const [messagesConversationId, setMessagesConversationId] = useState<string | null>(null);
   const [failedMessagesConversationId, setFailedMessagesConversationId] = useState<string | null>(null);
   const [conversationLoadError, setConversationLoadError] = useState<string | null>(null);
@@ -668,6 +669,12 @@ export function ProjectView({
       cancelled = true;
     };
   }, [project.id, activeConversationId, messageLoadRetryNonce]);
+
+  // Mirror messages into a ref so async callbacks (run-status, persistNow)
+  // can read the latest snapshot without stale-closure issues.
+  useEffect(() => {
+    messagesRef.current = messages;
+  }, [messages]);
 
   useEffect(() => {
     return () => {

--- a/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
@@ -1513,9 +1513,10 @@ describe('ProjectView daemon cleanup', () => {
     // Drain mount-time fetchLiveArtifacts calls so we observe only the
     // resolver produced by the live_artifact event handler.
     for (let i = 0; i < 5; i++) {
-      if (resolveLiveArtifacts) {
-        resolveLiveArtifacts();
-        resolveLiveArtifacts = null;
+      const resolver = liveArtifactsResolver.current;
+      if (resolver) {
+        liveArtifactsResolver.current = null;
+        resolver();
       }
       await new Promise<void>((resolve) => setTimeout(resolve, 0));
     }
@@ -1541,10 +1542,11 @@ describe('ProjectView daemon cleanup', () => {
     await new Promise<void>((resolve) => setTimeout(resolve, 10));
     expect(onProjectsRefresh).not.toHaveBeenCalled();
 
-    if (!resolveLiveArtifacts) {
+    const eventResolver = liveArtifactsResolver.current;
+    if (!eventResolver) {
       throw new Error('Expected fetchLiveArtifacts to be invoked by the event handler');
     }
-    resolveLiveArtifacts();
+    eventResolver();
 
     await waitFor(() => expect(onProjectsRefresh).toHaveBeenCalledTimes(1));
 

--- a/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
@@ -897,4 +897,225 @@ describe('ProjectView daemon cleanup', () => {
 
     view.unmount();
   });
+
+  it('delays projects refresh in reattach onRunStatus("canceled") until saveMessage resolves', async () => {
+    const onProjectsRefresh = vi.fn();
+    let capturedOnRunStatus: ((status: string) => void) | null = null;
+
+    const pendingResolvers: Array<() => void> = [];
+    saveMessage.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          pendingResolvers.push(resolve);
+        }),
+    );
+
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([
+      {
+        id: 'msg-1',
+        role: 'assistant',
+        content: 'working',
+        createdAt: Date.now(),
+        runId: 'run-cancel',
+        runStatus: 'running',
+      },
+    ]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    fetchChatRunStatus.mockResolvedValue({
+      id: 'run-cancel',
+      status: 'running',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      exitCode: null,
+      signal: null,
+    });
+    listActiveChatRuns.mockResolvedValue([]);
+    reattachDaemonRun.mockImplementation(async (options: { onRunStatus?: (status: string) => void }) => {
+      capturedOnRunStatus = options.onRunStatus ?? null;
+      return new Promise<void>(() => {});
+    });
+
+    const view = render(
+      <ProjectView
+        project={{ id: 'project-1', name: 'Project', skillId: null, designSystemId: null } as never}
+        routeFileName={null}
+        config={{ mode: 'daemon', agentId: 'agent-1', notifications: undefined, agentModels: {} } as never}
+        agents={[{ id: 'agent-1', name: 'OpenCode', models: [] } as never]}
+        skills={[]}
+        designTemplates={[]}
+        designSystems={[]}
+        daemonLive
+        onModeChange={() => {}}
+        onAgentChange={() => {}}
+        onAgentModelChange={() => {}}
+        onRefreshAgents={() => {}}
+        onOpenSettings={() => {}}
+        onBack={() => {}}
+        onClearPendingPrompt={() => {}}
+        onTouchProject={() => {}}
+        onProjectChange={() => {}}
+        onProjectsRefresh={onProjectsRefresh}
+      />,
+    );
+
+    await waitFor(() => expect(reattachDaemonRun).toHaveBeenCalledTimes(1));
+    const onRunStatus = capturedOnRunStatus as ((status: string) => void) | null;
+    if (!onRunStatus) throw new Error('Expected reattach onRunStatus handler to be captured');
+
+    // Drain any saveMessage resolvers queued by mount so we only observe the
+    // resolvers produced by the terminal canceled persist.
+    while (pendingResolvers.length > 0) {
+      const resolver = pendingResolvers.shift();
+      resolver?.();
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    onProjectsRefresh.mockClear();
+    saveMessage.mockClear();
+
+    onRunStatus('canceled');
+
+    // saveMessage for the canceled terminal status is still pending — the
+    // projects refresh must wait. If persistNow's promise were dropped (the
+    // regression: `persistNow(...)` without assigning to `persisted`),
+    // Promise.allSettled would only see the synchronous updateMessageById
+    // promise and the refresh would fire before persistence settles.
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    expect(saveMessage).toHaveBeenCalled();
+    expect(onProjectsRefresh).not.toHaveBeenCalled();
+
+    if (pendingResolvers.length === 0) {
+      throw new Error('Expected canceled saveMessage to be invoked');
+    }
+    for (const resolve of pendingResolvers.splice(0)) resolve();
+
+    await waitFor(() => expect(onProjectsRefresh).toHaveBeenCalled());
+
+    view.unmount();
+  });
+
+  it('persists a failed assistant snapshot when new-run handlers.onError fires while saveMessage is pending', async () => {
+    const onProjectsRefresh = vi.fn();
+    let capturedHandlers:
+      | { onError?: (err: Error) => void; onRunCreated?: (runId: string) => void }
+      | null = null;
+
+    const pendingResolvers: Array<() => void> = [];
+    const savedSnapshots: Array<Record<string, unknown>> = [];
+    saveMessage.mockImplementation(
+      (_projectId: string, _conversationId: string, msg: Record<string, unknown>) => {
+        savedSnapshots.push(msg);
+        return new Promise<void>((resolve) => {
+          pendingResolvers.push(resolve);
+        });
+      },
+    );
+
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    listActiveChatRuns.mockResolvedValue([]);
+    streamViaDaemon.mockImplementation(
+      async (options: {
+        handlers: { onError?: (err: Error) => void };
+        onRunCreated?: (runId: string) => void;
+      }) => {
+        capturedHandlers = { onError: options.handlers.onError, onRunCreated: options.onRunCreated };
+        return new Promise<void>(() => {});
+      },
+    );
+
+    const view = render(
+      <ProjectView
+        project={{ id: 'project-1', name: 'Project', skillId: null, designSystemId: null } as never}
+        routeFileName={null}
+        config={{ mode: 'daemon', agentId: 'agent-1', notifications: undefined, agentModels: {} } as never}
+        agents={[{ id: 'agent-1', name: 'OpenCode', models: [] } as never]}
+        skills={[]}
+        designTemplates={[]}
+        designSystems={[]}
+        daemonLive
+        onModeChange={() => {}}
+        onAgentChange={() => {}}
+        onAgentModelChange={() => {}}
+        onRefreshAgents={() => {}}
+        onOpenSettings={() => {}}
+        onBack={() => {}}
+        onClearPendingPrompt={() => {}}
+        onTouchProject={() => {}}
+        onProjectChange={() => {}}
+        onProjectsRefresh={onProjectsRefresh}
+      />,
+    );
+
+    await waitFor(() => expect(capturedChatPaneProps.current).not.toBeNull());
+    const props = capturedChatPaneProps.current as Record<string, unknown> | null;
+    if (!props || typeof props.onSend !== 'function') {
+      throw new Error('Expected ChatPane onSend to be available');
+    }
+
+    await (props.onSend as (
+      prompt: string,
+      attachments: unknown[],
+      commentAttachments: unknown[],
+    ) => Promise<void>)('hello', [], []);
+
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
+    const handlers = capturedHandlers as
+      | { onError?: (err: Error) => void; onRunCreated?: (runId: string) => void }
+      | null;
+    if (!handlers?.onError || !handlers.onRunCreated) {
+      throw new Error('Expected streamViaDaemon to capture handlers.onError and onRunCreated');
+    }
+
+    // Simulate the daemon registering a runId before the failure — this puts
+    // the assistant into a state where prev.runId is set so the onError branch
+    // flips runStatus to 'failed' (matching the production code path).
+    handlers.onRunCreated('run-new-err');
+
+    // Drain any saveMessage resolvers queued by the initial send so we only
+    // observe the snapshot produced by the terminal onError persist.
+    while (pendingResolvers.length > 0) {
+      const resolver = pendingResolvers.shift();
+      resolver?.();
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    onProjectsRefresh.mockClear();
+    saveMessage.mockClear();
+    savedSnapshots.length = 0;
+
+    handlers.onError(new Error('ACP response timed out after 180000ms'));
+
+    // saveMessage for the failed assistant snapshot is still pending — the
+    // projects refresh must wait until persistence settles, and the persisted
+    // record must reflect the failed runStatus (not the prior 'running' /
+    // 'queued' snapshot the old updateAssistant + messagesRef.find path
+    // would have captured before React applied the setMessages update).
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    expect(saveMessage).toHaveBeenCalled();
+    expect(onProjectsRefresh).not.toHaveBeenCalled();
+    const failedSnapshot = savedSnapshots.find((m) => m.runStatus === 'failed');
+    expect(failedSnapshot).toBeTruthy();
+
+    if (pendingResolvers.length === 0) {
+      throw new Error('Expected failed assistant saveMessage to be invoked');
+    }
+    for (const resolve of pendingResolvers.splice(0)) resolve();
+
+    await waitFor(() => expect(onProjectsRefresh).toHaveBeenCalled());
+
+    view.unmount();
+  });
 });

--- a/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
@@ -24,6 +24,7 @@ const fetchChatRunStatus = vi.fn();
 const listActiveChatRuns = vi.fn();
 const reattachDaemonRun = vi.fn();
 const streamViaDaemon = vi.fn();
+const streamMessage = vi.fn();
 const saveMessage = vi.fn();
 const createConversation = vi.fn();
 const patchConversation = vi.fn();
@@ -36,7 +37,7 @@ vi.mock('../../src/i18n', () => ({
 }));
 
 vi.mock('../../src/providers/anthropic', () => ({
-  streamMessage: vi.fn(),
+  streamMessage: (...args: unknown[]) => streamMessage(...args),
 }));
 
 vi.mock('../../src/providers/daemon', () => ({
@@ -1112,6 +1113,244 @@ describe('ProjectView daemon cleanup', () => {
 
     if (pendingResolvers.length === 0) {
       throw new Error('Expected failed assistant saveMessage to be invoked');
+    }
+    for (const resolve of pendingResolvers.splice(0)) resolve();
+
+    await waitFor(() => expect(onProjectsRefresh).toHaveBeenCalled());
+
+    view.unmount();
+  });
+
+  // Regression for issue #731: the Designs home card status was set to
+  // "Completed" before the assistant message's terminal runStatus was
+  // persisted. If the user navigated home in that window, listProjects
+  // re-read the still-active row and the card disagreed with the detail
+  // page. The fix: handleSend's onDone success path must await the
+  // terminal-status persist before invoking onProjectsRefresh.
+  it('delays projects refresh in new-run handlers.onDone success path until terminal saveMessage resolves', async () => {
+    const onProjectsRefresh = vi.fn();
+    let capturedHandlers:
+      | { onDone?: (text?: string) => void; onRunCreated?: (runId: string) => void }
+      | null = null;
+
+    const pendingResolvers: Array<() => void> = [];
+    saveMessage.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          pendingResolvers.push(resolve);
+        }),
+    );
+
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    listActiveChatRuns.mockResolvedValue([]);
+    streamViaDaemon.mockImplementation(
+      async (options: {
+        handlers: { onDone?: (text?: string) => void };
+        onRunCreated?: (runId: string) => void;
+      }) => {
+        capturedHandlers = { onDone: options.handlers.onDone, onRunCreated: options.onRunCreated };
+        return new Promise<void>(() => {});
+      },
+    );
+
+    const view = render(
+      <ProjectView
+        project={{ id: 'project-1', name: 'Project', skillId: null, designSystemId: null } as never}
+        routeFileName={null}
+        config={{ mode: 'daemon', agentId: 'agent-1', notifications: undefined, agentModels: {} } as never}
+        agents={[{ id: 'agent-1', name: 'OpenCode', models: [] } as never]}
+        skills={[]}
+        designTemplates={[]}
+        designSystems={[]}
+        daemonLive
+        onModeChange={() => {}}
+        onAgentChange={() => {}}
+        onAgentModelChange={() => {}}
+        onRefreshAgents={() => {}}
+        onOpenSettings={() => {}}
+        onBack={() => {}}
+        onClearPendingPrompt={() => {}}
+        onTouchProject={() => {}}
+        onProjectChange={() => {}}
+        onProjectsRefresh={onProjectsRefresh}
+      />,
+    );
+
+    await waitFor(() => expect(capturedChatPaneProps.current).not.toBeNull());
+    const props = capturedChatPaneProps.current as Record<string, unknown> | null;
+    if (!props || typeof props.onSend !== 'function') {
+      throw new Error('Expected ChatPane onSend to be available');
+    }
+
+    await (props.onSend as (
+      prompt: string,
+      attachments: unknown[],
+      commentAttachments: unknown[],
+    ) => Promise<void>)('hello', [], []);
+
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
+    const handlers = capturedHandlers as
+      | { onDone?: (text?: string) => void; onRunCreated?: (runId: string) => void }
+      | null;
+    if (!handlers?.onDone || !handlers.onRunCreated) {
+      throw new Error('Expected streamViaDaemon to capture handlers.onDone and onRunCreated');
+    }
+
+    // Pin a runId so the assistant row is a real (non-phantom) write and
+    // the terminal-status persist actually reaches saveMessage.
+    handlers.onRunCreated('run-success-xyz');
+
+    // Drain any saveMessage resolvers queued by the initial send / onRunCreated
+    // so we only observe the resolvers produced by the terminal persist.
+    while (pendingResolvers.length > 0) {
+      const resolver = pendingResolvers.shift();
+      resolver?.();
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    onProjectsRefresh.mockClear();
+    saveMessage.mockClear();
+
+    handlers.onDone('hello world');
+
+    // saveMessage for the terminal succeeded status is still pending — the
+    // projects refresh must wait. If the success path called
+    // onProjectsRefresh() synchronously (regression), the home card would
+    // be re-read before the row's runStatus settled and the card status
+    // would drift from the detail page.
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    expect(saveMessage).toHaveBeenCalled();
+    expect(onProjectsRefresh).not.toHaveBeenCalled();
+
+    if (pendingResolvers.length === 0) {
+      throw new Error('Expected terminal saveMessage to be invoked');
+    }
+    for (const resolve of pendingResolvers.splice(0)) resolve();
+
+    await waitFor(() => expect(onProjectsRefresh).toHaveBeenCalled());
+
+    view.unmount();
+  });
+
+  // Sister regression for issue #731: the API-mode empty-response branch
+  // marks the assistant message as failed but used to fire
+  // onProjectsRefresh synchronously, before the failed runStatus row was
+  // persisted. The home card then showed the prior state (often
+  // "succeeded") instead of the empty-response failure visible in the
+  // detail view.
+  it('delays projects refresh in API empty-response onDone path until terminal saveMessage resolves', async () => {
+    const onProjectsRefresh = vi.fn();
+    let capturedHandlers: { onDone?: (text?: string) => void } | null = null;
+
+    const pendingResolvers: Array<() => void> = [];
+    saveMessage.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          pendingResolvers.push(resolve);
+        }),
+    );
+
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    listActiveChatRuns.mockResolvedValue([]);
+    streamMessage.mockImplementation(
+      async (
+        _cfg: unknown,
+        _system: string,
+        _history: unknown,
+        _signal: AbortSignal,
+        handlers: { onDone?: (text?: string) => void },
+      ) => {
+        capturedHandlers = handlers;
+        return new Promise<void>(() => {});
+      },
+    );
+
+    const view = render(
+      <ProjectView
+        project={{ id: 'project-1', name: 'Project', skillId: null, designSystemId: null } as never}
+        routeFileName={null}
+        config={{
+          mode: 'api',
+          apiProtocol: 'openai',
+          apiKey: 'sk-test',
+          baseUrl: 'https://api.example.com',
+          model: 'test-model',
+          notifications: undefined,
+          agentModels: {},
+        } as never}
+        agents={[]}
+        skills={[]}
+        designTemplates={[]}
+        designSystems={[]}
+        daemonLive
+        onModeChange={() => {}}
+        onAgentChange={() => {}}
+        onAgentModelChange={() => {}}
+        onRefreshAgents={() => {}}
+        onOpenSettings={() => {}}
+        onBack={() => {}}
+        onClearPendingPrompt={() => {}}
+        onTouchProject={() => {}}
+        onProjectChange={() => {}}
+        onProjectsRefresh={onProjectsRefresh}
+      />,
+    );
+
+    await waitFor(() => expect(capturedChatPaneProps.current).not.toBeNull());
+    const props = capturedChatPaneProps.current as Record<string, unknown> | null;
+    if (!props || typeof props.onSend !== 'function') {
+      throw new Error('Expected ChatPane onSend to be available');
+    }
+
+    await (props.onSend as (
+      prompt: string,
+      attachments: unknown[],
+      commentAttachments: unknown[],
+    ) => Promise<void>)('hello', [], []);
+
+    await waitFor(() => expect(streamMessage).toHaveBeenCalledTimes(1));
+    const handlers = capturedHandlers as { onDone?: (text?: string) => void } | null;
+    if (!handlers?.onDone) {
+      throw new Error('Expected streamMessage to capture handlers.onDone');
+    }
+
+    // Drain any saveMessage resolvers queued by the initial send so we
+    // only observe the resolvers produced by the terminal persist.
+    while (pendingResolvers.length > 0) {
+      const resolver = pendingResolvers.shift();
+      resolver?.();
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    onProjectsRefresh.mockClear();
+    saveMessage.mockClear();
+
+    // Empty provider response: handlers.onDone with no streamed text and no
+    // artifact triggers the emptyApiResponse branch.
+    handlers.onDone('');
+
+    // saveMessage for the terminal failed status is still pending — the
+    // projects refresh must wait.
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    expect(saveMessage).toHaveBeenCalled();
+    expect(onProjectsRefresh).not.toHaveBeenCalled();
+
+    if (pendingResolvers.length === 0) {
+      throw new Error('Expected terminal saveMessage to be invoked');
     }
     for (const resolve of pendingResolvers.splice(0)) resolve();
 

--- a/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
@@ -1358,4 +1358,91 @@ describe('ProjectView daemon cleanup', () => {
 
     view.unmount();
   });
+
+  // Regression for issue #731: when the reattach loop discovers that the
+  // daemon has no record of the runId (fetchChatRunStatus -> null), the
+  // assistant message is marked failed locally and onProjectsRefresh used
+  // to fire synchronously — before the failed runStatus row was persisted.
+  // The Designs home card then re-read the still-running row and showed
+  // "Completed" while the detail view showed the failed state.
+  it('delays projects refresh in reattach missing-status recovery until saveMessage resolves', async () => {
+    const onProjectsRefresh = vi.fn();
+
+    const pendingResolvers: Array<() => void> = [];
+    saveMessage.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          pendingResolvers.push(resolve);
+        }),
+    );
+
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([
+      {
+        id: 'msg-1',
+        role: 'assistant',
+        content: 'working',
+        createdAt: Date.now(),
+        runId: 'run-missing',
+        runStatus: 'running',
+      },
+    ]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    fetchChatRunStatus.mockResolvedValue(null);
+    listActiveChatRuns.mockResolvedValue([]);
+    reattachDaemonRun.mockImplementation(async () => new Promise<void>(() => {}));
+
+    const view = render(
+      <ProjectView
+        project={{ id: 'project-1', name: 'Project', skillId: null, designSystemId: null } as never}
+        routeFileName={null}
+        config={{ mode: 'daemon', agentId: 'agent-1', notifications: undefined, agentModels: {} } as never}
+        agents={[{ id: 'agent-1', name: 'OpenCode', models: [] } as never]}
+        skills={[]}
+        designTemplates={[]}
+        designSystems={[]}
+        daemonLive
+        onModeChange={() => {}}
+        onAgentChange={() => {}}
+        onAgentModelChange={() => {}}
+        onRefreshAgents={() => {}}
+        onOpenSettings={() => {}}
+        onBack={() => {}}
+        onClearPendingPrompt={() => {}}
+        onTouchProject={() => {}}
+        onProjectChange={() => {}}
+        onProjectsRefresh={onProjectsRefresh}
+      />,
+    );
+
+    await waitFor(() => expect(fetchChatRunStatus).toHaveBeenCalled());
+
+    // Wait for the failed snapshot saveMessage to be queued.
+    await waitFor(() => {
+      const failedCall = saveMessage.mock.calls.find(
+        (call) =>
+          call[2]?.id === 'msg-1' && call[2]?.runStatus === 'failed',
+      );
+      expect(failedCall).toBeTruthy();
+    });
+
+    // saveMessage is still pending — the projects refresh must wait.
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    expect(onProjectsRefresh).not.toHaveBeenCalled();
+
+    if (pendingResolvers.length === 0) {
+      throw new Error('Expected saveMessage to be invoked');
+    }
+    for (const resolve of pendingResolvers.splice(0)) resolve();
+
+    await waitFor(() => expect(onProjectsRefresh).toHaveBeenCalled());
+
+    view.unmount();
+  });
 });

--- a/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
@@ -29,6 +29,7 @@ const createConversation = vi.fn();
 const patchConversation = vi.fn();
 const patchProject = vi.fn();
 const saveTabs = vi.fn();
+const capturedChatPaneProps: { current: Record<string, unknown> | null } = { current: null };
 
 vi.mock('../../src/i18n', () => ({
   useT: () => ((value: string) => value),
@@ -117,6 +118,7 @@ describe('ProjectView daemon cleanup', () => {
   afterEach(() => {
     cleanup();
     vi.clearAllMocks();
+    capturedChatPaneProps.current = null;
   });
 
   it('does not abort daemon cancel reattach controllers during unmount cleanup', async () => {
@@ -614,5 +616,175 @@ describe('ProjectView daemon cleanup', () => {
         !call[2]?.runId,
     );
     expect(phantomSave).toBeUndefined();
+  });
+
+  it('delays projects refresh in reattach onError until saveMessage resolves', async () => {
+    const onProjectsRefresh = vi.fn();
+    let capturedHandlers: { onError?: (err: Error) => void } | null = null;
+
+    const pendingResolvers: Array<() => void> = [];
+    saveMessage.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          pendingResolvers.push(resolve);
+        }),
+    );
+
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([
+      {
+        id: 'msg-1',
+        role: 'assistant',
+        content: 'working',
+        createdAt: Date.now(),
+        runId: 'run-err',
+        runStatus: 'running',
+      },
+    ]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    fetchChatRunStatus.mockResolvedValue({
+      id: 'run-err',
+      status: 'running',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      exitCode: null,
+      signal: null,
+    });
+    listActiveChatRuns.mockResolvedValue([]);
+    reattachDaemonRun.mockImplementation(async (options: { handlers: { onError?: (err: Error) => void } }) => {
+      capturedHandlers = options.handlers;
+      return new Promise<void>(() => {});
+    });
+
+    const view = render(
+      <ProjectView
+        project={{ id: 'project-1', name: 'Project', skillId: null, designSystemId: null } as never}
+        routeFileName={null}
+        config={{ mode: 'daemon', agentId: 'agent-1', notifications: undefined, agentModels: {} } as never}
+        agents={[{ id: 'agent-1', name: 'OpenCode', models: [] } as never]}
+        skills={[]}
+        designSystems={[]}
+        daemonLive
+        onModeChange={() => {}}
+        onAgentChange={() => {}}
+        onAgentModelChange={() => {}}
+        onRefreshAgents={() => {}}
+        onOpenSettings={() => {}}
+        onBack={() => {}}
+        onClearPendingPrompt={() => {}}
+        onTouchProject={() => {}}
+        onProjectChange={() => {}}
+        onProjectsRefresh={onProjectsRefresh}
+      />,
+    );
+
+    await waitFor(() => expect(reattachDaemonRun).toHaveBeenCalledTimes(1));
+    const handlers = capturedHandlers as { onError?: (err: Error) => void } | null;
+    if (!handlers?.onError) throw new Error('Expected reattach onError handler to be captured');
+
+    handlers.onError(new Error('ACP response timed out after 180000ms'));
+
+    // saveMessage is still pending — the projects refresh must wait.
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    expect(onProjectsRefresh).not.toHaveBeenCalled();
+    expect(saveMessage).toHaveBeenCalled();
+
+    if (pendingResolvers.length === 0) throw new Error('Expected saveMessage to be invoked');
+    for (const resolve of pendingResolvers) resolve();
+
+    await waitFor(() => expect(onProjectsRefresh).toHaveBeenCalled());
+
+    view.unmount();
+  });
+
+  it('refreshes projects list after new-run terminal onRunStatus events', async () => {
+    const onProjectsRefresh = vi.fn();
+    let capturedStreamOptions:
+      | {
+          handlers: { onError?: (err: Error) => void };
+          onRunStatus?: (status: string) => void;
+          onRunCreated?: (runId: string) => void;
+        }
+      | null = null;
+
+    saveMessage.mockResolvedValue(undefined);
+
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    listActiveChatRuns.mockResolvedValue([]);
+    streamViaDaemon.mockImplementation(async (options: typeof capturedStreamOptions) => {
+      capturedStreamOptions = options;
+      return new Promise<void>(() => {});
+    });
+
+    const view = render(
+      <ProjectView
+        project={{ id: 'project-1', name: 'Project', skillId: null, designSystemId: null } as never}
+        routeFileName={null}
+        config={{ mode: 'daemon', agentId: 'agent-1', notifications: undefined, agentModels: {} } as never}
+        agents={[{ id: 'agent-1', name: 'OpenCode', models: [] } as never]}
+        skills={[]}
+        designSystems={[]}
+        daemonLive
+        onModeChange={() => {}}
+        onAgentChange={() => {}}
+        onAgentModelChange={() => {}}
+        onRefreshAgents={() => {}}
+        onOpenSettings={() => {}}
+        onBack={() => {}}
+        onClearPendingPrompt={() => {}}
+        onTouchProject={() => {}}
+        onProjectChange={() => {}}
+        onProjectsRefresh={onProjectsRefresh}
+      />,
+    );
+
+    await waitFor(() => expect(capturedChatPaneProps.current).not.toBeNull());
+    const props = capturedChatPaneProps.current as Record<string, unknown> | null;
+    if (!props || typeof props.onSend !== 'function') {
+      throw new Error('Expected ChatPane onSend to be available');
+    }
+
+    await (props.onSend as (prompt: string, attachments: unknown[], commentAttachments: unknown[]) => Promise<void>)(
+      'hello',
+      [],
+      [],
+    );
+
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
+    const streamOptions = capturedStreamOptions as
+      | {
+          handlers: { onError?: (err: Error) => void };
+          onRunStatus?: (status: string) => void;
+          onRunCreated?: (runId: string) => void;
+        }
+      | null;
+    if (!streamOptions || typeof streamOptions.onRunStatus !== 'function') {
+      throw new Error('Expected streamViaDaemon to capture onRunStatus');
+    }
+    const onRunStatus = streamOptions.onRunStatus;
+
+    onProjectsRefresh.mockClear();
+    onRunStatus('failed');
+    await waitFor(() => expect(onProjectsRefresh).toHaveBeenCalled());
+
+    onProjectsRefresh.mockClear();
+    onRunStatus('canceled');
+    await waitFor(() => expect(onProjectsRefresh).toHaveBeenCalled());
+
+    view.unmount();
   });
 });

--- a/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
@@ -91,6 +91,7 @@ const chatPaneSpy = vi.fn();
 vi.mock('../../src/components/ChatPane', () => ({
   ChatPane: (props: Record<string, unknown>) => {
     chatPaneSpy(props);
+    capturedChatPaneProps.current = props;
     return null;
   },
 }));

--- a/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
@@ -669,6 +669,7 @@ describe('ProjectView daemon cleanup', () => {
         config={{ mode: 'daemon', agentId: 'agent-1', notifications: undefined, agentModels: {} } as never}
         agents={[{ id: 'agent-1', name: 'OpenCode', models: [] } as never]}
         skills={[]}
+        designTemplates={[]}
         designSystems={[]}
         daemonLive
         onModeChange={() => {}}
@@ -737,6 +738,7 @@ describe('ProjectView daemon cleanup', () => {
         config={{ mode: 'daemon', agentId: 'agent-1', notifications: undefined, agentModels: {} } as never}
         agents={[{ id: 'agent-1', name: 'OpenCode', models: [] } as never]}
         skills={[]}
+        designTemplates={[]}
         designSystems={[]}
         daemonLive
         onModeChange={() => {}}
@@ -783,6 +785,114 @@ describe('ProjectView daemon cleanup', () => {
 
     onProjectsRefresh.mockClear();
     onRunStatus('canceled');
+    await waitFor(() => expect(onProjectsRefresh).toHaveBeenCalled());
+
+    view.unmount();
+  });
+
+  it('delays projects refresh in new-run onRunStatus terminal events until saveMessage resolves', async () => {
+    const onProjectsRefresh = vi.fn();
+    let capturedStreamOptions:
+      | {
+          handlers: { onError?: (err: Error) => void };
+          onRunStatus?: (status: string) => void;
+          onRunCreated?: (runId: string) => void;
+        }
+      | null = null;
+
+    const pendingResolvers: Array<() => void> = [];
+    saveMessage.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          pendingResolvers.push(resolve);
+        }),
+    );
+
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    listActiveChatRuns.mockResolvedValue([]);
+    streamViaDaemon.mockImplementation(async (options: typeof capturedStreamOptions) => {
+      capturedStreamOptions = options;
+      return new Promise<void>(() => {});
+    });
+
+    const view = render(
+      <ProjectView
+        project={{ id: 'project-1', name: 'Project', skillId: null, designSystemId: null } as never}
+        routeFileName={null}
+        config={{ mode: 'daemon', agentId: 'agent-1', notifications: undefined, agentModels: {} } as never}
+        agents={[{ id: 'agent-1', name: 'OpenCode', models: [] } as never]}
+        skills={[]}
+        designTemplates={[]}
+        designSystems={[]}
+        daemonLive
+        onModeChange={() => {}}
+        onAgentChange={() => {}}
+        onAgentModelChange={() => {}}
+        onRefreshAgents={() => {}}
+        onOpenSettings={() => {}}
+        onBack={() => {}}
+        onClearPendingPrompt={() => {}}
+        onTouchProject={() => {}}
+        onProjectChange={() => {}}
+        onProjectsRefresh={onProjectsRefresh}
+      />,
+    );
+
+    await waitFor(() => expect(capturedChatPaneProps.current).not.toBeNull());
+    const props = capturedChatPaneProps.current as Record<string, unknown> | null;
+    if (!props || typeof props.onSend !== 'function') {
+      throw new Error('Expected ChatPane onSend to be available');
+    }
+
+    await (props.onSend as (prompt: string, attachments: unknown[], commentAttachments: unknown[]) => Promise<void>)(
+      'hello',
+      [],
+      [],
+    );
+
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
+    const streamOptions = capturedStreamOptions as
+      | {
+          handlers: { onError?: (err: Error) => void };
+          onRunStatus?: (status: string) => void;
+          onRunCreated?: (runId: string) => void;
+        }
+      | null;
+    if (!streamOptions || typeof streamOptions.onRunStatus !== 'function') {
+      throw new Error('Expected streamViaDaemon to capture onRunStatus');
+    }
+    const onRunStatus = streamOptions.onRunStatus;
+
+    // Drain any saveMessage resolvers already queued by mount/send so we
+    // only observe the resolvers produced by the terminal status persist.
+    while (pendingResolvers.length > 0) {
+      const resolver = pendingResolvers.shift();
+      resolver?.();
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    onProjectsRefresh.mockClear();
+    saveMessage.mockClear();
+
+    onRunStatus('failed');
+
+    // saveMessage for the terminal status is still pending — refresh must wait.
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    expect(saveMessage).toHaveBeenCalled();
+    expect(onProjectsRefresh).not.toHaveBeenCalled();
+
+    if (pendingResolvers.length === 0) {
+      throw new Error('Expected terminal saveMessage to be invoked');
+    }
+    for (const resolve of pendingResolvers.splice(0)) resolve();
+
     await waitFor(() => expect(onProjectsRefresh).toHaveBeenCalled());
 
     view.unmount();

--- a/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
@@ -31,6 +31,9 @@ const patchConversation = vi.fn();
 const patchProject = vi.fn();
 const saveTabs = vi.fn();
 const capturedChatPaneProps: { current: Record<string, unknown> | null } = { current: null };
+const capturedProjectEventHandler: {
+  current: ((evt: Record<string, unknown>) => void) | null;
+} = { current: null };
 
 vi.mock('../../src/i18n', () => ({
   useT: () => ((value: string) => value),
@@ -60,7 +63,13 @@ vi.mock('../../src/providers/registry', () => ({
 }));
 
 vi.mock('../../src/providers/project-events', () => ({
-  useProjectFileEvents: vi.fn(),
+  useProjectFileEvents: (
+    _projectId: string | null | undefined,
+    _enabled: boolean,
+    onChange: (evt: Record<string, unknown>) => void,
+  ) => {
+    capturedProjectEventHandler.current = onChange;
+  },
 }));
 
 vi.mock('../../src/router', () => ({
@@ -121,6 +130,7 @@ describe('ProjectView daemon cleanup', () => {
     cleanup();
     vi.clearAllMocks();
     capturedChatPaneProps.current = null;
+    capturedProjectEventHandler.current = null;
   });
 
   it('does not abort daemon cancel reattach controllers during unmount cleanup', async () => {
@@ -1442,6 +1452,101 @@ describe('ProjectView daemon cleanup', () => {
     for (const resolve of pendingResolvers.splice(0)) resolve();
 
     await waitFor(() => expect(onProjectsRefresh).toHaveBeenCalled());
+
+    view.unmount();
+  });
+
+  // Regression for issue #731: when a live_artifact ProjectEvent fires
+  // (chat-turn-emitted artifact), the detail view used to fire
+  // onProjectsRefresh synchronously while refreshLiveArtifacts was still
+  // resolving. listProjects then re-read a snapshot in which the
+  // project's live artifacts hadn't settled, so the Designs home card
+  // briefly showed "Completed" while the detail view still showed
+  // Working / error / timed out. The fix awaits refreshLiveArtifacts
+  // before invoking onProjectsRefresh on both success and failure.
+  it('delays projects refresh on live_artifact event until refreshLiveArtifacts resolves', async () => {
+    const onProjectsRefresh = vi.fn();
+
+    const liveArtifactsResolver: { current: (() => void) | null } = { current: null };
+    fetchLiveArtifacts.mockImplementation(
+      () =>
+        new Promise<unknown[]>((resolve) => {
+          liveArtifactsResolver.current = () => resolve([]);
+        }),
+    );
+
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    listActiveChatRuns.mockResolvedValue([]);
+
+    const view = render(
+      <ProjectView
+        project={{ id: 'project-1', name: 'Project', skillId: null, designSystemId: null } as never}
+        routeFileName={null}
+        config={{ mode: 'daemon', agentId: 'agent-1', notifications: undefined, agentModels: {} } as never}
+        agents={[{ id: 'agent-1', name: 'OpenCode', models: [] } as never]}
+        skills={[]}
+        designTemplates={[]}
+        designSystems={[]}
+        daemonLive
+        onModeChange={() => {}}
+        onAgentChange={() => {}}
+        onAgentModelChange={() => {}}
+        onRefreshAgents={() => {}}
+        onOpenSettings={() => {}}
+        onBack={() => {}}
+        onClearPendingPrompt={() => {}}
+        onTouchProject={() => {}}
+        onProjectChange={() => {}}
+        onProjectsRefresh={onProjectsRefresh}
+      />,
+    );
+
+    await waitFor(() => expect(capturedProjectEventHandler.current).not.toBeNull());
+
+    // Drain mount-time fetchLiveArtifacts calls so we observe only the
+    // resolver produced by the live_artifact event handler.
+    for (let i = 0; i < 5; i++) {
+      if (resolveLiveArtifacts) {
+        resolveLiveArtifacts();
+        resolveLiveArtifacts = null;
+      }
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    }
+    onProjectsRefresh.mockClear();
+    fetchLiveArtifacts.mockClear();
+
+    const handler = capturedProjectEventHandler.current;
+    if (!handler) throw new Error('Expected useProjectFileEvents handler to be captured');
+
+    handler({
+      type: 'live_artifact',
+      action: 'updated',
+      projectId: 'project-1',
+      artifactId: 'artifact-1',
+      title: 'Live Artifact',
+      refreshStatus: 'failed',
+    });
+
+    // refreshLiveArtifacts was invoked but is still pending — the home
+    // refresh must wait so the card status is computed against the same
+    // committed snapshot the detail view just refetched.
+    await waitFor(() => expect(fetchLiveArtifacts).toHaveBeenCalled());
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    expect(onProjectsRefresh).not.toHaveBeenCalled();
+
+    if (!resolveLiveArtifacts) {
+      throw new Error('Expected fetchLiveArtifacts to be invoked by the event handler');
+    }
+    resolveLiveArtifacts();
+
+    await waitFor(() => expect(onProjectsRefresh).toHaveBeenCalledTimes(1));
 
     view.unmount();
   });


### PR DESCRIPTION
## Summary
The Designs home card status was only refreshed after a successful run, so a failed, canceled, or timed-out run left the card showing the previous run's "Completed" while the detail view showed the actual outcome. This wires `onProjectsRefresh()` into every terminal run-status path in `ProjectView` so both views read the same `/api/projects` state once a run ends.

## Changes
- `apps/web/src/components/ProjectView.tsx`: call `onProjectsRefresh()` from the new-run `onError` handler, the new-run `onRunStatus` terminal branch, and the `.catch` fallback so failed/canceled/timed-out runs invalidate the cached projects list.
- `apps/web/src/components/ProjectView.tsx`: call `onProjectsRefresh()` from the reattach `onError` handler and the reattach `onRunStatus` terminal branch, plus the reattach completion-detected branch that marks the run done on initial load.
- `apps/web/tests/components/ProjectView.run-cleanup.test.tsx`: add a regression test that drives a reattached run through `onError` and asserts `onProjectsRefresh` is invoked.

## Testing
- `pnpm --filter @open-design/web test -- ProjectView.run-cleanup`

## Notes
Scope assumption per the issue: the daemon already persists the correct terminal status to `messages.run_status` (see `reconcileAssistantMessageOnRunEnd`), so the server-side `/api/projects` payload is accurate after a failure — only the web client's cached `projects` array was stale. If a reproduction shows `/api/projects` itself still reporting `succeeded` after a timeout, that would point at a deeper reconciliation issue in `apps/daemon` and is left out of scope here.

Closes #731