### PR TITLE
fix: force HtmlViewer remount on tab switch to prevent blank preview

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -642,6 +642,7 @@ export function FileViewer({
   if (rendererMatch?.renderer.id === 'html' || rendererMatch?.renderer.id === 'deck-html') {
     return (
       <HtmlViewer
+        key={`${projectId}::${file.name}`}
         projectId={projectId}
         projectKind={projectKind}
         file={file}


### PR DESCRIPTION
Fixes #1946

## Problem
When switching between HTML file tabs, the preview iframe renders blank because the component's state transition (`null` → `oldText` → `null` → `newText`) within the same mounted instance fails to recommit `srcDoc`.

## Solution
Added `key={\`${projectId}::${file.name}\`}` to `<HtmlViewer>` at line 644 to force a fresh component instance on every tab switch, bypassing the race condition entirely.

## Trade-off
Per-file inspect/board/zoom/manualEdit state is lost on switch, but this is acceptable given the alternative is a broken preview.

## Testing
1. Open a project with at least two HTML files (e.g., `a.html`, `b.html`)
2. Click `a.html` → preview renders
3. Click `b.html` → preview renders
4. Click `a.html` again → **preview should still render** (previously blank)

## Notes
This is the cheap mitigation suggested in the issue. A proper fix would track down which dependent effect is failing to recommit srcDoc, but this unblocks users immediately.

**Changes**: 1 line (added `key` prop)