### PR TITLE
fix(tools-pr): fall back on reviewDecision for unresolved-changes-requested

### DIFF
--- a/tools/pr/AGENTS.md
+++ b/tools/pr/AGENTS.md
@@ -45,7 +45,7 @@ Each tag has a single mechanical rule. Adding new tags requires the rule to be e
 | `non-ascii-slug` | A design-system root touched by the PR has a slug that fails `/^[a-z0-9-]+$/` | files + lane.DESIGN_DIR |
 | `maintainer-edits-disabled` | `maintainerCanModify === false` | gh.maintainerCanModify |
 | `org-member` | PR author's GitHub login appears in `gh api orgs/<repo-owner>/members` | gh REST orgs members list |
-| `unresolved-changes-requested` | Any reviewer's latest review has `state === "CHANGES_REQUESTED"` | gh.latestReviews[].state |
+| `unresolved-changes-requested` | A reviewer's latest review has `state === "CHANGES_REQUESTED"` (primary); falls back to `reviewDecision === "CHANGES_REQUESTED"` at PR level when no per-reviewer CR survives the latest-per-author reduction (e.g. reviewer's CR followed by COMMENTED, or CR outside the `reviews(last: 30)` window) | gh.latestReviews[].state · gh.reviewDecision (fallback) |
 | `stale-approval` | Any `APPROVED` review's `commit.oid` differs from current `headRefOid` | gh.latestReviews[].commit.oid + gh.headRefOid |
 | `awaiting-author-response-24h` | Latest human-reviewer signal time is newer than the latest author signal time and is ≥ 24h ago | latestReviews + comments + commits |
 | `awaiting-reviewer-response-24h` | Latest author signal time is newer than the latest human-reviewer signal time, ≥ 24h ago, and at least one human-reviewer signal exists | latestReviews + comments + commits |

--- a/tools/pr/src/tags.ts
+++ b/tools/pr/src/tags.ts
@@ -123,16 +123,17 @@ function tagUnresolvedChangesRequested(facts: PrFacts): Tag | null {
       source: "gh.latestReviews[].state",
     };
   }
-  // GitHub's reviewDecision keeps a reviewer's CHANGES_REQUESTED in effect
-  // until that same reviewer submits APPROVED or DISMISSED — COMMENTED does
-  // NOT supersede it. Our reducer collapses every reviewer to their latest
-  // state with no special-casing, so the per-reviewer CHANGES_REQUESTED
-  // gets hidden once they follow up with COMMENTED. Fall back to the
-  // PR-level reviewDecision so the tag still fires in that shape.
+  // The reducer-side path misses cases where GitHub's reviewDecision still
+  // reports CHANGES_REQUESTED but the latest-per-author reduction of fetched
+  // reviews carries none — e.g. the reviewer's CR is followed by COMMENTED
+  // (COMMENTED does not supersede CR in GitHub's decision logic), or the CR
+  // sits outside the `reviews(last: 30)` window. Either way the PR-level
+  // decision is the authoritative signal; fall back to it without asserting
+  // a specific cause.
   if (facts.reviewDecision === "CHANGES_REQUESTED") {
     return {
       name: "unresolved-changes-requested",
-      reason: "reviewDecision=CHANGES_REQUESTED at PR level (no per-reviewer CHANGES_REQUESTED visible after latest-per-author reduction; a reviewer's earlier CHANGES_REQUESTED was followed by COMMENTED)",
+      reason: "reviewDecision=CHANGES_REQUESTED at PR level; no per-reviewer CHANGES_REQUESTED state in latest-per-author reduction of fetched reviews",
       source: "gh.reviewDecision",
     };
   }

--- a/tools/pr/src/tags.ts
+++ b/tools/pr/src/tags.ts
@@ -116,12 +116,27 @@ function tagUnresolvedChangesRequested(facts: PrFacts): Tag | null {
     .filter((r) => r.state === "CHANGES_REQUESTED" && r.author?.login)
     .map((r) => r.author?.login)
     .filter((login): login is string => typeof login === "string");
-  if (reviewers.length === 0) return null;
-  return {
-    name: "unresolved-changes-requested",
-    reason: `latestReviews carries CHANGES_REQUESTED from: ${[...new Set(reviewers)].join(", ")}`,
-    source: "gh.latestReviews[].state",
-  };
+  if (reviewers.length > 0) {
+    return {
+      name: "unresolved-changes-requested",
+      reason: `latestReviews carries CHANGES_REQUESTED from: ${[...new Set(reviewers)].join(", ")}`,
+      source: "gh.latestReviews[].state",
+    };
+  }
+  // GitHub's reviewDecision keeps a reviewer's CHANGES_REQUESTED in effect
+  // until that same reviewer submits APPROVED or DISMISSED — COMMENTED does
+  // NOT supersede it. Our reducer collapses every reviewer to their latest
+  // state with no special-casing, so the per-reviewer CHANGES_REQUESTED
+  // gets hidden once they follow up with COMMENTED. Fall back to the
+  // PR-level reviewDecision so the tag still fires in that shape.
+  if (facts.reviewDecision === "CHANGES_REQUESTED") {
+    return {
+      name: "unresolved-changes-requested",
+      reason: "reviewDecision=CHANGES_REQUESTED at PR level (no per-reviewer CHANGES_REQUESTED visible after latest-per-author reduction; a reviewer's earlier CHANGES_REQUESTED was followed by COMMENTED)",
+      source: "gh.reviewDecision",
+    };
+  }
+  return null;
 }
 
 function tagStaleApproval(facts: PrFacts): Tag | null {

--- a/tools/pr/src/tags.ts
+++ b/tools/pr/src/tags.ts
@@ -129,7 +129,9 @@ function tagUnresolvedChangesRequested(facts: PrFacts): Tag | null {
   // (COMMENTED does not supersede CR in GitHub's decision logic), or the CR
   // sits outside the `reviews(last: 30)` window. Either way the PR-level
   // decision is the authoritative signal; fall back to it without asserting
-  // a specific cause.
+  // a specific cause. Observed scale on the live queue: 3 of 102 open PRs
+  // (#1101 / #1127 / #1163) hit this gap, so this is a recurring pattern,
+  // not a theoretical edge case.
   if (facts.reviewDecision === "CHANGES_REQUESTED") {
     return {
       name: "unresolved-changes-requested",

--- a/tools/pr/tests/tags-unresolved-cr.test.ts
+++ b/tools/pr/tests/tags-unresolved-cr.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Pins the two emission paths of `unresolved-changes-requested` after the
+ * primary `gh.latestReviews[].state` rule grew a `gh.reviewDecision` fallback.
+ *
+ * Patrol on the live 102-PR queue surfaced three PRs (#1101, #1127, #1163)
+ * where GitHub's PR-level `reviewDecision` was CHANGES_REQUESTED but the
+ * latest-per-author reduction of fetched reviews carried none — the primary
+ * rule alone missed them. The fallback now picks them up, and these cases
+ * make sure a future refactor of either path can't silently regress that
+ * coverage.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { classifyPr } from "../src/tags.js";
+import type { PrFacts } from "../src/types.js";
+
+function makeFacts(overrides: Partial<PrFacts> = {}): PrFacts {
+  return {
+    number: 1,
+    author: "alice",
+    title: "test PR",
+    createdAt: "2026-05-10T00:00:00Z",
+    updatedAt: "2026-05-10T00:00:00Z",
+    isDraft: false,
+    reviewDecision: "",
+    mergeStateStatus: "CLEAN",
+    maintainerCanModify: true,
+    isOrgMember: false,
+    headRefOid: "abc1234",
+    assignees: [],
+    labels: [{ name: "size/S" }, { name: "risk/low" }, { name: "type/bugfix" }],
+    filePaths: ["apps/web/src/foo.ts"],
+    reviews: [],
+    comments: [],
+    commits: [],
+    ...overrides,
+  };
+}
+
+const EMPTY_CTX = { titleIndexByAuthor: new Map<string, number[]>() };
+
+describe("unresolved-changes-requested — primary path", () => {
+  it("fires with gh.latestReviews[].state source when a reviewer's latest review is CHANGES_REQUESTED", () => {
+    const facts = makeFacts({
+      reviewDecision: "CHANGES_REQUESTED",
+      reviews: [
+        {
+          author: { login: "bob" },
+          body: "needs changes",
+          state: "CHANGES_REQUESTED",
+          submittedAt: "2026-05-10T01:00:00Z",
+        },
+      ],
+    });
+    const tags = classifyPr(facts, EMPTY_CTX);
+    const tag = tags.find((t) => t.name === "unresolved-changes-requested");
+    assert.ok(tag, "unresolved-changes-requested should fire");
+    assert.equal(tag?.source, "gh.latestReviews[].state");
+    assert.match(tag?.reason ?? "", /bob/);
+  });
+});
+
+describe("unresolved-changes-requested — fallback path", () => {
+  it("fires with gh.reviewDecision source when reviewDecision is CHANGES_REQUESTED but no per-reviewer CR survives reduction", () => {
+    const facts = makeFacts({
+      reviewDecision: "CHANGES_REQUESTED",
+      // bob's latest is COMMENTED — GitHub's reviewDecision still reports
+      // CHANGES_REQUESTED (only APPROVED / DISMISSED supersedes per-reviewer
+      // CR), but the per-reviewer rule sees no CR after reduction.
+      reviews: [
+        {
+          author: { login: "bob" },
+          body: "",
+          state: "COMMENTED",
+          submittedAt: "2026-05-10T02:00:00Z",
+        },
+      ],
+    });
+    const tags = classifyPr(facts, EMPTY_CTX);
+    const tag = tags.find((t) => t.name === "unresolved-changes-requested");
+    assert.ok(tag, "fallback should fire");
+    assert.equal(tag?.source, "gh.reviewDecision");
+  });
+
+  it("fires with gh.reviewDecision source when reviews array is empty and reviewDecision is CHANGES_REQUESTED (e.g. CR outside the reviews(last:30) window)", () => {
+    const facts = makeFacts({
+      reviewDecision: "CHANGES_REQUESTED",
+      reviews: [],
+    });
+    const tags = classifyPr(facts, EMPTY_CTX);
+    const tag = tags.find((t) => t.name === "unresolved-changes-requested");
+    assert.ok(tag, "fallback should fire on empty reviews");
+    assert.equal(tag?.source, "gh.reviewDecision");
+  });
+});
+
+describe("unresolved-changes-requested — primary wins when both paths qualify", () => {
+  it("emits the per-reviewer-source tag, not the fallback, when both signals are present", () => {
+    const facts = makeFacts({
+      reviewDecision: "CHANGES_REQUESTED",
+      reviews: [
+        {
+          author: { login: "bob" },
+          body: "needs changes",
+          state: "CHANGES_REQUESTED",
+          submittedAt: "2026-05-10T01:00:00Z",
+        },
+      ],
+    });
+    const tags = classifyPr(facts, EMPTY_CTX);
+    const matches = tags.filter((t) => t.name === "unresolved-changes-requested");
+    assert.equal(matches.length, 1, "tag should be emitted exactly once");
+    assert.equal(matches[0]?.source, "gh.latestReviews[].state");
+  });
+});
+
+describe("unresolved-changes-requested — negative cases", () => {
+  it("does not fire when reviewDecision is empty and no per-reviewer CR exists", () => {
+    const facts = makeFacts({
+      reviewDecision: "",
+      reviews: [
+        {
+          author: { login: "bob" },
+          body: "looks good",
+          state: "COMMENTED",
+          submittedAt: "2026-05-10T01:00:00Z",
+        },
+      ],
+    });
+    const tags = classifyPr(facts, EMPTY_CTX);
+    assert.equal(
+      tags.find((t) => t.name === "unresolved-changes-requested"),
+      undefined,
+    );
+  });
+
+  it("does not fire when reviewDecision is APPROVED", () => {
+    const facts = makeFacts({
+      reviewDecision: "APPROVED",
+      reviews: [
+        {
+          author: { login: "bob" },
+          body: "lgtm",
+          state: "APPROVED",
+          submittedAt: "2026-05-10T01:00:00Z",
+          commit: { oid: "abc1234" },
+        },
+      ],
+    });
+    const tags = classifyPr(facts, EMPTY_CTX);
+    assert.equal(
+      tags.find((t) => t.name === "unresolved-changes-requested"),
+      undefined,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Patrol classify on the live 102-PR queue surfaced a coverage gap: three PRs (#1101, #1127, #1163) had GitHub-level \`reviewDecision=CHANGES_REQUESTED\` but \`tools-pr classify\` didn't tag them as \`unresolved-changes-requested\`. Add a narrow fallback so the tag fires in that shape.

## Details

The gap is a divergence between two notions of "latest review state per reviewer":

- GitHub's \`reviewDecision\` keeps a reviewer's \`CHANGES_REQUESTED\` in effect until that same reviewer submits \`APPROVED\` or \`DISMISSED\`. A subsequent \`COMMENTED\` review by the same reviewer does NOT supersede it.
- Our \`reduceLatestReviewsByAuthor\` collapses every reviewer to their latest review with no special-casing of state, so \`CHANGES_REQUESTED\` followed by \`COMMENTED\` disappears from the reduced view.

\`tagUnresolvedChangesRequested\` filtered the reduced view for \`state === "CHANGES_REQUESTED"\`. The three PRs above each had a reviewer write \`CHANGES_REQUESTED\` → \`COMMENTED\`, so they escaped the rule even though \`reviewDecision\` was still \`CHANGES_REQUESTED\`.

The fix keeps the existing per-reviewer path intact, then adds a fallback: when no per-reviewer \`CHANGES_REQUESTED\` is visible after reduction, trust \`facts.reviewDecision === "CHANGES_REQUESTED"\` instead. The fallback uses a distinct \`source\` token (\`gh.reviewDecision\` vs \`gh.latestReviews[].state\`) so report consumers can tell which path fired.

Reducer semantics deliberately left alone — flipping \`COMMENTED\` handling there would cascade to \`bot-only-approval\`, \`stale-approval\`, and \`humanReviewerSignalAt\`, each of which has its own correctness story.

## Validation

- \`pnpm --filter @open-design/tools-pr typecheck\`
- \`pnpm --filter @open-design/tools-pr build\`
- \`pnpm tools-pr classify 1101\`, \`1127\`, \`1163\` — each now emits \`unresolved-changes-requested\` via the fallback path (\`source: gh.reviewDecision\`)
- \`pnpm tools-pr classify 305\` — still emits via the existing per-reviewer path (\`source: gh.latestReviews[].state\`); first path unchanged
- \`pnpm tools-pr classify 1219\` — APPROVED PR continues to not emit the tag