### PR TITLE
fix(daemon): surface ACP model selection failures instead of silently…

### DIFF
--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -507,10 +507,20 @@ export function attachAcpSession({
     }
   };
 
-  const recoverFromModelSelectionError = () => {
+  const recoverFromModelSelectionError = (errorCode?: unknown, errorMessage?: string) => {
+    const requestedModel = model;
     setModelRequestId = null;
     activeModel = activeModel || 'default';
     send('agent', { type: 'status', label: 'model', model: activeModel });
+    const codeHint = typeof errorCode === 'number' ? ` (error ${errorCode})` : '';
+    const detail = errorMessage ? `: ${errorMessage}` : '';
+    const warningMsg =
+      `Model "${requestedModel}" could not be set${codeHint}${detail}. ` +
+      `Using CLI default "${activeModel}" instead.`;
+    // Surface the warning as a status event the frontend already renders.
+    send('agent', { type: 'status', label: 'model_selection_failed', detail: warningMsg });
+    // Also emit to stderr so `pnpm tools-dev logs` captures it.
+    console.warn(`[acp] ${warningMsg}`);
     sendPrompt();
   };
 
@@ -536,7 +546,8 @@ export function attachAcpSession({
         modelSelectionErrorIsRecoverable(error?.code) &&
         promptRequestId === null
       ) {
-        recoverFromModelSelectionError();
+        const errMsg = typeof error?.message === 'string' ? error.message : undefined;
+        recoverFromModelSelectionError(error?.code, errMsg);
         return;
       }
       if (error?.code === -32603 && obj.id !== expectedId) {

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -253,6 +253,75 @@ function agentModelStatuses(events: Array<{ event: string; payload: unknown }>):
     .map((entry) => (entry.payload as { model?: unknown }).model);
 }
 
+test('attachAcpSession emits model_selection_failed warning when set_model returns a recoverable error', () => {
+  const child = new FakeAcpChild();
+  const writes: string[] = [];
+  const events: Array<{ event: string; payload: unknown }> = [];
+  child.stdin.on('data', (chunk) => writes.push(String(chunk)));
+
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'hello',
+    cwd: '/tmp/od-project',
+    model: 'claude-opus-4-7-max',
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  // initialize → success
+  writeAcpResult(child, 1, {});
+  // session/new → success with a default model
+  writeAcpResult(child, 2, {
+    sessionId: 'session-1',
+    models: { currentModelId: 'swe-1-6-fast', availableModels: [] },
+  });
+  // session/set_model → -32602 error (method not supported)
+  child.stdout.write(`${JSON.stringify({
+    jsonrpc: '2.0',
+    id: 3,
+    error: { code: -32602, message: 'Model selection not supported' },
+  })}\n`);
+
+  // Should emit model status fallback AND a warning event
+  const statusEvents = events.filter((e) => {
+    const p = e.payload as { type?: string; label?: string };
+    return e.event === 'agent' && p.type === 'status';
+  });
+  const warningEvent = statusEvents.find(
+    (e) => (e.payload as { label?: string }).label === 'model_selection_failed',
+  );
+  assert.ok(warningEvent, 'should emit a model_selection_failed status event');
+  const warningPayload = warningEvent.payload as { detail?: string };
+  assert.ok(
+    warningPayload.detail?.includes('claude-opus-4-7-max'),
+    'warning should mention the requested model',
+  );
+  assert.ok(
+    warningPayload.detail?.includes('swe-1-6-fast'),
+    'warning should mention the fallback model',
+  );
+  assert.ok(
+    warningPayload.detail?.includes('-32602'),
+    'warning should include the error code',
+  );
+
+  // Should have logged to stderr
+  assert.ok(warnSpy.mock.calls.length > 0, 'should log warning to console');
+  assert.ok(
+    String(warnSpy.mock.calls[0][0]).includes('claude-opus-4-7-max'),
+    'console warning should mention requested model',
+  );
+
+  warnSpy.mockRestore();
+
+  // Should still proceed with sendPrompt (session/prompt is the next RPC)
+  const requests = parseRpcWrites(writes);
+  const promptRequest = requests.find((entry) => entry.method === 'session/prompt');
+  assert.ok(promptRequest, 'should still send the prompt after recovery');
+});
+
 test('attachAcpSession force-terminates the child after a clean prompt completion if it does not exit on stdin.end()', async () => {
   vi.useFakeTimers();
   try {


### PR DESCRIPTION
… falling back

When an ACP runtime (Kiro CLI, Devin, Hermes, Kimi, etc.) rejects a session/set_model or session/set_config_option request with a recoverable error (-32602, -32603, -32601, -32002), the daemon previously swallowed the error and silently continued with the CLI's default model. Users had no indication that their model selection did not take effect.

Now the daemon:
1. Emits a 'status' SSE event with label 'model_selection_failed' and a human-readable detail string that names the requested model, the fallback model, and the error code.
2. Logs a console.warn so the failure appears in 'pnpm tools-dev logs'.
3. Still recovers gracefully and proceeds with the prompt (no breaking change to the existing fallback behavior).

Adds test coverage for the new warning path.

<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works.
     Delete this whole block if the PR genuinely doesn't close any issue. -->
Fixes #

## Why

<!-- Why are you opening this PR? Cover two things:
       - Your use case — what made you write this today? Did you hit it yourself
         while building on top of OD, are you scratching an itch for a team, or
         are you speculatively adding for others? All are fine, but say which.
       - The pain being addressed — user-facing problem, technical debt, a prod
         issue, or unblocking another change.
     For non-trivial features, please open a discussion or issue first to align
     on scope and UX before writing code. -->


## What users will see

<!-- Describe the change from a user's perspective, not in code terms. Examples:
       - "Settings → AI Providers has a new 'Custom endpoint' field, off by default"
       - "Right-clicking a design file shows a new 'Duplicate' option"
       - "Default model changed from X to Y — existing users will notice on first launch"
       - "New `od skills install <name>` subcommand"
     Skip this section only if you check "None" below. -->


## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only


## Screenshots

<!-- If you checked "UI" above, attach screenshots showing the entry point —
     where users discover the change — not just the feature in isolation.
     Before/after is best for behavior changes. Short GIFs welcome. -->


## Bug fix verification

<!-- Skip if this PR isn't a bug fix.

     Per AGENTS.md → "Bug follow-up workflow", bugs should be encoded as a
     falsifiable test that goes red before the source change. Confirm:
       - Test path that reproduces the bug:
       - Did the test go red on `main` and green on this branch? (yes / no)
       - If a red spec wasn't cheap to write, explain why and what verification
         you did instead. -->

-


## Validation

<!-- What you actually ran. Default minimum: `pnpm guard` + `pnpm typecheck`,
     plus the package-scoped tests/build for the files you changed
     (e.g. `pnpm --filter @open-design/web test`). -->

-
