### PR TITLE
Fix/priority improvements 2026 05 17

### DIFF
--- a/QUICKSTART.de.md
+++ b/QUICKSTART.de.md
@@ -8,8 +8,12 @@ Führen Sie das vollständige Produkt lokal aus.
 
 - **Node.js:** `~24` (Node 24.x). Das Repository erzwingt dies über `package.json#engines`.
 - **pnpm:** `10.33.x`. Das Repository pinnt `pnpm@10.33.2` über `packageManager`; verwenden Sie Corepack, damit automatisch die gepinnte Version gewählt wird.
-- **OS:** macOS, Linux und WSL2 sind die primären Pfade. Windows nativ sollte für die meisten Abläufe funktionieren, WSL2 ist aber die sicherere Basis.
-- **Optionale lokale Agent-CLI:** Claude Code, Codex, Gemini CLI, OpenCode, Cursor Agent, Qwen, GitHub Copilot CLI usw. Wenn keine installiert ist, verwenden Sie den BYOK-API-Modus in den Einstellungen.
+- **OS:** macOS, Linux und WSL2 sind die primären Pfade. Windows nativ wird unterstützt; lesen Sie [`docs/windows-troubleshooting.md`](docs/windows-troubleshooting.md) für häufige Setup-Probleme.
+- **Optionale lokale Agent-CLI:** Claude Code, Codex, Devin for Terminal, Gemini CLI, OpenCode, Cursor Agent, Qwen, Qoder CLI, GitHub Copilot CLI, etc. Wenn keine installiert ist, verwenden Sie den BYOK-API-Modus in den Einstellungen.
+
+### Lokale Agent-CLI und PATH
+
+Der Daemon scannt Ihr **`PATH`** (plus gängige Benutzer-Toolchain-Verzeichnisse). Wenn Sie eine CLI mit **`npm install -g`** oder **Homebrew** installieren und Open Design sie immer noch als *nicht installiert* anzeigt, startet die GUI möglicherweise mit einem minimalen `PATH`, das Ihr globales npm- oder Homebrew-`bin`-Verzeichnis nicht enthält (häufig auf macOS, wenn die App nicht aus einer vollständigen Login-Shell gestartet wird). Stellen Sie sicher, dass das Verzeichnis der ausführbaren Datei im `PATH` für den Prozess liegt, der den Daemon ausführt, und verwenden Sie dann **Rescan** in **Settings → Execution mode**.
 
 `nvm` / `fnm` sind optionale Komfortwerkzeuge, keine Voraussetzung für das Projektsetup. Wenn Sie eines davon verwenden, installieren/selektieren Sie Node 24 vor pnpm:
 
@@ -30,6 +34,129 @@ corepack enable
 corepack pnpm --version   # sollte 10.33.2 ausgeben
 ```
 
+## Docker Setup
+
+Führen Sie Open Design in einer vollständig containerisierten Umgebung aus, ohne Node.js oder pnpm lokal zu installieren.
+
+### Anforderungen
+
+* Docker Desktop
+* Docker Compose v2
+
+Überprüfen Sie, ob Docker korrekt installiert ist:
+
+```bash
+docker compose version
+```
+
+---
+
+## Open Design starten
+
+Aus dem Repository-Root:
+
+```bash
+cd deploy
+docker compose up -d
+```
+
+Öffnen Sie die App in Ihrem Browser:
+
+```text
+http://localhost:7456
+```
+
+Der erste Start kann einige Sekunden dauern, während Docker das neueste Image herunterlädt.
+
+---
+
+## Häufige Docker-Befehle
+
+### Logs anzeigen
+
+```bash
+docker compose logs -f
+```
+
+### Container neu starten
+
+```bash
+docker compose restart
+```
+
+### Container stoppen
+
+```bash
+docker compose down
+```
+
+### Neuestes Image herunterladen
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+### Alle lokalen App-Daten entfernen
+
+```bash
+docker compose down -v
+```
+
+---
+
+## Umgebungskonfiguration
+
+Erstellen Sie eine `deploy/.env`-Datei, um die Standardkonfiguration zu überschreiben:
+
+```env
+# Port, der auf dem Host exponiert wird
+OPEN_DESIGN_PORT=7456
+
+# Container-Speicherlimit
+OPEN_DESIGN_MEM_LIMIT=384m
+
+# Erlaubte CORS-Ursprünge
+OPEN_DESIGN_ALLOWED_ORIGINS=https://yourdomain.com
+
+# Docker-Image-Tag
+OPEN_DESIGN_IMAGE=docker.io/vanjayak/open-design:latest
+```
+
+---
+
+## Persistenter Speicher
+
+Open Design speichert Projekte und SQLite-Daten in einem Docker-Volume:
+
+```text
+open_design_data
+```
+
+Das Volume wird gemountet nach:
+
+```text
+/app/.od
+```
+
+Daten bleiben über Container-Neustarts und Image-Updates hinweg bestehen.
+
+Überprüfen Sie das Volume:
+
+```bash
+docker volume inspect open-design_open_design_data
+```
+
+---
+
+## Hinweise
+
+* Der Docker-Modus ist ideal für Mitwirkende, die keine lokale Node.js- oder pnpm-Einrichtung wünschen.
+* Der Container exponiert den Produktions-Daemon-Build direkt auf Port `7456`.
+* Für Entwicklungsworkflows und erweiterte lokale Einrichtung lesen Sie den Rest dieser Schnellstartanleitung.
+
+---
+
 ## One-shot (Dev-Modus)
 
 ```bash
@@ -45,7 +172,7 @@ Für die Desktop-Shell und alle verwalteten Sidecars im Hintergrund:
 pnpm tools-dev # startet daemon + web + desktop im Hintergrund
 ```
 
-Beim ersten Laden erkennt die App Ihre installierte Code-Agent-CLI (Claude Code / Codex / Gemini / OpenCode / Cursor Agent / Qwen), wählt sie automatisch und nutzt standardmäßig den `web-prototype` Skill sowie das `Neutral Modern` Design System. Geben Sie einen Prompt ein und klicken Sie auf **Senden**. Der Agent streamt in den linken Bereich; das `<artifact>` Tag wird herausgeparst und das HTML rechts live gerendert. Nach Abschluss können Sie das Artifact mit **Auf Datenträger speichern** unter `./.od/artifacts/<timestamp>-<slug>/index.html` speichern.
+Beim ersten Laden erkennt die App Ihre installierte Code-Agent-CLI (Claude Code / Codex / Devin for Terminal / Gemini / OpenCode / Cursor Agent / Qwen / Qoder CLI), wählt sie automatisch und nutzt standardmäßig den `web-prototype` Skill sowie das `Neutral Modern` Design System. Geben Sie einen Prompt ein und klicken Sie auf **Senden**. Der Agent streamt in den linken Bereich; das `<artifact>` Tag wird herausgeparst und das HTML rechts live gerendert. Nach Abschluss können Sie das Artifact mit **Auf Datenträger speichern** unter `./.od/artifacts/<timestamp>-<slug>/index.html` speichern.
 
 Das Dropdown **Designsystem** enthält 71 integrierte Systeme: 2 handgeschriebene Starter (Neutral Modern, Warm Editorial) und 69 Produktsysteme, importiert aus [`awesome-design-md`](https://github.com/VoltAgent/awesome-design-md), gruppiert nach Kategorie (AI & LLM, Developer Tools, Productivity, Backend, Design Tools, Fintech, E-Commerce, Media, Automotive). Wählen Sie eines aus, um jeden Prototyp in der Ästhetik dieser Marke zu gestalten.
 
@@ -215,7 +342,7 @@ open-design/
 ## Fehlerbehebung
 
 - **"no agents found on PATH"** — installieren Sie eine davon: `claude`, `codex`, `gemini`, `opencode`, `cursor-agent`, `qwen`, `copilot`. Alternativ wechseln Sie in der oberen Leiste zu "Anthropic API · BYOK" und fügen in **Einstellungen** einen Key ein.
-- **daemon 500 on /api/chat** — prüfen Sie das daemon-Terminal und den stderr-Auszug; meist hat die CLI ihre Argumente abgelehnt. Unterschiedliche CLIs haben unterschiedliche argv-Formen; siehe `apps/daemon/src/agents.ts` `buildArgs`, falls Sie nachjustieren müssen.
+- **daemon 500 on /api/chat** — prüfen Sie das daemon-Terminal und den stderr-Auszug; meist hat die CLI ihre Argumente abgelehnt. Unterschiedliche CLIs haben unterschiedliche argv-Formen; sehen Sie `apps/daemon/src/agents.ts` `buildArgs`, falls Sie nachjustieren müssen.
 - **media generation says `OD_BIN` is missing or daemon URL is `:0`** — führen Sie die Media Dispatcher Checks oben aus. Setzen Sie keine alte CLI-Session fort; öffnen Sie das Projekt aus der Open Design App neu, damit der daemon frische `OD_*` Variablen injiziert.
 - **Codex lädt zu viel Plugin-Kontext** — starten Sie Open Design mit `OD_CODEX_DISABLE_PLUGINS=1 pnpm tools-dev`, damit vom daemon gestartete Codex-Prozesse mit `--disable plugins` laufen.
 - **artifact never renders** — das Modell hat Text ohne `<artifact>` Wrapper erzeugt. Prüfen Sie, ob der System Prompt ankommt (daemon log), und wechseln Sie ggf. zu einem stärkeren Modell oder strengeren Skill.

--- a/QUICKSTART.fr.md
+++ b/QUICKSTART.fr.md
@@ -6,10 +6,14 @@ Exécutez le produit complet localement.
 
 ## Prérequis
 
-- **Node.js :** `~24` (Node 24.x). Le repo l’impose via `package.json#engines`.
+- **Node.js :** `~24` (Node 24.x). Le repo l'impose via `package.json#engines`.
 - **pnpm :** `10.33.x`. Le repo fixe `pnpm@10.33.2` via `packageManager` ; utilisez Corepack pour que la bonne version soit sélectionnée automatiquement.
-- **OS :** macOS, Linux et WSL2 sont les environnements principaux pris en charge. Windows natif devrait fonctionner pour la plupart des workflows, mais WSL2 reste l’option la plus fiable.
-- **CLI d’agent locale optionnelle :** Claude Code, Codex, Devin for Terminal, Gemini CLI, OpenCode, Cursor Agent, Qwen, GitHub Copilot CLI, etc. Si aucune n’est installée, utilisez le mode BYOK API depuis Settings.
+- **OS :** macOS, Linux et WSL2 sont les environnements principaux pris en charge. Windows natif est supporté ; consultez [`docs/windows-troubleshooting.md`](docs/windows-troubleshooting.md) pour les problèmes courants de configuration.
+- **CLI d'agent local optionnelle :** Claude Code, Codex, Devin for Terminal, Gemini CLI, OpenCode, Cursor Agent, Qwen, Qoder CLI, GitHub Copilot CLI, etc. Si aucune n'est installée, utilisez le mode BYOK API depuis Settings.
+
+### CLI d'agent local et PATH
+
+Le daemon scanne votre **`PATH`** (plus les répertoires courants de toolchain utilisateur). Si vous installez une CLI avec **`npm install -g`** ou **Homebrew** et qu'Open Design l'affiche toujours comme *non installée*, l'interface graphique peut démarrer avec un `PATH` minimal qui n'inclut pas votre répertoire global npm ou Homebrew `bin` (courant sur macOS lorsque l'application n'est pas lancée depuis un shell de connexion complet). Assurez-vous que le répertoire de l'exécutable est dans le `PATH` du processus qui exécute le daemon, puis utilisez **Rescan** dans **Settings → Execution mode**.
 
 `nvm` / `fnm` sont des outils de confort optionnels, pas une étape obligatoire de la configuration du projet. Si vous en utilisez un, installez/sélectionnez Node 24 avant de lancer pnpm :
 
@@ -30,13 +34,136 @@ corepack enable
 corepack pnpm --version   # doit afficher 10.33.2
 ```
 
+## Configuration Docker
+
+Exécutez Open Design dans un environnement entièrement containerisé sans installer Node.js ou pnpm localement.
+
+### Prérequis
+
+* Docker Desktop
+* Docker Compose v2
+
+Vérifiez que Docker est correctement installé :
+
+```bash
+docker compose version
+```
+
+---
+
+## Démarrer Open Design
+
+Depuis la racine du dépôt :
+
+```bash
+cd deploy
+docker compose up -d
+```
+
+Ouvrez l'application dans votre navigateur :
+
+```text
+http://localhost:7456
+```
+
+Le premier démarrage peut prendre quelques secondes pendant que Docker extrait la dernière image.
+
+---
+
+## Commandes Docker courantes
+
+### Voir les logs
+
+```bash
+docker compose logs -f
+```
+
+### Redémarrer les conteneurs
+
+```bash
+docker compose restart
+```
+
+### Arrêter les conteneurs
+
+```bash
+docker compose down
+```
+
+### Télécharger la dernière image
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+### Supprimer toutes les données locales de l'application
+
+```bash
+docker compose down -v
+```
+
+---
+
+## Configuration de l'environnement
+
+Créez un fichier `deploy/.env` pour remplacer la configuration par défaut :
+
+```env
+# Port exposé sur l'hôte
+OPEN_DESIGN_PORT=7456
+
+# Limite de mémoire du conteneur
+OPEN_DESIGN_MEM_LIMIT=384m
+
+# Origines CORS autorisées
+OPEN_DESIGN_ALLOWED_ORIGINS=https://yourdomain.com
+
+# Tag de l'image Docker
+OPEN_DESIGN_IMAGE=docker.io/vanjayak/open-design:latest
+```
+
+---
+
+## Stockage persistant
+
+Open Design stocke les projets et les données SQLite dans un volume Docker :
+
+```text
+open_design_data
+```
+
+Le volume est monté sur :
+
+```text
+/app/.od
+```
+
+Les données persistent entre les redémarrages de conteneur et les mises à jour d'image.
+
+Inspectez le volume :
+
+```bash
+docker volume inspect open-design_open_design_data
+```
+
+---
+
+## Notes
+
+* Le mode Docker est idéal pour les contributeurs qui ne souhaitent pas de configuration Node.js ou pnpm locale.
+* Le conteneur expose directement le build daemon de production sur le port `7456`.
+* Pour les workflows de développement et la configuration locale avancée, consultez le reste de ce guide de démarrage rapide.
+
+---
+
 ## Démarrage rapide (mode dev)
 
 ```bash
 corepack enable
 pnpm install
 pnpm tools-dev run web # démarre daemon + web au premier plan
-# ouvrez l’URL web affichée par tools-dev
+# ouvrez l'URL web affichée par tools-dev
 ```
 
 Pour le shell desktop et tous les sidecars gérés en arrière-plan :
@@ -45,17 +172,16 @@ Pour le shell desktop et tous les sidecars gérés en arrière-plan :
 pnpm tools-dev # démarre daemon + web + desktop en arrière-plan
 ```
 
-Au premier chargement, l’app détecte votre CLI de coding agent installée (Claude Code / Codex / Devin for Terminal / Gemini / OpenCode / Cursor Agent / Qwen), la sélectionne automatiquement, puis utilise par défaut le Skill `web-prototype` et le Design System `Neutral Modern`. Tapez un prompt et cliquez sur **Send**. Les sorties de l’agent s’affichent en streaming dans le panneau gauche ; la balise `<artifact>` est extraite et le HTML s’affiche en direct à droite. Une fois la génération terminée, cliquez sur **Save to disk** pour enregistrer l’artifact sous `./.od/artifacts/<timestamp>-<slug>/index.html`.
+Au premier chargement, l'app détecte votre CLI de coding agent installée (Claude Code / Codex / Devin for Terminal / Gemini / OpenCode / Cursor Agent / Qwen / Qoder CLI), la sélectionne automatiquement, puis utilise par défaut le Skill `web-prototype` et le Design System `Neutral Modern`. Tapez un prompt et cliquez sur **Send**. Les sorties de l'agent s'affichent en streaming dans le panneau gauche ; la balise `<artifact>` est extraite et le HTML s'affiche en direct à droite. Une fois la génération terminée, cliquez sur **Save to disk** pour enregistrer l'artifact sous `./.od/artifacts/<timestamp>-<slug>/index.html`.
 
-Le menu déroulant **Design System** charge les Design Systems depuis `design-systems/*/DESIGN.md` : starters écrits à la main, product systems intégrés et design skills normalisés. Choisissez-en un pour habiller chaque prototype dans l’esthétique de cette marque.
+Le menu déroulant **Design System** charge 71 systèmes intégrés : 2 starters écrits à la main (Neutral Modern, Warm Editorial) et 69 systèmes de produits importés depuis [`awesome-design-md`](https://github.com/VoltAgent/awesome-design-md), groupés par catégorie (AI & LLM, Developer Tools, Productivity, Backend, Design Tools, Fintech, E-Commerce, Media, Automotive). Choisissez-en un pour habiller chaque prototype dans l'esthétique de cette marque.
 
-Le menu déroulant **Skill** regroupe les entrées par `mode` / `surface` et affiche le Skill par défaut de chaque mode avec un suffixe `· default`. Le catalogue live vient de [`skills/`](skills/) et couvre les workflows web, deck, Design System, image, vidéo et audio. Exemples inclus :
+Le menu déroulant **Skill** regroupe les entrées par mode (Prototype / Deck / Template / Design system) et affiche le Skill par défaut de chaque mode avec un suffixe `· default`. Skills inclus :
 
 - **Prototype** — `web-prototype` (générique), `saas-landing`, `dashboard`, `pricing-page`, `docs-page`, `blog-post`, `mobile-app`.
-- **Deck / PPT** — `simple-deck` (swipe horizontal single-file) et `magazine-web-ppt` (le bundle `guizang-ppt` depuis [`op7418/guizang-ppt-skill`](https://github.com/op7418/guizang-ppt-skill), par défaut en mode deck, avec ses propres assets/template + 4 références). Les Skills avec side files reçoivent automatiquement un préambule "Skill root (absolute)" pour que l’agent puisse résoudre `assets/template.html` et `references/*.md` depuis le vrai chemin disque au lieu de son CWD.
-- **Médias et Design System** — par exemple `image-poster`, `video-shortform`, `audio-jingle`, `hyperframes` et `design-brief`.
+- **Deck / PPT** — `simple-deck` (swipe horizontal single-file) et `magazine-web-ppt` (le bundle `guizang-ppt` depuis [`op7418/guizang-ppt-skill`](https://github.com/op7418/guizang-ppt-skill), par défaut en mode deck, avec ses propres assets/template + 4 références). Les Skills avec side files reçoivent automatiquement un préambule "Skill root (absolute)" pour que l'agent puisse résoudre `assets/template.html` et `references/*.md` depuis le vrai chemin disque au lieu de son CWD.
 
-Associez un Skill, un Design System et un seul prompt : vous obtenez un prototype, un deck ou un rendu adapté au mode / à la surface choisie.
+Associez un Skill, un Design System et un seul prompt : vous obtenez un prototype ou un deck adapté à la langue visuelle choisie.
 
 ## Autres scripts
 
@@ -74,16 +200,16 @@ pnpm --filter @open-design/web build     # build du paquet web si nécessaire
 pnpm typecheck                 # typecheck du workspace
 ```
 
-`pnpm tools-dev` est le seul point d’entrée du lifecycle local. N’utilisez pas les anciens alias root supprimés (`pnpm dev`, `pnpm dev:all`, `pnpm daemon`, `pnpm preview`, `pnpm start`).
+`pnpm tools-dev` est le seul point d'entrée du lifecycle local. N'utilisez pas les anciens alias root supprimés (`pnpm dev`, `pnpm dev:all`, `pnpm daemon`, `pnpm preview`, `pnpm start`).
 
-Pendant le développement local, `tools-dev` démarre d’abord le daemon, transmet son port à `apps/web`, puis `apps/web/next.config.ts` réécrit `/api/*`, `/artifacts/*` et `/frames/*` vers ce port daemon. L’app App Router peut ainsi parler au processus Express voisin sans configuration CORS.
+Pendant le développement local, `tools-dev` démarre d'abord le daemon, transmet son port à `apps/web`, puis `apps/web/next.config.ts` réécrit `/api/*`, `/artifacts/*` et `/frames/*` vers ce port daemon. L'app App Router peut ainsi parler au processus Express voisin sans configuration CORS.
 
 ## Checks de génération média / agent dispatcher
 
-Les Skills image, vidéo, audio et HyperFrames appellent la CLI locale `od` via des variables d’environnement injectées par le daemon lorsqu’il lance un agent :
+Les Skills image, vidéo, audio et HyperFrames appellent la CLI locale `od` via des variables d'environnement injectées par le daemon lorsqu'il lance un agent :
 
 - `OD_BIN` — chemin absolu vers `apps/daemon/dist/cli.js`.
-- `OD_DAEMON_URL` — URL du daemon en cours d’exécution.
+- `OD_DAEMON_URL` — URL du daemon en cours d'exécution.
 - `OD_PROJECT_ID` — id du projet actif.
 - `OD_PROJECT_DIR` — dossier de fichiers du projet actif.
 
@@ -96,7 +222,7 @@ ls -la apps/daemon/dist/cli.js
 curl -s http://127.0.0.1:7457/api/health
 ```
 
-Ouvrez ensuite de nouveau le projet depuis l’app Open Design au lieu de reprendre une ancienne session agent dans le terminal. Un agent lancé par le daemon devrait voir des valeurs comme :
+Ouvrez ensuite de nouveau le projet depuis l'app Open Design au lieu de reprendre une ancienne session agent dans le terminal. Un agent lancé par le daemon devrait voir des valeurs comme :
 
 ```bash
 echo "OD_BIN=$OD_BIN"
@@ -108,7 +234,7 @@ ls -la "$OD_BIN"
 
 `OD_DAEMON_URL` doit être un vrai port daemon comme `http://127.0.0.1:7457`, pas `http://127.0.0.1:0`. La valeur `:0` est seulement une indication interne "choisir un port libre" au lancement et ne doit pas se retrouver dans les sessions agent.
 
-En mode production daemon-only, le daemon sert lui-même l’export static Next.js à `http://localhost:7456`; aucun reverse proxy n’est impliqué.
+En mode production daemon-only, le daemon sert lui-même l'export static Next.js à `http://localhost:7456`; aucun reverse proxy n'est impliqué.
 
 Si vous placez nginx devant le daemon, gardez les routes SSE non bufferisées et non compressées. Un échec courant : la console navigateur affiche `net::ERR_INCOMPLETE_CHUNKED_ENCODING 200 (OK)` après 80-90 secondes, parce que `gzip on` dans nginx bufferise les réponses SSE chunked même quand le daemon envoie `X-Accel-Buffering: no`.
 
@@ -131,18 +257,18 @@ location /api/ {
 }
 ```
 
-## Deux modes d’exécution
+## Deux modes d'exécution
 
-| Mode | Valeur du picker | Flux d’une requête |
+| Mode | Valeur du picker | Flux d'une requête |
 |---|---|---|
 | **Local CLI** (par défaut quand le daemon détecte un agent) | "Local CLI" | Frontend → daemon `/api/chat` → `spawn(<agent>, ...)` → stdout → SSE → parser `<artifact>` → preview |
 | **Mode API** (fallback / aucune CLI) | "Anthropic API" / "OpenAI API" / "Azure OpenAI" / "Google Gemini" | Frontend → daemon `/api/proxy/{provider}/stream` → SSE provider normalisé en `delta/end/error` → parser `<artifact>` → preview |
 
-Les deux modes alimentent le **même** parser `<artifact>` et la **même** iframe sandboxée. Seuls le transport et la livraison du system prompt changent : les CLI locales n’ont pas de canal système séparé, donc le prompt composé est intégré au message utilisateur.
+Les deux modes alimentent le **même** parser `<artifact>` et la **même** iframe sandboxée. Seuls le transport et la livraison du system prompt changent : les CLI locales n'ont pas de canal système séparé, donc le prompt composé est intégré au message utilisateur.
 
 ## Composition du prompt
 
-À chaque envoi, l’app construit un system prompt à partir de trois couches et l’envoie au provider :
+À chaque envoi, l'app construit un system prompt à partir de trois couches et l'envoie au provider :
 
 ```
 BASE_SYSTEM_PROMPT   (contrat de sortie : wrap in <artifact>, no code fences)
@@ -150,7 +276,7 @@ BASE_SYSTEM_PROMPT   (contrat de sortie : wrap in <artifact>, no code fences)
    + active skill body          (SKILL.md — workflow and output rules)
 ```
 
-Changez le Skill ou le Design System dans la barre supérieure : le prochain envoi utilise le nouveau stack. Les contenus sont mis en cache en mémoire par session, donc un choix ne coûte qu’un fetch daemon.
+Changez le Skill ou le Design System dans la barre supérieure : le prochain envoi utilise le nouveau stack. Les contenus sont mis en cache en mémoire par session, donc un choix ne coûte qu'un fetch daemon.
 
 ## File map
 
@@ -173,7 +299,7 @@ open-design/
 │       │   ├── providers/     # transports daemon + BYOK API
 │       │   ├── prompts/       # system, discovery, directions, deck framework
 │       │   ├── artifacts/     # parser <artifact> streaming + manifests
-│       │   ├── runtime/       # iframe srcdoc, markdown, helpers d’export
+│       │   ├── runtime/       # iframe srcdoc, markdown, helpers d'export
 │       │   └── state/         # localStorage + état projet persisté par le daemon
 │       ├── sidecar/           # wrapper sidecar web pour tools-dev
 │       └── next.config.ts     # rewrites tools-dev + config export prod apps/web/out
@@ -185,8 +311,8 @@ open-design/
 │   └── platform/              # primitives process/platform génériques
 ├── tools/dev/                 # lifecycle `pnpm tools-dev` et inspect CLI
 ├── e2e/                       # UI Playwright + harness intégration externe/Vitest
-├── skills/                    # SKILL.md — drop-in depuis n’importe quel repo Claude Code skill
-│   ├── web-prototype/         # prototype single-screen générique (défaut du mode prototype)
+├── skills/                    # SKILL.md — drop-in depuis n'importe quel repo Claude Code skill
+│   ├── web-protpective/         # prototype single-screen générique (défaut du mode prototype)
 │   ├── saas-landing/          # page marketing (hero / features / pricing / CTA)
 │   ├── dashboard/             # dashboard admin / analytics
 │   ├── pricing-page/          # pricing autonome + comparaison
@@ -208,7 +334,7 @@ open-design/
 ├── .od/                       # données runtime (gitignored, auto-créées)
 │   ├── app.sqlite              #   projects / conversations / messages / tabs
 │   ├── artifacts/              #   rendus ponctuels "Save to disk"
-│   └── projects/<id>/          #   dossier de travail par projet + cwd de l’agent
+│   └── projects/<id>/          #   dossier de travail par projet + cwd de l'agent
 ├── pnpm-workspace.yaml        # apps/* + packages/* + tools/* + e2e
 └── package.json               # scripts qualité root + bin `od`
 ```
@@ -216,10 +342,10 @@ open-design/
 ## Dépannage
 
 - **"no agents found on PATH"** — installez une CLI compatible, par exemple `claude`, `codex`, `gemini`, `opencode`, `cursor-agent`, `qwen` ou `copilot`. La liste exacte des adapters détectés vit dans `apps/daemon/src/agents.ts`. Ou passez au mode API/BYOK dans la barre supérieure et collez une clé dans **Settings**.
-- **daemon 500 sur /api/chat** — vérifiez la fin de stderr dans le terminal daemon ; la CLI a généralement rejeté ses args. Les CLIs n’acceptent pas toutes la même forme d’argv ; consultez `apps/daemon/src/agents.ts` `buildArgs` si vous devez ajuster.
-- **la génération média dit que `OD_BIN` manque ou que l’URL daemon vaut `:0`** — exécutez les checks du dispatcher média ci-dessus. Ne reprenez pas l’ancienne session CLI ; rouvrez le projet depuis l’app Open Design pour que le daemon injecte des variables `OD_*` fraîches.
+- **daemon 500 sur /api/chat** — vérifiez la fin de stderr dans le terminal daemon ; la CLI a généralement rejeté ses args. Les CLIs n'acceptent pas toutes la même forme d'argv ; consultez `apps/daemon/src/agents.ts` `buildArgs` si vous devez ajuster.
+- **la génération média dit que `OD_BIN` manque ou que l'URL daemon vaut `:0`** — exécutez les checks du dispatcher média ci-dessus. Ne reprenez pas l'ancienne session CLI ; rouvrez le projet depuis l'app Open Design pour que le daemon injecte des variables `OD_*` fraîches.
 - **Codex charge trop de contexte plugin** — démarrez Open Design avec `OD_CODEX_DISABLE_PLUGINS=1 pnpm tools-dev` pour que les processus Codex lancés par le daemon tournent avec `--disable plugins`.
-- **l’artifact ne rend jamais** — le modèle a produit du texte sans wrapper `<artifact>`. Vérifiez que le system prompt passe bien (log daemon) et envisagez un modèle plus capable ou un Skill plus strict.
+- **l'artifact ne rend jamais** — le modèle a produit du texte sans wrapper `<artifact>`. Vérifiez que le system prompt passe bien (log daemon) et envisagez un modèle plus capable ou un Skill plus strict.
 
 ## Retour à la vision
 

--- a/QUICKSTART.ja-JP.md
+++ b/QUICKSTART.ja-JP.md
@@ -8,10 +8,14 @@
 
 - **Node.js:** `~24`（Node 24.x）。リポジトリは `package.json#engines` を通じてこれを強制しています。
 - **pnpm:** `10.33.x`。リポジトリは `packageManager` を通じて `pnpm@10.33.2` をピン留めしています。Corepack を使用すれば、ピン留めされたバージョンが自動的に選択されます。
-- **OS:** macOS、Linux、WSL2 が主要なパスです。Windows ネイティブはほとんどのフローで動作するはずですが、WSL2 のほうが安全なベースラインです。
-- **オプションのローカルエージェント CLI:** Claude Code、Codex、Devin for Terminal、Gemini CLI、OpenCode、Cursor Agent、Qwen、GitHub Copilot CLI など。何もインストールされていない場合は、設定から BYOK API モードを使用してください。
+- **OS:** macOS、Linux、WSL2 が主要なパスです。Windows ネイティブはサポートされています。[`docs/windows-troubleshooting.md`](docs/windows-troubleshooting.md) に一般的なセットアップの問題点が記載されています。
+- **オプションのローカルエージェント CLI:** Claude Code、Codex、Devin for Terminal、Gemini CLI、OpenCode、Cursor Agent、Qwen、Qoder CLI、GitHub Copilot CLI など。何もインストールされていない場合は、設定から BYOK API モードを使用してください。
 
-`nvm` / `fnm` はオプションの便利なツールであり、必須のプロジェクトセットアップではありません。使用する場合は、pnpm を実行する前に Node 24 をインストール／選択してください。
+### ローカルエージェント CLI と PATH
+
+デーモンは **`PATH`**（plus common user toolchain directories）をスキャンします。CLI を **`npm install -g`** または **Homebrew** でインストールしても Open Design がまだ*インストールされていない*と表示する場合は、GUI が最小化された `PATH` で起動している可能性があります（アプリがフルログインシェルから起動されていない macOS で一般的）。実行可能ファイルのディレクトリがデーモンを実行するプロセスの `PATH` 上にあることを確認し、**Settings → Execution mode** で **Rescan** を使用してください。
+
+`nvm` / `fnm` はオプションの便利なツールであり必須のプロジェクトセットアップではありません。使用する場合は、pnpm を実行する前に Node 24 をインストール／選択してください。
 
 ```bash
 # nvm
@@ -30,6 +34,129 @@ corepack enable
 corepack pnpm --version   # 10.33.2 が表示されるはずです
 ```
 
+## Docker セットアップ
+
+Node.js や pnpm をローカルにインストールせずに、完全コンテナ化された環境で Open Design を実行します。
+
+### 要件
+
+* Docker Desktop
+* Docker Compose v2
+
+Docker が正しくインストールされていることを確認します：
+
+```bash
+docker compose version
+```
+
+---
+
+## Open Design の起動
+
+リポジトリのルートから：
+
+```bash
+cd deploy
+docker compose up -d
+```
+
+ブラウザでアプリを開きます：
+
+```text
+http://localhost:7456
+```
+
+最初の起動は、Docker が最新イメージをダウンロードしているため、数秒かかる場合があります。
+
+---
+
+## 一般的な Docker コマンド
+
+### ログの表示
+
+```bash
+docker compose logs -f
+```
+
+### コンテナの再起動
+
+```bash
+docker compose restart
+```
+
+### コンテナの停止
+
+```bash
+docker compose down
+```
+
+### 最新イメージの取得
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+### すべてのローカルアプリデータを削除
+
+```bash
+docker compose down -v
+```
+
+---
+
+## 環境設定
+
+デフォルト設定を上書きするために `deploy/.env` ファイルを作成します：
+
+```env
+# ホストで公開されるポート
+OPEN_DESIGN_PORT=7456
+
+# コンテナのメモリ制限
+OPEN_DESIGN_MEM_LIMIT=384m
+
+# 許可された CORS  origins
+OPEN_DESIGN_ALLOWED_ORIGINS=https://yourdomain.com
+
+# Docker イメージタグ
+OPEN_DESIGN_IMAGE=docker.io/vanjayak/open-design:latest
+```
+
+---
+
+## 永続ストレージ
+
+Open Design はプロジェクトと SQLite データを Docker ボリューム内に保存します：
+
+```text
+open_design_data
+```
+
+ボリュームは以下にマウントされます：
+
+```text
+/app/.od
+```
+
+データはコンテナの再起動やイメージの更新後も保持されます。
+
+ボリュームを確認：
+
+```bash
+docker volume inspect open-design_open_design_data
+```
+
+---
+
+## 注意事项
+
+* Docker モードは、ローカルに Node.js や pnpm のセットアップを望まない貢献者に最適です。
+* コンテナは本番用デーモンビルドをポート `7456` に直接公開します。
+* 開発ワークフローや高度なローカルセットアップについては、このクイックスタートガイドの続きを参照してください。
+
+---
+
 ## ワンショット（dev モード）
 
 ```bash
@@ -45,14 +172,14 @@ pnpm tools-dev run web # daemon と web をフォアグラウンドで起動し�
 pnpm tools-dev # daemon + web + desktop をバックグラウンドで起動します
 ```
 
-初回起動時、アプリはインストール済みのコードエージェント CLI（Claude Code / Codex / Devin for Terminal / Gemini / OpenCode / Cursor Agent / Qwen）を検出して自動選択し、デフォルトで `web-prototype` スキルと `Neutral Modern` デザインシステムを採用します。プロンプトを入力して **Send** を押してください。エージェントが左ペインにストリーミングし、`<artifact>` タグが解析されて HTML が右側にライブレンダリングされます。完了したら **Save to disk** をクリックして、アーティファクトを `./.od/artifacts/<timestamp>-<slug>/index.html` に永続化します。
+初回起動時、アプリはインストール済みのコードエージェント CLI（Claude Code / Codex / Devin for Terminal / Gemini / OpenCode / Cursor Agent / Qwen / Qoder CLI）を検出して自動選択し、デフォルトで `web-prototype` スキルと `Neutral Modern` デザインシステムを採用します。プロンプトを入力して **Send** を押してください。エージェントが左ペインにストリーミングし、`<artifact>` タグが解析されて HTML が右側にライブレンダリングされます。完了したら **Save to disk** をクリックして、アーティファクトを `./.od/artifacts/<timestamp>-<slug>/index.html` に永続化します。
 
-**Design system** ドロップダウンには **129 のデザインシステム** が同梱されています — 手作りのスターター 2 種（Neutral Modern、Warm Editorial）、バンドルされた製品システム 70 種、[`awesome-design-skills`](https://github.com/bergside/awesome-design-skills) から取得した 57 のデザインスキルです。1 つを選ぶと、すべてのプロトタイプがそのブランドの美学でスキニングされます。
+**Design system** ドロップダウンには **129 のデザインシステム** がバンドルされています — 手作りのスターター 2 種（Neutral Modern、Warm Editorial）、[`awesome-design-md`](https://github.com/VoltAgent/awesome-design-md) からインポートされた 69 の製品システム（AI & LLM、Developer Tools、Productivity、Backend、Design Tools、Fintech、E-Commerce、Media、Automotive で分類）、[`awesome-design-skills`](https://github.com/bergside/awesome-design-skills) から取得された 57 のデザインスキル。1 つを選ぶと、すべてのプロトタイプがそのブランドの美学でスキニングされます。
 
 **Skill** ドロップダウンはモード（Prototype / Deck / Template / Design system）でグループ化され、モードごとのデフォルトスキルには `· default` サフィックスが付きます。バンドルされているスキル：
 
 - **Prototype** — `web-prototype`（汎用）、`saas-landing`、`dashboard`、`pricing-page`、`docs-page`、`blog-post`、`mobile-app`。
-- **Deck / PPT** — `simple-deck`（単一ファイルの横スワイプ）と `magazine-web-ppt`（[`op7418/guizang-ppt-skill`](https://github.com/op7418/guizang-ppt-skill) からの `guizang-ppt` バンドル — deck モードのデフォルト。独自のアセット／テンプレート + 4 つのリファレンスを同梱）。サイドファイルを持つスキルには自動的に「Skill root (absolute)」のプリアンブルが付与され、エージェントが CWD ではなく実際のディスク上のパスに対して `assets/template.html` や `references/*.md` を解決できるようになります。
+- **Deck / PPT** — `simple-deck`（単一ファイルの横スワイプ）と `magazine-web-ppt`（[`op7418/guizang-ppt-skill`](https://github.com/op7418/guizang-ppt-skill) からの `guizang-ppt` バンドル — deck モードのデフォルト。独自のアセット／テンプレート + 4 つのリファレンスをバンドル）。サイドファイルを持つスキルには自動的に「Skill root (absolute)」のプリアンブルが付与され、エージェントが CWD ではなく実際のディスク上のパスに対して `assets/template.html` や `references/*.md` を解決できるようになります。
 
 スキルとデザインシステムを組み合わせれば、単一のプロンプトから選択した視覚言語でレイアウトに適したプロトタイプまたはデッキが生成されます。
 
@@ -75,18 +202,18 @@ pnpm typecheck                 # workspace の typecheck
 
 `pnpm tools-dev` がローカルライフサイクルの唯一のエントリポイントです。削除済みのレガシールートエイリアス（`pnpm dev`、`pnpm dev:all`、`pnpm daemon`、`pnpm preview`、`pnpm start`）は使用しないでください。
 
-ローカル開発中、`tools-dev` は最初に daemon を起動し、そのポートを `apps/web` に渡します。`apps/web/next.config.ts` は `/api/*`、`/artifacts/*`、`/frames/*` をその daemon ポートに書き換えるため、App Router アプリは CORS 設定なしで隣接する Express プロセスと通信できます。
+ローカル開発中、`tools-dev` は最初にデーモンを起動し、そのポートを `apps/web` に渡します。`apps/web/next.config.ts` は `/api/*`、`/artifacts/*`、`/frames/*` をそのデーモンポートに書き換えるため、App Router アプリは CORS 設定なしで隣接する Express プロセスと通信できます。
 
 ## メディア生成 / エージェントディスパッチャーチェック
 
-Image、Video、Audio、HyperFrames スキルは、daemon がエージェントを起動する際に注入する環境変数を通じてローカル `od` CLI を呼び出します：
+Image、Video、Audio、HyperFrames スキルは、デーモンがエージェントを起動する際に注入する環境変数を通じてローカル `od` CLI を呼び出します：
 
 - `OD_BIN` — `apps/daemon/dist/cli.js` への絶対パス。
-- `OD_DAEMON_URL` — 実行中の daemon URL。
+- `OD_DAEMON_URL` — 実行中のデーモン URL。
 - `OD_PROJECT_ID` — アクティブなプロジェクト ID。
 - `OD_PROJECT_DIR` — アクティブなプロジェクトのファイルディレクトリ。
 
-メディア生成が `OD_BIN: parameter not set`、`apps/daemon/dist/cli.js` の欠落、または `failed to reach daemon at http://127.0.0.1:0` で失敗する場合は、daemon CLI を再ビルドして管理対象ランタイムを再起動してください：
+メディア生成が `OD_BIN: parameter not set`、`apps/daemon/dist/cli.js` の欠落、または `failed to reach daemon at http://127.0.0.1:0` で失敗する場合は、デーモン CLI を再ビルドして管理対象ランタイムを再起動してください：
 
 ```bash
 pnpm --filter @open-design/daemon build
@@ -95,7 +222,7 @@ ls -la apps/daemon/dist/cli.js
 curl -s http://127.0.0.1:7457/api/health
 ```
 
-その後、古いターミナルエージェントセッションを再開する代わりに、Open Design アプリからプロジェクトを再度開いてください。daemon から起動されたエージェントは、次のような値を確認できるはずです：
+その後、古いターミナルエージェントセッションを再開する代わりに、Open Design アプリからプロジェクトを再度開いてください。デーモンから起動されたエージェントは、次のような値を確認できるはずです：
 
 ```bash
 echo "OD_BIN=$OD_BIN"
@@ -105,11 +232,11 @@ echo "OD_DAEMON_URL=$OD_DAEMON_URL"
 ls -la "$OD_BIN"
 ```
 
-`OD_DAEMON_URL` は `http://127.0.0.1:0` ではなく、`http://127.0.0.1:7457` のような実際の daemon ポートでなければなりません。`:0` という値は内部的な「空きポートを選択する」起動ヒントにすぎず、エージェントセッションに漏れてはなりません。
+`OD_DAEMON_URL` は `http://127.0.0.1:0` ではなく、`http://127.0.0.1:7457` のような実際のデーモンポートでなければなりません。`:0` という値は内部的な「空きポートを選択する」起動ヒントにすぎず、エージェントセッションに漏れてはなりません。
 
-daemon のみの本番モードでは、daemon 自身が `http://localhost:7456` で静的な Next.js エクスポートを提供するため、リバースプロキシは関与しません。
+デーモンのみの本番モードでは、デーモン自身が `http://localhost:7456` で静的な Next.js エクスポートを提供するため、リバースプロキシは関与しません。
 
-daemon の前段に nginx を配置する場合は、SSE ルートをバッファリングなし・圧縮なしに保ってください。一般的な失敗例は、ブラウザコンソールに 80〜90 秒後に `net::ERR_INCOMPLETE_CHUNKED_ENCODING 200 (OK)` が表示されるというもので、これは daemon が `X-Accel-Buffering: no` を送信していても、nginx の `gzip on` がチャンク分割された SSE レスポンスをバッファリングしてしまうために発生します。
+デーモンの前段に nginx を配置する場合は、SSE ルートをバッファリングなし・圧縮なしに保ってください。一般的な失敗例は、ブラウザコンソールに 80〜90 秒後に `net::ERR_INCOMPLETE_CHUNKED_ENCODING 200 (OK)` が表示されるというもので、これはデーモンが `X-Accel-Buffering: no` を送信していても、nginx の `gzip on` がチャンク分割された SSE レスポンスをバッファリングしてしまうために発生します。
 
 ```nginx
 location /api/ {
@@ -134,8 +261,8 @@ location /api/ {
 
 | モード | ピッカーの値 | リクエストの流れ |
 |---|---|---|
-| **Local CLI**（daemon がエージェントを検出した場合のデフォルト） | "Local CLI" | フロントエンド → daemon `/api/chat` → `spawn(<agent>, ...)` → stdout → SSE → アーティファクトパーサー → プレビュー |
-| **Anthropic API**（フォールバック / CLI なし） | "Anthropic API · BYOK" | フロントエンド → `@anthropic-ai/sdk` 直接呼び出し（`dangerouslyAllowBrowser`） → アーティファクトパーサー → プレビュー |
+| **Local CLI**（デーモンがエージェントを検出した場合のデフォルト） | "Local CLI" | フロントエンド → デーモン `/api/chat` → `spawn(<agent>, ...)` → stdout → SSE → アーティファクトパーサー → プレビュー |
+| **API モード**（フォールバック / CLI なし） | "Anthropic API" / "OpenAI API" / "Azure OpenAI" / "Google Gemini" | フロントエンド → デーモン `/api/proxy/{provider}/stream` → プロバイダー SSE を `delta/end/error` に正規化 → アーティファクトパーサー → プレビュー |
 
 両モードとも **同じ** `<artifact>` パーサーと **同じ** サンドボックス化された iframe にデータを供給します。異なるのはトランスポートとシステムプロンプトの配信方法だけです（ローカル CLI には独立したシステムチャンネルがないため、合成プロンプトはユーザーメッセージに折り込まれます）。
 
@@ -149,7 +276,7 @@ BASE_SYSTEM_PROMPT   （出力契約：<artifact> でラップ、コードフェ
    + アクティブなスキル本文          （SKILL.md — ワークフローと出力ルール）
 ```
 
-トップバーでスキルまたはデザインシステムを切り替えると、次回の送信から新しいスタックが使用されます。本文はセッションごとにメモリ内にキャッシュされるため、選択ごとに 1 回の daemon フェッチで済みます。
+トップバーでスキルまたはデザインシステムを切り替えると、次回の送信から新しいスタックが使用されます。本文はセッションごとにメモリ内にキャッシュされるため、選択ごとに 1 回のデーモンフェッチで済みます。
 
 ## ファイルマップ
 
@@ -214,17 +341,17 @@ open-design/
 
 ## トラブルシューティング
 
-- **「no agents found on PATH」** — `claude`、`codex`、`devin`、`gemini`、`opencode`、`cursor-agent`、`qwen`、`copilot` のいずれかをインストールしてください。または、トップバーで「Anthropic API · BYOK」に切り替え、**設定** にキーを貼り付けます。
-- **/api/chat で daemon が 500 を返す** — daemon ターミナルで stderr の末尾を確認してください。通常は CLI が引数を拒否しています。CLI ごとに argv の形式が異なります。調整が必要な場合は `apps/daemon/src/agents.ts` の `buildArgs` を参照してください。
-- **メディア生成で `OD_BIN` が欠落、または daemon URL が `:0`** — 上記のメディアディスパッチャーチェックを実行してください。古い CLI セッションを再開せず、Open Design アプリからプロジェクトを再度開いて、daemon が新しい `OD_*` 変数を注入できるようにしてください。
-- **Codex がプラグインコンテキストを多く読み込みすぎる** — `OD_CODEX_DISABLE_PLUGINS=1 pnpm tools-dev` で Open Design を起動すると、daemon から起動された Codex プロセスが `--disable plugins` で実行されます。
-- **アーティファクトがレンダリングされない** — モデルが `<artifact>` でラップせずにテキストを生成しました。システムプロンプトが通っていることを確認し（daemon ログを確認）、より高性能なモデルまたは厳格なスキルへの切り替えを検討してください。
+- **「no agents found on PATH」** — `claude`、`codex`、`devin`、`gemini`、`opencode`、`cursor-agent`、`qwen`、`qodercli`、`copilot` のいずれかをインストールしてください。または、トップバーで API/BYOK モードに切り替えて、**設定** にキーを貼り付けます。
+- **/api/chat でデーモンが 500 を返す** — デーモンターミナルで stderr の末尾を確認してください。通常は CLI が引数を拒否しています。CLI ごとに argv の形式が異なります。調整が必要な場合は `apps/daemon/src/agents.ts` の `buildArgs` を参照してください。
+- **メディア生成で `OD_BIN` が欠落、またはデーモン URL が `:0`** — 上記のメディアディスパッチャーチェックを実行してください。古い CLI セッションを再開せず、Open Design アプリからプロジェクトを再度開いて、デーモンが新しい `OD_*` 変数を注入できるようにしてください。
+- **Codex がプラグインコンテキスト多くを読み込みすぎる** — `OD_CODEX_DISABLE_PLUGINS=1 pnpm tools-dev` で Open Design を起動すると、デーモンから起動された Codex プロセスが `--disable plugins` で実行されます。
+- **アーティファクトがレンダリングされない** — モデルが `<artifact>` でラップせずにテキストを生成しました。システムプロンプトが通っていることを確認し（デーモンログを確認）、より高性能なモデルまたは厳格なスキルへの切り替えを検討してください。
 
 ## ビジョンへのマッピング
 
 このクイックスタートは [`docs/`](docs/) にある仕様の実行可能なシードです。仕様は、これがどこへ成長するかを記述しています（[`docs/roadmap.md`](docs/roadmap.md) を参照）。ハイライト：
 
-- `docs/architecture.md` は、出荷されたスタックを説明しています：前面に Next.js 16 App Router、その背後にローカル daemon、そして `apps/web/next.config.ts` の dev 時 rewrites によってブラウザが同じ `/api` 表面と通信し続けるようにします。
+- `docs/architecture.md` は、出荷されたスタックを説明しています：前面に Next.js 16 App Router、その背後にローカルデーモン、そして `apps/web/next.config.ts` の dev 時 rewrites によってブラウザが同じ `/api` 表面と通信し続けるようにします。
 - `docs/skills-protocol.md` は、完全な `od:` フロントマター（型付き入力、スライダー、機能ゲーティング）について説明しています。この MVP は `name` / `description` / `triggers` / `od.mode` / `od.design_system.requires` のみを読み取ります — 残りを追加するには `apps/daemon/src/skills.ts` を拡張してください。
 - `docs/agent-adapters.md` はより豊かなディスパッチ（機能検出、ストリーミングツール呼び出し）を予見しています。`apps/daemon/src/agents.ts` は最小限のディスパッチャーです — 配線を証明するには十分です。
 - `docs/modes.md` は 4 つのモード（prototype / deck / template / design-system）を列挙しています。最初の 2 つのスキルを出荷しています。ピッカーはすでに `mode` でフィルタリングしています。

--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -288,6 +288,9 @@ startServer({ port, host, returnServer: true }).then((started) => {
   };
   process.on('SIGINT', stop);
   process.on('SIGTERM', stop);
+  process.on('unhandledRejection', (reason, _promise) => {
+    console.error('[od] unhandled rejection:', reason);
+  });
   console.log(`[od] listening on ${url}`);
   if (open) {
     openBrowser(url);
@@ -4286,6 +4289,9 @@ async function runDaemonStart(flags) {
   };
   process.on('SIGINT', stop);
   process.on('SIGTERM', stop);
+  process.on('unhandledRejection', (reason, _promise) => {
+    console.error('[od] unhandled rejection:', reason);
+  });
   console.log(`[od] listening on ${url} (${headless ? 'headless' : 'desktop'})`);
   if (!headless) {
     const opener = process.platform === 'darwin' ? 'open'

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -231,7 +231,6 @@ import {
   resolveProjectDir,
   sanitizeName,
   searchProjectFiles,
-  resolveProjectDir,
   resolveProjectFilePath,
   writeProjectFile,
 } from './projects.js';


### PR DESCRIPTION
<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works.
     Delete this whole block if the PR genuinely doesn't close any issue. -->
Fixes #

## Why

<!-- Why are you opening this PR? Cover two things:
       - Your use case — what made you write this today? Did you hit it yourself
         while building on top of OD, are you scratching an itch for a team, or
         are you speculatively adding for others? All are fine, but say which.
       - The pain being addressed — user-facing problem, technical debt, a prod
         issue, or unblocking another change.
     For non-trivial features, please open a discussion or issue first to align
     on scope and UX before writing code. -->


## What users will see

<!-- Describe the change from a user's perspective, not in code terms. Examples:
       - "Settings → AI Providers has a new 'Custom endpoint' field, off by default"
       - "Right-clicking a design file shows a new 'Duplicate' option"
       - "Default model changed from X to Y — existing users will notice on first launch"
       - "New `od skills install <name>` subcommand"
     Skip this section only if you check "None" below. -->


## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only


## Screenshots

<!-- If you checked "UI" above, attach screenshots showing the entry point —
     where users discover the change — not just the feature in isolation.
     Before/after is best for behavior changes. Short GIFs welcome. -->


## Bug fix verification

<!-- Skip if this PR isn't a bug fix.

     Per AGENTS.md → "Bug follow-up workflow", bugs should be encoded as a
     falsifiable test that goes red before the source change. Confirm:
       - Test path that reproduces the bug:
       - Did the test go red on `main` and green on this branch? (yes / no)
       - If a red spec wasn't cheap to write, explain why and what verification
         you did instead. -->

-


## Validation

<!-- What you actually ran. Default minimum: `pnpm guard` + `pnpm typecheck`,
     plus the package-scoped tests/build for the files you changed
     (e.g. `pnpm --filter @open-design/web test`). -->

-
