### PR TITLE
Fix long project names in the top bar

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -11814,6 +11814,7 @@ button.ghost.mcp-copy-btn:hover:not(:disabled) {
   border-radius: 4px;
   padding: 1px 4px;
   margin: -1px -4px;
+  max-width: min(100%, 420px);
 }
 .topbar-title .title.editable:focus,
 .app-project-title .title.editable:focus {


### PR DESCRIPTION
Closes #1763\n\n- Cap the editable project title width so long names truncate instead of stretching the header.