### PR TITLE
fix(web): surface daemon error messages for invalid folder imports

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -892,14 +892,12 @@ export function App() {
 
   const handleImportFolder = useCallback(async (baseDir: string) => {
     const result = await importFolderProject({ baseDir });
-    if (!result) return false;
     setProjects((curr) => [result.project, ...curr.filter((p) => p.id !== result.project.id)]);
     navigate({
       kind: 'project',
       projectId: result.project.id,
       fileName: result.entryFile,
     });
-    return true;
   }, []);
 
   // PR #974: on Electron, the desktop main process owns the picker and

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -217,7 +217,7 @@ interface Props {
     locale?: string,
   ) => Promise<PluginShareProjectOutcome>;
   onImportClaudeDesign: (file: File) => Promise<void> | void;
-  onImportFolder?: (baseDir: string) => Promise<boolean> | boolean;
+  onImportFolder?: (baseDir: string) => Promise<void> | void;
   onOpenProject: (id: string) => void;
   onOpenLiveArtifact: (projectId: string, artifactId: string) => void;
   onDeleteProject: (id: string) => void;

--- a/apps/web/src/components/EntryView.tsx
+++ b/apps/web/src/components/EntryView.tsx
@@ -99,7 +99,7 @@ interface Props {
     locale?: string,
   ) => Promise<PluginShareProjectOutcome>;
   onImportClaudeDesign: (file: File) => Promise<void> | void;
-  onImportFolder?: (baseDir: string) => Promise<boolean> | boolean;
+  onImportFolder?: (baseDir: string) => Promise<void> | void;
   onImportFolderResponse?: (response: ImportFolderResponse) => Promise<void> | void;
   onOpenProject: (id: string) => void;
   onOpenLiveArtifact: (projectId: string, artifactId: string) => void;

--- a/apps/web/src/components/NewProjectModal.tsx
+++ b/apps/web/src/components/NewProjectModal.tsx
@@ -33,7 +33,7 @@ interface Props {
   loading?: boolean;
   onCreate: (input: CreateInput) => void;
   onImportClaudeDesign?: (file: File) => Promise<void> | void;
-  onImportFolder?: (baseDir: string) => Promise<boolean> | boolean;
+  onImportFolder?: (baseDir: string) => Promise<void> | void;
   onOpenConnectorsTab?: () => void;
   onClose: () => void;
 }

--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -150,7 +150,7 @@ interface Props {
   // input and the renderer POSTs `/api/import/folder` itself. Browser
   // builds have no `shell.openPath` surface, so the renderer naming a
   // path here cannot escalate (PR #974 trust model).
-  onImportFolder?: (baseDir: string) => Promise<boolean> | boolean;
+  onImportFolder?: (baseDir: string) => Promise<void> | void;
   // Electron flow: the desktop main process owns the picker dialog and
   // the import call atomically (`pickAndImport` IPC). The renderer
   // never sees the path or the HMAC token; it only receives the
@@ -619,19 +619,17 @@ export function NewProjectPanel({
     }
     if (!onImportFolder) return;
     const trimmed = baseDir.trim();
-    if (!trimmed) return;
+    if (!trimmed) {
+      setImportFolderError({ message: 'Path cannot be empty' });
+      return;
+    }
     setImportFolderError(null);
     setImportingFolder(true);
     try {
-      const opened = await onImportFolder(trimmed);
-      if (!opened) {
-        setImportFolderError({
-          message: `Open folder failed: ${trimmed}`,
-        });
-      }
+      await onImportFolder(trimmed);
     } catch (err) {
       setImportFolderError({
-        message: `Open folder failed: ${err instanceof Error ? err.message : 'unknown error'}`,
+        message: err instanceof Error ? err.message : 'Failed to import folder',
       });
     } finally {
       setImportingFolder(false);

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -90,18 +90,21 @@ export async function createProject(input: {
 
 export async function importFolderProject(
   input: ImportFolderRequest,
-): Promise<ImportFolderResponse | null> {
-  try {
-    const resp = await fetch('/api/import/folder', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(input),
-    });
-    if (!resp.ok) return null;
-    return (await resp.json()) as ImportFolderResponse;
-  } catch {
-    return null;
+): Promise<ImportFolderResponse> {
+  const resp = await fetch('/api/import/folder', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  });
+  if (!resp.ok) {
+    let message = 'Failed to import folder';
+    try {
+      const body = await resp.json();
+      if (body?.error?.message) message = body.error.message;
+    } catch { /* use default message */ }
+    throw new Error(message);
   }
+  return (await resp.json()) as ImportFolderResponse;
 }
 
 export async function importClaudeDesignZip(

--- a/apps/web/tests/components/NewProjectPanel.test.tsx
+++ b/apps/web/tests/components/NewProjectPanel.test.tsx
@@ -635,8 +635,8 @@ describe('NewProjectPanel design system defaults', () => {
 });
 
 describe('NewProjectPanel folder import feedback', () => {
-  it('shows an error when manual folder import resolves as failed', async () => {
-    const onImportFolder = vi.fn().mockResolvedValue(false);
+  it('shows an error when manual folder import rejects with a daemon message', async () => {
+    const onImportFolder = vi.fn().mockRejectedValue(new Error('folder not found'));
 
     render(
       <NewProjectPanel
@@ -657,7 +657,7 @@ describe('NewProjectPanel folder import feedback', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Open folder' }));
 
     expect(onImportFolder).toHaveBeenCalledWith('/missing/project');
-    expect(await screen.findByText('Open folder failed: /missing/project')).toBeTruthy();
+    expect(await screen.findByText('folder not found')).toBeTruthy();
   });
 });
 

--- a/apps/web/tests/state/projects.test.ts
+++ b/apps/web/tests/state/projects.test.ts
@@ -3,6 +3,7 @@ import {
   applyPlugin,
   contributeGeneratedPluginToOpenDesign,
   createPluginShareProject,
+  importFolderProject,
   installGeneratedPluginFolder,
   listPlugins,
   publishGeneratedPluginToGitHub,
@@ -276,5 +277,66 @@ describe('createPluginShareProject', () => {
       code: 'share-action-plugin-missing',
       message: 'Restart the daemon.',
     });
+  });
+});
+
+describe('importFolderProject', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns the project on success', async () => {
+    const response = {
+      project: { id: 'p-1', name: 'My Folder' },
+      conversationId: 'conv-1',
+      entryFile: 'index.html',
+    };
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response(
+      JSON.stringify(response),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    )));
+
+    const result = await importFolderProject({ baseDir: '/home/user/project' });
+    expect(result).toMatchObject({ project: { id: 'p-1' }, entryFile: 'index.html' });
+  });
+
+  it('throws with daemon error message for filesystem root', async () => {
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response(
+      JSON.stringify({ error: { code: 'BAD_REQUEST', message: 'cannot import the filesystem root' } }),
+      { status: 400, headers: { 'content-type': 'application/json' } },
+    )));
+
+    await expect(importFolderProject({ baseDir: '/' }))
+      .rejects.toThrow('cannot import the filesystem root');
+  });
+
+  it('throws with daemon error message for non-existent folder', async () => {
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response(
+      JSON.stringify({ error: { code: 'BAD_REQUEST', message: 'folder not found' } }),
+      { status: 400, headers: { 'content-type': 'application/json' } },
+    )));
+
+    await expect(importFolderProject({ baseDir: '/abc/xyz/notexist' }))
+      .rejects.toThrow('folder not found');
+  });
+
+  it('throws with daemon error message for file path', async () => {
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response(
+      JSON.stringify({ error: { code: 'BAD_REQUEST', message: 'path must be a directory' } }),
+      { status: 400, headers: { 'content-type': 'application/json' } },
+    )));
+
+    await expect(importFolderProject({ baseDir: '/etc/hosts' }))
+      .rejects.toThrow('path must be a directory');
+  });
+
+  it('throws a fallback message when response body has no error detail', async () => {
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response(
+      'Internal Server Error',
+      { status: 500 },
+    )));
+
+    await expect(importFolderProject({ baseDir: '/some/path' }))
+      .rejects.toThrow('Failed to import folder');
   });
 });


### PR DESCRIPTION
Fixes #1186

## Why

When users enter an invalid file path in the "Open folder" flow, the daemon already returns specific error messages (`cannot import the filesystem root`, `folder not found`, `path must be a directory`, etc.), but the web client was discarding them. `importFolderProject()` collapsed every non-2xx response to `null`, so the UI could only show a generic `Open folder failed: <path>` — no actionable feedback for the user.

Additionally, submitting an empty path silently did nothing.

## What users will see

- Entering `/` → toast: **"cannot import the filesystem root"**
- Entering `/abc/xyz/notexist` → toast: **"folder not found"**
- Entering `/etc/hosts` → toast: **"path must be a directory"**
- Entering empty/whitespace → toast: **"Path cannot be empty"**
- Valid folder paths work as before

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only

## Bug fix verification

- Reproduced on `main`: entering `/`, non-existent paths, or empty input produces only a generic `Open folder failed: <path>` toast (or no feedback at all for empty input)
- After fix: daemon's specific error messages are displayed in the toast
- 5 new unit tests added to `apps/web/tests/state/projects.test.ts` covering success, filesystem root, non-existent folder, file-not-directory, and unparseable error body

## Validation

- `pnpm guard` ✅
- `pnpm --filter @open-design/web typecheck` ✅
- `pnpm --filter @open-design/web exec vitest run tests/state/projects.test.ts` — 13/13 passed ✅
- Manual testing in browser against running daemon ✅