### PR TITLE
[test] new contributor webhook smoke

### DIFF
--- a/docs/new-contributor-webhook-smoke-811634243-sketch.md
+++ b/docs/new-contributor-webhook-smoke-811634243-sketch.md
@@ -1,0 +1,3 @@
+Temporary new contributor webhook smoke test.
+
+This PR is opened by 811634243-sketch to verify the Discord new-contributor announcement path and can be closed after verification.


### PR DESCRIPTION
Temporary PR to verify the GitHub new-contributor webhook path for the Discord announcer. This can be closed after verification.