### PR TITLE
fix(cli): plugin publish reads manifest version when stored row is the 0.0.0 sentinel

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -3013,9 +3013,25 @@ publish from a frozen run snapshot rather than the live installed copy.`);
     const resp = await fetch(`${base}/api/plugins/${encodeURIComponent(id)}`);
     if (resp.ok) {
       const row = await resp.json();
+      // The daemon's plugin row carries a stored `version` plus the full
+      // manifest. For project-local plugins (`generated-plugin/`, snapshots,
+      // freshly imported folders) the stored `version` is `'0.0.0'` until
+      // the registry handshake runs, but the manifest's `version` is the
+      // real value the author wrote. Mirror `plugins/marketplaces.ts:298,328`
+      // and prefer the manifest version when the stored row reads as the
+      // pre-handshake sentinel. Closes #1765.
+      const storedVersion = typeof row.version === 'string' && row.version.length > 0
+        ? row.version
+        : null;
+      const manifestVersion = typeof row.manifest?.version === 'string' && row.manifest.version.length > 0
+        ? row.manifest.version
+        : null;
+      const resolvedVersion = (storedVersion && storedVersion !== '0.0.0')
+        ? storedVersion
+        : (manifestVersion ?? storedVersion ?? '0.0.0');
       meta = {
         pluginId:          row.id ?? id,
-        pluginVersion:     row.version ?? '0.0.0',
+        pluginVersion:     resolvedVersion,
         ...(row.title              ? { pluginTitle: row.title }                       : {}),
         ...(row.manifest?.description ? { pluginDescription: row.manifest.description } : {}),
       };


### PR DESCRIPTION
Closes #1765

## Why

`od plugin publish --to open-design` builds the registry-submission body from the daemon's `/api/plugins/:id` row. The row carries a stored `version` plus the full manifest. For **project-local plugins** — `generated-plugin/`, snapshots, freshly imported folders — the stored `version` reads as `'0.0.0'` until the registry handshake stamps the real version. The manifest's `version` is the author's real value the whole time.

Before this patch, the publish flow consumed `row.version` directly and printed `version: 0.0.0` into the registry submission body even when the plugin's `open-design.json` declared `0.1.0` or any other non-sentinel version. From the user side this makes the Open Design PR flow look broken or stuck.

## The change

`apps/daemon/src/cli.ts`, one site (`runPluginPublish`): replace

```ts
pluginVersion: row.version ?? '0.0.0',
```

with a manifest-aware fallback chain that mirrors `apps/daemon/src/plugins/marketplaces.ts:298,328`:

1. `row.version`, when it exists and isn't `'0.0.0'`
2. `row.manifest.version`, when it exists and is non-empty
3. `row.version` (even if `'0.0.0'`) — preserves today's behavior for plugins that genuinely have no manifest data
4. `'0.0.0'` literal, when nothing else is available

## Why this is safe

- The fallback chain is conservative: it never substitutes a higher version the author didn't already declare somewhere — it just prefers the manifest over the stored sentinel.
- The publish flow itself doesn't mutate any catalog; it just renders the PR body the author copies into the upstream review flow. A wrong version in that body is the only visible symptom, and that's exactly what this PR fixes.
- The check is shape-defensive: both `row.version` and `row.manifest.version` are tested for `typeof === 'string'` and non-empty before being used, so a daemon variant that omits one or the other still falls through gracefully.

## What users will see

`od plugin publish <generated-local-plugin> --to open-design` now prints `version: 0.1.0` (or whatever the manifest declares) into the registry submission body instead of the misleading `version: 0.0.0`. No other user-visible change.

## Surface area

- [x] **CLI / env var** — behavior of an existing `od plugin publish --to open-design` command (no new flag)

## Bug fix verification

Per AGENTS.md → "Bug follow-up workflow":

- The bug is in CLI glue between the daemon HTTP response and the publish builder, which is a thin layer with no test today (`apps/daemon/tests/plugins-publish.test.ts` covers the publish-builder primitives, not the CLI glue). Writing an end-to-end CLI test would need a running daemon harness — out of scope for this small fix.
- Confirmed manually by reading `apps/daemon/src/plugins/marketplaces.ts:298` and `:328` — both already use the same `row.version === '0.0.0' ? manifest.version : row.version` pattern for the marketplace-side response. This PR brings the publish-side glue in line with that existing pattern, so the inconsistency itself is the diagnostic.
- `pnpm --filter @open-design/daemon test -- tests/plugins-publish.test.ts` → green (the existing publish-builder primitives unaffected).

## Validation

- `pnpm --filter @open-design/daemon typecheck` → green
- `pnpm --filter @open-design/daemon test -- tests/plugins-publish.test.ts` → green
- 1 file changed, 17 insertions(+), 1 deletion(-)