### PR TITLE
fix(landing): expose blog RSS feed alias

### DIFF
--- a/apps/landing-page/app/_components/seo-head.astro
+++ b/apps/landing-page/app/_components/seo-head.astro
@@ -52,7 +52,7 @@ const isArticle = props.kind === 'article';
 
 const canonical = new URL(props.pathname, Astro.site).toString();
 const image = props.image ?? new URL(ogDefaultImage, Astro.site).toString();
-const rssUrl = new URL('/rss.xml', Astro.site).toString();
+const rssUrl = new URL('/blog/rss.xml', Astro.site).toString();
 
 const fullTitle = isArticle ? `${props.title} — ${SITE_NAME}` : props.title;
 const ogTitle = props.title;
@@ -129,7 +129,7 @@ const blogJsonLd =
 <meta name='description' content={props.description} />
 <meta name='theme-color' content='#efe7d2' />
 <link rel='canonical' href={canonical} />
-<link rel='alternate' type='application/rss+xml' title='Open Design Blog RSS' href={rssUrl} />
+<link rel='alternate' type='application/rss+xml' title='Open Design Blog' href={rssUrl} />
 
 {props.googleSiteVerification && (
   <meta name='google-site-verification' content={props.googleSiteVerification} />

--- a/apps/landing-page/app/_components/site-footer.astro
+++ b/apps/landing-page/app/_components/site-footer.astro
@@ -39,6 +39,7 @@ const REPO = 'https://github.com/nexu-io/open-design';
           <li><a href={REPO} target='_blank' rel='noopener'>GitHub</a></li>
           <li><a href={`${REPO}/issues`} target='_blank' rel='noopener'>Issues</a></li>
           <li><a href={`${REPO}/releases`} target='_blank' rel='noopener'>Releases</a></li>
+          <li><a href='/blog/rss.xml'>RSS</a></li>
           <li><a href='/#contact'>Contact</a></li>
         </ul>
       </div>

--- a/apps/landing-page/app/_lib/blog-rss.ts
+++ b/apps/landing-page/app/_lib/blog-rss.ts
@@ -1,0 +1,23 @@
+import rss from '@astrojs/rss';
+import { getCollection } from 'astro:content';
+
+export async function buildBlogRss(context: { site: URL }) {
+  const posts = (await getCollection('blog')).sort(
+    (a, b) => b.data.date.getTime() - a.data.date.getTime(),
+  );
+
+  return rss({
+    title: 'Open Design Blog',
+    description:
+      'Editorial notes on Open Design, agent-native design workflows, BYOK, skills, systems, and community.',
+    site: context.site,
+    items: posts.map((post) => ({
+      title: post.data.title,
+      description: post.data.summary,
+      pubDate: post.data.date,
+      link: `/blog/${post.id}/`,
+      categories: [post.data.category],
+    })),
+  });
+}
+

--- a/apps/landing-page/app/pages/blog/rss.xml.ts
+++ b/apps/landing-page/app/pages/blog/rss.xml.ts
@@ -1,5 +1,6 @@
-import { buildBlogRss } from '../_lib/blog-rss';
+import { buildBlogRss } from '../../_lib/blog-rss';
 
 export async function GET(context: { site: URL }) {
   return buildBlogRss(context);
 }
+

--- a/apps/landing-page/public/llms.txt
+++ b/apps/landing-page/public/llms.txt
@@ -14,7 +14,7 @@ hosted AI design tools.
 - Systems: https://open-design.ai/systems/
 - Craft: https://open-design.ai/craft/
 - Templates: https://open-design.ai/templates/
-- RSS: https://open-design.ai/rss.xml
+- RSS: https://open-design.ai/blog/rss.xml
 - Sitemap: https://open-design.ai/sitemap-index.xml
 
 ## Key Blog Posts

--- a/apps/landing-page/public/robots.txt
+++ b/apps/landing-page/public/robots.txt
@@ -14,5 +14,5 @@ Disallow: /og/
 Sitemap: https://open-design.ai/sitemap-index.xml
 
 # Machine-readable discovery surfaces for feed readers and LLM crawlers.
-# RSS: https://open-design.ai/rss.xml
+# RSS: https://open-design.ai/blog/rss.xml
 # LLMs: https://open-design.ai/llms.txt


### PR DESCRIPTION
Fixes #1424

## Summary

- Add `/blog/rss.xml` as the canonical blog RSS feed route while keeping the existing `/rss.xml` route working.
- Share RSS generation through a landing-page helper so both feed URLs produce the same XML.
- Point blog RSS discovery metadata, the site footer RSS link, `robots.txt`, and `llms.txt` at `/blog/rss.xml`.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — blog RSS discovery now points at `/blog/rss.xml` while `/rss.xml` remains compatible
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Verification

- `pnpm --filter @open-design/landing-page typecheck`
- `pnpm --filter @open-design/landing-page build`
- `xmllint --noout apps/landing-page/out/blog/rss.xml`
- `cmp -s apps/landing-page/out/rss.xml apps/landing-page/out/blog/rss.xml`
- Checked built blog index and article HTML for `<link rel="alternate" type="application/rss+xml" title="Open Design Blog" href="https://open-design.ai/blog/rss.xml">` and footer `/blog/rss.xml` link.

## Review

- Read-only subagent review found no blockers. It confirmed the Astro route imports are correct, `/rss.xml` compatibility is preserved, and the implementation satisfies the issue acceptance criteria.