### PR TITLE
fix(ci): avoid duplicate nix-check runs on PR branches

### DIFF
--- a/.github/workflows/nix-check.yml
+++ b/.github/workflows/nix-check.yml
@@ -1,6 +1,29 @@
 name: nix-check
 
 on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.mdx'
+      - '**/*.txt'
+      - LICENSE
+      - .gitignore
+      - .editorconfig
+      - .vscode/**
+      - .idea/**
+      - docs/**
+      - assets/**
+      - '**/*.png'
+      - '**/*.jpg'
+      - '**/*.jpeg'
+      - '**/*.gif'
+      - '**/*.svg'
+      - '**/*.webp'
+      - .github/ISSUE_TEMPLATE/**
+      - .github/PULL_REQUEST_TEMPLATE.md
+      - .github/CODEOWNERS
   pull_request:
     paths-ignore:
       - '**/*.md'

--- a/.github/workflows/nix-check.yml
+++ b/.github/workflows/nix-check.yml
@@ -1,27 +1,6 @@
 name: nix-check
 
 on:
-  push:
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.mdx'
-      - '**/*.txt'
-      - LICENSE
-      - .gitignore
-      - .editorconfig
-      - .vscode/**
-      - .idea/**
-      - docs/**
-      - assets/**
-      - '**/*.png'
-      - '**/*.jpg'
-      - '**/*.jpeg'
-      - '**/*.gif'
-      - '**/*.svg'
-      - '**/*.webp'
-      - .github/ISSUE_TEMPLATE/**
-      - .github/PULL_REQUEST_TEMPLATE.md
-      - .github/CODEOWNERS
   pull_request:
     paths-ignore:
       - '**/*.md'


### PR DESCRIPTION
## Why

I hit duplicate `nix-check` runs from both `push` and `pull_request` on ordinary PR branches. This spends CI time twice on the same validation without adding signal.

## What users will see

Maintainers will see `nix-check` run for pull requests, but not again for the same branch's ordinary push event.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots


## Bug fix verification

- Not a user-facing bug fix; this is a CI trigger policy change.

## Validation

- Not run (workflow trigger change only)