### PR TITLE
fix: horizontal overflow pushes chat panel and toolbar off-screen whe…(#1929)

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -476,9 +476,11 @@ code {
    * viewport). The split gets explicit `grid-row: 3` below so the
    * layout works whether the toolbar is rendered or returns null
    * (workspace-focused mode). */
+  grid-template-columns: minmax(0, 1fr);
   grid-template-rows: auto auto 1fr;
   height: 100vh;
   background: var(--bg-app);
+  overflow: hidden;
 }
 .app > .split {
   grid-row: 3;
@@ -10721,6 +10723,7 @@ button.connector-action.is-loading {
   display: flex;
   align-items: flex-start;
   justify-content: center;
+  min-width: 0;
   padding: 24px;
   background:
     linear-gradient(45deg, color-mix(in srgb, var(--border) 28%, transparent) 25%, transparent 25%),


### PR DESCRIPTION
…n iframe preview exceeds viewport width


## Why

       - Your use case — I am scratching an itch for a team.
       - The pain being addressed — user-facing problem.
     For non-trivial features, please open a discussion or issue first to align



## What users will see

The user will observe a change on the UI.


## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only


## Screenshots

before:
<img width="1024" height="533" alt="ced0eb0f-1b17-4f35-97f1-2c6a1b6b63eb" src="https://github.com/user-attachments/assets/fabedf15-c78e-45aa-87df-f0e67ace5da8" />
after:
<img width="1500" height="769" alt="1a06ea20aab13091cd54385427b5c71b" src="https://github.com/user-attachments/assets/1bc261ad-fde8-4e85-a516-b351746f6c11" />



## Bug fix verification

  1. Open any project and generate an HTML artifact (e.g., a todo app page)
  2. Open the artifact in preview mode (desktop viewport)
  3. Observe that the .split grid container expands to the scroll width of the .app grid column
 The page layout stays fixed to the viewport width. Only the iframe / preview area scrolls internally. The chat
  panel, resize handle, toolbar, and workspace tabs all remain at their intended positions within one screen
  width.


-


## Validation

pnpm --filter @open-design/web test

-
