### PR TITLE
fix: add SPA fallback for static export in production daemon

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -9976,6 +9976,17 @@ export async function startServer({
       await design.runs.shutdownActive({ graceMs: resolveChatRunShutdownGraceMs() });
       await design.analytics.shutdown();
     };
+    if (fs.existsSync(STATIC_DIR)) {
+      const spaIndex = path.join(STATIC_DIR, 'index.html');
+      app.use((req, res, next) => {
+        if (req.method === 'GET' && !req.path.startsWith('/api/') && !req.path.startsWith('/artifacts/') && !req.path.startsWith('/frames/')) {
+          res.sendFile(spaIndex);
+        } else {
+          next();
+        }
+      });
+    }
+
     let server;
     try {
       server = app.listen(port, host, () => {


### PR DESCRIPTION
## Why

Hit this myself while deploying Open Design as a Docker container (daemon + static export) behind an nginx ingress on Kubernetes. Any browser refresh on a client-side route like `/projects/:id` or `/projects/:id/files/:name` returns Express's default 404 ("Cannot GET ...") because the daemon's `express.static(STATIC_DIR)` has no catch-all fallback to serve `index.html` for the SPA router.

In development this doesn't surface because Next.js dev server handles all routing. In production with the static export (`output: 'export'` → `apps/web/out/`), the daemon is the only server — it must serve `index.html` for any path that isn't a real static file or API endpoint so the React client can hydrate and take over routing.

## What users will see

Browser refresh on any non-root page (projects, conversations, file views) now loads the app instead of showing "Cannot GET /projects/...". Affects anyone running the daemon in Docker/production mode with the static export.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only


## Bug fix verification

- A red spec isn't cheap for this because it requires an e2e test against the built static export served by the daemon (not the Next.js dev server). The bug is only observable in the `output: 'export'` production path.
- Verified manually: deployed the patched daemon behind `https://od.xxx.com`, navigated to `/projects/:id/files/:name.html`, refreshed — page loads correctly. Before the fix, same URL returned HTTP 404 with "Cannot GET".

## Validation

- `pnpm --filter @open-design/daemon build` (confirms the patch compiles)
- Manual Docker deployment via `deploy/Dockerfile` — daemon starts, serves SPA routes on refresh