### PR TITLE
Fix Inspect preview transport flash

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -58,7 +58,7 @@ import {
   requestPreviewSnapshot,
 } from '../runtime/exports';
 import { buildReactComponentSrcdoc } from '../runtime/react-component';
-import { buildSrcdoc } from '../runtime/srcdoc';
+import { buildLazySrcdocTransport, buildSrcdoc } from '../runtime/srcdoc';
 import {
   hasUrlModeBridge,
   htmlNeedsSandboxShim,
@@ -3502,6 +3502,7 @@ function HtmlViewer({
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const urlPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);
   const srcDocPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);
+  const activatedSrcDocTransportHtmlRef = useRef<string | null>(null);
   const isActivePreviewIframeSource = useCallback((source: MessageEventSource | null) => {
     return !!source && source === iframeRef.current?.contentWindow;
   }, []);
@@ -3951,6 +3952,36 @@ function HtmlViewer({
     }) : ''),
     [previewSource, effectiveDeck, projectId, file.name, previewStateKey, manualEditMode, selectedPalette],
   );
+  const lazySrcDocTransport = useMemo(() => buildLazySrcdocTransport(), []);
+  const [hasLazySrcDocTransport, setHasLazySrcDocTransport] = useState(useUrlLoadPreview);
+  const [srcDocTransportResetKey, setSrcDocTransportResetKey] = useState(0);
+  const wasUrlLoadPreviewRef = useRef(useUrlLoadPreview);
+  useEffect(() => {
+    if (useUrlLoadPreview) setHasLazySrcDocTransport(true);
+  }, [useUrlLoadPreview]);
+  const useLazySrcDocTransport = useUrlLoadPreview || hasLazySrcDocTransport;
+  const srcDocTransportContent = useLazySrcDocTransport ? lazySrcDocTransport : srcDoc;
+  const urlTransportSrc = useUrlLoadPreview ? previewSrcUrl : 'about:blank';
+  const activateSrcDocTransport = useCallback((target: HTMLIFrameElement | null = srcDocPreviewIframeRef.current) => {
+    const win = target?.contentWindow;
+    if (!win || !srcDoc || useUrlLoadPreview || !useLazySrcDocTransport) return false;
+    if (activatedSrcDocTransportHtmlRef.current === srcDoc) return false;
+    win.postMessage({ type: 'od:srcdoc-transport-activate', html: srcDoc }, '*');
+    activatedSrcDocTransportHtmlRef.current = srcDoc;
+    return true;
+  }, [srcDoc, useLazySrcDocTransport, useUrlLoadPreview]);
+  useEffect(() => {
+    if (useUrlLoadPreview) {
+      activatedSrcDocTransportHtmlRef.current = null;
+      if (!wasUrlLoadPreviewRef.current) {
+        setSrcDocTransportResetKey((key) => key + 1);
+      }
+      wasUrlLoadPreviewRef.current = true;
+      return;
+    }
+    wasUrlLoadPreviewRef.current = false;
+    activateSrcDocTransport();
+  }, [activateSrcDocTransport, useUrlLoadPreview]);
   useEffect(() => {
     restorePreviewScrollPosition();
   }, [boardMode, manualEditMode, srcDoc, restorePreviewScrollPosition]);
@@ -5875,7 +5906,7 @@ function HtmlViewer({
                       tabIndex={useUrlLoadPreview ? 0 : -1}
                       title={file.name}
                       sandbox="allow-scripts allow-downloads"
-                      src={previewSrcUrl}
+                      src={urlTransportSrc}
                       onLoad={() => {
                         const frame = urlPreviewIframeRef.current;
                         if (useUrlLoadPreview) iframeRef.current = frame;
@@ -5889,6 +5920,7 @@ function HtmlViewer({
                       }}
                     />
                     <iframe
+                      key={srcDocTransportResetKey}
                       ref={srcDocPreviewIframeRef}
                       data-testid={useUrlLoadPreview ? 'artifact-preview-frame-srcdoc' : 'artifact-preview-frame'}
                       data-od-render-mode="srcdoc"
@@ -5897,10 +5929,11 @@ function HtmlViewer({
                       tabIndex={useUrlLoadPreview ? -1 : 0}
                       title={file.name}
                       sandbox="allow-scripts allow-downloads"
-                      srcDoc={srcDoc}
+                      srcDoc={srcDocTransportContent}
                       onLoad={() => {
                         const frame = srcDocPreviewIframeRef.current;
                         if (!useUrlLoadPreview) iframeRef.current = frame;
+                        activateSrcDocTransport(frame);
                         dcViewportRestoreAtRef.current = Date.now();
                         frame?.contentWindow?.postMessage({
                           type: '__dc_set_viewport',

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -3500,6 +3500,19 @@ function HtmlViewer({
   const [manualEditViewportWidth, setManualEditViewportWidth] = useState<number | null>(null);
   const [previewBodyRef, previewBodySize] = usePreviewCanvasSize<HTMLDivElement>();
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const urlPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);
+  const srcDocPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);
+  const isActivePreviewIframeSource = useCallback((source: MessageEventSource | null) => {
+    return !!source && source === iframeRef.current?.contentWindow;
+  }, []);
+  const isOurPreviewIframeSource = useCallback((source: MessageEventSource | null) => {
+    if (!source) return false;
+    return (
+      source === iframeRef.current?.contentWindow ||
+      source === urlPreviewIframeRef.current?.contentWindow ||
+      source === srcDocPreviewIframeRef.current?.contentWindow
+    );
+  }, []);
   const previewScrollRestoreRef = useRef<{
     hostLeft: number;
     hostTop: number;
@@ -3896,14 +3909,16 @@ function HtmlViewer({
   useEffect(() => {
     setPreviewSrcUrl(basePreviewSrcUrl);
   }, [basePreviewSrcUrl]);
+  useEffect(() => {
+    iframeRef.current = useUrlLoadPreview ? urlPreviewIframeRef.current : srcDocPreviewIframeRef.current;
+  }, [useUrlLoadPreview]);
 
   useEffect(() => {
-    if (!useUrlLoadPreview) return;
     if (filesRefreshKey === 0) return;
     const nextSrc = `${basePreviewSrcUrl}&fr=${filesRefreshKey}`;
     const timeout = window.setTimeout(() => {
-      if (iframeRef.current?.contentWindow) {
-        iframeRef.current.contentWindow.location.replace(nextSrc);
+      if (useUrlLoadPreview && urlPreviewIframeRef.current?.contentWindow) {
+        urlPreviewIframeRef.current.contentWindow.location.replace(nextSrc);
       } else {
         setPreviewSrcUrl(nextSrc);
       }
@@ -3929,13 +3944,12 @@ function HtmlViewer({
       deck: effectiveDeck,
       baseHref: projectRawUrl(projectId, baseDirFor(file.name)),
       initialSlideIndex: htmlPreviewSlideState.get(previewStateKey)?.active ?? 0,
-      commentBridge: (boardMode && !manualEditMode) || drawClickSelectionMode,
-      inspectBridge: inspectMode,
+      selectionBridge: true,
       editBridge: manualEditMode,
       paletteBridge: true,
       initialPalette: selectedPalette,
     }) : ''),
-    [previewSource, effectiveDeck, projectId, file.name, previewStateKey, boardMode, manualEditMode, drawClickSelectionMode, inspectMode, selectedPalette],
+    [previewSource, effectiveDeck, projectId, file.name, previewStateKey, manualEditMode, selectedPalette],
   );
   useEffect(() => {
     restorePreviewScrollPosition();
@@ -3943,7 +3957,8 @@ function HtmlViewer({
 
   useEffect(() => {
     function onMessage(ev: MessageEvent) {
-      if (ev.source !== iframeRef.current?.contentWindow) return;
+      if (!isOurPreviewIframeSource(ev.source)) return;
+      if (!isActivePreviewIframeSource(ev.source)) return;
       const data = ev.data as {
         type?: string;
         frameLeft?: number;
@@ -3968,7 +3983,8 @@ function HtmlViewer({
       };
     }
     function onRestoreRequest(ev: MessageEvent) {
-      if (ev.source !== iframeRef.current?.contentWindow) return;
+      if (!isOurPreviewIframeSource(ev.source)) return;
+      if (!isActivePreviewIframeSource(ev.source)) return;
       const data = ev.data as { type?: string } | null;
       if (!data || data.type !== 'od:preview-scroll-request') return;
       previewScrollRequestAtRef.current = Date.now();
@@ -3988,7 +4004,8 @@ function HtmlViewer({
       }, '*');
     }
     function onDcViewportMessage(ev: MessageEvent) {
-      if (ev.source !== iframeRef.current?.contentWindow) return;
+      if (!isOurPreviewIframeSource(ev.source)) return;
+      if (!isActivePreviewIframeSource(ev.source)) return;
       const data = ev.data as {
         type?: string;
         x?: number;
@@ -4026,7 +4043,7 @@ function HtmlViewer({
       window.removeEventListener('message', onRestoreRequest);
       window.removeEventListener('message', onDcViewportMessage);
     };
-  }, []);
+  }, [isActivePreviewIframeSource, isOurPreviewIframeSource]);
 
   useEffect(() => {
     if (!effectiveDeck) {
@@ -4035,7 +4052,8 @@ function HtmlViewer({
     }
     setSlideState(htmlPreviewSlideState.get(previewStateKey) ?? null);
     function onMessage(ev: MessageEvent) {
-      if (ev.source !== iframeRef.current?.contentWindow) return;
+      if (!isOurPreviewIframeSource(ev.source)) return;
+      if (!isActivePreviewIframeSource(ev.source)) return;
       const data = ev?.data as
         | { type?: string; active?: number; count?: number }
         | null;
@@ -4047,7 +4065,7 @@ function HtmlViewer({
     }
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, [effectiveDeck, previewStateKey]);
+  }, [effectiveDeck, isActivePreviewIframeSource, isOurPreviewIframeSource, previewStateKey]);
 
   useEffect(() => {
     const win = iframeRef.current?.contentWindow;
@@ -4073,14 +4091,14 @@ function HtmlViewer({
     return true;
   }, []);
 
-  function postSelectedManualEditTargetToIframe(id: string | null) {
-    const win = iframeRef.current?.contentWindow;
+  function postSelectedManualEditTargetToIframe(id: string | null, target: HTMLIFrameElement | null = iframeRef.current) {
+    const win = target?.contentWindow;
     if (!win) return;
     win.postMessage({ type: 'od-edit-selected-target', id }, '*');
   }
 
-  function syncBridgeModes() {
-    const win = iframeRef.current?.contentWindow;
+  function syncBridgeModes(target: HTMLIFrameElement | null = iframeRef.current) {
+    const win = target?.contentWindow;
     if (!win) return;
     win.postMessage({
       type: 'od:comment-mode',
@@ -4088,7 +4106,10 @@ function HtmlViewer({
       mode: drawClickSelectionMode ? 'picker' : boardTool,
     }, '*');
     win.postMessage({ type: 'od-edit-mode', enabled: manualEditMode }, '*');
-    postSelectedManualEditTargetToIframe(manualEditMode ? selectedManualEditTarget?.id ?? null : null);
+    postSelectedManualEditTargetToIframe(manualEditMode ? selectedManualEditTarget?.id ?? null : null, target);
+    win.postMessage({ type: 'od:inspect-mode', enabled: inspectMode }, '*');
+    const palette = previewPalette ?? selectedPalette;
+    win.postMessage({ type: 'od:palette', palette }, '*');
   }
 
   useEffect(() => {
@@ -4121,7 +4142,7 @@ function HtmlViewer({
       return;
     }
     function onMessage(ev: MessageEvent) {
-      if (ev.source !== iframeRef.current?.contentWindow) return;
+      if (!isOurPreviewIframeSource(ev.source)) return;
       const data = ev.data as
         | {
             type?: string;
@@ -4154,7 +4175,7 @@ function HtmlViewer({
     }
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, [inspectMode, boardMode, drawClickSelectionMode, file.name]);
+  }, [inspectMode, boardMode, drawClickSelectionMode, file.name, isOurPreviewIframeSource]);
 
   useEffect(() => {
     setActiveCommentTarget(null);
@@ -4251,7 +4272,7 @@ function HtmlViewer({
       podMembers: Array.isArray(data.podMembers) ? data.podMembers : undefined,
     });
     function onMessage(ev: MessageEvent) {
-      if (ev.source !== iframeRef.current?.contentWindow) return;
+      if (!isOurPreviewIframeSource(ev.source)) return;
       const data = ev.data as (Partial<PreviewCommentSnapshot> & {
         type?: string;
         targets?: Array<Partial<PreviewCommentSnapshot>>;
@@ -4348,7 +4369,7 @@ function HtmlViewer({
     }
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, [boardMode, drawClickSelectionMode, file.name, previewComments]);
+  }, [boardMode, drawClickSelectionMode, file.name, isOurPreviewIframeSource, previewComments]);
 
   useEffect(() => {
     if (!manualEditMode) {
@@ -4363,7 +4384,7 @@ function HtmlViewer({
       return;
     }
     function onMessage(ev: MessageEvent) {
-      if (ev.source !== iframeRef.current?.contentWindow) return;
+      if (!isOurPreviewIframeSource(ev.source)) return;
       const data = ev.data as ManualEditBridgeMessage | null;
       if (!data?.type) return;
       if (data.type === 'od-edit-targets' && Array.isArray(data.targets)) {
@@ -4385,7 +4406,7 @@ function HtmlViewer({
     }
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, [manualEditMode, source]);
+  }, [isOurPreviewIframeSource, manualEditMode, source]);
 
   function nextManualEditPreviewVersion(): number {
     manualEditPreviewVersionRef.current += 1;
@@ -4645,7 +4666,7 @@ function HtmlViewer({
   useEffect(() => {
     if (!inspectMode) return;
     function onMessage(ev: MessageEvent) {
-      if (ev.source !== iframeRef.current?.contentWindow) return;
+      if (!isOurPreviewIframeSource(ev.source)) return;
       const data = ev.data as
         | { type?: string; elementId?: string; selector?: string; label?: string; text?: string; style?: InspectStyleSnapshot }
         | null;
@@ -4663,7 +4684,7 @@ function HtmlViewer({
     }
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, [inspectMode]);
+  }, [inspectMode, isOurPreviewIframeSource]);
 
   function postSlide(action: 'next' | 'prev' | 'first' | 'last') {
     const win = iframeRef.current?.contentWindow;
@@ -4706,8 +4727,8 @@ function HtmlViewer({
   // the bridge's DOM-hydrated one and silently strip the persisted styles
   // from preview. Re-derive synchronously from `source` whenever the
   // hydration ref disagrees so onLoad never sends a stale snapshot.
-  function replayInspectOverridesToIframe() {
-    const win = iframeRef.current?.contentWindow;
+  function replayInspectOverridesToIframe(target: HTMLIFrameElement | null = iframeRef.current) {
+    const win = target?.contentWindow;
     if (!win) return;
     const overrides = inspectHydratedSourceRef.current === source
       ? inspectOverrides
@@ -5844,46 +5865,53 @@ function HtmlViewer({
                   sendDisabled={streaming}
                   sendDisabledReason="当前正有任务在执行"
                 >
-                  {useUrlLoadPreview ? (
+                  <div className="artifact-preview-transport-stack">
                     <iframe
-                      ref={iframeRef}
-                      data-testid="artifact-preview-frame"
+                      ref={urlPreviewIframeRef}
+                      data-testid={useUrlLoadPreview ? 'artifact-preview-frame' : 'artifact-preview-frame-url-load'}
                       data-od-render-mode="url-load"
+                      data-od-active={useUrlLoadPreview ? 'true' : 'false'}
+                      aria-hidden={useUrlLoadPreview ? undefined : true}
+                      tabIndex={useUrlLoadPreview ? 0 : -1}
                       title={file.name}
                       sandbox="allow-scripts allow-downloads"
                       src={previewSrcUrl}
                       onLoad={() => {
+                        const frame = urlPreviewIframeRef.current;
+                        if (useUrlLoadPreview) iframeRef.current = frame;
                         dcViewportRestoreAtRef.current = Date.now();
-                        iframeRef.current?.contentWindow?.postMessage({
+                        frame?.contentWindow?.postMessage({
                           type: '__dc_set_viewport',
                           ...dcViewportRef.current,
                         }, '*');
-                        syncBridgeModes();
-                        restorePreviewScrollPosition();
+                        syncBridgeModes(frame);
+                        if (useUrlLoadPreview) restorePreviewScrollPosition();
                       }}
-                      style={{ width: '100%', height: '100%', border: 0 }}
                     />
-                  ) : (
                     <iframe
-                      ref={iframeRef}
-                      data-testid="artifact-preview-frame"
+                      ref={srcDocPreviewIframeRef}
+                      data-testid={useUrlLoadPreview ? 'artifact-preview-frame-srcdoc' : 'artifact-preview-frame'}
                       data-od-render-mode="srcdoc"
+                      data-od-active={useUrlLoadPreview ? 'false' : 'true'}
+                      aria-hidden={useUrlLoadPreview ? true : undefined}
+                      tabIndex={useUrlLoadPreview ? -1 : 0}
                       title={file.name}
                       sandbox="allow-scripts allow-downloads"
                       srcDoc={srcDoc}
                       onLoad={() => {
+                        const frame = srcDocPreviewIframeRef.current;
+                        if (!useUrlLoadPreview) iframeRef.current = frame;
                         dcViewportRestoreAtRef.current = Date.now();
-                        iframeRef.current?.contentWindow?.postMessage({
+                        frame?.contentWindow?.postMessage({
                           type: '__dc_set_viewport',
                           ...dcViewportRef.current,
                         }, '*');
-                        replayInspectOverridesToIframe();
-                        syncBridgeModes();
-                        restorePreviewScrollPosition();
+                        replayInspectOverridesToIframe(frame);
+                        syncBridgeModes(frame);
+                        if (!useUrlLoadPreview) restorePreviewScrollPosition();
                       }}
-                      style={{ width: '100%', height: '100%', border: 0 }}
                     />
-                  )}
+                  </div>
                 </PreviewDrawOverlay>
               </div>
             </div>

--- a/apps/web/src/components/PreviewDrawOverlay.tsx
+++ b/apps/web/src/components/PreviewDrawOverlay.tsx
@@ -138,6 +138,13 @@ export function PreviewDrawOverlay({
     return { x: e.clientX - rect.left, y: e.clientY - rect.top };
   }
 
+  function activePreviewIframe(): HTMLIFrameElement | null {
+    return (
+      wrapRef.current?.querySelector<HTMLIFrameElement>('iframe[data-od-active="true"]') ??
+      wrapRef.current?.querySelector<HTMLIFrameElement>('iframe')
+    ) ?? null;
+  }
+
   function onPointerDown(e: PointerEvent) {
     if (mode !== 'draw' || sending) return;
     (e.target as Element).setPointerCapture?.(e.pointerId);
@@ -161,7 +168,7 @@ export function PreviewDrawOverlay({
 
   function onCanvasWheel(e: WheelEvent<HTMLCanvasElement>) {
     if (mode !== 'draw' || sending) return;
-    const iframe = wrapRef.current?.querySelector('iframe');
+    const iframe = activePreviewIframe();
     const win = iframe?.contentWindow;
     if (!win || typeof win.scrollBy !== 'function') return;
     e.preventDefault();
@@ -223,7 +230,7 @@ export function PreviewDrawOverlay({
   }
 
   async function requestSnapshot(): Promise<{ dataUrl: string; w: number; h: number } | null> {
-    const iframe = wrapRef.current?.querySelector('iframe') as HTMLIFrameElement | null;
+    const iframe = activePreviewIframe();
     if (!iframe) return null;
     return requestPreviewSnapshot(iframe);
   }
@@ -270,7 +277,7 @@ export function PreviewDrawOverlay({
   }
 
   async function compositeWithBackground(snap: { dataUrl: string; w: number; h: number }): Promise<Blob | null> {
-    const iframe = wrapRef.current?.querySelector('iframe');
+    const iframe = activePreviewIframe();
     if (!iframe) return null;
     const rect = iframe.getBoundingClientRect();
     const out = document.createElement('canvas');

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -10646,6 +10646,20 @@ button.connector-action.is-loading {
   border: none;
   background: white;
 }
+.artifact-preview-transport-stack {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+.artifact-preview-transport-stack iframe {
+  position: absolute;
+  inset: 0;
+}
+.artifact-preview-transport-stack iframe[data-od-active='false'] {
+  visibility: hidden;
+  pointer-events: none;
+}
 .viewer-viewport-switcher {
   position: relative;
   display: inline-flex;

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -27,6 +27,7 @@ export type SrcdocOptions = {
   initialSlideIndex?: number;
   commentBridge?: boolean;
   inspectBridge?: boolean;
+  selectionBridge?: boolean;
   editBridge?: boolean;
   paletteBridge?: boolean;
   initialPalette?: string | null;
@@ -61,7 +62,7 @@ export function buildSrcdoc(
   // active — without that initial seed there is a window after each
   // srcdoc rebuild where the host's `od:*-mode` postMessage races the
   // bridge's own listener install and the iframe ignores clicks.
-  const withSelection = options.commentBridge || options.inspectBridge
+  const withSelection = options.selectionBridge || options.commentBridge || options.inspectBridge
     ? injectSelectionBridge(withDeck, {
         initialCommentMode: !!options.commentBridge,
         initialInspectMode: !!options.inspectBridge,

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -72,7 +72,40 @@ export function buildSrcdoc(
     ? injectPaletteBridge(withSelection, { initialPalette: options.initialPalette ?? null })
     : withSelection;
   const withEdit = options.editBridge ? injectManualEditBridge(withPalette) : withPalette;
-  return injectSnapshotBridge(withEdit);
+  return injectSrcdocTransportActivationBridge(injectSnapshotBridge(withEdit));
+}
+
+export function buildLazySrcdocTransport(): string {
+  return `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script data-od-lazy-srcdoc-transport>(function(){
+      window.addEventListener('message', function(ev){
+        var data = ev && ev.data;
+        if (!data || data.type !== 'od:srcdoc-transport-activate' || typeof data.html !== 'string') return;
+        document.open();
+        document.write(data.html);
+        document.close();
+      });
+    })();</script>
+  </head>
+  <body></body>
+</html>`;
+}
+
+function injectSrcdocTransportActivationBridge(doc: string): string {
+  const script = `<script data-od-srcdoc-transport-activation>(function(){
+  window.addEventListener('message', function(ev){
+    var data = ev && ev.data;
+    if (!data || data.type !== 'od:srcdoc-transport-activate' || typeof data.html !== 'string') return;
+    document.open();
+    document.write(data.html);
+    document.close();
+  });
+})();</script>`;
+  return injectBeforeBodyEnd(doc, script);
 }
 
 function injectSnapshotBridge(doc: string): string {

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -66,6 +66,16 @@ function deferredResponse() {
   return { promise, resolve };
 }
 
+function srcDocActivationMessages(calls: readonly (readonly unknown[])[]) {
+  return calls
+    .map(([message]) => message)
+    .filter((message): message is { type: 'od:srcdoc-transport-activate'; html: string } => {
+      if (typeof message !== 'object' || message === null) return false;
+      const data = message as { type?: unknown; html?: unknown };
+      return data.type === 'od:srcdoc-transport-activate' && typeof data.html === 'string';
+    });
+}
+
 describe('FileViewer preview scale', () => {
   it('uses the requested zoom for desktop preview overlays', () => {
     expect(effectivePreviewScale('desktop', 1.5, { width: 320, height: 480 })).toBe(1.5);
@@ -365,7 +375,7 @@ describe('FileViewer SVG artifacts', () => {
     expect(markup).toContain('sandbox="allow-scripts allow-downloads"');
   });
 
-  it('keeps both HTML preview transports mounted when Inspect switches to srcDoc', () => {
+  it('keeps inactive HTML preview transports mounted without booting the artifact', async () => {
     const file = baseFile({
       name: 'page.html',
       path: 'page.html',
@@ -386,7 +396,7 @@ describe('FileViewer SVG artifacts', () => {
         projectId="project-1"
         projectKind="prototype"
         file={file}
-        liveHtml='<html><body><main data-od-id="hero">Hero</main></body></html>'
+        liveHtml='<html><body><script>window.__odArtifactBootCount = (window.__odArtifactBootCount || 0) + 1;</script><main data-od-id="hero">Hero</main></body></html>'
       />,
     );
 
@@ -397,9 +407,10 @@ describe('FileViewer SVG artifacts', () => {
     expect(srcDocFrame).toBeTruthy();
     expect(urlFrame?.getAttribute('data-od-active')).toBe('true');
     expect(srcDocFrame?.getAttribute('data-od-active')).toBe('false');
-    expect(srcDocFrame?.srcdoc).toContain('data-od-selection-bridge');
+    expect(srcDocFrame?.srcdoc).toContain('data-od-lazy-srcdoc-transport');
+    expect(srcDocFrame?.srcdoc).not.toContain('__odArtifactBootCount');
 
-    const initialSrcDoc = srcDocFrame?.srcdoc;
+    const postMessageSpy = vi.spyOn(srcDocFrame!.contentWindow!, 'postMessage');
     fireEvent.click(screen.getByTestId('inspect-mode-toggle'));
 
     const urlFrameAfter = container.querySelector('iframe[data-od-render-mode="url-load"]') as HTMLIFrameElement | null;
@@ -408,8 +419,16 @@ describe('FileViewer SVG artifacts', () => {
     expect(urlFrameAfter).toBe(urlFrame);
     expect(srcDocFrameAfter).toBe(srcDocFrame);
     expect(urlFrameAfter?.getAttribute('data-od-active')).toBe('false');
+    expect(urlFrameAfter?.getAttribute('src')).toBe('about:blank');
     expect(srcDocFrameAfter?.getAttribute('data-od-active')).toBe('true');
-    expect(srcDocFrameAfter?.srcdoc).toBe(initialSrcDoc);
+    expect(srcDocFrameAfter?.srcdoc).toContain('data-od-lazy-srcdoc-transport');
+    expect(srcDocFrameAfter?.srcdoc).not.toContain('__odArtifactBootCount');
+
+    await waitFor(() => {
+      const activations = srcDocActivationMessages(postMessageSpy.mock.calls);
+      expect(activations.at(-1)?.html).toContain('__odArtifactBootCount');
+      expect(activations.at(-1)?.html).toContain('data-od-selection-bridge');
+    });
   });
 
   it('allows downloads in the in-tab HTML presentation iframe', async () => {
@@ -1163,13 +1182,18 @@ describe('FileViewer tweaks toolbar', () => {
     );
 
     expect((screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement).getAttribute('data-od-render-mode')).toBe('url-load');
+    const inactiveSrcDocFrame = screen.getByTestId('artifact-preview-frame-srcdoc') as HTMLIFrameElement;
+    const postMessageSpy = vi.spyOn(inactiveSrcDocFrame.contentWindow!, 'postMessage');
     fireEvent.click(screen.getByTestId('draw-overlay-toggle'));
 
     const frame = await waitFor(() => {
       const activeFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
       expect(activeFrame.getAttribute('data-od-render-mode')).toBe('srcdoc');
-      expect(activeFrame.srcdoc).toContain('data-od-selection-bridge');
+      expect(activeFrame.srcdoc).toContain('data-od-lazy-srcdoc-transport');
       return activeFrame;
+    });
+    await waitFor(() => {
+      expect(srcDocActivationMessages(postMessageSpy.mock.calls).at(-1)?.html).toContain('data-od-selection-bridge');
     });
     const initialSrcDoc = frame.srcdoc;
 

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -359,9 +359,57 @@ describe('FileViewer SVG artifacts', () => {
 
     expect(markup).toContain('data-testid="artifact-preview-frame"');
     expect(markup).toContain('data-od-render-mode="url-load"');
+    expect(markup).toContain('data-od-render-mode="url-load" data-od-active="true"');
+    expect(markup).toContain('data-od-render-mode="srcdoc" data-od-active="false"');
     expect(markup).toContain('src="/api/projects/project-1/raw/page.html?v=1710000000&amp;r=0"');
     expect(markup).toContain('sandbox="allow-scripts allow-downloads"');
-    expect(markup).not.toContain('data-od-render-mode="srcdoc"');
+  });
+
+  it('keeps both HTML preview transports mounted when Inspect switches to srcDoc', () => {
+    const file = baseFile({
+      name: 'page.html',
+      path: 'page.html',
+      mime: 'text/html',
+      kind: 'html',
+      artifactManifest: {
+        version: 1,
+        kind: 'html',
+        title: 'Page',
+        entry: 'page.html',
+        renderer: 'html',
+        exports: ['html'],
+      },
+    });
+
+    const { container } = render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={file}
+        liveHtml='<html><body><main data-od-id="hero">Hero</main></body></html>'
+      />,
+    );
+
+    const urlFrame = container.querySelector('iframe[data-od-render-mode="url-load"]') as HTMLIFrameElement | null;
+    const srcDocFrame = container.querySelector('iframe[data-od-render-mode="srcdoc"]') as HTMLIFrameElement | null;
+
+    expect(urlFrame).toBeTruthy();
+    expect(srcDocFrame).toBeTruthy();
+    expect(urlFrame?.getAttribute('data-od-active')).toBe('true');
+    expect(srcDocFrame?.getAttribute('data-od-active')).toBe('false');
+    expect(srcDocFrame?.srcdoc).toContain('data-od-selection-bridge');
+
+    const initialSrcDoc = srcDocFrame?.srcdoc;
+    fireEvent.click(screen.getByTestId('inspect-mode-toggle'));
+
+    const urlFrameAfter = container.querySelector('iframe[data-od-render-mode="url-load"]') as HTMLIFrameElement | null;
+    const srcDocFrameAfter = container.querySelector('iframe[data-od-render-mode="srcdoc"]') as HTMLIFrameElement | null;
+
+    expect(urlFrameAfter).toBe(urlFrame);
+    expect(srcDocFrameAfter).toBe(srcDocFrame);
+    expect(urlFrameAfter?.getAttribute('data-od-active')).toBe('false');
+    expect(srcDocFrameAfter?.getAttribute('data-od-active')).toBe('true');
+    expect(srcDocFrameAfter?.srcdoc).toBe(initialSrcDoc);
   });
 
   it('allows downloads in the in-tab HTML presentation iframe', async () => {
@@ -448,8 +496,9 @@ describe('FileViewer SVG artifacts', () => {
 
     expect(markup).toContain('data-testid="artifact-preview-frame"');
     expect(markup).toContain('data-od-render-mode="srcdoc"');
+    expect(markup).toContain('data-od-render-mode="srcdoc" data-od-active="true"');
+    expect(markup).toContain('data-od-render-mode="url-load" data-od-active="false"');
     expect(markup).toContain('sandbox="allow-scripts allow-downloads"');
-    expect(markup).not.toContain('data-od-render-mode="url-load"');
   });
 
   it('falls back to srcDoc when the HTML body looks deck-shaped even without an isDeck hint', () => {
@@ -475,7 +524,8 @@ describe('FileViewer SVG artifacts', () => {
     );
 
     expect(markup).toContain('data-od-render-mode="srcdoc"');
-    expect(markup).not.toContain('data-od-render-mode="url-load"');
+    expect(markup).toContain('data-od-render-mode="srcdoc" data-od-active="true"');
+    expect(markup).toContain('data-od-render-mode="url-load" data-od-active="false"');
   });
 
   it('hides preview-only toolbar controls when switching an HTML deck to source view', async () => {
@@ -1105,21 +1155,28 @@ describe('FileViewer tweaks toolbar', () => {
     expect(screen.queryByPlaceholderText('Type anywhere to add a note')).toBeNull();
   });
 
-  it('enables element picking while the Draw bar is in click mode', async () => {
+  it('keeps the preloaded selection bridge mounted while the Draw bar switches to click mode', async () => {
     render(
       <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
         liveHtml='<html><body><main data-od-id="hero">Hero</main></body></html>'
       />,
     );
 
-    const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    expect((screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement).getAttribute('data-od-render-mode')).toBe('url-load');
     fireEvent.click(screen.getByTestId('draw-overlay-toggle'));
-    await waitFor(() => expect(frame.srcdoc).not.toContain('data-od-selection-bridge'));
+
+    const frame = await waitFor(() => {
+      const activeFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      expect(activeFrame.getAttribute('data-od-render-mode')).toBe('srcdoc');
+      expect(activeFrame.srcdoc).toContain('data-od-selection-bridge');
+      return activeFrame;
+    });
+    const initialSrcDoc = frame.srcdoc;
 
     fireEvent.click(screen.getByRole('button', { name: 'Click' }));
 
-    await waitFor(() => expect(frame.srcdoc).toContain('data-od-selection-bridge'));
-    expect(frame.srcdoc).toContain('data-od-comment-mode');
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Click' }).getAttribute('aria-pressed')).toBe('true'));
+    expect((screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement).srcdoc).toBe(initialSrcDoc);
   });
 
   it('disables Draw direct send while a task is running but keeps queue available', () => {


### PR DESCRIPTION
Fixes #1700

## Why

Clicking Inspect on plain HTML previews forced FileViewer to replace the URL-loaded iframe with a new srcDoc iframe. I hit this from the reported Inspect-mode bug: the preview visually blinked because entering Inspect changed the iframe transport instead of activating inspection on a prepared preview surface.

This PR keeps the bridge-capable srcDoc transport mounted in parallel so Inspect can switch the active surface without replacing the iframe node at click time.

## What users will see

HTML previews should no longer visibly flash when clicking Inspect. The preview keeps the URL-loaded transport for normal browsing and swaps visibility to a preloaded srcDoc transport only when a bridge-only mode needs it.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. The visible change is removal of a transient iframe flash; the regression is covered by the red spec below by asserting the URL and srcDoc iframe nodes stay mounted while Inspect switches the active transport.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/FileViewer.test.tsx` (`keeps both HTML preview transports mounted when Inspect switches to srcDoc`)
- Did the test go red on `main` and green on this branch? Red on the pre-fix tree with the regression test applied (`srcDocFrame` was `null`), green after this change.

## Validation

- `pnpm install`
- `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/components/FileViewer.test.tsx`
- `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/components/FileViewer.test.tsx tests/components/file-viewer-render-mode.test.ts tests/runtime/srcdoc.test.ts tests/components/PreviewDrawOverlay.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`

Note: this environment runs Node v26.0.0 while the repo asks for Node ~24, so pnpm printed engine warnings during validation. The commands above completed successfully.
