### PR TITLE
ci: add Cloudflare Pages PR preview for apps/web

### DIFF
--- a/.github/workflows/web-preview.yml
+++ b/.github/workflows/web-preview.yml
@@ -1,0 +1,101 @@
+name: web-preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - .github/workflows/web-preview.yml
+      - apps/web/**
+      - packages/**
+      - package.json
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+
+permissions:
+  contents: read
+  deployments: write
+  pull-requests: write
+
+concurrency:
+  group: web-preview-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy web preview
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    # Forks cannot read secrets — skip the deploy step entirely instead of
+    # failing the workflow. Reviewers can ask the contributor to push to a
+    # branch on this repo when a preview matters.
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 10.33.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Mirror ci.yml's prebuild step — apps/web's typecheck depends on these
+      # generated declaration files from sibling packages.
+      - name: Prebuild workspace type declarations
+        run: |
+          pnpm --filter @open-design/daemon build
+          pnpm --filter @open-design/web build:sidecar
+
+      - name: Build web (static export)
+        env:
+          NODE_ENV: production
+        run: pnpm --filter @open-design/web build
+
+      # The `out/` directory is the static export target when NODE_ENV=production
+      # and OD_WEB_OUTPUT_MODE is unset; see apps/web/next.config.ts.
+      - name: Verify static export exists
+        run: |
+          if [ ! -d "apps/web/out" ]; then
+            echo "Expected apps/web/out to exist after build; check next.config.ts output mode."
+            exit 1
+          fi
+
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: apps/web
+          packageManager: npm
+          command: >
+            pages deploy out
+            --project-name=open-design-web
+            --branch=pr-${{ github.event.pull_request.number }}
+
+      - name: Comment preview URL on PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: web-preview
+          message: |
+            ### Web app preview is ready
+
+            | Field | Value |
+            | --- | --- |
+            | Preview | https://pr-${{ github.event.pull_request.number }}.open-design-web.pages.dev |
+            | Commit | `${{ github.event.pull_request.head.sha }}` |
+            | Workflow | [run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) |
+
+            Updates on every push to this PR. This is a static export of
+            `apps/web`, so daemon-backed routes (`/api`, `/artifacts`, `/frames`)
+            will 404 unless a separate daemon is reachable.


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/web-preview.yml` — a Cloudflare Pages PR preview workflow for `apps/web`
- Triggers on PRs that touch `apps/web/**`, `packages/**`, or workspace lockfiles
- Builds the static export (`output: 'export'`) and deploys to a per-PR branch on Cloudflare Pages
- Posts a sticky comment with the preview URL (updates on subsequent pushes instead of creating a new comment)
- Reuses the same `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` secrets as `landing-page-deploy.yml`
- External fork PRs skip the deploy step (no secrets access)

## One-time setup before merging

Create the Cloudflare Pages project once (separate from `landing-page` to avoid overwriting it):

```bash
npx wrangler@latest pages project create open-design-web --production-branch main
```

## Test plan

- [ ] Merge this PR
- [ ] Open a follow-up PR that touches `apps/web/**`
- [ ] Verify the `web-preview` workflow runs
- [ ] Verify the sticky comment shows `https://pr-<number>.open-design-web.pages.dev`
- [ ] Click the link and confirm the static export loads

## Known limitations

- Static export only — no daemon, so `/api`, `/artifacts`, `/frames` routes will 404 in the preview. Good enough for visual review of UI changes; for full-stack previews we'd need to either expose the daemon via a Cloudflare Tunnel or migrate to `@cloudflare/next-on-pages`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
