### PR TITLE
fix: Fix Open project button text visibility on hover

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -18683,7 +18683,7 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   gap: 4px;
   font-weight: 500;
 }
-.routines-history-link:hover { background: var(--text); color: var(--bg); border-color: var(--text); }
+.routines-history-link:hover { background: var(--text); color: var(--bg-canvas); border-color: var(--text); }
 
 .routines-status {
   display: inline-block;


### PR DESCRIPTION
Fixes #1357

## Problem

In the **Routines** settings page, the **Open project** button text in history rows became **invisible on hover**, making the button appear broken.

### Current Behavior
- ❌ Hover state: text disappears
- ❌ Button looks disabled or broken
- ❌ Poor usability and affordance

### Expected Behavior
- ✅ Text remains clearly readable on hover
- ✅ Proper contrast in all states
- ✅ Clear visual feedback

## Root Cause

The CSS hover rule at `index.css:18686` set the text color to `var(--bg)`, which is the same as or very similar to the button's background color, causing the text to disappear:

```css
.routines-history-link:hover { 
  background: var(--text); 
  color: var(--bg);  /* ❌ Text becomes invisible */
  border-color: var(--text); 
}
```

The intent was to invert colors on hover (dark background, light text), but `var(--bg)` doesn't provide sufficient contrast against the inverted background.

## Solution

### Updated CSS

**Before:**
```css
.routines-history-link:hover { 
  background: var(--text); 
  color: var(--bg); 
  border-color: var(--text); 
}
```

**After:**
```css
.routines-history-link:hover { 
  background: var(--text); 
  color: var(--bg-canvas);  /* ✅ Proper contrast */
  border-color: var(--text); 
}
```

### Why `var(--bg-canvas)`?

- `var(--bg)` is the local background color (often the same as the button's container)
- `var(--bg-canvas)` is the canvas/page background color, guaranteed to contrast with `var(--text)`
- This ensures the inverted hover state has proper contrast in both light and dark themes

## Testing

- [x] Verified hover state now shows visible text
- [x] Works in both light and dark themes
- [x] Maintains proper contrast ratios

## Impact

- **Surface area:** Routines → History rows → Open project button
- **User experience:** Button now clearly readable on hover
- **Files changed:** 1 (index.css)