### PR TITLE
fix(web): localize accent controls in settings

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -4744,7 +4744,7 @@ function AppearanceSection({
   const current = cfg.theme ?? 'system';
   const currentAccent = normalizeAccentColor(cfg.accentColor) ?? DEFAULT_ACCENT_COLOR;
   const accentLabel = t('pet.fieldAccent');
-  const defaultAccentLabel = `${t('common.default')} ${accentLabel}`;
+  const defaultAccentLabel = t('pet.fieldAccentDefault');
   const customAccentLabel = t('pet.fieldAccentCustom');
 
   // Apply the draft theme immediately so the user sees a live preview

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -4742,7 +4742,10 @@ function AppearanceSection({
 }) {
   const { t } = useI18n();
   const current = cfg.theme ?? 'system';
-  const currentAccent = resolveAccentColor(cfg.accentColor);
+  const currentAccent = normalizeAccentColor(cfg.accentColor) ?? DEFAULT_ACCENT_COLOR;
+  const accentLabel = t('pet.fieldAccent');
+  const defaultAccentLabel = `${t('common.default')} ${accentLabel}`;
+  const customAccentLabel = t('pet.fieldAccentCustom');
 
   // Apply the draft theme immediately so the user sees a live preview
   // before hitting Save. SettingsDialog's cleanup reverts this on cancel.
@@ -4779,8 +4782,8 @@ function AppearanceSection({
         ))}
       </div>
       <div className="field">
-        <span className="field-label">Accent color</span>
-        <div className="pet-swatches" role="radiogroup" aria-label="Accent color">
+        <span className="field-label">{accentLabel}</span>
+        <div className="pet-swatches" role="radiogroup" aria-label={accentLabel}>
           {ACCENT_SWATCHES.map((color) => {
             const active = currentAccent === color;
             return (
@@ -4789,7 +4792,7 @@ function AppearanceSection({
                 type="button"
                 className={`pet-swatch${active ? ' active' : ''}`}
                 style={{ background: color }}
-                aria-label={color === DEFAULT_ACCENT_COLOR ? 'Default accent color' : color}
+                aria-label={color === DEFAULT_ACCENT_COLOR ? defaultAccentLabel : color}
                 aria-checked={active}
                 role="radio"
                 onClick={() => setAccentColor(color)}
@@ -4798,7 +4801,7 @@ function AppearanceSection({
           })}
           <input
             type="color"
-            aria-label="Custom accent color"
+            aria-label={customAccentLabel}
             className="pet-swatch-picker"
             value={currentAccent}
             onChange={(e) => setAccentColor(e.target.value)}

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -1065,6 +1065,7 @@ export const ar: Dict = {
   'pet.fieldGreeting': 'التحية',
   'pet.fieldAccent': 'لون التمييز',
   'pet.fieldAccentCustom': 'لون مخصص',
+  'pet.fieldAccentDefault': 'لون التمييز الافتراضي',
   'pet.overlayAria': 'رفيق الحيوان الأليف',
   'pet.spriteAria': '{name} - اسحب للتحريك، اضغط للدردشة',
   'pet.spriteTitle': 'مرحباً من {name}! اضغط للدردشة.',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -994,6 +994,7 @@ export const de: Dict = {
   'pet.fieldGreeting': 'Begrüßung',
   'pet.fieldAccent': 'Akzentfarbe',
   'pet.fieldAccentCustom': 'Eigene Farbe',
+  'pet.fieldAccentDefault': 'Standard-Akzentfarbe',
   'pet.overlayAria': 'Haustier-Begleiter',
   'pet.spriteAria': '{name} — zum Bewegen ziehen, zum Plaudern klicken',
   'pet.spriteTitle': 'Hallo von {name}! Klick zum Plaudern.',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1278,6 +1278,7 @@ export const en: Dict = {
   'pet.fieldGreeting': 'Greeting',
   'pet.fieldAccent': 'Accent color',
   'pet.fieldAccentCustom': 'Custom color',
+  'pet.fieldAccentDefault': 'Default accent color',
   'pet.overlayAria': 'Pet companion',
   'pet.spriteAria': '{name} — drag to move, click to chat',
   'pet.spriteTitle': 'Hi from {name}! Click to chat.',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -954,6 +954,7 @@ export const esES: Dict = {
   'pet.fieldGreeting': 'Saludo',
   'pet.fieldAccent': 'Color de acento',
   'pet.fieldAccentCustom': 'Color personalizado',
+  'pet.fieldAccentDefault': 'Color de acento predeterminado',
   'pet.overlayAria': 'Compañero',
   'pet.spriteAria': '{name} — arrastra para mover, haz clic para conversar',
   'pet.spriteTitle': '¡Hola de {name}! Haz clic para conversar.',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -1108,6 +1108,7 @@ export const fa: Dict = {
   'pet.fieldGreeting': 'پیام خوش‌آمد',
   'pet.fieldAccent': 'رنگ تأکید',
   'pet.fieldAccentCustom': 'رنگ سفارشی',
+  'pet.fieldAccentDefault': 'رنگ تأکید پیش‌فرض',
   'pet.overlayAria': 'همراه حیوان خانگی',
   'pet.spriteAria': '{name} — برای جابجایی بکشید، برای گفت‌وگو کلیک کنید',
   'pet.spriteTitle': 'سلام از طرف {name}! برای گفت‌وگو کلیک کنید.',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -1065,6 +1065,7 @@ export const fr: Dict = {
   'pet.fieldGreeting': 'Salutation',
   'pet.fieldAccent': 'Couleur d\'accent',
   'pet.fieldAccentCustom': 'Couleur personnalisée',
+  'pet.fieldAccentDefault': 'Couleur d\'accent par défaut',
   'pet.overlayAria': 'Compagnon',
   'pet.spriteAria': '{name} — glisser pour déplacer, cliquer pour chatter',
   'pet.spriteTitle': 'Salut de {name} ! Cliquez pour chatter.',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -1065,6 +1065,7 @@ export const hu: Dict = {
   'pet.fieldGreeting': 'Üdvözlés',
   'pet.fieldAccent': 'Kiemelőszín',
   'pet.fieldAccentCustom': 'Egyedi szín',
+  'pet.fieldAccentDefault': 'Alapértelmezett kiemelőszín',
   'pet.overlayAria': 'Háziállat társ',
   'pet.spriteAria': '{name} — húzd a mozgatáshoz, kattints a beszélgetéshez',
   'pet.spriteTitle': 'Üdv tőlem, {name}! Kattints a beszélgetéshez.',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -1214,6 +1214,7 @@ export const id: Dict = {
   'pet.fieldGreeting': 'Sapaan',
   'pet.fieldAccent': 'Aksen',
   'pet.fieldAccentCustom': 'Kustom',
+  'pet.fieldAccentDefault': 'Warna aksen default',
   'pet.overlayAria': 'Overlay pet',
   'pet.spriteAria': '{name} - geser untuk memindahkan, klik untuk chat',
   'pet.spriteTitle': 'Halo dari {name}! Klik untuk chat.',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -993,6 +993,7 @@ export const ja: Dict = {
   'pet.fieldGreeting': 'あいさつ',
   'pet.fieldAccent': 'アクセントカラー',
   'pet.fieldAccentCustom': 'カスタムカラー',
+  'pet.fieldAccentDefault': 'デフォルトのアクセントカラー',
   'pet.overlayAria': 'ペットの相棒',
   'pet.spriteAria': '{name} — ドラッグで移動、クリックで会話',
   'pet.spriteTitle': '{name} からこんにちは！クリックで会話。',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -1106,6 +1106,7 @@ export const ko: Dict = {
   'pet.fieldGreeting': '인사말',
   'pet.fieldAccent': '강조 색상',
   'pet.fieldAccentCustom': '사용자 색상',
+  'pet.fieldAccentDefault': '기본 강조 색상',
   'pet.overlayAria': '펫 친구',
   'pet.spriteAria': '{name} — 드래그하여 이동, 클릭하여 대화',
   'pet.spriteTitle': '{name}의 인사! 클릭해서 대화하세요.',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -1065,6 +1065,7 @@ export const pl: Dict = {
   'pet.fieldGreeting': 'Powitanie',
   'pet.fieldAccent': 'Kolor akcentu',
   'pet.fieldAccentCustom': 'Własny kolor',
+  'pet.fieldAccentDefault': 'Domyślny kolor akcentu',
   'pet.overlayAria': 'Towarzysz pupil',
   'pet.spriteAria': '{name} — przeciągnij, aby przesunąć, kliknij, aby porozmawiać',
   'pet.spriteTitle': 'Cześć od {name}! Kliknij, aby porozmawiać.',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -1106,6 +1106,7 @@ export const ptBR: Dict = {
   'pet.fieldGreeting': 'Saudação',
   'pet.fieldAccent': 'Cor de destaque',
   'pet.fieldAccentCustom': 'Cor personalizada',
+  'pet.fieldAccentDefault': 'Cor de destaque padrão',
   'pet.overlayAria': 'Companheiro',
   'pet.spriteAria': '{name} — arraste para mover, clique para conversar',
   'pet.spriteTitle': 'Olá de {name}! Clique para conversar.',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -1106,6 +1106,7 @@ export const ru: Dict = {
   'pet.fieldGreeting': 'Приветствие',
   'pet.fieldAccent': 'Акцентный цвет',
   'pet.fieldAccentCustom': 'Свой цвет',
+  'pet.fieldAccentDefault': 'Цвет акцента по умолчанию',
   'pet.overlayAria': 'Питомец-компаньон',
   'pet.spriteAria': '{name} — тащите, чтобы переместить, кликните, чтобы пообщаться',
   'pet.spriteTitle': 'Привет от {name}! Кликните, чтобы пообщаться.',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -1055,6 +1055,7 @@ export const th: Dict = {
   'pet.fieldGreeting': 'เสียงคำทักทายที่กล่าวไว้',
   'pet.fieldAccent': 'ใช้สีโทนสดใสของเน้นตัว',
   'pet.fieldAccentCustom': 'ปรับแต่งของสีด้วยตัวเอง',
+  'pet.fieldAccentDefault': 'สีเน้นเริ่มต้น',
   'pet.overlayAria': 'เป็นโชว์แผงของสัตว์',
   'pet.spriteAria': 'นี่ของ {name} — ตัวกดจับลากและแชทเข้าพูด',
   'pet.spriteTitle': 'แวะมาหวัดดีจาก {name}! จิ้มมาสนทนากัน',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -1052,6 +1052,7 @@ export const tr: Dict = {
   'pet.fieldGreeting': 'Selamlama',
   'pet.fieldAccent': 'Vurgu rengi',
   'pet.fieldAccentCustom': 'Özel renk',
+  'pet.fieldAccentDefault': 'Varsayılan vurgu rengi',
   'pet.overlayAria': 'Evcil dost yoldaş',
   'pet.spriteAria': '{name} — taşımak için sürükle, sohbet için tıkla',
   'pet.spriteTitle': '{name} merhaba diyor! Sohbet için tıkla.',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -1107,6 +1107,7 @@ export const uk: Dict = {
   'pet.fieldGreeting': 'Привіт',
   'pet.fieldAccent': 'Колір акценту',
   'pet.fieldAccentCustom': 'Власний колір',
+  'pet.fieldAccentDefault': 'Колір акценту за замовчуванням',
   'pet.overlayAria': 'Супутник домашної тварини',
   'pet.spriteAria': '{name} — перетягніть для переміщення, натисніть для чату',
   'pet.spriteTitle': 'Привіт від {name}! Натисніть для чату.',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1242,6 +1242,7 @@ export const zhCN: Dict = {
   'pet.fieldGreeting': '问候语',
   'pet.fieldAccent': '主题色',
   'pet.fieldAccentCustom': '自定义颜色',
+  'pet.fieldAccentDefault': '默认主题色',
   'pet.overlayAria': '宠物伙伴',
   'pet.spriteAria': '{name} — 拖动可移动，点击与它互动',
   'pet.spriteTitle': '{name} 来打招呼啦！点击聊天。',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -1195,6 +1195,7 @@ export const zhTW: Dict = {
   'pet.fieldGreeting': '問候語',
   'pet.fieldAccent': '主題色',
   'pet.fieldAccentCustom': '自訂顏色',
+  'pet.fieldAccentDefault': '預設主題色',
   'pet.overlayAria': '寵物夥伴',
   'pet.spriteAria': '{name} — 拖曳可移動，點擊與它互動',
   'pet.spriteTitle': '{name} 來打招呼啦！點擊聊天。',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -1476,6 +1476,7 @@ export interface Dict {
   'pet.fieldGreeting': string;
   'pet.fieldAccent': string;
   'pet.fieldAccentCustom': string;
+  'pet.fieldAccentDefault': string;
   'pet.overlayAria': string;
   'pet.spriteAria': string;
   'pet.spriteTitle': string;

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -433,6 +433,7 @@ describe('FileViewer SVG artifacts', () => {
     const { container } = render(
       <FileViewer
         projectId="project-1"
+        projectKind="prototype"
         file={file}
         isDeck
         liveHtml={'<html><body><section class="slide">one</section><section class="slide">two</section></body></html>'}

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -1825,7 +1825,7 @@ describe('SettingsDialog appearance interactions', () => {
 
     expect(screen.getByText('主题色')).toBeTruthy();
     expect(screen.getByRole('radiogroup', { name: '主题色' })).toBeTruthy();
-    expect(screen.getByRole('radio', { name: '默认 主题色' })).toBeTruthy();
+    expect(screen.getByRole('radio', { name: '默认主题色' })).toBeTruthy();
     expect(screen.getByLabelText('自定义颜色')).toBeTruthy();
   });
 });

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -1792,7 +1792,7 @@ describe('SettingsDialog appearance interactions', () => {
       {},
     );
 
-    fireEvent.change(screen.getByLabelText('Custom accent color'), {
+    fireEvent.change(screen.getByLabelText('Custom color'), {
       target: { value: '#123456' },
     });
     expect(document.documentElement.style.getPropertyValue('--accent')).toBe('#123456');
@@ -1804,6 +1804,29 @@ describe('SettingsDialog appearance interactions', () => {
       }),
       {},
     );
+  });
+
+  it('localizes the accent color controls in Chinese', () => {
+    render(
+      <I18nProvider initial="zh-CN">
+        <SettingsDialog
+          initial={{ ...baseConfig, theme: 'light' }}
+          agents={availableAgents}
+          daemonLive={true}
+          appVersionInfo={null}
+          initialSection="appearance"
+          onPersist={vi.fn()}
+          onPersistComposioKey={vi.fn()}
+          onClose={vi.fn()}
+          onRefreshAgents={vi.fn()}
+        />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText('主题色')).toBeTruthy();
+    expect(screen.getByRole('radiogroup', { name: '主题色' })).toBeTruthy();
+    expect(screen.getByRole('radio', { name: '默认 主题色' })).toBeTruthy();
+    expect(screen.getByLabelText('自定义颜色')).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
## Summary
- localize the Settings → Appearance accent color label, swatch group, default swatch, and custom color input
- add a Chinese regression test for the localized copy

## Why
The accent controls in Settings → Appearance still exposed English-only text in an otherwise localized surface. That created a mixed-language experience for translated users and made the controls harder to scan consistently.

## What users will see
- The accent color label, swatch group, default swatch, and custom color input are localized in Settings → Appearance.
- Chinese users see translated copy for the accent controls and matching accessibility labels.
- No behavior changes beyond the copy shown in the UI.

## Surface area
- [x] UI
- [x] i18n keys
- [x] Tests
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] New top-level dependency
- [ ] None

- `apps/web/src/components/SettingsDialog.tsx`
- `apps/web/tests/components/SettingsDialog.execution.test.tsx`

## Screenshots
- N/A

## Bug fix verification
- Regression test: `apps/web/tests/components/SettingsDialog.execution.test.tsx` (`localizes the accent color controls in Chinese`)
- Red/green on main: not re-run on `main`; verified on this branch with the new regression test.

## Validation
- `vitest run -c vitest.config.ts tests/components/SettingsDialog.execution.test.tsx -t "localizes the accent color controls in Chinese"`
