### PR TITLE
Add batch design system testing

### DIFF
--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -63,7 +63,7 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
 
   app.post('/api/projects', async (req, res) => {
     try {
-      const { id, name, skillId, designSystemId, pendingPrompt, metadata, customInstructions } =
+      const { id, name, skillId, designSystemId, pendingPrompt, metadata, customInstructions, skipDiscoveryBrief } =
         req.body || {};
       if (typeof id !== 'string' || !/^[A-Za-z0-9._-]{1,128}$/.test(id)) {
         return sendApiError(res, 400, 'BAD_REQUEST', 'invalid project id');
@@ -101,6 +101,24 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       if (typeof customInstructions === 'string' && customInstructions.length > 5000) {
         return sendApiError(res, 400, 'BAD_REQUEST', 'customInstructions exceeds 5 000 character limit');
       }
+      if (skipDiscoveryBrief !== undefined && typeof skipDiscoveryBrief !== 'boolean') {
+        return sendApiError(res, 400, 'BAD_REQUEST', 'skipDiscoveryBrief must be a boolean');
+      }
+      const projectMetadata =
+        metadata && typeof metadata === 'object'
+          ? {
+              ...metadata,
+              ...(skipDiscoveryBrief === true ? { skipDiscoveryBrief: true } : {}),
+              ...(Array.isArray(metadata.linkedDirs)
+                ? (() => {
+                    const v = validateLinkedDirs(metadata.linkedDirs);
+                    return v.error ? {} : { linkedDirs: v.dirs };
+                  })()
+                : {}),
+            }
+          : skipDiscoveryBrief === true
+            ? { skipDiscoveryBrief: true }
+            : null;
       const now = Date.now();
       const project = insertProject(db, {
         id,
@@ -108,18 +126,7 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
         skillId: skillId ?? null,
         designSystemId: designSystemId ?? null,
         pendingPrompt: pendingPrompt || null,
-        metadata:
-          metadata && typeof metadata === 'object'
-            ? {
-                ...metadata,
-                ...(Array.isArray(metadata.linkedDirs)
-                  ? (() => {
-                      const v = validateLinkedDirs(metadata.linkedDirs);
-                      return v.error ? {} : { linkedDirs: v.dirs };
-                    })()
-                  : {}),
-              }
-            : null,
+        metadata: projectMetadata,
         customInstructions:
           typeof customInstructions === 'string'
             ? customInstructions

--- a/apps/daemon/src/prompts/discovery.ts
+++ b/apps/daemon/src/prompts/discovery.ts
@@ -3,14 +3,13 @@
  *
  * This is the dominant layer of the composed system prompt. It stacks
  * BEFORE the official OD designer prompt so the hard rules below — emit
- * a discovery form on turn 1, branch into a direction picker / brand
+ * a discovery form on turn 1, branch into brand extraction when needed,
  * extraction on turn 2, plan with TodoWrite on turn 3 — beat the softer
  * "skip questions for small tweaks" wording in the base prompt.
  *
  * The arc:
  *   Turn 1  →  one prose line + <question-form id="discovery"> + STOP
  *   Turn 2  →  branch on the brand answer:
- *                · "Pick a direction for me"   →  emit a 2nd <question-form id="direction"> + STOP
  *                · "I have a brand spec / Match a reference site / screenshot"
  *                                              →  brand-spec extraction (Bash + Read), then TodoWrite
  *                · otherwise                   →  TodoWrite directly
@@ -21,7 +20,7 @@
  * op7418/guizang-ppt-skill (pre-flight asset reads, P0 self-check,
  * theme-rhythm rules).
  */
-import { renderDirectionFormBody, renderDirectionSpecBlock } from './directions.js';
+import { renderDirectionSpecBlock } from './directions.js';
 
 export const DISCOVERY_AND_PHILOSOPHY = `# OD core directives (read first — these override anything later in this prompt)
 
@@ -80,29 +79,11 @@ When skipping, jump straight to RULE 3.
 
 ---
 
-## RULE 2 — turn 2 branches on the \`brand\` answer
+## RULE 2 — turn 2 branches on the \`brand\` answer, but never asks for visual direction again
 
 Once the user submits the discovery form (their next message starts with \`[form answers — discovery]\`), look at the \`brand\` field and branch:
 
-### Branch A — \`brand: "Pick a direction for me"\`
-
-Don't go to TodoWrite yet. Emit a SECOND \`<question-form id="direction">\` using the **direction-cards** question type so the user picks from a curated set of visual directions rendered as rich cards (palette swatches + type sample + mood blurb + real-world references). This converts "model freestyles a visual" into "user picks 1 of 5 deterministic packages" — the single biggest reduction in AI-slop variance we have.
-
-Emit this verbatim (the JSON body is generated from the canonical direction library, so palette / fonts / refs match the **Direction library** spec block below):
-
-\`\`\`
-<question-form id="direction" title="Pick a visual direction">
-${renderDirectionFormBody()}
-</question-form>
-\`\`\`
-
-After \`</question-form>\`, stop. Wait for the user to pick.
-
-The form's answer comes back as the direction's **id** (e.g. \`editorial-monocle\`, \`modern-minimal\`). Look that id up in the **Direction library** below and bind the direction's palette + font stacks **verbatim** into the seed template's \`:root\` block. Do not improvise palette values.
-
-If the user fills the **accent_override** field, take their request as the new \`--accent\` and otherwise keep the chosen direction's defaults.
-
-### Branch B — \`brand: "I have a brand spec — I'll share it"\` or \`"Match a reference site / screenshot"\`
+### Branch A — \`brand: "I have a brand spec — I'll share it"\` or \`"Match a reference site / screenshot"\`
 
 Run brand-spec extraction *before* TodoWrite — five steps, each in its own \`Bash\` / \`Read\` / \`WebFetch\` call:
 
@@ -117,9 +98,9 @@ Run brand-spec extraction *before* TodoWrite — five steps, each in its own \`B
 
 Then proceed to RULE 3.
 
-### Branch C — anything else (or no brand info)
+### Branch B — anything else (including \`brand: "Pick a direction for me"\`, no brand info, or an active design system)
 
-Skip directly to RULE 3.
+Skip directly to RULE 3. Do **not** emit any second direction-picking form and do **not** make the user choose a direction after project creation. If an active design system is present, use its DESIGN.md as the visual direction and bind its tokens/rules first. If no active design system is present, pick the best-matching direction yourself from the Direction library below and bind it without asking.
 
 ---
 
@@ -131,15 +112,15 @@ Emit \`<artifact>\` **only when this turn wrote a new canonical HTML file**. If 
 
 ## RULE 3 — TodoWrite the plan, then live updates
 
-Once direction / brand-spec is locked, your **first tool call** is TodoWrite with a plan of 5–10 short imperative items in the order you'll do them. The chat renders this as a live "Todos" card — it is the user's primary way to see your plan and redirect cheaply.
+Once the design-system / inferred direction / brand-spec is locked, your **first tool call** is TodoWrite with a plan of 5–10 short imperative items in the order you'll do them. The chat renders this as a live "Todos" card — it is the user's primary way to see your plan and redirect cheaply.
 
 The standard plan template (adapt the middle steps to the brief):
 
 \`\`\`
 - 1.  Read active DESIGN.md + skill assets (template.html, layouts.md, checklist.md)
-- 2.  (if branch B) Confirm brand-spec.md + bind to :root
-       (if branch A) Bind chosen direction's palette to :root
-       (else) Pick a direction matching the tone, bind to :root
+- 2.  (if branch A) Confirm brand-spec.md + bind to :root
+       (if active DESIGN.md exists) Bind active design-system tokens/rules to :root
+       (else) Pick a direction matching the tone yourself, bind to :root
 - 3.  Plan section/slide/screen list with platform variants and rhythm (state list aloud before writing)
 - 4.  Copy the seed template to project root
 - 5.  Paste & fill the planned layouts/screens/slides
@@ -275,8 +256,7 @@ The single-screen \`mobile-app\` skill already inlines the iPhone frame in its s
 
 - **Turn 1** — short prose line + \`<question-form id="discovery">\` + stop.
 - **Turn 2** — branch on \`brand\`:
-  - "Pick a direction for me" → emit \`<question-form id="direction">\` + stop.
   - "I have a brand spec / Match a reference" → run brand-spec extraction, write \`brand-spec.md\`, then TodoWrite.
-  - else → TodoWrite directly.
+  - else → TodoWrite directly; if a design system is active, use it as the visual direction without asking again.
 - **Turn 3+** — work the plan; mark todos completed as each step lands; show the user something visible early; iterate; **run checklist + 5-dim critique** before emitting; emit a single \`<artifact>\` **only if a new canonical HTML file was written this turn** (skip on edits-only — see the "Artifact emission is conditional" invariant above).
 `;

--- a/apps/daemon/src/prompts/system.ts
+++ b/apps/daemon/src/prompts/system.ts
@@ -50,6 +50,7 @@ type ProjectMetadata = {
   platform?: string | null;
   platformTargets?: string[] | null;
   inspirationDesignSystemIds?: string[];
+  skipDiscoveryBrief?: boolean | null;
   imageModel?: string | null;
   imageAspect?: string | null;
   imageStyle?: string | null;
@@ -81,6 +82,10 @@ type ProjectMetadata = {
 type ProjectTemplate = { name: string; description?: string | null; files: Array<{ name: string; content: string }> };
 
 export const BASE_SYSTEM_PROMPT = OFFICIAL_DESIGNER_PROMPT;
+
+export const SKIP_DISCOVERY_BRIEF_OVERRIDE = `# Automated project mode — skip discovery form
+
+This project was created through the daemon API with \`skipDiscoveryBrief: true\`. Override the discovery rules below: do NOT emit \`<question-form id="discovery">\`, do NOT show "Quick brief — 30 seconds", and do NOT ask a first-turn clarification form. Treat the user's first message and project metadata as the brief, then proceed directly to planning/building under the normal artifact workflow. Ask at most one concise follow-up only if a required detail is impossible to infer safely.`;
 
 export interface ComposeInput {
   agentId?: string | null | undefined;
@@ -205,6 +210,11 @@ export function composeSystemPrompt({
   // behaviour.
   if (streamFormat === 'plain') {
     parts.push(API_MODE_OVERRIDE);
+    parts.push('\n\n---\n\n');
+  }
+
+  if (metadata?.skipDiscoveryBrief === true) {
+    parts.push(SKIP_DISCOVERY_BRIEF_OVERRIDE);
     parts.push('\n\n---\n\n');
   }
 

--- a/apps/daemon/tests/projects-routes.test.ts
+++ b/apps/daemon/tests/projects-routes.test.ts
@@ -106,6 +106,45 @@ describe('GET /api/projects/:id resolvedDir', () => {
     expect(path.isAbsolute(detail.resolvedDir)).toBe(true);
   });
 
+  it('persists skipDiscoveryBrief for batch-created projects', async () => {
+    const projectId = `proj-skip-discovery-${Date.now()}`;
+    const createResp = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id: projectId,
+        name: 'Batch fixture',
+        skillId: null,
+        designSystemId: 'default',
+        metadata: { kind: 'prototype', platform: 'responsive' },
+        skipDiscoveryBrief: true,
+      }),
+    });
+    expect(createResp.status).toBe(200);
+    const body = (await createResp.json()) as {
+      project: { designSystemId?: string | null; metadata?: { skipDiscoveryBrief?: boolean } };
+    };
+    expect(body.project.designSystemId).toBe('default');
+    expect(body.project.metadata?.skipDiscoveryBrief).toBe(true);
+  });
+
+  it('rejects non-boolean skipDiscoveryBrief on POST /api/projects', async () => {
+    const projectId = `proj-skip-discovery-bad-${Date.now()}`;
+    const resp = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id: projectId,
+        name: 'Bad batch fixture',
+        skipDiscoveryBrief: 'yes',
+      }),
+    });
+    expect(resp.status).toBe(400);
+    const body = (await resp.json()) as { error?: { code?: string; message?: string } };
+    expect(body.error?.code).toBe('BAD_REQUEST');
+    expect(body.error?.message).toMatch(/skipDiscoveryBrief/i);
+  });
+
   it('returns 404 with PROJECT_NOT_FOUND for unknown ids', async () => {
     const resp = await fetch(`${baseUrl}/api/projects/does-not-exist-${Date.now()}`);
     expect(resp.status).toBe(404);

--- a/apps/daemon/tests/system-prompt-template.test.ts
+++ b/apps/daemon/tests/system-prompt-template.test.ts
@@ -32,6 +32,34 @@ const baseSummary = {
 };
 
 describe('composeSystemPrompt — metadata.promptTemplate', () => {
+  it('pins the API batch-mode discovery skip before the normal discovery rules', () => {
+    const out = composeSystemPrompt({
+      metadata: {
+        kind: 'prototype',
+        skipDiscoveryBrief: true,
+      },
+    });
+
+    const overrideIdx = out.indexOf('Automated project mode — skip discovery form');
+    const discoveryIdx = out.indexOf('# OD core directives');
+    expect(overrideIdx).toBeGreaterThanOrEqual(0);
+    expect(discoveryIdx).toBeGreaterThanOrEqual(0);
+    expect(overrideIdx).toBeLessThan(discoveryIdx);
+    expect(out).toMatch(/do NOT emit `<question-form id="discovery">`/);
+  });
+
+  it('does not instruct agents to ask for a second visual-direction picker', () => {
+    const out = composeSystemPrompt({
+      metadata: { kind: 'prototype' },
+      designSystemBody: '# Brand\n\nUse brand tokens.',
+      designSystemTitle: 'Brand',
+    });
+
+    expect(out).not.toContain('<question-form id="direction"');
+    expect(out).not.toContain('Pick a visual direction');
+    expect(out).toContain('if a design system is active, use it as the visual direction without asking again');
+  });
+
   it('inlines the prompt body, attribution, and reference-template label for image projects', () => {
     const out = composeSystemPrompt({
       metadata: {

--- a/packages/contracts/src/api/projects.ts
+++ b/packages/contracts/src/api/projects.ts
@@ -113,6 +113,9 @@ export interface ProjectMetadata {
   promptTemplate?: PromptTemplateMetadata;
   // Absolute paths to local code folders the agent can read via --add-dir.
   linkedDirs?: string[];
+  // Batch/API-created projects can opt out of the initial discovery form so
+  // the first agent turn builds immediately from the submitted brief.
+  skipDiscoveryBrief?: boolean;
 }
 
 export interface Project {
@@ -152,6 +155,8 @@ export interface CreateProjectRequest {
   pendingPrompt?: string;
   metadata?: ProjectMetadata;
   customInstructions?: string;
+  /** Persisted to metadata.skipDiscoveryBrief for automated project runs. */
+  skipDiscoveryBrief?: boolean;
 }
 
 export interface UpdateProjectRequest {

--- a/packages/contracts/src/prompts/discovery.ts
+++ b/packages/contracts/src/prompts/discovery.ts
@@ -3,14 +3,13 @@
  *
  * This is the dominant layer of the composed system prompt. It stacks
  * BEFORE the official OD designer prompt so the hard rules below — emit
- * a discovery form on turn 1, branch into a direction picker / brand
+ * a discovery form on turn 1, branch into brand extraction when needed,
  * extraction on turn 2, plan with TodoWrite on turn 3 — beat the softer
  * "skip questions for small tweaks" wording in the base prompt.
  *
  * The arc:
  *   Turn 1  →  one prose line + <question-form id="discovery"> + STOP
  *   Turn 2  →  branch on the brand answer:
- *                · "Pick a direction for me"   →  emit a 2nd <question-form id="direction"> + STOP
  *                · "I have a brand spec / Match a reference site / screenshot"
  *                                              →  brand-spec extraction (Bash + Read), then TodoWrite
  *                · otherwise                   →  TodoWrite directly
@@ -21,7 +20,7 @@
  * op7418/guizang-ppt-skill (pre-flight asset reads, P0 self-check,
  * theme-rhythm rules).
  */
-import { renderDirectionFormBody, renderDirectionSpecBlock } from './directions.js';
+import { renderDirectionSpecBlock } from './directions.js';
 
 export const DISCOVERY_AND_PHILOSOPHY = `# OD core directives (read first — these override anything later in this prompt)
 
@@ -80,29 +79,11 @@ When skipping, jump straight to RULE 3.
 
 ---
 
-## RULE 2 — turn 2 branches on the \`brand\` answer
+## RULE 2 — turn 2 branches on the \`brand\` answer, but never asks for visual direction again
 
 Once the user submits the discovery form (their next message starts with \`[form answers — discovery]\`), look at the \`brand\` field and branch:
 
-### Branch A — \`brand: "Pick a direction for me"\`
-
-Don't go to TodoWrite yet. Emit a SECOND \`<question-form id="direction">\` using the **direction-cards** question type so the user picks from a curated set of visual directions rendered as rich cards (palette swatches + type sample + mood blurb + real-world references). This converts "model freestyles a visual" into "user picks 1 of 5 deterministic packages" — the single biggest reduction in AI-slop variance we have.
-
-Emit this verbatim (the JSON body is generated from the canonical direction library, so palette / fonts / refs match the **Direction library** spec block below):
-
-\`\`\`
-<question-form id="direction" title="Pick a visual direction">
-${renderDirectionFormBody()}
-</question-form>
-\`\`\`
-
-After \`</question-form>\`, stop. Wait for the user to pick.
-
-The form's answer comes back as the direction's **id** (e.g. \`editorial-monocle\`, \`modern-minimal\`). Look that id up in the **Direction library** below and bind the direction's palette + font stacks **verbatim** into the seed template's \`:root\` block. Do not improvise palette values.
-
-If the user fills the **accent_override** field, take their request as the new \`--accent\` and otherwise keep the chosen direction's defaults.
-
-### Branch B — \`brand: "I have a brand spec — I'll share it"\` or \`"Match a reference site / screenshot"\`
+### Branch A — \`brand: "I have a brand spec — I'll share it"\` or \`"Match a reference site / screenshot"\`
 
 Run brand-spec extraction *before* TodoWrite — five steps, each in its own \`Bash\` / \`Read\` / \`WebFetch\` call:
 
@@ -117,23 +98,23 @@ Run brand-spec extraction *before* TodoWrite — five steps, each in its own \`B
 
 Then proceed to RULE 3.
 
-### Branch C — anything else (or no brand info)
+### Branch B — anything else (including \`brand: "Pick a direction for me"\`, no brand info, or an active design system)
 
-Skip directly to RULE 3.
+Skip directly to RULE 3. Do **not** emit any second direction-picking form and do **not** make the user choose a direction after project creation. If an active design system is present, use its DESIGN.md as the visual direction and bind its tokens/rules first. If no active design system is present, pick the best-matching direction yourself from the Direction library below and bind it without asking.
 
 ---
 
 ## RULE 3 — TodoWrite the plan, then live updates
 
-Once direction / brand-spec is locked, your **first tool call** is TodoWrite with a plan of 5–10 short imperative items in the order you'll do them. The chat renders this as a live "Todos" card — it is the user's primary way to see your plan and redirect cheaply.
+Once the design-system / inferred direction / brand-spec is locked, your **first tool call** is TodoWrite with a plan of 5–10 short imperative items in the order you'll do them. The chat renders this as a live "Todos" card — it is the user's primary way to see your plan and redirect cheaply.
 
 The standard plan template (adapt the middle steps to the brief):
 
 \`\`\`
 - 1.  Read active DESIGN.md + skill assets (template.html, layouts.md, checklist.md)
-- 2.  (if branch B) Confirm brand-spec.md + bind to :root
-       (if branch A) Bind chosen direction's palette to :root
-       (else) Pick a direction matching the tone, bind to :root
+- 2.  (if branch A) Confirm brand-spec.md + bind to :root
+       (if active DESIGN.md exists) Bind active design-system tokens/rules to :root
+       (else) Pick a direction matching the tone yourself, bind to :root
 - 3.  Plan section/slide/screen list with platform variants and rhythm (state list aloud before writing)
 - 4.  Copy the seed template to project root
 - 5.  Paste & fill the planned layouts/screens/slides
@@ -270,8 +251,7 @@ The single-screen \`mobile-app\` skill already inlines the iPhone frame in its s
 
 - **Turn 1** — short prose line + \`<question-form id="discovery">\` + stop.
 - **Turn 2** — branch on \`brand\`:
-  - "Pick a direction for me" → emit \`<question-form id="direction">\` + stop.
   - "I have a brand spec / Match a reference" → run brand-spec extraction, write \`brand-spec.md\`, then TodoWrite.
-  - else → TodoWrite directly.
+  - else → TodoWrite directly; if a design system is active, use it as the visual direction without asking again.
 - **Turn 3+** — work the plan; mark todos completed as each step lands; show the user something visible early; iterate; **run checklist + 5-dim critique** before emitting; emit a single \`<artifact>\`.
 `;

--- a/packages/contracts/src/prompts/system.ts
+++ b/packages/contracts/src/prompts/system.ts
@@ -37,6 +37,10 @@ import { MEDIA_GENERATION_CONTRACT } from './media-contract.js';
 
 export const BASE_SYSTEM_PROMPT = OFFICIAL_DESIGNER_PROMPT;
 
+export const SKIP_DISCOVERY_BRIEF_OVERRIDE = `# Automated project mode — skip discovery form
+
+This project was created through the daemon API with \`skipDiscoveryBrief: true\`. Override the discovery rules below: do NOT emit \`<question-form id="discovery">\`, do NOT show "Quick brief — 30 seconds", and do NOT ask a first-turn clarification form. Treat the user's first message and project metadata as the brief, then proceed directly to planning/building under the normal artifact workflow. Ask at most one concise follow-up only if a required detail is impossible to infer safely.`;
+
 export interface ComposeInput {
   skillBody?: string | undefined;
   skillName?: string | undefined;
@@ -106,6 +110,11 @@ export function composeSystemPrompt({
   // later" header.
   if (streamFormat === 'plain') {
     parts.push(API_MODE_OVERRIDE);
+    parts.push('\n\n---\n\n');
+  }
+
+  if (metadata?.skipDiscoveryBrief === true) {
+    parts.push(SKIP_DISCOVERY_BRIEF_OVERRIDE);
     parts.push('\n\n---\n\n');
   }
 

--- a/packages/contracts/tests/system-prompt-api-mode.test.ts
+++ b/packages/contracts/tests/system-prompt-api-mode.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { composeSystemPrompt } from '../src/prompts/system.js';
+import { composeSystemPrompt, SKIP_DISCOVERY_BRIEF_OVERRIDE } from '../src/prompts/system.js';
 
 /**
  * Regression coverage for #313 — Anthropic API mode renders TodoWrite /
@@ -97,6 +97,18 @@ describe('composeSystemPrompt — API mode (#313)', () => {
     it('still allows <artifact> HTML output', () => {
       const prompt = composeSystemPrompt({ streamFormat: 'plain' });
       expect(prompt).toMatch(/<artifact>/);
+    });
+
+    it('honors metadata.skipDiscoveryBrief before the discovery rules', () => {
+      const prompt = composeSystemPrompt({
+        streamFormat: 'plain',
+        metadata: { kind: 'prototype', skipDiscoveryBrief: true },
+      });
+      const skipIdx = prompt.indexOf(SKIP_DISCOVERY_BRIEF_OVERRIDE);
+      const discoveryIdx = prompt.indexOf('# OD core directives');
+      expect(skipIdx).toBeGreaterThanOrEqual(0);
+      expect(skipIdx).toBeLessThan(discoveryIdx);
+      expect(prompt).toMatch(/do NOT emit `?<question-form id="discovery">`?/i);
     });
   });
 });

--- a/packages/contracts/tests/system-prompt-api-mode.test.ts
+++ b/packages/contracts/tests/system-prompt-api-mode.test.ts
@@ -27,6 +27,13 @@ describe('composeSystemPrompt — API mode (#313)', () => {
       expect(prompt).toMatch(/TodoWrite/);
     });
 
+    it('does not instruct agents to ask for a second visual-direction picker', () => {
+      const prompt = composeSystemPrompt({});
+      expect(prompt).not.toContain('<question-form id="direction"');
+      expect(prompt).not.toContain('Pick a visual direction');
+      expect(prompt).toContain('if a design system is active, use it as the visual direction without asking again');
+    });
+
     it('does not inject the API-mode preamble', () => {
       const prompt = composeSystemPrompt({});
       expect(prompt).not.toMatch(/API mode — no tools available/i);

--- a/scripts/batch-design-system-test.test.ts
+++ b/scripts/batch-design-system-test.test.ts
@@ -6,6 +6,8 @@ import { fileURLToPath } from "node:url";
 
 import {
   buildAssistantMessageUpdate,
+  cancelTimedOutRun,
+  createRunTimeoutError,
   dedupeDesignSystemIds,
   resolveDryRunDesignSystems,
   validateExplicitDesignSystemIds,
@@ -84,6 +86,52 @@ test("buildAssistantMessageUpdate keeps the daemon run id on final assistant upd
       producedFiles: [{ path: "index.html" }],
     },
   );
+});
+
+test("cancelTimedOutRun posts to the daemon cancel endpoint for timeout errors", async () => {
+  const originalFetch = globalThis.fetch;
+  const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
+  globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(url), init });
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+
+  try {
+    const canceled = await cancelTimedOutRun("http://127.0.0.1:4321", createRunTimeoutError("run-123", 5000, "running"));
+    assert.equal(canceled, true);
+    assert.deepEqual(calls, [
+      {
+        url: "http://127.0.0.1:4321/api/runs/run-123/cancel",
+        init: {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({}),
+        },
+      },
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("cancelTimedOutRun ignores non-timeout errors", async () => {
+  const originalFetch = globalThis.fetch;
+  let called = false;
+  globalThis.fetch = (async () => {
+    called = true;
+    throw new Error("should not be called");
+  }) as typeof fetch;
+
+  try {
+    const canceled = await cancelTimedOutRun("http://127.0.0.1:4321", new Error("not a timeout"));
+    assert.equal(canceled, false);
+    assert.equal(called, false);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
 
 test("CLI dry-run with explicit design systems succeeds without daemon discovery", () => {

--- a/scripts/batch-design-system-test.test.ts
+++ b/scripts/batch-design-system-test.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { dedupeDesignSystemIds, validateExplicitDesignSystemIds } from "./batch-design-system-test.ts";
+
+test("dedupeDesignSystemIds trims and preserves first-seen order", () => {
+  assert.deepEqual(dedupeDesignSystemIds([" default ", "kami", "default", "", "kami "]), ["default", "kami"]);
+});
+
+test("validateExplicitDesignSystemIds rejects unknown design system ids", () => {
+  assert.throws(
+    () => validateExplicitDesignSystemIds(["default", "typo"], ["default", "kami"]),
+    /unknown design system id\(s\): typo/,
+  );
+});
+
+test("validateExplicitDesignSystemIds returns the normalized explicit ids when all exist", () => {
+  assert.deepEqual(validateExplicitDesignSystemIds([" default ", "kami", "default"], ["default", "kami"]), ["default", "kami"]);
+});

--- a/scripts/batch-design-system-test.test.ts
+++ b/scripts/batch-design-system-test.test.ts
@@ -1,7 +1,16 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
-import { dedupeDesignSystemIds, validateExplicitDesignSystemIds } from "./batch-design-system-test.ts";
+import {
+  dedupeDesignSystemIds,
+  resolveDryRunDesignSystems,
+  validateExplicitDesignSystemIds,
+} from "./batch-design-system-test.ts";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
 
 test("dedupeDesignSystemIds trims and preserves first-seen order", () => {
   assert.deepEqual(dedupeDesignSystemIds([" default ", "kami", "default", "", "kami "]), ["default", "kami"]);
@@ -16,4 +25,43 @@ test("validateExplicitDesignSystemIds rejects unknown design system ids", () => 
 
 test("validateExplicitDesignSystemIds returns the normalized explicit ids when all exist", () => {
   assert.deepEqual(validateExplicitDesignSystemIds([" default ", "kami", "default"], ["default", "kami"]), ["default", "kami"]);
+});
+
+test("resolveDryRunDesignSystems normalizes explicit ids without daemon access", () => {
+  assert.deepEqual(resolveDryRunDesignSystems({ designSystems: [" default ", "kami", "default"] }), ["default", "kami"]);
+});
+
+test("resolveDryRunDesignSystems rejects --all-design-systems in dry-run mode", () => {
+  assert.throws(
+    () => resolveDryRunDesignSystems({ allDesignSystems: true }),
+    /dry-run with --all-design-systems still requires daemon access/,
+  );
+});
+
+test("CLI dry-run with explicit design systems succeeds without daemon discovery", () => {
+  const result = spawnSync(
+    process.execPath,
+    [
+      "--experimental-strip-types",
+      path.join(HERE, "batch-design-system-test.ts"),
+      "--prompt",
+      "Test prompt",
+      "--design-systems",
+      "default,kami",
+      "--dry-run",
+    ],
+    {
+      cwd: path.resolve(HERE, ".."),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        OD_DAEMON_URL: "",
+        OD_PORT: "",
+      },
+    },
+  );
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /design systems \(2\): default, kami/);
+  assert.doesNotMatch(result.stdout + result.stderr, /cannot determine daemon URL/);
 });

--- a/scripts/batch-design-system-test.test.ts
+++ b/scripts/batch-design-system-test.test.ts
@@ -5,6 +5,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import {
+  buildAssistantMessageUpdate,
   dedupeDesignSystemIds,
   resolveDryRunDesignSystems,
   validateExplicitDesignSystemIds,
@@ -35,6 +36,53 @@ test("resolveDryRunDesignSystems rejects --all-design-systems in dry-run mode", 
   assert.throws(
     () => resolveDryRunDesignSystems({ allDesignSystems: true }),
     /dry-run with --all-design-systems still requires daemon access/,
+  );
+});
+
+test("buildAssistantMessageUpdate persists the daemon run id on queued assistant rows", () => {
+  assert.deepEqual(
+    buildAssistantMessageUpdate({
+      agentId: "claude",
+      runId: "run-123",
+      runStatus: "queued",
+      createdAt: 123,
+    }),
+    {
+      role: "assistant",
+      content: "",
+      agentId: "claude",
+      agentName: "claude",
+      runId: "run-123",
+      runStatus: "queued",
+      startedAt: 123,
+      createdAt: 123,
+    },
+  );
+});
+
+test("buildAssistantMessageUpdate keeps the daemon run id on final assistant updates", () => {
+  assert.deepEqual(
+    buildAssistantMessageUpdate({
+      agentId: "claude",
+      runId: "run-123",
+      runStatus: "succeeded",
+      createdAt: 123,
+      content: "done",
+      endedAt: 456,
+      producedFiles: [{ path: "index.html" }],
+    }),
+    {
+      role: "assistant",
+      content: "done",
+      agentId: "claude",
+      agentName: "claude",
+      runId: "run-123",
+      runStatus: "succeeded",
+      startedAt: 123,
+      createdAt: 123,
+      endedAt: 456,
+      producedFiles: [{ path: "index.html" }],
+    },
   );
 });
 

--- a/scripts/batch-design-system-test.ts
+++ b/scripts/batch-design-system-test.ts
@@ -27,7 +27,7 @@
 import { spawn } from 'node:child_process';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(HERE, '..');
@@ -168,6 +168,20 @@ function parseCsv(value: string): string[] {
     .split(',')
     .map((part) => part.trim())
     .filter(Boolean);
+}
+
+export function dedupeDesignSystemIds(ids: string[]): string[] {
+  return [...new Set(ids.map((id) => id.trim()).filter(Boolean))];
+}
+
+export function validateExplicitDesignSystemIds(requestedIds: string[], availableIds: string[]): string[] {
+  const requested = dedupeDesignSystemIds(requestedIds);
+  const available = new Set(availableIds.map((id) => id.trim()).filter(Boolean));
+  const unknown = requested.filter((id) => !available.has(id));
+  if (unknown.length > 0) {
+    throw new Error(`unknown design system id(s): ${unknown.join(', ')}`);
+  }
+  return requested;
 }
 
 function parseJsonObject(value: string, label: string): Record<string, unknown> {
@@ -338,18 +352,18 @@ async function resolvePrompt(config: BatchConfig): Promise<string> {
 }
 
 async function resolveDesignSystems(daemonUrl: string, config: BatchConfig): Promise<string[]> {
+  const body = await api<DesignSystemsResponse>(daemonUrl, 'GET', '/api/design-systems');
+  const systems = body.designSystems ?? body.systems ?? [];
+  const availableIds = dedupeDesignSystemIds(systems.map((system) => system.id));
+  if (availableIds.length === 0) throw new Error('daemon returned no design systems');
   if (config.allDesignSystems) {
-    const body = await api<DesignSystemsResponse>(daemonUrl, 'GET', '/api/design-systems');
-    const systems = body.designSystems ?? body.systems ?? [];
-    const ids = systems.map((s) => s.id).filter(Boolean);
-    if (ids.length === 0) throw new Error('daemon returned no design systems');
-    return ids;
+    return availableIds;
   }
-  const ids = (config.designSystems ?? []).map((id) => id.trim()).filter(Boolean);
+  const ids = config.designSystems ?? [];
   if (ids.length === 0) {
     throw new Error('missing design systems: pass --design-systems, --design-system, --all-design-systems, or config.designSystems');
   }
-  return [...new Set(ids)];
+  return validateExplicitDesignSystemIds(ids, availableIds);
 }
 
 async function resolveAgentId(daemonUrl: string, config: BatchConfig): Promise<string> {
@@ -556,7 +570,9 @@ async function main(): Promise<void> {
   if (failures.length > 0) process.exit(1);
 }
 
-main().catch((err) => {
-  console.error(err instanceof Error ? err.message : String(err));
-  process.exit(1);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  });
+}

--- a/scripts/batch-design-system-test.ts
+++ b/scripts/batch-design-system-test.ts
@@ -128,6 +128,12 @@ interface AssistantMessageUpdate {
   producedFiles?: unknown[];
 }
 
+type RunTimeoutError = Error & {
+  code: 'RUN_TIMEOUT';
+  runId: string;
+  lastStatus?: RunStatusResponse['status'];
+};
+
 function buildRunPrompt(prompt: string, skipDiscoveryBrief: boolean): string {
   if (!skipDiscoveryBrief) return prompt;
   // The persisted skipDiscoveryBrief flag is understood by newer daemons, but
@@ -252,6 +258,29 @@ export function buildAssistantMessageUpdate(params: {
     ...(endedAt !== undefined ? { endedAt } : {}),
     ...(producedFiles !== undefined ? { producedFiles } : {}),
   };
+}
+
+export function createRunTimeoutError(
+  runId: string,
+  timeoutMs: number,
+  lastStatus?: RunStatusResponse['status'],
+): RunTimeoutError {
+  const error = new Error(
+    `run timed out after ${timeoutMs}ms${lastStatus ? ` (last status: ${lastStatus})` : ''}`,
+  ) as RunTimeoutError;
+  error.code = 'RUN_TIMEOUT';
+  error.runId = runId;
+  if (lastStatus !== undefined) error.lastStatus = lastStatus;
+  return error;
+}
+
+function isRunTimeoutError(error: unknown): error is RunTimeoutError {
+  return (
+    !!error &&
+    typeof error === 'object' &&
+    (error as { code?: unknown }).code === 'RUN_TIMEOUT' &&
+    typeof (error as { runId?: unknown }).runId === 'string'
+  );
 }
 
 function parseJsonObject(value: string, label: string): Record<string, unknown> {
@@ -489,7 +518,18 @@ async function waitForRun(daemonUrl: string, runId: string, timeoutMs: number): 
     if (terminal(last.status)) return last;
     await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
   }
-  throw new Error(`run timed out after ${timeoutMs}ms${last ? ` (last status: ${last.status})` : ''}`);
+  throw createRunTimeoutError(runId, timeoutMs, last?.status);
+}
+
+export async function cancelTimedOutRun(daemonUrl: string, error: unknown): Promise<boolean> {
+  if (!isRunTimeoutError(error)) return false;
+  await api<{ ok: true }>(
+    daemonUrl,
+    'POST',
+    `/api/runs/${encodeURIComponent(error.runId)}/cancel`,
+    {},
+  );
+  return true;
 }
 
 async function readRunAssistantText(daemonUrl: string, runId: string): Promise<string> {
@@ -587,7 +627,22 @@ async function runOne(params: {
     return { designSystemId, projectId, projectName, conversationId, runId: run.runId, status: 'queued', daemonUrl };
   }
 
-  const finalStatus = await waitForRun(daemonUrl, run.runId, config.timeoutMs);
+  let finalStatus: RunStatusResponse;
+  try {
+    finalStatus = await waitForRun(daemonUrl, run.runId, config.timeoutMs);
+  } catch (err) {
+    try {
+      const canceled = await cancelTimedOutRun(daemonUrl, err);
+      if (canceled) {
+        process.stderr.write(`warning: canceled timed-out run ${run.runId} for ${designSystemId}\n`);
+      }
+    } catch (cancelErr) {
+      process.stderr.write(
+        `warning: failed to cancel timed-out run ${run.runId} for ${designSystemId}: ${(cancelErr as Error).message || String(cancelErr)}\n`,
+      );
+    }
+    throw err;
+  }
   const assistantText = await readRunAssistantText(daemonUrl, run.runId).catch(() => '');
   const producedFiles = await api<ProjectFilesResponse>(daemonUrl, 'GET', `/api/projects/${projectId}/files`)
     .then((body) => body.files ?? [])

--- a/scripts/batch-design-system-test.ts
+++ b/scripts/batch-design-system-test.ts
@@ -1,0 +1,540 @@
+#!/usr/bin/env node
+// Batch-create and optionally run one design brief across multiple design
+// systems through the public daemon API. Intended for fast visual regression
+// sweeps while iterating on DESIGN.md files.
+//
+// Usage (daemon must be running — e.g. `pnpm tools-dev`):
+//   node --experimental-strip-types scripts/batch-design-system-test.ts \
+//     --prompt "Design a pricing landing page for an AI notes app" \
+//     --design-systems default,kami \
+//     --skill open-design-landing \
+//     --agent claude
+//
+// Config-file equivalent:
+//   node --experimental-strip-types scripts/batch-design-system-test.ts --config batch-ds.json
+//
+//   {
+//     "prompt": "Design a pricing landing page for an AI notes app",
+//     "designSystems": ["default", "kami"],
+//     "skillId": "open-design-landing",
+//     "agentId": "claude",
+//     "metadata": { "kind": "prototype", "platform": "responsive" },
+//     "concurrency": 2,
+//     "timeoutMs": 900000,
+//     "output": ".tmp/design-system-batch.jsonl"
+//   }
+
+import { spawn } from 'node:child_process';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..');
+const RUN_PREFIX = 'ds-batch-';
+const DEFAULT_AGENT_ID = 'claude';
+const DEFAULT_KIND = 'prototype';
+const DEFAULT_PLATFORM = 'responsive';
+const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
+const POLL_INTERVAL_MS = 1_500;
+
+type ProjectKind = 'prototype' | 'deck' | 'template' | 'other' | 'image' | 'video' | 'audio';
+
+interface ProjectMetadata {
+  kind: ProjectKind;
+  platform?: string;
+  [key: string]: unknown;
+}
+
+interface BatchConfig {
+  daemonUrl?: string | null;
+  prompt?: string;
+  promptFile?: string;
+  designSystems?: string[];
+  allDesignSystems?: boolean;
+  agentId?: string;
+  skillId?: string | null;
+  model?: string | null;
+  reasoning?: string | null;
+  namePrefix?: string;
+  metadata?: ProjectMetadata;
+  customInstructions?: string | null;
+  skipDiscoveryBrief?: boolean;
+  startRuns?: boolean;
+  wait?: boolean;
+  concurrency?: number;
+  timeoutMs?: number;
+  output?: string | null;
+  dryRun?: boolean;
+}
+
+interface Args extends BatchConfig {
+  configPath?: string;
+}
+
+interface CreateProjectResponse {
+  project: { id: string; name: string; designSystemId: string | null };
+  conversationId?: string;
+}
+
+interface RunCreateResponse {
+  runId: string;
+}
+
+interface RunStatusResponse {
+  id: string;
+  status: 'queued' | 'running' | 'succeeded' | 'failed' | 'canceled';
+  exitCode?: number | null;
+  error?: string | null;
+  updatedAt?: number;
+}
+
+interface DesignSystemsResponse {
+  designSystems?: Array<{ id: string; title?: string }>;
+  systems?: Array<{ id: string; title?: string }>;
+}
+
+interface BatchResult {
+  designSystemId: string;
+  projectId: string;
+  projectName: string;
+  conversationId: string | null;
+  runId: string | null;
+  status: 'created' | RunStatusResponse['status'];
+  daemonUrl: string;
+  error?: string;
+}
+
+function printHelp(): void {
+  console.log(`Usage: node --experimental-strip-types scripts/batch-design-system-test.ts [opts]
+
+Creates one project per design system with the same prompt. By default it also
+starts an agent run and waits for every run to finish.
+
+Required input:
+  --prompt <text>              Brief to run for every design system.
+  --prompt-file <path>         Read the brief from a file instead of --prompt.
+  --design-systems <ids>       Comma-separated design system ids, e.g. default,kami.
+  --design-system <id>         Add one design system id. Can be repeated.
+  --all-design-systems         Use every design system reported by the daemon.
+  --config <path>              JSON config file. CLI flags override config values.
+
+Run/project options:
+  --daemon <url>               Daemon base URL. Falls back to OD_DAEMON_URL,
+                               OD_PORT, then tools-dev status discovery.
+  --agent <id>                 Agent id for /api/runs. Default: ${DEFAULT_AGENT_ID}.
+  --skill <id|null>            Skill/design-template id to bind to each project.
+  --model <id>                 Optional per-run model override.
+  --reasoning <id>             Optional per-run reasoning override.
+  --kind <kind>                Project kind metadata. Default: ${DEFAULT_KIND}.
+  --platform <platform>        Project platform metadata. Default: ${DEFAULT_PLATFORM}.
+  --metadata <json>            Extra metadata JSON merged into project metadata.
+  --custom-instructions <txt>  Project-level custom instructions.
+  --name-prefix <text>         Project name prefix. Default includes timestamp.
+  --no-skip-discovery          Do not set skipDiscoveryBrief on created projects.
+
+Batch options:
+  --concurrency <n>            Parallel project/run count. Default: 1.
+  --timeout-ms <n>             Per-run wait timeout. Default: ${DEFAULT_TIMEOUT_MS}.
+  --create-only                Create projects but do not start agent runs.
+  --no-wait                    Start runs and return after run ids are created.
+  --output <path>              Write JSONL results to a file.
+  --dry-run                    Print the resolved plan without calling daemon.
+  -h, --help                   Show this help.
+
+Example config:
+  {
+    "prompt": "Build a responsive pricing page for an AI notes app",
+    "designSystems": ["default", "kami"],
+    "skillId": "open-design-landing",
+    "agentId": "claude",
+    "metadata": { "kind": "prototype", "platform": "responsive" },
+    "concurrency": 2,
+    "timeoutMs": 900000,
+    "output": ".tmp/design-system-batch.jsonl"
+  }
+`);
+}
+
+function parseCsv(value: string): string[] {
+  return value
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function parseJsonObject(value: string, label: string): Record<string, unknown> {
+  const parsed = JSON.parse(value) as unknown;
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`${label} must be a JSON object`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function parseArgs(argv: string[]): Args {
+  const out: Args = {};
+  const designSystems: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    const next = () => {
+      const value = argv[++i];
+      if (!value) throw new Error(`${flag} requires a value`);
+      return value;
+    };
+    if (flag === '--config') out.configPath = next();
+    else if (flag === '--daemon' || flag === '--daemon-url') out.daemonUrl = next();
+    else if (flag === '--prompt') out.prompt = next();
+    else if (flag === '--prompt-file') out.promptFile = next();
+    else if (flag === '--design-systems') designSystems.push(...parseCsv(next()));
+    else if (flag === '--design-system') designSystems.push(next());
+    else if (flag === '--all-design-systems') out.allDesignSystems = true;
+    else if (flag === '--agent') out.agentId = next();
+    else if (flag === '--skill') {
+      const value = next();
+      out.skillId = value === 'null' || value === 'none' ? null : value;
+    } else if (flag === '--model') out.model = next();
+    else if (flag === '--reasoning') out.reasoning = next();
+    else if (flag === '--kind') {
+      out.metadata = { ...(out.metadata ?? { kind: DEFAULT_KIND }), kind: next() as ProjectKind };
+    } else if (flag === '--platform') {
+      out.metadata = { ...(out.metadata ?? { kind: DEFAULT_KIND }), platform: next() };
+    } else if (flag === '--metadata') {
+      const metadata = parseJsonObject(next(), '--metadata');
+      out.metadata = { ...(out.metadata ?? { kind: DEFAULT_KIND }), ...metadata } as ProjectMetadata;
+    } else if (flag === '--custom-instructions') out.customInstructions = next();
+    else if (flag === '--name-prefix') out.namePrefix = next();
+    else if (flag === '--no-skip-discovery') out.skipDiscoveryBrief = false;
+    else if (flag === '--concurrency') out.concurrency = positiveInteger(next(), '--concurrency');
+    else if (flag === '--timeout-ms') out.timeoutMs = positiveInteger(next(), '--timeout-ms');
+    else if (flag === '--create-only') out.startRuns = false;
+    else if (flag === '--no-wait') out.wait = false;
+    else if (flag === '--output') out.output = next();
+    else if (flag === '--dry-run') out.dryRun = true;
+    else if (flag === '-h' || flag === '--help') {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`unknown flag: ${flag}`);
+    }
+  }
+  if (designSystems.length > 0) out.designSystems = designSystems;
+  return out;
+}
+
+function positiveInteger(value: string, label: string): number {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n <= 0) throw new Error(`${label} must be a positive integer`);
+  return n;
+}
+
+async function readConfig(pathLike: string | undefined): Promise<BatchConfig> {
+  if (!pathLike) return {};
+  const absolute = path.resolve(REPO_ROOT, pathLike);
+  const parsed = JSON.parse(await readFile(absolute, 'utf8')) as unknown;
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`config must be a JSON object: ${pathLike}`);
+  }
+  return parsed as BatchConfig;
+}
+
+function mergeConfig(fileConfig: BatchConfig, cli: Args): BatchConfig {
+  const merged: BatchConfig = { ...fileConfig, ...cli };
+  delete (merged as { configPath?: string }).configPath;
+  merged.metadata = {
+    kind: DEFAULT_KIND,
+    platform: DEFAULT_PLATFORM,
+    ...(fileConfig.metadata ?? {}),
+    ...(cli.metadata ?? {}),
+  };
+  if (cli.designSystems) merged.designSystems = cli.designSystems;
+  return merged;
+}
+
+function isDiscoverablePort(value: string | undefined): value is string {
+  if (value == null || value.length === 0) return false;
+  const n = Number(value);
+  return Number.isInteger(n) && n > 0 && n < 65536;
+}
+
+async function discoverDaemonUrlFromToolsDev(): Promise<string | null> {
+  return await new Promise<string | null>((resolve) => {
+    let child;
+    try {
+      child = spawn('pnpm', ['--silent', 'exec', 'tools-dev', 'status', '--json'], {
+        cwd: REPO_ROOT,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+    } catch {
+      resolve(null);
+      return;
+    }
+    let stdout = '';
+    child.stdout?.on('data', (chunk: Buffer | string) => {
+      stdout += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+    });
+    child.stderr?.resume();
+    child.on('error', () => resolve(null));
+    child.on('exit', () => resolve(extractDaemonUrlFromStatusOutput(stdout)));
+  });
+}
+
+function extractDaemonUrlFromStatusOutput(stdout: string): string | null {
+  for (let i = stdout.indexOf('{'); i !== -1; i = stdout.indexOf('{', i + 1)) {
+    try {
+      const parsed = JSON.parse(stdout.slice(i)) as {
+        apps?: { daemon?: { url?: string | null } };
+        url?: string | null;
+      };
+      const url = parsed.apps?.daemon?.url ?? parsed.url ?? null;
+      if (typeof url === 'string' && url.length > 0) return url;
+    } catch {
+      // try the next possible JSON object
+    }
+  }
+  return null;
+}
+
+async function resolveDaemonUrl(config: BatchConfig): Promise<string> {
+  if (config.daemonUrl) return config.daemonUrl;
+  if (process.env.OD_DAEMON_URL) return process.env.OD_DAEMON_URL;
+  if (isDiscoverablePort(process.env.OD_PORT)) return `http://127.0.0.1:${process.env.OD_PORT}`;
+  const discovered = await discoverDaemonUrlFromToolsDev();
+  if (discovered) return discovered;
+  throw new Error('cannot determine daemon URL; start `pnpm tools-dev` or pass --daemon <url>');
+}
+
+async function api<T = unknown>(daemonUrl: string, method: string, pathPart: string, body?: unknown): Promise<T> {
+  const url = `${daemonUrl.replace(/\/$/, '')}${pathPart}`;
+  const init: RequestInit = { method };
+  if (body !== undefined) {
+    init.headers = { 'content-type': 'application/json' };
+    init.body = JSON.stringify(body);
+  }
+  let resp: Response;
+  try {
+    resp = await fetch(url, init);
+  } catch (err) {
+    throw new Error(`cannot reach daemon at ${daemonUrl}: ${(err as Error).message || String(err)}`);
+  }
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => '');
+    throw new Error(`${method} ${pathPart} → ${resp.status}: ${text}`);
+  }
+  if (resp.status === 204) return undefined as T;
+  return (await resp.json()) as T;
+}
+
+async function resolvePrompt(config: BatchConfig): Promise<string> {
+  if (typeof config.prompt === 'string' && config.prompt.trim()) return config.prompt.trim();
+  if (config.promptFile) return (await readFile(path.resolve(REPO_ROOT, config.promptFile), 'utf8')).trim();
+  throw new Error('missing prompt: pass --prompt, --prompt-file, or config.prompt');
+}
+
+async function resolveDesignSystems(daemonUrl: string, config: BatchConfig): Promise<string[]> {
+  if (config.allDesignSystems) {
+    const body = await api<DesignSystemsResponse>(daemonUrl, 'GET', '/api/design-systems');
+    const systems = body.designSystems ?? body.systems ?? [];
+    const ids = systems.map((s) => s.id).filter(Boolean);
+    if (ids.length === 0) throw new Error('daemon returned no design systems');
+    return ids;
+  }
+  const ids = (config.designSystems ?? []).map((id) => id.trim()).filter(Boolean);
+  if (ids.length === 0) {
+    throw new Error('missing design systems: pass --design-systems, --design-system, --all-design-systems, or config.designSystems');
+  }
+  return [...new Set(ids)];
+}
+
+function makeProjectId(designSystemId: string): string {
+  const ts = Date.now().toString(36);
+  const rand = Math.random().toString(36).slice(2, 7);
+  const slug = designSystemId.replace(/[^A-Za-z0-9._-]/g, '-').slice(0, 50);
+  return `${RUN_PREFIX}${slug}-${ts}-${rand}`.slice(0, 128);
+}
+
+function makeMessageId(kind: 'user' | 'assistant'): string {
+  return `${RUN_PREFIX}${kind}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`;
+}
+
+function terminal(status: RunStatusResponse['status']): boolean {
+  return status === 'succeeded' || status === 'failed' || status === 'canceled';
+}
+
+async function waitForRun(daemonUrl: string, runId: string, timeoutMs: number): Promise<RunStatusResponse> {
+  const deadline = Date.now() + timeoutMs;
+  let last: RunStatusResponse | null = null;
+  while (Date.now() < deadline) {
+    last = await api<RunStatusResponse>(daemonUrl, 'GET', `/api/runs/${encodeURIComponent(runId)}`);
+    if (terminal(last.status)) return last;
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+  throw new Error(`run timed out after ${timeoutMs}ms${last ? ` (last status: ${last.status})` : ''}`);
+}
+
+async function appendJsonl(output: string | null | undefined, row: BatchResult): Promise<void> {
+  if (!output) return;
+  const absolute = path.resolve(REPO_ROOT, output);
+  await mkdir(path.dirname(absolute), { recursive: true });
+  await writeFile(absolute, `${JSON.stringify(row)}\n`, { flag: 'a' });
+}
+
+async function runOne(params: {
+  daemonUrl: string;
+  prompt: string;
+  designSystemId: string;
+  config: Required<Pick<BatchConfig, 'agentId' | 'startRuns' | 'wait' | 'skipDiscoveryBrief' | 'timeoutMs'>> & BatchConfig;
+}): Promise<BatchResult> {
+  const { daemonUrl, prompt, designSystemId, config } = params;
+  const projectId = makeProjectId(designSystemId);
+  const projectName = `${config.namePrefix ?? `DS batch ${new Date().toISOString()}`} — ${designSystemId}`;
+  const metadata: ProjectMetadata = {
+    kind: DEFAULT_KIND,
+    platform: DEFAULT_PLATFORM,
+    ...(config.metadata ?? {}),
+    source: 'batch-design-system-test',
+    batchDesignSystemTest: true,
+  };
+
+  const created = await api<CreateProjectResponse>(daemonUrl, 'POST', '/api/projects', {
+    id: projectId,
+    name: projectName,
+    skillId: config.skillId ?? null,
+    designSystemId,
+    pendingPrompt: prompt,
+    metadata,
+    customInstructions: config.customInstructions ?? undefined,
+    skipDiscoveryBrief: config.skipDiscoveryBrief,
+  });
+  const conversationId = created.conversationId ?? null;
+  if (!config.startRuns) {
+    return { designSystemId, projectId, projectName, conversationId, runId: null, status: 'created', daemonUrl };
+  }
+  if (!conversationId) throw new Error('daemon did not return conversationId');
+
+  const now = Date.now();
+  const userMessageId = makeMessageId('user');
+  const assistantMessageId = makeMessageId('assistant');
+  await api(daemonUrl, 'PUT', `/api/projects/${projectId}/conversations/${conversationId}/messages/${userMessageId}`, {
+    role: 'user',
+    content: prompt,
+    createdAt: now,
+  });
+  await api(daemonUrl, 'PUT', `/api/projects/${projectId}/conversations/${conversationId}/messages/${assistantMessageId}`, {
+    role: 'assistant',
+    content: '',
+    agentId: config.agentId,
+    runStatus: 'queued',
+    startedAt: now,
+    createdAt: now,
+  });
+
+  const run = await api<RunCreateResponse>(daemonUrl, 'POST', '/api/runs', {
+    agentId: config.agentId,
+    message: prompt,
+    currentPrompt: prompt,
+    projectId,
+    conversationId,
+    assistantMessageId,
+    clientRequestId: `${RUN_PREFIX}${projectId}`,
+    skillId: config.skillId ?? null,
+    designSystemId,
+    model: config.model ?? null,
+    reasoning: config.reasoning ?? null,
+  });
+  if (!config.wait) {
+    return { designSystemId, projectId, projectName, conversationId, runId: run.runId, status: 'queued', daemonUrl };
+  }
+
+  const finalStatus = await waitForRun(daemonUrl, run.runId, config.timeoutMs);
+  return {
+    designSystemId,
+    projectId,
+    projectName,
+    conversationId,
+    runId: run.runId,
+    status: finalStatus.status,
+    daemonUrl,
+    ...(finalStatus.error ? { error: finalStatus.error } : {}),
+  };
+}
+
+async function runWithConcurrency<T, R>(items: T[], concurrency: number, worker: (item: T) => Promise<R>): Promise<R[]> {
+  const results: R[] = [];
+  let nextIndex = 0;
+  async function loop(): Promise<void> {
+    for (;;) {
+      const index = nextIndex++;
+      const item = items[index];
+      if (item === undefined) return;
+      results[index] = await worker(item);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => loop()));
+  return results;
+}
+
+async function main(): Promise<void> {
+  const cli = parseArgs(process.argv.slice(2));
+  const fileConfig = await readConfig(cli.configPath);
+  const config = mergeConfig(fileConfig, cli);
+  const daemonUrl = await resolveDaemonUrl(config);
+  const prompt = await resolvePrompt(config);
+  const designSystems = await resolveDesignSystems(daemonUrl, config);
+  const resolved = {
+    ...config,
+    agentId: config.agentId ?? DEFAULT_AGENT_ID,
+    startRuns: config.startRuns ?? true,
+    wait: config.wait ?? true,
+    skipDiscoveryBrief: config.skipDiscoveryBrief ?? true,
+    concurrency: config.concurrency ?? 1,
+    timeoutMs: config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  };
+
+  console.log(`design-system batch → ${daemonUrl}`);
+  console.log(`prompt: ${prompt.slice(0, 120)}${prompt.length > 120 ? '…' : ''}`);
+  console.log(`design systems (${designSystems.length}): ${designSystems.join(', ')}`);
+  console.log(`agent=${resolved.agentId} skill=${resolved.skillId ?? 'null'} startRuns=${resolved.startRuns} wait=${resolved.wait} concurrency=${resolved.concurrency}`);
+  if (resolved.dryRun) return;
+
+  if (resolved.output) {
+    const absolute = path.resolve(REPO_ROOT, resolved.output);
+    await mkdir(path.dirname(absolute), { recursive: true });
+    await writeFile(absolute, '');
+  }
+
+  const failures: BatchResult[] = [];
+  const results = await runWithConcurrency(designSystems, resolved.concurrency, async (designSystemId) => {
+    process.stdout.write(`  - ${designSystemId}: creating\n`);
+    try {
+      const row = await runOne({ daemonUrl, prompt, designSystemId, config: resolved });
+      await appendJsonl(resolved.output, row);
+      process.stdout.write(`  ✓ ${designSystemId}: ${row.status} project=${row.projectId}${row.runId ? ` run=${row.runId}` : ''}\n`);
+      if (row.status === 'failed' || row.status === 'canceled') failures.push(row);
+      return row;
+    } catch (err) {
+      const row: BatchResult = {
+        designSystemId,
+        projectId: '',
+        projectName: '',
+        conversationId: null,
+        runId: null,
+        status: 'failed',
+        daemonUrl,
+        error: (err as Error).message || String(err),
+      };
+      await appendJsonl(resolved.output, row);
+      failures.push(row);
+      process.stderr.write(`  ! ${designSystemId}: ${row.error}\n`);
+      return row;
+    }
+  });
+
+  const succeeded = results.filter((r) => r.status === 'created' || r.status === 'queued' || r.status === 'succeeded').length;
+  console.log(`done: ${succeeded}/${results.length} ok${resolved.output ? `; results: ${resolved.output}` : ''}`);
+  if (failures.length > 0) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/scripts/batch-design-system-test.ts
+++ b/scripts/batch-design-system-test.ts
@@ -32,7 +32,7 @@ import { fileURLToPath } from 'node:url';
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(HERE, '..');
 const RUN_PREFIX = 'ds-batch-';
-const DEFAULT_AGENT_ID = 'claude';
+const FALLBACK_AGENT_ID = 'claude';
 const DEFAULT_KIND = 'prototype';
 const DEFAULT_PLATFORM = 'responsive';
 const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
@@ -94,6 +94,12 @@ interface DesignSystemsResponse {
   systems?: Array<{ id: string; title?: string }>;
 }
 
+interface AppConfigResponse {
+  config?: {
+    agentId?: string | null;
+  };
+}
+
 interface BatchResult {
   designSystemId: string;
   projectId: string;
@@ -122,7 +128,8 @@ Required input:
 Run/project options:
   --daemon <url>               Daemon base URL. Falls back to OD_DAEMON_URL,
                                OD_PORT, then tools-dev status discovery.
-  --agent <id>                 Agent id for /api/runs. Default: ${DEFAULT_AGENT_ID}.
+  --agent <id>                 Agent id for /api/runs. Default: daemon's saved
+                               app config agentId, then ${FALLBACK_AGENT_ID}.
   --skill <id|null>            Skill/design-template id to bind to each project.
   --model <id>                 Optional per-run model override.
   --reasoning <id>             Optional per-run reasoning override.
@@ -345,6 +352,20 @@ async function resolveDesignSystems(daemonUrl: string, config: BatchConfig): Pro
   return [...new Set(ids)];
 }
 
+async function resolveAgentId(daemonUrl: string, config: BatchConfig): Promise<string> {
+  if (typeof config.agentId === 'string' && config.agentId.trim()) return config.agentId.trim();
+  try {
+    const body = await api<AppConfigResponse>(daemonUrl, 'GET', '/api/app-config');
+    const configured = body.config?.agentId;
+    if (typeof configured === 'string' && configured.trim()) return configured.trim();
+  } catch (err) {
+    process.stderr.write(
+      `warning: could not read daemon app config; falling back to ${FALLBACK_AGENT_ID}: ${(err as Error).message || String(err)}\n`,
+    );
+  }
+  return FALLBACK_AGENT_ID;
+}
+
 function makeProjectId(designSystemId: string): string {
   const ts = Date.now().toString(36);
   const rand = Math.random().toString(36).slice(2, 7);
@@ -480,9 +501,10 @@ async function main(): Promise<void> {
   const daemonUrl = await resolveDaemonUrl(config);
   const prompt = await resolvePrompt(config);
   const designSystems = await resolveDesignSystems(daemonUrl, config);
+  const agentId = await resolveAgentId(daemonUrl, config);
   const resolved = {
     ...config,
-    agentId: config.agentId ?? DEFAULT_AGENT_ID,
+    agentId,
     startRuns: config.startRuns ?? true,
     wait: config.wait ?? true,
     skipDiscoveryBrief: config.skipDiscoveryBrief ?? true,

--- a/scripts/batch-design-system-test.ts
+++ b/scripts/batch-design-system-test.ts
@@ -115,6 +115,19 @@ interface BatchResult {
   error?: string;
 }
 
+interface AssistantMessageUpdate {
+  role: 'assistant';
+  content: string;
+  agentId: string;
+  agentName: string;
+  runId: string;
+  runStatus: RunStatusResponse['status'];
+  startedAt: number;
+  createdAt: number;
+  endedAt?: number;
+  producedFiles?: unknown[];
+}
+
 function buildRunPrompt(prompt: string, skipDiscoveryBrief: boolean): string {
   if (!skipDiscoveryBrief) return prompt;
   // The persisted skipDiscoveryBrief flag is understood by newer daemons, but
@@ -215,6 +228,30 @@ export function validateExplicitDesignSystemIds(requestedIds: string[], availabl
     throw new Error(`unknown design system id(s): ${unknown.join(', ')}`);
   }
   return requested;
+}
+
+export function buildAssistantMessageUpdate(params: {
+  agentId: string;
+  runId: string;
+  runStatus: RunStatusResponse['status'];
+  createdAt: number;
+  content?: string;
+  endedAt?: number;
+  producedFiles?: unknown[];
+}): AssistantMessageUpdate {
+  const { agentId, runId, runStatus, createdAt, content = '', endedAt, producedFiles } = params;
+  return {
+    role: 'assistant',
+    content,
+    agentId,
+    agentName: agentId,
+    runId,
+    runStatus,
+    startedAt: createdAt,
+    createdAt,
+    ...(endedAt !== undefined ? { endedAt } : {}),
+    ...(producedFiles !== undefined ? { producedFiles } : {}),
+  };
 }
 
 function parseJsonObject(value: string, label: string): Record<string, unknown> {
@@ -535,6 +572,17 @@ async function runOne(params: {
     model: config.model ?? null,
     reasoning: config.reasoning ?? null,
   });
+  await api(
+    daemonUrl,
+    'PUT',
+    `/api/projects/${projectId}/conversations/${conversationId}/messages/${assistantMessageId}`,
+    buildAssistantMessageUpdate({
+      agentId: config.agentId,
+      runId: run.runId,
+      runStatus: 'queued',
+      createdAt: now,
+    }),
+  );
   if (!config.wait) {
     return { designSystemId, projectId, projectName, conversationId, runId: run.runId, status: 'queued', daemonUrl };
   }
@@ -545,17 +593,20 @@ async function runOne(params: {
     .then((body) => body.files ?? [])
     .catch(() => []);
   const endedAt = Date.now();
-  await api(daemonUrl, 'PUT', `/api/projects/${projectId}/conversations/${conversationId}/messages/${assistantMessageId}`, {
-    role: 'assistant',
-    content: assistantText,
-    agentId: config.agentId,
-    agentName: config.agentId,
-    runStatus: finalStatus.status,
-    startedAt: now,
-    endedAt,
-    producedFiles,
-    createdAt: now,
-  }).catch((err) => {
+  await api(
+    daemonUrl,
+    'PUT',
+    `/api/projects/${projectId}/conversations/${conversationId}/messages/${assistantMessageId}`,
+    buildAssistantMessageUpdate({
+      agentId: config.agentId,
+      runId: run.runId,
+      runStatus: finalStatus.status,
+      createdAt: now,
+      content: assistantText,
+      endedAt,
+      producedFiles,
+    }),
+  ).catch((err) => {
     process.stderr.write(`warning: failed to persist assistant message for ${designSystemId}: ${(err as Error).message || String(err)}\n`);
   });
   return {

--- a/scripts/batch-design-system-test.ts
+++ b/scripts/batch-design-system-test.ts
@@ -384,6 +384,17 @@ async function resolvePrompt(config: BatchConfig): Promise<string> {
   throw new Error('missing prompt: pass --prompt, --prompt-file, or config.prompt');
 }
 
+export function resolveDryRunDesignSystems(config: BatchConfig): string[] {
+  if (config.allDesignSystems) {
+    throw new Error('dry-run with --all-design-systems still requires daemon access; pass explicit --design-systems instead');
+  }
+  const ids = config.designSystems ?? [];
+  if (ids.length === 0) {
+    throw new Error('missing design systems: pass --design-systems, --design-system, --all-design-systems, or config.designSystems');
+  }
+  return dedupeDesignSystemIds(ids);
+}
+
 async function resolveDesignSystems(daemonUrl: string, config: BatchConfig): Promise<string[]> {
   const body = await api<DesignSystemsResponse>(daemonUrl, 'GET', '/api/design-systems');
   const systems = body.designSystems ?? body.systems ?? [];
@@ -578,13 +589,10 @@ async function main(): Promise<void> {
   const cli = parseArgs(process.argv.slice(2));
   const fileConfig = await readConfig(cli.configPath);
   const config = mergeConfig(fileConfig, cli);
-  const daemonUrl = await resolveDaemonUrl(config);
   const prompt = await resolvePrompt(config);
-  const designSystems = await resolveDesignSystems(daemonUrl, config);
-  const agentId = await resolveAgentId(daemonUrl, config);
   const resolved = {
     ...config,
-    agentId,
+    agentId: typeof config.agentId === 'string' && config.agentId.trim() ? config.agentId.trim() : FALLBACK_AGENT_ID,
     startRuns: config.startRuns ?? true,
     wait: config.wait ?? true,
     skipDiscoveryBrief: config.skipDiscoveryBrief ?? true,
@@ -592,11 +600,28 @@ async function main(): Promise<void> {
     timeoutMs: config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
   };
 
+  if (resolved.dryRun) {
+    const designSystems = resolveDryRunDesignSystems(config);
+    const daemonUrl =
+      config.daemonUrl ??
+      process.env.OD_DAEMON_URL ??
+      (isDiscoverablePort(process.env.OD_PORT) ? `http://127.0.0.1:${process.env.OD_PORT}` : '(not resolved in dry-run)');
+
+    console.log(`design-system batch → ${daemonUrl}`);
+    console.log(`prompt: ${prompt.slice(0, 120)}${prompt.length > 120 ? '…' : ''}`);
+    console.log(`design systems (${designSystems.length}): ${designSystems.join(', ')}`);
+    console.log(`agent=${resolved.agentId} skill=${resolved.skillId ?? 'null'} startRuns=${resolved.startRuns} wait=${resolved.wait} concurrency=${resolved.concurrency}`);
+    return;
+  }
+
+  const daemonUrl = await resolveDaemonUrl(config);
+  const designSystems = await resolveDesignSystems(daemonUrl, config);
+  resolved.agentId = await resolveAgentId(daemonUrl, config);
+
   console.log(`design-system batch → ${daemonUrl}`);
   console.log(`prompt: ${prompt.slice(0, 120)}${prompt.length > 120 ? '…' : ''}`);
   console.log(`design systems (${designSystems.length}): ${designSystems.join(', ')}`);
   console.log(`agent=${resolved.agentId} skill=${resolved.skillId ?? 'null'} startRuns=${resolved.startRuns} wait=${resolved.wait} concurrency=${resolved.concurrency}`);
-  if (resolved.dryRun) return;
 
   if (resolved.output) {
     const absolute = path.resolve(REPO_ROOT, resolved.output);

--- a/scripts/batch-design-system-test.ts
+++ b/scripts/batch-design-system-test.ts
@@ -89,6 +89,10 @@ interface RunStatusResponse {
   updatedAt?: number;
 }
 
+interface ProjectFilesResponse {
+  files?: unknown[];
+}
+
 interface DesignSystemsResponse {
   designSystems?: Array<{ id: string; title?: string }>;
   systems?: Array<{ id: string; title?: string }>;
@@ -109,6 +113,35 @@ interface BatchResult {
   status: 'created' | RunStatusResponse['status'];
   daemonUrl: string;
   error?: string;
+}
+
+function buildRunPrompt(prompt: string, skipDiscoveryBrief: boolean): string {
+  if (!skipDiscoveryBrief) return prompt;
+  // The persisted skipDiscoveryBrief flag is understood by newer daemons, but
+  // this script is often run against an already-started daemon while developing
+  // the branch. Include the user-level escape hatch too so older daemons still
+  // bypass the discovery form and actually build files.
+  return `skip questions, just build. no questions, go.\n\n${prompt}`;
+}
+
+function extractAgentTextFromSse(body: string): string {
+  const chunks: string[] = [];
+  for (const block of body.split(/\n\n+/)) {
+    const eventLine = block.split('\n').find((line) => line.startsWith('event:'));
+    if (eventLine?.slice('event:'.length).trim() !== 'agent') continue;
+    const dataLines = block
+      .split('\n')
+      .filter((line) => line.startsWith('data:'))
+      .map((line) => line.slice('data:'.length).trimStart());
+    if (dataLines.length === 0) continue;
+    try {
+      const payload = JSON.parse(dataLines.join('\n')) as { type?: string; delta?: unknown };
+      if (payload.type === 'text_delta' && typeof payload.delta === 'string') chunks.push(payload.delta);
+    } catch {
+      // Ignore malformed/non-JSON event payloads.
+    }
+  }
+  return chunks.join('');
 }
 
 function printHelp(): void {
@@ -391,6 +424,11 @@ function makeMessageId(kind: 'user' | 'assistant'): string {
   return `${RUN_PREFIX}${kind}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`;
 }
 
+function formatBatchTimestamp(date: Date): string {
+  const pad = (value: number) => String(value).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
 function terminal(status: RunStatusResponse['status']): boolean {
   return status === 'succeeded' || status === 'failed' || status === 'canceled';
 }
@@ -404,6 +442,14 @@ async function waitForRun(daemonUrl: string, runId: string, timeoutMs: number): 
     await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
   }
   throw new Error(`run timed out after ${timeoutMs}ms${last ? ` (last status: ${last.status})` : ''}`);
+}
+
+async function readRunAssistantText(daemonUrl: string, runId: string): Promise<string> {
+  const body = await fetch(`${daemonUrl.replace(/\/$/, '')}/api/runs/${encodeURIComponent(runId)}/events`).then((resp) => {
+    if (!resp.ok) throw new Error(`GET /api/runs/${runId}/events → ${resp.status}`);
+    return resp.text();
+  });
+  return extractAgentTextFromSse(body);
 }
 
 async function appendJsonl(output: string | null | undefined, row: BatchResult): Promise<void> {
@@ -420,8 +466,9 @@ async function runOne(params: {
   config: Required<Pick<BatchConfig, 'agentId' | 'startRuns' | 'wait' | 'skipDiscoveryBrief' | 'timeoutMs'>> & BatchConfig;
 }): Promise<BatchResult> {
   const { daemonUrl, prompt, designSystemId, config } = params;
+  const runPrompt = buildRunPrompt(prompt, config.skipDiscoveryBrief);
   const projectId = makeProjectId(designSystemId);
-  const projectName = `${config.namePrefix ?? `DS batch ${new Date().toISOString()}`} — ${designSystemId}`;
+  const projectName = `${config.namePrefix ?? 'DS batch'} — ${designSystemId} — ${formatBatchTimestamp(new Date())}`;
   const metadata: ProjectMetadata = {
     kind: DEFAULT_KIND,
     platform: DEFAULT_PLATFORM,
@@ -435,7 +482,7 @@ async function runOne(params: {
     name: projectName,
     skillId: config.skillId ?? null,
     designSystemId,
-    pendingPrompt: prompt,
+    pendingPrompt: runPrompt,
     metadata,
     customInstructions: config.customInstructions ?? undefined,
     skipDiscoveryBrief: config.skipDiscoveryBrief,
@@ -451,13 +498,14 @@ async function runOne(params: {
   const assistantMessageId = makeMessageId('assistant');
   await api(daemonUrl, 'PUT', `/api/projects/${projectId}/conversations/${conversationId}/messages/${userMessageId}`, {
     role: 'user',
-    content: prompt,
+    content: runPrompt,
     createdAt: now,
   });
   await api(daemonUrl, 'PUT', `/api/projects/${projectId}/conversations/${conversationId}/messages/${assistantMessageId}`, {
     role: 'assistant',
     content: '',
     agentId: config.agentId,
+    agentName: config.agentId,
     runStatus: 'queued',
     startedAt: now,
     createdAt: now,
@@ -465,8 +513,8 @@ async function runOne(params: {
 
   const run = await api<RunCreateResponse>(daemonUrl, 'POST', '/api/runs', {
     agentId: config.agentId,
-    message: prompt,
-    currentPrompt: prompt,
+    message: runPrompt,
+    currentPrompt: runPrompt,
     projectId,
     conversationId,
     assistantMessageId,
@@ -481,6 +529,24 @@ async function runOne(params: {
   }
 
   const finalStatus = await waitForRun(daemonUrl, run.runId, config.timeoutMs);
+  const assistantText = await readRunAssistantText(daemonUrl, run.runId).catch(() => '');
+  const producedFiles = await api<ProjectFilesResponse>(daemonUrl, 'GET', `/api/projects/${projectId}/files`)
+    .then((body) => body.files ?? [])
+    .catch(() => []);
+  const endedAt = Date.now();
+  await api(daemonUrl, 'PUT', `/api/projects/${projectId}/conversations/${conversationId}/messages/${assistantMessageId}`, {
+    role: 'assistant',
+    content: assistantText,
+    agentId: config.agentId,
+    agentName: config.agentId,
+    runStatus: finalStatus.status,
+    startedAt: now,
+    endedAt,
+    producedFiles,
+    createdAt: now,
+  }).catch((err) => {
+    process.stderr.write(`warning: failed to persist assistant message for ${designSystemId}: ${(err as Error).message || String(err)}\n`);
+  });
   return {
     designSystemId,
     projectId,


### PR DESCRIPTION
## Summary
- Add `skipDiscoveryBrief` to project creation so API-created batch projects can start from the submitted brief without the Quick brief form.
- Remove the second visual-direction picker from discovery flow; active design systems now serve as the visual direction directly.
- Add `scripts/batch-design-system-test.ts` for creating/running the same prompt across multiple design systems with config, concurrency, wait, and JSONL output support.

## Validation
- `node --experimental-strip-types scripts/batch-design-system-test.ts --help`
- `node --experimental-strip-types scripts/batch-design-system-test.ts --daemon http://127.0.0.1:1 --prompt "Test prompt" --design-systems default,kami --create-only --dry-run`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/projects-routes.test.ts tests/system-prompt-template.test.ts`
- `pnpm --filter @open-design/contracts exec vitest run tests/system-prompt-api-mode.test.ts`
- `pnpm --filter @open-design/contracts typecheck`
- `pnpm --filter @open-design/daemon typecheck`
- `tsc -p scripts/tsconfig.json --noEmit`
- `pnpm guard`