### PR TITLE
[codex] fix conversation title editing

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -510,6 +510,65 @@ export function ChatPane({
 
   const activeConversation =
     conversations.find((c) => c.id === activeConversationId) ?? null;
+  const activeConversationMissing = !activeConversation;
+  const activeConversationTitle =
+    activeConversation
+      ? activeConversation.title || t('chat.untitledConversation')
+      : t('chat.conversationsHeading');
+  const activeConversationRenameLabel = activeConversation
+    ? t('chat.renameConversationLabel', { title: activeConversationTitle })
+    : '';
+  const titleEditClosedRef = useRef(false);
+  const [editingActiveTitle, setEditingActiveTitle] = useState(false);
+  const [activeTitleDraft, setActiveTitleDraft] = useState('');
+
+  useEffect(() => {
+    if (editingActiveTitle) return;
+    setActiveTitleDraft(activeConversation?.title ?? '');
+  }, [activeConversation?.title, editingActiveTitle]);
+
+  // Switching conversations should always close the inline editor so the
+  // old draft cannot leak into the next conversation.
+  useEffect(() => {
+    titleEditClosedRef.current = true;
+    setEditingActiveTitle(false);
+  }, [activeConversationId]);
+
+  // The selected id can stay stable while the record temporarily vanishes
+  // during a reload; cancel the editor in that case as well.
+  useEffect(() => {
+    if (!activeConversationMissing) return;
+    titleEditClosedRef.current = true;
+    setEditingActiveTitle(false);
+  }, [activeConversationMissing]);
+
+  function beginActiveTitleRename() {
+    if (!activeConversation || !onRenameConversation) return;
+    titleEditClosedRef.current = false;
+    setActiveTitleDraft(activeConversation.title ?? '');
+    setEditingActiveTitle(true);
+  }
+
+  function commitActiveTitleRename() {
+    if (titleEditClosedRef.current) return;
+    titleEditClosedRef.current = true;
+    if (activeConversation && onRenameConversation) {
+      const nextTitle = normalizeConversationRename(
+        activeConversation.title,
+        activeTitleDraft,
+      );
+      if (nextTitle !== null) {
+        onRenameConversation(activeConversation.id, nextTitle);
+      }
+    }
+    setEditingActiveTitle(false);
+  }
+
+  function cancelActiveTitleRename() {
+    titleEditClosedRef.current = true;
+    setActiveTitleDraft(activeConversation?.title ?? '');
+    setEditingActiveTitle(false);
+  }
 
   function jumpToBottom() {
     const el = logRef.current;
@@ -520,6 +579,49 @@ export function ChatPane({
   return (
     <div className="pane">
       <div className="chat-header">
+        <div className="chat-active-conversation">
+          {editingActiveTitle && activeConversation && onRenameConversation ? (
+            <input
+              autoFocus
+              className="chat-active-conversation-input"
+              data-testid="chat-active-conversation-rename-input"
+              aria-label={activeConversationRenameLabel}
+              value={activeTitleDraft}
+              onChange={(e) => setActiveTitleDraft(e.target.value)}
+              onBlur={commitActiveTitleRename}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  commitActiveTitleRename();
+                } else if (e.key === 'Escape') {
+                  e.preventDefault();
+                  cancelActiveTitleRename();
+                }
+              }}
+            />
+          ) : (
+            <>
+              <span
+                className="chat-active-conversation-title"
+                data-testid="chat-active-conversation-title"
+                title={activeConversationTitle}
+              >
+                {activeConversationTitle}
+              </span>
+              {activeConversation && onRenameConversation ? (
+                <button
+                  type="button"
+                  className="chat-active-conversation-rename"
+                  aria-label={activeConversationRenameLabel}
+                  title={t('common.rename')}
+                  onClick={beginActiveTitleRename}
+                >
+                  <Icon name="pencil" size={13} />
+                </button>
+              ) : null}
+            </>
+          )}
+        </div>
         <div className="chat-header-actions">
           <div
             className={`chat-history-wrap${showConvList ? ' open' : ''}`}
@@ -883,8 +985,35 @@ function ConversationRow({
 }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(conversation.title ?? '');
+  const titleEditClosedRef = useRef(false);
   const displayTitle =
     conversation.title || t('chat.untitledConversation');
+
+  function beginConversationRename() {
+    if (!onRename) return;
+    titleEditClosedRef.current = false;
+    setDraft(conversation.title ?? '');
+    setEditing(true);
+  }
+
+  function commitConversationRename() {
+    if (titleEditClosedRef.current) return;
+    titleEditClosedRef.current = true;
+    if (onRename) {
+      const nextTitle = normalizeConversationRename(conversation.title, draft);
+      if (nextTitle !== null) {
+        onRename(conversation.id, nextTitle);
+      }
+    }
+    setEditing(false);
+  }
+
+  function cancelConversationRename() {
+    titleEditClosedRef.current = true;
+    setDraft(conversation.title ?? '');
+    setEditing(false);
+  }
+
   return (
     <div
       className={`chat-conv-item${active ? ' active' : ''}`}
@@ -896,16 +1025,14 @@ function ConversationRow({
           className="chat-conv-rename-input"
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
-          onBlur={() => {
-            onRename(conversation.id, draft);
-            setEditing(false);
-          }}
+          onBlur={commitConversationRename}
           onKeyDown={(e) => {
             if (e.key === 'Enter') {
-              onRename(conversation.id, draft);
-              setEditing(false);
+              e.preventDefault();
+              commitConversationRename();
             } else if (e.key === 'Escape') {
-              setEditing(false);
+              e.preventDefault();
+              cancelConversationRename();
             }
           }}
           style={{ flex: 1, padding: '2px 6px', fontSize: 12 }}
@@ -917,11 +1044,7 @@ function ConversationRow({
           data-testid={`conversation-select-${conversation.id}`}
           style={{ background: 'transparent', border: 'none', padding: 0, textAlign: 'left' }}
           onClick={onSelect}
-          onDoubleClick={() => {
-            if (!onRename) return;
-            setDraft(conversation.title ?? '');
-            setEditing(true);
-          }}
+          onDoubleClick={beginConversationRename}
         >
           {displayTitle}
         </button>
@@ -945,6 +1068,15 @@ function ConversationRow({
       </button>
     </div>
   );
+}
+
+function normalizeConversationRename(
+  currentTitle: string | null | undefined,
+  draft: string,
+): string | null {
+  const current = (currentTitle ?? '').trim();
+  const next = draft.trim();
+  return next === current ? null : next;
 }
 
 function UserMessage({

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -575,6 +575,7 @@ export const ar: Dict = {
   'chat.new': 'جديد',
   'chat.emptyConversations': 'لا توجد محادثات بعد.',
   'chat.deleteConversation': 'حذف المحادثة',
+  'chat.renameConversationLabel': 'إعادة تسمية "{title}"',
   'chat.deleteConversationConfirm':
     'هل تريد حذف "{title}"؟ سيؤدي هذا لإزالة رسائلها.',
   'chat.untitledConversation': 'محادثة بدون عنوان',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -463,6 +463,7 @@ export const de: Dict = {
   'chat.new': 'Neu',
   'chat.emptyConversations': 'Noch keine Konversationen.',
   'chat.deleteConversation': 'Konversation löschen',
+  'chat.renameConversationLabel': '„{title}“ umbenennen',
   'chat.deleteConversationConfirm':
     '„{title}“ löschen? Dadurch werden die Nachrichten entfernt.',
   'chat.untitledConversation': 'Konversation ohne Titel',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -669,6 +669,7 @@ export const en: Dict = {
   'chat.new': 'New',
   'chat.emptyConversations': 'No conversations yet.',
   'chat.deleteConversation': 'Delete conversation',
+  'chat.renameConversationLabel': 'Rename "{title}"',
   'chat.deleteConversationConfirm':
     'Delete "{title}"? This removes its messages.',
   'chat.untitledConversation': 'Untitled conversation',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -464,6 +464,7 @@ export const esES: Dict = {
   'chat.new': 'Nueva',
   'chat.emptyConversations': 'Aún no hay conversaciones.',
   'chat.deleteConversation': 'Eliminar conversación',
+  'chat.renameConversationLabel': 'Renombrar «{title}»',
   'chat.deleteConversationConfirm':
     '¿Eliminar «{title}»? Se borrarán sus mensajes.',
   'chat.untitledConversation': 'Conversación sin título',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -597,6 +597,7 @@ export const fa: Dict = {
   'chat.new': 'جدید',
   'chat.emptyConversations': 'هنوز هیچ مکالمه‌ای وجود ندارد.',
   'chat.deleteConversation': 'حذف مکالمه',
+  'chat.renameConversationLabel': 'تغییر نام «{title}»',
   'chat.deleteConversationConfirm':
     'آیا «{title}» حذف شود؟ این کار پیام‌های آن را حذف می‌کند.',
   'chat.untitledConversation': 'مکالمه بدون عنوان',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -575,6 +575,7 @@ export const fr: Dict = {
   'chat.new': 'Nouvelle',
   'chat.emptyConversations': 'Aucune conversation pour l\'instant.',
   'chat.deleteConversation': 'Supprimer la conversation',
+  'chat.renameConversationLabel': 'Renommer « {title} »',
   'chat.deleteConversationConfirm':
     'Supprimer « {title} » ? Cela supprime ses messages.',
   'chat.untitledConversation': 'Conversation sans titre',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -575,6 +575,7 @@ export const hu: Dict = {
   'chat.new': 'Új',
   'chat.emptyConversations': 'Még nincs beszélgetés.',
   'chat.deleteConversation': 'Beszélgetés törlése',
+  'chat.renameConversationLabel': '„{title}” átnevezése',
   'chat.deleteConversationConfirm':
     'Törlöd a(z) „{title}" beszélgetést? Ez eltávolítja az üzeneteit.',
   'chat.untitledConversation': 'Cím nélküli beszélgetés',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -692,6 +692,7 @@ export const id: Dict = {
   'chat.new': 'Baru',
   'chat.emptyConversations': 'Belum ada percakapan.',
   'chat.deleteConversation': 'Hapus percakapan',
+  'chat.renameConversationLabel': 'Ganti nama "{title}"',
   'chat.deleteConversationConfirm': 'Hapus "{title}"? Semua pesannya ikut dihapus.',
   'chat.untitledConversation': 'Percakapan tanpa judul',
   'chat.startTitle': 'Mulai percakapan',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -462,6 +462,7 @@ export const ja: Dict = {
   'chat.new': '新規',
   'chat.emptyConversations': 'まだ会話がありません。',
   'chat.deleteConversation': '会話を削除',
+  'chat.renameConversationLabel': '「{title}」の名前を変更',
   'chat.deleteConversationConfirm':
     '"{title}" を削除しますか？メッセージも削除されます。',
   'chat.untitledConversation': '無題の会話',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -575,6 +575,7 @@ export const ko: Dict = {
   'chat.new': '새로 만들기',
   'chat.emptyConversations': '아직 대화가 없습니다.',
   'chat.deleteConversation': '대화 삭제',
+  'chat.renameConversationLabel': '"{title}" 이름 변경',
   'chat.deleteConversationConfirm':
     '"{title}" 대화를 삭제하시겠습니까? 관련 메시지가 모두 삭제됩니다.',
   'chat.untitledConversation': '제목 없는 대화',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -575,6 +575,7 @@ export const pl: Dict = {
   'chat.new': 'Nowa',
   'chat.emptyConversations': 'Brak rozmów.',
   'chat.deleteConversation': 'Usuń rozmowę',
+  'chat.renameConversationLabel': 'Zmień nazwę „{title}”',
   'chat.deleteConversationConfirm':
       'Usunąć „{title}”? Spowoduje to usunięcie wszystkich wiadomości.',
   'chat.untitledConversation': 'Rozmowa bez tytułu',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -596,6 +596,7 @@ export const ptBR: Dict = {
   'chat.new': 'Nova',
   'chat.emptyConversations': 'Ainda não há conversas.',
   'chat.deleteConversation': 'Excluir conversa',
+  'chat.renameConversationLabel': 'Renomear "{title}"',
   'chat.deleteConversationConfirm':
     'Excluir "{title}"? Isso remove as mensagens.',
   'chat.untitledConversation': 'Conversa sem título',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -596,6 +596,7 @@ export const ru: Dict = {
   'chat.new': 'Новый',
   'chat.emptyConversations': 'Разговоров пока нет.',
   'chat.deleteConversation': 'Удалить разговор',
+  'chat.renameConversationLabel': 'Переименовать «{title}»',
   'chat.deleteConversationConfirm':
     'Удалить «{title}»? Это удалит его сообщения.',
   'chat.untitledConversation': 'Разговор без названия',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -563,6 +563,7 @@ export const th: Dict = {
   'chat.new': 'ใหม่',
   'chat.emptyConversations': 'ยังไม่มีบทสนทนา',
   'chat.deleteConversation': 'ลบบทสนทนา',
+  'chat.renameConversationLabel': 'เปลี่ยนชื่อ "{title}"',
   'chat.deleteConversationConfirm': 'ลบ "{title}" หรือไม่?',
   'chat.untitledConversation': 'บทสนทนาที่ไม่มีชื่อ',
   'chat.startTitle': 'เริ่มแชทได้เลย',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -564,6 +564,7 @@ export const tr: Dict = {
   'chat.new': 'Yeni',
   'chat.emptyConversations': 'Henüz konuşma yok.',
   'chat.deleteConversation': 'Konuşmayı sil',
+  'chat.renameConversationLabel': '"{title}" adını değiştir',
   'chat.deleteConversationConfirm':
     '"{title}"’ı sil? Bu mesajları silecektir.',
   'chat.untitledConversation': 'Başlıksız konuşma',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -597,6 +597,7 @@ export const uk: Dict = {
   'chat.new': 'Нова',
   'chat.emptyConversations': 'Розмов ще немає.',
   'chat.deleteConversation': 'Видалити розмову',
+  'chat.renameConversationLabel': 'Перейменувати "{title}"',
   'chat.deleteConversationConfirm':
     'Видалити "{title}"? Це видалить усі її повідомлення.',
   'chat.untitledConversation': 'Розмова без назви',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -662,6 +662,7 @@ export const zhCN: Dict = {
   'chat.new': '新建',
   'chat.emptyConversations': '还没有对话。',
   'chat.deleteConversation': '删除对话',
+  'chat.renameConversationLabel': '重命名「{title}」',
   'chat.deleteConversationConfirm': '确定删除「{title}」？该操作会删除其消息。',
   'chat.untitledConversation': '未命名对话',
   'chat.startTitle': '开始一个对话',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -653,6 +653,7 @@ export const zhTW: Dict = {
   'chat.new': '新建',
   'chat.emptyConversations': '還沒有對話。',
   'chat.deleteConversation': '刪除對話',
+  'chat.renameConversationLabel': '重新命名「{title}」',
   'chat.deleteConversationConfirm': '確定刪除「{title}」？該操作會刪除其訊息。',
   'chat.untitledConversation': '未命名對話',
   'chat.startTitle': '開始一個對話',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -928,6 +928,7 @@ export interface Dict {
   'chat.new': string;
   'chat.emptyConversations': string;
   'chat.deleteConversation': string;
+  'chat.renameConversationLabel': string;
   'chat.deleteConversationConfirm': string;
   'chat.untitledConversation': string;
   'chat.startTitle': string;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1031,7 +1031,61 @@ code {
   color: var(--text);
   border-bottom-color: var(--text);
 }
-.chat-header-actions { display: inline-flex; gap: 4px; align-items: center; margin-left: auto; }
+.chat-active-conversation {
+  min-width: 0;
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.chat-active-conversation-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+.chat-active-conversation-rename {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-faint);
+  border-radius: 5px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+}
+.chat-active-conversation-rename:hover {
+  background: var(--bg-subtle);
+  color: var(--text);
+}
+.chat-active-conversation-rename:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.chat-active-conversation-input {
+  width: 100%;
+  min-width: 0;
+  height: 28px;
+  padding: 3px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 600;
+}
+.chat-active-conversation-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+.chat-header-actions { display: inline-flex; gap: 4px; align-items: center; }
 .chat-header-actions .icon-only {
   width: 28px; height: 28px;
   padding: 0;

--- a/apps/web/tests/components/ChatPane.conversation-title.test.tsx
+++ b/apps/web/tests/components/ChatPane.conversation-title.test.tsx
@@ -1,0 +1,288 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { forwardRef } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ChatPane } from '../../src/components/ChatPane';
+import type { ChatMessage, Conversation } from '../../src/types';
+
+vi.mock('../../src/i18n', () => ({
+  useT: () => (key: string, vars?: Record<string, string | number>) => {
+    if (key === 'chat.renameConversationLabel') {
+      return `chat.renameConversationLabel ${vars?.title ?? ''}`;
+    }
+    return key;
+  },
+}));
+
+vi.mock('../../src/components/AssistantMessage', () => ({
+  AssistantMessage: ({ message }: { message: ChatMessage }) => (
+    <div data-testid={`assistant-${message.id}`}>{message.content}</div>
+  ),
+}));
+
+vi.mock('../../src/components/ChatComposer', () => ({
+  ChatComposer: forwardRef((_props, _ref) => <div data-testid="composer" />),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('ChatPane conversation title', () => {
+  it('shows the active conversation title in the chat header', () => {
+    renderChatPane({
+      conversations: [conversation({ id: 'conv-1', title: 'Contract review draft' })],
+      activeConversationId: 'conv-1',
+    });
+
+    expect(screen.getByTestId('chat-active-conversation-title').textContent).toBe('Contract review draft');
+  });
+
+  it('renames the active conversation from the chat header', () => {
+    const onRenameConversation = vi.fn();
+    renderChatPane({
+      conversations: [conversation({ id: 'conv-1', title: 'Contract review draft' })],
+      activeConversationId: 'conv-1',
+      onRenameConversation,
+    });
+
+    fireEvent.click(screen.getByLabelText('chat.renameConversationLabel Contract review draft'));
+    const input = screen.getByTestId('chat-active-conversation-rename-input');
+    fireEvent.change(input, { target: { value: '  Contract review v2  ' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    fireEvent.blur(input);
+
+    expect(onRenameConversation).toHaveBeenCalledTimes(1);
+    expect(onRenameConversation).toHaveBeenCalledWith('conv-1', 'Contract review v2');
+  });
+
+  it('cancels the active conversation rename without saving', () => {
+    const onRenameConversation = vi.fn();
+    renderChatPane({
+      conversations: [conversation({ id: 'conv-1', title: 'Contract review draft' })],
+      activeConversationId: 'conv-1',
+      onRenameConversation,
+    });
+
+    fireEvent.click(screen.getByLabelText('chat.renameConversationLabel Contract review draft'));
+    const input = screen.getByTestId('chat-active-conversation-rename-input');
+    fireEvent.change(input, { target: { value: 'Do not save this' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+    fireEvent.blur(input);
+
+    expect(onRenameConversation).not.toHaveBeenCalled();
+    expect(screen.getByTestId('chat-active-conversation-title').textContent).toBe('Contract review draft');
+  });
+
+  it('does not save unchanged titles', () => {
+    const onRenameConversation = vi.fn();
+    renderChatPane({
+      conversations: [conversation({ id: 'conv-1', title: 'Contract review draft' })],
+      activeConversationId: 'conv-1',
+      onRenameConversation,
+    });
+
+    fireEvent.click(screen.getByLabelText('chat.renameConversationLabel Contract review draft'));
+    const input = screen.getByTestId('chat-active-conversation-rename-input');
+    fireEvent.change(input, { target: { value: '  Contract review draft  ' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onRenameConversation).not.toHaveBeenCalled();
+  });
+
+  it('submits an empty title when clearing an existing title', () => {
+    const onRenameConversation = vi.fn();
+    renderChatPane({
+      conversations: [conversation({ id: 'conv-1', title: 'Contract review draft' })],
+      activeConversationId: 'conv-1',
+      onRenameConversation,
+    });
+
+    fireEvent.click(screen.getByLabelText('chat.renameConversationLabel Contract review draft'));
+    const input = screen.getByTestId('chat-active-conversation-rename-input');
+    fireEvent.change(input, { target: { value: '   ' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onRenameConversation).toHaveBeenCalledTimes(1);
+    expect(onRenameConversation).toHaveBeenCalledWith('conv-1', '');
+  });
+
+  it('does not submit an empty title when the conversation is already untitled', () => {
+    const onRenameConversation = vi.fn();
+    renderChatPane({
+      conversations: [conversation({ id: 'conv-1', title: null })],
+      activeConversationId: 'conv-1',
+      onRenameConversation,
+    });
+
+    fireEvent.click(screen.getByLabelText('chat.renameConversationLabel chat.untitledConversation'));
+    const input = screen.getByTestId('chat-active-conversation-rename-input');
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onRenameConversation).not.toHaveBeenCalled();
+  });
+
+  it('does not show a rename control when there is no active conversation', () => {
+    renderChatPane({
+      conversations: [],
+      activeConversationId: null,
+    });
+
+    expect(screen.getByTestId('chat-active-conversation-title').textContent).toBe('chat.conversationsHeading');
+    expect(screen.queryByLabelText(/^chat\.renameConversationLabel /)).toBeNull();
+  });
+
+  it('does not show a rename control when rename handling is unavailable', () => {
+    renderChatPane({
+      conversations: [conversation({ id: 'conv-1', title: 'Contract review draft' })],
+      activeConversationId: 'conv-1',
+      onRenameConversation: undefined,
+    });
+
+    expect(screen.getByTestId('chat-active-conversation-title').textContent).toBe('Contract review draft');
+    expect(screen.queryByLabelText(/^chat\.renameConversationLabel /)).toBeNull();
+  });
+
+  it('trims the conversation history rename flow the same way as the header', () => {
+    const onRenameConversation = vi.fn();
+    renderChatPane({
+      conversations: [conversation({ id: 'conv-1', title: 'Contract review draft' })],
+      activeConversationId: 'conv-1',
+      onRenameConversation,
+    });
+
+    fireEvent.click(screen.getByTestId('conversation-history-trigger'));
+    fireEvent.doubleClick(screen.getByTestId('conversation-select-conv-1'));
+
+    const input = screen.getByDisplayValue('Contract review draft');
+    fireEvent.change(input, { target: { value: '  Contract review v2  ' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onRenameConversation).toHaveBeenCalledTimes(1);
+    expect(onRenameConversation).toHaveBeenCalledWith('conv-1', 'Contract review v2');
+  });
+
+  it('does not save unchanged titles from the conversation history menu', () => {
+    const onRenameConversation = vi.fn();
+    renderChatPane({
+      conversations: [conversation({ id: 'conv-1', title: 'Contract review draft' })],
+      activeConversationId: 'conv-1',
+      onRenameConversation,
+    });
+
+    fireEvent.click(screen.getByTestId('conversation-history-trigger'));
+    fireEvent.doubleClick(screen.getByTestId('conversation-select-conv-1'));
+
+    const input = screen.getByDisplayValue('Contract review draft');
+    fireEvent.change(input, { target: { value: '  Contract review draft  ' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onRenameConversation).not.toHaveBeenCalled();
+  });
+
+  it('exits title editing when the active conversation changes', () => {
+    const onRenameConversation = vi.fn();
+    const { rerender } = renderChatPane({
+      conversations: [
+        conversation({ id: 'conv-1', title: 'First conversation' }),
+        conversation({ id: 'conv-2', title: 'Second conversation' }),
+      ],
+      activeConversationId: 'conv-1',
+      onRenameConversation,
+    });
+
+    fireEvent.click(screen.getByLabelText('chat.renameConversationLabel First conversation'));
+    fireEvent.change(screen.getByTestId('chat-active-conversation-rename-input'), {
+      target: { value: 'Unsaved draft' },
+    });
+
+    rerender(chatPaneElement({
+      conversations: [
+        conversation({ id: 'conv-1', title: 'First conversation' }),
+        conversation({ id: 'conv-2', title: 'Second conversation' }),
+      ],
+      activeConversationId: 'conv-2',
+      onRenameConversation,
+    }));
+
+    expect(screen.queryByTestId('chat-active-conversation-rename-input')).toBeNull();
+    expect(screen.getByTestId('chat-active-conversation-title').textContent).toBe('Second conversation');
+    expect(onRenameConversation).not.toHaveBeenCalled();
+  });
+
+  it('exits title editing when the active conversation record disappears', () => {
+    const onRenameConversation = vi.fn();
+    const { rerender } = renderChatPane({
+      conversations: [conversation({ id: 'conv-1', title: 'First conversation' })],
+      activeConversationId: 'conv-1',
+      onRenameConversation,
+    });
+
+    fireEvent.click(screen.getByLabelText('chat.renameConversationLabel First conversation'));
+    fireEvent.change(screen.getByTestId('chat-active-conversation-rename-input'), {
+      target: { value: 'Unsaved draft' },
+    });
+
+    rerender(chatPaneElement({
+      conversations: [],
+      activeConversationId: 'conv-1',
+      onRenameConversation,
+    }));
+
+    expect(screen.queryByTestId('chat-active-conversation-rename-input')).toBeNull();
+    expect(screen.getByTestId('chat-active-conversation-title').textContent).toBe('chat.conversationsHeading');
+    expect(onRenameConversation).not.toHaveBeenCalled();
+  });
+});
+
+function renderChatPane({
+  conversations,
+  activeConversationId,
+  onRenameConversation,
+}: {
+  conversations: Conversation[];
+  activeConversationId: string | null;
+  onRenameConversation?: (id: string, title: string) => void;
+}) {
+  return render(chatPaneElement({ conversations, activeConversationId, onRenameConversation }));
+}
+
+function chatPaneElement({
+  conversations,
+  activeConversationId,
+  onRenameConversation,
+}: {
+  conversations: Conversation[];
+  activeConversationId: string | null;
+  onRenameConversation?: ((id: string, title: string) => void) | undefined;
+}) {
+  return (
+    <ChatPane
+      messages={[]}
+      streaming={false}
+      error={null}
+      projectId="project-1"
+      projectFiles={[]}
+      onEnsureProject={async () => 'project-1'}
+      onSend={vi.fn()}
+      onStop={vi.fn()}
+      conversations={conversations}
+      activeConversationId={activeConversationId}
+      onSelectConversation={vi.fn()}
+      onDeleteConversation={vi.fn()}
+      onRenameConversation={onRenameConversation}
+    />
+  );
+}
+
+function conversation(input: { id: string; title: string | null }): Conversation {
+  return {
+    id: input.id,
+    projectId: 'project-1',
+    title: input.title,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}


### PR DESCRIPTION
## Summary
- Show the active conversation title in the chat header and add an inline rename control.
- Normalize rename submission across the header and conversation list so trim / unchanged / empty-title behavior is consistent.
- Add i18n keys, styles, and tests for the new title UI.

## Why
The generated conversation title was not visible or editable from the active chat view, which made the feature hard to discover and use.

## Validation
- pnpm --filter @open-design/web test -- tests/components/ChatPane.conversation-title.test.tsx
- pnpm --filter @open-design/web test -- tests/components/ChatPane.streaming.test.tsx tests/components/chat-scroll-preservation.test.tsx tests/components/conversation-timestamps.test.tsx
- pnpm --filter @open-design/web typecheck
- pnpm guard
- Browser verification in a local namespace

Fixes #1911
