### PR TITLE
Make de/fr/ru content i18n optional

### DIFF
--- a/apps/web/tests/i18n/content.test.ts
+++ b/apps/web/tests/i18n/content.test.ts
@@ -61,6 +61,9 @@ describe('localized resource content', () => {
     );
     expect(localized.category).toBe('Infographie');
     expect(localized.tags).toEqual(['3D', 'unknown-tag']);
+    expect(
+      localizePromptTemplateSummary('fr', { ...translatedTemplate, category: 'Unknown category' }).category,
+    ).toBe('Unknown category');
 
     const englishOnlyTemplate = {
       ...translatedTemplate,

--- a/docs/skills-contributing.md
+++ b/docs/skills-contributing.md
@@ -192,14 +192,14 @@ The `e2e/tests/localized-content.test.ts` test enforces that every directory und
 For a non-featured skill, the cheap path is to keep the source metadata complete:
 
 - [ ] **Ensure `SKILL.md` has complete English display copy**: title/name, description, example prompt, and any picker metadata required by the skill schema. The localized runtime uses these fields as the fallback display path.
-- [ ] **Run `pnpm --filter @open-design/web test` and `pnpm --filter @open-design/e2e test tests/localized-content.test.ts`** locally before pushing. These suites catch missing localized dictionaries and undisplayable discovered resources.
+- [ ] **Run `pnpm --filter @open-design/web test` and `pnpm --filter @open-design/e2e test tests/localized-content.test.ts`** locally before pushing. These suites catch undisplayable discovered resources and verify localized fallback behavior.
 
 ### Featured skills (optional path)
 
 If you set `od.featured: 1`, also:
 
 - [ ] **Add a screenshot** at `docs/screenshots/skills/<skill>.png`. PNG, ~1024×640 retina, captured from the real `example.html` at zoomed-out browser scale.
-- [ ] **Add full localized display copy** in `content.ts` (DE), `content.fr.ts` (FR), `content.ru.ts` (RU) — title, summary, scenario tag. The featured row in the picker uses this copy; the default fallback path renders English everywhere.
+- [ ] **Optionally add full localized display copy** in `content.ts` (DE), `content.fr.ts` (FR), `content.ru.ts` (RU) — title, summary, scenario tag. The featured row in the picker uses this copy when present; the default fallback path renders English everywhere.
 
 ### Forking
 

--- a/docs/testing/e2e-coverage/settings.md
+++ b/docs/testing/e2e-coverage/settings.md
@@ -66,7 +66,7 @@
 | SET-041 | 切换到 `fa` 等 RTL 语言后，会同步更新 `html[dir=rtl]`，且语言菜单支持 `Escape` 关闭 | `SettingsDialog.execution.test.tsx` |
 | SET-042 | Language 页面不依赖全局保存按钮；语言切换即时生效，关闭 Settings 也不会回滚已应用 locale | `SettingsDialog.execution.test.tsx` |
 | SET-043 | 多语言内容资源可通过翻译字典或英文 fallback 渲染为非空 skill、design system、prompt template 展示内容 | `localized-content.test.ts` |
-| SET-044 | Prompt template category 和 tag 在缺少 locale 字典项时回退到源值，已有字典项仍可本地化 | `localized-content.test.ts` |
+| SET-044 | Design system category、prompt template category 和 tag 在缺少 locale 字典项时回退到源值，已有字典项仍可本地化 | `localized-content.test.ts` |
 | SET-045 | Notifications 默认以 `offline` 展示；开启 completion sound 后才会显示成功/失败音选择器，并立即试听默认成功音 | `SettingsDialog.execution.test.tsx` |
 | SET-046 | Notifications 支持切换 success / failure sound，并把声音选择保存到通知配置 | `SettingsDialog.execution.test.tsx` |
 | SET-047 | Desktop notification 在授权成功后会切为 `active`，支持发送测试通知并展示发送结果文案 | `SettingsDialog.execution.test.tsx` |

--- a/docs/testing/e2e-coverage/settings.md
+++ b/docs/testing/e2e-coverage/settings.md
@@ -65,8 +65,8 @@
 | SET-040 | 在 Language 页面切换语言后，触发器文案会立即更新，同时把 locale 写入 `localStorage` 并同步 `html[lang]` | `SettingsDialog.execution.test.tsx` |
 | SET-041 | 切换到 `fa` 等 RTL 语言后，会同步更新 `html[dir=rtl]`，且语言菜单支持 `Escape` 关闭 | `SettingsDialog.execution.test.tsx` |
 | SET-042 | Language 页面不依赖全局保存按钮；语言切换即时生效，关闭 Settings 也不会回滚已应用 locale | `SettingsDialog.execution.test.tsx` |
-| SET-043 | 每个 locale 都覆盖了所有 curated skill、design system、prompt template id | `localized-content.test.ts` |
-| SET-044 | 每个 locale 都覆盖了要求的展示分类和 prompt tag | `localized-content.test.ts` |
+| SET-043 | 多语言内容资源可通过翻译字典或英文 fallback 渲染为非空 skill、design system、prompt template 展示内容 | `localized-content.test.ts` |
+| SET-044 | Prompt template category 和 tag 在缺少 locale 字典项时回退到源值，已有字典项仍可本地化 | `localized-content.test.ts` |
 | SET-045 | Notifications 默认以 `offline` 展示；开启 completion sound 后才会显示成功/失败音选择器，并立即试听默认成功音 | `SettingsDialog.execution.test.tsx` |
 | SET-046 | Notifications 支持切换 success / failure sound，并把声音选择保存到通知配置 | `SettingsDialog.execution.test.tsx` |
 | SET-047 | Desktop notification 在授权成功后会切为 `active`，支持发送测试通知并展示发送结果文案 | `SettingsDialog.execution.test.tsx` |

--- a/e2e/tests/localized-content.test.ts
+++ b/e2e/tests/localized-content.test.ts
@@ -11,6 +11,7 @@ declare global {
 }
 
 type LocalizedContentModule = {
+  localizeDesignSystemCategory: (locale: string, category: string) => string;
   localizeDesignSystemSummary: (locale: string, system: DesignSystemResource) => string;
   localizePromptTemplateSummary: (
     locale: string,
@@ -34,8 +35,12 @@ if (localizedContentModule == null) {
   throw new Error('Failed to load apps/web localized content ids');
 }
 
-const { localizeDesignSystemSummary, localizePromptTemplateSummary, localizeSkillDescription } =
-  localizedContentModule;
+const {
+  localizeDesignSystemCategory,
+  localizeDesignSystemSummary,
+  localizePromptTemplateSummary,
+  localizeSkillDescription,
+} = localizedContentModule;
 const COVERAGE_LOCALES = ['de', 'fr', 'ru'] as const;
 const RESOURCE_ID_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 
@@ -364,7 +369,7 @@ describe('localized display content coverage', () => {
   });
 
   for (const locale of COVERAGE_LOCALES) {
-    it(`falls back to source prompt-template category and tags for ${locale} when dictionary entries are missing`, () => {
+    it(`falls back to source design-system and prompt-template metadata for ${locale} when dictionary entries are missing`, () => {
       const localized = localizePromptTemplateSummary(locale, {
         id: 'missing-template-translation',
         category: 'Untranslated Category',
@@ -373,12 +378,15 @@ describe('localized display content coverage', () => {
         summary: ' English summary from source ',
       });
 
+      expect(localizeDesignSystemCategory(locale, 'Untranslated Category')).toBe(
+        'Untranslated Category',
+      );
       expect(localized.title).toBe(' English title from source ');
       expect(localized.summary).toBe(' English summary from source ');
       expect(localized.category).toBe('Untranslated Category');
       expect(localized.tags[0]).toBe('untranslated-tag');
       expect(normalizeText(localized.tags[1] ?? ''), `${locale} should still localize known tags`).not.toEqual(
-        '',
+        '3d',
       );
     });
   }

--- a/e2e/tests/localized-content.test.ts
+++ b/e2e/tests/localized-content.test.ts
@@ -10,17 +10,7 @@ declare global {
   }
 }
 
-type LocalizedContentIds = {
-  skills: string[];
-  designSystems: string[];
-  designSystemCategories: string[];
-  promptTemplates: string[];
-  promptTemplateCategories: string[];
-  promptTemplateTags: string[];
-};
-
 type LocalizedContentModule = {
-  LOCALIZED_CONTENT_IDS: Record<string, LocalizedContentIds>;
   localizeDesignSystemSummary: (locale: string, system: DesignSystemResource) => string;
   localizePromptTemplateSummary: (
     locale: string,
@@ -44,12 +34,8 @@ if (localizedContentModule == null) {
   throw new Error('Failed to load apps/web localized content ids');
 }
 
-const {
-  LOCALIZED_CONTENT_IDS,
-  localizeDesignSystemSummary,
-  localizePromptTemplateSummary,
-  localizeSkillDescription,
-} = localizedContentModule;
+const { localizeDesignSystemSummary, localizePromptTemplateSummary, localizeSkillDescription } =
+  localizedContentModule;
 const COVERAGE_LOCALES = ['de', 'fr', 'ru'] as const;
 const RESOURCE_ID_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 
@@ -378,35 +364,22 @@ describe('localized display content coverage', () => {
   });
 
   for (const locale of COVERAGE_LOCALES) {
-    const ids = LOCALIZED_CONTENT_IDS[locale];
-    invariant(ids, `Localized content ids are missing for ${locale}`);
+    it(`falls back to source prompt-template category and tags for ${locale} when dictionary entries are missing`, () => {
+      const localized = localizePromptTemplateSummary(locale, {
+        id: 'missing-template-translation',
+        category: 'Untranslated Category',
+        tags: ['untranslated-tag', '3d'],
+        title: ' English title from source ',
+        summary: ' English summary from source ',
+      });
 
-    it(`covers every discovered design-system category and prompt tag for ${locale}`, async () => {
-      const [designSystems, promptTemplates] = await Promise.all([
-        readDesignSystemResources(),
-        readPromptTemplateResources(),
-      ]);
-
-      const designSystemCategories = uniqueSorted(designSystems.map((system) => system.category));
-      const promptTemplateCategories = uniqueSorted(
-        promptTemplates.map((template) => template.category),
+      expect(localized.title).toBe(' English title from source ');
+      expect(localized.summary).toBe(' English summary from source ');
+      expect(localized.category).toBe('Untranslated Category');
+      expect(localized.tags[0]).toBe('untranslated-tag');
+      expect(normalizeText(localized.tags[1] ?? ''), `${locale} should still localize known tags`).not.toEqual(
+        '',
       );
-      const promptTemplateTags = uniqueSorted(
-        promptTemplates.flatMap((template) => template.tags),
-      );
-
-      expect(
-        sorted(ids.designSystemCategories),
-        `${locale} is missing localized design-system category translations for: ${designSystemCategories.filter((category) => !ids.designSystemCategories.includes(category)).join(', ') || 'none'}`,
-      ).toEqual(expect.arrayContaining(designSystemCategories));
-      expect(
-        sorted(ids.promptTemplateCategories),
-        `${locale} is missing localized prompt-template category translations for: ${promptTemplateCategories.filter((category) => !ids.promptTemplateCategories.includes(category)).join(', ') || 'none'}`,
-      ).toEqual(expect.arrayContaining(promptTemplateCategories));
-      expect(
-        sorted(ids.promptTemplateTags),
-        `${locale} is missing localized prompt-template tag translations for: ${promptTemplateTags.filter((tag) => !ids.promptTemplateTags.includes(tag)).join(', ') || 'none'}`,
-      ).toEqual(expect.arrayContaining(promptTemplateTags));
     });
   }
 });

--- a/specs/change/20260513-optional-content-i18n/spec.md
+++ b/specs/change/20260513-optional-content-i18n/spec.md
@@ -9,69 +9,69 @@ created: '2026-05-13'
 
 ### Problem Statement
 
-- `apps/web/src/i18n` 下的内容翻译包含 `de`、`fr`、`ru`，但当前翻译覆盖不完整。
-- 这些内容型 i18n 翻译需要改为非强制性，避免内容型贡献者必须补全相关语言内容。
+- Content translations under `apps/web/src/i18n` include `de`, `fr`, and `ru`, but current translation coverage is incomplete.
+- These content-oriented i18n translations need to become optional so content contributors are not required to fill in every related language entry.
 
 ### Goals
 
-- 降低内容型贡献的门槛。
-- 降低补全多语言内容时产生冲突的几率。
+- Lower the barrier for content-oriented contributions.
+- Reduce the chance of conflicts when multilingual content is completed later.
 
 ### Scope
 
-- 调整 `apps/web/src/i18n` 下内容型翻译的要求，使 `de`、`fr`、`ru` 这类不完整翻译可选。
+- Adjust the requirements for content-oriented translations under `apps/web/src/i18n` so incomplete translations such as `de`, `fr`, and `ru` are optional.
 
 ### Success Criteria
 
-- 内容型贡献者可以提交主要内容变更，无需同时补全 `de`、`fr`、`ru` 的所有内容型 i18n 翻译。
-- 不完整的 `de`、`fr`、`ru` 内容翻译不会阻塞相关贡献流程。
+- Content contributors can submit primary content changes without also completing every content-oriented i18n translation for `de`, `fr`, and `ru`.
+- Incomplete `de`, `fr`, and `ru` content translations do not block the related contribution flow.
 
 ## Research
 
 ### Existing System
 
-- `apps/web/src/i18n/content.ts` 聚合 `de`、`ru`、`fr` 三个 content bundle，并从各 bundle 的字典 key 构建 `LOCALIZED_CONTENT_IDS`。Source: `apps/web/src/i18n/content.ts:954-996`
-- 当前 content ids 覆盖 6 类资源：skills、designSystems、designSystemCategories、promptTemplates、promptTemplateCategories、promptTemplateTags。Source: `apps/web/src/i18n/content.ts:26-33,981-989`
-- 运行时本身已有英文 fallback：skill description / prompt、design-system summary、design-system category、prompt-template category / tags、prompt-template title / summary 缺翻译时会回退到源内容或原始标签。Source: `apps/web/src/i18n/content.ts:1010-1053`
-- Web 单元测试确认 localized ids 只来自 localized dictionaries，同时确认缺少 localized copy 时字段级回退到英文源内容或原始 tag。Source: `apps/web/tests/i18n/content.test.ts:12-19,21-80`
-- E2E localized-content 测试会从仓库真实资源读取 skills、design systems、prompt templates，并对 `de`、`fr`、`ru` 循环验证 display content。Source: `e2e/tests/localized-content.test.ts:333-377`
+- `apps/web/src/i18n/content.ts` aggregates the three content bundles for `de`, `ru`, and `fr`, then builds `LOCALIZED_CONTENT_IDS` from each bundle's dictionary keys. Source: `apps/web/src/i18n/content.ts:954-996`
+- Current content ids cover six resource groups: skills, designSystems, designSystemCategories, promptTemplates, promptTemplateCategories, and promptTemplateTags. Source: `apps/web/src/i18n/content.ts:26-33,981-989`
+- The runtime already has English fallbacks: skill description / prompt, design-system summary, design-system category, prompt-template category / tags, and prompt-template title / summary fall back to source content or the original tag when translations are missing. Source: `apps/web/src/i18n/content.ts:1010-1053`
+- Web unit tests confirm that localized ids only come from localized dictionaries, and that fields fall back to English source content or the original tag when localized copy is missing. Source: `apps/web/tests/i18n/content.test.ts:12-19,21-80`
+- The E2E localized-content test reads real repository resources for skills, design systems, and prompt templates, then loops over `de`, `fr`, and `ru` to verify display content. Source: `e2e/tests/localized-content.test.ts:333-377`
 
 ### Current Mandatory Translation Triggers
 
-- Design System 新增全新 category 会触发强制补全：测试从 `design-systems/*/DESIGN.md` 的 `> Category:` 提取 category，并要求每个 locale 的 `ids.designSystemCategories` 包含所有发现到的 category。Source: `e2e/tests/localized-content.test.ts:194-240,390,398-401`
-- Prompt Template 新增全新 category 会触发强制补全：测试从 `prompt-templates/image/*.json` 和 `prompt-templates/video/*.json` 读取 `category`，缺省为 `General`，并要求每个 locale 的 `ids.promptTemplateCategories` 覆盖所有发现到的 category。Source: `e2e/tests/localized-content.test.ts:243-330,391-405`
-- Prompt Template 新增全新 tag 会触发强制补全：测试读取 prompt template 的 `tags` 数组并要求每个 locale 的 `ids.promptTemplateTags` 覆盖所有发现到的 tag。Source: `e2e/tests/localized-content.test.ts:313-318,394-409`
-- Featured Skill / Design Template 的 locale 专属展示文案要求来自贡献文档：设置 `od.featured: 1` 时，文档要求在 `content.ts`、`content.fr.ts`、`content.ru.ts` 添加完整 localized display copy。Source: `docs/skills-contributing.md:197-202`
+- Adding a completely new Design System category triggers mandatory completion: the test extracts categories from `> Category:` in `design-systems/*/DESIGN.md` and requires each locale's `ids.designSystemCategories` to include every discovered category. Source: `e2e/tests/localized-content.test.ts:194-240,390,398-401`
+- Adding a completely new Prompt Template category triggers mandatory completion: the test reads `category` from `prompt-templates/image/*.json` and `prompt-templates/video/*.json`, defaults missing values to `General`, and requires each locale's `ids.promptTemplateCategories` to cover every discovered category. Source: `e2e/tests/localized-content.test.ts:243-330,391-405`
+- Adding a completely new Prompt Template tag triggers mandatory completion: the test reads prompt template `tags` arrays and requires each locale's `ids.promptTemplateTags` to cover every discovered tag. Source: `e2e/tests/localized-content.test.ts:313-318,394-409`
+- Featured Skill / Design Template locale-specific display copy requirements come from the contribution docs: when `od.featured: 1` is set, the docs require complete localized display copy in `content.ts`, `content.fr.ts`, and `content.ru.ts`. Source: `docs/skills-contributing.md:197-202`
 
 ### Non-Mandatory or Already-Fallback Paths
 
-- 新增普通 skill 或 design template 时，E2E 测试要求资源可显示；非 featured 路径通过 `SKILL.md` 英文 display fields 作为 fallback。Source: `docs/skills-contributing.md:188-195`; `e2e/tests/localized-content.test.ts:155-191,351-357`
-- 新增 design system summary 时，文档说明 localized summary 字典只在已有翻译时更新，默认英文 fallback 自动生效。Source: `docs/design-systems.md:251-273`
-- 新增 prompt template title / summary 时，E2E 测试只要求 localized result 非空；运行时会在缺 localized prompt-template copy 时回退到英文 `title` 和 `summary`。Source: `e2e/tests/localized-content.test.ts:366-375`; `apps/web/src/i18n/content.ts:1045-1051`
-- Scenario tag 的 UI 标签使用 `SCENARIO_LABEL_KEY` 中的固定 i18n key；未知 tag 会 title-case 原 tag。Source: `apps/web/src/components/ExamplesTab.tsx:51-70,423-431`
+- When adding a regular skill or design template, the E2E test requires the resource to be displayable; non-featured paths use English display fields from `SKILL.md` as the fallback. Source: `docs/skills-contributing.md:188-195`; `e2e/tests/localized-content.test.ts:155-191,351-357`
+- When adding a design system summary, the docs say the localized summary dictionary is only updated when a translation already exists, and the English fallback applies automatically by default. Source: `docs/design-systems.md:251-273`
+- When adding a prompt template title / summary, the E2E test only requires the localized result to be non-empty; at runtime, missing localized prompt-template copy falls back to the English `title` and `summary`. Source: `e2e/tests/localized-content.test.ts:366-375`; `apps/web/src/i18n/content.ts:1045-1051`
+- Scenario tag UI labels use fixed i18n keys from `SCENARIO_LABEL_KEY`; unknown tags are title-cased from the original tag. Source: `apps/web/src/components/ExamplesTab.tsx:51-70,423-431`
 
 ### Available Approaches
 
-- 调整 E2E category/tag 覆盖断言，让 `de`、`fr`、`ru` content dictionaries 对 design-system categories、prompt-template categories、prompt-template tags 变为可选，并依赖现有运行时 fallback。Source: `e2e/tests/localized-content.test.ts:380-409`; `apps/web/src/i18n/content.ts:1031-1052`
-- 保留资源可显示的 smoke coverage：继续验证 skills、design systems、prompt templates 在 `de`、`fr`、`ru` 下会得到非空展示内容。Source: `e2e/tests/localized-content.test.ts:333-377`
-- 更新贡献文档，把 featured localized copy 从强制要求改为可选或推荐，并明确英文 fallback 路径。Source: `docs/skills-contributing.md:188-202`
-- 同步更新覆盖文档中关于 localized-content 的描述，使其表达“可显示 + fallback”而非“每个 locale 都覆盖所有 id / category / tag”。Source: `docs/testing/e2e-coverage/settings.md:68-69,121`
+- Adjust the E2E category/tag coverage assertions so the `de`, `fr`, and `ru` content dictionaries become optional for design-system categories, prompt-template categories, and prompt-template tags, relying on the existing runtime fallback. Source: `e2e/tests/localized-content.test.ts:380-409`; `apps/web/src/i18n/content.ts:1031-1052`
+- Preserve smoke coverage that resources are displayable: continue verifying that skills, design systems, and prompt templates produce non-empty display content under `de`, `fr`, and `ru`. Source: `e2e/tests/localized-content.test.ts:333-377`
+- Update contribution docs to change featured localized copy from required to optional or recommended, and explicitly describe the English fallback path. Source: `docs/skills-contributing.md:188-202`
+- Update the coverage docs for localized-content so they describe "displayable + fallback" instead of "every locale covers every id / category / tag." Source: `docs/testing/e2e-coverage/settings.md:68-69,121`
 
 ### Constraints & Dependencies
 
-- `LOCALIZED_CONTENT_IDS` 目前直接由 localized dictionaries 的 key 生成；任何仍使用这些 ids 做 array-containing 全量覆盖的测试都会把缺翻译变成阻塞。Source: `apps/web/src/i18n/content.ts:981-996`; `e2e/tests/localized-content.test.ts:398-409`
-- Prompt template category 缺失时会被测试资源读取逻辑归为 `General`；新增 template 未设置 category 时仍会纳入 `General` 的覆盖集合。Source: `e2e/tests/localized-content.test.ts:311-312`
-- Prompt template tags 会过滤掉非字符串和空字符串，强制覆盖只发生在有效非空 tag 上。Source: `e2e/tests/localized-content.test.ts:313-318`
-- 贡献文档当前把 featured localized copy 标为 required path；实现变更需要同步文档，否则内容型贡献者仍会被文档要求补齐翻译。Source: `docs/skills-contributing.md:197-202,232-241`
+- `LOCALIZED_CONTENT_IDS` is currently generated directly from localized dictionary keys; any test that still uses these ids for full array-containing coverage will make missing translations blocking. Source: `apps/web/src/i18n/content.ts:981-996`; `e2e/tests/localized-content.test.ts:398-409`
+- When a prompt template category is missing, the test resource reader classifies it as `General`; newly added templates without a category still enter the `General` coverage set. Source: `e2e/tests/localized-content.test.ts:311-312`
+- Prompt template tags filter out non-string and empty string values, so mandatory coverage only applies to valid non-empty tags. Source: `e2e/tests/localized-content.test.ts:313-318`
+- The contribution docs currently mark featured localized copy as a required path; the implementation change must update those docs too, otherwise content contributors will still be asked by the docs to complete translations. Source: `docs/skills-contributing.md:197-202,232-241`
 
 ### Key References
 
-- `apps/web/src/i18n/content.ts:954-1053` - localized bundle、content ids、runtime fallback。
-- `e2e/tests/localized-content.test.ts:333-409` - localized display coverage 与 category/tag 强制覆盖断言。
-- `apps/web/tests/i18n/content.test.ts:12-80` - localized ids 与 fallback 单元测试。
-- `docs/skills-contributing.md:188-202,232-241` - skill / design-template i18n 贡献要求。
-- `docs/design-systems.md:251-273` - design-system localized summary fallback 文档。
-- `docs/testing/e2e-coverage/settings.md:68-69,121` - e2e coverage 文档对 localized-content 的描述。
+- `apps/web/src/i18n/content.ts:954-1053` - localized bundles, content ids, and runtime fallback.
+- `e2e/tests/localized-content.test.ts:333-409` - localized display coverage and mandatory category/tag coverage assertions.
+- `apps/web/tests/i18n/content.test.ts:12-80` - localized ids and fallback unit tests.
+- `docs/skills-contributing.md:188-202,232-241` - skill / design-template i18n contribution requirements.
+- `docs/design-systems.md:251-273` - design-system localized summary fallback docs.
+- `docs/testing/e2e-coverage/settings.md:68-69,121` - e2e coverage docs describing localized-content.
 
 ## Design
 
@@ -79,107 +79,107 @@ created: '2026-05-13'
 
 ```mermaid
 flowchart TD
-  A[内容资源: skills / design-systems / prompt-templates] --> B[英文源 metadata]
+  A[Content resources: skills / design-systems / prompt-templates] --> B[English source metadata]
   B --> C[localized runtime helpers]
-  D[可选 localized dictionaries: de / fr / ru] --> C
-  C --> E[非空展示内容]
+  D[Optional localized dictionaries: de / fr / ru] --> C
+  C --> E[Non-empty display content]
   F[e2e localized-content smoke] --> E
-  G[覆盖文档 / 贡献文档] --> H[贡献者预期: 英文 fallback 必填, de/fr/ru 翻译可选]
+  G[Coverage docs / contribution docs] --> H[Contributor expectation: English fallback required, de/fr/ru translations optional]
 ```
 
 ### Change Scope
 
-- Area: `e2e/tests/localized-content.test.ts` 的 category / tag 覆盖断言。Impact: 移除 `de` / `fr` / `ru` 字典必须覆盖所有 discovered design-system category、prompt-template category、prompt-template tag 的硬性要求，保留资源可显示 smoke。Source: `e2e/tests/localized-content.test.ts:333-409`
-- Area: `apps/web/src/i18n/content.ts` runtime fallback。Impact: 作为可选翻译的运行时基础，不需要新增 fallback 机制。Source: `apps/web/src/i18n/content.ts:1010-1053`
-- Area: `apps/web/tests/i18n/content.test.ts` fallback 单元测试。Impact: 补强或保留字段级 fallback 断言，确保缺 localized copy 时英文源字段继续生效。Source: `apps/web/tests/i18n/content.test.ts:21-80`
-- Area: `docs/skills-contributing.md` 和 `docs/testing/e2e-coverage/settings.md`。Impact: 把贡献者要求和覆盖说明改成“英文 fallback 必填、localized copy 可选”。Source: `docs/skills-contributing.md:188-202,232-241`; `docs/testing/e2e-coverage/settings.md:68-69,121`
-- Area: `docs/design-systems.md`。Impact: 保持现有 design-system fallback 文档语义一致，只有相关 wording 需要同步时再改。Source: `docs/design-systems.md:251-273`
+- Area: category / tag coverage assertions in `e2e/tests/localized-content.test.ts`. Impact: remove the hard requirement that `de` / `fr` / `ru` dictionaries cover every discovered design-system category, prompt-template category, and prompt-template tag, while preserving the resource display smoke test. Source: `e2e/tests/localized-content.test.ts:333-409`
+- Area: runtime fallback in `apps/web/src/i18n/content.ts`. Impact: this is the runtime foundation for optional translations; no new fallback mechanism is required. Source: `apps/web/src/i18n/content.ts:1010-1053`
+- Area: fallback unit tests in `apps/web/tests/i18n/content.test.ts`. Impact: strengthen or preserve field-level fallback assertions to ensure English source fields still apply when localized copy is missing. Source: `apps/web/tests/i18n/content.test.ts:21-80`
+- Area: `docs/skills-contributing.md` and `docs/testing/e2e-coverage/settings.md`. Impact: update contributor requirements and coverage descriptions to say "English fallback required, localized copy optional." Source: `docs/skills-contributing.md:188-202,232-241`; `docs/testing/e2e-coverage/settings.md:68-69,121`
+- Area: `docs/design-systems.md`. Impact: keep the existing design-system fallback docs semantically aligned, and only update wording if synchronization is needed. Source: `docs/design-systems.md:251-273`
 
 ### Design Decisions
 
-- Decision: 不改 `LOCALIZED_CONTENT_IDS` 的生成方式；它继续表达“当前 locale 已经存在翻译的 id 集合”。Source: `apps/web/src/i18n/content.ts:981-996`; `apps/web/tests/i18n/content.test.ts:12-19`
-- Decision: 删除或改写 e2e 中 `covers every discovered design-system category and prompt tag` 的全量覆盖断言，让 category / tag 字典 key 成为可选翻译清单。Source: `e2e/tests/localized-content.test.ts:380-409`; `apps/web/src/i18n/content.ts:1031-1052`
-- Decision: 保留 `derives displayable resources from discovered English fallback content` 这条 e2e smoke，继续要求 skills、design systems、prompt templates 在 `de` / `fr` / `ru` 下能展示非空内容。Source: `e2e/tests/localized-content.test.ts:333-377`
-- Decision: 保留资源读取阶段的 fail-fast 英文 fallback 校验，例如缺 `description`、design-system `category`、prompt-template `title` / `summary` 时继续失败。Source: `e2e/tests/localized-content.test.ts:155-179,194-240,243-330`
-- Decision: 文档把 featured localized copy 改为推荐增强路径，贡献 PR 的 required path 聚焦完整英文 display copy 与 fallback 覆盖。Source: `docs/skills-contributing.md:188-202,232-241`
-- Decision: 覆盖矩阵中的 SET-043 / SET-044 改写为 fallback 展示完整性与可选翻译校验，避免文档继续表达全 locale 全 id 覆盖。Source: `docs/testing/e2e-coverage/settings.md:68-69,121`
+- Decision: Do not change how `LOCALIZED_CONTENT_IDS` is generated; it continues to express "the set of ids that currently have translations for this locale." Source: `apps/web/src/i18n/content.ts:981-996`; `apps/web/tests/i18n/content.test.ts:12-19`
+- Decision: Delete or rewrite the full coverage assertion in E2E named `covers every discovered design-system category and prompt tag`, making category / tag dictionary keys an optional translation list. Source: `e2e/tests/localized-content.test.ts:380-409`; `apps/web/src/i18n/content.ts:1031-1052`
+- Decision: Keep the E2E smoke test `derives displayable resources from discovered English fallback content`, so skills, design systems, and prompt templates must still produce displayable non-empty content under `de` / `fr` / `ru`. Source: `e2e/tests/localized-content.test.ts:333-377`
+- Decision: Keep fail-fast English fallback validation in the resource-reading phase, such as missing `description`, design-system `category`, or prompt-template `title` / `summary`. Source: `e2e/tests/localized-content.test.ts:155-179,194-240,243-330`
+- Decision: Change docs so featured localized copy becomes a recommended enhancement path, while the required path for contribution PRs focuses on complete English display copy and fallback coverage. Source: `docs/skills-contributing.md:188-202,232-241`
+- Decision: Rewrite SET-043 / SET-044 in the coverage matrix as fallback display integrity and optional translation validation, so the docs no longer express full locale / full id coverage. Source: `docs/testing/e2e-coverage/settings.md:68-69,121`
 
 ### Why this design
 
-- 当前 runtime 已有字段级 fallback，变更主要是把测试与文档从“翻译完整性 gate”调整为“展示完整性 gate”。
-- `LOCALIZED_CONTENT_IDS` 继续保留现有语义，后续仍可用于展示翻译覆盖情况或检查已存在翻译字典本身。
-- 资源仍必须提供完整英文 metadata，缺少真正必需的 fallback 输入会继续早失败。
+- The runtime already has field-level fallback, so the change is mainly to shift tests and docs from a "translation completeness gate" to a "display integrity gate."
+- `LOCALIZED_CONTENT_IDS` keeps its current meaning, so it can still be used later to show translation coverage or inspect existing translation dictionaries.
+- Resources still must provide complete English metadata, and missing truly required fallback inputs continue to fail early.
 
 ### Test Strategy
 
-- E2E: 运行 `pnpm --filter @open-design/e2e test tests/localized-content.test.ts`，验证真实仓库资源在 `de` / `fr` / `ru` 下仍可展示，且 category / tag 缺翻译不会阻塞。Source: `e2e/tests/localized-content.test.ts:333-377`; `e2e/AGENTS.md:40-55`
-- Web unit: 运行 `pnpm --filter @open-design/web test`，覆盖 localized ids 仍来自字典，以及 skill/design-system/prompt-template 字段级 fallback。Source: `apps/web/tests/i18n/content.test.ts:12-80`; `apps/AGENTS.md:27-33,47-59`
-- Probe: 本地临时新增一个未补 `de` / `fr` / `ru` localized dictionary 的 probe 类内容资源，然后运行 CI 等价验证，确认英文 fallback 可显示且缺可选翻译不会阻塞；验证后移除临时 probe 内容。Source: `e2e/tests/localized-content.test.ts:155-409`; `docs/skills-contributing.md:188-202`
-- Repo checks: 运行 `pnpm guard` 和 `pnpm typecheck`，覆盖仓库级脚本与类型边界。Source: `AGENTS.md#validation-strategy`
+- E2E: run `pnpm --filter @open-design/e2e test tests/localized-content.test.ts` to verify real repository resources remain displayable under `de` / `fr` / `ru`, and missing category / tag translations do not block. Source: `e2e/tests/localized-content.test.ts:333-377`; `e2e/AGENTS.md:40-55`
+- Web unit: run `pnpm --filter @open-design/web test` to cover localized ids still coming from dictionaries, plus skill/design-system/prompt-template field-level fallback. Source: `apps/web/tests/i18n/content.test.ts:12-80`; `apps/AGENTS.md:27-33,47-59`
+- Probe: temporarily add a probe content resource without matching `de` / `fr` / `ru` localized dictionary entries, then run CI-equivalent verification to confirm English fallback is displayable and missing optional translations do not block; remove the temporary probe content afterward. Source: `e2e/tests/localized-content.test.ts:155-409`; `docs/skills-contributing.md:188-202`
+- Repo checks: run `pnpm guard` and `pnpm typecheck` to cover repository-level scripts and type boundaries. Source: `AGENTS.md#validation-strategy`
 
 ### Pseudocode
 
 Flow:
-  1. 读取真实资源并校验英文 fallback metadata 必填字段。
-  2. 对 `de` / `fr` / `ru` 调用 runtime localization helper。
-  3. 断言 skill description、design-system summary、prompt-template title / summary 非空。
-  4. 让 design-system category、prompt-template category、prompt-template tag 缺 localized dictionary 时走原值 fallback。
-  5. 文档说明 localized dictionaries 是可选增强，英文 fallback metadata 是贡献必填项。
+  1. Read real resources and validate required English fallback metadata fields.
+  2. Call the runtime localization helper for `de` / `fr` / `ru`.
+  3. Assert that skill description, design-system summary, and prompt-template title / summary are non-empty.
+  4. Let design-system category, prompt-template category, and prompt-template tag use original-value fallback when localized dictionary entries are missing.
+  5. Document localized dictionaries as optional enhancements, while English fallback metadata is required for contributions.
 
 ### File Structure
 
-- `e2e/tests/localized-content.test.ts` - 调整 category / tag 覆盖测试，保留真实资源 fallback smoke。
-- `apps/web/tests/i18n/content.test.ts` - 保留或补强 fallback 单元测试。
-- `docs/skills-contributing.md` - 更新 skill / design-template 贡献 i18n 要求。
-- `docs/testing/e2e-coverage/settings.md` - 更新 localized-content 覆盖矩阵说明。
-- `docs/design-systems.md` - 需要时同步 wording，保持 design-system fallback 文档一致。
+- `e2e/tests/localized-content.test.ts` - adjust category / tag coverage tests and keep the real-resource fallback smoke test.
+- `apps/web/tests/i18n/content.test.ts` - preserve or strengthen fallback unit tests.
+- `docs/skills-contributing.md` - update skill / design-template contribution i18n requirements.
+- `docs/testing/e2e-coverage/settings.md` - update localized-content coverage matrix descriptions.
+- `docs/design-systems.md` - synchronize wording if needed so design-system fallback docs stay consistent.
 
 ### Interfaces / APIs
 
-- 无外部 API、DTO、数据库 schema、sidecar protocol 变更。
-- `LOCALIZED_CONTENT_IDS` 导出保持现状，继续表示已有 localized dictionary 的 key 集合。Source: `apps/web/src/i18n/content.ts:981-1000`
+- No external API, DTO, database schema, or sidecar protocol changes.
+- The `LOCALIZED_CONTENT_IDS` export remains unchanged and continues to represent the key set of existing localized dictionaries. Source: `apps/web/src/i18n/content.ts:981-1000`
 
 ### Edge Cases
 
-- Prompt template 没有 `category` 时继续归入 `General`，`General` 缺 localized copy 时 fallback 为原值。Source: `e2e/tests/localized-content.test.ts:311-312`; `apps/web/src/i18n/content.ts:1035-1052`
-- Prompt template tags 只对有效非空字符串生效，缺 localized tag 时 fallback 为原 tag。Source: `e2e/tests/localized-content.test.ts:313-318`; `apps/web/src/i18n/content.ts:1045-1052`
-- Featured skill 缺 localized copy 时展示英文 fallback，文档将其定位为推荐增强路径。Source: `docs/skills-contributing.md:188-202`
-- 缺英文 fallback metadata 时继续失败，防止以空展示内容掩盖资源错误。Source: `e2e/tests/localized-content.test.ts:155-179,194-240,243-330`
+- A prompt template without `category` continues to be classified as `General`; if `General` has no localized copy, it falls back to the original value. Source: `e2e/tests/localized-content.test.ts:311-312`; `apps/web/src/i18n/content.ts:1035-1052`
+- Prompt template tags only apply to valid non-empty strings; a missing localized tag falls back to the original tag. Source: `e2e/tests/localized-content.test.ts:313-318`; `apps/web/src/i18n/content.ts:1045-1052`
+- A featured skill without localized copy displays the English fallback, and the docs position localized copy as a recommended enhancement path. Source: `docs/skills-contributing.md:188-202`
+- Missing English fallback metadata continues to fail, preventing empty display content from hiding resource errors. Source: `e2e/tests/localized-content.test.ts:155-179,194-240,243-330`
 
 ## Plan
 
-- [x] Step 1: 调整 localized-content 测试 gate
-  - [x] Substep 1.1 Implement: 移除或改写 `LOCALIZED_CONTENT_IDS` 对 discovered category / tag 的全量覆盖断言。
-  - [x] Substep 1.2 Implement: 保留真实资源在 `de` / `fr` / `ru` 下非空显示的 fallback smoke。
-  - [x] Substep 1.3 Implement: 需要时增加 category / tag fallback 的直接断言，覆盖缺字典时返回原值。
-  - [x] Substep 1.4 Verify: 运行 `pnpm --filter @open-design/e2e test tests/localized-content.test.ts`。
-- [x] Step 2: 同步贡献和覆盖文档
-  - [x] Substep 2.1 Implement: 更新 `docs/skills-contributing.md`，把 featured localized copy 表达为可选增强路径。
-  - [x] Substep 2.2 Implement: 更新 `docs/testing/e2e-coverage/settings.md` 中 SET-043 / SET-044 的覆盖描述。
-  - [x] Substep 2.3 Implement: 复核 `docs/design-systems.md` 与新语义一致，必要时微调 wording。
-  - [x] Substep 2.4 Verify: 人工检查文档中不再把 `de` / `fr` / `ru` 内容翻译描述为内容型贡献的硬性阻塞项。
-- [x] Step 3: 回归验证
-  - [x] Substep 3.1 Verify: 运行 `pnpm --filter @open-design/web test`。
-  - [x] Substep 3.2 Verify: 本地临时新增一个未补 `de` / `fr` / `ru` localized dictionary 的 probe 类内容资源，运行 CI 等价验证，确认通过后移除 probe 内容。
-  - [x] Substep 3.3 Verify: 运行 `pnpm guard`。
-  - [x] Substep 3.4 Verify: 运行 `pnpm typecheck`。
+- [x] Step 1: Adjust the localized-content test gate
+  - [x] Substep 1.1 Implement: Remove or rewrite the full coverage assertions that compare `LOCALIZED_CONTENT_IDS` against discovered categories / tags.
+  - [x] Substep 1.2 Implement: Preserve the fallback smoke test that real resources display non-empty content under `de` / `fr` / `ru`.
+  - [x] Substep 1.3 Implement: Add direct category / tag fallback assertions when needed, covering the behavior where missing dictionary entries return original values.
+  - [x] Substep 1.4 Verify: Run `pnpm --filter @open-design/e2e test tests/localized-content.test.ts`.
+- [x] Step 2: Synchronize contribution and coverage docs
+  - [x] Substep 2.1 Implement: Update `docs/skills-contributing.md` so featured localized copy is described as an optional enhancement path.
+  - [x] Substep 2.2 Implement: Update SET-043 / SET-044 coverage descriptions in `docs/testing/e2e-coverage/settings.md`.
+  - [x] Substep 2.3 Implement: Review `docs/design-systems.md` for consistency with the new semantics, and make minor wording adjustments only if needed.
+  - [x] Substep 2.4 Verify: Manually check that the docs no longer describe `de` / `fr` / `ru` content translations as a hard blocking requirement for content contributions.
+- [x] Step 3: Regression verification
+  - [x] Substep 3.1 Verify: Run `pnpm --filter @open-design/web test`.
+  - [x] Substep 3.2 Verify: Temporarily add a probe content resource without `de` / `fr` / `ru` localized dictionary entries, run CI-equivalent verification, confirm it passes, then remove the probe content.
+  - [x] Substep 3.3 Verify: Run `pnpm guard`.
+  - [x] Substep 3.4 Verify: Run `pnpm typecheck`.
 
 ## Notes
 
 ### Implementation
 
-- `e2e/tests/localized-content.test.ts` - 移除 discovered category / tag 对 `LOCALIZED_CONTENT_IDS` 的全量覆盖 gate，保留真实资源可显示 smoke，并新增缺 prompt-template category / tag 字典项时回退源值的直接断言。
-- `apps/web/tests/i18n/content.test.ts` - 补强 prompt-template 未知 category 的 fallback 单元断言。
-- `docs/skills-contributing.md` - 将 localized display copy 调整为 featured skill 的可选增强路径，并说明测试关注可显示资源与 fallback 行为。
-- `docs/testing/e2e-coverage/settings.md` - 将 SET-043 / SET-044 改写为 fallback 展示完整性和可选翻译行为覆盖。
-- `docs/design-systems.md` - 现有 wording 已表达英文 fallback 和可选 localized summary，无需修改。
+- `e2e/tests/localized-content.test.ts` - removed the full coverage gate that compared discovered category / tag values against `LOCALIZED_CONTENT_IDS`, kept the real-resource displayability smoke test, and added direct assertions that prompt-template category / tag values fall back to source values when dictionary entries are missing.
+- `apps/web/tests/i18n/content.test.ts` - strengthened the unit assertion for fallback behavior when a prompt-template category is unknown.
+- `docs/skills-contributing.md` - changed localized display copy into an optional enhancement path for featured skills, and clarified that tests focus on displayable resources and fallback behavior.
+- `docs/testing/e2e-coverage/settings.md` - rewrote SET-043 / SET-044 as fallback display integrity and optional translation behavior coverage.
+- `docs/design-systems.md` - existing wording already described English fallback and optional localized summaries, so no change was needed.
 
 ### Verification
 
-- `pnpm --filter @open-design/web test tests/i18n/content.test.ts` - passed。
-- `pnpm --filter @open-design/e2e test tests/localized-content.test.ts` - 初次发现并清理前序 probe 空目录后 passed。
-- 临时新增英文-only skill、design template、design system、prompt template probe，并运行 `pnpm --filter @open-design/e2e test tests/localized-content.test.ts` - passed；随后移除临时 probe 内容。
-- `pnpm --filter @open-design/e2e test tests/localized-content.test.ts` - final passed。
-- `pnpm --filter @open-design/web test` - passed，110 files / 1013 tests。
-- `pnpm guard` - passed。
-- `pnpm typecheck` - passed。
+- `pnpm --filter @open-design/web test tests/i18n/content.test.ts` - passed.
+- `pnpm --filter @open-design/e2e test tests/localized-content.test.ts` - initially found and cleaned up a pre-existing probe empty directory, then passed.
+- Temporarily added English-only skill, design template, design system, and prompt template probes, then ran `pnpm --filter @open-design/e2e test tests/localized-content.test.ts` - passed; removed the temporary probe content afterward.
+- `pnpm --filter @open-design/e2e test tests/localized-content.test.ts` - final passed.
+- `pnpm --filter @open-design/web test` - passed, 110 files / 1013 tests.
+- `pnpm guard` - passed.
+- `pnpm typecheck` - passed.

--- a/specs/change/20260513-optional-content-i18n/spec.md
+++ b/specs/change/20260513-optional-content-i18n/spec.md
@@ -168,7 +168,7 @@ Flow:
 
 ### Implementation
 
-- `e2e/tests/localized-content.test.ts` - removed the full coverage gate that compared discovered category / tag values against `LOCALIZED_CONTENT_IDS`, kept the real-resource displayability smoke test, and added direct assertions that prompt-template category / tag values fall back to source values when dictionary entries are missing.
+- `e2e/tests/localized-content.test.ts` - removed the full coverage gate that compared discovered category / tag values against `LOCALIZED_CONTENT_IDS`, kept the real-resource displayability smoke test, and added direct assertions that design-system category plus prompt-template category / tag values fall back to source values when dictionary entries are missing.
 - `apps/web/tests/i18n/content.test.ts` - strengthened the unit assertion for fallback behavior when a prompt-template category is unknown.
 - `docs/skills-contributing.md` - changed localized display copy into an optional enhancement path for featured skills, and clarified that tests focus on displayable resources and fallback behavior.
 - `docs/testing/e2e-coverage/settings.md` - rewrote SET-043 / SET-044 as fallback display integrity and optional translation behavior coverage.

--- a/specs/change/20260513-optional-content-i18n/spec.md
+++ b/specs/change/20260513-optional-content-i18n/spec.md
@@ -1,7 +1,7 @@
 ---
 id: 20260513-optional-content-i18n
 name: Optional Content I18n
-status: researched
+status: designed
 created: '2026-05-13'
 ---
 
@@ -75,34 +75,94 @@ created: '2026-05-13'
 
 ## Design
 
-<!-- Technical approach, architecture decisions, and test strategy. Each design decision should cite a fact source. -->
+### Architecture Overview
+
+```mermaid
+flowchart TD
+  A[内容资源: skills / design-systems / prompt-templates] --> B[英文源 metadata]
+  B --> C[localized runtime helpers]
+  D[可选 localized dictionaries: de / fr / ru] --> C
+  C --> E[非空展示内容]
+  F[e2e localized-content smoke] --> E
+  G[覆盖文档 / 贡献文档] --> H[贡献者预期: 英文 fallback 必填, de/fr/ru 翻译可选]
+```
+
+### Change Scope
+
+- Area: `e2e/tests/localized-content.test.ts` 的 category / tag 覆盖断言。Impact: 移除 `de` / `fr` / `ru` 字典必须覆盖所有 discovered design-system category、prompt-template category、prompt-template tag 的硬性要求，保留资源可显示 smoke。Source: `e2e/tests/localized-content.test.ts:333-409`
+- Area: `apps/web/src/i18n/content.ts` runtime fallback。Impact: 作为可选翻译的运行时基础，不需要新增 fallback 机制。Source: `apps/web/src/i18n/content.ts:1010-1053`
+- Area: `apps/web/tests/i18n/content.test.ts` fallback 单元测试。Impact: 补强或保留字段级 fallback 断言，确保缺 localized copy 时英文源字段继续生效。Source: `apps/web/tests/i18n/content.test.ts:21-80`
+- Area: `docs/skills-contributing.md` 和 `docs/testing/e2e-coverage/settings.md`。Impact: 把贡献者要求和覆盖说明改成“英文 fallback 必填、localized copy 可选”。Source: `docs/skills-contributing.md:188-202,232-241`; `docs/testing/e2e-coverage/settings.md:68-69,121`
+- Area: `docs/design-systems.md`。Impact: 保持现有 design-system fallback 文档语义一致，只有相关 wording 需要同步时再改。Source: `docs/design-systems.md:251-273`
+
+### Design Decisions
+
+- Decision: 不改 `LOCALIZED_CONTENT_IDS` 的生成方式；它继续表达“当前 locale 已经存在翻译的 id 集合”。Source: `apps/web/src/i18n/content.ts:981-996`; `apps/web/tests/i18n/content.test.ts:12-19`
+- Decision: 删除或改写 e2e 中 `covers every discovered design-system category and prompt tag` 的全量覆盖断言，让 category / tag 字典 key 成为可选翻译清单。Source: `e2e/tests/localized-content.test.ts:380-409`; `apps/web/src/i18n/content.ts:1031-1052`
+- Decision: 保留 `derives displayable resources from discovered English fallback content` 这条 e2e smoke，继续要求 skills、design systems、prompt templates 在 `de` / `fr` / `ru` 下能展示非空内容。Source: `e2e/tests/localized-content.test.ts:333-377`
+- Decision: 保留资源读取阶段的 fail-fast 英文 fallback 校验，例如缺 `description`、design-system `category`、prompt-template `title` / `summary` 时继续失败。Source: `e2e/tests/localized-content.test.ts:155-179,194-240,243-330`
+- Decision: 文档把 featured localized copy 改为推荐增强路径，贡献 PR 的 required path 聚焦完整英文 display copy 与 fallback 覆盖。Source: `docs/skills-contributing.md:188-202,232-241`
+- Decision: 覆盖矩阵中的 SET-043 / SET-044 改写为 fallback 展示完整性与可选翻译校验，避免文档继续表达全 locale 全 id 覆盖。Source: `docs/testing/e2e-coverage/settings.md:68-69,121`
+
+### Why this design
+
+- 当前 runtime 已有字段级 fallback，变更主要是把测试与文档从“翻译完整性 gate”调整为“展示完整性 gate”。
+- `LOCALIZED_CONTENT_IDS` 继续保留现有语义，后续仍可用于展示翻译覆盖情况或检查已存在翻译字典本身。
+- 资源仍必须提供完整英文 metadata，缺少真正必需的 fallback 输入会继续早失败。
+
+### Test Strategy
+
+- E2E: 运行 `pnpm --filter @open-design/e2e test tests/localized-content.test.ts`，验证真实仓库资源在 `de` / `fr` / `ru` 下仍可展示，且 category / tag 缺翻译不会阻塞。Source: `e2e/tests/localized-content.test.ts:333-377`; `e2e/AGENTS.md:40-55`
+- Web unit: 运行 `pnpm --filter @open-design/web test`，覆盖 localized ids 仍来自字典，以及 skill/design-system/prompt-template 字段级 fallback。Source: `apps/web/tests/i18n/content.test.ts:12-80`; `apps/AGENTS.md:27-33,47-59`
+- Probe: 本地临时新增一个未补 `de` / `fr` / `ru` localized dictionary 的 probe 类内容资源，然后运行 CI 等价验证，确认英文 fallback 可显示且缺可选翻译不会阻塞；验证后移除临时 probe 内容。Source: `e2e/tests/localized-content.test.ts:155-409`; `docs/skills-contributing.md:188-202`
+- Repo checks: 运行 `pnpm guard` 和 `pnpm typecheck`，覆盖仓库级脚本与类型边界。Source: `AGENTS.md#validation-strategy`
+
+### Pseudocode
+
+Flow:
+  1. 读取真实资源并校验英文 fallback metadata 必填字段。
+  2. 对 `de` / `fr` / `ru` 调用 runtime localization helper。
+  3. 断言 skill description、design-system summary、prompt-template title / summary 非空。
+  4. 让 design-system category、prompt-template category、prompt-template tag 缺 localized dictionary 时走原值 fallback。
+  5. 文档说明 localized dictionaries 是可选增强，英文 fallback metadata 是贡献必填项。
+
+### File Structure
+
+- `e2e/tests/localized-content.test.ts` - 调整 category / tag 覆盖测试，保留真实资源 fallback smoke。
+- `apps/web/tests/i18n/content.test.ts` - 保留或补强 fallback 单元测试。
+- `docs/skills-contributing.md` - 更新 skill / design-template 贡献 i18n 要求。
+- `docs/testing/e2e-coverage/settings.md` - 更新 localized-content 覆盖矩阵说明。
+- `docs/design-systems.md` - 需要时同步 wording，保持 design-system fallback 文档一致。
+
+### Interfaces / APIs
+
+- 无外部 API、DTO、数据库 schema、sidecar protocol 变更。
+- `LOCALIZED_CONTENT_IDS` 导出保持现状，继续表示已有 localized dictionary 的 key 集合。Source: `apps/web/src/i18n/content.ts:981-1000`
+
+### Edge Cases
+
+- Prompt template 没有 `category` 时继续归入 `General`，`General` 缺 localized copy 时 fallback 为原值。Source: `e2e/tests/localized-content.test.ts:311-312`; `apps/web/src/i18n/content.ts:1035-1052`
+- Prompt template tags 只对有效非空字符串生效，缺 localized tag 时 fallback 为原 tag。Source: `e2e/tests/localized-content.test.ts:313-318`; `apps/web/src/i18n/content.ts:1045-1052`
+- Featured skill 缺 localized copy 时展示英文 fallback，文档将其定位为推荐增强路径。Source: `docs/skills-contributing.md:188-202`
+- 缺英文 fallback metadata 时继续失败，防止以空展示内容掩盖资源错误。Source: `e2e/tests/localized-content.test.ts:155-179,194-240,243-330`
 
 ## Plan
 
-<!-- Optional: Step breakdown for complex features that need multiple implementation steps.
-     Decided during Design. Checked off during Implement.
-     Keep this section compact and step-based.
-     Use markdown checkboxes for all step and substep items, for example:
-     - [ ] Step 1: Foo
-       - [ ] Substep 1.1 Implement: Foo foundation
-       - [ ] Substep 1.2 Implement: Foo integration
-       - [ ] Substep 1.3 Implement: Foo edge handling
-       - [ ] Substep 1.4 Verify: Foo automated coverage
-       - [ ] Substep 1.5 Verify: Foo manual workflow
-     - [ ] Step 2: Bar
-       - [ ] Substep 2.1 Implement: Bar
-       - [ ] Substep 2.2 Verify: Bar
-     - [ ] Step 3: Baz
-       - [ ] Substep 3.1 Implement: Baz
-       - [ ] Substep 3.2 Verify: Baz
-     Use a capability-based step breakdown with reviewable, meaningful increments.
-     Good boundaries align with one user-visible workflow, one subsystem/integration boundary, one migration/rollout step, or one stabilization milestone.
-     Each step must include small, independent substeps for implementation and immediate testing/verification.
-     Within each step, list implementation substeps before verification substeps.
-     The final step may focus on overall testing/verification, edge cases, regression coverage, and coverage improvements.
-     A step is complete only when relevant tests pass.
-     Size steps so one coding agent can implement + validate in a single session.
-     Write each substep as one small, independent task. -->
+- [ ] Step 1: 调整 localized-content 测试 gate
+  - [ ] Substep 1.1 Implement: 移除或改写 `LOCALIZED_CONTENT_IDS` 对 discovered category / tag 的全量覆盖断言。
+  - [ ] Substep 1.2 Implement: 保留真实资源在 `de` / `fr` / `ru` 下非空显示的 fallback smoke。
+  - [ ] Substep 1.3 Implement: 需要时增加 category / tag fallback 的直接断言，覆盖缺字典时返回原值。
+  - [ ] Substep 1.4 Verify: 运行 `pnpm --filter @open-design/e2e test tests/localized-content.test.ts`。
+- [ ] Step 2: 同步贡献和覆盖文档
+  - [ ] Substep 2.1 Implement: 更新 `docs/skills-contributing.md`，把 featured localized copy 表达为可选增强路径。
+  - [ ] Substep 2.2 Implement: 更新 `docs/testing/e2e-coverage/settings.md` 中 SET-043 / SET-044 的覆盖描述。
+  - [ ] Substep 2.3 Implement: 复核 `docs/design-systems.md` 与新语义一致，必要时微调 wording。
+  - [ ] Substep 2.4 Verify: 人工检查文档中不再把 `de` / `fr` / `ru` 内容翻译描述为内容型贡献的硬性阻塞项。
+- [ ] Step 3: 回归验证
+  - [ ] Substep 3.1 Verify: 运行 `pnpm --filter @open-design/web test`。
+  - [ ] Substep 3.2 Verify: 本地临时新增一个未补 `de` / `fr` / `ru` localized dictionary 的 probe 类内容资源，运行 CI 等价验证，确认通过后移除 probe 内容。
+  - [ ] Substep 3.3 Verify: 运行 `pnpm guard`。
+  - [ ] Substep 3.4 Verify: 运行 `pnpm typecheck`。
 
 ## Notes
 

--- a/specs/change/20260513-optional-content-i18n/spec.md
+++ b/specs/change/20260513-optional-content-i18n/spec.md
@@ -1,0 +1,117 @@
+---
+id: 20260513-optional-content-i18n
+name: Optional Content I18n
+status: researched
+created: '2026-05-13'
+---
+
+## Overview
+
+### Problem Statement
+
+- `apps/web/src/i18n` 下的内容翻译包含 `de`、`fr`、`ru`，但当前翻译覆盖不完整。
+- 这些内容型 i18n 翻译需要改为非强制性，避免内容型贡献者必须补全相关语言内容。
+
+### Goals
+
+- 降低内容型贡献的门槛。
+- 降低补全多语言内容时产生冲突的几率。
+
+### Scope
+
+- 调整 `apps/web/src/i18n` 下内容型翻译的要求，使 `de`、`fr`、`ru` 这类不完整翻译可选。
+
+### Success Criteria
+
+- 内容型贡献者可以提交主要内容变更，无需同时补全 `de`、`fr`、`ru` 的所有内容型 i18n 翻译。
+- 不完整的 `de`、`fr`、`ru` 内容翻译不会阻塞相关贡献流程。
+
+## Research
+
+### Existing System
+
+- `apps/web/src/i18n/content.ts` 聚合 `de`、`ru`、`fr` 三个 content bundle，并从各 bundle 的字典 key 构建 `LOCALIZED_CONTENT_IDS`。Source: `apps/web/src/i18n/content.ts:954-996`
+- 当前 content ids 覆盖 6 类资源：skills、designSystems、designSystemCategories、promptTemplates、promptTemplateCategories、promptTemplateTags。Source: `apps/web/src/i18n/content.ts:26-33,981-989`
+- 运行时本身已有英文 fallback：skill description / prompt、design-system summary、design-system category、prompt-template category / tags、prompt-template title / summary 缺翻译时会回退到源内容或原始标签。Source: `apps/web/src/i18n/content.ts:1010-1053`
+- Web 单元测试确认 localized ids 只来自 localized dictionaries，同时确认缺少 localized copy 时字段级回退到英文源内容或原始 tag。Source: `apps/web/tests/i18n/content.test.ts:12-19,21-80`
+- E2E localized-content 测试会从仓库真实资源读取 skills、design systems、prompt templates，并对 `de`、`fr`、`ru` 循环验证 display content。Source: `e2e/tests/localized-content.test.ts:333-377`
+
+### Current Mandatory Translation Triggers
+
+- Design System 新增全新 category 会触发强制补全：测试从 `design-systems/*/DESIGN.md` 的 `> Category:` 提取 category，并要求每个 locale 的 `ids.designSystemCategories` 包含所有发现到的 category。Source: `e2e/tests/localized-content.test.ts:194-240,390,398-401`
+- Prompt Template 新增全新 category 会触发强制补全：测试从 `prompt-templates/image/*.json` 和 `prompt-templates/video/*.json` 读取 `category`，缺省为 `General`，并要求每个 locale 的 `ids.promptTemplateCategories` 覆盖所有发现到的 category。Source: `e2e/tests/localized-content.test.ts:243-330,391-405`
+- Prompt Template 新增全新 tag 会触发强制补全：测试读取 prompt template 的 `tags` 数组并要求每个 locale 的 `ids.promptTemplateTags` 覆盖所有发现到的 tag。Source: `e2e/tests/localized-content.test.ts:313-318,394-409`
+- Featured Skill / Design Template 的 locale 专属展示文案要求来自贡献文档：设置 `od.featured: 1` 时，文档要求在 `content.ts`、`content.fr.ts`、`content.ru.ts` 添加完整 localized display copy。Source: `docs/skills-contributing.md:197-202`
+
+### Non-Mandatory or Already-Fallback Paths
+
+- 新增普通 skill 或 design template 时，E2E 测试要求资源可显示；非 featured 路径通过 `SKILL.md` 英文 display fields 作为 fallback。Source: `docs/skills-contributing.md:188-195`; `e2e/tests/localized-content.test.ts:155-191,351-357`
+- 新增 design system summary 时，文档说明 localized summary 字典只在已有翻译时更新，默认英文 fallback 自动生效。Source: `docs/design-systems.md:251-273`
+- 新增 prompt template title / summary 时，E2E 测试只要求 localized result 非空；运行时会在缺 localized prompt-template copy 时回退到英文 `title` 和 `summary`。Source: `e2e/tests/localized-content.test.ts:366-375`; `apps/web/src/i18n/content.ts:1045-1051`
+- Scenario tag 的 UI 标签使用 `SCENARIO_LABEL_KEY` 中的固定 i18n key；未知 tag 会 title-case 原 tag。Source: `apps/web/src/components/ExamplesTab.tsx:51-70,423-431`
+
+### Available Approaches
+
+- 调整 E2E category/tag 覆盖断言，让 `de`、`fr`、`ru` content dictionaries 对 design-system categories、prompt-template categories、prompt-template tags 变为可选，并依赖现有运行时 fallback。Source: `e2e/tests/localized-content.test.ts:380-409`; `apps/web/src/i18n/content.ts:1031-1052`
+- 保留资源可显示的 smoke coverage：继续验证 skills、design systems、prompt templates 在 `de`、`fr`、`ru` 下会得到非空展示内容。Source: `e2e/tests/localized-content.test.ts:333-377`
+- 更新贡献文档，把 featured localized copy 从强制要求改为可选或推荐，并明确英文 fallback 路径。Source: `docs/skills-contributing.md:188-202`
+- 同步更新覆盖文档中关于 localized-content 的描述，使其表达“可显示 + fallback”而非“每个 locale 都覆盖所有 id / category / tag”。Source: `docs/testing/e2e-coverage/settings.md:68-69,121`
+
+### Constraints & Dependencies
+
+- `LOCALIZED_CONTENT_IDS` 目前直接由 localized dictionaries 的 key 生成；任何仍使用这些 ids 做 array-containing 全量覆盖的测试都会把缺翻译变成阻塞。Source: `apps/web/src/i18n/content.ts:981-996`; `e2e/tests/localized-content.test.ts:398-409`
+- Prompt template category 缺失时会被测试资源读取逻辑归为 `General`；新增 template 未设置 category 时仍会纳入 `General` 的覆盖集合。Source: `e2e/tests/localized-content.test.ts:311-312`
+- Prompt template tags 会过滤掉非字符串和空字符串，强制覆盖只发生在有效非空 tag 上。Source: `e2e/tests/localized-content.test.ts:313-318`
+- 贡献文档当前把 featured localized copy 标为 required path；实现变更需要同步文档，否则内容型贡献者仍会被文档要求补齐翻译。Source: `docs/skills-contributing.md:197-202,232-241`
+
+### Key References
+
+- `apps/web/src/i18n/content.ts:954-1053` - localized bundle、content ids、runtime fallback。
+- `e2e/tests/localized-content.test.ts:333-409` - localized display coverage 与 category/tag 强制覆盖断言。
+- `apps/web/tests/i18n/content.test.ts:12-80` - localized ids 与 fallback 单元测试。
+- `docs/skills-contributing.md:188-202,232-241` - skill / design-template i18n 贡献要求。
+- `docs/design-systems.md:251-273` - design-system localized summary fallback 文档。
+- `docs/testing/e2e-coverage/settings.md:68-69,121` - e2e coverage 文档对 localized-content 的描述。
+
+## Design
+
+<!-- Technical approach, architecture decisions, and test strategy. Each design decision should cite a fact source. -->
+
+## Plan
+
+<!-- Optional: Step breakdown for complex features that need multiple implementation steps.
+     Decided during Design. Checked off during Implement.
+     Keep this section compact and step-based.
+     Use markdown checkboxes for all step and substep items, for example:
+     - [ ] Step 1: Foo
+       - [ ] Substep 1.1 Implement: Foo foundation
+       - [ ] Substep 1.2 Implement: Foo integration
+       - [ ] Substep 1.3 Implement: Foo edge handling
+       - [ ] Substep 1.4 Verify: Foo automated coverage
+       - [ ] Substep 1.5 Verify: Foo manual workflow
+     - [ ] Step 2: Bar
+       - [ ] Substep 2.1 Implement: Bar
+       - [ ] Substep 2.2 Verify: Bar
+     - [ ] Step 3: Baz
+       - [ ] Substep 3.1 Implement: Baz
+       - [ ] Substep 3.2 Verify: Baz
+     Use a capability-based step breakdown with reviewable, meaningful increments.
+     Good boundaries align with one user-visible workflow, one subsystem/integration boundary, one migration/rollout step, or one stabilization milestone.
+     Each step must include small, independent substeps for implementation and immediate testing/verification.
+     Within each step, list implementation substeps before verification substeps.
+     The final step may focus on overall testing/verification, edge cases, regression coverage, and coverage improvements.
+     A step is complete only when relevant tests pass.
+     Size steps so one coding agent can implement + validate in a single session.
+     Write each substep as one small, independent task. -->
+
+## Notes
+
+<!-- Optional sections — add what's relevant. -->
+
+### Implementation
+
+<!-- Files created/modified, decisions made during coding, deviations from design -->
+
+### Verification
+
+<!-- How the feature was verified: tests written, manual testing steps, results -->

--- a/specs/change/20260513-optional-content-i18n/spec.md
+++ b/specs/change/20260513-optional-content-i18n/spec.md
@@ -1,7 +1,7 @@
 ---
 id: 20260513-optional-content-i18n
 name: Optional Content I18n
-status: designed
+status: implemented
 created: '2026-05-13'
 ---
 
@@ -148,30 +148,38 @@ Flow:
 
 ## Plan
 
-- [ ] Step 1: 调整 localized-content 测试 gate
-  - [ ] Substep 1.1 Implement: 移除或改写 `LOCALIZED_CONTENT_IDS` 对 discovered category / tag 的全量覆盖断言。
-  - [ ] Substep 1.2 Implement: 保留真实资源在 `de` / `fr` / `ru` 下非空显示的 fallback smoke。
-  - [ ] Substep 1.3 Implement: 需要时增加 category / tag fallback 的直接断言，覆盖缺字典时返回原值。
-  - [ ] Substep 1.4 Verify: 运行 `pnpm --filter @open-design/e2e test tests/localized-content.test.ts`。
-- [ ] Step 2: 同步贡献和覆盖文档
-  - [ ] Substep 2.1 Implement: 更新 `docs/skills-contributing.md`，把 featured localized copy 表达为可选增强路径。
-  - [ ] Substep 2.2 Implement: 更新 `docs/testing/e2e-coverage/settings.md` 中 SET-043 / SET-044 的覆盖描述。
-  - [ ] Substep 2.3 Implement: 复核 `docs/design-systems.md` 与新语义一致，必要时微调 wording。
-  - [ ] Substep 2.4 Verify: 人工检查文档中不再把 `de` / `fr` / `ru` 内容翻译描述为内容型贡献的硬性阻塞项。
-- [ ] Step 3: 回归验证
-  - [ ] Substep 3.1 Verify: 运行 `pnpm --filter @open-design/web test`。
-  - [ ] Substep 3.2 Verify: 本地临时新增一个未补 `de` / `fr` / `ru` localized dictionary 的 probe 类内容资源，运行 CI 等价验证，确认通过后移除 probe 内容。
-  - [ ] Substep 3.3 Verify: 运行 `pnpm guard`。
-  - [ ] Substep 3.4 Verify: 运行 `pnpm typecheck`。
+- [x] Step 1: 调整 localized-content 测试 gate
+  - [x] Substep 1.1 Implement: 移除或改写 `LOCALIZED_CONTENT_IDS` 对 discovered category / tag 的全量覆盖断言。
+  - [x] Substep 1.2 Implement: 保留真实资源在 `de` / `fr` / `ru` 下非空显示的 fallback smoke。
+  - [x] Substep 1.3 Implement: 需要时增加 category / tag fallback 的直接断言，覆盖缺字典时返回原值。
+  - [x] Substep 1.4 Verify: 运行 `pnpm --filter @open-design/e2e test tests/localized-content.test.ts`。
+- [x] Step 2: 同步贡献和覆盖文档
+  - [x] Substep 2.1 Implement: 更新 `docs/skills-contributing.md`，把 featured localized copy 表达为可选增强路径。
+  - [x] Substep 2.2 Implement: 更新 `docs/testing/e2e-coverage/settings.md` 中 SET-043 / SET-044 的覆盖描述。
+  - [x] Substep 2.3 Implement: 复核 `docs/design-systems.md` 与新语义一致，必要时微调 wording。
+  - [x] Substep 2.4 Verify: 人工检查文档中不再把 `de` / `fr` / `ru` 内容翻译描述为内容型贡献的硬性阻塞项。
+- [x] Step 3: 回归验证
+  - [x] Substep 3.1 Verify: 运行 `pnpm --filter @open-design/web test`。
+  - [x] Substep 3.2 Verify: 本地临时新增一个未补 `de` / `fr` / `ru` localized dictionary 的 probe 类内容资源，运行 CI 等价验证，确认通过后移除 probe 内容。
+  - [x] Substep 3.3 Verify: 运行 `pnpm guard`。
+  - [x] Substep 3.4 Verify: 运行 `pnpm typecheck`。
 
 ## Notes
 
-<!-- Optional sections — add what's relevant. -->
-
 ### Implementation
 
-<!-- Files created/modified, decisions made during coding, deviations from design -->
+- `e2e/tests/localized-content.test.ts` - 移除 discovered category / tag 对 `LOCALIZED_CONTENT_IDS` 的全量覆盖 gate，保留真实资源可显示 smoke，并新增缺 prompt-template category / tag 字典项时回退源值的直接断言。
+- `apps/web/tests/i18n/content.test.ts` - 补强 prompt-template 未知 category 的 fallback 单元断言。
+- `docs/skills-contributing.md` - 将 localized display copy 调整为 featured skill 的可选增强路径，并说明测试关注可显示资源与 fallback 行为。
+- `docs/testing/e2e-coverage/settings.md` - 将 SET-043 / SET-044 改写为 fallback 展示完整性和可选翻译行为覆盖。
+- `docs/design-systems.md` - 现有 wording 已表达英文 fallback 和可选 localized summary，无需修改。
 
 ### Verification
 
-<!-- How the feature was verified: tests written, manual testing steps, results -->
+- `pnpm --filter @open-design/web test tests/i18n/content.test.ts` - passed。
+- `pnpm --filter @open-design/e2e test tests/localized-content.test.ts` - 初次发现并清理前序 probe 空目录后 passed。
+- 临时新增英文-only skill、design template、design system、prompt template probe，并运行 `pnpm --filter @open-design/e2e test tests/localized-content.test.ts` - passed；随后移除临时 probe 内容。
+- `pnpm --filter @open-design/e2e test tests/localized-content.test.ts` - final passed。
+- `pnpm --filter @open-design/web test` - passed，110 files / 1013 tests。
+- `pnpm guard` - passed。
+- `pnpm typecheck` - passed。


### PR DESCRIPTION
## Summary
- Make incomplete de/fr/ru content translations optional for content-style contributions.
- Keep English source metadata as the required fallback path so skills, design systems, and prompt templates remain displayable across locales.
- Update localized-content coverage and contributor docs so missing de/fr/ru category/tag copy no longer blocks related contribution flows.

## Validation
- `pnpm --filter @open-design/e2e test tests/localized-content.test.ts`
- `pnpm --filter @open-design/web test`
- `pnpm guard`
- `pnpm typecheck`