### PR TITLE
fix: parse accumulated input_json_delta on content_block_stop

### DIFF
--- a/apps/daemon/src/claude-stream.ts
+++ b/apps/daemon/src/claude-stream.ts
@@ -206,11 +206,22 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
         return;
       }
     }
-
+    
     if (ev.type === 'content_block_stop') {
-      blocks.delete(blockKey(ev.index));
-      return;
+  const state = blocks.get(blockKey(ev.index));
+  
+  if (state && state.type === 'tool_use') {
+    try {
+      const parsedInput = JSON.parse(state.input || '{}');
+      onEvent({ type: 'tool_use', id: state.id, name: state.name, input: parsedInput });
+    } catch {
+      onEvent({ type: 'tool_use', id: state.id, name: state.name, input: {} });
     }
+  }
+  
+  blocks.delete(blockKey(ev.index));
+  return;
+}   
   }
 
   return { feed, flush };


### PR DESCRIPTION
## Problem
Fixes #1475

When Claude Code streamed large tool inputs (Write/Bash), 
the input_json_delta chunks were accumulated in state.input 
but dropped on content_block_stop — causing empty {} inputs 
and InputValidationError failures.

## Fix
Before deleting the block state on content_block_stop, 
parse the accumulated JSON and emit the complete tool_use event.

## Testing
- Tested with large Write payloads
- Bash command inputs preserved correctly