### PR TITLE
fix(skills): repoint coreyhaines31 upstream URLs to marketingskills

### DIFF
--- a/scripts/seed-curated-design-skills.ts
+++ b/scripts/seed-curated-design-skills.ts
@@ -907,7 +907,7 @@ const CATALOGUE: CuratedSkill[] = [
     triggers: ['ad creative', 'ad headline', 'ad copy', 'paid social ad', 'search ad'],
     mode: 'design-system',
     category: 'marketing-creative',
-    upstream: 'https://github.com/coreyhaines31/skills',
+    upstream: 'https://github.com/coreyhaines31/marketingskills',
     attribution: 'Curated from Corey Haines.',
   },
   {
@@ -917,7 +917,7 @@ const CATALOGUE: CuratedSkill[] = [
     triggers: ['copywriting', 'landing copy', 'ad copy', 'homepage copy', 'rewrite copy'],
     mode: 'design-system',
     category: 'marketing-creative',
-    upstream: 'https://github.com/coreyhaines31/skills',
+    upstream: 'https://github.com/coreyhaines31/marketingskills',
     attribution: 'Curated from Corey Haines.',
   },
   {
@@ -927,7 +927,7 @@ const CATALOGUE: CuratedSkill[] = [
     triggers: ['marketing psychology', 'behavioral copy', 'persuasion', 'framing', 'cognitive bias'],
     mode: 'design-system',
     category: 'marketing-creative',
-    upstream: 'https://github.com/coreyhaines31/skills',
+    upstream: 'https://github.com/coreyhaines31/marketingskills',
     attribution: 'Curated from Corey Haines.',
   },
   {
@@ -937,7 +937,7 @@ const CATALOGUE: CuratedSkill[] = [
     triggers: ['paywall', 'upgrade screen', 'cro paywall', 'upsell modal', 'pricing screen'],
     mode: 'design-system',
     category: 'marketing-creative',
-    upstream: 'https://github.com/coreyhaines31/skills',
+    upstream: 'https://github.com/coreyhaines31/marketingskills',
     attribution: 'Curated from Corey Haines.',
   },
   {

--- a/skills/ad-creative/SKILL.md
+++ b/skills/ad-creative/SKILL.md
@@ -11,7 +11,7 @@ triggers:
 od:
   mode: design-system
   category: marketing-creative
-  upstream: "https://github.com/coreyhaines31/skills"
+  upstream: "https://github.com/coreyhaines31/marketingskills"
 ---
 
 # ad-creative
@@ -24,7 +24,7 @@ Generate and iterate ad creative including headlines, descriptions, and primary 
 
 ## Source
 
-- Upstream: https://github.com/coreyhaines31/skills
+- Upstream: https://github.com/coreyhaines31/marketingskills
 - Category: `marketing-creative`
 
 ## How to use
@@ -36,7 +36,7 @@ bundle into your active agent's skills directory:
 
 ```bash
 # Inspect the upstream README for exact paths
-open https://github.com/coreyhaines31/skills
+open https://github.com/coreyhaines31/marketingskills
 ```
 
 Then ask the agent to invoke this skill by name (`ad-creative`) or with

--- a/skills/copywriting/SKILL.md
+++ b/skills/copywriting/SKILL.md
@@ -11,7 +11,7 @@ triggers:
 od:
   mode: design-system
   category: marketing-creative
-  upstream: "https://github.com/coreyhaines31/skills"
+  upstream: "https://github.com/coreyhaines31/marketingskills"
 ---
 
 # copywriting
@@ -24,7 +24,7 @@ Write and rewrite marketing copy for landing pages, homepages, and ads. Useful a
 
 ## Source
 
-- Upstream: https://github.com/coreyhaines31/skills
+- Upstream: https://github.com/coreyhaines31/marketingskills
 - Category: `marketing-creative`
 
 ## How to use
@@ -36,7 +36,7 @@ bundle into your active agent's skills directory:
 
 ```bash
 # Inspect the upstream README for exact paths
-open https://github.com/coreyhaines31/skills
+open https://github.com/coreyhaines31/marketingskills
 ```
 
 Then ask the agent to invoke this skill by name (`copywriting`) or with

--- a/skills/marketing-psychology/SKILL.md
+++ b/skills/marketing-psychology/SKILL.md
@@ -11,7 +11,7 @@ triggers:
 od:
   mode: design-system
   category: marketing-creative
-  upstream: "https://github.com/coreyhaines31/skills"
+  upstream: "https://github.com/coreyhaines31/marketingskills"
 ---
 
 # marketing-psychology
@@ -24,7 +24,7 @@ Apply psychological principles and behavioral science to copy and design. Useful
 
 ## Source
 
-- Upstream: https://github.com/coreyhaines31/skills
+- Upstream: https://github.com/coreyhaines31/marketingskills
 - Category: `marketing-creative`
 
 ## How to use
@@ -36,7 +36,7 @@ bundle into your active agent's skills directory:
 
 ```bash
 # Inspect the upstream README for exact paths
-open https://github.com/coreyhaines31/skills
+open https://github.com/coreyhaines31/marketingskills
 ```
 
 Then ask the agent to invoke this skill by name (`marketing-psychology`) or with

--- a/skills/paywall-upgrade-cro/SKILL.md
+++ b/skills/paywall-upgrade-cro/SKILL.md
@@ -11,7 +11,7 @@ triggers:
 od:
   mode: design-system
   category: marketing-creative
-  upstream: "https://github.com/coreyhaines31/skills"
+  upstream: "https://github.com/coreyhaines31/marketingskills"
 ---
 
 # paywall-upgrade-cro
@@ -24,7 +24,7 @@ Design and optimize upgrade screens, paywalls, and upsell modals. Useful for Saa
 
 ## Source
 
-- Upstream: https://github.com/coreyhaines31/skills
+- Upstream: https://github.com/coreyhaines31/marketingskills
 - Category: `marketing-creative`
 
 ## How to use
@@ -36,7 +36,7 @@ bundle into your active agent's skills directory:
 
 ```bash
 # Inspect the upstream README for exact paths
-open https://github.com/coreyhaines31/skills
+open https://github.com/coreyhaines31/marketingskills
 ```
 
 Then ask the agent to invoke this skill by name (`paywall-upgrade-cro`) or with


### PR DESCRIPTION
## Why

While browsing the curated skill catalogue in this fork I clicked the "source" link on the **ad-creative** skill and hit a GitHub 404. The upstream repo `github.com/coreyhaines31/skills` no longer exists — it was renamed to `github.com/coreyhaines31/marketingskills`.

Four curated `marketing-creative` stubs still advertised the dead URL via `od.upstream` and in their body, so the Settings → Skills "source" link and the `open <url>` hint in each stub body all lead nowhere. This is link rot, not a feature.

Verified the new repo is the right target for each skill (coreyhaines31 only publishes two skill repos — `marketingskills` and `cybersecurity-skills` — and all four folder names + descriptions match the `marketingskills` entries):

| Stub | marketingskills entry | Match |
|---|---|---|
| `ad-creative` | `skills/ad-creative` | generate/iterate ad creative — headlines, descriptions, primary text ✅ |
| `copywriting` | `skills/copywriting` | write/rewrite marketing copy for landing/home/pricing pages ✅ |
| `marketing-psychology` | `skills/marketing-psychology` | apply psychological principles / behavioral science to marketing ✅ |
| `paywall-upgrade-cro` | `skills/paywalls` | optimize paywalls, upgrade screens, upsell modals (renamed upstream in v2.0) ✅ |

## What users will see

In Settings → Skills, opening any of the four `marketing-creative` skills (ad-creative, copywriting, marketing-psychology, paywall-upgrade-cro) now shows a "source" link that opens the live `coreyhaines31/marketingskills` repo instead of a 404 page. The `open <url>` hint in each stub body points there too.

No skill was renamed — `paywall-upgrade-cro` keeps its folder and `id`; only its upstream URL is repointed (the upstream skill is now called `paywalls`).

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

Touches `skills/{ad-creative,copywriting,marketing-psychology,paywall-upgrade-cro}/SKILL.md` and the matching entries in `scripts/seed-curated-design-skills.ts` (kept in sync so re-seeding stays consistent). No skill add/rename, so German display metadata and `content.test.ts` are unaffected.

## Bug fix verification

- A falsifiable red spec isn't meaningful here — nothing in the suite asserts external-URL liveness, and adding a network test would be flaky. Verified manually instead:
  - `github.com/coreyhaines31/skills` → HTTP 404 (dead).
  - `github.com/coreyhaines31/marketingskills` → exists; all four skill folders present and their descriptions match the stubs (table above).
  - `git grep coreyhaines31` → all 16 references now point at `marketingskills`, zero bare `coreyhaines31/skills` remain.

## Validation

- `pnpm install`
- `pnpm guard` — pass
- `pnpm typecheck` — pass
- `node --experimental-strip-types scripts/seed-curated-design-skills.ts` — idempotent no-op (`0 created, 92 skipped`), confirms the seed script still parses and the stubs stay in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)