### PR TITLE
docs: add Windows launcher note

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,8 @@ pnpm tools-dev run web
 
 Environment requirements: Node `~24` and pnpm `10.33.x`. `nvm`/`fnm` are optional helpers only; if you use one, run `nvm install 24 && nvm use 24` or `fnm install 24 && fnm use 24` before `pnpm install`.
 
+Windows users can follow [`docs/windows-troubleshooting.md`](docs/windows-troubleshooting.md) for the native setup path and a tiny double-click launcher.
+
 For desktop/background startup, fixed-port restarts, and media generation dispatcher checks (`OD_BIN`, `OD_DAEMON_URL`, `apps/daemon/dist/cli.js`), see [`QUICKSTART.md`](QUICKSTART.md).
 
 The first load:

--- a/docs/windows-troubleshooting.md
+++ b/docs/windows-troubleshooting.md
@@ -203,6 +203,18 @@ python --version   # or py --version
 Get-ExecutionPolicy -List
 ```
 
+## 7. Optional: quick launcher
+
+If you want a double-click entry point on Windows, create a `launch.bat` file in the repo root with:
+
+```bat
+@echo off
+cd /d %~dp0
+corepack pnpm tools-dev run web
+```
+
+That keeps the launcher on the supported `pnpm tools-dev run web` path while still giving you a one-click start.
+
 ---
 
 ## Optional: OpenCode agent CLI on Windows


### PR DESCRIPTION
Related to #433.

## Why
Windows users benefit from a single place in the repo that points them to the existing launcher and the supported dev-server flow, instead of hunting through old notes.

## What users will see
- A short Windows onboarding note in README
- A link to the launcher from `docs/windows-troubleshooting.md`
- A clearer path to the supported dev-server startup flow

## Surface area
- [x] Docs
- [ ] UI
- [ ] API
- [ ] Daemon
- [ ] Tests
- [ ] None

## Screenshots
- N/A

## Validation
- `git diff --check`
- Local smoke check still isn’t runnable here because the repo dev deps aren’t installed in this worktree
