### PR TITLE
fix(tools-pr): chunk stats fetch through cursor-paginated GraphQL

### DIFF
--- a/tools/pr/src/gh.ts
+++ b/tools/pr/src/gh.ts
@@ -193,6 +193,29 @@ async function fetchPaginatedPrList<N>(nodeFields: string): Promise<N[]> {
  * the other heavy chunks (reviews, comments, assignment timelines).
  */
 
+/**
+ * Per-PR merge/diff stats — `additions`, `mergeStateStatus`, etc. `gh pr
+ * list --json mergeStateStatus,...` 502s once the requested page is
+ * above ~60 because the gateway has to recompute merge state for every
+ * PR up front. Cursor-paginated GraphQL at PR_LIST_PAGE_SIZE keeps each
+ * round trip well within the budget and consistent with how the other
+ * heavy chunks (reviews, comments, commits, assignment timelines) are
+ * fetched.
+ */
+async function fetchOpenPrStats(): Promise<GhStats[]> {
+  return fetchPaginatedPrList<GhStats>(
+    `number
+     additions
+     deletions
+     changedFiles
+     headRefName
+     headRefOid
+     baseRefName
+     mergeable
+     mergeStateStatus`,
+  );
+}
+
 async function fetchOpenPrReviews(): Promise<GhReviewsLite[]> {
   type Node = {
     number: number;
@@ -424,11 +447,7 @@ export async function fetchOpenPrs(
     "--json",
     "number,title,author,createdAt,updatedAt,isDraft,reviewDecision,labels,maintainerCanModify,assignees",
   ]);
-  const statsPromise = gh<GhStats[]>([
-    ...baseArgs,
-    "--json",
-    "number,additions,deletions,changedFiles,headRefName,headRefOid,baseRefName,mergeable,mergeStateStatus",
-  ]);
+  const statsPromise = fetchOpenPrStats();
   const filesPromise = gh<GhFiles[]>([...baseArgs, "--json", "number,files"]);
   const reviewsPromise = fetchOpenPrReviews();
   const commitsPromise = options.includeCommits


### PR DESCRIPTION
Fixes a regression introduced by #1259's `--limit 1000` default.

## Summary

`fetchOpenPrs` was reading the stats chunk via `gh pr list --limit 1000 --json mergeStateStatus,...`. On the live 107-PR queue this 502s reliably, because GitHub's GraphQL gateway has to recompute merge state for every PR up front and the resulting query exceeds the gateway budget once the requested page passes ~60 PRs.

Switch the stats chunk to `fetchPaginatedPrList`, the same cursor-paginated GraphQL helper already used for reviews, comments, commits, and assignment timelines. Page size stays at `PR_LIST_PAGE_SIZE` (30), well within the gateway budget; the stats fetch is now consistent with the other heavy chunks.

## Details

- New `fetchOpenPrStats()` in `tools/pr/src/gh.ts` returns `GhStats[]` via `fetchPaginatedPrList` using the same field set as before (`number, additions, deletions, changedFiles, headRefName, headRefOid, baseRefName, mergeable, mergeStateStatus`).
- `fetchOpenPrs` swaps its `gh<GhStats[]>(...)` call for `fetchOpenPrStats()`. No behavior change to consumers — the resulting `GhStats[]` shape is identical.

## Validation

- `pnpm --filter @open-design/tools-pr typecheck`
- `pnpm --filter @open-design/tools-pr build`
- `pnpm tools-pr list` against the live 107-PR queue — completes without a 502 (reproduces the failure on `main` head `8c0fb8dc`)