### PR TITLE
chore: add issue templates (bug, feature, preview/0.8.0) + chooser config

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,82 @@
+name: 🐛 Bug report
+description: Something isn't working as expected in Open Design.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! A clear, reproducible report helps us fix it faster.
+
+        Before you submit:
+        - Check whether the issue is already reported in [open issues](https://github.com/nexu-io/open-design/issues?q=is%3Aissue).
+        - If your report is about the `preview/0.8.0` feature branch (Skills tab / Automations), please use the **🧪 Preview 0.8.0 feedback** template instead.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear and concise description of the bug.
+      placeholder: When I do X, I expected Y but I see Z.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps that reliably reproduce the problem.
+      placeholder: |
+        1. Open Open Design
+        2. Click ...
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Open Design version
+      description: Find this in the app's About menu, or run `od --version`.
+      placeholder: e.g. 0.7.0
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - macOS (Apple Silicon)
+        - macOS (Intel)
+        - Windows
+        - Linux
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots (optional)
+      description: |
+        If relevant, paste any error output, console logs, or screenshots.
+        For daemon logs, run `pnpm tools-dev logs --json`.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else that might help us understand the issue (plugins installed, design systems in use, related issues, etc.).
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,17 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🧪 Preview 0.8.0 feedback
+    url: https://github.com/nexu-io/open-design/issues/new?template=preview-0.8.0-feedback.yml
+    about: Reporting something specific about the preview/0.8.0 feature branch (Skills, Automations, plugin model). Auto-tagged for the team.
+  - name: 💬 Ask a question
+    url: https://github.com/nexu-io/open-design/discussions/categories/q-a
+    about: How do I use X? Why does Y behave like that? — Q&A on Discussions gets faster answers and stays searchable for others.
+  - name: 💡 Discuss an idea
+    url: https://github.com/nexu-io/open-design/discussions/categories/ideas
+    about: Have a half-formed idea you want to chew on before opening a formal feature request? Start a thread in Ideas.
+  - name: 🙌 Show what you've made
+    url: https://github.com/nexu-io/open-design/discussions/categories/show-and-tell
+    about: Built something cool with Open Design? Share it in Show and tell.
+  - name: 🗣 General discussion
+    url: https://github.com/nexu-io/open-design/discussions/categories/general
+    about: Anything else — chat, suggestions, community talk.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,58 @@
+name: 💡 Feature request
+description: Suggest a new feature or improvement for Open Design.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing your idea!
+
+        Before you submit:
+        - Check whether the same idea is already discussed in [open issues](https://github.com/nexu-io/open-design/issues?q=is%3Aissue+label%3Aenhancement) or [Discussions → Ideas](https://github.com/nexu-io/open-design/discussions/categories/ideas).
+        - If you're still exploring an idea and want a conversation first, prefer [Discussions → Ideas](https://github.com/nexu-io/open-design/discussions/new?category=ideas).
+        - If your suggestion relates to the `preview/0.8.0` feature branch, please use the **🧪 Preview 0.8.0 feedback** template instead.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the pain or limitation, not the solution. Why does today's behavior fall short?
+      placeholder: When I try to do X, the current flow forces me to ... which makes it hard to ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you'd like
+      description: What's your proposed behavior, UI, or capability?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you've considered
+      description: Other ways you've thought about solving this, and why they fall short.
+      placeholder: I also considered ... but it doesn't work because ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, links to related issues, prior art in other tools, anything that helps.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: contribution
+    attributes:
+      label: Would you be willing to contribute a PR?
+      options:
+        - "Yes, I can take this on"
+        - "Yes, with guidance from a maintainer"
+        - "No, just suggesting"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/preview-0.8.0-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/preview-0.8.0-feedback.yml
@@ -1,0 +1,85 @@
+name: 🧪 Preview 0.8.0 feedback
+description: Report a bug, suggest an improvement, or share feedback about the preview/0.8.0 branch (Skills + Automations).
+labels: ["preview/0.8.0"]
+title: "[preview/0.8.0] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for trying `preview/0.8.0`! This template is for feedback about the **Skills tab in `/integrations`** and the **Automations cards** that are being previewed before they land in `main`.
+
+        For general bugs unrelated to the preview, please open a regular issue instead.
+
+  - type: dropdown
+    id: feature
+    attributes:
+      label: Which feature does this relate to?
+      options:
+        - Skills tab (/integrations)
+        - Automations cards (Routines / Schedules / Live artifacts)
+        - Both / general preview build
+        - Other / not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type of feedback
+      options:
+        - Bug / broken behavior
+        - UX or design concern
+        - Suggestion / feature request
+        - Question
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened, or what would you like to see?
+      description: For bugs, include steps to reproduce. For suggestions, describe the use case.
+      placeholder: |
+        1. Open /integrations
+        2. Click the Skills tab
+        3. Expected X, saw Y
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior (skip if not a bug)
+      placeholder: What did you expect to happen?
+    validations:
+      required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: Build / version
+      description: From the app's About menu, or run `git rev-parse HEAD` if you built from source.
+      placeholder: e.g. 0.8.0-preview.1 — or commit hash 640a3322
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - macOS (Apple Silicon)
+        - macOS (Intel)
+        - Windows
+        - Linux
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Plugins installed, design systems in use, anything else relevant.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

Sets up the first issue-template scaffolding for the repo. Until now, **New Issue** opened a blank textarea — no guidance, no auto-labeling, nowhere to route question-type traffic.

This PR adds:

- **🐛 Bug report** (`bug-report.yml`) — generic template for any bug. Auto-applies the `bug` label.
- **💡 Feature request** (`feature-request.yml`) — problem-first framing, alternatives field, willing-to-contribute dropdown. Auto-applies the `enhancement` label.
- **🧪 Preview 0.8.0 feedback** (`preview-0.8.0-feedback.yml`) — targeted template for the [`preview/0.8.0`](https://github.com/nexu-io/open-design/tree/preview/0.8.0) community feature branch. Auto-applies the `preview/0.8.0` label, pre-fills the title prefix.
- **Chooser config** (`config.yml`) — disables blank issues, redirects Q&A / Ideas / Show-and-tell / general chat to the appropriate Discussions category.

## After merge: what the chooser will look like

Visiting [/issues/new/choose](https://github.com/nexu-io/open-design/issues/new/choose) will show:

**Templates**
- 🐛 Bug report
- 💡 Feature request
- 🧪 Preview 0.8.0 feedback

**Contact links** (above/below the templates per GitHub's renderer)
- 🧪 Preview 0.8.0 feedback (quick re-entry)
- 💬 Ask a question → Discussions Q&A
- 💡 Discuss an idea → Discussions Ideas
- 🙌 Show what you've made → Discussions Show and tell
- 🗣 General discussion → Discussions General

## Why

1. **Preview 0.8.0 launch is imminent.** We need a single filterable view of all preview-related reports — see [open issues tagged preview/0.8.0](https://github.com/nexu-io/open-design/issues?q=is%3Aopen+label%3A%22preview%2F0.8.0%22). A template ensures the label is applied consistently without relying on testers to remember.
2. **The repo has been growing fast** and we have zero structured intake. Reporters write whatever — sometimes 3-line "it broke" issues, sometimes 5-screen rants. Bug + feature templates give a consistent shape.
3. **Discussions are underused** because there's no obvious path from "New Issue" to "actually you want Discussions." `config.yml` adds explicit routing.

## Test plan

- [ ] After merge, open https://github.com/nexu-io/open-design/issues/new/choose
- [ ] Confirm all 3 templates appear
- [ ] Confirm 5 contact links appear (Preview feedback + 4 Discussions categories)
- [ ] Confirm "Open a blank issue" entry is gone
- [ ] Open a test issue via each template, confirm labels auto-apply
- [ ] Confirm Discussions links land on the right categories