### PR TITLE
fix(web): remove redundant bulk-select button

### DIFF
--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -720,9 +720,6 @@ export function DesignFilesPanel({
                       {t('designFiles.pageInfo', { start: rangeStart, end: rangeEnd, total: sortedFiles.length })}
                     </span>
                     <div className="df-select-bar">
-                      <button type="button" className="df-select-all" onClick={toggleSelectPage}>
-                        {t('designFiles.selectPage')}
-                      </button>
                       {selected.size < sortedFiles.length ? (
                         <button type="button" className="df-select-all" onClick={selectAllFiles}>
                           {t('designFiles.selectAll', { n: sortedFiles.length })}

--- a/apps/web/tests/components/DesignFilesPanel.test.tsx
+++ b/apps/web/tests/components/DesignFilesPanel.test.tsx
@@ -360,6 +360,14 @@ describe('DesignFilesPanel large-list regression', () => {
     expect(getPageInfo(container)).toContain('31–60 of 500');
   });
 
+  it('keeps the bulk toolbar focused on the all-files action instead of duplicating page select', () => {
+    const { container } = renderPanel(generateFiles(3));
+
+    const toolbar = container.querySelector('.df-select-bar');
+    expect(toolbar?.textContent).toContain('Select everything');
+    expect(toolbar?.textContent).not.toContain('Select all on page');
+  });
+
   it('uses non-control table cells as file row click targets', () => {
     const files = generateFiles(1);
     const { container, onOpenFile } = renderPanel(files);


### PR DESCRIPTION
Closes #1536\n\nRemoves the duplicate page-select button from the file list toolbar. The table header checkbox still handles page selection, while the toolbar keeps the all-files action and clear-selection state.