### PR TITLE
fix: Make template toolbar sticky during scroll

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5575,6 +5575,10 @@ code {
   /* Older browsers ignore row-gap on flex with wrap — explicit row-gap keeps
      the wrapped row visually separated rather than flush against the pill. */
   row-gap: 8px;
+  position: sticky;
+  top: 0;
+  z-index: 4;
+  background: var(--bg-panel);
 }
 .tab-panel-toolbar .toolbar-left {
   display: flex;


### PR DESCRIPTION
## Description

Fixes the template browsing experience by making the toolbar (search input + category/source dropdowns + count) sticky during scroll. This keeps filter controls visible while browsing the template gallery.

## Changes

- Added `position: sticky`, `top: 0`, `z-index: 4` to `.tab-panel-toolbar`
- Added `background: var(--bg-panel)` to prevent content showing through

## Rationale

As noted by @lefarcen in #1778, the `.tab-panel-toolbar` was missing sticky positioning that other headers in the app (chat header, kanban columns, etc.) already have. This caused the filter controls to scroll off-screen, making the browsing experience awkward.

The fix follows the existing pattern:
- `z-index: 4` matches other sticky headers in the codebase
- `background: var(--bg-panel)` ensures proper layering

## Testing

- [ ] Verified toolbar stays visible while scrolling through templates
- [ ] Checked that z-index doesn't conflict with other UI elements
- [ ] Tested on different screen sizes

Fixes #1778