### PR TITLE
fix: Add visual distinction for user messages with right-aligned blue bubbles

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1224,7 +1224,32 @@ code {
   flex: 1;
 }
 .msg.user .role::before { content: ''; }
-.msg.user .user-text { white-space: pre-wrap; color: var(--text); }
+.msg.user {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  margin-left: auto;
+  max-width: 80%;
+}
+.msg.user .role {
+  flex-direction: row-reverse;
+}
+.msg.user .user-text {
+  white-space: pre-wrap;
+  color: white;
+  background: var(--accent, #0066ff);
+  padding: 10px 14px;
+  border-radius: 16px;
+  border-bottom-right-radius: 4px;
+  max-width: 100%;
+}
+.msg.user .user-attachments {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+  margin-bottom: 6px;
+}
 .msg.assistant .prose { margin-top: 4px; }
 .msg .artifact-badge {
   display: inline-block;


### PR DESCRIPTION
Fixes #1518

## Problem

User messages in the chat panel were visually indistinguishable from assistant messages. Both appeared as plain left-aligned text, making it hard to follow the conversation flow.

## Solution

Implemented a common IM pattern where user messages appear on the right in colored bubbles:

- **Right-aligned layout**: User messages now align to the right with 80% max-width
- **Blue bubble background**: Uses `var(--accent)` with white text for high contrast
- **Distinctive styling**: Rounded corners with a sharper bottom-right corner (like iMessage/WhatsApp)
- **Consistent alignment**: Role label and attachments also align to the right

## Changes

### CSS (`apps/web/src/index.css`)

- `.msg.user`: Added flexbox layout with `align-items: flex-end` and `margin-left: auto` for right alignment
- `.msg.user .role`: Reversed flex direction to match right-side layout
- `.msg.user .user-text`: Added blue background, white text, padding, and rounded corners
- `.msg.user .user-attachments`: Aligned attachments to the right

## Visual Result

**Before**: User and assistant messages looked the same (left-aligned, no background)

**After**: 
- User messages: Right-aligned blue bubbles with white text
- Assistant messages: Left-aligned plain text (unchanged)

## Testing

- [x] User messages appear on the right with blue background
- [x] Assistant messages remain on the left (unchanged)
- [x] Attachments align with user messages on the right
- [x] Text wraps correctly within the bubble
- [x] Role labels and timestamps display correctly

## Files Changed

- 1 file modified
- 26 insertions, 1 deletion
- CSS-only fix, no component changes needed