### PR TITLE
fix(web): keep picker hint clear of comments panel

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -6214,7 +6214,12 @@ function HtmlViewer({
               && openHintBox
               && !activeInspectTarget
               && !activeCommentTarget ? (
-              <div className="inspect-empty-hint-container">
+              <div
+                className={`inspect-empty-hint-container${
+                  boardMode && !commentSidePanelCollapsed ? ' comment-side-panel-open' : ''
+                }`}
+                data-testid="inspect-empty-hint-container"
+              >
                 {liveCommentTargets.size === 0 ? (
                   <div
                     className="inspect-empty-hint"

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -10714,6 +10714,20 @@ button.ghost.mcp-copy-btn:hover:not(:disabled) {
   pointer-events: none;
 }
 
+.inspect-empty-hint-container.comment-side-panel-open {
+  right: 340px;
+  max-width: min(480px, calc(100% - 368px));
+}
+
+@media (max-width: 760px) {
+  .inspect-empty-hint-container.comment-side-panel-open {
+    left: 14px;
+    right: 14px;
+    top: 54px;
+    max-width: none;
+  }
+}
+
 .inspect-empty-hint-container button,
 .inspect-empty-hint-container .close-button {
   pointer-events: auto;

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -1176,6 +1176,30 @@ describe('FileViewer tweaks toolbar', () => {
     expect(screen.queryByText('Already sent to Claude')).toBeNull();
   });
 
+  it('keeps the picker hint clear of the open comment side panel', () => {
+    render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={htmlPreviewFile()}
+        liveHtml='<html><body><main data-od-id="hero">Hero</main></body></html>'
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('board-mode-toggle'));
+
+    expect(screen.getByTestId('comment-side-panel')).toBeTruthy();
+    expect(screen.getByTestId('inspect-empty-hint-container').className).toContain(
+      'comment-side-panel-open',
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /hide comments/i }));
+
+    expect(screen.getByTestId('inspect-empty-hint-container').className).not.toContain(
+      'comment-side-panel-open',
+    );
+  });
+
   it('does not preload non-open element comments into the picker composer', async () => {
     const applyingElementComment: PreviewComment = {
       id: 'comment-element-applying',


### PR DESCRIPTION
## Summary

Fixes #1816.

Keeps the Inspect/Picker hint banner out of the open Comments side panel footprint in comment mode, so the hint and its close action stay usable. When the panel is collapsed, the hint returns to its normal placement.

## Surface area

- [x] UI
- [ ] Daemon/API
- [ ] CLI
- [ ] Tests only
- [ ] Docs only

## Testing

- `git diff --check`
- `corepack pnpm --filter @open-design/web test -- FileViewer.test.tsx` *(blocked locally: this checkout has no `node_modules`, so `vitest` is not installed; local Node is `v25.9.0` while the repo expects `~24`)*

## Screenshots

Not attached: local app dependencies are not installed in this checkout, so I could not boot the UI for a reliable screenshot.
