### PR TITLE
Fix Codex message item line boundaries

### DIFF
--- a/apps/daemon/src/json-event-stream.ts
+++ b/apps/daemon/src/json-event-stream.ts
@@ -8,6 +8,8 @@ type ParserState = {
   openCodeToolUses: Set<string>;
   codexToolUses: Set<string>;
   codexErrorEmitted: boolean;
+  codexPreviousEventWasAgentMessage: boolean;
+  codexLastAgentMessageEndedWithNewline: boolean;
 };
 
 type Usage = {
@@ -302,6 +304,8 @@ if (obj.type === 'error') {
   }
 
   if (obj.type === 'turn.started') {
+    state.codexPreviousEventWasAgentMessage = false;
+    state.codexLastAgentMessageEndedWithNewline = false;
     onEvent({ type: 'status', label: 'running' });
     return true;
   }
@@ -309,6 +313,8 @@ if (obj.type === 'error') {
   if (obj.type === 'item.started' && isRecord(obj.item)) {
     const item = obj.item;
     if (item.type === 'command_execution' && typeof item.id === 'string') {
+      state.codexPreviousEventWasAgentMessage = false;
+      state.codexLastAgentMessageEndedWithNewline = false;
       if (!state.codexToolUses.has(item.id)) {
         state.codexToolUses.add(item.id);
         onEvent({
@@ -327,6 +333,8 @@ if (obj.type === 'error') {
   if (obj.type === 'item.completed' && isRecord(obj.item)) {
     const item = obj.item;
     if (item.type === 'command_execution' && typeof item.id === 'string') {
+      state.codexPreviousEventWasAgentMessage = false;
+      state.codexLastAgentMessageEndedWithNewline = false;
       if (!state.codexToolUses.has(item.id)) {
         state.codexToolUses.add(item.id);
         onEvent({
@@ -355,7 +363,15 @@ if (obj.type === 'error') {
     typeof obj.item.text === 'string' &&
     obj.item.text.length > 0
   ) {
-    onEvent({ type: 'text_delta', delta: obj.item.text });
+    const text = obj.item.text;
+    const needsBoundary =
+      state.codexPreviousEventWasAgentMessage &&
+      !state.codexLastAgentMessageEndedWithNewline &&
+      !text.startsWith('\n');
+    const delta = needsBoundary ? `\n${text}` : text;
+    onEvent({ type: 'text_delta', delta });
+    state.codexPreviousEventWasAgentMessage = true;
+    state.codexLastAgentMessageEndedWithNewline = text.endsWith('\n');
     return true;
   }
 
@@ -380,6 +396,8 @@ export function createJsonEventStreamHandler(kind: ParserKind, onEvent: StreamEv
     openCodeToolUses: new Set<string>(),
     codexToolUses: new Set<string>(),
     codexErrorEmitted: false,
+    codexPreviousEventWasAgentMessage: false,
+    codexLastAgentMessageEndedWithNewline: false,
   };
 
   function handleLine(line: string): void {

--- a/apps/daemon/tests/json-event-stream.test.ts
+++ b/apps/daemon/tests/json-event-stream.test.ts
@@ -318,6 +318,65 @@ test('codex json stream emits status text and usage events', () => {
   ]);
 });
 
+test('codex json stream preserves line boundaries between assistant message items', () => {
+  const { events, handler } = collectEvents('codex');
+
+  handler.feed(
+    JSON.stringify({ type: 'turn.started' }) + '\n' +
+    JSON.stringify({
+      type: 'item.completed',
+      item: { id: 'item-1', type: 'agent_message', text: 'English: one' },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'item.completed',
+      item: { id: 'item-2', type: 'agent_message', text: 'Chinese: 一' },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'item.completed',
+      item: { id: 'item-3', type: 'agent_message', text: 'English: two' },
+    }) +
+    '\n',
+  );
+
+  const text = events
+    .filter((event) => event.type === 'text_delta')
+    .map((event) => event.delta)
+    .join('');
+
+  assert.equal(text, 'English: one\nChinese: 一\nEnglish: two');
+});
+
+test('codex json stream does not duplicate existing assistant message newlines', () => {
+  const { events, handler } = collectEvents('codex');
+
+  handler.feed(
+    JSON.stringify({
+      type: 'item.completed',
+      item: { id: 'item-1', type: 'agent_message', text: 'English: one\n' },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'item.completed',
+      item: { id: 'item-2', type: 'agent_message', text: 'Chinese: 一' },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'item.completed',
+      item: { id: 'item-3', type: 'agent_message', text: '\nEnglish: two' },
+    }) +
+    '\n',
+  );
+
+  const text = events
+    .filter((event) => event.type === 'text_delta')
+    .map((event) => event.delta)
+    .join('');
+
+  assert.equal(text, 'English: one\nChinese: 一\nEnglish: two');
+});
+
 test('codex json stream emits structured errors once', () => {
   const { events, handler } = collectEvents('codex');
 


### PR DESCRIPTION
## Why

I hit a Codex streaming display bug where separate assistant message items such as bilingual `English:` / `Chinese:` pairs were rendered as one continuous paragraph in Open Design. The pain is user-facing: Codex Desktop preserves the visible line breaks, but Open Design flattened adjacent Codex `agent_message` items before the web renderer could display them.

## What users will see

Codex assistant replies that arrive as separate message items now keep a single line break between those items, so paired bilingual output displays as separate lines instead of being joined inline.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached; this is a parser-level fix covered by a daemon regression test.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/json-event-stream.test.ts`
- Did the test go red on `main` and green on this branch? No; I validated the failure with a direct parser-model reproduction, then added the daemon regression test and confirmed it passes on this branch.

## Validation

- `pnpm install`
- `pnpm --dir apps/daemon exec vitest run tests/json-event-stream.test.ts -c vitest.config.ts`
- `pnpm --filter @open-design/daemon typecheck`

Note: `pnpm --filter @open-design/daemon test -- tests/json-event-stream.test.ts` unexpectedly ran the broader daemon suite and hit an unrelated local `better-sqlite3` Node ABI mismatch (`NODE_MODULE_VERSION 141` vs Node `137`), so the parser test was rerun directly with Vitest.