### PR TITLE
fix(daemon): skip Cursor model_call_id replay to prevent duplicate output

### DIFF
--- a/apps/daemon/src/json-event-stream.ts
+++ b/apps/daemon/src/json-event-stream.ts
@@ -236,10 +236,21 @@ function handleCursorEvent(obj: unknown, onEvent: StreamEventHandler, state: Par
 
   if (obj.type === 'assistant' && obj.message) {
     // Cursor sends a final assistant message with `model_call_id` that
-    // replays the full accumulated text for the turn. Since the
-    // incremental deltas have already been emitted, skip this replay
-    // to avoid duplicating content in the persisted message.
-    if (typeof obj.model_call_id === 'string') return true;
+    // replays the full accumulated text for the turn. If all incremental
+    // deltas arrived, the replay content equals `cursorTextSoFar` and
+    // emitCursorTextDelta will deduplicate it. If a streamed chunk was
+    // dropped, the replay may contain a suffix that was never emitted —
+    // emit only that missing suffix to keep the persisted message complete
+    // without duplicating the content that was already sent.
+    if (typeof obj.model_call_id === 'string') {
+      const text = extractCursorText(obj.message);
+      if (text && text.length > state.cursorTextSoFar.length && state.cursorTextSoFar.length > 0) {
+        const suffix = text.slice(state.cursorTextSoFar.length);
+        if (suffix) onEvent({ type: 'text_delta', delta: suffix });
+        state.cursorTextSoFar = text;
+      }
+      return true;
+    }
     const text = extractCursorText(obj.message);
     if (!text) return false;
     emitCursorTextDelta(text, onEvent, state);

--- a/apps/daemon/src/json-event-stream.ts
+++ b/apps/daemon/src/json-event-stream.ts
@@ -5,6 +5,7 @@ type ParserKind = string;
 
 type ParserState = {
   cursorTextSoFar: string;
+  cursorTurnStart: number;
   openCodeToolUses: Set<string>;
   codexToolUses: Set<string>;
   codexErrorEmitted: boolean;
@@ -236,24 +237,33 @@ function handleCursorEvent(obj: unknown, onEvent: StreamEventHandler, state: Par
 
   if (obj.type === 'assistant' && obj.message) {
     // Cursor sends a final assistant message with `model_call_id` that
-    // replays the full accumulated text for the turn. If all incremental
-    // deltas arrived, the replay content equals `cursorTextSoFar` and
-    // emitCursorTextDelta will deduplicate it. If a streamed chunk was
-    // dropped, the replay may contain a suffix that was never emitted —
-    // emit only that missing suffix to keep the persisted message complete
-    // without duplicating the content that was already sent.
+    // replays the full accumulated text for the current turn. Compare
+    // the replay against only the current turn's portion of
+    // `cursorTextSoFar` (starting from `cursorTurnStart`). If a
+    // streamed chunk was dropped, the replay may be longer than what
+    // we emitted for this turn — emit the missing suffix.
     if (typeof obj.model_call_id === 'string') {
       const text = extractCursorText(obj.message);
-      if (text && text.length > state.cursorTextSoFar.length && state.cursorTextSoFar.length > 0) {
-        const suffix = text.slice(state.cursorTextSoFar.length);
+      const turnLength = state.cursorTextSoFar.length - state.cursorTurnStart;
+      if (text && text.length > turnLength) {
+        const suffix = text.slice(turnLength);
         if (suffix) onEvent({ type: 'text_delta', delta: suffix });
-        state.cursorTextSoFar = text;
+        state.cursorTextSoFar += suffix;
       }
+      // Mark the next turn's start after processing the replay.
+      state.cursorTurnStart = state.cursorTextSoFar.length;
       return true;
     }
     const text = extractCursorText(obj.message);
     if (!text) return false;
     emitCursorTextDelta(text, onEvent, state);
+    // Non-timestamped assistant events are final replays that mark a turn
+    // boundary. Advance cursorTurnStart so the next model_call_id replay
+    // measures turnLength from the right offset. Timestamped events are
+    // incremental streaming chunks within a turn and must not advance it.
+    if (typeof obj.timestamp_ms !== 'number') {
+      state.cursorTurnStart = state.cursorTextSoFar.length;
+    }
     return true;
   }
 
@@ -405,6 +415,7 @@ export function createJsonEventStreamHandler(kind: ParserKind, onEvent: StreamEv
   let buffer = '';
   const state: ParserState = {
     cursorTextSoFar: '',
+    cursorTurnStart: 0,
     openCodeToolUses: new Set<string>(),
     codexToolUses: new Set<string>(),
     codexErrorEmitted: false,

--- a/apps/daemon/src/json-event-stream.ts
+++ b/apps/daemon/src/json-event-stream.ts
@@ -235,12 +235,13 @@ function handleCursorEvent(obj: unknown, onEvent: StreamEventHandler, state: Par
   }
 
   if (obj.type === 'assistant' && obj.message) {
+    // Cursor sends a final assistant message with `model_call_id` that
+    // replays the full accumulated text for the turn. Since the
+    // incremental deltas have already been emitted, skip this replay
+    // to avoid duplicating content in the persisted message.
+    if (typeof obj.model_call_id === 'string') return true;
     const text = extractCursorText(obj.message);
     if (!text) return false;
-    if (typeof obj.timestamp_ms === 'number') {
-      emitCursorTextDelta(text, onEvent, state);
-      return true;
-    }
     emitCursorTextDelta(text, onEvent, state);
     return true;
   }

--- a/apps/daemon/tests/json-event-stream.test.ts
+++ b/apps/daemon/tests/json-event-stream.test.ts
@@ -350,6 +350,34 @@ test('cursor stream skips model_call_id replay to avoid duplicate content', () =
   ]);
 });
 
+test('cursor stream emits missing suffix from model_call_id replay when chunks are dropped', () => {
+  const { events, handler } = collectEvents('cursor-agent');
+
+  // Only partial fragments arrive — the last chunk is dropped
+  handler.feed(
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 1,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hello' }] },
+    }) +
+    '\n' +
+    // " world" chunk was dropped / never received
+    // Full replay arrives with model_call_id — should emit the missing suffix
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 2,
+      model_call_id: 'call-1',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hello world' }] },
+    }) +
+    '\n',
+  );
+
+  assert.deepEqual(events, [
+    { type: 'text_delta', delta: 'hello' },
+    { type: 'text_delta', delta: ' world' },
+  ]);
+});
+
 test('codex json stream emits status text and usage events', () => {
   const { events, handler } = collectEvents('codex');
 

--- a/apps/daemon/tests/json-event-stream.test.ts
+++ b/apps/daemon/tests/json-event-stream.test.ts
@@ -378,6 +378,99 @@ test('cursor stream emits missing suffix from model_call_id replay when chunks a
   ]);
 });
 
+test('cursor stream emits missing suffix from model_call_id replay in second turn', () => {
+  const { events, handler } = collectEvents('cursor-agent');
+
+  // Turn 1: all chunks arrive, replay matches
+  handler.feed(
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 1,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hello world' }] },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 2,
+      model_call_id: 'call-1',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hello world' }] },
+    }) +
+    '\n',
+  );
+
+  // Turn 2: "second" arrives but " turn" is dropped
+  handler.feed(
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 3,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'second' }] },
+    }) +
+    '\n' +
+    // Replay contains "second turn" — should emit missing " turn"
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 4,
+      model_call_id: 'call-2',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'second turn' }] },
+    }) +
+    '\n',
+  );
+
+  assert.deepEqual(events, [
+    { type: 'text_delta', delta: 'hello world' },
+    { type: 'text_delta', delta: 'second' },
+    { type: 'text_delta', delta: ' turn' },
+  ]);
+});
+
+test('cursor stream recovers dropped chunk via model_call_id after fallback-terminated turn', () => {
+  const { events, handler } = collectEvents('cursor-agent');
+
+  // Turn 1 ends via the non-model_call_id fallback path (no timestamp)
+  handler.feed(
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 1,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hello' }] },
+    }) +
+    '\n' +
+    // Final replay without model_call_id — fallback path
+    JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hello world' }] },
+    }) +
+    '\n',
+  );
+
+  // Turn 2: "second" arrives but " turn" is dropped, then model_call_id
+  // replay recovers the missing suffix. Without the cursorTurnStart
+  // advancement in the fallback path, turnLength would be computed from
+  // position 0 (including turn 1's text), making the replay length
+  // appear shorter than what was already emitted — losing " turn".
+  handler.feed(
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 2,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'second' }] },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 3,
+      model_call_id: 'call-2',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'second turn' }] },
+    }) +
+    '\n',
+  );
+
+  assert.deepEqual(events, [
+    { type: 'text_delta', delta: 'hello' },
+    { type: 'text_delta', delta: ' world' },
+    { type: 'text_delta', delta: 'second' },
+    { type: 'text_delta', delta: ' turn' },
+  ]);
+});
+
 test('codex json stream emits status text and usage events', () => {
   const { events, handler } = collectEvents('codex');
 

--- a/apps/daemon/tests/json-event-stream.test.ts
+++ b/apps/daemon/tests/json-event-stream.test.ts
@@ -292,6 +292,64 @@ test('cursor stream de-duplicates cumulative timestamped assistant chunks', () =
   ]);
 });
 
+test('cursor stream skips model_call_id replay to avoid duplicate content', () => {
+  const { events, handler } = collectEvents('cursor-agent');
+
+  // Cursor sends incremental deltas as independent fragments, then a
+  // final assistant message with model_call_id that replays the full
+  // accumulated text. The replay must be skipped to avoid duplication.
+  handler.feed(
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 1,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hello' }] },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 2,
+      message: { role: 'assistant', content: [{ type: 'text', text: ' world' }] },
+    }) +
+    '\n' +
+    // Full replay with model_call_id — should be skipped
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 3,
+      model_call_id: 'call-1',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hello world' }] },
+    }) +
+    '\n' +
+    // New turn starts with fresh incremental deltas
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 4,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'second' }] },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 5,
+      message: { role: 'assistant', content: [{ type: 'text', text: ' turn' }] },
+    }) +
+    '\n' +
+    // Full replay of second turn — should also be skipped
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 6,
+      model_call_id: 'call-2',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'second turn' }] },
+    }) +
+    '\n',
+  );
+
+  assert.deepEqual(events, [
+    { type: 'text_delta', delta: 'hello' },
+    { type: 'text_delta', delta: ' world' },
+    { type: 'text_delta', delta: 'second' },
+    { type: 'text_delta', delta: ' turn' },
+  ]);
+});
+
 test('codex json stream emits status text and usage events', () => {
   const { events, handler } = collectEvents('codex');
 


### PR DESCRIPTION
Fixes #1840

## Why

When using Cursor CLI as the agent, every paragraph in the assistant response was duplicated — both during streaming and in the persisted message after refresh. This made Cursor unusable for real conversations.

## Root cause

Cursor streams assistant messages as **independent incremental fragments** (each event carries only the new text for that chunk), then sends a **final assistant message with `model_call_id`** that replays the full accumulated text for the turn.

Here's what Cursor actually sends (captured from daemon logs with `OD_DEBUG_CURSOR_STREAM=1`):

```
# Turn 1: independent incremental fragments
{"type":"assistant","message":{"content":[{"type":"text","text":"正在"}]},"timestamp_ms":1779013673287}
{"type":"assistant","message":{"content":[{"type":"text","text":"查看项目"}]},"timestamp_ms":1779013673290}
{"type":"assistant","message":{"content":[{"type":"text","text":"当前"}]},"timestamp_ms":1779013673291}
{"type":"assistant","message":{"content":[{"type":"text","text":"状态，以便"}]},"timestamp_ms":1779013673291}
...more fragments...

# Turn 1 replay: full accumulated text WITH model_call_id
{"type":"assistant","message":{"content":[{"type":"text","text":"正在查看项目当前状态，以便回复你的问候并确认页面是否已就绪。\n\n"}]},"model_call_id":"c5f20c6a-...","timestamp_ms":1779013673356}

# Turn 2: new independent fragments
{"type":"assistant","message":{"content":[{"type":"text","text":"你好。\n\n"}]},"timestamp_ms":1779013680759}
{"type":"assistant","message":{"content":[{"type":"text","text":"当前项目里已经"}]},"timestamp_ms":1779013680759}
...more fragments, content repeats here...
```

The existing `emitCursorTextDelta` assumed **cumulative text** (each message contains all prior text plus new content). But Cursor sends **independent fragments** — each event only carries the new chunk. Every fragment hit the fallback path and was appended to `cursorTextSoFar`. When the `model_call_id` replay arrived, `cursorTextSoFar` had already grown past the replay length, so the replay was not deduplicated — its full content was emitted again as new deltas, causing every paragraph to appear twice.

## Fix

Skip assistant messages that carry a `model_call_id` field — their content has already been emitted via the preceding incremental deltas.

## What users will see

Cursor CLI output no longer duplicates paragraphs in the chat.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only

## Bug fix verification

- Reproduced on `main` with Cursor CLI (Composer 2 Fast): every paragraph appeared twice, persisted after refresh
- After fix: output appears once, verified by restarting daemon and re-running with Cursor
- Added regression test `cursor stream skips model_call_id replay to avoid duplicate content` covering two turns with replay messages

## Validation

- `pnpm --filter @open-design/daemon exec vitest run tests/json-event-stream.test.ts` — 22/22 passed ✅
- Manual testing with Cursor CLI on macOS ✅