### PR TITLE
ci: skip upstream-only workflows on forks

### DIFF
--- a/.github/workflows/contributor-card-bot.yml
+++ b/.github/workflows/contributor-card-bot.yml
@@ -32,11 +32,14 @@ jobs:
   recognize:
     name: Render and post contributor card
     if: |
-      (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true) ||
-      (github.event_name == 'issues' && github.event.action == 'opened') ||
-      (github.event_name == 'discussion' && github.event.action == 'created') ||
-      (github.event_name == 'discussion_comment' && github.event.action == 'created') ||
-      github.event_name == 'workflow_dispatch'
+      github.repository == 'nexu-io/open-design' &&
+      (
+        (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true) ||
+        (github.event_name == 'issues' && github.event.action == 'opened') ||
+        (github.event_name == 'discussion' && github.event.action == 'created') ||
+        (github.event_name == 'discussion_comment' && github.event.action == 'created') ||
+        github.event_name == 'workflow_dispatch'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 8
 

--- a/.github/workflows/discord-resolved.yml
+++ b/.github/workflows/discord-resolved.yml
@@ -40,7 +40,7 @@ jobs:
   notify:
     # state_reason "completed" excludes "not planned" closures.
     # We further require an actual merged-PR linkage in the script below.
-    if: github.event.issue.state_reason == 'completed'
+    if: github.repository == 'nexu-io/open-design' && github.event.issue.state_reason == 'completed'
     runs-on: ubuntu-latest
     steps:
       - name: Find the merged PR that closed this issue

--- a/.github/workflows/landing-page-deploy.yml
+++ b/.github/workflows/landing-page-deploy.yml
@@ -35,6 +35,7 @@ concurrency:
 jobs:
   deploy:
     name: Deploy landing page
+    if: github.repository == 'nexu-io/open-design'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -18,6 +18,7 @@ permissions:
 jobs:
   metrics:
     name: Generate repository metrics SVG
+    if: github.repository == 'nexu-io/open-design'
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub repository metrics

--- a/.github/workflows/refresh-contributors-wall.yml
+++ b/.github/workflows/refresh-contributors-wall.yml
@@ -20,6 +20,7 @@ concurrency:
 jobs:
   refresh:
     name: Refresh contributors wall cache bust
+    if: github.repository == 'nexu-io/open-design'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -45,6 +45,7 @@ env:
 jobs:
   metadata:
     name: Prepare beta metadata
+    if: github.repository == 'nexu-io/open-design'
     runs-on: ubuntu-latest
     env:
       OPEN_DESIGN_BETA_METADATA_URL: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}/beta/latest/metadata.json

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -36,6 +36,7 @@ env:
 jobs:
   metadata:
     name: Prepare release metadata
+    if: github.repository == 'nexu-io/open-design'
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Why

Fork pushes to `main` currently produce a red ❌ on every push because `landing-page-deploy.yml` calls `cloudflare/wrangler-action` with `secrets.CLOUDFLARE_API_TOKEN` / `secrets.CLOUDFLARE_ACCOUNT_ID` that only exist on the upstream repo. Scheduled crons (`refresh-contributors-wall`, `metrics`) and the bot / Discord workflows have the same shape — secrets the fork can't have. I hit this on my own fork; a red ❌ on a forker's first push reads like they broke something.

## What users will see

- **Forkers**: `landing-page-deploy`, `refresh-contributors-wall`, `metrics`, `contributor-card-bot`, `discord-resolved`, `release-beta`, and `release-stable` now show up as **Skipped** (grey, not red) on any fork. `ci.yml`, `landing-page-ci.yml`, and `nix-check.yml` are untouched — no secret dependency, still useful on forks.
- **Upstream (`nexu-io/open-design`)**: no change. Every guard evaluates `true` on the upstream repo.

## Surface area

  - [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or
  `apps/desktop` (including Electron menu bar)
  - [ ] **Keyboard shortcut** — new or changed
  - [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or
   new `OD_*` env var
  - [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
  - [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`,
   or change to the skills protocol
  - [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
  - [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or
   `devDependencies`); workspace-package `package.json` files are out of scope.
  - [ ] **Default behavior change** — changes what existing users experience without opting in (default
  model, default setting, file/SQLite schema, auto-network on startup, auto-install)
  - [x] **None** — internal refactor, docs, tests, or translation update only

  ## Validation

  - YAML-only change to `.github/workflows/*.yml`; no source or build wiring touched.
  - Failure mode reproducible on `heylakatos/open-design`: `npx wrangler pages deploy ... failed with exit code 1`. With this patch the job's `if:` evaluates `false` on the fork, so GitHub Actions skips it at evaluation time before any step runs.