### PR TITLE
Reject filesystem root folder imports

### DIFF
--- a/apps/daemon/src/import-export-routes.ts
+++ b/apps/daemon/src/import-export-routes.ts
@@ -157,6 +157,9 @@ export function registerImportRoutes(app: Express, ctx: RegisterImportRoutesDeps
       if (!dirStat.isDirectory()) {
         return sendApiError(res, 400, 'BAD_REQUEST', 'path must be a directory');
       }
+      if (path.parse(normalizedPath).root === normalizedPath) {
+        return sendApiError(res, 400, 'BAD_REQUEST', 'cannot import the filesystem root');
+      }
       // Prevent importing the data directory into itself (post-realpath so
       // a symlink pointing into RUNTIME_DATA_DIR is also caught). Compare
       // against the canonical alias because `normalizedPath` is the import

--- a/apps/daemon/tests/folder-import-route.test.ts
+++ b/apps/daemon/tests/folder-import-route.test.ts
@@ -116,6 +116,14 @@ describe('POST /api/import/folder', () => {
     expect(body.error?.message).toMatch(/directory/i);
   });
 
+  it('rejects the filesystem root as an import folder', async () => {
+    const root = path.parse(process.cwd()).root;
+    const resp = await importFolder({ baseDir: root });
+    expect(resp.status).toBe(400);
+    const body = (await resp.json()) as { error?: { message?: string } };
+    expect(body.error?.message).toMatch(/filesystem root/i);
+  });
+
   // Security: a user-controlled symlink at baseDir would let writeProjectFile
   // escape the project sandbox at every later call (resolveSafe checks the
   // *literal* baseDir, but the OS follows symlinks at open() time). The


### PR DESCRIPTION
Fixes #1243

This rejects filesystem root paths in the folder import endpoint after canonicalization, so a typed `/` path cannot create a project rooted at the whole disk and poison later template/file handling.

Validation:
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/folder-import-route.test.ts`
- `pnpm --filter @open-design/daemon typecheck`

Note: I also tried the package test script first, but it ran the full daemon suite instead of the single file; unrelated existing flakes failed in `chat-route.test.ts` and `project-watchers.test.ts`. The targeted import-folder suite passes.
