### PR TITLE
fix(desktop+web): keep macOS fullscreen Space from blacking out on close (#1215)

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -35,7 +35,12 @@ import { createDesktopRuntime } from "./runtime.js";
 // runtime. They are part of the security boundary for child-window
 // navigation (see `setWindowOpenHandler` in `runtime.ts`), so
 // pinning them is worth the small extra surface.
-export { isAllowedChildWindowUrl, isHttpUrl, resolveDesktopStatusUrl } from "./runtime.js";
+export {
+  exitFullscreenBeforeHide,
+  isAllowedChildWindowUrl,
+  isHttpUrl,
+  resolveDesktopStatusUrl,
+} from "./runtime.js";
 
 // Re-export the path-validation helpers for the same reason (#974).
 // shell.openPath is privileged main-process behaviour; pinning the

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -602,6 +602,38 @@ export function resolveDesktopStatusUrl(currentUrl: string | null, pendingUrl: s
   return pendingUrl ?? currentUrl;
 }
 
+// Drive the macOS native-fullscreen exit transition to completion
+// before the caller hides the window. Used by the close handler in
+// `createDesktopRuntime` to avoid leaving the fullscreen Space painted
+// as a solid black surface after `window.hide()` runs mid-transition
+// (the bug in #1215).
+//
+// On non-fullscreen windows the call resolves on the next tick with no
+// side effect, so callers can use it unconditionally. The exit is
+// observed via Electron's `leave-full-screen` event; a 2-second safety
+// timeout resolves the promise even if the event is missed so we never
+// strand the close path.
+//
+// Pure with respect to the input window: the caller decides whether to
+// `hide()` / `close()` / `destroy()` after the promise resolves.
+export function exitFullscreenBeforeHide(window: BrowserWindow): Promise<void> {
+  if (window.isDestroyed()) return Promise.resolve();
+  if (!window.isFullScreen()) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      window.removeListener("leave-full-screen", finish);
+      clearTimeout(timeout);
+      resolve();
+    };
+    window.once("leave-full-screen", finish);
+    const timeout = setTimeout(finish, 2000);
+    window.setFullScreen(false);
+  });
+}
+
 function installWindowChromeCssHook(window: BrowserWindow): void {
   window.webContents.on("did-finish-load", () => {
     void applyWindowChromeCss(window).catch((error: unknown) => {
@@ -868,10 +900,17 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
 
   if (process.platform === "darwin") {
     window.on("close", (event) => {
-      if (!stopped) {
-        event.preventDefault();
-        window.hide();
-      }
+      if (stopped) return;
+      event.preventDefault();
+      // Hiding the window while it is still in macOS native fullscreen
+      // leaves the fullscreen Space painted as a solid black surface
+      // (the user sees a black screen until they switch Spaces). Exit
+      // fullscreen first and wait for the animated transition to
+      // complete before hiding so the Space animates back to the
+      // previous app.
+      void exitFullscreenBeforeHide(window).then(() => {
+        if (!stopped && !window.isDestroyed()) window.hide();
+      });
     });
   }
 

--- a/apps/packaged/tests/desktop-fullscreen-on-close.test.ts
+++ b/apps/packaged/tests/desktop-fullscreen-on-close.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Regression coverage for the macOS-only fullscreen-exit-before-hide
+ * path used by the BrowserWindow close handler in
+ * `apps/desktop/src/main/runtime.ts`. Hiding the window mid-
+ * fullscreen-transition leaves the macOS Space painted as a solid
+ * black surface (the bug in #1215). The helper waits for the
+ * `leave-full-screen` event before resolving so the caller can hide()
+ * cleanly.
+ *
+ * @see https://github.com/nexu-io/open-design/issues/1215
+ */
+
+import { vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  BrowserWindow: class {},
+  dialog: { showOpenDialog: vi.fn() },
+  ipcMain: { handle: vi.fn(), removeHandler: vi.fn() },
+  shell: { openExternal: vi.fn() },
+  app: { whenReady: vi.fn() },
+}));
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { exitFullscreenBeforeHide } from '@open-design/desktop/main';
+
+type Listener = (...args: unknown[]) => void;
+
+/**
+ * Minimal Electron BrowserWindow stand-in. Mirrors only the surface
+ * the helper actually uses: `isDestroyed`, `isFullScreen`,
+ * `setFullScreen`, `once`, `removeListener`. Driven by the test so
+ * we can assert the call order + event-driven resolution without
+ * spinning up a real window.
+ */
+class FakeWindow {
+  destroyed = false;
+  fullscreen: boolean;
+  readonly setFullScreenCalls: boolean[] = [];
+  private listeners = new Map<string, Listener[]>();
+
+  constructor(initial: { fullscreen: boolean; destroyed?: boolean } = { fullscreen: false }) {
+    this.fullscreen = initial.fullscreen;
+    this.destroyed = initial.destroyed ?? false;
+  }
+
+  isDestroyed(): boolean {
+    return this.destroyed;
+  }
+
+  isFullScreen(): boolean {
+    return this.fullscreen;
+  }
+
+  setFullScreen(value: boolean): void {
+    this.setFullScreenCalls.push(value);
+    // Don't flip `fullscreen` synchronously — the real Electron call
+    // kicks off an animated transition, and our event-driven helper
+    // expects the `leave-full-screen` event to be the resolution
+    // signal, not the synchronous return.
+  }
+
+  once(eventName: string, fn: Listener): void {
+    const list = this.listeners.get(eventName) ?? [];
+    list.push(fn);
+    this.listeners.set(eventName, list);
+  }
+
+  removeListener(eventName: string, fn: Listener): void {
+    const list = this.listeners.get(eventName);
+    if (!list) return;
+    const next = list.filter((l) => l !== fn);
+    if (next.length === 0) this.listeners.delete(eventName);
+    else this.listeners.set(eventName, next);
+  }
+
+  /** Test helper: simulate Electron firing `leave-full-screen`. */
+  emit(eventName: string): void {
+    const list = this.listeners.get(eventName);
+    if (!list) return;
+    for (const fn of [...list]) fn();
+  }
+}
+
+describe('exitFullscreenBeforeHide', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('resolves immediately when the window is not fullscreen, without touching setFullScreen', async () => {
+    // The close handler unconditionally calls this helper before
+    // hiding, so the no-op path matters: a non-fullscreen window
+    // must not pay an event-wait cost.
+    const win = new FakeWindow({ fullscreen: false });
+    await exitFullscreenBeforeHide(win as never);
+    expect(win.setFullScreenCalls).toEqual([]);
+  });
+
+  it('resolves immediately on a destroyed window without touching setFullScreen', async () => {
+    // Defensive: if `window.isDestroyed()` is true the close listener
+    // has already been beaten to the punch (e.g. forced quit). The
+    // helper must not throw or call into Electron methods that would
+    // throw on a destroyed window.
+    const win = new FakeWindow({ fullscreen: true, destroyed: true });
+    await exitFullscreenBeforeHide(win as never);
+    expect(win.setFullScreenCalls).toEqual([]);
+  });
+
+  it('calls setFullScreen(false) and waits for the leave-full-screen event before resolving', async () => {
+    // The canonical #1215 path: window is in macOS native fullscreen,
+    // close fires, helper requests fullscreen exit, then waits for
+    // the animated transition to complete (Electron emits
+    // `leave-full-screen` at the end of the animation). The caller
+    // hides the window only after the promise resolves.
+    const win = new FakeWindow({ fullscreen: true });
+    let resolved = false;
+    const done = exitFullscreenBeforeHide(win as never).then(() => {
+      resolved = true;
+    });
+
+    // setFullScreen(false) called synchronously — Electron's
+    // transition kicks off immediately even though the event fires
+    // later.
+    expect(win.setFullScreenCalls).toEqual([false]);
+
+    // Before the event fires, the promise is still pending.
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    // Simulating Electron's `leave-full-screen` resolves the helper.
+    win.emit('leave-full-screen');
+    await done;
+    expect(resolved).toBe(true);
+  });
+
+  it('settles on a 2-second safety timeout if leave-full-screen never fires', async () => {
+    // Belt-and-braces: if some macOS edge case swallows the event
+    // we cannot leave the close path stranded forever. The 2s
+    // timeout matches what a reasonable user would tolerate
+    // between clicking close and seeing the window disappear.
+    const win = new FakeWindow({ fullscreen: true });
+    let resolved = false;
+    const done = exitFullscreenBeforeHide(win as never).then(() => {
+      resolved = true;
+    });
+    expect(win.setFullScreenCalls).toEqual([false]);
+
+    // Advance fake timers past the safety window without firing
+    // the Electron event.
+    await vi.advanceTimersByTimeAsync(2000);
+    await done;
+    expect(resolved).toBe(true);
+  });
+
+  it('removes the leave-full-screen listener after it fires (no double-resolve)', async () => {
+    // If the helper left its listener attached, a later
+    // `leave-full-screen` event (e.g. user enters and exits
+    // fullscreen again later in the same window's lifetime) would
+    // double-resolve the original promise. Resolution is a one-shot
+    // contract — verify the listener is removed.
+    const win = new FakeWindow({ fullscreen: true });
+    const done = exitFullscreenBeforeHide(win as never);
+    win.emit('leave-full-screen');
+    await done;
+
+    // After resolution, no listener should remain attached. Emitting
+    // again must not throw or settle anything new.
+    expect(() => win.emit('leave-full-screen')).not.toThrow();
+  });
+});

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useId, useMemo, useRef, useState, type CSSProperties, type MouseEvent as ReactMouseEvent, type ReactNode } from 'react';
+import { useCallback, useEffect, useId, useMemo, useRef, useState, type CSSProperties, type MouseEvent as ReactMouseEvent, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import { APP_CHROME_FILE_ACTIONS_ID } from './AppChromeHeader';
 import { MarkdownRenderer, artifactRendererRegistry } from '../artifacts/renderer-registry';
 import { renderMarkdownToSafeHtml } from '../artifacts/markdown';
 import { useT } from '../i18n';
+import { useResetOnFullscreenExit } from '../hooks/useResetOnFullscreenExit';
 import type { Dict } from '../i18n/types';
 import {
   fetchLiveArtifact,
@@ -601,6 +602,15 @@ export function LiveArtifactViewer({
     document.addEventListener('keydown', onKey);
     return () => document.removeEventListener('keydown', onKey);
   }, [inTabPresent]);
+
+  // Mirror native fullscreen state into React so the in-tab present
+  // overlay doesn't linger after the user exits fullscreen via Esc,
+  // the OS menu, or the macOS window close path. Without this,
+  // entering both "Present in this tab" and then "Present fullscreen"
+  // could leave `inTabPresent` true after exit, keeping the
+  // `is-tab-present` class on the viewer while native fullscreen is
+  // gone.
+  useResetOnFullscreenExit(useCallback(() => setInTabPresent(false), []));
 
   return (
     <div className={`viewer html-viewer live-artifact-viewer${inTabPresent ? ' is-tab-present' : ''}`}>
@@ -3901,6 +3911,11 @@ function HtmlViewer({
     document.addEventListener('keydown', onKey);
     return () => document.removeEventListener('keydown', onKey);
   }, [inTabPresent]);
+
+  // Same fullscreen-exit sync as the live-artifact viewer above —
+  // keeps the in-tab present overlay from sticking when the user
+  // leaves native fullscreen by any non-React path.
+  useResetOnFullscreenExit(useCallback(() => setInTabPresent(false), []));
 
   function openInNewTab() {
     if (!source) return;

--- a/apps/web/src/hooks/useResetOnFullscreenExit.ts
+++ b/apps/web/src/hooks/useResetOnFullscreenExit.ts
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+
+/**
+ * Subscribe to the document's `fullscreenchange` event and call `reset`
+ * whenever the browser leaves fullscreen (`document.fullscreenElement`
+ * becomes null).
+ *
+ * Used by viewers that combine in-app present-mode state (e.g. a React
+ * `inTabPresent` flag) with the browser's native fullscreen API. When
+ * the user exits fullscreen via Esc, the OS menu, the macOS window
+ * close button, or any other path outside React's event surface, the
+ * in-app state would otherwise stay stuck — leaving a present-mode
+ * overlay rendered over a non-fullscreen viewer. Mirrors the same
+ * Esc-keeps-React-in-sync trick PreviewModal added in #168, and is the
+ * "FileViewer fullscreenchange sync" piece of the #1215 fix.
+ *
+ * The hook is a no-op when `document` is unavailable (SSR-safe) and
+ * automatically cleans up the listener on unmount.
+ */
+export function useResetOnFullscreenExit(reset: () => void): void {
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const onFsChange = () => {
+      if (!document.fullscreenElement) reset();
+    };
+    document.addEventListener('fullscreenchange', onFsChange);
+    return () => document.removeEventListener('fullscreenchange', onFsChange);
+  }, [reset]);
+}

--- a/apps/web/tests/hooks/useResetOnFullscreenExit.test.tsx
+++ b/apps/web/tests/hooks/useResetOnFullscreenExit.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useResetOnFullscreenExit } from '../../src/hooks/useResetOnFullscreenExit';
+
+describe('useResetOnFullscreenExit', () => {
+  let originalDescriptor: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    // Save and stub document.fullscreenElement so each test can drive
+    // the "are we still in fullscreen?" check the hook reads from the
+    // event handler.
+    originalDescriptor = Object.getOwnPropertyDescriptor(Document.prototype, 'fullscreenElement');
+  });
+
+  afterEach(() => {
+    if (originalDescriptor) {
+      Object.defineProperty(Document.prototype, 'fullscreenElement', originalDescriptor);
+    } else {
+      // jsdom defaults to undefined for the property; restore that.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (Document.prototype as any).fullscreenElement;
+    }
+  });
+
+  function setFullscreenElement(value: Element | null) {
+    Object.defineProperty(Document.prototype, 'fullscreenElement', {
+      configurable: true,
+      get: () => value,
+    });
+  }
+
+  it('calls reset when fullscreenchange fires with no fullscreen element (exit path)', () => {
+    setFullscreenElement(null);
+    const reset = vi.fn();
+    renderHook(() => useResetOnFullscreenExit(reset));
+
+    // Sanity: subscribed but not yet fired.
+    expect(reset).not.toHaveBeenCalled();
+
+    document.dispatchEvent(new Event('fullscreenchange'));
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT call reset when fullscreenchange fires with a fullscreen element (enter path)', () => {
+    // Entering fullscreen also fires `fullscreenchange`. The hook
+    // only triggers on the exit transition — otherwise it would
+    // immediately reset the React present-mode state the very
+    // moment the user enters fullscreen.
+    const fakeElement = document.createElement('div');
+    setFullscreenElement(fakeElement);
+    const reset = vi.fn();
+    renderHook(() => useResetOnFullscreenExit(reset));
+
+    document.dispatchEvent(new Event('fullscreenchange'));
+    expect(reset).not.toHaveBeenCalled();
+  });
+
+  it('removes the listener on unmount so reset is not called after the consumer is gone', () => {
+    setFullscreenElement(null);
+    const reset = vi.fn();
+    const { unmount } = renderHook(() => useResetOnFullscreenExit(reset));
+    unmount();
+    document.dispatchEvent(new Event('fullscreenchange'));
+    expect(reset).not.toHaveBeenCalled();
+  });
+
+  it('does not throw and is a no-op when document is undefined (SSR-safe)', () => {
+    // The hook checks `typeof document === 'undefined'` up-front so
+    // consumers that get rendered in an SSR context (or any future
+    // jsdom-less environment) do not crash on the event-listener
+    // call. We can't truly remove `document` mid-test, but we can
+    // assert the hook mounts without throwing and never invokes
+    // reset before an event fires.
+    setFullscreenElement(null);
+    const reset = vi.fn();
+    expect(() => renderHook(() => useResetOnFullscreenExit(reset))).not.toThrow();
+    expect(reset).not.toHaveBeenCalled();
+  });
+
+  it('re-subscribes when reset identity changes (so consumers can switch handlers)', () => {
+    setFullscreenElement(null);
+    const firstReset = vi.fn();
+    const secondReset = vi.fn();
+    const { rerender } = renderHook(({ fn }) => useResetOnFullscreenExit(fn), {
+      initialProps: { fn: firstReset },
+    });
+
+    document.dispatchEvent(new Event('fullscreenchange'));
+    expect(firstReset).toHaveBeenCalledTimes(1);
+
+    rerender({ fn: secondReset });
+    document.dispatchEvent(new Event('fullscreenchange'));
+    expect(firstReset).toHaveBeenCalledTimes(1);
+    expect(secondReset).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1215 (P0). Presenting a file in fullscreen (`File viewer → 演示 → 全屏`) and then clicking the macOS red close button leaves the fullscreen Space painted as a solid black surface — the user has to manually switch Spaces to recover. Following @lefarcen's diagnosis in the thread, this PR fixes both sides of the same bug:

1. **Desktop**: the macOS-only `window.on(\"close\")` handler in `apps/desktop/src/main/runtime.ts` calls `event.preventDefault()` + `window.hide()` without first exiting native fullscreen. Hiding a window mid-fullscreen-transition leaves the OS Space in a half-rendered state and the user sees black.
2. **Web**: `FileViewer` enters native fullscreen via `requestFullscreen` but has no `fullscreenchange` listener, so when fullscreen exits via Esc / OS menu / the window close path the React `inTabPresent` flag can stay stuck — keeping the `is-tab-present` overlay class on a non-fullscreen viewer.

## Approach

### Desktop side — `exitFullscreenBeforeHide(window)`

A new exported helper drives the macOS native-fullscreen exit transition to completion before the caller hides the window:

- Returns immediately on non-fullscreen / destroyed windows.
- Otherwise calls `window.setFullScreen(false)` and waits for Electron's `leave-full-screen` event before resolving.
- 2-second safety timeout so the close path never strands if some macOS edge case swallows the event.

The darwin `window.on(\"close\")` handler now awaits this helper before hiding, and guards against `window.isDestroyed()` in the post-await branch:

```diff
 if (process.platform === \"darwin\") {
   window.on(\"close\", (event) => {
-    if (!stopped) {
-      event.preventDefault();
-      window.hide();
-    }
+    if (stopped) return;
+    event.preventDefault();
+    void exitFullscreenBeforeHide(window).then(() => {
+      if (!stopped && !window.isDestroyed()) window.hide();
+    });
   });
 }
```

The helper is exported through `apps/desktop/src/main/index.ts` so the packaged workspace can pin the contract under tests (same pattern PR #911 used for the URL allowlist helpers).

### Web side — `useResetOnFullscreenExit` hook

New `apps/web/src/hooks/useResetOnFullscreenExit.ts` subscribes to `fullscreenchange` and calls a `reset` callback whenever the browser leaves fullscreen. SSR-safe, cleans up on unmount, re-subscribes when `reset` identity changes. Mirrors the Esc-syncs-React-state pattern PR #168 added to `PreviewModal`.

Both `FileViewer` viewers (live-artifact and HTML) wire that hook to clear `inTabPresent`:

```tsx
useResetOnFullscreenExit(useCallback(() => setInTabPresent(false), []));
```

## Reproduce

1. Open Design (macOS, packaged or dev).
2. Open a project, open a file viewer (live artifact or HTML).
3. Click the **Present** menu → **Present fullscreen** to enter native fullscreen.
4. Click the macOS red close button (top-left) to close the window.

**Before this PR**: the fullscreen Space stays painted as a solid black surface until you manually switch Spaces (Mission Control / Ctrl+arrow / clicking another app in the dock).
**After this PR**: the Space animates back to the previous app cleanly, the window is hidden, and the user is returned to their normal context.

## Verification

- `pnpm --filter @open-design/web typecheck` — exit 0
- `pnpm --filter @open-design/desktop typecheck` — exit 0
- `pnpm --filter @open-design/web test` — **86 files, 762/762 passed** (includes the new 5-case hook test)
- `cd apps/packaged && pnpm exec vitest run tests/desktop-fullscreen-on-close.test.ts tests/desktop-url-allowlist.test.ts` — **15/15 passed** (new 5-case desktop helper test + existing URL allowlist)
- `pnpm guard` — 5/5 invariants

### Pre-existing failure note

`apps/packaged/tests/desktop-project-root-gate.test.ts` has 2 pre-existing failures on macOS (`/var/folders/...` vs `/private/var/folders/...` realpath comparison in `validateExistingDirectory`). I verified these reproduce identically on `origin/main` with this branch's source changes stashed — unrelated to fullscreen behavior, untouched by this PR.

## New tests

| File | Cases | What it pins |
|---|---|---|
| `apps/packaged/tests/desktop-fullscreen-on-close.test.ts` | 5 | Desktop helper against a mocked BrowserWindow: no-op on non-fullscreen, no-op on destroyed, canonical `setFullScreen(false)` → wait-for-`leave-full-screen` → resolve path, 2s safety-timeout escape hatch, listener cleanup so a later `leave-full-screen` doesn't double-resolve. |
| `apps/web/tests/hooks/useResetOnFullscreenExit.test.tsx` | 5 | Hook contract: fires `reset` on exit, ignores enter, removes listener on unmount, SSR-safe, re-subscribes when `reset` identity changes. |

## Test plan

- [ ] CI green on the `apps/web` and `apps/packaged` packages
- [ ] Manual macOS smoke: reproduce per the steps above on a packaged build (or `pnpm tools-dev` desktop run). Confirm the Space animates back cleanly after close-from-fullscreen.

## Not in scope

- Non-macOS close behavior (the broken handler is gated on `process.platform === \"darwin\"`).
- macOS \"simple fullscreen\" (`setSimpleFullScreen`) is a separate code path that doesn't have the same animated-transition timing — the helper only handles native fullscreen which is what `FileViewer` requests via `requestFullscreen`.