### PR TITLE
feat(media): add SenseAudio TTS provider

### DIFF
--- a/apps/daemon/src/media-config.ts
+++ b/apps/daemon/src/media-config.ts
@@ -85,6 +85,7 @@ const ENV_KEYS: Record<string, string[]> = {
   udio: ['OD_UDIO_API_KEY'],
   elevenlabs: ['OD_ELEVENLABS_API_KEY', 'ELEVENLABS_API_KEY'],
   fishaudio: ['OD_FISHAUDIO_API_KEY', 'FISH_AUDIO_API_KEY'],
+  senseaudio: ['OD_SENSEAUDIO_API_KEY', 'SENSEAUDIO_API_KEY'],
   tavily: ['OD_TAVILY_API_KEY', 'TAVILY_API_KEY'],
 };
 

--- a/apps/daemon/src/media-models.ts
+++ b/apps/daemon/src/media-models.ts
@@ -128,12 +128,12 @@ export const AUDIO_MODELS_BY_KIND: Record<AudioKind, MediaModel[]> = {
     { id: 'lyria-2', label: 'lyria-2', hint: 'Google', provider: 'google', caps: ['music'] },
   ],
   speech: [
-    { id: 'gpt-4o-mini-tts', label: 'gpt-4o-mini-tts', hint: 'OpenAI · expressive TTS', provider: 'openai', caps: ['tts'] },
-    { id: 'minimax-tts', label: 'minimax-tts', hint: 'MiniMax · default', provider: 'minimax', caps: ['tts'], default: true },
+    { id: 'minimax-tts', label: 'minimax-tts', hint: 'MiniMax', provider: 'minimax', caps: ['tts'], default: true },
     { id: 'fish-speech-2', label: 'fish-speech-2', hint: 'FishAudio', provider: 'fishaudio', caps: ['tts', 'voice-clone'] },
     { id: 'elevenlabs-v3', label: 'elevenlabs-v3', hint: 'ElevenLabs', provider: 'elevenlabs', caps: ['tts', 'voice-clone'] },
     { id: 'senseaudio-tts', label: 'senseaudio-tts', hint: 'SenseAudio', provider: 'senseaudio', caps: ['tts', 'voice-clone'] },
-    { id: 'doubao-tts', label: 'doubao-tts', hint: 'Volcengine · TTS', provider: 'volcengine', caps: ['tts'] },
+    { id: 'doubao-tts', label: 'doubao-tts', hint: 'Volcengine', provider: 'volcengine', caps: ['tts'] },
+    { id: 'gpt-4o-mini-tts', label: 'gpt-4o-mini-tts', hint: 'OpenAI', provider: 'openai', caps: ['tts'] },
   ],
   sfx: [
     { id: 'elevenlabs-sfx', label: 'elevenlabs-sfx', hint: 'ElevenLabs SFX', provider: 'elevenlabs', caps: ['sfx'], default: true },

--- a/apps/daemon/src/media-models.ts
+++ b/apps/daemon/src/media-models.ts
@@ -53,6 +53,14 @@ export const MEDIA_PROVIDERS: MediaProvider[] = [
     docsUrl: 'https://elevenlabs.io/app/settings/api-keys',
   },
   { id: 'fishaudio', label: 'FishAudio', hint: 'Speech / voice clone', integrated: true, defaultBaseUrl: 'https://api.fish.audio' },
+  {
+    id: 'senseaudio',
+    label: 'SenseAudio',
+    hint: 'TTS · 70+ system voices · clone',
+    integrated: true,
+    defaultBaseUrl: 'https://api.senseaudio.cn',
+    docsUrl: 'https://docs.senseaudio.cn',
+  },
   { id: 'tavily', label: 'Tavily Search', hint: 'Agent-callable web research', integrated: true, defaultBaseUrl: 'https://api.tavily.com' },
   { id: 'stub', label: 'Stub (placeholder)', hint: 'Deterministic local placeholder bytes', integrated: true },
 ];
@@ -124,6 +132,7 @@ export const AUDIO_MODELS_BY_KIND: Record<AudioKind, MediaModel[]> = {
     { id: 'minimax-tts', label: 'minimax-tts', hint: 'MiniMax · default', provider: 'minimax', caps: ['tts'], default: true },
     { id: 'fish-speech-2', label: 'fish-speech-2', hint: 'FishAudio', provider: 'fishaudio', caps: ['tts', 'voice-clone'] },
     { id: 'elevenlabs-v3', label: 'elevenlabs-v3', hint: 'ElevenLabs', provider: 'elevenlabs', caps: ['tts', 'voice-clone'] },
+    { id: 'senseaudio-tts', label: 'senseaudio-tts', hint: 'SenseAudio', provider: 'senseaudio', caps: ['tts', 'voice-clone'] },
     { id: 'doubao-tts', label: 'doubao-tts', hint: 'Volcengine · TTS', provider: 'volcengine', caps: ['tts'] },
   ],
   sfx: [

--- a/apps/daemon/src/media.ts
+++ b/apps/daemon/src/media.ts
@@ -1672,8 +1672,9 @@ async function renderMinimaxTTS(ctx: MediaContext, credentials: ProviderConfig):
 // envelope that distinguishes HTTP-level from API-level failures, again
 // mirroring MiniMax. The catalogue id we surface as `senseaudio-tts`
 // resolves to `senseaudio-tts-1.5-260319` on the wire — SenseAudio's
-// recommended flagship model (情绪 / 多音字 / 公式朗读 / 克隆 / 文生音色 支持)。
-// Default voice is `female_0033_b` per the official example; the agent
+// recommended flagship model (supports emotion control, polyphonic
+// characters, LaTeX formula reading, voice cloning, and text-generated
+// voices). Default voice is `female_0033_b` per the official example; the agent
 // can override via the model registry's `voice` slot with any system,
 // cloned, or text-generated voice id from the customer's catalogue.
 // Audio shape is hard-coded to mp3 / 32kHz / 128kbps / stereo for parity

--- a/apps/daemon/src/media.ts
+++ b/apps/daemon/src/media.ts
@@ -472,6 +472,11 @@ export async function generateMedia(args: {
       bytes = result.bytes;
       providerNote = result.providerNote;
       suggestedExt = result.suggestedExt;
+    } else if (def.provider === 'senseaudio' && surface === 'audio') {
+      const result = await renderSenseAudioTTS(ctx, credentials);
+      bytes = result.bytes;
+      providerNote = result.providerNote;
+      suggestedExt = result.suggestedExt;
     } else if (def.provider === 'fishaudio' && surface === 'audio') {
       const result = await renderFishAudioTTS(ctx, credentials);
       bytes = result.bytes;
@@ -1654,6 +1659,108 @@ async function renderMinimaxTTS(ctx: MediaContext, credentials: ProviderConfig):
   return {
     bytes,
     providerNote: `minimax/${wireModel} · ${voiceId} · ${seconds}s · ${bytes.length} bytes`,
+    suggestedExt: '.mp3',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Provider: SenseAudio — senseaudio-tts-1.5 text-to-speech (synchronous).
+//
+// Docs: https://docs.senseaudio.cn — POST /v1/t2a_v2 with a JSON body
+// shaped like MiniMax's (voice_setting / audio_setting). The response is
+// JSON with hex-encoded audio under `data.audio` and a `base_resp`
+// envelope that distinguishes HTTP-level from API-level failures, again
+// mirroring MiniMax. The catalogue id we surface as `senseaudio-tts`
+// resolves to `senseaudio-tts-1.5-260319` on the wire — SenseAudio's
+// recommended flagship model (情绪 / 多音字 / 公式朗读 / 克隆 / 文生音色 支持)。
+// Default voice is `female_0033_b` per the official example; the agent
+// can override via the model registry's `voice` slot with any system,
+// cloned, or text-generated voice id from the customer's catalogue.
+// Audio shape is hard-coded to mp3 / 32kHz / 128kbps / stereo for parity
+// with the other TTS providers; SenseAudio supports wav/pcm/flac and
+// other sample rates but we don't expose them through MediaContext yet.
+// ---------------------------------------------------------------------------
+
+const SENSEAUDIO_DEFAULT_BASE_URL = 'https://api.senseaudio.cn';
+const SENSEAUDIO_DEFAULT_VOICE_ID = 'female_0033_b';
+
+const SENSEAUDIO_TTS_MODEL_MAP = {
+  'senseaudio-tts': 'senseaudio-tts-1.5-260319',
+} as Record<string, string>;
+
+async function renderSenseAudioTTS(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {
+  if (!credentials.apiKey) {
+    throw new Error(
+      'no SenseAudio API key — configure it in Settings or set OD_SENSEAUDIO_API_KEY',
+    );
+  }
+  const baseUrl = (credentials.baseUrl || SENSEAUDIO_DEFAULT_BASE_URL).replace(
+    /\/$/,
+    '',
+  );
+  const wireModel = SENSEAUDIO_TTS_MODEL_MAP[ctx.model] || ctx.model;
+  const text = (ctx.prompt && ctx.prompt.trim()) || 'This is a test.';
+  const voiceId = (ctx.voice && ctx.voice.trim()) || SENSEAUDIO_DEFAULT_VOICE_ID;
+
+  const body = {
+    model: wireModel,
+    text,
+    stream: false,
+    voice_setting: {
+      voice_id: voiceId,
+      speed: 1,
+      vol: 1,
+      pitch: 0,
+    },
+    audio_setting: {
+      format: 'mp3',
+      sample_rate: 32000,
+      bitrate: 128000,
+      channel: 2,
+    },
+  };
+
+  const resp = await fetch(`${baseUrl}/v1/t2a_v2`, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${credentials.apiKey}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  const respText = await resp.text();
+  if (!resp.ok) {
+    throw new Error(`senseaudio tts ${resp.status}: ${truncate(respText, 240)}`);
+  }
+  let data: any;
+  try {
+    data = JSON.parse(respText);
+  } catch {
+    throw new Error(`senseaudio tts non-JSON: ${truncate(respText, 200)}`);
+  }
+  // SenseAudio mirrors MiniMax's base_resp envelope: HTTP 200 can still
+  // be a logical failure (auth, quota, voice not on this account, …).
+  // Surface the upstream status_code/status_msg so users see the real
+  // cause instead of a downstream "missing data.audio" red herring.
+  if (data?.base_resp && data.base_resp.status_code !== 0) {
+    throw new Error(
+      `senseaudio tts api error ${data.base_resp.status_code}: ${data.base_resp.status_msg || 'unknown'}`,
+    );
+  }
+  const hex = data?.data?.audio;
+  if (typeof hex !== 'string' || !hex) {
+    throw new Error('senseaudio tts response missing data.audio');
+  }
+  const bytes = Buffer.from(hex, 'hex');
+  if (bytes.length === 0) {
+    throw new Error('senseaudio tts decoded zero bytes');
+  }
+  const xi = data?.extra_info || {};
+  const seconds = xi.audio_length ? Math.round(xi.audio_length / 100) / 10 : '?';
+
+  return {
+    bytes,
+    providerNote: `senseaudio/${wireModel} · ${voiceId} · ${seconds}s · ${bytes.length} bytes`,
     suggestedExt: '.mp3',
   };
 }

--- a/apps/daemon/tests/media-senseaudio.test.ts
+++ b/apps/daemon/tests/media-senseaudio.test.ts
@@ -1,0 +1,330 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { generateMedia } from '../src/media.js';
+
+const TEST_SENSEAUDIO_BASE_URL = 'https://senseaudio-gateway.example.test';
+const WIRE_MODEL = 'senseaudio-tts-1.5-260319';
+
+function buildOkResponse(audioBytes: Buffer, opts?: { audioLength?: number }) {
+  return new Response(
+    JSON.stringify({
+      data: { audio: audioBytes.toString('hex'), status: 2 },
+      extra_info: {
+        audio_length: opts?.audioLength ?? 12340,
+        audio_sample_rate: 32000,
+        audio_size: audioBytes.length,
+        bitrate: 128000,
+        audio_format: 'mp3',
+        audio_channel: 2,
+        word_count: 8,
+        usage_characters: 8,
+      },
+      trace_id: 'trace-test',
+      base_resp: { status_code: 0, status_msg: 'success' },
+    }),
+    { status: 200, headers: { 'content-type': 'application/json' } },
+  );
+}
+
+describe('senseaudio media generation', () => {
+  let root: string;
+  let projectRoot: string;
+  let projectsRoot: string;
+  const realFetch = globalThis.fetch;
+  const originalMediaConfigDir = process.env.OD_MEDIA_CONFIG_DIR;
+  const originalDataDir = process.env.OD_DATA_DIR;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'od-senseaudio-'));
+    projectRoot = path.join(root, 'project-root');
+    projectsRoot = path.join(projectRoot, '.od', 'projects');
+    await mkdir(projectsRoot, { recursive: true });
+    delete process.env.OD_MEDIA_CONFIG_DIR;
+    delete process.env.OD_DATA_DIR;
+    delete process.env.OD_SENSEAUDIO_API_KEY;
+    delete process.env.SENSEAUDIO_API_KEY;
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = realFetch;
+    if (originalMediaConfigDir == null) {
+      delete process.env.OD_MEDIA_CONFIG_DIR;
+    } else {
+      process.env.OD_MEDIA_CONFIG_DIR = originalMediaConfigDir;
+    }
+    if (originalDataDir == null) {
+      delete process.env.OD_DATA_DIR;
+    } else {
+      process.env.OD_DATA_DIR = originalDataDir;
+    }
+    delete process.env.OD_SENSEAUDIO_API_KEY;
+    delete process.env.SENSEAUDIO_API_KEY;
+    await rm(root, { recursive: true, force: true });
+  });
+
+  async function writeConfig(data: unknown) {
+    const file = path.join(projectRoot, '.od', 'media-config.json');
+    await mkdir(path.dirname(file), { recursive: true });
+    await writeFile(file, JSON.stringify(data), 'utf8');
+  }
+
+  it('renders SenseAudio speech with the documented defaults', async () => {
+    await writeConfig({
+      providers: {
+        senseaudio: {
+          apiKey: 'sense-test-key',
+          baseUrl: TEST_SENSEAUDIO_BASE_URL,
+        },
+      },
+    });
+
+    const mp3Bytes = Buffer.from([0x49, 0x44, 0x33, 0x04, 0x00, 0x00, 0x73, 0x65, 0x6e]);
+    const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
+      expect(String(input)).toBe(`${TEST_SENSEAUDIO_BASE_URL}/v1/t2a_v2`);
+      expect(init?.method).toBe('POST');
+      expect(init?.headers).toMatchObject({
+        authorization: 'Bearer sense-test-key',
+        'content-type': 'application/json',
+      });
+      expect(JSON.parse(String(init?.body))).toEqual({
+        model: WIRE_MODEL,
+        text: '你好，欢迎使用 SenseAudio 语音合成服务。',
+        stream: false,
+        voice_setting: {
+          voice_id: 'female_0033_b',
+          speed: 1,
+          vol: 1,
+          pitch: 0,
+        },
+        audio_setting: {
+          format: 'mp3',
+          sample_rate: 32000,
+          bitrate: 128000,
+          channel: 2,
+        },
+      });
+      return buildOkResponse(mp3Bytes);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'audio',
+      model: 'senseaudio-tts',
+      audioKind: 'speech',
+      prompt: '你好，欢迎使用 SenseAudio 语音合成服务。',
+      output: 'senseaudio-speech.mp3',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.providerId).toBe('senseaudio');
+    expect(result.providerNote).toContain(`senseaudio/${WIRE_MODEL}`);
+    expect(result.providerNote).toContain('female_0033_b');
+
+    const bytes = await readFile(path.join(projectsRoot, 'project-1', 'senseaudio-speech.mp3'));
+    expect(bytes.equals(mp3Bytes)).toBe(true);
+  });
+
+  it('passes custom voice id through to the request body', async () => {
+    await writeConfig({
+      providers: {
+        senseaudio: {
+          apiKey: 'sense-test-key',
+          baseUrl: TEST_SENSEAUDIO_BASE_URL,
+        },
+      },
+    });
+
+    const mp3Bytes = Buffer.from([0xff, 0xfb, 0x90, 0x00]);
+    const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      expect(body.voice_setting.voice_id).toBe('male_0001_a');
+      return buildOkResponse(mp3Bytes);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'audio',
+      model: 'senseaudio-tts',
+      audioKind: 'speech',
+      voice: 'male_0001_a',
+      prompt: 'Custom voice line.',
+      output: 'senseaudio-custom.mp3',
+    });
+
+    expect(result.providerNote).toContain('male_0001_a');
+  });
+
+  it('falls back to the canonical base URL when none is configured', async () => {
+    await writeConfig({
+      providers: {
+        senseaudio: { apiKey: 'sense-test-key' },
+      },
+    });
+
+    const fetchMock = vi.fn(async (input: unknown) => {
+      expect(String(input)).toBe('https://api.senseaudio.cn/v1/t2a_v2');
+      return buildOkResponse(Buffer.from([0x01, 0x02, 0x03]));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'audio',
+      model: 'senseaudio-tts',
+      audioKind: 'speech',
+      prompt: 'Default base url.',
+      output: 'senseaudio-default-base.mp3',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('reads the API key from OD_SENSEAUDIO_API_KEY when storage is empty', async () => {
+    process.env.OD_SENSEAUDIO_API_KEY = 'env-sense-key';
+    const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
+      expect(init?.headers).toMatchObject({
+        authorization: 'Bearer env-sense-key',
+      });
+      return buildOkResponse(Buffer.from([0x10, 0x20]));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'audio',
+      model: 'senseaudio-tts',
+      audioKind: 'speech',
+      prompt: 'Env-only key.',
+      output: 'senseaudio-env.mp3',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('errors when no API key is configured', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      generateMedia({
+        projectRoot,
+        projectsRoot,
+        projectId: 'project-1',
+        surface: 'audio',
+        model: 'senseaudio-tts',
+        audioKind: 'speech',
+        prompt: 'Should fail.',
+        output: 'senseaudio-no-key.mp3',
+      }),
+    ).rejects.toThrow(/no SenseAudio API key/);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('surfaces upstream base_resp failures verbatim', async () => {
+    await writeConfig({
+      providers: {
+        senseaudio: { apiKey: 'sense-test-key', baseUrl: TEST_SENSEAUDIO_BASE_URL },
+      },
+    });
+
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          data: null,
+          base_resp: { status_code: 1004, status_msg: 'voice_id not found' },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      generateMedia({
+        projectRoot,
+        projectsRoot,
+        projectId: 'project-1',
+        surface: 'audio',
+        model: 'senseaudio-tts',
+        audioKind: 'speech',
+        voice: 'does-not-exist',
+        prompt: 'Bad voice.',
+        output: 'senseaudio-bad-voice.mp3',
+      }),
+    ).rejects.toThrow('senseaudio tts api error 1004: voice_id not found');
+  });
+
+  it('errors when the audio payload is missing', async () => {
+    await writeConfig({
+      providers: {
+        senseaudio: { apiKey: 'sense-test-key', baseUrl: TEST_SENSEAUDIO_BASE_URL },
+      },
+    });
+
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          data: {},
+          base_resp: { status_code: 0, status_msg: 'success' },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      generateMedia({
+        projectRoot,
+        projectsRoot,
+        projectId: 'project-1',
+        surface: 'audio',
+        model: 'senseaudio-tts',
+        audioKind: 'speech',
+        prompt: 'Missing audio.',
+        output: 'senseaudio-missing-audio.mp3',
+      }),
+    ).rejects.toThrow('senseaudio tts response missing data.audio');
+  });
+
+  it('surfaces HTTP-level failures with the status code and truncated body', async () => {
+    await writeConfig({
+      providers: {
+        senseaudio: { apiKey: 'sense-test-key', baseUrl: TEST_SENSEAUDIO_BASE_URL },
+      },
+    });
+
+    const fetchMock = vi.fn(async () =>
+      new Response('unauthorized', {
+        status: 401,
+        headers: { 'content-type': 'text/plain' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      generateMedia({
+        projectRoot,
+        projectsRoot,
+        projectId: 'project-1',
+        surface: 'audio',
+        model: 'senseaudio-tts',
+        audioKind: 'speech',
+        prompt: 'Bad auth.',
+        output: 'senseaudio-401.mp3',
+      }),
+    ).rejects.toThrow('senseaudio tts 401: unauthorized');
+  });
+});

--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -2198,7 +2198,7 @@ export function supportedModels(surface: 'image' | 'video' | 'audio', models: Me
   const supportedProviders: Record<'image' | 'video' | 'audio', Set<string>> = {
     image: new Set(['openai', 'volcengine', 'grok', 'nanobanana']),
     video: new Set(['volcengine', 'hyperframes', 'grok']),
-    audio: new Set(['minimax', 'fishaudio', 'elevenlabs']),
+    audio: new Set(['minimax', 'fishaudio', 'senseaudio', 'elevenlabs']),
   };
   return models.filter((model) => {
     const provider = findProvider(model.provider);

--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -2198,7 +2198,7 @@ export function supportedModels(surface: 'image' | 'video' | 'audio', models: Me
   const supportedProviders: Record<'image' | 'video' | 'audio', Set<string>> = {
     image: new Set(['openai', 'volcengine', 'grok', 'nanobanana']),
     video: new Set(['volcengine', 'hyperframes', 'grok']),
-    audio: new Set(['minimax', 'fishaudio', 'senseaudio', 'elevenlabs']),
+    audio: new Set(['minimax', 'fishaudio', 'senseaudio', 'elevenlabs', 'openai', 'volcengine']),
   };
   return models.filter((model) => {
     const provider = findProvider(model.provider);

--- a/apps/web/src/media/models.ts
+++ b/apps/web/src/media/models.ts
@@ -422,12 +422,12 @@ export const AUDIO_MODELS_BY_KIND: Record<AudioKind, MediaModel[]> = {
     { id: 'lyria-2', label: 'lyria-2', hint: 'Google', provider: 'google', caps: ['music'] },
   ],
   speech: [
-    { id: 'gpt-4o-mini-tts', label: 'gpt-4o-mini-tts', hint: 'OpenAI · expressive TTS', provider: 'openai', caps: ['tts'] },
-    { id: 'minimax-tts', label: 'minimax-tts', hint: 'MiniMax · default', provider: 'minimax', caps: ['tts'], default: true },
+    { id: 'minimax-tts', label: 'minimax-tts', hint: 'MiniMax', provider: 'minimax', caps: ['tts'], default: true },
     { id: 'fish-speech-2', label: 'fish-speech-2', hint: 'FishAudio', provider: 'fishaudio', caps: ['tts', 'voice-clone'] },
     { id: 'elevenlabs-v3', label: 'elevenlabs-v3', hint: 'ElevenLabs', provider: 'elevenlabs', caps: ['tts', 'voice-clone'] },
     { id: 'senseaudio-tts', label: 'senseaudio-tts', hint: 'SenseAudio', provider: 'senseaudio', caps: ['tts', 'voice-clone'] },
-    { id: 'doubao-tts', label: 'doubao-tts', hint: 'Volcengine · TTS', provider: 'volcengine', caps: ['tts'] },
+    { id: 'doubao-tts', label: 'doubao-tts', hint: 'Volcengine', provider: 'volcengine', caps: ['tts'] },
+    { id: 'gpt-4o-mini-tts', label: 'gpt-4o-mini-tts', hint: 'OpenAI', provider: 'openai', caps: ['tts'] },
   ],
   sfx: [
     { id: 'elevenlabs-sfx', label: 'elevenlabs-sfx', hint: 'ElevenLabs SFX', provider: 'elevenlabs', caps: ['sfx'], default: true },

--- a/apps/web/src/media/models.ts
+++ b/apps/web/src/media/models.ts
@@ -44,6 +44,7 @@ export type MediaProviderId =
   | 'udio'
   | 'elevenlabs'
   | 'fishaudio'
+  | 'senseaudio'
   | 'tavily'
   | 'stub';
 
@@ -195,6 +196,14 @@ export const MEDIA_PROVIDERS: MediaProvider[] = [
     integrated: true,
     defaultBaseUrl: 'https://api.fish.audio',
     docsUrl: 'https://fish.audio',
+  },
+  {
+    id: 'senseaudio',
+    label: 'SenseAudio',
+    hint: 'TTS · 70+ system voices · clone',
+    integrated: true,
+    defaultBaseUrl: 'https://api.senseaudio.cn',
+    docsUrl: 'https://docs.senseaudio.cn',
   },
   {
     id: 'tavily',
@@ -417,6 +426,7 @@ export const AUDIO_MODELS_BY_KIND: Record<AudioKind, MediaModel[]> = {
     { id: 'minimax-tts', label: 'minimax-tts', hint: 'MiniMax · default', provider: 'minimax', caps: ['tts'], default: true },
     { id: 'fish-speech-2', label: 'fish-speech-2', hint: 'FishAudio', provider: 'fishaudio', caps: ['tts', 'voice-clone'] },
     { id: 'elevenlabs-v3', label: 'elevenlabs-v3', hint: 'ElevenLabs', provider: 'elevenlabs', caps: ['tts', 'voice-clone'] },
+    { id: 'senseaudio-tts', label: 'senseaudio-tts', hint: 'SenseAudio', provider: 'senseaudio', caps: ['tts', 'voice-clone'] },
     { id: 'doubao-tts', label: 'doubao-tts', hint: 'Volcengine · TTS', provider: 'volcengine', caps: ['tts'] },
   ],
   sfx: [


### PR DESCRIPTION
## Why

I was using Open Design to draft a cinematic VO with SenseAudio (a Mandarin-leaning TTS service with built-in emotion control, polyphonic-character disambiguation, LaTeX formula reading, voice cloning, and text-generated voices — API reference: https://docs.senseaudio.cn/api-reference/endpoint/tts/synthesize), and noticed the only paths the dispatcher offered for speech were ElevenLabs, MiniMax, FishAudio, OpenAI, and Volcengine. The integration shape is the same as the other TTS providers in the dispatcher, so the cost of adding one more provider is low.

## What users will see

- A new **SenseAudio** card appears in Settings → Media Providers with API key + Base URL fields, identical UX to the MiniMax / FishAudio cards.
- The audio model picker (New Project → Audio → Speech) shows a new **senseaudio-tts** entry alongside `minimax-tts`, `fish-speech-2`, `elevenlabs-v3`, and `doubao-tts`. Picking it dispatches through SenseAudio's `POST /v1/t2a_v2`.
- New env vars: `OD_SENSEAUDIO_API_KEY` (project-reserved override, takes precedence) and `SENSEAUDIO_API_KEY` (canonical upstream env, picked up automatically if already exported for the official SDK). Same dual-alias pattern every other integrated provider uses.
- CLI shape unchanged: `od media generate --surface audio --model senseaudio-tts --voice <voice-id> --prompt "..." --output file.mp3`.

Existing users see no change — the new provider is opt-in (no key → still picks one of the providers they already configured).

## Surface area

- [x] **UI** — new Settings → Media Providers card and new entry in the audio model picker (driven entirely by the catalogue registry; no new components).
- [ ] **Keyboard shortcut**
- [x] **CLI / env var** — two new env vars (`OD_SENSEAUDIO_API_KEY`, `SENSEAUDIO_API_KEY`); no new CLI flags.
- [ ] **API / contract** — no changes to `packages/contracts`, no new `/api/*` endpoint, no new SSE event.
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change** — only adds an opt-in provider; default audio model stays `minimax-tts`.

## Screenshots
<img width="923" height="690" alt="sh2026-05-14 11 59 24" src="https://github.com/user-attachments/assets/503bad04-96ff-4cb2-9b87-e958393e8deb" />
<img width="1472" height="742" alt="sh2026-05-14 12 03 25" src="https://github.com/user-attachments/assets/21f313c7-4297-4230-9cc7-34d0a0d279d2" />



## Validation

- `pnpm install`
- `pnpm guard` — green
- `pnpm typecheck` — green for everything I touched (pre-existing `FileViewer.test.tsx` typecheck error on `main` is unrelated and was confirmed by stashing my changes and re-running)
- `node scripts/verify-media-models.mjs` — `OK (TS + JS registries match)`
- `pnpm --filter @open-design/daemon test` — 1848/1848 pass, including 8 new specs in `apps/daemon/tests/media-senseaudio.test.ts` covering: default request body, custom `--voice`, default base URL fall-back, env-key resolution, missing-key error, `base_resp.status_code != 0` failures, missing `data.audio` payloads, and HTTP non-2xx responses. Patterned on `media-elevenlabs.test.ts` so future provider additions keep a consistent test shape.
- `pnpm --filter @open-design/web test` — 1150/1150 pass, including `SettingsDialog media providers interactions` (the new SenseAudio card slots into the existing registry-driven section without bespoke wiring).
- End-to-end smoke: launched `pnpm tools-dev run web`, set `SENSEAUDIO_API_KEY`, generated `cinematic-vo.mp3` through the in-app agent (`od media generate --surface audio --model senseaudio-tts --prompt "..." --output cinematic-vo.mp3`). MP3 file lands in the project panel with the correct `providerNote` (`senseaudio/senseaudio-tts-1.5-260319 · female_0033_b · …`) and is playable.
