### PR TITLE
replace time-specific Orbit greetings with neutral defaults

### DIFF
--- a/design-templates/orbit-general/SKILL.md
+++ b/design-templates/orbit-general/SKILL.md
@@ -17,7 +17,7 @@ triggers:
   - "daily digest"
   - "morning briefing"
   - "每日简报"
-  - "每日简报"
+  - "早安简报"
   - "跨工具汇总"
 od:
   mode: prototype

--- a/design-templates/orbit-general/SKILL.md
+++ b/design-templates/orbit-general/SKILL.md
@@ -16,7 +16,7 @@ triggers:
   - "orbit"
   - "daily digest"
   - "morning briefing"
-  - "早安简报"
+  - "每日简报"
   - "每日简报"
   - "跨工具汇总"
 od:
@@ -107,7 +107,7 @@ Connector icons must be monochrome line SVG (1.5 stroke).
 ## Page sections (top to bottom)
 
 1. **Hero** — single row, ~80px tall.
-   Left: `☀ 早安, Eli` (Cormorant 38px, with `,` in `--orange`).
+   Left: `☀ 你好, Eli` (Cormorant 38px, with `,` in `--orange`).
    Right of name: `· 2026 年 5 月 6 日 · 星期三` (muted, 18px).
    Far right: round avatar (40px) + small ⚙ + ✕ icons.
 

--- a/design-templates/orbit-general/example.html
+++ b/design-templates/orbit-general/example.html
@@ -26,7 +26,7 @@
 })();</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=1440">
-<title>Open Orbit — 早安简报</title>
+<title>Open Orbit — 每日简报</title>
 <style>
   @import url('https://fonts.googleapis.com/css2?family=Cormorant:ital,wght@0,400;0,600;0,700;1,400;1,600&family=Inter:wght@400;500;600;700&display=swap');
 
@@ -652,7 +652,7 @@
         <line x1="33.9" y1="14.1" x2="38.14" y2="9.86"/>
       </g>
     </svg>
-    <h1>早安，<span>Eli</span></h1>
+    <h1>你好，<span>Eli</span></h1>
     <div class="hero-date">2026 年 5 月 6 日 · 星期三</div>
   </div>
 

--- a/design-templates/orbit-gmail/example.html
+++ b/design-templates/orbit-gmail/example.html
@@ -467,7 +467,7 @@ body {
     <div class="digest-body">
 
       <div class="greeting">
-        早上好 Eli 👋<br>
+        你好 Eli 👋<br>
         以下是你昨天（5月5日）的 Gmail 简报。共 <strong>6 封值得关注</strong>，已按优先级分组。
       </div>
 

--- a/design-templates/orbit-linear/example.html
+++ b/design-templates/orbit-linear/example.html
@@ -286,7 +286,7 @@ body {
     </div>
 
     <div class="greeting">
-      <h1>Good morning, Eli</h1>
+      <h1>Hello, Eli</h1>
       <p>Tuesday, May 6, 2026 — here's what changed in Linear overnight.</p>
     </div>
 

--- a/design-templates/orbit-notion/SKILL.md
+++ b/design-templates/orbit-notion/SKILL.md
@@ -118,7 +118,7 @@ column at ~720px max width with the rest as `--gray-light` rails.
    `#E9E5E0`, optional small "Add cover" hint hidden in the corner.
 
 4. **Page header inside content column** — emoji icon (60px) at top,
-   then page title `早安简报 · 2026 年 5 月 6 日 (Wed)` in 40px bold,
+   then page title `每日简报 · 2026 年 5 月 6 日 (Wed)` in 40px bold,
    then a row of property chips (gray):
    `🗂 Type: Daily Briefing  ·  👤 Owner: Eli  ·  📅 Created: 06:42`.
 

--- a/design-templates/orbit-notion/example.html
+++ b/design-templates/orbit-notion/example.html
@@ -388,7 +388,7 @@
       <div class="breadcrumb">
         <a href="#">Open Orbit</a>
         <span>/</span>
-        <a href="#">早安简报</a>
+        <a href="#">每日简报</a>
         <span>/</span>
         <span style="color: var(--notion-black);">5 月 6 日</span>
       </div>
@@ -401,7 +401,7 @@
       <!-- page content -->
       <div class="page-content" data-od-id="page-body">
         <h1 class="page-title" data-od-id="headline">📒 Notion · 昨日 3 条与你相关</h1>
-        <p class="page-subtitle">2026-05-06 早安，Eli · 由 Open Orbit 自动生成</p>
+        <p class="page-subtitle">2026-05-06 你好，Eli · 由 Open Orbit 自动生成</p>
 
         <hr class="notion-divider" />
 


### PR DESCRIPTION
Fixes #1272 
                                                                                    
  ## Summary                                                                          
  - Replace time-specific default greetings with neutral alternatives across four     
  Orbit templates (orbit-general, orbit-notion, orbit-linear, orbit-gmail)            
  - 早安/早上好 → 你好, Good morning → Hello, 早安简报 → 每日简报                     
                                                                                      
  ## Validation                                                                     
  - Opened each template's example.html in browser and confirmed hero/greeting area
  shows neutral greeting                                                              
  - Verified no remaining morning-specific greetings in orbit templates via grep