### PR TITLE
fix: Make ACP timeout settings configurable via environment variables

### DIFF
--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -3,8 +3,8 @@ import type { Writable } from 'node:stream';
 import path from 'node:path';
 
 const ACP_PROTOCOL_VERSION = 1;
-const DEFAULT_TIMEOUT_MS = 15_000;
-const DEFAULT_STAGE_TIMEOUT_MS = 180_000;
+const DEFAULT_TIMEOUT_MS = Number(process.env.OD_ACP_TIMEOUT_MS) || 15_000;
+const DEFAULT_STAGE_TIMEOUT_MS = Number(process.env.OD_ACP_STAGE_TIMEOUT_MS) || 180_000;
 
 type JsonRpcId = string | number;
 type JsonObject = Record<string, unknown>;


### PR DESCRIPTION
Fixes #1469

## Problem

The current hardcoded ACP timeout values were too restrictive for local and mid-scale inference environments:

```typescript
const DEFAULT_TIMEOUT_MS = 15_000;        // 15 seconds
const DEFAULT_STAGE_TIMEOUT_MS = 180_000; // 3 minutes
```

While these defaults work well for:
- ✅ Cloud-hosted LLM APIs (OpenAI, Anthropic, etc.)
- ✅ Low-latency enterprise inference endpoints

They become critical blockers for:
- ❌ Local inference servers (llama.cpp, vLLM, Ollama)
- ❌ Mid-sized lab deployments
- ❌ Custom tuned models with higher first-token latency
- ❌ Long reasoning chains

### Impact

In practice, these timeouts caused:
- Premature ACP session termination
- False "model stalled" errors
- Broken agent workflows despite successful model execution
- **Inability to use Open Design reliably with local models**

This effectively excluded a growing core audience: developers and labs running local or hybrid inference stacks.

## Solution

Made timeout values configurable via environment variables while maintaining backward compatibility:

### Environment Variables

- **`OD_ACP_TIMEOUT_MS`**: Initial connection timeout (default: `15000` ms)
- **`OD_ACP_STAGE_TIMEOUT_MS`**: Stage execution timeout (default: `180000` ms)

### Usage Example

```bash
# For local inference with longer response times
export OD_ACP_TIMEOUT_MS=1800000       # 30 minutes
export OD_ACP_STAGE_TIMEOUT_MS=3600000 # 60 minutes

# Then start the daemon
pnpm daemon-dev
```

### Real-world Example

From the issue reporter:

> In a local setup using a tuned inference pipeline, the default ACP timeout caused consistent failures at ~180 seconds, despite the model actively generating valid responses.
>
> After setting these environment variables to 30/60 minutes:
> - ✅ ACP sessions complete successfully
> - ✅ Long reasoning chains work correctly
> - ✅ Open Design becomes fully usable with local models

## Changes

### `apps/daemon/src/acp.ts`

```diff
-const DEFAULT_TIMEOUT_MS = 15_000;
-const DEFAULT_STAGE_TIMEOUT_MS = 180_000;
+const DEFAULT_TIMEOUT_MS = Number(process.env.OD_ACP_TIMEOUT_MS) || 15_000;
+const DEFAULT_STAGE_TIMEOUT_MS = Number(process.env.OD_ACP_STAGE_TIMEOUT_MS) || 180_000;
```

## Benefits

- ✅ **Supports local and hybrid inference setups**
- ✅ **Prevents unnecessary agent failures**
- ✅ **Makes Open Design truly backend-agnostic for LLM inference speed**
- ✅ **Zero breaking changes** (defaults unchanged)
- ✅ **Simple implementation** (2 lines changed)
- ✅ **Immediate impact** for local model users

## Testing

### Default Behavior (unchanged)
```bash
# No env vars set
pnpm daemon-dev
# Uses 15s and 180s timeouts (original behavior)
```

### Custom Timeouts
```bash
# Set custom timeouts
export OD_ACP_TIMEOUT_MS=1800000
export OD_ACP_STAGE_TIMEOUT_MS=3600000
pnpm daemon-dev
# Uses 30min and 60min timeouts
```

### Invalid Values (fallback to defaults)
```bash
export OD_ACP_TIMEOUT_MS=invalid
pnpm daemon-dev
# Number("invalid") returns NaN, || operator falls back to 15000
```

## Future Enhancements (out of scope)

As suggested in the issue, a future PR could add:
- Advanced Settings UI section exposing these timeouts
- Config file support (`.od/config.json`)
- Per-project timeout overrides

This PR focuses on the immediate fix: making timeouts configurable for users who need it now.

## Files Changed

- 1 file modified
- 2 insertions, 2 deletions
- Zero breaking changes

---

**Credit**: Issue reported by @xWaLeEdOoOx (Waleed Kh. Tolbah) with clear problem analysis and suggested solution.