### PR TITLE
fix: treat Codex reconnect events as warnings not fatal errors

### DIFF
--- a/apps/daemon/src/json-event-stream.ts
+++ b/apps/daemon/src/json-event-stream.ts
@@ -267,16 +267,23 @@ function handleCursorEvent(obj: unknown, onEvent: StreamEventHandler, state: Par
 function handleCodexEvent(obj: unknown, onEvent: StreamEventHandler, state: ParserState): boolean {
   if (!isRecord(obj)) return false;
 
-  if (obj.type === 'error') {
-    if (!state.codexErrorEmitted) {
-      state.codexErrorEmitted = true;
-      onEvent({
-        type: 'error',
-        message: extractErrorMessage(obj.message ?? obj.error, 'Codex error'),
-      });
-    }
+if (obj.type === 'error') {
+  const message = extractErrorMessage(obj.message ?? obj.error, 'Codex error');
+  // Reconnecting events are recoverable — treat as status warning, not fatal
+  if (
+    typeof message === 'string' &&
+    message.includes('Reconnecting...') &&
+    message.includes('timeout waiting for child process to exit')
+  ) {
+    onEvent({ type: 'status', label: message });
     return true;
   }
+  if (!state.codexErrorEmitted) {
+    state.codexErrorEmitted = true;
+    onEvent({ type: 'error', message });
+  }
+  return true;
+}
 
   if (obj.type === 'turn.failed') {
     if (!state.codexErrorEmitted) {

--- a/apps/daemon/tests/json-event-stream.test.ts
+++ b/apps/daemon/tests/json-event-stream.test.ts
@@ -397,3 +397,36 @@ test('unhandled structured events fall back to raw', () => {
 
   assert.deepEqual(events, [{ type: 'raw', line: '{"type":"unhandled.event","foo":"bar"}' }]);
 });
+test('codex json stream treats reconnect errors as status warnings not fatal (regression of #1471)', () => {
+  const { events, handler } = collectEvents('codex');
+
+  handler.feed(
+    JSON.stringify({ type: 'thread.started', thread_id: 'thr-1' }) + '\n' +
+    JSON.stringify({ type: 'turn.started' }) + '\n' +
+    JSON.stringify({ type: 'error', message: 'Reconnecting... 2/5 (timeout waiting for child process to exit)' }) + '\n' +
+    JSON.stringify({ type: 'item.completed', item: { id: 'item-0', type: 'agent_message', text: 'OK' } }) + '\n' +
+    JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 5, output_tokens: 2, cached_input_tokens: 0 } }) + '\n',
+  );
+
+  assert.deepEqual(events, [
+    { type: 'status', label: 'initializing' },
+    { type: 'status', label: 'running' },
+    { type: 'status', label: 'Reconnecting... 2/5 (timeout waiting for child process to exit)' },
+    { type: 'text_delta', delta: 'OK' },
+    { type: 'usage', usage: { input_tokens: 5, output_tokens: 2, cached_read_tokens: 0 } },
+  ]);
+});
+
+test('codex json stream still treats real errors as fatal after reconnect warnings', () => {
+  const { events, handler } = collectEvents('codex');
+
+  handler.feed(
+    JSON.stringify({ type: 'error', message: 'Reconnecting... 2/5 (timeout waiting for child process to exit)' }) + '\n' +
+    JSON.stringify({ type: 'error', message: 'Authentication failed: invalid API key' }) + '\n',
+  );
+
+  assert.deepEqual(events, [
+    { type: 'status', label: 'Reconnecting... 2/5 (timeout waiting for child process to exit)' },
+    { type: 'error', message: 'Authentication failed: invalid API key' },
+  ]);
+});

--- a/apps/daemon/tests/json-event-stream.test.ts
+++ b/apps/daemon/tests/json-event-stream.test.ts
@@ -15,8 +15,8 @@ test('opencode json stream emits text and usage events', () => {
 
   handler.feed(
     '{"type":"step_start","sessionID":"ses-1","part":{"type":"step-start"}}\n' +
-      '{"type":"text","sessionID":"ses-1","part":{"type":"text","text":"hello"}}\n' +
-      '{"type":"step_finish","sessionID":"ses-1","part":{"type":"step-finish","tokens":{"input":11,"output":7,"reasoning":3,"cache":{"read":5,"write":2}},"cost":0}}\n',
+    '{"type":"text","sessionID":"ses-1","part":{"type":"text","text":"hello"}}\n' +
+    '{"type":"step_finish","sessionID":"ses-1","part":{"type":"step-finish","tokens":{"input":11,"output":7,"reasoning":3,"cache":{"read":5,"write":2}},"cost":0}}\n',
   );
 
   assert.deepEqual(events, [
@@ -177,13 +177,13 @@ test('gemini stream emits init text and usage events', () => {
 
   handler.feed(
     JSON.stringify({ type: 'init', session_id: 'gm-1', model: 'gemini-3-flash-preview' }) + '\n' +
-      JSON.stringify({ type: 'message', role: 'assistant', content: 'hello', delta: true }) + '\n' +
-      JSON.stringify({
-        type: 'result',
-        status: 'success',
-        stats: { input_tokens: 9, output_tokens: 4, cached: 2, duration_ms: 321 },
-      }) +
-      '\n',
+    JSON.stringify({ type: 'message', role: 'assistant', content: 'hello', delta: true }) + '\n' +
+    JSON.stringify({
+      type: 'result',
+      status: 'success',
+      stats: { input_tokens: 9, output_tokens: 4, cached: 2, duration_ms: 321 },
+    }) +
+    '\n',
   );
 
   assert.deepEqual(events, [
@@ -202,29 +202,29 @@ test('cursor stream emits partial text once and usage events', () => {
 
   handler.feed(
     JSON.stringify({ type: 'system', subtype: 'init', model: 'GPT-5 Mini' }) + '\n' +
-      JSON.stringify({
-        type: 'assistant',
-        timestamp_ms: 1,
-        message: { role: 'assistant', content: [{ type: 'text', text: 'OD' }] },
-      }) +
-      '\n' +
-      JSON.stringify({
-        type: 'assistant',
-        timestamp_ms: 2,
-        message: { role: 'assistant', content: [{ type: 'text', text: '_OK' }] },
-      }) +
-      '\n' +
-      JSON.stringify({
-        type: 'assistant',
-        message: { role: 'assistant', content: [{ type: 'text', text: 'OD_OK' }] },
-      }) +
-      '\n' +
-      JSON.stringify({
-        type: 'result',
-        duration_ms: 120,
-        usage: { inputTokens: 5, outputTokens: 2, cacheReadTokens: 1, cacheWriteTokens: 0 },
-      }) +
-      '\n',
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 1,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'OD' }] },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 2,
+      message: { role: 'assistant', content: [{ type: 'text', text: '_OK' }] },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'OD_OK' }] },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'result',
+      duration_ms: 120,
+      usage: { inputTokens: 5, outputTokens: 2, cacheReadTokens: 1, cacheWriteTokens: 0 },
+    }) +
+    '\n',
   );
 
   assert.deepEqual(events, [
@@ -248,12 +248,12 @@ test('cursor stream emits suffix when final assistant extends partial text', () 
       timestamp_ms: 1,
       message: { role: 'assistant', content: [{ type: 'text', text: 'hello' }] },
     }) +
-      '\n' +
-      JSON.stringify({
-        type: 'assistant',
-        message: { role: 'assistant', content: [{ type: 'text', text: 'hello world' }] },
-      }) +
-      '\n',
+    '\n' +
+    JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hello world' }] },
+    }) +
+    '\n',
   );
 
   assert.deepEqual(events, [
@@ -271,19 +271,19 @@ test('cursor stream de-duplicates cumulative timestamped assistant chunks', () =
       timestamp_ms: 1,
       message: { role: 'assistant', content: [{ type: 'text', text: 'hello' }] },
     }) +
-      '\n' +
-      JSON.stringify({
-        type: 'assistant',
-        timestamp_ms: 2,
-        message: { role: 'assistant', content: [{ type: 'text', text: 'hello world' }] },
-      }) +
-      '\n' +
-      JSON.stringify({
-        type: 'assistant',
-        timestamp_ms: 3,
-        message: { role: 'assistant', content: [{ type: 'text', text: 'hello world' }] },
-      }) +
-      '\n',
+    '\n' +
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 2,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hello world' }] },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 3,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hello world' }] },
+    }) +
+    '\n',
   );
 
   assert.deepEqual(events, [
@@ -297,17 +297,17 @@ test('codex json stream emits status text and usage events', () => {
 
   handler.feed(
     JSON.stringify({ type: 'thread.started', thread_id: 'thr-1' }) + '\n' +
-      JSON.stringify({ type: 'turn.started' }) + '\n' +
-      JSON.stringify({
-        type: 'item.completed',
-        item: { id: 'item-1', type: 'agent_message', text: 'hello' },
-      }) +
-      '\n' +
-      JSON.stringify({
-        type: 'turn.completed',
-        usage: { input_tokens: 12, cached_input_tokens: 4, output_tokens: 3 },
-      }) +
-      '\n',
+    JSON.stringify({ type: 'turn.started' }) + '\n' +
+    JSON.stringify({
+      type: 'item.completed',
+      item: { id: 'item-1', type: 'agent_message', text: 'hello' },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'turn.completed',
+      usage: { input_tokens: 12, cached_input_tokens: 4, output_tokens: 3 },
+    }) +
+    '\n',
   );
 
   assert.deepEqual(events, [
@@ -328,12 +328,12 @@ test('codex json stream emits structured errors once', () => {
         detail: "The 'gpt-5.5' model requires a newer version of Codex.",
       }),
     }) +
-      '\n' +
-      JSON.stringify({
-        type: 'turn.failed',
-        error: { message: 'plain failure' },
-      }) +
-      '\n',
+    '\n' +
+    JSON.stringify({
+      type: 'turn.failed',
+      error: { message: 'plain failure' },
+    }) +
+    '\n',
   );
 
   assert.deepEqual(events, [
@@ -359,19 +359,19 @@ test('codex json stream emits command execution tool events', () => {
         status: 'in_progress',
       },
     }) +
-      '\n' +
-      JSON.stringify({
-        type: 'item.completed',
-        item: {
-          id: 'item-1',
-          type: 'command_execution',
-          command: "/bin/zsh -lc 'echo hello-from-codex'",
-          aggregated_output: 'hello-from-codex\n',
-          exit_code: 0,
-          status: 'completed',
-        },
-      }) +
-      '\n',
+    '\n' +
+    JSON.stringify({
+      type: 'item.completed',
+      item: {
+        id: 'item-1',
+        type: 'command_execution',
+        command: "/bin/zsh -lc 'echo hello-from-codex'",
+        aggregated_output: 'hello-from-codex\n',
+        exit_code: 0,
+        status: 'completed',
+      },
+    }) +
+    '\n',
   );
 
   assert.deepEqual(events, [


### PR DESCRIPTION
Fixes #1471

## Summary
Codex CLI emits recoverable `type: "error"` reconnect events like:
`Reconnecting... 2/5 (timeout waiting for child process to exit)`

These are not fatal — Codex eventually completes successfully.
Previously, Open Design treated ALL type:"error" events as fatal
and exited the run early before the final agent_message arrived.

This fix checks if the error message is a reconnect warning and
surfaces it as a `status` event instead of a fatal `error` event.
Real errors (auth failures, turn.failed) are still treated as fatal.

## Validation
- Recoverable reconnect messages → emitted as `status` warning
- Real Codex errors → still fatal as before
- Codex run completes successfully after reconnect attempts