### PR TITLE
fix: Implement file grouping by type in design files panel

### DIFF
--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -47,6 +47,35 @@ const MODIFIED_SECTION_LABEL_KEY: Record<ModifiedSection, keyof Dict> = {
   older: 'designFiles.modifiedOlder',
 };
 
+const KIND_ORDER: ProjectFileKind[] = [
+  'html',
+  'text',
+  'code',
+  'sketch',
+  'image',
+  'document',
+  'pdf',
+  'presentation',
+  'spreadsheet',
+  'video',
+  'audio',
+  'binary',
+];
+const KIND_LABEL_KEY: Record<ProjectFileKind, keyof Dict> = {
+  html: 'designFiles.kindHtml',
+  image: 'designFiles.kindImage',
+  video: 'designFiles.kindVideo',
+  audio: 'designFiles.kindAudio',
+  sketch: 'designFiles.kindSketch',
+  text: 'designFiles.kindText',
+  code: 'designFiles.kindCode',
+  pdf: 'designFiles.kindPdf',
+  document: 'designFiles.kindDocument',
+  presentation: 'designFiles.kindPresentation',
+  spreadsheet: 'designFiles.kindSpreadsheet',
+  binary: 'designFiles.kindBinary',
+};
+
 /**
  * Full-panel browser for a project's `.od/projects/<id>/` folder. Mirrors
  * Claude Design's "Design Files" surface: grouped sections, hover-revealed
@@ -87,6 +116,9 @@ export function DesignFilesPanel({
   const [groupMode, setGroupMode] = useState<DesignFilesGroupMode>('kind');
   const [collapsedModifiedSections, setCollapsedModifiedSections] = useState<
     Set<ModifiedSection>
+  >(new Set());
+  const [collapsedKindSections, setCollapsedKindSections] = useState<
+    Set<ProjectFileKind>
   >(new Set());
   const [renaming, setRenaming] = useState<{ name: string; draft: string; saving: boolean } | null>(null);
   const [dayBoundary, setDayBoundary] = useState(() => Date.now());
@@ -131,6 +163,29 @@ export function DesignFilesPanel({
   }, [dayBoundary, pageFiles]);
   const visibleModifiedSections = MODIFIED_SECTION_ORDER.filter(
     (section) => modifiedGroups[section].length > 0,
+  );
+  const kindGroups = useMemo(() => {
+    const groups: Record<ProjectFileKind, ProjectFile[]> = {
+      html: [],
+      text: [],
+      code: [],
+      sketch: [],
+      image: [],
+      document: [],
+      pdf: [],
+      presentation: [],
+      spreadsheet: [],
+      video: [],
+      audio: [],
+      binary: [],
+    };
+    for (const f of pageFiles) {
+      groups[f.kind].push(f);
+    }
+    return groups;
+  }, [pageFiles]);
+  const visibleKindSections = KIND_ORDER.filter(
+    (kind) => kindGroups[kind].length > 0,
   );
   const rangeStart = safePage * effectivePageSize + 1;
   const rangeEnd = Math.min((safePage + 1) * effectivePageSize, sortedFiles.length);
@@ -331,6 +386,18 @@ export function DesignFilesPanel({
     });
   }
 
+  function toggleKindSection(kind: ProjectFileKind) {
+    setCollapsedKindSections((prev) => {
+      const next = new Set(prev);
+      if (next.has(kind)) {
+        next.delete(kind);
+      } else {
+        next.add(kind);
+      }
+      return next;
+    });
+  }
+
   function renderFileRow(f: ProjectFile) {
     const active = preview === f.name;
     const isHovered = hover === f.name;
@@ -489,6 +556,32 @@ export function DesignFilesPanel({
               aria-expanded={!collapsed}
               aria-label={`${collapsed ? t('designFiles.expandGroup') : t('designFiles.collapseGroup')} ${label}`}
               onClick={() => toggleModifiedSection(section)}
+            >
+              <Icon name={collapsed ? 'chevron-right' : 'chevron-down'} size={13} />
+              <span>{label}</span>
+              <span className="df-section-count">{sectionFiles.length}</span>
+            </button>
+          </td>
+        </tr>,
+        ...(collapsed ? [] : sectionFiles.map(renderFileRow)),
+      ];
+    });
+  }
+
+  function renderKindSections() {
+    return visibleKindSections.flatMap((kind) => {
+      const sectionFiles = kindGroups[kind];
+      const collapsed = collapsedKindSections.has(kind);
+      const label = t(KIND_LABEL_KEY[kind]);
+      return [
+        <tr className="df-section-row" key={`${kind}-label`}>
+          <td colSpan={6}>
+            <button
+              type="button"
+              className="df-section-toggle"
+              aria-expanded={!collapsed}
+              aria-label={`${collapsed ? t('designFiles.expandGroup') : t('designFiles.collapseGroup')} ${label}`}
+              onClick={() => toggleKindSection(kind)}
             >
               <Icon name={collapsed ? 'chevron-right' : 'chevron-down'} size={13} />
               <span>{label}</span>
@@ -807,7 +900,9 @@ export function DesignFilesPanel({
                     <tbody>
                       {groupMode === 'modified'
                         ? renderModifiedSections()
-                        : pageFiles.map(renderFileRow)}
+                        : groupMode === 'kind'
+                          ? renderKindSections()
+                          : pageFiles.map(renderFileRow)}
                     </tbody>
                   </table>
                   <div className="df-pagination df-pagination-center">


### PR DESCRIPTION
Fixes #1548

## Problem

Selecting `按类型` (group by type) in the file list grouping control **does not actually group files by type**. The control reflects that type grouping is selected, but the file list still appears as a flat list without any visual separation by file kind.

### Current Behavior
- ❌ Grouping mode selector shows "类型" as selected
- ❌ Files remain in a flat list
- ❌ No visual separation by file type
- ❌ Grouping behavior does not match the selected mode

### Expected Behavior
- ✅ Files grouped into clear type-based sections
- ✅ Visual separation by file kind (HTML, Images, Code, etc.)
- ✅ Collapsible sections for each file type
- ✅ Consistent with "Modified" grouping behavior

## Root Cause

The code had full implementation for **modified-time grouping** (`modifiedGroups`, `renderModifiedSections`, etc.) but was **missing the corresponding implementation for kind grouping**.

In the rendering logic (line 900-903), the code only checked:
```tsx
{groupMode === 'modified'
  ? renderModifiedSections()
  : pageFiles.map(renderFileRow)}
```

When `groupMode === 'kind'`, it fell through to the flat list rendering, completely ignoring the selected grouping mode.

## Solution

Implemented the missing kind-grouping functionality following the exact same pattern as modified-time grouping:

### 1. Added Constants
```tsx
const KIND_ORDER: ProjectFileKind[] = [
  'html', 'text', 'code', 'sketch', 'image',
  'document', 'pdf', 'presentation', 'spreadsheet',
  'video', 'audio', 'binary',
];

const KIND_LABEL_KEY: Record<ProjectFileKind, keyof Dict> = {
  html: 'designFiles.kindHtml',
  image: 'designFiles.kindImage',
  // ... all 12 file types
};
```

### 2. Added State
```tsx
const [collapsedKindSections, setCollapsedKindSections] = useState<
  Set<ProjectFileKind>
>(new Set());
```

### 3. Added Grouping Logic
```tsx
const kindGroups = useMemo(() => {
  const groups: Record<ProjectFileKind, ProjectFile[]> = {
    html: [], text: [], code: [], sketch: [], image: [],
    document: [], pdf: [], presentation: [], spreadsheet: [],
    video: [], audio: [], binary: [],
  };
  for (const f of pageFiles) {
    groups[f.kind].push(f);
  }
  return groups;
}, [pageFiles]);

const visibleKindSections = KIND_ORDER.filter(
  (kind) => kindGroups[kind].length > 0,
);
```

### 4. Added Toggle Function
```tsx
function toggleKindSection(kind: ProjectFileKind) {
  setCollapsedKindSections((prev) => {
    const next = new Set(prev);
    if (next.has(kind)) next.delete(kind);
    else next.add(kind);
    return next;
  });
}
```

### 5. Added Render Function
```tsx
function renderKindSections() {
  return visibleKindSections.flatMap((kind) => {
    const sectionFiles = kindGroups[kind];
    const collapsed = collapsedKindSections.has(kind);
    const label = t(KIND_LABEL_KEY[kind]);
    return [
      <tr className="df-section-row" key={`${kind}-label`}>
        <td colSpan={6}>
          <button
            type="button"
            className="df-section-toggle"
            aria-expanded={!collapsed}
            onClick={() => toggleKindSection(kind)}
          >
            <Icon name={collapsed ? 'chevron-right' : 'chevron-down'} size={13} />
            <span>{label}</span>
            <span className="df-section-count">{sectionFiles.length}</span>
          </button>
        </td>
      </tr>,
      ...(collapsed ? [] : sectionFiles.map(renderFileRow)),
    ];
  });
}
```

### 6. Updated Rendering Logic
```tsx
{groupMode === 'modified'
  ? renderModifiedSections()
  : groupMode === 'kind'
    ? renderKindSections()
    : pageFiles.map(renderFileRow)}
```

## Testing

- [x] Added KIND_ORDER constant with all 12 file types
- [x] Added KIND_LABEL_KEY mapping to i18n keys
- [x] Added kindGroups useMemo for grouping logic
- [x] Added collapsedKindSections state
- [x] Added toggleKindSection function
- [x] Added renderKindSections function
- [x] Updated tbody rendering to check groupMode === 'kind'
- [x] Follows exact same pattern as modified-time grouping
- [x] Sections are collapsible/expandable
- [x] Only non-empty sections are shown

## Impact

- **Surface area:** Design Files panel → Group by type mode
- **User experience:** Files now properly group by type when "类型" is selected
- **Consistency:** Kind grouping now works the same way as modified-time grouping
- **Files changed:** 1 (DesignFilesPanel.tsx)
- **Lines changed:** +96 -1

## File Type Groups

When grouping by type is active, files are organized into these collapsible sections:
- **HTML** - HTML artifacts
- **Text** - Plain text files
- **Code** - Source code files
- **Sketch** - Sketch JSON files
- **Image** - PNG, JPG, SVG, etc.
- **Document** - Word documents
- **PDF** - PDF files
- **Presentation** - PowerPoint files
- **Spreadsheet** - Excel files
- **Video** - MP4, WebM, etc.
- **Audio** - MP3, WAV, etc.
- **Binary** - Other binary files

## Priority

This is a **P1 bug** because:
- The UI control is visible and selectable
- Users expect it to work when they click it
- It's a core file management feature
- The broken state erodes trust in the file browser