### PR TITLE
fix(daemon): raise ACP stage timeout to match outer chat inactivity watchdog

### DIFF
--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -4,7 +4,14 @@ import path from 'node:path';
 
 const ACP_PROTOCOL_VERSION = 1;
 const DEFAULT_TIMEOUT_MS = 15_000;
-const DEFAULT_STAGE_TIMEOUT_MS = 180_000;
+// Gap-between-chunks watchdog for an ACP session stage. The timer resets on
+// every line received from the agent, so this bounds *silent* periods, not
+// total runtime. Default kept in line with the outer chat-run inactivity
+// watchdog (10 min) so agents that spend several minutes silently writing
+// large artifacts do not get killed before the outer watchdog can apply.
+// Callers can override via `stageTimeoutMs`; the chat server reads
+// `OD_ACP_STAGE_TIMEOUT_MS` from the environment.
+const DEFAULT_STAGE_TIMEOUT_MS = 600_000;
 
 type JsonRpcId = string | number;
 type JsonObject = Record<string, unknown>;

--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -11,6 +11,10 @@ const DEFAULT_TIMEOUT_MS = 15_000;
 // large artifacts do not get killed before the outer watchdog can apply.
 // Callers can override via `stageTimeoutMs`; the chat server reads
 // `OD_ACP_STAGE_TIMEOUT_MS` from the environment.
+// A non-positive `stageTimeoutMs` (`<= 0`) disables the watchdog entirely,
+// mirroring the outer chat watchdog's escape-hatch semantics — without this,
+// `OD_ACP_STAGE_TIMEOUT_MS=0` would call `setTimeout(..., 0)` and fail every
+// ACP session on the next tick instead of disabling the watchdog.
 const DEFAULT_STAGE_TIMEOUT_MS = 600_000;
 
 type JsonRpcId = string | number;
@@ -434,8 +438,15 @@ export function attachAcpSession({
   let aborted = false;
   let stageTimer: TimerHandle | null = null;
 
+  const stageWatchdogDisabled = stageTimeoutMs <= 0;
   const resetStageTimer = (label: string) => {
     if (stageTimer) clearTimeout(stageTimer);
+    // `stageTimeoutMs <= 0` disables the watchdog. Mirrors the outer chat
+    // inactivity watchdog escape hatch (see server.ts → inactivityTimer).
+    // Without this, an operator setting `OD_ACP_STAGE_TIMEOUT_MS=0` would
+    // schedule a 0ms timeout that fires on the next tick and kills the
+    // session immediately.
+    if (stageWatchdogDisabled) return;
     stageTimer = setTimeout(() => {
       fail(`ACP ${label} timed out after ${stageTimeoutMs}ms`);
     }, stageTimeoutMs);

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -2158,6 +2158,17 @@ function resolveChatRunShutdownGraceMs() {
   return Math.max(0, Math.floor(raw));
 }
 
+function resolveAcpStageTimeoutMs(): number | undefined {
+  // Per-stage silence watchdog for ACP chat sessions. Defaults are owned by
+  // `attachAcpSession` in acp.ts; this resolver only applies when an operator
+  // sets `OD_ACP_STAGE_TIMEOUT_MS`. Bounded to the same 24h ceiling as the
+  // outer chat inactivity watchdog so an oversized override doesn't get
+  // clamped to 1ms by Node's signed-32-bit delay limit.
+  const raw = Number(process.env.OD_ACP_STAGE_TIMEOUT_MS);
+  if (!Number.isFinite(raw)) return undefined;
+  return Math.min(MAX_CHAT_RUN_INACTIVITY_TIMEOUT_MS, Math.max(0, Math.floor(raw)));
+}
+
 export async function startServer({
   port = 7456,
   host = process.env.OD_BIND_HOST || '127.0.0.1',
@@ -4433,6 +4444,7 @@ export async function startServer({
         uploadRoot: UPLOAD_DIR,
       });
     } else if (def.streamFormat === 'acp-json-rpc') {
+      const acpStageTimeoutMs = resolveAcpStageTimeoutMs();
       acpSession = attachAcpSession({
         child,
         prompt: composed,
@@ -4443,6 +4455,7 @@ export async function startServer({
           noteAgentActivity();
           send(event, data);
         },
+        ...(acpStageTimeoutMs !== undefined ? { stageTimeoutMs: acpStageTimeoutMs } : {}),
       });
     } else if (def.streamFormat === 'json-event-stream') {
       // Pipe through sendAgentEvent so the OpenCode `type:'error'` frame

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -348,6 +348,67 @@ test('attachAcpSession.completedSuccessfully reflects abort and fatal-error stat
   assert.equal(session.completedSuccessfully(), false);
 });
 
+test('attachAcpSession default stage timeout tolerates >3min of silence between chunks', async () => {
+  vi.useFakeTimers();
+  try {
+    const child = new FakeAcpChild();
+    const events: Array<{ event: string; payload: unknown }> = [];
+
+    attachAcpSession({
+      child: child as never,
+      prompt: 'write a large landing page',
+      cwd: '/tmp/od-project',
+      model: null,
+      mcpServers: [],
+      send: (event, payload) => events.push({ event, payload }),
+    });
+
+    child.stdout.write(`${JSON.stringify({ id: 1, result: {} })}\n`);
+    child.stdout.write(`${JSON.stringify({ id: 2, result: { sessionId: 'session-1' } })}\n`);
+
+    // Simulate an agent silently writing a large artifact for ~4 minutes —
+    // longer than the historical 180_000ms default that killed long
+    // generations mid-response.
+    await vi.advanceTimersByTimeAsync(240_000);
+
+    const errors = events.filter((e) => e.event === 'error');
+    assert.equal(errors.length, 0, `expected no stage-timeout error, got: ${JSON.stringify(errors)}`);
+    assert.equal(child.killed, false);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test('attachAcpSession honors caller-supplied stageTimeoutMs override', async () => {
+  vi.useFakeTimers();
+  try {
+    const child = new FakeAcpChild();
+    const events: Array<{ event: string; payload: unknown }> = [];
+
+    attachAcpSession({
+      child: child as never,
+      prompt: 'hello',
+      cwd: '/tmp/od-project',
+      model: null,
+      mcpServers: [],
+      send: (event, payload) => events.push({ event, payload }),
+      stageTimeoutMs: 1_000,
+    });
+
+    child.stdout.write(`${JSON.stringify({ id: 1, result: {} })}\n`);
+    child.stdout.write(`${JSON.stringify({ id: 2, result: { sessionId: 'session-1' } })}\n`);
+
+    await vi.advanceTimersByTimeAsync(1_500);
+
+    const error = events.find((e) => e.event === 'error');
+    assert.ok(error, 'expected a stage-timeout error event');
+    const message = (error.payload as { message?: string }).message ?? '';
+    assert.match(message, /1000ms/);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
 class FakeAcpChild extends EventEmitter {
   stdin = new PassThrough();
   stdout = new PassThrough();

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -409,6 +409,42 @@ test('attachAcpSession honors caller-supplied stageTimeoutMs override', async ()
   }
 });
 
+test('attachAcpSession treats stageTimeoutMs <= 0 as a watchdog disable, not an immediate-failure schedule', async () => {
+  vi.useFakeTimers();
+  try {
+    const child = new FakeAcpChild();
+    const events: Array<{ event: string; payload: unknown }> = [];
+
+    attachAcpSession({
+      child: child as never,
+      prompt: 'hello',
+      cwd: '/tmp/od-project',
+      model: null,
+      mcpServers: [],
+      send: (event, payload) => events.push({ event, payload }),
+      // OD_ACP_STAGE_TIMEOUT_MS=0 escape hatch: operator wants to disable the
+      // inner stage watchdog entirely (e.g. when relying solely on the outer
+      // chat inactivity watchdog). Must NOT schedule a 0ms setTimeout that
+      // would fail every ACP session on the next tick.
+      stageTimeoutMs: 0,
+    });
+
+    // Drive past where the next-tick failure would have fired, plus a long
+    // silent period that would trip any positive default watchdog.
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+
+    const errors = events.filter((e) => e.event === 'error');
+    assert.equal(
+      errors.length,
+      0,
+      `expected stageTimeoutMs=0 to disable the watchdog, got: ${JSON.stringify(errors)}`,
+    );
+    assert.equal(child.killed, false);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
 class FakeAcpChild extends EventEmitter {
   stdin = new PassThrough();
   stdout = new PassThrough();


### PR DESCRIPTION
Fixes the `ACP response timed out after 180000ms` error that killed long agent generations mid-response.

## Why

Hit while generating a long landing page in one turn: the agent went silent for ~3 min while writing a large HTML artifact, the inner ACP stage watchdog fired, and the response was killed before the agent could emit its next chunk.

Pain: the outer chat-run inactivity watchdog at `apps/daemon/src/server.ts` is already 10 minutes precisely because, per its own comment, *"agents [...] spend several minutes silently writing large artifacts"*. The inner ACP stage watchdog at `apps/daemon/src/acp.ts` was undercutting that stated design intent at 3 min, with no env override to tune it.

## What users will see

- Long single-turn generations (large HTML, long markdown, multi-file scaffolds) no longer get killed at the 3-minute mark.
- **Default behavior change:** tolerated silence between agent chunks goes from 3 min → 10 min, matching the outer chat watchdog.
- **New env var** `OD_ACP_STAGE_TIMEOUT_MS` for further tuning, bounded by the same 24h ceiling as `OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS`. Setting it to `0` disables the inner watchdog entirely (mirrors the outer watchdog's `<=0` escape hatch).

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope.
- [x] **Default behavior change** — ACP stage timeout default 3 min → 10 min. Existing users will notice that long generations that previously failed at 3 min now complete.
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — no UI surface touched.

## Bug fix verification

Per AGENTS.md → "Bug follow-up workflow", the bug is encoded as a falsifiable test that goes red on `main` and green on this branch.

- Test path that reproduces the bug: `apps/daemon/tests/acp.test.ts` → *"attachAcpSession default stage timeout tolerates >3min of silence between chunks"*.
- Did the test go red on `main` and green on this branch? **Yes.** Confirmed by advancing fake timers 240_000ms with no agent activity: red on old `DEFAULT_STAGE_TIMEOUT_MS=180_000`, green on the new `600_000`.
- Two additional tests cover the override path and the `<=0` disable semantics requested in review.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run tests/acp.test.ts` → 15/15 pass (3 new).
- `pnpm typecheck` → pass.
- `pnpm guard` → pass.
- Packaged Mac build (`pnpm tools-pack mac build --to all && pnpm tools-pack mac install`) → success.

## Related open PRs

@lefarcen flagged that #765 and #1527 also touch `DEFAULT_STAGE_TIMEOUT_MS` / the env-var problem. This PR goes further — the `server.ts` resolver mirroring `resolveChatRunInactivityTimeoutMs`, the `<=0` disable escape hatch, and the regression coverage are a more complete implementation. Maintainers can pick whichever lands.
