### PR TITLE
prevent duplicate saves and add template deletion

### DIFF
--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -609,6 +609,22 @@ export function getTemplate(db: SqliteDb, id: string) {
   return row ? normalizeTemplate(row) : null;
 }
 
+export function findTemplateByNameAndProject(
+  db: SqliteDb,
+  name: string,
+  sourceProjectId: string,
+) {
+  const row = db
+    .prepare(
+      `SELECT id, name, description, source_project_id AS sourceProjectId,
+              files_json AS filesJson, created_at AS createdAt
+         FROM templates
+        WHERE name = ? AND source_project_id = ?`,
+    )
+    .get(name, sourceProjectId) as DbRow | undefined;
+  return row ? normalizeTemplate(row) : null;
+}
+
 export function insertTemplate(db: SqliteDb, t: DbRow) {
   db.prepare(
     `INSERT INTO templates (id, name, description, source_project_id, files_json, created_at)
@@ -622,6 +638,17 @@ export function insertTemplate(db: SqliteDb, t: DbRow) {
     t.createdAt,
   );
   return getTemplate(db, t.id);
+}
+
+export function updateTemplate(
+  db: SqliteDb,
+  id: string,
+  t: { description: string | null; files: unknown[]; createdAt: number },
+) {
+  db.prepare(
+    `UPDATE templates SET description = ?, files_json = ?, created_at = ? WHERE id = ?`,
+  ).run(t.description, JSON.stringify(t.files), t.createdAt, id);
+  return getTemplate(db, id);
 }
 
 export function deleteTemplate(db: SqliteDb, id: string) {

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -643,11 +643,11 @@ export function insertTemplate(db: SqliteDb, t: DbRow) {
 export function updateTemplate(
   db: SqliteDb,
   id: string,
-  t: { description: string | null; files: unknown[]; createdAt: number },
+  t: { description: string | null; files: unknown[] },
 ) {
   db.prepare(
-    `UPDATE templates SET description = ?, files_json = ?, created_at = ? WHERE id = ?`,
-  ).run(t.description, JSON.stringify(t.files), t.createdAt, id);
+    `UPDATE templates SET description = ?, files_json = ? WHERE id = ?`,
+  ).run(t.description, JSON.stringify(t.files), id);
   return getTemplate(db, id);
 }
 

--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -10,7 +10,7 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
   const { insertProject, validateLinkedDirs, getProject, updateProject, dbDeleteProject, removeProjectDir } = ctx.projectStore;
   const { writeProjectFile, readProjectFile, ensureProject, listFiles, listTabs, setTabs, resolveProjectDir } = ctx.projectFiles;
   const { insertConversation, getConversation, listConversations, updateConversation, deleteConversation, listMessages, upsertMessage, listPreviewComments, upsertPreviewComment, updatePreviewCommentStatus, deletePreviewComment } = ctx.conversations;
-  const { getTemplate, listTemplates, deleteTemplate, insertTemplate } = ctx.templates;
+  const { getTemplate, listTemplates, deleteTemplate, insertTemplate, findTemplateByNameAndProject, updateTemplate } = ctx.templates;
   const { listLatestProjectRunStatuses, listProjectsAwaitingInput, normalizeProjectDisplayStatus, composeProjectDisplayStatus, listProjects } = ctx.status;
   const { subscribeFileEvents, activeProjectEventSinks } = ctx.events;
   const { randomId } = ctx.ids;
@@ -533,14 +533,26 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
           });
         }
       }
-      const t = insertTemplate(db, {
-        id: randomId(),
-        name: name.trim(),
-        description: typeof description === 'string' ? description : null,
-        sourceProjectId,
-        files: snapshot,
-        createdAt: Date.now(),
-      });
+      const trimmedName = name.trim();
+      const descValue = typeof description === 'string' ? description : null;
+      const existing = findTemplateByNameAndProject(db, trimmedName, sourceProjectId);
+      let t;
+      if (existing) {
+        t = updateTemplate(db, existing.id, {
+          description: descValue,
+          files: snapshot,
+          createdAt: Date.now(),
+        });
+      } else {
+        t = insertTemplate(db, {
+          id: randomId(),
+          name: trimmedName,
+          description: descValue,
+          sourceProjectId,
+          files: snapshot,
+          createdAt: Date.now(),
+        });
+      }
       res.json({ template: t });
     } catch (err: any) {
       res.status(400).json({ error: String(err) });

--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -503,6 +503,9 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       if (typeof name !== 'string' || !name.trim()) {
         return res.status(400).json({ error: 'name required' });
       }
+      if (name.length > 100) {
+        return res.status(400).json({ error: 'name must be 100 characters or fewer' });
+      }
       if (typeof sourceProjectId !== 'string') {
         return res.status(400).json({ error: 'sourceProjectId required' });
       }

--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -544,7 +544,6 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
         t = updateTemplate(db, existing.id, {
           description: descValue,
           files: snapshot,
-          createdAt: Date.now(),
         });
       } else {
         t = insertTemplate(db, {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -183,6 +183,8 @@ import {
   insertRoutine,
   insertRoutineRun,
   insertTemplate,
+  findTemplateByNameAndProject,
+  updateTemplate,
   listProjectsAwaitingInput,
   listConversations,
   listDeployments,
@@ -2669,7 +2671,7 @@ export async function startServer({
     updatePreviewCommentStatus,
     deletePreviewComment,
   };
-  const templateDeps = { getTemplate, listTemplates, deleteTemplate, insertTemplate };
+  const templateDeps = { getTemplate, listTemplates, deleteTemplate, insertTemplate, findTemplateByNameAndProject, updateTemplate };
   const projectStatusDeps = {
     listLatestProjectRunStatuses,
     listProjectsAwaitingInput,

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -44,6 +44,7 @@ import {
   importFolderProject,
   listProjects,
   listTemplates,
+  deleteTemplate,
   patchProject,
 } from './state/projects';
 import { useI18n } from './i18n';
@@ -444,6 +445,12 @@ export function App() {
     const list = await listTemplates();
     setTemplates(list);
   }, []);
+
+  const handleDeleteTemplate = useCallback(async (id: string) => {
+    const ok = await deleteTemplate(id);
+    if (ok) await refreshTemplates();
+    return ok;
+  }, [refreshTemplates]);
 
   const reloadMediaProvidersFromDaemon = useCallback(async () => {
     const result = await fetchMediaProvidersFromDaemon();
@@ -894,6 +901,7 @@ export function App() {
           designSystems={enabledDS}
           projects={projects}
           templates={templates}
+          onDeleteTemplate={handleDeleteTemplate}
           promptTemplates={promptTemplates}
           defaultDesignSystemId={config.designSystemId}
           config={config}

--- a/apps/web/src/components/EntryView.tsx
+++ b/apps/web/src/components/EntryView.tsx
@@ -50,6 +50,7 @@ interface Props {
   designSystems: DesignSystemSummary[];
   projects: Project[];
   templates: ProjectTemplate[];
+  onDeleteTemplate: (id: string) => Promise<boolean>;
   promptTemplates: PromptTemplateSummary[];
   defaultDesignSystemId: string | null;
   config: AppConfig;
@@ -227,6 +228,7 @@ export function EntryView({
   designSystems,
   projects,
   templates,
+  onDeleteTemplate,
   promptTemplates,
   defaultDesignSystemId,
   config,
@@ -484,6 +486,7 @@ export function EntryView({
           designSystems={designSystems}
           defaultDesignSystemId={defaultDesignSystemId}
           templates={templates}
+          onDeleteTemplate={onDeleteTemplate}
           promptTemplates={promptTemplates}
           onCreate={handleCreate}
           onImportClaudeDesign={onImportClaudeDesign}

--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -93,6 +93,7 @@ interface Props {
   designSystems: DesignSystemSummary[];
   defaultDesignSystemId: string | null;
   templates: ProjectTemplate[];
+  onDeleteTemplate: (id: string) => Promise<boolean>;
   promptTemplates: PromptTemplateSummary[];
   onCreate: (input: CreateInput) => void;
   onImportClaudeDesign?: (file: File) => Promise<void> | void;
@@ -152,6 +153,7 @@ export function NewProjectPanel({
   designSystems,
   defaultDesignSystemId,
   templates,
+  onDeleteTemplate,
   promptTemplates,
   onCreate,
   onImportClaudeDesign,
@@ -653,6 +655,7 @@ export function NewProjectPanel({
               templates={templates}
               value={templateId}
               onChange={setTemplateId}
+              onDelete={onDeleteTemplate}
             />
             <ToggleRow
               label={t('newproj.toggleAnimations')}
@@ -1010,10 +1013,12 @@ function TemplatePicker({
   templates,
   value,
   onChange,
+  onDelete,
 }: {
   templates: ProjectTemplate[];
   value: string | null;
   onChange: (id: string | null) => void;
+  onDelete: (id: string) => Promise<boolean>;
 }) {
   const t = useT();
   return (
@@ -1041,6 +1046,10 @@ function TemplatePicker({
                 key={tpl.id}
                 active={value === tpl.id}
                 onClick={() => onChange(tpl.id)}
+                onDelete={async () => {
+                  const ok = await onDelete(tpl.id);
+                  if (ok && value === tpl.id) onChange(null);
+                }}
                 name={tpl.name}
                 description={tpl.description ?? fallbackDesc}
               />
@@ -1351,27 +1360,40 @@ function PromptTemplateAvatar({
 function TemplateOption({
   active,
   onClick,
+  onDelete,
   name,
   description,
 }: {
   active: boolean;
   onClick: () => void;
+  onDelete: () => void;
   name: string;
   description: string;
 }) {
   return (
-    <button
-      type="button"
-      className={`template-option${active ? ' active' : ''}`}
-      onClick={onClick}
-      aria-pressed={active}
-    >
-      <span className={`template-radio${active ? ' active' : ''}`} aria-hidden />
-      <span className="template-option-text">
-        <span className="template-option-name">{name}</span>
-        <span className="template-option-desc">{description}</span>
-      </span>
-    </button>
+    <div className={`template-option${active ? ' active' : ''}`}>
+      <button
+        type="button"
+        className="template-option-select"
+        onClick={onClick}
+        aria-pressed={active}
+      >
+        <span className={`template-radio${active ? ' active' : ''}`} aria-hidden />
+        <span className="template-option-text">
+          <span className="template-option-name">{name}</span>
+          <span className="template-option-desc">{description}</span>
+        </span>
+      </button>
+      <button
+        type="button"
+        className="template-option-delete"
+        onClick={(e) => { e.stopPropagation(); onDelete(); }}
+        title="Delete template"
+        aria-label={`Delete template ${name}`}
+      >
+        ✕
+      </button>
+    </div>
   );
 }
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4272,13 +4272,10 @@ code {
 }
 .template-option {
   display: flex;
-  align-items: flex-start;
-  gap: 10px;
-  padding: 12px 14px;
+  align-items: center;
   background: var(--bg-panel);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
-  cursor: pointer;
   text-align: left;
   transition: border-color 120ms ease, background 120ms ease;
 }
@@ -4287,6 +4284,33 @@ code {
   border-color: var(--accent);
   background: var(--accent-tint);
 }
+.template-option-select {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  flex: 1;
+  min-width: 0;
+  padding: 12px 14px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+}
+.template-option-delete {
+  flex: none;
+  padding: 4px 10px;
+  margin-right: 8px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 12px;
+  border-radius: var(--radius-sm);
+  opacity: 0;
+  transition: opacity 120ms ease, color 120ms ease;
+}
+.template-option:hover .template-option-delete { opacity: 1; }
+.template-option-delete:hover { color: var(--danger, #e53e3e); }
 .template-radio {
   flex: none;
   margin-top: 2px;

--- a/apps/web/tests/components/NewProjectPanel.media.test.tsx
+++ b/apps/web/tests/components/NewProjectPanel.media.test.tsx
@@ -26,6 +26,7 @@ describe('NewProjectPanel media provider badges', () => {
         designSystems={[]}
         defaultDesignSystemId={null}
         templates={[]}
+        onDeleteTemplate={vi.fn()}
         promptTemplates={[]}
         onCreate={vi.fn()}
         mediaProviders={{

--- a/apps/web/tests/components/NewProjectPanel.test.tsx
+++ b/apps/web/tests/components/NewProjectPanel.test.tsx
@@ -90,6 +90,7 @@ describe('NewProjectPanel design system defaults', () => {
         designSystems={designSystems}
         defaultDesignSystemId="clay"
         templates={[]}
+        onDeleteTemplate={vi.fn()}
         promptTemplates={[]}
         onCreate={vi.fn()}
       />,
@@ -119,6 +120,7 @@ describe('NewProjectPanel design system defaults', () => {
         designSystems={designSystems}
         defaultDesignSystemId="clay"
         templates={[]}
+        onDeleteTemplate={vi.fn()}
         promptTemplates={[]}
         onCreate={onCreate}
       />,
@@ -156,6 +158,7 @@ describe('NewProjectPanel design system defaults', () => {
         designSystems={designSystems}
         defaultDesignSystemId="clay"
         templates={[]}
+        onDeleteTemplate={vi.fn()}
         promptTemplates={[]}
         onCreate={onCreate}
       />,
@@ -195,6 +198,7 @@ describe('NewProjectPanel design system defaults', () => {
         designSystems={designSystems}
         defaultDesignSystemId={null}
         templates={[]}
+        onDeleteTemplate={vi.fn()}
         promptTemplates={[]}
         onCreate={onCreate}
       />,
@@ -224,6 +228,7 @@ describe('NewProjectPanel design system defaults', () => {
         designSystems={designSystems}
         defaultDesignSystemId="clay"
         templates={[]}
+        onDeleteTemplate={vi.fn()}
         promptTemplates={[]}
         onCreate={onCreate}
         connectors={[]}
@@ -257,6 +262,7 @@ describe('NewProjectPanel design system defaults', () => {
         designSystems={designSystems}
         defaultDesignSystemId="clay"
         templates={[]}
+        onDeleteTemplate={vi.fn()}
         promptTemplates={[]}
         onCreate={onCreate}
       />,
@@ -288,6 +294,7 @@ describe('NewProjectPanel design system defaults', () => {
         designSystems={designSystems}
         defaultDesignSystemId="clay"
         templates={[]}
+        onDeleteTemplate={vi.fn()}
         promptTemplates={[]}
         onCreate={emptyOnCreate}
       />,
@@ -307,6 +314,7 @@ describe('NewProjectPanel design system defaults', () => {
         designSystems={designSystems}
         defaultDesignSystemId="clay"
         templates={templates}
+        onDeleteTemplate={vi.fn()}
         promptTemplates={[]}
         onCreate={templateOnCreate}
       />,
@@ -341,6 +349,7 @@ describe('NewProjectPanel design system defaults', () => {
         designSystems={designSystems}
         defaultDesignSystemId="clay"
         templates={[]}
+        onDeleteTemplate={vi.fn()}
         promptTemplates={[]}
         onCreate={onCreate}
       />,
@@ -378,6 +387,7 @@ describe('NewProjectPanel design system defaults', () => {
         designSystems={designSystems}
         defaultDesignSystemId="clay"
         templates={[]}
+        onDeleteTemplate={vi.fn()}
         promptTemplates={[]}
         onCreate={onCreate}
       />,
@@ -415,6 +425,7 @@ describe('NewProjectPanel design system defaults', () => {
         designSystems={designSystems}
         defaultDesignSystemId="clay"
         templates={[]}
+        onDeleteTemplate={vi.fn()}
         promptTemplates={[]}
         onCreate={onCreate}
       />,
@@ -495,6 +506,7 @@ describe('NewProjectPanel design system defaults', () => {
         designSystems={designSystems}
         defaultDesignSystemId="clay"
         templates={[]}
+        onDeleteTemplate={vi.fn()}
         promptTemplates={[]}
         onCreate={onCreate}
       />,

--- a/apps/web/tests/components/NewProjectPanel.test.tsx
+++ b/apps/web/tests/components/NewProjectPanel.test.tsx
@@ -531,3 +531,30 @@ describe('NewProjectPanel design system defaults', () => {
     );
   });
 });
+
+describe('NewProjectPanel template deletion', () => {
+  beforeEach(() => {
+    globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+    Element.prototype.scrollIntoView = () => {};
+  });
+
+  it('calls onDeleteTemplate when user clicks delete button', async () => {
+    const onDelete = vi.fn().mockResolvedValue(true);
+    render(
+      <NewProjectPanel
+        skills={skills}
+        designSystems={designSystems}
+        defaultDesignSystemId="clay"
+        templates={templates}
+        onDeleteTemplate={onDelete}
+        promptTemplates={[]}
+        onCreate={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: 'From template' }));
+    const deleteBtn = screen.getByLabelText(/delete template/i);
+    fireEvent.click(deleteBtn);
+    expect(onDelete).toHaveBeenCalledWith('tmpl-landing');
+  });
+});


### PR DESCRIPTION
Fixes #1237 , Fixes #1252

  ## Summary
  - **Duplicate save prevention (#1237)**: When saving a template with the same `name`+`source_project_id` that already exists, the existing record is updated instead of creating a duplicate entry
    - Added `findTemplateByNameAndProject()` lookup in the daemon DB layer
    - Added `updateTemplate()` to overwrite description, files snapshot, and timestamp
    - POST `/api/templates` handler now checks for existing match before insert
  - **Template deletion UI (#1252)**: Added a delete button to the saved template list
   in the template picker
    - Each template shows a ✕ button on hover, calling the existing `DELETE /api/templates/:id` endpoint
    - Template list refreshes automatically after deletion
    - If the currently selected template is deleted, selection resets to none

  ## Validation
  - Save a file as template with name "test-template"
  - Save the same file again with the same name → template list shows 1 entry
  (updated), not 2
  - Save with a different name → new entry created as expected
  - Hover over a saved template → x delete button appears
  - Click x → template is removed from the list and does not reappear after refresh