### PR TITLE
fix: restore custom dropdown chevron for timezone selector in dark mode

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -16770,6 +16770,27 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   font-family: inherit;
   transition: border-color 120ms ease, box-shadow 120ms ease;
 }
+
+/* Restore custom dropdown chevron for select elements in routines form.
+   The appearance:none above removes the native chevron, so we paint our own
+   via background-image (matching the global select styling). */
+.routines-field select {
+  padding-right: 32px;
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' fill='none' stroke='%2374716b' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='3 5 6 8 9 5'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  background-size: 12px 12px;
+}
+
+[data-theme='dark'] .routines-field select {
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' fill='none' stroke='%239a9690' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='3 5 6 8 9 5'/%3E%3C/svg%3E");
+}
+
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme]) .routines-field select {
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' fill='none' stroke='%239a9690' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='3 5 6 8 9 5'/%3E%3C/svg%3E");
+  }
+}
 .routines-field input:focus,
 .routines-field textarea:focus,
 .routines-field select:focus,


### PR DESCRIPTION
Fixes #1359

## Summary

The timezone selector in the Routines form was showing repeated dropdown icons and poor text readability in dark mode.

## Root Cause

1. `.routines-field select` set `appearance: none` to remove the native chevron, but did not restore a custom one via `background-image`
2. Missing `padding-right: 32px` caused text to overlap with any chevron that did render
3. No dark-mode-specific chevron color was defined for this selector

## Changes

Added custom dropdown chevron styling for `.routines-field select` that:
- Matches the global `select` behavior (lines 258-275 in index.css)
- Includes proper `padding-right: 32px` to prevent text overlap
- Provides dark-mode color variants (`stroke=%239a9690` for dark theme)
- Supports both explicit `[data-theme=dark]` and system `prefers-color-scheme: dark`

## Result

- ✅ Single, correctly-positioned chevron icon
- ✅ Sufficient padding prevents text overlap
- ✅ Proper contrast in both light and dark themes
- ✅ Consistent visual behavior with other form controls

## Testing

- Verified the CSS changes follow the existing pattern for `select` elements
- The fix applies the same chevron SVG and positioning used globally
- Dark mode color (`%239a9690`) matches other dark-mode selects in the app