### PR TITLE
docs(landing-page): fix dead skill references in AGENTS.md

### DIFF
--- a/apps/landing-page/AGENTS.md
+++ b/apps/landing-page/AGENTS.md
@@ -12,10 +12,10 @@ principle, and live-artifact template in the repo root.
 
 Tightly coupled with:
 
-- Skill: `skills/open-design-landing/` — agent workflow + the source-of-truth
+- Design template: `design-templates/open-design-landing/` — agent workflow + the source-of-truth
   `example.html` known-good rendering for the homepage hero.
 - Design system: `design-systems/atelier-zero/DESIGN.md` — token spec.
-- Image assets: `skills/open-design-landing/assets/*.png` are uploaded to
+- Image assets: `design-templates/open-design-landing/assets/*.png` are uploaded to
   Cloudflare R2 (`open-design-static`) and served through
   `static.open-design.ai` with Image Resizing (`format=auto`). Do not
   commit local mirrored PNGs into `apps/landing-page/public/assets/`.
@@ -44,7 +44,7 @@ Tightly coupled with:
   CDN-ready HTML/CSS plus a small inline enhancement script;
   no React runtime ships to browsers.
 - All styles split between `app/globals.css` (homepage, kept in
-  lockstep with `skills/open-design-landing/example.html`) and
+  lockstep with `design-templates/open-design-landing/example.html`) and
   `app/sub-pages.css` (catalog/facet/detail pages).
 - All page imagery is referenced through `app/image-assets.ts`, which
   builds Cloudflare Image Resizing URLs for the R2 originals.
@@ -81,7 +81,7 @@ Tightly coupled with:
   labs pills, selected-work fractions, footer Library, and
   `<meta name="description">` all derive from the same call so a
   fresh content edit can never publish contradictory totals.
-- When the canonical `skills/open-design-landing/example.html`
+- When the canonical `design-templates/open-design-landing/example.html`
   changes, the corresponding section JSX in `app/page.tsx` and rules
   in `app/globals.css` must be updated to match. Those two files are
   kept in lockstep; the rest of the landing-page sources are not.
@@ -128,6 +128,6 @@ pnpm --filter @open-design/landing-page build        # static export → out/
   and route entries that match the existing index/detail/facet pattern.
 - New section added to the canonical landing page → port it into
   `app/page.tsx` and `app/globals.css` keeping lockstep with
-  `skills/open-design-landing/example.html`.
+  `design-templates/open-design-landing/example.html`.
 - Brand re-keying for a non-Open-Design tenant → fork the app, update
   copy, swap PNGs. Do not parameterize this app for multi-tenancy.


### PR DESCRIPTION
Fixes #1891

## Why

PR #955 moved `skills/open-design-landing/` to `design-templates/open-design-landing/` during the skills/design-templates split, but `apps/landing-page/AGENTS.md` was not updated. This leaves 5 references pointing at a path that no longer exists, breaking the lockstep contract described in the file and sending contributors to a dead path.

## What users will see

No user-facing change. This is an internal documentation fix for contributors and agents following `AGENTS.md`.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only

## Validation

- Confirmed `skills/open-design-landing/` does not exist on `main`
- Confirmed `design-templates/open-design-landing/` exists with the full file set (`example.html`, `SKILL.md`, `assets/`, `scripts/`, etc.)
- Verified via `git log` that PR #955 (`b5eb8c16`) was the commit that moved the directory
- All 5 references updated from `skills/open-design-landing/` to `design-templates/open-design-landing/`
- First reference label corrected from `Skill` to `Design template`