### PR TITLE
Fix Windows resource cache for Orbit templates

### DIFF
--- a/tools/pack/src/win/resources.ts
+++ b/tools/pack/src/win/resources.ts
@@ -6,15 +6,18 @@ import type { ToolPackConfig } from "../config.js";
 import { copyBundledResourceTrees, winResources } from "../resources.js";
 import type { WinPaths, ResourceTreeCacheMetadata } from "./types.js";
 
+const RESOURCE_TREE_CACHE_SCHEMA_VERSION = 2;
+
 async function createResourceTreeCacheKey(config: ToolPackConfig): Promise<string> {
   return hashJson({
     assetsCommunityPets: await hashPath(join(config.workspaceRoot, "assets", "community-pets")),
     assetsFrames: await hashPath(join(config.workspaceRoot, "assets", "frames")),
     craft: await hashPath(join(config.workspaceRoot, "craft")),
     designSystems: await hashPath(join(config.workspaceRoot, "design-systems")),
+    designTemplates: await hashPath(join(config.workspaceRoot, "design-templates")),
     node: "win.resource-tree",
     promptTemplates: await hashPath(join(config.workspaceRoot, "prompt-templates")),
-    schemaVersion: 1,
+    schemaVersion: RESOURCE_TREE_CACHE_SCHEMA_VERSION,
     skills: await hashPath(join(config.workspaceRoot, "skills")),
   });
 }

--- a/tools/pack/tests/win-resources.test.ts
+++ b/tools/pack/tests/win-resources.test.ts
@@ -1,0 +1,76 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { ToolPackCache } from "../src/cache.js";
+import type { ToolPackConfig } from "../src/config.js";
+import { prepareResourceTree } from "../src/win/resources.js";
+import type { WinPaths } from "../src/win/types.js";
+
+async function createWorkspaceFixture(workspaceRoot: string): Promise<void> {
+  await mkdir(join(workspaceRoot, "skills", "sample"), { recursive: true });
+  await mkdir(join(workspaceRoot, "design-templates", "orbit-general"), {
+    recursive: true,
+  });
+  await mkdir(join(workspaceRoot, "design-systems", "sample"), {
+    recursive: true,
+  });
+  await mkdir(join(workspaceRoot, "craft", "sample"), { recursive: true });
+  await mkdir(join(workspaceRoot, "assets", "frames"), { recursive: true });
+  await mkdir(join(workspaceRoot, "assets", "community-pets", "sample"), {
+    recursive: true,
+  });
+  await mkdir(join(workspaceRoot, "prompt-templates", "image"), {
+    recursive: true,
+  });
+}
+
+describe("prepareResourceTree", () => {
+  it("invalidates the Windows resource tree cache when design templates change", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-win-resources-"));
+    const workspaceRoot = join(root, "workspace");
+    const resourceRoot = join(root, "materialized", "open-design");
+    const cache = new ToolPackCache(join(root, "cache"));
+    const config = { workspaceRoot } as ToolPackConfig;
+    const paths = { resourceRoot } as WinPaths;
+    const templatePath = join(
+      workspaceRoot,
+      "design-templates",
+      "orbit-general",
+      "SKILL.md",
+    );
+    const materializedTemplatePath = join(
+      resourceRoot,
+      "design-templates",
+      "orbit-general",
+      "SKILL.md",
+    );
+
+    try {
+      await createWorkspaceFixture(workspaceRoot);
+      await writeFile(templatePath, "version one\n", "utf8");
+
+      await prepareResourceTree(config, paths, cache, { materialize: true });
+
+      await expect(readFile(materializedTemplatePath, "utf8")).resolves.toBe(
+        "version one\n",
+      );
+
+      await writeFile(templatePath, "version two\n", "utf8");
+
+      await prepareResourceTree(config, paths, cache, { materialize: true });
+
+      await expect(readFile(materializedTemplatePath, "utf8")).resolves.toBe(
+        "version two\n",
+      );
+      expect(cache.report().entries.map((entry) => entry.status)).toEqual([
+        "miss",
+        "miss",
+      ]);
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- include `design-templates` in the Windows `win.resource-tree` cache key
- bump the Windows resource-tree cache schema marker so old entries are not reused
- add a regression test proving `design-templates/orbit-general` changes invalidate and rematerialize the Windows resource tree

Fixes #1507

## Why
The packaged resource copy already includes `design-templates`, but the Windows resource-tree cache key did not hash that tree. A stale `win.resource-tree` cache could therefore keep reusing a pre-migration resource tree that lacked Orbit templates, and `win.electron-builder-dir` would inherit that stale key downstream.

## Validation
- red spec before fix: `pnpm -C tools/pack exec vitest run tests/win-resources.test.ts --reporter verbose` failed with stale `version one` content after updating `design-templates/orbit-general/SKILL.md`
- `pnpm -C tools/pack exec vitest run tests/win-resources.test.ts tests/resources.test.ts --reporter verbose`
- `pnpm --filter @open-design/tools-pack typecheck`
- `pnpm --filter @open-design/tools-pack test`
- `pnpm --filter @open-design/tools-pack build`
- `git diff --check`
- `pnpm guard`
- `pnpm typecheck`

## Packaged artifact proof
- Built a real Windows dir artifact: `pnpm tools-pack win build --to dir --namespace o1507 --dir C:\tmp\od-1507 --json`
- Confirmed `win-unpacked/resources/open-design/design-templates` contains `orbit-general`, `orbit-github`, `orbit-gmail`, `orbit-linear`, and `orbit-notion`
- Confirmed `orbit-general/SKILL.md` exists in the artifact
- Started the packaged dir artifact and verified `document.title` is `Open Design`
- Verified runtime `/api/design-templates` exposes all five Orbit template ids above
- Stopped the packaged process and removed `C:\tmp\od-1507`

## Notes
- PR #1521 separately adds resource-copy coverage for `orbit-general`; this PR fixes the Windows cache invalidation boundary that can keep packaged artifacts stale.
- `pnpm typecheck` completed successfully with existing Astro content warnings and Shiki `urdu` fallback warnings.