### PR TITLE
fix: show success feedback after saving API key

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -2576,8 +2576,17 @@ function ConnectorSection({
   // completes, the daemon returns a tail-only echo, and we land in
   // the saved state with the same UI as a key loaded from disk.
   const [keySaveStatus, setKeySaveStatus] =
-    useState<'idle' | 'saving' | 'error'>('idle');
+    useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
+  const keySavedTimerRef = useRef<number | null>(null);
   const [catalogRefreshNonce, setCatalogRefreshNonce] = useState(0);
+  // Clear the saved-state timer on unmount
+  useEffect(() => {
+    return () => {
+      if (keySavedTimerRef.current != null) {
+        window.clearTimeout(keySavedTimerRef.current);
+      }
+    };
+  }, []);
   const handleSaveKey = async () => {
     if (keySaveStatus === 'saving') return;
     if (!hasPendingEdit) return;
@@ -2597,7 +2606,13 @@ function ConnectorSection({
         apiKeyTail: pendingKey.trim().slice(-4),
       });
       setCatalogRefreshNonce((nonce) => nonce + 1);
-      setKeySaveStatus('idle');
+      setKeySaveStatus('saved');
+      if (keySavedTimerRef.current != null) {
+        window.clearTimeout(keySavedTimerRef.current);
+      }
+      keySavedTimerRef.current = window.setTimeout(() => {
+        setKeySaveStatus('idle');
+      }, 2000);
     } catch {
       setKeySaveStatus('error');
     }
@@ -2790,6 +2805,11 @@ function ConnectorSection({
               <>
                 <Icon name="spinner" size={12} className="icon-spin" />
                 <span>{t('settings.connectorsKeySaving')}</span>
+              </>
+            ) : keySaveStatus === 'saved' ? (
+              <>
+                <Icon name="check" size={12} />
+                <span>{t('settings.connectorsKeySaved')}</span>
               </>
             ) : (
               t('settings.connectorsSaveKey')

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -2577,9 +2577,9 @@ function ConnectorSection({
   // the saved state with the same UI as a key loaded from disk.
   const [keySaveStatus, setKeySaveStatus] =
     useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
-  const keySavedTimerRef = useRef<number | null>(null);
   const [catalogRefreshNonce, setCatalogRefreshNonce] = useState(0);
-  // Clear the saved-state timer on unmount
+  const keySavedTimerRef = useRef<number | null>(null);
+  // Clear the saved-state timer on unmount to avoid setState after unmount
   useEffect(() => {
     return () => {
       if (keySavedTimerRef.current != null) {
@@ -2606,10 +2606,13 @@ function ConnectorSection({
         apiKeyTail: pendingKey.trim().slice(-4),
       });
       setCatalogRefreshNonce((nonce) => nonce + 1);
-      setKeySaveStatus('saved');
+      // Clear any existing timer before starting a new one to avoid
+      // a stale timeout flipping status back to 'idle' after a
+      // subsequent save or clear.
       if (keySavedTimerRef.current != null) {
         window.clearTimeout(keySavedTimerRef.current);
       }
+      setKeySaveStatus('saved');
       keySavedTimerRef.current = window.setTimeout(() => {
         setKeySaveStatus('idle');
       }, 2000);
@@ -2700,6 +2703,9 @@ function ConnectorSection({
       setCatalogRefreshNonce((nonce) => nonce + 1);
       setClearStage('idle');
       setClearArmed(false);
+      if (keySavedTimerRef.current != null) {
+        window.clearTimeout(keySavedTimerRef.current);
+      }
       setKeySaveStatus('idle');
     } catch {
       setKeySaveStatus('error');

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -2591,6 +2591,12 @@ function ConnectorSection({
     if (keySaveStatus === 'saving') return;
     if (!hasPendingEdit) return;
     if (composioConfigLoading) return;
+    // Clear any stale timer before transitioning to 'saving' to prevent
+    // it from firing during the await and flipping the button back to idle.
+    if (keySavedTimerRef.current != null) {
+      window.clearTimeout(keySavedTimerRef.current);
+      keySavedTimerRef.current = null;
+    }
     const pendingKey = composio.apiKey ?? '';
     setKeySaveStatus('saving');
     try {
@@ -2617,7 +2623,11 @@ function ConnectorSection({
         setKeySaveStatus('idle');
       }, 2000);
     } catch {
+      if (keySavedTimerRef.current != null) {
+        window.clearTimeout(keySavedTimerRef.current);
+      }
       setKeySaveStatus('error');
+      keySavedTimerRef.current = null;
     }
   };
 
@@ -2691,6 +2701,12 @@ function ConnectorSection({
   const handleClearCommit = async () => {
     if (keySaveStatus === 'saving') return;
     if (!clearArmed) return;
+    // Clear any stale timer before transitioning to 'saving', matching
+    // handleSaveKey's pattern for consistency.
+    if (keySavedTimerRef.current != null) {
+      window.clearTimeout(keySavedTimerRef.current);
+      keySavedTimerRef.current = null;
+    }
     setKeySaveStatus('saving');
     try {
       const cleared = {
@@ -2703,12 +2719,13 @@ function ConnectorSection({
       setCatalogRefreshNonce((nonce) => nonce + 1);
       setClearStage('idle');
       setClearArmed(false);
+      setKeySaveStatus('idle');
+    } catch {
       if (keySavedTimerRef.current != null) {
         window.clearTimeout(keySavedTimerRef.current);
       }
-      setKeySaveStatus('idle');
-    } catch {
       setKeySaveStatus('error');
+      keySavedTimerRef.current = null;
     }
   };
 

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -1167,6 +1167,7 @@ export const ar: Dict = {
   'settings.connectorsSaveKey': "حفظ المفتاح",
   'settings.connectorsSaveKeyTitle': "إرسال هذا المفتاح إلى الـ daemon المحلي",
   'settings.connectorsKeySaving': "جارٍ الحفظ…",
+  'settings.connectorsKeySaved': "تم الحفظ ✓",
   'settings.connectorsKeyError': "تعذّر حفظ المفتاح. تأكد أن الـ daemon المحلي يعمل ثم حاول مرة أخرى.",
   'settings.connectorsHelpSaved': 'يفتح مفتاحك الكتالوج أدناه ويبقى في daemon المحلي. الصق مفتاحًا جديدًا لاستبداله أو امسحه لإزالته.',
   'settings.connectorsHelpUnsaved': "تغييرات غير محفوظة — اضغط على \"حفظ المفتاح\" لتخزين بيانات الاعتماد في الـ daemon المحلي وفتح الكتالوج أدناه.",

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -1055,6 +1055,7 @@ export const de: Dict = {
   'settings.connectorsSaveKey': "Key speichern",
   'settings.connectorsSaveKeyTitle': "Diesen Key an den lokalen Daemon senden",
   'settings.connectorsKeySaving': "Speichere…",
+  'settings.connectorsKeySaved': "Gespeichert ✓",
   'settings.connectorsKeyError': "Key konnte nicht gespeichert werden. Prüfe, ob der lokale Daemon läuft, und versuche es erneut.",
   'settings.connectorsHelpSaved': 'Dein Schlüssel entsperrt den Katalog unten und bleibt im lokalen Daemon. Füge einen neuen Schlüssel ein, um ihn zu ersetzen, oder lösche ihn.',
   'settings.connectorsHelpUnsaved': "Ungespeicherte Änderungen — klicke auf „Key speichern“, um diesen Schlüssel im lokalen Daemon abzulegen und den Katalog unten freizuschalten.",

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1269,6 +1269,7 @@ export const en: Dict = {
   'settings.connectorsSaveKey': 'Save key',
   'settings.connectorsSaveKeyTitle': 'Send this key to the local daemon',
   'settings.connectorsKeySaving': 'Saving\u2026',
+  'settings.connectorsKeySaved': "Saved ✓",
   'settings.connectorsKeyError': 'Couldn\u2019t save the key. Check that the local daemon is running and try again.',
   'settings.connectorsHelpSaved': 'Your key is saved in the local daemon. Paste a new key to replace it, or Clear to remove.',
   'settings.connectorsHelpUnsaved': 'Unsaved changes \u2014 click Save key to store this credential in the local daemon and refresh the catalog below.',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -1056,6 +1056,7 @@ export const esES: Dict = {
   'settings.connectorsSaveKey': "Guardar clave",
   'settings.connectorsSaveKeyTitle': "Enviar esta clave al daemon local",
   'settings.connectorsKeySaving': "Guardando…",
+  'settings.connectorsKeySaved': "Guardado ✓",
   'settings.connectorsKeyError': "No se pudo guardar la clave. Comprueba que el daemon local está activo y vuelve a intentarlo.",
   'settings.connectorsHelpSaved': 'Tu clave desbloquea el catálogo de abajo y permanece en el daemon local. Pega una clave nueva para sustituirla o bórrala.',
   'settings.connectorsHelpUnsaved': "Cambios sin guardar — pulsa Guardar clave para almacenar esta credencial en el daemon local y desbloquear el catálogo de abajo.",

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -1201,6 +1201,7 @@ export const fa: Dict = {
   'settings.connectorsSaveKey': "ذخیره کلید",
   'settings.connectorsSaveKeyTitle': "ارسال این کلید به daemon محلی",
   'settings.connectorsKeySaving': "در حال ذخیره…",
+  'settings.connectorsKeySaved': "ذخیره شد ✓",
   'settings.connectorsKeyError': "ذخیره کلید ممکن نشد. بررسی کنید daemon محلی در حال اجراست و دوباره تلاش کنید.",
   'settings.connectorsHelpSaved': 'کلید شما کاتالوگ پایین را باز می‌کند و در daemon محلی می‌ماند. برای جایگزینی، کلید جدیدی جای‌گذاری کنید یا برای حذف، پاک کنید.',
   'settings.connectorsHelpUnsaved': "تغییرات ذخیره‌نشده — برای ذخیرهٔ این اعتبارنامه در daemon محلی و باز کردن کاتالوگ پایین، روی «ذخیره کلید» بزنید.",

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -1167,6 +1167,7 @@ export const fr: Dict = {
   'settings.connectorsSaveKey': "Enregistrer la clé",
   'settings.connectorsSaveKeyTitle': "Envoyer cette clé au daemon local",
   'settings.connectorsKeySaving': "Enregistrement…",
+  'settings.connectorsKeySaved': "Enregistré ✓",
   'settings.connectorsKeyError': "Impossible d’enregistrer la clé. Vérifie que le daemon local est lancé puis réessaie.",
   'settings.connectorsHelpSaved': 'Votre clé déverrouille le catalogue ci-dessous et reste dans le daemon local. Collez une nouvelle clé pour la remplacer ou effacez-la.',
   'settings.connectorsHelpUnsaved': "Modifications non enregistrées — clique sur Enregistrer la clé pour stocker cette information dans le daemon local et débloquer le catalogue ci-dessous.",

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -1177,6 +1177,7 @@ export const hu: Dict = {
   'settings.connectorsSaveKey': "Kulcs mentése",
   'settings.connectorsSaveKeyTitle': "Kulcs elküldése a helyi daemonhoz",
   'settings.connectorsKeySaving': "Mentés…",
+  'settings.connectorsKeySaved': "Mentve ✓",
   'settings.connectorsKeyError': "A kulcs mentése nem sikerült. Ellenőrizd, hogy a helyi daemon fut-e, majd próbáld újra.",
   'settings.connectorsHelpSaved': 'A kulcs feloldja az alábbi katalógust, és a helyi daemonban marad. Illessz be új kulcsot a cseréhez, vagy töröld az eltávolításhoz.',
   'settings.connectorsHelpUnsaved': "Mentetlen változtatások — kattints a Kulcs mentése gombra, hogy a hitelesítő adat a helyi daemonba kerüljön, és nyíljon a lenti katalógus.",

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -210,6 +210,7 @@ export const id: Dict = {
   'settings.connectorsSaveKey': 'Simpan key',
   'settings.connectorsSaveKeyTitle': 'Kirim key ini ke daemon lokal',
   'settings.connectorsKeySaving': 'Menyimpan…',
+  'settings.connectorsKeySaved': "Tersimpan ✓",
   'settings.connectorsKeyError': 'Tidak bisa menyimpan key. Pastikan daemon lokal berjalan lalu coba lagi.',
   'settings.connectorsHelpSaved':
     'Key kamu tersimpan di daemon lokal. Tempel key baru untuk menggantinya, atau Hapus untuk menghapusnya.',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -1054,6 +1054,7 @@ export const ja: Dict = {
   'settings.connectorsSaveKey': "キーを保存",
   'settings.connectorsSaveKeyTitle': "このキーをローカルの daemon に送信",
   'settings.connectorsKeySaving': "保存中…",
+  'settings.connectorsKeySaved': "保存完了 ✓",
   'settings.connectorsKeyError': "キーを保存できませんでした。ローカルの daemon が起動しているか確認して、もう一度お試しください。",
   'settings.connectorsHelpSaved': 'キーは下のカタログを有効にし、ローカル daemon に保持されます。置き換えるには新しいキーを貼り付け、削除するにはクリアしてください。',
   'settings.connectorsHelpUnsaved': "未保存の変更があります — 「キーを保存」をクリックすると、この資格情報がローカル daemon に保存され、下のカタログが解除されます。",

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -1167,6 +1167,7 @@ export const ko: Dict = {
   'settings.connectorsSaveKey': "키 저장",
   'settings.connectorsSaveKeyTitle': "이 키를 로컬 데몬으로 전송",
   'settings.connectorsKeySaving': "저장 중…",
+  'settings.connectorsKeySaved': "저장됨 ✓",
   'settings.connectorsKeyError': "키를 저장하지 못했습니다. 로컬 데몬이 실행 중인지 확인한 뒤 다시 시도하세요.",
   'settings.connectorsHelpSaved': '키가 아래 카탈로그를 열며 로컬 daemon에 유지됩니다. 교체하려면 새 키를 붙여넣고, 제거하려면 지우세요.',
   'settings.connectorsHelpUnsaved': "저장되지 않은 변경사항 — 「키 저장」을 눌러 이 자격 정보를 로컬 데몬에 저장하고 아래 카탈로그를 해제하세요.",

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -1167,6 +1167,7 @@ export const pl: Dict = {
   'settings.connectorsSaveKey': "Zapisz klucz",
   'settings.connectorsSaveKeyTitle': "Wyślij ten klucz do lokalnego demona",
   'settings.connectorsKeySaving': "Zapisywanie…",
+  'settings.connectorsKeySaved': "Zapisano ✓",
   'settings.connectorsKeyError': "Nie udało się zapisać klucza. Sprawdź, czy lokalny demon działa, i spróbuj ponownie.",
   'settings.connectorsHelpSaved': 'Twój klucz odblokowuje katalog poniżej i pozostaje w lokalnym daemon. Wklej nowy klucz, aby go zastąpić, albo wyczyść, aby usunąć.',
   'settings.connectorsHelpUnsaved': "Niezapisane zmiany — kliknij Zapisz klucz, aby zachować te dane w lokalnym demonie i odblokować katalog poniżej.",

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -1199,6 +1199,7 @@ export const ptBR: Dict = {
   'settings.connectorsSaveKey': "Salvar chave",
   'settings.connectorsSaveKeyTitle': "Enviar esta chave para o daemon local",
   'settings.connectorsKeySaving': "Salvando…",
+  'settings.connectorsKeySaved': "Salvo ✓",
   'settings.connectorsKeyError': "Não foi possível salvar a chave. Confirme que o daemon local está ativo e tente novamente.",
   'settings.connectorsHelpSaved': 'Sua chave desbloqueia o catálogo abaixo e permanece no daemon local. Cole uma nova chave para substituí-la ou limpe para remover.',
   'settings.connectorsHelpUnsaved': "Alterações não salvas — clique em Salvar chave para armazenar esta credencial no daemon local e desbloquear o catálogo abaixo.",

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -1199,6 +1199,7 @@ export const ru: Dict = {
   'settings.connectorsSaveKey': "Сохранить ключ",
   'settings.connectorsSaveKeyTitle': "Отправить ключ локальному демону",
   'settings.connectorsKeySaving': "Сохранение…",
+  'settings.connectorsKeySaved': "Сохранено ✓",
   'settings.connectorsKeyError': "Не удалось сохранить ключ. Убедитесь, что локальный демон запущен, и попробуйте снова.",
   'settings.connectorsHelpSaved': 'Ваш ключ открывает каталог ниже и остаётся в локальном daemon. Вставьте новый ключ для замены или очистите, чтобы удалить.',
   'settings.connectorsHelpUnsaved': "Несохранённые изменения — нажмите «Сохранить ключ», чтобы передать его локальному демону и открыть каталог ниже.",

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -1150,6 +1150,7 @@ export const th: Dict = {
   'settings.connectorsSaveKey': 'อัดลงบันทึกชุดคีย์เลย',
   'settings.connectorsSaveKeyTitle': 'ดึงโอนความของคีย์ที่ได้รับกลับมาให้ที่ส่วนระบบเครื่องส่วน Local Daemon ต่อเลย',
   'settings.connectorsKeySaving': 'เก็บรักษาที่ส่วนข้อมูล…',
+  'settings.connectorsKeySaved': "บันทึกแล้ว ✓",
   'settings.connectorsKeyError': 'ไม่สามารถบันทึกได้ ลองตรวจสอบตัว Daemon ให้ดี',
   'settings.connectorsHelpSaved': 'รหัสเก็บอยู่ในเครื่องเรียบร้อย นำรหัสใหม่ใส่ได้ตลอด หรือเอาออกด้วยปุ่มล้างข้อมูล',
   'settings.connectorsHelpUnsaved': 'ผลต่างของการแก้ที่คงไม่ทันบันทึก — กดที่คำบันทึกคีย์มาทำให้เป็นบันทึกเข้าเอาในของระบบไว้เพื่อให้เปิดตรงข้อมูลหน้าได้ดูความพร้อมในแถบเครื่องมือ',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -1158,6 +1158,7 @@ export const tr: Dict = {
   'settings.connectorsSaveKey': "Anahtarı kaydet",
   'settings.connectorsSaveKeyTitle': "Bu anahtarı yerel daemon’a gönder",
   'settings.connectorsKeySaving': "Kaydediliyor…",
+  'settings.connectorsKeySaved': "Kaydedildi ✓",
   'settings.connectorsKeyError': "Anahtar kaydedilemedi. Yerel daemon’ın çalıştığını doğrulayın ve tekrar deneyin.",
   'settings.connectorsHelpSaved': 'Anahtarınız aşağıdaki kataloğu açar ve yerel daemon’da kalır. Değiştirmek için yeni anahtar yapıştırın veya kaldırmak için temizleyin.',
   'settings.connectorsHelpUnsaved': "Kaydedilmemiş değişiklikler — bu kimlik bilgisini yerel daemon’a kaydetmek ve aşağıdaki kataloğu açmak için Anahtarı kaydet’e tıklayın.",

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -1200,6 +1200,7 @@ export const uk: Dict = {
   'settings.connectorsSaveKey': "Зберегти ключ",
   'settings.connectorsSaveKeyTitle': "Надіслати цей ключ локальному демону",
   'settings.connectorsKeySaving': "Збереження…",
+  'settings.connectorsKeySaved': "Збережено ✓",
   'settings.connectorsKeyError': "Не вдалося зберегти ключ. Перевірте, чи запущено локальний демон, і спробуйте ще раз.",
   'settings.connectorsHelpSaved': 'Ваш ключ відкриває каталог нижче й залишається в локальному daemon. Вставте новий ключ, щоб замінити його, або очистіть, щоб видалити.',
   'settings.connectorsHelpUnsaved': "Незбережені зміни — натисніть «Зберегти ключ», щоб надіслати ці дані локальному демону і відкрити каталог нижче.",

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1239,6 +1239,7 @@ export const zhCN: Dict = {
   'settings.connectorsSaveKey': "保存密钥",
   'settings.connectorsSaveKeyTitle': "将此密钥发送到本地 daemon",
   'settings.connectorsKeySaving': "保存中…",
+  'settings.connectorsKeySaved': "已保存 ✓",
   'settings.connectorsKeyError': "保存密钥失败。请确认本地 daemon 已启动后再试。",
   'settings.connectorsHelpSaved': '你的密钥会解锁下方目录，并保留在本地 daemon 中。粘贴新密钥可替换，或清除以移除。',
   'settings.connectorsHelpUnsaved': "尚未保存 — 点击「保存密钥」即可把它存入本地 daemon，并解锁下方目录。",

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -1232,6 +1232,7 @@ export const zhTW: Dict = {
   'settings.connectorsSaveKey': "儲存金鑰",
   'settings.connectorsSaveKeyTitle': "將此金鑰送往本機 daemon",
   'settings.connectorsKeySaving': "儲存中…",
+  'settings.connectorsKeySaved': "已儲存 ✓",
   'settings.connectorsKeyError': "儲存金鑰失敗。請確認本機 daemon 已啟動後再試。",
   'settings.connectorsHelpSaved': '你的金鑰會解鎖下方目錄，並保留在本機 daemon 中。貼上新金鑰可取代，或清除以移除。',
   'settings.connectorsHelpUnsaved': "尚未儲存 — 點擊「儲存金鑰」即可將其存入本機 daemon，並解鎖下方目錄。",

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -274,6 +274,7 @@ export interface Dict {
   'settings.connectorsSaveKey': string;
   'settings.connectorsSaveKeyTitle': string;
   'settings.connectorsKeySaving': string;
+  'settings.connectorsKeySaved': string;
   'settings.connectorsKeyError': string;
   'settings.connectorsHelpSaved': string;
   'settings.connectorsHelpUnsaved': string;


### PR DESCRIPTION
## Summary

Fixes #654 — saving an API key now shows explicit success feedback before returning to the default state.

## What changed

1. Added a `'saved'` state to the Composio API key save button. After a successful save, it briefly shows "✓ Saved" for 2 seconds, then returns to the "Save Key" button.
2. Added the `settings.connectorsKeySaved` translation key to all 18 locale files.
3. Added a cleanup `useEffect` to clear the saved-state timer on unmount.

## Before / After

**Before**: Button goes from "Saving…" → "Save Key" with no confirmation. Users have to reopen Settings to verify the key was saved.

**After**: Button goes from "Saving…" → "✓ Saved" (2s) → "Save Key". Clear visual confirmation that the save succeeded.
