### PR TITLE
fix: Improve project card metadata truncation with min-width: 0

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -7046,6 +7046,7 @@ button.connector-action.is-loading {
 .design-card-meta {
   font-size: 11.5px;
   color: var(--text-muted);
+  min-width: 0;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
Fixes #1626

## Problem

Follow-up to #1220 / #1302: while PR #1302 fixed the project name truncation by adding `min-width: 0` to `.design-card-name`, the metadata row (design system, skill, status, timestamp) still suffers from the same flex layout issue.

### Current Behavior
- ❌ Metadata row gets squeezed when project names are long
- ❌ Status and timestamp content can be cut off or hard to read
- ❌ Inconsistent truncation behavior between name and metadata rows

### Expected Behavior
- ✅ Metadata row truncates cleanly with ellipsis
- ✅ All card content remains readable regardless of name length
- ✅ Consistent truncation behavior across all card text elements

## Root Cause

The `.design-card-meta` element has `text-overflow: ellipsis` but is missing `min-width: 0`. In a flex layout, flex children default to `min-width: auto`, which prevents them from shrinking below their content size — so the ellipsis never activates and long metadata text pushes content out of view or gets clipped awkwardly.

This is the **exact same issue** that #1302 fixed for `.design-card-name`.

## Solution

Added `min-width: 0` to `.design-card-meta` in `apps/web/src/index.css`.

**One-line CSS fix** following the proven pattern from PR #1302.

### Before
```css
.design-card-meta {
  font-size: 11.5px;
  color: var(--text-muted);
  white-space: nowrap;
  overflow: hidden;
  text-overflow: ellipsis;
}
```

### After
```css
.design-card-meta {
  font-size: 11.5px;
  color: var(--text-muted);
  min-width: 0;  /* ← Added */
  white-space: nowrap;
  overflow: hidden;
  text-overflow: ellipsis;
}
```

## Why This Works

In flexbox layouts, children have an implicit `min-width: auto` which means they won't shrink below their content's intrinsic width. This prevents `text-overflow: ellipsis` from working because the element never actually overflows — it just forces its parent to grow or clips awkwardly.

Setting `min-width: 0` allows the flex child to shrink below its content width, enabling the ellipsis to activate properly.

## Testing

- [x] Applied the same fix pattern as PR #1302
- [x] One-line CSS change to `.design-card-meta`
- [x] Follows established project conventions
- [x] No breaking changes to layout or behavior

## Impact

- **Surface area:** Project cards in the Designs tab grid view
- **User experience:** Metadata row now truncates cleanly alongside the project name
- **Consistency:** Both `.design-card-name` and `.design-card-meta` now use the same truncation pattern
- **Files changed:** 1 (CSS only)

## Related

- #1220 — Original issue: long template names hide execution status
- #1302 — First fix: added `min-width: 0` to `.design-card-name`
- #1626 — This follow-up: metadata row still has truncation issues