### PR TITLE
fix(security): pin fast-uri and devalue via pnpm.overrides to resolve 3 HIGH advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,10 @@
       "better-sqlite3",
       "electron",
       "esbuild"
-    ]
+    ],
+    "overrides": {
+      "fast-uri": "3.1.2",
+      "devalue": "5.8.1"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  fast-uri: 3.1.2
+  devalue: 5.8.1
+
 importers:
 
   .:
@@ -2592,8 +2596,8 @@ packages:
     resolution: {integrity: sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==}
     engines: {node: '>=18'}
 
-  devalue@5.8.0:
-    resolution: {integrity: sha512-2zA9pFEsnp7vWBZbXF5JAgAq0fsUIt/1XPbRiAmRV3lp/2C3upzH+sADiyy66aFCihoLEsrQHxNM5w1gIDfsBg==}
+  devalue@5.8.1:
+    resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -2839,8 +2843,8 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fast-xml-builder@1.2.0:
     resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
@@ -6448,7 +6452,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6562,7 +6566,7 @@ snapshots:
       cssesc: 3.0.0
       debug: 4.4.3
       deterministic-object-hash: 2.0.2
-      devalue: 5.8.0
+      devalue: 5.8.1
       diff: 8.0.4
       dlv: 1.1.3
       dset: 3.1.4
@@ -7067,7 +7071,7 @@ snapshots:
     dependencies:
       base-64: 1.0.0
 
-  devalue@5.8.0: {}
+  devalue@5.8.1: {}
 
   devlop@1.1.0:
     dependencies:
@@ -7469,7 +7473,7 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fast-xml-builder@1.2.0:
     dependencies:


### PR DESCRIPTION
<!-- This PR addresses two of the four HIGH-severity dependency advisories flagged in #1892. -->

Refs #1892

## Why

`pnpm audit --prod --json` at the repo root currently surfaces **4 HIGH-severity advisories** on `main`:

```
high    1117870  fast-uri  <=3.1.0   path traversal via percent-encoded dots
high    1117884  fast-uri  <=3.1.1   host confusion via percent-encoded authority
high    1118938  next      >=16.0.0 <16.2.6   Middleware/Proxy bypass in App Router
high    1119005  devalue   >=5.6.3 <=5.8.0    Svelte devalue: DoS via sparse array deserialization
```

This PR resolves **three of the four** via the most surgical change possible — a `pnpm.overrides` block in the root `package.json`. All three vulnerable packages (`fast-uri` x2 + `devalue` x1) are pinned transitively (`fast-uri` reaches `apps/daemon` via `@modelcontextprotocol/sdk` → `ajv`; `devalue` reaches `apps/landing-page` via `astro`), and none has a direct dependency in any workspace manifest, so a single overrides block is the right tool: it forces the patched version into the resolved tree without bumping any workspace's declared dependency surface.

Verified with `pnpm audit --prod --json` after `pnpm install`: the three resolved HIGH advisories drop off (`fast-uri@<=3.1.0`, `fast-uri@<=3.1.1`, `devalue@>=5.6.3 <=5.8.0`). Only `next` HIGH remains.

The remaining HIGH advisory — `next@^16.2.5` (direct in `apps/web`) — is intentionally held back to keep this PR easy to revert if anything downstream catches a transitive resolution change. See #1892 for the proposed split; the Astro 5 → 6 major bump path noted in that issue is also out of scope here because the `devalue` override in this PR already neutralizes that advisory without needing the major bump.

## What users will see

Nothing user-facing changes. Wire formats, APIs, UI, and shipped JavaScript are unaffected; only the resolved transitive versions of `fast-uri` and `devalue` move up to the patched lines.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only (root `package.json` + `pnpm-lock.yaml` only)

## Validation

- `pnpm install` regenerates the lockfile with `fast-uri@>=3.1.2` and `devalue@>=5.8.1` resolved across every transitive consumer.
- `pnpm audit --prod` after the change: the two `fast-uri` HIGH advisories and the `devalue` HIGH advisory drop off. `next@^16.2.5` remains until the follow-up PR.
- `pnpm typecheck` — green across every workspace.
- `pnpm guard` — green.
- Each touched-workspace test suite I could run locally — green (contracts, sidecar, platform, sidecar-proto, registry-protocol).

## Why I'm holding the other two HIGH advisories back

- **`next@^16.2.5` → `next@^16.2.6`**: a Next.js patch bump is mechanical, but it touches `apps/web` directly, so I'd rather land it as its own PR with a focused web-test run. Filed as a follow-up in #1892.
- **`astro@^5.15.4` → `astro@^6.x`**: that's a major-version bump for `apps/landing-page`, with a real risk of breaking-change surface in content collections, view transitions, etc. The landing page deploys to Cloudflare Pages on every push to `main` (`.github/workflows/landing-page-deploy.yml`), so I don't want to land an Astro 6 path here. The `devalue` override in this PR resolves the `devalue` DoS without needing the Astro bump — it forces the patched `devalue@>=5.8.1` into Astro 5's resolved tree.

## Open question for reviewers

If you'd rather see all four advisories handled in a single consolidated PR, I'll fold the `next` patch + Astro 6 path in. The reason this PR is scoped narrowly is risk surface: the overrides change is mechanically safe (transitive resolution only), where the direct-dep bumps need more attention.
