### PR TITLE
fix: Localize Accent color label in Settings

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -4789,8 +4789,8 @@ function AppearanceSection({
         ))}
       </div>
       <div className="field">
-        <span className="field-label">Accent color</span>
-        <div className="pet-swatches" role="radiogroup" aria-label="Accent color">
+        <span className="field-label">{t('pet.fieldAccent')}</span>
+        <div className="pet-swatches" role="radiogroup" aria-label={t('pet.fieldAccent')}>
           {ACCENT_SWATCHES.map((color) => {
             const active = currentAccent === color;
             return (


### PR DESCRIPTION
Fixes #1560

## Problem

When the app language was set to **Chinese** (or any non-English language), the `Accent color` label in Settings → Appearance remained in **English**, creating a **mixed-language experience** in a core settings surface.

### Hardcoded English Strings
- `Accent color` (field label)
- `Accent color` (aria-label)

### Current Behavior
- ❌ Accent color label: English only
- ❌ Mixed-language settings UI
- ❌ Inconsistent with rest of the app

### Expected Behavior
- ✅ Accent color label: Fully localized
- ✅ Consistent language experience
- ✅ All text in the selected language

## Root Cause

The `SettingsDialog.tsx` component contained **hardcoded English strings** instead of using the i18n translation system, even though the translation key `pet.fieldAccent` already existed in all 18 supported languages.

## Solution

### Updated SettingsDialog Component

**Before:**
```tsx
<span className="field-label">Accent color</span>
<div className="pet-swatches" role="radiogroup" aria-label="Accent color">
```

**After:**
```tsx
<span className="field-label">{t('pet.fieldAccent')}</span>
<div className="pet-swatches" role="radiogroup" aria-label={t('pet.fieldAccent')}>
```

## Testing

- [x] Verified `pet.fieldAccent` exists in all 18 locale files
- [x] Chinese translation: "主题色"
- [x] Applied to both visible label and aria-label for accessibility

## Impact

- **Surface area:** Settings → Appearance
- **Languages affected:** All 18 supported languages
- **Files changed:** 1 (SettingsDialog.tsx)