### PR TITLE
fix: prevent chat message content clipping in assistant messages

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1628,6 +1628,14 @@ a.avatar-item:visited {
   align-items: flex-end;
   max-width: min(78%, 560px);
 }
+.msg.assistant {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  max-width: 100%;
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
 .msg .role {
   display: flex;
   align-items: baseline;


### PR DESCRIPTION
## Summary

Fixes #1797

Prevents chat message content from being clipped in assistant messages, particularly after starting the publish flow from plugin detail view.

## Changes

- **Add explicit `.msg.assistant` styles** with proper word breaking and layout constraints
- **Set `display: flex` and `flex-direction: column`** for consistent layout structure
- **Add `overflow-wrap: break-word` and `word-break: break-word`** to handle long words and URLs
- **Ensure `min-width: 0` and `max-width: 100%`** to respect container bounds and prevent overflow

## Surface area

- [x] UI

## Verification

Verified the fix by:
1. Opening Plugins detail view
2. Clicking "Start publishing" to trigger the publish flow
3. Confirming that the assistant's publish instructions (including long URLs and structured data) display completely without clipping
4. Testing with various message types containing long URLs, code blocks, and unbroken strings
5. Verifying that content wraps properly within the chat panel bounds

## Before

- Assistant messages inherited only base `.msg` styles
- No explicit word-breaking rules for assistant content
- Long content (especially publish instructions with URLs, code blocks, or structured data) could overflow the container
- Content appeared clipped/truncated in the chat panel
- Issue particularly visible after "Start publishing" from plugin detail

## After

- Assistant messages have explicit flex layout with proper constraints
- Long words and URLs break correctly within container bounds
- Content wraps properly without clipping
- Full message text is visible and readable
- Consistent behavior across different message types and lengths

## Testing

- [x] Assistant messages display full content without clipping
- [x] Long URLs and code blocks wrap correctly
- [x] Publish flow instructions display completely
- [x] No horizontal overflow in chat panel
- [x] Word breaking works for long unbroken strings
- [x] Layout remains consistent with user messages

## Technical Details

**Root cause:**
- `.msg.user` had explicit `max-width: min(78%, 560px)` constraint
- `.msg.assistant` only inherited base `.msg` styles with `max-width: 100%`
- No explicit word-breaking rules for assistant messages
- Long content could exceed container bounds without proper wrapping

**Solution:**
```css
.msg.assistant {
  display: flex;              /* Explicit flex container */
  flex-direction: column;     /* Stack children vertically */
  min-width: 0;              /* Allow flex item to shrink below content size */
  max-width: 100%;           /* Respect parent container width */
  overflow-wrap: break-word; /* Break long words at arbitrary points */
  word-break: break-word;    /* Break words to prevent overflow */
}
```

**Why both `overflow-wrap` and `word-break`?**
- `overflow-wrap: break-word` - breaks long words only when necessary
- `word-break: break-word` - more aggressive breaking for edge cases
- Together they ensure content never overflows horizontally

**Why `min-width: 0`?**
- Flex items have an implicit `min-width: auto` which prevents shrinking below content size
- Setting `min-width: 0` allows the flex item to shrink and forces content to wrap
- Critical for proper text wrapping in flex containers
