### PR TITLE
fix(contracts): tighten LiveArtifactSsePayload.refreshStatus to LiveArtifactRefreshStatus

### DIFF
--- a/packages/contracts/src/sse/chat.ts
+++ b/packages/contracts/src/sse/chat.ts
@@ -1,3 +1,4 @@
+import type { LiveArtifactRefreshStatus } from '../api/live-artifacts.js';
 import type { SseErrorPayload } from '../errors.js';
 import type { SseTransportEvent } from './common.js';
 
@@ -10,7 +11,14 @@ export interface LiveArtifactSsePayload {
   projectId: string;
   artifactId: string;
   title: string;
-  refreshStatus?: string;
+  /**
+   * Refresh lifecycle state of the artifact at emit time. Typed against the
+   * canonical `LiveArtifactRefreshStatus` enum used by the REST API so that
+   * SSE consumers (web, CLI) can switch on the same union members without
+   * widening to `string`. Optional because the daemon may omit the field on
+   * legacy events; consumers must still null-check before narrowing.
+   */
+  refreshStatus?: LiveArtifactRefreshStatus;
 }
 
 export interface LiveArtifactRefreshSsePayload {


### PR DESCRIPTION
<!-- This PR is a contract type tightening. It does not close a specific issue. -->

## Why

I was auditing the open-source codebase for type-safety gaps between `packages/contracts` and its consumers when I noticed that `LiveArtifactSsePayload.refreshStatus` was typed as `string | undefined`, while every consumer and the REST counterpart treat it as the canonical `LiveArtifactRefreshStatus` enum (`'never' | 'idle' | 'running' | 'succeeded' | 'failed'`).

The drift is silent and easy to miss:

- The daemon emitter at `apps/daemon/src/server.ts` already passes `artifact.refreshStatus`, which is typed as the enum on `LiveArtifact`.
- Web consumers in `apps/web/src/components/{DesignsTab,FileViewer,LiveArtifactBadges}.tsx` `switch` on the enum members.
- But the SSE contract typed it as a bare `string`, so a daemon adding a new refresh state for REST could ship it out via SSE as an opaque string with no compile-time signal to the consumer that a `switch` is now non-exhaustive.

This PR aligns the SSE payload type with the canonical enum so the two transports cannot drift unnoticed. Runtime behavior is unchanged — this is a type-only fix.

## What users will see

Nothing user-facing changes. The wire format is identical; only TypeScript types are tightened.

## Surface area

- [x] **API / contract** — changed shape in `packages/contracts` (type tightening only; no field added/removed)

## Bug fix verification

A red spec wasn't cheap here because the bug is a *future-drift hazard* rather than a current incorrect-runtime-behavior bug — at the moment, every consumer happens to compare against valid enum members, so no red runtime test exists today. The verification I ran is type-level:

- Before this change: a hypothetical daemon emit of `refreshStatus: 'totally-bogus'` would type-check on the daemon side and on the consumer side (because the consumer accepts `string`).
- After this change: the same emit would fail `pnpm typecheck` on both ends, because the SSE payload narrows to the enum.

I confirmed this by hand-testing both directions in a scratch file.

## Validation

- `pnpm --filter @open-design/contracts build` — green
- `pnpm --filter @open-design/contracts test` — 78 tests passed
- `pnpm --filter @open-design/web typecheck` — green
- `pnpm --filter @open-design/daemon typecheck` — green
- `pnpm guard` — green
- No `apps/web` runtime changes, no SSE wire format change, so no Playwright regression run is necessary. The two consumers that read this field (`AssistantMessage`/streaming flow, `DesignsTab` cards) keep the same JavaScript output before/after.
