### PR TITLE
fix(daemon): use danger-full-access codex sandbox on Windows to unblock PowerShell

### DIFF
--- a/apps/daemon/src/runtimes/defs/codex.ts
+++ b/apps/daemon/src/runtimes/defs/codex.ts
@@ -44,15 +44,24 @@ export const codexAgentDef = {
       options = {},
       runtimeContext = {},
     ) => {
-      const args = [
-        'exec',
-        '--json',
-        '--skip-git-repo-check',
-        '--sandbox',
-        'workspace-write',
-        '-c',
-        'sandbox_workspace_write.network_access=true',
-      ];
+      // Codex CLI's `workspace-write` sandbox blocks shell invocations on
+      // Windows ("powershell.exe ... rejected: blocked by policy", #1721),
+      // because Codex has no working OS-level sandbox on Windows and falls
+      // back to a coarse policy that rejects any shell. macOS (Seatbelt)
+      // and Linux (Landlock+seccomp) keep workspace-write because their
+      // sandbox enforcement permits shell while restricting writes.
+      const isWindows = process.platform === 'win32';
+      const args = isWindows
+        ? ['exec', '--json', '--skip-git-repo-check', '--sandbox', 'danger-full-access']
+        : [
+            'exec',
+            '--json',
+            '--skip-git-repo-check',
+            '--sandbox',
+            'workspace-write',
+            '-c',
+            'sandbox_workspace_write.network_access=true',
+          ];
       if (process.env.OD_CODEX_DISABLE_PLUGINS === '1') {
         args.push('--disable', 'plugins');
       }

--- a/apps/daemon/tests/runtimes/registry-and-args.test.ts
+++ b/apps/daemon/tests/runtimes/registry-and-args.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest';
 import {
-  AGENT_DEFS, assert, chmodSync, codex, detectAgents, join, mkdtempSync, rmSync, tmpdir, writeFileSync,
+  AGENT_DEFS, assert, chmodSync, codex, detectAgents, join, mkdtempSync, rmSync, tmpdir, withPlatform, writeFileSync,
 } from './helpers/test-helpers.js';
 
 test('AGENT_DEFS ids are unique', () => {
@@ -12,52 +12,90 @@ test('AGENT_DEFS ids are unique', () => {
 test('codex args disable plugins when OD_CODEX_DISABLE_PLUGINS is 1', () => {
   process.env.OD_CODEX_DISABLE_PLUGINS = '1';
 
-  const args = codex.buildArgs('', [], [], {}, { cwd: '/tmp/od-project' });
+  withPlatform('darwin', () => {
+    const args = codex.buildArgs('', [], [], {}, { cwd: '/tmp/od-project' });
 
-  assert.deepEqual(args.slice(0, 9), [
-    'exec',
-    '--json',
-    '--skip-git-repo-check',
-    '--sandbox',
-    'workspace-write',
-    '-c',
-    'sandbox_workspace_write.network_access=true',
-    '--disable',
-    'plugins',
-  ]);
+    assert.deepEqual(args.slice(0, 9), [
+      'exec',
+      '--json',
+      '--skip-git-repo-check',
+      '--sandbox',
+      'workspace-write',
+      '-c',
+      'sandbox_workspace_write.network_access=true',
+      '--disable',
+      'plugins',
+    ]);
+  });
 });
 
-test('codex args use workspace-write sandbox instead of deprecated full-auto', () => {
+test('codex args use workspace-write sandbox on macOS and Linux', () => {
   delete process.env.OD_CODEX_DISABLE_PLUGINS;
 
-  const args = codex.buildArgs('', [], [], {}, { cwd: '/tmp/od-project' });
+  for (const platform of ['darwin', 'linux'] as const) {
+    withPlatform(platform, () => {
+      const args = codex.buildArgs('', [], [], {}, { cwd: '/tmp/od-project' });
+      assert.equal(args.includes('--full-auto'), false);
+      assert.deepEqual(args.slice(0, 5), [
+        'exec',
+        '--json',
+        '--skip-git-repo-check',
+        '--sandbox',
+        'workspace-write',
+      ]);
+    });
+  }
+});
 
-  assert.equal(args.includes('--full-auto'), false);
-  assert.deepEqual(args.slice(0, 5), [
-    'exec',
-    '--json',
-    '--skip-git-repo-check',
-    '--sandbox',
-    'workspace-write',
-  ]);
+test('codex args use danger-full-access sandbox on Windows because workspace-write blocks PowerShell', () => {
+  // Codex CLI's workspace-write sandbox mode on Windows lacks a working
+  // OS-level sandbox and falls back to a policy that rejects shell
+  // invocations such as powershell.exe with "blocked by policy".
+  // The agent cannot list files or run any shell-backed tool under that
+  // policy. danger-full-access is Codex CLI's documented Windows-compatible
+  // mode (issue #1721).
+  delete process.env.OD_CODEX_DISABLE_PLUGINS;
+
+  withPlatform('win32', () => {
+    const args = codex.buildArgs('', [], [], {}, { cwd: '/tmp/od-project' });
+
+    assert.deepEqual(args.slice(0, 5), [
+      'exec',
+      '--json',
+      '--skip-git-repo-check',
+      '--sandbox',
+      'danger-full-access',
+    ]);
+    // The workspace-write-scoped network override is meaningless under
+    // danger-full-access and must not appear on Windows.
+    assert.equal(args.includes('workspace-write'), false);
+    assert.equal(
+      args.includes('sandbox_workspace_write.network_access=true'),
+      false,
+    );
+  });
 });
 
 test('codex args keep plugins enabled when OD_CODEX_DISABLE_PLUGINS is unset', () => {
   delete process.env.OD_CODEX_DISABLE_PLUGINS;
 
-  const args = codex.buildArgs('', [], [], {}, { cwd: '/tmp/od-project' });
+  withPlatform('darwin', () => {
+    const args = codex.buildArgs('', [], [], {}, { cwd: '/tmp/od-project' });
 
-  assert.equal(args.includes('--disable'), false);
-  assert.equal(args.includes('plugins'), false);
+    assert.equal(args.includes('--disable'), false);
+    assert.equal(args.includes('plugins'), false);
+  });
 });
 
 test('codex args keep plugins enabled when OD_CODEX_DISABLE_PLUGINS is not 1', () => {
   process.env.OD_CODEX_DISABLE_PLUGINS = 'true';
 
-  const args = codex.buildArgs('', [], [], {}, { cwd: '/tmp/od-project' });
+  withPlatform('darwin', () => {
+    const args = codex.buildArgs('', [], [], {}, { cwd: '/tmp/od-project' });
 
-  assert.equal(args.includes('--disable'), false);
-  assert.equal(args.includes('plugins'), false);
+    assert.equal(args.includes('--disable'), false);
+    assert.equal(args.includes('plugins'), false);
+  });
 });
 
 test('codex model picker includes current OpenAI choices in priority order', async () => {


### PR DESCRIPTION
<div align="center">

# 🪟 Codex CLI on Windows · PowerShell unblock

Switch `--sandbox workspace-write` → `--sandbox danger-full-access` on `win32` only, because Codex's workspace-write policy on Windows rejects every shell invocation.

![scope](https://img.shields.io/badge/scope-daemon%20%C2%B7%20runtime%20adapter-1f6feb) ![surface](https://img.shields.io/badge/surface-codex%20agent-blueviolet) ![platform](https://img.shields.io/badge/platform-windows%20only-2ea44f) ![risk](https://img.shields.io/badge/risk-low%20%C2%B7%20no%20cross%E2%80%91platform%20regression-success)

Fixes #1721.

</div>

## Why

@kutzki reported on v0.7.0 / Windows that picking the Codex CLI agent and asking it to do basic work blew up with `"...powershell.exe" -Command 'Get-ChildItem ...' rejected: blocked by policy`. The agent cannot list files, cannot read attachments, cannot run anything shell-backed. From a user perspective Codex CLI is unusable on Windows, even though it works fine on macOS and Linux.

Root cause is on the Codex CLI side, but the fix lives in OD's adapter:

- Open Design launches Codex CLI with [`--sandbox workspace-write`](https://github.com/nexu-io/open-design/blob/main/apps/daemon/src/runtimes/defs/codex.ts) so the agent can write inside the project directory while the rest of the filesystem stays read-only.
- On macOS, `workspace-write` is enforced via Seatbelt (`sandbox-exec`). On Linux, via Landlock + seccomp. Both let the agent run `bash`, `sh`, `find`, etc. while still restricting writes.
- On Windows, Codex CLI has **no working OS-level sandbox**. It falls back to a coarse policy that rejects every shell invocation (`powershell.exe`, `cmd.exe`, `bash.exe`) entirely. That is the "blocked by policy" message kutzki saw.

`danger-full-access` is Codex CLI's documented Windows-compatible mode (per Codex's own README) and is what users have been recommending in upstream issues as the Windows workaround.

This PR does not regress the macOS / Linux story: those platforms keep `workspace-write` and continue to enforce real sandboxing.

## What users will see

```
                +--------------------+        +--------------------+
                |  process.platform  |        |  --sandbox arg     |
                +--------------------+        +--------------------+
  Before:           win32             ----->     workspace-write    --> PowerShell rejected, agent dead
                    darwin            ----->     workspace-write    --> works (Seatbelt sandboxing)
                    linux             ----->     workspace-write    --> works (Landlock+seccomp)

  After:            win32             ----->     danger-full-access --> works
                    darwin            ----->     workspace-write    --> unchanged
                    linux             ----->     workspace-write    --> unchanged
```

Concretely for kutzki on Windows: the Codex CLI agent stops failing on `Get-ChildItem -Force`, can list project files again, and can run the shell-backed tools the model decides to use.

The workspace-write-scoped network config override (`-c sandbox_workspace_write.network_access=true`) is dropped on Windows since it has no meaning under `danger-full-access`; this also removes a misleading config that previously did nothing on Windows.

## Surface area

| Surface | Status |
|---|---|
| `apps/daemon/src/runtimes/defs/codex.ts` (runtime adapter) | ✅ touched |
| `apps/daemon/tests/runtimes/registry-and-args.test.ts` (red spec + non-windows anchors) | ✅ touched |
| Cross-platform sandbox on macOS / Linux | ⚪ unchanged |
| User-facing UI / i18n / contracts | ⚪ none |
| CLI flags / env vars | ⚪ none added |
| Docs | ⚪ none (code comment carries the explanation) |
| New dependencies | ⚪ none |
| Default behavior change | 🟡 Windows only: more permissive sandbox than before (acknowledges that Codex had no working sandbox on Windows anyway) |

## Why I went with `danger-full-access` and not a config carve-out

Considered alternatives:

1. **Pass a Codex config flag that whitelists PowerShell on workspace-write.** Codex CLI accepts `-c key=value` overrides, but there is no documented or shipping option that selectively unblocks shell under `workspace-write` on Windows. Trying to invent one would be brittle.
2. **Detect Windows and silently switch to a different agent.** Surprising and rude; the user picked Codex for a reason.
3. **Show a friendly error and refuse to launch.** Better than a cryptic policy block, but still leaves Codex CLI Windows users with no working path.

`danger-full-access` is the path Codex CLI itself recommends for Windows. It is the smallest change that gives Windows users a working agent without paying any cost on macOS / Linux.

## Red spec → green

Lead with a falsifiable test per the bug follow-up workflow in `AGENTS.md`:

- Anchored the existing workspace-write assertions explicitly to `darwin` and `linux` via `withPlatform()` (the test helper that was already in `apps/daemon/tests/runtimes/helpers/test-helpers.ts`). Before this PR those tests passed accidentally on macOS / Linux CI and would have started failing on a Windows runner the moment one was added.
- Added a `win32` test that asserts the new `danger-full-access` shape and that the workspace-write-scoped network override is absent.

The Windows test goes red on this branch before the source change (proving it pins the right behavior) and green after.

<details>
<summary><b>Validation commands run on this branch head (<code>ef718fb6</code>)</b></summary>

```
pnpm --filter @open-design/daemon typecheck     # clean
pnpm --filter @open-design/daemon test tests/runtimes/registry-and-args.test.ts
  # 9 passed / 1 failed
  # The 1 failure is the pre-existing `codex model picker includes current
  # OpenAI choices in priority order` test which writes a `#!/bin/sh`
  # shebang script and chmods it executable, neither of which works on
  # Windows. Confirmed the same failure on `main` HEAD via `git stash`
  # baseline diff -- this PR neither caused nor regressed it.
```

</details>

## Adjacent issue (not bundling)

The `codex model picker includes current OpenAI choices in priority order` test at `apps/daemon/tests/runtimes/registry-and-args.test.ts:154` fails on Windows because it shebangs `#!/bin/sh` and relies on `chmodSync(..., 0o755)` for executability. Both are no-ops on Windows. Sibling test files in `apps/daemon/tests/runtimes/` already use the `fsTest = process.platform === 'win32' ? test.skip : test` pattern for this exact situation (`env-and-detection.test.ts:9`, `launch.test.ts:18`, `executables.test.ts:6`). Converting this one test to the same skip pattern is a one-liner but it is outside the scope of issue #1721 and belongs in its own focused follow-up.
