### PR TITLE
fix(daemon): preserve Orbit no-artifact explanation

### DIFF
--- a/apps/daemon/src/orbit-agent-summary.ts
+++ b/apps/daemon/src/orbit-agent-summary.ts
@@ -1,0 +1,39 @@
+const NO_LIVE_ARTIFACT_SUMMARY =
+  'Agent succeeded but did not register a live artifact for this Orbit run.';
+
+const MAX_FINAL_EXPLANATION_CHARS = 2_000;
+
+interface RunEventRecord {
+  event?: unknown;
+  data?: unknown;
+}
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object') return null;
+  return value as Record<string, unknown>;
+}
+
+function textDeltaFromEvent(record: RunEventRecord): string | null {
+  if (record.event !== 'agent') return null;
+  const data = asObject(record.data);
+  if (!data || data.type !== 'text_delta') return null;
+  return typeof data.delta === 'string' ? data.delta : null;
+}
+
+export function extractOrbitAgentFinalExplanation(events: readonly RunEventRecord[]): string | null {
+  const text = events
+    .map(textDeltaFromEvent)
+    .filter((delta): delta is string => delta !== null)
+    .join('')
+    .trim();
+  if (!text) return null;
+  if (text.length <= MAX_FINAL_EXPLANATION_CHARS) return text;
+  return `${text.slice(0, MAX_FINAL_EXPLANATION_CHARS).trimEnd()}...`;
+}
+
+export function buildOrbitNoLiveArtifactSummary(events: readonly RunEventRecord[]): string {
+  const explanation = extractOrbitAgentFinalExplanation(events);
+  return explanation
+    ? `${NO_LIVE_ARTIFACT_SUMMARY}\n\n${explanation}`
+    : NO_LIVE_ARTIFACT_SUMMARY;
+}

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -142,6 +142,7 @@ import {
 } from './mcp-tokens.js';
 import { agentCliEnvForAgent, readAppConfig, writeAppConfig } from './app-config.js';
 import { OrbitService, formatLocalProjectTimestamp, renderOrbitTemplateSystemPrompt } from './orbit.js';
+import { buildOrbitNoLiveArtifactSummary } from './orbit-agent-summary.js';
 import {
   RoutineService,
   validateSchedule as validateRoutineSchedule,
@@ -4396,7 +4397,9 @@ export async function startServer({
         ...(artifact?.id ? { artifactId: artifact.id, artifactProjectId: projectId } : {}),
         summary: artifact?.id
           ? `Agent ${finalStatus.status} and registered live artifact ${artifact.title}.`
-          : `Agent ${finalStatus.status} but did not register a live artifact for this Orbit run.`,
+          : finalStatus.status === 'succeeded'
+            ? buildOrbitNoLiveArtifactSummary(run.events)
+            : `Agent ${finalStatus.status} but did not register a live artifact for this Orbit run.`,
       };
     })();
 

--- a/apps/daemon/tests/orbit-agent-summary.test.ts
+++ b/apps/daemon/tests/orbit-agent-summary.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildOrbitNoLiveArtifactSummary,
+  extractOrbitAgentFinalExplanation,
+} from '../src/orbit-agent-summary.js';
+
+describe('Orbit agent summary helpers', () => {
+  it('preserves the agent final explanation for no-live-artifact Orbit runs', () => {
+    const summary = buildOrbitNoLiveArtifactSummary([
+      { event: 'agent', data: { type: 'text_delta', delta: 'Data loading failed, ' } },
+      { event: 'agent', data: { type: 'text_delta', delta: 'so I did not create a daily digest artifact.' } },
+    ]);
+
+    expect(summary).toContain(
+      'Agent succeeded but did not register a live artifact for this Orbit run.',
+    );
+    expect(summary).toContain(
+      'Data loading failed, so I did not create a daily digest artifact.',
+    );
+  });
+
+  it('extracts only user-visible text deltas from run events', () => {
+    expect(
+      extractOrbitAgentFinalExplanation([
+        { event: 'stdout', data: { chunk: 'raw tool output' } },
+        { event: 'stderr', data: { chunk: 'OPENAI_API_KEY=sk-raw-secret' } },
+        { event: 'tool_result', data: { output: 'token=raw-tool-secret' } },
+        { event: 'agent', data: { type: 'thinking_delta', delta: 'private reasoning' } },
+        { event: 'agent', data: { type: 'tool_use', name: 'Read' } },
+        { event: 'agent', data: { type: 'text_delta', delta: 'GitHub auth failed.' } },
+      ]),
+    ).toBe('GitHub auth failed.');
+  });
+
+  it('falls back to the implementation-level no-artifact marker without final text', () => {
+    expect(buildOrbitNoLiveArtifactSummary([])).toBe(
+      'Agent succeeded but did not register a live artifact for this Orbit run.',
+    );
+  });
+
+  it('bounds long final explanations before storing them in the Orbit receipt', () => {
+    const explanation = extractOrbitAgentFinalExplanation([
+      { event: 'agent', data: { type: 'text_delta', delta: 'x'.repeat(2_100) } },
+    ]);
+
+    expect(explanation).toHaveLength(2_003);
+    expect(explanation?.endsWith('...')).toBe(true);
+  });
+});

--- a/apps/daemon/tests/orbit.test.ts
+++ b/apps/daemon/tests/orbit.test.ts
@@ -277,6 +277,43 @@ describe('OrbitService', () => {
     }
   });
 
+  it('persists failed Orbit agent summaries in the last-run receipt markdown', async () => {
+    const dataDir = await mkdtemp(path.join(os.tmpdir(), 'orbit-test-'));
+    try {
+      const service = new OrbitService(dataDir);
+      service.setRunHandler(async () => ({
+        projectId: 'project-1',
+        agentRunId: 'agent-1',
+        completion: Promise.resolve({
+          agentRunId: 'agent-1',
+          status: 'failed',
+          summary:
+            'Agent succeeded but did not register a live artifact for this Orbit run.\n\nGitHub auth failed, so I did not create a daily digest artifact.',
+        }),
+      }));
+
+      await service.start('manual');
+      let status = await service.status();
+      for (let attempt = 0; attempt < 10 && (status.running || !status.lastRun); attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        status = await service.status();
+      }
+
+      expect(status.lastRun).not.toBeNull();
+      expect(status.running).toBe(false);
+      expect(status.lastRun?.connectorsSucceeded).toBe(0);
+      expect(status.lastRun?.connectorsFailed).toBe(1);
+      expect(status.lastRun?.markdown).toContain(
+        'Agent succeeded but did not register a live artifact for this Orbit run.',
+      );
+      expect(status.lastRun?.markdown).toContain(
+        'GitHub auth failed, so I did not create a daily digest artifact.',
+      );
+    } finally {
+      await rm(dataDir, { recursive: true, force: true });
+    }
+  });
+
   it('tracks the most recent run per template alongside the global last run', async () => {
     vi.useFakeTimers();
     const dataDir = await mkdtemp(path.join(os.tmpdir(), 'orbit-test-'));


### PR DESCRIPTION
Fixes #1557

## Why

Orbit can complete an unattended agent turn without registering a live artifact when data loading fails. Before this change, the Settings -> Orbit last-run receipt only kept the implementation-level no-artifact marker and dropped the agent's final user-facing explanation, leaving users without the connector/auth remediation they need.

I am opening this to preserve the actionable final explanation while keeping the no-artifact failure semantics intact.

## What users will see

When an Orbit run succeeds at the agent level but cannot register a live artifact, the last-run summary still reports that no live artifact was registered, and now also includes the agent's final explanation, such as which data source or connector auth problem prevented the digest from being created.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A - daemon receipt summary behavior only.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/orbit-agent-summary.test.ts`, plus receipt persistence coverage in `apps/daemon/tests/orbit.test.ts`
- Did the test go red on `main` and green on this branch? Not run on `main`; the new helper test encodes the missing no-artifact explanation behavior and passes on this branch.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run tests/orbit-agent-summary.test.ts tests/orbit.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- `git diff --check`
