### PR TITLE
fix(runtime): improve DOM fallback target selection for comment picker

### DIFF
--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -724,10 +724,54 @@ function injectSelectionBridge(
     }
     return true;
   }
+function meaningfulDomFallbackTarget(el) {
+  if (!visibleTarget(el)) return false;
+
+  var tag = el.tagName ? el.tagName.toLowerCase() : '';
+
+  if (/^(a|button|input|textarea|select|label|img|video|canvas|h1|h2|h3|h4|h5|h6|p|li|td|th|section|article|main|aside|nav)$/.test(tag)) {
+    return true;
+  }
+
+  if (
+    el.getAttribute &&
+    (
+      el.getAttribute('role') ||
+      el.getAttribute('aria-label') ||
+      el.getAttribute('title')
+    )
+  ) {
+    return true;
+  }
+
+  if (tag === 'svg') {
+    return !!(
+      el.getAttribute &&
+      (
+        el.getAttribute('role') ||
+        el.getAttribute('aria-label') ||
+        el.getAttribute('title')
+      )
+    );
+  }
+
+  var text = (el.textContent || '').replace(/\s+/g, ' ').trim();
+  if (!text) return false;
+
+  var meaningfulChildren = 0;
+  for (var child = el.firstElementChild;child;child = child.nextElementSibling) {
+    if ((child.textContent || '').replace(/\s+/g, ' ').trim()) {
+      meaningfulChildren++;
+      if (meaningfulChildren > 1) return false;
+    }
+  }
+
+  return true;
+}
   function targetFrom(el, allowDomFallback){
     var id = el.getAttribute('data-od-id') || el.getAttribute('data-screen-label');
     var selector = annotatedSelectorFor(el);
-    if (!id && allowDomFallback && visibleTarget(el)) {
+    if (!id && allowDomFallback && meaningfulDomFallbackTarget(el)) {
       selector = domSelectorFor(el);
       if (selector) id = 'dom:' + selector;
     }
@@ -797,7 +841,7 @@ function injectSelectionBridge(
     var allowDomFallback = mode === 'picker' && canUseDomFallback();
     while (el && el !== document.documentElement) {
       if (el.getAttribute && (el.hasAttribute('data-od-id') || el.hasAttribute('data-screen-label'))) return el;
-      if (!fallback && allowDomFallback && visibleTarget(el)) fallback = el;
+if (!fallback && allowDomFallback && meaningfulDomFallbackTarget(el)) fallback = el;
       el = el.parentElement;
     }
     return fallback;


### PR DESCRIPTION
Fixes #1692 

## Why

Generated preview artifacts without `data-od-id` or `data-screen-label` annotations fall back to DOM-based comment targeting. In fallback mode, the picker currently treats any visible DOM node as a valid target, which can cause comments to attach to structural layout wrappers such as containers, grids, or page shells instead of meaningful UI elements.

This becomes easier to reproduce in narrower viewports where layout containers occupy a larger portion of the visible interaction area.

This PR improves fallback target heuristics to prefer meaningful UI/content elements while still preserving semantic container selection behavior for unannotated pages.

## What users will see

When using the comment picker on generated previews without explicit annotation anchors, comments are more consistently attached to meaningful interface elements instead of generic layout wrappers.

Semantic containers such as sections/cards remain targetable, while broad structural wrappers are less likely to be selected accidentally.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency**
- [x] **Default behavior change** — changes fallback comment target selection behavior for unannotated preview artifacts
- [ ] **None**

## Screenshots

N/A

## Bug fix verification

- Test path that reproduces the bug:
  - `apps/web/tests/runtime/srcdoc-bridge-empty-targets.test.ts`
- Did the test go red on `main` and green on this branch?
  - yes

## Validation

- `pnpm typecheck`
- `pnpm --filter @open-design/web test`