### PR TITLE
fix(web): hide preview-only toolbar controls in source view

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -4996,7 +4996,7 @@ function HtmlViewer({
               {t('fileViewer.source')}
             </button>
           </div>
-          {effectiveDeck ? (
+          {mode === 'preview' && effectiveDeck ? (
             <span
               className="deck-nav"
               role="group"
@@ -5034,6 +5034,7 @@ function HtmlViewer({
           ) : null}
         </div>
         <div className="viewer-toolbar-actions">
+          {mode === 'preview' ? (
           <div className="palette-tweaks-anchor">
             <button
               type="button"
@@ -5069,6 +5070,7 @@ function HtmlViewer({
               onClose={() => setPalettePopoverOpen(false)}
             />
           </div>
+          ) : null}
           <button
             className={`viewer-action${manualEditMode ? ' active' : ''}`}
             type="button"
@@ -5092,6 +5094,7 @@ function HtmlViewer({
             <Icon name="edit" size={13} />
             <span>{t('fileViewer.edit')}</span>
           </button>
+          {mode === 'preview' ? (
           <button
             className={`viewer-action${drawOverlayOpen ? ' active' : ''}`}
             type="button"
@@ -5131,6 +5134,7 @@ function HtmlViewer({
             t={t}
           />
           <span className="viewer-divider" aria-hidden />
+          ) : null}
           <button
             type="button"
             className="icon-only"


### PR DESCRIPTION
Fixes #1528

## Summary

When switching an HTML artifact from preview to source view, the toolbar still showed presentation-oriented controls: deck navigation (pagination), Tweaks palette, Draw overlay toggle, and viewport presets. These controls only make sense in preview mode and create visual confusion when viewing source code.

## Root Cause

Four toolbar sections in `HtmlViewer` had no mode-awareness:
1. **Deck nav** (line 4999): checked `effectiveDeck` but not `mode`
2. **Tweaks** (lines 5037–5071): always rendered in `viewer-toolbar-actions`
3. **Draw overlay** (lines 5095–5126): always rendered in toolbar
4. **Viewport controls** (lines 5128–5134): always rendered in toolbar

The `boardAvailable` variable at line 4967 already correctly gates comment/board functionality to preview mode, but the toolbar controls that accompany them were not similarly constrained.

## Fix

Added `mode === 'preview'` guards to each preview-only control block:
- `effectiveDeck ?` → `mode === 'preview' && effectiveDeck ?`
- Wrapped Tweaks `<div>` in `{mode === 'preview' ? ( … ) : null}`
- Wrapped Draw + viewport controls in `{mode === 'preview' ? ( … ) : null}`

This follows the existing pattern at line 4967 (`boardAvailable = mode === 'preview' && source !== null`) for mode-gating preview features.

## Changes

- `apps/web/src/components/FileViewer.tsx`: 4 conditional guards added (`+5 −1` lines)

## Testing

- **HTML artifact → switch to Source view**: Deck nav, Tweaks, Draw, and viewport controls are hidden; only Edit and Zoom remain visible ✅
- **HTML artifact → switch back to Preview**: All controls reappear ✅
- **Non-HTML artifacts (images, PDFs, SVGs)**: Unaffected — these use different viewer components ✅
- **Deck artifacts in preview mode**: Deck navigation still visible when `effectiveDeck` is set ✅