### PR TITLE
fix: make Routine empty state CTA clickable and prevent button wrapping

### DIFF
--- a/apps/web/src/components/RoutinesSection.tsx
+++ b/apps/web/src/components/RoutinesSection.tsx
@@ -632,7 +632,20 @@ export function RoutinesSection() {
       ) : routines.length === 0 ? (
         <div className="routines-empty">
           <strong>No routines yet.</strong>
-          <p>Click <em>New routine</em> to schedule an unattended agent run.</p>
+          <p>
+            Click{' '}
+            <button
+              type="button"
+              className="routines-empty-cta"
+              onClick={() => {
+                setForm(emptyForm());
+                setShowForm(true);
+              }}
+            >
+              New routine
+            </button>{' '}
+            to schedule an unattended agent run.
+          </p>
         </div>
       ) : (
         <ul className="routines-list">

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -16722,6 +16722,13 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
 
 .routines-section .section-head { align-items: flex-start; }
 
+/* Prevent the "New routine" button from wrapping awkwardly. The button
+   should stay visually stable even when the section-head is narrow. */
+.routines-section .section-head button {
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
 .routines-card {
   background: var(--bg-panel);
   border: 1px solid var(--border);
@@ -16745,6 +16752,35 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
 .routines-empty strong { color: var(--text); display: block; margin-bottom: 4px; font-size: 14px; }
 .routines-empty p { margin: 0; font-size: 13px; }
 .routines-empty em { color: var(--text); font-style: normal; font-weight: 600; }
+
+/* Inline CTA button in the empty state message. Styled as a subtle link-like
+   button that integrates naturally into the prose while remaining clickable. */
+.routines-empty-cta {
+  appearance: none;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: var(--text);
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-color: var(--border-strong);
+  text-underline-offset: 2px;
+  transition: color 120ms ease, text-decoration-color 120ms ease;
+}
+
+.routines-empty-cta:hover {
+  color: var(--accent);
+  text-decoration-color: var(--accent);
+}
+
+.routines-empty-cta:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
 
 .routines-field { display: flex; flex-direction: column; gap: 6px; }
 .routines-field > span {


### PR DESCRIPTION
Fixes #1358

## Summary

The Routines empty state had two UX issues that made the entry path feel unpolished:
1. The **New routine** button in the header wrapped awkwardly on narrow screens
2. The inline **New routine** text in the empty state message was not clickable

## Changes

### 1. Made inline CTA clickable

Converted the inline "New routine" text from a styled `<em>` element to a clickable `<button>` with link-like styling:
- Appears as underlined text that integrates naturally into the prose
- Triggers the same action as the header button (opens the routine form)
- Includes proper hover states (accent color) and focus indicators
- Maintains semantic HTML with `type="button"` and proper event handling

### 2. Prevented header button wrapping

Added CSS rules to keep the header button visually stable:
- `white-space: nowrap` prevents the button text from breaking into multiple lines
- `flex-shrink: 0` ensures the button maintains its size even when space is tight
- Button remains readable and clickable at all viewport sizes

## Result

- ✅ Header button stays visually stable and does not wrap awkwardly
- ✅ Empty state message provides a directly clickable CTA
- ✅ Inline button integrates naturally into the prose (looks like emphasized text)
- ✅ Proper hover and focus states for accessibility
- ✅ Consistent interaction pattern — both CTAs open the same form
- ✅ Improved empty state discoverability and polish

## Testing

- Verified the inline CTA button triggers the form correctly
- Confirmed the header button no longer wraps on narrow screens
- Tested hover and focus states for both buttons
- Checked that the inline button styling integrates naturally into the text