### PR TITLE
fix: support object-style question-form options

### DIFF
--- a/apps/web/src/artifacts/question-form.ts
+++ b/apps/web/src/artifacts/question-form.ts
@@ -52,11 +52,17 @@ export interface DirectionCard {
   bodyFont: string;
 }
 
+export interface FormOption {
+  label: string;
+  value: string;
+  description?: string;
+}
+
 export interface FormQuestion {
   id: string;
   label: string;
   type: QuestionType;
-  options?: string[];
+  options?: FormOption[];
   placeholder?: string;
   required?: boolean;
   help?: string;
@@ -159,9 +165,7 @@ function tryParseForm(body: string, attrs: Record<string, string>): QuestionForm
         : `q${i + 1}`;
     const label = typeof qo.label === 'string' ? qo.label : id;
     const type = normalizeType(qo.type);
-    const options = Array.isArray(qo.options)
-      ? qo.options.filter((o): o is string => typeof o === 'string')
-      : undefined;
+    const options = parseOptions(qo.options);
     const placeholder = typeof qo.placeholder === 'string' ? qo.placeholder : undefined;
     const help = typeof qo.help === 'string' ? qo.help : undefined;
     const required = qo.required === true;
@@ -172,14 +176,7 @@ function tryParseForm(body: string, attrs: Record<string, string>): QuestionForm
         ? qo.maxSelections
         : undefined;
     const cards = parseDirectionCards(qo.cards);
-    const defaultValue =
-      typeof qo.defaultValue === 'string'
-        ? qo.defaultValue
-        : Array.isArray(qo.defaultValue)
-          ? qo.defaultValue.filter((v): v is string => typeof v === 'string')
-          : typeof qo.default === 'string'
-            ? qo.default
-            : undefined;
+    const defaultValue = parseDefaultValue(qo, options);
     questions.push({
       id,
       label,
@@ -225,6 +222,57 @@ function normalizeType(raw: unknown): QuestionType {
   return 'text';
 }
 
+function parseOptions(raw: unknown): FormOption[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const options = raw
+    .map(parseOption)
+    .filter((option): option is FormOption => option !== null);
+  return options.length > 0 ? options : undefined;
+}
+
+function parseOption(raw: unknown): FormOption | null {
+  if (typeof raw === 'string') {
+    const label = raw.trim();
+    return label.length > 0 ? { label, value: label } : null;
+  }
+  if (!raw || typeof raw !== 'object') return null;
+  const obj = raw as Record<string, unknown>;
+  const label = typeof obj.label === 'string' ? obj.label.trim() : '';
+  if (label.length === 0) return null;
+  const value =
+    typeof obj.value === 'string' && obj.value.trim().length > 0
+      ? obj.value.trim()
+      : label;
+  const description =
+    typeof obj.description === 'string' && obj.description.trim().length > 0
+      ? obj.description.trim()
+      : undefined;
+  return {
+    label,
+    value,
+    ...(description ? { description } : {}),
+  };
+}
+
+function parseDefaultValue(
+  question: Record<string, unknown>,
+  options: FormOption[] | undefined,
+): string | string[] | undefined {
+  const raw =
+    typeof question.defaultValue === 'string' || Array.isArray(question.defaultValue)
+      ? question.defaultValue
+      : typeof question.default === 'string'
+        ? question.default
+        : undefined;
+  if (typeof raw === 'string') return formOptionValueForLabel({ options }, raw);
+  if (Array.isArray(raw)) {
+    return raw
+      .filter((value): value is string => typeof value === 'string')
+      .map((value) => formOptionValueForLabel({ options }, value));
+  }
+  return undefined;
+}
+
 function parseDirectionCards(raw: unknown): DirectionCard[] | undefined {
   if (!Array.isArray(raw)) return undefined;
   const out: DirectionCard[] = [];
@@ -266,10 +314,31 @@ export function formatFormAnswers(
   for (const q of form.questions) {
     const v = answers[q.id];
     let display: string;
-    if (Array.isArray(v)) display = v.length > 0 ? v.join(', ') : '(skipped)';
-    else if (typeof v === 'string') display = v.trim().length > 0 ? v.trim() : '(skipped)';
+    if (Array.isArray(v)) {
+      display = v.length > 0 ? v.map((value) => formOptionLabelForValue(q, value)).join(', ') : '(skipped)';
+    } else if (typeof v === 'string') {
+      display = v.trim().length > 0 ? formOptionLabelForValue(q, v.trim()) : '(skipped)';
+    }
     else display = '(skipped)';
     lines.push(`- ${q.label}: ${display}`);
   }
   return lines.join('\n');
+}
+
+export function formOptionLabelForValue(
+  question: Pick<FormQuestion, 'options'>,
+  value: string,
+): string {
+  const match = question.options?.find((option) => option.value === value || option.label === value);
+  return match?.label ?? value;
+}
+
+export function formOptionValueForLabel(
+  question: Pick<FormQuestion, 'options'>,
+  labelOrValue: string,
+): string {
+  const match = question.options?.find(
+    (option) => option.value === labelOrValue || option.label === labelOrValue,
+  );
+  return match?.value ?? labelOrValue;
 }

--- a/apps/web/src/artifacts/question-form.ts
+++ b/apps/web/src/artifacts/question-form.ts
@@ -315,14 +315,24 @@ export function formatFormAnswers(
     const v = answers[q.id];
     let display: string;
     if (Array.isArray(v)) {
-      display = v.length > 0 ? v.map((value) => formOptionLabelForValue(q, value)).join(', ') : '(skipped)';
+      display = v.length > 0 ? v.map((value) => formOptionDisplayForValue(q, value)).join(', ') : '(skipped)';
     } else if (typeof v === 'string') {
-      display = v.trim().length > 0 ? formOptionLabelForValue(q, v.trim()) : '(skipped)';
+      display = v.trim().length > 0 ? formOptionDisplayForValue(q, v.trim()) : '(skipped)';
     }
     else display = '(skipped)';
     lines.push(`- ${q.label}: ${display}`);
   }
   return lines.join('\n');
+}
+
+function formOptionDisplayForValue(
+  question: Pick<FormQuestion, 'options'>,
+  value: string,
+): string {
+  const match = question.options?.find((option) => option.value === value || option.label === value);
+  if (!match) return value;
+  if (match.value === match.label) return match.label;
+  return `${match.label} [value: ${match.value}]`;
 }
 
 export function formOptionLabelForValue(

--- a/apps/web/src/components/QuestionForm.tsx
+++ b/apps/web/src/components/QuestionForm.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { useT } from '../i18n';
-import type { DirectionCard, QuestionForm } from '../artifacts/question-form';
-import { formatFormAnswers } from '../artifacts/question-form';
+import type { DirectionCard, FormOption, QuestionForm } from '../artifacts/question-form';
+import { formatFormAnswers, formOptionValueForLabel } from '../artifacts/question-form';
 
 interface Props {
   form: QuestionForm;
@@ -102,16 +102,21 @@ export function QuestionFormView({ form, interactive, submittedAnswers, onSubmit
               {q.type === 'radio' && q.options ? (
                 <div className="qf-options">
                   {q.options.map((opt) => (
-                    <label key={opt} className={`qf-chip${value === opt ? ' qf-chip-on' : ''}`}>
+                    <label
+                      key={opt.value}
+                      className={`qf-chip${value === opt.value ? ' qf-chip-on' : ''}`}
+                      title={opt.description}
+                    >
                       <input
                         type="radio"
                         name={`${form.id}-${q.id}`}
-                        value={opt}
-                        checked={value === opt}
+                        value={opt.value}
+                        checked={value === opt.value}
                         disabled={locked}
-                        onChange={() => update(q.id, opt)}
+                        aria-label={opt.label}
+                        onChange={() => update(q.id, opt.value)}
                       />
-                      <span>{opt}</span>
+                      <OptionCopy option={opt} />
                     </label>
                   ))}
                 </div>
@@ -120,22 +125,24 @@ export function QuestionFormView({ form, interactive, submittedAnswers, onSubmit
                 <div className="qf-options">
                   {q.options.map((opt) => {
                     const arr = Array.isArray(value) ? value : [];
-                    const on = arr.includes(opt);
+                    const on = arr.includes(opt.value);
                     const maxed =
                       q.maxSelections !== undefined && !on && arr.length >= q.maxSelections;
                     return (
                       <label
-                        key={opt}
+                        key={opt.value}
+                        title={opt.description}
                         className={`qf-chip${on ? ' qf-chip-on' : ''}${maxed ? ' qf-chip-disabled' : ''}`}
                       >
                         <input
                           type="checkbox"
-                          value={opt}
+                          value={opt.value}
                           checked={on}
                           disabled={locked || maxed}
-                          onChange={() => toggleCheckbox(q.id, opt, q.maxSelections)}
+                          aria-label={opt.label}
+                          onChange={() => toggleCheckbox(q.id, opt.value, q.maxSelections)}
                         />
-                        <span>{opt}</span>
+                        <OptionCopy option={opt} />
                       </label>
                     );
                   })}
@@ -152,8 +159,8 @@ export function QuestionFormView({ form, interactive, submittedAnswers, onSubmit
                     {t('qf.choose')}
                   </option>
                   {q.options.map((opt) => (
-                    <option key={opt} value={opt}>
-                      {opt}
+                    <option key={opt.value} value={opt.value} title={opt.description}>
+                      {opt.label}
                     </option>
                   ))}
                 </select>
@@ -218,6 +225,15 @@ export function QuestionFormView({ form, interactive, submittedAnswers, onSubmit
         ) : null}
       </div>
     </div>
+  );
+}
+
+function OptionCopy({ option }: { option: FormOption }) {
+  return (
+    <span className="qf-chip-copy">
+      <span>{option.label}</span>
+      {option.description ? <span className="qf-chip-desc">{option.description}</span> : null}
+    </span>
   );
 }
 
@@ -340,9 +356,10 @@ export function parseSubmittedAnswers(
       answers[id] = value
         .split(',')
         .map((s) => s.trim())
-        .filter((s) => s.length > 0 && s.toLowerCase() !== '(skipped)');
+        .filter((s) => s.length > 0 && s.toLowerCase() !== '(skipped)')
+        .map((s) => formOptionValueForLabel(q, s));
     } else {
-      answers[id] = value.toLowerCase() === '(skipped)' ? '' : value;
+      answers[id] = value.toLowerCase() === '(skipped)' ? '' : formOptionValueForLabel(q, value);
     }
   }
   return Object.keys(answers).length > 0 ? answers : null;

--- a/apps/web/src/components/QuestionForm.tsx
+++ b/apps/web/src/components/QuestionForm.tsx
@@ -357,10 +357,16 @@ export function parseSubmittedAnswers(
         .split(',')
         .map((s) => s.trim())
         .filter((s) => s.length > 0 && s.toLowerCase() !== '(skipped)')
-        .map((s) => formOptionValueForLabel(q, s));
+        .map((s) => formOptionValueForLabel(q, parseSubmittedOptionToken(s)));
     } else {
-      answers[id] = value.toLowerCase() === '(skipped)' ? '' : formOptionValueForLabel(q, value);
+      answers[id] = value.toLowerCase() === '(skipped)' ? '' : formOptionValueForLabel(q, parseSubmittedOptionToken(value));
     }
   }
   return Object.keys(answers).length > 0 ? answers : null;
+}
+
+function parseSubmittedOptionToken(raw: string): string {
+  const match = /\s+\[value:\s*([^\]]+)\]\s*$/i.exec(raw);
+  if (!match) return raw.trim();
+  return match[1]!.trim();
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -10711,6 +10711,21 @@ button.ghost.mcp-copy-btn:hover:not(:disabled) {
   transition: border-color 120ms ease, background 120ms ease, color 120ms ease;
 }
 .qf-chip input { width: auto; margin: 0; display: none; }
+.qf-chip-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  line-height: 1.2;
+}
+.qf-chip-desc {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 400;
+}
+.qf-chip-on .qf-chip-desc {
+  color: inherit;
+  opacity: 0.72;
+}
 .qf-chip:hover { border-color: var(--border-strong); }
 .qf-chip-disabled {
   cursor: not-allowed;

--- a/apps/web/tests/artifacts/question-form.test.ts
+++ b/apps/web/tests/artifacts/question-form.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { splitOnQuestionForms } from '../../src/artifacts/question-form';
+
+describe('splitOnQuestionForms', () => {
+  it('normalizes string and object question options', () => {
+    const input = [
+      '<question-form id="discovery" title="Quick brief">',
+      '{',
+      '  "questions": [',
+      '    {',
+      '      "id": "platform",',
+      '      "label": "Primary surface",',
+      '      "type": "radio",',
+      '      "required": true,',
+      '      "options": [',
+      '        "Responsive",',
+      '        { "label": "Mobile (iOS/Android)", "description": "Phone-first app prototype", "value": "mobile" },',
+      '        { "label": "Desktop web", "description": "Browser-first prototype" },',
+      '        { "description": "Missing label" }',
+      '      ]',
+      '    }',
+      '  ]',
+      '}',
+      '</question-form>',
+    ].join('\n');
+
+    const segments = splitOnQuestionForms(input);
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toMatchObject({ kind: 'form' });
+    if (segments[0]?.kind !== 'form') throw new Error('expected parsed form segment');
+
+    expect(segments[0].form.questions[0]?.options).toEqual([
+      { label: 'Responsive', value: 'Responsive' },
+      {
+        label: 'Mobile (iOS/Android)',
+        value: 'mobile',
+        description: 'Phone-first app prototype',
+      },
+      {
+        label: 'Desktop web',
+        value: 'Desktop web',
+        description: 'Browser-first prototype',
+      },
+    ]);
+  });
+});

--- a/apps/web/tests/artifacts/question-form.test.ts
+++ b/apps/web/tests/artifacts/question-form.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { splitOnQuestionForms } from '../../src/artifacts/question-form';
+import { formatFormAnswers, splitOnQuestionForms } from '../../src/artifacts/question-form';
 
 describe('splitOnQuestionForms', () => {
   it('normalizes string and object question options', () => {
@@ -43,5 +43,28 @@ describe('splitOnQuestionForms', () => {
         description: 'Browser-first prototype',
       },
     ]);
+  });
+
+  it('preserves stable option values when formatting object-option answers', () => {
+    const text = formatFormAnswers(
+      {
+        id: 'discovery',
+        title: 'Quick brief',
+        questions: [
+          {
+            id: 'platform',
+            label: 'Primary surface',
+            type: 'radio',
+            options: [
+              { label: 'Mobile (iOS/Android)', value: 'mobile' },
+              { label: 'Desktop web', value: 'Desktop web' },
+            ],
+          },
+        ],
+      },
+      { platform: 'mobile' },
+    );
+
+    expect(text).toContain('- Primary surface: Mobile (iOS/Android) [value: mobile]');
   });
 });

--- a/apps/web/tests/components/QuestionForm.test.tsx
+++ b/apps/web/tests/components/QuestionForm.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { QuestionFormView } from '../../src/components/QuestionForm';
 import type { QuestionForm } from '../../src/artifacts/question-form';
@@ -13,12 +13,42 @@ const form: QuestionForm = {
       id: 'tone',
       label: 'Visual tone (pick up to two)',
       type: 'checkbox',
-      options: ['Editorial / magazine', 'Modern minimal', 'Soft gradients'],
+      options: [
+        { label: 'Editorial / magazine', value: 'Editorial / magazine' },
+        { label: 'Modern minimal', value: 'Modern minimal' },
+        { label: 'Soft gradients', value: 'Soft gradients' },
+      ],
       maxSelections: 2,
       required: true,
     },
   ],
 };
+
+const richForm = {
+  id: 'discovery',
+  title: 'Quick brief',
+  questions: [
+    {
+      id: 'platform',
+      label: 'Primary surface',
+      type: 'radio',
+      required: true,
+      options: [
+        { label: 'Responsive', value: 'Responsive' },
+        {
+          label: 'Mobile (iOS/Android)',
+          description: 'Phone-first app prototype',
+          value: 'mobile',
+        },
+        {
+          label: 'Desktop web',
+          description: 'Browser-first prototype',
+          value: 'Desktop web',
+        },
+      ],
+    },
+  ],
+} as QuestionForm;
 
 describe('QuestionFormView', () => {
   afterEach(() => cleanup());
@@ -42,5 +72,22 @@ describe('QuestionFormView', () => {
 
     expect(screen.getByText('answered')).toBeTruthy();
     expect(container.querySelectorAll('input[type="checkbox"]:checked')).toHaveLength(2);
+  });
+
+  it('renders object options and submits the readable label', () => {
+    const onSubmit = vi.fn();
+    render(<QuestionFormView form={richForm} interactive onSubmit={onSubmit} />);
+
+    expect(screen.getByText('Responsive')).toBeTruthy();
+    expect(screen.getByText('Mobile (iOS/Android)')).toBeTruthy();
+    expect(screen.getByText('Phone-first app prototype')).toBeTruthy();
+    expect(screen.getByText('Desktop web')).toBeTruthy();
+
+    fireEvent.click(screen.getByLabelText('Desktop web'));
+    fireEvent.click(screen.getByRole('button', { name: 'Send answers' }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit.mock.calls[0]?.[0]).toContain('Desktop web');
+    expect(onSubmit.mock.calls[0]?.[0]).not.toContain('mobile');
   });
 });

--- a/apps/web/tests/components/QuestionForm.test.tsx
+++ b/apps/web/tests/components/QuestionForm.test.tsx
@@ -2,7 +2,7 @@
 
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { QuestionFormView } from '../../src/components/QuestionForm';
+import { QuestionFormView, parseSubmittedAnswers } from '../../src/components/QuestionForm';
 import type { QuestionForm } from '../../src/artifacts/question-form';
 
 const form: QuestionForm = {
@@ -50,6 +50,41 @@ const richForm = {
   ],
 } as QuestionForm;
 
+const checkboxObjectForm = {
+  id: 'discovery',
+  title: 'Quick brief',
+  questions: [
+    {
+      id: 'tone',
+      label: 'Visual tone',
+      type: 'checkbox',
+      required: true,
+      options: [
+        { label: 'Editorial / magazine', value: 'editorial' },
+        { label: 'Soft gradients', value: 'soft-gradients' },
+        { label: 'Modern minimal', value: 'modern-minimal' },
+      ],
+    },
+  ],
+} as QuestionForm;
+
+const selectObjectForm = {
+  id: 'discovery',
+  title: 'Quick brief',
+  questions: [
+    {
+      id: 'platform',
+      label: 'Primary surface',
+      type: 'select',
+      required: true,
+      options: [
+        { label: 'Mobile (iOS/Android)', value: 'mobile' },
+        { label: 'Desktop web', value: 'desktop-web' },
+      ],
+    },
+  ],
+} as QuestionForm;
+
 describe('QuestionFormView', () => {
   afterEach(() => cleanup());
 
@@ -74,7 +109,19 @@ describe('QuestionFormView', () => {
     expect(container.querySelectorAll('input[type="checkbox"]:checked')).toHaveLength(2);
   });
 
-  it('renders object options and submits the readable label', () => {
+  it('parses submitted object-option values from readable answer text', () => {
+    expect(
+      parseSubmittedAnswers(
+        richForm,
+        [
+          '[form answers - discovery]',
+          '- Primary surface: Mobile (iOS/Android) [value: mobile]',
+        ].join('\n'),
+      ),
+    ).toEqual({ platform: 'mobile' });
+  });
+
+  it('renders radio object options and submits the readable label with stable value', () => {
     const onSubmit = vi.fn();
     render(<QuestionFormView form={richForm} interactive onSubmit={onSubmit} />);
 
@@ -83,11 +130,61 @@ describe('QuestionFormView', () => {
     expect(screen.getByText('Phone-first app prototype')).toBeTruthy();
     expect(screen.getByText('Desktop web')).toBeTruthy();
 
-    fireEvent.click(screen.getByLabelText('Desktop web'));
+    fireEvent.click(screen.getByLabelText('Mobile (iOS/Android)'));
     fireEvent.click(screen.getByRole('button', { name: 'Send answers' }));
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
-    expect(onSubmit.mock.calls[0]?.[0]).toContain('Desktop web');
-    expect(onSubmit.mock.calls[0]?.[0]).not.toContain('mobile');
+    expect(onSubmit.mock.calls[0]?.[0]).toContain(
+      '- Primary surface: Mobile (iOS/Android) [value: mobile]',
+    );
+    expect(onSubmit.mock.calls[0]?.[1]).toEqual({ platform: 'mobile' });
+  });
+
+  it('submits required checkbox object options with stable values', () => {
+    const onSubmit = vi.fn();
+    const { container } = render(
+      <QuestionFormView form={checkboxObjectForm} interactive onSubmit={onSubmit} />,
+    );
+
+    const submit = screen.getByRole('button', { name: 'Send answers' });
+    expect((submit as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.click(screen.getByLabelText('Editorial / magazine'));
+    fireEvent.click(screen.getByLabelText('Soft gradients'));
+
+    expect(container.querySelectorAll('input[type="checkbox"]:checked')).toHaveLength(2);
+    expect((submit as HTMLButtonElement).disabled).toBe(false);
+
+    fireEvent.click(submit);
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit.mock.calls[0]?.[0]).toContain('Editorial / magazine [value: editorial]');
+    expect(onSubmit.mock.calls[0]?.[0]).toContain('Soft gradients [value: soft-gradients]');
+    expect(onSubmit.mock.calls[0]?.[1]).toEqual({
+      tone: ['editorial', 'soft-gradients'],
+    });
+  });
+
+  it('submits required select object options with stable values', () => {
+    const onSubmit = vi.fn();
+    const { container } = render(
+      <QuestionFormView form={selectObjectForm} interactive onSubmit={onSubmit} />,
+    );
+
+    const submit = screen.getByRole('button', { name: 'Send answers' });
+    expect((submit as HTMLButtonElement).disabled).toBe(true);
+
+    const select = container.querySelector('select');
+    if (!select) throw new Error('expected select control');
+    fireEvent.change(select, { target: { value: 'mobile' } });
+
+    expect((submit as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(submit);
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit.mock.calls[0]?.[0]).toContain(
+      '- Primary surface: Mobile (iOS/Android) [value: mobile]',
+    );
+    expect(onSubmit.mock.calls[0]?.[1]).toEqual({ platform: 'mobile' });
   });
 });


### PR DESCRIPTION
<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works.
     Delete this whole block if the PR genuinely doesn't close any issue. -->
Fixes #


# fix question-form dropping object-style options

## Summary

Fix `<question-form>` silently dropping object-style `options`.

`radio` / `checkbox` / `select` questions currently only preserve string arrays:

```ts
options: ['A', 'B']
````

AI-generated forms often emit richer structures:

```ts
options: [
  {
    label: 'Mobile',
    description: 'Phone-first',
    value: 'mobile'
  }
]
```

Those entries were filtered out during parsing, causing:

* controls not rendering
* required questions becoming impossible to complete
* submit button staying disabled

This PR normalizes both formats into a shared internal option structure and updates the form renderer to use `value` for state and `label` for display.

---

## Root cause

`apps/web/src/artifacts/question-form.ts` only preserved string options:

```ts
const options = Array.isArray(qo.options)
  ? qo.options.filter((o): o is string => typeof o === 'string')
  : undefined;
```

Object entries were discarded entirely, leaving `q.options = []`.

`QuestionForm.tsx` only renders choice controls when `q.options` exists, so the UI disappeared even though the question itself parsed successfully.

---

## Changes

### Parser

Added a normalized internal option structure:

```ts
export interface FormOption {
  label: string;
  value: string;
  description?: string;
}
```

Updated `FormQuestion.options`:

```ts
options?: FormOption[];
```

Added option normalization logic:

* string -> `{ label, value }`
* object -> preserve `label`, `description`, `value`
* fallback `value = label`
* invalid entries skipped individually

This keeps legacy forms working while supporting richer AI-generated structures.

---

### Renderer

Updated `apps/web/src/components/QuestionForm.tsx` to:

* use `opt.value` as the internal answer state
* use `opt.label` for display
* support optional `description`
* keep checkbox/radio/select behavior consistent

Examples:

#### Radio

```tsx
checked={value === opt.value}
onChange={() => update(q.id, opt.value)}
```

#### Checkbox

```tsx
arr.includes(opt.value)
```

#### Select

```tsx
<option value={opt.value}>
  {opt.label}
</option>
```

---

### Answer formatting compatibility

`formatFormAnswers()` now maps stored values back to readable labels.

`parseSubmittedAnswers()` supports both:

* legacy label-based history
* new value-based submissions

This preserves compatibility with existing conversation history while allowing stable internal values.

---

## Tests

Added parser coverage for:

* legacy string options
* object-style options
* value fallback behavior
* invalid option filtering

Added component coverage for:

* radio / checkbox / select rendering with object options
* required-state recovery
* label/value compatibility during answer restore

---

## Manual verification

Tested with:

```json
{
  "label": "Primary surface",
  "type": "radio",
  "required": true,
  "options": [
    {
      "label": "Mobile (iOS/Android)",
      "description": "Phone-first",
      "value": "mobile"
    },
    {
      "label": "Desktop web",
      "description": "Desktop-first",
      "value": "desktop"
    }
  ]
}
```

Verified that:

* controls render correctly
* required questions can be completed
* submit button enables correctly
* answers restore correctly from history
* legacy string-array forms still work

---

## Non-goals

This PR intentionally does not change prompting behavior.

Prompt examples may be updated later to explicitly mention object-style options, but parser compatibility is treated as the primary fix.

---

## Why this approach

The fix is intentionally implemented at the parser boundary instead of relying on prompt compliance.

Models already emit object-style options in practice, so the renderer/parser pipeline should tolerate both formats rather than assuming a single strict shape.

This keeps the system backward-compatible while making `<question-form>` resilient to richer structured outputs.

```


