### PR TITLE
Limit DOM fallback comment targets

### DIFF
--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -724,10 +724,22 @@ function injectSelectionBridge(
     }
     return true;
   }
+  function meaningfulDomFallbackTarget(el){
+    if (!visibleTarget(el)) return false;
+    var tag = el.tagName ? el.tagName.toLowerCase() : '';
+    if (/^(a|button|input|textarea|select|label|img|video|canvas|svg|h1|h2|h3|h4|h5|h6|p|li|td|th)$/.test(tag)) return true;
+    if (el.getAttribute && (el.getAttribute('role') || el.getAttribute('aria-label') || el.getAttribute('title'))) return true;
+    var text = (el.textContent || '').replace(/\s+/g, ' ').trim();
+    if (!text) return false;
+    for (var child = el.firstElementChild; child; child = child.nextElementSibling) {
+      if ((child.textContent || '').replace(/\s+/g, ' ').trim()) return false;
+    }
+    return true;
+  }
   function targetFrom(el, allowDomFallback){
     var id = el.getAttribute('data-od-id') || el.getAttribute('data-screen-label');
     var selector = annotatedSelectorFor(el);
-    if (!id && allowDomFallback && visibleTarget(el)) {
+    if (!id && allowDomFallback && meaningfulDomFallbackTarget(el)) {
       selector = domSelectorFor(el);
       if (selector) id = 'dom:' + selector;
     }
@@ -797,7 +809,7 @@ function injectSelectionBridge(
     var allowDomFallback = mode === 'picker' && canUseDomFallback();
     while (el && el !== document.documentElement) {
       if (el.getAttribute && (el.hasAttribute('data-od-id') || el.hasAttribute('data-screen-label'))) return el;
-      if (!fallback && allowDomFallback && visibleTarget(el)) fallback = el;
+      if (!fallback && allowDomFallback && meaningfulDomFallbackTarget(el)) fallback = el;
       el = el.parentElement;
     }
     return fallback;


### PR DESCRIPTION
## Summary
Tightens the comment picker DOM fallback so previews without explicit anchors only target interactive, semantic, media, heading, list/table, ARIA-labelled, or text-leaf elements instead of any visible wrapper.

## Why
This came up while checking comment picker behavior on generated previews that do not include `data-od-id` or `data-screen-label` anchors. In that fallback path, the picker could attach comments to layout wrappers after viewport reflow, which makes anchors and labels confusing instead of pointing at the interface element the user clicked.

## What users will see
When using the comment picker on unannotated generated previews, clicks are less likely to select broad layout containers such as shells, grids, and cards. The picker will prefer visible UI/content elements, while empty or structural surfaces can still fall through to the existing free-pin behavior.

## Surface area
- [x] Web app / UI runtime
- [ ] Daemon / API
- [ ] Desktop / packaged runtime
- [ ] CLI flags or environment variables
- [ ] Skills / design systems / design templates / craft
- [ ] Documentation

## Validation
- `git diff --check`
- `pnpm --filter @open-design/web typecheck` could not run locally because this checkout has no `node_modules` installed; pnpm reported `tsc: not found`.

Closes #1692
