### PR TITLE
fix(ci): only run docker image workflow for release tags

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,18 +3,11 @@ name: Docker image
 # Phase 5 / spec §15.5 — multi-arch image builds.
 #
 # Pushes to ghcr.io on:
-#   - main branch     → ghcr.io/<owner>/od:edge + :sha-<short>
-#   - tag (v*)        → ghcr.io/<owner>/od:<tag> + :latest
-#
-# Pull requests build the image but do not push (smoke test only).
+#   - tag (v*.*.*)    → ghcr.io/<owner>/od:<tag> + :latest
 
 on:
   push:
-    branches: [main]
     tags: ['v*.*.*']
-  pull_request:
-    branches: [main]
-  workflow_dispatch:
 
 jobs:
   build-and-push:


### PR DESCRIPTION
## Why

I hit the Docker image workflow running on ordinary PRs even though Docker is not an officially supported surface for this repo. The current trigger policy spends CI time on a non-primary delivery path and creates noise for unrelated changes.

## What users will see

Maintainers will only see the Docker image workflow run for version tag pushes matching `v*.*.*`. Regular PRs, branch pushes, and manual dispatches will no longer trigger this workflow.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots


## Bug fix verification

- Not a user-facing bug fix; this is a CI trigger policy change.

## Validation

- Not run (workflow trigger change only)