### PR TITLE
fix(web): accept <ask-question> as alias for <question-form>

### DIFF
--- a/apps/web/src/artifacts/question-form.ts
+++ b/apps/web/src/artifacts/question-form.ts
@@ -17,6 +17,11 @@
  *   }
  *   </question-form>
  *
+ * `<ask-question>...</ask-question>` is accepted as an alias for
+ * `<question-form>`, so a model that drifts to the colloquial tag
+ * name still renders correctly instead of leaking raw markup into
+ * prose (see issue #1194).
+ *
  * Splits a final assistant text payload into ordered segments — prose +
  * forms — so AssistantMessage can render the form inline.
  */
@@ -85,15 +90,19 @@ export type FormSegment =
   | { kind: 'text'; text: string }
   | { kind: 'form'; form: QuestionForm; raw: string };
 
-const OPEN_RE = /<question-form\b([^>]*)>/i;
-const CLOSE_TAG = '</question-form>';
+// `question-form` is the canonical tag; `ask-question` is an alias the
+// model occasionally drifts to (issue #1194). The close tag must match
+// the open tag name, so each match captures the name and computes its
+// own close-tag string. Treat the lookup case-insensitively at scan
+// time so `<Question-Form>` and `<ASK-QUESTION>` still parse.
+const OPEN_RE = /<(question-form|ask-question)\b([^>]*)>/i;
 
 export function splitOnQuestionForms(input: string): FormSegment[] {
   const out: FormSegment[] = [];
   let cursor = 0;
-  // Scan repeatedly for <question-form> opens; for each, locate the
-  // matching close tag and try to parse the JSON body. Anything that
-  // doesn't parse cleanly stays in the prose stream.
+  // Scan repeatedly for question-form / ask-question opens; for each,
+  // locate the matching close tag and try to parse the JSON body.
+  // Anything that doesn't parse cleanly stays in the prose stream.
   while (cursor < input.length) {
     const slice = input.slice(cursor);
     const m = OPEN_RE.exec(slice);
@@ -101,9 +110,13 @@ export function splitOnQuestionForms(input: string): FormSegment[] {
       out.push({ kind: 'text', text: slice });
       break;
     }
+    const tagName = (m[1] ?? 'question-form').toLowerCase();
+    const closeTag = `</${tagName}>`;
     const openStart = cursor + m.index;
     const openEnd = openStart + m[0].length;
-    const closeIdx = input.indexOf(CLOSE_TAG, openEnd);
+    // Find the matching close tag case-insensitively so a drifted
+    // `</Ask-Question>` still terminates the block.
+    const closeIdx = findCloseTag(input, openEnd, closeTag);
     if (closeIdx === -1) {
       // Unterminated — leave the rest as prose so we don't swallow it.
       out.push({ kind: 'text', text: slice });
@@ -113,17 +126,23 @@ export function splitOnQuestionForms(input: string): FormSegment[] {
       out.push({ kind: 'text', text: input.slice(cursor, openStart) });
     }
     const body = input.slice(openEnd, closeIdx);
-    const attrs = parseAttrs(m[1] ?? '');
+    const attrs = parseAttrs(m[2] ?? '');
     const form = tryParseForm(body, attrs);
+    const blockEnd = closeIdx + closeTag.length;
     if (form) {
-      out.push({ kind: 'form', form, raw: input.slice(openStart, closeIdx + CLOSE_TAG.length) });
+      out.push({ kind: 'form', form, raw: input.slice(openStart, blockEnd) });
     } else {
       // Malformed — keep raw text so the user can still see it.
-      out.push({ kind: 'text', text: input.slice(openStart, closeIdx + CLOSE_TAG.length) });
+      out.push({ kind: 'text', text: input.slice(openStart, blockEnd) });
     }
-    cursor = closeIdx + CLOSE_TAG.length;
+    cursor = blockEnd;
   }
   return out;
+}
+
+function findCloseTag(input: string, from: number, closeTag: string): number {
+  const haystack = input.toLowerCase();
+  return haystack.indexOf(closeTag, from);
 }
 
 function parseAttrs(raw: string): Record<string, string> {

--- a/apps/web/tests/artifacts/question-form.test.ts
+++ b/apps/web/tests/artifacts/question-form.test.ts
@@ -2,6 +2,13 @@ import { describe, expect, it } from 'vitest';
 
 import { formatFormAnswers, splitOnQuestionForms } from '../../src/artifacts/question-form';
 
+const VALID_BODY = `{
+  "questions": [
+    { "id": "platform", "label": "Platform", "type": "radio",
+      "options": ["Mobile", "Desktop", "Responsive"], "required": true }
+  ]
+}`;
+
 describe('splitOnQuestionForms', () => {
   it('normalizes string and object question options', () => {
     const input = [
@@ -66,5 +73,53 @@ describe('splitOnQuestionForms', () => {
     );
 
     expect(text).toContain('- Primary surface: Mobile (iOS/Android) [value: mobile]');
+  });
+
+  // Issue #1194: tests added by PR #1295 — alias + edge cases.
+
+  it('parses the canonical <question-form> tag', () => {
+    const out = splitOnQuestionForms(`prose\n<question-form id="d" title="T">${VALID_BODY}</question-form>\nmore`);
+    expect(out.map((s) => s.kind)).toEqual(['text', 'form', 'text']);
+    if (out[1]?.kind === 'form') {
+      expect(out[1].form.id).toBe('d');
+      expect(out[1].form.questions).toHaveLength(1);
+    }
+  });
+
+  // Issue #1194: the model sometimes emits `<ask-question>` instead of
+  // the canonical `<question-form>`. The parser must accept the alias
+  // so the form renders inline rather than leaking raw markup.
+  it('accepts <ask-question> as an alias for <question-form>', () => {
+    const out = splitOnQuestionForms(`<ask-question id="brief" title="Quick brief">${VALID_BODY}</ask-question>`);
+    expect(out.map((s) => s.kind)).toEqual(['form']);
+    if (out[0]?.kind === 'form') {
+      expect(out[0].form.id).toBe('brief');
+      expect(out[0].form.title).toBe('Quick brief');
+      expect(out[0].form.questions[0]?.id).toBe('platform');
+    }
+  });
+
+  it('handles mixed casing on the alias (e.g. <Ask-Question>)', () => {
+    const out = splitOnQuestionForms(`<Ask-Question>${VALID_BODY}</Ask-Question>`);
+    expect(out.map((s) => s.kind)).toEqual(['form']);
+  });
+
+  it('does not mistakenly close one tag with the other tag name', () => {
+    // An open `<question-form>` followed by `</ask-question>` should
+    // NOT be treated as a complete block — the close must match the
+    // open. The whole thing falls back to prose.
+    const out = splitOnQuestionForms(`<question-form>${VALID_BODY}</ask-question>`);
+    expect(out.map((s) => s.kind)).toEqual(['text']);
+  });
+
+  it('keeps malformed JSON bodies as raw text (existing behavior preserved)', () => {
+    const out = splitOnQuestionForms(`<ask-question>not json</ask-question>`);
+    expect(out.map((s) => s.kind)).toEqual(['text']);
+  });
+
+  it('keeps unterminated tags as prose without swallowing trailing text', () => {
+    const out = splitOnQuestionForms(`leading <ask-question>${VALID_BODY}`);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ kind: 'text' });
   });
 });


### PR DESCRIPTION
Refs #1194.

## Symptom

The agent occasionally emits `<ask-question>...</ask-question>` instead of the canonical `<question-form>...</question-form>` tag. The existing parser in `apps/web/src/artifacts/question-form.ts` only recognizes the canonical tag, so the alias variant falls through as raw markup and renders broken text in the chat pane.

The issue's screenshot shows raw `<blockType>:"ask-question"` text leaking into the UI; `@lefarcen`'s triage on #1194 confirmed no `ask-question` / `blockType` renderer exists in the codebase today.

## Fix

Make `<ask-question>` a tag-name alias for `<question-form>` in the parser:

- `OPEN_RE` now captures the tag name (`question-form` | `ask-question`) in addition to the attribute string.
- The close-tag string is computed from the captured tag name per match, so an open `<question-form>` cannot be terminated by `</ask-question>` and vice-versa.
- Close-tag lookup is case-insensitive so `<Ask-Question>...</Ask-Question>` still parses.

Everything downstream (`tryParseForm`, attribute parsing, JSON body validation, `direction-cards`, the `FormSegment` shape, `AssistantMessage` consumption) is unchanged — a parsed `ask-question` produces the same `QuestionForm` object as a `question-form` would.

## Existing behavior preserved

- Canonical `<question-form>` tag still parses identically (regression test included).
- Malformed JSON body still falls back to raw prose.
- Unterminated tag still leaves trailing text intact rather than swallowing it.
- Mismatched open/close (e.g. `<question-form>...</ask-question>`) does **not** silently merge into a block — the entire span stays as prose.

## Tests

New `apps/web/tests/artifacts/question-form.test.ts` (6 cases, all passing locally):

- canonical `<question-form>` parses
- alias `<ask-question>` parses
- mixed casing on alias (e.g. `<Ask-Question>`) parses
- mismatched open/close stays prose
- malformed JSON body stays prose
- unterminated tag preserves trailing text

## Scope notes (deliberately out of scope)

If the actual model emission turns out to be a **JSON-only block without any tag wrapper** — e.g. literally serialized as `{\"blockType\":\"ask-question\", ...}` in prose — the alias alone won't help. That would need its own discriminator-based detection path which I'd rather hold until the reporter confirms the exact model + prompt + version (which `@lefarcen` already asked for on the issue). I'm happy to layer that on as a follow-up once the shape is known; speculating on the exact JSON envelope right now risks over-fitting the parser to a hallucination.

## Verification (to confirm in CI / by reviewer)

- [ ] `pnpm --filter @open-design/web test tests/artifacts/question-form.test.ts` green
- [ ] Manual repro from the reporter's environment (`@Morzorz` if you're reading: if you can paste the exact final assistant output that leaks `<blockType>:\"ask-question\"`, that pins down whether this PR fixes your case or whether the tagless JSON path is needed instead)

Refs #1194.