### PR TITLE
fix(web): protect built-in skills from delete

### DIFF
--- a/apps/web/src/components/SkillsSection.tsx
+++ b/apps/web/src/components/SkillsSection.tsx
@@ -528,6 +528,7 @@ function SkillRow({
 }: SkillRowProps) {
   const t = useT();
   const summaryName = skill.name || skill.id;
+  const canDelete = skill.source === 'user';
   return (
     <div
       className={`skills-row${enabled ? '' : ' skills-row-disabled'}${
@@ -576,7 +577,7 @@ function SkillRow({
           </span>
         </button>
         <div className="skills-row-actions">
-          {confirmDelete ? (
+          {canDelete && confirmDelete ? (
             <span className="skills-delete-confirm" role="group">
               <button
                 type="button"
@@ -605,15 +606,17 @@ function SkillRow({
               >
                 <Icon name="edit" size={13} />
               </button>
-              <button
-                type="button"
-                className="icon-btn"
-                onClick={onArmDelete}
-                title={t('settings.skillsDelete')}
-                data-testid="skills-delete"
-              >
-                <Icon name="close" size={13} />
-              </button>
+              {canDelete ? (
+                <button
+                  type="button"
+                  className="icon-btn"
+                  onClick={onArmDelete}
+                  title={t('settings.skillsDelete')}
+                  data-testid="skills-delete"
+                >
+                  <Icon name="close" size={13} />
+                </button>
+              ) : null}
             </>
           )}
           <label

--- a/apps/web/tests/components/SkillsSection.test.tsx
+++ b/apps/web/tests/components/SkillsSection.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { SkillsSection } from '../../src/components/SkillsSection';
+import type { AppConfig } from '../../src/types';
+import type { SkillSummary } from '@open-design/contracts';
+
+const originalFetch = globalThis.fetch;
+
+const TEST_CONFIG: AppConfig = {
+  mode: 'daemon',
+  apiKey: '',
+  baseUrl: '',
+  model: '',
+  agentId: null,
+  skillId: null,
+  designSystemId: null,
+  disabledSkills: [],
+};
+
+function makeSkill(overrides: Partial<SkillSummary>): SkillSummary {
+  return {
+    id: 'skill',
+    name: 'Skill',
+    description: 'A skill',
+    triggers: [],
+    mode: 'prototype',
+    previewType: 'html',
+    designSystemRequired: true,
+    defaultFor: [],
+    upstream: null,
+    hasBody: true,
+    examplePrompt: '',
+    aggregatesExamples: false,
+    source: 'built-in',
+    ...overrides,
+  };
+}
+
+function renderSkillsSection(skills: SkillSummary[]) {
+  const setCfg = vi.fn();
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = input.toString();
+    if (url === '/api/skills' && (!init || init.method === undefined)) {
+      return new Response(JSON.stringify({ skills }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    if (url.startsWith('/api/skills/') && init?.method === 'DELETE') {
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    return new Response(JSON.stringify({}), { status: 404 });
+  }) as typeof fetch;
+
+  render(
+    <SkillsSection
+      cfg={TEST_CONFIG}
+      setCfg={setCfg}
+    />,
+  );
+  return { fetchMock: globalThis.fetch as ReturnType<typeof vi.fn>, setCfg };
+}
+
+describe('SkillsSection', () => {
+  afterEach(() => {
+    cleanup();
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('does not expose delete actions for built-in skills', async () => {
+    renderSkillsSection([
+      makeSkill({
+        id: 'builtin-skill',
+        name: 'Built-in skill',
+        source: 'built-in',
+      }),
+    ]);
+
+    const row = await screen.findByTestId('skill-row-builtin-skill');
+
+    expect(within(row).queryByTestId('skills-delete')).toBeNull();
+    expect(within(row).queryByTestId('skills-delete-confirm')).toBeNull();
+  });
+
+  it('keeps delete confirmation and commit available for user skills', async () => {
+    const { fetchMock } = renderSkillsSection([
+      makeSkill({
+        id: 'user-skill',
+        name: 'User skill',
+        source: 'user',
+      }),
+    ]);
+
+    const row = await screen.findByTestId('skill-row-user-skill');
+    fireEvent.click(within(row).getByTestId('skills-delete'));
+    fireEvent.click(within(row).getByTestId('skills-delete-confirm'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/skills/user-skill', {
+        method: 'DELETE',
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fixes #1383

## Why

Built-in skills are part of the bundled catalog, but the Skills page exposed the same destructive delete affordance that user-installed skills have. This PR keeps that action scoped to user-managed skills.

## What users will see

Settings -> Skills no longer shows the delete button or delete confirmation for built-in skills. User-installed skills still expose the existing delete flow.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A. This removes a destructive affordance from built-in rows; the component test verifies the button and confirmation are absent for built-in skills and still present for user skills.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/SkillsSection.test.tsx`
- Did the test go red on `main` and green on this branch? no. I added a focused regression test on this branch and verified it passes with the source change.
- Additional verification: the test covers both the blocked built-in path and the preserved user-skill delete path.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/SkillsSection.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `git diff --check`