### PR TITLE
feat(daemon): inject compiled design-system tokens + fixture into prompts

### DIFF
--- a/apps/daemon/src/design-systems.ts
+++ b/apps/daemon/src/design-systems.ts
@@ -62,6 +62,42 @@ export async function readDesignSystem(root: string, id: string): Promise<string
   }
 }
 
+/**
+ * Structured (compiled) form of a brand's design system. Optional sibling
+ * files alongside DESIGN.md that, when present, give agents a
+ * machine-readable token contract and a worked fixture instead of having
+ * to re-derive both from prose. Both fields are individually optional —
+ * the daemon falls back to the DESIGN.md-only path when neither is
+ * available, which is the current state for the ~138 brands without
+ * hand-authored or derived tokens.
+ *
+ * - `tokensCss`     — verbatim content of `<brand>/tokens.css`.
+ * - `fixtureHtml`   — verbatim content of `<brand>/components.html`.
+ */
+export type DesignSystemAssets = {
+  tokensCss?: string | undefined;
+  fixtureHtml?: string | undefined;
+};
+
+export async function readDesignSystemAssets(
+  root: string,
+  id: string,
+): Promise<DesignSystemAssets> {
+  const [tokensCss, fixtureHtml] = await Promise.all([
+    readFileOptional(path.join(root, id, 'tokens.css')),
+    readFileOptional(path.join(root, id, 'components.html')),
+  ]);
+  return { tokensCss, fixtureHtml };
+}
+
+async function readFileOptional(file: string): Promise<string | undefined> {
+  try {
+    return await readFile(file, 'utf8');
+  } catch {
+    return undefined;
+  }
+}
+
 function summarize(raw: string): string {
   const lines = raw.split(/\r?\n/);
   const firstH1 = lines.findIndex((l) => /^#\s+/.test(l));

--- a/apps/daemon/src/design-systems.ts
+++ b/apps/daemon/src/design-systems.ts
@@ -93,9 +93,27 @@ export async function readDesignSystemAssets(
 async function readFileOptional(file: string): Promise<string | undefined> {
   try {
     return await readFile(file, 'utf8');
-  } catch {
-    return undefined;
+  } catch (err) {
+    // Only swallow "file genuinely does not exist" failures. Today the
+    // ~138 brands without hand-authored or derived tokens.css /
+    // components.html siblings hit this path on the empty side, which
+    // is the legacy fallback we deliberately preserve. Every other
+    // failure mode — permission denied (`EACCES`), parent-shadowed by
+    // a non-directory (`EPERM`), a directory at the file path
+    // (`EISDIR`), a broken packaged-resource symlink, a transient I/O
+    // error — means the token channel is misconfigured; the caller
+    // (and the smoke-test rollout) needs to see that explicitly
+    // instead of silently degrading to the DESIGN.md-only prompt and
+    // making the experiment look ineffective for the wrong reason.
+    if (isAbsenceError(err)) return undefined;
+    throw err;
   }
+}
+
+function isAbsenceError(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false;
+  const code = (err as { code?: unknown }).code;
+  return code === 'ENOENT' || code === 'ENOTDIR';
 }
 
 function summarize(raw: string): string {

--- a/apps/daemon/src/prompts/system.ts
+++ b/apps/daemon/src/prompts/system.ts
@@ -95,6 +95,22 @@ export interface ComposeInput {
     | undefined;
   designSystemBody?: string | undefined;
   designSystemTitle?: string | undefined;
+  // Compiled (machine-readable) form of the active brand's design system,
+  // shipped as sibling files to DESIGN.md when available. Both fields are
+  // optional and only injected when the daemon is running with the
+  // `OD_DESIGN_TOKEN_CHANNEL` env flag enabled (today's experimental
+  // gate). When present they are appended AFTER the DESIGN.md block so
+  // prose still sets the high-level voice and the structured form
+  // disambiguates token names + worked component shapes.
+  //
+  // - `designSystemTokensCss`    — verbatim `tokens.css` :root contract
+  //                                that the agent pastes into the
+  //                                artifact's <style>.
+  // - `designSystemFixtureHtml`  — verbatim `components.html` reference
+  //                                fixture demonstrating button / card /
+  //                                type-scale shapes wired to the tokens.
+  designSystemTokensCss?: string | undefined;
+  designSystemFixtureHtml?: string | undefined;
   // Craft references the active skill opted into via `od.craft.requires`.
   // The daemon resolves the slug list to file contents and concatenates
   // them with section headers; we inject them between the DESIGN.md and
@@ -147,6 +163,8 @@ export function composeSystemPrompt({
   skillMode,
   designSystemBody,
   designSystemTitle,
+  designSystemTokensCss,
+  designSystemFixtureHtml,
   craftBody,
   craftSections,
   memoryBody,
@@ -192,6 +210,27 @@ export function composeSystemPrompt({
   if (designSystemBody && designSystemBody.trim().length > 0) {
     parts.push(
       `\n\n## Active design system${designSystemTitle ? ` — ${designSystemTitle}` : ''}\n\nTreat the following DESIGN.md as authoritative for color, typography, spacing, and component rules. Do not invent tokens outside this palette. When you copy the active skill's seed template, bind these tokens into its \`:root\` block before generating any layout.\n\n${designSystemBody.trim()}`,
+    );
+  }
+
+  // Structured (compiled) form of the active brand. The DESIGN.md above
+  // sets voice and intent; the tokens.css block below is the SAME
+  // contract in machine-readable form — names + values the agent pastes
+  // verbatim instead of re-deriving from prose. The components.html
+  // fixture grounds the token vocabulary in worked component shapes
+  // (button / card / type roles) so the agent can copy fragments
+  // directly. Both blocks are individually gated: missing files (today,
+  // every brand except `default` and `kami`) skip silently, preserving
+  // the legacy DESIGN.md-only behaviour for the other ~138 brands.
+  if (designSystemTokensCss && designSystemTokensCss.trim().length > 0) {
+    parts.push(
+      `\n\n## Active design system tokens${designSystemTitle ? ` — ${designSystemTitle}` : ''}\n\nThe block below is this brand's tokens.css contract — every \`:root\` custom property and any scoped override (e.g. \`:root[lang=...]\`) the brand defines. **Paste the unscoped \`:root { ... }\` block verbatim into the artifact's first \`<style>\`** so every \`var(--*)\` reference resolves at runtime.\n\nDo not invent new tokens. Do not redefine these values. Do not write raw hex outside this :root block. The DESIGN.md above is prose; this is the binding contract.\n\n\`\`\`css\n${designSystemTokensCss.trim()}\n\`\`\``,
+    );
+  }
+
+  if (designSystemFixtureHtml && designSystemFixtureHtml.trim().length > 0) {
+    parts.push(
+      `\n\n## Reference fixture${designSystemTitle ? ` — ${designSystemTitle}` : ''}\n\nA self-contained worked artifact in this design system. Match its component shapes (button structure, card structure, type-scale rhythm, focus ring, spacing cadence) when generating new artifacts. Copying fragments is encouraged as long as you keep the \`var(--*)\` references intact — they are already wired to the tokens above.\n\n\`\`\`html\n${designSystemFixtureHtml.trim()}\n\`\`\``,
     );
   }
 

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -37,7 +37,7 @@ import { installFromTarget, uninstallById, sanitizeRepoName } from './library-in
 import { buildWindowsFolderDialogCommand, parseFolderDialogStdout } from './native-folder-dialog.js';
 import { listCodexPets, readCodexPetSpritesheet } from './codex-pets.js';
 import { syncCommunityPets } from './community-pets-sync.js';
-import { listDesignSystems, readDesignSystem } from './design-systems.js';
+import { listDesignSystems, readDesignSystem, readDesignSystemAssets } from './design-systems.js';
 import {
   composeMemoryBody,
   deleteMemoryEntry,
@@ -2977,6 +2977,15 @@ export async function startServer({
 
     let designSystemBody;
     let designSystemTitle;
+    // Compiled (tokens.css + components.html) form of the active brand.
+    // Gated by `OD_DESIGN_TOKEN_CHANNEL` while the experiment is in the
+    // smoke-test phase: flag-off keeps the daemon byte-equivalent to the
+    // pre-PR-C path; flag-on appends the tokens contract + reference
+    // fixture to the system prompt for any brand that ships those files
+    // (today: `default` and `kami`; every other brand falls through
+    // silently because the files are absent).
+    let designSystemTokensCss;
+    let designSystemFixtureHtml;
     if (effectiveDesignSystemId) {
       const systems = await listAllDesignSystems();
       const summary = systems.find((s) => s.id === effectiveDesignSystemId);
@@ -2985,6 +2994,23 @@ export async function startServer({
         (await readDesignSystem(DESIGN_SYSTEMS_DIR, effectiveDesignSystemId)) ??
         (await readDesignSystem(USER_DESIGN_SYSTEMS_DIR, effectiveDesignSystemId)) ??
         undefined;
+      if (process.env.OD_DESIGN_TOKEN_CHANNEL === '1') {
+        // Try built-in dir first, then user-installed dir, mirroring the
+        // DESIGN.md fallback chain above. Any individual file may be
+        // missing (e.g. tokens.css present, components.html absent); the
+        // composer gates each block independently.
+        const builtIn = await readDesignSystemAssets(DESIGN_SYSTEMS_DIR, effectiveDesignSystemId);
+        const installed = builtIn.tokensCss && builtIn.fixtureHtml
+          ? builtIn
+          : {
+              tokensCss: builtIn.tokensCss
+                ?? (await readDesignSystemAssets(USER_DESIGN_SYSTEMS_DIR, effectiveDesignSystemId)).tokensCss,
+              fixtureHtml: builtIn.fixtureHtml
+                ?? (await readDesignSystemAssets(USER_DESIGN_SYSTEMS_DIR, effectiveDesignSystemId)).fixtureHtml,
+            };
+        designSystemTokensCss = installed.tokensCss;
+        designSystemFixtureHtml = installed.fixtureHtml;
+      }
     }
 
     const template =
@@ -3045,6 +3071,8 @@ export async function startServer({
       skillMode,
       designSystemBody,
       designSystemTitle,
+      designSystemTokensCss,
+      designSystemFixtureHtml,
       craftBody,
       craftSections,
       memoryBody,

--- a/apps/daemon/tests/design-system-assets.test.ts
+++ b/apps/daemon/tests/design-system-assets.test.ts
@@ -73,4 +73,42 @@ describe('readDesignSystemAssets', () => {
     expect(assets.tokensCss).toBeUndefined();
     expect(assets.fixtureHtml).toBeUndefined();
   });
+
+  // Reviewer feedback (nettee, PR-C #1385): the prior implementation
+  // swallowed every readFile() error as "absent", which would silently
+  // hide non-absence failures (EACCES, EISDIR, broken packaged
+  // resource paths, transient I/O) and ship the legacy DESIGN.md-only
+  // prompt as if the token channel had succeeded. That corrupts the
+  // exact signal the smoke-test rollout depends on. The reader now
+  // only swallows ENOENT / ENOTDIR; everything else must surface.
+  it('rejects on non-absence read failures so token-channel misconfigurations surface', async () => {
+    const root = fresh();
+    const dir = brandDir(root, 'broken-tokens');
+    // Plant a DIRECTORY at the tokens.css path. readFile() rejects
+    // with EISDIR — a real-world stand-in for permission / packaged-
+    // resource path bugs that should fail visibly, not silently fall
+    // back. EACCES would be more lifelike but is hard to simulate
+    // portably across CI runners; EISDIR exercises the exact same
+    // "non-absence error" branch.
+    mkdirSync(path.join(dir, 'tokens.css'));
+
+    await expect(readDesignSystemAssets(root, 'broken-tokens')).rejects.toThrow(
+      /EISDIR|illegal operation|directory/i,
+    );
+  });
+
+  it('still treats ENOENT as absence even when one sibling is present (per-file independence holds under the stricter contract)', async () => {
+    // Pin the flip side of the rejection test above: tightening the
+    // catch must NOT regress the legacy ~138-brand fallback. With
+    // tokens.css present and components.html absent, the reader
+    // returns the present side and undefined for the missing one,
+    // exactly as before.
+    const root = fresh();
+    const dir = brandDir(root, 'partial');
+    writeFileSync(path.join(dir, 'tokens.css'), ':root { --x: 1; }');
+
+    const assets = await readDesignSystemAssets(root, 'partial');
+    expect(assets.tokensCss).toBe(':root { --x: 1; }');
+    expect(assets.fixtureHtml).toBeUndefined();
+  });
 });

--- a/apps/daemon/tests/design-system-assets.test.ts
+++ b/apps/daemon/tests/design-system-assets.test.ts
@@ -1,0 +1,76 @@
+// Focused test for readDesignSystemAssets — the new sibling-file reader
+// that lets the daemon ship the compiled (tokens.css + components.html)
+// form of a brand alongside its DESIGN.md prose. The legacy reader
+// (`readDesignSystem`, returning DESIGN.md content) already has implicit
+// coverage through the showcase + chat-route tests; this file pins the
+// new helper's contract so future changes can't silently regress the
+// "either or both files may be absent" semantics that PR-C relies on
+// for graceful fallback across the ~138 brands without compiled tokens
+// today.
+
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { readDesignSystemAssets } from '../src/design-systems.js';
+
+function fresh(): string {
+  return mkdtempSync(path.join(tmpdir(), 'od-design-system-assets-'));
+}
+
+function brandDir(root: string, id: string): string {
+  const dir = path.join(root, id);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe('readDesignSystemAssets', () => {
+  it('returns both fields when tokens.css and components.html are both present', async () => {
+    const root = fresh();
+    const dir = brandDir(root, 'sample');
+    writeFileSync(path.join(dir, 'tokens.css'), ':root {\n  --bg: #fff;\n}\n');
+    writeFileSync(
+      path.join(dir, 'components.html'),
+      '<!doctype html><html><body>fixture</body></html>\n',
+    );
+
+    const assets = await readDesignSystemAssets(root, 'sample');
+    expect(assets.tokensCss).toContain('--bg: #fff');
+    expect(assets.fixtureHtml).toContain('fixture');
+  });
+
+  it('returns the single field that exists when its sibling is missing (per-file independence)', async () => {
+    const root = fresh();
+    const dir = brandDir(root, 'tokens-only');
+    writeFileSync(path.join(dir, 'tokens.css'), ':root { --x: 1; }');
+
+    const tokensOnly = await readDesignSystemAssets(root, 'tokens-only');
+    expect(tokensOnly.tokensCss).toBe(':root { --x: 1; }');
+    expect(tokensOnly.fixtureHtml).toBeUndefined();
+
+    const fixtureDir = brandDir(root, 'fixture-only');
+    writeFileSync(path.join(fixtureDir, 'components.html'), '<p>only</p>');
+
+    const fixtureOnly = await readDesignSystemAssets(root, 'fixture-only');
+    expect(fixtureOnly.tokensCss).toBeUndefined();
+    expect(fixtureOnly.fixtureHtml).toBe('<p>only</p>');
+  });
+
+  it('returns an empty object when the brand directory has neither file', async () => {
+    const root = fresh();
+    brandDir(root, 'prose-only');
+
+    const assets = await readDesignSystemAssets(root, 'prose-only');
+    expect(assets.tokensCss).toBeUndefined();
+    expect(assets.fixtureHtml).toBeUndefined();
+  });
+
+  it('returns an empty object when the brand directory itself does not exist (legacy ~138-brand fallback)', async () => {
+    const root = fresh();
+    const assets = await readDesignSystemAssets(root, 'nonexistent-brand');
+    expect(assets.tokensCss).toBeUndefined();
+    expect(assets.fixtureHtml).toBeUndefined();
+  });
+});

--- a/apps/daemon/tests/prompts/system.test.ts
+++ b/apps/daemon/tests/prompts/system.test.ts
@@ -205,4 +205,94 @@ describe('composeSystemPrompt', () => {
       expect(prompt).not.toContain('- `github` (github)');
     });
   });
+
+  // The daemon experiment for compiling a brand's design system from prose
+  // (DESIGN.md) into a machine-readable contract (tokens.css) plus a worked
+  // fixture (components.html) lives in PR-C. The composer exposes two new
+  // optional inputs (`designSystemTokensCss`, `designSystemFixtureHtml`)
+  // that the daemon populates only when `OD_DESIGN_TOKEN_CHANNEL=1` is set
+  // AND the active brand actually ships those files. These tests pin the
+  // injection shape so the prompt structure cannot drift silently.
+  describe('design-system token + fixture injection (#PR-C)', () => {
+    const sampleTokensCss = ':root {\n  --bg: #ffffff;\n  --fg: #111111;\n  --accent: #0050d8;\n}';
+    const sampleFixtureHtml = '<!doctype html>\n<html lang="en">\n  <body><button class="btn btn-primary">Subscribe</button></body>\n</html>';
+
+    it('appends BOTH a tokens block and a fixture block when both inputs are present', () => {
+      const prompt = composeSystemPrompt({
+        designSystemTitle: 'default',
+        designSystemBody: '# Neutral Modern\n\n> Category: Utility\n\nProse description.',
+        designSystemTokensCss: sampleTokensCss,
+        designSystemFixtureHtml: sampleFixtureHtml,
+      });
+
+      expect(prompt).toContain('## Active design system tokens — default');
+      expect(prompt).toContain('Paste the unscoped `:root { ... }` block verbatim');
+      expect(prompt).toContain('--accent: #0050d8;');
+
+      expect(prompt).toContain('## Reference fixture — default');
+      expect(prompt).toContain('Match its component shapes');
+      expect(prompt).toContain('class="btn btn-primary"');
+    });
+
+    it('keeps the prompt byte-equivalent to the legacy path when both inputs are omitted', () => {
+      const baseline = composeSystemPrompt({
+        designSystemTitle: 'default',
+        designSystemBody: '# Neutral Modern\n\nProse only.',
+      });
+      const withFlagOffEquivalent = composeSystemPrompt({
+        designSystemTitle: 'default',
+        designSystemBody: '# Neutral Modern\n\nProse only.',
+        designSystemTokensCss: undefined,
+        designSystemFixtureHtml: undefined,
+      });
+
+      expect(withFlagOffEquivalent).toBe(baseline);
+      expect(withFlagOffEquivalent).not.toContain('## Active design system tokens');
+      expect(withFlagOffEquivalent).not.toContain('## Reference fixture');
+    });
+
+    it('gates the tokens and fixture blocks independently — either may be absent', () => {
+      const tokensOnly = composeSystemPrompt({
+        designSystemTitle: 'default',
+        designSystemBody: '# x\n\nbody',
+        designSystemTokensCss: sampleTokensCss,
+      });
+      expect(tokensOnly).toContain('## Active design system tokens — default');
+      expect(tokensOnly).not.toContain('## Reference fixture');
+
+      const fixtureOnly = composeSystemPrompt({
+        designSystemTitle: 'default',
+        designSystemBody: '# x\n\nbody',
+        designSystemFixtureHtml: sampleFixtureHtml,
+      });
+      expect(fixtureOnly).not.toContain('## Active design system tokens');
+      expect(fixtureOnly).toContain('## Reference fixture — default');
+    });
+
+    it('places the tokens + fixture blocks AFTER the DESIGN.md prose block (prose sets voice, structured form binds names)', () => {
+      const prompt = composeSystemPrompt({
+        designSystemTitle: 'default',
+        designSystemBody: 'PROSE_BODY_MARKER',
+        designSystemTokensCss: sampleTokensCss,
+        designSystemFixtureHtml: sampleFixtureHtml,
+      });
+      const proseAt = prompt.indexOf('PROSE_BODY_MARKER');
+      const tokensAt = prompt.indexOf('## Active design system tokens');
+      const fixtureAt = prompt.indexOf('## Reference fixture');
+      expect(proseAt).toBeGreaterThan(0);
+      expect(tokensAt).toBeGreaterThan(proseAt);
+      expect(fixtureAt).toBeGreaterThan(tokensAt);
+    });
+
+    it('treats whitespace-only inputs as absent (defensive, matches DESIGN.md block behavior)', () => {
+      const prompt = composeSystemPrompt({
+        designSystemTitle: 'default',
+        designSystemBody: '# x\n\nbody',
+        designSystemTokensCss: '   \n  \t  ',
+        designSystemFixtureHtml: '\n\n',
+      });
+      expect(prompt).not.toContain('## Active design system tokens');
+      expect(prompt).not.toContain('## Reference fixture');
+    });
+  });
 });


### PR DESCRIPTION
## Why

Follow-up to #1231. That PR landed the **structured** (machine-readable)
form of two brands — `design-systems/default/tokens.css` +
`components.html`, and the same pair for `kami` — and codified the
schema, but explicitly stopped short of changing runtime behavior:

> Daemon doesn't read these files yet — that's intentional. Prompt
> injection lands in a follow-up PR so the schema can absorb review
> feedback before downstream code starts depending on the shape.

This is that follow-up. Today the daemon's system prompt only carries
each brand's `DESIGN.md` prose — agents have to translate
`Primary: #000000` to `var(--accent)` themselves every turn, and that
translation step is where most token misuse happens (wrong slot,
inlined hex, invented names). With this change the daemon ships the
brand's `tokens.css` :root block AND a worked `components.html`
fixture alongside the prose, so agents can paste tokens verbatim and
copy fragments instead of re-deriving from English.

## What ships

Three small surface changes in the daemon, all on the prompt-assembly
path that fires for every chat run:

```
apps/daemon/src/design-systems.ts
  + readDesignSystemAssets(root, id) → { tokensCss?, fixtureHtml? }
    reads `<brand>/tokens.css` and `<brand>/components.html` if
    they exist; returns `undefined` for either missing file
    individually so brands with partial coverage still work

apps/daemon/src/server.ts
  + when an active design-system id is selected, also call
    readDesignSystemAssets() (gated by OD_DESIGN_TOKEN_CHANNEL=1),
    fall back from built-in dir → user-installed dir mirroring
    the existing readDesignSystem() chain
  + thread `designSystemTokensCss` + `designSystemFixtureHtml`
    into composeSystemPrompt({...}) alongside the existing
    designSystemBody / designSystemTitle

apps/daemon/src/prompts/system.ts
  + new optional ComposeInput fields:
      designSystemTokensCss?: string
      designSystemFixtureHtml?: string
  + each gated independently (whitespace-only counts as absent),
    appended AFTER the DESIGN.md block so prose still sets voice
    and the structured form binds names
```

Block ordering in the composed prompt is deliberate:

```
... discovery + identity charter + memory ...

## Active design system — <title>           ← DESIGN.md prose (existing)
  Treat the following DESIGN.md as authoritative for color, typography,
  spacing, and component rules ...

## Active design system tokens — <title>     ← NEW, gated
  The block below is this brand's tokens.css contract — every :root
  custom property the brand defines. Paste the unscoped :root { ... }
  block verbatim into the artifact's first <style> ...

## Reference fixture — <title>               ← NEW, gated
  A self-contained worked artifact in this design system. Match its
  component shapes ... copying fragments is encouraged as long as
  you keep the var(--*) references intact ...

## Active craft references ...               ← existing
## Active skill ...                          ← existing
```

DESIGN.md still leads because the prose carries voice, intent, and
the "feel" notes that aren't in the token grid. The compiled blocks
follow because their job is to disambiguate names + ground them in
worked HTML, not to set tone.

## Feature flag

Gated by `OD_DESIGN_TOKEN_CHANNEL=1` (env var, default off).

- **Flag off (default):** prompt is byte-equivalent to today's path.
  `readDesignSystemAssets()` is never called, no new strings appear
  in the composed prompt, no behavior change for any of the ~140
  brands — including `default` and `kami` which now ship the files.
- **Flag on:** the two new blocks are appended for any brand that
  ships either file. Today only `default` and `kami` do; the other
  ~138 brands silently skip both blocks because both files are absent.

The flag exists so PR-C can land before the smoke-test results are
in, and so a regression in artifact quality on the structured-form
path can be rolled back by clearing one env var instead of reverting
a merged PR. **Default flips to on in a follow-up** once the smoke
test (see below) confirms artifact quality improves on `default` +
`kami`. PR-B (the bulk derive script that gives the other ~138
brands their `tokens.css`) is on a separate, longer track.

## Verification

- `pnpm --filter @open-design/daemon test` → 1722 tests pass (115
  files), including the new ones below
- `pnpm --filter @open-design/daemon typecheck` → clean
- `pnpm guard` → all 6 design-system checks still green (this PR
  doesn't touch the structured-form contract from #1231; the guard
  state is identical pre/post)
- New focused tests (pin both the consumer and the producer side):
  - `apps/daemon/tests/design-system-assets.test.ts` — pins
    `readDesignSystemAssets()`'s "either-or-both files may be
    absent" semantics across 4 cases (both / tokens-only / fixture-
    only / brand-dir-empty), so future changes can't silently break
    the legacy ~138-brand fallback
  - `apps/daemon/tests/prompts/system.test.ts` (new
    `design-system token + fixture injection` describe block) —
    pins the prompt structure: both blocks appear when both inputs
    are present, prompt is byte-equivalent to baseline when both
    are absent (= flag-off), the two blocks are gated independently,
    they always land AFTER the DESIGN.md prose block, and
    whitespace-only inputs are treated as absent

## Smoke test (local, before defaulting flag on)

The structured-form contract is now consumed by the daemon, but
whether it actually moves the needle on artifact quality is an
empirical question. To answer it without a multi-week eval rig:

1. Pick one brand that ships the structured form: `default` or `kami`
2. Pick one prompt: e.g. *"做一个 hero 区块 + 主 CTA 按钮的着陆页"*
3. Run twice:
   - **Control:** `pnpm dev` (flag off) → produces `control.html`
   - **Treatment:** `OD_DESIGN_TOKEN_CHANNEL=1 pnpm dev` (same brief,
     same brand) → produces `treatment.html`
4. Eyeball the two artifacts side-by-side for these regressions that
   the structured form is supposed to fix:
   - **Color:** non-token hex values (purple gradient, random blue)
     in control but only `var(--accent)` / `var(--bg)` in treatment
   - **Type:** treatment matches the brand font; control sometimes
     falls back to system-ui or invents Inter
   - **Component shape:** treatment buttons / cards match
     `components.html` fixture; control's are generic
   - **Spacing:** treatment uses `var(--space-*)`; control hardcodes
     px values

Screenshots will be added to this PR description once the smoke
test runs. If treatment looks no better than control on either
brand, the flag stays off and the prompt copy gets revised before
flipping the default.

## Explicitly NOT in this PR

- **Default-on for `OD_DESIGN_TOKEN_CHANNEL`** — needs the smoke-test
  evidence first; lands as a one-line follow-up
- **Bulk coverage of the other ~138 brands** — needs the derive
  script (PR-B) that reads each `DESIGN.md` and emits a `tokens.css`
  draft for human review, sourcing A2 fallbacks from
  `_schema/defaults.css`
- **Misuse-rate quantification** — we agreed (in the PR-C planning
  thread) that a side-by-side eyeball comparison is sufficient signal
  for now; a formal lab can come later if smoke-test results are
  ambiguous

## Test plan

- [x] `pnpm --filter @open-design/daemon test` (1722 pass)
- [x] `pnpm --filter @open-design/daemon typecheck` (clean)
- [x] `pnpm guard` (6 design-system checks green)
- [ ] Smoke test on `default`, brief = hero + CTA, flag off vs on
- [ ] Smoke test on `kami`, brief = hero + CTA, flag off vs on
- [ ] (only if smoke tests are inconclusive) revise prompt copy and
      re-run before requesting review

Made with [Cursor](https://cursor.com)