### PR TITLE
fix(web): restore fullscreen deck navigation

### DIFF
--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -1306,6 +1306,28 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
   }
   ownDeckButton('deck-prev', 'prev');
   ownDeckButton('deck-next', 'next');
+  document.addEventListener('keydown', function(e){
+    var target = e.target;
+    var tag = target && target.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || (target && target.isContentEditable)) return;
+    if (e.key === 'ArrowRight' || e.key === 'PageDown') {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      go('next');
+    } else if (e.key === 'ArrowLeft' || e.key === 'PageUp') {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      go('prev');
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      go('first');
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      go('last');
+    }
+  }, true);
   // Report once on load and on every scroll-end so the host stays in sync.
   window.addEventListener('load', function(){ setTimeout(restoreInitialSlide, 200); });
   document.addEventListener('scroll', function(){

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-nested-slides.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-nested-slides.test.ts
@@ -99,4 +99,29 @@ describe('deck bridge — nested slide markup (#1530)', () => {
     expect(state).toBeDefined();
     expect(state.count).toBe(3);
   });
+
+  it('handles arrow keys inside the iframe so fullscreen decks still turn pages', async () => {
+    const slides = Array.from({ length: 3 }, (_, i) =>
+      `<section class="slide${i === 0 ? ' active' : ''}">Slide ${i + 1}</section>`,
+    ).join('');
+    const { win, parentPostMessage } = setupDeckBridge(
+      `<div class="deck">${slides}</div>`,
+    );
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 350));
+
+    win.document.body.dispatchEvent(
+      new win.KeyboardEvent('keydown', {
+        key: 'ArrowRight',
+        code: 'ArrowRight',
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+      }),
+    );
+
+    const state = lastSlideState(parentPostMessage);
+    expect(state).toBeDefined();
+    expect(state.count).toBe(3);
+    expect(state.active).toBe(1);
+  });
 });


### PR DESCRIPTION
Addresses #1777.

- add a capture-phase key handler inside the deck iframe so ArrowLeft/Right, PageUp/Down, Home, and End work in fullscreen mode
- keep the iframe bridge from double-firing when the deck has its own keyboard handler
- add regression coverage for arrow-key navigation inside the iframe bridge