### PR TITLE
Enable LAN web dev access

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from 'next';
+import { networkInterfaces } from 'node:os';
 import { dirname, isAbsolute, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -42,8 +43,66 @@ function resolveDevTsconfigPath() {
 
 const DEV_TSCONFIG_PATH = resolveDevTsconfigPath();
 
+function parseAllowedDevHost(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  try {
+    return new URL(trimmed).hostname.toLowerCase();
+  } catch {
+    try {
+      return new URL(`http://${trimmed}`).hostname.toLowerCase();
+    } catch {
+      return null;
+    }
+  }
+}
+
+function parseIpv4(value: string): [number, number, number, number] | null {
+  const parts = value.split('.');
+  if (parts.length !== 4) return null;
+  if (!parts.every((part) => /^\d+$/.test(part))) return null;
+  const octets = parts.map((part) => Number(part));
+  if (!octets.every((octet) => Number.isInteger(octet) && octet >= 0 && octet <= 255)) return null;
+  return octets as [number, number, number, number];
+}
+
+function isPrivateLanIpv4(value: string): boolean {
+  const octets = parseIpv4(value);
+  if (octets == null) return false;
+  const [a, b] = octets;
+  return (
+    a === 10 ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 169 && b === 254) ||
+    (a === 100 && b >= 64 && b <= 127)
+  );
+}
+
+function localPrivateLanHosts(): string[] {
+  return Object.values(networkInterfaces())
+    .flatMap((entries) => entries ?? [])
+    .filter((entry) => entry.family === 'IPv4' && !entry.internal && isPrivateLanIpv4(entry.address))
+    .map((entry) => entry.address);
+}
+
+function configuredAllowedDevHosts(): string[] {
+  const configured = (process.env.OD_ALLOWED_DEV_ORIGINS ?? '')
+    .split(',')
+    .map(parseAllowedDevHost)
+    .filter((host): host is string => host != null);
+
+  const bindHost = parseAllowedDevHost(process.env.OD_HOST ?? '');
+  return Array.from(new Set([
+    '127.0.0.1',
+    ...localPrivateLanHosts(),
+    ...(bindHost != null && bindHost !== '0.0.0.0' && bindHost !== '::' ? [bindHost] : []),
+    ...configured,
+  ]));
+}
+
 const nextConfig: NextConfig = {
-  allowedDevOrigins: ['127.0.0.1'],
+  allowedDevOrigins: configuredAllowedDevHosts(),
   outputFileTracingRoot: WORKSPACE_ROOT,
   reactStrictMode: true,
   turbopack: {

--- a/apps/web/sidecar/server.ts
+++ b/apps/web/sidecar/server.ts
@@ -242,6 +242,7 @@ function resolveHttpProxyTarget(
 export function normalizeDaemonProxyOriginHeader(options: {
   daemonOrigin: string;
   origin: string | undefined;
+  requestHost?: string | string[];
   webPort: number;
 }): string | undefined {
   if (options.origin == null || options.origin.length === 0) return options.origin;
@@ -252,7 +253,137 @@ export function normalizeDaemonProxyOriginHeader(options: {
     schemes.flatMap((scheme) => loopbackHosts.map((host) => `${scheme}://${host}:${options.webPort}`)),
   );
 
-  return allowedWebOrigins.has(options.origin) ? options.daemonOrigin : options.origin;
+  if (allowedWebOrigins.has(options.origin)) return options.daemonOrigin;
+
+  const parsedOrigin = parseHttpOrigin(options.origin);
+  if (
+    parsedOrigin != null &&
+    isSameBrowserHostOrigin({
+      origin: parsedOrigin,
+      requestHost: options.requestHost,
+      webPort: options.webPort,
+    })
+  ) {
+    return options.daemonOrigin;
+  }
+
+  return options.origin;
+}
+
+function firstHeaderValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function parseHostHeader(value: string | string[] | undefined): URL | null {
+  const raw = firstHeaderValue(value)?.trim();
+  if (raw == null || raw.length === 0) return null;
+  try {
+    return new URL(`http://${raw}`);
+  } catch {
+    return null;
+  }
+}
+
+function parseHttpOrigin(value: string): URL | null {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseAllowedDevHost(value: string): string | null {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return null;
+  try {
+    return new URL(trimmed).hostname.toLowerCase();
+  } catch {
+    try {
+      return new URL(`http://${trimmed}`).hostname.toLowerCase();
+    } catch {
+      return null;
+    }
+  }
+}
+
+function configuredAllowedDevHosts(): Set<string> {
+  return new Set(
+    (process.env.OD_ALLOWED_DEV_ORIGINS ?? "")
+      .split(",")
+      .map(parseAllowedDevHost)
+      .filter((host): host is string => host != null),
+  );
+}
+
+function isAllowedDevHost(hostname: string, allowedHosts: Set<string>): boolean {
+  const host = hostname.toLowerCase();
+  if (allowedHosts.has(host)) return true;
+
+  for (const allowedHost of allowedHosts) {
+    if (!allowedHost.startsWith("*.")) continue;
+    const suffix = allowedHost.slice(1);
+    if (host.endsWith(suffix) && host.length > suffix.length) return true;
+  }
+
+  return false;
+}
+
+function parseIpv4(value: string): [number, number, number, number] | null {
+  const parts = value.split(".");
+  if (parts.length !== 4) return null;
+  if (!parts.every((part) => /^\d+$/.test(part))) return null;
+  const octets = parts.map((part) => Number(part));
+  if (!octets.every((octet) => Number.isInteger(octet) && octet >= 0 && octet <= 255)) return null;
+  return octets as [number, number, number, number];
+}
+
+function isPrivateLanIpv4(value: string): boolean {
+  const octets = parseIpv4(value);
+  if (octets == null) return false;
+  const [a, b] = octets;
+  return (
+    a === 10 ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 169 && b === 254) ||
+    (a === 100 && b >= 64 && b <= 127)
+  );
+}
+
+function isLoopbackOrPrivateLanHost(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  return (
+    host === "localhost" ||
+    host === "127.0.0.1" ||
+    host === "::1" ||
+    host === "[::1]" ||
+    host === "0.0.0.0" ||
+    host === "::" ||
+    isPrivateLanIpv4(host)
+  );
+}
+
+function defaultPortForProtocol(protocol: string): string {
+  return protocol === "https:" ? "443" : "80";
+}
+
+function isSameBrowserHostOrigin(options: {
+  origin: URL;
+  requestHost?: string | string[];
+  webPort: number;
+}): boolean {
+  const requestHost = parseHostHeader(options.requestHost);
+  if (requestHost == null) return false;
+
+  const originPort = options.origin.port || defaultPortForProtocol(options.origin.protocol);
+  const requestPort = requestHost.port || "80";
+  if (originPort !== String(options.webPort) || requestPort !== originPort) return false;
+  if (requestHost.hostname.toLowerCase() !== options.origin.hostname.toLowerCase()) return false;
+
+  const allowedDevHosts = configuredAllowedDevHosts();
+  const originHost = options.origin.hostname.toLowerCase();
+  return isLoopbackOrPrivateLanHost(originHost) || isAllowedDevHost(originHost, allowedDevHosts);
 }
 
 async function proxyHttpRequest(
@@ -267,6 +398,7 @@ async function proxyHttpRequest(
     const origin = normalizeDaemonProxyOriginHeader({
       daemonOrigin: target.origin,
       origin: typeof request.headers.origin === "string" ? request.headers.origin : undefined,
+      requestHost: request.headers.host,
       webPort: options.daemonWebPort,
     });
     if (origin == null || origin.length === 0) {

--- a/apps/web/tests/sidecar-proxy.test.ts
+++ b/apps/web/tests/sidecar-proxy.test.ts
@@ -160,6 +160,46 @@ describe('normalizeDaemonProxyOriginHeader', () => {
     ).toBe('http://127.0.0.1:7456');
   });
 
+  it('normalizes matching private LAN browser origins to the daemon origin', () => {
+    expect(
+      normalizeDaemonProxyOriginHeader({
+        daemonOrigin: 'http://127.0.0.1:7456',
+        origin: 'http://192.168.3.23:8085',
+        requestHost: '192.168.3.23:8085',
+        webPort: 8085,
+      }),
+    ).toBe('http://127.0.0.1:7456');
+  });
+
+  it('does not normalize mismatched private LAN origins', () => {
+    expect(
+      normalizeDaemonProxyOriginHeader({
+        daemonOrigin: 'http://127.0.0.1:7456',
+        origin: 'http://192.168.3.23:8085',
+        requestHost: '192.168.3.24:8085',
+        webPort: 8085,
+      }),
+    ).toBe('http://192.168.3.23:8085');
+  });
+
+  it('normalizes matching wildcard configured dev origins to the daemon origin', () => {
+    const previous = process.env.OD_ALLOWED_DEV_ORIGINS;
+    process.env.OD_ALLOWED_DEV_ORIGINS = '*.local-origin.dev';
+    try {
+      expect(
+        normalizeDaemonProxyOriginHeader({
+          daemonOrigin: 'http://127.0.0.1:7456',
+          origin: 'http://app.local-origin.dev:8085',
+          requestHost: 'app.local-origin.dev:8085',
+          webPort: 8085,
+        }),
+      ).toBe('http://127.0.0.1:7456');
+    } finally {
+      if (previous == null) delete process.env.OD_ALLOWED_DEV_ORIGINS;
+      else process.env.OD_ALLOWED_DEV_ORIGINS = previous;
+    }
+  });
+
   it('does not rewrite unrelated browser origins', () => {
     expect(
       normalizeDaemonProxyOriginHeader({


### PR DESCRIPTION
## Summary
- allow Next dev origins for local private LAN hosts and configured dev hosts
- normalize same-origin LAN browser API requests before proxying to the loopback daemon
- cover LAN origin normalization and mismatched-host rejection in sidecar proxy tests

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Testing
- pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/sidecar-proxy.test.ts
- pnpm --filter @open-design/web build:sidecar
- pnpm exec tsc --noEmit --target ES2024 --lib ES2024,DOM --module NodeNext --moduleResolution NodeNext --types node --skipLibCheck apps/web/next.config.ts

## Notes
- Broader web test run had one unrelated existing failure: tests/components/MemorySection.test.tsx > keeps the expanded preview control visually distinct from delete.