### PR TITLE
fix: restore input focus after creating project

### DIFF
--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -165,6 +165,7 @@ export function NewProjectPanel({
 }: Props) {
   const t = useT();
   const importInputRef = useRef<HTMLInputElement | null>(null);
+  const nameInputRef = useRef<HTMLInputElement | null>(null);
   const [importing, setImporting] = useState(false);
   const [baseDir, setBaseDir] = useState('');
   const [importingFolder, setImportingFolder] = useState(false);
@@ -472,6 +473,12 @@ export function NewProjectPanel({
       designSystemId: primaryDs,
       metadata,
     });
+    // Reset name and refocus input after project creation
+    setName('');
+    // Use setTimeout to ensure the focus happens after any state updates
+    setTimeout(() => {
+      nameInputRef.current?.focus();
+    }, 0);
   }
 
   async function handleImportPicked(ev: React.ChangeEvent<HTMLInputElement>) {
@@ -589,6 +596,7 @@ export function NewProjectPanel({
         </h3>
 
         <input
+          ref={nameInputRef}
           className="newproj-name"
           data-testid="new-project-name"
           placeholder={t('newproj.namePlaceholder')}


### PR DESCRIPTION
Fixes #1129

## Summary

After creating a project and then attempting to create another one, the name input field would not receive focus, making it appear unresponsive. This was especially noticeable after deleting a project and trying to create a new one.

## Changes

- Add `nameInputRef` to track the project name input element
- Reset `name` state to empty string after project creation
- Automatically refocus the input field after creation
- Use `setTimeout` to ensure focus happens after state updates

## Impact

This ensures the input is always ready for the next project creation without requiring a page refresh or manual clicking.

## Testing

1. Create a project
2. Delete the project (or just create another one)
3. Try to type in the project name input
4. Verify that the input is focused and accepts keyboard input immediately