### PR TITLE
docs: sync Windows troubleshooting link across locale READMEs

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -333,6 +333,8 @@ pnpm tools-dev run web
 
 متطلّبات البيئة: Node `~24` و pnpm `10.33.x`. أدوات `nvm`/`fnm` اختيارية فقط؛ إن استخدمت إحداها فشغّل `nvm install 24 && nvm use 24` أو `fnm install 24 && fnm use 24` قبل `pnpm install`.
 
+يمكن لمستخدمي ويندوز اتباع [`docs/windows-troubleshooting.md`](docs/windows-troubleshooting.md) للحصول على مسار التثبيت الأصلي ومُشغّل صغير بنقرة مزدوجة.
+
 لتشغيل سطح المكتب / الخلفية، إعادة التشغيل بمنافذ ثابتة، وفحوص dispatcher توليد الوسائط (`OD_BIN`، `OD_DAEMON_URL`، `apps/daemon/dist/cli.js`) راجع [`QUICKSTART.md`](QUICKSTART.md).
 
 عند أوّل تحميل:

--- a/README.de.md
+++ b/README.de.md
@@ -330,6 +330,8 @@ pnpm tools-dev run web
 
 Umgebungsanforderungen: Node `~24` und pnpm `10.33.x`. `nvm`/`fnm` sind nur optionale Helfer; wenn Sie eines davon nutzen, führen Sie vor `pnpm install` `nvm install 24 && nvm use 24` oder `fnm install 24 && fnm use 24` aus.
 
+Windows-Nutzer:innen können [`docs/windows-troubleshooting.md`](docs/windows-troubleshooting.md) für den nativen Setup-Pfad und einen kleinen Doppelklick-Launcher folgen.
+
 Für Desktop-/Background-Start, Fixed-Port-Restarts und Media-Generation-Dispatcher-Checks (`OD_BIN`, `OD_DAEMON_URL`, `apps/daemon/dist/cli.js`) siehe [`QUICKSTART.de.md`](QUICKSTART.de.md).
 
 Der erste Load:

--- a/README.es.md
+++ b/README.es.md
@@ -321,6 +321,8 @@ pnpm tools-dev run web
 
 Requisitos de entorno: Node `~24` y pnpm `10.33.x`. `nvm`/`fnm` son helpers opcionales; si usas uno, ejecuta `nvm install 24 && nvm use 24` o `fnm install 24 && fnm use 24` antes de `pnpm install`.
 
+Los usuarios de Windows pueden seguir [`docs/windows-troubleshooting.md`](docs/windows-troubleshooting.md) para la ruta de instalación nativa y un pequeño lanzador de doble clic.
+
 Para arranque desktop/background, reinicios con puerto fijo y checks del dispatcher de media generation (`OD_BIN`, `OD_DAEMON_URL`, `apps/daemon/dist/cli.js`), consulta [`QUICKSTART.md`](QUICKSTART.md).
 
 La primera carga:

--- a/README.fr.md
+++ b/README.fr.md
@@ -331,6 +331,8 @@ pnpm tools-dev run web
 
 Prérequis : Node `~24` et pnpm `10.33.x`. `nvm` / `fnm` ne sont que des aides facultatives ; si vous en utilisez un, lancez `nvm install 24 && nvm use 24` ou `fnm install 24 && fnm use 24` avant `pnpm install`.
 
+Les utilisateurs Windows peuvent suivre [`docs/windows-troubleshooting.md`](docs/windows-troubleshooting.md) pour le chemin d'installation natif et un petit launcher en double-clic.
+
 Pour le démarrage desktop/background, les redémarrages sur ports fixes et les checks du dispatcher de génération média (`OD_BIN`, `OD_DAEMON_URL`, `apps/daemon/dist/cli.js`), voir [`QUICKSTART.fr.md`](QUICKSTART.fr.md).
 
 Au premier chargement :

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -331,6 +331,8 @@ pnpm tools-dev run web
 
 環境要件：Node `~24`、pnpm `10.33.x`。`nvm` / `fnm` はあくまでオプションのヘルパーです。使用する場合は `pnpm install` の前に `nvm install 24 && nvm use 24` または `fnm install 24 && fnm use 24` を実行してください。
 
+Windows ユーザーはネイティブセットアップパスと小さなダブルクリックランチャーについて [`docs/windows-troubleshooting.md`](docs/windows-troubleshooting.md) を参照してください。
+
 デスクトップ / バックグラウンド起動、固定ポート再起動、メディア生成ディスパッチャの確認（`OD_BIN`、`OD_DAEMON_URL`、`apps/daemon/dist/cli.js`）は [`QUICKSTART.ja-JP.md`](QUICKSTART.ja-JP.md) を参照。
 
 初回ロード時：

--- a/README.ko.md
+++ b/README.ko.md
@@ -330,6 +330,8 @@ pnpm tools-dev run web
 
 환경 요구사항: Node `~24`와 pnpm `10.33.x`. `nvm` / `fnm`은 선택적 보조 도구일 뿐입니다; 사용한다면 `pnpm install` 전에 `nvm install 24 && nvm use 24` 또는 `fnm install 24 && fnm use 24`를 실행하세요.
 
+Windows 사용자는 네이티브 설치 경로와 작은 더블 클릭 런처에 대해서는 [`docs/windows-troubleshooting.md`](docs/windows-troubleshooting.md)를 참고하세요.
+
 데스크톱/백그라운드 시작, 고정 포트 재시작, 미디어 생성 dispatcher 확인(`OD_BIN`, `OD_DAEMON_URL`, `apps/daemon/dist/cli.js`)은 [`QUICKSTART.md`](QUICKSTART.md)를 참고하세요.
 
 첫 번째 로드 시:

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -331,6 +331,8 @@ pnpm tools-dev run web
 
 Requisitos de ambiente: Node `~24` e pnpm `10.33.x`. `nvm`/`fnm` são apenas helpers opcionais; se você usa um, rode `nvm install 24 && nvm use 24` ou `fnm install 24 && fnm use 24` antes do `pnpm install`.
 
+Usuários de Windows podem seguir [`docs/windows-troubleshooting.md`](docs/windows-troubleshooting.md) para o caminho de setup nativo e um pequeno launcher de duplo clique.
+
 Para startup desktop/background, restart com porta fixa e checagens do dispatcher de geração de mídia (`OD_BIN`, `OD_DAEMON_URL`, `apps/daemon/dist/cli.js`), veja [`QUICKSTART.pt-BR.md`](QUICKSTART.pt-BR.md).
 
 No primeiro carregamento:

--- a/README.ru.md
+++ b/README.ru.md
@@ -331,6 +331,8 @@ pnpm tools-dev run web
 
 Требования к окружению: Node `~24` и pnpm `10.33.x`. `nvm`/`fnm` — только вспомогательные инструменты; если вы ими пользуетесь, выполните `nvm install 24 && nvm use 24` или `fnm install 24 && fnm use 24` перед `pnpm install`.
 
+Пользователи Windows могут воспользоваться [`docs/windows-troubleshooting.md`](docs/windows-troubleshooting.md), где описаны нативный путь установки и небольшой лаунчер для запуска по двойному клику.
+
 Для desktop/background startup, перезапуска на фиксированных портах и проверки dispatcher’а media generation (`OD_BIN`, `OD_DAEMON_URL`, `apps/daemon/dist/cli.js`) смотрите [`QUICKSTART.md`](QUICKSTART.md).
 
 При первой загрузке:

--- a/README.tr.md
+++ b/README.tr.md
@@ -322,6 +322,8 @@ pnpm tools-dev run web
 
 Ortam gereksinimleri: Node `~24` ve pnpm `10.33.x`. `nvm`/`fnm` yalnızca opsiyonel yardımcılardır; birini kullanıyorsan `pnpm install` öncesinde `nvm install 24 && nvm use 24` veya `fnm install 24 && fnm use 24` çalıştır.
 
+Windows kullanıcıları native kurulum yolu ve küçük bir çift-tıklama launcher için [`docs/windows-troubleshooting.md`](docs/windows-troubleshooting.md) belgesini takip edebilir.
+
 Desktop/background startup, fixed-port restart'lar ve medya üretimi dispatcher kontrolleri (`OD_BIN`, `OD_DAEMON_URL`, `apps/daemon/dist/cli.js`) için [`QUICKSTART.md`](QUICKSTART.md) oku.
 
 İlk yükleme:

--- a/README.uk.md
+++ b/README.uk.md
@@ -331,6 +331,8 @@ pnpm tools-dev run web
 
 Вимоги до середовища: Node `~24` та pnpm `10.33.x`. `nvm`/`fnm` є лише додатковими помічниками; якщо ви використовуєте один з них, запустіть `nvm install 24 && nvm use 24` або `fnm install 24 && fnm use 24` перед `pnpm install`.
 
+Користувачі Windows можуть скористатися [`docs/windows-troubleshooting.md`](docs/windows-troubleshooting.md) для нативного шляху встановлення та невеликого лаунчера з подвійним кліком.
+
 Для запуску desktop/background, перезапусків з фіксованими портами та перевірок диспетчера генерації медіа (`OD_BIN`, `OD_DAEMON_URL`, `apps/daemon/dist/cli.js`), див. [`QUICKSTART.md`](QUICKSTART.md).
 
 Перше завантаження:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -330,6 +330,8 @@ pnpm tools-dev run web
 
 环境要求：Node `~24`，pnpm `10.33.x`。`nvm` / `fnm` 只是可选辅助工具，不是项目必需步骤；如果使用它们，先执行 `nvm install 24 && nvm use 24` 或 `fnm install 24 && fnm use 24`，再运行 `pnpm install`。
 
+Windows 用户可参考 [`docs/windows-troubleshooting.md`](docs/windows-troubleshooting.md) 了解原生安装路径和一个小型的双击启动器。
+
 桌面端/后台启动、固定端口重启，以及 media 生成派发器检查（`OD_BIN`、`OD_DAEMON_URL`、`apps/daemon/dist/cli.js`）见 [`QUICKSTART.zh-CN.md`](QUICKSTART.zh-CN.md)。
 
 第一次加载会：

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -328,6 +328,8 @@ pnpm tools-dev run web
 
 環境要求：Node `~24`，pnpm `10.33.x`。`nvm` / `fnm` 只是可選輔助工具，不是專案必需步驟；如果使用它們，先執行 `nvm install 24 && nvm use 24` 或 `fnm install 24 && fnm use 24`，再執行 `pnpm install`。
 
+Windows 使用者可參考 [`docs/windows-troubleshooting.md`](docs/windows-troubleshooting.md) 了解原生安裝路徑與一個小型雙擊啟動器。
+
 桌面版/後臺啟動、固定埠重啟，以及 media 生成派發器檢查（`OD_BIN`、`OD_DAEMON_URL`、`apps/daemon/dist/cli.js`）見 [`QUICKSTART.zh-TW.md`](QUICKSTART.zh-TW.md)。
 
 第一次載入會：


### PR DESCRIPTION
<!-- This PR is a documentation translation-parity fix. It does not close a single issue. -->

## Why

PR #1546 (`docs: add Windows launcher note`) added a pointer to `docs/windows-troubleshooting.md` in the English `README.md`, slotted between the "Environment requirements" paragraph and the "For desktop/background startup, …" paragraph. The same line was not propagated to the 12 locale README translations, so anyone landing on a non-English README via the language switcher does not see the Windows native-setup path or the double-click launcher hint that English readers see.

This PR closes that translation gap.

## What users will see

Non-English README readers now see a single sentence pointing to `docs/windows-troubleshooting.md`, in the locale's own voice, at the same anchor position as the English README. No new docs file is introduced — every locale points back to the same English `docs/windows-troubleshooting.md`, matching how other locale-specific tips already cross-reference English docs in this repo.

Example (Korean):
> Windows 사용자는 네이티브 설치 경로와 작은 더블 클릭 런처에 대해서는 [`docs/windows-troubleshooting.md`](docs/windows-troubleshooting.md)를 참고하세요.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only (12 locale READMEs)

## Validation

- Pre-change grep: 12 of 12 locale READMEs missing the link.
- Post-change grep: 12 of 12 locale READMEs contain the link, each placed at the same anchor as the English README.
- Diff: 12 files changed, 24 insertions (+) — one one-sentence paragraph plus the surrounding blank line per file.
- No code changes; no test impact.

## Out of scope (filed as adjacent issue)

`README.ko.md` is also missing the "For desktop/background startup, fixed-port restarts, and media generation dispatcher checks (…), see [`QUICKSTART.md`](QUICKSTART.md)." paragraph that the other 11 locales already have. That's a separate translation-parity gap and should be handled when the broader ko translation is revisited; folding it into this PR would have mixed two different propagation gaps in one change.
