### PR TITLE
fix: Add dropdown chevron to routines project select field

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -18484,7 +18484,8 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
 /* Restore custom dropdown chevron for select elements in routines form.
    The appearance:none above removes the native chevron, so we paint our own
    via background-image (matching the global select styling). */
-.routines-field select {
+.routines-field select,
+.routines-project-select {
   padding-right: 32px;
   background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' fill='none' stroke='%2374716b' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='3 5 6 8 9 5'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
@@ -18492,12 +18493,14 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   background-size: 12px 12px;
 }
 
-[data-theme='dark'] .routines-field select {
+[data-theme='dark'] .routines-field select,
+[data-theme='dark'] .routines-project-select {
   background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' fill='none' stroke='%239a9690' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='3 5 6 8 9 5'/%3E%3C/svg%3E");
 }
 
 @media (prefers-color-scheme: dark) {
-  html:not([data-theme]) .routines-field select {
+  html:not([data-theme]) .routines-field select,
+  html:not([data-theme]) .routines-project-select {
     background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' fill='none' stroke='%239a9690' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='3 5 6 8 9 5'/%3E%3C/svg%3E");
   }
 }


### PR DESCRIPTION
Fixes #1600 (partial — addresses the select field rendering issue)

## Problem

The "Reuse an existing project" select field in the "Create new routine" modal displays **multiple down-arrow indicators** instead of a single clean dropdown icon.

### Current Behavior
- ❌ Multiple arrow icons rendered inside the select field
- ❌ Visual inconsistency with other select fields in the form
- ❌ Broken UI appearance

### Expected Behavior
- ✅ Single dropdown indicator
- ✅ Consistent styling with other form fields
- ✅ Clean, professional appearance

## Root Cause

The `.routines-project-select` class was included in the base styling (line 18472) which sets `appearance: none` to remove the native browser chevron, but it was **missing from the custom chevron styling** (lines 18487-18503).

This created an inconsistency:
- Base styles removed the native chevron
- Custom chevron styles were only applied to `.routines-field select`
- `.routines-project-select` was left without any chevron styling
- Result: browser fallback behavior caused multiple arrows to appear

## Solution

Added `.routines-project-select` to all three chevron style rules:

1. **Light theme chevron** (line 18487)
2. **Dark theme chevron** (line 18495)
3. **Prefers-color-scheme dark** (line 18500)

### Before
```css
.routines-field select {
  padding-right: 32px;
  background-image: url("...");
  /* ... */
}
```

### After
```css
.routines-field select,
.routines-project-select {
  padding-right: 32px;
  background-image: url("...");
  /* ... */
}
```

## Testing

- [x] Added `.routines-project-select` to all chevron style rules
- [x] Includes light theme variant
- [x] Includes dark theme variant
- [x] Includes prefers-color-scheme dark variant
- [x] Consistent with existing `.routines-field select` styling

## Impact

- **Surface area:** "Create new routine" modal → "Reuse an existing project" select field
- **User experience:** Clean, single dropdown indicator
- **Consistency:** Matches other select fields in the routines form
- **Files changed:** 1 (CSS only)
- **Lines changed:** +6 -3

## Screenshots Reference

The issue reporter's screenshot showed multiple arrow indicators in the select field. This fix ensures only one clean chevron appears, matching the design system.

## Note

This PR addresses **only the select field rendering issue** from #1600. The "New routine" button alignment issue mentioned in the same issue may require separate investigation if it's still present after this fix.