### PR TITLE
Refine preview and project dropdown controls

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -319,21 +319,69 @@ function PreviewViewportControls({
   t: TranslateFn;
   tabIndex?: number;
 }) {
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const listboxId = useId();
+  const activePreset =
+    PREVIEW_VIEWPORT_PRESETS.find((preset) => preset.id === viewport) ?? PREVIEW_VIEWPORT_PRESETS[0]!;
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: PointerEvent) => {
+      if (!menuRef.current) return;
+      if (!menuRef.current.contains(event.target as Node)) setOpen(false);
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('pointerdown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open]);
+
   return (
-    <div className="viewer-viewport-switcher" role="group" aria-label={t('fileViewer.viewportAria')}>
-      {PREVIEW_VIEWPORT_PRESETS.map((preset) => (
-        <button
-          key={preset.id}
-          type="button"
-          className={`viewer-action viewer-viewport-button${viewport === preset.id ? ' active' : ''}`}
-          aria-pressed={viewport === preset.id}
-          title={t(preset.titleKey)}
-          tabIndex={tabIndex}
-          onClick={() => onViewport(preset.id)}
-        >
-          {t(preset.labelKey)}
-        </button>
-      ))}
+    <div className="viewer-viewport-switcher" ref={menuRef}>
+      <button
+        type="button"
+        className="viewer-action viewer-viewport-trigger"
+        aria-label={t('fileViewer.viewportAria')}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={open ? listboxId : undefined}
+        title={t(activePreset.titleKey)}
+        tabIndex={tabIndex}
+        onClick={() => setOpen((value) => !value)}
+      >
+        <span>{t(activePreset.labelKey)}</span>
+        <Icon name="chevron-down" size={11} />
+      </button>
+      {open ? (
+        <div className="viewer-viewport-menu" id={listboxId} role="listbox" aria-label={t('fileViewer.viewportAria')}>
+          {PREVIEW_VIEWPORT_PRESETS.map((preset) => {
+            const selected = viewport === preset.id;
+            return (
+              <button
+                key={preset.id}
+                type="button"
+                className={`viewer-viewport-menu-item${selected ? ' active' : ''}`}
+                role="option"
+                aria-selected={selected}
+                title={t(preset.titleKey)}
+                onClick={() => {
+                  onViewport(preset.id);
+                  setOpen(false);
+                }}
+              >
+                <span>{t(preset.labelKey)}</span>
+                {selected ? <Icon name="check" size={13} /> : null}
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
 import {
   createTabToTracking,
   projectKindToTracking,
@@ -737,7 +737,6 @@ export function NewProjectPanel({
           <SurfaceOptions
             includeLandingPage={includeLandingPage}
             includeOsWidgets={includeOsWidgets}
-            osWidgetsAvailable={platformTargetsSupportOsWidgets(platformTargets)}
             onIncludeLandingPage={setIncludeLandingPage}
             onIncludeOsWidgets={setIncludeOsWidgets}
           />
@@ -914,6 +913,33 @@ function PlatformPicker({
   value: NewProjectPlatform[];
   onChange: (v: NewProjectPlatform[]) => void;
 }) {
+  const [open, setOpen] = useState(false);
+  const pickerRef = useRef<HTMLDivElement | null>(null);
+  const listboxId = useId();
+  const selectedOptions = DESIGN_PLATFORMS.filter((option) => value.includes(option.value));
+  const triggerLabel =
+    selectedOptions.length === 1
+      ? selectedOptions[0]!.label
+      : `${selectedOptions.length} platforms`;
+  const triggerTitle = selectedOptions.map((option) => `${option.label}: ${option.hint}`).join('\n');
+
+  useEffect(() => {
+    if (!open) return;
+    function onPointer(e: MouseEvent) {
+      if (pickerRef.current?.contains(e.target as Node)) return;
+      setOpen(false);
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false);
+    }
+    document.addEventListener('mousedown', onPointer);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onPointer);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
   function togglePlatform(next: NewProjectPlatform) {
     const active = value.includes(next);
     const updated = active
@@ -929,23 +955,46 @@ function PlatformPicker({
         Pick one or more. Responsive web covers browser breakpoints only; add iOS,
         Android, tablet app, or desktop app for native cross-platform variants.
       </p>
-      <div className="platform-grid">
-        {DESIGN_PLATFORMS.map((option) => {
-          const active = value.includes(option.value);
-          return (
-            <button
-              key={option.value}
-              type="button"
-              className={`newproj-card platform-card${active ? ' active' : ''}`}
-              onClick={() => togglePlatform(option.value)}
-              title={option.hint}
-              aria-pressed={active}
-            >
-              <span className="platform-card-title">{option.label}</span>
-              <span className="platform-card-hint">{option.hint}</span>
-            </button>
-          );
-        })}
+      <div className="platform-dropdown" ref={pickerRef}>
+        <button
+          type="button"
+          className="platform-dropdown-trigger"
+          aria-haspopup="listbox"
+          aria-expanded={open}
+          aria-controls={open ? listboxId : undefined}
+          title={triggerTitle}
+          onClick={() => setOpen((value) => !value)}
+        >
+          <span className="platform-dropdown-label">{triggerLabel}</span>
+          <span className="platform-dropdown-count">{selectedOptions.length}</span>
+          <Icon name="chevron-down" size={12} />
+        </button>
+        {open ? (
+          <div className="platform-dropdown-menu" id={listboxId} role="listbox" aria-label="Target platforms">
+            {DESIGN_PLATFORMS.map((option) => {
+              const active = value.includes(option.value);
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  className={`platform-dropdown-item${active ? ' active' : ''}`}
+                  role="option"
+                  aria-selected={active}
+                  title={option.hint}
+                  onClick={() => togglePlatform(option.value)}
+                >
+                  <span className="platform-dropdown-check" aria-hidden>
+                    {active ? <Icon name="check" size={12} /> : null}
+                  </span>
+                  <span className="platform-dropdown-copy">
+                    <span className="platform-dropdown-title">{option.label}</span>
+                    <span className="platform-dropdown-hint">{option.hint}</span>
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        ) : null}
       </div>
     </div>
   );
@@ -954,13 +1003,11 @@ function PlatformPicker({
 function SurfaceOptions({
   includeLandingPage,
   includeOsWidgets,
-  osWidgetsAvailable,
   onIncludeLandingPage,
   onIncludeOsWidgets,
 }: {
   includeLandingPage: boolean;
   includeOsWidgets: boolean;
-  osWidgetsAvailable: boolean;
   onIncludeLandingPage: (v: boolean) => void;
   onIncludeOsWidgets: (v: boolean) => void;
 }) {
@@ -968,24 +1015,52 @@ function SurfaceOptions({
   return (
     <div className="newproj-section surface-options">
       <label className="newproj-label">{t('newproj.surfaceOptionsLabel')}</label>
-      <ToggleRow
-        label={t('newproj.includeLandingPage')}
-        hint={t('newproj.includeLandingPageHint')}
-        checked={includeLandingPage}
-        onChange={onIncludeLandingPage}
-      />
-      <ToggleRow
-        label={t('newproj.includeOsWidgets')}
-        hint={
-          osWidgetsAvailable
-            ? t('newproj.includeOsWidgetsHint')
-            : t('newproj.includeOsWidgetsDisabledHint')
-        }
-        checked={osWidgetsAvailable && includeOsWidgets}
-        disabled={!osWidgetsAvailable}
-        onChange={onIncludeOsWidgets}
-      />
+      <div className="surface-checkbox-row">
+        <SurfaceOptionCheckbox
+          label={t('newproj.includeLandingPage')}
+          hint={t('newproj.includeLandingPageHint')}
+          checked={includeLandingPage}
+          onChange={onIncludeLandingPage}
+        />
+        <SurfaceOptionCheckbox
+          label={t('newproj.includeOsWidgets')}
+          hint={t('newproj.includeOsWidgetsHint')}
+          checked={includeOsWidgets}
+          onChange={onIncludeOsWidgets}
+        />
+      </div>
     </div>
+  );
+}
+
+function SurfaceOptionCheckbox({
+  label,
+  hint,
+  checked,
+  onChange,
+}: {
+  label: string;
+  hint: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={`surface-checkbox${checked ? ' active' : ''}`}
+      role="checkbox"
+      aria-checked={checked}
+      aria-label={`${label}. ${hint}`}
+      onClick={() => onChange(!checked)}
+    >
+      <span className="surface-checkbox-box" aria-hidden>
+        {checked ? <Icon name="check" size={12} /> : null}
+      </span>
+      <span className="surface-checkbox-label">{label}</span>
+      <span className="surface-checkbox-tip" role="tooltip">
+        {hint}
+      </span>
+    </button>
   );
 }
 
@@ -2397,10 +2472,9 @@ function buildMetadata(input: {
         : input.tab;
   const selectedPlatforms = normalizeSelectedPlatforms(input.platformTargets);
   const concreteTargets = platformTargetsFor(selectedPlatforms);
-  const canIncludeOsWidgets = platformTargetsSupportOsWidgets(concreteTargets);
   const surfaceOptions = {
     ...(input.includeLandingPage ? { includeLandingPage: true } : {}),
-    ...(input.includeOsWidgets && canIncludeOsWidgets ? { includeOsWidgets: true } : {}),
+    ...(input.includeOsWidgets ? { includeOsWidgets: true } : {}),
   };
   const base = {
     platform: selectedPlatforms[0],

--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -2472,9 +2472,10 @@ function buildMetadata(input: {
         : input.tab;
   const selectedPlatforms = normalizeSelectedPlatforms(input.platformTargets);
   const concreteTargets = platformTargetsFor(selectedPlatforms);
+  const canIncludeOsWidgets = platformTargetsSupportOsWidgets(concreteTargets);
   const surfaceOptions = {
     ...(input.includeLandingPage ? { includeLandingPage: true } : {}),
-    ...(input.includeOsWidgets ? { includeOsWidgets: true } : {}),
+    ...(input.includeOsWidgets && canIncludeOsWidgets ? { includeOsWidgets: true } : {}),
   };
   const base = {
     platform: selectedPlatforms[0],

--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -970,7 +970,13 @@ function PlatformPicker({
           <Icon name="chevron-down" size={12} />
         </button>
         {open ? (
-          <div className="platform-dropdown-menu" id={listboxId} role="listbox" aria-label="Target platforms">
+          <div
+            className="platform-dropdown-menu"
+            id={listboxId}
+            role="listbox"
+            aria-label="Target platforms"
+            aria-multiselectable="true"
+          >
             {DESIGN_PLATFORMS.map((option) => {
               const active = value.includes(option.value);
               return (

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4088,31 +4088,124 @@ code {
 }
 .newproj-name { width: 100%; }
 .newproj-section { display: flex; flex-direction: column; gap: 6px; }
-.platform-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px;
-}
 .platform-picker-hint {
   margin: 0;
   color: var(--text-muted);
   font-size: 11px;
   line-height: 1.35;
 }
-.platform-card {
-  min-height: 64px;
-  padding: 10px;
+.platform-dropdown {
+  position: relative;
+}
+.platform-dropdown-trigger {
+  width: 100%;
+  min-height: 38px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-panel);
+  color: var(--text);
+  font-size: 12.5px;
+  text-align: left;
+  box-shadow: var(--shadow-xs);
+  transition: border-color 120ms ease, background 120ms ease;
+}
+.platform-dropdown-trigger:hover,
+.platform-dropdown-trigger[aria-expanded='true'] {
+  border-color: var(--border-strong);
+  background: var(--bg-subtle);
+}
+.platform-dropdown-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 600;
+}
+.platform-dropdown-count {
+  flex: none;
+  min-width: 20px;
+  height: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-pill);
+  background: var(--accent-tint);
+  color: var(--accent-strong);
+  font-size: 11px;
+  font-weight: 700;
+}
+.platform-dropdown-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  z-index: 85;
+  max-height: 260px;
+  overflow-y: auto;
+  padding: 6px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-panel);
+  box-shadow: var(--shadow-md);
+  overflow: hidden auto;
+}
+.platform-dropdown-item {
+  width: 100%;
+  min-height: 48px;
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  text-align: left;
+  color: var(--text-muted);
+}
+.platform-dropdown-item:hover {
+  background: var(--bg-subtle);
+  color: var(--text);
+}
+.platform-dropdown-item.active {
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
+  background: var(--accent-tint);
+}
+.platform-dropdown-check {
+  flex: none;
+  width: 16px;
+  height: 16px;
+  margin-top: 1px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border-strong);
+  border-radius: 4px;
+  color: var(--accent-strong);
+  background: var(--bg-panel);
+}
+.platform-dropdown-item.active .platform-dropdown-check {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: white;
+}
+.platform-dropdown-copy {
+  min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 2px;
 }
-.platform-card-title {
+.platform-dropdown-title {
   color: var(--text-strong);
   font-size: 12.5px;
   font-weight: 650;
   line-height: 1.2;
 }
-.platform-card-hint {
+.platform-dropdown-hint {
   color: var(--text-muted);
   font-size: 11px;
   line-height: 1.3;
@@ -4282,7 +4375,6 @@ code {
 @media (max-width: 560px) {
   .newproj-model-grid,
   .newproj-option-grid,
-  .platform-grid,
   .newproj-option-grid.aspect-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -4524,6 +4616,91 @@ code {
 }
 .toggle-row.on .toggle-row-switch { background: var(--accent); }
 .toggle-row.on .toggle-row-switch::after { transform: translateX(14px); }
+
+.surface-checkbox-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+.surface-checkbox {
+  position: relative;
+  min-height: 34px;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 9px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-panel);
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 500;
+  text-align: left;
+  transition: border-color 120ms ease, background 120ms ease, color 120ms ease;
+}
+.surface-checkbox:hover:not(:disabled) {
+  border-color: var(--border-strong);
+  background: var(--bg-subtle);
+}
+.surface-checkbox.active {
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
+  background: var(--accent-tint);
+  color: var(--accent-strong);
+}
+.surface-checkbox-box {
+  flex: none;
+  width: 16px;
+  height: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border-strong);
+  border-radius: 4px;
+  background: var(--bg-panel);
+  color: var(--accent-strong);
+}
+.surface-checkbox.active .surface-checkbox-box {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: white;
+}
+.surface-checkbox-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.surface-checkbox-tip {
+  position: absolute;
+  left: 0;
+  top: calc(100% + 7px);
+  z-index: 90;
+  width: max-content;
+  max-width: 220px;
+  padding: 7px 9px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-panel);
+  box-shadow: var(--shadow-md);
+  color: var(--text);
+  font-size: 11.5px;
+  font-weight: 400;
+  line-height: 1.35;
+  white-space: normal;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-2px);
+  transition: opacity 120ms ease, transform 120ms ease;
+}
+.surface-checkbox:hover .surface-checkbox-tip,
+.surface-checkbox:focus-visible .surface-checkbox-tip {
+  opacity: 1;
+  transform: translateY(0);
+}
+.surface-checkbox:nth-child(2n) .surface-checkbox-tip {
+  left: auto;
+  right: 0;
+}
 
 /* -------- Template picker (template tab) ---------------------------- */
 .template-list {
@@ -9083,25 +9260,64 @@ button.connector-action.is-loading {
   background: white;
 }
 .viewer-viewport-switcher {
+  position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 2px;
-  padding: 2px;
+  width: 96px;
+}
+.viewer-viewport-trigger {
+  width: 100%;
+  min-height: 26px;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 4px 8px 4px 10px;
+  border-color: var(--border);
+  background-color: var(--bg-panel);
+  color: var(--text);
+  font-size: 12.5px;
+  line-height: 1.2;
+  box-shadow: var(--shadow-xs);
+}
+.viewer-viewport-trigger:hover:not(:disabled),
+.viewer-viewport-trigger[aria-expanded='true'] {
+  border-color: var(--border-strong);
+  background-color: var(--bg-subtle);
+}
+.viewer-viewport-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 80;
+  width: 100%;
+  padding: 5px;
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
-  background: var(--bg-subtle);
-}
-.viewer-viewport-button {
-  min-height: 26px;
-  padding-inline: 8px;
-  border-color: transparent;
-  background: transparent;
-}
-.viewer-viewport-button.active {
-  color: var(--text);
-  border-color: var(--border);
   background: var(--bg-panel);
-  box-shadow: var(--shadow-xs);
+  box-shadow: var(--shadow-md);
+  overflow: hidden;
+}
+.viewer-viewport-menu-item {
+  width: 100%;
+  min-height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 5px 8px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 12.5px;
+  text-align: left;
+}
+.viewer-viewport-menu-item:hover {
+  background: var(--bg-subtle);
+  color: var(--text);
+}
+.viewer-viewport-menu-item.active {
+  background: var(--accent-tint);
+  color: var(--accent-strong);
 }
 .live-artifact-preview-layer,
 .comment-preview-layer {

--- a/apps/web/tests/components/NewProjectPanel.test.tsx
+++ b/apps/web/tests/components/NewProjectPanel.test.tsx
@@ -148,6 +148,35 @@ describe('NewProjectPanel design system defaults', () => {
     );
   });
 
+  it('does not persist OS widgets metadata for web-only platform targets', () => {
+    const onCreate = vi.fn();
+    render(
+      <NewProjectPanel
+        skills={skills}
+        designSystems={designSystems}
+        defaultDesignSystemId="clay"
+        templates={[]}
+        promptTemplates={[]}
+        onCreate={onCreate}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId('new-project-name'), {
+      target: { value: 'Responsive web payload' },
+    });
+    fireEvent.click(screen.getByRole('checkbox', { name: /OS widgets/i }));
+    fireEvent.click(screen.getByTestId('create-project'));
+
+    const payload = onCreate.mock.calls[0]?.[0];
+    expect(payload.metadata).toEqual(
+      expect.objectContaining({
+        platform: 'responsive',
+        platformTargets: ['responsive'],
+      }),
+    );
+    expect(payload.metadata).not.toHaveProperty('includeOsWidgets');
+  });
+
   it('clears design system metadata when freeform is selected in multi mode', () => {
     const onCreate = vi.fn();
     render(

--- a/apps/web/tests/components/NewProjectPanel.test.tsx
+++ b/apps/web/tests/components/NewProjectPanel.test.tsx
@@ -177,6 +177,25 @@ describe('NewProjectPanel design system defaults', () => {
     expect(payload.metadata).not.toHaveProperty('includeOsWidgets');
   });
 
+  it('marks the target platform dropdown as a multi-select listbox', () => {
+    render(
+      <NewProjectPanel
+        skills={skills}
+        designSystems={designSystems}
+        defaultDesignSystemId="clay"
+        templates={[]}
+        promptTemplates={[]}
+        onCreate={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Responsive web/i }));
+
+    expect(screen.getByRole('listbox', { name: 'Target platforms' }).getAttribute('aria-multiselectable')).toBe(
+      'true',
+    );
+  });
+
   it('clears design system metadata when freeform is selected in multi mode', () => {
     const onCreate = vi.fn();
     render(


### PR DESCRIPTION
## Summary
- replace the preview viewport segmented control with a compact dropdown menu
- convert Target platforms to a multi-select dropdown
- compact Companion surfaces into independent checkbox controls with hover tips

## Validation
- pnpm --filter @open-design/web typecheck

Note: validation emitted the existing engine warning because this machine is on Node v22.22.0 while the repo expects ~24.