### PR TITLE
[codex] Add release-preview workflow placeholder

### DIFF
--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -1,0 +1,21 @@
+name: release-preview
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: open-design-release-preview
+  cancel-in-progress: false
+
+jobs:
+  placeholder:
+    name: Preview release placeholder
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain placeholder
+        run: |
+          echo "release-preview is reserved for the preview release channel."
+          echo "The full build and publish implementation will land in a follow-up change."


### PR DESCRIPTION
## Why

This splits the first `release-preview` workflow entrypoint into a tiny PR before the full preview release implementation. The follow-up work can build on a stable workflow path without mixing release-channel behavior changes into this placeholder.

## What users will see

No app-facing behavior changes. Maintainers will see a manual `release-preview` workflow in GitHub Actions; it currently runs only a placeholder job and does not publish artifacts.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A

## Bug fix verification

N/A

## Validation

- `pnpm guard`
- `pnpm typecheck`
