### PR TITLE
fix: Restore dropdown chevron in page-size selector for dark mode

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -8331,7 +8331,7 @@ button.connector-action.is-loading {
   padding: 2px 6px;
   border: 1px solid var(--border);
   border-radius: 4px;
-  background: var(--bg);
+  background-color: var(--bg);
   color: var(--text);
   cursor: pointer;
 }


### PR DESCRIPTION
## Summary

Fixes the page-size selector rendering issue in dark mode where the dropdown chevron icon was missing.

## Why

The `.df-pagination select` CSS rule was using `background: var(--bg)` which is a shorthand property that resets all background-related properties, including `background-image`. This caused the dropdown chevron icon (defined in the global `select` styles) to disappear in dark mode.

## What users will see

- ✅ Dropdown chevron icon now visible in dark mode
- ✅ Proper contrast and readability
- ✅ Consistent styling with other select elements

## Surface area

- **Changed**: `apps/web/src/index.css` - `.df-pagination select` background property
- **Impact**: All pagination controls with page-size selectors

## Validation

1. Enable dark mode
2. Open any file list view with pagination controls
3. Verify the page-size selector (e.g., "30" dropdown) displays the chevron icon
4. Verify the icon has proper contrast against the dark background
5. Test both explicit `[data-theme="dark"]` and system `prefers-color-scheme: dark`

## Technical details

Changed from:
```css
background: var(--bg);
```

To:
```css
background-color: var(--bg);
```

This preserves the global `select` background-image (chevron icon) while still setting the background color.

Fixes #1697