### PR TITLE
Reject reserved project paths in artifact lint

### DIFF
--- a/apps/daemon/src/lint-artifact.ts
+++ b/apps/daemon/src/lint-artifact.ts
@@ -127,6 +127,17 @@ export function lintArtifact(rawHtml: unknown): LintFinding[] {
   const html = rawHtml.replace(/<!--[\s\S]*?-->/g, '');
   const lower = html.toLowerCase();
 
+  const reservedPath = detectReservedProjectPathReference(html);
+  if (reservedPath) {
+    out.push({
+      severity: 'P0',
+      id: 'reserved-project-path',
+      message: `Artifact references reserved internal project path "${reservedPath.segment}".`,
+      fix: 'Use a public preview/embed route instead of linking to internal project storage paths such as .live-artifacts, .od, or .tmp.',
+      snippet: clip(reservedPath.snippet),
+    });
+  }
+
   // ── P0-1: purple gradient backgrounds ─────────────────────────────
   for (const hex of PURPLE_HEXES) {
     const re = new RegExp(
@@ -544,6 +555,35 @@ function clip(s: string): string {
   if (!s) return '';
   const trimmed = s.replace(/\s+/g, ' ').trim();
   return trimmed.length > 200 ? trimmed.slice(0, 197) + '…' : trimmed;
+}
+
+const RESERVED_PROJECT_PATH_SEGMENTS = ['.live-artifacts', '.od', '.tmp'];
+
+function detectReservedProjectPathReference(html: string): { segment: string; snippet: string } | undefined {
+  const attrRe = /\b(?:src|href)\s*=\s*([\"'])(.*?)\1/gi;
+  let match: RegExpExecArray | null;
+  while ((match = attrRe.exec(html)) !== null) {
+    const value = match[2] || '';
+    for (const segment of RESERVED_PROJECT_PATH_SEGMENTS) {
+      if (referencesReservedProjectPath(value, segment)) {
+        return { segment, snippet: match[0] };
+      }
+    }
+  }
+  return undefined;
+}
+
+function referencesReservedProjectPath(value: string, segment: string): boolean {
+  const decoded = safeDecodeURIComponent(value);
+  return decoded === segment || decoded.startsWith(`${segment}/`) || decoded.includes(`/${segment}/`);
+}
+
+function safeDecodeURIComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
 }
 
 function escapeRe(s: string): string {

--- a/apps/daemon/tests/lint-artifact.test.ts
+++ b/apps/daemon/tests/lint-artifact.test.ts
@@ -8,6 +8,26 @@ function requiredFinding(findings: LintFinding[], id: string): LintFinding {
   return hit;
 }
 
+describe('reserved-project-path', () => {
+  it('flags artifacts that iframe live artifact storage directly', () => {
+    const html = `<iframe src=".live-artifacts/demo/index.html"></iframe>`;
+    const findings = lintArtifact(html);
+    const hit = requiredFinding(findings, 'reserved-project-path');
+    expect(hit.severity).toBe('P0');
+  });
+
+  it('flags other reserved internal project path references', () => {
+    const findings = lintArtifact(`<a href="assets/.tmp/render.html">Preview</a>`);
+    expect(findings.find((f) => f.id === 'reserved-project-path')).toBeDefined();
+  });
+
+  it('allows supported live artifact preview routes', () => {
+    const html = `<iframe src="/api/live-artifacts/demo/preview"></iframe>`;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'reserved-project-path')).toBeUndefined();
+  });
+});
+
 describe('ai-default-indigo', () => {
   it('flags solid #6366f1 used as accent', () => {
     const html = `


### PR DESCRIPTION
This adds artifact lint coverage for HTML that links directly into reserved project storage paths such as `.live-artifacts`, `.od`, or `.tmp`. Those references now produce a P0 finding before save/preview, while the supported `/api/live-artifacts/:id/preview` route remains allowed. Fixes #1665.

## Why
Orbit follow-up preview artifacts could save successfully while embedding `.live-artifacts/...`, then fail at preview time because that path is intentionally blocked by the project file layer.

## What users will see
Artifacts that reference internal storage paths are flagged with a clear lint finding instead of being accepted silently and failing later.

## Validation
- `npx tsc -p apps/daemon/tsconfig.tests.json --noEmit --pretty false` passed.
- `pnpm --filter @open-design/daemon test -- apps/daemon/tests/lint-artifact.test.ts` could not run because `vitest` was not installed in the checkout after dependency installation timed out in this environment.

## Surface area
- [x] Daemon / API
- [x] Tests
- [ ] Web UI
- [ ] Desktop
- [ ] CLI flags
- [ ] Environment variables
- [ ] i18n keys
- [ ] Root package dependencies