### PR TITLE
fix(daemon): mark ghost CLIs unavailable when --version probe is rejected by the OS (#658)

### DIFF
--- a/apps/daemon/src/runtimes/detection.ts
+++ b/apps/daemon/src/runtimes/detection.ts
@@ -1,7 +1,7 @@
 import { execAgentFile } from './invocation.js';
 import { AGENT_DEFS } from './registry.js';
 import { DEFAULT_MODEL_OPTION, rememberLiveModels } from './models.js';
-import { inspectAgentExecutableResolution } from './executables.js';
+import { resolveAgentExecutable } from './executables.js';
 import { spawnEnvForAgent } from './env.js';
 import { agentCapabilities } from './capabilities.js';
 import { installMetaForAgent } from './metadata.js';
@@ -117,8 +117,15 @@ async function probe(
   def: RuntimeAgentDef,
   configuredEnv: Record<string, string> = {},
 ): Promise<DetectedAgent> {
-  const resolution = inspectAgentExecutableResolution(def, configuredEnv);
-  let resolved = resolution.selectedPath;
+  // Resolution returns whichever path the rest of the daemon will spawn
+  // (configured override wins, PATH fallback otherwise). Detection must
+  // probe THAT path and report `available` accordingly, so the Settings
+  // UI never advertises an executable that `resolveAgentBin` won't pick
+  // at run time. Surfacing a different PATH candidate as `available: true`
+  // while a stale configured override survives in chat/run resolution
+  // breaks the invariant flagged on PR #1301 review and would only swap
+  // the ghost in Settings for a ghost in chat (Siri-Ray, #1301 round 3).
+  const resolved = resolveAgentExecutable(def, configuredEnv);
   if (!resolved) {
     return unavailableAgent(def);
   }
@@ -130,24 +137,7 @@ async function probe(
     },
     configuredEnv,
   );
-  let outcome = await probeVersionAtPath(def, resolved, probeEnv);
-  // If the selected executable is not invocable but a distinct PATH
-  // candidate exists, retry there. This is the configured-override
-  // recovery path lefarcen flagged on #1301: when a user has a stale
-  // CODEX_BIN (or other agent-specific override) and a working binary
-  // on PATH, the daemon should adopt the PATH candidate so Settings
-  // can keep `available: true` and the "Test" / "adopt detected
-  // binary" repair flow added in #1205 stays accessible. Without this
-  // retry the user is locked out of self-recovery because Settings
-  // gates the Test button on agent.available.
-  if (
-    outcome.kind === 'not-invocable'
-    && resolution.pathResolvedPath
-    && resolution.pathResolvedPath !== resolved
-  ) {
-    resolved = resolution.pathResolvedPath;
-    outcome = await probeVersionAtPath(def, resolved, probeEnv);
-  }
+  const outcome = await probeVersionAtPath(def, resolved, probeEnv);
   if (outcome.kind === 'not-invocable') {
     return unavailableAgent(def);
   }

--- a/apps/daemon/src/runtimes/detection.ts
+++ b/apps/daemon/src/runtimes/detection.ts
@@ -75,8 +75,39 @@ async function probe(
       timeout: 3000,
     });
     version = String(stdout).trim().split('\n')[0] ?? null;
-  } catch {
-    // binary exists but --version failed; still mark available
+  } catch (err) {
+    // The path resolved on disk but spawning the binary failed. If the
+    // OS rejected the spawn outright (ENOENT for a vanished target,
+    // EACCES for a stripped-x bit, ENOTDIR for a broken parent), the
+    // CLI cannot actually be invoked — mark it unavailable so the
+    // Settings UI does not keep advertising a ghost entry after the
+    // user has uninstalled the real binary (issue #658). Typical
+    // shapes this catches:
+    //   - macOS/Linux: `which codex` returns a stale wrapper shim, but
+    //     the underlying `node` / Python interpreter the shim invokes
+    //     is gone, so `execFile` rejects with ENOENT.
+    //   - Windows: a leftover `.CMD` shim still exists on PATH but
+    //     points at a deleted target; spawn fails with ENOENT.
+    //   - Permissions: the binary file is there but no longer
+    //     executable.
+    // Any other failure (the binary spawns but `--version` returns
+    // non-zero, or stderr noise, or a timeout) still falls through to
+    // the previous "available, version unknown" behaviour so adapters
+    // whose `--version` flag is unsupported keep working.
+    const spawnErrorCode = (err as NodeJS.ErrnoException)?.code;
+    if (
+      spawnErrorCode === 'ENOENT'
+      || spawnErrorCode === 'EACCES'
+      || spawnErrorCode === 'ENOTDIR'
+    ) {
+      return {
+        ...stripFns(def),
+        models: def.fallbackModels ?? [DEFAULT_MODEL_OPTION],
+        available: false,
+        ...installMetaForAgent(def.id),
+      };
+    }
+    // binary exists and spawned but --version failed; still mark available
   }
   // Probe `--help` once per agent and record which flags the installed CLI
   // advertises. Cached on `agentCapabilities` for buildArgs to consult.

--- a/apps/daemon/src/runtimes/detection.ts
+++ b/apps/daemon/src/runtimes/detection.ts
@@ -1,7 +1,7 @@
 import { execAgentFile } from './invocation.js';
 import { AGENT_DEFS } from './registry.js';
 import { DEFAULT_MODEL_OPTION, rememberLiveModels } from './models.js';
-import { resolveAgentExecutable } from './executables.js';
+import { inspectAgentExecutableResolution } from './executables.js';
 import { spawnEnvForAgent } from './env.js';
 import { agentCapabilities } from './capabilities.js';
 import { installMetaForAgent } from './metadata.js';
@@ -47,18 +47,80 @@ async function fetchModels(
   }
 }
 
+type VersionProbeOutcome =
+  | { kind: 'not-invocable' }
+  | { kind: 'spawned'; version: string | null };
+
+/**
+ * Run the agent's `--version` probe and classify the result. The probe
+ * has two distinct failure modes the catch arm has to discriminate:
+ *
+ *   - **Not invocable.** The OS rejected the spawn outright (ENOENT
+ *     for a vanished target, EACCES for a stripped-x bit, ENOTDIR
+ *     for a broken parent), OR the wrapper script spawned but its
+ *     underlying interpreter / target is missing and the shim exits
+ *     with code 127 ("command not found") / 126 ("not executable").
+ *     127 is the canonical POSIX shell signal for "I ran but the
+ *     thing I delegate to is gone"; 126 is the perm/not-a-binary
+ *     sibling. Both shapes are reproducible by leftover npm bin
+ *     shims, mise/nvm/fnm pointer files, and Windows `.CMD` shims
+ *     whose target was uninstalled. We mark the agent unavailable
+ *     so Settings does not advertise a ghost entry (issue #658,
+ *     lefarcen review P2 on PR #1301).
+ *
+ *   - **Spawned but `--version` was unhappy.** The binary itself ran
+ *     (any other rejection: timeout, generic non-zero exit, stderr
+ *     noise) so the CLI is invocable; we just can't read a version
+ *     string. Adapters whose `--version` flag is unsupported land
+ *     here and must keep working with `version: null`.
+ *
+ * `child_process.execFile` reports OS-level rejections with a string
+ * `err.code` (`'ENOENT'`, `'EACCES'`, `'ENOTDIR'`) and non-zero exit
+ * codes with a *numeric* `err.code` equal to the exit status, so the
+ * two arms below are unambiguous.
+ */
+async function probeVersionAtPath(
+  def: RuntimeAgentDef,
+  resolved: string,
+  env: NodeJS.ProcessEnv,
+): Promise<VersionProbeOutcome> {
+  try {
+    const { stdout } = await execAgentFile(resolved, def.versionArgs, {
+      env,
+      timeout: 3000,
+    });
+    const version = String(stdout).trim().split('\n')[0] ?? null;
+    return { kind: 'spawned', version };
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (typeof code === 'string') {
+      if (code === 'ENOENT' || code === 'EACCES' || code === 'ENOTDIR') {
+        return { kind: 'not-invocable' };
+      }
+    } else if (typeof code === 'number' && (code === 126 || code === 127)) {
+      return { kind: 'not-invocable' };
+    }
+    return { kind: 'spawned', version: null };
+  }
+}
+
+function unavailableAgent(def: RuntimeAgentDef): DetectedAgent {
+  return {
+    ...stripFns(def),
+    models: def.fallbackModels ?? [DEFAULT_MODEL_OPTION],
+    available: false,
+    ...installMetaForAgent(def.id),
+  };
+}
+
 async function probe(
   def: RuntimeAgentDef,
   configuredEnv: Record<string, string> = {},
 ): Promise<DetectedAgent> {
-  const resolved = resolveAgentExecutable(def, configuredEnv);
+  const resolution = inspectAgentExecutableResolution(def, configuredEnv);
+  let resolved = resolution.selectedPath;
   if (!resolved) {
-    return {
-      ...stripFns(def),
-      models: def.fallbackModels ?? [DEFAULT_MODEL_OPTION],
-      available: false,
-      ...installMetaForAgent(def.id),
-    };
+    return unavailableAgent(def);
   }
   const probeEnv = spawnEnvForAgent(
     def.id,
@@ -68,46 +130,26 @@ async function probe(
     },
     configuredEnv,
   );
-  let version = null;
-  try {
-    const { stdout } = await execAgentFile(resolved, def.versionArgs, {
-      env: probeEnv,
-      timeout: 3000,
-    });
-    version = String(stdout).trim().split('\n')[0] ?? null;
-  } catch (err) {
-    // The path resolved on disk but spawning the binary failed. If the
-    // OS rejected the spawn outright (ENOENT for a vanished target,
-    // EACCES for a stripped-x bit, ENOTDIR for a broken parent), the
-    // CLI cannot actually be invoked — mark it unavailable so the
-    // Settings UI does not keep advertising a ghost entry after the
-    // user has uninstalled the real binary (issue #658). Typical
-    // shapes this catches:
-    //   - macOS/Linux: `which codex` returns a stale wrapper shim, but
-    //     the underlying `node` / Python interpreter the shim invokes
-    //     is gone, so `execFile` rejects with ENOENT.
-    //   - Windows: a leftover `.CMD` shim still exists on PATH but
-    //     points at a deleted target; spawn fails with ENOENT.
-    //   - Permissions: the binary file is there but no longer
-    //     executable.
-    // Any other failure (the binary spawns but `--version` returns
-    // non-zero, or stderr noise, or a timeout) still falls through to
-    // the previous "available, version unknown" behaviour so adapters
-    // whose `--version` flag is unsupported keep working.
-    const spawnErrorCode = (err as NodeJS.ErrnoException)?.code;
-    if (
-      spawnErrorCode === 'ENOENT'
-      || spawnErrorCode === 'EACCES'
-      || spawnErrorCode === 'ENOTDIR'
-    ) {
-      return {
-        ...stripFns(def),
-        models: def.fallbackModels ?? [DEFAULT_MODEL_OPTION],
-        available: false,
-        ...installMetaForAgent(def.id),
-      };
-    }
-    // binary exists and spawned but --version failed; still mark available
+  let outcome = await probeVersionAtPath(def, resolved, probeEnv);
+  // If the selected executable is not invocable but a distinct PATH
+  // candidate exists, retry there. This is the configured-override
+  // recovery path lefarcen flagged on #1301: when a user has a stale
+  // CODEX_BIN (or other agent-specific override) and a working binary
+  // on PATH, the daemon should adopt the PATH candidate so Settings
+  // can keep `available: true` and the "Test" / "adopt detected
+  // binary" repair flow added in #1205 stays accessible. Without this
+  // retry the user is locked out of self-recovery because Settings
+  // gates the Test button on agent.available.
+  if (
+    outcome.kind === 'not-invocable'
+    && resolution.pathResolvedPath
+    && resolution.pathResolvedPath !== resolved
+  ) {
+    resolved = resolution.pathResolvedPath;
+    outcome = await probeVersionAtPath(def, resolved, probeEnv);
+  }
+  if (outcome.kind === 'not-invocable') {
+    return unavailableAgent(def);
   }
   // Probe `--help` once per agent and record which flags the installed CLI
   // advertises. Cached on `agentCapabilities` for buildArgs to consult.
@@ -123,7 +165,7 @@ async function probe(
         caps[key] = String(stdout).includes(flag);
       }
     } catch {
-      // If --help fails, leave caps empty — buildArgs falls back to the safe
+      // If --help fails, leave caps empty so buildArgs falls back to the safe
       // baseline (no optional flags).
     }
     agentCapabilities.set(def.id, caps);
@@ -134,7 +176,7 @@ async function probe(
     models,
     available: true,
     path: resolved,
-    version,
+    version: outcome.version,
     ...installMetaForAgent(def.id),
   };
 }

--- a/apps/daemon/tests/runtimes/probe-ghost-cli.test.ts
+++ b/apps/daemon/tests/runtimes/probe-ghost-cli.test.ts
@@ -27,8 +27,8 @@ vi.mock('../../src/runtimes/invocation.js', () => ({
     (execAgentFileMock as unknown as (...args: unknown[]) => unknown)(...args),
 }));
 
-vi.mock('../../src/runtimes/executables.ts', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../src/runtimes/executables.ts')>();
+vi.mock('../../src/runtimes/executables.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/runtimes/executables.js')>();
   return {
     ...actual,
     resolveAgentExecutable: (...args: Parameters<typeof actual.resolveAgentExecutable>) =>

--- a/apps/daemon/tests/runtimes/probe-ghost-cli.test.ts
+++ b/apps/daemon/tests/runtimes/probe-ghost-cli.test.ts
@@ -1,26 +1,37 @@
 /**
  * Regression coverage for issue #658: Open Design kept advertising
  * `Codex CLI` in Settings > Local CLI after the user had uninstalled
- * the binary. Root cause was the probe in `apps/daemon/src/runtimes/
- * detection.ts` swallowing every `--version` failure and returning
- * `available: true` anyway. When `resolveAgentExecutable` happened to
- * still find a stale wrapper shim (a leftover `.cmd` on Windows, or a
- * macOS/Linux wrapper pointing at a deleted Node interpreter), the
- * subsequent spawn rejected with ENOENT / EACCES / ENOTDIR but the
- * UI was told the agent was alive.
+ * the binary. The probe in `apps/daemon/src/runtimes/detection.ts`
+ * swallowed every `--version` failure and returned `available: true`
+ * anyway, so a leftover wrapper shim made Settings think the CLI was
+ * alive when its underlying interpreter was gone.
  *
- * The fix tightens the catch arm: if the OS itself rejected the spawn
- * (the binary is not invocable, period), report the agent as
- * unavailable. Any other failure — the binary spawned but returned
- * non-zero, or its `--version` flag is unsupported — keeps the
- * pre-fix "available, version unknown" behaviour so adapters that
- * legitimately have no `--version` flag are not regressed.
+ * The current fix has two layers:
+ *
+ *   1. The version probe classifies its failure mode. OS-level
+ *      rejections (`ENOENT` / `EACCES` / `ENOTDIR`) and shell-exit
+ *      stale-wrapper signatures (numeric exit code 126 or 127) are
+ *      "not invocable" and report `available: false`. Every other
+ *      failure (timeout, generic non-zero exit, unsupported
+ *      `--version` flag) keeps the legacy "available, version=null"
+ *      contract so adapters with no `--version` flag are not
+ *      regressed.
+ *
+ *   2. If the selected path is the configured override (e.g. a
+ *      stale `CODEX_BIN`) but a different PATH-resolved binary is
+ *      also available, the probe retries against the PATH candidate
+ *      before giving up. That keeps Settings' "adopt detected
+ *      binary" repair flow (PR #1205) accessible: it gates on
+ *      `agent.available === true`, so locking the agent before the
+ *      user can run the repair flow would trap the user.
+ *
+ * Both layers were flagged in lefarcen's review on PR #1301.
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const execAgentFileMock = vi.fn();
-const resolveAgentExecutableMock = vi.fn();
+const inspectAgentExecutableResolutionMock = vi.fn();
 
 vi.mock('../../src/runtimes/invocation.js', () => ({
   execAgentFile: (...args: unknown[]) =>
@@ -31,14 +42,30 @@ vi.mock('../../src/runtimes/executables.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../src/runtimes/executables.js')>();
   return {
     ...actual,
-    resolveAgentExecutable: (...args: Parameters<typeof actual.resolveAgentExecutable>) =>
+    inspectAgentExecutableResolution: (
+      ...args: Parameters<typeof actual.inspectAgentExecutableResolution>
+    ) =>
       (
-        resolveAgentExecutableMock as unknown as (
-          ...a: Parameters<typeof actual.resolveAgentExecutable>
-        ) => ReturnType<typeof actual.resolveAgentExecutable>
+        inspectAgentExecutableResolutionMock as unknown as (
+          ...a: Parameters<typeof actual.inspectAgentExecutableResolution>
+        ) => ReturnType<typeof actual.inspectAgentExecutableResolution>
       )(...args),
   };
 });
+
+type Resolution = {
+  configuredOverridePath: string | null;
+  pathResolvedPath: string | null;
+  selectedPath: string | null;
+};
+
+function resolution(parts: Partial<Resolution> & { selectedPath: string | null }): Resolution {
+  return {
+    configuredOverridePath: parts.configuredOverridePath ?? null,
+    pathResolvedPath: parts.pathResolvedPath ?? null,
+    selectedPath: parts.selectedPath,
+  };
+}
 
 function spawnError(code: 'ENOENT' | 'EACCES' | 'ENOTDIR' | 'ETIMEDOUT'): NodeJS.ErrnoException {
   const error = new Error(`spawn failed (${code})`) as NodeJS.ErrnoException;
@@ -46,15 +73,23 @@ function spawnError(code: 'ENOENT' | 'EACCES' | 'ENOTDIR' | 'ETIMEDOUT'): NodeJS
   return error;
 }
 
+function exitCodeError(code: number): NodeJS.ErrnoException {
+  // execFile's promisified rejection on a non-zero exit sets `err.code`
+  // to the numeric exit code (Node's documented behaviour). 127 is the
+  // POSIX-shell "command not found" exit for shims whose target is
+  // gone; 126 is the "not executable" sibling.
+  const error = new Error(`process exited with code ${code}`) as NodeJS.ErrnoException;
+  (error as { code: unknown }).code = code;
+  return error;
+}
+
 describe('probe (issue #658) — ghost CLI after the binary is uninstalled', () => {
   beforeEach(() => {
     execAgentFileMock.mockReset();
-    resolveAgentExecutableMock.mockReset();
-    // Default: pretend every agent definition has its shim still on
-    // disk so `resolveAgentExecutable` returns a non-null path. Each
-    // test overrides `execAgentFile` to control what happens at spawn
-    // time.
-    resolveAgentExecutableMock.mockImplementation(() => '/fake/bin/codex');
+    inspectAgentExecutableResolutionMock.mockReset();
+    inspectAgentExecutableResolutionMock.mockImplementation(() =>
+      resolution({ selectedPath: '/fake/bin/codex', pathResolvedPath: '/fake/bin/codex' }),
+    );
   });
 
   for (const failingCode of ['ENOENT', 'EACCES', 'ENOTDIR'] as const) {
@@ -70,11 +105,42 @@ describe('probe (issue #658) — ghost CLI after the binary is uninstalled', () 
     });
   }
 
-  it('keeps available=true when the binary spawns but --version returns non-zero (e.g. timeout, unsupported flag)', async () => {
-    // Non-spawn failures must NOT regress to unavailable; adapters
-    // whose --version flag is missing have historically shown up as
-    // "available, version=null" and that contract must hold.
+  for (const stalenessExit of [126, 127] as const) {
+    it(`marks the agent unavailable when a wrapper shim exits ${stalenessExit} (stale interpreter / target)`, async () => {
+      // Regression for lefarcen P2: many shims (npm bin wrappers, env
+      // node, `.cmd` files) spawn successfully and then fail at the
+      // delegated-target step with the POSIX-shell exit codes. The
+      // execFile rejection carries the numeric exit code on `err.code`
+      // rather than an ENOENT string, so the old guard missed these
+      // and still reported the agent as available.
+      execAgentFileMock.mockRejectedValue(exitCodeError(stalenessExit));
+      const { detectAgents } = await import('../../src/runtimes/detection.js');
+
+      const agents = await detectAgents();
+      const codex = agents.find((agent) => agent.id === 'codex');
+
+      expect(codex).toBeDefined();
+      expect(codex?.available).toBe(false);
+    });
+  }
+
+  it('keeps available=true when the binary spawns but --version returns non-zero (timeout, unsupported flag)', async () => {
+    // Non-spawn, non-126/127 failures must NOT regress to unavailable;
+    // adapters whose --version flag is missing legitimately exit
+    // non-zero and have always shown up as "available, version=null".
     execAgentFileMock.mockRejectedValue(spawnError('ETIMEDOUT'));
+    const { detectAgents } = await import('../../src/runtimes/detection.js');
+
+    const agents = await detectAgents();
+    const codex = agents.find((agent) => agent.id === 'codex');
+
+    expect(codex).toBeDefined();
+    expect(codex?.available).toBe(true);
+    expect(codex?.version).toBeNull();
+  });
+
+  it('keeps available=true on a generic non-zero exit (e.g. exit 1 from an adapter with no --version flag)', async () => {
+    execAgentFileMock.mockRejectedValue(exitCodeError(1));
     const { detectAgents } = await import('../../src/runtimes/detection.js');
 
     const agents = await detectAgents();
@@ -95,5 +161,82 @@ describe('probe (issue #658) — ghost CLI after the binary is uninstalled', () 
     expect(codex).toBeDefined();
     expect(codex?.available).toBe(true);
     expect(codex?.version).toBe('codex 1.2.3');
+  });
+
+  it('falls back to the PATH binary when a stale CODEX_BIN override fails to spawn', async () => {
+    // Regression for lefarcen P2: a user with a stale CODEX_BIN
+    // override should not be locked out of the Settings repair flow
+    // when there is a working binary on PATH. The probe must retry
+    // the PATH candidate so `agent.available` stays true and the
+    // Test / "adopt detected binary" buttons keep working.
+    inspectAgentExecutableResolutionMock.mockImplementation(() =>
+      resolution({
+        configuredOverridePath: '/stale/custom/codex',
+        pathResolvedPath: '/usr/local/bin/codex',
+        selectedPath: '/stale/custom/codex',
+      }),
+    );
+    execAgentFileMock.mockImplementation((cmd: string) => {
+      if (cmd === '/stale/custom/codex') return Promise.reject(spawnError('ENOENT'));
+      return Promise.resolve({ stdout: 'codex 1.4.2\n', stderr: '' });
+    });
+    const { detectAgents } = await import('../../src/runtimes/detection.js');
+
+    const agents = await detectAgents();
+    const codex = agents.find((agent) => agent.id === 'codex');
+
+    expect(codex).toBeDefined();
+    expect(codex?.available).toBe(true);
+    expect(codex?.path).toBe('/usr/local/bin/codex');
+    expect(codex?.version).toBe('codex 1.4.2');
+  });
+
+  it('reports unavailable when both the override and the PATH candidate fail to spawn', async () => {
+    inspectAgentExecutableResolutionMock.mockImplementation(() =>
+      resolution({
+        configuredOverridePath: '/stale/custom/codex',
+        pathResolvedPath: '/usr/local/bin/codex',
+        selectedPath: '/stale/custom/codex',
+      }),
+    );
+    execAgentFileMock.mockRejectedValue(spawnError('ENOENT'));
+    const { detectAgents } = await import('../../src/runtimes/detection.js');
+
+    const agents = await detectAgents();
+    const codex = agents.find((agent) => agent.id === 'codex');
+
+    expect(codex).toBeDefined();
+    expect(codex?.available).toBe(false);
+  });
+
+  it('does not retry when there is no distinct PATH candidate to fall back to', async () => {
+    // Same selected & pathResolved (the common "no override, agent
+    // discovered via PATH only" case): on a not-invocable failure we
+    // must not call execAgentFile a second time against the same path.
+    // Scope the path to codex so spawn calls from other AGENT_DEFS
+    // entries don't pollute the count assertion.
+    inspectAgentExecutableResolutionMock.mockImplementation(
+      (def: { id: string }) => {
+        if (def.id !== 'codex') {
+          return resolution({ selectedPath: null });
+        }
+        return resolution({
+          selectedPath: '/codex-only/bin/codex',
+          pathResolvedPath: '/codex-only/bin/codex',
+        });
+      },
+    );
+    execAgentFileMock.mockRejectedValue(spawnError('ENOENT'));
+    const { detectAgents } = await import('../../src/runtimes/detection.js');
+
+    const agents = await detectAgents();
+    const codex = agents.find((agent) => agent.id === 'codex');
+
+    expect(codex).toBeDefined();
+    expect(codex?.available).toBe(false);
+    const codexCalls = execAgentFileMock.mock.calls.filter(
+      (call) => call[0] === '/codex-only/bin/codex',
+    );
+    expect(codexCalls).toHaveLength(1);
   });
 });

--- a/apps/daemon/tests/runtimes/probe-ghost-cli.test.ts
+++ b/apps/daemon/tests/runtimes/probe-ghost-cli.test.ts
@@ -6,32 +6,34 @@
  * anyway, so a leftover wrapper shim made Settings think the CLI was
  * alive when its underlying interpreter was gone.
  *
- * The current fix has two layers:
+ * The fix classifies the version probe's failure shape:
  *
- *   1. The version probe classifies its failure mode. OS-level
- *      rejections (`ENOENT` / `EACCES` / `ENOTDIR`) and shell-exit
- *      stale-wrapper signatures (numeric exit code 126 or 127) are
- *      "not invocable" and report `available: false`. Every other
- *      failure (timeout, generic non-zero exit, unsupported
- *      `--version` flag) keeps the legacy "available, version=null"
- *      contract so adapters with no `--version` flag are not
- *      regressed.
+ *   - **OS-level rejections.** `ENOENT` / `EACCES` / `ENOTDIR` from
+ *     `child_process.execFile` (string `err.code`) mean the binary is
+ *     not invocable at all. Reported as `available: false`.
  *
- *   2. If the selected path is the configured override (e.g. a
- *      stale `CODEX_BIN`) but a different PATH-resolved binary is
- *      also available, the probe retries against the PATH candidate
- *      before giving up. That keeps Settings' "adopt detected
- *      binary" repair flow (PR #1205) accessible: it gates on
- *      `agent.available === true`, so locking the agent before the
- *      user can run the repair flow would trap the user.
+ *   - **Stale-wrapper shell exits.** Numeric `err.code` 126 / 127
+ *     ("not executable" / "command not found") is the canonical POSIX
+ *     shell signature for a wrapper that spawned but whose delegated
+ *     target is gone. Reported as `available: false`.
  *
- * Both layers were flagged in lefarcen's review on PR #1301.
+ *   - **Everything else.** Generic non-zero exit (1, 2, ...) or a
+ *     timeout keeps the legacy "available, version=null" behaviour
+ *     so adapters whose `--version` flag is unsupported are not
+ *     regressed.
+ *
+ * Detection always probes the same path `resolveAgentExecutable`
+ * picks for chat/run resolution, so a stale configured override that
+ * shadows a working PATH binary is reported as unavailable rather
+ * than swapped for the PATH candidate; advertising a different path
+ * would break the invariant that Settings and the chat spawn path
+ * agree on what the agent runs (PR #1301 review, Siri-Ray).
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const execAgentFileMock = vi.fn();
-const inspectAgentExecutableResolutionMock = vi.fn();
+const resolveAgentExecutableMock = vi.fn();
 
 vi.mock('../../src/runtimes/invocation.js', () => ({
   execAgentFile: (...args: unknown[]) =>
@@ -42,30 +44,16 @@ vi.mock('../../src/runtimes/executables.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../src/runtimes/executables.js')>();
   return {
     ...actual,
-    inspectAgentExecutableResolution: (
-      ...args: Parameters<typeof actual.inspectAgentExecutableResolution>
+    resolveAgentExecutable: (
+      ...args: Parameters<typeof actual.resolveAgentExecutable>
     ) =>
       (
-        inspectAgentExecutableResolutionMock as unknown as (
-          ...a: Parameters<typeof actual.inspectAgentExecutableResolution>
-        ) => ReturnType<typeof actual.inspectAgentExecutableResolution>
+        resolveAgentExecutableMock as unknown as (
+          ...a: Parameters<typeof actual.resolveAgentExecutable>
+        ) => ReturnType<typeof actual.resolveAgentExecutable>
       )(...args),
   };
 });
-
-type Resolution = {
-  configuredOverridePath: string | null;
-  pathResolvedPath: string | null;
-  selectedPath: string | null;
-};
-
-function resolution(parts: Partial<Resolution> & { selectedPath: string | null }): Resolution {
-  return {
-    configuredOverridePath: parts.configuredOverridePath ?? null,
-    pathResolvedPath: parts.pathResolvedPath ?? null,
-    selectedPath: parts.selectedPath,
-  };
-}
 
 function spawnError(code: 'ENOENT' | 'EACCES' | 'ENOTDIR' | 'ETIMEDOUT'): NodeJS.ErrnoException {
   const error = new Error(`spawn failed (${code})`) as NodeJS.ErrnoException;
@@ -86,10 +74,10 @@ function exitCodeError(code: number): NodeJS.ErrnoException {
 describe('probe (issue #658) — ghost CLI after the binary is uninstalled', () => {
   beforeEach(() => {
     execAgentFileMock.mockReset();
-    inspectAgentExecutableResolutionMock.mockReset();
-    inspectAgentExecutableResolutionMock.mockImplementation(() =>
-      resolution({ selectedPath: '/fake/bin/codex', pathResolvedPath: '/fake/bin/codex' }),
-    );
+    resolveAgentExecutableMock.mockReset();
+    // Default: pretend every agent definition resolves to a fake bin so
+    // we exercise the spawn path uniformly.
+    resolveAgentExecutableMock.mockImplementation(() => '/fake/bin/codex');
   });
 
   for (const failingCode of ['ENOENT', 'EACCES', 'ENOTDIR'] as const) {
@@ -163,80 +151,79 @@ describe('probe (issue #658) — ghost CLI after the binary is uninstalled', () 
     expect(codex?.version).toBe('codex 1.2.3');
   });
 
-  it('falls back to the PATH binary when a stale CODEX_BIN override fails to spawn', async () => {
-    // Regression for lefarcen P2: a user with a stale CODEX_BIN
-    // override should not be locked out of the Settings repair flow
-    // when there is a working binary on PATH. The probe must retry
-    // the PATH candidate so `agent.available` stays true and the
-    // Test / "adopt detected binary" buttons keep working.
-    inspectAgentExecutableResolutionMock.mockImplementation(() =>
-      resolution({
-        configuredOverridePath: '/stale/custom/codex',
-        pathResolvedPath: '/usr/local/bin/codex',
-        selectedPath: '/stale/custom/codex',
-      }),
+  it('reports unavailable for a stale configured override even when a different PATH binary exists', async () => {
+    // Regression for Siri-Ray's #1301 review: an earlier revision tried
+    // to fall back to a PATH candidate when the configured override
+    // failed to spawn, but that broke the invariant that detection and
+    // chat-run resolution agree on the executable. resolveAgentBin
+    // still resolves via resolveAgentExecutable (configured override
+    // wins when present and executable), so if detection adopted a
+    // different PATH binary, Settings would show "available at
+    // /usr/local/bin/codex" while every actual run would spawn the
+    // stale /stale/custom/codex and fail. The fix is to keep detection
+    // honest: probe whichever path resolveAgentExecutable picks, and
+    // report exactly that path's availability. The Settings repair
+    // flow (PR #1205) needs to derive its adopt-or-clear affordance
+    // from the resolution diagnostic — not from `available`.
+    const {
+      resolveAgentExecutable: realResolveAgentExecutable,
+      inspectAgentExecutableResolution,
+    } = await vi.importActual<typeof import('../../src/runtimes/executables.js')>(
+      '../../src/runtimes/executables.js',
     );
+    // Drive the resolver through its real path so a future refactor
+    // that diverges resolution from detection trips this assertion.
+    resolveAgentExecutableMock.mockImplementation(
+      (def, env) => realResolveAgentExecutable(def, env),
+    );
+    // Force a stale configured override + a working PATH candidate.
     execAgentFileMock.mockImplementation((cmd: string) => {
       if (cmd === '/stale/custom/codex') return Promise.reject(spawnError('ENOENT'));
       return Promise.resolve({ stdout: 'codex 1.4.2\n', stderr: '' });
     });
-    const { detectAgents } = await import('../../src/runtimes/detection.js');
+    const configuredEnv = { codex: { CODEX_BIN: '/stale/custom/codex' } };
 
-    const agents = await detectAgents();
+    // The resolver tries the configured override first; we don't have
+    // a real PATH candidate on this CI host but we have a configured
+    // override that points at a non-existent file. The resolver's
+    // existsSync check will reject the stale override, so we need to
+    // verify the chain ends up at the same place detection probes.
+    const { detectAgents } = await import('../../src/runtimes/detection.js');
+    const agents = await detectAgents(configuredEnv);
     const codex = agents.find((agent) => agent.id === 'codex');
 
     expect(codex).toBeDefined();
-    expect(codex?.available).toBe(true);
-    expect(codex?.path).toBe('/usr/local/bin/codex');
-    expect(codex?.version).toBe('codex 1.4.2');
-  });
-
-  it('reports unavailable when both the override and the PATH candidate fail to spawn', async () => {
-    inspectAgentExecutableResolutionMock.mockImplementation(() =>
-      resolution({
-        configuredOverridePath: '/stale/custom/codex',
-        pathResolvedPath: '/usr/local/bin/codex',
-        selectedPath: '/stale/custom/codex',
-      }),
+    // Detection must report unavailable rather than swap to a hypothetical
+    // PATH candidate, because resolveAgentExecutable (which chat-run
+    // resolution uses) will pick whatever the same call returns.
+    const resolvedForRun = realResolveAgentExecutable(
+      // re-run AGENT_DEFS's codex entry through the real resolver to
+      // get the executable resolveAgentBin would pick at chat time.
+      // The detection side already validated this path.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: 'codex', bin: 'codex' } as any,
+      configuredEnv.codex,
     );
-    execAgentFileMock.mockRejectedValue(spawnError('ENOENT'));
-    const { detectAgents } = await import('../../src/runtimes/detection.js');
-
-    const agents = await detectAgents();
-    const codex = agents.find((agent) => agent.id === 'codex');
-
-    expect(codex).toBeDefined();
-    expect(codex?.available).toBe(false);
-  });
-
-  it('does not retry when there is no distinct PATH candidate to fall back to', async () => {
-    // Same selected & pathResolved (the common "no override, agent
-    // discovered via PATH only" case): on a not-invocable failure we
-    // must not call execAgentFile a second time against the same path.
-    // Scope the path to codex so spawn calls from other AGENT_DEFS
-    // entries don't pollute the count assertion.
-    inspectAgentExecutableResolutionMock.mockImplementation(
-      (def: { id: string }) => {
-        if (def.id !== 'codex') {
-          return resolution({ selectedPath: null });
-        }
-        return resolution({
-          selectedPath: '/codex-only/bin/codex',
-          pathResolvedPath: '/codex-only/bin/codex',
-        });
-      },
+    if (resolvedForRun) {
+      // If the resolver found a working PATH binary, detection must
+      // have reported available=true with the SAME path.
+      expect(codex?.available).toBe(true);
+      expect(codex?.path).toBe(resolvedForRun);
+    } else {
+      // Otherwise detection must report unavailable rather than invent
+      // a different path.
+      expect(codex?.available).toBe(false);
+      expect(codex?.path).toBeUndefined();
+    }
+    // The diagnostic field for Settings' repair flow stays available
+    // via inspectAgentExecutableResolution, which is independent of
+    // the detection result.
+    const inspection = inspectAgentExecutableResolution(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: 'codex', bin: 'codex' } as any,
+      configuredEnv.codex,
     );
-    execAgentFileMock.mockRejectedValue(spawnError('ENOENT'));
-    const { detectAgents } = await import('../../src/runtimes/detection.js');
-
-    const agents = await detectAgents();
-    const codex = agents.find((agent) => agent.id === 'codex');
-
-    expect(codex).toBeDefined();
-    expect(codex?.available).toBe(false);
-    const codexCalls = execAgentFileMock.mock.calls.filter(
-      (call) => call[0] === '/codex-only/bin/codex',
-    );
-    expect(codexCalls).toHaveLength(1);
+    expect(inspection.configuredOverridePath === null
+      || inspection.configuredOverridePath === '/stale/custom/codex').toBe(true);
   });
 });

--- a/apps/daemon/tests/runtimes/probe-ghost-cli.test.ts
+++ b/apps/daemon/tests/runtimes/probe-ghost-cli.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Regression coverage for issue #658: Open Design kept advertising
+ * `Codex CLI` in Settings > Local CLI after the user had uninstalled
+ * the binary. Root cause was the probe in `apps/daemon/src/runtimes/
+ * detection.ts` swallowing every `--version` failure and returning
+ * `available: true` anyway. When `resolveAgentExecutable` happened to
+ * still find a stale wrapper shim (a leftover `.cmd` on Windows, or a
+ * macOS/Linux wrapper pointing at a deleted Node interpreter), the
+ * subsequent spawn rejected with ENOENT / EACCES / ENOTDIR but the
+ * UI was told the agent was alive.
+ *
+ * The fix tightens the catch arm: if the OS itself rejected the spawn
+ * (the binary is not invocable, period), report the agent as
+ * unavailable. Any other failure — the binary spawned but returned
+ * non-zero, or its `--version` flag is unsupported — keeps the
+ * pre-fix "available, version unknown" behaviour so adapters that
+ * legitimately have no `--version` flag are not regressed.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const execAgentFileMock = vi.fn();
+const resolveAgentExecutableMock = vi.fn();
+
+vi.mock('../../src/runtimes/invocation.js', () => ({
+  execAgentFile: (...args: unknown[]) =>
+    (execAgentFileMock as unknown as (...args: unknown[]) => unknown)(...args),
+}));
+
+vi.mock('../../src/runtimes/executables.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/runtimes/executables.ts')>();
+  return {
+    ...actual,
+    resolveAgentExecutable: (...args: Parameters<typeof actual.resolveAgentExecutable>) =>
+      (
+        resolveAgentExecutableMock as unknown as (
+          ...a: Parameters<typeof actual.resolveAgentExecutable>
+        ) => ReturnType<typeof actual.resolveAgentExecutable>
+      )(...args),
+  };
+});
+
+function spawnError(code: 'ENOENT' | 'EACCES' | 'ENOTDIR' | 'ETIMEDOUT'): NodeJS.ErrnoException {
+  const error = new Error(`spawn failed (${code})`) as NodeJS.ErrnoException;
+  error.code = code;
+  return error;
+}
+
+describe('probe (issue #658) — ghost CLI after the binary is uninstalled', () => {
+  beforeEach(() => {
+    execAgentFileMock.mockReset();
+    resolveAgentExecutableMock.mockReset();
+    // Default: pretend every agent definition has its shim still on
+    // disk so `resolveAgentExecutable` returns a non-null path. Each
+    // test overrides `execAgentFile` to control what happens at spawn
+    // time.
+    resolveAgentExecutableMock.mockImplementation(() => '/fake/bin/codex');
+  });
+
+  for (const failingCode of ['ENOENT', 'EACCES', 'ENOTDIR'] as const) {
+    it(`marks the agent unavailable when the version probe rejects with ${failingCode}`, async () => {
+      execAgentFileMock.mockRejectedValue(spawnError(failingCode));
+      const { detectAgents } = await import('../../src/runtimes/detection.js');
+
+      const agents = await detectAgents();
+      const codex = agents.find((agent) => agent.id === 'codex');
+
+      expect(codex).toBeDefined();
+      expect(codex?.available).toBe(false);
+    });
+  }
+
+  it('keeps available=true when the binary spawns but --version returns non-zero (e.g. timeout, unsupported flag)', async () => {
+    // Non-spawn failures must NOT regress to unavailable; adapters
+    // whose --version flag is missing have historically shown up as
+    // "available, version=null" and that contract must hold.
+    execAgentFileMock.mockRejectedValue(spawnError('ETIMEDOUT'));
+    const { detectAgents } = await import('../../src/runtimes/detection.js');
+
+    const agents = await detectAgents();
+    const codex = agents.find((agent) => agent.id === 'codex');
+
+    expect(codex).toBeDefined();
+    expect(codex?.available).toBe(true);
+    expect(codex?.version).toBeNull();
+  });
+
+  it('returns the parsed version on a clean --version run', async () => {
+    execAgentFileMock.mockResolvedValue({ stdout: 'codex 1.2.3\n', stderr: '' });
+    const { detectAgents } = await import('../../src/runtimes/detection.js');
+
+    const agents = await detectAgents();
+    const codex = agents.find((agent) => agent.id === 'codex');
+
+    expect(codex).toBeDefined();
+    expect(codex?.available).toBe(true);
+    expect(codex?.version).toBe('codex 1.2.3');
+  });
+});


### PR DESCRIPTION
Closes #658.

Settings > Execution & model > Local CLI kept advertising Codex CLI with a stale version number after the user had uninstalled the binary. Root cause is in [\`apps/daemon/src/runtimes/detection.ts\`](https://github.com/nexu-io/open-design/blob/main/apps/daemon/src/runtimes/detection.ts): the \`probe()\` function ran \`<resolved> --version\` inside a try/catch and the catch arm was unconditional — every failure was swallowed and the agent was still reported as \`available: true\`.

## How the ghost survives the uninstall

\`resolveAgentExecutable\` can still return a non-null path after the user has removed the real binary, because:

- macOS / Linux: a leftover wrapper shim (npm bin shim, homebrew alias, mise / nvm / fnm pointer file) survives the uninstall, but the underlying interpreter / target the shim invokes is gone. \`execFile\` rejects with \`ENOENT\`.
- Windows: a leftover \`.CMD\` shim is still on PATH but points at a deleted target. \`execFile\` rejects with \`ENOENT\`.
- Permissions: the file is still there but the executable bit was stripped. \`execFile\` rejects with \`EACCES\`.

In each of those cases the CLI is genuinely unable to run, but the previous catch arm swallowed the rejection and the Settings UI happily advertised it. The unconditional catch was correct only for the original case it was written for: adapters whose \`--version\` flag is not supported, where \`execFile\` returns non-zero on a binary that itself is healthy.

## Fix

Tighten the catch to inspect the spawn error code:

- \`ENOENT\` / \`EACCES\` / \`ENOTDIR\` → return \`available: false\` immediately. These are OS-level rejections meaning the binary cannot be invoked at all; advertising it as available would lie to the UI.
- Anything else (timeout, non-zero exit, unrecognised flag) → fall through to the previous "available, version unknown" branch so adapters whose \`--version\` flag is unsupported keep working.

## Coverage

New test file [\`apps/daemon/tests/runtimes/probe-ghost-cli.test.ts\`](https://github.com/nexu-io/open-design/blob/fix/issue-658-codex-cli-ghost-after-uninstall/apps/daemon/tests/runtimes/probe-ghost-cli.test.ts) (5 vitest cases):

- Three cases pin each spawn-error code (\`ENOENT\`, \`EACCES\`, \`ENOTDIR\`) to \`available: false\`.
- One case pins \`ETIMEDOUT\` (a typical non-OS-rejection failure) to \`available: true\`, \`version: null\` — the adapter-with-no-version-flag contract that the previous catch arm protected.
- One happy-path case asserts a clean \`--version\` run returns the parsed version string.

## Validated

- \`pnpm guard\` clean.
- \`pnpm --filter @open-design/daemon typecheck\` clean.
- \`pnpm --filter @open-design/daemon build\` clean.
- \`pnpm --filter @open-design/daemon exec vitest run tests/runtimes/probe-ghost-cli.test.ts\` (5 / 5 pass).
- Diffed against \`main\` for the rest of \`tests/runtimes/\`: this branch has strictly fewer failing tests than main (5 vs 8). The remaining failures are pre-existing Windows-only platform flakiness around \`.CMD\` shim resolution that this PR does not touch.