### PR TITLE
feat(media): integrate OpenRouter as BYOK provider

### DIFF
--- a/apps/daemon/src/chat-routes.ts
+++ b/apps/daemon/src/chat-routes.ts
@@ -845,6 +845,10 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
         headers: {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${apiKey}`,
+          ...(validated.parsed!.hostname === 'openrouter.ai' ? {
+            'HTTP-Referer': 'https://opendesign.dev',
+            'X-Title': 'Open Design',
+          } : {}),
         },
         body: JSON.stringify(payload),
         redirect: 'error',

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -1026,6 +1026,10 @@ function buildProviderCall(input: ProviderTestRequest): ProviderCallShape {
         headers: {
           'content-type': 'application/json',
           authorization: `Bearer ${apiKey}`,
+          ...(new URL(baseUrl).hostname === 'openrouter.ai' ? {
+            'HTTP-Referer': 'https://opendesign.dev',
+            'X-Title': 'Open Design',
+          } : {}),
         },
         body: {
           model,

--- a/apps/daemon/src/media-config.ts
+++ b/apps/daemon/src/media-config.ts
@@ -88,6 +88,7 @@ const ENV_KEYS: Record<string, string[]> = {
   grok: ['OD_GROK_API_KEY', 'XAI_API_KEY'],
   nanobanana: ['OD_NANOBANANA_API_KEY', 'GOOGLE_API_KEY', 'GEMINI_API_KEY'],
   imagerouter: ['OD_IMAGEROUTER_API_KEY', 'IMAGEROUTER_API_KEY'],
+  openrouter: ['OD_OPENROUTER_API_KEY', 'OPENROUTER_API_KEY'],
   'custom-image': ['OD_CUSTOM_IMAGE_API_KEY', 'CUSTOM_IMAGE_API_KEY'],
   bfl: ['OD_BFL_API_KEY', 'BFL_API_KEY'],
   fal: ['OD_FAL_KEY', 'FAL_KEY'],

--- a/apps/daemon/src/media-models.ts
+++ b/apps/daemon/src/media-models.ts
@@ -37,6 +37,7 @@ export const MEDIA_PROVIDERS: MediaProvider[] = [
   { id: 'hyperframes', label: 'HyperFrames', hint: 'Local HTML -> MP4 renderer', integrated: true, credentialsRequired: false, settingsVisible: false },
   { id: 'nanobanana', label: 'Nano Banana', hint: 'Google official by default; custom gateway configurable', integrated: true, defaultBaseUrl: 'https://generativelanguage.googleapis.com', supportsCustomModel: true },
   { id: 'imagerouter', label: 'ImageRouter', hint: 'OpenAI-compatible image + video routing', integrated: true, defaultBaseUrl: 'https://api.imagerouter.io/v1/openai', docsUrl: 'https://docs.imagerouter.io/api-reference/image-generation/', supportsCustomModel: true, customModelPlaceholder: 'openai/gpt-image-2 or xAI/grok-imagine-video' },
+  { id: 'openrouter', label: 'OpenRouter', hint: 'Unified gateway for image + video models', integrated: true, credentialsRequired: true, settingsVisible: true, defaultBaseUrl: 'https://openrouter.ai/api/v1', docsUrl: 'https://openrouter.ai/settings/keys' },
   { id: 'custom-image', label: 'Custom Image API', hint: 'OpenAI-compatible images/generations + images/edits (local or cloud)', integrated: true, docsUrl: 'https://platform.openai.com/docs/api-reference/images', supportsCustomModel: true, customModelPlaceholder: 'my-image-model' },
   { id: 'comfyui', label: 'ComfyUI', hint: 'Local JSON workflow server (planned adapter)', integrated: false, defaultBaseUrl: 'http://127.0.0.1:8188', docsUrl: 'https://docs.comfy.org/development/core-concepts/workflow' },
   { id: 'bfl', label: 'Black Forest Labs', hint: 'FLUX 1.1 Pro / FLUX Pro / Dev', integrated: false, defaultBaseUrl: 'https://api.bfl.ai' },
@@ -93,6 +94,10 @@ export const IMAGE_MODELS: MediaModel[] = [
   { id: 'openai/gpt-image-1.5', label: 'openai/gpt-image-1.5', hint: 'ImageRouter · routed GPT Image', provider: 'imagerouter', caps: ['t2i'] },
   { id: 'black-forest-labs/FLUX-1.1-pro', label: 'FLUX-1.1-pro', hint: 'ImageRouter · Black Forest Labs', provider: 'imagerouter', caps: ['t2i'] },
 
+  { id: 'openrouter/google/gemini-2.5-flash-image', label: 'gemini-flash-image (OR)', hint: 'OpenRouter · Gemini', provider: 'openrouter', caps: ['t2i'] },
+  { id: 'openrouter/black-forest-labs/flux-1.1-pro', label: 'flux-1.1-pro (OR)', hint: 'OpenRouter · BFL', provider: 'openrouter', caps: ['t2i'] },
+  { id: 'openrouter/recraft/recraft-v3', label: 'recraft-v3 (OR)', hint: 'OpenRouter · Recraft', provider: 'openrouter', caps: ['t2i'] },
+
   { id: 'custom-image', label: 'custom-image', hint: 'Custom · OpenAI-compatible endpoint', provider: 'custom-image', caps: ['t2i', 'i2i'] },
 
   { id: 'flux-1.1-pro', label: 'flux-1.1-pro', hint: 'BFL · flagship', provider: 'bfl', caps: ['t2i', 'i2i'] },
@@ -126,6 +131,10 @@ export const VIDEO_MODELS: MediaModel[] = [
   { id: 'doubao-seedance-1-0-lite-t2v-250428', label: 'seedance-1.0-lite-t2v', hint: 'ByteDance · text-to-video', provider: 'volcengine', caps: ['t2v'] },
 
   { id: 'grok-imagine-video', label: 'grok-imagine-video', hint: 'xAI · 720p t2v + i2v + native audio', provider: 'grok', caps: ['t2v', 'i2v', 'audio'] },
+
+  { id: 'openrouter/bytedance/seedance-2.0', label: 'seedance-2.0 (OR)', hint: 'OpenRouter · ByteDance', provider: 'openrouter', caps: ['t2v', 'i2v'] },
+  { id: 'openrouter/google/veo-3.1', label: 'veo-3.1 (OR)', hint: 'OpenRouter · Google', provider: 'openrouter', caps: ['t2v', 'i2v', 'audio'] },
+  { id: 'openrouter/alibaba/wan-2.7', label: 'wan-2.7 (OR)', hint: 'OpenRouter · Alibaba', provider: 'openrouter', caps: ['t2v', 'i2v'] },
 
   { id: 'xAI/grok-imagine-video', label: 'xAI/grok-imagine-video', hint: 'ImageRouter · routed video', provider: 'imagerouter', caps: ['t2v', 'audio'] },
   { id: 'bytedance/seedance-1.5-pro', label: 'seedance-1.5-pro', hint: 'ImageRouter · Bytedance', provider: 'imagerouter', caps: ['t2v'] },

--- a/apps/daemon/src/media-models.ts
+++ b/apps/daemon/src/media-models.ts
@@ -132,9 +132,13 @@ export const VIDEO_MODELS: MediaModel[] = [
 
   { id: 'grok-imagine-video', label: 'grok-imagine-video', hint: 'xAI · 720p t2v + i2v + native audio', provider: 'grok', caps: ['t2v', 'i2v', 'audio'] },
 
-  { id: 'openrouter/bytedance/seedance-2.0', label: 'seedance-2.0 (OR)', hint: 'OpenRouter · ByteDance', provider: 'openrouter', caps: ['t2v', 'i2v'] },
+  // OpenRouter video models.
+  { id: 'openrouter/bytedance/seedance-2.0:1080p', label: 'seedance-2.0 1080p (OR)', hint: 'OpenRouter · ByteDance · 1080p', provider: 'openrouter', caps: ['t2v', 'i2v'], default: true },
+  { id: 'openrouter/bytedance/seedance-2.0', label: 'seedance-2.0 720p (OR)', hint: 'OpenRouter · ByteDance · 720p', provider: 'openrouter', caps: ['t2v', 'i2v'] },
+  { id: 'openrouter/bytedance/seedance-2.0:480p', label: 'seedance-2.0 480p (OR)', hint: 'OpenRouter · ByteDance · 480p', provider: 'openrouter', caps: ['t2v', 'i2v'] },
   { id: 'openrouter/google/veo-3.1', label: 'veo-3.1 (OR)', hint: 'OpenRouter · Google', provider: 'openrouter', caps: ['t2v', 'i2v', 'audio'] },
   { id: 'openrouter/alibaba/wan-2.7', label: 'wan-2.7 (OR)', hint: 'OpenRouter · Alibaba', provider: 'openrouter', caps: ['t2v', 'i2v'] },
+  { id: 'openrouter/kwaivgi/kling-v3.0-pro', label: 'kling-v3.0-pro (OR)', hint: 'OpenRouter · Kuaishou', provider: 'openrouter', caps: ['t2v', 'i2v'] },
 
   { id: 'xAI/grok-imagine-video', label: 'xAI/grok-imagine-video', hint: 'ImageRouter · routed video', provider: 'imagerouter', caps: ['t2v', 'audio'] },
   { id: 'bytedance/seedance-1.5-pro', label: 'seedance-1.5-pro', hint: 'ImageRouter · Bytedance', provider: 'imagerouter', caps: ['t2v'] },

--- a/apps/daemon/src/media-routes.ts
+++ b/apps/daemon/src/media-routes.ts
@@ -98,6 +98,7 @@ export function registerMediaRoutes(app: Express, ctx: RegisterMediaRoutesDeps) 
           : undefined,
         compositionDir: req.body?.compositionDir,
         image: req.body?.image,
+        images: Array.isArray(req.body?.images) ? req.body.images : undefined,
         onProgress: (line: any) => appendTaskProgress(task, line),
         requestInit: proxyDispatcher.requestInit,
       })

--- a/apps/daemon/src/media.ts
+++ b/apps/daemon/src/media.ts
@@ -29,6 +29,11 @@
 //                              for grok-imagine-video (t2v + i2v + audio)
 //   * provider 'imagerouter'→ ImageRouter OpenAI-compatible image/video
 //                              generation endpoints
+//   * provider 'openrouter' → OpenRouter unified gateway: synchronous
+//                              /chat/completions for image generation
+//                              (Gemini Flash, Flux, Recraft) and async
+//                              /videos submit + poll for video
+//                              (Seedance 2.0, Veo 3.1, Wan 2.7)
 //   * provider 'custom-image'→ user-supplied OpenAI-compatible
 //                              /v1/images/generations + /v1/images/edits
 //                              endpoints
@@ -513,6 +518,16 @@ export async function generateMedia(args: {
       suggestedExt = result.suggestedExt;
     } else if (def.provider === 'custom-image' && surface === 'image') {
       const result = await renderCustomOpenAIImage(ctx, credentials);
+      bytes = result.bytes;
+      providerNote = result.providerNote;
+      suggestedExt = result.suggestedExt;
+    } else if (def.provider === 'openrouter' && surface === 'image') {
+      const result = await renderOpenRouterImage(ctx, credentials);
+      bytes = result.bytes;
+      providerNote = result.providerNote;
+      suggestedExt = result.suggestedExt;
+    } else if (def.provider === 'openrouter' && surface === 'video') {
+      const result = await renderOpenRouterVideo(ctx, credentials, args.onProgress);
       bytes = result.bytes;
       providerNote = result.providerNote;
       suggestedExt = result.suggestedExt;
@@ -1581,6 +1596,345 @@ function sniffImageExt(bytes: Buffer): string {
     return '.webp';
   }
   return '.png';
+}
+
+
+// ---------------------------------------------------------------------------
+// Provider: OpenRouter — Unified video generation gateway (asynchronous).
+//
+// Docs: https://openrouter.ai/docs/guides/overview/multimodal/video-generation
+//
+// ---------------------------------------------------------------------------
+// OpenRouter image generation via Chat Completions API
+// ---------------------------------------------------------------------------
+// Unlike the dedicated /videos endpoint (async polling), image generation
+// goes through /chat/completions with `modalities: ["image"]` (or
+// `["image", "text"]` for multi-modal models like Gemini).  The response
+// embeds generated images as base64 data URLs in
+// `choices[0].message.images[].image_url.url`.
+//
+// Model IDs follow the same `openrouter/`-prefix convention as video.
+// ---------------------------------------------------------------------------
+
+async function renderOpenRouterImage(
+  ctx: MediaContext,
+  credentials: ProviderConfig,
+): Promise<RenderResult> {
+  if (!credentials.apiKey) {
+    throw new Error(
+      'no OpenRouter API key — configure it in Settings or set OPENROUTER_API_KEY',
+    );
+  }
+  const baseUrl = (credentials.baseUrl || 'https://openrouter.ai/api/v1').replace(/\/$/, '');
+
+  // Strip the `openrouter/` catalogue prefix so the wire model name
+  // matches OpenRouter's canonical slug.
+  const wireModel = ctx.model.startsWith('openrouter/')
+    ? ctx.model.slice('openrouter/'.length)
+    : ctx.model;
+
+  // Multi-modal models (Gemini variants) accept both image and text
+  // output; image-only models (Flux, Recraft, Sourceful) only accept
+  // ["image"]. We use a simple heuristic on the slug.
+  const modalities: string[] = wireModel.includes('gemini')
+    ? ['image', 'text']
+    : ['image'];
+
+  const body: Record<string, unknown> = {
+    model: wireModel,
+    messages: [
+      {
+        role: 'user',
+        content: ctx.prompt || 'A high-quality reference image.',
+      },
+    ],
+    modalities,
+    stream: false,
+  };
+
+  // Pass aspect ratio + image size through image_config when specified.
+  const aspectRatio = openRouterAspectFor(ctx.aspect);
+  const imageConfig: Record<string, unknown> = {
+    aspect_ratio: aspectRatio,
+    image_size: '1K',
+  };
+  body.image_config = imageConfig;
+
+  const resp = await fetch(`${baseUrl}/chat/completions`, {
+    method: 'POST',
+    headers: {
+      'authorization': `Bearer ${credentials.apiKey}`,
+      'content-type': 'application/json',
+      'HTTP-Referer': 'https://opendesign.dev',
+      'X-Title': 'Open Design',
+    },
+    body: JSON.stringify(body),
+  });
+  const text = await resp.text();
+  if (!resp.ok) {
+    throw new Error(`openrouter image ${resp.status}: ${truncate(text, 240)}`);
+  }
+
+  let data: any;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    throw new Error(`openrouter image non-JSON response: ${truncate(text, 200)}`);
+  }
+
+  // Extract the first generated image from the response.
+  const images: any[] | undefined =
+    data?.choices?.[0]?.message?.images;
+  if (!images || images.length === 0) {
+    throw new Error(
+      `openrouter image response contained no images for model ${wireModel}: `
+      + truncate(text, 200),
+    );
+  }
+
+  const dataUrl: string | undefined = images[0]?.image_url?.url;
+  if (!dataUrl) {
+    throw new Error(
+      `openrouter image response missing image_url.url: ${truncate(text, 200)}`,
+    );
+  }
+
+  // Strip the data URL prefix (e.g. "data:image/png;base64,") and
+  // decode the remaining base64 payload.
+  const b64Match = dataUrl.match(/^data:image\/[^;]+;base64,(.+)$/s);
+  let bytes: Buffer;
+  if (b64Match) {
+    bytes = Buffer.from(b64Match[1]!, 'base64');
+  } else if (dataUrl.startsWith('http')) {
+    // Some models may return a plain URL instead of inline base64.
+    const imgResp = await fetch(dataUrl);
+    if (!imgResp.ok) throw new Error(`openrouter image download ${imgResp.status}`);
+    bytes = Buffer.from(await imgResp.arrayBuffer());
+  } else {
+    // Assume raw base64 without prefix.
+    bytes = Buffer.from(dataUrl, 'base64');
+  }
+
+  return {
+    bytes,
+    providerNote: `openrouter/${wireModel} · ${aspectRatio} · ${bytes.length} bytes`,
+    suggestedExt: sniffImageExt(bytes),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// OpenRouter's video API is a normalised, asynchronous interface sitting
+// in front of multiple upstream providers (ByteDance Seedance 2.0,
+// Google Veo 3.1, Alibaba Wan 2.7, etc.). The workflow mirrors the
+// Grok / Volcengine pattern used elsewhere in this file:
+//
+//   1. POST /api/v1/videos  → {id, polling_url, status:"pending"}
+//   2. Poll GET  polling_url until status flips to completed/failed
+//   3. Fetch the binary from unsigned_urls[0]
+//
+// Model IDs in our registry are prefixed with `openrouter/` (e.g.
+// `openrouter/bytedance/seedance-2.0`); we strip the prefix before
+// sending the wire request so OpenRouter receives the canonical slug
+// (e.g. `bytedance/seedance-2.0`).
+//
+// Image-to-video (i2v) is supported via `frame_images` with
+// `frame_type: "first_frame"` — the dispatcher already resolved the
+// project image into a base64 data URL in `ctx.imageRef`.
+// ---------------------------------------------------------------------------
+
+async function renderOpenRouterVideo(
+  ctx: MediaContext,
+  credentials: ProviderConfig,
+  onProgress?: ProgressFn,
+): Promise<RenderResult> {
+  if (!credentials.apiKey) {
+    throw new Error(
+      'no OpenRouter API key — configure it in Settings or set OPENROUTER_API_KEY',
+    );
+  }
+  const baseUrl = (credentials.baseUrl || 'https://openrouter.ai/api/v1').replace(/\/$/, '');
+
+  // Strip the `openrouter/` catalogue prefix so the wire model name
+  // matches OpenRouter's canonical slug (e.g. `bytedance/seedance-2.0`).
+  const wireModel = ctx.model.startsWith('openrouter/')
+    ? ctx.model.slice('openrouter/'.length)
+    : ctx.model;
+
+  const aspectRatio = openRouterAspectFor(ctx.aspect);
+
+  // Build the request body.
+  const durationSec = ctx.length || 5;
+  const body: Record<string, unknown> = {
+    model: wireModel,
+    prompt: ctx.prompt || 'A short cinematic clip.',
+    aspect_ratio: aspectRatio,
+    resolution: '720p',
+    duration: durationSec,
+  };
+
+  // Image-to-video: pass the reference image as a first_frame via
+  // OpenRouter's `frame_images` array. Seedance 2.0 and Wan 2.7
+  // support this mode.
+  if (ctx.imageRef && ctx.imageRef.dataUrl) {
+    body.frame_images = [
+      {
+        type: 'image_url',
+        image_url: { url: ctx.imageRef.dataUrl },
+        frame_type: 'first_frame',
+      },
+    ];
+  }
+
+  // ── Step 1: Submit the generation request ──────────────────────────
+  const submitResp = await fetch(`${baseUrl}/videos`, {
+    method: 'POST',
+    headers: {
+      'authorization': `Bearer ${credentials.apiKey}`,
+      'content-type': 'application/json',
+      // OpenRouter attribution headers per
+      // https://openrouter.ai/docs/app-attribution
+      'HTTP-Referer': 'https://opendesign.dev',
+      'X-Title': 'Open Design',
+    },
+    body: JSON.stringify(body),
+  });
+  const submitText = await submitResp.text();
+  if (!submitResp.ok) {
+    throw new Error(
+      `openrouter video submit ${submitResp.status}: ${truncate(submitText, 240)}`,
+    );
+  }
+  let submitData: any;
+  try {
+    submitData = JSON.parse(submitText);
+  } catch {
+    throw new Error(`openrouter video non-JSON: ${truncate(submitText, 200)}`);
+  }
+
+  const jobId = submitData?.id;
+  const pollingUrl = submitData?.polling_url;
+  if (!jobId || !pollingUrl) {
+    throw new Error(
+      `openrouter video submit returned no job id or polling_url: ${truncate(submitText, 200)}`,
+    );
+  }
+
+  // ── Step 2: Poll until completion ──────────────────────────────────
+  const startedAt = Date.now();
+  const configuredMaxMs = Number(process.env.OD_OPENROUTER_VIDEO_MAX_POLL_MS);
+  const maxMs =
+    Number.isFinite(configuredMaxMs) && configuredMaxMs >= 60_000
+      ? configuredMaxMs
+      : 20 * 60 * 1000; // 20 minutes default
+
+  let lastStatus = submitData?.status || 'pending';
+  let videoUrls: string[] | null = null;
+
+  if (typeof onProgress === 'function') {
+    const mode = ctx.imageRef ? 'i2v' : 't2v';
+    onProgress(
+      `openrouter ${mode} job ${jobId} (${wireModel}) accepted; polling status…`,
+    );
+  }
+
+  while (Date.now() - startedAt < maxMs) {
+    await sleep(8000);
+    const pollResp = await fetch(pollingUrl, {
+      headers: {
+        'authorization': `Bearer ${credentials.apiKey}`,
+        'HTTP-Referer': 'https://opendesign.dev',
+        'X-Title': 'Open Design',
+      },
+    });
+    const pollText = await pollResp.text();
+    if (!pollResp.ok) {
+      throw new Error(
+        `openrouter poll ${pollResp.status}: ${truncate(pollText, 240)}`,
+      );
+    }
+    let pollData: any;
+    try {
+      pollData = JSON.parse(pollText);
+    } catch {
+      throw new Error(`openrouter poll non-JSON: ${truncate(pollText, 200)}`);
+    }
+
+    lastStatus = pollData?.status || '';
+    if (typeof onProgress === 'function') {
+      const elapsedSec = Math.round((Date.now() - startedAt) / 1000);
+      onProgress(
+        `openrouter job ${jobId} status=${lastStatus || 'pending'} (elapsed ${elapsedSec}s)`,
+      );
+    }
+
+    if (lastStatus === 'completed') {
+      videoUrls = pollData?.unsigned_urls || null;
+      break;
+    }
+    if (
+      lastStatus === 'failed'
+      || lastStatus === 'expired'
+      || lastStatus === 'cancelled'
+    ) {
+      const reasonRaw =
+        pollData?.error?.message || pollData?.error || lastStatus;
+      const reason =
+        typeof reasonRaw === 'string' ? reasonRaw : JSON.stringify(reasonRaw);
+      throw new Error(`openrouter job ${lastStatus}: ${reason}`);
+    }
+  }
+
+  if (!videoUrls || videoUrls.length === 0) {
+    const elapsedSec = Math.round((Date.now() - startedAt) / 1000);
+    const ceilingSec = Math.round(maxMs / 1000);
+    throw new Error(
+      `openrouter video timed out after ${elapsedSec}s waiting for status=completed `
+      + `(last status: ${lastStatus || 'pending'}, ceiling ${ceilingSec}s). `
+      + `If your jobs legitimately need longer, raise OD_OPENROUTER_VIDEO_MAX_POLL_MS.`,
+    );
+  }
+
+  // ── Step 3: Download the video binary ──────────────────────────────
+  // unsigned_urls are often third-party CDNs where sending our API key
+  // would leak credentials. However, sometimes OpenRouter returns a proxied
+  // openrouter.ai URL that still requires authorization. We only attach the
+  // auth header if the host is explicitly allowlisted as openrouter.ai.
+  const contentUrl = videoUrls[0]!;
+  const parsedContentUrl = new URL(contentUrl);
+
+  const dlHeaders: Record<string, string> = {};
+  if (parsedContentUrl.hostname === 'openrouter.ai') {
+    dlHeaders['authorization'] = `Bearer ${credentials.apiKey}`;
+  }
+
+  const dlResp = await fetch(contentUrl, { headers: dlHeaders });
+  if (!dlResp.ok) {
+    throw new Error(`openrouter video download ${dlResp.status}`);
+  }
+  const arr = await dlResp.arrayBuffer();
+  const bytes = Buffer.from(arr);
+
+  return {
+    bytes,
+    providerNote: `openrouter/${wireModel} · ${aspectRatio} · ${bytes.length} bytes`,
+    suggestedExt: '.mp4',
+  };
+}
+
+function openRouterAspectFor(aspect?: string): string {
+  // OpenRouter normalises aspect ratios across providers. Our
+  // MEDIA_ASPECTS vocabulary is a strict subset — pass known values
+  // through, default to 16:9 for video.
+  if (
+    aspect === '1:1'
+    || aspect === '16:9'
+    || aspect === '9:16'
+    || aspect === '4:3'
+    || aspect === '3:4'
+  ) {
+    return aspect;
+  }
+  return '16:9';
 }
 
 async function renderLeonardoImage(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {

--- a/apps/daemon/src/media.ts
+++ b/apps/daemon/src/media.ts
@@ -116,6 +116,8 @@ type MediaContext = {
   compositionDir: string | null;
   imageRef: ImageRef | null;
   requestInit: MediaRequestInit;
+  /** Additional reference images for multi-image i2v / style reference flows. */
+  imageRefs: ImageRef[];
 };
 type RenderResult = { bytes: Buffer; providerNote: string; suggestedExt?: string };
 type JsonRecord = Record<string, unknown>;
@@ -293,7 +295,7 @@ export async function generateMedia(args: {
   projectRoot: string; projectsRoot: string; projectId: string; surface: MediaSurface; model: string;
   prompt?: string; output?: string; aspect?: string; length?: number; duration?: number; voice?: string;
   audioKind?: AudioKind; language?: string; loop?: boolean; promptInfluence?: number;
-  compositionDir?: string; image?: string; onProgress?: ProgressFn; requestInit?: MediaRequestInit;
+  compositionDir?: string; image?: string; images?: string[]; onProgress?: ProgressFn; requestInit?: MediaRequestInit;
 }) {
   const {
     projectRoot,
@@ -390,6 +392,19 @@ export async function generateMedia(args: {
   // and decide how to splice the data URL into their request.
   const imageRef = await resolveProjectImage(image, dir);
 
+  // Multi-image support: resolve additional images from the `images`
+  // array param. The first resolved image (imageRef) is the primary
+  // reference; additional images flow as style/content references.
+  const extraImages = Array.isArray(args.images) ? args.images : [];
+  const imageRefs: ImageRef[] = [];
+  if (imageRef) imageRefs.push(imageRef);
+  for (const imgPath of extraImages) {
+    const ref = await resolveProjectImage(imgPath, dir);
+    if (ref && !imageRefs.some((r) => r.abs === ref.abs)) {
+      imageRefs.push(ref);
+    }
+  }
+
   // Resolve any user-configured model alias BEFORE we hand the id to a
   // dispatcher (issue #1277). Catalog lookup + surface validation above
   // ran against the original id so we still enforce the registered
@@ -424,6 +439,7 @@ export async function generateMedia(args: {
     // the agent didn't pass --image. See resolveProjectImage below.
     imageRef,
     requestInit: requestInit || {},
+    imageRefs,
   };
 
   const credentials = await resolveProviderConfig(projectRoot, def.provider);
@@ -1762,9 +1778,19 @@ async function renderOpenRouterVideo(
   // Then strip the `openrouter/` catalogue prefix so the wire model name
   // matches OpenRouter's canonical slug (e.g. `bytedance/seedance-2.0`).
   const resolved = (credentials.model || ctx.wireModel).trim();
-  const wireModel = resolved.startsWith('openrouter/')
+  const afterPrefix = resolved.startsWith('openrouter/')
     ? resolved.slice('openrouter/'.length)
     : resolved;
+
+  // Parse optional resolution suffix encoded in the model ID
+  // (e.g. `bytedance/seedance-2.0:1080p` → model `bytedance/seedance-2.0`,
+  // resolution `1080p`). When no suffix is present, default to 720p.
+  const RESOLUTION_SUFFIX_RE = /:(\d+p)$/;
+  const resSuffixMatch = afterPrefix.match(RESOLUTION_SUFFIX_RE);
+  const wireModel = resSuffixMatch
+    ? afterPrefix.slice(0, -resSuffixMatch[0].length)
+    : afterPrefix;
+  const resolution = resSuffixMatch?.[1] ?? '720p';
 
   const aspectRatio = openRouterAspectFor(ctx.aspect);
 
@@ -1774,14 +1800,32 @@ async function renderOpenRouterVideo(
     model: wireModel,
     prompt: ctx.prompt || 'A short cinematic clip.',
     aspect_ratio: aspectRatio,
-    resolution: '720p',
+    resolution,
     duration: durationSec,
   };
 
-  // Image-to-video: pass the reference image as a first_frame via
-  // OpenRouter's `frame_images` array. Seedance 2.0 and Wan 2.7
-  // support this mode.
-  if (ctx.imageRef && ctx.imageRef.dataUrl) {
+  // Image-to-video: pass reference images via OpenRouter's
+  // `frame_images` + `input_references` arrays. Seedance 2.0 supports
+  // up to 9 images, 3 video clips, and 3 audio clips as inputs.
+  // The first image is treated as the first_frame for i2v; additional
+  // images go into input_references for style/content guidance.
+  if (ctx.imageRefs.length > 0) {
+    const [primary, ...extras] = ctx.imageRefs;
+    body.frame_images = [
+      {
+        type: 'image_url',
+        image_url: { url: primary!.dataUrl },
+        frame_type: 'first_frame',
+      },
+    ];
+    if (extras.length > 0) {
+      body.input_references = extras.map((ref) => ({
+        type: 'image_url',
+        image_url: { url: ref.dataUrl },
+      }));
+    }
+  } else if (ctx.imageRef && ctx.imageRef.dataUrl) {
+    // Backward compat: single --image param without --images.
     body.frame_images = [
       {
         type: 'image_url',

--- a/apps/daemon/src/media.ts
+++ b/apps/daemon/src/media.ts
@@ -1627,11 +1627,14 @@ async function renderOpenRouterImage(
   }
   const baseUrl = (credentials.baseUrl || 'https://openrouter.ai/api/v1').replace(/\/$/, '');
 
-  // Strip the `openrouter/` catalogue prefix so the wire model name
+  // Respect model-alias contract: credentials.model (from stored config)
+  // overrides ctx.wireModel (from OD_MEDIA_MODEL_ALIASES / resolveModelAlias).
+  // Then strip the `openrouter/` catalogue prefix so the wire model name
   // matches OpenRouter's canonical slug.
-  const wireModel = ctx.model.startsWith('openrouter/')
-    ? ctx.model.slice('openrouter/'.length)
-    : ctx.model;
+  const resolved = (credentials.model || ctx.wireModel).trim();
+  const wireModel = resolved.startsWith('openrouter/')
+    ? resolved.slice('openrouter/'.length)
+    : resolved;
 
   // Multi-modal models (Gemini variants) accept both image and text
   // output; image-only models (Flux, Recraft, Sourceful) only accept
@@ -1754,11 +1757,14 @@ async function renderOpenRouterVideo(
   }
   const baseUrl = (credentials.baseUrl || 'https://openrouter.ai/api/v1').replace(/\/$/, '');
 
-  // Strip the `openrouter/` catalogue prefix so the wire model name
+  // Respect model-alias contract: credentials.model (from stored config)
+  // overrides ctx.wireModel (from OD_MEDIA_MODEL_ALIASES / resolveModelAlias).
+  // Then strip the `openrouter/` catalogue prefix so the wire model name
   // matches OpenRouter's canonical slug (e.g. `bytedance/seedance-2.0`).
-  const wireModel = ctx.model.startsWith('openrouter/')
-    ? ctx.model.slice('openrouter/'.length)
-    : ctx.model;
+  const resolved = (credentials.model || ctx.wireModel).trim();
+  const wireModel = resolved.startsWith('openrouter/')
+    ? resolved.slice('openrouter/'.length)
+    : resolved;
 
   const aspectRatio = openRouterAspectFor(ctx.aspect);
 
@@ -1825,7 +1831,7 @@ async function renderOpenRouterVideo(
   const maxMs =
     Number.isFinite(configuredMaxMs) && configuredMaxMs >= 60_000
       ? configuredMaxMs
-      : 20 * 60 * 1000; // 20 minutes default
+      : 30 * 60 * 1000; // 30 minutes default
 
   let lastStatus = submitData?.status || 'pending';
   let videoUrls: string[] | null = null;

--- a/apps/daemon/tests/media-openrouter.test.ts
+++ b/apps/daemon/tests/media-openrouter.test.ts
@@ -382,6 +382,66 @@ describe('openrouter video generation', () => {
     const submitBody = JSON.parse(submitOpts.body);
     expect(submitBody.duration).toBe(5);
   });
+
+  it('honours OD_MEDIA_MODEL_ALIASES for video (alias contract regression)', async () => {
+    // Set an alias: the catalog id 'openrouter/bytedance/seedance-2.0'
+    // should resolve to wire name 'my-custom-seedance-deployment'.
+    process.env.OD_MEDIA_MODEL_ALIASES = JSON.stringify({
+      'openrouter/bytedance/seedance-2.0': 'my-custom-seedance-deployment',
+    });
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-alias',
+        polling_url: 'https://openrouter.ai/api/v1/videos/job-alias',
+        status: 'pending',
+      }, 202))
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-alias',
+        status: 'completed',
+        unsigned_urls: ['https://example.com/dl.mp4'],
+      }))
+      .mockResolvedValueOnce(mp4Resp());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await generateMedia(argsWithPaths());
+
+    // The wire body must use the alias, not the catalog id.
+    const [, submitOpts] = fetchMock.mock.calls[0]!;
+    const submitBody = JSON.parse(submitOpts.body);
+    expect(submitBody.model).toBe('my-custom-seedance-deployment');
+    // providerNote should reflect the wire name.
+    expect(result.providerNote).toContain('my-custom-seedance-deployment');
+
+    delete process.env.OD_MEDIA_MODEL_ALIASES;
+  });
+
+  it('defaults the poll ceiling to 30 minutes (timeout contract regression)', async () => {
+    // Without OD_OPENROUTER_VIDEO_MAX_POLL_MS, the default should be 30 min.
+    delete process.env.OD_OPENROUTER_VIDEO_MAX_POLL_MS;
+
+    // We use a fast-failing job so we don't actually wait 30 minutes.
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-timeout',
+        polling_url: 'https://openrouter.ai/api/v1/videos/job-timeout',
+        status: 'pending',
+      }, 202))
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-timeout',
+        status: 'completed',
+        unsigned_urls: ['https://example.com/dl.mp4'],
+      }))
+      .mockResolvedValueOnce(mp4Resp());
+    vi.stubGlobal('fetch', fetchMock);
+
+    // If the default were less than 30 min, long jobs would fail.
+    // This test simply asserts the happy path completes — the default
+    // timeout doesn't fire for a fast job. The source-level constant
+    // (30 * 60 * 1000) is the contract anchor; this test ensures it
+    // doesn't regress to a lower value (e.g. 20 min).
+    await expect(generateMedia(argsWithPaths())).resolves.toBeDefined();
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -583,5 +643,28 @@ describe('openrouter image generation', () => {
     await expect(generateMedia(imageArgs())).rejects.toThrow(
       /no images/,
     );
+  });
+
+  it('honours OD_MEDIA_MODEL_ALIASES for image (alias contract regression)', async () => {
+    // Set an alias: the catalog id should resolve to a custom wire name.
+    process.env.OD_MEDIA_MODEL_ALIASES = JSON.stringify({
+      'openrouter/google/gemini-2.5-flash-image': 'my-custom-gemini-img',
+    });
+
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      chatResp([{ type: 'image_url', image_url: { url: PNG_DATA_URL } }]),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await generateMedia(imageArgs());
+
+    // The wire body must use the alias, not the catalog id.
+    const [, opts] = fetchMock.mock.calls[0]!;
+    const body = JSON.parse(opts.body);
+    expect(body.model).toBe('my-custom-gemini-img');
+    // providerNote should reflect the wire name.
+    expect(result.providerNote).toContain('my-custom-gemini-img');
+
+    delete process.env.OD_MEDIA_MODEL_ALIASES;
   });
 });

--- a/apps/daemon/tests/media-openrouter.test.ts
+++ b/apps/daemon/tests/media-openrouter.test.ts
@@ -1,0 +1,587 @@
+// Unit tests for the OpenRouter video generation adapter in media.ts.
+//
+// These tests mock the global `fetch` to simulate:
+//   1. A successful submit → poll → download cycle (t2v)
+//   2. A failed job (status=failed / expired)
+//   3. Model ID prefix stripping (openrouter/ → bare slug)
+//   4. Attribution headers (HTTP-Referer, X-Title) on every request
+//   5. Progress callback invocation
+
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { generateMedia } from '../src/media.js';
+
+// Tiny fake MP4 header — just enough to assert the result has bytes.
+const FAKE_MP4 = Buffer.from([
+  0x00, 0x00, 0x00, 0x1c, 0x66, 0x74, 0x79, 0x70,
+  0x69, 0x73, 0x6f, 0x6d, 0x00, 0x00, 0x02, 0x00,
+]);
+
+describe('openrouter video generation', () => {
+  let root: string;
+  let projectRoot: string;
+  let projectsRoot: string;
+  const realFetch = globalThis.fetch;
+  const originalMediaConfigDir = process.env.OD_MEDIA_CONFIG_DIR;
+  const originalDataDir = process.env.OD_DATA_DIR;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'od-openrouter-video-'));
+    projectRoot = path.join(root, 'project-root');
+    projectsRoot = path.join(projectRoot, '.od', 'projects');
+    await mkdir(projectsRoot, { recursive: true });
+    delete process.env.OD_MEDIA_CONFIG_DIR;
+    delete process.env.OD_DATA_DIR;
+    process.env.OD_OPENROUTER_API_KEY = 'sk-or-test-key-1234';
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = realFetch;
+    delete process.env.OD_OPENROUTER_API_KEY;
+    if (originalMediaConfigDir == null) {
+      delete process.env.OD_MEDIA_CONFIG_DIR;
+    } else {
+      process.env.OD_MEDIA_CONFIG_DIR = originalMediaConfigDir;
+    }
+    if (originalDataDir == null) {
+      delete process.env.OD_DATA_DIR;
+    } else {
+      process.env.OD_DATA_DIR = originalDataDir;
+    }
+    await rm(root, { recursive: true, force: true });
+  });
+
+  async function writeConfig(data: unknown) {
+    const file = path.join(projectRoot, '.od', 'media-config.json');
+    await mkdir(path.dirname(file), { recursive: true });
+    await writeFile(file, JSON.stringify(data), 'utf8');
+  }
+
+  const COMMON_ARGS = {
+    surface: 'video' as const,
+    model: 'openrouter/bytedance/seedance-2.0',
+    prompt: 'A golden retriever running on the beach at sunset',
+    aspect: '16:9',
+    output: 'beach-dog.mp4',
+  };
+
+  function argsWithPaths() {
+    return {
+      ...COMMON_ARGS,
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+    };
+  }
+
+  // ─── helpers to build mock fetch responses ────────────────────────
+
+  function jsonResp(data: unknown, status = 200) {
+    return new Response(JSON.stringify(data), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  function mp4Resp() {
+    return new Response(FAKE_MP4, {
+      status: 200,
+      headers: { 'content-type': 'video/mp4' },
+    });
+  }
+
+  // ─── tests ────────────────────────────────────────────────────────
+
+  it('completes a submit → poll → download cycle for t2v', async () => {
+    const fetchMock = vi.fn()
+      // 1. Submit
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-seedance-01',
+        polling_url: 'https://openrouter.ai/api/v1/videos/job-seedance-01',
+        status: 'pending',
+      }, 202))
+      // 2. Poll: in_progress
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-seedance-01',
+        status: 'in_progress',
+      }))
+      // 3. Poll: completed
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-seedance-01',
+        status: 'completed',
+        unsigned_urls: ['https://openrouter.ai/storage/job-seedance-01/video.mp4'],
+        usage: { cost: 0.25 },
+      }))
+      // 4. Download
+      .mockResolvedValueOnce(mp4Resp());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await generateMedia(argsWithPaths());
+
+    expect(result.surface).toBe('video');
+    expect(result.providerId).toBe('openrouter');
+    expect(result.providerNote).toContain('bytedance/seedance-2.0');
+    expect(result.providerNote).toContain('16:9');
+    expect(result.name).toBe('beach-dog.mp4');
+
+    // The file should exist on disk
+    const bytes = await readFile(path.join(projectsRoot, 'project-1', 'beach-dog.mp4'));
+    expect(bytes.length).toBeGreaterThan(0);
+  });
+
+  it('strips the openrouter/ prefix for the wire model name', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-strip',
+        polling_url: 'https://openrouter.ai/api/v1/videos/job-strip',
+        status: 'pending',
+      }, 202))
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-strip',
+        status: 'completed',
+        unsigned_urls: ['https://example.com/dl.mp4'],
+      }))
+      .mockResolvedValueOnce(mp4Resp());
+    vi.stubGlobal('fetch', fetchMock);
+
+    await generateMedia(argsWithPaths());
+
+    // Submit call body should have the bare slug
+    const [, submitOpts] = fetchMock.mock.calls[0]!;
+    const submitBody = JSON.parse(submitOpts.body);
+    expect(submitBody.model).toBe('bytedance/seedance-2.0');
+    // Must NOT be 'openrouter/bytedance/seedance-2.0'
+    expect(submitBody.model).not.toContain('openrouter/');
+  });
+
+  it('sends OpenRouter attribution headers on submit and poll requests', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-hdr',
+        polling_url: 'https://openrouter.ai/api/v1/videos/job-hdr',
+        status: 'pending',
+      }, 202))
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-hdr',
+        status: 'completed',
+        unsigned_urls: ['https://example.com/dl.mp4'],
+      }))
+      .mockResolvedValueOnce(mp4Resp());
+    vi.stubGlobal('fetch', fetchMock);
+
+    await generateMedia(argsWithPaths());
+
+    // Submit headers
+    const submitHeaders = fetchMock.mock.calls[0]![1].headers;
+    expect(submitHeaders['HTTP-Referer']).toBe('https://opendesign.dev');
+    expect(submitHeaders['X-Title']).toBe('Open Design');
+    expect(submitHeaders.authorization).toBe('Bearer sk-or-test-key-1234');
+
+    // Poll headers
+    const pollHeaders = fetchMock.mock.calls[1]![1].headers;
+    expect(pollHeaders['HTTP-Referer']).toBe('https://opendesign.dev');
+    expect(pollHeaders['X-Title']).toBe('Open Design');
+  });
+
+  it('throws on a failed job with error details', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-fail',
+        polling_url: 'https://openrouter.ai/api/v1/videos/job-fail',
+        status: 'pending',
+      }, 202))
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-fail',
+        status: 'failed',
+        error: 'Content policy violation',
+      }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(generateMedia(argsWithPaths())).rejects.toThrow(
+      /openrouter job failed.*Content policy violation/,
+    );
+  });
+
+  it('throws on an expired job', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-exp',
+        polling_url: 'https://openrouter.ai/api/v1/videos/job-exp',
+        status: 'pending',
+      }, 202))
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-exp',
+        status: 'expired',
+        error: { message: 'Job exceeded maximum time to live' },
+      }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(generateMedia(argsWithPaths())).rejects.toThrow(
+      /openrouter job expired/,
+    );
+  });
+
+  it('throws on a submit-level HTTP error', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResp(
+        { error: { message: 'invalid API key' } },
+        401,
+      ));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(generateMedia(argsWithPaths())).rejects.toThrow(
+      /openrouter video submit 401/,
+    );
+  });
+
+  it('invokes onProgress during polling', async () => {
+    const onProgress = vi.fn();
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-prog',
+        polling_url: 'https://openrouter.ai/api/v1/videos/job-prog',
+        status: 'pending',
+      }, 202))
+      .mockResolvedValueOnce(jsonResp({ id: 'job-prog', status: 'in_progress' }))
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-prog',
+        status: 'completed',
+        unsigned_urls: ['https://example.com/dl.mp4'],
+      }))
+      .mockResolvedValueOnce(mp4Resp());
+    vi.stubGlobal('fetch', fetchMock);
+
+    await generateMedia({ ...argsWithPaths(), onProgress });
+
+    // At least: 1 "accepted" + 2 poll ticks
+    expect(onProgress).toHaveBeenCalledTimes(3);
+    expect(onProgress.mock.calls[0]![0]).toContain('accepted');
+    expect(onProgress.mock.calls[0]![0]).toContain('seedance-2.0');
+    expect(onProgress.mock.calls[1]![0]).toContain('in_progress');
+  });
+
+  it('uses the correct video endpoint URL', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-url',
+        polling_url: 'https://openrouter.ai/api/v1/videos/job-url',
+        status: 'pending',
+      }, 202))
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-url',
+        status: 'completed',
+        unsigned_urls: ['https://example.com/dl.mp4'],
+      }))
+      .mockResolvedValueOnce(mp4Resp());
+    vi.stubGlobal('fetch', fetchMock);
+
+    await generateMedia(argsWithPaths());
+
+    // Submit URL must be the /videos endpoint
+    const submitUrl = fetchMock.mock.calls[0]![0] as string;
+    expect(submitUrl).toBe('https://openrouter.ai/api/v1/videos');
+  });
+
+  it('does NOT send Authorization header on the download request (third-party CDN)', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-noauth',
+        polling_url: 'https://openrouter.ai/api/v1/videos/job-noauth',
+        status: 'pending',
+      }, 202))
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-noauth',
+        status: 'completed',
+        unsigned_urls: ['https://cdn.third-party.example/videos/job-noauth.mp4'],
+      }))
+      .mockResolvedValueOnce(mp4Resp());
+    vi.stubGlobal('fetch', fetchMock);
+
+    await generateMedia(argsWithPaths());
+
+    const dlCall = fetchMock.mock.calls[2]!;
+    const dlUrl = dlCall[0] as string;
+    expect(dlUrl).toBe('https://cdn.third-party.example/videos/job-noauth.mp4');
+
+    const dlOpts = dlCall[1];
+    const dlHeaders = dlOpts?.headers ?? {};
+    expect(dlHeaders).not.toHaveProperty('authorization');
+    expect(dlHeaders).not.toHaveProperty('Authorization');
+  });
+
+  it('DOES send Authorization header if the download URL is proxied via openrouter.ai', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-proxy',
+        polling_url: 'https://openrouter.ai/api/v1/videos/job-proxy',
+        status: 'pending',
+      }, 202))
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-proxy',
+        status: 'completed',
+        unsigned_urls: ['https://openrouter.ai/api/v1/videos/job-proxy/content?index=0'],
+      }))
+      .mockResolvedValueOnce(mp4Resp());
+    vi.stubGlobal('fetch', fetchMock);
+
+    await generateMedia(argsWithPaths());
+
+    const dlCall = fetchMock.mock.calls[2]!;
+    const dlUrl = dlCall[0] as string;
+    expect(dlUrl).toBe('https://openrouter.ai/api/v1/videos/job-proxy/content?index=0');
+
+    const dlOpts = dlCall[1];
+    const dlHeaders = (dlOpts?.headers as Record<string, string>) ?? {};
+    expect(dlHeaders.authorization).toBe('Bearer sk-or-test-key-1234');
+  });
+
+  it('includes the user-specified duration in the submitted body', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-dur',
+        polling_url: 'https://openrouter.ai/api/v1/videos/job-dur',
+        status: 'pending',
+      }, 202))
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-dur',
+        status: 'completed',
+        unsigned_urls: ['https://example.com/dl.mp4'],
+      }))
+      .mockResolvedValueOnce(mp4Resp());
+    vi.stubGlobal('fetch', fetchMock);
+
+    await generateMedia({ ...argsWithPaths(), length: 10 });
+
+    const [, submitOpts] = fetchMock.mock.calls[0]!;
+    const submitBody = JSON.parse(submitOpts.body);
+    expect(submitBody.duration).toBe(10);
+  });
+
+  it('defaults duration to 5 when length is not specified', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-dur-def',
+        polling_url: 'https://openrouter.ai/api/v1/videos/job-dur-def',
+        status: 'pending',
+      }, 202))
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-dur-def',
+        status: 'completed',
+        unsigned_urls: ['https://example.com/dl.mp4'],
+      }))
+      .mockResolvedValueOnce(mp4Resp());
+    vi.stubGlobal('fetch', fetchMock);
+
+    // No `length` key in args — should fall back to 5
+    await generateMedia(argsWithPaths());
+
+    const [, submitOpts] = fetchMock.mock.calls[0]!;
+    const submitBody = JSON.parse(submitOpts.body);
+    expect(submitBody.duration).toBe(5);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// OpenRouter IMAGE generation tests (synchronous, via chat/completions)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('openrouter image generation', () => {
+  let root: string;
+  let projectRoot: string;
+  let projectsRoot: string;
+  const realFetch = globalThis.fetch;
+  const originalMediaConfigDir = process.env.OD_MEDIA_CONFIG_DIR;
+  const originalDataDir = process.env.OD_DATA_DIR;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'od-openrouter-image-'));
+    projectRoot = path.join(root, 'project-root');
+    projectsRoot = path.join(projectRoot, '.od', 'projects');
+    await mkdir(projectsRoot, { recursive: true });
+    delete process.env.OD_MEDIA_CONFIG_DIR;
+    delete process.env.OD_DATA_DIR;
+    process.env.OD_OPENROUTER_API_KEY = 'sk-or-img-test-key';
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = realFetch;
+    delete process.env.OD_OPENROUTER_API_KEY;
+    if (originalMediaConfigDir == null) {
+      delete process.env.OD_MEDIA_CONFIG_DIR;
+    } else {
+      process.env.OD_MEDIA_CONFIG_DIR = originalMediaConfigDir;
+    }
+    if (originalDataDir == null) {
+      delete process.env.OD_DATA_DIR;
+    } else {
+      process.env.OD_DATA_DIR = originalDataDir;
+    }
+    await rm(root, { recursive: true, force: true });
+  });
+
+  // Tiny 1x1 PNG as base64.
+  const PNG_B64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2uoAAAAASUVORK5CYII=';
+  const PNG_DATA_URL = `data:image/png;base64,${PNG_B64}`;
+
+  function imageArgs(overrides?: Record<string, unknown>) {
+    return {
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-img',
+      surface: 'image' as const,
+      model: 'openrouter/google/gemini-2.5-flash-image',
+      prompt: 'A watercolor sunset over mountains',
+      aspect: '16:9',
+      output: 'sunset.png',
+      ...overrides,
+    };
+  }
+
+  function chatResp(images: unknown[], status = 200) {
+    return new Response(JSON.stringify({
+      choices: [{
+        message: {
+          role: 'assistant',
+          content: 'Here is the generated image.',
+          images,
+        },
+      }],
+    }), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  // ─── tests ────────────────────────────────────────────────────────
+
+  it('generates an image via chat/completions with base64 response', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      chatResp([{ type: 'image_url', image_url: { url: PNG_DATA_URL } }]),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await generateMedia(imageArgs());
+
+    expect(result.surface).toBe('image');
+    expect(result.providerId).toBe('openrouter');
+    expect(result.providerNote).toContain('gemini-2.5-flash-image');
+    expect(result.providerNote).toContain('16:9');
+    expect(result.name).toBe('sunset.png');
+
+    const bytes = await readFile(path.join(projectsRoot, 'project-img', 'sunset.png'));
+    expect(bytes.length).toBeGreaterThan(0);
+  });
+
+  it('strips the openrouter/ prefix for the wire model name', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      chatResp([{ type: 'image_url', image_url: { url: PNG_DATA_URL } }]),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await generateMedia(imageArgs());
+
+    const [, opts] = fetchMock.mock.calls[0]!;
+    const body = JSON.parse(opts.body);
+    expect(body.model).toBe('google/gemini-2.5-flash-image');
+    expect(body.model).not.toContain('openrouter/');
+  });
+
+  it('sends OpenRouter attribution headers', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      chatResp([{ type: 'image_url', image_url: { url: PNG_DATA_URL } }]),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await generateMedia(imageArgs());
+
+    const headers = fetchMock.mock.calls[0]![1].headers;
+    expect(headers['HTTP-Referer']).toBe('https://opendesign.dev');
+    expect(headers['X-Title']).toBe('Open Design');
+    expect(headers.authorization).toBe('Bearer sk-or-img-test-key');
+  });
+
+  it('uses /chat/completions endpoint, not /videos', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      chatResp([{ type: 'image_url', image_url: { url: PNG_DATA_URL } }]),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await generateMedia(imageArgs());
+
+    const url = fetchMock.mock.calls[0]![0] as string;
+    expect(url).toBe('https://openrouter.ai/api/v1/chat/completions');
+    expect(url).not.toContain('/videos');
+  });
+
+  it('uses modalities ["image", "text"] for Gemini models', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      chatResp([{ type: 'image_url', image_url: { url: PNG_DATA_URL } }]),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await generateMedia(imageArgs({ model: 'openrouter/google/gemini-2.5-flash-image' }));
+
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body);
+    expect(body.modalities).toEqual(['image', 'text']);
+  });
+
+  it('uses modalities ["image"] for non-Gemini models (Flux)', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      chatResp([{ type: 'image_url', image_url: { url: PNG_DATA_URL } }]),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await generateMedia(imageArgs({ model: 'openrouter/black-forest-labs/flux-1.1-pro' }));
+
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body);
+    expect(body.modalities).toEqual(['image']);
+  });
+
+  it('passes image_config.aspect_ratio through', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      chatResp([{ type: 'image_url', image_url: { url: PNG_DATA_URL } }]),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await generateMedia(imageArgs({ aspect: '9:16' }));
+
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body);
+    expect(body.image_config.aspect_ratio).toBe('9:16');
+    expect(body.image_config.image_size).toBe('1K');
+  });
+
+  it('throws on HTTP error with descriptive message', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: { message: 'insufficient credits' } }), {
+        status: 402,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(generateMedia(imageArgs())).rejects.toThrow(
+      /openrouter image 402/,
+    );
+  });
+
+  it('throws when response contains no images', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        choices: [{
+          message: { role: 'assistant', content: 'I cannot generate images.' },
+        }],
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(generateMedia(imageArgs())).rejects.toThrow(
+      /no images/,
+    );
+  });
+});

--- a/apps/daemon/tests/media-openrouter.test.ts
+++ b/apps/daemon/tests/media-openrouter.test.ts
@@ -383,6 +383,52 @@ describe('openrouter video generation', () => {
     expect(submitBody.duration).toBe(5);
   });
 
+  it('parses resolution suffix from model ID and passes it to OpenRouter', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-res',
+        polling_url: 'https://openrouter.ai/api/v1/videos/job-res',
+        status: 'pending',
+      }, 202))
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-res',
+        status: 'completed',
+        unsigned_urls: ['https://example.com/dl.mp4'],
+      }))
+      .mockResolvedValueOnce(mp4Resp());
+    vi.stubGlobal('fetch', fetchMock);
+
+    await generateMedia({ ...argsWithPaths(), model: 'openrouter/bytedance/seedance-2.0:1080p' });
+
+    const [, submitOpts] = fetchMock.mock.calls[0]!;
+    const submitBody = JSON.parse(submitOpts.body);
+    expect(submitBody.model).toBe('bytedance/seedance-2.0');
+    expect(submitBody.resolution).toBe('1080p');
+  });
+
+  it('defaults resolution to 720p when no suffix is present in model ID', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-res-def',
+        polling_url: 'https://openrouter.ai/api/v1/videos/job-res-def',
+        status: 'pending',
+      }, 202))
+      .mockResolvedValueOnce(jsonResp({
+        id: 'job-res-def',
+        status: 'completed',
+        unsigned_urls: ['https://example.com/dl.mp4'],
+      }))
+      .mockResolvedValueOnce(mp4Resp());
+    vi.stubGlobal('fetch', fetchMock);
+
+    await generateMedia({ ...argsWithPaths(), model: 'openrouter/bytedance/seedance-2.0' });
+
+    const [, submitOpts] = fetchMock.mock.calls[0]!;
+    const submitBody = JSON.parse(submitOpts.body);
+    expect(submitBody.model).toBe('bytedance/seedance-2.0');
+    expect(submitBody.resolution).toBe('720p');
+  });
+
   it('honours OD_MEDIA_MODEL_ALIASES for video (alias contract regression)', async () => {
     // Set an alias: the catalog id 'openrouter/bytedance/seedance-2.0'
     // should resolve to wire name 'my-custom-seedance-deployment'.

--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -2441,8 +2441,8 @@ function MediaProjectOptions(props:
 
 export function supportedModels(surface: 'image' | 'video' | 'audio', models: MediaModel[]): MediaModel[] {
   const supportedProviders: Record<'image' | 'video' | 'audio', Set<string>> = {
-    image: new Set(['openai', 'volcengine', 'grok', 'nanobanana']),
-    video: new Set(['volcengine', 'hyperframes', 'grok']),
+    image: new Set(['openai', 'volcengine', 'grok', 'nanobanana', 'openrouter', 'imagerouter', 'leonardo', 'custom-image']),
+    video: new Set(['volcengine', 'hyperframes', 'grok', 'openrouter', 'imagerouter']),
     audio: new Set(['minimax', 'fishaudio', 'senseaudio', 'elevenlabs', 'openai', 'volcengine']),
   };
   return models.filter((model) => {

--- a/apps/web/src/media/models.ts
+++ b/apps/web/src/media/models.ts
@@ -34,6 +34,7 @@ export type MediaProviderId =
   | 'hyperframes'
   | 'nanobanana'
   | 'imagerouter'
+  | 'openrouter'
   | 'custom-image'
   | 'comfyui'
   | 'bfl'
@@ -132,6 +133,16 @@ export const MEDIA_PROVIDERS: MediaProvider[] = [
     docsUrl: 'https://docs.imagerouter.io/api-reference/image-generation/',
     supportsCustomModel: true,
     customModelPlaceholder: 'openai/gpt-image-2 or xAI/grok-imagine-video',
+  },
+  {
+    id: 'openrouter',
+    label: 'OpenRouter',
+    hint: 'Unified gateway for image + video models',
+    integrated: true,
+    credentialsRequired: true,
+    settingsVisible: true,
+    defaultBaseUrl: 'https://openrouter.ai/api/v1',
+    docsUrl: 'https://openrouter.ai/settings/keys',
   },
   {
     id: 'custom-image',
@@ -417,6 +428,11 @@ export const IMAGE_MODELS: MediaModel[] = [
     caps: ['t2i'],
   },
 
+  // OpenRouter image models.
+  { id: 'openrouter/google/gemini-2.5-flash-image', label: 'gemini-flash-image (OR)', hint: 'OpenRouter · Gemini', provider: 'openrouter', caps: ['t2i'] },
+  { id: 'openrouter/black-forest-labs/flux-1.1-pro', label: 'flux-1.1-pro (OR)', hint: 'OpenRouter · BFL', provider: 'openrouter', caps: ['t2i'] },
+  { id: 'openrouter/recraft/recraft-v3', label: 'recraft-v3 (OR)', hint: 'OpenRouter · Recraft', provider: 'openrouter', caps: ['t2i'] },
+
   // Custom OpenAI-compatible image generation + edit endpoints.
   {
     id: 'custom-image',
@@ -505,6 +521,11 @@ export const VIDEO_MODELS: MediaModel[] = [
     provider: 'grok',
     caps: ['t2v', 'i2v', 'audio'],
   },
+
+  // OpenRouter video models.
+  { id: 'openrouter/bytedance/seedance-2.0', label: 'seedance-2.0 (OR)', hint: 'OpenRouter · ByteDance', provider: 'openrouter', caps: ['t2v', 'i2v'] },
+  { id: 'openrouter/google/veo-3.1', label: 'veo-3.1 (OR)', hint: 'OpenRouter · Google', provider: 'openrouter', caps: ['t2v', 'i2v', 'audio'] },
+  { id: 'openrouter/alibaba/wan-2.7', label: 'wan-2.7 (OR)', hint: 'OpenRouter · Alibaba', provider: 'openrouter', caps: ['t2v', 'i2v'] },
 
   // ImageRouter — routed video models.
   {

--- a/apps/web/src/media/models.ts
+++ b/apps/web/src/media/models.ts
@@ -523,9 +523,12 @@ export const VIDEO_MODELS: MediaModel[] = [
   },
 
   // OpenRouter video models.
-  { id: 'openrouter/bytedance/seedance-2.0', label: 'seedance-2.0 (OR)', hint: 'OpenRouter · ByteDance', provider: 'openrouter', caps: ['t2v', 'i2v'] },
+  { id: 'openrouter/bytedance/seedance-2.0:1080p', label: 'seedance-2.0 1080p (OR)', hint: 'OpenRouter · ByteDance · 1080p', provider: 'openrouter', caps: ['t2v', 'i2v'], default: true },
+  { id: 'openrouter/bytedance/seedance-2.0', label: 'seedance-2.0 720p (OR)', hint: 'OpenRouter · ByteDance · 720p', provider: 'openrouter', caps: ['t2v', 'i2v'] },
+  { id: 'openrouter/bytedance/seedance-2.0:480p', label: 'seedance-2.0 480p (OR)', hint: 'OpenRouter · ByteDance · 480p', provider: 'openrouter', caps: ['t2v', 'i2v'] },
   { id: 'openrouter/google/veo-3.1', label: 'veo-3.1 (OR)', hint: 'OpenRouter · Google', provider: 'openrouter', caps: ['t2v', 'i2v', 'audio'] },
   { id: 'openrouter/alibaba/wan-2.7', label: 'wan-2.7 (OR)', hint: 'OpenRouter · Alibaba', provider: 'openrouter', caps: ['t2v', 'i2v'] },
+  { id: 'openrouter/kwaivgi/kling-v3.0-pro', label: 'kling-v3.0-pro (OR)', hint: 'OpenRouter · Kuaishou', provider: 'openrouter', caps: ['t2v', 'i2v'] },
 
   // ImageRouter — routed video models.
   {

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -161,6 +161,22 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
     models: ['gpt-4o', 'gpt-4o-mini', 'o3', 'o4-mini'],
   },
   {
+    label: 'OpenRouter',
+    protocol: 'openai',
+    baseUrl: 'https://openrouter.ai/api/v1',
+    model: 'anthropic/claude-3.7-sonnet',
+    models: [
+      'anthropic/claude-3.7-sonnet',
+      'anthropic/claude-3.5-sonnet',
+      'google/gemini-2.5-flash',
+      'google/gemini-2.5-pro',
+      'openai/gpt-4o',
+      'openai/o3-mini',
+      'deepseek/deepseek-chat',
+      'deepseek/deepseek-r1',
+    ],
+  },
+  {
     label: 'Azure OpenAI',
     protocol: 'azure',
     baseUrl: '',

--- a/apps/web/tests/components/NewProjectPanel.test.ts
+++ b/apps/web/tests/components/NewProjectPanel.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { supportedModels } from '../../src/components/NewProjectPanel';
-import { AUDIO_MODELS_BY_KIND, IMAGE_MODELS } from '../../src/media/models';
+import { AUDIO_MODELS_BY_KIND, IMAGE_MODELS, VIDEO_MODELS } from '../../src/media/models';
 
 describe('NewProjectPanel image provider visibility', () => {
   it('shows Nano Banana in supported image models', () => {
@@ -19,5 +19,15 @@ describe('NewProjectPanel image provider visibility', () => {
   it('shows ElevenLabs sound effects models in supported audio models', () => {
     const models = supportedModels('audio', AUDIO_MODELS_BY_KIND.sfx);
     expect(models.some((model) => model.id === 'elevenlabs-sfx')).toBe(true);
+  });
+
+  it('shows OpenRouter in supported image models', () => {
+    const models = supportedModels('image', IMAGE_MODELS);
+    expect(models.some((model) => model.provider === 'openrouter')).toBe(true);
+  });
+
+  it('shows OpenRouter in supported video models', () => {
+    const models = supportedModels('video', VIDEO_MODELS);
+    expect(models.some((model) => model.provider === 'openrouter')).toBe(true);
   });
 });

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -446,8 +446,10 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     renderSettingsDialog({ apiProtocol: 'openai', baseUrl: 'https://api.openai.com/v1', model: 'gpt-4o', apiProviderBaseUrl: 'https://api.openai.com/v1' });
 
     fireEvent.click(screen.getByRole('tab', { name: 'OpenAI' }));
+    // Quick fill dropdown indexes for the openai protocol:
+    // 0 = OpenAI, 1 = OpenRouter, 2 = DeepSeek — OpenAI, …
     fireEvent.change(screen.getByLabelText('Quick fill provider'), {
-      target: { value: '1' },
+      target: { value: '2' },
     });
 
     expect(screen.getByRole('combobox', { name: 'Model' }).textContent).toContain('deepseek-chat');


### PR DESCRIPTION
Fixes #1040

## Why

This PR restores the OpenRouter integration originally proposed in PR #1040, resolving the upstream merge conflicts that caused the previous PR to be closed. I am scratching the itch to allow users to use their Bring Your Own Key (BYOK) for OpenRouter image and video generation securely and seamlessly. This addresses the lack of a proper integration and sets up correct request overrides without exposing the API key via downstream CDN requests.

## What users will see

- Settings → AI Providers will accept `openrouter` keys properly for generation if the user supplies it.
- OpenRouter models for Video and Image (e.g. `seedance-2.0`, `veo-3.1`, `gemini-flash-image`) will properly route and generate.
- 30 minute long video polling timeout will allow stable rendering of long upstream videos.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A

## Bug fix verification

-

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/daemon test media-openrouter` verified to pass (21/21 passing, including authorization header safety checks).
