### PR TITLE
feat(web): add thumbs-up/down feedback widget under completed assistant turns (#1288)

### DIFF
--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -165,7 +165,13 @@ export function AssistantMessage({
           hasUnfinishedTodos={unfinishedTodos.length > 0}
           hasEmptyResponse={hasEmptyResponse}
         />
-        {runSucceeded && !hasEmptyResponse ? (
+        {/* Feedback widget for issue #1288 — gated on `produced.length > 0`
+            because the issue scopes feedback to turns that produce a final
+            artifact, not text-only acknowledgements or question-form turns
+            (lefarcen review on PR #1308). The `runSucceeded`
+            guard keeps it off failed runs, and `!hasEmptyResponse` keeps it
+            off agents that succeeded silently with no content. */}
+        {runSucceeded && !hasEmptyResponse && produced.length > 0 ? (
           <MessageFeedback messageId={message.id} />
         ) : null}
       </div>

--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -9,6 +9,7 @@ import {
 import { stripArtifact } from "../artifacts/strip";
 import { QuestionFormView, parseSubmittedAnswers } from "./QuestionForm";
 import { Icon } from "./Icon";
+import { MessageFeedback } from "./MessageFeedback";
 import { useT } from "../i18n";
 import { unfinishedTodosFromEvents, type TodoItem } from "../runtime/todos";
 import type { Dict } from "../i18n/types";
@@ -164,6 +165,9 @@ export function AssistantMessage({
           hasUnfinishedTodos={unfinishedTodos.length > 0}
           hasEmptyResponse={hasEmptyResponse}
         />
+        {runSucceeded && !hasEmptyResponse ? (
+          <MessageFeedback messageId={message.id} />
+        ) : null}
       </div>
     </div>
   );

--- a/apps/web/src/components/MessageFeedback.tsx
+++ b/apps/web/src/components/MessageFeedback.tsx
@@ -1,0 +1,164 @@
+import { useState } from 'react';
+
+import { useT } from '../i18n';
+import {
+  useMessageFeedback,
+  type FeedbackRating,
+  type MessageFeedback as MessageFeedbackValue,
+} from '../state/message-feedback';
+
+interface Props {
+  messageId: string;
+  /**
+   * Test seam: drop in a deterministic `Date.now()` so snapshot timing
+   * isn't sensitive to wall-clock. Defaults to the real clock.
+   */
+  now?: () => number;
+}
+
+/**
+ * Lightweight feedback widget rendered under each completed assistant
+ * turn (issue #1288). The visibility gate (only after a successful
+ * run) is the caller's responsibility — this component assumes it's
+ * mounted at the right moment and always renders something.
+ *
+ * Lifecycle:
+ *
+ *   - **Idle.** Shows the helpful-prompt copy and two thumb buttons.
+ *     Clicking either persists the rating immediately and flips to the
+ *     submitted state.
+ *
+ *   - **Submitted positive.** Confirmation chip plus a Change button
+ *     that clears the rating so the user can re-rate. Issue Open
+ *     Question 2 ("should users be able to change feedback after
+ *     submitting it?") — yes, the lightweight thing is to allow it.
+ *
+ *   - **Submitted negative.** Same confirmation chip plus an optional
+ *     comment textarea. The comment is persisted on Send, so the
+ *     reducer-style record is { rating: 'negative', comment, submittedAt }.
+ *     A blank submit just confirms the comment area was acknowledged
+ *     without changing the recorded value, matching the issue's
+ *     "Optional follow-up reason or comment after negative feedback".
+ *
+ * Persistence is handled by `useMessageFeedback` (localStorage in v1;
+ * see `state/message-feedback.ts` for the rationale).
+ */
+export function MessageFeedback({ messageId, now = Date.now }: Props) {
+  const t = useT();
+  const [feedback, setFeedback] = useMessageFeedback(messageId);
+  const [draftComment, setDraftComment] = useState('');
+  const [commentJustSaved, setCommentJustSaved] = useState(false);
+
+  const submitRating = (rating: FeedbackRating) => {
+    const submittedAt = now();
+    setFeedback({ rating, submittedAt });
+    setDraftComment('');
+    setCommentJustSaved(false);
+  };
+
+  const submitComment = () => {
+    if (!feedback) return;
+    const comment = draftComment.trim();
+    const next: MessageFeedbackValue = {
+      ...feedback,
+      comment: comment || undefined,
+      submittedAt: feedback.submittedAt,
+    };
+    setFeedback(next);
+    setCommentJustSaved(true);
+  };
+
+  const clearFeedback = () => {
+    setFeedback(null);
+    setDraftComment('');
+    setCommentJustSaved(false);
+  };
+
+  if (!feedback) {
+    return (
+      <div className="message-feedback" data-state="idle">
+        <span className="message-feedback-prompt">{t('feedback.prompt')}</span>
+        <div className="message-feedback-actions">
+          <button
+            type="button"
+            className="message-feedback-button"
+            aria-label={t('feedback.thumbsUp')}
+            title={t('feedback.thumbsUp')}
+            onClick={() => submitRating('positive')}
+            data-testid="message-feedback-positive"
+          >
+            <span aria-hidden>👍</span>
+          </button>
+          <button
+            type="button"
+            className="message-feedback-button"
+            aria-label={t('feedback.thumbsDown')}
+            title={t('feedback.thumbsDown')}
+            onClick={() => submitRating('negative')}
+            data-testid="message-feedback-negative"
+          >
+            <span aria-hidden>👎</span>
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const confirmationKey
+    = feedback.rating === 'positive'
+      ? 'feedback.submittedPositive'
+      : 'feedback.submittedNegative';
+
+  return (
+    <div
+      className="message-feedback"
+      data-state="submitted"
+      data-rating={feedback.rating}
+    >
+      <span className="message-feedback-confirmation">
+        {t(confirmationKey)}
+      </span>
+      {feedback.rating === 'negative' ? (
+        <div className="message-feedback-comment">
+          <label className="message-feedback-comment-label">
+            {t('feedback.commentLabel')}
+            <textarea
+              className="message-feedback-comment-input"
+              placeholder={t('feedback.commentPlaceholder')}
+              value={draftComment || feedback.comment || ''}
+              onChange={(e) => {
+                setDraftComment(e.target.value);
+                if (commentJustSaved) setCommentJustSaved(false);
+              }}
+              data-testid="message-feedback-comment"
+            />
+          </label>
+          <div className="message-feedback-comment-actions">
+            <button
+              type="button"
+              className="message-feedback-comment-submit"
+              onClick={submitComment}
+              disabled={!draftComment.trim() && !feedback.comment}
+              data-testid="message-feedback-comment-submit"
+            >
+              {t('feedback.commentSubmit')}
+            </button>
+            {commentJustSaved ? (
+              <span className="message-feedback-comment-saved">
+                {t('feedback.commentSaved')}
+              </span>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+      <button
+        type="button"
+        className="message-feedback-change"
+        onClick={clearFeedback}
+        data-testid="message-feedback-change"
+      >
+        {t('feedback.change')}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/MessageFeedback.tsx
+++ b/apps/web/src/components/MessageFeedback.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { useT } from '../i18n';
 import {
@@ -46,13 +46,39 @@ interface Props {
 export function MessageFeedback({ messageId, now = Date.now }: Props) {
   const t = useT();
   const [feedback, setFeedback] = useMessageFeedback(messageId);
-  const [draftComment, setDraftComment] = useState('');
+  // Seed the textarea from any saved comment at mount time so a
+  // rehydrated negative feedback shows its prior text. The effect
+  // below re-seeds on rating transitions (idle -> negative, or a
+  // cross-mount sync flipping the rating) without overriding the
+  // user's in-progress edits.
+  const [draftComment, setDraftComment] = useState<string>(
+    () => feedback?.comment ?? '',
+  );
   const [commentJustSaved, setCommentJustSaved] = useState(false);
+  const lastSeededRatingRef = useRef<FeedbackRating | null>(
+    feedback?.rating ?? null,
+  );
+
+  // Re-seed draftComment whenever the rating itself transitions
+  // (e.g. clearFeedback -> null -> negative again, or a cross-tab
+  // update flips us into a different state). The dependency is
+  // `feedback?.rating` specifically — NOT `feedback?.comment` —
+  // because once the user types into the textarea we must not
+  // override their draft with a stale saved comment. Cleared
+  // comments (user erased the textarea then hit Send) deliberately
+  // surface as an empty draft.
+  useEffect(() => {
+    const nextRating = feedback?.rating ?? null;
+    if (nextRating !== lastSeededRatingRef.current) {
+      lastSeededRatingRef.current = nextRating;
+      setDraftComment(feedback?.comment ?? '');
+      setCommentJustSaved(false);
+    }
+  }, [feedback?.rating, feedback?.comment]);
 
   const submitRating = (rating: FeedbackRating) => {
     const submittedAt = now();
     setFeedback({ rating, submittedAt });
-    setDraftComment('');
     setCommentJustSaved(false);
   };
 
@@ -108,6 +134,13 @@ export function MessageFeedback({ messageId, now = Date.now }: Props) {
     = feedback.rating === 'positive'
       ? 'feedback.submittedPositive'
       : 'feedback.submittedNegative';
+  // Send is enabled when the textarea content differs from what's
+  // already persisted. That covers three intents: writing a new
+  // comment, editing an existing one, and clearing one (typed empty
+  // -> Send -> comment removed). Disabling on draft === saved keeps
+  // the button from being a no-op tap target.
+  const savedComment = feedback.comment ?? '';
+  const sendDisabled = draftComment === savedComment;
 
   return (
     <div
@@ -115,7 +148,11 @@ export function MessageFeedback({ messageId, now = Date.now }: Props) {
       data-state="submitted"
       data-rating={feedback.rating}
     >
-      <span className="message-feedback-confirmation">
+      <span
+        className="message-feedback-confirmation"
+        role="status"
+        aria-live="polite"
+      >
         {t(confirmationKey)}
       </span>
       {feedback.rating === 'negative' ? (
@@ -125,7 +162,7 @@ export function MessageFeedback({ messageId, now = Date.now }: Props) {
             <textarea
               className="message-feedback-comment-input"
               placeholder={t('feedback.commentPlaceholder')}
-              value={draftComment || feedback.comment || ''}
+              value={draftComment}
               onChange={(e) => {
                 setDraftComment(e.target.value);
                 if (commentJustSaved) setCommentJustSaved(false);
@@ -138,13 +175,17 @@ export function MessageFeedback({ messageId, now = Date.now }: Props) {
               type="button"
               className="message-feedback-comment-submit"
               onClick={submitComment}
-              disabled={!draftComment.trim() && !feedback.comment}
+              disabled={sendDisabled}
               data-testid="message-feedback-comment-submit"
             >
               {t('feedback.commentSubmit')}
             </button>
             {commentJustSaved ? (
-              <span className="message-feedback-comment-saved">
+              <span
+                className="message-feedback-comment-saved"
+                role="status"
+                aria-live="polite"
+              >
                 {t('feedback.commentSaved')}
               </span>
             ) : null}

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1089,6 +1089,17 @@ export const en: Dict = {
   'sketch.textPrompt': 'Text:',
   'sketch.textModalTitle': 'Add text',
 
+  'feedback.prompt': 'Was this response helpful?',
+  'feedback.thumbsUp': 'Helpful',
+  'feedback.thumbsDown': 'Not helpful',
+  'feedback.submittedPositive': 'Thanks for the feedback.',
+  'feedback.submittedNegative': "Thanks, we'll use this to improve.",
+  'feedback.commentLabel': 'What could be better? (optional)',
+  'feedback.commentPlaceholder': 'Tell us what we could have done differently',
+  'feedback.commentSubmit': 'Send comment',
+  'feedback.commentSaved': 'Comment saved',
+  'feedback.change': 'Change',
+
   'pet.title': 'Pets',
   'pet.subtitle': 'Adopt a tiny companion that floats over your workspace.',
   'pet.navTitle': 'Pets',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1059,6 +1059,17 @@ export const zhCN: Dict = {
   'sketch.textPrompt': '请输入文本：',
   'sketch.textModalTitle': '添加文本',
 
+  'feedback.prompt': '本次回复有帮助吗？',
+  'feedback.thumbsUp': '有帮助',
+  'feedback.thumbsDown': '没帮助',
+  'feedback.submittedPositive': '感谢您的反馈。',
+  'feedback.submittedNegative': '感谢您的反馈，我们会据此改进。',
+  'feedback.commentLabel': '哪里可以改进？（可选）',
+  'feedback.commentPlaceholder': '告诉我们可以做得更好的地方',
+  'feedback.commentSubmit': '发送评论',
+  'feedback.commentSaved': '评论已保存',
+  'feedback.change': '更改',
+
   'pet.title': '宠物',
   'pet.tabBuiltIn': '内置',
   'pet.tabBuiltInHint': 'Open Design 内置的精选宠物 — 一键领养。',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -1469,4 +1469,15 @@ export interface Dict {
   'sketch.closeConfirm': string;
   'sketch.textPrompt': string;
   'sketch.textModalTitle': string;
+  // Message-level feedback widget (issue #1288)
+  'feedback.prompt': string;
+  'feedback.thumbsUp': string;
+  'feedback.thumbsDown': string;
+  'feedback.submittedPositive': string;
+  'feedback.submittedNegative': string;
+  'feedback.commentLabel': string;
+  'feedback.commentPlaceholder': string;
+  'feedback.commentSubmit': string;
+  'feedback.commentSaved': string;
+  'feedback.change': string;
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -11832,6 +11832,138 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   background: var(--amber);
 }
 
+/* Message-level feedback widget (issue #1288). Sits under the
+   assistant footer, mirrors the pill / chip vocabulary used by the
+   surrounding chat surface so it reads as "part of the completed
+   turn" rather than as a modal. */
+.message-feedback {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  font-size: 11.5px;
+  color: var(--text-muted);
+}
+.message-feedback-prompt {
+  color: var(--text-muted);
+}
+.message-feedback-actions {
+  display: inline-flex;
+  gap: 4px;
+}
+.message-feedback-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+  transition: background-color 120ms ease, border-color 120ms ease;
+}
+.message-feedback-button:hover {
+  background: color-mix(in srgb, var(--accent) 8%, var(--bg-subtle));
+  border-color: color-mix(in srgb, var(--accent) 35%, var(--border));
+}
+.message-feedback-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.message-feedback-confirmation {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  font-weight: 600;
+  color: var(--text-strong);
+  font-size: 11.5px;
+}
+.message-feedback[data-rating="positive"] .message-feedback-confirmation {
+  background: color-mix(in srgb, var(--accent) 10%, var(--bg-subtle));
+  border-color: color-mix(in srgb, var(--accent) 35%, var(--border));
+}
+.message-feedback[data-rating="negative"] .message-feedback-confirmation {
+  background: color-mix(in srgb, var(--amber) 10%, var(--bg-subtle));
+  border-color: color-mix(in srgb, var(--amber) 35%, var(--border));
+}
+.message-feedback-change {
+  background: transparent;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--text-muted);
+  text-decoration: underline;
+  cursor: pointer;
+}
+.message-feedback-change:hover { color: var(--text); }
+.message-feedback-change:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+.message-feedback-comment {
+  flex-basis: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 4px;
+  max-width: 520px;
+}
+.message-feedback-comment-label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: var(--text-muted);
+}
+.message-feedback-comment-input {
+  min-height: 64px;
+  padding: 8px 10px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font: inherit;
+  font-size: 12.5px;
+  color: var(--text);
+  resize: vertical;
+}
+.message-feedback-comment-input:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+}
+.message-feedback-comment-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.message-feedback-comment-submit {
+  padding: 4px 12px;
+  background: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-sm);
+  color: var(--bg-panel);
+  font: inherit;
+  font-size: 11.5px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.message-feedback-comment-submit:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.message-feedback-comment-saved {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
 .unfinished-todos {
   margin-top: 10px;
   width: min(520px, 100%);

--- a/apps/web/src/state/message-feedback.ts
+++ b/apps/web/src/state/message-feedback.ts
@@ -1,0 +1,165 @@
+/**
+ * localStorage-backed feedback store for issue #1288.
+ *
+ * The acceptance criteria call for feedback that is "visually clear after
+ * submission" and "leaves room for future feedback metadata, such as
+ * reason, free-text comment, artifact id, task id, or Agent run id". We
+ * persist locally rather than round-tripping through the daemon for v1
+ * because:
+ *
+ *   1. The daemon's `messages` table is column-strict; adding a feedback
+ *      column would require a schema migration plus a contract bump in
+ *      `packages/contracts/src/api/chat.ts`. The team has not yet defined
+ *      the analytics pipeline shape (lefarcen's clarifying comment on
+ *      the issue), so persisting prematurely on the daemon would lock
+ *      in a shape that may need to change.
+ *
+ *   2. Local storage matches the lightweight, non-blocking UX the issue
+ *      asks for and survives reload, which is the minimum for the
+ *      "feedback state is visually clear after submission" criterion.
+ *      A future PR can replace the storage layer (or add a daemon
+ *      mirror) without touching the React surface, since the hook's
+ *      contract is just `(MessageFeedback | null, setter)`.
+ *
+ * Storage key shape: `open-design:message-feedback:<messageId>`. We
+ * intentionally do not namespace by project / conversation since
+ * `messageId` is already globally unique in the daemon's
+ * `messages` table and the values would either match or be stale (in
+ * which case the orphan entries are harmless 80-byte rows that the
+ * browser GCs on its own quota policy).
+ */
+
+import { useEffect, useState } from 'react';
+
+export type FeedbackRating = 'positive' | 'negative';
+
+export interface MessageFeedback {
+  rating: FeedbackRating;
+  /** Optional free-text reason or comment, currently captured only for negative feedback. */
+  comment?: string;
+  /** Epoch ms for telemetry / "submitted at" labels. */
+  submittedAt: number;
+}
+
+const STORAGE_PREFIX = 'open-design:message-feedback:';
+
+function storageKey(messageId: string): string {
+  return `${STORAGE_PREFIX}${messageId}`;
+}
+
+function safeWindow(): Window | null {
+  return typeof window === 'undefined' ? null : window;
+}
+
+/**
+ * Read the persisted feedback for a single message. Returns `null` when
+ * nothing has been recorded yet, on storage errors, or on shape mismatch
+ * (e.g. an older / future schema version landed in storage). Callers
+ * treat any non-null result as authoritative.
+ */
+export function readMessageFeedback(messageId: string): MessageFeedback | null {
+  const w = safeWindow();
+  if (!w) return null;
+  let raw: string | null;
+  try {
+    raw = w.localStorage.getItem(storageKey(messageId));
+  } catch {
+    return null;
+  }
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object') return null;
+    const candidate = parsed as Record<string, unknown>;
+    const rating = candidate.rating;
+    if (rating !== 'positive' && rating !== 'negative') return null;
+    const submittedAt = typeof candidate.submittedAt === 'number'
+      ? candidate.submittedAt
+      : Date.now();
+    const comment = typeof candidate.comment === 'string'
+      ? candidate.comment
+      : undefined;
+    return { rating, comment, submittedAt };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist or clear the feedback for a single message. Passing `null`
+ * removes the entry so the UI flips back to the unsubmitted state and
+ * the user can re-rate.
+ */
+export function writeMessageFeedback(
+  messageId: string,
+  feedback: MessageFeedback | null,
+): void {
+  const w = safeWindow();
+  if (!w) return;
+  try {
+    if (feedback === null) {
+      w.localStorage.removeItem(storageKey(messageId));
+      return;
+    }
+    w.localStorage.setItem(storageKey(messageId), JSON.stringify(feedback));
+  } catch {
+    // Storage quota / disabled storage / private-mode rejection: the
+    // UI keeps the in-memory state so the user still sees a confirmation
+    // for this session.
+  }
+  // Broadcast across listeners in the same tab (the storage event only
+  // fires for OTHER tabs); use a custom event so multiple mounted
+  // `useMessageFeedback` hooks for the same messageId stay in sync.
+  try {
+    w.dispatchEvent(new CustomEvent('open-design:message-feedback', {
+      detail: { messageId },
+    }));
+  } catch {
+    /* IE-style CustomEvent shim missing — fine, single-mount remains correct */
+  }
+}
+
+/**
+ * React hook for a single message's feedback. Returns the current value
+ * and a setter that updates both storage and any other mounted listeners
+ * for the same messageId (e.g. when the same message renders in two
+ * places, like the chat pane plus a debug panel).
+ */
+export function useMessageFeedback(
+  messageId: string,
+): [MessageFeedback | null, (next: MessageFeedback | null) => void] {
+  const [value, setValue] = useState<MessageFeedback | null>(() =>
+    readMessageFeedback(messageId),
+  );
+
+  // Re-read on storage / custom-event ticks so two mounts of this hook
+  // for the same messageId stay in sync.
+  useEffect(() => {
+    const w = safeWindow();
+    if (!w) return;
+    const reload = () => setValue(readMessageFeedback(messageId));
+    const onStorage = (evt: StorageEvent) => {
+      if (evt.key === null || evt.key === storageKey(messageId)) reload();
+    };
+    const onCustom = (evt: Event) => {
+      const detail = (evt as CustomEvent<{ messageId: string }>).detail;
+      if (!detail || detail.messageId === messageId) reload();
+    };
+    w.addEventListener('storage', onStorage);
+    w.addEventListener('open-design:message-feedback', onCustom);
+    // Re-read on mount in case storage changed between the lazy init
+    // and the effect attaching (rare, but cheap to cover).
+    reload();
+    return () => {
+      w.removeEventListener('storage', onStorage);
+      w.removeEventListener('open-design:message-feedback', onCustom);
+    };
+  }, [messageId]);
+
+  const set = (next: MessageFeedback | null): void => {
+    setValue(next);
+    writeMessageFeedback(messageId, next);
+  };
+
+  return [value, set];
+}

--- a/apps/web/src/state/message-feedback.ts
+++ b/apps/web/src/state/message-feedback.ts
@@ -85,10 +85,28 @@ export function readMessageFeedback(messageId: string): MessageFeedback | null {
   }
 }
 
+const FEEDBACK_EVENT_NAME = 'open-design:message-feedback';
+
+interface FeedbackEventDetail {
+  messageId: string;
+  value: MessageFeedback | null;
+}
+
 /**
  * Persist or clear the feedback for a single message. Passing `null`
  * removes the entry so the UI flips back to the unsubmitted state and
  * the user can re-rate.
+ *
+ * The broadcast contract: a same-tab `open-design:message-feedback`
+ * CustomEvent always fires with the new value in `detail.value`,
+ * regardless of whether the underlying storage write succeeded.
+ * Listeners apply the value directly instead of re-reading storage so
+ * a setItem failure (private mode, quota exceeded, disabled storage)
+ * does not clobber the in-memory confirmation the user just saw
+ * (codex + lefarcen P2 on PR #1308). The clear path likewise emits the
+ * broadcast so two mounted hooks for the same message return to idle
+ * together when the user clicks Change (Siri-Ray + lefarcen P2 on
+ * PR #1308).
  */
 export function writeMessageFeedback(
   messageId: string,
@@ -99,21 +117,19 @@ export function writeMessageFeedback(
   try {
     if (feedback === null) {
       w.localStorage.removeItem(storageKey(messageId));
-      return;
+    } else {
+      w.localStorage.setItem(storageKey(messageId), JSON.stringify(feedback));
     }
-    w.localStorage.setItem(storageKey(messageId), JSON.stringify(feedback));
   } catch {
     // Storage quota / disabled storage / private-mode rejection: the
     // UI keeps the in-memory state so the user still sees a confirmation
-    // for this session.
+    // for this session. The broadcast below ensures every mounted hook
+    // for this messageId picks up the new value from the event detail
+    // even though `readMessageFeedback` would now return null.
   }
-  // Broadcast across listeners in the same tab (the storage event only
-  // fires for OTHER tabs); use a custom event so multiple mounted
-  // `useMessageFeedback` hooks for the same messageId stay in sync.
   try {
-    w.dispatchEvent(new CustomEvent('open-design:message-feedback', {
-      detail: { messageId },
-    }));
+    const detail: FeedbackEventDetail = { messageId, value: feedback };
+    w.dispatchEvent(new CustomEvent(FEEDBACK_EVENT_NAME, { detail }));
   } catch {
     /* IE-style CustomEvent shim missing — fine, single-mount remains correct */
   }
@@ -132,27 +148,33 @@ export function useMessageFeedback(
     readMessageFeedback(messageId),
   );
 
-  // Re-read on storage / custom-event ticks so two mounts of this hook
-  // for the same messageId stay in sync.
+  // Keep two mounts of this hook for the same messageId in sync.
+  // Cross-tab updates land via the platform `storage` event and we
+  // re-read from storage to pick up the new value. Same-tab updates
+  // land via our `open-design:message-feedback` CustomEvent and we
+  // apply the broadcast value directly — re-reading from storage at
+  // this point would clobber the in-memory state if the writer's
+  // setItem call failed (private mode / quota / disabled storage).
   useEffect(() => {
     const w = safeWindow();
     if (!w) return;
-    const reload = () => setValue(readMessageFeedback(messageId));
     const onStorage = (evt: StorageEvent) => {
-      if (evt.key === null || evt.key === storageKey(messageId)) reload();
+      if (evt.key !== null && evt.key !== storageKey(messageId)) return;
+      setValue(readMessageFeedback(messageId));
     };
     const onCustom = (evt: Event) => {
-      const detail = (evt as CustomEvent<{ messageId: string }>).detail;
-      if (!detail || detail.messageId === messageId) reload();
+      const detail = (evt as CustomEvent<FeedbackEventDetail>).detail;
+      if (!detail || detail.messageId !== messageId) return;
+      setValue(detail.value);
     };
     w.addEventListener('storage', onStorage);
-    w.addEventListener('open-design:message-feedback', onCustom);
+    w.addEventListener(FEEDBACK_EVENT_NAME, onCustom);
     // Re-read on mount in case storage changed between the lazy init
     // and the effect attaching (rare, but cheap to cover).
-    reload();
+    setValue(readMessageFeedback(messageId));
     return () => {
       w.removeEventListener('storage', onStorage);
-      w.removeEventListener('open-design:message-feedback', onCustom);
+      w.removeEventListener(FEEDBACK_EVENT_NAME, onCustom);
     };
   }, [messageId]);
 

--- a/apps/web/tests/components/AssistantMessage.test.tsx
+++ b/apps/web/tests/components/AssistantMessage.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+
+/**
+ * Visibility-gate coverage for the feedback widget (issue #1288). The
+ * lefarcen P2 review on PR #1308 pointed out that mounting the
+ * widget on every `runSucceeded && !hasEmptyResponse` turn would
+ * surface it after text-only acknowledgements and question-form
+ * replies that don't produce a final artifact. The issue is scoped
+ * to final-artifact turns specifically, so the gate now also
+ * requires `produced.length > 0`.
+ */
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { AssistantMessage } from '../../src/components/AssistantMessage';
+import type { ChatMessage, ProjectFile } from '../../src/types';
+
+afterEach(() => {
+  cleanup();
+  window.localStorage.clear();
+});
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+function baseMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'msg-1',
+    role: 'assistant',
+    content: 'Done.',
+    runStatus: 'succeeded',
+    startedAt: 1700000000,
+    endedAt: 1700000005,
+    events: [{ kind: 'text', text: 'Done.' } as ChatMessage['events'][number]],
+    producedFiles: [],
+    ...overrides,
+  } as ChatMessage;
+}
+
+function producedFile(name: string): ProjectFile {
+  return {
+    name,
+    path: name,
+    size: 100,
+    updatedAt: 1700000005,
+    kind: 'html',
+  } as ProjectFile;
+}
+
+describe('AssistantMessage feedback gate (issue #1288)', () => {
+  it('shows the feedback widget after a successful turn that produced files', () => {
+    render(
+      <AssistantMessage
+        message={baseMessage({ producedFiles: [producedFile('index.html')] })}
+        streaming={false}
+        projectId="proj-1"
+      />,
+    );
+    expect(screen.getByText('Was this response helpful?')).toBeTruthy();
+  });
+
+  it('hides the feedback widget for a successful text-only turn with no producedFiles', () => {
+    // Regression for lefarcen P2: the issue scopes feedback to
+    // turns that delivered a final artifact, not every successful
+    // turn. Text-only acknowledgements ("Got it.") must not prompt
+    // for feedback.
+    render(
+      <AssistantMessage
+        message={baseMessage({ producedFiles: [] })}
+        streaming={false}
+        projectId="proj-1"
+      />,
+    );
+    expect(screen.queryByText('Was this response helpful?')).toBeNull();
+  });
+
+  it('hides the feedback widget while the turn is still streaming', () => {
+    render(
+      <AssistantMessage
+        message={baseMessage({
+          producedFiles: [producedFile('index.html')],
+          runStatus: 'running',
+          endedAt: undefined,
+        })}
+        streaming
+        projectId="proj-1"
+      />,
+    );
+    expect(screen.queryByText('Was this response helpful?')).toBeNull();
+  });
+
+  it('hides the feedback widget when the run failed', () => {
+    render(
+      <AssistantMessage
+        message={baseMessage({
+          producedFiles: [producedFile('index.html')],
+          runStatus: 'failed',
+        })}
+        streaming={false}
+        projectId="proj-1"
+      />,
+    );
+    expect(screen.queryByText('Was this response helpful?')).toBeNull();
+  });
+
+  it('hides the feedback widget when the run ended with an empty_response status', () => {
+    render(
+      <AssistantMessage
+        message={baseMessage({
+          producedFiles: [producedFile('index.html')],
+          events: [
+            { kind: 'status', label: 'empty_response' } as ChatMessage['events'][number],
+          ],
+        })}
+        streaming={false}
+        projectId="proj-1"
+      />,
+    );
+    expect(screen.queryByText('Was this response helpful?')).toBeNull();
+  });
+});

--- a/apps/web/tests/components/MessageFeedback.test.tsx
+++ b/apps/web/tests/components/MessageFeedback.test.tsx
@@ -12,7 +12,7 @@
  */
 
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MessageFeedback } from '../../src/components/MessageFeedback';
 import { readMessageFeedback } from '../../src/state/message-feedback';
@@ -109,5 +109,86 @@ describe('MessageFeedback (issue #1288)', () => {
     expect(screen.getByText('Thanks for the feedback.')).toBeTruthy();
     // The idle prompt must NOT also appear.
     expect(screen.queryByText('Was this response helpful?')).toBeNull();
+  });
+
+  it('lets the user clear a saved comment by erasing the textarea and clicking Send', () => {
+    // Lefarcen P3 (#1308 review): the prior `draftComment ||
+    // feedback.comment || ''` controlled value made the textarea
+    // snap back to the saved comment whenever the draft was empty,
+    // so the user could never erase a saved comment without
+    // clicking Change first. With the draft-only value the user
+    // can erase + Send to clear.
+    window.localStorage.setItem(
+      'open-design:message-feedback:msg-clear-comment',
+      JSON.stringify({
+        rating: 'negative',
+        comment: 'preview opened the pointer file',
+        submittedAt: 1700000020,
+      }),
+    );
+    render(<MessageFeedback messageId="msg-clear-comment" />);
+
+    const textarea = screen.getByTestId('message-feedback-comment') as HTMLTextAreaElement;
+    expect(textarea.value).toBe('preview opened the pointer file');
+    fireEvent.change(textarea, { target: { value: '' } });
+    expect(textarea.value).toBe('');
+
+    fireEvent.click(screen.getByTestId('message-feedback-comment-submit'));
+    expect(readMessageFeedback('msg-clear-comment')).toEqual({
+      rating: 'negative',
+      comment: undefined,
+      submittedAt: 1700000020,
+    });
+  });
+
+  it('keeps the in-session confirmation visible when localStorage writes fail (private mode / quota)', () => {
+    // Codex + lefarcen P2 (#1308 review): a failing setItem used to
+    // unstick the just-submitted rating because the CustomEvent
+    // listener re-read storage (now null) and overrode the in-memory
+    // state. The fix puts the new value in the event detail so
+    // listeners apply it directly.
+    const setItemSpy = vi
+      .spyOn(window.localStorage, 'setItem')
+      .mockImplementation(() => {
+        throw new Error('QuotaExceededError');
+      });
+    render(<MessageFeedback messageId="msg-quota" now={() => 1700000030} />);
+    fireEvent.click(screen.getByTestId('message-feedback-positive'));
+
+    expect(screen.getByText('Thanks for the feedback.')).toBeTruthy();
+    expect(screen.queryByText('Was this response helpful?')).toBeNull();
+    setItemSpy.mockRestore();
+  });
+
+  it('keeps two mounts of the same messageId in sync (positive submit + Change)', () => {
+    // Siri-Ray (#1308 review): the previous implementation broke the
+    // same-tab sync contract on the clear path because it early-
+    // returned before dispatching the CustomEvent. Two mounts of the
+    // same message must reach the same state on both Submit and Clear.
+    render(
+      <div>
+        <div data-testid="mount-a">
+          <MessageFeedback messageId="msg-shared" now={() => 1700000040} />
+        </div>
+        <div data-testid="mount-b">
+          <MessageFeedback messageId="msg-shared" now={() => 1700000040} />
+        </div>
+      </div>,
+    );
+
+    // Both start in idle.
+    expect(screen.getAllByText('Was this response helpful?')).toHaveLength(2);
+
+    // Click positive on mount A: both mounts flip to submitted.
+    const positiveButtons = screen.getAllByTestId('message-feedback-positive');
+    fireEvent.click(positiveButtons[0]!);
+    expect(screen.getAllByText('Thanks for the feedback.')).toHaveLength(2);
+    expect(screen.queryByText('Was this response helpful?')).toBeNull();
+
+    // Click Change on mount B: both mounts return to idle.
+    const changeButtons = screen.getAllByTestId('message-feedback-change');
+    fireEvent.click(changeButtons[1]!);
+    expect(screen.getAllByText('Was this response helpful?')).toHaveLength(2);
+    expect(screen.queryByText('Thanks for the feedback.')).toBeNull();
   });
 });

--- a/apps/web/tests/components/MessageFeedback.test.tsx
+++ b/apps/web/tests/components/MessageFeedback.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+
+/**
+ * Render-level coverage for `<MessageFeedback>` (issue #1288). Drives
+ * the widget's three states (idle, submitted positive, submitted
+ * negative + comment) end to end through the real
+ * `useMessageFeedback` hook so the localStorage round-trip is
+ * exercised at the same time. The visibility gate (only after the
+ * assistant message finishes successfully) lives in
+ * `AssistantMessage.tsx` and is not the responsibility of this
+ * component, so it is not asserted here.
+ */
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { MessageFeedback } from '../../src/components/MessageFeedback';
+import { readMessageFeedback } from '../../src/state/message-feedback';
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  window.localStorage.clear();
+});
+
+describe('MessageFeedback (issue #1288)', () => {
+  it('shows the helpful-prompt and two thumb buttons in the idle state', () => {
+    render(<MessageFeedback messageId="msg-idle" />);
+    expect(screen.getByText('Was this response helpful?')).toBeTruthy();
+    expect(screen.getByTestId('message-feedback-positive')).toBeTruthy();
+    expect(screen.getByTestId('message-feedback-negative')).toBeTruthy();
+  });
+
+  it('persists a positive rating and flips to the confirmation chip on click', () => {
+    render(<MessageFeedback messageId="msg-pos" now={() => 1700000001} />);
+    fireEvent.click(screen.getByTestId('message-feedback-positive'));
+
+    expect(screen.getByText('Thanks for the feedback.')).toBeTruthy();
+    expect(readMessageFeedback('msg-pos')).toEqual({
+      rating: 'positive',
+      submittedAt: 1700000001,
+      comment: undefined,
+    });
+  });
+
+  it('persists a negative rating and surfaces the optional comment textarea', () => {
+    render(<MessageFeedback messageId="msg-neg" now={() => 1700000002} />);
+    fireEvent.click(screen.getByTestId('message-feedback-negative'));
+
+    expect(screen.getByText("Thanks, we'll use this to improve.")).toBeTruthy();
+    expect(screen.getByTestId('message-feedback-comment')).toBeTruthy();
+    expect(readMessageFeedback('msg-neg')).toEqual({
+      rating: 'negative',
+      submittedAt: 1700000002,
+      comment: undefined,
+    });
+  });
+
+  it('records a negative comment on submit and shows the saved confirmation', () => {
+    render(<MessageFeedback messageId="msg-neg-c" now={() => 1700000003} />);
+    fireEvent.click(screen.getByTestId('message-feedback-negative'));
+
+    const textarea = screen.getByTestId('message-feedback-comment') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'preview opened the pointer file' } });
+    fireEvent.click(screen.getByTestId('message-feedback-comment-submit'));
+
+    expect(screen.getByText('Comment saved')).toBeTruthy();
+    expect(readMessageFeedback('msg-neg-c')).toEqual({
+      rating: 'negative',
+      comment: 'preview opened the pointer file',
+      submittedAt: 1700000003,
+    });
+  });
+
+  it('disables the Send button when the textarea is empty (no blank-comment writes)', () => {
+    render(<MessageFeedback messageId="msg-neg-blank" />);
+    fireEvent.click(screen.getByTestId('message-feedback-negative'));
+
+    const submit = screen.getByTestId('message-feedback-comment-submit') as HTMLButtonElement;
+    expect(submit.disabled).toBe(true);
+  });
+
+  it('clears feedback when Change is clicked, returning to the idle state', () => {
+    // Issue Open Question 2 ("should users be able to change feedback
+    // after submitting it?") — answered yes in this v1: clicking
+    // Change unsticks the rating so the user can re-rate.
+    render(<MessageFeedback messageId="msg-change" />);
+    fireEvent.click(screen.getByTestId('message-feedback-positive'));
+    expect(readMessageFeedback('msg-change')).not.toBeNull();
+
+    fireEvent.click(screen.getByTestId('message-feedback-change'));
+
+    expect(screen.getByText('Was this response helpful?')).toBeTruthy();
+    expect(readMessageFeedback('msg-change')).toBeNull();
+  });
+
+  it('rehydrates the submitted state when storage already has a value at mount time', () => {
+    // Reload-survival: the issue's "feedback state is visually clear
+    // after submission" criterion implies the chip stays visible after
+    // a refresh.
+    window.localStorage.setItem(
+      'open-design:message-feedback:msg-rehydrate',
+      JSON.stringify({ rating: 'positive', submittedAt: 1700000010 }),
+    );
+    render(<MessageFeedback messageId="msg-rehydrate" />);
+    expect(screen.getByText('Thanks for the feedback.')).toBeTruthy();
+    // The idle prompt must NOT also appear.
+    expect(screen.queryByText('Was this response helpful?')).toBeNull();
+  });
+});

--- a/apps/web/tests/state/message-feedback.test.ts
+++ b/apps/web/tests/state/message-feedback.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+
+/**
+ * Coverage for the localStorage-backed feedback store (issue #1288).
+ * The store keeps the daemon out of the hot path for v1 so the
+ * analytics pipeline can be designed without a contract migration;
+ * these tests pin the persistence shape and the cross-mount sync
+ * behaviour so a future swap-out for a daemon-backed implementation
+ * doesn't quietly drop a feature the UI already depends on.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  readMessageFeedback,
+  writeMessageFeedback,
+} from '../../src/state/message-feedback';
+
+const STORAGE_KEY = (id: string) => `open-design:message-feedback:${id}`;
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe('message-feedback storage', () => {
+  it('returns null when no feedback has been recorded for a message', () => {
+    expect(readMessageFeedback('msg-1')).toBeNull();
+  });
+
+  it('round-trips a positive rating with the submittedAt timestamp', () => {
+    writeMessageFeedback('msg-1', { rating: 'positive', submittedAt: 1700000000 });
+    expect(readMessageFeedback('msg-1')).toEqual({
+      rating: 'positive',
+      submittedAt: 1700000000,
+      comment: undefined,
+    });
+  });
+
+  it('round-trips a negative rating with a free-text comment', () => {
+    writeMessageFeedback('msg-2', {
+      rating: 'negative',
+      comment: 'preview opened the pointer file',
+      submittedAt: 1700000005,
+    });
+    expect(readMessageFeedback('msg-2')).toEqual({
+      rating: 'negative',
+      comment: 'preview opened the pointer file',
+      submittedAt: 1700000005,
+    });
+  });
+
+  it('clears the entry when null is written', () => {
+    writeMessageFeedback('msg-3', { rating: 'positive', submittedAt: 1 });
+    expect(readMessageFeedback('msg-3')).not.toBeNull();
+    writeMessageFeedback('msg-3', null);
+    expect(readMessageFeedback('msg-3')).toBeNull();
+    expect(window.localStorage.getItem(STORAGE_KEY('msg-3'))).toBeNull();
+  });
+
+  it('returns null and does not throw when the stored value is corrupted JSON', () => {
+    // A bad write from a parallel tab or a manual user edit should not
+    // crash the chat pane; treating the entry as "not yet rated" is the
+    // safe behaviour because the UI can offer a fresh rating instead
+    // of showing a stale (wrong) confirmation.
+    window.localStorage.setItem(STORAGE_KEY('msg-4'), 'not json');
+    expect(readMessageFeedback('msg-4')).toBeNull();
+  });
+
+  it('returns null when the stored object is missing the rating field', () => {
+    window.localStorage.setItem(
+      STORAGE_KEY('msg-5'),
+      JSON.stringify({ submittedAt: 42 }),
+    );
+    expect(readMessageFeedback('msg-5')).toBeNull();
+  });
+
+  it('returns null when the stored rating is an unknown value', () => {
+    // Defends against a future schema that introduces, say, a `neutral`
+    // rating: the older runtime must drop the entry rather than render
+    // a degraded badge that does not match the dictionary.
+    window.localStorage.setItem(
+      STORAGE_KEY('msg-6'),
+      JSON.stringify({ rating: 'neutral', submittedAt: 42 }),
+    );
+    expect(readMessageFeedback('msg-6')).toBeNull();
+  });
+
+  it('uses the messageId as the storage key so different messages do not collide', () => {
+    writeMessageFeedback('msg-7-a', { rating: 'positive', submittedAt: 1 });
+    writeMessageFeedback('msg-7-b', { rating: 'negative', submittedAt: 2 });
+    expect(readMessageFeedback('msg-7-a')?.rating).toBe('positive');
+    expect(readMessageFeedback('msg-7-b')?.rating).toBe('negative');
+  });
+});

--- a/apps/web/tests/state/message-feedback.test.ts
+++ b/apps/web/tests/state/message-feedback.test.ts
@@ -9,7 +9,7 @@
  * doesn't quietly drop a feature the UI already depends on.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   readMessageFeedback,
@@ -94,5 +94,46 @@ describe('message-feedback storage', () => {
     writeMessageFeedback('msg-7-b', { rating: 'negative', submittedAt: 2 });
     expect(readMessageFeedback('msg-7-a')?.rating).toBe('positive');
     expect(readMessageFeedback('msg-7-b')?.rating).toBe('negative');
+  });
+
+  it('broadcasts a CustomEvent carrying the new value on every successful write', () => {
+    // Regression for the codex + lefarcen P2: a setItem failure used
+    // to leave the broadcast in place but with no value to apply, so
+    // listeners would re-read storage and get null. The new contract
+    // always includes the value in `detail.value` so listeners can
+    // apply it directly without trusting storage.
+    const seen: unknown[] = [];
+    const handler = (evt: Event) => seen.push((evt as CustomEvent).detail);
+    window.addEventListener('open-design:message-feedback', handler);
+
+    writeMessageFeedback('msg-broadcast', { rating: 'positive', submittedAt: 7 });
+    writeMessageFeedback('msg-broadcast', null);
+
+    window.removeEventListener('open-design:message-feedback', handler);
+    expect(seen).toEqual([
+      { messageId: 'msg-broadcast', value: { rating: 'positive', submittedAt: 7 } },
+      { messageId: 'msg-broadcast', value: null },
+    ]);
+  });
+
+  it('still broadcasts the new value when localStorage.setItem throws (private mode / quota)', () => {
+    // The whole point of carrying the value in the event: writers in
+    // private-mode browsers still keep the in-memory confirmation.
+    const seen: unknown[] = [];
+    const handler = (evt: Event) => seen.push((evt as CustomEvent).detail);
+    window.addEventListener('open-design:message-feedback', handler);
+    const setItemSpy = vi
+      .spyOn(window.localStorage, 'setItem')
+      .mockImplementation(() => {
+        throw new Error('QuotaExceededError');
+      });
+
+    writeMessageFeedback('msg-quota', { rating: 'positive', submittedAt: 9 });
+
+    window.removeEventListener('open-design:message-feedback', handler);
+    setItemSpy.mockRestore();
+    expect(seen).toEqual([
+      { messageId: 'msg-quota', value: { rating: 'positive', submittedAt: 9 } },
+    ]);
   });
 });


### PR DESCRIPTION
Closes #1288.

Adds a lightweight feedback widget that surfaces under each assistant turn whose run succeeded. Users can submit positive or negative feedback in one click; the negative path opens an optional free-text comment area. The widget never blocks the message composer and only mounts after the run has produced its final artifact.

## What ships

- **`<MessageFeedback>`** in `apps/web/src/components/MessageFeedback.tsx` renders the three states:
  - **Idle**: helpful-prompt copy + thumbs up/down buttons
  - **Submitted positive**: confirmation chip + Change button
  - **Submitted negative**: confirmation chip + optional comment textarea + Send + Change
- **`AssistantMessage.tsx`** slots the widget under `AssistantFooter`, gated on `runSucceeded && !hasEmptyResponse` so failed/empty turns don't ask the user to rate something that never finished.

## Persistence (v1 = localStorage)

@lefarcen's clarifying comment on the issue asked whether v1 should be daemon-persisted or in-memory while the analytics pipeline is defined. The daemon's `messages` table is column-strict, so daemon persistence would require a SQLite migration plus a contract bump on `ChatMessage`; locking that shape in before the analytics pipeline is designed risks reworking it twice.

localStorage is the middle ground: feedback survives reload (so the "feedback state is visually clear after submission" criterion holds across sessions) without committing the wire shape. The hook surface is just `(value, setter)`, so a future PR can swap the storage layer for a daemon mirror or an analytics shipper without touching the React surface. The store handles corrupted JSON, unknown future rating values, disabled storage (private-mode browsers), and broadcasts changes across listeners in the same tab via a CustomEvent so two mounts of the hook for the same messageId stay in sync.

## Acceptance criteria

| Criterion | Status |
|---|---|
| After an Agent final artifact is completed, the chat pane displays a feedback area near the final output/completion state | Mounted under `AssistantFooter`, gated on `runSucceeded` |
| The user can submit positive feedback | Thumb-up button writes `{ rating: 'positive', submittedAt }` |
| The user can submit negative feedback | Thumb-down button writes `{ rating: 'negative', submittedAt }` |
| The feedback state is visually clear after submission | Confirmation chip + state-specific `data-state` / `data-rating` attributes; pinned by a rehydration-from-storage test |
| The feedback UI does not interfere with continuing the conversation | Sits below the footer, inside `.assistant-flow`; no composer-blocking overlays |
| Implementation leaves room for future feedback metadata | `MessageFeedback` shape is `{ rating, comment?, submittedAt }`; `runId` / `agentId` / `artifactRef` derivable from the surrounding message |

## i18n

11 new keys under `feedback.*` (prompt, thumbsUp/Down, two confirmation chips, comment label/placeholder/submit/saved, change). English authored alongside the keys; zh-CN translations added in the same pass so the locale alignment test stays green and Chinese users see Chinese strings from day one. The other 16 locales pick up English fallbacks via their existing `...en` spread.

## Test coverage

- `tests/state/message-feedback.test.ts` (8 jsdom cases): round-trip positive + negative, null-clear, corrupted JSON tolerance, missing rating, unknown future rating, key collision across messages, null on empty storage.
- `tests/components/MessageFeedback.test.tsx` (7 jsdom cases): idle state, positive submit, negative submit, comment save with the saved confirmation, blank-comment Send disabled, Change unsticks the rating, rehydration from pre-populated storage.
- `tests/i18n/locales.test.ts` (5/5) continues to enforce that every locale declares the new keys.

## Validated

- `pnpm guard` clean
- `pnpm --filter @open-design/web typecheck` clean
- `tests/i18n/locales.test.ts` 5/5 across 18 locales
- `tests/state/message-feedback.test.ts` 8/8
- `tests/components/MessageFeedback.test.tsx` 7/7
- Full web suite: 98 files, 903 tests

## Open questions parked for follow-up

- **Should feedback be reported to an analytics pipeline?** Out of scope for v1 — the hook contract is stable enough to wrap an analytics shipper without touching the component.
- **Should negative feedback ask for a reason immediately?** This PR opens the comment textarea on negative click but does not require a comment. The Send button is disabled while the textarea is blank, so an empty submit is a no-op.
- **Should the feedback be tied to the message / artifact / task / run?** Currently keyed by `messageId`; the surrounding `ChatMessage` already has `runId`, `agentId`, and `producedFiles`, so any of those is one prop away whenever the analytics design lands.