### PR TITLE
fix(web): auto-scroll feedback form

### DIFF
--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -1,4 +1,4 @@
-import { Fragment, type ReactNode, useEffect, useMemo, useState } from "react";
+import { Fragment, type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { ToolCard } from "./ToolCard";
 import { renderMarkdown } from "../runtime/markdown";
 import { projectFileUrl } from "../providers/registry";
@@ -399,6 +399,7 @@ function AssistantFeedback({
   const [burstKey, setBurstKey] = useState(0);
   const [reasonRating, setReasonRating] =
     useState<ChatMessageFeedbackRating | null>(null);
+  const reasonsRef = useRef<HTMLDivElement | null>(null);
   const [draftReasonCodes, setDraftReasonCodes] = useState<
     Set<ChatMessageFeedbackReasonCode>
   >(() => new Set());
@@ -408,6 +409,10 @@ function AssistantFeedback({
     if (selected) return;
     setReasonRating(null);
   }, [selected]);
+  useEffect(() => {
+    if (!reasonRating) return;
+    reasonsRef.current?.scrollIntoView({ block: "start", behavior: "smooth" });
+  }, [reasonRating]);
   const toggleFeedback = (rating: ChatMessageFeedbackRating) => {
     const nextRating = selected === rating ? null : rating;
     if (nextRating === "positive") setBurstKey((key) => key + 1);
@@ -495,7 +500,7 @@ function AssistantFeedback({
     <div className="assistant-feedback-wrap">
       <AssistantFooter {...footerProps} feedbackControls={controls} />
       {reasonRating ? (
-        <div className="assistant-feedback-reasons">
+        <div className="assistant-feedback-reasons" ref={reasonsRef}>
           <div className="assistant-feedback-reason-title">
             <span>{t("assistant.feedbackReasonTitle")}</span>
             <span className="assistant-feedback-reason-emoji" aria-hidden="true">

--- a/apps/web/tests/components/chat-feedback.test.tsx
+++ b/apps/web/tests/components/chat-feedback.test.tsx
@@ -13,9 +13,15 @@ if (typeof HTMLElement.prototype.scrollTo !== 'function') {
 }
 
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ChatPane } from '../../src/components/ChatPane';
 import type { ChatMessage, ChatMessageFeedbackChange } from '../../src/types';
+
+const originalScrollIntoView = Element.prototype.scrollIntoView;
+
+if (typeof Element.prototype.scrollIntoView !== 'function') {
+  Element.prototype.scrollIntoView = vi.fn();
+}
 
 function completedAssistant(
   input: Partial<ChatMessage> = {},
@@ -125,6 +131,15 @@ function renderChatPane({
 
 describe('chat assistant feedback', () => {
   afterEach(() => cleanup());
+
+  beforeEach(() => {
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  afterEach(() => {
+    Element.prototype.scrollIntoView = originalScrollIntoView;
+    vi.restoreAllMocks();
+  });
 
   it('collects feedback only after an assistant turn produces an artifact', () => {
     renderChatPane({
@@ -310,6 +325,19 @@ describe('chat assistant feedback', () => {
 
     expect(screen.getByText('Tell us why')).toBeTruthy();
     expect(screen.getByText('😔')).toBeTruthy();
+  });
+
+  it('scrolls the feedback reasons panel into view after selecting a rating', () => {
+    const scrollIntoView = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+
+    renderChatPane({
+      messages: [completedArtifactAssistant()],
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Not helpful' }));
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: 'start', behavior: 'smooth' });
   });
 
   it('does not ask for feedback while the assistant is still running', () => {


### PR DESCRIPTION
Fixes #1563.

When a user selects feedback, the reasons panel now scrolls into view so the form is immediately visible.

Tested with:
- pnpm exec vitest run -c vitest.config.ts tests/components/chat-feedback.test.tsx