### PR TITLE
fix(web): ensure routine history 'Open project' button text is visible on hover

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -18867,7 +18867,18 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   gap: 4px;
   font-weight: 500;
 }
-.routines-history-link:hover { background: var(--text); color: var(--bg); border-color: var(--text); }
+.routines-history-link:hover {
+  background: var(--text);
+  color: var(--bg-panel);
+  border-color: var(--text);
+}
+.routines-history-link:focus-visible {
+  outline: 2px solid var(--selected);
+  outline-offset: 1px;
+}
+.routines-history-link:active {
+  opacity: 0.85;
+}
 
 .routines-status {
   display: inline-block;


### PR DESCRIPTION
## Why

The **Open project** button in the Routine history row becomes unreadable on hover because the button label effectively disappears. The original hover CSS swapped `color` to `var(--bg)`, which can resolve to a color too close to the panel background in certain theme contexts, making the text nearly invisible.

Fixes #1357

## What users will see

- **Before**: Hovering over the "Open project" button in Settings → Routines → history rows would make the button text disappear or become nearly invisible.
- **After**: The button text remains clearly readable in all states — default, hover, focus-visible, and active. The hover state inverts colors cleanly: dark background with light text (or vice versa in dark theme).

## Changes

- Changed hover `color` from `var(--bg)` to `var(--bg-panel)` — the panel surface color guarantees contrast against the `var(--text)` hover background in both light and dark themes
- Added `:focus-visible` outline for keyboard accessibility
- Added `:active` state for tactile affordance

## Surface area checklist

- [x] `apps/web` — CSS change in `apps/web/src/index.css`
- [ ] `apps/daemon`
- [ ] `apps/desktop`
- [ ] `apps/packaged`
- [ ] Extension points (skills/design-systems/design-templates/craft)
- [ ] CLI flags
- [ ] Environment variables
- [ ] i18n keys
- [ ] `package.json` dependencies