### PR TITLE
[codex] Update release light background

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -7,8 +7,8 @@
   /* Surface palette — neutral app chrome that does not bias generated artifacts.
      Keep warm/brand colors out of preview backgrounds; generated product UI
      must choose its own palette through the active skill/design brief. */
-  --bg: #f6f7f9;
-  --bg-app: #f6f7f9;
+  --bg: #faf9f7;
+  --bg-app: #faf9f7;
   --bg-panel: #ffffff;
   --bg-subtle: #eef1f5;
   --bg-muted: #e4e8ef;

--- a/apps/web/tests/state/appearance.test.ts
+++ b/apps/web/tests/state/appearance.test.ts
@@ -45,6 +45,19 @@ describe('applyAppearanceToDocument', () => {
     expect(document.documentElement.style.getPropertyValue('--accent-hover')).toContain('#4f46e5');
   });
 
+  it('does not apply appearance colors to global background variables', () => {
+    document.documentElement.style.setProperty('--bg', '#faf9f7');
+    document.documentElement.style.setProperty('--bg-app', '#faf9f7');
+
+    applyAppearanceToDocument({ theme: 'light', accentColor: '#059669' });
+
+    expect(document.documentElement.style.getPropertyValue('--bg')).toBe('#faf9f7');
+    expect(document.documentElement.style.getPropertyValue('--bg-app')).toBe('#faf9f7');
+
+    document.documentElement.style.removeProperty('--bg');
+    document.documentElement.style.removeProperty('--bg-app');
+  });
+
   it('applies accent variables while clearing an explicit theme for system mode', () => {
     document.documentElement.setAttribute('data-theme', 'dark');
 

--- a/apps/web/tests/styles/default-background.test.ts
+++ b/apps/web/tests/styles/default-background.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const indexCss = readFileSync(new URL('../../src/index.css', import.meta.url), 'utf8');
+
+function cssBlock(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = new RegExp(`${escaped}\\s*\\{([^}]*)\\}`).exec(indexCss);
+  if (!match) throw new Error(`Missing CSS block for ${selector}`);
+  return match[1] ?? '';
+}
+
+describe('default app background colors', () => {
+  it('uses the release light background color by default', () => {
+    const root = cssBlock(':root');
+
+    expect(root).toContain('--bg: #faf9f7;');
+    expect(root).toContain('--bg-app: #faf9f7;');
+  });
+
+  it('keeps the dark theme background unchanged', () => {
+    const dark = cssBlock('[data-theme="dark"]');
+
+    expect(dark).toContain('--bg: #1a1917;');
+    expect(dark).toContain('--bg-app: #1a1917;');
+  });
+});


### PR DESCRIPTION
## Summary
- Change the light-mode app background tokens to `#faf9f7`.
- Keep Settings -> Appearance -> Color scoped to accent/detail colors only.
- Add regression coverage for default light/dark backgrounds and for Appearance color not mutating global background variables.

## Validation
- `pnpm exec vitest run -c vitest.config.ts tests/state/appearance.test.ts tests/styles/default-background.test.ts`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web test`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`