### PR TITLE
docs(pr): require user-perspective description and surface area

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,7 +29,7 @@ Fixes #
 - [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
 - [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
 - [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
-- [ ] **New top-level dependency** — adding a runtime dep to `package.json`; include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
+- [ ] **New top-level dependency** — adding any new entry to `package.json` (`dependencies` or `devDependencies`); include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
 - [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
 - [ ] **None** — internal refactor, docs, tests, or translation update only
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,8 +3,48 @@
      Delete this whole block if the PR genuinely doesn't close any issue. -->
 Fixes #
 
-## Summary
--
+## Problem
+
+<!-- What user-facing problem does this solve? For non-trivial features, please
+     open a discussion or issue first to align on scope and UX before writing code. -->
+
+
+## What users will see
+
+<!-- Describe the change from a user's perspective, not in code terms. Examples:
+       - "Settings → AI Providers has a new 'Custom endpoint' field, off by default"
+       - "Right-clicking a design file shows a new 'Duplicate' option"
+       - "Default model changed from X to Y — existing users will notice on first launch"
+       - "New `od skills install <name>` subcommand"
+     Skip this section only if you check "None" below. -->
+
+
+## Surface area
+
+<!-- Check every box that applies. Reviewers use this to scope the review. -->
+
+- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
+- [ ] **Keyboard shortcut** — new or changed
+- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
+- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
+- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
+- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
+- [ ] **New top-level dependency** — adding a runtime dep to `package.json`; include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
+- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
+- [ ] **None** — internal refactor, docs, tests, or translation update only
+
+
+## Screenshots
+
+<!-- If you checked "UI" above, attach screenshots showing the entry point —
+     where users discover the change — not just the feature in isolation.
+     Before/after is best for behavior changes. Short GIFs welcome. -->
+
 
 ## Validation
+
+<!-- What you actually ran. Default minimum: `pnpm guard` + `pnpm typecheck`,
+     plus the package-scoped tests/build for the files you changed
+     (e.g. `pnpm --filter @open-design/web test`). -->
+
 -

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,10 +3,16 @@
      Delete this whole block if the PR genuinely doesn't close any issue. -->
 Fixes #
 
-## Problem
+## Why
 
-<!-- What user-facing problem does this solve? For non-trivial features, please
-     open a discussion or issue first to align on scope and UX before writing code. -->
+<!-- Why are you opening this PR? Cover two things:
+       - Your use case — what made you write this today? Did you hit it yourself
+         while building on top of OD, are you scratching an itch for a team, or
+         are you speculatively adding for others? All are fine, but say which.
+       - The pain being addressed — user-facing problem, technical debt, a prod
+         issue, or unblocking another change.
+     For non-trivial features, please open a discussion or issue first to align
+     on scope and UX before writing code. -->
 
 
 ## What users will see
@@ -29,7 +35,7 @@ Fixes #
 - [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
 - [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
 - [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
-- [ ] **New top-level dependency** — adding any new entry to `package.json` (`dependencies` or `devDependencies`); include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
+- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
 - [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
 - [ ] **None** — internal refactor, docs, tests, or translation update only
 
@@ -39,6 +45,20 @@ Fixes #
 <!-- If you checked "UI" above, attach screenshots showing the entry point —
      where users discover the change — not just the feature in isolation.
      Before/after is best for behavior changes. Short GIFs welcome. -->
+
+
+## Bug fix verification
+
+<!-- Skip if this PR isn't a bug fix.
+
+     Per AGENTS.md → "Bug follow-up workflow", bugs should be encoded as a
+     falsifiable test that goes red before the source change. Confirm:
+       - Test path that reproduces the bug:
+       - Did the test go red on `main` and green on this branch? (yes / no)
+       - If a red spec wasn't cheap to write, explain why and what verification
+         you did instead. -->
+
+-
 
 
 ## Validation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,9 +74,11 @@ This file is the single source of truth for agents entering this repository. Rea
 ## Pull request expectations
 
 - Opening a PR uses `.github/pull_request_template.md`; fill every section, not just the title.
+- "Why" must answer both the author's use case (what made you write this PR) and the pain being addressed (user problem, technical debt, prod issue, or unblocker), not just a one-line restatement of the title.
 - "What users will see" describes the change from a user's perspective — what they click, what new thing appears, what default behavior changed — not from a code perspective.
-- The Surface area checklist must reflect actual surfaces touched; check every box that applies, including extension points (`skills/`, `design-systems/`, `design-templates/`, `craft/`), CLI flags, env vars, i18n keys, and new top-level dependencies.
+- The Surface area checklist must reflect actual surfaces touched; check every box that applies, including extension points (`skills/`, `design-systems/`, `design-templates/`, `craft/`), CLI flags, env vars, i18n keys, and new root `package.json` dependencies.
 - If any UI surface is checked, attach screenshots showing the entry point — where users discover the change — not just the feature in isolation; before/after is best for behavior changes.
+- For bug-fix PRs, link the red-spec test that reproduces the bug and confirm it went red on `main` and green on the branch, per the `Bug follow-up workflow` section above.
 - `CONTRIBUTING.md` covers PR scope, title format, dependency policy, and the issue-first rule for non-trivial features; `docs/code-review-guidelines.md` is the reviewer-facing complement.
 
 ## Code review guide

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,14 @@ This file is the single source of truth for agents entering this repository. Rea
 
 - Git commits must not include `Co-authored-by` trailers or any other co-author metadata.
 
+## Pull request expectations
+
+- Opening a PR uses `.github/pull_request_template.md`; fill every section, not just the title.
+- "What users will see" describes the change from a user's perspective — what they click, what new thing appears, what default behavior changed — not from a code perspective.
+- The Surface area checklist must reflect actual surfaces touched; check every box that applies, including extension points (`skills/`, `design-systems/`, `design-templates/`, `craft/`), CLI flags, env vars, i18n keys, and new top-level dependencies.
+- If any UI surface is checked, attach screenshots showing the entry point — where users discover the change — not just the feature in isolation; before/after is best for behavior changes.
+- `CONTRIBUTING.md` covers PR scope, title format, dependency policy, and the issue-first rule for non-trivial features; `docs/code-review-guidelines.md` is the reviewer-facing complement.
+
 ## Code review guide
 
 - Use `docs/code-review-guidelines.md` as the repository-wide review standard. That document is the operational guide; this `AGENTS.md` is the source of truth when the two disagree.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -245,7 +245,7 @@ Beyond that:
 
 - **One concern per PR.** Adding a skill + refactoring the parser + bumping a dep is three PRs.
 - **Title is imperative + scope.** `add dating-web skill`, `fix daemon SSE backpressure when CLI hangs`, `docs: clarify .od layout`.
-- **Use the PR template.** Fill every section of [`.github/pull_request_template.md`](.github/pull_request_template.md) — Problem, What users will see, Surface area, Screenshots (if UI), Validation. Empty sections earn a "please fill in" reply.
+- **Use the PR template.** Fill every section of [`.github/pull_request_template.md`](.github/pull_request_template.md) — Why, What users will see, Surface area, Screenshots (if UI), Bug fix verification (if bug fix), Validation. Empty sections earn a "please fill in" reply.
 - **Body explains the why.** "What does this do" is usually obvious from the diff; "why does this need to exist" rarely is.
 - **Reference an issue** if there is one. If there isn't and the PR is non-trivial, open one first so we can agree the change is wanted before you spend the time.
 - **No squash-during-review.** Push fixups; we'll squash on merge.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -245,6 +245,7 @@ Beyond that:
 
 - **One concern per PR.** Adding a skill + refactoring the parser + bumping a dep is three PRs.
 - **Title is imperative + scope.** `add dating-web skill`, `fix daemon SSE backpressure when CLI hangs`, `docs: clarify .od layout`.
+- **Use the PR template.** Fill every section of [`.github/pull_request_template.md`](.github/pull_request_template.md) — Problem, What users will see, Surface area, Screenshots (if UI), Validation. Empty sections earn a "please fill in" reply.
 - **Body explains the why.** "What does this do" is usually obvious from the diff; "why does this need to exist" rarely is.
 - **Reference an issue** if there is one. If there isn't and the PR is non-trivial, open one first so we can agree the change is wanted before you spend the time.
 - **No squash-during-review.** Push fixups; we'll squash on merge.


### PR DESCRIPTION
## Problem

External-contributor PRs often arrive with code-perspective descriptions ("added X function, refactored Y") rather than user-perspective ones ("user will see a new Z option under Settings"). This leaves reviewers guessing which UI/CLI/API surfaces actually changed, and we've been finding surprises during release verification — new menu items, new settings, new flags — that the PR body never mentioned.

The existing template (`Summary` + `Validation`) didn't push contributors toward the user view and didn't enumerate the surfaces worth flagging.

## What users will see

No user-visible runtime change. This affects the PR-authoring experience:

- Anyone opening a PR will see a structured template prompting for **Problem**, **What users will see**, **Surface area** (9-item checklist), **Screenshots** (when UI is checked), and **Validation**.
- Authors using AI agents will see the new `## Pull request expectations` section in `AGENTS.md`; that's the channel for Claude Code / Cursor / Codex to pick up the user-perspective + screenshot requirement automatically.
- The existing `Fixes #` issue-link prompt at the top is preserved verbatim — auto-linking on merge still works.

## Surface area

- [ ] **UI** — no
- [ ] **Keyboard shortcut** — no
- [ ] **CLI / env var** — no
- [ ] **API / contract** — no
- [ ] **Extension point** — no
- [ ] **i18n keys** — no
- [ ] **New top-level dependency** — no
- [ ] **Default behavior change** — no
- [x] **None** — governance docs only (`AGENTS.md` + `CONTRIBUTING.md` + `.github/pull_request_template.md`)

This is a governance-lane PR per `docs/code-review-guidelines.md` § "Repository governance documentation": new repository rules updated in the authoritative `AGENTS.md` first, with operational guides (template, CONTRIBUTING) following.

## Screenshots

n/a — no UI surface.

## Validation

n/a — markdown-only change. `pnpm guard` / `pnpm typecheck` have nothing to assert against `.md` content; CI will run them anyway.

## Follow-up

Localized `CONTRIBUTING.{zh-CN,de,fr,ja-JP,pt-BR}.md` files each have a translated `## Commit 与 PR` / `## Commits & Pull Requests` / etc. section that should pick up the same "Use the PR template" pointer line. Following the existing translation-PR pattern (e.g. #309), these are left for follow-up translation PRs rather than bundled here.