### PR TITLE
fix: hide preview chrome in source view

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -4965,6 +4965,7 @@ function HtmlViewer({
     return t('fileViewer.deployLinkPreparingLabel');
   };
   const boardAvailable = mode === 'preview' && source !== null;
+  const showPreviewToolbarControls = mode === 'preview';
 
   return (
     <div className="viewer html-viewer">
@@ -4996,7 +4997,7 @@ function HtmlViewer({
               {t('fileViewer.source')}
             </button>
           </div>
-          {effectiveDeck ? (
+          {showPreviewToolbarControls && effectiveDeck ? (
             <span
               className="deck-nav"
               role="group"
@@ -5034,155 +5035,159 @@ function HtmlViewer({
           ) : null}
         </div>
         <div className="viewer-toolbar-actions">
-          <div className="palette-tweaks-anchor">
-            <button
-              type="button"
-              className={`viewer-action${selectedPalette || palettePopoverOpen ? ' active' : ''}`}
-              data-testid="palette-tweaks-toggle"
-              title="Tweaks"
-              aria-haspopup="dialog"
-              aria-expanded={palettePopoverOpen}
-              onClick={() => setPalettePopoverOpen((v) => !v)}
-            >
-              <Icon name="tweaks" size={13} />
-              <span>Tweaks</span>
-              {selectedPalette ? (
-                <span
-                  className="palette-tweaks-badge"
-                  aria-hidden
-                  style={{
-                    backgroundColor:
-                      selectedPalette === 'coral' ? '#ff5a3c' :
-                      selectedPalette === 'electric' ? '#7c3aed' :
-                      selectedPalette === 'acid-forest' ? '#16a34a' :
-                      selectedPalette === 'risograph' ? '#e11d48' :
-                      '#0a0a0a',
-                  }}
+          {showPreviewToolbarControls ? (
+            <>
+              <div className="palette-tweaks-anchor">
+                <button
+                  type="button"
+                  className={`viewer-action${selectedPalette || palettePopoverOpen ? ' active' : ''}`}
+                  data-testid="palette-tweaks-toggle"
+                  title="Tweaks"
+                  aria-haspopup="dialog"
+                  aria-expanded={palettePopoverOpen}
+                  onClick={() => setPalettePopoverOpen((v) => !v)}
+                >
+                  <Icon name="tweaks" size={13} />
+                  <span>Tweaks</span>
+                  {selectedPalette ? (
+                    <span
+                      className="palette-tweaks-badge"
+                      aria-hidden
+                      style={{
+                        backgroundColor:
+                          selectedPalette === 'coral' ? '#ff5a3c' :
+                          selectedPalette === 'electric' ? '#7c3aed' :
+                          selectedPalette === 'acid-forest' ? '#16a34a' :
+                          selectedPalette === 'risograph' ? '#e11d48' :
+                          '#0a0a0a',
+                      }}
+                    />
+                  ) : null}
+                </button>
+                <PaletteTweaks
+                  open={palettePopoverOpen}
+                  selected={selectedPalette}
+                  onChange={setSelectedPalette}
+                  onPreview={setPreviewPalette}
+                  onClose={() => setPalettePopoverOpen(false)}
                 />
-              ) : null}
-            </button>
-            <PaletteTweaks
-              open={palettePopoverOpen}
-              selected={selectedPalette}
-              onChange={setSelectedPalette}
-              onPreview={setPreviewPalette}
-              onClose={() => setPalettePopoverOpen(false)}
-            />
-          </div>
-          <button
-            className={`viewer-action${manualEditMode ? ' active' : ''}`}
-            type="button"
-            data-testid="manual-edit-mode-toggle"
-            title={t('fileViewer.edit')}
-            aria-pressed={manualEditMode}
-            onClick={() => {
-              if (!manualEditMode) {
-                setBoardMode(false);
-                clearBoardComposer();
-                setInspectMode(false);
-                setDrawOverlayOpen(false);
-                setMode('preview');
-                setManualEditViewportWidth(previewBodyRef.current?.clientWidth ?? null);
-                setManualEditMode(true);
-                return;
-              }
-              void exitManualEditModeAfterFlush();
-            }}
-          >
-            <Icon name="edit" size={13} />
-            <span>{t('fileViewer.edit')}</span>
-          </button>
-          <button
-            className={`viewer-action${drawOverlayOpen ? ' active' : ''}`}
-            type="button"
-            data-testid="draw-overlay-toggle"
-            title={t('fileViewer.draw')}
-            aria-pressed={drawOverlayOpen}
-            onClick={() => {
-              const next = !drawOverlayOpen;
-              if (!next) {
-                setDrawOverlayOpen(false);
-                return;
-              }
-              const activateDraw = () => {
-                setBoardMode(false);
-                clearBoardComposer();
-                setInspectMode(false);
-                setDrawOverlayMode('draw');
-                setMode('preview');
-                setDrawOverlayOpen(true);
-              };
-              if (manualEditMode) {
-                void exitManualEditModeAfterFlush().then((ok) => {
-                  if (ok) activateDraw();
-                });
-                return;
-              }
-              activateDraw();
-            }}
-          >
-            <Icon name="draw" size={13} />
-            <span>{t('fileViewer.draw')}</span>
-          </button>
-          <span className="viewer-divider" aria-hidden />
-          <PreviewViewportControls
-            viewport={previewViewport}
-            onViewport={setPreviewViewport}
-            t={t}
-          />
-          <span className="viewer-divider" aria-hidden />
-          <button
-            type="button"
-            className="icon-only"
-            onClick={() => bumpZoom(-25)}
-            title={t('fileViewer.zoomOut')}
-            aria-label={t('fileViewer.zoomOut')}
-          >
-            <Icon name="minus" size={14} />
-          </button>
-          <div className="zoom-menu" ref={zoomMenuRef}>
-            <button
-              type="button"
-              className="viewer-action zoom-trigger"
-              aria-haspopup="menu"
-              aria-expanded={zoomMenuOpen}
-              onClick={() => setZoomMenuOpen((v) => !v)}
-              style={{ minWidth: 64 }}
-            >
-              <span style={{ fontVariantNumeric: 'tabular-nums' }}>{zoom}%</span>
-              <Icon name="chevron-down" size={11} />
-            </button>
-            {zoomMenuOpen ? (
-              <div className="zoom-menu-popover" role="menu">
-                {[50, 75, 100, 125, 150, 200].map((level) => (
-                  <button
-                    key={level}
-                    type="button"
-                    className={`zoom-menu-item${zoom === level ? ' active' : ''}`}
-                    role="menuitem"
-                    onClick={() => {
-                      setZoom(level);
-                      setZoomMenuOpen(false);
-                    }}
-                  >
-                    <span style={{ fontVariantNumeric: 'tabular-nums' }}>{level}%</span>
-                    {zoom === level ? (
-                      <Icon name="check" size={13} />
-                    ) : null}
-                  </button>
-                ))}
               </div>
-            ) : null}
-          </div>
-          <button
-            type="button"
-            className="icon-only"
-            onClick={() => bumpZoom(25)}
-            title={t('fileViewer.zoomIn')}
-            aria-label={t('fileViewer.zoomIn')}
-          >
-            <Icon name="plus" size={14} />
-          </button>
+              <button
+                className={`viewer-action${manualEditMode ? ' active' : ''}`}
+                type="button"
+                data-testid="manual-edit-mode-toggle"
+                title={t('fileViewer.edit')}
+                aria-pressed={manualEditMode}
+                onClick={() => {
+                  if (!manualEditMode) {
+                    setBoardMode(false);
+                    clearBoardComposer();
+                    setInspectMode(false);
+                    setDrawOverlayOpen(false);
+                    setMode('preview');
+                    setManualEditViewportWidth(previewBodyRef.current?.clientWidth ?? null);
+                    setManualEditMode(true);
+                    return;
+                  }
+                  void exitManualEditModeAfterFlush();
+                }}
+              >
+                <Icon name="edit" size={13} />
+                <span>{t('fileViewer.edit')}</span>
+              </button>
+              <button
+                className={`viewer-action${drawOverlayOpen ? ' active' : ''}`}
+                type="button"
+                data-testid="draw-overlay-toggle"
+                title={t('fileViewer.draw')}
+                aria-pressed={drawOverlayOpen}
+                onClick={() => {
+                  const next = !drawOverlayOpen;
+                  if (!next) {
+                    setDrawOverlayOpen(false);
+                    return;
+                  }
+                  const activateDraw = () => {
+                    setBoardMode(false);
+                    clearBoardComposer();
+                    setInspectMode(false);
+                    setDrawOverlayMode('draw');
+                    setMode('preview');
+                    setDrawOverlayOpen(true);
+                  };
+                  if (manualEditMode) {
+                    void exitManualEditModeAfterFlush().then((ok) => {
+                      if (ok) activateDraw();
+                    });
+                    return;
+                  }
+                  activateDraw();
+                }}
+              >
+                <Icon name="draw" size={13} />
+                <span>{t('fileViewer.draw')}</span>
+              </button>
+              <span className="viewer-divider" aria-hidden />
+              <PreviewViewportControls
+                viewport={previewViewport}
+                onViewport={setPreviewViewport}
+                t={t}
+              />
+              <span className="viewer-divider" aria-hidden />
+              <button
+                type="button"
+                className="icon-only"
+                onClick={() => bumpZoom(-25)}
+                title={t('fileViewer.zoomOut')}
+                aria-label={t('fileViewer.zoomOut')}
+              >
+                <Icon name="minus" size={14} />
+              </button>
+              <div className="zoom-menu" ref={zoomMenuRef}>
+                <button
+                  type="button"
+                  className="viewer-action zoom-trigger"
+                  aria-haspopup="menu"
+                  aria-expanded={zoomMenuOpen}
+                  onClick={() => setZoomMenuOpen((v) => !v)}
+                  style={{ minWidth: 64 }}
+                >
+                  <span style={{ fontVariantNumeric: 'tabular-nums' }}>{zoom}%</span>
+                  <Icon name="chevron-down" size={11} />
+                </button>
+                {zoomMenuOpen ? (
+                  <div className="zoom-menu-popover" role="menu">
+                    {[50, 75, 100, 125, 150, 200].map((level) => (
+                      <button
+                        key={level}
+                        type="button"
+                        className={`zoom-menu-item${zoom === level ? ' active' : ''}`}
+                        role="menuitem"
+                        onClick={() => {
+                          setZoom(level);
+                          setZoomMenuOpen(false);
+                        }}
+                      >
+                        <span style={{ fontVariantNumeric: 'tabular-nums' }}>{level}%</span>
+                        {zoom === level ? (
+                          <Icon name="check" size={13} />
+                        ) : null}
+                      </button>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+              <button
+                type="button"
+                className="icon-only"
+                onClick={() => bumpZoom(25)}
+                title={t('fileViewer.zoomIn')}
+                aria-label={t('fileViewer.zoomIn')}
+              >
+                <Icon name="plus" size={14} />
+              </button>
+            </>
+          ) : null}
         </div>
       </div>
       {((filePrimaryActions: ReactNode) => (

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -5073,29 +5073,6 @@ function HtmlViewer({
                 />
               </div>
               <button
-                className={`viewer-action${manualEditMode ? ' active' : ''}`}
-                type="button"
-                data-testid="manual-edit-mode-toggle"
-                title={t('fileViewer.edit')}
-                aria-pressed={manualEditMode}
-                onClick={() => {
-                  if (!manualEditMode) {
-                    setBoardMode(false);
-                    clearBoardComposer();
-                    setInspectMode(false);
-                    setDrawOverlayOpen(false);
-                    setMode('preview');
-                    setManualEditViewportWidth(previewBodyRef.current?.clientWidth ?? null);
-                    setManualEditMode(true);
-                    return;
-                  }
-                  void exitManualEditModeAfterFlush();
-                }}
-              >
-                <Icon name="edit" size={13} />
-                <span>{t('fileViewer.edit')}</span>
-              </button>
-              <button
                 className={`viewer-action${drawOverlayOpen ? ' active' : ''}`}
                 type="button"
                 data-testid="draw-overlay-toggle"
@@ -5133,61 +5110,84 @@ function HtmlViewer({
                 onViewport={setPreviewViewport}
                 t={t}
               />
-              <span className="viewer-divider" aria-hidden />
-              <button
-                type="button"
-                className="icon-only"
-                onClick={() => bumpZoom(-25)}
-                title={t('fileViewer.zoomOut')}
-                aria-label={t('fileViewer.zoomOut')}
-              >
-                <Icon name="minus" size={14} />
-              </button>
-              <div className="zoom-menu" ref={zoomMenuRef}>
-                <button
-                  type="button"
-                  className="viewer-action zoom-trigger"
-                  aria-haspopup="menu"
-                  aria-expanded={zoomMenuOpen}
-                  onClick={() => setZoomMenuOpen((v) => !v)}
-                  style={{ minWidth: 64 }}
-                >
-                  <span style={{ fontVariantNumeric: 'tabular-nums' }}>{zoom}%</span>
-                  <Icon name="chevron-down" size={11} />
-                </button>
-                {zoomMenuOpen ? (
-                  <div className="zoom-menu-popover" role="menu">
-                    {[50, 75, 100, 125, 150, 200].map((level) => (
-                      <button
-                        key={level}
-                        type="button"
-                        className={`zoom-menu-item${zoom === level ? ' active' : ''}`}
-                        role="menuitem"
-                        onClick={() => {
-                          setZoom(level);
-                          setZoomMenuOpen(false);
-                        }}
-                      >
-                        <span style={{ fontVariantNumeric: 'tabular-nums' }}>{level}%</span>
-                        {zoom === level ? (
-                          <Icon name="check" size={13} />
-                        ) : null}
-                      </button>
-                    ))}
-                  </div>
-                ) : null}
-              </div>
-              <button
-                type="button"
-                className="icon-only"
-                onClick={() => bumpZoom(25)}
-                title={t('fileViewer.zoomIn')}
-                aria-label={t('fileViewer.zoomIn')}
-              >
-                <Icon name="plus" size={14} />
-              </button>
             </>
           ) : null}
+          <button
+            className={`viewer-action${manualEditMode ? ' active' : ''}`}
+            type="button"
+            data-testid="manual-edit-mode-toggle"
+            title={t('fileViewer.edit')}
+            aria-pressed={manualEditMode}
+            onClick={() => {
+              if (!manualEditMode) {
+                setBoardMode(false);
+                clearBoardComposer();
+                setInspectMode(false);
+                setDrawOverlayOpen(false);
+                setMode('preview');
+                setManualEditViewportWidth(previewBodyRef.current?.clientWidth ?? null);
+                setManualEditMode(true);
+                return;
+              }
+              void exitManualEditModeAfterFlush();
+            }}
+          >
+            <Icon name="edit" size={13} />
+            <span>{t('fileViewer.edit')}</span>
+          </button>
+          <span className="viewer-divider" aria-hidden />
+          <button
+            type="button"
+            className="icon-only"
+            onClick={() => bumpZoom(-25)}
+            title={t('fileViewer.zoomOut')}
+            aria-label={t('fileViewer.zoomOut')}
+          >
+            <Icon name="minus" size={14} />
+          </button>
+          <div className="zoom-menu" ref={zoomMenuRef}>
+            <button
+              type="button"
+              className="viewer-action zoom-trigger"
+              aria-haspopup="menu"
+              aria-expanded={zoomMenuOpen}
+              onClick={() => setZoomMenuOpen((v) => !v)}
+              style={{ minWidth: 64 }}
+            >
+              <span style={{ fontVariantNumeric: 'tabular-nums' }}>{zoom}%</span>
+              <Icon name="chevron-down" size={11} />
+            </button>
+            {zoomMenuOpen ? (
+              <div className="zoom-menu-popover" role="menu">
+                {[50, 75, 100, 125, 150, 200].map((level) => (
+                  <button
+                    key={level}
+                    type="button"
+                    className={`zoom-menu-item${zoom === level ? ' active' : ''}`}
+                    role="menuitem"
+                    onClick={() => {
+                      setZoom(level);
+                      setZoomMenuOpen(false);
+                    }}
+                  >
+                    <span style={{ fontVariantNumeric: 'tabular-nums' }}>{level}%</span>
+                    {zoom === level ? (
+                      <Icon name="check" size={13} />
+                    ) : null}
+                  </button>
+                ))}
+              </div>
+            ) : null}
+          </div>
+          <button
+            type="button"
+            className="icon-only"
+            onClick={() => bumpZoom(25)}
+            title={t('fileViewer.zoomIn')}
+            aria-label={t('fileViewer.zoomIn')}
+          >
+            <Icon name="plus" size={14} />
+          </button>
         </div>
       </div>
       {((filePrimaryActions: ReactNode) => (

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -418,6 +418,47 @@ describe('FileViewer SVG artifacts', () => {
     expect(markup).not.toContain('data-od-render-mode="url-load"');
   });
 
+  it('hides preview-only toolbar controls when switching an HTML deck to source view', async () => {
+    const file = baseFile({
+      name: 'deck.html',
+      path: 'deck.html',
+      mime: 'text/html',
+      kind: 'html',
+      artifactManifest: {
+        version: 1,
+        kind: 'html',
+        title: 'Deck',
+        entry: 'deck.html',
+        renderer: 'html',
+        exports: ['html'],
+      },
+    });
+
+    const { container } = render(
+      <FileViewer
+        projectId="project-1"
+        file={file}
+        isDeck
+        liveHtml={'<html><body><section class="slide">one</section><section class="slide">two</section></body></html>'}
+      />,
+    );
+
+    expect(container.querySelector('.deck-nav')).toBeTruthy();
+    expect(container.querySelector('.palette-tweaks-anchor')).toBeTruthy();
+    expect(container.querySelector('.viewer-viewport-switcher')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: /^source$/i }));
+
+    await waitFor(() => {
+      expect(container.querySelector('.deck-nav')).toBeNull();
+      expect(container.querySelector('.palette-tweaks-anchor')).toBeNull();
+      expect(container.querySelector('.viewer-viewport-switcher')).toBeNull();
+      expect(screen.queryByTestId('manual-edit-mode-toggle')).toBeNull();
+      expect(screen.queryByTestId('draw-overlay-toggle')).toBeNull();
+      expect(screen.queryByTestId('palette-tweaks-toggle')).toBeNull();
+    });
+  });
+
   it('shows Cloudflare Pages as a deploy action without requiring a project name input', async () => {
     const file = baseFile({
       name: 'index.html',

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -453,9 +453,11 @@ describe('FileViewer SVG artifacts', () => {
       expect(container.querySelector('.deck-nav')).toBeNull();
       expect(container.querySelector('.palette-tweaks-anchor')).toBeNull();
       expect(container.querySelector('.viewer-viewport-switcher')).toBeNull();
-      expect(screen.queryByTestId('manual-edit-mode-toggle')).toBeNull();
+      expect(screen.getByTestId('manual-edit-mode-toggle')).toBeTruthy();
       expect(screen.queryByTestId('draw-overlay-toggle')).toBeNull();
       expect(screen.queryByTestId('palette-tweaks-toggle')).toBeNull();
+      expect(screen.getByRole('button', { name: /zoom out/i })).toBeTruthy();
+      expect(screen.getByRole('button', { name: /zoom in/i })).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
Closes #1528

## Why

Source mode was hiding too much of the HTML viewer chrome. I hit this while cleaning up the source-view toolbar: the preview-only controls needed to disappear, but Edit and zoom still needed to stay available.

## What users will see

When they switch an HTML deck into Source view, the deck nav, Tweaks, Draw, and viewport picker disappear. Edit and zoom controls stay visible.

## Surface area

- [x] **UI** — `apps/web` HTML viewer toolbar
- [x] **Default behavior change** — source view now keeps Edit/zoom available
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **None**

## Screenshots

Not captured.

## Bug fix verification

- Regression test: `apps/web/tests/components/FileViewer.test.tsx` (`hides preview-only toolbar controls when switching an HTML deck to source view`)
- Red/green on main: not re-run on `main`; verified on this branch with the new regression test.

## Validation

- `pnpm vitest run -c vitest.config.ts tests/components/FileViewer.test.tsx`
