### PR TITLE
fix(web): align comment marker numbering

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -5299,7 +5299,9 @@ function HtmlViewer({
   const exportTitle = file.name.replace(/\.html?$/i, '') || file.name;
   const canPptx = canShare && Boolean(onExportAsPptx) && !streaming;
   const visibleSideComments = useMemo(
-    () => previewComments.filter((comment) => comment.filePath === file.name && comment.status === 'open'),
+    () => previewComments
+      .filter((comment) => comment.filePath === file.name && comment.status === 'open')
+      .sort((a, b) => b.createdAt - a.createdAt),
     [file.name, previewComments],
   );
   useEffect(() => {

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -1200,6 +1200,52 @@ describe('FileViewer tweaks toolbar', () => {
     );
   });
 
+  it('keeps saved comment marker numbers aligned with the side panel order', () => {
+    const olderComment: PreviewComment = {
+      id: 'comment-older',
+      projectId: 'project-1',
+      conversationId: 'conversation-1',
+      filePath: 'preview.html',
+      elementId: 'pin-older',
+      selector: '[data-od-pin="pin-older"]',
+      label: 'pin-older',
+      text: '',
+      htmlHint: '',
+      position: { x: 24, y: 32, width: 18, height: 18 },
+      note: 'Older comment',
+      status: 'open',
+      createdAt: 10,
+      updatedAt: 10,
+    };
+    const newerComment: PreviewComment = {
+      ...olderComment,
+      id: 'comment-newer',
+      elementId: 'pin-newer',
+      selector: '[data-od-pin="pin-newer"]',
+      label: 'pin-newer',
+      position: { x: 72, y: 32, width: 18, height: 18 },
+      note: 'Newer comment',
+      createdAt: 20,
+      updatedAt: 20,
+    };
+
+    render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={htmlPreviewFile()}
+        liveHtml='<html><body><main data-od-id="hero">Hero</main></body></html>'
+        previewComments={[olderComment, newerComment]}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('board-mode-toggle'));
+
+    expect(screen.getAllByTestId('comment-side-item')[0]?.textContent).toContain('Newer comment');
+    expect(screen.getByTestId('comment-saved-marker-pin-newer').textContent).toContain('1');
+    expect(screen.getByTestId('comment-saved-marker-pin-older').textContent).toContain('2');
+  });
+
   it('does not preload non-open element comments into the picker composer', async () => {
     const applyingElementComment: PreviewComment = {
       id: 'comment-element-applying',


### PR DESCRIPTION
## Summary

Fixes #1809.

Uses the same newest-first saved-comment ordering for preview markers and the Comments side panel, so the marker numbers match the order users see in the panel.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — fixes the default saved-comment marker numbering behavior
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached: local app dependencies are not installed in this checkout, so I could not boot the UI for a reliable screenshot.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/FileViewer.test.tsx` (`keeps saved comment marker numbers aligned with the side panel order`)
- Did the test go red on `main` and green on this branch? Not confirmed locally because this checkout has no `node_modules`, so `vitest` is unavailable. The pushed PR CI completed successfully.
- Regression encoded by asserting marker labels follow the same newest-first ordering as the Comments side panel.

## Validation

- `git diff --check`
- `corepack pnpm --filter @open-design/web test -- FileViewer.test.tsx` *(blocked locally: this checkout has no `node_modules`, so `vitest` is not installed; local Node is `v25.9.0` while the repo expects `~24`)*
- PR CI: `Detect PR change scopes`, `build`, and `Validate workspace` passed
