### PR TITLE
fix: improve Open Project button hover state readability in Routine history

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -16951,7 +16951,11 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   gap: 4px;
   font-weight: 500;
 }
-.routines-history-link:hover { background: var(--text); color: var(--bg); border-color: var(--text); }
+.routines-history-link:hover {
+  background: var(--bg-hover);
+  color: var(--text-strong);
+  border-color: var(--border-strong);
+}
 
 .routines-status {
   display: inline-block;


### PR DESCRIPTION
Fixes #1357

## Problem

In the **Routines** settings page, the **Open project** button in the history row becomes unreadable on hover because the text effectively disappears. The hover state was using `var(--text)` for background and `var(--bg)` for text color, which created poor or zero contrast in some themes.

## Root Cause

The CSS hover rule at line 16954 was:
```css
.routines-history-link:hover { 
  background: var(--text); 
  color: var(--bg); 
  border-color: var(--text); 
}
```

This inverted the colors in a way that:
- Made the text color match or nearly match the background in some themes
- Created a jarring visual effect
- Reduced readability instead of improving affordance

## Solution

Changed the hover state to use semantic design tokens that provide proper contrast:

```css
.routines-history-link:hover {
  background: var(--bg-hover);
  color: var(--text-strong);
  border-color: var(--border-strong);
}
```

### Why These Tokens?

- **`var(--bg-hover)`**: Standard hover background used throughout the app for subtle interactive feedback
- **`var(--text-strong)`**: Ensures high contrast text that's clearly readable
- **`var(--border-strong)`**: Maintains visual hierarchy and button definition

These tokens are designed to work correctly in both light and dark themes, and they follow the same hover pattern used by other buttons in the app.

## Testing

- ✅ Button text remains clearly readable on hover
- ✅ Hover state provides visual feedback without losing readability
- ✅ Works correctly in both light and dark themes
- ✅ Consistent with other button hover states in the app
- ✅ Border remains visible and defined
- ✅ No contrast issues

## Impact

This is a **P2 bug fix** that improves usability:
- Users can now read the button label in all states
- Hover state feels polished and intentional
- Consistent with the rest of the design system
- No more "broken button" perception

## Before/After

**Before**: Text disappears or becomes unreadable on hover (as shown in issue screenshots)
**After**: Text remains clearly readable with subtle hover background

## Files Changed

- `apps/web/src/index.css`: Updated `.routines-history-link:hover` rule (1 line → 4 lines for readability)