### PR TITLE
fix(ci): let metrics PRs trigger required checks

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -33,6 +33,7 @@ jobs:
           # as a read/render fallback because many orgs disallow PR creation from it.
           token: ${{ secrets.METRICS_TOKEN || secrets.GITHUB_TOKEN }}
           committer_token: ${{ secrets.METRICS_TOKEN }}
+          committer_message: Update ${filename}
           output_action: pull-request
           output_condition: data-changed
 


### PR DESCRIPTION
## Why

Metrics bot PRs can be blocked by branch protection when their generated commit message skips GitHub Actions, leaving the required `Validate workspace` check missing. This change aligns metrics PR behavior with the contributors-wall bot PRs so required checks are produced normally.

## What users will see

No product UI change. Maintainers will see future metrics SVG update PRs trigger the required CI check instead of being blocked with no checks.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A.

## Bug fix verification

- No red spec added; this is a GitHub Actions configuration fix for generated metrics PRs. Verified by comparing the blocked metrics PR behavior with the contributors-wall workflow pattern.

## Validation

- Not run locally; workflow-only configuration change.