### PR TITLE
fix(web): use background-color instead of background shorthand

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -893,7 +893,7 @@ code {
   padding: 4px 6px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border);
-  background: var(--bg-panel);
+  background-color: var(--bg-panel);
   color: var(--text);
   cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- Fix `.avatar-select` chevron background image being horizontally repeated due to `background-repeat` being reset to default `repeat` by the `background` shorthand property

## Test plan
- [ ] Open avatar menu dropdown
- [ ] Verify select elements show single chevron icon (not repeated)