### PR TITLE
fix(web): remove duplicate select-all entry in file list toolbar

### DIFF
--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -720,9 +720,6 @@ export function DesignFilesPanel({
                       {t('designFiles.pageInfo', { start: rangeStart, end: rangeEnd, total: sortedFiles.length })}
                     </span>
                     <div className="df-select-bar">
-                      <button type="button" className="df-select-all" onClick={toggleSelectPage}>
-                        {t('designFiles.selectPage')}
-                      </button>
                       {selected.size < sortedFiles.length ? (
                         <button type="button" className="df-select-all" onClick={selectAllFiles}>
                           {t('designFiles.selectAll', { n: sortedFiles.length })}

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -667,7 +667,6 @@ export const ar: Dict = {
   'designFiles.download': 'تحميل',
   'designFiles.downloadSelected': 'تنزيل {n} كـ ZIP',
   'designFiles.clearSelection': 'مسح التحديد',
-  'designFiles.selectPage': 'تحديد الكل في الصفحة',
   'designFiles.selectAll': 'تحديد الكل',
   'designFiles.dropTitle': '⤓ أسقط الملفات هنا',
   'designFiles.dropDesc':

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -555,7 +555,6 @@ export const de: Dict = {
   'designFiles.downloadSelected': '{n} als ZIP herunterladen',
   'designFiles.deleteSelected': '{n} löschen',
   'designFiles.clearSelection': 'Auswahl aufheben',
-  'designFiles.selectPage': 'Alle auf dieser Seite auswählen',
   'designFiles.selectAll': 'Alle auswählen',
   'designFiles.dropTitle': '⤓ Dateien hier ablegen',
   'designFiles.dropDesc':

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -761,7 +761,6 @@ export const en: Dict = {
   'designFiles.downloadSelected': 'Download {n} as ZIP',
   'designFiles.deleteSelected': 'Delete {n}',
   'designFiles.clearSelection': 'Clear',
-  'designFiles.selectPage': 'Select all on page',
   'designFiles.selectAll': 'Select everything',
   'designFiles.dropTitle': '⤓ Drop files here',
   'designFiles.dropDesc':

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -556,7 +556,6 @@ export const esES: Dict = {
   'designFiles.downloadSelected': 'Descargar {n} como ZIP',
   'designFiles.deleteSelected': 'Eliminar {n}',
   'designFiles.clearSelection': 'Limpiar selección',
-  'designFiles.selectPage': 'Seleccionar todo en la página',
   'designFiles.selectAll': 'Seleccionar todo',
   'designFiles.dropTitle': '⤓ Suelta archivos aquí',
   'designFiles.dropDesc':

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -689,7 +689,6 @@ export const fa: Dict = {
   'designFiles.download': 'دانلود',
   'designFiles.downloadSelected': 'دانلود {n} به صورت ZIP',
   'designFiles.clearSelection': 'پاک کردن انتخاب',
-  'designFiles.selectPage': 'انتخاب همه در صفحه',
   'designFiles.selectAll': 'انتخاب همه',
   'designFiles.dropTitle': '⤓ فایل‌ها را اینجا رها کنید',
   'designFiles.dropDesc':

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -666,7 +666,6 @@ export const fr: Dict = {
   'designFiles.download': 'Télécharger',
   'designFiles.downloadSelected': 'Télécharger {n} sélectionnés en ZIP',
   'designFiles.clearSelection': 'Effacer la sélection',
-  'designFiles.selectPage': 'Tout sélectionner sur la page',
   'designFiles.selectAll': 'Tout sélectionner',
   'designFiles.deleteSelected': 'Supprimer {n}',
   'designFiles.dropTitle': '⤓ Déposez les fichiers ici',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -666,7 +666,6 @@ export const hu: Dict = {
   'designFiles.download': 'Letöltés',
   'designFiles.downloadSelected': '{n} fájl letöltése ZIP-ként',
   'designFiles.clearSelection': 'Kijelölés törlése',
-  'designFiles.selectPage': 'Összes kijelölése az oldalon',
   'designFiles.selectAll': 'Összes kijelölése',
   'designFiles.deleteSelected': '{n} törlése',
   'designFiles.dropTitle': '⤓ Húzd ide a fájlokat',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -780,7 +780,6 @@ export const id: Dict = {
   'designFiles.downloadSelected': 'Unduh {n} sebagai ZIP',
   'designFiles.deleteSelected': 'Hapus {n}',
   'designFiles.clearSelection': 'Bersihkan',
-  'designFiles.selectPage': 'Pilih semua di halaman',
   'designFiles.selectAll': 'Pilih semua',
   'designFiles.dropTitle': 'Lepaskan file di sini',
   'designFiles.dropDesc': 'Upload file desain, gambar, dokumen, atau aset lain ke proyek ini.',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -554,7 +554,6 @@ export const ja: Dict = {
   'designFiles.downloadSelected': '{n}件をZIPとしてダウンロード',
   'designFiles.deleteSelected': '{n} 件を削除',
   'designFiles.clearSelection': '選択をクリア',
-  'designFiles.selectPage': 'このページをすべて選択',
   'designFiles.selectAll': 'すべて選択',
   'designFiles.dropTitle': '⤓ ファイルをここにドロップ',
   'designFiles.dropDesc':

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -666,7 +666,6 @@ export const ko: Dict = {
   'designFiles.download': '다운로드',
   'designFiles.downloadSelected': '{n}개를 ZIP으로 다운로드',
   'designFiles.clearSelection': '선택 해제',
-  'designFiles.selectPage': '페이지에서 모두 선택',
   'designFiles.selectAll': '모두 선택',
   'designFiles.deleteSelected': '{n}개 삭제',
   'designFiles.dropTitle': '⤓ 여기에 파일을 놓으세요',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -666,7 +666,6 @@ export const pl: Dict = {
   'designFiles.download': 'Pobierz',
   'designFiles.downloadSelected': 'Pobierz {n} jako ZIP',
   'designFiles.clearSelection': 'Wyczyść zaznaczenie',
-  'designFiles.selectPage': 'Zaznacz wszystko na stronie',
   'designFiles.selectAll': 'Zaznacz wszystko',
   'designFiles.deleteSelected': 'Usuń {n}',
   'designFiles.dropTitle': '⤓ Upuść pliki tutaj',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -687,7 +687,6 @@ export const ptBR: Dict = {
   'designFiles.download': 'Baixar',
   'designFiles.downloadSelected': 'Baixar {n} selecionados como ZIP',
   'designFiles.clearSelection': 'Limpar seleção',
-  'designFiles.selectPage': 'Selecionar tudo na página',
   'designFiles.selectAll': 'Selecionar tudo',
   'designFiles.deleteSelected': 'Excluir {n}',
   'designFiles.dropTitle': '⤓ Solte arquivos aqui',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -687,7 +687,6 @@ export const ru: Dict = {
   'designFiles.download': 'Скачать',
   'designFiles.downloadSelected': 'Скачать {n} как ZIP',
   'designFiles.clearSelection': 'Очистить выделение',
-  'designFiles.selectPage': 'Выбрать всё на странице',
   'designFiles.selectAll': 'Выбрать всё',
   'designFiles.deleteSelected': 'Удалить {n}',
   'designFiles.dropTitle': '⤓ Перетащите файлы сюда',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -646,7 +646,6 @@ export const th: Dict = {
   'designFiles.downloadSelected': 'โหลด {n} ลงเป็น ZIP',
   'designFiles.deleteSelected': 'ลบ {n}',
   'designFiles.clearSelection': 'ล้างการเลือก',
-  'designFiles.selectPage': 'เลือกทั้งหมดหน้านี้',
   'designFiles.selectAll': 'เลือกทุกอย่าง',
   'designFiles.dropTitle': '⤓ วางไฟล์ที่นี่',
   'designFiles.dropDesc': 'รูป เอกสาร อ้างอิง — เอเจนต์จะเก็บมาใช้วิเคราะห์',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -653,7 +653,6 @@ export const tr: Dict = {
   'designFiles.download': 'İndir',
   'designFiles.downloadSelected': '{n} dosyayı ZIP olarak indir',
   'designFiles.clearSelection': 'Seçimi temizle',
-  'designFiles.selectPage': 'Sayfadaki tümünü seç',
   'designFiles.selectAll': 'Tümünü seç',
   'designFiles.deleteSelected': '{n} sil',
   'designFiles.dropTitle': '⤓ Dosyaları buraya sürükleyin',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -688,7 +688,6 @@ export const uk: Dict = {
   'designFiles.download': 'Завантажити',
   'designFiles.downloadSelected': 'Завантажити {n} як ZIP',
   'designFiles.clearSelection': 'Очистити виділення',
-  'designFiles.selectPage': 'Вибрати все на сторінці',
   'designFiles.selectAll': 'Вибрати все',
   'designFiles.deleteSelected': 'Видалити {n}',
   'designFiles.dropTitle': '⤓ Перенесіть файли сюди',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -751,7 +751,6 @@ export const zhCN: Dict = {
   'designFiles.downloadSelected': '下载选中的 {n} 个文件为 ZIP',
   'designFiles.deleteSelected': '删除 {n} 个',
   'designFiles.clearSelection': '取消选择',
-  'designFiles.selectPage': '全选此页',
   'designFiles.selectAll': '全选',
   'designFiles.dropTitle': '⤓ 把文件拖到这里',
   'designFiles.dropDesc': '图片、文档、参考资料或文件夹 — 智能体都会用作上下文。',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -742,7 +742,6 @@ export const zhTW: Dict = {
   'designFiles.downloadSelected': '下載選中的 {n} 個檔案為 ZIP',
   'designFiles.deleteSelected': '刪除 {n} 個',
   'designFiles.clearSelection': '取消選擇',
-  'designFiles.selectPage': '全選此頁',
   'designFiles.selectAll': '全選',
   'designFiles.dropTitle': '⤓ 把檔案拖到這裡',
   'designFiles.dropDesc': '圖片、文件、參考資料或資料夾 — 智慧體都會用作上下文。',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -1020,7 +1020,6 @@ export interface Dict {
   'designFiles.downloadSelected': string;
   'designFiles.deleteSelected': string;
   'designFiles.clearSelection': string;
-  'designFiles.selectPage': string;
   'designFiles.selectAll': string;
   'designFiles.dropTitle': string;
   'designFiles.dropDesc': string;


### PR DESCRIPTION
## Summary

Remove the duplicate `designFiles.selectPage` button from the file list toolbar in `DesignFilesPanel`. The toolbar had two select-all actions appearing side by side (`全选此页` and `全选`), which felt redundant.

## Root Cause

The `df-select-bar` rendered both a page-level toggle (`toggleSelectPage`) and a global select-all (`selectAllFiles`) button. The page-level select-all is already provided by the tri-state header checkbox in the table's `<thead>`, making the extra button redundant.

## Fix

- Removed the `全选此页` button from the `df-select-bar` in `DesignFilesPanel.tsx`
- Removed the unused `designFiles.selectPage` i18n key from all 18 locale files and the `types.ts` type definition
- Preserved the `toggleSelectPage` function, `allPageSelected`, and `somePageSelected` as they remain used by the header checkbox

## Changes

| File | Change |
|------|--------|
| `apps/web/src/components/DesignFilesPanel.tsx` | Remove the `selectPage` button from `df-select-bar` |
| `apps/web/src/i18n/types.ts` | Remove `designFiles.selectPage` type key |
| `apps/web/src/i18n/locales/*.ts` (18 files) | Remove `designFiles.selectPage` translations |

## Testing

- Verified no remaining references to `designFiles.selectPage` in the codebase
- The header checkbox continues to provide page-level select/deselect