### PR TITLE
[codex] Fix appearance accent color persistence

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -26,7 +26,7 @@ export const viewport: Viewport = {
  * Keep the accent variable mix ratios in sync with `accentVars()` in
  * `src/state/appearance.ts`; this script cannot import application modules.
  */
-const themeInitScript = `(function(){try{var c=JSON.parse(localStorage.getItem('open-design:config')||'{}');var t=c.theme;if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);var a=typeof c.accentColor==='string'&&/^#[0-9a-fA-F]{6}$/.test(c.accentColor.trim())?c.accentColor.trim().toLowerCase():'';if(a){var s=document.documentElement.style;s.setProperty('--accent',a);s.setProperty('--accent-strong','color-mix(in srgb, '+a+' 86%, var(--text-strong))');s.setProperty('--accent-soft','color-mix(in srgb, '+a+' 22%, var(--bg-panel))');s.setProperty('--accent-tint','color-mix(in srgb, '+a+' 12%, var(--bg-panel))');s.setProperty('--accent-hover','color-mix(in srgb, '+a+' 90%, var(--text-strong))');}}catch(e){}})();`;
+const themeInitScript = `(function(){try{var c=JSON.parse(localStorage.getItem('open-design:config')||'{}');var t=c.theme;if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);var a=typeof c.accentColor==='string'&&/^#[0-9a-fA-F]{6}$/.test(c.accentColor.trim())?c.accentColor.trim().toLowerCase():'#c96442';var s=document.documentElement.style;s.setProperty('--accent',a);s.setProperty('--accent-strong','color-mix(in srgb, '+a+' 86%, var(--text-strong))');s.setProperty('--accent-soft','color-mix(in srgb, '+a+' 22%, var(--bg-panel))');s.setProperty('--accent-tint','color-mix(in srgb, '+a+' 12%, var(--bg-panel))');s.setProperty('--accent-hover','color-mix(in srgb, '+a+' 90%, var(--text-strong))');}catch(e){}})();`;
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -65,8 +65,11 @@ import { ConnectorsBrowser } from './ConnectorsBrowser';
 import { MemoryModelInline } from './MemoryModelInline';
 import { MemorySection } from './MemorySection';
 import {
+  ACCENT_SWATCHES,
+  DEFAULT_ACCENT_COLOR,
   applyAppearanceToDocument,
   normalizeAccentColor,
+  resolveAccentColor,
 } from '../state/appearance';
 import { isAutosaveDraftOnlyChange } from '../App';
 import {
@@ -635,18 +638,26 @@ export function SettingsDialog({
 }: Props) {
   const { t, locale, setLocale } = useI18n();
   const [cfg, setCfg] = useState<AppConfig>(initial);
+  const lastSavedAppearanceRef = useRef({
+    theme: initial.theme ?? 'system',
+    accentColor: resolveAccentColor(initial.accentColor),
+  });
 
-  // Revert the live theme preview when the dialog closes without saving.
-  // On Save, App's useLayoutEffect fires after unmount and applies the new
-  // saved theme, so this cleanup is effectively a no-op in that path.
-  useLayoutEffect(() => {
-    return () => {
-      applyAppearanceToDocument({
-        theme: initial.theme ?? 'system',
-        accentColor: initial.accentColor,
-      });
+  useEffect(() => {
+    lastSavedAppearanceRef.current = {
+      theme: initial.theme ?? 'system',
+      accentColor: resolveAccentColor(initial.accentColor),
     };
   }, [initial.theme, initial.accentColor]);
+
+  // Revert the live theme preview to the most recently persisted appearance.
+  // That is the initial appearance until autosave succeeds; after autosave,
+  // closing Settings must not roll the document back to stale colors.
+  useLayoutEffect(() => {
+    return () => {
+      applyAppearanceToDocument(lastSavedAppearanceRef.current);
+    };
+  }, []);
   const [showApiKey, setShowApiKey] = useState(false);
   const [languageOpen, setLanguageOpen] = useState(false);
   const [activeSection, setActiveSection] = useState<SettingsSection>(initialSection);
@@ -1198,6 +1209,10 @@ export function SettingsDialog({
         try {
           await onPersist(snapshot, persistOptions);
           autosaveLastSavedRef.current = snapshot;
+          lastSavedAppearanceRef.current = {
+            theme: snapshot.theme ?? 'system',
+            accentColor: resolveAccentColor(snapshot.accentColor),
+          };
           if (persistOptions.forceMediaProviderSync) {
             lastSyncedMediaProvidersVersionRef.current = mediaProvidersVersion;
           }
@@ -4594,18 +4609,6 @@ const THEMES: Array<{ value: AppTheme; labelKey: 'settings.themeSystem' | 'setti
   { value: 'dark', labelKey: 'settings.themeDark' },
 ];
 
-const DEFAULT_ACCENT_COLOR = '#c96442';
-const ACCENT_SWATCHES = [
-  DEFAULT_ACCENT_COLOR,
-  '#2563eb',
-  '#7c3aed',
-  '#059669',
-  '#dc2626',
-  '#d97706',
-  '#0891b2',
-  '#db2777',
-] as const;
-
 function AppearanceSection({
   cfg,
   setCfg,
@@ -4615,19 +4618,19 @@ function AppearanceSection({
 }) {
   const { t } = useI18n();
   const current = cfg.theme ?? 'system';
-  const currentAccent = normalizeAccentColor(cfg.accentColor) ?? DEFAULT_ACCENT_COLOR;
+  const currentAccent = resolveAccentColor(cfg.accentColor);
 
   // Apply the draft theme immediately so the user sees a live preview
   // before hitting Save. SettingsDialog's cleanup reverts this on cancel.
   useLayoutEffect(() => {
     applyAppearanceToDocument({
       theme: current,
-      accentColor: cfg.accentColor,
+      accentColor: currentAccent,
     });
-  }, [current, cfg.accentColor]);
+  }, [current, currentAccent]);
 
-  const setAccentColor = (color: string | undefined) => {
-    setCfg((c) => ({ ...c, accentColor: color ? normalizeAccentColor(color) ?? c.accentColor : undefined }));
+  const setAccentColor = (color: string) => {
+    setCfg((c) => ({ ...c, accentColor: normalizeAccentColor(color) ?? c.accentColor ?? DEFAULT_ACCENT_COLOR }));
   };
 
   return (
@@ -4665,7 +4668,7 @@ function AppearanceSection({
                 aria-label={color === DEFAULT_ACCENT_COLOR ? 'Default accent color' : color}
                 aria-checked={active}
                 role="radio"
-                onClick={() => setAccentColor(color === DEFAULT_ACCENT_COLOR ? undefined : color)}
+                onClick={() => setAccentColor(color)}
               />
             );
           })}

--- a/apps/web/src/state/appearance.ts
+++ b/apps/web/src/state/appearance.ts
@@ -8,10 +8,26 @@ const ACCENT_VARS = [
   '--accent-hover',
 ] as const;
 
+export const DEFAULT_ACCENT_COLOR = '#c96442';
+export const ACCENT_SWATCHES = [
+  DEFAULT_ACCENT_COLOR,
+  '#2563eb',
+  '#7c3aed',
+  '#059669',
+  '#dc2626',
+  '#d97706',
+  '#0891b2',
+  '#db2777',
+] as const;
+
 export function normalizeAccentColor(value: unknown): string | null {
   if (typeof value !== 'string') return null;
   const trimmed = value.trim();
   return /^#[0-9a-fA-F]{6}$/.test(trimmed) ? trimmed.toLowerCase() : null;
+}
+
+export function resolveAccentColor(value: unknown): string {
+  return normalizeAccentColor(value) ?? DEFAULT_ACCENT_COLOR;
 }
 
 function accentVars(accentColor: string): Record<(typeof ACCENT_VARS)[number], string> {
@@ -39,12 +55,7 @@ export function applyAppearanceToDocument({
     root.removeAttribute('data-theme');
   }
 
-  const normalized = normalizeAccentColor(accentColor);
-  if (!normalized) {
-    for (const name of ACCENT_VARS) root.style.removeProperty(name);
-    return;
-  }
-
+  const normalized = resolveAccentColor(accentColor);
   const vars = accentVars(normalized);
   for (const name of ACCENT_VARS) {
     root.style.setProperty(name, vars[name]);

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -9,7 +9,10 @@ import type {
   OrbitConfig,
   PetConfig,
 } from '../types';
-import { normalizeAccentColor } from './appearance';
+import {
+  DEFAULT_ACCENT_COLOR,
+  normalizeAccentColor,
+} from './appearance';
 import {
   DEFAULT_FAILURE_SOUND_ID,
   DEFAULT_SUCCESS_SOUND_ID,
@@ -71,6 +74,7 @@ export const DEFAULT_CONFIG: AppConfig = {
   designSystemId: null,
   onboardingCompleted: false,
   theme: 'system',
+  accentColor: DEFAULT_ACCENT_COLOR,
   mediaProviders: {},
   composio: {},
   agentModels: {},

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -1669,6 +1669,16 @@ describe('SettingsDialog appearance interactions', () => {
     expect(screen.getByRole('button', { name: 'Dark' }).getAttribute('aria-pressed')).toBe('false');
   });
 
+  it('applies the first accent color as the default appearance color', () => {
+    renderSettingsDialog(
+      { theme: 'system' },
+      { initialSection: 'appearance' },
+    );
+
+    expect(screen.getByRole('radio', { name: 'Default accent color' }).getAttribute('aria-checked')).toBe('true');
+    expect(document.documentElement.style.getPropertyValue('--accent')).toBe('#c96442');
+  });
+
   it('live previews explicit themes and removes the explicit document theme when switching back to System', () => {
     renderSettingsDialog(
       { theme: 'dark' },
@@ -1719,6 +1729,48 @@ describe('SettingsDialog appearance interactions', () => {
       }),
       {},
     );
+  });
+
+  it('switches back to the default accent color and persists it explicitly', async () => {
+    const { onPersist } = renderSettingsDialog(
+      { mode: 'daemon', agentId: 'codex', theme: 'light', accentColor: '#2563eb' },
+      { initialSection: 'appearance' },
+    );
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Default accent color' }));
+
+    expect(document.documentElement.style.getPropertyValue('--accent')).toBe('#c96442');
+
+    await waitForPersist(
+      onPersist,
+      expect.objectContaining({
+        accentColor: '#c96442',
+      }),
+      {},
+    );
+  });
+
+  it('keeps an autosaved accent color applied after the dialog closes', async () => {
+    const view = renderSettingsDialog(
+      { mode: 'daemon', agentId: 'codex', theme: 'light', accentColor: '#2563eb' },
+      { initialSection: 'appearance' },
+    );
+
+    fireEvent.click(screen.getByRole('radio', { name: '#059669' }));
+
+    await waitForPersist(
+      view.onPersist,
+      expect.objectContaining({
+        accentColor: '#059669',
+      }),
+      {},
+    );
+
+    fireEvent.click(view.container.querySelector('.settings-close') as HTMLElement);
+    expect(view.onClose).toHaveBeenCalledTimes(1);
+
+    view.unmount();
+    expect(document.documentElement.style.getPropertyValue('--accent')).toBe('#059669');
   });
 
   it('live previews and autosaves preset and custom accent colors', async () => {

--- a/apps/web/tests/state/appearance.test.ts
+++ b/apps/web/tests/state/appearance.test.ts
@@ -2,8 +2,10 @@
 
 import { afterEach, describe, expect, it } from 'vitest';
 import {
+  DEFAULT_ACCENT_COLOR,
   applyAppearanceToDocument,
   normalizeAccentColor,
+  resolveAccentColor,
 } from '../../src/state/appearance';
 
 describe('normalizeAccentColor', () => {
@@ -15,6 +17,13 @@ describe('normalizeAccentColor', () => {
     expect(normalizeAccentColor('blue')).toBeNull();
     expect(normalizeAccentColor('#123')).toBeNull();
     expect(normalizeAccentColor('#12345g')).toBeNull();
+  });
+});
+
+describe('resolveAccentColor', () => {
+  it('falls back to the first appearance color for missing or invalid values', () => {
+    expect(resolveAccentColor(undefined)).toBe(DEFAULT_ACCENT_COLOR);
+    expect(resolveAccentColor('blue')).toBe(DEFAULT_ACCENT_COLOR);
   });
 });
 
@@ -62,12 +71,12 @@ describe('applyAppearanceToDocument', () => {
     expect(document.documentElement.style.getPropertyValue('--accent-hover')).toContain('#ef4444');
   });
 
-  it('clears accent overrides when no valid accent is configured', () => {
+  it('falls back to the default accent when no valid accent is configured', () => {
     document.documentElement.style.setProperty('--accent', '#4f46e5');
 
     applyAppearanceToDocument({ theme: 'system', accentColor: 'not-a-color' });
 
     expect(document.documentElement.hasAttribute('data-theme')).toBe(false);
-    expect(document.documentElement.style.getPropertyValue('--accent')).toBe('');
+    expect(document.documentElement.style.getPropertyValue('--accent')).toBe(DEFAULT_ACCENT_COLOR);
   });
 });

--- a/apps/web/tests/state/config.test.ts
+++ b/apps/web/tests/state/config.test.ts
@@ -786,6 +786,7 @@ describe('loadConfig', () => {
   it('sets an explicit apiProtocol for new default configs', () => {
     expect(DEFAULT_CONFIG.apiProtocol).toBe('anthropic');
     expect(DEFAULT_CONFIG.configMigrationVersion).toBe(1);
+    expect(DEFAULT_CONFIG.accentColor).toBe('#c96442');
   });
 });
 


### PR DESCRIPTION
## Summary

- Make the Appearance accent default explicit as the first swatch color (`#c96442`).
- Apply that default through config loading, the pre-hydration theme script, and document appearance updates.
- Preserve the most recently autosaved appearance when closing Settings so Color changes do not roll back.

## Root Cause

The default Appearance Color only existed as a local UI fallback. Selecting the first swatch wrote `undefined`, and the document cleanup on Settings close reapplied the stale appearance from when the dialog opened. That made the default read as unset and could make saved Color changes appear ineffective after closing Settings.

## Validation

- `pnpm install`
- Red `pnpm --filter @open-design/web test -- SettingsDialog.execution.test.tsx` failed on the new default-color expectations.
- Red `pnpm --filter @open-design/web test -- SettingsDialog.execution.test.tsx` failed on the close-after-autosave rollback expectation.
- `pnpm --filter @open-design/web test -- SettingsDialog.execution.test.tsx state/appearance.test.ts state/config.test.ts`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`