### PR TITLE
fix(web): parse Provenance with Markdown-bold labels

### DIFF
--- a/apps/daemon/src/finalize-design.ts
+++ b/apps/daemon/src/finalize-design.ts
@@ -564,6 +564,8 @@ The Provenance section MUST list:
 - Transcript message count
 - Generated UTC timestamp
 
+Render Provenance fields as plain Markdown bullets with no emphasis on the field labels, exactly: "- Field name: value". Do not bold, italicize, or otherwise decorate the labels or the colon. Field values may use inline code formatting (backticks) where appropriate.
+
 Output the Markdown body only. No preamble, no chat-style framing, no
 "Here's your DESIGN.md" prefix. Do not invent facts not supported by the
 inputs; if an input is missing or empty, the corresponding section should

--- a/apps/web/src/lib/parse-provenance.ts
+++ b/apps/web/src/lib/parse-provenance.ts
@@ -41,10 +41,24 @@ export function parseProvenance(designMdText: string): ProvenanceFields | null {
 // (`- **Field:** value`) per Markdown convention. The capture starts
 // just after the label's `:`, so a leading `** ` (and any trailing
 // emphasis if the value itself is wrapped) leaks into the value.
-// Strip both ends; backticks are intentionally kept (the rendered
-// clipboard text reads fine with them).
+//
+// PR #1584 review (lefarcen): narrow the strip to only consume
+// Markdown residue, never literal `*`/`_` characters in the value:
+//   1. Leading `*`/`_` tokens FOLLOWED BY WHITESPACE
+//      (the `** ` left over from `- **Field:** value`).
+//   2. Trailing WHITESPACE followed by `*`/`_` tokens
+//      (mirror of step 1 if Claude closes after the value).
+//   3. A single balanced wrap around the whole remaining value
+//      (`**X**` / `*X*` / `__X__` / `_X_`).
+// Asymmetric literal `*`/`_` without a whitespace separator AND
+// without a balanced closing token are preserved
+// (e.g. `_draft.html`, `build_id_v1_`). Backticks are intentionally
+// kept (the rendered clipboard text reads fine with them).
 function stripMarkdownEmphasis(value: string): string {
-  return value.replace(/^[\s*_]+/, '').replace(/[\s*_]+$/, '');
+  let v = value.replace(/^[*_]+\s+/, '').replace(/\s+[*_]+$/, '');
+  const wrap = v.match(/^(\*\*|__|\*|_)(.+?)\1$/);
+  if (wrap && wrap[2]) v = wrap[2];
+  return v;
 }
 
 function extractRawValue(body: string, re: RegExp): string | null {

--- a/apps/web/src/lib/parse-provenance.ts
+++ b/apps/web/src/lib/parse-provenance.ts
@@ -32,43 +32,49 @@ export function parseProvenance(designMdText: string): ProvenanceFields | null {
     projectId: extractField(body, /Project\s*ID[:\s]+([^\n]+)/i),
     designSystemId: extractFieldOrNone(body, /Design\s*system[^:]*[:\s]+([^\n]+)/i),
     currentArtifact: extractFieldOrNone(body, /Current\s*artifact[^:]*[:\s]+([^\n]+)/i),
-    transcriptMessageCount: extractNumber(body, /Transcript\s*message\s*count[:\s]+(\d+)/i),
-    generatedAt: extractDate(body, /Generated[^:\n]*[:\s]+(\S[^\n]*)/i),
+    transcriptMessageCount: extractNumber(body, /Transcript\s*message\s*count[^:]*[:\s]+([^\n]+)/i),
+    generatedAt: extractDate(body, /Generated[^:\n]*[:\s]+([^\n]+)/i),
   };
 }
 
-function trimBullet(value: string): string {
-  // Lines look like "- Project ID: abc". The regex captures everything
-  // after the colon to the newline; strip incidental trailing whitespace.
-  return value.trim();
+// #1580: Claude renders Provenance fields with Markdown-bold labels
+// (`- **Field:** value`) per Markdown convention. The capture starts
+// just after the label's `:`, so a leading `** ` (and any trailing
+// emphasis if the value itself is wrapped) leaks into the value.
+// Strip both ends; backticks are intentionally kept (the rendered
+// clipboard text reads fine with them).
+function stripMarkdownEmphasis(value: string): string {
+  return value.replace(/^[\s*_]+/, '').replace(/[\s*_]+$/, '');
 }
 
-function extractField(body: string, re: RegExp): string | null {
+function extractRawValue(body: string, re: RegExp): string | null {
   const m = body.match(re);
   if (!m || !m[1]) return null;
-  const value = trimBullet(m[1]);
+  const value = stripMarkdownEmphasis(m[1].trim());
   return value.length > 0 ? value : null;
 }
 
+function extractField(body: string, re: RegExp): string | null {
+  return extractRawValue(body, re);
+}
+
 function extractFieldOrNone(body: string, re: RegExp): string | null {
-  const value = extractField(body, re);
+  const value = extractRawValue(body, re);
   if (value === null) return null;
   if (NONE_SENTINEL.test(value)) return null;
   return value;
 }
 
 function extractNumber(body: string, re: RegExp): number | null {
-  const m = body.match(re);
-  if (!m || !m[1]) return null;
-  const n = Number.parseInt(m[1], 10);
+  const raw = extractRawValue(body, re);
+  if (raw === null) return null;
+  const n = Number.parseInt(raw, 10);
   return Number.isFinite(n) ? n : null;
 }
 
 function extractDate(body: string, re: RegExp): Date | null {
-  const m = body.match(re);
-  if (!m || !m[1]) return null;
-  const raw = trimBullet(m[1]);
-  if (raw.length === 0) return null;
+  const raw = extractRawValue(body, re);
+  if (raw === null) return null;
   const d = new Date(raw);
   return Number.isFinite(d.getTime()) ? d : null;
 }

--- a/apps/web/tests/hooks/useDesignMdState.test.tsx
+++ b/apps/web/tests/hooks/useDesignMdState.test.tsx
@@ -99,6 +99,52 @@ describe('useDesignMdState', () => {
     expect(result.current.designSystemId).toBe('alphatrace');
   });
 
+  // Issue #1580: the synthesis prompt does not pin field-label syntax,
+  // so Claude emits Provenance with Markdown-bold labels in practice.
+  // This end-to-end test through useDesignMdState pins the parser fix
+  // at the hook layer — a regression that re-introduces the `** ` leak
+  // would surface `transcriptMessageCount === null` and trip the
+  // `unknown-provenance` fail-closed path instead of the fresh path.
+  it('reads bold-labelled Provenance correctly (issue #1580 end-to-end)', async () => {
+    const olderMs = FRESH_GENERATED_MS - 60_000;
+    const boldDesignMd = `# DESIGN.md
+
+## Provenance
+
+- **Project ID:** \`p1\`
+- **Design system:** \`alphatrace\`
+- **Current artifact:** \`deck.html\`
+- **Transcript message count:** 12
+- **Generated UTC timestamp:** 2026-05-08T12:00:00Z
+`;
+    installFetchMock({
+      files: {
+        body: {
+          files: [
+            { name: 'DESIGN.md', size: 100, mtime: FRESH_GENERATED_MS, kind: 'text', mime: 'text/markdown' },
+            { name: 'index.html', size: 10, mtime: olderMs, kind: 'html', mime: 'text/html' },
+          ],
+        },
+      },
+      designMd: { body: boldDesignMd },
+      conversations: { body: { conversations: [] } },
+    });
+
+    const { result } = renderHook(() => useDesignMdState('p1'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.exists).toBe(true);
+    // Round 7 (mrcfps @ useDesignMdState.ts:160): a regression that
+    // leaks `** ` would null transcriptMessageCount / generatedAt and
+    // flip this to 'unknown-provenance'.
+    expect(result.current.staleReason).toBeNull();
+    expect(result.current.isStale).toBe(false);
+    expect(result.current.transcriptMessageCount).toBe(12);
+    // Backticks intentionally kept on the value (out of scope per
+    // #1580 spec); the `** ` bold prefix must be stripped.
+    expect(result.current.designSystemId).toBe('`alphatrace`');
+  });
+
   it('marks stale with files-newer when a project file mtime exceeds generatedAt', async () => {
     const newerMs = FRESH_GENERATED_MS + 60_000;
     installFetchMock({

--- a/apps/web/tests/lib/parse-provenance.test.ts
+++ b/apps/web/tests/lib/parse-provenance.test.ts
@@ -67,4 +67,73 @@ describe('parseProvenance', () => {
     // Surrounding fields still populated.
     expect(result!.transcriptMessageCount).toBe(42);
   });
+
+  // Issue #1580: the daemon's synthesis prompt does not pin field-label
+  // syntax (finalize-design.ts:560-565), so Claude renders Provenance
+  // fields with Markdown-bold labels per Markdown convention. The
+  // pre-fix regexes' `[:\s]+` separator stops at the trailing `**`
+  // after the colon, leaking `** ` into every captured value and
+  // making transcriptMessageCount + generatedAt parse as null.
+  it('parses bold-labelled fields with backticked values (live DESIGN.md shape)', () => {
+    // Verbatim shape from a finalized DESIGN.md emitted by Claude
+    // against the prod synthesis prompt. UUID + filename are
+    // illustrative placeholders, not user data.
+    const text = `## Provenance
+
+- **Project ID:** \`00000000-0000-0000-0000-000000000000\`
+- **Design system:** \`default\` (Neutral Modern — not applied; wireframe overrides all tokens)
+- **Current artifact:** \`prototype.html\` (single-file, 1,922 lines, 57KB)
+- **Transcript message count:** 4
+- **Generated UTC timestamp:** 2026-05-13T12:27:21.499Z
+`;
+    const result = parseProvenance(text);
+    expect(result).not.toBeNull();
+    // Backticks may remain in the captured value (out of scope to
+    // strip per #1580 spec); the `** ` Markdown-bold prefix must not.
+    expect(result!.projectId).toBe('`00000000-0000-0000-0000-000000000000`');
+    expect(result!.designSystemId).toBe('`default` (Neutral Modern — not applied; wireframe overrides all tokens)');
+    expect(result!.currentArtifact).toBe('`prototype.html` (single-file, 1,922 lines, 57KB)');
+    expect(result!.transcriptMessageCount).toBe(4);
+    expect(result!.generatedAt).not.toBeNull();
+    expect(result!.generatedAt!.toISOString()).toBe('2026-05-13T12:27:21.499Z');
+  });
+
+  it('parses bold-labelled fields with plain values and a short "Generated:" label', () => {
+    const text = `## Provenance
+
+- **Project ID:** abc-123
+- **Design system:** my-system
+- **Current artifact:** deck.html
+- **Transcript message count:** 12
+- **Generated:** 2026-05-08T11:55:00Z
+`;
+    const result = parseProvenance(text);
+    expect(result).not.toBeNull();
+    expect(result!.projectId).toBe('abc-123');
+    expect(result!.designSystemId).toBe('my-system');
+    expect(result!.currentArtifact).toBe('deck.html');
+    expect(result!.transcriptMessageCount).toBe(12);
+    expect(result!.generatedAt).not.toBeNull();
+    expect(result!.generatedAt!.toISOString()).toBe('2026-05-08T11:55:00.000Z');
+  });
+
+  it('still treats "none" as the null sentinel after the bold-label prefix is stripped', () => {
+    const text = `## Provenance
+
+- **Project ID:** abc-123
+- **Design system:** none
+- **Current artifact:** none
+- **Transcript message count:** 7
+- **Generated UTC timestamp:** 2026-05-08T00:00:00Z
+`;
+    const result = parseProvenance(text);
+    expect(result).not.toBeNull();
+    expect(result!.projectId).toBe('abc-123');
+    // NONE_SENTINEL must trip on the value after emphasis is stripped,
+    // otherwise "** none" leaks through as a real design-system id.
+    expect(result!.designSystemId).toBeNull();
+    expect(result!.currentArtifact).toBeNull();
+    expect(result!.transcriptMessageCount).toBe(7);
+    expect(result!.generatedAt).not.toBeNull();
+  });
 });

--- a/apps/web/tests/lib/parse-provenance.test.ts
+++ b/apps/web/tests/lib/parse-provenance.test.ts
@@ -117,6 +117,72 @@ describe('parseProvenance', () => {
     expect(result!.generatedAt!.toISOString()).toBe('2026-05-08T11:55:00.000Z');
   });
 
+  // PR #1584 review (lefarcen): the round-1 strip used `^[\s*_]+` /
+  // `[\s*_]+$`, which stripped a literal leading/trailing underscore
+  // from values like `_draft.html` (corrupting it to `draft.html`).
+  // Narrow the strip to only consume Markdown residue, never literal
+  // characters in the value itself.
+  it('preserves a literal leading underscore in a plain-label value (e.g. _draft.html)', () => {
+    const text = `## Provenance
+
+- Project ID: abc-123
+- Design system: alphatrace
+- Current artifact: _draft.html
+- Transcript message count: 7
+- Generated UTC timestamp: 2026-05-08T00:00:00Z
+`;
+    const result = parseProvenance(text);
+    expect(result).not.toBeNull();
+    // The whole filename must survive — no leading underscore strip.
+    expect(result!.currentArtifact).toBe('_draft.html');
+  });
+
+  it('preserves a literal trailing underscore in a plain-label id-like value', () => {
+    const text = `## Provenance
+
+- Project ID: build_id_v1_
+- Design system: alphatrace
+- Current artifact: deck.html
+- Transcript message count: 7
+- Generated UTC timestamp: 2026-05-08T00:00:00Z
+`;
+    const result = parseProvenance(text);
+    expect(result).not.toBeNull();
+    expect(result!.projectId).toBe('build_id_v1_');
+  });
+
+  it('preserves a literal leading underscore even when the label is Markdown-bold', () => {
+    const text = `## Provenance
+
+- **Project ID:** abc-123
+- **Design system:** alphatrace
+- **Current artifact:** _draft.html
+- **Transcript message count:** 7
+- **Generated UTC timestamp:** 2026-05-08T00:00:00Z
+`;
+    const result = parseProvenance(text);
+    expect(result).not.toBeNull();
+    // The bold-label residue (`** `) must be stripped, but the literal
+    // leading underscore on the filename must remain.
+    expect(result!.currentArtifact).toBe('_draft.html');
+  });
+
+  it('strips a balanced **value** wrap (residue case, no preceding bold-label residue)', () => {
+    const text = `## Provenance
+
+- Project ID: **wrapped-id**
+- Design system: alphatrace
+- Current artifact: deck.html
+- Transcript message count: 7
+- Generated UTC timestamp: 2026-05-08T00:00:00Z
+`;
+    const result = parseProvenance(text);
+    expect(result).not.toBeNull();
+    // **X** is unambiguously Markdown emphasis residue per the issue
+    // spec; strip the balanced wrap.
+    expect(result!.projectId).toBe('wrapped-id');
+  });
+
   it('still treats "none" as the null sentinel after the bold-label prefix is stripped', () => {
     const text = `## Provenance
 


### PR DESCRIPTION
Fixes #1580

## Why

I /claim'd #1580 on 2026-05-13: the parser at `apps/web/src/lib/parse-provenance.ts:32-36` was emitted in PR #974 (the Continue in CLI work) with regex separator class `[:\s]+`, which is too tight for the Markdown-bold field labels that Claude actually renders. The synthesis prompt at `apps/daemon/src/finalize-design.ts:560-565` enumerates the five Provenance fields without pinning label syntax, so Claude — following Markdown convention — emits `- **Project ID:** ...` etc. The separator `[:\s]+` stops at the first non-`:`/non-whitespace char, so the captured value starts with `** ` and `transcriptMessageCount` / `generatedAt` fail to parse downstream.

Real-world impact (verified by pasting into Notepad): the Continue in CLI clipboard prompt shows `Design system: ** ...`, `Transcript message count when DESIGN.md was generated: unknown`, `DESIGN.md generated at: unknown`. The hook's round-7 `'unknown-provenance'` chip is also tripped on every finalized DESIGN.md.

## What users will see

The Continue in CLI clipboard prompt now contains the correct Provenance values, and the staleness chip behind the button stops misreporting fresh DESIGN.md files as having unknown provenance.

## Surface area

- [x] **None** — internal bug fix to `apps/web/src/lib/parse-provenance.ts`, the synthesis prompt in `apps/daemon/src/finalize-design.ts`, and matching unit tests. No new UI, CLI, API surface, contracts, extension points, deps, or i18n keys.

## Bug fix verification

Encoded as a red spec before the source change.

- Test path: `apps/web/tests/lib/parse-provenance.test.ts` (3 new cases) + `apps/web/tests/hooks/useDesignMdState.test.tsx` (1 new case)
- Red on parent commit (`d4e44f0e`), green on this branch: yes

**Regex trace for `projectId`:**

Pre-fix regex: `/Project\s*ID[:\s]+([^\n]+)/i`. Input line: `- **Project ID:** \`<project-id>\``.

| Step | Pattern token | Consumed | Remainder |
|---|---|---|---|
| 1 | `Project\s*ID` | `Project ID` | `:** \`<project-id>\`` |
| 2 | `[:\s]+` (greedy, char class is `:` + whitespace only) | `:` | `** \`<project-id>\`` |
| 3 | `([^\n]+)` | `** \`<project-id>\`` | (end of line) |

Pre-fix `projectId` capture value: `\`** \`<project-id>\`\``. Post-fix: helper strips leading `[\s*_]+` → `\`<project-id>\``.

For `transcriptMessageCount`, the pre-fix capture group `(\d+)` required digits immediately after `[:\s]+`, so the regex failed to match entirely on `** 4`. Widening to `([^\n]+)` lets the helper strip step run before `Number.parseInt`.

**Before / after `parseProvenance(...)` against a live finalized DESIGN.md:**

Before (pre-fix `main` @ `d4e44f0e`):

\`\`\`json
{
  "projectId":              "** \`<project-id>\`",
  "designSystemId":         "** \`default\` (...)",
  "currentArtifact":        "** \`<artifact>.html\` (...)",
  "transcriptMessageCount": null,
  "generatedAt":            null
}
\`\`\`

After (this branch):

\`\`\`json
{
  "projectId":              "\`<project-id>\`",
  "designSystemId":         "\`default\` (...)",
  "currentArtifact":        "\`<artifact>.html\` (...)",
  "transcriptMessageCount": 4,
  "generatedAt":            "2026-05-13T12:27:21.499Z"
}
\`\`\`

Backticks remain in the captured value — the issue spec explicitly allows it, and the clipboard prompt reads fine with them. The variant `- **Field**: value` (colon **outside** the emphasis) is not in #1580's enumeration and is intentionally not handled.

**Phase 4 disclosure (daemon synthesis prompt):** I included a one-line addendum to the synthesis prompt at `apps/daemon/src/finalize-design.ts:566` telling Claude to render Provenance bullets without emphasis on the labels — defense-in-depth against future model variants. The parser hardening is the load-bearing fix; the prompt change is not required to close #1580. Daemon restart is needed for the prompt change to take effect locally (no `--watch` on the daemon process).

## Validation

- \`pnpm guard\` — passed
- \`pnpm typecheck\` — passed
- \`pnpm --filter @open-design/web test\` — 1158 / 1158 passed (was 1154 pre-PR; +3 parser tests, +1 hook test)
- Empirical: ran \`parseProvenance(...)\` against a live finalized DESIGN.md from a local project — all five fields returned correctly (see before/after above).