### PR TITLE
fix(web): keep filter pill hover labels readable

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -13516,7 +13516,11 @@ button.ghost.mcp-copy-btn:hover:not(:disabled) {
   gap: 6px;
   align-items: center;
 }
-.filter-pill:hover { border-color: var(--border-strong); color: var(--text); }
+button.filter-pill:hover:not(:disabled) {
+  background: var(--bg-muted);
+  border-color: var(--border-strong);
+  color: var(--text);
+}
 /*
   Selected filter pill — quiet "I am the chosen one" treatment, NOT a CTA.
   Earlier the active pill borrowed the full `--accent` fill, which read as
@@ -13532,7 +13536,7 @@ button.ghost.mcp-copy-btn:hover:not(:disabled) {
   color: var(--text);
   font-weight: 600;
 }
-.filter-pill.active:hover {
+button.filter-pill.active:hover:not(:disabled) {
   background: var(--bg-muted);
   border-color: var(--border-strong);
   color: var(--text);
@@ -13540,6 +13544,11 @@ button.ghost.mcp-copy-btn:hover:not(:disabled) {
 .filter-pill-count {
   font-size: 11px;
   opacity: 0.7;
+}
+button.filter-pill:hover:not(:disabled) .filter-pill-count,
+.filter-pill.active .filter-pill-count {
+  color: currentColor;
+  opacity: 0.9;
 }
 .example-card-actions {
   display: flex;

--- a/apps/web/tests/styles/filter-pill.test.ts
+++ b/apps/web/tests/styles/filter-pill.test.ts
@@ -1,0 +1,93 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const indexCss = readFileSync(new URL('../../src/index.css', import.meta.url), 'utf8');
+
+function cssBlock(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = new RegExp(`${escaped}\\s*\\{([^}]*)\\}`).exec(indexCss);
+  if (!match) throw new Error(`Missing CSS block for ${selector}`);
+  return match[1] ?? '';
+}
+
+function cssVar(block: string, name: string): string {
+  const match = new RegExp(`${name}:\\s*([^;]+);`).exec(block);
+  if (!match) throw new Error(`Missing CSS variable ${name}`);
+  return match[1]!.trim();
+}
+
+function ruleValue(block: string, property: string): string {
+  const match = new RegExp(`(?:^|;)\\s*${property}:\\s*([^;]+);`).exec(block);
+  if (!match) throw new Error(`Missing CSS property ${property}`);
+  return match[1]!.trim();
+}
+
+function resolveVar(value: string, variables: Record<string, string>): string {
+  const match = /^var\((--[^)]+)\)$/.exec(value);
+  if (!match) return value;
+  const key = match[1];
+  if (!key) throw new Error(`Invalid CSS variable reference ${value}`);
+  const resolved = variables[key];
+  if (!resolved) throw new Error(`Missing resolved value for ${match[1]}`);
+  return resolved;
+}
+
+function hexToRgb(hex: string): [number, number, number] {
+  const normalized = hex.trim().replace(/^#/, '');
+  if (!/^[0-9a-f]{6}$/i.test(normalized)) throw new Error(`Expected #rrggbb, got ${hex}`);
+  return [
+    Number.parseInt(normalized.slice(0, 2), 16),
+    Number.parseInt(normalized.slice(2, 4), 16),
+    Number.parseInt(normalized.slice(4, 6), 16),
+  ];
+}
+
+function luminance([r, g, b]: [number, number, number]): number {
+  const channel = (value: number) => {
+    const normalized = value / 255;
+    return normalized <= 0.03928
+      ? normalized / 12.92
+      : ((normalized + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+function contrastRatio(foreground: string, background: string): number {
+  const first = luminance(hexToRgb(foreground));
+  const second = luminance(hexToRgb(background));
+  const lighter = Math.max(first, second);
+  const darker = Math.min(first, second);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+describe('filter pill hover contrast', () => {
+  it('keeps hover labels readable in light and dark themes', () => {
+    const rootVars = {
+      '--bg-muted': cssVar(cssBlock(':root'), '--bg-muted'),
+      '--text': cssVar(cssBlock(':root'), '--text'),
+    };
+    const darkVars = {
+      '--bg-muted': cssVar(cssBlock('[data-theme="dark"]'), '--bg-muted'),
+      '--text': cssVar(cssBlock('[data-theme="dark"]'), '--text'),
+    };
+    const hover = cssBlock('button.filter-pill:hover:not(:disabled)');
+    const activeHover = cssBlock('button.filter-pill.active:hover:not(:disabled)');
+    const countHover = cssBlock('button.filter-pill:hover:not(:disabled) .filter-pill-count,\n.filter-pill.active .filter-pill-count');
+
+    for (const block of [hover, activeHover]) {
+      expect(ruleValue(block, 'background')).toBe('var(--bg-muted)');
+      expect(ruleValue(block, 'color')).toBe('var(--text)');
+      expect(contrastRatio(
+        resolveVar(ruleValue(block, 'color'), rootVars),
+        resolveVar(ruleValue(block, 'background'), rootVars),
+      )).toBeGreaterThanOrEqual(4.5);
+      expect(contrastRatio(
+        resolveVar(ruleValue(block, 'color'), darkVars),
+        resolveVar(ruleValue(block, 'background'), darkVars),
+      )).toBeGreaterThanOrEqual(4.5);
+    }
+
+    expect(ruleValue(countHover, 'color')).toBe('currentColor');
+    expect(ruleValue(countHover, 'opacity')).toBe('0.9');
+  });
+});


### PR DESCRIPTION
Fixes #1804

## Why

The Official starters filter pills could lose readable contrast on hover because the shared global button hover rule changed the pill background without the pill rule winning the cascade consistently. This made labels such as Create hard to read in the preview branch.

## What users will see

Hovering Official starters filter pills keeps the label and count readable in both light and dark themes. Active filter pills keep the same quiet selected treatment and no longer look like primary CTAs.

## Surface area

- [x] **UI** — shared filter pill hover state in `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

![Filter pill hover contrast](https://raw.githubusercontent.com/YUHAO-corn/open-design/pr-assets/1804-filter-hover/pr-1804-filter-hover.png)

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/styles/filter-pill.test.ts`
- The test asserts the hover selectors win over the global button hover selector shape and keeps both light/dark hover label contrast at WCAG AA level.
- The count text inherits the hover/active color with stronger opacity so pill labels and counts remain readable together.

## Validation

- `pnpm --filter @open-design/web test -- tests/styles/filter-pill.test.ts --runInBand` (130 files, 1277 tests passed)
- `pnpm --filter @open-design/web typecheck`
- subagent read-only review after specificity fix: no remaining blockers
