### PR TITLE
Improve DeepSeek TUI diagnostics

### DIFF
--- a/apps/daemon/src/runtimes/auth.ts
+++ b/apps/daemon/src/runtimes/auth.ts
@@ -9,8 +9,15 @@ export type AgentAuthProbeResult = {
 const CURSOR_AUTH_GUIDANCE =
   'Cursor Agent is not authenticated. Run `cursor-agent login`, then `cursor-agent status`, and retry. For automation, ensure CURSOR_API_KEY is set in the Open Design process environment.';
 
+const DEEPSEEK_AUTH_GUIDANCE =
+  'DeepSeek TUI is installed but is not authenticated. Add or verify your API key in `~/.deepseek/config.toml` as `api_key = "..."`, or expose DEEPSEEK_API_KEY to the Open Design daemon process, then retry. If Open Design is launched outside an interactive shell, shell rc files such as ~/.zshrc may not be loaded.';
+
 export function cursorAuthGuidance(): string {
   return CURSOR_AUTH_GUIDANCE;
+}
+
+export function deepseekAuthGuidance(): string {
+  return DEEPSEEK_AUTH_GUIDANCE;
 }
 
 export function isCursorAuthFailureText(text: string): boolean {
@@ -26,16 +33,37 @@ export function isCursorAuthFailureText(text: string): boolean {
   );
 }
 
+export function isDeepSeekAuthFailureText(text: string): boolean {
+  const value = String(text || '');
+  if (!value.trim()) return false;
+  return (
+    /KEY=<your-key>/i.test(value) ||
+    /api_key\s*=\s*["']<your-key>["']/i.test(value) ||
+    (/~\/\.deepseek\/config\.toml/i.test(value) && /api[_ -]?key|KEY=/i.test(value)) ||
+    (/DEEPSEEK_API_KEY/i.test(value) &&
+      /auth|api[_ -]?key|missing|not set|required|unauthorized/i.test(value))
+  );
+}
+
 export function classifyAgentAuthFailure(
   agentId: string,
   text: string,
 ): AgentAuthProbeResult | null {
-  if (agentId !== 'cursor-agent') return null;
-  if (!isCursorAuthFailureText(text)) return null;
-  return {
-    status: 'missing',
-    message: cursorAuthGuidance(),
-  };
+  if (agentId === 'cursor-agent') {
+    if (!isCursorAuthFailureText(text)) return null;
+    return {
+      status: 'missing',
+      message: cursorAuthGuidance(),
+    };
+  }
+  if (agentId === 'deepseek') {
+    if (!isDeepSeekAuthFailureText(text)) return null;
+    return {
+      status: 'missing',
+      message: deepseekAuthGuidance(),
+    };
+  }
+  return null;
 }
 
 export async function probeAgentAuthStatus(

--- a/apps/daemon/src/runtimes/prompt-budget.ts
+++ b/apps/daemon/src/runtimes/prompt-budget.ts
@@ -1,5 +1,21 @@
 import type { RuntimeAgentDef, RuntimePromptBudgetError } from './types.js';
 
+function promptArgvBudgetMessage(
+  def: RuntimeAgentDef,
+  bytes: number,
+): string {
+  if (def.id === 'deepseek') {
+    return (
+      `${def.name} currently accepts prompts only as a command-line argument, and this run's composed prompt exceeds the safe size (${bytes} > ${def.maxPromptArgBytes} bytes). ` +
+      'Reduce the selected skills/design-system context or conversation length, or use DeepSeek through an API/provider model connection for large contexts. Pick a stdin-capable adapter when the prompt must include large local context.'
+    );
+  }
+  return (
+    `${def.name} requires the prompt as a command-line argument and this run's composed prompt exceeds the safe size (${bytes} > ${def.maxPromptArgBytes} bytes). ` +
+    'Reduce the selected skills/design-system context, shorten the conversation, or pick an adapter with stdin support.'
+  );
+}
+
 export function checkPromptArgvBudget(
   def: RuntimeAgentDef | null | undefined,
   composed: unknown,
@@ -12,9 +28,7 @@ export function checkPromptArgvBudget(
   if (bytes <= def.maxPromptArgBytes) return null;
   return {
     code: 'AGENT_PROMPT_TOO_LARGE',
-    message:
-      `${def.name} requires the prompt as a command-line argument and this run's composed prompt exceeds the safe size (${bytes} > ${def.maxPromptArgBytes} bytes). ` +
-      'Reduce the selected skills/design-system context, shorten the conversation, or pick an adapter with stdin support.',
+    message: promptArgvBudgetMessage(def, bytes),
     bytes,
     limit: def.maxPromptArgBytes,
   };

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -9056,7 +9056,7 @@ export async function startServer({
         if (authFailure?.status === 'missing') {
           send('error', createSseErrorPayload(
             'AGENT_AUTH_REQUIRED',
-            cursorAuthGuidance(),
+            authFailure.message ?? cursorAuthGuidance(),
             { retryable: true },
           ));
           return;
@@ -9246,15 +9246,20 @@ export async function startServer({
       }
       if (
         code !== 0 &&
-        !run.cancelRequested &&
-        classifyAgentAuthFailure(agentId, `${agentStderrTail}\n${agentStdoutTail}`)?.status === 'missing'
+        !run.cancelRequested
       ) {
-        send('error', createSseErrorPayload(
-          'AGENT_AUTH_REQUIRED',
-          cursorAuthGuidance(),
-          { retryable: true },
-        ));
-        return design.runs.finish(run, 'failed', code ?? 1, signal ?? null);
+        const authFailure = classifyAgentAuthFailure(
+          agentId,
+          `${agentStderrTail}\n${agentStdoutTail}`,
+        );
+        if (authFailure?.status === 'missing') {
+          send('error', createSseErrorPayload(
+            'AGENT_AUTH_REQUIRED',
+            authFailure.message ?? cursorAuthGuidance(),
+            { retryable: true },
+          ));
+          return design.runs.finish(run, 'failed', code ?? 1, signal ?? null);
+        }
       }
       // Empty-output guard: a clean `code === 0` exit on a stream we are
       // tracking, with no error frame and no substantive event, means the

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -348,6 +348,64 @@ process.exit(1);
     );
   });
 
+  it('classifies DeepSeek TUI config guidance as typed auth failures', async () => {
+    await withFakeAgent(
+      'deepseek',
+      `
+const args = process.argv.slice(2);
+if (args[0] === '--version') {
+  console.log('deepseek 0.3.0-test');
+  process.exit(0);
+}
+console.error('KEY=<your-key> deepseek --api-key <your-key>');
+console.error('api_key = "<your-key>" in ~/.deepseek/config.toml');
+process.exit(1);
+`,
+      async () => {
+        const deepseek = getAgentDef('deepseek');
+        expect(deepseek).toBeDefined();
+        const originalBudget = deepseek?.maxPromptArgBytes;
+        if (deepseek) deepseek.maxPromptArgBytes = 200_000;
+        try {
+          const createResponse = await fetch(`${baseUrl}/api/runs`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              agentId: 'deepseek',
+              message: 'hello',
+            }),
+          });
+          expect(createResponse.status).toBe(202);
+          const { runId } = await createResponse.json() as { runId: string };
+
+          const eventsController = new AbortController();
+          const eventsResponse = await fetch(`${baseUrl}/api/runs/${runId}/events`, {
+            signal: eventsController.signal,
+          });
+          const eventsBody = await readSseUntil(eventsResponse, 'AGENT_AUTH_REQUIRED');
+          eventsController.abort();
+          const statusBody = await waitForRunStatus(baseUrl, runId);
+
+          expect(eventsBody).toContain('event: error');
+          expect(eventsBody).toContain('AGENT_AUTH_REQUIRED');
+          expect(eventsBody).toContain('~/.deepseek/config.toml');
+          expect(eventsBody).toContain('DEEPSEEK_API_KEY');
+          expect(eventsBody).not.toContain('cursor-agent login');
+          expect(eventsBody).not.toContain('AGENT_EXECUTION_FAILED');
+          expect(statusBody.status).toBe('failed');
+        } finally {
+          if (deepseek) {
+            if (originalBudget === undefined) {
+              delete deepseek.maxPromptArgBytes;
+            } else {
+              deepseek.maxPromptArgBytes = originalBudget;
+            }
+          }
+        }
+      },
+    );
+  });
+
   it('surfaces Qoder assistant error records through the SSE error channel', async () => {
     const qoderErrorLine = JSON.stringify({
       type: 'assistant',

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -98,6 +98,10 @@ async function withFakeCursorAgent<T>(script: string, run: () => Promise<T>): Pr
   return withFakeAgent('cursor-agent', script, run);
 }
 
+async function withFakeDeepSeek<T>(script: string, run: () => Promise<T>): Promise<T> {
+  return withFakeAgent('deepseek', script, run);
+}
+
 async function waitForFile(file: string, timeoutMs = 5_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -1746,6 +1750,31 @@ process.exit(1);
           agentName: 'Cursor Agent',
           detail: expect.stringContaining('cursor-agent status'),
         });
+      },
+    );
+  });
+
+  it('classifies DeepSeek TUI config guidance from stderr as missing auth', async () => {
+    await withFakeDeepSeek(
+      `
+const args = process.argv.slice(2);
+if (args[0] === '--version') {
+  console.log('deepseek 0.3.0-test');
+  process.exit(0);
+}
+console.error('KEY=<your-key> deepseek --api-key <your-key>');
+console.error('api_key = "<your-key>" in ~/.deepseek/config.toml');
+process.exit(0);
+`,
+      async () => {
+        const result = await testAgentConnection({ agentId: 'deepseek' });
+        expect(result).toMatchObject({
+          ok: false,
+          kind: 'agent_auth_required',
+          agentName: 'DeepSeek TUI',
+          detail: expect.stringContaining('~/.deepseek/config.toml'),
+        });
+        expect(result.detail).toContain('DEEPSEEK_API_KEY');
       },
     );
   });

--- a/apps/daemon/tests/runtimes/prompt-budget.test.ts
+++ b/apps/daemon/tests/runtimes/prompt-budget.test.ts
@@ -74,7 +74,7 @@ test('checkPromptArgvBudget flags oversized DeepSeek prompts and lets short prom
   assert.equal(flagged.bytes, deepseekMaxPromptArgBytes + 1);
   assert.match(flagged.message, /DeepSeek/);
   assert.match(flagged.message, /command-line argument/);
-  assert.match(flagged.message, /stdin support/);
+  assert.match(flagged.message, /stdin-capable adapter/);
 
   // Normal-sized prompts must not trip the guard; the chat happy path
   // depends on this returning null so it can proceed to spawn.
@@ -94,6 +94,17 @@ test('checkPromptArgvBudget flags oversized DeepSeek prompts and lets short prom
   const cjkFlagged = checkPromptArgvBudget(deepseek, cjkOversized);
   assert.ok(cjkFlagged, 'byte-counted UTF-8 prompts must also trip the guard');
   assert.equal(cjkFlagged.code, 'AGENT_PROMPT_TOO_LARGE');
+});
+
+test('checkPromptArgvBudget gives DeepSeek-specific guidance for large contexts', () => {
+  const oversized = 'x'.repeat(deepseekMaxPromptArgBytes + 1);
+  const flagged = checkPromptArgvBudget(deepseek, oversized);
+
+  assert.ok(flagged, 'oversized DeepSeek prompts must return a diagnostic');
+  assert.match(flagged.message, /DeepSeek TUI/);
+  assert.match(flagged.message, /currently accepts prompts only as a command-line argument/);
+  assert.match(flagged.message, /API\/provider model connection/);
+  assert.match(flagged.message, /stdin-capable adapter/);
 });
 
 // Adapters that ship the prompt over stdin (every other code agent


### PR DESCRIPTION
Fixes #1872

## Why

I hit the DeepSeek TUI setup path while checking local agent connectivity. When DeepSeek TUI is installed but not configured, Settings surfaced the raw CLI stderr instead of a typed auth-required message. Larger Open Design project prompts also failed with a generic argv-size diagnostic that did not explain the DeepSeek-specific limitation or the better large-context path.

This PR keeps the scope to daemon diagnostics: classify the DeepSeek TUI config/key guidance as an auth-required failure, and make the large-prompt message tell users why DeepSeek TUI cannot take that prompt shape today.

## What users will see

DeepSeek TUI failures that print key/config guidance now show an `AGENT_AUTH_REQUIRED` diagnostic with `~/.deepseek/config.toml` / `DEEPSEEK_API_KEY` setup guidance instead of raw stderr. Oversized DeepSeek TUI prompts now explain that DeepSeek TUI currently accepts prompts only as a command-line argument, and suggest reducing selected context or using an API/provider model connection for large contexts.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No UI surface changed; this is daemon-side connection/run diagnostics only.

## Bug fix verification

- Test path that reproduces the bug:
  - `apps/daemon/tests/connection-test.test.ts` covers the Settings Test DeepSeek TUI config stderr path.
  - `apps/daemon/tests/chat-route.test.ts` covers chat-run auth guidance using the agent-specific message instead of Cursor guidance.
  - `apps/daemon/tests/runtimes/prompt-budget.test.ts` covers DeepSeek-specific large prompt guidance.
- Did the test go red on `main` and green on this branch? No; I did not switch the worktree back to `main`. The new tests encode the issue-reported DeepSeek stderr and large-prompt behavior and pass on this branch.

## Validation

- `pnpm guard`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/chat-route.test.ts tests/connection-test.test.ts tests/runtimes/prompt-budget.test.ts`
- `pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/connection-test.test.ts -t "hard-cancels aborted agent probes before cleaning up"`
- `pnpm --dir apps/daemon exec vitest run -c vitest.config.ts` ran the daemon suite; all changed-area tests passed, and one unrelated abort-cleanup test was flaky in the full run (`term` marker ENOENT). The same test passed when rerun directly as listed above.