### PR TITLE
Fix OpenCode stdin prompt invocation

### DIFF
--- a/apps/daemon/src/runtimes/defs/opencode.ts
+++ b/apps/daemon/src/runtimes/defs/opencode.ts
@@ -22,8 +22,10 @@ export const opencodeAgentDef = {
       { id: 'openai/gpt-5', label: 'openai/gpt-5' },
       { id: 'google/gemini-2.5-pro', label: 'google/gemini-2.5-pro' },
     ],
-    // Prompt delivered via stdin (`opencode run -`) to avoid Windows
-    // `spawn ENAMETOOLONG` while preserving OpenCode's structured stream.
+    // Prompt delivered via stdin (`opencode run` with no message argv) to
+    // avoid Windows `spawn ENAMETOOLONG` while preserving OpenCode's
+    // structured stream. A literal `-` is parsed as a positional message by
+    // OpenCode 1.14.x and can surface as "Session not found".
     buildArgs: (_prompt, _imagePaths, _extra, options = {}) => {
       const args = [
         'run',
@@ -34,7 +36,6 @@ export const opencodeAgentDef = {
       if (options.model && options.model !== 'default') {
         args.push('--model', options.model);
       }
-      args.push('-');
       return args;
     },
     promptViaStdin: true,

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest';
 import {
-  assert, claude, codex, copilot, cursorAgent, deepseek, devin, detectAgents, gemini, join, kilo, kiro, mkdtempSync, pi, qoder, rmSync, spawnEnvForAgent, tmpdir, vibe, writeFileSync, chmodSync,
+  assert, claude, codex, copilot, cursorAgent, deepseek, devin, detectAgents, gemini, join, kilo, kiro, mkdtempSync, opencode, pi, qoder, rmSync, spawnEnvForAgent, tmpdir, vibe, writeFileSync, chmodSync,
 } from './helpers/test-helpers.js';
 import type { TestAgentDef } from './helpers/test-helpers.js';
 
@@ -22,6 +22,35 @@ test('cursor-agent args deliver prompts via stdin without passing a literal dash
     '--trust',
     '--workspace',
     '/tmp/od-project',
+  ]);
+});
+
+test('opencode args deliver prompts via stdin without passing a literal dash prompt', () => {
+  const prompt = 'design a dashboard';
+  const baseArgs = opencode.buildArgs(prompt, [], [], {});
+  assert.equal(opencode.promptViaStdin, true);
+  assert.equal(baseArgs.includes('-'), false);
+  assert.equal(baseArgs.includes(prompt), false);
+  assert.deepEqual(baseArgs, [
+    'run',
+    '--format',
+    'json',
+    '--dangerously-skip-permissions',
+  ]);
+
+  const withModel = opencode.buildArgs(
+    prompt,
+    [],
+    [],
+    { model: 'anthropic/claude-sonnet-4-5' },
+  );
+  assert.deepEqual(withModel, [
+    'run',
+    '--format',
+    'json',
+    '--dangerously-skip-permissions',
+    '--model',
+    'anthropic/claude-sonnet-4-5',
   ]);
 });
 


### PR DESCRIPTION
Fixes #677

## Summary
- remove the literal `-` positional message from the OpenCode runtime argv so `opencode run` reads the prompt from stdin directly
- add a daemon runtime regression test that pins OpenCode stdin delivery without embedding the prompt body or dash sentinel in argv

## Validation
- `pnpm --filter @open-design/daemon test -- runtimes/agent-args`
- `pnpm --filter @open-design/daemon test -- connection-test -t OpenCode`
- `pnpm --filter @open-design/daemon test -- json-event-stream`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`

Note: `pnpm --filter @open-design/daemon test -- connection-test json-event-stream` was also tried; the OpenCode/json-event-stream coverage passed, but three unrelated Codex `CODEX_BIN` override assertions failed on this Windows worktree because extensionless temporary configured binaries were treated as invalid and the tests fell back to the PATH Codex executable.