### PR TITLE
Set up agent docs and stabilize workspace tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,7 @@ jobs:
       - name: App workspace tests
         run: |
           pnpm --filter @open-design/daemon test
+          pnpm --filter @open-design/telemetry-worker test
           pnpm --filter @open-design/web test
           pnpm --filter @open-design/tools-dev test
           pnpm --filter @open-design/tools-pack test
@@ -165,6 +166,40 @@ jobs:
       # races outweigh the lost parallelism; revisit if the package count grows.
       - name: Build workspaces
         run: pnpm -r --workspace-concurrency=1 --if-present run build
+
+  automerge-gate:
+    name: automerge-gate
+    runs-on: ubuntu-latest
+    needs: [validate, packaged_changes, packaged_smoke_mac, packaged_smoke_win]
+    if: ${{ always() }}
+
+    steps:
+      - name: Require workspace and packaged validation to pass
+        env:
+          VALIDATE_RESULT: ${{ needs.validate.result }}
+          PACKAGED_CHANGES_RESULT: ${{ needs.packaged_changes.result }}
+          PACKAGED_REQUIRED: ${{ needs.packaged_changes.outputs.required }}
+          MAC_SMOKE_RESULT: ${{ needs.packaged_smoke_mac.result }}
+          WIN_SMOKE_RESULT: ${{ needs.packaged_smoke_win.result }}
+        run: |
+          if [ "$VALIDATE_RESULT" != "success" ]; then
+            echo "validate result: $VALIDATE_RESULT"
+            exit 1
+          fi
+          if [ "$PACKAGED_CHANGES_RESULT" != "success" ]; then
+            echo "packaged_changes result: $PACKAGED_CHANGES_RESULT"
+            exit 1
+          fi
+          if [ "$PACKAGED_REQUIRED" = "true" ]; then
+            if [ "$MAC_SMOKE_RESULT" != "success" ]; then
+              echo "packaged_smoke_mac result: $MAC_SMOKE_RESULT"
+              exit 1
+            fi
+            if [ "$WIN_SMOKE_RESULT" != "success" ]; then
+              echo "packaged_smoke_win result: $WIN_SMOKE_RESULT"
+              exit 1
+            fi
+          fi
 
   packaged_smoke_mac:
     name: Packaged mac smoke

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -2,8 +2,9 @@ name: github-metrics
 
 on:
   schedule:
-    # Runs daily at 00:15 UTC; output is committed to docs/assets/github-metrics.svg.
-    - cron: '15 0 * * *'
+    # Runs weekly Mon 00:15 UTC (was daily); output is committed to docs/assets/github-metrics.svg.
+    # Reduced from daily to cut Actions minutes — this is a vanity metrics SVG. Use workflow_dispatch for ad-hoc refresh.
+    - cron: '15 0 * * 1'
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/refresh-contributors-wall.yml
+++ b/.github/workflows/refresh-contributors-wall.yml
@@ -1,10 +1,11 @@
 name: refresh-contributors-wall
 
 on:
-  # Daily refresh keeps the contributors wall CDN cache moving even when
-  # contributor data changes outside pull request merges.
+  # Weekly refresh (was daily) keeps the contributors wall CDN cache moving even when
+  # contributor data changes outside pull request merges. Reduced to cut Actions minutes;
+  # use workflow_dispatch for an immediate refresh after bulk contributor updates.
   schedule:
-    - cron: '0 1 * * *'
+    - cron: '0 1 * * 1'
   # Manual trigger: Use when you need to force-refresh the contributors wall
   # outside the daily schedule (e.g., after a bulk contributor update or
   # after fixing the cache_bust pattern in README files).

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -33,7 +33,12 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  OPEN_DESIGN_DAEMON_SENTRY_ENVIRONMENT: production
+  OPEN_DESIGN_DAEMON_SENTRY_TRACES_SAMPLE_RATE: "0.1"
   OPEN_DESIGN_TELEMETRY_RELAY_URL: ${{ vars.OPEN_DESIGN_TELEMETRY_RELAY_URL }}
+  SENTRY_ENVIRONMENT: production
+  SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+  SENTRY_PROJECT: ${{ vars.OPEN_DESIGN_WEB_SENTRY_PROJECT }}
 
 jobs:
   metadata:
@@ -148,6 +153,10 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.OPEN_DESIGN_WEB_SENTRY_DSN }}
+          OPEN_DESIGN_DAEMON_SENTRY_DSN: ${{ secrets.OPEN_DESIGN_DAEMON_SENTRY_DSN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_DSN: ${{ secrets.OPEN_DESIGN_WEB_SENTRY_DSN }}
         run: |
           set -euo pipefail
           tools_pack_dir="$RUNNER_TEMP/tools-pack"
@@ -316,6 +325,11 @@ jobs:
         run: npm pkg set "version=${{ needs.metadata.outputs.beta_version }}" --prefix apps/packaged
 
       - name: Build beta mac intel artifacts
+        env:
+          NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.OPEN_DESIGN_WEB_SENTRY_DSN }}
+          OPEN_DESIGN_DAEMON_SENTRY_DSN: ${{ secrets.OPEN_DESIGN_DAEMON_SENTRY_DSN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_DSN: ${{ secrets.OPEN_DESIGN_WEB_SENTRY_DSN }}
         run: |
           set -euo pipefail
           pnpm exec tools-pack mac build \
@@ -401,6 +415,11 @@ jobs:
 
       - name: Build beta windows artifacts
         id: win_tools_pack_build
+        env:
+          NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.OPEN_DESIGN_WEB_SENTRY_DSN }}
+          OPEN_DESIGN_DAEMON_SENTRY_DSN: ${{ secrets.OPEN_DESIGN_DAEMON_SENTRY_DSN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_DSN: ${{ secrets.OPEN_DESIGN_WEB_SENTRY_DSN }}
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
@@ -554,6 +573,11 @@ jobs:
       # distros than ubuntu-latest's glibc 2.39. Docker is preinstalled on the
       # GitHub-hosted ubuntu-latest runner, so no extra setup is required.
       - name: Build beta linux artifacts
+        env:
+          NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.OPEN_DESIGN_WEB_SENTRY_DSN }}
+          OPEN_DESIGN_DAEMON_SENTRY_DSN: ${{ secrets.OPEN_DESIGN_DAEMON_SENTRY_DSN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_DSN: ${{ secrets.OPEN_DESIGN_WEB_SENTRY_DSN }}
         run: |
           set -euo pipefail
           pnpm exec tools-pack linux build \

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -25,7 +25,12 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  OPEN_DESIGN_DAEMON_SENTRY_ENVIRONMENT: production
+  OPEN_DESIGN_DAEMON_SENTRY_TRACES_SAMPLE_RATE: "0.1"
   OPEN_DESIGN_TELEMETRY_RELAY_URL: ${{ vars.OPEN_DESIGN_TELEMETRY_RELAY_URL }}
+  SENTRY_ENVIRONMENT: production
+  SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+  SENTRY_PROJECT: ${{ vars.OPEN_DESIGN_WEB_SENTRY_PROJECT }}
 
 jobs:
   metadata:
@@ -194,6 +199,10 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.OPEN_DESIGN_WEB_SENTRY_DSN }}
+          OPEN_DESIGN_DAEMON_SENTRY_DSN: ${{ secrets.OPEN_DESIGN_DAEMON_SENTRY_DSN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_DSN: ${{ secrets.OPEN_DESIGN_WEB_SENTRY_DSN }}
         run: |
           set -euo pipefail
           tools_pack_dir="$RUNNER_TEMP/tools-pack"
@@ -379,6 +388,10 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.OPEN_DESIGN_WEB_SENTRY_DSN }}
+          OPEN_DESIGN_DAEMON_SENTRY_DSN: ${{ secrets.OPEN_DESIGN_DAEMON_SENTRY_DSN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_DSN: ${{ secrets.OPEN_DESIGN_WEB_SENTRY_DSN }}
         run: |
           set -euo pipefail
           pnpm exec tools-pack mac build \
@@ -466,6 +479,11 @@ jobs:
 
       - name: Build release windows artifacts
         id: win_tools_pack_build
+        env:
+          NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.OPEN_DESIGN_WEB_SENTRY_DSN }}
+          OPEN_DESIGN_DAEMON_SENTRY_DSN: ${{ secrets.OPEN_DESIGN_DAEMON_SENTRY_DSN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_DSN: ${{ secrets.OPEN_DESIGN_WEB_SENTRY_DSN }}
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
@@ -624,6 +642,11 @@ jobs:
       # distros than ubuntu-latest's glibc 2.39. Docker is preinstalled on the
       # GitHub-hosted ubuntu-latest runner, so no extra setup is required.
       - name: Build release linux artifacts
+        env:
+          NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.OPEN_DESIGN_WEB_SENTRY_DSN }}
+          OPEN_DESIGN_DAEMON_SENTRY_DSN: ${{ secrets.OPEN_DESIGN_DAEMON_SENTRY_DSN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_DSN: ${{ secrets.OPEN_DESIGN_WEB_SENTRY_DSN }}
         run: |
           set -euo pipefail
           pnpm exec tools-pack linux build \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,15 @@
 @AGENTS.md
+
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs are tracked in GitHub Issues for `zhenheco/open-design`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Triage uses the default five-label vocabulary. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+This repo uses a single-context domain-doc layout. See `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -32,12 +32,66 @@ _Avoid_: upstream, dependency
 This repo's role when it builds on a chosen upstream while adding fixes, integration work, and differentiation.
 _Avoid_: rewrite, clone
 
+**Guided create flow**:
+The primary creation entry where the user starts by choosing an artifact intent such as EDM, landing page, social post, deck, banner, or custom size, then the system applies suitable dimensions, constraints, and prompting.
+_Avoid_: onboarding tutorial, empty project wizard
+
+**Artifact intent catalog**:
+The broad set of design outcomes the **Guided create flow** can start from, covering digital, print, document, presentation, video, web, merchandise, packaging, signage, and custom formats.
+_Avoid_: small template list, mode switch only
+
+**Conversational design creation**:
+The target interaction model where the user can describe the desired design in conversation and Open Design drives the artifact generation/editing loop.
+_Avoid_: form-only generator, template picker
+
+**Taste profile**:
+A persistent design-preference memory for the user. It captures preferred direction, style, palette, typography feel, layout tendencies, and repeated feedback across projects.
+_Avoid_: brand system, theme preset, one-off prompt
+
+**Reference board**:
+A place where the user can save design references discovered over time, such as Pinterest pins, Behance projects, websites, screenshots, or notes, so Open Design can later extract taste signals from them.
+_Avoid_: per-run link dump, asset library
+
+**Style card**:
+A structured, editable summary of extracted taste signals from one or more references. It translates raw inspiration into generation-ready direction such as color behavior, typography personality, composition, density, mood, medium-transfer notes, and constraints.
+_Avoid_: raw screenshot, template, moodboard only
+
+**Taste extraction**:
+The process that turns references and feedback into structured preference signals for the **Taste profile**.
+_Avoid_: copying designs, scraping for templates
+
+**Cross-medium taste transfer**:
+Using a reference from one medium, such as packaging, editorial layout, interior branding, or a website, to inform a different artifact type such as a DM, business card, EDM, or social post.
+_Avoid_: same-format template matching, direct copying
+
+**Print spec**:
+A printer-provided requirement set for physical production, including final size, bleed, safe area, color mode/profile, resolution, paper or material, finishing, dieline, folds, binding, spot colors, and file delivery rules.
+_Avoid_: generic PDF setting, design brief
+
+**Print spec preset**:
+A reusable saved **Print spec** for a known vendor, product, size, material, or dieline, so future projects can start from the same production constraints without re-uploading the spec.
+_Avoid_: template, design preset
+
+**Print-ready handoff**:
+An export package intended for a print vendor, including preflight checks and files such as PDF Print/PDF-X-compatible output, CMYK-compatible color, bleed, crop marks, embedded or outlined fonts, high-resolution images, and any required dielines or notes.
+_Avoid_: screenshot export, web PDF, final-looking preview
+
+**Taste evolution**:
+The product promise that Open Design improves its understanding of the user's design taste over time by updating the **Taste profile** from the **Reference board**, conversations, and accepted/rejected outputs.
+_Avoid_: automatic brand rewrite, hidden design-system mutation
+
 ## Relationships
 
 - **Open Design** produces **Design artifacts** by orchestrating coding agents through **Skills**.
 - A **Design system** constrains the visual language used by a **Skill** when generating a **Design artifact**.
 - `nexu-io/open-design` is the **Upstream** for this **Productization fork**.
 - `OpenCoworkAI/open-codesign`, `multica-ai/multica`, `op7418/guizang-ppt-skill`, and similar repos are **Reference projects** unless explicitly promoted to **Upstream**.
+- **Guided create flow** chooses from the **Artifact intent catalog** and applies starting constraints before the user enters **Conversational design creation**.
+- **Reference board** entries feed **Taste extraction**; extracted signals become **Style cards** and can update the **Taste profile**.
+- **Cross-medium taste transfer** lets a saved reference influence a different output medium by extracting palette, composition, mood, material feel, typography personality, and visual hierarchy rather than copying the source.
+- **Style cards** are the generation-facing form of taste. Raw references remain inspectable, but agents should consume structured style signals when possible.
+- Print-oriented artifact intents may attach a **Print spec** or **Print spec preset** and should end in a **Print-ready handoff**, not only a previewable design artifact.
+- **Taste profile** informs future **Conversational design creation**, but a project **Design system** still wins when brand tokens or rules conflict with user taste.
 
 ## Example dialogue
 
@@ -47,3 +101,4 @@ _Avoid_: rewrite, clone
 ## Flagged ambiguities
 
 - "repo to fork" was ambiguous between **Upstream** and **Reference project**. Resolved: `nexu-io/open-design` is the upstream; other repos are evaluated for reusable patterns, skills, or license-compatible vendoring.
+- "auto-evolution" was ambiguous between evolving artifacts, mutating design systems, and learning user taste. Resolved: **Taste evolution** means the user's **Taste profile** improves over time from saved references and feedback. It does not silently rewrite a project **Design system**.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,49 @@
+# Open Design
+
+Open Design is an open-source substrate for generating editable design artifacts through the user's existing coding-agent CLI. This context captures the product language and architectural boundaries used when planning the system.
+
+## Language
+
+**Open Design**:
+The product system this repo is building: a web app plus local daemon that turns briefs into editable design artifacts through external coding agents.
+_Avoid_: Claude Design clone, design generator
+
+**Design artifact**:
+A generated, previewable output such as an HTML prototype, deck, template, media composition, or `DESIGN.md`.
+_Avoid_: mockup, output, result
+
+**Skill**:
+A file-based agent instruction package, usually `SKILL.md` plus optional assets and references, that teaches an agent how to produce a specific artifact shape.
+_Avoid_: plugin, template, prompt
+
+**Design system**:
+A versioned `DESIGN.md` file that defines reusable visual language for artifacts.
+_Avoid_: theme, style preset
+
+**Upstream**:
+The external repository treated as the primary source of architectural direction and mergeable changes.
+_Avoid_: inspiration, reference
+
+**Reference project**:
+An external project used for patterns or validation without treating its codebase as the product base.
+_Avoid_: upstream, dependency
+
+**Productization fork**:
+This repo's role when it builds on a chosen upstream while adding fixes, integration work, and differentiation.
+_Avoid_: rewrite, clone
+
+## Relationships
+
+- **Open Design** produces **Design artifacts** by orchestrating coding agents through **Skills**.
+- A **Design system** constrains the visual language used by a **Skill** when generating a **Design artifact**.
+- `nexu-io/open-design` is the **Upstream** for this **Productization fork**.
+- `OpenCoworkAI/open-codesign`, `multica-ai/multica`, `op7418/guizang-ppt-skill`, and similar repos are **Reference projects** unless explicitly promoted to **Upstream**.
+
+## Example dialogue
+
+> **Dev:** "Should we fork Open CoDesign and build from there?"
+> **Domain expert:** "No. Treat `nexu-io/open-design` as the **Upstream**. Open CoDesign is a **Reference project** for UX patterns, not the base for this **Productization fork**."
+
+## Flagged ambiguities
+
+- "repo to fork" was ambiguous between **Upstream** and **Reference project**. Resolved: `nexu-io/open-design` is the upstream; other repos are evaluated for reusable patterns, skills, or license-compatible vendoring.

--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -37,6 +37,7 @@
     "@open-design/platform": "workspace:*",
     "@open-design/sidecar": "workspace:*",
     "@open-design/sidecar-proto": "workspace:*",
+    "@sentry/node": "^10.63.0",
     "better-sqlite3": "^12.9.0",
     "blake3-wasm": "2.1.5",
     "chokidar": "^5.0.0",

--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 // @ts-nocheck
+import './sentry-init.js';
 import { startServer } from './server.js';
 import { runLiveArtifactsMcpServer } from './mcp-live-artifacts-server.js';
 import { runConnectorsToolCli } from './tools-connectors-cli.js';

--- a/apps/daemon/src/express-async.ts
+++ b/apps/daemon/src/express-async.ts
@@ -1,0 +1,50 @@
+import type { Application, NextFunction, Request, RequestHandler, Response } from 'express';
+
+type ExpressHandler = (...args: any[]) => unknown;
+
+function isPromiseLike(value: unknown): value is Promise<unknown> {
+  return Boolean(value) && typeof (value as { then?: unknown }).then === 'function';
+}
+
+export function wrapExpressAsyncHandler<T extends ExpressHandler>(handler: T): T {
+  if (handler.length >= 4) {
+    return handler;
+  }
+
+  return function wrappedExpressAsyncHandler(
+    this: unknown,
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): unknown {
+    try {
+      const result = handler.call(this, req, res, next);
+      if (isPromiseLike(result)) {
+        return result.catch(next);
+      }
+      return result;
+    } catch (error) {
+      return next(error);
+    }
+  } as T;
+}
+
+function wrapExpressRouteArg(arg: unknown): unknown {
+  if (Array.isArray(arg)) {
+    return arg.map(wrapExpressRouteArg);
+  }
+  if (typeof arg === 'function') {
+    return wrapExpressAsyncHandler(arg as RequestHandler);
+  }
+  return arg;
+}
+
+export function installExpressAsyncErrorForwarding(app: Application): void {
+  const methods = ['all', 'delete', 'get', 'head', 'options', 'patch', 'post', 'put', 'use'] as const;
+  for (const method of methods) {
+    const original = (app[method] as unknown as ExpressHandler).bind(app);
+    (app[method] as unknown as ExpressHandler) = ((...args: unknown[]) => {
+      return original(...args.map(wrapExpressRouteArg));
+    }) as ExpressHandler;
+  }
+}

--- a/apps/daemon/src/print-spec-presets.ts
+++ b/apps/daemon/src/print-spec-presets.ts
@@ -1,0 +1,79 @@
+import { promises as fsp } from 'node:fs';
+import path from 'node:path';
+import type { PrintSpecMetadata, PrintSpecPreset } from '@open-design/contracts/print-specs';
+
+const PRESET_DIR = 'print-spec-presets';
+const PRESET_FILE = 'presets.json';
+
+function presetsPath(dataDir: string): string {
+  return path.join(dataDir, PRESET_DIR, PRESET_FILE);
+}
+
+export async function listPrintSpecPresets(dataDir: string): Promise<PrintSpecPreset[]> {
+  try {
+    const raw = await fsp.readFile(presetsPath(dataDir), 'utf8');
+    const parsed = JSON.parse(raw) as { presets?: unknown[] };
+    return Array.isArray(parsed.presets)
+      ? parsed.presets.filter(isPreset)
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function upsertPrintSpecPreset(
+  dataDir: string,
+  input: { label?: string; spec?: PrintSpecMetadata },
+): Promise<{ preset: PrintSpecPreset; presets: PrintSpecPreset[] }> {
+  if (!input.spec || !isPrintSpec(input.spec)) {
+    throw new Error('print spec is required');
+  }
+  const now = Date.now();
+  const label = input.label?.trim() || input.spec.label;
+  const preset: PrintSpecPreset = {
+    id: derivePresetId(label),
+    label,
+    spec: { ...input.spec, source: 'preset' },
+    createdAt: now,
+    updatedAt: now,
+  };
+  const current = await listPrintSpecPresets(dataDir);
+  const previous = current.find((item) => item.id === preset.id);
+  if (previous) preset.createdAt = previous.createdAt;
+  const presets = [
+    preset,
+    ...current.filter((item) => item.id !== preset.id),
+  ];
+  await fsp.mkdir(path.join(dataDir, PRESET_DIR), { recursive: true });
+  await fsp.writeFile(presetsPath(dataDir), JSON.stringify({ presets }, null, 2));
+  return { preset, presets };
+}
+
+function isPreset(value: unknown): value is PrintSpecPreset {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Partial<PrintSpecPreset>;
+  return (
+    typeof record.id === 'string'
+    && typeof record.label === 'string'
+    && isPrintSpec(record.spec)
+    && typeof record.createdAt === 'number'
+    && typeof record.updatedAt === 'number'
+  );
+}
+
+function isPrintSpec(value: unknown): value is PrintSpecMetadata {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Partial<PrintSpecMetadata>;
+  return (
+    typeof record.id === 'string'
+    && typeof record.label === 'string'
+    && typeof record.rawText === 'string'
+    && !!record.requirements
+    && Array.isArray(record.checklist)
+  );
+}
+
+function derivePresetId(label: string): string {
+  const slug = label.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '').slice(0, 64);
+  return `preset_${slug || 'print_spec'}`;
+}

--- a/apps/daemon/src/prompts/system.ts
+++ b/apps/daemon/src/prompts/system.ts
@@ -40,6 +40,49 @@ import { defaultCritiqueConfig, type CritiqueConfig } from '@open-design/contrac
 type ProjectMetadata = {
   kind?: string;
   intent?: string | null;
+  artifactIntent?: {
+    id?: string | null;
+    label?: string | null;
+    group?: string | null;
+    dimensions?: {
+      width?: number | null;
+      height?: number | null;
+      unit?: string | null;
+      dpi?: number | null;
+    } | null;
+    mediumConstraints?: string[] | null;
+    outputExpectations?: string[] | null;
+    printReady?: boolean | null;
+  } | null;
+  styleCard?: {
+    id?: string | null;
+    label?: string | null;
+    source?: string | null;
+    sourceReferences?: Array<{ id?: string | null; name?: string | null }> | null;
+    signals?: {
+      mood?: string | null;
+      color?: string | null;
+      typography?: string | null;
+      composition?: string | null;
+      density?: string | null;
+      transferNotes?: string | null;
+    } | null;
+  } | null;
+  printSpec?: {
+    id?: string | null;
+    label?: string | null;
+    source?: string | null;
+    rawText?: string | null;
+    requirements?: {
+      colorMode?: string | null;
+      bleedMm?: number | null;
+      safeAreaMm?: number | null;
+      dpi?: number | null;
+      finish?: string | null;
+      material?: string | null;
+    } | null;
+    checklist?: string[] | null;
+  } | null;
   fidelity?: string | null;
   speakerNotes?: boolean | null;
   animations?: boolean | null;
@@ -128,6 +171,9 @@ export interface ComposeInput {
   // built-in identity charter but still defer to the brand's hard tokens
   // and the active skill's workflow. Empty/undefined skips the block.
   memoryBody?: string | undefined;
+  // Accepted style cards from the Taste profile. This is durable taste
+  // context and must be translated across media, not copied verbatim.
+  tasteProfileBody?: string | undefined;
   // Project-level metadata captured by the new-project panel. Drives the
   // agent's understanding of artifact kind, fidelity, speaker-notes intent
   // and animation intent. Missing fields here are exactly what the
@@ -172,6 +218,7 @@ export function composeSystemPrompt({
   craftBody,
   craftSections,
   memoryBody,
+  tasteProfileBody,
   metadata,
   template,
   critique,
@@ -208,6 +255,11 @@ export function composeSystemPrompt({
   if (memoryBody && memoryBody.trim().length > 0) {
     parts.push(
       `\n\n## Personal memory (auto-extracted from past chats)\n\nThe following facts have been sedimented from this user's previous conversations and edited in the settings panel. Treat them as preferences and context, NOT hard rules: when they collide with the active design system tokens, the brand wins; when they collide with the active skill's workflow, the skill wins. They are still authoritative for tone, voice, terminology, and what the user already told you about themselves and their goals — never re-ask the user about something already captured here.\n\n${memoryBody.trim()}`,
+    );
+  }
+  if (tasteProfileBody && tasteProfileBody.trim().length > 0) {
+    parts.push(
+      `\n\n## Taste profile (accepted Style cards)\n\nThese are user-accepted design taste signals. Use them as durable style context, but translate them to the selected artifact intent and medium. Do not copy source artwork, logos, protected layouts, or the original medium one-to-one.\n\n${tasteProfileBody.trim()}`,
     );
   }
 
@@ -490,6 +542,9 @@ function renderMetadataBlock(
   );
   lines.push('');
   lines.push(`- **kind**: ${metadata.kind}`);
+  appendArtifactIntentMetadata(lines, metadata);
+  appendStyleCardMetadata(lines, metadata);
+  appendPrintSpecMetadata(lines, metadata);
   if (metadata.platform) {
     lines.push(`- **platform**: ${metadata.platform}`);
   } else if (metadata.kind === 'prototype' || metadata.kind === 'template' || metadata.kind === 'other') {
@@ -716,6 +771,86 @@ function renderMetadataBlock(
   }
 
   return lines.join('\n');
+}
+
+function appendArtifactIntentMetadata(lines: string[], metadata: ProjectMetadata): void {
+  const intent = metadata.artifactIntent;
+  if (!intent) return;
+  const id = typeof intent.id === 'string' && intent.id.length > 0 ? intent.id : 'unknown';
+  const label = typeof intent.label === 'string' && intent.label.length > 0 ? intent.label : id;
+  lines.push(`- **artifactIntent**: ${label} (\`${id}\`)`);
+  if (
+    intent.dimensions &&
+    typeof intent.dimensions.width === 'number' &&
+    typeof intent.dimensions.height === 'number' &&
+    typeof intent.dimensions.unit === 'string'
+  ) {
+    const dpi = typeof intent.dimensions.dpi === 'number' ? ` @ ${intent.dimensions.dpi} DPI` : '';
+    lines.push(
+      `- **artifactDimensions**: ${intent.dimensions.width} x ${intent.dimensions.height} ${intent.dimensions.unit}${dpi}`,
+    );
+  }
+  const mediumConstraints = Array.isArray(intent.mediumConstraints) ? intent.mediumConstraints : [];
+  if (mediumConstraints.length > 0) {
+    lines.push(`- **artifactMediumConstraints**: ${mediumConstraints.join('; ')}`);
+  }
+  const outputExpectations = Array.isArray(intent.outputExpectations) ? intent.outputExpectations : [];
+  if (outputExpectations.length > 0) {
+    lines.push(`- **artifactOutputExpectations**: ${outputExpectations.join('; ')}`);
+  }
+  lines.push(`- **printReadinessRelevant**: ${intent.printReady ? 'true' : 'false'}`);
+}
+
+function appendStyleCardMetadata(lines: string[], metadata: ProjectMetadata): void {
+  const styleCard = metadata.styleCard;
+  if (!styleCard) return;
+  const id = typeof styleCard.id === 'string' && styleCard.id.length > 0 ? styleCard.id : 'unknown';
+  const label = typeof styleCard.label === 'string' && styleCard.label.length > 0 ? styleCard.label : id;
+  const source = typeof styleCard.source === 'string' && styleCard.source.length > 0 ? styleCard.source : 'unknown';
+  lines.push(`- **styleCard**: ${label} (\`${id}\`, ${source})`);
+  const sourceReferences = Array.isArray(styleCard.sourceReferences)
+    ? styleCard.sourceReferences
+        .filter((ref) => ref && typeof ref.id === 'string' && typeof ref.name === 'string')
+        .map((ref) => `${ref.name} (\`${ref.id}\`)`)
+    : [];
+  if (sourceReferences.length > 0) {
+    lines.push(`- **styleSourceReferences**: ${sourceReferences.join('; ')}`);
+  }
+  const signals = styleCard.signals;
+  if (!signals) return;
+  if (signals.mood) lines.push(`- **styleMood**: ${signals.mood}`);
+  if (signals.color) lines.push(`- **styleColor**: ${signals.color}`);
+  if (signals.typography) lines.push(`- **styleTypography**: ${signals.typography}`);
+  if (signals.composition) lines.push(`- **styleComposition**: ${signals.composition}`);
+  if (signals.density) lines.push(`- **styleDensity**: ${signals.density}`);
+  if (signals.transferNotes) lines.push(`- **styleTransferNotes**: ${signals.transferNotes}`);
+  if (source === 'extracted' || sourceReferences.length > 0) {
+    lines.push(
+      '- **crossMediumStyleTransferRule**: translate the extracted style signals to the selected artifact intent; do not copy source artwork, logos, protected layouts, or the original medium one-to-one.',
+    );
+  }
+}
+
+function appendPrintSpecMetadata(lines: string[], metadata: ProjectMetadata): void {
+  const spec = metadata.printSpec;
+  if (!spec) return;
+  const id = typeof spec.id === 'string' && spec.id.length > 0 ? spec.id : 'unknown';
+  const label = typeof spec.label === 'string' && spec.label.length > 0 ? spec.label : id;
+  const source = typeof spec.source === 'string' && spec.source.length > 0 ? spec.source : 'unknown';
+  lines.push(`- **printSpec**: ${label} (\`${id}\`, ${source})`);
+  const requirements = spec.requirements;
+  if (requirements) {
+    if (requirements.colorMode) lines.push(`- **printColorMode**: ${requirements.colorMode}`);
+    if (requirements.bleedMm !== undefined && requirements.bleedMm !== null) lines.push(`- **printBleedMm**: ${requirements.bleedMm}`);
+    if (requirements.safeAreaMm !== undefined && requirements.safeAreaMm !== null) lines.push(`- **printSafeAreaMm**: ${requirements.safeAreaMm}`);
+    if (requirements.dpi !== undefined && requirements.dpi !== null) lines.push(`- **printDpi**: ${requirements.dpi}`);
+    if (requirements.material) lines.push(`- **printMaterial**: ${requirements.material}`);
+    if (requirements.finish) lines.push(`- **printFinish**: ${requirements.finish}`);
+  }
+  if (Array.isArray(spec.checklist) && spec.checklist.length > 0) {
+    lines.push(`- **printChecklist**: ${spec.checklist.join(' | ')}`);
+  }
+  lines.push('- **basicPrintHandoffRule**: produce a Level 2.5 print handoff: final design plus explicit trim size, bleed, safe area, DPI, CMYK-compatible color notes, asset resolution notes, and vendor assumptions. Do not stop at a screen-only preview.');
 }
 
 /**

--- a/apps/daemon/src/sentry-init.ts
+++ b/apps/daemon/src/sentry-init.ts
@@ -1,0 +1,3 @@
+import { initSentryFromEnv } from './sentry.js';
+
+initSentryFromEnv();

--- a/apps/daemon/src/sentry.ts
+++ b/apps/daemon/src/sentry.ts
@@ -1,0 +1,222 @@
+import * as Sentry from '@sentry/node';
+import type { Event, NodeOptions } from '@sentry/node';
+
+type Env = Record<string, string | undefined>;
+type SentryInit = Pick<typeof Sentry, 'init'>;
+type SentryExpress = Pick<typeof Sentry, 'setupExpressErrorHandler'>;
+type SentryCapture = Pick<typeof Sentry, 'captureException' | 'flush'>;
+
+const DEFAULT_TRACES_SAMPLE_RATE = 0.1;
+const FILTERED = '[Filtered]';
+
+let initialized = false;
+
+function readEnvValue(env: Env, key: string): string | undefined {
+  const value = env[key]?.trim();
+  return value ? value : undefined;
+}
+
+function parseSampleRate(value: string | undefined): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 && parsed <= 1 ? parsed : DEFAULT_TRACES_SAMPLE_RATE;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeSensitiveKey(key: string): string {
+  return key.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+function isSensitiveKey(key: string): boolean {
+  const normalized = normalizeSensitiveKey(key);
+  return [
+    'authorization',
+    'cookie',
+    'setcookie',
+    'token',
+    'secret',
+    'password',
+    'apikey',
+    'querystring',
+    'session',
+    'sentrydsn',
+    'openai',
+    'anthropic',
+    'gemini',
+    'langfuse',
+  ].some((needle) => normalized.includes(needle));
+}
+
+function stripUrlSearchFromText(value: string): string {
+  return value.replace(/https?:\/\/[^\s'"<>]+/g, (match) => stripUrlSearch(match));
+}
+
+function scrubNestedField(key: string, value: unknown): unknown {
+  if (isSensitiveKey(key)) {
+    return FILTERED;
+  }
+
+  const normalized = normalizeSensitiveKey(key);
+  if (normalized === 'headers') {
+    return scrubHeaders(value);
+  }
+
+  if ((normalized === 'url' || normalized.endsWith('url')) && typeof value === 'string') {
+    return stripUrlSearch(value);
+  }
+
+  if (typeof value === 'string') {
+    return stripUrlSearchFromText(value);
+  }
+
+  return scrubNestedValue(value);
+}
+
+function scrubNestedValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => scrubNestedValue(item));
+  }
+
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, nestedValue]) => [key, scrubNestedField(key, nestedValue)]),
+  );
+}
+
+function scrubHeaders(headers: unknown): unknown {
+  if (!isRecord(headers)) {
+    return headers;
+  }
+
+  return Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [key, isSensitiveKey(key) ? FILTERED : value]),
+  );
+}
+
+function stripUrlSearch(value: string): string {
+  try {
+    const url = new URL(value);
+    url.search = '';
+    return url.toString();
+  } catch {
+    const searchIndex = value.indexOf('?');
+    if (searchIndex < 0) {
+      return value;
+    }
+    const hashIndex = value.indexOf('#', searchIndex);
+    return hashIndex < 0 ? value.slice(0, searchIndex) : `${value.slice(0, searchIndex)}${value.slice(hashIndex)}`;
+  }
+}
+
+export function scrubSentryEvent<T extends Event>(event: T): T {
+  const scrubbed: Event = { ...event };
+
+  if (event.request) {
+    scrubbed.request = { ...event.request };
+    delete scrubbed.request.data;
+    delete scrubbed.request.query_string;
+
+    if (typeof event.request.url === 'string') {
+      scrubbed.request.url = stripUrlSearch(event.request.url);
+    }
+
+    if (event.request.headers) {
+      scrubbed.request.headers = scrubHeaders(event.request.headers) as Record<string, string>;
+    }
+
+    if ('cookies' in scrubbed.request) {
+      delete scrubbed.request.cookies;
+    }
+  }
+
+  if (event.extra) {
+    scrubbed.extra = scrubNestedValue(event.extra) as NonNullable<Event['extra']>;
+  }
+
+  if (event.breadcrumbs) {
+    scrubbed.breadcrumbs = scrubNestedValue(event.breadcrumbs) as NonNullable<Event['breadcrumbs']>;
+  }
+
+  if (event.tags) {
+    scrubbed.tags = scrubNestedValue(event.tags) as NonNullable<Event['tags']>;
+  }
+
+  if (event.contexts) {
+    scrubbed.contexts = scrubNestedValue(event.contexts) as NonNullable<Event['contexts']>;
+  }
+
+  if ('spans' in event && Array.isArray((event as Event & { spans?: unknown }).spans)) {
+    (scrubbed as any).spans = scrubNestedValue((event as Event & { spans?: unknown }).spans);
+  }
+
+  if (event.user?.id) {
+    scrubbed.user = { id: event.user.id };
+  } else if ('user' in scrubbed) {
+    delete scrubbed.user;
+  }
+
+  return scrubbed as T;
+}
+
+export function buildSentryOptions(env: Env = process.env): NodeOptions {
+  const dsn = readEnvValue(env, 'SENTRY_DSN');
+  const release = readEnvValue(env, 'SENTRY_RELEASE');
+  const options: NodeOptions = {
+    enabled: Boolean(dsn),
+    environment: readEnvValue(env, 'SENTRY_ENVIRONMENT') ?? readEnvValue(env, 'NODE_ENV') ?? 'production',
+    sendDefaultPii: false,
+    tracesSampleRate: parseSampleRate(readEnvValue(env, 'SENTRY_TRACES_SAMPLE_RATE')),
+    beforeSend: (event) => scrubSentryEvent(event),
+    beforeSendTransaction: (event) => scrubSentryEvent(event),
+  };
+
+  if (dsn) {
+    options.dsn = dsn;
+  }
+
+  if (release) {
+    options.release = release;
+  }
+
+  return options;
+}
+
+export function setupSentryExpressErrorHandler(
+  app: Parameters<typeof Sentry.setupExpressErrorHandler>[0],
+  sentry: SentryExpress = Sentry,
+): void {
+  sentry.setupExpressErrorHandler(app);
+}
+
+export async function captureStartupException(
+  error: unknown,
+  sentry: SentryCapture = Sentry,
+): Promise<void> {
+  try {
+    sentry.captureException(error);
+    await sentry.flush(2000);
+  } catch {
+    // Startup error reporting must never mask the original daemon failure.
+  }
+}
+
+export function initSentryFromEnv(env: Env = process.env, sentry: SentryInit = Sentry): boolean {
+  const options = buildSentryOptions(env);
+  if (initialized || !options.enabled) {
+    return false;
+  }
+
+  if (sentry === Sentry) {
+    Sentry.init(options);
+  } else {
+    sentry.init(options);
+  }
+
+  initialized = true;
+  return true;
+}

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -15,6 +15,7 @@ import {
   renderCodexImagegenOverride,
   shouldRenderCodexImagegenOverride,
 } from './prompts/system.js';
+import { extractStyleCardFromReferences } from '@open-design/contracts';
 import { expandHomePrefix, resolveProjectRelativePath } from './home-expansion.js';
 import { createCommandInvocation } from '@open-design/platform';
 import { SIDECAR_DEFAULTS, SIDECAR_ENV } from '@open-design/sidecar-proto';
@@ -99,6 +100,15 @@ import { buildDesktopPdfExportInput } from './pdf-export.js';
 import { generateMedia } from './media.js';
 import { searchResearch, ResearchError } from './research/index.js';
 import { renderResearchCommandContract } from './prompts/research-contract.js';
+import {
+  acceptTasteProfileStyleCard,
+  composeTasteProfileBody,
+  readTasteProfile,
+} from './taste-profile.js';
+import {
+  listPrintSpecPresets,
+  upsertPrintSpecPreset,
+} from './print-spec-presets.js';
 import {
   AUDIO_DURATIONS_SEC,
   AUDIO_MODELS_BY_KIND,
@@ -2520,6 +2530,100 @@ export async function startServer({
     }
   });
 
+  app.post('/api/style-cards/extract', async (req, res) => {
+    try {
+      const body = req.body && typeof req.body === 'object' ? req.body : {};
+      const referenceIds = Array.isArray(body.referenceIds)
+        ? body.referenceIds
+            .filter((id) => typeof id === 'string' && /^[a-z0-9_]+$/.test(id))
+            .slice(0, 24)
+        : [];
+      if (referenceIds.length === 0) {
+        return res.status(400).json({ error: 'referenceIds is required' });
+      }
+      const references = [];
+      for (const id of referenceIds) {
+        const entry = await readMemoryEntry(RUNTIME_DATA_DIR, id);
+        if (!entry || entry.type !== 'reference') continue;
+        references.push({
+          id: entry.id,
+          name: entry.name,
+          description: entry.description,
+          body: entry.body,
+        });
+      }
+      if (references.length === 0) {
+        return res.status(404).json({ error: 'no reference memories found' });
+      }
+      const styleCard = extractStyleCardFromReferences({
+        label: typeof body.label === 'string' ? body.label : undefined,
+        references,
+      });
+      res.json({
+        styleCard,
+        references: references.map((ref) => ({
+          id: ref.id,
+          name: ref.name,
+          description: ref.description,
+        })),
+      });
+    } catch (err) {
+      res.status(400).json({ error: String((err && err.message) || err) });
+    }
+  });
+
+  app.get('/api/taste-profile', async (_req, res) => {
+    try {
+      const profile = await readTasteProfile(RUNTIME_DATA_DIR);
+      res.json({ profile });
+    } catch (err) {
+      res.status(500).json({ error: String((err && err.message) || err) });
+    }
+  });
+
+  app.get('/api/taste-profile/system-prompt', async (_req, res) => {
+    try {
+      const body = await composeTasteProfileBody(RUNTIME_DATA_DIR);
+      res.json({ body });
+    } catch (err) {
+      res.status(500).json({ error: String((err && err.message) || err) });
+    }
+  });
+
+  app.post('/api/taste-profile/style-cards', async (req, res) => {
+    try {
+      const body = req.body && typeof req.body === 'object' ? req.body : {};
+      const result = await acceptTasteProfileStyleCard(
+        RUNTIME_DATA_DIR,
+        body.styleCard,
+      );
+      res.json(result);
+    } catch (err) {
+      res.status(400).json({ error: String((err && err.message) || err) });
+    }
+  });
+
+  app.get('/api/print-spec-presets', async (_req, res) => {
+    try {
+      res.json({ presets: await listPrintSpecPresets(RUNTIME_DATA_DIR) });
+    } catch (err) {
+      res.status(500).json({ error: String((err && err.message) || err) });
+    }
+  });
+
+  app.post('/api/print-spec-presets', async (req, res) => {
+    try {
+      const body = req.body && typeof req.body === 'object' ? req.body : {};
+      const result = await upsertPrintSpecPreset(RUNTIME_DATA_DIR, {
+        label: typeof body.label === 'string' ? body.label : undefined,
+        spec: body.spec,
+      });
+      res.json(result);
+    } catch (err) {
+      res.status(400).json({ error: String((err && err.message) || err) });
+    }
+  });
+
   // Composed memory body for the system prompt. Daemon-side chat runs
   // call `composeMemoryBody()` directly; the web app (BYOK / API mode)
   // can't import daemon internals, so this endpoint exposes the same
@@ -2979,6 +3083,12 @@ export async function startServer({
     } catch (err) {
       console.warn('[memory] composeMemoryBody failed', err);
     }
+    let tasteProfileBody = '';
+    try {
+      tasteProfileBody = await composeTasteProfileBody(RUNTIME_DATA_DIR);
+    } catch (err) {
+      console.warn('[taste-profile] composeTasteProfileBody failed', err);
+    }
 
     let designSystemBody;
     let designSystemTitle;
@@ -3081,6 +3191,7 @@ export async function startServer({
       craftBody,
       craftSections,
       memoryBody,
+      tasteProfileBody,
       metadata,
       template,
       critique: critiqueShouldRun ? critiqueCfg : undefined,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -157,6 +157,7 @@ import {
   validateTarget as validateRoutineTarget,
 } from './routines.js';
 import { buildMcpInstallPayload } from './mcp-install-info.js';
+import { installExpressAsyncErrorForwarding } from './express-async.js';
 import {
   buildProjectArchive,
   buildBatchArchive,
@@ -249,6 +250,7 @@ import { registerChatRoutes } from './chat-routes.js';
 import { registerStaticResourceRoutes } from './static-resource-routes.js';
 import { registerRoutineRoutes, routineDbRowToContract } from './routine-routes.js';
 import { assertServerContextSatisfiesRoutes } from './route-context-contract.js';
+import { setupSentryExpressErrorHandler } from './sentry.js';
 import { configureConnectorCredentialStore, ConnectorServiceError, FileConnectorCredentialStore } from './connectors/service.js';
 import { composioConnectorProvider } from './connectors/composio.js';
 import { configureComposioConfigStore } from './connectors/composio-config.js';
@@ -2083,6 +2085,7 @@ export async function startServer({
   let daemonShuttingDown = false;
   const extraAllowedOrigins = configuredAllowedOrigins();
   const app = express();
+  installExpressAsyncErrorForwarding(app);
   app.use(express.json({ limit: '4mb' }));
 
   // Multi-directory scanning shared by every skill / template surface. The
@@ -4660,6 +4663,8 @@ export async function startServer({
     lifecycle: { isDaemonShuttingDown: () => daemonShuttingDown },
 
   });
+
+  setupSentryExpressErrorHandler(app);
 
   // Wait for `listen` to bind so callers always see the resolved URL —
   // critical when port=0 (ephemeral port) and when the embedding sidecar

--- a/apps/daemon/src/sidecar/index.ts
+++ b/apps/daemon/src/sidecar/index.ts
@@ -1,7 +1,10 @@
+import "../sentry-init.js";
+
 import { APP_KEYS, OPEN_DESIGN_SIDECAR_CONTRACT } from "@open-design/sidecar-proto";
 import { bootstrapSidecarRuntime } from "@open-design/sidecar";
 import { readProcessStamp } from "@open-design/platform";
 
+import { captureStartupException } from "../sentry.js";
 import { startDaemonSidecar } from "./server.js";
 
 async function main(): Promise<void> {
@@ -18,7 +21,8 @@ async function main(): Promise<void> {
   await server.waitUntilStopped();
 }
 
-void main().catch((error: unknown) => {
+void main().catch(async (error: unknown) => {
+  await captureStartupException(error);
   console.error(error instanceof Error ? error.stack || error.message : String(error));
   process.exit(1);
 });

--- a/apps/daemon/src/taste-profile.ts
+++ b/apps/daemon/src/taste-profile.ts
@@ -1,0 +1,111 @@
+import { promises as fsp } from 'node:fs';
+import path from 'node:path';
+import type { StyleCardMetadata } from '@open-design/contracts/style-cards';
+import type { TasteProfile } from '@open-design/contracts/api/taste-profile';
+
+const PROFILE_DIR = 'taste-profile';
+const PROFILE_FILE = 'style-cards.json';
+
+function profilePath(dataDir: string): string {
+  return path.join(dataDir, PROFILE_DIR, PROFILE_FILE);
+}
+
+async function ensureProfileDir(dataDir: string): Promise<void> {
+  await fsp.mkdir(path.join(dataDir, PROFILE_DIR), { recursive: true });
+}
+
+export async function readTasteProfile(dataDir: string): Promise<TasteProfile> {
+  try {
+    const raw = await fsp.readFile(profilePath(dataDir), 'utf8');
+    const parsed = JSON.parse(raw) as Partial<TasteProfile>;
+    return {
+      styleCards: Array.isArray(parsed.styleCards)
+        ? parsed.styleCards.filter(isStyleCard)
+        : [],
+      updatedAt: typeof parsed.updatedAt === 'number' ? parsed.updatedAt : null,
+    };
+  } catch {
+    return { styleCards: [], updatedAt: null };
+  }
+}
+
+export async function acceptTasteProfileStyleCard(
+  dataDir: string,
+  input: unknown,
+): Promise<{ styleCard: StyleCardMetadata; profile: TasteProfile }> {
+  if (!isStyleCard(input)) {
+    throw new Error('styleCard with six signals is required');
+  }
+  const now = Date.now();
+  const accepted: StyleCardMetadata = {
+    ...input,
+    source: isStyleCardSource(input.source) ? input.source : 'extracted',
+    status: 'accepted',
+    signals: { ...input.signals },
+    updatedAt: now,
+  };
+  if (typeof input.createdAt === 'number') accepted.createdAt = input.createdAt;
+  else accepted.createdAt = now;
+  if (input.parameters) accepted.parameters = input.parameters;
+  if (input.sourceReferences) {
+    accepted.sourceReferences = input.sourceReferences.map((ref) => ({ ...ref }));
+  }
+
+  const current = await readTasteProfile(dataDir);
+  const nextCards = [
+    accepted,
+    ...current.styleCards.filter((card) => card.id !== accepted.id),
+  ];
+  const profile: TasteProfile = { styleCards: nextCards, updatedAt: now };
+  await ensureProfileDir(dataDir);
+  await fsp.writeFile(profilePath(dataDir), JSON.stringify(profile, null, 2));
+  return { styleCard: accepted, profile };
+}
+
+export async function composeTasteProfileBody(dataDir: string): Promise<string> {
+  const profile = await readTasteProfile(dataDir);
+  const accepted = profile.styleCards.filter((card) => card.status === 'accepted');
+  if (accepted.length === 0) return '';
+  const lines = ['## Taste profile', ''];
+  for (const card of accepted) {
+    lines.push(`- **${card.label}** (\`${card.id}\`)`);
+    lines.push(`  - Mood: ${card.signals.mood}`);
+    lines.push(`  - Color: ${card.signals.color}`);
+    lines.push(`  - Typography: ${card.signals.typography}`);
+    lines.push(`  - Composition: ${card.signals.composition}`);
+    lines.push(`  - Density: ${card.signals.density}`);
+    lines.push(`  - Transfer: ${card.signals.transferNotes}`);
+    if (card.sourceReferences?.length) {
+      lines.push(
+        `  - Sources: ${card.sourceReferences
+          .map((ref) => `${ref.name} (${ref.id})`)
+          .join('; ')}`,
+      );
+    }
+    lines.push(
+      '  - Cross-medium rule: Adapt these accepted style signals across media without copying source artwork, logos, protected layouts, or the original medium one-to-one.',
+    );
+  }
+  return lines.join('\n').trim();
+}
+
+function isStyleCard(value: unknown): value is StyleCardMetadata {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Partial<StyleCardMetadata>;
+  const signals = record.signals;
+  return (
+    typeof record.id === 'string'
+    && typeof record.label === 'string'
+    && !!signals
+    && typeof signals.mood === 'string'
+    && typeof signals.color === 'string'
+    && typeof signals.typography === 'string'
+    && typeof signals.composition === 'string'
+    && typeof signals.density === 'string'
+    && typeof signals.transferNotes === 'string'
+  );
+}
+
+function isStyleCardSource(value: unknown): value is StyleCardMetadata['source'] {
+  return value === 'starter' || value === 'reference' || value === 'extracted';
+}

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -23,11 +23,18 @@ import {
   validateCodexGeneratedImagesDir,
 } from '../src/server.js';
 import { getAgentDef } from '../src/agents.js';
+import { readAppConfig, writeAppConfig, type AgentCliEnvPrefs } from '../src/app-config.js';
 import { renderCodexImagegenOverride } from '../src/prompts/system.js';
 
 function symlinkDir(target: string, link: string): void {
   symlinkSync(target, link, process.platform === 'win32' ? 'junction' : 'dir');
 }
+
+const FAKE_AGENT_CONFIG_KEYS: Record<string, { agentId: string; envKey: string }> = {
+  claude: { agentId: 'claude', envKey: 'CLAUDE_BIN' },
+  opencode: { agentId: 'opencode', envKey: 'OPENCODE_BIN' },
+  qodercli: { agentId: 'qoder', envKey: 'QODER_BIN' },
+};
 
 async function withFakeAgent<T>(
   binName: string,
@@ -36,23 +43,40 @@ async function withFakeAgent<T>(
 ): Promise<T> {
   const dir = await fsp.mkdtemp(join(tmpdir(), 'od-chat-route-bin-'));
   const oldPath = process.env.PATH;
+  const dataDir = process.env.OD_DATA_DIR;
+  const previousConfig = dataDir ? await readAppConfig(dataDir) : {};
   try {
+    let binPath: string;
     if (process.platform === 'win32') {
       const runner = join(dir, `${binName}-test-runner.cjs`);
       await fsp.writeFile(runner, script);
-      await fsp.writeFile(
-        join(dir, `${binName}.cmd`),
-        `@echo off\r\nnode "${runner}" %*\r\n`,
-      );
+      binPath = join(dir, `${binName}.cmd`);
+      await fsp.writeFile(binPath, `@echo off\r\nnode "${runner}" %*\r\n`);
     } else {
-      const bin = join(dir, binName);
-      await fsp.writeFile(bin, `#!/usr/bin/env node\n${script}`);
-      await fsp.chmod(bin, 0o755);
+      binPath = join(dir, binName);
+      await fsp.writeFile(binPath, `#!/usr/bin/env node\n${script}`);
+      await fsp.chmod(binPath, 0o755);
+    }
+    const configKey = FAKE_AGENT_CONFIG_KEYS[binName];
+    if (dataDir && configKey) {
+      const agentCliEnv: AgentCliEnvPrefs = {
+        ...(previousConfig.agentCliEnv ?? {}),
+        [configKey.agentId]: {
+          ...(previousConfig.agentCliEnv?.[configKey.agentId] ?? {}),
+          [configKey.envKey]: binPath,
+        },
+      };
+      await writeAppConfig(dataDir, { agentCliEnv });
     }
     process.env.PATH = `${dir}${delimiter}${oldPath ?? ''}`;
     return await run();
   } finally {
     process.env.PATH = oldPath;
+    if (dataDir) {
+      await writeAppConfig(dataDir, {
+        agentCliEnv: previousConfig.agentCliEnv ?? null,
+      });
+    }
     await fsp.rm(dir, { recursive: true, force: true });
   }
 }
@@ -294,7 +318,7 @@ setInterval(() => {}, 1000);
 
   it('keeps Claude stream runs alive while structured output is still flowing', async () => {
     const previous = process.env.OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS;
-    process.env.OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS = '900';
+    process.env.OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS = '3000';
     try {
       await withFakeAgent(
         'claude',
@@ -315,7 +339,7 @@ const timer = setInterval(() => {
     return;
   }
   console.log(lines[index++]);
-}, 200);
+}, 500);
 `,
         async () => {
           const createResponse = await fetch(`${baseUrl}/api/runs`, {
@@ -532,7 +556,7 @@ async function waitForRunStatus(
   runId: string,
   done: (status: string) => boolean = (status) => status !== 'queued' && status !== 'running',
 ): Promise<{ status: string }> {
-  for (let attempt = 0; attempt < 120; attempt += 1) {
+  for (let attempt = 0; attempt < 240; attempt += 1) {
     const statusResponse = await fetch(`${baseUrl}/api/runs/${runId}`);
     const statusBody = await statusResponse.json() as { status: string };
     if (done(statusBody.status)) return statusBody;

--- a/apps/daemon/tests/express-async.test.ts
+++ b/apps/daemon/tests/express-async.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { wrapExpressAsyncHandler } from '../src/express-async.js';
+
+describe('wrapExpressAsyncHandler', () => {
+  it('forwards rejected async route handlers to Express next()', async () => {
+    const error = new Error('async route failed');
+    const next = vi.fn();
+    const handler = wrapExpressAsyncHandler(async (_req: unknown, _res: unknown, _next: unknown) => {
+      throw error;
+    });
+
+    await handler({} as any, {} as any, next);
+
+    expect(next).toHaveBeenCalledWith(error);
+  });
+
+  it('does not wrap Express error middleware', () => {
+    function errorMiddleware(err: unknown, _req: unknown, _res: unknown, next: (error: unknown) => void) {
+      next(err);
+    }
+
+    expect(wrapExpressAsyncHandler(errorMiddleware)).toBe(errorMiddleware);
+  });
+});

--- a/apps/daemon/tests/memory-routes.test.ts
+++ b/apps/daemon/tests/memory-routes.test.ts
@@ -227,6 +227,64 @@ describe('memory routes', () => {
     ]);
   });
 
+  it('extracts a draft Style card from reference memory entries', async () => {
+    const createRes = await fetch(`${baseUrl}/api/memory`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Tea packaging reference',
+        description: 'Quiet premium packaging with foil label hierarchy',
+        type: 'reference',
+        body: [
+          '- Mood: calm, premium, editorial',
+          '- Color palette: deep green, ivory, muted gold foil',
+          '- Typography: elegant serif headline with tiny uppercase details',
+          '- Composition: centered label grid with generous whitespace',
+          '- Density: low density front, detailed information on back',
+        ].join('\n'),
+      }),
+    });
+    expect(createRes.status).toBe(200);
+    const created = await createRes.json() as { entry: { id: string } };
+
+    const extractRes = await fetch(`${baseUrl}/api/style-cards/extract`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        label: 'Premium tea packaging direction',
+        referenceIds: [created.entry.id],
+      }),
+    });
+    expect(extractRes.status).toBe(200);
+
+    const json = await extractRes.json() as {
+      styleCard: {
+        id: string;
+        source: string;
+        status?: string;
+        signals: {
+          color: string;
+          typography: string;
+          transferNotes: string;
+        };
+        sourceReferences?: Array<{ id: string; name: string }>;
+      };
+    };
+    expect(json.styleCard).toMatchObject({
+      id: 'style_premium_tea_packaging_direction',
+      source: 'extracted',
+      status: 'draft',
+      signals: {
+        color: expect.stringContaining('deep green'),
+        typography: expect.stringContaining('serif'),
+      },
+      sourceReferences: [
+        { id: created.entry.id, name: 'Tea packaging reference' },
+      ],
+    });
+    expect(json.styleCard.signals.transferNotes).toContain('Tea packaging reference');
+  });
+
   it('returns the composed system prompt body from indexed memory entries', async () => {
     await fetch(`${baseUrl}/api/memory`, {
       method: 'POST',

--- a/apps/daemon/tests/origin-validation.test.ts
+++ b/apps/daemon/tests/origin-validation.test.ts
@@ -371,22 +371,36 @@ describe('daemon origin validation middleware', () => {
 
   it('allows requests from OD_WEB_PORT (web proxy port)', async () => {
     const webPort = port + 1000;
-    process.env.OD_WEB_PORT = String(webPort);
-    const res = await request(port, 'GET', '/api/projects', {
-      origin: `http://127.0.0.1:${webPort}`,
+    const ports = allowedBrowserPorts(port, {
+      ...process.env,
+      OD_WEB_PORT: String(webPort),
     });
-    delete process.env.OD_WEB_PORT;
-    expect(res.status).toBe(200);
+    expect(
+      isAllowedBrowserOrigin(
+        `http://127.0.0.1:${webPort}`,
+        `127.0.0.1:${port}`,
+        ports,
+        '127.0.0.1',
+        [],
+      ),
+    ).toBe(true);
   });
 
   it('blocks requests from unknown ports even with OD_WEB_PORT set', async () => {
     const webPort = port + 1000;
-    process.env.OD_WEB_PORT = String(webPort);
-    const res = await request(port, 'GET', '/api/projects', {
-      origin: `http://127.0.0.1:${port + 2000}`,
+    const ports = allowedBrowserPorts(port, {
+      ...process.env,
+      OD_WEB_PORT: String(webPort),
     });
-    delete process.env.OD_WEB_PORT;
-    expect(res.status).toBe(403);
+    expect(
+      isAllowedBrowserOrigin(
+        `http://127.0.0.1:${port + 2000}`,
+        `127.0.0.1:${port}`,
+        ports,
+        '127.0.0.1',
+        [],
+      ),
+    ).toBe(false);
   });
 
   // Note: fail-closed coverage when port=0 is tested in the dedicated

--- a/apps/daemon/tests/print-spec-presets-routes.test.ts
+++ b/apps/daemon/tests/print-spec-presets-routes.test.ts
@@ -1,0 +1,71 @@
+import type http from 'node:http';
+import { promises as fsp } from 'node:fs';
+import path from 'node:path';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { startServer } from '../src/server.js';
+
+const dataDir = process.env.OD_DATA_DIR as string;
+
+let baseUrl: string;
+let server: http.Server;
+
+beforeAll(async () => {
+  const started = (await startServer({
+    port: 0,
+    returnServer: true,
+  })) as { url: string; server: http.Server };
+  baseUrl = started.url;
+  server = started.server;
+});
+
+afterAll(() => (
+  server
+    ? new Promise<void>((resolve) => server.close(() => resolve()))
+    : undefined
+));
+
+beforeEach(async () => {
+  await fsp.rm(path.join(dataDir, 'print-spec-presets'), { recursive: true, force: true });
+});
+
+describe('print spec preset routes', () => {
+  it('stores and lists reusable print specs', async () => {
+    const create = await fetch(`${baseUrl}/api/print-spec-presets`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        label: 'Business card vendor',
+        spec: {
+          id: 'print_business_card_print_spec',
+          label: 'Business card print spec',
+          source: 'paste',
+          rawText: 'CMYK only\nBleed: 3mm\nSafe area: 2mm\n300 DPI',
+          requirements: {
+            colorMode: 'cmyk-compatible',
+            bleedMm: 3,
+            safeAreaMm: 2,
+            dpi: 300,
+          },
+          checklist: ['Use CMYK-compatible colors and avoid relying on screen-only RGB glow.'],
+        },
+      }),
+    });
+    expect(create.status).toBe(200);
+    const created = await create.json() as {
+      preset: { id: string; spec: { source: string; requirements: { bleedMm: number } } };
+    };
+    expect(created.preset).toMatchObject({
+      id: 'preset_business_card_vendor',
+      spec: {
+        source: 'preset',
+        requirements: { bleedMm: 3 },
+      },
+    });
+
+    const list = await fetch(`${baseUrl}/api/print-spec-presets`);
+    expect(list.status).toBe(200);
+    const listed = await list.json() as { presets: Array<{ id: string }> };
+    expect(listed.presets.map((preset) => preset.id)).toEqual(['preset_business_card_vendor']);
+  });
+});

--- a/apps/daemon/tests/projects-routes.test.ts
+++ b/apps/daemon/tests/projects-routes.test.ts
@@ -106,6 +106,66 @@ describe('GET /api/projects/:id resolvedDir', () => {
     expect(path.isAbsolute(detail.resolvedDir)).toBe(true);
   });
 
+  it('round-trips artifact intent metadata on project creation', async () => {
+    const projectId = `proj-intent-${Date.now()}`;
+    const createResp = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id: projectId,
+        name: 'Business card fixture',
+        skillId: null,
+        designSystemId: null,
+        metadata: {
+          kind: 'prototype',
+          artifactIntent: {
+            id: 'business-card',
+            label: 'Business card',
+            group: 'print-products',
+            dimensions: { width: 90, height: 54, unit: 'mm', dpi: 300 },
+            mediumConstraints: ['two-sided physical print surface'],
+            outputExpectations: ['print handoff'],
+            printReady: true,
+          },
+        },
+      }),
+    });
+    expect(createResp.status).toBe(200);
+    const createBody = (await createResp.json()) as {
+      project: {
+        metadata?: {
+          artifactIntent?: {
+            id?: string;
+            dimensions?: { width?: number; height?: number; unit?: string; dpi?: number };
+            printReady?: boolean;
+          };
+        };
+      };
+    };
+    expect(createBody.project.metadata?.artifactIntent).toMatchObject({
+      id: 'business-card',
+      dimensions: { width: 90, height: 54, unit: 'mm', dpi: 300 },
+      printReady: true,
+    });
+
+    const detailResp = await fetch(`${baseUrl}/api/projects/${projectId}`);
+    expect(detailResp.status).toBe(200);
+    const detail = (await detailResp.json()) as {
+      project: {
+        metadata?: {
+          artifactIntent?: {
+            id?: string;
+            outputExpectations?: string[];
+          };
+        };
+      };
+    };
+    expect(detail.project.metadata?.artifactIntent).toMatchObject({
+      id: 'business-card',
+      outputExpectations: ['print handoff'],
+    });
+  });
+
   it('returns 404 with PROJECT_NOT_FOUND for unknown ids', async () => {
     const resp = await fetch(`${baseUrl}/api/projects/does-not-exist-${Date.now()}`);
     expect(resp.status).toBe(404);

--- a/apps/daemon/tests/prompts/system.test.ts
+++ b/apps/daemon/tests/prompts/system.test.ts
@@ -113,6 +113,131 @@ describe('composeSystemPrompt', () => {
     expect(prompt).not.toContain('**platformTargets**');
   });
 
+  it('includes artifact intent constraints in project metadata guidance', () => {
+    const prompt = composeSystemPrompt({
+      metadata: {
+        kind: 'prototype',
+        platform: 'responsive',
+        artifactIntent: {
+          id: 'business-card',
+          label: 'Business card',
+          group: 'print-products',
+          dimensions: {
+            width: 90,
+            height: 54,
+            unit: 'mm',
+            dpi: 300,
+          },
+          mediumConstraints: ['two-sided physical print surface'],
+          outputExpectations: ['print handoff'],
+          printReady: true,
+        },
+      } as any,
+    });
+
+    expect(prompt).toContain('- **artifactIntent**: Business card (`business-card`)');
+    expect(prompt).toContain('- **artifactDimensions**: 90 x 54 mm @ 300 DPI');
+    expect(prompt).toContain('- **artifactMediumConstraints**: two-sided physical print surface');
+    expect(prompt).toContain('- **artifactOutputExpectations**: print handoff');
+    expect(prompt).toContain('- **printReadinessRelevant**: true');
+  });
+
+  it('includes selected Style card signals in project metadata guidance', () => {
+    const prompt = composeSystemPrompt({
+      metadata: {
+        kind: 'prototype',
+        styleCard: {
+          id: 'editorial-noir',
+          label: 'Editorial noir',
+          source: 'starter',
+          signals: {
+            mood: 'dramatic, refined, high-confidence',
+            color: 'black and warm white with one sharp accent',
+            typography: 'condensed editorial sans headlines',
+            composition: 'asymmetric magazine-like grid',
+            density: 'medium-high information density with deliberate whitespace',
+            transferNotes: 'use the editorial contrast without copying a magazine cover',
+          },
+        },
+      } as any,
+    });
+
+    expect(prompt).toContain('- **styleCard**: Editorial noir (`editorial-noir`, starter)');
+    expect(prompt).toContain('- **styleMood**: dramatic, refined, high-confidence');
+    expect(prompt).toContain('- **styleColor**: black and warm white with one sharp accent');
+    expect(prompt).toContain('- **styleTypography**: condensed editorial sans headlines');
+    expect(prompt).toContain('- **styleComposition**: asymmetric magazine-like grid');
+    expect(prompt).toContain('- **styleDensity**: medium-high information density with deliberate whitespace');
+    expect(prompt).toContain('- **styleTransferNotes**: use the editorial contrast without copying a magazine cover');
+  });
+
+  it('adds cross-medium transfer guidance for extracted Style cards', () => {
+    const prompt = composeSystemPrompt({
+      metadata: {
+        kind: 'prototype',
+        artifactIntent: {
+          id: 'business-card',
+          label: 'Business card',
+          group: 'print-products',
+          dimensions: { width: 90, height: 54, unit: 'mm', dpi: 300 },
+          mediumConstraints: ['two-sided physical print surface'],
+          outputExpectations: ['print handoff'],
+          printReady: true,
+        },
+        styleCard: {
+          id: 'style_premium_packaging_direction',
+          label: 'Premium packaging direction',
+          source: 'extracted',
+          signals: {
+            mood: 'premium, confident',
+            color: 'deep green, ivory, muted gold foil',
+            typography: 'elegant serif with uppercase details',
+            composition: 'centered label grid',
+            density: 'low density front, detailed back',
+            transferNotes: 'Adapt packaging signals to the selected medium without copying source art.',
+          },
+          sourceReferences: [
+            { id: 'reference_packaging_ref', name: 'Packaging reference' },
+          ],
+        },
+      } as any,
+    });
+
+    expect(prompt).toContain('- **styleSourceReferences**: Packaging reference (`reference_packaging_ref`)');
+    expect(prompt).toContain('- **crossMediumStyleTransferRule**: translate the extracted style signals to the selected artifact intent; do not copy source artwork, logos, protected layouts, or the original medium one-to-one.');
+  });
+
+  it('includes print specs and Level 2.5 print handoff guidance', () => {
+    const prompt = composeSystemPrompt({
+      metadata: {
+        kind: 'prototype',
+        printSpec: {
+          id: 'print_business_card_print_spec',
+          label: 'Business card print spec',
+          source: 'paste',
+          rawText: 'CMYK only\nBleed: 3mm\nSafe area: 2mm\n300 DPI',
+          requirements: {
+            colorMode: 'cmyk-compatible',
+            bleedMm: 3,
+            safeAreaMm: 2,
+            dpi: 300,
+          },
+          checklist: [
+            'Use CMYK-compatible colors and avoid relying on screen-only RGB glow.',
+            'Extend backgrounds 3mm into bleed.',
+          ],
+        },
+      } as any,
+    });
+
+    expect(prompt).toContain('- **printSpec**: Business card print spec (`print_business_card_print_spec`, paste)');
+    expect(prompt).toContain('- **printColorMode**: cmyk-compatible');
+    expect(prompt).toContain('- **printBleedMm**: 3');
+    expect(prompt).toContain('- **printSafeAreaMm**: 2');
+    expect(prompt).toContain('- **printDpi**: 300');
+    expect(prompt).toContain('Level 2.5 print handoff');
+  });
+
   describe('artifact handoff no-emit clauses (#1143)', () => {
     it('drops the absolute "non-negotiable" framing in favor of conditional language', () => {
       const prompt = composeSystemPrompt({});

--- a/apps/daemon/tests/sentry.test.ts
+++ b/apps/daemon/tests/sentry.test.ts
@@ -1,0 +1,220 @@
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import packageJsonSource from '../package.json?raw';
+import cliSource from '../src/cli.ts?raw';
+import serverSource from '../src/server.ts?raw';
+import sidecarSource from '../src/sidecar/index.ts?raw';
+
+const packageJson = JSON.parse(packageJsonSource) as {
+  dependencies?: Record<string, string>;
+};
+
+async function loadSentryModule() {
+  const moduleUrl = new URL('../src/sentry.ts', import.meta.url);
+  expect(existsSync(fileURLToPath(moduleUrl)), 'src/sentry.ts should exist').toBe(true);
+  return import('../src/sentry.js');
+}
+
+describe('Sentry onboarding', () => {
+  it('installs and initializes Sentry before the daemon starts', () => {
+    expect(packageJson.dependencies?.['@sentry/node']).toBeDefined();
+    expect(cliSource.indexOf("import './sentry-init.js';")).toBeGreaterThanOrEqual(0);
+    expect(cliSource.indexOf("import './sentry-init.js';")).toBeLessThan(
+      cliSource.indexOf("import { startServer } from './server.js';"),
+    );
+    const sidecarSentryImportIndex = sidecarSource.indexOf('sentry-init.js');
+    expect(sidecarSentryImportIndex).toBeGreaterThanOrEqual(0);
+    expect(sidecarSentryImportIndex).toBeLessThan(
+      sidecarSource.indexOf('import { startDaemonSidecar } from "./server.js";'),
+    );
+  });
+
+  it('registers Sentry Express error handling after routes and before listen', () => {
+    expect(serverSource).toContain("import { setupSentryExpressErrorHandler } from './sentry.js';");
+    expect(serverSource).toContain('setupSentryExpressErrorHandler(app);');
+    expect(serverSource.indexOf('setupSentryExpressErrorHandler(app);')).toBeGreaterThan(
+      serverSource.indexOf('registerChatRoutes(app, {'),
+    );
+    expect(serverSource.indexOf('setupSentryExpressErrorHandler(app);')).toBeLessThan(
+      serverSource.indexOf('server = app.listen'),
+    );
+  });
+
+  it('builds safe daemon options from environment variables', async () => {
+    const { buildSentryOptions } = await loadSentryModule();
+
+    const options = buildSentryOptions({
+      SENTRY_DSN: 'https://public@example.ingest.sentry.io/1',
+      SENTRY_ENVIRONMENT: 'production',
+      SENTRY_RELEASE: 'open-design-daemon@abc123',
+      SENTRY_TRACES_SAMPLE_RATE: '0.25',
+    });
+
+    expect(options).toMatchObject({
+      dsn: 'https://public@example.ingest.sentry.io/1',
+      enabled: true,
+      environment: 'production',
+      release: 'open-design-daemon@abc123',
+      sendDefaultPii: false,
+      tracesSampleRate: 0.25,
+    });
+    expect(options.beforeSend).toBeTypeOf('function');
+    expect(options.beforeSendTransaction).toBeTypeOf('function');
+  });
+
+  it('disables Sentry when no DSN is configured', async () => {
+    const { buildSentryOptions } = await loadSentryModule();
+
+    const options = buildSentryOptions({
+      SENTRY_ENVIRONMENT: 'production',
+      SENTRY_TRACES_SAMPLE_RATE: '0.1',
+    });
+
+    expect(options.enabled).toBe(false);
+    expect(options.dsn).toBeUndefined();
+  });
+
+  it('scrubs request, extra, spans, and user PII before daemon events leave the process', async () => {
+    const { scrubSentryEvent } = await loadSentryModule();
+
+    const scrubbed = scrubSentryEvent({
+      request: {
+        data: { prompt: 'private design prompt' },
+        query_string: 'code=oauth-code&state=oauth-state',
+        url: 'http://127.0.0.1:7456/api/mcp/oauth/callback?code=oauth-code&state=oauth-state#done',
+        headers: {
+          authorization: 'Bearer secret',
+          cookie: 'sid=secret',
+          'x-api-key': 'secret',
+          accept: 'application/json',
+        },
+      },
+      extra: {
+        OPENAI_API_KEY: 'secret',
+        nested: { token: 'secret', keep: 'ok' },
+      },
+      breadcrumbs: [
+        {
+          message: 'handled connector callback',
+          data: {
+            authorization: 'Bearer secret',
+            nested: { token: 'secret', keep: 'ok' },
+          },
+        },
+      ],
+      tags: {
+        feature: 'mcp',
+        session_token: 'secret',
+      },
+      contexts: {
+        oauth: {
+          url: 'http://127.0.0.1:7456/api/mcp/oauth/callback?code=oauth-code&state=oauth-state#done',
+          headers: {
+            cookie: 'sid=secret',
+            accept: 'application/json',
+          },
+          nested: { apiKey: 'secret', keep: 'ok' },
+        },
+      },
+      spans: [
+        {
+          op: 'http.client',
+          description: 'GET https://generativelanguage.googleapis.com/v1beta/models?key=provider-key',
+          data: {
+            'http.url': 'https://generativelanguage.googleapis.com/v1beta/models?key=provider-key',
+            query_string: 'key=provider-key',
+            nested: { apiKey: 'secret', keep: 'ok' },
+          },
+        },
+      ],
+      user: {
+        id: 'installation-1',
+        email: 'user@example.com',
+        username: 'person',
+      },
+    } as any) as any;
+
+    expect(scrubbed.request?.url).toBe('http://127.0.0.1:7456/api/mcp/oauth/callback#done');
+    expect(scrubbed.request?.query_string).toBeUndefined();
+    expect(scrubbed.request?.headers).toEqual({
+      authorization: '[Filtered]',
+      cookie: '[Filtered]',
+      'x-api-key': '[Filtered]',
+      accept: 'application/json',
+    });
+    expect(scrubbed.request?.data).toBeUndefined();
+    expect(scrubbed.extra).toEqual({
+      OPENAI_API_KEY: '[Filtered]',
+      nested: { token: '[Filtered]', keep: 'ok' },
+    });
+    expect(scrubbed.breadcrumbs).toEqual([
+      {
+        message: 'handled connector callback',
+        data: {
+          authorization: '[Filtered]',
+          nested: { token: '[Filtered]', keep: 'ok' },
+        },
+      },
+    ]);
+    expect(scrubbed.tags).toEqual({
+      feature: 'mcp',
+      session_token: '[Filtered]',
+    });
+    expect(scrubbed.contexts).toEqual({
+      oauth: {
+        url: 'http://127.0.0.1:7456/api/mcp/oauth/callback#done',
+        headers: {
+          cookie: '[Filtered]',
+          accept: 'application/json',
+        },
+        nested: { apiKey: '[Filtered]', keep: 'ok' },
+      },
+    });
+    expect(scrubbed.spans).toEqual([
+      {
+        op: 'http.client',
+        description: 'GET https://generativelanguage.googleapis.com/v1beta/models',
+        data: {
+          'http.url': 'https://generativelanguage.googleapis.com/v1beta/models',
+          query_string: '[Filtered]',
+          nested: { apiKey: '[Filtered]', keep: 'ok' },
+        },
+      },
+    ]);
+    expect(scrubbed.user).toEqual({ id: 'installation-1' });
+  });
+
+  it('captures and flushes handled sidecar startup failures', async () => {
+    const { captureStartupException } = await loadSentryModule();
+    const error = new Error('sidecar boot failed');
+    const sentry = {
+      captureException: vi.fn(),
+      flush: vi.fn().mockResolvedValue(true),
+    };
+
+    await captureStartupException(error, sentry);
+
+    expect(sentry.captureException).toHaveBeenCalledWith(error);
+    expect(sentry.flush).toHaveBeenCalledWith(2000);
+    expect(sidecarSource).toContain('captureStartupException');
+    expect(sidecarSource).toContain('await captureStartupException(error);');
+  });
+
+  it('initializes the SDK at most once', async () => {
+    const { initSentryFromEnv } = await loadSentryModule();
+    const sentry = { init: vi.fn() };
+
+    expect(initSentryFromEnv({
+      SENTRY_DSN: 'https://public@example.ingest.sentry.io/1',
+      SENTRY_ENVIRONMENT: 'production',
+    }, sentry)).toBe(true);
+    expect(initSentryFromEnv({
+      SENTRY_DSN: 'https://public@example.ingest.sentry.io/1',
+      SENTRY_ENVIRONMENT: 'production',
+    }, sentry)).toBe(false);
+    expect(sentry.init).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/daemon/tests/taste-profile-routes.test.ts
+++ b/apps/daemon/tests/taste-profile-routes.test.ts
@@ -1,0 +1,99 @@
+import type http from 'node:http';
+import { promises as fsp } from 'node:fs';
+import path from 'node:path';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { startServer } from '../src/server.js';
+
+interface StartedServer {
+  url: string;
+  server: http.Server;
+}
+
+const dataDir = process.env.OD_DATA_DIR as string;
+
+let baseUrl: string;
+let server: http.Server;
+
+beforeAll(async () => {
+  const started = (await startServer({
+    port: 0,
+    returnServer: true,
+  })) as StartedServer;
+  baseUrl = started.url;
+  server = started.server;
+});
+
+afterAll(() => (
+  server
+    ? new Promise<void>((resolve) => server.close(() => resolve()))
+    : undefined
+));
+
+beforeEach(async () => {
+  await fsp.rm(path.join(dataDir, 'taste-profile'), { recursive: true, force: true });
+});
+
+describe('taste profile routes', () => {
+  it('accepts a draft Style card into the long-term taste profile', async () => {
+    const getEmpty = await fetch(`${baseUrl}/api/taste-profile`);
+    expect(getEmpty.status).toBe(200);
+    expect(await getEmpty.json()).toMatchObject({
+      profile: { styleCards: [], updatedAt: null },
+    });
+
+    const acceptRes = await fetch(`${baseUrl}/api/taste-profile/style-cards`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        styleCard: {
+          id: 'style_premium_packaging_direction',
+          label: 'Premium packaging direction',
+          source: 'extracted',
+          status: 'draft',
+          signals: {
+            mood: 'premium, confident',
+            color: 'deep green, ivory, muted gold foil',
+            typography: 'elegant serif with uppercase details',
+            composition: 'centered label grid',
+            density: 'low density front, detailed back',
+            transferNotes: 'Adapt packaging signals without copying source art.',
+          },
+          sourceReferences: [
+            { id: 'reference_packaging_ref', name: 'Packaging reference' },
+          ],
+        },
+      }),
+    });
+    expect(acceptRes.status).toBe(200);
+    const accepted = await acceptRes.json() as {
+      styleCard: { id: string; status?: string };
+      profile: { styleCards: Array<{ id: string; status?: string }> };
+    };
+    expect(accepted.styleCard).toMatchObject({
+      id: 'style_premium_packaging_direction',
+      status: 'accepted',
+    });
+    expect(accepted.profile.styleCards).toEqual([
+      expect.objectContaining({
+        id: 'style_premium_packaging_direction',
+        status: 'accepted',
+      }),
+    ]);
+
+    const getProfile = await fetch(`${baseUrl}/api/taste-profile`);
+    const profile = await getProfile.json() as {
+      profile: { styleCards: Array<{ id: string; signals: { color: string } }> };
+    };
+    expect(profile.profile.styleCards[0]?.signals.color).toContain('deep green');
+
+    const promptRes = await fetch(`${baseUrl}/api/taste-profile/system-prompt`);
+    expect(promptRes.status).toBe(200);
+    const prompt = await promptRes.json() as { body: string };
+    expect(prompt.body).toContain('## Taste profile');
+    expect(prompt.body).toContain('Premium packaging direction');
+    expect(prompt.body).toContain('deep green, ivory, muted gold foil');
+    expect(prompt.body).toContain('Adapt these accepted style signals across media');
+    expect(prompt.body).toContain('Packaging reference');
+  });
+});

--- a/apps/daemon/tests/vite-env.d.ts
+++ b/apps/daemon/tests/vite-env.d.ts
@@ -1,0 +1,4 @@
+declare module '*?raw' {
+  const source: string;
+  export default source;
+}

--- a/apps/daemon/vitest.config.ts
+++ b/apps/daemon/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     environment: 'node',
     include: ['tests/**/*.test.{ts,tsx,js,mjs,cjs}'],
     setupFiles: ['tests/setup.ts'],
+    fileParallelism: false,
     testTimeout: 20_000,
   },
 });

--- a/apps/packaged/src/config.ts
+++ b/apps/packaged/src/config.ts
@@ -21,9 +21,13 @@ export type RawPackagedConfig = {
   namespaceBaseRoot?: string;
   nodeCommandRelative?: string;
   resourceRoot?: string;
+  sentryDsn?: string;
+  sentryEnvironment?: string;
+  sentryTracesSampleRate?: string;
   // Baked by tools/pack from OPEN_DESIGN_TELEMETRY_RELAY_URL and forwarded to
   // the daemon at runtime; Langfuse credentials never ship in packaged config.
   telemetryRelayUrl?: string;
+  webSentryDsn?: string;
   webSidecarEntryRelative?: string;
   webStandaloneRoot?: string;
   webOutputMode?: string;
@@ -37,7 +41,11 @@ export type PackagedConfig = {
   namespaceBaseRoot: string;
   nodeCommand: string | null;
   resourceRoot: string;
+  sentryDsn: string | null;
+  sentryEnvironment: string | null;
+  sentryTracesSampleRate: string | null;
   telemetryRelayUrl: string | null;
+  webSentryDsn: string | null;
   webSidecarEntry: string | null;
   webStandaloneRoot: string | null;
   webOutputMode: PackagedWebOutputMode;
@@ -156,7 +164,14 @@ export async function readPackagedConfig(): Promise<PackagedConfig> {
     namespaceBaseRoot,
     nodeCommand,
     resourceRoot,
+    sentryDsn: cleanOptionalString(process.env.OPEN_DESIGN_DAEMON_SENTRY_DSN) ?? cleanOptionalString(raw.sentryDsn),
+    sentryEnvironment:
+      cleanOptionalString(process.env.OPEN_DESIGN_DAEMON_SENTRY_ENVIRONMENT) ?? cleanOptionalString(raw.sentryEnvironment),
+    sentryTracesSampleRate:
+      cleanOptionalString(process.env.OPEN_DESIGN_DAEMON_SENTRY_TRACES_SAMPLE_RATE) ??
+      cleanOptionalString(raw.sentryTracesSampleRate),
     telemetryRelayUrl: cleanOptionalString(raw.telemetryRelayUrl),
+    webSentryDsn: cleanOptionalString(process.env.SENTRY_DSN) ?? cleanOptionalString(raw.webSentryDsn),
     webSidecarEntry,
     webStandaloneRoot,
     webOutputMode,

--- a/apps/packaged/src/headless.ts
+++ b/apps/packaged/src/headless.ts
@@ -60,8 +60,18 @@ function resolveHeadlessConfig(): PackagedConfig {
     namespaceBaseRoot,
     nodeCommand: null,
     resourceRoot,
+    sentryDsn:
+      process.env.OPEN_DESIGN_DAEMON_SENTRY_DSN?.trim() ||
+      null,
+    sentryEnvironment:
+      process.env.OPEN_DESIGN_DAEMON_SENTRY_ENVIRONMENT?.trim() ||
+      null,
+    sentryTracesSampleRate:
+      process.env.OPEN_DESIGN_DAEMON_SENTRY_TRACES_SAMPLE_RATE?.trim() ||
+      null,
     telemetryRelayUrl: process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL?.trim() || null,
     webSidecarEntry: null,
+    webSentryDsn: process.env.SENTRY_DSN?.trim() || null,
     webStandaloneRoot: null,
     webOutputMode: "server",
   };
@@ -108,6 +118,9 @@ async function main(): Promise<void> {
     daemonCliEntry: config.daemonCliEntry,
     daemonSidecarEntry: config.daemonSidecarEntry,
     nodeCommand: config.nodeCommand,
+    sentryDsn: config.sentryDsn,
+    sentryEnvironment: config.sentryEnvironment,
+    sentryTracesSampleRate: config.sentryTracesSampleRate,
     telemetryRelayUrl: config.telemetryRelayUrl,
     // PR #974 round-5 (lefarcen P2): headless packaged mode runs daemon
     // + web only, no Electron, no privileged shell.openPath surface.
@@ -118,6 +131,7 @@ async function main(): Promise<void> {
     // passes `true` because it does start desktop main.
     requireDesktopAuth: false,
     webSidecarEntry: config.webSidecarEntry,
+    webSentryDsn: config.webSentryDsn,
     webStandaloneRoot: config.webStandaloneRoot,
     webOutputMode: config.webOutputMode,
   });

--- a/apps/packaged/src/index.ts
+++ b/apps/packaged/src/index.ts
@@ -84,6 +84,9 @@ async function main(): Promise<void> {
     daemonCliEntry: config.daemonCliEntry,
     daemonSidecarEntry: config.daemonSidecarEntry,
     nodeCommand: config.nodeCommand,
+    sentryDsn: config.sentryDsn,
+    sentryEnvironment: config.sentryEnvironment,
+    sentryTracesSampleRate: config.sentryTracesSampleRate,
     telemetryRelayUrl: config.telemetryRelayUrl,
     // PR #974 round-5 (lefarcen P2): the Electron entry runs desktop
     // main alongside the daemon, so the import-folder gate must be
@@ -91,6 +94,7 @@ async function main(): Promise<void> {
     // the daemon+web-only counterpart that passes `false`.
     requireDesktopAuth: true,
     webSidecarEntry: config.webSidecarEntry,
+    webSentryDsn: config.webSentryDsn,
     webStandaloneRoot: config.webStandaloneRoot,
     webOutputMode: config.webOutputMode,
   });

--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -218,7 +218,18 @@ export type PackagedDaemonSpawnEnvOptions = {
    */
   requireDesktopAuth: boolean;
   legacyDataDir?: string | null;
+  sentryDsn?: string | null;
+  sentryEnvironment?: string | null;
+  sentryTracesSampleRate?: string | null;
   telemetryRelayUrl?: string | null;
+};
+
+type PackagedWebSpawnEnvOptions = {
+  webOutputMode: PackagedWebOutputMode;
+  webStandaloneRoot: string | null;
+  webSentryDsn?: string | null;
+  webSentryEnvironment?: string | null;
+  webSentryTracesSampleRate?: string | null;
 };
 
 /**
@@ -260,6 +271,45 @@ export function buildPackagedDaemonSpawnEnv(
     ...(options.legacyDataDir == null || options.legacyDataDir.length === 0
       ? {}
       : { OD_LEGACY_DATA_DIR: options.legacyDataDir }),
+    ...(options.sentryDsn == null || options.sentryDsn.length === 0
+      ? {}
+      : {
+          SENTRY_DSN: options.sentryDsn,
+          ...(options.sentryEnvironment == null || options.sentryEnvironment.length === 0
+            ? {}
+            : { SENTRY_ENVIRONMENT: options.sentryEnvironment }),
+          ...(options.sentryTracesSampleRate == null || options.sentryTracesSampleRate.length === 0
+            ? {}
+            : { SENTRY_TRACES_SAMPLE_RATE: options.sentryTracesSampleRate }),
+        }),
+  };
+}
+
+export function buildPackagedWebSpawnEnv(
+  daemonStatus: Pick<DaemonStatusSnapshot, "url">,
+  options: PackagedWebSpawnEnvOptions,
+): NodeJS.ProcessEnv {
+  if (daemonStatus.url == null) {
+    throw new Error("daemon did not report a URL");
+  }
+
+  return {
+    [SIDECAR_ENV.DAEMON_PORT]: extractPort(daemonStatus.url),
+    [SIDECAR_ENV.WEB_PORT]: "0",
+    ...(options.webStandaloneRoot == null ? {} : { OD_WEB_STANDALONE_ROOT: options.webStandaloneRoot }),
+    OD_WEB_OUTPUT_MODE: options.webOutputMode,
+    PORT: "0",
+    ...(options.webSentryDsn == null || options.webSentryDsn.length === 0
+      ? {}
+      : {
+          SENTRY_DSN: options.webSentryDsn,
+          ...(options.webSentryEnvironment == null || options.webSentryEnvironment.length === 0
+            ? {}
+            : { SENTRY_ENVIRONMENT: options.webSentryEnvironment }),
+          ...(options.webSentryTracesSampleRate == null || options.webSentryTracesSampleRate.length === 0
+            ? {}
+            : { SENTRY_TRACES_SAMPLE_RATE: options.webSentryTracesSampleRate }),
+        }),
   };
 }
 
@@ -338,6 +388,9 @@ export async function startPackagedSidecars(
     daemonCliEntry: string | null;
     daemonSidecarEntry: string | null;
     nodeCommand: string | null;
+    sentryDsn: string | null;
+    sentryEnvironment: string | null;
+    sentryTracesSampleRate: string | null;
     telemetryRelayUrl: string | null;
     /**
      * PR #974 round-5 (lefarcen P2): caller asserts whether a desktop
@@ -350,6 +403,7 @@ export async function startPackagedSidecars(
      */
     requireDesktopAuth: boolean;
     webSidecarEntry: string | null;
+    webSentryDsn: string | null;
     webStandaloneRoot: string | null;
     webOutputMode: PackagedWebOutputMode;
   },
@@ -374,6 +428,9 @@ export async function startPackagedSidecars(
         daemonCliEntry: options.daemonCliEntry,
         legacyDataDir: process.env.OD_LEGACY_DATA_DIR ?? null,
         requireDesktopAuth: options.requireDesktopAuth,
+        sentryDsn: options.sentryDsn,
+        sentryEnvironment: options.sentryEnvironment,
+        sentryTracesSampleRate: options.sentryTracesSampleRate,
         telemetryRelayUrl: options.telemetryRelayUrl,
       }),
       nodeCommand: options.nodeCommand,
@@ -397,13 +454,13 @@ export async function startPackagedSidecars(
     const web = await spawnSidecarChild({
       app: APP_KEYS.WEB,
       entryPath: options.webSidecarEntry ?? resolveSidecarEntry("@open-design/web", "sidecar"),
-      env: {
-        [SIDECAR_ENV.DAEMON_PORT]: extractPort(daemonStatus.url),
-        [SIDECAR_ENV.WEB_PORT]: "0",
-        ...(options.webStandaloneRoot == null ? {} : { OD_WEB_STANDALONE_ROOT: options.webStandaloneRoot }),
-        OD_WEB_OUTPUT_MODE: options.webOutputMode,
-        PORT: "0",
-      },
+      env: buildPackagedWebSpawnEnv(daemonStatus, {
+        webOutputMode: options.webOutputMode,
+        webStandaloneRoot: options.webStandaloneRoot,
+        webSentryDsn: options.webSentryDsn,
+        webSentryEnvironment: options.sentryEnvironment,
+        webSentryTracesSampleRate: options.sentryTracesSampleRate,
+      }),
       nodeCommand: options.nodeCommand,
       paths,
       runtime,

--- a/apps/packaged/tests/desktop-project-root-gate.test.ts
+++ b/apps/packaged/tests/desktop-project-root-gate.test.ts
@@ -13,7 +13,7 @@
  *      and `openPath(projectId)` must only forward projects whose
  *      resolvedDir came from the trusted-picker flow.
  */
-import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -70,7 +70,7 @@ describe("validateExistingDirectory", () => {
   it("accepts an existing absolute directory and returns the realpath", async () => {
     const result = await validateExistingDirectory(tempRoot);
     expect(result.ok).toBe(true);
-    if (result.ok) expect(result.resolved).toBe(tempRoot);
+    if (result.ok) expect(result.resolved).toBe(realpathSync(tempRoot));
   });
 
   it("realpath-resolves symlinks so attackers cannot register one path and reach another", async () => {
@@ -80,7 +80,7 @@ describe("validateExistingDirectory", () => {
     symlinkSync(realDir, linkDir, "dir");
     const result = await validateExistingDirectory(linkDir);
     expect(result.ok).toBe(true);
-    if (result.ok) expect(result.resolved).toBe(realDir);
+    if (result.ok) expect(result.resolved).toBe(realpathSync(realDir));
   });
 
   it("rejects macOS .app bundles even though they are technically directories", async () => {

--- a/apps/packaged/tests/sidecars.test.ts
+++ b/apps/packaged/tests/sidecars.test.ts
@@ -21,8 +21,10 @@ import { tmpdir } from 'node:os';
 import { delimiter, join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
+import headlessSource from '../src/headless.ts?raw';
 import {
   buildPackagedDaemonSpawnEnv,
+  buildPackagedWebSpawnEnv,
   resolveDaemonStatusTimeoutMs,
   resolvePackagedChildBaseEnv,
   resolvePackagedPathEnv,
@@ -61,6 +63,57 @@ describe('resolveDaemonStatusTimeoutMs', () => {
       if (original == null) delete process.env.OD_LEGACY_DATA_DIR;
       else process.env.OD_LEGACY_DATA_DIR = original;
     }
+  });
+});
+
+describe('buildPackagedWebSpawnEnv', () => {
+  it('forwards packaged web Sentry env separately from daemon Sentry env', () => {
+    const env = buildPackagedWebSpawnEnv(
+      { url: 'http://127.0.0.1:7456' },
+      {
+        webOutputMode: 'standalone',
+        webStandaloneRoot: '/tmp/od-web-standalone',
+        webSentryDsn: 'https://public@example.ingest.sentry.io/2',
+        webSentryEnvironment: 'production',
+        webSentryTracesSampleRate: '0.2',
+      },
+    );
+
+    expect(env.SENTRY_DSN).toBe('https://public@example.ingest.sentry.io/2');
+    expect(env.SENTRY_ENVIRONMENT).toBe('production');
+    expect(env.SENTRY_TRACES_SAMPLE_RATE).toBe('0.2');
+    expect(env.OPEN_DESIGN_DAEMON_SENTRY_DSN).toBeUndefined();
+    expect(env.OD_WEB_OUTPUT_MODE).toBe('standalone');
+    expect(env.OD_WEB_STANDALONE_ROOT).toBe('/tmp/od-web-standalone');
+  });
+
+  it('omits web Sentry env when no web DSN is configured', () => {
+    const env = buildPackagedWebSpawnEnv(
+      { url: 'http://127.0.0.1:7456' },
+      {
+        webOutputMode: 'server',
+        webStandaloneRoot: null,
+        webSentryDsn: null,
+        webSentryEnvironment: 'production',
+        webSentryTracesSampleRate: '0.2',
+      },
+    );
+
+    expect(env.SENTRY_DSN).toBeUndefined();
+    expect(env.SENTRY_ENVIRONMENT).toBeUndefined();
+    expect(env.SENTRY_TRACES_SAMPLE_RATE).toBeUndefined();
+  });
+});
+
+describe('headless packaged config scope', () => {
+  it('keeps headless packaged mode on explicit env instead of arbitrary config files', () => {
+    expect(headlessSource).toContain('process.env.OPEN_DESIGN_DAEMON_SENTRY_DSN');
+    expect(headlessSource).toContain('process.env.SENTRY_DSN');
+    expect(headlessSource).not.toContain('OD_PACKAGED_CONFIG_PATH');
+    expect(headlessSource).not.toContain('OD_WEB_OUTPUT_MODE');
+    expect(headlessSource).not.toContain('readFileSync');
+    expect(headlessSource).not.toContain('HeadlessRawPackagedConfig');
+    expect(headlessSource).not.toContain('raw.');
   });
 });
 
@@ -220,6 +273,34 @@ describe('buildPackagedDaemonSpawnEnv', () => {
     expect(env.OPEN_DESIGN_TELEMETRY_RELAY_URL).toBe(
       'https://telemetry.open-design.ai/api/langfuse',
     );
+  });
+
+  it('forwards packaged daemon Sentry env only when a daemon DSN is configured', () => {
+    const withSentry = buildPackagedDaemonSpawnEnv(fakePaths(), {
+      appVersion: null,
+      daemonCliEntry: null,
+      legacyDataDir: null,
+      requireDesktopAuth: true,
+      sentryDsn: 'https://public@example.ingest.sentry.io/1',
+      sentryEnvironment: 'production',
+      sentryTracesSampleRate: '0.25',
+    });
+    expect(withSentry.SENTRY_DSN).toBe('https://public@example.ingest.sentry.io/1');
+    expect(withSentry.SENTRY_ENVIRONMENT).toBe('production');
+    expect(withSentry.SENTRY_TRACES_SAMPLE_RATE).toBe('0.25');
+
+    const withoutSentry = buildPackagedDaemonSpawnEnv(fakePaths(), {
+      appVersion: null,
+      daemonCliEntry: null,
+      legacyDataDir: null,
+      requireDesktopAuth: true,
+      sentryDsn: null,
+      sentryEnvironment: 'production',
+      sentryTracesSampleRate: '0.25',
+    });
+    expect(withoutSentry.SENTRY_DSN).toBeUndefined();
+    expect(withoutSentry.SENTRY_ENVIRONMENT).toBeUndefined();
+    expect(withoutSentry.SENTRY_TRACES_SAMPLE_RATE).toBeUndefined();
   });
 });
 

--- a/apps/packaged/tests/vite-env.d.ts
+++ b/apps/packaged/tests/vite-env.d.ts
@@ -1,0 +1,4 @@
+declare module '*?raw' {
+  const source: string;
+  export default source;
+}

--- a/apps/telemetry-worker/package.json
+++ b/apps/telemetry-worker/package.json
@@ -15,5 +15,8 @@
   },
   "engines": {
     "node": "~24"
+  },
+  "dependencies": {
+    "@sentry/cloudflare": "^10.63.0"
   }
 }

--- a/apps/telemetry-worker/src/index.ts
+++ b/apps/telemetry-worker/src/index.ts
@@ -1,8 +1,15 @@
+import * as Sentry from '@sentry/cloudflare';
+import type { CloudflareOptions, ErrorEvent, Event } from '@sentry/cloudflare';
+
 const DEFAULT_LANGFUSE_BASE_URL = 'https://us.cloud.langfuse.com';
 const MAX_BODY_BYTES = 1024 * 1024;
 const MAX_BATCH_EVENTS = 100;
 const RELAY_MARKER_HEADER = 'X-Open-Design-Telemetry';
 const RELAY_MARKER_VALUE = 'langfuse-ingestion-v1';
+const DEFAULT_SENTRY_TRACES_SAMPLE_RATE = 0.1;
+const FILTERED_VALUE = '[Filtered]';
+const SENSITIVE_KEY_PATTERN =
+  /authorization|cookie|password|secret|token|api[-_]?key|session|langfuse/i;
 const ALLOWED_EVENT_TYPES = new Set([
   'trace-create',
   'span-create',
@@ -19,6 +26,10 @@ export interface Env {
   LANGFUSE_PUBLIC_KEY?: string;
   LANGFUSE_SECRET_KEY?: string;
   LANGFUSE_BASE_URL?: string;
+  SENTRY_DSN?: string;
+  SENTRY_ENVIRONMENT?: string;
+  SENTRY_RELEASE?: string;
+  SENTRY_TRACES_SAMPLE_RATE?: string;
   TELEMETRY_CLIENT_RATE_LIMITER?: RateLimitBinding;
   TELEMETRY_IP_RATE_LIMITER?: RateLimitBinding;
 }
@@ -35,6 +46,86 @@ function jsonResponse(status: number, body: Record<string, unknown>): Response {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function shouldScrubKey(key: string): boolean {
+  return SENSITIVE_KEY_PATTERN.test(key);
+}
+
+function scrubValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => scrubValue(item));
+  }
+
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  const scrubbed: Record<string, unknown> = {};
+  for (const [key, nestedValue] of Object.entries(value)) {
+    scrubbed[key] = shouldScrubKey(key) ? FILTERED_VALUE : scrubValue(nestedValue);
+  }
+  return scrubbed;
+}
+
+function parseSampleRate(value: string | undefined): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 && parsed <= 1
+    ? parsed
+    : DEFAULT_SENTRY_TRACES_SAMPLE_RATE;
+}
+
+export function scrubSentryEvent(event: Event): Event {
+  const scrubbed: Event = { ...event };
+
+  if (event.request) {
+    scrubbed.request = { ...event.request };
+    delete scrubbed.request.data;
+    if (event.request.headers && isRecord(event.request.headers)) {
+      scrubbed.request.headers = scrubValue(event.request.headers) as Record<string, string>;
+    }
+  }
+
+  if (event.extra) {
+    scrubbed.extra = scrubValue(event.extra) as NonNullable<Event['extra']>;
+  }
+
+  if (event.user) {
+    const userId = typeof event.user.id === 'string' ? event.user.id : undefined;
+    if (userId) {
+      scrubbed.user = { id: userId };
+    } else {
+      delete scrubbed.user;
+    }
+  }
+
+  return scrubbed;
+}
+
+export function buildSentryOptions(env: Env): CloudflareOptions {
+  const dsn = env.SENTRY_DSN?.trim();
+  const release = env.SENTRY_RELEASE?.trim();
+  const environment = env.SENTRY_ENVIRONMENT?.trim() || 'production';
+  const options: CloudflareOptions = {
+    enabled: Boolean(dsn),
+    environment,
+    sendDefaultPii: false,
+    tracesSampleRate: parseSampleRate(env.SENTRY_TRACES_SAMPLE_RATE),
+    integrations: (integrations) => [
+      ...integrations.filter((integration) => integration.name !== 'HttpServer'),
+      Sentry.httpServerIntegration({ maxRequestBodySize: 'none' }),
+    ],
+    beforeSend: (event) => scrubSentryEvent(event) as ErrorEvent,
+  };
+
+  if (dsn) {
+    options.dsn = dsn;
+  }
+  if (release) {
+    options.release = release;
+  }
+
+  return options;
 }
 
 function bodySizeBytes(value: string): number {
@@ -196,6 +287,6 @@ async function handleRequest(request: Request, env: Env): Promise<Response> {
   });
 }
 
-export default {
+export default Sentry.withSentry<Env>((env) => buildSentryOptions(env), {
   fetch: handleRequest,
-};
+});

--- a/apps/telemetry-worker/tests/github-gates.test.ts
+++ b/apps/telemetry-worker/tests/github-gates.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import ciWorkflow from '../../../.github/workflows/ci.yml?raw';
+
+describe('GitHub automation gates', () => {
+  it('exposes an automerge-gate job backed by workspace and packaged validation', () => {
+    expect(ciWorkflow).toContain('automerge-gate:');
+    expect(ciWorkflow).toContain('name: automerge-gate');
+    expect(ciWorkflow).toContain(
+      'needs: [validate, packaged_changes, packaged_smoke_mac, packaged_smoke_win]',
+    );
+    expect(ciWorkflow).toContain('VALIDATE_RESULT');
+    expect(ciWorkflow).toContain('PACKAGED_REQUIRED');
+    expect(ciWorkflow).toContain('MAC_SMOKE_RESULT');
+    expect(ciWorkflow).toContain('WIN_SMOKE_RESULT');
+    expect(ciWorkflow).toContain('exit 1');
+    expect(ciWorkflow).toContain('pnpm --filter @open-design/telemetry-worker test');
+  });
+});

--- a/apps/telemetry-worker/tests/github-gates.test.ts
+++ b/apps/telemetry-worker/tests/github-gates.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import ciWorkflow from '../../../.github/workflows/ci.yml?raw';
+import releaseBetaWorkflow from '../../../.github/workflows/release-beta.yml?raw';
+import releaseStableWorkflow from '../../../.github/workflows/release-stable.yml?raw';
 
 describe('GitHub automation gates', () => {
   it('exposes an automerge-gate job backed by workspace and packaged validation', () => {
@@ -15,5 +17,44 @@ describe('GitHub automation gates', () => {
     expect(ciWorkflow).toContain('WIN_SMOKE_RESULT');
     expect(ciWorkflow).toContain('exit 1');
     expect(ciWorkflow).toContain('pnpm --filter @open-design/telemetry-worker test');
+  });
+
+  it('keeps release Sentry credentials secret-scoped and out of top-level workflow env', () => {
+    for (const workflow of [releaseBetaWorkflow, releaseStableWorkflow]) {
+      expect(workflow).not.toContain('${{ vars.OPEN_DESIGN_WEB_SENTRY_DSN }}');
+      expect(workflow).not.toContain('${{ vars.OPEN_DESIGN_DAEMON_SENTRY_DSN }}');
+      expect(workflow).not.toContain('\n  SENTRY_AUTH_TOKEN:');
+      expect(workflow).not.toContain('\n  NEXT_PUBLIC_SENTRY_DSN:');
+      expect(workflow).not.toContain('\n  OPEN_DESIGN_DAEMON_SENTRY_DSN:');
+      expect(workflow).not.toContain('\n  SENTRY_DSN:');
+      expect(workflow).not.toContain('\n  SENTRY_ORG: zhenheai');
+      expect(workflow).not.toContain('\n  SENTRY_PROJECT: open-design-web');
+
+      expect(workflow).toContain('NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.OPEN_DESIGN_WEB_SENTRY_DSN }}');
+      expect(workflow).toContain('OPEN_DESIGN_DAEMON_SENTRY_DSN: ${{ secrets.OPEN_DESIGN_DAEMON_SENTRY_DSN }}');
+      expect(workflow).toContain('SENTRY_DSN: ${{ secrets.OPEN_DESIGN_WEB_SENTRY_DSN }}');
+      expect(workflow).toContain('SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}');
+      expect(workflow).toContain('SENTRY_ORG: ${{ vars.SENTRY_ORG }}');
+      expect(workflow).toContain('SENTRY_PROJECT: ${{ vars.OPEN_DESIGN_WEB_SENTRY_PROJECT }}');
+    }
+  });
+
+  it('keeps Windows tools-pack cache keys free of Sentry secret-derived material', () => {
+    for (const workflow of [releaseBetaWorkflow, releaseStableWorkflow]) {
+      const cacheKeyStep = workflow.match(
+        /- name: Compute Windows tools-pack cache key[\s\S]*?\n\n      - name: Restore Windows tools-pack cache/,
+      )?.[0];
+
+      expect(cacheKeyStep).toBeTruthy();
+      expect(cacheKeyStep).toContain('WIN_TOOLS_PACK_ORIGIN_KEY');
+      expect(cacheKeyStep).not.toContain('WIN_TOOLS_PACK_CACHE_EPOCH');
+      expect(cacheKeyStep).not.toContain('OPEN_DESIGN_DAEMON_SENTRY_DSN');
+      expect(cacheKeyStep).not.toContain('NEXT_PUBLIC_SENTRY_DSN');
+      expect(cacheKeyStep).not.toContain('SENTRY_AUTH_TOKEN');
+      expect(cacheKeyStep).not.toContain('SENTRY_DSN');
+      expect(cacheKeyStep).not.toContain('$sentryInputs');
+      expect(cacheKeyStep).not.toContain('$sentryHash');
+      expect(cacheKeyStep).not.toContain('[System.Security.Cryptography.SHA256]');
+    }
   });
 });

--- a/apps/telemetry-worker/tests/sentry.test.ts
+++ b/apps/telemetry-worker/tests/sentry.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import packageJsonSource from '../package.json?raw';
+import source from '../src/index.ts?raw';
+import wranglerSource from '../wrangler.toml?raw';
+import { buildSentryOptions, scrubSentryEvent } from '../src/index';
+
+const packageJson = JSON.parse(packageJsonSource) as {
+  dependencies?: Record<string, string>;
+};
+
+describe('Sentry onboarding', () => {
+  it('installs and wraps the Cloudflare worker with Sentry', () => {
+    expect(packageJson.dependencies?.['@sentry/cloudflare']).toBeDefined();
+    expect(source).toContain("@sentry/cloudflare");
+    expect(source).toContain('Sentry.withSentry');
+    expect(source).toContain('buildSentryOptions');
+    expect(source).toContain('httpServerIntegration');
+    expect(source).toContain("maxRequestBodySize: 'none'");
+  });
+
+  it('declares only non-secret Sentry vars in Wrangler config', () => {
+    expect(wranglerSource).toContain('compatibility_flags = ["nodejs_compat"]');
+    expect(wranglerSource).toContain('SENTRY_ENVIRONMENT = "production"');
+    expect(wranglerSource).toContain('SENTRY_TRACES_SAMPLE_RATE = "0.1"');
+    expect(wranglerSource).not.toContain('SENTRY_DSN');
+  });
+
+  it('builds safe options from Worker secrets', () => {
+    const options = buildSentryOptions({
+      SENTRY_DSN: 'https://public@example.ingest.sentry.io/1',
+      SENTRY_ENVIRONMENT: 'production',
+      SENTRY_RELEASE: 'open-design-telemetry@abc123',
+      SENTRY_TRACES_SAMPLE_RATE: '0.25',
+    });
+
+    expect(options).toMatchObject({
+      dsn: 'https://public@example.ingest.sentry.io/1',
+      enabled: true,
+      environment: 'production',
+      release: 'open-design-telemetry@abc123',
+      sendDefaultPii: false,
+      tracesSampleRate: 0.25,
+    });
+    expect(options.beforeSend).toBeTypeOf('function');
+  });
+
+  it('disables the SDK when no DSN secret is configured', () => {
+    const options = buildSentryOptions({
+      SENTRY_ENVIRONMENT: 'production',
+      SENTRY_TRACES_SAMPLE_RATE: '0.1',
+    });
+
+    expect(options.enabled).toBe(false);
+    expect(options.dsn).toBeUndefined();
+  });
+
+  it('scrubs request, extra, and user PII before events leave the relay', () => {
+    const scrubbed = scrubSentryEvent({
+      request: {
+        data: {
+          batch: [{ body: { prompt: 'private prompt' } }],
+        },
+        headers: {
+          authorization: 'Bearer secret',
+          cookie: 'sid=secret',
+          'x-api-key': 'secret',
+          accept: 'application/json',
+        },
+      },
+      extra: {
+        LANGFUSE_SECRET_KEY: 'secret',
+        nested: { token: 'secret', keep: 'ok' },
+      },
+      user: {
+        id: 'installation-1',
+        email: 'user@example.com',
+        username: 'person',
+      },
+    });
+
+    expect(scrubbed.request?.headers).toEqual({
+      authorization: '[Filtered]',
+      cookie: '[Filtered]',
+      'x-api-key': '[Filtered]',
+      accept: 'application/json',
+    });
+    expect(scrubbed.request?.data).toBeUndefined();
+    expect(scrubbed.extra).toEqual({
+      LANGFUSE_SECRET_KEY: '[Filtered]',
+      nested: { token: '[Filtered]', keep: 'ok' },
+    });
+    expect(scrubbed.user).toEqual({ id: 'installation-1' });
+  });
+});

--- a/apps/telemetry-worker/tests/vite-env.d.ts
+++ b/apps/telemetry-worker/tests/vite-env.d.ts
@@ -1,0 +1,4 @@
+declare module '*?raw' {
+  const source: string;
+  export default source;
+}

--- a/apps/telemetry-worker/wrangler.toml
+++ b/apps/telemetry-worker/wrangler.toml
@@ -2,6 +2,7 @@ name = "open-design-telemetry-relay"
 account_id = "64ad4569ffd912432d6b86d5656484c4"
 main = "src/index.ts"
 compatibility_date = "2026-05-01"
+compatibility_flags = ["nodejs_compat"]
 workers_dev = false
 routes = [
   { pattern = "telemetry.open-design.ai", custom_domain = true }
@@ -9,6 +10,8 @@ routes = [
 
 [vars]
 LANGFUSE_BASE_URL = "https://us.cloud.langfuse.com"
+SENTRY_ENVIRONMENT = "production"
+SENTRY_TRACES_SAMPLE_RATE = "0.1"
 
 [[ratelimits]]
 name = "TELEMETRY_CLIENT_RATE_LIMITER"

--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -1,0 +1,14 @@
+import * as Sentry from '@sentry/nextjs';
+
+import { buildBrowserSentryOptions } from './src/sentry';
+
+Sentry.init(buildBrowserSentryOptions({
+  NEXT_PUBLIC_ENV: process.env.NEXT_PUBLIC_ENV,
+  NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  NEXT_PUBLIC_SENTRY_ENVIRONMENT: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
+  NEXT_PUBLIC_SENTRY_RELEASE: process.env.NEXT_PUBLIC_SENTRY_RELEASE,
+  NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE: process.env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE,
+  NODE_ENV: process.env.NODE_ENV,
+}));
+
+export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1,0 +1,9 @@
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    await import('./sentry.server.config');
+  }
+
+  if (process.env.NEXT_RUNTIME === 'edge') {
+    await import('./sentry.edge.config');
+  }
+}

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from 'next';
+import { withSentryConfig, type SentryBuildOptions } from '@sentry/nextjs';
 import { dirname, isAbsolute, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -86,4 +87,34 @@ const nextConfig: NextConfig = {
       : {}),
 };
 
-export default nextConfig;
+const sentryOrg = process.env.SENTRY_ORG?.trim();
+const sentryProject = process.env.SENTRY_PROJECT?.trim();
+
+const sentryBuildOptions: SentryBuildOptions = {
+  ...(sentryOrg ? { org: sentryOrg } : {}),
+  ...(sentryProject ? { project: sentryProject } : {}),
+  silent: !process.env.SENTRY_AUTH_TOKEN,
+  telemetry: false,
+  widenClientFileUpload: true,
+  webpack: {
+    treeshake: {
+      removeDebugLogging: true,
+    },
+  },
+  sourcemaps: {
+    disable: !process.env.SENTRY_AUTH_TOKEN,
+    deleteSourcemapsAfterUpload: true,
+  },
+};
+
+if (process.env.SENTRY_AUTH_TOKEN) {
+  sentryBuildOptions.authToken = process.env.SENTRY_AUTH_TOKEN;
+}
+
+if (process.env.SENTRY_RELEASE) {
+  sentryBuildOptions.release = {
+    name: process.env.SENTRY_RELEASE,
+  };
+}
+
+export default withSentryConfig(nextConfig, sentryBuildOptions);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,6 +33,7 @@
     "@open-design/platform": "workspace:*",
     "@open-design/sidecar": "workspace:*",
     "@open-design/sidecar-proto": "workspace:*",
+    "@sentry/nextjs": "^10.63.0",
     "next": "^16.2.5",
     "openai": "^6.36.0",
     "react": "^18.3.1",

--- a/apps/web/sentry.edge.config.ts
+++ b/apps/web/sentry.edge.config.ts
@@ -1,0 +1,5 @@
+import * as Sentry from '@sentry/nextjs';
+
+import { buildServerSentryOptions } from './src/sentry';
+
+Sentry.init(buildServerSentryOptions());

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -1,0 +1,5 @@
+import * as Sentry from '@sentry/nextjs';
+
+import { buildServerSentryOptions } from './src/sentry';
+
+Sentry.init(buildServerSentryOptions());

--- a/apps/web/src/components/EntryView.tsx
+++ b/apps/web/src/components/EntryView.tsx
@@ -24,6 +24,7 @@ import { ExamplesTab } from './ExamplesTab';
 import { Icon } from './Icon';
 import { LanguageMenu } from './LanguageMenu';
 import { CenteredLoader } from './Loading';
+import { MemorySection } from './MemorySection';
 import { NewProjectPanel, type CreateInput } from './NewProjectPanel';
 import {
   fetchConnectors,
@@ -34,7 +35,7 @@ import { PromptTemplatePreviewModal } from './PromptTemplatePreviewModal';
 import { PromptTemplatesTab } from './PromptTemplatesTab';
 import { apiProtocolLabel } from '../utils/apiProtocol';
 
-type TopTab = 'designs' | 'templates' | 'design-systems' | 'image-templates' | 'video-templates';
+type TopTab = 'designs' | 'templates' | 'design-systems' | 'references' | 'image-templates' | 'video-templates';
 
 interface Props {
   // Union of functional skills + design templates — used for id-based
@@ -536,6 +537,12 @@ export function EntryView({
             />
             <TopTabButton
               current={topTab}
+              value="references"
+              label="References"
+              onClick={setTopTab}
+            />
+            <TopTabButton
+              current={topTab}
               value="image-templates"
               label={t('entry.tabImageTemplates')}
               onClick={setTopTab}
@@ -589,6 +596,15 @@ export function EntryView({
                 onPreview={previewDesignSystem}
               />
             )
+          ) : null}
+          {topTab === 'references' ? (
+            <MemorySection
+              heading="Reference board"
+              description="Save design references, notes, and inspiration for later taste extraction."
+              initialFilter="reference"
+              defaultNewType="reference"
+              enableStyleCardExtraction
+            />
           ) : null}
           {topTab === 'image-templates' ? (
             promptTemplatesLoading ? (

--- a/apps/web/src/components/MemorySection.tsx
+++ b/apps/web/src/components/MemorySection.tsx
@@ -20,6 +20,8 @@ import type {
   MemoryExtractionsResponse,
   MemoryListResponse,
   MemoryType,
+  AcceptStyleCardResponse,
+  StyleCardMetadata,
 } from '@open-design/contracts';
 
 const TYPES: MemoryType[] = ['user', 'feedback', 'project', 'reference'];
@@ -38,6 +40,18 @@ const EMPTY_DRAFT: DraftEntry = {
   type: 'user',
   body: '',
 };
+
+const STYLE_SIGNAL_FIELDS: ReadonlyArray<{
+  key: keyof StyleCardMetadata['signals'];
+  label: string;
+}> = [
+  { key: 'mood', label: 'Mood' },
+  { key: 'color', label: 'Color' },
+  { key: 'typography', label: 'Typography' },
+  { key: 'composition', label: 'Composition' },
+  { key: 'density', label: 'Density' },
+  { key: 'transferNotes', label: 'Transfer notes' },
+];
 
 // Small uppercase caption used above each form field. Centralised so
 // every field renders with the same color/letter-spacing/baseline; this
@@ -161,6 +175,28 @@ async function clearExtractionHistory(): Promise<boolean> {
   return resp.ok;
 }
 
+async function extractStyleCard(referenceIds: string[], label: string): Promise<StyleCardMetadata | null> {
+  const resp = await fetch('/api/style-cards/extract', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ referenceIds, label }),
+  });
+  if (!resp.ok) return null;
+  const json = (await resp.json()) as { styleCard?: StyleCardMetadata };
+  return json.styleCard ?? null;
+}
+
+async function acceptStyleCard(styleCard: StyleCardMetadata): Promise<StyleCardMetadata | null> {
+  const resp = await fetch('/api/taste-profile/style-cards', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ styleCard }),
+  });
+  if (!resp.ok) return null;
+  const json = (await resp.json()) as AcceptStyleCardResponse;
+  return json.styleCard ?? null;
+}
+
 // Map a record back to a single human label for the small badge that
 // appears next to the row's preview text. Centralised so phase + skip
 // reason render consistently across the empty banner and the list.
@@ -264,7 +300,21 @@ function formatDuration(record: MemoryExtractionRecord): string | null {
 
 type FlashKind = 'created' | 'saved' | 'deleted' | 'indexSaved';
 
-export function MemorySection() {
+interface MemorySectionProps {
+  heading?: string;
+  description?: string;
+  initialFilter?: 'all' | MemoryType;
+  defaultNewType?: MemoryType;
+  enableStyleCardExtraction?: boolean;
+}
+
+export function MemorySection({
+  heading,
+  description,
+  initialFilter = 'all',
+  defaultNewType = 'user',
+  enableStyleCardExtraction = false,
+}: MemorySectionProps = {}) {
   const t = useT();
   const [enabled, setEnabled] = useState(true);
   const [rootDir, setRootDir] = useState('');
@@ -275,7 +325,10 @@ export function MemorySection() {
   const [previewBody, setPreviewBody] = useState<string | null>(null);
   const [editing, setEditing] = useState<DraftEntry | null>(null);
   const [busy, setBusy] = useState(false);
-  const [filter, setFilter] = useState<'all' | MemoryType>('all');
+  const [styleCardBusy, setStyleCardBusy] = useState(false);
+  const [styleCardDraft, setStyleCardDraft] = useState<StyleCardMetadata | null>(null);
+  const [styleCardMessage, setStyleCardMessage] = useState<string | null>(null);
+  const [filter, setFilter] = useState<'all' | MemoryType>(initialFilter);
   // Brief inline confirmation after a manual save/create/delete. The
   // form vanishes on success and the existing list re-renders, but
   // those signals are subtle — a 1.8s pill makes "your click did
@@ -398,6 +451,11 @@ export function MemorySection() {
     return entries.filter((e) => e.type === filter);
   }, [entries, filter]);
 
+  const referenceEntries = useMemo(
+    () => entries.filter((e) => e.type === 'reference'),
+    [entries],
+  );
+
   // The "no API key" banner only shows when the most recent attempt
   // skipped for that specific reason. We don't show it for
   // memory-disabled (the user's own toggle) or empty-message (a
@@ -458,8 +516,8 @@ export function MemorySection() {
   }, []);
 
   const startNew = useCallback(() => {
-    setEditing({ ...EMPTY_DRAFT });
-  }, []);
+    setEditing({ ...EMPTY_DRAFT, type: defaultNewType });
+  }, [defaultNewType]);
 
   const cancelEdit = useCallback(() => {
     setEditing(null);
@@ -496,6 +554,70 @@ export function MemorySection() {
   const onToggleEnabled = useCallback(async (next: boolean) => {
     setEnabled(next);
     await setMemoryEnabled(next);
+  }, []);
+
+  const onExtractStyleCard = useCallback(async () => {
+    const references = referenceEntries;
+    if (references.length === 0) return;
+    const label = references.length === 1
+      ? `${references[0]!.name} direction`
+      : 'Reference board direction';
+    setStyleCardBusy(true);
+    setStyleCardMessage(null);
+    try {
+      const card = await extractStyleCard(
+        references.map((entry) => entry.id),
+        label,
+      );
+      if (card) setStyleCardDraft(card);
+    } finally {
+      setStyleCardBusy(false);
+    }
+  }, [referenceEntries]);
+
+  const updateStyleSignal = useCallback(
+    (key: keyof StyleCardMetadata['signals'], value: string) => {
+      setStyleCardDraft((current) =>
+        current
+          ? {
+              ...current,
+              signals: { ...current.signals, [key]: value },
+              updatedAt: Date.now(),
+            }
+          : current,
+      );
+    },
+    [],
+  );
+
+  const updateStyleLabel = useCallback((value: string) => {
+    setStyleCardDraft((current) =>
+      current ? { ...current, label: value, updatedAt: Date.now() } : current,
+    );
+  }, []);
+
+  const onAcceptStyleCard = useCallback(async () => {
+    if (!styleCardDraft) return;
+    setStyleCardBusy(true);
+    setStyleCardMessage(null);
+    try {
+      const accepted = await acceptStyleCard(styleCardDraft);
+      if (accepted) {
+        setStyleCardDraft(accepted);
+        setStyleCardMessage('Accepted to taste profile');
+      }
+    } finally {
+      setStyleCardBusy(false);
+    }
+  }, [styleCardDraft]);
+
+  const onIgnoreStyleCard = useCallback(() => {
+    setStyleCardDraft((current) =>
+      current
+        ? { ...current, status: 'ignored', updatedAt: Date.now() }
+        : current,
+    );
+    setStyleCardMessage('Ignored for now');
   }, []);
 
   const onSaveIndex = useCallback(async () => {
@@ -537,8 +659,8 @@ export function MemorySection() {
     <section className={`settings-section${enabled ? '' : ' is-disabled'}`}>
       <div className="section-head">
         <div>
-          <h3>{t('settings.memory')}</h3>
-          <p className="hint">{t('settings.memoryDescription')}</p>
+          <h3>{heading ?? t('settings.memory')}</h3>
+          <p className="hint">{description ?? t('settings.memoryDescription')}</p>
         </div>
         <label
           className="toggle-switch"
@@ -610,6 +732,88 @@ export function MemorySection() {
           <span>{t('settings.memoryNew')}</span>
         </button>
       </div>
+
+      {enableStyleCardExtraction ? (
+        <div className="style-card-extraction-panel">
+          <div>
+            <strong>Style card extraction</strong>
+            <p className="hint">
+              Turn saved references into an editable generation-ready style direction.
+            </p>
+          </div>
+          <button
+            type="button"
+            className="secondary"
+            onClick={onExtractStyleCard}
+            disabled={styleCardBusy || referenceEntries.length === 0}
+          >
+            <Icon name="sparkles" size={14} />
+            <span>{styleCardBusy ? 'Extracting...' : 'Extract Style card'}</span>
+          </button>
+        </div>
+      ) : null}
+
+      {styleCardDraft ? (
+        <div className="style-card-editor" aria-label="Style card proposal">
+          <div className="style-card-editor-head">
+            <div>
+              <strong>Style card proposal</strong>
+              <p className="hint">
+                Edit these fields before using this direction in a project.
+              </p>
+            </div>
+            <span className="library-card-badge">{styleCardDraft.status ?? 'draft'}</span>
+          </div>
+          <label className="style-card-field">
+            <span>Label</span>
+            <input
+              type="text"
+              value={styleCardDraft.label}
+              onChange={(event) => updateStyleLabel(event.target.value)}
+            />
+          </label>
+          <div className="style-card-signal-grid">
+            {STYLE_SIGNAL_FIELDS.map((field) => (
+              <label key={field.key} className="style-card-field">
+                <span>{field.label}</span>
+                <textarea
+                  rows={3}
+                  value={styleCardDraft.signals[field.key]}
+                  onChange={(event) => updateStyleSignal(field.key, event.target.value)}
+                />
+              </label>
+            ))}
+          </div>
+          {styleCardDraft.sourceReferences?.length ? (
+            <p className="hint">
+              Sources: {styleCardDraft.sourceReferences.map((ref) => ref.name).join(', ')}
+            </p>
+          ) : null}
+          <div className="style-card-actions">
+            <button
+              type="button"
+              className="ghost"
+              onClick={onIgnoreStyleCard}
+              disabled={styleCardBusy || styleCardDraft.status === 'accepted'}
+            >
+              Ignore
+            </button>
+            <button
+              type="button"
+              className="primary"
+              onClick={onAcceptStyleCard}
+              disabled={styleCardBusy || styleCardDraft.status === 'accepted'}
+            >
+              {styleCardBusy ? 'Saving...' : 'Accept Style card'}
+            </button>
+          </div>
+          {styleCardMessage ? (
+            <div role="status" className="memory-flash-pill">
+              {styleCardMessage}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
 
       {flash ? (
         <div

--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -1,5 +1,17 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import type { ConnectorDetail, ImportFolderResponse } from '@open-design/contracts';
+import {
+  ARTIFACT_INTENT_GROUPS,
+  INITIAL_ARTIFACT_INTENTS,
+  STARTER_STYLE_CARDS,
+  buildPrintSpecMetadata,
+  cloneStyleCardMetadata,
+  findArtifactIntentPreset,
+  findStarterStyleCard,
+  toArtifactIntentMetadata,
+  type ArtifactIntentId,
+  type ConnectorDetail,
+  type ImportFolderResponse,
+} from '@open-design/contracts';
 
 // Window.electronAPI is declared globally in apps/web/src/types/electron.d.ts
 // so the new openPath + pickAndImport methods (#451 / PR #974) and
@@ -224,6 +236,10 @@ export function NewProjectPanel({
     { message: string; details?: string } | null
   >(null);
   const [tab, setTab] = useState<CreateTab>('prototype');
+  const [artifactIntentId, setArtifactIntentId] =
+    useState<ArtifactIntentId>('landing-page');
+  const [styleCardId, setStyleCardId] = useState('neutral');
+  const [printSpecText, setPrintSpecText] = useState('');
   // Media tab consolidates image / video / audio. The active surface picks
   // which set of options + skill resolution applies; submission still maps
   // back to the existing image/video/audio ProjectKind branches so the
@@ -439,6 +455,10 @@ export function NewProjectPanel({
 
   const canCreate =
     !loading && (tab !== 'template' || templateId != null);
+  const selectedArtifactIntent = findArtifactIntentPreset(artifactIntentId);
+  const showPrintSpecInput =
+    (tab === 'prototype' || tab === 'live-artifact' || tab === 'template' || tab === 'other')
+    && selectedArtifactIntent.printReady;
 
   function updateTabScrollState() {
     const el = tabsRef.current;
@@ -523,6 +543,9 @@ export function NewProjectPanel({
       voice,
       inspirationIds: inspirations,
       promptTemplate: promptTemplatePick,
+      artifactIntentId,
+      styleCardId,
+      printSpecText,
     });
     onCreate({
       name: name.trim() || autoName(tab, mediaSurface, t),
@@ -653,6 +676,36 @@ export function NewProjectPanel({
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
+
+        {tab === 'prototype' || tab === 'live-artifact' || tab === 'template' || tab === 'other' ? (
+          <ArtifactIntentPicker
+            value={artifactIntentId}
+            onChange={setArtifactIntentId}
+          />
+        ) : null}
+
+        {tab === 'prototype' || tab === 'live-artifact' || tab === 'template' || tab === 'other' ? (
+          <StarterStyleCardPicker
+            value={styleCardId}
+            onChange={setStyleCardId}
+          />
+        ) : null}
+
+        {showPrintSpecInput ? (
+          <section className="print-spec-box" aria-label="Print spec panel">
+            <div className="newproj-field-head">
+              <span>Print spec</span>
+              <small>Paste the vendor spec for CMYK, bleed, safe area, DPI, material, or finish.</small>
+            </div>
+            <textarea
+              aria-label="Print spec"
+              value={printSpecText}
+              onChange={(event) => setPrintSpecText(event.target.value)}
+              placeholder="CMYK only&#10;Bleed: 3mm&#10;Safe area: 2mm&#10;300 DPI"
+              rows={5}
+            />
+          </section>
+        ) : null}
 
         {showDesignSystemPicker ? (
           <DesignSystemPicker
@@ -881,6 +934,90 @@ export function NewProjectPanel({
           onDismiss={() => setImportFolderError(null)}
         />
       ) : null}
+    </div>
+  );
+}
+
+function formatIntentDimensions(intentId: ArtifactIntentId): string {
+  const dimensions = findArtifactIntentPreset(intentId).dimensions;
+  if (!dimensions) return 'Custom';
+  const dpi = dimensions.dpi ? ` @ ${dimensions.dpi} DPI` : '';
+  return `${dimensions.width} x ${dimensions.height} ${dimensions.unit}${dpi}`;
+}
+
+function ArtifactIntentPicker({
+  value,
+  onChange,
+}: {
+  value: ArtifactIntentId;
+  onChange: (v: ArtifactIntentId) => void;
+}) {
+  return (
+    <div className="newproj-section">
+      <label className="newproj-label">What are you making?</label>
+      <div className="artifact-intent-groups" role="radiogroup" aria-label="Artifact intent">
+        {ARTIFACT_INTENT_GROUPS.map((group) => {
+          const groupIntents = INITIAL_ARTIFACT_INTENTS.filter(
+            (intent) => intent.group === group.id,
+          );
+          if (groupIntents.length === 0) return null;
+          return (
+            <section key={group.id} className="artifact-intent-group" aria-label={group.label}>
+              <div className="artifact-intent-group-label">{group.label}</div>
+              <div className="artifact-intent-grid">
+                {groupIntents.map((intent) => {
+                  const active = value === intent.id;
+                  return (
+                    <button
+                      key={intent.id}
+                      type="button"
+                      role="radio"
+                      aria-checked={active}
+                      className={`newproj-card artifact-intent-card${active ? ' active' : ''}`}
+                      onClick={() => onChange(intent.id)}
+                    >
+                      <span className="artifact-intent-name">{intent.label}</span>
+                      <span className="artifact-intent-meta">{formatIntentDimensions(intent.id)}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            </section>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function StarterStyleCardPicker({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div className="newproj-section">
+      <label className="newproj-label">Style direction</label>
+      <div className="style-card-grid" role="radiogroup" aria-label="Style direction">
+        {STARTER_STYLE_CARDS.map((card) => {
+          const active = value === card.id;
+          return (
+            <button
+              key={card.id}
+              type="button"
+              role="radio"
+              aria-checked={active}
+              className={`newproj-card style-card-option${active ? ' active' : ''}`}
+              onClick={() => onChange(card.id)}
+            >
+              <span className="style-card-option-name">{card.label}</span>
+              <span className="style-card-option-meta">{card.signals.mood}</span>
+            </button>
+          );
+        })}
+      </div>
     </div>
   );
 }
@@ -2385,6 +2522,9 @@ function buildMetadata(input: {
   voice: string;
   inspirationIds: string[];
   promptTemplate: PromptTemplatePick | null;
+  artifactIntentId: ArtifactIntentId;
+  styleCardId: string;
+  printSpecText: string;
 }): ProjectMetadata {
   const kind: ProjectKind =
     input.tab === 'live-artifact'
@@ -2407,9 +2547,23 @@ function buildMetadata(input: {
   const inspirations = input.inspirationIds.length > 0
     ? { inspirationDesignSystemIds: input.inspirationIds }
     : {};
+  const artifactIntent = toArtifactIntentMetadata(
+    findArtifactIntentPreset(input.artifactIntentId),
+  );
+  const styleCard = cloneStyleCardMetadata(findStarterStyleCard(input.styleCardId));
+  const printSpec = buildPrintSpecMetadata({
+    label: `${artifactIntent.label} print spec`,
+    text: input.printSpecText,
+  });
+  const creationContext = {
+    artifactIntent,
+    styleCard,
+    ...(printSpec ? { printSpec } : {}),
+  };
   if (input.tab === 'prototype' || input.tab === 'live-artifact') {
     return {
       kind,
+      ...creationContext,
       ...base,
       // Live artifact is locked to high fidelity (the picker is hidden in
       // the panel) — wireframe live artifacts don't make sense.
@@ -2423,13 +2577,14 @@ function buildMetadata(input: {
   }
   if (input.tab === 'template') {
     if (input.templateId == null) {
-      return { kind, ...base, animations: input.animations, ...inspirations };
+      return { kind, ...creationContext, ...base, animations: input.animations, ...inspirations };
     }
     const tpl = input.templates.find((x) => x.id === input.templateId);
     // The fallback label is consumed by the agent prompt rather than the
     // UI, so we keep it in English to match the rest of the prompt corpus.
     return {
       kind,
+      ...creationContext,
       ...base,
       animations: input.animations,
       templateId: input.templateId,
@@ -2466,7 +2621,7 @@ function buildMetadata(input: {
       ...inspirations,
     };
   }
-  return { kind: 'other', ...base, ...inspirations };
+  return { kind: 'other', ...creationContext, ...base, ...inspirations };
 }
 
 function normalizeSelectedPlatforms(platforms: NewProjectPlatform[]): NewProjectPlatform[] {

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -853,6 +853,18 @@ export function ProjectView({
     } catch {
       // Ignore; memory injection is best-effort.
     }
+    let tasteProfileBody: string | undefined;
+    try {
+      const resp = await fetch('/api/taste-profile/system-prompt');
+      if (resp.ok) {
+        const json = (await resp.json()) as { body?: string };
+        if (typeof json.body === 'string' && json.body.trim().length > 0) {
+          tasteProfileBody = json.body;
+        }
+      }
+    } catch {
+      // Ignore; taste-profile injection is best-effort.
+    }
     return composeSystemPrompt({
       skillBody,
       skillName,
@@ -860,6 +872,7 @@ export function ProjectView({
       designSystemBody,
       designSystemTitle,
       memoryBody,
+      tasteProfileBody,
       metadata: project.metadata,
       template,
       streamFormat: config.mode === 'api' ? 'plain' : undefined,

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4041,6 +4041,88 @@ code {
 }
 .newproj-name { width: 100%; }
 .newproj-section { display: flex; flex-direction: column; gap: 6px; }
+.artifact-intent-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: 360px;
+  overflow: auto;
+  padding-right: 2px;
+}
+.artifact-intent-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.artifact-intent-group-label {
+  color: var(--text-muted);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.artifact-intent-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+.artifact-intent-card {
+  min-height: 58px;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.artifact-intent-name {
+  color: var(--text-strong);
+  font-size: 12.5px;
+  font-weight: 650;
+  line-height: 1.2;
+}
+.artifact-intent-meta {
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.25;
+}
+.style-card-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+.style-card-option {
+  min-height: 66px;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.style-card-option-name {
+  color: var(--text-strong);
+  font-size: 12.5px;
+  font-weight: 650;
+  line-height: 1.2;
+}
+.style-card-option-meta {
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.25;
+}
+
+.print-spec-box {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid var(--border-subtle, rgba(0, 0, 0, 0.08));
+  border-radius: 8px;
+  background: var(--surface-subtle, rgba(0, 0, 0, 0.02));
+}
+
+.print-spec-box textarea {
+  width: 100%;
+  resize: vertical;
+}
+
 .platform-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -15531,6 +15613,63 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
 .memory-root-dir {
   word-break: break-all;
   font-size: 11px;
+}
+
+.style-card-extraction-panel,
+.style-card-editor {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin: 12px 0;
+  padding: 12px;
+  border: 1px solid var(--border-subtle, rgba(0, 0, 0, 0.08));
+  border-radius: 8px;
+  background: var(--surface-subtle, rgba(0, 0, 0, 0.02));
+}
+
+.style-card-editor {
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.style-card-editor-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.style-card-signal-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 10px;
+}
+
+.style-card-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.style-card-field span {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+}
+
+.style-card-field textarea,
+.style-card-field input {
+  width: 100%;
+}
+
+.style-card-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
 }
 
 /* Memory section: extraction-history list. One row per recorded LLM

--- a/apps/web/src/sentry.ts
+++ b/apps/web/src/sentry.ts
@@ -1,0 +1,194 @@
+import type { BrowserOptions, Event, NodeOptions } from '@sentry/nextjs';
+
+type Env = Record<string, string | undefined>;
+
+const DEFAULT_TRACES_SAMPLE_RATE = 0.1;
+const FILTERED = '[Filtered]';
+
+function readEnvValue(env: Env, key: string): string | undefined {
+  const value = env[key]?.trim();
+  return value ? value : undefined;
+}
+
+function parseSampleRate(value: string | undefined): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 && parsed <= 1 ? parsed : DEFAULT_TRACES_SAMPLE_RATE;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeSensitiveKey(key: string): string {
+  return key.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+function isSensitiveKey(key: string): boolean {
+  const normalized = normalizeSensitiveKey(key);
+  return [
+    'authorization',
+    'cookie',
+    'setcookie',
+    'token',
+    'secret',
+    'password',
+    'apikey',
+    'session',
+    'sentrydsn',
+    'openai',
+    'anthropic',
+    'gemini',
+    'langfuse',
+  ].some((needle) => normalized.includes(needle));
+}
+
+function scrubNestedField(key: string, value: unknown): unknown {
+  if (isSensitiveKey(key)) {
+    return FILTERED;
+  }
+
+  const normalized = normalizeSensitiveKey(key);
+  if (normalized === 'headers') {
+    return scrubHeaders(value);
+  }
+
+  if ((normalized === 'url' || normalized.endsWith('url')) && typeof value === 'string') {
+    return stripUrlSearch(value);
+  }
+
+  return scrubNestedValue(value);
+}
+
+function scrubNestedValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => scrubNestedValue(item));
+  }
+
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, nestedValue]) => [key, scrubNestedField(key, nestedValue)]),
+  );
+}
+
+function scrubHeaders(headers: unknown): unknown {
+  if (!isRecord(headers)) {
+    return headers;
+  }
+
+  return Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [key, isSensitiveKey(key) ? FILTERED : value]),
+  );
+}
+
+function stripUrlSearch(value: string): string {
+  try {
+    const url = new URL(value);
+    url.search = '';
+    return url.toString();
+  } catch {
+    const searchIndex = value.indexOf('?');
+    if (searchIndex < 0) {
+      return value;
+    }
+    const hashIndex = value.indexOf('#', searchIndex);
+    return hashIndex < 0 ? value.slice(0, searchIndex) : `${value.slice(0, searchIndex)}${value.slice(hashIndex)}`;
+  }
+}
+
+export function scrubSentryEvent<T extends Event>(event: T): T {
+  const scrubbed: Event = { ...event };
+
+  if (event.request) {
+    scrubbed.request = { ...event.request };
+    delete scrubbed.request.data;
+    delete scrubbed.request.query_string;
+
+    if (typeof event.request.url === 'string') {
+      scrubbed.request.url = stripUrlSearch(event.request.url);
+    }
+
+    if (event.request.headers) {
+      scrubbed.request.headers = scrubHeaders(event.request.headers) as Record<string, string>;
+    }
+
+    if ('cookies' in scrubbed.request) {
+      delete scrubbed.request.cookies;
+    }
+  }
+
+  if (event.extra) {
+    scrubbed.extra = scrubNestedValue(event.extra) as Event['extra'];
+  }
+
+  if (event.breadcrumbs) {
+    scrubbed.breadcrumbs = scrubNestedValue(event.breadcrumbs) as NonNullable<Event['breadcrumbs']>;
+  }
+
+  if (event.tags) {
+    scrubbed.tags = scrubNestedValue(event.tags) as NonNullable<Event['tags']>;
+  }
+
+  if (event.contexts) {
+    scrubbed.contexts = scrubNestedValue(event.contexts) as NonNullable<Event['contexts']>;
+  }
+
+  if (event.user?.id) {
+    scrubbed.user = { id: event.user.id };
+  } else if ('user' in scrubbed) {
+    delete scrubbed.user;
+  }
+
+  return scrubbed as T;
+}
+
+export function buildBrowserSentryOptions(env: Env = process.env): BrowserOptions {
+  const dsn = readEnvValue(env, 'NEXT_PUBLIC_SENTRY_DSN');
+  const release = readEnvValue(env, 'NEXT_PUBLIC_SENTRY_RELEASE');
+  const options: BrowserOptions = {
+    enabled: Boolean(dsn),
+    environment:
+      readEnvValue(env, 'NEXT_PUBLIC_SENTRY_ENVIRONMENT') ??
+      readEnvValue(env, 'NEXT_PUBLIC_ENV') ??
+      readEnvValue(env, 'NODE_ENV') ??
+      'production',
+    sendDefaultPii: false,
+    tracesSampleRate: parseSampleRate(readEnvValue(env, 'NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE')),
+    beforeSend: (event) => scrubSentryEvent(event),
+  };
+
+  if (dsn) {
+    options.dsn = dsn;
+  }
+
+  if (release) {
+    options.release = release;
+  }
+
+  return options;
+}
+
+export function buildServerSentryOptions(env: Env = process.env): NodeOptions {
+  const dsn = readEnvValue(env, 'SENTRY_DSN');
+  const release = readEnvValue(env, 'SENTRY_RELEASE');
+  const options: NodeOptions = {
+    enabled: Boolean(dsn),
+    environment: readEnvValue(env, 'SENTRY_ENVIRONMENT') ?? readEnvValue(env, 'NODE_ENV') ?? 'production',
+    sendDefaultPii: false,
+    tracesSampleRate: parseSampleRate(readEnvValue(env, 'SENTRY_TRACES_SAMPLE_RATE')),
+    beforeSend: (event) => scrubSentryEvent(event),
+    beforeSendTransaction: (event) => scrubSentryEvent(event),
+  };
+
+  if (dsn) {
+    options.dsn = dsn;
+  }
+
+  if (release) {
+    options.release = release;
+  }
+
+  return options;
+}

--- a/apps/web/tests/components/EntryView.references.test.tsx
+++ b/apps/web/tests/components/EntryView.references.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { EntryView } from '../../src/components/EntryView';
+import { I18nProvider } from '../../src/i18n';
+import type { AppConfig } from '../../src/types';
+
+vi.mock('../../src/providers/registry', () => ({
+  fetchConnectors: vi.fn(async () => []),
+  fetchConnectorStatuses: vi.fn(async () => []),
+}));
+
+const originalFetch = globalThis.fetch;
+const originalEventSource = globalThis.EventSource;
+const originalResizeObserver = globalThis.ResizeObserver;
+const originalScrollIntoView = Element.prototype.scrollIntoView;
+
+class StubEventSource {
+  constructor(_url: string | URL) {}
+  addEventListener() {}
+  close() {}
+}
+
+class StubResizeObserver {
+  observe() {}
+  disconnect() {}
+}
+
+function renderEntryView() {
+  const config = {
+    mode: 'daemon',
+    apiKey: '',
+    baseUrl: 'http://127.0.0.1:17456',
+    model: 'local-cli',
+    agentId: null,
+    skillId: null,
+    designSystemId: null,
+    mediaProviders: {},
+  } satisfies AppConfig;
+
+  render(
+    <I18nProvider initial="en">
+      <EntryView
+        skills={[]}
+        designTemplates={[]}
+        designSystems={[]}
+        projects={[]}
+        templates={[]}
+        onDeleteTemplate={vi.fn(async () => true)}
+        promptTemplates={[]}
+        defaultDesignSystemId={null}
+        config={config}
+        agents={[]}
+        onCreateProject={vi.fn()}
+        onImportClaudeDesign={vi.fn()}
+        onOpenProject={vi.fn()}
+        onOpenLiveArtifact={vi.fn()}
+        onDeleteProject={vi.fn()}
+        onRenameProject={vi.fn()}
+        onChangeDefaultDesignSystem={vi.fn()}
+        onOpenSettings={vi.fn()}
+        onAdoptPet={vi.fn()}
+        onAdoptPetInline={vi.fn()}
+        onTogglePet={vi.fn()}
+      />
+    </I18nProvider>,
+  );
+}
+
+describe('EntryView references tab', () => {
+  afterEach(() => {
+    cleanup();
+    globalThis.fetch = originalFetch;
+    if (originalEventSource) {
+      globalThis.EventSource = originalEventSource;
+    } else {
+      // @ts-expect-error jsdom shim cleanup
+      delete globalThis.EventSource;
+    }
+    if (originalResizeObserver) {
+      globalThis.ResizeObserver = originalResizeObserver;
+    } else {
+      // @ts-expect-error jsdom shim cleanup
+      delete globalThis.ResizeObserver;
+    }
+    Element.prototype.scrollIntoView = originalScrollIntoView;
+    vi.restoreAllMocks();
+  });
+
+  it('opens a first-class reference board from the home tabs', async () => {
+    globalThis.EventSource = StubEventSource as unknown as typeof EventSource;
+    globalThis.ResizeObserver = StubResizeObserver as unknown as typeof ResizeObserver;
+    Element.prototype.scrollIntoView = vi.fn();
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === '/api/memory') {
+        return new Response(JSON.stringify({
+          enabled: true,
+          rootDir: '/tmp/memory',
+          index: '# Memory\n',
+          entries: [
+            {
+              id: 'reference_packaging_ref',
+              name: 'Packaging reference',
+              description: 'Foil label and dense product hierarchy',
+              type: 'reference',
+              updatedAt: Date.now(),
+            },
+            {
+              id: 'user_ui_preferences',
+              name: 'UI preferences',
+              description: 'General UI preferences',
+              type: 'user',
+              updatedAt: Date.now(),
+            },
+          ],
+          extraction: null,
+        }), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      if (url === '/api/memory/extractions') {
+        return new Response(JSON.stringify({ extractions: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({}), { status: 404 });
+    }) as typeof fetch;
+
+    renderEntryView();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'References' }));
+
+    expect(await screen.findByText('Reference board')).toBeTruthy();
+    expect(screen.getByText('Packaging reference')).toBeTruthy();
+    expect(screen.queryByText('UI preferences')).toBeNull();
+  });
+});

--- a/apps/web/tests/components/McpJsonHelper.test.tsx
+++ b/apps/web/tests/components/McpJsonHelper.test.tsx
@@ -54,5 +54,5 @@ describe('McpJsonHelper (production)', () => {
     const panel = document.getElementById(ariaControls!);
     expect(panel).toBeTruthy();
     expect(panel?.textContent).toContain('Example MCP JSON');
-  });
+  }, 15000);
 });

--- a/apps/web/tests/components/MemorySection.test.tsx
+++ b/apps/web/tests/components/MemorySection.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import type { ComponentProps } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { MemorySection } from '../../src/components/MemorySection';
@@ -31,10 +32,10 @@ class StubEventSource {
   close() {}
 }
 
-function renderMemorySection() {
+function renderMemorySection(props?: ComponentProps<typeof MemorySection>) {
   render(
     <I18nProvider initial="en">
-      <MemorySection />
+      <MemorySection {...props} />
     </I18nProvider>,
   );
 }
@@ -172,6 +173,158 @@ describe('MemorySection', () => {
         description: 'Persistent UI rendering preferences',
         type: 'user',
         body: '- Prefer dark mode\n- Prefer generous spacing',
+      },
+    ]);
+  });
+
+  it('can be opened as a reference board with reference-only defaults', async () => {
+    globalThis.EventSource = StubEventSource as unknown as typeof EventSource;
+    const entries = [
+      {
+        id: 'reference_packaging_ref',
+        name: 'Packaging reference',
+        description: 'Foil label and dense product hierarchy',
+        type: 'reference',
+        updatedAt: Date.now(),
+      },
+      {
+        id: 'user_ui_preferences',
+        name: 'UI preferences',
+        description: 'General UI preferences',
+        type: 'user',
+        updatedAt: Date.now(),
+      },
+    ];
+
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === '/api/memory') {
+        return new Response(JSON.stringify({
+          enabled: true,
+          rootDir: '/tmp/memory',
+          index: '# Memory\n',
+          entries,
+          extraction: null,
+        }), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      if (url === '/api/memory/extractions') {
+        return new Response(JSON.stringify({ extractions: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({}), { status: 404 });
+    }) as typeof fetch;
+
+    renderMemorySection({
+      heading: 'Reference board',
+      description: 'Save design references, notes, and inspiration for later taste extraction.',
+      initialFilter: 'reference',
+      defaultNewType: 'reference',
+    });
+
+    expect(await screen.findByText('Reference board')).toBeTruthy();
+    expect(screen.getByText('Packaging reference')).toBeTruthy();
+    expect(screen.queryByText('UI preferences')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'New memory' }));
+
+    const typeSelect = screen.getByDisplayValue('Reference') as HTMLSelectElement;
+    expect(typeSelect.value).toBe('reference');
+  });
+
+  it('extracts an editable Style card proposal from reference entries', async () => {
+    globalThis.EventSource = StubEventSource as unknown as typeof EventSource;
+    const extractBodies: unknown[] = [];
+    const entries = [
+      {
+        id: 'reference_packaging_ref',
+        name: 'Packaging reference',
+        description: 'Foil label and dense product hierarchy',
+        type: 'reference',
+        updatedAt: Date.now(),
+      },
+    ];
+
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url === '/api/memory') {
+        return new Response(JSON.stringify({
+          enabled: true,
+          rootDir: '/tmp/memory',
+          index: '# Memory\n',
+          entries,
+          extraction: null,
+        }), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      if (url === '/api/memory/extractions') {
+        return new Response(JSON.stringify({ extractions: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url === '/api/style-cards/extract' && init?.method === 'POST') {
+        extractBodies.push(JSON.parse(String(init.body)));
+        return new Response(JSON.stringify({
+          styleCard: {
+            id: 'style_premium_packaging_direction',
+            label: 'Premium packaging direction',
+            source: 'extracted',
+            status: 'draft',
+            signals: {
+              mood: 'premium, confident',
+              color: 'deep green, ivory, muted gold foil',
+              typography: 'elegant serif with uppercase details',
+              composition: 'centered label grid',
+              density: 'low density front, detailed back',
+              transferNotes: 'Adapt Packaging reference without copying source artwork.',
+            },
+            sourceReferences: [
+              { id: 'reference_packaging_ref', name: 'Packaging reference' },
+            ],
+          },
+        }), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      if (url === '/api/taste-profile/style-cards' && init?.method === 'POST') {
+        const body = JSON.parse(String(init.body));
+        return new Response(JSON.stringify({
+          styleCard: {
+            ...body.styleCard,
+            status: 'accepted',
+          },
+          profile: {
+            styleCards: [{ ...body.styleCard, status: 'accepted' }],
+            updatedAt: Date.now(),
+          },
+        }), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({}), { status: 404 });
+    }) as typeof fetch;
+
+    renderMemorySection({
+      heading: 'Reference board',
+      initialFilter: 'reference',
+      defaultNewType: 'reference',
+      enableStyleCardExtraction: true,
+    });
+
+    expect(await screen.findByText('Packaging reference')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Extract Style card' }));
+
+    expect(await screen.findByDisplayValue('Premium packaging direction')).toBeTruthy();
+    const colorField = screen.getByLabelText('Color') as HTMLTextAreaElement;
+    fireEvent.change(colorField, {
+      target: { value: 'forest green, ivory, sharp silver accent' },
+    });
+
+    expect(colorField.value).toBe('forest green, ivory, sharp silver accent');
+    fireEvent.click(screen.getByRole('button', { name: 'Accept Style card' }));
+
+    expect(await screen.findByText('Accepted to taste profile')).toBeTruthy();
+    expect(extractBodies).toEqual([
+      {
+        referenceIds: ['reference_packaging_ref'],
+        label: 'Packaging reference direction',
       },
     ]);
   });

--- a/apps/web/tests/components/NewProjectPanel.test.tsx
+++ b/apps/web/tests/components/NewProjectPanel.test.tsx
@@ -150,6 +150,155 @@ describe('NewProjectPanel design system defaults', () => {
     );
   });
 
+  it('saves the selected artifact intent and its default constraints into the create payload', () => {
+    const onCreate = vi.fn();
+    render(
+      <NewProjectPanel
+        skills={skills}
+        designSystems={designSystems}
+        defaultDesignSystemId={null}
+        templates={[]}
+        onDeleteTemplate={vi.fn()}
+        promptTemplates={[]}
+        onCreate={onCreate}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId('new-project-name'), {
+      target: { value: 'Business card payload' },
+    });
+    fireEvent.click(screen.getByRole('radio', { name: /Business card/i }));
+    fireEvent.click(screen.getByTestId('create-project'));
+
+    expect(onCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Business card payload',
+        metadata: expect.objectContaining({
+          kind: 'prototype',
+          artifactIntent: expect.objectContaining({
+            id: 'business-card',
+            label: 'Business card',
+            dimensions: {
+              width: 90,
+              height: 54,
+              unit: 'mm',
+              dpi: 300,
+            },
+            printReady: true,
+            outputExpectations: expect.arrayContaining(['print handoff']),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('saves pasted print specs for print-ready artifact intents', () => {
+    const onCreate = vi.fn();
+    render(
+      <NewProjectPanel
+        skills={skills}
+        designSystems={designSystems}
+        defaultDesignSystemId={null}
+        templates={[]}
+        onDeleteTemplate={vi.fn()}
+        promptTemplates={[]}
+        onCreate={onCreate}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId('new-project-name'), {
+      target: { value: 'Printable card payload' },
+    });
+    fireEvent.click(screen.getByRole('radio', { name: /Business card/i }));
+    fireEvent.change(screen.getByLabelText('Print spec'), {
+      target: { value: 'CMYK only\nBleed: 3mm\nSafe area: 2mm\n300 DPI' },
+    });
+    fireEvent.click(screen.getByTestId('create-project'));
+
+    expect(onCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          printSpec: expect.objectContaining({
+            label: 'Business card print spec',
+            requirements: expect.objectContaining({
+              colorMode: 'cmyk-compatible',
+              bleedMm: 3,
+              safeAreaMm: 2,
+              dpi: 300,
+            }),
+            checklist: expect.arrayContaining([
+              'Use CMYK-compatible colors and avoid relying on screen-only RGB glow.',
+            ]),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('renders artifact intents as a grouped catalog', () => {
+    render(
+      <NewProjectPanel
+        skills={skills}
+        designSystems={designSystems}
+        defaultDesignSystemId={null}
+        templates={[]}
+        onDeleteTemplate={vi.fn()}
+        promptTemplates={[]}
+        onCreate={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Social')).toBeTruthy();
+    expect(screen.getByText('Ads and marketing')).toBeTruthy();
+    expect(screen.getByText('Packaging')).toBeTruthy();
+    expect(screen.getByText('Video and motion')).toBeTruthy();
+    expect(screen.getByRole('radio', { name: /Instagram post/i })).toBeTruthy();
+    expect(screen.getByRole('radio', { name: /Box/i })).toBeTruthy();
+    expect(screen.getByRole('radio', { name: /Short video/i })).toBeTruthy();
+  });
+
+  it('saves the selected starter Style card into the create payload', () => {
+    const onCreate = vi.fn();
+    render(
+      <NewProjectPanel
+        skills={skills}
+        designSystems={designSystems}
+        defaultDesignSystemId={null}
+        templates={[]}
+        onDeleteTemplate={vi.fn()}
+        promptTemplates={[]}
+        onCreate={onCreate}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId('new-project-name'), {
+      target: { value: 'Styled landing page' },
+    });
+    fireEvent.click(screen.getByRole('radio', { name: /Editorial noir/i }));
+    fireEvent.click(screen.getByTestId('create-project'));
+
+    expect(onCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Styled landing page',
+        metadata: expect.objectContaining({
+          styleCard: expect.objectContaining({
+            id: 'editorial-noir',
+            label: 'Editorial noir',
+            source: 'starter',
+            signals: expect.objectContaining({
+              mood: expect.any(String),
+              color: expect.any(String),
+              typography: expect.any(String),
+              composition: expect.any(String),
+              density: expect.any(String),
+              transferNotes: expect.any(String),
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+
   it('clears design system metadata when freeform is selected in multi mode', () => {
     const onCreate = vi.fn();
     render(

--- a/apps/web/tests/i18n/locales.test.ts
+++ b/apps/web/tests/i18n/locales.test.ts
@@ -54,7 +54,7 @@ describe('i18n locales', () => {
         );
       }
     }
-  });
+  }, 15000);
 
   it('keeps Indonesian connector settings copy translated instead of falling back to English', () => {
     const translatedKeys: Array<keyof Dict> = [

--- a/apps/web/tests/sentry.test.ts
+++ b/apps/web/tests/sentry.test.ts
@@ -1,0 +1,183 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import packageJsonSource from '../package.json?raw';
+import nextConfigSource from '../next.config.ts?raw';
+
+const packageJson = JSON.parse(packageJsonSource) as {
+  dependencies?: Record<string, string>;
+};
+
+function readSource(relativePath: string) {
+  const filePath = fileURLToPath(new URL(`../${relativePath}`, import.meta.url));
+  return existsSync(filePath) ? readFileSync(filePath, 'utf8') : '';
+}
+
+async function loadSentryModule() {
+  const moduleUrl = new URL('../src/sentry.ts', import.meta.url);
+  expect(existsSync(fileURLToPath(moduleUrl)), 'src/sentry.ts should exist').toBe(true);
+  return import('../src/sentry');
+}
+
+describe('Sentry onboarding', () => {
+  it('installs Next Sentry SDK and wraps the Next config for source maps', () => {
+    expect(packageJson.dependencies?.['@sentry/nextjs']).toBeDefined();
+    expect(nextConfigSource).toContain('@sentry/nextjs');
+    expect(nextConfigSource).toContain('withSentryConfig');
+    expect(nextConfigSource).toContain('process.env.SENTRY_ORG');
+    expect(nextConfigSource).toContain('process.env.SENTRY_PROJECT');
+    expect(nextConfigSource).not.toContain("|| 'zhenheai'");
+    expect(nextConfigSource).not.toContain("|| 'open-design-web'");
+    expect(nextConfigSource).toContain('widenClientFileUpload');
+    expect(nextConfigSource).toContain('deleteSourcemapsAfterUpload');
+  });
+
+  it('declares browser, server, and edge Sentry init files', () => {
+    const browserSource = readSource('instrumentation-client.ts');
+    const instrumentationSource = readSource('instrumentation.ts');
+    const serverSource = readSource('sentry.server.config.ts');
+    const edgeSource = readSource('sentry.edge.config.ts');
+
+    expect(browserSource).toContain('buildBrowserSentryOptions');
+    expect(browserSource).toContain('process.env.NEXT_PUBLIC_SENTRY_DSN');
+    expect(browserSource).toContain('buildBrowserSentryOptions({');
+    expect(browserSource).toContain('captureRouterTransitionStart');
+    expect(instrumentationSource).toContain('export async function register()');
+    expect(instrumentationSource).toContain("await import('./sentry.server.config')");
+    expect(instrumentationSource).toContain("await import('./sentry.edge.config')");
+    expect(serverSource).toContain('buildServerSentryOptions');
+    expect(edgeSource).toContain('buildServerSentryOptions');
+  });
+
+  it('builds safe browser options from public env variables', async () => {
+    const { buildBrowserSentryOptions } = await loadSentryModule();
+
+    const options = buildBrowserSentryOptions({
+      NEXT_PUBLIC_SENTRY_DSN: 'https://public@example.ingest.sentry.io/2',
+      NEXT_PUBLIC_SENTRY_ENVIRONMENT: 'production',
+      NEXT_PUBLIC_SENTRY_RELEASE: 'open-design-web@abc123',
+      NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE: '0.2',
+    });
+
+    expect(options).toMatchObject({
+      dsn: 'https://public@example.ingest.sentry.io/2',
+      enabled: true,
+      environment: 'production',
+      release: 'open-design-web@abc123',
+      sendDefaultPii: false,
+      tracesSampleRate: 0.2,
+    });
+    expect(options.beforeSend).toBeTypeOf('function');
+  });
+
+  it('builds safe server options from secret env variables', async () => {
+    const { buildServerSentryOptions } = await loadSentryModule();
+
+    const options = buildServerSentryOptions({
+      SENTRY_DSN: 'https://public@example.ingest.sentry.io/3',
+      SENTRY_ENVIRONMENT: 'production',
+      SENTRY_RELEASE: 'open-design-web@abc123',
+      SENTRY_TRACES_SAMPLE_RATE: '0.15',
+    });
+
+    expect(options).toMatchObject({
+      dsn: 'https://public@example.ingest.sentry.io/3',
+      enabled: true,
+      environment: 'production',
+      release: 'open-design-web@abc123',
+      sendDefaultPii: false,
+      tracesSampleRate: 0.15,
+    });
+    expect(options.beforeSend).toBeTypeOf('function');
+  });
+
+  it('scrubs request, extra, and user PII before web events leave the app', async () => {
+    const { scrubSentryEvent } = await loadSentryModule();
+
+    const scrubbed = scrubSentryEvent({
+      request: {
+        data: { prompt: 'private design prompt' },
+        query_string: 'code=oauth-code&state=oauth-state',
+        url: 'https://open-design.ai/api/mcp/oauth/callback?code=oauth-code&state=oauth-state#done',
+        headers: {
+          authorization: 'Bearer secret',
+          cookie: 'sid=secret',
+          'x-api-key': 'secret',
+          accept: 'application/json',
+        },
+      },
+      extra: {
+        OPENAI_API_KEY: 'secret',
+        nested: { token: 'secret', keep: 'ok' },
+      },
+      breadcrumbs: [
+        {
+          message: 'handled connector callback',
+          data: {
+            authorization: 'Bearer secret',
+            nested: { token: 'secret', keep: 'ok' },
+          },
+        },
+      ],
+      tags: {
+        feature: 'mcp',
+        session_token: 'secret',
+      },
+      contexts: {
+        oauth: {
+          url: 'https://open-design.ai/api/mcp/oauth/callback?code=oauth-code&state=oauth-state#done',
+          headers: {
+            cookie: 'sid=secret',
+            accept: 'application/json',
+          },
+          nested: { apiKey: 'secret', keep: 'ok' },
+        },
+      },
+      user: {
+        id: 'installation-1',
+        email: 'user@example.com',
+        username: 'person',
+      },
+    });
+
+    expect(scrubbed.request?.url).toBe('https://open-design.ai/api/mcp/oauth/callback#done');
+    expect(scrubbed.request?.query_string).toBeUndefined();
+    expect(scrubbed.request?.headers).toEqual({
+      authorization: '[Filtered]',
+      cookie: '[Filtered]',
+      'x-api-key': '[Filtered]',
+      accept: 'application/json',
+    });
+    expect(scrubbed.request?.data).toBeUndefined();
+    expect(scrubbed.extra).toEqual({
+      OPENAI_API_KEY: '[Filtered]',
+      nested: { token: '[Filtered]', keep: 'ok' },
+    });
+    expect(scrubbed.breadcrumbs).toEqual([
+      {
+        message: 'handled connector callback',
+        data: {
+          authorization: '[Filtered]',
+          nested: { token: '[Filtered]', keep: 'ok' },
+        },
+      },
+    ]);
+    expect(scrubbed.tags).toEqual({
+      feature: 'mcp',
+      session_token: '[Filtered]',
+    });
+    expect(scrubbed.contexts).toEqual({
+      oauth: {
+        url: 'https://open-design.ai/api/mcp/oauth/callback#done',
+        headers: {
+          cookie: '[Filtered]',
+          accept: 'application/json',
+        },
+        nested: { apiKey: '[Filtered]', keep: 'ok' },
+      },
+    });
+    expect(scrubbed.user).toEqual({ id: 'installation-1' });
+  });
+});

--- a/apps/web/tests/setup/local-storage.ts
+++ b/apps/web/tests/setup/local-storage.ts
@@ -1,0 +1,60 @@
+function hasUsableLocalStorage(value: unknown): value is Storage {
+  const maybeStorage = value as Partial<Storage> | undefined;
+  return Boolean(
+    maybeStorage &&
+      typeof maybeStorage.getItem === 'function' &&
+      typeof maybeStorage.setItem === 'function' &&
+      typeof maybeStorage.removeItem === 'function' &&
+      typeof maybeStorage.clear === 'function',
+  );
+}
+
+function createMemoryStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value));
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+}
+
+function readLocalStorage(target: { localStorage?: Storage }): Storage | undefined {
+  try {
+    return target.localStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+function installLocalStorage(target: { localStorage?: Storage }, storage: Storage) {
+  Object.defineProperty(target, 'localStorage', {
+    configurable: true,
+    writable: true,
+    value: storage,
+  });
+}
+
+const globalStorage = readLocalStorage(globalThis);
+const storage = hasUsableLocalStorage(globalStorage) ? globalStorage : createMemoryStorage();
+
+if (!hasUsableLocalStorage(globalStorage)) {
+  installLocalStorage(globalThis, storage);
+}
+
+if (typeof window !== 'undefined') {
+  const windowStorage = readLocalStorage(window);
+  if (!hasUsableLocalStorage(windowStorage)) {
+    installLocalStorage(window, storage);
+  }
+}

--- a/apps/web/tests/vite-env.d.ts
+++ b/apps/web/tests/vite-env.d.ts
@@ -1,0 +1,4 @@
+declare module '*?raw' {
+  const source: string;
+  export default source;
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -4,5 +4,6 @@ export default defineConfig({
   test: {
     environment: 'node',
     include: ['tests/**/*.test.{ts,tsx}'],
+    setupFiles: ['./tests/setup/local-storage.ts'],
   },
 });

--- a/docs/adr/0001-use-nexu-open-design-as-upstream.md
+++ b/docs/adr/0001-use-nexu-open-design-as-upstream.md
@@ -1,0 +1,14 @@
+# Use nexu-io/open-design as the upstream
+
+We will treat `nexu-io/open-design` as the primary upstream for this repo and build this productization fork from that architecture, rather than switching the base to `OpenCoworkAI/open-codesign`. `open-codesign` remains an important reference project for UX patterns such as comment mode, tweak sliders, previews, and exports, but its Electron form factor and owned provider loop conflict with the Open Design direction of a Next.js web app plus local daemon that delegates to the user's existing coding-agent CLI.
+
+## Considered Options
+
+- `nexu-io/open-design` as upstream: matches the desired web plus daemon architecture and file-based skills/design-systems direction.
+- `OpenCoworkAI/open-codesign` as base fork: strong UX reference, but would require replacing its Electron and provider-loop assumptions.
+
+## Consequences
+
+Future work should first reconcile against `nexu-io/open-design` before importing patterns from other repositories. External repositories are reference projects unless a separate ADR promotes one to upstream or vendored dependency.
+
+Git remotes should follow this convention: `origin` points at this productization fork, and `upstream` points at `https://github.com/nexu-io/open-design.git`.

--- a/docs/adr/0002-stabilize-upstream-before-differentiation.md
+++ b/docs/adr/0002-stabilize-upstream-before-differentiation.md
@@ -1,0 +1,12 @@
+# Stabilize upstream before differentiation
+
+For v1, we will first make the upstream Open Design system run reliably in this productization fork before adding differentiated features. The stabilization target is the main local loop: install dependencies, typecheck, test, run the web plus daemon lifecycle, and verify that skills can produce previewable design artifacts.
+
+## Considered Options
+
+- Stabilize upstream first: reduces uncertainty and gives every later feature a working baseline.
+- Build differentiated features immediately: moves faster on visible novelty, but risks stacking product ideas on an unverified runtime.
+
+## Consequences
+
+Feature work such as repository discovery, a skill marketplace, expanded media generation, or deeper Open CoDesign UX imports should wait until the upstream runtime path is known-good in this fork. Bugs that block install, test, typecheck, local lifecycle, skill loading, or artifact preview take priority over new feature work during v1.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,35 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root.
+- **`docs/adr/`** for ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo:
+
+```
+/
+|-- CONTEXT.md
+|-- docs/adr/
+|   |-- 0001-event-sourced-orders.md
+|   `-- 0002-postgres-for-write-model.md
+`-- src/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept in an issue title, a refactor proposal, a hypothesis, or a test name, use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal: either you're inventing language the project doesn't use, or there's a real gap to note for `/grill-with-docs`.
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders), but worth reopening because..._

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues in `zhenheco/open-design`. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v`; `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role, for example "apply the AFK-ready triage label", use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/docs/plans/design-taste-evolution.md
+++ b/docs/plans/design-taste-evolution.md
@@ -1,0 +1,206 @@
+# Design Taste Evolution
+
+**Parent:** [`v1-baseline.md`](v1-baseline.md) · **Context:** [`../../CONTEXT.md`](../../CONTEXT.md)
+
+This plan captures the first differentiated product direction after the v1 baseline is stable. The goal is not to make a better empty canvas. The goal is to let a user talk to Open Design and have the system generate design artifacts using a remembered understanding of what the user likes.
+
+Canva is a coverage benchmark for breadth of creation entry points and print handoff expectations, not a UI clone target. Canva's public create guides list broad document types such as banners, brochures, social media, business cards, docs, whiteboards, flyers, labels, menus, posters, presentations, videos, and websites, while Canva Print groups physical products across marketing materials, branded merchandise, office supplies, apparel, and signage.
+
+## Product Thesis
+
+Open Design should become a conversational design system that learns the user's taste over time.
+
+The user should not need to paste the same Pinterest, Behance, website, or screenshot references into every generation. They should be able to save references whenever they find them, let Open Design organize and extract taste signals, and later ask for an EDM, web page, social post, deck, banner, or custom artifact through conversation.
+
+References can come from a different medium than the final artifact. A designer may like a package, poster, storefront, magazine spread, or website and later want that taste translated into a DM, business card, EDM, or landing page. Open Design should support this **Cross-medium taste transfer** by extracting reusable visual signals instead of treating references as same-format templates.
+
+## Experience Shape
+
+The primary creation path is a **Guided create flow**, not a traditional onboarding tutorial:
+
+1. Choose artifact intent from the **Artifact intent catalog**.
+2. Apply starting dimensions, platform constraints, and output expectations.
+3. Choose or infer a style direction from the user's **Taste profile**.
+4. Optionally attach project-specific references or brand rules.
+5. Enter **Conversational design creation** to generate and refine the artifact.
+
+The learning path is separate but connected:
+
+1. User saves references into a **Reference board** over time.
+2. Open Design performs **Taste extraction** to identify complete style signals.
+3. Extracted signals become editable **Style cards** and can update the user's **Taste profile**.
+4. Future conversations use the profile unless a project **Design system** or explicit brief overrides it.
+
+The **Reference board** is a first-class product entry, not a hidden settings panel. Settings/Memory can remain the first implementation substrate, but the user-facing shape must make saving day-to-day inspiration feel like a normal part of the product.
+
+## Artifact Intent Catalog
+
+The catalog should be broad like Canva, but grouped for guided creation instead of shown as one overwhelming template wall.
+
+| Group | Starting intents |
+|---|---|
+| Social | Instagram post/story/reel cover, Facebook post/cover/ad, LinkedIn post/banner, X/Twitter post/header, YouTube thumbnail/banner, TikTok cover, Lemon8, Pinterest pin, social carousel |
+| Ads and marketing | EDM, newsletter, DM, flyer, brochure, rack card, poster, banner, display ad, product launch graphic, sales sheet, coupon, gift certificate |
+| Web and app | Landing page, website section, hero, pricing page, dashboard, app screen, prototype, email capture page, product page |
+| Brand identity | Logo concept, brand board, business card, letterhead, envelope, email signature, brand guideline excerpt |
+| Documents | Proposal, report, invoice, resume, worksheet, form, checklist, menu, calendar, planner, certificate, flashcard |
+| Presentations | Pitch deck, sales deck, lesson deck, product demo deck, keynote-style slides, webinar slides |
+| Print products | Business card, postcard, invitation, thank-you card, sticker, label, notebook cover, photobook, booklet, magazine, catalog, wrapping paper |
+| Packaging | Box, sleeve, pouch, bottle label, jar label, paper bag, shipping envelope, hang tag, insert card |
+| Merchandise | T-shirt, hoodie, tote bag, mug, water bottle, coaster, mouse pad, magnet |
+| Signage and large format | Yard sign, floor decal, storefront sign, event signage, roll-up banner, trade show panel |
+| Video and motion | Short video, video cover, animated social post, intro/outro card, lower third |
+| Custom | Custom size, custom ratio, printer-defined size, uploaded spec |
+
+Each intent should carry defaults for dimensions, aspect ratio, safe area, export type, content density, and whether print readiness is relevant.
+
+## Print Readiness
+
+Print output is a differentiated requirement because many AI design tools stop at a good-looking preview. Open Design should support the last mile: files a print vendor can actually inspect and produce.
+
+For print-oriented intents, the guided flow should allow a user to upload or paste a **Print spec** from a print vendor. The spec may be a PDF, image, web page, text block, or structured form. Open Design should extract and confirm:
+
+| Print spec field | Examples |
+|---|---|
+| Final size | A4, US Letter, 90 x 54 mm business card, custom dieline size |
+| Bleed and safe area | 3 mm bleed, 0.125 in bleed, text safe margin |
+| Color | CMYK required, RGB accepted, ICC profile, Pantone/spot color, rich black guidance |
+| Resolution | 300 DPI target, minimum image DPI, vector-preferred assets |
+| File format | PDF Print, PDF/X-compatible PDF, TIFF, EPS, packaged source, flattened PDF |
+| Marks and trim | Crop marks, trim box, bleed box, registration marks |
+| Fonts | Embedded fonts, outlined fonts, licensed font warning |
+| Images | Embedded images, linked image handling, compression limits |
+| Material | Paper stock, coated/uncoated, vinyl, fabric, sticker, packaging substrate |
+| Finishing | Fold, binding, lamination, foil, emboss/deboss, die cut, rounded corners, varnish |
+| Dieline | Cut line, fold line, glue area, no-print area, barcode/QR placement |
+| Quantity/context | One-off proof, bulk run, local print shop, online print vendor |
+
+Print-ready handoff should be treated as levels:
+
+| Level | Capability |
+|---|---|
+| 0 Digital preview | Looks correct on screen only. Not enough for print. |
+| 1 Print-aware layout | Uses physical units, final size, safe area, bleed guides, and DPI warnings. |
+| 2 Printer spec intake | Extracts and confirms print vendor requirements before generation. |
+| 2.5 Basic print handoff | Uses the uploaded spec to constrain generation, exports a PDF Print target plus production summary, and runs basic preflight checks while labeling CMYK as a compatibility target. |
+| 3 Preflight | Checks color mode/profile, bleed coverage, text safety, image DPI, font embedding/outline status, missing assets, transparent effects, spot colors, and dieline constraints. |
+| 4 Print-ready package | Exports vendor-facing files and notes: PDF Print/PDF-X-compatible output where possible, CMYK-compatible color, crop marks, bleed, embedded/outlined fonts, high-resolution images, dielines, and a production summary. |
+
+CMYK compatibility is a requirement for print-ready outputs, but the implementation should be honest about the level achieved. Browser previews may remain RGB; the export/preflight pipeline owns CMYK-compatible conversion, proof warnings, and print handoff validation.
+
+The first differentiated print milestone should target **Level 2.5 Basic print handoff**. Full PDF/X validation, ICC-managed conversion, spot color handling, and dieline rule checking can follow after the guided flow proves useful.
+
+Print specs should start as project-level uploads, then become reusable **Print spec presets** when the user chooses to save them. The first version does not need a full vendor database, but the data model should support common future reuse cases:
+
+- repeated business card specs from the same print shop;
+- recurring DM or flyer sizes;
+- packaging dielines;
+- preferred paper stock and finishing options;
+- vendor-specific export notes.
+
+## Boundaries
+
+- The **Taste profile** is user-level memory; it is not the same thing as a project **Design system**.
+- **Taste evolution** must not silently mutate brand tokens or a `DESIGN.md`.
+- References are used to extract preference signals, not to copy a third-party design.
+- References do not need to match the target artifact type; cross-medium translation is a core behavior.
+- Raw references and extracted **Style cards** are both retained. Raw references preserve evidence; **Style cards** are the generation-ready layer.
+- A project-specific design system wins over taste preferences when they conflict.
+- A skill's workflow wins over taste preferences when the artifact type has structural requirements.
+
+## Taste Extraction Parameters
+
+Taste extraction should be broad enough for high-quality generation but structured enough that a non-designer never has to operate the full control panel manually.
+
+Each **Style card** should support these parameter groups:
+
+| Group | Signals to extract |
+|---|---|
+| Source | URL, screenshot/image, origin site, capture date, source medium, user note, rights/caution note |
+| Medium | Any **Artifact intent catalog** group plus observed source medium, targetable output media, and cross-medium transfer fit |
+| Intent | Premium, playful, editorial, sales-driven, educational, event-driven, product launch, announcement, recruitment, community |
+| Audience | Consumer, B2B, luxury, youth, parent, technical buyer, creative professional, local business, broad public |
+| Mood | Calm, energetic, refined, bold, warm, futuristic, nostalgic, minimal, expressive, handmade, clinical, friendly |
+| Brand personality | Conservative, experimental, elegant, rebellious, trustworthy, cute, sharp, organic, industrial, artistic |
+| Color | Dominant colors, accent colors, contrast level, saturation, warmth/coolness, color rhythm, background behavior, dark/light bias |
+| Typography | Serif/sans/mono/display tendency, weight, width, case behavior, contrast, spacing, editorial vs utility feel, headline/body relationship |
+| Composition | Grid behavior, symmetry/asymmetry, focal point, layering, framing, crop style, alignment, negative space, reading path |
+| Visual hierarchy | Primary message treatment, secondary info density, CTA prominence, grouping, scale jumps, emphasis rhythm |
+| Spacing and density | Airy/dense, margin behavior, section rhythm, card/list density, information compression, whitespace personality |
+| Imagery | Photo vs illustration, subject treatment, crop, angle, background, realism, texture, iconography, product visibility |
+| Shape language | Corners, borders, geometry, organic forms, badges, containers, dividers, line weight, pattern use |
+| Material and texture | Paper, foil, plastic, glass, metal, grain, shadow, embossing, print texture, tactile cues |
+| Lighting and depth | Flat, layered, shadowed, glossy, studio-lit, ambient, 3D depth, physicality |
+| Motion/interaction | Digital-only cues such as hover feel, transition energy, scroll rhythm, animation restraint |
+| Content style | Short/long copy tendency, headline tone, label style, editorial voice, CTA directness, information order |
+| Accessibility | Legibility risk, contrast risk, text-on-image risk, small-type risk, color-only meaning risk |
+| Transfer notes | What should transfer to another medium, what should not transfer, likely artifact types, adaptation warnings |
+| Negative constraints | Things to avoid because they weaken the reference's appeal or clash with the user's taste |
+| Confidence | High/medium/low confidence per group, evidence snippets, needs-human-review flags |
+
+The first usable **Taste extraction** schema should persist the full parameter set above, but the novice-facing **Style card** UI should initially expose only six fields:
+
+- Mood
+- Color
+- Typography
+- Composition
+- Density
+- Transfer notes
+
+This keeps the data model future-proof while keeping the first review/edit experience simple enough for non-designers.
+
+## Novice-Safe UX
+
+The product should be usable by someone with no design vocabulary. The UI must not require the user to understand grids, type scale, hierarchy, or color theory before they can produce good work.
+
+Product rules:
+
+- Ask one plain-language question at a time.
+- Prefer visual choices over abstract sliders.
+- Show style options as named **Style cards**, not raw parameter forms.
+- Use simple labels first, with expert details expandable.
+- Auto-fill dimensions and constraints after the user chooses an artifact intent.
+- Provide safe defaults and warn when a choice will likely make the result worse.
+- Let users say "more like this" or "less like this" instead of editing technical parameters.
+- Keep expert controls available for designers, but never make them required for first success.
+
+## Implementation Slices
+
+Slice 1 should prove the main creation path before building the full learning system:
+
+1. Add the **Guided create flow** as the primary creation entry.
+2. Let the user choose an artifact intent from a small but extensible **Artifact intent catalog**.
+3. Apply default dimensions, medium constraints, and output expectations from that intent.
+4. Offer a small set of starter **Style cards** or a neutral default style.
+5. Enter **Conversational design creation** with the selected intent and style card included in the generation context.
+
+Slice 2 should connect taste learning and production constraints:
+
+1. Add the first-class **Reference board**.
+2. Support saving URLs, screenshots/images, and notes as raw references.
+3. Run **Taste extraction** into editable **Style cards**.
+4. Let the user accept, modify, or ignore extracted **Style cards** before they update the user's long-term **Taste profile**.
+5. Add project-level **Print spec** upload/paste for print-oriented intents.
+6. Generate **Level 2.5 Basic print handoff** outputs.
+
+## Existing Hooks
+
+The repo already has primitives that can support this direction:
+
+- `MemorySection` can store user, feedback, project, and reference memories.
+- `/api/memory/extract` already sediments conversation signals into memory.
+- System prompts already inject personal memory as preferences and context.
+- `inspirationDesignSystemIds` already expresses secondary design inspiration alongside a primary design system.
+
+The differentiation work should productize these hooks instead of creating an unrelated preference subsystem.
+
+## Decisions
+
+- 2026-05-12 — Make the **Reference board** a first-class product entry while initially reusing the existing memory/reference substrate. *Why:* the differentiation depends on users saving inspiration continuously, not only configuring assistant memory in settings.
+- 2026-05-12 — Keep both raw references and extracted **Style cards**. *Why:* raw references preserve provenance and review context, while style cards provide the structured design language agents need for reliable generation.
+- 2026-05-12 — Treat print readiness as a differentiated last-mile workflow, including printer spec upload and CMYK-compatible handoff. *Why:* good-looking AI previews are not enough when the user needs a file that can be sent to a print vendor.
+- 2026-05-12 — Target **Level 2.5 Basic print handoff** for the first print milestone. *Why:* spec intake, layout constraints, PDF Print export, production summary, and basic preflight create practical user value without blocking on full PDF/X, ICC, spot color, and dieline validation.
+- 2026-05-12 — Start print specs as project-level uploads, but model them so they can be saved as reusable **Print spec presets**. *Why:* users need immediate upload support first, while repeated vendors, sizes, and dielines should become one-click constraints later.
+- 2026-05-12 — Implement the Canva-style guided creation flow and starter **Style cards** before the full reference-learning and print-spec workflows. *Why:* the creation entry determines how intent, dimensions, style, conversation, references, and print constraints fit together.
+- 2026-05-13 — Require user acceptance before extracted **Style cards** update the long-term **Taste profile**. *Why:* automatic extraction is useful, but one-off references should not silently become durable user taste.
+- 2026-05-13 — Persist the full **Taste extraction** parameter set, but expose only Mood, Color, Typography, Composition, Density, and Transfer notes in the first novice-facing **Style card** UI. *Why:* generation needs structured depth, while first-time users need a short review surface.

--- a/docs/plans/v1-baseline.md
+++ b/docs/plans/v1-baseline.md
@@ -1,0 +1,68 @@
+# v1 Baseline Plan
+
+**Parent:** [`roadmap.md`](../roadmap.md) · **Decision:** [`ADR 0002`](../adr/0002-stabilize-upstream-before-differentiation.md)
+
+This plan defines the first productization milestone for this fork. The v1 baseline is not a feature-differentiation phase. It is the point where the chosen upstream can be installed, validated, run, and inspected reliably enough that later product work has a stable base.
+
+## Goal
+
+Make `nexu-io/open-design` reliable as this fork's upstream runtime before adding new product surface area.
+
+The baseline is met when a clean local checkout can:
+
+- install dependencies with Node 24 and the pinned pnpm version;
+- pass workspace typecheck and tests;
+- start the local daemon/web lifecycle through `pnpm tools-dev`;
+- create a project, run an agent path, and persist a previewable design artifact;
+- run the desktop shell against the local web/daemon runtime;
+- keep fork-specific decisions documented in `CONTEXT.md` and `docs/adr/`.
+
+## Current State
+
+- Upstream remote is `nexu-io/open-design`.
+- This fork tracks upstream `main` and carries only a small set of productization commits.
+- Node 24 is the authoritative validation runtime.
+- Workspace typecheck and recursive tests pass locally with Node 24.
+- PRs to upstream should stay draft until CI, local lifecycle, and desktop smoke results are known.
+
+## Included Work
+
+- Keep this fork rebased on upstream `main`.
+- Fix install, typecheck, test, and package-boundary failures.
+- Stabilize flaky tests when they block reliable baseline validation.
+- Preserve repo rules around contracts, sidecar boundaries, runtime paths, and `tools-dev`.
+- Document fork decisions as ADRs instead of leaving them in chat.
+- Run and record local smoke checks for web, daemon, desktop, and artifact persistence.
+
+## Explicitly Deferred
+
+- New marketplace or skill-discovery product flows.
+- UI imports from reference projects.
+- Major design-system editor changes.
+- New hosted or SaaS deployment topology.
+- Large adapter expansion beyond what is needed to validate the upstream runtime.
+- Branding, marketing pages, or landing-page work.
+
+## Validation Ladder
+
+Use the smallest check that proves the current change, then climb the ladder before marking baseline work ready:
+
+1. Targeted test or repro for the changed package.
+2. Package typecheck/test for affected package boundaries.
+3. Workspace typecheck:
+   `PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm typecheck`
+4. Workspace tests:
+   `PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm -r --if-present run test`
+5. Local lifecycle smoke:
+   `PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm tools-dev run web --daemon-port <port> --web-port <port>`
+6. Desktop smoke on a GUI-capable machine:
+   `pnpm tools-dev inspect desktop status --json`
+
+## Exit Criteria
+
+- `pnpm install`, `pnpm typecheck`, and `pnpm -r --if-present run test` pass under Node 24.
+- `pnpm tools-dev run web` can serve the app through the daemon/web pair.
+- A project can run through the configured agent path and produce a saved artifact.
+- Desktop can discover the web URL through sidecar IPC.
+- Known warnings are documented or converted into issues.
+- The fork is ready for narrow differentiated work without first debugging the foundation.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,7 +4,7 @@
 
 Phased plan from "spec-only today" to "usable MVP" to "published v1." All estimates assume one focused developer; multiply by 0.6 for two and 0.4 for three.
 
-For this productization fork, use [`plans/v1-baseline.md`](plans/v1-baseline.md) as the current near-term execution plan before differentiated feature work.
+For this productization fork, use [`plans/v1-baseline.md`](plans/v1-baseline.md) as the current near-term execution plan before differentiated feature work. The first documented differentiation direction is [`plans/design-taste-evolution.md`](plans/design-taste-evolution.md).
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,6 +4,8 @@
 
 Phased plan from "spec-only today" to "usable MVP" to "published v1." All estimates assume one focused developer; multiply by 0.6 for two and 0.4 for three.
 
+For this productization fork, use [`plans/v1-baseline.md`](plans/v1-baseline.md) as the current near-term execution plan before differentiated feature work.
+
 ---
 
 ## Phase 0 — Spec finalization (current, ~3–5 days)

--- a/e2e/ui/app-manual-edit.test.ts
+++ b/e2e/ui/app-manual-edit.test.ts
@@ -3,9 +3,22 @@ import type { Page } from '@playwright/test';
 
 const STORAGE_KEY = 'open-design:config';
 
-test.describe.configure({ timeout: 15_000 });
+test.describe.configure({ timeout: 25_000 });
 
 test.beforeEach(async ({ page }) => {
+  await page.route('**/api/app-config', async (route) => {
+    if (route.request().method() !== 'GET') return route.fallback();
+    await route.fulfill({
+      json: {
+        config: {
+          onboardingCompleted: true,
+          privacyDecisionAt: 1,
+          telemetry: { metrics: false, content: false, artifactManifest: false },
+        },
+      },
+    });
+  });
+
   await page.addInitScript((key) => {
     window.localStorage.setItem(
       key,
@@ -84,8 +97,9 @@ test('manual edit mode applies content, style, attribute, HTML, source, undo, an
   await page.getByRole('button', { name: 'Redo' }).click();
   await expect(frame.getByRole('heading', { name: 'Full Source Hero' })).toBeVisible();
 
-  await page.getByRole('button', { name: /Tweaks/ }).click();
+  await page.getByTestId('board-mode-toggle').click();
   await expect(page.getByTestId('comment-mode-toggle')).toBeVisible();
+  await page.getByTestId('comment-mode-toggle').click();
   await frame.getByRole('heading', { name: 'Full Source Hero' }).click();
   await expect(page.getByTestId('comment-popover')).toBeVisible();
 

--- a/e2e/ui/app-restoration.test.ts
+++ b/e2e/ui/app-restoration.test.ts
@@ -5,7 +5,7 @@ import type { UiScenario } from '@/playwright/resources';
 
 const STORAGE_KEY = 'open-design:config';
 
-test.describe.configure({ timeout: 15_000 });
+test.describe.configure({ timeout: 25_000 });
 
 test.beforeEach(async ({ page }) => {
   await page.addInitScript((key) => {
@@ -2273,13 +2273,12 @@ async function runCommentAttachmentFlow(
   await frame.locator('[data-od-id="hero-title"]').click();
   await expect(page.getByTestId('comment-popover')).toBeVisible();
   await page.getByTestId('comment-popover-input').fill('Make the headline more specific.');
-  await page.getByTestId('comment-popover').getByRole('button', { name: 'Save comment' }).click();
+  await page.getByTestId('comment-popover-save').click();
 
   await expect(page.getByTestId('comment-saved-marker-hero-title')).toBeVisible();
   await expect(page.getByTestId('staged-comment-attachments')).toHaveCount(0);
   await expect(page.getByTestId('chat-composer-input')).toHaveValue('');
   await expect(page.getByTestId('chat-send')).toBeDisabled();
-  await page.getByTestId('comment-popover').getByRole('button', { name: 'Close' }).click();
 
   await frame.locator('[data-od-id="hero-copy"]').hover();
   await expect(page.getByTestId('comment-target-overlay')).toBeVisible();
@@ -2290,40 +2289,17 @@ async function runCommentAttachmentFlow(
   await expect(page.getByTestId('comment-popover-input')).toHaveValue('Make the headline more specific.');
   await page.getByTestId('comment-popover').getByRole('button', { name: 'Close' }).click();
 
-  await page.getByRole('tab', { name: 'Comments' }).click();
-  await expect(page.getByTestId('comments-panel')).toBeVisible();
-  await expect(page.getByTestId('comments-panel').getByRole('heading', { name: 'Saved comments' })).toBeVisible();
-  await page.getByTestId('comments-panel')
-    .locator('[data-testid="comment-card-hero-title"]')
-    .getByRole('button', { name: 'Add' })
+  await expect(page.getByTestId('comment-side-panel')).toBeVisible();
+  await expect(page.getByTestId('comment-side-panel')).toContainText('Make the headline more specific.');
+  await page.getByTestId('comment-side-item')
+    .filter({ hasText: 'Make the headline more specific.' })
+    .getByRole('button', { name: 'Select' })
     .click();
-  await page.getByRole('tab', { name: 'Chat' }).click();
-  await expect(page.getByTestId('staged-comment-attachments')).toBeVisible();
-  await expect(page.getByTestId('staged-comment-attachments')).toContainText('hero-title');
-  await expect(page.getByTestId('staged-comment-attachments')).toContainText('Make the headline more specific.');
-
-  await page.getByRole('tab', { name: 'Comments' }).click();
-  await expect(page.getByTestId('comments-panel').getByRole('heading', { name: 'Attached to chat' })).toBeVisible();
-  await page.getByTestId('comments-panel')
-    .locator('[data-testid="comment-card-hero-title"]')
-    .getByRole('button', { name: 'Remove' })
-    .click();
-  await page.getByRole('tab', { name: 'Chat' }).click();
-  await expect(page.getByTestId('staged-comment-attachments')).toHaveCount(0);
-  await expect(page.getByTestId('chat-send')).toBeDisabled();
-
-  await page.getByRole('tab', { name: 'Comments' }).click();
-  await page.getByTestId('comments-panel')
-    .locator('[data-testid="comment-card-hero-title"]')
-    .getByRole('button', { name: 'Add' })
-    .click();
-  await page.getByRole('tab', { name: 'Chat' }).click();
-  await expect(page.getByTestId('staged-comment-attachments')).toContainText('hero-title');
-
+  await expect(page.getByTestId('comment-side-selectbar')).toContainText('1 selected');
   const runRequest = page.waitForRequest(
     isCreateRunRequest,
   );
-  await page.getByTestId('chat-send').click();
+  await page.getByTestId('comment-side-send-claude').click();
   const request = await runRequest;
   const body = request.postDataJSON() as {
     message?: string;

--- a/e2e/ui/app.test.ts
+++ b/e2e/ui/app.test.ts
@@ -11,6 +11,19 @@ const APP_OWNED_SCENARIO_FLOWS = new Set([
 ]);
 
 test.beforeEach(async ({ page }) => {
+  await page.route('**/api/app-config', async (route) => {
+    if (route.request().method() !== 'GET') return route.fallback();
+    await route.fulfill({
+      json: {
+        config: {
+          onboardingCompleted: true,
+          privacyDecisionAt: 1,
+          telemetry: { metrics: false, content: false, artifactManifest: false },
+        },
+      },
+    });
+  });
+
   await page.addInitScript((key) => {
     window.localStorage.setItem(
       key,
@@ -33,6 +46,10 @@ for (const entry of automatedUiScenarios().filter(
   (scenario) => !APP_OWNED_SCENARIO_FLOWS.has(scenario.flow ?? ''),
 )) {
   test(`${entry.id}: ${entry.title}`, async ({ page }) => {
+    if (entry.flow === 'comment-attachment-flow') {
+      test.setTimeout(20_000);
+    }
+
     await page.route('**/api/agents', async (route) => {
       await route.fulfill({
         json: {
@@ -625,13 +642,12 @@ async function runCommentAttachmentFlow(
   await frame.locator('[data-od-id="hero-title"]').click();
   await expect(page.getByTestId('comment-popover')).toBeVisible();
   await page.getByTestId('comment-popover-input').fill('Make the headline more specific.');
-  await page.getByTestId('comment-popover').getByRole('button', { name: 'Save comment' }).click();
+  await page.getByTestId('comment-popover-save').click();
 
   await expect(page.getByTestId('comment-saved-marker-hero-title')).toBeVisible();
   await expect(page.getByTestId('staged-comment-attachments')).toHaveCount(0);
   await expect(page.getByTestId('chat-composer-input')).toHaveValue('');
   await expect(page.getByTestId('chat-send')).toBeDisabled();
-  await page.getByTestId('comment-popover').getByRole('button', { name: 'Close' }).click();
 
   await frame.locator('[data-od-id="hero-copy"]').hover();
   await expect(page.getByTestId('comment-target-overlay')).toBeVisible();
@@ -642,40 +658,17 @@ async function runCommentAttachmentFlow(
   await expect(page.getByTestId('comment-popover-input')).toHaveValue('Make the headline more specific.');
   await page.getByTestId('comment-popover').getByRole('button', { name: 'Close' }).click();
 
-  await page.getByRole('tab', { name: 'Comments' }).click();
-  await expect(page.getByTestId('comments-panel')).toBeVisible();
-  await expect(page.getByTestId('comments-panel').getByRole('heading', { name: 'Saved comments' })).toBeVisible();
-  await page.getByTestId('comments-panel')
-    .locator('[data-testid="comment-card-hero-title"]')
-    .getByRole('button', { name: 'Add' })
+  await expect(page.getByTestId('comment-side-panel')).toBeVisible();
+  await expect(page.getByTestId('comment-side-panel')).toContainText('Make the headline more specific.');
+  await page.getByTestId('comment-side-item')
+    .filter({ hasText: 'Make the headline more specific.' })
+    .getByRole('button', { name: 'Select' })
     .click();
-  await page.getByRole('tab', { name: 'Chat' }).click();
-  await expect(page.getByTestId('staged-comment-attachments')).toBeVisible();
-  await expect(page.getByTestId('staged-comment-attachments')).toContainText('hero-title');
-  await expect(page.getByTestId('staged-comment-attachments')).toContainText('Make the headline more specific.');
-
-  await page.getByRole('tab', { name: 'Comments' }).click();
-  await expect(page.getByTestId('comments-panel').getByRole('heading', { name: 'Attached to chat' })).toBeVisible();
-  await page.getByTestId('comments-panel')
-    .locator('[data-testid="comment-card-hero-title"]')
-    .getByRole('button', { name: 'Remove' })
-    .click();
-  await page.getByRole('tab', { name: 'Chat' }).click();
-  await expect(page.getByTestId('staged-comment-attachments')).toHaveCount(0);
-  await expect(page.getByTestId('chat-send')).toBeDisabled();
-
-  await page.getByRole('tab', { name: 'Comments' }).click();
-  await page.getByTestId('comments-panel')
-    .locator('[data-testid="comment-card-hero-title"]')
-    .getByRole('button', { name: 'Add' })
-    .click();
-  await page.getByRole('tab', { name: 'Chat' }).click();
-  await expect(page.getByTestId('staged-comment-attachments')).toContainText('hero-title');
-
+  await expect(page.getByTestId('comment-side-selectbar')).toContainText('1 selected');
   const runRequest = page.waitForRequest(
     isCreateRunRequest,
   );
-  await page.getByTestId('chat-send').click();
+  await page.getByTestId('comment-side-send-claude').click();
   const request = await runRequest;
   const body = request.postDataJSON() as {
     message?: string;

--- a/e2e/ui/entry-chrome-flows.test.ts
+++ b/e2e/ui/entry-chrome-flows.test.ts
@@ -66,12 +66,14 @@ test('entry top navigation matches the current home tab structure', async ({ pag
     'Designs',
     'Templates',
     'Design systems',
+    'References',
     'Image templates',
     'Video templates',
   ]);
   await expect(page.getByTestId('entry-tab-designs')).toHaveAttribute('aria-selected', 'true');
   await expect(page.getByTestId('entry-tab-templates')).toBeVisible();
   await expect(page.getByTestId('entry-tab-design-systems')).toBeVisible();
+  await expect(page.getByTestId('entry-tab-references')).toBeVisible();
   await expect(page.getByTestId('entry-tab-image-templates')).toBeVisible();
   await expect(page.getByTestId('entry-tab-video-templates')).toBeVisible();
   await expect(page.locator('.entry-tabs').getByRole('tab', { name: 'Connectors' })).toHaveCount(0);

--- a/nix/package-daemon.nix
+++ b/nix/package-daemon.nix
@@ -44,7 +44,7 @@ let
   # `nix build .#daemon` will fail with the expected hash printed; copy
   # that into `pnpmDepsHash` below. Bump it whenever pnpm-lock.yaml
   # changes.
-  pnpmDepsHash = "sha256-mVxYroVE1MZuW1RvXCI3PsnZBcTiTI80s6cD++8IC4E=";
+  pnpmDepsHash = "sha256-U6STrxeEny2PVfG8FB8JDXDqMWS6NihAKa4f1GMc05M=";
   # pnpmDepsHash = lib.fakeHash;
 in
   stdenv.mkDerivation (finalAttrs: {

--- a/nix/package-daemon.nix
+++ b/nix/package-daemon.nix
@@ -44,7 +44,7 @@ let
   # `nix build .#daemon` will fail with the expected hash printed; copy
   # that into `pnpmDepsHash` below. Bump it whenever pnpm-lock.yaml
   # changes.
-  pnpmDepsHash = "sha256-KF3Mld72/iau+pJmA7HvnanRx8VLtDP0N624SKrtrrc=";
+  pnpmDepsHash = "sha256-mVxYroVE1MZuW1RvXCI3PsnZBcTiTI80s6cD++8IC4E=";
   # pnpmDepsHash = lib.fakeHash;
 in
   stdenv.mkDerivation (finalAttrs: {

--- a/nix/package-web.nix
+++ b/nix/package-web.nix
@@ -30,7 +30,7 @@ let
   # `nix build .#web` will fail with the expected hash printed; copy
   # that into `pnpmDepsHash` below. Bump it whenever pnpm-lock.yaml
   # changes.
-  pnpmDepsHash = "sha256-KF3Mld72/iau+pJmA7HvnanRx8VLtDP0N624SKrtrrc=";
+  pnpmDepsHash = "sha256-mVxYroVE1MZuW1RvXCI3PsnZBcTiTI80s6cD++8IC4E=";
   # pnpmDepsHash = lib.fakeHash;
 in
   stdenv.mkDerivation (finalAttrs: {

--- a/nix/package-web.nix
+++ b/nix/package-web.nix
@@ -30,7 +30,7 @@ let
   # `nix build .#web` will fail with the expected hash printed; copy
   # that into `pnpmDepsHash` below. Bump it whenever pnpm-lock.yaml
   # changes.
-  pnpmDepsHash = "sha256-mVxYroVE1MZuW1RvXCI3PsnZBcTiTI80s6cD++8IC4E=";
+  pnpmDepsHash = "sha256-U6STrxeEny2PVfG8FB8JDXDqMWS6NihAKa4f1GMc05M=";
   # pnpmDepsHash = lib.fakeHash;
 in
   stdenv.mkDerivation (finalAttrs: {

--- a/packages/contracts/esbuild.config.mjs
+++ b/packages/contracts/esbuild.config.mjs
@@ -6,7 +6,10 @@ await build({
   entryPoints: [
     "./src/index.ts",
     "./src/critique.ts",
+    "./src/style-cards.ts",
+    "./src/print-specs.ts",
     "./src/api/connectionTest.ts",
+    "./src/api/taste-profile.ts",
     "./src/api/orbit.ts",
     "./src/api/finalize.ts",
     "./src/api/providerModels.ts",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -14,9 +14,21 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.mjs"
     },
+    "./style-cards": {
+      "types": "./dist/style-cards.d.ts",
+      "default": "./dist/style-cards.mjs"
+    },
+    "./print-specs": {
+      "types": "./dist/print-specs.d.ts",
+      "default": "./dist/print-specs.mjs"
+    },
     "./api/connectionTest": {
       "types": "./dist/api/connectionTest.d.ts",
       "default": "./dist/api/connectionTest.mjs"
+    },
+    "./api/taste-profile": {
+      "types": "./dist/api/taste-profile.d.ts",
+      "default": "./dist/api/taste-profile.mjs"
     },
     "./api/orbit": {
       "types": "./dist/api/orbit.d.ts",

--- a/packages/contracts/src/api/projects.ts
+++ b/packages/contracts/src/api/projects.ts
@@ -1,4 +1,7 @@
 import type { ChatMessage } from './chat.js';
+import type { ArtifactIntentMetadata } from '../artifact-intents.js';
+import type { StyleCardMetadata } from '../style-cards.js';
+import type { PrintSpecMetadata } from '../print-specs.js';
 
 export type ProjectKind =
   | 'prototype'
@@ -65,6 +68,9 @@ export interface PromptTemplateMetadata {
 export interface ProjectMetadata {
   kind: ProjectKind;
   intent?: 'live-artifact';
+  artifactIntent?: ArtifactIntentMetadata;
+  styleCard?: StyleCardMetadata;
+  printSpec?: PrintSpecMetadata;
   fidelity?: 'wireframe' | 'high-fidelity';
   speakerNotes?: boolean;
   animations?: boolean;

--- a/packages/contracts/src/api/taste-profile.ts
+++ b/packages/contracts/src/api/taste-profile.ts
@@ -1,0 +1,19 @@
+import type { StyleCardMetadata } from '../style-cards.js';
+
+export interface TasteProfile {
+  styleCards: StyleCardMetadata[];
+  updatedAt: number | null;
+}
+
+export interface TasteProfileResponse {
+  profile: TasteProfile;
+}
+
+export interface AcceptStyleCardRequest {
+  styleCard: StyleCardMetadata;
+}
+
+export interface AcceptStyleCardResponse {
+  styleCard: StyleCardMetadata;
+  profile: TasteProfile;
+}

--- a/packages/contracts/src/artifact-intents.ts
+++ b/packages/contracts/src/artifact-intents.ts
@@ -1,0 +1,189 @@
+import type { ProjectKind, ProjectPlatform } from './api/projects.js';
+
+export type ArtifactIntentId = string;
+
+export type ArtifactIntentGroup =
+  | 'social'
+  | 'ads-marketing'
+  | 'web-app'
+  | 'brand-identity'
+  | 'documents'
+  | 'presentations'
+  | 'print-products'
+  | 'packaging'
+  | 'merchandise'
+  | 'signage'
+  | 'video-motion'
+  | 'custom';
+
+export type ArtifactIntentUnit = 'px' | 'mm' | 'in';
+
+export interface ArtifactIntentGroupInfo {
+  id: ArtifactIntentGroup;
+  label: string;
+}
+
+export interface ArtifactIntentDimensions {
+  width: number;
+  height: number;
+  unit: ArtifactIntentUnit;
+  dpi?: number;
+}
+
+export interface ArtifactIntentMetadata {
+  id: ArtifactIntentId;
+  label: string;
+  group: ArtifactIntentGroup;
+  dimensions?: ArtifactIntentDimensions;
+  mediumConstraints: string[];
+  outputExpectations: string[];
+  printReady: boolean;
+}
+
+export interface ArtifactIntentPreset extends ArtifactIntentMetadata {
+  defaultKind: ProjectKind;
+  defaultPlatformTargets: ProjectPlatform[];
+}
+
+export const ARTIFACT_INTENT_GROUPS: readonly ArtifactIntentGroupInfo[] = [
+  { id: 'social', label: 'Social' },
+  { id: 'ads-marketing', label: 'Ads and marketing' },
+  { id: 'web-app', label: 'Web and app' },
+  { id: 'brand-identity', label: 'Brand identity' },
+  { id: 'documents', label: 'Documents' },
+  { id: 'presentations', label: 'Presentations' },
+  { id: 'print-products', label: 'Print products' },
+  { id: 'packaging', label: 'Packaging' },
+  { id: 'merchandise', label: 'Merchandise' },
+  { id: 'signage', label: 'Signage and large format' },
+  { id: 'video-motion', label: 'Video and motion' },
+  { id: 'custom', label: 'Custom' },
+];
+
+function px(width: number, height: number): ArtifactIntentDimensions {
+  return { width, height, unit: 'px' };
+}
+
+function mm(width: number, height: number, dpi = 300): ArtifactIntentDimensions {
+  return { width, height, unit: 'mm', dpi };
+}
+
+function intent(input: {
+  id: string;
+  label: string;
+  group: ArtifactIntentGroup;
+  dimensions?: ArtifactIntentDimensions;
+  constraints: string[];
+  expectations: string[];
+  printReady?: boolean;
+  kind?: ProjectKind;
+  platformTargets?: ProjectPlatform[];
+}): ArtifactIntentPreset {
+  return {
+    id: input.id,
+    label: input.label,
+    group: input.group,
+    defaultKind: input.kind ?? 'prototype',
+    defaultPlatformTargets: input.platformTargets ?? ['responsive'],
+    ...(input.dimensions ? { dimensions: input.dimensions } : {}),
+    mediumConstraints: input.constraints,
+    outputExpectations: input.expectations,
+    printReady: input.printReady ?? false,
+  };
+}
+
+export const INITIAL_ARTIFACT_INTENTS: readonly ArtifactIntentPreset[] = [
+  intent({ id: 'instagram-post', label: 'Instagram post', group: 'social', dimensions: px(1080, 1080), constraints: ['square social composition'], expectations: ['shareable social visual'] }),
+  intent({ id: 'instagram-story', label: 'Instagram story', group: 'social', dimensions: px(1080, 1920), constraints: ['vertical story safe zones'], expectations: ['mobile-first story visual'] }),
+  intent({ id: 'facebook-cover', label: 'Facebook cover', group: 'social', dimensions: px(1640, 924), constraints: ['wide social header'], expectations: ['brand cover visual'] }),
+  intent({ id: 'linkedin-banner', label: 'LinkedIn banner', group: 'social', dimensions: px(1584, 396), constraints: ['professional wide header'], expectations: ['profile or company banner'] }),
+  intent({ id: 'youtube-thumbnail', label: 'YouTube thumbnail', group: 'social', dimensions: px(1280, 720), constraints: ['high-contrast thumbnail'], expectations: ['clickable video cover'] }),
+  intent({ id: 'tiktok-cover', label: 'TikTok cover', group: 'social', dimensions: px(1080, 1920), constraints: ['vertical cover composition'], expectations: ['short-form video cover'] }),
+  intent({ id: 'pinterest-pin', label: 'Pinterest pin', group: 'social', dimensions: px(1000, 1500), constraints: ['vertical discovery card'], expectations: ['pin-ready visual'] }),
+  intent({ id: 'social-carousel', label: 'Social carousel', group: 'social', dimensions: px(1080, 1080), constraints: ['multi-slide social sequence'], expectations: ['carousel structure'] }),
+
+  intent({ id: 'edm', label: 'EDM', group: 'ads-marketing', dimensions: px(600, 1200), constraints: ['email-safe narrow layout', 'mobile-readable sections'], expectations: ['email marketing layout', 'CTA-forward content structure'] }),
+  intent({ id: 'newsletter', label: 'Newsletter', group: 'ads-marketing', dimensions: px(600, 1400), constraints: ['email content hierarchy'], expectations: ['newsletter-ready layout'] }),
+  intent({ id: 'dm', label: 'DM', group: 'ads-marketing', dimensions: mm(210, 99), constraints: ['direct-mail print surface'], expectations: ['print-aware promotional layout'], printReady: true }),
+  intent({ id: 'flyer', label: 'Flyer', group: 'ads-marketing', dimensions: mm(210, 297), constraints: ['single-page promotional print'], expectations: ['flyer layout'], printReady: true }),
+  intent({ id: 'brochure', label: 'Brochure', group: 'ads-marketing', dimensions: mm(297, 210), constraints: ['fold-aware marketing print'], expectations: ['brochure panel structure'], printReady: true }),
+  intent({ id: 'poster', label: 'Poster', group: 'ads-marketing', dimensions: mm(420, 594), constraints: ['large-format hierarchy'], expectations: ['poster layout'], printReady: true }),
+  intent({ id: 'display-ad', label: 'Display ad', group: 'ads-marketing', dimensions: px(1200, 628), constraints: ['paid media crop safety'], expectations: ['ad creative'] }),
+  intent({ id: 'sales-sheet', label: 'Sales sheet', group: 'ads-marketing', dimensions: mm(210, 297), constraints: ['one-page sales information'], expectations: ['printable sales collateral'], printReady: true }),
+
+  intent({ id: 'landing-page', label: 'Landing page', group: 'web-app', dimensions: px(1440, 1200), constraints: ['responsive web page', 'browser preview'], expectations: ['editable HTML artifact', 'responsive layout'] }),
+  intent({ id: 'website-section', label: 'Website section', group: 'web-app', dimensions: px(1440, 800), constraints: ['section-level responsive layout'], expectations: ['web section'] }),
+  intent({ id: 'hero', label: 'Hero', group: 'web-app', dimensions: px(1440, 760), constraints: ['first viewport web composition'], expectations: ['hero section'] }),
+  intent({ id: 'pricing-page', label: 'Pricing page', group: 'web-app', dimensions: px(1440, 1200), constraints: ['conversion-focused pricing layout'], expectations: ['pricing page'] }),
+  intent({ id: 'dashboard', label: 'Dashboard', group: 'web-app', dimensions: px(1440, 1024), constraints: ['data-dense product UI'], expectations: ['dashboard screen'] }),
+  intent({ id: 'app-screen', label: 'App screen', group: 'web-app', dimensions: px(390, 844), constraints: ['mobile app viewport'], expectations: ['app screen'] }),
+  intent({ id: 'product-page', label: 'Product page', group: 'web-app', dimensions: px(1440, 1400), constraints: ['commerce content hierarchy'], expectations: ['product detail page'] }),
+
+  intent({ id: 'logo-concept', label: 'Logo concept', group: 'brand-identity', dimensions: px(1200, 1200), constraints: ['identity mark exploration'], expectations: ['logo concept board'] }),
+  intent({ id: 'brand-board', label: 'Brand board', group: 'brand-identity', dimensions: px(1600, 1200), constraints: ['brand system summary'], expectations: ['brand board'] }),
+  intent({ id: 'business-card', label: 'Business card', group: 'print-products', dimensions: mm(90, 54), constraints: ['two-sided physical print surface', 'safe area and trim awareness'], expectations: ['print handoff', 'front/back card concept'], printReady: true }),
+  intent({ id: 'letterhead', label: 'Letterhead', group: 'brand-identity', dimensions: mm(210, 297), constraints: ['stationery print surface'], expectations: ['letterhead layout'], printReady: true }),
+  intent({ id: 'email-signature', label: 'Email signature', group: 'brand-identity', dimensions: px(600, 220), constraints: ['email client-safe block'], expectations: ['signature layout'] }),
+
+  intent({ id: 'proposal', label: 'Proposal', group: 'documents', dimensions: mm(210, 297), constraints: ['multi-section document'], expectations: ['proposal page system'], printReady: true }),
+  intent({ id: 'report', label: 'Report', group: 'documents', dimensions: mm(210, 297), constraints: ['document hierarchy'], expectations: ['report layout'], printReady: true }),
+  intent({ id: 'resume', label: 'Resume', group: 'documents', dimensions: mm(210, 297), constraints: ['resume scanability'], expectations: ['resume layout'], printReady: true }),
+  intent({ id: 'worksheet', label: 'Worksheet', group: 'documents', dimensions: mm(210, 297), constraints: ['fillable print layout'], expectations: ['worksheet page'], printReady: true }),
+  intent({ id: 'menu', label: 'Menu', group: 'documents', dimensions: mm(210, 297), constraints: ['restaurant information hierarchy'], expectations: ['menu layout'], printReady: true }),
+  intent({ id: 'certificate', label: 'Certificate', group: 'documents', dimensions: mm(297, 210), constraints: ['formal landscape print'], expectations: ['certificate layout'], printReady: true }),
+
+  intent({ id: 'pitch-deck', label: 'Pitch deck', group: 'presentations', dimensions: px(1920, 1080), constraints: ['slide narrative'], expectations: ['deck structure'], kind: 'deck' }),
+  intent({ id: 'sales-deck', label: 'Sales deck', group: 'presentations', dimensions: px(1920, 1080), constraints: ['sales story slides'], expectations: ['sales deck'], kind: 'deck' }),
+  intent({ id: 'lesson-deck', label: 'Lesson deck', group: 'presentations', dimensions: px(1920, 1080), constraints: ['teaching slide sequence'], expectations: ['lesson deck'], kind: 'deck' }),
+  intent({ id: 'webinar-slides', label: 'Webinar slides', group: 'presentations', dimensions: px(1920, 1080), constraints: ['webinar presentation'], expectations: ['webinar slide deck'], kind: 'deck' }),
+
+  intent({ id: 'postcard', label: 'Postcard', group: 'print-products', dimensions: mm(148, 105), constraints: ['two-sided postcard'], expectations: ['print handoff'], printReady: true }),
+  intent({ id: 'invitation', label: 'Invitation', group: 'print-products', dimensions: mm(127, 178), constraints: ['event print card'], expectations: ['invitation layout'], printReady: true }),
+  intent({ id: 'sticker', label: 'Sticker', group: 'print-products', dimensions: mm(75, 75), constraints: ['die-cut sticker awareness'], expectations: ['sticker art'], printReady: true }),
+  intent({ id: 'label', label: 'Label', group: 'print-products', dimensions: mm(100, 50), constraints: ['product label safe area'], expectations: ['label layout'], printReady: true }),
+  intent({ id: 'booklet', label: 'Booklet', group: 'print-products', dimensions: mm(148, 210), constraints: ['multi-page print'], expectations: ['booklet system'], printReady: true }),
+  intent({ id: 'catalog', label: 'Catalog', group: 'print-products', dimensions: mm(210, 297), constraints: ['product catalog pages'], expectations: ['catalog page system'], printReady: true }),
+
+  intent({ id: 'box', label: 'Box', group: 'packaging', dimensions: mm(200, 120), constraints: ['packaging panel layout', 'dieline awareness'], expectations: ['packaging concept'], printReady: true }),
+  intent({ id: 'sleeve', label: 'Sleeve', group: 'packaging', dimensions: mm(220, 80), constraints: ['wraparound packaging surface'], expectations: ['sleeve design'], printReady: true }),
+  intent({ id: 'pouch', label: 'Pouch', group: 'packaging', dimensions: mm(140, 200), constraints: ['flexible pouch front'], expectations: ['pouch design'], printReady: true }),
+  intent({ id: 'bottle-label', label: 'Bottle label', group: 'packaging', dimensions: mm(180, 90), constraints: ['cylindrical label wrap'], expectations: ['bottle label'], printReady: true }),
+  intent({ id: 'paper-bag', label: 'Paper bag', group: 'packaging', dimensions: mm(240, 320), constraints: ['bag face print area'], expectations: ['bag design'], printReady: true }),
+  intent({ id: 'hang-tag', label: 'Hang tag', group: 'packaging', dimensions: mm(50, 90), constraints: ['small print tag'], expectations: ['hang tag'], printReady: true }),
+
+  intent({ id: 't-shirt', label: 'T-shirt', group: 'merchandise', dimensions: px(4500, 5400), constraints: ['apparel print area'], expectations: ['shirt graphic'], printReady: true }),
+  intent({ id: 'tote-bag', label: 'Tote bag', group: 'merchandise', dimensions: px(3600, 4200), constraints: ['fabric print area'], expectations: ['tote graphic'], printReady: true }),
+  intent({ id: 'mug', label: 'Mug', group: 'merchandise', dimensions: px(2700, 1050), constraints: ['wraparound mug print'], expectations: ['mug artwork'], printReady: true }),
+  intent({ id: 'water-bottle', label: 'Water bottle', group: 'merchandise', dimensions: px(2400, 900), constraints: ['cylindrical product print'], expectations: ['bottle artwork'], printReady: true }),
+
+  intent({ id: 'yard-sign', label: 'Yard sign', group: 'signage', dimensions: mm(610, 457), constraints: ['outdoor sign legibility'], expectations: ['large-format sign'], printReady: true }),
+  intent({ id: 'storefront-sign', label: 'Storefront sign', group: 'signage', dimensions: mm(1200, 400), constraints: ['distance legibility'], expectations: ['signage concept'], printReady: true }),
+  intent({ id: 'roll-up-banner', label: 'Roll-up banner', group: 'signage', dimensions: mm(850, 2000), constraints: ['vertical event signage'], expectations: ['roll-up banner'], printReady: true }),
+  intent({ id: 'trade-show-panel', label: 'Trade show panel', group: 'signage', dimensions: mm(1000, 2200), constraints: ['large event panel'], expectations: ['trade show graphic'], printReady: true }),
+
+  intent({ id: 'short-video', label: 'Short video', group: 'video-motion', dimensions: px(1080, 1920), constraints: ['vertical motion composition'], expectations: ['short video structure'], kind: 'video' }),
+  intent({ id: 'video-cover', label: 'Video cover', group: 'video-motion', dimensions: px(1280, 720), constraints: ['video thumbnail'], expectations: ['cover frame'] }),
+  intent({ id: 'animated-social-post', label: 'Animated social post', group: 'video-motion', dimensions: px(1080, 1080), constraints: ['loopable social motion'], expectations: ['animated post plan'], kind: 'video' }),
+  intent({ id: 'lower-third', label: 'Lower third', group: 'video-motion', dimensions: px(1920, 250), constraints: ['broadcast overlay safe area'], expectations: ['lower-third graphic'] }),
+
+  intent({ id: 'custom-size', label: 'Custom size', group: 'custom', constraints: ['user-defined dimensions'], expectations: ['custom artifact constraints'] }),
+  intent({ id: 'custom-ratio', label: 'Custom ratio', group: 'custom', dimensions: px(1200, 800), constraints: ['user-defined aspect ratio'], expectations: ['custom ratio artifact'] }),
+  intent({ id: 'uploaded-spec', label: 'Uploaded spec', group: 'custom', constraints: ['printer or platform-defined requirements'], expectations: ['spec-driven artifact constraints'], printReady: true }),
+];
+
+export function findArtifactIntentPreset(id: ArtifactIntentId): ArtifactIntentPreset {
+  return INITIAL_ARTIFACT_INTENTS.find((item) => item.id === id)
+    ?? INITIAL_ARTIFACT_INTENTS[0]!;
+}
+
+export function toArtifactIntentMetadata(
+  preset: ArtifactIntentPreset,
+): ArtifactIntentMetadata {
+  const { defaultKind: _defaultKind, defaultPlatformTargets: _defaultPlatformTargets, ...metadata } = preset;
+  return {
+    ...metadata,
+    mediumConstraints: [...metadata.mediumConstraints],
+    outputExpectations: [...metadata.outputExpectations],
+    ...(metadata.dimensions ? { dimensions: { ...metadata.dimensions } } : {}),
+  };
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,6 +1,9 @@
 export * from './common';
 export * from './errors';
 export * from './tasks';
+export * from './artifact-intents';
+export * from './style-cards';
+export * from './print-specs';
 export * from './api/app-config';
 export * from './api/artifacts';
 export * from './api/chat';
@@ -12,6 +15,7 @@ export * from './api/finalize';
 export * from './api/live-artifacts';
 export * from './api/mcp';
 export * from './api/memory';
+export * from './api/taste-profile';
 export * from './api/orbit';
 export * from './api/providerModels';
 export * from './api/projects';

--- a/packages/contracts/src/print-specs.ts
+++ b/packages/contracts/src/print-specs.ts
@@ -1,0 +1,121 @@
+export type PrintSpecSource = 'paste' | 'upload' | 'preset';
+
+export interface PrintSpecRequirements {
+  colorMode: 'cmyk-compatible' | 'rgb-ok';
+  bleedMm?: number;
+  safeAreaMm?: number;
+  dpi?: number;
+  finish?: string;
+  material?: string;
+}
+
+export interface PrintSpecMetadata {
+  id: string;
+  label: string;
+  source: PrintSpecSource;
+  rawText: string;
+  requirements: PrintSpecRequirements;
+  checklist: string[];
+}
+
+export interface PrintSpecPreset {
+  id: string;
+  label: string;
+  spec: PrintSpecMetadata;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface PrintSpecPresetsResponse {
+  presets: PrintSpecPreset[];
+}
+
+export interface UpsertPrintSpecPresetRequest {
+  label?: string;
+  spec: PrintSpecMetadata;
+}
+
+export interface UpsertPrintSpecPresetResponse {
+  preset: PrintSpecPreset;
+  presets: PrintSpecPreset[];
+}
+
+export function buildPrintSpecMetadata(input: {
+  label?: string;
+  source?: PrintSpecSource;
+  text: string;
+}): PrintSpecMetadata | undefined {
+  const rawText = input.text.trim();
+  if (!rawText) return undefined;
+  const label = normalize(input.label || 'Print vendor spec');
+  const requirements = extractPrintRequirements(rawText);
+  return {
+    id: derivePrintSpecId(label),
+    label,
+    source: input.source ?? 'paste',
+    rawText,
+    requirements,
+    checklist: buildChecklist(requirements),
+  };
+}
+
+function extractPrintRequirements(text: string): PrintSpecRequirements {
+  const lower = text.toLowerCase();
+  const bleedMm = pickMm(lower, /bleed[^0-9]*(\d+(?:\.\d+)?)\s*mm/i)
+    ?? pickMm(lower, /出血[^0-9]*(\d+(?:\.\d+)?)\s*mm/i);
+  const safeAreaMm = pickMm(lower, /(?:safe|safety)[^0-9]*(\d+(?:\.\d+)?)\s*mm/i)
+    ?? pickMm(lower, /安全[^0-9]*(\d+(?:\.\d+)?)\s*mm/i);
+  const dpi = pickInt(lower, /(\d{2,4})\s*dpi/i);
+  const requirements: PrintSpecRequirements = {
+    colorMode: lower.includes('cmyk') || lower.includes('四色') ? 'cmyk-compatible' : 'rgb-ok',
+  };
+  if (bleedMm !== undefined) requirements.bleedMm = bleedMm;
+  if (safeAreaMm !== undefined) requirements.safeAreaMm = safeAreaMm;
+  if (dpi !== undefined) requirements.dpi = dpi;
+  const finish = findLine(text, ['finish', 'foil', 'lamination', 'uv', '加工', '燙', '霧膜']);
+  if (finish) requirements.finish = finish;
+  const material = findLine(text, ['paper', 'stock', 'material', 'gsm', '材質', '紙']);
+  if (material) requirements.material = material;
+  return requirements;
+}
+
+function buildChecklist(requirements: PrintSpecRequirements): string[] {
+  const checklist = [
+    'Use CMYK-compatible colors and avoid relying on screen-only RGB glow.',
+    'Keep live text and important marks inside the safe area.',
+    'Include print handoff notes with size, bleed, safe area, DPI, and finish assumptions.',
+  ];
+  if (requirements.bleedMm !== undefined) checklist.push(`Extend backgrounds ${requirements.bleedMm}mm into bleed.`);
+  if (requirements.dpi !== undefined) checklist.push(`Prepare raster assets at ${requirements.dpi} DPI or higher.`);
+  return checklist;
+}
+
+function derivePrintSpecId(label: string): string {
+  const slug = label.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '').slice(0, 64);
+  return `print_${slug || 'spec'}`;
+}
+
+function normalize(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function pickMm(text: string, re: RegExp): number | undefined {
+  const match = re.exec(text);
+  if (!match?.[1]) return undefined;
+  const value = Number(match[1]);
+  return Number.isFinite(value) ? value : undefined;
+}
+
+function pickInt(text: string, re: RegExp): number | undefined {
+  const match = re.exec(text);
+  if (!match?.[1]) return undefined;
+  const value = Number.parseInt(match[1], 10);
+  return Number.isFinite(value) ? value : undefined;
+}
+
+function findLine(text: string, keywords: string[]): string | undefined {
+  return text
+    .split(/\r?\n/)
+    .map((line) => normalize(line.replace(/^[-*]\s*/, '')))
+    .find((line) => keywords.some((keyword) => line.toLowerCase().includes(keyword.toLowerCase())));
+}

--- a/packages/contracts/src/prompts/system.ts
+++ b/packages/contracts/src/prompts/system.ts
@@ -57,6 +57,9 @@ export interface ComposeInput {
   // way the string is folded in right after the base charter so the
   // model treats it as preferences/context rather than hard rules.
   memoryBody?: string | undefined;
+  // Accepted style cards from the Taste profile. This is durable taste
+  // context and must be translated across media, not copied verbatim.
+  tasteProfileBody?: string | undefined;
   // Project-level metadata captured by the new-project panel. Drives the
   // agent's understanding of artifact kind, fidelity, speaker-notes intent
   // and animation intent. Missing fields here are exactly what the
@@ -78,6 +81,7 @@ export function composeSystemPrompt({
   designSystemBody,
   designSystemTitle,
   memoryBody,
+  tasteProfileBody,
   metadata,
   template,
   streamFormat,
@@ -117,6 +121,11 @@ export function composeSystemPrompt({
   if (memoryBody && memoryBody.trim().length > 0) {
     parts.push(
       `\n\n## Personal memory (auto-extracted from past chats)\n\nThe following facts have been sedimented from this user's previous conversations and edited in the settings panel. Treat them as preferences and context, NOT hard rules: when they collide with the active design system tokens, the brand wins; when they collide with the active skill's workflow, the skill wins. They are still authoritative for tone, voice, terminology, and what the user already told you about themselves and their goals — never re-ask the user about something already captured here.\n\n${memoryBody.trim()}`,
+    );
+  }
+  if (tasteProfileBody && tasteProfileBody.trim().length > 0) {
+    parts.push(
+      `\n\n## Taste profile (accepted Style cards)\n\nThese are user-accepted design taste signals. Use them as durable style context, but translate them to the selected artifact intent and medium. Do not copy source artwork, logos, protected layouts, or the original medium one-to-one.\n\n${tasteProfileBody.trim()}`,
     );
   }
 
@@ -218,6 +227,9 @@ function renderMetadataBlock(
   );
   lines.push('');
   lines.push(`- **kind**: ${metadata.kind}`);
+  appendArtifactIntentMetadata(lines, metadata);
+  appendStyleCardMetadata(lines, metadata);
+  appendPrintSpecMetadata(lines, metadata);
   if (metadata.platform) {
     lines.push(`- **platform**: ${metadata.platform}`);
   } else if (metadata.kind === 'prototype' || metadata.kind === 'template' || metadata.kind === 'other') {
@@ -437,6 +449,63 @@ function renderMetadataBlock(
   }
 
   return lines.join('\n');
+}
+
+function appendArtifactIntentMetadata(lines: string[], metadata: ProjectMetadata): void {
+  const intent = metadata.artifactIntent;
+  if (!intent) return;
+  lines.push(`- **artifactIntent**: ${intent.label} (\`${intent.id}\`)`);
+  if (intent.dimensions) {
+    const dpi = intent.dimensions.dpi ? ` @ ${intent.dimensions.dpi} DPI` : '';
+    lines.push(
+      `- **artifactDimensions**: ${intent.dimensions.width} x ${intent.dimensions.height} ${intent.dimensions.unit}${dpi}`,
+    );
+  }
+  if (intent.mediumConstraints.length > 0) {
+    lines.push(`- **artifactMediumConstraints**: ${intent.mediumConstraints.join('; ')}`);
+  }
+  if (intent.outputExpectations.length > 0) {
+    lines.push(`- **artifactOutputExpectations**: ${intent.outputExpectations.join('; ')}`);
+  }
+  lines.push(`- **printReadinessRelevant**: ${intent.printReady ? 'true' : 'false'}`);
+}
+
+function appendStyleCardMetadata(lines: string[], metadata: ProjectMetadata): void {
+  const styleCard = metadata.styleCard;
+  if (!styleCard) return;
+  lines.push(`- **styleCard**: ${styleCard.label} (\`${styleCard.id}\`, ${styleCard.source})`);
+  if (styleCard.sourceReferences?.length) {
+    lines.push(
+      `- **styleSourceReferences**: ${styleCard.sourceReferences
+        .map((ref) => `${ref.name} (\`${ref.id}\`)`)
+        .join('; ')}`,
+    );
+  }
+  lines.push(`- **styleMood**: ${styleCard.signals.mood}`);
+  lines.push(`- **styleColor**: ${styleCard.signals.color}`);
+  lines.push(`- **styleTypography**: ${styleCard.signals.typography}`);
+  lines.push(`- **styleComposition**: ${styleCard.signals.composition}`);
+  lines.push(`- **styleDensity**: ${styleCard.signals.density}`);
+  lines.push(`- **styleTransferNotes**: ${styleCard.signals.transferNotes}`);
+  if (styleCard.source === 'extracted' || styleCard.sourceReferences?.length) {
+    lines.push(
+      '- **crossMediumStyleTransferRule**: translate the extracted style signals to the selected artifact intent; do not copy source artwork, logos, protected layouts, or the original medium one-to-one.',
+    );
+  }
+}
+
+function appendPrintSpecMetadata(lines: string[], metadata: ProjectMetadata): void {
+  const spec = metadata.printSpec;
+  if (!spec) return;
+  lines.push(`- **printSpec**: ${spec.label} (\`${spec.id}\`, ${spec.source})`);
+  lines.push(`- **printColorMode**: ${spec.requirements.colorMode}`);
+  if (spec.requirements.bleedMm !== undefined) lines.push(`- **printBleedMm**: ${spec.requirements.bleedMm}`);
+  if (spec.requirements.safeAreaMm !== undefined) lines.push(`- **printSafeAreaMm**: ${spec.requirements.safeAreaMm}`);
+  if (spec.requirements.dpi !== undefined) lines.push(`- **printDpi**: ${spec.requirements.dpi}`);
+  if (spec.requirements.material) lines.push(`- **printMaterial**: ${spec.requirements.material}`);
+  if (spec.requirements.finish) lines.push(`- **printFinish**: ${spec.requirements.finish}`);
+  if (spec.checklist.length > 0) lines.push(`- **printChecklist**: ${spec.checklist.join(' | ')}`);
+  lines.push('- **basicPrintHandoffRule**: produce a Level 2.5 print handoff: final design plus explicit trim size, bleed, safe area, DPI, CMYK-compatible color notes, asset resolution notes, and vendor assumptions. Do not stop at a screen-only preview.');
 }
 
 /**

--- a/packages/contracts/src/style-cards.ts
+++ b/packages/contracts/src/style-cards.ts
@@ -1,0 +1,337 @@
+export type StyleCardId = string;
+export type StyleCardSource = 'starter' | 'reference' | 'extracted';
+export type StyleCardStatus = 'draft' | 'accepted' | 'ignored';
+
+export interface StyleCardSignals {
+  mood: string;
+  color: string;
+  typography: string;
+  composition: string;
+  density: string;
+  transferNotes: string;
+}
+
+export interface StyleCardMetadata {
+  id: StyleCardId;
+  label: string;
+  source: StyleCardSource;
+  status?: StyleCardStatus;
+  signals: StyleCardSignals;
+  parameters?: StyleCardParameterSet;
+  sourceReferences?: StyleCardReference[];
+  createdAt?: number;
+  updatedAt?: number;
+}
+
+export interface StyleCardReference {
+  id: string;
+  name: string;
+}
+
+export interface StyleCardReferenceInput extends StyleCardReference {
+  description?: string;
+  body?: string;
+}
+
+export interface StyleCardExtractionInput {
+  label?: string;
+  references: readonly StyleCardReferenceInput[];
+}
+
+export interface StyleCardParameterSet {
+  mood: {
+    keywords: string[];
+    energy: string;
+    formality: string;
+  };
+  color: {
+    palette: string[];
+    contrast: string;
+    avoid: string[];
+  };
+  typography: {
+    headline: string;
+    body: string;
+    details: string;
+  };
+  composition: {
+    grid: string;
+    focalPoint: string;
+    whitespace: string;
+  };
+  density: {
+    level: string;
+    informationPacing: string;
+  };
+  imagery: {
+    treatment: string;
+    texture: string;
+  };
+  motion: {
+    tempo: string;
+    transitions: string;
+  };
+  print: {
+    material: string;
+    finish: string;
+  };
+  transfer: {
+    notes: string;
+    constraints: string[];
+  };
+}
+
+export const STARTER_STYLE_CARDS: readonly StyleCardMetadata[] = [
+  {
+    id: 'neutral',
+    label: 'Neutral default',
+    source: 'starter',
+    signals: {
+      mood: 'clear, practical, product-appropriate',
+      color: 'balanced neutral foundation with one purposeful accent',
+      typography: 'clean system sans with strong hierarchy',
+      composition: 'predictable grid with clear focal point',
+      density: 'medium density with readable spacing',
+      transferNotes: 'adapt to the selected artifact intent without adding a strong style bias',
+    },
+  },
+  {
+    id: 'editorial-noir',
+    label: 'Editorial noir',
+    source: 'starter',
+    signals: {
+      mood: 'dramatic, refined, high-confidence',
+      color: 'black and warm white with one sharp accent',
+      typography: 'condensed editorial sans headlines with restrained body copy',
+      composition: 'asymmetric magazine-like grid with decisive scale jumps',
+      density: 'medium-high information density with deliberate whitespace',
+      transferNotes: 'use editorial contrast and hierarchy without copying a magazine cover',
+    },
+  },
+  {
+    id: 'playful-bold',
+    label: 'Playful bold',
+    source: 'starter',
+    signals: {
+      mood: 'energetic, friendly, optimistic',
+      color: 'bright primary palette with clear contrast and limited accents',
+      typography: 'rounded or geometric sans with large friendly headings',
+      composition: 'chunky modular layout with simple focal areas',
+      density: 'low-medium density with generous breathing room',
+      transferNotes: 'carry the playful rhythm across media while preserving readability',
+    },
+  },
+  {
+    id: 'premium-calm',
+    label: 'Premium calm',
+    source: 'starter',
+    signals: {
+      mood: 'quiet, polished, trustworthy',
+      color: 'muted neutrals with a restrained premium accent',
+      typography: 'elegant sans or soft serif with careful spacing',
+      composition: 'centered or balanced layout with high whitespace discipline',
+      density: 'low density and calm pacing',
+      transferNotes: 'translate the premium restraint into the target format without making it empty',
+    },
+  },
+  {
+    id: 'utility-tech',
+    label: 'Utility tech',
+    source: 'starter',
+    signals: {
+      mood: 'precise, efficient, credible',
+      color: 'cool neutral UI palette with status and action colors',
+      typography: 'system sans with optional monospace details',
+      composition: 'data-aware grid with compact modules',
+      density: 'medium-high density optimized for scanning',
+      transferNotes: 'keep the operational clarity when moving between web, print, and social formats',
+    },
+  },
+  {
+    id: 'organic-craft',
+    label: 'Organic craft',
+    source: 'starter',
+    signals: {
+      mood: 'warm, handmade, tactile',
+      color: 'earth-informed palette with natural contrast',
+      typography: 'humanist serif or relaxed sans with tactile details',
+      composition: 'soft asymmetry with material or texture cues',
+      density: 'medium density with hand-finished spacing',
+      transferNotes: 'transfer material feel and warmth without defaulting to generic beige',
+    },
+  },
+];
+
+export function findStarterStyleCard(id: StyleCardId): StyleCardMetadata {
+  return STARTER_STYLE_CARDS.find((card) => card.id === id)
+    ?? STARTER_STYLE_CARDS[0]!;
+}
+
+export function cloneStyleCardMetadata(card: StyleCardMetadata): StyleCardMetadata {
+  const next: StyleCardMetadata = {
+    ...card,
+    signals: { ...card.signals },
+  };
+  if (card.parameters) next.parameters = cloneParameters(card.parameters);
+  if (card.sourceReferences) {
+    next.sourceReferences = card.sourceReferences.map((ref) => ({ ...ref }));
+  }
+  return next;
+}
+
+export function extractStyleCardFromReferences(input: StyleCardExtractionInput): StyleCardMetadata {
+  const references = input.references.filter((ref) => ref.id && ref.name);
+  const fallbackLabel = references.length === 1
+    ? `${references[0]!.name} direction`
+    : 'Extracted style direction';
+  const label = normalizeWhitespace(input.label || fallbackLabel);
+  const text = references
+    .map((ref) => [ref.name, ref.description, ref.body].filter(Boolean).join('\n'))
+    .join('\n\n');
+  const mood = pickSignal(text, ['mood', 'feel', 'feeling', 'style', 'tone', 'atmosphere', 'vibe'], 'calm, coherent, reference-informed');
+  const color = pickSignal(text, ['color', 'colour', 'palette', '配色', '色彩'], 'palette derived from the references with controlled contrast');
+  const typography = pickSignal(text, ['typography', 'type', 'font', 'serif', 'sans', '字體', '字型'], 'typography chosen to match the reference personality');
+  const composition = pickSignal(text, ['composition', 'layout', 'grid', 'hierarchy', '版面', '構圖'], 'structured layout with a clear focal hierarchy');
+  const density = pickSignal(text, ['density', 'spacing', 'dense', 'compact', 'minimal', 'information', '留白', '密度'], 'medium density with intentional spacing');
+  const referenceNames = references.map((ref) => ref.name).join(', ');
+  const transferNotes = `Adapt signals from ${referenceNames || 'the selected references'} to the target medium without copying source artwork, logos, or protected layouts.`;
+  const parameters: StyleCardParameterSet = {
+    mood: {
+      keywords: splitSignal(mood),
+      energy: inferEnergy(mood),
+      formality: inferFormality(mood),
+    },
+    color: {
+      palette: splitSignal(color),
+      contrast: inferContrast(color),
+      avoid: [],
+    },
+    typography: {
+      headline: typography,
+      body: typography,
+      details: findDetail(text, ['uppercase', 'caption', 'microcopy', 'details']) || 'keep supporting text disciplined and readable',
+    },
+    composition: {
+      grid: composition,
+      focalPoint: findDetail(text, ['focal', 'hero', 'label', 'headline']) || 'single clear primary focal point',
+      whitespace: findDetail(text, ['whitespace', 'space', 'spacing', '留白']) || density,
+    },
+    density: {
+      level: density,
+      informationPacing: density,
+    },
+    imagery: {
+      treatment: findDetail(text, ['image', 'imagery', 'photo', 'illustration', 'texture']) || 'use imagery only when it reinforces the style signal',
+      texture: findDetail(text, ['texture', 'paper', 'material', 'foil', 'grain']) || 'no mandatory texture',
+    },
+    motion: {
+      tempo: findDetail(text, ['motion', 'animation', 'tempo']) || 'none unless the target medium is motion',
+      transitions: findDetail(text, ['transition', 'easing']) || 'keep transitions simple and style-consistent',
+    },
+    print: {
+      material: findDetail(text, ['paper', 'stock', 'material']) || 'unspecified',
+      finish: findDetail(text, ['foil', 'spot uv', 'emboss', 'finish']) || 'unspecified',
+    },
+    transfer: {
+      notes: transferNotes,
+      constraints: ['Do not copy source artwork', 'Translate style signals across media'],
+    },
+  };
+
+  const now = Date.now();
+  return {
+    id: deriveStyleCardId(label),
+    label,
+    source: 'extracted',
+    status: 'draft',
+    signals: {
+      mood,
+      color,
+      typography,
+      composition,
+      density,
+      transferNotes,
+    },
+    parameters,
+    sourceReferences: references.map((ref) => ({ id: ref.id, name: ref.name })),
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function cloneParameters(parameters: StyleCardParameterSet): StyleCardParameterSet {
+  return {
+    mood: { ...parameters.mood, keywords: [...parameters.mood.keywords] },
+    color: { ...parameters.color, palette: [...parameters.color.palette], avoid: [...parameters.color.avoid] },
+    typography: { ...parameters.typography },
+    composition: { ...parameters.composition },
+    density: { ...parameters.density },
+    imagery: { ...parameters.imagery },
+    motion: { ...parameters.motion },
+    print: { ...parameters.print },
+    transfer: { ...parameters.transfer, constraints: [...parameters.transfer.constraints] },
+  };
+}
+
+function deriveStyleCardId(label: string): string {
+  const slug = normalizeWhitespace(label)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 64);
+  return `style_${slug || 'extracted_direction'}`;
+}
+
+function normalizeWhitespace(value: string): string {
+  return String(value || '').replace(/\s+/g, ' ').trim();
+}
+
+function pickSignal(text: string, keywords: readonly string[], fallback: string): string {
+  const lines = text
+    .split(/\r?\n/)
+    .map((line) => normalizeWhitespace(line.replace(/^[-*]\s*/, '')))
+    .filter(Boolean);
+  for (const keyword of keywords) {
+    const lowerKeyword = keyword.toLowerCase();
+    const match = lines.find((line) => line.toLowerCase().includes(lowerKeyword));
+    if (match) return stripSignalPrefix(match);
+  }
+  return fallback;
+}
+
+function stripSignalPrefix(line: string): string {
+  return normalizeWhitespace(line.replace(/^[A-Za-z ]{2,24}[:：]\s*/, ''));
+}
+
+function splitSignal(signal: string): string[] {
+  return signal
+    .split(/[,;/]| and /i)
+    .map((part) => normalizeWhitespace(part))
+    .filter(Boolean)
+    .slice(0, 8);
+}
+
+function findDetail(text: string, keywords: readonly string[]): string {
+  return pickSignal(text, keywords, '');
+}
+
+function inferEnergy(mood: string): string {
+  const lower = mood.toLowerCase();
+  if (/(bold|energetic|dynamic|playful|loud)/.test(lower)) return 'high';
+  if (/(calm|quiet|minimal|serene|soft)/.test(lower)) return 'low';
+  return 'medium';
+}
+
+function inferFormality(mood: string): string {
+  const lower = mood.toLowerCase();
+  if (/(premium|editorial|luxury|formal|refined)/.test(lower)) return 'formal';
+  if (/(playful|casual|friendly)/.test(lower)) return 'casual';
+  return 'neutral';
+}
+
+function inferContrast(color: string): string {
+  const lower = color.toLowerCase();
+  if (/(black|white|sharp|high contrast)/.test(lower)) return 'high';
+  if (/(muted|soft|low contrast|pastel)/.test(lower)) return 'low-medium';
+  return 'medium';
+}

--- a/packages/contracts/tests/artifact-intents.test.ts
+++ b/packages/contracts/tests/artifact-intents.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ARTIFACT_INTENT_GROUPS,
+  INITIAL_ARTIFACT_INTENTS,
+} from '../src/artifact-intents';
+
+describe('artifact intent catalog', () => {
+  it('covers every first-class guided creation group', () => {
+    expect(ARTIFACT_INTENT_GROUPS.map((group) => group.id)).toEqual([
+      'social',
+      'ads-marketing',
+      'web-app',
+      'brand-identity',
+      'documents',
+      'presentations',
+      'print-products',
+      'packaging',
+      'merchandise',
+      'signage',
+      'video-motion',
+      'custom',
+    ]);
+
+    for (const group of ARTIFACT_INTENT_GROUPS) {
+      expect(
+        INITIAL_ARTIFACT_INTENTS.some((intent) => intent.group === group.id),
+      ).toBe(true);
+    }
+  });
+
+  it('keeps every intent generation-ready with defaults', () => {
+    expect(INITIAL_ARTIFACT_INTENTS.length).toBeGreaterThan(30);
+
+    for (const intent of INITIAL_ARTIFACT_INTENTS) {
+      expect(intent.id).toBeTruthy();
+      expect(intent.label).toBeTruthy();
+      expect(intent.defaultKind).toBeTruthy();
+      expect(intent.defaultPlatformTargets.length).toBeGreaterThan(0);
+      expect(intent.mediumConstraints.length).toBeGreaterThan(0);
+      expect(intent.outputExpectations.length).toBeGreaterThan(0);
+      if (intent.id !== 'custom-size' && intent.id !== 'uploaded-spec') {
+        expect(intent.dimensions).toBeTruthy();
+      }
+    }
+  });
+});

--- a/packages/contracts/tests/print-specs.test.ts
+++ b/packages/contracts/tests/print-specs.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildPrintSpecMetadata } from '../src/print-specs';
+
+describe('print specs', () => {
+  it('extracts print handoff requirements from vendor text', () => {
+    const spec = buildPrintSpecMetadata({
+      label: 'Business card vendor spec',
+      text: [
+        'CMYK only',
+        'Bleed: 3mm',
+        'Safe area: 2mm',
+        '300 DPI',
+        'Paper stock: 350gsm matte',
+        'Finish: spot UV logo',
+      ].join('\n'),
+    });
+
+    expect(spec).toMatchObject({
+      id: 'print_business_card_vendor_spec',
+      requirements: {
+        colorMode: 'cmyk-compatible',
+        bleedMm: 3,
+        safeAreaMm: 2,
+        dpi: 300,
+      },
+    });
+    expect(spec?.checklist).toEqual(expect.arrayContaining([
+      'Use CMYK-compatible colors and avoid relying on screen-only RGB glow.',
+      'Extend backgrounds 3mm into bleed.',
+      'Prepare raster assets at 300 DPI or higher.',
+    ]));
+  });
+});

--- a/packages/contracts/tests/style-cards.test.ts
+++ b/packages/contracts/tests/style-cards.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  STARTER_STYLE_CARDS,
+  extractStyleCardFromReferences,
+} from '../src/style-cards';
+
+describe('starter style cards', () => {
+  it('ships a neutral option and opinionated starter directions', () => {
+    expect(STARTER_STYLE_CARDS.length).toBeGreaterThanOrEqual(5);
+    expect(STARTER_STYLE_CARDS[0]?.id).toBe('neutral');
+    expect(STARTER_STYLE_CARDS.map((card) => card.id)).toContain('editorial-noir');
+  });
+
+  it('keeps each starter card generation-ready with six novice-facing signals', () => {
+    for (const card of STARTER_STYLE_CARDS) {
+      expect(card.label).toBeTruthy();
+      expect(card.signals.mood).toBeTruthy();
+      expect(card.signals.color).toBeTruthy();
+      expect(card.signals.typography).toBeTruthy();
+      expect(card.signals.composition).toBeTruthy();
+      expect(card.signals.density).toBeTruthy();
+      expect(card.signals.transferNotes).toBeTruthy();
+    }
+  });
+
+  it('extracts an editable style card proposal from reference notes', () => {
+    const card = extractStyleCardFromReferences({
+      label: 'Premium tea packaging direction',
+      references: [
+        {
+          id: 'reference_tea_packaging',
+          name: 'Tea packaging reference',
+          description: 'Quiet premium packaging with foil label hierarchy',
+          body: [
+            '- Mood: calm, premium, editorial',
+            '- Color palette: deep green, ivory, muted gold foil',
+            '- Typography: elegant serif headline with tiny uppercase details',
+            '- Composition: centered label grid with generous whitespace',
+            '- Density: low density front, detailed information on back',
+          ].join('\n'),
+        },
+      ],
+    });
+
+    expect(card).toMatchObject({
+      id: 'style_premium_tea_packaging_direction',
+      label: 'Premium tea packaging direction',
+      source: 'extracted',
+      status: 'draft',
+      signals: {
+        mood: expect.stringContaining('calm'),
+        color: expect.stringContaining('deep green'),
+        typography: expect.stringContaining('serif'),
+        composition: expect.stringContaining('centered'),
+        density: expect.stringContaining('low density'),
+      },
+    });
+    expect(card.sourceReferences).toEqual([
+      { id: 'reference_tea_packaging', name: 'Tea packaging reference' },
+    ]);
+    expect(card.parameters?.color?.palette).toContain('deep green');
+  });
+});

--- a/packages/contracts/tests/system-prompt-api-mode.test.ts
+++ b/packages/contracts/tests/system-prompt-api-mode.test.ts
@@ -92,4 +92,39 @@ describe('composeSystemPrompt — API mode (#313)', () => {
       expect(prompt).toMatch(/<artifact>/);
     });
   });
+
+  it('includes accepted taste profile and cross-medium style transfer guidance', () => {
+    const prompt = composeSystemPrompt({
+      tasteProfileBody: [
+        '## Taste profile',
+        '- **Premium packaging direction** (`style_premium_packaging_direction`)',
+        '  - Color: deep green, ivory, muted gold foil',
+        '  - Transfer: Adapt these accepted style signals across media.',
+      ].join('\n'),
+      metadata: {
+        kind: 'prototype',
+        styleCard: {
+          id: 'style_premium_packaging_direction',
+          label: 'Premium packaging direction',
+          source: 'extracted',
+          signals: {
+            mood: 'premium, confident',
+            color: 'deep green, ivory, muted gold foil',
+            typography: 'elegant serif',
+            composition: 'centered label grid',
+            density: 'low density',
+            transferNotes: 'Adapt packaging signals without copying source art.',
+          },
+          sourceReferences: [
+            { id: 'reference_packaging_ref', name: 'Packaging reference' },
+          ],
+        },
+      } as any,
+    });
+
+    expect(prompt).toContain('## Taste profile');
+    expect(prompt).toContain('deep green, ivory, muted gold foil');
+    expect(prompt).toContain('- **styleSourceReferences**: Packaging reference (`reference_packaging_ref`)');
+    expect(prompt).toContain('- **crossMediumStyleTransferRule**: translate the extracted style signals to the selected artifact intent; do not copy source artwork, logos, protected layouts, or the original medium one-to-one.');
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@open-design/sidecar-proto':
         specifier: workspace:*
         version: link:../../packages/sidecar-proto
+      '@sentry/node':
+        specifier: ^10.63.0
+        version: 10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))
       better-sqlite3:
         specifier: ^12.9.0
         version: 12.9.0
@@ -83,7 +86,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@20.19.39)(jsdom@29.1.1)
+        version: 2.1.9(@types/node@20.19.39)(jsdom@29.1.1)(terser@5.48.0)
 
   apps/desktop:
     dependencies:
@@ -108,7 +111,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@24.12.2)(jsdom@29.1.1)
+        version: 2.1.9(@types/node@24.12.2)(jsdom@29.1.1)(terser@5.48.0)
 
   apps/landing-page:
     dependencies:
@@ -117,7 +120,7 @@ importers:
         version: 3.7.2
       astro:
         specifier: ^5.15.4
-        version: 5.18.1(@types/node@20.19.39)(jiti@2.6.1)(rollup@4.60.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)
+        version: 5.18.1(@types/node@20.19.39)(jiti@2.6.1)(rollup@4.62.2)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -176,7 +179,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@24.12.2)(jsdom@29.1.1)
+        version: 2.1.9(@types/node@24.12.2)(jsdom@29.1.1)(terser@5.48.0)
 
   apps/telemetry-worker:
     dependencies:
@@ -189,7 +192,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@24.12.2)(jsdom@29.1.1)
+        version: 2.1.9(@types/node@24.12.2)(jsdom@29.1.1)(terser@5.48.0)
 
   apps/web:
     dependencies:
@@ -208,9 +211,12 @@ importers:
       '@open-design/sidecar-proto':
         specifier: workspace:*
         version: link:../../packages/sidecar-proto
+      '@sentry/nextjs':
+        specifier: ^10.63.0
+        version: 10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.5(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.108.3)
       next:
         specifier: ^16.2.5
-        version: 16.2.5(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 16.2.5(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       openai:
         specifier: ^6.36.0
         version: 6.36.0(zod@4.4.2)
@@ -244,7 +250,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@20.19.39)(jsdom@29.1.0)
+        version: 2.1.9(@types/node@20.19.39)(jsdom@29.1.0)(terser@5.48.0)
 
   e2e:
     devDependencies:
@@ -262,7 +268,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@20.19.39)(jsdom@29.1.1)
+        version: 2.1.9(@types/node@20.19.39)(jsdom@29.1.1)(terser@5.48.0)
 
   packages/contracts:
     dependencies:
@@ -278,7 +284,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@24.12.2)(jsdom@29.1.1)
+        version: 2.1.9(@types/node@24.12.2)(jsdom@29.1.1)(terser@5.48.0)
 
   packages/platform:
     devDependencies:
@@ -293,7 +299,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@24.12.2)(jsdom@29.1.1)
+        version: 2.1.9(@types/node@24.12.2)(jsdom@29.1.1)(terser@5.48.0)
 
   packages/sidecar:
     devDependencies:
@@ -308,7 +314,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@24.12.2)(jsdom@29.1.1)
+        version: 2.1.9(@types/node@24.12.2)(jsdom@29.1.1)(terser@5.48.0)
 
   packages/sidecar-proto:
     devDependencies:
@@ -323,7 +329,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@24.12.2)(jsdom@29.1.1)
+        version: 2.1.9(@types/node@24.12.2)(jsdom@29.1.1)(terser@5.48.0)
 
   tools/dev:
     dependencies:
@@ -391,7 +397,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@24.12.2)(jsdom@29.1.1)
+        version: 2.1.9(@types/node@24.12.2)(jsdom@29.1.1)(terser@5.48.0)
 
   tools/pr:
     dependencies:
@@ -419,6 +425,17 @@ packages:
 
   '@anthropic-ai/sdk@0.32.1':
     resolution: {integrity: sha512-U9JwTrDvdQ9iWuABVsMLj8nJVwAyQz6QXvgLsVhryhCEPkLsbcP/MXxm+jYcAwLoV8ESbaTTjnD4kuAFa+Hyjg==}
+
+  '@apm-js-collab/code-transformer-bundler-plugins@0.5.0':
+    resolution: {integrity: sha512-YxLBY5nGlurL7QeJLq6e5g0ouBpAp0pwgyA/5rHXEXwhiPLn9ZHbT+Y2LlP90GT872cSocfjWRYu/fnpuBudNQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@apm-js-collab/code-transformer@0.15.0':
+    resolution: {integrity: sha512-XmXYVs8CzJ1Aj79noVbn2weUO/XWtRyURpGqx7aU7DOXlUQhR0WKOQNF0okh7PCeY37vxf7kU3v57OAkEPm3ww==}
+    hasBin: true
+
+  '@apm-js-collab/tracing-hooks@0.10.1':
+    resolution: {integrity: sha512-w2OWXR7FWrKqSziuE9+QclaZrStxO/8+OwbXM635s/zs0Eez1Qo3ivSPdB2WsaPY/iznKTytONPx/PitD7IXcA==}
 
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
@@ -480,12 +497,62 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/parser@7.29.3':
@@ -493,12 +560,29 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@bramus/specificity@2.4.2':
@@ -1239,8 +1323,24 @@ packages:
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/source-map@0.3.11':
+    resolution: {integrity: sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@malept/cross-spawn-promise@2.0.0':
     resolution: {integrity: sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==}
@@ -1315,9 +1415,47 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@opentelemetry/api-logs@0.214.0':
+    resolution: {integrity: sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@2.9.0':
+    resolution: {integrity: sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/instrumentation@0.214.0':
+    resolution: {integrity: sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.9.0':
+    resolution: {integrity: sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.9.0':
+    resolution: {integrity: sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace@2.9.0':
+    resolution: {integrity: sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.41.1':
+    resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
+    engines: {node: '>=14'}
 
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
@@ -1326,6 +1464,15 @@ packages:
     resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@rollup/plugin-commonjs@28.0.1':
+    resolution: {integrity: sha512-+tNWdlWKbpB3WgBN7ijjYkq9X5uhjmcvyjEght4NmH5fAU++zfQzAJ6wumLS+dNcvwEZhKx2Z+skY8m7v0wGSA==}
+    engines: {node: '>=16.0.0 || 14 >= 14.17'}
+    peerDependencies:
+      rollup: ^2.68.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
 
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
@@ -1341,8 +1488,18 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
+    cpu: [arm]
+    os: [android]
+
   '@rollup/rollup-android-arm64@4.60.2':
     resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
     cpu: [arm64]
     os: [android]
 
@@ -1351,8 +1508,18 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rollup/rollup-darwin-x64@4.60.2':
     resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
     cpu: [x64]
     os: [darwin]
 
@@ -1361,13 +1528,29 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@rollup/rollup-freebsd-x64@4.60.2':
     resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
     cpu: [x64]
     os: [freebsd]
 
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
+    cpu: [x64]
+    os: [freebsd]
+
   '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
@@ -1378,8 +1561,20 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -1390,8 +1585,20 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
@@ -1402,8 +1609,20 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
@@ -1414,8 +1633,20 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
@@ -1426,8 +1657,20 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
@@ -1438,8 +1681,20 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -1449,8 +1704,18 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
+    cpu: [x64]
+    os: [openbsd]
+
   '@rollup/rollup-openharmony-arm64@4.60.2':
     resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
     cpu: [arm64]
     os: [openharmony]
 
@@ -1459,8 +1724,18 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
+    cpu: [arm64]
+    os: [win32]
+
   '@rollup/rollup-win32-ia32-msvc@4.60.2':
     resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==}
     cpu: [ia32]
     os: [win32]
 
@@ -1469,10 +1744,88 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
+    cpu: [x64]
+    os: [win32]
+
   '@rollup/rollup-win32-x64-msvc@4.60.2':
     resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
     cpu: [x64]
     os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@sentry/babel-plugin-component-annotate@5.3.0':
+    resolution: {integrity: sha512-p4q8gn8wcFqZGP/s2MnJCAAd8fTikaU6A0mM97RDHQgStcrYiaS0Sc5zUNfb1V+UOLPuvdEdL6MwyxfzjYJQTA==}
+    engines: {node: '>= 18'}
+
+  '@sentry/browser-utils@10.63.0':
+    resolution: {integrity: sha512-DhUGNN+CH8fzAs6qAsueKPU70qShyTX3NxLhIP+l5DbGXDSXpYXBT6s8ubZus0/LhxpLvI0iSyNIDvZRD/gZaA==}
+    engines: {node: '>=18'}
+
+  '@sentry/browser@10.63.0':
+    resolution: {integrity: sha512-0mi56YOkwgyjdLOcN5cB1//EcYzEOt3NZ2GLygE92B3zAAwVM1WgbmibZCXToKFClH7z1uH3VWVfBffmkwIMYw==}
+    engines: {node: '>=18'}
+
+  '@sentry/bundler-plugin-core@5.3.0':
+    resolution: {integrity: sha512-L5T60sWdAI3qWwdg3Ptwek/0TY59PERrxyqp4XMUkroayQvGd9r5dIW9Q1kSeXX9iJ442nXbFZKAOyCKV4Z13Q==}
+    engines: {node: '>= 18'}
+
+  '@sentry/cli-darwin@2.58.6':
+    resolution: {integrity: sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==}
+    engines: {node: '>=10'}
+    os: [darwin]
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    resolution: {integrity: sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-arm@2.58.6':
+    resolution: {integrity: sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-i686@2.58.6':
+    resolution: {integrity: sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-x64@2.58.6':
+    resolution: {integrity: sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    resolution: {integrity: sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@sentry/cli-win32-i686@2.58.6':
+    resolution: {integrity: sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [win32]
+
+  '@sentry/cli-win32-x64@2.58.6':
+    resolution: {integrity: sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@sentry/cli@2.58.6':
+    resolution: {integrity: sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==}
+    engines: {node: '>= 10'}
+    hasBin: true
 
   '@sentry/cloudflare@10.63.0':
     resolution: {integrity: sha512-no7bfrBqO3Niy+3vEqktYrNoTtBJtlJxpnTutmpSz55x+ytpNj+1YUUUbJRFctttDuPe38/+c6m1FwXGQg074A==}
@@ -1483,9 +1836,84 @@ packages:
       '@cloudflare/workers-types':
         optional: true
 
+  '@sentry/conventions@0.12.0':
+    resolution: {integrity: sha512-z1JQrl/1SLY+8wpzvork6vl+fpsg/oCCxM7HWWhUnI/R+OGNyoIzieQuggX3uUMY7NBtp8UWCQx6FeFazzOF9g==}
+    engines: {node: '>=14'}
+
   '@sentry/core@10.63.0':
     resolution: {integrity: sha512-OtUbsrnbEHffOF2S2+M5zXa3HIM0U2b4CDVLKMY1dgS0J3ivRF8XvkjvyIcEG/y8JXnwXbnprLyjhG+AqMdUZQ==}
     engines: {node: '>=18'}
+
+  '@sentry/feedback@10.63.0':
+    resolution: {integrity: sha512-If/+72xFg9ylz4twUo3U9gUpZ+Ys+T/3Y09WH7r2gGhWEOF9bp+ta94+Pg7Lb0M2nVD7waz4OxIvB49GEvtLDA==}
+    engines: {node: '>=18'}
+
+  '@sentry/nextjs@10.63.0':
+    resolution: {integrity: sha512-SN3tBm+wpDmr4GONaxuIRjQglAiPBKF7JEsQlli1HNfar1JG+fRsxWy0/aKcn9Kp/XX1kOpFgW9tcfuE4UKm7Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      next: ^13.2.0 || ^14.0 || ^15.0.0-rc.0 || ^16.0.0-0
+
+  '@sentry/node-core@10.63.0':
+    resolution: {integrity: sha512-TaNtkGDRNxH3SjOea2PDtaebkNjMbAH8ZFsEcwlqmadpS7nqSR7z6slZy/iu7y1nLiUdbmcM5JmXwxksy52WRQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/exporter-trace-otlp-http': '>=0.57.0 <1'
+      '@opentelemetry/instrumentation': '>=0.57.1 <1'
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/core':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-http':
+        optional: true
+      '@opentelemetry/instrumentation':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+
+  '@sentry/node@10.63.0':
+    resolution: {integrity: sha512-E+JfDTdUDGQPRsAfCTR2YgmQgxYdoxk4ks6niHN+ByW8alEZL+nXlcN9vI57qj1LsS4v2jjfLxJf1/cMMt84YA==}
+    engines: {node: '>=18'}
+
+  '@sentry/opentelemetry@10.63.0':
+    resolution: {integrity: sha512-8yqi8+Ej/anmMn82blXA0BNMeAMs4av6nx0DzhxDrFya28ZaYOn19PChd3erMidfU0HnLLFNqWiFlYxBKq+/KA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+
+  '@sentry/react@10.63.0':
+    resolution: {integrity: sha512-+/Y0dd4EMqyqYBJ1D3bAYYuG+ccIx5+IFcbTZ9p+XWnW6nNIVjy5zttVftYo6xOmtTQbzRuPT/vO4dqDHKKmfw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.14.0 || 17.x || 18.x || 19.x
+
+  '@sentry/replay-canvas@10.63.0':
+    resolution: {integrity: sha512-1Dg6yo+KDNZcE9M6V2EP4DGgTDJMcUgg5ui69w/E96ZZPWErS/bibK2bGj20H3qwpJXlnEwXB5YAJ2fZ620T1A==}
+    engines: {node: '>=18'}
+
+  '@sentry/replay@10.63.0':
+    resolution: {integrity: sha512-u4fDaLbd4QmJbU0qGzV5g2B2hjw5utdeZzpTrmq565AS5o6mfaZdCz30zF9R2Unkn0g9SJr90piTN2RMwvDrkw==}
+    engines: {node: '>=18'}
+
+  '@sentry/server-utils@10.63.0':
+    resolution: {integrity: sha512-7NN//DG9Yak8t2+6WiEcNmN269iHRVdtZtZIwucEd0OXyZ3FEBBDaBF+bT9V6H/kPtUvVMkHQ72Bn2Xs5JYGxg==}
+    engines: {node: '>=18'}
+
+  '@sentry/vercel-edge@10.63.0':
+    resolution: {integrity: sha512-6vay7/Skgjt1SiDchobaN7mOeSDRwhQUikVvuT7Q/0nX5Xg5TRlSMbqwcllqKxwDXdJiW3MVdqqLixY1c8WjJA==}
+    engines: {node: '>=18'}
+
+  '@sentry/webpack-plugin@5.3.0':
+    resolution: {integrity: sha512-i3OQUrS0FZlXLgq57RIKDp+vHHzuvYKPCKewAPXULWKMsBXFGhP6veGRQ+6To/pmZkkXjEX5ofVNDy9C3jEPKQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      webpack: '>=5.0.0'
 
   '@shikijs/core@3.23.0':
     resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
@@ -1559,6 +1987,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
   '@types/express-serve-static-core@4.19.8':
     resolution: {integrity: sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==}
 
@@ -1579,6 +2010,9 @@ packages:
 
   '@types/jsdom@28.0.1':
     resolution: {integrity: sha512-GJq2QE4TAZ5ajSoCasn5DOFm8u1mI3tIFvM5tIq3W5U/RTB6gsHwc6Yhpl91X9VSDOUVblgXmG+2+sSvFQrdlw==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/keyv@3.1.4':
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
@@ -1659,6 +2093,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
@@ -1715,6 +2150,51 @@ packages:
   '@vscode/l10n@0.0.18':
     resolution: {integrity: sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==}
 
+  '@webassemblyjs/ast@1.14.1':
+    resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
+
+  '@webassemblyjs/floating-point-hex-parser@1.13.2':
+    resolution: {integrity: sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==}
+
+  '@webassemblyjs/helper-api-error@1.13.2':
+    resolution: {integrity: sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==}
+
+  '@webassemblyjs/helper-buffer@1.14.1':
+    resolution: {integrity: sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==}
+
+  '@webassemblyjs/helper-numbers@1.13.2':
+    resolution: {integrity: sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==}
+
+  '@webassemblyjs/helper-wasm-bytecode@1.13.2':
+    resolution: {integrity: sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==}
+
+  '@webassemblyjs/helper-wasm-section@1.14.1':
+    resolution: {integrity: sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==}
+
+  '@webassemblyjs/ieee754@1.13.2':
+    resolution: {integrity: sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==}
+
+  '@webassemblyjs/leb128@1.13.2':
+    resolution: {integrity: sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==}
+
+  '@webassemblyjs/utf8@1.13.2':
+    resolution: {integrity: sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==}
+
+  '@webassemblyjs/wasm-edit@1.14.1':
+    resolution: {integrity: sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==}
+
+  '@webassemblyjs/wasm-gen@1.14.1':
+    resolution: {integrity: sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==}
+
+  '@webassemblyjs/wasm-opt@1.14.1':
+    resolution: {integrity: sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==}
+
+  '@webassemblyjs/wasm-parser@1.14.1':
+    resolution: {integrity: sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==}
+
+  '@webassemblyjs/wast-printer@1.14.1':
+    resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
+
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
@@ -1722,6 +2202,12 @@ packages:
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+
+  '@xtuc/ieee754@1.2.0':
+    resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
+
+  '@xtuc/long@4.2.2':
+    resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
 
   abbrev@4.0.0:
     resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
@@ -1739,10 +2225,25 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
+  acorn-import-attributes@1.9.5:
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
+
+  acorn-import-phases@1.0.4:
+    resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
+    engines: {node: '>=10.13.0'}
+    peerDependencies:
+      acorn: ^8.14.0
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -1760,6 +2261,14 @@ packages:
       ajv:
         optional: true
 
+  ajv-formats@2.1.1:
+    resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
@@ -1772,6 +2281,11 @@ packages:
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
     peerDependencies:
       ajv: ^6.9.1
+
+  ajv-keywords@5.1.0:
+    resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
+    peerDependencies:
+      ajv: ^8.8.2
 
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
@@ -1850,6 +2364,10 @@ packages:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
 
+  astring@1.9.0:
+    resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
+    hasBin: true
+
   astro@5.18.1:
     resolution: {integrity: sha512-m4VWilWZ+Xt6NPoYzC4CgGZim/zQUO7WFL0RHCH0AiEavF1153iC3+me2atDvXpf/yX4PyGUeD8wZLq1cirT3g==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0'}
@@ -1891,6 +2409,11 @@ packages:
 
   baseline-browser-mapping@2.10.23:
     resolution: {integrity: sha512-xwVXGqevyKPsiuQdLj+dZMVjidjJV508TBqexND5HrF89cGdCYCJFB3qhcxRHSeMctdCfbR1jrxBajhDy7o29g==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  baseline-browser-mapping@2.10.41:
+    resolution: {integrity: sha512-WwS7MHhqGHHlaVsqRZnhvCEMS0owDX+SxRlve7JkuH7My1Ara3ZriTmCQupPfYjxMZ8I/tgxtJYr2t7taHaH4A==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1938,6 +2461,11 @@ packages:
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
+
+  browserslist@4.28.4:
+    resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
 
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
@@ -1990,6 +2518,9 @@ packages:
   caniuse-lite@1.0.30001791:
     resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
 
+  caniuse-lite@1.0.30001800:
+    resolution: {integrity: sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==}
+
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
@@ -2033,6 +2564,10 @@ packages:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
 
+  chrome-trace-event@1.0.4:
+    resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
+    engines: {node: '>=6.0'}
+
   chromium-pickle-js@0.2.0:
     resolution: {integrity: sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==}
 
@@ -2043,6 +2578,9 @@ packages:
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
+
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
 
   cli-boxes@3.0.0:
     resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
@@ -2084,6 +2622,9 @@ packages:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
 
+  commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
   commander@5.1.0:
     resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
     engines: {node: '>= 6'}
@@ -2094,6 +2635,9 @@ packages:
 
   common-ancestor-path@1.0.1:
     resolution: {integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==}
+
+  commondir@1.0.1:
+    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
 
   compare-version@0.1.2:
     resolution: {integrity: sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==}
@@ -2117,6 +2661,9 @@ packages:
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie-es@1.2.3:
     resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
@@ -2346,6 +2893,9 @@ packages:
   electron-publish@26.8.1:
     resolution: {integrity: sha512-q+jrSTIh/Cv4eGZa7oVR+grEJo/FoLMYBAnSL5GCtqwUpr1T+VgKB/dn1pnzxIxqD8S/jP1yilT9VrwCqINR4w==}
 
+  electron-to-chromium@1.5.385:
+    resolution: {integrity: sha512-78sa/M08MNAYHQfjoWMvOlKQqZ0ElhSm/L5HNUc96VZ3b+KvDVnngFm8sYQy0XrhTRgAhggHr5abA7yTvRdo4Q==}
+
   electron-winstaller@5.4.0:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
@@ -2370,6 +2920,10 @@ packages:
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  enhanced-resolve@5.24.1:
+    resolution: {integrity: sha512-7DdUaTjmNwMcH2gLr1qycesKII3BK4RLy/mdAb7x10Lq7bR4aNKHt1BR1ZALSv0rPM/hF5wYF0PhGop/rJm8vw==}
+    engines: {node: '>=10.13.0'}
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
@@ -2400,6 +2954,9 @@ packages:
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-module-lexer@2.3.0:
+    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -2442,6 +2999,26 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
+  eslint-scope@5.1.1:
+    resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
+    engines: {node: '>=8.0.0'}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@4.3.0:
+    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
@@ -2458,6 +3035,10 @@ packages:
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
 
   eventsource-parser@3.0.8:
     resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
@@ -2539,6 +3120,10 @@ packages:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
 
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
   flattie@1.1.1:
     resolution: {integrity: sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==}
     engines: {node: '>=8'}
@@ -2612,6 +3197,10 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -2640,6 +3229,10 @@ packages:
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -2749,6 +3342,10 @@ packages:
     resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
     engines: {node: '>=10.19.0'}
 
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
@@ -2778,6 +3375,10 @@ packages:
 
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
+  import-in-the-middle@3.2.0:
+    resolution: {integrity: sha512-vR2B6HKIhaBjcZr2bLpFiJ1VbzOlRQ7aby4/gw5WPIzToLjqpfWw3VJ4sk1uDchoOODEirvO2jyrSPtUSL5CrQ==}
+    engines: {node: '>=18'}
 
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
@@ -2827,6 +3428,9 @@ packages:
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
+  is-reference@1.2.1:
+    resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
+
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
@@ -2857,6 +3461,10 @@ packages:
     resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  jest-worker@27.5.1:
+    resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
+    engines: {node: '>= 10.13.0'}
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
@@ -2889,6 +3497,11 @@ packages:
     peerDependenciesMeta:
       canvas:
         optional: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -2942,6 +3555,14 @@ packages:
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
+  loader-runner@4.3.2:
+    resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
+    engines: {node: '>=6.11.5'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
@@ -2962,6 +3583,9 @@ packages:
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
     engines: {node: 20 || >=22}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
@@ -3047,6 +3671,13 @@ packages:
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
+
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  meriyah@6.1.4:
+    resolution: {integrity: sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==}
+    engines: {node: '>=18.0.0'}
 
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -3188,6 +3819,49 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  minimizer-webpack-plugin@5.6.1:
+    resolution: {integrity: sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@minify-html/node': '*'
+      '@swc/core': '*'
+      '@swc/css': '*'
+      '@swc/html': '*'
+      clean-css: '*'
+      cssnano: '*'
+      csso: '*'
+      esbuild: '*'
+      html-minifier-terser: '*'
+      lightningcss: '*'
+      postcss: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@minify-html/node':
+        optional: true
+      '@swc/core':
+        optional: true
+      '@swc/css':
+        optional: true
+      '@swc/html':
+        optional: true
+      clean-css:
+        optional: true
+      cssnano:
+        optional: true
+      csso:
+        optional: true
+      esbuild:
+        optional: true
+      html-minifier-terser:
+        optional: true
+      lightningcss:
+        optional: true
+      postcss:
+        optional: true
+      uglify-js:
+        optional: true
+
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -3202,6 +3876,9 @@ packages:
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -3235,6 +3912,9 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  neo-async@2.6.2:
+    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
   neotraverse@0.6.18:
     resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
@@ -3302,6 +3982,10 @@ packages:
 
   node-mock-http@1.0.4:
     resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
+
+  node-releases@2.0.50:
+    resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
+    engines: {node: '>=18'}
 
   nopt@9.0.0:
     resolution: {integrity: sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==}
@@ -3374,6 +4058,10 @@ packages:
     resolution: {integrity: sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==}
     engines: {node: '>=18'}
 
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
   p-queue@8.1.1:
     resolution: {integrity: sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==}
     engines: {node: '>=18'}
@@ -3404,6 +4092,10 @@ packages:
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
@@ -3411,6 +4103,10 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-to-regexp@0.1.13:
     resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
@@ -3528,6 +4224,9 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
@@ -3649,6 +4348,10 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
+
   resedit@1.7.2:
     resolution: {integrity: sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==}
     engines: {node: '>=12', npm: '>=6'}
@@ -3692,6 +4395,11 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rollup@4.62.2:
+    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
@@ -3718,6 +4426,13 @@ packages:
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  schema-utils@4.3.3:
+    resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
+    engines: {node: '>= 10.13.0'}
+
+  semifies@1.0.0:
+    resolution: {integrity: sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==}
 
   semver-compare@1.0.0:
     resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
@@ -3848,6 +4563,10 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  stacktrace-parser@0.1.11:
+    resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
+    engines: {node: '>=6'}
+
   stat-mode@1.0.0:
     resolution: {integrity: sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==}
     engines: {node: '>= 6'}
@@ -3916,6 +4635,10 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
   svgo@4.0.1:
     resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
     engines: {node: '>=16'}
@@ -3923,6 +4646,10 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
 
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
@@ -3941,6 +4668,11 @@ packages:
   temp@0.9.4:
     resolution: {integrity: sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==}
     engines: {node: '>=6.0.0'}
+
+  terser@5.48.0:
+    resolution: {integrity: sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   tiny-async-pool@1.3.0:
     resolution: {integrity: sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==}
@@ -4015,6 +4747,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -4036,6 +4769,10 @@ packages:
   type-fest@0.13.1:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
     engines: {node: '>=10'}
+
+  type-fest@0.7.1:
+    resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
+    engines: {node: '>=8'}
 
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
@@ -4203,6 +4940,12 @@ packages:
         optional: true
       uploadthing:
         optional: true
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -4439,6 +5182,10 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
+  watchpack@2.5.2:
+    resolution: {integrity: sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==}
+    engines: {node: '>=10.13.0'}
+
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
@@ -4452,6 +5199,20 @@ packages:
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
+
+  webpack-sources@3.5.0:
+    resolution: {integrity: sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==}
+    engines: {node: '>=10.13.0'}
+
+  webpack@5.108.3:
+    resolution: {integrity: sha512-hOpaCHmQVVY66IVTjofnH14IgSdmod2aquSGHGuYig/OIdWge01Hk2Wt988DZcwXumFUT4+FvJY5N+ikl8o/ww==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
 
   whatwg-mimetype@5.0.0:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
@@ -4520,6 +5281,9 @@ packages:
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
@@ -4604,6 +5368,30 @@ snapshots:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
+
+  '@apm-js-collab/code-transformer-bundler-plugins@0.5.0':
+    dependencies:
+      '@apm-js-collab/code-transformer': 0.15.0
+      es-module-lexer: 2.3.0
+      magic-string: 0.30.21
+      module-details-from-path: 1.0.4
+
+  '@apm-js-collab/code-transformer@0.15.0':
+    dependencies:
+      '@types/estree': 1.0.8
+      astring: 1.9.0
+      esquery: 1.7.0
+      meriyah: 6.1.4
+      semifies: 1.0.0
+      source-map: 0.6.1
+
+  '@apm-js-collab/tracing-hooks@0.10.1':
+    dependencies:
+      '@apm-js-collab/code-transformer': 0.15.0
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -4723,20 +5511,120 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.4
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.3':
     dependencies:
       '@babel/types': 7.29.0
 
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
   '@babel/runtime@7.29.2': {}
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/types@7.29.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@bramus/specificity@2.4.2':
     dependencies:
@@ -5235,7 +6123,29 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/source-map@0.3.11':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@malept/cross-spawn-promise@2.0.0':
     dependencies:
@@ -5298,7 +6208,48 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.2.5':
     optional: true
 
+  '@opentelemetry/api-logs@0.214.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
   '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.214.0
+      import-in-the-middle: 3.2.0
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/resources@2.9.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/sdk-trace@2.9.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/semantic-conventions@1.41.1': {}
 
   '@oslojs/encoding@1.1.0': {}
 
@@ -5306,95 +6257,361 @@ snapshots:
     dependencies:
       playwright: 1.59.1
 
-  '@rollup/pluginutils@5.3.0(rollup@4.60.2)':
+  '@rollup/plugin-commonjs@28.0.1(rollup@4.62.2)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.62.2)
+      commondir: 1.0.1
+      estree-walker: 2.0.2
+      fdir: 6.5.0(picomatch@4.0.4)
+      is-reference: 1.2.1
+      magic-string: 0.30.21
+      picomatch: 4.0.4
+    optionalDependencies:
+      rollup: 4.62.2
+
+  '@rollup/pluginutils@5.3.0(rollup@4.62.2)':
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.4
     optionalDependencies:
-      rollup: 4.60.2
+      rollup: 4.62.2
 
   '@rollup/rollup-android-arm-eabi@4.60.2':
+    optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.62.2':
     optional: true
 
   '@rollup/rollup-android-arm64@4.60.2':
     optional: true
 
+  '@rollup/rollup-android-arm64@4.62.2':
+    optional: true
+
   '@rollup/rollup-darwin-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.60.2':
     optional: true
 
+  '@rollup/rollup-darwin-x64@4.62.2':
+    optional: true
+
   '@rollup/rollup-freebsd-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.60.2':
     optional: true
 
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    optional: true
+
   '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     optional: true
 
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    optional: true
+
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     optional: true
 
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    optional: true
+
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
     optional: true
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     optional: true
 
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    optional: true
+
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     optional: true
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     optional: true
 
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    optional: true
+
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     optional: true
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     optional: true
 
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    optional: true
+
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     optional: true
 
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    optional: true
+
   '@rollup/rollup-linux-x64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
     optional: true
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     optional: true
 
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    optional: true
+
   '@rollup/rollup-openharmony-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.60.2':
     optional: true
 
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    optional: true
+
   '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
     optional: true
 
   '@rollup/rollup-win32-x64-gnu@4.60.2':
     optional: true
 
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    optional: true
+
   '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    optional: true
+
+  '@sentry/babel-plugin-component-annotate@5.3.0': {}
+
+  '@sentry/browser-utils@10.63.0':
+    dependencies:
+      '@sentry/core': 10.63.0
+
+  '@sentry/browser@10.63.0':
+    dependencies:
+      '@sentry/browser-utils': 10.63.0
+      '@sentry/core': 10.63.0
+      '@sentry/feedback': 10.63.0
+      '@sentry/replay': 10.63.0
+      '@sentry/replay-canvas': 10.63.0
+
+  '@sentry/bundler-plugin-core@5.3.0':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@sentry/babel-plugin-component-annotate': 5.3.0
+      '@sentry/cli': 2.58.6
+      dotenv: 16.6.1
+      find-up: 5.0.0
+      glob: 13.0.6
+      magic-string: 0.30.21
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/cli-darwin@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli@2.58.6':
+    dependencies:
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.7.0
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 2.58.6
+      '@sentry/cli-linux-arm': 2.58.6
+      '@sentry/cli-linux-arm64': 2.58.6
+      '@sentry/cli-linux-i686': 2.58.6
+      '@sentry/cli-linux-x64': 2.58.6
+      '@sentry/cli-win32-arm64': 2.58.6
+      '@sentry/cli-win32-i686': 2.58.6
+      '@sentry/cli-win32-x64': 2.58.6
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   '@sentry/cloudflare@10.63.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@sentry/core': 10.63.0
 
+  '@sentry/conventions@0.12.0': {}
+
   '@sentry/core@10.63.0': {}
+
+  '@sentry/feedback@10.63.0':
+    dependencies:
+      '@sentry/core': 10.63.0
+
+  '@sentry/nextjs@10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.5(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.108.3)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@rollup/plugin-commonjs': 28.0.1(rollup@4.62.2)
+      '@sentry/browser-utils': 10.63.0
+      '@sentry/bundler-plugin-core': 5.3.0
+      '@sentry/conventions': 0.12.0
+      '@sentry/core': 10.63.0
+      '@sentry/node': 10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))
+      '@sentry/opentelemetry': 10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))
+      '@sentry/react': 10.63.0(react@18.3.1)
+      '@sentry/vercel-edge': 10.63.0
+      '@sentry/webpack-plugin': 5.3.0(webpack@5.108.3)
+      next: 16.2.5(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rollup: 4.62.2
+      stacktrace-parser: 0.1.11
+    transitivePeerDependencies:
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - '@opentelemetry/sdk-trace-base'
+      - encoding
+      - react
+      - supports-color
+      - webpack
+
+  '@sentry/node-core@10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@sentry/conventions': 0.12.0
+      '@sentry/core': 10.63.0
+      '@sentry/opentelemetry': 10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))
+      import-in-the-middle: 3.2.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.9.0(@opentelemetry/api@1.9.1)
+
+  '@sentry/node@10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@sentry/conventions': 0.12.0
+      '@sentry/core': 10.63.0
+      '@sentry/node-core': 10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))
+      '@sentry/opentelemetry': 10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))
+      '@sentry/server-utils': 10.63.0
+      import-in-the-middle: 3.2.0
+    transitivePeerDependencies:
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
+
+  '@sentry/opentelemetry@10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.9.0(@opentelemetry/api@1.9.1)
+      '@sentry/conventions': 0.12.0
+      '@sentry/core': 10.63.0
+
+  '@sentry/react@10.63.0(react@18.3.1)':
+    dependencies:
+      '@sentry/browser': 10.63.0
+      '@sentry/core': 10.63.0
+      react: 18.3.1
+
+  '@sentry/replay-canvas@10.63.0':
+    dependencies:
+      '@sentry/core': 10.63.0
+      '@sentry/replay': 10.63.0
+
+  '@sentry/replay@10.63.0':
+    dependencies:
+      '@sentry/browser-utils': 10.63.0
+      '@sentry/core': 10.63.0
+
+  '@sentry/server-utils@10.63.0':
+    dependencies:
+      '@apm-js-collab/code-transformer': 0.15.0
+      '@apm-js-collab/code-transformer-bundler-plugins': 0.5.0
+      '@apm-js-collab/tracing-hooks': 0.10.1
+      '@sentry/conventions': 0.12.0
+      '@sentry/core': 10.63.0
+      magic-string: 0.30.21
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sentry/vercel-edge@10.63.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@sentry/core': 10.63.0
+
+  '@sentry/webpack-plugin@5.3.0(webpack@5.108.3)':
+    dependencies:
+      '@sentry/bundler-plugin-core': 5.3.0
+      webpack: 5.108.3
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   '@shikijs/core@3.23.0':
     dependencies:
@@ -5488,6 +6705,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/estree@1.0.9': {}
+
   '@types/express-serve-static-core@4.19.8':
     dependencies:
       '@types/node': 20.19.39
@@ -5520,6 +6739,8 @@ snapshots:
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
       undici-types: 7.25.0
+
+  '@types/json-schema@7.0.15': {}
 
   '@types/keyv@3.1.4':
     dependencies:
@@ -5623,21 +6844,21 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@20.19.39))':
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@20.19.39)(terser@5.48.0))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 5.4.21(@types/node@20.19.39)
+      vite: 5.4.21(@types/node@20.19.39)(terser@5.48.0)
 
-  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@24.12.2))':
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@24.12.2)(terser@5.48.0))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 5.4.21(@types/node@24.12.2)
+      vite: 5.4.21(@types/node@24.12.2)(terser@5.48.0)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -5714,10 +6935,90 @@ snapshots:
 
   '@vscode/l10n@0.0.18': {}
 
+  '@webassemblyjs/ast@1.14.1':
+    dependencies:
+      '@webassemblyjs/helper-numbers': 1.13.2
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+
+  '@webassemblyjs/floating-point-hex-parser@1.13.2': {}
+
+  '@webassemblyjs/helper-api-error@1.13.2': {}
+
+  '@webassemblyjs/helper-buffer@1.14.1': {}
+
+  '@webassemblyjs/helper-numbers@1.13.2':
+    dependencies:
+      '@webassemblyjs/floating-point-hex-parser': 1.13.2
+      '@webassemblyjs/helper-api-error': 1.13.2
+      '@xtuc/long': 4.2.2
+
+  '@webassemblyjs/helper-wasm-bytecode@1.13.2': {}
+
+  '@webassemblyjs/helper-wasm-section@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/wasm-gen': 1.14.1
+
+  '@webassemblyjs/ieee754@1.13.2':
+    dependencies:
+      '@xtuc/ieee754': 1.2.0
+
+  '@webassemblyjs/leb128@1.13.2':
+    dependencies:
+      '@xtuc/long': 4.2.2
+
+  '@webassemblyjs/utf8@1.13.2': {}
+
+  '@webassemblyjs/wasm-edit@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/helper-wasm-section': 1.14.1
+      '@webassemblyjs/wasm-gen': 1.14.1
+      '@webassemblyjs/wasm-opt': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      '@webassemblyjs/wast-printer': 1.14.1
+
+  '@webassemblyjs/wasm-gen@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/ieee754': 1.13.2
+      '@webassemblyjs/leb128': 1.13.2
+      '@webassemblyjs/utf8': 1.13.2
+
+  '@webassemblyjs/wasm-opt@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/wasm-gen': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+
+  '@webassemblyjs/wasm-parser@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-api-error': 1.13.2
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/ieee754': 1.13.2
+      '@webassemblyjs/leb128': 1.13.2
+      '@webassemblyjs/utf8': 1.13.2
+
+  '@webassemblyjs/wast-printer@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@xtuc/long': 4.2.2
+
   '@xmldom/xmldom@0.8.13': {}
 
   '@xmldom/xmldom@0.9.10':
     optional: true
+
+  '@xtuc/ieee754@1.2.0': {}
+
+  '@xtuc/long@4.2.2': {}
 
   abbrev@4.0.0: {}
 
@@ -5735,7 +7036,21 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
+  acorn-import-attributes@1.9.5(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn-import-phases@1.0.4(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
   acorn@8.16.0: {}
+
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   agent-base@7.1.4: {}
 
@@ -5747,6 +7062,10 @@ snapshots:
     optionalDependencies:
       ajv: 8.20.0
 
+  ajv-formats@2.1.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
@@ -5754,6 +7073,11 @@ snapshots:
   ajv-keywords@3.5.2(ajv@6.15.0):
     dependencies:
       ajv: 6.15.0
+
+  ajv-keywords@5.1.0(ajv@8.20.0):
+    dependencies:
+      ajv: 8.20.0
+      fast-deep-equal: 3.1.3
 
   ajv@6.15.0:
     dependencies:
@@ -5859,7 +7183,9 @@ snapshots:
   astral-regex@2.0.0:
     optional: true
 
-  astro@5.18.1(@types/node@20.19.39)(jiti@2.6.1)(rollup@4.60.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4):
+  astring@1.9.0: {}
+
+  astro@5.18.1(@types/node@20.19.39)(jiti@2.6.1)(rollup@4.62.2)(terser@5.48.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4):
     dependencies:
       '@astrojs/compiler': 2.13.1
       '@astrojs/internal-helpers': 0.7.6
@@ -5867,7 +7193,7 @@ snapshots:
       '@astrojs/telemetry': 3.3.0
       '@capsizecss/unpack': 4.0.0
       '@oslojs/encoding': 1.1.0
-      '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
+      '@rollup/pluginutils': 5.3.0(rollup@4.62.2)
       acorn: 8.16.0
       aria-query: 5.3.2
       axobject-query: 4.1.0
@@ -5916,8 +7242,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.5
       vfile: 6.0.3
-      vite: 6.4.2(@types/node@20.19.39)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4)
-      vitefu: 1.1.3(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
+      vite: 6.4.2(@types/node@20.19.39)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.4)
+      vitefu: 1.1.3(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.4))
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
       yocto-spinner: 0.2.3
@@ -5982,6 +7308,8 @@ snapshots:
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.23: {}
+
+  baseline-browser-mapping@2.10.41: {}
 
   better-sqlite3@12.9.0:
     dependencies:
@@ -6064,6 +7392,14 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
+  browserslist@4.28.4:
+    dependencies:
+      baseline-browser-mapping: 2.10.41
+      caniuse-lite: 1.0.30001800
+      electron-to-chromium: 1.5.385
+      node-releases: 2.0.50
+      update-browserslist-db: 1.2.3(browserslist@4.28.4)
+
   buffer-crc32@0.2.13: {}
 
   buffer-from@1.1.2: {}
@@ -6135,6 +7471,8 @@ snapshots:
 
   caniuse-lite@1.0.30001791: {}
 
+  caniuse-lite@1.0.30001800: {}
+
   ccount@2.0.1: {}
 
   chai@5.3.3:
@@ -6172,11 +7510,15 @@ snapshots:
 
   chownr@3.0.0: {}
 
+  chrome-trace-event@1.0.4: {}
+
   chromium-pickle-js@0.2.0: {}
 
   ci-info@4.3.1: {}
 
   ci-info@4.4.0: {}
+
+  cjs-module-lexer@2.2.0: {}
 
   cli-boxes@3.0.0: {}
 
@@ -6214,12 +7556,16 @@ snapshots:
 
   commander@11.1.0: {}
 
+  commander@2.20.3: {}
+
   commander@5.1.0: {}
 
   commander@9.5.0:
     optional: true
 
   common-ancestor-path@1.0.1: {}
+
+  commondir@1.0.1: {}
 
   compare-version@0.1.2: {}
 
@@ -6239,6 +7585,8 @@ snapshots:
   content-disposition@1.1.0: {}
 
   content-type@1.0.5: {}
+
+  convert-source-map@2.0.0: {}
 
   cookie-es@1.2.3: {}
 
@@ -6490,6 +7838,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  electron-to-chromium@1.5.385: {}
+
   electron-winstaller@5.4.0:
     dependencies:
       '@electron/asar': 3.4.1
@@ -6525,6 +7875,11 @@ snapshots:
     dependencies:
       once: 1.4.0
 
+  enhanced-resolve@5.24.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
   entities@4.5.0: {}
 
   entities@6.0.1: {}
@@ -6540,6 +7895,8 @@ snapshots:
   es-errors@1.3.0: {}
 
   es-module-lexer@1.7.0: {}
+
+  es-module-lexer@2.3.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -6648,6 +8005,23 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
+  eslint-scope@5.1.1:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 4.3.0
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@4.3.0: {}
+
+  estraverse@5.3.0: {}
+
   estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
@@ -6659,6 +8033,8 @@ snapshots:
   event-target-shim@5.0.1: {}
 
   eventemitter3@5.0.4: {}
+
+  events@3.3.0: {}
 
   eventsource-parser@3.0.8: {}
 
@@ -6804,6 +8180,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
   flattie@1.1.1: {}
 
   fontace@0.4.1:
@@ -6878,6 +8259,8 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  gensync@1.0.0-beta.2: {}
+
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.5.0: {}
@@ -6911,6 +8294,12 @@ snapshots:
   github-from-package@0.0.0: {}
 
   github-slugger@2.0.0: {}
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
 
   glob@7.2.3:
     dependencies:
@@ -7109,6 +8498,13 @@ snapshots:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
 
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
@@ -7142,6 +8538,13 @@ snapshots:
 
   immediate@3.0.6: {}
 
+  import-in-the-middle@3.2.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      cjs-module-lexer: 2.2.0
+      module-details-from-path: 1.0.4
+
   import-meta-resolve@4.2.0: {}
 
   inflight@1.0.6:
@@ -7173,6 +8576,10 @@ snapshots:
 
   is-promise@4.0.0: {}
 
+  is-reference@1.2.1:
+    dependencies:
+      '@types/estree': 1.0.8
+
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
@@ -7194,6 +8601,12 @@ snapshots:
       async: 3.2.6
       filelist: 1.0.6
       picocolors: 1.1.1
+
+  jest-worker@27.5.1:
+    dependencies:
+      '@types/node': 20.19.39
+      merge-stream: 2.0.0
+      supports-color: 8.1.1
 
   jiti@2.6.1: {}
 
@@ -7258,6 +8671,8 @@ snapshots:
       - '@noble/hashes'
     optional: true
 
+  jsesc@3.1.0: {}
+
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
@@ -7306,6 +8721,12 @@ snapshots:
     dependencies:
       immediate: 3.0.6
 
+  loader-runner@4.3.2: {}
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
   lodash@4.18.1: {}
 
   longest-streak@3.1.0: {}
@@ -7319,6 +8740,10 @@ snapshots:
   lowercase-keys@2.0.0: {}
 
   lru-cache@11.3.5: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
 
   lru-cache@6.0.0:
     dependencies:
@@ -7476,6 +8901,10 @@ snapshots:
   merge-descriptors@1.0.3: {}
 
   merge-descriptors@2.0.0: {}
+
+  merge-stream@2.0.0: {}
+
+  meriyah@6.1.4: {}
 
   methods@1.1.2: {}
 
@@ -7708,6 +9137,14 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minimizer-webpack-plugin@5.6.1(webpack@5.108.3):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.48.0
+      webpack: 5.108.3
+
   minipass@7.1.3: {}
 
   minizlib@3.1.0:
@@ -7719,6 +9156,8 @@ snapshots:
   mkdirp@0.5.6:
     dependencies:
       minimist: 1.2.8
+
+  module-details-from-path@1.0.4: {}
 
   mrmime@2.0.1: {}
 
@@ -7743,9 +9182,11 @@ snapshots:
 
   negotiator@1.0.0: {}
 
+  neo-async@2.6.2: {}
+
   neotraverse@0.6.18: {}
 
-  next@16.2.5(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@16.2.5(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 16.2.5
       '@swc/helpers': 0.5.15
@@ -7754,7 +9195,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.6(react@18.3.1)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@18.3.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.5
       '@next/swc-darwin-x64': 16.2.5
@@ -7813,6 +9254,8 @@ snapshots:
 
   node-mock-http@1.0.4: {}
 
+  node-releases@2.0.50: {}
+
   nopt@9.0.0:
     dependencies:
       abbrev: 4.0.0
@@ -7870,6 +9313,10 @@ snapshots:
     dependencies:
       yocto-queue: 1.2.2
 
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
   p-queue@8.1.1:
     dependencies:
       eventemitter3: 5.0.4
@@ -7902,9 +9349,16 @@ snapshots:
 
   path-browserify@1.0.1: {}
 
+  path-exists@4.0.0: {}
+
   path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.3.5
+      minipass: 7.1.3
 
   path-to-regexp@0.1.13: {}
 
@@ -8019,6 +9473,8 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  proxy-from-env@1.1.0: {}
 
   pump@3.0.4:
     dependencies:
@@ -8184,6 +9640,13 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
+
   resedit@1.7.2:
     dependencies:
       pe-library: 0.4.1
@@ -8268,6 +9731,37 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
 
+  rollup@4.62.2:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.62.2
+      '@rollup/rollup-android-arm64': 4.62.2
+      '@rollup/rollup-darwin-arm64': 4.62.2
+      '@rollup/rollup-darwin-x64': 4.62.2
+      '@rollup/rollup-freebsd-arm64': 4.62.2
+      '@rollup/rollup-freebsd-x64': 4.62.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.2
+      '@rollup/rollup-linux-arm64-gnu': 4.62.2
+      '@rollup/rollup-linux-arm64-musl': 4.62.2
+      '@rollup/rollup-linux-loong64-gnu': 4.62.2
+      '@rollup/rollup-linux-loong64-musl': 4.62.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.2
+      '@rollup/rollup-linux-ppc64-musl': 4.62.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.2
+      '@rollup/rollup-linux-riscv64-musl': 4.62.2
+      '@rollup/rollup-linux-s390x-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-musl': 4.62.2
+      '@rollup/rollup-openbsd-x64': 4.62.2
+      '@rollup/rollup-openharmony-arm64': 4.62.2
+      '@rollup/rollup-win32-arm64-msvc': 4.62.2
+      '@rollup/rollup-win32-ia32-msvc': 4.62.2
+      '@rollup/rollup-win32-x64-gnu': 4.62.2
+      '@rollup/rollup-win32-x64-msvc': 4.62.2
+      fsevents: 2.3.3
+
   router@2.2.0:
     dependencies:
       debug: 4.4.3
@@ -8297,6 +9791,15 @@ snapshots:
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
+
+  schema-utils@4.3.3:
+    dependencies:
+      '@types/json-schema': 7.0.15
+      ajv: 8.20.0
+      ajv-formats: 2.1.1(ajv@8.20.0)
+      ajv-keywords: 5.1.0(ajv@8.20.0)
+
+  semifies@1.0.0: {}
 
   semver-compare@1.0.0:
     optional: true
@@ -8498,6 +10001,10 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  stacktrace-parser@0.1.11:
+    dependencies:
+      type-fest: 0.7.1
+
   stat-mode@1.0.0: {}
 
   statuses@2.0.2: {}
@@ -8543,10 +10050,12 @@ snapshots:
 
   strip-json-comments@2.0.1: {}
 
-  styled-jsx@5.1.6(react@18.3.1):
+  styled-jsx@5.1.6(@babel/core@7.29.7)(react@18.3.1):
     dependencies:
       client-only: 0.0.1
       react: 18.3.1
+    optionalDependencies:
+      '@babel/core': 7.29.7
 
   sumchecker@3.0.1:
     dependencies:
@@ -8555,6 +10064,10 @@ snapshots:
       - supports-color
 
   supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-color@8.1.1:
     dependencies:
       has-flag: 4.0.0
 
@@ -8569,6 +10082,8 @@ snapshots:
       sax: 1.6.0
 
   symbol-tree@3.2.4: {}
+
+  tapable@2.3.3: {}
 
   tar-fs@2.1.4:
     dependencies:
@@ -8602,6 +10117,13 @@ snapshots:
     dependencies:
       mkdirp: 0.5.6
       rimraf: 2.6.3
+
+  terser@5.48.0:
+    dependencies:
+      '@jridgewell/source-map': 0.3.11
+      acorn: 8.16.0
+      commander: 2.20.3
+      source-map-support: 0.5.21
 
   tiny-async-pool@1.3.0:
     dependencies:
@@ -8677,6 +10199,8 @@ snapshots:
 
   type-fest@0.13.1:
     optional: true
+
+  type-fest@0.7.1: {}
 
   type-fest@4.41.0: {}
 
@@ -8796,6 +10320,12 @@ snapshots:
       ofetch: 1.5.1
       ufo: 1.6.4
 
+  update-browserslist-db@1.2.3(browserslist@4.28.4):
+    dependencies:
+      browserslist: 4.28.4
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
@@ -8830,13 +10360,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@2.1.9(@types/node@20.19.39):
+  vite-node@2.1.9(@types/node@20.19.39)(terser@5.48.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 1.1.2
-      vite: 5.4.21(@types/node@20.19.39)
+      vite: 5.4.21(@types/node@20.19.39)(terser@5.48.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -8848,13 +10378,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@2.1.9(@types/node@24.12.2):
+  vite-node@2.1.9(@types/node@24.12.2)(terser@5.48.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 1.1.2
-      vite: 5.4.21(@types/node@24.12.2)
+      vite: 5.4.21(@types/node@24.12.2)(terser@5.48.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -8866,7 +10396,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.21(@types/node@20.19.39):
+  vite@5.4.21(@types/node@20.19.39)(terser@5.48.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.12
@@ -8874,8 +10404,9 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.39
       fsevents: 2.3.3
+      terser: 5.48.0
 
-  vite@5.4.21(@types/node@24.12.2):
+  vite@5.4.21(@types/node@24.12.2)(terser@5.48.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.12
@@ -8883,8 +10414,9 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.12.2
       fsevents: 2.3.3
+      terser: 5.48.0
 
-  vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4):
+  vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -8896,17 +10428,18 @@ snapshots:
       '@types/node': 20.19.39
       fsevents: 2.3.3
       jiti: 2.6.1
+      terser: 5.48.0
       tsx: 4.21.0
       yaml: 2.8.4
 
-  vitefu@1.1.3(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4)):
+  vitefu@1.1.3(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.4)):
     optionalDependencies:
-      vite: 6.4.2(@types/node@20.19.39)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4)
+      vite: 6.4.2(@types/node@20.19.39)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.4)
 
-  vitest@2.1.9(@types/node@20.19.39)(jsdom@29.1.0):
+  vitest@2.1.9(@types/node@20.19.39)(jsdom@29.1.0)(terser@5.48.0):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@20.19.39))
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@20.19.39)(terser@5.48.0))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -8922,8 +10455,8 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.1.1
       tinyrainbow: 1.2.0
-      vite: 5.4.21(@types/node@20.19.39)
-      vite-node: 2.1.9(@types/node@20.19.39)
+      vite: 5.4.21(@types/node@20.19.39)(terser@5.48.0)
+      vite-node: 2.1.9(@types/node@20.19.39)(terser@5.48.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.39
@@ -8939,10 +10472,10 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.1.9(@types/node@20.19.39)(jsdom@29.1.1):
+  vitest@2.1.9(@types/node@20.19.39)(jsdom@29.1.1)(terser@5.48.0):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@20.19.39))
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@20.19.39)(terser@5.48.0))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -8958,8 +10491,8 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.1.1
       tinyrainbow: 1.2.0
-      vite: 5.4.21(@types/node@20.19.39)
-      vite-node: 2.1.9(@types/node@20.19.39)
+      vite: 5.4.21(@types/node@20.19.39)(terser@5.48.0)
+      vite-node: 2.1.9(@types/node@20.19.39)(terser@5.48.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.39
@@ -8975,10 +10508,10 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.1.9(@types/node@24.12.2)(jsdom@29.1.1):
+  vitest@2.1.9(@types/node@24.12.2)(jsdom@29.1.1)(terser@5.48.0):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@24.12.2))
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@24.12.2)(terser@5.48.0))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -8994,8 +10527,8 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.1.1
       tinyrainbow: 1.2.0
-      vite: 5.4.21(@types/node@24.12.2)
-      vite-node: 2.1.9(@types/node@24.12.2)
+      vite: 5.4.21(@types/node@24.12.2)(terser@5.48.0)
+      vite-node: 2.1.9(@types/node@24.12.2)(terser@5.48.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.2
@@ -9112,6 +10645,10 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
+  watchpack@2.5.2:
+    dependencies:
+      graceful-fs: 4.2.11
+
   web-namespaces@2.0.1: {}
 
   web-streams-polyfill@4.0.0-beta.3: {}
@@ -9119,6 +10656,46 @@ snapshots:
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@8.0.1: {}
+
+  webpack-sources@3.5.0: {}
+
+  webpack@5.108.3:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.4
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.24.1
+      es-module-lexer: 2.3.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      graceful-fs: 4.2.11
+      loader-runner: 4.3.2
+      mime-db: 1.54.0
+      minimizer-webpack-plugin: 5.6.1(webpack@5.108.3)
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      watchpack: 2.5.2
+      webpack-sources: 3.5.0
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
 
   whatwg-mimetype@5.0.0: {}
 
@@ -9181,6 +10758,8 @@ snapshots:
   xxhash-wasm@1.1.0: {}
 
   y18n@5.0.8: {}
+
+  yallist@3.1.1: {}
 
   yallist@4.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,10 @@ importers:
         version: 2.1.9(@types/node@24.12.2)(jsdom@29.1.1)
 
   apps/telemetry-worker:
+    dependencies:
+      '@sentry/cloudflare':
+        specifier: ^10.63.0
+        version: 10.63.0
     devDependencies:
       typescript:
         specifier: ^5.6.3
@@ -206,7 +210,7 @@ importers:
         version: link:../../packages/sidecar-proto
       next:
         specifier: ^16.2.5
-        version: 16.2.5(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 16.2.5(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       openai:
         specifier: ^6.36.0
         version: 6.36.0(zod@4.4.2)
@@ -1311,6 +1315,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
@@ -1465,6 +1473,19 @@ packages:
     resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
     cpu: [x64]
     os: [win32]
+
+  '@sentry/cloudflare@10.63.0':
+    resolution: {integrity: sha512-no7bfrBqO3Niy+3vEqktYrNoTtBJtlJxpnTutmpSz55x+ytpNj+1YUUUbJRFctttDuPe38/+c6m1FwXGQg074A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.x
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
+  '@sentry/core@10.63.0':
+    resolution: {integrity: sha512-OtUbsrnbEHffOF2S2+M5zXa3HIM0U2b4CDVLKMY1dgS0J3ivRF8XvkjvyIcEG/y8JXnwXbnprLyjhG+AqMdUZQ==}
+    engines: {node: '>=18'}
 
   '@shikijs/core@3.23.0':
     resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
@@ -5277,6 +5298,8 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.2.5':
     optional: true
 
+  '@opentelemetry/api@1.9.1': {}
+
   '@oslojs/encoding@1.1.0': {}
 
   '@playwright/test@1.59.1':
@@ -5365,6 +5388,13 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
+
+  '@sentry/cloudflare@10.63.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@sentry/core': 10.63.0
+
+  '@sentry/core@10.63.0': {}
 
   '@shikijs/core@3.23.0':
     dependencies:
@@ -7715,7 +7745,7 @@ snapshots:
 
   neotraverse@0.6.18: {}
 
-  next@16.2.5(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@16.2.5(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 16.2.5
       '@swc/helpers': 0.5.15
@@ -7734,6 +7764,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.5
       '@next/swc-win32-arm64-msvc': 16.2.5
       '@next/swc-win32-x64-msvc': 16.2.5
+      '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.59.1
       sharp: 0.34.5
     transitivePeerDependencies:

--- a/skills/design-memory-bridge/SKILL.md
+++ b/skills/design-memory-bridge/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: design-memory-bridge
+description: |
+  Pre-flight context loader that fetches design-lab memory from the
+  local sidecar before generating UI, visual systems, product pages,
+  dashboards, or design assets. Falls back silently to no-memory
+  generation when the sidecar or token is unavailable.
+---
+
+# design-memory-bridge
+
+Use this skill when generating UI, visual systems, product pages, dashboards, or design assets where design-lab memory can improve taste alignment.
+
+## Design-lab bridge
+
+Before generation, try to load design-lab context from the local sidecar:
+
+1. Read token from `$HOME/.claude/state/design-lab/api-token`.
+2. Call `GET http://127.0.0.1:5174/api/context?client=<client>&scenario=<scenario>` with `X-Design-Lab-Token`.
+3. If the response is `401`, re-read the token once and retry once.
+4. If token read fails, fetch throws, response is non-2xx, or retry also fails, continue with no-memory generation.
+5. Never ask the user for the token and never print the token.
+
+Recommended helper path: `lib/design-lab-context.ts` (relative to this skill).
+
+```typescript
+import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+
+const SIDECAR_URL = process.env.DESIGN_LAB_SIDECAR_URL ?? 'http://127.0.0.1:5174';
+const TOKEN_PATH = `${homedir()}/.claude/state/design-lab/api-token`;
+
+function readToken(): string | null {
+    try {
+        const token = readFileSync(TOKEN_PATH, 'utf8').trim();
+        return token || null;
+    } catch {
+        return null;
+    }
+}
+
+async function requestContext(url: URL, token: string): Promise<Response> {
+    return fetch(url, {
+        headers: {
+            'Accept': 'application/json',
+            'X-Design-Lab-Token': token
+        }
+    });
+}
+
+export async function loadDesignLabContext(input: {
+    client?: string;
+    scenario?: string;
+}): Promise<unknown | null> {
+    const url = new URL('/api/context', SIDECAR_URL);
+    if (input.client) url.searchParams.set('client', input.client);
+    if (input.scenario) url.searchParams.set('scenario', input.scenario);
+
+    let token = readToken();
+    if (!token) return null;
+
+    try {
+        let response = await requestContext(url, token);
+        if (response.status === 401) {
+            token = readToken();
+            if (!token) return null;
+            response = await requestContext(url, token);
+        }
+
+        if (!response.ok) return null;
+        return await response.json();
+    } catch {
+        return null;
+    }
+}
+```
+
+Generation flow:
+
+```text
+memory = await loadDesignLabContext({ client, scenario })
+if memory:
+    generate with design-lab evidence
+else:
+    generate normally without memory
+```
+
+## Failure modes (fail-soft)
+
+| Condition | Behavior |
+|---|---|
+| Token file missing / unreadable | Return `null`, generate without memory |
+| Sidecar not running / fetch throws | Return `null`, generate without memory |
+| HTTP 401 | Re-read token once, retry once. Still 401 → `null` |
+| HTTP 4xx/5xx (non-401) | Return `null`, generate without memory |
+| JSON parse error | Return `null`, generate without memory |
+
+The bridge **must never** block, retry indefinitely, ask the user for the token, or print the token. Sidecar lifecycle (start/stop/rotate token) is owned by design-lab's `ensure-sidecar.sh`; this skill is read-only.

--- a/skills/design-memory-bridge/SKILL.md
+++ b/skills/design-memory-bridge/SKILL.md
@@ -30,6 +30,41 @@ import { homedir } from 'node:os';
 const SIDECAR_URL = process.env.DESIGN_LAB_SIDECAR_URL ?? 'http://127.0.0.1:5174';
 const TOKEN_PATH = `${homedir()}/.claude/state/design-lab/api-token`;
 
+interface CaseSummary {
+    slug?: string;
+    quotes_from_user?: string[];
+    aspects?: Array<{
+        dimension?: string;
+        verdict?: 'like' | 'dislike' | string;
+        note?: string;
+    }>;
+    tokens?: {
+        palette?: unknown;
+        fonts?: unknown;
+        [key: string]: unknown;
+    };
+}
+
+interface NeverRule {
+    id?: string;
+    rule?: string;
+    detector?: {
+        pattern?: string;
+        [key: string]: unknown;
+    };
+}
+
+interface DesignLabContext {
+    client?: unknown;
+    styleGuide?: string;
+    brandStyleGuide?: string;
+    scenarioOverride?: string;
+    cases?: CaseSummary[];
+    antiCases?: CaseSummary[];
+    neverRules?: NeverRule[];
+    retrievedFrom?: string[];
+}
+
 function readToken(): string | null {
     try {
         const token = readFileSync(TOKEN_PATH, 'utf8').trim();
@@ -51,7 +86,7 @@ async function requestContext(url: URL, token: string): Promise<Response> {
 export async function loadDesignLabContext(input: {
     client?: string;
     scenario?: string;
-}): Promise<unknown | null> {
+}): Promise<DesignLabContext | null> {
     const url = new URL('/api/context', SIDECAR_URL);
     if (input.client) url.searchParams.set('client', input.client);
     if (input.scenario) url.searchParams.set('scenario', input.scenario);
@@ -68,21 +103,53 @@ export async function loadDesignLabContext(input: {
         }
 
         if (!response.ok) return null;
-        return await response.json();
+        return await response.json() as DesignLabContext;
     } catch {
         return null;
     }
 }
+
+export function framePrompt(basePrompt: string, context: DesignLabContext | null): string {
+    if (!context) return basePrompt;
+
+    const sections: string[] = [];
+
+    // styleGuide / brandStyleGuide are follow/system guidance.
+    // scenarioOverride takes precedence over the brand guide.
+    // neverRules are HARD NEVER constraints.
+    // cases are liked references to emulate.
+    // antiCases are disliked references to avoid.
+    // Build semantic sections from trimmed strings and omit empty sections.
+
+    return sections.length > 0
+        ? [
+            basePrompt,
+            '',
+            ...sections,
+            '',
+            'Apply the brand guide + scenario override; emulate liked references; never violate the hard constraints.'
+        ].join('\n')
+        : basePrompt;
+}
 ```
+
+Bridge contract:
+
+- `styleGuide` and `brandStyleGuide` → `## Brand style guide (follow)`.
+- `scenarioOverride` → `## Scenario override (takes precedence over the brand guide)`.
+- `neverRules` → `## HARD CONSTRAINTS — NEVER violate`; include rule id, rule text, and detector pattern when present.
+- `cases` → `## Liked references — emulate these`; include slug, compact `tokens.palette` / `tokens.fonts`, user quotes, and liked aspects.
+- `antiCases` → `## Avoid — anti-patterns`; include slug, user quotes, and disliked aspects.
+- Never pass raw `/api/context` JSON into the generation prompt. The bridge frames context semantically so the model follows the brand guide, emulates liked references, and hard-avoids NEVER rules.
 
 Generation flow:
 
 ```text
 memory = await loadDesignLabContext({ client, scenario })
 if memory:
-    generate with design-lab evidence
+    prompt = framePrompt(basePrompt, memory)
 else:
-    generate normally without memory
+    prompt = basePrompt
 ```
 
 ## Failure modes (fail-soft)

--- a/skills/design-memory-bridge/lib/design-lab-context.test.ts
+++ b/skills/design-memory-bridge/lib/design-lab-context.test.ts
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { framePrompt, type DesignLabContext } from './design-lab-context.ts';
+
+const fullContext: DesignLabContext = {
+    client: { slug: 'acme' },
+    styleGuide: 'Use restrained surfaces and crisp hierarchy.',
+    brandStyleGuide: 'Prefer editorial spacing over dense card walls.',
+    scenarioOverride: 'For dashboards, keep data controls compact.',
+    neverRules: [
+        {
+            id: 'no-x',
+            rule: 'no neon',
+            detector: {
+                type: 'color',
+                pattern: '#0f0',
+                target: 'palette'
+            }
+        }
+    ],
+    cases: [
+        {
+            slug: 'calm-dashboard',
+            scenario: 'dashboard',
+            quotes_from_user: ['This feels focused.'],
+            aspects: [
+                {
+                    dimension: 'palette',
+                    verdict: 'like',
+                    note: 'muted contrast with a single accent'
+                },
+                {
+                    dimension: 'density',
+                    verdict: 'dislike',
+                    note: 'too sparse for operators'
+                }
+            ],
+            tags: ['dashboard'],
+            tokens: {
+                palette: ['#101820', '#f5f7f8'],
+                fonts: ['Inter', 'Newsreader']
+            }
+        }
+    ],
+    antiCases: [
+        {
+            slug: 'neon-wall',
+            scenario: 'dashboard',
+            quotes_from_user: ['This is too loud.'],
+            aspects: [
+                {
+                    dimension: 'palette',
+                    verdict: 'dislike',
+                    note: 'neon green overwhelms the content'
+                }
+            ],
+            tags: ['anti-pattern'],
+            tokens: {
+                palette: ['#0f0']
+            }
+        }
+    ],
+    retrievedFrom: ['design-lab']
+};
+
+test('framePrompt adds semantic design-lab sections without raw JSON framing', () => {
+    const prompt = framePrompt('BASE', fullContext);
+
+    assert.match(prompt, /BASE/);
+    assert.match(prompt, /## HARD CONSTRAINTS/);
+    assert.match(prompt, /no-x/);
+    assert.match(prompt, /#0f0/);
+    assert.match(prompt, /## Liked references/);
+    assert.match(prompt, /calm-dashboard/);
+    assert.doesNotMatch(prompt, /\{\s*"styleGuide":/);
+});
+
+test('framePrompt returns the base prompt when context is missing or empty', () => {
+    assert.equal(framePrompt('BASE', null), 'BASE');
+    assert.equal(framePrompt('BASE', {}), 'BASE');
+});
+
+test('framePrompt omits missing sections while keeping available semantic sections', () => {
+    const prompt = framePrompt('BASE', {
+        styleGuide: 'Follow the brand guide.',
+        cases: [
+            {
+                slug: 'quiet-editor',
+                aspects: [
+                    {
+                        dimension: 'spacing',
+                        verdict: 'like',
+                        note: 'comfortable rhythm'
+                    }
+                ]
+            }
+        ]
+    });
+
+    assert.match(prompt, /## Brand style guide/);
+    assert.match(prompt, /## Liked references/);
+    assert.match(prompt, /quiet-editor/);
+    assert.doesNotMatch(prompt, /## Avoid/);
+});

--- a/skills/design-memory-bridge/lib/design-lab-context.ts
+++ b/skills/design-memory-bridge/lib/design-lab-context.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+
+const SIDECAR_URL = process.env.DESIGN_LAB_SIDECAR_URL ?? 'http://127.0.0.1:5174';
+const TOKEN_PATH = `${homedir()}/.claude/state/design-lab/api-token`;
+
+export interface DesignLabContext {
+    client?: unknown;
+    cases?: unknown[];
+    styleGuide?: unknown;
+}
+
+function readDesignLabToken(): string | null {
+    try {
+        const token = readFileSync(TOKEN_PATH, 'utf8').trim();
+        return token.length > 0 ? token : null;
+    } catch {
+        return null;
+    }
+}
+
+async function fetchContextOnce(url: URL, token: string): Promise<Response> {
+    return fetch(url, {
+        headers: {
+            'Accept': 'application/json',
+            'X-Design-Lab-Token': token
+        }
+    });
+}
+
+export async function loadDesignLabContext(input: {
+    client?: string;
+    scenario?: string;
+}): Promise<DesignLabContext | null> {
+    const url = new URL('/api/context', SIDECAR_URL);
+    if (input.client) url.searchParams.set('client', input.client);
+    if (input.scenario) url.searchParams.set('scenario', input.scenario);
+
+    let token = readDesignLabToken();
+    if (!token) return null;
+
+    try {
+        let resp = await fetchContextOnce(url, token);
+
+        if (resp.status === 401) {
+            // Token rotated after sidecar cold spawn. Re-read once, then fail soft.
+            token = readDesignLabToken();
+            if (!token) return null;
+            resp = await fetchContextOnce(url, token);
+        }
+
+        if (!resp.ok) return null;
+        return await resp.json() as DesignLabContext;
+    } catch {
+        return null;
+    }
+}
+
+export async function buildGenerationPrompt(basePrompt: string, input: {
+    client?: string;
+    scenario?: string;
+}): Promise<string> {
+    const context = await loadDesignLabContext(input);
+    if (!context) {
+        return basePrompt; // fallback to no-memory generation
+    }
+
+    return [
+        basePrompt,
+        '',
+        'Use this design-lab memory context as preference evidence:',
+        JSON.stringify(context, null, 2)
+    ].join('\n');
+}

--- a/skills/design-memory-bridge/lib/design-lab-context.ts
+++ b/skills/design-memory-bridge/lib/design-lab-context.ts
@@ -6,8 +6,45 @@ const TOKEN_PATH = `${homedir()}/.claude/state/design-lab/api-token`;
 
 export interface DesignLabContext {
     client?: unknown;
-    cases?: unknown[];
-    styleGuide?: unknown;
+    styleGuide?: string;
+    brandStyleGuide?: string;
+    scenarioOverride?: string;
+    cases?: CaseSummary[];
+    antiCases?: CaseSummary[];
+    neverRules?: NeverRule[];
+    retrievedFrom?: string[];
+}
+
+export interface CaseAspect {
+    dimension?: string;
+    verdict?: 'like' | 'dislike' | string;
+    note?: string;
+}
+
+export interface CaseSummary {
+    slug?: string;
+    scenario?: string;
+    quotes_from_user?: string[];
+    aspects?: CaseAspect[];
+    tags?: string[];
+    tokens?: {
+        palette?: unknown;
+        fonts?: unknown;
+        [key: string]: unknown;
+    };
+    [key: string]: unknown;
+}
+
+export interface NeverRule {
+    id?: string;
+    rule?: string;
+    detector?: {
+        type?: string;
+        pattern?: string;
+        target?: string;
+        [key: string]: unknown;
+    };
+    [key: string]: unknown;
 }
 
 function readDesignLabToken(): string | null {
@@ -56,19 +93,136 @@ export async function loadDesignLabContext(input: {
     }
 }
 
+function cleanText(value: unknown): string | null {
+    if (typeof value !== 'string') return null;
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+}
+
+function cleanList(values: unknown): string[] {
+    if (!Array.isArray(values)) return [];
+    return values
+        .map(cleanText)
+        .filter((value): value is string => value !== null);
+}
+
+function compactTokenValue(value: unknown): string | null {
+    if (Array.isArray(value)) {
+        const compact = value
+            .map((item) => typeof item === 'string' ? item.trim() : String(item))
+            .filter((item) => item.length > 0)
+            .join(', ');
+        return compact.length > 0 ? compact : null;
+    }
+
+    if (typeof value === 'string') return cleanText(value);
+    if (value && typeof value === 'object') return JSON.stringify(value);
+    if (value === null || value === undefined) return null;
+    return String(value);
+}
+
+function pushSection(sections: string[], title: string, lines: string[]): void {
+    const body = lines.filter((line) => line.trim().length > 0);
+    if (body.length === 0) return;
+    sections.push([title, ...body].join('\n'));
+}
+
+function formatCase(
+    item: CaseSummary,
+    aspectVerdict: 'like' | 'dislike',
+    tokenKeys: Array<keyof NonNullable<CaseSummary['tokens']>>
+): string[] {
+    const lines: string[] = [];
+    const slug = cleanText(item.slug) ?? 'unnamed-reference';
+    lines.push(`- ${slug}`);
+
+    const tokens = item.tokens ?? {};
+    const tokenLines = tokenKeys
+        .map((key) => {
+            const value = compactTokenValue(tokens[key]);
+            return value ? `  - ${key}: ${value}` : null;
+        })
+        .filter((line): line is string => line !== null);
+    lines.push(...tokenLines);
+
+    for (const quote of cleanList(item.quotes_from_user)) {
+        lines.push(`  - quote: ${quote}`);
+    }
+
+    const aspects = Array.isArray(item.aspects) ? item.aspects : [];
+    for (const aspect of aspects) {
+        if (aspect.verdict !== aspectVerdict) continue;
+        const dimension = cleanText(aspect.dimension);
+        const note = cleanText(aspect.note);
+        if (!dimension || !note) continue;
+        lines.push(`  - ${dimension}: ${note}`);
+    }
+
+    return lines.length > 1 ? lines : [];
+}
+
+export function framePrompt(basePrompt: string, context: DesignLabContext | null): string {
+    if (!context) return basePrompt;
+
+    const sections: string[] = [];
+    const styleGuide = cleanText(context.styleGuide);
+    const brandStyleGuide = cleanText(context.brandStyleGuide);
+    pushSection(
+        sections,
+        '## Brand style guide (follow)',
+        [styleGuide, brandStyleGuide].filter((value): value is string => value !== null)
+    );
+
+    const scenarioOverride = cleanText(context.scenarioOverride);
+    pushSection(
+        sections,
+        '## Scenario override (takes precedence over the brand guide)',
+        scenarioOverride ? [scenarioOverride] : []
+    );
+
+    const neverRules = Array.isArray(context.neverRules) ? context.neverRules : [];
+    pushSection(
+        sections,
+        '## HARD CONSTRAINTS — NEVER violate',
+        neverRules.flatMap((rule) => {
+            const id = cleanText(rule.id);
+            const ruleText = cleanText(rule.rule);
+            if (!id || !ruleText) return [];
+            const pattern = cleanText(rule.detector?.pattern);
+            return pattern
+                ? [`- ${id}: ${ruleText} (detector: ${pattern})`]
+                : [`- ${id}: ${ruleText}`];
+        })
+    );
+
+    const cases = Array.isArray(context.cases) ? context.cases : [];
+    pushSection(
+        sections,
+        '## Liked references — emulate these',
+        cases.flatMap((item) => formatCase(item, 'like', ['palette', 'fonts']))
+    );
+
+    const antiCases = Array.isArray(context.antiCases) ? context.antiCases : [];
+    pushSection(
+        sections,
+        '## Avoid — anti-patterns',
+        antiCases.flatMap((item) => formatCase(item, 'dislike', []))
+    );
+
+    if (sections.length === 0) return basePrompt;
+
+    return [
+        basePrompt,
+        '',
+        ...sections.flatMap((section) => [section, '']),
+        'Apply the brand guide + scenario override; emulate liked references; never violate the hard constraints.'
+    ].join('\n').trimEnd();
+}
+
 export async function buildGenerationPrompt(basePrompt: string, input: {
     client?: string;
     scenario?: string;
 }): Promise<string> {
     const context = await loadDesignLabContext(input);
-    if (!context) {
-        return basePrompt; // fallback to no-memory generation
-    }
-
-    return [
-        basePrompt,
-        '',
-        'Use this design-lab memory context as preference evidence:',
-        JSON.stringify(context, null, 2)
-    ].join('\n');
+    return framePrompt(basePrompt, context);
 }

--- a/tools/pack/resources/web-standalone-after-pack.cjs
+++ b/tools/pack/resources/web-standalone-after-pack.cjs
@@ -243,7 +243,7 @@ async function installStandaloneResource(config, resourcesRoot, platformName) {
   await copyOptional(path.join(sourceWebRoot, "package.json"), path.join(destinationWebRoot, "package.json"));
   const copiedNestedNodeModules = await copyOptional(path.join(sourceWebRoot, "node_modules"), path.join(destinationWebRoot, "node_modules"), copyOptions);
   const linkedHoistEntries = await linkPnpmPublicHoist(destinationRoot);
-  await copyRequired(path.join(sourceWebRoot, ".next"), path.join(destinationWebRoot, ".next"));
+  await copyRequired(path.join(sourceWebRoot, ".next"), path.join(destinationWebRoot, ".next"), copyOptions);
   const copiedStatic = await copyOptional(config.webStaticSourceRoot, path.join(destinationWebRoot, ".next", "static"));
   const copiedPublic = await copyOptional(config.webPublicSourceRoot, path.join(destinationWebRoot, "public"));
   const rewrittenSymlinks = platformName === "win32"

--- a/tools/pack/src/config.ts
+++ b/tools/pack/src/config.ts
@@ -72,8 +72,18 @@ export type ToolPackConfig = {
   roots: ToolPackRoots;
   silent: boolean;
   signed: boolean;
+  sentryAuthToken?: string;
+  sentryDsn?: string;
+  sentryEnvironment?: string;
+  sentryOrg?: string;
+  sentryProject?: string;
+  sentryRelease?: string;
+  sentryTracesSampleRate?: string;
   telemetryRelayUrl?: string;
   to: ToolPackBuildOutput;
+  webSentryDsn?: string;
+  webSentryPublicDsn?: string;
+  webSentryTracesSampleRate?: string;
   webOutputMode: ToolPackWebOutputMode;
   workspaceRoot: string;
 };
@@ -125,6 +135,72 @@ function resolveToolPackTelemetryRelayUrl(value: string | undefined): string | u
   return normalized.replace(/\/+$/, "");
 }
 
+function resolveToolPackDaemonSentryDsn(value: string | undefined): string | undefined {
+  if (value == null) return undefined;
+  const normalized = value.trim();
+  if (normalized.length === 0) return undefined;
+  let parsed: URL;
+  try {
+    parsed = new URL(normalized);
+  } catch {
+    throw new Error(`OPEN_DESIGN_DAEMON_SENTRY_DSN must be an absolute https URL: ${value}`);
+  }
+  if (parsed.protocol !== "https:") {
+    throw new Error(`OPEN_DESIGN_DAEMON_SENTRY_DSN must use https: ${value}`);
+  }
+  return normalized;
+}
+
+function resolveToolPackDaemonSentryEnvironment(value: string | undefined): string | undefined {
+  if (value == null) return undefined;
+  const normalized = value.trim();
+  return normalized.length === 0 ? undefined : normalized;
+}
+
+function resolveToolPackDaemonSentryTracesSampleRate(value: string | undefined): string | undefined {
+  if (value == null) return undefined;
+  const normalized = value.trim();
+  if (normalized.length === 0) return undefined;
+  const parsed = Number(normalized);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) {
+    throw new Error("OPEN_DESIGN_DAEMON_SENTRY_TRACES_SAMPLE_RATE must be between 0 and 1");
+  }
+  return normalized;
+}
+
+function resolveToolPackSentryDsn(value: string | undefined, envName: string): string | undefined {
+  if (value == null) return undefined;
+  const normalized = value.trim();
+  if (normalized.length === 0) return undefined;
+  let parsed: URL;
+  try {
+    parsed = new URL(normalized);
+  } catch {
+    throw new Error(`${envName} must be an absolute https URL: ${value}`);
+  }
+  if (parsed.protocol !== "https:") {
+    throw new Error(`${envName} must use https: ${value}`);
+  }
+  return normalized;
+}
+
+function resolveOptionalEnvValue(value: string | undefined): string | undefined {
+  if (value == null) return undefined;
+  const normalized = value.trim();
+  return normalized.length === 0 ? undefined : normalized;
+}
+
+function resolveToolPackSentrySampleRate(value: string | undefined, envName: string): string | undefined {
+  if (value == null) return undefined;
+  const normalized = value.trim();
+  if (normalized.length === 0) return undefined;
+  const parsed = Number(normalized);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) {
+    throw new Error(`${envName} must be between 0 and 1`);
+  }
+  return normalized;
+}
+
 function resolveElectronVersion(workspaceRoot: string): string {
   const require = createRequire(join(workspaceRoot, "apps/desktop/package.json"));
   const desktopPackage = require(join(workspaceRoot, "apps/desktop/package.json")) as {
@@ -152,6 +228,20 @@ export function resolveToolPackConfig(
   platform: ToolPackPlatform,
   options: ToolPackCliOptions = {},
 ): ToolPackConfig {
+  const sentryDsn = resolveToolPackDaemonSentryDsn(process.env.OPEN_DESIGN_DAEMON_SENTRY_DSN);
+  const webSentryDsn = resolveToolPackSentryDsn(process.env.SENTRY_DSN, "SENTRY_DSN");
+  const webSentryPublicDsn = resolveToolPackSentryDsn(process.env.NEXT_PUBLIC_SENTRY_DSN, "NEXT_PUBLIC_SENTRY_DSN");
+  const sentryEnvironment =
+    resolveOptionalEnvValue(process.env.SENTRY_ENVIRONMENT) ??
+    resolveToolPackDaemonSentryEnvironment(process.env.OPEN_DESIGN_DAEMON_SENTRY_ENVIRONMENT);
+  const sentryTracesSampleRate =
+    resolveToolPackSentrySampleRate(process.env.SENTRY_TRACES_SAMPLE_RATE, "SENTRY_TRACES_SAMPLE_RATE") ??
+    resolveToolPackDaemonSentryTracesSampleRate(process.env.OPEN_DESIGN_DAEMON_SENTRY_TRACES_SAMPLE_RATE);
+  const webSentryTracesSampleRate =
+    resolveToolPackSentrySampleRate(
+      process.env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE,
+      "NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE",
+    ) ?? sentryTracesSampleRate;
   const namespace = resolveNamespace({
     contract: OPEN_DESIGN_SIDECAR_CONTRACT,
     env: process.env,
@@ -194,6 +284,35 @@ export function resolveToolPackConfig(
     removeSidecars: options.removeSidecars === true,
     silent: options.silent !== false,
     signed: options.signed === true,
+    ...(sentryDsn == null
+      ? {}
+      : {
+          sentryDsn,
+          sentryEnvironment: sentryEnvironment ?? "production",
+          sentryTracesSampleRate: sentryTracesSampleRate ?? "0.1",
+        }),
+    ...(webSentryDsn == null && webSentryPublicDsn == null
+      ? {}
+      : {
+          ...(resolveOptionalEnvValue(process.env.SENTRY_AUTH_TOKEN) == null
+            ? {}
+            : { sentryAuthToken: resolveOptionalEnvValue(process.env.SENTRY_AUTH_TOKEN) }),
+          ...(webSentryDsn == null ? {} : { webSentryDsn }),
+          ...(webSentryPublicDsn == null
+            ? {}
+            : { webSentryPublicDsn }),
+          ...(sentryEnvironment == null ? { sentryEnvironment: "production" } : { sentryEnvironment }),
+          ...(resolveOptionalEnvValue(process.env.SENTRY_ORG) == null
+            ? {}
+            : { sentryOrg: resolveOptionalEnvValue(process.env.SENTRY_ORG) }),
+          ...(resolveOptionalEnvValue(process.env.SENTRY_PROJECT) == null
+            ? {}
+            : { sentryProject: resolveOptionalEnvValue(process.env.SENTRY_PROJECT) }),
+          ...(resolveOptionalEnvValue(process.env.SENTRY_RELEASE) == null
+            ? {}
+            : { sentryRelease: resolveOptionalEnvValue(process.env.SENTRY_RELEASE) }),
+          ...(webSentryTracesSampleRate == null ? {} : { webSentryTracesSampleRate }),
+        }),
     telemetryRelayUrl: resolveToolPackTelemetryRelayUrl(process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL),
     to: resolveToolPackBuildOutput(platform, options.to),
     webOutputMode: resolveToolPackWebOutputMode(platform, process.env.OD_WEB_OUTPUT_MODE),

--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -25,6 +25,7 @@ import {
 } from "@open-design/platform";
 
 import type { ToolPackConfig } from "./config.js";
+import { createPackagedRuntimeConfig } from "./packaged-config.js";
 import { copyBundledResourceTrees, linuxResources } from "./resources.js";
 
 const execFileAsync = promisify(execFile);
@@ -77,6 +78,40 @@ function toDockerMountPath(value: string): string {
 
 function shellQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function pushDockerEnvName(args: string[], name: string, value: string | undefined): void {
+  if (value != null) {
+    args.push("-e", name);
+  }
+}
+
+export function buildDockerEnv(
+  config: ToolPackConfig,
+  baseEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...baseEnv };
+  const set = (name: string, value: string | undefined) => {
+    if (value != null) {
+      env[name] = value;
+    }
+  };
+
+  set("OPEN_DESIGN_DAEMON_SENTRY_DSN", config.sentryDsn);
+  set("OPEN_DESIGN_DAEMON_SENTRY_ENVIRONMENT", config.sentryEnvironment);
+  set("SENTRY_ENVIRONMENT", config.sentryEnvironment);
+  set("NEXT_PUBLIC_SENTRY_ENVIRONMENT", config.sentryEnvironment);
+  set("OPEN_DESIGN_DAEMON_SENTRY_TRACES_SAMPLE_RATE", config.sentryTracesSampleRate);
+  set("SENTRY_DSN", config.webSentryDsn);
+  set("NEXT_PUBLIC_SENTRY_DSN", config.webSentryPublicDsn);
+  set("SENTRY_AUTH_TOKEN", config.sentryAuthToken);
+  set("SENTRY_ORG", config.sentryOrg);
+  set("SENTRY_PROJECT", config.sentryProject);
+  set("SENTRY_RELEASE", config.sentryRelease);
+  set("NEXT_PUBLIC_SENTRY_RELEASE", config.sentryRelease);
+  set("NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE", config.webSentryTracesSampleRate);
+
+  return env;
 }
 
 export function buildDockerArgs(
@@ -132,7 +167,7 @@ export function buildDockerArgs(
   if (config.appVersion != null) {
     innerArgs.push(`--app-version ${shellQuote(config.appVersion)}`);
   }
-  const innerCommand = `${pnpmCmd} install --frozen-lockfile && ` + innerArgs.join(" ");
+  const innerCommand = `env -u SENTRY_AUTH_TOKEN ${pnpmCmd} install --frozen-lockfile && ` + innerArgs.join(" ");
 
   const dockerArgs = [
     "run",
@@ -159,6 +194,19 @@ export function buildDockerArgs(
   if (config.telemetryRelayUrl != null) {
     dockerArgs.push("-e", `OPEN_DESIGN_TELEMETRY_RELAY_URL=${config.telemetryRelayUrl}`);
   }
+  pushDockerEnvName(dockerArgs, "OPEN_DESIGN_DAEMON_SENTRY_DSN", config.sentryDsn);
+  pushDockerEnvName(dockerArgs, "OPEN_DESIGN_DAEMON_SENTRY_ENVIRONMENT", config.sentryEnvironment);
+  pushDockerEnvName(dockerArgs, "SENTRY_ENVIRONMENT", config.sentryEnvironment);
+  pushDockerEnvName(dockerArgs, "NEXT_PUBLIC_SENTRY_ENVIRONMENT", config.sentryEnvironment);
+  pushDockerEnvName(dockerArgs, "OPEN_DESIGN_DAEMON_SENTRY_TRACES_SAMPLE_RATE", config.sentryTracesSampleRate);
+  pushDockerEnvName(dockerArgs, "SENTRY_DSN", config.webSentryDsn);
+  pushDockerEnvName(dockerArgs, "NEXT_PUBLIC_SENTRY_DSN", config.webSentryPublicDsn);
+  pushDockerEnvName(dockerArgs, "SENTRY_AUTH_TOKEN", config.sentryAuthToken);
+  pushDockerEnvName(dockerArgs, "SENTRY_ORG", config.sentryOrg);
+  pushDockerEnvName(dockerArgs, "SENTRY_PROJECT", config.sentryProject);
+  pushDockerEnvName(dockerArgs, "SENTRY_RELEASE", config.sentryRelease);
+  pushDockerEnvName(dockerArgs, "NEXT_PUBLIC_SENTRY_RELEASE", config.sentryRelease);
+  pushDockerEnvName(dockerArgs, "NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE", config.webSentryTracesSampleRate);
   dockerArgs.push(
     "-w",
     "/project",
@@ -387,13 +435,9 @@ async function writeAssembledApp(
   await writeFile(
     paths.packagedConfigPath,
     `${JSON.stringify(
-      {
-        appVersion: version,
-        namespace: config.namespace,
+      createPackagedRuntimeConfig(config, version, {
         nodeCommandRelative: "open-design/bin/node",
-        ...(config.telemetryRelayUrl == null ? {} : { telemetryRelayUrl: config.telemetryRelayUrl }),
-        ...(config.portable ? {} : { namespaceBaseRoot: config.roots.runtime.namespaceBaseRoot }),
-      },
+      }),
       null,
       2,
     )}\n`,
@@ -546,7 +590,7 @@ async function runBuildInContainer(config: ToolPackConfig): Promise<void> {
   const args = buildDockerArgs(config, { uid, gid });
 
   return new Promise((resolve, reject) => {
-    const child = spawn("docker", args, { stdio: "inherit", env: process.env });
+    const child = spawn("docker", args, { stdio: "inherit", env: buildDockerEnv(config) });
     // In Node's child-process `exit` event, code === null means the child was
     // terminated by a signal (SIGTERM, SIGKILL, etc.). A signal-terminated
     // build is NOT a successful build — the AppImage may be missing or partial,
@@ -1155,6 +1199,34 @@ async function waitForWebIdentity(config: ToolPackConfig, childPid: number, time
   return null;
 }
 
+export type HeadlessLauncherScriptValues = {
+  dataDir: string;
+  entryPath: string;
+  namespace: string;
+  nodePath: string;
+  resourceRoot: string;
+};
+
+export function renderHeadlessLauncherScript(values: HeadlessLauncherScriptValues): string {
+  const env = [
+    `OD_NAMESPACE=${JSON.stringify(values.namespace)}`,
+    `OD_DATA_DIR=${JSON.stringify(values.dataDir)}`,
+    `OD_RESOURCE_ROOT=${JSON.stringify(values.resourceRoot)}`,
+  ];
+
+  return [
+    "#!/bin/sh",
+    `# Open Design headless launcher — namespace: ${values.namespace}`,
+    [
+      ...env,
+      "exec",
+      JSON.stringify(values.nodePath),
+      JSON.stringify(values.entryPath),
+      '"$@"',
+    ].join(" "),
+  ].join("\n") + "\n";
+}
+
 export async function installPackedLinuxHeadless(config: ToolPackConfig): Promise<LinuxHeadlessInstallResult> {
   const paths = resolveLinuxPaths(config);
   const entryPath = resolveHeadlessEntryPath(paths);
@@ -1180,11 +1252,13 @@ export async function installPackedLinuxHeadless(config: ToolPackConfig): Promis
   // so the headless process writes its runtime data under the same paths that
   // tools-pack stop/logs expect.
   const dataDir = dirname(config.roots.runtime.namespaceBaseRoot);
-  const script = [
-    "#!/bin/sh",
-    `# Open Design headless launcher — namespace: ${config.namespace}`,
-    `OD_NAMESPACE=${JSON.stringify(config.namespace)} OD_DATA_DIR=${JSON.stringify(dataDir)} OD_RESOURCE_ROOT=${JSON.stringify(paths.resourceRoot)} exec ${JSON.stringify(nodePath)} ${JSON.stringify(entryPath)} "$@"`,
-  ].join("\n") + "\n";
+  const script = renderHeadlessLauncherScript({
+    dataDir,
+    entryPath,
+    namespace: config.namespace,
+    nodePath,
+    resourceRoot: paths.resourceRoot,
+  });
 
   await writeFile(launcherPath, script, { encoding: "utf8", mode: 0o755 });
 

--- a/tools/pack/src/mac/app.ts
+++ b/tools/pack/src/mac/app.ts
@@ -2,6 +2,7 @@ import { chmod, cp, mkdir, readdir, rm, writeFile } from "node:fs/promises";
 import { dirname, join, relative } from "node:path";
 
 import type { ToolPackConfig } from "../config.js";
+import { createPackagedRuntimeConfig } from "../packaged-config.js";
 import {
   MAC_DAEMON_PREBUNDLE_ESM_REQUIRE_BANNER,
   MAC_PREBUNDLE_ESBUILD_TARGET,
@@ -227,17 +228,12 @@ export async function writeAssembledApp(
   await writeFile(
     paths.packagedConfigPath,
     `${JSON.stringify(
-      {
-        appVersion: packagedVersion,
+      createPackagedRuntimeConfig(config, packagedVersion, {
         ...(usePrebundledStandaloneWeb ? { daemonCliEntryRelative: MAC_PREBUNDLED_DAEMON_CLI_RELATIVE_PATH } : {}),
         ...(usePrebundledStandaloneWeb ? { daemonSidecarEntryRelative: MAC_PREBUNDLED_DAEMON_SIDECAR_RELATIVE_PATH } : {}),
-        namespace: config.namespace,
         nodeCommandRelative: "open-design/bin/node",
-        ...(config.telemetryRelayUrl == null ? {} : { telemetryRelayUrl: config.telemetryRelayUrl }),
         ...(usePrebundledStandaloneWeb ? { webSidecarEntryRelative: MAC_PREBUNDLED_WEB_SIDECAR_RELATIVE_PATH } : {}),
-        webOutputMode: config.webOutputMode,
-        ...(config.portable ? {} : { namespaceBaseRoot: config.roots.runtime.namespaceBaseRoot }),
-      },
+      }),
       null,
       2,
     )}\n`,

--- a/tools/pack/src/packaged-config.ts
+++ b/tools/pack/src/packaged-config.ts
@@ -1,0 +1,24 @@
+import type { ToolPackConfig } from "./config.js";
+
+type PackagedRuntimeConfigExtra = Record<string, unknown>;
+
+export function createPackagedRuntimeConfig(
+  config: ToolPackConfig,
+  packagedVersion: string,
+  extra: PackagedRuntimeConfigExtra = {},
+): Record<string, unknown> {
+  const webSentryDsn = config.webSentryDsn ?? config.webSentryPublicDsn;
+
+  return {
+    appVersion: packagedVersion,
+    namespace: config.namespace,
+    ...extra,
+    ...(config.sentryDsn == null ? {} : { sentryDsn: config.sentryDsn }),
+    ...(config.sentryEnvironment == null ? {} : { sentryEnvironment: config.sentryEnvironment }),
+    ...(config.sentryTracesSampleRate == null ? {} : { sentryTracesSampleRate: config.sentryTracesSampleRate }),
+    ...(config.telemetryRelayUrl == null ? {} : { telemetryRelayUrl: config.telemetryRelayUrl }),
+    webOutputMode: config.webOutputMode,
+    ...(webSentryDsn == null ? {} : { webSentryDsn }),
+    ...(config.portable ? {} : { namespaceBaseRoot: config.roots.runtime.namespaceBaseRoot }),
+  };
+}

--- a/tools/pack/src/win/manifest.ts
+++ b/tools/pack/src/win/manifest.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
 import type { ToolPackConfig } from "../config.js";
+import { createPackagedRuntimeConfig } from "../packaged-config.js";
 import { pathExists } from "./fs.js";
 import type { WinBuiltAppManifest, WinPaths } from "./types.js";
 
@@ -16,13 +17,7 @@ export async function readPackagedVersion(config: ToolPackConfig): Promise<strin
 }
 
 function createPackagedConfig(config: ToolPackConfig, packagedVersion: string): Record<string, unknown> {
-  return {
-    appVersion: packagedVersion,
-    namespace: config.namespace,
-    ...(config.telemetryRelayUrl == null ? {} : { telemetryRelayUrl: config.telemetryRelayUrl }),
-    webOutputMode: config.webOutputMode,
-    ...(config.portable ? {} : { namespaceBaseRoot: config.roots.runtime.namespaceBaseRoot }),
-  };
+  return createPackagedRuntimeConfig(config, packagedVersion);
 }
 
 export async function writePackagedConfigFile(

--- a/tools/pack/tests/config.test.ts
+++ b/tools/pack/tests/config.test.ts
@@ -3,6 +3,15 @@ import { afterEach, describe, expect, it } from "vitest";
 import { resolveToolPackConfig } from "../src/config.js";
 
 const savedTelemetryRelayUrl = process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+const savedDaemonSentryDsn = process.env.OPEN_DESIGN_DAEMON_SENTRY_DSN;
+const savedDaemonSentryEnvironment = process.env.OPEN_DESIGN_DAEMON_SENTRY_ENVIRONMENT;
+const savedDaemonSentryTracesSampleRate = process.env.OPEN_DESIGN_DAEMON_SENTRY_TRACES_SAMPLE_RATE;
+const savedNextPublicSentryDsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+const savedSentryAuthToken = process.env.SENTRY_AUTH_TOKEN;
+const savedSentryDsn = process.env.SENTRY_DSN;
+const savedSentryEnvironment = process.env.SENTRY_ENVIRONMENT;
+const savedSentryOrg = process.env.SENTRY_ORG;
+const savedSentryProject = process.env.SENTRY_PROJECT;
 
 afterEach(() => {
   if (savedTelemetryRelayUrl == null) {
@@ -10,6 +19,73 @@ afterEach(() => {
   } else {
     process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL = savedTelemetryRelayUrl;
   }
+  if (savedDaemonSentryDsn == null) {
+    delete process.env.OPEN_DESIGN_DAEMON_SENTRY_DSN;
+  } else {
+    process.env.OPEN_DESIGN_DAEMON_SENTRY_DSN = savedDaemonSentryDsn;
+  }
+  if (savedDaemonSentryEnvironment == null) {
+    delete process.env.OPEN_DESIGN_DAEMON_SENTRY_ENVIRONMENT;
+  } else {
+    process.env.OPEN_DESIGN_DAEMON_SENTRY_ENVIRONMENT = savedDaemonSentryEnvironment;
+  }
+  if (savedDaemonSentryTracesSampleRate == null) {
+    delete process.env.OPEN_DESIGN_DAEMON_SENTRY_TRACES_SAMPLE_RATE;
+  } else {
+    process.env.OPEN_DESIGN_DAEMON_SENTRY_TRACES_SAMPLE_RATE = savedDaemonSentryTracesSampleRate;
+  }
+  if (savedNextPublicSentryDsn == null) {
+    delete process.env.NEXT_PUBLIC_SENTRY_DSN;
+  } else {
+    process.env.NEXT_PUBLIC_SENTRY_DSN = savedNextPublicSentryDsn;
+  }
+  if (savedSentryAuthToken == null) {
+    delete process.env.SENTRY_AUTH_TOKEN;
+  } else {
+    process.env.SENTRY_AUTH_TOKEN = savedSentryAuthToken;
+  }
+  if (savedSentryDsn == null) {
+    delete process.env.SENTRY_DSN;
+  } else {
+    process.env.SENTRY_DSN = savedSentryDsn;
+  }
+  if (savedSentryEnvironment == null) {
+    delete process.env.SENTRY_ENVIRONMENT;
+  } else {
+    process.env.SENTRY_ENVIRONMENT = savedSentryEnvironment;
+  }
+  if (savedSentryOrg == null) {
+    delete process.env.SENTRY_ORG;
+  } else {
+    process.env.SENTRY_ORG = savedSentryOrg;
+  }
+  if (savedSentryProject == null) {
+    delete process.env.SENTRY_PROJECT;
+  } else {
+    process.env.SENTRY_PROJECT = savedSentryProject;
+  }
+});
+
+describe("resolveToolPackConfig web Sentry", () => {
+  it("reads web Sentry build env separately from daemon Sentry env", () => {
+    process.env.OPEN_DESIGN_DAEMON_SENTRY_DSN = "https://public@example.ingest.sentry.io/daemon";
+    process.env.NEXT_PUBLIC_SENTRY_DSN = " https://public@example.ingest.sentry.io/web-public ";
+    process.env.SENTRY_AUTH_TOKEN = " upload-token ";
+    process.env.SENTRY_DSN = " https://public@example.ingest.sentry.io/web ";
+    process.env.SENTRY_ENVIRONMENT = " production ";
+    process.env.SENTRY_ORG = " zhenheai ";
+    process.env.SENTRY_PROJECT = " open-design-web ";
+
+    const config = resolveToolPackConfig("mac", { namespace: "web-sentry-test" });
+
+    expect(config.sentryDsn).toBe("https://public@example.ingest.sentry.io/daemon");
+    expect(config.webSentryDsn).toBe("https://public@example.ingest.sentry.io/web");
+    expect(config.webSentryPublicDsn).toBe("https://public@example.ingest.sentry.io/web-public");
+    expect(config.sentryAuthToken).toBe("upload-token");
+    expect(config.sentryEnvironment).toBe("production");
+    expect(config.sentryOrg).toBe("zhenheai");
+    expect(config.sentryProject).toBe("open-design-web");
+  });
 });
 
 describe("resolveToolPackConfig telemetry relay", () => {
@@ -30,6 +106,43 @@ describe("resolveToolPackConfig telemetry relay", () => {
     process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL = "http://telemetry.open-design.ai/api/langfuse";
     expect(() => resolveToolPackConfig("mac")).toThrow(
       /OPEN_DESIGN_TELEMETRY_RELAY_URL must use https/,
+    );
+  });
+});
+
+describe("resolveToolPackConfig daemon Sentry", () => {
+  it("reads and normalizes daemon Sentry env for packaged config", () => {
+    process.env.OPEN_DESIGN_DAEMON_SENTRY_DSN = " https://public@example.ingest.sentry.io/1 ";
+    process.env.OPEN_DESIGN_DAEMON_SENTRY_ENVIRONMENT = " production ";
+    process.env.OPEN_DESIGN_DAEMON_SENTRY_TRACES_SAMPLE_RATE = "0.25";
+
+    const config = resolveToolPackConfig("mac", { namespace: "sentry-test" });
+
+    expect(config.sentryDsn).toBe("https://public@example.ingest.sentry.io/1");
+    expect(config.sentryEnvironment).toBe("production");
+    expect(config.sentryTracesSampleRate).toBe("0.25");
+  });
+
+  it("rejects invalid daemon Sentry DSNs", () => {
+    process.env.OPEN_DESIGN_DAEMON_SENTRY_DSN = "not-a-url";
+    expect(() => resolveToolPackConfig("mac")).toThrow(
+      /OPEN_DESIGN_DAEMON_SENTRY_DSN must be an absolute https URL/,
+    );
+  });
+
+  it("rejects plaintext daemon Sentry DSNs", () => {
+    process.env.OPEN_DESIGN_DAEMON_SENTRY_DSN = "http://example.ingest.sentry.io/1";
+    expect(() => resolveToolPackConfig("mac")).toThrow(
+      /OPEN_DESIGN_DAEMON_SENTRY_DSN must use https/,
+    );
+  });
+
+  it("rejects invalid daemon Sentry sample rates", () => {
+    process.env.OPEN_DESIGN_DAEMON_SENTRY_DSN = "https://public@example.ingest.sentry.io/1";
+    process.env.OPEN_DESIGN_DAEMON_SENTRY_TRACES_SAMPLE_RATE = "1.5";
+
+    expect(() => resolveToolPackConfig("mac")).toThrow(
+      /OPEN_DESIGN_DAEMON_SENTRY_TRACES_SAMPLE_RATE must be between 0 and 1/,
     );
   });
 });

--- a/tools/pack/tests/linux.test.ts
+++ b/tools/pack/tests/linux.test.ts
@@ -8,8 +8,10 @@ import { describe, expect, it } from "vitest";
 import type { ToolPackConfig } from "../src/config.js";
 import {
   buildDockerArgs,
+  buildDockerEnv,
   matchesAppImageProcess,
   renderDesktopTemplate,
+  renderHeadlessLauncherScript,
   sanitizeNamespace,
 } from "../src/linux.js";
 
@@ -97,10 +99,47 @@ describe("buildDockerArgs", () => {
     expect(args).toContain("OPEN_DESIGN_TELEMETRY_RELAY_URL=https://telemetry.open-design.ai/api/langfuse");
   });
 
+  it("passes web Sentry build env into containerized builds without exposing values in docker argv", () => {
+    const config = {
+      ...makeConfig(),
+      sentryAuthToken: "upload-token",
+      sentryDsn: "https://public@example.ingest.sentry.io/daemon",
+      sentryEnvironment: "production",
+      sentryOrg: "zhenheai",
+      sentryProject: "open-design-web",
+      webSentryDsn: "https://public@example.ingest.sentry.io/web",
+      webSentryPublicDsn: "https://public@example.ingest.sentry.io/web",
+    };
+    const args = buildDockerArgs(config, { uid: 1000, gid: 1000 });
+    const dockerEnv = buildDockerEnv(config, {});
+
+    expect(args).toContain("OPEN_DESIGN_DAEMON_SENTRY_DSN");
+    expect(args).toContain("SENTRY_DSN");
+    expect(args).toContain("NEXT_PUBLIC_SENTRY_DSN");
+    expect(args).toContain("SENTRY_AUTH_TOKEN");
+    expect(args).toContain("SENTRY_ORG");
+    expect(args).toContain("SENTRY_PROJECT");
+    expect(args).toContain("SENTRY_ENVIRONMENT");
+    expect(args).not.toContain("OPEN_DESIGN_DAEMON_SENTRY_DSN=https://public@example.ingest.sentry.io/daemon");
+    expect(args).not.toContain("SENTRY_DSN=https://public@example.ingest.sentry.io/web");
+    expect(args).not.toContain("NEXT_PUBLIC_SENTRY_DSN=https://public@example.ingest.sentry.io/web");
+    expect(args).not.toContain("SENTRY_AUTH_TOKEN=upload-token");
+
+    expect(dockerEnv).toMatchObject({
+      NEXT_PUBLIC_SENTRY_DSN: "https://public@example.ingest.sentry.io/web",
+      OPEN_DESIGN_DAEMON_SENTRY_DSN: "https://public@example.ingest.sentry.io/daemon",
+      SENTRY_AUTH_TOKEN: "upload-token",
+      SENTRY_DSN: "https://public@example.ingest.sentry.io/web",
+      SENTRY_ENVIRONMENT: "production",
+      SENTRY_ORG: "zhenheai",
+      SENTRY_PROJECT: "open-design-web",
+    });
+  });
+
   it("re-invokes pnpm tools-pack linux build inside the container without --containerized", () => {
     const args = buildDockerArgs(makeConfig(), { uid: 1000, gid: 1000 });
     const last = args[args.length - 1];
-    expect(last).toMatch(/npx --yes pnpm@\d+\.\d+\.\d+ install --frozen-lockfile/);
+    expect(last).toMatch(/env -u SENTRY_AUTH_TOKEN npx --yes pnpm@\d+\.\d+\.\d+ install --frozen-lockfile/);
     expect(last).toMatch(/npx --yes pnpm@\d+\.\d+\.\d+ tools-pack linux build --to all --namespace default/);
     expect(last).not.toMatch(/--containerized/);
   });
@@ -163,6 +202,34 @@ describe("buildDockerArgs", () => {
     );
     const last = args[args.length - 1];
     expect(last).toContain("--app-version '0.5.0-beta.1'\\''quoted'");
+  });
+});
+
+describe("renderHeadlessLauncherScript", () => {
+  it("keeps Sentry DSNs out of installed headless launchers", () => {
+    const sentryValues = {
+      sentryDsn: "https://public@example.ingest.sentry.io/daemon",
+      sentryEnvironment: "production",
+      sentryTracesSampleRate: "0.1",
+      webSentryDsn: "https://public@example.ingest.sentry.io/web",
+    };
+    const script = renderHeadlessLauncherScript({
+      dataDir: "/work/.tmp/tools-pack/runtime/linux",
+      entryPath: "/work/.tmp/tools-pack/out/linux/namespaces/default/app/node_modules/@open-design/packaged/dist/headless.mjs",
+      namespace: "default",
+      nodePath: "/work/.tmp/tools-pack/out/linux/namespaces/default/app/open-design/bin/node",
+      resourceRoot: "/work/.tmp/tools-pack/out/linux/namespaces/default/open-design",
+      ...sentryValues,
+    });
+
+    expect(script).not.toContain("OD_PACKAGED_CONFIG_PATH");
+    expect(script).toContain('OD_DATA_DIR="/work/.tmp/tools-pack/runtime/linux"');
+    expect(script).toContain('OD_RESOURCE_ROOT="/work/.tmp/tools-pack/out/linux/namespaces/default/open-design"');
+    expect(script).not.toContain("OPEN_DESIGN_DAEMON_SENTRY_DSN");
+    expect(script).not.toContain("OPEN_DESIGN_DAEMON_SENTRY_ENVIRONMENT");
+    expect(script).not.toContain("OPEN_DESIGN_DAEMON_SENTRY_TRACES_SAMPLE_RATE");
+    expect(script).not.toContain("SENTRY_DSN");
+    expect(script).not.toContain("https://public@example.ingest.sentry.io");
   });
 });
 

--- a/tools/pack/tests/packaged-config.test.ts
+++ b/tools/pack/tests/packaged-config.test.ts
@@ -1,0 +1,69 @@
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import type { ToolPackConfig } from "../src/config.js";
+import { createPackagedRuntimeConfig } from "../src/packaged-config.js";
+
+function createConfig(root: string): ToolPackConfig {
+  return {
+    containerized: false,
+    electronBuilderCliPath: "/x/electron-builder/cli.js",
+    electronDistPath: "/x/electron/dist",
+    electronVersion: "41.3.0",
+    macCompression: "normal",
+    namespace: "release-beta",
+    platform: "mac",
+    portable: false,
+    removeData: false,
+    removeLogs: false,
+    removeProductUserData: false,
+    removeSidecars: false,
+    roots: {
+      output: {
+        appBuilderRoot: join(root, "out", "mac", "namespaces", "release-beta", "builder"),
+        namespaceRoot: join(root, "out", "mac", "namespaces", "release-beta"),
+        platformRoot: join(root, "out", "mac"),
+        root: join(root, "out"),
+      },
+      runtime: {
+        namespaceBaseRoot: join(root, "runtime", "mac", "namespaces"),
+        namespaceRoot: join(root, "runtime", "mac", "namespaces", "release-beta"),
+      },
+      cacheRoot: join(root, "cache"),
+      toolPackRoot: root,
+    },
+    sentryAuthToken: "upload-token",
+    sentryDsn: "https://public@example.ingest.sentry.io/daemon",
+    sentryEnvironment: "production",
+    sentryTracesSampleRate: "0.1",
+    signed: false,
+    silent: true,
+    to: "app",
+    webOutputMode: "standalone",
+    webSentryDsn: "https://public@example.ingest.sentry.io/web",
+    workspaceRoot: root,
+  };
+}
+
+describe("createPackagedRuntimeConfig", () => {
+  it("bakes public Sentry DSNs into packaged runtime config without storing upload tokens", () => {
+    const config = createPackagedRuntimeConfig(createConfig("/work"), "1.2.3", {
+      nodeCommandRelative: "open-design/bin/node",
+    });
+
+    expect(config).toMatchObject({
+      appVersion: "1.2.3",
+      namespace: "release-beta",
+      namespaceBaseRoot: join("/work", "runtime", "mac", "namespaces"),
+      nodeCommandRelative: "open-design/bin/node",
+      sentryDsn: "https://public@example.ingest.sentry.io/daemon",
+      sentryEnvironment: "production",
+      sentryTracesSampleRate: "0.1",
+      webOutputMode: "standalone",
+      webSentryDsn: "https://public@example.ingest.sentry.io/web",
+    });
+    expect(config).not.toHaveProperty("sentryAuthToken");
+    expect(config).not.toHaveProperty("SENTRY_AUTH_TOKEN");
+  });
+});

--- a/tools/pack/tests/web-standalone-after-pack.test.ts
+++ b/tools/pack/tests/web-standalone-after-pack.test.ts
@@ -48,7 +48,12 @@ async function writeRootWebPackage(resourcesRoot: string): Promise<void> {
 
 async function writeStandaloneFixture(
   workspaceRoot: string,
-  options: { includeHoistedNext: boolean; includeWebNext: boolean; useAbsolutePnpmSymlinks?: boolean },
+  options: {
+    includeHoistedNext: boolean;
+    includeNextDotNodeModulesSymlinks?: boolean;
+    includeWebNext: boolean;
+    useAbsolutePnpmSymlinks?: boolean;
+  },
 ): Promise<string> {
   const standaloneRoot = join(workspaceRoot, "apps", "web", ".next", "standalone");
   const sourceWebRoot = join(standaloneRoot, "apps", "web");
@@ -75,6 +80,15 @@ async function writeStandaloneFixture(
     }
   }
 
+  if (options.includeNextDotNodeModulesSymlinks) {
+    const importInTheMiddleRoot = await writePnpmLinkedPackage(standaloneRoot, "import-in-the-middle");
+    const requireInTheMiddleRoot = await writePnpmLinkedPackage(standaloneRoot, "require-in-the-middle");
+    const nextNodeModulesRoot = join(sourceWebRoot, ".next", "node_modules");
+    await mkdir(nextNodeModulesRoot, { recursive: true });
+    await symlink(importInTheMiddleRoot, join(nextNodeModulesRoot, "import-in-the-middle-3b8720d58ab45988"));
+    await symlink(requireInTheMiddleRoot, join(nextNodeModulesRoot, "require-in-the-middle-a99415fa67232f7f"));
+  }
+
   await mkdir(join(sourceWebRoot, ".next", "static"), { recursive: true });
   await writeFile(join(sourceWebRoot, "server.js"), "module.exports = {};\n", "utf8");
   await writeFile(join(sourceWebRoot, ".next", "BUILD_ID"), "fixture\n", "utf8");
@@ -87,6 +101,7 @@ async function writeStandaloneFixture(
 
 async function runFixture(options: {
   includeHoistedNext?: boolean;
+  includeNextDotNodeModulesSymlinks?: boolean;
   includeWebNext: boolean;
   omitMacAdhocBundleSign?: boolean;
   platformName?: "darwin" | "win32";
@@ -95,12 +110,14 @@ async function runFixture(options: {
   appOutDir: string;
   auditReportPath: string;
   destinationRoot: string;
+  destinationWebRoot: string;
   root: string;
 }> {
   const root = await mkdtemp(join(tmpdir(), "open-design-web-standalone-hook-"));
   const workspaceRoot = join(root, "workspace");
   const standaloneSourceRoot = await writeStandaloneFixture(workspaceRoot, {
     includeHoistedNext: options.includeHoistedNext ?? true,
+    includeNextDotNodeModulesSymlinks: options.includeNextDotNodeModulesSymlinks,
     includeWebNext: options.includeWebNext,
     useAbsolutePnpmSymlinks: options.useAbsolutePnpmSymlinks,
   });
@@ -159,6 +176,7 @@ async function runFixture(options: {
     appOutDir,
     auditReportPath,
     destinationRoot: join(resourcesRoot, "open-design-web-standalone"),
+    destinationWebRoot: join(resourcesRoot, "open-design-web-standalone", "apps", "web"),
     root,
   };
 }
@@ -216,6 +234,32 @@ describe("web standalone afterPack hook", () => {
 
       expect(report.platformName).toBe("win32");
       expect(report.macAdhocBundleSign).toEqual([]);
+    } finally {
+      await rm(fixture.root, { force: true, recursive: true });
+    }
+  });
+
+  it("dereferences win32 copied .next node_modules symlinks from Sentry instrumentation deps", async () => {
+    const fixture = await runFixture({
+      includeNextDotNodeModulesSymlinks: true,
+      includeWebNext: true,
+      platformName: "win32",
+    });
+
+    try {
+      const report = JSON.parse(await readFile(fixture.auditReportPath, "utf8")) as {
+        copiedAudit: { externalSymlinks: string[] };
+      };
+      const copiedImportLink = join(
+        fixture.destinationWebRoot,
+        ".next",
+        "node_modules",
+        "import-in-the-middle-3b8720d58ab45988",
+      );
+
+      expect(report.copiedAudit.externalSymlinks).toEqual([]);
+      await expect(readlink(copiedImportLink)).rejects.toThrow();
+      expect(await pathExists(join(copiedImportLink, "package.json"))).toBe(true);
     } finally {
       await rm(fixture.root, { force: true, recursive: true });
     }

--- a/tools/pack/tests/win-builder.test.ts
+++ b/tools/pack/tests/win-builder.test.ts
@@ -4,7 +4,9 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import type { ToolPackConfig } from "../src/config.js";
 import { materializeCachedUnpackedForInstaller } from "../src/win/builder.js";
+import { writePackagedConfigFile } from "../src/win/manifest.js";
 import type { WinPaths } from "../src/win/types.js";
 
 function createPaths(root: string): WinPaths {
@@ -44,6 +46,72 @@ function createPaths(root: string): WinPaths {
     unpackedRoot: join(namespaceRoot, "builder", "win-unpacked"),
   };
 }
+
+function createConfig(root: string): ToolPackConfig {
+  return {
+    containerized: false,
+    electronBuilderCliPath: "/x/electron-builder/cli.js",
+    electronDistPath: "/x/electron/dist",
+    electronVersion: "41.3.0",
+    macCompression: "normal",
+    namespace: "second",
+    platform: "win",
+    portable: false,
+    removeData: false,
+    removeLogs: false,
+    removeProductUserData: false,
+    removeSidecars: false,
+    roots: {
+      output: {
+        appBuilderRoot: join(root, "namespaces", "second", "builder"),
+        namespaceRoot: join(root, "namespaces", "second"),
+        platformRoot: join(root, "namespaces"),
+        root,
+      },
+      runtime: {
+        namespaceBaseRoot: join(root, "runtime", "namespaces"),
+        namespaceRoot: join(root, "runtime", "namespaces", "second"),
+      },
+      cacheRoot: join(root, "cache"),
+      toolPackRoot: root,
+    },
+    sentryDsn: "https://public@example.ingest.sentry.io/daemon",
+    sentryEnvironment: "production",
+    sentryTracesSampleRate: "0.1",
+    signed: false,
+    silent: true,
+    to: "nsis",
+    webOutputMode: "standalone",
+    webSentryDsn: "https://public@example.ingest.sentry.io/web",
+    workspaceRoot: root,
+  };
+}
+
+describe("writePackagedConfigFile", () => {
+  it("persists public Sentry DSNs in Windows packaged config without the upload token", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-win-config-"));
+    const paths = createPaths(root);
+
+    try {
+      await writePackagedConfigFile(paths.packagedConfigPath, createConfig(root), "1.2.3");
+      const config = JSON.parse(await readFile(paths.packagedConfigPath, "utf8")) as Record<string, unknown>;
+
+      expect(config).toMatchObject({
+        appVersion: "1.2.3",
+        namespace: "second",
+        sentryDsn: "https://public@example.ingest.sentry.io/daemon",
+        sentryEnvironment: "production",
+        sentryTracesSampleRate: "0.1",
+        webOutputMode: "standalone",
+        webSentryDsn: "https://public@example.ingest.sentry.io/web",
+      });
+      expect(config).not.toHaveProperty("sentryAuthToken");
+      expect(config).not.toHaveProperty("SENTRY_AUTH_TOKEN");
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});
 
 describe("materializeCachedUnpackedForInstaller", () => {
   it("overwrites cached packaged config and app package version", async () => {


### PR DESCRIPTION
## Summary
- add agent-skill context docs for tracker, triage labels, domain docs, and upstream strategy
- record upstream-first stabilization ADRs for nexu-io/open-design
- stabilize daemon, web, and packaged tests under the Node 24 workspace baseline

## Validation
- PATH=/opt/homebrew/opt/node@24/bin:/Users/avyhsu/.codex/tmp/arg0/codex-arg08Duaw5:/opt/homebrew/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/Users/avyhsu/.local/bin:/Users/avyhsu/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/Obsidian.app/Contents/MacOS:/Applications/Warp.app/Contents/Resources/bin pnpm install
- PATH=/opt/homebrew/opt/node@24/bin:/Users/avyhsu/.codex/tmp/arg0/codex-arg08Duaw5:/opt/homebrew/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/Users/avyhsu/.local/bin:/Users/avyhsu/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/Obsidian.app/Contents/MacOS:/Applications/Warp.app/Contents/Resources/bin pnpm typecheck
- PATH=/opt/homebrew/opt/node@24/bin:/Users/avyhsu/.codex/tmp/arg0/codex-arg08Duaw5:/opt/homebrew/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/Users/avyhsu/.local/bin:/Users/avyhsu/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/Obsidian.app/Contents/MacOS:/Applications/Warp.app/Contents/Resources/bin pnpm -r --if-present run test

## Notes
- Node 24.15.0 was installed via Homebrew as keg-only and used only through PATH for validation.