### PR TITLE
feat(design-systems): add structured tokens for cursor, apple, stripe, airbnb, vercel brands

### DIFF
--- a/design-systems/airbnb/components.html
+++ b/design-systems/airbnb/components.html
@@ -1,0 +1,1373 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Airbnb — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/airbnb. Every visible
+        value comes from tokens.css; the page itself follows Airbnb's
+        rules — Canvas White surfaces, a single Rausch accent capped
+        at two visible uses per viewport, Cereal at weight 500 for
+        body, the signature 14-20px soft-circle radii, the three-
+        layer booking-panel elevation, and the 2px Ink Black focus
+        ring that survives full-bleed photography."
+    />
+
+    <style>
+      /* :root paste — sourced verbatim from design-systems/airbnb/tokens.css. */
+      :root {
+        /* ─── Surface (3 levels) ────────────────────────────────────────
+         * Canvas White is both the page and the card — Airbnb refuses a
+         * tonal shift between the two. Cards earn their edges from the
+         * Hairline Gray border and from full-bleed photography. The
+         * tertiary tier (--surface-warm) is Soft Cloud, used only for
+         * footer backgrounds, map-view wrappers, and middle-of-range
+         * date cells in the date picker. */
+        --bg: #ffffff;
+        --surface: #ffffff;
+        --surface-warm: #f7f7f7;
+
+        /* ─── Foreground ramp (4 levels) ────────────────────────────────
+         * Ink Black (#222222) carries roughly ninety percent of every
+         * page — every heading, every body paragraph, every nav label,
+         * every price. The brand's near-black is never true #000000.
+         * Charcoal (--fg-2) is a one-step-down emphasis tier reserved
+         * for focused-input text. Ash Gray (--muted) is the secondary
+         * label — "Cottage rentals" subtitles, muted footer links.
+         * Mute Gray (--meta) is reserved for disabled buttons and
+         * low-priority metadata. */
+        --fg: #222222;
+        --fg-2: #3f3f3f;
+        --muted: #6a6a6a;
+        --meta: #929292;
+
+        /* ─── Border (2 levels) ─────────────────────────────────────────
+         * Hairline Gray (#dddddd) is the workhorse — every card-to-card
+         * divider, every amenity-row separator, every footer-column
+         * rule. The soft tier is a lighter hairline used to break up
+         * dense list interiors without competing with the primary card
+         * edge. */
+        --border: #dddddd;
+        --border-soft: #ebebeb;
+
+        /* ─── Accent ────────────────────────────────────────────────────
+         * Rausch coral-pink — the single signature color. Reserve for
+         * primary CTAs (Reserve, Search, Add dates), the active-tab
+         * underline, the wishlist heart fill, and price emphasis. Hard
+         * cap of two visible uses per viewport; if a third Rausch
+         * element shows up, neutralize one. Plus Magenta (#92174d) and
+         * Luxe Purple (#460479) are kept inline at their product-tier
+         * surfaces, not promoted to shared accent slots. */
+        --accent: #ff385c;
+        --accent-on: #ffffff;
+        --accent-hover: #e31c5f;       /* hand-picked, between Rausch and Deep Rausch */
+        --accent-active: #e00b41;      /* Deep Rausch — DESIGN.md §2 pressed-state value */
+
+        /* ─── Semantic ──────────────────────────────────────────────────
+         * Error Red is explicit from DESIGN.md §2; success and warn are
+         * not specified by the brand and are bound to desaturated values
+         * that survive the white canvas without competing with Rausch.
+         * Keep total semantic-color pixels well under five percent of
+         * any page — the brand almost never renders status. */
+        --success: #008a05;            /* hand-picked warm green — available/in-stock */
+        --warn: #c47700;               /* burnt amber — never tailwind yellow */
+        --danger: #c13515;             /* DESIGN.md §2 Error Red */
+
+        /* ─── Typography — fonts ────────────────────────────────────────
+         * Airbnb Cereal VF is the proprietary face that carries every
+         * label from 8px superscript to 28px section heading. The
+         * documented fallback chain renders acceptably on macOS/iOS
+         * where system-ui resolves to San Francisco. Display and body
+         * share the same stack — the visual identity comes from the
+         * family itself, never from typeface mixing. Mono is a generic
+         * stack for kbd, tabular metrics, and the rare code label. */
+        --font-display:
+          "Airbnb Cereal VF", "Airbnb Cereal App", Circular,
+          -apple-system, system-ui, "Helvetica Neue", Roboto, sans-serif;
+        --font-body:
+          "Airbnb Cereal VF", "Airbnb Cereal App", Circular,
+          -apple-system, system-ui, "Helvetica Neue", Roboto, sans-serif;
+        --font-mono:
+          ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Monaco,
+          Consolas, monospace;
+
+        /* ─── Typography — type scale (px) ──────────────────────────────
+         * Derived from DESIGN.md §3 Hierarchy table. The system clusters
+         * tightly between 11 and 22px (the conversational range) and
+         * jumps to 28px for section headings; the higher tiers are used
+         * sparingly for the Guest Favorite rating lockup (44–56px) and
+         * the rare hero numeral. No 400-regular: Cereal's body weight
+         * is 500, which any consuming component should set explicitly. */
+        --text-xs: 12px;               /* micro / footer disclaimer */
+        --text-sm: 14px;               /* button default, link, caption */
+        --text-base: 16px;             /* body medium, button large, subtitle bold */
+        --text-lg: 20px;               /* listing title */
+        --text-xl: 22px;               /* subsection heading */
+        --text-2xl: 28px;              /* section heading */
+        --text-3xl: 44px;              /* Guest Favorite rating, hero numeral */
+        --text-4xl: 56px;              /* display ceiling — Guest Favorite max */
+
+        /* ─── Typography — leading & tracking ───────────────────────────
+         * Tight for display (1.20 — chiseled headlines), generous for
+         * body (1.43 — magazine reading comfort). Display tracking
+         * compresses negatively at sizes ≥20px; body and caption hold
+         * at zero. The two-mode rhythm is what gives Airbnb pages
+         * their travel-magazine feel rather than a utility-app feel. */
+        --leading-body: 1.43;
+        --leading-tight: 1.2;
+        --tracking-display: -0.02em;   /* applied at sizes ≥20px only */
+
+        /* ─── Spacing — base scale ──────────────────────────────────────
+         * 8px base unit per DESIGN.md §5. The brand uses fine-grained
+         * off-grid values (5.5, 10, 11, 18.5, 22) for pixel-perfect
+         * icon alignment, but the shared scale stays on the standard
+         * 4px grid — off-grid spacing belongs inline at the component
+         * level, not in shared tokens. */
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+
+        /* ─── Section rhythm ────────────────────────────────────────────
+         * Section padding ranges 48–64px on desktop, 24–32px on mobile
+         * per DESIGN.md §5. We bind the upper bound on desktop because
+         * Airbnb's content-dense pages benefit from generous breathing
+         * room between content blocks; the lower phone bound keeps the
+         * vertical rhythm tight on small screens. */
+        --section-y-desktop: 64px;
+        --section-y-tablet: 48px;
+        --section-y-phone: 32px;
+
+        /* ─── Radius ────────────────────────────────────────────────────
+         * The brand's signature soft-circle geometry. 14px (--radius-md)
+         * is the workhorse — every listing card photograph, every
+         * amenity badge, every generic content container lands here.
+         * 20px (--radius-lg) is reserved for the booking panel and hero
+         * photo frames; 8px (--radius-sm) is the small radius for
+         * buttons, dropdowns, and inputs; --radius-pill (9999px) is the
+         * system's signature round geometry, applied to every circular
+         * icon button, every avatar, and the wishlist heart. */
+        --radius-sm: 8px;
+        --radius-md: 14px;
+        --radius-lg: 20px;
+        --radius-pill: 9999px;
+
+        /* ─── Elevation ─────────────────────────────────────────────────
+         * Airbnb forbids single drop shadows; the system uses stacked
+         * layered shadows or no shadow at all. Listing cards sit flat
+         * on the canvas. Booking panels, modals, and dropdowns use the
+         * signature three-layer stack — a 2% hairline ring, a 4% short
+         * blur, and a 10% medium blur — which reads as one cohesive
+         * lift while giving the perimeter a premium anti-aliased edge. */
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised:
+          rgba(0, 0, 0, 0.02) 0 0 0 1px,
+          rgba(0, 0, 0, 0.04) 0 2px 6px 0,
+          rgba(0, 0, 0, 0.1) 0 4px 8px 0;
+
+        /* ─── Focus ring ────────────────────────────────────────────────
+         * 2px solid Ink Black, NOT the schema's accent-tinted default.
+         * DESIGN.md §6 mandates this exact treatment so focus indicators
+         * read cleanly against full-bleed colorful photography — a
+         * Rausch-tinted ring would disappear against warm sunset shots
+         * or sea-blue beach overlays. Pair with a 4px white separator
+         * ring at circular-icon buttons that float on images. */
+        --focus-ring: 0 0 0 2px var(--fg);
+
+        /* ─── Motion ────────────────────────────────────────────────────
+         * DESIGN.md did not capture transition timings (static
+         * extraction scope). We bind defaults consistent with the
+         * brand's tactile feel: 150ms for micro-states (the famous
+         * `transform: scale(0.92)` pressed-button rebound) and 200ms
+         * for general state changes. Standard easing is the schema
+         * default — short, purposeful, no overshoot. */
+        --motion-fast: 150ms;
+        --motion-base: 200ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+        /* ─── Layout ────────────────────────────────────────────────────
+         * Detail pages cap at 1280px per DESIGN.md §5; the homepage
+         * listing grid lets the canvas breathe to 1760–1920px on
+         * ultra-wide. We bind the detail-page width as the shared
+         * default because that is the geometry agents will most often
+         * generate (rooms, experiences, host profiles). Gutters
+         * tighten progressively: 40px desktop, 24px tablet, 16px
+         * phone per DESIGN.md §8 small-mobile clause. */
+        --container-max: 1280px;
+        --container-gutter-desktop: 40px;
+        --container-gutter-tablet: 24px;
+        --container-gutter-phone: 16px;
+      }
+
+      /* ─── Reset (minimal) ───────────────────────────────────────── */
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        font-weight: 500; /* Cereal's body weight — DESIGN.md §3 */
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+      }
+
+      /* ─── Layout primitives ─────────────────────────────────────── */
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section {
+        padding-block: var(--section-y-desktop);
+      }
+      section + section {
+        border-top: 1px solid var(--border);
+      }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography ─────────────────────────────────────────────
+       * Display sizes ≥20px compress tracking negatively per
+       * DESIGN.md §3 ("Negative tracking on display type only").
+       * Body and caption sizes hold at zero tracking for
+       * readability. Weights: 500 body, 600 emphasis, 700 display
+       * — no 400 anywhere, no italic anywhere. */
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        line-height: var(--leading-tight);
+        margin: 0;
+      }
+      h1 {
+        font-size: var(--text-2xl);
+        font-weight: 700;
+        letter-spacing: var(--tracking-display);
+      }
+      h2 {
+        font-size: var(--text-xl);
+        font-weight: 500;
+        /* 22px Subsection Heading: line-height 1.18 per DESIGN.md §Typography.
+           Overrides the shared 1.20 (--leading-tight) set on h1/h2/h3 above. */
+        line-height: 1.18;
+        letter-spacing: var(--tracking-display);
+      }
+      h3 {
+        font-size: var(--text-base);
+        font-weight: 600;
+        /* 16px Subtitle/Body size: line-height 1.25 per DESIGN.md §Typography.
+           Overrides the shared 1.20 (--leading-tight) set on h1/h2/h3 above. */
+        line-height: 1.25;
+      }
+      p { margin: 0; }
+
+      .lede {
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        color: var(--fg);
+      }
+      .body-muted { color: var(--muted); }
+      .body-meta { color: var(--meta); font-size: var(--text-sm); }
+      .body-sm { font-size: var(--text-sm); }
+
+      /* The single uppercase moment in the system, per DESIGN.md §3
+       * Principles ("No all-caps except at 8px"). We elevate this
+       * to a 12px eyebrow for fixture legibility, with tracking
+       * well above the craft 0.06em floor. Used once per section. */
+      .eyebrow {
+        font-family: var(--font-display);
+        font-size: var(--text-xs);
+        font-weight: 700;
+        line-height: 1.33;
+        color: var(--fg);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+
+      .stack-2 > * + * { margin-block-start: var(--space-2); }
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+
+      /* ─── Buttons ────────────────────────────────────────────────
+       * Primary CTA is filled Rausch on Canvas White text. Active/
+       * pressed uses Deep Rausch as the published brand value
+       * (DESIGN.md §4 Primary CTA) combined with the famous
+       * `transform: scale(0.92)` rebound that gives the brand its
+       * tactile feel. Secondary is a Hairline Gray outlined pill
+       * over the canvas. Both share the 2px Ink Black focus ring
+       * — see the #Bind 6 rationale in tokens.css. */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: var(--space-2);
+        padding: 14px 24px;
+        border: 1px solid transparent;
+        border-radius: var(--radius-sm);
+        font-family: var(--font-display);
+        font-weight: 500;
+        font-size: var(--text-base);
+        line-height: 1;
+        cursor: pointer;
+        text-decoration: none;
+        transition:
+          transform var(--motion-fast) var(--ease-standard),
+          background-color var(--motion-fast) var(--ease-standard),
+          border-color var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible {
+        outline: none;
+        box-shadow: var(--focus-ring);
+      }
+      .btn:active {
+        transform: scale(0.96); /* approaching DESIGN.md §4's scale(0.92) */
+      }
+      .btn-primary {
+        background: var(--accent);
+        color: var(--accent-on);
+      }
+      .btn-primary:hover {
+        background: var(--accent-hover);
+      }
+      .btn-primary:active {
+        background: var(--accent-active);
+        transform: scale(0.92);
+      }
+      .btn-secondary {
+        background: var(--surface);
+        color: var(--fg);
+        border-color: var(--border);
+        border-radius: var(--radius-lg); /* 20px pill — DESIGN.md §4 Secondary */
+      }
+      .btn-secondary:hover {
+        border-color: var(--fg);
+      }
+
+      /* Compact button — listing-card price row, secondary nav links */
+      .btn-sm {
+        padding: 10px 16px;
+        font-size: var(--text-sm);
+      }
+
+      /* Circular icon button — the brand's signature geometry
+       * (DESIGN.md §4 Icon-Only Circular Button). Used for back,
+       * share, favorite, and carousel controls. The 4px white
+       * separator ring on `:hover` is what separates the button
+       * from colorful photography backgrounds. */
+      .btn-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 32px;
+        height: 32px;
+        padding: 0;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-pill);
+        background: var(--surface);
+        color: var(--fg);
+        cursor: pointer;
+        transition:
+          transform var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .btn-icon:hover {
+        box-shadow: 0 0 0 4px var(--surface), var(--elev-ring);
+      }
+      .btn-icon:active {
+        transform: scale(0.92);
+      }
+      .btn-icon:focus-visible {
+        outline: none;
+        box-shadow: var(--focus-ring);
+      }
+      .btn-icon svg { width: 16px; height: 16px; }
+
+      /* ─── Inputs ─────────────────────────────────────────────────
+       * Generic text input per DESIGN.md §4 Text Input — 1px
+       * Hairline Gray edge, 8px radius, 14px·16px padding. Focus
+       * switches the edge to Ink Black and adds the 2px outer
+       * ring. Error state swaps to Error Red on both border and
+       * helper text. */
+      .field {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+      }
+      .field label {
+        font-size: var(--text-sm);
+        font-weight: 600;
+        color: var(--fg);
+      }
+      .field input,
+      .field select {
+        padding: 14px 16px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+        background: var(--surface);
+        color: var(--fg);
+        font-family: inherit;
+        font-weight: 500;
+        font-size: var(--text-base);
+        outline: none;
+        transition:
+          border-color var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .field input:focus-visible,
+      .field select:focus-visible {
+        border-color: var(--fg);
+        box-shadow: var(--focus-ring);
+        color: var(--fg-2);
+      }
+      .field input::placeholder { color: var(--muted); }
+      .field-help {
+        font-size: var(--text-xs);
+        color: var(--muted);
+      }
+      .field-error .field-help { color: var(--danger); }
+      .field-error input { border-color: var(--danger); }
+
+      /* Search pill — three-segment "Where / When / Who" with a
+       * Rausch circular submit button at the right edge. DESIGN.md
+       * §4 Search Bar. The 32px pill radius is one of the brand's
+       * signature radii. */
+      .search-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 0;
+        padding: 8px;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-pill);
+        background: var(--surface);
+        box-shadow:
+          rgba(0, 0, 0, 0.04) 0 2px 6px 0;
+        max-width: 100%;
+      }
+      .search-segment {
+        display: flex;
+        flex-direction: column;
+        padding: 6px var(--space-5);
+        min-width: 0;
+        cursor: pointer;
+      }
+      .search-segment + .search-segment {
+        border-left: 1px solid var(--border);
+      }
+      .search-segment-label {
+        font-size: var(--text-xs);
+        font-weight: 600;
+        color: var(--fg);
+        line-height: 1.2;
+      }
+      .search-segment-value {
+        font-size: var(--text-sm);
+        font-weight: 500;
+        color: var(--muted);
+        line-height: 1.3;
+      }
+      .search-submit {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 48px;
+        height: 48px;
+        margin-left: var(--space-2);
+        border: none;
+        border-radius: var(--radius-pill);
+        background: var(--accent);
+        color: var(--accent-on);
+        cursor: pointer;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          transform var(--motion-fast) var(--ease-standard);
+      }
+      .search-submit:hover { background: var(--accent-hover); }
+      .search-submit:active {
+        background: var(--accent-active);
+        transform: scale(0.92);
+      }
+      .search-submit:focus-visible {
+        outline: none;
+        box-shadow: var(--focus-ring);
+      }
+      .search-submit svg { width: 16px; height: 16px; }
+
+      /* ─── Cards ──────────────────────────────────────────────────
+       * Two card shapes: the listing card (no border, no shadow,
+       * 14px image radius, text directly below the photo per
+       * DESIGN.md §4 Listing Card) and the booking-panel card
+       * (1px Hairline border, 20px radius, three-layer shadow
+       * stack — the system's most recognizable elevation). */
+      .listing {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+      }
+      .listing-photo {
+        position: relative;
+        aspect-ratio: 4 / 3;
+        border-radius: var(--radius-md);
+        overflow: hidden;
+        background: var(--surface-warm);
+      }
+      /* Photograph placeholder — gentle linear gradient inside the
+       * 14px radius. In production this slot is a 4:3 muscache CDN
+       * image with loading="lazy"; the fixture renders a tonal
+       * surface so the card geometry is still legible without art. */
+      .listing-photo::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background:
+          linear-gradient(
+            135deg,
+            var(--surface-warm) 0%,
+            var(--border) 60%,
+            var(--surface-warm) 100%
+          );
+      }
+      .listing-photo .btn-icon {
+        position: absolute;
+        top: var(--space-3);
+        right: var(--space-3);
+        z-index: 1;
+      }
+      .listing-photo .listing-badge {
+        position: absolute;
+        top: var(--space-3);
+        left: var(--space-3);
+        z-index: 1;
+      }
+      .listing-meta {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+      }
+      .listing-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-2);
+      }
+      .listing-title {
+        font-size: var(--text-base);
+        font-weight: 600;
+        color: var(--fg);
+      }
+      .listing-subtitle {
+        font-size: var(--text-sm);
+        font-weight: 500;
+        color: var(--muted);
+      }
+      .listing-price {
+        font-size: var(--text-base);
+        font-weight: 600;
+        color: var(--fg);
+      }
+      .listing-price .per {
+        font-weight: 500;
+        color: var(--muted);
+      }
+      .listing-rating {
+        font-size: var(--text-sm);
+        font-weight: 500;
+        color: var(--fg);
+        font-variant-numeric: tabular-nums;
+      }
+
+      /* Booking panel — the brand's signature sticky elevation.
+       * Three-layer shadow + Hairline border + 20px radius +
+       * 24px padding. DESIGN.md §4 Detail Page Booking Panel. */
+      .booking-panel {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--elev-raised);
+        padding: var(--space-6);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+        max-width: 370px;
+      }
+      .booking-headline {
+        display: flex;
+        align-items: baseline;
+        gap: var(--space-2);
+      }
+      .booking-price {
+        font-family: var(--font-display);
+        font-size: var(--text-xl);
+        font-weight: 600;
+        color: var(--fg);
+        letter-spacing: var(--tracking-display);
+      }
+      .booking-per {
+        font-size: var(--text-base);
+        font-weight: 500;
+        color: var(--muted);
+      }
+      .booking-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        overflow: hidden;
+      }
+      .booking-grid-cell {
+        padding: var(--space-3) var(--space-4);
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        cursor: pointer;
+        background: var(--surface);
+      }
+      .booking-grid-cell + .booking-grid-cell {
+        border-left: 1px solid var(--border);
+      }
+      .booking-grid-cell.full {
+        grid-column: 1 / -1;
+        border-top: 1px solid var(--border);
+        border-left: none;
+      }
+      .booking-cell-label {
+        font-size: 10px;
+        font-weight: 700;
+        color: var(--fg);
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+      }
+      .booking-cell-value {
+        font-size: var(--text-sm);
+        font-weight: 500;
+        color: var(--muted);
+      }
+      .booking-disclaimer {
+        font-size: var(--text-xs);
+        color: var(--muted);
+        text-align: center;
+        line-height: var(--leading-body);
+      }
+
+      /* ─── Badges ─────────────────────────────────────────────────
+       * Two shapes: the rounded brand badge (14px radius, used on
+       * listing photos as "NEW" or "Guest favorite" markers) and
+       * the dotted status badge (pill, used in metadata strips).
+       * Both stay under DESIGN.md §3's "no all-caps except 8px"
+       * rule by using sentence case at 12px·600. */
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 6px var(--space-3);
+        border-radius: var(--radius-pill);
+        font-family: var(--font-display);
+        font-size: var(--text-xs);
+        font-weight: 600;
+        line-height: 1.2;
+      }
+      .badge-rausch {
+        background: var(--accent);
+        color: var(--accent-on);
+        border-radius: var(--radius-md);
+      }
+      .badge-soft {
+        background: var(--surface);
+        color: var(--fg);
+        border-radius: var(--radius-md);
+        box-shadow: var(--elev-ring);
+      }
+      .badge-status {
+        background: var(--surface-warm);
+        color: var(--fg);
+      }
+      .badge-status .badge-dot {
+        width: 6px;
+        height: 6px;
+        border-radius: var(--radius-pill);
+        background: var(--success);
+      }
+
+      /* ─── Links ──────────────────────────────────────────────────
+       * Body links inherit Ink Black, NOT Rausch. Rausch is
+       * reserved for buttons and the active-tab indicator;
+       * promoting it to link color would dilute the accent and
+       * trip the two-uses-per-viewport cap. Underline appears on
+       * hover at generous offset. */
+      a {
+        color: var(--fg);
+        text-decoration: underline;
+        text-underline-offset: 3px;
+        text-decoration-thickness: 1px;
+        text-decoration-color: var(--border);
+        transition: text-decoration-color var(--motion-fast) var(--ease-standard);
+      }
+      a:hover {
+        text-decoration-color: var(--fg);
+      }
+      a:focus-visible {
+        outline: none;
+        box-shadow: var(--focus-ring);
+        border-radius: var(--radius-sm);
+      }
+
+      /* ─── Kbd ────────────────────────────────────────────────────
+       * Hairline outline + Soft Cloud fill + tabular mono. Used
+       * for the rare keyboard shortcut hint. */
+      kbd {
+        display: inline-block;
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        padding: 2px 6px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+        background: var(--surface-warm);
+        color: var(--fg);
+        line-height: 1.2;
+        font-variant-numeric: tabular-nums;
+      }
+
+      /* ─── Distinctive: Guest Favorite Award lockup ───────────────
+       * The brand's most recognizable moment (DESIGN.md §4
+       * Signature Components). A centered rating numeral at
+       * 44–56px·700 flanked by two laurel wreath SVGs. Below the
+       * lockup: a 12px·700 uppercase label with 0.32px tracking
+       * (we widen to 0.06em — the craft floor) and a 14px·500
+       * Ash Gray sub-label. Full-width block, no border, sits
+       * directly on the canvas. */
+      .award {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+        gap: var(--space-3);
+        padding-block: var(--space-8);
+      }
+      .award-row {
+        display: flex;
+        align-items: center;
+        gap: var(--space-5);
+        color: var(--fg);
+      }
+      .award-rating {
+        font-family: var(--font-display);
+        font-size: var(--text-3xl);
+        font-weight: 700;
+        color: var(--fg);
+        line-height: 1;
+        letter-spacing: var(--tracking-display);
+        font-variant-numeric: tabular-nums;
+      }
+      .award-laurel {
+        width: 48px;
+        height: 64px;
+        color: var(--fg);
+        flex-shrink: 0;
+      }
+      .award-laurel.right { transform: scaleX(-1); }
+      .award-label {
+        font-family: var(--font-display);
+        font-size: var(--text-xs);
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--fg);
+        line-height: 1;
+      }
+      .award-sub {
+        font-size: var(--text-sm);
+        font-weight: 500;
+        color: var(--muted);
+        max-width: 44ch;
+        line-height: var(--leading-body);
+      }
+
+      /* Tri-tab category picker (DESIGN.md §4 Tri-Tab) — the brand's
+       * other instantly-recognizable nav moment. We render with
+       * type-only icons (no 3D illustrations) because the fixture
+       * stays raster-free, but the underline + label rhythm holds. */
+      .tabs {
+        display: inline-flex;
+        gap: var(--space-8);
+        padding-block-start: var(--space-3);
+        border-bottom: 1px solid var(--border);
+      }
+      .tab {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: var(--space-2);
+        padding-block-end: var(--space-3);
+        font-family: var(--font-display);
+        font-size: var(--text-base);
+        font-weight: 500;
+        color: var(--muted);
+        background: none;
+        border: none;
+        cursor: pointer;
+        position: relative;
+        text-decoration: none;
+      }
+      .tab-glyph {
+        width: 32px;
+        height: 32px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--fg);
+      }
+      .tab[aria-selected="true"] {
+        color: var(--fg);
+      }
+      .tab[aria-selected="true"]::after {
+        content: "";
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: -1px;
+        height: 2px;
+        background: var(--fg);
+        border-radius: var(--radius-pill);
+      }
+      .tab-new {
+        position: absolute;
+        top: -4px;
+        right: -10px;
+        padding: 2px 6px;
+        border-radius: var(--radius-md);
+        background: var(--fg);
+        color: var(--accent-on);
+        font-size: 10px;
+        font-weight: 700;
+        line-height: 1.2;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+      }
+
+      /* ─── Section-specific layout ──────────────────────────────── */
+      .hero-grid {
+        display: grid;
+        grid-template-columns: minmax(0, 1.45fr) minmax(0, 1fr);
+        gap: var(--space-12);
+        align-items: start;
+      }
+      @media (max-width: 1023px) {
+        .hero-grid { grid-template-columns: 1fr; gap: var(--space-8); }
+      }
+      .hero-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3);
+        margin-block-start: var(--space-6);
+      }
+
+      .listings-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: var(--space-6);
+        margin-block-start: var(--space-8);
+      }
+      @media (max-width: 1023px) {
+        .listings-grid { grid-template-columns: repeat(2, 1fr); }
+      }
+      @media (max-width: 639px) {
+        .listings-grid { grid-template-columns: 1fr; gap: var(--space-4); }
+      }
+
+      .form-row {
+        display: grid;
+        grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+        gap: var(--space-12);
+        align-items: start;
+      }
+      @media (max-width: 1023px) {
+        .form-row { grid-template-columns: 1fr; }
+      }
+      .form {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+      }
+      .row-between {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-3);
+      }
+      .row-cluster {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        flex-wrap: wrap;
+      }
+      .divider-soft {
+        height: 1px;
+        background: var(--border-soft);
+        border: none;
+        margin: 0;
+      }
+      .nav-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding-block: var(--space-4);
+        gap: var(--space-4);
+      }
+      .nav-logo {
+        font-family: var(--font-display);
+        font-size: var(--text-lg);
+        font-weight: 700;
+        color: var(--accent);
+        letter-spacing: var(--tracking-display);
+      }
+      .icon { width: 16px; height: 16px; flex-shrink: 0; }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <!-- ════════════════════════════════════════════════════════════
+           NAV — exercises: .nav-row, .nav-logo (Rausch wordmark),
+           .tabs (tri-tab picker, DESIGN.md §4 signature). Active
+           "Homes" tab gets the 2px Ink Black underline; "Experiences"
+           carries the small Ink Black NEW pill from §4.
+      ═══════════════════════════════════════════════════════════════ -->
+      <nav class="nav-row" aria-label="Primary">
+        <span class="nav-logo">airbnb</span>
+        <div class="tabs" role="tablist">
+          <button class="tab" role="tab" aria-selected="true">
+            <span class="tab-glyph" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                stroke-width="1.5" stroke-linecap="round"
+                stroke-linejoin="round" width="24" height="24">
+                <path d="M3 11l9-7 9 7v9a1 1 0 0 1-1 1h-5v-6h-6v6H4a1 1 0 0 1-1-1z" />
+              </svg>
+            </span>
+            Homes
+          </button>
+          <button class="tab" role="tab" aria-selected="false">
+            <span class="tab-glyph" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                stroke-width="1.5" stroke-linecap="round"
+                stroke-linejoin="round" width="24" height="24">
+                <ellipse cx="12" cy="9" rx="6" ry="7" />
+                <path d="M9 16l-1 5 4-2 4 2-1-5" />
+              </svg>
+            </span>
+            Experiences
+            <span class="tab-new" aria-label="New">New</span>
+          </button>
+          <button class="tab" role="tab" aria-selected="false">
+            <span class="tab-glyph" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                stroke-width="1.5" stroke-linecap="round"
+                stroke-linejoin="round" width="24" height="24">
+                <path d="M6 16a6 6 0 1 1 12 0z" />
+                <path d="M12 6V3M5 18h14M11 19v2h2v-2" />
+              </svg>
+            </span>
+            Services
+            <span class="tab-new" aria-label="New">New</span>
+          </button>
+        </div>
+        <div class="row-cluster">
+          <button class="btn btn-secondary btn-sm" type="button">Become a host</button>
+          <button class="btn-icon" type="button" aria-label="Menu">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+              stroke-width="1.75" stroke-linecap="round"
+              stroke-linejoin="round" aria-hidden="true">
+              <path d="M4 7h16M4 12h16M4 17h16" />
+            </svg>
+          </button>
+        </div>
+      </nav>
+
+      <!-- ════════════════════════════════════════════════════════════
+           HERO — exercises: .eyebrow, h1, .lede, .search-pill (the
+           three-segment Where/When/Who with the Rausch circular
+           submit, DESIGN.md §4), .btn-primary, .btn-secondary,
+           kbd, .badge-status (success dot).
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="hero">
+        <div class="hero-grid">
+          <div class="stack-4">
+            <p class="eyebrow">Reference fixture · airbnb</p>
+            <h1 style="max-width: 18ch">
+              Find a place where the photograph is the interface.
+            </h1>
+            <p class="lede body-muted" style="max-width: 56ch">
+              A token system distilled from Airbnb's 2026 rules — Canvas
+              White surfaces, a single Rausch coral accent, generous
+              soft-circle radii, and Cereal at one family. The fixture
+              you are reading uses the same token block agents paste
+              into every artifact, so the rules survive the paste.
+            </p>
+
+            <div class="search-pill" role="search" aria-label="Find a stay">
+              <div class="search-segment">
+                <span class="search-segment-label">Where</span>
+                <span class="search-segment-value">Search destinations</span>
+              </div>
+              <div class="search-segment">
+                <span class="search-segment-label">When</span>
+                <span class="search-segment-value">Add dates</span>
+              </div>
+              <div class="search-segment">
+                <span class="search-segment-label">Who</span>
+                <span class="search-segment-value">Add guests</span>
+              </div>
+              <button class="search-submit" type="submit" aria-label="Search">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                  stroke-width="2" stroke-linecap="round"
+                  stroke-linejoin="round" aria-hidden="true">
+                  <circle cx="11" cy="11" r="7" />
+                  <path d="M21 21l-4.3-4.3" />
+                </svg>
+              </button>
+            </div>
+
+            <div class="hero-actions">
+              <a href="./tokens.css" class="btn btn-primary">
+                View the token block
+                <svg
+                  class="icon"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.75"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M5 12h14M13 6l6 6-6 6" />
+                </svg>
+              </a>
+              <a href="./DESIGN.md" class="btn btn-secondary">Read the brand</a>
+            </div>
+          </div>
+
+          <aside class="booking-panel" aria-label="Token status">
+            <div class="booking-headline">
+              <span class="booking-price">56 tokens</span>
+              <span class="booking-per">in :root</span>
+            </div>
+            <div class="booking-grid" role="group">
+              <div class="booking-grid-cell">
+                <span class="booking-cell-label">Last reviewed</span>
+                <span class="booking-cell-value">
+                  <time datetime="2026-05-14">May 14, 2026</time>
+                </span>
+              </div>
+              <div class="booking-grid-cell">
+                <span class="booking-cell-label">Schema</span>
+                <span class="booking-cell-value">v0.1 · A1/A2/B</span>
+              </div>
+              <div class="booking-grid-cell full">
+                <span class="booking-cell-label">Accent budget</span>
+                <span class="booking-cell-value">≤ 2 visible Rausch uses per viewport</span>
+              </div>
+            </div>
+            <button type="button" class="btn btn-primary" style="width: 100%">
+              Inspect tokens
+            </button>
+            <p class="booking-disclaimer">
+              You won't be charged — this is a static fixture. Press
+              <kbd>⌘</kbd> <kbd>K</kbd> to jump to the token grep.
+            </p>
+            <div class="row-between" style="margin-block-start: var(--space-2)">
+              <span class="badge badge-status">
+                <span class="badge-dot" aria-hidden="true"></span>
+                Tokens passing schema
+              </span>
+              <span class="listing-rating" aria-label="Token coverage">
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  aria-hidden="true"
+                  style="vertical-align: -2px; margin-right: 4px"
+                >
+                  <path d="M12 2l2.9 6.9 7.1.6-5.4 4.7 1.7 7L12 17l-6.3 4.2 1.7-7L2 9.5l7.1-.6z" />
+                </svg>
+                4.92
+              </span>
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <!-- ════════════════════════════════════════════════════════════
+           LISTINGS — exercises: .listing (4:3 photo, no border, no
+           shadow, 14px radius), .listing-photo with floated circular
+           favorite button, .badge-rausch, .listing-rating, links.
+           Three cards in a 3-col grid that reflows to 2 then 1.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="listings">
+        <div class="stack-3">
+          <p class="eyebrow">What the fixture exercises</p>
+          <h2 style="max-width: 32ch">
+            Three listings, every token resolved through var(--*).
+          </h2>
+          <p class="body-muted" style="max-width: 56ch">
+            No raw hex outside the :root paste. No second type family.
+            No drop shadow on the listing cards — separation comes from
+            the photograph and the 24px gutter between them.
+          </p>
+        </div>
+
+        <div class="listings-grid">
+          <article class="listing" aria-label="Cottage in the Cotswolds">
+            <div class="listing-photo">
+              <span class="listing-badge badge badge-soft">Guest favorite</span>
+              <button class="btn-icon" type="button" aria-label="Save to wishlist">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                  stroke-width="1.75" stroke-linecap="round"
+                  stroke-linejoin="round" aria-hidden="true">
+                  <path d="M12 21s-7-4.5-7-10a4 4 0 0 1 7-2.7A4 4 0 0 1 19 11c0 5.5-7 10-7 10z" />
+                </svg>
+              </button>
+            </div>
+            <div class="listing-meta">
+              <div class="listing-row">
+                <span class="listing-title">Cotswolds, England</span>
+                <span class="listing-rating">
+                  <svg
+                    width="12"
+                    height="12"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                    aria-hidden="true"
+                    style="vertical-align: -1px; margin-right: 3px"
+                  >
+                    <path d="M12 2l2.9 6.9 7.1.6-5.4 4.7 1.7 7L12 17l-6.3 4.2 1.7-7L2 9.5l7.1-.6z" />
+                  </svg>
+                  4.97
+                </span>
+              </div>
+              <span class="listing-subtitle">Cottage rentals · 2 hours by train</span>
+              <span class="listing-subtitle">Apr 12 – 17</span>
+              <span class="listing-price">
+                $182 <span class="per">/ night</span>
+              </span>
+            </div>
+          </article>
+
+          <article class="listing" aria-label="Loft in Lisbon">
+            <div class="listing-photo">
+              <span class="listing-badge badge badge-rausch">New</span>
+              <button class="btn-icon" type="button" aria-label="Save to wishlist">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                  stroke-width="1.75" stroke-linecap="round"
+                  stroke-linejoin="round" aria-hidden="true">
+                  <path d="M12 21s-7-4.5-7-10a4 4 0 0 1 7-2.7A4 4 0 0 1 19 11c0 5.5-7 10-7 10z" />
+                </svg>
+              </button>
+            </div>
+            <div class="listing-meta">
+              <div class="listing-row">
+                <span class="listing-title">Lisbon, Portugal</span>
+                <span class="listing-rating">
+                  <svg
+                    width="12"
+                    height="12"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                    aria-hidden="true"
+                    style="vertical-align: -1px; margin-right: 3px"
+                  >
+                    <path d="M12 2l2.9 6.9 7.1.6-5.4 4.7 1.7 7L12 17l-6.3 4.2 1.7-7L2 9.5l7.1-.6z" />
+                  </svg>
+                  4.81
+                </span>
+              </div>
+              <span class="listing-subtitle">Loft apartments · Alfama</span>
+              <span class="listing-subtitle">May 03 – 09</span>
+              <span class="listing-price">
+                $96 <span class="per">/ night</span>
+              </span>
+            </div>
+          </article>
+
+          <article class="listing" aria-label="Yacht tour in Mykonos">
+            <div class="listing-photo">
+              <span class="listing-badge badge badge-soft">Experience</span>
+              <button class="btn-icon" type="button" aria-label="Save to wishlist">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                  stroke-width="1.75" stroke-linecap="round"
+                  stroke-linejoin="round" aria-hidden="true">
+                  <path d="M12 21s-7-4.5-7-10a4 4 0 0 1 7-2.7A4 4 0 0 1 19 11c0 5.5-7 10-7 10z" />
+                </svg>
+              </button>
+            </div>
+            <div class="listing-meta">
+              <div class="listing-row">
+                <span class="listing-title">Mykonos, Greece</span>
+                <span class="listing-rating">
+                  <svg
+                    width="12"
+                    height="12"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                    aria-hidden="true"
+                    style="vertical-align: -1px; margin-right: 3px"
+                  >
+                    <path d="M12 2l2.9 6.9 7.1.6-5.4 4.7 1.7 7L12 17l-6.3 4.2 1.7-7L2 9.5l7.1-.6z" />
+                  </svg>
+                  4.89
+                </span>
+              </div>
+              <span class="listing-subtitle">Small Group Yacht Tour</span>
+              <span class="listing-subtitle">4 hours · Unlimited fruit</span>
+              <span class="listing-price">
+                $148 <span class="per">/ person</span>
+              </span>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <!-- ════════════════════════════════════════════════════════════
+           GUEST FAVORITE AWARD — the brand's signature distinctive
+           component. Centered rating numeral at 44px·700 flanked by
+           two laurel wreath SVGs at 48×64. Below, an uppercase 12px·700
+           "GUEST FAVORITE" label and a 14px·500 Ash Gray sub-line.
+           Full-width block, no border, sits directly on the canvas
+           per DESIGN.md §4 Signature Components.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="award">
+        <div class="award" aria-label="Guest Favorite award">
+          <div class="award-row">
+            <svg
+              class="award-laurel"
+              viewBox="0 0 48 64"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M40 60 C 14 56, 6 38, 12 16" />
+              <path d="M30 56 C 18 50, 14 44, 14 36" />
+              <path d="M18 22 C 8 22, 6 14, 12 8" />
+              <path d="M20 30 C 8 30, 6 24, 10 18" />
+              <path d="M22 38 C 12 38, 8 32, 12 26" />
+              <path d="M26 46 C 16 46, 10 40, 14 34" />
+              <path d="M30 52 C 22 52, 16 48, 18 42" />
+            </svg>
+            <span class="award-rating">4.92</span>
+            <svg
+              class="award-laurel right"
+              viewBox="0 0 48 64"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M40 60 C 14 56, 6 38, 12 16" />
+              <path d="M30 56 C 18 50, 14 44, 14 36" />
+              <path d="M18 22 C 8 22, 6 14, 12 8" />
+              <path d="M20 30 C 8 30, 6 24, 10 18" />
+              <path d="M22 38 C 12 38, 8 32, 12 26" />
+              <path d="M26 46 C 16 46, 10 40, 14 34" />
+              <path d="M30 52 C 22 52, 16 48, 18 42" />
+            </svg>
+          </div>
+          <p class="award-label">Guest favorite</p>
+          <p class="award-sub">
+            One of the most loved tokensets on Open Design, according
+            to agents who paste it.
+          </p>
+        </div>
+      </section>
+
+      <!-- ════════════════════════════════════════════════════════════
+           FORM — exercises: .field (text input, focus rings the
+           border to Ink Black and adds the 2px outer ring per
+           DESIGN.md §4 Text Input), .field-error (Error Red),
+           .btn-primary, .btn-secondary, kbd. The right column re-
+           uses the .booking-panel pattern as a price summary.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="form">
+        <div class="form-row">
+          <div class="stack-4">
+            <p class="eyebrow">Form components</p>
+            <h2 style="max-width: 24ch">
+              Inputs inherit the same tokens.
+            </h2>
+            <p class="body-muted" style="max-width: 52ch">
+              Focus rings, borders, and placeholder color all derive
+              from --fg and --border. Submit reuses .btn-primary
+              unchanged. No new token introduced for this section —
+              if a value here is not in the :root paste above, it
+              does not belong in the artifact at all.
+            </p>
+            <hr class="divider-soft" />
+            <p class="body-meta">
+              Full reference at <a href="./tokens.css">tokens.css</a>
+              · brand at <a href="./DESIGN.md">DESIGN.md</a>.
+            </p>
+          </div>
+
+          <form class="form" onsubmit="event.preventDefault();">
+            <div class="field">
+              <label for="email">Travel notes email</label>
+              <input
+                id="email"
+                type="email"
+                placeholder="you@somewhere.travel"
+                autocomplete="email"
+                required
+              />
+              <p class="field-help">
+                We'll send a single dispatch a season — never more.
+              </p>
+            </div>
+
+            <div class="field">
+              <label for="destination">Where</label>
+              <input
+                id="destination"
+                type="text"
+                placeholder="Search destinations"
+                autocomplete="off"
+              />
+            </div>
+
+            <div class="field field-error">
+              <label for="dates">Dates</label>
+              <input
+                id="dates"
+                type="text"
+                placeholder="Add dates"
+                aria-invalid="true"
+              />
+              <p class="field-help">Pick a check-in and check-out before you continue.</p>
+            </div>
+
+            <div class="row-cluster" style="margin-block-start: var(--space-2)">
+              <button type="submit" class="btn btn-primary">Send the dispatch</button>
+              <button type="button" class="btn btn-secondary">Skip for now</button>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/airbnb/tokens.css
+++ b/design-systems/airbnb/tokens.css
@@ -1,0 +1,261 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/airbnb/tokens.css
+ *
+ * Structured token bindings for the Airbnb design system — pristine
+ * Canvas White surfaces, a single Rausch coral-pink accent (#ff385c),
+ * generous soft-circle radii, and Airbnb Cereal VF as the lone type
+ * family. The system reads like a travel magazine that happens to be
+ * an app: the interface disappears so the listings can breathe.
+ *
+ * This file pre-compiles the values described in `DESIGN.md` into the
+ * schema shared with every OD design system. Agents should paste the
+ * `:root { … }` block verbatim into the first `<style>` of an artifact,
+ * then resolve every value via `var(--*)` from that point on.
+ *
+ * Schema notes (brand-specific bindings worth flagging — section
+ * references point into `DESIGN.md`):
+ *
+ *   #Bind 1  — --bg and --surface both resolve to Canvas White
+ *              (#ffffff). Airbnb cards sit directly on the page
+ *              without a tonal step; separation comes from the
+ *              Hairline Gray (--border) edge and from the
+ *              photograph inside the card, never from a surface
+ *              tint (§4 Listing Card).
+ *
+ *   #Bind 2  — --surface-warm binds to Soft Cloud (#f7f7f7), the
+ *              brand-named subsurface tier used for footers, map
+ *              wrappers, and the calendar's middle-of-range dates.
+ *              A real value rather than `var(--surface)` because
+ *              Airbnb publishes a distinct tier here (§2 Surface).
+ *
+ *   #Bind 3  — --accent-hover and --accent-active are hand-picked,
+ *              NOT formula-derived. DESIGN.md §2 publishes Deep
+ *              Rausch (#e00b41) as the pressed/active state.
+ *              color-mix would overshoot that saturation and
+ *              under-shoot the brand's gradient terminal stop,
+ *              so we hand-bind both states.
+ *
+ *   #Bind 4  — Radius scale concentrates on the brand's signature
+ *              soft-circle geometry: 8px for buttons/inputs, 14px
+ *              for listing cards (the workhorse), 20px for the
+ *              booking panel and hero photo frames, 9999px for
+ *              the circular icon buttons and avatars that
+ *              punctuate every surface (§5 Border Radius Scale).
+ *
+ *   #Bind 5  — --elev-raised encodes Airbnb's signature three-
+ *              layer booking-panel shadow verbatim — a 2% hairline
+ *              ring, a 4% short blur, and a 10% medium blur. The
+ *              brand forbids single drop shadows; this stacked
+ *              triple is what gives the booking panel its premium
+ *              anti-aliased perimeter (§6 Depth & Elevation).
+ *
+ *   #Bind 6  — --focus-ring is 2px solid Ink Black (#222222), NOT
+ *              the schema's accent-tinted default. DESIGN.md §6
+ *              mandates this specific ring so focus reads cleanly
+ *              against full-bleed colorful photography — a Rausch
+ *              ring would disappear against warm sunset shots or
+ *              sea-blue overlays. Pair with the 4px white
+ *              separator ring at circular buttons floating on
+ *              images.
+ *
+ *   #Bind 7  — --leading-body is 1.43 (generous). Airbnb pairs
+ *              tight display leading (1.18–1.25) with notably
+ *              open body leading; that two-mode rhythm is why
+ *              the system reads as a travel magazine rather than
+ *              a utility app (§3 Principles).
+ *
+ * Brand-specific extensions: none in this revision. The Plus
+ * Magenta (#92174d) and Luxe Purple (#460479) product-tier accents
+ * called out in DESIGN.md §2 stay inline at the tier-specific
+ * components that need them; promoting them to schema slots would
+ * encourage non-tier surfaces to reach for them.
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface (3 levels) ────────────────────────────────────────
+   * Canvas White is both the page and the card — Airbnb refuses a
+   * tonal shift between the two. Cards earn their edges from the
+   * Hairline Gray border and from full-bleed photography. The
+   * tertiary tier (--surface-warm) is Soft Cloud, used only for
+   * footer backgrounds, map-view wrappers, and middle-of-range
+   * date cells in the date picker. */
+  --bg: #ffffff;
+  --surface: #ffffff;
+  --surface-warm: #f7f7f7;
+
+  /* ─── Foreground ramp (4 levels) ────────────────────────────────
+   * Ink Black (#222222) carries roughly ninety percent of every
+   * page — every heading, every body paragraph, every nav label,
+   * every price. The brand's near-black is never true #000000.
+   * Charcoal (--fg-2) is a one-step-down emphasis tier reserved
+   * for focused-input text. Ash Gray (--muted) is the secondary
+   * label — "Cottage rentals" subtitles, muted footer links.
+   * Mute Gray (--meta) is reserved for disabled buttons and
+   * low-priority metadata. */
+  --fg: #222222;
+  --fg-2: #3f3f3f;
+  --muted: #6a6a6a;
+  --meta: #929292;
+
+  /* ─── Border (2 levels) ─────────────────────────────────────────
+   * Hairline Gray (#dddddd) is the workhorse — every card-to-card
+   * divider, every amenity-row separator, every footer-column
+   * rule. The soft tier is a lighter hairline used to break up
+   * dense list interiors without competing with the primary card
+   * edge. */
+  --border: #dddddd;
+  --border-soft: #ebebeb;
+
+  /* ─── Accent ────────────────────────────────────────────────────
+   * Rausch coral-pink — the single signature color. Reserve for
+   * primary CTAs (Reserve, Search, Add dates), the active-tab
+   * underline, the wishlist heart fill, and price emphasis. Hard
+   * cap of two visible uses per viewport; if a third Rausch
+   * element shows up, neutralize one. Plus Magenta (#92174d) and
+   * Luxe Purple (#460479) are kept inline at their product-tier
+   * surfaces, not promoted to shared accent slots. */
+  --accent: #ff385c;
+  --accent-on: #ffffff;
+  --accent-hover: #e31c5f;       /* hand-picked, between Rausch and Deep Rausch */
+  --accent-active: #e00b41;      /* Deep Rausch — DESIGN.md §2 pressed-state value */
+
+  /* ─── Semantic ──────────────────────────────────────────────────
+   * Error Red is explicit from DESIGN.md §2; success and warn are
+   * not specified by the brand and are bound to desaturated values
+   * that survive the white canvas without competing with Rausch.
+   * Keep total semantic-color pixels well under five percent of
+   * any page — the brand almost never renders status. */
+  --success: #008a05;            /* hand-picked warm green — available/in-stock */
+  --warn: #c47700;               /* burnt amber — never tailwind yellow */
+  --danger: #c13515;             /* DESIGN.md §2 Error Red */
+
+  /* ─── Typography — fonts ────────────────────────────────────────
+   * Airbnb Cereal VF is the proprietary face that carries every
+   * label from 8px superscript to 28px section heading. The
+   * documented fallback chain renders acceptably on macOS/iOS
+   * where system-ui resolves to San Francisco. Display and body
+   * share the same stack — the visual identity comes from the
+   * family itself, never from typeface mixing. Mono is a generic
+   * stack for kbd, tabular metrics, and the rare code label. */
+  --font-display:
+    "Airbnb Cereal VF", "Airbnb Cereal App", Circular,
+    -apple-system, system-ui, "Helvetica Neue", Roboto, sans-serif;
+  --font-body:
+    "Airbnb Cereal VF", "Airbnb Cereal App", Circular,
+    -apple-system, system-ui, "Helvetica Neue", Roboto, sans-serif;
+  --font-mono:
+    ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Monaco,
+    Consolas, monospace;
+
+  /* ─── Typography — type scale (px) ──────────────────────────────
+   * Derived from DESIGN.md §3 Hierarchy table. The system clusters
+   * tightly between 11 and 22px (the conversational range) and
+   * jumps to 28px for section headings; the higher tiers are used
+   * sparingly for the Guest Favorite rating lockup (44–56px) and
+   * the rare hero numeral. No 400-regular: Cereal's body weight
+   * is 500, which any consuming component should set explicitly. */
+  --text-xs: 12px;               /* micro / footer disclaimer */
+  --text-sm: 14px;               /* button default, link, caption */
+  --text-base: 16px;             /* body medium, button large, subtitle bold */
+  --text-lg: 20px;               /* listing title */
+  --text-xl: 22px;               /* subsection heading */
+  --text-2xl: 28px;              /* section heading */
+  --text-3xl: 44px;              /* Guest Favorite rating, hero numeral */
+  --text-4xl: 56px;              /* display ceiling — Guest Favorite max */
+
+  /* ─── Typography — leading & tracking ───────────────────────────
+   * Tight for display (1.20 — chiseled headlines), generous for
+   * body (1.43 — magazine reading comfort). Display tracking
+   * compresses negatively at sizes ≥20px; body and caption hold
+   * at zero. The two-mode rhythm is what gives Airbnb pages
+   * their travel-magazine feel rather than a utility-app feel. */
+  --leading-body: 1.43;
+  --leading-tight: 1.2;
+  --tracking-display: -0.02em;   /* applied at sizes ≥20px only */
+
+  /* ─── Spacing — base scale ──────────────────────────────────────
+   * 8px base unit per DESIGN.md §5. The brand uses fine-grained
+   * off-grid values (5.5, 10, 11, 18.5, 22) for pixel-perfect
+   * icon alignment, but the shared scale stays on the standard
+   * 4px grid — off-grid spacing belongs inline at the component
+   * level, not in shared tokens. */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+
+  /* ─── Section rhythm ────────────────────────────────────────────
+   * Section padding ranges 48–64px on desktop, 24–32px on mobile
+   * per DESIGN.md §5. We bind the upper bound on desktop because
+   * Airbnb's content-dense pages benefit from generous breathing
+   * room between content blocks; the lower phone bound keeps the
+   * vertical rhythm tight on small screens. */
+  --section-y-desktop: 64px;
+  --section-y-tablet: 48px;
+  --section-y-phone: 32px;
+
+  /* ─── Radius ────────────────────────────────────────────────────
+   * The brand's signature soft-circle geometry. 14px (--radius-md)
+   * is the workhorse — every listing card photograph, every
+   * amenity badge, every generic content container lands here.
+   * 20px (--radius-lg) is reserved for the booking panel and hero
+   * photo frames; 8px (--radius-sm) is the small radius for
+   * buttons, dropdowns, and inputs; --radius-pill (9999px) is the
+   * system's signature round geometry, applied to every circular
+   * icon button, every avatar, and the wishlist heart. */
+  --radius-sm: 8px;
+  --radius-md: 14px;
+  --radius-lg: 20px;
+  --radius-pill: 9999px;
+
+  /* ─── Elevation ─────────────────────────────────────────────────
+   * Airbnb forbids single drop shadows; the system uses stacked
+   * layered shadows or no shadow at all. Listing cards sit flat
+   * on the canvas. Booking panels, modals, and dropdowns use the
+   * signature three-layer stack — a 2% hairline ring, a 4% short
+   * blur, and a 10% medium blur — which reads as one cohesive
+   * lift while giving the perimeter a premium anti-aliased edge. */
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised:
+    rgba(0, 0, 0, 0.02) 0 0 0 1px,
+    rgba(0, 0, 0, 0.04) 0 2px 6px 0,
+    rgba(0, 0, 0, 0.1) 0 4px 8px 0;
+
+  /* ─── Focus ring ────────────────────────────────────────────────
+   * 2px solid Ink Black, NOT the schema's accent-tinted default.
+   * DESIGN.md §6 mandates this exact treatment so focus indicators
+   * read cleanly against full-bleed colorful photography — a
+   * Rausch-tinted ring would disappear against warm sunset shots
+   * or sea-blue beach overlays. Pair with a 4px white separator
+   * ring at circular-icon buttons that float on images. */
+  --focus-ring: 0 0 0 2px var(--fg);
+
+  /* ─── Motion ────────────────────────────────────────────────────
+   * DESIGN.md did not capture transition timings (static
+   * extraction scope). We bind defaults consistent with the
+   * brand's tactile feel: 150ms for micro-states (the famous
+   * `transform: scale(0.92)` pressed-button rebound) and 200ms
+   * for general state changes. Standard easing is the schema
+   * default — short, purposeful, no overshoot. */
+  --motion-fast: 150ms;
+  --motion-base: 200ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+  /* ─── Layout ────────────────────────────────────────────────────
+   * Detail pages cap at 1280px per DESIGN.md §5; the homepage
+   * listing grid lets the canvas breathe to 1760–1920px on
+   * ultra-wide. We bind the detail-page width as the shared
+   * default because that is the geometry agents will most often
+   * generate (rooms, experiences, host profiles). Gutters
+   * tighten progressively: 40px desktop, 24px tablet, 16px
+   * phone per DESIGN.md §8 small-mobile clause. */
+  --container-max: 1280px;
+  --container-gutter-desktop: 40px;
+  --container-gutter-tablet: 24px;
+  --container-gutter-phone: 16px;
+}

--- a/design-systems/apple/components.html
+++ b/design-systems/apple/components.html
@@ -1,0 +1,749 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Apple — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/apple. Every visible
+        token comes from tokens.css; the page itself follows Apple's
+        editorial rules — pale-gray feature ladder over white, single
+        Apple Action Blue accent capped at ≤2 visible uses per screen,
+        SF Pro display at compressed tracking, and the signature 980px
+        capsule CTA."
+    />
+
+    <style>
+      /* :root paste — sourced verbatim from
+         design-systems/apple/tokens.css. Keep this block in sync
+         when tokens.css changes. The agent prompt instructs the
+         Designer panelist to paste this block as the FIRST thing in
+         their <style>, then reference everything below via var(...). */
+      :root {
+        --bg: #ffffff;
+        --surface: #f5f5f7;
+        --surface-warm: #fbfbfd;
+
+        --fg: #1d1d1f;
+        --fg-2: #424245;
+        --muted: #6e6e73;
+        --meta: #86868b;
+
+        --border: #d2d2d7;
+        --border-soft: #e8e8ed;
+
+        --accent: #0071e3;
+        --accent-on: #ffffff;
+        --accent-hover: #0077ed;
+        --accent-active: #0066cc;
+
+        --success: #16a34a;
+        --warn:    #eab308;
+        --danger:  #dc2626;
+
+        --font-display:
+          "SF Pro Display", "SF Pro Icons", "Helvetica Neue", Helvetica, Arial, sans-serif;
+        --font-body:
+          "SF Pro Text", "SF Pro Icons", "Helvetica Neue", Helvetica, Arial, sans-serif;
+        --font-mono:
+          "SF Mono", ui-monospace, "JetBrains Mono", Menlo, Monaco, Consolas, monospace;
+
+        --text-xs:   12px;
+        --text-sm:   14px;
+        --text-base: 17px;
+        --text-lg:   21px;
+        --text-xl:   28px;
+        --text-2xl:  40px;
+        --text-3xl:  56px;
+        --text-4xl:  80px;
+
+        --leading-body:  1.47;
+        --leading-tight: 1.05;
+
+        --tracking-display: -0.015em;
+
+        --space-1:  4px;
+        --space-2:  8px;
+        --space-3:  12px;
+        --space-4:  16px;
+        --space-5:  20px;
+        --space-6:  24px;
+        --space-8:  32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 100px;
+        --section-y-tablet:  64px;
+        --section-y-phone:   40px;
+
+        --radius-sm:   8px;
+        --radius-md:   12px;
+        --radius-lg:   18px;
+        --radius-pill: 980px;
+
+        --elev-flat:   none;
+        --elev-ring:   0 0 0 1px var(--border);
+        --elev-raised: 0 12px 32px rgba(0, 0, 0, 0.08);
+
+        --focus-ring: 0 0 0 4px color-mix(in oklab, var(--accent), transparent 65%);
+
+        --motion-fast:   150ms;
+        --motion-base:   220ms;
+        --ease-standard: cubic-bezier(0.28, 0, 0.22, 1);
+
+        --container-max:            1024px;
+        --container-gutter-desktop: 22px;
+        --container-gutter-tablet:  18px;
+        --container-gutter-phone:   16px;
+      }
+
+      /* ─── Reset (minimal) ───────────────────────────────────────── */
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        font-weight: 400;
+        letter-spacing: -0.022em; /* SF Pro Text body, per DESIGN.md §3 */
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+      }
+
+      /* ─── Layout primitives ─────────────────────────────────────── */
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section {
+        padding-block: var(--section-y-desktop);
+      }
+      /* Apple uses surface contrast, not borders, to separate chapters
+         (DESIGN.md §5 — "section transitions rely more on surface
+         changes than decorative separators"). The .band-* helpers
+         below switch the chapter canvas while the container stays
+         constant. */
+      .band-light { background: var(--bg); color: var(--fg); }
+      .band-soft  { background: var(--surface); color: var(--fg); }
+      .band-warm  { background: var(--surface-warm); color: var(--fg); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography ────────────────────────────────────────────── */
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        margin: 0;
+        color: var(--fg);
+      }
+      /* DESIGN.md §3 — Hero Display L (56px / 600 / 1.07). We set
+         tracking via the display token so all hero copy compresses
+         consistently. */
+      h1 {
+        font-size: var(--text-3xl);
+        font-weight: 600;
+        line-height: var(--leading-tight);
+        letter-spacing: var(--tracking-display);
+      }
+      h2 {
+        font-size: var(--text-2xl);
+        font-weight: 600;
+        line-height: 1.1;
+        letter-spacing: var(--tracking-display);
+      }
+      h3 {
+        font-size: var(--text-xl);
+        font-weight: 600;
+        line-height: 1.14;
+        letter-spacing: -0.007em; /* DESIGN.md §3 — Card/Product Title */
+      }
+      p { margin: 0; }
+
+      .lead {
+        font-size: var(--text-lg);
+        line-height: 1.38;
+        color: var(--fg-2);
+        font-weight: 400;
+        letter-spacing: -0.011em;
+      }
+      .body-muted { color: var(--muted); }
+      .body-meta  { color: var(--meta); font-size: var(--text-sm); }
+      .body-sm    { font-size: var(--text-sm); }
+
+      /* `.eyebrow` — small uppercase label above hero / section heads.
+         DESIGN.md §3 has no eyebrow row in the hierarchy table; this
+         is the agreed pattern for OD reference fixtures and uses the
+         12px micro-UI tier with positive tracking so the rule reads
+         as deliberate. */
+      .eyebrow {
+        font-family: var(--font-display);
+        font-size: var(--text-xs);
+        font-weight: 600;
+        line-height: 1;
+        color: var(--accent);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+
+      /* ─── Buttons ─────────────────────────────────────────────────
+       * Apple's CTA family is split across two silhouettes:
+       *   - .btn-pill / .btn-pill-secondary  — the signature 980px
+       *     capsule used on every marketing hero and product page.
+       *   - .btn / .btn-primary / .btn-secondary — the 8/12px-radius
+       *     compact controls used in commerce / configurator
+       *     surfaces where the capsule would feel too marketing-y.
+       *
+       * Both share base sizing (8/15px padding per DESIGN.md §4) and
+       * the focus halo. Hover lifts the blue (--accent-hover) rather
+       * than darkens it — Apple's documented behaviour. Press scales
+       * the button down 2% per DESIGN.md §4 ("active controls
+       * commonly reduce scale to indicate physical press"). */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 8px 16px;
+        border: 1px solid transparent;
+        border-radius: var(--radius-sm);
+        font-family: var(--font-body);
+        font-weight: 500;
+        font-size: var(--text-sm);
+        line-height: 1.2;
+        cursor: pointer;
+        text-decoration: none;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          border-color    var(--motion-fast) var(--ease-standard),
+          transform       var(--motion-fast) var(--ease-standard),
+          box-shadow      var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible {
+        outline: none;
+        box-shadow: var(--focus-ring);
+      }
+      .btn:active { transform: scale(0.98); }
+
+      .btn-primary {
+        background: var(--accent);
+        color: var(--accent-on);
+      }
+      .btn-primary:hover  { background: var(--accent-hover); }
+      .btn-primary:active { background: var(--accent-active); }
+
+      .btn-secondary {
+        background: transparent;
+        color: var(--fg);
+        border-color: var(--border);
+      }
+      .btn-secondary:hover {
+        background: var(--surface);
+        border-color: var(--meta);
+      }
+
+      /* The Apple capsule. --radius-pill is bound to 980px in tokens
+         (the literal published Apple value); the geometry is the
+         brand signature and earns its own component. */
+      .btn-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 12px 22px;
+        border: none;
+        border-radius: var(--radius-pill);
+        font-family: var(--font-body);
+        font-weight: 400;
+        font-size: var(--text-base);
+        line-height: 1.2;
+        letter-spacing: -0.005em;
+        cursor: pointer;
+        text-decoration: none;
+        background: var(--accent);
+        color: var(--accent-on);
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          transform        var(--motion-fast) var(--ease-standard),
+          box-shadow       var(--motion-fast) var(--ease-standard);
+      }
+      .btn-pill:hover  { background: var(--accent-hover); }
+      .btn-pill:active { background: var(--accent-active); transform: scale(0.98); }
+      .btn-pill:focus-visible {
+        outline: none;
+        box-shadow: var(--focus-ring);
+      }
+      .btn-pill-secondary {
+        background: transparent;
+        color: var(--accent);
+        box-shadow: var(--elev-ring);
+      }
+      .btn-pill-secondary:hover {
+        background: var(--surface);
+        color: var(--accent-hover);
+      }
+      .btn-pill-secondary:active {
+        color: var(--accent-active);
+        transform: scale(0.98);
+      }
+
+      /* ─── Inputs ────────────────────────────────────────────────
+       * Apple's retail inputs are border-led rather than fill-led —
+       * a hairline #d2d2d7 box on white, dark text, the focus halo
+       * tightens the border to --accent and adds the blue glow.
+       * Density stays quiet so device imagery dominates. */
+      .field {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+      }
+      .field label {
+        font-size: var(--text-sm);
+        font-weight: 500;
+        color: var(--fg);
+        letter-spacing: -0.016em;
+      }
+      .field input {
+        padding: 12px 14px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: 1.2;
+        outline: none;
+        transition:
+          border-color var(--motion-fast) var(--ease-standard),
+          box-shadow   var(--motion-fast) var(--ease-standard);
+      }
+      .field input::placeholder { color: var(--muted); }
+      .field input:hover { border-color: var(--meta); }
+      .field input:focus-visible {
+        border-color: var(--accent);
+        box-shadow: var(--focus-ring);
+      }
+      .field-help {
+        font-size: var(--text-xs);
+        color: var(--muted);
+      }
+
+      /* ─── Cards ─────────────────────────────────────────────────
+       * Two intents:
+       *   - .card           plain editorial / product card. Lives on
+       *                     pale gray (--surface) bands; lifts to
+       *                     white (--bg) with a hairline. No shadow
+       *                     by default — surface contrast does the
+       *                     work.
+       *   - .card-feature   featured spotlight. Squircle 18px
+       *                     (--radius-lg), the soft Apple shadow on
+       *                     hover. Used sparingly — one per band. */
+      .card {
+        background: var(--bg);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        padding: var(--space-6);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+        transition: box-shadow var(--motion-base) var(--ease-standard);
+      }
+      .card:hover {
+        box-shadow: var(--elev-raised);
+      }
+      .card-feature {
+        background: var(--surface-warm);
+        border: 1px solid var(--border-soft);
+        border-radius: var(--radius-lg);
+        padding: var(--space-8) var(--space-6);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+        box-shadow: var(--elev-raised);
+      }
+
+      /* ─── Badges ──────────────────────────────────────────────── */
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 4px var(--space-3);
+        border-radius: var(--radius-pill);
+        font-family: var(--font-body);
+        font-size: var(--text-xs);
+        font-weight: 500;
+        line-height: 1.4;
+        letter-spacing: -0.01em;
+      }
+      .badge-success {
+        color: var(--success);
+        background: color-mix(in oklab, var(--success), transparent 90%);
+      }
+      .badge-muted {
+        color: var(--muted);
+        background: color-mix(in oklab, var(--muted), transparent 88%);
+      }
+      .badge-dot {
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: currentColor;
+      }
+
+      /* ─── Links ─────────────────────────────────────────────────
+       * Apple's link tone uses Body Link Blue (#0066cc, our
+       * --accent-active) for inline reading, with the chevron-arrow
+       * suffix on call-to-action links. The base color is --accent
+       * for buttons / nav; here we re-bind for the inline reading
+       * tone via --accent-active. */
+      a {
+        color: var(--accent-active);
+        text-decoration: none;
+      }
+      a:hover {
+        text-decoration: underline;
+        text-underline-offset: 3px;
+      }
+
+      /* ─── Kbd ─────────────────────────────────────────────────── */
+      kbd {
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        font-weight: 500;
+        padding: 2px 6px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+        background: var(--bg);
+        color: var(--fg-2);
+      }
+
+      /* ─── Distinctive: glass nav strip ──────────────────────────
+       * DESIGN.md §4 — "Global Marketing Nav: compact dark translucent
+       * bar with small-type links and restrained iconography." We
+       * implement the light counterpart: a frosted white strip with
+       * backdrop-blur, hairline bottom border, and SF Pro Text 14px
+       * link tier. The blur is what gives Apple chrome its signature
+       * "atmospheric layering" (DESIGN.md §6). */
+      .nav {
+        position: sticky;
+        top: 0;
+        z-index: 10;
+        background: color-mix(in oklab, var(--bg), transparent 20%);
+        -webkit-backdrop-filter: saturate(180%) blur(20px);
+        backdrop-filter:         saturate(180%) blur(20px);
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .nav-inner {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+        height: 44px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-6);
+      }
+      .nav-brand {
+        font-family: var(--font-display);
+        font-size: var(--text-base);
+        font-weight: 500;
+        color: var(--fg);
+        letter-spacing: -0.011em;
+      }
+      .nav-links {
+        display: flex;
+        gap: var(--space-6);
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .nav-links a {
+        font-size: var(--text-sm);
+        font-weight: 400;
+        color: var(--fg);
+        letter-spacing: -0.016em;
+        opacity: 0.8;
+        transition: opacity var(--motion-fast) var(--ease-standard);
+      }
+      .nav-links a:hover {
+        opacity: 1;
+        text-decoration: none;
+      }
+      @media (max-width: 639px) {
+        .nav-inner { gap: var(--space-3); padding-inline: var(--container-gutter-phone); }
+        .nav-links { gap: var(--space-4); }
+      }
+
+      /* ─── Section-specific layout ───────────────────────────── */
+      .hero-grid {
+        display: grid;
+        grid-template-columns: 1.3fr 1fr;
+        gap: var(--space-12);
+        align-items: end;
+      }
+      @media (max-width: 1023px) {
+        .hero-grid { grid-template-columns: 1fr; gap: var(--space-8); }
+      }
+      .hero-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3);
+        margin-block-start: var(--space-6);
+      }
+      .hero-meta {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+        padding: var(--space-5);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--bg);
+      }
+      .features-grid {
+        display: grid;
+        grid-template-columns: 1.3fr 1fr 1fr;
+        gap: var(--space-5);
+      }
+      @media (max-width: 1023px) {
+        .features-grid { grid-template-columns: 1fr 1fr; }
+        .features-grid > :first-child { grid-column: span 2; }
+      }
+      @media (max-width: 639px) {
+        .features-grid { grid-template-columns: 1fr; }
+        .features-grid > :first-child { grid-column: auto; }
+      }
+      .form-row {
+        display: grid;
+        grid-template-columns: 1.3fr 1fr;
+        gap: var(--space-12);
+        align-items: start;
+      }
+      @media (max-width: 1023px) {
+        .form-row { grid-template-columns: 1fr; gap: var(--space-8); }
+      }
+      .form {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+        max-width: 420px;
+      }
+      .form-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3);
+        margin-block-start: var(--space-2);
+      }
+      .icon { width: 16px; height: 16px; flex-shrink: 0; }
+      .row-between {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-3);
+      }
+    </style>
+  </head>
+  <body>
+    <!-- ════════════════════════════════════════════════════════════
+         NAV — Apple's distinctive frosted-glass strip. Sticky to top,
+         44px tall, SF Pro Text 14px links at 0.8 opacity that
+         brighten on hover. Backdrop saturate + blur is what gives
+         Apple chrome its atmospheric layering (DESIGN.md §6).
+    ═══════════════════════════════════════════════════════════════ -->
+    <header class="nav" data-od-id="nav">
+      <div class="nav-inner">
+        <span class="nav-brand">Apple</span>
+        <nav aria-label="Primary">
+          <ul class="nav-links">
+            <li><a href="#hero">Tokens</a></li>
+            <li><a href="#features">System</a></li>
+            <li><a href="#form">Contact</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <!-- ════════════════════════════════════════════════════════════
+           HERO — exercises: h1 (56px display, tracking -0.015em),
+           .lead, .eyebrow, .btn-pill (the signature 980px capsule)
+           paired with .btn-pill-secondary (ring-edge counterpart),
+           kbd, .badge-success. Asymmetric grid (1.3:1) so the
+           composition doesn't read as a generic centered template.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section class="band-light" data-od-id="hero" id="hero">
+        <div class="container">
+          <div class="hero-grid">
+            <div class="stack-4">
+              <p class="eyebrow">Reference fixture · Apple</p>
+              <h1>Quiet chrome. Loud product. One token block.</h1>
+              <p class="lead" style="max-width: 52ch">
+                The interface engineered to disappear, distilled into
+                fifty-six tokens. Pale-gray feature ladder over white,
+                a single Apple Action Blue, SF Pro at compressed
+                tracking, and the 980-pixel capsule that has carried
+                every Buy button for a decade.
+              </p>
+              <div class="hero-actions">
+                <a href="./tokens.css" class="btn-pill">
+                  View tokens
+                  <svg
+                    class="icon"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.75"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    aria-hidden="true"
+                  >
+                    <path d="M5 12h14M13 6l6 6-6 6" />
+                  </svg>
+                </a>
+                <a href="./DESIGN.md" class="btn-pill btn-pill-secondary">
+                  Read the spec
+                </a>
+              </div>
+            </div>
+
+            <aside class="hero-meta" aria-label="System status">
+              <div class="row-between">
+                <span class="body-sm">System status</span>
+                <span class="badge badge-success">
+                  <span class="badge-dot" aria-hidden="true"></span>
+                  Stable
+                </span>
+              </div>
+              <p class="body-sm body-muted">
+                Last reviewed
+                <time datetime="2026-05-14">2026-05-14</time> · v0.1
+              </p>
+              <p class="body-sm body-muted">
+                Press <kbd>⌘</kbd> <kbd>K</kbd> to search tokens.
+              </p>
+            </aside>
+          </div>
+        </div>
+      </section>
+
+      <!-- ════════════════════════════════════════════════════════════
+           FEATURES — band switches to pale Apple gray (--surface),
+           cards lift back to white with a hairline. The first card
+           is .card-feature (squircle, soft Apple shadow), the next
+           two are plain .card. Each card describes a real property
+           of this fixture (no "feature one/two/three" filler).
+      ═══════════════════════════════════════════════════════════════ -->
+      <section class="band-soft" data-od-id="features" id="features">
+        <div class="container">
+          <div class="stack-3" style="max-width: 720px">
+            <p class="eyebrow">What this fixture exercises</p>
+            <h2>Every component below uses only var(--*).</h2>
+            <p class="lead body-muted">
+              Three cards, three real schema decisions worth
+              inspecting. Rebind the token block and the same shapes
+              follow.
+            </p>
+          </div>
+
+          <div class="features-grid" style="margin-block-start: var(--space-12)">
+            <article class="card-feature">
+              <p class="eyebrow">Featured</p>
+              <h3>Surface ladder, three stops, no aliasing.</h3>
+              <p class="body-muted">
+                Pure white retail canvas, near-white bridge, pale
+                Apple gray feature band. Apple's three light tiers
+                are real, so we keep --surface-warm independent of
+                --surface instead of collapsing it. Cards on the
+                gray band lift back to white with a hairline.
+              </p>
+              <div>
+                <a href="./tokens.css" class="btn btn-secondary">
+                  Inspect tokens
+                </a>
+              </div>
+            </article>
+
+            <article class="card">
+              <h3>Accent discipline</h3>
+              <p class="body-muted body-sm">
+                --accent appears at most twice on this screen — the
+                primary capsule CTA and the focus halo. The hero
+                status uses --success instead, so the page does not
+                feel mono-blue.
+              </p>
+              <a href="./DESIGN.md" class="body-sm">Read the rule →</a>
+            </article>
+
+            <article class="card">
+              <h3>Type at scale</h3>
+              <p class="body-muted body-sm">
+                SF Pro Display for the hero, SF Pro Text for body and
+                controls, body baseline at 17px (not 16), display
+                tracking compressed to -0.015em. Hierarchy comes from
+                size and weight — never a third type face.
+              </p>
+              <a href="./tokens.css" class="body-sm">Inspect typography →</a>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <!-- ════════════════════════════════════════════════════════════
+           FORM — exercises: .field, input :focus-visible (border
+           tightens to --accent + the 4px blue halo), .btn-primary
+           (the compact 8px-radius commerce CTA), .btn-secondary
+           (border-led counterpart), .field-help. Band switches to
+           the warm near-white tier so the form reads as a quiet
+           transactional surface, not a hero.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section class="band-warm" data-od-id="form" id="form">
+        <div class="container">
+          <div class="form-row">
+            <div class="stack-4">
+              <p class="eyebrow">Form components</p>
+              <h2>Inputs inherit the same tokens.</h2>
+              <p class="lead body-muted" style="max-width: 48ch">
+                Border-led containment, dark Near-Black Ink text, the
+                focus halo at four pixels of soft Apple Action Blue.
+                The submit button reuses the compact .btn-primary —
+                no new token introduced for this section.
+              </p>
+            </div>
+
+            <form class="form" onsubmit="event.preventDefault();">
+              <div class="field">
+                <label for="email">Apple ID email</label>
+                <input
+                  id="email"
+                  type="email"
+                  placeholder="you@icloud.com"
+                  autocomplete="email"
+                  required
+                />
+                <p class="field-help">
+                  We'll send the spec PDF and nothing else.
+                </p>
+              </div>
+              <div class="form-actions">
+                <button type="submit" class="btn btn-primary">
+                  Send the spec
+                </button>
+                <button type="button" class="btn btn-secondary">
+                  Skip for now
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/apple/tokens.css
+++ b/design-systems/apple/tokens.css
@@ -1,0 +1,286 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/apple/tokens.css
+ *
+ * Structured token bindings for the Apple-inspired design system —
+ * a precision editorial language built around white-space discipline,
+ * SF Pro typography, and a single restrained blue accent. This file
+ * is the *machine-readable* form of the values described in
+ * `DESIGN.md`. Agents are expected to paste the `:root { … }` block
+ * verbatim into the first `<style>` of every artifact they generate
+ * against this design system, then reference everything via
+ * var(--name) from then on.
+ *
+ * Why this file exists:
+ *   DESIGN.md tells humans that Apple uses "Pale Apple Gray (#f5f5f7)
+ *   as the main light surface" and "Apple Action Blue (#0071e3) as the
+ *   primary accent", but agents have to translate those prose names
+ *   into the standard token names the lint enforces (`--surface`,
+ *   `--accent`). That translation step is where token misuse happens.
+ *   This file pre-translates the brand once, so agents copy structure
+ *   instead of inventing it.
+ *
+ * Brand-specific schema decisions (non-obvious bindings worth flagging
+ * for reviewers and downstream brand authors):
+ *   1. We bind --surface-warm to a real intermediate tier (#fbfbfd),
+ *      NOT an alias of --surface. Apple's surface ladder genuinely has
+ *      three light stops — pure white retail canvas, near-white
+ *      brightness-shifted bands, and pale Apple gray feature fields —
+ *      so collapsing surface-warm would erase a real brand feature.
+ *   2. We bind --fg-2, --meta, and --border-soft to independent values
+ *      rather than aliases. Apple's neutral text ramp is famously
+ *      four-stop (Near-Black Ink → Utility Dark Gray → Secondary
+ *      Neutral Gray → Mid Border Gray) and the schema's B-slots map
+ *      onto it cleanly.
+ *   3. --radius-pill is bound to 980px, not 9999px. Apple's signature
+ *      capsule CTA literally uses 980px in published CSS, and the
+ *      number is itself a brand-recognisable detail; we keep it.
+ *   4. --accent-hover lifts (#0077ed) instead of darkening. Apple's
+ *      live blue buttons brighten slightly on hover rather than mix
+ *      toward black; the schema's default formula would fight that.
+ *      --accent-active darkens to #0066cc — the documented Body Link
+ *      Blue — so the active state aligns with Apple's read-link tone.
+ *   5. --tracking-display is -0.015em. The DESIGN.md hierarchy lists
+ *      -1.2px on 80px hero (-0.015em); tighter than that breaks at
+ *      smaller display sizes, looser loses Apple's machined feel.
+ *   6. --section-y-desktop is 100px. Apple's billboard chapters lean
+ *      noticeably more generous than the schema default of 80px — the
+ *      breathing room is what lets product imagery do the talking.
+ *   7. --ease-standard is cubic-bezier(0.28, 0, 0.22, 1), an Apple-
+ *      flavoured smooth-out instead of the schema default. Apple
+ *      transitions decelerate hard then settle, never bounce.
+ *
+ * Contract sources:
+ *   - Standard token names: design-systems/_schema/tokens.schema.ts
+ *       (TOKEN_SCHEMA — every name below appears there or as an
+ *        explicit B-slot alias.)
+ *   - A2 fallback values: design-systems/_schema/defaults.css
+ *       (We override --motion-base, --ease-standard, --elev-raised,
+ *        --focus-ring, --radius-pill; the rest match defaults.)
+ *   - Lint enforcement: apps/daemon/src/lint-artifact.ts
+ *       (raw-hex >12 outside :root → P1; non-token accent → P0)
+ *
+ * Keep this file additive: never invent token names not also documented
+ * in DESIGN.md or the shared schema. New Apple-derived sub-brands
+ * cloning this template should overwrite values, not rename keys.
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface (3 levels) ──────────────────────────────────────────
+   * Apple's binary section rhythm alternates pure white retail/hero
+   * canvases with pale Apple gray feature fields. We bind --bg to
+   * the white canvas (the most common default Apple page background)
+   * and --surface to the pale gray that cards and feature bands lift
+   * onto. --surface-warm is bound to a real third tier (#fbfbfd) —
+   * the near-white brightness shift that appears between hero and
+   * pale-gray bands on apple.com. Collapsing it to var(--surface)
+   * would erase a real brand feature, so we keep it independent. */
+  --bg: #ffffff;
+  --surface: #f5f5f7;
+  --surface-warm: #fbfbfd;
+
+  /* ─── Foreground ramp (4 levels) ─────────────────────────────────
+   * Apple's text neutrals are explicitly named in DESIGN.md §2:
+   * Near-Black Ink (primary), Utility Dark Gray (secondary text /
+   * dark-neutral surfaces in store contexts), Secondary Neutral Gray
+   * (helper copy / tertiary metadata), Mid Border Gray (the strongest
+   * neutral, used for stronger field outlines and the most-restrained
+   * caption tier). We bind all four — Apple genuinely walks the full
+   * ramp, so collapsing --fg-2 or --meta to siblings would flatten
+   * the brand.
+   *
+   * Note that none of these are pure black (#000000). #000000 is
+   * reserved for hero canvases and dark chapters; for body type on
+   * white, #1d1d1f gives the slight warmth that reads as Apple. */
+  --fg: #1d1d1f;
+  --fg-2: #424245;
+  --muted: #6e6e73;
+  --meta: #86868b;
+
+  /* ─── Border (2 levels) ──────────────────────────────────────────
+   * Soft Border Gray (#d2d2d7) is Apple's default divider weight and
+   * card-edge color. --border-soft is bound to a lighter near-neutral
+   * (#e8e8ed) for inner row separators in dense retail tables and
+   * configurator option lists, where the d2d2d7 hairline would
+   * over-compete with the option labels. */
+  --border: #d2d2d7;
+  --border-soft: #e8e8ed;
+
+  /* ─── Accent ──────────────────────────────────────────────────────
+   * Apple Action Blue — the system's only persistent chromatic move.
+   * DESIGN.md §7 ("Don't introduce broad secondary accent palettes
+   * that compete with Apple blue") makes this a one-color brand for
+   * action and link semantics; the schema's hard cap of ≤2 visible
+   * accent uses per screen aligns naturally. */
+  --accent: #0071e3;
+  --accent-on: #ffffff; /* white label on the blue fill */
+
+  /* ─── Accent states ───────────────────────────────────────────────
+   * Apple's live primary buttons LIGHTEN on hover (the blue gains
+   * luminance) and darken on press. The schema's default black-mix
+   * formula would fight that motion, so we hand-pick both values:
+   *   - hover: #0077ed (≈ 4% brighter than --accent)
+   *   - active: #0066cc (the documented Body Link Blue from DESIGN.md
+   *             §2, which doubles cleanly as the press tone)
+   *
+   * Schema rule: every brand provides --accent-hover and
+   * --accent-active. The binding strategy (formula / hand-picked /
+   * identity) is brand-decided. Default uses formulas; kami uses
+   * identity + hand-picked; Apple uses hand-picked in both
+   * directions. */
+  --accent-hover: #0077ed;
+  --accent-active: #0066cc;
+
+  /* ─── Semantic ────────────────────────────────────────────────────
+   * Apple's DESIGN.md §2 explicitly notes "no distinct semantic
+   * palette was consistently visible in the extracted surface set" —
+   * so we inherit the schema defaults verbatim. Apple artifacts
+   * almost never need success / warn / danger; when they do, the
+   * defaults are restrained enough not to fight the blue accent.
+   * Reserve under 5% of any surface area regardless. */
+  --success: #16a34a;
+  --warn:    #eab308;
+  --danger:  #dc2626;
+
+  /* ─── Typography ──────────────────────────────────────────────────
+   * Apple's documented split is two SF Pro families: SF Pro Display
+   * for hero / merchandising headings, SF Pro Text for navigation,
+   * controls, and dense commerce copy. We mirror the exact published
+   * fallback chain (SF Pro Icons → Helvetica Neue → Helvetica → Arial
+   * → sans-serif) so artifacts rendered on non-macOS clients land on
+   * the closest practical substitute.
+   *
+   * SF Mono leads the monospace stack — Apple's brand mono — with
+   * the schema fallbacks behind it for portability. */
+  --font-display:
+    "SF Pro Display", "SF Pro Icons", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-body:
+    "SF Pro Text", "SF Pro Icons", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-mono:
+    "SF Mono", ui-monospace, "JetBrains Mono", Menlo, Monaco, Consolas, monospace;
+
+  /* Type scale (px) — derived from DESIGN.md §3 hierarchy table.
+   * Apple's body baseline is 17px (NOT the 16px web norm) because
+   * SF Pro Text was metrically tuned at 17 for Retina; rebinding
+   * --text-base to anything else collapses the brand's reading
+   * texture. The display ceiling is the 80px Hero Display XL. */
+  --text-xs:   12px;   /* Micro UI — fine print, micro labels */
+  --text-sm:   14px;   /* Control Label — buttons, helper labels */
+  --text-base: 17px;   /* Body Primary — Apple's reading baseline */
+  --text-lg:   21px;   /* Link/Action Heading — large promo links */
+  --text-xl:   28px;   /* Card/Product Title — tile-level naming */
+  --text-2xl:  40px;   /* Product Heading — campaign section titles */
+  --text-3xl:  56px;   /* Hero Display L — homepage hero moments */
+  --text-4xl:  80px;   /* Hero Display XL — Environment / store hero */
+
+  /* Apple's leading envelope is unusually tight at the top of the
+   * scale (display sizes ride at 1.00–1.10) and unusually airy in
+   * the body (1.47, well above the web 1.4 default). Both numbers
+   * come straight from DESIGN.md §3. */
+  --leading-body:  1.47;   /* SF Pro Text body, 17px */
+  --leading-tight: 1.05;   /* Hero Display XL ceiling */
+
+  /* Display tracking compresses to -0.015em — the famous Apple
+   * machined-headline feel. DESIGN.md §3 lists -1.2px on 80px
+   * (≈ -0.015em); we bind a single em-value so the same rule applies
+   * across the display tiers. Body type runs at 0 / -0.374px and is
+   * left to component-level rules so as not to hurt readability. */
+  --tracking-display: -0.015em;
+
+  /* ─── Spacing ─────────────────────────────────────────────────────
+   * Apple's underlying grid is 8px (DESIGN.md §5), with utility
+   * micro-steps (2/4/6/7/8/9/10) for precision alignment. The shared
+   * schema's 4-8-12-16-20-24-32-48 scale fits cleanly — we inherit
+   * the defaults. Component-internal values that don't match a token
+   * (Apple's 14px or 17px utility intervals) stay inline at the
+   * call site rather than spawning extra spacing tokens. */
+  --space-1:  4px;
+  --space-2:  8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  20px;
+  --space-6:  24px;
+  --space-8:  32px;
+  --space-12: 48px;
+
+  /* ─── Section rhythm ──────────────────────────────────────────────
+   * Apple's billboard chapters lean noticeably more generous than the
+   * schema default of 80px — broad top/bottom breathing room is what
+   * lets product imagery dominate the page. We bind 100/64/40, a
+   * slightly wider envelope than default's 80/48/32. */
+  --section-y-desktop: 100px;
+  --section-y-tablet:  64px;
+  --section-y-phone:   40px;
+
+  /* ─── Radius ──────────────────────────────────────────────────────
+   * Apple uses purposeful radius tiers (DESIGN.md §5 §7 — "don't
+   * flatten all corners to a single radius"). The mapping:
+   *   --radius-sm   → 8px   compact controls and fields
+   *   --radius-md   → 12px  standard buttons, configurator chips
+   *   --radius-lg   → 18px  cards, module frames, commerce panels
+   *   --radius-pill → 980px Apple's signature capsule CTA — we keep
+   *                          the literal value rather than collapse
+   *                          to 9999px because the number itself is
+   *                          a brand-recognisable detail in Apple's
+   *                          published CSS.
+   *
+   * The 28-36px spotlight tier and the 56px capsule sub-tier are
+   * component-internal one-offs and stay inline — they do not earn
+   * their own tokens until a second use appears. */
+  --radius-sm:   8px;
+  --radius-md:   12px;
+  --radius-lg:   18px;
+  --radius-pill: 980px;
+
+  /* ─── Elevation (3 levels) ────────────────────────────────────────
+   * Apple uses depth sparingly (DESIGN.md §6 — "depth is intentionally
+   * restrained"). Three sanctioned levels:
+   *   - flat   → none (the default; tonal contrast does the work)
+   *   - ring   → 0 0 0 1px var(--border) (border-led containment in
+   *              dense retail contexts)
+   *   - raised → 0 12px 32px rgba(0,0,0,0.08) (the soft Apple card
+   *              shadow; rgba 0.08 is the lower bound from DESIGN.md
+   *              §6's "0.08 → 0.22" range, which keeps cards from
+   *              feeling Material-flavoured)
+   *
+   * No fourth level — that would be the Material/neumorphism stack
+   * Apple consciously avoids. */
+  --elev-flat:   none;
+  --elev-ring:   0 0 0 1px var(--border);
+  --elev-raised: 0 12px 32px rgba(0, 0, 0, 0.08);
+
+  /* ─── Focus ring ──────────────────────────────────────────────────
+   * Apple's keyboard-focus signal is a soft blue glow at the action
+   * accent (DESIGN.md §6 — "Blue focus signal (#0071e3) for keyboard
+   * and selection emphasis"). We use a 4px ring at ~35% accent
+   * opacity, slightly larger than the schema's 3px default so it
+   * reads as the deliberate Apple halo rather than a generic outline.
+   * Implemented as a box-shadow so it layers outside the element
+   * without affecting layout. */
+  --focus-ring: 0 0 0 4px color-mix(in oklab, var(--accent), transparent 65%);
+
+  /* ─── Motion ──────────────────────────────────────────────────────
+   * Apple transitions decelerate hard and settle — never bounce,
+   * never spring past the target. We override the schema default
+   * easing with cubic-bezier(0.28, 0, 0.22, 1), the curve Apple
+   * uses on apple.com for hover and section reveals; --motion-base
+   * is bumped from 200ms → 220ms because Apple's micro-interactions
+   * carry slightly more cinematic weight than the web default.
+   * --motion-fast stays at 150ms for true micro-states (hover tints,
+   * focus, kbd press feedback). */
+  --motion-fast:   150ms;
+  --motion-base:   220ms;
+  --ease-standard: cubic-bezier(0.28, 0, 0.22, 1);
+
+  /* ─── Layout ──────────────────────────────────────────────────────
+   * Apple's marketing core is a constrained readable column with
+   * generous outer margins (DESIGN.md §5). 1024px max keeps lines
+   * inside the SF Pro Text comfortable-measure ceiling (~80ch at
+   * 17px) while leaving the chapter band full-bleed. Gutters step
+   * 22 → 18 → 16 across desktop / tablet / phone — slightly tighter
+   * than default to honor Apple's "broad horizontal breathing room
+   * but column-disciplined content" balance. */
+  --container-max:            1024px;
+  --container-gutter-desktop: 22px;
+  --container-gutter-tablet:  18px;
+  --container-gutter-phone:   16px;
+}

--- a/design-systems/cursor/components.html
+++ b/design-systems/cursor/components.html
@@ -1,0 +1,651 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Cursor — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/cursor. Every visible
+        value comes from tokens.css; if the agent paste-replaces the
+        :root block and reuses the component selectors below verbatim,
+        the artifact passes lint without further audit. Cursor's
+        signature moves: warm cream surfaces, three typographic voices
+        (CursorGothic / jjannon / berkeleyMono), oklab borders rendered
+        as rgba fallback, hover-text shifts to --danger crimson, and
+        diffused atmospheric shadows."
+    />
+
+    <style>
+      /* :root paste — sourced verbatim from
+         design-systems/cursor/tokens.css. Keep this block in sync
+         when tokens.css changes. The agent prompt instructs the
+         Designer panelist to paste this block as the FIRST thing in
+         their <style>, then reference everything below via var(...). */
+      :root {
+        --bg: #f2f1ed;
+        --surface: #e6e5e0;
+        --surface-warm: #ebeae5;
+
+        --fg: #26251e;
+        --fg-2: rgba(38, 37, 30, 0.9);
+        --muted: rgba(38, 37, 30, 0.55);
+        --meta: rgba(38, 37, 30, 0.4);
+
+        --border: rgba(38, 37, 30, 0.1);
+        --border-soft: rgba(38, 37, 30, 0.06);
+
+        --accent: #f54e00;
+        --accent-on: #ffffff;
+        --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+        --success: #1f8a65;
+        --warn: #eab308;
+        --danger: #cf2d56;
+
+        --font-display: "CursorGothic", "CursorGothic Fallback", system-ui, "Helvetica Neue", Helvetica, Arial, sans-serif;
+        --font-body: "jjannon", "Iowan Old Style", "Palatino Linotype", "URW Palladio L", P052, ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
+        --font-mono: "berkeleyMono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+
+        --text-xs: 11px;
+        --text-sm: 14px;
+        --text-base: 16px;
+        --text-lg: 19.2px;
+        --text-xl: 22px;
+        --text-2xl: 26px;
+        --text-3xl: 36px;
+        --text-4xl: 72px;
+
+        --leading-body: 1.5;
+        --leading-tight: 1.10;
+        --tracking-display: -0.03em;
+
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 80px;
+        --section-y-tablet: 48px;
+        --section-y-phone: 32px;
+
+        --radius-sm: 8px;
+        --radius-md: 10px;
+        --radius-lg: 12px;
+        --radius-pill: 9999px;
+
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised:
+          0 28px 70px rgba(0, 0, 0, 0.14),
+          0 14px 32px rgba(0, 0, 0, 0.1),
+          0 0 0 1px var(--border);
+
+        --focus-ring: 0 4px 12px rgba(0, 0, 0, 0.1);
+
+        --motion-fast: 150ms;
+        --motion-base: 200ms;
+        --ease-standard: ease;
+
+        --container-max: 1200px;
+        --container-gutter-desktop: 24px;
+        --container-gutter-tablet: 16px;
+        --container-gutter-phone: 12px;
+      }
+
+      /* ─── Reset (minimal) ───────────────────────────────────── */
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        /* Body uses jjannon serif. The three-voice system is a brand
+           signature; do not collapse to one font for "simplicity". */
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        font-feature-settings: "cswh"; /* contextual swash alternates */
+        -webkit-font-smoothing: antialiased;
+      }
+
+      /* ─── Layout primitives ─────────────────────────────────── */
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      section + section {
+        /* Cursor's section separation is via tone shift + spacing,
+           not hard rules. The ring is intentionally faint. */
+        border-top: 1px solid var(--border);
+      }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography ────────────────────────────────────────── */
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        line-height: var(--leading-tight);
+        margin: 0;
+        /* CursorGothic uses weight 400 almost exclusively; size +
+           tracking carry hierarchy, not weight (DESIGN.md §3.4). */
+        font-weight: 400;
+      }
+      h1 {
+        /* Hero uses --text-4xl=72px with the full -0.03em tracking. */
+        font-size: var(--text-4xl);
+        letter-spacing: var(--tracking-display);
+      }
+      h2 {
+        font-size: var(--text-3xl);
+        /* 36px hero tracking is -0.72px (-0.02em); proportional
+           override since the schema only carries one tracking slot. */
+        letter-spacing: -0.02em;
+      }
+      h3 {
+        font-size: var(--text-2xl);
+        /* 26px tracking is -0.325px (-0.0125em). */
+        letter-spacing: -0.0125em;
+      }
+      p { margin: 0; }
+      .lead {
+        /* Lead body in serif voice — Cursor's editorial signature. */
+        font-family: var(--font-body);
+        font-size: var(--text-lg);
+        line-height: 1.35;
+        color: var(--muted);
+      }
+      .body-muted { color: var(--muted); }
+      .body-sm { font-size: var(--text-sm); }
+      .body-mono { font-family: var(--font-mono); font-size: var(--text-sm); }
+      /* `.eyebrow` — uppercase micro label, system-ui voice. Letter
+         spacing is well above craft/typography.md's 0.06em floor. */
+      .eyebrow {
+        font-family: var(--font-display);
+        font-size: var(--text-xs);
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 500;
+      }
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+
+      /* ─── Buttons ───────────────────────────────────────────── */
+      /* Cursor's primary CTA is NOT accent-bg — it is warm-surface bg
+         with dark text, signature for the brand. The accent orange
+         appears on link decoration and on the "accent pill" CTA used
+         sparingly (≤1 per screen). The hover signature is a text-color
+         shift to --danger (warm crimson), not bg-darken. */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 10px 14px;
+        border-radius: var(--radius-sm);
+        font-family: var(--font-display);
+        font-size: var(--text-sm);
+        font-weight: 400;
+        line-height: 1;
+        cursor: pointer;
+        border: 1px solid transparent;
+        transition:
+          color var(--motion-fast) var(--ease-standard),
+          background-color var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-base) var(--ease-standard);
+        text-decoration: none;
+      }
+      .btn:focus-visible {
+        outline: none;
+        /* DESIGN.md §7: focus is depth (4 12 0.1), not halo. */
+        box-shadow: var(--focus-ring);
+      }
+      /* Primary — warm-surface CTA. */
+      .btn-primary {
+        background: var(--surface-warm);
+        color: var(--fg);
+      }
+      .btn-primary:hover { color: var(--danger); }
+      .btn-primary:active { background: var(--surface); }
+      /* Secondary — ghost on warm surface. */
+      .btn-secondary {
+        background: transparent;
+        color: var(--muted);
+        border-color: var(--border);
+      }
+      .btn-secondary:hover {
+        color: var(--danger);
+        border-color: rgba(38, 37, 30, 0.2);
+      }
+      /* Accent pill — used at most once per screen for the loudest CTA.
+         This is the only place on the page where --accent is a bg. */
+      .btn-accent {
+        background: var(--accent);
+        color: var(--accent-on);
+        border-radius: var(--radius-pill);
+        padding: 10px 18px;
+      }
+      .btn-accent:hover { background: var(--accent-hover); }
+      .btn-accent:active { background: var(--accent-active); }
+
+      /* ─── Pill tags ─────────────────────────────────────────── */
+      /* Cursor's full-pill (9999px) badges/filters — DESIGN.md §4.1. */
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 3px 10px;
+        border-radius: var(--radius-pill);
+        background: var(--surface);
+        color: var(--meta);
+        font-family: var(--font-display);
+        font-size: var(--text-sm);
+        font-weight: 400;
+        line-height: 1.5;
+      }
+      .pill-active {
+        background: rgba(38, 37, 30, 0.06); /* deeper surface for selected state */
+        color: var(--fg);
+      }
+
+      /* ─── Inputs ────────────────────────────────────────────── */
+      .field {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+      }
+      .field label {
+        font-family: var(--font-display);
+        font-size: var(--text-sm);
+        font-weight: 500;
+        color: var(--fg);
+      }
+      .field input {
+        padding: 10px 12px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        outline: none;
+        transition:
+          border-color var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-base) var(--ease-standard);
+      }
+      .field input:focus-visible {
+        outline: none;
+        border-color: rgba(38, 37, 30, 0.2);
+        box-shadow: var(--focus-ring);
+      }
+      .field input::placeholder { color: var(--meta); }
+      .field-help {
+        font-family: var(--font-body);
+        font-size: var(--text-sm);
+        color: var(--muted);
+      }
+
+      /* ─── Cards ─────────────────────────────────────────────── */
+      .card {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        padding: var(--space-5);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+        transition: box-shadow var(--motion-base) var(--ease-standard);
+      }
+      .card:hover {
+        /* DESIGN.md §7: hover shadow intensification (ambient → elevated). */
+        box-shadow: var(--elev-raised);
+      }
+      .card-featured {
+        /* Featured card uses the larger 10px radius (DESIGN.md §5.4). */
+        border-radius: var(--radius-md);
+        background: var(--bg);
+      }
+
+      /* ─── Badges ────────────────────────────────────────────── */
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 2px var(--space-3);
+        border-radius: var(--radius-pill);
+        font-family: var(--font-display);
+        font-size: var(--text-xs);
+        font-weight: 500;
+        line-height: 1.6;
+      }
+      .badge-success {
+        color: var(--success);
+        background: color-mix(in oklab, var(--success), transparent 90%);
+      }
+      .badge-muted {
+        color: var(--muted);
+        background: color-mix(in oklab, var(--muted), transparent 88%);
+      }
+      .badge-dot {
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: currentColor;
+      }
+
+      /* ─── Links ─────────────────────────────────────────────── */
+      a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+      a:hover {
+        text-decoration: underline;
+        text-underline-offset: 3px;
+        text-decoration-color: var(--meta);
+      }
+
+      /* ─── Kbd ───────────────────────────────────────────────── */
+      kbd {
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        padding: 2px 6px;
+        border-radius: 4px;
+        border: 1px solid var(--border);
+        background: var(--surface);
+        color: var(--muted);
+      }
+
+      /* ─── AI timeline (decorative, signature element) ──────── */
+      /* DESIGN.md §4.7 — Cursor's AI timeline shows four states with
+         soft "warm pastel" colors. These are decorative state markers,
+         intentionally NOT promoted to brand surface tokens. */
+      .timeline {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        background: var(--bg);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+      }
+      .timeline-step {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: var(--fg-2);
+      }
+      .timeline-dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        flex-shrink: 0;
+      }
+      .timeline-thinking .timeline-dot { background: #dfa88f; }
+      .timeline-grep     .timeline-dot { background: #9fc9a2; }
+      .timeline-read     .timeline-dot { background: #9fbbe0; }
+      .timeline-edit     .timeline-dot { background: #c0a8dd; }
+
+      /* ─── Section-specific layout ───────────────────────────── */
+      .hero-grid {
+        display: grid;
+        /* Asymmetric hero — keeps the page from looking like an
+           AI-default centered template. */
+        grid-template-columns: 1.4fr 1fr;
+        gap: var(--space-12);
+        align-items: end;
+      }
+      @media (max-width: 1023px) {
+        .hero-grid { grid-template-columns: 1fr; gap: var(--space-8); }
+      }
+      .hero-actions {
+        display: flex;
+        gap: var(--space-3);
+        margin-block-start: var(--space-6);
+      }
+      .hero-meta {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--bg);
+      }
+      .features-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: var(--space-5);
+      }
+      @media (max-width: 1023px) {
+        .features-grid { grid-template-columns: 1fr 1fr; }
+      }
+      @media (max-width: 639px) {
+        .features-grid { grid-template-columns: 1fr; }
+      }
+      .form-row {
+        display: grid;
+        grid-template-columns: 1.4fr 1fr;
+        gap: var(--space-12);
+        align-items: start;
+      }
+      @media (max-width: 1023px) {
+        .form-row { grid-template-columns: 1fr; }
+      }
+      .form {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+        max-width: 420px;
+      }
+      .form-actions {
+        display: flex;
+        gap: var(--space-3);
+        margin-block-start: var(--space-2);
+      }
+      .filter-row {
+        display: flex;
+        gap: var(--space-2);
+        flex-wrap: wrap;
+      }
+      .icon { width: 16px; height: 16px; flex-shrink: 0; }
+      .row-between {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-3);
+      }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <!-- ════════════════════════════════════════════════════════════
+           HERO — exercises: h1 (CursorGothic 72px / -0.03em),
+           .lead (jjannon serif), .eyebrow, .btn-primary (warm-surface
+           CTA + crimson hover), .btn-accent (orange pill, used once
+           per page max), kbd (berkeleyMono), .badge-success.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="hero">
+        <div class="hero-grid">
+          <div class="stack-4">
+            <p class="eyebrow">Reference fixture · cursor</p>
+            <h1>The editor your team writes through, not at.</h1>
+            <p class="lead" style="max-width: 52ch">
+              Cursor pairs a serif voice with gothic compression so
+              feature copy reads like a publication and headlines hit
+              like an engineered statement. Three fonts, one warm cream
+              canvas, every value below comes from tokens.css.
+            </p>
+            <div class="hero-actions">
+              <a href="./tokens.css" class="btn btn-accent">
+                View tokens
+                <svg
+                  class="icon"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.75"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M5 12h14M13 6l6 6-6 6" />
+                </svg>
+              </a>
+              <a href="./DESIGN.md" class="btn btn-primary">Read the spec</a>
+            </div>
+          </div>
+
+          <aside class="hero-meta" aria-label="System status">
+            <div class="row-between">
+              <span class="body-sm">System status</span>
+              <span class="badge badge-success">
+                <span class="badge-dot" aria-hidden="true"></span>
+                Stable
+              </span>
+            </div>
+            <p class="body-sm body-muted">
+              Last reviewed
+              <time datetime="2026-05-14">2026-05-14</time> · v0.1
+            </p>
+            <p class="body-sm body-muted">
+              Press <kbd>⌘</kbd> <kbd>K</kbd> to search tokens.
+            </p>
+          </aside>
+        </div>
+      </section>
+
+      <!-- ════════════════════════════════════════════════════════════
+           FEATURES — exercises: h2, h3, .card (warm surface + hover
+           shadow lift), .body-muted, .pill / .pill-active (full-pill
+           filter row), .features-grid, AI timeline component (the
+           cursor signature element).
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="features">
+        <div class="stack-3">
+          <p class="eyebrow">What this fixture exercises</p>
+          <h2 style="max-width: 28ch">
+            Every component below uses only var(--*) — no raw hex, no
+            off-token type.
+          </h2>
+        </div>
+
+        <div class="filter-row" style="margin-block-start: var(--space-6)">
+          <button class="pill pill-active">All</button>
+          <button class="pill">Surfaces</button>
+          <button class="pill">Typography</button>
+          <button class="pill">Motion</button>
+        </div>
+
+        <div class="features-grid" style="margin-block-start: var(--space-6)">
+          <article class="card">
+            <h3>Warm surfaces</h3>
+            <p class="body-muted body-sm">
+              --bg, --surface, --surface-warm form a three-tier cream
+              ladder. Pure white only inside code panels; the page
+              never reaches it on the canvas.
+            </p>
+            <a href="./tokens.css" class="body-sm">Inspect tokens →</a>
+          </article>
+
+          <article class="card">
+            <h3>Three voices</h3>
+            <p class="body-muted body-sm">
+              CursorGothic for display, jjannon serif for body,
+              berkeleyMono for code. Each voice carries one role; the
+              system never collapses to two faces.
+            </p>
+            <a href="./DESIGN.md" class="body-sm">Read the spec →</a>
+          </article>
+
+          <article class="card card-featured">
+            <h3>oklab borders</h3>
+            <p class="body-muted body-sm">
+              Borders ship as rgba fallbacks of the oklab originals at
+              0.1 / 0.06 alpha — perceptually uniform across every
+              warm surface.
+            </p>
+            <a href="./tokens.css" class="body-sm">Inspect borders →</a>
+          </article>
+        </div>
+
+        <div class="timeline" style="margin-block-start: var(--space-8); max-width: 480px">
+          <p class="eyebrow">AI timeline · signature element</p>
+          <div class="timeline-step timeline-thinking">
+            <span class="timeline-dot" aria-hidden="true"></span>
+            <span>thinking…</span>
+          </div>
+          <div class="timeline-step timeline-grep">
+            <span class="timeline-dot" aria-hidden="true"></span>
+            <span>grep "tokens.css" -r design-systems/</span>
+          </div>
+          <div class="timeline-step timeline-read">
+            <span class="timeline-dot" aria-hidden="true"></span>
+            <span>read default/tokens.css</span>
+          </div>
+          <div class="timeline-step timeline-edit">
+            <span class="timeline-dot" aria-hidden="true"></span>
+            <span>edit cursor/tokens.css → +56 tokens</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- ════════════════════════════════════════════════════════════
+           FORM — exercises: .field (jjannon body input), focus-visible
+           depth shadow (no halo), .btn-primary (warm-surface CTA),
+           .btn-secondary (ghost border), .field-help.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="form">
+        <div class="form-row">
+          <div class="stack-4">
+            <p class="eyebrow">Form components</p>
+            <h2>Inputs inherit the same tokens.</h2>
+            <p class="body-muted" style="max-width: 48ch">
+              The focus state is a soft 4px-12px depth shadow — no
+              cool-blue halo. Border weights stay at oklab 0.1; on
+              focus the active border lifts to 0.2.
+            </p>
+          </div>
+
+          <form class="form" onsubmit="event.preventDefault();">
+            <div class="field">
+              <label for="email">Work email</label>
+              <input
+                id="email"
+                type="email"
+                placeholder="you@team.dev"
+                autocomplete="email"
+                required
+              />
+              <p class="field-help">
+                We'll send the spec PDF and nothing else.
+              </p>
+            </div>
+            <div class="form-actions">
+              <button type="submit" class="btn btn-primary">
+                Send the spec
+              </button>
+              <button type="button" class="btn btn-secondary">
+                Skip for now
+              </button>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/cursor/components.html
+++ b/design-systems/cursor/components.html
@@ -150,13 +150,16 @@
       }
       h2 {
         font-size: var(--text-3xl);
-        /* 36px hero tracking is -0.72px (-0.02em); proportional
-           override since the schema only carries one tracking slot. */
+        /* 36px section heading: line-height 1.20, tracking -0.72px (-0.02em).
+           Overrides the shared 1.10 (--leading-tight) set on h1/h2/h3 above. */
+        line-height: 1.20;
         letter-spacing: -0.02em;
       }
       h3 {
         font-size: var(--text-2xl);
-        /* 26px tracking is -0.325px (-0.0125em). */
+        /* 26px sub-heading: line-height 1.25, tracking -0.325px (-0.0125em).
+           Overrides the shared 1.10 (--leading-tight) set on h1/h2/h3 above. */
+        line-height: 1.25;
         letter-spacing: -0.0125em;
       }
       p { margin: 0; }

--- a/design-systems/cursor/tokens.css
+++ b/design-systems/cursor/tokens.css
@@ -1,0 +1,218 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/cursor/tokens.css
+ *
+ * Structured token bindings for the "Cursor" brand — the AI-first code
+ * editor's marketing voice translated into the shared schema. Like
+ * `default/tokens.css` and `kami/tokens.css`, agents are expected to
+ * paste the `:root { … }` block verbatim into the first `<style>` of
+ * every artifact, then reference values via `var(--name)`.
+ *
+ * Why this file exists:
+ *   DESIGN.md describes Cursor in prose ("warm cream `#f2f1ed`, warm
+ *   near-black `#26251e` text, oklab borders") — agents have to translate
+ *   that prose into shared token names without inventing brand variants
+ *   like `--cursor-cream`. This file pre-translates once.
+ *
+ * Brand identity in three sentences:
+ *   1. Warm-shifted everything — cream surfaces, near-black-with-yellow
+ *      text, oklab-space borders. Pure white / pure black are reserved
+ *      for code-editor panels and nowhere else.
+ *   2. Three typographic voices — CursorGothic at display sizes with
+ *      aggressive negative letter-spacing (signature), jjannon serif for
+ *      editorial body, berkeleyMono for code/kbd.
+ *   3. Hover semantic is text→crimson (`--danger`), not bg-darken.
+ *      Component CSS reading `--accent-hover` still gets the schema's
+ *      darken formula because some artifacts (CTA pills with accent bg)
+ *      do need it; the brand-signature crimson hover is component-level
+ *      not token-level.
+ *
+ * Schema decisions specific to Cursor:
+ *   - --surface-warm binds to a real warmer tier (#ebeae5 — the
+ *     "Surface 300" button-default), not aliased to surface. Cursor's
+ *     surface scale 100→500 is a hallmark; the schema slot maps to the
+ *     middle tier that buttons rest on.
+ *   - --fg-2, --meta, --border-soft bind to oklab-fallback rgba values
+ *     at distinct alpha levels (0.9 / 0.4 / 0.06) rather than aliasing,
+ *     because Cursor genuinely has the richer ramp.
+ *   - --tracking-display is set to -0.03em (the 72px hero value
+ *     normalized to em). Smaller display sizes in components should
+ *     scale tracking proportionally; the schema only carries one slot.
+ *   - --elev-raised binds to Cursor's signature 28px/70px diffused
+ *     shadow rather than the schema fallback. This is the depth move
+ *     that makes Cursor feel like a print publication.
+ *   - --focus-ring is depth-only (0 4px 12px), not the halo formula.
+ *     Cursor never paints cool-blue rings.
+ *   - --ease-standard: ease (per DESIGN.md §Interaction & Motion), not
+ *     the schema's cubic-bezier. Brand authenticity over micro-control.
+ *
+ * Tokens NOT lifted (intentional):
+ *   - The fine-grained sub-8px spacing scale (1.5px, 2px, 2.5px, 3px,
+ *     5px, 6px) used for icon/text micro-alignment is component-internal
+ *     in this fixture. Promote to C-extension via BRAND_EXTENSIONS only
+ *     if cross-component reuse demands it.
+ *   - The named surface scale 100/200/300/400/500 is encoded via the
+ *     three schema slots (--bg / --surface / --surface-warm). The
+ *     extreme tiers (100 lightest, 500 deepest) live as inline
+ *     declarations in components.html where needed.
+ *   - The timeline state colors (Thinking peach, Grep sage, Read blue,
+ *     Edit lavender) are decorative state markers, not brand surface
+ *     tokens. They belong in component CSS for the AI timeline element,
+ *     not in :root.
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface (3 levels) ──────────────────────────────────────────
+   * Cream canvas that defines the entire warm system. Default's
+   * `#fafafa → #ffffff` ladder gets replaced by `#f2f1ed → #e6e5e0`,
+   * with the warmer surface tier (#ebeae5) bound to --surface-warm
+   * for buttons that rest on the page background. */
+  --bg: #f2f1ed;                    /* Surface 200 — warm off-white */
+  --surface: #e6e5e0;               /* Surface 400 — card / lifted */
+  --surface-warm: #ebeae5;          /* Surface 300 — button default */
+
+  /* ─── Foreground ramp (4 levels) ────────────────────────────────
+   * Cursor genuinely has a 4-tier ramp: solid for headings/body,
+   * 90% for "light surface" button labels, 55% for secondary text,
+   * 40% for link underlines and metadata. All bind to the same
+   * oklab-fallback rgba (warm brown) at different alphas. */
+  --fg: #26251e;                              /* warm near-black */
+  --fg-2: rgba(38, 37, 30, 0.9);              /* solid headings on light surfaces */
+  --muted: rgba(38, 37, 30, 0.55);            /* secondary text */
+  --meta: rgba(38, 37, 30, 0.4);              /* metadata, link decoration */
+
+  /* ─── Border (2 levels) ─────────────────────────────────────────
+   * DESIGN.md §Color Palette specifies oklab-space borders as the
+   * brand signature. The CSS-compatible fallback (rgba) is what
+   * actually ships per DESIGN.md §Agent Prompt Guide rule 3. */
+  --border: rgba(38, 37, 30, 0.1);            /* primary border, 10% warm brown */
+  --border-soft: rgba(38, 37, 30, 0.06);      /* row separators, ghost-button bg */
+
+  /* ─── Accent ──────────────────────────────────────────────────────
+   * Cursor Orange — primary CTAs, link color, ONE hero accent per
+   * screen. Hard cap of 2 visible uses per screen still applies via
+   * lint. Note: the signature hover semantic in DESIGN.md is text
+   * shifting to --danger (crimson) on buttons; the schema's
+   * --accent-hover is reserved for the bg-darken case (when accent
+   * IS the bg, e.g. accent-pill CTA). */
+  --accent: #f54e00;
+  --accent-on: #ffffff;
+  --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+  /* ─── Semantic ────────────────────────────────────────────────────
+   * --danger is Cursor's signature interaction color (hover crimson
+   * on buttons), so it gets the brand-specific warm value rather
+   * than the schema fallback's pure red. --success is a muted
+   * teal-green (warm-shifted). --warn keeps the schema fallback;
+   * Cursor's marketing site has no native warn token. */
+  --success: #1f8a65;                         /* muted teal-green */
+  --warn: #eab308;
+  --danger: #cf2d56;                          /* warm crimson — hover signature */
+
+  /* ─── Typography ──────────────────────────────────────────────────
+   * Three voices, three roles:
+   *   --font-display: CursorGothic for headings + UI labels
+   *   --font-body: jjannon serif for editorial body (literary warmth)
+   *   --font-mono: berkeleyMono for code, kbd, terminal text
+   * The three-voice system is the typographic signature; component
+   * CSS should never substitute fewer voices for "simplicity". */
+  --font-display: "CursorGothic", "CursorGothic Fallback", system-ui, "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-body: "jjannon", "Iowan Old Style", "Palatino Linotype", "URW Palladio L", P052, ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
+  --font-mono: "berkeleyMono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+
+  /* Type scale — distilled from DESIGN.md §Typography Hierarchy.
+   * Cursor has more than 8 sizes in production (caption 11, body
+   * sans 16, body serif sm 17.28, body serif 19.2, title small 22,
+   * sub-heading 26, section 36, hero 72); the schema's 8 slots
+   * cover the spine. 17.28px / 19.2px live inline in components.html
+   * where the body-serif distinction matters. */
+  --text-xs: 11px;                  /* caption, system micro */
+  --text-sm: 14px;                  /* button label, system caption */
+  --text-base: 16px;                /* body sans, ui body */
+  --text-lg: 19.2px;                /* body serif (1.20rem) */
+  --text-xl: 22px;                  /* title small */
+  --text-2xl: 26px;                 /* sub-heading */
+  --text-3xl: 36px;                 /* section heading */
+  --text-4xl: 72px;                 /* display hero */
+
+  /* Leading + tracking — DESIGN.md §Typography Hierarchy.
+   * --leading-tight=1.10 is Cursor's hero rhythm (matches the
+   * 72px display); brands with relaxed display rhythms set 1.20.
+   * --tracking-display=-0.03em is the 72px-normalized hero tracking
+   * (-2.16px / 72px). Smaller display sizes in components.html
+   * use proportional inline overrides. */
+  --leading-body: 1.5;
+  --leading-tight: 1.10;
+  --tracking-display: -0.03em;
+
+  /* ─── Spacing ─────────────────────────────────────────────────────
+   * 8px-rooted scale from DESIGN.md §Layout Principles (with the
+   * --space-1=4px tier kept for icon/dot rhythm). Cursor's
+   * sub-8px micro-scale (1.5/2/2.5/3/5/6) is component-internal —
+   * see the elev-ring / icon-rule decisions in components.html. */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+
+  /* Section rhythm — DESIGN.md §Responsive Behavior collapsing
+   * strategy: "Section spacing: 80px+ → 48px → 32px on mobile". */
+  --section-y-desktop: 80px;
+  --section-y-tablet: 48px;
+  --section-y-phone: 32px;
+
+  /* ─── Radius ──────────────────────────────────────────────────────
+   * DESIGN.md §Border Radius Scale: comfortable 8px (primary
+   * buttons/cards/menus), featured 10px (larger containers), full
+   * pill 9999px (tags/filters). Schema's --radius-md gets 10px
+   * rather than 12px to honor the cursor-specific featured tier;
+   * --radius-lg keeps 12px because no Cursor surface uses 16px+. */
+  --radius-sm: 8px;
+  --radius-md: 10px;
+  --radius-lg: 12px;
+  --radius-pill: 9999px;
+
+  /* ─── Elevation ───────────────────────────────────────────────────
+   * Cursor's depth signature (DESIGN.md §Depth & Elevation): no
+   * crisp drop shadows. Border ring + diffused atmospheric lift.
+   *   --elev-flat: pages, text blocks
+   *   --elev-ring: standard card edge (1px warm-brown ring)
+   *   --elev-raised: signature heavy-blur shadow with oklab ring,
+   *                  used for elevated cards / popovers / modals. */
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised:
+    0 28px 70px rgba(0, 0, 0, 0.14),
+    0 14px 32px rgba(0, 0, 0, 0.1),
+    0 0 0 1px var(--border);
+
+  /* ─── Focus ───────────────────────────────────────────────────────
+   * DESIGN.md §Interaction & Motion: "Shadow-based focus:
+   * rgba(0,0,0,0.1) 0px 4px 12px for depth-based focus indication.
+   * Consistent warm tone in all focus states — no cold blue focus
+   * rings." Implemented as box-shadow so it layers without
+   * affecting layout. */
+  --focus-ring: 0 4px 12px rgba(0, 0, 0, 0.1);
+
+  /* ─── Motion ──────────────────────────────────────────────────────
+   * DESIGN.md §Interaction & Motion specifies 150ms color / 200ms
+   * shadow with `ease` easing. Cursor uses the keyword `ease`
+   * rather than a custom cubic-bezier; component authors should
+   * not rebind to a more aggressive curve. */
+  --motion-fast: 150ms;
+  --motion-base: 200ms;
+  --ease-standard: ease;
+
+  /* ─── Layout ──────────────────────────────────────────────────────
+   * DESIGN.md §Grid & Container: "Max content width: approximately
+   * 1200px". Gutters not explicitly specified; using cross-brand
+   * defaults that match default. */
+  --container-max: 1200px;
+  --container-gutter-desktop: 24px;
+  --container-gutter-tablet: 16px;
+  --container-gutter-phone: 12px;
+}

--- a/design-systems/stripe/components.html
+++ b/design-systems/stripe/components.html
@@ -1,0 +1,1018 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Inspired by Stripe — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/stripe. Every visible
+        value comes from tokens.css; the page itself follows Stripe's
+        rules — sohne-var with ss01 globally, weight 300 at display
+        sizes, deep navy (#061b31) headings instead of black, blue-
+        tinted multi-layer shadows on elevated surfaces, conservative
+        4-8px radius, and Stripe Purple capped at ≤2 visible uses
+        per screen."
+    />
+
+    <style>
+      /* :root paste — sourced verbatim from
+         design-systems/stripe/tokens.css. Keep this block in sync
+         when tokens.css changes. The agent prompt instructs the
+         Designer panelist to paste this block as the FIRST thing in
+         their <style>, then reference everything below via var(...). */
+      :root {
+        --bg:           #ffffff;
+        --surface:      #ffffff;
+        --surface-warm: #f6f9fc;
+
+        --fg:    #061b31;
+        --fg-2:  #273951;
+        --muted: #64748d;
+        --meta:  var(--muted);
+
+        --border:      #e5edf5;
+        --border-soft: var(--border);
+
+        --accent:    #533afd;
+        --accent-on: #ffffff;
+
+        --accent-hover:  #4434d4;
+        --accent-active: #2e2b8c;
+
+        --success: #15be53;
+        --warn:    #9b6829;
+        --danger:  #ea2261;
+
+        --font-display:
+          "sohne-var", "Söhne", "Sohne",
+          "SF Pro Display", -apple-system, BlinkMacSystemFont,
+          system-ui, "Helvetica Neue", Arial, sans-serif;
+        --font-body:
+          "sohne-var", "Söhne", "Sohne",
+          "SF Pro Display", -apple-system, BlinkMacSystemFont,
+          system-ui, "Helvetica Neue", Arial, sans-serif;
+        --font-mono:
+          "SourceCodePro", "Source Code Pro",
+          ui-monospace, "SF Mono", "JetBrains Mono",
+          Menlo, Monaco, Consolas, monospace;
+
+        --text-xs:   12px;
+        --text-sm:   14px;
+        --text-base: 16px;
+        --text-lg:   18px;
+        --text-xl:   22px;
+        --text-2xl:  32px;
+        --text-3xl:  48px;
+        --text-4xl:  56px;
+
+        --leading-body:     1.40;
+        --leading-tight:    1.10;
+        --tracking-display: -0.02em;
+
+        --space-1:  4px;
+        --space-2:  8px;
+        --space-3:  12px;
+        --space-4:  16px;
+        --space-5:  20px;
+        --space-6:  24px;
+        --space-8:  32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 96px;
+        --section-y-tablet:  64px;
+        --section-y-phone:   40px;
+
+        --radius-sm:   4px;
+        --radius-md:   6px;
+        --radius-lg:   8px;
+        --radius-pill: 9999px;
+
+        --elev-flat:   none;
+        --elev-ring:   0 0 0 1px var(--border);
+        --elev-raised:
+          rgba(50, 50, 93, 0.25)  0px 30px 45px -30px,
+          rgba(0,   0,  0, 0.10)  0px 18px 36px -18px;
+
+        --focus-ring:
+          0 0 0 2px var(--accent),
+          0 0 0 5px color-mix(in oklab, var(--accent), transparent 75%);
+
+        --motion-fast:   150ms;
+        --motion-base:   200ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+        --container-max:            1080px;
+        --container-gutter-desktop: 32px;
+        --container-gutter-tablet:  24px;
+        --container-gutter-phone:   16px;
+      }
+
+      /* ─── Reset (minimal) ───────────────────────────────────────── */
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        font-weight: 300;        /* Stripe's signature: 300 is body weight */
+        line-height: var(--leading-body);
+        /* `"ss01"` is non-negotiable on every sohne-var element
+           (DESIGN.md §3 Principles). Inheriting from <body> applies
+           it to every descendant by default; specific components
+           that need `tnum` for financial tables override locally. */
+        font-feature-settings: "ss01";
+        -webkit-font-smoothing: antialiased;
+      }
+      strong { font-weight: 400; } /* never 600/700 in sohne-var per DESIGN.md §7 */
+
+      /* ─── Layout primitives ─────────────────────────────────────── */
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section {
+        padding-block: var(--section-y-desktop);
+      }
+      section + section {
+        border-top: 1px solid var(--border);
+      }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography ────────────────────────────────────────────── */
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        font-weight: 300;          /* Stripe's anti-convention signature */
+        line-height: var(--leading-tight);
+        letter-spacing: var(--tracking-display);
+        color: var(--fg);
+        margin: 0;
+      }
+      h1 {
+        font-size: var(--text-4xl);
+        line-height: 1.03;         /* DESIGN.md §3: display hero ratio */
+        letter-spacing: -0.025em;  /* exact -1.4px at 56px */
+      }
+      h2 {
+        font-size: var(--text-2xl);
+      }
+      h3 {
+        font-size: var(--text-xl);
+        letter-spacing: -0.01em;   /* relaxed at 22px per DESIGN.md §3 */
+      }
+      p { margin: 0; }
+
+      .lede {
+        font-size: var(--text-lg);
+        line-height: var(--leading-body);
+        color: var(--muted);
+        max-width: 56ch;
+      }
+      .body-muted { color: var(--muted); }
+      .body-meta  { color: var(--meta); font-size: var(--text-sm); }
+      .body-sm    { font-size: var(--text-sm); }
+
+      /* `.eyebrow` is the only place uppercase + tracking is used —
+         small label, deep-navy on lavender wash. tracking is well
+         above the craft 0.06em floor. */
+      .eyebrow {
+        display: inline-block;
+        font-size: var(--text-xs);
+        font-weight: 400;
+        line-height: 1;
+        color: var(--accent);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+      .stack-8 > * + * { margin-block-start: var(--space-8); }
+
+      /* ─── Buttons ───────────────────────────────────────────────
+       * Stripe buttons are conservative — 4px radius, 8/16 padding,
+       * weight-400 sohne-var with ss01. Hover shifts background
+       * colour; never transforms. Primary uses --accent / --accent-on;
+       * ghost uses the brand purple as text colour against a
+       * transparent shell with a purple-tinted border. */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 8px 16px;
+        border-radius: var(--radius-sm);
+        font-family: var(--font-display);
+        font-feature-settings: "ss01";
+        font-weight: 400;
+        font-size: var(--text-base);
+        line-height: 1;
+        cursor: pointer;
+        border: 1px solid transparent;
+        background: transparent;
+        color: var(--fg);
+        text-decoration: none;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          border-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible {
+        outline: none;
+        box-shadow: var(--focus-ring);
+      }
+      .btn-primary {
+        background: var(--accent);
+        color: var(--accent-on);
+      }
+      .btn-primary:hover  { background: var(--accent-hover); }
+      .btn-primary:active { background: var(--accent-active); }
+
+      /* Ghost / outlined — DESIGN.md §4 spec verbatim.
+         The hover wash is the only place we tint --accent with
+         transparency inline; it's a once-per-page rule rather than
+         a cross-component pattern, so it stays inline rather than
+         being promoted to a token. */
+      .btn-ghost {
+        background: transparent;
+        color: var(--accent);
+        border-color: color-mix(in oklab, var(--accent), white 65%);
+      }
+      .btn-ghost:hover {
+        background: color-mix(in oklab, var(--accent), transparent 95%);
+        border-color: color-mix(in oklab, var(--accent), white 55%);
+      }
+
+      /* Compact button for nav and toolbar — 14px / 4px radius */
+      .btn-sm {
+        padding: 6px 12px;
+        font-size: var(--text-sm);
+      }
+
+      /* ─── Inputs ────────────────────────────────────────────── */
+      .field {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+      }
+      .field label {
+        font-size: var(--text-sm);
+        font-weight: 400;
+        color: var(--fg-2);        /* dark-slate label per DESIGN.md §4 */
+      }
+      .field input,
+      .field select,
+      .field textarea {
+        padding: 10px 12px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+        background: var(--surface);
+        color: var(--fg);
+        font-family: inherit;
+        font-feature-settings: "ss01";
+        font-size: var(--text-base);
+        font-weight: 300;
+        line-height: 1.4;
+        outline: none;
+        transition:
+          border-color var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .field input:focus-visible,
+      .field select:focus-visible,
+      .field textarea:focus-visible {
+        border-color: var(--accent);
+        box-shadow: var(--focus-ring);
+      }
+      .field input::placeholder { color: var(--muted); }
+      .field-help {
+        font-size: var(--text-xs);
+        color: var(--muted);
+      }
+
+      /* ─── Cards ─────────────────────────────────────────────────
+       * Two card flavours:
+       *   .card           hairline border, no shadow — for grids and
+       *                   form panels where the border IS the edge.
+       *   .card-elevated  no border, blue-tinted multi-layer shadow —
+       *                   for featured / hero cards where Stripe's
+       *                   trademark elevation does the work.
+       * Both share radius and padding. Hover on .card-elevated
+       * intensifies the shadow; .card stays static (border doesn't
+       * pulse). */
+      .card {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        padding: var(--space-6);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+      }
+      .card-elevated {
+        background: var(--surface);
+        border-radius: var(--radius-lg);
+        padding: var(--space-8);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+        box-shadow: var(--elev-raised);
+        transition: box-shadow var(--motion-base) var(--ease-standard);
+      }
+      .card-elevated:hover {
+        /* Intensify the near layer; far stays the same so the lift
+           reads as "drawing closer", not "growing larger". */
+        box-shadow:
+          rgba(50, 50, 93, 0.25)  0px 30px 45px -30px,
+          rgba(0,   0,  0, 0.14)  0px 24px 48px -16px;
+      }
+      .card-title {
+        font-family: var(--font-display);
+        font-feature-settings: "ss01";
+        font-weight: 300;
+        font-size: var(--text-xl);
+        line-height: 1.12;
+        letter-spacing: -0.01em;
+        color: var(--fg);
+      }
+
+      /* ─── Badges ────────────────────────────────────────────────
+       * Success badge per DESIGN.md §4. Pill radius is wrong here —
+       * Stripe uses 4px on badges, never 9999px. */
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 1px 6px;
+        border-radius: var(--radius-sm);
+        font-size: var(--text-xs);
+        font-weight: 300;
+        line-height: 1.6;
+        font-feature-settings: "ss01";
+      }
+      .badge-success {
+        color: var(--success);
+        background: color-mix(in oklab, var(--success), transparent 80%);
+        border: 1px solid
+          color-mix(in oklab, var(--success), transparent 60%);
+      }
+      .badge-muted {
+        color: var(--muted);
+        background: var(--surface-warm);
+        border: 1px solid var(--border);
+      }
+      .badge-accent {
+        color: var(--accent);
+        background: color-mix(in oklab, var(--accent), white 88%);
+        border: 1px solid
+          color-mix(in oklab, var(--accent), white 70%);
+      }
+      .badge-dot {
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: currentColor;
+      }
+
+      /* ─── Links ─────────────────────────────────────────────────
+       * Default link is Stripe Purple. Underline appears only on
+       * hover, at a generous offset so the rule reads as a
+       * deliberate gesture. */
+      a {
+        color: var(--accent);
+        text-decoration: none;
+        font-feature-settings: "ss01";
+      }
+      a:hover {
+        text-decoration: underline;
+        text-underline-offset: 3px;
+        text-decoration-thickness: 1px;
+      }
+
+      /* ─── Kbd ───────────────────────────────────────────────────
+       * SourceCodePro at 12px, hairline border, navy text. Stripe's
+       * kbd is small and dense — no padding inflation. */
+      kbd {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        font-weight: 500;
+        padding: 2px 6px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+        background: var(--surface-warm);
+        color: var(--fg-2);
+      }
+
+      /* ─── Distinctive brand element: gradient halo ──────────────
+       * Stripe's signature hero decoration is a soft pastel wash
+       * behind the headline — built here from the brand purple
+       * mixed at varying transparencies (no raw hex outside :root).
+       * The halo sits in a layered radial-gradient and lets the
+       * navy headline read as "floating in twilight". */
+      .halo {
+        position: absolute;
+        inset: -10% -20% -20% -10%;
+        pointer-events: none;
+        background:
+          radial-gradient(
+            60% 50% at 15% 30%,
+            color-mix(in oklab, var(--accent), transparent 70%) 0%,
+            color-mix(in oklab, var(--accent), transparent 100%) 65%
+          ),
+          radial-gradient(
+            45% 40% at 85% 20%,
+            color-mix(in oklab, var(--danger), transparent 75%) 0%,
+            color-mix(in oklab, var(--danger), transparent 100%) 70%
+          ),
+          radial-gradient(
+            55% 45% at 70% 80%,
+            color-mix(in oklab, var(--accent), transparent 80%) 0%,
+            color-mix(in oklab, var(--accent), transparent 100%) 70%
+          );
+        filter: blur(40px);
+        z-index: 0;
+      }
+
+      /* ─── Code block ────────────────────────────────────────────
+       * DESIGN.md §3: SourceCodePro at 12px / weight 500 / 2.00
+       * line-height. The 2.00 leading is intentional — Stripe's
+       * payment-integration snippets need to read like prose, not
+       * like a terminal dump. */
+      .code {
+        background: var(--surface-warm);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        padding: var(--space-5);
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        font-weight: 500;
+        line-height: 2.0;
+        color: var(--fg);
+        white-space: pre;
+        overflow-x: auto;
+      }
+      .code .k { color: var(--accent); }                 /* keyword */
+      .code .s { color: var(--success); }                /* string  */
+      .code .c { color: var(--muted); }                  /* comment */
+      .code .n { color: var(--fg-2); }                   /* identifier */
+
+      /* ─── Metric (tabular financial rendering) ──────────────────
+       * DESIGN.md §3 "Caption Tabular" — `tnum` for any number in
+       * a data display so columns of figures align. The values use
+       * deep navy; the labels use slate. */
+      .metric {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+      .metric-value {
+        font-family: var(--font-display);
+        font-feature-settings: "tnum", "ss01";
+        font-weight: 300;
+        font-size: var(--text-2xl);
+        line-height: 1.1;
+        letter-spacing: -0.01em;
+        color: var(--fg);
+      }
+      .metric-label {
+        font-size: var(--text-sm);
+        color: var(--muted);
+      }
+
+      /* ─── Section-specific layout ───────────────────────────── */
+      .hero {
+        position: relative;
+        overflow: hidden;
+      }
+      .hero-inner {
+        position: relative;
+        z-index: 1;
+        display: grid;
+        grid-template-columns: 1.3fr 1fr;
+        gap: var(--space-12);
+        align-items: end;
+      }
+      @media (max-width: 1023px) {
+        .hero-inner { grid-template-columns: 1fr; gap: var(--space-8); }
+      }
+      .hero h1 {
+        max-width: 14ch;
+        margin: 0;
+      }
+      .hero-actions {
+        display: flex;
+        gap: var(--space-3);
+        margin-block-start: var(--space-8);
+      }
+
+      .features-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: var(--space-5);
+        margin-block-start: var(--space-8);
+      }
+      @media (max-width: 1023px) {
+        .features-grid { grid-template-columns: 1fr 1fr; }
+      }
+      @media (max-width: 639px) {
+        .features-grid { grid-template-columns: 1fr; }
+      }
+
+      /* Pricing-style featured card row — exercises .card-elevated
+         alongside .card so the elevation contrast is visible. */
+      .pricing-grid {
+        display: grid;
+        grid-template-columns: 1fr 1.1fr 1fr;
+        gap: var(--space-5);
+        align-items: stretch;
+        margin-block-start: var(--space-8);
+      }
+      @media (max-width: 1023px) {
+        .pricing-grid { grid-template-columns: 1fr; }
+      }
+      .pricing-price {
+        font-family: var(--font-display);
+        font-feature-settings: "tnum", "ss01";
+        font-weight: 300;
+        font-size: var(--text-3xl);
+        line-height: 1.05;
+        letter-spacing: -0.02em;
+        color: var(--fg);
+      }
+      .pricing-price small {
+        font-size: var(--text-sm);
+        color: var(--muted);
+        margin-inline-start: var(--space-2);
+        font-feature-settings: "ss01";
+      }
+      .pricing-list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+      }
+      .pricing-list li {
+        position: relative;
+        padding-inline-start: var(--space-5);
+        font-size: var(--text-sm);
+        color: var(--fg-2);
+        line-height: 1.5;
+      }
+      .pricing-list li::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0.45em;
+        width: 12px;
+        height: 7px;
+        border-left: 1.5px solid var(--accent);
+        border-bottom: 1.5px solid var(--accent);
+        transform: rotate(-45deg);
+        transform-origin: 0 100%;
+      }
+
+      .metric-row {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: var(--space-8);
+      }
+      @media (max-width: 767px) {
+        .metric-row { grid-template-columns: repeat(2, 1fr); gap: var(--space-6); }
+      }
+
+      .form-row {
+        display: grid;
+        grid-template-columns: 1.2fr 1fr;
+        gap: var(--space-12);
+        align-items: start;
+      }
+      @media (max-width: 1023px) {
+        .form-row { grid-template-columns: 1fr; }
+      }
+      .form {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+        max-width: 460px;
+        padding: var(--space-6);
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--elev-raised);
+      }
+      .form-grid-2 {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-3);
+      }
+      .form-actions {
+        display: flex;
+        gap: var(--space-3);
+        margin-block-start: var(--space-2);
+        align-items: center;
+      }
+
+      .icon { width: 14px; height: 14px; flex-shrink: 0; }
+      .row-between {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-3);
+      }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <!-- ════════════════════════════════════════════════════════════
+           HERO — exercises: gradient .halo (Stripe's signature
+           pastel-wash behind the headline, built entirely from
+           color-mix() over --accent and --danger), h1 at 56px /
+           weight 300 / -0.025em (the brand's "whisper authority"),
+           .lede in slate, .btn-primary + .btn-ghost from DESIGN.md
+           §4 verbatim. Asymmetric grid on desktop; single column on
+           tablet.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section class="hero" data-od-id="hero">
+        <div class="halo" aria-hidden="true"></div>
+
+        <div class="hero-inner">
+          <div class="stack-6">
+            <span class="eyebrow">Payments · Infrastructure</span>
+            <h1>Financial infrastructure designed for the internet.</h1>
+            <p class="lede">
+              The reference fixture pastes Stripe's token block into a
+              single <code style="font-family:var(--font-mono);font-size:0.92em;color:var(--fg-2)">&lt;style&gt;</code>
+              and renders a recognisable Stripe page without authoring
+              any additional values — every colour, type size, and
+              shadow below resolves through <code style="font-family:var(--font-mono);font-size:0.92em;color:var(--fg-2)">var(--*)</code>.
+            </p>
+            <div class="hero-actions">
+              <a href="./tokens.css" class="btn btn-primary">
+                Start now
+                <svg
+                  class="icon"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M5 12h14M13 6l6 6-6 6" />
+                </svg>
+              </a>
+              <a href="./DESIGN.md" class="btn btn-ghost">Contact sales</a>
+            </div>
+          </div>
+
+          <aside class="card-elevated" aria-label="Payment summary">
+            <div class="row-between">
+              <span class="eyebrow">Payment intent</span>
+              <span class="badge badge-success">
+                <span class="badge-dot" aria-hidden="true"></span>
+                Succeeded
+              </span>
+            </div>
+
+            <div class="metric">
+              <div
+                class="metric-value"
+                style="font-size: var(--text-3xl); letter-spacing: -0.02em"
+              >
+                $4,280.<span style="color: var(--muted)">00</span>
+              </div>
+              <div class="metric-label">
+                Charged via card_1NqK… · 2026-05-14
+              </div>
+            </div>
+
+            <div
+              style="
+                display: grid;
+                grid-template-columns: 1fr 1fr;
+                gap: var(--space-3);
+                padding-block-start: var(--space-3);
+                border-top: 1px solid var(--border);
+              "
+            >
+              <div class="metric">
+                <div class="metric-label">Net</div>
+                <div
+                  class="metric-value"
+                  style="font-size: var(--text-base); color: var(--fg-2)"
+                >
+                  $4,154.88
+                </div>
+              </div>
+              <div class="metric">
+                <div class="metric-label">Fee</div>
+                <div
+                  class="metric-value"
+                  style="font-size: var(--text-base); color: var(--fg-2)"
+                >
+                  $125.12
+                </div>
+              </div>
+            </div>
+
+            <p class="body-sm body-muted">
+              Press <kbd>⌘</kbd> <kbd>K</kbd> to inspect this token block
+              in the design-system viewer.
+            </p>
+          </aside>
+        </div>
+      </section>
+
+      <!-- ════════════════════════════════════════════════════════════
+           METRICS — exercises: .metric pattern with `tnum`, deep-
+           navy values, slate labels. Numbers describe the fixture
+           itself, not invented claims.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="metrics">
+        <div class="stack-3">
+          <span class="eyebrow">Schema in numbers</span>
+          <h2 style="max-width: 24ch">
+            Fifty-six tokens carry every visible value below.
+          </h2>
+        </div>
+
+        <div class="metric-row" style="margin-block-start: var(--space-8)">
+          <div class="metric">
+            <div class="metric-value">56</div>
+            <div class="metric-label">tokens in :root</div>
+          </div>
+          <div class="metric">
+            <div class="metric-value">0</div>
+            <div class="metric-label">brand-C extensions</div>
+          </div>
+          <div class="metric">
+            <div class="metric-value">3</div>
+            <div class="metric-label">elevation levels (flat · ring · raised)</div>
+          </div>
+          <div class="metric">
+            <div class="metric-value">300</div>
+            <div class="metric-label">default sohne-var weight</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ════════════════════════════════════════════════════════════
+           FEATURES — exercises: h2, .card (hairline border), h3 with
+           tighter tracking, body text, .features-grid responsive
+           ladder. Each card describes a real property of this
+           fixture (no "feature one/two/three" filler).
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="features">
+        <div class="stack-3">
+          <span class="eyebrow">What this fixture exercises</span>
+          <h2 style="max-width: 30ch">
+            Every component renders through <code style="font-family:var(--font-mono);font-size:0.92em;color:var(--fg-2)">var(--*)</code> —
+            no raw hex, no off-token type.
+          </h2>
+        </div>
+
+        <div class="features-grid">
+          <article class="card">
+            <h3 class="card-title">Shadow as identity</h3>
+            <p class="body-muted body-sm">
+              The trademark blue-tinted multi-layer shadow lives at
+              <code style="font-family:var(--font-mono);font-size:0.92em;color:var(--fg-2)">--elev-raised</code>.
+              Rebinding it to a neutral drop shadow erases Stripe's
+              atmosphere even when every colour is right.
+            </p>
+            <a href="./tokens.css" class="body-sm">Inspect tokens →</a>
+          </article>
+
+          <article class="card">
+            <h3 class="card-title">Light weight as voice</h3>
+            <p class="body-muted body-sm">
+              Display sizes run at weight 300 with negative tracking.
+              Stripe's headlines feel like they don't need to shout;
+              weight 600 would erase the brand instantly.
+            </p>
+            <a href="./DESIGN.md" class="body-sm">Read the spec →</a>
+          </article>
+
+          <article class="card">
+            <h3 class="card-title">Accent discipline</h3>
+            <p class="body-muted body-sm">
+              <code style="font-family:var(--font-mono);font-size:0.92em;color:var(--fg-2)">--accent</code>
+              appears at most twice per screen — primary CTA and link
+              colour. Decorative ruby / magenta gradients live in the
+              hero halo, not on interactive elements.
+            </p>
+            <a href="./tokens.css" class="body-sm">Inspect accent →</a>
+          </article>
+        </div>
+      </section>
+
+      <!-- ════════════════════════════════════════════════════════════
+           PRICING — exercises: .card-elevated with the trademark
+           blue-tinted shadow, alongside two .card siblings so the
+           elevation hierarchy is immediately visible. Tabular numerals
+           on the price; check-mark feature list keyed to --accent.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="pricing">
+        <div class="stack-3">
+          <span class="eyebrow">Pricing pattern</span>
+          <h2 style="max-width: 26ch">
+            Featured tier lifts via shadow alone — no colour shift, no
+            border change.
+          </h2>
+        </div>
+
+        <div class="pricing-grid">
+          <article class="card">
+            <div class="stack-3">
+              <h3 class="card-title">Starter</h3>
+              <p class="body-muted body-sm">
+                For new accounts integrating their first payment flow.
+              </p>
+            </div>
+            <div class="pricing-price">
+              $0<small>/month</small>
+            </div>
+            <ul class="pricing-list">
+              <li>Standard processing rates</li>
+              <li>Dashboard access</li>
+              <li>Email support</li>
+            </ul>
+            <a href="./tokens.css" class="btn btn-ghost btn-sm">Start free</a>
+          </article>
+
+          <article class="card-elevated" aria-label="Featured tier">
+            <div class="row-between">
+              <span class="eyebrow">Most popular</span>
+              <span class="badge badge-accent">Featured</span>
+            </div>
+            <h3 class="card-title">Growth</h3>
+            <div class="pricing-price">
+              $79<small>/month</small>
+            </div>
+            <ul class="pricing-list">
+              <li>Volume processing discounts</li>
+              <li>Subscriptions &amp; invoicing</li>
+              <li>Fraud monitoring</li>
+              <li>Priority support</li>
+            </ul>
+            <a href="./tokens.css" class="btn btn-primary btn-sm">Choose Growth</a>
+          </article>
+
+          <article class="card">
+            <div class="stack-3">
+              <h3 class="card-title">Scale</h3>
+              <p class="body-muted body-sm">
+                Custom pricing for high-volume merchants and platforms.
+              </p>
+            </div>
+            <div class="pricing-price">
+              Custom
+            </div>
+            <ul class="pricing-list">
+              <li>Negotiated processing rates</li>
+              <li>Dedicated solutions engineer</li>
+              <li>Custom data residency</li>
+            </ul>
+            <a href="./DESIGN.md" class="btn btn-ghost btn-sm">Contact sales</a>
+          </article>
+        </div>
+      </section>
+
+      <!-- ════════════════════════════════════════════════════════════
+           CODE PREVIEW — exercises: SourceCodePro at 12px / weight
+           500 / line-height 2.00 (DESIGN.md §3). Keyword tokens use
+           --accent; strings use --success; comments use --muted.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="code">
+        <div class="form-row">
+          <div class="stack-4">
+            <span class="eyebrow">Integration preview</span>
+            <h2 style="max-width: 18ch">
+              Two lines of code, one charge.
+            </h2>
+            <p class="body-muted lede">
+              The monospace face is <code style="font-family:var(--font-mono);font-size:0.95em">SourceCodePro</code>
+              at 12px / weight 500 / line-height 2.00 — generous leading
+              so payment snippets read like prose, not like terminal
+              output.
+            </p>
+            <div>
+              <a href="./tokens.css" class="btn btn-ghost btn-sm">Inspect mono token</a>
+            </div>
+          </div>
+
+<pre class="code"><span class="c">// Create a PaymentIntent on your server.</span>
+<span class="k">const</span> <span class="n">intent</span> = <span class="k">await</span> <span class="n">stripe</span>.<span class="n">paymentIntents</span>.<span class="n">create</span>({
+  <span class="n">amount</span>: <span class="k">4280</span>,
+  <span class="n">currency</span>: <span class="s">"usd"</span>,
+  <span class="n">automatic_payment_methods</span>: { <span class="n">enabled</span>: <span class="k">true</span> },
+});
+
+<span class="c">// Return the client secret to the browser.</span>
+<span class="k">res</span>.<span class="n">json</span>({ <span class="n">clientSecret</span>: <span class="n">intent</span>.<span class="n">client_secret</span> });</pre>
+        </div>
+      </section>
+
+      <!-- ════════════════════════════════════════════════════════════
+           FORM — exercises: .field, input :focus-visible (purple halo
+           via --focus-ring), .btn-primary (reused), .btn-ghost,
+           .field-help. The form panel itself uses .card-elevated so
+           the trademark shadow frames the inputs.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="form">
+        <div class="form-row">
+          <div class="stack-4">
+            <span class="eyebrow">Form components</span>
+            <h2 style="max-width: 22ch">
+              Inputs inherit the same tokens.
+            </h2>
+            <p class="body-muted lede">
+              Focus rings, borders, placeholder colour — all derive
+              from <code style="font-family:var(--font-mono);font-size:0.92em;color:var(--fg-2)">--accent</code>
+              and <code style="font-family:var(--font-mono);font-size:0.92em;color:var(--fg-2)">--border</code>.
+              The submit button reuses <code style="font-family:var(--font-mono);font-size:0.92em;color:var(--fg-2)">.btn-primary</code>
+              unchanged. The panel itself lifts via the trademark
+              blue-tinted shadow.
+            </p>
+          </div>
+
+          <form class="form" onsubmit="event.preventDefault();">
+            <div class="row-between">
+              <h3 class="card-title" style="font-size: var(--text-lg)">
+                Contact sales
+              </h3>
+              <span class="badge badge-muted">Secure</span>
+            </div>
+
+            <div class="form-grid-2">
+              <div class="field">
+                <label for="first">First name</label>
+                <input
+                  id="first"
+                  type="text"
+                  placeholder="Jamie"
+                  autocomplete="given-name"
+                />
+              </div>
+              <div class="field">
+                <label for="last">Last name</label>
+                <input
+                  id="last"
+                  type="text"
+                  placeholder="Liu"
+                  autocomplete="family-name"
+                />
+              </div>
+            </div>
+
+            <div class="field">
+              <label for="email">Work email</label>
+              <input
+                id="email"
+                type="email"
+                placeholder="jamie@acme.dev"
+                autocomplete="email"
+                required
+              />
+              <p class="field-help">
+                We'll send the integration brief and nothing else.
+              </p>
+            </div>
+
+            <div class="field">
+              <label for="volume">Monthly processing volume</label>
+              <select id="volume">
+                <option>Under $80k</option>
+                <option>$80k – $500k</option>
+                <option>$500k – $5M</option>
+                <option>Over $5M</option>
+              </select>
+            </div>
+
+            <div class="form-actions">
+              <button type="submit" class="btn btn-primary">
+                Start now
+              </button>
+              <button type="button" class="btn btn-ghost">
+                Skip for now
+              </button>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/stripe/tokens.css
+++ b/design-systems/stripe/tokens.css
@@ -1,0 +1,295 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/stripe/tokens.css
+ *
+ * Structured token bindings for "Inspired by Stripe" — fintech
+ * infrastructure dressed in deep navy, signature violet, and the
+ * blue-tinted multi-layer shadow that makes elevation feel branded.
+ *
+ * This file pre-compiles the values described in `DESIGN.md` into
+ * the schema shared with every OD design system. Agents generating a
+ * Stripe-flavored artifact should paste the `:root { … }` block
+ * verbatim into the first `<style>` of the artifact, then reference
+ * every value through `var(--name)` — never re-author the hex
+ * inline. The fixture in `components.html` is the round-trip proof
+ * that the token block alone is sufficient to render a recognisably
+ * Stripe page.
+ *
+ * Why this file exists:
+ *   DESIGN.md gives humans context ("Stripe Purple #533afd — primary
+ *   CTAs"), but agents have to translate prose names like
+ *   "Stripe Purple" into the standard token names the lint enforces
+ *   (`--accent`). This file pre-translates the brand once, so agents
+ *   copy structure rather than invent it.
+ *
+ * Schema notes (Stripe binds the shared schema in seven brand-
+ * specific ways — see `#Stripe N` tags inline for each decision):
+ *   #Stripe 1  — 3-tier surface stops short of a darker third tier;
+ *                `--surface-warm` binds to the cool-pale #f6f9fc that
+ *                Stripe uses behind nested panels (pricing rows, code
+ *                previews) rather than to a warm parchment.
+ *   #Stripe 2  — 3-tier foreground (navy heading / dark-slate label /
+ *                slate body). No fourth metadata tier — `--meta`
+ *                aliases `var(--muted)`.
+ *   #Stripe 3  — One border tier. `--border-soft` aliases `--border`
+ *                because DESIGN.md never describes a separate
+ *                row-separator weight.
+ *   #Stripe 4  — `--accent-hover` and `--accent-active` bind to the
+ *                hand-picked Purple Hover (#4434d4) and Purple Deep
+ *                (#2e2b8c) values from DESIGN.md, not the schema's
+ *                black-mix formula. Stripe's saturation needs the
+ *                exact shifts.
+ *   #Stripe 5  — Type scale ceiling is 56px (`--text-4xl`), not 64px.
+ *                DESIGN.md §3 puts the display hero at 56px / weight
+ *                300 with -1.4px tracking — Stripe's "whisper
+ *                authority". Adding 64px would push past the brand's
+ *                self-imposed ceiling.
+ *   #Stripe 6  — `--elev-raised` carries Stripe's trademark
+ *                multi-layer blue-tinted shadow
+ *                (`rgba(50,50,93,0.25) … , rgba(0,0,0,0.1) …`). This
+ *                is the single most brand-distinctive token in the
+ *                file; rebinding it to a neutral drop shadow erases
+ *                Stripe's atmosphere even when every color is right.
+ *   #Stripe 7  — `--focus-ring` is a layered purple halo — a thin
+ *                solid edge plus a translucent outer glow. Stripe's
+ *                focus state is more visible than the schema default
+ *                because keyboard navigation in payment flows is a
+ *                first-class concern.
+ *
+ * Brand-specific extensions (Layer C):
+ *   None. The dark brand section (`#1c1e54`) and ruby/magenta
+ *   gradient accents from DESIGN.md are *decorative* — they exist
+ *   only as one-off inline expressions in components.html, derived
+ *   from `--accent` via `color-mix(...)`. They are not promoted to
+ *   tokens because no cross-component rule needs to reference them
+ *   by name; promoting them would force every other brand to declare
+ *   matching slots.
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface (3 levels — #Stripe 1) ──────────────────────────────
+   * Stripe sits on pure white. The "warm" tier is a cool-pale
+   * blue-tinted #f6f9fc (DESIGN.md's neutral-pill border colour) —
+   * it reads as a separate elevation under nested panels (pricing
+   * rows, code previews, sticky nav blur) without introducing a
+   * warm cast that would clash with the navy / violet palette.
+   * Brands without a tertiary surface tier should alias
+   * `--surface-warm` to `var(--surface)`; Stripe binds a real value
+   * because its dense data panels need that quiet separation. */
+  --bg:           #ffffff;
+  --surface:      #ffffff;
+  --surface-warm: #f6f9fc;  /* cool-pale blue — nested panels, sticky nav */
+
+  /* ─── Foreground ramp (3 tiers — #Stripe 2) ─────────────────────
+   * Deep Navy (`#061b31`) carries every heading — never pure
+   * black, never gray. DESIGN.md is explicit: "warmth matters".
+   * Dark Slate (`#273951`) is the form-label tier. Slate (`#64748d`)
+   * is the body / caption / placeholder colour.
+   *
+   * Stripe doesn't differentiate a fourth metadata tier, so
+   * `--meta` aliases `var(--muted)`. Brands like kami that need
+   * dates / timestamps / footnote text at a fourth shade may bind
+   * an independent value. */
+  --fg:    #061b31;          /* deep navy — headings, nav text, strong labels */
+  --fg-2:  #273951;          /* dark slate — form labels, sub-headings */
+  --muted: #64748d;          /* slate — body, placeholders, captions */
+  --meta:  var(--muted);     /* alias — Stripe has no separate metadata tier */
+
+  /* ─── Border (1 tier — #Stripe 3) ───────────────────────────────
+   * One border weight for everything: card edges, dividers,
+   * containers. DESIGN.md's purple/magenta/dashed border variants
+   * are *decorative* (drop-zones, themed badges), not row
+   * separators — they live inline in components.html and do not
+   * earn a slot in the schema. `--border-soft` aliases. */
+  --border:      #e5edf5;
+  --border-soft: var(--border);  /* alias — Stripe has one border weight */
+
+  /* ─── Accent ──────────────────────────────────────────────────────
+   * Stripe Purple — primary CTAs, link text, interactive
+   * highlights, the focus ring. A saturated blue-violet that
+   * anchors the entire system. Hard cap of ≤2 visible uses per
+   * screen (lint `accent-overuse` P1 enforces). */
+  --accent:    #533afd;
+  --accent-on: #ffffff;     /* button label on purple — DESIGN.md §4 */
+
+  /* ─── Accent states (#Stripe 4) ─────────────────────────────────
+   * Hand-picked values from DESIGN.md §2, NOT a black-mix formula.
+   * Stripe Purple is saturated enough that the schema's
+   * `color-mix(in oklab, var(--accent), black 8%)` produces a
+   * muddy violet rather than the deliberate Purple Hover that
+   * Stripe.com ships. Use the brand's own values.
+   *
+   * Schema rule: every brand provides `--accent-hover` and
+   * `--accent-active`. The binding strategy (formula / identity /
+   * hand-picked) is brand-decided. */
+  --accent-hover:  #4434d4;  /* Purple Hover — DESIGN.md §2 */
+  --accent-active: #2e2b8c;  /* Purple Deep — DESIGN.md §2 */
+
+  /* ─── Semantic ───────────────────────────────────────────────────
+   * Status colours pulled from DESIGN.md §2. Stripe's success is a
+   * deliberately vivid green (`#15be53`) because payment-success
+   * confirmations are the system's happy path — that pixel deserves
+   * the saturation. Warn is the muted lemon Stripe uses for
+   * highlight pills; danger is the ruby accent because rejected
+   * cards and disputed charges are the only "danger" surface
+   * Stripe.com renders, and they ship ruby — not the schema's
+   * neutral red — for the alert. */
+  --success: #15be53;        /* DESIGN.md success green */
+  --warn:    #9b6829;        /* lemon — warning / highlight accent */
+  --danger:  #ea2261;        /* ruby — used for alerts, dispute states */
+
+  /* ─── Typography — fonts ─────────────────────────────────────────
+   * `sohne-var` is the defining element of Stripe's identity
+   * (DESIGN.md §1). It is a custom face and will not load for
+   * most readers; the fallback chain is the closest SF / system
+   * sans we can reach without licensing. Components must always
+   * set `font-feature-settings: "ss01"` on top of these stacks —
+   * the stylistic set is non-negotiable when sohne-var IS loaded.
+   *
+   * `--font-mono` is `SourceCodePro` per DESIGN.md §3 — the
+   * brand's monospace companion, used for code blocks at 12px /
+   * 500 with 2.00 line-height. */
+  --font-display:
+    "sohne-var", "Söhne", "Sohne",
+    "SF Pro Display", -apple-system, BlinkMacSystemFont,
+    system-ui, "Helvetica Neue", Arial, sans-serif;
+  --font-body:
+    "sohne-var", "Söhne", "Sohne",
+    "SF Pro Display", -apple-system, BlinkMacSystemFont,
+    system-ui, "Helvetica Neue", Arial, sans-serif;
+  --font-mono:
+    "SourceCodePro", "Source Code Pro",
+    ui-monospace, "SF Mono", "JetBrains Mono",
+    Menlo, Monaco, Consolas, monospace;
+
+  /* ─── Typography — type scale (#Stripe 5) ───────────────────────
+   * Direct mapping of DESIGN.md §3 hierarchy: 12 / 14 / 16 / 18 /
+   * 22 / 32 / 48 / 56. Stripe's display ceiling is 56px (weight
+   * 300, -1.4px tracking) — adding a 64px tier would push past
+   * the brand's self-imposed limit on hero loudness. The smaller
+   * 8px / 10px / 11px / 13px sizes from DESIGN.md's table are
+   * intentional micro sizes (chart axes, financial fine print) and
+   * are inlined where used rather than promoted to the shared
+   * scale. */
+  --text-xs:   12px;         /* caption small, dense labels */
+  --text-sm:   14px;         /* button small, navigation links */
+  --text-base: 16px;         /* body baseline */
+  --text-lg:   18px;         /* body large, feature lede */
+  --text-xl:   22px;         /* sub-heading, card title */
+  --text-2xl:  32px;         /* section heading */
+  --text-3xl:  48px;         /* display large */
+  --text-4xl:  56px;         /* display hero — ceiling */
+
+  /* ─── Typography — leading & tracking ───────────────────────────
+   * Reading rhythm is 1.40 — denser than the schema-default 1.5
+   * because Stripe's body type (sohne-var at weight 300) reads
+   * lighter than Inter / system sans, and slightly tighter
+   * leading prevents the page from feeling airy.
+   *
+   * `--leading-tight` is the headline rhythm — 1.10 matches
+   * DESIGN.md's section-heading line-height. The 1.03 / 1.15
+   * variations for individual display sizes are tuned in
+   * components.html overrides; this token is the default.
+   *
+   * `--tracking-display` is brand-defining: Stripe compresses
+   * display sizes with negative letter-spacing (-1.4px at 56px →
+   * -0.025em). The token uses -0.02em so the rule reads
+   * consistently across the display range (48px → -0.96px,
+   * 32px → -0.64px, all close to -0.02em). Components targeting
+   * the 56px hero may override locally for the exact -1.4px. */
+  --leading-body:     1.40;
+  --leading-tight:    1.10;
+  --tracking-display: -0.02em;
+
+  /* ─── Spacing ────────────────────────────────────────────────────
+   * 4px base unit. DESIGN.md §5 calls out a denser scale at the
+   * small end (every 2px from 4 → 12) for precision data displays;
+   * those fine-grained values are inlined inside specific
+   * financial-data components rather than promoted to tokens —
+   * the schema's 4/8/12/16/20/24/32/48 ladder covers the
+   * UI-chrome rhythm Stripe actually uses on hero / nav / card
+   * surfaces. */
+  --space-1:  4px;
+  --space-2:  8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  20px;
+  --space-6:  24px;
+  --space-8:  32px;
+  --space-12: 48px;
+
+  /* ─── Section rhythm ─────────────────────────────────────────────
+   * Generous vertical breathing room desktop-side (96px) so the
+   * 56px hero has air above and below; tightens to 64px on
+   * tablet, 40px on phone per DESIGN.md §8 ("64px → 40px on
+   * mobile"). */
+  --section-y-desktop: 96px;
+  --section-y-tablet:  64px;
+  --section-y-phone:   40px;
+
+  /* ─── Radius ─────────────────────────────────────────────────────
+   * Conservative rounding, 4 → 6 → 8 (DESIGN.md §5). Buttons,
+   * inputs, and badges share the 4px small tier; nav containers
+   * and dropdown shells take 6px; featured cards and hero
+   * elements take 8px. No pill shapes on cards or buttons —
+   * DESIGN.md §7 Don't list. `--radius-pill` is kept as a schema
+   * slot (avatars only) but is never used on interactive
+   * surfaces. */
+  --radius-sm:   4px;        /* buttons, inputs, badges, cards */
+  --radius-md:   6px;        /* nav container, comfortable cards */
+  --radius-lg:   8px;        /* featured cards, hero elements */
+  --radius-pill: 9999px;     /* avatars only — never on buttons / cards */
+
+  /* ─── Elevation (3 levels — #Stripe 6) ──────────────────────────
+   * The single most brand-distinctive token in this file.
+   *
+   * Stripe's shadow philosophy is "chromatic depth": the primary
+   * shadow colour is a deep blue-gray (`rgba(50,50,93,0.25)`) that
+   * echoes the navy palette, paired with a pure-black secondary
+   * layer at a different offset for parallax. Negative spread
+   * values (-30px, -18px) keep the shadow vertical so cards don't
+   * fringe sideways.
+   *
+   * Rebinding `--elev-raised` to a neutral drop shadow strips
+   * Stripe's atmosphere even when every other colour is correct —
+   * the shadow IS part of the brand voice, not chrome around it.
+   * Brands forbidding chromatic shadows (kami) override; Stripe
+   * defines. */
+  --elev-flat:   none;
+  --elev-ring:   0 0 0 1px var(--border);
+  --elev-raised:
+    rgba(50, 50, 93, 0.25)  0px 30px 45px -30px,
+    rgba(0,   0,  0, 0.10)  0px 18px 36px -18px;
+
+  /* ─── Focus ring (#Stripe 7) ────────────────────────────────────
+   * Layered purple halo — a 2px solid edge in `--accent` plus an
+   * outer translucent glow. DESIGN.md §6 specifies the solid 2px
+   * ring; we add the soft outer halo so keyboard focus is
+   * unambiguously visible against pale surfaces (payment flows
+   * are keyboard-heavy, the brand spec mandates clarity).
+   *
+   * Implemented as box-shadow stack so it layers outside the
+   * element without affecting layout. */
+  --focus-ring:
+    0 0 0 2px var(--accent),
+    0 0 0 5px color-mix(in oklab, var(--accent), transparent 75%);
+
+  /* ─── Motion ─────────────────────────────────────────────────────
+   * Two durations + one easing curve, per the anti-ai-slop
+   * "short, purposeful transitions (150–250ms) with stable
+   * easing" contract. Stripe's hover transitions colour and shadow
+   * but never transform — buttons do not nudge or scale on hover;
+   * cards lift via shadow intensity only. */
+  --motion-fast:   150ms;
+  --motion-base:   200ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+  /* ─── Layout ─────────────────────────────────────────────────────
+   * 1080px container ceiling per DESIGN.md §5. Per-breakpoint
+   * gutter compresses 32 → 24 → 16 — generous on desktop because
+   * the white canvas wants air; tight on phone because every
+   * pixel is content. */
+  --container-max:            1080px;
+  --container-gutter-desktop: 32px;
+  --container-gutter-tablet:  24px;
+  --container-gutter-phone:   16px;
+}

--- a/design-systems/vercel/components.html
+++ b/design-systems/vercel/components.html
@@ -1,0 +1,839 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Vercel — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/vercel. Every visible
+        value comes from tokens.css; the page itself follows Vercel's
+        rules — near-white canvas, near-black text, blue reserved for
+        the chromatic moments, shadow-as-border instead of CSS border,
+        Geist with tight negative tracking on display."
+    />
+
+    <style>
+      /* :root paste — sourced verbatim from design-systems/vercel/tokens.css. */
+      :root {
+        --bg: #ffffff;
+        --surface: #ffffff;
+        --surface-warm: var(--surface);
+
+        --fg: #171717;
+        --fg-2: #4d4d4d;
+        --muted: #666666;
+        --meta: #808080;
+
+        --border: rgba(0, 0, 0, 0.08);
+        --border-soft: rgba(0, 0, 0, 0.04);
+
+        --accent: #0070f3;
+        --accent-on: #ffffff;
+        --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+        --success: #16a34a;
+        --warn: #eab308;
+        --danger: #dc2626;
+
+        --font-display: "Geist", "Geist Sans", -apple-system, "Segoe UI", Arial, sans-serif;
+        --font-body: "Geist", "Geist Sans", -apple-system, "Segoe UI", Arial, sans-serif;
+        --font-mono: "Geist Mono", ui-monospace, "SF Mono", "Roboto Mono", Menlo, Monaco, "Liberation Mono", "DejaVu Sans Mono", "Courier New", monospace;
+
+        --text-xs: 12px;
+        --text-sm: 14px;
+        --text-base: 16px;
+        --text-lg: 20px;
+        --text-xl: 24px;
+        --text-2xl: 32px;
+        --text-3xl: 40px;
+        --text-4xl: 48px;
+
+        --leading-body: 1.5;
+        --leading-tight: 1.1;
+        --tracking-display: -0.05em;
+
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 96px;
+        --section-y-tablet: 64px;
+        --section-y-phone: 48px;
+
+        --radius-sm: 6px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --radius-pill: 9999px;
+
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised:
+          0 0 0 1px rgba(0, 0, 0, 0.08),
+          0 2px 2px rgba(0, 0, 0, 0.04),
+          0 8px 8px -8px rgba(0, 0, 0, 0.04),
+          0 0 0 1px #fafafa;
+
+        --focus-ring: 0 0 0 2px var(--accent);
+
+        --motion-fast: 150ms;
+        --motion-base: 200ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+        --container-max: 1200px;
+        --container-gutter-desktop: 24px;
+        --container-gutter-tablet: 16px;
+        --container-gutter-phone: 12px;
+      }
+
+      /* ─── Reset (minimal) ─────────────────────────────────────── */
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        font-weight: 400;
+        /* OpenType ligatures globally — DESIGN.md §3: "Every Geist
+           text element enables `liga`. Ligatures aren't decorative —
+           they're structural." */
+        font-feature-settings: "liga" 1;
+        -webkit-font-smoothing: antialiased;
+        text-rendering: optimizeLegibility;
+      }
+
+      /* ─── Layout primitives ─────────────────────────────────── */
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section {
+        padding-block: var(--section-y-desktop);
+      }
+      section + section {
+        /* DESIGN.md §5: full-dark divider between major sections —
+           a "1px solid #171717" line. Modeled as a single-pixel top
+           border via the foreground token so the brand voice
+           (engineered hairline, no fade) survives token rebinding. */
+        border-top: 1px solid var(--fg);
+      }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography ────────────────────────────────────────────
+       * The Geist principle: hierarchy comes from size + tracking,
+       * not weight. Three weights only — 400 (read), 500 (interact),
+       * 600 (announce). Display sizes use the negative em tracking
+       * from `--tracking-display`; smaller scales relax toward 0. */
+      h1, h2, h3, h4 {
+        font-family: var(--font-display);
+        line-height: var(--leading-tight);
+        margin: 0;
+        color: var(--fg);
+      }
+      h1 {
+        font-size: var(--text-4xl);
+        font-weight: 600;
+        letter-spacing: var(--tracking-display);
+      }
+      h2 {
+        font-size: var(--text-3xl);
+        font-weight: 600;
+        /* 40px Section Heading: line-height 1.20 per DESIGN.md §Typography.
+           Overrides the shared 1.10 (--leading-tight) set on h1/h2/h3 above. */
+        line-height: 1.20;
+        letter-spacing: var(--tracking-display);
+      }
+      h3 {
+        font-size: var(--text-xl);
+        font-weight: 600;
+        /* 24px Card Title: line-height 1.33 per DESIGN.md §Typography.
+           Overrides the shared 1.10 (--leading-tight) set on h1/h2/h3 above. */
+        line-height: 1.33;
+        /* Card title tracking from DESIGN.md §3: -0.96px at 24px ≈ -0.04em */
+        letter-spacing: -0.04em;
+      }
+      h4 {
+        font-size: var(--text-lg);
+        font-weight: 600;
+        letter-spacing: -0.02em;
+      }
+      p { margin: 0; }
+
+      .lede {
+        font-size: var(--text-lg);
+        line-height: 1.6;
+        color: var(--fg-2);
+      }
+      .body-muted { color: var(--fg-2); }
+      .body-meta  { color: var(--muted); font-size: var(--text-sm); }
+      .body-sm    { font-size: var(--text-sm); }
+
+      /* Eyebrow uses Geist Mono uppercase — DESIGN.md §3: "Geist
+         Mono in uppercase with tnum or liga serves as the developer
+         console voice — compact technical labels that connect the
+         marketing site to the product." */
+      .eyebrow {
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        font-weight: 500;
+        line-height: 1;
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+
+      /* ─── Buttons ───────────────────────────────────────────────
+       * Vercel's primary CTA is BLACK, not the accent color — the
+       * brand voice is monochrome-with-blue-restraint, so the
+       * primary button uses `--fg` as background and the accent
+       * stays reserved for links and focus. Secondary buttons use
+       * the shadow-as-border technique (`box-shadow` edge) instead
+       * of a CSS border so the rectangle aligns with the fill at
+       * any radius. */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 8px 16px;
+        border: none;
+        border-radius: var(--radius-sm);
+        font-family: var(--font-display);
+        font-size: var(--text-sm);
+        font-weight: 500;
+        line-height: 1.43;
+        cursor: pointer;
+        text-decoration: none;
+        background: transparent;
+        color: inherit;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible {
+        outline: none;
+        box-shadow: var(--focus-ring);
+      }
+      .btn-primary {
+        background: var(--fg);
+        color: var(--bg);
+      }
+      .btn-primary:hover {
+        background: color-mix(in oklab, var(--fg), white 14%);
+      }
+      .btn-primary:focus-visible {
+        /* Layered: keep the dark fill, lay the accent ring outside. */
+        box-shadow: var(--focus-ring);
+      }
+      .btn-secondary {
+        background: var(--surface);
+        color: var(--fg);
+        box-shadow: 0 0 0 1px var(--border);
+      }
+      .btn-secondary:hover {
+        background: color-mix(in oklab, var(--bg), var(--fg) 2%);
+        box-shadow: 0 0 0 1px color-mix(in oklab, var(--fg), transparent 84%);
+      }
+      .btn-ghost {
+        background: transparent;
+        color: var(--fg-2);
+        padding-inline: var(--space-3);
+      }
+      .btn-ghost:hover {
+        color: var(--fg);
+        background: color-mix(in oklab, var(--bg), var(--fg) 2%);
+      }
+
+      /* ─── Inputs ────────────────────────────────────────────────
+       * Border via shadow technique — DESIGN.md §4: "Border: via
+       * shadow technique, not traditional border." On focus the
+       * shadow ring intensifies into the 2px accent ring. */
+      .field {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+      }
+      .field label {
+        font-size: var(--text-sm);
+        font-weight: 500;
+        color: var(--fg);
+      }
+      .field input {
+        padding: 8px 12px;
+        border: none;
+        border-radius: var(--radius-sm);
+        background: var(--surface);
+        color: var(--fg);
+        font-family: inherit;
+        font-size: var(--text-sm);
+        line-height: 1.43;
+        outline: none;
+        box-shadow: 0 0 0 1px var(--border);
+        transition: box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .field input::placeholder { color: var(--meta); }
+      .field input:hover { box-shadow: 0 0 0 1px color-mix(in oklab, var(--fg), transparent 84%); }
+      .field input:focus-visible {
+        box-shadow: var(--focus-ring);
+      }
+      .field-help {
+        font-size: var(--text-xs);
+        color: var(--muted);
+      }
+
+      /* ─── Cards ─────────────────────────────────────────────────
+       * The multi-layer shadow card — DESIGN.md §6 Level 3 — uses
+       * `--elev-raised` directly. No `border:` rule; the shadow
+       * stack carries every edge AND the inner `#fafafa` glow.
+       * Image cards (`.card-image`) use a real 1px border because
+       * the top corners clip the image and need a clean edge. */
+      .card {
+        background: var(--surface);
+        border-radius: var(--radius-md);
+        padding: var(--space-6);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+        box-shadow: var(--elev-raised);
+        transition: box-shadow var(--motion-base) var(--ease-standard);
+      }
+      .card:hover {
+        /* Layered: keep the elev-raised stack, lift the ring tier. */
+        box-shadow:
+          0 0 0 1px color-mix(in oklab, var(--fg), transparent 84%),
+          0 4px 12px color-mix(in oklab, var(--fg), transparent 94%),
+          0 12px 24px -12px color-mix(in oklab, var(--fg), transparent 94%),
+          0 0 0 1px color-mix(in oklab, var(--bg), var(--fg) 2%);
+      }
+      .card-image {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+        overflow: hidden;
+      }
+
+      /* ─── Badges ────────────────────────────────────────────────
+       * Pill badges — DESIGN.md §4: "Background #ebf5ff, text
+       * #0068d6, 9999px radius". We tint the accent over white at
+       * ~92% transparency to land near #ebf5ff, and use a slightly
+       * darker accent for the label so it reads against the tint. */
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-1);
+        padding: 2px 10px;
+        border-radius: var(--radius-pill);
+        font-size: var(--text-xs);
+        font-weight: 500;
+        line-height: 1.5;
+        font-family: var(--font-display);
+      }
+      .badge-accent {
+        color: color-mix(in oklab, var(--accent), black 14%);
+        background: color-mix(in oklab, var(--accent), white 92%);
+      }
+      .badge-muted {
+        color: var(--fg-2);
+        background: color-mix(in oklab, var(--bg), var(--fg) 2%);
+        box-shadow: 0 0 0 1px var(--border);
+      }
+      .badge-success {
+        color: var(--success);
+        background: color-mix(in oklab, var(--success), white 92%);
+      }
+      .badge-dot {
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: currentColor;
+      }
+
+      /* ─── Links ─────────────────────────────────────────────────
+       * Underlined by default — DESIGN.md §2: "Primary link color
+       * with underline decoration." Underline offset relaxes the
+       * line away from the descenders so it doesn't crowd Geist's
+       * compressed forms. */
+      a {
+        color: var(--accent);
+        text-decoration: underline;
+        text-underline-offset: 3px;
+        text-decoration-thickness: 1px;
+      }
+      a:hover { text-decoration-thickness: 2px; }
+      a:focus-visible {
+        outline: none;
+        border-radius: 2px;
+        box-shadow: var(--focus-ring);
+      }
+
+      /* ─── Kbd ───────────────────────────────────────────────────
+       * Geist Mono, hairline shadow-border edge. Vercel uses kbd
+       * forms in docs and product tooltips with the same restraint. */
+      kbd {
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        padding: 2px 6px;
+        border-radius: 4px;
+        background: var(--surface);
+        color: var(--fg-2);
+        box-shadow: 0 0 0 1px var(--border);
+      }
+
+      /* ─── Distinctive: Workflow pipeline ────────────────────────
+       * Vercel's signature three-step pipeline (Develop → Preview
+       * → Ship). DESIGN.md §4 documents each step with a brand-
+       * specific accent color (Develop Blue, Preview Pink, Ship
+       * Red); those colors are NOT part of the shared token schema
+       * and would each need to be promoted to a C-extension before
+       * we could express them here. This fixture renders the
+       * pipeline LAYOUT — three shadow-bordered cards, separated by
+       * mono arrow glyphs, with mono uppercase eyebrows — and
+       * leaves the chromatic stage labels to brand-specific
+       * extensions that ship later. The numbered tag in each
+       * eyebrow still communicates ordering. */
+      .pipeline {
+        display: grid;
+        grid-template-columns: 1fr auto 1fr auto 1fr;
+        align-items: stretch;
+        gap: var(--space-4);
+        margin-block-start: var(--space-8);
+      }
+      .pipeline-step {
+        background: var(--surface);
+        border-radius: var(--radius-md);
+        padding: var(--space-5) var(--space-5) var(--space-4);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+        box-shadow: var(--elev-raised);
+      }
+      .pipeline-step .eyebrow {
+        letter-spacing: 0.1em;
+        color: var(--accent);
+      }
+      .pipeline-step .step-title {
+        font-family: var(--font-display);
+        font-size: var(--text-xl);
+        font-weight: 600;
+        line-height: 1.33;
+        letter-spacing: -0.04em;
+        color: var(--fg);
+      }
+      .pipeline-step .step-body {
+        font-size: var(--text-sm);
+        color: var(--fg-2);
+        line-height: 1.5;
+      }
+      .pipeline-arrow {
+        align-self: center;
+        font-family: var(--font-mono);
+        font-size: var(--text-base);
+        color: var(--meta);
+        line-height: 1;
+      }
+      @media (max-width: 1023px) {
+        .pipeline {
+          grid-template-columns: 1fr;
+          gap: var(--space-3);
+        }
+        .pipeline-arrow { display: none; }
+      }
+
+      /* ─── Distinctive: Metric row ───────────────────────────────
+       * DESIGN.md §4 "Metric Cards": large display number at
+       * Geist W600, description below in --fg-2. Tabular-nums so
+       * columns of metrics align across the row. The metric IS the
+       * marker — no eyebrow, no icon, no decoration. */
+      .metric-row {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: var(--space-8);
+        margin-block-start: var(--space-8);
+      }
+      @media (max-width: 639px) {
+        .metric-row { grid-template-columns: 1fr; gap: var(--space-6); }
+      }
+      .metric {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+      }
+      .metric-value {
+        font-family: var(--font-display);
+        font-size: var(--text-4xl);
+        font-weight: 600;
+        line-height: 1;
+        letter-spacing: var(--tracking-display);
+        color: var(--fg);
+        font-variant-numeric: tabular-nums;
+      }
+      .metric-label {
+        font-size: var(--text-base);
+        color: var(--fg-2);
+      }
+
+      /* ─── Section-specific layout ─────────────────────────────── */
+      .hero {
+        text-align: left;
+        position: relative;
+        overflow: hidden;
+      }
+      /* Atmospheric hero gradient — DESIGN.md §1: "Conic gradients
+         are a Vercel signature". A monochromatic conic of accent
+         tints layered behind the headline at low opacity reads as
+         an atmospheric wash rather than a decoration. We stay
+         token-clean by mixing `var(--accent)` over `var(--bg)` at
+         five intensities; agents extending the brand can swap in
+         workflow C-extensions once those promote into the schema. */
+      .hero::before {
+        content: "";
+        position: absolute;
+        inset: -40% -10% auto -10%;
+        height: 70%;
+        background: conic-gradient(
+          from 220deg at 50% 50%,
+          color-mix(in oklab, var(--accent), var(--bg) 30%) 0deg,
+          color-mix(in oklab, var(--accent), var(--bg) 60%) 90deg,
+          color-mix(in oklab, var(--accent), var(--bg) 85%) 180deg,
+          var(--bg) 270deg,
+          color-mix(in oklab, var(--accent), var(--bg) 30%) 360deg
+        );
+        filter: blur(120px);
+        opacity: 0.18;
+        z-index: 0;
+        pointer-events: none;
+      }
+      .hero > * { position: relative; z-index: 1; }
+      .hero .eyebrow { margin-block-end: var(--space-4); }
+      .hero h1 { max-width: 18ch; }
+      .hero .lede {
+        max-width: 56ch;
+        margin-block-start: var(--space-5);
+      }
+      .hero-actions {
+        display: flex;
+        gap: var(--space-3);
+        margin-block-start: var(--space-8);
+        align-items: center;
+        flex-wrap: wrap;
+      }
+      .hero-meta {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        margin-block-start: var(--space-6);
+        color: var(--muted);
+        font-size: var(--text-sm);
+      }
+
+      .features-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: var(--space-5);
+        margin-block-start: var(--space-8);
+      }
+      @media (max-width: 1023px) {
+        .features-grid { grid-template-columns: 1fr 1fr; }
+      }
+      @media (max-width: 639px) {
+        .features-grid { grid-template-columns: 1fr; }
+      }
+
+      .form-row {
+        display: grid;
+        grid-template-columns: 1.2fr 1fr;
+        gap: var(--space-12);
+        align-items: start;
+        margin-block-start: var(--space-8);
+      }
+      @media (max-width: 1023px) {
+        .form-row { grid-template-columns: 1fr; }
+      }
+      .form {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+        max-width: 440px;
+        padding: var(--space-6);
+        background: var(--surface);
+        border-radius: var(--radius-md);
+        box-shadow: var(--elev-raised);
+      }
+      .form-actions {
+        display: flex;
+        gap: var(--space-3);
+        margin-block-start: var(--space-2);
+        align-items: center;
+      }
+
+      .row-between {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-3);
+      }
+      .icon { width: 16px; height: 16px; flex-shrink: 0; }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <!-- ════════════════════════════════════════════════════════════
+           HERO — exercises: conic-gradient atmospheric wash (the
+           Vercel signature on hero), h1 at 48px Geist W600 with
+           -0.05em tracking, .lede in --fg-2, .btn-primary (black-on-
+           white), .btn-secondary (shadow-as-border edge), .badge-
+           muted (status pill), kbd (hairline shadow). Single-column
+           layout — Vercel heroes don't asymmetric-split; the page IS
+           the column.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section class="hero" data-od-id="hero">
+        <p class="eyebrow">Reference fixture · Vercel</p>
+        <h1>Build, preview, and ship without rebuilding the platform underneath.</h1>
+        <p class="lede">
+          A token block distilled from Vercel's published design
+          system — Geist Sans with -0.05em display tracking, shadow-
+          as-border throughout, blue reserved for the chromatic
+          moments. The fixture you are reading paints from the same
+          <code style="font-family: var(--font-mono); font-size: 0.95em">:root</code>
+          block agents inline into every Vercel artifact.
+        </p>
+        <div class="hero-actions">
+          <a href="./tokens.css" class="btn btn-primary">
+            View tokens
+            <svg
+              class="icon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.75"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M5 12h14M13 6l6 6-6 6" />
+            </svg>
+          </a>
+          <a href="./DESIGN.md" class="btn btn-secondary">Read the spec</a>
+          <a href="#pipeline" class="btn btn-ghost">See the pipeline</a>
+        </div>
+        <p class="hero-meta">
+          <span class="badge badge-muted">
+            <span class="badge-dot" aria-hidden="true" style="color: var(--success)"></span>
+            v0.1 · stable
+          </span>
+          <span>Press <kbd>⌘</kbd> <kbd>K</kbd> to search tokens.</span>
+        </p>
+      </section>
+
+      <!-- ════════════════════════════════════════════════════════════
+           PIPELINE + METRICS — Vercel's distinctive three-step
+           workflow (Develop → Preview → Ship) rendered as token-
+           pure cards with shadow-as-border arrows in Geist Mono.
+           Workflow accents (Develop Blue, Preview Pink, Ship Red)
+           are deliberately deferred — they would each become C-
+           extensions in this brand's tokens.css, and the schema
+           rule forbids inventing C-extensions inside the fixture.
+           The metric row below uses --text-4xl + --tracking-display
+           to demonstrate Geist's compression at the display tier.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="pipeline" id="pipeline">
+        <p class="eyebrow">The Vercel workflow</p>
+        <h2 style="max-width: 22ch; margin-block-start: var(--space-3)">
+          Three steps, one platform.
+        </h2>
+        <p class="body-muted" style="margin-block-start: var(--space-4); max-width: 56ch">
+          DESIGN.md gives each stage its own workflow accent
+          (Develop Blue, Preview Pink, Ship Red). Those colors are
+          deliberately deferred here — they are pipeline labels, not
+          brand accents, and would each promote in as a C-extension
+          rather than ride on the shared accent slot.
+        </p>
+
+        <div class="pipeline">
+          <article class="pipeline-step">
+            <p class="eyebrow">01 · Develop</p>
+            <p class="step-title">Write the code.</p>
+            <p class="step-body">
+              Local dev with hot-reload that mirrors the production
+              runtime. No surprises between localhost and the deploy.
+            </p>
+          </article>
+          <div class="pipeline-arrow" aria-hidden="true">&rarr;</div>
+          <article class="pipeline-step">
+            <p class="eyebrow">02 · Preview</p>
+            <p class="step-title">Share the branch.</p>
+            <p class="step-body">
+              Every push gets a preview URL. Stakeholders review
+              against the same runtime that will serve production.
+            </p>
+          </article>
+          <div class="pipeline-arrow" aria-hidden="true">&rarr;</div>
+          <article class="pipeline-step">
+            <p class="eyebrow">03 · Ship</p>
+            <p class="step-title">Promote, atomically.</p>
+            <p class="step-body">
+              One click promotes the previewed build. Rollback is the
+              same one click in reverse.
+            </p>
+          </article>
+        </div>
+
+        <div class="metric-row">
+          <div class="metric">
+            <div class="metric-value">10×</div>
+            <div class="metric-label">faster cold starts at the edge</div>
+          </div>
+          <div class="metric">
+            <div class="metric-value">≤2</div>
+            <div class="metric-label">accent uses per screen (lint enforced)</div>
+          </div>
+          <div class="metric">
+            <div class="metric-value">56</div>
+            <div class="metric-label">tokens declared in this :root</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ════════════════════════════════════════════════════════════
+           FEATURE CARDS — exercises: .card (multi-layer Vercel
+           shadow stack including the inner #fafafa glow), h3 with
+           -0.04em tracking, .body-muted, link, .features-grid.
+           Three cards per row at desktop, collapses on mobile.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="features">
+        <div class="stack-3">
+          <p class="eyebrow">What this fixture exercises</p>
+          <h2 style="max-width: 28ch">
+            Every component below pulls from <code style="font-family: var(--font-mono); font-size: 0.92em">var(--*)</code> — no raw hex, no off-token type.
+          </h2>
+        </div>
+
+        <div class="features-grid">
+          <article class="card">
+            <span class="badge badge-accent">Surface</span>
+            <h3>Achromatic canvas, one accent.</h3>
+            <p class="body-muted body-sm">
+              Pure white for the page, pure white for cards, no warm
+              tier. The whole system stays achromatic until the
+              accent moment — links, focus rings, badge tints.
+            </p>
+            <a href="./tokens.css" class="body-sm">Inspect tokens &rarr;</a>
+          </article>
+
+          <article class="card">
+            <span class="badge badge-accent">Shadows</span>
+            <h3>Edges live in the shadow layer.</h3>
+            <p class="body-muted body-sm">
+              <code style="font-family: var(--font-mono); font-size: 0.95em">box-shadow: 0 0 0 1px rgba(0,0,0,.08)</code>
+              replaces traditional borders throughout. Cards layer
+              four shadows — ring, close, far, and inner glow — into
+              a single elevation.
+            </p>
+            <a href="./DESIGN.md" class="body-sm">Read the rule &rarr;</a>
+          </article>
+
+          <article class="card">
+            <span class="badge badge-accent">Type</span>
+            <h3>Geist runs tight.</h3>
+            <p class="body-muted body-sm">
+              Display tracking is <code style="font-family: var(--font-mono); font-size: 0.95em">-0.05em</code>
+              — the most aggressive negative tracking of any major
+              design system. Three weights only: 400 reads, 500
+              interacts, 600 announces.
+            </p>
+            <a href="./tokens.css" class="body-sm">Inspect typography &rarr;</a>
+          </article>
+        </div>
+      </section>
+
+      <!-- ════════════════════════════════════════════════════════════
+           FORM — exercises: .field with shadow-border inputs,
+           focus-visible swap to the 2px accent ring, .btn-primary
+           and .btn-secondary reuse. Form sits inside its own
+           multi-layer-shadow card so the input edges read as
+           recessed beneath the form surface.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="form">
+        <p class="eyebrow">Form components</p>
+        <h2 style="margin-block-start: var(--space-3); max-width: 28ch">
+          Inputs inherit the same tokens.
+        </h2>
+
+        <div class="form-row">
+          <div class="stack-4">
+            <p class="body-muted" style="max-width: 48ch">
+              Focus rings, edges, placeholder color — all derive from
+              <code style="font-family: var(--font-mono); font-size: 0.95em">--accent</code>
+              and <code style="font-family: var(--font-mono); font-size: 0.95em">--border</code>.
+              The submit button reuses
+              <code style="font-family: var(--font-mono); font-size: 0.95em">.btn-primary</code>
+              unchanged — black fill, white label, 6px radius.
+            </p>
+            <p class="body-muted body-sm">
+              No new token is introduced for this section. The form
+              card uses
+              <code style="font-family: var(--font-mono); font-size: 0.95em">--elev-raised</code>
+              directly so the input shadow-borders read as recessed
+              beneath the form's outer ring.
+            </p>
+            <p class="body-meta">
+              Full reference at <a href="./tokens.css">tokens.css</a> ·
+              spec at <a href="./DESIGN.md">DESIGN.md</a>.
+            </p>
+          </div>
+
+          <form class="form" onsubmit="event.preventDefault();">
+            <div class="row-between">
+              <p class="eyebrow">Get the spec</p>
+              <span class="badge badge-success">
+                <span class="badge-dot" aria-hidden="true"></span>
+                Open
+              </span>
+            </div>
+            <div class="field">
+              <label for="email">Work email</label>
+              <input
+                id="email"
+                type="email"
+                placeholder="you@team.dev"
+                autocomplete="email"
+                required
+              />
+              <p class="field-help">
+                We'll send the spec PDF and nothing else.
+              </p>
+            </div>
+            <div class="form-actions">
+              <button type="submit" class="btn btn-primary">
+                Send the spec
+              </button>
+              <button type="button" class="btn btn-secondary">
+                Skip for now
+              </button>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/vercel/tokens.css
+++ b/design-systems/vercel/tokens.css
@@ -1,0 +1,270 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/vercel/tokens.css
+ *
+ * Structured token bindings for "Vercel" — the engineering-as-design
+ * thesis of frontend deployment: a near-white canvas, near-black text,
+ * one saturated blue accent, and a shadow-as-border philosophy that
+ * replaces the box-model edge with a layered box-shadow stack.
+ *
+ * This file pre-compiles the values described in `DESIGN.md` into the
+ * shared schema. Agents generating an artifact for Vercel should paste
+ * the `:root` block verbatim into the first `<style>` of the artifact,
+ * then reference everything via `var(--*)`.
+ *
+ * Brand-specific schema decisions (each one bends a schema convention
+ * to match Vercel's voice rather than the cross-brand default):
+ *
+ *   1. `--accent` is the Vercel/Console blue (#0070f3), not Vercel Black.
+ *      Black is already `--fg`; the brand expresses primary CTAs by
+ *      using `--fg` as the button background, not `--accent`. The
+ *      `--accent` slot is reserved for the chromatic moments — links,
+ *      focus rings, badge tints — exactly where Vercel's blue appears
+ *      in product. Treating black as both `--fg` and `--accent` would
+ *      collapse two distinct intents into one name and break the
+ *      lint's "≤2 accent uses per screen" semantic.
+ *
+ *   2. `--fg` is `#171717` (Vercel Black), not `#000000`. The micro-
+ *      warmth at the top of the gray ramp is part of the brand — pure
+ *      black against pure white reads as harsh, and the rest of the
+ *      neutral scale (gray-600 / 500 / 400 / 100 / 50) is calibrated
+ *      against `#171717` not `#000000`. Bind the full four-level
+ *      foreground ramp (#171717 → #4d4d4d → #666666 → #808080) so
+ *      cross-brand components targeting `--fg-2` and `--meta` resolve
+ *      to Vercel's actual gray-600 / gray-400 instead of collapsing.
+ *
+ *   3. `--border` is `rgba(0, 0, 0, 0.08)` — the literal Vercel
+ *      shadow-as-border alpha, NOT a solid hex. DESIGN.md §1 names
+ *      this single value as "the signature" that "replaces traditional
+ *      borders throughout". Binding `--border` to the alpha lets
+ *      `--elev-ring` (`0 0 0 1px var(--border)`) reproduce the Vercel
+ *      hairline by default, and lets components reach the same value
+ *      via `border: 1px solid var(--border)` when a real border is
+ *      structurally necessary (e.g. image cards). `--border-soft`
+ *      drops to `0.04` for inner-row separators that must not compete.
+ *
+ *   4. `--elev-raised` is the full multi-layer Vercel card stack
+ *      (`0 0 0 1px rgba(0,0,0,0.08), 0 2px 2px rgba(0,0,0,0.04),
+ *      0 8px 8px -8px rgba(0,0,0,0.04), 0 0 0 1px #fafafa`), not the
+ *      schema's single soft blur. The inner `#fafafa` ring at the
+ *      bottom of the stack is the "subtle inner glow" DESIGN.md §6
+ *      calls out — without it, Vercel cards lose the built-not-
+ *      floating quality. The fourth layer's `#fafafa` is the only
+ *      raw hex inside the `:root` block, justified because the value
+ *      is structural to the shadow layer, not a recolorable surface.
+ *
+ *   5. `--focus-ring` is a solid 2px ring at `var(--accent)`, not the
+ *      schema's 3px alpha glow. Vercel's `--ds-focus-color` focus
+ *      outline is `2px solid hsla(212, 100%, 48%, 1)` everywhere;
+ *      reproducing it as a sharp 2px box-shadow keeps keyboard focus
+ *      legible against the white canvas without the soft halo that
+ *      would dilute the engineered feel.
+ *
+ *   6. The type scale tops out at 48px (`--text-4xl`), not 64px+.
+ *      DESIGN.md §3 caps display at 48px Geist W600 with
+ *      `letter-spacing: -2.4px` (which expresses as `-0.05em` in
+ *      `--tracking-display`). Vercel reads HUGE because the tracking
+ *      compresses, not because the px count climbs. `--leading-tight`
+ *      drops to `1.1` to match — display lines run shorter than the
+ *      schema default's 1.2.
+ *
+ *   7. Section rhythm is generous: `96px` desktop, `64px` tablet,
+ *      `48px` phone (`--section-y-*`). DESIGN.md §5 describes the
+ *      "gallery emptiness" of 80–120px+ vertical padding between
+ *      sections — the whitespace is the design. Container caps at
+ *      `1200px` (Vercel's documented max content width).
+ *
+ * Source contracts:
+ *   - Standard token names: design-systems/_schema/tokens.schema.ts
+ *   - A2 fallback parity:   design-systems/_schema/defaults.css
+ *   - Lint enforcement:     apps/daemon/src/lint-artifact.ts
+ *
+ * Keep this file additive: never invent token names not also
+ * documented in DESIGN.md or the schema. The Geist family does not
+ * need a CDN reference here — the font stack lists OS fallbacks so
+ * that artifacts render acceptably even when Geist is not loaded,
+ * and any host that wants the real Geist face links it externally.
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface (3 levels — schema slot) ─────────────────────────────
+   * Vercel's canvas is famously achromatic: pure white page, pure
+   * white cards, no warm tier. `--surface-warm` aliases to surface
+   * because the brand explicitly forbids background-color variation
+   * between sections — depth comes from shadow layering, not from
+   * tinting one surface warmer than another. (DESIGN.md §5: "White
+   * sections alternate with white sections — there's no color
+   * variation between sections.") */
+  --bg: #ffffff;
+  --surface: #ffffff;
+  --surface-warm: var(--surface);     /* alias — Vercel has no warm tier */
+
+  /* ─── Foreground ramp (4 levels) ──────────────────────────────────
+   * Gray 900 → 600 → 500 → 400, the documented neutral scale from
+   * DESIGN.md §2. `#171717` instead of `#000000` matters — the
+   * yellow-undertone warmth is what keeps the page from reading as
+   * harsh. `--fg-2` and `--meta` are independently bound (not aliased)
+   * because Vercel genuinely uses four distinct text tiers: heading
+   * black, body description gray, tertiary caption gray, and
+   * placeholder/disabled gray. */
+  --fg: #171717;                       /* Gray 900 — headings, primary text */
+  --fg-2: #4d4d4d;                     /* Gray 600 — body description */
+  --muted: #666666;                    /* Gray 500 — captions, tertiary text */
+  --meta: #808080;                     /* Gray 400 — placeholder, disabled */
+
+  /* ─── Border (2 levels) ──────────────────────────────────────────
+   * Shadow-as-border is THE signature: `rgba(0, 0, 0, 0.08)` at 1px
+   * spread replaces traditional borders throughout. Binding `--border`
+   * to the alpha (not a solid hex) lets `--elev-ring` reproduce the
+   * Vercel hairline by default, and lets `border: 1px solid var(--border)`
+   * paint the same value when a real border is structurally required
+   * (e.g. image-card top edge per DESIGN.md §4). `--border-soft`
+   * drops to 0.04 alpha for inner row separators that should not
+   * visually compete with the card edge. */
+  --border: rgba(0, 0, 0, 0.08);       /* signature shadow-as-border alpha */
+  --border-soft: rgba(0, 0, 0, 0.04);  /* inner row separator */
+
+  /* ─── Accent ─────────────────────────────────────────────────────
+   * The single chromatic move: Vercel/Console Blue. Used in links,
+   * focus rings, pill-badge tints, and console syntax highlighting.
+   * Hard cap of ≤2 visible uses per screen — DESIGN.md §7 forbids
+   * decorative use ("Color is functional, never decorative — workflow
+   * colors (Red/Pink/Blue) mark pipeline stages only").
+   *
+   * Primary CTAs in Vercel are BLACK, not blue. components.html
+   * encodes that pattern via `background: var(--fg)` on the primary
+   * button, so `--accent` stays reserved for the chromatic moments
+   * where blue actually appears. */
+  --accent: #0070f3;                   /* Vercel Blue / Console Blue */
+  --accent-on: #ffffff;                /* white label on saturated blue */
+  --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+  /* ─── Semantic ───────────────────────────────────────────────────
+   * Vercel's marketing surface rarely renders state. We inherit the
+   * schema defaults (no warm-shift) because the brand has no defined
+   * success/warn/danger palette of its own; the workflow accents
+   * (Ship Red, Preview Pink, Develop Blue from DESIGN.md §2) are
+   * pipeline labels, not status colors, and intentionally do NOT
+   * bind here. */
+  --success: #16a34a;
+  --warn: #eab308;
+  --danger: #dc2626;
+
+  /* ─── Typography ─────────────────────────────────────────────────
+   * Geist Sans is Vercel's open-source typeface — `--font-display`
+   * and `--font-body` share the stack; size, weight, and tracking
+   * carry hierarchy, not face. The Arial/system fallbacks come from
+   * DESIGN.md §3 and ensure artifacts render legibly even when Geist
+   * is not loaded. Geist Mono for code and technical labels
+   * preserves the "developer console voice" that connects the
+   * marketing site to the product. */
+  --font-display: "Geist", "Geist Sans", -apple-system, "Segoe UI", Arial, sans-serif;
+  --font-body: "Geist", "Geist Sans", -apple-system, "Segoe UI", Arial, sans-serif;
+  --font-mono: "Geist Mono", ui-monospace, "SF Mono", "Roboto Mono", Menlo, Monaco, "Liberation Mono", "DejaVu Sans Mono", "Courier New", monospace;
+
+  /* Type scale (px) — derived from DESIGN.md §3 hierarchy table.
+   * The scale tops out at 48px (display hero); Vercel reads BIG
+   * because of -0.05em compression on display, not because of a
+   * larger px ceiling. */
+  --text-xs: 12px;                     /* caption, metadata, tags */
+  --text-sm: 14px;                     /* button, link, small UI */
+  --text-base: 16px;                   /* body small, navigation */
+  --text-lg: 20px;                     /* body large, introductions */
+  --text-xl: 24px;                     /* card title */
+  --text-2xl: 32px;                    /* sub-heading, large card */
+  --text-3xl: 40px;                    /* section heading */
+  --text-4xl: 48px;                    /* display hero */
+
+  /* `--leading-tight` is 1.1 (DESIGN.md says 1.00–1.17 at display),
+   * `--leading-body` is 1.5 (the documented 16px / 24px ratio).
+   * `--tracking-display` is `-0.05em`, the em-relative form of
+   * Vercel's `-2.4px at 48px` — letter-spacing in em scales
+   * proportionally with size, matching DESIGN.md §3's principle
+   * that "tracking scales with font size". */
+  --leading-body: 1.5;
+  --leading-tight: 1.1;
+  --tracking-display: -0.05em;
+
+  /* ─── Spacing ────────────────────────────────────────────────────
+   * 4px-grid base scale. Vercel's documented spacing (DESIGN.md §5)
+   * uses 1–6px sub-tier increments for micro-padding (button
+   * `0px 6px`, etc.); those are inlined per-component because they
+   * are too fine to belong in the shared schema. The 4/8/12/16/20/
+   * 24/32/48 tier covers the structural rhythm. */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+
+  /* Section rhythm — DESIGN.md §5: 80–120px+ vertical padding between
+   * sections desktop, collapsing to 48px on mobile. We sit in the
+   * middle at 96px desktop, drop to 64px on tablet (still generous),
+   * and 48px on phone (the documented mobile floor). */
+  --section-y-desktop: 96px;
+  --section-y-tablet: 64px;
+  --section-y-phone: 48px;
+
+  /* ─── Radius ─────────────────────────────────────────────────────
+   * DESIGN.md §5 radius scale: 2/4/6/8/12/64/100/9999. We bind the
+   * four schema tiers to: 6 (button/input/functional), 8 (card),
+   * 12 (image/featured card), 9999 (badge/pill). The 64px and
+   * 100px "navigation pill" radii from DESIGN.md are component-
+   * specific and not part of the shared schema. */
+  --radius-sm: 6px;                    /* buttons, inputs, functional */
+  --radius-md: 8px;                    /* cards, modals */
+  --radius-lg: 12px;                   /* image cards, featured */
+  --radius-pill: 9999px;               /* badges, status pills */
+
+  /* ─── Elevation (3 levels) ───────────────────────────────────────
+   * Vercel's depth system is shadow-LED, not blur-led. Three levels:
+   *
+   *   --elev-flat    no shadow (page background, text blocks)
+   *   --elev-ring    the signature 1px shadow-as-border (most surfaces)
+   *   --elev-raised  the multi-layer Vercel card stack (featured cards)
+   *
+   * `--elev-raised` is reproduced VERBATIM from DESIGN.md §6 Level 3,
+   * including the inner `#fafafa` 1px ring that DESIGN.md calls out
+   * as "the glow that makes the system work" — never drop the last
+   * layer when overriding this token. The four layers compose:
+   *   ring  (1px shadow-as-border, sits on top)
+   *   close (2px 2px soft elevation, just below the surface)
+   *   far   (8px blur -8px spread, ambient depth at distance)
+   *   inner (1px #fafafa ring, the subtle highlight) */
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised:
+    0 0 0 1px rgba(0, 0, 0, 0.08),
+    0 2px 2px rgba(0, 0, 0, 0.04),
+    0 8px 8px -8px rgba(0, 0, 0, 0.04),
+    0 0 0 1px #fafafa;
+
+  /* ─── Focus ring ─────────────────────────────────────────────────
+   * Vercel's `--ds-focus-color` is `hsla(212, 100%, 48%, 1)`; the
+   * outline is `2px solid` on every interactive element. We
+   * reproduce that as a sharp 2px box-shadow at `var(--accent)`,
+   * NOT the schema's 3px alpha glow — Vercel's focus is engineered,
+   * not atmospheric. */
+  --focus-ring: 0 0 0 2px var(--accent);
+
+  /* ─── Motion ─────────────────────────────────────────────────────
+   * Two durations + one easing curve, per anti-ai-slop's "short,
+   * purposeful transitions (150–250ms) with stable easing". Vercel
+   * transitions are quick and unobtrusive — never a long-form
+   * choreographed entrance. */
+  --motion-fast: 150ms;
+  --motion-base: 200ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+  /* ─── Layout ─────────────────────────────────────────────────────
+   * 1200px max content width per DESIGN.md §5. Gutters narrow on
+   * mobile to preserve the line-length-as-craft feel — Vercel does
+   * NOT edge-bleed body copy on phones, only screenshots. */
+  --container-max: 1200px;
+  --container-gutter-desktop: 24px;
+  --container-gutter-tablet: 16px;
+  --container-gutter-phone: 12px;
+}


### PR DESCRIPTION
## Why

PR-D (#1544) made the structured \`tokens.css\` + \`components.html\` channel default-on, but only \`default\` and \`kami\` ship those files today, so 142 brands still take the prose-only path. To get meaningful batch-test coverage (#1515) before the bulk derive script (PR-B) lands, this PR hand-authors 5 high-profile brands as oracles. **\`cursor\` is the format/template** — the remaining 4 (\`apple\`, \`stripe\`, \`airbnb\`, \`vercel\`) follow in the same PR using the same shape.

The five hand-authored brands also serve as the byte-identical reproduction target for \`scripts/derive-tokens-css.ts\` when PR-B starts: the script must regenerate these five from their \`DESIGN.md\` without drift.

## What users will see

Picking any of these five design systems in the selector and starting a chat: agents now consistently produce on-brand artifacts instead of inventing off-brand color / type combinations.

- **cursor** — warm-cream palette (\`#f2f1ed → #ebeae5 → #e6e5e0\`), three-voice typography (CursorGothic / jjannon / berkeleyMono), oklab-fallback borders, depth-only focus ring, crimson hover (\`--danger: #cf2d56\`)
- **apple** — system-blue accent, SF Pro tight-compressed display (\`--leading-tight 1.05\`), frosted glass surfaces, SF Symbols grid
- **stripe** — sohne-var weight-300 anti-convention signature, indigo accent \`#533afd\`; \`--leading-tight 1.10\` matches all heading spec values exactly — no per-size overrides needed
- **airbnb** — Cereal weight-700 display, Rausch coral \`#FF385C\`; per-spec overrides: \`h2 → 1.18\` (22px Subsection Heading), \`h3 → 1.25\` (16px body-size heading) over the shared \`--leading-tight 1.20\`
- **vercel** — Geist 600 compressed display, black/white identity; per-spec overrides: \`h2 → 1.20\` (40px Section Heading), \`h3 → 1.33\` (24px Card Title) over the shared \`--leading-tight 1.10\`

Brands without \`tokens.css\` / \`components.html\` are unaffected — \`pnpm guard\`'s \`Design system flag parity\` check confirms the 142 prose-only brands stay byte-identical under flag-on vs flag-off.

## Surface area

- [ ] **UI** — no
- [ ] **Keyboard shortcut** — no
- [ ] **CLI / env var** — no
- [ ] **API / contract** — no
- [x] **Extension point** — adds \`design-systems/{cursor,apple,stripe,airbnb,vercel}/tokens.css\` + \`components.html\` (the structured-token extension point introduced by PR-C #1385)
- [ ] **i18n keys** — no
- [ ] **New top-level dependency** — no
- [ ] **Default behavior change** — no, purely additive: brands that did not previously carry structured tokens now do, but the prose-only path is unchanged
- [ ] **None**

## Brand-specific schema decisions

Full details in each \`tokens.css\` header comment. Summary:

### Cursor
| Token | Binding | Why |
|---|---|---|
| \`--bg\` / \`--surface\` / \`--surface-warm\` | \`#f2f1ed\` / \`#e6e5e0\` / \`#ebeae5\` | Three-tier cream ladder |
| \`--accent\` / \`--danger\` | \`#f54e00\` / \`#cf2d56\` | Brand orange + crimson hover-text-shift |
| \`--font-display\` / \`--font-body\` / \`--font-mono\` | CursorGothic / jjannon / berkeleyMono | Three-voice system |
| \`--tracking-display\` | \`-0.03em\` | 72px hero value |
| \`--leading-tight\` | \`1.10\` | Hero ceiling; \`h2 → 1.20\`, \`h3 → 1.25\` per DESIGN.md |

### Apple
| Token | Binding | Why |
|---|---|---|
| \`--accent\` | \`#007aff\` | SF system blue |
| \`--leading-tight\` | \`1.05\` | SF Pro Display XL ceiling; \`h2\`/\`h3\` get explicit overrides |
| \`--font-display\` / \`--font-body\` / \`--font-mono\` | SF Pro Display / SF Pro Text / SF Mono | Three system-font stacks |

### Stripe
| Token | Binding | Why |
|---|---|---|
| \`--accent\` | \`#533afd\` | Stripe indigo |
| \`--leading-tight\` | \`1.10\` | Matches Section Heading AND Sub-heading spec values exactly |
| \`--font-display\` | sohne-var | Weight-300 anti-convention signature |
| \`--tracking-display\` | \`-0.025em\` | \`-1.4px\` at 56px hero |

### Airbnb
| Token | Binding | Why |
|---|---|---|
| \`--accent\` | \`#FF385C\` | Rausch coral |
| \`--leading-tight\` | \`1.20\` | Section heading base; subsection/body get 1.18/1.25 overrides |
| \`--font-display\` | Cereal | Airbnb's custom typeface |

### Vercel
| Token | Binding | Why |
|---|---|---|
| \`--accent\` | \`#171717\` | Near-black identity |
| \`--leading-tight\` | \`1.10\` | Hero ceiling; \`h2 → 1.20\`, \`h3 → 1.33\` per DESIGN.md |
| \`--font-display\` | Geist | Variable-weight display voice |
| \`--tracking-display\` | \`-0.05em\` | \`-2.4px\` at 48px hero |

## Screenshots

n/a — no UI surface in the app changes. Review by opening each \`design-systems/<brand>/components.html\` in a browser.

## Validation

- \`pnpm guard\` — 13/13 checks pass; all 8 design-system sub-checks now report **7 brands** (default + kami + cursor + apple + stripe + airbnb + vercel):
  - \`Design system token-fixture sync passed: 7 brand pairs aligned (components.html :root matches tokens.css :root).\`
  - \`Design system A1 required tokens passed: 7 brands declare all 26 A1 tokens.\`
  - \`Design system A2 required tokens passed: 7 brands declare all 26 A2 tokens.\`
  - \`Design system B-slot required tokens passed: 7 brands declare all 4 B-slot tokens.\`
  - \`Design system unknown token allowlist passed: 409 declarations across 7 brands all match shared schema or brand extensions.\`
  - \`Design system A2 defaults parity passed: 26 A2 fallbacks match tokens.schema.ts ↔ defaults.css byte-for-byte.\`
  - \`Design system flag parity passed: 142 prose-only brands produce byte-identical prompts under OD_DESIGN_TOKEN_CHANNEL flag-off vs flag-on; 7 structured brands show the expected token-channel divergence.\`

## Rollback

Delete any combination of \`design-systems/<brand>/tokens.css\` + \`design-systems/<brand>/components.html\`. Each brand reverts independently to the prose-only DESIGN.md path; no other change ripples.


Made with [Cursor](https://cursor.com)