### PR TITLE
fix(web): center avatar-item icons using flexbox instead of text-align

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -850,7 +850,11 @@ code {
 }
 .avatar-item:hover { background: var(--bg-subtle); }
 .avatar-item .avatar-item-icon {
-  width: 18px; text-align: center; color: var(--text-muted); flex-shrink: 0;
+  display: flex;
+  justify-content: center;
+  width: 18px;
+  color: var(--text-muted);
+  flex-shrink: 0;
 }
 .avatar-item .avatar-item-meta {
   margin-left: auto;


### PR DESCRIPTION
Fixes #

## Why

The avatar dropdown menu items (rescan, settings, back to projects) had icons that were not visually centered. The span.avatar-item-icon used `text-align: center` but this has no effect on inline SVG children (SVG elements are replaced elements and don't participate in text alignment).

## What users will see

Avatar dropdown menu icons for rescan, settings, and back-to-projects actions are now properly centered in their 18px container.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Before/after comparison of avatar dropdown menu items showing icon centering difference.

## Bug fix verification

- Test path that reproduces the bug: Manual inspection of avatar dropdown icons
- Did the test go red on `main` and green on this branch? (yes / no): N/A - visual inspection

## Validation

`pnpm guard` + `pnpm --filter @open-design/web typecheck`