### PR TITLE
fix(viewer): hide viewport controls in source view + fix #1532 wrapping

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -4996,7 +4996,7 @@ function HtmlViewer({
               {t('fileViewer.source')}
             </button>
           </div>
-          {effectiveDeck ? (
+          {effectiveDeck && mode === 'preview' ? (
             <span
               className="deck-nav"
               role="group"
@@ -5034,41 +5034,43 @@ function HtmlViewer({
           ) : null}
         </div>
         <div className="viewer-toolbar-actions">
-          <div className="palette-tweaks-anchor">
-            <button
-              type="button"
-              className={`viewer-action${selectedPalette || palettePopoverOpen ? ' active' : ''}`}
-              data-testid="palette-tweaks-toggle"
-              title="Tweaks"
-              aria-haspopup="dialog"
-              aria-expanded={palettePopoverOpen}
-              onClick={() => setPalettePopoverOpen((v) => !v)}
-            >
-              <Icon name="tweaks" size={13} />
-              <span>Tweaks</span>
-              {selectedPalette ? (
-                <span
-                  className="palette-tweaks-badge"
-                  aria-hidden
-                  style={{
-                    backgroundColor:
-                      selectedPalette === 'coral' ? '#ff5a3c' :
-                      selectedPalette === 'electric' ? '#7c3aed' :
-                      selectedPalette === 'acid-forest' ? '#16a34a' :
-                      selectedPalette === 'risograph' ? '#e11d48' :
-                      '#0a0a0a',
-                  }}
-                />
-              ) : null}
-            </button>
-            <PaletteTweaks
-              open={palettePopoverOpen}
-              selected={selectedPalette}
-              onChange={setSelectedPalette}
-              onPreview={setPreviewPalette}
-              onClose={() => setPalettePopoverOpen(false)}
-            />
-          </div>
+          {mode === 'preview' ? (
+            <div className="palette-tweaks-anchor">
+              <button
+                type="button"
+                className={`viewer-action${selectedPalette || palettePopoverOpen ? ' active' : ''}`}
+                data-testid="palette-tweaks-toggle"
+                title="Tweaks"
+                aria-haspopup="dialog"
+                aria-expanded={palettePopoverOpen}
+                onClick={() => setPalettePopoverOpen((v) => !v)}
+              >
+                <Icon name="tweaks" size={13} />
+                <span>Tweaks</span>
+                {selectedPalette ? (
+                  <span
+                    className="palette-tweaks-badge"
+                    aria-hidden
+                    style={{
+                      backgroundColor:
+                        selectedPalette === 'coral' ? '#ff5a3c' :
+                        selectedPalette === 'electric' ? '#7c3aed' :
+                        selectedPalette === 'acid-forest' ? '#16a34a' :
+                        selectedPalette === 'risograph' ? '#e11d48' :
+                        '#0a0a0a',
+                    }}
+                  />
+                ) : null}
+              </button>
+              <PaletteTweaks
+                open={palettePopoverOpen}
+                selected={selectedPalette}
+                onChange={setSelectedPalette}
+                onPreview={setPreviewPalette}
+                onClose={() => setPalettePopoverOpen(false)}
+              />
+            </div>
+          ) : null}
           <button
             className={`viewer-action${manualEditMode ? ' active' : ''}`}
             type="button"
@@ -5092,44 +5094,48 @@ function HtmlViewer({
             <Icon name="edit" size={13} />
             <span>{t('fileViewer.edit')}</span>
           </button>
-          <button
-            className={`viewer-action${drawOverlayOpen ? ' active' : ''}`}
-            type="button"
-            data-testid="draw-overlay-toggle"
-            title={t('fileViewer.draw')}
-            aria-pressed={drawOverlayOpen}
-            onClick={() => {
-              const next = !drawOverlayOpen;
-              if (!next) {
-                setDrawOverlayOpen(false);
-                return;
-              }
-              const activateDraw = () => {
-                setBoardMode(false);
-                clearBoardComposer();
-                setInspectMode(false);
-                setDrawOverlayMode('draw');
-                setMode('preview');
-                setDrawOverlayOpen(true);
-              };
-              if (manualEditMode) {
-                void exitManualEditModeAfterFlush().then((ok) => {
-                  if (ok) activateDraw();
-                });
-                return;
-              }
-              activateDraw();
-            }}
-          >
-            <Icon name="draw" size={13} />
-            <span>{t('fileViewer.draw')}</span>
-          </button>
-          <span className="viewer-divider" aria-hidden />
-          <PreviewViewportControls
-            viewport={previewViewport}
-            onViewport={setPreviewViewport}
-            t={t}
-          />
+          {mode === 'preview' ? (
+            <>
+              <button
+                className={`viewer-action${drawOverlayOpen ? ' active' : ''}`}
+                type="button"
+                data-testid="draw-overlay-toggle"
+                title={t('fileViewer.draw')}
+                aria-pressed={drawOverlayOpen}
+                onClick={() => {
+                  const next = !drawOverlayOpen;
+                  if (!next) {
+                    setDrawOverlayOpen(false);
+                    return;
+                  }
+                  const activateDraw = () => {
+                    setBoardMode(false);
+                    clearBoardComposer();
+                    setInspectMode(false);
+                    setDrawOverlayMode('draw');
+                    setMode('preview');
+                    setDrawOverlayOpen(true);
+                  };
+                  if (manualEditMode) {
+                    void exitManualEditModeAfterFlush().then((ok) => {
+                      if (ok) activateDraw();
+                    });
+                    return;
+                  }
+                  activateDraw();
+                }}
+              >
+                <Icon name="draw" size={13} />
+                <span>{t('fileViewer.draw')}</span>
+              </button>
+              <span className="viewer-divider" aria-hidden />
+              <PreviewViewportControls
+                viewport={previewViewport}
+                onViewport={setPreviewViewport}
+                t={t}
+              />
+            </>
+          ) : null}
           <span className="viewer-divider" aria-hidden />
           <button
             type="button"

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -1049,6 +1049,37 @@ describe('FileViewer tweaks toolbar', () => {
     expect(send.disabled).toBe(true);
     expect(send.getAttribute('title')).toBe('当前正有任务在执行');
   });
+
+  it('hides preview-only controls in source view', () => {
+    render(
+      <FileViewer
+        projectId="project-1"
+        file={htmlPreviewFile()}
+        liveHtml='<html><body><main data-od-id="hero">Hero</main></body></html>'
+      />,
+    );
+
+    // Preview mode: preview-only controls should be present
+    expect(screen.getByTestId('palette-tweaks-toggle')).toBeTruthy();
+    expect(screen.getByTestId('draw-overlay-toggle')).toBeTruthy();
+    expect(screen.getByRole('group', { name: /viewport/i })).toBeTruthy();
+
+    // Switch to source view
+    fireEvent.click(screen.getByRole('button', { name: /source/i }));
+
+    // Preview-only controls should be hidden
+    expect(screen.queryByTestId('palette-tweaks-toggle')).toBeNull();
+    expect(screen.queryByTestId('draw-overlay-toggle')).toBeNull();
+    expect(screen.queryByRole('group', { name: /viewport/i })).toBeNull();
+
+    // Edit and Zoom controls should remain visible in source view
+    expect(screen.getByTestId('manual-edit-mode-toggle')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /zoom out/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /zoom in/i })).toBeTruthy();
+
+    // Source tab should be active
+    expect(screen.getByRole('button', { name: /source/i }).classList.contains('active')).toBe(true);
+  });
 });
 
 describe('applyInspectOverridesToSource', () => {


### PR DESCRIPTION
Fixes #1528

Also addresses the over-wrapping introduced in #1532 (Edit and Zoom were mistakenly hidden too).

## Why

When switching an HTML artifact from preview to source view, several preview-only toolbar controls (Tweaks, Draw overlay toggle, and PreviewViewportControls / viewport selector) remained visible. They don't apply to source code and cause visual confusion. The root cause: these controls had no `mode` guard — they rendered unconditionally regardless of the current tab.

Edit and Zoom are intentionally kept visible in source view (Edit switches back to preview on click; Zoom may be useful for dense code).

## What users will see

- Switching to **Source** tab hides: Tweaks button, Draw button, viewport selector (desktop/tablet/mobile)
- Edit and Zoom controls remain visible in both modes
- Switching back to **Preview** restores all controls

## Surface area

- [x] **UI** — toolbar controls in `apps/web` HtmlViewer

## Screenshots

<!-- Before/after: open an HTML artifact → switch to Source tab → Tweaks/Draw/viewport selector disappear -->
(UI-only change in toolbar; before: all controls visible in source view, after: only Edit + Zoom remain)

## Bug fix verification

- Test path: `apps/web/tests/components/FileViewer.test.tsx` → `hides preview-only controls in source view`
- Test goes **red on `main`**, green on this branch: yes
- Validates: palette-tweaks-toggle, draw-overlay-toggle, and viewport group absent after clicking Source tab

## Validation

`pnpm --filter @open-design/web test` — 76/76 passed ✅