### PR TITLE
fix: Add clipboard confirmation to Continue in CLI toast

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -2345,17 +2345,17 @@ export function ProjectView({
     const launched = await terminalLauncher.open(project.id);
     if (launched.kind === 'electron' && launched.ok) {
       setProjectActionsToast({
-        message: 'Folder opened. Run `claude` in your terminal here and paste the prompt.',
+        message: 'Prompt copied. Folder opened. Run `claude` in your terminal here and paste.',
         details: null,
       });
     } else if (launched.kind === 'electron' && !launched.ok) {
       setProjectActionsToast({
-        message: `Couldn't open the folder. Open your terminal at ${projectDir}, run \`claude\`, and paste the prompt.`,
+        message: `Prompt copied. Couldn't open the folder. Open your terminal at ${projectDir}, run \`claude\`, and paste.`,
         details: null,
       });
     } else {
       setProjectActionsToast({
-        message: `Open your terminal at ${projectDir}, run \`claude\`, and paste the prompt.`,
+        message: `Prompt copied. Open your terminal at ${projectDir}, run \`claude\`, and paste.`,
         details: null,
       });
     }


### PR DESCRIPTION
Fixes #1582

## Problem

When clicking **Continue in CLI**, the toast messages said "paste the prompt" but never confirmed that the clipboard was actually populated. In browser mode (no visual folder-open feedback), users had no way to know `Ctrl+V` would yield the prepared prompt.

### Current Behavior
- ❌ Toast says "paste the prompt" but doesn't confirm clipboard write
- ❌ No visual signal that clipboard was populated
- ❌ Users unsure if `Ctrl+V` will work

### Expected Behavior
- ✅ Toast explicitly confirms "Prompt copied"
- ✅ Clear feedback that clipboard is ready
- ✅ Users confident to paste

## Root Cause

All three success-path toast messages at `ProjectView.tsx:2348,2353,2358` omitted clipboard confirmation, even though `copyToClipboard(prompt)` succeeded at line 2331.

The failure path (line 2339) correctly shows the prompt body when clipboard write fails, but the success paths were silent about the clipboard state.

## Solution

### Updated Toast Messages

**Before:**
```tsx
// Electron success
'Folder opened. Run `claude` in your terminal here and paste the prompt.'

// Electron failure  
"Couldn't open the folder. Open your terminal at ${projectDir}, run `claude`, and paste the prompt."

// Web fallback
"Open your terminal at ${projectDir}, run `claude`, and paste the prompt."
```

**After:**
```tsx
// Electron success
'Prompt copied. Folder opened. Run `claude` in your terminal here and paste.'

// Electron failure
"Prompt copied. Couldn't open the folder. Open your terminal at ${projectDir}, run `claude`, and paste."

// Web fallback  
"Prompt copied. Open your terminal at ${projectDir}, run `claude`, and paste."
```

## Changes

1. **Added "Prompt copied." prefix** to all three success-path messages
2. **Shortened "paste the prompt"** to "paste" for brevity (the context is clear)
3. **Preserved failure path** (line 2339) which already handles clipboard unavailable correctly

## Testing

- [x] Verified all three toast branches are updated
- [x] Clipboard confirmation now explicit in success paths
- [x] Failure path unchanged (already correct)

## Impact

- **Surface area:** Continue in CLI feature
- **User experience:** Clear feedback that clipboard is ready
- **Files changed:** 1 (ProjectView.tsx)