### PR TITLE
fix: Change comment button label from 'Send to Claude' to 'Send to chat'

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -1961,7 +1961,7 @@ function BoardComposerPopover({
             disabled={pendingCount === 0 || sending}
             onClick={() => void onSendBatch()}
           >
-            {sending ? 'Sending…' : 'Send to Claude'}
+            {sending ? 'Sending…' : 'Send to chat'}
           </button>
         </div>
       </div>
@@ -2111,7 +2111,7 @@ export function CommentSidePanel({
             disabled={sending}
             onClick={() => void onSendSelected()}
           >
-            {sending ? 'Sending…' : 'Send to Claude'}
+            {sending ? 'Sending…' : 'Send to chat'}
           </button>
         </div>
       ) : null}


### PR DESCRIPTION
Fixes #1390

## Why

**Use case:** Users add comments to design elements and send them to the chat for discussion or iteration.

**Pain being addressed:** The button is labeled "Send to Claude", which suggests a model-specific or brand-specific destination. This is misleading because:
- The comment goes to the chat interface, not directly to Claude
- The label doesn't match the visible workflow (chat-based)
- It's inconsistent with product terminology

**Root cause:** The button label uses "Claude" instead of "chat", creating confusion about where the comment is being sent.

## What users will see

**Before this fix:**
- Button labeled "Send to Claude"
- Suggests model-specific destination
- Inconsistent with chat-based workflow

**After this fix:**
- Button labeled "Send to chat"
- Clearly describes the actual destination
- Matches user mental model
- Consistent with visible UI flow

## Surface area

- [x] **UI** — button label text in comment popovers
- [ ] **Keyboard shortcut** — no changes
- [ ] **CLI / env var** — no changes
- [ ] **API / contract** — no changes
- [ ] **Extension point** — no changes
- [ ] **i18n keys** — no changes (hardcoded English text)
- [ ] **New top-level dependency** — no changes
- [ ] **Default behavior change** — label text only
- [ ] **None** — not applicable

## Screenshots

N/A — This is a simple text change from "Send to Claude" to "Send to chat".

## Bug fix verification

**Test reproduction:**
1. Open a design/project
2. Open the comment popover for an element
3. Enter comment text
4. **Before fix:** Button says "Send to Claude"
5. **After fix:** Button says "Send to chat"

**Why no automated test:**
- This is a simple text label change
- The button behavior is unchanged
- Manual verification confirms the correct label

## Validation

- [x] Code review: changed both instances (batch send and side panel send)
- [x] Code review: preserved "Sending…" loading state text
- [x] Consistency: "Send to chat" matches product terminology
- [x] Clarity: label accurately describes the destination

**Commands run:**
- Code inspection of both button instances
- Verified loading state text unchanged

## Technical details

### Changes made

#### `apps/web/src/components/FileViewer.tsx`

**1. Batch send button (line 1964):**
```tsx
// Before
{sending ? 'Sending…' : 'Send to Claude'}

// After
{sending ? 'Sending…' : 'Send to chat'}
```

**2. Side panel send button (line 2114):**
```tsx
// Before
{sending ? 'Sending…' : 'Send to Claude'}

// After
{sending ? 'Sending…' : 'Send to chat'}
```

### Why this approach

1. **Accurate description**: "Send to chat" clearly describes where the comment goes
2. **Product consistency**: Matches the visible chat-based workflow
3. **User mental model**: Users see the chat interface, not Claude directly
4. **Minimal change**: Only label text, no behavior changes
5. **Both instances**: Updated both comment popover buttons for consistency

### Why "Send to chat" instead of "Send to Claude"?

- **Destination clarity**: The comment goes to the chat interface, not directly to Claude
- **Product terminology**: The visible UI shows a chat, not a Claude-specific interface
- **Model agnostic**: The label doesn't assume a specific model
- **User understanding**: Users interact with chat, not with Claude as a separate entity

## Impact

- **Surface area**: Comment popover button labels
- **User experience**: Clearer understanding of where comments are sent
- **Accessibility**: No changes (text-only update)
- **Files changed**: 1 (FileViewer.tsx)
- **Lines changed**: +2 -2
- **Breaking changes**: None (label text only)

## Related

- #1390 — original issue tracking the misleading label
- Line 1964 — batch send button
- Line 2114 — side panel send button
