### PR TITLE
fix(web): add breathing room to plugin publish footer

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -21405,6 +21405,9 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
 .plugin-share-confirm__panel {
   max-width: 720px;
 }
+.plugin-share-confirm .plugin-details-modal__foot {
+  padding: 16px 24px 22px;
+}
 .plugin-share-confirm__steps {
   margin: 12px 0 0;
   padding-left: 20px;

--- a/apps/web/tests/styles/plugin-share-confirm.test.ts
+++ b/apps/web/tests/styles/plugin-share-confirm.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+describe('plugin share confirmation styles', () => {
+  it('keeps the publish dialog footer away from the modal edge', () => {
+    const css = readFileSync(join(process.cwd(), 'src/index.css'), 'utf8');
+
+    expect(css).toContain('.plugin-share-confirm .plugin-details-modal__foot');
+    expect(css).toContain('padding: 16px 24px 22px;');
+  });
+});


### PR DESCRIPTION
Fixes #1799

## Why

I picked this up from the 0.8.0 preview Plugins publish-dialog report. The confirmation modal footer was using the shared detail-modal padding, which leaves the Cancel / Start action row visually tight against the bottom modal border in this smaller publish flow.

## What users will see

The plugin publish confirmation dialog keeps the same buttons and behavior, but the action row now has more bottom and side breathing room so the footer no longer feels cramped against the modal edge.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached; this is a small spacing-only adjustment to the existing publish confirmation footer.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/styles/plugin-share-confirm.test.ts`
- Did the test go red on `main` and green on this branch? Yes. With only the test present, the scoped publish-footer spacing rule is missing; with this branch it passes.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/styles/plugin-share-confirm.test.ts`
- `pnpm guard`
- `pnpm --filter @open-design/contracts build && pnpm --filter @open-design/web typecheck`
- `git diff --check`