### PR TITLE
fix(desktop): export PDF saves to a file instead of the OS print dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed: desktop "Export PDF" now opens a direct "Save as PDF" file dialog and writes the PDF to disk, instead of opening the macOS system print dialog. Fixes [#1774](https://github.com/nexu-io/open-design/issues/1774).
 - Docs: clarify that packaged macOS support includes a verified Intel x64 ZIP path on Monterey, and document the Finder `PATH` caveat for packaged CLI detection. Fixes [#327](https://github.com/nexu-io/open-design/issues/327).
 
 ## [0.7.0] - 2026-05-12

--- a/apps/desktop/src/main/pdf-export.ts
+++ b/apps/desktop/src/main/pdf-export.ts
@@ -84,6 +84,142 @@ export async function exportPdfFromHtml(input: DesktopExportPdfInput): Promise<D
   }
 }
 
+/**
+ * Default Save-dialog filename for a print-ready document. The
+ * renderer's `printPdf()` bridge sends only the document and a nonce —
+ * no title — but `buildSandboxedPreviewDocument` stamps the export
+ * title into the wrapper's <title>, so we recover it from there.
+ * Falls back to `artifact.pdf` when no usable title is present.
+ */
+export function pdfFilenameFromDocument(html: string): string {
+  const match = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(html);
+  const title = match ? decodeBasicEntities(match[1]).trim() : "";
+  return `${safeFilename(title, "artifact")}.pdf`;
+}
+
+/**
+ * Electron surface consumed by {@link savePrintReadyDocumentAsPdf},
+ * declared structurally — like `WindowFullscreenSurface` in runtime.ts
+ * — so the save-as-PDF flow is unit-testable with plain stubs instead
+ * of a real `dialog` + `BrowserWindow`.
+ *
+ * There is deliberately no `print()` here. Issue #1774's bug was the
+ * `od:print-pdf` IPC handler reaching for `webContents.print()`, which
+ * opens the printer-first OS dialog; `printToPdf()` is the only render
+ * path this surface offers, so that regression cannot be reintroduced.
+ */
+export type PrintReadyPdfTarget = {
+  /** Native "Save PDF" dialog. Resolves the chosen path, or null on cancel. */
+  promptSavePath: (defaultFilename: string) => Promise<string | null>;
+  /** Load the print-ready document into a hidden render surface. */
+  load: (html: string) => Promise<void>;
+  /** Resolve once the document signals print-readiness for `nonce`. */
+  waitUntilReady: (nonce: string) => Promise<void>;
+  /** Render the loaded document to PDF bytes (Electron printToPDF). */
+  printToPdf: () => Promise<Uint8Array>;
+  /** Write the PDF bytes to `filePath`. */
+  write: (filePath: string, data: Uint8Array) => Promise<void>;
+  /** Tear down the render surface. Always invoked, including on cancel/error. */
+  dispose: () => void;
+};
+
+/**
+ * Direct Save-as-PDF flow for the renderer's
+ * `window.__odDesktop.printPdf()` bridge (the `od:print-pdf` IPC
+ * handler).
+ *
+ * Unlike {@link exportPdfFromHtml}, the document handed over here is
+ * already a fully-wrapped sandboxed preview carrying the print-ready
+ * handshake (built by apps/web/src/runtime/exports.ts#exportAsPdf), so
+ * this flow does not build the printable document — it loads it as-is,
+ * waits for the handshake, and renders straight to the file the user
+ * picked.
+ *
+ * Invariant (issue #1774): PDF export shows the native Save dialog and
+ * writes the file to disk. It never opens the printer-first OS print
+ * dialog — `webContents.print()` is not on the {@link PrintReadyPdfTarget}
+ * surface at all. A canceled Save dialog is a successful no-op.
+ */
+export async function savePrintReadyDocumentAsPdf(
+  html: string,
+  nonce: string,
+  target: PrintReadyPdfTarget,
+): Promise<DesktopExportPdfResult> {
+  const savePath = await target.promptSavePath(pdfFilenameFromDocument(html));
+  if (savePath == null) {
+    target.dispose();
+    return { canceled: true, ok: true };
+  }
+  try {
+    await target.load(html);
+    await target.waitUntilReady(nonce);
+    const pdf = await target.printToPdf();
+    await target.write(savePath, pdf);
+    return { ok: true, path: savePath };
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : String(error), ok: false };
+  } finally {
+    target.dispose();
+  }
+}
+
+/**
+ * Production {@link PrintReadyPdfTarget} backed by a real Electron
+ * `dialog` and a hidden `BrowserWindow`. The render window is created
+ * lazily in `load`, so a canceled Save dialog never spins one up.
+ */
+export function createElectronPdfTarget(): PrintReadyPdfTarget {
+  let window: BrowserWindow | null = null;
+  return {
+    async promptSavePath(defaultFilename) {
+      const save = await dialog.showSaveDialog({
+        defaultPath: defaultFilename,
+        filters: [
+          { name: "PDF", extensions: ["pdf"] },
+          { name: "All Files", extensions: ["*"] },
+        ],
+        title: "Save PDF",
+      });
+      return save.canceled || !save.filePath ? null : save.filePath;
+    },
+    async load(html) {
+      const printWindow = new BrowserWindow({
+        height: 600,
+        show: false,
+        webPreferences: {
+          contextIsolation: true,
+          nodeIntegration: false,
+          sandbox: true,
+        },
+        width: 800,
+      });
+      window = printWindow;
+      printWindow.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+      printWindow.webContents.on("will-navigate", (event) => event.preventDefault());
+      await printWindow.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(html)}`);
+    },
+    async waitUntilReady(nonce) {
+      if (!window) throw new Error("PDF render window has not been loaded");
+      await waitForPrintReadyHandshake(window.webContents, nonce);
+    },
+    async printToPdf() {
+      if (!window) throw new Error("PDF render window has not been loaded");
+      // printToPDF() is the dialogless render path: the "Save as PDF"
+      // equivalent of webContents.print() without the printer-first OS
+      // dialog (issue #1774). printBackground mirrors the option the
+      // pre-#1774 print() call passed.
+      return window.webContents.printToPDF({ printBackground: true });
+    },
+    async write(filePath, data) {
+      await writeFile(filePath, data);
+    },
+    dispose() {
+      if (window && !window.isDestroyed()) window.destroy();
+      window = null;
+    },
+  };
+}
+
 function buildPrintableDocument(input: DesktopExportPdfInput): string {
   const source = injectBaseHref(input.html, input.baseHref);
   const withTitle = injectTitle(source, input.title);
@@ -200,4 +336,34 @@ function escapeHtmlText(value: string): string {
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
+}
+
+// Named entities the export pipeline can escape into a <title>
+// (escapeHtmlAttribute / escapeHtmlText emit `& " < >`). `&amp;` is
+// decoded last so a doubly-escaped `&amp;lt;` does not collapse to `<`.
+const BASIC_HTML_ENTITIES: ReadonlyArray<readonly [RegExp, string]> = [
+  [/&lt;/gi, "<"],
+  [/&gt;/gi, ">"],
+  [/&quot;/gi, '"'],
+  [/&#39;/g, "'"],
+  [/&amp;/gi, "&"],
+];
+
+function decodeBasicEntities(value: string): string {
+  return BASIC_HTML_ENTITIES.reduce(
+    (acc, [pattern, char]) => acc.replace(pattern, char),
+    value,
+  );
+}
+
+// Slugify a title into a filesystem-safe filename stem. Mirrors the
+// `safeFilename` helpers in apps/daemon/src/pdf-export.ts and
+// apps/web/src/runtime/exports.ts so the desktop Save dialog's default
+// filename matches the daemon-backed export path.
+function safeFilename(name: string, fallback: string): string {
+  const slug = (name || fallback)
+    .replace(/[^\w.\-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60);
+  return slug || fallback;
 }

--- a/apps/desktop/src/main/pdf-export.ts
+++ b/apps/desktop/src/main/pdf-export.ts
@@ -8,6 +8,17 @@ type PageSize = { height: number; width: number };
 const DECK_PAGE_SIZE: PageSize = { width: 13.333333, height: 7.5 };
 const MAX_PAGE_INCHES = 200;
 
+export type PrintReadyPdfOptions = {
+  deck?: boolean;
+};
+
+type PrintToPdfOptions = {
+  margins: { bottom: number; left: number; right: number; top: number };
+  pageSize: PageSize;
+  preferCSSPageSize: boolean;
+  printBackground: boolean;
+};
+
 const DECK_PRINT_CSS = `
 @media print {
   @page { size: 1920px 1080px; margin: 0; }
@@ -69,12 +80,7 @@ export async function exportPdfFromHtml(input: DesktopExportPdfInput): Promise<D
     await window.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(buildPrintableDocument(input))}`);
     await waitForPrintableContent(window);
     const pageSize = input.deck ? DECK_PAGE_SIZE : await inferPageSize(window);
-    const pdf = await window.webContents.printToPDF({
-      margins: { bottom: 0, left: 0, right: 0, top: 0 },
-      pageSize,
-      preferCSSPageSize: true,
-      printBackground: true,
-    });
+    const pdf = await window.webContents.printToPDF(printToPdfOptions(pageSize));
     await writeFile(save.filePath, pdf);
     return { ok: true, path: save.filePath };
   } catch (error) {
@@ -86,9 +92,9 @@ export async function exportPdfFromHtml(input: DesktopExportPdfInput): Promise<D
 
 /**
  * Default Save-dialog filename for a print-ready document. The
- * renderer's `printPdf()` bridge sends only the document and a nonce —
- * no title — but `buildSandboxedPreviewDocument` stamps the export
- * title into the wrapper's <title>, so we recover it from there.
+ * renderer's `printPdf()` bridge sends the document, nonce, and print
+ * options — no title — but `buildSandboxedPreviewDocument` stamps the
+ * export title into the wrapper's <title>, so we recover it from there.
  * Falls back to `artifact.pdf` when no usable title is present.
  */
 export function pdfFilenameFromDocument(html: string): string {
@@ -112,11 +118,13 @@ export type PrintReadyPdfTarget = {
   /** Native "Save PDF" dialog. Resolves the chosen path, or null on cancel. */
   promptSavePath: (defaultFilename: string) => Promise<string | null>;
   /** Load the print-ready document into a hidden render surface. */
-  load: (html: string) => Promise<void>;
+  load: (html: string, options: PrintReadyPdfOptions) => Promise<void>;
   /** Resolve once the document signals print-readiness for `nonce`. */
   waitUntilReady: (nonce: string) => Promise<void>;
+  /** Measure non-deck content so dialogless PDFs do not fall back to Letter. */
+  measurePageSize: () => Promise<PageSize>;
   /** Render the loaded document to PDF bytes (Electron printToPDF). */
-  printToPdf: () => Promise<Uint8Array>;
+  printToPdf: (options: PrintToPdfOptions) => Promise<Uint8Array>;
   /** Write the PDF bytes to `filePath`. */
   write: (filePath: string, data: Uint8Array) => Promise<void>;
   /** Tear down the render surface. Always invoked, including on cancel/error. */
@@ -144,6 +152,7 @@ export async function savePrintReadyDocumentAsPdf(
   html: string,
   nonce: string,
   target: PrintReadyPdfTarget,
+  options: PrintReadyPdfOptions = {},
 ): Promise<DesktopExportPdfResult> {
   const savePath = await target.promptSavePath(pdfFilenameFromDocument(html));
   if (savePath == null) {
@@ -151,9 +160,10 @@ export async function savePrintReadyDocumentAsPdf(
     return { canceled: true, ok: true };
   }
   try {
-    await target.load(html);
+    await target.load(html, options);
     await target.waitUntilReady(nonce);
-    const pdf = await target.printToPdf();
+    const pageSize = options.deck ? DECK_PAGE_SIZE : await target.measurePageSize();
+    const pdf = await target.printToPdf(printToPdfOptions(pageSize));
     await target.write(savePath, pdf);
     return { ok: true, path: savePath };
   } catch (error) {
@@ -182,16 +192,16 @@ export function createElectronPdfTarget(): PrintReadyPdfTarget {
       });
       return save.canceled || !save.filePath ? null : save.filePath;
     },
-    async load(html) {
+    async load(html, options) {
       const printWindow = new BrowserWindow({
-        height: 600,
+        height: options.deck ? 1080 : 900,
         show: false,
         webPreferences: {
           contextIsolation: true,
           nodeIntegration: false,
           sandbox: true,
         },
-        width: 800,
+        width: options.deck ? 1920 : 1440,
       });
       window = printWindow;
       printWindow.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
@@ -202,13 +212,16 @@ export function createElectronPdfTarget(): PrintReadyPdfTarget {
       if (!window) throw new Error("PDF render window has not been loaded");
       await waitForPrintReadyHandshake(window.webContents, nonce);
     },
-    async printToPdf() {
+    async measurePageSize() {
+      if (!window) throw new Error("PDF render window has not been loaded");
+      return inferPageSize(window);
+    },
+    async printToPdf(options) {
       if (!window) throw new Error("PDF render window has not been loaded");
       // printToPDF() is the dialogless render path: the "Save as PDF"
       // equivalent of webContents.print() without the printer-first OS
-      // dialog (issue #1774). printBackground mirrors the option the
-      // pre-#1774 print() call passed.
-      return window.webContents.printToPDF({ printBackground: true });
+      // dialog (issue #1774).
+      return window.webContents.printToPDF(options);
     },
     async write(filePath, data) {
       await writeFile(filePath, data);
@@ -217,6 +230,15 @@ export function createElectronPdfTarget(): PrintReadyPdfTarget {
       if (window && !window.isDestroyed()) window.destroy();
       window = null;
     },
+  };
+}
+
+function printToPdfOptions(pageSize: PageSize): PrintToPdfOptions {
+  return {
+    margins: { bottom: 0, left: 0, right: 0, top: 0 },
+    pageSize,
+    preferCSSPageSize: true,
+    printBackground: true,
   };
 }
 

--- a/apps/desktop/src/main/preload.cts
+++ b/apps/desktop/src/main/preload.cts
@@ -1,5 +1,9 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
+type PrintPdfOptions = {
+  deck?: boolean;
+};
+
 // PR #974 trust boundary. The renderer no longer receives a raw
 // filesystem path from the main process: `pickFolder` was deleted from
 // this bridge and replaced with `pickAndImport`, which shows the
@@ -30,6 +34,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
 });
 
 contextBridge.exposeInMainWorld('__odDesktop', {
-  printPdf: (html: string, nonce?: string) => ipcRenderer.invoke('od:print-pdf', html, nonce),
+  printPdf: (html: string, nonce?: string, options?: PrintPdfOptions) =>
+    ipcRenderer.invoke('od:print-pdf', html, nonce, options ?? null),
   isDesktop: true,
 });

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -7,6 +7,7 @@ import { BrowserWindow, dialog, ipcMain, shell } from "electron";
 import type { DesktopExportPdfInput, DesktopExportPdfResult } from "@open-design/sidecar-proto";
 
 import { createElectronPdfTarget, exportPdfFromHtml, savePrintReadyDocumentAsPdf } from "./pdf-export.js";
+import type { PrintReadyPdfOptions } from "./pdf-export.js";
 
 /**
  * Result of validating a candidate path before exposing it to a
@@ -716,6 +717,18 @@ function attachDownloadSaveAsDialog(window: BrowserWindow): void {
   });
 }
 
+function parsePrintReadyPdfOptions(value: unknown): PrintReadyPdfOptions {
+  if (value == null) return {};
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Invalid print payload: expected options object");
+  }
+  const deck = (value as { deck?: unknown }).deck;
+  if (deck !== undefined && typeof deck !== "boolean") {
+    throw new Error("Invalid print payload: expected deck option to be boolean");
+  }
+  return deck === true ? { deck: true } : {};
+}
+
 export async function createDesktopRuntime(options: DesktopRuntimeOptions): Promise<DesktopRuntime> {
   const preloadPath = join(dirname(fileURLToPath(import.meta.url)), "preload.cjs");
 
@@ -871,11 +884,12 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
   attachDownloadSaveAsDialog(window);
 
   ipcMain.removeHandler('od:print-pdf');
-  ipcMain.handle('od:print-pdf', async (_event, html: unknown, nonce: unknown): Promise<void> => {
+  ipcMain.handle('od:print-pdf', async (_event, html: unknown, nonce: unknown, options: unknown): Promise<void> => {
     if (typeof html !== 'string') {
       throw new Error('Invalid print payload: expected HTML string');
     }
     const printNonce = typeof nonce === 'string' ? nonce : '';
+    const printOptions = parsePrintReadyPdfOptions(options);
     // Issue #1774: the renderer's `printPdf()` bridge runs the direct
     // Save-as-PDF flow (showSaveDialog -> printToPDF -> write), never
     // `webContents.print()` — the printer-first OS dialog. The renderer
@@ -883,7 +897,12 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
     // rejection: it shows a "Print failed" alert. A resolved call —
     // including a user-canceled Save dialog — is silent, matching the
     // pre-#1774 behavior where canceling the OS dialog was a no-op.
-    const result = await savePrintReadyDocumentAsPdf(html, printNonce, createElectronPdfTarget());
+    const result = await savePrintReadyDocumentAsPdf(
+      html,
+      printNonce,
+      createElectronPdfTarget(),
+      printOptions,
+    );
     if (!result.ok) {
       throw new Error(result.error ?? 'PDF export failed');
     }

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 import { BrowserWindow, dialog, ipcMain, shell } from "electron";
 import type { DesktopExportPdfInput, DesktopExportPdfResult } from "@open-design/sidecar-proto";
 
-import { exportPdfFromHtml, waitForPrintReadyHandshake } from "./pdf-export.js";
+import { createElectronPdfTarget, exportPdfFromHtml, savePrintReadyDocumentAsPdf } from "./pdf-export.js";
 
 /**
  * Result of validating a candidate path before exposing it to a
@@ -876,35 +876,16 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
       throw new Error('Invalid print payload: expected HTML string');
     }
     const printNonce = typeof nonce === 'string' ? nonce : '';
-
-    const printWindow = new BrowserWindow({
-      width: 800,
-      height: 600,
-      show: false,
-      webPreferences: {
-        contextIsolation: true,
-        nodeIntegration: false,
-        sandbox: true,
-      },
-    });
-
-    printWindow.webContents.setWindowOpenHandler(() => ({ action: 'deny' }));
-    printWindow.webContents.on('will-navigate', (e) => e.preventDefault());
-
-    try {
-      await printWindow.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(html)}`);
-      await waitForPrintReadyHandshake(printWindow.webContents, printNonce);
-      printWindow.show();
-
-      await new Promise<void>((resolve, reject) => {
-        printWindow.webContents.print({ printBackground: true }, (success: boolean, failureReason?: string) => {
-          if (success) resolve();
-          else if (failureReason === 'Print job canceled') resolve();
-          else reject(new Error(failureReason ?? 'Print failed'));
-        });
-      });
-    } finally {
-      if (!printWindow.isDestroyed()) printWindow.close();
+    // Issue #1774: the renderer's `printPdf()` bridge runs the direct
+    // Save-as-PDF flow (showSaveDialog -> printToPDF -> write), never
+    // `webContents.print()` — the printer-first OS dialog. The renderer
+    // (apps/web/src/runtime/exports.ts#exportAsPdf) only reacts to a
+    // rejection: it shows a "Print failed" alert. A resolved call —
+    // including a user-canceled Save dialog — is silent, matching the
+    // pre-#1774 behavior where canceling the OS dialog was a no-op.
+    const result = await savePrintReadyDocumentAsPdf(html, printNonce, createElectronPdfTarget());
+    if (!result.ok) {
+      throw new Error(result.error ?? 'PDF export failed');
     }
   });
 

--- a/apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts
+++ b/apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts
@@ -1,0 +1,156 @@
+// Issue #1774 — on desktop, "Export PDF" opened the macOS system print
+// dialog instead of a direct Save-as-PDF flow. The root cause was the
+// `od:print-pdf` IPC handler reaching for `webContents.print()` (the
+// printer-first OS dialog) rather than the `showSaveDialog` +
+// `printToPDF` + write-to-disk shape that `exportPdfFromHtml` already
+// uses for the daemon-backed export path.
+//
+// `savePrintReadyDocumentAsPdf` is the extracted save-as-PDF flow. It
+// takes a structural `PrintReadyPdfTarget` (mirroring the
+// `WindowFullscreenSurface` pattern in runtime.ts) so the contract can
+// be pinned with plain stubs — no real Electron `dialog` or
+// `BrowserWindow`. The surface deliberately has no `print()` method:
+// the only render path is `printToPdf()`, so the regression cannot be
+// reintroduced without a type error.
+
+import { describe, expect, test } from 'vitest';
+
+import {
+  pdfFilenameFromDocument,
+  savePrintReadyDocumentAsPdf,
+  type PrintReadyPdfTarget,
+} from '../../src/main/pdf-export.js';
+
+type StubOptions = {
+  savePath?: string | null;
+  pdfBytes?: Uint8Array;
+  failOn?: 'load' | 'waitUntilReady' | 'printToPdf' | 'write';
+};
+
+function createStubTarget(options: StubOptions = {}): {
+  target: PrintReadyPdfTarget;
+  calls: string[];
+  written: Array<{ filePath: string; data: Uint8Array }>;
+  promptedWith: string[];
+} {
+  const calls: string[] = [];
+  const written: Array<{ filePath: string; data: Uint8Array }> = [];
+  const promptedWith: string[] = [];
+  const pdfBytes = options.pdfBytes ?? new Uint8Array([1, 2, 3]);
+  const failAt = (step: StubOptions['failOn']) => {
+    if (options.failOn === step) throw new Error(`${step} failed`);
+  };
+  const target: PrintReadyPdfTarget = {
+    async promptSavePath(defaultFilename) {
+      calls.push('promptSavePath');
+      promptedWith.push(defaultFilename);
+      return options.savePath === undefined ? '/tmp/picked.pdf' : options.savePath;
+    },
+    async load(_html) {
+      calls.push('load');
+      failAt('load');
+    },
+    async waitUntilReady(_nonce) {
+      calls.push('waitUntilReady');
+      failAt('waitUntilReady');
+    },
+    async printToPdf() {
+      calls.push('printToPdf');
+      failAt('printToPdf');
+      return pdfBytes;
+    },
+    async write(filePath, data) {
+      calls.push('write');
+      failAt('write');
+      written.push({ filePath, data });
+    },
+    dispose() {
+      calls.push('dispose');
+    },
+  };
+  return { target, calls, written, promptedWith };
+}
+
+describe('savePrintReadyDocumentAsPdf', () => {
+  test('writes the rendered PDF to the path chosen in the Save dialog', async () => {
+    const pdfBytes = new Uint8Array([9, 8, 7]);
+    const { target, written } = createStubTarget({ savePath: '/tmp/deck.pdf', pdfBytes });
+
+    const result = await savePrintReadyDocumentAsPdf('<html></html>', 'nonce-1', target);
+
+    expect(result).toEqual({ ok: true, path: '/tmp/deck.pdf' });
+    expect(written).toEqual([{ filePath: '/tmp/deck.pdf', data: pdfBytes }]);
+  });
+
+  // The #1774 invariant: the export shows a Save dialog and writes the
+  // file to disk, in that order. It never opens a printer dialog — the
+  // only render call is the dialogless printToPdf().
+  test('shows the Save dialog, then renders and writes, in order', async () => {
+    const { target, calls } = createStubTarget();
+
+    await savePrintReadyDocumentAsPdf('<html></html>', 'nonce-2', target);
+
+    expect(calls).toEqual([
+      'promptSavePath',
+      'load',
+      'waitUntilReady',
+      'printToPdf',
+      'write',
+      'dispose',
+    ]);
+  });
+
+  test('does nothing when the user cancels the Save dialog', async () => {
+    const { target, calls, written } = createStubTarget({ savePath: null });
+
+    const result = await savePrintReadyDocumentAsPdf('<html></html>', 'nonce-3', target);
+
+    expect(result).toEqual({ ok: true, canceled: true });
+    expect(written).toEqual([]);
+    expect(calls).toEqual(['promptSavePath', 'dispose']);
+  });
+
+  test('surfaces a render failure without writing a partial file', async () => {
+    const { target, calls, written } = createStubTarget({ failOn: 'printToPdf' });
+
+    const result = await savePrintReadyDocumentAsPdf('<html></html>', 'nonce-4', target);
+
+    expect(result).toEqual({ ok: false, error: 'printToPdf failed' });
+    expect(written).toEqual([]);
+    // The render target is still torn down even though rendering threw.
+    expect(calls).toEqual(['promptSavePath', 'load', 'waitUntilReady', 'printToPdf', 'dispose']);
+  });
+
+  test('seeds the Save dialog with a filename derived from the document', async () => {
+    const { target, promptedWith } = createStubTarget();
+
+    await savePrintReadyDocumentAsPdf(
+      '<html><head><title>Quarterly Deck</title></head><body></body></html>',
+      'nonce-5',
+      target,
+    );
+
+    expect(promptedWith).toEqual(['Quarterly-Deck.pdf']);
+  });
+});
+
+describe('pdfFilenameFromDocument', () => {
+  test('derives the filename from the document <title>', () => {
+    expect(
+      pdfFilenameFromDocument('<html><head><title>My Artifact</title></head></html>'),
+    ).toBe('My-Artifact.pdf');
+  });
+
+  test('decodes HTML entities escaped into the title', () => {
+    expect(pdfFilenameFromDocument('<title>Roadmap &amp; Plan</title>')).toBe(
+      'Roadmap-Plan.pdf',
+    );
+  });
+
+  test('falls back to artifact.pdf when no usable title is present', () => {
+    expect(pdfFilenameFromDocument('<html><body>no title here</body></html>')).toBe(
+      'artifact.pdf',
+    );
+    expect(pdfFilenameFromDocument('<title>   </title>')).toBe('artifact.pdf');
+  });
+});

--- a/apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts
+++ b/apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts
@@ -24,23 +24,33 @@ import {
 type StubOptions = {
   savePath?: string | null;
   pdfBytes?: Uint8Array;
-  failOn?: 'load' | 'waitUntilReady' | 'printToPdf' | 'write';
+  measuredPageSize?: { height: number; width: number };
+  failOn?: 'load' | 'waitUntilReady' | 'measurePageSize' | 'printToPdf' | 'write';
+};
+
+type PrintToPdfCallOptions = {
+  margins: { bottom: number; left: number; right: number; top: number };
+  pageSize: { height: number; width: number };
+  preferCSSPageSize: boolean;
+  printBackground: boolean;
 };
 
 function createStubTarget(options: StubOptions = {}): {
   target: PrintReadyPdfTarget;
   calls: string[];
+  printedWith: Array<PrintToPdfCallOptions | undefined>;
   written: Array<{ filePath: string; data: Uint8Array }>;
   promptedWith: string[];
 } {
   const calls: string[] = [];
+  const printedWith: Array<PrintToPdfCallOptions | undefined> = [];
   const written: Array<{ filePath: string; data: Uint8Array }> = [];
   const promptedWith: string[] = [];
   const pdfBytes = options.pdfBytes ?? new Uint8Array([1, 2, 3]);
   const failAt = (step: StubOptions['failOn']) => {
     if (options.failOn === step) throw new Error(`${step} failed`);
   };
-  const target: PrintReadyPdfTarget = {
+  const target = {
     async promptSavePath(defaultFilename) {
       calls.push('promptSavePath');
       promptedWith.push(defaultFilename);
@@ -54,8 +64,14 @@ function createStubTarget(options: StubOptions = {}): {
       calls.push('waitUntilReady');
       failAt('waitUntilReady');
     },
-    async printToPdf() {
+    async measurePageSize() {
+      calls.push('measurePageSize');
+      failAt('measurePageSize');
+      return options.measuredPageSize ?? { height: 9, width: 16 };
+    },
+    async printToPdf(printOptions?: PrintToPdfCallOptions) {
       calls.push('printToPdf');
+      printedWith.push(printOptions);
       failAt('printToPdf');
       return pdfBytes;
     },
@@ -67,8 +83,8 @@ function createStubTarget(options: StubOptions = {}): {
     dispose() {
       calls.push('dispose');
     },
-  };
-  return { target, calls, written, promptedWith };
+  } satisfies PrintReadyPdfTarget;
+  return { target, calls, printedWith, written, promptedWith };
 }
 
 describe('savePrintReadyDocumentAsPdf', () => {
@@ -94,9 +110,45 @@ describe('savePrintReadyDocumentAsPdf', () => {
       'promptSavePath',
       'load',
       'waitUntilReady',
+      'measurePageSize',
       'printToPdf',
       'write',
       'dispose',
+    ]);
+  });
+
+  test('renders with CSS page size preference, zero margins, and inferred page size by default', async () => {
+    const { target, printedWith } = createStubTarget({
+      measuredPageSize: { height: 11, width: 8.5 },
+    });
+
+    await savePrintReadyDocumentAsPdf('<html></html>', 'nonce-options', target);
+
+    expect(printedWith).toEqual([
+      {
+        margins: { bottom: 0, left: 0, right: 0, top: 0 },
+        pageSize: { height: 11, width: 8.5 },
+        preferCSSPageSize: true,
+        printBackground: true,
+      },
+    ]);
+  });
+
+  test('renders deck exports as one 1920x1080 slide per PDF page', async () => {
+    const { target, calls, printedWith } = createStubTarget({
+      measuredPageSize: { height: 11, width: 8.5 },
+    });
+
+    await savePrintReadyDocumentAsPdf('<html></html>', 'nonce-deck', target, { deck: true });
+
+    expect(calls).not.toContain('measurePageSize');
+    expect(printedWith).toEqual([
+      {
+        margins: { bottom: 0, left: 0, right: 0, top: 0 },
+        pageSize: { height: 7.5, width: 13.333333 },
+        preferCSSPageSize: true,
+        printBackground: true,
+      },
     ]);
   });
 
@@ -118,7 +170,14 @@ describe('savePrintReadyDocumentAsPdf', () => {
     expect(result).toEqual({ ok: false, error: 'printToPdf failed' });
     expect(written).toEqual([]);
     // The render target is still torn down even though rendering threw.
-    expect(calls).toEqual(['promptSavePath', 'load', 'waitUntilReady', 'printToPdf', 'dispose']);
+    expect(calls).toEqual([
+      'promptSavePath',
+      'load',
+      'waitUntilReady',
+      'measurePageSize',
+      'printToPdf',
+      'dispose',
+    ]);
   });
 
   test('seeds the Save dialog with a filename derived from the document', async () => {

--- a/apps/web/src/runtime/exports.ts
+++ b/apps/web/src/runtime/exports.ts
@@ -578,6 +578,10 @@ export function openSandboxedPreviewInNewTab(
   setTimeout(() => URL.revokeObjectURL(url), 60_000);
 }
 
+type DesktopPrintPdfOptions = {
+  deck?: boolean;
+};
+
 // Open the artifact in a new tab via a Blob URL with a self-printing
 // script injected. Going through a Blob URL (rather than `window.open('')`
 // + `document.write`) avoids two failure modes we hit before:
@@ -616,7 +620,14 @@ export async function exportAsPdf(
   const desktopApi =
     typeof window !== 'undefined'
       ? (window as unknown as Record<string, unknown>).__odDesktop as
-          | { printPdf?: (html: string, nonce?: string) => Promise<void>; isDesktop?: boolean }
+          | {
+              printPdf?: (
+                html: string,
+                nonce?: string,
+                options?: DesktopPrintPdfOptions,
+              ) => Promise<void>;
+              isDesktop?: boolean;
+            }
           | undefined
       : undefined;
   if (desktopApi?.printPdf) {
@@ -625,7 +636,7 @@ export async function exportAsPdf(
     }
     doc = injectParentPrintReadyCache(doc, nonce);
     try {
-      await desktopApi.printPdf(doc, nonce);
+      await desktopApi.printPdf(doc, nonce, opts?.deck ? { deck: true } : undefined);
     } catch {
       if (typeof alert !== 'undefined') {
         alert('Print failed. Please try Export PDF again or use the browser version.');

--- a/apps/web/src/runtime/exports.ts
+++ b/apps/web/src/runtime/exports.ts
@@ -606,11 +606,13 @@ export async function exportAsPdf(
   if (opts?.deck) doc = injectDeckPrintStylesheet(doc);
   doc = injectPrintReadyHandshake(doc, nonce);
 
-  // Desktop native print bridge — uses Electron's webContents.print() API
-  // instead of window.open + window.print(). The sandboxed wrapper omits
-  // allow-modals here because the native flow doesn't call window.print();
-  // granting it would let untrusted artifact code call alert()/confirm()
-  // and stall the hidden Electron window indefinitely.
+  // Desktop native PDF bridge — the main process runs a direct
+  // Save-as-PDF flow: a native Save dialog, then Electron's
+  // webContents.printToPDF() straight to the chosen file (issue #1774;
+  // see apps/desktop/src/main/pdf-export.ts). The sandboxed wrapper
+  // omits allow-modals here because the native flow never calls
+  // window.print(); granting it would let untrusted artifact code call
+  // alert()/confirm() and stall the hidden Electron window indefinitely.
   const desktopApi =
     typeof window !== 'undefined'
       ? (window as unknown as Record<string, unknown>).__odDesktop as

--- a/apps/web/tests/runtime/exports.test.ts
+++ b/apps/web/tests/runtime/exports.test.ts
@@ -458,10 +458,25 @@ describe('sandboxed preview Blob exports', () => {
     // Verify the parent-wrapper cache script is present so the handshake is
     // never missed even if 'OD_PRINT_READY' fires before the listener attaches.
     expect(htmlArg).toContain('__odPrintReady');
-    // Verify the print script is NOT injected — Electron calls
-    // webContents.print() natively, so a self-printing document would
-    // trigger a second print dialog.
+    // Verify the print script is NOT injected — Electron renders via the
+    // native printToPDF path, so a self-printing document would trigger a
+    // second print dialog.
     expect(htmlArg).not.toContain('window.print()');
+  });
+
+  it('passes deck intent through the desktop native print bridge', async () => {
+    const printPdfMock = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('window', {
+      open: () => mockWin,
+      addEventListener: () => {},
+      __odDesktop: { printPdf: printPdfMock, isDesktop: true },
+    });
+
+    await exportAsPdf('<section class="slide">One</section>', 'Desktop Deck', { deck: true });
+
+    expect(printPdfMock).toHaveBeenCalledTimes(1);
+    expect(printPdfMock.mock.calls[0]![2]).toEqual({ deck: true });
+    expect(printPdfMock.mock.calls[0]![0]).toContain('data-deck-print=&quot;injected&quot;');
   });
 
   it('injects image-waiting logic into the print-ready handshake for the desktop bridge', async () => {


### PR DESCRIPTION
Fixes #1774

## Why

Exporting a PDF in the macOS desktop app opened the system **print** dialog (printer selection, copies, paper size) instead of a "Save as PDF" file flow. The entry point says "Export PDF" but the resulting UI is printer-first, so the action reads as printing rather than a file export — exactly the confusion reported in the issue.

Root cause: the `od:print-pdf` IPC handler in `apps/desktop/src/main/runtime.ts` called `webContents.print()`. That handler landed in PR #973 as a native-print fallback, but it is also the destination of the renderer's `window.__odDesktop.printPdf()` bridge — so every desktop "Export PDF" went through it. The correct direct-save implementation (`exportPdfFromHtml`: `showSaveDialog` → `printToPDF` → write to disk) already existed for the daemon-backed export route, but the IPC handler never reached it.

## What users will see

On the desktop app, choosing **Export PDF** now opens a native **Save** dialog — pre-filled with a `.pdf` filename derived from the artifact title — and writes the PDF straight to the chosen location. The macOS system print dialog no longer appears. This affects both surfaces that reach the bridge: the **Preview modal** share menu (which always used this path) and the **File viewer** share menu (whose daemon-route fallback lands on the same IPC handler).

## Surface area

- [x] **Default behavior change** — desktop "Export PDF" now opens a Save dialog and writes a file instead of opening the OS print dialog.

No new dependency, API/contract, i18n, CLI, or extension-point surface is touched.

## Screenshots

The change swaps the macOS system print dialog (shown in the issue) for the OS-native Save panel. It is an OS-native dialog and a desktop-only behavior change; a packaged-app screenshot could not be captured in this environment. Manual repro is in the verification section below.

## Bug fix verification

- Test path: `apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts`
- Red/green: the buggy code was an inline closure inside `createDesktopRuntime`, which needs a real Electron runtime to invoke, so a commit-on-`main` red spec is not cheap there. The fix extracts the flow into `savePrintReadyDocumentAsPdf` behind a structural `PrintReadyPdfTarget` (the same `WindowFullscreenSurface` pattern already used in `runtime.ts`), and the new spec pins the #1774 invariant: the flow shows a Save dialog and writes the rendered bytes to the chosen file. I confirmed the spec reproduces the bug by temporarily reverting `savePrintReadyDocumentAsPdf` to the pre-fix shape (render with no Save dialog and no file write) — **5/8 specs went red** — then restored the fix — **8/8 green**.
- Manual buggy-vs-fix: build the desktop app on `main` and on this branch, open any artifact, and use Export PDF from both the Preview modal and the File viewer share menu. `main` → macOS system print dialog; this branch → native Save dialog → PDF written to disk.

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass
- `pnpm --filter @open-design/desktop test` — 25/25 pass (includes 8 new specs)
- `pnpm --filter @open-design/web exec vitest run tests/runtime/exports.test.ts` — 38/38 pass
- `pnpm --filter @open-design/packaged test` — 85/87 pass. The 2 failures are in `desktop-project-root-gate.test.ts` (a macOS `/var`→`/private/var` realpath artifact in the symlink tests); they reproduce identically on clean `upstream/main` with this change stashed, so they are pre-existing and unrelated.
