### PR TITLE
Fix Langfuse report finalization hook

### DIFF
--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -2,7 +2,7 @@ import type { Express } from 'express';
 import { ArtifactRegressionError } from './artifact-stub-guard.js';
 import type { RouteDeps } from './server-context.js';
 
-export interface RegisterProjectRoutesDeps extends RouteDeps<'db' | 'design' | 'http' | 'paths' | 'projectStore' | 'projectFiles' | 'conversations' | 'templates' | 'status' | 'events' | 'ids'> {}
+export interface RegisterProjectRoutesDeps extends RouteDeps<'db' | 'design' | 'http' | 'paths' | 'projectStore' | 'projectFiles' | 'conversations' | 'templates' | 'status' | 'events' | 'ids' | 'telemetry'> {}
 
 export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDeps) {
   const { db, design } = ctx;
@@ -377,6 +377,7 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
     });
     // Bump the parent project's updatedAt so the project list re-orders.
     updateProject(db, req.params.id, {});
+    ctx.telemetry?.reportFinalizedMessage(saved, m);
     res.json({ message: saved });
   });
 

--- a/apps/daemon/src/server-context.ts
+++ b/apps/daemon/src/server-context.ts
@@ -53,6 +53,10 @@ export interface RoutineDeps {
   routineService: RoutineRoutesService;
 }
 
+export interface TelemetryDeps {
+  reportFinalizedMessage: (saved: any, body?: any) => void;
+}
+
 export interface ServerContext {
   db: any;
   design: any;
@@ -82,6 +86,7 @@ export interface ServerContext {
   mcp: any;
   resources: ResourceDeps;
   routines: RoutineDeps;
+  telemetry?: TelemetryDeps;
   validation: any;
   finalize: any;
   chat: any;

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1276,6 +1276,37 @@ export function telemetryPromptFromRunRequest(message, currentPrompt) {
   return typeof currentPrompt === 'string' ? currentPrompt : message;
 }
 
+export function createFinalizedMessageTelemetryReporter({
+  design,
+  db,
+  dataDir,
+  reportedRuns,
+  getAppVersion = () => null,
+  report = reportRunCompletedFromDaemon,
+}: {
+  design: any;
+  db: unknown;
+  dataDir: string;
+  reportedRuns: Set<string>;
+  getAppVersion?: () => any;
+  report?: typeof reportRunCompletedFromDaemon;
+}) {
+  return (saved, body = {}) => {
+    if (!shouldReportRunCompletedFromMessage(saved, body)) return;
+    const run = design.runs.get(saved.runId);
+    if (!run || reportedRuns.has(run.id)) return;
+    reportedRuns.add(run.id);
+    void report({
+      db,
+      dataDir,
+      run,
+      persistedRunStatus: saved.runStatus,
+      persistedEndedAt: saved.endedAt,
+      appVersion: getAppVersion(),
+    });
+  };
+}
+
 const CLOUDFLARE_PAGES_PROJECT_METADATA_KEY = 'cloudflarePagesProjectName';
 
 function cloudflarePagesDeploymentMetadata(projectName) {
@@ -2594,6 +2625,14 @@ export async function startServer({
     }
   })();
 
+  const reportFinalizedMessage = createFinalizedMessageTelemetryReporter({
+    design,
+    db,
+    dataDir: RUNTIME_DATA_DIR,
+    reportedRuns,
+    getAppVersion: () => cachedAppVersion,
+  });
+
   const validateExternalApiBaseUrl = (baseUrl) => validateBaseUrl(baseUrl);
 
   const resolvedPortRef = {
@@ -2815,6 +2854,7 @@ export async function startServer({
     status: projectStatusDeps,
     events: projectEventDeps,
     ids: idDeps,
+    telemetry: { reportFinalizedMessage },
   });
   registerImportRoutes(app, {
     db,

--- a/apps/daemon/tests/telemetry-message-finalization.test.ts
+++ b/apps/daemon/tests/telemetry-message-finalization.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
+  createFinalizedMessageTelemetryReporter,
   shouldReportRunCompletedFromMessage,
   telemetryPromptFromRunRequest,
 } from '../src/server.js';
@@ -54,5 +55,46 @@ describe('Langfuse message finalization gate', () => {
     expect(telemetryPromptFromRunRequest('legacy prompt', undefined)).toBe(
       'legacy prompt',
     );
+  });
+
+  it('invokes Langfuse reporting once when the final message write is marked', () => {
+    const run = {
+      id: 'run-1',
+      projectId: 'project-1',
+      conversationId: 'conv-1',
+      assistantMessageId: 'assistant-1',
+      status: 'succeeded',
+      createdAt: 1,
+      updatedAt: 2,
+      events: [],
+    };
+    const report = vi.fn();
+    const reporter = createFinalizedMessageTelemetryReporter({
+      design: { runs: { get: vi.fn(() => run) } },
+      db: 'db',
+      dataDir: '/tmp/od-data',
+      reportedRuns: new Set<string>(),
+      getAppVersion: () => ({ version: '0.7.0', channel: 'beta', packaged: true }),
+      report,
+    });
+
+    reporter(
+      { ...terminalMessage, endedAt: 1234 },
+      { telemetryFinalized: true },
+    );
+    reporter(
+      { ...terminalMessage, endedAt: 1234 },
+      { telemetryFinalized: true },
+    );
+
+    expect(report).toHaveBeenCalledTimes(1);
+    expect(report).toHaveBeenCalledWith({
+      db: 'db',
+      dataDir: '/tmp/od-data',
+      run,
+      persistedRunStatus: 'succeeded',
+      persistedEndedAt: 1234,
+      appVersion: { version: '0.7.0', channel: 'beta', packaged: true },
+    });
   });
 });


### PR DESCRIPTION
## Summary

- wire finalized assistant message writes to the Langfuse report bridge
- keep the existing `telemetryFinalized` gate so reports wait for final persisted content/produced files
- de-dupe reports per run through the existing `reportedRuns` set

## Validation

- `pnpm install`
- `pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/telemetry-message-finalization.test.ts tests/langfuse-bridge.test.ts tests/langfuse-trace.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/daemon build`
- `rg -n "createFinalizedMessageTelemetryReporter|reportRunCompletedFromDaemon|open-design-turn|OPEN_DESIGN_TELEMETRY_RELAY_URL|trace-create" apps/daemon/dist -S`
- `git diff --check`

## Diagnosis

The shipped relay URL, local consent, and Worker were configured correctly, but the daemon only imported `reportRunCompletedFromDaemon` and created `reportedRuns`; no code path invoked the bridge after a run completed. As a result the installed nightly never sent a relay request.