### PR TITLE
fix(daemon+web): emit conversation-created SSE event when routine run starts

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1111,7 +1111,7 @@ function emitLiveArtifactEvent(grant, action, artifact) {
     title: artifact.title ?? artifact.id,
     refreshStatus: artifact.refreshStatus,
   };
-  let emitted = emitProjectLiveArtifactEvent(payload.projectId, payload);
+  let emitted = emitProjectEvent(payload.projectId, payload);
   if (grant?.runId) emitted = emitChatAgentEvent(grant.runId, payload) || emitted;
   return emitted;
 }
@@ -1123,12 +1123,16 @@ function emitLiveArtifactRefreshEvent(grant, payload) {
     projectId: grant.projectId,
     ...payload,
   };
-  let emitted = emitProjectLiveArtifactEvent(grant.projectId, event);
+  let emitted = emitProjectEvent(grant.projectId, event);
   if (grant?.runId) emitted = emitChatAgentEvent(grant.runId, event) || emitted;
   return emitted;
 }
 
-function emitProjectLiveArtifactEvent(projectId, payload) {
+// Broadcast an event to every SSE subscriber currently watching the given
+// project's `/api/projects/:id/events` stream. The payload's `type` field
+// becomes the SSE event name (see project-routes.ts). Used for live-artifact
+// events and `conversation-created` events emitted by routine runs (#1361).
+function emitProjectEvent(projectId, payload) {
   const sinks = activeProjectEventSinks.get(projectId);
   if (!sinks || sinks.size === 0) return false;
   for (const sink of Array.from(sinks)) {
@@ -4445,6 +4449,21 @@ export async function startServer({
       title: conversationTitle,
       createdAt: now,
       updatedAt: now,
+    });
+
+    // Notify any open `ProjectView` watching this project so its
+    // conversation list picks up the new routine conversation without
+    // requiring the user to leave and re-enter the project (#1361).
+    // For reuse-an-existing-project mode this is the only path the
+    // open view has to learn the conversation exists; for new-project
+    // mode this is harmless (no subscribers for a project that was
+    // just created milliseconds ago).
+    emitProjectEvent(projectId, {
+      type: 'conversation-created',
+      projectId,
+      conversationId,
+      title: conversationTitle,
+      createdAt: now,
     });
 
     const assistantMessageId = `routine-assistant-${randomUUID()}`;

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -275,6 +275,7 @@ import {
 /** @typedef {import('@open-design/contracts').ChatSseEvent} ChatSseEvent */
 /** @typedef {import('@open-design/contracts').ProxyStreamRequest} ProxyStreamRequest */
 /** @typedef {import('@open-design/contracts').ProxySseEvent} ProxySseEvent */
+/** @typedef {import('@open-design/contracts').ProjectConversationCreatedSsePayload} ProjectConversationCreatedSsePayload */
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -4457,14 +4458,18 @@ export async function startServer({
     // For reuse-an-existing-project mode this is the only path the
     // open view has to learn the conversation exists; for new-project
     // mode this is harmless (no subscribers for a project that was
-    // just created milliseconds ago).
-    emitProjectEvent(projectId, {
+    // just created milliseconds ago). The payload shape is the shared
+    // `ProjectConversationCreatedSsePayload` from `@open-design/contracts`
+    // so the daemon producer and the web consumer cannot drift.
+    /** @type {ProjectConversationCreatedSsePayload} */
+    const conversationCreatedEvent = {
       type: 'conversation-created',
       projectId,
       conversationId,
       title: conversationTitle,
       createdAt: now,
-    });
+    };
+    emitProjectEvent(projectId, conversationCreatedEvent);
 
     const assistantMessageId = `routine-assistant-${randomUUID()}`;
     const run = design.runs.create({

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -220,6 +220,7 @@ export function projectSplitClassName(workspaceFocused: boolean): string {
 
 function projectEventToAgentEvent(evt: ProjectEvent): LiveArtifactEventItem['event'] | null {
   if (evt.type === 'file-changed') return null;
+  if (evt.type === 'conversation-created') return null;
   if (evt.type === 'live_artifact') {
     return {
       kind: 'live_artifact',
@@ -750,6 +751,28 @@ export function ProjectView({
       setDesignMdRefreshKey((n) => n + 1);
       return;
     }
+    if (evt.type === 'conversation-created') {
+      // A new conversation was inserted into this project by a path the
+      // open project view can't observe through its own state (currently:
+      // Routines "Run now" in reuse-an-existing-project mode, #1361).
+      // Refetch the conversation list so the new entry becomes visible
+      // without requiring the user to leave and re-enter the project.
+      // Deliberately do NOT change the active conversation here — the
+      // user keeps their current context. Auto-switch is a separate UX
+      // decision tracked in #1361.
+      if (evt.projectId !== project.id) return;
+      void (async () => {
+        try {
+          const list = await listConversations(project.id);
+          setConversations(list);
+        } catch {
+          // Defensive: refresh failed (network blip, daemon gone). The
+          // next project mount or another conversation-created event
+          // will retry; no need to surface an error here.
+        }
+      })();
+      return;
+    }
     const agentEvent = projectEventToAgentEvent(evt);
     if (!agentEvent) return;
     setLiveArtifactEvents((prev) => appendLiveArtifactEventItem(prev, agentEvent));
@@ -758,7 +781,7 @@ export function ProjectView({
     // Live artifact events come from chat-turn-emitted artifacts; they
     // also imply the conversation transcript changed.
     setDesignMdRefreshKey((n) => n + 1);
-  }, [onProjectsRefresh, refreshLiveArtifacts]);
+  }, [onProjectsRefresh, refreshLiveArtifacts, project.id]);
   useProjectFileEvents(project.id, daemonLive, handleProjectEvent);
 
   // When the URL points at a specific file, fire an open request so the

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -419,6 +419,24 @@ export function ProjectView({
   // correctly gate new-conversation creation even during async loads.
   const messagesConversationIdRef = useRef<string | null>(null);
   const creatingConversationRef = useRef(false);
+  // Live mirror of the currently-viewed project id. Used to bail out of
+  // the conversation-created async refresh (#1361) if the user switches
+  // projects while the refetch is in flight — the existing project-load
+  // effects use the same kind of cancellation guard.
+  const projectIdRef = useRef(project.id);
+  useEffect(() => {
+    projectIdRef.current = project.id;
+  }, [project.id]);
+  // Monotonic token bumped on every `conversation-created` refresh dispatch.
+  // Two rapid events (e.g. concurrent routine runs against the same reused
+  // project, #1502) can start overlapping `listConversations` calls; if the
+  // later request resolves first with N+1 conversations and the earlier
+  // request resolves afterwards with only N, an unconditional
+  // `setConversations(list)` would drop the newest conversation. Each
+  // dispatch captures the token at start; only the dispatch whose token
+  // still equals `conversationsRefreshTokenRef.current` at await-return is
+  // allowed to apply its result.
+  const conversationsRefreshTokenRef = useRef(0);
   const [creatingConversation, setCreatingConversation] = useState(false);
   const currentConversationHasActiveRun = useMemo(
     () => messages.some((m) => m.role === 'assistant' && isActiveRunStatus(m.runStatus)),
@@ -761,9 +779,24 @@ export function ProjectView({
       // user keeps their current context. Auto-switch is a separate UX
       // decision tracked in #1361.
       if (evt.projectId !== project.id) return;
+      const capturedProjectId = project.id;
+      const myToken = ++conversationsRefreshTokenRef.current;
       void (async () => {
         try {
-          const list = await listConversations(project.id);
+          const list = await listConversations(capturedProjectId);
+          // Bail if the user switched projects while this request was in
+          // flight (#1361 review, Codex P1). The captured project id is the
+          // one we asked the daemon about; the live ref is the one the
+          // user is looking at right now. If they don't match, applying
+          // the list would overwrite the new project's sidebar with
+          // stale data from the old one.
+          if (projectIdRef.current !== capturedProjectId) return;
+          // Bail if a newer conversation-created event already dispatched
+          // its own refresh after us (#1361 review, lefarcen P2). With two
+          // rapid events the later request may resolve first; if this
+          // earlier request resolves afterwards it would drop the newer
+          // conversation. Only the latest dispatch is allowed to apply.
+          if (conversationsRefreshTokenRef.current !== myToken) return;
           setConversations(list);
         } catch {
           // Defensive: refresh failed (network blip, daemon gone). The

--- a/apps/web/src/providers/project-events.ts
+++ b/apps/web/src/providers/project-events.ts
@@ -1,26 +1,20 @@
 import { useEffect, useRef } from 'react';
-import type { LiveArtifactRefreshSsePayload, LiveArtifactSsePayload } from '@open-design/contracts';
+import type {
+  LiveArtifactRefreshSsePayload,
+  LiveArtifactSsePayload,
+  ProjectConversationCreatedSsePayload,
+} from '@open-design/contracts';
 export interface ProjectFileChangeEvent {
   type: 'file-changed';
   path: string;
   kind: 'add' | 'change' | 'unlink';
 }
 
-// Emitted by the daemon when a new conversation is inserted into a project
-// from a path the open project view can't observe through its own state
-// (currently: Routines "Run now" in reuse-an-existing-project mode). The
-// open `ProjectView` listens for these so its conversation list stays
-// aligned with the database without requiring the user to leave and re-enter
-// the project. The active conversation is intentionally NOT changed here —
-// the user keeps their current context; auto-switch is a separate UX
-// decision tracked in #1361.
-export interface ProjectConversationCreatedEvent {
-  type: 'conversation-created';
-  projectId: string;
-  conversationId: string;
-  title: string | null;
-  createdAt: number;
-}
+// Re-exported under the local "project event" naming so consumers in this
+// package keep their existing import shape; the canonical type lives in
+// `packages/contracts` alongside the other SSE payloads (per repo review
+// guidance on contract/protocol seams).
+export type ProjectConversationCreatedEvent = ProjectConversationCreatedSsePayload;
 
 export type ProjectLiveArtifactEvent = LiveArtifactSsePayload | LiveArtifactRefreshSsePayload;
 

--- a/apps/web/src/providers/project-events.ts
+++ b/apps/web/src/providers/project-events.ts
@@ -6,9 +6,28 @@ export interface ProjectFileChangeEvent {
   kind: 'add' | 'change' | 'unlink';
 }
 
+// Emitted by the daemon when a new conversation is inserted into a project
+// from a path the open project view can't observe through its own state
+// (currently: Routines "Run now" in reuse-an-existing-project mode). The
+// open `ProjectView` listens for these so its conversation list stays
+// aligned with the database without requiring the user to leave and re-enter
+// the project. The active conversation is intentionally NOT changed here —
+// the user keeps their current context; auto-switch is a separate UX
+// decision tracked in #1361.
+export interface ProjectConversationCreatedEvent {
+  type: 'conversation-created';
+  projectId: string;
+  conversationId: string;
+  title: string | null;
+  createdAt: number;
+}
+
 export type ProjectLiveArtifactEvent = LiveArtifactSsePayload | LiveArtifactRefreshSsePayload;
 
-export type ProjectEvent = ProjectFileChangeEvent | ProjectLiveArtifactEvent;
+export type ProjectEvent =
+  | ProjectFileChangeEvent
+  | ProjectConversationCreatedEvent
+  | ProjectLiveArtifactEvent;
 
 export interface ProjectEventsConnectionOptions {
   /** Test seam: substitute a mock EventSource constructor. */
@@ -100,6 +119,22 @@ export function createProjectEventsConnection(
     };
     es.addEventListener('live_artifact', handleLiveArtifactEvent);
     es.addEventListener('live_artifact_refresh', handleLiveArtifactEvent);
+    es.addEventListener('conversation-created', (evt) => {
+      try {
+        const data = JSON.parse(
+          (evt as MessageEvent).data,
+        ) as ProjectConversationCreatedEvent;
+        onChange(data);
+      } catch (err) {
+        if (
+          typeof process !== 'undefined' &&
+          process.env?.NODE_ENV === 'development'
+        ) {
+          // eslint-disable-next-line no-console
+          console.warn('[project-events] malformed conversation-created payload', err);
+        }
+      }
+    });
     es.addEventListener('error', () => {
       if (cancelled) return;
       es.close();

--- a/apps/web/tests/providers/project-events.test.ts
+++ b/apps/web/tests/providers/project-events.test.ts
@@ -158,6 +158,85 @@ describe('createProjectEventsConnection', () => {
     conn.close();
   });
 
+  it('parses conversation-created events emitted by routine reuse runs (#1361)', () => {
+    const seen: ProjectEvent[] = [];
+    const conn = createProjectEventsConnection(
+      'p1',
+      (evt) => seen.push(evt),
+      { EventSourceCtor: MockEventSource as unknown as typeof EventSource },
+    );
+    const es = MockEventSource.instances[0]!;
+    es.dispatch('conversation-created', {
+      data: JSON.stringify({
+        type: 'conversation-created',
+        projectId: 'p1',
+        conversationId: 'routine-conv-aaa',
+        title: 'Routine · 2026-05-13',
+        createdAt: 1747109840000,
+      }),
+    });
+
+    expect(seen).toEqual([
+      {
+        type: 'conversation-created',
+        projectId: 'p1',
+        conversationId: 'routine-conv-aaa',
+        title: 'Routine · 2026-05-13',
+        createdAt: 1747109840000,
+      },
+    ]);
+    conn.close();
+  });
+
+  // Concurrent routine runs (#1502): two Run-now clicks against the same
+  // reuse-an-existing-project routine each create their own conversation.
+  // Both events should be delivered to the open `ProjectView` so the
+  // conversation list surfaces all of them, not just the latest one.
+  it('delivers multiple concurrent conversation-created events (covers #1502)', () => {
+    const seen: ProjectEvent[] = [];
+    const conn = createProjectEventsConnection(
+      'p1',
+      (evt) => seen.push(evt),
+      { EventSourceCtor: MockEventSource as unknown as typeof EventSource },
+    );
+    const es = MockEventSource.instances[0]!;
+    es.dispatch('conversation-created', {
+      data: JSON.stringify({
+        type: 'conversation-created',
+        projectId: 'p1',
+        conversationId: 'routine-conv-aaa',
+        title: 'Routine · 8:12 AM',
+        createdAt: 1747109520000,
+      }),
+    });
+    es.dispatch('conversation-created', {
+      data: JSON.stringify({
+        type: 'conversation-created',
+        projectId: 'p1',
+        conversationId: 'routine-conv-bbb',
+        title: 'Routine · 8:13 AM',
+        createdAt: 1747109580000,
+      }),
+    });
+
+    expect(seen.map((e) => e.type === 'conversation-created' ? e.conversationId : null))
+      .toEqual(['routine-conv-aaa', 'routine-conv-bbb']);
+    conn.close();
+  });
+
+  it('ignores malformed conversation-created payloads instead of throwing', () => {
+    const seen: ProjectEvent[] = [];
+    const conn = createProjectEventsConnection(
+      'p1',
+      (evt) => seen.push(evt),
+      { EventSourceCtor: MockEventSource as unknown as typeof EventSource },
+    );
+    const es = MockEventSource.instances[0]!;
+    expect(() => es.dispatch('conversation-created', { data: '{not-json' })).not.toThrow();
+    expect(seen).toEqual([]);
+    conn.close();
+  });
+
   it('reconnects with exponential backoff on error', () => {
     let nextDelay = 0;
     const setTimeoutFn = vi.fn((cb: () => void, ms: number) => {

--- a/packages/contracts/src/sse/chat.ts
+++ b/packages/contracts/src/sse/chat.ts
@@ -24,6 +24,23 @@ export interface LiveArtifactRefreshSsePayload {
   error?: string;
 }
 
+/**
+ * Emitted by the daemon on `/api/projects/:id/events` when a new
+ * conversation is inserted into a project from a path the open
+ * project view can't observe through its own state — currently
+ * Routines "Run now" in reuse-an-existing-project mode (#1361).
+ *
+ * Lives in `packages/contracts` so the daemon producer and the web
+ * consumer share one type and can't drift as the stream grows.
+ */
+export interface ProjectConversationCreatedSsePayload {
+  type: 'conversation-created';
+  projectId: string;
+  conversationId: string;
+  title: string | null;
+  createdAt: number;
+}
+
 export const CHAT_SSE_PROTOCOL_VERSION = 1;
 
 export interface ChatSseStartPayload {


### PR DESCRIPTION
## Summary

Fixes #1361. Likely also addresses #1502 (see below).

When a Routine is configured to **Reuse an existing project** and the user clicks **Run now** while the project view is already open, the daemon creates a new conversation in the project's database row, but the open `ProjectView` has no way to learn it: the project events SSE stream only carries `file-changed` and `live_artifact*` events, and `ProjectView` reloads conversations only when `project.id` changes. The "Run now" appears to do nothing until the user exits and re-enters the project, where the missing conversations finally show up.

This PR adds a `conversation-created` event to the existing project events SSE stream and has `ProjectView` refetch its conversation list when one arrives. The active conversation is intentionally **not** changed — per maintainer guidance on #1361, auto-switching is left for a separate UX decision.

## Per-bullet against the maintainer's PR checklist (#1361)

- ✅ **The event only targets the affected project** — the daemon broadcasts through the existing `activeProjectEventSinks` map keyed by `projectId`. Sinks for other projects do not receive it. The web consumer additionally checks `evt.projectId !== project.id` before acting.
- ✅ **The current project view refreshes the conversation list when that event arrives** — `handleProjectEvent` calls `listConversations(project.id)` and `setConversations(list)`.
- ✅ **It does not change the active conversation automatically** — no call to `setActiveConversationId` in the new code path. The user keeps their current context.
- ✅ **A small test / coverage path for the reuse-existing-project case** — `apps/web/tests/providers/project-events.test.ts` adds three tests: single delivery, concurrent-runs delivery (#1502 coverage), and malformed-payload defensive behavior. Manual repro was driven end-to-end via the packaged app; recording attached below.

## What changed

| File | Purpose |
|---|---|
| `apps/daemon/src/server.ts` | Renamed the (already-generic) `emitProjectLiveArtifactEvent` to `emitProjectEvent`; after `insertConversation` in the routine `setRunHandler`, broadcast `{ type: 'conversation-created', projectId, conversationId, title, createdAt }` through it. |
| `apps/web/src/providers/project-events.ts` | Added `ProjectConversationCreatedEvent` type, extended the `ProjectEvent` union, added an `addEventListener('conversation-created', ...)` that mirrors the existing `file-changed` / `live_artifact` defensive parsing. |
| `apps/web/src/components/ProjectView.tsx` | `handleProjectEvent` handles `conversation-created` by refetching `listConversations` and calling `setConversations` (no active-conversation change). `projectEventToAgentEvent` returns null for the new type so it doesn't get routed into the live-artifact path. |
| `apps/web/tests/providers/project-events.test.ts` | Three new tests (see above). |

Diff: 4 files, +161 −5.

## Likely also addresses #1502

#1502 ("Cannot switch between multiple concurrent runs from the same Routine inside a project") is the same root cause from a different angle: routine-created conversations exist in the backend but aren't surfaced in the already-open project conversation list. Because this PR fires a `conversation-created` event for **every** new routine conversation regardless of how many runs are in flight, concurrent runs targeting the same reused project should now all become visible in the sidebar as they're created.

Per the discussion on #1361, this PR uses the wording **"Likely also addresses #1502"** rather than the auto-closing `Fixes #1502` keyword: #1502 also has a "which run did Open project intend to focus?" deep-link/focus angle that may need a separate follow-up after this lands. The concurrent-runs case is covered by a dedicated test in this PR.

## Before / after

**Before** — from the original issue, with the project view open: clicking `Run now` produces a SUCCEEDED entry in the routine history but the project's conversation list stays unchanged until the user exits and re-enters the project.

**After** — local build of this branch, same flow: clicking `Run now` causes the new routine conversation to appear in the project sidebar within roughly a second, without the user leaving the project. Clicking `Run now` twice in quick succession adds two new conversations, both visible.



## Verified

- `pnpm guard` — clean
- `pnpm --filter @open-design/web typecheck` — clean
- `pnpm --filter @open-design/daemon typecheck` — clean
- `pnpm --filter @open-design/web test` — **1016 tests pass**, including 3 new tests in `tests/providers/project-events.test.ts` (single delivery, concurrent-runs delivery for #1502 coverage, defensive malformed-payload handling).
- Manual end-to-end: built via `pnpm exec tools-pack mac build --to app --portable`, installed locally, reproduced the original bug (with the build immediately before this fix), then verified the same flow succeeds with this fix in place. Both single and concurrent Run-now were exercised against an existing reuse-target project.
