### PR TITLE
fix(test): align MemorySection expand-action assertion with the repo's close-icon path

### DIFF
--- a/apps/web/tests/components/MemorySection.test.tsx
+++ b/apps/web/tests/components/MemorySection.test.tsx
@@ -518,7 +518,13 @@ describe('MemorySection', () => {
     fireEvent.click(within(card).getByTitle('Preview'));
 
     await screen.findByText('Keep memory actions clear');
-    const closeIconPaths = card.querySelectorAll('path[d="M18 6 6 18"]');
+    // The repo's `Icon name="close"` deliberately uses 4→20 coordinates
+    // (`M20 4 4 20` + `m4 4 16 16`) instead of the Lucide default 6→18 to
+    // make compact close glyphs read better — see `apps/web/src/components/Icon.tsx`.
+    // The delete button is the only consumer of `name="close"` on this card;
+    // the expanded preview control now uses `chevron-down`, so exactly one
+    // close-shaped path should be present.
+    const closeIconPaths = card.querySelectorAll('path[d="M20 4 4 20"]');
 
     expect(closeIconPaths).toHaveLength(1);
   });


### PR DESCRIPTION
<!-- Restores `main` to green by aligning a stale assertion. Does not close a specific issue. -->

## Why

`main` has been red on the **Validate workspace → App workspace web tests** job for every web-touching PR opened since #1813 merged. I noticed the failure on my own #1871 (a type-only contracts change) and bisected to confirm the failure is **not** in my changes — it's pre-existing on `main`.

Repro on `origin/main` at `1896c699`:

```
pnpm --filter @open-design/web test -- tests/components/MemorySection.test.tsx
…
× MemorySection > keeps the expanded preview control visually distinct from delete
  → expected to have a length of 1 but got +0
```

Bisect:
- `3f56395e` (one commit before #1813): **158 files / 1489 tests pass — green**
- `6b152368` (#1813 merge): **1 failure, red**

#1813 ("fix(web): distinguish expanded memory preview action") did two things in one commit:
1. Flipped the expanded-preview icon in `apps/web/src/components/MemorySection.tsx` from `name="close"` to `name="chevron-down"` (the intended UX fix).
2. Added a new regression test in `apps/web/tests/components/MemorySection.test.tsx` that asserts the card contains exactly one close-shaped path:

   ```ts
   card.querySelectorAll('path[d="M18 6 6 18"]')
   ```

The hard-coded `d` is the **Lucide default** (a `6→18` X inside a 24-unit viewBox). But this repo's `Icon name="close"` deliberately uses **`4→20` coordinates** — see the inline rationale in `apps/web/src/components/Icon.tsx`:

```ts
case 'close':
  // Tighter X than the Lucide default (which uses coords 6→18 inside a
  // 24-unit viewBox, so the visible glyph is only 50% of the icon box).
  // ...
  // Extending the strokes to 4→20 lifts the visible extent to ~67% ...
  return (
    <svg {...common}>
      <path d="M20 4 4 20" />
      <path d="m4 4 16 16" />
    </svg>
  );
```

So the assertion has matched **zero** paths since #1813 merged. The new test was effectively never green.

## What users will see

Nothing user-facing changes. This restores `main` to a passing test suite, which unblocks reviewers from having to mentally filter out a "main is red" failure on every web-touching PR's CI.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only (one test assertion)

## Bug fix verification

- Red spec: `MemorySection > keeps the expanded preview control visually distinct from delete` on `origin/main` (`1896c699`).
- Bisect confirms the failure was introduced by #1813 itself (the new assertion in the same commit that flipped the icon, but pointed at the wrong `d` value).
- Green spec: same test on this branch — 158 files / 1490 tests pass, no other test files changed.

## Validation

```
pnpm --filter @open-design/web test -- tests/components/MemorySection.test.tsx
→ 158 files / 1490 tests pass
```

## Test intent is preserved

#1813's goal — "the expanded preview control is visually distinct from delete" — is unchanged. The card has three buttons: Preview (`chevron-down`/`chevron-right`), Edit (`edit`), Delete (`close`). After #1813's icon flip, only the Delete button renders a `close`-shaped path. Retargeting the assertion at `path[d="M20 4 4 20"]` (the actual path the repo's close glyph renders) verifies exactly that invariant: one close-shaped path on the card, owned by Delete; Preview is not a close glyph.

I also left a short comment next to the assertion pointing back at `Icon.tsx`, so if the close glyph is ever revisited the assertion doesn't silently drift again.
