### PR TITLE
fix: preserve Claude tool inputs

### DIFF
--- a/apps/daemon/src/claude-stream.ts
+++ b/apps/daemon/src/claude-stream.ts
@@ -32,6 +32,10 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
 
   // Per-content-block scratch, keyed by `${messageId}:${blockIndex}`.
   const blocks = new Map<string, BlockState>();
+  // Tool uses already emitted from streamed `input_json_delta` data.
+  // Claude Code still repeats them in the final assistant wrapper, often with
+  // empty `{}` inputs, so we suppress that duplicate emission.
+  const streamedToolUseIds = new Set<string>();
   // Most recent assistant message id so content_block_* events without an id
   // can be attributed correctly.
   let currentMessageId: string | null = null;
@@ -112,6 +116,10 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
       for (const block of obj.message.content) {
         if (!isRecord(block)) continue;
         if (block.type === 'tool_use') {
+          if (typeof block.id === 'string' && streamedToolUseIds.has(block.id)) {
+            streamedToolUseIds.delete(block.id);
+            continue;
+          }
           onEvent({
             type: 'tool_use',
             id: block.id,
@@ -208,7 +216,23 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
     }
 
     if (ev.type === 'content_block_stop') {
-      blocks.delete(blockKey(ev.index));
+      const key = blockKey(ev.index);
+      const state = blocks.get(key);
+      if (state && state.type === 'tool_use' && typeof state.id === 'string' && state.input.trim()) {
+        try {
+          onEvent({
+            type: 'tool_use',
+            id: state.id,
+            name: state.name,
+            input: JSON.parse(state.input),
+          });
+          streamedToolUseIds.add(state.id);
+        } catch {
+          // Fall through to the final assistant wrapper's input if the
+          // streamed JSON is malformed or incomplete.
+        }
+      }
+      blocks.delete(key);
       return;
     }
   }

--- a/apps/daemon/tests/structured-streams.test.ts
+++ b/apps/daemon/tests/structured-streams.test.ts
@@ -35,6 +35,60 @@ describe('structured agent stream fixtures', () => {
     });
   });
 
+  it('preserves streamed Claude Code tool input_json_delta payloads', () => {
+    const events: unknown[] = [];
+    const handler = createClaudeStreamHandler((event: unknown) => events.push(event));
+
+    handler.feed(`${JSON.stringify({
+      type: 'stream_event',
+      event: { type: 'message_start', message: { id: 'msg-1' } },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'tool_use', id: 'toolu-1', name: 'Write' },
+      },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'input_json_delta', partial_json: '{"file_path":"admin-dashboard.html",' },
+      },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'input_json_delta', partial_json: '"content":"<html></html>"}' },
+      },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: { type: 'content_block_stop', index: 0 },
+    })}\n${JSON.stringify({
+      type: 'assistant',
+      message: {
+        id: 'msg-1',
+        content: [{ type: 'tool_use', id: 'toolu-1', name: 'Write', input: {} }],
+      },
+    })}\n`);
+    handler.flush();
+
+    const toolUses = events.filter((event) => typeof event === 'object' && event !== null && (event as { type?: string }).type === 'tool_use');
+
+    expect(toolUses).toHaveLength(1);
+    expect(toolUses).toContainEqual({
+      type: 'tool_use',
+      id: 'toolu-1',
+      name: 'Write',
+      input: {
+        file_path: 'admin-dashboard.html',
+        content: '<html></html>',
+      },
+    });
+  });
+
   it('emits TodoWrite tool_use from Pi RPC tool_execution events', () => {
     const events: unknown[] = [];
     const send = (_channel: string, payload: unknown) => { events.push(payload); };


### PR DESCRIPTION
## Summary

Claude Code was dropping streamed tool input JSON, so tool calls like Write and Bash could arrive as {} and fail validation. This patch reads the accumulated JSON when a tool block stops, then skips the duplicate empty tool_use that comes later in the final assistant wrapper.

## Changes

- Parse streamed tool input at content_block_stop
- Ignore the duplicate assistant-wrapper tool_use when streamed input was already emitted
- Add a regression test for streamed Write payloads

## Testing

- pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/structured-streams.test.ts
- pnpm --dir apps/daemon typecheck

Fixes nexu-io/open-design#1475