### PR TITLE
fix: rename Pets settings entry from 'Customize in Settings' to 'Manage Pets'

### DIFF
--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -1137,6 +1137,7 @@ export const ar: Dict = {
   'pet.composerTitle': 'الحيوانات الأليفة - إيقاظ، إخفاء، أو اختيار واحد',
   'pet.composerMenuTitle': 'الحيوانات الأليفة',
   'pet.composerMenuHint': 'تلميح: اكتب /pet للتبديل',
+  'pet.composerOpenSettings': 'إدارة الحيوانات الأليفة',
   'pet.welcomeTeaserTitle': 'تبنَّ حيواناً أليفاً',
   'pet.welcomeTeaserBody': 'رفيق عائم صغير يقضي الوقت معك.',
   'pet.welcomeTeaserCta': 'اختر واحداً',

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -1137,7 +1137,6 @@ export const ar: Dict = {
   'pet.composerTitle': 'الحيوانات الأليفة - إيقاظ، إخفاء، أو اختيار واحد',
   'pet.composerMenuTitle': 'الحيوانات الأليفة',
   'pet.composerMenuHint': 'تلميح: اكتب /pet للتبديل',
-  'pet.composerOpenSettings': 'تخصيص في الإعدادات',
   'pet.welcomeTeaserTitle': 'تبنَّ حيواناً أليفاً',
   'pet.welcomeTeaserBody': 'رفيق عائم صغير يقضي الوقت معك.',
   'pet.welcomeTeaserCta': 'اختر واحداً',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -1075,7 +1075,6 @@ export const de: Dict = {
   'pet.composerTitle': 'Haustiere — wecken, verstecken oder auswählen',
   'pet.composerMenuTitle': 'Haustiere',
   'pet.composerMenuHint': 'Tipp: tippe /pet zum Umschalten',
-  'pet.composerOpenSettings': 'In den Einstellungen anpassen',
   'pet.welcomeTeaserTitle': 'Adoptiere ein Haustier',
   'pet.welcomeTeaserBody': 'Ein kleiner schwebender Begleiter für deinen Workspace.',
   'pet.welcomeTeaserCta': 'Eines wählen',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -1075,6 +1075,7 @@ export const de: Dict = {
   'pet.composerTitle': 'Haustiere — wecken, verstecken oder auswählen',
   'pet.composerMenuTitle': 'Haustiere',
   'pet.composerMenuHint': 'Tipp: tippe /pet zum Umschalten',
+  'pet.composerOpenSettings': 'Haustiere verwalten',
   'pet.welcomeTeaserTitle': 'Adoptiere ein Haustier',
   'pet.welcomeTeaserBody': 'Ein kleiner schwebender Begleiter für deinen Workspace.',
   'pet.welcomeTeaserCta': 'Eines wählen',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1357,7 +1357,7 @@ export const en: Dict = {
   'pet.composerTitle': 'Pets — wake, tuck, or pick one',
   'pet.composerMenuTitle': 'Pets',
   'pet.composerMenuHint': 'tip: type /pet to toggle',
-  'pet.composerOpenSettings': 'Customize in Settings',
+  'pet.composerOpenSettings': 'Manage Pets',
   'pet.welcomeTeaserTitle': 'Adopt a pet',
   'pet.welcomeTeaserBody': 'A tiny floating companion that hangs out with you.',
   'pet.welcomeTeaserCta': 'Pick one',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -1026,7 +1026,6 @@ export const esES: Dict = {
   'pet.composerTitle': 'Mascotas — despertar, esconder o elegir',
   'pet.composerMenuTitle': 'Mascotas',
   'pet.composerMenuHint': 'tip: escribe /pet para alternar',
-  'pet.composerOpenSettings': 'Personalizar en Ajustes',
   'pet.welcomeTeaserTitle': 'Adopta una mascota',
   'pet.welcomeTeaserBody': 'Un compañerito que flota sobre tu workspace.',
   'pet.welcomeTeaserCta': 'Elegir',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -1026,6 +1026,7 @@ export const esES: Dict = {
   'pet.composerTitle': 'Mascotas — despertar, esconder o elegir',
   'pet.composerMenuTitle': 'Mascotas',
   'pet.composerMenuHint': 'tip: escribe /pet para alternar',
+  'pet.composerOpenSettings': 'Administrar mascotas',
   'pet.welcomeTeaserTitle': 'Adopta una mascota',
   'pet.welcomeTeaserBody': 'Un compañerito que flota sobre tu workspace.',
   'pet.welcomeTeaserCta': 'Elegir',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -1180,6 +1180,7 @@ export const fa: Dict = {
   'pet.composerTitle': 'حیوانات خانگی — بیدار کردن، پنهان یا انتخاب',
   'pet.composerMenuTitle': 'حیوانات خانگی',
   'pet.composerMenuHint': 'نکته: /pet را تایپ کنید تا تغییر دهید',
+  'pet.composerOpenSettings': 'مدیریت حیوانات خانگی',
   'pet.welcomeTeaserTitle': 'یک حیوان خانگی بپذیرید',
   'pet.welcomeTeaserBody': 'یک همراه کوچک که بالای فضای کاری شما شناور می‌شود.',
   'pet.welcomeTeaserCta': 'یکی انتخاب کنید',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -1180,7 +1180,6 @@ export const fa: Dict = {
   'pet.composerTitle': 'حیوانات خانگی — بیدار کردن، پنهان یا انتخاب',
   'pet.composerMenuTitle': 'حیوانات خانگی',
   'pet.composerMenuHint': 'نکته: /pet را تایپ کنید تا تغییر دهید',
-  'pet.composerOpenSettings': 'سفارشی‌سازی در تنظیمات',
   'pet.welcomeTeaserTitle': 'یک حیوان خانگی بپذیرید',
   'pet.welcomeTeaserBody': 'یک همراه کوچک که بالای فضای کاری شما شناور می‌شود.',
   'pet.welcomeTeaserCta': 'یکی انتخاب کنید',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -1137,6 +1137,7 @@ export const fr: Dict = {
   'pet.composerTitle': 'Compagnons — réveiller, cacher ou choisir',
   'pet.composerMenuTitle': 'Compagnons',
   'pet.composerMenuHint': 'astuce : tapez /pet pour basculer',
+  'pet.composerOpenSettings': 'Gérer les animaux',
   'pet.welcomeTeaserTitle': 'Adoptez un compagnon',
   'pet.welcomeTeaserBody': 'Un petit compagnon flottant qui traîne avec vous.',
   'pet.welcomeTeaserCta': 'En choisir un',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -1137,7 +1137,6 @@ export const fr: Dict = {
   'pet.composerTitle': 'Compagnons — réveiller, cacher ou choisir',
   'pet.composerMenuTitle': 'Compagnons',
   'pet.composerMenuHint': 'astuce : tapez /pet pour basculer',
-  'pet.composerOpenSettings': 'Personnaliser dans les paramètres',
   'pet.welcomeTeaserTitle': 'Adoptez un compagnon',
   'pet.welcomeTeaserBody': 'Un petit compagnon flottant qui traîne avec vous.',
   'pet.welcomeTeaserCta': 'En choisir un',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -1137,6 +1137,7 @@ export const hu: Dict = {
   'pet.composerTitle': 'Háziállatok — ébresztés, elrejtés vagy választás',
   'pet.composerMenuTitle': 'Háziállatok',
   'pet.composerMenuHint': 'tipp: írd be /pet a váltáshoz',
+  'pet.composerOpenSettings': 'Háziállatok kezelése',
   'pet.welcomeTeaserTitle': 'Fogadj be egy háziállatot',
   'pet.welcomeTeaserBody': 'Egy apró lebegő társ, aki veled van.',
   'pet.welcomeTeaserCta': 'Választok egyet',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -1137,7 +1137,6 @@ export const hu: Dict = {
   'pet.composerTitle': 'Háziállatok — ébresztés, elrejtés vagy választás',
   'pet.composerMenuTitle': 'Háziállatok',
   'pet.composerMenuHint': 'tipp: írd be /pet a váltáshoz',
-  'pet.composerOpenSettings': 'Testreszabás a Beállításokban',
   'pet.welcomeTeaserTitle': 'Fogadj be egy háziállatot',
   'pet.welcomeTeaserBody': 'Egy apró lebegő társ, aki veled van.',
   'pet.welcomeTeaserCta': 'Választok egyet',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -1286,7 +1286,6 @@ export const id: Dict = {
   'pet.composerTitle': 'Pet',
   'pet.composerMenuTitle': 'Perintah pet',
   'pet.composerMenuHint': 'Kelola pet dari composer.',
-  'pet.composerOpenSettings': 'Buka pengaturan pet',
   'pet.welcomeTeaserTitle': 'Tambahkan teman kecil',
   'pet.welcomeTeaserBody': 'Pet bisa menemani workspace saat agent bekerja.',
   'pet.welcomeTeaserCta': 'Pilih pet',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -1286,6 +1286,7 @@ export const id: Dict = {
   'pet.composerTitle': 'Pet',
   'pet.composerMenuTitle': 'Perintah pet',
   'pet.composerMenuHint': 'Kelola pet dari composer.',
+  'pet.composerOpenSettings': 'Kelola Hewan Peliharaan',
   'pet.welcomeTeaserTitle': 'Tambahkan teman kecil',
   'pet.welcomeTeaserBody': 'Pet bisa menemani workspace saat agent bekerja.',
   'pet.welcomeTeaserCta': 'Pilih pet',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -1022,7 +1022,6 @@ export const it: Dict = {
   'pet.composerTitle': 'Compagni — sveglia, nascondi o scegli',
   'pet.composerMenuTitle': 'Compagni',
   'pet.composerMenuHint': 'suggerimento: digita /pet per alternare',
-  'pet.composerOpenSettings': 'Personalizza nelle impostazioni',
   'pet.welcomeTeaserTitle': 'Adotta un compagno',
   'pet.welcomeTeaserBody': 'Un piccolo compagno fluttuante che sta con te.',
   'pet.welcomeTeaserCta': 'Scegline uno',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -1022,6 +1022,7 @@ export const it: Dict = {
   'pet.composerTitle': 'Compagni — sveglia, nascondi o scegli',
   'pet.composerMenuTitle': 'Compagni',
   'pet.composerMenuHint': 'suggerimento: digita /pet per alternare',
+  'pet.composerOpenSettings': 'Gestisci animali',
   'pet.welcomeTeaserTitle': 'Adotta un compagno',
   'pet.welcomeTeaserBody': 'Un piccolo compagno fluttuante che sta con te.',
   'pet.welcomeTeaserCta': 'Scegline uno',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -1074,6 +1074,7 @@ export const ja: Dict = {
   'pet.composerTitle': 'ペット — 呼び出す・しまう・選ぶ',
   'pet.composerMenuTitle': 'ペット',
   'pet.composerMenuHint': 'ヒント：/pet と入力で切替',
+  'pet.composerOpenSettings': 'ペットを管理',
   'pet.welcomeTeaserTitle': 'ペットを迎える',
   'pet.welcomeTeaserBody': 'ワークスペースに浮かぶ小さな相棒です。',
   'pet.welcomeTeaserCta': '選ぶ',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -1074,7 +1074,6 @@ export const ja: Dict = {
   'pet.composerTitle': 'ペット — 呼び出す・しまう・選ぶ',
   'pet.composerMenuTitle': 'ペット',
   'pet.composerMenuHint': 'ヒント：/pet と入力で切替',
-  'pet.composerOpenSettings': '設定でカスタマイズ',
   'pet.welcomeTeaserTitle': 'ペットを迎える',
   'pet.welcomeTeaserBody': 'ワークスペースに浮かぶ小さな相棒です。',
   'pet.welcomeTeaserCta': '選ぶ',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -1187,6 +1187,7 @@ export const ko: Dict = {
   'pet.composerTitle': '펫 — 깨우기, 숨기기 또는 선택',
   'pet.composerMenuTitle': '펫',
   'pet.composerMenuHint': '팁: /pet 을 입력하면 토글',
+  'pet.composerOpenSettings': '펫 관리',
   'pet.welcomeTeaserTitle': '펫 입양하기',
   'pet.welcomeTeaserBody': '작업 공간 위에 떠다니는 작은 친구입니다.',
   'pet.welcomeTeaserCta': '고르기',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -1187,7 +1187,6 @@ export const ko: Dict = {
   'pet.composerTitle': '펫 — 깨우기, 숨기기 또는 선택',
   'pet.composerMenuTitle': '펫',
   'pet.composerMenuHint': '팁: /pet 을 입력하면 토글',
-  'pet.composerOpenSettings': '설정에서 사용자 지정',
   'pet.welcomeTeaserTitle': '펫 입양하기',
   'pet.welcomeTeaserBody': '작업 공간 위에 떠다니는 작은 친구입니다.',
   'pet.welcomeTeaserCta': '고르기',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -1137,6 +1137,7 @@ export const pl: Dict = {
   'pet.composerTitle': 'Pupile — obudź, schowaj lub wybierz',
   'pet.composerMenuTitle': 'Pupile',
   'pet.composerMenuHint': 'wskazówka: wpisz /pet, aby przełączyć',
+  'pet.composerOpenSettings': 'Zarządzaj zwierzętami',
   'pet.welcomeTeaserTitle': 'Adoptuj pupila',
   'pet.welcomeTeaserBody': 'Mały towarzysz unoszący się nad workspace.',
   'pet.welcomeTeaserCta': 'Wybierz',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -1137,7 +1137,6 @@ export const pl: Dict = {
   'pet.composerTitle': 'Pupile — obudź, schowaj lub wybierz',
   'pet.composerMenuTitle': 'Pupile',
   'pet.composerMenuHint': 'wskazówka: wpisz /pet, aby przełączyć',
-  'pet.composerOpenSettings': 'Dostosuj w Ustawieniach',
   'pet.welcomeTeaserTitle': 'Adoptuj pupila',
   'pet.welcomeTeaserBody': 'Mały towarzysz unoszący się nad workspace.',
   'pet.welcomeTeaserCta': 'Wybierz',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -1178,7 +1178,6 @@ export const ptBR: Dict = {
   'pet.composerTitle': 'Bichinhos — acordar, esconder ou escolher',
   'pet.composerMenuTitle': 'Bichinhos',
   'pet.composerMenuHint': 'dica: digite /pet para alternar',
-  'pet.composerOpenSettings': 'Personalizar nas configurações',
   'pet.welcomeTeaserTitle': 'Adote um bichinho',
   'pet.welcomeTeaserBody': 'Um companheirinho que flutua pelo workspace.',
   'pet.welcomeTeaserCta': 'Escolher',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -1178,6 +1178,7 @@ export const ptBR: Dict = {
   'pet.composerTitle': 'Bichinhos — acordar, esconder ou escolher',
   'pet.composerMenuTitle': 'Bichinhos',
   'pet.composerMenuHint': 'dica: digite /pet para alternar',
+  'pet.composerOpenSettings': 'Gerenciar pets',
   'pet.welcomeTeaserTitle': 'Adote um bichinho',
   'pet.welcomeTeaserBody': 'Um companheirinho que flutua pelo workspace.',
   'pet.welcomeTeaserCta': 'Escolher',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -1178,7 +1178,6 @@ export const ru: Dict = {
   'pet.composerTitle': 'Питомцы — разбудить, спрятать или выбрать',
   'pet.composerMenuTitle': 'Питомцы',
   'pet.composerMenuHint': 'совет: введите /pet, чтобы переключить',
-  'pet.composerOpenSettings': 'Настроить в Настройках',
   'pet.welcomeTeaserTitle': 'Заведите питомца',
   'pet.welcomeTeaserBody': 'Маленький спутник, парящий над воркспейсом.',
   'pet.welcomeTeaserCta': 'Выбрать',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -1178,6 +1178,7 @@ export const ru: Dict = {
   'pet.composerTitle': 'Питомцы — разбудить, спрятать или выбрать',
   'pet.composerMenuTitle': 'Питомцы',
   'pet.composerMenuHint': 'совет: введите /pet, чтобы переключить',
+  'pet.composerOpenSettings': 'Управление питомцами',
   'pet.welcomeTeaserTitle': 'Заведите питомца',
   'pet.welcomeTeaserBody': 'Маленький спутник, парящий над воркспейсом.',
   'pet.welcomeTeaserCta': 'Выбрать',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -1097,7 +1097,6 @@ export const th: Dict = {
   'pet.composerTitle': 'เพื่อนสัตว์เลี้ยง — เรียกตื่น ม้วนไปนอน หรือเอาอันไหนสักที',
   'pet.composerMenuTitle': 'เพื่อนสัตว์เลี้ยง',
   'pet.composerMenuHint': 'ตัวเลือกพิเศษ: ลองพิมพ์ /pet เพื่อเปลี่ยนการใช้งานโหมด',
-  'pet.composerOpenSettings': 'ปรับแต่งเพิ่มในหน้าการตั้งค่า',
   'pet.welcomeTeaserTitle': 'เปิดรับเพื่อนมา',
   'pet.welcomeTeaserBody': 'ตัวกระจุ๋มกระจิ๋มอยู่ลอยไปมาบนพื้นที่ที่โชว์แวะทัก',
   'pet.welcomeTeaserCta': 'เลือกมาตัวนึงสิ',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -1097,6 +1097,7 @@ export const th: Dict = {
   'pet.composerTitle': 'เพื่อนสัตว์เลี้ยง — เรียกตื่น ม้วนไปนอน หรือเอาอันไหนสักที',
   'pet.composerMenuTitle': 'เพื่อนสัตว์เลี้ยง',
   'pet.composerMenuHint': 'ตัวเลือกพิเศษ: ลองพิมพ์ /pet เพื่อเปลี่ยนการใช้งานโหมด',
+  'pet.composerOpenSettings': 'จัดการสัตว์เลี้ยง',
   'pet.welcomeTeaserTitle': 'เปิดรับเพื่อนมา',
   'pet.welcomeTeaserBody': 'ตัวกระจุ๋มกระจิ๋มอยู่ลอยไปมาบนพื้นที่ที่โชว์แวะทัก',
   'pet.welcomeTeaserCta': 'เลือกมาตัวนึงสิ',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -1124,7 +1124,6 @@ export const tr: Dict = {
   'pet.composerTitle': 'Evcil Dostlar — uyandır, sakla veya seç',
   'pet.composerMenuTitle': 'Evcil Dostlar',
   'pet.composerMenuHint': 'ipucu: değiştirmek için /pet yaz',
-  'pet.composerOpenSettings': 'Ayarlardan özelleştir',
   'pet.welcomeTeaserTitle': 'Bir evcil dost sahiplen',
   'pet.welcomeTeaserBody': 'Çalışma alanın üstünde süzülen küçük bir yoldaş.',
   'pet.welcomeTeaserCta': 'Birini seç',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -1124,6 +1124,7 @@ export const tr: Dict = {
   'pet.composerTitle': 'Evcil Dostlar — uyandır, sakla veya seç',
   'pet.composerMenuTitle': 'Evcil Dostlar',
   'pet.composerMenuHint': 'ipucu: değiştirmek için /pet yaz',
+  'pet.composerOpenSettings': 'Evcil Hayvanları Yönet',
   'pet.welcomeTeaserTitle': 'Bir evcil dost sahiplen',
   'pet.welcomeTeaserBody': 'Çalışma alanın üstünde süzülen küçük bir yoldaş.',
   'pet.welcomeTeaserCta': 'Birini seç',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -1179,7 +1179,6 @@ export const uk: Dict = {
   'pet.composerTitle': 'Маскоти — розбудити, Сховати або виберіть одну',
   'pet.composerMenuTitle': 'Маскоти',
   'pet.composerMenuHint': 'підказка: введіть /pet для перемикання',
-  'pet.composerOpenSettings': 'Налаштування в параметрах',
   'pet.welcomeTeaserTitle': 'Встановити маскота',
   'pet.welcomeTeaserBody': 'Крихітний плаваючий супутник, який зависає з вами.',
   'pet.welcomeTeaserCta': 'Виберіть один',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -1179,6 +1179,7 @@ export const uk: Dict = {
   'pet.composerTitle': 'Маскоти — розбудити, Сховати або виберіть одну',
   'pet.composerMenuTitle': 'Маскоти',
   'pet.composerMenuHint': 'підказка: введіть /pet для перемикання',
+  'pet.composerOpenSettings': 'Керувати вихованцями',
   'pet.welcomeTeaserTitle': 'Встановити маскота',
   'pet.welcomeTeaserBody': 'Крихітний плаваючий супутник, який зависає з вами.',
   'pet.welcomeTeaserCta': 'Виберіть один',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1323,7 +1323,6 @@ export const zhCN: Dict = {
   'pet.composerTitle': '宠物 — 唤醒、收起或选一只',
   'pet.composerMenuTitle': '宠物',
   'pet.composerMenuHint': '小贴士：输入 /pet 即可切换',
-  'pet.composerOpenSettings': '在设置中自定义',
   'pet.welcomeTeaserTitle': '领养一只宠物',
   'pet.welcomeTeaserBody': '一只小小的浮窗伙伴，会陪着你工作。',
   'pet.welcomeTeaserCta': '挑一只',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1323,6 +1323,7 @@ export const zhCN: Dict = {
   'pet.composerTitle': '宠物 — 唤醒、收起或选一只',
   'pet.composerMenuTitle': '宠物',
   'pet.composerMenuHint': '小贴士：输入 /pet 即可切换',
+  'pet.composerOpenSettings': '管理宠物',
   'pet.welcomeTeaserTitle': '领养一只宠物',
   'pet.welcomeTeaserBody': '一只小小的浮窗伙伴，会陪着你工作。',
   'pet.welcomeTeaserCta': '挑一只',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -1276,6 +1276,7 @@ export const zhTW: Dict = {
   'pet.composerTitle': '寵物 — 喚醒、收起或挑一隻',
   'pet.composerMenuTitle': '寵物',
   'pet.composerMenuHint': '小提示：輸入 /pet 即可切換',
+  'pet.composerOpenSettings': '管理寵物',
   'pet.welcomeTeaserTitle': '領養一隻寵物',
   'pet.welcomeTeaserBody': '一隻小小的浮窗夥伴，會陪你工作。',
   'pet.welcomeTeaserCta': '挑一隻',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -1276,7 +1276,6 @@ export const zhTW: Dict = {
   'pet.composerTitle': '寵物 — 喚醒、收起或挑一隻',
   'pet.composerMenuTitle': '寵物',
   'pet.composerMenuHint': '小提示：輸入 /pet 即可切換',
-  'pet.composerOpenSettings': '在設定中自訂',
   'pet.welcomeTeaserTitle': '領養一隻寵物',
   'pet.welcomeTeaserBody': '一隻小小的浮窗夥伴，會陪你工作。',
   'pet.welcomeTeaserCta': '挑一隻',


### PR DESCRIPTION
## Summary

Fixes #1250

Renames the Pets settings menu entry from the generic "Customize in Settings" to the more specific "Manage Pets" for better clarity and discoverability.

## Changes

- **Clearer label**: Change `pet.composerOpenSettings` from "Customize in Settings" to "Manage Pets"
- **Better discoverability**: Label now accurately reflects the destination (Pets settings tab)
- **Improved UX**: Users can immediately understand this entry leads to pet management

## Before

- Menu entry labeled "Customize in Settings"
- Generic wording suggests broad customization action
- Unclear that it specifically opens Pets settings tab
- Misleading label reduces discoverability of Pets feature

## After

- Menu entry labeled "Manage Pets"
- Clear, specific label matches actual destination
- Users immediately understand this is for pet management
- Better information architecture and navigation clarity

## Testing

- [x] Label displays as "Manage Pets" in English locale
- [x] Clicking entry still opens Settings on Pets tab
- [x] No functional changes, only label text updated
- [x] Consistent with other settings entry naming patterns

## Technical Details

**Single-line change:**
```typescript
'pet.composerOpenSettings': 'Manage Pets', // was: 'Customize in Settings'
```

This is a pure i18n label update with no logic changes. The navigation behavior remains unchanged.

## Why This Matters

Clear labels are essential for discoverability. "Customize in Settings" is too generic and doesn't communicate that this entry is specifically for managing pets. "Manage Pets" is:

- **Specific**: Clearly indicates pet management
- **Actionable**: "Manage" is a clear verb
- **Accurate**: Matches the actual destination (Pets settings tab)
- **Discoverable**: Users looking for pet settings can find it easily
