### PR TITLE
fix(orbit): surface the failure reason in no-artifact summaries

### DIFF
--- a/apps/daemon/src/orbit-summary.ts
+++ b/apps/daemon/src/orbit-summary.ts
@@ -1,0 +1,25 @@
+export function formatOrbitCompletionSummary({
+  status,
+  artifactTitle,
+  assistantMessage,
+}: {
+  status: string;
+  artifactTitle?: string | null;
+  assistantMessage?: string | null;
+}): string {
+  if (artifactTitle) {
+    return `Agent ${status} and registered live artifact ${artifactTitle}.`;
+  }
+
+  const detail = compactSummaryText(assistantMessage);
+  return detail
+    ? `Agent ${status} but did not register a live artifact for this Orbit run: ${detail}`
+    : `Agent ${status} but did not register a live artifact for this Orbit run.`;
+}
+
+function compactSummaryText(text: string | null | undefined, maxLength = 220): string {
+  const firstBlock = typeof text === 'string' ? text.trim().split(/\n\s*\n/, 1)[0]?.trim() ?? '' : '';
+  const singleLine = firstBlock.replace(/\s+/g, ' ');
+  if (singleLine.length <= maxLength) return singleLine;
+  return `${singleLine.slice(0, maxLength - 1).trimEnd()}…`;
+}

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -72,6 +72,7 @@ import { handleCritiqueArtifact } from './critique/artifact-handler.js';
 import { createCopilotStreamHandler } from './copilot-stream.js';
 import { createJsonEventStreamHandler } from './json-event-stream.js';
 import { createQoderStreamHandler } from './qoder-stream.js';
+import { formatOrbitCompletionSummary } from './orbit-summary.js';
 import { subscribe as subscribeFileEvents } from './project-watchers.js';
 import { renderDesignSystemPreview } from './design-system-preview.js';
 import { renderDesignSystemShowcase } from './design-system-showcase.js';
@@ -4469,13 +4470,16 @@ export async function startServer({
       const artifacts = await listLiveArtifacts({ projectsRoot: PROJECTS_DIR, projectId });
       const artifact = artifacts.find((candidate) => candidate.createdByRunId === run.id);
       const status = finalStatus.status === 'succeeded' && !artifact ? 'failed' : finalStatus.status;
+      const assistantMessage = listMessages(db, conversationId).find((message) => message.id === assistantMessageId)?.content ?? null;
       return {
         agentRunId: run.id,
         status,
         ...(artifact?.id ? { artifactId: artifact.id, artifactProjectId: projectId } : {}),
-        summary: artifact?.id
-          ? `Agent ${finalStatus.status} and registered live artifact ${artifact.title}.`
-          : `Agent ${finalStatus.status} but did not register a live artifact for this Orbit run.`,
+        summary: formatOrbitCompletionSummary({
+          status,
+          artifactTitle: artifact?.title ?? null,
+          assistantMessage,
+        }),
       };
     })();
 

--- a/apps/daemon/tests/orbit-summary.test.ts
+++ b/apps/daemon/tests/orbit-summary.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatOrbitCompletionSummary } from '../src/orbit-summary.js';
+
+describe('formatOrbitCompletionSummary', () => {
+  it('prefers the artifact title when a live artifact was registered', () => {
+    expect(
+      formatOrbitCompletionSummary({
+        status: 'succeeded',
+        artifactTitle: 'Daily digest',
+        assistantMessage: 'ignored',
+      }),
+    ).toBe('Agent succeeded and registered live artifact Daily digest.');
+  });
+
+  it('appends a compact assistant-message excerpt when no artifact was registered', () => {
+    expect(
+      formatOrbitCompletionSummary({
+        status: 'failed',
+        assistantMessage: 'Data loading failed, so I did not create a daily digest artifact.\n\nGitHub auth expired.',
+      }),
+    ).toBe(
+      'Agent failed but did not register a live artifact for this Orbit run: Data loading failed, so I did not create a daily digest artifact.',
+    );
+  });
+
+  it('falls back to the generic no-artifact summary when there is no assistant message', () => {
+    expect(
+      formatOrbitCompletionSummary({
+        status: 'failed',
+      }),
+    ).toBe('Agent failed but did not register a live artifact for this Orbit run.');
+  });
+});


### PR DESCRIPTION
## Why
Orbit summaries needed to keep a useful final explanation even when no live artifact was registered. Without that, the fallback message was too generic and hid the actual failure context.

## What users will see
- No-artifact runs now keep a compact excerpt from the assistant's final explanation.
- The generic fallback still exists, but it no longer drops the useful context on the floor.
- The summary reads more like the actual run result and less like a generic failure.

## Surface area
- [x] Daemon
- [x] Tests
- [ ] UI
- [ ] API
- [ ] Docs
- [ ] None

## Validation
- `pnpm exec vitest run -c vitest.config.ts tests/orbit-summary.test.ts`
- `pnpm exec tsc -p tsconfig.json --noEmit`
