### PR TITLE
fix(web): make file grouping by kind work

### DIFF
--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -501,6 +501,29 @@ export function DesignFilesPanel({
     });
   }
 
+  function renderKindSections() {
+    const grouped = new Map<ProjectFileKind, ProjectFile[]>();
+    for (const file of pageFiles) {
+      const next = grouped.get(file.kind) ?? [];
+      next.push(file);
+      grouped.set(file.kind, next);
+    }
+
+    return [...grouped.entries()]
+      .sort(([a], [b]) => kindSortPriority(a) - kindSortPriority(b))
+      .flatMap(([kind, kindFiles]) => [
+        <tr className="df-section-row" key={`${kind}-label`}>
+          <td colSpan={6}>
+            <div className="df-section-label">
+              <span>{kindLabel(kind, t)}</span>
+              <span className="df-section-count">{kindFiles.length}</span>
+            </div>
+          </td>
+        </tr>,
+        ...kindFiles.map(renderFileRow),
+      ]);
+  }
+
   async function handleBatchDownload() {
     const fileList = [...selected];
     if (fileList.length === 0) return;
@@ -807,7 +830,9 @@ export function DesignFilesPanel({
                     <tbody>
                       {groupMode === 'modified'
                         ? renderModifiedSections()
-                        : pageFiles.map(renderFileRow)}
+                        : groupMode === 'kind'
+                          ? renderKindSections()
+                          : pageFiles.map(renderFileRow)}
                     </tbody>
                   </table>
                   <div className="df-pagination df-pagination-center">

--- a/apps/web/tests/components/DesignFilesPanel.test.tsx
+++ b/apps/web/tests/components/DesignFilesPanel.test.tsx
@@ -129,8 +129,11 @@ describe('DesignFilesPanel grouping', () => {
       file({ name: 'chart.png', kind: 'image', mime: 'image/png' }),
     ]);
 
-    expect(screen.getByText('HTML page')).toBeTruthy();
-    expect(screen.getByText('Image')).toBeTruthy();
+    const sectionLabels = Array.from(
+      document.querySelectorAll<HTMLElement>('.df-section-label'),
+    ).map((el) => el.textContent ?? '');
+    expect(sectionLabels.some((text) => text.includes('HTML page'))).toBe(true);
+    expect(sectionLabels.some((text) => text.includes('Image'))).toBe(true);
     expect(screen.getByTestId('design-file-row-page.html')).toBeTruthy();
     expect(screen.getByTestId('design-file-row-chart.png')).toBeTruthy();
     expect(screen.queryByText('Today')).toBeNull();
@@ -465,11 +468,15 @@ describe('DesignFilesPanel large-list regression', () => {
     const { container, onDeleteFiles } = renderPanel(files);
     const rows = Array.from(container.querySelectorAll('.df-file-row'));
 
+    const firstName = rows[0]!.getAttribute('data-testid')!.replace(/^design-file-row-/, '');
+    const secondName = rows[1]!.getAttribute('data-testid')!.replace(/^design-file-row-/, '');
     fireEvent.click(rows[0]!.querySelector('.df-row-check')!);
     fireEvent.click(rows[1]!.querySelector('.df-row-check')!);
     fireEvent.click(container.querySelector('[data-testid="design-files-batch-delete"]')!);
 
-    expect(onDeleteFiles).toHaveBeenCalledWith(['file-1.html', 'file-2.png']);
+    expect(onDeleteFiles).toHaveBeenCalledTimes(1);
+    expect(onDeleteFiles).toHaveBeenCalledWith(expect.arrayContaining([firstName, secondName]));
+    expect(onDeleteFiles.mock.calls[0][0]).toHaveLength(2);
   });
 
   it('renders 500 files within a reasonable time', () => {

--- a/apps/web/tests/components/DesignFilesPanel.test.tsx
+++ b/apps/web/tests/components/DesignFilesPanel.test.tsx
@@ -475,8 +475,7 @@ describe('DesignFilesPanel large-list regression', () => {
     fireEvent.click(container.querySelector('[data-testid="design-files-batch-delete"]')!);
 
     expect(onDeleteFiles).toHaveBeenCalledTimes(1);
-    expect(onDeleteFiles).toHaveBeenCalledWith(expect.arrayContaining([firstName, secondName]));
-    expect(onDeleteFiles.mock.calls[0][0]).toHaveLength(2);
+    expect(onDeleteFiles).toHaveBeenCalledWith([firstName, secondName]);
   });
 
   it('renders 500 files within a reasonable time', () => {

--- a/apps/web/tests/components/DesignFilesPanel.test.tsx
+++ b/apps/web/tests/components/DesignFilesPanel.test.tsx
@@ -123,7 +123,20 @@ describe('DesignFilesPanel grouping', () => {
     expect(screen.getByTestId('design-file-row-live:artifact-1')).toBeTruthy();
   });
 
-  it('keeps the ungrouped table view as the default view', () => {
+  it('groups files by kind when kind grouping is selected', () => {
+    renderPanel([
+      file({ name: 'page.html', kind: 'html', mime: 'text/html' }),
+      file({ name: 'chart.png', kind: 'image', mime: 'image/png' }),
+    ]);
+
+    expect(screen.getByText('HTML page')).toBeTruthy();
+    expect(screen.getByText('Image')).toBeTruthy();
+    expect(screen.getByTestId('design-file-row-page.html')).toBeTruthy();
+    expect(screen.getByTestId('design-file-row-chart.png')).toBeTruthy();
+    expect(screen.queryByText('Today')).toBeNull();
+  });
+
+  it('keeps kind grouping selected by default', () => {
     renderPanel([
       file({ name: 'page.html', kind: 'html', mime: 'text/html' }),
       file({ name: 'chart.png', kind: 'image', mime: 'image/png' }),

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -433,6 +433,7 @@ describe('FileViewer SVG artifacts', () => {
     const { container } = render(
       <FileViewer
         projectId="project-1"
+        projectKind="prototype"
         file={file}
         isDeck
         liveHtml={'<html><body><section class="slide">one</section><section class="slide">two</section></body></html>'}


### PR DESCRIPTION
Fixes #1548.

## Why
The kind grouping control looked selectable, but the file list stayed flat. That made the option feel broken.

## What users will see
- The file list now splits into sections by file kind
- HTML, image, code, and other file types get their own headers
- The default Kind view finally matches the label in the toolbar

## Surface area
- [x] UI
- [x] Tests
- [ ] API
- [ ] Daemon
- [ ] Docs
- [ ] None

## Screenshots
- N/A

## Validation
- `git diff --check`
- Not run in this worktree: `pnpm vitest run apps/web/tests/components/DesignFilesPanel.test.tsx`
