### PR TITLE
feat(design-systems): add structured tokens for notion, linear, github, figma, slack, discord, openai, shopify, spotify, uber

### DIFF
--- a/design-systems/_schema/tokens.schema.ts
+++ b/design-systems/_schema/tokens.schema.ts
@@ -210,6 +210,9 @@ export const BRAND_EXTENSIONS: Readonly<Record<string, readonly string[]>> = {
   default: [
     "--space-20", // 80px — used as section-y-desktop's twin; only default needs it
   ],
+  openai: [
+    "--space-16", // 64px — major section gap in OpenAI's DESIGN.md §5 spacing scale
+  ],
   kami: [
     "--accent-light", // brighter ink-blue for links on dark surfaces
     "--text-md", // 15px lede tier between --text-base and --text-lg

--- a/design-systems/discord/components.html
+++ b/design-systems/discord/components.html
@@ -1,0 +1,359 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Discord — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/discord. Every visible
+        value comes from tokens.css. Discord's signature moves: dark-first
+        three-step depth ladder, gg sans with friendly geometry, Blurple
+        accent (#5865f2), semi-transparent white borders."
+    />
+
+    <style>
+      :root {
+        --bg:           #313338;
+        --surface:      #2b2d31;
+        --surface-warm: #1e1f22;
+
+        --fg:   #dbdee1;
+        --fg-2: #f2f3f5;
+        --muted: #949ba4;
+        --meta:  #80848e;
+
+        --border:      rgba(255, 255, 255, 0.06);
+        --border-soft: #3f4147;
+
+        --accent:        #5865f2;
+        --accent-on:     #ffffff;
+        --accent-hover:  #4752c4;
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+        --success: #23a55a;
+        --warn:    #f0b232;
+        --danger:  #f23f43;
+
+        --font-display: "gg sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+        --font-body:    "gg sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+        --font-mono:    "gg mono", Consolas, "Andale Mono", "Courier New", Courier, monospace;
+
+        --text-xs:   12px;
+        --text-sm:   14px;
+        --text-base: 16px;
+        --text-lg:   18px;
+        --text-xl:   20px;
+        --text-2xl:  24px;
+        --text-3xl:  32px;
+        --text-4xl:  56px;
+
+        --leading-body:     1.375;
+        --leading-tight:    1.10;
+        --tracking-display: -0.02em;
+
+        --space-1:  4px;
+        --space-2:  8px;
+        --space-3:  12px;
+        --space-4:  16px;
+        --space-5:  20px;
+        --space-6:  24px;
+        --space-8:  32px;
+        --space-12: 40px;
+
+        --section-y-desktop: 80px;
+        --section-y-tablet:  48px;
+        --section-y-phone:   32px;
+
+        --radius-sm:   4px;
+        --radius-md:   8px;
+        --radius-lg:   16px;
+        --radius-pill: 9999px;
+
+        --elev-flat:   none;
+        --elev-ring:   0 0 0 1px var(--border);
+        --elev-raised:
+          rgba(0, 0, 0, 0.4) 0px 2px 4px,
+          0 0 0 1px rgba(255, 255, 255, 0.06);
+
+        --focus-ring: 0 0 0 3px rgba(88, 101, 242, 0.3);
+
+        --motion-fast:   80ms;
+        --motion-base:   200ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+        --container-max:            1200px;
+        --container-gutter-desktop: 24px;
+        --container-gutter-tablet:  16px;
+        --container-gutter-phone:   16px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      section + section { border-top: 1px solid var(--border); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography ─────────────────────────── */
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        font-weight: 800;
+        margin: 0;
+        color: var(--fg-2);
+        line-height: var(--leading-tight);
+      }
+      h1 {
+        font-size: var(--text-4xl);
+        letter-spacing: var(--tracking-display);
+      }
+      h2 {
+        font-size: var(--text-3xl);
+        /* 32px section: line-height 1.20, normal tracking. */
+        line-height: 1.20;
+        font-weight: 700;
+      }
+      h3 {
+        font-size: var(--text-2xl);
+        /* 24px page heading: line-height 1.25 per DESIGN.md.
+           Overrides the shared 1.10 set above. */
+        line-height: 1.25;
+        font-weight: 700;
+      }
+      p { margin: 0; }
+      .lead { font-size: var(--text-lg); line-height: 1.55; color: var(--muted); font-weight: 400; }
+      .body-muted { color: var(--muted); }
+      .body-sm { font-size: var(--text-sm); color: var(--muted); }
+      .eyebrow {
+        font-size: var(--text-xs);
+        font-weight: 500;
+        color: var(--meta);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+
+      /* ─── Buttons ─────────────────────────────── */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 8px 16px;
+        border-radius: var(--radius-sm);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        font-weight: 500;
+        line-height: 1;
+        cursor: pointer;
+        border: none;
+        transition: background-color var(--motion-fast) var(--ease-standard);
+        text-decoration: none;
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn-primary { background: var(--accent); color: var(--accent-on); }
+      .btn-primary:hover { background: var(--accent-hover); }
+      .btn-secondary { background: #4e5058; color: #ffffff; }
+      .btn-secondary:hover { background: #6d6f78; }
+      .btn-danger { background: #da373c; color: #ffffff; }
+
+      /* ─── Server avatars ─────────────────────── */
+      .server-rail {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: var(--space-2);
+        padding: var(--space-3);
+        background: var(--surface-warm);
+        border-radius: var(--radius-md);
+      }
+      .server-icon {
+        width: 48px;
+        height: 48px;
+        border-radius: 16px;
+        background: var(--accent);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: var(--text-sm);
+        font-weight: 600;
+        color: white;
+        cursor: pointer;
+        transition: border-radius var(--motion-base) cubic-bezier(0.215, 0.61, 0.355, 1);
+      }
+      .server-icon:hover { border-radius: 50%; }
+
+      /* ─── Mention pill ───────────────────────── */
+      .mention {
+        display: inline;
+        background: rgba(88, 101, 242, 0.3);
+        color: #c9cdfb;
+        padding: 0 2px;
+        border-radius: 3px;
+        font-weight: 500;
+      }
+
+      /* ─── Card ───────────────────────────────── */
+      .card {
+        background: var(--surface);
+        border: 1px solid var(--border-soft);
+        border-radius: var(--radius-md);
+        padding: var(--space-6);
+      }
+
+      /* ─── Inputs ─────────────────────────────── */
+      .field { display: flex; flex-direction: column; gap: var(--space-2); }
+      .field label { font-size: var(--text-sm); font-weight: 600; color: var(--fg-2); text-transform: uppercase; letter-spacing: 0.04em; }
+      .field input {
+        background: var(--surface-warm);
+        color: var(--fg);
+        border: 1px solid var(--surface-warm);
+        border-radius: var(--radius-sm);
+        padding: 10px 12px;
+        font-size: var(--text-base);
+        outline: none;
+        transition: border-color var(--motion-fast) var(--ease-standard);
+      }
+      .field input::placeholder { color: var(--muted); }
+      .field input:focus { border-color: var(--accent); }
+
+      /* ─── Layout ─────────────────────────────── */
+      .hero-grid {
+        display: grid;
+        grid-template-columns: 1.3fr 1fr;
+        gap: var(--space-12);
+        align-items: center;
+      }
+      @media (max-width: 1023px) { .hero-grid { grid-template-columns: 1fr; } }
+      .features-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: var(--space-4);
+      }
+      @media (max-width: 1023px) { .features-grid { grid-template-columns: 1fr 1fr; } }
+      @media (max-width: 639px)  { .features-grid { grid-template-columns: 1fr; } }
+      .hero-actions { display: flex; gap: var(--space-3); margin-block-start: var(--space-6); flex-wrap: wrap; }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <!-- HERO -->
+      <section data-od-id="hero">
+        <div class="hero-grid">
+          <div class="stack-4">
+            <p class="eyebrow">Reference fixture · discord</p>
+            <h1>Your place to talk.</h1>
+            <p class="lead" style="max-width:46ch">
+              Discord is the easiest way to talk over voice, video, and text.
+              Dark-first, Blurple accent, gg sans — every value from tokens.css.
+            </p>
+            <div class="hero-actions">
+              <a href="./tokens.css" class="btn btn-primary">Download for free</a>
+              <a href="./DESIGN.md" class="btn btn-secondary">Read the spec</a>
+            </div>
+          </div>
+
+          <aside style="display:flex;gap:var(--space-4);align-items:flex-start">
+            <div class="server-rail">
+              <div class="server-icon">OD</div>
+              <div style="width:32px;height:2px;background:var(--border-soft);border-radius:2px"></div>
+              <div class="server-icon" style="background:#23a55a;font-size:18px">🎮</div>
+              <div class="server-icon" style="background:#8250df;font-size:18px">🎨</div>
+            </div>
+            <div class="card stack-3" style="flex:1">
+              <p class="eyebrow"># general</p>
+              <p style="font-size:var(--text-base);color:var(--fg)">
+                <span style="font-weight:500;color:#f2f3f5">Ada</span>&nbsp;
+                <span style="font-size:var(--text-xs);color:var(--meta)">Today at 4:32 PM</span>
+              </p>
+              <p style="font-size:var(--text-base)">
+                Adding token fixtures for <span class="mention">@batch-2</span> brands today.
+              </p>
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <!-- FEATURES -->
+      <section data-od-id="features">
+        <div class="stack-3" style="margin-bottom:var(--space-6)">
+          <p class="eyebrow">What this fixture exercises</p>
+          <h2>Dark depth through luminance steps.</h2>
+        </div>
+
+        <div class="features-grid">
+          <article class="card stack-3">
+            <h3>Three-step depth</h3>
+            <p class="body-sm">
+              #1e1f22 server rail → #2b2d31 sidebar → #313338 chat. Each step
+              slightly lighter. No color variation — only luminance.
+            </p>
+          </article>
+          <article class="card stack-3">
+            <h3>Blurple accent</h3>
+            <p class="body-sm">
+              #5865f2 — reserved for CTAs, mentions, and "you" affordances.
+              Hover: #4752c4. Used sparingly so it pops against muted neutrals.
+            </p>
+          </article>
+          <article class="card stack-3">
+            <h3>gg sans geometry</h3>
+            <p class="body-sm">
+              Friendly rounded terminals on a/g/s. Weight 400/500/600/700/800 —
+              hierarchy through contrast, not color. 16px body never shrinks.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <!-- FORM -->
+      <section data-od-id="form">
+        <div style="display:grid;grid-template-columns:1.2fr 1fr;gap:var(--space-12);align-items:start">
+          <div class="stack-4">
+            <p class="eyebrow">Form components</p>
+            <h2>Inputs on dark surfaces.</h2>
+            <p class="lead" style="max-width:44ch">
+              Background: #1e1f22. Border shifts to Blurple on focus.
+              Labels: uppercase, 0.04em tracking, weight 600.
+            </p>
+          </div>
+          <form style="display:flex;flex-direction:column;gap:var(--space-4);max-width:400px"
+                onsubmit="event.preventDefault()">
+            <div class="field">
+              <label for="email">Email</label>
+              <input id="email" type="email" placeholder="you@example.com" />
+            </div>
+            <div class="field">
+              <label for="username">Username</label>
+              <input id="username" type="text" placeholder="cooluser#1234" />
+            </div>
+            <div style="display:flex;gap:var(--space-3);margin-top:var(--space-2)">
+              <button type="submit" class="btn btn-primary">Continue</button>
+              <button type="button" class="btn btn-secondary">Back</button>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/discord/tokens.css
+++ b/design-systems/discord/tokens.css
@@ -1,0 +1,125 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/discord/tokens.css
+ *
+ * Structured token bindings for the "Discord" brand — deep blurple,
+ * dark-first surfaces, voice-and-chat for gaming and community.
+ *
+ * Brand identity in three sentences:
+ *   1. Dark-first: three-step depth ladder (#1e1f22 deepest → #2b2d31
+ *      sidebar → #313338 chat surface), pixel-snapped 1px dividers at
+ *      low alpha, rounded-square server avatars that morph to circles.
+ *   2. gg sans (friendly geometric, Whitney-replacement) for all text at
+ *      400/500/600/700/800 weights; 16px body never shrinks; hierarchy
+ *      comes from weight contrast over color contrast.
+ *   3. Blurple (#5865f2) as the single saturated accent — reserved for
+ *      brand mark, primary CTAs, mentions, and "you" affordances; used
+ *      sparingly so it pops against the muted dark surface.
+ *
+ * Schema decisions:
+ *   - --bg: #313338 (chat surface / primary dark); --surface: #2b2d31.
+ *   - --surface-warm: #191a1e (deepest — server list rail, level below).
+ *   - --fg: #dbdee1 (text-normal — cooler than pure white).
+ *   - --fg-2: #f2f3f5 (header-primary — modal titles, channel headers).
+ *   - --muted: #949ba4 (text-muted — timestamps, metadata).
+ *   - --border: rgba(255,255,255,0.06); --border-soft: same.
+ *   - --accent: #5865f2 (Blurple); --accent-hover: #4752c4.
+ *   - --tracking-display: -0.02em (display 56px hero per DESIGN.md).
+ *   - --radius-sm: 4px (buttons/inputs); --radius-md: 8px (cards).
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface ──────────────────────────────────────────────────── */
+  --bg:           #313338;              /* chat surface / primary dark */
+  --surface:      #2b2d31;              /* channel sidebar, settings sidebar */
+  --surface-warm: #1e1f22;             /* server list rail — deepest layer */
+
+  /* ─── Foreground ───────────────────────────────────────────────── */
+  --fg:   #dbdee1;                      /* text-normal — slightly cooler than white */
+  --fg-2: #f2f3f5;                      /* header-primary — modal titles */
+  --muted: #949ba4;                     /* text-muted — timestamps, server names */
+  --meta:  #80848e;                     /* channels-default — inactive sidebar names */
+
+  /* ─── Border ───────────────────────────────────────────────────── */
+  --border:      rgba(255, 255, 255, 0.06);  /* standard divider */
+  --border-soft: #3f4147;                    /* solid divider for cards */
+
+  /* ─── Accent ───────────────────────────────────────────────────── */
+  --accent:        #5865f2;            /* Blurple — brand primary CTA */
+  --accent-on:     #ffffff;
+  --accent-hover:  #4752c4;            /* darker hover */
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+  /* ─── Semantic ─────────────────────────────────────────────────── */
+  --success: #23a55a;                  /* status-online green */
+  --warn:    #f0b232;                  /* status-idle yellow */
+  --danger:  #f23f43;                  /* status-dnd / destructive red */
+
+  /* ─── Typography ───────────────────────────────────────────────── */
+  --font-display: "gg sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-body:    "gg sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-mono:    "gg mono", Consolas, "Andale Mono", "Courier New", Courier, monospace;
+
+  /* Type scale — DESIGN.md §Typography Hierarchy.
+   * Discord: 56px display, 24px page heading, 16px body (never shrinks).
+   * Schema spine: xs=12 (timestamp/caption), base=16, 4xl=56. */
+  --text-xs:   12px;                   /* timestamp / caption / meta */
+  --text-sm:   14px;                   /* compact metadata */
+  --text-base: 16px;                   /* message body — never below 16px */
+  --text-lg:   18px;                   /* feature heading */
+  --text-xl:   20px;                   /* sub-heading */
+  --text-2xl:  24px;                   /* page heading — settings/profile */
+  --text-3xl:  32px;                   /* section heading */
+  --text-4xl:  56px;                   /* display hero — marketing */
+
+  /* Leading + tracking.
+   * --leading-tight=1.10: 56px hero compression.
+   * h2 (32px) → 1.20; h3 (24px) → 1.25 per brand feel.
+   * --tracking-display: -0.02em (display 56px per DESIGN.md). */
+  --leading-body:     1.375;
+  --leading-tight:    1.10;
+  --tracking-display: -0.02em;
+
+  /* ─── Spacing ──────────────────────────────────────────────────── */
+  /* 4px base grid per DESIGN.md §Spacing & Layout. */
+  --space-1:  4px;
+  --space-2:  8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  20px;
+  --space-6:  24px;
+  --space-8:  32px;
+  --space-12: 40px;
+
+  /* Section rhythm. */
+  --section-y-desktop: 80px;
+  --section-y-tablet:  48px;
+  --section-y-phone:   32px;
+
+  /* ─── Radius ───────────────────────────────────────────────────── */
+  /* 4px for buttons/inputs; 8px for cards. Rounded but not balloon-soft. */
+  --radius-sm:   4px;
+  --radius-md:   8px;
+  --radius-lg:   16px;
+  --radius-pill: 9999px;
+
+  /* ─── Elevation ────────────────────────────────────────────────── */
+  /* Dark surfaces: luminance stepping; semi-transparent white borders
+     as depth signal rather than drop shadows. */
+  --elev-flat:   none;
+  --elev-ring:   0 0 0 1px var(--border);
+  --elev-raised: rgba(0, 0, 0, 0.4) 0px 2px 4px, 0 0 0 1px rgba(255, 255, 255, 0.06);
+
+  /* ─── Focus ────────────────────────────────────────────────────── */
+  --focus-ring: 0 0 0 3px rgba(88, 101, 242, 0.3);
+
+  /* ─── Motion ───────────────────────────────────────────────────── */
+  --motion-fast:   80ms;
+  --motion-base:   200ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+  /* ─── Layout ───────────────────────────────────────────────────── */
+  --container-max:            1200px;
+  --container-gutter-desktop: 24px;
+  --container-gutter-tablet:  16px;
+  --container-gutter-phone:   16px;
+}

--- a/design-systems/figma/components.html
+++ b/design-systems/figma/components.html
@@ -1,0 +1,344 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Figma — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/figma. Every visible
+        value comes from tokens.css. Figma's signature moves: strictly
+        black-and-white interface, figmaSans variable weights (320–700),
+        pill (50px) and circular (50%) geometry, dashed focus outlines,
+        figmaMono uppercase labels with positive letter-spacing."
+    />
+
+    <style>
+      :root {
+        --bg:           #ffffff;
+        --surface:      #ffffff;
+        --surface-warm: var(--surface);
+
+        --fg:   #000000;
+        --fg-2: #000000;
+        --muted: rgba(0, 0, 0, 0.55);
+        --meta:  rgba(0, 0, 0, 0.40);
+
+        --border:      rgba(0, 0, 0, 0.12);
+        --border-soft: rgba(0, 0, 0, 0.06);
+
+        --accent:        #000000;
+        --accent-on:     #ffffff;
+        --accent-hover:  rgba(0, 0, 0, 0.85);
+        --accent-active: rgba(0, 0, 0, 0.08);
+
+        --success: #16a34a;
+        --warn:    #eab308;
+        --danger:  #dc2626;
+
+        --font-display: "figmaSans", "figmaSans Fallback", "SF Pro Display", system-ui, Helvetica, sans-serif;
+        --font-body:    "figmaSans", "figmaSans Fallback", "SF Pro Display", system-ui, Helvetica, sans-serif;
+        --font-mono:    "figmaMono", "figmaMono Fallback", "SF Mono", Menlo, ui-monospace, monospace;
+
+        --text-xs:   12px;
+        --text-sm:   16px;
+        --text-base: 16px;
+        --text-lg:   20px;
+        --text-xl:   26px;
+        --text-2xl:  26px;
+        --text-3xl:  64px;
+        --text-4xl:  86px;
+
+        --leading-body:     1.40;
+        --leading-tight:    1.00;
+        --tracking-display: -0.02em;
+
+        --space-1:  4px;
+        --space-2:  8px;
+        --space-3:  12px;
+        --space-4:  16px;
+        --space-5:  20px;
+        --space-6:  24px;
+        --space-8:  32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 96px;
+        --section-y-tablet:  64px;
+        --section-y-phone:   40px;
+
+        --radius-sm:   50px;
+        --radius-md:   8px;
+        --radius-lg:   8px;
+        --radius-pill: 9999px;
+
+        --elev-flat:   none;
+        --elev-ring:   0 0 0 1px var(--border);
+        --elev-raised: 0 4px 16px rgba(0, 0, 0, 0.08);
+
+        --focus-ring: 0 0 0 2px rgba(0, 0, 0, 0.8);
+
+        --motion-fast:   150ms;
+        --motion-base:   200ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+        --container-max:            1920px;
+        --container-gutter-desktop: 40px;
+        --container-gutter-tablet:  24px;
+        --container-gutter-phone:   16px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        /* OpenType kern on all text — structural, not decorative. */
+        font-feature-settings: "kern";
+        -webkit-font-smoothing: antialiased;
+      }
+
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      section + section { border-top: 1px solid var(--border); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography ─────────────────────────── */
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        font-weight: 400;              /* figmaSans light — base display weight */
+        margin: 0;
+        line-height: var(--leading-tight);
+        font-feature-settings: "kern";
+      }
+      h1 {
+        font-size: var(--text-4xl);
+        letter-spacing: var(--tracking-display);
+      }
+      h2 {
+        font-size: var(--text-3xl);
+        /* 64px section: line-height 1.10, tracking -0.96px (-0.015em). */
+        line-height: 1.10;
+        letter-spacing: -0.015em;
+      }
+      h3 {
+        font-size: var(--text-xl);
+        /* 26px sub-heading: line-height 1.35, tracking -0.26px (-0.01em).
+           Overrides the shared 1.00 set above. */
+        line-height: 1.35;
+        letter-spacing: -0.01em;
+        font-weight: 540;
+      }
+      p { margin: 0; }
+      .lead {
+        font-size: var(--text-lg);
+        line-height: 1.40;
+        color: var(--muted);
+        font-weight: 330;
+        letter-spacing: -0.007em;
+      }
+      /* figmaMono uppercase label — section signpost. */
+      .mono-label {
+        font-family: var(--font-mono);
+        font-size: 18px;
+        font-weight: 400;
+        text-transform: uppercase;
+        letter-spacing: 0.54px;
+        color: var(--fg);
+        line-height: 1.30;
+      }
+      .body-muted { color: var(--muted); }
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+
+      /* ─── Buttons ─────────────────────────────── */
+      /* All buttons use pill (50px) or circle (50%) — non-negotiable. */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 10px 20px;
+        border-radius: var(--radius-sm);   /* 50px pill */
+        font-family: var(--font-display);
+        font-size: var(--text-base);
+        font-weight: 400;
+        font-feature-settings: "kern";
+        line-height: 1;
+        cursor: pointer;
+        border: none;
+        transition: background-color var(--motion-fast) var(--ease-standard),
+                    color var(--motion-fast) var(--ease-standard);
+        text-decoration: none;
+      }
+      /* Figma focus: dashed 2px outline — the editor selection handle echo. */
+      .btn:focus-visible { outline: 2px dashed var(--fg); outline-offset: 2px; }
+      .btn-black {
+        background: var(--fg);
+        color: var(--accent-on);
+      }
+      .btn-black:hover { background: rgba(0, 0, 0, 0.85); }
+      .btn-white {
+        background: var(--bg);
+        color: var(--fg);
+        border: 1px solid rgba(0, 0, 0, 0.15);
+      }
+      .btn-white:hover { background: rgba(0, 0, 0, 0.04); }
+
+      /* ─── Product tab bar ─────────────────────── */
+      .tab-bar {
+        display: flex;
+        gap: var(--space-2);
+        flex-wrap: wrap;
+      }
+      .tab {
+        padding: 8px 18px;
+        border-radius: var(--radius-sm);  /* 50px pill */
+        font-size: var(--text-base);
+        font-weight: 480;
+        cursor: pointer;
+        border: none;
+        background: transparent;
+        color: var(--fg);
+        font-feature-settings: "kern";
+        transition: background-color var(--motion-fast) var(--ease-standard);
+      }
+      .tab:hover { background: rgba(0, 0, 0, 0.06); }
+      .tab.active { background: var(--fg); color: var(--accent-on); }
+      .tab:focus-visible { outline: 2px dashed var(--fg); outline-offset: 2px; }
+
+      /* ─── Cards ──────────────────────────────── */
+      .card {
+        background: var(--bg);
+        border-radius: var(--radius-md);
+        padding: var(--space-6);
+        box-shadow: var(--elev-raised);
+      }
+
+      /* ─── Layout ─────────────────────────────── */
+      .hero-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-12);
+        align-items: center;
+      }
+      @media (max-width: 1023px) { .hero-grid { grid-template-columns: 1fr; } }
+      .features-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: var(--space-5);
+      }
+      @media (max-width: 1023px) { .features-grid { grid-template-columns: 1fr 1fr; } }
+      @media (max-width: 639px)  { .features-grid { grid-template-columns: 1fr; } }
+      .hero-actions { display: flex; gap: var(--space-3); margin-block-start: var(--space-6); flex-wrap: wrap; }
+      .icon { width: 16px; height: 16px; flex-shrink: 0; }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <!-- HERO -->
+      <section data-od-id="hero">
+        <div class="hero-grid">
+          <div class="stack-4">
+            <p class="mono-label">Reference fixture · figma</p>
+            <h1>Nothing great is made alone.</h1>
+            <p class="lead" style="max-width:48ch">
+              Figma brings teams together to design, prototype, and build.
+              A strictly black-and-white interface where product content is the
+              hero. Every value below from tokens.css.
+            </p>
+            <div class="hero-actions">
+              <a href="./tokens.css" class="btn btn-black">
+                Get started for free
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                     stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M5 12h14M13 6l6 6-6 6"/>
+                </svg>
+              </a>
+              <a href="./DESIGN.md" class="btn btn-white">Read the spec</a>
+            </div>
+          </div>
+
+          <aside>
+            <div class="card">
+              <p class="mono-label" style="margin-bottom:var(--space-4)">Product areas</p>
+              <div class="tab-bar">
+                <button class="tab active">Design</button>
+                <button class="tab">Dev Mode</button>
+                <button class="tab">Prototype</button>
+                <button class="tab">Slides</button>
+              </div>
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <!-- FEATURES -->
+      <section data-od-id="features">
+        <p class="mono-label" style="margin-bottom:var(--space-6)">What this fixture exercises</p>
+
+        <div class="features-grid">
+          <article class="card stack-3">
+            <h3>Variable precision</h3>
+            <p class="body-muted" style="font-size:var(--text-base);font-weight:330;letter-spacing:-0.007em">
+              Weight stops 320, 330, 340, 450, 480, 540, 700 — the granular
+              control IS the design. Hierarchy through micro-differences.
+            </p>
+          </article>
+          <article class="card stack-3">
+            <h3 style="font-weight:340">Monochrome chrome</h3>
+            <p class="body-muted" style="font-size:var(--text-base);font-weight:330;letter-spacing:-0.007em">
+              #000000 and #ffffff only. Color lives in product content —
+              gradients, screenshots, and embedded designs — never the shell.
+            </p>
+          </article>
+          <article class="card stack-3">
+            <h3>Dashed focus</h3>
+            <p class="body-muted" style="font-size:var(--text-base);font-weight:330;letter-spacing:-0.007em">
+              2px dashed outline on all interactive elements — echoes selection
+              handles in the Figma editor. The website speaks the product's UI.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <!-- FORM / ACTIONS -->
+      <section data-od-id="actions">
+        <div style="display:grid;grid-template-columns:1.2fr 1fr;gap:var(--space-12);align-items:start">
+          <div class="stack-4">
+            <p class="mono-label">Actions</p>
+            <h2 style="font-size:var(--text-xl);line-height:1.35;letter-spacing:-0.01em;font-weight:540">All buttons use pill (50px) radius.</h2>
+            <p class="lead" style="max-width:44ch">
+              No sharp corners on interactive elements. Black solid for primary;
+              bordered white for secondary. Focus is dashed, never solid.
+            </p>
+          </div>
+          <div style="display:flex;flex-direction:column;gap:var(--space-4)">
+            <div style="display:flex;gap:var(--space-3);flex-wrap:wrap">
+              <button class="btn btn-black">Primary action</button>
+              <button class="btn btn-white">Secondary</button>
+            </div>
+            <div style="display:flex;gap:var(--space-3);flex-wrap:wrap">
+              <button class="tab active">Active tab</button>
+              <button class="tab">Inactive tab</button>
+              <button class="tab">Another</button>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/figma/tokens.css
+++ b/design-systems/figma/tokens.css
@@ -1,0 +1,126 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/figma/tokens.css
+ *
+ * Structured token bindings for the "Figma" brand — vibrant product
+ * content inside a strictly black-and-white interface shell.
+ *
+ * Brand identity in three sentences:
+ *   1. Monochrome interface absolutely — pure black (#000000) for all
+ *      text, borders, and solid buttons; pure white (#ffffff) for all
+ *      backgrounds; no mid-tones in the chrome layer whatsoever.
+ *   2. figmaSans variable font at unusual weight stops (320, 330, 340,
+ *      450, 480, 540, 700); figmaMono for uppercase section labels with
+ *      positive letter-spacing; OpenType "kern" on all text.
+ *   3. Pill (50px) and circular (50%) geometry on all interactive
+ *      elements; dashed 2px focus outlines echoing editor selection
+ *      handles; negative tracking even on body text (-0.14px).
+ *
+ * Schema decisions:
+ *   - --bg: #ffffff; --surface: #ffffff (gallery wall — no surface tint).
+ *   - --surface-warm aliases --surface (B&W system has no warm tier).
+ *   - --fg: #000000; --muted: rgba(0,0,0,0.55) for secondary text.
+ *   - --accent: #000000 (black IS the accent in a monochrome system).
+ *   - --accent-on: #ffffff; hover and active via glass tint overlays.
+ *   - --tracking-display: -0.02em (-1.72px / 86px normalized).
+ *   - --leading-tight: 1.00 (display hero line-height).
+ *   - --radius-sm: 50px (pill — all interactive elements); pill = pill.
+ *   - Focus: dashed 2px outline — encoded in components.html, not ring.
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface ──────────────────────────────────────────────────── */
+  --bg:           #ffffff;
+  --surface:      #ffffff;              /* gallery wall — no surface tint */
+  --surface-warm: var(--surface);       /* no warm tier in B&W system */
+
+  /* ─── Foreground ───────────────────────────────────────────────── */
+  --fg:   #000000;
+  --fg-2: #000000;                      /* B&W — no secondary ink tier */
+  --muted: rgba(0, 0, 0, 0.55);        /* secondary text on white */
+  --meta:  rgba(0, 0, 0, 0.40);        /* metadata, captions */
+
+  /* ─── Border ───────────────────────────────────────────────────── */
+  --border:      rgba(0, 0, 0, 0.12);  /* minimal — only where structurally needed */
+  --border-soft: rgba(0, 0, 0, 0.06);
+
+  /* ─── Accent ───────────────────────────────────────────────────── */
+  /* In a strictly B&W system, black IS the accent (solid CTA). */
+  --accent:        #000000;
+  --accent-on:     #ffffff;
+  --accent-hover:  rgba(0, 0, 0, 0.85);
+  --accent-active: rgba(0, 0, 0, 0.08); /* glass dark — secondary button bg */
+
+  /* ─── Semantic ─────────────────────────────────────────────────── */
+  --success: #16a34a;
+  --warn:    #eab308;
+  --danger:  #dc2626;
+
+  /* ─── Typography ───────────────────────────────────────────────── */
+  --font-display: "figmaSans", "figmaSans Fallback", "SF Pro Display", system-ui, Helvetica, sans-serif;
+  --font-body:    "figmaSans", "figmaSans Fallback", "SF Pro Display", system-ui, Helvetica, sans-serif;
+  --font-mono:    "figmaMono", "figmaMono Fallback", "SF Mono", Menlo, ui-monospace, monospace;
+
+  /* Type scale — DESIGN.md §Typography Hierarchy.
+   * Figma's display range 86px→12px. The schema spine: 86px hero,
+   * 64px section, 26px sub-heading, 20px body-large, 16px body. */
+  --text-xs:   12px;                   /* mono small — uppercase tiny labels */
+  --text-sm:   16px;                   /* body / button */
+  --text-base: 16px;                   /* body baseline */
+  --text-lg:   20px;                   /* body large — descriptions */
+  --text-xl:   26px;                   /* sub-heading */
+  --text-2xl:  26px;                   /* sub-heading (same tier, weight varies) */
+  --text-3xl:  64px;                   /* section heading */
+  --text-4xl:  86px;                   /* display / hero */
+
+  /* Leading + tracking.
+   * --leading-tight=1.00: 86px hero compression.
+   * --tracking-display: -0.02em = -1.72px / 86px normalized.
+   * Body text: -0.14px inline; mono labels: +0.54px inline. */
+  --leading-body:     1.40;
+  --leading-tight:    1.00;
+  --tracking-display: -0.02em;
+
+  /* ─── Spacing ──────────────────────────────────────────────────── */
+  --space-1:  4px;
+  --space-2:  8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  20px;
+  --space-6:  24px;
+  --space-8:  32px;
+  --space-12: 48px;
+
+  /* Section rhythm — gallery-like pacing between product sections. */
+  --section-y-desktop: 96px;
+  --section-y-tablet:  64px;
+  --section-y-phone:   40px;
+
+  /* ─── Radius ───────────────────────────────────────────────────── */
+  /* Figma uses pill (50px) for all CTAs/tabs; 8px for card containers. */
+  --radius-sm:   50px;                 /* pill — all interactive elements */
+  --radius-md:   8px;                  /* cards, images, dialogs */
+  --radius-lg:   8px;
+  --radius-pill: 9999px;
+
+  /* ─── Elevation ────────────────────────────────────────────────── */
+  /* Depth via background contrast, not shadows. */
+  --elev-flat:   none;
+  --elev-ring:   0 0 0 1px var(--border);
+  --elev-raised: 0 4px 16px rgba(0, 0, 0, 0.08);
+
+  /* ─── Focus ────────────────────────────────────────────────────── */
+  /* Figma's signature: dashed 2px outline encoded at component level.
+     --focus-ring is used as the fallback shadow for keyboard nav. */
+  --focus-ring: 0 0 0 2px rgba(0, 0, 0, 0.8);
+
+  /* ─── Motion ───────────────────────────────────────────────────── */
+  --motion-fast:   150ms;
+  --motion-base:   200ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+  /* ─── Layout ───────────────────────────────────────────────────── */
+  --container-max:            1920px;
+  --container-gutter-desktop: 40px;
+  --container-gutter-tablet:  24px;
+  --container-gutter-phone:   16px;
+}

--- a/design-systems/github/components.html
+++ b/design-systems/github/components.html
@@ -1,0 +1,383 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>GitHub — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/github. Every visible
+        value comes from tokens.css. GitHub's signature moves: true white
+        canvas, hairline borders (#d0d7de), Primer blue CTAs, GitHub green
+        for success/merge, system-ui fonts, 14px body density."
+    />
+
+    <style>
+      :root {
+        --bg:           #ffffff;
+        --surface:      #f6f8fa;
+        --surface-warm: var(--surface);
+
+        --fg:   #1f2328;
+        --fg-2: #1f2328;
+        --muted: #656d76;
+        --meta:  #656d76;
+
+        --border:      #d0d7de;
+        --border-soft: #d8dee4;
+
+        --accent:        #0969da;
+        --accent-on:     #ffffff;
+        --accent-hover:  #0550ae;
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+        --success: #1a7f37;
+        --warn:    #9a6700;
+        --danger:  #cf222e;
+
+        --font-display: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+        --font-body:    -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+        --font-mono:    ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+
+        --text-xs:   12px;
+        --text-sm:   14px;
+        --text-base: 14px;
+        --text-lg:   16px;
+        --text-xl:   20px;
+        --text-2xl:  24px;
+        --text-3xl:  28px;
+        --text-4xl:  32px;
+
+        --leading-body:     1.5;
+        --leading-tight:    1.25;
+        --tracking-display: -0.01em;
+
+        --space-1:  4px;
+        --space-2:  8px;
+        --space-3:  12px;
+        --space-4:  16px;
+        --space-5:  20px;
+        --space-6:  24px;
+        --space-8:  32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 64px;
+        --section-y-tablet:  48px;
+        --section-y-phone:   32px;
+
+        --radius-sm:   6px;
+        --radius-md:   6px;
+        --radius-lg:   12px;
+        --radius-pill: 9999px;
+
+        --elev-flat:   none;
+        --elev-ring:   0 0 0 1px var(--border);
+        --elev-raised: 0 1px 3px rgba(31, 35, 40, 0.12), 0 8px 24px rgba(66, 74, 83, 0.12);
+
+        --focus-ring: 0 0 0 3px rgba(9, 105, 218, 0.3);
+
+        --motion-fast:   80ms;
+        --motion-base:   200ms;
+        --ease-standard: ease-out;
+
+        --container-max:            1280px;
+        --container-gutter-desktop: 24px;
+        --container-gutter-tablet:  16px;
+        --container-gutter-phone:   16px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      section + section { border-top: 1px solid var(--border); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography ─────────────────────────── */
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        font-weight: 600;
+        margin: 0;
+        line-height: var(--leading-tight);
+      }
+      h1 {
+        font-size: var(--text-4xl);
+        letter-spacing: var(--tracking-display);
+      }
+      h2 {
+        font-size: var(--text-xl);
+        /* 20px section heading: line-height 1.25, normal tracking. */
+      }
+      h3 {
+        font-size: var(--text-lg);
+        /* 16px sub-section/panel header: line-height 1.25.
+           Overrides the shared --leading-tight set above. */
+      }
+      p { margin: 0; }
+      .body-muted { color: var(--muted); }
+      .body-sm { font-size: var(--text-sm); }
+      .body-xs { font-size: var(--text-xs); }
+      .eyebrow {
+        font-size: var(--text-xs);
+        font-weight: 600;
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+      }
+      code {
+        font-family: var(--font-mono);
+        font-size: 0.85em;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        padding: 1px 4px;
+      }
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+
+      /* ─── Buttons ────────────────────────────── */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 5px 16px;
+        border-radius: var(--radius-sm);
+        font-family: var(--font-body);
+        font-size: var(--text-sm);
+        font-weight: 400;
+        line-height: 1.5;
+        cursor: pointer;
+        border: 1px solid transparent;
+        transition: background-color var(--motion-fast) var(--ease-standard),
+                    border-color var(--motion-fast) var(--ease-standard);
+        text-decoration: none;
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn-primary {
+        background: #1f883d;
+        color: #ffffff;
+        border-color: rgba(31, 35, 40, 0.15);
+        box-shadow: 0 1px 0 rgba(31, 35, 40, 0.1);
+        font-weight: 500;
+      }
+      .btn-primary:hover { background: var(--success); }
+      .btn-default {
+        background: var(--surface);
+        color: var(--fg);
+        border-color: var(--border);
+      }
+      .btn-default:hover { background: #f3f4f6; }
+      .btn-outline {
+        background: var(--bg);
+        color: var(--accent);
+        border-color: var(--border);
+      }
+      .btn-outline:hover { background: var(--accent); color: white; }
+
+      /* ─── Status pills ───────────────────────── */
+      .status-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-1);
+        padding: 4px 10px;
+        border-radius: var(--radius-pill);
+        font-size: var(--text-xs);
+        font-weight: 500;
+        color: white;
+        line-height: 1;
+      }
+      .status-open    { background: #1a7f37; }
+      .status-closed  { background: #cf222e; }
+      .status-merged  { background: #8250df; }
+      .status-draft   { background: #6e7781; }
+
+      /* ─── Box / Card ─────────────────────────── */
+      .box {
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        overflow: hidden;
+      }
+      .box-header {
+        background: var(--surface);
+        border-bottom: 1px solid var(--border);
+        padding: var(--space-3) var(--space-4);
+        font-weight: 600;
+        font-size: var(--text-sm);
+      }
+      .box-body { padding: var(--space-4); }
+
+      /* ─── Inputs ─────────────────────────────── */
+      .field { display: flex; flex-direction: column; gap: var(--space-2); }
+      .field label { font-size: var(--text-sm); font-weight: 600; color: var(--fg); }
+      .field input {
+        background: var(--bg);
+        color: var(--fg);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        padding: 5px 12px;
+        font-family: var(--font-body);
+        font-size: var(--text-sm);
+        outline: none;
+        transition: border-color var(--motion-fast) var(--ease-standard),
+                    box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .field input::placeholder { color: var(--muted); }
+      .field input:focus {
+        border-color: var(--accent);
+        box-shadow: var(--focus-ring);
+      }
+
+      /* ─── Layout ─────────────────────────────── */
+      .hero-grid {
+        display: grid;
+        grid-template-columns: 1.2fr 1fr;
+        gap: var(--space-8);
+        align-items: start;
+      }
+      @media (max-width: 1023px) { .hero-grid { grid-template-columns: 1fr; } }
+      .features-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: var(--space-4);
+      }
+      @media (max-width: 1023px) { .features-grid { grid-template-columns: 1fr 1fr; } }
+      @media (max-width: 639px)  { .features-grid { grid-template-columns: 1fr; } }
+      .hero-actions { display: flex; gap: var(--space-3); margin-block-start: var(--space-4); flex-wrap: wrap; }
+      .icon { width: 16px; height: 16px; flex-shrink: 0; }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <!-- HERO -->
+      <section data-od-id="hero">
+        <div class="hero-grid">
+          <div class="stack-4">
+            <p class="eyebrow">Reference fixture · github</p>
+            <h1>Where the world builds software.</h1>
+            <p class="body-muted" style="max-width:48ch;font-size:var(--text-lg);line-height:1.5;margin-top:var(--space-3)">
+              Millions of developers and companies build, ship, and maintain
+              their software on GitHub. Every value below comes from tokens.css
+              — no raw hex, no off-token type.
+            </p>
+            <div class="hero-actions">
+              <a href="./tokens.css" class="btn btn-primary">Sign up for free</a>
+              <a href="./DESIGN.md" class="btn btn-default">Read the spec</a>
+            </div>
+          </div>
+
+          <aside>
+            <div class="box">
+              <div class="box-header">open-design / design-systems</div>
+              <div class="box-body stack-3">
+                <div style="display:flex;align-items:center;justify-content:space-between">
+                  <span class="body-sm" style="font-weight:600;color:var(--accent)">Pull requests</span>
+                  <span class="status-pill status-open">Open</span>
+                </div>
+                <div style="font-size:var(--text-xs);color:var(--muted)">
+                  #1652 · feat: add structured tokens for 5 brands
+                </div>
+                <div style="font-size:var(--text-xs);color:var(--muted)">
+                  #1653 · feat: add batch 2 token fixtures
+                </div>
+                <div style="display:flex;gap:var(--space-2);margin-top:var(--space-2)">
+                  <span class="status-pill status-merged">Merged</span>
+                  <span class="status-pill status-draft">Draft</span>
+                  <span class="status-pill status-closed">Closed</span>
+                </div>
+              </div>
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <!-- FEATURES -->
+      <section data-od-id="features">
+        <div class="stack-3">
+          <p class="eyebrow">What this fixture exercises</p>
+          <h2>Dense, functional, system-native.</h2>
+        </div>
+
+        <div class="features-grid" style="margin-block-start:var(--space-6)">
+          <article class="box stack-3">
+            <div class="box-header">14px body</div>
+            <div class="box-body">
+              <p class="body-sm body-muted">
+                Not 16px — GitHub's prose density is its identity. 14px base
+                fits more content per viewport. system-ui renders instantly on
+                every OS with zero webfont load.
+              </p>
+            </div>
+          </article>
+          <article class="box stack-3">
+            <div class="box-header">Hairline borders</div>
+            <div class="box-body">
+              <p class="body-sm body-muted">
+                <code>#d0d7de</code> — every pane, panel, and card. Structure
+                communicated by stroke, not shadow. Density without visual noise.
+              </p>
+            </div>
+          </article>
+          <article class="box stack-3">
+            <div class="box-header">Primer blue + green</div>
+            <div class="box-body">
+              <p class="body-sm body-muted">
+                <code>#0969da</code> for all interactive affordances.
+                <code>#1a7f37</code> exclusively for success/merge states.
+                Both restrained — never decorative.
+              </p>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <!-- FORM -->
+      <section data-od-id="form">
+        <div style="display:grid;grid-template-columns:1.2fr 1fr;gap:var(--space-12);align-items:start">
+          <div class="stack-4">
+            <p class="eyebrow">Form components</p>
+            <h2>Primer form inputs.</h2>
+            <p class="body-muted" style="max-width:44ch">
+              Focus: border <code>#0969da</code> + <code>0 0 0 3px rgba(9,105,218,0.3)</code>.
+              5px 12px padding. 6px radius. Weight 600 label.
+            </p>
+          </div>
+          <form style="display:flex;flex-direction:column;gap:var(--space-4);max-width:400px"
+                onsubmit="event.preventDefault()">
+            <div class="field">
+              <label for="email">Email address</label>
+              <input id="email" type="email" placeholder="you@example.com" />
+            </div>
+            <div class="field">
+              <label for="repo">Repository name</label>
+              <input id="repo" type="text" placeholder="my-project" />
+            </div>
+            <div style="display:flex;gap:var(--space-3);margin-top:var(--space-2)">
+              <button type="submit" class="btn btn-primary">Create repository</button>
+              <button type="button" class="btn btn-default">Cancel</button>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/github/tokens.css
+++ b/design-systems/github/tokens.css
@@ -1,0 +1,125 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/github/tokens.css
+ *
+ * Structured token bindings for the "GitHub" brand — Primer foundations,
+ * functional density, blue-on-white precision.
+ *
+ * Brand identity in three sentences:
+ *   1. True white canvas (#ffffff) with a clean canvas-subtle (#f6f8fa)
+ *      secondary surface; hairline borders (#d0d7de) define every pane
+ *      — density over decoration, information over aesthetics.
+ *   2. System-ui stack throughout — no custom webfont; type renders at
+ *      instant on every OS; 14px body (not 16px) is the identity.
+ *   3. Primer blue (#0969da) for all interactive affordances; GitHub
+ *      green (#1a7f37) reserved for success/merge states only.
+ *
+ * Schema decisions:
+ *   - --bg: #ffffff; --surface: #f6f8fa (canvas-subtle).
+ *   - --surface-warm aliases --surface (no warm tier in Primer).
+ *   - --fg: #1f2328 (fg-default); --muted: #656d76 (fg-muted).
+ *   - --border: #d0d7de (1px hairline — the structural backbone).
+ *   - --accent: #0969da (Primer Blue); --accent-hover: #0550ae.
+ *   - --success bound to GitHub green (#1a7f37) — merge / open state.
+ *   - --tracking-display: -0.01em (only display-size headings use it).
+ *   - --text-base: 14px (the 14px body IS GitHub's product density).
+ *   - --radius-sm: 6px (universal Primer radius for buttons/inputs).
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface ──────────────────────────────────────────────────── */
+  --bg:           #ffffff;
+  --surface:      #f6f8fa;              /* canvas-subtle — sidebar, input bg */
+  --surface-warm: var(--surface);       /* Primer has no warm tier */
+
+  /* ─── Foreground ───────────────────────────────────────────────── */
+  --fg:   #1f2328;                      /* fg-default — ink */
+  --fg-2: #1f2328;                      /* same ink; no B-slot split in Primer */
+  --muted: #656d76;                     /* fg-muted — captions, file paths */
+  --meta:  #656d76;                     /* same muted tier */
+
+  /* ─── Border ───────────────────────────────────────────────────── */
+  --border:      #d0d7de;              /* border-default — hairline structural */
+  --border-soft: #d8dee4;             /* border-muted — inner panel dividers */
+
+  /* ─── Accent ───────────────────────────────────────────────────── */
+  --accent:        #0969da;            /* Primer Blue — links, primary CTAs */
+  --accent-on:     #ffffff;
+  --accent-hover:  #0550ae;            /* darker pressed state */
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+  /* ─── Semantic ─────────────────────────────────────────────────── */
+  --success: #1a7f37;                  /* GitHub green — merge, open, success */
+  --warn:    #9a6700;                  /* attention amber text */
+  --danger:  #cf222e;                  /* closed / destructive red */
+
+  /* ─── Typography ───────────────────────────────────────────────── */
+  /* System fonts only — no webfonts load in GitHub. */
+  --font-display: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+  --font-body:    -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+  --font-mono:    ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+
+  /* Type scale — DESIGN.md §Typography.
+   * GitHub's prose density: 14px body (not 16px). Display sits at 32px.
+   * h2 (20px) and h3 (16px) collapse close together for density. */
+  --text-xs:   12px;                   /* body-small — captions, metadata */
+  --text-sm:   14px;                   /* body — default UI (GitHub's base) */
+  --text-base: 14px;                   /* body baseline = 14px for density */
+  --text-lg:   16px;                   /* h3 / panel header */
+  --text-xl:   20px;                   /* h2 — section heading */
+  --text-2xl:  24px;                   /* h1 — page heading */
+  --text-3xl:  28px;                   /* subpage display */
+  --text-4xl:  32px;                   /* display — repo header / hero */
+
+  /* Leading + tracking.
+   * GitHub uses 1.25 for headings (tight-but-readable), 1.5 for body.
+   * Only display gets the -0.01em tracking. */
+  --leading-body:     1.5;
+  --leading-tight:    1.25;
+  --tracking-display: -0.01em;
+
+  /* ─── Spacing ──────────────────────────────────────────────────── */
+  /* 4px base grid — Primer spacing. Row padding 16px h, 12px v. */
+  --space-1:  4px;
+  --space-2:  8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  20px;
+  --space-6:  24px;
+  --space-8:  32px;
+  --space-12: 48px;
+
+  /* Section rhythm — GitHub marketing pages. */
+  --section-y-desktop: 64px;
+  --section-y-tablet:  48px;
+  --section-y-phone:   32px;
+
+  /* ─── Radius ───────────────────────────────────────────────────── */
+  /* 6px is the universal Primer radius for all interactive elements. */
+  --radius-sm:   6px;
+  --radius-md:   6px;
+  --radius-lg:   12px;
+  --radius-pill: 9999px;
+
+  /* ─── Elevation ────────────────────────────────────────────────── */
+  /* GitHub uses hairline borders, not shadows, as the primary depth
+     signal. --elev-raised is a whisper for the rare floating element. */
+  --elev-flat:   none;
+  --elev-ring:   0 0 0 1px var(--border);
+  --elev-raised: 0 1px 3px rgba(31, 35, 40, 0.12), 0 8px 24px rgba(66, 74, 83, 0.12);
+
+  /* ─── Focus ────────────────────────────────────────────────────── */
+  /* Primer focus: 3px rgba ring on the accent color. */
+  --focus-ring: 0 0 0 3px rgba(9, 105, 218, 0.3);
+
+  /* ─── Motion ───────────────────────────────────────────────────── */
+  /* GitHub avoids animation. 80ms hover, 200ms open — short and purposeful. */
+  --motion-fast:   80ms;
+  --motion-base:   200ms;
+  --ease-standard: ease-out;
+
+  /* ─── Layout ───────────────────────────────────────────────────── */
+  --container-max:            1280px;
+  --container-gutter-desktop: 24px;
+  --container-gutter-tablet:  16px;
+  --container-gutter-phone:   16px;
+}

--- a/design-systems/linear-app/components.html
+++ b/design-systems/linear-app/components.html
@@ -76,7 +76,7 @@
           rgba(0, 0, 0, 0.4) 0px 2px 4px,
           0 0 0 1px rgba(255, 255, 255, 0.05);
 
-        --focus-ring: 0 4px 12px rgba(0, 0, 0, 0.1);
+        --focus-ring: 0 0 0 2px color-mix(in oklab, var(--accent), transparent 30%), 0 4px 12px rgba(0, 0, 0, 0.1);
 
         --motion-fast:   150ms;
         --motion-base:   200ms;

--- a/design-systems/linear-app/components.html
+++ b/design-systems/linear-app/components.html
@@ -1,0 +1,370 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Linear — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/linear-app. Every visible
+        value comes from tokens.css. Linear's signature moves: near-black
+        canvas, Inter Variable with cv01+ss03, weight-510 emphasis, indigo
+        accent, semi-transparent white borders, luminance stepping for depth."
+    />
+
+    <style>
+      :root {
+        --bg:           #08090a;
+        --surface:      #191a1b;
+        --surface-warm: var(--surface);
+
+        --fg:   #f7f8f8;
+        --fg-2: #d0d6e0;
+        --muted: #8a8f98;
+        --meta:  #62666d;
+
+        --border:      rgba(255, 255, 255, 0.08);
+        --border-soft: rgba(255, 255, 255, 0.05);
+
+        --accent:        #5e6ad2;
+        --accent-on:     #ffffff;
+        --accent-hover:  #828fff;
+        --accent-active: #4752c4;
+
+        --success: #27a644;
+        --warn:    #eab308;
+        --danger:  #dc2626;
+
+        --font-display: "Inter Variable", "Inter", "SF Pro Display", -apple-system, system-ui, "Segoe UI", Roboto, sans-serif;
+        --font-body:    "Inter Variable", "Inter", "SF Pro Display", -apple-system, system-ui, "Segoe UI", Roboto, sans-serif;
+        --font-mono:    "Berkeley Mono", ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
+
+        --text-xs:   12px;
+        --text-sm:   14px;
+        --text-base: 16px;
+        --text-lg:   18px;
+        --text-xl:   24px;
+        --text-2xl:  32px;
+        --text-3xl:  48px;
+        --text-4xl:  72px;
+
+        --leading-body:     1.5;
+        --leading-tight:    1.00;
+        --tracking-display: -0.022em;
+
+        --space-1:  4px;
+        --space-2:  8px;
+        --space-3:  12px;
+        --space-4:  16px;
+        --space-5:  20px;
+        --space-6:  24px;
+        --space-8:  32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 80px;
+        --section-y-tablet:  48px;
+        --section-y-phone:   32px;
+
+        --radius-sm:   6px;
+        --radius-md:   8px;
+        --radius-lg:   12px;
+        --radius-pill: 9999px;
+
+        --elev-flat:   none;
+        --elev-ring:   0 0 0 1px var(--border);
+        --elev-raised:
+          rgba(0, 0, 0, 0.4) 0px 2px 4px,
+          0 0 0 1px rgba(255, 255, 255, 0.05);
+
+        --focus-ring: 0 4px 12px rgba(0, 0, 0, 0.1);
+
+        --motion-fast:   150ms;
+        --motion-base:   200ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+        --container-max:            1200px;
+        --container-gutter-desktop: 24px;
+        --container-gutter-tablet:  16px;
+        --container-gutter-phone:   12px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg-2);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        /* Linear's signature: cv01 (alternate 'a') + ss03 (geometric alternates). */
+        font-feature-settings: "cv01", "ss03";
+        -webkit-font-smoothing: antialiased;
+      }
+
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      section + section { border-top: 1px solid var(--border); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography ────────────────────────────────────────────── */
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        font-weight: 510;              /* Linear's signature between-weight */
+        margin: 0;
+        color: var(--fg);
+        font-feature-settings: "cv01", "ss03";
+        line-height: var(--leading-tight);
+      }
+      h1 {
+        font-size: var(--text-4xl);
+        letter-spacing: var(--tracking-display);
+      }
+      h2 {
+        font-size: var(--text-2xl);
+        /* 32px heading 1: line-height 1.13, tracking -0.704px (-0.022em). */
+        line-height: 1.13;
+        letter-spacing: -0.022em;
+      }
+      h3 {
+        font-size: var(--text-xl);
+        /* 24px heading 2: line-height 1.33, tracking -0.288px (-0.012em).
+           Overrides the shared 1.00 set on h1/h2/h3 above. */
+        line-height: 1.33;
+        letter-spacing: -0.012em;
+        font-weight: 590;
+      }
+      p { margin: 0; }
+      .lead {
+        font-size: var(--text-lg);
+        line-height: 1.60;
+        color: var(--muted);
+        font-weight: 400;
+        letter-spacing: -0.009em;
+      }
+      .body-muted { color: var(--muted); }
+      .body-sm { font-size: var(--text-sm); color: var(--muted); }
+      .eyebrow {
+        font-size: var(--text-xs);
+        font-weight: 510;
+        color: var(--meta);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+
+      /* ─── Buttons ───────────────────────────────────────────────── */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 8px 16px;
+        border-radius: var(--radius-sm);
+        font-family: var(--font-display);
+        font-size: var(--text-sm);
+        font-weight: 510;
+        font-feature-settings: "cv01", "ss03";
+        line-height: 1;
+        cursor: pointer;
+        border: 1px solid transparent;
+        transition: background-color var(--motion-fast) var(--ease-standard),
+                    color var(--motion-fast) var(--ease-standard);
+        text-decoration: none;
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn-primary {
+        background: var(--accent);
+        color: var(--accent-on);
+      }
+      .btn-primary:hover { background: var(--accent-hover); }
+      .btn-ghost {
+        background: rgba(255, 255, 255, 0.02);
+        color: #e2e4e7;
+        border-color: rgba(36, 40, 44, 1);
+      }
+      .btn-ghost:hover { background: rgba(255, 255, 255, 0.05); }
+
+      /* ─── Pill badges ───────────────────────────────────────────── */
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        padding: 0 10px 0 5px;
+        border-radius: var(--radius-pill);
+        font-size: var(--text-xs);
+        font-weight: 510;
+        color: var(--fg-2);
+        border: 1px solid #23252a;
+        line-height: 1.8;
+      }
+
+      /* ─── Cards ─────────────────────────────────────────────────── */
+      .card {
+        background: rgba(255, 255, 255, 0.02);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        padding: var(--space-6);
+        transition: background-color var(--motion-base) var(--ease-standard);
+      }
+      .card:hover { background: rgba(255, 255, 255, 0.04); }
+
+      /* ─── Inputs ────────────────────────────────────────────────── */
+      .field { display: flex; flex-direction: column; gap: var(--space-2); }
+      .field label {
+        font-size: var(--text-sm);
+        font-weight: 510;
+        color: var(--fg-2);
+        font-feature-settings: "cv01", "ss03";
+      }
+      .field input {
+        background: rgba(255, 255, 255, 0.02);
+        color: var(--fg-2);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        padding: 12px 14px;
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        font-feature-settings: "cv01", "ss03";
+        outline: none;
+        transition: border-color var(--motion-fast) var(--ease-standard);
+      }
+      .field input::placeholder { color: var(--meta); }
+      .field input:focus { border-color: var(--accent); }
+
+      /* ─── Layout ────────────────────────────────────────────────── */
+      .hero-grid {
+        display: grid;
+        grid-template-columns: 1.2fr 1fr;
+        gap: var(--space-12);
+        align-items: center;
+      }
+      @media (max-width: 1023px) { .hero-grid { grid-template-columns: 1fr; } }
+      .features-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: var(--space-4);
+      }
+      @media (max-width: 1023px) { .features-grid { grid-template-columns: 1fr 1fr; } }
+      @media (max-width: 639px)  { .features-grid { grid-template-columns: 1fr; } }
+      .hero-actions { display: flex; gap: var(--space-3); margin-block-start: var(--space-6); }
+      .icon { width: 16px; height: 16px; flex-shrink: 0; }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <!-- HERO -->
+      <section data-od-id="hero">
+        <div class="hero-grid">
+          <div class="stack-4">
+            <p class="eyebrow">Reference fixture · linear</p>
+            <h1>Built for the next era of product development.</h1>
+            <p class="lead" style="max-width:50ch">
+              Linear streamlines software projects, sprints, tasks, and bug
+              tracking. Precision engineered — from the 510 between-weight to
+              the semi-transparent white borders. Every value from tokens.css.
+            </p>
+            <div class="hero-actions">
+              <a href="./tokens.css" class="btn btn-primary">Start building</a>
+              <a href="./DESIGN.md" class="btn btn-ghost">Read the spec</a>
+            </div>
+          </div>
+
+          <aside style="display:flex;flex-direction:column;gap:var(--space-4)">
+            <div class="card">
+              <p class="eyebrow" style="margin-bottom:var(--space-3)">Issue tracker</p>
+              <div style="display:flex;flex-direction:column;gap:var(--space-2)">
+                <div style="display:flex;align-items:center;gap:var(--space-3);font-size:var(--text-sm);color:var(--fg-2)">
+                  <span style="width:8px;height:8px;border-radius:50%;background:#27a644;flex-shrink:0"></span>
+                  Fix token channel drift in derive script
+                </div>
+                <div style="display:flex;align-items:center;gap:var(--space-3);font-size:var(--text-sm);color:var(--muted)">
+                  <span style="width:8px;height:8px;border-radius:50%;background:var(--accent);flex-shrink:0"></span>
+                  Add 10 brand oracle fixtures
+                </div>
+                <div style="display:flex;align-items:center;gap:var(--space-3);font-size:var(--text-sm);color:var(--meta)">
+                  <span style="width:8px;height:8px;border-radius:2px;background:rgba(255,255,255,0.1);flex-shrink:0"></span>
+                  Ship PR-B derive script
+                </div>
+              </div>
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <!-- FEATURES -->
+      <section data-od-id="features">
+        <div class="stack-3">
+          <p class="eyebrow">What this fixture exercises</p>
+          <h2 style="max-width:28ch">Darkness as the native medium.</h2>
+        </div>
+
+        <div class="features-grid" style="margin-block-start:var(--space-6)">
+          <article class="card stack-3">
+            <h3>Dark-first</h3>
+            <p class="body-sm">
+              #08090a marketing black → #191a1b elevated surface. Luminance
+              stepping, not color: each level increases white opacity by 0.02.
+            </p>
+          </article>
+          <article class="card stack-3">
+            <h3>Weight 510</h3>
+            <p class="body-sm">
+              Inter Variable's between-weight. Not 500, not 600 — precisely 510.
+              cv01+ss03 on all text transforms generic Inter into Linear's face.
+            </p>
+          </article>
+          <article class="card stack-3">
+            <h3>Indigo accent</h3>
+            <p class="body-sm">
+              #5e6ad2 for CTA backgrounds; #7170ff for interactive; #828fff
+              on hover. The only chromatic color in an otherwise achromatic system.
+            </p>
+          </article>
+        </div>
+
+        <div style="margin-block-start:var(--space-6);display:flex;gap:var(--space-2);flex-wrap:wrap">
+          <span class="pill">All issues</span>
+          <span class="pill">Active</span>
+          <span class="pill">Backlog</span>
+          <span class="pill">Done</span>
+        </div>
+      </section>
+
+      <!-- FORM -->
+      <section data-od-id="form">
+        <div style="display:grid;grid-template-columns:1.2fr 1fr;gap:var(--space-12);align-items:start">
+          <div class="stack-4">
+            <p class="eyebrow">Form components</p>
+            <h2>Inputs on dark surfaces.</h2>
+            <p class="lead" style="max-width:44ch">
+              rgba(255,255,255,0.02) background, border: 1px solid rgba(255,255,255,0.08).
+              Focus shifts border to --accent; no halo, no blue ring.
+            </p>
+          </div>
+          <form style="display:flex;flex-direction:column;gap:var(--space-4);max-width:400px"
+                onsubmit="event.preventDefault()">
+            <div class="field">
+              <label for="email">Work email</label>
+              <input id="email" type="email" placeholder="you@company.com" />
+            </div>
+            <div style="display:flex;gap:var(--space-3);margin-top:var(--space-2)">
+              <button type="submit" class="btn btn-primary">Sign up</button>
+              <button type="button" class="btn btn-ghost">Learn more</button>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/linear-app/tokens.css
+++ b/design-systems/linear-app/tokens.css
@@ -111,7 +111,11 @@
     0 0 0 1px rgba(255, 255, 255, 0.05);
 
   /* ─── Focus ────────────────────────────────────────────────────── */
-  --focus-ring: 0 4px 12px rgba(0, 0, 0, 0.1);
+  /* Multi-layer stack per DESIGN.md §6 + §7: accent ring makes the
+     indicator visible on the near-black #08090a canvas. */
+  --focus-ring:
+    0 0 0 2px color-mix(in oklab, var(--accent), transparent 30%),
+    0 4px 12px rgba(0, 0, 0, 0.1);
 
   /* ─── Motion ───────────────────────────────────────────────────── */
   --motion-fast:   150ms;

--- a/design-systems/linear-app/tokens.css
+++ b/design-systems/linear-app/tokens.css
@@ -1,0 +1,126 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/linear-app/tokens.css
+ *
+ * Structured token bindings for the "Linear" brand — the dark-mode-native
+ * project management tool's precision engineering voice.
+ *
+ * Brand identity in three sentences:
+ *   1. Darkness as the native medium — near-black canvas (#08090a) where
+ *      information density is managed through luminance steps rather than
+ *      color variation; semi-transparent white borders throughout.
+ *   2. Inter Variable with OpenType "cv01","ss03" at all sizes, signature
+ *      weight 510 (between regular and medium), aggressive negative
+ *      letter-spacing at display sizes (-1.584px at 72px).
+ *   3. Almost entirely achromatic — the single chromatic color is Linear's
+ *      indigo-violet (#5e6ad2 bg / #7170ff interactive), used only for
+ *      CTAs and active states; everything else is grayscale.
+ *
+ * Schema decisions:
+ *   - --bg: #08090a (marketing black); --surface: #191a1b (elevated).
+ *   - --surface-warm aliases --surface (dark system, no warm tier).
+ *   - --fg: #f7f8f8 (near-white — not pure white, prevents eye strain).
+ *   - --fg-2: #d0d6e0 (silver-gray body text).
+ *   - --border: rgba(255,255,255,0.08); --border-soft: rgba(255,255,255,0.05).
+ *   - --accent: #5e6ad2 (brand indigo bg); --accent-hover: #828fff.
+ *   - --tracking-display: -0.022em (-1.584px / 72px normalized).
+ *   - --radius-sm: 6px (buttons/inputs); --radius-md: 8px (cards).
+ *   - --elev-raised: luminance stepping — no opaque shadow on dark.
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface ──────────────────────────────────────────────────── */
+  --bg:           #08090a;              /* marketing black — hero canvas */
+  --surface:      #191a1b;              /* elevated surface — cards, dropdowns */
+  --surface-warm: var(--surface);       /* no warm tier in dark achromatic system */
+
+  /* ─── Foreground ───────────────────────────────────────────────── */
+  --fg:   #f7f8f8;                      /* near-white primary text */
+  --fg-2: #d0d6e0;                      /* silver-gray body / secondary text */
+  --muted: #8a8f98;                     /* tertiary — placeholders, metadata */
+  --meta:  #62666d;                     /* quaternary — timestamps, disabled */
+
+  /* ─── Border ───────────────────────────────────────────────────── */
+  --border:      rgba(255, 255, 255, 0.08);   /* standard semi-transparent white */
+  --border-soft: rgba(255, 255, 255, 0.05);   /* ultra-subtle divider */
+
+  /* ─── Accent ───────────────────────────────────────────────────── */
+  --accent:        #5e6ad2;             /* brand indigo — CTA backgrounds */
+  --accent-on:     #ffffff;
+  --accent-hover:  #828fff;             /* lighter saturated hover */
+  --accent-active: #4752c4;             /* darker pressed state */
+
+  /* ─── Semantic ─────────────────────────────────────────────────── */
+  --success: #27a644;                   /* Linear green */
+  --warn:    #eab308;
+  --danger:  #dc2626;
+
+  /* ─── Typography ───────────────────────────────────────────────── */
+  --font-display: "Inter Variable", "Inter", "SF Pro Display", -apple-system, system-ui, "Segoe UI", Roboto, sans-serif;
+  --font-body:    "Inter Variable", "Inter", "SF Pro Display", -apple-system, system-ui, "Segoe UI", Roboto, sans-serif;
+  --font-mono:    "Berkeley Mono", ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
+
+  /* Type scale — DESIGN.md §Typography Hierarchy.
+   * Linear's display range 72px→10px; the 8 schema slots map the
+   * key stops. 64px secondary-hero lives inline in components.html. */
+  --text-xs:   12px;                    /* label / micro */
+  --text-sm:   14px;                    /* caption large / link small */
+  --text-base: 16px;                    /* body — standard reading */
+  --text-lg:   18px;                    /* body large — feature descriptions */
+  --text-xl:   24px;                    /* heading 2 */
+  --text-2xl:  32px;                    /* heading 1 */
+  --text-3xl:  48px;                    /* display — section headlines */
+  --text-4xl:  72px;                    /* display XL — hero */
+
+  /* Leading + tracking.
+   * --leading-tight=1.00: Linear's signature "engineered" compression.
+   * h2 (32px) → 1.13; h3 (24px) → 1.33 per DESIGN.md spec.
+   * --tracking-display: -0.022em = -1.584px / 72px normalized. */
+  --leading-body:     1.5;
+  --leading-tight:    1.00;
+  --tracking-display: -0.022em;
+
+  /* ─── Spacing ──────────────────────────────────────────────────── */
+  --space-1:  4px;
+  --space-2:  8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  20px;
+  --space-6:  24px;
+  --space-8:  32px;
+  --space-12: 48px;
+
+  /* Section rhythm — DESIGN.md §Whitespace Philosophy. */
+  --section-y-desktop: 80px;
+  --section-y-tablet:  48px;
+  --section-y-phone:   32px;
+
+  /* ─── Radius ───────────────────────────────────────────────────── */
+  /* 6px for buttons/inputs (comfortable), 8px cards, 12px panels. */
+  --radius-sm:   6px;
+  --radius-md:   8px;
+  --radius-lg:   12px;
+  --radius-pill: 9999px;
+
+  /* ─── Elevation ────────────────────────────────────────────────── */
+  /* On dark surfaces: luminance stepping, not opaque drop shadows.
+     --elev-raised uses semi-transparent border-as-shadow technique. */
+  --elev-flat:   none;
+  --elev-ring:   0 0 0 1px var(--border);
+  --elev-raised:
+    rgba(0, 0, 0, 0.4) 0px 2px 4px,
+    0 0 0 1px rgba(255, 255, 255, 0.05);
+
+  /* ─── Focus ────────────────────────────────────────────────────── */
+  --focus-ring: 0 4px 12px rgba(0, 0, 0, 0.1);
+
+  /* ─── Motion ───────────────────────────────────────────────────── */
+  --motion-fast:   150ms;
+  --motion-base:   200ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+  /* ─── Layout ───────────────────────────────────────────────────── */
+  --container-max:            1200px;
+  --container-gutter-desktop: 24px;
+  --container-gutter-tablet:  16px;
+  --container-gutter-phone:   12px;
+}

--- a/design-systems/notion/components.html
+++ b/design-systems/notion/components.html
@@ -1,0 +1,413 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Notion — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/notion. Every visible
+        value comes from tokens.css. Notion's signature moves: warm neutral
+        surfaces, NotionInter with aggressive negative letter-spacing at
+        display sizes, whisper-thin borders (rgba(0,0,0,0.1)), multi-layer
+        shadows with sub-0.05 opacity, Notion Blue CTAs."
+    />
+
+    <style>
+      :root {
+        --bg:           #ffffff;
+        --surface:      #f6f5f4;
+        --surface-warm: var(--surface);
+
+        --fg:   rgba(0, 0, 0, 0.95);
+        --fg-2: #31302e;
+        --muted: #615d59;
+        --meta:  #a39e98;
+
+        --border:      rgba(0, 0, 0, 0.1);
+        --border-soft: rgba(0, 0, 0, 0.06);
+
+        --accent:        #0075de;
+        --accent-on:     #ffffff;
+        --accent-hover:  #005bab;
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+        --success: #1aae39;
+        --warn:    #dd5b00;
+        --danger:  #dc2626;
+
+        --font-display: "NotionInter", "Inter", -apple-system, system-ui, "Segoe UI", Helvetica, Arial, sans-serif;
+        --font-body:    "NotionInter", "Inter", -apple-system, system-ui, "Segoe UI", Helvetica, Arial, sans-serif;
+        --font-mono:    ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Monaco, Consolas, monospace;
+
+        --text-xs:   12px;
+        --text-sm:   14px;
+        --text-base: 16px;
+        --text-lg:   20px;
+        --text-xl:   26px;
+        --text-2xl:  40px;
+        --text-3xl:  48px;
+        --text-4xl:  64px;
+
+        --leading-body:     1.5;
+        --leading-tight:    1.00;
+        --tracking-display: -0.033em;
+
+        --space-1:  4px;
+        --space-2:  8px;
+        --space-3:  12px;
+        --space-4:  16px;
+        --space-5:  20px;
+        --space-6:  24px;
+        --space-8:  32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 80px;
+        --section-y-tablet:  48px;
+        --section-y-phone:   32px;
+
+        --radius-sm:   4px;
+        --radius-md:   8px;
+        --radius-lg:   12px;
+        --radius-pill: 9999px;
+
+        --elev-flat:   none;
+        --elev-ring:   0 0 0 1px var(--border);
+        --elev-raised:
+          rgba(0, 0, 0, 0.04) 0px 4px 18px,
+          rgba(0, 0, 0, 0.027) 0px 2px 7.85px,
+          rgba(0, 0, 0, 0.02) 0px 0.8px 2.93px,
+          rgba(0, 0, 0, 0.01) 0px 0.175px 1.04px;
+
+        --focus-ring: 0 0 0 3px rgba(9, 127, 232, 0.3);
+
+        --motion-fast:   150ms;
+        --motion-base:   200ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+        --container-max:            1200px;
+        --container-gutter-desktop: 24px;
+        --container-gutter-tablet:  16px;
+        --container-gutter-phone:   12px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        font-feature-settings: "lnum", "locl";
+        -webkit-font-smoothing: antialiased;
+      }
+
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      section + section { border-top: 1px solid var(--border); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography ────────────────────────────────────────────── */
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        font-weight: 700;
+        margin: 0;
+        line-height: var(--leading-tight);
+      }
+      h1 {
+        font-size: var(--text-4xl);
+        letter-spacing: var(--tracking-display);
+        /* 64px display: -2.125px = -0.033em; OpenType lnum+locl. */
+        font-feature-settings: "lnum", "locl";
+      }
+      h2 {
+        font-size: var(--text-3xl);
+        /* 48px section heading: line-height 1.00, tracking -1.5px (-0.031em). */
+        letter-spacing: -0.031em;
+        font-feature-settings: "lnum";
+      }
+      h3 {
+        font-size: var(--text-xl);
+        /* 26px sub-heading: line-height 1.23, tracking -0.625px (-0.024em).
+           Overrides the shared 1.00 (--leading-tight) set above. */
+        line-height: 1.23;
+        letter-spacing: -0.024em;
+      }
+      p { margin: 0; }
+      .lead {
+        font-size: var(--text-lg);
+        line-height: 1.40;
+        color: var(--muted);
+        font-weight: 600;
+      }
+      .body-muted { color: var(--muted); }
+      .body-sm { font-size: var(--text-sm); }
+      .eyebrow {
+        font-size: var(--text-xs);
+        font-weight: 600;
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+
+      /* ─── Buttons ───────────────────────────────────────────────── */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 8px 16px;
+        border-radius: var(--radius-sm);
+        font-family: var(--font-display);
+        font-size: var(--text-sm);
+        font-weight: 600;
+        line-height: 1.33;
+        cursor: pointer;
+        border: 1px solid transparent;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard),
+          transform var(--motion-fast) var(--ease-standard);
+        text-decoration: none;
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn:active { transform: scale(0.95); }
+      .btn-primary {
+        background: var(--accent);
+        color: var(--accent-on);
+        border-color: transparent;
+      }
+      .btn-primary:hover { background: var(--accent-hover); }
+      .btn-secondary {
+        background: rgba(0, 0, 0, 0.05);
+        color: var(--fg);
+        border-color: transparent;
+      }
+      .btn-secondary:hover { background: rgba(0, 0, 0, 0.08); }
+      .btn-ghost {
+        background: transparent;
+        color: var(--fg);
+        text-decoration: underline;
+        padding: 8px 4px;
+      }
+
+      /* ─── Pill badges ───────────────────────────────────────────── */
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-1);
+        padding: 4px 8px;
+        border-radius: var(--radius-pill);
+        font-size: var(--text-xs);
+        font-weight: 600;
+        letter-spacing: 0.125px;
+        line-height: 1.33;
+      }
+      .pill-blue { background: #f2f9ff; color: #097fe8; }
+      .pill-green { background: #e8faf0; color: #1aae39; }
+
+      /* ─── Cards ─────────────────────────────────────────────────── */
+      .card {
+        background: var(--bg);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        padding: var(--space-6);
+        transition: box-shadow var(--motion-base) var(--ease-standard);
+      }
+      .card:hover { box-shadow: var(--elev-raised); }
+      .card-warm { background: var(--surface); }
+
+      /* ─── Inputs ────────────────────────────────────────────────── */
+      .field { display: flex; flex-direction: column; gap: var(--space-2); }
+      .field label {
+        font-size: var(--text-sm);
+        font-weight: 500;
+        color: var(--fg);
+      }
+      .field input {
+        background: var(--bg);
+        color: var(--fg);
+        border: 1px solid #dddddd;
+        border-radius: var(--radius-sm);
+        padding: 6px 8px;
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        outline: none;
+        transition: border-color var(--motion-fast) var(--ease-standard),
+                    box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .field input::placeholder { color: var(--meta); }
+      .field input:focus {
+        border-color: var(--accent);
+        box-shadow: var(--focus-ring);
+      }
+
+      /* ─── Layout helpers ────────────────────────────────────────── */
+      .hero-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-12);
+        align-items: center;
+      }
+      @media (max-width: 1023px) { .hero-grid { grid-template-columns: 1fr; } }
+      .features-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: var(--space-5);
+      }
+      @media (max-width: 1023px) { .features-grid { grid-template-columns: 1fr 1fr; } }
+      @media (max-width: 639px)  { .features-grid { grid-template-columns: 1fr; } }
+      .hero-actions { display: flex; gap: var(--space-3); margin-block-start: var(--space-6); }
+      .row-between {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-3);
+      }
+      .icon { width: 16px; height: 16px; flex-shrink: 0; }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <!-- ════════════════════════════════════════════════════════════
+           HERO — h1 (NotionInter 64px / -0.033em), .lead, .eyebrow,
+           .btn-primary (Notion Blue), .btn-secondary, .pill-blue.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="hero">
+        <div class="hero-grid">
+          <div class="stack-4">
+            <p class="eyebrow">Reference fixture · notion</p>
+            <h1>The connected workspace where better work happens.</h1>
+            <p class="lead" style="max-width: 48ch">
+              Notion combines notes, docs, wikis, and project management in one
+              warm, approachable tool. Every value below comes from tokens.css —
+              no raw hex, no off-token type.
+            </p>
+            <div class="hero-actions">
+              <a href="./tokens.css" class="btn btn-primary">
+                Get Notion free
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                     stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M5 12h14M13 6l6 6-6 6" />
+                </svg>
+              </a>
+              <a href="./DESIGN.md" class="btn btn-secondary">Read the spec</a>
+            </div>
+          </div>
+
+          <aside style="display:flex;flex-direction:column;gap:var(--space-4)">
+            <div class="card card-warm" style="display:flex;flex-direction:column;gap:var(--space-3)">
+              <div class="row-between">
+                <span class="body-sm" style="font-weight:500">Trusted by teams at</span>
+                <span class="pill pill-blue">New</span>
+              </div>
+              <p class="body-sm body-muted">Figma, Notion, Vercel, Linear, and 4M+ teams worldwide.</p>
+              <span class="pill pill-green">
+                <svg width="8" height="8" viewBox="0 0 8 8" fill="currentColor" aria-hidden="true"><circle cx="4" cy="4" r="4"/></svg>
+                All systems operational
+              </span>
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <!-- ════════════════════════════════════════════════════════════
+           FEATURES — h2 (48px / tight), h3 (26px / 1.23),
+           .card (whisper border + multi-layer shadow hover),
+           .pill-blue, warm section background.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="features" style="background:var(--surface);margin-inline:calc(var(--container-gutter-desktop)*-1);padding-inline:var(--container-gutter-desktop)">
+        <div class="stack-3">
+          <p class="eyebrow">What this fixture exercises</p>
+          <h2 style="max-width:26ch">Every component uses only var(--*) tokens.</h2>
+        </div>
+
+        <div class="features-grid" style="margin-block-start:var(--space-6)">
+          <article class="card">
+            <h3>Warm neutrals</h3>
+            <p class="body-muted body-sm" style="margin-top:var(--space-3)">
+              --bg white, --surface #f6f5f4 (warm white). Grays carry
+              yellow-brown undertones — never blue-gray. The warmth is
+              imperceptible individually, defining at scale.
+            </p>
+            <a href="./tokens.css" class="body-sm" style="display:block;margin-top:var(--space-4);color:var(--accent)">Inspect tokens →</a>
+          </article>
+
+          <article class="card">
+            <h3>Compression at scale</h3>
+            <p class="body-muted body-sm" style="margin-top:var(--space-3)">
+              -2.125px at 64px, -1.5px at 48px, -0.625px at 26px,
+              relaxing to normal at 16px. Density at headlines,
+              readability at body.
+            </p>
+            <a href="./DESIGN.md" class="body-sm" style="display:block;margin-top:var(--space-4);color:var(--accent)">Read the spec →</a>
+          </article>
+
+          <article class="card">
+            <h3>Whisper depth</h3>
+            <p class="body-muted body-sm" style="margin-top:var(--space-3)">
+              1px solid rgba(0,0,0,0.1) borders. Shadows use 4 layers
+              at max opacity 0.04 — depth felt rather than seen.
+              Hover reveals the --elev-raised stack.
+            </p>
+            <a href="./tokens.css" class="body-sm" style="display:block;margin-top:var(--space-4);color:var(--accent)">Inspect borders →</a>
+          </article>
+        </div>
+      </section>
+
+      <!-- ════════════════════════════════════════════════════════════
+           FORM — .field (4px radius inputs), blue focus ring,
+           .btn-primary, .btn-ghost, metric card with large number.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="form">
+        <div style="display:grid;grid-template-columns:1.2fr 1fr;gap:var(--space-12);align-items:start">
+          <div class="stack-4">
+            <p class="eyebrow">Form components</p>
+            <h2>Inputs inherit the same token system.</h2>
+            <p class="body-muted" style="max-width:44ch">
+              Focus ring: 2px solid #097fe8 + shadow reinforcement.
+              Border at rest: 1px solid #dddddd — standard Notion input.
+              Hover and active use scale(0.95) via CSS transform.
+            </p>
+
+            <div class="card card-warm" style="max-width:320px">
+              <p class="eyebrow">Teams using Notion</p>
+              <p style="font-size:var(--text-2xl);font-weight:700;letter-spacing:-0.02em;line-height:1.5;margin-top:var(--space-2)">4,000,000+</p>
+              <p class="body-sm body-muted">across engineering, design, and ops.</p>
+            </div>
+          </div>
+
+          <form style="display:flex;flex-direction:column;gap:var(--space-4);max-width:400px"
+                onsubmit="event.preventDefault()">
+            <div class="field">
+              <label for="email">Work email</label>
+              <input id="email" type="email" placeholder="you@company.com" autocomplete="email" />
+            </div>
+            <div class="field">
+              <label for="name">Full name</label>
+              <input id="name" type="text" placeholder="Ada Lovelace" autocomplete="name" />
+            </div>
+            <div style="display:flex;gap:var(--space-3);margin-top:var(--space-2)">
+              <button type="submit" class="btn btn-primary">Get started free</button>
+              <button type="button" class="btn btn-ghost">Skip for now</button>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/notion/tokens.css
+++ b/design-systems/notion/tokens.css
@@ -1,0 +1,130 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/notion/tokens.css
+ *
+ * Structured token bindings for the "Notion" brand — the all-in-one
+ * workspace's warm minimalism translated into the shared schema.
+ *
+ * Brand identity in three sentences:
+ *   1. Warm neutrals throughout — grays carry yellow-brown undertones
+ *      (#f6f5f4, #31302e, #615d59, #a39e98); pure white canvas with
+ *      near-black text (rgba(0,0,0,0.95)) that softens imperceptibly.
+ *   2. NotionInter (modified Inter) with aggressive negative
+ *      letter-spacing at display sizes (-2.125px at 64px), four
+ *      weights (400/500/600/700), OpenType "lnum"+"locl" at display.
+ *   3. Whisper borders (1px rgba(0,0,0,0.1)) and multi-layer shadows
+ *      with sub-0.05 opacity — depth felt rather than seen.
+ *
+ * Schema decisions:
+ *   - --bg binds to pure white; --surface to warm white (#f6f5f4).
+ *   - --surface-warm aliases --surface (same warm white tier).
+ *   - --fg binds to rgba(0,0,0,0.95) — the signature near-black.
+ *   - --fg-2 binds to #31302e (warm dark) for headings on surfaces.
+ *   - --accent is Notion Blue (#0075de) — the only saturated color.
+ *   - --tracking-display: -0.033em (-2.125px / 64px normalized).
+ *   - --elev-raised is the 4-layer multi-layer card shadow with max
+ *     opacity 0.04 — felt-not-seen Notion depth.
+ *   - --radius-sm: 4px (buttons/inputs); --radius-md: 8px (cards).
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface ──────────────────────────────────────────────────── */
+  --bg:           #ffffff;
+  --surface:      #f6f5f4;               /* warm white — section alternation */
+  --surface-warm: var(--surface);        /* aliases to warm white tier */
+
+  /* ─── Foreground ───────────────────────────────────────────────── */
+  --fg:   rgba(0, 0, 0, 0.95);           /* near-black — primary text */
+  --fg-2: #31302e;                       /* warm dark — headings on surfaces */
+  --muted: #615d59;                      /* warm gray 500 — secondary text */
+  --meta:  #a39e98;                      /* warm gray 300 — placeholder/captions */
+
+  /* ─── Border ───────────────────────────────────────────────────── */
+  --border:      rgba(0, 0, 0, 0.1);    /* whisper border — standard */
+  --border-soft: rgba(0, 0, 0, 0.06);  /* subtler row dividers */
+
+  /* ─── Accent ───────────────────────────────────────────────────── */
+  --accent:        #0075de;             /* Notion Blue — links, primary CTAs */
+  --accent-on:     #ffffff;
+  --accent-hover:  #005bab;             /* Active Blue — pressed state */
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+  /* ─── Semantic ─────────────────────────────────────────────────── */
+  --success: #1aae39;                   /* Notion green — confirmation */
+  --warn:    #dd5b00;                   /* Notion orange — warning */
+  --danger:  #dc2626;
+
+  /* ─── Typography ───────────────────────────────────────────────── */
+  --font-display: "NotionInter", "Inter", -apple-system, system-ui, "Segoe UI", Helvetica, Arial, sans-serif;
+  --font-body:    "NotionInter", "Inter", -apple-system, system-ui, "Segoe UI", Helvetica, Arial, sans-serif;
+  --font-mono:    ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Monaco, Consolas, monospace;
+
+  /* Type scale — DESIGN.md §Typography Hierarchy.
+   * Notion's display range 64px→12px; the 8 schema slots map to the
+   * spine. 54px secondary-hero sits between --text-4xl and --text-3xl
+   * and appears inline in components.html where needed. */
+  --text-xs:   12px;                    /* badge / micro label */
+  --text-sm:   14px;                    /* caption / footer */
+  --text-base: 16px;                    /* body */
+  --text-lg:   20px;                    /* body large — introductions */
+  --text-xl:   26px;                    /* sub-heading */
+  --text-2xl:  40px;                    /* sub-heading large */
+  --text-3xl:  48px;                    /* section heading */
+  --text-4xl:  64px;                    /* display hero */
+
+  /* Leading + tracking.
+   * --leading-tight=1.00: max compression at 64px display.
+   * h2 (48px) → 1.00; h3 (40px) → 1.50 per DESIGN.md §Typography.
+   * --tracking-display: -0.033em = -2.125px / 64px normalized. */
+  --leading-body:     1.5;
+  --leading-tight:    1.00;
+  --tracking-display: -0.033em;
+
+  /* ─── Spacing ──────────────────────────────────────────────────── */
+  --space-1:  4px;
+  --space-2:  8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  20px;
+  --space-6:  24px;
+  --space-8:  32px;
+  --space-12: 48px;
+
+  /* Section rhythm — DESIGN.md §Responsive Behavior. */
+  --section-y-desktop: 80px;
+  --section-y-tablet:  48px;
+  --section-y-phone:   32px;
+
+  /* ─── Radius ───────────────────────────────────────────────────── */
+  /* Micro 4px for buttons/inputs; standard 12px for cards; pill for
+     badges. --radius-md maps to 8px (small cards, containers). */
+  --radius-sm:   4px;
+  --radius-md:   8px;
+  --radius-lg:   12px;
+  --radius-pill: 9999px;
+
+  /* ─── Elevation ────────────────────────────────────────────────── */
+  /* Multi-layer stack: individual opacity never > 0.04.
+     Depth felt rather than seen — the Notion shadow philosophy. */
+  --elev-flat:   none;
+  --elev-ring:   0 0 0 1px var(--border);
+  --elev-raised:
+    rgba(0, 0, 0, 0.04) 0px 4px 18px,
+    rgba(0, 0, 0, 0.027) 0px 2px 7.85px,
+    rgba(0, 0, 0, 0.02) 0px 0.8px 2.93px,
+    rgba(0, 0, 0, 0.01) 0px 0.175px 1.04px;
+
+  /* ─── Focus ────────────────────────────────────────────────────── */
+  /* 2px solid outline + shadow reinforcement per DESIGN.md §8. */
+  --focus-ring: 0 0 0 3px rgba(9, 127, 232, 0.3);
+
+  /* ─── Motion ───────────────────────────────────────────────────── */
+  --motion-fast:   150ms;
+  --motion-base:   200ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+  /* ─── Layout ───────────────────────────────────────────────────── */
+  --container-max:            1200px;
+  --container-gutter-desktop: 24px;
+  --container-gutter-tablet:  16px;
+  --container-gutter-phone:   12px;
+}

--- a/design-systems/openai/components.html
+++ b/design-systems/openai/components.html
@@ -56,10 +56,11 @@
         --space-2:  8px;
         --space-3:  12px;
         --space-4:  16px;
-        --space-5:  24px;
-        --space-6:  32px;
-        --space-8:  48px;
-        --space-12: 64px;
+        --space-5:  20px;
+        --space-6:  24px;
+        --space-8:  32px;
+        --space-12: 48px;
+        --space-16: 64px;
 
         --section-y-desktop: 96px;
         --section-y-tablet:  64px;

--- a/design-systems/openai/components.html
+++ b/design-systems/openai/components.html
@@ -1,0 +1,381 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>OpenAI — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/openai. Every visible
+        value comes from tokens.css. OpenAI's signature moves: true white
+        canvas, Signifier serif for editorial display, Söhne sans for UI,
+        OpenAI Teal accent (#10a37f), generous line-heights, hairline borders."
+    />
+
+    <style>
+      :root {
+        --bg:           #ffffff;
+        --surface:      #f5f5f5;
+        --surface-warm: #fafafa;
+
+        --fg:   #0d0d0d;
+        --fg-2: #1a1a1a;
+        --muted: #6e6e6e;
+        --meta:  #9b9b9b;
+
+        --border:      #e5e5e5;
+        --border-soft: #ededed;
+
+        --accent:        #10a37f;
+        --accent-on:     #ffffff;
+        --accent-hover:  #0a7a5e;
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+        --success: #10a37f;
+        --warn:    #f5a623;
+        --danger:  #ef4146;
+
+        --font-display: "Signifier", "Source Serif Pro", Georgia, ui-serif, serif;
+        --font-body:    "Söhne", "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+        --font-mono:    "Söhne Mono", ui-monospace, "JetBrains Mono", Menlo, Consolas, monospace;
+
+        --text-xs:   12px;
+        --text-sm:   13px;
+        --text-base: 16px;
+        --text-lg:   18px;
+        --text-xl:   20px;
+        --text-2xl:  28px;
+        --text-3xl:  40px;
+        --text-4xl:  56px;
+
+        --leading-body:     1.65;
+        --leading-tight:    1.08;
+        --tracking-display: -0.02em;
+
+        --space-1:  4px;
+        --space-2:  8px;
+        --space-3:  12px;
+        --space-4:  16px;
+        --space-5:  24px;
+        --space-6:  32px;
+        --space-8:  48px;
+        --space-12: 64px;
+
+        --section-y-desktop: 96px;
+        --section-y-tablet:  64px;
+        --section-y-phone:   48px;
+
+        --radius-sm:   12px;
+        --radius-md:   16px;
+        --radius-lg:   16px;
+        --radius-pill: 9999px;
+
+        --elev-flat:   none;
+        --elev-ring:   0 0 0 1px var(--border);
+        --elev-raised: 0 4px 16px rgba(13, 13, 13, 0.06);
+
+        --focus-ring: 0 0 0 3px rgba(16, 163, 127, 0.12);
+
+        --motion-fast:   150ms;
+        --motion-base:   220ms;
+        --ease-standard: cubic-bezier(0.16, 1, 0.3, 1);
+
+        --container-max:            1200px;
+        --container-gutter-desktop: 48px;
+        --container-gutter-tablet:  24px;
+        --container-gutter-phone:   24px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      section + section { border-top: 1px solid var(--border); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography ─────────────────────────── */
+      /* h1 uses Signifier (serif editorial voice). */
+      h1 {
+        font-family: var(--font-display);
+        font-size: var(--text-4xl);
+        font-weight: 400;
+        letter-spacing: var(--tracking-display);
+        line-height: var(--leading-tight);
+        margin: 0;
+        color: var(--fg);
+      }
+      /* h2 and h3 use Söhne (sans UI voice). */
+      h2 {
+        font-family: var(--font-body);
+        font-size: var(--text-2xl);
+        font-weight: 600;
+        /* 28px section heading: line-height 1.20, tracking -0.005em. */
+        line-height: 1.20;
+        letter-spacing: -0.005em;
+        margin: 0;
+        color: var(--fg);
+      }
+      h3 {
+        font-family: var(--font-body);
+        font-size: var(--text-xl);
+        font-weight: 600;
+        /* 20px sub-section: line-height 1.30, normal tracking.
+           Overrides h1 leading-tight. */
+        line-height: 1.30;
+        margin: 0;
+        color: var(--fg);
+      }
+      p { margin: 0; }
+      .lead {
+        font-size: var(--text-lg);
+        line-height: 1.60;
+        color: var(--muted);
+        font-weight: 400;
+      }
+      .body-muted { color: var(--muted); }
+      .body-sm { font-size: var(--text-sm); }
+      .label {
+        font-size: var(--text-xs);
+        font-weight: 500;
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        font-family: var(--font-body);
+      }
+      code {
+        font-family: var(--font-mono);
+        font-size: 0.875em;
+        background: var(--surface);
+        border: 1px solid var(--border-soft);
+        border-radius: var(--radius-sm);
+        padding: 1px 5px;
+      }
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+
+      /* ─── Buttons ─────────────────────────────── */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 10px 18px;
+        border-radius: var(--radius-sm);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        font-weight: 500;
+        line-height: 1;
+        cursor: pointer;
+        border: 1px solid transparent;
+        transition: background-color var(--motion-fast) var(--ease-standard),
+                    border-color var(--motion-fast) var(--ease-standard);
+        text-decoration: none;
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn-primary {
+        background: var(--fg);
+        color: #ffffff;
+        border-radius: var(--radius-sm);
+      }
+      .btn-primary:hover { background: var(--fg-2); }
+      .btn-secondary {
+        background: var(--bg);
+        color: var(--fg);
+        border-color: var(--border);
+      }
+      .btn-secondary:hover { background: var(--surface-warm); border-color: #d4d4d4; }
+      .btn-teal {
+        background: var(--accent);
+        color: var(--accent-on);
+      }
+      .btn-teal:hover { background: var(--accent-hover); }
+      /* Chip / pill */
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        padding: 4px 10px;
+        border-radius: var(--radius-pill);
+        font-size: var(--text-xs);
+        font-weight: 500;
+        background: var(--surface);
+        color: var(--muted);
+      }
+      .chip-teal { background: #e8f5f0; color: var(--accent); }
+
+      /* ─── Cards ──────────────────────────────── */
+      .card {
+        background: var(--bg);
+        border: 1px solid var(--border-soft);
+        border-radius: var(--radius-md);
+        padding: var(--space-6);
+        transition: box-shadow var(--motion-base) var(--ease-standard);
+      }
+      .card:hover { box-shadow: var(--elev-raised); }
+
+      /* ─── Inputs ─────────────────────────────── */
+      .field { display: flex; flex-direction: column; gap: var(--space-2); }
+      .field label { font-size: var(--text-sm); font-weight: 500; color: var(--fg); }
+      .field input {
+        background: var(--bg);
+        color: var(--fg);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        padding: 12px 14px;
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        outline: none;
+        transition: border-color var(--motion-fast) var(--ease-standard),
+                    box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .field input::placeholder { color: var(--meta); }
+      .field input:focus {
+        border-color: var(--accent);
+        box-shadow: var(--focus-ring);
+      }
+
+      /* ─── Layout ─────────────────────────────── */
+      .hero-grid {
+        display: grid;
+        grid-template-columns: 1.2fr 1fr;
+        gap: var(--space-12);
+        align-items: center;
+      }
+      @media (max-width: 1023px) { .hero-grid { grid-template-columns: 1fr; } }
+      .features-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: var(--space-5);
+      }
+      @media (max-width: 1023px) { .features-grid { grid-template-columns: 1fr 1fr; } }
+      @media (max-width: 639px)  { .features-grid { grid-template-columns: 1fr; } }
+      .hero-actions { display: flex; gap: var(--space-3); margin-block-start: var(--space-6); flex-wrap: wrap; }
+      .icon { width: 16px; height: 16px; flex-shrink: 0; }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <!-- HERO — Signifier serif display voice. -->
+      <section data-od-id="hero">
+        <div class="hero-grid">
+          <div class="stack-4">
+            <p class="label">Reference fixture · openai</p>
+            <h1>AI that works for everyone.</h1>
+            <p class="lead" style="max-width:46ch">
+              OpenAI builds safe artificial general intelligence for humanity.
+              A quietly literary interface: Signifier for display moments,
+              Söhne for system text, OpenAI Teal as the lone accent.
+            </p>
+            <div class="hero-actions">
+              <a href="./tokens.css" class="btn btn-primary">
+                Try ChatGPT
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                     stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M5 12h14M13 6l6 6-6 6"/>
+                </svg>
+              </a>
+              <a href="./DESIGN.md" class="btn btn-secondary">Read the spec</a>
+            </div>
+          </div>
+
+          <aside style="display:flex;flex-direction:column;gap:var(--space-4)">
+            <div class="card">
+              <p class="label" style="margin-bottom:var(--space-4)">Recent models</p>
+              <div style="display:flex;flex-direction:column;gap:var(--space-3)">
+                <div style="display:flex;justify-content:space-between;align-items:center">
+                  <span style="font-size:var(--text-sm);font-weight:500">GPT-4o</span>
+                  <span class="chip chip-teal">Latest</span>
+                </div>
+                <div style="display:flex;justify-content:space-between;align-items:center">
+                  <span style="font-size:var(--text-sm)">GPT-4 Turbo</span>
+                  <span class="chip">Stable</span>
+                </div>
+                <div style="display:flex;justify-content:space-between;align-items:center">
+                  <span style="font-size:var(--text-sm)">o1</span>
+                  <span class="chip">Preview</span>
+                </div>
+              </div>
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <!-- FEATURES -->
+      <section data-od-id="features" style="background:var(--surface-warm);margin-inline:calc(var(--container-gutter-desktop)*-1);padding-inline:var(--container-gutter-desktop)">
+        <div class="stack-3" style="margin-bottom:var(--space-6)">
+          <p class="label">What this fixture exercises</p>
+          <h2>Restraint as identity.</h2>
+        </div>
+
+        <div class="features-grid">
+          <article class="card stack-3">
+            <h3>Two voices</h3>
+            <p class="body-muted" style="font-size:var(--text-sm)">
+              Signifier (serif) for editorial display moments only. Söhne sans
+              for all UI and body text. Weights cap at 600 — 700+ feels off-brand.
+            </p>
+          </article>
+          <article class="card stack-3">
+            <h3>Teal accent</h3>
+            <p class="body-muted" style="font-size:var(--text-sm)">
+              <code>#10a37f</code> — the lone color in an otherwise neutral system.
+              Links, highlight badges, success path CTAs. Hairline borders
+              (#e5e5e5) used sparingly; whitespace as primary divider.
+            </p>
+          </article>
+          <article class="card stack-3">
+            <h3>Generous rhythm</h3>
+            <p class="body-muted" style="font-size:var(--text-sm)">
+              --leading-body: 1.65. --leading-tight (Signifier display): 1.08.
+              96px section rhythm on desktop. Whitespace is the architecture.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <!-- FORM -->
+      <section data-od-id="form">
+        <div style="display:grid;grid-template-columns:1.2fr 1fr;gap:var(--space-12);align-items:start">
+          <div class="stack-4">
+            <p class="label">Form components</p>
+            <h2>Soft radius, teal focus.</h2>
+            <p class="lead" style="max-width:44ch">
+              12px radius on inputs; border: 1px solid #e5e5e5 at rest.
+              Focus: border <code>#10a37f</code> + 3px rgba ring.
+            </p>
+          </div>
+          <form style="display:flex;flex-direction:column;gap:var(--space-4);max-width:400px"
+                onsubmit="event.preventDefault()">
+            <div class="field">
+              <label for="email">Email address</label>
+              <input id="email" type="email" placeholder="you@example.com" />
+            </div>
+            <div style="display:flex;gap:var(--space-3);margin-top:var(--space-2)">
+              <button type="submit" class="btn btn-teal">Sign in</button>
+              <button type="button" class="btn btn-secondary">Create account</button>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/openai/tokens.css
+++ b/design-systems/openai/tokens.css
@@ -84,15 +84,20 @@
   --tracking-display: -0.02em;
 
   /* ─── Spacing ──────────────────────────────────────────────────── */
-  /* 4px base grid. Section rhythm: 96–128px desktop per DESIGN.md. */
+  /* 4px base grid; schema spine: --space-N = N×4 px.
+     OpenAI's DESIGN.md §5 scale (4 8 12 16 24 32 48 64 96 128) maps
+     naturally onto the spine — 64px lives in --space-16 (brand ext). */
   --space-1:  4px;
   --space-2:  8px;
   --space-3:  12px;
   --space-4:  16px;
-  --space-5:  24px;
-  --space-6:  32px;
-  --space-8:  48px;
-  --space-12: 64px;
+  --space-5:  20px;
+  --space-6:  24px;
+  --space-8:  32px;
+  --space-12: 48px;
+
+  /* Brand extension — 64px gap used between major page sections. */
+  --space-16: 64px;
 
   /* Section rhythm — generous whitespace is the primary divider. */
   --section-y-desktop: 96px;

--- a/design-systems/openai/tokens.css
+++ b/design-systems/openai/tokens.css
@@ -1,0 +1,128 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/openai/tokens.css
+ *
+ * Structured token bindings for the "OpenAI" brand — calm, near-monochrome
+ * system anchored in deep teal-black with editorial serif display.
+ *
+ * Brand identity in three sentences:
+ *   1. True white canvas (#ffffff) against deep teal-black ink (#0d0d0d)
+ *      with a subtle cool undertone; chromatic neutrality that puts model
+ *      output front and center rather than the chrome around it.
+ *   2. Söhne / Inter at restrained weights (400/500/600 — never 700+)
+ *      paired with Signifier serif for editorial display moments only;
+ *      generous line-height (1.55–1.65) and near-zero tracking.
+ *   3. Single brand color: OpenAI Teal (#10a37f) — the lone accent in an
+ *      otherwise neutral system; hairline borders (#e5e5e5) used sparingly;
+ *      whitespace as the primary section divider.
+ *
+ * Schema decisions:
+ *   - --bg: #ffffff; --surface: #f5f5f5 (pearl — card surface).
+ *   - --surface-warm: #fafafa (mist — section break bg, footer).
+ *   - --fg: #0d0d0d (ink black); --fg-2: #1a1a1a (soft black).
+ *   - --muted: #6e6e6e (slate — secondary text, captions).
+ *   - --accent: #10a37f (OpenAI Teal); --accent-hover: #0a7a5e.
+ *   - --font-display: Signifier (serif — editorial hero moments only).
+ *   - --font-body: Söhne / Inter (sans — all UI and body text).
+ *   - --tracking-display: -0.02em (display 56px per DESIGN.md).
+ *   - --leading-tight: 1.08 (Signifier display hero rhythm).
+ *   - h2 (28px sans) → 1.20; h3 (20px) → 1.30 per DESIGN.md.
+ *   - --radius-md: 16px (cards); --radius-sm: 12px (buttons, inputs).
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface ──────────────────────────────────────────────────── */
+  --bg:           #ffffff;
+  --surface:      #f5f5f5;             /* pearl — card surface, elevated panel */
+  --surface-warm: #fafafa;             /* mist — section break, footer */
+
+  /* ─── Foreground ───────────────────────────────────────────────── */
+  --fg:   #0d0d0d;                     /* ink black — primary text, brand mark */
+  --fg-2: #1a1a1a;                     /* soft black — alternative headings */
+  --muted: #6e6e6e;                    /* slate — secondary text, captions */
+  --meta:  #9b9b9b;                    /* ash — tertiary, placeholder */
+
+  /* ─── Border ───────────────────────────────────────────────────── */
+  --border:      #e5e5e5;             /* hairline — standard separator */
+  --border-soft: #ededed;             /* card outline on white surface */
+
+  /* ─── Accent ───────────────────────────────────────────────────── */
+  --accent:        #10a37f;           /* OpenAI Teal — links, highlight, CTA */
+  --accent-on:     #ffffff;
+  --accent-hover:  #0a7a5e;           /* teal deep — hover/pressed */
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+  /* ─── Semantic ─────────────────────────────────────────────────── */
+  --success: #10a37f;                 /* teal — success path */
+  --warn:    #f5a623;                 /* amber — advisory */
+  --danger:  #ef4146;                 /* error — validation, destructive */
+
+  /* ─── Typography ───────────────────────────────────────────────── */
+  /* --font-display binds to Signifier — editorial serif for display only.
+     --font-body binds to Söhne/Inter — all UI and reading text. */
+  --font-display: "Signifier", "Source Serif Pro", Georgia, ui-serif, serif;
+  --font-body:    "Söhne", "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+  --font-mono:    "Söhne Mono", ui-monospace, "JetBrains Mono", Menlo, Consolas, monospace;
+
+  /* Type scale — DESIGN.md §Typography Hierarchy.
+   * Signifier at 56px display; Söhne from 40px H1 down to 12px label.
+   * Schema spine maps the key stops. */
+  --text-xs:   12px;                  /* label — eyebrow, uppercase nav */
+  --text-sm:   13px;                  /* caption — metadata, badges */
+  --text-base: 16px;                  /* body — standard reading */
+  --text-lg:   18px;                  /* body large — lede paragraphs */
+  --text-xl:   20px;                  /* h3 — sub-section */
+  --text-2xl:  28px;                  /* h2 — section heading */
+  --text-3xl:  40px;                  /* h1 — page heading */
+  --text-4xl:  56px;                  /* display — Signifier editorial hero */
+
+  /* Leading + tracking.
+   * --leading-tight=1.08: Signifier display compression.
+   * h2 (Söhne 28px) → 1.20; h3 (20px) → 1.30 per DESIGN.md.
+   * --tracking-display: -0.02em (display size negative tracking). */
+  --leading-body:     1.65;
+  --leading-tight:    1.08;
+  --tracking-display: -0.02em;
+
+  /* ─── Spacing ──────────────────────────────────────────────────── */
+  /* 4px base grid. Section rhythm: 96–128px desktop per DESIGN.md. */
+  --space-1:  4px;
+  --space-2:  8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  24px;
+  --space-6:  32px;
+  --space-8:  48px;
+  --space-12: 64px;
+
+  /* Section rhythm — generous whitespace is the primary divider. */
+  --section-y-desktop: 96px;
+  --section-y-tablet:  64px;
+  --section-y-phone:   48px;
+
+  /* ─── Radius ───────────────────────────────────────────────────── */
+  /* Uniformly soft: 12px buttons/inputs; 16px cards; 9999px chips/pills. */
+  --radius-sm:   12px;
+  --radius-md:   16px;
+  --radius-lg:   16px;
+  --radius-pill: 9999px;
+
+  /* ─── Elevation ────────────────────────────────────────────────── */
+  /* No shadow by default; hover reveals a whisper lift. */
+  --elev-flat:   none;
+  --elev-ring:   0 0 0 1px var(--border);
+  --elev-raised: 0 4px 16px rgba(13, 13, 13, 0.06);
+
+  /* ─── Focus ────────────────────────────────────────────────────── */
+  --focus-ring: 0 0 0 3px rgba(16, 163, 127, 0.12);
+
+  /* ─── Motion ───────────────────────────────────────────────────── */
+  --motion-fast:   150ms;
+  --motion-base:   220ms;
+  --ease-standard: cubic-bezier(0.16, 1, 0.3, 1);
+
+  /* ─── Layout ───────────────────────────────────────────────────── */
+  --container-max:            1200px;
+  --container-gutter-desktop: 48px;
+  --container-gutter-tablet:  24px;
+  --container-gutter-phone:   24px;
+}

--- a/design-systems/shopify/components.html
+++ b/design-systems/shopify/components.html
@@ -1,0 +1,342 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Shopify — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/shopify. Every visible
+        value comes from tokens.css. Shopify's signature moves: dark-first
+        cinematic (void black canvas), NeueHaasGrotesk ultra-light display,
+        full-pill CTAs, neon green (#36F4A4) focus rings only."
+    />
+
+    <style>
+      :root {
+        --bg:           #000000;
+        --surface:      #02090a;
+        --surface-warm: #061a1c;
+
+        --fg:   #ffffff;
+        --fg-2: #ffffff;
+        --muted: #a1a1aa;
+        --meta:  #71717a;
+
+        --border:      #1e2c31;
+        --border-soft: #3f3f46;
+
+        --accent:        #36f4a4;
+        --accent-on:     #000000;
+        --accent-hover:  #2de097;
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+        --success: #36f4a4;
+        --warn:    #eab308;
+        --danger:  #dc2626;
+
+        --font-display: "NeueHaasGrotesk", "Helvetica Neue", Helvetica, Arial, sans-serif;
+        --font-body:    "Inter Variable", "Inter", "Helvetica Neue", Helvetica, Arial, sans-serif;
+        --font-mono:    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+
+        --text-xs:   12px;
+        --text-sm:   14px;
+        --text-base: 18px;
+        --text-lg:   20px;
+        --text-xl:   32px;
+        --text-2xl:  48px;
+        --text-3xl:  70px;
+        --text-4xl:  96px;
+
+        --leading-body:     1.56;
+        --leading-tight:    1.00;
+        --tracking-display: 0em;
+
+        --space-1:  4px;
+        --space-2:  8px;
+        --space-3:  12px;
+        --space-4:  16px;
+        --space-5:  24px;
+        --space-6:  28px;
+        --space-8:  36px;
+        --space-12: 64px;
+
+        --section-y-desktop: 96px;
+        --section-y-tablet:  64px;
+        --section-y-phone:   40px;
+
+        --radius-sm:   9999px;
+        --radius-md:   8px;
+        --radius-lg:   12px;
+        --radius-pill: 9999px;
+
+        --elev-flat:   none;
+        --elev-ring:   0 0 0 1px var(--border);
+        --elev-raised:
+          rgba(0, 0, 0, 0.1) 0px 0px 0px 1px,
+          rgba(0, 0, 0, 0.1) 0px 2px 2px,
+          rgba(0, 0, 0, 0.1) 0px 4px 4px,
+          rgba(0, 0, 0, 0.1) 0px 8px 8px,
+          rgba(255, 255, 255, 0.03) 0px 1px 0px inset;
+
+        --focus-ring: 0 0 0 2px #36f4a4;
+
+        --motion-fast:   150ms;
+        --motion-base:   200ms;
+        --ease-standard: ease;
+
+        --container-max:            1280px;
+        --container-gutter-desktop: 64px;
+        --container-gutter-tablet:  32px;
+        --container-gutter-phone:   16px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--muted);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        /* ss03 on all text per brand spec. */
+        font-feature-settings: "ss03";
+        -webkit-font-smoothing: antialiased;
+      }
+
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      section + section { border-top: 1px solid var(--border); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography ─────────────────────────── */
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        font-weight: 330;              /* ultra-light — the Shopify signature */
+        margin: 0;
+        color: var(--fg);
+        font-feature-settings: "ss03";
+        line-height: var(--leading-tight);
+      }
+      h1 {
+        font-size: var(--text-4xl);
+        /* 96px display: weight 330, line-height 1.00. */
+      }
+      h2 {
+        font-size: var(--text-3xl);
+        /* 70px heading 1: line-height 1.00. */
+      }
+      h3 {
+        font-size: var(--text-xl);
+        /* 32px heading 4: line-height 1.14, tracking 0.32px (positive).
+           Overrides the shared 1.00 set above. */
+        line-height: 1.14;
+        letter-spacing: 0.32px;
+        font-weight: 360;
+      }
+      p { margin: 0; }
+      .lead {
+        font-size: var(--text-lg);
+        line-height: 1.40;
+        color: var(--muted);
+        font-weight: 500;
+        letter-spacing: 0.3px;
+      }
+      .body-muted { color: var(--muted); }
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+
+      /* ─── Buttons — full pill for all CTAs. ──── */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 12px 26px 12px 16px;
+        border-radius: var(--radius-sm);   /* 9999px full pill */
+        font-family: var(--font-display);
+        font-size: var(--text-base);
+        font-weight: 400;
+        font-feature-settings: "ss03";
+        line-height: 1.5;
+        cursor: pointer;
+        border: 2px solid transparent;
+        transition: all var(--motion-base) var(--ease-standard);
+        text-decoration: none;
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn-primary {
+        background: var(--fg);
+        color: var(--bg);
+        border-color: transparent;
+      }
+      .btn-primary:hover { opacity: 0.9; }
+      .btn-ghost {
+        background: transparent;
+        color: var(--fg);
+        border-color: var(--fg);
+      }
+      .btn-ghost:hover { background: var(--fg); color: var(--bg); }
+
+      /* ─── Cards ──────────────────────────────── */
+      .card {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        padding: var(--space-6);
+        box-shadow: var(--elev-raised);
+        transition: box-shadow var(--motion-base) var(--ease-standard);
+      }
+
+      /* ─── Stats ──────────────────────────────── */
+      .stat {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+      }
+      .stat-number {
+        font-family: var(--font-display);
+        font-size: var(--text-3xl);
+        font-weight: 750;
+        color: var(--fg);
+        font-feature-settings: "ss03";
+        line-height: 1.00;
+      }
+
+      /* ─── Inputs ─────────────────────────────── */
+      .field { display: flex; flex-direction: column; gap: var(--space-2); }
+      .field label { font-size: var(--text-sm); font-weight: 500; color: var(--muted); }
+      .field input {
+        background: var(--surface-warm);
+        color: var(--fg);
+        border: 1px solid var(--border-soft);
+        border-radius: var(--radius-md);
+        padding: 12px 16px;
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        outline: none;
+        transition: border-color var(--motion-fast) var(--ease-standard),
+                    box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .field input::placeholder { color: var(--meta); }
+      .field input:focus {
+        border-color: var(--accent);
+        box-shadow: var(--focus-ring);
+      }
+
+      /* ─── Layout ─────────────────────────────── */
+      .hero-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-12);
+        align-items: center;
+      }
+      @media (max-width: 1023px) { .hero-grid { grid-template-columns: 1fr; } }
+      .stats-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: var(--space-8);
+      }
+      @media (max-width: 639px) { .stats-grid { grid-template-columns: 1fr; } }
+      .hero-actions { display: flex; gap: var(--space-4); margin-block-start: var(--space-8); flex-wrap: wrap; }
+      .icon { width: 16px; height: 16px; flex-shrink: 0; }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <!-- HERO -->
+      <section data-od-id="hero">
+        <div class="hero-grid">
+          <div class="stack-6">
+            <h1>Commerce is yours to own.</h1>
+            <p class="lead" style="max-width:46ch">
+              Start, run, and grow your business. Shopify's cinematic dark canvas
+              stages commerce like a product keynote. Ultra-light NeueHaasGrotesk
+              at 96px. Every value from tokens.css.
+            </p>
+            <div class="hero-actions">
+              <a href="./tokens.css" class="btn btn-primary">
+                Start for free
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                     stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M5 12h14M13 6l6 6-6 6"/>
+                </svg>
+              </a>
+              <a href="./DESIGN.md" class="btn btn-ghost">Read the spec</a>
+            </div>
+          </div>
+
+          <aside>
+            <div class="card">
+              <p style="font-size:var(--text-sm);color:var(--meta);margin-bottom:var(--space-4)">Commerce data</p>
+              <div class="stats-grid" style="grid-template-columns:1fr 1fr">
+                <div class="stat">
+                  <span class="stat-number">150M+</span>
+                  <span style="font-size:var(--text-sm);color:var(--muted)">buyers served</span>
+                </div>
+                <div class="stat">
+                  <span class="stat-number">15+</span>
+                  <span style="font-size:var(--text-sm);color:var(--muted)">years in commerce</span>
+                </div>
+              </div>
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <!-- FEATURES -->
+      <section data-od-id="features" style="background:var(--surface-warm);margin-inline:calc(var(--container-gutter-desktop)*-1);padding-inline:var(--container-gutter-desktop)">
+        <h2 style="max-width:24ch;margin-bottom:var(--space-8)">Built for scale.</h2>
+
+        <div class="stats-grid">
+          <div class="stat">
+            <span style="font-family:var(--font-display);font-size:var(--text-3xl);font-weight:750;color:var(--fg);font-feature-settings:'ss03';line-height:1">96px</span>
+            <span style="font-size:var(--text-sm);color:var(--muted);margin-top:var(--space-2)">Display XL, weight 330 — featherweight monumental type</span>
+          </div>
+          <div class="stat">
+            <span style="font-family:var(--font-display);font-size:var(--text-3xl);font-weight:750;color:var(--accent);font-feature-settings:'ss03';line-height:1">#36F4A4</span>
+            <span style="font-size:var(--text-sm);color:var(--muted);margin-top:var(--space-2)">Neon Green — focus rings only, never fills large surfaces</span>
+          </div>
+          <div class="stat">
+            <span style="font-family:var(--font-display);font-size:var(--text-3xl);font-weight:750;color:var(--fg);font-feature-settings:'ss03';line-height:1">9999px</span>
+            <span style="font-size:var(--text-sm);color:var(--muted);margin-top:var(--space-2)">Full pill for all primary CTAs — non-negotiable brand rule</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- FORM -->
+      <section data-od-id="form">
+        <div style="display:grid;grid-template-columns:1.2fr 1fr;gap:var(--space-12);align-items:start">
+          <div class="stack-4">
+            <h3>Start your free trial.</h3>
+            <p style="font-size:var(--text-base);color:var(--muted);line-height:var(--leading-body);margin-top:var(--space-3)">
+              Dark input surfaces. Border: 1px solid #3f3f46 at rest.
+              Focus: 2px solid neon green. 8px radius on inputs.
+            </p>
+          </div>
+          <form style="display:flex;flex-direction:column;gap:var(--space-4);max-width:400px"
+                onsubmit="event.preventDefault()">
+            <div class="field">
+              <label for="email">Email address</label>
+              <input id="email" type="email" placeholder="you@store.com" />
+            </div>
+            <div style="margin-top:var(--space-2)">
+              <button type="submit" class="btn btn-primary">Start for free</button>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/shopify/tokens.css
+++ b/design-systems/shopify/tokens.css
@@ -1,0 +1,141 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/shopify/tokens.css
+ *
+ * Structured token bindings for the "Shopify" brand — dark-first cinematic,
+ * ethereal ultra-light display type, neon green accent.
+ *
+ * Brand identity in three sentences:
+ *   1. Darkness as theatre — deep forest-teal surfaces (not pure black:
+ *      #000000 root, #02090A cards, #061A1C sections, #102620 elevated)
+ *      create a nocturnal keynote atmosphere, staged like a product reveal.
+ *   2. NeueHaasGrotesk variable at monumental scale (96px) with impossible
+ *      lightness (weight 330–400, OpenType ss03); Inter Variable handles
+ *      body at unusual weights (420/450/550); combined they feel etched.
+ *   3. Neon Green (#36F4A4) is the singular high-energy accent — pulsing
+ *      like a bioluminescent signal exclusively for focus rings and accent
+ *      highlights; white is the only text color on dark.
+ *
+ * Schema decisions:
+ *   - --bg: #000000 (void — root page background, true black).
+ *   - --surface: #02090A (deep teal — card surfaces).
+ *   - --surface-warm: #061A1C (dark forest — section backgrounds).
+ *   - --fg: #ffffff (white — the only text color on dark).
+ *   - --fg-2: #ffffff (same; no secondary ink split on dark canvas).
+ *   - --muted: #a1a1aa (muted zinc — secondary text, descriptions).
+ *   - --meta: #71717a (shade-50 — timestamps, tertiary info).
+ *   - --border: #1e2c31 (dark card border); --border-soft: #3f3f46.
+ *   - --accent: #36F4A4 (neon green — focus/accent only, not bg).
+ *   - --accent-on: #000000 (black text on neon green).
+ *   - --tracking-display: 0em (NeueHaasGrotesk at 96px tracks neutral).
+ *   - --leading-tight: 1.00 (display XL line-height at 96px).
+ *   - --radius-sm: 9999px (full pill for all CTAs per brand identity).
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface ──────────────────────────────────────────────────── */
+  --bg:           #000000;             /* void — true black root */
+  --surface:      #02090a;             /* deep teal — card surfaces */
+  --surface-warm: #061a1c;             /* dark forest — section backgrounds */
+
+  /* ─── Foreground ───────────────────────────────────────────────── */
+  --fg:   #ffffff;                     /* white — only text color on dark */
+  --fg-2: #ffffff;                     /* same; no secondary ink split */
+  --muted: #a1a1aa;                    /* muted zinc — secondary text */
+  --meta:  #71717a;                    /* shade-50 — timestamps, tertiary */
+
+  /* ─── Border ───────────────────────────────────────────────────── */
+  --border:      #1e2c31;             /* dark card border */
+  --border-soft: #3f3f46;             /* shade-70 — subtle dividers */
+
+  /* ─── Accent ───────────────────────────────────────────────────── */
+  /* Neon Green is precious — focus rings and critical accent highlights only.
+     It never fills large surfaces. --accent-on is black for contrast. */
+  --accent:        #36f4a4;           /* neon green */
+  --accent-on:     #000000;
+  --accent-hover:  #2de097;           /* slightly darker neon on hover */
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+  /* ─── Semantic ─────────────────────────────────────────────────── */
+  --success: #36f4a4;                 /* neon green — success state */
+  --warn:    #eab308;
+  --danger:  #dc2626;
+
+  /* ─── Typography ───────────────────────────────────────────────── */
+  --font-display: "NeueHaasGrotesk", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-body:    "Inter Variable", "Inter", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-mono:    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+
+  /* Type scale — DESIGN.md §Typography Hierarchy.
+   * NeueHaasGrotesk from 96px (display XL) to 24px (heading 6).
+   * Inter Variable from 20px (body large) to 12px (label).
+   * Schema spine maps the key stops. */
+  --text-xs:   12px;                  /* label — uppercase, wide-tracked */
+  --text-sm:   14px;                  /* caption — metadata */
+  --text-base: 18px;                  /* body — standard Inter reading */
+  --text-lg:   20px;                  /* body large — lead paragraphs */
+  --text-xl:   32px;                  /* heading 4 — card headings */
+  --text-2xl:  48px;                  /* heading 3 — feature titles */
+  --text-3xl:  70px;                  /* heading 1 — section titles */
+  --text-4xl:  96px;                  /* display XL — cinematic hero */
+
+  /* Leading + tracking.
+   * --leading-tight=1.00: display XL at 96px.
+   * h2 (70px) → 1.00; h3 (48px) → 1.14 per DESIGN.md.
+   * --tracking-display: 0em (NeueHaasGrotesk tracks neutral at display).
+   * NB: positive tracking (0.32px–2.4px) exists at smaller NeueHaas sizes
+   * and is set inline in components.html. */
+  --leading-body:     1.56;
+  --leading-tight:    1.00;
+  --tracking-display: 0em;
+
+  /* ─── Spacing ──────────────────────────────────────────────────── */
+  /* 8px base unit per DESIGN.md §Spacing System. */
+  --space-1:  4px;
+  --space-2:  8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  24px;
+  --space-6:  28px;
+  --space-8:  36px;
+  --space-12: 64px;
+
+  /* Section rhythm — theatrical pacing: vast dark expanse between sections. */
+  --section-y-desktop: 96px;
+  --section-y-tablet:  64px;
+  --section-y-phone:   40px;
+
+  /* ─── Radius ───────────────────────────────────────────────────── */
+  /* Full pill for all primary CTAs — non-negotiable brand identity.
+     Cards: 8px standard, 12px featured. */
+  --radius-sm:   9999px;              /* full pill — all CTA buttons */
+  --radius-md:   8px;                 /* standard cards, inputs */
+  --radius-lg:   12px;                /* featured cards */
+  --radius-pill: 9999px;
+
+  /* ─── Elevation ────────────────────────────────────────────────── */
+  /* Multi-layered shadow: 1px ring + progressive blur + inset white glow.
+     Shadows are "ambient occlusion" on dark surfaces, not traditional lift. */
+  --elev-flat:   none;
+  --elev-ring:   0 0 0 1px var(--border);
+  --elev-raised:
+    rgba(0, 0, 0, 0.1) 0px 0px 0px 1px,
+    rgba(0, 0, 0, 0.1) 0px 2px 2px,
+    rgba(0, 0, 0, 0.1) 0px 4px 4px,
+    rgba(0, 0, 0, 0.1) 0px 8px 8px,
+    rgba(255, 255, 255, 0.03) 0px 1px 0px inset;
+
+  /* ─── Focus ────────────────────────────────────────────────────── */
+  /* Neon Green focus ring — 2px ring, brand signature. */
+  --focus-ring: 0 0 0 2px #36f4a4;
+
+  /* ─── Motion ───────────────────────────────────────────────────── */
+  --motion-fast:   150ms;
+  --motion-base:   200ms;
+  --ease-standard: ease;
+
+  /* ─── Layout ───────────────────────────────────────────────────── */
+  --container-max:            1280px;
+  --container-gutter-desktop: 64px;
+  --container-gutter-tablet:  32px;
+  --container-gutter-phone:   16px;
+}

--- a/design-systems/slack/components.html
+++ b/design-systems/slack/components.html
@@ -71,7 +71,7 @@
         --radius-pill: 9999px;
 
         --elev-flat:   none;
-        --elev-ring:   0 1px 3px rgba(0, 0, 0, 0.08);
+        --elev-ring:   0 0 0 1px var(--border);
         --elev-raised: 0 4px 12px rgba(0, 0, 0, 0.12);
 
         --focus-ring: 0 0 0 2px rgba(18, 100, 163, 0.25);

--- a/design-systems/slack/components.html
+++ b/design-systems/slack/components.html
@@ -1,0 +1,387 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Slack — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/slack. Every visible
+        value comes from tokens.css. Slack's signature moves: aubergine
+        sidebar (#4A154B), white content surfaces, Larsseit display,
+        4px button radius, logo-color semantic palette."
+    />
+
+    <style>
+      :root {
+        --bg:           #ffffff;
+        --surface:      #f8f8f8;
+        --surface-warm: var(--surface);
+
+        --fg:   #1d1c1d;
+        --fg-2: #1d1c1d;
+        --muted: #616061;
+        --meta:  #616061;
+
+        --border:      #dddddd;
+        --border-soft: #f1f1f1;
+
+        --accent:        #4a154b;
+        --accent-on:     #ffffff;
+        --accent-hover:  #611f69;
+        --accent-active: #350d36;
+
+        --success: #2eb67d;
+        --warn:    #ecb22e;
+        --danger:  #e01e5a;
+
+        --font-display: "Larsseit", "Helvetica Neue", Arial, sans-serif;
+        --font-body:    system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+        --font-mono:    "Monaco", "Menlo", "Courier New", Courier, monospace;
+
+        --text-xs:   12px;
+        --text-sm:   13px;
+        --text-base: 15px;
+        --text-lg:   16px;
+        --text-xl:   22px;
+        --text-2xl:  28px;
+        --text-3xl:  36px;
+        --text-4xl:  48px;
+
+        --leading-body:     1.5;
+        --leading-tight:    1.10;
+        --tracking-display: -0.021em;
+
+        --space-1:  4px;
+        --space-2:  8px;
+        --space-3:  12px;
+        --space-4:  16px;
+        --space-5:  20px;
+        --space-6:  24px;
+        --space-8:  32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 80px;
+        --section-y-tablet:  48px;
+        --section-y-phone:   32px;
+
+        --radius-sm:   4px;
+        --radius-md:   8px;
+        --radius-lg:   12px;
+        --radius-pill: 9999px;
+
+        --elev-flat:   none;
+        --elev-ring:   0 1px 3px rgba(0, 0, 0, 0.08);
+        --elev-raised: 0 4px 12px rgba(0, 0, 0, 0.12);
+
+        --focus-ring: 0 0 0 2px rgba(18, 100, 163, 0.25);
+
+        --motion-fast:   150ms;
+        --motion-base:   200ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+        --container-max:            1200px;
+        --container-gutter-desktop: 24px;
+        --container-gutter-tablet:  16px;
+        --container-gutter-phone:   16px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      section + section { border-top: 1px solid var(--border-soft); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography ─────────────────────────── */
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        font-weight: 700;
+        margin: 0;
+        line-height: var(--leading-tight);
+        color: var(--fg);
+      }
+      h1 {
+        font-size: var(--text-4xl);
+        letter-spacing: var(--tracking-display);
+      }
+      h2 {
+        font-size: var(--text-3xl);
+        /* 36px section hero: line-height 1.15, tracking -0.5px (-0.014em). */
+        line-height: 1.15;
+        letter-spacing: -0.014em;
+      }
+      h3 {
+        font-size: var(--text-2xl);
+        /* 28px heading 1: line-height 1.25 per DESIGN.md.
+           Overrides the shared 1.10 set above. */
+        line-height: 1.25;
+      }
+      p { margin: 0; }
+      .lead {
+        font-size: var(--text-lg);
+        line-height: 1.5;
+        color: var(--muted);
+      }
+      .body-muted { color: var(--muted); }
+      .body-sm { font-size: var(--text-sm); }
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+
+      /* ─── Buttons ─────────────────────────────── */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 0 var(--space-4);
+        height: 36px;
+        border-radius: var(--radius-sm);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        font-weight: 700;
+        line-height: 1;
+        cursor: pointer;
+        border: none;
+        transition: background-color var(--motion-fast) var(--ease-standard);
+        text-decoration: none;
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn-primary {
+        background: var(--accent);
+        color: var(--accent-on);
+      }
+      .btn-primary:hover { background: var(--accent-hover); }
+      .btn-secondary {
+        background: var(--bg);
+        color: var(--fg);
+        border: 1px solid var(--border);
+      }
+      .btn-secondary:hover { background: var(--surface); }
+      .btn-danger {
+        background: var(--danger);
+        color: #ffffff;
+      }
+
+      /* ─── Sidebar ─────────────────────────────── */
+      .sidebar {
+        background: var(--accent);
+        border-radius: var(--radius-md);
+        padding: var(--space-4);
+        color: rgba(255, 255, 255, 0.9);
+        font-size: var(--text-base);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+        min-width: 220px;
+      }
+      .sidebar-title {
+        font-weight: 700;
+        color: #ffffff;
+        font-size: var(--text-base);
+        padding: var(--space-2) var(--space-4);
+        margin-bottom: var(--space-2);
+      }
+      .channel-item {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        height: 28px;
+        padding: 0 var(--space-4);
+        border-radius: 6px;
+        color: rgba(255, 255, 255, 0.7);
+        font-size: var(--text-base);
+        font-weight: 400;
+        cursor: pointer;
+        transition: background-color var(--motion-fast) var(--ease-standard),
+                    color var(--motion-fast) var(--ease-standard);
+      }
+      .channel-item:hover {
+        background: rgba(255, 255, 255, 0.1);
+        color: #ffffff;
+      }
+      .channel-item.active {
+        background: rgba(255, 255, 255, 0.2);
+        color: #ffffff;
+      }
+      .channel-item.unread {
+        color: #ffffff;
+        font-weight: 700;
+      }
+
+      /* ─── Reaction ───────────────────────────── */
+      .reaction {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-1);
+        border: 1px solid var(--border);
+        border-radius: 24px;
+        background: var(--surface);
+        padding: 2px 8px;
+        font-size: var(--text-sm);
+        cursor: pointer;
+        transition: background-color var(--motion-fast) var(--ease-standard);
+      }
+      .reaction:hover { background: var(--border-soft); }
+      .reaction.active {
+        background: rgba(18, 100, 163, 0.1);
+        border-color: #1264a3;
+      }
+
+      /* ─── Input ──────────────────────────────── */
+      .field { display: flex; flex-direction: column; gap: var(--space-2); }
+      .field label { font-size: var(--text-base); font-weight: 700; color: var(--fg); }
+      .field input {
+        background: var(--bg);
+        color: var(--fg);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        padding: 8px 12px;
+        font-size: var(--text-base);
+        height: 36px;
+        outline: none;
+        transition: border-color var(--motion-fast) var(--ease-standard),
+                    box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .field input::placeholder { color: var(--muted); }
+      .field input:focus {
+        border-color: #1264a3;
+        box-shadow: var(--focus-ring);
+      }
+
+      /* ─── Layout ─────────────────────────────── */
+      .hero-grid {
+        display: grid;
+        grid-template-columns: 1.3fr 1fr;
+        gap: var(--space-12);
+        align-items: center;
+      }
+      @media (max-width: 1023px) { .hero-grid { grid-template-columns: 1fr; } }
+      .features-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: var(--space-5);
+      }
+      @media (max-width: 1023px) { .features-grid { grid-template-columns: 1fr 1fr; } }
+      @media (max-width: 639px)  { .features-grid { grid-template-columns: 1fr; } }
+      .hero-actions { display: flex; gap: var(--space-3); margin-block-start: var(--space-6); flex-wrap: wrap; }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <!-- HERO -->
+      <section data-od-id="hero">
+        <div class="hero-grid">
+          <div class="stack-4">
+            <h1>Made for people. Built for productivity.</h1>
+            <p class="lead" style="max-width:48ch">
+              Slack brings your team's communication and tools together in one
+              place. Warm, human, and structured around the aubergine sidebar
+              that's become a workplace icon.
+            </p>
+            <div class="hero-actions">
+              <a href="./tokens.css" class="btn btn-primary">Try Slack for free</a>
+              <a href="./DESIGN.md" class="btn btn-secondary">Read the spec</a>
+            </div>
+          </div>
+
+          <aside>
+            <div class="sidebar">
+              <div class="sidebar-title">open-design ▼</div>
+              <div class="channel-item"># threads</div>
+              <div class="channel-item"># all-dms</div>
+              <div class="channel-item active"># general</div>
+              <div class="channel-item unread"># design ●</div>
+              <div class="channel-item"># engineering</div>
+              <div class="channel-item"># random</div>
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <!-- FEATURES -->
+      <section data-od-id="features">
+        <h2 style="max-width:28ch;margin-bottom:var(--space-6)">Warm, professional, human.</h2>
+
+        <div class="features-grid">
+          <article style="border:1px solid var(--border);border-radius:var(--radius-md);padding:var(--space-6)" class="stack-3">
+            <h3>Aubergine sidebar</h3>
+            <p class="body-muted body-sm">
+              #4A154B — the most recognizable UI element in workplace software.
+              Channel items: 28px height, 6px radius, bold when unread.
+            </p>
+          </article>
+          <article style="border:1px solid var(--border);border-radius:var(--radius-md);padding:var(--space-6)" class="stack-3">
+            <h3>Logo palette</h3>
+            <p class="body-muted body-sm">
+              Blue (#36C5F0), green (#2EB67D), yellow (#ECB22E), red (#E01E5A) —
+              strictly semantic. Info, success, warning, danger. Never decorative.
+            </p>
+            <div style="display:flex;gap:var(--space-2);margin-top:var(--space-3)">
+              <span style="display:inline-block;width:20px;height:20px;border-radius:4px;background:#36c5f0"></span>
+              <span style="display:inline-block;width:20px;height:20px;border-radius:4px;background:#2eb67d"></span>
+              <span style="display:inline-block;width:20px;height:20px;border-radius:4px;background:#ecb22e"></span>
+              <span style="display:inline-block;width:20px;height:20px;border-radius:4px;background:#e01e5a"></span>
+            </div>
+          </article>
+          <article style="border:1px solid var(--border);border-radius:var(--radius-md);padding:var(--space-6)" class="stack-3">
+            <h3>Reactions</h3>
+            <p class="body-muted body-sm">
+              Pill border-radius 24px, 1px border, surface background. Active
+              state: tinted blue. Timestamps show on hover only.
+            </p>
+            <div style="display:flex;gap:var(--space-2);margin-top:var(--space-3);flex-wrap:wrap">
+              <span class="reaction active">👍 3</span>
+              <span class="reaction">🎉 1</span>
+              <span class="reaction">❤️ 2</span>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <!-- FORM -->
+      <section data-od-id="form">
+        <div style="display:grid;grid-template-columns:1.2fr 1fr;gap:var(--space-12);align-items:start">
+          <div class="stack-4">
+            <h2>Inputs and buttons.</h2>
+            <p class="body-muted" style="max-width:44ch">
+              4px radius on buttons and inputs — not cartoonish.
+              Focus ring: 2px solid #1264A3. Height 36px, font-size 15px.
+            </p>
+          </div>
+          <form style="display:flex;flex-direction:column;gap:var(--space-4);max-width:400px"
+                onsubmit="event.preventDefault()">
+            <div class="field">
+              <label for="email">Work email</label>
+              <input id="email" type="email" placeholder="you@company.com" />
+            </div>
+            <div style="display:flex;gap:var(--space-3);margin-top:var(--space-2)">
+              <button type="submit" class="btn btn-primary">Get started</button>
+              <button type="button" class="btn btn-secondary">Skip</button>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/slack/tokens.css
+++ b/design-systems/slack/tokens.css
@@ -107,7 +107,7 @@
   /* ─── Elevation ────────────────────────────────────────────────── */
   /* Light shadows on a light surface. */
   --elev-flat:   none;
-  --elev-ring:   0 1px 3px rgba(0, 0, 0, 0.08);
+  --elev-ring:   0 0 0 1px var(--border);
   --elev-raised: 0 4px 12px rgba(0, 0, 0, 0.12);
 
   /* ─── Focus ────────────────────────────────────────────────────── */

--- a/design-systems/slack/tokens.css
+++ b/design-systems/slack/tokens.css
@@ -1,0 +1,127 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/slack/tokens.css
+ *
+ * Structured token bindings for the "Slack" brand — aubergine sidebar,
+ * light content surfaces, warm and human workplace communication.
+ *
+ * Brand identity in three sentences:
+ *   1. Light-first content surfaces (white #FFFFFF / near-white #F8F8F8)
+ *      anchored by the iconic deep aubergine (#4A154B) sidebar — the most
+ *      recognizable UI element in workplace software.
+ *   2. Larsseit for marketing display headings; system-ui for all product
+ *      UI at 15px base (slightly below 16px for density); bold (700)
+ *      channel names are the primary unread indicator.
+ *   3. Four logo accent colors (blue, green, yellow, red) are strictly
+ *      semantic (info/success/warn/danger) — never decorative accents;
+ *      #1264A3 for links and focus rings.
+ *
+ * Schema decisions:
+ *   - --bg: #FFFFFF; --surface: #F8F8F8 (thread panels, secondary).
+ *   - --surface-warm aliases --surface (no warm tier in Slack's system).
+ *   - --fg: #1D1C1D (near-black — not pure black per brand spec).
+ *   - --accent: #4A154B (aubergine — primary CTAs and the sidebar).
+ *   - --accent-hover: #611f69 (active aubergine).
+ *   - --leading-tight: 1.10 (display compression at 48px).
+ *   - h2 (36px) → 1.15; h3 (28px) → 1.25 per DESIGN.md type table.
+ *   - --tracking-display: -0.021em (-1px / 48px normalized).
+ *   - --radius-sm: 4px (buttons/inputs — Slack uses conservative radius).
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface ──────────────────────────────────────────────────── */
+  --bg:           #ffffff;
+  --surface:      #f8f8f8;              /* thread panels, secondary surfaces */
+  --surface-warm: var(--surface);       /* no warm tier in Slack's system */
+
+  /* ─── Foreground ───────────────────────────────────────────────── */
+  --fg:   #1d1c1d;                      /* near-black — not pure black */
+  --fg-2: #1d1c1d;                      /* same ink; no split tier */
+  --muted: #616061;                     /* timestamps, muted labels */
+  --meta:  #616061;                     /* same muted tier */
+
+  /* ─── Border ───────────────────────────────────────────────────── */
+  --border:      #dddddd;              /* standard dividers, card borders */
+  --border-soft: #f1f1f1;             /* subtle row separators */
+
+  /* ─── Accent ───────────────────────────────────────────────────── */
+  --accent:        #4a154b;            /* aubergine — primary CTAs, sidebar bg */
+  --accent-on:     #ffffff;
+  --accent-hover:  #611f69;            /* active/hover aubergine */
+  --accent-active: #350d36;            /* deep aubergine — pressed */
+
+  /* ─── Semantic ─────────────────────────────────────────────────── */
+  /* Logo palette: these ARE the semantic colors (info/success/warn/danger). */
+  --success: #2eb67d;                  /* Slack teal green — online, success */
+  --warn:    #ecb22e;                  /* Slack gold — away, warning */
+  --danger:  #e01e5a;                  /* Slack ruby — notifications, errors */
+
+  /* ─── Typography ───────────────────────────────────────────────── */
+  --font-display: "Larsseit", "Helvetica Neue", Arial, sans-serif;
+  --font-body:    system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  --font-mono:    "Monaco", "Menlo", "Courier New", Courier, monospace;
+
+  /* Type scale — DESIGN.md §Type Scale.
+   * Slack base size is 15px (density). Display: 48px marketing hero.
+   * Schema maps: xs=12, sm=15, base=15(=body), lg=18, xl=22, 2xl=28,
+   * 3xl=36, 4xl=48. */
+  --text-xs:   12px;                   /* caption / timestamp */
+  --text-sm:   13px;                   /* body SM — secondary metadata */
+  --text-base: 15px;                   /* default UI text (Slack's base) */
+  --text-lg:   16px;                   /* body L — messages, descriptions */
+  --text-xl:   22px;                   /* heading 2 — card titles */
+  --text-2xl:  28px;                   /* heading 1 — modal titles */
+  --text-3xl:  36px;                   /* display L — section heroes */
+  --text-4xl:  48px;                   /* display XL — marketing hero */
+
+  /* Leading + tracking.
+   * --leading-tight=1.10: display hero compression.
+   * h2 (36px) → 1.15; h3 (28px) → 1.25 per DESIGN.md.
+   * --tracking-display: -0.021em = -1px / 48px normalized. */
+  --leading-body:     1.5;
+  --leading-tight:    1.10;
+  --tracking-display: -0.021em;
+
+  /* ─── Spacing ──────────────────────────────────────────────────── */
+  /* 4px base grid per DESIGN.md §Spacing System. */
+  --space-1:  4px;
+  --space-2:  8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  20px;
+  --space-6:  24px;
+  --space-8:  32px;
+  --space-12: 48px;
+
+  /* Section rhythm. */
+  --section-y-desktop: 80px;
+  --section-y-tablet:  48px;
+  --section-y-phone:   32px;
+
+  /* ─── Radius ───────────────────────────────────────────────────── */
+  /* 4px is Slack's standard for buttons and inputs — not cartoonish. */
+  --radius-sm:   4px;
+  --radius-md:   8px;
+  --radius-lg:   12px;
+  --radius-pill: 9999px;
+
+  /* ─── Elevation ────────────────────────────────────────────────── */
+  /* Light shadows on a light surface. */
+  --elev-flat:   none;
+  --elev-ring:   0 1px 3px rgba(0, 0, 0, 0.08);
+  --elev-raised: 0 4px 12px rgba(0, 0, 0, 0.12);
+
+  /* ─── Focus ────────────────────────────────────────────────────── */
+  /* Slack focus: blue ring on #1264A3. */
+  --focus-ring: 0 0 0 2px rgba(18, 100, 163, 0.25);
+
+  /* ─── Motion ───────────────────────────────────────────────────── */
+  --motion-fast:   150ms;
+  --motion-base:   200ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+  /* ─── Layout ───────────────────────────────────────────────────── */
+  --container-max:            1200px;
+  --container-gutter-desktop: 24px;
+  --container-gutter-tablet:  16px;
+  --container-gutter-phone:   16px;
+}

--- a/design-systems/spotify/components.html
+++ b/design-systems/spotify/components.html
@@ -1,0 +1,365 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Spotify — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/spotify. Every visible
+        value comes from tokens.css. Spotify's signature moves: near-black
+        immersive surfaces, Spotify Green (#1ed760) for play/active/CTA only,
+        full-pill and circular geometry, uppercase button labels with wide tracking."
+    />
+
+    <style>
+      :root {
+        --bg:           #121212;
+        --surface:      #181818;
+        --surface-warm: #1f1f1f;
+
+        --fg:   #ffffff;
+        --fg-2: #fdfdfd;
+        --muted: #b3b3b3;
+        --meta:  #cbcbcb;
+
+        --border:      #4d4d4d;
+        --border-soft: rgba(255, 255, 255, 0.1);
+
+        --accent:        #1ed760;
+        --accent-on:     #000000;
+        --accent-hover:  #1db954;
+        --accent-active: color-mix(in oklab, var(--accent), black 10%);
+
+        --success: #1ed760;
+        --warn:    #ffa42b;
+        --danger:  #f3727f;
+
+        --font-display: "SpotifyMixUITitle", "CircularSp", "Helvetica Neue", Helvetica, Arial, sans-serif;
+        --font-body:    "SpotifyMixUI", "CircularSp", "Helvetica Neue", Helvetica, Arial, sans-serif;
+        --font-mono:    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+
+        --text-xs:   10px;
+        --text-sm:   12px;
+        --text-base: 16px;
+        --text-lg:   18px;
+        --text-xl:   20px;
+        --text-2xl:  24px;
+        --text-3xl:  24px;
+        --text-4xl:  24px;
+
+        --leading-body:     1.50;
+        --leading-tight:    1.00;
+        --tracking-display: normal;
+
+        --space-1:  4px;
+        --space-2:  8px;
+        --space-3:  12px;
+        --space-4:  16px;
+        --space-5:  20px;
+        --space-6:  24px;
+        --space-8:  32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 64px;
+        --section-y-tablet:  40px;
+        --section-y-phone:   24px;
+
+        --radius-sm:   9999px;
+        --radius-md:   6px;
+        --radius-lg:   8px;
+        --radius-pill: 9999px;
+
+        --elev-flat:   none;
+        --elev-ring:   0 0 0 1px var(--border);
+        --elev-raised: rgba(0, 0, 0, 0.3) 0px 8px 8px;
+
+        --focus-ring: 0 0 0 3px rgba(30, 215, 96, 0.4);
+
+        --motion-fast:   150ms;
+        --motion-base:   200ms;
+        --ease-standard: ease;
+
+        --container-max:            1280px;
+        --container-gutter-desktop: 24px;
+        --container-gutter-tablet:  16px;
+        --container-gutter-phone:   16px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      section + section { border-top: 1px solid var(--border-soft); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography ─────────────────────────── */
+      h1, h2 {
+        font-family: var(--font-display);
+        font-weight: 700;
+        margin: 0;
+        color: var(--fg);
+        line-height: var(--leading-tight);
+      }
+      h1 { font-size: var(--text-2xl); }
+      h2 { font-size: var(--text-2xl); }
+      h3 {
+        font-family: var(--font-body);
+        font-size: var(--text-lg);
+        font-weight: 600;
+        line-height: 1.30;
+        margin: 0;
+        color: var(--fg);
+      }
+      p { margin: 0; }
+      .body-muted { color: var(--muted); }
+      .body-sm { font-size: var(--text-sm); color: var(--muted); }
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+
+      /* ─── Buttons — full pill; uppercase + wide tracking on labels. */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 8px 16px;
+        border-radius: var(--radius-sm);   /* 9999px full pill */
+        font-family: var(--font-body);
+        font-size: 14px;
+        font-weight: 700;
+        line-height: 1;
+        cursor: pointer;
+        border: none;
+        transition: background-color var(--motion-fast) var(--ease-standard),
+                    opacity var(--motion-fast) var(--ease-standard);
+        text-decoration: none;
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      /* Standard dark pill. */
+      .btn-dark {
+        background: var(--surface-warm);
+        color: var(--fg);
+      }
+      .btn-dark:hover { background: #2a2a2a; }
+      /* Outlined pill. */
+      .btn-outline {
+        background: transparent;
+        color: var(--fg);
+        border: 1px solid var(--border);
+        padding: 4px 16px 4px 36px;
+      }
+      /* Uppercase CTA label variant. */
+      .btn-upper {
+        text-transform: uppercase;
+        letter-spacing: 1.4px;
+        font-size: 12px;
+      }
+      /* Green circular play button. */
+      .btn-play {
+        background: var(--accent);
+        color: var(--accent-on);
+        width: 56px;
+        height: 56px;
+        border-radius: 50%;
+        padding: 0;
+        justify-content: center;
+        flex-shrink: 0;
+      }
+      .btn-play:hover { background: var(--accent-hover); transform: scale(1.04); }
+
+      /* ─── Nav pill ───────────────────────────── */
+      .nav-pill {
+        display: inline-flex;
+        align-items: center;
+        padding: 8px 16px;
+        border-radius: var(--radius-sm);
+        font-size: 14px;
+        font-weight: 700;
+        color: var(--fg);
+        background: var(--surface);
+        text-decoration: none;
+        transition: background-color var(--motion-fast) var(--ease-standard);
+      }
+      .nav-pill.active { background: var(--surface-warm); }
+      .nav-pill:hover { background: #2a2a2a; }
+
+      /* ─── Track row ──────────────────────────── */
+      .track-row {
+        display: flex;
+        align-items: center;
+        gap: var(--space-4);
+        padding: var(--space-2) var(--space-3);
+        border-radius: var(--radius-md);
+        transition: background-color var(--motion-fast) var(--ease-standard);
+        cursor: pointer;
+      }
+      .track-row:hover { background: rgba(255, 255, 255, 0.1); }
+      .track-thumb {
+        width: 40px;
+        height: 40px;
+        border-radius: var(--radius-md);
+        background: var(--surface-warm);
+        flex-shrink: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 18px;
+      }
+      .track-info { flex: 1; min-width: 0; }
+      .track-name { font-size: var(--text-base); font-weight: 400; color: var(--fg); }
+      .track-artist { font-size: var(--text-sm); color: var(--muted); }
+      .track-duration { font-size: var(--text-sm); color: var(--muted); font-tabular-nums: tabular-nums; }
+
+      /* ─── Card ───────────────────────────────── */
+      .card {
+        background: var(--surface);
+        border-radius: var(--radius-md);
+        padding: var(--space-4);
+        transition: background-color var(--motion-base) var(--ease-standard);
+      }
+      .card:hover { background: #202020; box-shadow: var(--elev-raised); }
+
+      /* ─── Layout ─────────────────────────────── */
+      .hero-grid {
+        display: grid;
+        grid-template-columns: 1.3fr 1fr;
+        gap: var(--space-8);
+        align-items: center;
+      }
+      @media (max-width: 1023px) { .hero-grid { grid-template-columns: 1fr; } }
+      .album-grid {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: var(--space-4);
+      }
+      @media (max-width: 1023px) { .album-grid { grid-template-columns: repeat(2, 1fr); } }
+      @media (max-width: 639px)  { .album-grid { grid-template-columns: 1fr 1fr; } }
+      .hero-actions { display: flex; gap: var(--space-3); margin-block-start: var(--space-6); flex-wrap: wrap; align-items: center; }
+      .icon { width: 16px; height: 16px; flex-shrink: 0; }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <!-- HERO -->
+      <section data-od-id="hero">
+        <div class="hero-grid">
+          <div class="stack-4">
+            <h1>Music for everyone.</h1>
+            <p class="body-muted" style="font-size:var(--text-base);margin-top:var(--space-3)">
+              Millions of songs and podcasts. No credit card needed.
+              Dark immersion — the UI recedes so content can glow.
+            </p>
+            <div class="hero-actions">
+              <a href="./tokens.css" class="btn btn-play" aria-label="Play">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                  <path d="M8 5v14l11-7z"/>
+                </svg>
+              </a>
+              <a href="./tokens.css" class="btn btn-dark btn-upper">Get Spotify free</a>
+              <a href="./DESIGN.md" class="btn btn-outline">Read the spec</a>
+            </div>
+          </div>
+
+          <aside>
+            <div class="card stack-4">
+              <p style="font-size:var(--text-sm);font-weight:700;color:var(--fg)">Now playing</p>
+              <div class="track-row" style="padding:0">
+                <div class="track-thumb" style="background:var(--accent);color:#000;font-size:24px">♪</div>
+                <div class="track-info">
+                  <p class="track-name">design-systems/tokens</p>
+                  <p class="track-artist">Open Design · 2026</p>
+                </div>
+                <span class="track-duration">3:22</span>
+              </div>
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <!-- FEATURES / PLAYLIST -->
+      <section data-od-id="features">
+        <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:var(--space-5)">
+          <h2>Recent picks</h2>
+          <a href="#" style="font-size:var(--text-sm);font-weight:700;color:var(--muted);text-decoration:none;text-transform:uppercase;letter-spacing:1.4px">Show all</a>
+        </div>
+
+        <div class="album-grid">
+          <div class="card stack-3">
+            <div style="width:100%;aspect-ratio:1;background:linear-gradient(135deg,#5e6ad2,#1ed760);border-radius:var(--radius-md);margin-bottom:var(--space-3)"></div>
+            <p style="font-weight:700;font-size:var(--text-base)">Token Fixtures</p>
+            <p class="body-sm">Brand oracle collection</p>
+          </div>
+          <div class="card stack-3">
+            <div style="width:100%;aspect-ratio:1;background:linear-gradient(135deg,#f54e00,#cf2d56);border-radius:var(--radius-md);margin-bottom:var(--space-3)"></div>
+            <p style="font-weight:700;font-size:var(--text-base)">Cursor Sessions</p>
+            <p class="body-sm">Warm cream meets code</p>
+          </div>
+          <div class="card stack-3">
+            <div style="width:100%;aspect-ratio:1;background:linear-gradient(135deg,#10a37f,#0d0d0d);border-radius:var(--radius-md);margin-bottom:var(--space-3)"></div>
+            <p style="font-weight:700;font-size:var(--text-base)">OpenAI Calm</p>
+            <p class="body-sm">Research lab dressed public</p>
+          </div>
+          <div class="card stack-3">
+            <div style="width:100%;aspect-ratio:1;background:linear-gradient(135deg,#0969da,#1a7f37);border-radius:var(--radius-md);margin-bottom:var(--space-3)"></div>
+            <p style="font-weight:700;font-size:var(--text-base)">GitHub Primer</p>
+            <p class="body-sm">Density over decoration</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- TRACKS -->
+      <section data-od-id="tracks">
+        <h2 style="margin-bottom:var(--space-5)">Track list</h2>
+        <div style="display:flex;flex-direction:column;gap:var(--space-1)">
+          <div class="track-row">
+            <span style="color:var(--muted);font-size:var(--text-sm);width:16px;text-align:right">1</span>
+            <div class="track-thumb">🎵</div>
+            <div class="track-info">
+              <p class="track-name">tokens.css</p>
+              <p class="track-artist">notion · design-systems</p>
+            </div>
+            <span class="track-duration">4:12</span>
+          </div>
+          <div class="track-row">
+            <span style="color:var(--accent);font-size:var(--text-sm);width:16px;text-align:right">▶</span>
+            <div class="track-thumb" style="background:linear-gradient(135deg,#5e6ad2,#191a1b)">🎸</div>
+            <div class="track-info">
+              <p class="track-name" style="color:var(--accent)">components.html</p>
+              <p class="track-artist">linear-app · design-systems</p>
+            </div>
+            <span class="track-duration">3:55</span>
+          </div>
+          <div class="track-row">
+            <span style="color:var(--muted);font-size:var(--text-sm);width:16px;text-align:right">3</span>
+            <div class="track-thumb">🎹</div>
+            <div class="track-info">
+              <p class="track-name">DESIGN.md</p>
+              <p class="track-artist">github · design-systems</p>
+            </div>
+            <span class="track-duration">2:48</span>
+          </div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/spotify/tokens.css
+++ b/design-systems/spotify/tokens.css
@@ -1,0 +1,127 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/spotify/tokens.css
+ *
+ * Structured token bindings for the "Spotify" brand — near-black immersive
+ * dark theme, vibrant green accent, bold type, album-art-driven.
+ *
+ * Brand identity in three sentences:
+ *   1. Content-first darkness — three-step charcoal ladder (#121212 deepest
+ *      → #181818 cards → #1f1f1f buttons) where the UI recedes so album
+ *      art and playlists can glow; achromatic chrome by design.
+ *   2. SpotifyMixUI/CircularSp family at bold (700) / semibold (600) /
+ *      regular (400); uppercase button labels with wide letter-spacing
+ *      (1.4px–2px) create a systematic label voice; compact 10–24px range.
+ *   3. Spotify Green (#1ed760) as the singular functional accent —
+ *      exclusively for play controls, active states, and primary CTAs;
+ *      never decorative; full-pill (500px–9999px) or circular (50%) geometry.
+ *
+ * Schema decisions:
+ *   - --bg: #121212 (near-black deepest); --surface: #181818 (cards).
+ *   - --surface-warm: #1f1f1f (button bg / interactive surfaces).
+ *   - --fg: #ffffff (white — primary text on dark).
+ *   - --fg-2: #fdfdfd (near-pure white — maximum emphasis).
+ *   - --muted: #b3b3b3 (silver — secondary text, inactive nav).
+ *   - --meta: #cbcbcb (near-white secondary body text).
+ *   - --border: #4d4d4d; --border-soft: rgba(255,255,255,0.1).
+ *   - --accent: #1ed760 (Spotify Green — play/active/CTA).
+ *   - --accent-on: #000000 (black text on green).
+ *   - --tracking-display: normal (titles use uppercase + wide tracking inline).
+ *   - --leading-tight: 1.00 (section title line-height).
+ *   - --radius-sm: 9999px (full pill); --radius-md: 6px (cards/containers).
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface ──────────────────────────────────────────────────── */
+  --bg:           #121212;             /* near-black — deepest background */
+  --surface:      #181818;             /* cards, sidebar, containers */
+  --surface-warm: #1f1f1f;            /* button bg / interactive surfaces */
+
+  /* ─── Foreground ───────────────────────────────────────────────── */
+  --fg:   #ffffff;                     /* primary text — white on dark */
+  --fg-2: #fdfdfd;                     /* near-pure white — maximum emphasis */
+  --muted: #b3b3b3;                    /* silver — secondary, inactive nav */
+  --meta:  #cbcbcb;                    /* slightly brighter secondary text */
+
+  /* ─── Border ───────────────────────────────────────────────────── */
+  --border:      #4d4d4d;             /* button borders on dark */
+  --border-soft: rgba(255, 255, 255, 0.1);
+
+  /* ─── Accent ───────────────────────────────────────────────────── */
+  --accent:        #1ed760;           /* Spotify Green — functional only */
+  --accent-on:     #000000;           /* black text on green */
+  --accent-hover:  #1db954;           /* green border variant on hover */
+  --accent-active: color-mix(in oklab, var(--accent), black 10%);
+
+  /* ─── Semantic ─────────────────────────────────────────────────── */
+  --success: #1ed760;                 /* green — completion, active */
+  --warn:    #ffa42b;                 /* warning orange */
+  --danger:  #f3727f;                 /* negative red — error states */
+
+  /* ─── Typography ───────────────────────────────────────────────── */
+  --font-display: "SpotifyMixUITitle", "CircularSp", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-body:    "SpotifyMixUI", "CircularSp", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-mono:    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+
+  /* Type scale — DESIGN.md §Typography.
+   * Spotify's compact range: 10px–24px. The schema spine maps key stops.
+   * No display hero larger than 24px; this is an app, not a magazine. */
+  --text-xs:   10px;                  /* micro / badge */
+  --text-sm:   12px;                  /* small — tags, counts */
+  --text-base: 16px;                  /* body bold / body regular */
+  --text-lg:   18px;                  /* feature heading — semibold */
+  --text-xl:   20px;                  /* section sub-heading */
+  --text-2xl:  24px;                  /* section title — SpotifyMixUITitle */
+  --text-3xl:  24px;                  /* same tier — max useful display size */
+  --text-4xl:  24px;                  /* Spotify caps at 24px in the schema */
+
+  /* Leading + tracking.
+   * Compact and dense — this is an app built for scanning playlists.
+   * Button labels are uppercase + 1.4px–2px tracking (set inline in CSS). */
+  --leading-body:     1.50;
+  --leading-tight:    1.00;
+  --tracking-display: normal;
+
+  /* ─── Spacing ──────────────────────────────────────────────────── */
+  /* 8px base unit per DESIGN.md §Spacing System. Compact scale. */
+  --space-1:  4px;
+  --space-2:  8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  20px;
+  --space-6:  24px;
+  --space-8:  32px;
+  --space-12: 48px;
+
+  /* Section rhythm — dark compression; density over breathing room. */
+  --section-y-desktop: 64px;
+  --section-y-tablet:  40px;
+  --section-y-phone:   24px;
+
+  /* ─── Radius ───────────────────────────────────────────────────── */
+  /* Pill everything — 9999px for navigation pills, 500px for large pill
+     buttons, 6px for album art and card containers. */
+  --radius-sm:   9999px;              /* full pill — buttons/navigation */
+  --radius-md:   6px;                 /* cards, album art containers */
+  --radius-lg:   8px;                 /* dialogs, panels */
+  --radius-pill: 9999px;
+
+  /* ─── Elevation ────────────────────────────────────────────────── */
+  /* Heavy shadows needed on dark — 0.3–0.5 opacity for visibility. */
+  --elev-flat:   none;
+  --elev-ring:   0 0 0 1px var(--border);
+  --elev-raised: rgba(0, 0, 0, 0.3) 0px 8px 8px;
+
+  /* ─── Focus ────────────────────────────────────────────────────── */
+  --focus-ring: 0 0 0 3px rgba(30, 215, 96, 0.4);
+
+  /* ─── Motion ───────────────────────────────────────────────────── */
+  --motion-fast:   150ms;
+  --motion-base:   200ms;
+  --ease-standard: ease;
+
+  /* ─── Layout ───────────────────────────────────────────────────── */
+  --container-max:            1280px;
+  --container-gutter-desktop: 24px;
+  --container-gutter-tablet:  16px;
+  --container-gutter-phone:   16px;
+}

--- a/design-systems/uber/components.html
+++ b/design-systems/uber/components.html
@@ -1,0 +1,347 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Uber — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/uber. Every visible
+        value comes from tokens.css. Uber's signature moves: pure black
+        and white (no tints), UberMove bold headlines, UberMoveText body,
+        999px full-pill buttons, whisper-soft shadows (0.12 opacity)."
+    />
+
+    <style>
+      :root {
+        --bg:           #ffffff;
+        --surface:      #ffffff;
+        --surface-warm: #f8f8f8;
+
+        --fg:   #000000;
+        --fg-2: #000000;
+        --muted: #4b4b4b;
+        --meta:  #afafaf;
+
+        --border:      #000000;
+        --border-soft: rgba(0, 0, 0, 0.1);
+
+        --accent:        #000000;
+        --accent-on:     #ffffff;
+        --accent-hover:  #e2e2e2;
+        --accent-active: rgba(0, 0, 0, 0.08);
+
+        --success: #16a34a;
+        --warn:    #eab308;
+        --danger:  #dc2626;
+
+        --font-display: "UberMove", "UberMoveText", system-ui, "Helvetica Neue", Helvetica, Arial, sans-serif;
+        --font-body:    "UberMoveText", system-ui, "Helvetica Neue", Helvetica, Arial, sans-serif;
+        --font-mono:    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+
+        --text-xs:   12px;
+        --text-sm:   14px;
+        --text-base: 16px;
+        --text-lg:   18px;
+        --text-xl:   24px;
+        --text-2xl:  32px;
+        --text-3xl:  36px;
+        --text-4xl:  52px;
+
+        --leading-body:     1.50;
+        --leading-tight:    1.23;
+        --tracking-display: normal;
+
+        --space-1:  4px;
+        --space-2:  8px;
+        --space-3:  12px;
+        --space-4:  16px;
+        --space-5:  20px;
+        --space-6:  24px;
+        --space-8:  32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 80px;
+        --section-y-tablet:  48px;
+        --section-y-phone:   32px;
+
+        --radius-sm:   999px;
+        --radius-md:   8px;
+        --radius-lg:   12px;
+        --radius-pill: 9999px;
+
+        --elev-flat:   none;
+        --elev-ring:   0 0 0 1px var(--border-soft);
+        --elev-raised: rgba(0, 0, 0, 0.12) 0px 4px 16px 0px;
+
+        --focus-ring: rgb(255, 255, 255) 0px 0px 0px 2px inset;
+
+        --motion-fast:   150ms;
+        --motion-base:   200ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+        --container-max:            1136px;
+        --container-gutter-desktop: 24px;
+        --container-gutter-tablet:  16px;
+        --container-gutter-phone:   16px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      section + section { border-top: 1px solid var(--border-soft); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography ─────────────────────────── */
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        font-weight: 700;              /* always bold — billboard force */
+        margin: 0;
+        color: var(--fg);
+        line-height: var(--leading-tight);
+      }
+      h1 {
+        font-size: var(--text-4xl);
+        /* 52px display: line-height 1.23 (--leading-tight), no letter-spacing. */
+      }
+      h2 {
+        font-size: var(--text-3xl);
+        /* 36px section heading: line-height 1.22. */
+        line-height: 1.22;
+      }
+      h3 {
+        font-size: var(--text-xl);
+        /* 24px sub-heading: line-height 1.33.
+           Overrides the shared 1.23 set above. */
+        line-height: 1.33;
+      }
+      p { margin: 0; }
+      .body-muted { color: var(--muted); }
+      .body-sm { font-size: var(--text-sm); }
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+
+      /* ─── Buttons — 999px full pill for all. ─── */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 10px 12px;
+        border-radius: var(--radius-sm);   /* 999px full pill */
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        font-weight: 500;
+        line-height: 1;
+        cursor: pointer;
+        border: none;
+        transition: background-color var(--motion-fast) var(--ease-standard);
+        text-decoration: none;
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn-black {
+        background: var(--fg);
+        color: var(--accent-on);
+      }
+      .btn-black:hover { background: #222; }
+      .btn-white {
+        background: var(--bg);
+        color: var(--fg);
+        border: 1px solid var(--border-soft);
+      }
+      .btn-white:hover { background: var(--accent-hover); }
+
+      /* ─── Chip / category pill ───────────────── */
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        padding: 14px 16px;
+        border-radius: var(--radius-sm);
+        font-family: var(--font-body);
+        font-size: var(--text-sm);
+        font-weight: 500;
+        background: #efefef;
+        color: var(--fg);
+        cursor: pointer;
+        border: none;
+        transition: background-color var(--motion-fast) var(--ease-standard);
+      }
+      .chip:hover { background: #e2e2e2; }
+      .chip.active { background: var(--fg); color: var(--accent-on); }
+
+      /* ─── Cards ──────────────────────────────── */
+      .card {
+        background: var(--bg);
+        border-radius: var(--radius-md);
+        padding: var(--space-6);
+        box-shadow: var(--elev-raised);
+      }
+      .card-featured {
+        border-radius: var(--radius-lg);
+      }
+
+      /* ─── Inputs ─────────────────────────────── */
+      .field { display: flex; flex-direction: column; gap: var(--space-2); }
+      .field label { font-size: var(--text-sm); font-weight: 500; color: var(--muted); }
+      .field input {
+        background: var(--bg);
+        color: var(--fg);
+        border: 1px solid var(--fg);
+        border-radius: var(--radius-md);
+        padding: 12px 16px;
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        outline: none;
+        transition: border-color var(--motion-fast) var(--ease-standard);
+      }
+      .field input::placeholder { color: var(--meta); }
+      .field input:focus { border-color: var(--fg); box-shadow: 0 0 0 2px rgba(0,0,0,0.1); }
+
+      /* ─── Dark footer ────────────────────────── */
+      .footer-dark {
+        background: var(--fg);
+        color: var(--accent-on);
+        padding: var(--space-8) 0;
+        margin-inline: calc(var(--container-gutter-desktop) * -1);
+        padding-inline: var(--container-gutter-desktop);
+      }
+
+      /* ─── Layout ─────────────────────────────── */
+      .hero-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-8);
+        align-items: center;
+      }
+      @media (max-width: 1023px) { .hero-grid { grid-template-columns: 1fr; } }
+      .features-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: var(--space-5);
+      }
+      @media (max-width: 1023px) { .features-grid { grid-template-columns: 1fr 1fr; } }
+      @media (max-width: 639px)  { .features-grid { grid-template-columns: 1fr; } }
+      .hero-actions { display: flex; gap: var(--space-3); margin-block-start: var(--space-6); flex-wrap: wrap; }
+      .chip-row { display: flex; gap: var(--space-2); flex-wrap: wrap; }
+      .icon { width: 16px; height: 16px; flex-shrink: 0; }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <!-- HERO -->
+      <section data-od-id="hero">
+        <div style="margin-bottom:var(--space-6)">
+          <div class="chip-row">
+            <button class="chip active">Ride</button>
+            <button class="chip">Drive</button>
+            <button class="chip">Business</button>
+            <button class="chip">Uber Eats</button>
+            <button class="chip">About</button>
+          </div>
+        </div>
+
+        <div class="hero-grid">
+          <div class="stack-4">
+            <h1>Get a ride in minutes.</h1>
+            <p class="body-muted" style="font-size:var(--text-lg);line-height:1.5;max-width:44ch;margin-top:var(--space-3)">
+              From your first trip to your thousandth, Uber is here for you.
+              Pure black-and-white, full-pill buttons, whisper-soft shadows.
+            </p>
+            <div class="hero-actions">
+              <a href="./tokens.css" class="btn btn-black">
+                See prices
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                     stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M5 12h14M13 6l6 6-6 6"/>
+                </svg>
+              </a>
+              <a href="./DESIGN.md" class="btn btn-white">Read the spec</a>
+            </div>
+          </div>
+
+          <aside>
+            <div class="card card-featured">
+              <p style="font-size:var(--text-sm);font-weight:500;color:var(--muted);margin-bottom:var(--space-4)">Your trip</p>
+              <div class="field" style="margin-bottom:var(--space-3)">
+                <label for="pickup">Pickup</label>
+                <input id="pickup" type="text" placeholder="Enter pickup location" />
+              </div>
+              <div class="field" style="margin-bottom:var(--space-5)">
+                <label for="dest">Destination</label>
+                <input id="dest" type="text" placeholder="Where to?" />
+              </div>
+              <button class="btn btn-black" style="width:100%;justify-content:center">See prices</button>
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <!-- FEATURES -->
+      <section data-od-id="features">
+        <h2 style="max-width:26ch;margin-bottom:var(--space-6)">Uber for business, every day.</h2>
+
+        <div class="features-grid">
+          <article class="card stack-3">
+            <h3>Black on white</h3>
+            <p class="body-muted body-sm">
+              True #000000 and #ffffff — not near-black, not off-white.
+              The stark duality IS Uber. No warmth, no tint, no gradients.
+            </p>
+          </article>
+          <article class="card stack-3">
+            <h3>999px radius</h3>
+            <p class="body-muted body-sm">
+              Every button, chip, and navigation item uses full-pill geometry.
+              UberMove Bold (700) for all headings — billboard force.
+            </p>
+          </article>
+          <article class="card stack-3">
+            <h3>Whisper shadow</h3>
+            <p class="body-muted body-sm">
+              rgba(0,0,0,0.12) 0px 4px 16px — bare minimum lift.
+              Cards defined by shadow, not border. Never dramatic depth.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <!-- DARK FOOTER -->
+      <section data-od-id="footer" style="padding-block:0">
+        <div class="footer-dark">
+          <h2 style="color:#ffffff;font-size:var(--text-xl);margin-bottom:var(--space-4)">Move the world forward.</h2>
+          <p style="font-size:var(--text-sm);color:var(--meta);max-width:44ch">
+            Uber's vision: transportation as reliable as running water, everywhere, for everyone.
+          </p>
+          <div style="display:flex;gap:var(--space-3);margin-top:var(--space-6);flex-wrap:wrap">
+            <a href="#" style="font-size:var(--text-sm);color:var(--meta);text-decoration:none">Company</a>
+            <a href="#" style="font-size:var(--text-sm);color:var(--meta);text-decoration:none">Newsroom</a>
+            <a href="#" style="font-size:var(--text-sm);color:var(--meta);text-decoration:none">Investors</a>
+            <a href="#" style="font-size:var(--text-sm);color:var(--meta);text-decoration:none">Blog</a>
+            <a href="#" style="font-size:var(--text-sm);color:var(--meta);text-decoration:none">Careers</a>
+          </div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/uber/tokens.css
+++ b/design-systems/uber/tokens.css
@@ -1,0 +1,131 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/uber/tokens.css
+ *
+ * Structured token bindings for the "Uber" brand — bold black-and-white,
+ * pill-shaped everything, tight urban energy.
+ *
+ * Brand identity in three sentences:
+ *   1. Pure black (#000000) and pure white (#ffffff) — not near-black or
+ *      off-white; the stark duality IS Uber; no warmth, no tint, no mid-tone
+ *      grays in the UI chrome (only #4b4b4b secondary and #afafaf tertiary).
+ *   2. UberMove (proprietary geometric sans) at 700 for all headings — bold
+ *      as a billboard; UberMoveText at 400–500 for body/UI; two fonts with
+ *      strict roles; no decorative type treatment whatsoever.
+ *   3. Pill-shaped everything: 999px radius on all buttons, chips, and nav
+ *      items — unmistakably Uber; whisper-soft shadows (0.12–0.16 opacity)
+ *      for the bare minimum card lift; gradient-free, flat color blocks.
+ *
+ * Schema decisions:
+ *   - --bg: #ffffff; --surface: #ffffff (cards defined by shadow, not color).
+ *   - --surface-warm: #f8f8f8 (thread panels / hover state — barely there).
+ *   - --fg: #000000 (true black); --fg-2: #000000 (same).
+ *   - --muted: #4b4b4b (body gray — secondary text); --meta: #afafaf.
+ *   - --border: #000000 (functional only — inputs); --border-soft: none.
+ *   - --accent: #000000 (black IS the primary CTA color in B&W system).
+ *   - --accent-on: #ffffff; --accent-hover: #e2e2e2 (hover gray on white).
+ *   - --tracking-display: normal (no letter-spacing — functional typography).
+ *   - --leading-tight: 1.23 (52px display hero line-height).
+ *   - h2 (36px) → 1.22; h3 (24px) → 1.33 per DESIGN.md type table.
+ *   - --radius-sm: 999px (full pill for all CTAs per brand identity).
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface ──────────────────────────────────────────────────── */
+  --bg:           #ffffff;
+  --surface:      #ffffff;             /* cards defined by shadow, not color */
+  --surface-warm: #f8f8f8;            /* hover bg / slightly elevated surface */
+
+  /* ─── Foreground ───────────────────────────────────────────────── */
+  --fg:   #000000;                     /* true black — uncompromising */
+  --fg-2: #000000;                     /* same; no secondary ink tier */
+  --muted: #4b4b4b;                    /* body gray — secondary text */
+  --meta:  #afafaf;                    /* muted gray — tertiary, footer links */
+
+  /* ─── Border ───────────────────────────────────────────────────── */
+  /* Borders are functional, not decorative. Inputs only. */
+  --border:      #000000;             /* input border — the only visible border */
+  --border-soft: rgba(0, 0, 0, 0.1); /* chip/card separation */
+
+  /* ─── Accent ───────────────────────────────────────────────────── */
+  /* In a pure B&W system, black IS the primary CTA. */
+  --accent:        #000000;           /* Uber Black — primary CTA */
+  --accent-on:     #ffffff;
+  --accent-hover:  #e2e2e2;           /* hover gray — white button hover */
+  --accent-active: rgba(0, 0, 0, 0.08); /* inset shadow pressed state */
+
+  /* ─── Semantic ─────────────────────────────────────────────────── */
+  --success: #16a34a;
+  --warn:    #eab308;
+  --danger:  #dc2626;
+
+  /* ─── Typography ───────────────────────────────────────────────── */
+  --font-display: "UberMove", "UberMoveText", system-ui, "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-body:    "UberMoveText", system-ui, "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-mono:    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+
+  /* Type scale — DESIGN.md §Typography Hierarchy.
+   * UberMove headlines: 52px display → 20px small heading (all weight 700).
+   * UberMoveText body: 16px standard → 12px micro.
+   * Schema spine maps the key stops. */
+  --text-xs:   12px;                  /* micro — fine print, legal */
+  --text-sm:   14px;                  /* caption — metadata, descriptions */
+  --text-base: 16px;                  /* body — standard body text */
+  --text-lg:   18px;                  /* nav / UI large — navigation links */
+  --text-xl:   24px;                  /* sub-heading */
+  --text-2xl:  32px;                  /* card title */
+  --text-3xl:  36px;                  /* section heading */
+  --text-4xl:  52px;                  /* display / hero — billboard */
+
+  /* Leading + tracking.
+   * --leading-tight=1.23: 52px display hero rhythm (tight/punchy).
+   * h2 (36px) → 1.22; h3 (24px) → 1.33 per DESIGN.md.
+   * No letter-spacing — "functional typography" (DESIGN.md §3). */
+  --leading-body:     1.50;
+  --leading-tight:    1.23;
+  --tracking-display: normal;
+
+  /* ─── Spacing ──────────────────────────────────────────────────── */
+  /* 8px base unit per DESIGN.md §Spacing System. Compact, efficient. */
+  --space-1:  4px;
+  --space-2:  8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  20px;
+  --space-6:  24px;
+  --space-8:  32px;
+  --space-12: 48px;
+
+  /* Section rhythm — efficient, not airy per DESIGN.md §Whitespace. */
+  --section-y-desktop: 80px;
+  --section-y-tablet:  48px;
+  --section-y-phone:   32px;
+
+  /* ─── Radius ───────────────────────────────────────────────────── */
+  /* Full pill 999px for all buttons and chips — non-negotiable.
+     8px for content cards; 12px for featured containers. */
+  --radius-sm:   999px;               /* full pill — all CTAs */
+  --radius-md:   8px;                 /* content cards */
+  --radius-lg:   12px;                /* featured containers */
+  --radius-pill: 9999px;
+
+  /* ─── Elevation ────────────────────────────────────────────────── */
+  /* Whisper-soft — bare minimum lift, never dramatic. */
+  --elev-flat:   none;
+  --elev-ring:   0 0 0 1px var(--border-soft);
+  --elev-raised: rgba(0, 0, 0, 0.12) 0px 4px 16px 0px;
+
+  /* ─── Focus ────────────────────────────────────────────────────── */
+  /* Inset white ring — the Uber focus signature. */
+  --focus-ring: rgb(255, 255, 255) 0px 0px 0px 2px inset;
+
+  /* ─── Motion ───────────────────────────────────────────────────── */
+  --motion-fast:   150ms;
+  --motion-base:   200ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+  /* ─── Layout ───────────────────────────────────────────────────── */
+  --container-max:            1136px;
+  --container-gutter-desktop: 24px;
+  --container-gutter-tablet:  16px;
+  --container-gutter-phone:   16px;
+}


### PR DESCRIPTION
## Why

This is the second batch of hand-authored oracle fixtures for the Design System Token Channel project (follow-on to #1652). The first batch provided 5 brands (cursor, apple, stripe, airbnb, vercel) as proof-of-concept oracles for the future bulk-derivation script (PR-B). This PR adds 10 more well-documented brands that agents and the derive script can validate against.

User pain addressed: agents currently invent brand-variant token names like `--notion-cream` or pick wrong weight values because the only source of truth is prose in `DESIGN.md`. Hand-authored `tokens.css` + `components.html` fixtures lock in the correct translations once, letting agents paste the `:root` block verbatim.

## What users will see

No visible product change. Design panel agents get a richer oracle set — 12 structured brands instead of 2 — so generated artifacts using notion, linear, github, figma, slack, discord, openai, shopify, spotify, or uber tokens will match the official brand specification more accurately.

## Changes

Added `tokens.css` and `components.html` for 10 brands:

| Brand | Visual theme | Accent | Notable schema decision |
|-------|-------------|--------|------------------------|
| notion | Warm white, near-black text | `#0075de` | `--radius-sm: 4px`; multi-layer shadow (max opacity 0.04) |
| linear-app | Dark #08090a, achromatic | `#5e6ad2` | weight-510; semi-transparent white borders |
| github | True white, hairline borders | `#0969da` | `--text-base: 14px` (density identity) |
| figma | Strict B&W, figmaSans variable | `#000000` | `--radius-sm: 50px` (pill); dashed focus |
| slack | White + aubergine sidebar | `#4a154b` | `--radius-sm: 4px`; logo palette = semantic only |
| discord | Dark #313338, 3-step depth | `#5865f2` | luminance stepping; gg sans weight 510 |
| openai | White, Signifier serif display | `#10a37f` | two font voices; `--radius-sm: 12px` |
| shopify | Void black, NeueHaasGrotesk | `#36f4a4` | `--radius-sm: 9999px`; ultra-light weight 330 |
| spotify | Near-black #121212 | `#1ed760` | `--radius-sm: 9999px`; uppercase button labels |
| uber | Pure B&W, UberMove bold | `#000000` | `--radius-sm: 999px`; whisper shadow 0.12 |

## Validation

```
pnpm guard
```

All 13 checks pass. Guard reports 12 structured brands (up from 2 on `main`), token-fixture sync verified for all 12 pairs.

## Surface area checklist

- [x] `design-systems/` — 10 new brand directories each adding `tokens.css` + `components.html`
- [ ] `skills/`
- [ ] `craft/`
- [ ] CLI flags / env vars
- [ ] i18n keys
- [ ] Root `package.json` dependencies
- [ ] `apps/`, `packages/`, `tools/`, `e2e/` source

## Related

Continues the oracle work from #1652 (`feat(design-systems): add structured tokens for cursor, apple, stripe, airbnb, vercel brands`).

Made with [Cursor](https://cursor.com)