### PR TITLE
fix: block internal storage refs in html artifacts

### DIFF
--- a/apps/web/src/artifacts/validate.ts
+++ b/apps/web/src/artifacts/validate.ts
@@ -14,6 +14,8 @@
  * - the *first* non-whitespace token is `<!doctype html>` or `<html`
  *   (anchored at the start; mid-string mentions of these tags do NOT count —
  *   AI prose like "Updated the <html lang> attribute…" must be rejected)
+ * - does not reference internal storage paths such as `.live-artifacts/`,
+ *   `.od/`, or `.tmp/`
  *
  * What this gate is NOT:
  * - It is **not** an HTML linter or validator. Malformed but recognizably
@@ -36,6 +38,7 @@
 
 const MIN_HTML_LENGTH = 64;
 const STARTS_WITH_DOCUMENT_RE = /^(?:<!doctype\s+html\b|<html\b)/i;
+const INTERNAL_STORAGE_PATH_RE = /(?:^|[./"'`(=\s])(?:\.live-artifacts|\.od|\.tmp)(?:[/?#]|$)/i;
 
 export type HtmlArtifactValidationResult =
   | { ok: true }
@@ -51,6 +54,9 @@ export function validateHtmlArtifact(content: string): HtmlArtifactValidationRes
   }
   if (!STARTS_WITH_DOCUMENT_RE.test(trimmed)) {
     return { ok: false, reason: 'content does not start with <!doctype html> or <html — looks like prose, not a complete HTML document' };
+  }
+  if (INTERNAL_STORAGE_PATH_RE.test(trimmed)) {
+    return { ok: false, reason: 'content references an internal storage path such as .live-artifacts, .od, or .tmp' };
   }
   return { ok: true };
 }

--- a/apps/web/src/artifacts/validate.ts
+++ b/apps/web/src/artifacts/validate.ts
@@ -38,7 +38,7 @@
 
 const MIN_HTML_LENGTH = 64;
 const STARTS_WITH_DOCUMENT_RE = /^(?:<!doctype\s+html\b|<html\b)/i;
-const INTERNAL_STORAGE_PATH_RE = /(?:^|[./"'`(=\s])(?:\.live-artifacts|\.od|\.tmp)(?:[/?#]|$)/i;
+const INTERNAL_STORAGE_PATH_RE = /(?:^|[./"'`(=\s])(?:\.live-artifacts|\.od|\.tmp)(?:[/?#"'`\s>)]|$)/i;
 
 export type HtmlArtifactValidationResult =
   | { ok: true }

--- a/apps/web/tests/artifacts/validate.test.ts
+++ b/apps/web/tests/artifacts/validate.test.ts
@@ -52,6 +52,13 @@ describe('validateHtmlArtifact', () => {
     expect(result.ok).toBe(false);
   });
 
+  it('rejects an otherwise valid document that points at an internal storage path', () => {
+    const html = '<!doctype html><html><body><a href="/.live-artifacts/artifact-1/preview.html">preview</a><p>Enough content to look like a real document.</p></body></html>';
+    const result = validateHtmlArtifact(html);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/internal storage path/i);
+  });
+
   it('accepts a complete <!doctype html> document', () => {
     const html = '<!doctype html><html><head><title>x</title></head><body><h1>hello</h1></body></html>';
     const result = validateHtmlArtifact(html);

--- a/apps/web/tests/artifacts/validate.test.ts
+++ b/apps/web/tests/artifacts/validate.test.ts
@@ -59,6 +59,13 @@ describe('validateHtmlArtifact', () => {
     if (!result.ok) expect(result.reason).toMatch(/internal storage path/i);
   });
 
+  it('rejects root reserved paths that end at an HTML terminator like a quote', () => {
+    const html = '<!doctype html><html><body><a href="/.live-artifacts">preview</a><p>Enough content to look like a real document.</p></body></html>';
+    const result = validateHtmlArtifact(html);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/internal storage path/i);
+  });
+
   it('accepts a complete <!doctype html> document', () => {
     const html = '<!doctype html><html><head><title>x</title></head><body><h1>hello</h1></body></html>';
     const result = validateHtmlArtifact(html);


### PR DESCRIPTION
Fixes #1665

## Summary
Reject AI-emitted HTML artifacts that reference internal storage paths like `.live-artifacts`, `.od`, or `.tmp` before they are saved.

## Why
Orbit can generate a follow-up artifact that embeds `.live-artifacts/` in an iframe or link. That content may save successfully, but the resulting file later opens with a 400 because the reserved path is blocked by the file API.

## What users will see
Instead of silently saving a broken artifact, the save is rejected with a clear validation error.

## Surface area
- [x] Default behavior change

## Validation
- `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/artifacts/validate.test.ts`
