### PR TITLE
feat: Add mouse wheel zoom support to preview

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -771,6 +771,26 @@ export function LiveArtifactViewer({
     setZoom((z) => Math.max(25, Math.min(200, z + delta)));
   }
 
+  // Mouse wheel zoom support
+  useEffect(() => {
+    const previewBody = previewBodyRef.current;
+    if (!previewBody || mode !== 'preview') return;
+
+    const handleWheel = (e: WheelEvent) => {
+      // Only zoom when Ctrl/Cmd is pressed (standard zoom gesture)
+      if (!e.ctrlKey && !e.metaKey) return;
+      
+      e.preventDefault();
+      
+      // deltaY < 0 means scroll up (zoom in), deltaY > 0 means scroll down (zoom out)
+      const delta = e.deltaY < 0 ? 10 : -10;
+      bumpZoom(delta);
+    };
+
+    previewBody.addEventListener('wheel', handleWheel, { passive: false });
+    return () => previewBody.removeEventListener('wheel', handleWheel);
+  }, [mode]);
+
   async function handleRefresh() {
     if (refreshing) return;
     setRefreshing(true);
@@ -4810,6 +4830,26 @@ function HtmlViewer({
   function bumpZoom(delta: number) {
     setZoom((z) => Math.max(25, Math.min(200, z + delta)));
   }
+
+  // Mouse wheel zoom support
+  useEffect(() => {
+    const previewBody = previewBodyRef.current;
+    if (!previewBody || mode !== 'preview') return;
+
+    const handleWheel = (e: WheelEvent) => {
+      // Only zoom when Ctrl/Cmd is pressed (standard zoom gesture)
+      if (!e.ctrlKey && !e.metaKey) return;
+      
+      e.preventDefault();
+      
+      // deltaY < 0 means scroll up (zoom in), deltaY > 0 means scroll down (zoom out)
+      const delta = e.deltaY < 0 ? 10 : -10;
+      bumpZoom(delta);
+    };
+
+    previewBody.addEventListener('wheel', handleWheel, { passive: false });
+    return () => previewBody.removeEventListener('wheel', handleWheel);
+  }, [mode]);
 
   function clearBoardComposer() {
     setActiveCommentTarget(null);


### PR DESCRIPTION
Fixes #1398

## Problem

Preview zoom currently only supports clicking the zoom controls and does not support mouse-wheel or similar direct zoom interactions. This makes zooming feel **slow and unnatural** during design review workflows.

### Current Behavior

- ❌ Users can only zoom via button clicks
- ❌ No mouse wheel support
- ❌ No trackpad gesture support
- ❌ Slower and less fluid than expected for a modern preview surface

### Expected Behavior

- ✅ Support mouse wheel zoom with modifier key
- ✅ Match standard OS/browser zoom conventions
- ✅ Make zoom a high-frequency action feel natural

---

## Solution

Added **mouse wheel zoom support** with **Ctrl/Cmd modifier key** (standard zoom gesture) to both preview components:

1. **LiveArtifactViewer** (line 773-792)
2. **HtmlViewer** (line 4833-4852)

### Implementation Details

#### Added `useEffect` hooks

```typescript
useEffect(() => {
  const previewBody = previewBodyRef.current;
  if (!previewBody || mode !== 'preview') return;

  const handleWheel = (e: WheelEvent) => {
    // Only zoom when Ctrl/Cmd is pressed (standard zoom gesture)
    if (!e.ctrlKey && !e.metaKey) return;
    
    e.preventDefault();
    
    // deltaY < 0 means scroll up (zoom in), deltaY > 0 means scroll down (zoom out)
    const delta = e.deltaY < 0 ? 10 : -10;
    bumpZoom(delta);
  };

  previewBody.addEventListener('wheel', handleWheel, { passive: false });
  return () => previewBody.removeEventListener('wheel', handleWheel);
}, [mode]);
```

#### Key Features

- **Modifier key required**: Only zoom when **Ctrl** (Windows/Linux) or **Cmd** (Mac) is pressed
- **Scroll direction**:
  - Scroll **up** (deltaY < 0) → Zoom **in** (+10%)
  - Scroll **down** (deltaY > 0) → Zoom **out** (-10%)
- **Prevent default**: `preventDefault()` to avoid page scroll during zoom
- **Cleanup**: Remove event listener on unmount and when mode changes
- **Mode-aware**: Only active in **preview mode** (not in source/code mode)

---

## Behavior

### Zoom Interaction

| Action | Result |
|--------|--------|
| **Ctrl/Cmd + Scroll Up** | Zoom in (+10%) |
| **Ctrl/Cmd + Scroll Down** | Zoom out (-10%) |
| **Scroll without modifier** | Normal page scroll (unchanged) |
| **Switch to source mode** | Wheel zoom disabled |

### Zoom Range

- **Min**: 25%
- **Max**: 200%
- **Increment**: 10% per scroll tick
- **Same as button controls** (no behavior change)

---

## Changes

### Files Modified

- **1 file changed**
- **40 insertions**

### Breakdown

**apps/web/src/components/FileViewer.tsx**:
- Line 773-792: Added wheel zoom to `LiveArtifactViewer`
- Line 4833-4852: Added wheel zoom to `HtmlViewer`

---

## Benefits

- ✅ **Natural zoom interaction**: Matches browser/OS conventions (Ctrl/Cmd + Wheel)
- ✅ **Faster design review**: High-frequency action feels fluid
- ✅ **Cross-platform**: Works on Windows/Linux (Ctrl) and Mac (Cmd)
- ✅ **No breaking changes**: Button controls still work exactly as before
- ✅ **Mode-aware**: Only active in preview mode (not in source/code)
- ✅ **Smooth incremental zooming**: 10% per scroll tick

---

## Testing

### Manual Testing Steps

1. Open a file in preview mode
2. Hold **Ctrl** (or **Cmd** on Mac)
3. **Scroll mouse wheel up** → Verify preview zooms in
4. **Scroll mouse wheel down** → Verify preview zooms out
5. Release Ctrl/Cmd → Verify normal scrolling resumes
6. Switch to **source mode** → Verify wheel zoom is disabled
7. Zoom to **25%** → Verify cannot zoom out further
8. Zoom to **200%** → Verify cannot zoom in further
9. Try without modifier key → Verify normal scroll (no zoom)

### Expected Behavior

- ✅ Ctrl/Cmd + Wheel zooms the preview
- ✅ Zoom increments by 10% per scroll tick
- ✅ Zoom stays within 25%-200% range
- ✅ Normal scroll works without modifier key
- ✅ Wheel zoom disabled in source/code mode
- ✅ Button controls still work
- ✅ No console errors

---

**Priority**: P2 (Usability improvement)
**Impact**: Low-risk enhancement with high UX improvement