### PR TITLE
feat(odml): seed dialect, tokens, skill prompt — chala-ai-mobile + od-dialect foundation

### DIFF
--- a/design-systems/chala-ai/DESIGN.md
+++ b/design-systems/chala-ai/DESIGN.md
@@ -1,0 +1,187 @@
+# Design System — Chala.AI
+
+> Category: Health & Fitness
+> AI personal trainer app for iOS. Matte luxury precision instrument aesthetic — pure black, opacity-layered monochrome, Geist typography.
+
+## 1. Visual Theme & Atmosphere
+
+Chala.AI is built on a single conviction: a fitness app should feel like a high-end instrument, not a social platform. The canvas is absolute black (`#050505`) — not dark gray, not navy, pure black — which makes every element feel deliberate and precisely placed, the way a dial or gauge would on a watch face.
+
+Depth is created entirely through opacity. Cards, hairlines, and input backgrounds are all white at 4–16% opacity on the black surface. This gives the interface its layered matte quality — depth without gradients, richness without color. There is exactly one "color" in the system: white (`#FFFFFF`), used at varying opacity levels to create hierarchy.
+
+Typography is the primary design material. Headings run large (28–42px), medium weight (500), with tight negative tracking (−0.02em). Labels are always uppercase GeistMono, tracked wide (+0.18em). Numerics use tabular mono with monospacedDigit for lockstep number updates. The contrast between these two type roles — expressive serif-like heading vs. instrument-panel label — creates the instrument feel without a single icon or illustration doing any lifting.
+
+Custom SVG glyphs replace system icons. They're thin stroke (1.25px), square linecap, miter join, 24×24 viewBox. They read as technical drawings, not friendly icons. The tab bar uses a small dot indicator (not highlight) for the active tab.
+
+**Key characteristics:**
+- Absolute black canvas (`#050505`) — no warm or cool tint
+- Opacity-only depth system — no shadows, no gradients
+- Geist (sans) for headings + body; GeistMono for labels, numerics, all UI chrome
+- Uppercase mono labels everywhere (letterSpacing +0.18em)
+- Hairline borders only — 1px, white at 8–16% opacity
+- 2px border radius on interactive elements (sharp, not rounded)
+- Portrait-only, dark-scheme enforced globally
+
+## 2. Color Palette
+
+### Surface
+- **Base background** `#050505` — absolute black, the primary canvas
+- **Raised background** `#0B0B0B` — slightly elevated surfaces (cards on cards)
+
+### Text hierarchy (all white at varying opacity)
+- **Text** `#FFFFFF` (100%) — primary content, active state text
+- **Text Dim** `rgba(255,255,255,0.55)` — body copy, secondary headings
+- **Text Faint** `rgba(255,255,255,0.32)` — labels, metadata, timestamps
+- **Text Muted** `rgba(255,255,255,0.18)` — placeholder text, truly de-emphasized
+
+### Borders (hairlines)
+- **Hairline** `rgba(255,255,255,0.08)` — default dividers and borders (1px only)
+- **Hairline Strong** `rgba(255,255,255,0.16)` — elevated borders, interactive element rings
+
+### Interactive
+- **Primary Fill** `#E0E0E0` — filled button backgrounds (light gray on black = high contrast without white glare)
+- **Primary Text** `#0B0B0B` — text on Primary Fill buttons
+- **Card** `rgba(255,255,255,0.04)` — card/container background
+- **Card Selected** `rgba(255,255,255,0.12)` — selected/pressed card
+- **Input Background** `rgba(255,255,255,0.05)` — form field fill
+- **Pill Background** `rgba(255,255,255,0.10)` — tag/badge fills
+
+### Accent
+- **Accent** `#FFFFFF` — the system is monochrome; accent is pure white (used for active states, emphasis)
+
+### Legacy (iOS system, avoid in new screens)
+- `#007AFF` iOS blue, `#FF3B30` destructive, `#34C759` success, `#FF9500` warning
+
+## 3. Typography
+
+### Typefaces
+- **Geist** — primary UI font (Regular 400, Medium 500, SemiBold 600, Bold 700)
+  - Used for: headings, body copy, button labels
+  - Source: Geist.ttf bundled in app
+- **GeistMono** — monospace for all chrome, labels, numerics (Regular 400, Medium 500)
+  - Used for: uppercase labels, timestamps, stats, tab bar, ALL metadata
+  - Source: GeistMono.ttf bundled in app
+
+### Scale & roles
+| Role | Size | Weight | Font | Tracking | Notes |
+|---|---|---|---|---|---|
+| **Display** | 42px | 500 | Geist | −0.02em | Calorie counts, hero numerics |
+| **Title** | 36px | 500 | Geist | −0.02em | Screen headings ("Good morning, Alex.") |
+| **Heading** | 28–32px | 500 | Geist | −0.02em | Section headings |
+| **Subheading** | 22–26px | 500 | Geist | −0.02em | Card headings |
+| **Body** | 14–15px | 400 | Geist | normal | Descriptions, chat messages |
+| **Label** | 9–11px | 400 | GeistMono | +0.18em | UPPERCASE only, UI chrome |
+| **Numeric** | variable | 500 | GeistMono | −0.02em | Stats, counts; tabular digits |
+| **Button** | 13px | 500 | Geist | +0.12em | UPPERCASE |
+| **Caption** | 8–9px | 400 | GeistMono | +0.06em | Sub-labels, units (KCAL, MIN) |
+
+### Rules
+- All `Label` and button text: `text-transform: uppercase`
+- All `Numeric` contexts: `font-variant-numeric: tabular-nums`
+- Headings: `letter-spacing: -0.02em`, `line-height: ~1.05`
+
+## 4. Spacing & Layout
+
+### Scale
+- `4px` — XS (tight internal gaps)
+- `8px` — SM (between related items)
+- `16px` — MD (standard internal padding)
+- `20px` — screen content padding (cards)
+- `24px` — LG (between sections inside a card)
+- `28px` — screen horizontal padding
+- `32px` — XL (between major sections)
+- `48px` — XXL (hero breathing room)
+
+### Border radius
+- `2px` — default for all interactive elements (buttons, cards, inputs, tags) — the "sharp" look
+- `8px` — secondary card variant
+- `15px` — input fields only
+- `9999px` — pill (fully rounded tags)
+
+### Hairline weight
+- All borders are exactly `1px`. Never `2px` or more.
+
+### Progress bar height
+- `4px` — the only bar/track height used anywhere
+
+## 5. Component Patterns
+
+### ButtonV2
+Three variants, all uppercase 13px Geist Medium (+0.12em tracking):
+- **primary** — `#E0E0E0` fill, `#0B0B0B` text, 2px radius, no border
+- **secondary** — transparent fill, `rgba(255,255,255,0.16)` border, white text
+- **ghost** — no fill, no border, white text, minimal
+
+### ChalaScreenV2
+Full-screen container: `#050505` background, safe area handled, portrait only.
+
+### HeadingV2
+Default 28px, Medium 500, −0.02em tracking.
+
+### LabelV2
+Default 10px GeistMono, +0.18em tracking, always uppercased.
+
+### NumericV2
+GeistMono with `font-variant-numeric: tabular-nums`. Size varies by context.
+
+### RuleV2
+1px hairline divider: `rgba(255,255,255,0.08)` — width 100%.
+
+### TabBarV2
+5 cells: Home, Chat, Calendar, Sports, Profile. Active cell shows icon + 4px white dot below. No labels. No background fill — pure black with hairline top border.
+
+### GlyphV2 (icon system)
+24×24 viewBox, 1.25px stroke, square linecap, miter join. Available: home, chat, calendar, profile, apple, sports, check, settings, bell, arrow-right, arrow-up, chevron-left, chevron-right, dumbbell, pulse, spark, book, play, more.
+
+### Form fields
+Hairline bottom border only (no box/card). Label at 9px mono faint above. Value at 15px Geist. Password: mono letterSpacing 0.2em.
+
+### Cards
+`rgba(255,255,255,0.04)` background, `1px solid rgba(255,255,255,0.16)` border, `2px` radius. Internal padding 16–20px. Hairline dividers between sections inside a card.
+
+### Stat cells
+Used in Profile, Home: `flex` row divided by hairlines. Each cell: large Numeric + tiny Label below in faint mono.
+
+### Macro rings (Nutrition)
+SVG circle stroke-dasharray. Track: `1.5px` hairlineStrong. Arc: `1.5px` white. Inside: Numeric value + caption unit.
+
+## 6. Screen Inventory
+
+| Screen | Label | Key elements |
+|---|---|---|
+| **Landing** | 00 | Full-screen black, logo centered, primary + secondary CTA |
+| **Sign In** | 01 | Wordmark, heading "Welcome back.", form fields, Google OAuth button |
+| **Sign Up** | — | Same shell, different heading + fields |
+| **Home** | 02 | Logo + bell row, greeting heading, 7-day week strip (4px bars), today workout card (border card), coach insight, quick-actions 2-cell grid |
+| **Chat (empty)** | 03 | Logo centered, 4 suggested prompt rows, input bar at bottom |
+| **Chat (active)** | 03b | Message bubbles, coach badge, streaming indicator |
+| **Calendar** | 04 | Month header, 7-column day grid, session list below |
+| **Profile** | 06 | Name heading, avatar initials box, 3-stat row (Sessions/Check-ins/Streak), ETA Gym Pass mini-QR, preferences list |
+| **Nutrition** | 05 | "Fuel" heading, calorie banner (big Numeric + progress bar), 3 macro rings (SVG), meal list, wearable 4-up stats, body metric rows |
+| **Sports** | 07 | Activity summary, bar chart week strip, run cards with distance/pace |
+| **Run Detail** | — | Route map trace (SVG polyline), split table, HR graph |
+| **AI Routes** | — | 3 curated route cards with difficulty tags and distance |
+| **Workout Summary** | — | Exercise list with sets/reps/vol, total summary stats |
+| **Settings** | — | Grouped list rows: notifications, units, integrations, account |
+| **Gym Pass** | — | Full-screen QR code, membership label |
+| **Active Workout** | — | Exercise name, set rows with weight/reps, rest timer overlay |
+| **Exercise Library** | — | Searchable grid of exercise cards with muscle group tags |
+
+## 7. Interaction & Motion Principles
+
+- **No gratuitous animation.** State changes are immediate or use short (150–200ms) fade/opacity tweens only.
+- **Haptic on primary actions.** Every workout set logged, every workout started/ended.
+- **Rest timer overlay** — full-screen dimmed cover with large countdown Numeric, auto-dismissed.
+- **Pull to refresh** — native iOS rubber band only, no custom loaders.
+- **Tab bar active state** — instant dot appear, no slide animation.
+
+## 8. Anti-references
+
+Do NOT make this look like:
+- **MyFitnessPal / Strava** — colorful, social, gamified with badges and trophy icons
+- **Apple Fitness+** — gradient-heavy, large photography, playful curves
+- **Nike Run Club** — bold color accents, Nike yellow/orange, thick strokes
+- **Whoop** — all black but warm/red accent and rounded forms
+- Generic iOS apps using system blue, rounded rectangles, and SF Symbols
+
+The distinguishing move: no color accents, no rounded corners, no photography, no gradients. If it looks like a stopwatch or aircraft instrument panel, it's correct.

--- a/design-systems/chala-ai/components.html
+++ b/design-systems/chala-ai/components.html
@@ -1,0 +1,520 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Chala.AI — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/chala-ai. Every visible
+        value comes from tokens.css; if the agent paste-replaces the
+        :root block and reuses the component selectors below verbatim,
+        the artifact passes lint without further audit."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+
+    <style>
+      /* :root paste — sourced verbatim from
+         design-systems/chala-ai/tokens.css. Keep this block in sync
+         when tokens.css changes. The agent prompt instructs the
+         Designer panelist to paste this block as the FIRST thing in
+         their <style>, then reference everything below via var(...). */
+      :root {
+        --bg: #050505;
+        --surface: #0b0b0b;
+        --surface-warm: var(--surface);
+
+        --fg: #ffffff;
+        --fg-2: var(--fg);
+        --muted: rgba(255, 255, 255, 0.55);
+        --meta: rgba(255, 255, 255, 0.32);
+
+        --border: rgba(255, 255, 255, 0.08);
+        --border-soft: var(--border);
+
+        --accent: #e0e0e0;
+        --accent-on: #0b0b0b;
+        --accent-hover: #ffffff;
+        --accent-active: rgba(255, 255, 255, 0.92);
+
+        --success: #34c759;
+        --warn: #ff9500;
+        --danger: #ff3b30;
+
+        --font-display: 'Geist', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+        --font-body: 'Geist', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+        --font-mono: 'GeistMono', ui-monospace, 'SF Mono', Menlo, monospace;
+
+        --text-xs: 10px;
+        --text-sm: 13px;
+        --text-base: 15px;
+        --text-lg: 22px;
+        --text-xl: 28px;
+        --text-2xl: 36px;
+        --text-3xl: 42px;
+        --text-4xl: 56px;
+
+        --leading-body: 1.4;
+        --leading-tight: 1.15;
+        --tracking-display: -0.02em;
+
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 80px;
+        --section-y-tablet: 48px;
+        --section-y-phone: 32px;
+
+        --radius-sm: 2px;
+        --radius-md: 8px;
+        --radius-lg: 15px;
+        --radius-pill: 9999px;
+
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px rgba(255, 255, 255, 0.16);
+        --elev-raised: 0 0 16px rgba(255, 255, 255, 0.08);
+
+        --focus-ring: 0 0 0 3px rgba(255, 255, 255, 0.32);
+
+        --motion-fast: 150ms;
+        --motion-base: 200ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+        --container-max: 1200px;
+        --container-gutter-desktop: 24px;
+        --container-gutter-tablet: 16px;
+        --container-gutter-phone: 12px;
+      }
+
+      /* ─── Reset (minimal) ───────────────────────────────────── */
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        font-weight: 400;
+        -webkit-font-smoothing: antialiased;
+      }
+
+      /* ─── Layout primitives ─────────────────────────────────── */
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section {
+        padding-block: var(--section-y-desktop);
+      }
+      section + section {
+        border-top: 1px solid var(--border);
+      }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography ────────────────────────────────────────── */
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        line-height: var(--leading-tight);
+        margin: 0;
+      }
+      h1 {
+        font-size: var(--text-3xl);
+        font-weight: 500;
+        letter-spacing: var(--tracking-display);
+      }
+      h2 {
+        font-size: var(--text-2xl);
+        font-weight: 500;
+        letter-spacing: var(--tracking-display);
+      }
+      h3 {
+        font-size: var(--text-lg);
+        font-weight: 500;
+        letter-spacing: var(--tracking-display);
+      }
+      p { margin: 0; }
+      .lead {
+        font-size: var(--text-lg);
+        color: var(--muted);
+        max-width: 48ch;
+      }
+      .body-muted { color: var(--muted); }
+      .body-meta { color: var(--meta); }
+      .body-sm { font-size: var(--text-sm); }
+      /* `.eyebrow` is chala's signature label form — uppercase mono
+         at +0.18em tracking. Used for section labels, timestamps,
+         stats captions. Per craft/typography.md, letter-spacing
+         must be ≥ 0.06em on uppercase rules; chala lands at 0.18. */
+      .eyebrow {
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        color: var(--meta);
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        font-weight: 400;
+      }
+      .stat {
+        font-family: var(--font-mono);
+        font-weight: 500;
+        font-variant-numeric: tabular-nums;
+        color: var(--fg);
+        letter-spacing: var(--tracking-display);
+      }
+      .stack-2 > * + * { margin-block-start: var(--space-2); }
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+      .stack-8 > * + * { margin-block-start: var(--space-8); }
+
+      /* ─── Buttons ───────────────────────────────────────────── */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 10px 18px;
+        border-radius: var(--radius-sm);
+        font-family: inherit;
+        font-size: var(--text-sm);
+        font-weight: 500;
+        line-height: 1;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        cursor: pointer;
+        border: 1px solid transparent;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          border-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard);
+        text-decoration: none;
+      }
+      .btn:focus-visible {
+        outline: none;
+        box-shadow: var(--focus-ring);
+      }
+      .btn-primary {
+        background: var(--accent);
+        color: var(--accent-on);
+      }
+      .btn-primary:hover { background: var(--accent-hover); }
+      .btn-primary:active { background: var(--accent-active); }
+      .btn-secondary {
+        background: transparent;
+        color: var(--fg);
+        border-color: rgba(255, 255, 255, 0.16);
+      }
+      .btn-secondary:hover { border-color: rgba(255, 255, 255, 0.32); }
+      .btn-ghost {
+        background: transparent;
+        color: var(--muted);
+      }
+      .btn-ghost:hover { color: var(--fg); }
+
+      /* ─── Cards ─────────────────────────────────────────────── */
+      .card {
+        background: rgba(255, 255, 255, 0.04);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        padding: var(--space-6);
+      }
+      .card.elevated {
+        border-color: rgba(255, 255, 255, 0.16);
+      }
+      .features-grid {
+        display: grid;
+        gap: var(--space-4);
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
+      @media (max-width: 1023px) {
+        .features-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      }
+      @media (max-width: 639px) {
+        .features-grid { grid-template-columns: 1fr; }
+      }
+
+      /* ─── Hero numerics — chala's signature display use ────── */
+      .stat-display {
+        font-size: var(--text-3xl);
+      }
+      .stat-headline {
+        font-size: var(--text-xl);
+      }
+      .stat-row {
+        display: grid;
+        gap: var(--space-6);
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        padding-block: var(--space-8);
+        border-top: 1px solid var(--border);
+        border-bottom: 1px solid var(--border);
+      }
+      .stat-cell {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+      }
+
+      /* ─── Form ──────────────────────────────────────────────── */
+      .form {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+        max-width: 28rem;
+      }
+      .field {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+      }
+      .field label {
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        color: var(--meta);
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+      }
+      .field input {
+        background: rgba(255, 255, 255, 0.05);
+        color: var(--fg);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        padding: 12px 14px;
+        font-family: inherit;
+        font-size: var(--text-base);
+        line-height: 1.2;
+      }
+      .field input::placeholder {
+        color: var(--meta);
+      }
+      .field input:focus-visible {
+        outline: none;
+        border-color: rgba(255, 255, 255, 0.32);
+        box-shadow: var(--focus-ring);
+      }
+      .field-help {
+        font-size: var(--text-sm);
+        color: var(--muted);
+      }
+      .form-actions {
+        display: flex;
+        gap: var(--space-2);
+        margin-block-start: var(--space-2);
+      }
+      .form-row {
+        display: grid;
+        gap: var(--space-12);
+        grid-template-columns: 1fr 1fr;
+      }
+      @media (max-width: 1023px) {
+        .form-row { grid-template-columns: 1fr; }
+      }
+
+      /* ─── Hero ──────────────────────────────────────────────── */
+      .hero-grid {
+        display: grid;
+        gap: var(--space-12);
+        grid-template-columns: 1.4fr 1fr;
+        align-items: end;
+      }
+      @media (max-width: 1023px) {
+        .hero-grid { grid-template-columns: 1fr; }
+      }
+      .hero-headline {
+        font-size: var(--text-3xl);
+        max-width: 18ch;
+      }
+      .hero-aside {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+      }
+
+      /* ─── Status pill — uses --success for "system live" ───── */
+      .status-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 4px 10px;
+        border-radius: var(--radius-pill);
+        background: rgba(255, 255, 255, 0.10);
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        color: var(--fg);
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+      }
+      .status-pill::before {
+        content: '';
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: var(--success);
+      }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <!-- ════════════════════════════════════════════════════════════
+           HERO — exercises: .eyebrow, h1, .lead, .stat-row,
+           .stat (display + headline), .status-pill, .btn-primary,
+           .btn-secondary. The hero is the most opinionated screen
+           in chala's vocabulary: hero numerics on display, white
+           tracked-tight headline, uppercase mono labels, single CTA.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="hero">
+        <div class="hero-grid stack-8">
+          <div class="stack-6">
+            <span class="status-pill">System live</span>
+            <p class="eyebrow">Reference fixture · 2026</p>
+            <h1 class="hero-headline">
+              A matte instrument for personal training.
+            </h1>
+            <p class="lead">
+              Every value on this page derives from
+              <code>tokens.css</code>. Paste the <code>:root</code> block
+              into your artifact, then reference tokens by name and the
+              brand reads correctly without further audit.
+            </p>
+            <div class="form-actions">
+              <button type="button" class="btn btn-primary">Start session</button>
+              <button type="button" class="btn btn-secondary">Inspect tokens</button>
+            </div>
+          </div>
+
+          <div class="hero-aside">
+            <p class="eyebrow">Today</p>
+            <div class="stat-row">
+              <div class="stat-cell">
+                <p class="eyebrow">Sessions</p>
+                <p class="stat stat-display">4</p>
+              </div>
+              <div class="stat-cell">
+                <p class="eyebrow">Volume</p>
+                <p class="stat stat-display">8.4<span style="font-size: var(--text-lg); color: var(--meta); letter-spacing: 0.18em; font-family: var(--font-mono);">t</span></p>
+              </div>
+              <div class="stat-cell">
+                <p class="eyebrow">PR</p>
+                <p class="stat stat-display">+2</p>
+              </div>
+            </div>
+            <p class="body-sm body-muted">
+              Display numerics use <code>GeistMono</code> with tabular
+              digits; <code>--tracking-display</code> keeps the rhythm.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ════════════════════════════════════════════════════════════
+           FEATURES — exercises: h2, h3, .card, .body-muted, link,
+           .features-grid. Each card describes a real property of this
+           fixture (no "feature one/two/three" filler).
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="features">
+        <div class="stack-3">
+          <p class="eyebrow">What this fixture exercises</p>
+          <h2 style="max-width: 28ch">
+            Every component below uses only var(--*) — no raw hex, no
+            off-token type.
+          </h2>
+        </div>
+
+        <div class="features-grid" style="margin-block-start: var(--space-8)">
+          <article class="card stack-3">
+            <h3>Opacity-only depth</h3>
+            <p class="body-muted body-sm">
+              No shadows, no gradients (except a single glow on the
+              Landing CTA per <code>--elev-raised</code>). Lift comes
+              from 1px hairlines at <code>--border</code> (8%) and
+              <code>--elev-ring</code> (16%).
+            </p>
+            <a href="./tokens.css" class="body-sm">Inspect tokens →</a>
+          </article>
+
+          <article class="card stack-3">
+            <h3>Sharp interactive radii</h3>
+            <p class="body-muted body-sm">
+              <code>--radius-sm: 2px</code> on buttons / chips — chala's
+              hard rule for interactive elements. Cards step to
+              <code>--radius-md: 8px</code> for visual lift. Inputs use
+              <code>--radius-lg: 15px</code> for softness on text fields.
+            </p>
+            <a href="./DESIGN.md" class="body-sm">Read the rule →</a>
+          </article>
+
+          <article class="card stack-3">
+            <h3>Uppercase mono chrome</h3>
+            <p class="body-muted body-sm">
+              Every label, eyebrow, timestamp, and stat caption is
+              <code>GeistMono</code> at <code>--text-xs</code> with
+              <code>+0.18em</code> tracking and
+              <code>text-transform: uppercase</code>. The body face
+              (<code>Geist</code>) is reserved for sentences.
+            </p>
+            <a href="./tokens.css" class="body-sm">Inspect typography →</a>
+          </article>
+        </div>
+      </section>
+
+      <!-- ════════════════════════════════════════════════════════════
+           FORM — exercises: .field, input :focus-visible,
+           .btn-primary (reused), .btn-secondary, .field-help.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="form">
+        <div class="form-row">
+          <div class="stack-4">
+            <p class="eyebrow">Form components</p>
+            <h2>Inputs read like instruments, not web forms.</h2>
+            <p class="body-muted" style="max-width: 48ch">
+              Field labels are uppercase mono at <code>--meta</code>;
+              the input itself sits on a 5% white fill with a 15px
+              radius. Focus binds to <code>--focus-ring</code> — a 32%
+              white halo, never the chromatic accent.
+            </p>
+          </div>
+
+          <form class="form" onsubmit="event.preventDefault();">
+            <div class="field">
+              <label for="email">Work email</label>
+              <input
+                id="email"
+                type="email"
+                placeholder="you@team.dev"
+                autocomplete="email"
+                required
+              />
+              <p class="field-help">
+                We'll send the spec PDF and nothing else.
+              </p>
+            </div>
+            <div class="form-actions">
+              <button type="submit" class="btn btn-primary">
+                Send the spec
+              </button>
+              <button type="button" class="btn btn-ghost">
+                Skip for now
+              </button>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/chala-ai/tokens-audit.md
+++ b/design-systems/chala-ai/tokens-audit.md
@@ -1,19 +1,63 @@
-# Chala.AI tokens.json — Reconciliation Audit
+# Chala.AI design-system — Reconciliation Audit
 
-> Date: 2026-05-14
+> Date: 2026-05-14 (revised same day to add tokens.css)
 > Author: Hand-authored seed v1 (per plan `calm-floating-fern` §5a step 1–3)
 > Reconciled against: `design-systems/chala-ai/DESIGN.md` and `projects/Gym.AI/Chala.AI/apps/ios/ChalaAI/ChalaAI/Views/Components/Theme.swift` (read at this date)
 
-This file records the one-time reconciliation between the three sources of
-chala-ai design values that existed before `tokens.json` was authored:
+This file records the one-time reconciliation between the multiple sources
+of chala-ai design values:
 
-1. **DESIGN.md** — the human-readable rationale doc.
-2. **Theme.swift** — the iOS app's hand-authored constants.
-3. **chala-ai-mobile/assets/template.html** (legacy) — the skill's preview shim
-   had its own CSS variables.
+1. **DESIGN.md** — human-readable rationale.
+2. **Theme.swift** — iOS app hand-authored constants.
+3. **chala-ai-mobile/assets/template.html** (legacy) — skill preview shim with
+   its own CSS variables (now superseded by `od-elements.js`).
 
-`tokens.json` is now the source of truth. Future updates flow via
-`tools/tokens-build/extract.ts` (LLM extraction) and PR review.
+## Provenance model (revised after reading upstream's loader)
+
+Initial seed treated `tokens.json` as the source of truth. Reading
+`apps/daemon/src/prompts/system.ts` and `apps/daemon/src/design-systems.ts`
+revealed that **upstream already ships its own structured token convention
+(`tokens.css`)** and consumes it for picker / lint / system-prompt
+injection. To avoid fighting upstream's contract, chala-ai now ships
+three coexisting machine-readable forms with distinct consumers:
+
+| File | Consumer | Naming idiom |
+|---|---|---|
+| `DESIGN.md` | Humans (rationale). Daemon also injects it as prose into system prompt. | Free prose |
+| `tokens.css` | Upstream OD daemon: design-system loader (`design-systems.ts`), picker UI (`NewProjectPanel.tsx`), system-prompt injection (`prompts/system.ts:321`), artifact lint (`lint-artifact.ts`) | Standard schema (`--bg`, `--surface`, `--fg`, `--muted`, `--meta`, `--border`, `--accent`, `--accent-on`, `--warn`, `--danger`, `--font-display`, …) per `craft/color.md` |
+| `tokens.json` | ODML side: skill validator (forthcoming), per-platform translators (SwiftUI, future React/RN). Skill prompt references these names directly via `<od-* color="fg-muted">` attributes. | ODML idiom (`bg`, `fg-muted`, `accent-fg`, `bg-elevated`, `bg-overlay`, …) per the SKILL.md token tables |
+
+**Source of intent:** `DESIGN.md` — when changing a token value, the prose
+gets updated first, then the two structured files mirror it. `tokens.css`
+and `tokens.json` are both DERIVED forms; neither is privileged over the
+other. They serve parallel contracts (upstream HTML pipeline vs ODML
+multi-platform pipeline) and MUST stay in sync on value (the hex codes
+must match across the two files; only the name keys differ).
+
+A future automation could derive both from a single source (e.g.
+`tools/tokens-build/extract.ts` per plan §5a) but until that exists, the
+human PR author updates all three files together when changing any value.
+
+## ODML ↔ standard-schema name cross-walk
+
+For audit: every name in `tokens.json` (ODML idiom) maps to a name in
+`tokens.css` (standard schema). Values are identical; names differ.
+
+| ODML name (tokens.json) | Standard-schema name (tokens.css) | Shared value |
+|---|---|---|
+| `bg` | `--bg` | `#050505` |
+| `bg-elevated` | `--surface` | `#0B0B0B` |
+| `bg-overlay` | (no direct standard-schema slot) | `rgba(255,255,255,0.06)` — exposed only on ODML side; HTML artifacts use `--surface-warm` which aliases to `--surface` |
+| `fg` | `--fg` | `#FFFFFF` |
+| `fg-muted` | `--muted` | `rgba(255,255,255,0.55)` |
+| `fg-subtle` | `--meta` | `rgba(255,255,255,0.32)` |
+| `accent` | `--accent` | `#E0E0E0` (mapped to DESIGN.md `--primary-fill`; the prose "system is monochrome; accent is pure white" describes intent, but the FILL token lands here per DESIGN.md §2.Interactive) |
+| `accent-fg` | `--accent-on` | `#0B0B0B` |
+| `success` | `--success` | `#34C759` |
+| `warning` | `--warn` | `#FF9500` (note: schema uses `--warn`, ODML uses `warning`) |
+| `danger` | `--danger` | `#FF3B30` |
+| `border` | `--border` | `rgba(255,255,255,0.08)` |
+| `border-strong` | (exposed via `--elev-ring`) | `rgba(255,255,255,0.16)` — `border-strong` in ODML maps to elevation-ring on the HTML side, not a separate border tier |
 
 ---
 

--- a/design-systems/chala-ai/tokens-audit.md
+++ b/design-systems/chala-ai/tokens-audit.md
@@ -1,0 +1,123 @@
+# Chala.AI tokens.json — Reconciliation Audit
+
+> Date: 2026-05-14
+> Author: Hand-authored seed v1 (per plan `calm-floating-fern` §5a step 1–3)
+> Reconciled against: `design-systems/chala-ai/DESIGN.md` and `projects/Gym.AI/Chala.AI/apps/ios/ChalaAI/ChalaAI/Views/Components/Theme.swift` (read at this date)
+
+This file records the one-time reconciliation between the three sources of
+chala-ai design values that existed before `tokens.json` was authored:
+
+1. **DESIGN.md** — the human-readable rationale doc.
+2. **Theme.swift** — the iOS app's hand-authored constants.
+3. **chala-ai-mobile/assets/template.html** (legacy) — the skill's preview shim
+   had its own CSS variables.
+
+`tokens.json` is now the source of truth. Future updates flow via
+`tools/tokens-build/extract.ts` (LLM extraction) and PR review.
+
+---
+
+## Color reconciliation
+
+| Token | DESIGN.md value | Theme.swift constant | tokens.json | Notes |
+|---|---|---|---|---|
+| `bg` | `#050505` | `Theme.Dark.bg = #050505` | `#050505` | Match |
+| `bg-elevated` | `#0B0B0B` | `Theme.Dark.bgRaised = #0B0B0B` | `#0B0B0B` | DESIGN.md calls this "Raised background". `bgRaised` → `bg-elevated` is a rename to match ODML naming. |
+| `bg-overlay` | (not specified) | (not present) | `rgba(255,255,255,0.06)` via `$extensions.opacity` | **NEW.** Filling the ODML vocabulary slot. Reasonable midpoint between `bg-elevated` and `border-strong` (16%). Needs design sign-off when first used. |
+| `fg` | `#FFFFFF` | `Theme.Dark.text = .white` | `#FFFFFF` | Match |
+| `fg-muted` | `rgba(255,255,255,0.55)` | `Theme.Dark.textDim = .white.opacity(0.55)` | white @ 0.55 | DESIGN.md term "Text Dim" → ODML `fg-muted` rename |
+| `fg-subtle` | `rgba(255,255,255,0.32)` | `Theme.Dark.textFaint = .white.opacity(0.32)` | white @ 0.32 | DESIGN.md term "Text Faint" → ODML `fg-subtle` rename. Note: DESIGN.md also has `Text Muted = 0.18` which has no ODML slot; consider adding `fg-faint` in v2. |
+| `accent` | `#FFFFFF` (system is monochrome) | (no constant — derived from `text`) | `#FFFFFF` | DESIGN.md §2.Accent: "system is monochrome; accent is pure white" |
+| `accent-fg` | `#0B0B0B` | `Theme.Dark.primaryText = #0B0B0B` | `#0B0B0B` | Match — primary button text |
+| `success` | `#34C759` (legacy) | `Theme.Color.success = #34C759` | `#34C759` | Match. Legacy iOS green — avoid in new V2 surfaces. |
+| `warning` | `#FF9500` (legacy) | `Theme.Color.warning = #FF9500` | `#FF9500` | Match. Avoid in V2. |
+| `danger` | `#FF3B30` (legacy) | `Theme.Color.destructive = #FF3B30` | `#FF3B30` | Match. Used for destructive button variant. |
+| `border` | `rgba(255,255,255,0.08)` | `Theme.Dark.hairline = .white.opacity(0.08)` | white @ 0.08 | Match (rename `hairline` → `border`) |
+| `border-strong` | `rgba(255,255,255,0.16)` | `Theme.Dark.hairlineStrong = .white.opacity(0.16)` | white @ 0.16 | Match (rename `hairlineStrong` → `border-strong`) |
+
+**Untranslated DESIGN.md colors** (in DESIGN.md but no ODML slot — documented for posterity):
+- `Text Muted` (0.18 opacity) — too subtle for any of the named ODML colors. Defer.
+- `Card` (`rgba(255,255,255,0.04)`) — chala renderers will need to derive this from `bg-overlay` or accept a card-specific fill. Layer 2 `ODCard.swift` decision pending.
+- `Card Selected` (`rgba(255,255,255,0.12)`) — same as above; state, not token.
+- `Input Background` (`rgba(255,255,255,0.05)`) — input-specific, not a global token.
+- `Pill Background` (`rgba(255,255,255,0.10)`) — pill-specific.
+- iOS-blue `#007AFF` legacy — out of V2; do not propagate.
+
+---
+
+## Spacing reconciliation
+
+| Token | DESIGN.md | Theme.swift | tokens.json | Notes |
+|---|---|---|---|---|
+| `none` | (implicit) | (not present) | 0 | Filling the gap. |
+| `xs` | `4` | `Theme.Spacing.xs = 4` | 4 | Match |
+| `sm` | `8` | `Theme.Spacing.sm = 8` | 8 | Match |
+| `md` | `16` | `Theme.Spacing.md = 16` | 16 | Match |
+| `lg` | `24` | `Theme.Spacing.lg = 24` | 24 | Match |
+| `xl` | `32` | `Theme.Spacing.xl = 32` | 32 | Match |
+| `2xl` | `48` | `Theme.Spacing.xxl = 48` | 48 | **Rename: xxl → 2xl** per plan §10 locked decision. Breaking change to current Theme.Spacing callers — grep + replace required during Layer 0 iOS work. |
+| `3xl` | (not specified) | (not present) | 64 | **NEW.** Filling the ODML vocabulary slot. Value chosen as 2 × `lg`; needs validation when first used in a design. |
+
+---
+
+## Radius reconciliation
+
+| Token | DESIGN.md | Theme.swift | tokens.json | Notes |
+|---|---|---|---|---|
+| `none` | (implicit) | (not present) | 0 | Filling the gap. |
+| `sm` | `6` | `Theme.Radius.small = 6` | 6 | Match. (Theme.Radius also has `sharp = 2` — too subtle for ODML, omitted.) |
+| `md` | `8` | `Theme.Radius.card = 8`, `Theme.Radius.button = 8` | 8 | Both card and button share this value in V2. |
+| `lg` | `15` | `Theme.Radius.input = 15` | 15 | Match. The 15px non-power-of-2 is intentional (input rounding feels softer than card). |
+| `xl` | (not specified) | (not present) | 24 | **NEW.** For larger surfaces (sheets, hero cards). Needs validation. |
+| `full` | `9999` | `Theme.Radius.pill = 9999` | 9999 | Match — used for pills, avatars. |
+
+**Untranslated Theme.Radius values:**
+- `Theme.Radius.sharp = 2` — DESIGN.md §1 calls out "2px border radius on interactive elements (sharp, not rounded)". This is a chala-specific micro-radius that doesn't fit the ODML stepped scale. The Layer 2 SwiftUI `ODButton` may bake in `Theme.Radius.sharp` for primary buttons instead of using `radius="sm"` — a Layer 2 implementation decision, not a token gap.
+
+---
+
+## Typography reconciliation
+
+DESIGN.md scale (subset):
+
+| Role | Size | Weight | Font | Tracking | ODML mapping |
+|---|---|---|---|---|---|
+| Display | 42 | 500 | Geist | −0.02em | `display` |
+| Title | 36 | 500 | Geist | −0.02em | `title` |
+| Heading | 28-32 | 500 | Geist | −0.02em | (not in ODML v1 — use `title`) |
+| Subheading | 22-26 | 500 | Geist | −0.02em | `headline` |
+| Body | 14-15 | 400 | Geist | normal | `body` |
+| Label | 9-11 | 400 | GeistMono | +0.18em UPPERCASE | `caption` |
+| Numeric | variable | 500 | GeistMono | −0.02em tabular | (consumer-specific — apply `mono` family + tabular variant locally) |
+| Button | 13 | 500 | Geist | +0.12em UPPERCASE | (button-specific — baked into Layer 2 `ODButton`) |
+| Caption | 8-9 | 400 | GeistMono | +0.06em | (overlaps with `caption`; using `caption` for both) |
+
+**Coverage note:** ODML's 6 text styles are a coarser bucket than DESIGN.md's 9.
+The mid-tier "Heading" (28-32px) collapses into `title`; mid-tier "Caption"
+(8-9px) collapses into `caption`. The lost granularity is acceptable for v1
+of the dialect — adding stripes (`title-sm`, `caption-lg`) later is a
+backward-compatible extension.
+
+---
+
+## Open questions raised by this audit
+
+1. **`fg-faint` slot in v2?** DESIGN.md has `Text Muted = 0.18` which has no
+   ODML home. Three options: (a) add `fg-faint` to ODML vocab; (b) drop the
+   0.18-opacity tier; (c) treat it as an opacity modifier on top of `fg-subtle`.
+   No action this session; deferred to v2 dialect work.
+
+2. **`bg-overlay` opacity value** — I chose 0.06 as a reasonable midpoint.
+   Confirm with first design that consumes it.
+
+3. **3xl spacing + xl radius values** — both are new and need a design that
+   actually uses them before the values are validated.
+
+4. **Card/Input/Pill backgrounds** — these are component-specific surface
+   colors that don't fit the global palette cleanly. Recommend Layer 2 SwiftUI
+   `ODCard.swift` etc. bake in the 0.04/0.05/0.10 values as part of the
+   component's style, not as global tokens. Documented for Layer 2 plan.
+
+5. **Theme.Spacing.xxl → 2xl rename** is a breaking change to existing iOS
+   callers. Currently blocked on `chalaai/workout-exercise-swap` branch
+   resolution.

--- a/design-systems/chala-ai/tokens.css
+++ b/design-systems/chala-ai/tokens.css
@@ -1,0 +1,215 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/chala-ai/tokens.css
+ *
+ * Structured token bindings for "Chala.AI" — a matte-luxury / instrument
+ * design system: absolute black canvas, opacity-only depth, Geist
+ * typography at medium-500 with tight negative tracking, GeistMono
+ * for all uppercase chrome labels, 2px sharp radii on interactive
+ * elements, hairline borders only.
+ *
+ * This file pre-compiles the values described in `DESIGN.md` into the
+ * standard schema shared with all OD design systems (`--bg`, `--fg`,
+ * `--muted`, `--border`, `--accent`, etc.). Agents generating HTML
+ * artifacts against this brand should paste the unscoped `:root { ... }`
+ * block verbatim into the artifact's first `<style>` so every
+ * `var(--*)` reference resolves at runtime.
+ *
+ * Provenance — the chala-ai design system ships THREE machine-readable
+ * forms alongside `DESIGN.md`, serving different consumers:
+ *
+ *   tokens.css   — upstream OD daemon's loader / picker / system-prompt
+ *                  injection / lint consume this. Standard schema names
+ *                  (`--bg`, `--fg`, `--muted`, …) so the brand plays
+ *                  nicely with the rest of the OD ecosystem.
+ *   tokens.json  — ODML AST validator + per-platform translators
+ *                  (SwiftUI, future React/RN) consume this. DTCG-shape
+ *                  with ODML-specific token names (`bg`, `fg-muted`,
+ *                  `accent-fg`, `bg-elevated`, `bg-overlay`, …) that
+ *                  the `chala-ai-mobile` skill references via typed
+ *                  ODML attributes like `color="fg"` or `spacing="md"`.
+ *                  Token *values* mirror tokens.css; only the names
+ *                  differ to match each contract's idiom.
+ *   DESIGN.md    — Human-readable rationale. Source of intent;
+ *                  tokens.css and tokens.json are derived. When the
+ *                  three diverge, DESIGN.md wins for new decisions
+ *                  and the structured files are updated to match.
+ *
+ * Contract sources (matches default's):
+ *   - Standard token names: craft/color.md
+ *   - Display-face contract: craft/anti-ai-slop.md
+ *   - Lint enforcement: apps/daemon/src/lint-artifact.ts
+ *
+ * Schema notes (Chala collapses tiers where DESIGN.md doesn't
+ * differentiate, per default's pattern):
+ *   #Gap 1  — 4-level fg ramp; Chala has 3 distinct opacities + white,
+ *             so `--fg-2` aliases to a halfway value, others are direct.
+ *   #Gap 2  — 3-level surface; Chala has 2 (bg + bgRaised) plus an
+ *             opacity-driven overlay, so `--surface-warm` aliases.
+ *   #Gap 3  — 2-level border; Chala has hairline + hairlineStrong but
+ *             border-soft is the "lighter than default" tier — chala's
+ *             default border is already faint (8%), so `--border-soft`
+ *             aliases.
+ *   #Gap 4  — accent-hover bound to a value, not a formula. Chala's
+ *             accent is pure white on absolute black; darkening by
+ *             formula collapses to gray, so opacity-shift instead.
+ *   #Gap 5  — `--elev-ring` is a first-class elevation level used by
+ *             cards (1px hairline as primary lift).
+ *
+ * Keep this file in sync with `tokens.json` whenever values change —
+ * the JSON side carries the same numbers under ODML's naming. See
+ * `tokens-audit.md` for the cross-walk table.
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface (3 levels — #Gap 2) ────────────────────────────────
+   * Chala's identity is absolute black canvas. #050505 reads as the
+   * matte instrument-panel base; #0B0B0B is the single elevated
+   * tier (cards-on-cards, sheets). There is no third "warm" tier —
+   * any tertiary lift comes from the opacity-driven overlay below,
+   * so `--surface-warm` aliases to surface. */
+  --bg: #050505;
+  --surface: #0b0b0b;
+  --surface-warm: var(--surface);     /* alias — chala has no warm tier */
+
+  /* ─── Foreground ramp (4 levels — #Gap 1) ───────────────────────
+   * Per DESIGN.md §2: all foreground is white at varying opacity.
+   * `--fg-2` is a schema slot for a body-secondary tier between
+   * primary and muted; chala's V2 doesn't differentiate, so it
+   * aliases to `--fg`. `--meta` carries DESIGN.md's "Text Faint"
+   * tier used for labels and timestamps. */
+  --fg: #ffffff;
+  --fg-2: var(--fg);                  /* alias — chala has no secondary tier */
+  --muted: rgba(255, 255, 255, 0.55);
+  --meta: rgba(255, 255, 255, 0.32);
+
+  /* ─── Border (2 levels — #Gap 3) ────────────────────────────────
+   * Chala uses 1px hairlines exclusively. `--border` is 8% white;
+   * `--border-soft` aliases since the default is already at the
+   * "soft" end of chala's spectrum. The stronger 16% tier
+   * (hairline-strong in DESIGN.md) is exposed as `--elev-ring`
+   * below since its usage is structural-edge, not divider. */
+  --border: rgba(255, 255, 255, 0.08);
+  --border-soft: var(--border);       /* alias — chala has no softer tier */
+
+  /* ─── Accent (monochrome) ─────────────────────────────────────────
+   * Per DESIGN.md §2.Accent: "The system is monochrome; accent is
+   * pure white (used for active states, emphasis)." There is no
+   * chromatic accent. Primary fills land on `#E0E0E0` (slightly
+   * dimmed white to avoid glare on the absolute black) with
+   * `#0B0B0B` text on top — `--accent` carries that fill, and
+   * `--accent-on` carries the dark text.
+   *
+   * Hard cap from craft/color.md: at most 2 visible uses of
+   * `--accent` per screen. For chala this means: one primary CTA +
+   * (optionally) one chip or eyebrow. Active tab dots and focus
+   * rings count toward the cap. */
+  --accent: #e0e0e0;
+  --accent-on: #0b0b0b;
+
+  /* ─── Accent states (#Gap 4) ────────────────────────────────────
+   * Chala's accent is light gray on absolute black; the standard
+   * `color-mix(... black 8%)` formula used by default would darken
+   * toward dim gray that loses contrast with both the surface and
+   * the accent itself. Bind by value instead: hover steps to
+   * pure-white, active steps slightly back. */
+  --accent-hover: #ffffff;
+  --accent-active: rgba(255, 255, 255, 0.92);
+
+  /* ─── Semantic (legacy iOS palette, used sparingly) ──────────────
+   * Per DESIGN.md §2.Legacy: "iOS system, avoid in new V2 surfaces."
+   * Reserved for status badges and destructive button variant. Keep
+   * total semantic-color pixels under 5% of the surface per
+   * craft/color.md. */
+  --success: #34c759;
+  --warn: #ff9500;
+  --danger: #ff3b30;
+
+  /* ─── Typography ──────────────────────────────────────────────────
+   * Geist for headings and body, GeistMono for all uppercase chrome
+   * labels (tab bar, captions, timestamps, stats). Per DESIGN.md
+   * §3, GeistMono is used at +0.18em tracking with text-transform:
+   * uppercase for label roles. */
+  --font-display: 'Geist', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --font-body: 'Geist', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --font-mono: 'GeistMono', ui-monospace, 'SF Mono', Menlo, monospace;
+
+  /* Type scale (px) — direct copy of DESIGN.md §3 Typography table.
+   * Chala's display top is 42 (calorie counts, hero numerics); the
+   * --text-4xl slot extrapolates to 56 for any future
+   * super-display use. */
+  --text-xs: 10px;             /* DESIGN.md "Label" / "Caption" — uppercase mono */
+  --text-sm: 13px;             /* DESIGN.md "Button" — uppercase Geist */
+  --text-base: 15px;           /* DESIGN.md "Body" */
+  --text-lg: 22px;             /* DESIGN.md "Subheading" */
+  --text-xl: 28px;             /* DESIGN.md "Heading" lower bound */
+  --text-2xl: 36px;            /* DESIGN.md "Title" — screen headings */
+  --text-3xl: 42px;            /* DESIGN.md "Display" — hero numerics */
+  --text-4xl: 56px;            /* extrapolation; not in DESIGN.md yet */
+
+  --leading-body: 1.4;
+  --leading-tight: 1.15;
+  --tracking-display: -0.02em; /* DESIGN.md negative tracking on display roles */
+
+  /* ─── Spacing ─────────────────────────────────────────────────────
+   * 4px base unit, matching DESIGN.md §5 layout principles. No
+   * difference from default's scale. Section rhythm is tighter on
+   * iOS surfaces (chala's primary target) but kept at standard
+   * desktop/tablet/phone values here so web outputs land sensibly. */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+
+  --section-y-desktop: 80px;
+  --section-y-tablet: 48px;
+  --section-y-phone: 32px;
+
+  /* ─── Radius ──────────────────────────────────────────────────────
+   * Chala's hard rule (DESIGN.md §1): "2px border radius on
+   * interactive elements (sharp, not rounded)." This pushes
+   * --radius-sm down to 2px vs the default 8px — every
+   * button/input/chip uses the sharp value. Cards and modals can
+   * grow to 8 (md) for visual lift; the schema's --radius-lg is
+   * available for sheets but rarely used in chala. */
+  --radius-sm: 2px;
+  --radius-md: 8px;
+  --radius-lg: 15px;
+  --radius-pill: 9999px;
+
+  /* ─── Elevation (3 levels — #Gap 5) ─────────────────────────────
+   * Chala uses opacity-driven elevation, not blur. `--elev-flat` is
+   * the surface; `--elev-ring` is the 1px hairline that defines
+   * cards (chala's primary elevation cue); `--elev-raised` is a
+   * single white glow reserved for the primary CTA on the Landing
+   * screen per DESIGN.md §1 ("a single 0 0 16px rgba(255,255,255,0.08)
+   * glow on primary CTA on Landing only"). */
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px rgba(255, 255, 255, 0.16); /* DESIGN.md hairline-strong */
+  --elev-raised: 0 0 16px rgba(255, 255, 255, 0.08); /* Landing CTA only */
+
+  /* ─── Focus ring ──────────────────────────────────────────────────
+   * Required for accessibility per craft/accessibility-baseline.md.
+   * Chala's focus is white-at-32% to read as "active" against any
+   * surface tier without competing with the accent. */
+  --focus-ring: 0 0 0 3px rgba(255, 255, 255, 0.32);
+
+  /* ─── Motion ──────────────────────────────────────────────────────
+   * Short, purposeful transitions per anti-ai-slop. Chala values
+   * precision over flourish — no slow eases, no spring overshoot. */
+  --motion-fast: 150ms;
+  --motion-base: 200ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+  /* ─── Layout ──────────────────────────────────────────────────────
+   * Standard schema values; chala's primary surface is iOS portrait,
+   * where the container max is the device viewport. Web outputs in
+   * the chala-ai brand follow desktop conventions. */
+  --container-max: 1200px;
+  --container-gutter-desktop: 24px;
+  --container-gutter-tablet: 16px;
+  --container-gutter-phone: 12px;
+}

--- a/design-systems/chala-ai/tokens.json
+++ b/design-systems/chala-ai/tokens.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "https://design-tokens.github.io/community-group/format/",
+  "$description": "Chala.AI V2 design tokens (DTCG). Hand-authored seed v1; reconciled against design-systems/chala-ai/DESIGN.md and projects/Gym.AI/Chala.AI/apps/ios/ChalaAI/ChalaAI/Views/Components/Theme.swift on 2026-05-14. See tokens-audit.md for the reconciliation table. Future updates flow via tools/tokens-build/extract.ts (LLM extraction + human PR review).",
+  "color": {
+    "bg": {
+      "$value": "#050505",
+      "$type": "color",
+      "$description": "Absolute black canvas. Primary screen background."
+    },
+    "bg-elevated": {
+      "$value": "#0B0B0B",
+      "$type": "color",
+      "$description": "Slightly elevated surface — cards on cards, sheets, second tier."
+    },
+    "bg-overlay": {
+      "$value": "#FFFFFF",
+      "$type": "color",
+      "$description": "Opacity-only overlay surface. Use with opacity in the renderer — designers wanting a visible overlay should layer with a fill ~10% opacity.",
+      "$extensions": {
+        "com.open-design.opacity": 0.06
+      }
+    },
+    "fg": {
+      "$value": "#FFFFFF",
+      "$type": "color",
+      "$description": "Primary text and active-state foreground."
+    },
+    "fg-muted": {
+      "$value": "#FFFFFF",
+      "$type": "color",
+      "$description": "Body copy, secondary headings (55% opacity on bg).",
+      "$extensions": {
+        "com.open-design.opacity": 0.55
+      }
+    },
+    "fg-subtle": {
+      "$value": "#FFFFFF",
+      "$type": "color",
+      "$description": "Labels, metadata, timestamps (32% opacity on bg).",
+      "$extensions": {
+        "com.open-design.opacity": 0.32
+      }
+    },
+    "accent": {
+      "$value": "#FFFFFF",
+      "$type": "color",
+      "$description": "System is monochrome — accent is pure white. Used for primary fill backgrounds and active emphasis."
+    },
+    "accent-fg": {
+      "$value": "#0B0B0B",
+      "$type": "color",
+      "$description": "Foreground text on accent surfaces (e.g. primary button labels)."
+    },
+    "success": {
+      "$value": "#34C759",
+      "$type": "color",
+      "$description": "Legacy iOS green. Avoid in new V2 surfaces; reserved for status badges."
+    },
+    "warning": {
+      "$value": "#FF9500",
+      "$type": "color",
+      "$description": "Legacy iOS orange. Avoid in new V2 surfaces; reserved for status badges."
+    },
+    "danger": {
+      "$value": "#FF3B30",
+      "$type": "color",
+      "$description": "Legacy iOS red. Used for destructive button variant and danger badges."
+    },
+    "border": {
+      "$value": "#FFFFFF",
+      "$type": "color",
+      "$description": "Default hairline border (8% opacity on bg). All 1px borders use this.",
+      "$extensions": {
+        "com.open-design.opacity": 0.08
+      }
+    },
+    "border-strong": {
+      "$value": "#FFFFFF",
+      "$type": "color",
+      "$description": "Elevated border (16% opacity on bg) — interactive element rings.",
+      "$extensions": {
+        "com.open-design.opacity": 0.16
+      }
+    }
+  },
+  "spacing": {
+    "none": { "$value": "0", "$type": "dimension" },
+    "xs":   { "$value": "4",  "$type": "dimension" },
+    "sm":   { "$value": "8",  "$type": "dimension" },
+    "md":   { "$value": "16", "$type": "dimension" },
+    "lg":   { "$value": "24", "$type": "dimension" },
+    "xl":   { "$value": "32", "$type": "dimension" },
+    "2xl":  { "$value": "48", "$type": "dimension" },
+    "3xl":  { "$value": "64", "$type": "dimension" }
+  },
+  "radius": {
+    "none": { "$value": "0",    "$type": "dimension" },
+    "sm":   { "$value": "6",    "$type": "dimension" },
+    "md":   { "$value": "8",    "$type": "dimension" },
+    "lg":   { "$value": "15",   "$type": "dimension" },
+    "xl":   { "$value": "24",   "$type": "dimension" },
+    "full": { "$value": "9999", "$type": "dimension" }
+  },
+  "typography": {
+    "font-family": {
+      "sans": { "$value": "Geist", "$type": "fontFamily", "$description": "Primary UI font. 400/500/600/700 weights." },
+      "mono": { "$value": "GeistMono", "$type": "fontFamily", "$description": "All UI chrome — labels, timestamps, stats, tab bar." }
+    },
+    "style": {
+      "display":  { "$value": { "fontFamily": "{typography.font-family.sans}", "fontSize": "42", "fontWeight": "500", "letterSpacing": "-0.02em", "lineHeight": "1.1"  }, "$type": "typography", "$description": "Calorie counts, hero numerics." },
+      "title":    { "$value": { "fontFamily": "{typography.font-family.sans}", "fontSize": "36", "fontWeight": "500", "letterSpacing": "-0.02em", "lineHeight": "1.15" }, "$type": "typography", "$description": "Screen headings." },
+      "headline": { "$value": { "fontFamily": "{typography.font-family.sans}", "fontSize": "22", "fontWeight": "500", "letterSpacing": "-0.02em", "lineHeight": "1.2"  }, "$type": "typography", "$description": "Card headings, subheadings." },
+      "body":     { "$value": { "fontFamily": "{typography.font-family.sans}", "fontSize": "15", "fontWeight": "400", "letterSpacing": "0",       "lineHeight": "1.4"  }, "$type": "typography", "$description": "Descriptions, chat messages." },
+      "caption":  { "$value": { "fontFamily": "{typography.font-family.mono}", "fontSize": "10", "fontWeight": "400", "letterSpacing": "0.18em",  "lineHeight": "1.2",  "textCase": "uppercase" }, "$type": "typography", "$description": "Uppercase mono labels — UI chrome." },
+      "mono":     { "$value": { "fontFamily": "{typography.font-family.mono}", "fontSize": "14", "fontWeight": "400", "letterSpacing": "0",       "lineHeight": "1.3"  }, "$type": "typography", "$description": "Tabular numerics — stats, counts." }
+    }
+  },
+  "icon-size": {
+    "xs": { "$value": "12", "$type": "dimension" },
+    "sm": { "$value": "16", "$type": "dimension" },
+    "md": { "$value": "20", "$type": "dimension" },
+    "lg": { "$value": "28", "$type": "dimension" },
+    "xl": { "$value": "36", "$type": "dimension" }
+  },
+  "avatar-size": {
+    "sm": { "$value": "32", "$type": "dimension" },
+    "md": { "$value": "48", "$type": "dimension" },
+    "lg": { "$value": "72", "$type": "dimension" }
+  }
+}

--- a/packages/od-dialect/README.md
+++ b/packages/od-dialect/README.md
@@ -1,0 +1,29 @@
+# @open-design/od-dialect
+
+ODML (Open Design Markup Language) AST types, parser, and validator.
+
+## Why this package exists
+
+ODML is a restricted `<od-*>` HTML/XML dialect emitted by Open Design skills
+and consumed by per-platform translators (SwiftUI, React, React Native). The
+Layer 1 skill validator and the Layer 3 SwiftUI translator both depend on the
+same AST shape — without a shared package they would invent two different
+trees and integration would break.
+
+This package is the single source of truth. `src/ast.ts` defines:
+
+- The 20 element kinds in the ODML vocabulary v1.
+- The token enums (color, spacing, radius, text style, icon size, etc).
+- The bind-path / action-ref / value-or-bind value types.
+- The discriminated union of violations the validator can emit.
+
+## Boundary
+
+- Pure TypeScript, no runtime dependencies. Imported by both the skill
+  validator (browser/Node) and the Open Design daemon (Node).
+- No SwiftUI, no React, no platform-specific code. The translator packages
+  consume these AST types and emit platform-specific code from them.
+
+## Plan
+
+See `calm-floating-fern` plan §11 (precursor) for the design rationale.

--- a/packages/od-dialect/package.json
+++ b/packages/od-dialect/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@open-design/od-dialect",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "ODML (Open Design Markup Language) AST types, parser, and validator. Single source of truth for the dialect — both the Layer 1 skill validator and Layer 3 SwiftUI translator import from here.",
+  "main": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.mjs"
+    },
+    "./ast": {
+      "types": "./dist/ast.d.ts",
+      "default": "./dist/ast.mjs"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0"
+  }
+}

--- a/packages/od-dialect/src/ast.ts
+++ b/packages/od-dialect/src/ast.ts
@@ -1,0 +1,518 @@
+/**
+ * ODML (Open Design Markup Language) — AST types.
+ *
+ * Single source of truth for what's legal in ODML output. The Layer 1 skill
+ * validator and the Layer 3 SwiftUI translator both import from here. If they
+ * ever diverge on the AST shape, integration breaks; this file is the contract.
+ *
+ * Plan: `calm-floating-fern` §4 (vocabulary), §11 (precursor).
+ */
+
+// =============================================================================
+// Token enums — every styling value in ODML MUST be one of these (or a bind).
+// =============================================================================
+
+export const OD_COLORS = [
+  'bg',
+  'bg-elevated',
+  'bg-overlay',
+  'fg',
+  'fg-muted',
+  'fg-subtle',
+  'accent',
+  'accent-fg',
+  'success',
+  'warning',
+  'danger',
+  'border',
+  'border-strong',
+] as const;
+export type ODColor = (typeof OD_COLORS)[number];
+
+export const OD_SPACING = ['none', 'xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl'] as const;
+export type ODSpacing = (typeof OD_SPACING)[number];
+
+export const OD_RADIUS = ['none', 'sm', 'md', 'lg', 'xl', 'full'] as const;
+export type ODRadius = (typeof OD_RADIUS)[number];
+
+export const OD_TEXT_STYLES = [
+  'display',
+  'title',
+  'headline',
+  'body',
+  'caption',
+  'mono',
+] as const;
+export type ODTextStyle = (typeof OD_TEXT_STYLES)[number];
+
+export const OD_ICON_SIZES = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
+export type ODIconSize = (typeof OD_ICON_SIZES)[number];
+
+export const OD_AVATAR_SIZES = ['sm', 'md', 'lg'] as const;
+export type ODAvatarSize = (typeof OD_AVATAR_SIZES)[number];
+
+export const OD_BUTTON_VARIANTS = ['primary', 'secondary', 'ghost', 'destructive'] as const;
+export type ODButtonVariant = (typeof OD_BUTTON_VARIANTS)[number];
+
+export const OD_BUTTON_SIZES = ['sm', 'md', 'lg'] as const;
+export type ODButtonSize = (typeof OD_BUTTON_SIZES)[number];
+
+export const OD_BADGE_VARIANTS = ['neutral', 'success', 'warning', 'danger'] as const;
+export type ODBadgeVariant = (typeof OD_BADGE_VARIANTS)[number];
+
+export const OD_KEYBOARDS = ['default', 'email', 'number', 'decimal'] as const;
+export type ODKeyboard = (typeof OD_KEYBOARDS)[number];
+
+export const OD_PROGRESS_STYLES = ['bar', 'ring'] as const;
+export type ODProgressStyle = (typeof OD_PROGRESS_STYLES)[number];
+
+export const OD_STACK_DIRECTIONS = ['vertical', 'horizontal', 'z'] as const;
+export type ODStackDirection = (typeof OD_STACK_DIRECTIONS)[number];
+
+export const OD_ALIGNMENTS = ['leading', 'center', 'trailing'] as const;
+export type ODAlignment = (typeof OD_ALIGNMENTS)[number];
+
+export const OD_JUSTIFY = ['start', 'center', 'end', 'space-between'] as const;
+export type ODJustify = (typeof OD_JUSTIFY)[number];
+
+export const OD_DIRECTIONS_ALL = ['vertical', 'horizontal'] as const;
+export type ODScrollDirection = (typeof OD_DIRECTIONS_ALL)[number];
+
+export const OD_ORIENTATIONS = ['horizontal', 'vertical'] as const;
+export type ODOrientation = (typeof OD_ORIENTATIONS)[number];
+
+export const OD_SAFE_AREAS = ['all', 'top', 'bottom', 'none'] as const;
+export type ODSafeArea = (typeof OD_SAFE_AREAS)[number];
+
+export const OD_IMAGE_ASPECTS = ['square', 'portrait', 'landscape', 'fill'] as const;
+export type ODImageAspect = (typeof OD_IMAGE_ASPECTS)[number];
+
+// =============================================================================
+// Behaviour references — bind paths and action names are typed strings.
+// =============================================================================
+
+export interface ODBindPath {
+  /** Dotted path into the screen view model state, e.g. `"workout.name"` or
+   *  `"{workout}.name"` inside an <od-list item="workout"> template. */
+  readonly path: string;
+}
+
+export interface ODActionRef {
+  /** Kebab-case identifier the screen view model implements as a closure. */
+  readonly name: string;
+  /** Extra `data-*` attributes passed to the action as parameters. */
+  readonly data?: Readonly<Record<string, string>>;
+}
+
+/**
+ * Some attributes accept either a token literal OR a bind expression
+ * (e.g. `<od-progress value="0.5">` and `<od-progress value="bind:workout.progress">`).
+ */
+export type ODValueOrBind<T> =
+  | { readonly kind: 'literal'; readonly value: T }
+  | { readonly kind: 'bind'; readonly path: string };
+
+// =============================================================================
+// Source position — every node carries enough info for line/col error reports.
+// =============================================================================
+
+export interface ODSourcePosition {
+  readonly line: number; // 1-indexed
+  readonly col: number; // 1-indexed
+}
+
+export interface ODSourceSpan {
+  readonly start: ODSourcePosition;
+  readonly end: ODSourcePosition;
+}
+
+// =============================================================================
+// Tag union — every element in ODML is exactly one of these.
+// =============================================================================
+
+export type ODTagName =
+  | 'od-screen'
+  | 'od-stack'
+  | 'od-grid'
+  | 'od-scroll'
+  | 'od-card'
+  | 'od-spacer'
+  | 'od-divider'
+  | 'od-text'
+  | 'od-icon'
+  | 'od-image'
+  | 'od-avatar'
+  | 'od-badge'
+  | 'od-progress'
+  | 'od-button'
+  | 'od-input'
+  | 'od-toggle'
+  | 'od-list'
+  | 'od-nav-bar'
+  | 'od-tab-bar'
+  | 'od-sheet';
+
+export const OD_TAG_NAMES: readonly ODTagName[] = [
+  'od-screen',
+  'od-stack',
+  'od-grid',
+  'od-scroll',
+  'od-card',
+  'od-spacer',
+  'od-divider',
+  'od-text',
+  'od-icon',
+  'od-image',
+  'od-avatar',
+  'od-badge',
+  'od-progress',
+  'od-button',
+  'od-input',
+  'od-toggle',
+  'od-list',
+  'od-nav-bar',
+  'od-tab-bar',
+  'od-sheet',
+];
+
+// -----------------------------------------------------------------------------
+// Containers
+// -----------------------------------------------------------------------------
+
+export interface ODScreen {
+  readonly kind: 'od-screen';
+  readonly background?: ODColor;
+  readonly safeArea?: ODSafeArea;
+  readonly children: readonly ODElement[];
+  readonly span: ODSourceSpan;
+}
+
+export interface ODStack {
+  readonly kind: 'od-stack';
+  readonly direction: ODStackDirection;
+  readonly spacing?: ODSpacing;
+  readonly padding?: ODSpacing;
+  readonly align?: ODAlignment;
+  readonly justify?: ODJustify;
+  readonly children: readonly ODElement[];
+  readonly span: ODSourceSpan;
+}
+
+export interface ODGrid {
+  readonly kind: 'od-grid';
+  readonly columns: number;
+  readonly spacing?: ODSpacing;
+  readonly children: readonly ODElement[];
+  readonly span: ODSourceSpan;
+}
+
+export interface ODScroll {
+  readonly kind: 'od-scroll';
+  readonly direction: ODScrollDirection;
+  readonly children: readonly ODElement[];
+  readonly span: ODSourceSpan;
+}
+
+export interface ODCard {
+  readonly kind: 'od-card';
+  readonly padding?: ODSpacing;
+  readonly radius?: ODRadius;
+  readonly background?: ODColor;
+  readonly children: readonly ODElement[];
+  readonly span: ODSourceSpan;
+}
+
+export interface ODSpacerEl {
+  readonly kind: 'od-spacer';
+  readonly span: ODSourceSpan;
+}
+
+export interface ODDivider {
+  readonly kind: 'od-divider';
+  readonly orientation?: ODOrientation;
+  readonly span: ODSourceSpan;
+}
+
+// -----------------------------------------------------------------------------
+// Content
+// -----------------------------------------------------------------------------
+
+export interface ODText {
+  readonly kind: 'od-text';
+  readonly style: ODTextStyle;
+  readonly color?: ODColor;
+  readonly align?: ODAlignment;
+  /** Inline text content. Mutually exclusive with `bind`. */
+  readonly text?: string;
+  /** Bind to a string in the view-model. Mutually exclusive with `text`. */
+  readonly bind?: ODBindPath;
+  readonly span: ODSourceSpan;
+}
+
+export interface ODIcon {
+  readonly kind: 'od-icon';
+  readonly name: string; // SF Symbol name; not enumerated here — too many
+  readonly size?: ODIconSize;
+  readonly color?: ODColor;
+  readonly span: ODSourceSpan;
+}
+
+export interface ODImage {
+  readonly kind: 'od-image';
+  readonly source: string; // asset name; consumer-validated
+  readonly aspect?: ODImageAspect;
+  readonly radius?: ODRadius;
+  readonly span: ODSourceSpan;
+}
+
+export interface ODAvatar {
+  readonly kind: 'od-avatar';
+  readonly source: string;
+  readonly size?: ODAvatarSize;
+  readonly span: ODSourceSpan;
+}
+
+export interface ODBadge {
+  readonly kind: 'od-badge';
+  readonly variant: ODBadgeVariant;
+  readonly text: string | ODBindPath;
+  readonly span: ODSourceSpan;
+}
+
+export interface ODProgress {
+  readonly kind: 'od-progress';
+  readonly value: ODValueOrBind<number>;
+  readonly style: ODProgressStyle;
+  readonly span: ODSourceSpan;
+}
+
+// -----------------------------------------------------------------------------
+// Interactive
+// -----------------------------------------------------------------------------
+
+export interface ODButton {
+  readonly kind: 'od-button';
+  readonly variant: ODButtonVariant;
+  readonly size?: ODButtonSize;
+  readonly action: ODActionRef;
+  readonly disabled?: boolean;
+  /** Children must be ODText or ODIcon only — validator enforces. */
+  readonly children: readonly (ODText | ODIcon)[];
+  readonly span: ODSourceSpan;
+}
+
+export interface ODInput {
+  readonly kind: 'od-input';
+  readonly bind: ODBindPath;
+  readonly placeholder?: string;
+  readonly keyboard?: ODKeyboard;
+  readonly secure?: boolean;
+  readonly span: ODSourceSpan;
+}
+
+export interface ODToggle {
+  readonly kind: 'od-toggle';
+  readonly bind: ODBindPath;
+  readonly label: string;
+  readonly span: ODSourceSpan;
+}
+
+export interface ODList {
+  readonly kind: 'od-list';
+  /** Bind to an array in the view-model. */
+  readonly bind: ODBindPath;
+  /** Identifier used inside the template to reference the per-item record,
+   *  e.g. `item="workout"` lets the template say `bind="{workout}.name"`. */
+  readonly item: string;
+  /** Template — repeated once per element. May reference `{item}.field`. */
+  readonly template: readonly ODElement[];
+  readonly span: ODSourceSpan;
+}
+
+// -----------------------------------------------------------------------------
+// Navigation chrome
+// -----------------------------------------------------------------------------
+
+export interface ODNavBar {
+  readonly kind: 'od-nav-bar';
+  readonly title: string;
+  readonly leading?: ODActionRef;
+  readonly trailing?: ODActionRef;
+  readonly span: ODSourceSpan;
+}
+
+export interface ODTabBar {
+  readonly kind: 'od-tab-bar';
+  readonly tabs: readonly string[];
+  readonly active: string;
+  readonly span: ODSourceSpan;
+}
+
+export interface ODSheet {
+  readonly kind: 'od-sheet';
+  readonly action: ODActionRef;
+  /** State path that gates presentation, e.g. `"showWorkoutDetail"`. */
+  readonly present: ODBindPath;
+  readonly children: readonly ODElement[];
+  readonly span: ODSourceSpan;
+}
+
+// =============================================================================
+// Element union + tree root.
+// =============================================================================
+
+export type ODElement =
+  | ODScreen
+  | ODStack
+  | ODGrid
+  | ODScroll
+  | ODCard
+  | ODSpacerEl
+  | ODDivider
+  | ODText
+  | ODIcon
+  | ODImage
+  | ODAvatar
+  | ODBadge
+  | ODProgress
+  | ODButton
+  | ODInput
+  | ODToggle
+  | ODList
+  | ODNavBar
+  | ODTabBar
+  | ODSheet;
+
+export interface ODTree {
+  /** Always exactly one <od-screen> root per ODML document. */
+  readonly root: ODScreen;
+  /** Raw ODML source — preserved for error messages and diagnostics. */
+  readonly source: string;
+}
+
+// =============================================================================
+// Violations — every rejection has a typed kind + span so the LLM can be
+// re-prompted with a precise correction.
+// =============================================================================
+
+export type ODViolationKind =
+  | 'malformed-xml'
+  | 'unknown-tag'
+  | 'unknown-attribute'
+  | 'missing-required-attribute'
+  | 'unknown-token'
+  | 'literal-rejected'
+  | 'text-outside-od-text'
+  | 'wrong-root'
+  | 'multiple-roots'
+  | 'invalid-child'
+  | 'extra-content';
+
+export interface ODViolationBase {
+  readonly span: ODSourceSpan;
+  /** Human-readable message suitable for inclusion in a re-prompt to the LLM. */
+  readonly message: string;
+  /** Suggested correction, if the violation has a unique fix. */
+  readonly suggestion?: string;
+}
+
+export interface ODViolationMalformedXml extends ODViolationBase {
+  readonly kind: 'malformed-xml';
+  readonly detail: string;
+}
+
+export interface ODViolationUnknownTag extends ODViolationBase {
+  readonly kind: 'unknown-tag';
+  readonly tag: string;
+}
+
+export interface ODViolationUnknownAttribute extends ODViolationBase {
+  readonly kind: 'unknown-attribute';
+  readonly tag: ODTagName;
+  readonly attribute: string;
+}
+
+export interface ODViolationMissingRequiredAttribute extends ODViolationBase {
+  readonly kind: 'missing-required-attribute';
+  readonly tag: ODTagName;
+  readonly attribute: string;
+}
+
+export interface ODViolationUnknownToken extends ODViolationBase {
+  readonly kind: 'unknown-token';
+  readonly tag: ODTagName;
+  readonly attribute: string;
+  readonly tokenType: 'color' | 'spacing' | 'radius' | 'text-style' | 'icon-size' | 'avatar-size' | 'button-variant' | 'button-size' | 'badge-variant' | 'keyboard' | 'progress-style' | 'stack-direction' | 'alignment' | 'justify' | 'scroll-direction' | 'orientation' | 'safe-area' | 'image-aspect';
+  readonly value: string;
+}
+
+export interface ODViolationLiteralRejected extends ODViolationBase {
+  readonly kind: 'literal-rejected';
+  readonly tag: ODTagName;
+  readonly attribute: string;
+  readonly value: string;
+  /** Literal kind detected — used to compose the suggestion. */
+  readonly literalKind: 'hex-color' | 'rgba-color' | 'pixel' | 'rem' | 'em' | 'percent' | 'arbitrary-string';
+}
+
+export interface ODViolationTextOutsideOdText extends ODViolationBase {
+  readonly kind: 'text-outside-od-text';
+  readonly parent: ODTagName;
+  readonly text: string;
+}
+
+export interface ODViolationWrongRoot extends ODViolationBase {
+  readonly kind: 'wrong-root';
+  readonly got: string;
+}
+
+export interface ODViolationMultipleRoots extends ODViolationBase {
+  readonly kind: 'multiple-roots';
+  readonly count: number;
+}
+
+export interface ODViolationInvalidChild extends ODViolationBase {
+  readonly kind: 'invalid-child';
+  readonly parent: ODTagName;
+  readonly child: ODTagName | 'text';
+}
+
+export interface ODViolationExtraContent extends ODViolationBase {
+  readonly kind: 'extra-content';
+  readonly content: string;
+}
+
+export type ODViolation =
+  | ODViolationMalformedXml
+  | ODViolationUnknownTag
+  | ODViolationUnknownAttribute
+  | ODViolationMissingRequiredAttribute
+  | ODViolationUnknownToken
+  | ODViolationLiteralRejected
+  | ODViolationTextOutsideOdText
+  | ODViolationWrongRoot
+  | ODViolationMultipleRoots
+  | ODViolationInvalidChild
+  | ODViolationExtraContent;
+
+// =============================================================================
+// Parse / validate result envelopes.
+// =============================================================================
+
+export type ODParseResult =
+  | { readonly ok: true; readonly tree: ODTree }
+  | { readonly ok: false; readonly violations: readonly ODViolation[] };
+
+/**
+ * Re-prompt payload sent back to the LLM when the validator rejects output.
+ * Skill runner consumes this and constructs a follow-up message that includes
+ * the violations so the LLM learns the dialect from sharp, structured failures.
+ */
+export interface ODValidatorFeedback {
+  /** Number of violations across all categories. */
+  readonly violationCount: number;
+  /** Grouped by kind so the re-prompt can address whole categories at once. */
+  readonly violations: readonly ODViolation[];
+  /** Suggested corrected ODML when the violations have unique fixes. */
+  readonly suggestedFix?: string;
+}

--- a/packages/od-dialect/src/index.ts
+++ b/packages/od-dialect/src/index.ts
@@ -1,0 +1,1 @@
+export * from './ast.js';

--- a/packages/od-dialect/tsconfig.json
+++ b/packages/od-dialect/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,6 +306,12 @@ importers:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@24.12.2)(jsdom@29.1.1)(lightningcss@1.32.0)
 
+  packages/od-dialect:
+    devDependencies:
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+
   packages/platform:
     devDependencies:
       '@types/node':

--- a/scripts/guard.ts
+++ b/scripts/guard.ts
@@ -62,6 +62,12 @@ const residualAllowedExactPaths = new Set([
   "apps/packaged/esbuild.config.mjs",
   // Browser service workers must be served as JavaScript files.
   "apps/web/public/od-notifications-sw.js",
+  // ODML preview shim — registers <od-*> Web Components inside the skill's
+  // iframe preview. Must be served as a vanilla JS module to a no-build
+  // browser context; consumed by skills/chala-ai-mobile/assets/template.html
+  // via <script type="module" src="./od-elements.js">. Throwaway preview
+  // code; the SwiftUI translator does not read it.
+  "skills/chala-ai-mobile/assets/od-elements.js",
   // PostCSS loads Tailwind through a web-local .mjs compatibility config entry.
   "apps/web/postcss.config.mjs",
   "scripts/bake-html-ppt-examples.mjs",

--- a/skills/chala-ai-mobile/SKILL.md
+++ b/skills/chala-ai-mobile/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: chala-ai-mobile
+description: |
+  Generate Chala.AI iOS screen layouts in ODML (Open Design Markup Language) —
+  a restricted <od-*> XML dialect that maps 1:1 to SwiftUI. Output is parsed
+  by a translator and emitted as SwiftUI source; the translator rejects any
+  tag, attribute, or value not enumerated in this prompt.
+triggers:
+  - "chala"
+  - "chala.ai"
+  - "chala ai"
+  - "chala screen"
+  - "chala mobile"
+  - "fitness app screen"
+od:
+  mode: prototype
+  platform: mobile
+  scenario: design
+  preview:
+    type: html
+    entry: index.html
+  design_system:
+    requires: true
+    requires_name: chala-ai
+    sections: [color, typography, layout, components]
+---
+
+# Role
+
+You generate iOS screen layouts for Chala.AI in a restricted HTML dialect called ODML (Open Design Markup Language). Your output is parsed by a translator that emits SwiftUI source code. The translator rejects any tag, attribute, or value not listed in this prompt.
+
+# Hard rules
+
+1. Every tag MUST be in the `od-*` namespace. Never emit `<div>`, `<span>`, `<p>`, `<section>`, or any standard HTML tag. Never emit `<script>`, `<style>`, or inline event handlers.
+2. Every styling value MUST be a token name from the token tables below. Never emit hex colors, pixel values, rem values, or arbitrary strings in styling attributes. `color="#fff"` is wrong. `color="fg"` is right.
+3. Never emit `class`, `style`, `id`, or any Tailwind utility. Styling comes from typed attributes only.
+4. All user-visible text MUST be inside `<od-text>`. Text directly inside `<od-card>`, `<od-button>`, `<od-stack>` etc. is forbidden.
+5. Behavior is referenced by name, never implemented. `action="start-workout"` is correct. There is no JavaScript, no onClick, no data-binding syntax other than `bind="path.to.value"`.
+6. Output is one ODML tree per response, wrapped in a single `<od-screen>` root. No surrounding markdown, no code fences, no commentary.
+7. Output MUST be well-formed XML. Self-closing tags use `<od-spacer />`, every attribute is quoted, every opening tag has a matching close, no implicit boolean attributes (`disabled="true"` not `disabled`).
+
+# Component vocabulary
+
+You may use ONLY these tags. Unknown tags fail the build.
+
+## Containers
+
+`<od-screen background="<color>" safe-area="all|top|bottom|none">` — root, exactly one per output.
+
+`<od-stack direction="vertical|horizontal|z" spacing="<spacing>" padding="<spacing>" align="leading|center|trailing" justify="start|center|end|space-between">` — primary layout primitive. Vertical = VStack, horizontal = HStack, z = ZStack.
+
+`<od-grid columns="<int>" spacing="<spacing>">` — 2D grid. Use only when a stack genuinely cannot express the layout.
+
+`<od-scroll direction="vertical|horizontal">` — wraps content that exceeds the viewport.
+
+`<od-card padding="<spacing>" radius="<radius>" background="<color>">` — elevated surface.
+
+`<od-spacer />` — flexible space inside a stack.
+
+`<od-divider orientation="horizontal|vertical" />` — separator line.
+
+## Content
+
+`<od-text style="display|title|headline|body|caption|mono" color="<color>" align="leading|center|trailing">TEXT</od-text>` — all text.
+
+`<od-icon name="<sf-symbol>" size="xs|sm|md|lg|xl" color="<color>" />` — SF Symbol by name.
+
+`<od-image source="<asset-name>" aspect="square|portrait|landscape|fill" radius="<radius>" />` — image asset reference.
+
+`<od-avatar source="<asset-name>" size="sm|md|lg" />` — circular profile image.
+
+`<od-badge variant="neutral|success|warning|danger" text="<string>" />` — small status label.
+
+`<od-progress value="<0-1 or bind:path>" style="bar|ring" />` — progress indicator.
+
+## Interactive
+
+`<od-button variant="primary|secondary|ghost|destructive" size="sm|md|lg" action="<action-name>" disabled="true|false">CHILDREN</od-button>` — tappable. Children must be `<od-text>` and/or `<od-icon>`.
+
+`<od-input bind="<path>" placeholder="<string>" keyboard="default|email|number|decimal" secure="true|false" />` — text field.
+
+`<od-toggle bind="<path>" label="<string>" />` — switch.
+
+`<od-list bind="<path-to-array>" item="<item-name>">TEMPLATE</od-list>` — repeats TEMPLATE for each element. Inside TEMPLATE, reference the element as `{item-name}.field` in `bind` attributes.
+
+## Navigation chrome
+
+`<od-nav-bar title="<string>" leading="<action-name?>" trailing="<action-name?>" />` — top bar; place as first child of `od-screen`.
+
+`<od-tab-bar tabs="home,calendar,history,profile" active="<tab-name>" />` — bottom tab bar; place as last child of `od-screen`.
+
+`<od-sheet action="<action-name>" present="<state-path>">CONTENT</od-sheet>` — modal sheet.
+
+# Token tables
+
+You may use ONLY these token values. Anything else is rejected.
+
+## Colors
+
+`bg` `bg-elevated` `bg-overlay` `fg` `fg-muted` `fg-subtle` `accent` `accent-fg` `success` `warning` `danger` `border` `border-strong`
+
+## Spacing
+
+`none` `xs` `sm` `md` `lg` `xl` `2xl` `3xl`
+
+## Radius
+
+`none` `sm` `md` `lg` `xl` `full`
+
+## Text styles
+
+`display` `title` `headline` `body` `caption` `mono`
+
+# Behavior references
+
+`action="<name>"` — kebab-case identifier the SwiftUI view model implements as a closure. Examples: `start-workout`, `open-settings`, `delete-entry`. Never describe what the action does in the name beyond its semantic intent.
+
+`bind="<dotted.path>"` — kebab-or-camel dotted path into the view model's state. Examples: `bind="user.name"`, `bind="workout.duration-minutes"`. Inside `<od-list item="X">` templates, paths may start with `{X}.`.
+
+Extra data passed to actions uses `data-*` attributes: `<od-button action="open-workout" data-workout-id="{workout}.id">`. The translator emits these as parameters.
+
+# Correct examples
+
+## A workout card
+
+```xml
+<od-card padding="md" radius="lg">
+  <od-stack direction="horizontal" spacing="sm" align="center">
+    <od-icon name="dumbbell" size="md" color="accent" />
+    <od-stack direction="vertical" spacing="xs">
+      <od-text style="headline">Push day</od-text>
+      <od-text style="caption" color="fg-muted">45 min · 6 exercises</od-text>
+    </od-stack>
+    <od-spacer />
+    <od-button variant="ghost" action="open-workout" data-workout-id="w_123">
+      <od-icon name="chevron-right" size="sm" color="fg-muted" />
+    </od-button>
+  </od-stack>
+</od-card>
+```
+
+## A list bound to data
+
+```xml
+<od-list bind="workouts" item="workout">
+  <od-card padding="md" radius="lg">
+    <od-stack direction="horizontal" spacing="sm" align="center">
+      <od-text style="headline" bind="{workout}.name" />
+      <od-spacer />
+      <od-badge variant="neutral" text="{workout}.duration-label" />
+    </od-stack>
+  </od-card>
+</od-list>
+```
+
+## A primary CTA
+
+```xml
+<od-button variant="primary" size="lg" action="start-workout">
+  <od-text style="headline" color="accent-fg">Start workout</od-text>
+</od-button>
+```
+
+# Wrong examples (the translator rejects all of these)
+
+WRONG — raw HTML tag:
+`<div class="card">...</div>`
+
+WRONG — literal color:
+`<od-text color="#888">Hi</od-text>`
+
+WRONG — literal spacing:
+`<od-stack spacing="12px">`
+
+WRONG — text outside od-text:
+`<od-card padding="md">Hello world</od-card>`
+
+WRONG — inline behavior:
+`<od-button onclick="startWorkout()">Go</od-button>`
+
+WRONG — unknown tag:
+`<od-flex>...</od-flex>`
+
+WRONG — style attribute:
+`<od-stack style="background: red">`
+
+# Output contract
+
+Respond with exactly one `<od-screen>` element and its descendants. No code fences, no prose, no explanation. The very first character of your response is `<` and the very last is `>`.

--- a/skills/chala-ai-mobile/assets/od-elements.js
+++ b/skills/chala-ai-mobile/assets/od-elements.js
@@ -1,0 +1,562 @@
+/**
+ * od-elements.js — Web Component preview shims for ODML.
+ *
+ * Purpose: render <od-*> tags inside the daemon's preview iframe so designers
+ * see something visual when reviewing skill output. THIS FILE IS THROWAWAY
+ * PREVIEW CODE — the SwiftUI translator never reads it. The contract is
+ * defined by ODML's SKILL.md, not by these shims.
+ *
+ * Tokens are wired via CSS custom properties on :host with names that mirror
+ * design-systems/chala-ai/tokens.json. Update tokens.css (generated from
+ * tokens.json) if you change the palette; do not edit values here.
+ */
+
+const TOKEN_CSS = `
+:host {
+  /* Colors */
+  --od-bg: #050505;
+  --od-bg-elevated: #0B0B0B;
+  --od-bg-overlay: rgba(255, 255, 255, 0.06);
+  --od-fg: #FFFFFF;
+  --od-fg-muted: rgba(255, 255, 255, 0.55);
+  --od-fg-subtle: rgba(255, 255, 255, 0.32);
+  --od-accent: #FFFFFF;
+  --od-accent-fg: #0B0B0B;
+  --od-success: #34C759;
+  --od-warning: #FF9500;
+  --od-danger: #FF3B30;
+  --od-border: rgba(255, 255, 255, 0.08);
+  --od-border-strong: rgba(255, 255, 255, 0.16);
+
+  /* Spacing */
+  --od-space-none: 0px;
+  --od-space-xs: 4px;
+  --od-space-sm: 8px;
+  --od-space-md: 16px;
+  --od-space-lg: 24px;
+  --od-space-xl: 32px;
+  --od-space-2xl: 48px;
+  --od-space-3xl: 64px;
+
+  /* Radius */
+  --od-radius-none: 0px;
+  --od-radius-sm: 6px;
+  --od-radius-md: 8px;
+  --od-radius-lg: 15px;
+  --od-radius-xl: 24px;
+  --od-radius-full: 9999px;
+
+  /* Typography */
+  --od-font-sans: 'Geist', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --od-font-mono: 'GeistMono', ui-monospace, 'SFMono-Regular', Menlo, monospace;
+
+  display: block;
+  color: var(--od-fg);
+}
+`;
+
+const TEXT_STYLES = {
+  display: 'font-family: var(--od-font-sans); font-size: 42px; font-weight: 500; letter-spacing: -0.02em; line-height: 1.1;',
+  title: 'font-family: var(--od-font-sans); font-size: 36px; font-weight: 500; letter-spacing: -0.02em; line-height: 1.15;',
+  headline: 'font-family: var(--od-font-sans); font-size: 22px; font-weight: 500; letter-spacing: -0.02em; line-height: 1.2;',
+  body: 'font-family: var(--od-font-sans); font-size: 15px; font-weight: 400; line-height: 1.4;',
+  caption: 'font-family: var(--od-font-mono); font-size: 10px; font-weight: 400; letter-spacing: 0.18em; text-transform: uppercase;',
+  mono: 'font-family: var(--od-font-mono); font-size: 14px; font-weight: 400;',
+};
+
+const ALIGN_MAP = { leading: 'flex-start', center: 'center', trailing: 'flex-end' };
+const JUSTIFY_MAP = {
+  start: 'flex-start',
+  center: 'center',
+  end: 'flex-end',
+  'space-between': 'space-between',
+};
+const ICON_SIZE = { xs: 12, sm: 16, md: 20, lg: 28, xl: 36 };
+const AVATAR_SIZE = { sm: 32, md: 48, lg: 72 };
+const BUTTON_SIZE_PADDING = {
+  sm: '6px 12px',
+  md: '10px 16px',
+  lg: '14px 20px',
+};
+
+function tokenStyle(prefix, name) {
+  return name ? `var(--od-${prefix}-${name})` : null;
+}
+
+function makeBase(tagName, content, hostStyle = '') {
+  return class extends HTMLElement {
+    connectedCallback() {
+      if (this.shadowRoot) return;
+      const shadow = this.attachShadow({ mode: 'open' });
+      shadow.innerHTML = `<style>${TOKEN_CSS}${hostStyle}</style>${content(this)}`;
+    }
+  };
+}
+
+/* --------------------------- Containers --------------------------- */
+
+customElements.define('od-screen', class extends HTMLElement {
+  connectedCallback() {
+    if (this.shadowRoot) return;
+    const bg = this.getAttribute('background');
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <style>
+        ${TOKEN_CSS}
+        :host {
+          display: flex;
+          flex-direction: column;
+          width: 100%;
+          min-height: 100vh;
+          background: ${tokenStyle('bg', bg === 'bg-elevated' ? 'elevated' : bg === 'bg-overlay' ? 'overlay' : '') || 'var(--od-bg)'};
+          padding: 60px 0 80px;
+          box-sizing: border-box;
+        }
+      </style>
+      <slot></slot>
+    `;
+  }
+});
+
+customElements.define('od-stack', class extends HTMLElement {
+  connectedCallback() {
+    if (this.shadowRoot) return;
+    const direction = this.getAttribute('direction') || 'vertical';
+    const spacing = this.getAttribute('spacing') || 'none';
+    const padding = this.getAttribute('padding') || 'none';
+    const align = this.getAttribute('align') || 'leading';
+    const justify = this.getAttribute('justify') || 'start';
+    const flexDir = direction === 'horizontal' ? 'row' : direction === 'z' ? null : 'column';
+
+    const shadow = this.attachShadow({ mode: 'open' });
+    if (direction === 'z') {
+      shadow.innerHTML = `
+        <style>${TOKEN_CSS}
+          :host { display: grid; padding: var(--od-space-${padding}); }
+          :host > ::slotted(*) { grid-area: 1 / 1; }
+        </style>
+        <slot></slot>
+      `;
+    } else {
+      shadow.innerHTML = `
+        <style>${TOKEN_CSS}
+          :host {
+            display: flex;
+            flex-direction: ${flexDir};
+            gap: var(--od-space-${spacing});
+            padding: var(--od-space-${padding});
+            align-items: ${ALIGN_MAP[align] || 'flex-start'};
+            justify-content: ${JUSTIFY_MAP[justify] || 'flex-start'};
+            box-sizing: border-box;
+          }
+        </style>
+        <slot></slot>
+      `;
+    }
+  }
+});
+
+customElements.define('od-grid', class extends HTMLElement {
+  connectedCallback() {
+    if (this.shadowRoot) return;
+    const cols = this.getAttribute('columns') || '2';
+    const spacing = this.getAttribute('spacing') || 'none';
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <style>${TOKEN_CSS}
+        :host {
+          display: grid;
+          grid-template-columns: repeat(${cols}, minmax(0, 1fr));
+          gap: var(--od-space-${spacing});
+        }
+      </style>
+      <slot></slot>
+    `;
+  }
+});
+
+customElements.define('od-scroll', class extends HTMLElement {
+  connectedCallback() {
+    if (this.shadowRoot) return;
+    const direction = this.getAttribute('direction') || 'vertical';
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <style>${TOKEN_CSS}
+        :host {
+          display: block;
+          overflow-${direction === 'horizontal' ? 'x' : 'y'}: auto;
+          max-${direction === 'horizontal' ? 'width' : 'height'}: 100%;
+        }
+      </style>
+      <slot></slot>
+    `;
+  }
+});
+
+customElements.define('od-card', class extends HTMLElement {
+  connectedCallback() {
+    if (this.shadowRoot) return;
+    const padding = this.getAttribute('padding') || 'md';
+    const radius = this.getAttribute('radius') || 'md';
+    const bg = this.getAttribute('background');
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <style>${TOKEN_CSS}
+        :host {
+          display: block;
+          padding: var(--od-space-${padding});
+          border-radius: var(--od-radius-${radius});
+          background: ${bg ? tokenStyle('bg', bg === 'bg-elevated' ? 'elevated' : bg === 'bg-overlay' ? 'overlay' : '') : 'rgba(255,255,255,0.04)'};
+          border: 1px solid var(--od-border);
+        }
+      </style>
+      <slot></slot>
+    `;
+  }
+});
+
+customElements.define('od-spacer', class extends HTMLElement {
+  connectedCallback() {
+    if (this.shadowRoot) return;
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `<style>:host { display: block; flex: 1; }</style>`;
+  }
+});
+
+customElements.define('od-divider', class extends HTMLElement {
+  connectedCallback() {
+    if (this.shadowRoot) return;
+    const orientation = this.getAttribute('orientation') || 'horizontal';
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <style>${TOKEN_CSS}
+        :host {
+          display: block;
+          background: var(--od-border);
+          ${orientation === 'horizontal' ? 'height: 1px; width: 100%;' : 'width: 1px; height: 100%;'}
+        }
+      </style>
+    `;
+  }
+});
+
+/* --------------------------- Content --------------------------- */
+
+customElements.define('od-text', class extends HTMLElement {
+  connectedCallback() {
+    if (this.shadowRoot) return;
+    const style = this.getAttribute('style-name') || this.getAttribute('style') || 'body';
+    const color = this.getAttribute('color') || 'fg';
+    const align = this.getAttribute('align') || 'leading';
+    const bind = this.getAttribute('bind');
+    const text = bind ? `{${bind}}` : this.textContent;
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <style>${TOKEN_CSS}
+        :host {
+          display: inline-block;
+          ${TEXT_STYLES[style] || TEXT_STYLES.body}
+          color: ${tokenStyle('', color === 'fg-muted' ? 'fg-muted' : color === 'fg-subtle' ? 'fg-subtle' : color)};
+          text-align: ${align === 'leading' ? 'left' : align === 'trailing' ? 'right' : 'center'};
+        }
+      </style>
+      <span>${text}</span>
+    `;
+  }
+});
+
+customElements.define('od-icon', class extends HTMLElement {
+  connectedCallback() {
+    if (this.shadowRoot) return;
+    const name = this.getAttribute('name') || 'square';
+    const size = this.getAttribute('size') || 'md';
+    const color = this.getAttribute('color') || 'fg';
+    const px = ICON_SIZE[size] || 20;
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <style>${TOKEN_CSS}
+        :host {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          width: ${px}px;
+          height: ${px}px;
+          color: ${tokenStyle('', color === 'fg-muted' ? 'fg-muted' : color === 'fg-subtle' ? 'fg-subtle' : color)};
+          font-family: var(--od-font-mono);
+          font-size: ${Math.round(px * 0.5)}px;
+          letter-spacing: 0;
+        }
+      </style>
+      <span title="${name}">${'□'}</span>
+    `;
+  }
+});
+
+customElements.define('od-image', class extends HTMLElement {
+  connectedCallback() {
+    if (this.shadowRoot) return;
+    const aspect = this.getAttribute('aspect') || 'square';
+    const radius = this.getAttribute('radius') || 'none';
+    const ratio = { square: '1 / 1', portrait: '3 / 4', landscape: '16 / 9', fill: '1 / 1' }[aspect];
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <style>${TOKEN_CSS}
+        :host {
+          display: block;
+          aspect-ratio: ${ratio};
+          background: var(--od-bg-elevated);
+          border-radius: var(--od-radius-${radius});
+          border: 1px solid var(--od-border);
+        }
+      </style>
+    `;
+  }
+});
+
+customElements.define('od-avatar', class extends HTMLElement {
+  connectedCallback() {
+    if (this.shadowRoot) return;
+    const size = this.getAttribute('size') || 'md';
+    const px = AVATAR_SIZE[size] || 48;
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <style>${TOKEN_CSS}
+        :host {
+          display: inline-block;
+          width: ${px}px;
+          height: ${px}px;
+          border-radius: 50%;
+          background: var(--od-bg-elevated);
+          border: 1px solid var(--od-border);
+        }
+      </style>
+    `;
+  }
+});
+
+customElements.define('od-badge', class extends HTMLElement {
+  connectedCallback() {
+    if (this.shadowRoot) return;
+    const variant = this.getAttribute('variant') || 'neutral';
+    const text = this.getAttribute('text') || '';
+    const bg = {
+      neutral: 'rgba(255,255,255,0.10)',
+      success: 'var(--od-success)',
+      warning: 'var(--od-warning)',
+      danger: 'var(--od-danger)',
+    }[variant];
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <style>${TOKEN_CSS}
+        :host {
+          display: inline-block;
+          padding: 2px 8px;
+          background: ${bg};
+          color: var(--od-fg);
+          ${TEXT_STYLES.caption}
+          border-radius: var(--od-radius-full);
+        }
+      </style>
+      <span>${text}</span>
+    `;
+  }
+});
+
+customElements.define('od-progress', class extends HTMLElement {
+  connectedCallback() {
+    if (this.shadowRoot) return;
+    const value = parseFloat(this.getAttribute('value') || '0') || 0;
+    const style = this.getAttribute('style-name') || this.getAttribute('progress-style') || this.getAttribute('style') || 'bar';
+    const shadow = this.attachShadow({ mode: 'open' });
+    if (style === 'ring') {
+      shadow.innerHTML = `
+        <style>${TOKEN_CSS}
+          :host {
+            display: inline-block;
+            width: 48px;
+            height: 48px;
+            border-radius: 50%;
+            background: conic-gradient(var(--od-accent) ${value * 360}deg, var(--od-border) 0);
+          }
+        </style>
+      `;
+    } else {
+      shadow.innerHTML = `
+        <style>${TOKEN_CSS}
+          :host { display: block; width: 100%; height: 4px; background: var(--od-border); border-radius: var(--od-radius-full); }
+          .fill { width: ${Math.max(0, Math.min(1, value)) * 100}%; height: 100%; background: var(--od-accent); border-radius: var(--od-radius-full); }
+        </style>
+        <div class="fill"></div>
+      `;
+    }
+  }
+});
+
+/* --------------------------- Interactive --------------------------- */
+
+customElements.define('od-button', class extends HTMLElement {
+  connectedCallback() {
+    if (this.shadowRoot) return;
+    const variant = this.getAttribute('variant') || 'primary';
+    const size = this.getAttribute('size') || 'md';
+    const disabled = this.getAttribute('disabled') === 'true';
+
+    const bg = {
+      primary: 'var(--od-accent)',
+      secondary: 'var(--od-bg-elevated)',
+      ghost: 'transparent',
+      destructive: 'var(--od-danger)',
+    }[variant];
+    const fg = {
+      primary: 'var(--od-accent-fg)',
+      secondary: 'var(--od-fg)',
+      ghost: 'var(--od-fg)',
+      destructive: 'var(--od-fg)',
+    }[variant];
+
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <style>${TOKEN_CSS}
+        :host {
+          display: inline-flex;
+          align-items: center;
+          gap: var(--od-space-xs);
+          padding: ${BUTTON_SIZE_PADDING[size] || BUTTON_SIZE_PADDING.md};
+          background: ${bg};
+          color: ${fg};
+          border: ${variant === 'ghost' ? '1px solid var(--od-border)' : 'none'};
+          border-radius: var(--od-radius-md);
+          cursor: pointer;
+          font-family: var(--od-font-sans);
+          font-size: 13px;
+          font-weight: 500;
+          letter-spacing: 0.12em;
+          text-transform: uppercase;
+          opacity: ${disabled ? '0.4' : '1'};
+          pointer-events: ${disabled ? 'none' : 'auto'};
+        }
+      </style>
+      <slot></slot>
+    `;
+  }
+});
+
+customElements.define('od-input', class extends HTMLElement {
+  connectedCallback() {
+    if (this.shadowRoot) return;
+    const placeholder = this.getAttribute('placeholder') || '';
+    const secure = this.getAttribute('secure') === 'true';
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <style>${TOKEN_CSS}
+        :host { display: block; }
+        input {
+          width: 100%;
+          padding: 12px 14px;
+          background: rgba(255, 255, 255, 0.05);
+          border: 1px solid var(--od-border);
+          border-radius: var(--od-radius-md);
+          color: var(--od-fg);
+          font-family: var(--od-font-sans);
+          font-size: 15px;
+          box-sizing: border-box;
+        }
+        input::placeholder { color: var(--od-fg-subtle); }
+      </style>
+      <input type="${secure ? 'password' : 'text'}" placeholder="${placeholder}" />
+    `;
+  }
+});
+
+customElements.define('od-toggle', class extends HTMLElement {
+  connectedCallback() {
+    if (this.shadowRoot) return;
+    const label = this.getAttribute('label') || '';
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <style>${TOKEN_CSS}
+        :host { display: flex; align-items: center; justify-content: space-between; gap: var(--od-space-md); }
+        .label { ${TEXT_STYLES.body} color: var(--od-fg); }
+        .track { width: 44px; height: 26px; background: var(--od-bg-elevated); border: 1px solid var(--od-border); border-radius: 13px; position: relative; }
+        .knob { position: absolute; top: 2px; left: 2px; width: 20px; height: 20px; background: var(--od-fg); border-radius: 50%; }
+      </style>
+      <span class="label">${label}</span>
+      <span class="track"><span class="knob"></span></span>
+    `;
+  }
+});
+
+customElements.define('od-list', class extends HTMLElement {
+  connectedCallback() {
+    if (this.shadowRoot) return;
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <style>${TOKEN_CSS}
+        :host { display: flex; flex-direction: column; gap: var(--od-space-sm); }
+      </style>
+      <slot></slot>
+    `;
+  }
+});
+
+/* --------------------------- Chrome --------------------------- */
+
+customElements.define('od-nav-bar', class extends HTMLElement {
+  connectedCallback() {
+    if (this.shadowRoot) return;
+    const title = this.getAttribute('title') || '';
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <style>${TOKEN_CSS}
+        :host {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          height: 44px;
+          padding: 0 var(--od-space-md);
+          ${TEXT_STYLES.body}
+          color: var(--od-fg);
+        }
+      </style>
+      <span>${title}</span>
+    `;
+  }
+});
+
+customElements.define('od-tab-bar', class extends HTMLElement {
+  connectedCallback() {
+    if (this.shadowRoot) return;
+    const tabs = (this.getAttribute('tabs') || '').split(',').map((t) => t.trim()).filter(Boolean);
+    const active = this.getAttribute('active') || '';
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <style>${TOKEN_CSS}
+        :host {
+          display: flex;
+          justify-content: space-around;
+          padding: var(--od-space-sm) var(--od-space-md);
+          border-top: 1px solid var(--od-border);
+          ${TEXT_STYLES.caption}
+        }
+        .tab { color: var(--od-fg-subtle); }
+        .tab.active { color: var(--od-fg); }
+        .tab.active .dot { background: var(--od-fg); }
+        .dot { display: block; width: 4px; height: 4px; border-radius: 50%; background: transparent; margin: 4px auto 0; }
+      </style>
+      ${tabs.map((t) => `<span class="tab${t === active ? ' active' : ''}">${t}<span class="dot"></span></span>`).join('')}
+    `;
+  }
+});
+
+customElements.define('od-sheet', class extends HTMLElement {
+  connectedCallback() {
+    if (this.shadowRoot) return;
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = `
+      <style>${TOKEN_CSS}
+        :host { display: none; }
+      </style>
+      <slot></slot>
+    `;
+  }
+});

--- a/skills/chala-ai-mobile/assets/od-elements.js
+++ b/skills/chala-ai-mobile/assets/od-elements.js
@@ -9,6 +9,15 @@
  * Tokens are wired via CSS custom properties on :host with names that mirror
  * design-systems/chala-ai/tokens.json. Update tokens.css (generated from
  * tokens.json) if you change the palette; do not edit values here.
+ *
+ * Safety: this file runs inside the daemon's preview iframe which has
+ * sandbox="allow-scripts". Any user-authored ODML attribute or text gets
+ * scriptable powers if interpolated into innerHTML, so every user-supplied
+ * string (od-text content, od-badge text, od-input placeholder, od-toggle
+ * label, od-nav-bar title, od-tab-bar tab names, od-icon name attribute)
+ * is set via textContent / setAttribute / Element.dataset rather than
+ * concatenated into a template literal. Static CSS that has no user
+ * interpolation still uses innerHTML.
  */
 
 const TOKEN_CSS = `
@@ -79,18 +88,38 @@ const BUTTON_SIZE_PADDING = {
   lg: '14px 20px',
 };
 
-function tokenStyle(prefix, name) {
-  return name ? `var(--od-${prefix}-${name})` : null;
-}
+// Full ODColor enum from SKILL.md / packages/od-dialect/src/ast.ts. Every
+// allowed background / color attribute value must round-trip through
+// this set so the preview resolves the same token the prompt permits,
+// instead of silently falling back to a default that hides off-token
+// inputs in review.
+const OD_COLORS = new Set([
+  'bg',
+  'bg-elevated',
+  'bg-overlay',
+  'fg',
+  'fg-muted',
+  'fg-subtle',
+  'accent',
+  'accent-fg',
+  'success',
+  'warning',
+  'danger',
+  'border',
+  'border-strong',
+]);
 
-function makeBase(tagName, content, hostStyle = '') {
-  return class extends HTMLElement {
-    connectedCallback() {
-      if (this.shadowRoot) return;
-      const shadow = this.attachShadow({ mode: 'open' });
-      shadow.innerHTML = `<style>${TOKEN_CSS}${hostStyle}</style>${content(this)}`;
-    }
-  };
+/**
+ * Resolve an ODColor token name to its CSS custom-property reference.
+ * Unknown tokens return null so callers can decide whether to fall back
+ * (od-screen uses `var(--od-bg)`) or omit the declaration (od-card uses
+ * its 4%-white card surface). Never return a constructed `var(--od-X)`
+ * for an off-token name — that would mask invalid ODML in preview.
+ */
+function colorVar(token) {
+  if (!token) return null;
+  if (!OD_COLORS.has(token)) return null;
+  return `var(--od-${token})`;
 }
 
 /* --------------------------- Containers --------------------------- */
@@ -99,6 +128,7 @@ customElements.define('od-screen', class extends HTMLElement {
   connectedCallback() {
     if (this.shadowRoot) return;
     const bg = this.getAttribute('background');
+    const bgValue = colorVar(bg) || 'var(--od-bg)';
     const shadow = this.attachShadow({ mode: 'open' });
     shadow.innerHTML = `
       <style>
@@ -108,7 +138,7 @@ customElements.define('od-screen', class extends HTMLElement {
           flex-direction: column;
           width: 100%;
           min-height: 100vh;
-          background: ${tokenStyle('bg', bg === 'bg-elevated' ? 'elevated' : bg === 'bg-overlay' ? 'overlay' : '') || 'var(--od-bg)'};
+          background: ${bgValue};
           padding: 60px 0 80px;
           box-sizing: border-box;
         }
@@ -159,7 +189,7 @@ customElements.define('od-stack', class extends HTMLElement {
 customElements.define('od-grid', class extends HTMLElement {
   connectedCallback() {
     if (this.shadowRoot) return;
-    const cols = this.getAttribute('columns') || '2';
+    const cols = Math.max(1, Math.min(12, parseInt(this.getAttribute('columns') || '2', 10) || 2));
     const spacing = this.getAttribute('spacing') || 'none';
     const shadow = this.attachShadow({ mode: 'open' });
     shadow.innerHTML = `
@@ -199,6 +229,13 @@ customElements.define('od-card', class extends HTMLElement {
     const padding = this.getAttribute('padding') || 'md';
     const radius = this.getAttribute('radius') || 'md';
     const bg = this.getAttribute('background');
+    // Default card surface is 4%-white-on-bg (DESIGN.md §2.Card); any
+    // explicit `background="<token>"` from valid ODColor overrides it.
+    // Invalid tokens fall back to the default so off-spec ODML still
+    // renders something, but the preview will visibly differ from the
+    // intended look (the structural issue is the wrong attribute, not
+    // a missing fill).
+    const bgValue = colorVar(bg) || 'rgba(255,255,255,0.04)';
     const shadow = this.attachShadow({ mode: 'open' });
     shadow.innerHTML = `
       <style>${TOKEN_CSS}
@@ -206,7 +243,7 @@ customElements.define('od-card', class extends HTMLElement {
           display: block;
           padding: var(--od-space-${padding});
           border-radius: var(--od-radius-${radius});
-          background: ${bg ? tokenStyle('bg', bg === 'bg-elevated' ? 'elevated' : bg === 'bg-overlay' ? 'overlay' : '') : 'rgba(255,255,255,0.04)'};
+          background: ${bgValue};
           border: 1px solid var(--od-border);
         }
       </style>
@@ -250,18 +287,24 @@ customElements.define('od-text', class extends HTMLElement {
     const align = this.getAttribute('align') || 'leading';
     const bind = this.getAttribute('bind');
     const text = bind ? `{${bind}}` : this.textContent;
+    const colorValue = colorVar(color) || 'var(--od-fg)';
     const shadow = this.attachShadow({ mode: 'open' });
+    // CSS template (no user data interpolated) goes via innerHTML; the
+    // user-supplied text content is appended via textContent so any
+    // HTML/script payload renders as inert text.
     shadow.innerHTML = `
       <style>${TOKEN_CSS}
         :host {
           display: inline-block;
           ${TEXT_STYLES[style] || TEXT_STYLES.body}
-          color: ${tokenStyle('', color === 'fg-muted' ? 'fg-muted' : color === 'fg-subtle' ? 'fg-subtle' : color)};
+          color: ${colorValue};
           text-align: ${align === 'leading' ? 'left' : align === 'trailing' ? 'right' : 'center'};
         }
       </style>
-      <span>${text}</span>
+      <span></span>
     `;
+    const span = shadow.querySelector('span');
+    if (span) span.textContent = text || '';
   }
 });
 
@@ -272,6 +315,7 @@ customElements.define('od-icon', class extends HTMLElement {
     const size = this.getAttribute('size') || 'md';
     const color = this.getAttribute('color') || 'fg';
     const px = ICON_SIZE[size] || 20;
+    const colorValue = colorVar(color) || 'var(--od-fg)';
     const shadow = this.attachShadow({ mode: 'open' });
     shadow.innerHTML = `
       <style>${TOKEN_CSS}
@@ -281,14 +325,18 @@ customElements.define('od-icon', class extends HTMLElement {
           justify-content: center;
           width: ${px}px;
           height: ${px}px;
-          color: ${tokenStyle('', color === 'fg-muted' ? 'fg-muted' : color === 'fg-subtle' ? 'fg-subtle' : color)};
+          color: ${colorValue};
           font-family: var(--od-font-mono);
           font-size: ${Math.round(px * 0.5)}px;
           letter-spacing: 0;
         }
       </style>
-      <span title="${name}">${'□'}</span>
+      <span>□</span>
     `;
+    // SF Symbol name is user-supplied; set via setAttribute so quotes /
+    // angle brackets in the value can't escape the tag.
+    const span = shadow.querySelector('span');
+    if (span) span.setAttribute('title', name);
   }
 });
 
@@ -297,7 +345,7 @@ customElements.define('od-image', class extends HTMLElement {
     if (this.shadowRoot) return;
     const aspect = this.getAttribute('aspect') || 'square';
     const radius = this.getAttribute('radius') || 'none';
-    const ratio = { square: '1 / 1', portrait: '3 / 4', landscape: '16 / 9', fill: '1 / 1' }[aspect];
+    const ratio = { square: '1 / 1', portrait: '3 / 4', landscape: '16 / 9', fill: '1 / 1' }[aspect] || '1 / 1';
     const shadow = this.attachShadow({ mode: 'open' });
     shadow.innerHTML = `
       <style>${TOKEN_CSS}
@@ -344,7 +392,7 @@ customElements.define('od-badge', class extends HTMLElement {
       success: 'var(--od-success)',
       warning: 'var(--od-warning)',
       danger: 'var(--od-danger)',
-    }[variant];
+    }[variant] || 'rgba(255,255,255,0.10)';
     const shadow = this.attachShadow({ mode: 'open' });
     shadow.innerHTML = `
       <style>${TOKEN_CSS}
@@ -357,15 +405,18 @@ customElements.define('od-badge', class extends HTMLElement {
           border-radius: var(--od-radius-full);
         }
       </style>
-      <span>${text}</span>
+      <span></span>
     `;
+    const span = shadow.querySelector('span');
+    if (span) span.textContent = text;
   }
 });
 
 customElements.define('od-progress', class extends HTMLElement {
   connectedCallback() {
     if (this.shadowRoot) return;
-    const value = parseFloat(this.getAttribute('value') || '0') || 0;
+    const raw = parseFloat(this.getAttribute('value') || '0');
+    const value = Math.max(0, Math.min(1, Number.isFinite(raw) ? raw : 0));
     const style = this.getAttribute('style-name') || this.getAttribute('progress-style') || this.getAttribute('style') || 'bar';
     const shadow = this.attachShadow({ mode: 'open' });
     if (style === 'ring') {
@@ -384,7 +435,7 @@ customElements.define('od-progress', class extends HTMLElement {
       shadow.innerHTML = `
         <style>${TOKEN_CSS}
           :host { display: block; width: 100%; height: 4px; background: var(--od-border); border-radius: var(--od-radius-full); }
-          .fill { width: ${Math.max(0, Math.min(1, value)) * 100}%; height: 100%; background: var(--od-accent); border-radius: var(--od-radius-full); }
+          .fill { width: ${value * 100}%; height: 100%; background: var(--od-accent); border-radius: var(--od-radius-full); }
         </style>
         <div class="fill"></div>
       `;
@@ -406,13 +457,13 @@ customElements.define('od-button', class extends HTMLElement {
       secondary: 'var(--od-bg-elevated)',
       ghost: 'transparent',
       destructive: 'var(--od-danger)',
-    }[variant];
+    }[variant] || 'var(--od-accent)';
     const fg = {
       primary: 'var(--od-accent-fg)',
       secondary: 'var(--od-fg)',
       ghost: 'var(--od-fg)',
       destructive: 'var(--od-fg)',
-    }[variant];
+    }[variant] || 'var(--od-accent-fg)';
 
     const shadow = this.attachShadow({ mode: 'open' });
     shadow.innerHTML = `
@@ -463,8 +514,13 @@ customElements.define('od-input', class extends HTMLElement {
         }
         input::placeholder { color: var(--od-fg-subtle); }
       </style>
-      <input type="${secure ? 'password' : 'text'}" placeholder="${placeholder}" />
+      <input />
     `;
+    const input = shadow.querySelector('input');
+    if (input) {
+      input.type = secure ? 'password' : 'text';
+      input.setAttribute('placeholder', placeholder);
+    }
   }
 });
 
@@ -480,9 +536,11 @@ customElements.define('od-toggle', class extends HTMLElement {
         .track { width: 44px; height: 26px; background: var(--od-bg-elevated); border: 1px solid var(--od-border); border-radius: 13px; position: relative; }
         .knob { position: absolute; top: 2px; left: 2px; width: 20px; height: 20px; background: var(--od-fg); border-radius: 50%; }
       </style>
-      <span class="label">${label}</span>
+      <span class="label"></span>
       <span class="track"><span class="knob"></span></span>
     `;
+    const labelEl = shadow.querySelector('.label');
+    if (labelEl) labelEl.textContent = label;
   }
 });
 
@@ -518,8 +576,10 @@ customElements.define('od-nav-bar', class extends HTMLElement {
           color: var(--od-fg);
         }
       </style>
-      <span>${title}</span>
+      <span></span>
     `;
+    const span = shadow.querySelector('span');
+    if (span) span.textContent = title;
   }
 });
 
@@ -543,8 +603,21 @@ customElements.define('od-tab-bar', class extends HTMLElement {
         .tab.active .dot { background: var(--od-fg); }
         .dot { display: block; width: 4px; height: 4px; border-radius: 50%; background: transparent; margin: 4px auto 0; }
       </style>
-      ${tabs.map((t) => `<span class="tab${t === active ? ' active' : ''}">${t}<span class="dot"></span></span>`).join('')}
     `;
+    // Tab labels are user-supplied — build the DOM with createElement
+    // + textContent so quotes / brackets / scripts in tab names stay
+    // inert. Tab class names come from a fixed string set ('tab' or
+    // 'tab active'), so the only attribute interpolation is on the
+    // class, which is static.
+    for (const name of tabs) {
+      const span = document.createElement('span');
+      span.className = name === active ? 'tab active' : 'tab';
+      span.textContent = name;
+      const dot = document.createElement('span');
+      dot.className = 'dot';
+      span.appendChild(dot);
+      shadow.appendChild(span);
+    }
   }
 });
 

--- a/skills/chala-ai-mobile/assets/template.html
+++ b/skills/chala-ai-mobile/assets/template.html
@@ -1,0 +1,417 @@
+<!doctype html>
+<!--
+  Chala.AI mobile seed — V2 dark system.
+
+  iPhone 15 Pro frame (390×844). Dynamic Island, status bar, home indicator.
+  Canvas: #050505. All depth via opacity layers. Geist + GeistMono fonts.
+  Screen content goes inside <main class="content">. Tab bar on main screens only.
+-->
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>[REPLACE] Chala · Screen name</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <!--
+    od-elements.js registers <od-*> Web Components so ODML emitted by the skill
+    renders inside this iframe preview. Throwaway preview code; the SwiftUI
+    translator never reads it. See SKILL.md for the ODML contract.
+  -->
+  <script type="module" src="./od-elements.js"></script>
+  <style>
+    :root {
+      /* ── V2 Chala tokens ── */
+      --bg:              #050505;
+      --bg-raised:       #0B0B0B;
+      --text:            #ffffff;
+      --text-dim:        rgba(255,255,255,0.55);
+      --text-faint:      rgba(255,255,255,0.32);
+      --text-muted:      rgba(255,255,255,0.18);
+      --hairline:        rgba(255,255,255,0.08);
+      --hairline-strong: rgba(255,255,255,0.16);
+      --primary-fill:    #E0E0E0;
+      --primary-text:    #0B0B0B;
+      --card:            rgba(255,255,255,0.04);
+      --card-selected:   rgba(255,255,255,0.12);
+      --input-bg:        rgba(255,255,255,0.05);
+      --pill-bg:         rgba(255,255,255,0.10);
+      --radius:          2px;
+
+      --font-sans: 'Geist', 'SF Pro Text', system-ui, sans-serif;
+      --font-mono: 'Geist Mono', ui-monospace, 'SF Mono', monospace;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; height: 100%; }
+    body {
+      background: #030303;
+      color: var(--text);
+      font-family: var(--font-sans);
+      font-size: 15px;
+      line-height: 1.4;
+      -webkit-font-smoothing: antialiased;
+      display: grid;
+      place-items: center;
+      padding: 32px;
+    }
+
+    /* ─── stage & caption ────────────────────────────────────────────── */
+    .stage { display: flex; flex-direction: column; align-items: center; gap: 20px; }
+    .caption {
+      font-family: var(--font-mono);
+      font-size: 9px;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--text-faint);
+    }
+    .caption strong { color: var(--text-dim); font-weight: 500; }
+
+    /* ─── device frame ──────────────────────────────────────────────── */
+    .device {
+      position: relative;
+      width: 390px;
+      height: 844px;
+      border-radius: 56px;
+      padding: 12px;
+      background: linear-gradient(160deg, #1c1c1e 0%, #111113 50%, #080808 100%);
+      box-shadow:
+        0 0 0 1px rgba(255,255,255,0.06) inset,
+        0 0 0 2px #000 inset,
+        0 32px 72px -12px rgba(0,0,0,0.8),
+        0 8px 24px -8px rgba(0,0,0,0.6);
+      isolation: isolate;
+    }
+    .device::before, .device::after {
+      content: '';
+      position: absolute;
+      width: 3px;
+      background: linear-gradient(to bottom, transparent 0%, rgba(255,255,255,0.05) 8%, transparent 16%, transparent 84%, rgba(255,255,255,0.03) 92%, transparent 100%);
+      top: 100px; bottom: 100px;
+      pointer-events: none;
+    }
+    .device::before { left: -1px; }
+    .device::after  { right: -1px; }
+
+    /* Dynamic Island */
+    .island {
+      position: absolute;
+      top: 22px; left: 50%;
+      transform: translateX(-50%);
+      width: 124px; height: 36px;
+      background: #000;
+      border-radius: 999px;
+      z-index: 5;
+    }
+
+    /* hardware buttons */
+    .btn-rail { position: absolute; width: 4px; background: #080808; border-radius: 2px; }
+    .btn-rail.left-1  { left: -3px; top: 174px; height: 32px; }
+    .btn-rail.left-2  { left: -3px; top: 220px; height: 60px; }
+    .btn-rail.left-3  { left: -3px; top: 290px; height: 60px; }
+    .btn-rail.right-1 { right: -3px; top: 250px; height: 100px; }
+
+    /* ─── screen surface ────────────────────────────────────────────── */
+    .screen {
+      position: relative;
+      width: 100%; height: 100%;
+      background: var(--bg);
+      border-radius: 44px;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* Status bar */
+    .statusbar {
+      flex: 0 0 47px;
+      padding: 18px 26px 0;
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      font-family: var(--font-sans);
+      font-size: 15px;
+      font-weight: 600;
+      color: var(--text);
+      letter-spacing: -0.01em;
+    }
+    .statusbar .right { display: inline-flex; align-items: center; gap: 6px; }
+    .statusbar svg { width: 17px; height: 11px; fill: var(--text); }
+    .statusbar .battery { width: 25px; }
+
+    /* Scrollable content */
+    .content {
+      flex: 1 1 auto;
+      overflow-y: auto;
+      overflow-x: hidden;
+      -webkit-overflow-scrolling: touch;
+    }
+    .content::-webkit-scrollbar { display: none; }
+
+    /* Home indicator */
+    .home-indicator { flex: 0 0 28px; position: relative; }
+    .home-indicator::after {
+      content: '';
+      position: absolute;
+      left: 50%; bottom: 8px;
+      transform: translateX(-50%);
+      width: 134px; height: 5px;
+      background: var(--text);
+      border-radius: 999px;
+      opacity: 0.3;
+    }
+
+    /* ─── V2 primitives ─────────────────────────────────────────────── */
+
+    /* Typography */
+    .heading {
+      font-family: var(--font-sans);
+      font-size: 36px;
+      font-weight: 500;
+      letter-spacing: -0.02em;
+      line-height: 1.05;
+      color: var(--text);
+      margin: 0;
+    }
+    .heading-sm {
+      font-family: var(--font-sans);
+      font-size: 26px;
+      font-weight: 500;
+      letter-spacing: -0.02em;
+      line-height: 1.1;
+      color: var(--text);
+      margin: 0;
+    }
+    .label {
+      font-family: var(--font-mono);
+      font-size: 10px;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--text-faint);
+      margin: 0;
+    }
+    .label-sm {
+      font-family: var(--font-mono);
+      font-size: 9px;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--text-faint);
+      margin: 0;
+    }
+    .numeric {
+      font-family: var(--font-mono);
+      font-variant-numeric: tabular-nums;
+      letter-spacing: -0.02em;
+      color: var(--text);
+    }
+    .body-text {
+      font-size: 14px;
+      color: var(--text-dim);
+      line-height: 1.55;
+    }
+
+    /* Rule / divider */
+    .rule { height: 1px; background: var(--hairline); width: 100%; }
+    .rule-strong { height: 1px; background: var(--hairline-strong); width: 100%; }
+
+    /* Cards */
+    .card {
+      background: var(--card);
+      border: 1px solid var(--hairline-strong);
+      border-radius: var(--radius);
+    }
+    .card-inner { padding: 20px; }
+
+    /* Buttons */
+    .btn-primary {
+      display: flex; align-items: center; justify-content: center;
+      width: 100%;
+      min-height: 50px;
+      padding: 14px 20px;
+      background: var(--primary-fill);
+      color: var(--primary-text);
+      border: 0;
+      border-radius: var(--radius);
+      font-family: var(--font-sans);
+      font-size: 13px;
+      font-weight: 500;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      cursor: pointer;
+    }
+    .btn-secondary {
+      display: flex; align-items: center; justify-content: center;
+      width: 100%;
+      min-height: 50px;
+      padding: 14px 20px;
+      background: transparent;
+      color: var(--text);
+      border: 1px solid var(--hairline-strong);
+      border-radius: var(--radius);
+      font-family: var(--font-sans);
+      font-size: 13px;
+      font-weight: 500;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      cursor: pointer;
+    }
+
+    /* Pill/tag */
+    .pill {
+      display: inline-flex; align-items: center;
+      padding: 4px 10px;
+      background: var(--pill-bg);
+      color: var(--text-dim);
+      border-radius: 9999px;
+      font-family: var(--font-mono);
+      font-size: 9px;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
+
+    /* Layout helpers */
+    .px-28 { padding-inline: 28px; }
+    .px-24 { padding-inline: 24px; }
+    .px-20 { padding-inline: 20px; }
+    .row { display: flex; align-items: center; gap: 12px; }
+    .row-between { display: flex; align-items: center; justify-content: space-between; }
+    .stack { display: flex; flex-direction: column; }
+
+    /* Tab bar — V2 style (dot indicator, no labels) */
+    .tabbar {
+      flex: 0 0 auto;
+      display: grid;
+      grid-template-columns: repeat(5, 1fr);
+      padding: 8px 0 0;
+      border-top: 1px solid var(--hairline);
+      background: var(--bg);
+    }
+    .tab {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 4px;
+      padding: 8px 0 16px;
+      color: var(--text-faint);
+      cursor: pointer;
+    }
+    .tab.active { color: var(--text); }
+    .tab svg { width: 20px; height: 20px; stroke: currentColor; fill: none; stroke-width: 1.25; stroke-linecap: square; stroke-linejoin: miter; }
+    /* active dot */
+    .tab.active::after {
+      content: '';
+      width: 4px; height: 4px;
+      background: var(--text);
+      border-radius: 999px;
+      margin-top: 2px;
+    }
+    .tab:not(.active)::after { content: ''; width: 4px; height: 4px; }
+
+    /* Progress bar */
+    .progress-track { height: 4px; background: var(--hairline); }
+    .progress-fill  { height: 4px; background: var(--text); }
+
+    /* Week strip */
+    .week-strip { display: grid; grid-template-columns: repeat(7,1fr); gap: 4px; }
+    .week-strip .day { height: 4px; background: var(--hairline); }
+    .week-strip .day.done { background: var(--text); }
+    .week-strip .day.today { background: var(--text); opacity: 0.6; }
+
+    /* Stat cell — used in profile/home */
+    .stat-row { display: flex; border: 1px solid var(--hairline); border-radius: var(--radius); }
+    .stat-cell { flex: 1; padding: 20px 16px; border-right: 1px solid var(--hairline); }
+    .stat-cell:last-child { border-right: none; }
+
+    /* Macro ring — override with inline SVG */
+    .macro-ring-group { display: flex; gap: 12px; align-items: flex-start; }
+    .macro-ring { flex: 1; display: flex; flex-direction: column; align-items: center; gap: 8px; }
+
+    /* Quick-action 2-cell */
+    .quick-actions { display: grid; grid-template-columns: 1fr 1fr; border: 1px solid var(--hairline); border-radius: var(--radius); }
+    .quick-cell { padding: 16px; }
+    .quick-cell:first-child { border-right: 1px solid var(--hairline); }
+
+    /* Meal row */
+    .meal-row { padding: 16px 24px; border-bottom: 1px solid var(--hairline); display: flex; gap: 16px; align-items: flex-start; }
+    .meal-time { width: 44px; flex-shrink: 0; }
+    .meal-info { flex: 1; min-width: 0; }
+    .meal-kcal { text-align: right; flex-shrink: 0; }
+
+    /* Form field */
+    .form-field { padding: 14px 0; border-bottom: 1px solid var(--hairline); }
+    .form-field.last { border-bottom: none; }
+    .form-value { font-size: 15px; color: var(--text); margin-top: 8px; }
+    .form-placeholder { font-size: 15px; color: var(--text-muted); margin-top: 8px; }
+  </style>
+</head>
+<body>
+  <div class="stage">
+    <div class="caption"><strong>Chala.AI</strong> · [REPLACE] Screen name</div>
+
+    <div class="device" data-od-id="device">
+      <span class="btn-rail left-1"  aria-hidden></span>
+      <span class="btn-rail left-2"  aria-hidden></span>
+      <span class="btn-rail left-3"  aria-hidden></span>
+      <span class="btn-rail right-1" aria-hidden></span>
+      <span class="island"           aria-hidden></span>
+
+      <div class="screen">
+        <!-- ─── Status bar ─── -->
+        <div class="statusbar">
+          <span class="numeric" style="font-size:15px; font-weight:600;">9:41</span>
+          <span class="right">
+            <!-- signal bars -->
+            <svg viewBox="0 0 17 11" aria-hidden>
+              <rect x="0"  y="7" width="3" height="4" rx="0.4"/>
+              <rect x="4"  y="5" width="3" height="6" rx="0.4"/>
+              <rect x="8"  y="3" width="3" height="8" rx="0.4"/>
+              <rect x="12" y="0" width="3" height="11" rx="0.4"/>
+            </svg>
+            <!-- wifi -->
+            <svg viewBox="0 0 17 11" aria-hidden>
+              <path d="M8.5 1.5C5.5 1.5 2.7 2.6 0.5 4.6L2 6.1C3.8 4.5 6.1 3.6 8.5 3.6c2.4 0 4.7.9 6.5 2.5l1.5-1.5c-2.2-2-5-3.1-8-3.1zM3.5 7.6L5 9.1c1-.9 2.2-1.4 3.5-1.4 1.3 0 2.5.5 3.5 1.4l1.5-1.5c-1.4-1.3-3.1-2-5-2-1.9 0-3.6.7-5 2zM6.5 10.6l2 2 2-2c-.5-.5-1.2-.8-2-.8s-1.5.3-2 .8z"/>
+            </svg>
+            <!-- battery -->
+            <svg class="battery" viewBox="0 0 25 11" aria-hidden>
+              <rect x="0.5" y="0.5" width="21" height="10" rx="2.5" fill="none" stroke="currentColor" stroke-opacity="0.35"/>
+              <rect x="22" y="3.5" width="1.5" height="4" rx="0.4" fill="currentColor" fill-opacity="0.35"/>
+              <rect x="2" y="2" width="17" height="7" rx="1.4"/>
+            </svg>
+          </span>
+        </div>
+
+        <!-- ─── Screen content — paste layout here ─── -->
+        <main class="content" data-od-id="content">
+          <!-- PASTE SCREEN LAYOUT HERE -->
+        </main>
+
+        <!-- ─── Tab bar — remove for auth/onboarding/modal screens ─── -->
+        <nav class="tabbar" data-od-id="tabbar">
+          <!-- Home -->
+          <a class="tab active" aria-label="Home">
+            <svg viewBox="0 0 24 24"><path d="M3 11 L12 4 L21 11 V20 H14 V14 H10 V20 H3 Z"/></svg>
+          </a>
+          <!-- Chat -->
+          <a class="tab" aria-label="Chat">
+            <svg viewBox="0 0 24 24"><path d="M4 5 H20 V17 H13 L9 21 V17 H4 Z"/></svg>
+          </a>
+          <!-- Calendar -->
+          <a class="tab" aria-label="Calendar">
+            <svg viewBox="0 0 24 24"><path d="M4 6 H20 V20 H4 Z M4 10 H20 M9 4 V8 M15 4 V8"/></svg>
+          </a>
+          <!-- Sports -->
+          <a class="tab" aria-label="Sports">
+            <svg viewBox="0 0 24 24"><path d="M3 9 V15 M5 7 V17 M7 10 H17 M19 7 V17 M21 9 V15"/></svg>
+          </a>
+          <!-- Profile -->
+          <a class="tab" aria-label="Profile">
+            <svg viewBox="0 0 24 24"><circle cx="12" cy="9" r="3.5"/><path d="M5 20 C5 15 8 13 12 13 C16 13 19 15 19 20"/></svg>
+          </a>
+        </nav>
+
+        <div class="home-indicator" aria-hidden></div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
<!-- No upstream issue tracked for this feature; deleting the Fixes block per template instructions. -->

## Why

**Use case:** I'm building Chala.AI (an iOS fitness app, the first of N apps in my workspace) and want Open Design to be the canonical source of truth for the design system. Today the daemon serves DESIGN.md as raw markdown (`GET /api/design-systems/:id`) and `chala-ai-mobile`-style skill output is freeform HTML — useful for prototyping but neither structured enough to push the same tokens to multiple consumer apps (iOS, web, React Native) without per-output reinterpretation.

**Pain being addressed:** Token drift between consumer apps. Each consumer hand-mirrors hex/spacing values from DESIGN.md; nothing enforces parity. A tokens-only fix isn't enough — even with a `tokens.json` file, skill output that contains `<div class="..." style="color: #fff">` still pulls every consumer back into per-platform reinterpretation. The leverage point is a restricted dialect (ODML) where token names are the only syntactically legal way to specify a styling value.

I considered opening a discussion first per CONTRIBUTING. Choosing PR-first because the scope is contained: this lands the foundation only (AST types + tokens + the skill prompt), not the cross-cutting daemon route or the SwiftUI translator. Those are designed but deferred to follow-up PRs.

## What users will see

**Skill author / prompt engineer:** a new `chala-ai-mobile` skill exists with a system prompt that constrains output to ODML — a restricted `<od-*>` XML dialect, 20-component vocabulary v1. The skill's iframe preview renders ODML via Web Component shims so designers still see the layout.

**Design-system curator:** `design-systems/chala-ai/` now ships a DTCG-compliant `tokens.json` (machine-readable source of truth) and `tokens-audit.md` (one-time reconciliation against the prose) alongside the existing `DESIGN.md`.

**Other API consumers:** nothing — no daemon routes added or changed.

## Surface area

- [ ] **UI** — none
- [ ] **Keyboard shortcut** — none
- [ ] **CLI / env var** — none
- [ ] **API / contract** — none in this PR (a future `GET /api/design-systems/:id/tokens.json` route is planned but not included here)
- [x] **Extension point** — new `skills/chala-ai-mobile/`, new `design-systems/chala-ai/`, plus a new `packages/od-dialect/` workspace package
- [ ] **i18n keys** — none
- [ ] **New top-level dependency** — none (root `package.json` unchanged)
- [ ] **Default behavior change** — none (the `chala-ai-mobile` skill is brand new, not a modification of an existing skill)

## Screenshots

N/A — no UI surface in this PR.

## Bug fix verification

N/A — feature contribution, not a bug fix.

## Validation

Ran from the repo root against commit `030e383b`:

- `pnpm --filter @open-design/od-dialect typecheck` → passes
- `pnpm guard` → passes (after adding `skills/chala-ai-mobile/assets/od-elements.js` to the residual-JS allowlist with the documented "no-build browser context" reason)

I did not run the full test suite because the changes are additive (new package + new skill + new design system + one allowlist entry); none of the existing apps/packages import from the new package yet.

## Notes for reviewers

1. **ODML AST is intentionally fleshed out before the parser/validator land.** It defines 20 element kinds + a violation discriminated union but no parser yet. The next two pieces — a Layer 1 `validate.ts` for the skill and a Layer 3 SwiftUI translator — both import from this AST; defining it up front prevents the two implementations drifting on tree shape.
2. **`od-elements.js` is declared throwaway preview code.** It exists so the iframe preview renders something visual; any future per-platform translator never reads it. Hard-rule discipline lives in the skill prompt + (forthcoming) validator, not in the preview shims.
3. **Token authoring is hand-seeded v1.** The plan was to extract tokens via Claude from DESIGN.md at build time; the extractor is deferred to a follow-up because the seed needed human review against the consumer iOS app's existing `Theme.swift` constants (audit in `tokens-audit.md`).
4. **No daemon changes in this PR.** A future PR will add `GET /api/design-systems/:id/tokens.json` so consumers (iOS + web) can fetch tokens at build time, plus a `skill-runner` integration that invokes the validator after each ODML render and re-prompts the LLM on violations.