### PR TITLE
fix: rename Pets settings entry to 'Manage Pets'

### DIFF
--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1135,7 +1135,7 @@ export const en: Dict = {
   'pet.composerTitle': 'Pets — wake, tuck, or pick one',
   'pet.composerMenuTitle': 'Pets',
   'pet.composerMenuHint': 'tip: type /pet to toggle',
-  'pet.composerOpenSettings': 'Customize in Settings',
+  'pet.composerOpenSettings': 'Manage Pets',
   'pet.welcomeTeaserTitle': 'Adopt a pet',
   'pet.welcomeTeaserBody': 'A tiny floating companion that hangs out with you.',
   'pet.welcomeTeaserCta': 'Pick one',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1105,7 +1105,7 @@ export const zhCN: Dict = {
   'pet.composerTitle': '宠物 — 唤醒、收起或选一只',
   'pet.composerMenuTitle': '宠物',
   'pet.composerMenuHint': '小贴士：输入 /pet 即可切换',
-  'pet.composerOpenSettings': '在设置中自定义',
+  'pet.composerOpenSettings': '管理宠物',
   'pet.welcomeTeaserTitle': '领养一只宠物',
   'pet.welcomeTeaserBody': '一只小小的浮窗伙伴，会陪着你工作。',
   'pet.welcomeTeaserCta': '挑一只',


### PR DESCRIPTION
## Summary

This PR fixes issue #1250 by renaming the Pets settings menu entry from "Customize in Settings" to "Manage Pets" for better clarity and discoverability.

## Problem

The current menu entry label is misleading:
- **Current label**: "Customize in Settings" (English) / "在设置中自定义" (Chinese)
- **Problem**: Suggests a broad customization action
- **Reality**: Opens Settings directly on the Pets tab
- **Impact**: Users may not understand what this entry does

## Solution

Rename the menu entry to clearly indicate its purpose:
- **New label**: "Manage Pets" (English) / "管理宠物" (Chinese)
- **Benefit**: Matches the actual destination and intent
- **Result**: Improved discoverability and reduced confusion

## Changes

- ✅ Update `en.ts`: "Customize in Settings" → "Manage Pets"
- ✅ Update `zh-CN.ts`: "在设置中自定义" → "管理宠物"

## Technical Details

The translation key `pet.composerOpenSettings` is used in:
- `ChatComposer.tsx` (lines 1001 and 1289)
- Clicking triggers `onOpenPetSettings` function
- `openPetSettings` function (App.tsx:754-758) already works correctly:
  - Sets `setSettingsInitialSection("pet")` - navigates to Pets tab
  - Sets `setSettingsOpen(true)` - opens Settings dialog

This PR only updates the label text. The underlying navigation functionality is already correct.

## User Experience

**Before:**
- Menu shows: "Customize in Settings" ❌
- User thinks: "What am I customizing?"
- Unclear destination

**After:**
- Menu shows: "Manage Pets" ✅
- User thinks: "This manages my pets"
- Clear destination

## Files Modified

- `apps/web/src/i18n/locales/en.ts` (1 line)
- `apps/web/src/i18n/locales/zh-CN.ts` (1 line)

## References

- Closes #1250
- Priority: P2 (UX/information architecture)

---

现在 Pets 设置入口的标签更清晰了！✨