### PR TITLE
fix(desktop): route WSL folder opening through explorer.exe

### DIFF
--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -6,10 +6,10 @@ import { release } from "node:os";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
-const execFileAsync = promisify(execFile);
-
 import { BrowserWindow, dialog, ipcMain, shell } from "electron";
 import type { DesktopExportPdfInput, DesktopExportPdfResult } from "@open-design/sidecar-proto";
+
+const execFileAsync = promisify(execFile);
 
 import { exportPdfFromHtml, waitForPrintReadyHandshake } from "./pdf-export.js";
 

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -3,10 +3,10 @@ import { mkdir, writeFile, realpath, stat } from "node:fs/promises";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { release } from "node:os";
-import { exec } from "node:child_process";
+import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 import { BrowserWindow, dialog, ipcMain, shell } from "electron";
 import type { DesktopExportPdfInput, DesktopExportPdfResult } from "@open-design/sidecar-proto";
@@ -841,10 +841,11 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
       
       if (isWSL) {
         // On WSL, use explorer.exe with wslpath to convert POSIX path to Windows path
+        // Use execFile with argument arrays to avoid shell injection
         try {
-          const { stdout } = await execAsync(`wslpath -w "${validated.resolved}"`);
+          const { stdout } = await execFileAsync("wslpath", ["-w", validated.resolved]);
           const windowsPath = stdout.trim();
-          await execAsync(`explorer.exe "${windowsPath}"`);
+          await execFileAsync("explorer.exe", [windowsPath]);
           return ""; // Success - empty string indicates no error
         } catch (wslErr) {
           // Fall back to shell.openPath if wslpath/explorer.exe fails

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -2,6 +2,11 @@ import { createHmac, randomBytes } from "node:crypto";
 import { mkdir, writeFile, realpath, stat } from "node:fs/promises";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { release } from "node:os";
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+
+const execAsync = promisify(exec);
 
 import { BrowserWindow, dialog, ipcMain, shell } from "electron";
 import type { DesktopExportPdfInput, DesktopExportPdfResult } from "@open-design/sidecar-proto";
@@ -831,6 +836,23 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
     const validated = await validateExistingDirectory(resolved.context.resolvedDir);
     if (!validated.ok) return `open-path: ${validated.reason}`;
     try {
+      // WSL detection: check if running on WSL (kernel release contains 'microsoft')
+      const isWSL = release().toLowerCase().includes('microsoft');
+      
+      if (isWSL) {
+        // On WSL, use explorer.exe with wslpath to convert POSIX path to Windows path
+        try {
+          const { stdout } = await execAsync(`wslpath -w "${validated.resolved}"`);
+          const windowsPath = stdout.trim();
+          await execAsync(`explorer.exe "${windowsPath}"`);
+          return ""; // Success - empty string indicates no error
+        } catch (wslErr) {
+          // Fall back to shell.openPath if wslpath/explorer.exe fails
+          return await shell.openPath(validated.resolved);
+        }
+      }
+      
+      // Non-WSL: use standard Electron shell.openPath
       return await shell.openPath(validated.resolved);
     } catch (err) {
       return err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Why

On WSL Electron, clicking "Continue in CLI" opens Chrome at a `file://` directory listing instead of a file manager. This happens because Electron's `shell.openPath` delegates to `xdg-open`, which on WSL typically routes directories through the default browser (Chrome) rather than a native file manager.

Fixes #1581

## What

- Added WSL detection via `os.release().toLowerCase().includes('microsoft')`
- On WSL: convert POSIX path to Windows path using `wslpath -w`, then call `explorer.exe`
- Falls back to `shell.openPath` if `wslpath` or `explorer.exe` fails
- Non-WSL behavior unchanged (macOS, Windows native, Linux native)

## What users will see

**Before (WSL)**: Clicking "Continue in CLI" opens Chrome with a file:// directory listing

**After (WSL)**: Clicking "Continue in CLI" opens Windows File Explorer at the project directory

**Other platforms**: No change — macOS Finder, Windows Explorer, and Linux file managers work as before

## Surface area

- [x] Desktop (Electron IPC handler in `apps/desktop/src/main/runtime.ts`)
- [x] WSL-specific behavior (new code path)

## Testing

- [x] Added WSL detection logic
- [x] Added wslpath conversion and explorer.exe invocation
- [x] Added fallback to shell.openPath if WSL-specific path fails
- [x] Preserved existing path validation (validateExistingDirectory, isOpenPathAllowedForProject)
- [ ] Manual test on WSL: click "Continue in CLI", verify Windows Explorer opens
- [ ] Manual test on macOS/Windows/Linux: verify no regression

## Implementation notes

- WSL detection uses `os.release()` containing 'microsoft' (standard WSL kernel marker)
- `wslpath -w` converts `/home/user/...` to `\\wsl$\Ubuntu\home\user\...` or `C:\Users\...` depending on mount
- `explorer.exe` is available on all WSL installations (Windows host binary)
- Fallback ensures graceful degradation if WSL environment is non-standard
