### PR TITLE
Recover Critique Theater stack

### DIFF
--- a/.github/workflows/critique-conformance.yml
+++ b/.github/workflows/critique-conformance.yml
@@ -1,0 +1,72 @@
+# Nightly Critique Theater conformance run (Phase 16).
+#
+# Feeds every registered adapter through the conformance harness and
+# writes one ConformanceDay row per adapter into the daemon's data
+# directory. The /api/critique/conformance route reads the rolling
+# 14-day window and surfaces the ratchet's promote / hold / demote
+# recommendation.
+#
+# Cadence: 03:00 UTC every day. The schedule is intentionally outside
+# the busy generation window so the cron does not contend with real
+# user runs for adapter rate-limit budgets.
+#
+# Operator workflow: a follow-up workflow consumes
+# /api/critique/conformance and either auto-flips
+# OD_CRITIQUE_ROLLOUT_PHASE or alerts a human. That step is deploy-
+# pipeline-specific and intentionally not built here.
+
+name: critique-conformance
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch: {}
+
+jobs:
+  run:
+    name: nightly conformance + ratchet snapshot
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install workspace
+        run: pnpm install --frozen-lockfile
+
+      - name: Build daemon
+        run: pnpm --filter @open-design/daemon build
+
+      # The full adapter sweep lives in a follow-up that wires every
+      # production agent CLI into the harness; here we drive the
+      # synthetic-good and synthetic-bad fixtures so the workflow
+      # proves the cron plumbing end-to-end (install + build + harness
+      # invocation + history write) without depending on every adapter
+      # binary being installable in the CI image. The runner exits
+      # non-zero on any thrown error so the workflow fails loudly
+      # instead of uploading an empty history snapshot.
+      - name: Run conformance harness (synthetic adapters)
+        run: |
+          node --import tsx apps/daemon/src/critique/__fixtures__/run-nightly.ts
+
+      - name: Upload history snapshot
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: critique-conformance-${{ github.run_id }}
+          path: .od/conformance/
+          if-no-files-found: ignore
+          retention-days: 30

--- a/.github/workflows/critique-conformance.yml
+++ b/.github/workflows/critique-conformance.yml
@@ -1,16 +1,18 @@
 # Nightly Critique Theater conformance run (Phase 16).
 #
-# Feeds every registered adapter through the conformance harness and
-# writes one ConformanceDay row per adapter into the daemon's data
-# directory. The /api/critique/conformance route reads the rolling
-# 14-day window and surfaces the ratchet's promote / hold / demote
-# recommendation.
+# Feeds synthetic adapters through the conformance harness and uploads
+# the generated history as a validation snapshot artifact.
+#
+# This CI job does not publish data into any deployed daemon. Production
+# ratchet history must be written by a deployment-local cron, or by an
+# explicit ingest step that runs with OD_DATA_DIR pointed at the daemon
+# data directory that serves /api/critique/conformance.
 #
 # Cadence: 03:00 UTC every day. The schedule is intentionally outside
 # the busy generation window so the cron does not contend with real
 # user runs for adapter rate-limit budgets.
 #
-# Operator workflow: a follow-up workflow consumes
+# Operator workflow: a deployment-local follow-up consumes
 # /api/critique/conformance and either auto-flips
 # OD_CRITIQUE_ROLLOUT_PHASE or alerts a human. That step is deploy-
 # pipeline-specific and intentionally not built here.
@@ -24,7 +26,7 @@ on:
 
 jobs:
   run:
-    name: nightly conformance + ratchet snapshot
+    name: validation conformance snapshot
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -37,12 +37,14 @@
     "@open-design/platform": "workspace:*",
     "@open-design/sidecar": "workspace:*",
     "@open-design/sidecar-proto": "workspace:*",
+    "@opentelemetry/api": "^1.9.0",
     "better-sqlite3": "^12.9.0",
     "blake3-wasm": "2.1.5",
     "chokidar": "^5.0.0",
     "express": "^4.19.2",
     "jszip": "^3.10.1",
     "multer": "^2.1.1",
+    "prom-client": "^15.1.0",
     "undici": "^7.16.0"
   },
   "devDependencies": {

--- a/apps/daemon/src/critique/__fixtures__/adapters/synthetic-bad.ts
+++ b/apps/daemon/src/critique/__fixtures__/adapters/synthetic-bad.ts
@@ -11,21 +11,23 @@
  */
 
 import { readFileSync } from 'node:fs';
-import path from 'node:path';
 import url from 'node:url';
 
-const __filename = url.fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+/**
+ * Module-URL-anchored fixture path (mirrors `synthetic-good.ts`; see
+ * lefarcen P2 on PR #1317 for the rationale).
+ */
+export const SYNTHETIC_BAD_FIXTURE_URL = new URL(
+  '../v1/malformed-unbalanced.txt',
+  import.meta.url,
+);
 
-export const SYNTHETIC_BAD_FIXTURE_PATH = path.join(
-  __dirname,
-  '..',
-  'v1',
-  'malformed-unbalanced.txt',
+export const SYNTHETIC_BAD_FIXTURE_PATH = url.fileURLToPath(
+  SYNTHETIC_BAD_FIXTURE_URL,
 );
 
 export function syntheticBadTranscript(): string {
-  return readFileSync(SYNTHETIC_BAD_FIXTURE_PATH, 'utf8');
+  return readFileSync(SYNTHETIC_BAD_FIXTURE_URL, 'utf8');
 }
 
 export async function* syntheticBadStream(): AsyncIterable<string> {

--- a/apps/daemon/src/critique/__fixtures__/adapters/synthetic-good.ts
+++ b/apps/daemon/src/critique/__fixtures__/adapters/synthetic-good.ts
@@ -16,26 +16,34 @@
  */
 
 import { readFileSync } from 'node:fs';
-import path from 'node:path';
 import url from 'node:url';
 
-const __filename = url.fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+/**
+ * Resolve the fixture relative to *this module's URL* rather than `cwd`.
+ * `new URL(relative, import.meta.url)` is the module-anchored equivalent
+ * of `path.join(__dirname, relative)` and is the form
+ * lefarcen P2 on PR #1317 asked for: a directory move of either this
+ * file or the fixture would surface as a clear ENOENT pointing at this
+ * exact line rather than a stale `path.join('..', 'v1', ...)` that
+ * silently resolves to the wrong place.
+ */
+export const SYNTHETIC_GOOD_FIXTURE_URL = new URL(
+  '../v1/happy-3-rounds.txt',
+  import.meta.url,
+);
 
-/** Path of the bundled fixture so test harnesses can `readFile` it directly. */
-export const SYNTHETIC_GOOD_FIXTURE_PATH = path.join(
-  __dirname,
-  '..',
-  'v1',
-  'happy-3-rounds.txt',
+/** String form of the fixture path so tests and tooling can still `path.join` against it. */
+export const SYNTHETIC_GOOD_FIXTURE_PATH = url.fileURLToPath(
+  SYNTHETIC_GOOD_FIXTURE_URL,
 );
 
 /**
  * Read the canonical happy-path transcript synchronously. The file ships
- * with the daemon source so the call cannot fail in a packaged build.
+ * with the daemon source so the call cannot fail in a packaged build;
+ * `readFileSync` accepts URL objects directly.
  */
 export function syntheticGoodTranscript(): string {
-  return readFileSync(SYNTHETIC_GOOD_FIXTURE_PATH, 'utf8');
+  return readFileSync(SYNTHETIC_GOOD_FIXTURE_URL, 'utf8');
 }
 
 /**

--- a/apps/daemon/src/critique/__fixtures__/run-nightly.ts
+++ b/apps/daemon/src/critique/__fixtures__/run-nightly.ts
@@ -1,0 +1,104 @@
+/**
+ * Nightly conformance entrypoint (Phase 16).
+ *
+ * The GitHub Actions workflow at `.github/workflows/critique-conformance.yml`
+ * invokes this script once a day. It runs the conformance harness
+ * against every synthetic adapter, classifies the outcome, and writes
+ * one `ConformanceDay` row per adapter into the daemon's history dir.
+ * The `/api/critique/conformance` route reads the rolling 14-day
+ * window and the ratchet returns its promote / hold / demote
+ * recommendation.
+ *
+ * Why synthetic-only for v1: the full production-adapter sweep needs
+ * every agent CLI installable in the CI image. Wiring that is its own
+ * focused follow-up. The synthetic adapters prove the cron plumbing
+ * (install + build + harness invocation + history write) without the
+ * dependency on third-party binaries. A real adapter is a one-line
+ * addition to `ADAPTERS` below once the harness wraps its stdout.
+ *
+ * Exit code: 0 only when every adapter ran (regardless of outcome).
+ * A thrown error or a missing fixture exits non-zero so the workflow
+ * fails the job instead of uploading an empty history snapshot
+ * (Codex + lefarcen P1 on PR #1499 caught the prior `|| echo` mask).
+ */
+
+import path from 'node:path';
+
+import { runAdapterConformance } from '../conformance.js';
+import { appendConformanceDay } from '../conformance-history.js';
+import type { ConformanceDay } from '../ratchet.js';
+import { syntheticGoodStream } from './adapters/synthetic-good.js';
+import { syntheticBadStream } from './adapters/synthetic-bad.js';
+
+interface NightlyAdapter {
+  id: string;
+  source: () => AsyncIterable<string>;
+}
+
+const ADAPTERS: readonly NightlyAdapter[] = [
+  { id: 'synthetic-good', source: syntheticGoodStream },
+  { id: 'synthetic-bad', source: syntheticBadStream },
+];
+
+/**
+ * Anchor the run at the project's `.od/` data dir by default; the
+ * Home Manager / NixOS / Playwright runtimes that already set
+ * `OD_DATA_DIR` keep their isolation here too.
+ */
+function resolveDataDir(): string {
+  const override = process.env.OD_DATA_DIR;
+  if (override && override.length > 0) return path.resolve(override);
+  return path.resolve(process.cwd(), '.od');
+}
+
+function isoDay(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+async function runOne(adapter: NightlyAdapter, dataDir: string, date: string): Promise<void> {
+  const outcome = await runAdapterConformance({
+    adapterId: adapter.id,
+    runId: `nightly-${date}-${adapter.id}`,
+    source: adapter.source(),
+  });
+  // shippedRate is 0 or 1 per single-run synthetic adapter; the
+  // production sweep that follows will run N briefs and the rate
+  // becomes a real fraction.
+  const shipped = outcome.kind === 'shipped' ? 1 : 0;
+  // A run is "clean" when zero parser_warning events were yielded
+  // along the way. The harness already collects every event for the
+  // outcome, so we walk it here rather than re-parsing.
+  const hadParserWarning = outcome.events.some((e) => e.type === 'parser_warning');
+  const cleanParse = hadParserWarning ? 0 : 1;
+  const row: ConformanceDay = {
+    date,
+    adapter: adapter.id,
+    shippedRate: shipped,
+    cleanParseRate: cleanParse,
+    totalRuns: 1,
+  };
+  await appendConformanceDay(dataDir, row);
+  // eslint-disable-next-line no-console
+  console.log(
+    `[nightly] ${adapter.id} ${outcome.kind}`
+      + (outcome.kind === 'degraded' || outcome.kind === 'failed'
+        ? ` (${'reason' in outcome ? outcome.reason : outcome.cause})`
+        : ''),
+  );
+}
+
+async function main(): Promise<void> {
+  const dataDir = resolveDataDir();
+  const date = isoDay(new Date());
+  // eslint-disable-next-line no-console
+  console.log(`[nightly] writing to ${path.join(dataDir, 'conformance')} for ${date}`);
+  for (const adapter of ADAPTERS) {
+    await runOne(adapter, dataDir, date);
+  }
+}
+
+main().catch((err) => {
+  // eslint-disable-next-line no-console
+  console.error('[nightly] failed:', err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/apps/daemon/src/critique/__fixtures__/run-nightly.ts
+++ b/apps/daemon/src/critique/__fixtures__/run-nightly.ts
@@ -2,12 +2,16 @@
  * Nightly conformance entrypoint (Phase 16).
  *
  * The GitHub Actions workflow at `.github/workflows/critique-conformance.yml`
- * invokes this script once a day. It runs the conformance harness
- * against every synthetic adapter, classifies the outcome, and writes
- * one `ConformanceDay` row per adapter into the daemon's history dir.
- * The `/api/critique/conformance` route reads the rolling 14-day
- * window and the ratchet returns its promote / hold / demote
- * recommendation.
+ * invokes this script once a day as a validation snapshot. It runs the
+ * conformance harness against every synthetic adapter, classifies the
+ * outcome, and writes one `ConformanceDay` row per adapter into the
+ * configured data dir.
+ *
+ * CI uploads that directory as an artifact only; it does not publish
+ * the rows into any deployed daemon. Production ratchet history must
+ * be written by a deployment-local cron, or by an explicit ingest step
+ * that runs with OD_DATA_DIR pointed at the daemon data directory that
+ * serves `/api/critique/conformance`.
  *
  * Why synthetic-only for v1: the full production-adapter sweep needs
  * every agent CLI installable in the CI image. Wiring that is its own

--- a/apps/daemon/src/critique/adapter-degraded.ts
+++ b/apps/daemon/src/critique/adapter-degraded.ts
@@ -16,6 +16,8 @@
 
 import type { DegradedReason } from '@open-design/contracts/critique';
 
+import { critiqueDegradedTotal } from '../metrics/index.js';
+
 export type DegradedSource = 'conformance' | 'orchestrator' | 'manual';
 
 export interface DegradedEntry {
@@ -65,6 +67,13 @@ export function markDegraded(
     expiresAtMs: markedAtMs + ttlMs,
   };
   store.set(adapterId, entry);
+  // Phase 12: every degraded mark increments the Prometheus counter so
+  // the dashboard's "adapter health" panel reflects the same rate the
+  // orchestrator and conformance harness observe. Bump is unconditional
+  // (every call records, including overwrites of a still-live entry)
+  // because the dashboard rate query divides over the time window, not
+  // over distinct adapters.
+  critiqueDegradedTotal.inc({ reason, adapter: adapterId });
   return entry;
 }
 

--- a/apps/daemon/src/critique/conformance-history.ts
+++ b/apps/daemon/src/critique/conformance-history.ts
@@ -1,0 +1,133 @@
+/**
+ * Conformance history persistence (Phase 16).
+ *
+ * The nightly cron writes one `ConformanceDay` row per adapter per day
+ * via `appendConformanceDay`. The `/api/critique/conformance` route
+ * reads the rolling N-day window via `readConformanceHistory` and
+ * feeds it into the `evaluateRollout` ratchet.
+ *
+ * Storage shape: append-only JSON-lines under
+ * `<dataDir>/conformance/<adapter>/<date>.jsonl`. One file per adapter
+ * per day so a corrupted line in one file cannot poison the read for
+ * another adapter / another day. JSON-lines (rather than a single JSON
+ * blob) so a cron interruption mid-write leaves a recoverable file:
+ * the writer always appends complete lines, and the reader drops any
+ * line that fails to parse rather than throwing.
+ *
+ * The path layout is intentionally directory-per-adapter so a future
+ * operator action like "purge all history for adapter X" is one `rm
+ * -rf`, not a grep + rewrite across a mixed-adapter file.
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import type { ConformanceDay } from './ratchet.js';
+
+/**
+ * Where conformance history lives, relative to the daemon's `.od` data
+ * dir. Wrapped in a function so a future override (env var, test seam)
+ * can swap it without rewriting call sites.
+ */
+export function conformanceHistoryDir(dataDir: string): string {
+  return path.join(dataDir, 'conformance');
+}
+
+function isoDay(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function adapterDir(dataDir: string, adapter: string): string {
+  return path.join(conformanceHistoryDir(dataDir), adapter);
+}
+
+function dayFile(dataDir: string, adapter: string, date: string): string {
+  return path.join(adapterDir(dataDir, adapter), `${date}.jsonl`);
+}
+
+/**
+ * Append one conformance row to the day's file. Idempotent in the
+ * weak sense: calling twice for the same `(adapter, date)` appends two
+ * rows, and the reader keeps the last entry per (adapter, date) so a
+ * retry-after-failure cron produces the right answer. The strong-sense
+ * fix (dedupe before appending) is deliberately not v1 scope; it would
+ * require a read-modify-write cycle whose cost grows with history
+ * size.
+ */
+export async function appendConformanceDay(
+  dataDir: string,
+  row: ConformanceDay,
+): Promise<void> {
+  const dir = adapterDir(dataDir, row.adapter);
+  await fs.mkdir(dir, { recursive: true });
+  const file = dayFile(dataDir, row.adapter, row.date);
+  const line = JSON.stringify(row) + '\n';
+  await fs.appendFile(file, line, 'utf8');
+}
+
+/**
+ * Read every `ConformanceDay` row in the trailing `windowDays` ending
+ * today (inclusive). Returns rows from every adapter in arbitrary
+ * order; the evaluator aggregates them per day.
+ *
+ * Missing adapter directories, missing day files, and malformed lines
+ * all collapse to "skip this row": a cron that has not run yet for a
+ * day is data missing, not data wrong, and the evaluator handles
+ * missing days by returning `hold` (insufficient data).
+ */
+export async function readConformanceHistory(
+  dataDir: string,
+  windowDays: number,
+  now: Date = new Date(),
+): Promise<ConformanceDay[]> {
+  const root = conformanceHistoryDir(dataDir);
+  let adapters: string[];
+  try {
+    adapters = await fs.readdir(root);
+  } catch {
+    return [];
+  }
+
+  const dates: string[] = [];
+  for (let i = 0; i < windowDays; i++) {
+    const d = new Date(now.getTime() - i * 24 * 60 * 60 * 1000);
+    dates.push(isoDay(d));
+  }
+
+  const out: ConformanceDay[] = [];
+  for (const adapter of adapters) {
+    for (const date of dates) {
+      let body: string;
+      try {
+        body = await fs.readFile(dayFile(dataDir, adapter, date), 'utf8');
+      } catch {
+        continue;
+      }
+      // Keep the last entry per (adapter, date) so a retry-after-failure
+      // cron produces the right answer without a dedupe pass at write
+      // time. JSON-lines are read top-down; we overwrite as we go.
+      let lastForToday: ConformanceDay | null = null;
+      for (const line of body.split('\n')) {
+        if (line.length === 0) continue;
+        try {
+          const candidate = JSON.parse(line) as unknown;
+          if (
+            candidate
+            && typeof candidate === 'object'
+            && typeof (candidate as ConformanceDay).date === 'string'
+            && typeof (candidate as ConformanceDay).adapter === 'string'
+            && Number.isFinite((candidate as ConformanceDay).shippedRate)
+            && Number.isFinite((candidate as ConformanceDay).cleanParseRate)
+            && Number.isFinite((candidate as ConformanceDay).totalRuns)
+          ) {
+            lastForToday = candidate as ConformanceDay;
+          }
+        } catch {
+          /* drop malformed lines */
+        }
+      }
+      if (lastForToday !== null) out.push(lastForToday);
+    }
+  }
+  return out;
+}

--- a/apps/daemon/src/critique/conformance.ts
+++ b/apps/daemon/src/critique/conformance.ts
@@ -19,9 +19,37 @@
  * Those policies live in the scheduler that calls this helper N times
  * across the adapter × template matrix; keeping the harness scoped to
  * a single run makes it testable in isolation.
+ *
+ * Classification rules (each row that matches wins, top to bottom):
+ *
+ *   1. The parser threw a MalformedBlockError / OversizeBlockError /
+ *      MissingArtifactError → degraded with that reason.
+ *   2. The adapter source threw any other error → failed
+ *      (`unexpected_error`).
+ *   3. The parser yielded a `parser_warning` event anywhere in the
+ *      stream (before OR after `ship`) → degraded (`parser_warning`).
+ *      The parser tolerated a soft violation (weak debate, unknown
+ *      role, clamped score, composite mismatch, duplicate ship) but
+ *      the conformance gate treats any of those as a "this adapter
+ *      is not protocol-clean" signal (lefarcen P2 on PR #1316,
+ *      tightened to post-ship warnings in lefarcen P2 on PR #1316
+ *      follow-up: the parser emits `duplicate_ship` AFTER the first
+ *      ship event yields, so the harness must drain the rest of the
+ *      stream before classifying instead of returning at first ship).
+ *   4. The parser yielded a `ship` event but the cast declared by
+ *      `run_started` did not all emit `panelist_close` IN THE
+ *      SHIPPING ROUND → degraded (`incomplete_panel`). The parser
+ *      only enforces the round-1 designer-artifact invariant; the
+ *      harness is what catches a ship that skipped panelists or
+ *      reused earlier-round closes to fake a complete cast (codex
+ *      P2 on PR #1316; per-round bucketing added in lefarcen P2 on
+ *      PR #1316 follow-up).
+ *   5. The parser yielded a `ship` event with a complete panel and no
+ *      parser warnings → shipped.
+ *   6. The stream ended without a `ship` event → failed (`no_ship`).
  */
 
-import type { PanelEvent } from '@open-design/contracts/critique';
+import type { DegradedReason, PanelEvent, PanelistRole } from '@open-design/contracts/critique';
 
 import { parseCritiqueStream, type ShipArtifactPayload } from './parser.js';
 import {
@@ -34,9 +62,39 @@ import {
   markDegraded,
 } from './adapter-degraded.js';
 
+/**
+ * Local degraded reasons. `'parser_warning'` and `'incomplete_panel'`
+ * are conformance-harness-only: they describe a stream the contracts
+ * `DegradedReason` does not currently model as a discrete value. The
+ * adapter-degraded registry stores the closest contracts reason via
+ * `toContractReason` below, so a downstream listing of degraded
+ * adapters still uses the wire-shape enum.
+ */
+export type ConformanceDegradedReason =
+  | 'malformed_block'
+  | 'oversize_block'
+  | 'missing_artifact'
+  | 'parser_warning'
+  | 'incomplete_panel';
+
 export type ConformanceOutcome =
-  | { kind: 'shipped'; round: number; composite: number; events: PanelEvent[] }
-  | { kind: 'degraded'; reason: 'malformed_block' | 'oversize_block' | 'missing_artifact'; events: PanelEvent[] }
+  | {
+      kind: 'shipped';
+      round: number;
+      composite: number;
+      events: PanelEvent[];
+      /**
+       * Artifact bytes the parser handed back via the `onArtifact`
+       * callback for the SHIP event. Callers that want to pin
+       * MIME / byte-length / hash on the nightly cycle read this
+       * directly. Always set on `shipped` because the parser rejects
+       * a missing-artifact SHIP with `MissingArtifactError` upstream
+       * (lefarcen P2 on PR #1317: previously captured-but-never-
+       * returned, masked by a `void shipPayload` lint trick).
+       */
+      artifact: ShipArtifactPayload | null;
+    }
+  | { kind: 'degraded'; reason: ConformanceDegradedReason; events: PanelEvent[] }
   | { kind: 'failed'; cause: 'no_ship' | 'unexpected_error'; events: PanelEvent[]; error?: string };
 
 export interface RunConformanceParams {
@@ -46,6 +104,22 @@ export interface RunConformanceParams {
   parserMaxBlockBytes?: number;
   projectId?: string;
   artifactId?: string;
+}
+
+/**
+ * Map a local conformance reason back to a contracts `DegradedReason`
+ * so the adapter-degraded registry stays consistent with the wire
+ * enum. Parser warnings collapse to `malformed_block` (the closest
+ * "the stream is not well-formed" reason) and an incomplete panel
+ * collapses to `missing_artifact` (the closest "required pieces
+ * absent" reason).
+ */
+function toContractReason(r: ConformanceDegradedReason): DegradedReason {
+  switch (r) {
+    case 'parser_warning':   return 'malformed_block';
+    case 'incomplete_panel': return 'missing_artifact';
+    default:                 return r;
+  }
 }
 
 /**
@@ -61,6 +135,21 @@ export async function runAdapterConformance(
 ): Promise<ConformanceOutcome> {
   const events: PanelEvent[] = [];
   let shipPayload: ShipArtifactPayload | null = null;
+  let parserWarningSeen = false;
+  let castRoles: PanelistRole[] | null = null;
+  // Per-round closed-roles map keyed by `round`. Built incrementally
+  // as panelist_close events arrive and consulted at SHIP time so the
+  // shipping round must independently satisfy the full cast. A round
+  // that closes only some panelists cannot piggy-back on an earlier
+  // round's closes (lefarcen P2 on PR #1316 follow-up).
+  const closedRolesByRound = new Map<number, Set<string>>();
+  // Captured SHIP event details. Set on the first SHIP the parser
+  // yields. The loop continues draining the stream so any
+  // `parser_warning` that arrives AFTER the ship (notably the
+  // `duplicate_ship` kind, which the parser emits when it sees a
+  // second `<SHIP>` block) still flips the run to degraded
+  // (lefarcen P2 on PR #1316 follow-up).
+  let shipEvent: Extract<PanelEvent, { type: 'ship' }> | null = null;
 
   try {
     for await (const event of parseCritiqueStream(params.source, {
@@ -74,13 +163,22 @@ export async function runAdapterConformance(
       },
     })) {
       events.push(event);
-      if (event.type === 'ship') {
-        return {
-          kind: 'shipped',
-          round: event.round,
-          composite: event.composite,
-          events,
-        };
+      if (event.type === 'run_started') {
+        castRoles = event.cast;
+      } else if (event.type === 'panelist_close') {
+        let bucket = closedRolesByRound.get(event.round);
+        if (!bucket) {
+          bucket = new Set<string>();
+          closedRolesByRound.set(event.round, bucket);
+        }
+        bucket.add(event.role);
+      } else if (event.type === 'parser_warning') {
+        parserWarningSeen = true;
+      } else if (event.type === 'ship' && shipEvent === null) {
+        // Capture the first ship but keep iterating so a later
+        // `parser_warning` (e.g. duplicate_ship) still tightens the
+        // classification to degraded.
+        shipEvent = event;
       }
     }
   } catch (err) {
@@ -90,8 +188,7 @@ export async function runAdapterConformance(
       : err instanceof MissingArtifactError ? 'missing_artifact'
       : null;
     if (reason) {
-      markDegraded(params.adapterId, reason, ADAPTER_DEGRADED_DEFAULT_TTL_MS, 'conformance');
-      return { kind: 'degraded', reason, events };
+      return mark(params.adapterId, reason, events);
     }
     return {
       kind: 'failed',
@@ -100,11 +197,42 @@ export async function runAdapterConformance(
       error: err instanceof Error ? err.message : String(err),
     };
   }
-  // Silence the unused-locals lint: shipPayload is filled by the
-  // onArtifact callback but only the parser-yielded SHIP event drives
-  // routing here, so the body is informational for callers that need
-  // it later (e.g. a follow-up that asserts artifact bytes round-trip).
-  void shipPayload;
 
-  return { kind: 'failed', cause: 'no_ship', events };
+  if (shipEvent === null) {
+    return { kind: 'failed', cause: 'no_ship', events };
+  }
+
+  if (parserWarningSeen) {
+    return mark(params.adapterId, 'parser_warning', events);
+  }
+
+  const expected = castRoles ?? ['designer', 'critic', 'brand', 'a11y', 'copy'];
+  const shippingRoundClosed
+    = closedRolesByRound.get(shipEvent.round) ?? new Set<string>();
+  const missing = expected.filter((r) => !shippingRoundClosed.has(r));
+  if (missing.length > 0) {
+    return mark(params.adapterId, 'incomplete_panel', events);
+  }
+
+  return {
+    kind: 'shipped',
+    round: shipEvent.round,
+    composite: shipEvent.composite,
+    events,
+    artifact: shipPayload,
+  };
+}
+
+function mark(
+  adapterId: string,
+  reason: ConformanceDegradedReason,
+  events: PanelEvent[],
+): ConformanceOutcome {
+  markDegraded(
+    adapterId,
+    toContractReason(reason),
+    ADAPTER_DEGRADED_DEFAULT_TTL_MS,
+    'conformance',
+  );
+  return { kind: 'degraded', reason, events };
 }

--- a/apps/daemon/src/critique/orchestrator.ts
+++ b/apps/daemon/src/critique/orchestrator.ts
@@ -28,6 +28,20 @@ import {
   OversizeBlockError,
   MissingArtifactError,
 } from './errors.js';
+import { trace, SpanStatusCode } from '@opentelemetry/api';
+import {
+  critiqueCompositeScore,
+  critiqueInterruptedTotal,
+  critiqueMustFixTotal,
+  critiqueParserErrorsTotal,
+  critiqueProtocolVersion,
+  critiqueRoundDurationMs,
+  critiqueRoundsTotal,
+  critiqueRunsTotal,
+} from '../metrics/index.js';
+import { logCritique } from '../logging/critique.js';
+
+const tracer = trace.getTracer('@open-design/daemon/critique');
 
 /**
  * Tolerance used when comparing the agent-supplied composite attribute on
@@ -53,6 +67,13 @@ export interface OrchestratorParams {
   artifactId: string;
   artifactDir: string;
   adapter: string;
+  /**
+   * SKILL.md id for the run, used as a Prometheus label so the dashboard
+   * can break adapter performance down by skill. Optional because not
+   * every spawn site has threaded it yet (Phase 12 follow-up). Defaults
+   * to 'unknown' so the series shape stays stable.
+   */
+  skill?: string;
   cfg: CritiqueConfig;
   db: Database.Database;
   bus: CritiqueSseBus;
@@ -103,6 +124,46 @@ export async function runOrchestrator(
   params: OrchestratorParams,
 ): Promise<OrchestratorResult> {
   const { runId, projectId, conversationId, artifactDir, adapter, cfg, db, bus, stdout } = params;
+  const skill = params.skill ?? 'unknown';
+  // Phase 12 round-duration histogram needs the wall-clock time the first
+  // panelist_open landed for each round, so we can subtract at round_end.
+  const roundStartMs = new Map<number, number>();
+
+  // Phase 12 outer trace span. No-op without an exporter wired; operators
+  // who attach OTLP / Tempo / Honeycomb / Jaeger pick the span up
+  // automatically through the existing `trace.getTracer` registry. Inner
+  // per-round / per-chunk spans are a follow-up; the outer span alone
+  // gives the trace a duration + final status + adapter/skill attributes,
+  // which is what 80% of dashboards correlate runs by.
+  const span = tracer.startSpan('critique.run', {
+    attributes: {
+      'critique.run_id': runId,
+      'critique.adapter': adapter,
+      'critique.skill': skill,
+    },
+  });
+
+  // Phase 12 parser-warning helper. Three orchestrator-side checks emit
+  // composite_mismatch / duplicate_ship as parser warnings; routing each
+  // through this helper guarantees the metric bump, the log line, and
+  // the SSE fan-out stay in lockstep. Parser-yielded warnings (from
+  // `parseCritiqueStream` directly) hit the matching switch case below.
+  const emitParserWarning = (
+    kind: Extract<PanelEvent, { type: 'parser_warning' }>['kind'],
+    position: number,
+    collected: PanelEvent[],
+  ): void => {
+    const warning: Extract<PanelEvent, { type: 'parser_warning' }> = {
+      type: 'parser_warning',
+      runId,
+      kind,
+      position,
+    };
+    collected.push(warning);
+    bus.emit(panelEventToSse(warning));
+    critiqueParserErrorsTotal.inc({ kind, adapter });
+    logCritique({ event: 'parser_recover', runId, kind, position });
+  };
   const signal = params.signal;
   const child = params.child;
   const childExitPromise = params.childExitPromise;
@@ -225,6 +286,17 @@ export async function runOrchestrator(
 
       switch (event.type) {
         case 'run_started': {
+          logCritique({
+            event: 'run_started',
+            runId,
+            adapter,
+            skill,
+            protocolVersion: event.protocolVersion,
+          });
+          critiqueProtocolVersion.set(
+            { version: String(event.protocolVersion) },
+            event.protocolVersion,
+          );
           break;
         }
 
@@ -240,6 +312,12 @@ export async function runOrchestrator(
           if (event.round !== currentRoundN) {
             currentRoundN = event.round;
             roundDeadline = Date.now() + cfg.perRoundTimeoutMs;
+          }
+          // Track first panelist_open wall-clock per round for the
+          // round_duration_ms histogram. Subsequent panelist_open events
+          // in the same round leave the start time untouched.
+          if (!roundStartMs.has(event.round)) {
+            roundStartMs.set(event.round, Date.now());
           }
           break;
         }
@@ -258,6 +336,17 @@ export async function runOrchestrator(
           if (rs !== undefined) {
             rs.mustFix += 1;
           }
+          // The wire-level panelist_must_fix event carries `text` but no
+          // dim name. Bump with `dim: 'unspecified'` so the dashboard
+          // panel stays stable: when a future parser revision adds a
+          // `dim` field, the label flips to the real value without a
+          // breaking metric rename.
+          critiqueMustFixTotal.inc({
+            panelist: event.role,
+            dim: 'unspecified',
+            adapter,
+            skill,
+          });
           break;
         }
 
@@ -273,18 +362,38 @@ export async function runOrchestrator(
             // events.
             if (Math.abs(event.composite - rs.composite) > COMPOSITE_TOLERANCE
               || event.mustFix !== rs.mustFix) {
-              const warning: Extract<PanelEvent, { type: 'parser_warning' }> = {
-                type: 'parser_warning',
-                runId,
-                kind: 'composite_mismatch',
-                position: 0,
-              };
-              collectedEvents.push(warning);
-              bus.emit(panelEventToSse(warning));
+              emitParserWarning('composite_mismatch', 0, collectedEvents);
             }
             completedRounds.push({ ...rs });
           }
           roundDeadline = null;
+          // Siri-Ray P2 on PR #1485: observe / log the daemon-authoritative
+          // round values (rs.composite, rs.mustFix), not the agent's
+          // <ROUND_END composite=...> attribute. If they disagree the
+          // composite_mismatch warning above already flagged it; persistence
+          // and ship decisions use rs, so dashboards must too. Skip the
+          // bumps entirely when rs is missing (degenerate round_end with no
+          // matching panelist_open): a metric series labeled with an
+          // untrusted composite is worse than one missing sample.
+          if (rs !== undefined) {
+            critiqueRoundsTotal.inc({ adapter, skill });
+            critiqueCompositeScore.observe({ adapter, skill }, rs.composite);
+            const startedAtMs = roundStartMs.get(event.round);
+            if (startedAtMs !== undefined) {
+              critiqueRoundDurationMs.observe(
+                { adapter, skill, round: String(event.round) },
+                Date.now() - startedAtMs,
+              );
+            }
+            logCritique({
+              event: 'round_closed',
+              runId,
+              round: event.round,
+              composite: rs.composite,
+              mustFix: rs.mustFix,
+              decision: event.decision,
+            });
+          }
           break;
         }
 
@@ -297,6 +406,20 @@ export async function runOrchestrator(
           // Extract designer round-1 ARTIFACT reference from dimNote is not
           // our job here; artifact path comes from the ship event's artifactRef
           // or from a panelist block. We store the artifactId from the ship event below.
+          break;
+        }
+
+        case 'parser_warning': {
+          // Parser-yielded warnings (score_clamped, unknown_role, etc.).
+          // Orchestrator-side warnings go through `emitParserWarning`
+          // and never re-enter this loop.
+          critiqueParserErrorsTotal.inc({ kind: event.kind, adapter });
+          logCritique({
+            event: 'parser_recover',
+            runId,
+            kind: event.kind,
+            position: event.position,
+          });
           break;
         }
 
@@ -319,14 +442,7 @@ export async function runOrchestrator(
         // daemon. Trusting it would re-open the scoring-integrity hole this
         // patch is meant to close, so we drop the agent ship, emit a
         // parser_warning, and fall through to the no-SHIP fallback policy.
-        const warning: Extract<PanelEvent, { type: 'parser_warning' }> = {
-          type: 'parser_warning',
-          runId,
-          kind: 'duplicate_ship',
-          position: 0,
-        };
-        collectedEvents.push(warning);
-        bus.emit(panelEventToSse(warning));
+        emitParserWarning('duplicate_ship', 0, collectedEvents);
         resolvedShip = null;
       }
     }
@@ -339,14 +455,7 @@ export async function runOrchestrator(
       const ship = resolvedShip;
       const shippedRound = completedRounds.find((r) => r.n === ship.round)!;
       if (Math.abs(ship.composite - shippedRound.composite) > COMPOSITE_TOLERANCE) {
-        const warning: Extract<PanelEvent, { type: 'parser_warning' }> = {
-          type: 'parser_warning',
-          runId,
-          kind: 'composite_mismatch',
-          position: 0,
-        };
-        collectedEvents.push(warning);
-        bus.emit(panelEventToSse(warning));
+        emitParserWarning('composite_mismatch', 0, collectedEvents);
       }
       const decision = decideRound(shippedRound.composite, shippedRound.mustFix, cfg);
       finalStatus = decision === 'ship' ? 'shipped' : 'below_threshold';
@@ -619,6 +728,53 @@ export async function runOrchestrator(
     decision: decideRound(r.composite, r.mustFix, cfg) as 'continue' | 'ship',
   }));
 
+  // Phase 12 terminal-status observability. Bumps runs_total once per
+  // run with the resolved status; runs that took the interrupt path
+  // also bump interrupted_total so the dashboard's user-interrupt
+  // panel reads off a labeled counter rather than a status filter.
+  // Logs the matching structured event so an ingest pipeline can key
+  // on namespace=critique + event=run_shipped/run_failed/degraded.
+  critiqueRunsTotal.inc({ status: finalStatus, adapter, skill });
+  switch (finalStatus) {
+    case 'shipped':
+    case 'below_threshold': {
+      logCritique({
+        event: 'run_shipped',
+        runId,
+        round: completedRounds.length > 0
+          ? (completedRounds[completedRounds.length - 1]?.n ?? 0)
+          : 0,
+        composite: finalComposite ?? 0,
+        status: finalStatus,
+      });
+      break;
+    }
+    case 'interrupted': {
+      critiqueInterruptedTotal.inc({ adapter });
+      logCritique({ event: 'run_failed', runId, cause: 'interrupted' });
+      break;
+    }
+    case 'timed_out': {
+      logCritique({ event: 'run_failed', runId, cause: 'timed_out' });
+      break;
+    }
+    case 'failed': {
+      logCritique({ event: 'run_failed', runId, cause: 'orchestrator_internal' });
+      break;
+    }
+    case 'degraded': {
+      logCritique({
+        event: 'degraded',
+        runId,
+        reason: 'orchestrator_classified',
+        adapter,
+      });
+      break;
+    }
+    default:
+      break;
+  }
+
   // Persist final state.
   updateCritiqueRun(db, runId, {
     status: finalStatus,
@@ -627,6 +783,20 @@ export async function runOrchestrator(
     transcriptPath,
     artifactPath,
   });
+
+  // Stamp the OTel span with the resolved terminal status before ending
+  // it, so a downstream tracing UI can filter by status without joining
+  // back to the Prometheus runs_total counter.
+  span.setAttribute('critique.final_status', finalStatus);
+  if (finalComposite !== null) {
+    span.setAttribute('critique.final_composite', finalComposite);
+  }
+  if (finalStatus === 'failed' || finalStatus === 'timed_out') {
+    span.setStatus({ code: SpanStatusCode.ERROR, message: finalStatus });
+  } else {
+    span.setStatus({ code: SpanStatusCode.OK });
+  }
+  span.end();
 
   return {
     status: finalStatus,

--- a/apps/daemon/src/critique/ratchet.ts
+++ b/apps/daemon/src/critique/ratchet.ts
@@ -1,0 +1,268 @@
+/**
+ * M-phase rollout ratchet (Phase 16).
+ *
+ * Phase 15 shipped the rollout resolver. Phase 12 shipped the
+ * observability surface that lets us measure conformance. This module
+ * is the bridge: it takes a window of daily conformance numbers and
+ * answers "given the current rollout phase, should we promote, hold,
+ * or demote?". The answer is a recommendation, not an action. An
+ * operator-driven follow-up wires the actual `OD_CRITIQUE_ROLLOUT_PHASE`
+ * flip into a deploy pipeline; this module's job is to make the
+ * recommendation explicit and auditable so the operator does not have
+ * to read a Grafana panel to know what to do.
+ *
+ * The function is pure: it takes data in and returns a decision out,
+ * with no I/O. That lets the same evaluator drive both the nightly
+ * recommendation log line and the `GET /api/critique/conformance`
+ * endpoint, and lets vitest pin every cell of the decision matrix
+ * without standing up a daemon.
+ *
+ * Spec source: `specs/current/critique-theater.md` § Rollout, which
+ * states the M3 threshold as "14 consecutive days at >= 90% adapter
+ * conformance across the fleet". The clean-parse threshold (>= 95%
+ * runs free of parser_warning) is a sibling gate; both must hold.
+ */
+
+import type { RolloutPhase } from './rollout.js';
+
+/**
+ * One day of conformance numbers for one adapter. The nightly cron
+ * collapses every (adapter, brief-template) run into one of these
+ * rows; the evaluator aggregates across adapters per day.
+ */
+export interface ConformanceDay {
+  /** ISO date `YYYY-MM-DD`. */
+  date: string;
+  /** Adapter id (matches `agentId` in the spawn handler). */
+  adapter: string;
+  /** Fraction of runs that hit the `shipped` terminal status, 0..1. */
+  shippedRate: number;
+  /** Fraction of runs with zero parser_warning events, 0..1. */
+  cleanParseRate: number;
+  /** Total runs the day's two rates were computed from. */
+  totalRuns: number;
+}
+
+export type RatchetDecision =
+  | {
+      kind: 'hold';
+      current: RolloutPhase;
+      /** Human-readable reason the rollout is holding at `current`. */
+      reason: string;
+      /** Days in the rolling window that passed every threshold. */
+      passingDays: number;
+      /** Days in the rolling window that have at least one row. */
+      observedDays: number;
+    }
+  | {
+      kind: 'promote';
+      from: RolloutPhase;
+      to: RolloutPhase;
+      /** Days in the rolling window that passed every threshold. */
+      evidenceDays: number;
+    }
+  | {
+      kind: 'demote';
+      from: RolloutPhase;
+      to: RolloutPhase;
+      /** Human-readable reason the rollout is being walked back. */
+      reason: string;
+    };
+
+export interface EvaluateRolloutParams {
+  current: RolloutPhase;
+  /** Rolling window of daily conformance rows. Order does not matter. */
+  history: ConformanceDay[];
+  /** Window size in days; defaults to 14 (the spec value). */
+  windowDays?: number;
+  /** Minimum shipped-rate per day; defaults to 0.90 (the spec value). */
+  shippedThreshold?: number;
+  /** Minimum clean-parse-rate per day; defaults to 0.95 (the spec value). */
+  cleanParseThreshold?: number;
+  /**
+   * Optional clock for deterministic tests. Production callers omit;
+   * tests pass `() => new Date('2026-05-13T00:00:00Z')` or similar so
+   * the "today" anchor is fixed.
+   */
+  now?: () => Date;
+}
+
+const PHASE_ORDER: readonly RolloutPhase[] = ['M0', 'M1', 'M2', 'M3'] as const;
+
+function nextPhase(p: RolloutPhase): RolloutPhase | null {
+  const i = PHASE_ORDER.indexOf(p);
+  return i >= 0 && i < PHASE_ORDER.length - 1 ? PHASE_ORDER[i + 1] ?? null : null;
+}
+
+function prevPhase(p: RolloutPhase): RolloutPhase | null {
+  const i = PHASE_ORDER.indexOf(p);
+  return i > 0 ? PHASE_ORDER[i - 1] ?? null : null;
+}
+
+function isoDay(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Compute the set of date strings in the `windowDays` ending today
+ * (inclusive). Pure, no Date side effects on the input.
+ */
+function rollingWindowDates(now: Date, windowDays: number): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < windowDays; i++) {
+    const d = new Date(now.getTime() - i * 24 * 60 * 60 * 1000);
+    out.push(isoDay(d));
+  }
+  return out;
+}
+
+/**
+ * Evaluate the rollout. Returns one of three decisions:
+ *
+ *   * `promote`: every day in the rolling window had at least one row
+ *     and every per-day fleet aggregate cleared both thresholds.
+ *   * `demote`: at least one day in the rolling window had a fleet
+ *     shipped-rate below the demote-floor (half of `shippedThreshold`).
+ *     The demote-floor is intentionally lower than the promote threshold
+ *     so a single noisy day at, say, 0.88 does not bounce the rollout
+ *     back; the demote signal is for sustained breakage.
+ *   * `hold`: anything else (data gaps, near-misses, or M3 with no
+ *     headroom).
+ *
+ * The function is total: it always returns a decision; M0 cannot demote
+ * (already at the floor) and M3 cannot promote (already at the ceiling).
+ * Both of those collapse to `hold` with a reason-string that explains
+ * why.
+ */
+export function evaluateRollout(params: EvaluateRolloutParams): RatchetDecision {
+  const rawWindow = params.windowDays ?? 14;
+  const rawShipped = params.shippedThreshold ?? 0.90;
+  const rawClean = params.cleanParseThreshold ?? 0.95;
+
+  // Codex + lefarcen P1 on PR #1499: defend at the evaluator entry so a
+  // malformed query string (`?windowDays=0`) or a buggy caller cannot
+  // produce a zero-evidence promotion. A non-positive window would make
+  // `passingDays >= windowDays` trivially true at 0 >= 0, and a
+  // threshold outside [0, 1] would either reject every legitimate day
+  // (> 1) or accept nonsense (< 0). Hold with a clear reason in either
+  // case instead.
+  if (!Number.isFinite(rawWindow) || rawWindow <= 0) {
+    return {
+      kind: 'hold',
+      current: params.current,
+      reason: `invalid windowDays: ${rawWindow}`,
+      passingDays: 0,
+      observedDays: 0,
+    };
+  }
+  if (!Number.isFinite(rawShipped) || rawShipped < 0 || rawShipped > 1) {
+    return {
+      kind: 'hold',
+      current: params.current,
+      reason: `invalid shippedThreshold: ${rawShipped}`,
+      passingDays: 0,
+      observedDays: 0,
+    };
+  }
+  if (!Number.isFinite(rawClean) || rawClean < 0 || rawClean > 1) {
+    return {
+      kind: 'hold',
+      current: params.current,
+      reason: `invalid cleanParseThreshold: ${rawClean}`,
+      passingDays: 0,
+      observedDays: 0,
+    };
+  }
+
+  const windowDays = Math.floor(rawWindow);
+  const shippedThreshold = rawShipped;
+  const cleanParseThreshold = rawClean;
+  const now = (params.now ?? (() => new Date()))();
+  const windowDates = new Set(rollingWindowDates(now, windowDays));
+
+  // Aggregate per-day across adapters. Each adapter's row contributes
+  // its `totalRuns` weight to both numerator and denominator so the
+  // fleet aggregate is a weighted mean, not a simple mean of rates.
+  type DayAgg = { runs: number; shipped: number; clean: number };
+  const byDay = new Map<string, DayAgg>();
+  for (const row of params.history) {
+    if (!windowDates.has(row.date)) continue;
+    if (!Number.isFinite(row.totalRuns) || row.totalRuns <= 0) continue;
+    if (!Number.isFinite(row.shippedRate) || row.shippedRate < 0 || row.shippedRate > 1) continue;
+    if (!Number.isFinite(row.cleanParseRate) || row.cleanParseRate < 0 || row.cleanParseRate > 1) continue;
+    const agg = byDay.get(row.date) ?? { runs: 0, shipped: 0, clean: 0 };
+    agg.runs += row.totalRuns;
+    agg.shipped += row.shippedRate * row.totalRuns;
+    agg.clean += row.cleanParseRate * row.totalRuns;
+    byDay.set(row.date, agg);
+  }
+
+  // Walk the window day by day. Count passing days (both thresholds
+  // met) and observed days (any row at all). A day with no rows is
+  // not a failure; it is missing data, which collapses to `hold`.
+  let passingDays = 0;
+  let demoteDay: string | null = null;
+  const demoteFloor = shippedThreshold / 2;
+  for (const date of windowDates) {
+    const agg = byDay.get(date);
+    if (agg === undefined) continue;
+    const shippedRate = agg.shipped / agg.runs;
+    const cleanRate = agg.clean / agg.runs;
+    if (shippedRate >= shippedThreshold && cleanRate >= cleanParseThreshold) {
+      passingDays += 1;
+    }
+    if (shippedRate < demoteFloor && demoteDay === null) {
+      demoteDay = date;
+    }
+  }
+  const observedDays = byDay.size;
+
+  if (demoteDay !== null) {
+    const to = prevPhase(params.current);
+    if (to !== null) {
+      return {
+        kind: 'demote',
+        from: params.current,
+        to,
+        reason: `fleet shipped-rate fell below ${(demoteFloor * 100).toFixed(0)}% on ${demoteDay}`,
+      };
+    }
+    return {
+      kind: 'hold',
+      current: params.current,
+      reason: `would demote (shipped-rate floor breach on ${demoteDay}) but already at M0`,
+      passingDays,
+      observedDays,
+    };
+  }
+
+  if (passingDays >= windowDays) {
+    const to = nextPhase(params.current);
+    if (to !== null) {
+      return {
+        kind: 'promote',
+        from: params.current,
+        to,
+        evidenceDays: passingDays,
+      };
+    }
+    return {
+      kind: 'hold',
+      current: params.current,
+      reason: `would promote (${passingDays} consecutive passing days) but already at M3`,
+      passingDays,
+      observedDays,
+    };
+  }
+
+  return {
+    kind: 'hold',
+    current: params.current,
+    reason:
+      observedDays < windowDays
+        ? `insufficient data: ${observedDays} / ${windowDays} days observed`
+        : `near-miss: ${passingDays} / ${windowDays} days cleared the ${(shippedThreshold * 100).toFixed(0)}% / ${(cleanParseThreshold * 100).toFixed(0)}% thresholds`,
+    passingDays,
+    observedDays,
+  };
+}

--- a/apps/daemon/src/critique/rollout.ts
+++ b/apps/daemon/src/critique/rollout.ts
@@ -1,0 +1,119 @@
+/**
+ * Critique Theater rollout-flag plumbing (Phase 15).
+ *
+ * The plan's rollout track is M0 dark-launch -> M1 settings toggle ->
+ * M2 default-on per skill -> M3 global default. This module is the
+ * single decision point every caller consults to know "should the
+ * orchestrator wire the critique pipeline for this run?" The same
+ * helper is consumed by:
+ *
+ *   - The orchestrator entry, before it spawns the critique CLI
+ *     adapter for a generation.
+ *   - The settings endpoint (GET /api/settings/critique) which echoes
+ *     the resolved value to the Settings UI.
+ *   - The conformance harness, so a nightly cycle can run against an
+ *     adapter even when the human-facing flag is off.
+ *
+ * Resolution order (highest priority first):
+ *
+ *   1. Per-skill override declared in `SKILL.md` frontmatter
+ *      (`od.critique.policy: required | opt-in | opt-out`).
+ *   2. Per-project override stored in the project settings table
+ *      (the M1 Settings toggle writes here).
+ *   3. Environment override (`OD_CRITIQUE_ENABLED=1`). Useful for
+ *      power users and CI fixtures.
+ *   4. Global default. M0 / M1 = false. M2 = true for skills tagged
+ *      `od.critique.policy: required`. M3 = true globally.
+ */
+
+export type SkillCritiquePolicy = 'required' | 'opt-in' | 'opt-out' | null;
+
+export type RolloutPhase = 'M0' | 'M1' | 'M2' | 'M3';
+
+export interface RolloutInputs {
+  /** Effective rollout phase. Reads from `OD_CRITIQUE_ROLLOUT_PHASE`
+   *  in production; tests pass it directly. */
+  phase: RolloutPhase;
+  /** Skill's `od.critique.policy` value, or `null` if the skill
+   *  did not declare one. */
+  skillPolicy: SkillCritiquePolicy;
+  /** Per-project setting written by the M1 Settings toggle, or
+   *  `null` if the project has not overridden the default. */
+  projectOverride: boolean | null;
+  /** Environment override (`OD_CRITIQUE_ENABLED=1`). */
+  envOverride: boolean | null;
+}
+
+/**
+ * Returns `true` when the orchestrator should run the critique
+ * pipeline for this generation. Returns `false` when it should skip.
+ *
+ * Decision matrix (first row that matches wins):
+ *
+ *   skillPolicy === 'opt-out'         -> false
+ *   skillPolicy === 'required'        -> true
+ *   projectOverride !== null          -> projectOverride
+ *   envOverride !== null              -> envOverride
+ *   phase === 'M0'                    -> false
+ *   phase === 'M1'                    -> false
+ *   phase === 'M2'                    -> skillPolicy === 'opt-in'
+ *   phase === 'M3'                    -> true
+ */
+export function isCritiqueEnabled(input: RolloutInputs): boolean {
+  // Skill-level vetoes win unconditionally. A skill that explicitly
+  // opts out cannot have critique forced on it by an env var or a
+  // global rollout; a skill that opts in cannot be vetoed.
+  if (input.skillPolicy === 'opt-out') return false;
+  if (input.skillPolicy === 'required') return true;
+
+  // Project-level override is the M1 Settings toggle. A user who
+  // explicitly enables or disables critique for a project beats the
+  // env default and the global rollout phase.
+  if (input.projectOverride !== null) return input.projectOverride;
+
+  // Env override is the power-user lane (CI fixtures, beta access).
+  if (input.envOverride !== null) return input.envOverride;
+
+  // Otherwise fall through to the rollout phase default.
+  switch (input.phase) {
+    case 'M0':
+    case 'M1':
+      return false;
+    case 'M2':
+      return input.skillPolicy === 'opt-in';
+    case 'M3':
+      return true;
+  }
+}
+
+/**
+ * Parse the `OD_CRITIQUE_ROLLOUT_PHASE` env var into a `RolloutPhase`.
+ * Defaults to `M0` (dark-launch) when the value is missing or unknown
+ * so a fresh install never surprises users with the feature on.
+ */
+export function parseRolloutPhase(raw: string | undefined): RolloutPhase {
+  switch ((raw ?? '').trim().toUpperCase()) {
+    case 'M1':
+      return 'M1';
+    case 'M2':
+      return 'M2';
+    case 'M3':
+      return 'M3';
+    default:
+      return 'M0';
+  }
+}
+
+/**
+ * Parse `OD_CRITIQUE_ENABLED`. Recognises the canonical truthy /
+ * falsy strings; returns `null` when the env var is unset so the
+ * resolver knows to fall through to the rollout phase default
+ * rather than treating "missing" as an explicit `false`.
+ */
+export function parseEnvEnabled(raw: string | undefined): boolean | null {
+  if (raw === undefined || raw === '') return null;
+  const v = raw.trim().toLowerCase();
+  if (v === '1' || v === 'true' || v === 'yes' || v === 'on') return true;
+  if (v === '0' || v === 'false' || v === 'no' || v === 'off') return false;
+  return null;
+}

--- a/apps/daemon/src/logging/critique.ts
+++ b/apps/daemon/src/logging/critique.ts
@@ -1,0 +1,72 @@
+/**
+ * Critique Theater structured logger (Phase 12).
+ *
+ * Six events, one JSON object per line on stdout, namespaced
+ * `critique`. Matches the JSON-line convention `cli.ts` and
+ * `mcp-live-artifacts-server.ts` already write so an operator's
+ * existing log pipeline (Loki, Cloudwatch, Datadog, etc.) ingests
+ * critique events without a new adapter.
+ *
+ * Why a discriminated union instead of pino / winston: the daemon
+ * already does JSON-per-line writes through `process.stdout`; adding
+ * pino would either wrap that surface (a refactor outside Phase 12's
+ * scope) or run two logger systems side by side. The thin wrapper
+ * below tests via `process.stdout.write` capture and a future system
+ * swap can replace the implementation without touching the call sites.
+ */
+
+export type CritiqueLogEvent =
+  | {
+      event: 'run_started';
+      runId: string;
+      adapter: string;
+      skill: string;
+      protocolVersion: number;
+    }
+  | {
+      event: 'round_closed';
+      runId: string;
+      round: number;
+      composite: number;
+      mustFix: number;
+      decision: 'continue' | 'ship';
+    }
+  | {
+      event: 'run_shipped';
+      runId: string;
+      round: number;
+      composite: number;
+      status: string;
+    }
+  | {
+      event: 'degraded';
+      runId: string;
+      reason: string;
+      adapter: string;
+    }
+  | {
+      event: 'parser_recover';
+      runId: string;
+      kind: string;
+      position: number;
+    }
+  | {
+      event: 'run_failed';
+      runId: string;
+      cause: string;
+      error?: string;
+    };
+
+/**
+ * Emit one JSON line for the given critique event. The timestamp is
+ * ISO-8601 with millisecond precision so an aggregator that ingests
+ * multiple log streams can stable-sort across them.
+ */
+export function logCritique(e: CritiqueLogEvent): void {
+  const line = JSON.stringify({
+    ...e,
+    namespace: 'critique',
+    timestamp: new Date().toISOString(),
+  });
+  process.stdout.write(line + '\n');
+}

--- a/apps/daemon/src/metrics/index.ts
+++ b/apps/daemon/src/metrics/index.ts
@@ -1,0 +1,128 @@
+/**
+ * Critique Theater Prometheus registry (Phase 12).
+ *
+ * Nine series, all under the `open_design_critique_*` namespace, scoped
+ * to the default `prom-client` registry so a single `/api/metrics`
+ * scrape returns everything the dashboard panels query.
+ *
+ * Label cardinality is bounded:
+ *   - `adapter` is the agent id, capped at installation-time discovery
+ *   - `skill` is the SKILL.md id, capped at the skills registry size
+ *   - `panelist` / `dim` are closed enums (`PANELIST_ROLES`, dimension
+ *     names from the parser contract)
+ *   - `reason` / `cause` / `kind` are closed enums in
+ *     `packages/contracts/src/critique.ts`
+ *   - `round` is small-integer (typical 1-3)
+ *   - `status` and `version` are closed enums / small integers
+ *
+ * Histogram buckets follow `specs/current/critique-theater.md` §
+ * Observability and are intentionally explicit so an operator can tune
+ * them after the first 1000 runs without code changes.
+ *
+ * No call signed off on a particular skill label being globally
+ * available; orchestrator call sites pass `skill ?? 'unknown'` when the
+ * spawn handler did not thread the skill id. Defaulting to 'unknown'
+ * keeps the series shape stable while threading the label is a
+ * separate fix.
+ */
+
+import {
+  Counter,
+  Gauge,
+  Histogram,
+  register,
+} from 'prom-client';
+
+export const critiqueRunsTotal = new Counter({
+  name: 'open_design_critique_runs_total',
+  help: 'Total Critique Theater runs that reached a terminal phase.',
+  labelNames: ['status', 'adapter', 'skill'] as const,
+  registers: [register],
+});
+
+export const critiqueRoundsTotal = new Counter({
+  name: 'open_design_critique_rounds_total',
+  help: 'Total round_end events processed across all runs.',
+  labelNames: ['adapter', 'skill'] as const,
+  registers: [register],
+});
+
+export const critiqueRoundDurationMs = new Histogram({
+  name: 'open_design_critique_round_duration_ms',
+  help: 'Wall-clock duration of a single round, in milliseconds.',
+  labelNames: ['adapter', 'skill', 'round'] as const,
+  buckets: [100, 250, 500, 1000, 2500, 5000, 10000, 30000, 60000],
+  registers: [register],
+});
+
+export const critiqueCompositeScore = new Histogram({
+  name: 'open_design_critique_composite_score',
+  help: 'Composite score reported by round_end events.',
+  labelNames: ['adapter', 'skill'] as const,
+  buckets: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+  registers: [register],
+});
+
+export const critiqueMustFixTotal = new Counter({
+  name: 'open_design_critique_must_fix_total',
+  help: 'Total panelist_must_fix events emitted across all runs.',
+  labelNames: ['panelist', 'dim', 'adapter', 'skill'] as const,
+  registers: [register],
+});
+
+export const critiqueDegradedTotal = new Counter({
+  name: 'open_design_critique_degraded_total',
+  help: 'Total times an adapter was marked degraded (TTL-bounded).',
+  labelNames: ['reason', 'adapter'] as const,
+  registers: [register],
+});
+
+export const critiqueInterruptedTotal = new Counter({
+  name: 'open_design_critique_interrupted_total',
+  help: 'Total runs terminated via the user interrupt path.',
+  labelNames: ['adapter'] as const,
+  registers: [register],
+});
+
+export const critiqueParserErrorsTotal = new Counter({
+  name: 'open_design_critique_parser_errors_total',
+  help: 'Total parser_warning events surfaced from the SSE stream.',
+  labelNames: ['kind', 'adapter'] as const,
+  registers: [register],
+});
+
+export const critiqueProtocolVersion = new Gauge({
+  name: 'open_design_critique_protocol_version',
+  help: 'Highest protocolVersion observed in a run_started frame.',
+  labelNames: ['version'] as const,
+  registers: [register],
+});
+
+/**
+ * Exposed to the `/api/metrics` route. Returns the full Prometheus
+ * exposition format as a single string with the correct content type
+ * available on `register.contentType`.
+ */
+export async function getCritiqueMetrics(): Promise<string> {
+  return register.metrics();
+}
+
+export { register };
+
+/**
+ * Test-only: wipe the default registry so vitest cases can assert
+ * series shape without leakage from a prior `runOrchestrator` call.
+ * Production code never reaches this; the function name is deliberate
+ * so a grep audit flags any accidental production caller.
+ */
+export function __resetCritiqueMetricsForTests(): void {
+  critiqueRunsTotal.reset();
+  critiqueRoundsTotal.reset();
+  critiqueRoundDurationMs.reset();
+  critiqueCompositeScore.reset();
+  critiqueMustFixTotal.reset();
+  critiqueDegradedTotal.reset();
+  critiqueInterruptedTotal.reset();
+  critiqueParserErrorsTotal.reset();
+  critiqueProtocolVersion.reset();
+}

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -2302,6 +2302,52 @@ export async function startServer({
     }
   });
 
+  app.get('/api/projects/:id/critique/settings', async (req, res) => {
+    try {
+      const project = getProject(db, req.params.id);
+      if (!project) {
+        sendApiError(res, 404, 'PROJECT_NOT_FOUND', 'project not found');
+        return;
+      }
+
+      const metadata = project.metadata;
+      const rawProjectOverride =
+        metadata && typeof metadata === 'object'
+          ? (metadata as { critiqueTheaterEnabled?: unknown }).critiqueTheaterEnabled
+          : undefined;
+      const projectOverride: boolean | null =
+        typeof rawProjectOverride === 'boolean' ? rawProjectOverride : null;
+
+      let skillPolicy: SkillCritiquePolicy = null;
+      if (typeof project.skillId === 'string' && project.skillId.length > 0) {
+        const skill = findSkillById(
+          await listAllSkillLikeEntries(),
+          project.skillId,
+        );
+        skillPolicy = skill?.critiquePolicy ?? null;
+      }
+
+      const phase = parseRolloutPhase(process.env.OD_CRITIQUE_ROLLOUT_PHASE);
+      const envOverride = parseEnvEnabled(process.env.OD_CRITIQUE_ENABLED);
+      const enabled = isCritiqueEnabled({
+        phase,
+        skillPolicy,
+        projectOverride,
+        envOverride,
+      });
+
+      res.json({
+        projectOverride,
+        envOverride,
+        phase,
+        skillPolicy,
+        enabled,
+      });
+    } catch (err) {
+      sendApiError(res, 500, 'INTERNAL_ERROR', err instanceof Error ? err.message : String(err));
+    }
+  });
+
   registerConnectorRoutes(app, {
     sendApiError,
     authorizeToolRequest,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -69,6 +69,15 @@ import { runOrchestrator } from './critique/orchestrator.js';
 import { createRunRegistry } from './critique/run-registry.js';
 import { handleCritiqueInterrupt } from './critique/interrupt-handler.js';
 import { handleCritiqueArtifact } from './critique/artifact-handler.js';
+import { getCritiqueMetrics, register } from './metrics/index.js';
+import { readConformanceHistory } from './critique/conformance-history.js';
+import { evaluateRollout } from './critique/ratchet.js';
+import {
+  isCritiqueEnabled,
+  parseEnvEnabled,
+  parseRolloutPhase,
+  type SkillCritiquePolicy,
+} from './critique/rollout.js';
 import { createCopilotStreamHandler } from './copilot-stream.js';
 import { createJsonEventStreamHandler } from './json-event-stream.js';
 import { createQoderStreamHandler } from './qoder-stream.js';
@@ -2256,6 +2265,43 @@ export async function startServer({
     res.json({ version });
   });
 
+  if (process.env.OD_METRICS_ENDPOINT !== 'disabled') {
+    app.get('/api/metrics', async (_req, res) => {
+      res.setHeader('Content-Type', register.contentType);
+      res.send(await getCritiqueMetrics());
+    });
+  }
+
+  const parsePositiveInt = (raw: unknown, fallback: number): number => {
+    if (typeof raw !== 'string' || raw.length === 0) return fallback;
+    const n = Number(raw);
+    return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
+  };
+  const parseRate = (raw: unknown, fallback: number): number => {
+    if (typeof raw !== 'string' || raw.length === 0) return fallback;
+    const n = Number(raw);
+    return Number.isFinite(n) && n >= 0 && n <= 1 ? n : fallback;
+  };
+
+  app.get('/api/critique/conformance', async (req, res) => {
+    try {
+      const windowDays = parsePositiveInt(req.query.windowDays, 14);
+      const shippedThreshold = parseRate(req.query.shippedThreshold, 0.90);
+      const cleanParseThreshold = parseRate(req.query.cleanParseThreshold, 0.95);
+      const history = await readConformanceHistory(RUNTIME_DATA_DIR, windowDays);
+      const decision = evaluateRollout({
+        current: parseRolloutPhase(process.env.OD_CRITIQUE_ROLLOUT_PHASE),
+        history,
+        windowDays,
+        shippedThreshold,
+        cleanParseThreshold,
+      });
+      res.json({ window: { days: windowDays, history }, decision });
+    } catch (err) {
+      sendApiError(res, 500, 'INTERNAL_ERROR', err instanceof Error ? err.message : String(err));
+    }
+  });
+
   registerConnectorRoutes(app, {
     sendApiError,
     authorizeToolRequest,
@@ -2941,6 +2987,7 @@ export async function startServer({
     let skillMode;
     let skillCraftRequires = [];
     let activeSkillDir = null;
+    let skillCritiquePolicy: SkillCritiquePolicy = null;
     if (effectiveSkillId) {
       // Span both functional skills and design templates so a project
       // saved against either surface keeps its system prompt after the
@@ -2954,6 +3001,7 @@ export async function startServer({
         skillName = skill.name;
         skillMode = skill.mode;
         activeSkillDir = skill.dir;
+        skillCritiquePolicy = skill.critiquePolicy;
         if (Array.isArray(skill.craftRequires))
           skillCraftRequires = skill.craftRequires;
       }
@@ -3035,18 +3083,29 @@ export async function startServer({
         ? (getTemplate(db, metadata.templateId) ?? undefined)
         : undefined;
 
+    const rawProjectOverride =
+      metadata && typeof metadata === 'object'
+        ? (metadata as { critiqueTheaterEnabled?: unknown }).critiqueTheaterEnabled
+        : undefined;
+    const projectCritiqueOverride: boolean | null =
+      typeof rawProjectOverride === 'boolean' ? rawProjectOverride : null;
+    const critiqueEnabledForRun = isCritiqueEnabled({
+      phase: parseRolloutPhase(process.env.OD_CRITIQUE_ROLLOUT_PHASE),
+      skillPolicy: skillCritiquePolicy,
+      projectOverride: projectCritiqueOverride,
+      envOverride: parseEnvEnabled(process.env.OD_CRITIQUE_ENABLED),
+    });
+
     // Thread the critique config plus the active design-system / skill data
-    // into the composer when critique is enabled. Without this the spawned
-    // child receives the legacy single-pass prompt and the parser waits for
-    // <CRITIQUE_RUN> tags the model was never told to emit. The composer
-    // itself ignores these fields when cfg.enabled is false, so the legacy
-    // path stays untouched.
-    const critiqueBrand = critiqueCfg.enabled
+    // into the composer when the rollout resolver enables critique. Without
+    // this the spawned child receives the legacy single-pass prompt and the
+    // parser waits for <CRITIQUE_RUN> tags the model was never told to emit.
+    const critiqueBrand = critiqueEnabledForRun
       && typeof designSystemTitle === 'string'
       && typeof designSystemBody === 'string'
       ? { name: designSystemTitle, design_md: designSystemBody }
       : undefined;
-    const critiqueSkill = critiqueCfg.enabled && typeof effectiveSkillId === 'string'
+    const critiqueSkill = critiqueEnabledForRun && typeof effectiveSkillId === 'string'
       ? { id: effectiveSkillId }
       : undefined;
     // Single-source-of-truth eligibility check. The composer downstream
@@ -3069,7 +3128,7 @@ export async function startServer({
       metadata?.kind === 'video' ||
       metadata?.kind === 'audio';
     const isPlainAdapter = (streamFormat ?? 'plain') === 'plain';
-    const critiqueShouldRun = critiqueCfg.enabled
+    const critiqueShouldRun = critiqueEnabledForRun
       && critiqueBrand !== undefined
       && critiqueSkill !== undefined
       && !isMediaSurface
@@ -3095,7 +3154,7 @@ export async function startServer({
       memoryBody,
       metadata,
       template,
-      critique: critiqueShouldRun ? critiqueCfg : undefined,
+      critique: critiqueShouldRun ? { ...critiqueCfg, enabled: true } : undefined,
       critiqueBrand: critiqueShouldRun ? critiqueBrand : undefined,
       critiqueSkill: critiqueShouldRun ? critiqueSkill : undefined,
       streamFormat,
@@ -3933,7 +3992,26 @@ export async function startServer({
         // than wrapping the frame inside the legacy 'agent' channel. Clients
         // that subscribe to the new event names see them directly with the
         // contract payload as event.data.
-        const critiqueBus = { emit: (e) => send(e.event, e.data) };
+        const critiqueProjectIdForBus =
+          typeof projectId === 'string' && projectId ? projectId : null;
+        const critiqueBus = {
+          emit: (e) => {
+            send(e.event, e.data);
+            if (critiqueProjectIdForBus) {
+              const sinks = activeProjectEventSinks.get(critiqueProjectIdForBus);
+              if (sinks && sinks.size > 0) {
+                const payload = { ...e.data, type: e.event };
+                for (const sink of Array.from(sinks)) {
+                  try {
+                    sink(payload);
+                  } catch {
+                    sinks.delete(sink);
+                  }
+                }
+              }
+            }
+          },
+        };
 
         // Register this run with the in-process registry so the interrupt
         // endpoint can cascade an AbortController to the orchestrator. The
@@ -3977,6 +4055,9 @@ export async function startServer({
             artifactId: critiqueRunId,
             artifactDir: critiqueArtifactDir,
             adapter: typeof agentId === 'string' ? agentId : 'unknown',
+            skill: typeof effectiveSkillId === 'string' && effectiveSkillId
+              ? effectiveSkillId
+              : undefined,
             cfg: critiqueCfg,
             db,
             bus: critiqueBus,

--- a/apps/daemon/src/skills.ts
+++ b/apps/daemon/src/skills.ts
@@ -10,6 +10,7 @@ import type { Dirent } from "node:fs";
 import { cp, mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { parseFrontmatter } from "./frontmatter.js";
+import type { SkillCritiquePolicy } from "./critique/rollout.js";
 import { SKILLS_CWD_ALIAS } from "./cwd-aliases.js";
 
 // Persisted skill ids on existing projects can outlive a folder rename.
@@ -38,6 +39,7 @@ interface SkillFrontmatter extends JsonRecord {
     craft?: JsonRecord;
     preview?: JsonRecord;
     design_system?: JsonRecord;
+    critique?: JsonRecord;
     category?: unknown;
   };
 }
@@ -75,6 +77,7 @@ export interface SkillInfo {
   animations: boolean | null;
   examplePrompt: string;
   aggregatesExamples: boolean;
+  critiquePolicy: SkillCritiquePolicy;
   body: string;
   dir: string;
 }
@@ -219,6 +222,7 @@ export async function listSkills(
           animations: normalizeBoolHint(data.od?.animations),
           examplePrompt: derivePrompt(data),
           aggregatesExamples,
+          critiquePolicy: normalizeCritiquePolicy(data.od?.critique?.policy),
           body: parentBody,
           dir,
         });
@@ -258,6 +262,7 @@ export async function listSkills(
             animations: normalizeBoolHint(data.od?.animations),
             examplePrompt: derivePrompt(data),
             aggregatesExamples: false,
+            critiquePolicy: normalizeCritiquePolicy(data.od?.critique?.policy),
             // Inherit the parent's full SKILL.md body so 'Use this prompt'
             // on a derived card seeds the agent with the same workflow
             // the parent describes. Without this, picking a derived card
@@ -480,6 +485,13 @@ function normalizeBoolHint(value: unknown): boolean | null {
     if (v === "true" || v === "yes" || v === "1") return true;
     if (v === "false" || v === "no" || v === "0") return false;
   }
+  return null;
+}
+
+function normalizeCritiquePolicy(value: unknown): SkillCritiquePolicy {
+  if (typeof value !== "string") return null;
+  const v = value.trim().toLowerCase();
+  if (v === "required" || v === "opt-in" || v === "opt-out") return v;
   return null;
 }
 

--- a/apps/daemon/tests/critique-conformance-history.test.ts
+++ b/apps/daemon/tests/critique-conformance-history.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Conformance history persistence (Phase 16). Pins the read-merge-write
+ * shape the nightly cron and the /api/critique/conformance route share:
+ * one JSON-line per adapter per day, with malformed lines silently
+ * dropped and the last entry per (adapter, date) winning so a
+ * retry-after-failure cron writes the right answer.
+ */
+
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  appendConformanceDay,
+  conformanceHistoryDir,
+  readConformanceHistory,
+} from '../src/critique/conformance-history.js';
+
+let tmp: string;
+
+beforeEach(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'od-conformance-history-'));
+});
+
+afterEach(async () => {
+  await fs.rm(tmp, { recursive: true, force: true });
+});
+
+const NOW = new Date('2026-05-13T12:00:00Z');
+
+function isoDay(offsetDays: number): string {
+  const d = new Date(NOW.getTime() - offsetDays * 24 * 60 * 60 * 1000);
+  return d.toISOString().slice(0, 10);
+}
+
+describe('conformance-history persistence (Phase 16)', () => {
+  it('returns an empty array when the directory does not exist yet', async () => {
+    const rows = await readConformanceHistory(tmp, 14, NOW);
+    expect(rows).toEqual([]);
+  });
+
+  it('round-trips a single row through append + read', async () => {
+    await appendConformanceDay(tmp, {
+      date: isoDay(0),
+      adapter: 'mock',
+      shippedRate: 0.95,
+      cleanParseRate: 0.98,
+      totalRuns: 100,
+    });
+    const rows = await readConformanceHistory(tmp, 14, NOW);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.adapter).toBe('mock');
+    expect(rows[0]?.shippedRate).toBe(0.95);
+  });
+
+  it('keeps the last entry per (adapter, date) so retries win', async () => {
+    const today = isoDay(0);
+    await appendConformanceDay(tmp, {
+      date: today,
+      adapter: 'mock',
+      shippedRate: 0.50,
+      cleanParseRate: 0.60,
+      totalRuns: 50,
+    });
+    // Retry the same day with a better number.
+    await appendConformanceDay(tmp, {
+      date: today,
+      adapter: 'mock',
+      shippedRate: 0.95,
+      cleanParseRate: 0.98,
+      totalRuns: 100,
+    });
+    const rows = await readConformanceHistory(tmp, 14, NOW);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.shippedRate).toBe(0.95);
+    expect(rows[0]?.totalRuns).toBe(100);
+  });
+
+  it('drops malformed lines silently instead of throwing', async () => {
+    // Hand-write a file with one valid row and one corrupt line.
+    const file = path.join(conformanceHistoryDir(tmp), 'mock', `${isoDay(0)}.jsonl`);
+    await fs.mkdir(path.dirname(file), { recursive: true });
+    const good = JSON.stringify({
+      date: isoDay(0),
+      adapter: 'mock',
+      shippedRate: 0.95,
+      cleanParseRate: 0.98,
+      totalRuns: 100,
+    });
+    await fs.writeFile(file, `${good}\nnot valid json{{\n`, 'utf8');
+    const rows = await readConformanceHistory(tmp, 14, NOW);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.adapter).toBe('mock');
+  });
+
+  it('ignores files outside the rolling window', async () => {
+    await appendConformanceDay(tmp, {
+      date: isoDay(20),
+      adapter: 'mock',
+      shippedRate: 0.10,
+      cleanParseRate: 0.10,
+      totalRuns: 100,
+    });
+    const rows = await readConformanceHistory(tmp, 14, NOW);
+    expect(rows).toEqual([]);
+  });
+
+  it('aggregates across adapter directories', async () => {
+    await appendConformanceDay(tmp, {
+      date: isoDay(0),
+      adapter: 'A',
+      shippedRate: 0.95,
+      cleanParseRate: 0.98,
+      totalRuns: 100,
+    });
+    await appendConformanceDay(tmp, {
+      date: isoDay(0),
+      adapter: 'B',
+      shippedRate: 0.92,
+      cleanParseRate: 0.97,
+      totalRuns: 50,
+    });
+    const rows = await readConformanceHistory(tmp, 14, NOW);
+    expect(rows).toHaveLength(2);
+    expect(new Set(rows.map((r) => r.adapter))).toEqual(new Set(['A', 'B']));
+  });
+
+  it('rejects rows with non-finite numeric fields', async () => {
+    const file = path.join(conformanceHistoryDir(tmp), 'mock', `${isoDay(0)}.jsonl`);
+    await fs.mkdir(path.dirname(file), { recursive: true });
+    const bad = JSON.stringify({
+      date: isoDay(0),
+      adapter: 'mock',
+      shippedRate: 'oops',
+      cleanParseRate: 0.98,
+      totalRuns: 100,
+    });
+    await fs.writeFile(file, `${bad}\n`, 'utf8');
+    const rows = await readConformanceHistory(tmp, 14, NOW);
+    expect(rows).toEqual([]);
+  });
+});

--- a/apps/daemon/tests/critique-conformance.test.ts
+++ b/apps/daemon/tests/critique-conformance.test.ts
@@ -51,6 +51,13 @@ describe('adapter conformance harness (Phase 10)', () => {
     // for downstream inspection.
     expect(outcome.events.length).toBeGreaterThan(0);
     expect(outcome.events.find((e) => e.type === 'ship')).toBeTruthy();
+    // The shipped outcome must surface the artifact bytes the parser
+    // handed back via onArtifact, so a nightly cycle can pin MIME /
+    // byte-length / hash without re-parsing the transcript (lefarcen
+    // P2 on PR #1317).
+    expect(outcome.artifact).not.toBeNull();
+    expect(outcome.artifact?.mime).toMatch(/^text\/(html|markdown)/);
+    expect(outcome.artifact?.body.length).toBeGreaterThan(0);
   });
 
   it('synthetic-bad emits degraded with the parser-derived reason and marks the adapter', async () => {
@@ -117,5 +124,222 @@ describe('adapter conformance harness (Phase 10)', () => {
     if (ship?.type !== 'ship') return;
     expect(ship.artifactRef.projectId).toBe('proj-conformance');
     expect(ship.artifactRef.artifactId).toBe('artifact-conformance');
+  });
+
+  it('classifies an oversize block as degraded oversize_block (lefarcen P2)', async () => {
+    // The synthetic-good transcript is fine under the default 256 KB
+    // block budget. Replay it through the harness with a tiny budget so
+    // the parser throws OversizeBlockError on the first ARTIFACT body
+    // and the harness has to surface `degraded: oversize_block`.
+    const outcome = await runAdapterConformance({
+      adapterId: 'synthetic-oversize',
+      runId: 'run-oversize',
+      source: syntheticGoodStream(),
+      parserMaxBlockBytes: 256,
+    });
+    expect(outcome.kind).toBe('degraded');
+    if (outcome.kind !== 'degraded') return;
+    expect(outcome.reason).toBe('oversize_block');
+    expect(isDegraded('synthetic-oversize')).toBe(true);
+  });
+
+  it('classifies an adapter that throws mid-stream as failed unexpected_error (lefarcen P2)', async () => {
+    class AdapterBoom extends Error {
+      constructor() {
+        super('adapter blew up');
+        this.name = 'AdapterBoom';
+      }
+    }
+    async function* throwing(): AsyncIterable<string> {
+      yield '<CRITIQUE_RUN version="1" runId="run-boom" projectId="p" artifactId="a">\n';
+      yield '<ROUND n="1">\n';
+      throw new AdapterBoom();
+    }
+    const outcome = await runAdapterConformance({
+      adapterId: 'synthetic-throwing',
+      runId: 'run-boom',
+      source: throwing(),
+    });
+    expect(outcome.kind).toBe('failed');
+    if (outcome.kind !== 'failed') return;
+    expect(outcome.cause).toBe('unexpected_error');
+    expect(outcome.error).toContain('adapter blew up');
+    // The adapter is NOT marked degraded here: an unexpected throw is a
+    // failure to evaluate, not evidence of a malformed stream. A real
+    // policy could choose to mark it after N consecutive throws; the
+    // harness leaves that decision to the caller.
+    expect(isDegraded('synthetic-throwing')).toBe(false);
+  });
+
+  it('classifies a clean SHIP that arrived alongside parser warnings as degraded parser_warning (lefarcen P2)', async () => {
+    // A panelist score outside [0, scale] makes the parser yield a
+    // `parser_warning` with kind=`score_clamped` BEFORE the panelist
+    // closes. The harness must promote the run to degraded even though
+    // a syntactically valid SHIP arrives later.
+    async function* withClampedScore(): AsyncIterable<string> {
+      yield '<CRITIQUE_RUN version="1" maxRounds="1" threshold="0.1" scale="10">\n';
+      yield '  <ROUND n="1">\n';
+      // designer must include an ARTIFACT in round 1 (parser invariant).
+      yield '    <PANELIST role="designer">\n';
+      yield '      <ARTIFACT mime="text/html"><![CDATA[<p>x</p>]]></ARTIFACT>\n';
+      yield '    </PANELIST>\n';
+      // Out-of-range score on `critic` triggers score_clamped warning.
+      yield '    <PANELIST role="critic" score="99"><DIM name="x" score="6">n</DIM></PANELIST>\n';
+      yield '    <PANELIST role="brand" score="6"><DIM name="x" score="6">n</DIM></PANELIST>\n';
+      yield '    <PANELIST role="a11y" score="6"><DIM name="x" score="6">n</DIM></PANELIST>\n';
+      yield '    <PANELIST role="copy" score="6"><DIM name="x" score="6">n</DIM></PANELIST>\n';
+      yield '    <ROUND_END n="1" composite="6.0" must_fix="0" decision="ship">\n';
+      yield '      <REASON>ok</REASON>\n';
+      yield '    </ROUND_END>\n';
+      yield '  </ROUND>\n';
+      yield '  <SHIP round="1" composite="6.0" status="shipped">\n';
+      yield '    <ARTIFACT mime="text/html"><![CDATA[<p>final</p>]]></ARTIFACT>\n';
+      yield '    <SUMMARY>ok</SUMMARY>\n';
+      yield '  </SHIP>\n';
+      yield '</CRITIQUE_RUN>\n';
+    }
+    const outcome = await runAdapterConformance({
+      adapterId: 'synthetic-warned',
+      runId: 'run-warned',
+      source: withClampedScore(),
+    });
+    expect(outcome.kind).toBe('degraded');
+    if (outcome.kind !== 'degraded') return;
+    expect(outcome.reason).toBe('parser_warning');
+    expect(outcome.events.some((e) => e.type === 'parser_warning')).toBe(true);
+    expect(isDegraded('synthetic-warned')).toBe(true);
+  });
+
+  it('classifies a SHIP that arrived before every panelist closed as degraded incomplete_panel (codex P2)', async () => {
+    // run_started declares the full 5-role cast, but only `designer`
+    // and `critic` ever emit panelist_close. The parser does not reject
+    // this on its own; the harness is the gate that catches it.
+    async function* incomplete(): AsyncIterable<string> {
+      yield '<CRITIQUE_RUN version="1" maxRounds="1" threshold="0.1" scale="10">\n';
+      yield '  <ROUND n="1">\n';
+      yield '    <PANELIST role="designer">\n';
+      yield '      <ARTIFACT mime="text/html"><![CDATA[<p>x</p>]]></ARTIFACT>\n';
+      yield '    </PANELIST>\n';
+      yield '    <PANELIST role="critic" score="6"><DIM name="x" score="6">n</DIM></PANELIST>\n';
+      yield '    <ROUND_END n="1" composite="6.0" must_fix="0" decision="ship">\n';
+      yield '      <REASON>ok</REASON>\n';
+      yield '    </ROUND_END>\n';
+      yield '  </ROUND>\n';
+      yield '  <SHIP round="1" composite="6.0" status="shipped">\n';
+      yield '    <ARTIFACT mime="text/html"><![CDATA[<p>final</p>]]></ARTIFACT>\n';
+      yield '    <SUMMARY>ok</SUMMARY>\n';
+      yield '  </SHIP>\n';
+      yield '</CRITIQUE_RUN>\n';
+    }
+    const outcome = await runAdapterConformance({
+      adapterId: 'synthetic-incomplete',
+      runId: 'run-incomplete',
+      source: incomplete(),
+    });
+    expect(outcome.kind).toBe('degraded');
+    if (outcome.kind !== 'degraded') return;
+    expect(outcome.reason).toBe('incomplete_panel');
+    expect(isDegraded('synthetic-incomplete')).toBe(true);
+  });
+
+  it('classifies a duplicate-SHIP stream as degraded parser_warning even though ship arrives first (lefarcen P2 follow-up)', async () => {
+    // Two `<SHIP>` blocks in the same transcript. The parser emits a
+    // SHIP event for the first and a `parser_warning` of kind
+    // `duplicate_ship` for the second; the warning arrives AFTER the
+    // ship. The harness must drain the rest of the stream and
+    // classify as degraded rather than returning on the first ship.
+    async function* duplicateShip(): AsyncIterable<string> {
+      yield '<CRITIQUE_RUN version="1" maxRounds="1" threshold="0.1" scale="10">\n';
+      yield '  <ROUND n="1">\n';
+      yield '    <PANELIST role="designer">\n';
+      yield '      <ARTIFACT mime="text/html"><![CDATA[<p>x</p>]]></ARTIFACT>\n';
+      yield '    </PANELIST>\n';
+      yield '    <PANELIST role="critic" score="6"><DIM name="x" score="6">n</DIM></PANELIST>\n';
+      yield '    <PANELIST role="brand" score="6"><DIM name="x" score="6">n</DIM></PANELIST>\n';
+      yield '    <PANELIST role="a11y" score="6"><DIM name="x" score="6">n</DIM></PANELIST>\n';
+      yield '    <PANELIST role="copy" score="6"><DIM name="x" score="6">n</DIM></PANELIST>\n';
+      yield '    <ROUND_END n="1" composite="6.0" must_fix="0" decision="ship">\n';
+      yield '      <REASON>ok</REASON>\n';
+      yield '    </ROUND_END>\n';
+      yield '  </ROUND>\n';
+      yield '  <SHIP round="1" composite="6.0" status="shipped">\n';
+      yield '    <ARTIFACT mime="text/html"><![CDATA[<p>first</p>]]></ARTIFACT>\n';
+      yield '    <SUMMARY>first</SUMMARY>\n';
+      yield '  </SHIP>\n';
+      // Second SHIP block triggers the parser_warning (duplicate_ship).
+      yield '  <SHIP round="1" composite="6.0" status="shipped">\n';
+      yield '    <ARTIFACT mime="text/html"><![CDATA[<p>second</p>]]></ARTIFACT>\n';
+      yield '    <SUMMARY>second</SUMMARY>\n';
+      yield '  </SHIP>\n';
+      yield '</CRITIQUE_RUN>\n';
+    }
+    const outcome = await runAdapterConformance({
+      adapterId: 'synthetic-duplicate-ship',
+      runId: 'run-dup',
+      source: duplicateShip(),
+    });
+    expect(outcome.kind).toBe('degraded');
+    if (outcome.kind !== 'degraded') return;
+    expect(outcome.reason).toBe('parser_warning');
+    // The events array must hold both the first ship AND the
+    // duplicate_ship warning so a debugger can see what happened.
+    expect(outcome.events.filter((e) => e.type === 'ship')).toHaveLength(1);
+    expect(
+      outcome.events.some(
+        (e) => e.type === 'parser_warning' && e.kind === 'duplicate_ship',
+      ),
+    ).toBe(true);
+    expect(isDegraded('synthetic-duplicate-ship')).toBe(true);
+  });
+
+  it('classifies a SHIP whose round did not close every cast role as incomplete_panel even if earlier rounds closed everyone (lefarcen P2 follow-up)', async () => {
+    // Round 1 closes all five cast roles cleanly. Round 2 closes only
+    // designer + critic before <SHIP round="2"> arrives. A cumulative
+    // (non-per-round) tracker would happily say "all five closed
+    // somewhere, ship is fine"; the corrected per-round tracker
+    // looks only at the shipping round's panelist_close set and
+    // flags incomplete_panel because brand / a11y / copy never
+    // closed in round 2.
+    async function* incompleteShippingRound(): AsyncIterable<string> {
+      yield '<CRITIQUE_RUN version="1" maxRounds="2" threshold="0.1" scale="10">\n';
+      // Round 1 — all five close.
+      yield '  <ROUND n="1">\n';
+      yield '    <PANELIST role="designer">\n';
+      yield '      <ARTIFACT mime="text/html"><![CDATA[<p>v1</p>]]></ARTIFACT>\n';
+      yield '    </PANELIST>\n';
+      yield '    <PANELIST role="critic" score="6"><DIM name="x" score="6">n</DIM></PANELIST>\n';
+      yield '    <PANELIST role="brand" score="6"><DIM name="x" score="6">n</DIM></PANELIST>\n';
+      yield '    <PANELIST role="a11y" score="6"><DIM name="x" score="6">n</DIM></PANELIST>\n';
+      yield '    <PANELIST role="copy" score="6"><DIM name="x" score="6">n</DIM></PANELIST>\n';
+      yield '    <ROUND_END n="1" composite="6.0" must_fix="3" decision="continue">\n';
+      yield '      <REASON>more work</REASON>\n';
+      yield '    </ROUND_END>\n';
+      yield '  </ROUND>\n';
+      // Round 2 — only designer + critic close (the cumulative bug
+      // would let this slide; the fix catches it).
+      yield '  <ROUND n="2">\n';
+      yield '    <PANELIST role="designer">\n';
+      yield '      <NOTES>iterating</NOTES>\n';
+      yield '    </PANELIST>\n';
+      yield '    <PANELIST role="critic" score="7"><DIM name="x" score="7">n</DIM></PANELIST>\n';
+      yield '    <ROUND_END n="2" composite="7.0" must_fix="0" decision="ship">\n';
+      yield '      <REASON>ok</REASON>\n';
+      yield '    </ROUND_END>\n';
+      yield '  </ROUND>\n';
+      yield '  <SHIP round="2" composite="7.0" status="shipped">\n';
+      yield '    <ARTIFACT mime="text/html"><![CDATA[<p>final</p>]]></ARTIFACT>\n';
+      yield '    <SUMMARY>ok</SUMMARY>\n';
+      yield '  </SHIP>\n';
+      yield '</CRITIQUE_RUN>\n';
+    }
+    const outcome = await runAdapterConformance({
+      adapterId: 'synthetic-incomplete-round-2',
+      runId: 'run-r2',
+      source: incompleteShippingRound(),
+    });
+    expect(outcome.kind).toBe('degraded');
+    if (outcome.kind !== 'degraded') return;
+    expect(outcome.reason).toBe('incomplete_panel');
+    expect(isDegraded('synthetic-incomplete-round-2')).toBe(true);
   });
 });

--- a/apps/daemon/tests/critique-ratchet.test.ts
+++ b/apps/daemon/tests/critique-ratchet.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Ratchet decision matrix (Phase 16). Drives `evaluateRollout` through
+ * every cell of the promote / hold / demote table the spec describes.
+ * The function is pure, so every case here is a direct (inputs ->
+ * outputs) assertion with no I/O.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  evaluateRollout,
+  type ConformanceDay,
+  type RatchetDecision,
+} from '../src/critique/ratchet.js';
+
+const FROZEN_NOW = () => new Date('2026-05-13T00:00:00Z');
+
+function isoDay(offsetDays: number): string {
+  const d = new Date(FROZEN_NOW().getTime() - offsetDays * 24 * 60 * 60 * 1000);
+  return d.toISOString().slice(0, 10);
+}
+
+function passingRow(date: string, adapter = 'mock'): ConformanceDay {
+  return { date, adapter, shippedRate: 0.95, cleanParseRate: 0.98, totalRuns: 100 };
+}
+
+function failingRow(date: string, adapter = 'mock'): ConformanceDay {
+  return { date, adapter, shippedRate: 0.30, cleanParseRate: 0.40, totalRuns: 100 };
+}
+
+describe('evaluateRollout (Phase 16)', () => {
+  it('promotes M0 -> M1 when every day in the window passes both thresholds', () => {
+    const history = Array.from({ length: 14 }, (_, i) => passingRow(isoDay(i)));
+    const decision = evaluateRollout({ current: 'M0', history, now: FROZEN_NOW });
+    expect(decision.kind).toBe('promote');
+    if (decision.kind === 'promote') {
+      expect(decision.from).toBe('M0');
+      expect(decision.to).toBe('M1');
+      expect(decision.evidenceDays).toBe(14);
+    }
+  });
+
+  it('promotes M2 -> M3 when every day passes', () => {
+    const history = Array.from({ length: 14 }, (_, i) => passingRow(isoDay(i)));
+    const decision = evaluateRollout({ current: 'M2', history, now: FROZEN_NOW });
+    expect(decision.kind).toBe('promote');
+    if (decision.kind === 'promote') expect(decision.to).toBe('M3');
+  });
+
+  it('holds at M3 when already at the ceiling (cannot promote further)', () => {
+    const history = Array.from({ length: 14 }, (_, i) => passingRow(isoDay(i)));
+    const decision = evaluateRollout({ current: 'M3', history, now: FROZEN_NOW });
+    expect(decision.kind).toBe('hold');
+    if (decision.kind === 'hold') {
+      expect(decision.current).toBe('M3');
+      expect(decision.reason).toContain('already at M3');
+      expect(decision.passingDays).toBe(14);
+    }
+  });
+
+  it('holds when one day in the window is a near-miss (89% shipped)', () => {
+    const history: ConformanceDay[] = [];
+    for (let i = 0; i < 14; i++) history.push(passingRow(isoDay(i)));
+    // Overwrite day 5 with a near-miss row.
+    history[5] = { date: isoDay(5), adapter: 'mock', shippedRate: 0.89, cleanParseRate: 0.98, totalRuns: 100 };
+    const decision = evaluateRollout({ current: 'M1', history, now: FROZEN_NOW });
+    expect(decision.kind).toBe('hold');
+    if (decision.kind === 'hold') {
+      expect(decision.passingDays).toBe(13);
+      expect(decision.observedDays).toBe(14);
+      expect(decision.reason).toContain('near-miss');
+    }
+  });
+
+  it('holds with "insufficient data" when only some window days have rows', () => {
+    const history = Array.from({ length: 7 }, (_, i) => passingRow(isoDay(i)));
+    const decision = evaluateRollout({ current: 'M1', history, now: FROZEN_NOW });
+    expect(decision.kind).toBe('hold');
+    if (decision.kind === 'hold') {
+      expect(decision.observedDays).toBe(7);
+      expect(decision.passingDays).toBe(7);
+      expect(decision.reason).toContain('insufficient data');
+    }
+  });
+
+  it('demotes M2 -> M1 when any day breaches the demote floor (shipped < 0.45)', () => {
+    const history = Array.from({ length: 14 }, (_, i) => passingRow(isoDay(i)));
+    history[3] = failingRow(isoDay(3));
+    const decision = evaluateRollout({ current: 'M2', history, now: FROZEN_NOW });
+    expect(decision.kind).toBe('demote');
+    if (decision.kind === 'demote') {
+      expect(decision.from).toBe('M2');
+      expect(decision.to).toBe('M1');
+      expect(decision.reason).toContain('fell below 45%');
+    }
+  });
+
+  it('cannot demote past M0; holds with a "would-demote" reason instead', () => {
+    const history: ConformanceDay[] = [];
+    for (let i = 0; i < 14; i++) history.push(passingRow(isoDay(i)));
+    history[3] = failingRow(isoDay(3));
+    const decision = evaluateRollout({ current: 'M0', history, now: FROZEN_NOW });
+    expect(decision.kind).toBe('hold');
+    if (decision.kind === 'hold') {
+      expect(decision.current).toBe('M0');
+      expect(decision.reason).toContain('already at M0');
+    }
+  });
+
+  it('aggregates across adapters per day as a weighted mean', () => {
+    // Two adapters, both observed for all 14 days. Adapter A passes
+    // at 0.95 shipped, adapter B passes at 0.92 shipped, both with
+    // equal weight (totalRuns = 100). Fleet shipped = 0.935, still
+    // above 0.90, so the day passes.
+    const history: ConformanceDay[] = [];
+    for (let i = 0; i < 14; i++) {
+      const date = isoDay(i);
+      history.push({ date, adapter: 'A', shippedRate: 0.95, cleanParseRate: 0.98, totalRuns: 100 });
+      history.push({ date, adapter: 'B', shippedRate: 0.92, cleanParseRate: 0.97, totalRuns: 100 });
+    }
+    const decision = evaluateRollout({ current: 'M1', history, now: FROZEN_NOW });
+    expect(decision.kind).toBe('promote');
+  });
+
+  it('does not double-count rows outside the window', () => {
+    // Days 0..13 inside, day 14 outside. Day 14 has a failing row that
+    // would otherwise trip the demote, but the evaluator should ignore
+    // it because it falls outside the rolling 14-day window.
+    const history: ConformanceDay[] = Array.from({ length: 14 }, (_, i) => passingRow(isoDay(i)));
+    history.push(failingRow(isoDay(14)));
+    const decision = evaluateRollout({ current: 'M1', history, now: FROZEN_NOW });
+    expect(decision.kind).toBe('promote');
+  });
+
+  it('clean-parse-rate gate fails the day even when shipped clears', () => {
+    const history: ConformanceDay[] = [];
+    for (let i = 0; i < 14; i++) {
+      history.push({ date: isoDay(i), adapter: 'mock', shippedRate: 0.95, cleanParseRate: 0.88, totalRuns: 100 });
+    }
+    const decision = evaluateRollout({ current: 'M1', history, now: FROZEN_NOW });
+    expect(decision.kind).toBe('hold');
+    if (decision.kind === 'hold') {
+      expect(decision.passingDays).toBe(0);
+      expect(decision.reason).toContain('near-miss');
+    }
+  });
+
+  it('refuses to promote on a zero-windowDays request even with no history (Codex + lefarcen P1)', () => {
+    // 0 >= 0 would trivially pass the promote gate at zero observed
+    // days without the entry-validation guard; assert that we hold
+    // with an explicit reason instead.
+    const decision = evaluateRollout({ current: 'M1', history: [], windowDays: 0, now: FROZEN_NOW });
+    expect(decision.kind).toBe('hold');
+    if (decision.kind === 'hold') {
+      expect(decision.reason).toContain('invalid windowDays');
+      expect(decision.passingDays).toBe(0);
+      expect(decision.observedDays).toBe(0);
+    }
+  });
+
+  it('refuses to evaluate on a negative windowDays', () => {
+    const decision = evaluateRollout({ current: 'M1', history: [], windowDays: -7, now: FROZEN_NOW });
+    expect(decision.kind).toBe('hold');
+    if (decision.kind === 'hold') expect(decision.reason).toContain('invalid windowDays');
+  });
+
+  it('refuses to evaluate on an out-of-range shippedThreshold', () => {
+    const decision = evaluateRollout({
+      current: 'M1',
+      history: [],
+      shippedThreshold: 1.5,
+      now: FROZEN_NOW,
+    });
+    expect(decision.kind).toBe('hold');
+    if (decision.kind === 'hold') expect(decision.reason).toContain('invalid shippedThreshold');
+  });
+
+  it('refuses to evaluate on a negative cleanParseThreshold', () => {
+    const decision = evaluateRollout({
+      current: 'M1',
+      history: [],
+      cleanParseThreshold: -0.1,
+      now: FROZEN_NOW,
+    });
+    expect(decision.kind).toBe('hold');
+    if (decision.kind === 'hold') expect(decision.reason).toContain('invalid cleanParseThreshold');
+  });
+
+  it('refuses NaN on every numeric input (PerishCode follow-up on PR #1499)', () => {
+    // Number.isFinite() rejects NaN, so the guard already handles
+    // these. Pin the behavior explicitly so a future refactor of the
+    // guard (`>= 0 && <= 1`, a typed parser, a clamp helper) cannot
+    // accidentally let NaN through and surface a zero-evidence
+    // promote signal.
+    const windowNaN = evaluateRollout({
+      current: 'M1',
+      history: [],
+      windowDays: Number.NaN,
+      now: FROZEN_NOW,
+    });
+    expect(windowNaN.kind).toBe('hold');
+    if (windowNaN.kind === 'hold') expect(windowNaN.reason).toContain('invalid windowDays');
+
+    const shippedNaN = evaluateRollout({
+      current: 'M1',
+      history: [],
+      shippedThreshold: Number.NaN,
+      now: FROZEN_NOW,
+    });
+    expect(shippedNaN.kind).toBe('hold');
+    if (shippedNaN.kind === 'hold') expect(shippedNaN.reason).toContain('invalid shippedThreshold');
+
+    const cleanNaN = evaluateRollout({
+      current: 'M1',
+      history: [],
+      cleanParseThreshold: Number.NaN,
+      now: FROZEN_NOW,
+    });
+    expect(cleanNaN.kind).toBe('hold');
+    if (cleanNaN.kind === 'hold') expect(cleanNaN.reason).toContain('invalid cleanParseThreshold');
+  });
+});
+
+// Type assertion: every RatchetDecision should be one of three kinds.
+// This is a compile-time guard, not a runtime test; if the discriminated
+// union grows a new kind, this will fail to compile until updated.
+const _decisionExhaustiveCheck = (d: RatchetDecision): string => {
+  switch (d.kind) {
+    case 'hold':
+    case 'promote':
+    case 'demote':
+      return d.kind;
+  }
+};
+void _decisionExhaustiveCheck;

--- a/apps/daemon/tests/critique-rollout.test.ts
+++ b/apps/daemon/tests/critique-rollout.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Coverage for the rollout-flag resolver (Phase 15). The orchestrator,
+ * the settings endpoint, and the conformance harness all read through
+ * `isCritiqueEnabled`, so the resolution order has to be airtight.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  isCritiqueEnabled,
+  parseEnvEnabled,
+  parseRolloutPhase,
+} from '../src/critique/rollout.js';
+
+describe('critique rollout flag resolver (Phase 15)', () => {
+  it('skill opt-out always wins, even on M3 global rollout', () => {
+    expect(
+      isCritiqueEnabled({
+        phase: 'M3',
+        skillPolicy: 'opt-out',
+        projectOverride: true,
+        envOverride: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('skill required always wins, even on M0 dark-launch', () => {
+    expect(
+      isCritiqueEnabled({
+        phase: 'M0',
+        skillPolicy: 'required',
+        projectOverride: false,
+        envOverride: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('project override beats env and rollout phase defaults', () => {
+    expect(
+      isCritiqueEnabled({
+        phase: 'M0',
+        skillPolicy: null,
+        projectOverride: true,
+        envOverride: false,
+      }),
+    ).toBe(true);
+    expect(
+      isCritiqueEnabled({
+        phase: 'M3',
+        skillPolicy: null,
+        projectOverride: false,
+        envOverride: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('env override flips an M0 default when no project override is set', () => {
+    expect(
+      isCritiqueEnabled({
+        phase: 'M0',
+        skillPolicy: null,
+        projectOverride: null,
+        envOverride: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('M0 default is off', () => {
+    expect(
+      isCritiqueEnabled({
+        phase: 'M0',
+        skillPolicy: null,
+        projectOverride: null,
+        envOverride: null,
+      }),
+    ).toBe(false);
+  });
+
+  it('M1 default is off (settings toggle has not been touched yet)', () => {
+    expect(
+      isCritiqueEnabled({
+        phase: 'M1',
+        skillPolicy: null,
+        projectOverride: null,
+        envOverride: null,
+      }),
+    ).toBe(false);
+  });
+
+  it('M2 default is on for opt-in skills only', () => {
+    expect(
+      isCritiqueEnabled({
+        phase: 'M2',
+        skillPolicy: 'opt-in',
+        projectOverride: null,
+        envOverride: null,
+      }),
+    ).toBe(true);
+    expect(
+      isCritiqueEnabled({
+        phase: 'M2',
+        skillPolicy: null,
+        projectOverride: null,
+        envOverride: null,
+      }),
+    ).toBe(false);
+  });
+
+  it('M3 default is on globally', () => {
+    expect(
+      isCritiqueEnabled({
+        phase: 'M3',
+        skillPolicy: null,
+        projectOverride: null,
+        envOverride: null,
+      }),
+    ).toBe(true);
+  });
+
+  it('parseRolloutPhase recognises every documented phase + falls back to M0', () => {
+    expect(parseRolloutPhase('M0')).toBe('M0');
+    expect(parseRolloutPhase('m1')).toBe('M1');
+    expect(parseRolloutPhase('  M2  ')).toBe('M2');
+    expect(parseRolloutPhase('M3')).toBe('M3');
+    expect(parseRolloutPhase('')).toBe('M0');
+    expect(parseRolloutPhase(undefined)).toBe('M0');
+    expect(parseRolloutPhase('M99')).toBe('M0');
+  });
+
+  it('parseEnvEnabled distinguishes truthy / falsy / missing', () => {
+    expect(parseEnvEnabled('1')).toBe(true);
+    expect(parseEnvEnabled('true')).toBe(true);
+    expect(parseEnvEnabled('YES')).toBe(true);
+    expect(parseEnvEnabled('on')).toBe(true);
+    expect(parseEnvEnabled('0')).toBe(false);
+    expect(parseEnvEnabled('false')).toBe(false);
+    expect(parseEnvEnabled('no')).toBe(false);
+    expect(parseEnvEnabled('OFF')).toBe(false);
+    expect(parseEnvEnabled(undefined)).toBeNull();
+    expect(parseEnvEnabled('')).toBeNull();
+    expect(parseEnvEnabled('maybe')).toBeNull();
+  });
+});

--- a/apps/daemon/tests/logging/critique.test.ts
+++ b/apps/daemon/tests/logging/critique.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Critique Theater structured logger test (Phase 12).
+ *
+ * Captures `process.stdout.write` while `logCritique` fires, parses the
+ * resulting JSON lines, and asserts the documented event shape. Locks
+ * the contract so an ingest pipeline (Loki / Datadog / Cloudwatch) that
+ * keys on `namespace=critique` and `event=...` does not silently break
+ * after a future refactor.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { logCritique } from '../../src/logging/critique.js';
+
+let captured: string[] = [];
+let originalWrite: typeof process.stdout.write;
+
+beforeEach(() => {
+  captured = [];
+  originalWrite = process.stdout.write.bind(process.stdout);
+  // Reassign rather than `vi.spyOn` because Node's overloaded
+  // `process.stdout.write` signature (string | Uint8Array, optional
+  // encoding, optional callback) does not narrow under
+  // MockInstance<unknown>. The override below captures the string
+  // form the logger uses and forwards bytes to the original sink
+  // for everything else so unrelated test output is not swallowed.
+  process.stdout.write = ((chunk: unknown, ...rest: unknown[]): boolean => {
+    if (typeof chunk === 'string') {
+      captured.push(chunk);
+      return true;
+    }
+    return (originalWrite as (chunk: unknown, ...rest: unknown[]) => boolean)(chunk, ...rest);
+  }) as typeof process.stdout.write;
+});
+
+afterEach(() => {
+  process.stdout.write = originalWrite;
+});
+
+function parseLines(): Array<Record<string, unknown>> {
+  return captured
+    .join('')
+    .split('\n')
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+describe('logCritique structured events (Phase 12)', () => {
+  it('emits run_started with adapter / skill / protocolVersion', () => {
+    logCritique({
+      event: 'run_started',
+      runId: 'r-1',
+      adapter: 'mock',
+      skill: 'unit-test',
+      protocolVersion: 1,
+    });
+    const lines = parseLines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatchObject({
+      event: 'run_started',
+      runId: 'r-1',
+      adapter: 'mock',
+      skill: 'unit-test',
+      protocolVersion: 1,
+      namespace: 'critique',
+    });
+    expect(typeof lines[0]!.timestamp).toBe('string');
+  });
+
+  it('emits round_closed with composite / mustFix / decision', () => {
+    logCritique({
+      event: 'round_closed',
+      runId: 'r-1',
+      round: 1,
+      composite: 8.6,
+      mustFix: 0,
+      decision: 'ship',
+    });
+    expect(parseLines()[0]).toMatchObject({
+      event: 'round_closed',
+      round: 1,
+      composite: 8.6,
+      mustFix: 0,
+      decision: 'ship',
+      namespace: 'critique',
+    });
+  });
+
+  it('emits run_shipped / degraded / parser_recover / run_failed', () => {
+    logCritique({
+      event: 'run_shipped', runId: 'r-1', round: 1, composite: 8.6, status: 'shipped',
+    });
+    logCritique({
+      event: 'degraded', runId: 'r-2', reason: 'malformed_block', adapter: 'mock',
+    });
+    logCritique({
+      event: 'parser_recover', runId: 'r-3', kind: 'composite_mismatch', position: 12,
+    });
+    logCritique({
+      event: 'run_failed', runId: 'r-4', cause: 'cli_exit_nonzero',
+    });
+    const lines = parseLines();
+    expect(lines).toHaveLength(4);
+    expect(lines.map((l) => l.event)).toEqual([
+      'run_shipped', 'degraded', 'parser_recover', 'run_failed',
+    ]);
+    for (const line of lines) {
+      expect(line.namespace).toBe('critique');
+      expect(typeof line.timestamp).toBe('string');
+    }
+  });
+
+  it('writes exactly one newline-terminated line per call', () => {
+    logCritique({ event: 'run_started', runId: 'r-1', adapter: 'm', skill: 's', protocolVersion: 1 });
+    logCritique({ event: 'run_started', runId: 'r-2', adapter: 'm', skill: 's', protocolVersion: 1 });
+    const joined = captured.join('');
+    const lines = joined.split('\n');
+    // joined ends with '\n' so split produces a trailing empty string.
+    expect(lines).toHaveLength(3);
+    expect(lines[2]).toBe('');
+  });
+});

--- a/apps/daemon/tests/metrics/critique.test.ts
+++ b/apps/daemon/tests/metrics/critique.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Critique Theater Prometheus registry shape test (Phase 12).
+ *
+ * Asserts every series the dashboard depends on is registered in the
+ * default registry and renders through `getCritiqueMetrics()` with the
+ * documented metric type. A rename or accidental drop would otherwise
+ * surface as an empty Grafana panel only at scrape time; this test
+ * catches it inside the daemon vitest lane.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  __resetCritiqueMetricsForTests,
+  critiqueCompositeScore,
+  critiqueDegradedTotal,
+  critiqueInterruptedTotal,
+  critiqueMustFixTotal,
+  critiqueParserErrorsTotal,
+  critiqueProtocolVersion,
+  critiqueRoundDurationMs,
+  critiqueRoundsTotal,
+  critiqueRunsTotal,
+  getCritiqueMetrics,
+  register,
+} from '../../src/metrics/index.js';
+
+afterEach(() => __resetCritiqueMetricsForTests());
+
+const EXPECTED_SERIES = [
+  { name: 'open_design_critique_runs_total', type: 'counter' as const },
+  { name: 'open_design_critique_rounds_total', type: 'counter' as const },
+  { name: 'open_design_critique_round_duration_ms', type: 'histogram' as const },
+  { name: 'open_design_critique_composite_score', type: 'histogram' as const },
+  { name: 'open_design_critique_must_fix_total', type: 'counter' as const },
+  { name: 'open_design_critique_degraded_total', type: 'counter' as const },
+  { name: 'open_design_critique_interrupted_total', type: 'counter' as const },
+  { name: 'open_design_critique_parser_errors_total', type: 'counter' as const },
+  { name: 'open_design_critique_protocol_version', type: 'gauge' as const },
+];
+
+describe('critique metrics registry (Phase 12)', () => {
+  it('registers every expected series in the default registry', () => {
+    const registered = register
+      .getMetricsAsArray()
+      .map((m) => ({ name: m.name, type: m.type }));
+    for (const want of EXPECTED_SERIES) {
+      const match = registered.find((r) => r.name === want.name);
+      expect(match, `expected ${want.name} to be registered`).toBeDefined();
+      expect(match!.type).toBe(want.type);
+    }
+  });
+
+  it('renders a happy-path bump into the exposition text', async () => {
+    critiqueRunsTotal.inc({ status: 'shipped', adapter: 'mock', skill: 'unit-test' });
+    critiqueRoundsTotal.inc({ adapter: 'mock', skill: 'unit-test' });
+    critiqueRoundDurationMs.observe({ adapter: 'mock', skill: 'unit-test', round: '1' }, 1234);
+    critiqueCompositeScore.observe({ adapter: 'mock', skill: 'unit-test' }, 8.6);
+    critiqueMustFixTotal.inc({
+      panelist: 'critic',
+      dim: 'hierarchy',
+      adapter: 'mock',
+      skill: 'unit-test',
+    });
+    critiqueDegradedTotal.inc({ reason: 'malformed_block', adapter: 'mock' });
+    critiqueInterruptedTotal.inc({ adapter: 'mock' });
+    critiqueParserErrorsTotal.inc({ kind: 'composite_mismatch', adapter: 'mock' });
+    critiqueProtocolVersion.set({ version: '1' }, 1);
+
+    const text = await getCritiqueMetrics();
+    expect(text).toContain('open_design_critique_runs_total{status="shipped",adapter="mock",skill="unit-test"} 1');
+    expect(text).toContain('open_design_critique_rounds_total{adapter="mock",skill="unit-test"} 1');
+    expect(text).toContain('open_design_critique_must_fix_total{panelist="critic",dim="hierarchy",adapter="mock",skill="unit-test"} 1');
+    expect(text).toContain('open_design_critique_degraded_total{reason="malformed_block",adapter="mock"} 1');
+    expect(text).toContain('open_design_critique_interrupted_total{adapter="mock"} 1');
+    expect(text).toContain('open_design_critique_parser_errors_total{kind="composite_mismatch",adapter="mock"} 1');
+    expect(text).toContain('open_design_critique_protocol_version{version="1"} 1');
+    // Histogram exposes _bucket / _sum / _count lines instead of a flat value.
+    expect(text).toContain('open_design_critique_round_duration_ms_bucket{');
+    expect(text).toContain('open_design_critique_composite_score_bucket{');
+  });
+
+  it('resets the registry between tests so cases stay isolated', async () => {
+    critiqueRunsTotal.inc({ status: 'shipped', adapter: 'a', skill: 's' }, 5);
+    __resetCritiqueMetricsForTests();
+    const text = await getCritiqueMetrics();
+    expect(text).not.toContain('open_design_critique_runs_total{status="shipped",adapter="a",skill="s"} 5');
+  });
+});

--- a/apps/daemon/tests/projects-routes.test.ts
+++ b/apps/daemon/tests/projects-routes.test.ts
@@ -12,7 +12,7 @@
  * than expanding any of them.
  */
 import type http from 'node:http';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -166,5 +166,112 @@ describe('GET /api/projects/:id resolvedDir', () => {
     const body = (await patchResp.json()) as { error?: { code?: string; message?: string } };
     expect(body.error?.code).toBe('BAD_REQUEST');
     expect(body.error?.message).toMatch(/fromTrustedPicker/i);
+  });
+
+  it('returns resolved Critique Theater settings for project and env overrides', async () => {
+    const projectId = `proj-critique-settings-${Date.now()}`;
+    const createResp = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id: projectId,
+        name: 'Critique settings fixture',
+        skillId: null,
+        designSystemId: null,
+        metadata: { critiqueTheaterEnabled: false },
+      }),
+    });
+    expect(createResp.status).toBe(200);
+
+    const previousEnabled = process.env.OD_CRITIQUE_ENABLED;
+    const previousPhase = process.env.OD_CRITIQUE_ROLLOUT_PHASE;
+    process.env.OD_CRITIQUE_ENABLED = '1';
+    process.env.OD_CRITIQUE_ROLLOUT_PHASE = 'M3';
+    try {
+      const resp = await fetch(`${baseUrl}/api/projects/${projectId}/critique/settings`);
+      expect(resp.status).toBe(200);
+      const body = (await resp.json()) as {
+        projectOverride: boolean | null;
+        envOverride: boolean | null;
+        phase: string;
+        skillPolicy: string | null;
+        enabled: boolean;
+      };
+      expect(body).toMatchObject({
+        projectOverride: false,
+        envOverride: true,
+        phase: 'M3',
+        skillPolicy: null,
+        enabled: false,
+      });
+    } finally {
+      if (previousEnabled === undefined) delete process.env.OD_CRITIQUE_ENABLED;
+      else process.env.OD_CRITIQUE_ENABLED = previousEnabled;
+      if (previousPhase === undefined) delete process.env.OD_CRITIQUE_ROLLOUT_PHASE;
+      else process.env.OD_CRITIQUE_ROLLOUT_PHASE = previousPhase;
+    }
+  });
+
+  it('lets skill critique policy participate in resolved Critique Theater settings', async () => {
+    const dataDir = process.env.OD_DATA_DIR;
+    if (!dataDir) throw new Error('OD_DATA_DIR is required for daemon route tests');
+    const skillDir = path.join(dataDir, 'skills', 'critique-required');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      path.join(skillDir, 'SKILL.md'),
+      [
+        '---',
+        'name: critique-required',
+        'description: Critique required fixture',
+        'od:',
+        '  critique:',
+        '    policy: required',
+        '---',
+        '',
+        '# Critique required',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const projectId = `proj-critique-policy-${Date.now()}`;
+    const createResp = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id: projectId,
+        name: 'Critique policy fixture',
+        skillId: 'critique-required',
+        designSystemId: null,
+      }),
+    });
+    expect(createResp.status).toBe(200);
+
+    const previousEnabled = process.env.OD_CRITIQUE_ENABLED;
+    const previousPhase = process.env.OD_CRITIQUE_ROLLOUT_PHASE;
+    delete process.env.OD_CRITIQUE_ENABLED;
+    process.env.OD_CRITIQUE_ROLLOUT_PHASE = 'M0';
+    try {
+      const resp = await fetch(`${baseUrl}/api/projects/${projectId}/critique/settings`);
+      expect(resp.status).toBe(200);
+      const body = (await resp.json()) as {
+        projectOverride: boolean | null;
+        envOverride: boolean | null;
+        phase: string;
+        skillPolicy: string | null;
+        enabled: boolean;
+      };
+      expect(body).toMatchObject({
+        projectOverride: null,
+        envOverride: null,
+        phase: 'M0',
+        skillPolicy: 'required',
+        enabled: true,
+      });
+    } finally {
+      if (previousEnabled === undefined) delete process.env.OD_CRITIQUE_ENABLED;
+      else process.env.OD_CRITIQUE_ENABLED = previousEnabled;
+      if (previousPhase === undefined) delete process.env.OD_CRITIQUE_ROLLOUT_PHASE;
+      else process.env.OD_CRITIQUE_ROLLOUT_PHASE = previousPhase;
+    }
   });
 });

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -94,6 +94,10 @@ import {
 import { AppChromeHeader } from './AppChromeHeader';
 import { AvatarMenu } from './AvatarMenu';
 import { ChatPane } from './ChatPane';
+import {
+  CritiqueTheaterMount,
+  useCritiqueTheaterEnabled,
+} from './Theater';
 import { decideAutoOpenAfterWrite } from './auto-open-file';
 import { FileWorkspace } from './FileWorkspace';
 import { Icon } from './Icon';
@@ -2367,8 +2371,14 @@ export function ProjectView({
     return () => window.removeEventListener('keydown', onKeyDown, { capture: true });
   }, [designMdState.exists, handleContinueInCli]);
 
+  const critiqueTheaterEnabled = useCritiqueTheaterEnabled();
+
   return (
     <div className="app">
+      <CritiqueTheaterMount
+        projectId={project.id}
+        enabled={critiqueTheaterEnabled}
+      />
       <AppChromeHeader
         onBack={onBack}
         backLabel={t('project.backToProjects')}

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -96,7 +96,7 @@ import { AvatarMenu } from './AvatarMenu';
 import { ChatPane } from './ChatPane';
 import {
   CritiqueTheaterMount,
-  useCritiqueTheaterEnabled,
+  useResolvedCritiqueTheaterEnabled,
 } from './Theater';
 import { decideAutoOpenAfterWrite } from './auto-open-file';
 import { FileWorkspace } from './FileWorkspace';
@@ -2371,7 +2371,7 @@ export function ProjectView({
     return () => window.removeEventListener('keydown', onKeyDown, { capture: true });
   }, [designMdState.exists, handleContinueInCli]);
 
-  const critiqueTheaterEnabled = useCritiqueTheaterEnabled();
+  const critiqueTheaterEnabled = useResolvedCritiqueTheaterEnabled(project.id);
 
   return (
     <div className="app">

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -23,7 +23,7 @@ import {
   syncMediaProvidersToDaemon,
 } from '../state/config';
 import type { KnownProvider } from '../state/config';
-import { navigate as navigateRoute } from '../router';
+import { navigate as navigateRoute, useRoute } from '../router';
 import {
   API_KEY_PLACEHOLDERS,
   API_PROTOCOL_LABELS,
@@ -65,6 +65,10 @@ import { ConnectorsBrowser } from './ConnectorsBrowser';
 import { MemoryModelInline } from './MemoryModelInline';
 import { MemorySection } from './MemorySection';
 import {
+  setCritiqueTheaterEnabled,
+  useCritiqueTheaterEnabled,
+} from './Theater';
+import {
   applyAppearanceToDocument,
   normalizeAccentColor,
 } from '../state/appearance';
@@ -88,6 +92,7 @@ export type SettingsSection =
   | 'mcpClient'
   | 'language'
   | 'appearance'
+  | 'critiqueTheater'
   | 'notifications'
   | 'pet'
   | 'skills'
@@ -1313,6 +1318,10 @@ export function SettingsDialog({
     mcpClient: { title: t('settings.externalMcpTitle'), subtitle: t('settings.externalMcpHint') },
     language: { title: t('settings.language'), subtitle: t('settings.languageHint') },
     appearance: { title: t('settings.appearance'), subtitle: t('settings.appearanceHint') },
+    critiqueTheater: {
+      title: t('critiqueTheater.settingsNav'),
+      subtitle: t('critiqueTheater.settingsNavHint'),
+    },
     notifications: { title: t('settings.notifications'), subtitle: t('settings.notificationsHint') },
     privacy: { title: t('settings.privacy'), subtitle: t('settings.privacyHint') },
     pet: { title: t('pet.title'), subtitle: t('pet.subtitle') },
@@ -1520,6 +1529,17 @@ export function SettingsDialog({
               <span>
                 <strong>{t('settings.appearance')}</strong>
                 <small>{t('settings.appearanceHint')}</small>
+              </span>
+            </button>
+            <button
+              type="button"
+              className={`settings-nav-item${activeSection === 'critiqueTheater' ? ' active' : ''}`}
+              onClick={() => setActiveSection('critiqueTheater')}
+            >
+              <Icon name="comment" size={18} />
+              <span>
+                <strong>{t('critiqueTheater.settingsNav')}</strong>
+                <small>{t('critiqueTheater.settingsNavHint')}</small>
               </span>
             </button>
             <button
@@ -2380,6 +2400,10 @@ export function SettingsDialog({
 
           {activeSection === 'appearance' ? (
             <AppearanceSection cfg={cfg} setCfg={setCfg} />
+          ) : null}
+
+          {activeSection === 'critiqueTheater' ? (
+            <CritiqueTheaterSection />
           ) : null}
 
           {activeSection === 'notifications' ? (
@@ -4613,6 +4637,50 @@ function AppearanceSection({
           />
         </div>
       </div>
+    </section>
+  );
+}
+
+function CritiqueTheaterSection() {
+  const { t } = useI18n();
+  const enabled = useCritiqueTheaterEnabled();
+  const route = useRoute();
+  const activeProjectId = route.kind === 'project' ? route.projectId : null;
+
+  return (
+    <section className="settings-section">
+      <div className="section-head">
+        <div>
+          <h3>{t('critiqueTheater.settingsNav')}</h3>
+          <p className="hint">{t('critiqueTheater.settingsNavHint')}</p>
+        </div>
+      </div>
+      <label className="field">
+        <span className="field-label">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => {
+              const next = e.target.checked;
+              if (activeProjectId !== null) {
+                setCritiqueTheaterEnabled(next, { projectId: activeProjectId });
+              } else {
+                setCritiqueTheaterEnabled(next);
+              }
+            }}
+          />
+          {' '}
+          {t('critiqueTheater.settingsEnabledLabel')}
+        </span>
+        <small className="hint">
+          {t('critiqueTheater.settingsEnabledDescription')}
+        </small>
+        <small className="hint">
+          {activeProjectId !== null
+            ? t('critiqueTheater.settingsEnabledProjectHint')
+            : t('critiqueTheater.settingsEnabledNoProjectHint')}
+        </small>
+      </label>
     </section>
   );
 }

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -66,7 +66,7 @@ import { MemoryModelInline } from './MemoryModelInline';
 import { MemorySection } from './MemorySection';
 import {
   setCritiqueTheaterEnabled,
-  useCritiqueTheaterEnabled,
+  useCritiqueTheaterProjectOverride,
 } from './Theater';
 import {
   applyAppearanceToDocument,
@@ -4643,9 +4643,9 @@ function AppearanceSection({
 
 function CritiqueTheaterSection() {
   const { t } = useI18n();
-  const enabled = useCritiqueTheaterEnabled();
   const route = useRoute();
   const activeProjectId = route.kind === 'project' ? route.projectId : null;
+  const enabled = useCritiqueTheaterProjectOverride(activeProjectId);
 
   return (
     <section className="settings-section">

--- a/apps/web/src/components/Theater/hooks/useCritiqueTheaterEnabled.ts
+++ b/apps/web/src/components/Theater/hooks/useCritiqueTheaterEnabled.ts
@@ -1,0 +1,238 @@
+import { useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'open-design:config';
+const TOGGLE_EVENT = 'open-design:critique-theater-toggle';
+
+interface ConfigShape {
+  critiqueTheaterEnabled?: boolean;
+  [k: string]: unknown;
+}
+
+/**
+ * Read the Settings-toggle flag for Critique Theater (Phase 15.3).
+ *
+ * Source of truth is the existing `open-design:config` localStorage
+ * blob the Settings panel already round-trips. The web layer reads the
+ * stored boolean; the daemon-side `isCritiqueEnabled` makes the final
+ * routing decision (project-level override, env override, rollout
+ * phase). When the two disagree, the daemon wins for backend gating
+ * and the web reflects what the user toggled.
+ *
+ * The hook participates in two refresh paths:
+ *
+ *   1. The platform `storage` event fires for other tabs and is how
+ *      the toggle stays in sync across browser windows.
+ *   2. A same-tab `open-design:critique-theater-toggle` CustomEvent so
+ *      a Settings save in the same window updates this hook without
+ *      a page reload. The Settings save handler emits the event after
+ *      it writes the new config blob.
+ *
+ * Same-tab payload handling (Siri-Ray + lefarcen P2 on PR #1320): the
+ * CustomEvent carries `detail.enabled: boolean`. The listener prefers
+ * the in-event payload over re-reading localStorage, because the
+ * setter intentionally swallows quota / private-mode write failures
+ * and still dispatches the event. Reading localStorage in that path
+ * would see the stale (or empty) blob and the in-session UI would
+ * lag the user's actual toggle. Storage events (cross-tab) do not
+ * carry a typed payload, so they still fall back to `readToggle()`.
+ */
+export function useCritiqueTheaterEnabled(): boolean {
+  const [enabled, setEnabled] = useState<boolean>(() => readToggle());
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const reload = (): void => setEnabled(readToggle());
+    const onStorage = (evt: StorageEvent): void => {
+      if (evt.key !== null && evt.key !== STORAGE_KEY) return;
+      reload();
+    };
+    const onCustom = (evt: Event): void => {
+      // Prefer the event's typed payload so a same-tab toggle still
+      // reflects in the UI even when localStorage is unwritable.
+      const detail = (evt as CustomEvent<{ enabled?: unknown }>).detail;
+      if (detail && typeof detail.enabled === 'boolean') {
+        setEnabled(detail.enabled);
+        return;
+      }
+      // Malformed CustomEvent (no detail, or detail.enabled not
+      // boolean): degrade to the localStorage path.
+      reload();
+    };
+    window.addEventListener('storage', onStorage);
+    window.addEventListener(TOGGLE_EVENT, onCustom);
+    reload();
+    return () => {
+      window.removeEventListener('storage', onStorage);
+      window.removeEventListener(TOGGLE_EVENT, onCustom);
+    };
+  }, []);
+  return enabled;
+}
+
+/**
+ * Imperative setter the Settings panel calls. Mutates the stored
+ * config, emits the same-tab CustomEvent so every mounted
+ * `useCritiqueTheaterEnabled` updates without a reload, and (when a
+ * project id is supplied) round-trips the same value through the
+ * existing `/api/projects/:id` settings endpoint so the daemon's
+ * spawn-time resolver picks the override up the next time the
+ * project starts a generation.
+ *
+ * Three writes, in order:
+ *
+ *   1. localStorage. What the web's `useCritiqueTheaterEnabled` hook
+ *      reads, so the in-session UI flips immediately.
+ *   2. Same-tab CustomEvent. Every mounted hook updates from the
+ *      typed payload without re-reading storage.
+ *   3. Project PATCH (when `projectId` is supplied). The setter GETs
+ *      the project, spreads its current `metadata` into the patch,
+ *      overlays `critiqueTheaterEnabled`, then PATCHes the merged
+ *      object. The read-merge-write is mandatory because
+ *      `PATCH /api/projects/:id` replaces `metadata` wholesale and a
+ *      bare patch would wipe the row's other fields (`kind`,
+ *      `templateId`, `linkedDirs`, ...). PerishCode P2 on PR #1338.
+ *
+ * Failure modes:
+ *
+ *   - localStorage rejected (quota / private mode): falls through to
+ *     the dispatch + PATCH; the in-session UI still flips.
+ *   - CustomEvent shim missing: single-mount remains correct.
+ *   - Project GET fails: PATCH is skipped entirely so the row's other
+ *     metadata fields are not at risk.
+ *   - PATCH fails: logged in dev; the in-session UI is already
+ *     consistent.
+ *
+ * `fetchProjectSettings` is a test seam mirroring the
+ * `fetchInterrupt` pattern on `CritiqueTheaterMount`; production
+ * callers pass nothing and the platform `fetch` is used.
+ */
+export interface SetCritiqueTheaterEnabledOptions {
+  /** Project id to round-trip the override through the daemon. */
+  projectId?: string;
+  /** Test seam: swap the PATCH transport. */
+  fetchProjectSettings?: (url: string, init: RequestInit) => Promise<Response>;
+}
+
+export function setCritiqueTheaterEnabled(
+  next: boolean,
+  options: SetCritiqueTheaterEnabledOptions = {},
+): void {
+  if (typeof window === 'undefined') return;
+  let parsed: ConfigShape = {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const candidate: unknown = JSON.parse(raw);
+      if (candidate && typeof candidate === 'object') {
+        parsed = candidate as ConfigShape;
+      }
+    }
+  } catch {
+    /* fall through to fresh object */
+  }
+  parsed.critiqueTheaterEnabled = next;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(parsed));
+  } catch {
+    /* private mode / quota / disabled storage: the in-session event
+       below still propagates to other mounts so the UI stays
+       consistent for the rest of the session. */
+  }
+  try {
+    window.dispatchEvent(new CustomEvent(TOGGLE_EVENT, { detail: { enabled: next } }));
+  } catch {
+    /* CustomEvent shim missing: single mount remains correct. */
+  }
+  // Round-trip the override through the existing project-settings
+  // endpoint so the daemon's spawn-time resolver picks it up on the
+  // next generation. Read-merge-write rather than a bare patch:
+  // `PATCH /api/projects/:id` replaces `metadata` wholesale (the
+  // route only re-stamps the three immutable folder-import fields),
+  // so sending only `{ critiqueTheaterEnabled }` would wipe `kind`,
+  // `templateId`, `linkedDirs`, and any other field the rest of the
+  // app reads. We GET the project first, overlay the toggle on the
+  // returned metadata, then PATCH the merged object. PerishCode P2
+  // on PR #1338.
+  //
+  // Failure handling:
+  //   - GET fails → skip the PATCH entirely. We cannot construct a
+  //     safe merged body without the current state, and a bare patch
+  //     would wipe other metadata. The in-session CustomEvent fired
+  //     above still keeps every mounted hook consistent; the next
+  //     save retries the round-trip.
+  //   - PATCH fails → log in dev. The in-session UI is already
+  //     correct via the CustomEvent.
+  //
+  // Skipped silently when no projectId is provided (the bare hook
+  // still works for integrators that drive a non-project surface).
+  if (options.projectId) {
+    const projectId = options.projectId;
+    const fetcher = options.fetchProjectSettings
+      ?? ((url: string, init: RequestInit) => fetch(url, init));
+    const projectUrl = `/api/projects/${encodeURIComponent(projectId)}`;
+    (async () => {
+      let existingMetadata: Record<string, unknown> = {};
+      try {
+        const getRes = await fetcher(projectUrl, { method: 'GET' });
+        if (!getRes.ok) {
+          throw new Error(`prefetch returned status ${getRes.status}`);
+        }
+        const body = (await getRes.json()) as {
+          project?: { metadata?: unknown };
+        };
+        const meta = body?.project?.metadata;
+        if (meta && typeof meta === 'object' && !Array.isArray(meta)) {
+          existingMetadata = meta as Record<string, unknown>;
+        }
+      } catch (err) {
+        if (
+          typeof process !== 'undefined'
+          && process.env?.NODE_ENV === 'development'
+        ) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            '[critique-theater] project-settings prefetch failed; skipping PATCH to avoid clobbering metadata',
+            err,
+          );
+        }
+        return;
+      }
+      try {
+        await fetcher(projectUrl, {
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            metadata: { ...existingMetadata, critiqueTheaterEnabled: next },
+          }),
+        });
+      } catch (err) {
+        if (
+          typeof process !== 'undefined'
+          && process.env?.NODE_ENV === 'development'
+        ) {
+          // eslint-disable-next-line no-console
+          console.warn('[critique-theater] project-settings PATCH failed', err);
+        }
+      }
+    })().catch(() => {
+      /* Already surfaced inside the async block. */
+    });
+  }
+}
+
+function readToggle(): boolean {
+  if (typeof window === 'undefined') return false;
+  let raw: string | null;
+  try {
+    raw = window.localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return false;
+  }
+  if (!raw) return false;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return false;
+    return (parsed as ConfigShape).critiqueTheaterEnabled === true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/web/src/components/Theater/hooks/useCritiqueTheaterEnabled.ts
+++ b/apps/web/src/components/Theater/hooks/useCritiqueTheaterEnabled.ts
@@ -8,6 +8,16 @@ interface ConfigShape {
   [k: string]: unknown;
 }
 
+export interface CritiqueTheaterProjectSettings {
+  projectOverride: boolean | null;
+  envOverride: boolean | null;
+  phase: 'M0' | 'M1' | 'M2' | 'M3';
+  skillPolicy: 'required' | 'opt-in' | 'opt-out' | null;
+  enabled: boolean;
+}
+
+type FetchProjectSettings = (url: string, init?: RequestInit) => Promise<Response>;
+
 /**
  * Read the Settings-toggle flag for Critique Theater (Phase 15.3).
  *
@@ -65,6 +75,117 @@ export function useCritiqueTheaterEnabled(): boolean {
       window.removeEventListener(TOGGLE_EVENT, onCustom);
     };
   }, []);
+  return enabled;
+}
+
+export function useResolvedCritiqueTheaterEnabled(projectId: string | null): boolean {
+  const [enabled, setEnabled] = useState<boolean>(() => (projectId ? false : readToggle()));
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (!projectId) {
+      const reload = (): void => setEnabled(readToggle());
+      const onStorage = (evt: StorageEvent): void => {
+        if (evt.key !== null && evt.key !== STORAGE_KEY) return;
+        reload();
+      };
+      const onCustom = (evt: Event): void => {
+        const detail = (evt as CustomEvent<{ enabled?: unknown }>).detail;
+        if (detail && typeof detail.enabled === 'boolean') {
+          setEnabled(detail.enabled);
+          return;
+        }
+        reload();
+      };
+      window.addEventListener('storage', onStorage);
+      window.addEventListener(TOGGLE_EVENT, onCustom);
+      reload();
+      return () => {
+        window.removeEventListener('storage', onStorage);
+        window.removeEventListener(TOGGLE_EVENT, onCustom);
+      };
+    }
+
+    let alive = true;
+    const reload = async (): Promise<void> => {
+      try {
+        const settings = await fetchCritiqueTheaterProjectSettings(projectId);
+        if (alive) setEnabled(settings.enabled);
+      } catch {
+        if (alive) setEnabled(readToggle());
+      }
+    };
+    const onCustom = (evt: Event): void => {
+      const detail = (evt as CustomEvent<{ enabled?: unknown; projectId?: unknown }>).detail;
+      if (detail?.projectId === projectId && typeof detail.enabled === 'boolean') {
+        setEnabled(detail.enabled);
+        void reload();
+        return;
+      }
+      void reload();
+    };
+    window.addEventListener(TOGGLE_EVENT, onCustom);
+    void reload();
+    return () => {
+      alive = false;
+      window.removeEventListener(TOGGLE_EVENT, onCustom);
+    };
+  }, [projectId]);
+
+  return enabled;
+}
+
+export function useCritiqueTheaterProjectOverride(projectId: string | null): boolean {
+  const [enabled, setEnabled] = useState<boolean>(() => (projectId ? false : readToggle()));
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (!projectId) {
+      const reload = (): void => setEnabled(readToggle());
+      const onStorage = (evt: StorageEvent): void => {
+        if (evt.key !== null && evt.key !== STORAGE_KEY) return;
+        reload();
+      };
+      const onCustom = (evt: Event): void => {
+        const detail = (evt as CustomEvent<{ enabled?: unknown }>).detail;
+        if (detail && typeof detail.enabled === 'boolean') {
+          setEnabled(detail.enabled);
+          return;
+        }
+        reload();
+      };
+      window.addEventListener('storage', onStorage);
+      window.addEventListener(TOGGLE_EVENT, onCustom);
+      reload();
+      return () => {
+        window.removeEventListener('storage', onStorage);
+        window.removeEventListener(TOGGLE_EVENT, onCustom);
+      };
+    }
+
+    let alive = true;
+    const reload = async (): Promise<void> => {
+      try {
+        const settings = await fetchCritiqueTheaterProjectSettings(projectId);
+        if (alive) setEnabled(settings.projectOverride === true);
+      } catch {
+        if (alive) setEnabled(false);
+      }
+    };
+    const onCustom = (evt: Event): void => {
+      const detail = (evt as CustomEvent<{ enabled?: unknown; projectId?: unknown }>).detail;
+      if (detail?.projectId === projectId && typeof detail.enabled === 'boolean') {
+        setEnabled(detail.enabled);
+      }
+    };
+    window.addEventListener(TOGGLE_EVENT, onCustom);
+    void reload();
+    return () => {
+      alive = false;
+      window.removeEventListener(TOGGLE_EVENT, onCustom);
+    };
+  }, [projectId]);
+
   return enabled;
 }
 
@@ -138,7 +259,9 @@ export function setCritiqueTheaterEnabled(
        consistent for the rest of the session. */
   }
   try {
-    window.dispatchEvent(new CustomEvent(TOGGLE_EVENT, { detail: { enabled: next } }));
+    window.dispatchEvent(new CustomEvent(TOGGLE_EVENT, {
+      detail: { enabled: next, projectId: options.projectId },
+    }));
   } catch {
     /* CustomEvent shim missing: single mount remains correct. */
   }
@@ -217,6 +340,49 @@ export function setCritiqueTheaterEnabled(
       /* Already surfaced inside the async block. */
     });
   }
+}
+
+export async function fetchCritiqueTheaterProjectSettings(
+  projectId: string,
+  fetchProjectSettings: FetchProjectSettings = (url, init) => fetch(url, init),
+): Promise<CritiqueTheaterProjectSettings> {
+  const res = await fetchProjectSettings(
+    `/api/projects/${encodeURIComponent(projectId)}/critique/settings`,
+    { method: 'GET' },
+  );
+  if (!res.ok) {
+    throw new Error(`critique settings returned status ${res.status}`);
+  }
+  const body = await res.json() as unknown;
+  return normalizeCritiqueTheaterProjectSettings(body);
+}
+
+function normalizeCritiqueTheaterProjectSettings(
+  value: unknown,
+): CritiqueTheaterProjectSettings {
+  const body = value && typeof value === 'object'
+    ? value as Partial<CritiqueTheaterProjectSettings>
+    : {};
+  const phase = body.phase === 'M1' || body.phase === 'M2' || body.phase === 'M3'
+    ? body.phase
+    : 'M0';
+  const skillPolicy =
+    body.skillPolicy === 'required'
+    || body.skillPolicy === 'opt-in'
+    || body.skillPolicy === 'opt-out'
+      ? body.skillPolicy
+      : null;
+  return {
+    projectOverride: typeof body.projectOverride === 'boolean'
+      ? body.projectOverride
+      : null,
+    envOverride: typeof body.envOverride === 'boolean'
+      ? body.envOverride
+      : null,
+    phase,
+    skillPolicy,
+    enabled: body.enabled === true,
+  };
 }
 
 function readToggle(): boolean {

--- a/apps/web/src/components/Theater/index.ts
+++ b/apps/web/src/components/Theater/index.ts
@@ -16,6 +16,10 @@ export { TheaterTranscript } from './TheaterTranscript';
 export { InterruptButton } from './InterruptButton';
 export { useCritiqueStream } from './hooks/useCritiqueStream';
 export { useCritiqueReplay } from './hooks/useCritiqueReplay';
+export {
+  setCritiqueTheaterEnabled,
+  useCritiqueTheaterEnabled,
+} from './hooks/useCritiqueTheaterEnabled';
 export type {
   CritiqueState,
   CritiqueAction,

--- a/apps/web/src/components/Theater/index.ts
+++ b/apps/web/src/components/Theater/index.ts
@@ -17,9 +17,13 @@ export { InterruptButton } from './InterruptButton';
 export { useCritiqueStream } from './hooks/useCritiqueStream';
 export { useCritiqueReplay } from './hooks/useCritiqueReplay';
 export {
+  fetchCritiqueTheaterProjectSettings,
+  useCritiqueTheaterProjectOverride,
+  useResolvedCritiqueTheaterEnabled,
   setCritiqueTheaterEnabled,
   useCritiqueTheaterEnabled,
 } from './hooks/useCritiqueTheaterEnabled';
+export type { CritiqueTheaterProjectSettings } from './hooks/useCritiqueTheaterEnabled';
 export type {
   CritiqueState,
   CritiqueAction,

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1246,6 +1246,15 @@ export const en: Dict = {
   'critiqueTheater.replaySpeedInstant': 'Instant',
   'critiqueTheater.replaySpeedLive': 'Live',
   'critiqueTheater.replaySpeedFast': 'Fast',
+  'critiqueTheater.settingsNav': 'Design Jury',
+  'critiqueTheater.settingsNavHint': 'Five-panel design review for your runs',
+  'critiqueTheater.settingsEnabledLabel': 'Show Design Jury during agent runs',
+  'critiqueTheater.settingsEnabledDescription':
+    'When enabled, a five-panel review appears alongside agent generations and scores the output before shipping. You can interrupt at any time.',
+  'critiqueTheater.settingsEnabledProjectHint':
+    'Saved for this project. New runs in this project will route through Design Jury server-side.',
+  'critiqueTheater.settingsEnabledNoProjectHint':
+    'Open a project to persist this server-side. Until then, this only changes the in-browser preference.',
 
   'pet.title': 'Pets',
   'pet.subtitle': 'Adopt a tiny companion that floats over your workspace.',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1210,6 +1210,15 @@ export const zhCN: Dict = {
   'critiqueTheater.replaySpeedInstant': '瞬时',
   'critiqueTheater.replaySpeedLive': '实时',
   'critiqueTheater.replaySpeedFast': '快进',
+  'critiqueTheater.settingsNav': '设计评审团',
+  'critiqueTheater.settingsNavHint': '为运行提供五角色设计评审',
+  'critiqueTheater.settingsEnabledLabel': '在 agent 运行时显示设计评审团',
+  'critiqueTheater.settingsEnabledDescription':
+    '启用后，五角色评审会在 agent 生成过程中显示，并在交付前为输出评分。你可以随时中断。',
+  'critiqueTheater.settingsEnabledProjectHint':
+    '已保存到当前项目。此项目的新运行会在服务端通过设计评审团。',
+  'critiqueTheater.settingsEnabledNoProjectHint':
+    '打开项目后才能在服务端持久化；在此之前这里只会修改浏览器内偏好。',
 
   'pet.title': '宠物',
   'pet.tabBuiltIn': '内置',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -1619,4 +1619,10 @@ export interface Dict {
   'critiqueTheater.replaySpeedInstant': string;
   'critiqueTheater.replaySpeedLive': string;
   'critiqueTheater.replaySpeedFast': string;
+  'critiqueTheater.settingsNav': string;
+  'critiqueTheater.settingsNavHint': string;
+  'critiqueTheater.settingsEnabledLabel': string;
+  'critiqueTheater.settingsEnabledDescription': string;
+  'critiqueTheater.settingsEnabledProjectHint': string;
+  'critiqueTheater.settingsEnabledNoProjectHint': string;
 }

--- a/apps/web/tests/components/ProjectView.critique-theater.test.tsx
+++ b/apps/web/tests/components/ProjectView.critique-theater.test.tsx
@@ -1,0 +1,245 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ProjectView } from '../../src/components/ProjectView';
+import type {
+  AgentInfo,
+  AppConfig,
+  Conversation,
+  DesignSystemSummary,
+  Project,
+  SkillSummary,
+} from '../../src/types';
+import {
+  fetchLiveArtifacts,
+  fetchPreviewComments,
+  fetchProjectFiles,
+} from '../../src/providers/registry';
+
+const theaterHarness = vi.hoisted(() => ({
+  resolvedEnabled: false,
+}));
+
+vi.mock('../../src/i18n', () => ({
+  useT: () => (key: string) => key,
+}));
+
+vi.mock('../../src/router', () => ({
+  navigate: vi.fn(),
+}));
+
+vi.mock('../../src/providers/anthropic', () => ({
+  streamMessage: vi.fn(),
+}));
+
+vi.mock('../../src/providers/daemon', () => ({
+  fetchChatRunStatus: vi.fn(),
+  listActiveChatRuns: vi.fn().mockResolvedValue([]),
+  reattachDaemonRun: vi.fn(),
+  streamViaDaemon: vi.fn(),
+}));
+
+vi.mock('../../src/providers/project-events', () => ({
+  useProjectFileEvents: vi.fn(),
+}));
+
+vi.mock('../../src/providers/registry', async () => {
+  const actual = await vi.importActual<typeof import('../../src/providers/registry')>(
+    '../../src/providers/registry',
+  );
+  return {
+    ...actual,
+    deletePreviewComment: vi.fn(),
+    fetchDesignSystem: vi.fn(),
+    fetchLiveArtifacts: vi.fn().mockResolvedValue([]),
+    fetchPreviewComments: vi.fn().mockResolvedValue([]),
+    fetchProjectFiles: vi.fn().mockResolvedValue([]),
+    fetchSkill: vi.fn(),
+    patchPreviewCommentStatus: vi.fn(),
+    upsertPreviewComment: vi.fn(),
+    writeProjectTextFile: vi.fn(),
+  };
+});
+
+vi.mock('../../src/state/projects', async () => {
+  const actual = await vi.importActual<typeof import('../../src/state/projects')>(
+    '../../src/state/projects',
+  );
+  const conversation: Conversation = {
+    id: 'conv-1',
+    projectId: 'project-1',
+    title: null,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+  return {
+    ...actual,
+    createConversation: vi.fn().mockResolvedValue(conversation),
+    deleteConversation: vi.fn(),
+    getTemplate: vi.fn().mockResolvedValue(null),
+    listConversations: vi.fn().mockResolvedValue([conversation]),
+    listMessages: vi.fn().mockResolvedValue([]),
+    loadTabs: vi.fn().mockResolvedValue({ tabs: [], active: null }),
+    patchConversation: vi.fn(),
+    patchProject: vi.fn(),
+    saveMessage: vi.fn(),
+    saveTabs: vi.fn(),
+  };
+});
+
+vi.mock('../../src/components/Theater', async () => {
+  const actual = await vi.importActual<typeof import('../../src/components/Theater')>(
+    '../../src/components/Theater',
+  );
+  return {
+    ...actual,
+    CritiqueTheaterMount: ({ enabled }: { enabled: boolean }) => (
+      enabled ? <div data-testid="critique-theater-mount" /> : null
+    ),
+    useResolvedCritiqueTheaterEnabled: vi.fn(() => theaterHarness.resolvedEnabled),
+  };
+});
+
+vi.mock('../../src/components/AppChromeHeader', () => ({
+  AppChromeHeader: ({ children }: { children: ReactNode }) => <header>{children}</header>,
+}));
+
+vi.mock('../../src/components/AvatarMenu', () => ({
+  AvatarMenu: () => null,
+}));
+
+vi.mock('../../src/components/FileWorkspace', () => ({
+  FileWorkspace: () => <div data-testid="file-workspace" />,
+}));
+
+vi.mock('../../src/components/Loading', () => ({
+  CenteredLoader: () => <div data-testid="loader" />,
+}));
+
+vi.mock('../../src/components/ChatPane', () => ({
+  ChatPane: () => <div data-testid="chat-pane" />,
+}));
+
+const mockedFetchProjectFiles = vi.mocked(fetchProjectFiles);
+const mockedFetchLiveArtifacts = vi.mocked(fetchLiveArtifacts);
+const mockedFetchPreviewComments = vi.mocked(fetchPreviewComments);
+
+const config: AppConfig = {
+  mode: 'api',
+  apiProtocol: 'openai',
+  apiKey: 'sk-test',
+  baseUrl: 'https://api.example.com',
+  model: 'model',
+  agentId: null,
+  skillId: null,
+  designSystemId: null,
+};
+
+const project: Project = {
+  id: 'project-1',
+  name: 'Project 1',
+  skillId: null,
+  designSystemId: null,
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+function ensureLocalStorage(): Storage {
+  const current = window.localStorage as Partial<Storage> | undefined;
+  if (
+    current
+    && typeof current.getItem === 'function'
+    && typeof current.setItem === 'function'
+    && typeof current.removeItem === 'function'
+    && typeof current.clear === 'function'
+  ) {
+    return current as Storage;
+  }
+  const values = new Map<string, string>();
+  const storage: Storage = {
+    get length() {
+      return values.size;
+    },
+    clear: () => {
+      values.clear();
+    },
+    getItem: (key: string) => values.get(key) ?? null,
+    key: (index: number) => Array.from(values.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      values.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      values.set(key, String(value));
+    },
+  };
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: storage,
+  });
+  return storage;
+}
+
+function renderProjectView() {
+  return render(
+    <ProjectView
+      project={project}
+      routeFileName={null}
+      config={config}
+      agents={[] as AgentInfo[]}
+      skills={[] as SkillSummary[]}
+      designTemplates={[] as SkillSummary[]}
+      designSystems={[] as DesignSystemSummary[]}
+      daemonLive
+      onModeChange={vi.fn()}
+      onAgentChange={vi.fn()}
+      onAgentModelChange={vi.fn()}
+      onRefreshAgents={vi.fn()}
+      onOpenSettings={vi.fn()}
+      onBack={vi.fn()}
+      onClearPendingPrompt={vi.fn()}
+      onTouchProject={vi.fn()}
+      onProjectChange={vi.fn()}
+      onProjectsRefresh={vi.fn()}
+    />,
+  );
+}
+
+describe('ProjectView Critique Theater resolved mount gating', () => {
+  beforeEach(() => {
+    ensureLocalStorage();
+    window.localStorage.setItem(
+      'open-design:config',
+      JSON.stringify({ critiqueTheaterEnabled: false }),
+    );
+    theaterHarness.resolvedEnabled = false;
+    mockedFetchProjectFiles.mockResolvedValue([]);
+    mockedFetchLiveArtifacts.mockResolvedValue([]);
+    mockedFetchPreviewComments.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    ensureLocalStorage();
+    window.localStorage.clear();
+  });
+
+  it('mounts Theater when daemon-resolved critique is enabled even if localStorage is false', async () => {
+    theaterHarness.resolvedEnabled = true;
+
+    renderProjectView();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('critique-theater-mount')).toBeTruthy();
+    });
+  });
+
+  it('keeps Theater disabled when the project resolved setting is disabled', async () => {
+    renderProjectView();
+
+    expect(screen.queryByTestId('critique-theater-mount')).toBeNull();
+  });
+});

--- a/apps/web/tests/components/SettingsDialog.critique-theater.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.critique-theater.test.tsx
@@ -1,0 +1,211 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SettingsDialog } from '../../src/components/SettingsDialog';
+import type { AgentInfo, AppConfig } from '../../src/types';
+
+vi.mock('../../src/providers/registry', async () => {
+  const actual = await vi.importActual<typeof import('../../src/providers/registry')>(
+    '../../src/providers/registry',
+  );
+  return {
+    ...actual,
+    fetchCodexPets: vi.fn().mockResolvedValue([]),
+    fetchDesignSystems: vi.fn().mockResolvedValue([]),
+    fetchSkills: vi.fn().mockResolvedValue([]),
+    syncCommunityPets: vi.fn().mockResolvedValue({ pets: [] }),
+  };
+});
+
+vi.mock('../../src/providers/provider-models', () => ({
+  fetchProviderModels: vi.fn(),
+}));
+
+const baseConfig: AppConfig = {
+  mode: 'api',
+  apiKey: '',
+  apiProtocol: 'anthropic',
+  baseUrl: 'https://api.anthropic.com',
+  model: 'claude-sonnet-4-5',
+  agentId: null,
+  skillId: null,
+  designSystemId: null,
+  mediaProviders: {},
+  agentModels: {},
+  agentCliEnv: {},
+};
+
+const availableAgents: AgentInfo[] = [
+  {
+    id: 'codex',
+    name: 'Codex CLI',
+    bin: 'codex',
+    available: true,
+    version: '0.80.0',
+    models: [{ id: 'default', label: 'Default' }],
+  },
+];
+
+function ensureLocalStorage(): Storage {
+  const current = window.localStorage as Partial<Storage> | undefined;
+  if (
+    current
+    && typeof current.getItem === 'function'
+    && typeof current.setItem === 'function'
+    && typeof current.removeItem === 'function'
+    && typeof current.clear === 'function'
+  ) {
+    return current as Storage;
+  }
+  const values = new Map<string, string>();
+  const storage: Storage = {
+    get length() {
+      return values.size;
+    },
+    clear: () => {
+      values.clear();
+    },
+    getItem: (key: string) => values.get(key) ?? null,
+    key: (index: number) => Array.from(values.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      values.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      values.set(key, String(value));
+    },
+  };
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: storage,
+  });
+  return storage;
+}
+
+function mockCritiqueSettings(overrides: Record<string, boolean | null>) {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+    const url = String(input);
+    const projectId = decodeURIComponent(url.split('/')[3] ?? '');
+    const projectOverride = overrides[projectId] ?? null;
+    return new Response(JSON.stringify({
+      projectOverride,
+      envOverride: null,
+      phase: 'M0',
+      skillPolicy: null,
+      enabled: projectOverride === true,
+    }), { status: 200, headers: { 'content-type': 'application/json' } });
+  });
+}
+
+function renderCritiqueSettings(projectId: string | null = null) {
+  window.history.replaceState(
+    null,
+    '',
+    projectId ? `/projects/${encodeURIComponent(projectId)}` : '/',
+  );
+  return render(
+    <SettingsDialog
+      initial={baseConfig}
+      agents={availableAgents}
+      daemonLive
+      appVersionInfo={null}
+      initialSection="critiqueTheater"
+      onPersist={vi.fn()}
+      onPersistComposioKey={vi.fn()}
+      onClose={vi.fn()}
+      onRefreshAgents={vi.fn()}
+    />,
+  );
+}
+
+describe('SettingsDialog Critique Theater project toggle', () => {
+  beforeEach(() => {
+    ensureLocalStorage();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    ensureLocalStorage();
+    window.localStorage.clear();
+  });
+
+  it('shows independent checked states for different active projects', async () => {
+    mockCritiqueSettings({
+      'project-a': true,
+      'project-b': false,
+    });
+
+    const view = renderCritiqueSettings('project-a');
+    const checkbox = await screen.findByRole('checkbox', {
+      name: /show design jury during agent runs/i,
+    });
+    await waitFor(() => expect(checkbox).toHaveProperty('checked', true));
+
+    view.unmount();
+    renderCritiqueSettings('project-b');
+    const projectBCheckbox = await screen.findByRole('checkbox', {
+      name: /show design jury during agent runs/i,
+    });
+    await waitFor(() => expect(projectBCheckbox).toHaveProperty('checked', false));
+  });
+
+  it('falls back to browser preference when Settings is opened off-project', async () => {
+    window.localStorage.setItem(
+      'open-design:config',
+      JSON.stringify({ critiqueTheaterEnabled: true }),
+    );
+    mockCritiqueSettings({});
+
+    renderCritiqueSettings(null);
+
+    const checkbox = await screen.findByRole('checkbox', {
+      name: /show design jury during agent runs/i,
+    });
+    expect(checkbox).toHaveProperty('checked', true);
+    expect(globalThis.fetch).not.toHaveBeenCalledWith(
+      expect.stringContaining('/critique/settings'),
+      expect.anything(),
+    );
+  });
+
+  it('keeps the project PATCH path when toggling inside a project', async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const url = String(input);
+      calls.push({ url, init });
+      if (init?.method === 'GET' && url === '/api/projects/project-a') {
+        return new Response(JSON.stringify({
+          project: { metadata: { kind: 'prototype', critiqueTheaterEnabled: false } },
+        }), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      if (init?.method === 'PATCH') {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      return new Response(JSON.stringify({
+        projectOverride: false,
+        envOverride: null,
+        phase: 'M0',
+        skillPolicy: null,
+        enabled: false,
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    });
+
+    renderCritiqueSettings('project-a');
+    const checkbox = await screen.findByRole('checkbox', {
+      name: /show design jury during agent runs/i,
+    });
+    fireEvent.click(checkbox);
+
+    await waitFor(() => {
+      const patch = calls.find((call) => call.init?.method === 'PATCH');
+      expect(patch).toBeTruthy();
+      expect(patch?.url).toBe('/api/projects/project-a');
+      expect(JSON.parse(String(patch?.init?.body))).toEqual({
+        metadata: { kind: 'prototype', critiqueTheaterEnabled: true },
+      });
+    });
+  });
+});

--- a/apps/web/tests/components/Theater/hooks/useCritiqueTheaterEnabled.test.tsx
+++ b/apps/web/tests/components/Theater/hooks/useCritiqueTheaterEnabled.test.tsx
@@ -1,0 +1,447 @@
+// @vitest-environment jsdom
+
+/**
+ * Coverage for the M1 Settings-toggle hook (Phase 15.3). The hook
+ * reads from the existing `open-design:config` localStorage blob and
+ * stays in sync via the platform `storage` event (cross-tab) and a
+ * `open-design:critique-theater-toggle` CustomEvent (same-tab).
+ */
+
+import { act, cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  setCritiqueTheaterEnabled,
+  useCritiqueTheaterEnabled,
+} from '../../../../src/components/Theater/hooks/useCritiqueTheaterEnabled';
+
+function ensureLocalStorage(): Storage {
+  const current = window.localStorage as Partial<Storage> | undefined;
+  if (
+    current
+    && typeof current.getItem === 'function'
+    && typeof current.setItem === 'function'
+    && typeof current.removeItem === 'function'
+    && typeof current.clear === 'function'
+  ) {
+    return current as Storage;
+  }
+
+  const values = new Map<string, string>();
+  const storage: Storage = {
+    get length() {
+      return values.size;
+    },
+    clear: () => {
+      values.clear();
+    },
+    getItem: (key: string) => values.get(key) ?? null,
+    key: (index: number) => Array.from(values.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      values.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      values.set(key, String(value));
+    },
+  };
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: storage,
+  });
+  return storage;
+}
+
+afterEach(() => {
+  cleanup();
+  ensureLocalStorage();
+  window.localStorage.clear();
+});
+
+beforeEach(() => {
+  ensureLocalStorage();
+  window.localStorage.clear();
+});
+
+function Probe({ sink }: { sink: { enabled?: boolean } }) {
+  sink.enabled = useCritiqueTheaterEnabled();
+  return null;
+}
+
+describe('useCritiqueTheaterEnabled (Phase 15.3)', () => {
+  it('returns false on first read with no stored config', () => {
+    const sink: { enabled?: boolean } = {};
+    render(<Probe sink={sink} />);
+    expect(sink.enabled).toBe(false);
+  });
+
+  it('reads the toggle from the existing open-design:config blob', () => {
+    window.localStorage.setItem(
+      'open-design:config',
+      JSON.stringify({
+        critiqueTheaterEnabled: true,
+        mode: 'daemon',
+      }),
+    );
+    const sink: { enabled?: boolean } = {};
+    render(<Probe sink={sink} />);
+    expect(sink.enabled).toBe(true);
+  });
+
+  it('flips when the same-tab CustomEvent fires (Settings save handshake)', () => {
+    const sink: { enabled?: boolean } = {};
+    render(<Probe sink={sink} />);
+    expect(sink.enabled).toBe(false);
+    act(() => {
+      setCritiqueTheaterEnabled(true);
+    });
+    expect(sink.enabled).toBe(true);
+    act(() => {
+      setCritiqueTheaterEnabled(false);
+    });
+    expect(sink.enabled).toBe(false);
+  });
+
+  it('preserves the rest of the stored config when writing the toggle', () => {
+    window.localStorage.setItem(
+      'open-design:config',
+      JSON.stringify({
+        mode: 'daemon',
+        apiKey: 'sk-test',
+        critiqueTheaterEnabled: false,
+      }),
+    );
+    setCritiqueTheaterEnabled(true);
+    const stored = JSON.parse(window.localStorage.getItem('open-design:config') ?? '{}');
+    expect(stored.critiqueTheaterEnabled).toBe(true);
+    // Other fields stay intact: the toggle handshake does not stomp
+    // user config.
+    expect(stored.mode).toBe('daemon');
+    expect(stored.apiKey).toBe('sk-test');
+  });
+
+  it('tolerates corrupted JSON in the stored config (returns false, does not throw)', () => {
+    window.localStorage.setItem('open-design:config', 'not json');
+    const sink: { enabled?: boolean } = {};
+    render(<Probe sink={sink} />);
+    expect(sink.enabled).toBe(false);
+  });
+
+  it('reacts to cross-tab storage events', () => {
+    const sink: { enabled?: boolean } = {};
+    render(<Probe sink={sink} />);
+    expect(sink.enabled).toBe(false);
+    act(() => {
+      window.localStorage.setItem(
+        'open-design:config',
+        JSON.stringify({ critiqueTheaterEnabled: true }),
+      );
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: 'open-design:config',
+          newValue: JSON.stringify({ critiqueTheaterEnabled: true }),
+        }),
+      );
+    });
+    expect(sink.enabled).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Failure-mode coverage (lefarcen P2 on PR #1320). The hook + setter both
+  // intentionally swallow these errors in production so a private-mode browser
+  // or a stripped CustomEvent shim does not crash the React tree. The tests
+  // below pin that behavior so the swallow is not silently traded for a throw
+  // in a future refactor.
+  // ---------------------------------------------------------------------------
+
+  it('returns false and does not throw when stored JSON is a non-object value (array)', () => {
+    // `JSON.parse('[1,2,3]')` is a valid array, not an object. The hook must
+    // not treat that as a config blob; the `critiqueTheaterEnabled` lookup
+    // would fall through to `undefined` and the function should return false.
+    window.localStorage.setItem('open-design:config', '[1,2,3]');
+    const sink: { enabled?: boolean } = {};
+    render(<Probe sink={sink} />);
+    expect(sink.enabled).toBe(false);
+  });
+
+  it('returns false and does not throw when stored JSON parses to null', () => {
+    // `null` is JSON-valid and `typeof null === 'object'` in JS, so the
+    // guard has to check for null explicitly. If it did not, `null.critique...`
+    // would throw on read.
+    window.localStorage.setItem('open-design:config', 'null');
+    const sink: { enabled?: boolean } = {};
+    render(<Probe sink={sink} />);
+    expect(sink.enabled).toBe(false);
+  });
+
+  it('returns false when localStorage.getItem throws (private mode / disabled storage)', () => {
+    const original = window.localStorage.getItem;
+    const restore = () => {
+      Object.defineProperty(window.localStorage, 'getItem', {
+        configurable: true,
+        value: original,
+      });
+    };
+    try {
+      Object.defineProperty(window.localStorage, 'getItem', {
+        configurable: true,
+        value: () => {
+          throw new DOMException(
+            'storage disabled (synthetic)',
+            'SecurityError',
+          );
+        },
+      });
+      const sink: { enabled?: boolean } = {};
+      render(<Probe sink={sink} />);
+      // Hook swallows the throw; UI sees `false` and the rest of the app
+      // keeps running.
+      expect(sink.enabled).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
+  it('falls back to readToggle when the same-tab CustomEvent carries no usable detail', () => {
+    // A malformed dispatcher (no detail at all, or detail.enabled not a
+    // boolean) must not break the listener. The hook degrades to the
+    // localStorage path so cross-tab semantics still work for a stale
+    // emitter. Siri-Ray + lefarcen P2 on PR #1320.
+    window.localStorage.setItem(
+      'open-design:config',
+      JSON.stringify({ critiqueTheaterEnabled: true }),
+    );
+    const sink: { enabled?: boolean } = {};
+    render(<Probe sink={sink} />);
+    expect(sink.enabled).toBe(true);
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('open-design:critique-theater-toggle', {
+          // No detail at all.
+        }),
+      );
+    });
+    // Storage still says true; listener falls back to readToggle and
+    // keeps reporting true.
+    expect(sink.enabled).toBe(true);
+    act(() => {
+      window.localStorage.setItem(
+        'open-design:config',
+        JSON.stringify({ critiqueTheaterEnabled: false }),
+      );
+      window.dispatchEvent(
+        new CustomEvent('open-design:critique-theater-toggle', {
+          // Detail with wrong shape: not a boolean.
+          detail: { enabled: 'maybe' },
+        }),
+      );
+    });
+    // Same path: malformed detail falls back to readToggle, which
+    // now sees the freshly-written `false`.
+    expect(sink.enabled).toBe(false);
+  });
+
+  it('still emits the same-tab CustomEvent when localStorage.setItem throws (quota / disabled storage)', () => {
+    // setCritiqueTheaterEnabled writes localStorage first and then dispatches
+    // the same-tab event. If the write throws (quota exceeded, private mode),
+    // the production code falls through to the dispatch so every mounted
+    // hook in the session still updates even though the value cannot
+    // persist across reloads. The listener honors the event's typed
+    // detail payload directly (it does NOT read localStorage), so the
+    // UI stays consistent even when the write was rejected. Siri-Ray
+    // + lefarcen P2 on PR #1320.
+    const original = window.localStorage.setItem;
+    const restore = () => {
+      Object.defineProperty(window.localStorage, 'setItem', {
+        configurable: true,
+        value: original,
+      });
+    };
+    try {
+      Object.defineProperty(window.localStorage, 'setItem', {
+        configurable: true,
+        value: () => {
+          throw new DOMException(
+            'quota exceeded (synthetic)',
+            'QuotaExceededError',
+          );
+        },
+      });
+
+      const sink: { enabled?: boolean } = {};
+      render(<Probe sink={sink} />);
+      expect(sink.enabled).toBe(false);
+      act(() => {
+        setCritiqueTheaterEnabled(true);
+      });
+      // The dispatch path is exercised even though localStorage rejected
+      // the write: every mounted hook updates from the in-session event.
+      expect(sink.enabled).toBe(true);
+    } finally {
+      restore();
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Project-settings round-trip (lefarcen P2 on PR #1338). The setter writes
+  // the override to localStorage AND, when a projectId is provided, PATCHes
+  // /api/projects/:id with metadata.critiqueTheaterEnabled so the daemon's
+  // spawn-time resolver picks up the same value on the next generation.
+  // ---------------------------------------------------------------------------
+
+  it('GETs the project then PATCHes with merged metadata when a projectId is supplied', async () => {
+    // PerishCode P2 on PR #1338: the daemon's `updateProject` does a
+    // shallow `{ ...existing, ...patch }`, so `patch.metadata` REPLACES
+    // the row's metadata. Sending only `{ critiqueTheaterEnabled }` in
+    // the patch would wipe `kind`, `templateId`, `linkedDirs`, and
+    // every other field the rest of the app reads. The setter has to
+    // read the current metadata first and overlay the toggle on top.
+    const fetchCalls: Array<{ url: string; method: string; body: string | null }> = [];
+    const fetchProjectSettings = (url: string, init: RequestInit) => {
+      const method = init.method ?? 'GET';
+      const body = init.body ? String(init.body) : null;
+      fetchCalls.push({ url, method, body });
+      if (method === 'GET') {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              project: {
+                id: 'proj-abc',
+                name: 'p',
+                metadata: {
+                  kind: 'template',
+                  templateId: 'modern-blog',
+                  linkedDirs: ['/Users/me/work'],
+                },
+              },
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          ),
+        );
+      }
+      return Promise.resolve(new Response(null, { status: 200 }));
+    };
+    await act(async () => {
+      setCritiqueTheaterEnabled(true, {
+        projectId: 'proj-abc',
+        fetchProjectSettings,
+      });
+      // Let the GET + PATCH microtasks settle.
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(fetchCalls).toHaveLength(2);
+    expect(fetchCalls[0]).toMatchObject({
+      url: '/api/projects/proj-abc',
+      method: 'GET',
+    });
+    expect(fetchCalls[1]).toMatchObject({
+      url: '/api/projects/proj-abc',
+      method: 'PATCH',
+    });
+    const body = JSON.parse(fetchCalls[1]!.body ?? '{}');
+    expect(body).toEqual({
+      metadata: {
+        kind: 'template',
+        templateId: 'modern-blog',
+        linkedDirs: ['/Users/me/work'],
+        critiqueTheaterEnabled: true,
+      },
+    });
+  });
+
+  it('PATCHes with just the toggle when the project has no prior metadata', async () => {
+    const fetchCalls: Array<{ url: string; method: string; body: string | null }> = [];
+    const fetchProjectSettings = (url: string, init: RequestInit) => {
+      const method = init.method ?? 'GET';
+      const body = init.body ? String(init.body) : null;
+      fetchCalls.push({ url, method, body });
+      if (method === 'GET') {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ project: { id: 'proj-bare', name: 'p' } }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          ),
+        );
+      }
+      return Promise.resolve(new Response(null, { status: 200 }));
+    };
+    await act(async () => {
+      setCritiqueTheaterEnabled(true, {
+        projectId: 'proj-bare',
+        fetchProjectSettings,
+      });
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(fetchCalls).toHaveLength(2);
+    const body = JSON.parse(fetchCalls[1]!.body ?? '{}');
+    expect(body).toEqual({ metadata: { critiqueTheaterEnabled: true } });
+  });
+
+  it('skips the daemon PATCH when no projectId is supplied (bare integrator surface)', () => {
+    const fetchProjectSettings = vi.fn(() =>
+      Promise.resolve(new Response(null, { status: 200 })),
+    );
+    act(() => {
+      setCritiqueTheaterEnabled(true, { fetchProjectSettings });
+    });
+    expect(fetchProjectSettings).not.toHaveBeenCalled();
+  });
+
+  it('skips the PATCH (does not stomp metadata) when the prefetch GET fails', async () => {
+    // If the GET fails we cannot construct a safe merged patch, and a
+    // bare `{ metadata: { critiqueTheaterEnabled } }` would wipe the
+    // project's other metadata fields server-side. Swallow the failure
+    // and rely on the in-session CustomEvent for UI consistency; the
+    // next save retries the round-trip.
+    const fetchCalls: Array<{ url: string; method: string }> = [];
+    const fetchProjectSettings = (url: string, init: RequestInit) => {
+      fetchCalls.push({ url, method: init.method ?? 'GET' });
+      if ((init.method ?? 'GET') === 'GET') {
+        return Promise.reject(new Error('network down'));
+      }
+      return Promise.resolve(new Response(null, { status: 200 }));
+    };
+    const sink: { enabled?: boolean } = {};
+    render(<Probe sink={sink} />);
+    await act(async () => {
+      setCritiqueTheaterEnabled(true, {
+        projectId: 'proj-abc',
+        fetchProjectSettings,
+      });
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    // Only the GET fired; the PATCH was skipped because we could not
+    // build a safe merged body.
+    expect(fetchCalls.map((c) => c.method)).toEqual(['GET']);
+    // In-session UI still flips via the CustomEvent.
+    expect(sink.enabled).toBe(true);
+  });
+
+  it('swallows a rejected PATCH after a successful prefetch so the in-session UI still flips', async () => {
+    const fetchProjectSettings = (url: string, init: RequestInit) => {
+      if ((init.method ?? 'GET') === 'GET') {
+        return Promise.resolve(
+          new Response(JSON.stringify({ project: { id: 'p', metadata: {} } }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      return Promise.reject(new Error('boom'));
+    };
+    const sink: { enabled?: boolean } = {};
+    render(<Probe sink={sink} />);
+    expect(sink.enabled).toBe(false);
+    await act(async () => {
+      setCritiqueTheaterEnabled(true, {
+        projectId: 'proj-abc',
+        fetchProjectSettings,
+      });
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    // The localStorage write + the CustomEvent dispatch fire before
+    // the network round-trip, so the in-session UI flips regardless of
+    // the network outcome. A transient PATCH failure does not unwind
+    // the flip; the next save retries.
+    expect(sink.enabled).toBe(true);
+  });
+});

--- a/apps/web/tests/components/Theater/hooks/useCritiqueTheaterEnabled.test.tsx
+++ b/apps/web/tests/components/Theater/hooks/useCritiqueTheaterEnabled.test.tsx
@@ -7,12 +7,13 @@
  * `open-design:critique-theater-toggle` CustomEvent (same-tab).
  */
 
-import { act, cleanup, render } from '@testing-library/react';
+import { act, cleanup, render, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   setCritiqueTheaterEnabled,
   useCritiqueTheaterEnabled,
+  useResolvedCritiqueTheaterEnabled,
 } from '../../../../src/components/Theater/hooks/useCritiqueTheaterEnabled';
 
 function ensureLocalStorage(): Storage {
@@ -53,6 +54,11 @@ function ensureLocalStorage(): Storage {
 
 afterEach(() => {
   cleanup();
+  const fetchMock = globalThis.fetch as typeof globalThis.fetch & {
+    mockRestore?: () => void;
+  };
+  fetchMock.mockRestore?.();
+  vi.clearAllMocks();
   ensureLocalStorage();
   window.localStorage.clear();
 });
@@ -64,6 +70,17 @@ beforeEach(() => {
 
 function Probe({ sink }: { sink: { enabled?: boolean } }) {
   sink.enabled = useCritiqueTheaterEnabled();
+  return null;
+}
+
+function ResolvedProbe({
+  projectId,
+  sink,
+}: {
+  projectId: string | null;
+  sink: { enabled?: boolean };
+}) {
+  sink.enabled = useResolvedCritiqueTheaterEnabled(projectId);
   return null;
 }
 
@@ -143,6 +160,54 @@ describe('useCritiqueTheaterEnabled (Phase 15.3)', () => {
       );
     });
     expect(sink.enabled).toBe(true);
+  });
+
+  it('uses the daemon-resolved project setting even when localStorage is false', async () => {
+    window.localStorage.setItem(
+      'open-design:config',
+      JSON.stringify({ critiqueTheaterEnabled: false }),
+    );
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({
+        projectOverride: null,
+        envOverride: true,
+        phase: 'M0',
+        skillPolicy: null,
+        enabled: true,
+      }), { status: 200, headers: { 'content-type': 'application/json' } }),
+    );
+
+    const sink: { enabled?: boolean } = {};
+    render(<ResolvedProbe projectId="proj-1" sink={sink} />);
+
+    await waitFor(() => expect(sink.enabled).toBe(true));
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/api/projects/proj-1/critique/settings',
+      { method: 'GET' },
+    );
+  });
+
+  it('keeps project mode disabled until the daemon response enables it', async () => {
+    window.localStorage.setItem(
+      'open-design:config',
+      JSON.stringify({ critiqueTheaterEnabled: true }),
+    );
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({
+        projectOverride: false,
+        envOverride: true,
+        phase: 'M3',
+        skillPolicy: null,
+        enabled: false,
+      }), { status: 200, headers: { 'content-type': 'application/json' } }),
+    );
+
+    const sink: { enabled?: boolean } = {};
+    render(<ResolvedProbe projectId="proj-1" sink={sink} />);
+
+    expect(sink.enabled).toBe(false);
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+    expect(sink.enabled).toBe(false);
   });
 
   // ---------------------------------------------------------------------------

--- a/e2e/ui/critique-theater.test.ts
+++ b/e2e/ui/critique-theater.test.ts
@@ -121,12 +121,21 @@ async function stubProjectEvents(page: Page, frames: CritiqueFrame[]): Promise<v
   });
 }
 
-// Parked behind test.describe.fixme until the follow-up that lands the
-// PNG baselines + the goto('/projects/:id') fixture (the current bootstrap
-// lands on '/' where ProjectView is not mounted, so CritiqueTheaterMount
-// never renders and every assertion times out). Removed from
-// test:ui:extended in the same merge per PerishCode P1 on PR #1338.
-test.describe.fixme('Critique Theater e2e (Phase 11)', () => {
+/**
+ * Parked behind `test.describe.fixme` until the next follow-up PR
+ * (PerishCode P1 on PR #1338). The suite as written assumes the route
+ * at `/` mounts `<ProjectView>` and therefore renders
+ * `<CritiqueTheaterMount>`, but the home route shows the entry gallery;
+ * the mount only renders inside `/projects/:id`. The follow-up commit
+ * replaces the `await page.goto('/')` calls with seeded-project
+ * navigation (similar to `app-design-files.test.ts`), splits the SSE
+ * fixture into a live prefix and a terminal suffix (Codex P2 on PR
+ * #1320), and commits the first PNG baselines. Until that lands, the
+ * suite would time out on every assertion; `fixme` skips at run time
+ * while keeping the spec visible to the contributor who finishes the
+ * wireup.
+ */
+test.describe.fixme('Critique Theater e2e (Phase 11) [awaiting full mount-route follow-up, see file header]', () => {
   test.beforeEach(async ({ page }) => {
     await bootAppWithCritiqueEnabled(page);
   });

--- a/nix/package-daemon.nix
+++ b/nix/package-daemon.nix
@@ -44,7 +44,7 @@ let
   # `nix build .#daemon` will fail with the expected hash printed; copy
   # that into `pnpmDepsHash` below. Bump it whenever pnpm-lock.yaml
   # changes.
-  pnpmDepsHash = "sha256-HFLm+8hv3o5x3Xem4MXNsNclIgiVRc70+EBafL0rVn8=";
+  pnpmDepsHash = "sha256-7R1sQC38gOT0gsZ2oNOviCZ486cbbGJGJCis6WI8z9s=";
   # pnpmDepsHash = lib.fakeHash;
 in
   stdenv.mkDerivation (finalAttrs: {

--- a/nix/package-web.nix
+++ b/nix/package-web.nix
@@ -30,7 +30,7 @@ let
   # `nix build .#web` will fail with the expected hash printed; copy
   # that into `pnpmDepsHash` below. Bump it whenever pnpm-lock.yaml
   # changes.
-  pnpmDepsHash = "sha256-HFLm+8hv3o5x3Xem4MXNsNclIgiVRc70+EBafL0rVn8=";
+  pnpmDepsHash = "sha256-7R1sQC38gOT0gsZ2oNOviCZ486cbbGJGJCis6WI8z9s=";
   # pnpmDepsHash = lib.fakeHash;
 in
   stdenv.mkDerivation (finalAttrs: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@open-design/sidecar-proto':
         specifier: workspace:*
         version: link:../../packages/sidecar-proto
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.1
       better-sqlite3:
         specifier: ^12.9.0
         version: 12.9.0
@@ -62,6 +65,9 @@ importers:
       multer:
         specifier: ^2.1.1
         version: 2.1.1
+      prom-client:
+        specifier: ^15.1.0
+        version: 15.1.3
       undici:
         specifier: ^7.16.0
         version: 7.25.0
@@ -212,7 +218,7 @@ importers:
         version: link:../../packages/sidecar-proto
       next:
         specifier: ^16.2.5
-        version: 16.2.5(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 16.2.5(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       openai:
         specifier: ^6.36.0
         version: 6.36.0(zod@4.4.2)
@@ -1343,6 +1349,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
@@ -2006,6 +2016,9 @@ packages:
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -3692,6 +3705,10 @@ packages:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
 
+  prom-client@15.1.3:
+    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
+    engines: {node: ^16 || ^18 || >=20}
+
   promise-retry@2.0.1:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
     engines: {node: '>=10'}
@@ -4122,6 +4139,9 @@ packages:
   tar@7.5.13:
     resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
     engines: {node: '>=18'}
+
+  tdigest@0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
   temp-file@3.4.0:
     resolution: {integrity: sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==}
@@ -5505,6 +5525,8 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.2.5':
     optional: true
 
+  '@opentelemetry/api@1.9.1': {}
+
   '@oslojs/encoding@1.1.0': {}
 
   '@playwright/test@1.59.1':
@@ -6262,6 +6284,8 @@ snapshots:
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
+
+  bintrees@1.0.2: {}
 
   bl@4.1.0:
     dependencies:
@@ -8066,7 +8090,7 @@ snapshots:
 
   neotraverse@0.6.18: {}
 
-  next@16.2.5(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@16.2.5(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 16.2.5
       '@swc/helpers': 0.5.15
@@ -8085,6 +8109,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.5
       '@next/swc-win32-arm64-msvc': 16.2.5
       '@next/swc-win32-x64-msvc': 16.2.5
+      '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.59.1
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -8316,6 +8341,11 @@ snapshots:
   process-nextick-args@2.0.1: {}
 
   progress@2.0.3: {}
+
+  prom-client@15.1.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      tdigest: 0.1.2
 
   promise-retry@2.0.1:
     dependencies:
@@ -8916,6 +8946,10 @@ snapshots:
       minipass: 7.1.3
       minizlib: 3.1.0
       yallist: 5.0.0
+
+  tdigest@0.1.2:
+    dependencies:
+      bintrees: 1.0.2
 
   temp-file@3.4.0:
     dependencies:

--- a/tools/dev/dashboards/critique.json
+++ b/tools/dev/dashboards/critique.json
@@ -1,0 +1,196 @@
+{
+  "annotations": { "list": [] },
+  "description": "Critique Theater observability dashboard. Imports the 9 open_design_critique_* series the daemon exposes on /api/metrics and renders the three default views the spec calls out: fleet quality, adapter health, and brief throughput. Tune buckets and queries after the first 1000 runs; this file is the starting point, not the prescribed final shape.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Fleet quality",
+      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 1 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Composite score by adapter (p50 / p90 / p99)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "x": 0, "y": 1, "w": 16, "h": 8 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(open_design_critique_composite_score_bucket[5m])) by (le, adapter))",
+          "legendFormat": "{{adapter}} p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.90, sum(rate(open_design_critique_composite_score_bucket[5m])) by (le, adapter))",
+          "legendFormat": "{{adapter}} p90",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(open_design_critique_composite_score_bucket[5m])) by (le, adapter))",
+          "legendFormat": "{{adapter}} p99",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "min": 0, "max": 10, "unit": "short" },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } }
+    },
+    {
+      "id": 3,
+      "type": "heatmap",
+      "title": "Composite distribution by adapter",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "x": 16, "y": 1, "w": 8, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(open_design_critique_composite_score_bucket[5m])) by (le)",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "calculate": false,
+        "yAxis": { "decimals": 0, "min": 0, "max": 10 }
+      }
+    },
+    {
+      "id": 10,
+      "type": "row",
+      "title": "Adapter health",
+      "gridPos": { "x": 0, "y": 9, "w": 24, "h": 1 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 11,
+      "type": "barchart",
+      "title": "Degraded marks per 5m by adapter and reason",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "x": 0, "y": 10, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(open_design_critique_degraded_total[5m])) by (adapter, reason)",
+          "legendFormat": "{{adapter}} / {{reason}}",
+          "refId": "A"
+        }
+      ],
+      "options": { "stacking": "normal", "showValue": "auto" }
+    },
+    {
+      "id": 12,
+      "type": "barchart",
+      "title": "Parser errors per 5m by adapter and kind",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "x": 12, "y": 10, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(open_design_critique_parser_errors_total[5m])) by (adapter, kind)",
+          "legendFormat": "{{adapter}} / {{kind}}",
+          "refId": "A"
+        }
+      ],
+      "options": { "stacking": "normal", "showValue": "auto" }
+    },
+    {
+      "id": 20,
+      "type": "row",
+      "title": "Brief throughput",
+      "gridPos": { "x": 0, "y": 18, "w": 24, "h": 1 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "Runs per hour by terminal status",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "x": 0, "y": 19, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(open_design_critique_runs_total[1h])) by (status) * 3600",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 22,
+      "type": "stat",
+      "title": "Avg rounds per run by adapter",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "x": 12, "y": 19, "w": 6, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(open_design_critique_rounds_total[1h])) by (adapter) / clamp_min(sum(rate(open_design_critique_runs_total[1h])) by (adapter), 1)",
+          "legendFormat": "{{adapter}}",
+          "refId": "A"
+        }
+      ],
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "" } }
+    },
+    {
+      "id": 23,
+      "type": "timeseries",
+      "title": "Round duration ms (p50 / p90 / p99)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "x": 18, "y": 19, "w": 6, "h": 8 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(open_design_critique_round_duration_ms_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.90, sum(rate(open_design_critique_round_duration_ms_bucket[5m])) by (le))",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(open_design_critique_round_duration_ms_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ms" }, "overrides": [] }
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["critique-theater", "open-design"],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": { "selected": false, "text": "Prometheus", "value": "prometheus" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "options": [],
+        "refresh": 1,
+        "skipUrlSync": false
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Critique Theater",
+  "uid": "open-design-critique-theater",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
## Summary

This maintainer recovery PR replaces the conflicted Critique Theater stacked PRs instead of rebasing or merging those branches directly.

It starts from latest `origin/main` and recovers only the remaining valuable Theater-owned deltas:

- Phase 10 conformance fixes from #1316: synthetic fixture URL anchoring, shipped artifact exposure, parser-warning degradation, and per-round panel completeness checks.
- Phase 15 rollout/toggle/wireup: rollout resolver, skill `od.critique.policy`, ProjectView Theater mount, Settings toggle, and project metadata persistence.
- Phase 12 observability: Prometheus metrics, structured critique logging, adapter degradation counters, and orchestrator labels.
- Phase 16 ratchet: conformance history persistence, ratchet evaluator, nightly synthetic conformance workflow, and dashboard JSON.

This intentionally does not carry over the old stacked branch's stale changes to README files, landing-page files, manual-edit code, generic i18n cleanup, or removed custom-instructions behavior.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/critique-conformance.test.ts tests/critique-conformance-history.test.ts tests/critique-rollout.test.ts tests/critique-ratchet.test.ts tests/metrics/critique.test.ts tests/logging/critique.test.ts`
- `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/components/Theater/hooks/useCritiqueTheaterEnabled.test.tsx`
- `pnpm guard`

Notes:

- The local shell is Node 25 while the repo target is Node `~24`, so commands emit the existing engine warning.
- Broad `pnpm --filter ... test -- <file>` invocations were not used as final evidence because they expanded to the wider package suite in this workspace; the direct `pnpm --dir ... exec vitest ...` commands above are the exact-file validation.
