### PR TITLE
fix(web): increase the padding for titlebar from top only

### DIFF
--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -473,7 +473,10 @@ const MAC_WINDOW_CHROME_CSS = `
   .prompt-template-lightbox-backdrop * {
     -webkit-app-region: no-drag;
   }
-  .entry-brand,
+  .entry-brand {
+    -webkit-app-region: drag;
+    padding-top: 32px !important;
+  }
   .entry-header {
     -webkit-app-region: drag;
   }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -3819,7 +3819,7 @@ code {
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 24px 20px 18px;
+  padding: 32px 20px 18px;
 }
 .entry-brand-actions {
   margin-left: auto;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -3819,7 +3819,7 @@ code {
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 32px 20px 18px;
+  padding: 24px 20px 18px;
 }
 .entry-brand-actions {
   margin-left: auto;


### PR DESCRIPTION
Fixes #1427

## Summary

* Increased spacing between the window controls and the Open Design logo in the title bar
* Improved visual balance and reduced cramped spacing in the header area

## Validation

* Verified spacing and alignment changes locally
* Confirmed no layout regressions in the header/title bar