### PR TITLE
chore(ci): scope nix-check workflow permissions to contents:read

### DIFF
--- a/.github/workflows/nix-check.yml
+++ b/.github/workflows/nix-check.yml
@@ -44,6 +44,9 @@ on:
       - .github/PULL_REQUEST_TEMPLATE.md
       - .github/CODEOWNERS
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Required for issue/PR auto-link. Delete this whole block if the PR genuinely doesn't close any issue. -->
<!-- This PR does not close a specific issue. -->

## Why

Hardening the CI workflow surface as part of an open-source review pass.

Every other workflow under `.github/workflows/` (12 of them) declares an explicit `permissions:` block scoping the `GITHUB_TOKEN` to the minimum needed (typically `contents: read` for build-only flows). `nix-check.yml` was the lone outlier — it inherited the repository's default token permissions instead of declaring its own.

The default for repos that have never narrowed token permissions is `permissions-write-all`, which grants the workflow's token write access across the repo. `nix-check` only checks out code, runs `nix flake check`, and uploads a logs artifact on failure — it has no legitimate need for write scope. Scoping it down brings the file into line with GitHub's least-privilege workflow guidance and matches the convention already followed by the rest of the workflow suite.

## What users will see

Nothing user-facing changes. This is an internal CI hardening adjustment that only affects the permissions of the workflow's GITHUB_TOKEN.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only (CI workflow permissions hardening)

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/nix-check.yml'))"` — YAML parses
- diff is the minimal 3-line addition matching the pattern of `ci.yml`, `landing-page-ci.yml`, etc.
- No effect on workflow steps; the job still only reads the repo and uploads artifacts on failure (uploader action handles its own write scope internally).
