### PR TITLE
fix(picker): improve provider group header separation in Media model picker

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -17937,7 +17937,9 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   top: 0;
   background: var(--bg-panel);
   padding: 8px 10px 4px;
+  min-height: 32px;
   z-index: 1;
+  border-bottom: 1px solid var(--border);
 }
 
 .palette-tweaks-anchor { position: relative; display: inline-flex; }


### PR DESCRIPTION
Hey! 👋

This PR fixes the visual overlap issue in the Media model picker where the provider group header doesn't fully separate from the model content below.

## The Problem

When creating a new project and selecting a model under Media, the provider grouping layout appears visually broken. The OpenAI section header doesn't fully cover or clearly separate from the model item beneath it.

## The Solution

Added `min-height` and `border-bottom` to the sticky provider group header to ensure it fully separates from the model content below.

## What Changed

- Added `min-height: 32px` to ensure the header has enough height
- Added `border-bottom: 1px solid var(--border)` to create a clear visual separation

## Testing

- Verified the fix resolves the visual overlap issue
- No visual regression on other parts of the UI

Fixes #1434