### PR TITLE
fix(web): distinguish expanded memory preview action

### DIFF
--- a/apps/web/src/components/MemorySection.tsx
+++ b/apps/web/src/components/MemorySection.tsx
@@ -902,7 +902,7 @@ export function MemorySection() {
                     title={t('settings.memoryPreview')}
                   >
                     <Icon
-                      name={previewId === entry.id ? 'close' : 'chevron-right'}
+                      name={previewId === entry.id ? 'chevron-down' : 'chevron-right'}
                       size={14}
                     />
                   </button>

--- a/apps/web/tests/components/MemorySection.test.tsx
+++ b/apps/web/tests/components/MemorySection.test.tsx
@@ -409,6 +409,59 @@ describe('MemorySection', () => {
     expect(screen.getByText('Updated preference')).toBeTruthy();
   });
 
+  it('keeps the expanded preview control visually distinct from delete', async () => {
+    globalThis.EventSource = StubEventSource as unknown as typeof EventSource;
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url === '/api/memory' && (!init || init.method === undefined)) {
+        return new Response(JSON.stringify({
+          enabled: true,
+          rootDir: '/tmp/memory',
+          index: '# Memory\n',
+          entries: [
+            {
+              id: 'project_scope',
+              name: 'Project scope',
+              description: 'Current project constraints',
+              type: 'project',
+              updatedAt: Date.now(),
+            },
+          ],
+          extraction: null,
+        }), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      if (url === '/api/memory/extractions') {
+        return new Response(JSON.stringify({ extractions: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url === '/api/memory/project_scope' && (!init || init.method === undefined)) {
+        return new Response(JSON.stringify({
+          entry: {
+            id: 'project_scope',
+            name: 'Project scope',
+            description: 'Current project constraints',
+            type: 'project',
+            body: '- Keep memory actions clear',
+            updatedAt: Date.now(),
+          },
+        }), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({}), { status: 404 });
+    }) as typeof fetch;
+
+    renderMemorySection();
+
+    const card = (await screen.findByText('Project scope')).closest('.library-card') as HTMLElement;
+    fireEvent.click(within(card).getByTitle('Preview'));
+
+    await screen.findByText('Keep memory actions clear');
+    const closeIconPaths = card.querySelectorAll('path[d="M18 6 6 18"]');
+
+    expect(closeIconPaths).toHaveLength(1);
+  });
+
   it('deletes an existing memory entry from the list', async () => {
     globalThis.EventSource = StubEventSource as unknown as typeof EventSource;
     let entries = [


### PR DESCRIPTION
Fixes #1810

## Why

I picked this up from the Settings > Memory preview bug report. Expanded Project memory rows currently use the same close-shaped icon for the preview toggle and the delete action, which makes the row look like it has two destructive controls.

## What users will see

When a memory entry preview is expanded, the preview toggle now shows a downward chevron instead of a close icon. The real delete action remains the only close-shaped/destructive-looking control in the row.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached from this fresh local clone because the workspace is not bootstrapped. The UI change is limited to the expanded memory preview affordance: close icon -> downward chevron.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/MemorySection.test.tsx`
- Did the test go red on `main` and green on this branch? no; local test execution is blocked because this fresh clone has no `node_modules` and `vitest` is not installed.
- The added regression asserts that an expanded memory card has only one close-shaped icon path, leaving the delete action as the only close-shaped control.

## Validation

- `git diff --check`
- `corepack pnpm --filter @open-design/web test -- MemorySection.test.tsx` (blocked: node_modules missing / vitest not found; local Node is v25.9.0 while the repo expects ~24)
