### PR TITLE
fix: Restore @-mention skill composition (regression from PR #955)

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -3108,6 +3108,7 @@ export async function startServer({
     agentId,
     projectId,
     skillId,
+    skillIds,
     designSystemId,
     streamFormat,
     connectedExternalMcp,
@@ -3150,6 +3151,34 @@ export async function startServer({
         skillCritiquePolicy = skill.critiquePolicy;
         if (Array.isArray(skill.craftRequires))
           skillCraftRequires = skill.craftRequires;
+      }
+    }
+
+    // Ad-hoc @-mention skill composition. When the user selects skills via
+    // the @ popover, the frontend sends skillIds[] and we concatenate their
+    // bodies into the system prompt. This runs after the project-level skill
+    // so @-mention skills augment (not replace) the project's base workflow.
+    if (Array.isArray(skillIds) && skillIds.length > 0) {
+      const allSkills = await listAllSkillLikeEntries();
+      const mentionedSkills = skillIds
+        .map((id) => findSkillById(allSkills, id))
+        .filter(Boolean);
+      if (mentionedSkills.length > 0) {
+        const mentionedBodies = mentionedSkills.map((s) => s.body).join('\n\n');
+        if (skillBody) {
+          // Project has a skill + user @-mentioned additional skills.
+          // Concatenate so both are active.
+          skillBody = `${skillBody}\n\n${mentionedBodies}`;
+        } else {
+          // No project skill, only @-mentioned skills.
+          skillBody = mentionedBodies;
+        }
+        // Merge craftRequires from all @-mentioned skills.
+        for (const s of mentionedSkills) {
+          if (Array.isArray(s.craftRequires)) {
+            skillCraftRequires.push(...s.craftRequires);
+          }
+        }
       }
     }
 
@@ -3383,6 +3412,7 @@ export async function startServer({
       assistantMessageId,
       clientRequestId,
       skillId,
+      skillIds,
       designSystemId,
       attachments = [],
       commentAttachments = [],
@@ -3616,6 +3646,7 @@ export async function startServer({
         agentId,
         projectId,
         skillId,
+        skillIds,
         designSystemId,
         streamFormat: def?.streamFormat ?? 'plain',
         connectedExternalMcp,


### PR DESCRIPTION
Fixes #1635

## Why

**Use case:** While testing the @-mention skill composition feature in Open Design, I discovered it was completely non-functional. Users could select skills via the `@` popover, see the skill chip in the composer, but the LLM completely ignored the skill workflow and generated output independently.

**Pain being addressed:** This is a **critical regression** introduced in PR #955 (commit `b5eb8c16`). During the squash merge conflict resolution when adding `connectedExternalMcp` to `composeDaemonSystemPrompt`, the `skillIds` parameter and its ~30 lines of processing logic were accidentally deleted. This broke a core feature that allows users to compose multiple skills per message — affecting all projects, all tabs, all skills, and all agents.

## What users will see

**Before this fix:**
- User types `@` in chat composer and selects a skill (e.g., `@faq-page`)
- Skill chip appears in the composer
- User sends message
- ❌ LLM ignores the skill and builds from scratch (missing workflow steps, category filters, etc.)

**After this fix:**
- User types `@` in chat composer and selects a skill (e.g., `@faq-page`)
- Skill chip appears in the composer
- User sends message
- ✅ LLM follows the skill workflow and generates complete output with all required features

The fix is transparent — no UI changes, no new settings. The @-mention feature simply works as originally designed.

## Surface area

- [x] **API / contract** — restored `skillIds` parameter processing in `/api/chat` endpoint
- [ ] **UI** — no UI changes
- [ ] **Keyboard shortcut** — no changes
- [ ] **CLI / env var** — no changes
- [ ] **Extension point** — no changes
- [ ] **i18n keys** — no changes
- [ ] **New top-level dependency** — no changes
- [ ] **Default behavior change** — restores original behavior (fix, not change)
- [ ] **None** — not applicable (this is a functional fix)

## Screenshots

N/A — This is a backend fix with no UI changes. The @-mention UI already worked correctly; only the backend processing was broken.

## Bug fix verification

**Test reproduction:**
- Manual verification with `@faq-page` skill on an "Other" tab project (no project-level skill)
- **Before fix:** LLM built FAQ page from scratch, missing category filters, search functionality, and accordion structure defined in the skill
- **After fix:** LLM followed faq-page skill workflow, generated complete HTML with search, category filters, accordion, and footer CTA

**Why no automated test:**
- This bug requires end-to-end testing with actual LLM calls and skill loading
- The fix restores deleted code that was previously working and tested
- Manual verification confirms the skill content is now injected into the system prompt

## Validation

- [x] Code review: verified all 4 changes are present (destructuring, function signature, processing logic, function call)
- [x] Manual testing: tested @-mention with `@faq-page` skill — LLM now follows skill workflow
- [x] Regression check: verified project-level skills still work (not affected by this change)
- [x] Edge cases: tested empty skillIds, null skillIds, project skill + @-mention skills (concatenation)
- [x] Code inspection: confirmed `skillIds` flows through entire pipeline (frontend → contract → backend → system prompt)

**Commands run:**
- Manual code review of all 4 change locations
- End-to-end testing with actual skill composition
- Verified no TypeScript errors in modified file

## Technical details

### Changes made

1. **Line 3386**: Added `skillIds` to chatBody destructuring
2. **Line 3111**: Added `skillIds` to `composeDaemonSystemPrompt` function signature  
3. **Lines 3157-3183**: Added ad-hoc skill composition logic (28 lines)
   - Loads skills by ID from `listAllSkillLikeEntries()`
   - Concatenates skill bodies with `\n\n`
   - Merges with project skill (if present) or replaces it (if absent)
   - Merges `craftRequires` from all @-mentioned skills
4. **Line 3649**: Passed `skillIds` to function call

### How it works

1. User selects skill via `@` popover → Frontend sends `skillIds: ['faq-page']`
2. Backend receives `skillIds` in `ChatRequest`
3. `composeDaemonSystemPrompt` loads each skill by ID
4. Skill bodies are concatenated and injected into system prompt
5. LLM receives skill instructions and follows the workflow

### Regression timeline

```
commit 6c23cf7b — "feat: general-purpose skills with @-mention composition"
  ├── Frontend: ChatComposer.tsx sends skillIds ✅
  ├── Contract: ChatRequest.skillIds defined ✅
  └── Backend: server.ts processes skillIds ✅
         ↓
PR #955 squash merge — commit b5eb8c16
  ├── Frontend: preserved ✅
  ├── Contract: preserved ✅
  └── Backend: skillIds removed during conflict resolution ❌
         ↓
This PR — restores deleted code
  └── Backend: skillIds processing restored ✅
```