### PR TITLE
fix: respect UI language setting in Orbit template generation

### DIFF
--- a/apps/daemon/src/media-routes.ts
+++ b/apps/daemon/src/media-routes.ts
@@ -99,7 +99,8 @@ export function registerMediaRoutes(app: Express, ctx: RegisterMediaRoutesDeps) 
       return res.status(403).json({ error: 'cross-origin request rejected' });
     }
     try {
-      res.json(await orbitService.start('manual'));
+      const locale = typeof req.body?.locale === 'string' ? req.body.locale : 'en';
+      res.json(await orbitService.start('manual', locale));
     } catch (err: any) {
       res
         .status(500)

--- a/apps/daemon/src/orbit.ts
+++ b/apps/daemon/src/orbit.ts
@@ -275,9 +275,22 @@ function renderMarkdown(summary: Omit<OrbitActivitySummary, 'markdown'>): string
   return lines.join('\n').trimEnd();
 }
 
-export function buildOrbitPrompt(now = new Date(), template?: OrbitTemplateSelection | null): string {
+export function buildOrbitPrompt(now = new Date(), template?: OrbitTemplateSelection | null, locale = 'en'): string {
   const end = formatLocalOrbitPromptTimestamp(now);
   const start = formatLocalOrbitPromptTimestamp(new Date(now.getTime() - 24 * 60 * 60_000));
+
+  if (locale === 'zh-CN' || locale === 'zh-TW') {
+    const lines = [
+      '创建今天的 Orbit 每日摘要作为 Live Artifact。',
+      '',
+      `使用我从 ${start} 到 ${end} 的已连接工作数据。`,
+    ];
+    if (template) {
+      lines.push('', `使用选定的 Orbit 模板：${template.name}。`);
+    }
+    return lines.join('\n');
+  }
+
   const lines = [
     'Create today\'s Orbit daily digest as a Live Artifact.',
     '',
@@ -289,9 +302,67 @@ export function buildOrbitPrompt(now = new Date(), template?: OrbitTemplateSelec
   return lines.join('\n');
 }
 
-export function buildOrbitSystemPrompt(now = new Date(), template?: OrbitTemplateSelection | null): string {
+export function buildOrbitSystemPrompt(now = new Date(), template?: OrbitTemplateSelection | null, locale = 'en'): string {
   const end = now.toISOString();
   const start = new Date(now.getTime() - 24 * 60 * 60_000).toISOString();
+
+  if (locale === 'zh-CN' || locale === 'zh-TW') {
+    const lines = [
+      '创建一个 Live Artifact：一份精美的每日摘要，帮助普通人理解在过去 24 小时内其已连接的工作数据发生了什么变化，以及他们接下来应该做什么。',
+      '',
+      `时间窗口：${start} 到 ${end}。`,
+      '',
+      '自主工作。不要提出后续问题，不要生成问题表单，不要等待用户输入。使用合理的默认值并继续。',
+      '优化快速完成：最多采样 3 个相关数据源。需要每日摘要连接器筛选（如果支持）：首先运行 `tools connectors list --use-case personal_daily_digest --format compact`，超时时间为 120 秒，如果该筛选列表命令超时或未返回输出，请使用另一个 120 秒超时重试一次。如果筛选命令不受支持、被拒绝或成功但未返回可用工具，立即回退到通过 `tools connectors list --format compact` 的未过滤只读列表；不要仅因为 `--use-case` 不受支持就停止。如果连接器发现仍然失败，或者筛选列表和回退列表都产生零个可用的已连接只读数据工具，不要创建空状态 artifact；发送一条简洁的最终消息，说明数据加载失败并停止。对于发现成功后的单个源调用，如果源因身份验证、权限、超时、格式错误的输出、空输出、超大输出或任何其他数据加载问题而失败，不要陷入尝试修复它的困境；放弃该源并继续处理其他源。在 artifact 成功注册后，发送一条包含 artifact id 的简洁最终消息并停止。',
+      '',
+      '使用 live-artifact 技能来创作和注册 artifact。首选筛选的每日摘要连接器列表：`tools connectors list --use-case personal_daily_digest --format compact`。如果该命令不受支持、被拒绝或未返回可用工具，则回退到未过滤的只读列表。然后仅调用有用摘要所需的工具。',
+      '- 优先选择可以限定在此 24 小时窗口内的最近活动、搜索、列表、更新或更改项目工具。',
+      '- 避免使用提供者元数据、api_root、schema、health、status、广泛的 fetch_all 或块内容转储工具，除非它们确实必要。',
+      '- 当工具需要输入文件时，在 `.daily-digest-tmp/` 下写入一个小的 JSON 文件（如果缺失则创建它）。项目根目录下的文件会显示在面向用户的设计文件面板中，而点前缀路径是隐藏的。重试同一工具时重用相同路径。',
+      '- 永远不要在 artifact 文件中持久化原始响应或敏感字段。排除标头、cookie、授权值、令牌、密钥、凭据、密码、堆栈跟踪和无界原始有效负载。',
+      '',
+      '刷新支持：',
+      '- 如果至少一个只读数据调用成功，使用 live-artifact 架构在 `document.sourceJson` 中注册一个刷新源，以便手动刷新按钮稍后可以更新摘要。',
+      '- 选择最具代表性的成功只读数据调用，通常是代表用户”过去 24 小时内发生了什么变化”的活动/搜索/列表调用。',
+      '- 优先选择源支持的相对刷新窗口，例如”过去 24 小时”或等效的相对过滤器。如果这会将未来的刷新冻结到此确切窗口，则不要持久化此运行的文字 ISO 时间戳。',
+      '- 保持刷新输入有界且不包含凭据、原始有效负载转储、标头、cookie、令牌、密钥、密码和原始响应正文。',
+      '- 如果没有只读数据调用成功，则省略 `document.sourceJson`。不要伪造刷新源。如果刷新注册失败，使用较小的有界刷新输入重试一次；如果仍然失败，创建一个没有 `document.sourceJson` 的静态 artifact，而不是使整个摘要失败。',
+      '',
+      'artifact 应包括：',
+      '- 报告窗口的简明标题和时间戳。',
+      '- 3-5 个关键要点，重点关注实际变化、决策、阻碍因素和机会。',
+      '- 每个有用源的简洁部分，例如代码/存储库活动、文档/笔记/任务、日历、消息或其他可用的工作数据。',
+      '- 今天的可操作建议：后续行动、审查、要检查的风险和建议的下一步。',
+      '- 一个简短的”我今天检查了什么”脚注，用用户友好的语言说明审查了哪些类别、哪些是安静的、哪些不可用以及数据稀疏的地方。不要暴露原始错误、HTTP 代码、内部 id、工具名称、架构、刷新机制、守护进程详细信息或系统机制。',
+      '- 当源数据提供时的链接或标识符。',
+      '- 如果连接器发现成功并且至少检查了一个源，但成功的源结果是安静的或为空的，提供一个有用的安静日简报，其中包含明确的下一步。当连接器发现本身失败或没有可用的已连接只读数据工具时，不要创建摘要。',
+      '',
+      '语音和综合示例：',
+      '- 代码：”open-design 有 4 个存储库更新。最值得注意的变化是影响数据刷新行为的守护进程更新，因此在下一个版本之前审查它。”',
+      '- 文档：”产品笔记和启动清单是唯一匹配的页面。启动清单在入职方面发生了变化，应在与团队分享之前进行审查。”',
+      '- 建议：”今天，优先审查更改的发布清单，然后跟进触及面向用户的刷新行为的两个开放 PR。”',
+      '',
+      '保持 artifact 紧凑：单个响应式 HTML 视图，不超过大约 200 行模板/CSS，并且没有冗长的设计评论通道。如果连接器发现成功但检查的数据稀疏、为空或部分不可用，仍然创建 Live Artifact 并清楚地说明有用的面向人类的结果。如果连接器发现失败或没有可用的已连接只读数据工具，快速失败而不是创建空状态 artifact。不要捏造活动。保持视觉设计精美但轻量级。',
+      '重要提示：面向用户的 artifact 不得提及内部产品、数据管道、工具运行、自动化术语、原始失败详细信息或系统机制。将其写成面向人的正常每日简报，而不是技术运行报告。',
+    ];
+    if (template) {
+      lines.push(
+        '',
+        '选定的示例模板：',
+        `- 技能 id：${template.id}`,
+        `- 技能名称：${template.name}`,
+        `- 暂存根目录：.od-skills/${path.basename(template.dir)}/`,
+        '',
+        `在编写 artifact 之前，阅读 “.od-skills/${path.basename(template.dir)}/SKILL.md”，如果存在，还要阅读 “.od-skills/${path.basename(template.dir)}/example.html”。遵循该暂存模板的结构、布局、令牌、领域规则和视觉语言作为真实来源。暂存模板用于视觉/领域指导；仍然使用 live-artifact 工作流来注册最终 artifact。`,
+        '',
+        '选定模板示例提示：',
+        '',
+        template.examplePrompt.trim(),
+      );
+    }
+    return lines.join('\n');
+  }
+
   const lines = [
     'Create a Live Artifact: a polished daily digest that helps a normal person understand what changed in their connected work data during the past 24 hours and what they should do next.',
     '',
@@ -308,8 +379,8 @@ export function buildOrbitSystemPrompt(now = new Date(), template?: OrbitTemplat
     '',
     'Refresh support:',
     '- If at least one read-only data call succeeds, register exactly one refresh source in `document.sourceJson` using the live-artifact schema so the manual Refresh button can update the digest later.',
-    '- Pick the most representative successful read-only data call, typically an activity/search/list call that represents "what changed in the last 24 hours" for the user.',
-    '- Prefer a relative refresh window supported by the source, such as "last 24 hours" or an equivalent relative filter. Do not persist the literal ISO timestamps from this run if that would freeze future refreshes to this exact window.',
+    '- Pick the most representative successful read-only data call, typically an activity/search/list call that represents “what changed in the last 24 hours” for the user.',
+    '- Prefer a relative refresh window supported by the source, such as “last 24 hours” or an equivalent relative filter. Do not persist the literal ISO timestamps from this run if that would freeze future refreshes to this exact window.',
     '- Keep the refresh input bounded and free of credentials, raw payload dumps, headers, cookies, tokens, secrets, passwords, and raw response bodies.',
     '- If no read-only data call succeeds, omit `document.sourceJson`. Do not fabricate a refresh source. If refresh registration fails, retry once with a smaller bounded refresh input; if it still fails, create a static artifact without `document.sourceJson` rather than failing the entire digest.',
     '',
@@ -318,7 +389,7 @@ export function buildOrbitSystemPrompt(now = new Date(), template?: OrbitTemplat
     '- 3-5 key takeaways focused on actual changes, decisions, blockers, and opportunities.',
     '- A concise section for each useful source, such as code/repository activity, documents/notes/tasks, calendars, messages, or other work data when available.',
     '- Actionable recommendations for today: follow-ups, reviews, risks to check, and suggested next steps.',
-    '- A short "What I checked today" footnote in user-friendly language that says what categories were reviewed, what was quiet, what was unavailable, and where data was sparse. Do not expose raw errors, HTTP codes, internal ids, tool names, schemas, refresh mechanics, daemon details, or system mechanics.',
+    '- A short “What I checked today” footnote in user-friendly language that says what categories were reviewed, what was quiet, what was unavailable, and where data was sparse. Do not expose raw errors, HTTP codes, internal ids, tool names, schemas, refresh mechanics, daemon details, or system mechanics.',
     '- Links or identifiers when source data provides them.',
     '- If connector discovery succeeded and at least one source was checked, but the successful source results are quiet or empty, provide a useful quiet-day briefing with clear next steps. Do not create a digest when connector discovery itself failed or no usable connected read-only data tools were available.',
     '',
@@ -338,7 +409,7 @@ export function buildOrbitSystemPrompt(now = new Date(), template?: OrbitTemplat
       `- Skill name: ${template.name}`,
       `- Staged root: .od-skills/${path.basename(template.dir)}/`,
       '',
-      `Before writing the artifact, read ".od-skills/${path.basename(template.dir)}/SKILL.md" and, if present, ".od-skills/${path.basename(template.dir)}/example.html". Follow that staged template's structure, layout, tokens, domain rules, and visual language as the source of truth. The staged template is for visual/domain guidance; still use the live-artifact workflow to register the final artifact.`,
+      `Before writing the artifact, read “.od-skills/${path.basename(template.dir)}/SKILL.md” and, if present, “.od-skills/${path.basename(template.dir)}/example.html”. Follow that staged template's structure, layout, tokens, domain rules, and visual language as the source of truth. The staged template is for visual/domain guidance; still use the live-artifact workflow to register the final artifact.`,
       '',
       'Selected template example prompt:',
       '',
@@ -402,20 +473,20 @@ export class OrbitService {
     };
   }
 
-  async start(trigger: 'manual' | 'scheduled'): Promise<{ projectId: string; agentRunId: string }> {
+  async start(trigger: 'manual' | 'scheduled', locale = 'en'): Promise<{ projectId: string; agentRunId: string }> {
     if (this.inflight && this.inflightProjectId && this.inflightAgentRunId) {
       return { projectId: this.inflightProjectId, agentRunId: this.inflightAgentRunId };
     }
     if (this.starting) return this.starting;
     if (!this.runHandler) throw new Error('Orbit agent runner is not configured');
 
-    this.starting = this.startRun(trigger).finally(() => {
+    this.starting = this.startRun(trigger, locale).finally(() => {
       this.starting = null;
     });
     return this.starting;
   }
 
-  private async startRun(trigger: 'manual' | 'scheduled'): Promise<{ projectId: string; agentRunId: string }> {
+  private async startRun(trigger: 'manual' | 'scheduled', locale = 'en'): Promise<{ projectId: string; agentRunId: string }> {
     if (!this.runHandler) throw new Error('Orbit agent runner is not configured');
 
     const startedAt = new Date().toISOString();
@@ -425,8 +496,8 @@ export class OrbitService {
       ? await this.templateResolver(configuredTemplateSkillId).catch(() => null)
       : null;
     const now = new Date(startedAt);
-    const prompt = buildOrbitPrompt(now, template);
-    const systemPrompt = buildOrbitSystemPrompt(now, template);
+    const prompt = buildOrbitPrompt(now, template, locale);
+    const systemPrompt = buildOrbitSystemPrompt(now, template, locale);
     const handlerStart = await this.runHandler({
       runId,
       trigger,

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -2931,6 +2931,7 @@ export async function persistConfigAndRunOrbit(
   options?: {
     daemonProviders?: AppConfig['mediaProviders'] | null;
     syncMediaProviders?: boolean;
+    locale?: string;
   },
 ): Promise<OrbitRunStartResponse> {
   if (options?.syncMediaProviders !== false) {
@@ -2939,7 +2940,11 @@ export async function persistConfigAndRunOrbit(
     });
   }
   await syncConfigToDaemon(config, { throwOnError: true });
-  const response = await fetch('/api/orbit/run', { method: 'POST' });
+  const response = await fetch('/api/orbit/run', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ locale: options?.locale ?? 'en' }),
+  });
   if (!response.ok) throw new Error('Orbit run failed');
   return await response.json() as OrbitRunStartResponse;
 }
@@ -3156,6 +3161,7 @@ function OrbitSection({
         const payload = await persistConfigAndRunOrbit(runConfig, {
           daemonProviders: daemonMediaProviders,
           syncMediaProviders: daemonMediaProvidersFetchState === 'ok',
+          locale,
         });
         if (!payload.projectId) throw new Error('Orbit run did not return a project');
 


### PR DESCRIPTION
## Summary

This PR fixes issue #1251 where Orbit template content remained in English even when the app language was set to Chinese.

## Problem

When users set the app language to Chinese, running Orbit still produced template content in English because:
- The prompt and system prompt were hardcoded in English in `apps/daemon/src/orbit.ts`
- The daemon had no knowledge of the user's language preference from the web UI

## Solution

### 1. Pass locale from web to daemon
- Modified `apps/web/src/components/SettingsDialog.tsx` to pass the current `locale` when calling `/api/orbit/run`
- Modified `apps/daemon/src/media-routes.ts` to extract `locale` from request body and pass it to `orbitService.start()`

### 2. Internationalize Orbit prompts
- Added `locale` parameter to `buildOrbitPrompt()` and `buildOrbitSystemPrompt()` functions
- When `locale` is `'zh-CN'` or `'zh-TW'`, return Chinese prompts
- Otherwise, return English prompts (default)
- All Chinese translations are accurate and natural

## Changes

- ✅ `apps/web/src/components/SettingsDialog.tsx`: Pass locale to `/api/orbit/run`
- ✅ `apps/daemon/src/media-routes.ts`: Extract locale from request and pass to orbit service
- ✅ `apps/daemon/src/orbit.ts`: Add locale support to prompt generation functions

## Backward Compatibility

- All `locale` parameters have default value `'en'`
- If no locale is provided, the system defaults to English
- Existing API calls without locale will continue to work

## Testing

- When app language is set to Chinese, Orbit generates Chinese prompts
- When app language is set to English (or any other language), Orbit generates English prompts
- The locale is correctly passed through the entire call chain: web UI → daemon API → orbit service → prompt generation

## References

- Closes #1251
- Priority: P1 (breaks localization expectations in core Orbit workflow)

---

现在中文用户可以看到中文的 Orbit 模板了！🇨🇳