### PR TITLE
fix(web): allow downloads from preview iframes

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -1106,7 +1106,7 @@ export function LiveArtifactViewer({
                     ref={iframeRef}
                     data-testid="live-artifact-preview-frame"
                     title={liveArtifact.title}
-                    sandbox="allow-scripts allow-popups"
+                    sandbox="allow-scripts allow-popups allow-downloads"
                     src={previewUrl}
                   />
                 </PreviewDrawOverlay>
@@ -3399,7 +3399,7 @@ function ReactComponentViewer({
             <iframe
               data-testid="react-component-preview-frame"
               title={file.name}
-              sandbox="allow-scripts"
+              sandbox="allow-scripts allow-downloads"
               srcDoc={srcDoc}
               style={{ width: '100%', height: '100%', border: 0 }}
             />
@@ -5758,7 +5758,7 @@ function HtmlViewer({
                       data-testid="artifact-preview-frame"
                       data-od-render-mode="url-load"
                       title={file.name}
-                      sandbox="allow-scripts"
+                      sandbox="allow-scripts allow-downloads"
                       src={previewSrcUrl}
                       onLoad={syncBridgeModes}
                       style={{ width: '100%', height: '100%', border: 0 }}
@@ -5769,7 +5769,7 @@ function HtmlViewer({
                       data-testid="artifact-preview-frame"
                       data-od-render-mode="srcdoc"
                       title={file.name}
-                      sandbox="allow-scripts"
+                      sandbox="allow-scripts allow-downloads"
                       srcDoc={srcDoc}
                       onLoad={() => {
                         replayInspectOverridesToIframe();
@@ -6002,14 +6002,14 @@ function HtmlViewer({
           {useUrlLoadPreview ? (
             <iframe
               title="present"
-              sandbox="allow-scripts"
+              sandbox="allow-scripts allow-downloads"
               data-od-render-mode="url-load"
               src={previewSrcUrl}
             />
           ) : (
             <iframe
               title="present"
-              sandbox="allow-scripts"
+              sandbox="allow-scripts allow-downloads"
               data-od-render-mode="srcdoc"
               srcDoc={srcDoc}
             />

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -360,7 +360,67 @@ describe('FileViewer SVG artifacts', () => {
     expect(markup).toContain('data-testid="artifact-preview-frame"');
     expect(markup).toContain('data-od-render-mode="url-load"');
     expect(markup).toContain('src="/api/projects/project-1/raw/page.html?v=1710000000&amp;r=0"');
+    expect(markup).toContain('sandbox="allow-scripts allow-downloads"');
     expect(markup).not.toContain('data-od-render-mode="srcdoc"');
+  });
+
+  it('allows downloads in the in-tab HTML presentation iframe', async () => {
+    const file = baseFile({
+      name: 'page.html',
+      path: 'page.html',
+      mime: 'text/html',
+      kind: 'html',
+      artifactManifest: {
+        version: 1,
+        kind: 'html',
+        title: 'Page',
+        entry: 'page.html',
+        renderer: 'html',
+        exports: ['html'],
+      },
+    });
+
+    const { container } = render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={file} liveHtml="<html><body>hi</body></html>" />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /present/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /in this tab/i }));
+
+    await waitFor(() => {
+      const frame = container.querySelector('.present-overlay iframe');
+      expect(frame?.getAttribute('sandbox')).toBe('allow-scripts allow-downloads');
+      expect(frame?.getAttribute('data-od-render-mode')).toBe('url-load');
+    });
+  });
+
+  it('allows downloads in React component preview iframes', async () => {
+    const file = baseFile({
+      name: 'Card.jsx',
+      path: 'Card.jsx',
+      mime: 'text/jsx',
+      kind: 'code',
+      artifactManifest: {
+        version: 1,
+        kind: 'react-component',
+        title: 'Card',
+        entry: 'Card.jsx',
+        renderer: 'react-component',
+        exports: ['jsx', 'html', 'zip'],
+      },
+    });
+    vi.stubGlobal('fetch', vi.fn(async (input: string | URL | Request) => {
+      const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+      if (url === '/api/projects/project-1/raw/Card.jsx') {
+        return new Response('export default function Card() { return <button>Download</button>; }');
+      }
+      return new Response('', { status: 404 });
+    }));
+
+    render(<FileViewer projectId="project-1" projectKind="prototype" file={file} />);
+
+    const frame = await screen.findByTestId('react-component-preview-frame');
+    expect(frame.getAttribute('sandbox')).toBe('allow-scripts allow-downloads');
   });
 
   it('keeps decks on the srcDoc path so the deck postMessage bridge can run', () => {
@@ -388,6 +448,7 @@ describe('FileViewer SVG artifacts', () => {
 
     expect(markup).toContain('data-testid="artifact-preview-frame"');
     expect(markup).toContain('data-od-render-mode="srcdoc"');
+    expect(markup).toContain('sandbox="allow-scripts allow-downloads"');
     expect(markup).not.toContain('data-od-render-mode="url-load"');
   });
 


### PR DESCRIPTION
Fixes #1717

## Summary
- add `allow-downloads` to FileViewer sandboxed preview and in-tab presentation iframes
- keep the existing sandbox restrictions otherwise, including no `allow-same-origin` or top-navigation permissions
- cover HTML URL-load, deck srcDoc, in-tab presentation, and React component preview sandbox attributes in tests

## Surface area
- [x] UI
- [ ] Keyboard shortcut
- [ ] CLI
- [ ] env var
- [ ] API
- [x] Default behavior change
- [ ] i18n keys
- [ ] Extension point
- [ ] New top-level dependency
- [ ] None

## Validation
- `pnpm --filter @open-design/web test -- tests/components/FileViewer.test.tsx` (126 files, 1247 tests passed)
- `pnpm guard`