### PR TITLE
docs(ko): add desktop/background startup paragraph to README.ko

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -330,6 +330,8 @@ pnpm tools-dev run web
 
 환경 요구사항: Node `~24`와 pnpm `10.33.x`. `nvm` / `fnm`은 선택적 보조 도구일 뿐입니다; 사용한다면 `pnpm install` 전에 `nvm install 24 && nvm use 24` 또는 `fnm install 24 && fnm use 24`를 실행하세요.
 
+데스크톱/백그라운드 시작, 고정 포트 재시작, 미디어 생성 dispatcher 확인(`OD_BIN`, `OD_DAEMON_URL`, `apps/daemon/dist/cli.js`)은 [`QUICKSTART.md`](QUICKSTART.md)를 참고하세요.
+
 첫 번째 로드 시:
 
 1. `PATH`에 어떤 에이전트 CLI가 있는지 감지하고 자동으로 하나를 선택합니다.


### PR DESCRIPTION
<!-- Translation-parity fix for README.ko.md. Does not close a specific issue. -->

## Why

`README.ko.md` is missing the paragraph that points readers to `QUICKSTART.md` for desktop/background startup, fixed-port restarts, and media-generation dispatcher checks (`OD_BIN`, `OD_DAEMON_URL`, `apps/daemon/dist/cli.js`). The English README has it, and every other locale README (ar, de, es, fr, ja-JP, pt-BR, ru, tr, uk, zh-CN, zh-TW) translated the paragraph at the same anchor position.

A Korean reader landing on the README through the language switcher therefore does not see this operational pointer and has to discover the env vars by reading the English QUICKSTART unprompted. This PR closes that single translation-parity gap, which #1875 (multi-locale Windows troubleshooting link sync) explicitly carved out as out-of-scope.

## What users will see

`README.ko.md` now carries a single one-sentence paragraph in Korean, slotted between the existing "환경 요구사항" paragraph and the "첫 번째 로드 시:" enumeration:

> 데스크톱/백그라운드 시작, 고정 포트 재시작, 미디어 생성 dispatcher 확인(`OD_BIN`, `OD_DAEMON_URL`, `apps/daemon/dist/cli.js`)은 [`QUICKSTART.md`](QUICKSTART.md)를 참고하세요.

The link target is `QUICKSTART.md` (the English file), matching the convention already followed by `README.ru.md`, `README.uk.md`, `README.es.md`, `README.tr.md`, and `README.ar.md` — none of those have a locale-specific QUICKSTART either, and they all point back to the English file. A future locale-specific `QUICKSTART.ko.md` would be a separate change.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only

## Validation

- Pre-change grep on README.ko.md: no `QUICKSTART.md` reference in the Quickstart section.
- Post-change grep: paragraph present at the same anchor position used by 11 other locales.
- Diff: 1 file changed, 2 insertions (+).
- No code changes; no test impact.

## Relationship to #1875

Independent and non-conflicting. #1875 adds a Windows-troubleshooting link to all 12 locale READMEs (including a one-line addition to `README.ko.md` at a different paragraph slot). This PR adds the desktop/background paragraph at a separate anchor in `README.ko.md` only. The two changes touch different lines, so they merge cleanly in either order.
