### PR TITLE
fix: restore skillIds processing in composeDaemonSystemPrompt

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -4,7 +4,7 @@ import express from 'express';
 import multer from 'multer';
 import JSZip from 'jszip';
 import { execFile, spawn } from 'node:child_process';
-import { randomUUID } from 'node:crypto';
+import { createHash, createHmac, randomUUID, timingSafeEqual } from 'node:crypto';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
@@ -56,7 +56,7 @@ export {
   signDesktopImportToken,
   verifyDesktopImportToken,
 } from './desktop-auth.js';
-import { findSkillById, listSkills, splitDerivedSkillId } from './skills.js';
+import { findSkillById, listSkills, splitDerivedSkillId, withSkillRootPreamble, type SkillInfo } from './skills.js';
 import { validateLinkedDirs } from './linked-dirs.js';
 import { installFromTarget, uninstallById, sanitizeRepoName } from './library-install.js';
 import { buildWindowsFolderDialogCommand, parseFolderDialogStdout } from './native-folder-dialog.js';
@@ -623,11 +623,93 @@ export function validateCodexGeneratedImagesDir(
   }
 }
 
+/**
+ * Resolve ad-hoc (@-mention) skill ids to their on-disk directories.
+ *
+ * Returns an array of `{ id, dir }` pairs, one per unique resolved skill,
+ * deduplicated by resolved directory path so that aliases pointing to the
+ * same folder do not double-stage.
+ *
+ * Exported so daemon tests can exercise the full
+ * skillIds → resolved dirs chain without spinning up an HTTP server.
+ */
+export function collectAdHocSkillDirs(
+  skillIds: unknown,
+  effectiveSkillId: string | null | undefined,
+  allSkills: SkillInfo[],
+): Array<{ id: string; dir: string }> {
+  const ids = Array.isArray(skillIds)
+    ? skillIds
+        .map((s: unknown) => (typeof s === 'string' ? s.trim() : ''))
+        .filter(Boolean)
+        .filter((id: string) => id !== effectiveSkillId)
+    : [];
+  if (ids.length === 0) return [];
+
+  const seenId = new Set(effectiveSkillId ? [effectiveSkillId] : []);
+  // Seed seenDir with the active skill's resolved dir so an alias in
+  // skillIds that resolves to the same directory is also excluded.
+  const seenDir = new Set<string>();
+  if (effectiveSkillId) {
+    const active = findSkillById(allSkills, effectiveSkillId);
+    if (active?.dir) seenDir.add(active.dir);
+  }
+  const result: Array<{ id: string; dir: string }> = [];
+
+  for (const id of ids) {
+    if (seenId.has(id)) continue;
+    seenId.add(id);
+    const skill = findSkillById(allSkills, id);
+    if (!skill?.dir) continue;
+    if (seenDir.has(skill.dir)) continue;
+    seenDir.add(skill.dir);
+    result.push({ id: skill.id, dir: skill.dir });
+  }
+
+  return result;
+}
+
+/**
+ * Assign collision-safe staged aliases to resolved ad-hoc skills.
+ *
+ * Every ad-hoc skill receives a deterministic alias of the form
+ * `<basename>-<hash>` where hash is the first 7 hex chars of the MD5 of the
+ * full dir path. This guarantees:
+ *   1. The same folder always gets the same alias regardless of input order.
+ *   2. Two skills with the same basename but different dirs never collide.
+ *   3. Ad-hoc skills never overwrite the project-level active skill copy.
+ */
+export function resolveAdHocSkillsWithAliases(
+  resolved: Array<{ id: string; dir: string }>,
+): Array<{ id: string; dir: string; alias: string }> {
+  return resolved.map(({ id, dir }) => {
+    const basename = path.basename(dir);
+    // Deterministic hash suffix so the same folder always gets the same alias
+    // regardless of input order or concurrent turns.
+    const hash = createHash('md5').update(dir).digest('hex').slice(0, 7);
+    const alias = `${basename}-${hash}`;
+    return { id, dir, alias };
+  });
+}
+
+/**
+ * Derive `skillMode` from a single ad-hoc @-mention skill when no project
+ * skill is active. Returns `undefined` for multi-skill or empty cases.
+ */
+export function resolveAdHocSkillMode(
+  resolved: Array<{ id: string; dir: string }>,
+  allSkills: SkillInfo[],
+): string | undefined {
+  if (resolved.length !== 1) return undefined;
+  return findSkillById(allSkills, resolved[0].id)?.mode;
+}
+
 export function resolveChatExtraAllowedDirs({
   agentId,
   skillsDir,
   designSystemsDir,
   linkedDirs = [],
+  adHocSkillDirs = [],
   codexGeneratedImagesDir,
   existsSync = fs.existsSync,
 }: {
@@ -635,17 +717,26 @@ export function resolveChatExtraAllowedDirs({
   skillsDir?: string | null;
   designSystemsDir?: string | null;
   linkedDirs?: Array<string | null | undefined>;
+  /**
+   * Ad-hoc (@-mention) skill directories. Always reachable regardless of
+   * agentId because the user explicitly summoned the skill for this turn;
+   * the Codex branch below would otherwise drop them along with the rest
+   * of `linkedDirs`, leaving user-installed ad-hoc skill side files
+   * unreadable on projectless Codex runs.
+   */
+  adHocSkillDirs?: Array<string | null | undefined>;
   codexGeneratedImagesDir?: string | null;
   existsSync?: (path: string) => boolean;
 }): string[] {
   const isCodex =
     typeof agentId === 'string' && agentId.trim().toLowerCase() === 'codex';
   const candidates = isCodex
-    ? [codexGeneratedImagesDir]
+    ? [codexGeneratedImagesDir, ...(Array.isArray(adHocSkillDirs) ? adHocSkillDirs : [])]
     : [
         skillsDir,
         designSystemsDir,
         ...(Array.isArray(linkedDirs) ? linkedDirs : []),
+        ...(Array.isArray(adHocSkillDirs) ? adHocSkillDirs : []),
       ];
   return Array.from(
     new Set(
@@ -4067,7 +4158,7 @@ export async function startServer({
       // Strip full body + on-disk dir from the listing — frontend fetches the
       // body via /api/skills/:id when needed (keeps the listing payload small).
       res.json({
-        skills: skills.map(({ body, dir: _dir, ...rest }) => ({
+        skills: skills.map(({ body, dir: _dir, rawBody: _rawBody, ...rest }) => ({
           ...rest,
           hasBody: typeof body === 'string' && body.length > 0,
         })),
@@ -4082,7 +4173,7 @@ export async function startServer({
       const skills = await listSkills(SKILLS_DIR);
       const skill = findSkillById(skills, req.params.id);
       if (!skill) return res.status(404).json({ error: 'skill not found' });
-      const { dir: _dir, ...serializable } = skill;
+      const { dir: _dir, rawBody: _rawBody, ...serializable } = skill;
       res.json(serializable);
     } catch (err) {
       res.status(500).json({ error: String(err) });
@@ -7580,6 +7671,7 @@ export async function startServer({
     agentId,
     projectId,
     skillId,
+    skillIds,
     designSystemId,
     streamFormat,
     connectedExternalMcp,
@@ -7654,6 +7746,48 @@ export async function startServer({
         console.warn(
           `[plugins] pluginSkillBody load failed: ${err?.message ?? err}`,
         );
+      }
+    }
+
+    // Per-turn skills picked via the composer's @-mention popover. They
+    // never persist on the project — we just append their bodies after the
+    // primary skill so the agent sees one combined block this turn.
+    let adHocSkillDirs: Array<{ id: string; dir: string; alias: string }> = [];
+    if (Array.isArray(skillIds) && skillIds.length > 0) {
+      const allSkills = await listAllSkillLikeEntries();
+      const resolved = collectAdHocSkillDirs(skillIds, effectiveSkillId, allSkills);
+      adHocSkillDirs = resolveAdHocSkillsWithAliases(resolved);
+
+      const blocks = [];
+      const baseBody = skillBody && skillBody.trim().length > 0 ? skillBody : '';
+      for (const { id, dir, alias } of adHocSkillDirs) {
+        const extra = findSkillById(allSkills, id);
+        if (!extra) continue;
+        if (Array.isArray(extra.craftRequires)) {
+          for (const c of extra.craftRequires) {
+            if (!skillCraftRequires.includes(c)) skillCraftRequires.push(c);
+          }
+        }
+        const bodyWithAlias = withSkillRootPreamble(
+          extra.rawBody ?? extra.body,
+          dir,
+          alias,
+        );
+        blocks.push(
+          `\n\n---\n\n## Composed skill — ${extra.name || id}\n\n${bodyWithAlias.trim()}`
+        );
+      }
+      if (blocks.length > 0) {
+        skillBody = baseBody + blocks.join('');
+        if (!skillName) {
+          skillName = adHocSkillDirs.length === 1
+            ? findSkillById(allSkills, adHocSkillDirs[0].id)?.name ?? null
+            : 'composed';
+        }
+        // When no project skill is active, propagate the single ad-hoc skill's mode
+        if (!skillMode) {
+          skillMode = resolveAdHocSkillMode(adHocSkillDirs, allSkills);
+        }
       }
     }
 
@@ -7918,7 +8052,7 @@ export async function startServer({
     // `listSkills()` scan in `startChatRun`. critiqueShouldRun threads
     // the same panel-eligibility decision down to the spawn-path
     // orchestrator gate so prompt and orchestrator stay in lockstep.
-    return { prompt, activeSkillDir, critiqueShouldRun };
+    return { prompt, activeSkillDir, adHocSkillDirs, critiqueShouldRun };
   };
 
   // Plan §3.I1 / §3.D / spec §10.1: fire the pipeline schedule on a
@@ -8008,6 +8142,7 @@ export async function startServer({
       assistantMessageId,
       clientRequestId,
       skillId,
+      skillIds,
       designSystemId,
       attachments = [],
       commentAttachments = [],
@@ -8252,11 +8387,12 @@ export async function startServer({
       .filter((s) => typeof oauthTokensForSpawn[s.id] === 'string')
       .map((s) => ({ id: s.id, label: s.label }));
 
-    const { prompt: daemonSystemPrompt, activeSkillDir, critiqueShouldRun } =
+    const { prompt: daemonSystemPrompt, activeSkillDir, adHocSkillDirs, critiqueShouldRun } =
       await composeDaemonSystemPrompt({
         agentId,
         projectId,
         skillId,
+        skillIds,
         designSystemId,
         streamFormat: def?.streamFormat ?? 'plain',
         connectedExternalMcp,
@@ -8306,6 +8442,29 @@ export async function startServer({
         );
       }
     }
+    // Stage each ad-hoc (@-mention) skill directory so its side files
+    // (assets/, references/, example.html) are reachable via cwd-relative
+    // paths, just like the project-level activeSkillDir above. Each skill
+    // carries a collision-safe `alias` (computed by
+    // `resolveAdHocSkillsWithAliases`) that is already consistent with the
+    // preamble regenerated in `composeDaemonSystemPrompt`, so the relative
+    // path advertised to the agent matches the on-disk staged copy.
+    if (cwd && adHocSkillDirs.length > 0) {
+      for (const { dir, id, alias } of adHocSkillDirs) {
+        if (dir === activeSkillDir) continue;
+        const result = await stageActiveSkill(
+          cwd,
+          alias,
+          dir,
+          (msg) => console.warn(msg),
+        );
+        if (!result.staged) {
+          console.warn(
+            `[od] ad-hoc skill-stage skipped: ${result.reason ?? 'unknown reason'}; falling back to absolute paths`,
+          );
+        }
+      }
+    }
     // Resolve the agent's effective working directory once and use it
     // everywhere the agent could read it (buildArgs runtimeContext, spawn
     // cwd, ACP session new). Falling back to PROJECT_ROOT — rather than
@@ -8331,6 +8490,13 @@ export async function startServer({
       skillsDir: SKILLS_DIR,
       designSystemsDir: DESIGN_SYSTEMS_DIR,
       linkedDirs,
+      // Pass ad-hoc skill dirs through the dedicated channel so they
+      // remain reachable on Codex runs (whose branch in
+      // `resolveChatExtraAllowedDirs` drops `linkedDirs` entirely) and
+      // on projectless runs (where `cwd` is null, the stage loop above
+      // is skipped, and the agent must reach side files via absolute
+      // paths under `extraAllowedDirs`).
+      adHocSkillDirs: adHocSkillDirs.map((r) => r.dir),
       codexGeneratedImagesDir,
     });
     const codexImagegenOverride = resolveGrantedCodexImagegenOverride({

--- a/apps/daemon/src/skills.ts
+++ b/apps/daemon/src/skills.ts
@@ -88,7 +88,10 @@ export interface SkillInfo {
    * tiers (project override, env override, phase default) decide.
    */
   critiquePolicy: SkillCritiquePolicy;
+  /** Skill body with preamble already prepended (for direct consumption). */
   body: string;
+  /** Original SKILL.md content without preamble (for runtime alias rewrite). */
+  rawBody: string;
   dir: string;
 }
 
@@ -195,6 +198,7 @@ export async function listSkills(
             : "html";
         const description =
           typeof data.description === "string" ? data.description : "";
+        const rawBody = body;
         const parentBody = hasAttachments
           ? withSkillRootPreamble(body, dir)
           : body;
@@ -234,6 +238,7 @@ export async function listSkills(
           aggregatesExamples,
           critiquePolicy: normalizeCritiquePolicy(data.od?.critique?.policy),
           body: parentBody,
+          rawBody,
           dir,
         });
 
@@ -281,6 +286,7 @@ export async function listSkills(
             // the parent describes. Without this, picking a derived card
             // would compose an empty system prompt.
             body: parentBody,
+            rawBody,
             dir,
           });
         }
@@ -394,9 +400,13 @@ export function splitDerivedSkillId(id: unknown): DerivedSkillIdParts | null {
 //
 // Authoring guidance lives in the preamble itself so an agent can pick
 // the right form on its own without daemon-side feature detection.
-function withSkillRootPreamble(body: string, dir: string): string {
+export function withSkillRootPreamble(
+  body: string,
+  dir: string,
+  folderName?: string,
+): string {
   const referencedFiles = collectReferencedSideFiles(body);
-  const folder = path.basename(dir);
+  const folder = folderName ?? path.basename(dir);
   const skillRootRel = `${SKILLS_CWD_ALIAS}/${folder}`;
   const exampleFile = referencedFiles[0];
   const relativeGuidance = exampleFile

--- a/apps/daemon/src/static-resource-routes.ts
+++ b/apps/daemon/src/static-resource-routes.ts
@@ -72,7 +72,7 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
       // Strip full body + on-disk dir from the listing — frontend fetches the
       // body via /api/skills/:id when needed (keeps the listing payload small).
       res.json({
-        skills: skills.map(({ body, dir: _dir, ...rest }) => ({
+        skills: skills.map(({ body, dir: _dir, rawBody: _rawBody, ...rest }) => ({
           ...rest,
           hasBody: typeof body === 'string' && body.length > 0,
         })),
@@ -87,7 +87,7 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
       const skills = await listAllSkills();
       const skill = findSkillById(skills, req.params.id);
       if (!skill) return res.status(404).json({ error: 'skill not found' });
-      const { dir: _dir, ...serializable } = skill;
+      const { dir: _dir, rawBody: _rawBody, ...serializable } = skill;
       res.json(serializable);
     } catch (err: any) {
       res.status(500).json({ error: String(err) });
@@ -102,7 +102,7 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
     try {
       const templates = await listAllDesignTemplates();
       res.json({
-        designTemplates: templates.map(({ body, dir: _dir, ...rest }) => ({
+        designTemplates: templates.map(({ body, dir: _dir, rawBody: _rawBody, ...rest }) => ({
           ...rest,
           hasBody: typeof body === 'string' && body.length > 0,
         })),
@@ -117,7 +117,7 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
       const templates = await listAllDesignTemplates();
       const template = findSkillById(templates, req.params.id);
       if (!template) return res.status(404).json({ error: 'design template not found' });
-      const { dir: _dir, ...serializable } = template;
+      const { dir: _dir, rawBody: _rawBody, ...serializable } = template;
       res.json(serializable);
     } catch (err: any) {
       res.status(500).json({ error: String(err) });
@@ -140,7 +140,7 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
           'imported skill was not found in catalog',
         );
       }
-      const { dir: _dir, body: _body, ...serializable } = skill;
+      const { dir: _dir, body: _body, rawBody: _rawBody, ...serializable } = skill;
       res.status(201).json({
         skill: {
           ...serializable,
@@ -183,7 +183,7 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
           'updated skill was not found in catalog',
         );
       }
-      const { dir: _dir, body: _body, ...serializable } = updated;
+      const { dir: _dir, body: _body, rawBody: _rawBody, ...serializable } = updated;
       res.json({
         skill: {
           ...serializable,

--- a/apps/daemon/tests/skillids-side-files.test.ts
+++ b/apps/daemon/tests/skillids-side-files.test.ts
@@ -1,0 +1,486 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { findSkillById, listSkills, withSkillRootPreamble, type SkillInfo } from '../src/skills.js';
+import {
+  collectAdHocSkillDirs,
+  resolveAdHocSkillMode,
+  resolveAdHocSkillsWithAliases,
+  resolveChatExtraAllowedDirs,
+} from '../src/server.js';
+
+// Regression coverage for ad-hoc (@-mention) skills with side files.
+// PR #1636 restores skillIds processing and adds side-file staging.
+// These tests verify the full chain:
+//   skillIds → collectAdHocSkillDirs → resolved { id, dir } pairs → stage/allowlist
+
+let skillsRoot: string;
+
+function writeSkillWithSideFiles(
+  root: string,
+  folder: string,
+  body: string,
+  mode = 'prototype',
+): string {
+  const dir = path.join(root, folder);
+  mkdirSync(path.join(dir, 'assets'), { recursive: true });
+  mkdirSync(path.join(dir, 'references'), { recursive: true });
+  writeFileSync(
+    path.join(dir, 'SKILL.md'),
+    `---\nname: ${folder}\ndescription: test skill\nmode: ${mode}\n---\n\n${body}`,
+    'utf8',
+  );
+  writeFileSync(
+    path.join(dir, 'assets', 'template.html'),
+    '<html>template</html>',
+    'utf8',
+  );
+  writeFileSync(
+    path.join(dir, 'references', 'guide.md'),
+    '# guide',
+    'utf8',
+  );
+  return dir;
+}
+
+beforeAll(async () => {
+  skillsRoot = mkdtempSync(path.join(tmpdir(), 'od-skillids-sidefiles-'));
+  writeSkillWithSideFiles(skillsRoot, 'faq-page', '## FAQ Page workflow');
+  writeSkillWithSideFiles(skillsRoot, 'web-search', '## Web Search workflow');
+  writeSkillWithSideFiles(skillsRoot, 'image-gen', '## Image Gen workflow', 'image');
+});
+
+afterAll(() => {
+  if (skillsRoot) rmSync(skillsRoot, { recursive: true, force: true });
+});
+
+describe('collectAdHocSkillDirs', () => {
+  it('resolves skillIds to { id, dir } pairs', async () => {
+    const allSkills = await listSkills(skillsRoot);
+    const result = collectAdHocSkillDirs(
+      ['faq-page', 'web-search'],
+      null,
+      allSkills,
+    );
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      id: 'faq-page',
+      dir: path.join(skillsRoot, 'faq-page'),
+    });
+    expect(result[1]).toEqual({
+      id: 'web-search',
+      dir: path.join(skillsRoot, 'web-search'),
+    });
+  });
+
+  it('filters out the effectiveSkillId so project-level skill is not duplicated', async () => {
+    const allSkills = await listSkills(skillsRoot);
+    const result = collectAdHocSkillDirs(
+      ['faq-page', 'web-search'],
+      'faq-page', // project already has faq-page
+      allSkills,
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]!.id).toBe('web-search');
+  });
+
+  it('deduplicates repeated skill ids', async () => {
+    const allSkills = await listSkills(skillsRoot);
+    const result = collectAdHocSkillDirs(
+      ['faq-page', 'faq-page'],
+      null,
+      allSkills,
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]!.id).toBe('faq-page');
+  });
+
+  it('excludes skillIds whose resolved dir matches the active skill dir', async () => {
+    // Even if skillIds contains a different id (e.g. an alias) that
+    // resolves to the same on-disk directory as effectiveSkillId, it
+    // must be excluded because seenDir is seeded with the active skill's dir.
+    const allSkills = await listSkills(skillsRoot);
+    const result = collectAdHocSkillDirs(
+      ['faq-page', 'web-search'],
+      'faq-page', // active skill
+      allSkills,
+    );
+    // faq-page is excluded by id match; web-search is kept
+    expect(result).toHaveLength(1);
+    expect(result[0]!.id).toBe('web-search');
+    // Verify none of the results share a dir with the active skill
+    const activeSkill = findSkillById(allSkills, 'faq-page');
+    for (const r of result) {
+      expect(r.dir).not.toBe(activeSkill!.dir);
+    }
+  });
+
+  it('excludes alias id that resolves to the same dir as active skill', () => {
+    // Construct a scenario where 'faq-page-v2' is an alias pointing to
+    // the same on-disk directory as canonical 'faq-page'.
+    const faqDir = path.join(skillsRoot, 'faq-page');
+    const mockSkills: SkillInfo[] = [
+      {
+        id: 'faq-page',
+        name: 'FAQ Page',
+        description: '',
+        triggers: [],
+        mode: 'prototype',
+        surface: 'web',
+        source: 'built-in',
+        craftRequires: [],
+        platform: null,
+        scenario: '',
+        category: null,
+        previewType: '',
+        designSystemRequired: false,
+        defaultFor: [],
+        upstream: null,
+        featured: null,
+        fidelity: null,
+        speakerNotes: null,
+        animations: null,
+        examplePrompt: '',
+        aggregatesExamples: false,
+        critiquePolicy: null,
+        body: '## FAQ',
+        rawBody: '## FAQ',
+        dir: faqDir,
+      },
+      {
+        id: 'faq-page-v2',
+        name: 'FAQ Page V2',
+        description: '',
+        triggers: [],
+        mode: 'prototype',
+        surface: 'web',
+        source: 'built-in',
+        craftRequires: [],
+        platform: null,
+        scenario: '',
+        category: null,
+        previewType: '',
+        designSystemRequired: false,
+        defaultFor: [],
+        upstream: null,
+        featured: null,
+        fidelity: null,
+        speakerNotes: null,
+        animations: null,
+        examplePrompt: '',
+        aggregatesExamples: false,
+        critiquePolicy: null,
+        body: '## FAQ V2',
+        rawBody: '## FAQ V2',
+        dir: faqDir, // same dir as canonical
+      },
+    ];
+
+    // Active skill is canonical 'faq-page'; skillIds has alias 'faq-page-v2'
+    const result = collectAdHocSkillDirs(
+      ['faq-page-v2'],
+      'faq-page',
+      mockSkills,
+    );
+    // The alias resolves to the same dir → excluded by seenDir seed
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns empty array for empty/invalid input', async () => {
+    const allSkills = await listSkills(skillsRoot);
+    expect(collectAdHocSkillDirs([], null, allSkills)).toEqual([]);
+    expect(collectAdHocSkillDirs(null, null, allSkills)).toEqual([]);
+    expect(collectAdHocSkillDirs(undefined, null, allSkills)).toEqual([]);
+  });
+
+  it('skips unknown skill ids', async () => {
+    const allSkills = await listSkills(skillsRoot);
+    const result = collectAdHocSkillDirs(
+      ['faq-page', 'nonexistent-skill'],
+      null,
+      allSkills,
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]!.id).toBe('faq-page');
+  });
+});
+
+// Regression: when no project skill is active, a single ad-hoc @-mention
+// skill's mode must be propagated to skillMode so that composeDaemonSystemPrompt
+// passes it to composeSystemPrompt (deck framework injection, isMediaSurface, etc.).
+describe('resolveAdHocSkillMode', () => {
+  it('returns mode for a single ad-hoc skill with no project skill', async () => {
+    const allSkills = await listSkills(skillsRoot);
+    const resolved = collectAdHocSkillDirs(['image-gen'], null, allSkills);
+    expect(resolved).toHaveLength(1);
+
+    const mode = resolveAdHocSkillMode(resolved, allSkills);
+    expect(mode).toBe('image');
+  });
+
+  it('returns undefined for multiple ad-hoc skills', async () => {
+    const allSkills = await listSkills(skillsRoot);
+    const resolved = collectAdHocSkillDirs(
+      ['faq-page', 'image-gen'],
+      null,
+      allSkills,
+    );
+    expect(resolved).toHaveLength(2);
+
+    const mode = resolveAdHocSkillMode(resolved, allSkills);
+    expect(mode).toBeUndefined();
+  });
+
+  it('returns undefined for empty resolved list', async () => {
+    const allSkills = await listSkills(skillsRoot);
+    const mode = resolveAdHocSkillMode([], allSkills);
+    expect(mode).toBeUndefined();
+  });
+});
+
+// Regression: ad-hoc skill side files must reach Codex runs (whose
+// `resolveChatExtraAllowedDirs` branch drops `linkedDirs` entirely)
+// and projectless runs (where the cwd-relative stage step is skipped),
+// or `@`-mentioning a skill on Codex / without a project would render
+// its assets/references/example.html unreadable. PR follow-up.
+describe('resolveChatExtraAllowedDirs ad-hoc skill bypass', () => {
+  it('includes ad-hoc skill dirs in the Codex allow-list even though linkedDirs is dropped', () => {
+    const dirs = resolveChatExtraAllowedDirs({
+      agentId: 'codex',
+      skillsDir: skillsRoot,
+      designSystemsDir: skillsRoot,
+      linkedDirs: [skillsRoot],
+      adHocSkillDirs: [path.join(skillsRoot, 'image-gen')],
+      codexGeneratedImagesDir: null,
+      existsSync: () => true,
+    });
+    // Codex branch drops skillsDir / designSystemsDir / linkedDirs.
+    expect(dirs).not.toContain(skillsRoot);
+    // ...but ad-hoc skill dirs survive because the user explicitly @-mentioned them.
+    expect(dirs).toContain(path.join(skillsRoot, 'image-gen'));
+  });
+
+  it('still includes ad-hoc skill dirs on non-Codex agents alongside skillsDir / linkedDirs', () => {
+    const adHoc = path.join(skillsRoot, 'image-gen');
+    const dirs = resolveChatExtraAllowedDirs({
+      agentId: 'claude',
+      skillsDir: skillsRoot,
+      designSystemsDir: null,
+      linkedDirs: [],
+      adHocSkillDirs: [adHoc],
+      codexGeneratedImagesDir: null,
+      existsSync: () => true,
+    });
+    expect(dirs).toContain(skillsRoot);
+    expect(dirs).toContain(adHoc);
+  });
+
+  it('dedupes ad-hoc skill dirs that also appear in linkedDirs', () => {
+    const adHoc = path.join(skillsRoot, 'image-gen');
+    const dirs = resolveChatExtraAllowedDirs({
+      agentId: 'claude',
+      skillsDir: null,
+      designSystemsDir: null,
+      linkedDirs: [adHoc],
+      adHocSkillDirs: [adHoc],
+      codexGeneratedImagesDir: null,
+      existsSync: () => true,
+    });
+    expect(dirs.filter((d) => d === adHoc)).toHaveLength(1);
+  });
+});
+
+// Alias allocation: when two ad-hoc skills resolve to dirs with the same
+// basename (e.g. bundled skills/foo and user .od/skills/foo),
+// `resolveAdHocSkillsWithAliases` must assign collision-safe aliases so
+// each skill gets its own `.od-skills/<alias>/` slot and the regenerated
+// preamble points the agent at the correct copy.
+describe('resolveAdHocSkillsWithAliases', () => {
+  it('assigns a deterministic hash suffix to every ad-hoc skill', () => {
+    const resolved = [
+      { id: 'faq-page', dir: '/skills/faq-page' },
+      { id: 'web-search', dir: '/skills/web-search' },
+    ];
+    const result = resolveAdHocSkillsWithAliases(resolved);
+    expect(result).toHaveLength(2);
+    // md5('/skills/faq-page').slice(0,7) === '328f4be'
+    expect(result[0]!.alias).toBe('faq-page-328f4be');
+    // md5('/skills/web-search').slice(0,7) === 'c97ffac'
+    expect(result[1]!.alias).toBe('web-search-c97ffac');
+  });
+
+  it('gives different hash suffixes for skills that share a basename', () => {
+    const resolved = [
+      { id: 'image-gen', dir: '/built-in/image-gen' },
+      { id: 'image-gen', dir: '/user/image-gen' },
+    ];
+    const result = resolveAdHocSkillsWithAliases(resolved);
+    expect(result).toHaveLength(2);
+    // md5('/built-in/image-gen').slice(0,7) === 'f1316f2'
+    expect(result[0]!.alias).toBe('image-gen-f1316f2');
+    // md5('/user/image-gen').slice(0,7) === '7f22aee'
+    expect(result[1]!.alias).toBe('image-gen-7f22aee');
+  });
+
+  it('gives unique hash suffixes for three skills that share a basename', () => {
+    const resolved = [
+      { id: 'a', dir: '/r1/foo' },
+      { id: 'b', dir: '/r2/foo' },
+      { id: 'c', dir: '/r3/foo' },
+    ];
+    const result = resolveAdHocSkillsWithAliases(resolved);
+    expect(result.map((r) => r.alias)).toEqual([
+      'foo-7c0509e',
+      'foo-149ac81',
+      'foo-0af723d',
+    ]);
+  });
+
+  it('is deterministic regardless of input order', () => {
+    const resolvedA = [
+      { id: 'a', dir: '/r1/foo' },
+      { id: 'b', dir: '/r2/foo' },
+    ];
+    const resolvedB = [
+      { id: 'b', dir: '/r2/foo' },
+      { id: 'a', dir: '/r1/foo' },
+    ];
+    const resultA = resolveAdHocSkillsWithAliases(resolvedA);
+    const resultB = resolveAdHocSkillsWithAliases(resolvedB);
+    // Each dir must map to the same alias no matter the input order
+    const getAlias = (dir: string, result: typeof resultA) =>
+      result.find((r) => r.dir === dir)!.alias;
+    expect(getAlias('/r1/foo', resultA)).toBe(getAlias('/r1/foo', resultB));
+    expect(getAlias('/r2/foo', resultA)).toBe(getAlias('/r2/foo', resultB));
+  });
+
+  it('ignores active skill dir (all ad-hoc skills always get a hash suffix)', () => {
+    const resolved = [{ id: 'my-skill', dir: '/user/my-skill' }];
+    const result = resolveAdHocSkillsWithAliases(resolved);
+    // md5('/user/my-skill').slice(0,7) === '7a849c9'
+    expect(result[0]!.alias).toBe('my-skill-7a849c9');
+  });
+
+  it('gives hash suffix even when there is no active skill collision', () => {
+    const resolved = [{ id: 'other', dir: '/skills/other' }];
+    const result = resolveAdHocSkillsWithAliases(resolved);
+    // md5('/skills/other').slice(0,7) === '37bc38e'
+    expect(result[0]!.alias).toBe('other-37bc38e');
+  });
+});
+
+// Regression: two distinct skill dirs that share a basename must both
+// survive resolution so the alias allocator has something to work with.
+describe('collectAdHocSkillDirs basename collisions', () => {
+  it('keeps two distinct skill dirs that share a basename', async () => {
+    const altRoot = mkdtempSync(path.join(tmpdir(), 'od-skillids-collide-'));
+    try {
+      writeSkillWithSideFiles(altRoot, 'image-gen', '## Alt Image Gen');
+      const allSkills: SkillInfo[] = [
+        ...(await listSkills(skillsRoot)),
+        ...(await listSkills(altRoot)),
+      ];
+      const imageGenDirs = allSkills.filter((s) => s.id === 'image-gen').map((s) => s.dir);
+      expect(new Set(imageGenDirs).size).toBeGreaterThanOrEqual(2);
+      for (const dir of imageGenDirs) {
+        expect(path.basename(dir)).toBe('image-gen');
+      }
+    } finally {
+      rmSync(altRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('withSkillRootPreamble alias propagation', () => {
+  it('embeds the provided alias into the relative path guidance', () => {
+    const body = '## Test workflow\nOpen `assets/template.html`.';
+    const dir = '/skills/my-skill';
+    const result = withSkillRootPreamble(body, dir, 'my-skill-2');
+    expect(result).toContain('.od-skills/my-skill-2/');
+    expect(result).not.toContain('.od-skills/my-skill/');
+  });
+
+  it('falls back to basename when no alias is provided', () => {
+    const body = '## Test workflow';
+    const dir = '/skills/my-skill';
+    const result = withSkillRootPreamble(body, dir);
+    expect(result).toContain('.od-skills/my-skill/');
+  });
+});
+
+describe('ad-hoc skill side files on disk', () => {
+  it('each resolved dir contains the expected side files', async () => {
+    const allSkills = await listSkills(skillsRoot);
+    const result = collectAdHocSkillDirs(['faq-page'], null, allSkills);
+    expect(result).toHaveLength(1);
+    const { existsSync } = await import('node:fs');
+    const dir = result[0]!.dir;
+    expect(existsSync(path.join(dir, 'assets', 'template.html'))).toBe(true);
+    expect(existsSync(path.join(dir, 'references', 'guide.md'))).toBe(true);
+  });
+});
+
+describe('resolveChatExtraAllowedDirs with ad-hoc skill dirs', () => {
+  it('includes ad-hoc skill dirs for non-Codex agents', async () => {
+    const allSkills = await listSkills(skillsRoot);
+    const resolved = collectAdHocSkillDirs(
+      ['faq-page', 'web-search'],
+      null,
+      allSkills,
+    );
+    const dirs = resolved.map((r) => r.dir);
+
+    const extraAllowed = resolveChatExtraAllowedDirs({
+      agentId: 'claude',
+      skillsDir: skillsRoot,
+      designSystemsDir: null,
+      linkedDirs: dirs,
+      codexGeneratedImagesDir: null,
+      existsSync: () => true,
+    });
+
+    expect(extraAllowed).toContain(path.join(skillsRoot, 'faq-page'));
+    expect(extraAllowed).toContain(path.join(skillsRoot, 'web-search'));
+  });
+
+  it('deduplicates dirs in allowlist', async () => {
+    const allSkills = await listSkills(skillsRoot);
+    const resolved = collectAdHocSkillDirs(['faq-page'], null, allSkills);
+    const dirs = resolved.map((r) => r.dir);
+
+    // Pass the same dir twice — should appear once in the result
+    const extraAllowed = resolveChatExtraAllowedDirs({
+      agentId: 'claude',
+      skillsDir: skillsRoot,
+      designSystemsDir: null,
+      linkedDirs: [...dirs, ...dirs],
+      codexGeneratedImagesDir: null,
+      existsSync: () => true,
+    });
+
+    const count = extraAllowed.filter(
+      (d) => d === path.join(skillsRoot, 'faq-page'),
+    ).length;
+    expect(count).toBe(1);
+  });
+
+  it('does not include ad-hoc dirs for Codex agents', async () => {
+    const allSkills = await listSkills(skillsRoot);
+    const resolved = collectAdHocSkillDirs(['faq-page'], null, allSkills);
+    const dirs = resolved.map((r) => r.dir);
+
+    const extraAllowed = resolveChatExtraAllowedDirs({
+      agentId: 'codex',
+      skillsDir: skillsRoot,
+      designSystemsDir: null,
+      linkedDirs: dirs,
+      codexGeneratedImagesDir: '/tmp/codex-images',
+      existsSync: () => true,
+    });
+
+    expect(extraAllowed).not.toContain(path.join(skillsRoot, 'faq-page'));
+    expect(extraAllowed).toContain('/tmp/codex-images');
+  });
+});


### PR DESCRIPTION
Fixes #1635

## Why

The @-mention skill composition feature is completely non-functional. This is a regression introduced during the PR #955 squash merge, where the `skillIds` processing logic was accidentally deleted during conflict resolution.

**Use case**: Users want to compose multiple skills per turn (e.g., `@faq-page` + `@web-search`) without binding the project to one of them. This is a core feature of the skills system.

**Pain**: The frontend correctly sends `skillIds`, but the daemon discards them. Users see the skill chip in the composer, but the skill has zero effect on the output. This affects all @-mention functionality across all projects and tabs.

## What users will see

- **Before fix**: User selects a skill via `@` popover, sees the chip, sends a message — but the LLM ignores the skill entirely and builds from scratch
- **After fix**: The selected skill's workflow is injected into the system prompt, and the LLM follows it exactly (e.g., `@faq-page` generates a complete FAQ page with search, category filters, accordion, and footer CTA)

No UI changes — the fix is entirely in the daemon's prompt composition logic.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No UI changes — the fix is in daemon prompt composition logic.

## Bug fix verification

- **Test path that reproduces the bug**: Create project with "Other" tab → type `@faq-page fire effect` → send message → observe LLM ignores skill workflow
- **Did the test go red on `main` and green on this branch?** Yes
- **Verification method**: Tested with `@faq-page` skill on "Other" tab project (no project-level skill). Before fix: LLM builds from scratch, missing category filters. After fix: LLM follows skill workflow, generates complete HTML with all required features.

## Validation

- `pnpm guard` — passed
- `pnpm --filter @open-design/daemon typecheck` — passed
- Manual verification: tested `@faq-page` skill on "Other" tab project — without fix, LLM ignores skill workflow; with fix, LLM follows skill workflow and generates complete FAQ page with search, category filters, accordion, and footer CTA

