### PR TITLE
fix: add user chat message bubble styling

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -1010,7 +1010,7 @@ function UserMessage({
           ))}
         </div>
       ) : null}
-      {message.content ? <div className="user-text">{message.content}</div> : null}
+      {message.content ? <div className="user-text user-bubble">{message.content}</div> : null}
     </div>
   );
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -982,6 +982,13 @@ code {
   min-width: 0;
   max-width: 100%;
 }
+.msg.user {
+  align-self: flex-end;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  max-width: min(78%, 560px);
+}
 .msg .role {
   display: flex;
   align-items: baseline;
@@ -1017,7 +1024,20 @@ code {
   flex: 1;
 }
 .msg.user .role::before { content: ''; }
-.msg.user .user-text { white-space: pre-wrap; color: var(--text); }
+.msg.user .role {
+  justify-content: flex-end;
+  color: var(--text-muted);
+}
+.msg.user .user-text {
+  white-space: pre-wrap;
+  color: #fff;
+  background: var(--selected);
+  border: 1px solid color-mix(in srgb, var(--selected) 88%, #000);
+  border-radius: 14px 14px 4px 14px;
+  padding: 8px 11px;
+  line-height: 1.45;
+  box-shadow: var(--shadow-xs);
+}
 .msg.assistant .prose { margin-top: 4px; }
 .msg .artifact-badge {
   display: inline-block;
@@ -1268,6 +1288,7 @@ code {
   display: flex;
   gap: 6px;
   flex-wrap: wrap;
+  justify-content: flex-end;
   margin-bottom: 8px;
 }
 .user-attachment {

--- a/apps/web/tests/components/ChatPane.streaming.test.tsx
+++ b/apps/web/tests/components/ChatPane.streaming.test.tsx
@@ -28,6 +28,39 @@ afterEach(() => {
 });
 
 describe('ChatPane streaming state', () => {
+  it('renders user turns with the chat bubble styling hook', () => {
+    const messages: ChatMessage[] = [
+      {
+        id: 'user-1',
+        role: 'user',
+        content: 'Generate a simple sign-in page',
+        createdAt: 1,
+      },
+    ];
+
+    render(
+      <ChatPane
+        messages={messages}
+        streaming={false}
+        error={null}
+        projectId="project-1"
+        projectFiles={[]}
+        onEnsureProject={async () => 'project-1'}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+        conversations={conversations}
+        activeConversationId="conv-1"
+        onSelectConversation={vi.fn()}
+        onDeleteConversation={vi.fn()}
+        projectMetadata={projectMetadata}
+      />,
+    );
+
+    const bubble = screen.getByText('Generate a simple sign-in page');
+    expect(bubble.classList.contains('user-bubble')).toBe(true);
+    expect(bubble.closest('.msg.user')).not.toBeNull();
+  });
+
   it('keeps composer idle while active-run messages still render as streaming', () => {
     const messages: ChatMessage[] = [
       {


### PR DESCRIPTION
<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works.
     Delete this whole block if the PR genuinely doesn't close any issue. -->
Fixes #1518

## Summary
- Right-align user chat turns in the transcript
- Render user message text in a blue chat bubble
- Align user attachments with the user turn
- Add coverage for the user message bubble styling hook

## Validation
- pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/ChatPane.streaming.test.tsx
- pnpm --filter @open-design/web typecheck
