### PR TITLE
fix: reset home page starter filters to All by default

### DIFF
--- a/apps/web/src/components/plugins-home/facets.ts
+++ b/apps/web/src/components/plugins-home/facets.ts
@@ -736,8 +736,8 @@ export function filterByQuery(
 // creation bucket first; Slides tends to contain polished, image-heavy
 // cards, while the broader Create lane remains one tap away.
 export const PREFERRED_DEFAULT_SELECTION: FacetSelection = {
-  category: 'create',
-  subcategory: 'deck',
+  category: null,
+  subcategory: null,
 };
 
 export function resolveDefaultSelection(catalog: FacetCatalog): FacetSelection {

--- a/apps/web/tests/components/plugins-home-facets.test.ts
+++ b/apps/web/tests/components/plugins-home-facets.test.ts
@@ -304,25 +304,25 @@ describe('isFeaturedPlugin', () => {
 });
 
 describe('resolveDefaultSelection', () => {
-  it('defaults the home catalog to Create > Slides when that bucket exists', () => {
+  it('defaults the home catalog to no filter (All) to show all plugins', () => {
     const catalog = buildFacetCatalog([
       fixture({ id: 'slides', od: { mode: 'deck' } }),
       fixture({ id: 'prototype', od: { mode: 'prototype' } }),
     ]);
 
     expect(resolveDefaultSelection(catalog)).toEqual({
-      category: 'create',
-      subcategory: 'deck',
+      category: null,
+      subcategory: null,
     });
   });
 
-  it('falls back to the Create lane when Slides is unavailable', () => {
+  it('returns no filter when catalog has plugins', () => {
     const catalog = buildFacetCatalog([
       fixture({ id: 'prototype', od: { mode: 'prototype' } }),
     ]);
 
     expect(resolveDefaultSelection(catalog)).toEqual({
-      category: 'create',
+      category: null,
       subcategory: null,
     });
   });

--- a/apps/web/tests/components/plugins-home-section.test.tsx
+++ b/apps/web/tests/components/plugins-home-section.test.tsx
@@ -126,14 +126,8 @@ describe('PluginsHomeSection (category bar)', () => {
     expect(screen.queryByTestId('plugins-home-pill-category-video')).toBeNull();
     expect(screen.queryByTestId('plugins-home-pill-category-image')).toBeNull();
     expect(screen.queryByTestId('plugins-home-pill-category-reactjs')).toBeNull();
-    expect(screen.getByTestId('plugins-home-row-subcategory-create')).toBeTruthy();
-    expect(screen.getByTestId('plugins-home-pill-subcategory-create-prototype')).toBeTruthy();
-    expect(screen.getByTestId('plugins-home-pill-subcategory-create-deck')).toBeTruthy();
-    expect(screen.getByTestId('plugins-home-pill-subcategory-create-design-system')).toBeTruthy();
-    expect(screen.getByTestId('plugins-home-pill-subcategory-create-hyperframes')).toBeTruthy();
-    expect(screen.getByTestId('plugins-home-pill-subcategory-create-image')).toBeTruthy();
-    expect(screen.getByTestId('plugins-home-pill-subcategory-create-video')).toBeTruthy();
-    expect(screen.getByTestId('plugins-home-pill-subcategory-create-audio')).toBeTruthy();
+    // Default selection is now All (no category filter), so no subcategory row is shown
+    expect(screen.queryByTestId('plugins-home-row-subcategory-create')).toBeNull();
     // Surface / Type / Scenario rows and the More disclosure are gone.
     expect(screen.queryByTestId('plugins-home-row-surface')).toBeNull();
     expect(screen.queryByTestId('plugins-home-row-type')).toBeNull();
@@ -152,6 +146,8 @@ describe('PluginsHomeSection (category bar)', () => {
         onOpenDetails={() => {}}
       />,
     );
+    // Click Create category to show subcategory row
+    fireEvent.click(screen.getByTestId('plugins-home-pill-category-create'));
     expect(screen.getByTestId('plugins-home-pill-subcategory-create-audio')).toBeTruthy();
   });
 
@@ -278,7 +274,22 @@ describe('PluginsHomeSection (category bar)', () => {
         onOpenDetails={() => {}}
       />,
     );
+    // Default selection is now All, so all plugins are shown
     let items = within(screen.getByRole('list')).getAllByRole('listitem');
+    expect(items.map((i) => i.getAttribute('data-plugin-id')).sort()).toEqual([
+      'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o',
+    ]);
+
+    // Click Create category to show subcategory row
+    fireEvent.click(screen.getByTestId('plugins-home-pill-category-create'));
+    items = within(screen.getByRole('list')).getAllByRole('listitem');
+    expect(items.map((i) => i.getAttribute('data-plugin-id')).sort()).toEqual([
+      'a', 'b', 'c', 'd', 'e', 'f',
+    ]);
+
+    // Click deck subcategory
+    fireEvent.click(screen.getByTestId('plugins-home-pill-subcategory-create-deck'));
+    items = within(screen.getByRole('list')).getAllByRole('listitem');
     expect(items.map((i) => i.getAttribute('data-plugin-id'))).toEqual(['f']);
     expect(screen.getByTestId('plugins-home-pill-subcategory-create-deck').getAttribute('aria-selected'))
       .toBe('true');


### PR DESCRIPTION
Fixes #1800

## Problem

On the Open Design 0.8.0 home page, the **Official starters** section defaults to **Create + Slides (deck)** filters instead of showing **All** starters. This affects discoverability because users see a filtered subset on first entry and may not realize the full catalog is available.

### Current Behavior
- ❌ Home page loads with Create and Slides filters pre-selected
- ❌ Users see only deck/slides starters by default
- ❌ Full catalog is hidden behind the default filter

### Expected Behavior
- ✅ Home page loads with All filter (no active filters)
- ✅ Users see the complete unfiltered starter catalog
- ✅ Users can narrow down by clicking filter pills

## Root Cause

`PREFERRED_DEFAULT_SELECTION` in `apps/web/src/components/plugins-home/facets.ts` was hardcoded to:
```typescript
{ category: 'create', subcategory: 'deck' }
```

This caused the filter UI to initialize with Create and Slides selected instead of the neutral All state.

## Solution

Change `PREFERRED_DEFAULT_SELECTION` to:
```typescript
{ category: null, subcategory: null }
```

This makes the home page start with no active filters, showing the full unfiltered starter catalog by default. Users can still narrow down to specific categories (Create, Import, Export, Refine, Extend) by clicking the filter pills.

## Surface area

- [x] UI / home-page starter-filter (Official starters section filter row)

## Bug fix verification

Updated 5 tests to reflect the new default selection behavior (All instead of Create > Slides):
- `apps/web/tests/components/plugins-home-facets.test.ts`: 2 tests in `resolveDefaultSelection` suite now expect `{category: null, subcategory: null}`
- `apps/web/tests/components/plugins-home-section.test.tsx`: 3 tests updated to account for All being the default (no subcategory row shown until a category is clicked)

All tests now pass ✅ (red → green coverage for the updated facet and section tests).

## Testing

Verified that:
- ✅ Home page now shows All starters by default (no filters selected)
- ✅ Filter pills work correctly when clicked
- ✅ Featured toggle still works as expected
- ✅ Search functionality remains intact
- ✅ Category and subcategory selection behavior unchanged

## Impact

- **Files changed**: 1 code file + 2 test files
- **Lines changed**: 2 lines (code) + 24 lines (tests)
- **Risk**: Low — only affects initial filter state, does not change filter behavior or catalog content
- **Backward compatibility**: Users who previously relied on the Create+Slides default can still reach it with one click

## Screenshots

### Before
Create and Slides filters pre-selected (as shown in issue #1800)

### After
All filter active by default, showing complete catalog

---

/claim