### PR TITLE
Fix Design Files dark-mode page-size selector

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -8371,10 +8371,10 @@ button.connector-action.is-loading {
 }
 .df-pagination select {
   font-size: 12px;
-  padding: 2px 6px;
+  padding: 2px 24px 2px 6px;
   border: 1px solid var(--border);
   border-radius: 4px;
-  background: var(--bg);
+  background-color: var(--bg-panel);
   color: var(--text);
   cursor: pointer;
 }


### PR DESCRIPTION
Fixes #1697

## Why

Design Files' page-size select in dark mode lost its chevron styling because the control was getting a shorthand background override. That made the pagination control look broken and harder to scan.

## What users will see

The page-size selector keeps its chevron in dark mode and still matches the shared select styling.

## Surface area

- [x] **UI**

## Validation

- `pnpm --filter @open-design/web test -- tests/components/DesignFilesPanel.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
