### PR TITLE
Support folder drops in Design Files

### DIFF
--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -31,6 +31,18 @@ type DesignFilesGroupMode = 'kind' | 'modified';
 type ModifiedSection = 'today' | 'yesterday' | 'previous7Days' | 'previous30Days' | 'older';
 type SortKey = 'name' | 'kind' | 'mtime';
 type SortDir = 'asc' | 'desc';
+type FileSystemEntryWithReader = FileSystemEntry & {
+  createReader?: () => FileSystemDirectoryReader;
+};
+type FileSystemFileEntryWithFile = FileSystemFileEntry & {
+  file: (
+    successCallback: (file: File) => void,
+    errorCallback?: (error: DOMException) => void,
+  ) => void;
+};
+type DataTransferItemWithEntry = DataTransferItem & {
+  webkitGetAsEntry?: () => FileSystemEntry | null;
+};
 
 const MODIFIED_SECTION_ORDER: ModifiedSection[] = [
   'today',
@@ -538,11 +550,11 @@ export function DesignFilesPanel({
     }
   }
 
-  function handleDrop(ev: React.DragEvent<HTMLDivElement>) {
+  async function handleDrop(ev: React.DragEvent<HTMLDivElement>) {
     ev.preventDefault();
     dragDepthRef.current = 0;
     setDraggingFiles(false);
-    const dropped = Array.from(ev.dataTransfer.files ?? []);
+    const dropped = await filesFromDataTransfer(ev.dataTransfer);
     if (dropped.length > 0) onUploadFiles(dropped);
   }
 
@@ -1076,6 +1088,49 @@ function dateDaysBefore(date: Date, days: number): Date {
   const result = new Date(date);
   result.setDate(result.getDate() - days);
   return result;
+}
+
+async function filesFromDataTransfer(dataTransfer: DataTransfer): Promise<File[]> {
+  const items = Array.from(dataTransfer.items ?? []);
+  if (items.length === 0) return Array.from(dataTransfer.files ?? []);
+
+  const files = await Promise.all(items.map(filesFromDataTransferItem));
+  const flattened = files.flat();
+  return flattened.length > 0 ? flattened : Array.from(dataTransfer.files ?? []);
+}
+
+async function filesFromDataTransferItem(item: DataTransferItem): Promise<File[]> {
+  const entry = (item as DataTransferItemWithEntry).webkitGetAsEntry?.();
+  if (!entry) {
+    const file = item.kind === 'file' ? item.getAsFile() : null;
+    return file ? [file] : [];
+  }
+  return filesFromFileSystemEntry(entry);
+}
+
+async function filesFromFileSystemEntry(entry: FileSystemEntry): Promise<File[]> {
+  if (entry.isFile) return [await fileFromEntry(entry as FileSystemFileEntryWithFile)];
+  if (!entry.isDirectory) return [];
+
+  const reader = (entry as FileSystemEntryWithReader).createReader?.();
+  if (!reader) return [];
+
+  const files: File[] = [];
+  for (;;) {
+    const entries = await readEntryBatch(reader);
+    if (entries.length === 0) break;
+    const nested = await Promise.all(entries.map(filesFromFileSystemEntry));
+    files.push(...nested.flat());
+  }
+  return files;
+}
+
+function fileFromEntry(entry: FileSystemFileEntryWithFile): Promise<File> {
+  return new Promise((resolve, reject) => entry.file(resolve, reject));
+}
+
+function readEntryBatch(reader: FileSystemDirectoryReader): Promise<FileSystemEntry[]> {
+  return new Promise((resolve, reject) => reader.readEntries(resolve, reject));
 }
 
 function kindGlyph(kind: ProjectFileKind): string {


### PR DESCRIPTION
Fixes #776

## Why

Dragging a folder into Design Files currently follows the flat file path and can send the folder placeholder as a single upload item, which fails even though the dropzone invites users to drop folders. I wanted the advertised folder drop path to work for the common case of bringing a local asset folder into a project.

## What users will see

Dropping a folder onto the Design Files dropzone now recursively expands the folder contents and uploads the files it contains. Existing single-file and multi-file drops continue to use the same upload flow.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No visual change; this updates the existing Design Files dropzone behavior.

## Bug fix verification

- Test path that reproduces the bug: manual browser drag-and-drop behavior depends on `DataTransferItem.webkitGetAsEntry`, so I verified the affected web package with typecheck and the existing Design Files/FileWorkspace test coverage instead of adding a jsdom-only red spec.

## Validation

- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web test -- --runInBand`
