### PR TITLE
Clarify ui-ux-pro-max catalog scope

### DIFF
--- a/scripts/seed-curated-design-skills.ts
+++ b/scripts/seed-curated-design-skills.ts
@@ -50,6 +50,9 @@ interface CuratedSkill {
   tagline?: string;
   // Optional credit line ("By @author") shown at the top of the body.
   attribution?: string;
+  // Optional warning for catalogue entries whose upstream workflow depends on
+  // assets or scripts that are not bundled by this repository.
+  catalogueOnlyNote?: string;
 }
 
 const CATALOGUE: CuratedSkill[] = [
@@ -643,12 +646,14 @@ const CATALOGUE: CuratedSkill[] = [
   {
     id: 'ui-ux-pro-max',
     description:
-      'UI/UX design patterns and best practices. Pattern library + heuristic checks for shipping clean, usable interfaces.',
+      'Catalog-only UI/UX Pro Max entry. The full upstream templates, data, and search workflow are not bundled in Open Design.',
     triggers: ['ui ux patterns', 'design patterns', 'ux heuristics', 'usability'],
     mode: 'design-system',
     category: 'design-systems',
     upstream: 'https://github.com/nextlevelbuilder/ui-ux-pro-max-skill',
     attribution: 'Curated from @nextlevelbuilder.',
+    catalogueOnlyNote:
+      'Open Design ships this entry as discovery metadata only. The upstream UI/UX Pro Max data CSVs, scripts/search.py helper, templates, references, and related skill instructions are not bundled here; if those files are absent, disclose the limitation before falling back to Open Design defaults.',
   },
   {
     id: 'taste-skill',
@@ -1046,6 +1051,12 @@ function buildBody(s: CuratedSkill): string {
   lines.push('');
   lines.push(s.description);
   lines.push('');
+  if (s.catalogueOnlyNote) {
+    lines.push('## Current Open Design scope');
+    lines.push('');
+    lines.push(s.catalogueOnlyNote);
+    lines.push('');
+  }
   lines.push('## Source');
   lines.push('');
   lines.push(`- Upstream: ${s.upstream}`);

--- a/skills/ui-ux-pro-max/SKILL.md
+++ b/skills/ui-ux-pro-max/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ui-ux-pro-max
 description: |
-  UI/UX design patterns and best practices. Pattern library + heuristic checks for shipping clean, usable interfaces.
+  Catalog-only UI/UX Pro Max entry. The full upstream templates, data, and search workflow are not bundled in Open Design.
 triggers:
   - "ui ux patterns"
   - "design patterns"
@@ -19,7 +19,18 @@ od:
 
 ## What it does
 
-UI/UX design patterns and best practices. Pattern library + heuristic checks for shipping clean, usable interfaces.
+Catalog-only UI/UX Pro Max entry. The full upstream templates, data, and search workflow are not bundled in Open Design.
+
+## Current Open Design scope
+
+Open Design currently ships this entry as discovery metadata only. If this `SKILL.md`
+is the only file under `skills/ui-ux-pro-max/`, the upstream UI/UX Pro Max
+workflow is not available locally.
+
+The full upstream workflow expects additional assets such as the searchable
+`data` CSVs, the `scripts/search.py` helper, reference material, templates, and
+related upstream skill instructions. Without those files, do not tell users that
+the full UI/UX Pro Max pattern library or template search is active.
 
 ## Source
 
@@ -40,3 +51,7 @@ open https://github.com/nextlevelbuilder/ui-ux-pro-max-skill
 
 Then ask the agent to invoke this skill by name (`ui-ux-pro-max`) or with
 one of the trigger phrases listed in this skill's frontmatter.
+
+If those upstream files are not installed, explain that Open Design only has the
+catalog entry for this skill and ask whether to continue with Open Design's
+default design-system guidance instead.


### PR DESCRIPTION
## Summary

- marks `ui-ux-pro-max` as a catalog-only Open Design entry instead of implying the full upstream workflow is bundled
- documents the missing upstream `data` CSVs, `scripts/search.py` helper, templates, references, and related skill instructions
- updates the curated-skill seeding script so this scope warning is preserved if the entry is regenerated

## Why

I opened this after checking #1949, where the current entry can be discovered during planning even though the local `skills/ui-ux-pro-max/` folder only contains `SKILL.md`.

That lets the agent fall back after reporting that no templates/search data are bundled, which is confusing for users expecting the upstream UI/UX Pro Max workflow.

This does not bundle the full upstream skill. It makes the current Open Design behavior explicit until the broader first-party integration direction in #1075 is decided.

## What users will see

When `ui-ux-pro-max` is discovered from Open Design's bundled skills, the entry now states that Open Design only ships catalog metadata for it. If the upstream files are not installed, the agent is told to disclose that limitation before falling back to Open Design's default design-system guidance.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — no UI surface changed.

## Bug fix verification

- Test path that reproduces the bug: #1949's reproduction uses the bundled `ui-ux-pro-max` entry and observes the missing upstream template/search context.
- Did the test go red on `main` and green on this branch? No automated red/green spec; this is a catalog-copy and seeding-script clarification.
- Verification used instead: inspected the current bundled `skills/ui-ux-pro-max/` shape and updated both the generated entry and its seeding source so the limitation is explicit.

## Validation

- `git diff --check`

Refs #1949
