### PR TITLE
Clarify Claude custom endpoint connection failures

### DIFF
--- a/apps/daemon/src/claude-diagnostics.ts
+++ b/apps/daemon/src/claude-diagnostics.ts
@@ -62,6 +62,19 @@ export function diagnoseClaudeCliFailure(
   const hasCustomBaseUrl = envValue(input.env, 'ANTHROPIC_BASE_URL') !== null;
   const hasConfigDir = envValue(input.env, 'CLAUDE_CONFIG_DIR') !== null;
 
+  const customEndpointConnectionFailure =
+    hasCustomBaseUrl &&
+    (/connectionrefused/i.test(text) ||
+      /connection refused/i.test(text) ||
+      /econnrefused/i.test(text));
+  if (customEndpointConnectionFailure) {
+    return withContext(
+      'Claude Code could not reach the configured custom Anthropic endpoint.',
+      'ANTHROPIC_BASE_URL appears to point at a local or proxy endpoint that refused the connection. Start or fix that proxy, clear the stale endpoint, or remove the custom endpoint to retry with standard Claude Code auth.',
+      input,
+    );
+  }
+
   const authFailure =
     /\b401\b/.test(text) ||
     /apikeysource["'\s:]+none/i.test(text) ||

--- a/apps/daemon/tests/claude-diagnostics.test.ts
+++ b/apps/daemon/tests/claude-diagnostics.test.ts
@@ -41,6 +41,22 @@ describe('diagnoseClaudeCliFailure', () => {
     expect(diagnostic?.detail).not.toContain('use `/login`');
   });
 
+  it('maps custom endpoint connection refusals before generic auth guidance', () => {
+    const diagnostic = diagnoseClaudeCliFailure({
+      agentId: 'claude',
+      exitCode: 1,
+      stderrTail:
+        '{"apiKeySource":"none"} API Error: Unable to connect to API (ConnectionRefused)',
+      env: { ANTHROPIC_BASE_URL: 'http://127.0.0.1:1337' },
+    });
+
+    expect(diagnostic?.message).toContain('could not reach');
+    expect(diagnostic?.detail).toContain('ANTHROPIC_BASE_URL');
+    expect(diagnostic?.detail).toContain('refused the connection');
+    expect(diagnostic?.detail).not.toContain('could not authenticate');
+    expect(diagnostic?.detail).not.toContain('use `/login`');
+  });
+
   it('maps silent custom endpoint exits to endpoint guidance', () => {
     const diagnostic = diagnoseClaudeCliFailure({
       agentId: 'claude',


### PR DESCRIPTION
## Summary
- detect `ConnectionRefused` / `ECONNREFUSED` failures from a configured `ANTHROPIC_BASE_URL` before the generic Claude auth bucket
- point users toward stale local/proxy endpoint fixes instead of `/login` when the custom endpoint refused the connection
- add a regression test for the `apiKeySource:none` + `ConnectionRefused` output seen in #1873

## What users will see

When Claude Code exits with a refused custom endpoint connection while `ANTHROPIC_BASE_URL` is set, Open Design now tells the user the configured endpoint could not be reached and suggests fixing/clearing the proxy instead of sending them back through `/login`.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope
- [x] **Default behavior change** — existing users with a refused custom Claude endpoint get a more specific diagnostic message
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Bug fix verification

- Test path: `apps/daemon/tests/claude-diagnostics.test.ts`
- Added a regression fixture for `apiKeySource:none` plus `ConnectionRefused` with `ANTHROPIC_BASE_URL` set, so this exact failure is classified before generic auth guidance.

## Validation

- `git diff --check`

Closes #1873? No — this just improves the diagnostic for one confirmed failure mode while the original reporter confirms their environment.
