### PR TITLE
chore: align issue templates to preview/v0.8.0 naming

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -9,7 +9,7 @@ body:
 
         Before you submit:
         - Check whether the issue is already reported in [open issues](https://github.com/nexu-io/open-design/issues?q=is%3Aissue).
-        - If your report is about the `preview/0.8.0` feature branch (Skills tab / Automations), please use the **🧪 Preview 0.8.0 feedback** template instead.
+        - If your report is about the `preview/v0.8.0` feature branch (Skills tab / Automations), please use the **🧪 Preview v0.8.0 feedback** template instead.
 
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
-  - name: 🧪 Preview 0.8.0 feedback
-    url: https://github.com/nexu-io/open-design/issues/new?template=preview-0.8.0-feedback.yml
-    about: Reporting something specific about the preview/0.8.0 feature branch (Skills, Automations, plugin model). Auto-tagged for the team.
+  - name: 🧪 Preview v0.8.0 feedback
+    url: https://github.com/nexu-io/open-design/issues/new?template=preview-v0.8.0-feedback.yml
+    about: Reporting something specific about the preview/v0.8.0 feature branch (Skills, Automations, plugin model). Auto-tagged for the team.
   - name: 💬 Ask a question
     url: https://github.com/nexu-io/open-design/discussions/categories/q-a
     about: How do I use X? Why does Y behave like that? — Q&A on Discussions gets faster answers and stays searchable for others.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -10,7 +10,7 @@ body:
         Before you submit:
         - Check whether the same idea is already discussed in [open issues](https://github.com/nexu-io/open-design/issues?q=is%3Aissue+label%3Aenhancement) or [Discussions → Ideas](https://github.com/nexu-io/open-design/discussions/categories/ideas).
         - If you're still exploring an idea and want a conversation first, prefer [Discussions → Ideas](https://github.com/nexu-io/open-design/discussions/new?category=ideas).
-        - If your suggestion relates to the `preview/0.8.0` feature branch, please use the **🧪 Preview 0.8.0 feedback** template instead.
+        - If your suggestion relates to the `preview/v0.8.0` feature branch, please use the **🧪 Preview v0.8.0 feedback** template instead.
 
   - type: textarea
     id: problem

--- a/.github/ISSUE_TEMPLATE/preview-v0.8.0-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/preview-v0.8.0-feedback.yml
@@ -1,12 +1,12 @@
-name: 🧪 Preview 0.8.0 feedback
-description: Report a bug, suggest an improvement, or share feedback about the preview/0.8.0 branch (Skills + Automations).
-labels: ["preview/0.8.0"]
-title: "[preview/0.8.0] "
+name: 🧪 Preview v0.8.0 feedback
+description: Report a bug, suggest an improvement, or share feedback about the preview/v0.8.0 branch (Skills + Automations).
+labels: ["preview/v0.8.0"]
+title: "[preview/v0.8.0] "
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for trying `preview/0.8.0`! This template is for feedback about the **Skills tab in `/integrations`** and the **Automations cards** that are being previewed before they land in `main`.
+        Thanks for trying `preview/v0.8.0`! This template is for feedback about the **Skills tab in `/integrations`** and the **Automations cards** that are being previewed before they land in `main`.
 
         For general bugs unrelated to the preview, please open a regular issue instead.
 
@@ -59,7 +59,7 @@ body:
     attributes:
       label: Build / version
       description: From the app's About menu, or run `git rev-parse HEAD` if you built from source.
-      placeholder: e.g. 0.8.0-preview.1 — or commit hash 640a3322
+      placeholder: e.g. 0.8.0-preview.2
     validations:
       required: true
 


### PR DESCRIPTION
## Summary

The community preview feature branch was renamed from `preview/0.8.0` → `preview/v0.8.0` to match the `release/v0.7.0` convention (all version-stamped branches now use the `v` prefix). This PR realigns the issue-template scaffolding that landed in #1708 with the new branch name.

## Changes

- `git mv preview-0.8.0-feedback.yml` → `preview-v0.8.0-feedback.yml` (history preserved)
- Inside that template:
  - `name`: 🧪 Preview 0.8.0 feedback → 🧪 Preview v0.8.0 feedback
  - `labels`: \`[\"preview/0.8.0\"]\` → \`[\"preview/v0.8.0\"]\`
  - `title`: \`[preview/0.8.0]\` → \`[preview/v0.8.0]\`
  - Description + body text references updated
  - Version-placeholder example bumped to `0.8.0-preview.2` (current build) and the now-stale commit-hash example removed
- `bug-report.yml`: updated the cross-reference pointing testers at the preview template
- `feature-request.yml`: same cross-reference update
- `config.yml`: first contact_link's name + URL + about text updated to match the new template filename

## What I already did outside this PR (so you know the picture)

- GitHub label `preview/0.8.0` → renamed to `preview/v0.8.0` (color and history preserved via `PATCH /labels`)
- Branch `preview/0.8.0` deleted on origin; `preview/v0.8.0` is the canonical branch
- Branch-protection ruleset still uses `preview/*` pattern → still covers the renamed branch

## Test plan

- [ ] After merge, open https://github.com/nexu-io/open-design/issues/new/choose
- [ ] Confirm \"🧪 Preview v0.8.0 feedback\" (with v) appears
- [ ] Confirm the deep-link https://github.com/nexu-io/open-design/issues/new?template=preview-v0.8.0-feedback.yml resolves directly to that template
- [ ] File a test issue via the template, confirm the `preview/v0.8.0` label auto-applies
- [ ] Confirm title prefix `[preview/v0.8.0]` is pre-filled
- [ ] Confirm the old deep-link with `preview-0.8.0-feedback.yml` 404s or falls back to the chooser (file no longer exists)