### PR TITLE
fix(ui) : radio button issue

### DIFF
--- a/apps/web/src/components/RoutinesSection.tsx
+++ b/apps/web/src/components/RoutinesSection.tsx
@@ -14,6 +14,10 @@ import { navigate } from '../router';
 
 type ProjectSummary = { id: string; name: string };
 
+type RoutinesSectionProps = {
+  onClose?: () => void;
+};
+
 type ScheduleKind = RoutineSchedule['kind'];
 
 const SCHEDULE_KINDS: { kind: ScheduleKind; label: string }[] = [
@@ -309,7 +313,7 @@ function ScheduleEditor({
   );
 }
 
-function RunHistory({ routineId, refreshKey }: { routineId: string; refreshKey: number }) {
+function RunHistory({ routineId, refreshKey, onClose }: { routineId: string; refreshKey: number; onClose?: () => void }) {
   const [runs, setRuns] = useState<RoutineRun[] | null>(null);
 
   useEffect(() => {
@@ -345,9 +349,10 @@ function RunHistory({ routineId, refreshKey }: { routineId: string; refreshKey: 
           <button
             type="button"
             className="routines-history-link"
-            onClick={() =>
-              navigate({ kind: 'project', projectId: r.projectId, fileName: null })
-            }
+            onClick={() => {
+              navigate({ kind: 'project', projectId: r.projectId, fileName: null });
+              onClose?.();
+            }}
             title="Open the project this run wrote to"
           >
             Open project
@@ -359,7 +364,7 @@ function RunHistory({ routineId, refreshKey }: { routineId: string; refreshKey: 
   );
 }
 
-export function RoutinesSection() {
+export function RoutinesSection({ onClose }: RoutinesSectionProps) {
   const [routines, setRoutines] = useState<Routine[]>([]);
   const [projects, setProjects] = useState<ProjectSummary[]>([]);
   const [loading, setLoading] = useState(true);
@@ -710,7 +715,7 @@ export function RoutinesSection() {
                 </div>
                 {isExpanded ? (
                   <div className="routines-item-history">
-                    <RunHistory routineId={r.id} refreshKey={historyTick} />
+                    <RunHistory routineId={r.id} refreshKey={historyTick} onClose={onClose} />
                   </div>
                 ) : null}
               </li>

--- a/apps/web/src/components/RoutinesSection.tsx
+++ b/apps/web/src/components/RoutinesSection.tsx
@@ -309,7 +309,7 @@ function ScheduleEditor({
   );
 }
 
-function RunHistory({ routineId, refreshKey, onClose }: { routineId: string; refreshKey: number; onClose?: () => void }) {
+function RunHistory({ routineId, refreshKey }: { routineId: string; refreshKey: number }) {
   const [runs, setRuns] = useState<RoutineRun[] | null>(null);
 
   useEffect(() => {
@@ -345,10 +345,9 @@ function RunHistory({ routineId, refreshKey, onClose }: { routineId: string; ref
           <button
             type="button"
             className="routines-history-link"
-            onClick={() => {
-              navigate({ kind: 'project', projectId: r.projectId, fileName: null });
-              onClose?.();
-            }}
+            onClick={() =>
+              navigate({ kind: 'project', projectId: r.projectId, fileName: null })
+            }
             title="Open the project this run wrote to"
           >
             Open project
@@ -360,7 +359,7 @@ function RunHistory({ routineId, refreshKey, onClose }: { routineId: string; ref
   );
 }
 
-export function RoutinesSection({ onClose }: { onClose?: () => void }) {
+export function RoutinesSection() {
   const [routines, setRoutines] = useState<Routine[]>([]);
   const [projects, setProjects] = useState<ProjectSummary[]>([]);
   const [loading, setLoading] = useState(true);
@@ -571,6 +570,7 @@ export function RoutinesSection({ onClose }: { onClose?: () => void }) {
 
           <fieldset className="routines-fieldset">
             <legend>Project</legend>
+
             <label className="routines-radio">
               <input
                 type="radio"
@@ -582,6 +582,7 @@ export function RoutinesSection({ onClose }: { onClose?: () => void }) {
                 <small>A fresh, isolated workspace per fire.</small>
               </span>
             </label>
+
             <label className="routines-radio">
               <input
                 type="radio"
@@ -593,7 +594,8 @@ export function RoutinesSection({ onClose }: { onClose?: () => void }) {
                 <small>Each run lives as a new conversation inside the project.</small>
               </span>
             </label>
-            {form.mode === 'reuse' ? (
+
+            {form.mode === 'reuse' && (
               <select
                 className="routines-project-select"
                 value={form.projectId}
@@ -607,7 +609,7 @@ export function RoutinesSection({ onClose }: { onClose?: () => void }) {
                   </option>
                 ))}
               </select>
-            ) : null}
+            )}
           </fieldset>
 
           <div className="routines-form-actions">
@@ -708,7 +710,7 @@ export function RoutinesSection({ onClose }: { onClose?: () => void }) {
                 </div>
                 {isExpanded ? (
                   <div className="routines-item-history">
-                    <RunHistory routineId={r.id} refreshKey={historyTick} onClose={onClose} />
+                    <RunHistory routineId={r.id} refreshKey={historyTick} />
                   </div>
                 ) : null}
               </li>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -18571,28 +18571,68 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   flex-direction: column;
   gap: 8px;
 }
+
 .routines-fieldset legend {
   font-size: 12px;
   font-weight: 600;
   color: var(--text-muted);
   padding: 0 6px;
 }
-.routines-radio {
-  display: grid;
-  grid-template-columns: 16px minmax(0, 1fr);
-  gap: 8px 10px;
-  padding: 10px 8px;
-  border-radius: var(--radius);
-  cursor: pointer;
-  transition: background 120ms ease;
-  align-items: flex-start;
-}
-.routines-radio:hover { background: var(--bg-subtle); }
-.routines-radio input { margin-top: 3px; }
-.routines-radio span { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
-.routines-radio strong { font-size: 14px; color: var(--text); font-weight: 600; }
-.routines-radio small { font-size: 12px; color: var(--text-muted); }
 
+.routines-radio {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 12px 14px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--bg-panel);
+  cursor: pointer;
+  transition: border-color 120ms ease, background 120ms ease;
+}
+
+.routines-radio:hover,
+.routines-radio:active,
+.routines-radio:focus {
+  background: var(--bg-subtle);
+  border-color: var(--border-strong);
+  outline: none;
+}
+
+.routines-radio input[type="radio"] {
+  display: none !important;
+}
+
+.routines-radio input:focus {
+  outline: none;
+}
+
+.routines-radio:has(input[type="radio"]:checked) {
+  border-color: var(--accent);
+  background: var(--accent-tint);
+}
+
+.routines-radio:has(input[type="radio"]:checked) strong {
+  color: var(--accent-strong);
+}
+
+.routines-radio span {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+}
+
+.routines-radio strong {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.routines-radio small {
+  font-size: 12px;
+  color: var(--text-muted);
+}
 .routines-form-actions {
   display: flex;
   gap: 8px;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -18591,7 +18591,11 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   transition: border-color 120ms ease, background 120ms ease;
 }
 
-.routines-radio:hover,
+.routines-radio:hover {
+  background: var(--bg-subtle);
+  border-color: var(--border-strong);
+}
+
 .routines-radio:has(input:focus-visible) {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
@@ -18607,11 +18611,6 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;
-}
-
-.routines-radio input:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
 }
 
 .routines-radio:has(input[type="radio"]:checked) {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -18592,19 +18592,26 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
 }
 
 .routines-radio:hover,
-.routines-radio:active,
-.routines-radio:focus {
-  background: var(--bg-subtle);
-  border-color: var(--border-strong);
-  outline: none;
+.routines-radio:has(input:focus-visible) {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .routines-radio input[type="radio"] {
-  display: none !important;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
-.routines-radio input:focus {
-  outline: none;
+.routines-radio input:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .routines-radio:has(input[type="radio"]:checked) {


### PR DESCRIPTION
Fixes #1430

## Why

While working on the routines scheduling UI, I wanted to simplify the project-selection area so it reads as a clear card-based choice instead of a small native radio control sitting beside the text. The previous markup/styling made the choice feel visually noisy and harder to scan.

This PR keeps the selection accessible while intentionally updating the presentation to a cleaner card-style interaction.

## What users will see

The routines project choice UI now appears as selectable cards.

Users will see:
- a cleaner card-style choice for "Create a new project each run" and "Reuse an existing project"
- the selected card highlighted more clearly
- the native radio input kept in the DOM for keyboard and screen-reader support
- the same overall routines scheduling behavior

This is an intentional UI polish, not a functional behavior change.

## Surface area

- [x] **UI** — routines project selection cards in the settings modal
- [x] **Default behavior change** — visual presentation of the choice control
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **None**

## Screenshots

Updated routines settings modal showing the card-style project selection UI.

<img width="1919" height="1048" alt="Routines settings modal" src="https://github.com/user-attachments/assets/f6782ee2-6459-4c92-9426-5996d8de1e5c" />

## Bug fix verification

- Confirmed the routines project choice still works with keyboard navigation
- Confirmed the native radio remains accessible but visually hidden
- Verified the selected card state updates correctly
- Checked the updated UI locally in the routines modal

## Validation

- `pnpm --filter @open-design/web typecheck`
- Manual check of the routines modal in the local environment
- Confirmed no layout or interaction regressions in the settings dialog