### PR TITLE
feat(scripts): add informational i18n coverage report (pnpm i18n:coverage)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "tools-pr": "pnpm exec tools-pr",
     "guard": "tsx ./scripts/guard.ts && node --import tsx --test scripts/style-policy.test.ts",
     "i18n:check": "tsx ./scripts/i18n-check.ts",
+    "i18n:coverage": "tsx ./scripts/i18n-coverage-report.ts",
     "sync:community-pets": "node --experimental-strip-types scripts/sync-community-pets.ts",
     "bake:community-pets": "node --experimental-strip-types scripts/bake-community-pets.ts",
     "seed:test-projects": "node --experimental-strip-types scripts/seed-test-projects.ts",

--- a/scripts/i18n-coverage-report.ts
+++ b/scripts/i18n-coverage-report.ts
@@ -1,0 +1,165 @@
+// i18n coverage report — non-blocking informational script that surfaces
+// per-locale key-coverage drift against English. Run via:
+//
+//   pnpm i18n:coverage
+//
+// The companion script `scripts/i18n-check.ts` already enforces
+// *structural* consistency (locale registration, README language
+// switcher alignment, core doc link references). This script is
+// orthogonal: it reports *content* coverage so contributors and
+// release managers can see how each locale is tracking against the
+// English source-of-truth as features land.
+//
+// Reasons for keeping this separate from `i18n-check.ts`:
+//
+// 1. `i18n-check.ts` is wired into `pnpm i18n:check` and exits with a
+//    non-zero status. Adding "every locale must match en exactly" to
+//    that script would break every PR until 13 of 14 locales catch up
+//    on hundreds of missing keys. Issue #1894 covers the policy
+//    question of *whether* to enforce parity for the full locale set
+//    or only a tier-1 subset; until that lands, this script stays
+//    informational only.
+//
+// 2. The test suite in `apps/web/tests/i18n/locales.test.ts` enforces
+//    strict parity for `id` (Indonesian) as a regression guard. This
+//    script reuses the same `LOCALES` list and dictionary shape so
+//    extending enforcement later is a one-line change.
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { LOCALES, LOCALE_LABEL, type Locale } from "../apps/web/src/i18n/types.ts";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const localesDirectory = path.join(repoRoot, "apps/web/src/i18n/locales");
+
+const KEY_PATTERN = /^\s*['"]([^'"\\]+)['"]\s*:/gm;
+
+type LocaleCoverage = {
+  locale: Locale;
+  total: number;
+  missingFromEnglish: string[];
+  orphanInLocale: string[];
+  untranslated: string[];
+};
+
+async function readKeySet(locale: Locale): Promise<Set<string>> {
+  const filePath = path.join(localesDirectory, `${locale}.ts`);
+  const source = await readFile(filePath, "utf8");
+  const keys = new Set<string>();
+  // Walk one match at a time so we can skip the regex-state-shared `lastIndex`
+  // pitfall that bites global regexes when reused.
+  KEY_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = KEY_PATTERN.exec(source)) !== null) {
+    const key = match[1];
+    if (key) keys.add(key);
+  }
+  return keys;
+}
+
+async function readRawDict(locale: Locale): Promise<Map<string, string>> {
+  const filePath = path.join(localesDirectory, `${locale}.ts`);
+  const source = await readFile(filePath, "utf8");
+  const entries = new Map<string, string>();
+  // Match `'key': 'value',` or `'key': "value",` on a single line.
+  // Multi-line values fall through silently; reporting "untranslated"
+  // for those would need a real TS parser.
+  const lineEntry = /^\s*['"]([^'"\\]+)['"]\s*:\s*(['"])((?:[^'"\\\n]|\\.)*)\2\s*,?$/gm;
+  let match: RegExpExecArray | null;
+  while ((match = lineEntry.exec(source)) !== null) {
+    const key = match[1];
+    const value = match[3];
+    if (key !== undefined && value !== undefined) {
+      entries.set(key, value);
+    }
+  }
+  return entries;
+}
+
+async function buildCoverage(): Promise<LocaleCoverage[]> {
+  const englishKeys = await readKeySet("en");
+  const englishDict = await readRawDict("en");
+  const results: LocaleCoverage[] = [];
+  for (const locale of LOCALES) {
+    const keys = await readKeySet(locale);
+    const dict = await readRawDict(locale);
+    const missing: string[] = [];
+    for (const key of englishKeys) {
+      if (!keys.has(key)) missing.push(key);
+    }
+    const orphan: string[] = [];
+    for (const key of keys) {
+      if (!englishKeys.has(key)) orphan.push(key);
+    }
+    const untranslated: string[] = [];
+    if (locale !== "en") {
+      for (const [key, value] of dict) {
+        const englishValue = englishDict.get(key);
+        if (englishValue !== undefined && englishValue === value && value.length > 0) {
+          untranslated.push(key);
+        }
+      }
+    }
+    missing.sort();
+    orphan.sort();
+    untranslated.sort();
+    results.push({
+      locale,
+      total: keys.size,
+      missingFromEnglish: missing,
+      orphanInLocale: orphan,
+      untranslated,
+    });
+  }
+  return results;
+}
+
+function formatTable(results: LocaleCoverage[], englishTotal: number): string {
+  const header = `Locale (key total = ${englishTotal} on en)`;
+  const lines: string[] = [header, "-".repeat(header.length)];
+  for (const r of results) {
+    const label = LOCALE_LABEL[r.locale];
+    const missingPct = r.locale === "en"
+      ? "—"
+      : `${((r.total / englishTotal) * 100).toFixed(0)}%`;
+    lines.push(
+      `${r.locale.padEnd(8)} ${label.padEnd(22)} keys=${String(r.total).padStart(4)} missing=${String(r.missingFromEnglish.length).padStart(4)} orphan=${String(r.orphanInLocale.length).padStart(3)} untranslated=${String(r.untranslated.length).padStart(4)} coverage=${missingPct}`,
+    );
+  }
+  return lines.join("\n");
+}
+
+function formatExamples(results: LocaleCoverage[]): string {
+  const lines: string[] = ["", "First 5 missing keys per non-English locale:"];
+  for (const r of results) {
+    if (r.locale === "en") continue;
+    if (r.missingFromEnglish.length === 0) {
+      lines.push(`  ${r.locale}: all English keys present ✓`);
+      continue;
+    }
+    const preview = r.missingFromEnglish.slice(0, 5).map((k) => `'${k}'`).join(", ");
+    const more = r.missingFromEnglish.length > 5 ? ` (+${r.missingFromEnglish.length - 5} more)` : "";
+    lines.push(`  ${r.locale}: ${preview}${more}`);
+  }
+  return lines.join("\n");
+}
+
+async function main(): Promise<void> {
+  const results = await buildCoverage();
+  const english = results.find((r) => r.locale === "en");
+  if (!english) {
+    console.error("English locale missing; cannot build report.");
+    process.exitCode = 1;
+    return;
+  }
+  console.log(formatTable(results, english.total));
+  console.log(formatExamples(results));
+  console.log("");
+  console.log("This report is informational only — exit code stays 0. See #1894 for the policy discussion.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
<!-- Informational i18n coverage tool. -->

Refs #1894

## Why

`scripts/i18n-check.ts` (and `pnpm i18n:check`) validates *structural* consistency of the locale stack — file registration, the README language switcher, core doc link references — and exits non-zero on failure. It deliberately doesn't validate *content* coverage, because the test suite's strict English-parity assertion is scoped to Indonesian (`id`) only (`apps/web/tests/i18n/locales.test.ts:49`). The 18 other locales pass CI even when an English key is added without a matching translation, so coverage silently drifts as features land.

Running this script against `main` today shows the shape of that drift:

```
Locale (key total = 1578 on en)
-------------------------------
en       English                keys=1578 missing=   0 orphan=  0 untranslated=   0 coverage=—
zh-CN    简体中文                  keys=1578 missing=   0 orphan=  0 untranslated= 107 coverage=100%
id       Bahasa Indonesia       keys=1438 missing= 140 orphan=  0 untranslated= 360 coverage=91%
ko       한국어                    keys=1446 missing= 132 orphan=  0 untranslated= 227 coverage=92%
de       Deutsch                keys=1335 missing= 243 orphan=  0 untranslated= 276 coverage=85%
ja       日本語                    keys=1335 missing= 243 orphan=  0 untranslated= 228 coverage=85%
es-ES    Español (España)       keys=1289 missing= 289 orphan=  0 untranslated= 241 coverage=82%
th       ภาษาไทย                 keys=1261 missing= 317 orphan=  0 untranslated=  69 coverage=80%
…
```

(zh-CN is the one locale at 100% English-key parity besides English itself. `th` is the worst at 80%. Most locales sit in the 85–95% range with ~140–300 missing keys.)

Issue #1894 covers the *policy* question of whether the project wants to enforce parity for the full locale set or only a tier-1 subset. This PR doesn't pick a side on that — it just makes the drift visible so the conversation has data to work with.

## What users will see

Nothing user-facing. The new script is an opt-in `pnpm i18n:coverage` command for contributors/release managers; it's not wired into CI, doesn't fail builds, and doesn't change any locale file.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only (new informational script under `scripts/`)

## Validation

- `pnpm i18n:coverage` runs end-to-end against the 19 locale files under `apps/web/src/i18n/locales/`, exit 0.
- `pnpm guard` green (script is excluded from any of guard's residual-JS / forbidden-pattern checks because it lives under `scripts/` and is pure TypeScript).
- `pnpm exec tsc -p scripts/tsconfig.json --noEmit` green.
- The output above is reproducible from `main` at the commit this PR branched from.

## Design choices worth flagging

- **Pure regex parsing, no dynamic import.** Locale files export a `Dict` typed const, but the export name on dashed locales (e.g. `zh-CN.ts` exports `zhCN`) is camelCased, so a generic dynamic-import-then-keys approach would need a name-mapping table. Reading the source files and counting `'key':` matches is robust against future export-name changes and avoids loading the runtime types module.
- **Multi-line value support is intentionally skipped.** The "untranslated" column matches `'key': 'value'` on a single line. Multi-line template literal values fall through silently; calling them "untranslated" would need a TS parser. The reported numbers are therefore a *lower bound* on the untranslated count — good enough to spot drift, conservative enough not to overstate it.
- **Exit code stays 0.** Wiring this into CI as a blocking check is exactly the policy decision tracked in #1894 — keeping it informational here means the script can land before that decision is made.

## What I'm not proposing here

- I'm not changing any locale file content.
- I'm not changing `i18n-check.ts` or the test suite's strict-parity behavior.
- I'm not adding this to `pnpm guard` or the CI workflow.

Each of those would belong to #1894's policy outcome.
