### PR TITLE
fix: gate Finalize design package when provider config is missing

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -2141,6 +2141,18 @@ export function ProjectView({
   // shortcut wiring. Close to the JSX so the data flow is easy to
   // trace from the toolbar back to its sources.
   const handleFinalize = useCallback(() => {
+    // Gate finalize when required provider config is missing (#1348).
+    // The daemon returns BAD_REQUEST when apiKey or model is empty, but
+    // we should prevent the request from being sent in the first place
+    // and show a clear preflight message instead.
+    if (!config.apiKey || !config.model) {
+      setProjectActionsToast({
+        message: 'Cannot finalize: API key and model are required.',
+        details: 'Configure your provider in Settings → Execution before finalizing.',
+      });
+      return;
+    }
+
     void finalize.trigger({
       apiKey: config.apiKey,
       baseUrl: config.baseUrl,


### PR DESCRIPTION
Fixes #1348

## Problem

The **Finalize design package** action is clickable even when required provider configuration (API key and model) is missing. Clicking it sends a request with empty config values and fails with:

> Bad request — check the API key and model.

This is a **P1 bug** because:
- It blocks a key end-of-flow action
- Users experience it as a broken feature
- The error message is backend-style and unhelpful
- The root cause is missing product-side gating, not a user mistake

## Root Cause

The `handleFinalize` function in `ProjectView.tsx` directly passes `config.apiKey` and `config.model` to `finalize.trigger()` without validating that they're present. When these values are empty (e.g., in Local CLI mode or when BYOK provider is not configured), the daemon returns `400 BAD_REQUEST`.

## Solution

Added **preflight validation** in `handleFinalize` before sending the request:

```tsx
if (!config.apiKey || !config.model) {
  setProjectActionsToast({
    message: 'Cannot finalize: API key and model are required.',
    details: 'Configure your provider in Settings → Execution before finalizing.',
  });
  return;
}
```

### Why This Approach?

**Handler-level validation** instead of disabling the button because:
1. **Button state is already complex**: 3 label variants based on DESIGN.md existence/staleness
2. **Discoverability**: Users need to see the action exists
3. **Actionable guidance**: Toast tells users exactly where to fix the issue (Settings → Execution)
4. **Consistent with app patterns**: Other gated actions (e.g., Orbit) use toast feedback

### Toast Message Design

- **Primary**: "Cannot finalize: API key and model are required."
  - Clear, specific, states the exact prerequisites
- **Details**: "Configure your provider in Settings → Execution before finalizing."
  - Actionable, tells users where to go and what to do

## Testing

- ✅ When `config.apiKey` is empty, clicking Finalize shows the toast and does not send a request
- ✅ When `config.model` is empty, clicking Finalize shows the toast and does not send a request
- ✅ When both are present, clicking Finalize sends the request as before
- ✅ Toast message is clear and actionable
- ✅ No backend error is surfaced
- ✅ Type checking passes

## Impact

This fix:
- **Prevents invalid requests** from being sent
- **Provides clear, actionable feedback** instead of cryptic backend errors
- **Improves UX** for users in Local CLI mode or with incomplete BYOK config
- **Follows product principle**: gate invalid actions before they fail
- **Reduces support burden**: users understand what's missing and where to fix it

## Before/After

**Before**:
1. User clicks "Finalize design package" without configuring provider
2. Request is sent with empty `apiKey` and `model`
3. Backend returns `400 BAD_REQUEST`
4. User sees: "Bad request — check the API key and model."
5. User is confused about what to check and where

**After**:
1. User clicks "Finalize design package" without configuring provider
2. Preflight validation catches missing config
3. Toast appears: "Cannot finalize: API key and model are required. Configure your provider in Settings → Execution before finalizing."
4. User knows exactly what's missing and where to fix it
5. No backend request is sent

## Files Changed

- `apps/web/src/components/ProjectView.tsx`: Added preflight validation in `handleFinalize`

## Future Enhancements

Potential improvements for future PRs:
- Disable the button when config is invalid (requires refactoring button state logic)
- Add a "Configure provider" quick action link in the toast
- Show a persistent banner when provider config is incomplete
- Gate other provider-dependent actions with similar validation