### PR TITLE
fix: gate chat token params by model family

### DIFF
--- a/apps/daemon/src/chat-routes.ts
+++ b/apps/daemon/src/chat-routes.ts
@@ -1,6 +1,7 @@
 import type { Express } from 'express';
 import type { RouteDeps } from './server-context.js';
 import { seedProviderIfMissing } from './media-config.js';
+import { buildOpenAIChatTokenParam } from './openai-chat-token-params.js';
 import {
   BYOK_SENSEAUDIO_TOOLS,
   executeGenerateImage,
@@ -756,8 +757,10 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
     const payload: any = {
       model,
       messages: payloadMessages,
-      max_tokens:
+      ...buildOpenAIChatTokenParam(
+        model,
         typeof maxTokens === 'number' && maxTokens > 0 ? maxTokens : 8192,
+      ),
       stream: true,
     };
 
@@ -869,8 +872,10 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
     const payload = {
       ...(usesVersionedOpenAIPath ? { model } : {}),
       messages: payloadMessages,
-      max_tokens:
+      ...buildOpenAIChatTokenParam(
+        model,
         typeof maxTokens === 'number' && maxTokens > 0 ? maxTokens : 8192,
+      ),
       stream: true,
     };
 

--- a/apps/daemon/src/chat-routes.ts
+++ b/apps/daemon/src/chat-routes.ts
@@ -1,7 +1,12 @@
 import type { Express } from 'express';
 import type { RouteDeps } from './server-context.js';
 import { seedProviderIfMissing } from './media-config.js';
-import { buildOpenAIChatTokenParam } from './openai-chat-token-params.js';
+import {
+  buildLegacyMaxTokensParam,
+  buildMaxCompletionTokensParam,
+  buildOpenAIChatTokenParam,
+  isUnsupportedMaxTokensError,
+} from './openai-chat-token-params.js';
 import {
   BYOK_SENSEAUDIO_TOOLS,
   executeGenerateImage,
@@ -869,40 +874,67 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
       payloadMessages.unshift({ role: 'system', content: systemPrompt });
     }
 
+    const effectiveMaxTokens =
+      typeof maxTokens === 'number' && maxTokens > 0 ? maxTokens : 8192;
     const payload = {
       ...(usesVersionedOpenAIPath ? { model } : {}),
       messages: payloadMessages,
-      ...buildOpenAIChatTokenParam(
-        model,
-        typeof maxTokens === 'number' && maxTokens > 0 ? maxTokens : 8192,
-      ),
+      ...buildLegacyMaxTokensParam(effectiveMaxTokens),
+      stream: true,
+    };
+    const retryPayload = {
+      ...(usesVersionedOpenAIPath ? { model } : {}),
+      messages: payloadMessages,
+      ...buildMaxCompletionTokensParam(effectiveMaxTokens),
       stream: true,
     };
 
     const sse = createSseResponse(res);
     sse.send('start', { model });
     try {
-      const response = await fetch(url, {
+      const requestInit = {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           'api-key': apiKey,
         },
+        redirect: 'error' as const,
+      };
+      let response = await fetch(url, {
+        ...requestInit,
         body: JSON.stringify(payload),
-        redirect: 'error',
       });
 
       if (!response.ok) {
-        const errorText = await response.text();
-        console.error(
-          `[proxy:azure] upstream error: ${response.status} ${redactAuthTokens(errorText)}`,
-        );
-        sendProxyError(sse, `Upstream error: ${response.status}`, {
-          code: proxyErrorCode(response.status),
-          details: errorText,
-          retryable: response.status === 429 || response.status >= 500,
-        });
-        return sse.end();
+        let errorText = await response.text();
+        if (
+          response.status === 400 &&
+          isUnsupportedMaxTokensError(errorText)
+        ) {
+          console.warn(
+            `[proxy:azure] retrying request with max_completion_tokens deployment=${model}`,
+          );
+          response = await fetch(url, {
+            ...requestInit,
+            body: JSON.stringify(retryPayload),
+          });
+          if (response.ok) {
+            errorText = '';
+          } else {
+            errorText = await response.text();
+          }
+        }
+        if (!response.ok) {
+          console.error(
+            `[proxy:azure] upstream error: ${response.status} ${redactAuthTokens(errorText)}`,
+          );
+          sendProxyError(sse, `Upstream error: ${response.status}`, {
+            code: proxyErrorCode(response.status),
+            details: errorText,
+            retryable: response.status === 429 || response.status >= 500,
+          });
+          return sse.end();
+        }
       }
 
       let ended = false;

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -40,7 +40,12 @@ import {
   cursorAuthGuidance,
   probeAgentAuthStatus,
 } from './runtimes/auth.js';
-import { buildOpenAIChatTokenParam } from './openai-chat-token-params.js';
+import {
+  buildLegacyMaxTokensParam,
+  buildMaxCompletionTokensParam,
+  buildOpenAIChatTokenParam,
+  isUnsupportedMaxTokensError,
+} from './openai-chat-token-params.js';
 import type { AgentCliEnvPrefs } from './app-config.js';
 import type { RuntimeAgentDef } from './runtimes/types.js';
 import {
@@ -516,6 +521,7 @@ interface ProviderCallShape {
   headers: Record<string, string>;
   body: unknown;
   extractText: (data: unknown) => string;
+  retryBodyOnUnsupportedMaxTokens?: unknown;
 }
 
 function buildProviderCall(input: ProviderTestRequest): ProviderCallShape {
@@ -601,10 +607,19 @@ function buildProviderCall(input: ProviderTestRequest): ProviderCallShape {
         },
         body: {
           ...(usesVersionedOpenAIPath ? { model } : {}),
-          ...buildOpenAIChatTokenParam(model, PROVIDER_MAX_TOKENS),
+          ...(usesVersionedOpenAIPath
+            ? buildOpenAIChatTokenParam(model, PROVIDER_MAX_TOKENS)
+            : buildLegacyMaxTokensParam(PROVIDER_MAX_TOKENS)),
           messages: [{ role: 'user', content: SMOKE_PROMPT }],
           stream: false,
         },
+        retryBodyOnUnsupportedMaxTokens: usesVersionedOpenAIPath
+          ? undefined
+          : {
+              messages: [{ role: 'user', content: SMOKE_PROMPT }],
+              stream: false,
+              ...buildMaxCompletionTokensParam(PROVIDER_MAX_TOKENS),
+            },
         extractText: extractOpenAIMessageText,
       };
     }
@@ -727,14 +742,58 @@ export async function testProviderConnection(
     );
     if (modelError) return modelError;
 
-    const response = await fetch(call.url, {
+    const requestInit = {
       method: 'POST',
       headers: call.headers,
-      body: JSON.stringify(call.body),
       signal: controller.signal,
-      redirect: 'error',
+      redirect: 'error' as const,
+    };
+    let response = await fetch(call.url, {
+      ...requestInit,
+      body: JSON.stringify(call.body),
     });
     const latencyMs = Date.now() - start;
+    if (
+      !response.ok &&
+      call.retryBodyOnUnsupportedMaxTokens !== undefined
+    ) {
+      let detailText = '';
+      try {
+        detailText = await response.text();
+      } catch {
+        detailText = '';
+      }
+      if (response.status === 400 && isUnsupportedMaxTokensError(detailText)) {
+        console.warn(
+          `[test:provider] ${input.protocol} ${validated.parsed.hostname} model=${input.model} → retrying with max_completion_tokens`,
+        );
+        response = await fetch(call.url, {
+          ...requestInit,
+          body: JSON.stringify(call.retryBodyOnUnsupportedMaxTokens),
+        });
+      } else {
+        const redactedDetail = redactSecrets(detailText.slice(0, 240), [
+          input.apiKey,
+        ]);
+        const kind = statusToKind(response.status, redactedDetail);
+        const detail =
+          redactedDetail ||
+          (response.status === 404
+            ? 'HTTP 404 from provider; check the Base URL path.'
+            : '');
+        console.warn(
+          `[test:provider] ${input.protocol} ${validated.parsed.hostname} model=${input.model} → ${response.status} in ${latencyMs}ms (${kind})${detail ? ` ${detail}` : ''}`,
+        );
+        return {
+          ok: false,
+          kind,
+          latencyMs,
+          model,
+          status: response.status,
+          detail,
+        };
+      }
+    }
     if (response.ok) {
       let data: unknown;
       let rawText = '';

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -749,7 +749,7 @@ export async function testProviderConnection(
       ...requestInit,
       body: JSON.stringify(call.body),
     });
-    const latencyMs = Date.now() - start;
+    let latencyMs = Date.now() - start;
     if (
       !response.ok &&
       call.retryBodyOnUnsupportedMaxTokens !== undefined
@@ -768,6 +768,7 @@ export async function testProviderConnection(
           ...requestInit,
           body: JSON.stringify(call.retryBodyOnUnsupportedMaxTokens),
         });
+        latencyMs = Date.now() - start;
       } else {
         const redactedDetail = redactSecrets(detailText.slice(0, 240), [
           input.apiKey,

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -607,19 +607,16 @@ function buildProviderCall(input: ProviderTestRequest): ProviderCallShape {
         },
         body: {
           ...(usesVersionedOpenAIPath ? { model } : {}),
-          ...(usesVersionedOpenAIPath
-            ? buildOpenAIChatTokenParam(model, PROVIDER_MAX_TOKENS)
-            : buildLegacyMaxTokensParam(PROVIDER_MAX_TOKENS)),
+          ...buildLegacyMaxTokensParam(PROVIDER_MAX_TOKENS),
           messages: [{ role: 'user', content: SMOKE_PROMPT }],
           stream: false,
         },
-        retryBodyOnUnsupportedMaxTokens: usesVersionedOpenAIPath
-          ? undefined
-          : {
-              messages: [{ role: 'user', content: SMOKE_PROMPT }],
-              stream: false,
-              ...buildMaxCompletionTokensParam(PROVIDER_MAX_TOKENS),
-            },
+        retryBodyOnUnsupportedMaxTokens: {
+          ...(usesVersionedOpenAIPath ? { model } : {}),
+          messages: [{ role: 'user', content: SMOKE_PROMPT }],
+          stream: false,
+          ...buildMaxCompletionTokensParam(PROVIDER_MAX_TOKENS),
+        },
         extractText: extractOpenAIMessageText,
       };
     }

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -40,6 +40,7 @@ import {
   cursorAuthGuidance,
   probeAgentAuthStatus,
 } from './runtimes/auth.js';
+import { buildOpenAIChatTokenParam } from './openai-chat-token-params.js';
 import type { AgentCliEnvPrefs } from './app-config.js';
 import type { RuntimeAgentDef } from './runtimes/types.js';
 import {
@@ -567,7 +568,7 @@ function buildProviderCall(input: ProviderTestRequest): ProviderCallShape {
         },
         body: {
           model,
-          max_tokens: PROVIDER_MAX_TOKENS,
+          ...buildOpenAIChatTokenParam(model, PROVIDER_MAX_TOKENS),
           messages: [{ role: 'user', content: SMOKE_PROMPT }],
           stream: false,
         },
@@ -600,7 +601,7 @@ function buildProviderCall(input: ProviderTestRequest): ProviderCallShape {
         },
         body: {
           ...(usesVersionedOpenAIPath ? { model } : {}),
-          max_tokens: PROVIDER_MAX_TOKENS,
+          ...buildOpenAIChatTokenParam(model, PROVIDER_MAX_TOKENS),
           messages: [{ role: 'user', content: SMOKE_PROMPT }],
           stream: false,
         },

--- a/apps/daemon/src/openai-chat-token-params.ts
+++ b/apps/daemon/src/openai-chat-token-params.ts
@@ -1,0 +1,22 @@
+export function usesMaxCompletionTokens(model: string): boolean {
+  const normalized = model.trim().toLowerCase();
+  // Keep the generic OpenAI-compatible path on max_tokens by default. Only
+  // switch the newer GPT-5/o-series chat-completions families that reject the
+  // legacy field.
+  return (
+    /^gpt-5(?:[.-]|$)/.test(normalized) ||
+    /^o1(?:[.-]|$)/.test(normalized) ||
+    /^o3(?:[.-]|$)/.test(normalized) ||
+    /^o4(?:[.-]|$)/.test(normalized)
+  );
+}
+
+export function buildOpenAIChatTokenParam(
+  model: string,
+  maxTokens: number,
+): { max_tokens: number } | { max_completion_tokens: number } {
+  if (usesMaxCompletionTokens(model)) {
+    return { max_completion_tokens: maxTokens };
+  }
+  return { max_tokens: maxTokens };
+}

--- a/apps/daemon/src/openai-chat-token-params.ts
+++ b/apps/daemon/src/openai-chat-token-params.ts
@@ -20,3 +20,24 @@ export function buildOpenAIChatTokenParam(
   }
   return { max_tokens: maxTokens };
 }
+
+export function buildLegacyMaxTokensParam(
+  maxTokens: number,
+): { max_tokens: number } {
+  return { max_tokens: maxTokens };
+}
+
+export function buildMaxCompletionTokensParam(
+  maxTokens: number,
+): { max_completion_tokens: number } {
+  return { max_completion_tokens: maxTokens };
+}
+
+export function isUnsupportedMaxTokensError(detail: string): boolean {
+  const normalized = detail.toLowerCase();
+  return (
+    normalized.includes('unsupported parameter') &&
+    normalized.includes('max_tokens') &&
+    normalized.includes('max_completion_tokens')
+  );
+}

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -972,12 +972,23 @@ describe('POST /api/test/connection provider mode', () => {
     );
   });
 
-  it('uses max_completion_tokens for GPT-5 Azure OpenAI-compatible v1 connection tests', async () => {
-    const fetchMock = passThroughOrUpstream(() =>
-      jsonResponse({
+  it('retries Azure OpenAI-compatible v1 alias connection tests with max_completion_tokens when max_tokens is rejected', async () => {
+    const fetchMock = passThroughOrUpstream((_url, init) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      if ('max_tokens' in body) {
+        return jsonResponse({
+          error: {
+            message: "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.",
+            type: 'invalid_request_error',
+            param: 'max_tokens',
+            code: 'unsupported_parameter',
+          },
+        }, { status: 400 });
+      }
+      return jsonResponse({
         choices: [{ message: { role: 'assistant', content: 'ok' } }],
-      }),
-    );
+      });
+    });
     vi.stubGlobal('fetch', fetchMock);
 
     const res = await realFetch(`${baseUrl}/api/test/connection`, {
@@ -988,23 +999,32 @@ describe('POST /api/test/connection provider mode', () => {
         protocol: 'azure',
         baseUrl: 'https://my-resource.services.ai.azure.com/api/projects/project/openai/v1',
         apiKey: 'azure-key',
-        model: 'gpt-5.4',
+        model: 'prod',
         apiVersion: '',
       }),
     });
     const body = (await res.json()) as Record<string, unknown>;
     expect(body.ok).toBe(true);
-    const upstream = fetchMock.mock.calls.find(
+    const upstreamCalls = fetchMock.mock.calls.filter(
       ([input]) => !String(input).startsWith(baseUrl),
     );
-    expect(upstream).toBeDefined();
-    const [, upstreamInit] = upstream!;
-    expect(JSON.parse(String(upstreamInit?.body))).toMatchObject({
+    expect(upstreamCalls).toHaveLength(2);
+    const firstBody = JSON.parse(String(upstreamCalls[0]![1]?.body));
+    const secondBody = JSON.parse(String(upstreamCalls[1]![1]?.body));
+    expect(firstBody).toMatchObject({
+      model: 'prod',
+      messages: [{ role: 'user', content: 'Reply with only: ok' }],
+      max_tokens: 100,
+      stream: false,
+    });
+    expect(firstBody).not.toHaveProperty('max_completion_tokens');
+    expect(secondBody).toMatchObject({
+      model: 'prod',
       messages: [{ role: 'user', content: 'Reply with only: ok' }],
       max_completion_tokens: 100,
       stream: false,
     });
-    expect(JSON.parse(String(upstreamInit?.body))).not.toHaveProperty('max_tokens');
+    expect(secondBody).not.toHaveProperty('max_tokens');
   });
 
   it('retries Azure deployment-mode connection tests with max_completion_tokens when max_tokens is rejected', async () => {

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -972,6 +972,155 @@ describe('POST /api/test/connection provider mode', () => {
     );
   });
 
+  it('uses max_completion_tokens for GPT-5 Azure connection tests', async () => {
+    const fetchMock = passThroughOrUpstream(() =>
+      jsonResponse({
+        choices: [{ message: { role: 'assistant', content: 'ok' } }],
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await realFetch(`${baseUrl}/api/test/connection`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        mode: 'provider',
+        protocol: 'azure',
+        baseUrl: 'https://my-azure.openai.azure.com',
+        apiKey: 'azure-key',
+        model: 'gpt-5.4',
+        apiVersion: '2024-10-21',
+      }),
+    });
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+    const upstream = fetchMock.mock.calls.find(
+      ([input]) => !String(input).startsWith(baseUrl),
+    );
+    expect(upstream).toBeDefined();
+    const [, upstreamInit] = upstream!;
+    expect(JSON.parse(String(upstreamInit?.body))).toMatchObject({
+      messages: [{ role: 'user', content: 'Reply with only: ok' }],
+      max_completion_tokens: 100,
+      stream: false,
+    });
+    expect(JSON.parse(String(upstreamInit?.body))).not.toHaveProperty('max_tokens');
+  });
+
+  it('keeps max_tokens for legacy OpenAI connection tests', async () => {
+    const fetchMock = passThroughOrUpstream(() =>
+      jsonResponse({
+        choices: [{ message: { role: 'assistant', content: 'ok' } }],
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await realFetch(`${baseUrl}/api/test/connection`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        mode: 'provider',
+        protocol: 'openai',
+        baseUrl: 'https://api.openai.com/v1',
+        apiKey: 'sk-good',
+        model: 'gpt-4o',
+      }),
+    });
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+    const upstream = fetchMock.mock.calls.find(
+      ([input]) => !String(input).startsWith(baseUrl),
+    );
+    expect(upstream).toBeDefined();
+    const [, upstreamInit] = upstream!;
+    expect(JSON.parse(String(upstreamInit?.body))).toMatchObject({
+      model: 'gpt-4o',
+      max_tokens: 100,
+      stream: false,
+    });
+    expect(JSON.parse(String(upstreamInit?.body))).not.toHaveProperty(
+      'max_completion_tokens',
+    );
+  });
+
+  it('keeps max_tokens for DeepSeek-style OpenAI-compatible connection tests', async () => {
+    const fetchMock = passThroughOrUpstream((url) => {
+      if (url === 'https://api.deepseek.com/v1/models') {
+        return jsonResponse({
+          data: [{ id: 'deepseek-chat', object: 'model' }],
+        });
+      }
+      return jsonResponse({
+        choices: [{ message: { role: 'assistant', content: 'ok' } }],
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await realFetch(`${baseUrl}/api/test/connection`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        mode: 'provider',
+        protocol: 'openai',
+        baseUrl: 'https://api.deepseek.com',
+        apiKey: 'deepseek-key',
+        model: 'deepseek-chat',
+      }),
+    });
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+    const upstream = fetchMock.mock.calls.find(
+      ([input]) => String(input) === 'https://api.deepseek.com/v1/chat/completions',
+    );
+    expect(upstream).toBeDefined();
+    const [, upstreamInit] = upstream!;
+    expect(JSON.parse(String(upstreamInit?.body))).toMatchObject({
+      model: 'deepseek-chat',
+      max_tokens: 100,
+      stream: false,
+    });
+    expect(JSON.parse(String(upstreamInit?.body))).not.toHaveProperty(
+      'max_completion_tokens',
+    );
+  });
+
+  it('keeps max_tokens for Azure gpt-4o connection tests on the default deployment path', async () => {
+    const fetchMock = passThroughOrUpstream(() =>
+      jsonResponse({
+        choices: [{ message: { role: 'assistant', content: 'ok' } }],
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await realFetch(`${baseUrl}/api/test/connection`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        mode: 'provider',
+        protocol: 'azure',
+        baseUrl: 'https://my-azure.openai.azure.com',
+        apiKey: 'azure-key',
+        model: 'gpt-4o',
+        apiVersion: '',
+      }),
+    });
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+    const upstream = fetchMock.mock.calls.find(
+      ([input]) => !String(input).startsWith(baseUrl),
+    );
+    expect(upstream).toBeDefined();
+    const [, upstreamInit] = upstream!;
+    expect(JSON.parse(String(upstreamInit?.body))).toMatchObject({
+      messages: [{ role: 'user', content: 'Reply with only: ok' }],
+      max_tokens: 100,
+      stream: false,
+    });
+    expect(JSON.parse(String(upstreamInit?.body))).not.toHaveProperty(
+      'max_completion_tokens',
+    );
+  });
+
   it('keeps the default Azure api-version in connection tests when the field is blank', async () => {
     const fetchMock = passThroughOrUpstream(() =>
       jsonResponse({

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -1072,6 +1072,45 @@ describe('POST /api/test/connection provider mode', () => {
     expect(secondBody).not.toHaveProperty('max_tokens');
   });
 
+  it('reports Azure retry latency from the final provider response', async () => {
+    let now = 10_000;
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now);
+    const fetchMock = vi.fn((_input: FetchInput, init?: FetchInit) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      if ('max_tokens' in body) {
+        now += 25;
+        return Promise.resolve(jsonResponse({
+          error: {
+            message: "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.",
+            type: 'invalid_request_error',
+            param: 'max_tokens',
+            code: 'unsupported_parameter',
+          },
+        }, { status: 400 }));
+      }
+      now += 75;
+      return Promise.resolve(jsonResponse({
+        choices: [{ message: { role: 'assistant', content: 'ok' } }],
+      }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    try {
+      await expect(testProviderConnection({
+        protocol: 'azure',
+        baseUrl: 'https://my-azure.openai.azure.com',
+        apiKey: 'azure-key',
+        model: 'prod',
+        apiVersion: '',
+      })).resolves.toMatchObject({
+        ok: true,
+        latencyMs: 100,
+      });
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
   it('keeps max_tokens for legacy OpenAI connection tests', async () => {
     const fetchMock = passThroughOrUpstream(() =>
       jsonResponse({

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -1111,6 +1111,49 @@ describe('POST /api/test/connection provider mode', () => {
     }
   });
 
+  it('reports Azure failed-retry latency from the final provider response', async () => {
+    let now = 20_000;
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now);
+    const fetchMock = vi.fn((_input: FetchInput, init?: FetchInit) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      if ('max_tokens' in body) {
+        now += 25;
+        return Promise.resolve(jsonResponse({
+          error: {
+            message: "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.",
+            type: 'invalid_request_error',
+            param: 'max_tokens',
+            code: 'unsupported_parameter',
+          },
+        }, { status: 400 }));
+      }
+      now += 75;
+      return Promise.resolve(jsonResponse({
+        error: {
+          message: 'retry failed',
+        },
+      }, { status: 500 }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    try {
+      await expect(testProviderConnection({
+        protocol: 'azure',
+        baseUrl: 'https://my-azure.openai.azure.com',
+        apiKey: 'azure-key',
+        model: 'prod',
+        apiVersion: '',
+      })).resolves.toMatchObject({
+        ok: false,
+        kind: 'upstream_unavailable',
+        status: 500,
+        latencyMs: 100,
+      });
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
   it('keeps max_tokens for legacy OpenAI connection tests', async () => {
     const fetchMock = passThroughOrUpstream(() =>
       jsonResponse({

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -972,7 +972,7 @@ describe('POST /api/test/connection provider mode', () => {
     );
   });
 
-  it('uses max_completion_tokens for GPT-5 Azure connection tests', async () => {
+  it('uses max_completion_tokens for GPT-5 Azure OpenAI-compatible v1 connection tests', async () => {
     const fetchMock = passThroughOrUpstream(() =>
       jsonResponse({
         choices: [{ message: { role: 'assistant', content: 'ok' } }],
@@ -986,10 +986,10 @@ describe('POST /api/test/connection provider mode', () => {
       body: JSON.stringify({
         mode: 'provider',
         protocol: 'azure',
-        baseUrl: 'https://my-azure.openai.azure.com',
+        baseUrl: 'https://my-resource.services.ai.azure.com/api/projects/project/openai/v1',
         apiKey: 'azure-key',
         model: 'gpt-5.4',
-        apiVersion: '2024-10-21',
+        apiVersion: '',
       }),
     });
     const body = (await res.json()) as Record<string, unknown>;
@@ -1005,6 +1005,51 @@ describe('POST /api/test/connection provider mode', () => {
       stream: false,
     });
     expect(JSON.parse(String(upstreamInit?.body))).not.toHaveProperty('max_tokens');
+  });
+
+  it('retries Azure deployment-mode connection tests with max_completion_tokens when max_tokens is rejected', async () => {
+    const fetchMock = passThroughOrUpstream((_url, init) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      if ('max_tokens' in body) {
+        return jsonResponse({
+          error: {
+            message: "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.",
+            type: 'invalid_request_error',
+            param: 'max_tokens',
+            code: 'unsupported_parameter',
+          },
+        }, { status: 400 });
+      }
+      return jsonResponse({
+        choices: [{ message: { role: 'assistant', content: 'ok' } }],
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await realFetch(`${baseUrl}/api/test/connection`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        mode: 'provider',
+        protocol: 'azure',
+        baseUrl: 'https://my-azure.openai.azure.com',
+        apiKey: 'azure-key',
+        model: 'prod',
+        apiVersion: '',
+      }),
+    });
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+    const upstreamCalls = fetchMock.mock.calls.filter(
+      ([input]) => !String(input).startsWith(baseUrl),
+    );
+    expect(upstreamCalls).toHaveLength(2);
+    const firstBody = JSON.parse(String(upstreamCalls[0]![1]?.body));
+    const secondBody = JSON.parse(String(upstreamCalls[1]![1]?.body));
+    expect(firstBody).toMatchObject({ max_tokens: 100, stream: false });
+    expect(firstBody).not.toHaveProperty('max_completion_tokens');
+    expect(secondBody).toMatchObject({ max_completion_tokens: 100, stream: false });
+    expect(secondBody).not.toHaveProperty('max_tokens');
   });
 
   it('keeps max_tokens for legacy OpenAI connection tests', async () => {

--- a/apps/daemon/tests/proxy-routes.test.ts
+++ b/apps/daemon/tests/proxy-routes.test.ts
@@ -308,10 +308,27 @@ describe('API proxy routes', () => {
     expect(upstreamInit?.redirect).toBe('error');
   });
 
-  it('uses max_completion_tokens for GPT-5 Azure OpenAI-compatible v1 payloads', async () => {
+  it('retries Azure OpenAI-compatible v1 alias requests with max_completion_tokens when max_tokens is rejected', async () => {
     const fetchMock = vi.fn((input: FetchInput, init?: FetchInit) => {
       const url = String(input);
       if (url.startsWith(baseUrl)) return realFetch(input, init);
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      if ('max_tokens' in body) {
+        return Promise.resolve(new Response(
+          JSON.stringify({
+            error: {
+              message: "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.",
+              type: 'invalid_request_error',
+              param: 'max_tokens',
+              code: 'unsupported_parameter',
+            },
+          }),
+          {
+            status: 400,
+            headers: { 'content-type': 'application/json' },
+          },
+        ));
+      }
       return Promise.resolve(sseResponse('data: [DONE]\n\n'));
     });
     vi.stubGlobal('fetch', fetchMock);
@@ -322,20 +339,33 @@ describe('API proxy routes', () => {
       body: JSON.stringify({
         baseUrl: 'https://resource.services.ai.azure.com/api/projects/project/openai/v1',
         apiKey: 'azure-key',
-        model: 'gpt-5.4',
+        model: 'prod',
         apiVersion: '',
         maxTokens: 1234,
         messages: [{ role: 'user', content: 'hello' }],
       }),
     });
 
-    const [, upstreamInit] = fetchMock.mock.calls[0]!;
-    expect(JSON.parse(String(upstreamInit?.body))).toMatchObject({
+    const upstreamCalls = fetchMock.mock.calls.filter(
+      ([input]) => !String(input).startsWith(baseUrl),
+    );
+    expect(upstreamCalls).toHaveLength(2);
+    const firstBody = JSON.parse(String(upstreamCalls[0]![1]?.body));
+    const secondBody = JSON.parse(String(upstreamCalls[1]![1]?.body));
+    expect(firstBody).toMatchObject({
+      model: 'prod',
+      messages: [{ role: 'user', content: 'hello' }],
+      max_tokens: 1234,
+      stream: true,
+    });
+    expect(firstBody).not.toHaveProperty('max_completion_tokens');
+    expect(secondBody).toMatchObject({
+      model: 'prod',
       messages: [{ role: 'user', content: 'hello' }],
       max_completion_tokens: 1234,
       stream: true,
     });
-    expect(JSON.parse(String(upstreamInit?.body))).not.toHaveProperty('max_tokens');
+    expect(secondBody).not.toHaveProperty('max_tokens');
   });
 
   it('retries Azure deployment-mode requests with max_completion_tokens when max_tokens is rejected', async () => {

--- a/apps/daemon/tests/proxy-routes.test.ts
+++ b/apps/daemon/tests/proxy-routes.test.ts
@@ -308,7 +308,7 @@ describe('API proxy routes', () => {
     expect(upstreamInit?.redirect).toBe('error');
   });
 
-  it('uses max_completion_tokens for GPT-5 Azure chat-completions payloads', async () => {
+  it('uses max_completion_tokens for GPT-5 Azure OpenAI-compatible v1 payloads', async () => {
     const fetchMock = vi.fn((input: FetchInput, init?: FetchInit) => {
       const url = String(input);
       if (url.startsWith(baseUrl)) return realFetch(input, init);
@@ -320,10 +320,10 @@ describe('API proxy routes', () => {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
-        baseUrl: 'https://resource.openai.azure.com',
+        baseUrl: 'https://resource.services.ai.azure.com/api/projects/project/openai/v1',
         apiKey: 'azure-key',
         model: 'gpt-5.4',
-        apiVersion: '2024-10-21',
+        apiVersion: '',
         maxTokens: 1234,
         messages: [{ role: 'user', content: 'hello' }],
       }),
@@ -336,6 +336,54 @@ describe('API proxy routes', () => {
       stream: true,
     });
     expect(JSON.parse(String(upstreamInit?.body))).not.toHaveProperty('max_tokens');
+  });
+
+  it('retries Azure deployment-mode requests with max_completion_tokens when max_tokens is rejected', async () => {
+    const fetchMock = vi.fn((input: FetchInput, init?: FetchInit) => {
+      const url = String(input);
+      if (url.startsWith(baseUrl)) return realFetch(input, init);
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      if ('max_tokens' in body) {
+        return Promise.resolve(new Response(
+          JSON.stringify({
+            error: {
+              message: "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.",
+              type: 'invalid_request_error',
+              param: 'max_tokens',
+              code: 'unsupported_parameter',
+            },
+          }),
+          {
+            status: 400,
+            headers: { 'content-type': 'application/json' },
+          },
+        ));
+      }
+      return Promise.resolve(sseResponse('data: [DONE]\n\n'));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await realFetch(`${baseUrl}/api/proxy/azure/stream`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        baseUrl: 'https://resource.openai.azure.com',
+        apiKey: 'azure-key',
+        model: 'prod',
+        apiVersion: '',
+        maxTokens: 1234,
+        messages: [{ role: 'user', content: 'hello' }],
+      }),
+    });
+
+    await expect(res.text()).resolves.toContain('event: end');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const firstBody = JSON.parse(String(fetchMock.mock.calls[0]![1]?.body));
+    const secondBody = JSON.parse(String(fetchMock.mock.calls[1]![1]?.body));
+    expect(firstBody).toMatchObject({ max_tokens: 1234, stream: true });
+    expect(firstBody).not.toHaveProperty('max_completion_tokens');
+    expect(secondBody).toMatchObject({ max_completion_tokens: 1234, stream: true });
+    expect(secondBody).not.toHaveProperty('max_tokens');
   });
 
   it('keeps max_tokens for legacy OpenAI-compatible chat-completions payloads', async () => {

--- a/apps/daemon/tests/proxy-routes.test.ts
+++ b/apps/daemon/tests/proxy-routes.test.ts
@@ -308,6 +308,131 @@ describe('API proxy routes', () => {
     expect(upstreamInit?.redirect).toBe('error');
   });
 
+  it('uses max_completion_tokens for GPT-5 Azure chat-completions payloads', async () => {
+    const fetchMock = vi.fn((input: FetchInput, init?: FetchInit) => {
+      const url = String(input);
+      if (url.startsWith(baseUrl)) return realFetch(input, init);
+      return Promise.resolve(sseResponse('data: [DONE]\n\n'));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await realFetch(`${baseUrl}/api/proxy/azure/stream`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        baseUrl: 'https://resource.openai.azure.com',
+        apiKey: 'azure-key',
+        model: 'gpt-5.4',
+        apiVersion: '2024-10-21',
+        maxTokens: 1234,
+        messages: [{ role: 'user', content: 'hello' }],
+      }),
+    });
+
+    const [, upstreamInit] = fetchMock.mock.calls[0]!;
+    expect(JSON.parse(String(upstreamInit?.body))).toMatchObject({
+      messages: [{ role: 'user', content: 'hello' }],
+      max_completion_tokens: 1234,
+      stream: true,
+    });
+    expect(JSON.parse(String(upstreamInit?.body))).not.toHaveProperty('max_tokens');
+  });
+
+  it('keeps max_tokens for legacy OpenAI-compatible chat-completions payloads', async () => {
+    const fetchMock = vi.fn((input: FetchInput, init?: FetchInit) => {
+      const url = String(input);
+      if (url.startsWith(baseUrl)) return realFetch(input, init);
+      return Promise.resolve(sseResponse('data: [DONE]\n\n'));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await realFetch(`${baseUrl}/api/proxy/openai/stream`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        baseUrl: 'https://api.openai.com/v1',
+        apiKey: 'sk-test',
+        model: 'gpt-4o',
+        maxTokens: 4321,
+        messages: [{ role: 'user', content: 'hello' }],
+      }),
+    });
+
+    const [, upstreamInit] = fetchMock.mock.calls[0]!;
+    expect(JSON.parse(String(upstreamInit?.body))).toMatchObject({
+      model: 'gpt-4o',
+      max_tokens: 4321,
+      stream: true,
+    });
+    expect(JSON.parse(String(upstreamInit?.body))).not.toHaveProperty(
+      'max_completion_tokens',
+    );
+  });
+
+  it('keeps max_tokens for DeepSeek-style OpenAI-compatible hosts', async () => {
+    const fetchMock = vi.fn((input: FetchInput, init?: FetchInit) => {
+      const url = String(input);
+      if (url.startsWith(baseUrl)) return realFetch(input, init);
+      return Promise.resolve(sseResponse('data: [DONE]\n\n'));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await realFetch(`${baseUrl}/api/proxy/openai/stream`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        baseUrl: 'https://api.deepseek.com',
+        apiKey: 'sk-test',
+        model: 'deepseek-chat',
+        maxTokens: 2222,
+        messages: [{ role: 'user', content: 'hello' }],
+      }),
+    });
+
+    const [upstreamUrl, upstreamInit] = fetchMock.mock.calls[0]!;
+    expect(String(upstreamUrl)).toBe('https://api.deepseek.com/v1/chat/completions');
+    expect(JSON.parse(String(upstreamInit?.body))).toMatchObject({
+      model: 'deepseek-chat',
+      max_tokens: 2222,
+      stream: true,
+    });
+    expect(JSON.parse(String(upstreamInit?.body))).not.toHaveProperty(
+      'max_completion_tokens',
+    );
+  });
+
+  it('keeps max_tokens for Azure gpt-4o deployment chat-completions payloads', async () => {
+    const fetchMock = vi.fn((input: FetchInput, init?: FetchInit) => {
+      const url = String(input);
+      if (url.startsWith(baseUrl)) return realFetch(input, init);
+      return Promise.resolve(sseResponse('data: [DONE]\n\n'));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await realFetch(`${baseUrl}/api/proxy/azure/stream`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        baseUrl: 'https://resource.openai.azure.com',
+        apiKey: 'azure-key',
+        model: 'gpt-4o',
+        apiVersion: '',
+        maxTokens: 3333,
+        messages: [{ role: 'user', content: 'hello' }],
+      }),
+    });
+
+    const [, upstreamInit] = fetchMock.mock.calls[0]!;
+    expect(JSON.parse(String(upstreamInit?.body))).toMatchObject({
+      messages: [{ role: 'user', content: 'hello' }],
+      max_tokens: 3333,
+      stream: true,
+    });
+    expect(JSON.parse(String(upstreamInit?.body))).not.toHaveProperty(
+      'max_completion_tokens',
+    );
+  });
+
   it.each([
     ['anthropic', 'https://api.anthropic.com/v1/messages'],
     ['openai', 'https://api.openai.com/v1/chat/completions'],


### PR DESCRIPTION
Fixes #361

## Why

Azure chat-completions requests can use arbitrary deployment aliases in both the default `/openai/deployments/<deployment>` path and Azure OpenAI-compatible `/openai/v1`, so deriving `max_tokens` vs `max_completion_tokens` from the configured `model` string is unreliable. A GPT-5/o-series deployment named `prod` needs to recover based on Azure actual unsupported-parameter response.

## What users will see

Azure BYOK chat and Settings connection tests first try the legacy `max_tokens` field, preserving older deployment compatibility. When Azure rejects `max_tokens` for GPT-5/o-series deployments, Open Design retries once with `max_completion_tokens`, including for `/openai/v1` deployment aliases. Settings connection-test latency reflects the final provider response after that retry, including failed retry responses.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/proxy-routes.test.ts` and `apps/daemon/tests/connection-test.test.ts`
- Red/green check: the Azure `/openai/v1` alias retry specs using `model: "prod"` went red before the fix and green after the retry fallback was applied.
- Latency follow-up: the Azure retry latency regression returned `25ms` before the fix and `100ms` after `latencyMs` was refreshed after the retry fetch.
- Failed-retry latency follow-up: the new Azure failed-retry regression covers a 25ms first response plus 75ms retry response that returns 500 and asserts the returned `latencyMs` is `100`.
- Rebase follow-up: rebased onto `origin/main` at `b8cddc42` and refreshed workspace links with `pnpm install --config.confirmModulesPurge=false`.
- Additional regressions keep generic OpenAI-compatible hosts like DeepSeek on `max_tokens`, keep Azure `gpt-4o` deployment paths on `max_tokens`, and keep deployment-mode aliases on the same unsupported-parameter retry fallback.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/connection-test.test.ts` (71 passed)
- `pnpm exec vitest run -c vitest.config.ts tests/proxy-routes.test.ts tests/connection-test.test.ts` (147 passed)
- `pnpm guard`
- `pnpm typecheck`
