### PR TITLE
feat(daemon): add Claude Code finalize provider

### DIFF
--- a/apps/daemon/src/finalize-claude-code.ts
+++ b/apps/daemon/src/finalize-claude-code.ts
@@ -60,6 +60,38 @@ const VERSION_PROBE_TIMEOUT_MS = 5_000;
 const DEFAULT_CLAUDE_CODE_TIMEOUT_MS = 600_000;
 
 /**
+ * Full built-in tool surface of the Claude Code CLI. Passed to
+ * `--disallowedTools` so the synthesis run cannot launch Bash, read
+ * arbitrary files from the project cwd, search the web, etc. The
+ * synthesis prompt is self-contained — all transcript, design
+ * system, and artifact context is in stdin — so this list does not
+ * elide any capability the route genuinely needs.
+ *
+ * Keep in sync with upstream when new built-in tools ship; an unknown
+ * tool name in `--disallowedTools` is harmless, a missing one is a
+ * permission gap.
+ */
+export const CLAUDE_CODE_BUILTIN_TOOLS = [
+  'Bash',
+  'BashOutput',
+  'Edit',
+  'ExitPlanMode',
+  'Glob',
+  'Grep',
+  'KillShell',
+  'LS',
+  'MultiEdit',
+  'NotebookEdit',
+  'Read',
+  'SlashCommand',
+  'Task',
+  'TodoWrite',
+  'WebFetch',
+  'WebSearch',
+  'Write',
+] as const;
+
+/**
  * The local Claude Code CLI is not installed (or not on PATH the
  * daemon can see). Distinct from `FinalizeUpstreamError` so the route
  * handler can return a tailored 503 message instructing the user to
@@ -220,6 +252,7 @@ export async function callClaudeCodeCLI(input: {
   signal: AbortSignal;
   cwd: string;
   model?: string;
+  maxTokens?: number;
   transport?: ClaudeCodeCliTransport;
 }): Promise<FinalizeSynthesisResult> {
   const cliPath = input.transport?.cliPath ?? defaultCliBin();
@@ -236,9 +269,19 @@ export async function callClaudeCodeCLI(input: {
     '--verbose',
     '--append-system-prompt',
     input.systemPrompt,
-    // Synthesis never needs to read project files or run tools — the
-    // entire context is already in the user prompt. Disable tools so
-    // a Max plan user does not see surprising tool-permission prompts.
+    // Synthesis never needs project file access or tool invocations —
+    // the full transcript, design system, and current artifact are
+    // already in the user prompt. The CLI's default config allows the
+    // agent's built-in tool surface (Bash/Edit/Write/Read/Glob/Grep/
+    // WebFetch/WebSearch/Task/TodoWrite/NotebookEdit/MultiEdit/LS/
+    // SlashCommand/BashOutput/KillShell/ExitPlanMode), so we
+    // explicitly deny every one of them. `--permission-mode default`
+    // alone does NOT disable tools; it only controls how permission
+    // prompts are surfaced. The combination here keeps the CLI in a
+    // pure prompt-completion shape and prevents any side-effecting
+    // tool invocation against the user's project directory.
+    '--disallowedTools',
+    CLAUDE_CODE_BUILTIN_TOOLS.join(' '),
     '--permission-mode',
     'default',
   ];
@@ -254,10 +297,21 @@ export async function callClaudeCodeCLI(input: {
     throw err;
   }
 
+  // Claude Code reads its per-response output ceiling from the
+  // `CLAUDE_CODE_MAX_OUTPUT_TOKENS` env var (it has no equivalent
+  // CLI flag). Honoring `maxTokens` here keeps the route's request
+  // contract truthful: a caller that asks for a tighter ceiling
+  // actually gets one, matching the Anthropic provider's behavior.
+  const childEnv = { ...process.env };
+  if (typeof input.maxTokens === 'number' && input.maxTokens > 0) {
+    childEnv.CLAUDE_CODE_MAX_OUTPUT_TOKENS = String(Math.trunc(input.maxTokens));
+  }
+
   const spawnOptions: SpawnOptions = {
     cwd: input.cwd,
     stdio: ['pipe', 'pipe', 'pipe'],
     signal: input.signal,
+    env: childEnv,
   };
 
   let child: ChildProcess;
@@ -460,6 +514,7 @@ export async function finalizeDesignPackageWithClaudeCode(
       cwd,
     };
     if (options.model) callInput.model = options.model;
+    if (typeof options.maxTokens === 'number') callInput.maxTokens = options.maxTokens;
     if (options.cli) callInput.transport = options.cli;
     return callClaudeCodeCLI(callInput);
   };

--- a/apps/daemon/src/finalize-claude-code.ts
+++ b/apps/daemon/src/finalize-claude-code.ts
@@ -60,36 +60,16 @@ const VERSION_PROBE_TIMEOUT_MS = 5_000;
 const DEFAULT_CLAUDE_CODE_TIMEOUT_MS = 600_000;
 
 /**
- * Full built-in tool surface of the Claude Code CLI. Passed to
- * `--disallowedTools` so the synthesis run cannot launch Bash, read
- * arbitrary files from the project cwd, search the web, etc. The
- * synthesis prompt is self-contained — all transcript, design
- * system, and artifact context is in stdin — so this list does not
- * elide any capability the route genuinely needs.
+ * Empty allowlist literal passed to `--allowedTools` so the synthesis
+ * run has zero tool surface regardless of which built-in tools the
+ * installed CLI version ships or which MCP servers / configured tools
+ * the user has wired up. The synthesis prompt is self-contained — all
+ * transcript, design system, and artifact context is in stdin — so the
+ * provider never needs a tool.
  *
- * Keep in sync with upstream when new built-in tools ship; an unknown
- * tool name in `--disallowedTools` is harmless, a missing one is a
- * permission gap.
+ * Exported so tests can assert the argv contract.
  */
-export const CLAUDE_CODE_BUILTIN_TOOLS = [
-  'Bash',
-  'BashOutput',
-  'Edit',
-  'ExitPlanMode',
-  'Glob',
-  'Grep',
-  'KillShell',
-  'LS',
-  'MultiEdit',
-  'NotebookEdit',
-  'Read',
-  'SlashCommand',
-  'Task',
-  'TodoWrite',
-  'WebFetch',
-  'WebSearch',
-  'Write',
-] as const;
+export const CLAUDE_CODE_EMPTY_TOOL_ALLOWLIST = '' as const;
 
 /**
  * The local Claude Code CLI is not installed (or not on PATH the
@@ -271,17 +251,17 @@ export async function callClaudeCodeCLI(input: {
     input.systemPrompt,
     // Synthesis never needs project file access or tool invocations —
     // the full transcript, design system, and current artifact are
-    // already in the user prompt. The CLI's default config allows the
-    // agent's built-in tool surface (Bash/Edit/Write/Read/Glob/Grep/
-    // WebFetch/WebSearch/Task/TodoWrite/NotebookEdit/MultiEdit/LS/
-    // SlashCommand/BashOutput/KillShell/ExitPlanMode), so we
-    // explicitly deny every one of them. `--permission-mode default`
-    // alone does NOT disable tools; it only controls how permission
-    // prompts are surfaced. The combination here keeps the CLI in a
-    // pure prompt-completion shape and prevents any side-effecting
-    // tool invocation against the user's project directory.
-    '--disallowedTools',
-    CLAUDE_CODE_BUILTIN_TOOLS.join(' '),
+    // already in the user prompt. Pass an empty allowlist so the CLI
+    // runs with zero tool surface regardless of which built-in tools
+    // ship in the installed version or which MCP / configured tools
+    // the user has wired up. This is the inverse of an enumerated
+    // denylist: a denylist leaks any tool we forgot to name, an empty
+    // allowlist leaks nothing. `--permission-mode default` alone does
+    // NOT disable tools; it only controls how permission prompts are
+    // surfaced. The combination keeps the CLI in a pure
+    // prompt-completion shape.
+    '--allowedTools',
+    CLAUDE_CODE_EMPTY_TOOL_ALLOWLIST,
     '--permission-mode',
     'default',
   ];

--- a/apps/daemon/src/finalize-claude-code.ts
+++ b/apps/daemon/src/finalize-claude-code.ts
@@ -1,0 +1,498 @@
+// Provider-sibling of finalize-design.ts that synthesizes DESIGN.md via
+// the locally installed Claude Code CLI rather than calling
+// api.anthropic.com directly. Designed for Max plan subscribers, whose
+// CLI usage is subsidized by their subscription — paying per-token API
+// rates for finalize on top of an active Max plan is the gap this
+// module closes (GitHub issue nexu-io/open-design#963).
+//
+// The shared orchestration (lockfile, transcript export + truncation,
+// prompt build, atomic DESIGN.md write) lives in finalize-design.ts.
+// This module supplies a `FinalizeSynthesizer` that:
+//   1. Preflights `claude --version` so a missing CLI surfaces as a
+//      503-mappable error before the lockfile is even taken.
+//   2. Spawns `claude --print --output-format stream-json` with the
+//      project directory as cwd, writes the user prompt to stdin,
+//      and accumulates the stream-json `result` event for the body
+//      and (when surfaced) usage counters.
+//   3. Maps process-level failures (auth, abort, non-zero exit) onto
+//      `FinalizeUpstreamError` / `AbortError` so the route handler
+//      can reuse the Anthropic-route's status-aware mapping.
+
+import { spawn, type ChildProcess, type SpawnOptions } from 'node:child_process';
+import type Database from 'better-sqlite3';
+import type {
+  FinalizeClaudeCodeResponse,
+  FinalizeArtifactRef,
+} from '@open-design/contracts/api/finalize';
+import { getProject } from './db.js';
+import { resolveProjectDir } from './projects.js';
+import {
+  FinalizeUpstreamError,
+  runFinalizeWithSynthesizer,
+  type FinalizeSynthesisResult,
+  type FinalizeSynthesizer,
+  type RunFinalizeOptions,
+} from './finalize-design.js';
+
+export type { FinalizeClaudeCodeResponse };
+
+type Db = Database.Database;
+
+/**
+ * Resolve the CLI binary path. Production defaults to plain `claude`
+ * (PATH lookup); `OD_CLAUDE_CODE_CLI_BIN` overrides for users with
+ * non-PATH installs and for daemon integration tests that point the
+ * route at a controlled script.
+ */
+function defaultCliBin(): string {
+  return process.env.OD_CLAUDE_CODE_CLI_BIN || 'claude';
+}
+const VERSION_PROBE_TIMEOUT_MS = 5_000;
+/**
+ * Default upstream-call ceiling for the CLI route. Claude Code
+ * synthesis is meaningfully slower than a direct Anthropic Messages
+ * API call: the CLI streams its response, may retry internally, and
+ * has subprocess overhead the API path doesn't pay. A 2-minute
+ * ceiling (the Anthropic default) trips while the CLI is still
+ * legitimately working. 10 minutes accommodates a multi-turn
+ * synthesis without giving runaway processes an unbounded budget.
+ */
+const DEFAULT_CLAUDE_CODE_TIMEOUT_MS = 600_000;
+
+/**
+ * The local Claude Code CLI is not installed (or not on PATH the
+ * daemon can see). Distinct from `FinalizeUpstreamError` so the route
+ * handler can return a tailored 503 message instructing the user to
+ * install / re-login rather than the generic upstream-failed code.
+ */
+export class FinalizeClaudeCodeNotInstalledError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'FinalizeClaudeCodeNotInstalledError';
+  }
+}
+
+/**
+ * Test-injection seam. Production callers leave both fields
+ * unspecified and the synthesizer uses real `child_process.spawn`
+ * with the resolved CLI binary path. Tests substitute both.
+ */
+export interface ClaudeCodeCliTransport {
+  /** Override for the `claude` executable path. Default: `claude` (PATH lookup). */
+  cliPath?: string;
+  /** Override spawn implementation. Default: `child_process.spawn`. */
+  spawnImpl?: typeof spawn;
+}
+
+export interface FinalizeClaudeCodeOptions extends RunFinalizeOptions {
+  cli?: ClaudeCodeCliTransport;
+}
+
+/**
+ * One-shot preflight: run `claude --version` and resolve when the
+ * CLI prints a non-empty stdout AND exits zero. Maps ENOENT to
+ * `FinalizeClaudeCodeNotInstalledError`; any other failure (non-zero
+ * exit, empty stdout) to a generic 502 `FinalizeUpstreamError` so
+ * the route still maps to UPSTREAM_UNAVAILABLE.
+ *
+ * Bounded by a 5s internal timeout; the wider per-finalize timeout
+ * does not gate the preflight because it runs before the lockfile
+ * is taken and the orchestrator has not yet composed a signal.
+ */
+export async function probeClaudeCodeCli(
+  transport: ClaudeCodeCliTransport = {},
+): Promise<{ version: string }> {
+  const cliPath = transport.cliPath ?? defaultCliBin();
+  const spawnImpl = transport.spawnImpl ?? spawn;
+
+  return new Promise((resolve, reject) => {
+    let child: ChildProcess;
+    try {
+      child = spawnImpl(cliPath, ['--version'], { stdio: ['ignore', 'pipe', 'pipe'] });
+    } catch (err: unknown) {
+      const code = (err as NodeJS.ErrnoException)?.code;
+      if (code === 'ENOENT') {
+        return reject(
+          new FinalizeClaudeCodeNotInstalledError(
+            `claude CLI not found at "${cliPath}". Install Claude Code (https://docs.claude.com/en/docs/claude-code) and ensure it is on PATH.`,
+          ),
+        );
+      }
+      return reject(err);
+    }
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString('utf8');
+    });
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString('utf8');
+    });
+
+    const timer = setTimeout(() => {
+      child.kill('SIGTERM');
+      reject(new FinalizeUpstreamError(502, '', 'claude --version timed out'));
+    }, VERSION_PROBE_TIMEOUT_MS);
+
+    child.on('error', (err: NodeJS.ErrnoException) => {
+      clearTimeout(timer);
+      if (err.code === 'ENOENT') {
+        reject(
+          new FinalizeClaudeCodeNotInstalledError(
+            `claude CLI not found at "${cliPath}". Install Claude Code (https://docs.claude.com/en/docs/claude-code) and ensure it is on PATH.`,
+          ),
+        );
+        return;
+      }
+      reject(err);
+    });
+
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      if (code !== 0) {
+        reject(
+          new FinalizeUpstreamError(
+            502,
+            stderr,
+            `claude --version exited with code ${code}`,
+          ),
+        );
+        return;
+      }
+      const version = stdout.trim();
+      if (!version) {
+        reject(new FinalizeUpstreamError(502, '', 'claude --version produced no output'));
+        return;
+      }
+      resolve({ version });
+    });
+  });
+}
+
+interface StreamJsonResultEvent {
+  type: 'result';
+  subtype?: string;
+  is_error?: boolean;
+  result?: string;
+  model?: string;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  };
+}
+
+/**
+ * Authentication / login failure detected from CLI stderr or a
+ * stream-json `result` event with an error subtype. Keeps the auth
+ * vs general-upstream-failure distinction at the boundary so the
+ * route handler can return 401 UNAUTHORIZED with an actionable
+ * message ("run `claude /login`") rather than the catch-all 502.
+ */
+function isAuthFailureSignal(text: string): boolean {
+  const lower = text.toLowerCase();
+  return (
+    lower.includes('/login') ||
+    lower.includes('please run') ||
+    lower.includes('invalid api key') ||
+    lower.includes('not authenticated') ||
+    lower.includes('credentials')
+  );
+}
+
+/**
+ * Spawn the Claude Code CLI in headless print mode and feed it the
+ * synthesis prompts. Returns the final stream-json `result` event's
+ * text + usage. Errors map as:
+ *   - process spawn ENOENT → `FinalizeClaudeCodeNotInstalledError`
+ *   - signal abort → AbortError (orchestrator → route → 503)
+ *   - auth-signal-bearing stderr / error-subtype result → 401 via
+ *     `FinalizeUpstreamError(401)`
+ *   - any other non-zero exit / unparseable stream → 502 via
+ *     `FinalizeUpstreamError(502)` with the trailing stderr as
+ *     `rawText`
+ */
+export async function callClaudeCodeCLI(input: {
+  systemPrompt: string;
+  userPrompt: string;
+  signal: AbortSignal;
+  cwd: string;
+  model?: string;
+  transport?: ClaudeCodeCliTransport;
+}): Promise<FinalizeSynthesisResult> {
+  const cliPath = input.transport?.cliPath ?? defaultCliBin();
+  const spawnImpl = input.transport?.spawnImpl ?? spawn;
+
+  const args: string[] = [
+    '--print',
+    '--input-format',
+    'text',
+    '--output-format',
+    'stream-json',
+    // stream-json requires --verbose to emit per-event chunks rather
+    // than collapsing the run into a single terminal event.
+    '--verbose',
+    '--append-system-prompt',
+    input.systemPrompt,
+    // Synthesis never needs to read project files or run tools — the
+    // entire context is already in the user prompt. Disable tools so
+    // a Max plan user does not see surprising tool-permission prompts.
+    '--permission-mode',
+    'default',
+  ];
+  if (input.model) {
+    args.push('--model', input.model);
+  }
+
+  // Pre-abort short-circuit: if the caller already aborted before we
+  // spawned, raise AbortError without touching the CLI.
+  if (input.signal.aborted) {
+    const err = new Error('aborted');
+    err.name = 'AbortError';
+    throw err;
+  }
+
+  const spawnOptions: SpawnOptions = {
+    cwd: input.cwd,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    signal: input.signal,
+  };
+
+  let child: ChildProcess;
+  try {
+    child = spawnImpl(cliPath, args, spawnOptions);
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') {
+      throw new FinalizeClaudeCodeNotInstalledError(
+        `claude CLI not found at "${cliPath}"`,
+      );
+    }
+    throw err;
+  }
+
+  // Pipe the user prompt as plain text on stdin; the CLI's
+  // --input-format text mode treats stdin as the user message.
+  child.stdin?.on('error', () => {
+    // EPIPE if the CLI exits before we finish writing. Swallow; the
+    // close handler below maps the exit code to an error.
+  });
+  child.stdin?.end(input.userPrompt);
+
+  let stderrBuf = '';
+  child.stderr?.on('data', (chunk: Buffer) => {
+    stderrBuf += chunk.toString('utf8');
+  });
+
+  // Accumulate stdout line-by-line; the CLI emits one JSON object per
+  // line. We keep only the most recent `result` event and a list of
+  // any explicit error events for diagnostics.
+  let stdoutTail = '';
+  let resultEvent: StreamJsonResultEvent | null = null;
+
+  return await new Promise<FinalizeSynthesisResult>((resolve, reject) => {
+    const flushLines = (chunk: string): void => {
+      stdoutTail += chunk;
+      let newline: number;
+      while ((newline = stdoutTail.indexOf('\n')) !== -1) {
+        const line = stdoutTail.slice(0, newline).trim();
+        stdoutTail = stdoutTail.slice(newline + 1);
+        if (!line) continue;
+        try {
+          const event = JSON.parse(line) as { type?: unknown };
+          if (event && typeof event === 'object' && event.type === 'result') {
+            resultEvent = event as StreamJsonResultEvent;
+          }
+        } catch {
+          // Non-JSON line — ignore. The CLI occasionally prints
+          // diagnostic banners to stdout under unusual config; we
+          // tolerate them and rely on the final result event.
+        }
+      }
+    };
+
+    child.stdout?.on('data', (chunk: Buffer) => flushLines(chunk.toString('utf8')));
+
+    child.on('error', (err: NodeJS.ErrnoException) => {
+      if (err.code === 'ENOENT') {
+        reject(
+          new FinalizeClaudeCodeNotInstalledError(
+            `claude CLI not found at "${cliPath}"`,
+          ),
+        );
+        return;
+      }
+      // node propagates an abort by killing the child and emitting an
+      // 'error' with name === 'AbortError'; preserve the name so the
+      // orchestrator's downstream mapping treats it as a cancel.
+      if (err.name === 'AbortError' || input.signal.aborted) {
+        const aborted = new Error('aborted');
+        aborted.name = 'AbortError';
+        reject(aborted);
+        return;
+      }
+      reject(err);
+    });
+
+    child.on('close', (code, killSignal) => {
+      // Drain any trailing partial line.
+      if (stdoutTail.trim()) {
+        flushLines('\n');
+      }
+
+      if (input.signal.aborted) {
+        const aborted = new Error('aborted');
+        aborted.name = 'AbortError';
+        reject(aborted);
+        return;
+      }
+
+      if (resultEvent && resultEvent.is_error !== true && resultEvent.subtype === 'success') {
+        const text = typeof resultEvent.result === 'string' ? resultEvent.result : '';
+        if (!text) {
+          reject(
+            new FinalizeUpstreamError(
+              502,
+              stderrBuf,
+              'claude CLI returned an empty success result',
+            ),
+          );
+          return;
+        }
+        const usage = resultEvent.usage ?? {};
+        const inputTokens =
+          typeof usage.input_tokens === 'number' ? usage.input_tokens : null;
+        const outputTokens =
+          typeof usage.output_tokens === 'number' ? usage.output_tokens : null;
+        resolve({
+          designMd: text,
+          inputTokens,
+          outputTokens,
+          model: typeof resultEvent.model === 'string' ? resultEvent.model : null,
+        });
+        return;
+      }
+
+      // Result event present but flagged as an error — typically auth
+      // failure. Map auth-signal-bearing payloads to 401.
+      if (resultEvent && (resultEvent.is_error === true || resultEvent.subtype !== 'success')) {
+        const combined = `${stderrBuf}\n${JSON.stringify(resultEvent)}`;
+        if (isAuthFailureSignal(combined)) {
+          reject(
+            new FinalizeUpstreamError(
+              401,
+              combined,
+              'claude CLI is not authenticated — run `claude /login`',
+            ),
+          );
+          return;
+        }
+        reject(
+          new FinalizeUpstreamError(
+            502,
+            combined,
+            `claude CLI reported an error (subtype=${String(resultEvent.subtype ?? 'unknown')})`,
+          ),
+        );
+        return;
+      }
+
+      // No result event at all — the CLI exited without emitting one.
+      // Treat as upstream failure; surface stderr for diagnostics.
+      if (isAuthFailureSignal(stderrBuf)) {
+        reject(
+          new FinalizeUpstreamError(
+            401,
+            stderrBuf,
+            'claude CLI is not authenticated — run `claude /login`',
+          ),
+        );
+        return;
+      }
+      const trailer = killSignal ? ` (killed with ${killSignal})` : '';
+      reject(
+        new FinalizeUpstreamError(
+          502,
+          stderrBuf,
+          `claude CLI exited with code ${code}${trailer} without a result event`,
+        ),
+      );
+    });
+  });
+}
+
+/**
+ * Top-level entry point invoked by the route handler. Mirrors
+ * `finalizeDesignPackage` (the Anthropic provider) but routes the
+ * upstream call through the local Claude Code CLI. The function:
+ *   1. Resolves the project's working directory so the CLI inherits
+ *      a sensible cwd matching the user's mental model.
+ *   2. Probes `claude --version` before the lockfile is acquired so
+ *      a missing CLI does not leave a `.finalize.lock` behind.
+ *   3. Delegates to `runFinalizeWithSynthesizer` with a synthesizer
+ *      that spawns the CLI per call.
+ */
+export async function finalizeDesignPackageWithClaudeCode(
+  db: Db,
+  projectsRoot: string,
+  designSystemsRoot: string,
+  projectId: string,
+  options: FinalizeClaudeCodeOptions,
+): Promise<FinalizeClaudeCodeResponse> {
+  const project = getProject(db, projectId);
+  if (!project) {
+    throw new Error(`project not found: ${projectId}`);
+  }
+  const projectMetadata =
+    (project as { metadata?: { baseDir?: string } | null }).metadata ?? null;
+  const cwd = resolveProjectDir(projectsRoot, projectId, projectMetadata ?? undefined);
+
+  // Preflight outside the lockfile so a missing-CLI failure does not
+  // strand `.finalize.lock` on disk.
+  await probeClaudeCodeCli(options.cli ?? {});
+
+  const synthesize: FinalizeSynthesizer = ({ systemPrompt, userPrompt, signal }) => {
+    const callInput: Parameters<typeof callClaudeCodeCLI>[0] = {
+      systemPrompt,
+      userPrompt,
+      signal,
+      cwd,
+    };
+    if (options.model) callInput.model = options.model;
+    if (options.cli) callInput.transport = options.cli;
+    return callClaudeCodeCLI(callInput);
+  };
+
+  const runOptions: RunFinalizeOptions = {
+    // Apply the CLI-specific default ceiling unless the caller has
+    // explicitly opted into a shorter or longer budget; tests pass
+    // smaller values to exercise the abort path without burning
+    // wall-clock time.
+    timeoutMs: options.timeoutMs ?? DEFAULT_CLAUDE_CODE_TIMEOUT_MS,
+  };
+  if (options.model !== undefined) runOptions.model = options.model;
+  if (options.maxTokens !== undefined) runOptions.maxTokens = options.maxTokens;
+  if (options.now !== undefined) runOptions.now = options.now;
+  if (options.signal !== undefined) runOptions.signal = options.signal;
+  const result = await runFinalizeWithSynthesizer(
+    db,
+    projectsRoot,
+    designSystemsRoot,
+    projectId,
+    runOptions,
+    synthesize,
+  );
+
+  const artifact: FinalizeArtifactRef | null = result.artifact;
+  return {
+    designMdPath: result.designMdPath,
+    bytesWritten: result.bytesWritten,
+    model: result.model,
+    inputTokens: result.inputTokens,
+    outputTokens: result.outputTokens,
+    artifact,
+    transcriptMessageCount: result.transcriptMessageCount,
+    designSystemId: result.designSystemId,
+  };
+}

--- a/apps/daemon/src/finalize-claude-code.ts
+++ b/apps/daemon/src/finalize-claude-code.ts
@@ -33,6 +33,7 @@ import {
   type FinalizeSynthesizer,
   type RunFinalizeOptions,
 } from './finalize-design.js';
+import { spawnEnvForAgent } from './runtimes/env.js';
 
 export type { FinalizeClaudeCodeResponse };
 
@@ -285,7 +286,13 @@ export async function callClaudeCodeCLI(input: {
   // CLI flag). Honoring `maxTokens` here keeps the route's request
   // contract truthful: a caller that asks for a tighter ceiling
   // actually gets one, matching the Anthropic provider's behavior.
-  const childEnv = { ...process.env };
+  // Use the same env shaping as the claude agent runtime path: strip
+  // ANTHROPIC_API_KEY so Claude Code falls back to its own subscription
+  // auth (claude /login, Max/Pro plan) instead of silently API-billing
+  // a daemon that happens to have the key exported. This is the billing
+  // boundary the whole provider exists to preserve. Honors the
+  // ANTHROPIC_BASE_URL escape hatch (custom proxy).
+  const childEnv = spawnEnvForAgent('claude', process.env);
   if (typeof input.maxTokens === 'number' && input.maxTokens > 0) {
     childEnv.CLAUDE_CODE_MAX_OUTPUT_TOKENS = String(Math.trunc(input.maxTokens));
   }

--- a/apps/daemon/src/finalize-claude-code.ts
+++ b/apps/daemon/src/finalize-claude-code.ts
@@ -60,16 +60,18 @@ const VERSION_PROBE_TIMEOUT_MS = 5_000;
 const DEFAULT_CLAUDE_CODE_TIMEOUT_MS = 600_000;
 
 /**
- * Empty allowlist literal passed to `--allowedTools` so the synthesis
- * run has zero tool surface regardless of which built-in tools the
- * installed CLI version ships or which MCP servers / configured tools
- * the user has wired up. The synthesis prompt is self-contained — all
- * transcript, design system, and artifact context is in stdin — so the
- * provider never needs a tool.
+ * Empty value passed to `--tools` so the synthesis run has zero
+ * built-in tool surface regardless of which tools the installed CLI
+ * version ships or which MCP servers / configured tools the user has
+ * wired up. `--tools` is Claude Code's documented switch for
+ * constraining the built-in tool set; `--allowedTools` is a permission
+ * allowlist and does not replace the built-in surface. The synthesis
+ * prompt is self-contained — all transcript, design system, and
+ * artifact context is in stdin — so the provider never needs a tool.
  *
  * Exported so tests can assert the argv contract.
  */
-export const CLAUDE_CODE_EMPTY_TOOL_ALLOWLIST = '' as const;
+export const CLAUDE_CODE_EMPTY_TOOL_SET = '' as const;
 
 /**
  * The local Claude Code CLI is not installed (or not on PATH the
@@ -254,14 +256,15 @@ export async function callClaudeCodeCLI(input: {
     // already in the user prompt. Pass an empty allowlist so the CLI
     // runs with zero tool surface regardless of which built-in tools
     // ship in the installed version or which MCP / configured tools
-    // the user has wired up. This is the inverse of an enumerated
-    // denylist: a denylist leaks any tool we forgot to name, an empty
-    // allowlist leaks nothing. `--permission-mode default` alone does
-    // NOT disable tools; it only controls how permission prompts are
-    // surfaced. The combination keeps the CLI in a pure
+    // the user has wired up. `--tools` is Claude Code's documented
+    // switch for constraining the built-in tool set; passing an empty
+    // value disables all of them. `--allowedTools` is a permission
+    // allowlist and does NOT replace the built-in surface, and
+    // `--permission-mode default` alone only controls how permission
+    // prompts are surfaced. The combination keeps the CLI in a pure
     // prompt-completion shape.
-    '--allowedTools',
-    CLAUDE_CODE_EMPTY_TOOL_ALLOWLIST,
+    '--tools',
+    CLAUDE_CODE_EMPTY_TOOL_SET,
     '--permission-mode',
     'default',
   ];

--- a/apps/daemon/src/finalize-design.ts
+++ b/apps/daemon/src/finalize-design.ts
@@ -31,6 +31,7 @@ import type {
   FinalizeAnthropicRequest,
   FinalizeAnthropicResponse,
   FinalizeArtifactRef,
+  FinalizeClaudeCodeResponse,
 } from '@open-design/contracts/api/finalize';
 import { getProject } from './db.js';
 import { readDesignSystem } from './design-systems.js';
@@ -51,6 +52,7 @@ export type {
   FinalizeAnthropicRequest,
   FinalizeAnthropicResponse,
   FinalizeArtifactRef,
+  FinalizeClaudeCodeResponse,
 };
 
 const DEFAULT_BASE_URL = 'https://api.anthropic.com';
@@ -213,13 +215,82 @@ export async function resolveCurrentArtifact(
   return null;
 }
 
-export async function finalizeDesignPackage(
+/**
+ * Result of a single upstream synthesis call. `inputTokens` and
+ * `outputTokens` are nullable so providers that do not surface usage
+ * (e.g. some Claude Code CLI versions) can report null without
+ * forcing a fabricated 0. `model` is the actual model the upstream
+ * reported back; providers that cannot determine the post-hoc model
+ * return null and callers fall back to whatever the request asked
+ * for.
+ */
+export interface FinalizeSynthesisResult {
+  designMd: string;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  model: string | null;
+}
+
+/**
+ * Pluggable upstream synthesis adapter. The orchestration assembles
+ * the prompts, opens the lockfile, bounds the call with a composed
+ * AbortSignal (caller signal + DEFAULT_TIMEOUT_MS), and writes
+ * DESIGN.md atomically. The synthesizer's only job is to take the
+ * prompts and return the synthesized Markdown body.
+ *
+ * Implementations should throw `FinalizeUpstreamError` for
+ * recoverable upstream failures (status-aware mapping in the route
+ * handler) and let `AbortError` propagate unchanged.
+ */
+export type FinalizeSynthesizer = (input: {
+  systemPrompt: string;
+  userPrompt: string;
+  signal: AbortSignal;
+}) => Promise<FinalizeSynthesisResult>;
+
+/**
+ * Options accepted by the shared orchestration. Providers extend
+ * this with their own credential/transport fields.
+ */
+export interface RunFinalizeOptions {
+  model?: string;
+  maxTokens?: number;
+  now?: () => Date;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+}
+
+interface RunFinalizeResult {
+  designMdPath: string;
+  bytesWritten: number;
+  model: string | null;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  artifact: FinalizeArtifactRef | null;
+  transcriptMessageCount: number;
+  designSystemId: string | null;
+}
+
+/**
+ * Provider-agnostic finalize orchestration. Handles project lookup,
+ * lockfile, transcript export + truncation, design-system + artifact
+ * resolution, prompt build, abort/timeout composition, and the
+ * atomic DESIGN.md write. The actual upstream call is delegated to
+ * the supplied `synthesize` callback.
+ *
+ * Returns `model`/`inputTokens`/`outputTokens` as nullable so
+ * non-API-billed providers (Claude Code CLI) can faithfully report
+ * what their upstream surfaced; the Anthropic adapter narrows
+ * `model` back to a concrete string in `finalizeDesignPackage`.
+ */
+export async function runFinalizeWithSynthesizer(
   db: Db,
   projectsRoot: string,
   designSystemsRoot: string,
   projectId: string,
-  options: FinalizeOptions,
-): Promise<FinalizeAnthropicResponse> {
+  options: RunFinalizeOptions,
+  synthesize: FinalizeSynthesizer,
+): Promise<RunFinalizeResult> {
   const project = getProject(db, projectId);
   if (!project) {
     // Defensive — the route handler validates this and returns 404 before
@@ -245,8 +316,6 @@ export async function finalizeDesignPackage(
     `${OUTPUT_FILENAME}.tmp.${process.pid}.${randomBytes(4).toString('hex')}`,
   );
   const now = options.now ?? (() => new Date());
-  const baseUrl = options.baseUrl ?? DEFAULT_BASE_URL;
-  const maxTokens = options.maxTokens ?? DEFAULT_MAX_TOKENS;
 
   let lockFd: number | null = null;
   try {
@@ -260,10 +329,40 @@ export async function finalizeDesignPackage(
     throw err;
   }
 
+  // Idempotent lockfile release. Both the abort listener and the
+  // outer `finally` call this; the first invocation flips `lockFd`
+  // to null so the second is a no-op. This lets us release the lock
+  // the instant a cancel arrives — important for the Claude Code
+  // CLI provider, where the subprocess can take a second or two to
+  // wind down after SIGTERM. Without eager release, a user who
+  // cancels and immediately retries hits 409 CONFLICT until the
+  // subprocess fully exits.
+  const releaseLock = (): void => {
+    if (lockFd === null) return;
+    const fd = lockFd;
+    lockFd = null;
+    try {
+      fs.closeSync(fd);
+    } catch {
+      // ignore close-after-error
+    }
+    try {
+      fs.unlinkSync(lockPath);
+    } catch {
+      // lock may already be gone if disk vanished; not fatal
+    }
+  };
+
+  let abortReleaseListener: (() => void) | null = null;
+  if (options.signal) {
+    abortReleaseListener = releaseLock;
+    options.signal.addEventListener('abort', abortReleaseListener, { once: true });
+  }
+
   try {
     // Phase 3: export transcript via the PR #493 primitive. Returns the
     // disk path; we read the body and run it through the truncation
-    // policy so a 4 MB transcript does not blow Anthropic's context.
+    // policy so a 4 MB transcript does not blow the synthesis context.
     const transcriptResult = exportProjectTranscript(db, projectsRoot, projectId, { now });
     const transcriptJsonl = fs.readFileSync(transcriptResult.path, 'utf8');
     const truncatedJsonl = truncateTranscriptForPrompt(transcriptJsonl);
@@ -300,78 +399,29 @@ export async function finalizeDesignPackage(
       now: now(),
     });
 
-    // Phase 7: Anthropic call with bounded blocking timeout. The timeout
+    // Phase 7: upstream synthesis with bounded blocking timeout. The timeout
     // controller is always created so DEFAULT_TIMEOUT_MS bounds every call,
     // regardless of whether the caller supplied a request-abort signal.
     // When the caller does pass a signal, both cancel paths are honored via
     // AbortSignal.any so neither replaces the other (per @lefarcen P1 review
     // on PR #974 round 7: passing options.signal alone disabled the timeout).
-    //
-    // Network errors (DNS, ECONNREFUSED, ECONNRESET) and JSON parse errors
-    // on the response body are rewrapped as FinalizeUpstreamError(502) so
-    // the route handler maps them to 502 UPSTREAM_FAILED rather than 500
-    // INTERNAL. Per @lefarcen P1 review on PR #832: only HTTP-non-OK
-    // responses were previously wrapped, leaving DNS/parse failures to
-    // surface as generic 500s.
     const timeoutController = new AbortController();
     const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     const timeoutId = setTimeout(() => timeoutController.abort(), timeoutMs);
-    let response: Response;
+    let synthesis: FinalizeSynthesisResult;
     try {
-      const callParams: AnthropicCallParams = {
-        apiKey: options.apiKey,
-        baseUrl,
-        model: options.model,
-        maxTokens,
-        systemPrompt,
-        userPrompt,
-      };
-      callParams.signal = options.signal
+      const composedSignal = options.signal
         ? AbortSignal.any([options.signal, timeoutController.signal])
         : timeoutController.signal;
-      if (options.fetchImpl) callParams.fetchImpl = options.fetchImpl;
-      try {
-        response = await callAnthropicWithRetry(callParams);
-      } catch (err: unknown) {
-        if (err instanceof FinalizeUpstreamError) throw err;
-        const errName =
-          err && typeof err === 'object' && 'name' in err
-            ? (err as { name?: unknown }).name
-            : '';
-        if (errName === 'AbortError') throw err; // route handler maps to 503
-        // Network-level failure (TypeError from fetch, ENOTFOUND/ECONNREFUSED
-        // via cause.code, etc.) — rewrap as upstream failure so the route
-        // handler maps to 502 UPSTREAM_FAILED with redacted details.
-        const message = err instanceof Error ? err.message : String(err);
-        throw new FinalizeUpstreamError(502, '', `upstream network error: ${message}`);
-      }
+      synthesis = await synthesize({ systemPrompt, userPrompt, signal: composedSignal });
     } finally {
       clearTimeout(timeoutId);
     }
 
-    // Phase 8: extract DESIGN.md body and usage counters. A 200 with a body
-    // that isn't valid JSON (or isn't an object) is treated as an upstream
-    // failure rather than letting JSON.parse's SyntaxError surface as 500.
-    let payload: unknown;
-    try {
-      payload = await response.json();
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : String(err);
-      throw new FinalizeUpstreamError(
-        502,
-        '',
-        `upstream Anthropic returned non-JSON body: ${message}`,
-      );
-    }
-    const designMd = extractDesignMd(payload);
-    const usage = (payload as { usage?: { input_tokens?: number; output_tokens?: number } }).usage ?? {};
-    const inputTokens = typeof usage.input_tokens === 'number' ? usage.input_tokens : 0;
-    const outputTokens = typeof usage.output_tokens === 'number' ? usage.output_tokens : 0;
-
     // Phase 9: atomic write. Mirror PR #493: writeFileSync({flag:'wx'}) →
     // reopen for fsync → rename. On any failure unlink tmp; rethrow so the
     // route handler maps the error.
-    const encoded = Buffer.from(designMd, 'utf8');
+    const encoded = Buffer.from(synthesis.designMd, 'utf8');
     try {
       fs.writeFileSync(tmpPath, encoded, { flag: 'wx' });
       const fsyncFd = fs.openSync(tmpPath, 'r+');
@@ -393,9 +443,9 @@ export async function finalizeDesignPackage(
     return {
       designMdPath: finalPath,
       bytesWritten: encoded.length,
-      model: options.model,
-      inputTokens,
-      outputTokens,
+      model: synthesis.model ?? options.model ?? null,
+      inputTokens: synthesis.inputTokens,
+      outputTokens: synthesis.outputTokens,
       artifact: artifact
         ? {
             name: artifact.name,
@@ -409,19 +459,102 @@ export async function finalizeDesignPackage(
       designSystemId,
     };
   } finally {
-    if (lockFd !== null) {
-      try {
-        fs.closeSync(lockFd);
-      } catch {
-        // ignore close-after-error
-      }
-      try {
-        fs.unlinkSync(lockPath);
-      } catch {
-        // lock may already be gone if disk vanished; not fatal
-      }
+    if (abortReleaseListener && options.signal) {
+      options.signal.removeEventListener('abort', abortReleaseListener);
     }
+    releaseLock();
   }
+}
+
+export async function finalizeDesignPackage(
+  db: Db,
+  projectsRoot: string,
+  designSystemsRoot: string,
+  projectId: string,
+  options: FinalizeOptions,
+): Promise<FinalizeAnthropicResponse> {
+  const baseUrl = options.baseUrl ?? DEFAULT_BASE_URL;
+  const maxTokens = options.maxTokens ?? DEFAULT_MAX_TOKENS;
+
+  const synthesize: FinalizeSynthesizer = async ({ systemPrompt, userPrompt, signal }) => {
+    // Network errors (DNS, ECONNREFUSED, ECONNRESET) and JSON parse errors
+    // on the response body are rewrapped as FinalizeUpstreamError(502) so
+    // the route handler maps them to 502 UPSTREAM_FAILED rather than 500
+    // INTERNAL. Per @lefarcen P1 review on PR #832: only HTTP-non-OK
+    // responses were previously wrapped, leaving DNS/parse failures to
+    // surface as generic 500s.
+    let response: Response;
+    try {
+      const callParams: AnthropicCallParams = {
+        apiKey: options.apiKey,
+        baseUrl,
+        model: options.model,
+        maxTokens,
+        systemPrompt,
+        userPrompt,
+        signal,
+      };
+      if (options.fetchImpl) callParams.fetchImpl = options.fetchImpl;
+      response = await callAnthropicWithRetry(callParams);
+    } catch (err: unknown) {
+      if (err instanceof FinalizeUpstreamError) throw err;
+      const errName =
+        err && typeof err === 'object' && 'name' in err
+          ? (err as { name?: unknown }).name
+          : '';
+      if (errName === 'AbortError') throw err; // route handler maps to 503
+      const message = err instanceof Error ? err.message : String(err);
+      throw new FinalizeUpstreamError(502, '', `upstream network error: ${message}`);
+    }
+
+    // A 200 with a body that isn't valid JSON (or isn't an object) is
+    // treated as an upstream failure rather than letting JSON.parse's
+    // SyntaxError surface as 500.
+    let payload: unknown;
+    try {
+      payload = await response.json();
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new FinalizeUpstreamError(
+        502,
+        '',
+        `upstream Anthropic returned non-JSON body: ${message}`,
+      );
+    }
+    const designMd = extractDesignMd(payload);
+    const usage = (payload as { usage?: { input_tokens?: number; output_tokens?: number } }).usage ?? {};
+    const inputTokens = typeof usage.input_tokens === 'number' ? usage.input_tokens : 0;
+    const outputTokens = typeof usage.output_tokens === 'number' ? usage.output_tokens : 0;
+    return { designMd, inputTokens, outputTokens, model: options.model };
+  };
+
+  const runOptions: RunFinalizeOptions = { model: options.model };
+  if (options.maxTokens !== undefined) runOptions.maxTokens = options.maxTokens;
+  if (options.now !== undefined) runOptions.now = options.now;
+  if (options.signal !== undefined) runOptions.signal = options.signal;
+  if (options.timeoutMs !== undefined) runOptions.timeoutMs = options.timeoutMs;
+  const result = await runFinalizeWithSynthesizer(
+    db,
+    projectsRoot,
+    designSystemsRoot,
+    projectId,
+    runOptions,
+    synthesize,
+  );
+
+  // The Anthropic API path always knows its model and surfaces usage
+  // counters, so narrow the nullable shared shape back to the
+  // existing concrete response contract.
+  return {
+    designMdPath: result.designMdPath,
+    bytesWritten: result.bytesWritten,
+    model: result.model ?? options.model,
+    inputTokens: result.inputTokens ?? 0,
+    outputTokens: result.outputTokens ?? 0,
+    artifact: result.artifact,
+    transcriptMessageCount: result.transcriptMessageCount,
+    designSystemId: result.designSystemId,
+  };
 }
 
 /**

--- a/apps/daemon/src/finalize-design.ts
+++ b/apps/daemon/src/finalize-design.ts
@@ -408,14 +408,27 @@ export async function runFinalizeWithSynthesizer(
     const timeoutController = new AbortController();
     const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     const timeoutId = setTimeout(() => timeoutController.abort(), timeoutMs);
+    const composedSignal = options.signal
+      ? AbortSignal.any([options.signal, timeoutController.signal])
+      : timeoutController.signal;
     let synthesis: FinalizeSynthesisResult;
     try {
-      const composedSignal = options.signal
-        ? AbortSignal.any([options.signal, timeoutController.signal])
-        : timeoutController.signal;
       synthesis = await synthesize({ systemPrompt, userPrompt, signal: composedSignal });
     } finally {
       clearTimeout(timeoutId);
+    }
+
+    // Eager lock release on abort hands the lockfile to a retry the
+    // instant a cancel arrives, but a late-settling synthesizer can
+    // still resolve after that point. Without this guard, the canceled
+    // run would proceed into the phase-9 rename and overwrite the
+    // retry's newer DESIGN.md (last-writer-wins). Re-check the composed
+    // signal before any filesystem mutation so canceled invocations
+    // exit through the AbortError path instead of writing output.
+    if (composedSignal.aborted) {
+      const aborted = new Error('aborted');
+      aborted.name = 'AbortError';
+      throw aborted;
     }
 
     // Phase 9: atomic write. Mirror PR #493: writeFileSync({flag:'wx'}) →

--- a/apps/daemon/src/import-export-routes.ts
+++ b/apps/daemon/src/import-export-routes.ts
@@ -1,5 +1,6 @@
 import type { Express } from 'express';
 import type { RouteDeps } from './server-context.js';
+import type { FinalizeClaudeCodeOptions } from './finalize-claude-code.js';
 
 export interface RegisterImportRoutesDeps extends RouteDeps<'db' | 'http' | 'uploads' | 'node' | 'ids' | 'paths' | 'imports' | 'auth' | 'projectStore' | 'conversations' | 'projectFiles'> {}
 
@@ -352,7 +353,14 @@ export function registerFinalizeRoutes(app: Express, ctx: RegisterFinalizeRoutes
   const { PROJECTS_DIR, DESIGN_SYSTEMS_DIR } = ctx.paths;
   const { getProject } = ctx.projectStore;
   const { isSafeId, validateExternalApiBaseUrl } = ctx.validation;
-  const { finalizeDesignPackage, FinalizePackageLockedError, FinalizeUpstreamError, redactSecrets } = ctx.finalize;
+  const {
+    finalizeDesignPackage,
+    finalizeDesignPackageWithClaudeCode,
+    FinalizeClaudeCodeNotInstalledError,
+    FinalizePackageLockedError,
+    FinalizeUpstreamError,
+    redactSecrets,
+  } = ctx.finalize;
   app.post('/api/projects/:id/finalize/anthropic', async (req, res) => {
     const { apiKey, baseUrl, model, maxTokens } = req.body || {};
     try {
@@ -455,6 +463,82 @@ export function registerFinalizeRoutes(app: Express, ctx: RegisterFinalizeRoutes
       // through redactSecrets defensively.
       console.error('[finalize/anthropic]', err);
       const safeMsg = redactSecrets(String(err?.message || err), [apiKey]);
+      return sendApiError(res, 500, 'INTERNAL_ERROR', safeMsg);
+    }
+  });
+
+  app.post('/api/projects/:id/finalize/claude-code', async (req, res) => {
+    const { model, maxTokens } = req.body || {};
+    try {
+      if (!isSafeId(req.params.id)) {
+        return sendApiError(res, 400, 'BAD_REQUEST', 'invalid project id');
+      }
+      if (model !== undefined && (typeof model !== 'string' || !model.trim())) {
+        return sendApiError(res, 400, 'BAD_REQUEST', 'model must be a non-empty string when provided');
+      }
+      if (maxTokens !== undefined && (typeof maxTokens !== 'number' || maxTokens <= 0)) {
+        return sendApiError(res, 400, 'BAD_REQUEST', 'maxTokens must be a positive number when provided');
+      }
+
+      const project = getProject(db, req.params.id);
+      if (!project) {
+        return sendApiError(res, 404, 'PROJECT_NOT_FOUND', 'project not found');
+      }
+
+      const finalizeAbort = new AbortController();
+      const abortFromRequest = (): void => {
+        if (!finalizeAbort.signal.aborted) finalizeAbort.abort();
+      };
+      res.on('close', abortFromRequest);
+
+      let result;
+      try {
+        const opts: FinalizeClaudeCodeOptions = {
+          signal: finalizeAbort.signal,
+        };
+        if (typeof model === 'string') opts.model = model;
+        if (typeof maxTokens === 'number') opts.maxTokens = maxTokens;
+        result = await finalizeDesignPackageWithClaudeCode(
+          db,
+          PROJECTS_DIR,
+          DESIGN_SYSTEMS_DIR,
+          req.params.id,
+          opts,
+        );
+      } finally {
+        res.off('close', abortFromRequest);
+      }
+      res.json(result);
+    } catch (err: any) {
+      if (err instanceof FinalizePackageLockedError) {
+        return sendApiError(res, 409, 'CONFLICT', err.message);
+      }
+      // CLI not installed (or not on PATH the daemon can see). The
+      // caller cannot recover from inside the request, so surface a
+      // pointer to the install / login steps via the standard
+      // UPSTREAM_UNAVAILABLE code (no dedicated NOT_INSTALLED code
+      // in the contracts ApiErrorCode union).
+      if (err instanceof FinalizeClaudeCodeNotInstalledError) {
+        return sendApiError(res, 503, 'UPSTREAM_UNAVAILABLE', err.message);
+      }
+      if (err instanceof FinalizeUpstreamError) {
+        const safeDetails = redactSecrets(err.rawText || '', []);
+        const init = safeDetails ? { details: safeDetails } : {};
+        if (err.status === 401) {
+          return sendApiError(res, 401, 'UNAUTHORIZED', err.message, init);
+        }
+        if (err.status === 429) {
+          return sendApiError(res, 429, 'RATE_LIMITED', err.message, init);
+        }
+        return sendApiError(res, 502, 'UPSTREAM_UNAVAILABLE', err.message, init);
+      }
+      const errName =
+        err && typeof err === 'object' && 'name' in err ? (err as { name?: unknown }).name : '';
+      if (errName === 'AbortError') {
+        return sendApiError(res, 503, 'UPSTREAM_UNAVAILABLE', 'finalize timed out');
+      }
+      console.error('[finalize/claude-code]', err);
+      const safeMsg = redactSecrets(String(err?.message || err), []);
       return sendApiError(res, 500, 'INTERNAL_ERROR', safeMsg);
     }
   });

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -88,6 +88,10 @@ import {
   FinalizePackageLockedError,
   FinalizeUpstreamError,
 } from './finalize-design.js';
+import {
+  finalizeDesignPackageWithClaudeCode,
+  FinalizeClaudeCodeNotInstalledError,
+} from './finalize-claude-code.js';
 import { listPromptTemplates, readPromptTemplate } from './prompt-templates.js';
 import { buildDocumentPreview } from './document-preview.js';
 import { lintArtifact, renderFindingsForAgent } from './lint-artifact.js';
@@ -2738,6 +2742,8 @@ export async function startServer({
   };
   const finalizeDeps = {
     finalizeDesignPackage,
+    finalizeDesignPackageWithClaudeCode,
+    FinalizeClaudeCodeNotInstalledError,
     FinalizePackageLockedError,
     FinalizeUpstreamError,
     redactSecrets,

--- a/apps/daemon/tests/finalize-claude-code-route.test.ts
+++ b/apps/daemon/tests/finalize-claude-code-route.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Route-level integration coverage for
+ * `POST /api/projects/:id/finalize/claude-code` (GitHub issue
+ * nexu-io/open-design#963). Drives the real Express handler end to
+ * end, swapping in a controlled fake `claude` binary via the
+ * `OD_CLAUDE_CODE_CLI_BIN` env override so we can exercise the
+ * success path, the missing-CLI path, and the auth-failure path
+ * without the developer's actual Claude Code CLI.
+ *
+ * The fake binary is a tiny Node shebang script. It implements just
+ * enough of `claude --version` and `claude --print --output-format
+ * stream-json …` to satisfy the synthesizer: it emits a single JSON
+ * line on stdout and exits, with the body driven by env vars so
+ * each test case can shape the response.
+ */
+import * as http from 'node:http';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { startServer } from '../src/server.js';
+
+describe('POST /api/projects/:id/finalize/claude-code', () => {
+  let server: http.Server;
+  let baseUrl: string;
+  let fakeBinDir: string;
+  let fakeBinPath: string;
+
+  const PROJECT_ID_OK = 'fcc-route-ok';
+  const PROJECT_ID_AUTH = 'fcc-route-auth';
+  const PROJECT_ID_MISSING = 'fcc-route-missing';
+
+  const SUCCESS_DESIGN_MD = '# DESIGN.md\n## Summary\nfrom fake CLI\n';
+
+  beforeAll(async () => {
+    // Build the fake CLI script BEFORE startServer so the env vars
+    // are visible by the time the daemon module is imported (the
+    // synthesizer reads OD_CLAUDE_CODE_CLI_BIN at call time, so this
+    // is belt-and-suspenders).
+    fakeBinDir = mkdtempSync(path.join(tmpdir(), 'od-fake-claude-'));
+    fakeBinPath = path.join(fakeBinDir, 'fake-claude');
+    const script = `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === '--version') {
+  process.stdout.write('0.0.0-fake (Open Design test)\\n');
+  process.exit(0);
+}
+const mode = process.env.OD_FAKE_CLAUDE_MODE || 'success';
+const successBody = process.env.OD_FAKE_CLAUDE_BODY || '';
+if (mode === 'success') {
+  const event = {
+    type: 'result',
+    subtype: 'success',
+    is_error: false,
+    result: successBody,
+    model: 'fake-model',
+    usage: { input_tokens: 11, output_tokens: 22 },
+  };
+  process.stdout.write(JSON.stringify(event) + '\\n');
+  process.exit(0);
+} else if (mode === 'auth') {
+  const event = {
+    type: 'result',
+    subtype: 'error_during_execution',
+    is_error: true,
+    result: 'please run /login to authenticate',
+  };
+  process.stdout.write(JSON.stringify(event) + '\\n');
+  process.exit(1);
+}
+process.exit(2);
+`;
+    writeFileSync(fakeBinPath, script);
+    chmodSync(fakeBinPath, 0o755);
+
+    process.env.OD_CLAUDE_CODE_CLI_BIN = fakeBinPath;
+    process.env.OD_FAKE_CLAUDE_BODY = SUCCESS_DESIGN_MD;
+
+    const started = (await startServer({ port: 0, returnServer: true })) as {
+      url: string;
+      server: http.Server;
+    };
+    baseUrl = started.url;
+    server = started.server;
+
+    const dataDir = process.env.OD_DATA_DIR;
+    if (!dataDir) throw new Error('OD_DATA_DIR is required for daemon route tests');
+
+    for (const id of [PROJECT_ID_OK, PROJECT_ID_AUTH, PROJECT_ID_MISSING]) {
+      await fetch(`${baseUrl}/api/projects`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id, name: `Fixture ${id}` }),
+      });
+      const dir = path.join(dataDir, 'projects', id);
+      mkdirSync(dir, { recursive: true });
+      // Seed a conversation + one message so the transcript export
+      // phase has something to read.
+      const conv = await fetch(`${baseUrl}/api/projects/${id}/conversations`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'Seed' }),
+      });
+      const convBody = (await conv.json()) as { conversation: { id: string } };
+      await fetch(
+        `${baseUrl}/api/projects/${id}/conversations/${convBody.conversation.id}/messages/seed-msg`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            role: 'user',
+            createdAt: 1,
+            updatedAt: 1,
+            blocks: [{ type: 'text', text: 'design me a thing' }],
+          }),
+        },
+      );
+    }
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    delete process.env.OD_CLAUDE_CODE_CLI_BIN;
+    delete process.env.OD_FAKE_CLAUDE_MODE;
+    delete process.env.OD_FAKE_CLAUDE_BODY;
+    rmSync(fakeBinDir, { recursive: true, force: true });
+  });
+
+  it('writes DESIGN.md and returns the schema response on the success path', async () => {
+    process.env.OD_FAKE_CLAUDE_MODE = 'success';
+    const res = await fetch(
+      `${baseUrl}/api/projects/${PROJECT_ID_OK}/finalize/claude-code`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      designMdPath: string;
+      bytesWritten: number;
+      model: string | null;
+      inputTokens: number | null;
+      outputTokens: number | null;
+      transcriptMessageCount: number;
+    };
+    expect(body.model).toBe('fake-model');
+    expect(body.inputTokens).toBe(11);
+    expect(body.outputTokens).toBe(22);
+    expect(body.bytesWritten).toBe(Buffer.byteLength(SUCCESS_DESIGN_MD, 'utf8'));
+    expect(existsSync(body.designMdPath)).toBe(true);
+    expect(readFileSync(body.designMdPath, 'utf8')).toBe(SUCCESS_DESIGN_MD);
+  });
+
+  it('returns 401 UNAUTHORIZED when the CLI reports an auth failure', async () => {
+    process.env.OD_FAKE_CLAUDE_MODE = 'auth';
+    const res = await fetch(
+      `${baseUrl}/api/projects/${PROJECT_ID_AUTH}/finalize/claude-code`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      },
+    );
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe('UNAUTHORIZED');
+  });
+
+  it('returns 503 UPSTREAM_UNAVAILABLE when the CLI binary is missing', async () => {
+    const prev = process.env.OD_CLAUDE_CODE_CLI_BIN;
+    process.env.OD_CLAUDE_CODE_CLI_BIN = path.join(fakeBinDir, 'definitely-not-here');
+    try {
+      const res = await fetch(
+        `${baseUrl}/api/projects/${PROJECT_ID_MISSING}/finalize/claude-code`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        },
+      );
+      expect(res.status).toBe(503);
+      const body = (await res.json()) as { error?: { code?: string } };
+      expect(body.error?.code).toBe('UPSTREAM_UNAVAILABLE');
+    } finally {
+      process.env.OD_CLAUDE_CODE_CLI_BIN = prev;
+    }
+  });
+
+  it('rejects malformed model with 400 BAD_REQUEST', async () => {
+    const res = await fetch(
+      `${baseUrl}/api/projects/${PROJECT_ID_OK}/finalize/claude-code`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: '' }),
+      },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 for unknown project id', async () => {
+    const res = await fetch(
+      `${baseUrl}/api/projects/does-not-exist/finalize/claude-code`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      },
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/daemon/tests/finalize-claude-code-route.test.ts
+++ b/apps/daemon/tests/finalize-claude-code-route.test.ts
@@ -38,6 +38,7 @@ describe('POST /api/projects/:id/finalize/claude-code', () => {
   const PROJECT_ID_OK = 'fcc-route-ok';
   const PROJECT_ID_AUTH = 'fcc-route-auth';
   const PROJECT_ID_MISSING = 'fcc-route-missing';
+  const PROJECT_ID_ENV = 'fcc-route-env';
 
   const SUCCESS_DESIGN_MD = '# DESIGN.md\n## Summary\nfrom fake CLI\n';
 
@@ -56,6 +57,14 @@ if (args[0] === '--version') {
 }
 const mode = process.env.OD_FAKE_CLAUDE_MODE || 'success';
 const successBody = process.env.OD_FAKE_CLAUDE_BODY || '';
+const envDumpPath = process.env.OD_FAKE_CLAUDE_ENV_DUMP;
+if (envDumpPath) {
+  const fs = require('node:fs');
+  fs.writeFileSync(envDumpPath, JSON.stringify({
+    ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY ?? null,
+    CLAUDE_CODE_MAX_OUTPUT_TOKENS: process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS ?? null,
+  }));
+}
 if (mode === 'success') {
   const event = {
     type: 'result',
@@ -95,7 +104,7 @@ process.exit(2);
     const dataDir = process.env.OD_DATA_DIR;
     if (!dataDir) throw new Error('OD_DATA_DIR is required for daemon route tests');
 
-    for (const id of [PROJECT_ID_OK, PROJECT_ID_AUTH, PROJECT_ID_MISSING]) {
+    for (const id of [PROJECT_ID_OK, PROJECT_ID_AUTH, PROJECT_ID_MISSING, PROJECT_ID_ENV]) {
       await fetch(`${baseUrl}/api/projects`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -207,6 +216,39 @@ process.exit(2);
       },
     );
     expect(res.status).toBe(400);
+  });
+
+  it('strips ANTHROPIC_API_KEY from the spawn env so Max plan auth wins', async () => {
+    // Regression: the provider exists to let Max plan users finalize via
+    // their subscription. If ANTHROPIC_API_KEY leaks through to the
+    // child, Claude Code picks API-key billing over the user's
+    // `claude /login` credentials, defeating the whole feature.
+    process.env.OD_FAKE_CLAUDE_MODE = 'success';
+    const envDumpPath = path.join(fakeBinDir, 'env-dump.json');
+    process.env.OD_FAKE_CLAUDE_ENV_DUMP = envDumpPath;
+    const prevKey = process.env.ANTHROPIC_API_KEY;
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-should-not-leak';
+    try {
+      const res = await fetch(
+        `${baseUrl}/api/projects/${PROJECT_ID_ENV}/finalize/claude-code`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ maxTokens: 1234 }),
+        },
+      );
+      expect(res.status).toBe(200);
+      const dumped = JSON.parse(readFileSync(envDumpPath, 'utf8')) as {
+        ANTHROPIC_API_KEY: string | null;
+        CLAUDE_CODE_MAX_OUTPUT_TOKENS: string | null;
+      };
+      expect(dumped.ANTHROPIC_API_KEY).toBeNull();
+      expect(dumped.CLAUDE_CODE_MAX_OUTPUT_TOKENS).toBe('1234');
+    } finally {
+      if (prevKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+      else process.env.ANTHROPIC_API_KEY = prevKey;
+      delete process.env.OD_FAKE_CLAUDE_ENV_DUMP;
+    }
   });
 
   it('returns 404 for unknown project id', async () => {

--- a/apps/daemon/tests/finalize-claude-code.test.ts
+++ b/apps/daemon/tests/finalize-claude-code.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Unit coverage for the Claude Code CLI synthesizer that backs
+ * `POST /api/projects/:id/finalize/claude-code` (GitHub issue
+ * nexu-io/open-design#963). The orchestration (lockfile, transcript
+ * export, atomic write) is exercised by `finalize-design.test.ts`
+ * and is provider-agnostic; this file pins the CLI-spawning seam
+ * so future CLI argv changes do not silently break the route.
+ *
+ * Tests inject a fake `spawnImpl` returning an EventEmitter-backed
+ * fake child process, so they neither require the real `claude`
+ * binary nor touch the network.
+ */
+import { EventEmitter } from 'node:events';
+import { Writable } from 'node:stream';
+import { describe, expect, it } from 'vitest';
+
+import {
+  callClaudeCodeCLI,
+  FinalizeClaudeCodeNotInstalledError,
+  probeClaudeCodeCli,
+} from '../src/finalize-claude-code.js';
+import { FinalizeUpstreamError } from '../src/finalize-design.js';
+
+type FakeSpawn = (cmd: string, args: readonly string[], opts: any) => FakeChild;
+
+interface FakeChild extends EventEmitter {
+  stdin: Writable;
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: (signal?: string) => boolean;
+  /** Test hook: emit stdout JSONL events then close the process. */
+  finish: (events: string[], opts?: { exitCode?: number; stderr?: string }) => void;
+}
+
+function createFakeChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.stdin = new Writable({
+    write(_chunk, _enc, cb) {
+      cb();
+    },
+  });
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = () => true;
+  child.finish = (events, opts) => {
+    for (const e of events) {
+      child.stdout.emit('data', Buffer.from(e + '\n', 'utf8'));
+    }
+    if (opts?.stderr) child.stderr.emit('data', Buffer.from(opts.stderr, 'utf8'));
+    // Defer 'close' so the consumer's data handler runs synchronously
+    // before we resolve.
+    setImmediate(() => child.emit('close', opts?.exitCode ?? 0, null));
+  };
+  return child;
+}
+
+function makeSpawn(
+  onSpawn: (cmd: string, args: readonly string[]) => FakeChild,
+): FakeSpawn {
+  return ((cmd, args) => onSpawn(cmd, args)) as FakeSpawn;
+}
+
+describe('probeClaudeCodeCli', () => {
+  it('resolves with the trimmed --version output on success', async () => {
+    const spawnImpl = makeSpawn(() => {
+      const child = createFakeChild();
+      setImmediate(() => {
+        child.stdout.emit('data', Buffer.from('2.1.138 (Claude Code)\n'));
+        child.emit('close', 0, null);
+      });
+      return child;
+    });
+
+    const { version } = await probeClaudeCodeCli({ spawnImpl: spawnImpl as any });
+    expect(version).toBe('2.1.138 (Claude Code)');
+  });
+
+  it('throws FinalizeClaudeCodeNotInstalledError on ENOENT spawn failure', async () => {
+    const spawnImpl = makeSpawn(() => {
+      const child = createFakeChild();
+      const err: NodeJS.ErrnoException = new Error('spawn claude ENOENT');
+      err.code = 'ENOENT';
+      setImmediate(() => child.emit('error', err));
+      return child;
+    });
+
+    await expect(
+      probeClaudeCodeCli({ spawnImpl: spawnImpl as any }),
+    ).rejects.toBeInstanceOf(FinalizeClaudeCodeNotInstalledError);
+  });
+
+  it('throws FinalizeUpstreamError when the CLI exits non-zero', async () => {
+    const spawnImpl = makeSpawn(() => {
+      const child = createFakeChild();
+      setImmediate(() => {
+        child.stderr.emit('data', Buffer.from('cli broken'));
+        child.emit('close', 1, null);
+      });
+      return child;
+    });
+
+    await expect(
+      probeClaudeCodeCli({ spawnImpl: spawnImpl as any }),
+    ).rejects.toBeInstanceOf(FinalizeUpstreamError);
+  });
+});
+
+describe('callClaudeCodeCLI', () => {
+  const promptInput = {
+    systemPrompt: 'sys',
+    userPrompt: 'user',
+    cwd: '/tmp',
+  };
+
+  it('passes --append-system-prompt + --model and returns the result event body + usage', async () => {
+    let capturedArgs: readonly string[] = [];
+    const spawnImpl = makeSpawn((_cmd, args) => {
+      capturedArgs = args;
+      const child = createFakeChild();
+      setImmediate(() => {
+        child.finish([
+          JSON.stringify({
+            type: 'result',
+            subtype: 'success',
+            is_error: false,
+            result: '# DESIGN.md\nbody\n',
+            model: 'claude-opus-4-7',
+            usage: { input_tokens: 100, output_tokens: 200 },
+          }),
+        ]);
+      });
+      return child;
+    });
+
+    const out = await callClaudeCodeCLI({
+      ...promptInput,
+      model: 'claude-opus-4-7',
+      signal: new AbortController().signal,
+      transport: { spawnImpl: spawnImpl as any },
+    });
+
+    expect(out.designMd).toBe('# DESIGN.md\nbody\n');
+    expect(out.inputTokens).toBe(100);
+    expect(out.outputTokens).toBe(200);
+    expect(out.model).toBe('claude-opus-4-7');
+    expect(capturedArgs).toContain('--append-system-prompt');
+    expect(capturedArgs).toContain('--output-format');
+    expect(capturedArgs).toContain('stream-json');
+    expect(capturedArgs).toContain('--model');
+    expect(capturedArgs).toContain('claude-opus-4-7');
+  });
+
+  it('returns null model + token counters when the CLI omits them', async () => {
+    const spawnImpl = makeSpawn(() => {
+      const child = createFakeChild();
+      setImmediate(() => {
+        child.finish([
+          JSON.stringify({
+            type: 'result',
+            subtype: 'success',
+            is_error: false,
+            result: '# minimal\n',
+          }),
+        ]);
+      });
+      return child;
+    });
+
+    const out = await callClaudeCodeCLI({
+      ...promptInput,
+      signal: new AbortController().signal,
+      transport: { spawnImpl: spawnImpl as any },
+    });
+
+    expect(out.designMd).toBe('# minimal\n');
+    expect(out.inputTokens).toBeNull();
+    expect(out.outputTokens).toBeNull();
+    expect(out.model).toBeNull();
+  });
+
+  it('throws FinalizeUpstreamError(401) when the result event signals an auth failure', async () => {
+    const spawnImpl = makeSpawn(() => {
+      const child = createFakeChild();
+      setImmediate(() => {
+        child.finish(
+          [
+            JSON.stringify({
+              type: 'result',
+              subtype: 'error_during_execution',
+              is_error: true,
+              result: 'please run `/login` to authenticate',
+            }),
+          ],
+          { exitCode: 1 },
+        );
+      });
+      return child;
+    });
+
+    const err = await callClaudeCodeCLI({
+      ...promptInput,
+      signal: new AbortController().signal,
+      transport: { spawnImpl: spawnImpl as any },
+    }).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(FinalizeUpstreamError);
+    expect((err as FinalizeUpstreamError).status).toBe(401);
+  });
+
+  it('throws FinalizeUpstreamError(502) when no result event is emitted', async () => {
+    const spawnImpl = makeSpawn(() => {
+      const child = createFakeChild();
+      setImmediate(() => {
+        child.finish([], { exitCode: 1, stderr: 'crashed mid-call' });
+      });
+      return child;
+    });
+
+    const err = await callClaudeCodeCLI({
+      ...promptInput,
+      signal: new AbortController().signal,
+      transport: { spawnImpl: spawnImpl as any },
+    }).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(FinalizeUpstreamError);
+    expect((err as FinalizeUpstreamError).status).toBe(502);
+    expect((err as FinalizeUpstreamError).rawText).toContain('crashed mid-call');
+  });
+
+  it('rejects with AbortError when the signal is already aborted before spawn', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    let spawned = false;
+    const spawnImpl = makeSpawn(() => {
+      spawned = true;
+      return createFakeChild();
+    });
+
+    const err = await callClaudeCodeCLI({
+      ...promptInput,
+      signal: controller.signal,
+      transport: { spawnImpl: spawnImpl as any },
+    }).catch((e: unknown) => e);
+
+    expect(spawned).toBe(false);
+    expect((err as Error).name).toBe('AbortError');
+  });
+
+  it('rejects with AbortError when the signal aborts mid-call', async () => {
+    const controller = new AbortController();
+    const spawnImpl = makeSpawn(() => {
+      const child = createFakeChild();
+      // Simulate Node's AbortSignal-aware spawn behavior: when the
+      // signal aborts, it kills the child and emits an 'error' with
+      // name='AbortError'. We mimic this on signal abort.
+      controller.signal.addEventListener('abort', () => {
+        const err = new Error('aborted');
+        err.name = 'AbortError';
+        child.emit('error', err);
+      });
+      return child;
+    });
+
+    const promise = callClaudeCodeCLI({
+      ...promptInput,
+      signal: controller.signal,
+      transport: { spawnImpl: spawnImpl as any },
+    });
+
+    setImmediate(() => controller.abort());
+    const err = await promise.catch((e: unknown) => e);
+    expect((err as Error).name).toBe('AbortError');
+  });
+});

--- a/apps/daemon/tests/finalize-claude-code.test.ts
+++ b/apps/daemon/tests/finalize-claude-code.test.ts
@@ -16,7 +16,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   callClaudeCodeCLI,
-  CLAUDE_CODE_EMPTY_TOOL_ALLOWLIST,
+  CLAUDE_CODE_EMPTY_TOOL_SET,
   FinalizeClaudeCodeNotInstalledError,
   probeClaudeCodeCli,
 } from '../src/finalize-claude-code.js';
@@ -151,7 +151,7 @@ describe('callClaudeCodeCLI', () => {
     expect(capturedArgs).toContain('claude-opus-4-7');
   });
 
-  it('passes --allowedTools with an empty value so synthesis runs cannot launch any tool', async () => {
+  it('passes --tools with an empty value so synthesis runs cannot launch any tool', async () => {
     let capturedArgs: readonly string[] = [];
     const spawnImpl = makeSpawn((_cmd, args) => {
       capturedArgs = args;
@@ -175,15 +175,17 @@ describe('callClaudeCodeCLI', () => {
       transport: { spawnImpl: spawnImpl as any },
     });
 
-    const flagIdx = capturedArgs.indexOf('--allowedTools');
+    const flagIdx = capturedArgs.indexOf('--tools');
     expect(flagIdx).toBeGreaterThanOrEqual(0);
-    expect(capturedArgs[flagIdx + 1]).toBe(CLAUDE_CODE_EMPTY_TOOL_ALLOWLIST);
+    expect(capturedArgs[flagIdx + 1]).toBe(CLAUDE_CODE_EMPTY_TOOL_SET);
     expect(capturedArgs[flagIdx + 1]).toBe('');
-    // An empty allowlist is the contract: no enumerated denylist
-    // should be present, since the whole point of switching away from
-    // `--disallowedTools` is that hand-maintained denylists leak any
-    // tool we forget to name (installed built-ins, MCP tools, etc.).
+    // An empty `--tools` value is the contract: no enumerated denylist
+    // should be present, since hand-maintained denylists leak any tool
+    // we forget to name (installed built-ins, MCP tools, etc.).
+    // `--allowedTools` is a permission allowlist and does not replace
+    // the built-in tool surface, so it must not be used here either.
     expect(capturedArgs).not.toContain('--disallowedTools');
+    expect(capturedArgs).not.toContain('--allowedTools');
   });
 
   it('threads maxTokens into the child env as CLAUDE_CODE_MAX_OUTPUT_TOKENS', async () => {

--- a/apps/daemon/tests/finalize-claude-code.test.ts
+++ b/apps/daemon/tests/finalize-claude-code.test.ts
@@ -16,6 +16,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   callClaudeCodeCLI,
+  CLAUDE_CODE_BUILTIN_TOOLS,
   FinalizeClaudeCodeNotInstalledError,
   probeClaudeCodeCli,
 } from '../src/finalize-claude-code.js';
@@ -148,6 +149,99 @@ describe('callClaudeCodeCLI', () => {
     expect(capturedArgs).toContain('stream-json');
     expect(capturedArgs).toContain('--model');
     expect(capturedArgs).toContain('claude-opus-4-7');
+  });
+
+  it('passes --disallowedTools listing every built-in tool so synthesis runs cannot touch the project cwd', async () => {
+    let capturedArgs: readonly string[] = [];
+    const spawnImpl = makeSpawn((_cmd, args) => {
+      capturedArgs = args;
+      const child = createFakeChild();
+      setImmediate(() => {
+        child.finish([
+          JSON.stringify({
+            type: 'result',
+            subtype: 'success',
+            is_error: false,
+            result: 'ok',
+          }),
+        ]);
+      });
+      return child;
+    });
+
+    await callClaudeCodeCLI({
+      ...promptInput,
+      signal: new AbortController().signal,
+      transport: { spawnImpl: spawnImpl as any },
+    });
+
+    const flagIdx = capturedArgs.indexOf('--disallowedTools');
+    expect(flagIdx).toBeGreaterThanOrEqual(0);
+    const denyList = String(capturedArgs[flagIdx + 1] ?? '').split(/\s+/);
+    for (const tool of CLAUDE_CODE_BUILTIN_TOOLS) {
+      expect(denyList).toContain(tool);
+    }
+    // High-risk tools must be in the deny list specifically — these
+    // are the ones whose absence would let synthesis mutate the
+    // user's project from cwd.
+    for (const dangerous of ['Bash', 'Edit', 'Write', 'Read', 'WebFetch']) {
+      expect(denyList).toContain(dangerous);
+    }
+  });
+
+  it('threads maxTokens into the child env as CLAUDE_CODE_MAX_OUTPUT_TOKENS', async () => {
+    let capturedEnv: Record<string, string | undefined> = {};
+    const spawnImpl = ((_cmd: string, _args: readonly string[], opts: any) => {
+      capturedEnv = opts?.env ?? {};
+      const child = createFakeChild();
+      setImmediate(() => {
+        child.finish([
+          JSON.stringify({
+            type: 'result',
+            subtype: 'success',
+            is_error: false,
+            result: 'ok',
+          }),
+        ]);
+      });
+      return child;
+    }) as FakeSpawn;
+
+    await callClaudeCodeCLI({
+      ...promptInput,
+      signal: new AbortController().signal,
+      maxTokens: 4096,
+      transport: { spawnImpl: spawnImpl as any },
+    });
+
+    expect(capturedEnv.CLAUDE_CODE_MAX_OUTPUT_TOKENS).toBe('4096');
+  });
+
+  it('omits CLAUDE_CODE_MAX_OUTPUT_TOKENS when maxTokens is unset', async () => {
+    let capturedEnv: Record<string, string | undefined> = {};
+    const spawnImpl = ((_cmd: string, _args: readonly string[], opts: any) => {
+      capturedEnv = opts?.env ?? {};
+      const child = createFakeChild();
+      setImmediate(() => {
+        child.finish([
+          JSON.stringify({
+            type: 'result',
+            subtype: 'success',
+            is_error: false,
+            result: 'ok',
+          }),
+        ]);
+      });
+      return child;
+    }) as FakeSpawn;
+
+    await callClaudeCodeCLI({
+      ...promptInput,
+      signal: new AbortController().signal,
+      transport: { spawnImpl: spawnImpl as any },
+    });
+
+    expect(capturedEnv.CLAUDE_CODE_MAX_OUTPUT_TOKENS).toBeUndefined();
   });
 
   it('returns null model + token counters when the CLI omits them', async () => {

--- a/apps/daemon/tests/finalize-claude-code.test.ts
+++ b/apps/daemon/tests/finalize-claude-code.test.ts
@@ -16,7 +16,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   callClaudeCodeCLI,
-  CLAUDE_CODE_BUILTIN_TOOLS,
+  CLAUDE_CODE_EMPTY_TOOL_ALLOWLIST,
   FinalizeClaudeCodeNotInstalledError,
   probeClaudeCodeCli,
 } from '../src/finalize-claude-code.js';
@@ -151,7 +151,7 @@ describe('callClaudeCodeCLI', () => {
     expect(capturedArgs).toContain('claude-opus-4-7');
   });
 
-  it('passes --disallowedTools listing every built-in tool so synthesis runs cannot touch the project cwd', async () => {
+  it('passes --allowedTools with an empty value so synthesis runs cannot launch any tool', async () => {
     let capturedArgs: readonly string[] = [];
     const spawnImpl = makeSpawn((_cmd, args) => {
       capturedArgs = args;
@@ -175,18 +175,15 @@ describe('callClaudeCodeCLI', () => {
       transport: { spawnImpl: spawnImpl as any },
     });
 
-    const flagIdx = capturedArgs.indexOf('--disallowedTools');
+    const flagIdx = capturedArgs.indexOf('--allowedTools');
     expect(flagIdx).toBeGreaterThanOrEqual(0);
-    const denyList = String(capturedArgs[flagIdx + 1] ?? '').split(/\s+/);
-    for (const tool of CLAUDE_CODE_BUILTIN_TOOLS) {
-      expect(denyList).toContain(tool);
-    }
-    // High-risk tools must be in the deny list specifically — these
-    // are the ones whose absence would let synthesis mutate the
-    // user's project from cwd.
-    for (const dangerous of ['Bash', 'Edit', 'Write', 'Read', 'WebFetch']) {
-      expect(denyList).toContain(dangerous);
-    }
+    expect(capturedArgs[flagIdx + 1]).toBe(CLAUDE_CODE_EMPTY_TOOL_ALLOWLIST);
+    expect(capturedArgs[flagIdx + 1]).toBe('');
+    // An empty allowlist is the contract: no enumerated denylist
+    // should be present, since the whole point of switching away from
+    // `--disallowedTools` is that hand-maintained denylists leak any
+    // tool we forget to name (installed built-ins, MCP tools, etc.).
+    expect(capturedArgs).not.toContain('--disallowedTools');
   });
 
   it('threads maxTokens into the child env as CLAUDE_CODE_MAX_OUTPUT_TOKENS', async () => {

--- a/apps/daemon/tests/finalize-design.test.ts
+++ b/apps/daemon/tests/finalize-design.test.ts
@@ -1124,4 +1124,53 @@ describe('runFinalizeWithSynthesizer (eager-release-on-abort)', () => {
 
     await expect(first).rejects.toThrow(/aborted/);
   });
+
+  it('does not write DESIGN.md when the signal aborted before phase-9, even if the synthesizer resolves late', async () => {
+    // Regression guard for the race noted by @mrcfps / Codex on
+    // PR #1279: with eager lock release, a synthesizer that settles
+    // *after* the abort fires must not overwrite a retry's output.
+    // The orchestrator checks `composedSignal.aborted` before the
+    // atomic rename and exits via AbortError instead.
+    const { db, projectsRoot, designSystemsRoot } = setupPipeline();
+    const designMdPath = path.join(projectsRoot, PROJECT_ID, 'DESIGN.md');
+    fs.writeFileSync(designMdPath, '# DESIGN.md\nretry-output\n', 'utf8');
+    const controller = new AbortController();
+
+    const pending = runFinalizeWithSynthesizer(
+      db,
+      projectsRoot,
+      designSystemsRoot,
+      PROJECT_ID,
+      { signal: controller.signal, timeoutMs: 60_000 },
+      // Synthesizer ignores the abort and resolves with stale output
+      // shortly after the caller cancels. Without the phase-9 guard
+      // this body would clobber the retry's DESIGN.md on disk.
+      ({ signal }) =>
+        new Promise((resolve) => {
+          signal.addEventListener(
+            'abort',
+            () => {
+              setTimeout(
+                () =>
+                  resolve({
+                    designMd: '# DESIGN.md\nstale-cancelled-output\n',
+                    inputTokens: 0,
+                    outputTokens: 0,
+                    model: null,
+                  }),
+                25,
+              );
+            },
+            { once: true },
+          );
+        }),
+    );
+
+    await new Promise((r) => setTimeout(r, 50));
+    controller.abort();
+
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    // Retry's DESIGN.md must survive untouched.
+    expect(fs.readFileSync(designMdPath, 'utf8')).toBe('# DESIGN.md\nretry-output\n');
+  });
 });

--- a/apps/daemon/tests/finalize-design.test.ts
+++ b/apps/daemon/tests/finalize-design.test.ts
@@ -30,6 +30,7 @@ import {
   FinalizePackageLockedError,
   FinalizeUpstreamError,
   resolveCurrentArtifact,
+  runFinalizeWithSynthesizer,
   truncateTranscriptForPrompt,
 } from '../src/finalize-design.js';
 
@@ -975,5 +976,152 @@ describe('isSafeId — path-traversal regression', () => {
     expect(isSafeId('818cf7a8-8399-4220-a507-07802d8842a8')).toBe(true);
     expect(isSafeId('a')).toBe(true);
     expect(isSafeId('a.b.c')).toBe(true); // mixed-content with dots is fine
+  });
+});
+
+describe('runFinalizeWithSynthesizer (eager-release-on-abort)', () => {
+  // Verifies the abort-listener path added for #963: when the
+  // caller's AbortSignal fires while the synthesizer is still
+  // running, the lockfile is released immediately so a retry that
+  // arrives before the synthesizer has wound down can take the
+  // lock. Without this, a Claude Code CLI subprocess that takes a
+  // second to exit after SIGTERM keeps the lock held and the user's
+  // retry gets 409 CONFLICT.
+  let tempDir: string;
+  const PROJECT_ID = 'eager-release-fixture';
+
+  afterEach(() => {
+    if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function setupPipeline() {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'od-eager-release-'));
+    const designSystemsRoot = path.join(tempDir, 'design-systems');
+    fs.mkdirSync(designSystemsRoot, { recursive: true });
+    const db = openDatabase(tempDir);
+    insertProject(db, {
+      id: PROJECT_ID,
+      name: 'p',
+      designSystemId: null,
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    const projectsRoot = path.join(tempDir, 'projects');
+    fs.mkdirSync(path.join(projectsRoot, PROJECT_ID), { recursive: true });
+    insertConversation(db, {
+      id: 'c1',
+      projectId: PROJECT_ID,
+      title: 't',
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    upsertMessage(db, 'c1', {
+      id: 'm1',
+      role: 'user',
+      content: '',
+      events: [{ kind: 'text', text: 'hi' }],
+    });
+    return { db, projectsRoot, designSystemsRoot };
+  }
+
+  it('releases the lockfile the moment the signal aborts, without waiting for the synthesizer to settle', async () => {
+    const { db, projectsRoot, designSystemsRoot } = setupPipeline();
+    const lockPath = path.join(projectsRoot, PROJECT_ID, '.finalize.lock');
+    const controller = new AbortController();
+
+    // Synthesizer that never resolves on its own — only the abort
+    // listener can break the call. We assert the lock disappears
+    // BEFORE we let the synthesizer reject, proving the eager
+    // release runs without waiting for the upstream to wind down.
+    let lockGoneWhenAborted = false;
+    const pending = runFinalizeWithSynthesizer(
+      db,
+      projectsRoot,
+      designSystemsRoot,
+      PROJECT_ID,
+      { signal: controller.signal, timeoutMs: 60_000 },
+      ({ signal }) =>
+        new Promise((_resolve, reject) => {
+          signal.addEventListener(
+            'abort',
+            () => {
+              // Snapshot lock state at the exact moment the inner
+              // synthesizer sees the abort. The eager-release
+              // listener is registered earlier, so it should have
+              // already fired by now.
+              lockGoneWhenAborted = !fs.existsSync(lockPath);
+              const err = new Error('aborted');
+              err.name = 'AbortError';
+              reject(err);
+            },
+            { once: true },
+          );
+        }),
+    );
+
+    // Wait until the orchestrator has reached the synthesizer
+    // (lock + listener registered + composed signal handed off).
+    await new Promise((r) => setTimeout(r, 50));
+    expect(fs.existsSync(lockPath)).toBe(true);
+
+    controller.abort();
+    await expect(pending).rejects.toThrow(/aborted/);
+    expect(lockGoneWhenAborted).toBe(true);
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
+  it('allows a second finalize to take the lock immediately after the first is aborted', async () => {
+    const { db, projectsRoot, designSystemsRoot } = setupPipeline();
+    const lockPath = path.join(projectsRoot, PROJECT_ID, '.finalize.lock');
+    const controller = new AbortController();
+
+    const first = runFinalizeWithSynthesizer(
+      db,
+      projectsRoot,
+      designSystemsRoot,
+      PROJECT_ID,
+      { signal: controller.signal, timeoutMs: 60_000 },
+      ({ signal }) =>
+        new Promise<never>((_resolve, reject) => {
+          signal.addEventListener('abort', () => {
+            // Simulate a CLI subprocess that lingers for 100 ms
+            // after SIGTERM — long enough that a retry attempted in
+            // that window would observe the lockfile if the
+            // orchestrator waited for the synthesizer to settle.
+            setTimeout(() => {
+              const err = new Error('aborted');
+              err.name = 'AbortError';
+              reject(err);
+            }, 100);
+          });
+        }),
+    );
+
+    await new Promise((r) => setTimeout(r, 50));
+    controller.abort();
+    // Lock should be gone the instant abort fires, before the
+    // synthesizer settles.
+    expect(fs.existsSync(lockPath)).toBe(false);
+
+    // A retry can take the lock immediately and complete normally.
+    const second = await runFinalizeWithSynthesizer(
+      db,
+      projectsRoot,
+      designSystemsRoot,
+      PROJECT_ID,
+      { timeoutMs: 60_000 },
+      async () => ({
+        designMd: '# DESIGN.md\nretry-ok\n',
+        inputTokens: 0,
+        outputTokens: 0,
+        model: null,
+      }),
+    );
+    expect(second.bytesWritten).toBeGreaterThan(0);
+    expect(fs.readFileSync(second.designMdPath, 'utf8')).toBe(
+      '# DESIGN.md\nretry-ok\n',
+    );
+
+    await expect(first).rejects.toThrow(/aborted/);
   });
 });

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1958,12 +1958,27 @@ export function ProjectView({
   // shortcut wiring. Close to the JSX so the data flow is easy to
   // trace from the toolbar back to its sources.
   const handleFinalize = useCallback(() => {
-    void finalize.trigger({
-      apiKey: config.apiKey,
-      baseUrl: config.baseUrl,
-      model: config.model,
-      maxTokens: effectiveMaxTokens(config),
-    }).then((result) => {
+    // Route to the Claude Code CLI sibling endpoint (#963) when the
+    // user has the local Claude Code agent selected; this inherits
+    // their Max plan subscription so they do not pay per-token API
+    // costs on top. Every other configuration (BYOK API mode, or
+    // daemon mode with a non-claude agent) falls through to the
+    // Anthropic API route (#832), which still requires a BYOK key.
+    const useClaudeCode = config.mode === 'daemon' && config.agentId === 'claude';
+    const trigger = useClaudeCode
+      ? finalize.trigger({
+          provider: 'claude-code',
+          model: config.model,
+          maxTokens: effectiveMaxTokens(config),
+        })
+      : finalize.trigger({
+          provider: 'anthropic',
+          apiKey: config.apiKey,
+          baseUrl: config.baseUrl,
+          model: config.model,
+          maxTokens: effectiveMaxTokens(config),
+        });
+    void trigger.then((result) => {
       if (result) void designMdState.refresh();
     });
   }, [finalize, config, designMdState]);

--- a/apps/web/src/hooks/useFinalizeProject.ts
+++ b/apps/web/src/hooks/useFinalizeProject.ts
@@ -1,4 +1,4 @@
-// Wraps POST /api/projects/:id/finalize/anthropic for the Finalize
+// Wraps POST /api/projects/:id/finalize/<provider> for the Finalize
 // design package button (#451). The daemon route runs synchronously for
 // 60–120 s, so the hook owns:
 //   - request lifecycle (idle / pending / success / error)
@@ -8,20 +8,40 @@
 //     response is non-OK, body.error.{code,message,details} is the
 //     authoritative payload. The mapping table below produces the
 //     user-facing toast string for each `code`. `details`, when present,
-//     is rendered as a secondary toast line so the upstream Anthropic
-//     reason (e.g. account usage cap) is visible to the user instead of
-//     just the daemon's category label (#450 verification commitment).
+//     is rendered as a secondary toast line so the upstream provider's
+//     reason (e.g. account usage cap, missing CLI login) is visible to
+//     the user instead of just the daemon's category label.
+//
+// The hook is provider-aware via a tagged request union. `anthropic`
+// hits the BYOK API route (#832); `claude-code` hits the local CLI
+// route (#963) which Max plan subscribers prefer because it inherits
+// their subscription's subsidized billing. The caller chooses which
+// based on the user's AppConfig (mode + agentId) — the hook does not
+// pick a default of its own.
 
 import { useCallback, useRef, useState } from 'react';
 import type {
   ApiErrorCode,
   FinalizeAnthropicRequest,
   FinalizeAnthropicResponse,
+  FinalizeClaudeCodeRequest,
+  FinalizeClaudeCodeResponse,
 } from '@open-design/contracts';
 
-// 130 000 ms = daemon timeout (120 s) + 10 s buffer so the daemon's
-// own retry/timeout layer always wins under normal failure modes.
-const FETCH_TIMEOUT_MS = 130_000;
+// Per-provider client-side fetch ceiling. Each value is the daemon's
+// own upstream-call ceiling for that provider plus a small buffer so
+// the daemon's status-aware error mapping always wins under normal
+// failure modes (the client only times out when the daemon has gone
+// silent past its own ceiling, which signals a real disconnect rather
+// than a slow upstream).
+//   - anthropic:   daemon 120 s + 10 s buffer
+//   - claude-code: daemon 600 s + 30 s buffer (CLI synthesis is
+//                  meaningfully slower than a direct API call —
+//                  subprocess overhead, streaming, internal retries)
+const FETCH_TIMEOUT_BY_PROVIDER: Record<FinalizeProvider, number> = {
+  anthropic: 130_000,
+  'claude-code': 630_000,
+};
 
 export type FinalizeStatus = 'idle' | 'pending' | 'success' | 'error';
 
@@ -31,11 +51,32 @@ export interface FinalizeError {
   details: string | null;
 }
 
+export type FinalizeProvider = 'anthropic' | 'claude-code';
+
+/**
+ * Tagged-union request type. The discriminant selects the daemon
+ * route; the rest of the body is sent verbatim per the route's
+ * contract (anthropic: BYOK API key + model; claude-code: optional
+ * model only, CLI handles auth).
+ */
+export type FinalizeRequest =
+  | ({ provider: 'anthropic' } & FinalizeAnthropicRequest)
+  | ({ provider: 'claude-code' } & FinalizeClaudeCodeRequest);
+
+/**
+ * Provider-agnostic success response. The Anthropic route's fields
+ * are a strict subset of the Claude Code route's (the latter
+ * widens model/inputTokens/outputTokens to nullable), so this
+ * widened shape is safe to use for both. UI consumers that read
+ * token counts must accept nullable.
+ */
+export type FinalizeResponse = FinalizeClaudeCodeResponse;
+
 export interface FinalizeProjectState {
   status: FinalizeStatus;
   error: FinalizeError | null;
-  result: FinalizeAnthropicResponse | null;
-  trigger: (req: FinalizeAnthropicRequest) => Promise<FinalizeAnthropicResponse | null>;
+  result: FinalizeResponse | null;
+  trigger: (req: FinalizeRequest) => Promise<FinalizeResponse | null>;
   cancel: () => void;
 }
 
@@ -50,7 +91,7 @@ interface DaemonErrorEnvelope {
 export function useFinalizeProject(projectId: string): FinalizeProjectState {
   const [status, setStatus] = useState<FinalizeStatus>('idle');
   const [error, setError] = useState<FinalizeError | null>(null);
-  const [result, setResult] = useState<FinalizeAnthropicResponse | null>(null);
+  const [result, setResult] = useState<FinalizeResponse | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   // Tracks whether the in-flight controller's abort came from the
   // 130 s timeout (true) or the user clicking Cancel (false). The
@@ -63,7 +104,7 @@ export function useFinalizeProject(projectId: string): FinalizeProjectState {
   }, []);
 
   const trigger = useCallback(
-    async (req: FinalizeAnthropicRequest): Promise<FinalizeAnthropicResponse | null> => {
+    async (req: FinalizeRequest): Promise<FinalizeResponse | null> => {
       // Cancel any in-flight call before starting a new one so a
       // double-clicked button doesn't pile up two daemon requests.
       abortRef.current?.abort();
@@ -73,7 +114,7 @@ export function useFinalizeProject(projectId: string): FinalizeProjectState {
       const timeoutId = setTimeout(() => {
         timedOutRef.current = true;
         controller.abort();
-      }, FETCH_TIMEOUT_MS);
+      }, FETCH_TIMEOUT_BY_PROVIDER[req.provider]);
 
       setStatus('pending');
       setError(null);
@@ -88,12 +129,13 @@ export function useFinalizeProject(projectId: string): FinalizeProjectState {
       const isCurrent = () => abortRef.current === controller;
 
       try {
+        const { provider, ...payload } = req;
         const resp = await fetch(
-          `/api/projects/${encodeURIComponent(projectId)}/finalize/anthropic`,
+          `/api/projects/${encodeURIComponent(projectId)}/finalize/${provider}`,
           {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(req),
+            body: JSON.stringify(payload),
             signal: controller.signal,
           },
         );
@@ -106,7 +148,7 @@ export function useFinalizeProject(projectId: string): FinalizeProjectState {
           const details = typeof detailsRaw === 'string' ? detailsRaw : null;
           const finalizeError: FinalizeError = {
             code: code as FinalizeError['code'],
-            message: messageForCode(code as ApiErrorCode),
+            message: messageForCode(code as ApiErrorCode, req.provider),
             details,
           };
           setError(finalizeError);
@@ -114,7 +156,11 @@ export function useFinalizeProject(projectId: string): FinalizeProjectState {
           return null;
         }
 
-        const body = (await resp.json()) as FinalizeAnthropicResponse;
+        const raw = (await resp.json()) as FinalizeAnthropicResponse | FinalizeClaudeCodeResponse;
+        // Widen the Anthropic response (concrete model + tokens) to
+        // the union shape stored in state. The fields are guaranteed
+        // populated for the Anthropic route, so the cast is safe.
+        const body: FinalizeResponse = raw as FinalizeResponse;
         if (!isCurrent()) return null;
         setResult(body);
         setStatus('success');
@@ -131,7 +177,7 @@ export function useFinalizeProject(projectId: string): FinalizeProjectState {
             // synthesis, so the message names that explicitly.
             const finalizeError: FinalizeError = {
               code: 'TIMEOUT',
-              message: messageForCode('TIMEOUT'),
+              message: messageForCode('TIMEOUT', req.provider),
               details: null,
             };
             setError(finalizeError);
@@ -145,7 +191,7 @@ export function useFinalizeProject(projectId: string): FinalizeProjectState {
         }
         const finalizeError: FinalizeError = {
           code: 'NETWORK_ERROR',
-          message: messageForCode('NETWORK_ERROR'),
+          message: messageForCode('NETWORK_ERROR', req.provider),
           details: err instanceof Error ? err.message : String(err),
         };
         setError(finalizeError);
@@ -164,19 +210,32 @@ export function useFinalizeProject(projectId: string): FinalizeProjectState {
 
 // User-facing toast strings for each daemon error code. The unknown /
 // network branch covers transport errors and codes the daemon adds in
-// future without crashing the UI.
-export function messageForCode(code: ApiErrorCode | 'NETWORK_ERROR' | string): string {
+// future without crashing the UI. `provider` tailors three codes whose
+// remediation differs by route (UNAUTHORIZED, RATE_LIMITED,
+// UPSTREAM_UNAVAILABLE); the rest are provider-neutral.
+export function messageForCode(
+  code: ApiErrorCode | 'NETWORK_ERROR' | string,
+  provider: FinalizeProvider = 'anthropic',
+): string {
   switch (code) {
     case 'BAD_REQUEST':
-      return 'Bad request — check the API key and model.';
+      return provider === 'claude-code'
+        ? 'Bad request — check the model name.'
+        : 'Bad request — check the API key and model.';
     case 'UNAUTHORIZED':
-      return 'API key was rejected. Check it in Settings.';
+      return provider === 'claude-code'
+        ? 'Claude Code CLI is not signed in. Run `claude /login` in a terminal.'
+        : 'API key was rejected. Check it in Settings.';
     case 'FORBIDDEN':
       return 'Access denied by the upstream API.';
     case 'RATE_LIMITED':
-      return 'Anthropic rate-limited the request. Try again in a minute.';
+      return provider === 'claude-code'
+        ? 'Claude Code rate-limited the request. Try again in a minute.'
+        : 'Anthropic rate-limited the request. Try again in a minute.';
     case 'UPSTREAM_UNAVAILABLE':
-      return 'The Anthropic API is unavailable right now.';
+      return provider === 'claude-code'
+        ? 'Claude Code CLI is unavailable. Make sure `claude` is installed and on PATH.'
+        : 'The Anthropic API is unavailable right now.';
     case 'CONFLICT':
       return 'Another finalize is in progress for this project.';
     case 'PROJECT_NOT_FOUND':

--- a/apps/web/src/hooks/useFinalizeProject.ts
+++ b/apps/web/src/hooks/useFinalizeProject.ts
@@ -243,7 +243,9 @@ export function messageForCode(
     case 'INTERNAL_ERROR':
       return 'Something went wrong while finalizing. Check the daemon logs.';
     case 'TIMEOUT':
-      return 'Finalize timed out after 130 s. The daemon may still be running.';
+      return provider === 'claude-code'
+        ? 'Finalize timed out after 630 s. The daemon may still be running.'
+        : 'Finalize timed out after 130 s. The daemon may still be running.';
     case 'NETWORK_ERROR':
     default:
       return "Couldn't reach the daemon. Make sure it's running.";

--- a/apps/web/tests/hooks/useFinalizeProject.test.tsx
+++ b/apps/web/tests/hooks/useFinalizeProject.test.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../src/hooks/useFinalizeProject';
 
 const REQUEST = {
+  provider: 'anthropic' as const,
   apiKey: 'sk-test',
   baseUrl: 'https://api.anthropic.com',
   model: 'claude-opus-4-7',
@@ -56,11 +57,57 @@ describe('useFinalizeProject', () => {
     const [url, init] = fetchSpy.mock.calls[0]!;
     expect(url).toBe('/api/projects/p1/finalize/anthropic');
     const sent = JSON.parse((init as RequestInit).body as string);
-    expect(sent).toEqual(REQUEST);
+    // The `provider` discriminant selects the URL and is stripped
+    // from the body before POST so the daemon's request DTO stays
+    // free of UI-internal routing fields.
+    const { provider: _provider, ...expectedBody } = REQUEST;
+    expect(sent).toEqual(expectedBody);
     expect((init as RequestInit).method).toBe('POST');
     expect((init as RequestInit).headers).toMatchObject({
       'Content-Type': 'application/json',
     });
+  });
+
+  it('routes the claude-code provider to /finalize/claude-code without sending an apiKey', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(jsonResponse(SUCCESS_BODY));
+    const { result } = renderHook(() => useFinalizeProject('p1'));
+
+    await act(async () => {
+      await result.current.trigger({
+        provider: 'claude-code',
+        model: 'claude-opus-4-7',
+        maxTokens: 8192,
+      });
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe('/api/projects/p1/finalize/claude-code');
+    const sent = JSON.parse((init as RequestInit).body as string);
+    expect(sent).toEqual({ model: 'claude-opus-4-7', maxTokens: 8192 });
+    // The CLI route never receives an apiKey — its auth is the
+    // user's existing `claude /login` session.
+    expect(sent).not.toHaveProperty('apiKey');
+  });
+
+  it('emits a CLI-tailored UNAUTHORIZED message when /claude-code returns 401', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse(
+        { error: { code: 'UNAUTHORIZED', message: 'not signed in' } },
+        401,
+      ),
+    );
+    const { result } = renderHook(() => useFinalizeProject('p1'));
+
+    await act(async () => {
+      await result.current.trigger({ provider: 'claude-code' });
+    });
+
+    await waitFor(() => expect(result.current.status).toBe('error'));
+    expect(result.current.error?.code).toBe('UNAUTHORIZED');
+    expect(result.current.error?.message).toMatch(/claude \/login/i);
   });
 
   const ERROR_TABLE: Array<{ code: string; expected: string }> = [

--- a/packages/contracts/src/api/finalize.ts
+++ b/packages/contracts/src/api/finalize.ts
@@ -55,3 +55,38 @@ export interface FinalizeAnthropicResponse {
   transcriptMessageCount: number;
   designSystemId: string | null;
 }
+
+/**
+ * Request body for `POST /api/projects/:id/finalize/claude-code`.
+ *
+ * Auth is delegated to the user's existing Claude Code CLI login
+ * (`claude /login`) so Max plan subscribers do not pay per-token
+ * BYOK API costs for synthesis. Consequently there is no `apiKey`
+ * field. `model` is optional — when omitted, the daemon lets the
+ * CLI pick its configured default.
+ */
+export interface FinalizeClaudeCodeRequest {
+  model?: string;
+  maxTokens?: number;
+}
+
+/**
+ * Response body for `/finalize/claude-code`. Mirrors
+ * `FinalizeAnthropicResponse` except:
+ *   - `model` is nullable: when the request omits `model` and the
+ *     CLI's stream-json result event doesn't surface the model it
+ *     used, the daemon returns `null` rather than guessing.
+ *   - `inputTokens` / `outputTokens` are nullable: the CLI surfaces
+ *     usage in its final `result` event when available, but the
+ *     daemon does not synthesize counts when it isn't.
+ */
+export interface FinalizeClaudeCodeResponse {
+  designMdPath: string;
+  bytesWritten: number;
+  model: string | null;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  artifact: FinalizeArtifactRef | null;
+  transcriptMessageCount: number;
+  designSystemId: string | null;
+}


### PR DESCRIPTION
## Summary
- Adds a second finalize path at POST /api/projects/:id/finalize/claude-code alongside the existing Anthropic BYOK route, so users with a Claude Code CLI login (Max plan, OAuth) can synthesize DESIGN.md without paying per-token API costs. Auth is delegated to the local CLI — no apiKey field on the request.

Refactors finalize-design.ts to make synthesis pluggable: shared orchestration owns lockfile, prompt assembly, abort/timeout composition, and atomic write; provider adapters only turn prompts into Markdown. The Anthropic path is preserved as one adapter; the new finalize-claude-code.ts is the second.

Error mapping mirrors the Anthropic route (409 lock, 401/429/502 upstream, AbortError → 503), plus a dedicated
FinalizeClaudeCodeNotInstalledError surfaced as 503 UPSTREAM_UNAVAILABLE since the contracts ApiErrorCode union has no NOT_INSTALLED code.

Web hook and ProjectView gain a provider toggle; tests cover both the unit synthesis path and the route's error mapping.

## Validation
-

Fixes #963 
