### PR TITLE
fix(web/AssistantMessage): update status block detail to latest value instead of skipping

### DIFF
--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -1159,7 +1159,18 @@ function buildBlocks(events: AgentEvent[]): Block[] {
       )
         continue;
       const last = out[out.length - 1];
-      if (last && last.kind === "status" && last.label === ev.label) continue;
+      if (last && last.kind === "status" && last.label === ev.label) {
+        // Update detail to the latest value rather than skip. When an agent
+        // emits multiple status events with the same label (notably
+        // `label: 'model'` — fired once after `session/new` with the agent's
+        // initial default, then again after the explicit model-selection
+        // call completes), the badge UI must reflect the most recent detail,
+        // not the first one. Without this update the post-selection model
+        // (e.g. `claude-opus-4-7-high`) is silently replaced in the badge
+        // by the stale initial default (`swe-1-6-fast`).
+        last.detail = ev.detail;
+        continue;
+      }
       out.push({ kind: "status", label: ev.label, detail: ev.detail });
       continue;
     }

--- a/apps/web/tests/components/AssistantMessage.test.tsx
+++ b/apps/web/tests/components/AssistantMessage.test.tsx
@@ -125,3 +125,61 @@ describe('AssistantMessage feedback gate (issue #1288)', () => {
     expect(screen.queryByRole('group', { name: 'Feedback' })).toBeNull();
   });
 });
+
+describe('AssistantMessage status badge updates (Bug A)', () => {
+  // Regression coverage for the model-badge stale-detail bug. ACP agents
+  // emit two `status: 'model'` events per turn:
+  //   1. After session/new returns — the agent's initial default model
+  //      (e.g. `swe-1-6-fast` for Devin for Terminal)
+  //   2. After session/set_config_option (or legacy session/set_model)
+  //      succeeds — the user-selected model (e.g. `claude-opus-4-7-max`)
+  //
+  // The previous `buildBlocks` dedupe SKIPPED the second event and the
+  // badge stayed stuck on the initial default, even though the running
+  // model and the conversation header were already correct. The fix
+  // updates the existing block's detail to the latest value so the badge
+  // tracks the most recent model the daemon reported.
+  it('renders the most recent detail when multiple status events share a label', () => {
+    render(
+      <AssistantMessage
+        message={baseMessage({
+          events: [
+            { kind: 'status', label: 'model', detail: 'swe-1-6-fast' } as ChatMessage['events'][number],
+            { kind: 'status', label: 'model', detail: 'claude-opus-4-7-max' } as ChatMessage['events'][number],
+            { kind: 'text', text: 'Done.' } as ChatMessage['events'][number],
+          ],
+        })}
+        streaming={false}
+        projectId="proj-1"
+        onFeedback={vi.fn()}
+      />,
+    );
+
+    // Latest detail should be rendered in the badge.
+    expect(screen.getByText('claude-opus-4-7-max')).toBeTruthy();
+
+    // The initial default must not be present — if it is, the stale-detail
+    // bug is back.
+    expect(screen.queryByText('swe-1-6-fast')).toBeNull();
+  });
+
+  it('still collapses repeated status events with the same label and detail into a single badge', () => {
+    render(
+      <AssistantMessage
+        message={baseMessage({
+          events: [
+            { kind: 'status', label: 'model', detail: 'claude-opus-4-7-max' } as ChatMessage['events'][number],
+            { kind: 'status', label: 'model', detail: 'claude-opus-4-7-max' } as ChatMessage['events'][number],
+            { kind: 'text', text: 'Done.' } as ChatMessage['events'][number],
+          ],
+        })}
+        streaming={false}
+        projectId="proj-1"
+        onFeedback={vi.fn()}
+      />,
+    );
+
+    const matches = screen.queryAllByText('claude-opus-4-7-max');
+    expect(matches.length).toBe(1);
+  });
+});


### PR DESCRIPTION
Fixes #1410

## Summary

When using Open Design with an ACP agent (e.g. Devin for Terminal), after selecting a non-default model in the picker, the model badge under the conversation header kept showing the agent's initial default (`model swe-1-6-fast`) instead of the running model. The conversation header text and the agent itself reflected the selected model correctly — only the badge UI was stale.

**Root cause:** `buildBlocks()` in `apps/web/src/components/AssistantMessage.tsx` de-duplicated consecutive status events with the same label by SKIPPING the new one rather than updating the existing block:

```ts
const last = out[out.length - 1];
if (last && last.kind === "status" && last.label === ev.label) continue;
out.push({ kind: "status", label: ev.label, detail: ev.detail });
```

The daemon emits **two** `status: label='model'` events per turn for ACP agents (see `apps/daemon/src/acp.ts`):

| Order | Source | Detail |
|---|---|---|
| 1st | after `session/new` returns (line ~495) | the agent's initial default (e.g. `swe-1-6-fast`) |
| 2nd | after `session/set_config_option` succeeds (line ~587) or legacy `session/set_model` (line ~641) | the selected model (e.g. `claude-opus-4-7-high`) |

The dedupe kept the first event and skipped the second → badge stuck on default.

## Fix

Update the existing block's detail to the latest value instead of skipping:

```ts
const last = out[out.length - 1];
if (last && last.kind === "status" && last.label === ev.label) {
  last.detail = ev.detail;  // update instead of skip
  continue;
}
out.push({ kind: "status", label: ev.label, detail: ev.detail });
```

Other status labels reaching this code path (`'initializing'`, etc., after the early filter for transient labels like `streaming`/`starting`/`requesting`/`thinking`/`empty_response`) also benefit — "most recent detail wins" is more accurate than "first one wins forever."

## Validation

- `pnpm --filter @open-design/web exec vitest run tests/components/AssistantMessage.test.ts tests/components/AssistantMessage.test.tsx tests/components/assistant-message-tool-status.test.tsx tests/components/assistant-message-unfinished-todos.test.tsx` — **22/22 pass** (added 2 new regression tests in `AssistantMessage.test.tsx`):
  - Two sequential `status: 'model'` events with different details → block has the second detail (the Bug A scenario)
  - Two sequential events with the same detail → still collapses to a single badge (existing dedupe behavior preserved)
- `pnpm guard` — clean
- Manual UI verification on macOS (Apple Silicon) with Devin for Terminal `2026.5.6-4`:
  - Before the fix: badge shows `model swe-1-6-fast` regardless of selected model
  - After the fix: badge correctly tracks the selected model (`claude-opus-4-7-high`, `gpt-5-4-xhigh`, etc.) — verified across multiple model switches within the same conversation
  - Before/after screenshots attached below

## Notes

- Pre-invited by @lefarcen on the #1208 review thread ("address it as part of session-pool work / a quick follow-up PR after #1208 merges") — this PR delivers that follow-up.
- Bug B from the same #1208 validation was already addressed in #1286 (now merged).

Before
<img width="489" height="463" alt="Screenshot 2026-05-12 at 15 05 42" src="https://github.com/user-attachments/assets/e1b0e94b-fcb7-4e69-83c6-8b7333edf5fa" />

After
<img width="496" height="436" alt="Screenshot 2026-05-12 at 15 28 14" src="https://github.com/user-attachments/assets/be674c8a-0ae5-49ce-b316-32d8ade562c7" />
