### PR TITLE
fix(web): reveal memory editor after edit click

### DIFF
--- a/apps/web/src/components/MemorySection.tsx
+++ b/apps/web/src/components/MemorySection.tsx
@@ -2,6 +2,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type CSSProperties,
 } from 'react';
@@ -284,6 +285,9 @@ export function MemorySection() {
   const [flash, setFlash] = useState<{ kind: FlashKind; key: number } | null>(
     null,
   );
+  const editorRef = useRef<HTMLDivElement | null>(null);
+  const editorNameRef = useRef<HTMLInputElement | null>(null);
+  const editingTarget = editing?.id ?? (editing ? 'new' : null);
   // Recent LLM-extraction attempts, newest first. Driven by a one-shot
   // fetch on mount + live SSE updates merged by id so phase transitions
   // (running → success) replace the row in place.
@@ -298,6 +302,12 @@ export function MemorySection() {
     const id = setTimeout(() => setFlash(null), 1800);
     return () => clearTimeout(id);
   }, [flash]);
+
+  useEffect(() => {
+    if (!editingTarget) return;
+    editorRef.current?.scrollIntoView?.({ block: 'start', behavior: 'smooth' });
+    editorNameRef.current?.focus({ preventScroll: true });
+  }, [editingTarget]);
 
   const flashLabel = useMemo<Record<FlashKind, string>>(
     () => ({
@@ -679,6 +689,7 @@ export function MemorySection() {
 
       {editing ? (
         <div
+          ref={editorRef}
           className="library-card"
           style={{
             flexDirection: 'column',
@@ -747,6 +758,7 @@ export function MemorySection() {
                   {t('settings.memoryNameLabel')}
                 </label>
                 <input
+                  ref={editorNameRef}
                   type="text"
                   placeholder={t('settings.memoryName')}
                   value={editing.name}

--- a/apps/web/tests/components/MemorySection.test.tsx
+++ b/apps/web/tests/components/MemorySection.test.tsx
@@ -8,6 +8,7 @@ import { I18nProvider } from '../../src/i18n';
 
 const originalFetch = globalThis.fetch;
 const originalEventSource = globalThis.EventSource;
+const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
 
 class StubEventSource {
   url: string;
@@ -51,6 +52,11 @@ describe('MemorySection', () => {
       delete globalThis.EventSource;
     }
     vi.restoreAllMocks();
+    if (originalScrollIntoView) {
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    } else {
+      delete (HTMLElement.prototype as { scrollIntoView?: Element['scrollIntoView'] }).scrollIntoView;
+    }
   });
 
   it('shows the no-provider banner when the latest extraction skipped for missing credentials', async () => {
@@ -225,6 +231,61 @@ describe('MemorySection', () => {
       expect(screen.getByText('✓ Index saved')).toBeTruthy();
     });
     expect(putBodies).toEqual(['# Memory\n\n- Existing bullet\n- New bullet\n']);
+  });
+
+  it('reveals the editor after editing an existing memory entry', async () => {
+    globalThis.EventSource = StubEventSource as unknown as typeof EventSource;
+    const scrollIntoView = vi.fn();
+    HTMLElement.prototype.scrollIntoView = scrollIntoView as Element['scrollIntoView'];
+
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === '/api/memory') {
+        return new Response(JSON.stringify({
+          enabled: true,
+          rootDir: '/tmp/memory',
+          index: '# Memory\n',
+          entries: [
+            {
+              id: 'user_ui_preferences',
+              name: 'UI preferences',
+              description: 'Persistent UI rendering preferences',
+              type: 'user',
+              updatedAt: Date.now(),
+            },
+          ],
+          extraction: null,
+        }), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      if (url === '/api/memory/extractions') {
+        return new Response(JSON.stringify({ extractions: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url === '/api/memory/user_ui_preferences') {
+        return new Response(JSON.stringify({
+          entry: {
+            id: 'user_ui_preferences',
+            name: 'UI preferences',
+            description: 'Persistent UI rendering preferences',
+            type: 'user',
+            body: '- Prefer dark mode',
+            updatedAt: Date.now(),
+          },
+        }), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({}), { status: 404 });
+    }) as typeof fetch;
+
+    renderMemorySection();
+
+    const entryCard = (await screen.findByText('UI preferences')).closest('.library-card') as HTMLElement;
+    fireEvent.click(within(entryCard).getByTitle('Edit'));
+
+    const nameInput = await screen.findByDisplayValue('UI preferences');
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: 'start', behavior: 'smooth' });
+    expect(document.activeElement).toBe(nameInput);
   });
 
   it('uses the same expandable affordance for extraction history and memory index', async () => {


### PR DESCRIPTION
Fixes #1808

## Summary

- Scroll the Memory editor into view when an existing entry enters edit mode.
- Focus the editor name field so the edit action is visible and immediately usable.
- Add a regression test for the edit-button reveal behavior.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — fixes the default Settings > Memory edit reveal behavior
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached: this is a focus/scroll behavior change covered by the regression test, and local app dependencies are not installed in this checkout.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/MemorySection.test.tsx` (`reveals the editor after editing an existing memory entry`)
- Did the test go red on `main` and green on this branch? Not confirmed locally because this checkout has no `node_modules`, so `vitest` is unavailable. The pushed PR CI completed successfully.
- Regression encoded by asserting the edit action scrolls the editor into view and focuses the name field.

## Validation

- `git diff --check`
- `corepack pnpm --filter @open-design/web test -- MemorySection.test.tsx` *(blocked locally: this checkout has no `node_modules`, so `vitest` is not installed; local Node is `v25.9.0` while the repo expects `~24`)*
- PR CI: `Detect PR change scopes`, `build`, and `Validate workspace` passed
