### PR TITLE
fix(web): keep draw overlay scrollable

### DIFF
--- a/apps/web/src/components/PreviewDrawOverlay.tsx
+++ b/apps/web/src/components/PreviewDrawOverlay.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, type CSSProperties, type PointerEvent, type ReactNode } from 'react';
+import { useCallback, useEffect, useRef, useState, type CSSProperties, type PointerEvent, type ReactNode, type WheelEvent } from 'react';
 
 import { Icon } from './Icon';
 import type { PreviewVisualMarkKind } from '../types';
@@ -157,6 +157,15 @@ export function PreviewDrawOverlay({
     }
     drawingRef.current = null;
     redraw();
+  }
+
+  function onCanvasWheel(e: WheelEvent<HTMLCanvasElement>) {
+    if (mode !== 'draw' || sending) return;
+    const iframe = wrapRef.current?.querySelector('iframe');
+    const win = iframe?.contentWindow;
+    if (!win || typeof win.scrollBy !== 'function') return;
+    e.preventDefault();
+    win.scrollBy({ left: e.deltaX, top: e.deltaY, behavior: 'auto' });
   }
 
   function clearInk() {
@@ -374,6 +383,7 @@ export function PreviewDrawOverlay({
           onPointerMove={onPointerMove}
           onPointerUp={onPointerUp}
           onPointerCancel={onPointerUp}
+          onWheel={onCanvasWheel}
           style={{
             position: 'absolute',
             inset: 0,

--- a/apps/web/tests/components/PreviewDrawOverlay.test.tsx
+++ b/apps/web/tests/components/PreviewDrawOverlay.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { fireEvent, render, waitFor } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { PreviewDrawOverlay } from '../../src/components/PreviewDrawOverlay';
 
@@ -27,5 +27,31 @@ describe('PreviewDrawOverlay', () => {
     );
 
     await waitFor(() => expect(container.querySelector('canvas')).toBeNull());
+  });
+
+  it('forwards wheel scrolling to the preview iframe while drawing', () => {
+    const { container } = render(
+      <PreviewDrawOverlay active>
+        <iframe title="preview" />
+      </PreviewDrawOverlay>,
+    );
+
+    const canvas = container.querySelector('canvas');
+    const iframe = container.querySelector('iframe');
+    expect(canvas).toBeTruthy();
+    expect(iframe?.contentWindow).toBeTruthy();
+
+    const scrollBy = vi.fn();
+    Object.defineProperty(iframe!.contentWindow!, 'scrollBy', {
+      value: scrollBy,
+      configurable: true,
+    });
+
+    fireEvent.wheel(canvas!, {
+      deltaX: 12,
+      deltaY: 180,
+    });
+
+    expect(scrollBy).toHaveBeenCalledWith({ left: 12, top: 180, behavior: 'auto' });
   });
 });


### PR DESCRIPTION
Fixes #1817

## Why

I picked this up from the 0.8.0 preview Draw-mode report where annotations only worked comfortably on the first visible screen. The draw canvas sits above the preview iframe while Draw mode is active, so wheel/trackpad scrolling can land on the overlay instead of the scrollable preview underneath. That makes it hard to move through a long generated page and keep annotating lower sections.

## What users will see

In Draw mode, scrolling over the annotation canvas now moves the underlying preview iframe. Users can keep Draw mode open, scroll down a long preview, and continue marking the visible section instead of getting stuck on the initial viewport.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached; this changes wheel/trackpad behavior over the existing Draw overlay without changing visual layout.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/PreviewDrawOverlay.test.tsx`
- Did the test go red on `main` and green on this branch? Yes. With only the new regression test present, the scroll-forwarding case fails because `iframe.contentWindow.scrollBy` is never called; with this branch it passes.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/PreviewDrawOverlay.test.tsx`
- `pnpm guard`
- `pnpm --filter @open-design/contracts build && pnpm --filter @open-design/web typecheck`
- `git diff --check`