### PR TITLE
fix: Pass skillId to pickAndImport when opening folder

### DIFF
--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -560,7 +560,9 @@ export function NewProjectPanel({
       setImportFolderError(null);
       setImportingFolder(true);
       try {
-        const result = await window.electronAPI!.pickAndImport!();
+        const result = await window.electronAPI!.pickAndImport!({
+          skillId: skillIdForTab,
+        });
         if (!result) return;
         if (result.ok === true) {
           await onImportFolderResponse(result.response);


### PR DESCRIPTION
Fixes #1472

## Problem

When creating a project via **"Open folder"**, the project's `skillId` was never set, even when a default skill (e.g., `dsl-ui-builder` with `default_for: ["prototype"]`) was configured.

Projects created via the **"Create"** button worked correctly — `skillId` was properly set from `skillIdForTab`.

## Root Cause

`NewProjectPanel.tsx` line 563 — `handleOpenFolder()` called `pickAndImport()` with **no arguments**:

```typescript
const result = await window.electronAPI!.pickAndImport!();
```

But the API already accepts an optional init object:

```typescript
pickAndImport?: (init?: {
    name?: string;
    skillId?: string | null;
    designSystemId?: string | null;
}) => Promise<DesktopPickAndImportResult>;
```

`handleCreate()` (line 529) correctly passes `skillId: skillIdForTab`, but `handleOpenFolder()` didn't.

## Solution

Pass `skillId: skillIdForTab` to `pickAndImport()` in `handleOpenFolder()`, matching the behavior of `handleCreate()`:

```typescript
const result = await window.electronAPI!.pickAndImport!({
  skillId: skillIdForTab,
});
```

## Changes

- **File**: `apps/web/src/components/NewProjectPanel.tsx`
- **Line 563**: Changed from `pickAndImport!()` to `pickAndImport!({ skillId: skillIdForTab })`
- **Impact**: Projects created via "Open folder" now receive the same default skill as projects created via the "Create" button

## Testing

### Before
1. Install a skill with `default_for: ["prototype"]`
2. Create a project via "Open folder" → select an empty directory
3. Check the project in SQLite: `SELECT id, name, skillId FROM projects`
4. Result: `skillId` is empty ❌

### After
1. Same steps as above
2. Result: `skillId` is correctly set to the default skill ✅

## Files Changed

- 1 file modified
- 3 insertions, 1 deletion
- Single-line fix with clear impact