### PR TITLE
feat(i18n): Phase 1 README locale drift detection

### DIFF
--- a/.github/workflows/readme-drift.yml
+++ b/.github/workflows/readme-drift.yml
@@ -90,6 +90,8 @@ jobs:
       - name: Post PR comment
         if: steps.drift.outputs.has_drift == 'true'
         uses: actions/github-script@v7
+        env:
+          DRIFT_OUTPUT: ${{ steps.drift.outputs.drift }}
         with:
           script: |
             const body = [
@@ -105,7 +107,6 @@ jobs:
               '> To update, find your locale in the table above and bump the `l10n-source-commit` annotation.',
             ].join('\n');
 
-            const { DATA: commentBody } = process.env;
             const { number: prNumber } = context.payload.pull_request;
             const { owner, repo } = context.repo;
 
@@ -206,6 +207,11 @@ jobs:
 
       - name: Upsert tracking issue
         uses: actions/github-script@v7
+        env:
+          HEAD_SHA: ${{ steps.state.outputs.head_sha }}
+          TOTAL_H2: ${{ steps.state.outputs.total_h2 }}
+          DRIFT_MARKDOWN: ${{ steps.state.outputs.drift_md }}
+          TOTAL_BEHIND: ${{ steps.state.outputs.total_behind }}
         with:
           script: |
             const { owner, repo } = context.repo;

--- a/.github/workflows/readme-drift.yml
+++ b/.github/workflows/readme-drift.yml
@@ -270,7 +270,21 @@ jobs:
             const ours = existing.data.find(i => i.title.startsWith('README locales out of sync'));
 
             if (ours) {
-              // Append new snapshot as comment, then update body with collapsed history
+              // Append a history comment before updating body (preserves prior snapshots)
+              const historyComment = [
+                `### Snapshot — ${weekOf}`,
+                '',
+                `**Source:** \`README.md\` @ [\`${headSha.slice(0, 7)}\`](https://github.com/${owner}/${repo}/commit/${headSha}) · ${totalH2} H2 · ${totalBehind} behind`,
+                '',
+                driftMd || '- (no locale READMEs found)',
+              ].join('\n');
+
+              await github.rest.issues.createComment({
+                owner, repo,
+                issue_number: ours.number,
+                body: historyComment,
+              });
+
               const newBody = [
                 '## 📖 README Locale Sync Status — latest',
                 '',

--- a/.github/workflows/readme-drift.yml
+++ b/.github/workflows/readme-drift.yml
@@ -1,0 +1,256 @@
+name: README Locale Drift
+
+on:
+  pull_request:
+    paths:
+      - 'README.md'
+  schedule:
+    # Every Monday at 09:00 UTC
+    - cron: '0 9 * * 1'
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  # ─── PR trigger: comment on README.md PRs with behind-locale summary ───
+  pr-comment:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect drifting locales
+        id: drift
+        run: |
+          set -euo pipefail
+
+          readonly HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          readonly SOURCE_FILE="README.md"
+
+          # Map locale suffix → README file
+          declare -A LOCALES=(
+            [ar]="README.ar.md"
+            [de]="README.de.md"
+            [es]="README.es.md"
+            [fr]="README.fr.md"
+            [ja-JP]="README.ja-JP.md"
+            [ko]="README.ko.md"
+            [pt-BR]="README.pt-BR.md"
+            [ru]="README.ru.md"
+            [tr]="README.tr.md"
+            [uk]="README.uk.md"
+            [zh-CN]="README.zh-CN.md"
+            [zh-TW]="README.zh-TW.md"
+          )
+
+          DRIFT_OUTPUT=""
+          UP_TO_DATE=""
+
+          for locale in "${!LOCALES[@]}"; do
+            readme="${LOCALES[$locale]}"
+
+            # Read the annotated SHA from the translated README
+            annotated_sha=$(grep -m1 'l10n-source-commit:' "$readme" 2>/dev/null | sed 's/.*l10n-source-commit: //' | tr -d ' ')
+            if [[ -z "$annotated_sha" ]]; then
+              # No annotation yet — skip rather than false positive
+              continue
+            fi
+
+            # Check if the annotated SHA exists in history (handle rebased branches)
+            if ! git rev-list --quiet "$annotated_sha" -1 2>/dev/null; then
+              continue
+            fi
+
+            # Count H2 sections that differ between annotated SHA and HEAD
+            h2_annotated=$(git diff "$annotated_sha" HEAD -- "$SOURCE_FILE" 2>/dev/null | grep '^+## ' | wc -l || true)
+            h2_head=$(git diff "$annotated_sha" HEAD -- "$SOURCE_FILE" 2>/dev/null | grep '^-## ' | wc -l || true)
+
+            # Total number of H2 sections in HEAD (for context)
+            total_h2=$(grep -c '^## ' "$SOURCE_FILE" 2>/dev/null || echo 0)
+
+            behind_count=$((h2_annotated > h2_head ? h2_annotated : h2_head))
+
+            if [[ "$behind_count" -gt 0 ]]; then
+              DRIFT_OUTPUT+="- **$locale** — ~$behind_count H2 sections behind\n"
+            else
+              UP_TO_DATE+="- $locale ✅\n"
+            fi
+          done
+
+          echo "drift<<EOF" >> "$GITHUB_OUTPUT"
+          echo -e "${DRIFT_OUTPUT:-None}"
+          echo "EOF"
+          echo "up_to_date<<EOF" >> "$GITHUB_OUTPUT"
+          echo -e "${UP_TO_DATE:-All locales up to date}"
+          echo "EOF"
+          echo "has_drift=$([[ -n "$DRIFT_OUTPUT" ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+      - name: Post PR comment
+        if: steps.drift.outputs.has_drift == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = [
+              '## 📖 README Locale Drift Detected',
+              '',
+              'This PR touched `README.md`. The following locale READMEs are behind the current HEAD:',
+              '',
+              '```',
+              process.env.DRIFT_OUTPUT,
+              '```',
+              '',
+              '> ℹ️ This is a passive signal — not a merge blocker. Locale maintainers sync at their own pace.',
+              '> To update, find your locale in the table above and bump the `l10n-source-commit` annotation.',
+            ].join('\n');
+
+            const { DATA: commentBody } = process.env;
+            const { number: prNumber } = context.payload.pull_request;
+            const { owner, repo } = context.repo;
+
+            // Check if we already commented
+            const existing = await github.rest.issues.listComments({
+              owner, repo,
+              issue_number: prNumber,
+              per_page: 50,
+            });
+
+            const ourComment = existing.data.find(c =>
+              c.user.login === 'github-actions[bot]' &&
+              c.body.includes('README Locale Drift Detected')
+            );
+
+            if (ourComment) {
+              await github.rest.issues.updateComment({
+                owner, repo,
+                comment_id: ourComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo,
+                issue_number: prNumber,
+                body,
+              });
+            }
+
+  # ─── Cron trigger: open/update rolling tracking issue ───
+  track:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Compute drift state
+        id: state
+        run: |
+          set -euo pipefail
+
+          readonly HEAD_SHA=$(git rev-parse HEAD)
+          readonly SOURCE_FILE="README.md"
+          readonly TOTAL_H2=$(grep -c '^## ' "$SOURCE_FILE" 2>/dev/null || echo 0)
+
+          declare -A LOCALES=(
+            [ar]="README.ar.md"
+            [de]="README.de.md"
+            [es]="README.es.md"
+            [fr]="README.fr.md"
+            [ja-JP]="README.ja-JP.md"
+            [ko]="README.ko.md"
+            [pt-BR]="README.pt-BR.md"
+            [ru]="README.ru.md"
+            [tr]="README.tr.md"
+            [uk]="README.uk.md"
+            [zh-CN]="README.zh-CN.md"
+            [zh-TW]="README.zh-TW.md"
+          )
+
+          DRIFT_MARKDOWN=""
+          TOTAL_BEHIND=0
+
+          for locale in "${!LOCALES[@]}"; do
+            readme="${LOCALES[$locale]}"
+
+            annotated_sha=$(grep -m1 'l10n-source-commit:' "$readme" 2>/dev/null | sed 's/.*l10n-source-commit: //' | tr -d ' ')
+            if [[ -z "$annotated_sha" ]]; then
+              DRIFT_MARKDOWN+="- [ ] **$locale** — no source commit annotated yet\n"
+              continue
+            fi
+
+            if ! git rev-list --quiet "$annotated_sha" -1 2>/dev/null; then
+              DRIFT_MARKDOWN+="- [ ] **$locale** — annotated SHA `$annotated_sha` not in history (may have been rebased)\n"
+              continue
+            fi
+
+            # H2 sections added in HEAD vs annotated (new sections upstream added)
+            h2_added=$(git diff "$annotated_sha" HEAD -- "$SOURCE_FILE" 2>/dev/null | grep '^+## ' | wc -l || true)
+            h2_removed=$(git diff "$annotated_sha" HEAD -- "$SOURCE_FILE" 2>/dev/null | grep '^-## ' | wc -l || true)
+            behind=$((h2_added > h2_removed ? h2_added : h2_removed))
+
+            if [[ "$behind" -gt 0 ]]; then
+              DRIFT_MARKDOWN+="- [ ] **$locale** — $behind H2 section(s) behind (annotated SHA: \`$annotated_sha\`)\n"
+              TOTAL_BEHIND=$((TOTAL_BEHIND + 1))
+            else
+              DRIFT_MARKDOWN+="- [x] **$locale** — up to date ✅\n"
+            fi
+          done
+
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "total_h2=$TOTAL_H2" >> "$GITHUB_OUTPUT"
+          echo "drift_md<<EOF" >> "$GITHUB_OUTPUT"
+          echo -e "$DRIFT_MARKDOWN"
+          echo "EOF"
+          echo "total_behind=$TOTAL_BEHIND" >> "$GITHUB_OUTPUT"
+
+      - name: Upsert tracking issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const weekOf = new Date().toISOString().slice(0, 10);
+            const title = `README locales out of sync — week of ${weekOf}`;
+            const headSha = process.env.HEAD_SHA;
+            const totalH2 = process.env.TOTAL_H2;
+            const driftMd = process.env.DRIFT_MARKDOWN || '';
+            const totalBehind = parseInt(process.env.TOTAL_BEHIND || '0', 10);
+
+            const body = [
+              '## 📖 README Locale Sync Status',
+              '',
+              `**Source:** \`README.md\` @ [\`${headSha.slice(0, 7)}\`](https://github.com/${owner}/${repo}/commit/${headSha}) · $totalH2 H2 sections total',
+              '',
+              '### Locale checklist',
+              '',
+              driftMd || '- (no locale READMEs found)',
+              '',
+              '---',
+              '*Auto-generated by [`.github/workflows/readme-drift.yml`](.github/workflows/readme-drift.yml) ·兑*',
+            ].join('\n');
+
+            // Look for an existing tracking issue
+            const existing = await github.rest.issues.listForRepo({
+              owner, repo,
+              labels: ['locale-drift'],
+              state: 'open',
+              per_page: 20,
+            });
+
+            const ours = existing.data.find(i => i.title.startsWith('README locales out of sync'));
+
+            if (ours) {
+              await github.rest.issues.update({
+                owner, repo,
+                issue_number: ours.number,
+                title,
+                body,
+              });
+            } else {
+              const created = await github.rest.issues.create({
+                owner, repo,
+                title,
+                body,
+                labels: ['locale-drift'],
+              });
+            }

--- a/.github/workflows/readme-drift.yml
+++ b/.github/workflows/readme-drift.yml
@@ -9,6 +9,7 @@ on:
     - cron: '0 9 * * 1'
 
 permissions:
+  contents: read
   pull-requests: write
   issues: write
 
@@ -20,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Detect drifting locales
         id: drift
@@ -58,22 +61,26 @@ jobs:
               continue
             fi
 
-            # Check if the annotated SHA exists in history (handle rebased branches)
-            if ! git rev-list --quiet "$annotated_sha" -1 2>/dev/null; then
+            # Validate SHA format (7-40 hex chars)
+            if ! [[ "$annotated_sha" =~ ^[0-9a-f]{7,40}$ ]]; then
+              DRIFT_OUTPUT+="- **$locale** — invalid annotation format, cannot compare\n"
               continue
             fi
 
-            # Count H2 sections that differ between annotated SHA and HEAD
-            h2_annotated=$(git diff "$annotated_sha" HEAD -- "$SOURCE_FILE" 2>/dev/null | grep '^+## ' | wc -l || true)
-            h2_head=$(git diff "$annotated_sha" HEAD -- "$SOURCE_FILE" 2>/dev/null | grep '^-## ' | wc -l || true)
+            # Verify annotated SHA is a commit ancestor of HEAD
+            if ! git merge-base --is-ancestor "$annotated_sha" HEAD 2>/dev/null; then
+              DRIFT_OUTPUT+="- **$locale** — annotated SHA \`$annotated_sha\` is not an ancestor of HEAD (branch may have been force-pushed)\n"
+              continue
+            fi
 
-            # Total number of H2 sections in HEAD (for context)
-            total_h2=$(grep -c '^## ' "$SOURCE_FILE" 2>/dev/null || echo 0)
-
-            behind_count=$((h2_annotated > h2_head ? h2_annotated : h2_head))
-
-            if [[ "$behind_count" -gt 0 ]]; then
-              DRIFT_OUTPUT+="- **$locale** — ~$behind_count H2 sections behind\n"
+            # Any content diff since annotation → locale is behind
+            has_diff=$(git diff "$annotated_sha" HEAD -- "$SOURCE_FILE" 2>/dev/null | grep -c '^[+-]' || true)
+            if [[ "$has_diff" -gt 0 ]]; then
+              # Count H2 sections added/removed for human-readable summary
+              h2_added=$(git diff "$annotated_sha" HEAD -- "$SOURCE_FILE" 2>/dev/null | grep '^+## ' | wc -l || true)
+              h2_removed=$(git diff "$annotated_sha" HEAD -- "$SOURCE_FILE" 2>/dev/null | grep '^-## ' | wc -l || true)
+              behind_count=$((h2_added > h2_removed ? h2_added : h2_removed))
+              DRIFT_OUTPUT+="- **$locale** — $behind_count H2 section(s) behind (annotated \`$annotated_sha\`)\n"
             else
               UP_TO_DATE+="- $locale ✅\n"
             fi
@@ -89,6 +96,7 @@ jobs:
 
       - name: Post PR comment
         if: steps.drift.outputs.has_drift == 'true'
+        continue-on-error: true
         uses: actions/github-script@v7
         env:
           DRIFT_OUTPUT: ${{ steps.drift.outputs.drift }}
@@ -143,6 +151,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure locale-drift label exists
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const labelName = 'locale-drift';
+            try {
+              await github.rest.issues.getLabel({ owner, repo, name: labelName });
+            } catch {
+              // Label doesn't exist — create it
+              await github.rest.issues.createLabel({ owner, repo, name: labelName, color: 'ff6b6b', description: 'Tracks README locale drift detection workflow state' });
+            }
 
       - name: Compute drift state
         id: state
@@ -180,17 +203,23 @@ jobs:
               continue
             fi
 
-            if ! git rev-list --quiet "$annotated_sha" -1 2>/dev/null; then
-              DRIFT_MARKDOWN+="- [ ] **$locale** — annotated SHA `$annotated_sha` not in history (may have been rebased)\n"
+            # Validate SHA format
+            if ! [[ "$annotated_sha" =~ ^[0-9a-f]{7,40}$ ]]; then
+              DRIFT_MARKDOWN+="- [ ] **$locale** — invalid annotation format\n"
               continue
             fi
 
-            # H2 sections added in HEAD vs annotated (new sections upstream added)
-            h2_added=$(git diff "$annotated_sha" HEAD -- "$SOURCE_FILE" 2>/dev/null | grep '^+## ' | wc -l || true)
-            h2_removed=$(git diff "$annotated_sha" HEAD -- "$SOURCE_FILE" 2>/dev/null | grep '^-## ' | wc -l || true)
-            behind=$((h2_added > h2_removed ? h2_added : h2_removed))
+            if ! git merge-base --is-ancestor "$annotated_sha" HEAD 2>/dev/null; then
+              DRIFT_MARKDOWN+="- [ ] **$locale** — annotated SHA \`$annotated_sha\` not an ancestor of HEAD\n"
+              continue
+            fi
 
-            if [[ "$behind" -gt 0 ]]; then
+            # Any content diff → behind
+            has_diff=$(git diff "$annotated_sha" HEAD -- "$SOURCE_FILE" 2>/dev/null | grep -c '^[+-]' || true)
+            if [[ "$has_diff" -gt 0 ]]; then
+              h2_added=$(git diff "$annotated_sha" HEAD -- "$SOURCE_FILE" 2>/dev/null | grep '^+## ' | wc -l || true)
+              h2_removed=$(git diff "$annotated_sha" HEAD -- "$SOURCE_FILE" 2>/dev/null | grep '^-## ' | wc -l || true)
+              behind=$((h2_added > h2_removed ? h2_added : h2_removed))
               DRIFT_MARKDOWN+="- [ ] **$locale** — $behind H2 section(s) behind (annotated SHA: \`$annotated_sha\`)\n"
               TOTAL_BEHIND=$((TOTAL_BEHIND + 1))
             else
@@ -216,23 +245,18 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const weekOf = new Date().toISOString().slice(0, 10);
-            const title = `README locales out of sync — week of ${weekOf}`;
-            const headSha = process.env.HEAD_SHA;
-            const totalH2 = process.env.TOTAL_H2;
+            const headSha = process.env.HEAD_SHA || '';
+            const totalH2 = process.env.TOTAL_H2 || '0';
             const driftMd = process.env.DRIFT_MARKDOWN || '';
             const totalBehind = parseInt(process.env.TOTAL_BEHIND || '0', 10);
 
-            const body = [
-              '## 📖 README Locale Sync Status',
+            const currentSnapshot = [
+              `### ${weekOf}`,
               '',
-              `**Source:** \`README.md\` @ [\`${headSha.slice(0, 7)}\`](https://github.com/${owner}/${repo}/commit/${headSha}) · $totalH2 H2 sections total',
-              '',
-              '### Locale checklist',
+              `**Source:** \`README.md\` @ [\`${headSha.slice(0, 7)}\`](https://github.com/${owner}/${repo}/commit/${headSha}) · ${totalH2} H2 sections total · ${totalBehind} locale(s) behind`,
               '',
               driftMd || '- (no locale READMEs found)',
               '',
-              '---',
-              '*Auto-generated by [`.github/workflows/readme-drift.yml`](.github/workflows/readme-drift.yml) ·兑*',
             ].join('\n');
 
             // Look for an existing tracking issue
@@ -246,17 +270,36 @@ jobs:
             const ours = existing.data.find(i => i.title.startsWith('README locales out of sync'));
 
             if (ours) {
+              // Append new snapshot as comment, then update body with collapsed history
+              const newBody = [
+                '## 📖 README Locale Sync Status — latest',
+                '',
+                currentSnapshot,
+                '',
+                '---',
+                '*Auto-generated by [`.github/workflows/readme-drift.yml`](.github/workflows/readme-drift.yml) ·兑*',
+              ].join('\n');
+
               await github.rest.issues.update({
                 owner, repo,
                 issue_number: ours.number,
-                title,
-                body,
+                title: `README locales out of sync — week of ${weekOf}`,
+                body: newBody,
               });
             } else {
-              const created = await github.rest.issues.create({
+              const newBody = [
+                '## 📖 README Locale Sync Status — latest',
+                '',
+                currentSnapshot,
+                '',
+                '---',
+                '*Auto-generated by [`.github/workflows/readme-drift.yml`](.github/workflows/readme-drift.yml) ·兑*',
+              ].join('\n');
+
+              await github.rest.issues.create({
                 owner, repo,
-                title,
-                body,
+                title: `README locales out of sync — week of ${weekOf}`,
+                body: newBody,
                 labels: ['locale-drift'],
               });
             }

--- a/README.ar.md
+++ b/README.ar.md
@@ -1,5 +1,7 @@
 <div dir="rtl">
 
+<!-- l10n-source-commit: 87a95b7fb4eeb0a5c954dbe0dea95b3fa5c0dc46 -->
+
 # Open Design
 
 > **البديل مفتوح المصدر لـ [Claude Design][cd].** يعمل محلياً أولاً، قابل للنشر على Vercel، ويدعم BYOK في كل طبقة — **16 أداة CLI لوكلاء البرمجة** يكتشفها تلقائياً من `PATH` (Claude Code, Codex, Devin for Terminal, Cursor Agent, Gemini CLI, OpenCode, Qwen, Qoder CLI, GitHub Copilot CLI, Hermes, Kimi, Pi, Kiro, Kilo, Mistral Vibe, DeepSeek TUI) لتصبح هي محرّك التصميم، مدفوعةً بـ **31 Skill قابلة للتركيب** و**72 نظام تصميم بمستوى الهوية البصرية**. لا توجد لديك CLI؟ بروكسي BYOK متوافق مع OpenAI يقدّم نفس الحلقة بدون عملية الـ spawn.

--- a/README.de.md
+++ b/README.de.md
@@ -1,3 +1,4 @@
+<!-- l10n-source-commit: 87a95b7fb4eeb0a5c954dbe0dea95b3fa5c0dc46 -->
 # Open Design
 
 > **Die Open-Source-Alternative zu [Claude Design][cd].** Local-first, web-deploybar, BYOK auf jeder Ebene: **16 coding-agent CLIs** werden automatisch in Ihrem `PATH` erkannt (Claude Code, Codex, Devin for Terminal, Cursor Agent, Gemini CLI, OpenCode, Qwen, Qoder CLI, GitHub Copilot CLI, Hermes, Kimi, Pi, Kiro, Kilo, Mistral Vibe, DeepSeek TUI) und werden zur Design-Engine, gesteuert von **31 kombinierbaren Skills** und **72 brandreifen Design Systems**. Keine CLI? Ein OpenAI-kompatibler BYOK-Proxy ist dieselbe Schleife ohne Spawn.

--- a/README.es.md
+++ b/README.es.md
@@ -1,3 +1,5 @@
+<!-- l10n-source-commit: 87a95b7fb4eeb0a5c954dbe0dea95b3fa5c0dc46 -->
+
 # Open Design
 
 > **La alternativa open source a [Claude Design][cd].** Local-first, desplegable en web, BYOK en cada capa: **16 CLI de coding agents** detectadas automáticamente en tu `PATH` (Claude Code, Codex, Devin for Terminal, Cursor Agent, Gemini CLI, OpenCode, Qwen, Qoder CLI, GitHub Copilot CLI, Hermes, Kimi, Pi, Kiro, Kilo, Mistral Vibe, DeepSeek TUI) se convierten en el motor de diseño, impulsadas por **31 Skills componibles** y **72 Design Systems de nivel marca**. ¿No tienes una CLI? Un proxy BYOK compatible con OpenAI ejecuta el mismo bucle sin el spawn local.

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,3 +1,5 @@
+<!-- l10n-source-commit: 87a95b7fb4eeb0a5c954dbe0dea95b3fa5c0dc46 -->
+
 # Open Design
 
 > **L’alternative open source à [Claude Design][cd].** Local-first, déployable sur le web, BYOK à chaque couche : vos CLI de coding agents détectées automatiquement dans le `PATH` deviennent le design engine, piloté par les catalogues de **Skills** et de **Design Systems** du repo. Aucune CLI ? Le proxy BYOK multi-provider exécute la même boucle, sans spawn local.

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -1,3 +1,5 @@
+<!-- l10n-source-commit: 87a95b7fb4eeb0a5c954dbe0dea95b3fa5c0dc46 -->
+
 # Open Design
 
 > **[Claude Design][cd] のオープンソース代替。** ローカルファースト、Vercel デプロイ可能、あらゆるレイヤーで BYOK（Bring Your Own Key） — `PATH` 上で自動検出される **16 種類の coding-agent CLI**（Claude Code, Codex, Devin for Terminal, Cursor Agent, Gemini CLI, OpenCode, Qwen, Qoder CLI, GitHub Copilot CLI, Hermes, Kimi, Pi, Kiro, Kilo, Mistral Vibe, DeepSeek TUI）がデザインエンジンとなり、**31 個の組み合わせ可能な Skill** と **72 種のブランドグレード Design System** で駆動されます。CLI が未インストールでも、OpenAI 互換の BYOK プロキシ `/api/proxy/stream` で同じループを spawn なしで実行できます。

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,3 +1,5 @@
+<!-- l10n-source-commit: 87a95b7fb4eeb0a5c954dbe0dea95b3fa5c0dc46 -->
+
 # Open Design
 
 > **[Claude Design][cd]의 오픈소스 대안.** 로컬 우선, 웹 배포 가능, 모든 레이어에서 BYOK — `PATH`에서 자동 감지되는 **16개의 코딩 에이전트 CLI**(Claude Code, Codex, Devin for Terminal, Cursor Agent, Gemini CLI, OpenCode, Qwen, Qoder CLI, GitHub Copilot CLI, Hermes, Kimi, Pi, Kiro, Kilo, Mistral Vibe, DeepSeek TUI)가 **31가지 조합 가능한 Skill**과 **72가지 브랜드급 디자인 시스템**으로 구동되는 디자인 엔진이 됩니다. CLI가 하나도 없다? OpenAI 호환 BYOK 프록시가 spawn만 빠진 동일한 루프를 돌립니다.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,3 +1,5 @@
+<!-- l10n-source-commit: 87a95b7fb4eeb0a5c954dbe0dea95b3fa5c0dc46 -->
+
 # Open Design
 
 > **A alternativa open-source ao [Claude Design][cd].** Local-first, deployável via web, BYOK em toda camada — **16 CLIs de agentes de código** detectados automaticamente no seu `PATH` (Claude Code, Codex, Devin for Terminal, Cursor Agent, Gemini CLI, OpenCode, Qwen, Qoder CLI, GitHub Copilot CLI, Hermes, Kimi, Pi, Kiro, Kilo, Mistral Vibe, DeepSeek TUI) viram a engine de design, dirigidos por **31 Skills compositáveis** e **72 Design Systems de qualidade de marca**. Sem CLI? Um proxy BYOK compatível com OpenAI é o mesmo loop, só sem o spawn.

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,3 +1,5 @@
+<!-- l10n-source-commit: 87a95b7fb4eeb0a5c954dbe0dea95b3fa5c0dc46 -->
+
 # Open Design
 
 > **Открытая альтернатива [Claude Design][cd].** Локально-ориентированная, пригодная для web-деплоя, с BYOK на каждом уровне: **16 CLI coding-агентов** автоматически обнаруживаются в вашем `PATH` (Claude Code, Codex, Devin for Terminal, Cursor Agent, Gemini CLI, OpenCode, Qwen, Qoder CLI, GitHub Copilot CLI, Hermes, Kimi, Pi, Kiro, Kilo, Mistral Vibe, DeepSeek TUI) и превращаются в движок генерации дизайна, управляемый **31 комбинируемым навыком** и **72 дизайн-системами уровня бренда**. Нет CLI? OpenAI-совместимый BYOK-прокси даёт тот же цикл без локального запуска агента.

--- a/README.tr.md
+++ b/README.tr.md
@@ -1,3 +1,4 @@
+<!-- l10n-source-commit: 87a95b7fb4eeb0a5c954dbe0dea95b3fa5c0dc46 -->
 # Open Design
 
 > **[Claude Design][cd] için açık kaynak alternatif.** Yerel öncelikli, web'e dağıtılabilir, her katmanda BYOK; `PATH` üzerinde otomatik algılanan **16 coding-agent CLI** (Claude Code, Codex, Devin for Terminal, Cursor Agent, Gemini CLI, OpenCode, Qwen, Qoder CLI, GitHub Copilot CLI, Hermes, Kimi, Pi, Kiro, Kilo, Mistral Vibe, DeepSeek TUI) tasarım motoruna dönüşür. Hepsi **31 birleştirilebilir Skill** ve **72 marka kalitesinde Design System** tarafından yönlendirilir. CLI yok mu? OpenAI uyumlu BYOK proxy aynı döngünün agent spawn olmadan çalışan halidir.

--- a/README.uk.md
+++ b/README.uk.md
@@ -1,3 +1,5 @@
+<!-- l10n-source-commit: 87a95b7fb4eeb0a5c954dbe0dea95b3fa5c0dc46 -->
+
 # Open Design
 
 > **Альтернатива з відкритим кодом до [Claude Design][cd].** Локально-перший, розгортується в web, BYOK на кожному рівні — **16 CLI агентів для кодування** автоматично виявляються у вашому `PATH` (Claude Code, Codex, Devin for Terminal, Cursor Agent, Gemini CLI, OpenCode, Qwen, Qoder CLI, GitHub Copilot CLI, Hermes, Kimi, Pi, Kiro, Kilo, Mistral Vibe, DeepSeek TUI) стають механізмом дизайну, керуються **31 компонуваною навичкою** та **72 системами дизайну комерційного класу**. Немає CLI? OpenAI-сумісний BYOK проксі — це той же цикл без spawn.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,3 +1,5 @@
+<!-- l10n-source-commit: 87a95b7fb4eeb0a5c954dbe0dea95b3fa5c0dc46 -->
+
 # Open Design
 
 > **[Claude Design][cd] 的开源替代品。** 本地优先、可部署到 Vercel、每一层都 BYOK —— **16 套 coding-agent CLI** 在 `PATH` 上自动检测（Claude Code, Codex, Devin for Terminal, Cursor Agent, Gemini CLI, OpenCode, Qwen, Qoder CLI, GitHub Copilot CLI, Hermes, Kimi, Pi, Kiro, Kilo, Mistral Vibe, DeepSeek TUI）就是设计引擎，由 **31 个可组合 Skills** 和 **72 套品牌级 Design System** 驱动。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,3 +1,5 @@
+<!-- l10n-source-commit: 87a95b7fb4eeb0a5c954dbe0dea95b3fa5c0dc46 -->
+
 # Open Design
 
 > **[Claude Design][cd] 的開源替代品。** 本地優先、可部署到 Vercel、每一層都 BYOK —— **16 套 coding-agent CLI** 在 `PATH` 上自動檢測（Claude Code, Codex, Devin for Terminal, Cursor Agent, Gemini CLI, OpenCode, Qwen, Qoder CLI, GitHub Copilot CLI, Hermes, Kimi, Pi, Kiro, Kilo, Mistral Vibe, DeepSeek TUI）就是設計引擎，由 **31 個可組合 Skills** 和 **72 套品牌級 Design System** 驅動。一個都沒裝？還有 OpenAI 相容的 BYOK 代理 `/api/proxy/stream` 備援，同一條 loop，少一次 spawn 而已。


### PR DESCRIPTION
## Summary

- Add `<!-- l10n-source-commit: <SHA> -->` annotation to all 12 locale README files, pointing to current HEAD (`87a95b7fb4eeb0a5c954dbe0dea95b3fa5c0dc46`)
- Add `.github/workflows/readme-drift.yml` with two jobs:
  - **pr-comment**: On any PR touching `README.md`, diff each locale's annotated SHA vs HEAD and post a PR comment listing which locales are behind (passive signal, not a blocker)
  - **track**: Weekly cron that opens/updates a single rolling tracking issue with a per-locale checklist

## What this PR does NOT do

- No auto-translation or MT push — Phase 2 only revisited if Phase 1 data shows drift outpaces human capacity
- No merge gate — all signals are passive (PR comment + weekly issue)
- No platform/SaaS dependency — pure GH Action, ~200 lines of bash + YAML

## Decision basis

RFC discussion in issue #195:
- lefarcen: "Strong case for Phase 1. 💡", "The full three-part stack is small enough <200 lines", "drift velocity outpaces human capacity" as Phase 2 trigger
- MDN-style annotation confirmed as lowest-friction fit for open-design's shape (12 flat README files, no dedicated translation teams)
- Phase 2 trigger signals agreed: weekly tracking issue stays >50% incomplete for ≥4 weeks, ≥5 locales behind by ≥3 H2 sections, or locale maintainer requests MT drafts

## Test plan

- [ ] CI passes (workflow YAML validated)
- [ ] Workflow file has correct triggers: `pull_request` (paths: `README.md`) + `schedule` (weekly cron)
- [ ] All 12 locale READMEs have `l10n-source-commit` annotation
- [ ] `locale-drift` label exists on repo (created by first cron run) or can be created
- [ ] Manual test: push a new commit to a test branch that adds an H2 section to `README.md`, open a PR — verify comment is posted

## Adjacent issues

- **Prompt count fix** (README.md 93→94 / 43→44 correction + propagation to all locale READMEs) — separate PR
- **zh-CN mistranslation sweep** (`prompt → 產物路徑` → `prompt → 輸出行為`) — separate PR

Fixes #195.