### PR TITLE
fix: close Settings modal when opening project from Routines

### DIFF
--- a/apps/web/src/components/RoutinesSection.tsx
+++ b/apps/web/src/components/RoutinesSection.tsx
@@ -345,9 +345,10 @@ function RunHistory({ routineId, refreshKey }: { routineId: string; refreshKey: 
           <button
             type="button"
             className="routines-history-link"
-            onClick={() =>
-              navigate({ kind: 'project', projectId: r.projectId, fileName: null })
-            }
+            onClick={() => {
+              navigate({ kind: 'project', projectId: r.projectId, fileName: null });
+              onClose?.();
+            }}
             title="Open the project this run wrote to"
           >
             Open project
@@ -359,7 +360,7 @@ function RunHistory({ routineId, refreshKey }: { routineId: string; refreshKey: 
   );
 }
 
-export function RoutinesSection() {
+export function RoutinesSection({ onClose }: { onClose?: () => void }) {
   const [routines, setRoutines] = useState<Routine[]>([]);
   const [projects, setProjects] = useState<ProjectSummary[]>([]);
   const [loading, setLoading] = useState(true);

--- a/apps/web/src/components/RoutinesSection.tsx
+++ b/apps/web/src/components/RoutinesSection.tsx
@@ -309,7 +309,7 @@ function ScheduleEditor({
   );
 }
 
-function RunHistory({ routineId, refreshKey }: { routineId: string; refreshKey: number }) {
+function RunHistory({ routineId, refreshKey, onClose }: { routineId: string; refreshKey: number; onClose?: () => void }) {
   const [runs, setRuns] = useState<RoutineRun[] | null>(null);
 
   useEffect(() => {
@@ -708,7 +708,7 @@ export function RoutinesSection({ onClose }: { onClose?: () => void }) {
                 </div>
                 {isExpanded ? (
                   <div className="routines-item-history">
-                    <RunHistory routineId={r.id} refreshKey={historyTick} />
+                    <RunHistory routineId={r.id} refreshKey={historyTick} onClose={onClose} />
                   </div>
                 ) : null}
               </li>

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -2334,7 +2334,7 @@ export function SettingsDialog({
             />
           ) : null}
 
-          {activeSection === 'routines' ? <RoutinesSection /> : null}
+          {activeSection === 'routines' ? <RoutinesSection onClose={onClose} /> : null}
 
           {activeSection === 'orbit' ? (
             <OrbitSection


### PR DESCRIPTION
Fixes #1355

When clicking **Open project** in Routine history, the Settings modal now closes automatically, providing a clean transition to the project.

## Problem

Previously, clicking "Open project" would navigate to the project but leave the Settings modal open, creating a confusing state where both the modal and the project were visible.

## Solution

- Added `onClose` prop to `RoutinesSection` component
- Call `onClose()` after `navigate()` in the Open project button handler
- Pass `onClose` from `SettingsDialog` to `RoutinesSection`

This ensures the modal dismisses after navigation, consistent with other modal-based navigation actions in the app.

## Testing

1. Open Settings
2. Go to Routines section
3. Find a routine with history
4. Click "Open project"
5. ✅ Settings modal closes automatically
6. ✅ Project opens cleanly without modal overlay