### PR TITLE
skills: add superpowers workflow governance stubs + AGENTS.md integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,25 @@ The following is a working playbook for routine bug follow-ups, distilled from r
 
 For a worked example of one full loop (red e2e spec → fix → green), see `e2e/tests/dialog/stop-reconciles-message.test.ts` (issue #135).
 
+
+## Superpowers workflow skills
+
+The [superpowers plugin](https://github.com/obra/superpowers) is catalogued under `skills/` and available to any agent running in this repo. These skills govern the development workflow — invoke them at the right moment rather than proceeding by instinct:
+
+| When | Invoke |
+|---|---|
+| Before any new feature, component, or behaviour change | `brainstorming` |
+| Before touching code on a multi-step task | `writing-plans` |
+| Before writing any implementation code | `test-driven-development` |
+| When facing 2+ independent tasks that can run in parallel | `dispatching-parallel-agents` |
+| When encountering any bug, failure, or unexpected behaviour | `systematic-debugging` |
+| Before requesting review or opening a PR | `requesting-code-review` |
+| Before applying incoming code review suggestions | `receiving-code-review` |
+| Before claiming any work is complete or committing | `verification-before-completion` |
+| When implementation is done and tests pass | `finishing-a-development-branch` |
+
+Install the full upstream bundle into your agent's skills directory (`~/.claude/skills/superpowers` for Claude Code, or the equivalent path for your runtime) to run these with their original assets and references. Each `skills/<name>/SKILL.md` in this repo is a catalogue stub — it advertises the skill in the OD picker and tells the agent it exists, but the operative workflow lives upstream at [github.com/obra/superpowers](https://github.com/obra/superpowers).
+
 # Common commands
 
 ```bash

--- a/skills/dispatching-parallel-agents/SKILL.md
+++ b/skills/dispatching-parallel-agents/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: dispatching-parallel-agents
+description: |
+  Coordinate two or more independent tasks that can run in parallel without shared state or sequential dependencies.
+triggers:
+  - "parallel tasks"
+  - "run in parallel"
+  - "independent subtasks"
+  - "dispatch agents"
+  - "concurrent work"
+od:
+  mode: utility
+  category: development-workflow
+  upstream: "https://github.com/obra/superpowers"
+---
+
+# dispatching-parallel-agents
+
+> Curated from @obra.
+
+## What it does
+
+Identifies which subtasks in a larger job are truly independent, structures them for parallel dispatch, and coordinates the results back into a unified output.
+
+## Source
+
+- Upstream: https://github.com/obra/superpowers
+- Category: `development-workflow`
+
+## How to use
+
+Install the upstream bundle into your active agent's skills directory, then invoke by name (`dispatching-parallel-agents`) or with one of the trigger phrases above.
+
+```bash
+open https://github.com/obra/superpowers
+```

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: executing-plans
+description: |
+  Execute a written implementation plan in a separate session with review checkpoints between each step.
+triggers:
+  - "execute plan"
+  - "run the plan"
+  - "implement from spec"
+  - "step through plan"
+  - "plan execution"
+od:
+  mode: utility
+  category: development-workflow
+  upstream: "https://github.com/obra/superpowers"
+---
+
+# executing-plans
+
+> Curated from @obra.
+
+## What it does
+
+Takes a written plan and executes it step-by-step with explicit review checkpoints, ensuring each stage is verified before the next one starts.
+
+## Source
+
+- Upstream: https://github.com/obra/superpowers
+- Category: `development-workflow`
+
+## How to use
+
+Install the upstream bundle into your active agent's skills directory, then invoke by name (`executing-plans`) or with one of the trigger phrases above.
+
+```bash
+open https://github.com/obra/superpowers
+```

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: finishing-a-development-branch
+description: |
+  Structured guidance for completing a development branch once implementation is done and tests pass — merge, PR, or cleanup decision.
+triggers:
+  - "finish branch"
+  - "ready to merge"
+  - "wrap up feature"
+  - "branch completion"
+  - "implementation complete"
+od:
+  mode: utility
+  category: development-workflow
+  upstream: "https://github.com/obra/superpowers"
+---
+
+# finishing-a-development-branch
+
+> Curated from @obra.
+
+## What it does
+
+Presents structured options for integrating completed work: direct merge, PR, cleanup, or archival. Guides the decision based on branch state, test results, and target branch policy.
+
+## Source
+
+- Upstream: https://github.com/obra/superpowers
+- Category: `development-workflow`
+
+## How to use
+
+Install the upstream bundle into your active agent's skills directory, then invoke by name (`finishing-a-development-branch`) or with one of the trigger phrases above.
+
+```bash
+open https://github.com/obra/superpowers
+```

--- a/skills/receiving-code-review/SKILL.md
+++ b/skills/receiving-code-review/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: receiving-code-review
+description: |
+  Evaluate incoming code review feedback critically and technically before implementing suggestions — prevents blind or performative agreement.
+triggers:
+  - "receiving review"
+  - "applying feedback"
+  - "review feedback"
+  - "code review response"
+  - "before applying suggestions"
+od:
+  mode: utility
+  category: development-workflow
+  upstream: "https://github.com/obra/superpowers"
+---
+
+# receiving-code-review
+
+> Curated from @obra.
+
+## What it does
+
+Requires technical verification of review suggestions before applying them. Guards against implementing technically questionable feedback without independent verification.
+
+## Source
+
+- Upstream: https://github.com/obra/superpowers
+- Category: `development-workflow`
+
+## How to use
+
+Install the upstream bundle into your active agent's skills directory, then invoke by name (`receiving-code-review`) or with one of the trigger phrases above.
+
+```bash
+open https://github.com/obra/superpowers
+```

--- a/skills/requesting-code-review/SKILL.md
+++ b/skills/requesting-code-review/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: requesting-code-review
+description: |
+  Self-review checklist to run before requesting a human code review or merging a feature branch.
+triggers:
+  - "request review"
+  - "pre-review checklist"
+  - "ready for review"
+  - "self review"
+  - "before PR review"
+od:
+  mode: utility
+  category: development-workflow
+  upstream: "https://github.com/obra/superpowers"
+---
+
+# requesting-code-review
+
+> Curated from @obra.
+
+## What it does
+
+Runs a structured self-review — correctness, test coverage, boundary violations, docs — before marking work ready for human review or merging.
+
+## Source
+
+- Upstream: https://github.com/obra/superpowers
+- Category: `development-workflow`
+
+## How to use
+
+Install the upstream bundle into your active agent's skills directory, then invoke by name (`requesting-code-review`) or with one of the trigger phrases above.
+
+```bash
+open https://github.com/obra/superpowers
+```

--- a/skills/subagent-driven-development/SKILL.md
+++ b/skills/subagent-driven-development/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: subagent-driven-development
+description: |
+  Execute an implementation plan by dispatching independent tasks to subagents within the current session.
+triggers:
+  - "subagent development"
+  - "delegate to subagents"
+  - "parallel implementation"
+  - "agent-driven build"
+od:
+  mode: utility
+  category: development-workflow
+  upstream: "https://github.com/obra/superpowers"
+---
+
+# subagent-driven-development
+
+> Curated from @obra.
+
+## What it does
+
+Takes an implementation plan whose tasks are independent and dispatches each to a subagent, collecting results and synthesising them back into a coherent whole.
+
+## Source
+
+- Upstream: https://github.com/obra/superpowers
+- Category: `development-workflow`
+
+## How to use
+
+Install the upstream bundle into your active agent's skills directory, then invoke by name (`subagent-driven-development`) or with one of the trigger phrases above.
+
+```bash
+open https://github.com/obra/superpowers
+```

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: systematic-debugging
+description: |
+  Structured debugging workflow to follow when encountering any bug, test failure, or unexpected behaviour — before proposing any fix.
+triggers:
+  - "debug this"
+  - "systematic debug"
+  - "unexpected behaviour"
+  - "test failing"
+  - "bug investigation"
+od:
+  mode: utility
+  category: development-workflow
+  upstream: "https://github.com/obra/superpowers"
+---
+
+# systematic-debugging
+
+> Curated from @obra.
+
+## What it does
+
+A structured debugging sequence: isolate, reproduce, hypothesise, verify — in that order. Prevents jumping to a fix before the root cause is understood.
+
+## Source
+
+- Upstream: https://github.com/obra/superpowers
+- Category: `development-workflow`
+
+## How to use
+
+Install the upstream bundle into your active agent's skills directory, then invoke by name (`systematic-debugging`) or with one of the trigger phrases above.
+
+```bash
+open https://github.com/obra/superpowers
+```

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: test-driven-development
+description: |
+  Write tests before implementation code on any feature or bugfix. Establishes a failing spec that defines the target behaviour before a single source line changes.
+triggers:
+  - "TDD"
+  - "test first"
+  - "write tests before"
+  - "red-green-refactor"
+  - "failing spec first"
+od:
+  mode: utility
+  category: development-workflow
+  upstream: "https://github.com/obra/superpowers"
+---
+
+# test-driven-development
+
+> Curated from @obra.
+
+## What it does
+
+Enforce a test-first workflow on every feature or bugfix. The skill guides writing a failing spec that precisely describes the target behaviour, then implementing only enough code to make it pass.
+
+## Source
+
+- Upstream: https://github.com/obra/superpowers
+- Category: `development-workflow`
+
+## How to use
+
+Install the upstream bundle into your active agent's skills directory, then invoke by name (`test-driven-development`) or with one of the trigger phrases above.
+
+```bash
+open https://github.com/obra/superpowers
+```

--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: using-git-worktrees
+description: |
+  Set up an isolated git worktree before starting feature work that must not disturb the current workspace.
+triggers:
+  - "git worktree"
+  - "isolate feature work"
+  - "separate workspace"
+  - "worktree isolation"
+od:
+  mode: utility
+  category: development-workflow
+  upstream: "https://github.com/obra/superpowers"
+---
+
+# using-git-worktrees
+
+> Curated from @obra.
+
+## What it does
+
+Creates and configures a git worktree so feature work runs in full isolation — no stash, no branch-switching, no risk of cross-contaminating the main workspace.
+
+## Source
+
+- Upstream: https://github.com/obra/superpowers
+- Category: `development-workflow`
+
+## How to use
+
+Install the upstream bundle into your active agent's skills directory, then invoke by name (`using-git-worktrees`) or with one of the trigger phrases above.
+
+```bash
+open https://github.com/obra/superpowers
+```

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: verification-before-completion
+description: |
+  Run evidence-gathering checks before claiming any work is complete, fixed, or passing — before committing or opening a PR.
+triggers:
+  - "verify before done"
+  - "check before committing"
+  - "evidence before assertions"
+  - "confirm it works"
+  - "pre-commit verification"
+od:
+  mode: utility
+  category: development-workflow
+  upstream: "https://github.com/obra/superpowers"
+---
+
+# verification-before-completion
+
+> Curated from @obra.
+
+## What it does
+
+Prevents false completion claims by running a structured verification checklist — build, typecheck, tests, and behaviour checks — before any work is declared done or committed.
+
+## Source
+
+- Upstream: https://github.com/obra/superpowers
+- Category: `development-workflow`
+
+## How to use
+
+Install the upstream bundle into your active agent's skills directory, then invoke by name (`verification-before-completion`) or with one of the trigger phrases above.
+
+```bash
+open https://github.com/obra/superpowers
+```

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: writing-plans
+description: |
+  Write a structured implementation plan before touching code on any multi-step task. Surfaces assumptions, identifies critical files, and considers architectural trade-offs before a line is changed.
+triggers:
+  - "write a plan"
+  - "plan before coding"
+  - "implementation plan"
+  - "spec to plan"
+  - "planning phase"
+od:
+  mode: utility
+  category: development-workflow
+  upstream: "https://github.com/obra/superpowers"
+---
+
+# writing-plans
+
+> Curated from @obra.
+
+## What it does
+
+Write a structured implementation plan before touching code on any multi-step task. Use when you have a spec or requirements and need a step-by-step plan, file identification, and architectural trade-off analysis before execution.
+
+## Source
+
+- Upstream: https://github.com/obra/superpowers
+- Category: `development-workflow`
+
+## How to use
+
+Install the upstream bundle into your active agent's skills directory, then invoke by name (`writing-plans`) or with one of the trigger phrases above.
+
+```bash
+open https://github.com/obra/superpowers
+```


### PR DESCRIPTION
## Why

While building on top of OD and using the [superpowers plugin](https://github.com/obra/superpowers) alongside it, I noticed that only `brainstorming` was already catalogued as a skill stub. The remaining workflow-governance skills from superpowers -- the ones that gate *when* to plan, test, debug, verify, and finish branches -- were not surfaced in the skills picker, and `AGENTS.md` had no pointer to them.

The pain: contributors and agents working in this repo have access to the full superpowers governance workflow, but the repo's own agent guidance did not say when to invoke those skills during development work.

## What users will see

The Settings → Skills tab will gain 11 new entries under a `development-workflow` category, all from the superpowers upstream:

- `writing-plans`
- `test-driven-development`
- `systematic-debugging`
- `verification-before-completion`
- `finishing-a-development-branch`
- `dispatching-parallel-agents`
- `using-git-worktrees`
- `requesting-code-review`
- `receiving-code-review`
- `subagent-driven-development`
- `executing-plans`

Each is a lightweight catalogue stub pointing to [github.com/obra/superpowers](https://github.com/obra/superpowers), consistent with how the existing `brainstorming` stub works.

`AGENTS.md` gains a `## Superpowers workflow skills` section (after `## Bug follow-up workflow`) with a trigger table that tells agents exactly when to invoke each skill during development.

## Surface area

- [x] **Extension point** — new entries under `skills/`
- [x] **None** (for AGENTS.md) — docs update only

## Screenshots

No UI changes beyond new entries in the Skills picker.

## Bug fix verification

Not a bug fix.

## Validation

Stubs follow the same structure as the existing `brainstorming` catalogue entry. No build, typecheck, or test changes required for SKILL.md stub additions.

`pnpm guard` and `pnpm typecheck` are unaffected by SKILL.md additions (no TypeScript changes).