### PR TITLE
fix(web): confirm Continue in CLI copy

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -106,6 +106,7 @@ import { useDesignMdState } from '../hooks/useDesignMdState';
 import { useFinalizeProject } from '../hooks/useFinalizeProject';
 import { useProjectDetail } from '../hooks/useProjectDetail';
 import { useTerminalLaunch } from '../hooks/useTerminalLaunch';
+import { buildContinueInCliToast } from '../lib/build-continue-in-cli-toast';
 import { buildClipboardPrompt } from '../lib/build-clipboard-prompt';
 import { copyToClipboard } from '../lib/copy-to-clipboard';
 import { effectiveMaxTokens } from '../state/maxTokens';
@@ -2339,22 +2340,7 @@ export function ProjectView({
       return;
     }
     const launched = await terminalLauncher.open(project.id);
-    if (launched.kind === 'electron' && launched.ok) {
-      setProjectActionsToast({
-        message: 'Folder opened. Run `claude` in your terminal here and paste the prompt.',
-        details: null,
-      });
-    } else if (launched.kind === 'electron' && !launched.ok) {
-      setProjectActionsToast({
-        message: `Couldn't open the folder. Open your terminal at ${projectDir}, run \`claude\`, and paste the prompt.`,
-        details: null,
-      });
-    } else {
-      setProjectActionsToast({
-        message: `Open your terminal at ${projectDir}, run \`claude\`, and paste the prompt.`,
-        details: null,
-      });
-    }
+    setProjectActionsToast(buildContinueInCliToast(projectDir, launched));
   }, [
     project.id,
     project.name,

--- a/apps/web/src/lib/build-continue-in-cli-toast.ts
+++ b/apps/web/src/lib/build-continue-in-cli-toast.ts
@@ -1,0 +1,32 @@
+import type { TerminalLaunchResult } from '../hooks/useTerminalLaunch';
+
+export interface ContinueInCliToast {
+  message: string;
+  details: null;
+}
+
+const CLIPBOARD_PREFIX = 'Copied to clipboard. ';
+
+export function buildContinueInCliToast(
+  projectDir: string,
+  launched: TerminalLaunchResult,
+): ContinueInCliToast {
+  if (launched.kind === 'electron' && launched.ok) {
+    return {
+      message: `${CLIPBOARD_PREFIX}Folder opened. Run \`claude\` in your terminal here and paste the prompt.`,
+      details: null,
+    };
+  }
+
+  if (launched.kind === 'electron' && !launched.ok) {
+    return {
+      message: `${CLIPBOARD_PREFIX}Couldn't open the folder. Open your terminal at ${projectDir}, run \`claude\`, and paste the prompt.`,
+      details: null,
+    };
+  }
+
+  return {
+    message: `${CLIPBOARD_PREFIX}Open your terminal at ${projectDir}, run \`claude\`, and paste the prompt.`,
+    details: null,
+  };
+}

--- a/apps/web/tests/lib/build-continue-in-cli-toast.test.ts
+++ b/apps/web/tests/lib/build-continue-in-cli-toast.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildContinueInCliToast } from '../../src/lib/build-continue-in-cli-toast';
+
+describe('buildContinueInCliToast', () => {
+  it('prefixes every success path with clipboard confirmation', () => {
+    expect(
+      buildContinueInCliToast('/work/acme', { kind: 'electron', ok: true }),
+    ).toEqual({
+      message:
+        'Copied to clipboard. Folder opened. Run `claude` in your terminal here and paste the prompt.',
+      details: null,
+    });
+
+    expect(
+      buildContinueInCliToast('/work/acme', { kind: 'electron', ok: false }),
+    ).toEqual({
+      message:
+        "Copied to clipboard. Couldn't open the folder. Open your terminal at /work/acme, run `claude`, and paste the prompt.",
+      details: null,
+    });
+
+    expect(
+      buildContinueInCliToast('/work/acme', { kind: 'web-fallback', ok: true }),
+    ).toEqual({
+      message:
+        'Copied to clipboard. Open your terminal at /work/acme, run `claude`, and paste the prompt.',
+      details: null,
+    });
+  });
+});


### PR DESCRIPTION
Closes #1582\n\n## Summary\n- Prefix the Continue in CLI success toasts with explicit clipboard confirmation.\n- Add a small unit test covering the electron success, electron failure, and web fallback messages.\n\n## Checks\n- vitest run -c vitest.config.ts tests/lib/build-continue-in-cli-toast.test.ts\n- Web typecheck attempted, but the repo has pre-existing unrelated TS errors.