### PR TITLE
fix: Improve contrast for Routine history "Open project" button on hover

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -18529,7 +18529,11 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   gap: 4px;
   font-weight: 500;
 }
-.routines-history-link:hover { background: var(--text); color: var(--bg); border-color: var(--text); }
+.routines-history-link:hover {
+  background: var(--text);
+  color: #fff;
+  border-color: var(--text);
+}
 
 .routines-status {
   display: inline-block;


### PR DESCRIPTION
Fixes #1357

## Problem
The **Open project** button in Routine history rows became unreadable on hover because the text color effectively disappeared. The button used `color: var(--bg)` on hover, which could match the actual background color in some theme configurations, making the text invisible.

## Solution
Changed the hover text color from `var(--bg)` to explicit white (`#fff`) for consistent contrast.

### Changes
- Modified `.routines-history-link:hover` in `index.css`
- Changed `color: var(--bg)` to `color: #fff`
- Kept the inverted background (`background: var(--text)`) for the hover effect
- Text and icon now remain clearly visible in all theme configurations

## Testing
The button now maintains readable text in both:
- Default state: dark text on transparent background
- Hover state: white text on dark background

The Icon component uses `stroke: currentColor`, so it automatically inherits the white color on hover.

## Files Changed
- 1 file modified
- 5 insertions, 1 deletion
- CSS-only fix, no component changes needed