### PR TITLE
style(web): polish EntryView UI — sidebar layout, folder tabs, slim form, blue selected token

### DIFF
--- a/apps/web/src/components/EntryView.tsx
+++ b/apps/web/src/components/EntryView.tsx
@@ -258,8 +258,6 @@ export function EntryView({
   const [connectors, setConnectors] = useState<ConnectorDetail[]>([]);
   const [connectorsLoading, setConnectorsLoading] = useState(false);
   const [petRailHidden, setPetRailHiddenState] = useState<boolean>(() => loadPetRailHidden());
-  const [avatarMenuOpen, setAvatarMenuOpen] = useState(false);
-  const avatarMenuRef = useRef<HTMLDivElement | null>(null);
 
   function setPetRailHidden(next: boolean) {
     setPetRailHiddenState(next);
@@ -394,79 +392,6 @@ export function EntryView({
     return () => window.removeEventListener('focus', onFocus);
   }, [reloadConnectorStatuses]);
 
-  // Dismiss the avatar dropdown on outside-click / Escape so it behaves
-  // like the project-view AvatarMenu (which uses the same shell CSS).
-  useEffect(() => {
-    if (!avatarMenuOpen) return;
-    const onClick = (e: MouseEvent) => {
-      if (!avatarMenuRef.current) return;
-      if (!avatarMenuRef.current.contains(e.target as Node)) {
-        setAvatarMenuOpen(false);
-      }
-    };
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setAvatarMenuOpen(false);
-    };
-    document.addEventListener('mousedown', onClick);
-    document.addEventListener('keydown', onKey);
-    return () => {
-      document.removeEventListener('mousedown', onClick);
-      document.removeEventListener('keydown', onKey);
-    };
-  }, [avatarMenuOpen]);
-
-  const avatarMenu = (
-    <div className="avatar-menu" ref={avatarMenuRef}>
-      <button
-        type="button"
-        className="settings-icon-btn"
-        onClick={() => setAvatarMenuOpen((v) => !v)}
-        title={t('entry.openSettingsTitle')}
-        aria-label={t('entry.openSettingsAria')}
-        aria-haspopup="menu"
-        aria-expanded={avatarMenuOpen}
-      >
-        <Icon name="settings" size={17} />
-      </button>
-      {avatarMenuOpen ? (
-        <div className="avatar-popover" role="menu">
-          <button
-            type="button"
-            className="avatar-item"
-            onClick={() => {
-              setPetRailHidden(!petRailHidden);
-              setAvatarMenuOpen(false);
-            }}
-          >
-            <span className="avatar-item-icon" aria-hidden>
-              <Icon name={petRailHidden ? 'sparkles' : 'eye'} size={14} />
-            </span>
-            <span>
-              {petRailHidden
-                ? t('pet.railShow')
-                : t('pet.railHide')}
-            </span>
-          </button>
-          <div style={{ height: 1, background: 'var(--border-soft)', margin: '4px 6px' }} />
-          <button
-            type="button"
-            className="avatar-item"
-            onClick={() => {
-              setAvatarMenuOpen(false);
-              onOpenSettings();
-            }}
-          >
-            <span className="avatar-item-icon" aria-hidden>
-              <Icon name="settings" size={14} />
-            </span>
-            <span>{t('avatar.settings')}</span>
-            <span className="avatar-item-meta">{isMacPlatform() ? '⌘,' : 'Ctrl+,'}</span>
-          </button>
-        </div>
-      ) : null}
-    </div>
-  );
-
   return (
     <div className="entry-shell">
       <div
@@ -525,30 +450,42 @@ export function EntryView({
           </button>
           <div className="entry-side-foot-row">
             <LanguageMenu />
-            <button
-              type="button"
-              className={`foot-pill pet-pill${config.pet?.adopted ? '' : ' pet-pill-fresh'}`}
-              onClick={onAdoptPet}
-              title={
-                config.pet?.adopted
-                  ? t('pet.changePet')
-                  : t('pet.adoptCallout')
-              }
-            >
-              <span className="pet-pill-glyph" aria-hidden>
-                {config.pet?.adopted
-                  ? config.pet.petId === 'custom'
-                    ? config.pet.custom.glyph || '🦄'
-                    : '🐾'
-                  : '🐾'}
-              </span>
-              <span className="foot-pill-pet-label">
-                {config.pet?.adopted
-                  ? t('pet.changePet')
-                  : t('pet.adoptCallout')}
-              </span>
-              {!config.pet?.adopted ? <span className="pet-pill-dot" aria-hidden /> : null}
-            </button>
+            <div className={`foot-pill pet-pill${config.pet?.adopted ? '' : ' pet-pill-fresh'}`}>
+              <button
+                type="button"
+                className="pet-pill-main"
+                onClick={onAdoptPet}
+                title={
+                  config.pet?.adopted
+                    ? t('pet.changePet')
+                    : t('pet.adoptCallout')
+                }
+              >
+                <span className="pet-pill-glyph" aria-hidden>
+                  {config.pet?.adopted
+                    ? config.pet.petId === 'custom'
+                      ? config.pet.custom.glyph || '🦄'
+                      : '🐾'
+                    : '🐾'}
+                </span>
+                <span className="foot-pill-pet-label">
+                  {config.pet?.adopted
+                    ? t('pet.changePet')
+                    : t('pet.adoptCallout')}
+                </span>
+                {!config.pet?.adopted ? <span className="pet-pill-dot" aria-hidden /> : null}
+              </button>
+              <span className="pet-pill-divider" aria-hidden />
+              <button
+                type="button"
+                className="pet-pill-toggle"
+                onClick={() => setPetRailHidden(!petRailHidden)}
+                aria-label={petRailHidden ? t('pet.railShow') : t('pet.railHide')}
+                title={petRailHidden ? t('pet.railShow') : t('pet.railHide')}
+              >
+                <Icon name={petRailHidden ? 'eye' : 'eye-off'} size={12} />
+              </button>
+            </div>
             <a
               className="foot-pill foot-pill-follow"
               href="https://x.com/nexudotio"

--- a/apps/web/src/components/EntryView.tsx
+++ b/apps/web/src/components/EntryView.tsx
@@ -21,7 +21,6 @@ import { DesignsTab } from './DesignsTab';
 import { DesignSystemPreviewModal } from './DesignSystemPreviewModal';
 import { DesignSystemsTab } from './DesignSystemsTab';
 import { ExamplesTab } from './ExamplesTab';
-import { AppChromeHeader } from './AppChromeHeader';
 import { Icon } from './Icon';
 import { LanguageMenu } from './LanguageMenu';
 import { CenteredLoader } from './Loading';
@@ -34,7 +33,6 @@ import { PetRail } from './pet/PetRail';
 import { PromptTemplatePreviewModal } from './PromptTemplatePreviewModal';
 import { PromptTemplatesTab } from './PromptTemplatesTab';
 import { apiProtocolLabel } from '../utils/apiProtocol';
-import { isMacPlatform } from '../utils/platform';
 
 type TopTab = 'designs' | 'templates' | 'design-systems' | 'image-templates' | 'video-templates';
 

--- a/apps/web/src/components/EntryView.tsx
+++ b/apps/web/src/components/EntryView.tsx
@@ -469,7 +469,6 @@ export function EntryView({
 
   return (
     <div className="entry-shell">
-      <AppChromeHeader actions={avatarMenu} />
       <div
         className={`entry${petRailHidden ? '' : ' has-pet-rail'}`}
         style={{
@@ -479,6 +478,16 @@ export function EntryView({
         }}
       >
       <aside className="entry-side" style={{ width: sidebarWidth }}>
+        <div className="entry-brand">
+          <span className="entry-brand-mark" aria-hidden>
+            <img src="/app-icon.svg" alt="" className="brand-mark-img" draggable={false} />
+          </span>
+          <div className="entry-brand-text">
+            <div className="entry-brand-title-row">
+              <span className="entry-brand-title">{t('app.brand')}</span>
+            </div>
+          </div>
+        </div>
         <NewProjectPanel
           skills={skills}
           designSystems={designSystems}
@@ -496,7 +505,26 @@ export function EntryView({
           loading={skillsLoading || designSystemsLoading}
         />
         <div className="entry-side-foot">
+          <button
+            type="button"
+            className="foot-pill foot-pill-env"
+            onClick={() => onOpenSettings()}
+            aria-label={t('settings.envConfigure')}
+            title={t('settings.envConfigure')}
+          >
+            <Icon name="settings" size={12} />
+            <span>
+              {config.mode === 'daemon'
+                ? t('settings.localCli')
+                : apiProtocolLabel(config.apiProtocol)}
+            </span>
+            <span style={{ color: 'var(--text-faint)' }}>·</span>
+            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 180 }}>
+              {envMetaLine}
+            </span>
+          </button>
           <div className="entry-side-foot-row">
+            <LanguageMenu />
             <button
               type="button"
               className={`foot-pill pet-pill${config.pet?.adopted ? '' : ' pet-pill-fresh'}`}
@@ -530,28 +558,8 @@ export function EntryView({
               aria-label="Follow @nexudotio on X"
             >
               <Icon name="external-link" size={12} />
-              <span className="foot-pill-follow-label">Follow @nexudotio</span>
             </a>
           </div>
-          <button
-            type="button"
-            className="foot-pill"
-            onClick={() => onOpenSettings()}
-            aria-label={t('settings.envConfigure')}
-            title={t('settings.envConfigure')}
-          >
-            <Icon name="settings" size={12} />
-            <span>
-              {config.mode === 'daemon'
-                ? t('settings.localCli')
-                : apiProtocolLabel(config.apiProtocol)}
-            </span>
-            <span style={{ color: 'var(--text-faint)' }}>·</span>
-            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 180 }}>
-              {envMetaLine}
-            </span>
-          </button>
-          <LanguageMenu />
         </div>
         <button
           type="button"

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -52,10 +52,13 @@
   --shadow-md: 0 6px 24px rgba(28, 27, 26, 0.07), 0 2px 6px rgba(28, 27, 26, 0.04);
   --shadow-lg: 0 24px 60px rgba(28, 27, 26, 0.16), 0 8px 16px rgba(28, 27, 26, 0.07);
 
-  --radius-sm: 6px;
-  --radius: 10px;
-  --radius-lg: 14px;
+  --radius-sm: 8px;
+  --radius: 12px;
+  --radius-lg: 16px;
   --radius-pill: 999px;
+
+  --selected: #2563eb;
+  --selected-soft: rgba(37, 99, 235, 0.16);
 
   --serif: 'Source Serif Pro', 'Source Serif 4', 'Iowan Old Style', 'Apple Garamond', Georgia, 'Times New Roman', serif;
   --sans: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -3656,7 +3656,7 @@ code {
    ============================================================ */
 .entry-shell {
   display: grid;
-  grid-template-rows: auto 1fr;
+  grid-template-rows: 1fr;
   height: 100vh;
   min-height: 0;
   background: var(--bg);
@@ -3672,7 +3672,7 @@ code {
 
 .entry-side {
   border-right: 1px solid var(--border);
-  background: var(--bg-panel);
+  background: transparent;
   display: flex;
   flex-direction: column;
 }
@@ -3681,10 +3681,16 @@ code {
   display: flex;
   align-items: center;
   gap: 12px;
+  padding: 24px 20px 18px;
+}
+.entry-brand-actions {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
 }
 .entry-brand-mark {
-  width: 44px;
-  height: 44px;
+  width: 34px;
+  height: 34px;
   border-radius: 50%;
   background: linear-gradient(135deg, var(--accent-tint) 0%, var(--accent-soft) 100%);
   color: var(--accent);
@@ -3711,11 +3717,11 @@ code {
 }
 .entry-brand-title {
   font-family: var(--serif);
-  font-weight: 600;
+  font-weight: 450;
   font-size: 22px;
   letter-spacing: -0.015em;
   line-height: 1;
-  color: var(--text-strong);
+  color: var(--text);
 }
 .entry-brand-pill {
   font-size: 10.5px;
@@ -4792,12 +4798,14 @@ code {
 .entry-side-foot .foot-pill {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 4px 10px;
+  justify-content: center;
+  gap: 5px;
+  padding: 3px 8px;
+  min-height: 24px;
   background: var(--bg-subtle);
   border: 1px solid var(--border);
   border-radius: var(--radius-pill);
-  font-size: 11.5px;
+  font-size: 10.5px;
   color: var(--text-muted);
   align-self: flex-start;
   cursor: pointer;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -57,6 +57,12 @@
   --radius-lg: 16px;
   --radius-pill: 999px;
 
+  /* "Active option" indicator color, intentionally separate from --accent
+     (brand orange used by primary CTAs like Create / Save). Use --selected
+     for "this option is the one currently picked" affordances — selected
+     fidelity card, focused input ring, active filter pill — so a primary
+     CTA and a selected state can coexist on the same screen without
+     competing. --selected-soft is the 16% tint for outer rings / fills. */
   --selected: #2563eb;
   --selected-soft: rgba(37, 99, 235, 0.16);
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -12692,15 +12692,61 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
 /* ----- Entry sidebar adopt pill ----- */
 .pet-pill {
   position: relative;
+  height: 24px;
+  padding: 0;
+  gap: 0;
+  cursor: default;
 }
 .pet-pill .pet-pill-glyph {
-  font-size: 14px;
+  font-size: 12px;
   line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  width: 14px;
+  height: 14px;
+  justify-content: center;
+}
+.pet-pill > .pet-pill-main,
+.pet-pill > .pet-pill-toggle {
+  display: inline-flex;
+  align-items: center;
+  align-self: stretch;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  padding: 0 7px;
+}
+.pet-pill > .pet-pill-main {
+  gap: 5px;
+  border-radius: var(--radius-pill) 0 0 var(--radius-pill);
+}
+.pet-pill > .pet-pill-toggle {
+  justify-content: center;
+  padding: 0 7px;
+  border-radius: 0 var(--radius-pill) var(--radius-pill) 0;
+  color: var(--text-muted);
+}
+.pet-pill > .pet-pill-main:hover,
+.pet-pill > .pet-pill-toggle:hover {
+  background: var(--bg-panel);
+  color: var(--text);
+}
+.pet-pill-divider {
+  width: 1px;
+  align-self: stretch;
+  margin: 4px 0;
+  background: var(--border);
 }
 .pet-pill-fresh {
   border-color: var(--accent);
   color: var(--text);
   background: var(--accent-tint);
+}
+.pet-pill-fresh > .pet-pill-divider {
+  background: var(--accent);
+  opacity: 0.35;
 }
 .pet-pill-fresh:hover {
   background: var(--accent-soft);

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -3832,12 +3832,17 @@ code {
   transition: none;
 }
 .newproj-tab:focus,
-.newproj-tab:focus-visible,
 .newproj-tab:active {
   background: transparent;
   border-color: transparent;
   outline: none;
   color: var(--text-muted);
+}
+.newproj-tab:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px var(--selected);
+  border-radius: 8px 8px 0 0;
+  color: var(--text);
 }
 .newproj-tab:hover:not(:disabled) {
   background: transparent;
@@ -4954,13 +4959,18 @@ code {
   transition: none;
 }
 .entry-tab:focus,
-.entry-tab:focus-visible,
 .entry-tab:active {
   background: transparent;
   border-color: transparent;
   border-bottom-color: transparent;
   outline: none;
   color: var(--text-muted);
+}
+.entry-tab:focus-visible {
+  outline: 2px solid var(--selected);
+  outline-offset: 2px;
+  border-radius: 4px;
+  color: var(--text);
 }
 .entry-tab:hover:not(:disabled) {
   background: transparent;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -247,8 +247,8 @@ input, textarea, select {
 input::placeholder, textarea::placeholder { color: var(--text-faint); }
 input:focus, textarea:focus, select:focus {
   outline: none;
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px var(--accent-soft);
+  border-color: var(--border-strong);
+  box-shadow: none;
 }
 /* Native <select> on macOS uses its own intrinsic min-height that ends up
    shorter than <input> at the same `padding: 7px 10px` rule above, so any
@@ -4211,10 +4211,10 @@ code {
 }
 .fidelity-card:hover { border-color: var(--border-strong); }
 .fidelity-card.active {
-  border-color: var(--accent);
+  border-color: var(--selected);
   box-shadow:
-    0 0 0 1px var(--accent),
-    0 1px 0 rgba(180, 90, 59, 0.04);
+    0 0 0 1px var(--selected),
+    0 1px 0 rgba(37, 99, 235, 0.04);
 }
 .fidelity-thumb {
   display: block;
@@ -4227,7 +4227,7 @@ code {
 }
 .fidelity-thumb-wireframe { background: #fbfaf6; }
 .fidelity-thumb-high-fidelity { background: var(--bg-panel); }
-.fidelity-card.active .fidelity-thumb { border-color: var(--accent-soft); }
+.fidelity-card.active .fidelity-thumb { border-color: var(--selected-soft); }
 .fidelity-label {
   text-align: center;
   font-size: 12px;
@@ -6404,7 +6404,7 @@ button.connector-action.is-loading {
   padding: 3px;
   background: var(--bg-subtle);
   border: 1px solid var(--border);
-  border-radius: var(--radius-pill);
+  border-radius: var(--radius);
   gap: 2px;
   max-width: 100%;
   overflow-x: auto;
@@ -6414,7 +6414,7 @@ button.connector-action.is-loading {
 .subtab-pill button {
   background: transparent;
   border: none;
-  border-radius: var(--radius-pill);
+  border-radius: var(--radius-sm);
   padding: 5px 16px;
   font-size: 12px;
   color: var(--text-muted);
@@ -6423,8 +6423,8 @@ button.connector-action.is-loading {
 }
 .subtab-pill button:hover:not(.active) { background: rgba(255,255,255,0.6); border-color: transparent; color: var(--text); }
 .subtab-pill button.active {
-  background: var(--text);
-  color: var(--bg);
+  background: var(--bg-panel);
+  color: var(--text);
   box-shadow: var(--shadow-xs);
 }
 /* Icon-only variant: any pill button whose sole child is an SVG icon.

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -3865,7 +3865,12 @@ code {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  flex: 0 0 auto;
+  /* The parent `.newproj` is `overflow: hidden`; the card needs to be the
+     scroll container so taller form variants (image/media tabs, validation
+     messages, compact-height windows) stay reachable inside the sidebar. */
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
 }
 .newproj-title {
   margin: 0;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -3869,8 +3869,8 @@ code {
 }
 .newproj-title {
   margin: 0;
-  font-size: 14px;
-  font-weight: 600;
+  font-size: 13px;
+  font-weight: 550;
   display: flex;
   align-items: center;
   gap: 8px;
@@ -4137,8 +4137,8 @@ code {
   justify-content: center;
   gap: 8px;
   width: 100%;
-  padding: 11px;
-  margin-top: 4px;
+  padding: 8px 11px;
+  margin-top: 2px;
   font-size: 13px;
   border-radius: var(--radius-sm);
 }
@@ -4148,7 +4148,7 @@ code {
   justify-content: center;
   gap: 8px;
   width: 100%;
-  padding: 10px;
+  padding: 6px 10px;
   font-size: 12.5px;
   border-radius: var(--radius-sm);
 }
@@ -4183,7 +4183,7 @@ code {
   opacity: 0.7;
 }
 .newproj-footer {
-  padding: 0 24px 16px;
+  padding: 12px 24px 16px;
   font-size: 11px;
   color: var(--text-muted);
   text-align: center;
@@ -4201,8 +4201,8 @@ code {
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  gap: 8px;
-  padding: 10px 10px 12px;
+  gap: 6px;
+  padding: 8px 8px 10px;
   background: var(--bg-panel);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
@@ -4219,7 +4219,7 @@ code {
 .fidelity-thumb {
   display: block;
   width: 100%;
-  aspect-ratio: 12 / 7;
+  aspect-ratio: 16 / 7;
   border-radius: 4px;
   overflow: hidden;
   background: var(--bg-subtle);
@@ -4515,9 +4515,9 @@ code {
 .ds-picker-trigger {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   width: 100%;
-  padding: 8px 10px;
+  padding: 6px 10px;
   background: var(--bg-panel);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
@@ -4541,7 +4541,7 @@ code {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  font-size: 13px;
+  font-size: 12.5px;
   font-weight: 500;
   color: var(--text);
   overflow: hidden;
@@ -4575,9 +4575,9 @@ code {
 .ds-avatar {
   position: relative;
   flex: none;
-  width: 32px;
-  height: 32px;
-  border-radius: 6px;
+  width: 26px;
+  height: 26px;
+  border-radius: 5px;
   overflow: hidden;
   border: 1px solid var(--border);
   background: var(--bg-panel);

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4896,10 +4896,9 @@ code {
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  padding: 0 28px;
+  padding: 24px 28px 0;
   border-bottom: 1px solid var(--border);
   min-width: 0;
-  min-height: 52px;
 }
 .entry-header-tabs-row {
   display: flex;
@@ -4907,8 +4906,10 @@ code {
   gap: 24px;
 }
 .entry-tabs {
+  align-self: stretch;
   display: flex;
-  gap: 2px;
+  align-items: center;
+  gap: 24px;
   min-width: 0;
   overflow-x: auto;
   overflow-y: hidden;
@@ -4919,16 +4920,35 @@ code {
   background: transparent;
   border: none;
   border-bottom: 2px solid transparent;
-  border-radius: 6px 6px 0 0;
-  padding: 14px 11px;
-  font-size: 14px;
+  border-radius: 0;
+  padding: 6px 4px 8px;
+  font-size: 12px;
   color: var(--text-muted);
   font-weight: 500;
   flex: 0 0 auto;
   white-space: nowrap;
+  transition: none;
 }
-.entry-tab:hover:not(:disabled) { background: var(--bg-subtle); color: var(--text); }
-.entry-tab.active {
+.entry-tab:focus,
+.entry-tab:focus-visible,
+.entry-tab:active {
+  background: transparent;
+  border-color: transparent;
+  border-bottom-color: transparent;
+  outline: none;
+  color: var(--text-muted);
+}
+.entry-tab:hover:not(:disabled) {
+  background: transparent;
+  border-color: transparent;
+  border-bottom-color: transparent;
+  outline: none;
+  color: var(--text);
+}
+.entry-tab.active,
+.entry-tab.active:hover:not(:disabled),
+.entry-tab.active:focus,
+.entry-tab.active:focus-visible {
   color: var(--text);
   border-bottom-color: var(--text);
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -3748,13 +3748,15 @@ code {
 }
 .newproj-tabs-shell {
   position: relative;
-  overflow: hidden;
+  overflow: visible;
   padding: 0 24px;
+  margin-bottom: -1px;
+  z-index: 2;
   flex: 0 0 auto;
 }
 .newproj-tabs {
   display: flex;
-  padding: 0 4px;
+  padding: 0;
   gap: 2px;
   overflow-x: auto;
   overflow-y: hidden;
@@ -3776,23 +3778,18 @@ code {
 }
 .newproj-tabs-shell::before {
   left: 0;
-  background: linear-gradient(90deg, var(--bg-panel), transparent);
+  background: linear-gradient(90deg, var(--bg), transparent);
 }
 .newproj-tabs-shell::after {
   right: 0;
-  background: linear-gradient(270deg, var(--bg-panel), transparent);
+  background: linear-gradient(270deg, var(--bg), transparent);
 }
 .newproj-tabs-shell.can-left::before,
 .newproj-tabs-shell.can-right::after {
   opacity: 1;
 }
-.newproj-tabs-shell.can-left {
-  padding-left: 40px;
-}
-.newproj-tabs-shell.can-right {
-  padding-right: 40px;
-}
 .newproj-tabs-arrow {
+  display: none;
   position: absolute;
   top: 50%;
   z-index: 2;
@@ -3804,7 +3801,6 @@ code {
   background: var(--bg-panel);
   color: var(--text-strong);
   box-shadow: var(--shadow-xs);
-  display: inline-flex;
   align-items: center;
   justify-content: center;
   padding: 0;
@@ -3825,28 +3821,51 @@ code {
 .newproj-tab {
   flex: 0 0 auto;
   min-width: max-content;
-  padding: 10px 6px;
-  border: none;
+  padding: 7px 14px;
   background: transparent;
   font-size: 12px;
-  border-radius: 0;
   color: var(--text-muted);
-  border-bottom: 2px solid transparent;
   font-weight: 500;
+  border: 1px solid transparent;
+  border-radius: 12px 12px 0 0;
+  position: relative;
+  transition: none;
 }
-.newproj-tab:hover:not(:disabled) { background: var(--bg-subtle); color: var(--text); }
-.newproj-tab.active {
+.newproj-tab:focus,
+.newproj-tab:focus-visible,
+.newproj-tab:active {
+  background: transparent;
+  border-color: transparent;
+  outline: none;
+  color: var(--text-muted);
+}
+.newproj-tab:hover:not(:disabled) {
+  background: transparent;
+  border-color: transparent;
+  outline: none;
   color: var(--text);
-  border-bottom-color: var(--text);
+}
+.newproj-tab.active,
+.newproj-tab.active:hover:not(:disabled),
+.newproj-tab.active:focus,
+.newproj-tab.active:focus-visible {
+  color: var(--text);
+  background: var(--bg-panel);
+  border-color: var(--border);
+  border-bottom-color: var(--bg-panel);
+  z-index: 3;
 }
 .newproj-body {
-  padding: 18px 24px 28px;
+  margin: 0 24px;
+  padding: 16px 18px 18px;
+  border: 1px solid var(--border);
+  border-radius: 0 0 12px 12px;
+  background: var(--bg-panel);
+  box-shadow: var(--shadow-xs);
   display: flex;
   flex-direction: column;
-  gap: 14px;
-  flex: 1;
-  min-height: 0;
-  overflow-y: auto;
+  gap: 12px;
+  flex: 0 0 auto;
 }
 .newproj-title {
   margin: 0;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -247,6 +247,15 @@ input, textarea, select {
 input::placeholder, textarea::placeholder { color: var(--text-faint); }
 input:focus, textarea:focus, select:focus {
   outline: none;
+  border-color: var(--selected);
+  box-shadow: 0 0 0 3px var(--selected-soft);
+}
+/* Entry sidebar form fields keep a quieter focus so the orange "Create"
+   CTA stays the loudest thing in the panel. Settings, dialogs, and the
+   right-column tab content still get the global ring above. */
+.entry-side input:focus,
+.entry-side textarea:focus,
+.entry-side select:focus {
   border-color: var(--border-strong);
   box-shadow: none;
 }

--- a/e2e/ui/entry-chrome-flows.test.ts
+++ b/e2e/ui/entry-chrome-flows.test.ts
@@ -38,25 +38,22 @@ test.beforeEach(async ({ page }) => {
   });
 });
 
-test('entry chrome settings menu toggles pet rail visibility', async ({ page }) => {
+test('pet pill toggle hides and shows the pet rail', async ({ page }) => {
   await page.goto('/');
   await expect(page.getByTestId('new-project-panel')).toBeVisible();
-  await expect(page.locator('.app-chrome-header')).toBeVisible();
-  await expect(page.locator('.app-chrome-brand[aria-label="Open Design"]')).toBeVisible();
-  await expect(page.locator('.entry-brand')).toHaveCount(0);
+  await expect(page.locator('.entry-brand')).toBeVisible();
+  await expect(page.locator('.entry-brand .entry-brand-title')).toHaveText('Open Design');
+  await expect(page.locator('.app-chrome-header')).toHaveCount(0);
+  await expect(page.locator('.pet-rail')).toBeVisible();
 
-  const openSettings = page.getByRole('button', { name: /open settings/i });
-  await openSettings.click();
-  const settingsMenu = page.locator('.avatar-popover[role="menu"]');
-  await expect(settingsMenu).toBeVisible();
-
-  await settingsMenu.getByRole('button', { name: /hide pet picker/i }).click();
-  await expect(settingsMenu).toHaveCount(0);
+  const hideToggle = page.locator('.pet-pill-toggle');
+  await expect(hideToggle).toHaveAttribute('aria-label', /hide pet picker/i);
+  await hideToggle.click();
   await expect(page.locator('.pet-rail')).toHaveCount(0);
 
-  await openSettings.click();
-  await expect(page.getByRole('button', { name: /show pet picker/i })).toBeVisible();
-  await page.getByRole('button', { name: /show pet picker/i }).click();
+  const showToggle = page.locator('.pet-pill-toggle');
+  await expect(showToggle).toHaveAttribute('aria-label', /show pet picker/i);
+  await showToggle.click();
   await expect(page.locator('.pet-rail')).toBeVisible();
 });
 
@@ -85,15 +82,18 @@ test('entry chrome avoids horizontal overflow on compact desktop width', async (
   await page.setViewportSize({ width: 820, height: 900 });
   await page.goto('/');
   await expect(page.getByTestId('new-project-panel')).toBeVisible();
-  await expect(page.locator('.app-chrome-header')).toBeVisible();
+  await expect(page.locator('.entry-brand')).toBeVisible();
 
-  const overflow = await page.evaluate(() => {
-    const header = document.querySelector('.app-chrome-header');
-    if (!(header instanceof HTMLElement)) return null;
-    return Math.max(0, header.scrollWidth - header.clientWidth);
+  // The brand row replaced the old global chrome header; if it overflows
+  // horizontally on a compact desktop, the logo/title/settings cog will
+  // wrap or push the layout sideways. Keep it pinned to no-overflow.
+  const brandOverflow = await page.evaluate(() => {
+    const brand = document.querySelector('.entry-brand');
+    if (!(brand instanceof HTMLElement)) return null;
+    return Math.max(0, brand.scrollWidth - brand.clientWidth);
   });
-  expect(overflow).not.toBeNull();
-  expect(overflow!).toBeLessThanOrEqual(2);
+  expect(brandOverflow).not.toBeNull();
+  expect(brandOverflow!).toBeLessThanOrEqual(2);
 
   const pageOverflow = await page.evaluate(() =>
     Math.max(0, document.documentElement.scrollWidth - document.documentElement.clientWidth),

--- a/e2e/ui/project-management-flows.test.ts
+++ b/e2e/ui/project-management-flows.test.ts
@@ -123,7 +123,8 @@ test('new project tabs switch visible form sections and preserve drafts', async 
   await expect(page.locator('.newproj-title')).toContainText('New prototype');
   await expect(page.getByTestId('new-project-name')).toHaveValue('Prototype draft survives');
 
-  await page.getByRole('button', { name: 'Scroll project types right' }).click();
+  // Playwright auto-scrolls the tab into view; the explicit scroll-arrow
+  // button was removed when the newproj tabs adopted the folder-tab pattern.
   await page.getByTestId('new-project-tab-image').click();
   await expect(page.getByTestId('new-project-tab-image')).toHaveAttribute('aria-selected', 'true');
   await expect(page.locator('.newproj-title')).toContainText('New image');


### PR DESCRIPTION
## Summary

- Polish the home (`EntryView`) UI to better match the reference layout — a two-column layout (sidebar + content) with a single divider between them, instead of the current global top-strip + light-card sidebar.
- Cosmetic / token / a11y work only — no logic, no API, no daemon paths touched. Diff lives in `apps/web/src/index.css`, `apps/web/src/components/EntryView.tsx`, and two playwright tests.
- **Split into 12 focused commits** so each piece can be reviewed (or reverted) independently. Each commit message has a `WHAT / WHY / SCOPE` breakdown. Commits 1–6 are the original polish pass; 7 is the split pet pill; 8 updates e2e; 9–12 address review feedback from @lefarcen and @Siri-Ray.

## Review-feedback round (commits 9–12)

| Severity | Finding (reviewer) | Commit |
|:---:|:---|:---:|
| 🚨 P1 | `.newproj-body` lost its scroll container — taller forms (image tabs, validation, compact viewports, DS popover) could clip with no scrollbar. Regression vs #1038. (@lefarcen, @Siri-Ray) | [`9280aa55`](https://github.com/nexu-io/open-design/pull/1360/commits/9280aa55) |
| ♿ a11y | Project-type tabs hid keyboard focus entirely — keyboard users had no visible cue during arrow-key navigation. (@Siri-Ray) | [`1f62aa2a`](https://github.com/nexu-io/open-design/pull/1360/commits/1f62aa2a) |
| ♿ a11y | Global `input:focus` rule was scrubbed app-wide; the intended "quieter" focus only belonged on the entry sidebar. (@lefarcen P2) | [`69e573b2`](https://github.com/nexu-io/open-design/pull/1360/commits/69e573b2) |
| 🧹 P3 | Stale `AppChromeHeader` / `isMacPlatform` imports + `--selected` token had no in-file docs. (@lefarcen) | [`1c9054ba`](https://github.com/nexu-io/open-design/pull/1360/commits/1c9054ba) |

A few feedback items I'd like to discuss rather than silently apply — see [§ Open feedback](#open-feedback) below.

## Before / After — overall layout

PETS rail collapsed in both shots so the side-by-side reads cleanly.

**Before (`main`):**

![before — overall](https://raw.githubusercontent.com/Sid-Qin/open-design/assets/before-01-overall.png)

**After (this PR):**

![after — overall](https://raw.githubusercontent.com/Sid-Qin/open-design/assets/after-01-overall.png)

Key differences visible in the overview:

1. Global `AppChromeHeader` strip removed — brand mark moves into the sidebar; the divider becomes a single vertical line that runs full height.
2. Right tabs row aligns vertically with the sidebar brand row; active tab underline sits exactly on the header divider (no gap).
3. Left "Prototype / Live artifact / Slide deck / …" tabs use a folder-tab pattern that visually merges into the card top.
4. `New prototype` form is noticeably slimmer (title input → fidelity → Create / Import / Open folder).
5. Bottom chips reordered: `Local CLI` chip on top, then `English` / `Adopt a pet` (now a split chip with an in-pill pet-rail toggle) / `Follow` on the second row, all height-aligned to 24px.
6. Selected state for fidelity is **blue** (separated from the brand orange used for the primary CTA), and the `Recent` filter is now a rounded pill with a white active tab.

---

## Commits — one per concern

### 1. `chore(web): upgrade radius scale + introduce blue --selected token` — [`13dc8a65`](https://github.com/nexu-io/open-design/pull/1360/commits/13dc8a65)

Token-only change. Introduces a four-tier radius scale (`--radius-sm 8 / --radius 12 / --radius-lg 16 / --radius-pill 999`) and a new `--selected` / `--selected-soft` blue pair, so the rest of the PR can pick the right token per role:

- `--radius-sm` for inputs and inner controls,
- `--radius` for cards and pills,
- `--radius-pill` for environment chips,
- `--selected` blue for "this option is active" indicators, kept separate from `--accent` (brand orange used for the primary `Create` CTA).

Commit `1c9054ba` follows up with a doc comment directly above the token declaration so future readers understand the `--accent` vs `--selected` split without having to find this PR.

### 2. `refactor(web): replace entry global header with sidebar brand + reorder bottom chips` — [`5fe5721c`](https://github.com/nexu-io/open-design/pull/1360/commits/5fe5721c)

Layout-level change.

- Drops `<AppChromeHeader>` from `EntryView` (kept intact for `ProjectView`).
- Reuses the existing `.entry-brand` block at the top of the sidebar — logo + "Open Design" title in serif weight 450.
- `.entry-shell` becomes a single 1fr grid row (was 2-row: header + body). Sidebar background is set to transparent so only the right card surface is white.
- Bottom chip footer reordered: `Local CLI · Codex CLI · version` on its own row (informative, most important), then a single row with `Language · Adopt a pet · Follow @nexudotio` (action-y). Chip heights normalized via `min-height: 24px` and `padding: 3px 8px`.
- Removes the redundant top-right Settings cog (the Local CLI chip already opens settings).

**Sidebar brand:**

| Before | After |
| :---: | :---: |
| ![before — brand](https://raw.githubusercontent.com/Sid-Qin/open-design/assets/before-02-sidebar-brand.png) | ![after — brand](https://raw.githubusercontent.com/Sid-Qin/open-design/assets/after-02-sidebar-brand.png) |

**Bottom chips:**

| Before | After |
| :---: | :---: |
| ![before — chips](https://raw.githubusercontent.com/Sid-Qin/open-design/assets/before-05-bottom-chips.png) | ![after — chips](https://raw.githubusercontent.com/Sid-Qin/open-design/assets/after-05-bottom-chips.png) |

This is the largest behavioral diff in the PR — pulling out `AppChromeHeader` means the entry header is no longer shared with the project view. Easy to revert in isolation if maintainers want the global strip back.

### 3. `style(web): align right tabs row with brand row + strip hover/focus noise` — [`a186d247`](https://github.com/nexu-io/open-design/pull/1360/commits/a186d247)

Visual alignment for the right column.

- `.entry-header` gets `padding: 24px 28px 0` so the tabs row sits at the same Y as the sidebar brand row.
- `.entry-tabs` is `align-self: stretch` and `.entry-tab` uses `padding: 6px 4px 8px` so the active underline lands exactly on the header bottom border — no gap, no overlap.
- Tab font normalized to 12px (matches the left newproj tabs in the next commit).
- All tab `:hover` and pointer `:focus` background / border overrides removed; `:focus-visible` is restored in commit `1f62aa2a` so keyboard users still see the active tab.

**Right tabs row:**

| Before | After |
| :---: | :---: |
| ![before — right tabs](https://raw.githubusercontent.com/Sid-Qin/open-design/assets/before-06-right-tabs.png) | ![after — right tabs](https://raw.githubusercontent.com/Sid-Qin/open-design/assets/after-06-right-tabs.png) |

### 4. `style(web): folder-tab merge on left newproj tabs + flat card top corners` — [`24f9f43a`](https://github.com/nexu-io/open-design/pull/1360/commits/24f9f43a)

The trickiest visual detail in the PR.

- `.newproj-tabs-shell` carries `margin-bottom: -1px` + `z-index: 2` so the active tab's 1px bottom border overpaints the card's 1px top border by exactly 1px (no double-line, no gap).
- The inner `.newproj-tabs` keeps `overflow-x: auto` for horizontal scrolling — the negative margin lives on the *outer* shell so it isn't clipped.
- `.newproj-tab.active` has `border-bottom-color: var(--bg-panel)` so the bottom edge becomes invisible against the card surface, completing the folder-tab effect.
- `.newproj-body` top corners flattened (`border-radius: 0 0 12px 12px`) so the card's top edge is a straight line that meets the tab's straight bottom edge cleanly. Bottom corners remain `12px`.
- The grey scroll-arrow buttons are hidden — the row leans on the existing `.newproj-tabs-shell::before/::after` gradient shadows (toggled via the JS-managed `.can-left` / `.can-right` classes) to signal overflow. See [§ Open feedback](#open-feedback) for the discussion with @lefarcen on this choice.

**Folder-tab merge:**

| Before (underline + gap) | After (tab and card share an edge) |
| :---: | :---: |
| ![before — folder tab](https://raw.githubusercontent.com/Sid-Qin/open-design/assets/before-03-folder-tab-merge.png) | ![after — folder tab](https://raw.githubusercontent.com/Sid-Qin/open-design/assets/after-03-folder-tab-merge.png) |

### 5. `style(web): slim NewProjectPanel form (title, fidelity, buttons, ds-picker)` — [`ba44e396`](https://github.com/nexu-io/open-design/pull/1360/commits/ba44e396)

Density / proportion pass on the inner form.

- `.newproj-create` (the orange CTA) shrunk from `padding: 12px 14px` → `8px 11px`; `.newproj-import` from `8px 11px` → `6px 10px`. Vertical gap between the two reduced to `2px` so they read as a primary/secondary stack rather than two separate buttons.
- `.newproj-body` padding tightened to `16px 18px 18px`, internal `gap: 12px`. The `flex: 0 0 auto` regression introduced in this commit is undone in `9280aa55` — see the P1 row above.
- Fidelity cards: `aspect-ratio: 16 / 7` (was 16 / 9), `gap: 6px`, `padding: 8px 8px 10px` — the labels now read as captions, not chunky labels.
- Design-system picker (`.ds-picker-trigger`) avatar shrunk to `26 × 26`, title to `12.5px`, padding to `6px 10px` so it matches the slimmer Create / Import height.
- `.newproj-footer` (the "Only you can see your project by default" caption) padded down to `12px 24px 16px` so it breathes from the card above without dropping into the chip area.

**Form panel:**

| Before | After |
| :---: | :---: |
| ![before — form](https://raw.githubusercontent.com/Sid-Qin/open-design/assets/before-04-form-slim.png) | ![after — form](https://raw.githubusercontent.com/Sid-Qin/open-design/assets/after-04-form-slim.png) |

### 6. `style(web): blue selected indicators + Recent filter rounded + neutral input focus` — [`c515c3d0`](https://github.com/nexu-io/open-design/pull/1360/commits/c515c3d0)

The "consume the new tokens" pass — pure restyling of selected / focused states.

- `.fidelity-card.active` switches `border-color` and outer ring from `--accent` (orange) → `--selected` (blue).
- `.subtab-pill` (the `Recent / Your designs` filter on the right) becomes a rounded pill (`border-radius: var(--radius)`); the active state is `background: var(--bg-panel)` (white) with `box-shadow: var(--shadow-xs)`.
- Global `input:focus` was originally scrubbed app-wide here; that was scoped down to `.entry-side` only in `69e573b2`. Global ring is now blue (`--selected` + `--selected-soft`), so every other form in the app keeps a visible focus indicator.

**Fidelity (active blue):**

| Before (orange) | After (blue) |
| :---: | :---: |
| ![before — fidelity](https://raw.githubusercontent.com/Sid-Qin/open-design/assets/before-07-blue-fidelity-selected.png) | ![after — fidelity](https://raw.githubusercontent.com/Sid-Qin/open-design/assets/after-07-blue-fidelity-selected.png) |

**Recent / Your designs filter:**

| Before (dark active) | After (white active, rounded) |
| :---: | :---: |
| ![before — recent](https://raw.githubusercontent.com/Sid-Qin/open-design/assets/before-08-recent-pill.png) | ![after — recent](https://raw.githubusercontent.com/Sid-Qin/open-design/assets/after-08-recent-pill.png) |

### 7. `refactor(web): pet rail toggle moves inside pet pill as split button` — [`5eba746e`](https://github.com/nexu-io/open-design/pull/1360/commits/5eba746e)

After removing the global `AppChromeHeader`, the only remaining "Hide / Show pet picker" entrypoint was the cog popover that lived on it. Putting the cog back next to the brand mark felt wrong — it elevated Settings (already on the `Local CLI` chip) to a primary affordance and competed with the logo for hierarchy.

This commit gives the pet-rail toggle its proper home: it lives **inside the pet chip itself** as a split button.

- `.pet-pill` becomes a `<div>` with two `<button>` children separated by a 1px `--border` divider:
  - `.pet-pill-main` — glyph + "Adopt a pet" / "Change pet" label + unadopted dot.
  - `.pet-pill-toggle` — icon-only `eye` / `eye-off` toggle, flips `petRailHidden`.
- `.pet-pill { height: 24px }` and `.pet-pill-glyph { font-size: 12px; width:14; height:14 }` so the unicorn glyph stops pushing the chip taller than the row's 24px standard.
- The whole `avatarMenuOpen` state + outside-click effect + popover JSX in `EntryView.tsx` is gone (~70 lines).

### 8. `test(e2e): update entry chrome + project mgmt assertions for new layout` — [`726b14c7`](https://github.com/nexu-io/open-design/pull/1360/commits/726b14c7)

Tests follow the new affordances:

- `pet pill toggle hides and shows the pet rail` exercises `.pet-pill-toggle` directly (no popover chain).
- The compact-width overflow test measures `.entry-brand` (the new top-of-page chrome) instead of `.app-chrome-header`.
- The "new project tabs" test drops the explicit `Scroll project types right` click — Playwright's `locator.click()` calls `scrollIntoViewIfNeeded()`, which scrolls the off-screen `image` tab into view inside the `overflow-x: auto` `.newproj-tabs` container.

17/17 critical tests pass locally (chromium project, single worker, fresh daemon).

---

## Review-feedback commits

### 9. `fix(web): restore .newproj-body as scroll container (P1 regression)` — [`9280aa55`](https://github.com/nexu-io/open-design/pull/1360/commits/9280aa55)

Restores `flex: 1 1 auto; min-height: 0; overflow-y: auto;` on `.newproj-body`. Parent `.newproj` is `overflow: hidden`, so without the body acting as a scroll container, taller form states (image tab, validation, compact-height windows, full DS popover) were clipping with no scroll recovery. Reintroduced with an inline comment so a future refactor doesn't repeat the same mistake.

### 10. `fix(web): restore :focus-visible ring on entry-tab + newproj-tab (a11y)` — [`1f62aa2a`](https://github.com/nexu-io/open-design/pull/1360/commits/1f62aa2a)

Splits the prior `:focus, :focus-visible, :active` group on both tab selectors so `:focus-visible` no longer inherits the zero-out. Keyboard users get a 2px blue ring (inset shadow on `.newproj-tab`, outline on `.entry-tab`) without bringing the pointer-focus halo back.

### 11. `fix(web): scope quieted input focus to .entry-side, restore global ring (a11y)` — [`69e573b2`](https://github.com/nexu-io/open-design/pull/1360/commits/69e573b2)

Global `input:focus` rule restored to a visible ring — but in `--selected` blue instead of the original `--accent` orange (consumes the new token from commit 1). The "quieter" focus from commit 6 is now scoped to `.entry-side` only.

### 12. `chore(web): drop dead AppChromeHeader / isMacPlatform imports + document --selected token` — [`1c9054ba`](https://github.com/nexu-io/open-design/pull/1360/commits/1c9054ba)

`AppChromeHeader` is still used by `ProjectView`, just no longer in `EntryView`. `isMacPlatform` was only used by the avatar-menu popover (gone with commit 7). Both imports removed. The `--selected` token gets a docblock explaining the `--accent` vs `--selected` split.

---

## Open feedback

A few items from @lefarcen's review I'd rather discuss than silently take:

**Scroll arrows for project-type tabs (P2).** The `.newproj-tabs-arrow` buttons remain `display: none`. The discoverability concern is real, but the panel already renders the existing `.newproj-tabs-shell::before/::after` gradient shadows (toggled via JS-managed `.can-left` / `.can-right` classes) when content overflows — that's the "alternate overflow pattern" the review suggested as acceptable. Keyboard users now also have a visible focus ring on each tab (commit 10) and can arrow-key through. I'd prefer to keep the arrows hidden unless a maintainer specifically wants them back; happy to revisit if #1167's tab reduction lands first.

**Semantic overlap with #1167.** Acknowledged — both PRs touch `NewProjectPanel.tsx`, the same tab row, `index.css`, and `project-management-flows.test.ts`. I'll rebase on whichever lands first and pull the folder-tab pattern + token consumption forward into the new tab shape; the visual layer here should compose cleanly on top of #1167's structural change.

**Screenshot durability.** PR screenshots are currently hosted on a separate `assets` branch in my fork via `raw.githubusercontent.com`. Happy to migrate them to GitHub user-attachments if a maintainer can either link me the canonical pattern this repo uses or accept a follow-up. Not blocking on this for the review.

---

## Test plan

- [x] `pnpm --filter @open-design/web typecheck` → exit 0
- [x] `pnpm guard` → all 5 invariant checks pass
- [x] `pnpm exec playwright test ui/entry-chrome-flows.test.ts ui/entry-configuration-flows.test.ts ui/project-management-flows.test.ts` → 17/17 (chromium, single worker, fresh daemon)
- [x] Manual smoke in `apps/web` dev server at 1280×820: every interactive element on `EntryView` still reachable; pet rail open/close still works via the in-pill toggle; switching left and right tabs still works; keyboard Tab cycles through tabs with visible focus rings.

No daemon, API, or storage path was touched.

## Scope notes for reviewers

- Only `EntryView` is restructured. `ProjectView` and all of its descendants still use `AppChromeHeader` exactly as before.
- The new `--selected` token is consumed in three places now: `.fidelity-card.active`, `.subtab-pill button.active`, and the restored global `input:focus` ring. It is intentionally separated from `--accent` so future "active option" affordances have a token to reach for without competing with primary CTAs.
- The folder-tab merge in commit 4 relies on `.newproj-tabs-shell` keeping `overflow: visible` — the negative `margin-bottom: -1px` would otherwise be clipped and the active tab's bottom border would no longer overpaint the card edge.

> Screenshots above are hosted on a separate `assets` branch on my fork (`Sid-Qin/open-design`), referenced via `raw.githubusercontent.com` so they don't bloat this PR's diff.
