### PR TITLE
fix: add toast feedback when saving templates

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -81,6 +81,7 @@ import {
 } from '../edit-mode/source-patches';
 import type { ManualEditBridgeMessage, ManualEditHistoryEntry, ManualEditPatch, ManualEditTarget } from '../edit-mode/types';
 import { isRenderableSketchJson, SketchPreview } from './SketchPreview';
+import { Toast } from './Toast';
 
 type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => string;
 type SlideState = { active: number; count: number };
@@ -2968,6 +2969,7 @@ function HtmlViewer({
   const [templateName, setTemplateName] = useState('');
   const [templateDescription, setTemplateDescription] = useState('');
   const [templateSaveError, setTemplateSaveError] = useState<string | null>(null);
+  const [templateToast, setTemplateToast] = useState<{ message: string; isError: boolean } | null>(null);
   const [deployment, setDeployment] = useState<WebDeploymentInfo | null>(null);
   const [deploymentsByProvider, setDeploymentsByProvider] = useState<Partial<Record<WebDeployProviderId, WebDeploymentInfo>>>({});
   const [deployModalOpen, setDeployModalOpen] = useState(false);
@@ -3936,6 +3938,7 @@ function HtmlViewer({
     setSavingTemplate(true);
     setTemplateNote(null);
     setTemplateSaveError(null);
+    setTemplateToast(null);
     let savedName: string | null = null;
     try {
       const tpl = await saveTemplate({
@@ -3944,14 +3947,18 @@ function HtmlViewer({
         sourceProjectId: projectId,
       });
       if (!tpl) {
-        setTemplateSaveError(t('fileViewer.savedTemplateFail'));
+        const errorMsg = t('fileViewer.savedTemplateFail');
+        setTemplateSaveError(errorMsg);
+        setTemplateToast({ message: errorMsg, isError: true });
         return;
       }
       savedName = tpl.name;
+      const successMsg = t('fileViewer.savedTemplate', { name: tpl.name });
+      setTemplateToast({ message: successMsg, isError: false });
       setTemplateModalOpen(false);
       setTemplateName('');
       setTemplateDescription('');
-      setTemplateNote(t('fileViewer.savedTemplate', { name: tpl.name }));
+      setTemplateNote(successMsg);
     } finally {
       setSavingTemplate(false);
       if (savedName) {
@@ -5240,6 +5247,12 @@ function HtmlViewer({
             </div>
           </div>
         </div>
+      ) : null}
+      {templateToast ? (
+        <Toast
+          message={templateToast.message}
+          onDismiss={() => setTemplateToast(null)}
+        />
       ) : null}
     </div>
   );


### PR DESCRIPTION
## Summary

This PR fixes issue #1190 where users received no clear feedback when saving an artifact as a template.

## Problem

When saving an artifact as a template:
- The modal closes immediately on success, leaving users uncertain whether the save succeeded
- No visible confirmation appears
- Users cannot tell if the operation completed, is still running, or failed silently

## Solution

Add Toast notifications for both success and failure cases:

### Success Flow
1. User clicks Save
2. Modal closes immediately
3. Toast appears: "Saved as {template name}"
4. Toast auto-dismisses after 4 seconds

### Failure Flow
1. User clicks Save
2. Modal stays open
3. Toast appears with error message
4. Inline error also displays in the modal
5. User can retry

## Changes

- ✅ Import Toast component (already exists in the project)
- ✅ Add `templateToast` state to track message and error status
- ✅ Update `handleSaveAsTemplate()` to set toast on success/failure
- ✅ Render Toast component at end of HtmlViewer
- ✅ Reuse existing translation keys (`fileViewer.savedTemplate`, `fileViewer.savedTemplateFail`)

## Technical Details

```typescript
// New state
const [templateToast, setTemplateToast] = useState<{ message: string; isError: boolean } | null>(null);

// Success case
const successMsg = t('fileViewer.savedTemplate', { name: tpl.name });
setTemplateToast({ message: successMsg, isError: false });
setTemplateModalOpen(false); // Close modal immediately

// Failure case
const errorMsg = t('fileViewer.savedTemplateFail');
setTemplateSaveError(errorMsg); // Inline error
setTemplateToast({ message: errorMsg, isError: true }); // Toast
// Modal stays open for retry
```

## User Experience

**Before:**
- Save → [modal closes] → ❌ no feedback

**After:**
- Save → [modal closes] → ✅ Toast: "Saved as {name}" (4s)
- Save (error) → [modal stays open] → ✅ Toast + inline error

## Testing

- When save succeeds, modal closes and toast shows success message
- When save fails, modal stays open and both toast and inline error appear
- Toast auto-dismisses after 4 seconds
- Users can retry after failure without reopening the modal

## References

- Closes #1190
- Priority: P2 (affects user confidence in template saving)

---

现在用户可以清楚地看到模板保存的结果了！✨