### PR TITLE
fix: format smoke prompt as JSONL for claude-stream-json input format

### DIFF
--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -1333,7 +1333,12 @@ async function testAgentConnectionInternal(
           });
         }
       });
-      child.stdin.end(SMOKE_PROMPT, 'utf8');
+      child.stdin.end(
+  def.streamFormat === 'claude-stream-json'
+    ? JSON.stringify({ type: 'user', message: { role: 'user', content: SMOKE_PROMPT } }) + '\n'
+    : SMOKE_PROMPT,
+  'utf8'
+);
     }
     const cancellationPromise = new Promise<{ kind: 'timeout' } | { kind: 'aborted' }>((resolve) => {
       timer = setTimeout(() => resolve({ kind: 'timeout' }), agentTimeoutMs());


### PR DESCRIPTION
[connectionTest.ts was sending the smoke prompt as plain text, but Claude Code is spawned with --input-format stream-json which requires JSONL input.

<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works.
     Delete this whole block if the PR genuinely doesn't close any issue. -->
Fixes #

## Why

The connection test in connectionTest.ts sends the smoke prompt as plain text to stdin. However, Claude Code is spawned with --input-format stream-json, which requires JSONL-formatted input. This causes the smoke test to always fail with:

"Could not start Claude Code: exit 1 · stderr: Error parsing streaming input line: Reply with only: ok: SyntaxError: JSON Parse error: Unexpected identifier "Reply"."

The main run path in server.ts already handles this correctly (line 4630+).

Fixes #1834


## What users will see

The Claude Code connection test passes instead of failing. The green confirmation "Claude Code replied in Xms — 'ok'" appears in Settings → Configure execution mode.


## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only


## Screenshots

<!-- If you checked "UI" above, attach screenshots showing the entry point —
     where users discover the change — not just the feature in isolation.
     Before/after is best for behavior changes. Short GIFs welcome. -->


## Bug fix verification

<!-- Skip if this PR isn't a bug fix.

     Per AGENTS.md → "Bug follow-up workflow", bugs should be encoded as a
     falsifiable test that goes red before the source change. Confirm:
       - Test path that reproduces the bug:
       - Did the test go red on `main` and green on this branch? (yes / no)
       - If a red spec wasn't cheap to write, explain why and what verification
         you did instead. -->

-


## Validation

<!-- What you actually ran. Default minimum: `pnpm guard` + `pnpm typecheck`,
     plus the package-scoped tests/build for the files you changed
     (e.g. `pnpm --filter @open-design/web test`). -->

-
](fix: format smoke prompt as JSONL for claude-stream-json input format)