### PR TITLE
fix(web): stop conversation route sync from remounting ChatPane in a loop

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -400,6 +400,10 @@ export function ProjectView({
   // correctly gate new-conversation creation even during async loads.
   const messagesConversationIdRef = useRef<string | null>(null);
   const creatingConversationRef = useRef(false);
+  // Last conversation id this view pushed into the URL. Lets the
+  // route -> active-conversation sync tell a genuine external navigation
+  // apart from the URL merely lagging a local conversation switch.
+  const lastSyncedConversationIdRef = useRef<string | null>(null);
   // Live mirror of the currently-viewed project id. Used to bail out of
   // the conversation-created async refresh (#1361) if the user switches
   // projects while the refetch is in flight — the existing project-load
@@ -513,6 +517,13 @@ export function ProjectView({
     if (!routeConversationId) return;
     if (conversations.length === 0) return;
     if (routeConversationId === activeConversationId) return;
+    // When the route still points at the conversation this view last
+    // pushed to the URL, the mismatch means a local switch (new
+    // conversation, history pick) moved activeConversationId ahead and
+    // the URL sync below has not caught up yet. Following the stale
+    // route here would fight that sync and remount ChatPane in a loop,
+    // so only react to a genuinely external navigation.
+    if (routeConversationId === lastSyncedConversationIdRef.current) return;
     const match = conversations.find((c) => c.id === routeConversationId);
     if (match) setActiveConversationId(match.id);
   }, [routeConversationId, conversations, activeConversationId]);
@@ -859,6 +870,7 @@ export function ProjectView({
     const nextKey = `${activeConversationId ?? ''}:${target ?? ''}`;
     if (nextKey === lastSyncedRouteKeyRef.current) return;
     lastSyncedRouteKeyRef.current = nextKey;
+    lastSyncedConversationIdRef.current = activeConversationId;
     // PerishCode + Codex P1 on PR #1508: the prior version of this
     // sync stripped any `/conversations/:cid` segment from the URL as
     // soon as a tab became active, which regressed the deep-link


### PR DESCRIPTION
## Why

`main` CI's `Playwright extended` job is red: every conversation case in `e2e/ui/app-restoration.test.ts` (13 tests) fails because the chat composer detaches from the DOM in a loop after a new conversation is created.
I was investigating why `main` was red and traced it to PR #1508.
PR #1508 ("deep-link Routines history rows to their specific conversation") added a `routeConversationId -> activeConversationId` sync effect next to the existing `activeConversationId -> URL` sync, with no arbitration between the two. Creating or switching a conversation moves `activeConversationId` ahead of the URL; the route-sync effect then sees the now-stale `routeConversationId` and pulls `activeConversationId` back, while the URL sync pushes it forward again. `ChatPane` is keyed on `activeConversationId`, so each flip remounts `ChatPane` and its composer — the composer never settles and is unusable.

## What users will see

Creating a new conversation, switching conversations from history, or deleting the active conversation no longer makes the chat composer flicker / become uninteractable. The deep-link behaviour PR #1508 added (a routine history row opening its specific conversation) still works — the route-sync effect now only reacts to genuinely external navigation, not to the URL momentarily lagging a local conversation switch.

## Surface area

- [x] **None** — internal logic fix (regression fix in `ProjectView`), no new surface

## Bug fix verification

- **Red spec:** `e2e/ui/app-restoration.test.ts` — conversation cases at `:433`, `:511`, `:619`, `:703`, `:816`, `:903`, `:980`, `:1064`, `:1167`, `:1251`, `:1353`, `:1461`, `:1561`. The spec already exists in-tree (added by PR #1341); PR #1508 turned it red, so no new test was written.
- **Red on `main`:** yes — CI's `Playwright extended` step fails all 13 (e.g. https://github.com/nexu-io/open-design/actions/runs/25853917951); reproduces locally on `main` (all 13 timeout).
- **Green on this branch:** yes — all 13 pass locally.

## Validation

- `pnpm --filter @open-design/web typecheck` — pass
- `pnpm guard` — pass
- `cd e2e && pnpm exec playwright test -c playwright.config.ts ui/app-restoration.test.ts` — 21/22 pass (see baseline diff)
- `cd e2e && pnpm exec playwright test -c playwright.config.ts ui/project-management-flows.test.ts` — 9/9 pass (no regression in broader `ProjectView` usage)
