### PR TITLE
test(web): decouple memory preview icon assertion

### DIFF
--- a/apps/web/tests/components/MemorySection.test.tsx
+++ b/apps/web/tests/components/MemorySection.test.tsx
@@ -515,12 +515,23 @@ describe('MemorySection', () => {
     renderMemorySection();
 
     const card = (await screen.findByText('Project scope')).closest('.library-card') as HTMLElement;
-    fireEvent.click(within(card).getByTitle('Preview'));
+    const previewButton = within(card).getByTitle('Preview');
+    const deleteButton = within(card).getByTitle('Delete');
+    fireEvent.click(previewButton);
 
     await screen.findByText('Keep memory actions clear');
-    const closeIconPaths = card.querySelectorAll('path[d="M18 6 6 18"]');
+    const previewIcon = previewButton.querySelector('svg');
+    const deleteIcon = deleteButton.querySelector('svg');
+    const previewPaths = Array.from(
+      previewIcon?.querySelectorAll('path') ?? [],
+    ).map((path) => path.getAttribute('d'));
+    const deletePaths = Array.from(
+      deleteIcon?.querySelectorAll('path') ?? [],
+    ).map((path) => path.getAttribute('d'));
 
-    expect(closeIconPaths).toHaveLength(1);
+    expect(previewIcon).toBeTruthy();
+    expect(deleteIcon).toBeTruthy();
+    expect(previewPaths).not.toEqual(deletePaths);
   });
 
   it('deletes an existing memory entry from the list', async () => {


### PR DESCRIPTION
## Why

The current `main` web suite can fail in `MemorySection.test.tsx` because the test asserts the exact SVG path used by the shared `close` icon. The icon implementation intentionally changed from the old Lucide-sized path to a larger local X path, so the MemorySection test now fails even though the actual invariant is only that the expanded preview control stays visually distinct from delete.

This test-only PR removes that brittle coupling so unrelated PRs do not inherit a base CI failure.

## What users will see

No user-facing change. This only updates a web component test.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — test-only change.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/MemorySection.test.tsx`
- Did the test go red on `main` and green on this branch? Yes. On current `origin/main`, the focused test fails at the old `path[d="M18 6 6 18"]` assertion with `expected length 1, got 0`; on this branch the focused MemorySection suite passes.
- If a red spec wasn't cheap to write, explain why and what verification you did instead: the existing spec already captured the intended invariant, but it was tied to implementation-specific SVG coordinates. The assertion now checks that the expanded preview button and delete button render different SVG path sets.

## Validation

- `pnpm --filter @open-design/web exec vitest run tests/components/MemorySection.test.tsx -c vitest.config.ts`
- `pnpm --filter @open-design/web test`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `git diff --check`

## Review notes

A subagent review found no blocking issues and recommended comparing SVG path sets instead of full `innerHTML`; this PR uses that narrower assertion.