### PR TITLE
fix(web): pass skillId to pickAndImport in Open folder flow

### DIFF
--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -560,7 +560,9 @@ export function NewProjectPanel({
       setImportFolderError(null);
       setImportingFolder(true);
       try {
-        const result = await window.electronAPI!.pickAndImport!();
+        const result = await window.electronAPI!.pickAndImport!({
+          skillId: skillIdForTab,
+        });
         if (!result) return;
         if (result.ok === true) {
           await onImportFolderResponse(result.response);


### PR DESCRIPTION
## Summary

- Pass `skillId: skillIdForTab` to `pickAndImport()` in `handleOpenFolder()`, matching the behavior of `handleCreate()`
- Fixes #1472

## Problem

When creating a project via "Open folder", `handleOpenFolder()` called `pickAndImport()` with no arguments. The project was created without a `skillId`, so skills with `default_for` (e.g. `dsl-ui-builder`) were never applied.

## Fix

```diff
- const result = await window.electronAPI!.pickAndImport!();
+ const result = await window.electronAPI!.pickAndImport!({
+   skillId: skillIdForTab,
+ });
```

## Test plan

- [ ] Create a skill with `default_for: ["prototype"]`
- [ ] Create project via "Create" button → verify `skillId` is set
- [ ] Create project via "Open folder" → verify `skillId` is now also set
- [ ] Check SQLite: `SELECT id, name, skillId FROM projects`

> **Note**: The web fallback path (`onImportFolder(baseDir)`) has a different signature and is out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)