### PR TITLE
Fix Draw Send to chat during streaming

### DIFF
--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -229,6 +229,8 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
     }, [projectId, analytics.track]);
     const [staged, setStaged] = useState<ChatAttachment[]>([]);
     const [stagedVisualComments, setStagedVisualComments] = useState<ChatCommentAttachment[]>([]);
+    const streamingAnnotationSendPendingRef = useRef(false);
+    const [streamingAnnotationSendPending, setStreamingAnnotationSendPendingState] = useState(false);
     // Skills the user has @-mentioned for this turn. We dedupe on id and
     // strip the chip when the user removes the corresponding `@<skill>`
     // token from the draft, keeping draft and chips in sync.
@@ -700,6 +702,11 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
       return [...commentAttachments, ...stagedVisualComments, ...extra];
     }
 
+    function setStreamingAnnotationSendPending(value: boolean) {
+      streamingAnnotationSendPendingRef.current = value;
+      setStreamingAnnotationSendPendingState(value);
+    }
+
     function currentRunContextMeta(): ChatSendMeta | undefined {
       const skillIds = stagedSkills.map((s) => s.id);
       const mcpServerIds = stagedMcpServers.map((s) => s.id);
@@ -714,6 +721,19 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
         ...(Object.keys(context).length > 0 ? { context } : {}),
       };
       return Object.keys(meta).length > 0 ? meta : undefined;
+    }
+
+    function sendComposedTurn(
+      prompt: string,
+      attachments: ChatAttachment[],
+      nextCommentAttachments: ChatCommentAttachment[],
+      meta?: ChatSendMeta,
+    ): boolean {
+      setStreamingAnnotationSendPending(false);
+      if (!prompt && attachments.length === 0 && nextCommentAttachments.length === 0) return false;
+      onSend(prompt, attachments, nextCommentAttachments, meta);
+      reset();
+      return true;
     }
 
     async function insertSkillMention(skill: SkillSummary) {
@@ -842,6 +862,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
                 ]);
               }
               if (detail.note) setDraft((d) => (d ? `${d}\n${detail.note}` : detail.note));
+              setStreamingAnnotationSendPending(true);
               textareaRef.current?.focus();
               return;
             }
@@ -854,9 +875,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
             const prompt = [draft.trim(), detail.note].filter(Boolean).join('\n');
             const attachments = [...staged, ...uploaded];
             const nextCommentAttachments = currentCommentAttachments(visualAttachment ? [visualAttachment] : []);
-            if (!prompt && attachments.length === 0 && nextCommentAttachments.length === 0) return;
-            onSend(prompt, attachments, nextCommentAttachments, currentRunContextMeta());
-            reset();
+            sendComposedTurn(prompt, attachments, nextCommentAttachments, currentRunContextMeta());
             return;
           }
 
@@ -868,7 +887,37 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
       }
       window.addEventListener(ANNOTATION_EVENT, onAnnotation);
       return () => window.removeEventListener(ANNOTATION_EVENT, onAnnotation);
-    }, [commentAttachments, draft, onSend, projectId, staged, stagedSkills, stagedVisualComments, streaming]);
+    }, [
+      commentAttachments,
+      draft,
+      onSend,
+      projectId,
+      staged,
+      stagedConnectors,
+      stagedMcpServers,
+      stagedSkills,
+      stagedVisualComments,
+      streaming,
+    ]);
+
+    useEffect(() => {
+      if (!streamingAnnotationSendPending || !streamingAnnotationSendPendingRef.current) return;
+      if (streaming || sendDisabled) return;
+      const prompt = draft.trim();
+      sendComposedTurn(prompt, staged, currentCommentAttachments(), currentRunContextMeta());
+    }, [
+      commentAttachments,
+      draft,
+      onSend,
+      sendDisabled,
+      staged,
+      stagedConnectors,
+      stagedMcpServers,
+      stagedSkills,
+      stagedVisualComments,
+      streaming,
+      streamingAnnotationSendPending,
+    ]);
 
     function handlePaste(e: React.ClipboardEvent<HTMLTextAreaElement>) {
       const items = Array.from(e.clipboardData?.items ?? []);
@@ -1053,6 +1102,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
       const nextCommentAttachments = currentCommentAttachments();
       if (hatched) {
         if (streaming) return;
+        setStreamingAnnotationSendPending(false);
         onSend(hatched, staged, nextCommentAttachments, contextMeta);
         reset();
         return;
@@ -1060,6 +1110,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
       const search = researchAvailable ? expandSearchCommand(prompt) : null;
       if (search) {
         if (streaming) return;
+        setStreamingAnnotationSendPending(false);
         onSend(search.prompt, staged, nextCommentAttachments, {
           ...contextMeta,
           research: { enabled: true, query: search.query },
@@ -1068,8 +1119,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
         return;
       }
       if ((!prompt && staged.length === 0 && nextCommentAttachments.length === 0) || streaming) return;
-      onSend(prompt, staged, nextCommentAttachments, contextMeta);
-      reset();
+      sendComposedTurn(prompt, staged, nextCommentAttachments, contextMeta);
     }
 
     // The @-picker offers a unified search across context surfaces:

--- a/apps/web/src/components/PreviewDrawOverlay.tsx
+++ b/apps/web/src/components/PreviewDrawOverlay.tsx
@@ -318,7 +318,6 @@ export function PreviewDrawOverlay({
     const hasTarget = Boolean(captureTarget);
     const shouldCapture = hasInk || hasTarget;
     const canSubmit = shouldCapture || Boolean(note.trim());
-    if (action === 'send' && sendDisabled) return;
     if (sending || !canSubmit) return;
     setPendingAction(action);
     try {
@@ -370,7 +369,7 @@ export function PreviewDrawOverlay({
   const overlayPointer = mode === 'draw' ? 'auto' : 'none';
   const showCanvas = active || mode === 'draw' || hasInk;
   const canSubmit = hasInk || Boolean(captureTarget) || Boolean(note.trim());
-  const canSend = canSubmit && !sendDisabled;
+  const canSend = canSubmit;
 
   return (
     <div
@@ -482,27 +481,26 @@ export function PreviewDrawOverlay({
               'Queue'
             )}
           </button>
-          {!sendDisabled ? (
-            <button
-              type="button"
-              onClick={() => void send('send')}
-              disabled={sending || !canSend}
-              style={{
-                ...pillStyle(true),
-                opacity: canSend ? 1 : 0.4,
-                cursor: sending ? 'wait' : (canSend ? 'pointer' : 'not-allowed'),
-              }}
-            >
-              {pendingAction === 'send' ? (
-                <>
-                  <Icon name="spinner" size={12} />
-                  <span>Sending...</span>
-                </>
-              ) : (
-                'Send'
-              )}
-            </button>
-          ) : null}
+          <button
+            type="button"
+            onClick={() => void send('send')}
+            disabled={sending || !canSend}
+            title={sendDisabled ? sendDisabledReason : undefined}
+            style={{
+              ...pillStyle(true),
+              opacity: canSend ? 1 : 0.4,
+              cursor: sending ? 'wait' : (canSend ? 'pointer' : 'not-allowed'),
+            }}
+          >
+            {pendingAction === 'send' ? (
+              <>
+                <Icon name="spinner" size={12} />
+                <span>Sending...</span>
+              </>
+            ) : (
+              'Send'
+            )}
+          </button>
         </div>
       ) : null}
     </div>

--- a/apps/web/tests/components/ChatComposer.search.test.tsx
+++ b/apps/web/tests/components/ChatComposer.search.test.tsx
@@ -63,7 +63,7 @@ describe('ChatComposer /search command', () => {
     );
   });
 
-  it('keeps concurrent queued visual annotations distinct after uploads resolve', async () => {
+  it('auto-sends concurrent queued visual annotations when streaming ends', async () => {
     const onSend = vi.fn();
     const firstUpload = deferred<Awaited<ReturnType<typeof uploadProjectFiles>>>();
     const secondUpload = deferred<Awaited<ReturnType<typeof uploadProjectFiles>>>();
@@ -134,7 +134,6 @@ describe('ChatComposer /search command', () => {
         onStop={vi.fn()}
       />,
     );
-    fireEvent.click(screen.getByTestId('chat-send'));
 
     await waitFor(() => expect(onSend).toHaveBeenCalledTimes(1));
     const [, attachments, commentAttachments] = onSend.mock.calls[0]! as [
@@ -247,14 +246,14 @@ describe('ChatComposer /search command', () => {
     });
   });
 
-  it('queues draw screenshots with hidden visual target context while streaming', async () => {
+  it('auto-sends queued draw screenshots with hidden visual target context when streaming ends', async () => {
     const onSend = vi.fn();
     mockedUploadProjectFiles.mockResolvedValue({
       uploaded: [{ path: 'uploads/drawing.png', name: 'drawing.png', kind: 'image' }],
       failed: [],
     });
 
-    render(
+    const { rerender } = render(
       <ChatComposer
         projectId="project-1"
         projectFiles={[]}
@@ -282,6 +281,29 @@ describe('ChatComposer /search command', () => {
     expect(screen.queryByTestId('staged-comment-attachments')).toBeNull();
     expect((screen.getByTestId('chat-composer-input') as HTMLTextAreaElement).value).toBe('tighten this area');
     expect(onSend).not.toHaveBeenCalled();
+
+    rerender(
+      <ChatComposer
+        projectId="project-1"
+        projectFiles={[]}
+        streaming={false}
+        onEnsureProject={async () => 'project-1'}
+        onSend={onSend}
+        onStop={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledTimes(1));
+    const [prompt, attachments, commentAttachments] = onSend.mock.calls[0]!;
+    expect(prompt).toBe('tighten this area');
+    expect(attachments).toEqual([{ path: 'uploads/drawing.png', name: 'drawing.png', kind: 'image' }]);
+    expect(commentAttachments).toHaveLength(1);
+    expect(commentAttachments[0]).toMatchObject({
+      selectionKind: 'visual',
+      screenshotPath: 'uploads/drawing.png',
+      markKind: 'stroke',
+      comment: 'tighten this area',
+    });
   });
 
   it('previews a staged image attachment from its chip', () => {

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -6,6 +6,7 @@ import { useLayoutEffect, useRef, useState } from 'react';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ANNOTATION_EVENT } from '../../src/components/PreviewDrawOverlay';
 
 const { saveTemplateMock } = vi.hoisted(() => ({
   saveTemplateMock: vi.fn(),
@@ -1299,7 +1300,10 @@ describe('FileViewer tweaks toolbar', () => {
     expect((screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement).srcdoc).toBe(initialSrcDoc);
   });
 
-  it('disables Draw direct send while a task is running but keeps queue available', () => {
+  it('lets Draw direct send emit a queued annotation while a task is running', async () => {
+    const annotationSpy = vi.fn();
+    window.addEventListener(ANNOTATION_EVENT, annotationSpy);
+
     render(
       <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
         liveHtml='<html><body><main data-od-id="hero">Hero</main></body></html>'
@@ -1314,8 +1318,20 @@ describe('FileViewer tweaks toolbar', () => {
 
     const queue = screen.getByRole('button', { name: 'Queue' }) as HTMLButtonElement;
     expect(queue.disabled).toBe(false);
-    expect(screen.queryByRole('button', { name: 'Send' })).toBeNull();
-    expect(screen.queryByText('Queues while working')).toBeNull();
+    const send = screen.getByRole('button', { name: 'Send' }) as HTMLButtonElement;
+    expect(send.disabled).toBe(false);
+
+    fireEvent.click(send);
+
+    await waitFor(() => expect(annotationSpy).toHaveBeenCalledTimes(1));
+    expect(annotationSpy.mock.calls[0]?.[0]).toMatchObject({
+      detail: {
+        action: 'send',
+        note: 'mark this',
+        filePath: 'preview.html',
+      },
+    });
+    window.removeEventListener(ANNOTATION_EVENT, annotationSpy);
   });
 
   it('hides non-open saved comments from preview markers when the side panel is empty', () => {


### PR DESCRIPTION
## Summary
- Queue Draw `Send to chat` annotations while the current run is streaming, preserving the staged composer state.
- Keep the real Draw overlay `Send` action reachable during streaming so it emits the queued annotation event from the production FileViewer path.
- Automatically sends the queued composed turn when streaming/send-disabled state clears.
- Updates FileViewer + ChatComposer regression coverage for queued visual annotation auto-send, including concurrent annotation uploads.

Fixes #1670.

## Draw → Send to chat

![Draw Send to chat during streaming](https://imgbed.kami.fit:444/file/1779172889389_open-design-draw-send-streaming-v2.png)

Bug-fix verification:
- Before: when a run was streaming, `FileViewer` passed `sendDisabled={streaming}` into `PreviewDrawOverlay`; the overlay hid/blocked the Draw `Send` action, so ChatComposer's queued-send path could not be reached from the actual Draw UI.
- After: the Draw `Send` action remains available while streaming, dispatches `action: 'send'` from the overlay, ChatComposer stages the screenshot/comment while streaming, and the composed turn auto-sends once streaming/send-disabled state clears.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Test Plan
- pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/components/PreviewDrawOverlay.test.tsx tests/components/FileViewer.test.tsx tests/components/ChatComposer.search.test.tsx
- pnpm --dir apps/web typecheck
- git diff --check
