### PR TITLE
Persist routine failure reasons

### DIFF
--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -189,6 +189,7 @@ function migrate(db: SqliteDb): void {
       completed_at INTEGER,
       summary TEXT,
       error TEXT,
+      error_code TEXT,
       FOREIGN KEY(routine_id) REFERENCES routines(id) ON DELETE CASCADE
     );
 
@@ -225,6 +226,10 @@ function migrate(db: SqliteDb): void {
   }
   if (!messageCols.some((c: DbRow) => c.name === 'feedback_json')) {
     db.exec(`ALTER TABLE messages ADD COLUMN feedback_json TEXT`);
+  }
+  const routineRunCols = db.prepare(`PRAGMA table_info(routine_runs)`).all() as DbRow[];
+  if (!routineRunCols.some((c: DbRow) => c.name === 'error_code')) {
+    db.exec(`ALTER TABLE routine_runs ADD COLUMN error_code TEXT`);
   }
 
   const previewCommentCols = db.prepare(`PRAGMA table_info(preview_comments)`).all() as DbRow[];
@@ -967,6 +972,29 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
   return row ? normalizeMessage(row) : null;
 }
 
+export function appendMessageStatusEvent(db: SqliteDb, messageId: string, event: DbRow) {
+  const label = typeof event?.label === 'string' ? event.label.trim() : '';
+  const detail = typeof event?.detail === 'string' ? event.detail.trim() : '';
+  if (!label) return null;
+  const row = db
+    .prepare(`SELECT events_json AS eventsJson FROM messages WHERE id = ?`)
+    .get(messageId) as DbRow | undefined;
+  if (!row) return null;
+  const parsed = parseJsonOrUndef(row.eventsJson);
+  const events = Array.isArray(parsed) ? parsed : [];
+  const last = events[events.length - 1];
+  if (last?.kind === 'status' && last.label === label && (last.detail ?? '') === detail) {
+    return events;
+  }
+  const nextEvent = detail
+    ? { kind: 'status', label, detail }
+    : { kind: 'status', label };
+  const next = [...events, nextEvent];
+  db.prepare(`UPDATE messages SET events_json = ? WHERE id = ?`)
+    .run(JSON.stringify(next), messageId);
+  return next;
+}
+
 export function deleteMessage(db: SqliteDb, id: string) {
   db.prepare(`DELETE FROM messages WHERE id = ?`).run(id);
 }
@@ -1230,7 +1258,7 @@ const ROUTINE_COLS = `id, name, prompt,
 const ROUTINE_RUN_COLS = `id, routine_id AS routineId, trigger, status,
   project_id AS projectId, conversation_id AS conversationId,
   agent_run_id AS agentRunId, started_at AS startedAt,
-  completed_at AS completedAt, summary, error`;
+  completed_at AS completedAt, summary, error, error_code AS errorCode`;
 
 export function listRoutines(db: SqliteDb) {
   return (db
@@ -1364,8 +1392,8 @@ export function insertRoutineRun(db: SqliteDb, r: DbRow) {
   db.prepare(
     `INSERT INTO routine_runs
        (id, routine_id, trigger, status, project_id, conversation_id,
-        agent_run_id, started_at, completed_at, summary, error)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        agent_run_id, started_at, completed_at, summary, error, error_code)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     r.id,
     r.routineId,
@@ -1378,6 +1406,7 @@ export function insertRoutineRun(db: SqliteDb, r: DbRow) {
     r.completedAt ?? null,
     r.summary ?? null,
     r.error ?? null,
+    r.errorCode ?? null,
   );
   return getRoutineRun(db, r.id);
 }
@@ -1391,13 +1420,14 @@ export function updateRoutineRun(db: SqliteDb, id: string, patch: DbRow) {
   };
   db.prepare(
     `UPDATE routine_runs
-        SET status = ?, completed_at = ?, summary = ?, error = ?
+        SET status = ?, completed_at = ?, summary = ?, error = ?, error_code = ?
       WHERE id = ?`,
   ).run(
     merged.status,
     merged.completedAt ?? null,
     merged.summary ?? null,
     merged.error ?? null,
+    merged.errorCode ?? null,
     id,
   );
   return getRoutineRun(db, id);
@@ -1416,6 +1446,7 @@ function normalizeRoutineRun(row: DbRow) {
     completedAt: row.completedAt == null ? null : Number(row.completedAt),
     summary: row.summary ?? null,
     error: row.error ?? null,
+    errorCode: row.errorCode ?? null,
   };
 }
 

--- a/apps/daemon/src/routine-routes.ts
+++ b/apps/daemon/src/routine-routes.ts
@@ -54,6 +54,8 @@ export function routineDbRowToContract(row: any, latestRun: any) {
         conversationId: latestRun.conversationId,
         agentRunId: latestRun.agentRunId,
         ...(latestRun.summary ? { summary: latestRun.summary } : {}),
+        ...(latestRun.error ? { error: latestRun.error } : {}),
+        ...(latestRun.errorCode ? { errorCode: latestRun.errorCode } : {}),
       }
     : null;
   return {

--- a/apps/daemon/src/routines.ts
+++ b/apps/daemon/src/routines.ts
@@ -61,6 +61,7 @@ export interface RoutineRun {
   completedAt: number | null;
   summary: string | null;
   error: string | null;
+  errorCode: string | null;
 }
 
 export interface RoutineRunHandlerStart {
@@ -74,6 +75,7 @@ export interface RoutineRunCompletion {
   status: RoutineRunStatus;
   summary?: string;
   error?: string;
+  errorCode?: string | null;
 }
 
 export type RoutineRunHandler = (input: {
@@ -507,6 +509,7 @@ export class RoutineService {
         completedAt: null,
         summary: null,
         error: null,
+        errorCode: null,
       });
       handlerStart.completion
         .then((completion) => {
@@ -515,6 +518,7 @@ export class RoutineService {
             completedAt: Date.now(),
             summary: completion.summary ?? null,
             error: completion.error ?? null,
+            errorCode: completion.errorCode ?? null,
           });
         })
         .catch((error) => {
@@ -523,6 +527,7 @@ export class RoutineService {
             completedAt: Date.now(),
             summary: null,
             error: error instanceof Error ? error.message : String(error),
+            errorCode: null,
           });
         });
       return handlerStart;

--- a/apps/daemon/src/runs.ts
+++ b/apps/daemon/src/runs.ts
@@ -3,6 +3,19 @@ import { randomUUID } from 'node:crypto';
 
 export const TERMINAL_RUN_STATUSES = new Set(['succeeded', 'failed', 'canceled']);
 
+function readString(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function extractErrorDetails(data) {
+  const payload = data && typeof data === 'object' ? data : {};
+  const nested = payload.error && typeof payload.error === 'object' ? payload.error : {};
+  return {
+    error: readString(nested.message) ?? readString(payload.message),
+    errorCode: readString(nested.code) ?? readString(payload.code),
+  };
+}
+
 export function createChatRunService({
   createSseResponse,
   createSseErrorPayload,
@@ -43,6 +56,8 @@ export function createChatRunService({
       acpSession: null,
       exitCode: null,
       signal: null,
+      error: null,
+      errorCode: null,
       cancelRequested: false,
     };
     runs.set(run.id, run);
@@ -58,6 +73,11 @@ export function createChatRunService({
   };
 
   const emit = (run, event, data) => {
+    if (event === 'error') {
+      const details = extractErrorDetails(data);
+      if (details.error) run.error = details.error;
+      if (details.errorCode) run.errorCode = details.errorCode;
+    }
     const id = run.nextEventId++;
     const record = { id, event, data, timestamp: Date.now() };
     run.events.push(record);
@@ -80,9 +100,11 @@ export function createChatRunService({
     updatedAt: run.updatedAt,
     exitCode: run.exitCode,
     signal: run.signal,
+    error: run.error ?? null,
+    errorCode: run.errorCode ?? null,
   });
 
-  const finish = (run, status, code = null, signal = null) => {
+  const finish = (run, status, code: number | null = null, signal: string | null = null) => {
     if (TERMINAL_RUN_STATUSES.has(run.status)) return;
     run.status = status;
     run.exitCode = code;

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -238,6 +238,7 @@ import {
 import { validateArtifactManifestInput } from './artifact-manifest.js';
 import { readCurrentAppVersionInfo } from './app-version.js';
 import {
+  appendMessageStatusEvent,
   deleteConversation,
   deletePreviewComment,
   deleteProject as dbDeleteProject,
@@ -2725,6 +2726,7 @@ export async function startServer({
         completedAt: run.completedAt,
         summary: run.summary,
         error: run.error,
+        errorCode: run.errorCode,
       });
     },
     updateRun: (id, patch) => {
@@ -9880,11 +9882,27 @@ export async function startServer({
 
     const completion = (async () => {
       const finalStatus = await design.runs.wait(run);
+      const failureError = finalStatus.status === 'failed'
+        ? (typeof finalStatus.error === 'string' && finalStatus.error.trim() ? finalStatus.error.trim() : null)
+        : null;
+      const failureErrorCode = finalStatus.status === 'failed'
+        ? (typeof finalStatus.errorCode === 'string' && finalStatus.errorCode.trim() ? finalStatus.errorCode.trim() : null)
+        : null;
+      if (failureError) {
+        appendMessageStatusEvent(db, assistantMessageId, {
+          label: 'error',
+          detail: failureError,
+        });
+      }
       db.prepare(`UPDATE messages SET run_status = ?, ended_at = ? WHERE id = ?`)
         .run(finalStatus.status, Date.now(), assistantMessageId);
       return {
         status: finalStatus.status,
-        summary: `Routine "${routine.name}" ${finalStatus.status}.`,
+        summary: failureError
+          ? `Routine "${routine.name}" failed: ${failureError}`
+          : `Routine "${routine.name}" ${finalStatus.status}.`,
+        error: failureError ?? undefined,
+        errorCode: failureErrorCode ?? undefined,
       };
     })();
 

--- a/apps/daemon/tests/db-message-events.test.ts
+++ b/apps/daemon/tests/db-message-events.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  appendMessageStatusEvent,
+  closeDatabase,
+  insertConversation,
+  insertProject,
+  listMessages,
+  openDatabase,
+  upsertMessage,
+} from '../src/db.js';
+
+describe('message event persistence', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), 'od-db-message-events-'));
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('appends deduplicated failure status events to assistant messages', () => {
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    const now = Date.now();
+    insertProject(db, {
+      id: 'proj-1',
+      name: 'Routine project',
+      createdAt: now,
+      updatedAt: now,
+    });
+    insertConversation(db, {
+      id: 'conv-1',
+      projectId: 'proj-1',
+      title: 'Routine run',
+      createdAt: now,
+      updatedAt: now,
+    });
+    upsertMessage(db, 'conv-1', {
+      id: 'assistant-1',
+      role: 'assistant',
+      content: '',
+      runId: 'agent-run-1',
+      runStatus: 'running',
+      events: [{ kind: 'status', label: 'starting', detail: 'Codex' }],
+      startedAt: now,
+    });
+
+    appendMessageStatusEvent(db, 'assistant-1', {
+      label: 'error',
+      detail: 'Agent stalled without emitting any new output for 1s.',
+    });
+    appendMessageStatusEvent(db, 'assistant-1', {
+      label: 'error',
+      detail: 'Agent stalled without emitting any new output for 1s.',
+    });
+
+    expect(listMessages(db, 'conv-1')[0]?.events).toEqual([
+      { kind: 'status', label: 'starting', detail: 'Codex' },
+      {
+        kind: 'status',
+        label: 'error',
+        detail: 'Agent stalled without emitting any new output for 1s.',
+      },
+    ]);
+  });
+});

--- a/apps/daemon/tests/routine-routes.test.ts
+++ b/apps/daemon/tests/routine-routes.test.ts
@@ -284,6 +284,7 @@ describe('routine routes', () => {
         completedAt: Date.now(),
         summary: 'Connector auth failed',
         error: 'provider rejected credentials',
+        errorCode: 'AGENT_AUTH_REQUIRED',
       });
 
       const getRes = await fetch(`http://127.0.0.1:${port}/api/routines/${created.routine.id}`);
@@ -298,6 +299,8 @@ describe('routine routes', () => {
             conversationId: string;
             agentRunId: string;
             summary: string;
+            error: string;
+            errorCode: string;
             completedAt: number;
           } | null;
         };
@@ -310,6 +313,8 @@ describe('routine routes', () => {
         conversationId: 'conv-failed',
         agentRunId: 'agent-run-failed',
         summary: 'Connector auth failed',
+        error: 'provider rejected credentials',
+        errorCode: 'AGENT_AUTH_REQUIRED',
       });
       expect(json.routine.lastRun?.completedAt).toBeTypeOf('number');
     } finally {

--- a/apps/daemon/tests/runs.test.ts
+++ b/apps/daemon/tests/runs.test.ts
@@ -4,6 +4,33 @@ import { describe, expect, it, vi } from 'vitest';
 import { createChatRunService } from '../src/runs.js';
 
 describe('chat run service shutdown', () => {
+  it('retains structured error details on failed run status bodies', async () => {
+    const runs = createRuns();
+    const run = runs.create({ projectId: 'project-1', conversationId: 'conv-1' });
+
+    const wait = runs.wait(run);
+    runs.emit(run, 'error', {
+      message: 'Agent stalled without emitting any new output for 1s.',
+      error: {
+        code: 'AGENT_EXECUTION_FAILED',
+        message: 'Agent stalled without emitting any new output for 1s.',
+        retryable: true,
+      },
+    });
+    runs.finish(run, 'failed', 1, null);
+
+    expect(runs.statusBody(run)).toMatchObject({
+      status: 'failed',
+      errorCode: 'AGENT_EXECUTION_FAILED',
+      error: 'Agent stalled without emitting any new output for 1s.',
+    });
+    await expect(wait).resolves.toMatchObject({
+      status: 'failed',
+      errorCode: 'AGENT_EXECUTION_FAILED',
+      error: 'Agent stalled without emitting any new output for 1s.',
+    });
+  });
+
   it('filters active runs by conversation within the same project', () => {
     const runs = createRuns();
     const runA = runs.create({ projectId: 'project-1', conversationId: 'conv-a' });

--- a/apps/web/src/components/RoutinesSection.tsx
+++ b/apps/web/src/components/RoutinesSection.tsx
@@ -167,6 +167,16 @@ function formatRunTimestamp(ts: number): string {
   });
 }
 
+function runFailureReason(run: {
+  status: RoutineRun['status'];
+  error?: string | null;
+  summary?: string | null;
+} | null | undefined): string | null {
+  if (!run || run.status !== 'failed') return null;
+  const reason = (run.error || run.summary || '').trim();
+  return reason || null;
+}
+
 type FormState = {
   name: string;
   prompt: string;
@@ -367,38 +377,44 @@ function RunHistory({ routineId, refreshKey, onClose }: { routineId: string; ref
 
   return (
     <ul className="routines-history">
-      {runs.map((r) => (
-        <li key={r.id} className="routines-history-row">
-          <StatusPill status={r.status} />
-          <span className="routines-history-time">{formatRunTimestamp(r.startedAt)}</span>
-          <span className="routines-history-trigger">
-            {r.trigger === 'manual' ? 'manual' : 'scheduled'}
-          </span>
-          <button
-            type="button"
-            className="routines-history-link"
-            onClick={() => {
-              // Issue #1505: deep-link to this run's specific
-              // conversation, not just the project root. Without the
-              // conversation id, parallel runs that share a project
-              // (reuse mode) all resolve to the same default
-              // conversation in the project view, which made earlier
-              // runs look "absorbed" by the latest one.
-              navigate({
-                kind: 'project',
-                projectId: r.projectId,
-                conversationId: r.conversationId ?? null,
-                fileName: null,
-              });
-              onClose?.();
-            }}
-            title="Open the project this run wrote to"
-          >
-            Open project
-            <Icon name="chevron-right" size={12} />
-          </button>
-        </li>
-      ))}
+      {runs.map((r) => {
+        const failureReason = runFailureReason(r);
+        return (
+          <li key={r.id} className="routines-history-row">
+            <StatusPill status={r.status} />
+            <span className="routines-history-time">{formatRunTimestamp(r.startedAt)}</span>
+            <span className="routines-history-trigger">
+              {r.trigger === 'manual' ? 'manual' : 'scheduled'}
+            </span>
+            <button
+              type="button"
+              className="routines-history-link"
+              onClick={() => {
+                // Issue #1505: deep-link to this run's specific
+                // conversation, not just the project root. Without the
+                // conversation id, parallel runs that share a project
+                // (reuse mode) all resolve to the same default
+                // conversation in the project view, which made earlier
+                // runs look "absorbed" by the latest one.
+                navigate({
+                  kind: 'project',
+                  projectId: r.projectId,
+                  conversationId: r.conversationId ?? null,
+                  fileName: null,
+                });
+                onClose?.();
+              }}
+              title="Open the project this run wrote to"
+            >
+              Open project
+              <Icon name="chevron-right" size={12} />
+            </button>
+            {failureReason ? (
+              <div className="routines-history-error">{failureReason}</div>
+            ) : null}
+          </li>
+        );
+      })}
     </ul>
   );
 }
@@ -695,6 +711,7 @@ export function RoutinesSection({ onClose }: RoutinesSectionProps) {
                 : '→ new project each run';
             const isBusy = busyId === r.id;
             const isExpanded = expandedId === r.id;
+            const failureReason = runFailureReason(r.lastRun);
             return (
               <li key={r.id} className={`routines-card routines-item${r.enabled ? '' : ' is-disabled'}`}>
                 <div className="routines-item-head">
@@ -720,6 +737,9 @@ export function RoutinesSection({ onClose }: RoutinesSectionProps) {
                         </>
                       ) : null}
                     </div>
+                    {failureReason ? (
+                      <div className="routines-item-error">{failureReason}</div>
+                    ) : null}
                   </div>
                   <div className="routines-item-actions">
                     <button

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -22887,6 +22887,12 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   gap: 6px;
   align-items: center;
 }
+.routines-item-error {
+  color: #b3382b;
+  font-size: 12px;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
 .routines-tag {
   font-size: 11px;
   background: var(--bg-muted);
@@ -22924,6 +22930,12 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.06em;
+}
+.routines-history-error {
+  grid-column: 1 / -1;
+  color: #b3382b;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
 }
 .routines-history-link {
   background: transparent;

--- a/apps/web/tests/components/RoutinesSection.test.tsx
+++ b/apps/web/tests/components/RoutinesSection.test.tsx
@@ -426,6 +426,85 @@ describe('RoutinesSection', () => {
     );
   });
 
+  it('shows persisted failure reasons in the last-run summary and history', async () => {
+    const failure = 'Agent stalled without emitting any new output for 1s.';
+    const routines: Routine[] = [{
+      id: 'routine-1',
+      name: 'Morning briefing',
+      prompt: 'Morning summary',
+      schedule: { kind: 'daily', time: '09:00', timezone: 'UTC' },
+      target: { mode: 'create_each_run' },
+      skillId: null,
+      agentId: null,
+      enabled: true,
+      nextRunAt: Date.now() + 3600_000,
+      lastRun: {
+        runId: 'run-failed-1',
+        status: 'failed',
+        trigger: 'scheduled',
+        startedAt: Date.now() - 1000,
+        completedAt: Date.now(),
+        projectId: 'proj-run',
+        conversationId: 'conv-run',
+        agentRunId: 'agent-run-1',
+        error: failure,
+        errorCode: 'AGENT_EXECUTION_FAILED',
+      },
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    }];
+
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url === '/api/routines' && (!init || init.method === undefined)) {
+        return new Response(JSON.stringify({ routines }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url === '/api/projects' && (!init || init.method === undefined)) {
+        return new Response(JSON.stringify({ projects: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url === '/api/routines/routine-1/runs?limit=10') {
+        return new Response(JSON.stringify({
+          runs: [
+            {
+              id: 'run-failed-1',
+              routineId: 'routine-1',
+              trigger: 'scheduled',
+              status: 'failed',
+              projectId: 'proj-run',
+              conversationId: 'conv-run',
+              agentRunId: 'agent-run-1',
+              startedAt: Date.now() - 1000,
+              completedAt: Date.now(),
+              summary: null,
+              error: failure,
+              errorCode: 'AGENT_EXECUTION_FAILED',
+            },
+          ],
+        }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({}), { status: 404 });
+    }) as typeof fetch;
+
+    render(<RoutinesSection />);
+
+    const row = (await screen.findByText('Morning briefing')).closest('li')!;
+    expect(within(row).getByText(failure)).toBeTruthy();
+
+    fireEvent.click(within(row).getByRole('button', { name: 'History' }));
+    await waitFor(() => {
+      expect(screen.getAllByText(failure)).toHaveLength(2);
+    });
+  });
+
   it('shows the empty history state when a routine has never run', async () => {
     const routines = [{
       id: 'routine-1',

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -85,6 +85,8 @@ export interface ChatRunStatusResponse {
   updatedAt: number;
   exitCode?: number | null;
   signal?: string | null;
+  error?: string | null;
+  errorCode?: string | null;
 }
 
 export interface ChatRunListResponse {

--- a/packages/contracts/src/api/routines.ts
+++ b/packages/contracts/src/api/routines.ts
@@ -81,6 +81,8 @@ export interface RoutineLastRunSummary {
   conversationId: string;
   agentRunId: string;
   summary?: string;
+  error?: string;
+  errorCode?: string;
 }
 
 export interface Routine {
@@ -110,6 +112,7 @@ export interface RoutineRun {
   completedAt: number | null;
   summary: string | null;
   error: string | null;
+  errorCode: string | null;
 }
 
 export interface CreateRoutineRequest {


### PR DESCRIPTION
## Summary
- Persist structured chat run failures (`error` and `errorCode`) through routine run history, including inactivity watchdog failures and agent auth/execution errors.
- Surface failure reasons in routine last-run summaries and history rows.
- Persist a deduplicated error status event onto routine assistant messages so unattended failed runs remain diagnosable in the project conversation view.

Closes #1642.
Closes #1631.

## Test Plan
- `pnpm exec vitest run -c vitest.config.ts tests/runs.test.ts tests/routine-routes.test.ts tests/db-message-events.test.ts` from `apps/daemon`
- `pnpm exec vitest run -c vitest.config.ts tests/components/RoutinesSection.test.tsx` from `apps/web`
- `pnpm --filter @open-design/contracts typecheck`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
