### PR TITLE
fix(web): clear draw ink when exiting mode

### DIFF
--- a/apps/web/src/components/PreviewDrawOverlay.tsx
+++ b/apps/web/src/components/PreviewDrawOverlay.tsx
@@ -166,6 +166,14 @@ export function PreviewDrawOverlay({
     redraw();
   }
 
+  useEffect(() => {
+    if (active) return;
+    strokesRef.current = [];
+    drawingRef.current = null;
+    setHasInk(false);
+    redraw();
+  }, [active, redraw]);
+
   function strokeBounds(): { x: number; y: number; width: number; height: number } | null {
     const points = strokesRef.current.flatMap((stroke) => stroke.points);
     if (points.length === 0) return null;

--- a/apps/web/tests/components/PreviewDrawOverlay.test.tsx
+++ b/apps/web/tests/components/PreviewDrawOverlay.test.tsx
@@ -1,0 +1,31 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { PreviewDrawOverlay } from '../../src/components/PreviewDrawOverlay';
+
+describe('PreviewDrawOverlay', () => {
+  it('clears transient ink when draw mode exits', async () => {
+    const { container, rerender } = render(
+      <PreviewDrawOverlay active>
+        <div style={{ width: 320, height: 200 }} />
+      </PreviewDrawOverlay>,
+    );
+
+    const canvas = container.querySelector('canvas');
+    expect(canvas).toBeTruthy();
+
+    fireEvent.pointerDown(canvas!, { clientX: 10, clientY: 10, pointerId: 1 });
+    fireEvent.pointerMove(canvas!, { clientX: 40, clientY: 40, pointerId: 1 });
+    fireEvent.pointerUp(canvas!, { pointerId: 1 });
+
+    rerender(
+      <PreviewDrawOverlay active={false}>
+        <div style={{ width: 320, height: 200 }} />
+      </PreviewDrawOverlay>,
+    );
+
+    await waitFor(() => expect(container.querySelector('canvas')).toBeNull());
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1818.

Clears transient draw strokes when Draw mode is turned off, so temporary red annotations do not remain visible after exiting the mode. Added a focused regression test around the draw stroke -> exit Draw mode flow.

## Surface area

- [x] UI
- [ ] Daemon/API
- [ ] CLI
- [ ] Tests only
- [ ] Docs only

## Testing

- `git diff --check`
- `corepack pnpm --filter @open-design/web test -- PreviewDrawOverlay.test.tsx` *(blocked locally: this checkout has no `node_modules`, so `vitest` is not installed; local Node is `v25.9.0` while the repo expects `~24`)*

## Screenshots

Not attached: local app dependencies are not installed in this checkout, so I could not boot the UI for a reliable screenshot.
