### PR TITLE
fix(web): deep-link Routines history rows to their specific conversation (Fixes #1505)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -902,6 +902,7 @@ export function App() {
           key={activeProject.id}
           project={activeProject}
           routeFileName={route.kind === 'project' ? route.fileName : null}
+          routeConversationId={route.kind === 'project' ? route.conversationId : null}
           config={config}
           agents={agents}
           skills={enabledFunctionalSkills}

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -809,7 +809,14 @@ export function ProjectView({
   // Sync the URL when the active tab changes, so reload + share-link both
   // land back on the same view. Replace (not push) on tab activation so the
   // history stack doesn't fill with every tab click.
-  const lastSyncedFileRef = useRef<string | null>(null);
+  // Composite sync key: tracks BOTH the active file target AND the active
+  // conversation id, so a conversation-only change (e.g. `listConversations`
+  // resolves after `loadTabs` hydrated the active tab, or the user picks a
+  // different conversation under the same tab) still triggers the navigate
+  // and pushes `/conversations/:cid` into the URL. Keying only on the file
+  // target lost that update because the early-return saw `target` unchanged
+  // and skipped the navigate (lefarcen P1 on PR #1508).
+  const lastSyncedRouteKeyRef = useRef<string | null>(null);
   useEffect(() => {
     const target = openTabsState.active && (
       openTabsState.tabs.includes(openTabsState.active)
@@ -818,8 +825,9 @@ export function ProjectView({
     )
       ? openTabsState.active
       : null;
-    if (target === lastSyncedFileRef.current) return;
-    lastSyncedFileRef.current = target;
+    const nextKey = `${activeConversationId ?? ''}:${target ?? ''}`;
+    if (nextKey === lastSyncedRouteKeyRef.current) return;
+    lastSyncedRouteKeyRef.current = nextKey;
     // PerishCode + Codex P1 on PR #1508: the prior version of this
     // sync stripped any `/conversations/:cid` segment from the URL as
     // soon as a tab became active, which regressed the deep-link

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -820,11 +820,24 @@ export function ProjectView({
       : null;
     if (target === lastSyncedFileRef.current) return;
     lastSyncedFileRef.current = target;
+    // PerishCode + Codex P1 on PR #1508: the prior version of this
+    // sync stripped any `/conversations/:cid` segment from the URL as
+    // soon as a tab became active, which regressed the deep-link
+    // behavior the parent commit was meant to add (reload / share
+    // would fall back to `list[0]` instead of the routed run's
+    // conversation). Thread the active conversation id so the URL
+    // always reflects the conversation the project view is actually
+    // showing, matching how `fileName` already tracks the active tab.
     navigate(
-      { kind: 'project', projectId: project.id, fileName: target },
+      {
+        kind: 'project',
+        projectId: project.id,
+        conversationId: activeConversationId,
+        fileName: target,
+      },
       { replace: true },
     );
-  }, [openTabsState.active, projectFileNames, project.id]);
+  }, [openTabsState.active, projectFileNames, project.id, activeConversationId]);
 
   const handleEnsureProject = useCallback(async (): Promise<string | null> => {
     return project.id;

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -111,6 +111,18 @@ import { effectiveMaxTokens } from '../state/maxTokens';
 interface Props {
   project: Project;
   routeFileName: string | null;
+  /**
+   * Routed conversation id. When set (the URL is
+   * `/projects/:id/conversations/:cid[/...]`), the project view picks
+   * this conversation as active instead of defaulting to `list[0]`.
+   * Falls through to the default picker if the conversation does not
+   * exist (e.g. the run was deleted between the route landing and the
+   * conversation list loading). Issue #1505. Optional so existing
+   * test harnesses that mount ProjectView with a stub props bag do
+   * not have to be updated; production callers in `App.tsx` always
+   * pass the value from `useRoute()`.
+   */
+  routeConversationId?: string | null;
   config: AppConfig;
   agents: AgentInfo[];
   // Mentionable functional skills — already filtered by config.disabledSkills
@@ -295,6 +307,7 @@ function projectFeatureChips(project: Project): ProjectFeatureChip[] {
 export function ProjectView({
   project,
   routeFileName,
+  routeConversationId = null,
   config,
   agents,
   skills,
@@ -474,7 +487,15 @@ export function ProjectView({
           }
         } else {
           setConversations(list);
-          setActiveConversationId(list[0]!.id);
+          // Issue #1505: when the URL deep-links to a specific
+          // conversation, prefer that one. Falls through to list[0]
+          // when the routed id is null or no longer present (the
+          // routine row may have been deleted between the route
+          // landing and the conversation list loading).
+          const routedMatch = routeConversationId
+            ? list.find((c) => c.id === routeConversationId) ?? null
+            : null;
+          setActiveConversationId(routedMatch ? routedMatch.id : list[0]!.id);
         }
       } catch (err) {
         if (cancelled) return;
@@ -489,6 +510,22 @@ export function ProjectView({
       cancelled = true;
     };
   }, [project.id]);
+
+  // Issue #1505: when the URL changes the routed conversation id while
+  // we are already inside the project (e.g. the user clicks "Open
+  // project" on a different routine history row in the same project),
+  // switch the active conversation without re-fetching the list.
+  // Guards: only acts when the routed id is non-null AND present in
+  // the already-loaded list, and only when it differs from the current
+  // active id. Falls through to a no-op for stale / missing routes so
+  // the default picker above keeps its result.
+  useEffect(() => {
+    if (!routeConversationId) return;
+    if (conversations.length === 0) return;
+    if (routeConversationId === activeConversationId) return;
+    const match = conversations.find((c) => c.id === routeConversationId);
+    if (match) setActiveConversationId(match.id);
+  }, [routeConversationId, conversations, activeConversationId]);
 
   useEffect(() => {
     setWorkspaceFocused(false);

--- a/apps/web/src/components/RoutinesSection.tsx
+++ b/apps/web/src/components/RoutinesSection.tsx
@@ -346,7 +346,18 @@ function RunHistory({ routineId, refreshKey, onClose }: { routineId: string; ref
             type="button"
             className="routines-history-link"
             onClick={() => {
-              navigate({ kind: 'project', projectId: r.projectId, fileName: null });
+              // Issue #1505: deep-link to this run's specific
+              // conversation, not just the project root. Without the
+              // conversation id, parallel runs that share a project
+              // (reuse mode) all resolve to the same default
+              // conversation in the project view, which made earlier
+              // runs look "absorbed" by the latest one.
+              navigate({
+                kind: 'project',
+                projectId: r.projectId,
+                conversationId: r.conversationId ?? null,
+                fileName: null,
+              });
               onClose?.();
             }}
             title="Open the project this run wrote to"

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -3125,6 +3125,7 @@ function OrbitSection({
         navigateRoute({
           kind: 'project',
           projectId: payload.projectId,
+          conversationId: null,
           fileName: null,
         });
       } catch {

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -23,8 +23,17 @@ export type Route =
        * the user on that run's own conversation, not on whatever the
        * project happens to default to. Without this field the latest
        * conversation always wins and earlier rows look "absorbed".
+       *
+       * Optional (PerishCode + Codex P1 on PR #1508): the existing
+       * project-route call sites in App.tsx, ProjectView.tsx, and the
+       * older tests all construct `{ kind, projectId, fileName }`
+       * without a conversation segment. Treating the field as optional
+       * keeps those literals type-safe while letting the routine
+       * history surface populate it where the deep-link matters. The
+       * `parseRoute` and `buildPath` round-trip normalize undefined to
+       * null at the wire layer.
        */
-      conversationId: string | null;
+      conversationId?: string | null;
       fileName: string | null;
     };
 

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -7,21 +7,55 @@ import { useEffect, useState } from 'react';
 
 export type Route =
   | { kind: 'home' }
-  | { kind: 'project'; projectId: string; fileName: string | null };
+  | {
+      kind: 'project';
+      projectId: string;
+      /**
+       * Deep-link to a specific conversation inside the project. When
+       * present, the project view picks this conversation as the active
+       * one instead of defaulting to `list[0]`. Falls back to the
+       * default picker when the routed conversation no longer exists
+       * (e.g. the conversation was deleted between the route landing
+       * and the conversation list loading).
+       *
+       * Added for issue #1505: the Routines history surfaces one row
+       * per run, and clicking "Open project" on any row should land
+       * the user on that run's own conversation, not on whatever the
+       * project happens to default to. Without this field the latest
+       * conversation always wins and earlier rows look "absorbed".
+       */
+      conversationId: string | null;
+      fileName: string | null;
+    };
 
 export function parseRoute(pathname: string): Route {
   const parts = pathname.replace(/\/+$/, '').split('/').filter(Boolean);
   if (parts.length === 0) return { kind: 'home' };
   if (parts[0] === 'projects' && parts[1]) {
     const projectId = decodeURIComponent(parts[1]);
+    // /projects/:id/conversations/:cid[/files/...]
+    if (parts[2] === 'conversations' && parts[3]) {
+      const conversationId = decodeURIComponent(parts[3]);
+      if (parts[4] === 'files' && parts[5]) {
+        return {
+          kind: 'project',
+          projectId,
+          conversationId,
+          fileName: decodeURIComponent(parts.slice(5).join('/')),
+        };
+      }
+      return { kind: 'project', projectId, conversationId, fileName: null };
+    }
+    // /projects/:id/files/...
     if (parts[2] === 'files' && parts[3]) {
       return {
         kind: 'project',
         projectId,
+        conversationId: null,
         fileName: decodeURIComponent(parts.slice(3).join('/')),
       };
     }
-    return { kind: 'project', projectId, fileName: null };
+    return { kind: 'project', projectId, conversationId: null, fileName: null };
   }
   return { kind: 'home' };
 }
@@ -29,14 +63,16 @@ export function parseRoute(pathname: string): Route {
 export function buildPath(route: Route): string {
   if (route.kind === 'home') return '/';
   const id = encodeURIComponent(route.projectId);
-  if (route.fileName) {
-    const file = route.fileName
-      .split('/')
-      .map((s) => encodeURIComponent(s))
-      .join('/');
-    return `/projects/${id}/files/${file}`;
+  const file = route.fileName
+    ? route.fileName.split('/').map((s) => encodeURIComponent(s)).join('/')
+    : null;
+  if (route.conversationId) {
+    const cid = encodeURIComponent(route.conversationId);
+    return file
+      ? `/projects/${id}/conversations/${cid}/files/${file}`
+      : `/projects/${id}/conversations/${cid}`;
   }
-  return `/projects/${id}`;
+  return file ? `/projects/${id}/files/${file}` : `/projects/${id}`;
 }
 
 // Centralized navigation. Components call this instead of mutating

--- a/apps/web/tests/components/ProjectView.tabs-navigation.test.tsx
+++ b/apps/web/tests/components/ProjectView.tabs-navigation.test.tsx
@@ -181,7 +181,16 @@ describe('ProjectView tab URL hydration', () => {
 
     await waitFor(() => {
       expect(mockedNavigate).toHaveBeenCalledWith(
-        { kind: 'project', projectId: project.id, fileName: 'index.html' },
+        // The active conversation id is threaded into the URL alongside
+        // the active tab so a reload / share preserves the conversation
+        // segment of `/projects/:id/conversations/:cid/files/...`
+        // (PerishCode + Codex P1 on PR #1508).
+        {
+          kind: 'project',
+          projectId: project.id,
+          conversationId: 'conv-1',
+          fileName: 'index.html',
+        },
         { replace: true },
       );
     });

--- a/apps/web/tests/components/ProjectView.tabs-navigation.test.tsx
+++ b/apps/web/tests/components/ProjectView.tabs-navigation.test.tsx
@@ -195,4 +195,54 @@ describe('ProjectView tab URL hydration', () => {
       );
     });
   });
+
+  it('re-pushes /conversations/:cid when activeConversationId hydrates after the active tab has already synced (lefarcen P1 on PR #1508)', async () => {
+    // Race shape: `loadTabs` resolves and sets the active tab BEFORE
+    // `listConversations` resolves and sets `activeConversationId`.
+    // The first navigate fires with `conversationId: null` because
+    // the conversation hasn't loaded yet; the second navigate must
+    // fire with `conversationId: 'conv-1'` even though the active
+    // tab is identical. A ref guard that keys only on the file
+    // target skips the second call and the URL never gains the
+    // `/conversations/:cid` segment. The composite-key guard
+    // (`${activeConversationId}:${target}`) catches it.
+    let resolveConversations: (value: Conversation[]) => void = () => {};
+    const conversationsPromise = new Promise<Conversation[]>((resolve) => {
+      resolveConversations = resolve;
+    });
+    mockedListConversations.mockReturnValue(conversationsPromise);
+    mockedLoadTabs.mockResolvedValue({ tabs: ['index.html'], active: 'index.html' });
+
+    renderProjectView();
+
+    // First navigate: active tab synced, conversation still loading.
+    await waitFor(() => {
+      expect(mockedNavigate).toHaveBeenCalledWith(
+        {
+          kind: 'project',
+          projectId: project.id,
+          conversationId: null,
+          fileName: 'index.html',
+        },
+        { replace: true },
+      );
+    });
+
+    // Now resolve the conversation list. The active tab is unchanged
+    // but `activeConversationId` flips from `null` to `'conv-1'`, so
+    // a second navigate must fire.
+    resolveConversations([conversation]);
+
+    await waitFor(() => {
+      expect(mockedNavigate).toHaveBeenCalledWith(
+        {
+          kind: 'project',
+          projectId: project.id,
+          conversationId: 'conv-1',
+          fileName: 'index.html',
+        },
+        { replace: true },
+      );
+    });
+  });
 });

--- a/apps/web/tests/components/RoutinesSection.test.tsx
+++ b/apps/web/tests/components/RoutinesSection.test.tsx
@@ -417,7 +417,12 @@ describe('RoutinesSection', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Open project' }));
 
     expect(navigateSpy).toHaveBeenCalledWith(
-      { kind: 'project', projectId: 'proj-run', fileName: null },
+      {
+        kind: 'project',
+        projectId: 'proj-run',
+        conversationId: 'conv-run',
+        fileName: null,
+      },
     );
   });
 

--- a/apps/web/tests/router.test.ts
+++ b/apps/web/tests/router.test.ts
@@ -1,0 +1,114 @@
+/**
+ * URL router round-trip tests (issue #1505).
+ *
+ * Pins the deep-link shape for the project route:
+ *
+ *   /                                                 home
+ *   /projects/:id                                     project root
+ *   /projects/:id/files/:path                         file view
+ *   /projects/:id/conversations/:cid                  specific conversation
+ *   /projects/:id/conversations/:cid/files/:path      conversation + file
+ *
+ * The conversation segment was added to unblock the Routines history
+ * row: clicking "Open project" on a parallel run's row needs to land
+ * the user on that run's own conversation, not on whatever the
+ * project happens to default to.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { buildPath, parseRoute, type Route } from '../src/router';
+
+function roundTrip(route: Route): Route {
+  return parseRoute(buildPath(route));
+}
+
+describe('parseRoute / buildPath (issue #1505)', () => {
+  it('parses the home route', () => {
+    expect(parseRoute('/')).toEqual({ kind: 'home' });
+    expect(parseRoute('')).toEqual({ kind: 'home' });
+  });
+
+  it('round-trips a bare project route', () => {
+    const route: Route = {
+      kind: 'project',
+      projectId: 'p-1',
+      conversationId: null,
+      fileName: null,
+    };
+    expect(roundTrip(route)).toEqual(route);
+    expect(buildPath(route)).toBe('/projects/p-1');
+  });
+
+  it('round-trips a project + file route (no conversation)', () => {
+    const route: Route = {
+      kind: 'project',
+      projectId: 'p-1',
+      conversationId: null,
+      fileName: 'src/index.tsx',
+    };
+    expect(roundTrip(route)).toEqual(route);
+    expect(buildPath(route)).toBe('/projects/p-1/files/src/index.tsx');
+  });
+
+  it('round-trips a project + conversation route', () => {
+    const route: Route = {
+      kind: 'project',
+      projectId: 'p-1',
+      conversationId: 'conv-abc',
+      fileName: null,
+    };
+    expect(roundTrip(route)).toEqual(route);
+    expect(buildPath(route)).toBe('/projects/p-1/conversations/conv-abc');
+  });
+
+  it('round-trips a project + conversation + file route', () => {
+    const route: Route = {
+      kind: 'project',
+      projectId: 'p-1',
+      conversationId: 'conv-abc',
+      fileName: 'index.html',
+    };
+    expect(roundTrip(route)).toEqual(route);
+    expect(buildPath(route)).toBe('/projects/p-1/conversations/conv-abc/files/index.html');
+  });
+
+  it('percent-encodes ids and file names with reserved characters', () => {
+    const route: Route = {
+      kind: 'project',
+      projectId: 'p/1 with space',
+      conversationId: 'conv/abc with space',
+      fileName: 'dir/file name.tsx',
+    };
+    const built = buildPath(route);
+    expect(built).toContain('p%2F1%20with%20space');
+    expect(built).toContain('conv%2Fabc%20with%20space');
+    // File path components are percent-encoded individually so the
+    // slash between segments survives.
+    expect(built.endsWith('/dir/file%20name.tsx')).toBe(true);
+    expect(roundTrip(route)).toEqual(route);
+  });
+
+  it('parses a legacy project + file URL with no conversation segment', () => {
+    expect(parseRoute('/projects/p-1/files/README.md')).toEqual({
+      kind: 'project',
+      projectId: 'p-1',
+      conversationId: null,
+      fileName: 'README.md',
+    });
+  });
+
+  it('parses a project + conversation URL with no file segment', () => {
+    expect(parseRoute('/projects/p-1/conversations/c-2')).toEqual({
+      kind: 'project',
+      projectId: 'p-1',
+      conversationId: 'c-2',
+      fileName: null,
+    });
+  });
+
+  it('falls back to home when the URL is unrecognized', () => {
+    expect(parseRoute('/something/else')).toEqual({ kind: 'home' });
+    expect(parseRoute('/projects')).toEqual({ kind: 'home' });
+  });
+});


### PR DESCRIPTION
Fixes #1505.

When a Routine fires multiple runs into the same project (reuse mode), each run writes its own conversation but the history-row "Open project" button only navigated to the project root. The project view then defaults to `list[0]` (whichever conversation the list returns first), so opening any history row dropped the user on a single conversation regardless of which run they clicked. Earlier runs looked "absorbed" by the latest even though their conversations existed in the database. lefarcen flagged this shape on the issue thread.

### What changes

**Router extension.** The `project` variant of `Route` carries a new `conversationId` field. URL shape:

```
/projects/:id                                       project root (existing)
/projects/:id/files/:path                           project + file (existing, legacy URL)
/projects/:id/conversations/:cid                    project + specific conversation (new)
/projects/:id/conversations/:cid/files/:path        project + conversation + file (new)
```

`parseRoute` and `buildPath` round-trip every shape including percent-encoded ids and file names with reserved characters.

**Project view honors the route.** `ProjectView` takes a new `routeConversationId` prop. The conversation-load effect prefers `list.find(c => c.id === routeConversationId)` when the routed id is present and matches; falls through to `list[0]` when the id is null or absent (the routine row may have been deleted between route landing and list load). A second focused effect re-points `activeConversationId` when the URL changes the routed id while the user is already inside the project, so clicking a different history row in the same project switches without a refetch.

The prop is optional with a `null` default so the existing test harnesses that mount `ProjectView` with a stub props bag do not need to be updated; production callers in `App.tsx` always pass the value from `useRoute()`.

**Call-site updates.** `RoutinesSection`'s history-row button passes `r.conversationId` through `navigate()`. `SettingsDialog`'s orbit-leave handler now includes `conversationId: null` so the route shape stays type-safe at every call site.

### Test coverage

`apps/web/tests/router.test.ts` (new, 9 cases):

- home route parses (`/` and empty string)
- bare project route round-trip
- project + file route round-trip (legacy URL preserved)
- project + conversation route round-trip
- project + conversation + file route round-trip
- percent-encoding round-trip for ids and file paths with reserved characters
- legacy project + file URL parses with `conversationId: null`
- bare project + conversation URL parses with `fileName: null`
- unrecognized URLs fall back to home

### Adjacent issue (out of scope for this PR)

lefarcen also raised a daemon-side concurrency hypothesis on the issue thread: parallel `runNow` clicks may race the `inflight` guard in `RoutineService.start_`, because the guard clears as soon as the handler resolves (which is after `insertRun` but before the run actually completes). That can let 5 rapid clicks start 5 separate runs instead of deduping to a single in-flight run. The reporter's screenshot shows the routine in `create_each_run` mode where each run should already get its own distinct project, so the daemon-side race is a separate failure shape from the UI gap fixed here.

I have not changed the dedupe window in this PR. The right next step is a red spec at the daemon HTTP boundary (rapid-fire `POST /api/routines/:id/run` → assert N rows iff the policy is "allow N" or 1 row iff the policy is "dedupe"), then a fix that either widens the inflight window to cover completion or changes the policy explicitly. That deserves its own focused PR rather than getting bundled into a UI-routing change.

### Verification

- `pnpm --filter @open-design/web typecheck`: only pre-existing main-branch `customInstructions` errors remain. Confirmed by checking out main and reproducing the same errors without this branch's changes. No new typecheck errors introduced.
- `pnpm --filter @open-design/web exec vitest run tests/router.test.ts`: 9 / 9 green.