### PR TITLE
Fix truncated API stream continuation

### DIFF
--- a/apps/daemon/src/chat-routes.ts
+++ b/apps/daemon/src/chat-routes.ts
@@ -622,6 +622,13 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
     return '';
   };
 
+  const extractOpenAIFinishReason = (data: any) => {
+    const choices = data?.choices;
+    if (!Array.isArray(choices) || choices.length === 0) return '';
+    const first = choices[0];
+    return typeof first?.finish_reason === 'string' ? first.finish_reason : '';
+  };
+
   const extractStreamErrorMessage = (data: any) => {
     const err = data?.error;
     if (!err) return '';
@@ -640,6 +647,13 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
     const parts = candidates[0]?.content?.parts;
     if (!Array.isArray(parts)) return '';
     return parts.map((part) => part?.text).filter((text) => typeof text === 'string').join('');
+  };
+
+  const extractGeminiFinishReason = (data: any) => {
+    const candidates = data?.candidates;
+    if (!Array.isArray(candidates) || candidates.length === 0) return '';
+    const reason = candidates[0]?.finishReason;
+    return typeof reason === 'string' ? reason : '';
   };
 
   const benignGeminiFinishReasons = new Set(['', 'STOP', 'MAX_TOKENS', 'FINISH_REASON_UNSPECIFIED']);
@@ -746,6 +760,7 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
 
       let ended = false;
       const guard = createDeltaGuard(sse);
+      let finishReason = '';
       await streamUpstreamSse(response, ({ event, data }: any) => {
         if (!data) return false;
         if (event === 'error' || data.type === 'error') {
@@ -762,8 +777,11 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
             return true;
           }
         }
+        if (event === 'message_delta' && typeof data.delta?.stop_reason === 'string') {
+          finishReason = data.delta.stop_reason;
+        }
         if (event === 'message_stop') {
-          sse.send('end', {});
+          sse.send('end', finishReason ? { finishReason } : {});
           ended = true;
           return true;
         }
@@ -834,6 +852,7 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
 
       let ended = false;
       const guard = createDeltaGuard(sse);
+      let finishReason = '';
       await streamUpstreamSse(response, ({ data }: any) => {
         if (!data) return false;
         const streamError = extractStreamErrorMessage(data);
@@ -851,6 +870,8 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
             return true;
           }
         }
+        const reason = extractGeminiFinishReason(data);
+        if (reason) finishReason = reason;
         const blockMessage = extractGeminiBlockMessage(data);
         if (blockMessage) {
           sendProxyError(sse, blockMessage, { details: data });
@@ -859,7 +880,7 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
         }
         return false;
       });
-      if (!ended) sse.send('end', {});
+      if (!ended) sse.send('end', finishReason ? { finishReason } : {});
       sse.end();
     } catch (err: any) {
       console.error(`[${opts.logTag}] internal error: ${err.message}`);
@@ -1074,9 +1095,10 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
 
       let ended = false;
       const guard = createDeltaGuard(sse);
+      let finishReason = '';
       await streamUpstreamSse(response, ({ payload, data }: any) => {
         if (payload === '[DONE]') {
-          sse.send('end', {});
+          sse.send('end', finishReason ? { finishReason } : {});
           ended = true;
           return true;
         }
@@ -1088,14 +1110,16 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
           return true;
         }
         const delta = extractOpenAIText(data);
-        if (delta) { 
-          guard.sendDelta(delta); 
-          if (guard.contaminated) { 
-            sse.send('end', {}); 
-            ended = true; 
-            return true; 
-          } 
+        if (delta) {
+          guard.sendDelta(delta);
+          if (guard.contaminated) {
+            sse.send('end', {});
+            ended = true;
+            return true;
+          }
         }
+        const reason = extractOpenAIFinishReason(data);
+        if (reason) finishReason = reason;
         return false;
       });
       if (!ended) sse.send('end', {});
@@ -1229,9 +1253,10 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
 
       let ended = false;
       const guard = createDeltaGuard(sse);
+      let finishReason = '';
       await streamUpstreamSse(response, ({ payload: ssePayload, data }: any) => {
         if (ssePayload === '[DONE]') {
-          sse.send('end', {});
+          sse.send('end', finishReason ? { finishReason } : {});
           ended = true;
           return true;
         }
@@ -1243,13 +1268,16 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
           return true;
         }
         const delta = extractOpenAIText(data);
-        if (delta) { guard.sendDelta(delta); 
-          if (guard.contaminated) { 
-            sse.send('end', {}); 
-            ended = true; 
-            return true; 
-          } 
+        if (delta) {
+          guard.sendDelta(delta);
+          if (guard.contaminated) {
+            sse.send('end', {});
+            ended = true;
+            return true;
+          }
         }
+        const reason = extractOpenAIFinishReason(data);
+        if (reason) finishReason = reason;
         return false;
       });
       if (!ended) sse.send('end', {});

--- a/apps/daemon/tests/proxy-routes.test.ts
+++ b/apps/daemon/tests/proxy-routes.test.ts
@@ -322,6 +322,65 @@ describe('API proxy routes', () => {
     }
   });
 
+  it('forwards OpenAI-compatible length finish reasons on proxy end events', async () => {
+    vi.stubGlobal('fetch', vi.fn((input: FetchInput, init?: FetchInit) => {
+      const url = String(input);
+      if (url.startsWith(baseUrl)) return realFetch(input, init);
+      return Promise.resolve(sseResponse([
+        'data: {"choices":[{"delta":{"content":"partial"},"finish_reason":null}]}',
+        '',
+        'data: {"choices":[{"delta":{},"finish_reason":"length"}]}',
+        '',
+        'data: [DONE]',
+        '',
+      ].join('\n')));
+    }));
+
+    const res = await realFetch(`${baseUrl}/api/proxy/openai/stream`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        baseUrl: 'https://api.example.com/v1',
+        apiKey: 'sk-test',
+        model: 'gpt-test',
+        messages: [{ role: 'user', content: 'hello' }],
+      }),
+    });
+
+    await expect(res.text()).resolves.toContain('event: end\ndata: {"finishReason":"length"}');
+  });
+
+  it('forwards Anthropic max_tokens stop reasons on proxy end events', async () => {
+    vi.stubGlobal('fetch', vi.fn((input: FetchInput, init?: FetchInit) => {
+      const url = String(input);
+      if (url.startsWith(baseUrl)) return realFetch(input, init);
+      return Promise.resolve(sseResponse([
+        'event: content_block_delta',
+        'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"partial"}}',
+        '',
+        'event: message_delta',
+        'data: {"type":"message_delta","delta":{"stop_reason":"max_tokens"}}',
+        '',
+        'event: message_stop',
+        'data: {"type":"message_stop"}',
+        '',
+      ].join('\n')));
+    }));
+
+    const res = await realFetch(`${baseUrl}/api/proxy/anthropic/stream`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        baseUrl: 'https://api.anthropic.com',
+        apiKey: 'sk-test',
+        model: 'claude-test',
+        messages: [{ role: 'user', content: 'hello' }],
+      }),
+    });
+
+    await expect(res.text()).resolves.toContain('event: end\ndata: {"finishReason":"max_tokens"}');
+  });
+
   // Regression: appendVersionedApiPath needs to thread three shapes:
   //   * bare host                  → inject /v1 (api.openai.com)
   //   * sub-path containing /vN    → no inject (api.deepinfra.com/v1/openai)

--- a/apps/web/src/providers/api-proxy.ts
+++ b/apps/web/src/providers/api-proxy.ts
@@ -24,6 +24,11 @@ const TRUNCATED_FINISH_REASONS = new Set([
 
 const PREFILL_CONTINUATION_PROTOCOLS = new Set<ApiProtocol>(['anthropic']);
 const MAX_TRUNCATION_CONTINUATIONS = 8;
+const EXPLICIT_CONTINUATION_PROMPT = [
+  'Continue exactly from where your previous response stopped.',
+  'Do not repeat earlier text or add a preamble.',
+  'If you were writing an artifact, continue the same artifact and close it normally.',
+].join(' ');
 
 /**
  * Optional per-request context that some protocols thread into the
@@ -86,17 +91,12 @@ export async function streamProxyEndpoint(
         return;
       }
 
-      if (!canContinueWithAssistantPrefill(cfg.apiProtocol)) {
-        handlers.onDone(acc);
-        return;
-      }
-
       if (continuations >= MAX_TRUNCATION_CONTINUATIONS) {
         handlers.onError(new Error('Response was truncated repeatedly before the provider returned a final stop reason.'));
         return;
       }
       continuations += 1;
-      requestMessages = appendContinuationAssistantMessage(requestMessages, acc, cfg.apiProtocol);
+      requestMessages = buildContinuationMessages(requestMessages, acc, cfg.apiProtocol);
     }
   } catch (err) {
     if ((err as Error).name === 'AbortError') return;
@@ -376,6 +376,17 @@ function canContinueWithAssistantPrefill(protocol?: ApiProtocol): boolean {
   return protocol !== undefined && PREFILL_CONTINUATION_PROTOCOLS.has(protocol);
 }
 
+function buildContinuationMessages(
+  messages: ProxyMessage[],
+  assistantText: string,
+  protocol?: ApiProtocol,
+): ProxyMessage[] {
+  if (canContinueWithAssistantPrefill(protocol)) {
+    return appendContinuationAssistantMessage(messages, assistantText, protocol);
+  }
+  return appendExplicitContinuationRequest(messages, assistantText, protocol);
+}
+
 function appendContinuationAssistantMessage(
   messages: ProxyMessage[],
   assistantText: string,
@@ -390,6 +401,41 @@ function appendContinuationAssistantMessage(
     ];
   }
   return [...compacted, { role: 'assistant', content: assistantText }];
+}
+
+function appendExplicitContinuationRequest(
+  messages: ProxyMessage[],
+  assistantText: string,
+  protocol?: ApiProtocol,
+): ProxyMessage[] {
+  const compacted = compactContinuationHistory(messages, protocol);
+  const last = compacted[compacted.length - 1];
+  const previous = compacted[compacted.length - 2];
+  if (
+    last?.role === 'user'
+    && last.content === EXPLICIT_CONTINUATION_PROMPT
+    && previous?.role === 'assistant'
+  ) {
+    return [
+      ...compacted.slice(0, -2),
+      { ...previous, content: assistantText },
+      last,
+    ];
+  }
+
+  if (last?.role === 'assistant') {
+    return [
+      ...compacted.slice(0, -1),
+      { ...last, content: assistantText },
+      { role: 'user', content: EXPLICIT_CONTINUATION_PROMPT },
+    ];
+  }
+
+  return [
+    ...compacted,
+    { role: 'assistant', content: assistantText },
+    { role: 'user', content: EXPLICIT_CONTINUATION_PROMPT },
+  ];
 }
 
 function compactContinuationHistory(

--- a/apps/web/src/providers/api-proxy.ts
+++ b/apps/web/src/providers/api-proxy.ts
@@ -24,11 +24,6 @@ const TRUNCATED_FINISH_REASONS = new Set([
 
 const PREFILL_CONTINUATION_PROTOCOLS = new Set<ApiProtocol>(['anthropic']);
 const MAX_TRUNCATION_CONTINUATIONS = 8;
-const EXPLICIT_CONTINUATION_PROMPT = [
-  'Continue exactly from where your previous response stopped.',
-  'Do not repeat earlier text or add a preamble.',
-  'If you were writing an artifact, continue the same artifact and close it normally.',
-].join(' ');
 
 /**
  * Optional per-request context that some protocols thread into the
@@ -91,12 +86,17 @@ export async function streamProxyEndpoint(
         return;
       }
 
+      if (!canContinueWithAssistantPrefill(cfg.apiProtocol)) {
+        handlers.onDone(acc);
+        return;
+      }
+
       if (continuations >= MAX_TRUNCATION_CONTINUATIONS) {
         handlers.onError(new Error('Response was truncated repeatedly before the provider returned a final stop reason.'));
         return;
       }
       continuations += 1;
-      requestMessages = buildContinuationMessages(requestMessages, acc, cfg.apiProtocol);
+      requestMessages = appendContinuationAssistantMessage(requestMessages, acc, cfg.apiProtocol);
     }
   } catch (err) {
     if ((err as Error).name === 'AbortError') return;
@@ -376,17 +376,6 @@ function canContinueWithAssistantPrefill(protocol?: ApiProtocol): boolean {
   return protocol !== undefined && PREFILL_CONTINUATION_PROTOCOLS.has(protocol);
 }
 
-function buildContinuationMessages(
-  messages: ProxyMessage[],
-  assistantText: string,
-  protocol?: ApiProtocol,
-): ProxyMessage[] {
-  if (canContinueWithAssistantPrefill(protocol)) {
-    return appendContinuationAssistantMessage(messages, assistantText, protocol);
-  }
-  return appendExplicitContinuationRequest(messages, assistantText, protocol);
-}
-
 function appendContinuationAssistantMessage(
   messages: ProxyMessage[],
   assistantText: string,
@@ -401,41 +390,6 @@ function appendContinuationAssistantMessage(
     ];
   }
   return [...compacted, { role: 'assistant', content: assistantText }];
-}
-
-function appendExplicitContinuationRequest(
-  messages: ProxyMessage[],
-  assistantText: string,
-  protocol?: ApiProtocol,
-): ProxyMessage[] {
-  const compacted = compactContinuationHistory(messages, protocol);
-  const last = compacted[compacted.length - 1];
-  const previous = compacted[compacted.length - 2];
-  if (
-    last?.role === 'user'
-    && last.content === EXPLICIT_CONTINUATION_PROMPT
-    && previous?.role === 'assistant'
-  ) {
-    return [
-      ...compacted.slice(0, -2),
-      { ...previous, content: assistantText },
-      last,
-    ];
-  }
-
-  if (last?.role === 'assistant') {
-    return [
-      ...compacted.slice(0, -1),
-      { ...last, content: assistantText },
-      { role: 'user', content: EXPLICIT_CONTINUATION_PROMPT },
-    ];
-  }
-
-  return [
-    ...compacted,
-    { role: 'assistant', content: assistantText },
-    { role: 'user', content: EXPLICIT_CONTINUATION_PROMPT },
-  ];
 }
 
 function compactContinuationHistory(

--- a/apps/web/src/providers/api-proxy.ts
+++ b/apps/web/src/providers/api-proxy.ts
@@ -1,5 +1,5 @@
 import { effectiveMaxTokens } from '../state/maxTokens';
-import type { AppConfig, ChatMessage } from '../types';
+import type { ApiProtocol, AppConfig, ChatMessage } from '../types';
 import type {
   ProxyImageContentBlock,
   ProxyMessage,
@@ -10,6 +10,25 @@ import { projectFileUrl } from './registry';
 import type { StreamHandlers } from './anthropic';
 import { parseSseFrame } from './sse';
 import { isAnthropicSupportedImagePath } from '../utils/apiProtocol';
+
+type ProxyStreamResult =
+  | { kind: 'done'; finishReason: string | null }
+  | { kind: 'aborted' }
+  | { kind: 'error' };
+
+const TRUNCATED_FINISH_REASONS = new Set([
+  'length',
+  'max_tokens',
+  'MAX_TOKENS',
+]);
+
+const PREFILL_CONTINUATION_PROTOCOLS = new Set<ApiProtocol>(['anthropic']);
+const MAX_TRUNCATION_CONTINUATIONS = 8;
+const EXPLICIT_CONTINUATION_PROMPT = [
+  'Continue exactly from where your previous response stopped.',
+  'Do not repeat earlier text or add a preamble.',
+  'If you were writing an artifact, continue the same artifact and close it normally.',
+].join(' ');
 
 /**
  * Optional per-request context that some protocols thread into the
@@ -48,81 +67,37 @@ export async function streamProxyEndpoint(
   let acc = '';
 
   try {
-    const messages = await buildProxyMessages(endpoint, history, context);
-    const resp = await fetch(endpoint, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        baseUrl: cfg.baseUrl,
-        apiKey: cfg.apiKey,
-        model: cfg.model,
-        systemPrompt: system,
-        messages,
-        maxTokens: effectiveMaxTokens(cfg),
-        apiVersion: cfg.apiVersion,
-        ...(context?.projectId ? { projectId: context.projectId } : {}),
-        ...(context?.byokImageModel
-          ? { byokImageModel: context.byokImageModel }
-          : {}),
-        ...(context?.byokVideoModel
-          ? { byokVideoModel: context.byokVideoModel }
-          : {}),
-        ...(context?.byokSpeechModel
-          ? { byokSpeechModel: context.byokSpeechModel }
-          : {}),
-        ...(context?.byokSpeechVoice
-          ? { byokSpeechVoice: context.byokSpeechVoice }
-          : {}),
-      }),
-      signal,
-    });
-
-    if (!resp.ok || !resp.body) {
-      const text = await resp.text().catch(() => '');
-      handlers.onError(new Error(`proxy ${resp.status}: ${text || 'no body'}`));
-      return;
-    }
-
-    const reader = resp.body.getReader();
-    const decoder = new TextDecoder();
-    let buf = '';
+    let requestMessages = await buildProxyMessages(endpoint, history, context);
+    let continuations = 0;
 
     while (true) {
-      const { value, done } = await reader.read();
-      if (done) break;
-      buf += decoder.decode(value, { stream: true });
+      const result = await streamProxyAttempt({
+        endpoint,
+        cfg,
+        system,
+        messages: requestMessages,
+        signal,
+        handlers,
+        context,
+        onDelta: (text) => {
+          acc += text;
+          handlers.onDelta(text);
+        },
+      });
 
-      while (true) {
-        const match = buf.match(/\r?\n\r?\n/);
-        if (!match || match.index === undefined) break;
-        const frame = buf.slice(0, match.index);
-        buf = buf.slice(match.index + match[0].length);
-
-        const parsed = parseSseFrame(frame);
-        if (!parsed || parsed.kind !== 'event') continue;
-
-        if (parsed.event === 'delta') {
-          const text = String(parsed.data.delta ?? parsed.data.text ?? '');
-          if (text) {
-            acc += text;
-            handlers.onDelta(text);
-          }
-          continue;
-        }
-
-        if (parsed.event === 'error') {
-          handlers.onError(new Error(proxyErrorMessage(parsed.data)));
-          return;
-        }
-
-        if (parsed.event === 'end') {
-          handlers.onDone(acc);
-          return;
-        }
+      if (result.kind === 'aborted' || result.kind === 'error') return;
+      if (!isTruncatedFinishReason(result.finishReason)) {
+        handlers.onDone(acc);
+        return;
       }
-    }
 
-    handlers.onDone(acc);
+      if (continuations >= MAX_TRUNCATION_CONTINUATIONS) {
+        handlers.onError(new Error('Response was truncated repeatedly before the provider returned a final stop reason.'));
+        return;
+      }
+      continuations += 1;
+      requestMessages = buildContinuationMessages(requestMessages, acc, cfg.apiProtocol);
+    }
   } catch (err) {
     if ((err as Error).name === 'AbortError') return;
     handlers.onError(err instanceof Error ? err : new Error(String(err)));
@@ -271,6 +246,115 @@ function bytesToBase64(bytes: Uint8Array): string {
   return out;
 }
 
+async function streamProxyAttempt({
+  endpoint,
+  cfg,
+  system,
+  messages,
+  signal,
+  handlers,
+  context,
+  onDelta,
+}: {
+  endpoint: string;
+  cfg: AppConfig;
+  system: string;
+  messages: ProxyMessage[];
+  signal: AbortSignal;
+  handlers: StreamHandlers;
+  context?: ProxyContext;
+  onDelta: (text: string) => void;
+}): Promise<ProxyStreamResult> {
+  const resp = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      baseUrl: cfg.baseUrl,
+      apiKey: cfg.apiKey,
+      model: cfg.model,
+      systemPrompt: system,
+      messages,
+      maxTokens: effectiveMaxTokens(cfg),
+      apiVersion: cfg.apiVersion,
+      ...(context?.projectId ? { projectId: context.projectId } : {}),
+      ...(context?.byokImageModel
+        ? { byokImageModel: context.byokImageModel }
+        : {}),
+      ...(context?.byokVideoModel
+        ? { byokVideoModel: context.byokVideoModel }
+        : {}),
+      ...(context?.byokSpeechModel
+        ? { byokSpeechModel: context.byokSpeechModel }
+        : {}),
+      ...(context?.byokSpeechVoice
+        ? { byokSpeechVoice: context.byokSpeechVoice }
+        : {}),
+    }),
+    signal,
+  });
+
+  if (!resp.ok || !resp.body) {
+    const text = await resp.text().catch(() => '');
+    handlers.onError(new Error(`proxy ${resp.status}: ${text || 'no body'}`));
+    return { kind: 'error' };
+  }
+
+  const reader = resp.body.getReader();
+  const decoder = new TextDecoder();
+  let buf = '';
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+
+    while (true) {
+      const match = buf.match(/\r?\n\r?\n/);
+      if (!match || match.index === undefined) break;
+      const frame = buf.slice(0, match.index);
+      buf = buf.slice(match.index + match[0]!.length);
+
+      const parsed = parseSseFrame(frame);
+      if (!parsed || parsed.kind !== 'event') continue;
+
+      if (parsed.event === 'delta') {
+        const text = String(parsed.data.delta ?? parsed.data.text ?? '');
+        if (text) {
+          onDelta(text);
+        }
+        continue;
+      }
+
+      if (parsed.event === 'error') {
+        handlers.onError(new Error(proxyErrorMessage(parsed.data)));
+        return { kind: 'error' };
+      }
+
+      if (parsed.event === 'end') {
+        return { kind: 'done', finishReason: finishReasonFromEndPayload(parsed.data) };
+      }
+    }
+  }
+
+  const tail = buf.trim();
+  if (tail) {
+    const parsed = parseSseFrame(tail);
+    if (parsed?.kind === 'event') {
+      if (parsed.event === 'delta') {
+        const text = String(parsed.data.delta ?? parsed.data.text ?? '');
+        if (text) onDelta(text);
+      } else if (parsed.event === 'error') {
+        handlers.onError(new Error(proxyErrorMessage(parsed.data)));
+        return { kind: 'error' };
+      } else if (parsed.event === 'end') {
+        return { kind: 'done', finishReason: finishReasonFromEndPayload(parsed.data) };
+      }
+    }
+  }
+
+  return { kind: signal.aborted ? 'aborted' : 'done', finishReason: null };
+}
+
 function proxyErrorMessage(data: Record<string, unknown>): string {
   const nested = data.error;
   if (nested && typeof nested === 'object' && 'message' in nested) {
@@ -278,4 +362,124 @@ function proxyErrorMessage(data: Record<string, unknown>): string {
     if (typeof message === 'string' && message) return message;
   }
   return String(data.message ?? 'proxy error');
+}
+
+function finishReasonFromEndPayload(data: Record<string, unknown>): string | null {
+  return typeof data.finishReason === 'string' && data.finishReason ? data.finishReason : null;
+}
+
+function isTruncatedFinishReason(reason: string | null): boolean {
+  return reason !== null && TRUNCATED_FINISH_REASONS.has(reason);
+}
+
+function canContinueWithAssistantPrefill(protocol?: ApiProtocol): boolean {
+  return protocol !== undefined && PREFILL_CONTINUATION_PROTOCOLS.has(protocol);
+}
+
+function buildContinuationMessages(
+  messages: ProxyMessage[],
+  assistantText: string,
+  protocol?: ApiProtocol,
+): ProxyMessage[] {
+  if (canContinueWithAssistantPrefill(protocol)) {
+    return appendContinuationAssistantMessage(messages, assistantText, protocol);
+  }
+  return appendExplicitContinuationRequest(messages, assistantText, protocol);
+}
+
+function appendContinuationAssistantMessage(
+  messages: ProxyMessage[],
+  assistantText: string,
+  protocol?: ApiProtocol,
+): ProxyMessage[] {
+  const compacted = compactContinuationHistory(messages, protocol);
+  const last = compacted[compacted.length - 1];
+  if (last?.role === 'assistant') {
+    return [
+      ...compacted.slice(0, -1),
+      { ...last, content: assistantText },
+    ];
+  }
+  return [...compacted, { role: 'assistant', content: assistantText }];
+}
+
+function appendExplicitContinuationRequest(
+  messages: ProxyMessage[],
+  assistantText: string,
+  protocol?: ApiProtocol,
+): ProxyMessage[] {
+  const compacted = compactContinuationHistory(messages, protocol);
+  const last = compacted[compacted.length - 1];
+  const previous = compacted[compacted.length - 2];
+  if (
+    last?.role === 'user'
+    && last.content === EXPLICIT_CONTINUATION_PROMPT
+    && previous?.role === 'assistant'
+  ) {
+    return [
+      ...compacted.slice(0, -2),
+      { ...previous, content: assistantText },
+      last,
+    ];
+  }
+
+  if (last?.role === 'assistant') {
+    return [
+      ...compacted.slice(0, -1),
+      { ...last, content: assistantText },
+      { role: 'user', content: EXPLICIT_CONTINUATION_PROMPT },
+    ];
+  }
+
+  return [
+    ...compacted,
+    { role: 'assistant', content: assistantText },
+    { role: 'user', content: EXPLICIT_CONTINUATION_PROMPT },
+  ];
+}
+
+function compactContinuationHistory(
+  messages: ProxyMessage[],
+  protocol?: ApiProtocol,
+): ProxyMessage[] {
+  if (protocol === 'google') return messages;
+  const compacted: ProxyMessage[] = [];
+  for (const message of messages) {
+    const previous = compacted[compacted.length - 1];
+    if (previous?.role === message.role) {
+      compacted[compacted.length - 1] = {
+        ...previous,
+        content: mergeProxyMessageContent(previous.content, message.content),
+      };
+    } else {
+      compacted.push(message);
+    }
+  }
+  return compacted;
+}
+
+function mergeProxyMessageContent(
+  previous: ProxyMessageContent,
+  next: ProxyMessageContent,
+): ProxyMessageContent {
+  if (typeof previous === 'string' && typeof next === 'string') {
+    return `${previous}\n\n${next}`;
+  }
+
+  const previousBlocks = proxyContentBlocks(previous);
+  const nextBlocks = proxyContentBlocks(next);
+  return [
+    ...previousBlocks,
+    ...(previousBlocks.length > 0 && nextBlocks.length > 0
+      ? [{ type: 'text' as const, text: '\n\n' }]
+      : []),
+    ...nextBlocks,
+  ];
+}
+
+function proxyContentBlocks(
+  content: ProxyMessageContent,
+): Array<ProxyTextContentBlock | ProxyImageContentBlock> {
+  if (Array.isArray(content)) return content;
+  return content ? [{ type: 'text', text: content }] : [];
 }

--- a/apps/web/tests/providers/sse.test.ts
+++ b/apps/web/tests/providers/sse.test.ts
@@ -1236,6 +1236,67 @@ describe('streamViaDaemon', () => {
 });
 
 describe('streamMessageOpenAI', () => {
+  it('continues truncated OpenAI-compatible streams using accumulated assistant text', async () => {
+    const handlers = createStreamHandlers();
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(
+        sseResponse(
+          [
+            'event: delta',
+            'data: {"delta":"first chunk"}',
+            '',
+            'event: end',
+            'data: {"finishReason":"length"}',
+            '',
+            '',
+          ].join('\n'),
+        ),
+      )
+      .mockResolvedValueOnce(
+        sseResponse(
+          [
+            'event: delta',
+            'data: {"delta":" second chunk"}',
+            '',
+            'event: end',
+            'data: {"finishReason":"stop"}',
+            '',
+            '',
+          ].join('\n'),
+        ),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await streamMessageOpenAI(
+      {
+        mode: 'api',
+        apiKey: 'test-key',
+        baseUrl: 'https://example.test',
+        model: 'gpt-test',
+        agentId: null,
+        skillId: null,
+        designSystemId: null,
+      },
+      '',
+      [{ id: '1', role: 'user', content: 'hello' }],
+      new AbortController().signal,
+      handlers,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [, retryInit] = fetchMock.mock.calls[1] as unknown as [RequestInfo | URL, RequestInit];
+    expect(JSON.parse(String(retryInit.body))).toMatchObject({
+      messages: [
+        { role: 'user', content: 'hello' },
+        { role: 'assistant', content: 'first chunk' },
+      ],
+    });
+    expect(handlers.onDelta).toHaveBeenNthCalledWith(1, 'first chunk');
+    expect(handlers.onDelta).toHaveBeenNthCalledWith(2, ' second chunk');
+    expect(handlers.onError).not.toHaveBeenCalled();
+    expect(handlers.onDone).toHaveBeenCalledWith('first chunk second chunk');
+  });
+
   it('ignores comments and keeps delta/end behavior unchanged', async () => {
     const handlers = createStreamHandlers();
     vi.stubGlobal(

--- a/apps/web/tests/providers/sse.test.ts
+++ b/apps/web/tests/providers/sse.test.ts
@@ -7,6 +7,7 @@ import {
   sanitizePriorAssistantTurnForTranscript,
   streamViaDaemon,
 } from '../../src/providers/daemon';
+import { streamMessageAnthropicProxy } from '../../src/providers/anthropic-compatible';
 import { streamMessageOpenAI } from '../../src/providers/openai-compatible';
 import { parseSseFrame } from '../../src/providers/sse';
 
@@ -1236,35 +1237,21 @@ describe('streamViaDaemon', () => {
 });
 
 describe('streamMessageOpenAI', () => {
-  it('continues truncated OpenAI-compatible streams using accumulated assistant text', async () => {
+  it('does not continue truncated OpenAI-compatible streams with assistant prefill', async () => {
     const handlers = createStreamHandlers();
-    const fetchMock = vi.fn()
-      .mockResolvedValueOnce(
-        sseResponse(
-          [
-            'event: delta',
-            'data: {"delta":"first chunk"}',
-            '',
-            'event: end',
-            'data: {"finishReason":"length"}',
-            '',
-            '',
-          ].join('\n'),
-        ),
-      )
-      .mockResolvedValueOnce(
-        sseResponse(
-          [
-            'event: delta',
-            'data: {"delta":" second chunk"}',
-            '',
-            'event: end',
-            'data: {"finishReason":"stop"}',
-            '',
-            '',
-          ].join('\n'),
-        ),
-      );
+    const fetchMock = vi.fn(async () =>
+      sseResponse(
+        [
+          'event: delta',
+          'data: {"delta":"first chunk"}',
+          '',
+          'event: end',
+          'data: {"finishReason":"length"}',
+          '',
+          '',
+        ].join('\n'),
+      ),
+    );
     vi.stubGlobal('fetch', fetchMock);
 
     await streamMessageOpenAI(
@@ -1283,18 +1270,10 @@ describe('streamMessageOpenAI', () => {
       handlers,
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    const [, retryInit] = fetchMock.mock.calls[1] as unknown as [RequestInfo | URL, RequestInit];
-    expect(JSON.parse(String(retryInit.body))).toMatchObject({
-      messages: [
-        { role: 'user', content: 'hello' },
-        { role: 'assistant', content: 'first chunk' },
-      ],
-    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(handlers.onDelta).toHaveBeenNthCalledWith(1, 'first chunk');
-    expect(handlers.onDelta).toHaveBeenNthCalledWith(2, ' second chunk');
     expect(handlers.onError).not.toHaveBeenCalled();
-    expect(handlers.onDone).toHaveBeenCalledWith('first chunk second chunk');
+    expect(handlers.onDone).toHaveBeenCalledWith('first chunk');
   });
 
   it('ignores comments and keeps delta/end behavior unchanged', async () => {
@@ -1376,6 +1355,70 @@ describe('streamMessageOpenAI', () => {
     expect(fetchMock).toHaveBeenCalledWith('/api/proxy/openai/stream', expect.any(Object));
     expect(handlers.onDelta).toHaveBeenCalledWith('hi');
     expect(handlers.onDone).toHaveBeenCalledWith('hi');
+  });
+});
+
+describe('streamMessageAnthropicProxy', () => {
+  it('continues truncated Anthropic streams using accumulated assistant text', async () => {
+    const handlers = createStreamHandlers();
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(
+        sseResponse(
+          [
+            'event: delta',
+            'data: {"delta":"first chunk"}',
+            '',
+            'event: end',
+            'data: {"finishReason":"max_tokens"}',
+            '',
+            '',
+          ].join('\n'),
+        ),
+      )
+      .mockResolvedValueOnce(
+        sseResponse(
+          [
+            'event: delta',
+            'data: {"delta":" second chunk"}',
+            '',
+            'event: end',
+            'data: {"finishReason":"end_turn"}',
+            '',
+            '',
+          ].join('\n'),
+        ),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await streamMessageAnthropicProxy(
+      {
+        mode: 'api',
+        apiProtocol: 'anthropic',
+        apiKey: 'test-key',
+        baseUrl: 'https://example.test/anthropic',
+        model: 'claude-test',
+        agentId: null,
+        skillId: null,
+        designSystemId: null,
+      },
+      '',
+      [{ id: '1', role: 'user', content: 'hello' }],
+      new AbortController().signal,
+      handlers,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [, retryInit] = fetchMock.mock.calls[1] as unknown as [RequestInfo | URL, RequestInit];
+    expect(JSON.parse(String(retryInit.body))).toMatchObject({
+      messages: [
+        { role: 'user', content: 'hello' },
+        { role: 'assistant', content: 'first chunk' },
+      ],
+    });
+    expect(handlers.onDelta).toHaveBeenNthCalledWith(1, 'first chunk');
+    expect(handlers.onDelta).toHaveBeenNthCalledWith(2, ' second chunk');
+    expect(handlers.onError).not.toHaveBeenCalled();
+    expect(handlers.onDone).toHaveBeenCalledWith('first chunk second chunk');
   });
 });
 

--- a/apps/web/tests/providers/sse.test.ts
+++ b/apps/web/tests/providers/sse.test.ts
@@ -1237,21 +1237,35 @@ describe('streamViaDaemon', () => {
 });
 
 describe('streamMessageOpenAI', () => {
-  it('does not continue truncated OpenAI-compatible streams with assistant prefill', async () => {
+  it('continues truncated OpenAI-compatible streams with a follow-up user request', async () => {
     const handlers = createStreamHandlers();
-    const fetchMock = vi.fn(async () =>
-      sseResponse(
-        [
-          'event: delta',
-          'data: {"delta":"first chunk"}',
-          '',
-          'event: end',
-          'data: {"finishReason":"length"}',
-          '',
-          '',
-        ].join('\n'),
-      ),
-    );
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(
+        sseResponse(
+          [
+            'event: delta',
+            'data: {"delta":"first chunk"}',
+            '',
+            'event: end',
+            'data: {"finishReason":"length"}',
+            '',
+            '',
+          ].join('\n'),
+        ),
+      )
+      .mockResolvedValueOnce(
+        sseResponse(
+          [
+            'event: delta',
+            'data: {"delta":" second chunk"}',
+            '',
+            'event: end',
+            'data: {"finishReason":"stop"}',
+            '',
+            '',
+          ].join('\n'),
+        ),
+      );
     vi.stubGlobal('fetch', fetchMock);
 
     await streamMessageOpenAI(
@@ -1270,10 +1284,88 @@ describe('streamMessageOpenAI', () => {
       handlers,
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [, retryInit] = fetchMock.mock.calls[1] as unknown as [RequestInfo | URL, RequestInit];
+    const retryBody = JSON.parse(String(retryInit.body));
+    expect(retryBody.messages).toHaveLength(3);
+    expect(retryBody.messages[0]).toEqual({ role: 'user', content: 'hello' });
+    expect(retryBody.messages[1]).toEqual({ role: 'assistant', content: 'first chunk' });
+    expect(retryBody.messages[2]).toMatchObject({ role: 'user' });
+    expect(retryBody.messages[2].content).toContain('Continue exactly from where your previous response stopped');
     expect(handlers.onDelta).toHaveBeenNthCalledWith(1, 'first chunk');
+    expect(handlers.onDelta).toHaveBeenNthCalledWith(2, ' second chunk');
     expect(handlers.onError).not.toHaveBeenCalled();
-    expect(handlers.onDone).toHaveBeenCalledWith('first chunk');
+    expect(handlers.onDone).toHaveBeenCalledWith('first chunk second chunk');
+  });
+
+  it('updates the explicit continuation request with accumulated OpenAI-compatible text', async () => {
+    const handlers = createStreamHandlers();
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(
+        sseResponse(
+          [
+            'event: delta',
+            'data: {"delta":"first"}',
+            '',
+            'event: end',
+            'data: {"finishReason":"length"}',
+            '',
+            '',
+          ].join('\n'),
+        ),
+      )
+      .mockResolvedValueOnce(
+        sseResponse(
+          [
+            'event: delta',
+            'data: {"delta":" second"}',
+            '',
+            'event: end',
+            'data: {"finishReason":"length"}',
+            '',
+            '',
+          ].join('\n'),
+        ),
+      )
+      .mockResolvedValueOnce(
+        sseResponse(
+          [
+            'event: delta',
+            'data: {"delta":" third"}',
+            '',
+            'event: end',
+            'data: {"finishReason":"stop"}',
+            '',
+            '',
+          ].join('\n'),
+        ),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await streamMessageOpenAI(
+      {
+        mode: 'api',
+        apiKey: 'test-key',
+        baseUrl: 'https://example.test',
+        model: 'gpt-test',
+        agentId: null,
+        skillId: null,
+        designSystemId: null,
+      },
+      '',
+      [{ id: '1', role: 'user', content: 'hello' }],
+      new AbortController().signal,
+      handlers,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const [, thirdInit] = fetchMock.mock.calls[2] as unknown as [RequestInfo | URL, RequestInit];
+    const thirdBody = JSON.parse(String(thirdInit.body));
+    expect(thirdBody.messages).toHaveLength(3);
+    expect(thirdBody.messages[1]).toEqual({ role: 'assistant', content: 'first second' });
+    expect(thirdBody.messages[2].content).toContain('Continue exactly from where your previous response stopped');
+    expect(handlers.onError).not.toHaveBeenCalled();
+    expect(handlers.onDone).toHaveBeenCalledWith('first second third');
   });
 
   it('ignores comments and keeps delta/end behavior unchanged', async () => {

--- a/packages/contracts/src/api/proxy.ts
+++ b/packages/contracts/src/api/proxy.ts
@@ -46,4 +46,5 @@ export interface ProxyStreamDeltaPayload {
 
 export interface ProxyStreamEndPayload {
   code?: number;
+  finishReason?: string;
 }


### PR DESCRIPTION
Fixes #1709
Fixes #679
Fixes #722
Fixes #1174

## Why

BYOK API streams could stop mid-response when the upstream provider ended with a token-limit reason such as `finish_reason: "length"` or Anthropic `stop_reason: "max_tokens"`. I hit this through the upstream bug report for long-generation flows: Open Design treated the SSE `end` / transport EOF as a completed assistant turn, so users saw a successful but truncated answer with no automatic continuation.

This PR fixes that user-facing truncation path and keeps the response appended in one assistant message.

## What users will see

Long BYOK API-mode responses continue automatically when the provider reports an output-token truncation reason. The existing assistant message keeps streaming additional text until the provider returns a normal stop reason or another terminal state.

The continuation strategy is provider-aware:

- Anthropic-compatible streams use documented assistant prefill semantics, so the retry sends the accumulated assistant text as the trailing assistant turn.
- OpenAI-compatible, Azure, Gemini, and Ollama streams recover with an explicit follow-up user continuation request after the accumulated assistant text. That avoids relying on undocumented trailing-assistant/model prefill behavior while still recovering from `length` / token-limit terminations.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not a UI surface change.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/providers/sse.test.ts`, `apps/daemon/tests/proxy-routes.test.ts`
- Did the test go red on `main` and green on this branch? yes. The web regression test failed with one fetch instead of two before the fix; the daemon proxy tests emitted `event: end` with `{}` before the fix.

## Validation

- `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/providers/sse.test.ts`
- `pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/proxy-routes.test.ts`
- `pnpm --filter @open-design/contracts build`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/daemon typecheck`

Note: this workspace is running Node v26.0.0, so pnpm prints engine warnings because the repo requests Node `~24`; the commands above exited 0.
