### PR TITLE
fix(web): restore dark pagination select chevron

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -8371,12 +8371,27 @@ button.connector-action.is-loading {
 }
 .df-pagination select {
   font-size: 12px;
-  padding: 2px 6px;
+  padding: 2px 24px 2px 6px;
   border: 1px solid var(--border);
   border-radius: 4px;
-  background: var(--bg);
+  appearance: none;
+  -webkit-appearance: none;
+  background-color: var(--bg);
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' fill='none' stroke='%2374716b' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='3 5 6 8 9 5'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 6px center;
+  background-size: 12px 12px;
   color: var(--text);
   cursor: pointer;
+}
+.df-pagination select::-ms-expand { display: none; }
+[data-theme='dark'] .df-pagination select {
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' fill='none' stroke='%239a9690' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='3 5 6 8 9 5'/%3E%3C/svg%3E");
+}
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme]) .df-pagination select {
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' fill='none' stroke='%239a9690' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='3 5 6 8 9 5'/%3E%3C/svg%3E");
+  }
 }
 .df-pagination select:focus-visible {
   outline: 2px solid var(--accent);


### PR DESCRIPTION
Fixes #1697

## Summary
- restore custom select appearance for the DesignFiles pagination page-size control
- use `background-color` instead of the `background` shorthand so the chevron image is not cleared
- add explicit dark-theme and system-dark chevron overrides to match the existing select styling pattern

## Surface area
- [x] UI
- [ ] Keyboard shortcut
- [ ] CLI
- [ ] env var
- [ ] API
- [ ] Default behavior change
- [ ] i18n keys
- [ ] Extension point
- [ ] New top-level dependency
- [ ] None

## Validation
- `pnpm --filter @open-design/web test -- tests/components/DesignFilesPanel.test.tsx` (126 files, 1245 tests passed)
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- subagent read-only CSS review: no blocking issues