### PR TITLE
fix: wire onRenameProject through EntryShell to DesignsTab

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -221,6 +221,7 @@ interface Props {
   onOpenProject: (id: string) => void;
   onOpenLiveArtifact: (projectId: string, artifactId: string) => void;
   onDeleteProject: (id: string) => void;
+  onRenameProject: (id: string, name: string) => void;
   onChangeDefaultDesignSystem: (id: string) => void;
   onPersistComposioKey: (composio: AppConfig['composio']) => Promise<void> | void;
   onOpenSettings: (
@@ -270,6 +271,7 @@ export function EntryShell({
   onOpenProject,
   onOpenLiveArtifact,
   onDeleteProject,
+  onRenameProject,
   onChangeDefaultDesignSystem,
   onPersistComposioKey,
   onOpenSettings,
@@ -743,6 +745,7 @@ export function EntryShell({
                     onOpen={onOpenProject}
                     onOpenLiveArtifact={onOpenLiveArtifact}
                     onDelete={onDeleteProject}
+                    onRename={onRenameProject}
                   />
                 </div>
               )

--- a/apps/web/src/components/EntryView.tsx
+++ b/apps/web/src/components/EntryView.tsx
@@ -340,6 +340,7 @@ export function EntryView({
       onOpenProject={onOpenProject}
       onOpenLiveArtifact={onOpenLiveArtifact}
       onDeleteProject={onDeleteProject}
+      onRenameProject={onRenameProject}
       onChangeDefaultDesignSystem={onChangeDefaultDesignSystem}
       onPersistComposioKey={onPersistComposioKey}
       onOpenSettings={onOpenSettings}


### PR DESCRIPTION
Fixes #1790

## Problem

Project rename does not take effect in Open Design 0.8.0. After entering a new name and clicking **OK**, the project keeps its old name.

### Current Behavior
- ❌ Rename dialog accepts new name
- ❌ Clicking OK does nothing (silent no-op)
- ❌ Project keeps old name
- ❌ No error or feedback

### Expected Behavior
- ✅ Rename dialog accepts new name
- ✅ Clicking OK renames the project
- ✅ Project list reflects new name immediately

## Root Cause

The `onRenameProject` callback was **broken in the prop chain**:

```
App.tsx ──(handleRenameProject)──▶ EntryView ✅
EntryView ──(onRenameProject missing)──▶ EntryShell ❌
EntryShell ──(onRename not in Props)──▶ DesignsTab ❌
DesignsTab.commitRename() → onRename?.() → silent no-op ❌
```

**What happened:**
1. `EntryView` received `onRenameProject` from `App` ✅
2. `EntryView` never forwarded it to `EntryShell` ❌
3. `EntryShell` never received it, so couldn't pass it to `DesignsTab` ❌
4. `DesignsTab.commitRename()` called `onRename?.(id, trimmed)` → silent no-op ❌

Because the prop is typed **optional** (`onRename?:`), the missing callback caused a **silent no-op** instead of a TypeScript error.

**When it broke:**
This was introduced when `EntryShell` was added to the 0.8.0 codebase as an intermediate shell layer between `EntryView` and `DesignsTab`. The rename prop was missed during the handoff.

## Solution

Wire the callback through the missing links:

### 1. `apps/web/src/components/EntryView.tsx`
Pass `onRenameProject={onRenameProject}` to `<EntryShell>`

### 2. `apps/web/src/components/EntryShell.tsx`
- Add `onRenameProject: (id: string, name: string) => void` to Props interface
- Destructure it in function params
- Pass `onRename={onRenameProject}` to `<DesignsTab>`

Now the callback chain is complete:
```
App.tsx ──(handleRenameProject)──▶ EntryView ✅
EntryView ──(onRenameProject)──▶ EntryShell ✅
EntryShell ──(onRename)──▶ DesignsTab ✅
DesignsTab.commitRename() → onRename(id, trimmed) → success! ✅
```

## Testing

Verified that:
- ✅ Project rename dialog accepts new name
- ✅ Clicking OK successfully renames the project
- ✅ Project list reflects the new name immediately
- ✅ No console errors or warnings
- ✅ Rename validation still works (empty name rejected)

## Impact

- **Files changed**: 2 (`EntryView.tsx`, `EntryShell.tsx`)
- **Lines changed**: 4 lines (3 additions, 1 interface update)
- **Risk**: Low — only restores the missing prop forwarding, does not change any rename logic or validation
- **Backward compatibility**: 100% — fixes broken functionality, no API changes

## Related

- #1791 (no save feedback) is a downstream symptom of the same gap — once the rename fires correctly, the feedback gap can be addressed separately

---

Thanks to @lefarcen for the detailed root cause analysis in #1790!