### PR TITLE
fix: support CODEX_API_KEY for Codex CLI

### DIFF
--- a/apps/daemon/src/app-config.ts
+++ b/apps/daemon/src/app-config.ts
@@ -136,7 +136,7 @@ function validateTelemetry(raw: unknown): TelemetryPrefs | undefined {
 
 const AGENT_CLI_ENV_KEYS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
   ['claude', new Set(['CLAUDE_CONFIG_DIR', 'CLAUDE_BIN', 'ANTHROPIC_BASE_URL', 'ANTHROPIC_API_KEY'])],
-  ['codex', new Set(['CODEX_HOME', 'CODEX_BIN', 'OPENAI_BASE_URL', 'OPENAI_API_KEY'])],
+  ['codex', new Set(['CODEX_HOME', 'CODEX_BIN', 'OPENAI_BASE_URL', 'CODEX_API_KEY', 'OPENAI_API_KEY'])],
   ['copilot', new Set(['COPILOT_BIN'])],
   ['cursor-agent', new Set(['CURSOR_AGENT_BIN'])],
   ['deepseek', new Set(['DEEPSEEK_BIN'])],

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -1173,6 +1173,7 @@ describe('POST /api/test/connection agent mode', () => {
 const fs = require('node:fs');
 fs.writeFileSync(${JSON.stringify(envFile)}, JSON.stringify({
   CODEX_HOME: process.env.CODEX_HOME || null,
+  CODEX_API_KEY: process.env.CODEX_API_KEY || null,
   SHOULD_NOT_PASS: process.env.OD_CONNECTION_TEST_SHOULD_NOT_PASS || null,
 }));
 console.log(JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'ok' } }));
@@ -1187,6 +1188,7 @@ console.log(JSON.stringify({ type: 'item.completed', item: { type: 'agent_messag
               agentCliEnv: {
                 codex: {
                   CODEX_HOME: codexHome,
+                  CODEX_API_KEY: 'codex-key',
                   OD_CONNECTION_TEST_SHOULD_NOT_PASS: 'leaked',
                 },
                 claude: {
@@ -1204,6 +1206,7 @@ console.log(JSON.stringify({ type: 'item.completed', item: { type: 'agent_messag
           await expect(fsp.readFile(envFile, 'utf8')).resolves.toBe(
             JSON.stringify({
               CODEX_HOME: codexHome,
+              CODEX_API_KEY: 'codex-key',
               SHOULD_NOT_PASS: null,
             }),
           );

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -353,6 +353,7 @@ const AGENT_CLI_ENV_FIELDS = [
     agentId: 'codex',
     envKey: 'CODEX_API_KEY',
     labelKey: 'settings.cliEnvCodexApiKey',
+    labelSuffix: 'CODEX_API_KEY',
     placeholder: 'Paste CODEX_API_KEY',
     secret: true,
   },
@@ -360,6 +361,7 @@ const AGENT_CLI_ENV_FIELDS = [
     agentId: 'codex',
     envKey: 'OPENAI_API_KEY',
     labelKey: 'settings.cliEnvCodexApiKey',
+    labelSuffix: 'OPENAI_API_KEY · proxy/legacy',
     placeholder: 'Paste OPENAI_API_KEY',
     secret: true,
   },
@@ -2327,6 +2329,9 @@ export function SettingsDialog({
                           >
                             <span className="field-label">
                               {t(field.labelKey)}
+                              {'labelSuffix' in field
+                                ? ` (${field.labelSuffix})`
+                                : ''}
                             </span>
                             <input
                               type={

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -351,9 +351,16 @@ const AGENT_CLI_ENV_FIELDS = [
   },
   {
     agentId: 'codex',
+    envKey: 'CODEX_API_KEY',
+    labelKey: 'settings.cliEnvCodexApiKey',
+    placeholder: 'Paste CODEX_API_KEY',
+    secret: true,
+  },
+  {
+    agentId: 'codex',
     envKey: 'OPENAI_API_KEY',
     labelKey: 'settings.cliEnvCodexApiKey',
-    placeholder: 'Paste proxy API key',
+    placeholder: 'Paste OPENAI_API_KEY',
     secret: true,
   },
 ] as const;

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -561,7 +561,7 @@ const DAEMON_OWNED_KEYS = new Set<keyof AppConfig>([
   'privacyDecisionAt',
 ]);
 
-const AGENT_CLI_SECRET_ENV_KEYS = new Set(['ANTHROPIC_API_KEY', 'OPENAI_API_KEY']);
+const AGENT_CLI_SECRET_ENV_KEYS = new Set(['ANTHROPIC_API_KEY', 'CODEX_API_KEY', 'OPENAI_API_KEY']);
 
 function sanitizeAgentCliEnv(agentCliEnv: AppConfig['agentCliEnv']): AppConfig['agentCliEnv'] {
   if (!agentCliEnv) return agentCliEnv;

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -841,6 +841,13 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
       { agents: availableAgents },
     );
 
+    expect(
+      screen.getByLabelText('Codex/OpenAI proxy API key (CODEX_API_KEY)'),
+    ).toBeTruthy();
+    expect(
+      screen.getByLabelText('Codex/OpenAI proxy API key (OPENAI_API_KEY · proxy/legacy)'),
+    ).toBeTruthy();
+
     fireEvent.change(screen.getByLabelText('Codex home'), {
       target: { value: ' ~/.codex-team ' },
     });

--- a/apps/web/tests/state/config.test.ts
+++ b/apps/web/tests/state/config.test.ts
@@ -815,6 +815,7 @@ describe('saveConfig', () => {
           CLAUDE_CONFIG_DIR: '~/.claude-2',
         },
         codex: {
+          CODEX_API_KEY: 'sk-codex',
           OPENAI_API_KEY: 'sk-openai',
           OPENAI_BASE_URL: 'https://proxy.example/openai',
           CODEX_HOME: '~/.codex-alt',


### PR DESCRIPTION
Related to #302.

## Why

I hit the Codex CLI setup path from the installed desktop app: OpenCode can use a Codex/OpenAI provider, but selecting Codex directly in Open Design cannot reliably inherit shell-exported `CODEX_API_KEY` from a GUI-launched app.

The app already lets users configure Codex-specific CLI env in Settings, but the daemon allowlist and web form only covered `OPENAI_API_KEY`. Current Codex configurations commonly use `CODEX_API_KEY`, so the configured key was unavailable when the app spawned Codex.

## What users will see

Settings → Execution Model → Local CLI → Codex → Advanced proxy/custom paths now includes a `CODEX_API_KEY` password field. Values saved there are passed to Codex connection tests/runs through the daemon and are not persisted in browser localStorage.

The existing `OPENAI_API_KEY` field remains available for proxy/legacy Codex setups.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached: this is a text-only advanced Settings field added under the existing Codex CLI environment disclosure. Behavior was validated through the spawned Codex connection-test surface below.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/connection-test.test.ts` now asserts draft Codex CLI env passes `CODEX_API_KEY` through to the spawned agent process.
- Did the test go red on `main` and green on this branch? No; I did not run the new assertion on `main` separately. The change is a narrow allowlist/UI plumbing fix and was also manually verified with a fake Codex binary.

## Validation

- `corepack pnpm install`
- `corepack pnpm --filter @open-design/daemon test -- connection-test.test.ts` (repo config ran all daemon tests: 206 files / 2531 passed / 4 todo)
- `corepack pnpm --filter @open-design/web test -- state/config.test.ts SettingsDialog.test.ts SettingsDialog.execution.test.tsx` (repo config ran all web tests: 158 files / 1490 passed)
- `corepack pnpm guard`
- `corepack pnpm typecheck` with a temporary `pnpm` shim for package scripts (0 errors; pre-existing Astro inline-script hints only)
- `corepack pnpm --filter @open-design/daemon build`
- `corepack pnpm --filter @open-design/web build`
- Manual QA: used `testAgentConnection` with a fake configured Codex binary and confirmed the spawned process received `CODEX_API_KEY=sk-codex-qa` and `OPENAI_API_KEY=sk-openai-qa`.