### PR TITLE
fix(web): allow same-origin for url-load preview iframes

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -5160,7 +5160,7 @@ function HtmlViewer({
                     data-testid="artifact-preview-frame"
                     data-od-render-mode="url-load"
                     title={file.name}
-                    sandbox="allow-scripts"
+                    sandbox="allow-scripts allow-same-origin"
                     src={previewSrcUrl}
                     onLoad={syncBridgeModes}
                   />
@@ -5396,7 +5396,7 @@ function HtmlViewer({
           {useUrlLoadPreview ? (
             <iframe
               title="present"
-              sandbox="allow-scripts"
+              sandbox="allow-scripts allow-same-origin"
               data-od-render-mode="url-load"
               src={previewSrcUrl}
             />


### PR DESCRIPTION
## Summary

- React/i18next artifacts previewed through FileViewer's URL-load branch threw `SecurityError` on every `localStorage` / `document.cookie` read because the iframe was sandboxed without `allow-same-origin`. The previewed app never mounted.
- Adds `allow-same-origin` to the two URL-load iframes in `FileViewer.tsx` (inline artifact preview + in-tab Present overlay). The `srcDoc` siblings stay on `sandbox="allow-scripts"` — they have null origin by design and use parent-injected postMessage bridges.
- See #1403 for full repro, root-cause analysis, and the same-origin sandbox-escape tradeoff that this fix accepts.

Fixes #1403

## Test plan

- [x] `pnpm --filter @open-design/web typecheck` — no new errors introduced (pre-existing `ChatMessageFeedback` / `feedback` errors on `main` are unrelated; verified by stashing the diff and re-running).
- [x] Manual: open a React + in-browser-Babel artifact whose `App()` calls `useState(() => localStorage.getItem(...))`; load via FileViewer's URL-load preview (no inspect / comment / palette / deck mode). Before: red `SecurityError` cascade in DevTools, blank iframe. After: app mounts cleanly.
- [x] Manual: same artifact, click into in-tab Present overlay — same expectation.
- [x] Manual: re-open an artifact that *needs* the srcDoc path (inspect mode, or a deck) and confirm those bridges still work — they should, because that branch is unchanged.

## Out of scope / follow-ups

- `apps/web/src/components/DesignFilesPanel.tsx:974` has the same `sandbox="allow-scripts"` + `src={projectFileUrl(...)}` pattern for HTML file thumbnails. Same browser rule applies if a thumbnail's HTML accesses `localStorage` / cookies; left out here so this PR stays scoped to the reported symptom.
- Long-term, serving `/api/projects/:id/raw/*` from a separate origin (different port or `*.nip.io`) would let us keep `allow-scripts` + `allow-same-origin` without the same-origin sandbox-escape caveat. Out of scope for this PR; mentioned in the issue.