### PR TITLE
fix: use SKILL_ROOTS in /api/skills endpoints for correct source attribution

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -4127,7 +4127,7 @@ export async function startServer({
 
   app.get('/api/skills', async (_req, res) => {
     try {
-      const skills = await listSkills(SKILLS_DIR);
+      const skills = await listSkills(SKILL_ROOTS);
       // Strip full body + on-disk dir from the listing — frontend fetches the
       // body via /api/skills/:id when needed (keeps the listing payload small).
       res.json({
@@ -4143,7 +4143,7 @@ export async function startServer({
 
   app.get('/api/skills/:id', async (req, res) => {
     try {
-      const skills = await listSkills(SKILLS_DIR);
+      const skills = await listSkills(SKILL_ROOTS);
       const skill = findSkillById(skills, req.params.id);
       if (!skill) return res.status(404).json({ error: 'skill not found' });
       const { dir: _dir, ...serializable } = skill;


### PR DESCRIPTION
## Summary
- Fixed the `GET /api/skills` and `GET /api/skills/:id` daemon endpoints to use `SKILL_ROOTS = [USER_SKILLS_DIR, SKILLS_DIR]` instead of `SKILLS_DIR` alone
- This correctly separates user-installed skills (source: "user") from built-in skills (source: "built-in")
- Fixes incorrect source filter counts on the Skills settings page

## Why
`listSkills` determines a skill's source based on its root index: `rootIdx === 0 ? "user" : "built-in"`. When only `SKILLS_DIR` (built-in) was passed, ALL skills were attributed as "user" since that single root was at index 0. Using `SKILL_ROOTS` restores the correct two-root ordering where user skills shadow built-in skills.

This also aligns the `server.ts` handlers with `static-resource-routes.ts` which already correctly uses `listAllSkills()` → `listSkills(SKILL_ROOTS)`.

## What changed
- `apps/daemon/src/server.ts`: Changed `listSkills(SKILLS_DIR)` → `listSkills(SKILL_ROOTS)` in both `/api/skills` and `/api/skills/:id` handlers

## Test plan
- [ ] Verify `/api/skills` returns skills with correct `source` field ("user" for user-installed, "built-in" for built-in)
- [ ] Confirm Skills settings page shows accurate source filter counts