### PR TITLE
fix(daemon): wrap Claude smoke test stdin as stream-json

### DIFF
--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -40,6 +40,7 @@ import {
   probeAgentAuthStatus,
 } from './runtimes/auth.js';
 import type { AgentCliEnvPrefs } from './app-config.js';
+import type { RuntimeAgentDef } from './runtimes/types.js';
 import {
   isLoopbackApiHost,
   validateBaseUrl,
@@ -110,6 +111,23 @@ const SAMPLE_MAX_CHARS = 120;
 // before producing a visible `ok`.
 const PROVIDER_MAX_TOKENS = 100;
 const SMOKE_PROMPT = 'Reply with only: ok';
+
+function formatPromptForAgentStdin(
+  def: Pick<RuntimeAgentDef, 'promptInputFormat'>,
+  prompt: string,
+): string {
+  const promptInputFormat = def.promptInputFormat ?? 'text';
+  if (promptInputFormat === 'stream-json') {
+    return `${JSON.stringify({
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [{ type: 'text', text: prompt }],
+      },
+    })}\n`;
+  }
+  return prompt;
+}
 
 function codexExecutableGuidance(
   agentId: string,
@@ -1333,7 +1351,7 @@ async function testAgentConnectionInternal(
           });
         }
       });
-      child.stdin.end(SMOKE_PROMPT, 'utf8');
+      child.stdin.end(formatPromptForAgentStdin(def, SMOKE_PROMPT), 'utf8');
     }
     const cancellationPromise = new Promise<{ kind: 'timeout' } | { kind: 'aborted' }>((resolve) => {
       timer = setTimeout(() => resolve({ kind: 'timeout' }), agentTimeoutMs());

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -1182,6 +1182,54 @@ console.log(JSON.stringify({ type: 'item.completed', item: { type: 'agent_messag
     );
   });
 
+  it('wraps Claude connection smoke prompts as stream-json stdin', async () => {
+    await withFakeClaude(
+      `
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => { input += chunk; });
+process.stdin.on('end', () => {
+  try {
+    const line = input.trim();
+    const parsed = JSON.parse(line);
+    const content = parsed?.message?.content;
+    if (
+      parsed.type !== 'user' ||
+      parsed.message?.role !== 'user' ||
+      !Array.isArray(content) ||
+      content[0]?.type !== 'text' ||
+      content[0]?.text !== 'Reply with only: ok'
+    ) {
+      console.error('unexpected stdin payload: ' + line);
+      process.exit(1);
+    }
+    console.log(JSON.stringify({
+      type: 'assistant',
+      message: {
+        id: 'msg_1',
+        content: [{ type: 'text', text: 'ok' }],
+        stop_reason: 'end_turn',
+      },
+    }));
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+});
+`,
+      async () => {
+        const result = await testAgentConnection({ agentId: 'claude' });
+
+        expect(result).toMatchObject({
+          ok: true,
+          kind: 'success',
+          agentName: 'Claude Code',
+          sample: 'ok',
+        });
+      },
+    );
+  });
+
   it('returns Claude /login guidance when the spawned CLI cannot authenticate', async () => {
     await withFakeClaude(
       `console.error(JSON.stringify({ apiKeySource: 'none', error_status: 401 })); process.exit(1);`,


### PR DESCRIPTION
Fixes #1834

## Why

I picked this up after the Claude Code connection smoke test was reported failing when the adapter launches with `--input-format stream-json`. The Settings connection test was still writing the smoke prompt as plain text, so Claude tried to parse `Reply with only: ok` as JSONL and exited before users could confirm their local CLI setup.

## What users will see

Settings connection tests for Claude Code can now complete when Claude is configured with stream-json stdin. A working local Claude Code install should report the smoke-test success instead of failing with a JSON parse error.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this fixes daemon-side connection-test behavior without changing UI layout.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/connection-test.test.ts`
- Did the test go red on `main` and green on this branch? The new regression encodes the failing stdin shape from #1834: fake Claude parses stdin as stream-json JSONL and would fail if plain text is written. It passes on this branch after the daemon wraps the smoke prompt according to `promptInputFormat`.

## Validation

- `pnpm guard`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/connection-test.test.ts`
- `pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/connection-test.test.ts -t 'wraps Claude connection smoke prompts as stream-json stdin'`
