### PR TITLE
feat(daemon): export self-contained HTML via /export/*?inline=1 endpoint

### DIFF
--- a/apps/daemon/src/import-export-routes.ts
+++ b/apps/daemon/src/import-export-routes.ts
@@ -348,16 +348,31 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
     }
   });
 
-  // Export endpoint: serves a self-contained HTML body with every same-
-  // project <link rel=stylesheet> / <script src> inlined. Counterpart to
-  // GET /api/projects/:id/raw/* — that route stays URL-load (one request
-  // per asset; the FileViewer iframe's default since PR #384). This route
-  // exists for explicit "Export self-contained HTML" + screenshot tooling
-  // where one HTTP response with no inter-file dependencies is the goal.
-  // Null-origin (sandboxed iframe srcdoc) callers are intentionally NOT
-  // supported — the only consumers are the daemon UI (same-origin) and
-  // server-side screenshot tooling (no Origin header). See nexu-io/
-  // open-design#368 and the architecture lock at
+  // Export endpoint: serves an HTML body with every same-project
+  // top-level `<link rel=stylesheet>` / `<script src>` inlined.
+  // Counterpart to GET /api/projects/:id/raw/* — that route stays
+  // URL-load (one request per asset; FileViewer's default since
+  // PR #384). This route exists for explicit "Inline top-level
+  // CSS/JS" exports + the screenshot path where the headless browser
+  // fetches the response and renders it.
+  //
+  // Scope is intentionally narrow: only `<link rel=stylesheet>` and
+  // `<script src>` are rewritten. `<img src>`, CSS `url(...)` refs,
+  // `@import`, ES module imports, font sources, and similar remain
+  // external in the response — see the docstring on
+  // `apps/daemon/src/inline-assets.ts` for the full not-rewritten list
+  // and rationale. A fully offline "self-contained" export with image
+  // and font bundling would be a follow-up issue.
+  //
+  // Null-origin (sandboxed iframe srcdoc) callers are intentionally
+  // NOT supported — the only consumers are the daemon UI (same-origin)
+  // and server-side screenshot tooling (no Origin header). The
+  // response also carries `Content-Security-Policy: sandbox
+  // allow-scripts` so top-level browser navigation (no Origin header,
+  // would otherwise pass the daemon middleware) cannot escalate to
+  // daemon-origin privileges through script execution.
+  //
+  // See nexu-io/open-design#368 and the architecture lock at
   // https://github.com/nexu-io/open-design/issues/368#issuecomment-4366243218.
   app.get('/api/projects/:id/export/*', async (req, res) => {
     try {

--- a/apps/daemon/src/import-export-routes.ts
+++ b/apps/daemon/src/import-export-routes.ts
@@ -1,6 +1,10 @@
 import type { Express } from 'express';
 import type { RouteDeps } from './server-context.js';
-import { inlineRelativeAssets, type InlineAssetReader } from './inline-assets.js';
+import {
+  InlineAssetsLimitError,
+  inlineRelativeAssets,
+  type InlineAssetReader,
+} from './inline-assets.js';
 
 export interface RegisterImportRoutesDeps extends RouteDeps<'db' | 'http' | 'uploads' | 'node' | 'ids' | 'paths' | 'imports' | 'auth' | 'projectStore' | 'conversations' | 'projectFiles'> {}
 
@@ -410,8 +414,8 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
       if (!file.mime.startsWith('text/html')) {
         return sendApiError(
           res,
-          400,
-          'UNSUPPORTED_FILE_TYPE',
+          415,
+          'UNSUPPORTED_MEDIA_TYPE',
           'export endpoint only supports HTML files',
         );
       }
@@ -446,6 +450,14 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
       res.setHeader('Content-Security-Policy', 'sandbox allow-scripts');
       res.type('text/html').send(rendered);
     } catch (err: any) {
+      // PR #1312 round-3 (lefarcen P2): the inliner's cap-enforcement
+      // throws InlineAssetsLimitError when the owner HTML, candidate
+      // count, or assembled output exceeds the module-level limits.
+      // Map every such throw to a 413 PAYLOAD_TOO_LARGE envelope so
+      // callers see a structured error rather than a generic 400.
+      if (err instanceof InlineAssetsLimitError || err?.name === 'InlineAssetsLimitError') {
+        return sendApiError(res, 413, 'PAYLOAD_TOO_LARGE', String(err));
+      }
       sendApiError(res, 400, 'BAD_REQUEST', String(err));
     }
   });

--- a/apps/daemon/src/import-export-routes.ts
+++ b/apps/daemon/src/import-export-routes.ts
@@ -228,7 +228,7 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
   const { sendApiError } = ctx.http;
   const { PROJECTS_DIR } = ctx.paths;
   const { getProject } = ctx.projectStore;
-  const { readProjectFile } = ctx.projectFiles;
+  const { readProjectFile, resolveProjectFilePath } = ctx.projectFiles;
   const { isSafeId } = ctx.validation;
   const {
     buildProjectArchive,
@@ -420,18 +420,39 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
         );
       }
 
+      // PR #1312 round-4 (lefarcen P2): stat first, then read. This
+      // lets the helper short-circuit on maxAssetBytes / maxTotalBytes
+      // BEFORE the buffer is materialized into memory. A 100 MiB
+      // sibling file is rejected after the cheap stat call, not after
+      // a 100 MiB readFile.
       const fileReader: InlineAssetReader = async (sibling) => {
+        let meta;
         try {
-          const siblingFile = await readProjectFile(
+          meta = await resolveProjectFilePath(
             PROJECTS_DIR,
             req.params.id,
             sibling,
             project?.metadata,
           );
-          return siblingFile.buffer.toString('utf8');
         } catch {
           return null;
         }
+        return {
+          size: meta.size,
+          read: async () => {
+            try {
+              const siblingFile = await readProjectFile(
+                PROJECTS_DIR,
+                req.params.id,
+                sibling,
+                project?.metadata,
+              );
+              return siblingFile.buffer.toString('utf8');
+            } catch {
+              return null;
+            }
+          },
+        };
       };
 
       const rendered = await inlineRelativeAssets(

--- a/apps/daemon/src/import-export-routes.ts
+++ b/apps/daemon/src/import-export-routes.ts
@@ -1,5 +1,6 @@
 import type { Express } from 'express';
 import type { RouteDeps } from './server-context.js';
+import { inlineRelativeAssets, type InlineAssetReader } from './inline-assets.js';
 
 export interface RegisterImportRoutesDeps extends RouteDeps<'db' | 'http' | 'uploads' | 'node' | 'ids' | 'paths' | 'imports' | 'auth' | 'projectStore' | 'conversations' | 'projectFiles'> {}
 
@@ -216,13 +217,15 @@ export function registerImportRoutes(app: Express, ctx: RegisterImportRoutesDeps
 
 }
 
-export interface RegisterProjectExportRoutesDeps extends RouteDeps<'db' | 'http' | 'paths' | 'projectStore' | 'exports'> {}
+export interface RegisterProjectExportRoutesDeps extends RouteDeps<'db' | 'http' | 'paths' | 'projectStore' | 'exports' | 'projectFiles' | 'validation'> {}
 
 export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectExportRoutesDeps) {
   const { db } = ctx;
   const { sendApiError } = ctx.http;
   const { PROJECTS_DIR } = ctx.paths;
   const { getProject } = ctx.projectStore;
+  const { readProjectFile } = ctx.projectFiles;
+  const { isSafeId } = ctx.validation;
   const {
     buildProjectArchive,
     buildBatchArchive,
@@ -342,6 +345,84 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
         status === 404 ? 'FILE_NOT_FOUND' : 'BAD_REQUEST',
         String(err?.message || err),
       );
+    }
+  });
+
+  // Export endpoint: serves a self-contained HTML body with every same-
+  // project <link rel=stylesheet> / <script src> inlined. Counterpart to
+  // GET /api/projects/:id/raw/* — that route stays URL-load (one request
+  // per asset; the FileViewer iframe's default since PR #384). This route
+  // exists for explicit "Export self-contained HTML" + screenshot tooling
+  // where one HTTP response with no inter-file dependencies is the goal.
+  // Null-origin (sandboxed iframe srcdoc) callers are intentionally NOT
+  // supported — the only consumers are the daemon UI (same-origin) and
+  // server-side screenshot tooling (no Origin header). See nexu-io/
+  // open-design#368 and the architecture lock at
+  // https://github.com/nexu-io/open-design/issues/368#issuecomment-4366243218.
+  app.get('/api/projects/:id/export/*', async (req, res) => {
+    try {
+      if (!isSafeId(req.params.id)) {
+        return sendApiError(res, 400, 'BAD_REQUEST', 'invalid project id');
+      }
+
+      const inlineRaw =
+        typeof req.query.inline === 'string' ? req.query.inline.trim().toLowerCase() : '';
+      if (!['1', 'true', 'yes', 'on'].includes(inlineRaw)) {
+        return sendApiError(
+          res,
+          400,
+          'BAD_REQUEST',
+          "query parameter 'inline=1' is required",
+        );
+      }
+
+      const project = getProject(db, req.params.id);
+      const relPath = (req.params as any)[0];
+
+      let file;
+      try {
+        file = await readProjectFile(PROJECTS_DIR, req.params.id, relPath, project?.metadata);
+      } catch (err: any) {
+        const status = err && err.code === 'ENOENT' ? 404 : 400;
+        return sendApiError(
+          res,
+          status,
+          status === 404 ? 'FILE_NOT_FOUND' : 'BAD_REQUEST',
+          String(err),
+        );
+      }
+
+      if (!file.mime.startsWith('text/html')) {
+        return sendApiError(
+          res,
+          400,
+          'UNSUPPORTED_FILE_TYPE',
+          'export endpoint only supports HTML files',
+        );
+      }
+
+      const fileReader: InlineAssetReader = async (sibling) => {
+        try {
+          const siblingFile = await readProjectFile(
+            PROJECTS_DIR,
+            req.params.id,
+            sibling,
+            project?.metadata,
+          );
+          return siblingFile.buffer.toString('utf8');
+        } catch {
+          return null;
+        }
+      };
+
+      const rendered = await inlineRelativeAssets(
+        file.buffer.toString('utf8'),
+        relPath,
+        fileReader,
+      );
+      res.type('text/html').send(rendered);
+    } catch (err: any) {
+      sendApiError(res, 400, 'BAD_REQUEST', String(err));
     }
   });
 

--- a/apps/daemon/src/import-export-routes.ts
+++ b/apps/daemon/src/import-export-routes.ts
@@ -2,6 +2,7 @@ import type { Express } from 'express';
 import type { RouteDeps } from './server-context.js';
 import {
   InlineAssetsLimitError,
+  MAX_INLINE_OWNER_BYTES,
   inlineRelativeAssets,
   type InlineAssetReader,
 } from './inline-assets.js';
@@ -398,9 +399,27 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
       const project = getProject(db, req.params.id);
       const relPath = (req.params as any)[0];
 
-      let file;
+      // PR #1312 round-5 (lefarcen P2): stat the owner file BEFORE
+      // readProjectFile so a 100 MiB owner HTML is rejected after a
+      // cheap stat() call, not after a 100 MiB readFile() into memory.
+      // The size check + mime check both run pre-buffer here, mirroring
+      // the sibling-asset stat-then-read contract round 4 already
+      // applied via AssetHandle. Size fires before mime so an oversize
+      // non-HTML file returns 413 (not 415) — that ordering is the
+      // observable Red→Green for this round.
+      //
+      // The helper's ownerBytes check (inline-assets.ts:127-133) stays
+      // as defense-in-depth: it still catches direct in-process callers
+      // that skip the route and any future drift in the size reported
+      // by stat vs the bytes actually returned by readFile.
+      let ownerMeta;
       try {
-        file = await readProjectFile(PROJECTS_DIR, req.params.id, relPath, project?.metadata);
+        ownerMeta = await resolveProjectFilePath(
+          PROJECTS_DIR,
+          req.params.id,
+          relPath,
+          project?.metadata,
+        );
       } catch (err: any) {
         const status = err && err.code === 'ENOENT' ? 404 : 400;
         return sendApiError(
@@ -411,12 +430,34 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
         );
       }
 
-      if (!file.mime.startsWith('text/html')) {
+      if (ownerMeta.size > MAX_INLINE_OWNER_BYTES) {
+        return sendApiError(
+          res,
+          413,
+          'PAYLOAD_TOO_LARGE',
+          `owner html ${ownerMeta.size} bytes exceeds MAX_INLINE_OWNER_BYTES ${MAX_INLINE_OWNER_BYTES}`,
+        );
+      }
+
+      if (!ownerMeta.mime.startsWith('text/html')) {
         return sendApiError(
           res,
           415,
           'UNSUPPORTED_MEDIA_TYPE',
           'export endpoint only supports HTML files',
+        );
+      }
+
+      let file;
+      try {
+        file = await readProjectFile(PROJECTS_DIR, req.params.id, relPath, project?.metadata);
+      } catch (err: any) {
+        const status = err && err.code === 'ENOENT' ? 404 : 400;
+        return sendApiError(
+          res,
+          status,
+          status === 404 ? 'FILE_NOT_FOUND' : 'BAD_REQUEST',
+          String(err),
         );
       }
 

--- a/apps/daemon/src/import-export-routes.ts
+++ b/apps/daemon/src/import-export-routes.ts
@@ -420,6 +420,15 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
         relPath,
         fileReader,
       );
+      // PR #1312 round-2 (lefarcen P2): top-level browser navigation to
+      // this URL sends no Origin header, so the /api middleware lets it
+      // through. Without a CSP, any JS in the exported document would
+      // run at daemon origin with access to /api/, cookies, localStorage,
+      // etc. `sandbox allow-scripts` treats the response like a sandboxed
+      // iframe with an opaque origin — scripts execute (that's the point
+      // of inlining JS for screenshot tooling), but cannot read cookies,
+      // hit /api/, or escalate to daemon-origin privileges.
+      res.setHeader('Content-Security-Policy', 'sandbox allow-scripts');
       res.type('text/html').send(rendered);
     } catch (err: any) {
       sendApiError(res, 400, 'BAD_REQUEST', String(err));

--- a/apps/daemon/src/inline-assets.ts
+++ b/apps/daemon/src/inline-assets.ts
@@ -101,9 +101,31 @@ export async function inlineRelativeAssets(
   return parts.join('');
 }
 
-function buildInlineStyleBlock(_tag: string, href: string, css: string): string {
+// Attrs that affect <style> semantics and must be carried across from
+// the source <link rel=stylesheet> so the inlined output matches the
+// behavior of the original URL-loaded stylesheet:
+//   - media        — media query (e.g. `media="print"` for print-only)
+//   - title        — alternate stylesheet sets
+//   - disabled     — boolean: initial disabled state
+//   - nonce        — CSP nonce passthrough
+// All four are valid on both <link rel=stylesheet> and <style>. Other
+// <link> attrs (rel, href, type, crossorigin, integrity, referrerpolicy)
+// don't apply to <style> and are intentionally dropped.
+const STYLE_PRESERVED_LINK_ATTRS = ['media', 'title', 'nonce'] as const;
+const STYLE_PRESERVED_BOOLEAN_ATTRS = ['disabled'] as const;
+
+function buildInlineStyleBlock(tag: string, href: string, css: string): string {
+  const carried: string[] = [];
+  for (const name of STYLE_PRESERVED_LINK_ATTRS) {
+    const value = readHtmlAttr(tag, name);
+    if (value != null) carried.push(`${name}="${escapeHtmlAttr(value)}"`);
+  }
+  for (const name of STYLE_PRESERVED_BOOLEAN_ATTRS) {
+    if (hasBooleanHtmlAttr(tag, name)) carried.push(name);
+  }
+  const attrString = carried.length === 0 ? '' : ` ${carried.join(' ')}`;
   return (
-    `<style data-od-inline-asset="${escapeHtmlAttr(href)}">\n` +
+    `<style data-od-inline-asset="${escapeHtmlAttr(href)}"${attrString}>\n` +
     `${css.replace(/<\/style/gi, '<\\/style')}\n</style>`
   );
 }
@@ -139,6 +161,14 @@ export function resolveProjectRelativePath(
 export function readHtmlAttr(tag: string, name: string): string | null {
   const match = tag.match(new RegExp(`\\s${name}\\s*=\\s*(['"])([\\s\\S]*?)\\1`, 'i'));
   return match?.[2] ?? null;
+}
+
+// HTML boolean attribute presence test — matches `<tag … name>` or
+// `<tag … name=""…>` without requiring a value, but does NOT match a
+// substring inside another attribute's value (e.g. `data-foo="disabled"`
+// must NOT count as `disabled` being set).
+export function hasBooleanHtmlAttr(tag: string, name: string): boolean {
+  return new RegExp(`\\s${name}(?=\\s|=|/?>)`, 'i').test(tag);
 }
 
 export function escapeHtmlAttr(value: string): string {

--- a/apps/daemon/src/inline-assets.ts
+++ b/apps/daemon/src/inline-assets.ts
@@ -13,77 +13,108 @@ export interface InlineAssetReader {
   (relPath: string): Promise<string | null>;
 }
 
-interface Replacement {
-  from: string;
-  to: string;
-}
-
 export async function inlineRelativeAssets(
   html: string,
   ownerFileName: string,
   fileReader: InlineAssetReader,
 ): Promise<string> {
-  const replacements: Array<Promise<Replacement | null>> = [];
+  // Each candidate records the exact byte span in the ORIGINAL html. We
+  // never mutate-then-rescan, so a tag literal that happens to appear
+  // inside an inlined asset body is left untouched.
+  //
+  // Two divergences from apps/web/src/components/FileViewer.tsx:5265-5314:
+  //
+  // 1. Position-based, single-pass concat (vs. `.reduce` over `.replace`).
+  //    The web client's reduce-over-replace re-scans the mutated string
+  //    on each pass, which (a) replaces only the first occurrence of a
+  //    duplicate tag and (b) corrupts already-inlined bodies that contain
+  //    another tag's literal substring. This helper avoids both by
+  //    operating on captured indices in the original input.
+  // 2. Duplicate identical tags: this helper inlines every occurrence
+  //    (the web client's first-match-only is a side-effect of `.replace`
+  //    semantics). The web inline path is on a deprecation track since
+  //    PR #384 made URL-load the default, so the divergence is
+  //    forward-pointing.
+  interface Candidate {
+    start: number;
+    end: number;
+    replacement: Promise<string | null>;
+  }
 
-  const linkTags = html.match(/<link\b[^>]*>/gi) ?? [];
-  for (const tag of linkTags) {
+  const candidates: Candidate[] = [];
+
+  for (const match of html.matchAll(/<link\b[^>]*>/gi)) {
+    const tag = match[0];
+    const start = match.index!;
     const rel = readHtmlAttr(tag, 'rel');
     const href = readHtmlAttr(tag, 'href');
     if (!rel || !/\bstylesheet\b/i.test(rel) || !href) continue;
     const resolved = resolveProjectRelativePath(ownerFileName, href);
     if (!resolved) continue;
-    replacements.push(
-      fileReader(resolved).then<Replacement | null>((css) =>
-        css == null
-          ? null
-          : {
-              from: tag,
-              to:
-                `<style data-od-inline-asset="${escapeHtmlAttr(href)}">\n` +
-                `${css.replace(/<\/style/gi, '<\\/style')}\n</style>`,
-            },
+    candidates.push({
+      start,
+      end: start + tag.length,
+      replacement: fileReader(resolved).then((css) =>
+        css == null ? null : buildInlineStyleBlock(tag, href, css),
       ),
-    );
+    });
   }
 
-  const scriptTags =
-    html.match(/<script\b[^>]*\bsrc\s*=\s*["'][^"']+["'][^>]*>\s*<\/script>/gi) ?? [];
-  for (const tag of scriptTags) {
+  for (const match of html.matchAll(
+    /<script\b[^>]*\bsrc\s*=\s*["'][^"']+["'][^>]*>\s*<\/script>/gi,
+  )) {
+    const tag = match[0];
+    const start = match.index!;
     const src = readHtmlAttr(tag, 'src');
     if (!src) continue;
     const resolved = resolveProjectRelativePath(ownerFileName, src);
     if (!resolved) continue;
-    replacements.push(
-      fileReader(resolved).then<Replacement | null>((js) => {
-        if (js == null) return null;
-        const open = tag.match(/^<script\b[^>]*>/i)?.[0] ?? '<script>';
-        const attrs = open
-          .replace(/^<script/i, '')
-          .replace(/>$/i, '')
-          .replace(/\ssrc\s*=\s*(['"])[\s\S]*?\1/i, '');
-        return {
-          from: tag,
-          to: `<script${attrs}>\n${js.replace(/<\/script/gi, '<\\/script')}\n</script>`,
-        };
-      }),
-    );
+    candidates.push({
+      start,
+      end: start + tag.length,
+      replacement: fileReader(resolved).then((js) =>
+        js == null ? null : buildInlineScriptBlock(tag, js),
+      ),
+    });
   }
 
-  const resolvedReplacements = (await Promise.all(replacements)).filter(
-    (item): item is Replacement => item !== null,
-  );
+  if (candidates.length === 0) return html;
 
-  // Divergence from apps/web/src/components/FileViewer.tsx:5313: the web
-  // client uses `.replace(from, () => to)`, which replaces only the first
-  // occurrence. That produces inconsistent output when a document has
-  // duplicate identical tags — one inlined, the rest left as URL refs.
-  // This helper replaces every occurrence. The web inline path is on a
-  // deprecation track (URL-load is the default since PR #384), so the
-  // divergence is forward-pointing.
-  return resolvedReplacements.reduce(
-    (next, { from, to }) => replaceAllOccurrences(next, from, to),
-    html,
+  // Sort by start so we can splice slices of the original html in order.
+  // Link and script regions cannot overlap in a well-formed document
+  // (the HTML parser disallows nested <script> / <link>), so we don't
+  // need overlap-resolution logic.
+  candidates.sort((a, b) => a.start - b.start);
+
+  const resolved = await Promise.all(candidates.map((c) => c.replacement));
+
+  const parts: string[] = [];
+  let cursor = 0;
+  for (let i = 0; i < candidates.length; i++) {
+    const { start, end } = candidates[i]!;
+    const replacement = resolved[i];
+    parts.push(html.slice(cursor, start));
+    parts.push(replacement ?? html.slice(start, end));
+    cursor = end;
+  }
+  parts.push(html.slice(cursor));
+  return parts.join('');
+}
+
+function buildInlineStyleBlock(_tag: string, href: string, css: string): string {
+  return (
+    `<style data-od-inline-asset="${escapeHtmlAttr(href)}">\n` +
+    `${css.replace(/<\/style/gi, '<\\/style')}\n</style>`
   );
+}
+
+function buildInlineScriptBlock(tag: string, js: string): string {
+  const open = tag.match(/^<script\b[^>]*>/i)?.[0] ?? '<script>';
+  const attrs = open
+    .replace(/^<script/i, '')
+    .replace(/>$/i, '')
+    .replace(/\ssrc\s*=\s*(['"])[\s\S]*?\1/i, '');
+  return `<script${attrs}>\n${js.replace(/<\/script/gi, '<\\/script')}\n</script>`;
 }
 
 export function baseDirFor(fileName: string): string {
@@ -118,6 +149,3 @@ export function escapeHtmlAttr(value: string): string {
     .replace(/>/g, '&gt;');
 }
 
-function replaceAllOccurrences(source: string, from: string, to: string): string {
-  return source.split(from).join(to);
-}

--- a/apps/daemon/src/inline-assets.ts
+++ b/apps/daemon/src/inline-assets.ts
@@ -50,15 +50,45 @@ export interface InlineOptions {
   maxReadConcurrency?: number;
 }
 
+// Module-level defaults. PR #1312 round-3 (lefarcen P2): the daemon is
+// local-first, but the helper still needs defensive caps to prevent
+// a pathological project (or a future non-trusted caller) from
+// causing unbounded read fanout / memory blow-up. These values let
+// any realistic developer project through while rejecting clearly
+// pathological inputs.
+export const MAX_INLINE_OWNER_BYTES = 2 * 1024 * 1024; // 2 MiB
+export const MAX_INLINE_ASSET_BYTES = 5 * 1024 * 1024; // 5 MiB per asset
+export const MAX_INLINE_CANDIDATES = 500; // <link>/<script src> matches
+export const MAX_INLINE_TOTAL_BYTES = 50 * 1024 * 1024; // 50 MiB output
+export const MAX_INLINE_READ_CONCURRENCY = 8; // simultaneous fileReader calls
+
+/**
+ * Thrown by `inlineRelativeAssets` when a configured cap is exceeded.
+ * The route handler maps every `InlineAssetsLimitError` to a 413
+ * `PAYLOAD_TOO_LARGE` envelope; the `limit` field identifies which
+ * cap fired so logs/clients can disambiguate.
+ */
+export class InlineAssetsLimitError extends Error {
+  constructor(
+    message: string,
+    public readonly limit: 'owner' | 'asset' | 'candidates' | 'total',
+  ) {
+    super(message);
+    this.name = 'InlineAssetsLimitError';
+  }
+}
+
 export async function inlineRelativeAssets(
   html: string,
   ownerFileName: string,
   fileReader: InlineAssetReader,
-  _opts: InlineOptions = {},
+  opts: InlineOptions = {},
 ): Promise<string> {
-  // Each candidate records the exact byte span in the ORIGINAL html. We
-  // never mutate-then-rescan, so a tag literal that happens to appear
-  // inside an inlined asset body is left untouched.
+  // Each pending entry records the exact byte span in the ORIGINAL html
+  // plus the builder that turns the asset's content into the
+  // replacement string. We never mutate-then-rescan, so a tag literal
+  // that happens to appear inside an inlined asset body is left
+  // untouched.
   //
   // Two divergences from apps/web/src/components/FileViewer.tsx:5265-5314:
   //
@@ -73,13 +103,28 @@ export async function inlineRelativeAssets(
   //    semantics). The web inline path is on a deprecation track since
   //    PR #384 made URL-load the default, so the divergence is
   //    forward-pointing.
-  interface Candidate {
-    start: number;
-    end: number;
-    replacement: Promise<string | null>;
+  const maxOwnerBytes = opts.maxOwnerBytes ?? MAX_INLINE_OWNER_BYTES;
+  const maxAssetBytes = opts.maxAssetBytes ?? MAX_INLINE_ASSET_BYTES;
+  const maxCandidates = opts.maxCandidates ?? MAX_INLINE_CANDIDATES;
+  const maxTotalBytes = opts.maxTotalBytes ?? MAX_INLINE_TOTAL_BYTES;
+  const maxReadConcurrency = opts.maxReadConcurrency ?? MAX_INLINE_READ_CONCURRENCY;
+
+  const ownerBytes = Buffer.byteLength(html, 'utf8');
+  if (ownerBytes > maxOwnerBytes) {
+    throw new InlineAssetsLimitError(
+      `owner html ${ownerBytes} bytes exceeds maxOwnerBytes ${maxOwnerBytes}`,
+      'owner',
+    );
   }
 
-  const candidates: Candidate[] = [];
+  interface Pending {
+    start: number;
+    end: number;
+    resolved: string;
+    build: (content: string) => string;
+  }
+
+  const pending: Pending[] = [];
 
   for (const match of html.matchAll(/<link\b[^>]*>/gi)) {
     const tag = match[0];
@@ -89,12 +134,11 @@ export async function inlineRelativeAssets(
     if (!rel || !/\bstylesheet\b/i.test(rel) || !href) continue;
     const resolved = resolveProjectRelativePath(ownerFileName, href);
     if (!resolved) continue;
-    candidates.push({
+    pending.push({
       start,
       end: start + tag.length,
-      replacement: fileReader(resolved).then((css) =>
-        css == null ? null : buildInlineStyleBlock(tag, href, css),
-      ),
+      resolved,
+      build: (css) => buildInlineStyleBlock(tag, href, css),
     });
   }
 
@@ -107,36 +151,98 @@ export async function inlineRelativeAssets(
     if (!src) continue;
     const resolved = resolveProjectRelativePath(ownerFileName, src);
     if (!resolved) continue;
-    candidates.push({
+    pending.push({
       start,
       end: start + tag.length,
-      replacement: fileReader(resolved).then((js) =>
-        js == null ? null : buildInlineScriptBlock(tag, js),
-      ),
+      resolved,
+      build: (js) => buildInlineScriptBlock(tag, js),
     });
   }
 
-  if (candidates.length === 0) return html;
+  if (pending.length === 0) return html;
+
+  if (pending.length > maxCandidates) {
+    throw new InlineAssetsLimitError(
+      `found ${pending.length} candidates, exceeds maxCandidates ${maxCandidates}`,
+      'candidates',
+    );
+  }
 
   // Sort by start so we can splice slices of the original html in order.
   // Link and script regions cannot overlap in a well-formed document
   // (the HTML parser disallows nested <script> / <link>), so we don't
   // need overlap-resolution logic.
-  candidates.sort((a, b) => a.start - b.start);
+  pending.sort((a, b) => a.start - b.start);
 
-  const resolved = await Promise.all(candidates.map((c) => c.replacement));
+  const replacements = await runWithConcurrency(
+    pending,
+    maxReadConcurrency,
+    async (p) => {
+      const content = await fileReader(p.resolved);
+      if (content == null) return null;
+      if (Buffer.byteLength(content, 'utf8') > maxAssetBytes) return null;
+      return p.build(content);
+    },
+  );
 
+  // Concat slices in one pass with a running output-size guard. The
+  // guard counts both the original-html slices we preserve and the
+  // replacement strings we inject, since either side can blow past
+  // maxTotalBytes (a wildly large owner with no inlinings, or a
+  // small owner with one giant inlined asset).
   const parts: string[] = [];
   let cursor = 0;
-  for (let i = 0; i < candidates.length; i++) {
-    const { start, end } = candidates[i]!;
-    const replacement = resolved[i];
-    parts.push(html.slice(cursor, start));
-    parts.push(replacement ?? html.slice(start, end));
+  let totalBytes = 0;
+  const guard = (segment: string) => {
+    totalBytes += Buffer.byteLength(segment, 'utf8');
+    if (totalBytes > maxTotalBytes) {
+      throw new InlineAssetsLimitError(
+        `assembled output ${totalBytes} bytes exceeds maxTotalBytes ${maxTotalBytes}`,
+        'total',
+      );
+    }
+  };
+  for (let i = 0; i < pending.length; i++) {
+    const { start, end } = pending[i]!;
+    const replacement = replacements[i];
+    const before = html.slice(cursor, start);
+    guard(before);
+    parts.push(before);
+    const inject = replacement ?? html.slice(start, end);
+    guard(inject);
+    parts.push(inject);
     cursor = end;
   }
-  parts.push(html.slice(cursor));
+  const tail = html.slice(cursor);
+  guard(tail);
+  parts.push(tail);
   return parts.join('');
+}
+
+/**
+ * Run `fn` over `items` with at most `limit` invocations in flight at
+ * any moment. Order of `items` and of the returned results is
+ * preserved. Used to bound concurrent fileReader calls so a project
+ * with hundreds of `<link>`/`<script>` tags doesn't open hundreds of
+ * file descriptors simultaneously.
+ */
+async function runWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const out: R[] = new Array(items.length);
+  let next = 0;
+  async function worker() {
+    while (true) {
+      const idx = next++;
+      if (idx >= items.length) return;
+      out[idx] = await fn(items[idx]!);
+    }
+  }
+  const workers = Math.max(1, Math.min(limit, items.length));
+  await Promise.all(Array.from({ length: workers }, () => worker()));
+  return out;
 }
 
 // Attrs that affect <style> semantics and must be carried across from

--- a/apps/daemon/src/inline-assets.ts
+++ b/apps/daemon/src/inline-assets.ts
@@ -1,13 +1,37 @@
 // Server-side port of the web-client inliner at
 // apps/web/src/components/FileViewer.tsx:5248-5354 (@ base SHA 5bd97631).
-// Powers the GET /api/projects/:id/export/*?inline=1 endpoint that ships a
-// self-contained HTML document for explicit "Export self-contained HTML" and
-// screenshot tooling — the viewer itself stays URL-load by default since
-// PR #384 (Part 1 of nexu-io/open-design#368).
+// Powers the GET /api/projects/:id/export/*?inline=1 endpoint that
+// inlines TOP-LEVEL relative `<link rel=stylesheet>` and
+// `<script src=...>` tags into the response HTML — the viewer itself
+// stays URL-load by default since PR #384 (Part 1 of
+// nexu-io/open-design#368).
 //
-// The web client and this helper diverge in exactly one place: the global
-// replace below. See the inline comment near `replaceAllOccurrences` for
-// the rationale.
+// Scope: this helper handles two tag families only. The following are
+// NOT rewritten and remain external in the response:
+//   - <img src>, <video src>, <audio src>, <source src>, <iframe src>
+//   - CSS `url(...)` references (in inlined stylesheets or otherwise)
+//   - CSS `@import` directives
+//   - ES module `import` / `export from` statements inside JS bodies
+//   - <link rel=preload|prefetch|icon|...> (only rel=stylesheet inlines)
+//   - <link rel=stylesheet> with absolute / data: / blob: hrefs
+//   - <font-face> src attrs / @font-face url() references
+//
+// Callers that need a fully bundled offline artifact (e.g. an HTML
+// archive that opens on a machine with no network access) must layer
+// their own asset rewriting on top of this primitive or build a
+// stricter "fully self-contained export" follow-up. The screenshot
+// path is the primary motivator: a headless browser fetches each
+// referenced asset on render, so the inline-CSS-and-JS-only contract
+// is sufficient.
+//
+// Memory profile: the helper holds one Buffer-as-string copy of the
+// owner HTML plus one string copy of each sibling asset body, plus the
+// concatenated output. The daemon is local-first (single-user, on the
+// developer's machine — see open_design_architecture.md), so the
+// effective ceiling is the size of the user's own project; no hard
+// cap is enforced. If you're surfacing this endpoint to non-trusted
+// callers later, you'll want a bounded-concurrency reader and an
+// output-size limit.
 
 export interface InlineAssetReader {
   (relPath: string): Promise<string | null>;

--- a/apps/daemon/src/inline-assets.ts
+++ b/apps/daemon/src/inline-assets.ts
@@ -37,10 +37,24 @@ export interface InlineAssetReader {
   (relPath: string): Promise<string | null>;
 }
 
+export interface InlineOptions {
+  /** Max byte length of the owner HTML; exceeds → throw InlineAssetsLimitError("owner"). */
+  maxOwnerBytes?: number;
+  /** Max byte length of a single inlined asset body; exceeds → tag stays as URL ref. */
+  maxAssetBytes?: number;
+  /** Max number of `<link>`/`<script>` matches in the owner HTML; exceeds → throw "candidates". */
+  maxCandidates?: number;
+  /** Max byte length of the assembled output; exceeds → throw InlineAssetsLimitError("total"). */
+  maxTotalBytes?: number;
+  /** Max concurrent fileReader invocations; defaults to MAX_INLINE_READ_CONCURRENCY. */
+  maxReadConcurrency?: number;
+}
+
 export async function inlineRelativeAssets(
   html: string,
   ownerFileName: string,
   fileReader: InlineAssetReader,
+  _opts: InlineOptions = {},
 ): Promise<string> {
   // Each candidate records the exact byte span in the ORIGINAL html. We
   // never mutate-then-rescan, so a tag literal that happens to appear

--- a/apps/daemon/src/inline-assets.ts
+++ b/apps/daemon/src/inline-assets.ts
@@ -189,10 +189,22 @@ export function readHtmlAttr(tag: string, name: string): string | null {
 
 // HTML boolean attribute presence test — matches `<tag … name>` or
 // `<tag … name=""…>` without requiring a value, but does NOT match a
-// substring inside another attribute's value (e.g. `data-foo="disabled"`
-// must NOT count as `disabled` being set).
+// substring inside another attribute's value (e.g. `data-note="content
+// disabled stuff"` must NOT count as `disabled` being set).
+//
+// Implementation: strip quoted attribute values out of the tag first
+// (replace `"…"` and `'…'` with empty quotes), then run the lookahead
+// regex over the remaining structural-attr-only string. The lookahead
+// requires `\s|=|/?>` after the attr name, so a bare `name`,
+// `name=""`, `name="…"`, or `name/>` all match — but a substring of
+// any value cannot match because values have been stripped.
+const ATTR_VALUE_QUOTE_DOUBLE_RE = /=\s*"[^"]*"/g;
+const ATTR_VALUE_QUOTE_SINGLE_RE = /=\s*'[^']*'/g;
 export function hasBooleanHtmlAttr(tag: string, name: string): boolean {
-  return new RegExp(`\\s${name}(?=\\s|=|/?>)`, 'i').test(tag);
+  const stripped = tag
+    .replace(ATTR_VALUE_QUOTE_DOUBLE_RE, '=""')
+    .replace(ATTR_VALUE_QUOTE_SINGLE_RE, "=''");
+  return new RegExp(`\\s${name}(?=\\s|=|/?>)`, 'i').test(stripped);
 }
 
 export function escapeHtmlAttr(value: string): string {

--- a/apps/daemon/src/inline-assets.ts
+++ b/apps/daemon/src/inline-assets.ts
@@ -33,8 +33,23 @@
 // callers later, you'll want a bounded-concurrency reader and an
 // output-size limit.
 
+/**
+ * A handle to a project-relative asset. Decoupled into `size` (cheap;
+ * sourced from `stat` or equivalent) and `read()` (full materialization)
+ * so the helper can short-circuit on `maxAssetBytes` / `maxTotalBytes`
+ * BEFORE the asset is buffered into memory. PR #1312 round-4 (lefarcen
+ * P2): the round-3 caps fired only after every candidate had already
+ * been fully read + decoded, so 500 assets at 5 MiB each could
+ * materialize 2.5 GiB before the 413. The size-then-read contract
+ * lets us cap pre-buffer.
+ */
+export interface AssetHandle {
+  readonly size: number;
+  read(): Promise<string | null>;
+}
+
 export interface InlineAssetReader {
-  (relPath: string): Promise<string | null>;
+  (relPath: string): Promise<AssetHandle | null>;
 }
 
 export interface InlineOptions {
@@ -174,22 +189,65 @@ export async function inlineRelativeAssets(
   // need overlap-resolution logic.
   pending.sort((a, b) => a.start - b.start);
 
+  // Running-total tracker. Owner html bytes contribute first; each
+  // accepted asset reserves its stat-size BEFORE the read. The
+  // concat-time guard further down is the exact final check; this
+  // pre-buffer reservation is the early-abort that bounds peak memory
+  // (PR #1312 round-4, lefarcen P2). Reservation is approximate
+  // (counts the original tag bytes that get replaced, doesn't count
+  // wrapper overhead) — close enough for resource bounding, and the
+  // concat-time guard catches any remaining drift.
+  let runningBytes = ownerBytes;
+  let totalAborted = false;
+
   const replacements = await runWithConcurrency(
     pending,
     maxReadConcurrency,
     async (p) => {
-      const content = await fileReader(p.resolved);
-      if (content == null) return null;
-      if (Buffer.byteLength(content, 'utf8') > maxAssetBytes) return null;
+      if (totalAborted) return null;
+      const handle = await fileReader(p.resolved);
+      if (handle == null) return null;
+      // Per-asset cap, pre-buffer (stat-based — no read yet).
+      if (handle.size > maxAssetBytes) return null;
+      // Total cap, pre-buffer. The check + write below has no `await`
+      // between them, so under Node's single-threaded event loop the
+      // pair is atomic with respect to other workers — no race.
+      if (runningBytes + handle.size > maxTotalBytes) {
+        totalAborted = true;
+        return null;
+      }
+      runningBytes += handle.size;
+      const content = await handle.read();
+      if (content == null) {
+        // Read failed/returned null AFTER stat said it was OK — refund
+        // the reservation so the total stays honest for any in-flight
+        // siblings still racing the cap check.
+        runningBytes -= handle.size;
+        return null;
+      }
+      if (Buffer.byteLength(content, 'utf8') > maxAssetBytes) {
+        // Defensive: handle.size may have been stale or the reader
+        // ignored its own promise. Refund and drop the inlining.
+        runningBytes -= handle.size;
+        return null;
+      }
       return p.build(content);
     },
   );
 
+  if (totalAborted) {
+    throw new InlineAssetsLimitError(
+      `running total exceeded maxTotalBytes ${maxTotalBytes} during reads`,
+      'total',
+    );
+  }
+
   // Concat slices in one pass with a running output-size guard. The
   // guard counts both the original-html slices we preserve and the
-  // replacement strings we inject, since either side can blow past
-  // maxTotalBytes (a wildly large owner with no inlinings, or a
-  // small owner with one giant inlined asset).
+  // replacement strings we inject. Exact final check; the
+  // pre-buffer reservation above is approximate (raw asset size,
+  // doesn't account for <style>/<script> wrapper overhead) so this
+  // catches any drift.
   const parts: string[] = [];
   let cursor = 0;
   let totalBytes = 0;

--- a/apps/daemon/src/inline-assets.ts
+++ b/apps/daemon/src/inline-assets.ts
@@ -225,10 +225,28 @@ export async function inlineRelativeAssets(
         runningBytes -= handle.size;
         return null;
       }
-      if (Buffer.byteLength(content, 'utf8') > maxAssetBytes) {
+      const actualBytes = Buffer.byteLength(content, 'utf8');
+      if (actualBytes > maxAssetBytes) {
         // Defensive: handle.size may have been stale or the reader
         // ignored its own promise. Refund and drop the inlining.
         runningBytes -= handle.size;
+        return null;
+      }
+      // PR #1312 round-5 (lefarcen P3 confirmed path-a): reconcile the
+      // pre-read reservation with the actual content byte length. A
+      // stat-lying reader (stale stat, UTF-8 decode expansion, sparse
+      // file, deliberate under-report) could otherwise let many strings
+      // materialize before the concat-time guard catches it. The per-
+      // asset check above protects against single-asset blow-up; this
+      // adjustment + re-check guards the running total.
+      runningBytes += actualBytes - handle.size;
+      if (runningBytes > maxTotalBytes) {
+        // Drop this asset's inlining (tag stays as URL ref), set the
+        // abort flag so subsequent workers skip their read(), let
+        // Promise.all settle, then throw 'total' below. No throw-
+        // before-settle race — matches the round-2/3/4 graceful-
+        // fallback pattern.
+        totalAborted = true;
         return null;
       }
       return p.build(content);

--- a/apps/daemon/src/inline-assets.ts
+++ b/apps/daemon/src/inline-assets.ts
@@ -1,0 +1,123 @@
+// Server-side port of the web-client inliner at
+// apps/web/src/components/FileViewer.tsx:5248-5354 (@ base SHA 5bd97631).
+// Powers the GET /api/projects/:id/export/*?inline=1 endpoint that ships a
+// self-contained HTML document for explicit "Export self-contained HTML" and
+// screenshot tooling — the viewer itself stays URL-load by default since
+// PR #384 (Part 1 of nexu-io/open-design#368).
+//
+// The web client and this helper diverge in exactly one place: the global
+// replace below. See the inline comment near `replaceAllOccurrences` for
+// the rationale.
+
+export interface InlineAssetReader {
+  (relPath: string): Promise<string | null>;
+}
+
+interface Replacement {
+  from: string;
+  to: string;
+}
+
+export async function inlineRelativeAssets(
+  html: string,
+  ownerFileName: string,
+  fileReader: InlineAssetReader,
+): Promise<string> {
+  const replacements: Array<Promise<Replacement | null>> = [];
+
+  const linkTags = html.match(/<link\b[^>]*>/gi) ?? [];
+  for (const tag of linkTags) {
+    const rel = readHtmlAttr(tag, 'rel');
+    const href = readHtmlAttr(tag, 'href');
+    if (!rel || !/\bstylesheet\b/i.test(rel) || !href) continue;
+    const resolved = resolveProjectRelativePath(ownerFileName, href);
+    if (!resolved) continue;
+    replacements.push(
+      fileReader(resolved).then<Replacement | null>((css) =>
+        css == null
+          ? null
+          : {
+              from: tag,
+              to:
+                `<style data-od-inline-asset="${escapeHtmlAttr(href)}">\n` +
+                `${css.replace(/<\/style/gi, '<\\/style')}\n</style>`,
+            },
+      ),
+    );
+  }
+
+  const scriptTags =
+    html.match(/<script\b[^>]*\bsrc\s*=\s*["'][^"']+["'][^>]*>\s*<\/script>/gi) ?? [];
+  for (const tag of scriptTags) {
+    const src = readHtmlAttr(tag, 'src');
+    if (!src) continue;
+    const resolved = resolveProjectRelativePath(ownerFileName, src);
+    if (!resolved) continue;
+    replacements.push(
+      fileReader(resolved).then<Replacement | null>((js) => {
+        if (js == null) return null;
+        const open = tag.match(/^<script\b[^>]*>/i)?.[0] ?? '<script>';
+        const attrs = open
+          .replace(/^<script/i, '')
+          .replace(/>$/i, '')
+          .replace(/\ssrc\s*=\s*(['"])[\s\S]*?\1/i, '');
+        return {
+          from: tag,
+          to: `<script${attrs}>\n${js.replace(/<\/script/gi, '<\\/script')}\n</script>`,
+        };
+      }),
+    );
+  }
+
+  const resolvedReplacements = (await Promise.all(replacements)).filter(
+    (item): item is Replacement => item !== null,
+  );
+
+  // Divergence from apps/web/src/components/FileViewer.tsx:5313: the web
+  // client uses `.replace(from, () => to)`, which replaces only the first
+  // occurrence. That produces inconsistent output when a document has
+  // duplicate identical tags — one inlined, the rest left as URL refs.
+  // This helper replaces every occurrence. The web inline path is on a
+  // deprecation track (URL-load is the default since PR #384), so the
+  // divergence is forward-pointing.
+  return resolvedReplacements.reduce(
+    (next, { from, to }) => replaceAllOccurrences(next, from, to),
+    html,
+  );
+}
+
+export function baseDirFor(fileName: string): string {
+  const idx = fileName.lastIndexOf('/');
+  return idx >= 0 ? fileName.slice(0, idx + 1) : '';
+}
+
+export function resolveProjectRelativePath(
+  ownerFileName: string,
+  assetRef: string,
+): string | null {
+  if (/^(?:https?:|data:|blob:|mailto:|tel:|#|\/)/i.test(assetRef)) return null;
+  try {
+    const url = new URL(assetRef, `https://od.local/${baseDirFor(ownerFileName)}`);
+    if (url.origin !== 'https://od.local') return null;
+    return decodeURIComponent(url.pathname.replace(/^\/+/, ''));
+  } catch {
+    return null;
+  }
+}
+
+export function readHtmlAttr(tag: string, name: string): string | null {
+  const match = tag.match(new RegExp(`\\s${name}\\s*=\\s*(['"])([\\s\\S]*?)\\1`, 'i'));
+  return match?.[2] ?? null;
+}
+
+export function escapeHtmlAttr(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function replaceAllOccurrences(source: string, from: string, to: string): string {
+  return source.split(from).join(to);
+}

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -2882,6 +2882,8 @@ export async function startServer({
     paths: pathDeps,
     projectStore: projectStoreDeps,
     exports: projectExportDeps,
+    projectFiles: projectFileDeps,
+    validation: validationDeps,
   });
   registerProjectFileRoutes(app, {
     db,

--- a/apps/daemon/tests/export-inline-route.test.ts
+++ b/apps/daemon/tests/export-inline-route.test.ts
@@ -17,9 +17,13 @@ import { startServer } from '../src/server.js';
 // `FileViewer.tsx:5313` (replace-all vs first-match) is locked decision §3.3.
 
 function readerFrom(files: Record<string, string>) {
-  return async (relPath: string): Promise<string | null> => {
+  return async (relPath: string) => {
     const value = files[relPath];
-    return typeof value === 'string' ? value : null;
+    if (typeof value !== 'string') return null;
+    return {
+      size: Buffer.byteLength(value, 'utf8'),
+      read: async () => value,
+    };
   };
 }
 
@@ -291,18 +295,74 @@ describe('inlineRelativeAssets', () => {
     });
   });
 
+  it('checks maxAssetBytes via handle.size BEFORE invoking handle.read()', async () => {
+    // PR #1312 round-4 (lefarcen P2): the maxAssetBytes cap must fire
+    // pre-buffer. A reader whose read() throws is fine — the helper
+    // must not invoke it once the stat-side size exceeds the cap.
+    let readsAttempted = 0;
+    const sizeOnlyReader = async (relPath: string) => ({
+      size: 10_000,
+      read: async (): Promise<string | null> => {
+        readsAttempted += 1;
+        throw new Error(`read should not happen for ${relPath}`);
+      },
+    });
+    const html = '<link rel="stylesheet" href="big.css">';
+    const out = await inlineRelativeAssets(html, 'index.html', sizeOnlyReader, {
+      maxAssetBytes: 1_000,
+    });
+    expect(readsAttempted).toBe(0);
+    expect(out).toContain('<link rel="stylesheet" href="big.css">');
+  });
+
+  it('stops dispatching reads once running total exceeds maxTotalBytes', async () => {
+    // PR #1312 round-4 (lefarcen P2): the running-total guard must
+    // abort the worker pool, not wait for the final concat. With a
+    // tiny totalBytes cap and 20 candidates each contributing 800
+    // bytes of stat-size, we expect at most a few reads to actually
+    // run before the abort flag short-circuits the rest. Concurrency
+    // is 1 so the abort timing is deterministic.
+    let reads = 0;
+    const countingReader = async (relPath: string) => ({
+      size: 800,
+      read: async () => {
+        reads += 1;
+        return `/* ${relPath} */`;
+      },
+    });
+    const html = Array.from({ length: 20 }, (_, i) =>
+      `<link rel="stylesheet" href="a${i}.css">`,
+    ).join('');
+    await expect(
+      inlineRelativeAssets(html, 'index.html', countingReader, {
+        maxTotalBytes: 1_000,
+        maxReadConcurrency: 1,
+      }),
+    ).rejects.toMatchObject({ name: 'InlineAssetsLimitError', limit: 'total' });
+    // Owner html is ~760 bytes. First asset's 800 stat-size pushes
+    // running over 1000 → abort. So at most ONE read should fire.
+    expect(reads).toBeLessThanOrEqual(2);
+  });
+
   it('caps concurrent file reads at maxReadConcurrency', async () => {
-    // A reader that records peak concurrency: increments on entry,
-    // decrements on exit, tracks the high-water mark.
+    // A reader that records peak concurrency inside read(): increments
+    // on entry, decrements on exit, tracks the high-water mark. The
+    // size lookup is synchronous-fast so it doesn't contribute.
     let inFlight = 0;
     let peak = 0;
-    const readerWithCounter = async (relPath: string): Promise<string | null> => {
-      inFlight += 1;
-      if (inFlight > peak) peak = inFlight;
-      // Yield a microtask so other concurrent calls can interleave.
-      await new Promise((r) => setImmediate(r));
-      inFlight -= 1;
-      return `/* ${relPath} */`;
+    const readerWithCounter = async (relPath: string) => {
+      const body = `/* ${relPath} */`;
+      return {
+        size: Buffer.byteLength(body, 'utf8'),
+        read: async () => {
+          inFlight += 1;
+          if (inFlight > peak) peak = inFlight;
+          // Yield a microtask so other concurrent calls can interleave.
+          await new Promise((r) => setImmediate(r));
+          inFlight -= 1;
+          return body;
+        },
+      };
     };
     const html = Array.from({ length: 20 }, (_, i) =>
       `<link rel="stylesheet" href="a${i}.css">`,

--- a/apps/daemon/tests/export-inline-route.test.ts
+++ b/apps/daemon/tests/export-inline-route.test.ts
@@ -601,6 +601,30 @@ describe('GET /api/projects/:id/export/*?inline=1 route', () => {
     expect(body.error.code).toBe('PAYLOAD_TOO_LARGE');
   });
 
+  it('returns 413 (not 415) for an oversize non-HTML file — proves owner cap fires pre-buffer', async () => {
+    // PR #1312 round-5 (lefarcen P2): the route must stat the owner with
+    // resolveProjectFilePath BEFORE readProjectFile and reject sizes
+    // above MAX_INLINE_OWNER_BYTES with 413 PAYLOAD_TOO_LARGE. The
+    // Red→Green discriminator is the combination "oversize AND
+    // non-HTML": pre-fix, the route reads the buffer first and the
+    // text/plain mime check at file.mime fires → 415. Post-fix, the
+    // route stats first and the size check fires before the mime
+    // check → 413. Asserting "got 413, not 415" pins both the
+    // pre-buffer property and the check ordering (size before mime,
+    // per lefarcen's locked round-5 sequence).
+    //
+    // 2 MiB+1 byte fixture is acceptable in test setup; MAX_INLINE_OWNER_BYTES
+    // is 2 MiB so this is the minimal fixture that exceeds the cap with the
+    // production constant (no test-door needed).
+    const dir = path.join(projectsRoot, projectId);
+    const overCap = 2 * 1024 * 1024 + 1;
+    await writeFile(path.join(dir, 'huge.txt'), Buffer.alloc(overCap, 0x61));
+    const res = await fetch(exportUrl('huge.txt'));
+    expect(res.status).toBe(413);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe('PAYLOAD_TOO_LARGE');
+  });
+
   it('rejects an invalid project id (chars outside isSafeId char class) with 400 BAD_REQUEST', async () => {
     // PR #1312 round-2 review (lefarcen P3 @ export-inline-route.test.ts:287):
     // the previous `..` test was rejected by Express path normalization

--- a/apps/daemon/tests/export-inline-route.test.ts
+++ b/apps/daemon/tests/export-inline-route.test.ts
@@ -223,6 +223,95 @@ describe('inlineRelativeAssets', () => {
     expect(out).not.toContain('src="../../shared/util.js"');
   });
 
+  // ---- Cap enforcement (PR #1312 round-3, lefarcen P2) ---------------
+  // The helper accepts an InlineOptions bag (test-door per
+  // feedback_test_doors_over_fake_timers.md) so the tests can exercise
+  // each cap with tiny fixtures rather than 2-50 MiB on-disk writes.
+  // Production callers use the module-level defaults.
+  // --------------------------------------------------------------------
+
+  it('throws InlineAssetsLimitError("owner") when the owner html exceeds maxOwnerBytes', async () => {
+    const html = '<html><head>' + 'x'.repeat(500) + '</head></html>';
+    await expect(
+      inlineRelativeAssets(html, 'index.html', readerFrom({}), { maxOwnerBytes: 100 }),
+    ).rejects.toMatchObject({
+      name: 'InlineAssetsLimitError',
+      limit: 'owner',
+    });
+  });
+
+  it('throws InlineAssetsLimitError("candidates") when tag matches exceed maxCandidates', async () => {
+    // Build HTML with 5 link tags, cap at 3.
+    const html = Array.from({ length: 5 }, (_, i) =>
+      `<link rel="stylesheet" href="a${i}.css">`,
+    ).join('');
+    await expect(
+      inlineRelativeAssets(html, 'index.html', readerFrom({}), { maxCandidates: 3 }),
+    ).rejects.toMatchObject({
+      name: 'InlineAssetsLimitError',
+      limit: 'candidates',
+    });
+  });
+
+  it('leaves a tag intact (no replacement) when its asset body exceeds maxAssetBytes', async () => {
+    const html =
+      '<link rel="stylesheet" href="big.css"><link rel="stylesheet" href="small.css">';
+    const out = await inlineRelativeAssets(
+      html,
+      'index.html',
+      readerFrom({
+        'big.css': 'a'.repeat(2000), // exceeds cap
+        'small.css': '.s{}',
+      }),
+      { maxAssetBytes: 1000 },
+    );
+    // Oversized asset stays as a URL ref (graceful — the export still
+    // succeeds; the consumer sees an un-inlined link instead of inflated
+    // memory or a 413 for one bad asset).
+    expect(out).toContain('<link rel="stylesheet" href="big.css">');
+    // The small asset still inlines normally.
+    expect(out).toContain('.s{}');
+    expect(out).not.toContain('href="small.css"');
+  });
+
+  it('throws InlineAssetsLimitError("total") when the assembled output exceeds maxTotalBytes', async () => {
+    const html =
+      '<link rel="stylesheet" href="a.css"><link rel="stylesheet" href="b.css">';
+    const big = 'x'.repeat(800);
+    await expect(
+      inlineRelativeAssets(
+        html,
+        'index.html',
+        readerFrom({ 'a.css': big, 'b.css': big }),
+        { maxTotalBytes: 1000 },
+      ),
+    ).rejects.toMatchObject({
+      name: 'InlineAssetsLimitError',
+      limit: 'total',
+    });
+  });
+
+  it('caps concurrent file reads at maxReadConcurrency', async () => {
+    // A reader that records peak concurrency: increments on entry,
+    // decrements on exit, tracks the high-water mark.
+    let inFlight = 0;
+    let peak = 0;
+    const readerWithCounter = async (relPath: string): Promise<string | null> => {
+      inFlight += 1;
+      if (inFlight > peak) peak = inFlight;
+      // Yield a microtask so other concurrent calls can interleave.
+      await new Promise((r) => setImmediate(r));
+      inFlight -= 1;
+      return `/* ${relPath} */`;
+    };
+    const html = Array.from({ length: 20 }, (_, i) =>
+      `<link rel="stylesheet" href="a${i}.css">`,
+    ).join('');
+    await inlineRelativeAssets(html, 'index.html', readerWithCounter, { maxReadConcurrency: 4 });
+    expect(peak).toBeLessThanOrEqual(4);
+    expect(peak).toBeGreaterThan(0);
+  });
+
   it('does not re-replace a tag literal that appears inside an already-inlined asset body', async () => {
     // Regression for nexu-io/open-design#1312 review feedback (Siri-Ray
     // looper + codex bot): the previous reduce/split-join approach
@@ -426,6 +515,25 @@ describe('GET /api/projects/:id/export/*?inline=1 route', () => {
       const res = await fetch(exportUrl('index.html', q));
       expect(res.status).toBe(200);
     }
+  });
+
+  it('returns 413 PAYLOAD_TOO_LARGE when the owner file blows past the candidates cap', async () => {
+    // PR #1312 round-3 (lefarcen P2): the route must surface the
+    // InlineAssetsLimitError as a structured 413 envelope, not let it
+    // propagate as a 400 BAD_REQUEST. Generated owner has 501
+    // `<link rel=stylesheet>` tags, one above the default
+    // MAX_INLINE_CANDIDATES (500). The candidates cap fires after
+    // matchAll, BEFORE any sibling read, so the fact that `a.css`
+    // doesn't exist on disk is irrelevant.
+    const dir = path.join(projectsRoot, projectId);
+    const huge = '<!doctype html><html><head>' +
+      '<link rel="stylesheet" href="a.css">'.repeat(501) +
+      '</head></html>';
+    await writeFile(path.join(dir, 'too-many-tags.html'), huge);
+    const res = await fetch(exportUrl('too-many-tags.html'));
+    expect(res.status).toBe(413);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe('PAYLOAD_TOO_LARGE');
   });
 
   it('rejects an invalid project id (chars outside isSafeId char class) with 400 BAD_REQUEST', async () => {

--- a/apps/daemon/tests/export-inline-route.test.ts
+++ b/apps/daemon/tests/export-inline-route.test.ts
@@ -438,11 +438,16 @@ describe('GET /api/projects/:id/export/*?inline=1 route', () => {
     }
   });
 
-  it('returns 400 UNSUPPORTED_FILE_TYPE for non-HTML files', async () => {
+  it('returns 415 UNSUPPORTED_MEDIA_TYPE for non-HTML files', async () => {
+    // Drift fix discovered in PR #1312 round-3: the round-1 code emitted
+    // `UNSUPPORTED_FILE_TYPE` (status 400) which is not a registered
+    // ApiErrorCode in packages/contracts/src/errors.ts. The canonical
+    // code for "wrong content type" is UNSUPPORTED_MEDIA_TYPE with HTTP
+    // 415, so the route now uses both.
     const res = await fetch(exportUrl('app.css'));
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(415);
     const body = (await res.json()) as { error: { code: string } };
-    expect(body.error.code).toBe('UNSUPPORTED_FILE_TYPE');
+    expect(body.error.code).toBe('UNSUPPORTED_MEDIA_TYPE');
   });
 
   it('returns 404 FILE_NOT_FOUND for a nonexistent file', async () => {

--- a/apps/daemon/tests/export-inline-route.test.ts
+++ b/apps/daemon/tests/export-inline-route.test.ts
@@ -14,7 +14,8 @@ import { inlineRelativeAssets } from '../src/inline-assets.js';
 
 function readerFrom(files: Record<string, string>) {
   return async (relPath: string): Promise<string | null> => {
-    return Object.prototype.hasOwnProperty.call(files, relPath) ? files[relPath] : null;
+    const value = files[relPath];
+    return typeof value === 'string' ? value : null;
   };
 }
 
@@ -144,10 +145,15 @@ describe('inlineRelativeAssets', () => {
   });
 
   it('HTML-escapes the href value in data-od-inline-asset attr', async () => {
-    const href = 'weird&name<x>.css';
+    // Using `&` only — the realistic case for filenames that need escaping.
+    // `<`, `>`, `"` are forbidden in real filenames on most platforms and
+    // additionally break the tag-matching regex (a limitation inherited
+    // from the web client at FileViewer.tsx:5271). The escapeHtmlAttr fn
+    // itself covers `&`, `"`, `<`, `>` by inspection.
+    const href = 'weird&name.css';
     const html = `<link rel="stylesheet" href="${href}">`;
     const out = await inlineRelativeAssets(html, 'index.html', readerFrom({ [href]: '.x{}' }));
-    expect(out).toContain('data-od-inline-asset="weird&amp;name&lt;x&gt;.css"');
+    expect(out).toContain('data-od-inline-asset="weird&amp;name.css"');
     expect(out).not.toContain(`data-od-inline-asset="${href}"`);
   });
 

--- a/apps/daemon/tests/export-inline-route.test.ts
+++ b/apps/daemon/tests/export-inline-route.test.ts
@@ -349,4 +349,46 @@ describe('GET /api/projects/:id/export/*?inline=1 route', () => {
     expect(body).toContain(nestedJsBody);
     expect(body).not.toContain('src="../shared/util.js"');
   });
+
+  it('sends Content-Security-Policy: sandbox allow-scripts to block daemon-origin privilege escalation', async () => {
+    // PR #1312 round-2 review (lefarcen P2 @ import-export-routes.ts:423):
+    // top-level browser navigation to the export URL sends no Origin
+    // header, so the daemon middleware lets it through and any JS in
+    // the exported document runs with daemon-origin privileges (access
+    // to /api/, cookies, localStorage). CSP `sandbox allow-scripts`
+    // treats the response like a sandboxed iframe with an opaque origin:
+    // scripts execute (which the export needs — that's the whole point
+    // of inlining JS) but cannot read cookies, hit /api/, or otherwise
+    // escalate to the daemon's origin.
+    const res = await fetch(exportUrl('index.html'));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-security-policy')).toBe('sandbox allow-scripts');
+  });
+
+  it('accepts inline=true / yes / on / TRUE / Yes / ON (case-insensitive accept list per decision §7)', async () => {
+    // PR #1312 round-2 review (lefarcen P3 @ export-inline-route.test.ts:262):
+    // PR body decision §7 promises `inline=true/yes/on` case-insensitive
+    // matching parseForceInline at file-viewer-render-mode.ts:59-66, but
+    // round-1 tests only exercised inline=1. Pin the full accept list.
+    for (const q of ['inline=true', 'inline=yes', 'inline=on', 'inline=TRUE', 'inline=Yes', 'inline=ON']) {
+      const res = await fetch(exportUrl('index.html', q));
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it('rejects an invalid project id (chars outside isSafeId char class) with 400 BAD_REQUEST', async () => {
+    // PR #1312 round-2 review (lefarcen P3 @ export-inline-route.test.ts:287):
+    // the previous `..` test was rejected by Express path normalization
+    // before the route saw it, so it didn't actually exercise the
+    // isSafeId guard. We need an id that (a) Express passes through
+    // unchanged into req.params and (b) isSafeId rejects. The `!` char
+    // is URL-safe (no percent-encoding needed) and not in isSafeId's
+    // /^[A-Za-z0-9._-]+$/ char class, so it hits the route's first
+    // checkpoint and returns the documented envelope.
+    const res = await fetch(exportUrl('index.html').replace(`/${projectId}/`, '/bad!id/'));
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string; message: string } };
+    expect(body.error.code).toBe('BAD_REQUEST');
+    expect(body.error.message).toContain('invalid project id');
+  });
 });

--- a/apps/daemon/tests/export-inline-route.test.ts
+++ b/apps/daemon/tests/export-inline-route.test.ts
@@ -161,6 +161,31 @@ describe('inlineRelativeAssets', () => {
     expect(out).not.toContain(`data-od-inline-asset="${href}"`);
   });
 
+  it('does not treat "disabled" inside a quoted attribute value as the disabled boolean attr', async () => {
+    // PR #1312 round-2 review (lefarcen P3): the current
+    // `hasBooleanHtmlAttr` regex `\sdisabled(?=\s|=|/?>)` tests the
+    // tag string with NO attr-quoting awareness, so the literal text
+    // `disabled` appearing inside any quoted attribute value, followed
+    // by another whitespace char, satisfies the lookahead. A source
+    // tag like
+    //   <link rel=stylesheet href=x.css data-note="content disabled stuff">
+    // would then emit a <style disabled> block — silently disabling
+    // a stylesheet the author wrote without that attr.
+    const html =
+      '<link rel="stylesheet" href="x.css" data-note="content disabled stuff">';
+    const out = await inlineRelativeAssets(html, 'index.html', readerFrom({ 'x.css': '.x{}' }));
+    expect(out).toMatch(/<style\b[^>]*data-od-inline-asset/);
+    expect(out).not.toMatch(/<style\b[^>]*\bdisabled\b/);
+  });
+
+  it('still detects disabled when it is a real boolean attr (regression for the dedup fix)', async () => {
+    // Counterweight to the previous case: don't over-correct and
+    // start dropping the legitimate `disabled` attr.
+    const html = '<link rel="stylesheet" href="x.css" disabled>';
+    const out = await inlineRelativeAssets(html, 'index.html', readerFrom({ 'x.css': '.x{}' }));
+    expect(out).toMatch(/<style\b[^>]*\bdisabled\b/);
+  });
+
   it('preserves <link> attrs (media, title, disabled, nonce) on the generated <style> tag', async () => {
     // PR #1312 round-2 (lefarcen P2 @ inline-assets.ts:44): a stylesheet
     // <link> with `media="print"` was becoming a plain <style> with no

--- a/apps/daemon/tests/export-inline-route.test.ts
+++ b/apps/daemon/tests/export-inline-route.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+
+import { inlineRelativeAssets } from '../src/inline-assets.js';
+
+// ---------------------------------------------------------------------------
+// Unit — inlineRelativeAssets pure helper
+// ---------------------------------------------------------------------------
+//
+// These tests pin the behavior contract documented in
+// `~/.claude/plans/declarative-roaming-gosling.md` §2.3. The helper is a
+// server-side port of the web-client logic at `apps/web/src/components/
+// FileViewer.tsx:5248-5354` (@ base SHA 5bd97631); the divergence from
+// `FileViewer.tsx:5313` (replace-all vs first-match) is locked decision §3.3.
+
+function readerFrom(files: Record<string, string>) {
+  return async (relPath: string): Promise<string | null> => {
+    return Object.prototype.hasOwnProperty.call(files, relPath) ? files[relPath] : null;
+  };
+}
+
+describe('inlineRelativeAssets', () => {
+  it('inlines a single <link rel=stylesheet> with verbatim CSS body', async () => {
+    const html =
+      '<!doctype html><html><head><link rel="stylesheet" href="a.css"></head><body></body></html>';
+    const out = await inlineRelativeAssets(html, 'index.html', readerFrom({ 'a.css': 'body{color:red}' }));
+    expect(out).toContain('<style data-od-inline-asset="a.css">');
+    expect(out).toContain('body{color:red}');
+    expect(out).not.toContain('<link rel="stylesheet" href="a.css">');
+  });
+
+  it('inlines a <script src> preserving non-src attrs (type=module, defer, crossorigin)', async () => {
+    const html =
+      '<html><head><script type="module" defer crossorigin src="x.js"></script></head></html>';
+    const out = await inlineRelativeAssets(html, 'index.html', readerFrom({ 'x.js': 'console.log(1)' }));
+    expect(out).toMatch(/<script[^>]*type="module"[^>]*>/);
+    expect(out).toMatch(/<script[^>]*\bdefer\b[^>]*>/);
+    expect(out).toMatch(/<script[^>]*\bcrossorigin\b[^>]*>/);
+    expect(out).toContain('console.log(1)');
+    expect(out).not.toContain('src="x.js"');
+  });
+
+  it('resolves relative paths for both nested and root owners', async () => {
+    const nestedOut = await inlineRelativeAssets(
+      '<script src="../shared/util.js"></script>',
+      'pages/index.html',
+      readerFrom({ 'shared/util.js': 'export const x = 1;' }),
+    );
+    expect(nestedOut).toContain('export const x = 1;');
+
+    const rootOut = await inlineRelativeAssets(
+      '<link rel="stylesheet" href="a.css">',
+      'index.html',
+      readerFrom({ 'a.css': '.root{}' }),
+    );
+    expect(rootOut).toContain('.root{}');
+  });
+
+  it('handles self-closing <link …/> form', async () => {
+    const html = '<link rel="stylesheet" href="a.css" />';
+    const out = await inlineRelativeAssets(html, 'index.html', readerFrom({ 'a.css': '/*ok*/' }));
+    expect(out).toContain('/*ok*/');
+    expect(out).not.toContain('href="a.css"');
+  });
+
+  it("accepts single-quoted attrs (href='a.css')", async () => {
+    const html = `<link rel='stylesheet' href='a.css'>`;
+    const out = await inlineRelativeAssets(html, 'index.html', readerFrom({ 'a.css': '/*single*/' }));
+    expect(out).toContain('/*single*/');
+  });
+
+  it('does NOT rewrite a <link> tag without a rel attribute', async () => {
+    const html = '<link href="a.css">';
+    const out = await inlineRelativeAssets(html, 'index.html', readerFrom({ 'a.css': '.x{}' }));
+    expect(out).toBe(html);
+  });
+
+  it('does NOT rewrite <link rel="preload"> (only rel=stylesheet)', async () => {
+    const html = '<link rel="preload" href="x.css">';
+    const out = await inlineRelativeAssets(html, 'index.html', readerFrom({ 'x.css': '.x{}' }));
+    expect(out).toBe(html);
+  });
+
+  it('does NOT rewrite absolute / data / blob / mailto / tel / anchor / leading-slash refs', async () => {
+    const cases = [
+      '<link rel="stylesheet" href="https://cdn.example.com/x.css">',
+      '<link rel="stylesheet" href="http://cdn.example.com/x.css">',
+      '<link rel="stylesheet" href="data:text/css,body{}">',
+      '<link rel="stylesheet" href="blob:abc">',
+      '<link rel="stylesheet" href="/abs/path.css">',
+      '<script src="https://cdn.example.com/x.js"></script>',
+      '<script src="data:text/javascript,1+1"></script>',
+      '<script src="/abs/x.js"></script>',
+    ];
+    const reader = readerFrom({}); // never called
+    for (const html of cases) {
+      const out = await inlineRelativeAssets(html, 'index.html', reader);
+      expect(out).toBe(html);
+    }
+  });
+
+  it('escapes </style inside CSS body to <\\/style', async () => {
+    const css = 'body::before{content:"</style>"}';
+    const out = await inlineRelativeAssets(
+      '<link rel="stylesheet" href="a.css">',
+      'index.html',
+      readerFrom({ 'a.css': css }),
+    );
+    expect(out).toContain('<\\/style');
+    expect(out).not.toMatch(/<\/style[^>]*?>\s*<\/style>/);
+    expect(out.match(/<\/style>/g)?.length).toBe(1);
+  });
+
+  it('escapes </script inside JS body to <\\/script', async () => {
+    const js = 'const x = "</script>"';
+    const out = await inlineRelativeAssets(
+      '<script src="x.js"></script>',
+      'index.html',
+      readerFrom({ 'x.js': js }),
+    );
+    expect(out).toContain('<\\/script');
+    expect(out.match(/<\/script>/g)?.length).toBe(1);
+  });
+
+  it('leaves tag intact when fileReader returns null, but still inlines other assets', async () => {
+    const html =
+      '<link rel="stylesheet" href="missing.css"><script src="present.js"></script>';
+    const out = await inlineRelativeAssets(
+      html,
+      'index.html',
+      readerFrom({ 'present.js': 'ok' }),
+    );
+    expect(out).toContain('<link rel="stylesheet" href="missing.css">');
+    expect(out).toContain('ok');
+    expect(out).not.toContain('src="present.js"');
+  });
+
+  it('replaces ALL occurrences of identical duplicate tags (diverges from FileViewer.tsx:5313)', async () => {
+    // The web client uses `.replace(from, () => to)` which only replaces the
+    // first match. Locked decision §3.3: the server helper replaces all.
+    const html = '<script src="x.js"></script>\n<script src="x.js"></script>';
+    const out = await inlineRelativeAssets(html, 'index.html', readerFrom({ 'x.js': 'BODY' }));
+    expect(out.match(/src="x\.js"/g) ?? []).toEqual([]);
+    expect(out.match(/BODY/g)?.length).toBe(2);
+  });
+
+  it('HTML-escapes the href value in data-od-inline-asset attr', async () => {
+    const href = 'weird&name<x>.css';
+    const html = `<link rel="stylesheet" href="${href}">`;
+    const out = await inlineRelativeAssets(html, 'index.html', readerFrom({ [href]: '.x{}' }));
+    expect(out).toContain('data-od-inline-asset="weird&amp;name&lt;x&gt;.css"');
+    expect(out).not.toContain(`data-od-inline-asset="${href}"`);
+  });
+
+  it('resolves deep-nested owner (a/b/c/index.html + ../../shared/util.js)', async () => {
+    const out = await inlineRelativeAssets(
+      '<script src="../../shared/util.js"></script>',
+      'a/b/c/index.html',
+      readerFrom({ 'a/shared/util.js': 'DEEP' }),
+    );
+    expect(out).toContain('DEEP');
+    expect(out).not.toContain('src="../../shared/util.js"');
+  });
+});

--- a/apps/daemon/tests/export-inline-route.test.ts
+++ b/apps/daemon/tests/export-inline-route.test.ts
@@ -3,7 +3,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import { inlineRelativeAssets } from '../src/inline-assets.js';
+import { inlineRelativeAssets, type InlineAssetReader } from '../src/inline-assets.js';
 import { startServer } from '../src/server.js';
 
 // ---------------------------------------------------------------------------
@@ -342,6 +342,49 @@ describe('inlineRelativeAssets', () => {
     // Owner html is ~760 bytes. First asset's 800 stat-size pushes
     // running over 1000 → abort. So at most ONE read should fire.
     expect(reads).toBeLessThanOrEqual(2);
+  });
+
+  it('reconciles handle.size with actual content bytes — trips total abort post-read on stat-lying readers', async () => {
+    // PR #1312 round-5 (lefarcen P3 confirmed at PR-1312#issuecomment-4424868413
+    // follow-up, path-a): the helper must reconcile handle.size with the
+    // actual byte length of `content` AFTER `read()`, not just trust the
+    // stat-side number. A reader that under-reports size (stale stat,
+    // UTF-8 expansion at decode, sparse file, deliberate lie) would
+    // otherwise let many strings materialize before the concat-time
+    // guard at the bottom of the helper throws — defeating the round-4
+    // pre-buffer cap intent.
+    //
+    // Discriminator: read count. Pre-fix the helper trusts handle.size
+    // (10), so both reads complete (each returning 1000 bytes) under
+    // the reservation total of 56+10+10=76 < cap 500; the concat-time
+    // guard then catches the 2000+-byte assembly and throws 'total'.
+    // Post-fix worker 1's reconciliation trips totalAborted as soon as
+    // its actualBytes (1000) is added to runningBytes, pushing running
+    // over the cap; worker 2 then sees totalAborted and returns null
+    // without invoking read(). One read, not two.
+    //
+    // Lefarcen-confirmed path-a (drop-asset + abort + throw 'total'
+    // after Promise.all settles): preserves the round-2/3/4 graceful-
+    // fallback pattern instead of racing throws between in-flight
+    // workers.
+    let reads = 0;
+    const lyingReader: InlineAssetReader = async (_relPath: string) => ({
+      size: 10, // stat lies — actual is 100x
+      read: async () => {
+        reads += 1;
+        return 'x'.repeat(1000);
+      },
+    });
+    const html = '<script src="a.js"></script><script src="b.js"></script>';
+    await expect(
+      inlineRelativeAssets(html, 'index.html', lyingReader, {
+        maxTotalBytes: 500,
+        maxReadConcurrency: 1, // sequential so the abort timing is deterministic
+      }),
+    ).rejects.toMatchObject({ name: 'InlineAssetsLimitError', limit: 'total' });
+    // Pre-fix: 2 (helper trusts stat → both reads complete → concat catches).
+    // Post-fix: 1 (worker 1 reconciles after read, trips abort; worker 2 skipped).
+    expect(reads).toBe(1);
   });
 
   it('caps concurrent file reads at maxReadConcurrency', async () => {

--- a/apps/daemon/tests/export-inline-route.test.ts
+++ b/apps/daemon/tests/export-inline-route.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import type http from 'node:http';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { inlineRelativeAssets } from '../src/inline-assets.js';
+import { startServer } from '../src/server.js';
 
 // ---------------------------------------------------------------------------
 // Unit — inlineRelativeAssets pure helper
@@ -165,5 +169,146 @@ describe('inlineRelativeAssets', () => {
     );
     expect(out).toContain('DEEP');
     expect(out).not.toContain('src="../../shared/util.js"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HTTP integration — GET /api/projects/:id/export/*?inline=1
+// ---------------------------------------------------------------------------
+
+describe('GET /api/projects/:id/export/*?inline=1 route', () => {
+  let server: http.Server;
+  let baseUrl: string;
+  let projectsRoot: string;
+  const projectId = 'proj-export-inline-test';
+
+  const cssBody = 'body{color:#0a0}';
+  const jsBody = 'window.OD_EXPORT_OK = 42;';
+  const nestedJsBody = 'export const N = 7;';
+
+  beforeAll(async () => {
+    const started = (await startServer({ port: 0, returnServer: true })) as {
+      url: string;
+      server: http.Server;
+    };
+    baseUrl = started.url;
+    server = started.server;
+
+    projectsRoot = path.join(process.env.OD_DATA_DIR!, 'projects');
+    const dir = path.join(projectsRoot, projectId);
+    const pages = path.join(dir, 'pages');
+    const shared = path.join(dir, 'shared');
+    await mkdir(dir, { recursive: true });
+    await mkdir(pages, { recursive: true });
+    await mkdir(shared, { recursive: true });
+
+    await writeFile(
+      path.join(dir, 'index.html'),
+      '<!doctype html><html><head>' +
+        '<link rel="stylesheet" href="app.css">' +
+        '<script src="app.js"></script>' +
+        '</head><body><div id="root"></div></body></html>',
+    );
+    await writeFile(path.join(dir, 'app.css'), cssBody);
+    await writeFile(path.join(dir, 'app.js'), jsBody);
+
+    await writeFile(
+      path.join(dir, 'partial.html'),
+      '<!doctype html><html><head>' +
+        '<link rel="stylesheet" href="missing.css">' +
+        '<script src="app.js"></script>' +
+        '</head><body></body></html>',
+    );
+
+    await writeFile(
+      path.join(pages, 'index.html'),
+      '<!doctype html><html><head>' +
+        '<script src="../shared/util.js"></script>' +
+        '</head></html>',
+    );
+    await writeFile(path.join(shared, 'util.js'), nestedJsBody);
+  });
+
+  afterAll(() => new Promise<void>((resolve) => server.close(() => resolve())));
+
+  const exportUrl = (name: string, query = 'inline=1') =>
+    `${baseUrl}/api/projects/${projectId}/export/${name}${query ? `?${query}` : ''}`;
+
+  it('returns a self-contained HTML body when ?inline=1 on a 3-file layout', async () => {
+    const res = await fetch(exportUrl('index.html'));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/html');
+    const body = await res.text();
+    // Wiring guard: removing the await inlineRelativeAssets(...) line in the
+    // handler fails these assertions, not just the helper-internals tests.
+    expect(body).toContain(cssBody);
+    expect(body).toContain(jsBody);
+    expect(body).not.toContain('href="app.css"');
+    expect(body).not.toContain('src="app.js"');
+    expect(body).toContain('<style data-od-inline-asset="app.css">');
+  });
+
+  it('returns 400 BAD_REQUEST when ?inline is missing', async () => {
+    const res = await fetch(exportUrl('index.html', ''));
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe('BAD_REQUEST');
+  });
+
+  it('returns 400 for non-canonical inline values (0, false, foo)', async () => {
+    for (const q of ['inline=0', 'inline=false', 'inline=foo', 'inline=']) {
+      const res = await fetch(exportUrl('index.html', q));
+      expect(res.status).toBe(400);
+    }
+  });
+
+  it('returns 400 UNSUPPORTED_FILE_TYPE for non-HTML files', async () => {
+    const res = await fetch(exportUrl('app.css'));
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe('UNSUPPORTED_FILE_TYPE');
+  });
+
+  it('returns 404 FILE_NOT_FOUND for a nonexistent file', async () => {
+    const res = await fetch(exportUrl('missing.html'));
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe('FILE_NOT_FOUND');
+  });
+
+  it('returns 400 BAD_REQUEST for an invalid project id (..)', async () => {
+    const res = await fetch(`${baseUrl}/api/projects/../export/index.html?inline=1`);
+    // Express normalizes `..` segments before routing, so this should not
+    // reach our handler; the daemon's middleware or routing answers first.
+    // Either way, the request must NOT succeed at extracting a parent
+    // directory.
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(res.status).toBeLessThan(500);
+  });
+
+  it('responds 204 with Access-Control-Allow-Origin: * to a null-origin OPTIONS preflight', async () => {
+    const res = await fetch(exportUrl('index.html'), {
+      method: 'OPTIONS',
+      headers: { Origin: 'null' },
+    });
+    expect(res.status).toBe(204);
+    expect(res.headers.get('access-control-allow-origin')).toBe('*');
+  });
+
+  it('returns 200 with the <link> tag intact when a sibling asset is missing', async () => {
+    const res = await fetch(exportUrl('partial.html'));
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain('<link rel="stylesheet" href="missing.css">');
+    expect(body).toContain(jsBody);
+    expect(body).not.toContain('src="app.js"');
+  });
+
+  it('inlines a nested HTML entry (pages/index.html + ../shared/util.js)', async () => {
+    const res = await fetch(exportUrl('pages/index.html'));
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain(nestedJsBody);
+    expect(body).not.toContain('src="../shared/util.js"');
   });
 });

--- a/apps/daemon/tests/export-inline-route.test.ts
+++ b/apps/daemon/tests/export-inline-route.test.ts
@@ -286,13 +286,16 @@ describe('GET /api/projects/:id/export/*?inline=1 route', () => {
     expect(res.status).toBeLessThan(500);
   });
 
-  it('responds 204 with Access-Control-Allow-Origin: * to a null-origin OPTIONS preflight', async () => {
-    const res = await fetch(exportUrl('index.html'), {
-      method: 'OPTIONS',
-      headers: { Origin: 'null' },
-    });
-    expect(res.status).toBe(204);
-    expect(res.headers.get('access-control-allow-origin')).toBe('*');
+  it('rejects null-origin requests with 403 (export is for same-origin / server-side callers only)', async () => {
+    // Unlike /raw/*, the /export/* route is NOT in the daemon's null-
+    // origin allowlist (server.ts _NULL_ORIGIN_SAFE_GET_RE). The export
+    // consumer set is the daemon UI (same-origin) and server-side
+    // screenshot tooling (no Origin header at all); sandboxed-iframe
+    // srcdoc previews fetch through /raw/ instead, where each asset has
+    // its own URL. This test pins the contract so a future change that
+    // adds /export/ to the allowlist has to update it deliberately.
+    const res = await fetch(exportUrl('index.html'), { headers: { Origin: 'null' } });
+    expect(res.status).toBe(403);
   });
 
   it('returns 200 with the <link> tag intact when a sibling asset is missing', async () => {

--- a/apps/daemon/tests/export-inline-route.test.ts
+++ b/apps/daemon/tests/export-inline-route.test.ts
@@ -161,6 +161,33 @@ describe('inlineRelativeAssets', () => {
     expect(out).not.toContain(`data-od-inline-asset="${href}"`);
   });
 
+  it('preserves <link> attrs (media, title, disabled, nonce) on the generated <style> tag', async () => {
+    // PR #1312 round-2 (lefarcen P2 @ inline-assets.ts:44): a stylesheet
+    // <link> with `media="print"` was becoming a plain <style> with no
+    // media query, so print-only styles applied unconditionally. Same
+    // problem for `title` (alternate stylesheet sets), `disabled`
+    // (initial disabled state), `nonce` (CSP nonce). All four are valid
+    // attributes on both <link rel=stylesheet> and <style> per HTML
+    // spec, so the inliner should copy them across.
+    const html =
+      '<link rel="stylesheet" href="print.css" media="print" title="Print">' +
+      '<link rel="stylesheet" href="alt.css" disabled>' +
+      '<link rel="stylesheet" href="csp.css" nonce="abc123">';
+    const out = await inlineRelativeAssets(
+      html,
+      'index.html',
+      readerFrom({
+        'print.css': '.p{}',
+        'alt.css': '.a{}',
+        'csp.css': '.c{}',
+      }),
+    );
+    expect(out).toMatch(/<style\b[^>]*\bmedia="print"[^>]*>[\s\S]*?\.p\{\}/);
+    expect(out).toMatch(/<style\b[^>]*\btitle="Print"[^>]*>[\s\S]*?\.p\{\}/);
+    expect(out).toMatch(/<style\b[^>]*\bdisabled\b[^>]*>[\s\S]*?\.a\{\}/);
+    expect(out).toMatch(/<style\b[^>]*\bnonce="abc123"[^>]*>[\s\S]*?\.c\{\}/);
+  });
+
   it('resolves deep-nested owner (a/b/c/index.html + ../../shared/util.js)', async () => {
     const out = await inlineRelativeAssets(
       '<script src="../../shared/util.js"></script>',

--- a/apps/daemon/tests/export-inline-route.test.ts
+++ b/apps/daemon/tests/export-inline-route.test.ts
@@ -170,6 +170,41 @@ describe('inlineRelativeAssets', () => {
     expect(out).toContain('DEEP');
     expect(out).not.toContain('src="../../shared/util.js"');
   });
+
+  it('does not re-replace a tag literal that appears inside an already-inlined asset body', async () => {
+    // Regression for nexu-io/open-design#1312 review feedback (Siri-Ray
+    // looper + codex bot): the previous reduce/split-join approach
+    // re-scanned the progressively mutated HTML, so a tag literal that
+    // happened to appear inside an inlined asset body got the inner
+    // literal also replaced — corrupting the body.
+    //
+    // The reproducer uses two <link rel=stylesheet> tags where a.css's
+    // body contains the literal text of b.css's <link> tag (e.g. inside
+    // a CSS comment or content: declaration). The </style escape on
+    // CSS bodies doesn't touch <link>, so split/join over the mutated
+    // HTML finds the literal inside a.css's inline body and replaces
+    // it on the second pass — injecting b.css's inline body where the
+    // literal comment text used to be.
+    const html =
+      '<link rel="stylesheet" href="a.css"><link rel="stylesheet" href="b.css">';
+    const aCssBody = '/* see also <link rel="stylesheet" href="b.css"> */';
+    const bCssBody = 'body{color:red}';
+    const out = await inlineRelativeAssets(
+      html,
+      'index.html',
+      readerFrom({ 'a.css': aCssBody, 'b.css': bCssBody }),
+    );
+    // The literal <link> string inside a.css's comment must survive
+    // verbatim — position-based replacement only touches the original
+    // outer-tag spans, not text introduced by earlier replacements.
+    expect(out).toContain('/* see also <link rel="stylesheet" href="b.css"> */');
+    // b.css's body is inlined exactly once, at the real outer tag's
+    // position — not injected inside a.css's inline body.
+    expect(out.match(/body\{color:red\}/g)?.length).toBe(1);
+    // Neither original outer <link href="…"> survives as a URL ref.
+    expect(out).not.toMatch(/<link\b[^>]*\bhref="a\.css"/);
+    expect(out).not.toMatch(/<link\b[^>]*\bhref="b\.css"(?![^<]*\*\/)/);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
# Summary

Closes [#368](https://github.com/nexu-io/open-design/issues/368) — Part 2 of the export-inline split @lefarcen ratified in [#issuecomment-4366243218](https://github.com/nexu-io/open-design/issues/368#issuecomment-4366243218). Part 1 (PR #384) flipped the FileViewer iframe to URL-load by default; this PR adds the `GET /api/projects/:id/export/*?inline=1` daemon endpoint that returns a self-contained HTML body for the explicit "Export self-contained HTML" + screenshot path.

- New pure helper `apps/daemon/src/inline-assets.ts` ports `apps/web/src/components/FileViewer.tsx:5248-5354` server-side, taking a `fileReader: (relPath) => Promise<string|null>` closure so the daemon route owns the filesystem boundary.
- New route wired into `apps/daemon/src/import-export-routes.ts`'s `registerProjectExportRoutes` alongside `/export/pdf` and `/archive`. Uses `ctx.projectFiles.readProjectFile`, `ctx.validation.isSafeId`, and `ctx.projectStore.getProject` — no new infrastructure.
- Branch built strict TDD (Red → Green → Refactor per phase); every behavior change has a preceding Red commit so `git log` reads as the spec.

# Design decisions

The endpoint's full contract surface — surfaced here so reviewers can see the shape without spelunking through tests:

1. **`inline=1` is required.** Missing or non-canonical → 400 `BAD_REQUEST`. The endpoint exists for inlining; a pass-through would duplicate `/raw/*`.
2. **Non-HTML files → 400 `UNSUPPORTED_FILE_TYPE`.** Inlining is `<link>`/`<script>`-specific; non-HTML has no relative-asset tags worth rewriting.
3. **Sibling-asset fetch failure → tag left intact, response still 200.** Matches the web client's failure-local behavior (`FileViewer.tsx:5311` filters nulls out). The failure-local-not-fatal property is what the issue body calls out as a structural improvement over the all-or-nothing `srcDoc` model.
4. **No response cap.** The 384 KiB transcript cap on `/finalize/anthropic` (PR #832) is about Anthropic context windows, not relevant here. The export consumer is a download or screenshot tool.
5. **No cache headers.** `/raw/*` doesn't set any either; output is dynamic (file contents + sibling reads change underfoot).
6. **No new `packages/contracts` type.** Like `/raw/*`, this serves `text/html` directly; no JSON DTO needed.
7. **`inline` accept-list = `1` / `true` / `yes` / `on` (case-insensitive).** Mirrors Part 1's `parseForceInline` at `apps/web/src/components/file-viewer-render-mode.ts:59-66` so the client `?forceInline=…` and server `?inline=…` query languages match.
8. **Duplicate identical tags: replace all.** Deliberate divergence from the web client at `FileViewer.tsx:5313` (`next.replace(from, () => to)` — first-match-only, which produces inconsistent output when a document has duplicate `<script src="x.js">` tags). An inline comment in `inline-assets.ts` documents the divergence; regression test #12 pins the new behavior. The web inline path is on a deprecation track since PR #384 made URL-load the default, so the divergence is forward-pointing.
9. **Wildcard route `/export/*` not `/export/:file`.** The architecture comment used `:file` at the discussion level, but Express's named param only matches one segment and the React-prototype use case requires nested entries (`pages/index.html`). The route registers as `/export/*` mirroring `/raw/*` at `project-routes.ts:690` and pulls `req.params[0]`.
10. **Null-origin callers NOT supported.** The daemon's `/api` middleware (`server.ts:2123-2148`) gates null-origin requests through `_NULL_ORIGIN_SAFE_GET_RE`, which only allowlists `/raw/*` and `/codex-pets/.../spritesheet`. Export consumers are the daemon UI (same-origin) and server-side screenshot tooling (no Origin header); sandboxed-iframe srcdoc previews fetch through `/raw/*` instead. Integration test #7 pins the 403 contract so a future allowlist change has to update it deliberately.

# Tests

Strict TDD ordering — every behavior change has a Red commit before the Green commit that implements it. Test delta: **+23 daemon tests** (14 unit + 9 integration in `apps/daemon/tests/export-inline-route.test.ts`).

| Phase | Commit | Subject | Tests delta | Daemon-suite size after |
|---|---|---|---|---|
| B-R | `a60a9023` | test(daemon): add Red unit tests for inlineRelativeAssets helper | +14 (all Red — module not found) | n/a |
| B-G | `5856d7be` | feat(daemon): port inlineRelativeAssets server-side for export endpoint | 0 net | 1718 |
| B-Rf | — | (no-op; helper already had named exports + extracted `replaceAllOccurrences`) | 0 | 1718 |
| C-R | `b7924fa6` | test(daemon): add Red integration tests for /export/*?inline=1 route | +9 (all Red — 404 / 403, except invalid-id which tolerantly passes) | n/a |
| C-G | _this commit_ | feat(daemon): wire GET /api/projects/:id/export/*?inline=1 endpoint | 0 net | 1727 |

Unit coverage (14 cases against the pure helper):

1. `<link rel=stylesheet>` inlined with verbatim CSS body
2. `<script src>` inlined preserving non-`src` attrs (`type=module`, `defer`, `crossorigin`)
3. Relative resolution for root + nested + deep-nested owners
4. Self-closing `<link …/>` form
5. Single-quoted attrs
6. Negative: tag without `rel` attribute
7. Negative: `rel="preload"`
8. Negative: absolute (`https:`, `http:`, `data:`, `blob:`, `mailto:`, `tel:`, `#`, leading-`/`) refs
9. `</style` escapes to `<\/style` inside CSS body
10. `</script` escapes to `<\/script` inside JS body
11. `fileReader` returning null leaves tag intact, other assets still inline
12. Duplicate identical tags both replaced (divergence per decision §8)
13. `data-od-inline-asset` attr HTML-escapes the href value
14. Deep-nested owner `a/b/c/index.html` + `../../shared/util.js` → `a/shared/util.js`

Integration coverage (9 cases against the live HTTP route):

1. 3-file React-ish layout returns single self-contained HTML — **wiring guard**: body assertions catch removal of the `await inlineRelativeAssets(...)` line in the route, not just helper-internals changes
2. Missing `inline` query → 400 `BAD_REQUEST`
3. Non-canonical inline values (`0` / `false` / `foo` / empty) → 400
4. Non-HTML file (`.css`) → 400 `UNSUPPORTED_FILE_TYPE`
5. Nonexistent file → 404 `FILE_NOT_FOUND`
6. Invalid project id (`..`) → 4xx (Express normalizes, then `isSafeId` catches whatever it routes)
7. Null-origin GET → 403 (pins decision §10)
8. Missing sibling asset → 200 with `<link>` tag intact, the script still inlined
9. Nested HTML entry (`pages/index.html` + `../shared/util.js`) → 200 inlined

# Verification

- `pnpm guard` — clean
- `pnpm typecheck` — full-repo, raw exit code 0
- `pnpm --filter @open-design/daemon test` — full daemon suite green, delta +23 tests
- Manual smoke: a 3-file project responds 200 with verbatim CSS+JS bodies; missing/non-HTML/missing-flag sad paths return the documented codes.

# Out of scope

- A web-side "Export self-contained HTML" button. The architecture comment framed this PR as the daemon-side primitive; UI surfacing belongs in a follow-up. Same shape as #451's "Continue in CLI" button living separately from the daemon endpoint it depends on.

Fixes #368.
