### PR TITLE
feat: display and allow editing conversation title in chat header

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -621,6 +621,7 @@ export function ChatPane({
 
   const [editingTitle, setEditingTitle] = useState(false);
   const [titleDraft, setTitleDraft] = useState('');
+  const titleHandledRef = useRef(false);
 
   function jumpToBottom() {
     const el = logRef.current;
@@ -632,16 +633,24 @@ export function ChatPane({
     if (!activeConversation || !onRenameConversation) return;
     setTitleDraft(activeConversation.title ?? '');
     setEditingTitle(true);
+    titleHandledRef.current = false;
   }
 
   function handleTitleSave() {
     if (!activeConversation || !onRenameConversation) return;
+    titleHandledRef.current = true;
     onRenameConversation(activeConversation.id, titleDraft);
     setEditingTitle(false);
   }
 
   function handleTitleCancel() {
+    titleHandledRef.current = true;
     setEditingTitle(false);
+  }
+
+  function handleTitleBlur() {
+    if (titleHandledRef.current) return;
+    handleTitleSave();
   }
 
   return (
@@ -748,7 +757,7 @@ export function ChatPane({
                 className="chat-title-input"
                 value={titleDraft}
                 onChange={(e) => setTitleDraft(e.target.value)}
-                onBlur={handleTitleSave}
+                onBlur={handleTitleBlur}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') {
                     handleTitleSave();

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -619,10 +619,29 @@ export function ChatPane({
   const activeConversation =
     conversations.find((c) => c.id === activeConversationId) ?? null;
 
+  const [editingTitle, setEditingTitle] = useState(false);
+  const [titleDraft, setTitleDraft] = useState('');
+
   function jumpToBottom() {
     const el = logRef.current;
     if (!el) return;
     el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+  }
+
+  function handleTitleEdit() {
+    if (!activeConversation || !onRenameConversation) return;
+    setTitleDraft(activeConversation.title ?? '');
+    setEditingTitle(true);
+  }
+
+  function handleTitleSave() {
+    if (!activeConversation || !onRenameConversation) return;
+    onRenameConversation(activeConversation.id, titleDraft);
+    setEditingTitle(false);
+  }
+
+  function handleTitleCancel() {
+    setEditingTitle(false);
   }
 
   return (
@@ -721,6 +740,38 @@ export function ChatPane({
             </button>
           ) : null}
         </div>
+        {activeConversation ? (
+          <div className="chat-header-title">
+            {editingTitle && onRenameConversation ? (
+              <input
+                autoFocus
+                className="chat-title-input"
+                value={titleDraft}
+                onChange={(e) => setTitleDraft(e.target.value)}
+                onBlur={handleTitleSave}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    handleTitleSave();
+                  } else if (e.key === 'Escape') {
+                    handleTitleCancel();
+                  }
+                }}
+                data-testid="chat-title-input"
+              />
+            ) : (
+              <button
+                type="button"
+                className="chat-title-display"
+                onClick={handleTitleEdit}
+                disabled={!onRenameConversation}
+                title={onRenameConversation ? t('chat.editTitle') : undefined}
+                data-testid="chat-title-display"
+              >
+                {activeConversation.title || t('chat.untitledConversation')}
+              </button>
+            )}
+          </div>
+        ) : null}
       </div>
       {tab === 'chat' ? (
         <>

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -629,6 +629,7 @@ export const ar: Dict = {
   'chat.deleteConversationConfirm':
     'هل تريد حذف "{title}"؟ سيؤدي هذا لإزالة رسائلها.',
   'chat.untitledConversation': 'محادثة بدون عنوان',
+  'chat.editTitle': 'Click to edit conversation title',
   'chat.startTitle': 'ابدأ محادثة',
   'chat.startHint':
     'اسحب وأفلت الصور للمرجع البصري، أو اكتب @ لإرفاق ملف من هذا المشروع. أو جرب أحد هذه البدايات:',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -517,6 +517,7 @@ export const de: Dict = {
   'chat.deleteConversationConfirm':
     '„{title}“ löschen? Dadurch werden die Nachrichten entfernt.',
   'chat.untitledConversation': 'Konversation ohne Titel',
+  'chat.editTitle': 'Click to edit conversation title',
   'chat.startTitle': 'Konversation starten',
   'chat.startHint':
     'Legen Sie Bilder als visuelle Referenz ab, fügen Sie sie ein oder tippen Sie @, um eine Datei aus diesem Projekt anzuhängen. Oder probieren Sie einen dieser Starts:',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -721,6 +721,7 @@ export const en: Dict = {
   'chat.deleteConversationConfirm':
     'Delete "{title}"? This removes its messages.',
   'chat.untitledConversation': 'Untitled conversation',
+  'chat.editTitle': 'Click to edit conversation title',
   'chat.startTitle': 'Start a conversation',
   'chat.startHint':
     'Drop or paste images for visual reference, or type @ to attach a file from this project. Or try one of these starters:',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -518,6 +518,7 @@ export const esES: Dict = {
   'chat.deleteConversationConfirm':
     '¿Eliminar «{title}»? Se borrarán sus mensajes.',
   'chat.untitledConversation': 'Conversación sin título',
+  'chat.editTitle': 'Click to edit conversation title',
   'chat.startTitle': 'Empieza una conversación',
   'chat.startHint':
     'Suelta o pega imágenes como referencia visual, o escribe @ para adjuntar un archivo de este proyecto. O prueba uno de estos comienzos:',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -651,6 +651,7 @@ export const fa: Dict = {
   'chat.deleteConversationConfirm':
     'آیا «{title}» حذف شود؟ این کار پیام‌های آن را حذف می‌کند.',
   'chat.untitledConversation': 'مکالمه بدون عنوان',
+  'chat.editTitle': 'Click to edit conversation title',
   'chat.startTitle': 'یک مکالمه شروع کنید',
   'chat.startHint':
     'تصاویر را برای مرجع بصری رها کنید یا بچسبانید، یا @ را تایپ کنید تا یک فایل از این پروژه را ضمیمه کنید. یا یکی از این شروع‌کننده‌ها را امتحان کنید:',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -629,6 +629,7 @@ export const fr: Dict = {
   'chat.deleteConversationConfirm':
     'Supprimer « {title} » ? Cela supprime ses messages.',
   'chat.untitledConversation': 'Conversation sans titre',
+  'chat.editTitle': 'Click to edit conversation title',
   'chat.startTitle': 'Démarrer une conversation',
   'chat.startHint':
     'Déposez ou collez des images comme référence visuelle, ou tapez @ pour attacher un fichier du projet. Ou essayez l\'une de ces suggestions :',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -629,6 +629,7 @@ export const hu: Dict = {
   'chat.deleteConversationConfirm':
     'Törlöd a(z) „{title}" beszélgetést? Ez eltávolítja az üzeneteit.',
   'chat.untitledConversation': 'Cím nélküli beszélgetés',
+  'chat.editTitle': 'Click to edit conversation title',
   'chat.startTitle': 'Indíts beszélgetést',
   'chat.startHint':
     'Húzz vagy illessz be képeket vizuális hivatkozásként, vagy gépelj @-et a projekt egy fájljának csatolásához. Vagy próbáld ki ezeket a kezdéseket:',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -745,6 +745,7 @@ export const id: Dict = {
   'chat.deleteConversation': 'Hapus percakapan',
   'chat.deleteConversationConfirm': 'Hapus "{title}"? Semua pesannya ikut dihapus.',
   'chat.untitledConversation': 'Percakapan tanpa judul',
+  'chat.editTitle': 'Click to edit conversation title',
   'chat.startTitle': 'Mulai percakapan',
   'chat.startHint': 'Jelaskan apa yang ingin kamu buat. Agent akan menulis file dan menampilkan pratinjau di sini.',
   'chat.fillInputTitle': 'Isi brief dulu',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -549,6 +549,7 @@ export const it: Dict = {
   'chat.deleteConversationConfirm':
     'Eliminare « {title} » ? Questo elimina i suoi messaggi.',
   'chat.untitledConversation': 'Conversazione senza titolo',
+  'chat.editTitle': 'Click to edit conversation title',
   'chat.startTitle': 'Inizia una conversazione',
   'chat.startHint':
     'Trascina o incolla immagini come riferimento visivo, o digita @ per allegare un file del progetto. Oppure prova uno di questi suggerimenti:',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -516,6 +516,7 @@ export const ja: Dict = {
   'chat.deleteConversationConfirm':
     '"{title}" を削除しますか？メッセージも削除されます。',
   'chat.untitledConversation': '無題の会話',
+  'chat.editTitle': 'Click to edit conversation title',
   'chat.startTitle': '会話を始める',
   'chat.startHint':
     '画像をドロップまたは貼り付けてビジュアルリファレンスにするか、@ でこのプロジェクトのファイルを添付してください。またはこれらのスターターをお試しください:',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -629,6 +629,7 @@ export const ko: Dict = {
   'chat.deleteConversationConfirm':
     '"{title}" 대화를 삭제하시겠습니까? 관련 메시지가 모두 삭제됩니다.',
   'chat.untitledConversation': '제목 없는 대화',
+  'chat.editTitle': 'Click to edit conversation title',
   'chat.startTitle': '대화 시작하기',
   'chat.startHint':
     '시각적 참조를 위해 이미지를 붙여넣거나 끌어다 놓으세요. @를 입력하여 이 프로젝트의 파일을 첨부할 수도 있습니다. 아래 추천 질문으로 시작할 수도 있습니다:',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -629,6 +629,7 @@ export const pl: Dict = {
   'chat.deleteConversationConfirm':
       'Usunąć „{title}”? Spowoduje to usunięcie wszystkich wiadomości.',
   'chat.untitledConversation': 'Rozmowa bez tytułu',
+  'chat.editTitle': 'Click to edit conversation title',
   'chat.startTitle': 'Zacznij rozmowę',
   'chat.startHint':
       'Przeciągnij lub wklej obrazy jako referencję wizualną lub wpisz @, aby załączyć plik z tego projektu. Możesz też wypróbować jeden z tematów na start:',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -650,6 +650,7 @@ export const ptBR: Dict = {
   'chat.deleteConversationConfirm':
     'Excluir "{title}"? Isso remove as mensagens.',
   'chat.untitledConversation': 'Conversa sem título',
+  'chat.editTitle': 'Click to edit conversation title',
   'chat.startTitle': 'Comece uma conversa',
   'chat.startHint':
     'Arraste ou cole imagens como referência visual, ou digite @ para anexar um arquivo deste projeto. Ou experimente um destes começos:',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -650,6 +650,7 @@ export const ru: Dict = {
   'chat.deleteConversationConfirm':
     'Удалить «{title}»? Это удалит его сообщения.',
   'chat.untitledConversation': 'Разговор без названия',
+  'chat.editTitle': 'Click to edit conversation title',
   'chat.startTitle': 'Начать разговор',
   'chat.startHint':
     'Перетащите или вставьте изображения для визуальной ссылки или введите @ для прикрепления файла из этого проекта. Или попробуйте одно из этих начал:',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -583,6 +583,7 @@ export const th: Dict = {
   'chat.deleteConversation': 'ลบบทสนทนา',
   'chat.deleteConversationConfirm': 'ลบ "{title}" หรือไม่?',
   'chat.untitledConversation': 'บทสนทนาที่ไม่มีชื่อ',
+  'chat.editTitle': 'Click to edit conversation title',
   'chat.startTitle': 'เริ่มแชทได้เลย',
   'chat.startHint': 'ลากหรือวางรูปภาพที่นี่ หรือพิมพ์ @ เพื่อดึงไฟล์โปรเจกต์',
   'chat.fillInputTitle': 'คลิกเพื่อใส่ข้อความ',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -618,6 +618,7 @@ export const tr: Dict = {
   'chat.deleteConversationConfirm':
     '"{title}"’ı sil? Bu mesajları silecektir.',
   'chat.untitledConversation': 'Başlıksız konuşma',
+  'chat.editTitle': 'Click to edit conversation title',
   'chat.startTitle': 'Bir konuşma başlat',
   'chat.startHint':
     'Görsel referans için görsel sürükleyin veya yapıştırın, veya bu projeden bir dosya iliştirmek için @ yazın. Veya bu başlatıcılardan birini deneyin:',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -651,6 +651,7 @@ export const uk: Dict = {
   'chat.deleteConversationConfirm':
     'Видалити "{title}"? Це видалить усі її повідомлення.',
   'chat.untitledConversation': 'Розмова без назви',
+  'chat.editTitle': 'Click to edit conversation title',
   'chat.startTitle': 'Почніть розмову',
   'chat.startHint':
     'Перенесіть або вставте зображення для візуального посилання, або введіть @, щоб прикріпити файл з цього проекту. Або спробуйте один з цих стартерів:',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -715,6 +715,7 @@ export const zhCN: Dict = {
   'chat.deleteConversation': '删除对话',
   'chat.deleteConversationConfirm': '确定删除「{title}」？该操作会删除其消息。',
   'chat.untitledConversation': '未命名对话',
+  'chat.editTitle': 'Click to edit conversation title',
   'chat.startTitle': '开始一个对话',
   'chat.startHint':
     '可以拖拽或粘贴图片作为视觉参考，或键入 @ 引用本项目中的文件。也可以从下面的示例开始：',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -706,6 +706,7 @@ export const zhTW: Dict = {
   'chat.deleteConversation': '刪除對話',
   'chat.deleteConversationConfirm': '確定刪除「{title}」？該操作會刪除其訊息。',
   'chat.untitledConversation': '未命名對話',
+  'chat.editTitle': 'Click to edit conversation title',
   'chat.startTitle': '開始一個對話',
   'chat.startHint':
     '可以拖曳或貼上圖片作為視覺參考，或鍵入 @ 引用本專案中的檔案。也可以從下面的範例開始：',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -989,6 +989,7 @@ export interface Dict {
   'chat.deleteConversation': string;
   'chat.deleteConversationConfirm': string;
   'chat.untitledConversation': string;
+  'chat.editTitle': string;
   'chat.startTitle': string;
   'chat.startHint': string;
   'chat.fillInputTitle': string;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1600,6 +1600,59 @@ a.avatar-item:visited {
 }
 .chat-header-actions .icon-only:hover { background: var(--bg-subtle); color: var(--text); }
 
+.chat-header-title {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  min-width: 0;
+}
+
+.chat-title-display {
+  background: transparent;
+  border: none;
+  padding: 4px 8px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  cursor: pointer;
+  border-radius: 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  text-align: left;
+}
+
+.chat-title-display:hover {
+  background: var(--bg-subtle);
+}
+
+.chat-title-display:disabled {
+  cursor: default;
+  opacity: 0.7;
+}
+
+.chat-title-display:disabled:hover {
+  background: transparent;
+}
+
+.chat-title-input {
+  flex: 1;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  outline: none;
+}
+
+.chat-title-input:focus {
+  border-color: var(--accent);
+}
+
 .chat-log {
   flex: 1;
   overflow-y: auto;


### PR DESCRIPTION
## Summary

Fixes #1911

Adds visible conversation title display and inline editing capability in the chat header.

## Changes

- **Display title prominently**: Show current conversation title in chat header between history button and action buttons
- **Inline editing**: Click title to edit, Enter to save, Escape to cancel
- **Fallback text**: Display "Untitled conversation" when no title is set
- **i18n support**: Add `chat.editTitle` translation key for tooltip
- **Responsive styling**: Title uses ellipsis overflow for long titles, hover state for discoverability

## Before

- Conversation title only visible in tooltip on hover over history button
- Title editing only possible by opening conversation list and double-clicking
- No visible indication of current conversation name in active chat

## After

- Title prominently displayed in chat header
- Click title to edit directly in place
- Clear visual feedback for editable state
- Consistent with user expectations for title management

## Testing

- [x] Title displays correctly for titled conversations
- [x] "Untitled conversation" shows for conversations without titles
- [x] Click to edit works
- [x] Enter saves changes
- [x] Escape cancels editing
- [x] Blur saves changes
- [x] Long titles truncate with ellipsis
- [x] Hover state provides visual feedback
