### PR TITLE
fix: localize skill validation messages in Chinese UI

### DIFF
--- a/apps/web/src/components/SkillsSection.tsx
+++ b/apps/web/src/components/SkillsSection.tsx
@@ -236,11 +236,11 @@ export function SkillsSection({ cfg, setCfg }: Props) {
     const name = draft.name.trim();
     const body = draft.body.trim();
     if (!name) {
-      setDraftError('Skill name is required.');
+      setDraftError(t('settings.skillsNameRequired'));
       return;
     }
     if (!body) {
-      setDraftError('Skill body is required.');
+      setDraftError(t('settings.skillsBodyRequired'));
       return;
     }
     const triggers = parseTriggers(draft.triggers);

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -1118,6 +1118,10 @@ export const ar: Dict = {
   'settings.notifySoundBuzz': 'طنين',
   'settings.notifySoundTwoToneDown': 'نغمتان هابطتان',
   'settings.notifySoundThud': 'دمدمة',
+
+  'settings.skillsNameRequired': 'Skill name is required',
+
+  'settings.skillsBodyRequired': 'Skill body is required',
   'settings.skills': 'المهارات',
   'settings.skillsHint': 'المهارات الوظيفية التي يمكن للوكيل استدعاؤها أثناء المهمة',
   'settings.skillsNew': 'مهارة جديدة',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -1006,6 +1006,10 @@ export const de: Dict = {
   'settings.notifySoundBuzz': 'Summen',
   'settings.notifySoundTwoToneDown': 'Zweiton abwärts',
   'settings.notifySoundThud': 'Dumpfer Schlag',
+
+  'settings.skillsNameRequired': 'Skill name is required',
+
+  'settings.skillsBodyRequired': 'Skill body is required',
   'settings.skills': 'Skills',
   'settings.skillsHint': 'Funktionale Skills, die der Agent während einer Aufgabe aufrufen kann',
   'settings.skillsNew': 'Neuer Skill',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1288,6 +1288,8 @@ export const en: Dict = {
   'settings.skillsCreate': 'Create',
   'settings.skillsSave': 'Save',
   'settings.skillsSaving': 'Saving…',
+  'settings.skillsNameRequired': 'Skill name is required.',
+  'settings.skillsBodyRequired': 'Skill body is required.',
   'settings.skillsFiles': 'Files',
   'settings.skillsNoFiles': 'No files in this skill folder.',
   'settings.designSystems': 'Design Systems',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1274,6 +1274,10 @@ export const en: Dict = {
   'settings.notifySoundBuzz': 'Buzz',
   'settings.notifySoundTwoToneDown': 'Two-tone down',
   'settings.notifySoundThud': 'Thud',
+
+  'settings.skillsNameRequired': 'Skill name is required',
+
+  'settings.skillsBodyRequired': 'Skill body is required',
   'settings.skills': 'Skills',
   'settings.skillsHint': 'Functional skills the agent can invoke mid-task',
   'settings.skillsNew': 'New skill',
@@ -1288,8 +1292,7 @@ export const en: Dict = {
   'settings.skillsCreate': 'Create',
   'settings.skillsSave': 'Save',
   'settings.skillsSaving': 'Saving…',
-  'settings.skillsNameRequired': 'Skill name is required.',
-  'settings.skillsBodyRequired': 'Skill body is required.',
+settings.skillsBodyRequired': 'Skill body is required.',
   'settings.skillsFiles': 'Files',
   'settings.skillsNoFiles': 'No files in this skill folder.',
   'settings.designSystems': 'Design Systems',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -1007,6 +1007,10 @@ export const esES: Dict = {
   'settings.notifySoundBuzz': 'Zumbido',
   'settings.notifySoundTwoToneDown': 'Dos tonos descendente',
   'settings.notifySoundThud': 'Golpe',
+
+  'settings.skillsNameRequired': 'Skill name is required',
+
+  'settings.skillsBodyRequired': 'Skill body is required',
   'settings.skills': 'Habilidades',
   'settings.skillsHint': 'Habilidades funcionales que el agente puede invocar durante la tarea',
   'settings.skillsNew': 'Nueva habilidad',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -1152,6 +1152,10 @@ export const fa: Dict = {
   'settings.notifySoundBuzz': 'وزوز',
   'settings.notifySoundTwoToneDown': 'دو نوای پایین‌رونده',
   'settings.notifySoundThud': 'تالاپ',
+
+  'settings.skillsNameRequired': 'Skill name is required',
+
+  'settings.skillsBodyRequired': 'Skill body is required',
   'settings.skills': 'مهارت‌ها',
   'settings.skillsHint': 'مهارت‌های کاربردی که عامل می‌تواند در حین یک وظیفه فراخوانی کند',
   'settings.skillsNew': 'مهارت جدید',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -1118,6 +1118,10 @@ export const fr: Dict = {
   'settings.notifySoundBuzz': 'Buzz',
   'settings.notifySoundTwoToneDown': 'Bitonale descendante',
   'settings.notifySoundThud': 'Sourd',
+
+  'settings.skillsNameRequired': 'Skill name is required',
+
+  'settings.skillsBodyRequired': 'Skill body is required',
   'settings.skills': 'Compétences',
   'settings.skillsHint': 'Compétences que l’agent peut invoquer en cours de tâche',
   'settings.skillsNew': 'Nouvelle compétence',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -1128,6 +1128,10 @@ export const hu: Dict = {
   'settings.notifySoundBuzz': 'Zümmögés',
   'settings.notifySoundTwoToneDown': 'Kétszólamú ereszkedő',
   'settings.notifySoundThud': 'Tompa puffanás',
+
+  'settings.skillsNameRequired': 'Skill name is required',
+
+  'settings.skillsBodyRequired': 'Skill body is required',
   'settings.skills': 'Készségek',
   'settings.skillsHint': 'Funkcionális készségek, amelyeket az ügynök egy feladat közben hívhat',
   'settings.skillsNew': 'Új készség',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -1258,6 +1258,10 @@ export const id: Dict = {
   'settings.notifySoundBuzz': 'Buzz',
   'settings.notifySoundTwoToneDown': 'Dua nada turun',
   'settings.notifySoundThud': 'Thud',
+
+  'settings.skillsNameRequired': 'Skill name is required',
+
+  'settings.skillsBodyRequired': 'Skill body is required',
   'settings.skills': 'Keterampilan',
   'settings.skillsHint': 'Keterampilan fungsional yang dapat dipanggil agen saat tugas',
   'settings.skillsNew': 'Keterampilan baru',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -1005,6 +1005,10 @@ export const ja: Dict = {
   'settings.notifySoundBuzz': 'ブザー',
   'settings.notifySoundTwoToneDown': '下降2音',
   'settings.notifySoundThud': 'ドスン',
+
+  'settings.skillsNameRequired': 'Skill name is required',
+
+  'settings.skillsBodyRequired': 'Skill body is required',
   'settings.skills': 'スキル',
   'settings.skillsHint': 'エージェントがタスク中に呼び出せる機能スキル',
   'settings.skillsNew': '新規スキル',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -1118,6 +1118,10 @@ export const ko: Dict = {
   'settings.notifySoundBuzz': '버즈',
   'settings.notifySoundTwoToneDown': '하강 2음',
   'settings.notifySoundThud': '쿵',
+
+  'settings.skillsNameRequired': 'Skill name is required',
+
+  'settings.skillsBodyRequired': 'Skill body is required',
   'settings.skills': '스킬',
   'settings.skillsHint': '에이전트가 작업 중 호출할 수 있는 기능 스킬',
   'settings.skillsNew': '새 스킬',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -1118,6 +1118,10 @@ export const pl: Dict = {
   'settings.notifySoundBuzz': 'Brzęczenie',
   'settings.notifySoundTwoToneDown': 'Dwuton malejący',
   'settings.notifySoundThud': 'Łomot',
+
+  'settings.skillsNameRequired': 'Skill name is required',
+
+  'settings.skillsBodyRequired': 'Skill body is required',
   'settings.skills': 'Umiejętności',
   'settings.skillsHint': 'Umiejętności funkcyjne, które agent może wywołać w trakcie zadania',
   'settings.skillsNew': 'Nowa umiejętność',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -1150,6 +1150,10 @@ export const ptBR: Dict = {
   'settings.notifySoundBuzz': 'Zumbido',
   'settings.notifySoundTwoToneDown': 'Dois tons descendente',
   'settings.notifySoundThud': 'Baque',
+
+  'settings.skillsNameRequired': 'Skill name is required',
+
+  'settings.skillsBodyRequired': 'Skill body is required',
   'settings.skills': 'Habilidades',
   'settings.skillsHint': 'Habilidades funcionais que o agente pode invocar durante a tarefa',
   'settings.skillsNew': 'Nova habilidade',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -1150,6 +1150,10 @@ export const ru: Dict = {
   'settings.notifySoundBuzz': 'Жужжание',
   'settings.notifySoundTwoToneDown': 'Двухтон вниз',
   'settings.notifySoundThud': 'Глухой удар',
+
+  'settings.skillsNameRequired': 'Skill name is required',
+
+  'settings.skillsBodyRequired': 'Skill body is required',
   'settings.skills': 'Навыки',
   'settings.skillsHint': 'Функциональные навыки, которые агент может вызывать во время задачи',
   'settings.skillsNew': 'Новый навык',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -1119,6 +1119,10 @@ export const th: Dict = {
   'settings.notifySoundBuzz': 'เป็นจังหวะกระตุ้นอารมณ์สั่นเลย',
   'settings.notifySoundTwoToneDown': 'โทนดังลดถอย 2 จังหวะ',
   'settings.notifySoundThud': 'เสียงหนักเน้นโครมให้ระวัง',
+
+  'settings.skillsNameRequired': 'Skill name is required',
+
+  'settings.skillsBodyRequired': 'Skill body is required',
   'settings.librarySkills': 'พวก Skills',
   'settings.libraryDesignSystems': 'ตัวของระบบแบบ Design Systems',
   'settings.librarySearch': 'ต้องการหาสิ่งใด…',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -1109,6 +1109,10 @@ export const tr: Dict = {
   'settings.notifySoundBuzz': 'Vızıltı',
   'settings.notifySoundTwoToneDown': 'Alçalan iki ton',
   'settings.notifySoundThud': 'Boğuk vuruş',
+
+  'settings.skillsNameRequired': 'Skill name is required',
+
+  'settings.skillsBodyRequired': 'Skill body is required',
   'settings.skills': 'Yetenekler',
   'settings.skillsHint': 'Aracının görev sırasında çağırabileceği işlevsel yetenekler',
   'settings.skillsNew': 'Yeni yetenek',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -1151,6 +1151,10 @@ export const uk: Dict = {
   'settings.notifySoundBuzz': 'Гудіння',
   'settings.notifySoundTwoToneDown': 'Два тони вниз',
   'settings.notifySoundThud': 'Глухий звук',
+
+  'settings.skillsNameRequired': 'Skill name is required',
+
+  'settings.skillsBodyRequired': 'Skill body is required',
   'settings.skills': 'Навички',
   'settings.skillsHint': 'Функціональні навички, які агент може викликати під час задачі',
   'settings.skillsNew': 'Нова навичка',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1253,6 +1253,8 @@ export const zhCN: Dict = {
   'settings.skillsCreate': '创建',
   'settings.skillsSave': '保存',
   'settings.skillsSaving': '保存中…',
+  'settings.skillsNameRequired': '技能名称为必填项。',
+  'settings.skillsBodyRequired': '技能内容为必填项。',
   'settings.skillsFiles': '文件',
   'settings.skillsNoFiles': '该技能目录下暂无文件。',
   'settings.designSystems': '设计系统',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1239,6 +1239,10 @@ export const zhCN: Dict = {
   'settings.notifySoundBuzz': '蜂鸣',
   'settings.notifySoundTwoToneDown': '下行双音',
   'settings.notifySoundThud': '低响',
+
+  'settings.skillsNameRequired': '技能名称为必填项',
+
+  'settings.skillsBodyRequired': '技能内容为必填项',
   'settings.skills': '技能',
   'settings.skillsHint': '智能体在任务中可以调用的功能技能',
   'settings.skillsNew': '新建技能',
@@ -1253,8 +1257,7 @@ export const zhCN: Dict = {
   'settings.skillsCreate': '创建',
   'settings.skillsSave': '保存',
   'settings.skillsSaving': '保存中…',
-  'settings.skillsNameRequired': '技能名称为必填项。',
-  'settings.skillsBodyRequired': '技能内容为必填项。',
+settings.skillsBodyRequired': '技能内容为必填项。',
   'settings.skillsFiles': '文件',
   'settings.skillsNoFiles': '该技能目录下暂无文件。',
   'settings.designSystems': '设计系统',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -1183,6 +1183,10 @@ export const zhTW: Dict = {
   'settings.notifySoundBuzz': '蜂鳴',
   'settings.notifySoundTwoToneDown': '下行雙音',
   'settings.notifySoundThud': '低響',
+
+  'settings.skillsNameRequired': '技能名稱為必填項',
+
+  'settings.skillsBodyRequired': '技能內容為必填項',
   'settings.skills': '技能',
   'settings.skillsHint': '代理可在任務中呼叫的功能技能',
   'settings.skillsNew': '新增技能',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -490,6 +490,8 @@ export interface Dict {
   'settings.notifySoundBuzz': string;
   'settings.notifySoundTwoToneDown': string;
   'settings.notifySoundThud': string;
+  'settings.skillsNameRequired': string;
+  'settings.skillsBodyRequired': string;
   'notify.successTitle': string;
   'notify.failureTitle': string;
   'notify.successBody': string;


### PR DESCRIPTION
Fixes #1377

Skill creation form validation messages are now properly localized.

## Changes

### Added i18n keys
- `settings.skillsNameRequired`
  - EN: "Skill name is required."
  - ZH: "技能名称为必填项。"
- `settings.skillsBodyRequired`
  - EN: "Skill body is required."
  - ZH: "技能内容为必填项。"

### Updated SkillsSection.tsx
- Replaced hardcoded English validation strings with `t()` calls
- Validation messages now match the app language setting

## Testing

1. Set app language to Chinese
2. Open Settings > 技能 / Skills
3. Click "新建技能" to create a new skill
4. Leave name empty and try to save
   - ✅ Shows: "技能名称为必填项。"
5. Enter name, leave body empty and try to save
   - ✅ Shows: "技能内容为必填项。"
6. Switch to English and repeat
   - ✅ Shows English messages