### PR TITLE
fix(daemon/acp): terminate ACP child after clean prompt completion

### DIFF
--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -621,6 +621,19 @@ export function attachAcpSession({
       finished = true;
       clearStageTimer();
       stdin.end();
+      // Some ACP agents (e.g. Devin for Terminal) keep the child process
+      // alive after stdin closes, waiting for the next prompt. Each Open
+      // Design run spawns its own agent process per turn, so the child must
+      // terminate for `child.on('close')` to fire and the chat run to
+      // finalize — otherwise the chat stays stuck in the "working" state.
+      // Give the child a short grace period to exit on its own first; if it
+      // doesn't, SIGTERM forces it. This mirrors the pattern in
+      // detectAcpModels() which already kills the child after a clean
+      // model-discovery probe completes (see line ~270 in this file).
+      const cleanExitTimer = setTimeout(() => {
+        if (!child.killed) child.kill('SIGTERM');
+      }, 500);
+      child.once('close', () => clearTimeout(cleanExitTimer));
       return;
     }
     if (sessionId && model && model !== 'default' && obj.id === expectedId) {
@@ -647,6 +660,13 @@ export function attachAcpSession({
   return {
     hasFatalError() {
       return fatal;
+    },
+    completedSuccessfully() {
+      // Returns true when the prompt request resolved without a fatal error
+      // and was not aborted. The chat consumer treats this as a successful
+      // run even if the child process subsequently exited via SIGTERM
+      // (which is expected for agents that don't shut down on stdin.end()).
+      return finished && !fatal && !aborted;
     },
     abort() {
       if (aborted || finished) return;

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -851,7 +851,10 @@ export function createAgentSink(): AgentSink {
 
 interface AgentSpawnHandle {
   child: ReturnType<typeof spawn>;
-  acpSession?: { hasFatalError?: () => boolean } | null;
+  acpSession?: {
+    hasFatalError?: () => boolean;
+    completedSuccessfully?: () => boolean;
+  } | null;
 }
 
 function attachAgentStreamHandlers(
@@ -863,7 +866,10 @@ function attachAgentStreamHandlers(
   send: (event: string, payload: unknown) => void,
   appendRawStdout?: (chunk: string) => void,
 ): AgentSpawnHandle {
-  let acpSession: { hasFatalError?: () => boolean } | null = null;
+  let acpSession: {
+    hasFatalError?: () => boolean;
+    completedSuccessfully?: () => boolean;
+  } | null = null;
   child.stdout?.setEncoding('utf8');
   child.stderr?.setEncoding('utf8');
   if (def.streamFormat === 'claude-stream-json') {
@@ -1152,7 +1158,17 @@ async function testAgentConnectionInternal(
 
       const latencyMs = Date.now() - start;
       const buffered = sink.getText().trim();
-      const exitedCleanly = winner.code === 0 && !winner.signal;
+      // ACP agents that don't shut down on stdin.end() (e.g. Devin for
+      // Terminal) are now SIGTERM'd from attachAcpSession after a clean
+      // prompt completion, which sets `winner.signal === 'SIGTERM'`. For
+      // those runs we trust the ACP-level success signal so connection
+      // tests don't report `agent_spawn_failed` despite a healthy
+      // assistant response (see #1265 / #1286).
+      const acpCleanCompletion =
+        typeof acpSession?.completedSuccessfully === 'function' &&
+        acpSession.completedSuccessfully();
+      const exitedCleanly =
+        (winner.code === 0 && !winner.signal) || acpCleanCompletion;
       if (buffered) {
         const rawSample = truncateSample(buffered);
         if (rawSample && isLikelyModelErrorText(rawSample)) {

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -1161,14 +1161,25 @@ async function testAgentConnectionInternal(
       // ACP agents that don't shut down on stdin.end() (e.g. Devin for
       // Terminal) are now SIGTERM'd from attachAcpSession after a clean
       // prompt completion, which sets `winner.signal === 'SIGTERM'`. For
-      // those runs we trust the ACP-level success signal so connection
-      // tests don't report `agent_spawn_failed` despite a healthy
-      // assistant response (see #1265 / #1286).
+      // that exact forced-shutdown shape we trust the ACP-level success
+      // signal so connection tests don't report `agent_spawn_failed`
+      // despite a healthy assistant response (see #1265 / #1286).
+      //
+      // Scope the override narrowly: only `code === null` AND
+      // `signal === 'SIGTERM'` AND `acpCleanCompletion` count as a clean
+      // forced shutdown. Any other post-response process failure (non-zero
+      // exit code, SIGKILL, SIGSEGV, etc.) still falls through to
+      // `agent_spawn_failed`, preserving the existing connection-test
+      // failure behavior for genuine post-response problems.
       const acpCleanCompletion =
         typeof acpSession?.completedSuccessfully === 'function' &&
         acpSession.completedSuccessfully();
+      const acpForcedShutdown =
+        winner.code === null &&
+        winner.signal === 'SIGTERM' &&
+        acpCleanCompletion;
       const exitedCleanly =
-        (winner.code === 0 && !winner.signal) || acpCleanCompletion;
+        (winner.code === 0 && !winner.signal) || acpForcedShutdown;
       if (buffered) {
         const rawSample = truncateSample(buffered);
         if (rawSample && isLikelyModelErrorText(rawSample)) {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -4153,17 +4153,25 @@ export async function startServer({
       }
       // ACP agents that don't shut down on stdin.end() (e.g. Devin for
       // Terminal) are forced to exit via SIGTERM from attachAcpSession after
-      // a clean prompt completion. Without this check, the chat run would be
-      // marked `failed` because `code === 0` fails (code is null on a signal
-      // exit). `completedSuccessfully()` reports whether the ACP session
-      // resolved without a fatal error or abort, so we treat that as success
-      // even when the underlying process exit was signal-driven.
+      // a clean prompt completion. Without an override, the chat run would
+      // be marked `failed` because `code === 0` fails (code is null on a
+      // signal exit). `completedSuccessfully()` reports whether the ACP
+      // session resolved without a fatal error or abort.
+      //
+      // Scope the override narrowly to the exact forced-shutdown shape this
+      // PR introduces: code is null AND signal is SIGTERM AND the ACP
+      // session reported clean completion. Any other post-response failure
+      // (non-zero exit code, SIGKILL, SIGSEGV, etc.) still propagates as
+      // `failed`, preserving the existing close-status behavior for genuine
+      // post-response process problems.
       const acpCleanCompletion =
         typeof acpSession?.completedSuccessfully === 'function' &&
         acpSession.completedSuccessfully();
+      const acpForcedShutdown =
+        code === null && signal === 'SIGTERM' && acpCleanCompletion;
       const status = run.cancelRequested
         ? 'canceled'
-        : code === 0 || acpCleanCompletion
+        : code === 0 || acpForcedShutdown
           ? 'succeeded'
           : 'failed';
       if (status === 'failed') {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -4151,9 +4151,19 @@ export async function startServer({
         ));
         return design.runs.finish(run, 'failed', code, signal);
       }
+      // ACP agents that don't shut down on stdin.end() (e.g. Devin for
+      // Terminal) are forced to exit via SIGTERM from attachAcpSession after
+      // a clean prompt completion. Without this check, the chat run would be
+      // marked `failed` because `code === 0` fails (code is null on a signal
+      // exit). `completedSuccessfully()` reports whether the ACP session
+      // resolved without a fatal error or abort, so we treat that as success
+      // even when the underlying process exit was signal-driven.
+      const acpCleanCompletion =
+        typeof acpSession?.completedSuccessfully === 'function' &&
+        acpSession.completedSuccessfully();
       const status = run.cancelRequested
         ? 'canceled'
-        : code === 0
+        : code === 0 || acpCleanCompletion
           ? 'succeeded'
           : 'failed';
       if (status === 'failed') {

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
 import { PassThrough } from 'node:stream';
 import path from 'node:path';
-import { test } from 'vitest';
+import { test, vi } from 'vitest';
 import { attachAcpSession, buildAcpSessionNewParams, normalizeModels } from '../src/acp.js';
 
 const DEFAULT_MODEL_OPTION = { id: 'default', label: 'Default (CLI config)' };
@@ -252,6 +252,101 @@ function agentModelStatuses(events: Array<{ event: string; payload: unknown }>):
     })
     .map((entry) => (entry.payload as { model?: unknown }).model);
 }
+
+test('attachAcpSession force-terminates the child after a clean prompt completion if it does not exit on stdin.end()', async () => {
+  vi.useFakeTimers();
+  try {
+    const child = new FakeAcpChild();
+
+    const session = attachAcpSession({
+      child: child as never,
+      prompt: 'hello',
+      cwd: '/tmp/od-project',
+      model: null,
+      mcpServers: [],
+      send: () => {},
+    });
+
+    // Drive the protocol through to a clean prompt completion.
+    child.stdout.write(`${JSON.stringify({ id: 1, result: {} })}\n`);
+    child.stdout.write(`${JSON.stringify({ id: 2, result: { sessionId: 'session-1' } })}\n`);
+    child.stdout.write(`${JSON.stringify({ id: 3, result: { usage: { inputTokens: 1, outputTokens: 2 } } })}\n`);
+
+    // Child has not exited yet (simulates Devin for Terminal keeping the
+    // process alive past stdin.end()).
+    assert.equal(child.killed, false);
+
+    // After the grace period elapses, attachAcpSession should SIGTERM the
+    // child so child.on('close') can fire and the chat run can finalize.
+    await vi.advanceTimersByTimeAsync(500);
+    assert.equal(child.killed, true);
+
+    // The session reports the prompt completed successfully so the consumer
+    // can mark the run as 'succeeded' even though the underlying exit was
+    // signal-driven.
+    assert.equal(session.completedSuccessfully(), true);
+    assert.equal(session.hasFatalError(), false);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test('attachAcpSession does not double-kill a child that exits cleanly on stdin.end()', async () => {
+  vi.useFakeTimers();
+  try {
+    const child = new FakeAcpChild();
+
+    attachAcpSession({
+      child: child as never,
+      prompt: 'hello',
+      cwd: '/tmp/od-project',
+      model: null,
+      mcpServers: [],
+      send: () => {},
+    });
+
+    child.stdout.write(`${JSON.stringify({ id: 1, result: {} })}\n`);
+    child.stdout.write(`${JSON.stringify({ id: 2, result: { sessionId: 'session-1' } })}\n`);
+    child.stdout.write(`${JSON.stringify({ id: 3, result: {} })}\n`);
+
+    // Well-behaved agent exits on its own before the grace period elapses.
+    child.emit('close', 0, null);
+    assert.equal(child.killed, false);
+
+    // The grace-period timer should have been cleared by the close handler,
+    // so advancing time should not trigger a SIGTERM on the now-closed child.
+    await vi.advanceTimersByTimeAsync(2_000);
+    assert.equal(child.killed, false);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test('attachAcpSession.completedSuccessfully reflects abort and fatal-error states', () => {
+  const child = new FakeAcpChild();
+
+  const session = attachAcpSession({
+    child: child as never,
+    prompt: 'hello',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: () => {},
+  });
+
+  // Before any protocol traffic the session is not yet complete.
+  assert.equal(session.completedSuccessfully(), false);
+
+  // Drive through session creation, then abort before the prompt completes.
+  child.stdout.write(`${JSON.stringify({ id: 1, result: {} })}\n`);
+  child.stdout.write(`${JSON.stringify({ id: 2, result: { sessionId: 'session-1' } })}\n`);
+  session.abort();
+
+  // Aborted runs are not "successful completions" even though `finished` is
+  // set internally — the consumer should treat them as canceled, not
+  // succeeded.
+  assert.equal(session.completedSuccessfully(), false);
+});
 
 class FakeAcpChild extends EventEmitter {
   stdin = new PassThrough();

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -453,7 +453,19 @@ async function consumeDaemonRun({
 
     if (endStatus === 'canceled') return;
 
-    if (endStatus === 'failed' || exitSignal || (exitCode !== null && exitCode !== 0)) {
+    // Trust the server's authoritative `endStatus`. When the server reports
+    // `succeeded`, the run completed cleanly even if the underlying process
+    // exited via a signal — some agents (e.g. ACP agents like Devin for
+    // Terminal) intentionally exit via SIGTERM after a clean prompt
+    // completion because they don't shut down on stdin.end(). The
+    // signal/non-zero-code safety net only applies when the server hasn't
+    // explicitly declared success, so we never surface a fake error on a
+    // run the server already marked successful.
+    const looksLikeFailure =
+      endStatus === 'failed' ||
+      (endStatus !== 'succeeded' &&
+        (exitSignal || (exitCode !== null && exitCode !== 0)));
+    if (looksLikeFailure) {
       const tail = stderrBuf.trim().slice(-400);
       handlers.onError(
         new Error(`agent exited with ${exitSignal ? `signal ${exitSignal}` : `code ${exitCode}`}${tail ? `\n${tail}` : ''}`),

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -322,6 +322,15 @@ async function consumeDaemonRun({
   let exitCode: number | null = null;
   let exitSignal: string | null = null;
   let endStatus: ChatRunStatus | null = null;
+  // Tracks whether the server explicitly declared `status: 'succeeded'` in
+  // the SSE end payload (or via the fallback run-status fetch). Distinct
+  // from `endStatus === 'succeeded'`, which can be a local fallback when
+  // the SSE end event omits or sends an invalid `status` field. Only the
+  // explicit declaration is allowed to bypass the exit-code/signal safety
+  // net below — a missing-status fallback keeps the old behavior so a
+  // failure response with `{code:1}` or `{code:null,signal:"SIGTERM"}` and
+  // no `status` field still surfaces an error banner.
+  let serverDeclaredSuccess = false;
   let lastEventId: string | null = initialLastEventId ?? null;
   let canceled = false;
   const cancelRun = () => {
@@ -430,6 +439,11 @@ async function consumeDaemonRun({
           if (event.event === 'end') {
             exitCode = typeof event.data.code === 'number' ? event.data.code : null;
             exitSignal = typeof event.data.signal === 'string' ? event.data.signal : null;
+            // `serverDeclaredSuccess` records whether the server explicitly
+            // set `status: 'succeeded'` in the end payload — the local
+            // `'succeeded'` fallback below does not count and must keep
+            // hitting the exit-code/signal safety net later.
+            serverDeclaredSuccess = event.data.status === 'succeeded';
             endStatus = isChatRunStatus(event.data.status) ? event.data.status : 'succeeded';
             onRunStatus?.(endStatus);
           }
@@ -444,6 +458,11 @@ async function consumeDaemonRun({
         endStatus = status.status;
         exitCode = status.exitCode ?? null;
         exitSignal = status.signal ?? null;
+        // Fallback REST path: `status.status` is explicitly declared by the
+        // daemon's run record (it passed `isChatRunStatus()` above), so an
+        // explicit `'succeeded'` here is just as authoritative as the SSE
+        // end-event success.
+        serverDeclaredSuccess = status.status === 'succeeded';
         onRunStatus?.(endStatus);
       } else {
         handlers.onError(new Error('daemon stream disconnected before run completed'));
@@ -453,17 +472,22 @@ async function consumeDaemonRun({
 
     if (endStatus === 'canceled') return;
 
-    // Trust the server's authoritative `endStatus`. When the server reports
-    // `succeeded`, the run completed cleanly even if the underlying process
-    // exited via a signal — some agents (e.g. ACP agents like Devin for
-    // Terminal) intentionally exit via SIGTERM after a clean prompt
-    // completion because they don't shut down on stdin.end(). The
-    // signal/non-zero-code safety net only applies when the server hasn't
-    // explicitly declared success, so we never surface a fake error on a
-    // run the server already marked successful.
+    // Trust the server's authoritative success declaration. When the server
+    // explicitly sets `status: 'succeeded'` (either in the SSE end payload
+    // or via the fallback run-status fetch), the run completed cleanly even
+    // if the underlying process exited via a signal — some agents (e.g.
+    // ACP agents like Devin for Terminal) intentionally exit via SIGTERM
+    // after a clean prompt completion because they don't shut down on
+    // `stdin.end()`. The signal/non-zero-code safety net is bypassed only
+    // for that explicit declaration; a missing/invalid `status` from a
+    // compatible or older daemon still falls back to `endStatus =
+    // 'succeeded'` for the run-status surface but must keep the safety net
+    // intact so a real failure response like `{code:1}` or
+    // `{code:null,signal:"SIGTERM"}` without `status` still surfaces an
+    // error banner.
     const looksLikeFailure =
       endStatus === 'failed' ||
-      (endStatus !== 'succeeded' &&
+      (!serverDeclaredSuccess &&
         (exitSignal || (exitCode !== null && exitCode !== 0)));
     if (looksLikeFailure) {
       const tail = stderrBuf.trim().slice(-400);

--- a/apps/web/tests/providers/sse.test.ts
+++ b/apps/web/tests/providers/sse.test.ts
@@ -245,6 +245,113 @@ describe('streamViaDaemon', () => {
     expect(handlers.onDone).not.toHaveBeenCalled();
   });
 
+  it('treats an explicit succeeded status with a SIGTERM exit as a successful run', async () => {
+    // ACP agents that don't shut down on stdin.end() (e.g. Devin for Terminal)
+    // are SIGTERM'd by the daemon after a clean prompt completion. The end
+    // event still declares `status: 'succeeded'`, and the chat must trust
+    // that authoritative success even though `signal === 'SIGTERM'` would
+    // otherwise look like a failure to the exit-code/signal safety net.
+    const handlers = createDaemonHandlers();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce(jsonResponse({ runId: 'run-1' }))
+        .mockResolvedValueOnce(
+          sseResponse(
+            [
+              'event: stdout',
+              'data: {"chunk":"ok"}',
+              '',
+              'event: end',
+              'data: {"code":null,"signal":"SIGTERM","status":"succeeded"}',
+              '',
+              '',
+            ].join('\n'),
+          ),
+        ),
+    );
+
+    await streamViaDaemon({
+      agentId: 'mock',
+      history: [{ id: '1', role: 'user', content: 'hello' }],
+      systemPrompt: '',
+      signal: new AbortController().signal,
+      handlers,
+    });
+
+    expect(handlers.onDone).toHaveBeenCalledWith('ok');
+    expect(handlers.onError).not.toHaveBeenCalled();
+  });
+
+  it('still surfaces an error when the end event has a non-zero code and no status field', async () => {
+    // Regression guard for the local 'succeeded' fallback at the end-event
+    // handler: a compatible or older daemon may omit `status` from the end
+    // payload, in which case `endStatus` is filled with the local default
+    // `'succeeded'`. The exit-code/signal safety net must still apply for
+    // that case so a real failure is not silently suppressed.
+    const handlers = createDaemonHandlers();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce(jsonResponse({ runId: 'run-1' }))
+        .mockResolvedValueOnce(
+          sseResponse(
+            [
+              'event: end',
+              'data: {"code":1}',
+              '',
+              '',
+            ].join('\n'),
+          ),
+        ),
+    );
+
+    await streamViaDaemon({
+      agentId: 'mock',
+      history: [{ id: '1', role: 'user', content: 'hello' }],
+      systemPrompt: '',
+      signal: new AbortController().signal,
+      handlers,
+    });
+
+    expect(handlers.onError).toHaveBeenCalledWith(new Error('agent exited with code 1'));
+    expect(handlers.onDone).not.toHaveBeenCalled();
+  });
+
+  it('still surfaces an error when the end event has a signal but no status field', async () => {
+    // Same regression as above for the signal arm of the safety net. Without
+    // explicit `status: 'succeeded'` from the server, a SIGTERM-style signal
+    // exit must keep producing an error banner — only the explicit ACP
+    // success path is allowed to bypass.
+    const handlers = createDaemonHandlers();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce(jsonResponse({ runId: 'run-1' }))
+        .mockResolvedValueOnce(
+          sseResponse(
+            [
+              'event: end',
+              'data: {"code":null,"signal":"SIGTERM"}',
+              '',
+              '',
+            ].join('\n'),
+          ),
+        ),
+    );
+
+    await streamViaDaemon({
+      agentId: 'mock',
+      history: [{ id: '1', role: 'user', content: 'hello' }],
+      systemPrompt: '',
+      signal: new AbortController().signal,
+      handlers,
+    });
+
+    expect(handlers.onError).toHaveBeenCalledWith(new Error('agent exited with signal SIGTERM'));
+    expect(handlers.onDone).not.toHaveBeenCalled();
+  });
+
   it('keeps the daemon run alive when the browser-side stream aborts', async () => {
     const handlers = createDaemonHandlers();
     const controller = new AbortController();


### PR DESCRIPTION
Fixes #1265

## Summary

Bug B from the end-to-end validation of #1208: chat stays in `working` state after Devin (and any other ACP agent that doesn't exit on `stdin.end()`) finishes responding — the `Done · X.Xs · N out` indicator appears but the chat input never returns to ready. Manual stop click is required before sending the next message.

**Root cause:** Open Design's chat lifecycle finalizes runs via `child.on('close')` in `server.ts`. After a successful `session/prompt` response, `attachAcpSession` calls `stdin.end()` and waits for the child to exit on its own. Some ACP agents (notably Devin for Terminal) keep the child process alive past `stdin.end()`, waiting for the next prompt — so `child.on('close')` never fires and the chat run never finalizes.

**The fix (4 small targeted changes):**

- `apps/daemon/src/acp.ts` — After a clean `session/prompt` response, schedule a 500 ms grace period and then SIGTERM the child if it hasn't exited on its own. Mirrors the pattern `detectAcpModels()` already uses after the model-discovery probe (see same file, line ~270). Well-behaved agents that exit on `stdin.end()` are unaffected — the `child.once('close', ...)` handler clears the timer before SIGTERM fires.

- `apps/daemon/src/acp.ts` — New `completedSuccessfully()` method on the session handle reports whether the prompt resolved without a fatal error or abort. Lets the consumer distinguish clean-signal-exit from genuine-signal-failure.

- `apps/daemon/src/server.ts` — `child.on('close')` treats a SIGTERM exit as `'succeeded'` when `acpSession.completedSuccessfully()` is true. Without this, the chat run was marked `'failed'` because `code === 0` fails on a signal-driven exit (`code` is `null`, `signal` is `'SIGTERM'`).

- `apps/web/src/providers/daemon.ts` — Trust the server's authoritative `endStatus`. The signal/non-zero-code safety net no longer overrides an explicit `'succeeded'` status, so a clean ACP run no longer surfaces a fake `agent exited with signal SIGTERM` error in the chat UI.

**Codex comparison (independent confirmation):** Codex uses `streamFormat: 'json-event-stream'` rather than ACP, so it doesn't go through `attachAcpSession` at all — its CLI exits cleanly after each request, which is why Bug B never reproduces with Codex. The gap was in how the daemon was driving the ACP session lifecycle for agents that keep their child process alive.

This fix is scoped to the ACP transport and doesn't touch the model-selection path being fixed in #1208 — they're complementary fixes in adjacent code that can land in any order.

## Validation

- `pnpm --filter @open-design/daemon typecheck` — passes clean
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/acp.test.ts` — 8/8 pass (3 new tests cover the SIGTERM grace timer firing when the child doesn't exit, the timer being cleared when the child exits on its own, and `completedSuccessfully()` returning `false` on abort/fatal-error states)
- `pnpm guard` — passes (residual-JS, test-layout, e2e-layout, web-test-layout, tools-layout all clean)
- Manual UI verification on macOS (Apple Silicon):
  - Built via `pnpm exec tools-pack mac build --to app --portable` and installed locally
  - **Before the fix:** chat stuck in "working" state after Devin's `Done · 9.3s · 110 out`; manual stop click required before sending next prompt
  - **After the fix:** chat returns to ready automatically right after `Done · ...` appears; no fake error banner; next prompt can be typed and sent immediately
  - Tested with Devin for Terminal `2026.5.6-4`
  - Screenshot + screen recording of the fixed behavior at
<img width="487" height="723" alt="Screenshot 2026-05-11 at 17 04 48" src="https://github.com/user-attachments/assets/76ba5c38-1445-4def-adcb-1b6ccc8f1110" />
tached below

https://github.com/user-attachments/assets/83a5cb55-b615-480b-a30e-a202830a487e


