### PR TITLE
fix(web): route remaining crypto.randomUUID calls through utils/uuid (#1620)

### DIFF
--- a/apps/web/src/analytics/provider.tsx
+++ b/apps/web/src/analytics/provider.tsx
@@ -30,6 +30,7 @@ import {
   getAnonymousId,
   getSessionId,
 } from './identity';
+import { randomUUID } from '../utils/uuid';
 
 interface AnalyticsContextValue {
   // The track helper accepts any event/props pair; per-event safety is
@@ -202,7 +203,7 @@ export function AnalyticsProvider({ children }: { children: ReactNode }) {
 
   const track = useCallback<AnalyticsContextValue['track']>(
     (event, properties, options) => {
-      const insertId = options?.insertId ?? crypto.randomUUID();
+      const insertId = options?.insertId ?? randomUUID();
       const requestId = options?.requestId ?? null;
       // Attach request_id to the in-flight fetch wrapper too, so the daemon
       // can stitch click→result pairs without the caller threading it.
@@ -283,7 +284,7 @@ export function AnalyticsProvider({ children }: { children: ReactNode }) {
       },
       anonymousId: identity.anonymousId,
       sessionId: identity.sessionId,
-      newRequestId: () => crypto.randomUUID(),
+      newRequestId: () => randomUUID(),
     }),
     [track, identity, locale, appVersion],
   );
@@ -303,7 +304,7 @@ export function useAnalytics(): AnalyticsContextValue {
       setIdentity: () => undefined,
       anonymousId: 'unmounted',
       sessionId: 'unmounted',
-      newRequestId: () => crypto.randomUUID(),
+      newRequestId: () => randomUUID(),
     };
   }
   return value;

--- a/apps/web/src/runtime/exports.ts
+++ b/apps/web/src/runtime/exports.ts
@@ -15,6 +15,7 @@
 import { buildSrcdoc, type SrcdocOptions } from './srcdoc';
 import { buildReactComponentSrcdoc } from './react-component';
 import { buildZip } from './zip';
+import { randomUUID } from '../utils/uuid';
 
 const DESIGN_HANDOFF_FILENAME = 'DESIGN-HANDOFF.md';
 const DESIGN_MANIFEST_FILENAME = 'DESIGN-MANIFEST.json';
@@ -524,7 +525,7 @@ export async function exportAsPdf(
   const sandboxedPreview = opts?.sandboxedPreview ?? true;
   // Generate a per-export nonce so the print-ready handshake is resistant to
   // spoofing by untrusted scripts inside the exported artifact.
-  const nonce = crypto.randomUUID();
+  const nonce = randomUUID();
   let doc = buildSrcdoc(html, opts);
   if (opts?.deck) doc = injectDeckPrintStylesheet(doc);
   doc = injectPrintReadyHandshake(doc, nonce);


### PR DESCRIPTION
Fixes #1620

## Why

I hit this on my own self-hosted deployment (`http://192.168.1.48:7456`, the
Docker → TrueNAS path). After pulling main I get a blank page and the console
shows `TypeError: crypto.randomUUID is not a function` from inside
`<AnalyticsProvider>`. PR #900 added `apps/web/src/utils/uuid.ts` precisely
to dodge this — `crypto.randomUUID` is restricted to secure contexts
(HTTPS or `localhost`), and plain-HTTP LAN IPs are the standard Docker /
NAS / unRAID self-hosted setup. The helper degrades to
`crypto.getRandomValues` and ultimately `Math.random` so callers always
get a usable v4 UUID.

PR #1428 (PostHog product analytics) added three unguarded
`crypto.randomUUID()` calls in `apps/web/src/analytics/provider.tsx` that
bypass the helper, and `apps/web/src/runtime/exports.ts` had a fourth
from older PDF-export work. On a non-secure context those calls throw
during `<AnalyticsProvider>` rendering and take the whole app shell down
before any UI mounts. PDF export from the Share menu also fails on the
same origins.

#1620 has the full reproduction and call-site list.

## What users will see

- Self-hosted plain-HTTP / LAN-IP deployments (Docker, NAS, unRAID, etc.)
  load the app again. The blank-page regression introduced by #1428 is
  gone.
- PDF export from the Share menu works again on those same deployments.
- No visible behavior change on `localhost` or HTTPS — those origins
  were always taking the `crypto.randomUUID()` branch of the helper
  anyway, so the output is identical.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — self-hosted plain-HTTP / LAN-IP deployments stop crashing on load; no visible change for users on `localhost` / HTTPS.
- [ ] **None**

## Bug fix verification

This is mechanical: replace four `crypto.randomUUID()` callers with the
existing tiered helper from `apps/web/src/utils/uuid.ts`. A red spec
would have to fake a non-secure-context environment in JSDOM (delete
`globalThis.crypto.randomUUID` for the duration of an
`<AnalyticsProvider>` render) — happy to add one if reviewers want it,
but the helper itself is already covered by the original #900 work.

- Test path that reproduces the bug: n/a (covered manually against the
  affected deployment; see verification below).
- Did the test go red on `main` and green on this branch? n/a
- Manual verification: rebuilt the Docker image, redeployed, the app
  shell now mounts on `http://<lan-ip>:7456` instead of throwing on
  load.

## Validation

- `pnpm guard` — pass
- `pnpm --filter @open-design/web typecheck` — pass
- `pnpm --filter @open-design/web test analytics` — pass (14/14)
- Manual smoke against `http://192.168.1.48:7456` — app mounts, no
  console crypto error, PDF export works.

Pre-existing test failures on `origin/main` in
`AssistantMessage.test.tsx`, `DesignsTab.select-mode.test.tsx`,
`SettingsDialog.execution.test.tsx`, and
`Theater/hooks/useCritiqueTheaterEnabled.test.tsx` reproduce on `main`
before this branch and are unrelated to this change.