### PR TITLE
feat(web): free-form zoom in HTML and Live Artifact preview viewers

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useId, useMemo, useRef, useState, type CSSProperties, type MouseEvent as ReactMouseEvent, type ReactNode } from 'react';
+import { useCallback, useEffect, useId, useMemo, useRef, useState, type CSSProperties, type Dispatch, type MouseEvent as ReactMouseEvent, type ReactNode, type RefObject, type SetStateAction } from 'react';
 import { createPortal } from 'react-dom';
 import { APP_CHROME_FILE_ACTIONS_ID } from './AppChromeHeader';
 import {
@@ -180,6 +180,95 @@ const PREVIEW_VIEWPORT_PRESETS: PreviewViewportPreset[] = [
     titleKey: 'fileViewer.viewportMobileTitle',
   },
 ];
+
+// Free-form preview zoom: any integer percent in [ZOOM_MIN, ZOOM_MAX]. The
+// dropdown keeps the canonical presets, +/- step by ZOOM_STEP, Ctrl/Meta-wheel
+// multiplies by ZOOM_WHEEL_FACTOR per tick so big and small zooms feel even.
+const ZOOM_MIN = 25;
+const ZOOM_MAX = 200;
+const ZOOM_STEP = 10;
+const ZOOM_WHEEL_FACTOR = 1.1;
+const ZOOM_PRESETS = [50, 75, 100, 125, 150, 200];
+
+function clampZoom(n: number): number {
+  return Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, Math.round(n)));
+}
+
+function ZoomInput({
+  value,
+  onChange,
+  t,
+  tabIndex,
+}: {
+  value: number;
+  onChange: (next: number) => void;
+  t: TranslateFn;
+  tabIndex?: number;
+}) {
+  const [draft, setDraft] = useState<string | null>(null);
+  const revertRef = useRef(false);
+  const display = draft ?? `${value}%`;
+  return (
+    <input
+      type="text"
+      inputMode="numeric"
+      className="viewer-zoom-input"
+      value={display}
+      aria-label={t('fileViewer.zoomLevel')}
+      title={t('fileViewer.zoomLevelHint')}
+      tabIndex={tabIndex}
+      onFocus={(e) => {
+        setDraft(String(value));
+        const el = e.currentTarget;
+        // Select after React swaps the controlled value to the digit-only draft.
+        requestAnimationFrame(() => el.select());
+      }}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={(e) => {
+        if (revertRef.current) {
+          revertRef.current = false;
+          setDraft(null);
+          return;
+        }
+        const parsed = parseInt(e.target.value, 10);
+        setDraft(null);
+        if (Number.isFinite(parsed)) onChange(clampZoom(parsed));
+      }}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') {
+          (e.target as HTMLInputElement).blur();
+        } else if (e.key === 'Escape') {
+          revertRef.current = true;
+          (e.target as HTMLInputElement).blur();
+        }
+      }}
+      onDoubleClick={() => {
+        setDraft(null);
+        onChange(100);
+      }}
+    />
+  );
+}
+
+function usePreviewWheelZoom(
+  ref: RefObject<HTMLElement | null>,
+  setZoom: Dispatch<SetStateAction<number>>,
+) {
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const handler = (e: WheelEvent) => {
+      if (!(e.ctrlKey || e.metaKey)) return;
+      e.preventDefault();
+      const factor = e.deltaY < 0 ? ZOOM_WHEEL_FACTOR : 1 / ZOOM_WHEEL_FACTOR;
+      setZoom((z) => clampZoom(z * factor));
+    };
+    // React 18 synthetic wheel is passive; native listener is required so
+    // preventDefault stops Ctrl-scroll browser zoom and macOS trackpad pinch.
+    el.addEventListener('wheel', handler, { passive: false });
+    return () => el.removeEventListener('wheel', handler);
+  }, [ref, setZoom]);
+}
 
 // The five basic style facets the inspect panel exposes. Kept narrow on
 // purpose — open-slide's design tokens panel only edits global tokens, so
@@ -865,9 +954,10 @@ export function LiveArtifactViewer({
     [projectId, liveArtifact.artifactId, reloadKey],
   );
   const previewScale = zoom / 100;
+  usePreviewWheelZoom(previewBodyRef, setZoom);
 
   function bumpZoom(delta: number) {
-    setZoom((z) => Math.max(25, Math.min(200, z + delta)));
+    setZoom((z) => clampZoom(z + delta));
   }
 
   async function handleRefresh() {
@@ -1019,26 +1109,23 @@ export function LiveArtifactViewer({
             <button
               type="button"
               className="icon-only"
-              onClick={() => bumpZoom(-25)}
+              onClick={() => bumpZoom(-ZOOM_STEP)}
               title={t('fileViewer.zoomOut')}
               aria-label={t('fileViewer.zoomOut')}
               tabIndex={mode === 'preview' ? 0 : -1}
             >
               <Icon name="minus" size={14} />
             </button>
-            <button
-              type="button"
-              className="viewer-action viewer-zoom-level"
-              onClick={() => setZoom(100)}
-              title={t('fileViewer.resetZoom')}
+            <ZoomInput
+              value={zoom}
+              onChange={setZoom}
+              t={t}
               tabIndex={mode === 'preview' ? 0 : -1}
-            >
-              <span style={{ fontVariantNumeric: 'tabular-nums' }}>{zoom}%</span>
-            </button>
+            />
             <button
               type="button"
               className="icon-only"
-              onClick={() => bumpZoom(25)}
+              onClick={() => bumpZoom(ZOOM_STEP)}
               title={t('fileViewer.zoomIn')}
               aria-label={t('fileViewer.zoomIn')}
               tabIndex={mode === 'preview' ? 0 : -1}
@@ -3499,6 +3586,7 @@ function HtmlViewer({
   const [manualEditFrozenSource, setManualEditFrozenSource] = useState<string | null>(null);
   const [manualEditViewportWidth, setManualEditViewportWidth] = useState<number | null>(null);
   const [previewBodyRef, previewBodySize] = usePreviewCanvasSize<HTMLDivElement>();
+  usePreviewWheelZoom(previewBodyRef, setZoom);
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const urlPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);
   const srcDocPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);
@@ -5136,7 +5224,7 @@ function HtmlViewer({
   }
 
   function bumpZoom(delta: number) {
-    setZoom((z) => Math.max(25, Math.min(200, z + delta)));
+    setZoom((z) => clampZoom(z + delta));
   }
 
   function activateBoard(nextTool?: BoardTool) {
@@ -5560,27 +5648,27 @@ function HtmlViewer({
           <button
             type="button"
             className="icon-only"
-            onClick={() => bumpZoom(-25)}
+            onClick={() => bumpZoom(-ZOOM_STEP)}
             title={t('fileViewer.zoomOut')}
             aria-label={t('fileViewer.zoomOut')}
           >
             <Icon name="minus" size={14} />
           </button>
           <div className="zoom-menu" ref={zoomMenuRef}>
+            <ZoomInput value={zoom} onChange={setZoom} t={t} />
             <button
               type="button"
-              className="viewer-action zoom-trigger"
+              className="icon-only zoom-trigger"
               aria-haspopup="menu"
               aria-expanded={zoomMenuOpen}
+              aria-label={t('fileViewer.zoomLevel')}
               onClick={() => setZoomMenuOpen((v) => !v)}
-              style={{ minWidth: 64 }}
             >
-              <span style={{ fontVariantNumeric: 'tabular-nums' }}>{zoom}%</span>
               <Icon name="chevron-down" size={11} />
             </button>
             {zoomMenuOpen ? (
               <div className="zoom-menu-popover" role="menu">
-                {[50, 75, 100, 125, 150, 200].map((level) => (
+                {ZOOM_PRESETS.map((level) => (
                   <button
                     key={level}
                     type="button"
@@ -5603,7 +5691,7 @@ function HtmlViewer({
           <button
             type="button"
             className="icon-only"
-            onClick={() => bumpZoom(25)}
+            onClick={() => bumpZoom(ZOOM_STEP)}
             title={t('fileViewer.zoomIn')}
             aria-label={t('fileViewer.zoomIn')}
           >

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -253,10 +253,11 @@ function ZoomInput({
 function usePreviewWheelZoom(
   ref: RefObject<HTMLElement | null>,
   setZoom: Dispatch<SetStateAction<number>>,
+  enabled = true,
 ) {
   useEffect(() => {
     const el = ref.current;
-    if (!el) return;
+    if (!el || !enabled) return;
     const handler = (e: WheelEvent) => {
       if (!(e.ctrlKey || e.metaKey)) return;
       e.preventDefault();
@@ -267,7 +268,7 @@ function usePreviewWheelZoom(
     // preventDefault stops Ctrl-scroll browser zoom and macOS trackpad pinch.
     el.addEventListener('wheel', handler, { passive: false });
     return () => el.removeEventListener('wheel', handler);
-  }, [ref, setZoom]);
+  }, [enabled, ref, setZoom]);
 }
 
 // The five basic style facets the inspect panel exposes. Kept narrow on
@@ -954,7 +955,7 @@ export function LiveArtifactViewer({
     [projectId, liveArtifact.artifactId, reloadKey],
   );
   const previewScale = zoom / 100;
-  usePreviewWheelZoom(previewBodyRef, setZoom);
+  usePreviewWheelZoom(previewBodyRef, setZoom, mode === 'preview');
 
   function bumpZoom(delta: number) {
     setZoom((z) => clampZoom(z + delta));
@@ -3586,7 +3587,7 @@ function HtmlViewer({
   const [manualEditFrozenSource, setManualEditFrozenSource] = useState<string | null>(null);
   const [manualEditViewportWidth, setManualEditViewportWidth] = useState<number | null>(null);
   const [previewBodyRef, previewBodySize] = usePreviewCanvasSize<HTMLDivElement>();
-  usePreviewWheelZoom(previewBodyRef, setZoom);
+  usePreviewWheelZoom(previewBodyRef, setZoom, mode === 'preview');
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const urlPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);
   const srcDocPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -874,6 +874,8 @@ export const ar: Dict = {
   'fileViewer.zoomOut': 'تصغير',
   'fileViewer.zoomIn': 'تكبير',
   'fileViewer.resetZoom': 'إعادة تعيين الزوم',
+  'fileViewer.zoomLevel': 'Zoom level',
+  'fileViewer.zoomLevelHint': 'Type 25–200, or Ctrl/⌘+scroll over preview',
   'fileViewer.viewportAria': 'Preview viewport',
   'fileViewer.viewportDesktop': 'Desktop',
   'fileViewer.viewportDesktopTitle': 'Full-width desktop preview',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -762,6 +762,8 @@ export const de: Dict = {
   'fileViewer.zoomOut': 'Verkleinern',
   'fileViewer.zoomIn': 'Vergrößern',
   'fileViewer.resetZoom': 'Zoom zurücksetzen',
+  'fileViewer.zoomLevel': 'Zoomstufe',
+  'fileViewer.zoomLevelHint': '25–200 eingeben oder Strg/⌘ + Scrollen über der Vorschau',
   'fileViewer.viewportAria': 'Preview viewport',
   'fileViewer.viewportDesktop': 'Desktop',
   'fileViewer.viewportDesktopTitle': 'Full-width desktop preview',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -971,6 +971,8 @@ export const en: Dict = {
   'fileViewer.zoomOut': 'Zoom out',
   'fileViewer.zoomIn': 'Zoom in',
   'fileViewer.resetZoom': 'Reset zoom',
+  'fileViewer.zoomLevel': 'Zoom level',
+  'fileViewer.zoomLevelHint': 'Type 25–200, or Ctrl/⌘+scroll over preview',
   'fileViewer.viewportAria': 'Preview viewport',
   'fileViewer.viewportDesktop': 'Desktop',
   'fileViewer.viewportDesktopTitle': 'Full-width desktop preview',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -763,6 +763,8 @@ export const esES: Dict = {
   'fileViewer.zoomOut': 'Reducir zoom',
   'fileViewer.zoomIn': 'Aumentar zoom',
   'fileViewer.resetZoom': 'Restablecer zoom',
+  'fileViewer.zoomLevel': 'Nivel de zoom',
+  'fileViewer.zoomLevelHint': 'Escribe 25–200, o Ctrl/⌘ + rueda sobre la vista previa',
   'fileViewer.viewportAria': 'Preview viewport',
   'fileViewer.viewportDesktop': 'Desktop',
   'fileViewer.viewportDesktopTitle': 'Full-width desktop preview',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -898,6 +898,8 @@ export const fa: Dict = {
   'fileViewer.zoomOut': 'کوچک‌نمایی',
   'fileViewer.zoomIn': 'بزرگ‌نمایی',
   'fileViewer.resetZoom': 'بازنشانی زوم',
+  'fileViewer.zoomLevel': 'Zoom level',
+  'fileViewer.zoomLevelHint': 'Type 25–200, or Ctrl/⌘+scroll over preview',
   'fileViewer.viewportAria': 'Preview viewport',
   'fileViewer.viewportDesktop': 'Desktop',
   'fileViewer.viewportDesktopTitle': 'Full-width desktop preview',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -874,6 +874,8 @@ export const fr: Dict = {
   'fileViewer.zoomOut': 'Zoom arrière',
   'fileViewer.zoomIn': 'Zoom avant',
   'fileViewer.resetZoom': 'Réinitialiser le zoom',
+  'fileViewer.zoomLevel': 'Niveau de zoom',
+  'fileViewer.zoomLevelHint': 'Saisissez 25–200, ou Ctrl/⌘ + molette sur l’aperçu',
   'fileViewer.viewportAria': 'Preview viewport',
   'fileViewer.viewportDesktop': 'Desktop',
   'fileViewer.viewportDesktopTitle': 'Full-width desktop preview',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -874,6 +874,8 @@ export const hu: Dict = {
   'fileViewer.zoomOut': 'Kicsinyítés',
   'fileViewer.zoomIn': 'Nagyítás',
   'fileViewer.resetZoom': 'Nagyítás visszaállítása',
+  'fileViewer.zoomLevel': 'Zoom level',
+  'fileViewer.zoomLevelHint': 'Type 25–200, or Ctrl/⌘+scroll over preview',
   'fileViewer.viewportAria': 'Preview viewport',
   'fileViewer.viewportDesktop': 'Desktop',
   'fileViewer.viewportDesktopTitle': 'Full-width desktop preview',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -994,6 +994,8 @@ export const id: Dict = {
   'fileViewer.zoomOut': 'Perkecil',
   'fileViewer.zoomIn': 'Perbesar',
   'fileViewer.resetZoom': 'Atur ulang zoom',
+  'fileViewer.zoomLevel': 'Zoom level',
+  'fileViewer.zoomLevelHint': 'Type 25–200, or Ctrl/⌘+scroll over preview',
   'fileViewer.viewportAria': 'Preview viewport',
   'fileViewer.viewportDesktop': 'Desktop',
   'fileViewer.viewportDesktopTitle': 'Full-width desktop preview',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -761,6 +761,8 @@ export const ja: Dict = {
   'fileViewer.zoomOut': 'ズームアウト',
   'fileViewer.zoomIn': 'ズームイン',
   'fileViewer.resetZoom': 'ズームをリセット',
+  'fileViewer.zoomLevel': 'ズームレベル',
+  'fileViewer.zoomLevelHint': '25〜200 を入力、または Ctrl/⌘ を押しながらプレビュー上でスクロール',
   'fileViewer.viewportAria': 'Preview viewport',
   'fileViewer.viewportDesktop': 'Desktop',
   'fileViewer.viewportDesktopTitle': 'Full-width desktop preview',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -874,6 +874,8 @@ export const ko: Dict = {
   'fileViewer.zoomOut': '축소',
   'fileViewer.zoomIn': '확대',
   'fileViewer.resetZoom': '배율 초기화',
+  'fileViewer.zoomLevel': '배율 수준',
+  'fileViewer.zoomLevelHint': '25–200 입력 또는 미리보기 위에서 Ctrl/⌘ + 스크롤',
   'fileViewer.viewportAria': 'Preview viewport',
   'fileViewer.viewportDesktop': 'Desktop',
   'fileViewer.viewportDesktopTitle': 'Full-width desktop preview',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -874,6 +874,8 @@ export const pl: Dict = {
   'fileViewer.zoomOut': 'Pomniejsz',
   'fileViewer.zoomIn': 'Powiększ',
   'fileViewer.resetZoom': 'Resetuj powiększenie',
+  'fileViewer.zoomLevel': 'Zoom level',
+  'fileViewer.zoomLevelHint': 'Type 25–200, or Ctrl/⌘+scroll over preview',
   'fileViewer.viewportAria': 'Preview viewport',
   'fileViewer.viewportDesktop': 'Desktop',
   'fileViewer.viewportDesktopTitle': 'Full-width desktop preview',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -897,6 +897,8 @@ export const ptBR: Dict = {
   'fileViewer.zoomOut': 'Diminuir zoom',
   'fileViewer.zoomIn': 'Aumentar zoom',
   'fileViewer.resetZoom': 'Redefinir zoom',
+  'fileViewer.zoomLevel': 'Nível de zoom',
+  'fileViewer.zoomLevelHint': 'Digite 25–200, ou Ctrl/⌘ + rolagem sobre a prévia',
   'fileViewer.viewportAria': 'Preview viewport',
   'fileViewer.viewportDesktop': 'Desktop',
   'fileViewer.viewportDesktopTitle': 'Full-width desktop preview',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -897,6 +897,8 @@ export const ru: Dict = {
   'fileViewer.zoomOut': 'Уменьшить',
   'fileViewer.zoomIn': 'Увеличить',
   'fileViewer.resetZoom': 'Сбросить масштаб',
+  'fileViewer.zoomLevel': 'Zoom level',
+  'fileViewer.zoomLevelHint': 'Type 25–200, or Ctrl/⌘+scroll over preview',
   'fileViewer.viewportAria': 'Preview viewport',
   'fileViewer.viewportDesktop': 'Desktop',
   'fileViewer.viewportDesktopTitle': 'Full-width desktop preview',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -810,6 +810,8 @@ export const th: Dict = {
   'fileViewer.zoomOut': 'หุบมุมมอง',
   'fileViewer.zoomIn': 'ซูมมองชัด',
   'fileViewer.resetZoom': 'ซูมรีเซ็ตหน้าจอ',
+  'fileViewer.zoomLevel': 'Zoom level',
+  'fileViewer.zoomLevelHint': 'Type 25–200, or Ctrl/⌘+scroll over preview',
   'fileViewer.reloadAria': 'กดรีโหลดให้สด',
   'fileViewer.previousSlide': 'เลื่อนสไลด์ก่อนหน้า',
   'fileViewer.nextSlide': 'สไลด์แผ่นหน้า',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -861,6 +861,8 @@ export const tr: Dict = {
   'fileViewer.zoomOut': 'Yakınlaş',
   'fileViewer.zoomIn': 'Uzaklaş',
   'fileViewer.resetZoom': 'Uzaklığı sıfırla',
+  'fileViewer.zoomLevel': 'Zoom level',
+  'fileViewer.zoomLevelHint': 'Type 25–200, or Ctrl/⌘+scroll over preview',
   'fileViewer.viewportAria': 'Preview viewport',
   'fileViewer.viewportDesktop': 'Desktop',
   'fileViewer.viewportDesktopTitle': 'Full-width desktop preview',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -916,6 +916,8 @@ export const uk: Dict = {
   'fileViewer.zoomOut': 'Зменшити',
   'fileViewer.zoomIn': 'Збільшити',
   'fileViewer.resetZoom': 'Скинути масштаб',
+  'fileViewer.zoomLevel': 'Zoom level',
+  'fileViewer.zoomLevelHint': 'Type 25–200, or Ctrl/⌘+scroll over preview',
   'fileViewer.viewportAria': 'Preview viewport',
   'fileViewer.viewportDesktop': 'Desktop',
   'fileViewer.viewportDesktopTitle': 'Full-width desktop preview',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -961,6 +961,8 @@ export const zhCN: Dict = {
   'fileViewer.zoomOut': '缩小',
   'fileViewer.zoomIn': '放大',
   'fileViewer.resetZoom': '重置缩放',
+  'fileViewer.zoomLevel': '缩放比例',
+  'fileViewer.zoomLevelHint': '输入 25–200，或按住 Ctrl/⌘ 在预览区滚动缩放',
   'fileViewer.viewportAria': 'Preview viewport',
   'fileViewer.viewportDesktop': 'Desktop',
   'fileViewer.viewportDesktopTitle': 'Full-width desktop preview',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -949,6 +949,8 @@ export const zhTW: Dict = {
   'fileViewer.zoomOut': '縮小',
   'fileViewer.zoomIn': '放大',
   'fileViewer.resetZoom': '重設縮放',
+  'fileViewer.zoomLevel': '縮放比例',
+  'fileViewer.zoomLevelHint': '輸入 25–200，或按住 Ctrl/⌘ 在預覽區滾動縮放',
   'fileViewer.viewportAria': 'Preview viewport',
   'fileViewer.viewportDesktop': 'Desktop',
   'fileViewer.viewportDesktopTitle': 'Full-width desktop preview',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -1239,6 +1239,8 @@ export interface Dict {
   'fileViewer.zoomOut': string;
   'fileViewer.zoomIn': string;
   'fileViewer.resetZoom': string;
+  'fileViewer.zoomLevel': string;
+  'fileViewer.zoomLevelHint': string;
   'fileViewer.viewportAria': string;
   'fileViewer.viewportDesktop': string;
   'fileViewer.viewportDesktopTitle': string;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -10280,6 +10280,24 @@ button.connector-action.is-loading {
   min-width: 60px;
   justify-content: center;
 }
+.viewer-zoom-input {
+  width: 64px;
+  text-align: center;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  font: inherit;
+  font-variant-numeric: tabular-nums;
+  padding: 2px 6px;
+  cursor: text;
+}
+.viewer-zoom-input:hover { background: var(--bg-subtle); }
+.viewer-zoom-input:focus {
+  outline: none;
+  background: var(--bg);
+  border-color: var(--border);
+}
 .viewer-divider {
   width: 1px;
   height: 18px;

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -654,6 +654,41 @@ describe('FileViewer SVG artifacts', () => {
     });
   });
 
+  it('keeps HTML preview zoom unchanged when ctrl-wheel happens in source view', async () => {
+    const file = baseFile({
+      name: 'index.html',
+      path: 'index.html',
+      mime: 'text/html',
+      kind: 'html',
+      artifactManifest: {
+        version: 1,
+        kind: 'html',
+        title: 'Page',
+        entry: 'index.html',
+        renderer: 'html',
+        exports: ['html'],
+      },
+    });
+
+    const { container } = render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={file}
+        liveHtml={'<html><body><main>hello</main></body></html>'}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /^source$/i }));
+    const source = container.querySelector('.viewer-source');
+    expect(source).toBeTruthy();
+    expect((screen.getByRole('textbox', { name: /zoom level/i }) as HTMLInputElement).value).toBe('100%');
+
+    fireEvent.wheel(source!, { ctrlKey: true, deltaY: -100 });
+
+    expect((screen.getByRole('textbox', { name: /zoom level/i }) as HTMLInputElement).value).toBe('100%');
+  });
+
   it('shows Cloudflare Pages as a deploy action without requiring a project name input', async () => {
     const file = baseFile({
       name: 'index.html',
@@ -2187,6 +2222,40 @@ describe('LiveArtifactViewer', () => {
     });
     expect(container.querySelector('.live-artifact-viewer.is-tab-present')).toBeNull();
     expect(screen.queryByRole('button', { name: /exit fullscreen/i })).toBeNull();
+  });
+
+  it('keeps live artifact preview zoom unchanged when ctrl-wheel happens outside preview mode', async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+      if (url === '/api/live-artifacts/la_1?projectId=proj_1') {
+        return new Response(JSON.stringify({ artifact: baseLiveArtifact() }), { status: 200 });
+      }
+      if (url === '/api/live-artifacts/la_1/refreshes?projectId=proj_1') {
+        return new Response(JSON.stringify({ refreshes: [] }), { status: 200 });
+      }
+      if (url === '/api/live-artifacts/la_1/code?projectId=proj_1') {
+        return new Response(JSON.stringify({ files: [{ path: 'index.html', content: '<main />' }] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({}), { status: 404 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { container } = render(
+      <LiveArtifactViewer
+        projectId="proj_1"
+        liveArtifact={baseLiveArtifactWorkspaceEntry()}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /^code$/i }));
+    const viewerBody = container.querySelector('.viewer-body');
+    const zoomInput = container.querySelector<HTMLInputElement>('.viewer-zoom-input');
+    expect(viewerBody).toBeTruthy();
+    expect(zoomInput?.value).toBe('100%');
+
+    fireEvent.wheel(viewerBody!, { ctrlKey: true, deltaY: -100 });
+
+    expect(zoomInput?.value).toBe('100%');
   });
 
   it('requests fullscreen without entering in-tab presentation when fullscreen succeeds', async () => {


### PR DESCRIPTION
The preview zoom was locked to six presets (50/75/100/125/150/200%) plus +/- buttons that stepped by 25%. Common targets like 85% or 110% were unreachable - too small or too big, never just right.

## Why

HTML and Live Artifact previews need more precise zoom control so users can inspect generated output without relying only on fixed zoom steps.

## What users will see

Users can zoom preview content using Ctrl/? + wheel while preview mode is active. Editable zoom percentages remain available in the viewer toolbar.

This PR keeps the dropdown as a quick-jump menu and adds three ways to land on any integer percent in 25-200:

- Editable percent input: click to edit, type any number, Enter to commit, Esc to revert, double-click to reset to 100.
- Ctrl/Meta + wheel over the preview multiplies zoom by 1.1 per tick; macOS trackpad pinch fires the same path on Chromium/WebKit.
- +/- buttons now step by 10% instead of 25% for finer keyboard tuning.

The wheel listener is attached to the viewer body via native addEventListener with passive:false because React 18 synthetic wheel is passive - onWheel cannot preventDefault. The listener is now enabled only while preview mode is active, so source/code/non-preview tabs preserve their native wheel behavior and do not mutate hidden preview zoom.

Both viewers (LiveArtifactViewer and HtmlViewer) get the same affordances through a shared ZoomInput + usePreviewWheelZoom + clampZoom in FileViewer.tsx. Two new i18n keys (zoomLevel, zoomLevelHint) cover the new control across locales.

## Surface area

- [x] UI
- [x] i18n / copy
- [x] Keyboard shortcut

- HTML viewer preview zoom behavior
- Live Artifact viewer preview zoom behavior
- Zoom input UI
- i18n copy for zoom controls

## Validation

- Ran `pnpm test -- --run tests/components/FileViewer.test.tsx`
- Verified Ctrl/? + wheel changes zoom only while preview mode is active
- Verified Ctrl/? + wheel in HTML source view does not change preview zoom
- Verified Ctrl/? + wheel in Live Artifact non-preview tabs does not change preview zoom
