### PR TITLE
fix(web): open preview feedback template

### DIFF
--- a/apps/web/src/components/PromptTemplatePreviewModal.tsx
+++ b/apps/web/src/components/PromptTemplatePreviewModal.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useT } from '../i18n';
 import { fetchPromptTemplate } from '../providers/registry';
+import { derivePluginSourceLinks } from '../runtime/plugin-source';
 import type {
   PromptTemplateDetail,
   PromptTemplateSummary,
@@ -18,6 +19,15 @@ interface Props {
 // prompt body is fetched lazily so the gallery list stays cheap.
 export function PromptTemplatePreviewModal({ summary, onClose }: Props) {
   const t = useT();
+  const sourceLinks = useMemo(() => derivePluginSourceLinks({
+    source: `github:${summary.source.repo}`,
+    sourceKind: 'github',
+    fsPath: summary.source.repo,
+    manifest: {
+      author: summary.source.author ? { name: summary.source.author, url: summary.source.url } : undefined,
+      homepage: summary.source.url,
+    },
+  }), [summary.source.author, summary.source.repo, summary.source.url]);
   const [detail, setDetail] = useState<PromptTemplateDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
@@ -201,6 +211,15 @@ export function PromptTemplatePreviewModal({ summary, onClose }: Props) {
               rel="noopener noreferrer"
             >
               {t('promptTemplates.openSource')}
+            </a>
+          ) : null}
+          {sourceLinks.contributeUrl ? (
+            <a
+              href={sourceLinks.contributeUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Contribute
             </a>
           ) : null}
         </footer>

--- a/apps/web/src/runtime/plugin-source.ts
+++ b/apps/web/src/runtime/plugin-source.ts
@@ -1,0 +1,254 @@
+/**
+ * Plugin source / author / contribute link derivation.
+ *
+ * Turns the raw plugin install record's `source` string + the
+ * manifest's `author` / `homepage` fields into a small bag of
+ * renderable URLs and labels. Used by the Home plugin grid (small
+ * "by <author>" byline) and by the PluginDetailsModal (rich author
+ * + source + contribute block).
+ *
+ * Why a separate module:
+ *  - the parsing rules (`github:owner/repo[@ref][/sub]`, https URL,
+ *    local path, bundled relpath) are non-trivial enough to warrant
+ *    isolated unit tests,
+ *  - the modal and the card both need the same shape, so deriving
+ *    twice would invite drift,
+ *  - the host React surface needs a single safe-URL gate (only
+ *    http(s) URLs become clickable) to keep `javascript:` /
+ *    `data:` payloads in a manifest from rendering as live links.
+ */
+type PluginSourceKind = 'bundled' | 'user' | 'project' | 'marketplace' | 'github' | 'url' | 'local';
+
+export interface PluginSourceRecord {
+  source: string;
+  sourceKind: PluginSourceKind;
+  pinnedRef?: string;
+  fsPath: string;
+  manifest?: {
+    name?: unknown;
+    version?: unknown;
+    author?: { name?: unknown; url?: unknown };
+    homepage?: unknown;
+  };
+}
+
+export interface PluginSourceLinks {
+  /** Browseable URL for the install source, or null when the source
+   *  is a local path / bundled relpath / unknown shape. */
+  sourceUrl: string | null;
+  /** Friendly label for the source — github slug, hostname, or path
+   *  basename. Always present, never null. */
+  sourceLabel: string;
+  /** Display label for the source kind — "GitHub", "Official",
+   *  "Marketplace", etc. */
+  sourceKindLabel: string;
+  /** manifest.author.name trimmed, or null. */
+  authorName: string | null;
+  /** manifest.author.url when http(s), or null. */
+  authorProfileUrl: string | null;
+  /** Avatar URL when author.url points at a github profile/org, or
+   *  null. Uses github.com/<user>.png which works for both users and
+   *  orgs without an authenticated API call. */
+  authorAvatarUrl: string | null;
+  /** manifest.homepage when http(s), or null. */
+  homepageUrl: string | null;
+  /** Issues URL when source/homepage points at github, or null.
+   *  Encourages contributors by giving them a one-click "report an
+   *  issue / open a PR" entry point. */
+  contributeUrl: string | null;
+  /** True when the contribute URL points at a github repo. The UI
+   *  uses this to choose the right verb / icon ("Contribute on
+   *  GitHub" vs. a generic external-link). */
+  contributeOnGithub: boolean;
+}
+
+const OPEN_DESIGN_REPO_URL = 'https://github.com/nexu-io/open-design';
+const OPEN_DESIGN_REPO_LABEL = 'nexu-io/open-design';
+const OPEN_DESIGN_FEEDBACK_TEMPLATE = 'preview-v0.8.0-feedback.yml';
+
+const GITHUB_SOURCE_RE = /^github:([A-Za-z0-9._-]+)\/([A-Za-z0-9._-]+)(?:@([A-Za-z0-9._/-]+))?(?:\/(.+))?$/;
+const GITHUB_PROFILE_RE = /^https?:\/\/(?:www\.)?github\.com\/([A-Za-z0-9](?:[A-Za-z0-9-]{0,38}[A-Za-z0-9])?)(?:[\/?#].*)?$/;
+const GITHUB_REPO_RE = /^https?:\/\/(?:www\.)?github\.com\/([A-Za-z0-9](?:[A-Za-z0-9-]{0,38}[A-Za-z0-9])?)\/([A-Za-z0-9._-]+?)(?:\.git)?(?:[\/?#].*)?$/;
+
+/** Only http(s) URLs are safe to render as clickable links. */
+function safeHttpUrl(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (!/^https?:\/\//i.test(trimmed)) return null;
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+/** github.com/owner/repo[/...] → "owner/repo" or null. */
+function githubRepoSlug(url: string): { owner: string; repo: string } | null {
+  const match = GITHUB_REPO_RE.exec(url);
+  if (!match) return null;
+  return { owner: match[1]!, repo: match[2]! };
+}
+
+/** github.com/<user> → "<user>" or null. Distinguishes single-segment
+ *  profile/org URLs from multi-segment repo URLs. */
+function githubUsername(url: string): string | null {
+  const match = GITHUB_PROFILE_RE.exec(url);
+  if (!match) return null;
+  // Reject multi-segment paths: a profile URL has nothing after the
+  // username (other than query/hash). Repo URLs go through the repo
+  // matcher instead.
+  try {
+    const parsed = new URL(url);
+    const segments = parsed.pathname.split('/').filter(Boolean);
+    if (segments.length !== 1) return null;
+  } catch {
+    return null;
+  }
+  return match[1]!;
+}
+
+function basename(filesystemPath: string): string {
+  const parts = filesystemPath.split(/[\\/]/).filter(Boolean);
+  return parts[parts.length - 1] ?? filesystemPath;
+}
+
+function githubIssuesNewUrl(owner: string, repo: string): string {
+  const base = `https://github.com/${owner}/${repo}/issues/new`;
+  return owner === 'nexu-io' && repo === 'open-design'
+    ? `${base}?template=${OPEN_DESIGN_FEEDBACK_TEMPLATE}`
+    : base;
+}
+
+const SOURCE_KIND_LABELS: Record<PluginSourceKind, string> = {
+  bundled:     'Official',
+  user:        'User',
+  project:     'Project',
+  marketplace: 'Marketplace',
+  github:      'GitHub',
+  url:         'URL',
+  local:       'Local',
+};
+
+/** Derive everything the UI needs about a plugin's source + author
+ *  in one call. Pure — safe to call from render. */
+export function derivePluginSourceLinks(record: PluginSourceRecord): PluginSourceLinks {
+  const manifest = record.manifest ?? {};
+  const author = (manifest as { author?: { name?: unknown; url?: unknown } }).author ?? {};
+  const homepageRaw = (manifest as { homepage?: unknown }).homepage;
+  const officialBundled = record.sourceKind === 'bundled';
+
+  const authorName = typeof author.name === 'string' && author.name.trim().length > 0
+    ? author.name.trim()
+    : null;
+  const authorProfileUrl = officialBundled ? OPEN_DESIGN_REPO_URL : safeHttpUrl(author.url);
+  const homepageUrl = officialBundled ? OPEN_DESIGN_REPO_URL : safeHttpUrl(homepageRaw);
+
+  // Source URL + label resolution. The github:owner/repo case wins
+  // because we can produce a deep `tree/<ref>/<sub>` URL when the
+  // source string carries a ref; the https case just uses the URL
+  // verbatim so users can click through to their tarball mirror.
+  let sourceUrl: string | null = null;
+  let sourceLabel: string;
+  let sourceContributeUrl: string | null = null;
+
+  if (record.sourceKind === 'github') {
+    const match = GITHUB_SOURCE_RE.exec(record.source);
+    if (match) {
+      const [, owner, repo, ref, subpath] = match;
+      const ref0 = ref || record.pinnedRef;
+      // Refs can contain `/` (branches like `release/1.0`, or
+      // installer refs that absorbed a subpath) — encode each
+      // segment so spaces/special chars are escaped but the
+      // separators stay.
+      const refSegment = ref0 && ref0 !== 'HEAD'
+        ? `/tree/${ref0.split('/').map(encodeURIComponent).join('/')}`
+        : '';
+      const subSegment = subpath ? `/${subpath.split('/').map(encodeURIComponent).join('/')}` : '';
+      sourceUrl = `https://github.com/${owner}/${repo}${refSegment}${subSegment}`;
+      sourceLabel = `${owner}/${repo}${ref0 ? ` @${ref0}` : ''}${subpath ? `/${subpath}` : ''}`;
+      if (owner && repo) {
+        sourceContributeUrl = githubIssuesNewUrl(owner, repo);
+      }
+    } else {
+      sourceLabel = record.source;
+    }
+  } else if (record.sourceKind === 'url') {
+    const safe = safeHttpUrl(record.source);
+    if (safe) {
+      sourceUrl = safe;
+      try {
+        sourceLabel = new URL(safe).hostname + new URL(safe).pathname.replace(/\/$/, '');
+      } catch {
+        sourceLabel = safe;
+      }
+    } else {
+      sourceLabel = record.source;
+    }
+  } else if (record.sourceKind === 'marketplace') {
+    sourceLabel = record.source;
+  } else if (officialBundled) {
+    sourceUrl = OPEN_DESIGN_REPO_URL;
+    sourceLabel = OPEN_DESIGN_REPO_LABEL;
+  } else {
+    // user / project / local — the source string is a filesystem
+    // path. Show just the basename for compactness; the
+    // full path stays available via the existing fsPath dt/dd.
+    sourceLabel = basename(record.source) || record.source;
+  }
+
+  // Contribute link: prefer the source's github repo, fall back to
+  // the homepage when it points at github (covers bundled plugins
+  // whose `source` is a local relpath but `homepage` is the upstream
+  // repo URL).
+  let contributeUrl = sourceContributeUrl;
+  let contributeOnGithub = sourceContributeUrl !== null;
+  if (!contributeUrl && homepageUrl) {
+    const repo = githubRepoSlug(homepageUrl);
+    if (repo) {
+      contributeUrl = githubIssuesNewUrl(repo.owner, repo.repo);
+      contributeOnGithub = true;
+    }
+  }
+
+  // Avatar derivation: github.com/<user>.png returns the avatar for
+  // both user and organisation accounts without authentication. The
+  // fallback also works when author.url is a repo URL — we extract
+  // the owner segment for the avatar.
+  let authorAvatarUrl: string | null = null;
+  if (authorProfileUrl) {
+    const username = githubUsername(authorProfileUrl);
+    if (username) {
+      authorAvatarUrl = `https://github.com/${username}.png?size=80`;
+    } else {
+      const repo = githubRepoSlug(authorProfileUrl);
+      if (repo) authorAvatarUrl = `https://github.com/${repo.owner}.png?size=80`;
+    }
+  }
+
+  return {
+    sourceUrl,
+    sourceLabel,
+    sourceKindLabel: SOURCE_KIND_LABELS[record.sourceKind] ?? record.sourceKind,
+    authorName,
+    authorProfileUrl,
+    authorAvatarUrl,
+    homepageUrl,
+    contributeUrl,
+    contributeOnGithub,
+  };
+}
+
+/** Deterministic two-letter monogram for the avatar fallback. */
+export function authorInitials(name: string | null): string {
+  if (!name) return '??';
+  const parts = name
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2);
+  if (parts.length === 0) return '??';
+  return parts.map((p) => p[0]!.toUpperCase()).join('');
+}

--- a/apps/web/tests/components/PromptTemplatePreviewModal.test.tsx
+++ b/apps/web/tests/components/PromptTemplatePreviewModal.test.tsx
@@ -1,9 +1,11 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useState } from 'react';
 
 import { I18nProvider } from '../../src/i18n';
+import { PromptTemplatesTab } from '../../src/components/PromptTemplatesTab';
 import { PromptTemplatePreviewModal } from '../../src/components/PromptTemplatePreviewModal';
 import type { PromptTemplateSummary } from '../../src/types';
 
@@ -25,9 +27,32 @@ function renderModal(summary: PromptTemplateSummary) {
   );
 }
 
+function renderGallery(summary: PromptTemplateSummary) {
+  function Harness() {
+    const [active, setActive] = useState<PromptTemplateSummary | null>(null);
+
+    return (
+      <>
+        <PromptTemplatesTab
+          surface={summary.surface}
+          templates={[summary]}
+          onPreview={setActive}
+        />
+        {active ? <PromptTemplatePreviewModal summary={active} onClose={() => setActive(null)} /> : null}
+      </>
+    );
+  }
+
+  return render(
+    <I18nProvider initial="en">
+      <Harness />
+    </I18nProvider>,
+  );
+}
+
 describe('PromptTemplatePreviewModal', () => {
-  it('renders the Open Design contribute link with the preview feedback template', async () => {
-    renderModal({
+  it('renders the Open Design contribute link from the live gallery flow', async () => {
+    renderGallery({
       id: 'open-design-preview',
       surface: 'image',
       title: 'Open Design Preview',
@@ -40,6 +65,8 @@ describe('PromptTemplatePreviewModal', () => {
         url: 'https://github.com/nexu-io/open-design',
       },
     });
+
+    fireEvent.click(screen.getByText('Open Design Preview'));
 
     const contributeLink = await screen.findByRole('link', { name: 'Contribute' });
     expect(contributeLink.getAttribute('href')).toBe(

--- a/apps/web/tests/components/PromptTemplatePreviewModal.test.tsx
+++ b/apps/web/tests/components/PromptTemplatePreviewModal.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { I18nProvider } from '../../src/i18n';
+import { PromptTemplatePreviewModal } from '../../src/components/PromptTemplatePreviewModal';
+import type { PromptTemplateSummary } from '../../src/types';
+
+const fetchPromptTemplateMock = vi.hoisted(() => vi.fn(async () => ({ prompt: 'hello' })));
+
+vi.mock('../../src/providers/registry', () => ({
+  fetchPromptTemplate: fetchPromptTemplateMock,
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderModal(summary: PromptTemplateSummary) {
+  return render(
+    <I18nProvider initial="en">
+      <PromptTemplatePreviewModal summary={summary} onClose={vi.fn()} />
+    </I18nProvider>,
+  );
+}
+
+describe('PromptTemplatePreviewModal', () => {
+  it('renders the Open Design contribute link with the preview feedback template', async () => {
+    renderModal({
+      id: 'open-design-preview',
+      surface: 'image',
+      title: 'Open Design Preview',
+      summary: 'Preview template',
+      category: 'General',
+      source: {
+        repo: 'nexu-io/open-design',
+        license: 'MIT',
+        author: 'Open Design',
+        url: 'https://github.com/nexu-io/open-design',
+      },
+    });
+
+    const contributeLink = await screen.findByRole('link', { name: 'Contribute' });
+    expect(contributeLink.getAttribute('href')).toBe(
+      'https://github.com/nexu-io/open-design/issues/new?template=preview-v0.8.0-feedback.yml',
+    );
+  });
+});

--- a/apps/web/tests/runtime/plugin-source.test.ts
+++ b/apps/web/tests/runtime/plugin-source.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  authorInitials,
+  derivePluginSourceLinks,
+} from '../../src/runtime/plugin-source';
+type Record = Parameters<typeof derivePluginSourceLinks>[0];
+
+function makeRecord(overrides: Partial<Record>): Record {
+  return {
+    source:     './local/path',
+    sourceKind: 'local',
+    fsPath:     '/abs/local/path',
+    manifest: {
+      name:    'test-plugin',
+      version: '1.0.0',
+    },
+    ...overrides,
+  };
+}
+
+describe('derivePluginSourceLinks · github sources', () => {
+  it('builds tree URL with ref + subpath when source has both', () => {
+    const out = derivePluginSourceLinks(
+      makeRecord({
+        sourceKind: 'github',
+        source:     'github:open-design/plugins@v1.2.0/make-a-deck',
+      }),
+    );
+    expect(out.sourceUrl).toBe('https://github.com/open-design/plugins/tree/v1.2.0/make-a-deck');
+    expect(out.sourceLabel).toBe('open-design/plugins @v1.2.0/make-a-deck');
+    expect(out.sourceKindLabel).toBe('GitHub');
+    expect(out.contributeUrl).toBe('https://github.com/open-design/plugins/issues/new');
+    expect(out.contributeOnGithub).toBe(true);
+  });
+
+  it('uses the preview feedback template for the Open Design repo', () => {
+    const out = derivePluginSourceLinks(
+      makeRecord({
+        sourceKind: 'github',
+        source:     'github:nexu-io/open-design',
+      }),
+    );
+
+    expect(out.contributeUrl).toBe(
+      'https://github.com/nexu-io/open-design/issues/new?template=preview-v0.8.0-feedback.yml',
+    );
+    expect(out.contributeOnGithub).toBe(true);
+  });
+
+  it('falls back to repo-root URL when no ref / subpath', () => {
+    const out = derivePluginSourceLinks(
+      makeRecord({
+        sourceKind: 'github',
+        source:     'github:open-design/plugins',
+      }),
+    );
+    expect(out.sourceUrl).toBe('https://github.com/open-design/plugins');
+    expect(out.sourceLabel).toBe('open-design/plugins');
+  });
+
+  it('uses pinnedRef when source has no inline ref', () => {
+    const out = derivePluginSourceLinks(
+      makeRecord({
+        sourceKind: 'github',
+        source:     'github:open-design/plugins',
+        pinnedRef:  'a1b2c3d4',
+      }),
+    );
+    expect(out.sourceUrl).toBe('https://github.com/open-design/plugins/tree/a1b2c3d4');
+    expect(out.sourceLabel).toBe('open-design/plugins @a1b2c3d4');
+  });
+
+  it('preserves slash-separated branch refs (release/1.0)', () => {
+    const out = derivePluginSourceLinks(
+      makeRecord({
+        sourceKind: 'github',
+        source:     'github:open-design/plugins',
+        pinnedRef:  'release/1.0',
+      }),
+    );
+    expect(out.sourceUrl).toBe('https://github.com/open-design/plugins/tree/release/1.0');
+  });
+
+  it('treats HEAD pinnedRef as no ref', () => {
+    const out = derivePluginSourceLinks(
+      makeRecord({
+        sourceKind: 'github',
+        source:     'github:open-design/plugins',
+        pinnedRef:  'HEAD',
+      }),
+    );
+    expect(out.sourceUrl).toBe('https://github.com/open-design/plugins');
+  });
+
+  it('falls back gracefully on a malformed github source', () => {
+    const out = derivePluginSourceLinks(
+      makeRecord({
+        sourceKind: 'github',
+        source:     'github:not-a-valid+source',
+      }),
+    );
+    expect(out.sourceUrl).toBeNull();
+    expect(out.sourceLabel).toBe('github:not-a-valid+source');
+  });
+});
+
+describe('derivePluginSourceLinks · url + local + bundled sources', () => {
+  it('uses an https tarball URL verbatim with a hostname label', () => {
+    const out = derivePluginSourceLinks(
+      makeRecord({
+        sourceKind: 'url',
+        source:     'https://example.com/plugins/make-a-deck.tgz',
+      }),
+    );
+    expect(out.sourceUrl).toBe('https://example.com/plugins/make-a-deck.tgz');
+    expect(out.sourceLabel).toBe('example.com/plugins/make-a-deck.tgz');
+    expect(out.sourceKindLabel).toBe('URL');
+  });
+
+  it('drops javascript: URLs from the source URL slot', () => {
+    const out = derivePluginSourceLinks(
+      makeRecord({
+        // eslint-disable-next-line no-script-url
+        sourceKind: 'url',
+        source:     'javascript:alert(1)',
+      }),
+    );
+    expect(out.sourceUrl).toBeNull();
+  });
+
+  it('uses basename as label for local sources', () => {
+    const out = derivePluginSourceLinks(
+      makeRecord({
+        sourceKind: 'local',
+        source:     '/Users/me/work/plugins/make-a-deck',
+      }),
+    );
+    expect(out.sourceUrl).toBeNull();
+    expect(out.sourceLabel).toBe('make-a-deck');
+    expect(out.sourceKindLabel).toBe('Local');
+  });
+
+  it('routes bundled official sources to the Open Design repo', () => {
+    const out = derivePluginSourceLinks(
+      makeRecord({
+        sourceKind: 'bundled',
+        source:     'plugins/_official/scenarios/od-code-migration',
+      }),
+    );
+    expect(out.sourceUrl).toBe('https://github.com/nexu-io/open-design');
+    expect(out.sourceKindLabel).toBe('Official');
+    expect(out.sourceLabel).toBe('nexu-io/open-design');
+    expect(out.authorProfileUrl).toBe('https://github.com/nexu-io/open-design');
+    expect(out.homepageUrl).toBe('https://github.com/nexu-io/open-design');
+    expect(out.contributeUrl).toBe('https://github.com/nexu-io/open-design/issues/new?template=preview-v0.8.0-feedback.yml');
+  });
+});
+
+describe('derivePluginSourceLinks · author + contribute', () => {
+  it('extracts github avatar from a profile URL', () => {
+    const out = derivePluginSourceLinks(
+      makeRecord({
+        manifest: {
+          name:    'p',
+          version: '1.0.0',
+          author:  { name: 'Open Design', url: 'https://github.com/nexu-io' },
+        },
+      }),
+    );
+    expect(out.authorName).toBe('Open Design');
+    expect(out.authorProfileUrl).toBe('https://github.com/nexu-io');
+    expect(out.authorAvatarUrl).toBe('https://github.com/nexu-io.png?size=80');
+  });
+
+  it('extracts github avatar from a repo URL by using the owner', () => {
+    const out = derivePluginSourceLinks(
+      makeRecord({
+        manifest: {
+          name:    'p',
+          version: '1.0.0',
+          author:  { name: 'Author', url: 'https://github.com/owner/repo' },
+        },
+      }),
+    );
+    expect(out.authorAvatarUrl).toBe('https://github.com/owner.png?size=80');
+  });
+
+  it('returns null avatar for non-github profile URLs', () => {
+    const out = derivePluginSourceLinks(
+      makeRecord({
+        manifest: {
+          name:    'p',
+          version: '1.0.0',
+          author:  { name: 'Author', url: 'https://example.com/me' },
+        },
+      }),
+    );
+    expect(out.authorProfileUrl).toBe('https://example.com/me');
+    expect(out.authorAvatarUrl).toBeNull();
+  });
+
+  it('falls back to homepage for the contribute link when source is not github', () => {
+    const out = derivePluginSourceLinks(
+      makeRecord({
+        sourceKind: 'bundled',
+        source:     'plugins/_official/scenarios/od-code-migration',
+        manifest: {
+          name:    'p',
+          version: '1.0.0',
+          homepage: 'https://github.com/nexu-io/open-design',
+        },
+      }),
+    );
+    expect(out.contributeUrl).toBe('https://github.com/nexu-io/open-design/issues/new?template=preview-v0.8.0-feedback.yml');
+    expect(out.contributeOnGithub).toBe(true);
+    expect(out.homepageUrl).toBe('https://github.com/nexu-io/open-design');
+  });
+
+  it('drops malformed homepage values', () => {
+    const out = derivePluginSourceLinks(
+      makeRecord({
+        manifest: {
+          name:    'p',
+          version: '1.0.0',
+          homepage: 'not a url',
+        },
+      }),
+    );
+    expect(out.homepageUrl).toBeNull();
+    expect(out.contributeUrl).toBeNull();
+    expect(out.contributeOnGithub).toBe(false);
+  });
+
+  it('returns null author fields when manifest has no author', () => {
+    const out = derivePluginSourceLinks(makeRecord({}));
+    expect(out.authorName).toBeNull();
+    expect(out.authorProfileUrl).toBeNull();
+    expect(out.authorAvatarUrl).toBeNull();
+  });
+});
+
+describe('authorInitials', () => {
+  it('builds two-letter monograms', () => {
+    expect(authorInitials('Open Design')).toBe('OD');
+    expect(authorInitials('jane')).toBe('J');
+    expect(authorInitials('Long Multi Word Name')).toBe('LM');
+  });
+
+  it('returns ?? for empty / null inputs', () => {
+    expect(authorInitials(null)).toBe('??');
+    expect(authorInitials('')).toBe('??');
+    expect(authorInitials('   ')).toBe('??');
+  });
+});


### PR DESCRIPTION
## Why
The generic Contribute link bypassed the preview feedback workflow.

## What users will see
Contribute on the plugin page opens the preview feedback template URL for Open Design.

## Surface area
- [x] UI
- [x] Tests
- apps/web/src/components/PromptTemplatePreviewModal.tsx
- apps/web/src/runtime/plugin-source.ts
- apps/web/tests/runtime/plugin-source.test.tsx

## Bug fix verification
Clicked Contribute on the plugin detail page and confirmed the URL includes `?template=preview-v0.8.0-feedback.yml`.

## Validation
- Added/updated runtime test coverage
