### PR TITLE
fix(packaged): forward proxy env to sidecars

### DIFF
--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -32,7 +32,18 @@ import type { PackagedWebOutputMode } from "./config.js";
 import type { PackagedNamespacePaths } from "./paths.js";
 
 const require = createRequire(import.meta.url);
-const PACKAGED_CHILD_ENV_ALLOWLIST = ["HOME", "LANG", "LC_ALL", "LOGNAME", "TMPDIR", "USER", "VP_HOME"] as const;
+const PACKAGED_CHILD_ENV_ALLOWLIST = [
+  "HOME",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "LANG",
+  "LC_ALL",
+  "LOGNAME",
+  "NO_PROXY",
+  "TMPDIR",
+  "USER",
+  "VP_HOME",
+] as const;
 
 function shouldForwardPackagedChildEnv(key: string, includeProviderSecrets = false): boolean {
   return (

--- a/apps/packaged/tests/sidecars.test.ts
+++ b/apps/packaged/tests/sidecars.test.ts
@@ -81,6 +81,24 @@ describe('packaged child Vite+ environment forwarding', () => {
     expect(env.RANDOM_INTERNAL_FLAG).toBeUndefined();
   });
 
+  it('forwards standard proxy variables to packaged sidecars', () => {
+    const env = resolvePackagedChildBaseEnv({
+      HOME: '/Users/tester',
+      HTTP_PROXY: 'http://127.0.0.1:7890',
+      HTTPS_PROXY: 'http://127.0.0.1:7890',
+      NO_PROXY: 'localhost,127.0.0.1',
+      RANDOM_INTERNAL_FLAG: 'drop-me',
+    });
+
+    expect(env).toMatchObject({
+      HOME: '/Users/tester',
+      HTTP_PROXY: 'http://127.0.0.1:7890',
+      HTTPS_PROXY: 'http://127.0.0.1:7890',
+      NO_PROXY: 'localhost,127.0.0.1',
+    });
+    expect(env.RANDOM_INTERNAL_FLAG).toBeUndefined();
+  });
+
   it('adds custom VP_HOME/bin to the packaged PATH builder', () => {
     const vpHome = mkdtempSync(join(tmpdir(), 'od-packaged-vp-home-'));
     const originalVpHome = process.env.VP_HOME;


### PR DESCRIPTION
Fixes #1663

## Why

Packaged desktop starts daemon sidecars with a filtered environment. That keeps unrelated host environment variables out of child processes, but it also dropped the standard `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` variables.

This means proxy settings that were already present before launch could not reach the packaged daemon sidecar.

## What users will see

When the packaged desktop app is launched with standard proxy environment variables present, the sidecars now receive `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`. There is no new UI.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — no UI changes.

## Bug fix verification

- Test path that reproduces the bug: `apps/packaged/tests/sidecars.test.ts`
- Did the test go red on `main` and green on this branch? yes — the new regression test failed before adding the allowlist entries and passes on this branch.

## Validation

- `pnpm --dir apps/packaged exec vitest run -c vitest.config.ts tests/sidecars.test.ts`
- `pnpm --filter @open-design/packaged typecheck`
- `pnpm guard`
