### PR TITLE
feat(daemon): add Aider agent adapter

### DIFF
--- a/apps/daemon/src/app-config.ts
+++ b/apps/daemon/src/app-config.ts
@@ -142,6 +142,7 @@ function validateTelemetry(raw: unknown): TelemetryPrefs | undefined {
 }
 
 const AGENT_CLI_ENV_KEYS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
+  ['aider', new Set(['AIDER_BIN'])],
   ['claude', new Set(['CLAUDE_CONFIG_DIR', 'CLAUDE_BIN', 'ANTHROPIC_BASE_URL', 'ANTHROPIC_API_KEY'])],
   ['codex', new Set(['CODEX_HOME', 'CODEX_BIN', 'OPENAI_BASE_URL', 'CODEX_API_KEY', 'OPENAI_API_KEY'])],
   ['copilot', new Set(['COPILOT_BIN'])],

--- a/apps/daemon/src/runtimes/defs/aider.ts
+++ b/apps/daemon/src/runtimes/defs/aider.ts
@@ -1,0 +1,63 @@
+import { DEFAULT_MODEL_OPTION } from './shared.js';
+import type { RuntimeAgentDef } from '../types.js';
+
+export const aiderAgentDef = {
+    id: 'aider',
+    name: 'Aider',
+    bin: 'aider',
+    versionArgs: ['--version'],
+    // Aider proxies to whatever LLM the user configures via `--model` and
+    // routes through LiteLLM, so any concrete fallback list is necessarily
+    // partial. These are the commonly recommended starting points from
+    // aider.chat/docs; users can paste anything else through the custom-
+    // model input. The id strings follow LiteLLM provider/model spelling
+    // so Aider parses them without an extra `--provider` flag.
+    fallbackModels: [
+      DEFAULT_MODEL_OPTION,
+      { id: 'sonnet', label: 'sonnet' },
+      { id: 'gpt-4o', label: 'gpt-4o' },
+      { id: 'deepseek/deepseek-chat', label: 'deepseek/deepseek-chat' },
+      { id: 'gemini/gemini-2.0-flash', label: 'gemini/gemini-2.0-flash' },
+    ],
+    // Aider's one-shot mode requires the prompt as `--message <text>` on
+    // argv; neither `--message` nor `--message-file` accept `-` as a stdin
+    // sentinel (it is treated as a literal filename), so we cannot pipe
+    // the prompt in the way qwen/gemini do. Mirror the DeepSeek TUI
+    // pattern: ship the prompt as argv with a conservative byte budget so
+    // the /api/chat spawn path emits an actionable error before hitting
+    // Windows' ~32 KB CreateProcess limit or Linux MAX_ARG_STRLEN.
+    //
+    // The suppression flags are all there to keep aider runnable without
+    // a TTY:
+    //   --yes-always                       — skip per-action confirmation
+    //   --no-pretty                        — strip ANSI so stdout parses as plain text
+    //   --no-stream                        — left as default (streaming on)
+    //   --no-git / --no-auto-commits       — the daemon spawns aider inside
+    //                                        an OD project workspace that is
+    //                                        not the user's git repo, so the
+    //                                        commit machinery has nothing
+    //                                        useful to do here
+    //   --no-suggest-shell-commands        — avoids a follow-up interactive prompt
+    //   --no-show-model-warnings           — suppresses model-compat banners
+    //                                        that would otherwise prefix every
+    //                                        run with noise
+    buildArgs: (prompt, _imagePaths, _extra, options = {}) => {
+      const args = [
+        '--yes-always',
+        '--no-pretty',
+        '--no-git',
+        '--no-auto-commits',
+        '--no-suggest-shell-commands',
+        '--no-show-model-warnings',
+      ];
+      if (options.model && options.model !== 'default') {
+        args.push('--model', options.model);
+      }
+      args.push('--message', prompt);
+      return args;
+    },
+    maxPromptArgBytes: 30_000,
+    streamFormat: 'plain',
+    installUrl: 'https://aider.chat/docs/install.html',
+    docsUrl: 'https://aider.chat',
+} satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/executables.ts
+++ b/apps/daemon/src/runtimes/executables.ts
@@ -7,6 +7,7 @@ import { expandHomePath } from './paths.js';
 import type { RuntimeAgentDef } from './types.js';
 
 const AGENT_BIN_ENV_KEYS = new Map<string, string>([
+  ['aider', 'AIDER_BIN'],
   ['claude', 'CLAUDE_BIN'],
   ['codex', 'CODEX_BIN'],
   ['copilot', 'COPILOT_BIN'],

--- a/apps/daemon/src/runtimes/registry.ts
+++ b/apps/daemon/src/runtimes/registry.ts
@@ -16,6 +16,7 @@ import { kiroAgentDef } from './defs/kiro.js';
 import { kiloAgentDef } from './defs/kilo.js';
 import { vibeAgentDef } from './defs/vibe.js';
 import { deepseekAgentDef } from './defs/deepseek.js';
+import { aiderAgentDef } from './defs/aider.js';
 import { readLocalAgentProfileDefs as readLocalAgentProfileDefsFromFile } from './local-profiles.js';
 import type { RuntimeAgentDef } from './types.js';
 
@@ -38,6 +39,7 @@ const BASE_AGENT_DEFS: RuntimeAgentDef[] = [
   kiloAgentDef,
   vibeAgentDef,
   deepseekAgentDef,
+  aiderAgentDef,
 ];
 
 export function readLocalAgentProfileDefs(

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest';
 import {
-  assert, claude, codex, copilot, cursorAgent, deepseek, devin, detectAgents, gemini, join, kilo, kiro, mkdtempSync, opencode, pi, qoder, qwen, rmSync, spawnEnvForAgent, tmpdir, vibe, writeFileSync, chmodSync,
+  aider, assert, claude, codex, copilot, cursorAgent, deepseek, devin, detectAgents, gemini, join, kilo, kiro, mkdtempSync, opencode, pi, qoder, qwen, rmSync, spawnEnvForAgent, tmpdir, vibe, writeFileSync, chmodSync,
 } from './helpers/test-helpers.js';
 import type { TestAgentDef } from './helpers/test-helpers.js';
 
@@ -463,6 +463,58 @@ test('kiro fetchModels falls back to fallbackModels when detection fails', async
   const fallbackModel = kiro.fallbackModels[0];
   assert.ok(fallbackModel);
   assert.equal(fallbackModel.id, 'default');
+});
+
+test('aider args carry the non-TTY suppression flags, deliver the prompt via --message, and gate model behind an explicit selection', () => {
+  // Argv-only delivery: aider does not accept `-` as a stdin sentinel for
+  // either --message or --message-file, so the daemon must guard against
+  // ENAMETOOLONG before spawn. Same pattern as deepseek.
+  assert.equal(aider.promptViaStdin, undefined);
+  assert.equal(aider.maxPromptArgBytes, 30_000);
+  assert.equal(aider.streamFormat, 'plain');
+
+  const baseArgs = aider.buildArgs('hello world', [], [], {}, { cwd: '/tmp/od-project' });
+  assert.deepEqual(baseArgs, [
+    '--yes-always',
+    '--no-pretty',
+    '--no-git',
+    '--no-auto-commits',
+    '--no-suggest-shell-commands',
+    '--no-show-model-warnings',
+    '--message',
+    'hello world',
+  ]);
+
+  // The default sentinel is dropped so the user's aider config / env can
+  // pick the model unconstrained — matches qwen/deepseek behavior.
+  const defaultModelArgs = aider.buildArgs(
+    'hi',
+    [],
+    [],
+    { model: 'default' },
+    { cwd: '/tmp/od-project' },
+  );
+  assert.equal(defaultModelArgs.includes('--model'), false);
+
+  const withModel = aider.buildArgs(
+    'edit foo.ts',
+    [],
+    [],
+    { model: 'deepseek/deepseek-chat' },
+    { cwd: '/tmp/od-project' },
+  );
+  assert.deepEqual(withModel, [
+    '--yes-always',
+    '--no-pretty',
+    '--no-git',
+    '--no-auto-commits',
+    '--no-suggest-shell-commands',
+    '--no-show-model-warnings',
+    '--model',
+    'deepseek/deepseek-chat',
+    '--message',
+    'edit foo.ts',
+  ]);
 });
 
 test('kilo args use acp subcommand for json-rpc streaming', () => {

--- a/apps/daemon/tests/runtimes/env-and-detection.test.ts
+++ b/apps/daemon/tests/runtimes/env-and-detection.test.ts
@@ -127,6 +127,7 @@ test('resolveAgentExecutable supports configured binary overrides for non-Codex 
     ['copilot', 'copilot', 'COPILOT_BIN'],
     ['deepseek', 'deepseek', 'DEEPSEEK_BIN'],
     ['trae-cli', 'traecli', 'TRAE_CLI_BIN'],
+    ['aider', 'aider', 'AIDER_BIN'],
   ];
   const dir = mkdtempSync(join(tmpdir(), 'od-agent-bin-overrides-'));
   try {

--- a/apps/daemon/tests/runtimes/helpers/test-helpers.ts
+++ b/apps/daemon/tests/runtimes/helpers/test-helpers.ts
@@ -86,6 +86,7 @@ export const gemini = requireAgent('gemini');
 export const qoder = requireAgent('qoder');
 export const qwen = requireAgent('qwen');
 export const opencode = requireAgent('opencode');
+export const aider = requireAgent('aider');
 export const deepseekMaxPromptArgBytes = (() => {
   assert.ok(
     deepseek.maxPromptArgBytes !== undefined,

--- a/apps/web/src/utils/agentLabels.ts
+++ b/apps/web/src/utils/agentLabels.ts
@@ -1,4 +1,5 @@
 const AGENT_LABELS: Record<string, string> = {
+  aider: 'Aider',
   claude: 'Claude',
   codex: 'Codex',
   devin: 'Devin',
@@ -28,6 +29,8 @@ const AGENT_ALIASES: Record<string, string> = {
   'github copilot cli': 'copilot',
   'deepseek tui': 'deepseek',
   'deepseek-tui': 'deepseek',
+  'aider cli': 'aider',
+  'aider chat': 'aider',
 };
 
 export function agentDisplayName(


### PR DESCRIPTION
## Why

I use Aider day-to-day for editing TypeScript and Python projects from the terminal, and I wanted to drive it from Open Design the same way I drive Claude Code / Codex / Cursor / Gemini today. Adding the adapter also unlocks every provider Aider speaks (OpenAI, Anthropic, DeepSeek, Gemini, OpenRouter, local Ollama, …) without OD needing a separate adapter per provider, since Aider routes everything through LiteLLM.

`CONTRIBUTING.md` lists "Hook up a new coding-agent CLI" as one of the explicit "ship in one afternoon" surfaces, so I kept the change tight: one new adapter file, register it, wire the bin env override, label it in the web picker, add the matching test coverage. Same shape as the existing 16 adapters.

## What users will see

A new entry in **Settings → Execution mode → Local agent CLI** named **Aider**, shown alongside the existing entries (Claude Code, Codex, Cursor, etc.). It is detected automatically when `aider` is on `PATH`, or by setting `AIDER_BIN` to an absolute path. Users pick a model the same way they do for DeepSeek / Qwen — the four common starting points (`sonnet`, `gpt-4o`, `deepseek/deepseek-chat`, `gemini/gemini-2.0-flash`) appear in the picker as fallbacks, and any other LiteLLM model id can be pasted into the custom-model input. Nothing changes for users who don't have Aider installed.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

The CLI/env-var surface is a new `AIDER_BIN` agent-bin override (added to `AGENT_BIN_ENV_KEYS` in `executables.ts` and the per-agent allowlist in `app-config.ts`), following the same shape every other adapter uses.

No new top-level dependencies. No new top-level UI affordance beyond the auto-populated picker entry — the agent-picker iterates `AGENT_DEFS` and the new `Aider` label flows in through `apps/web/src/utils/agentLabels.ts`.

## Screenshots

N/A — no new dedicated UI surface; the Aider entry renders through the existing detected-agents picker.

## Bug fix verification

N/A — this is a new adapter, not a bug fix.

## Validation

- `pnpm guard` — pass (residual-JS, test-layout, style-policy, design-system token-fixture, A1/A2/B-slot tokens, schema parity)
- `pnpm typecheck` — pass (root, daemon, web, tools, contracts, registry-protocol)
- `pnpm --filter @open-design/daemon test tests/runtimes` — 123 passing, including the new aider buildArgs / streamFormat / maxPromptArgBytes coverage in `agent-args.test.ts` and the new `['aider', 'aider', 'AIDER_BIN']` row in `env-and-detection.test.ts`
- End-to-end probe against the live `aider` binary using the exact argv the adapter produces (`--yes-always --no-pretty --no-git --no-auto-commits --no-suggest-shell-commands --no-show-model-warnings --model deepseek/deepseek-chat --message <prompt>`) returned the expected output through the DeepSeek LiteLLM provider, confirming the suppression flags keep aider runnable without a TTY

## Notes for review

A few choices I want to call out so reviewers can push back early:

- **Prompt delivery is argv, not stdin.** Aider rejects `-` as a stdin sentinel for both `--message` and `--message-file` (treats it as a literal filename). The DeepSeek TUI adapter is in the same boat, so I copied its pattern: `maxPromptArgBytes: 30_000` and let the existing `/api/chat` budget check emit the actionable SSE error. Aider does support `--message-file <real-path>`, so a future iteration could switch to a per-run temp file to remove the budget ceiling, but that changes the cleanup contract; happy to do it as a follow-up if you prefer.
- **`--no-git` / `--no-auto-commits`.** The daemon spawns adapters inside `.od/projects/<id>/`, which is OD-owned scratch space, not a user-managed repo. Letting aider attempt commits there produces empty commit objects and noise on every run. Disabling matches the contract of every other adapter (none of them commit on the user's behalf).
- **Auth-failure guidance.** `runtimes/auth.ts` has bespoke guidance blocks for `cursor-agent` and `deepseek`. I intentionally left Aider on the default `null` path: the failure surface depends entirely on which LiteLLM provider the user pointed `--model` at, so the upstream error (e.g. litellm's own `AuthenticationError` with the right provider's docs URL) is already actionable. Happy to add a dedicated block in a follow-up if you'd rather.
- **No CSV analytics enum entry.** Per the comment in `packages/contracts/src/analytics/events.ts:535`, agents not in the CSV taxonomy fall through to `'other'`. I left it that way rather than widening the typed enum, but I can extend it (`aider_chat`?) if you want to track Aider runs distinctly.

If any of those are wrong defaults for OD, I'm happy to iterate.
