### PR TITLE
fix: truncate long template names on project cards

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6455,6 +6455,7 @@ button.connector-action.is-loading {
 .design-card-name {
   font-weight: 600;
   font-size: 13px;
+  min-width: 0;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
## Summary

Fixes #1220 — overly long template names on project cards now truncate with an ellipsis, keeping the task execution status (Running, Failed, Completed, etc.) visible.

## Root cause

The `.design-card-name` element had `text-overflow: ellipsis` but was missing `min-width: 0`. In a flex layout, flex children default to `min-width: auto`, which prevents them from shrinking below their content size — so the ellipsis never kicks in and the name pushes everything else out of view.

## Change

Added `min-width: 0` to `.design-card-name` in `apps/web/src/index.css`. One-line fix.

## Before / After

**Before**: Long template name fills the card, status badge is hidden or clipped.
**After**: Long template name truncates with "…" and the status badge remains visible.
