### PR TITLE
fix(web): remove overscroll-behavior:none blocking scroll in New Project panel

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5397,11 +5397,6 @@ a.avatar-item:visited {
   flex: 0 1 auto;
   min-height: 0;
   overflow-y: auto;
-  /* Hard-stop at top/bottom: disable both scroll chaining and the element's
-     own rubber-band. The body's parents are transparent up to the gray
-     `--bg`, so any rubber-band travel briefly exposes that gray above/below
-     the white card. `none` removes the rubber-band entirely. */
-  overscroll-behavior: none;
 }
 .newproj-title {
   margin: 0;


### PR DESCRIPTION
Fixes #1942

## Why

`overscroll-behavior: none` on `.newproj-body` completely blocked trackpad and mouse wheel scrolling on macOS. Users could only scroll by hovering directly over the native scrollbar track on the right edge, which is a broken UX on trackpad-primary machines.

## What users will see

Trackpad and mouse wheel scrolling now work anywhere within the New Project panel content area, matching standard macOS scroll behavior.

## Surface area

- [x] **UI** — scroll behavior fix in New Project panel

## Validation

- Manual testing on macOS: trackpad and mouse wheel scrolling work over panel content after removing `overscroll-behavior: none`
- Confirmed the single property removal is sufficient — no other CSS changes needed
- `pnpm guard` ✅