### PR TITLE
fix(daemon): dedupe scheduled routine slots

### DIFF
--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -1460,13 +1460,39 @@ export function insertRoutineRun(db: SqliteDb, r: DbRow) {
   return getRoutineRun(db, r.id);
 }
 
-export function claimRoutineScheduledSlot(db: SqliteDb, routineId: string, slotAt: number): boolean {
-  const result = db.prepare(
+export function insertScheduledRoutineRun(db: SqliteDb, r: DbRow, slotAt: number) {
+  const insertClaim = db.prepare(
     `INSERT OR IGNORE INTO routine_schedule_claims
        (routine_id, slot_at, claimed_at)
      VALUES (?, ?, ?)`,
-  ).run(routineId, slotAt, Date.now());
-  return result.changes > 0;
+  );
+  const insertRun = db.prepare(
+    `INSERT INTO routine_runs
+       (id, routine_id, trigger, status, project_id, conversation_id,
+        agent_run_id, started_at, completed_at, summary, error, error_code)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  );
+  const tx = db.transaction(() => {
+    const claim = insertClaim.run(r.routineId, slotAt, Date.now());
+    if (claim.changes === 0) return false;
+    insertRun.run(
+      r.id,
+      r.routineId,
+      r.trigger,
+      r.status,
+      r.projectId,
+      r.conversationId,
+      r.agentRunId,
+      r.startedAt,
+      r.completedAt ?? null,
+      r.summary ?? null,
+      r.error ?? null,
+      r.errorCode ?? null,
+    );
+    return true;
+  });
+  if (!tx()) return null;
+  return getRoutineRun(db, r.id);
 }
 
 export function updateRoutineRun(db: SqliteDb, id: string, patch: DbRow) {

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -1504,10 +1504,14 @@ export function updateRoutineRun(db: SqliteDb, id: string, patch: DbRow) {
   };
   db.prepare(
     `UPDATE routine_runs
-        SET status = ?, completed_at = ?, summary = ?, error = ?, error_code = ?
+        SET status = ?, project_id = ?, conversation_id = ?, agent_run_id = ?,
+            completed_at = ?, summary = ?, error = ?, error_code = ?
       WHERE id = ?`,
   ).run(
     merged.status,
+    merged.projectId,
+    merged.conversationId,
+    merged.agentRunId,
     merged.completedAt ?? null,
     merged.summary ?? null,
     merged.error ?? null,

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -195,6 +195,14 @@ function migrate(db: SqliteDb): void {
       FOREIGN KEY(routine_id) REFERENCES routines(id) ON DELETE CASCADE
     );
 
+    CREATE TABLE IF NOT EXISTS routine_schedule_claims (
+      routine_id TEXT NOT NULL,
+      slot_at INTEGER NOT NULL,
+      claimed_at INTEGER NOT NULL,
+      PRIMARY KEY(routine_id, slot_at),
+      FOREIGN KEY(routine_id) REFERENCES routines(id) ON DELETE CASCADE
+    );
+
     CREATE INDEX IF NOT EXISTS idx_routine_runs_routine
       ON routine_runs(routine_id, started_at DESC);
   `);
@@ -1450,6 +1458,15 @@ export function insertRoutineRun(db: SqliteDb, r: DbRow) {
     r.errorCode ?? null,
   );
   return getRoutineRun(db, r.id);
+}
+
+export function claimRoutineScheduledSlot(db: SqliteDb, routineId: string, slotAt: number): boolean {
+  const result = db.prepare(
+    `INSERT OR IGNORE INTO routine_schedule_claims
+       (routine_id, slot_at, claimed_at)
+     VALUES (?, ?, ?)`,
+  ).run(routineId, slotAt, Date.now());
+  return result.changes > 0;
 }
 
 export function updateRoutineRun(db: SqliteDb, id: string, patch: DbRow) {

--- a/apps/daemon/src/plugins/snapshots.ts
+++ b/apps/daemon/src/plugins/snapshots.ts
@@ -189,7 +189,7 @@ export function restoreProjectSnapshotLink(
   ).run(previous, projectId, snapshotIdToDiscard);
   const expiry = unreferencedSnapshotExpiry();
   if (typeof discardedRunId === 'string' && discardedRunId.length > 0) {
-    db.prepare(
+    const result = db.prepare(
       `UPDATE applied_plugin_snapshots
           SET run_id = NULL,
               expires_at = ?
@@ -197,7 +197,7 @@ export function restoreProjectSnapshotLink(
           AND project_id = ?
           AND run_id = ?`,
     ).run(expiry, snapshotIdToDiscard, projectId, discardedRunId);
-    return;
+    if (result.changes > 0) return;
   }
   db.prepare(
     `UPDATE applied_plugin_snapshots

--- a/apps/daemon/src/plugins/snapshots.ts
+++ b/apps/daemon/src/plugins/snapshots.ts
@@ -171,6 +171,48 @@ export function linkSnapshotToProject(db: SqliteDb, snapshotId: string, projectI
   ).run(snapshotId, projectId);
 }
 
+export function restoreProjectSnapshotLink(
+  db: SqliteDb,
+  projectId: string,
+  snapshotIdToDiscard: string,
+  previousSnapshotId: string | null | undefined,
+  discardedRunId?: string | null | undefined,
+): void {
+  const previous = typeof previousSnapshotId === 'string' && previousSnapshotId.length > 0
+    ? previousSnapshotId
+    : null;
+  db.prepare(
+    `UPDATE projects
+        SET applied_plugin_snapshot_id = ?
+      WHERE id = ?
+        AND applied_plugin_snapshot_id = ?`,
+  ).run(previous, projectId, snapshotIdToDiscard);
+  const expiry = unreferencedSnapshotExpiry();
+  if (typeof discardedRunId === 'string' && discardedRunId.length > 0) {
+    db.prepare(
+      `UPDATE applied_plugin_snapshots
+          SET run_id = NULL,
+              expires_at = ?
+        WHERE id = ?
+          AND project_id = ?
+          AND run_id = ?`,
+    ).run(expiry, snapshotIdToDiscard, projectId, discardedRunId);
+    return;
+  }
+  db.prepare(
+    `UPDATE applied_plugin_snapshots
+        SET expires_at = ?
+      WHERE id = ?
+        AND run_id IS NULL
+        AND project_id = ?`,
+  ).run(expiry, snapshotIdToDiscard, projectId);
+}
+
+function unreferencedSnapshotExpiry(): number | null {
+  const days = readPluginEnvKnobs().snapshotUnreferencedTtlDays;
+  return days > 0 ? Date.now() + days * 24 * 60 * 60 * 1000 : null;
+}
+
 // Pin a snapshot to a conversation row. Same shape as
 // `linkSnapshotToProject` but mutates `conversations.applied_plugin_snapshot_id`.
 // Used when a plugin is applied inside an existing chat composer (§8.4).

--- a/apps/daemon/src/routines.ts
+++ b/apps/daemon/src/routines.ts
@@ -109,7 +109,7 @@ interface ScheduledTimer {
   fireAt: Date;
 }
 
-function clearScheduledPlaceholderId(value: string): string {
+function clearRoutinePlaceholderId(value: string): string {
   return value.startsWith('routine-pending-') ? '' : value;
 }
 
@@ -565,16 +565,10 @@ export class RoutineService {
       };
       const scheduledSlotAt = options.scheduledSlotAt;
       const wasScheduled = scheduledSlotAt != null;
-      const publicProjectId = () => (
-        wasScheduled ? clearScheduledPlaceholderId(run.projectId) : run.projectId
-      );
-      const publicConversationId = () => (
-        wasScheduled ? clearScheduledPlaceholderId(run.conversationId) : run.conversationId
-      );
-      const publicAgentRunId = () => (
-        wasScheduled ? clearScheduledPlaceholderId(run.agentRunId) : run.agentRunId
-      );
-      const scrubScheduledPlaceholders = () => {
+      const publicProjectId = () => clearRoutinePlaceholderId(run.projectId);
+      const publicConversationId = () => clearRoutinePlaceholderId(run.conversationId);
+      const publicAgentRunId = () => clearRoutinePlaceholderId(run.agentRunId);
+      const scrubRoutinePlaceholders = () => {
         run.projectId = publicProjectId();
         run.conversationId = publicConversationId();
         run.agentRunId = publicAgentRunId();
@@ -609,7 +603,12 @@ export class RoutineService {
       }
       try {
         await handlerStart.prepare?.(run);
-        if (wasScheduled) {
+        if (
+          wasScheduled
+          || run.projectId !== handlerStart.projectId
+          || run.conversationId !== handlerStart.conversationId
+          || run.agentRunId !== handlerStart.agentRunId
+        ) {
           this.persistence.updateRun(runId, {
             projectId: run.projectId,
             conversationId: run.conversationId,
@@ -633,14 +632,14 @@ export class RoutineService {
             discardError instanceof Error ? discardError.message : discardError,
           );
         }
-        // Persist IDs only after `prepare()` has replaced the scheduled
+        // Persist IDs only after `prepare()` has replaced routine
         // placeholders with real resources. If preparation failed before
         // enrichment, clear the sentinels so the terminal row does not point
-        // at fabricated project/conversation IDs. The slot claim was already
-        // accepted at `insertRun()`, so retrying the same slot is not
-        // appropriate — let the error propagate so the scheduler advances
-        // to the next cadence.
-        scrubScheduledPlaceholders();
+        // at fabricated project/conversation IDs. For scheduled runs the
+        // slot claim was already accepted at `insertRun()`, so retrying the
+        // same slot is not appropriate — let the error propagate so the
+        // scheduler advances to the next cadence.
+        scrubRoutinePlaceholders();
         this.persistence.updateRun(runId, {
           status: 'failed',
           completedAt: Date.now(),

--- a/apps/daemon/src/routines.ts
+++ b/apps/daemon/src/routines.ts
@@ -77,6 +77,8 @@ export interface RoutineRunHandlerStart {
   conversationId: string;
   agentRunId: string;
   completion: Promise<RoutineRunCompletion>;
+  start?: () => void;
+  discard?: () => void;
 }
 
 export interface RoutineRunCompletion {
@@ -95,16 +97,30 @@ export type RoutineRunHandler = (input: {
 
 export interface RoutinePersistence {
   list(): Routine[];
-  insertRun(run: RoutineRun): void;
+  insertRun(run: RoutineRun, options?: { scheduledSlotAt?: number }): boolean | void;
   updateRun(id: string, patch: Partial<RoutineRun>): void;
   getLatestRun(routineId: string): RoutineRun | null;
-  claimScheduledSlot?(routineId: string, slotAt: number): boolean;
 }
 
 interface ScheduledTimer {
   routineId: string;
   timer: NodeJS.Timeout;
   fireAt: Date;
+}
+
+class ScheduledRunPersistenceError extends Error {
+  constructor(
+    readonly routineId: string,
+    readonly slotAt: number,
+    readonly originalError: unknown,
+  ) {
+    super(`Routine ${routineId} scheduled slot ${slotAt} could not be persisted`);
+    this.name = 'ScheduledRunPersistenceError';
+  }
+}
+
+function isScheduledRunPersistenceError(error: unknown): error is ScheduledRunPersistenceError {
+  return error instanceof ScheduledRunPersistenceError;
 }
 
 // ---------- timezone math ----------
@@ -459,6 +475,17 @@ export class RoutineService {
     if (!routine.enabled) return;
     const fireAt = nextRunAtForSchedule(routine.schedule);
     if (!fireAt) return;
+    this.scheduleRoutineAt(routine, fireAt);
+  }
+
+  private retryScheduledSlot(routineId: string, fireAt: Date): void {
+    if (!this.started) return;
+    const routine = this.persistence.list().find((candidate) => candidate.id === routineId);
+    if (!routine?.enabled) return;
+    this.scheduleRoutineAt(routine, fireAt);
+  }
+
+  private scheduleRoutineAt(routine: Routine, fireAt: Date): void {
     // setTimeout can't carry past 2^31 ms (~24.8 days); we cap and use
     // a chained re-schedule. Routines fire within hours/days, but a
     // misconfigured "next month" weekly value could otherwise overflow.
@@ -466,31 +493,25 @@ export class RoutineService {
     const timer = setTimeout(() => {
       this.timers.delete(routine.id);
       const slotAt = fireAt.getTime();
-      let claimed = true;
-      try {
-        claimed = this.persistence.claimScheduledSlot?.(routine.id, slotAt) ?? true;
-      } catch (error) {
-        console.error(
-          `[od] routine ${routine.id} scheduled slot claim failed:`,
-          error instanceof Error ? error.message : error,
-        );
-        this.rescheduleOne(routine.id);
-        return;
-      }
-      if (!claimed) {
-        this.rescheduleOne(routine.id);
-        return;
-      }
-      this.start_(routine.id, 'scheduled')
+      this.start_(routine.id, 'scheduled', { scheduledSlotAt: slotAt })
+        .then(() => {
+          // Always reschedule so a single fire keeps the cadence alive.
+          this.rescheduleOne(routine.id);
+        })
         .catch((error) => {
           console.error(
             `[od] routine ${routine.id} scheduled run failed:`,
-            error instanceof Error ? error.message : error,
+            error instanceof ScheduledRunPersistenceError
+              ? error.originalError instanceof Error
+                ? error.originalError.message
+                : error.originalError
+              : error instanceof Error ? error.message : error,
           );
-        })
-        .finally(() => {
-          // Always reschedule so a single fire keeps the cadence alive.
-          this.rescheduleOne(routine.id);
+          if (isScheduledRunPersistenceError(error)) {
+            this.retryScheduledSlot(routine.id, fireAt);
+          } else {
+            this.rescheduleOne(routine.id);
+          }
         });
     }, delay);
     if (typeof timer.unref === 'function') timer.unref();
@@ -508,6 +529,7 @@ export class RoutineService {
   private async start_(
     routineId: string,
     trigger: RoutineRunTrigger,
+    options: { scheduledSlotAt?: number } = {},
   ): Promise<RoutineRunHandlerStart> {
     if (!this.runHandler) throw new Error('Routine run handler is not configured');
     const inflight = this.inflight.get(routineId);
@@ -522,7 +544,7 @@ export class RoutineService {
       const handler = this.runHandler;
       if (!handler) throw new Error('Routine run handler is not configured');
       const handlerStart = await handler({ routine, trigger, startedAt, runId });
-      this.persistence.insertRun({
+      const run: RoutineRun = {
         id: runId,
         routineId: routine.id,
         trigger,
@@ -535,7 +557,21 @@ export class RoutineService {
         summary: null,
         error: null,
         errorCode: null,
-      });
+      };
+      let inserted = true;
+      try {
+        inserted = this.persistence.insertRun(run, options) !== false;
+      } catch (error) {
+        handlerStart.discard?.();
+        if (options.scheduledSlotAt != null) {
+          throw new ScheduledRunPersistenceError(routine.id, options.scheduledSlotAt, error);
+        }
+        throw error;
+      }
+      if (!inserted) {
+        handlerStart.discard?.();
+        return handlerStart;
+      }
       handlerStart.completion
         .then((completion) => {
           this.persistence.updateRun(runId, {
@@ -555,6 +591,18 @@ export class RoutineService {
             errorCode: null,
           });
         });
+      try {
+        handlerStart.start?.();
+      } catch (error) {
+        this.persistence.updateRun(runId, {
+          status: 'failed',
+          completedAt: Date.now(),
+          summary: null,
+          error: error instanceof Error ? error.message : String(error),
+          errorCode: null,
+        });
+        throw error;
+      }
       return handlerStart;
     })();
     this.inflight.set(routineId, promise);

--- a/apps/daemon/src/routines.ts
+++ b/apps/daemon/src/routines.ts
@@ -599,12 +599,37 @@ export class RoutineService {
           });
         }
       } catch (error) {
+        // Terminate the in-memory chat run created by `handler(...)` so its
+        // `completion` promise resolves instead of waiting forever on a
+        // run that will never start. Surface any cleanup failure rather
+        // than swallow it, but still finalize the persisted row.
+        let discardError: unknown = null;
+        try {
+          handlerStart.discard?.();
+        } catch (err) {
+          discardError = err;
+        }
+        if (discardError != null) {
+          console.error(
+            `[od] routine ${routine.id} prepare cleanup failed:`,
+            discardError instanceof Error ? discardError.message : discardError,
+          );
+        }
+        // Persist the real project/conversation/agentRunId that `prepare()`
+        // assigned before throwing so the row does not retain
+        // `routine-pending-*` placeholders. The slot claim was already
+        // accepted at `insertRun()`, so retrying the same slot is not
+        // appropriate — let the error propagate so the scheduler advances
+        // to the next cadence.
         this.persistence.updateRun(runId, {
           status: 'failed',
           completedAt: Date.now(),
           summary: null,
           error: error instanceof Error ? error.message : String(error),
           errorCode: null,
+          projectId: run.projectId,
+          conversationId: run.conversationId,
+          agentRunId: run.agentRunId,
         });
         throw error;
       }

--- a/apps/daemon/src/routines.ts
+++ b/apps/daemon/src/routines.ts
@@ -98,6 +98,7 @@ export interface RoutinePersistence {
   insertRun(run: RoutineRun): void;
   updateRun(id: string, patch: Partial<RoutineRun>): void;
   getLatestRun(routineId: string): RoutineRun | null;
+  claimScheduledSlot?(routineId: string, slotAt: number): boolean;
 }
 
 interface ScheduledTimer {
@@ -464,6 +465,22 @@ export class RoutineService {
     const delay = Math.max(1_000, Math.min(2_000_000_000, fireAt.getTime() - Date.now()));
     const timer = setTimeout(() => {
       this.timers.delete(routine.id);
+      const slotAt = fireAt.getTime();
+      let claimed = true;
+      try {
+        claimed = this.persistence.claimScheduledSlot?.(routine.id, slotAt) ?? true;
+      } catch (error) {
+        console.error(
+          `[od] routine ${routine.id} scheduled slot claim failed:`,
+          error instanceof Error ? error.message : error,
+        );
+        this.rescheduleOne(routine.id);
+        return;
+      }
+      if (!claimed) {
+        this.rescheduleOne(routine.id);
+        return;
+      }
       this.start_(routine.id, 'scheduled')
         .catch((error) => {
           console.error(

--- a/apps/daemon/src/routines.ts
+++ b/apps/daemon/src/routines.ts
@@ -626,12 +626,14 @@ export class RoutineService {
       }
       try {
         await handlerStart.prepare?.(run);
-        if (
-          wasScheduled
-          || run.projectId !== handlerStart.projectId
+        const preparedIdsChanged =
+          run.projectId !== handlerStart.projectId
           || run.conversationId !== handlerStart.conversationId
-          || run.agentRunId !== handlerStart.agentRunId
-        ) {
+          || run.agentRunId !== handlerStart.agentRunId;
+        handlerStart.projectId = run.projectId;
+        handlerStart.conversationId = run.conversationId;
+        handlerStart.agentRunId = run.agentRunId;
+        if (wasScheduled || preparedIdsChanged) {
           this.persistence.updateRun(runId, {
             projectId: run.projectId,
             conversationId: run.conversationId,

--- a/apps/daemon/src/routines.ts
+++ b/apps/daemon/src/routines.ts
@@ -109,6 +109,10 @@ interface ScheduledTimer {
   fireAt: Date;
 }
 
+function clearScheduledPlaceholderId(value: string): string {
+  return value.startsWith('routine-pending-') ? '' : value;
+}
+
 class ScheduledRunPersistenceError extends Error {
   constructor(
     readonly routineId: string,
@@ -615,9 +619,10 @@ export class RoutineService {
             discardError instanceof Error ? discardError.message : discardError,
           );
         }
-        // Persist the real project/conversation/agentRunId that `prepare()`
-        // assigned before throwing so the row does not retain
-        // `routine-pending-*` placeholders. The slot claim was already
+        // Persist IDs only after `prepare()` has replaced the scheduled
+        // placeholders with real resources. If preparation failed before
+        // enrichment, clear the sentinels so the terminal row does not point
+        // at fabricated project/conversation IDs. The slot claim was already
         // accepted at `insertRun()`, so retrying the same slot is not
         // appropriate — let the error propagate so the scheduler advances
         // to the next cadence.
@@ -627,9 +632,9 @@ export class RoutineService {
           summary: null,
           error: error instanceof Error ? error.message : String(error),
           errorCode: null,
-          projectId: run.projectId,
-          conversationId: run.conversationId,
-          agentRunId: run.agentRunId,
+          projectId: wasScheduled ? clearScheduledPlaceholderId(run.projectId) : run.projectId,
+          conversationId: wasScheduled ? clearScheduledPlaceholderId(run.conversationId) : run.conversationId,
+          agentRunId: wasScheduled ? clearScheduledPlaceholderId(run.agentRunId) : run.agentRunId,
         });
         throw error;
       }

--- a/apps/daemon/src/routines.ts
+++ b/apps/daemon/src/routines.ts
@@ -77,6 +77,7 @@ export interface RoutineRunHandlerStart {
   conversationId: string;
   agentRunId: string;
   completion: Promise<RoutineRunCompletion>;
+  prepare?: (run: RoutineRun) => void | Promise<void>;
   start?: () => void;
   discard?: () => void;
 }
@@ -558,19 +559,54 @@ export class RoutineService {
         error: null,
         errorCode: null,
       };
+      const scheduledSlotAt = options.scheduledSlotAt;
+      const wasScheduled = scheduledSlotAt != null;
       let inserted = true;
       try {
         inserted = this.persistence.insertRun(run, options) !== false;
       } catch (error) {
-        handlerStart.discard?.();
-        if (options.scheduledSlotAt != null) {
-          throw new ScheduledRunPersistenceError(routine.id, options.scheduledSlotAt, error);
+        try {
+          handlerStart.discard?.();
+        } catch (discardError) {
+          if (wasScheduled) {
+            throw new ScheduledRunPersistenceError(routine.id, scheduledSlotAt, discardError);
+          }
+          throw discardError;
+        }
+        if (wasScheduled) {
+          throw new ScheduledRunPersistenceError(routine.id, scheduledSlotAt, error);
         }
         throw error;
       }
       if (!inserted) {
-        handlerStart.discard?.();
+        try {
+          handlerStart.discard?.();
+        } catch (discardError) {
+          if (wasScheduled) {
+            throw new ScheduledRunPersistenceError(routine.id, scheduledSlotAt, discardError);
+          }
+          throw discardError;
+        }
         return handlerStart;
+      }
+      try {
+        await handlerStart.prepare?.(run);
+        if (wasScheduled) {
+          this.persistence.updateRun(runId, {
+            projectId: run.projectId,
+            conversationId: run.conversationId,
+            agentRunId: run.agentRunId,
+          });
+        }
+      } catch (error) {
+        this.persistence.updateRun(runId, {
+          status: 'failed',
+          completedAt: Date.now(),
+          summary: null,
+          error: error instanceof Error ? error.message : String(error),
+          errorCode: null,
+        });
+        throw error;
       }
       handlerStart.completion
         .then((completion) => {

--- a/apps/daemon/src/routines.ts
+++ b/apps/daemon/src/routines.ts
@@ -565,6 +565,20 @@ export class RoutineService {
       };
       const scheduledSlotAt = options.scheduledSlotAt;
       const wasScheduled = scheduledSlotAt != null;
+      const publicProjectId = () => (
+        wasScheduled ? clearScheduledPlaceholderId(run.projectId) : run.projectId
+      );
+      const publicConversationId = () => (
+        wasScheduled ? clearScheduledPlaceholderId(run.conversationId) : run.conversationId
+      );
+      const publicAgentRunId = () => (
+        wasScheduled ? clearScheduledPlaceholderId(run.agentRunId) : run.agentRunId
+      );
+      const scrubScheduledPlaceholders = () => {
+        run.projectId = publicProjectId();
+        run.conversationId = publicConversationId();
+        run.agentRunId = publicAgentRunId();
+      };
       let inserted = true;
       try {
         inserted = this.persistence.insertRun(run, options) !== false;
@@ -626,15 +640,16 @@ export class RoutineService {
         // accepted at `insertRun()`, so retrying the same slot is not
         // appropriate — let the error propagate so the scheduler advances
         // to the next cadence.
+        scrubScheduledPlaceholders();
         this.persistence.updateRun(runId, {
           status: 'failed',
           completedAt: Date.now(),
           summary: null,
           error: error instanceof Error ? error.message : String(error),
           errorCode: null,
-          projectId: wasScheduled ? clearScheduledPlaceholderId(run.projectId) : run.projectId,
-          conversationId: wasScheduled ? clearScheduledPlaceholderId(run.conversationId) : run.conversationId,
-          agentRunId: wasScheduled ? clearScheduledPlaceholderId(run.agentRunId) : run.agentRunId,
+          projectId: run.projectId,
+          conversationId: run.conversationId,
+          agentRunId: run.agentRunId,
         });
         throw error;
       }

--- a/apps/daemon/src/routines.ts
+++ b/apps/daemon/src/routines.ts
@@ -79,7 +79,22 @@ export interface RoutineRunHandlerStart {
   completion: Promise<RoutineRunCompletion>;
   prepare?: (run: RoutineRun) => void | Promise<void>;
   start?: () => void;
+  // Tear-down for the case where the handler returned a start handle but
+  // `RoutineService` later reached `prepare()` and it failed — i.e. the
+  // routine_run row exists, prepare may have partially mutated project /
+  // conversation / snapshot state, and the in-memory chat run still needs
+  // to terminate as `canceled`. Callers MUST surface failures rather than
+  // swallow them (the loser-retry path depends on it).
   discard?: () => void;
+  // Tear-down for the case where the run was NEVER durably inserted —
+  // either `insertRun()` threw, or `insertRun()` returned `false` because
+  // a sibling daemon already won the scheduled slot. Prepare has not run,
+  // so no project / conversation / snapshot writes need rolling back. The
+  // in-memory chat run must also be removed from the registry instead of
+  // being finalized as `canceled`, otherwise duplicate-loser slots would
+  // surface phantom canceled runs on `/api/runs`. Falls back to `discard`
+  // when the handler does not distinguish the two cases.
+  discardUnstarted?: () => void;
 }
 
 export interface RoutineRunCompletion {
@@ -573,12 +588,20 @@ export class RoutineService {
         run.conversationId = publicConversationId();
         run.agentRunId = publicAgentRunId();
       };
+      // Tear-down to use when the durable routine_run row was never
+      // inserted (insertRun threw, or another daemon already won the slot).
+      // Prefer the explicit `discardUnstarted` callback when the handler
+      // distinguishes the two cases — that one drops the in-memory chat run
+      // entirely instead of finalizing it as `canceled`, so duplicate
+      // scheduled losers do not surface phantom runs on `/api/runs`.
+      // Handlers that do not implement the split still see `discard`.
+      const discardUnstarted = handlerStart.discardUnstarted ?? handlerStart.discard;
       let inserted = true;
       try {
         inserted = this.persistence.insertRun(run, options) !== false;
       } catch (error) {
         try {
-          handlerStart.discard?.();
+          discardUnstarted?.();
         } catch (discardError) {
           if (wasScheduled) {
             throw new ScheduledRunPersistenceError(routine.id, scheduledSlotAt, discardError);
@@ -592,7 +615,7 @@ export class RoutineService {
       }
       if (!inserted) {
         try {
-          handlerStart.discard?.();
+          discardUnstarted?.();
         } catch (discardError) {
           if (wasScheduled) {
             throw new ScheduledRunPersistenceError(routine.id, scheduledSlotAt, discardError);

--- a/apps/daemon/src/runs.ts
+++ b/apps/daemon/src/runs.ts
@@ -244,6 +244,29 @@ export function createChatRunService({
     return new Promise((resolve) => run.waiters.add(resolve));
   };
 
+  // Drop a run from the in-memory registry without emitting any terminal
+  // event. Used by callers that prepared a run optimistically (created the
+  // record before some external precondition was checked) and need to undo
+  // the create without surfacing the run via `/api/runs`. Only valid before
+  // the run reaches a terminal status — terminal runs use scheduleCleanup
+  // and would already have notified any subscribers.
+  const drop = (run) => {
+    if (!run) return;
+    if (TERMINAL_RUN_STATUSES.has(run.status)) return;
+    runs.delete(run.id);
+    for (const sse of run.clients) {
+      try { sse.end(); } catch { /* best-effort detach */ }
+    }
+    run.clients.clear();
+    // Resolve any pending waiters with a synthetic "canceled" status so
+    // they unblock instead of hanging forever — the run is being dropped
+    // because nothing will ever start.
+    run.status = 'canceled';
+    run.updatedAt = Date.now();
+    for (const waiter of run.waiters) waiter(statusBody(run));
+    run.waiters.clear();
+  };
+
   return {
     create,
     start,
@@ -256,6 +279,7 @@ export function createChatRunService({
     emit,
     finish,
     fail,
+    drop,
     statusBody,
     isTerminal(status) {
       return TERMINAL_RUN_STATUSES.has(status);

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -12129,25 +12129,56 @@ export async function startServer({
 
     const assistantMessageId = `routine-assistant-${randomUUID()}`;
     let resolvedRoutineSnapshot = null;
+    // Tracks any snapshot id that `resolvePluginSnapshot()` already pinned
+    // to the reused project before the resolver threw on a later linking
+    // step. `finalizeOk()` performs `linkSnapshotToProject()` BEFORE
+    // `linkSnapshotToConversation()` / `linkSnapshotToRun()`, so a failure
+    // mid-resolve can leave `projects.applied_plugin_snapshot_id` repointed
+    // at a snapshot the routine never durably claimed. The rollback path in
+    // `discard()` falls back to this id when `resolvedRoutineSnapshot` is
+    // still null so the reused project pin is restored either way.
+    let partiallyAppliedSnapshotId: string | null = null;
     const primaryPluginId = routineContext.pluginIds?.[0] ?? null;
     const resolveRoutinePluginSnapshot = async () => {
       if (!primaryPluginId || resolvedRoutineSnapshot) return;
       const registry = await loadPluginRegistryView();
-      const resolved = resolvePluginSnapshot({
-        db,
-        body: {
-          pluginId: primaryPluginId,
-          pluginInputs: { prompt: routine.prompt },
-        },
-        projectId,
-        conversationId,
-        registry,
-        activeProjectDesignSystem:
-          typeof appConfig.designSystemId === 'string' && appConfig.designSystemId.length > 0
-            ? { id: appConfig.designSystemId }
-            : undefined,
-      });
+      const projectSnapshotBefore = routine.target.mode === 'reuse'
+        ? getProject(db, routine.target.projectId)?.appliedPluginSnapshotId ?? null
+        : null;
+      let resolved;
+      try {
+        resolved = resolvePluginSnapshot({
+          db,
+          body: {
+            pluginId: primaryPluginId,
+            pluginInputs: { prompt: routine.prompt },
+          },
+          projectId,
+          conversationId,
+          registry,
+          activeProjectDesignSystem:
+            typeof appConfig.designSystemId === 'string' && appConfig.designSystemId.length > 0
+              ? { id: appConfig.designSystemId }
+              : undefined,
+        });
+      } catch (resolverError) {
+        // `resolvePluginSnapshot()` may have already updated the reused
+        // project's pin via `linkSnapshotToProject()` before throwing on
+        // `linkSnapshotToConversation()` (or `linkSnapshotToRun()`). Capture
+        // whatever pin it left behind so `discard()` can roll it back even
+        // though `resolvedRoutineSnapshot` will stay null.
+        if (routine.target.mode === 'reuse') {
+          const after = getProject(db, routine.target.projectId)?.appliedPluginSnapshotId ?? null;
+          if (after && after !== projectSnapshotBefore) {
+            partiallyAppliedSnapshotId = after;
+          }
+        }
+        throw resolverError;
+      }
       if (resolved && !resolved.ok) {
+        // Non-throwing resolver failures cannot have called `finalizeOk()`,
+        // so the project pin is still the previous one — nothing to roll
+        // back beyond the loser cleanup the caller will perform.
         throw new Error(`Automation plugin ${primaryPluginId} could not be applied: ${JSON.stringify(resolved.body)}`);
       }
       resolvedRoutineSnapshot = resolved;
@@ -12230,6 +12261,16 @@ export async function startServer({
       }, run));
     };
 
+    // Tear-down for the case where the durable routine_run row was never
+    // inserted (sibling daemon won the slot, or insertRun threw). The
+    // in-memory chat run was created speculatively above, but the deferred
+    // `persistPreparedRun()` has not run yet — so no project / conversation
+    // / snapshot writes have to be rolled back. Dropping the run keeps it
+    // off `/api/runs` instead of leaving a phantom canceled entry there.
+    const discardUnstarted = () => {
+      design.runs.drop(run);
+    };
+
     const discard = () => {
       if (typeof run.projectId === 'string' && run.projectId.startsWith('routine-pending-')) {
         run.projectId = null;
@@ -12238,14 +12279,24 @@ export async function startServer({
         run.conversationId = null;
       }
       design.runs.finish(run, 'canceled');
-      if (resolvedRoutineSnapshot?.ok && routine.target.mode === 'reuse') {
-        restoreProjectSnapshotLink(
-          db,
-          projectId,
-          resolvedRoutineSnapshot.snapshotId,
-          previousProjectSnapshotId,
-          run.id,
-        );
+      if (routine.target.mode === 'reuse') {
+        // Prefer the fully-resolved snapshot id; fall back to whatever id
+        // `resolvePluginSnapshot()` left pinned on the project if it threw
+        // partway through linking — see the comment on
+        // `partiallyAppliedSnapshotId` above.
+        const snapshotIdToDiscard =
+          resolvedRoutineSnapshot?.ok
+            ? resolvedRoutineSnapshot.snapshotId
+            : partiallyAppliedSnapshotId;
+        if (snapshotIdToDiscard) {
+          restoreProjectSnapshotLink(
+            db,
+            projectId,
+            snapshotIdToDiscard,
+            previousProjectSnapshotId,
+            run.id,
+          );
+        }
       }
       if (createdConversationId) {
         deleteConversation(db, createdConversationId);
@@ -12311,6 +12362,7 @@ export async function startServer({
       prepare: persistPreparedRun,
       start,
       discard,
+      discardUnstarted,
     };
   });
   routineService.start();

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -329,11 +329,11 @@ import {
   getDeploymentById,
   getProject,
   getTemplate,
-  claimRoutineScheduledSlot,
   insertConversation,
   insertProject,
   insertRoutine,
   insertRoutineRun,
+  insertScheduledRoutineRun,
   insertTemplate,
   findTemplateByNameAndProject,
   updateTemplate,
@@ -3713,8 +3713,8 @@ export async function startServer({
   // delegates "list me everything" / "record a run" back to SQLite.
   routineService = new RoutineService({
     list: () => listRoutines(db).map((row) => routineDbRowToContract(row, null)),
-    insertRun: (run) => {
-      insertRoutineRun(db, {
+    insertRun: (run, options) => {
+      const row = {
         id: run.id,
         routineId: run.routineId,
         trigger: run.trigger,
@@ -3727,13 +3727,17 @@ export async function startServer({
         summary: run.summary,
         error: run.error,
         errorCode: run.errorCode,
-      });
+      };
+      if (options?.scheduledSlotAt != null) {
+        return Boolean(insertScheduledRoutineRun(db, row, options.scheduledSlotAt));
+      }
+      insertRoutineRun(db, row);
+      return true;
     },
     updateRun: (id, patch) => {
       updateRoutineRun(db, id, patch);
     },
     getLatestRun: (routineId) => getLatestRoutineRun(db, routineId),
-    claimScheduledSlot: (routineId, slotAt) => claimRoutineScheduledSlot(db, routineId, slotAt),
   });
   let daemonUrl = `http://127.0.0.1:${port}`;
 
@@ -12059,6 +12063,8 @@ export async function startServer({
     const stamp = formatLocalProjectTimestamp(new Date(now).toISOString());
     let projectId;
     let projectName;
+    let createdProjectId: string | null = null;
+    let createdConversationId: string | null = null;
     if (routine.target.mode === 'reuse') {
       const project = getProject(db, routine.target.projectId);
       if (!project) throw new Error(`Routine target project ${routine.target.projectId} not found`);
@@ -12084,6 +12090,7 @@ export async function startServer({
         createdAt: now,
         updatedAt: now,
       });
+      createdProjectId = projectId;
     }
 
     const conversationId = `routine-conv-${randomUUID()}`;
@@ -12097,16 +12104,8 @@ export async function startServer({
       createdAt: now,
       updatedAt: now,
     });
+    createdConversationId = conversationId;
 
-    // Notify any open `ProjectView` watching this project so its
-    // conversation list picks up the new routine conversation without
-    // requiring the user to leave and re-enter the project (#1361).
-    // For reuse-an-existing-project mode this is the only path the
-    // open view has to learn the conversation exists; for new-project
-    // mode this is harmless (no subscribers for a project that was
-    // just created milliseconds ago). The payload shape is the shared
-    // `ProjectConversationCreatedSsePayload` from `@open-design/contracts`
-    // so the daemon producer and the web consumer cannot drift.
     /** @type {ProjectConversationCreatedSsePayload} */
     const conversationCreatedEvent = {
       type: 'conversation-created',
@@ -12115,7 +12114,6 @@ export async function startServer({
       title: conversationTitle,
       createdAt: now,
     };
-    emitProjectEvent(projectId, conversationCreatedEvent);
 
     const assistantMessageId = `routine-assistant-${randomUUID()}`;
     let resolvedRoutineSnapshot = null;
@@ -12180,23 +12178,43 @@ export async function startServer({
     });
 
     const modelPrefs = appConfig.agentModels?.[agentId] ?? {};
-    design.runs.start(run, () => startChatRun({
-      agentId,
-      projectId,
-      conversationId: run.conversationId,
-      assistantMessageId: run.assistantMessageId,
-      clientRequestId: run.clientRequestId,
-      skillId: routineSkillId,
-      designSystemId: appConfig.designSystemId ?? null,
-      context: routineContext,
-      model: modelPrefs.model ?? null,
-      reasoning: modelPrefs.reasoning ?? null,
-      message: routine.prompt,
-      systemPrompt: [
-        `You are running an unattended scheduled routine named "${routine.name}".`,
-        'Do not ask follow-up questions, do not emit <question-form>, and do not wait for user input. Pick reasonable defaults and finish the task.',
-      ].join('\n'),
-    }, run));
+    const start = () => {
+      // Notify any open `ProjectView` only after the scheduled run row has
+      // been accepted, so duplicate scheduled slots do not surface phantom
+      // conversations (#1361).
+      emitProjectEvent(projectId, conversationCreatedEvent);
+      design.runs.start(run, () => startChatRun({
+        agentId,
+        projectId,
+        conversationId: run.conversationId,
+        assistantMessageId: run.assistantMessageId,
+        clientRequestId: run.clientRequestId,
+        skillId: routineSkillId,
+        designSystemId: appConfig.designSystemId ?? null,
+        context: routineContext,
+        model: modelPrefs.model ?? null,
+        reasoning: modelPrefs.reasoning ?? null,
+        message: routine.prompt,
+        systemPrompt: [
+          `You are running an unattended scheduled routine named "${routine.name}".`,
+          'Do not ask follow-up questions, do not emit <question-form>, and do not wait for user input. Pick reasonable defaults and finish the task.',
+        ].join('\n'),
+      }, run));
+    };
+
+    const discard = () => {
+      try {
+        design.runs.finish(run, 'canceled');
+      } catch {
+        // best-effort cleanup for an unstarted duplicate scheduled run
+      }
+      if (createdConversationId) {
+        try { deleteConversation(db, createdConversationId); } catch {}
+      }
+      if (createdProjectId) {
+        try { dbDeleteProject(db, createdProjectId); } catch {}
+      }
+    };
 
     const completion = (async () => {
       const finalStatus = await design.runs.wait(run);
@@ -12246,7 +12264,7 @@ export async function startServer({
       };
     })();
 
-    return { projectId, conversationId, agentRunId: run.id, completion };
+    return { projectId, conversationId, agentRunId: run.id, completion, start, discard };
   });
   routineService.start();
 

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -106,6 +106,7 @@ import {
   registerBuiltInAtomWorkers,
   registerBundledPlugins,
   registryRootsForDataDir,
+  restoreProjectSnapshotLink,
   resolvePluginSnapshot,
   runPipelineForRun,
   runStageWithRegistry,
@@ -12065,11 +12066,13 @@ export async function startServer({
     let projectName;
     let createdProjectId: string | null = null;
     let createdConversationId: string | null = null;
+    let previousProjectSnapshotId: string | null = null;
     if (routine.target.mode === 'reuse') {
       const project = getProject(db, routine.target.projectId);
       if (!project) throw new Error(`Routine target project ${routine.target.projectId} not found`);
       projectId = project.id;
       projectName = project.name;
+      previousProjectSnapshotId = project.appliedPluginSnapshotId ?? null;
     } else {
       projectId = `routine-${randomUUID()}`;
       projectName = `${routine.name} · ${stamp}`;
@@ -12207,6 +12210,19 @@ export async function startServer({
         design.runs.finish(run, 'canceled');
       } catch {
         // best-effort cleanup for an unstarted duplicate scheduled run
+      }
+      if (resolvedRoutineSnapshot?.ok && routine.target.mode === 'reuse') {
+        try {
+          restoreProjectSnapshotLink(
+            db,
+            projectId,
+            resolvedRoutineSnapshot.snapshotId,
+            previousProjectSnapshotId,
+            run.id,
+          );
+        } catch {
+          // best-effort cleanup for an unstarted duplicate scheduled run
+        }
       }
       if (createdConversationId) {
         try { deleteConversation(db, createdConversationId); } catch {}

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -12098,8 +12098,6 @@ export async function startServer({
       projectId = project.id;
       projectName = project.name;
       previousProjectSnapshotId = project.appliedPluginSnapshotId ?? null;
-    } else if (trigger !== 'scheduled') {
-      createRoutineProject();
     }
 
     let conversationId = `routine-conv-${randomUUID()}`;
@@ -12128,9 +12126,6 @@ export async function startServer({
         createdAt: now,
       };
     };
-    if (trigger !== 'scheduled') {
-      createRoutineConversation();
-    }
 
     const assistantMessageId = `routine-assistant-${randomUUID()}`;
     let resolvedRoutineSnapshot = null;
@@ -12157,10 +12152,6 @@ export async function startServer({
       }
       resolvedRoutineSnapshot = resolved;
     };
-    if (trigger !== 'scheduled') {
-      await resolveRoutinePluginSnapshot();
-    }
-
     const run = design.runs.create({
       projectId: projectId ?? scheduledPlaceholderProjectId,
       conversationId: createdConversationId ? conversationId : scheduledPlaceholderConversationId,
@@ -12175,11 +12166,18 @@ export async function startServer({
         : {}),
     });
     const persistPreparedRun = async (routineRun = null) => {
+      if (!projectId) {
+        createRoutineProject();
+      }
+      if (projectId) {
+        run.projectId = projectId;
+        if (routineRun) {
+          routineRun.projectId = projectId;
+        }
+      }
       createRoutineConversation();
-      run.projectId = projectId;
       run.conversationId = conversationId;
       if (routineRun) {
-        routineRun.projectId = projectId;
         routineRun.conversationId = conversationId;
         routineRun.agentRunId = run.id;
       }
@@ -12209,9 +12207,9 @@ export async function startServer({
 
     const modelPrefs = appConfig.agentModels?.[agentId] ?? {};
     const start = () => {
-      // Notify any open `ProjectView` only after the scheduled run row has
-      // been accepted, so duplicate scheduled slots do not surface phantom
-      // conversations (#1361).
+      // Notify any open `ProjectView` only after the routine run row has
+      // been accepted and preparation has completed, so failed setup does not
+      // surface phantom conversations (#1361).
       if (conversationCreatedEvent) emitProjectEvent(projectId, conversationCreatedEvent);
       design.runs.start(run, () => startChatRun({
         agentId,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -12206,9 +12206,6 @@ export async function startServer({
         startedAt: now,
       });
     };
-    if (trigger !== 'scheduled') {
-      await persistPreparedRun();
-    }
 
     const modelPrefs = appConfig.agentModels?.[agentId] ?? {};
     const start = () => {
@@ -12236,6 +12233,12 @@ export async function startServer({
     };
 
     const discard = () => {
+      if (typeof run.projectId === 'string' && run.projectId.startsWith('routine-pending-')) {
+        run.projectId = null;
+      }
+      if (typeof run.conversationId === 'string' && run.conversationId.startsWith('routine-pending-')) {
+        run.conversationId = null;
+      }
       design.runs.finish(run, 'canceled');
       if (resolvedRoutineSnapshot?.ok && routine.target.mode === 'reuse') {
         restoreProjectSnapshotLink(

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -12064,16 +12064,13 @@ export async function startServer({
     const stamp = formatLocalProjectTimestamp(new Date(now).toISOString());
     let projectId;
     let projectName;
+    const scheduledPlaceholderProjectId = `routine-pending-project-${runId}`;
+    const scheduledPlaceholderConversationId = `routine-pending-conv-${runId}`;
     let createdProjectId: string | null = null;
     let createdConversationId: string | null = null;
     let previousProjectSnapshotId: string | null = null;
-    if (routine.target.mode === 'reuse') {
-      const project = getProject(db, routine.target.projectId);
-      if (!project) throw new Error(`Routine target project ${routine.target.projectId} not found`);
-      projectId = project.id;
-      projectName = project.name;
-      previousProjectSnapshotId = project.appliedPluginSnapshotId ?? null;
-    } else {
+    const createRoutineProject = () => {
+      if (createdProjectId) return;
       projectId = `routine-${randomUUID()}`;
       projectName = `${routine.name} · ${stamp}`;
       insertProject(db, {
@@ -12094,34 +12091,52 @@ export async function startServer({
         updatedAt: now,
       });
       createdProjectId = projectId;
+    };
+    if (routine.target.mode === 'reuse') {
+      const project = getProject(db, routine.target.projectId);
+      if (!project) throw new Error(`Routine target project ${routine.target.projectId} not found`);
+      projectId = project.id;
+      projectName = project.name;
+      previousProjectSnapshotId = project.appliedPluginSnapshotId ?? null;
+    } else if (trigger !== 'scheduled') {
+      createRoutineProject();
     }
 
-    const conversationId = `routine-conv-${randomUUID()}`;
-    const conversationTitle = routine.target.mode === 'reuse'
+    let conversationId = `routine-conv-${randomUUID()}`;
+    let conversationCreatedEvent: ProjectConversationCreatedSsePayload | null = null;
+    const routineConversationTitle = () => routine.target.mode === 'reuse'
       ? `${routine.name} · ${stamp}`
       : projectName;
-    insertConversation(db, {
-      id: conversationId,
-      projectId,
-      title: conversationTitle,
-      createdAt: now,
-      updatedAt: now,
-    });
-    createdConversationId = conversationId;
-
-    /** @type {ProjectConversationCreatedSsePayload} */
-    const conversationCreatedEvent = {
-      type: 'conversation-created',
-      projectId,
-      conversationId,
-      title: conversationTitle,
-      createdAt: now,
+    const createRoutineConversation = () => {
+      if (createdConversationId) return;
+      if (!projectId) createRoutineProject();
+      if (!projectId) throw new Error('Routine project could not be prepared');
+      conversationId = `routine-conv-${randomUUID()}`;
+      insertConversation(db, {
+        id: conversationId,
+        projectId,
+        title: routineConversationTitle(),
+        createdAt: now,
+        updatedAt: now,
+      });
+      createdConversationId = conversationId;
+      conversationCreatedEvent = {
+        type: 'conversation-created',
+        projectId,
+        conversationId,
+        title: routineConversationTitle(),
+        createdAt: now,
+      };
     };
+    if (trigger !== 'scheduled') {
+      createRoutineConversation();
+    }
 
     const assistantMessageId = `routine-assistant-${randomUUID()}`;
     let resolvedRoutineSnapshot = null;
     const primaryPluginId = routineContext.pluginIds?.[0] ?? null;
-    if (primaryPluginId) {
+    const resolveRoutinePluginSnapshot = async () => {
+      if (!primaryPluginId || resolvedRoutineSnapshot) return;
       const registry = await loadPluginRegistryView();
       const resolved = resolvePluginSnapshot({
         db,
@@ -12141,11 +12156,14 @@ export async function startServer({
         throw new Error(`Automation plugin ${primaryPluginId} could not be applied: ${JSON.stringify(resolved.body)}`);
       }
       resolvedRoutineSnapshot = resolved;
+    };
+    if (trigger !== 'scheduled') {
+      await resolveRoutinePluginSnapshot();
     }
 
     const run = design.runs.create({
-      projectId,
-      conversationId,
+      projectId: projectId ?? scheduledPlaceholderProjectId,
+      conversationId: createdConversationId ? conversationId : scheduledPlaceholderConversationId,
       assistantMessageId,
       clientRequestId: `routine-${trigger}-${randomUUID()}`,
       agentId,
@@ -12156,36 +12174,48 @@ export async function startServer({
           }
         : {}),
     });
-    if (resolvedRoutineSnapshot?.ok) {
-      try {
+    const persistPreparedRun = async (routineRun = null) => {
+      createRoutineConversation();
+      run.projectId = projectId;
+      run.conversationId = conversationId;
+      if (routineRun) {
+        routineRun.projectId = projectId;
+        routineRun.conversationId = conversationId;
+        routineRun.agentRunId = run.id;
+      }
+      await resolveRoutinePluginSnapshot();
+      if (resolvedRoutineSnapshot?.ok) {
+        run.appliedPluginSnapshotId = resolvedRoutineSnapshot.snapshotId;
+        run.pluginId = resolvedRoutineSnapshot.snapshot.pluginId;
         const { linkSnapshotToRun } = await import('./plugins/snapshots.js');
         linkSnapshotToRun(db, resolvedRoutineSnapshot.snapshotId, run.id);
-      } catch {
-        // Snapshot linking is best-effort; the in-memory run still carries it.
       }
+      upsertMessage(db, conversationId, {
+        id: `routine-user-${run.id}`,
+        role: 'user',
+        content: routine.prompt,
+      });
+      upsertMessage(db, conversationId, {
+        id: assistantMessageId,
+        role: 'assistant',
+        content: '',
+        agentId,
+        agentName: getAgentDef(agentId)?.name ?? agentId,
+        runId: run.id,
+        runStatus: 'queued',
+        startedAt: now,
+      });
+    };
+    if (trigger !== 'scheduled') {
+      await persistPreparedRun();
     }
-    upsertMessage(db, conversationId, {
-      id: `routine-user-${run.id}`,
-      role: 'user',
-      content: routine.prompt,
-    });
-    upsertMessage(db, conversationId, {
-      id: assistantMessageId,
-      role: 'assistant',
-      content: '',
-      agentId,
-      agentName: getAgentDef(agentId)?.name ?? agentId,
-      runId: run.id,
-      runStatus: 'queued',
-      startedAt: now,
-    });
 
     const modelPrefs = appConfig.agentModels?.[agentId] ?? {};
     const start = () => {
       // Notify any open `ProjectView` only after the scheduled run row has
       // been accepted, so duplicate scheduled slots do not surface phantom
       // conversations (#1361).
-      emitProjectEvent(projectId, conversationCreatedEvent);
+      if (conversationCreatedEvent) emitProjectEvent(projectId, conversationCreatedEvent);
       design.runs.start(run, () => startChatRun({
         agentId,
         projectId,
@@ -12206,29 +12236,21 @@ export async function startServer({
     };
 
     const discard = () => {
-      try {
-        design.runs.finish(run, 'canceled');
-      } catch {
-        // best-effort cleanup for an unstarted duplicate scheduled run
-      }
+      design.runs.finish(run, 'canceled');
       if (resolvedRoutineSnapshot?.ok && routine.target.mode === 'reuse') {
-        try {
-          restoreProjectSnapshotLink(
-            db,
-            projectId,
-            resolvedRoutineSnapshot.snapshotId,
-            previousProjectSnapshotId,
-            run.id,
-          );
-        } catch {
-          // best-effort cleanup for an unstarted duplicate scheduled run
-        }
+        restoreProjectSnapshotLink(
+          db,
+          projectId,
+          resolvedRoutineSnapshot.snapshotId,
+          previousProjectSnapshotId,
+          run.id,
+        );
       }
       if (createdConversationId) {
-        try { deleteConversation(db, createdConversationId); } catch {}
+        deleteConversation(db, createdConversationId);
       }
       if (createdProjectId) {
-        try { dbDeleteProject(db, createdProjectId); } catch {}
+        dbDeleteProject(db, createdProjectId);
       }
     };
 
@@ -12280,7 +12302,15 @@ export async function startServer({
       };
     })();
 
-    return { projectId, conversationId, agentRunId: run.id, completion, start, discard };
+    return {
+      projectId: run.projectId,
+      conversationId: run.conversationId,
+      agentRunId: run.id,
+      completion,
+      prepare: persistPreparedRun,
+      start,
+      discard,
+    };
   });
   routineService.start();
 

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -329,6 +329,7 @@ import {
   getDeploymentById,
   getProject,
   getTemplate,
+  claimRoutineScheduledSlot,
   insertConversation,
   insertProject,
   insertRoutine,
@@ -3732,6 +3733,7 @@ export async function startServer({
       updateRoutineRun(db, id, patch);
     },
     getLatestRun: (routineId) => getLatestRoutineRun(db, routineId),
+    claimScheduledSlot: (routineId, slotAt) => claimRoutineScheduledSlot(db, routineId, slotAt),
   });
   let daemonUrl = `http://127.0.0.1:${port}`;
 

--- a/apps/daemon/tests/plugins-snapshots.test.ts
+++ b/apps/daemon/tests/plugins-snapshots.test.ts
@@ -17,7 +17,9 @@ import {
   createSnapshot,
   getSnapshot,
   linkSnapshotToRun,
+  linkSnapshotToProject,
   markSnapshotStale,
+  restoreProjectSnapshotLink,
 } from '../src/plugins/snapshots.js';
 
 let db: Database.Database;
@@ -104,6 +106,37 @@ describe('snapshots writer', () => {
     const after = db.prepare('SELECT run_id, expires_at FROM applied_plugin_snapshots WHERE id = ?').get(snap.snapshotId) as { run_id: string; expires_at: number | null };
     expect(after.run_id).toBe('run-1');
     expect(after.expires_at).toBeNull();
+  });
+
+  it('restoreProjectSnapshotLink makes an unlinked discarded snapshot expirable again', () => {
+    db.prepare('INSERT INTO projects (id, name) VALUES (?, ?)').run('project-1', 'Project 1');
+    const previous = createSnapshot(db, baseInput({ query: 'Previous {{topic}}' }));
+    linkSnapshotToProject(db, previous.snapshotId, 'project-1');
+    const discarded = createSnapshot(db, baseInput({ query: 'Discarded {{topic}}' }));
+    linkSnapshotToProject(db, discarded.snapshotId, 'project-1');
+
+    restoreProjectSnapshotLink(
+      db,
+      'project-1',
+      discarded.snapshotId,
+      previous.snapshotId,
+      'run-that-was-never-linked',
+    );
+
+    const project = db.prepare(
+      `SELECT applied_plugin_snapshot_id AS appliedPluginSnapshotId
+         FROM projects
+        WHERE id = ?`,
+    ).get('project-1') as { appliedPluginSnapshotId: string | null };
+    const discardedRow = db.prepare(
+      `SELECT run_id AS runId, expires_at AS expiresAt
+         FROM applied_plugin_snapshots
+        WHERE id = ?`,
+    ).get(discarded.snapshotId) as { runId: string | null; expiresAt: number | null };
+
+    expect(project.appliedPluginSnapshotId).toBe(previous.snapshotId);
+    expect(discardedRow.runId).toBeNull();
+    expect(discardedRow.expiresAt).not.toBeNull();
   });
 
   it('markSnapshotStale flips status', () => {

--- a/apps/daemon/tests/routine-schedule-claims.test.ts
+++ b/apps/daemon/tests/routine-schedule-claims.test.ts
@@ -527,6 +527,95 @@ describe('routine prepare failure cleanup', () => {
       await new Promise<void>((resolve) => started.server.close(() => resolve()));
     }
   });
+
+  it('rolls back a manual run when conversation creation fails before the handler returns', async () => {
+    const started = await startServer({ port: 0, returnServer: true }) as {
+      url: string;
+      server: http.Server;
+      shutdown?: () => Promise<void> | void;
+    };
+    const dataDir = process.env.OD_DATA_DIR;
+    if (!dataDir) throw new Error('OD_DATA_DIR is required for daemon route tests');
+    const db = openDatabase(tmp, { dataDir });
+
+    try {
+      const createRoutine = await fetch(`${started.url}/api/routines`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          name: 'Manual early conversation failure routine',
+          prompt: 'prepare resources',
+          schedule: { kind: 'hourly', minute: 1 },
+          target: { mode: 'create_each_run' },
+          agentId: 'codex',
+          enabled: false,
+        }),
+      });
+      expect(createRoutine.status).toBe(201);
+      const created = await createRoutine.json() as { routine: { id: string } };
+
+      db.exec(`
+        DROP TRIGGER IF EXISTS fail_manual_routine_conversation_insert;
+        CREATE TRIGGER fail_manual_routine_conversation_insert
+        BEFORE INSERT ON conversations
+        WHEN NEW.id LIKE 'routine-conv-%'
+          AND NEW.project_id IN (
+            SELECT id FROM projects
+             WHERE json_extract(metadata_json, '$.routineId') = '${created.routine.id}'
+          )
+        BEGIN
+          SELECT RAISE(ABORT, 'routine conversation insert failed');
+        END;
+      `);
+
+      const runRes = await fetch(`${started.url}/api/routines/${created.routine.id}/run`, {
+        method: 'POST',
+      });
+      expect(runRes.status).toBe(500);
+      expect(await runRes.text()).toContain('routine conversation insert failed');
+
+      const rows = db.prepare(
+        `SELECT status,
+                trigger,
+                project_id AS projectId,
+                conversation_id AS conversationId,
+                agent_run_id AS agentRunId,
+                error
+           FROM routine_runs
+          WHERE routine_id = ?`,
+      ).all(created.routine.id) as Array<{
+        status: string;
+        trigger: string;
+        projectId: string;
+        conversationId: string;
+        agentRunId: string;
+        error: string | null;
+      }>;
+      expect(rows).toHaveLength(1);
+      const row = rows[0]!;
+      expect(row).toMatchObject({
+        status: 'failed',
+        trigger: 'manual',
+        error: 'routine conversation insert failed',
+      });
+      expect(row.projectId).toMatch(/^routine-/);
+      expect(row.conversationId).toBe('');
+      expect(row.agentRunId).toMatch(/^[0-9a-f-]{36}$/);
+
+      expect(db.prepare(`SELECT COUNT(*) AS n FROM projects WHERE id = ?`).get(row.projectId))
+        .toEqual({ n: 0 });
+      expect(db.prepare(`SELECT COUNT(*) AS n FROM conversations WHERE project_id = ?`).get(row.projectId))
+        .toEqual({ n: 0 });
+    } finally {
+      try {
+        db.exec('DROP TRIGGER IF EXISTS fail_manual_routine_conversation_insert');
+      } catch {
+        // The test may fail before the trigger exists.
+      }
+      await Promise.resolve(started.shutdown?.());
+      await new Promise<void>((resolve) => started.server.close(() => resolve()));
+    }
+  });
 });
 
 function pluginRecord(id: string): InstalledPluginRecord {

--- a/apps/daemon/tests/routine-schedule-claims.test.ts
+++ b/apps/daemon/tests/routine-schedule-claims.test.ts
@@ -338,6 +338,197 @@ describe('routine scheduled loser cleanup', () => {
   });
 });
 
+describe('routine prepare failure cleanup', () => {
+  it('clears scheduled placeholder IDs when project creation fails before real IDs are assigned', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-17T10:00:00.000Z'));
+
+    const started = await startServer({ port: 0, returnServer: true }) as {
+      url: string;
+      server: http.Server;
+      shutdown?: () => Promise<void> | void;
+    };
+    const dataDir = process.env.OD_DATA_DIR;
+    if (!dataDir) throw new Error('OD_DATA_DIR is required for daemon route tests');
+    const db = openDatabase(tmp, { dataDir });
+
+    try {
+      const createRoutine = await fetch(`${started.url}/api/routines`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          name: 'Scheduled project failure routine',
+          prompt: 'create a project',
+          schedule: { kind: 'hourly', minute: 1 },
+          target: { mode: 'create_each_run' },
+          agentId: 'codex',
+          enabled: true,
+        }),
+      });
+      expect(createRoutine.status).toBe(201);
+      const created = await createRoutine.json() as { routine: { id: string } };
+
+      db.exec(`
+        DROP TRIGGER IF EXISTS fail_scheduled_routine_project_insert;
+        CREATE TRIGGER fail_scheduled_routine_project_insert
+        BEFORE INSERT ON projects
+        WHEN NEW.id LIKE 'routine-%'
+          AND json_extract(NEW.metadata_json, '$.routineId') = '${created.routine.id}'
+        BEGIN
+          SELECT RAISE(ABORT, 'routine project insert failed');
+        END;
+      `);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      await vi.advanceTimersByTimeAsync(0);
+      vi.useRealTimers();
+
+      let stored:
+        | { status: string; projectId: string; conversationId: string; agentRunId: string }
+        | undefined;
+      for (let attempt = 0; attempt < 200; attempt += 1) {
+        stored = db.prepare(
+          `SELECT status,
+                  project_id AS projectId,
+                  conversation_id AS conversationId,
+                  agent_run_id AS agentRunId
+             FROM routine_runs
+            WHERE routine_id = ?`,
+        ).get(created.routine.id) as typeof stored;
+        if (stored?.status === 'failed') break;
+        await sleep(10);
+      }
+
+      expect(stored).toBeDefined();
+      if (!stored) return;
+      expect(stored.status).toBe('failed');
+      expect(stored.projectId).toBe('');
+      expect(stored.conversationId).toBe('');
+      expect(stored.agentRunId).toMatch(/^[0-9a-f-]{36}$/);
+      expect(stored.projectId).not.toContain('routine-pending-project');
+      expect(stored.conversationId).not.toContain('routine-pending-conv');
+
+      const runsRes = await fetch(`${started.url}/api/runs`);
+      expect(runsRes.status).toBe(200);
+      const runsJson = await runsRes.json() as {
+        runs: Array<{ status: string; projectId: string | null; conversationId: string | null; assistantMessageId: string | null }>;
+      };
+      const chatRun = runsJson.runs.find((run) =>
+        typeof run.assistantMessageId === 'string'
+        && run.assistantMessageId.startsWith('routine-assistant-'));
+      expect(chatRun).toBeDefined();
+      expect(chatRun?.status).toBe('canceled');
+      expect(String(chatRun?.projectId ?? '')).not.toContain('routine-pending-project');
+      expect(String(chatRun?.conversationId ?? '')).not.toContain('routine-pending-conv');
+    } finally {
+      vi.useRealTimers();
+      try {
+        db.exec('DROP TRIGGER IF EXISTS fail_scheduled_routine_project_insert');
+      } catch {
+        // The test may fail before the trigger exists.
+      }
+      await Promise.resolve(started.shutdown?.());
+      await new Promise<void>((resolve) => started.server.close(() => resolve()));
+    }
+  });
+
+  it('finalizes and cleans up a manual run when prepare fails after creating the conversation', async () => {
+    const started = await startServer({ port: 0, returnServer: true }) as {
+      url: string;
+      server: http.Server;
+      shutdown?: () => Promise<void> | void;
+    };
+    const dataDir = process.env.OD_DATA_DIR;
+    if (!dataDir) throw new Error('OD_DATA_DIR is required for daemon route tests');
+    const db = openDatabase(tmp, { dataDir });
+
+    try {
+      const createRoutine = await fetch(`${started.url}/api/routines`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          name: 'Manual prepare failure routine',
+          prompt: 'write messages',
+          schedule: { kind: 'hourly', minute: 1 },
+          target: { mode: 'create_each_run' },
+          agentId: 'codex',
+          enabled: false,
+        }),
+      });
+      expect(createRoutine.status).toBe(201);
+      const created = await createRoutine.json() as { routine: { id: string } };
+
+      db.exec(`
+        DROP TRIGGER IF EXISTS fail_manual_routine_message_insert;
+        CREATE TRIGGER fail_manual_routine_message_insert
+        BEFORE INSERT ON messages
+        WHEN NEW.id LIKE 'routine-user-%'
+        BEGIN
+          SELECT RAISE(ABORT, 'routine message insert failed');
+        END;
+      `);
+
+      const runRes = await fetch(`${started.url}/api/routines/${created.routine.id}/run`, {
+        method: 'POST',
+      });
+      expect(runRes.status).toBe(500);
+      expect(await runRes.text()).toContain('routine message insert failed');
+
+      const rows = db.prepare(
+        `SELECT status,
+                trigger,
+                project_id AS projectId,
+                conversation_id AS conversationId,
+                agent_run_id AS agentRunId,
+                error
+           FROM routine_runs
+          WHERE routine_id = ?`,
+      ).all(created.routine.id) as Array<{
+        status: string;
+        trigger: string;
+        projectId: string;
+        conversationId: string;
+        agentRunId: string;
+        error: string | null;
+      }>;
+      expect(rows).toHaveLength(1);
+      const row = rows[0]!;
+      expect(row).toMatchObject({
+        status: 'failed',
+        trigger: 'manual',
+        error: 'routine message insert failed',
+      });
+      expect(row.projectId).toMatch(/^routine-/);
+      expect(row.conversationId).toMatch(/^routine-conv-/);
+      expect(row.agentRunId).toMatch(/^[0-9a-f-]{36}$/);
+
+      expect(db.prepare(`SELECT COUNT(*) AS n FROM projects WHERE id = ?`).get(row.projectId))
+        .toEqual({ n: 0 });
+      expect(db.prepare(`SELECT COUNT(*) AS n FROM conversations WHERE id = ?`).get(row.conversationId))
+        .toEqual({ n: 0 });
+
+      const runsRes = await fetch(`${started.url}/api/runs`);
+      expect(runsRes.status).toBe(200);
+      const runsJson = await runsRes.json() as {
+        runs: Array<{ status: string; assistantMessageId: string | null }>;
+      };
+      const chatRun = runsJson.runs.find((run) =>
+        typeof run.assistantMessageId === 'string'
+        && run.assistantMessageId.startsWith('routine-assistant-'));
+      expect(chatRun).toBeDefined();
+      expect(chatRun?.status).toBe('canceled');
+    } finally {
+      try {
+        db.exec('DROP TRIGGER IF EXISTS fail_manual_routine_message_insert');
+      } catch {
+        // The test may fail before the trigger exists.
+      }
+      await Promise.resolve(started.shutdown?.());
+      await new Promise<void>((resolve) => started.server.close(() => resolve()));
+    }
+  });
+});
+
 function pluginRecord(id: string): InstalledPluginRecord {
   const manifest: PluginManifest = {
     name: id,

--- a/apps/daemon/tests/routine-schedule-claims.test.ts
+++ b/apps/daemon/tests/routine-schedule-claims.test.ts
@@ -644,6 +644,67 @@ describe('routine prepare failure cleanup', () => {
     }
   });
 
+  it('returns prepared IDs for a successful manual create_each_run response', async () => {
+    const started = await startServer({ port: 0, returnServer: true }) as {
+      url: string;
+      server: http.Server;
+      shutdown?: () => Promise<void> | void;
+    };
+    const dataDir = process.env.OD_DATA_DIR;
+    if (!dataDir) throw new Error('OD_DATA_DIR is required for daemon route tests');
+    const db = openDatabase(tmp, { dataDir });
+
+    try {
+      const createRoutine = await fetch(`${started.url}/api/routines`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          name: 'Manual response routine',
+          prompt: 'prepare and return ids',
+          schedule: { kind: 'hourly', minute: 1 },
+          target: { mode: 'create_each_run' },
+          agentId: 'missing-agent-for-route-test',
+          enabled: false,
+        }),
+      });
+      expect(createRoutine.status).toBe(201);
+      const created = await createRoutine.json() as { routine: { id: string } };
+
+      const runRes = await fetch(`${started.url}/api/routines/${created.routine.id}/run`, {
+        method: 'POST',
+      });
+      expect(runRes.status).toBe(202);
+      const runJson = await runRes.json() as {
+        projectId: string;
+        conversationId: string;
+        agentRunId: string;
+        run: {
+          projectId: string;
+          conversationId: string;
+          agentRunId: string;
+        };
+      };
+
+      expect(runJson.projectId).toMatch(/^routine-/);
+      expect(runJson.conversationId).toMatch(/^routine-conv-/);
+      expect(runJson.agentRunId).toMatch(/^[0-9a-f-]{36}$/);
+      expect(runJson.projectId).not.toContain('routine-pending-project');
+      expect(runJson.conversationId).not.toContain('routine-pending-conv');
+      expect(runJson.run).toMatchObject({
+        projectId: runJson.projectId,
+        conversationId: runJson.conversationId,
+        agentRunId: runJson.agentRunId,
+      });
+      expect(db.prepare(`SELECT COUNT(*) AS n FROM projects WHERE id = ?`).get(runJson.projectId))
+        .toEqual({ n: 1 });
+      expect(db.prepare(`SELECT COUNT(*) AS n FROM conversations WHERE id = ?`).get(runJson.conversationId))
+        .toEqual({ n: 1 });
+    } finally {
+      await Promise.resolve(started.shutdown?.());
+      await new Promise<void>((resolve) => started.server.close(() => resolve()));
+    }
+  });
+
   it('finalizes and cleans up a manual run when prepare fails after creating the conversation', async () => {
     const started = await startServer({ port: 0, returnServer: true }) as {
       url: string;

--- a/apps/daemon/tests/routine-schedule-claims.test.ts
+++ b/apps/daemon/tests/routine-schedule-claims.test.ts
@@ -5,9 +5,10 @@ import path from 'node:path';
 import Database from 'better-sqlite3';
 
 import {
-  claimRoutineScheduledSlot,
   closeDatabase,
   insertRoutine,
+  insertRoutineRun,
+  insertScheduledRoutineRun,
   openDatabase,
 } from '../src/db.js';
 
@@ -25,7 +26,7 @@ afterEach(async () => {
 });
 
 describe('routine scheduled slot claims', () => {
-  it('deduplicates scheduled slot reservations across SQLite connections', () => {
+  it('deduplicates scheduled run insertion in the same transaction as the slot claim', () => {
     const first = openDatabase(tmp, { dataDir: tmp });
     insertRoutine(first, {
       id: 'routine-1',
@@ -47,11 +48,35 @@ describe('routine scheduled slot claims', () => {
     try {
       second.pragma('foreign_keys = ON');
 
-      expect(claimRoutineScheduledSlot(first, 'routine-1', 1779012900000)).toBe(true);
-      expect(claimRoutineScheduledSlot(second, 'routine-1', 1779012900000)).toBe(false);
-      expect(claimRoutineScheduledSlot(second, 'routine-1', 1779016500000)).toBe(true);
+      const firstRun = insertScheduledRoutineRun(first, makeRun('run-1'), 1779012900000);
+      const secondRun = insertScheduledRoutineRun(second, makeRun('run-2'), 1779012900000);
+      const manualRun = insertRoutineRun(second, makeRun('run-manual', { trigger: 'manual' }));
+
+      expect(firstRun?.id).toBe('run-1');
+      expect(secondRun).toBeNull();
+      expect(manualRun?.id).toBe('run-manual');
+      expect(
+        first.prepare(`SELECT id FROM routine_runs ORDER BY id`).all(),
+      ).toEqual([{ id: 'run-1' }, { id: 'run-manual' }]);
     } finally {
       second.close();
     }
   });
 });
+
+function makeRun(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    routineId: 'routine-1',
+    trigger: 'scheduled',
+    status: 'running',
+    projectId: `project-${id}`,
+    conversationId: `conversation-${id}`,
+    agentRunId: `agent-${id}`,
+    startedAt: 1779012900000,
+    completedAt: null,
+    summary: null,
+    error: null,
+    ...overrides,
+  };
+}

--- a/apps/daemon/tests/routine-schedule-claims.test.ts
+++ b/apps/daemon/tests/routine-schedule-claims.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+
+import {
+  claimRoutineScheduledSlot,
+  closeDatabase,
+  insertRoutine,
+  openDatabase,
+} from '../src/db.js';
+
+let tmp: string;
+let dbFile: string;
+
+beforeEach(async () => {
+  tmp = await mkdtemp(path.join(os.tmpdir(), 'od-routine-claims-'));
+  dbFile = path.join(tmp, 'app.sqlite');
+});
+
+afterEach(async () => {
+  closeDatabase();
+  await rm(tmp, { recursive: true, force: true });
+});
+
+describe('routine scheduled slot claims', () => {
+  it('deduplicates scheduled slot reservations across SQLite connections', () => {
+    const first = openDatabase(tmp, { dataDir: tmp });
+    insertRoutine(first, {
+      id: 'routine-1',
+      name: 'Daily brief',
+      prompt: 'Summarize the day',
+      scheduleKind: 'hourly',
+      scheduleValue: '15',
+      scheduleJson: JSON.stringify({ kind: 'hourly', minute: 15 }),
+      projectMode: 'create_each_run',
+      projectId: null,
+      skillId: null,
+      agentId: null,
+      enabled: true,
+      createdAt: 1779012000000,
+      updatedAt: 1779012000000,
+    });
+
+    const second = new Database(dbFile);
+    try {
+      second.pragma('foreign_keys = ON');
+
+      expect(claimRoutineScheduledSlot(first, 'routine-1', 1779012900000)).toBe(true);
+      expect(claimRoutineScheduledSlot(second, 'routine-1', 1779012900000)).toBe(false);
+      expect(claimRoutineScheduledSlot(second, 'routine-1', 1779016500000)).toBe(true);
+    } finally {
+      second.close();
+    }
+  });
+});

--- a/apps/daemon/tests/routine-schedule-claims.test.ts
+++ b/apps/daemon/tests/routine-schedule-claims.test.ts
@@ -1,16 +1,24 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type http from 'node:http';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mkdtemp, rm } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
 import Database from 'better-sqlite3';
+import type { InstalledPluginRecord, PluginManifest } from '@open-design/contracts';
 
 import {
   closeDatabase,
+  getProject,
   insertRoutine,
   insertRoutineRun,
   insertScheduledRoutineRun,
+  insertProject,
   openDatabase,
 } from '../src/db.js';
+import { startServer } from '../src/server.js';
+import { upsertInstalledPlugin } from '../src/plugins/registry.js';
+import { createSnapshot, linkSnapshotToProject } from '../src/plugins/snapshots.js';
 
 let tmp: string;
 let dbFile: string;
@@ -21,6 +29,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  vi.useRealTimers();
   closeDatabase();
   await rm(tmp, { recursive: true, force: true });
 });
@@ -78,5 +87,132 @@ function makeRun(id: string, overrides: Record<string, unknown> = {}) {
     summary: null,
     error: null,
     ...overrides,
+  };
+}
+
+describe('routine scheduled loser cleanup', () => {
+  it('does not let a discarded reuse-mode loser replace the shared project snapshot pin', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-17T10:00:00.000Z'));
+
+    const started = await startServer({ port: 0, returnServer: true }) as {
+      url: string;
+      server: http.Server;
+      shutdown?: () => Promise<void> | void;
+    };
+    const dataDir = process.env.OD_DATA_DIR;
+    if (!dataDir) throw new Error('OD_DATA_DIR is required for daemon route tests');
+    const db = openDatabase(tmp, { dataDir });
+    const projectId = 'routine-reuse-project';
+    const routinePlugin = pluginRecord('routine-plugin');
+    upsertInstalledPlugin(db, routinePlugin);
+    insertProject(db, {
+      id: projectId,
+      name: 'Routine reuse target',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    const previousSnapshot = createSnapshot(db, {
+      projectId,
+      pluginId: routinePlugin.id,
+      pluginVersion: routinePlugin.version,
+      manifestSourceDigest: '0'.repeat(64),
+      taskKind: 'new-generation',
+      inputs: { prompt: 'previous prompt' },
+      resolvedContext: { items: [] },
+      capabilitiesGranted: ['prompt:inject'],
+      capabilitiesRequired: ['prompt:inject'],
+      assetsStaged: [],
+      connectorsRequired: [],
+      connectorsResolved: [],
+      mcpServers: [],
+      query: 'Previous {{prompt}}',
+    });
+    linkSnapshotToProject(db, previousSnapshot.snapshotId, projectId);
+
+    try {
+      const createRoutine = await fetch(`${started.url}/api/routines`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          name: 'Scheduled reuse routine',
+          prompt: 'fresh prompt',
+          schedule: { kind: 'hourly', minute: 1 },
+          target: { mode: 'reuse', projectId },
+          context: { pluginIds: [routinePlugin.id] },
+          agentId: 'codex',
+          enabled: true,
+        }),
+      });
+      expect(createRoutine.status).toBe(201);
+      const created = await createRoutine.json() as { routine: { id: string } };
+      const slotAt = Date.UTC(2026, 4, 17, 10, 1);
+      insertScheduledRoutineRun(db, {
+        ...makeRun('winning-run', {
+          routineId: created.routine.id,
+          projectId,
+          conversationId: 'winning-conversation',
+          agentRunId: 'winning-agent-run',
+        }),
+      }, slotAt);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      vi.useRealTimers();
+      let snapshotCount = 0;
+      for (let attempt = 0; attempt < 200; attempt += 1) {
+        await sleep(10);
+        snapshotCount = (db.prepare(
+          `SELECT COUNT(*) AS n FROM applied_plugin_snapshots WHERE project_id = ?`,
+        ).get(projectId) as { n: number }).n;
+        if (snapshotCount > 1) break;
+      }
+
+      expect(snapshotCount).toBeGreaterThan(1);
+      expect(getProject(db, projectId)?.appliedPluginSnapshotId)
+        .toBe(previousSnapshot.snapshotId);
+      const loserSnapshot = db.prepare(
+        `SELECT run_id AS runId, expires_at AS expiresAt
+           FROM applied_plugin_snapshots
+          WHERE project_id = ?
+            AND id <> ?`,
+      ).get(projectId, previousSnapshot.snapshotId) as {
+        runId: string | null;
+        expiresAt: number | null;
+      };
+      expect(loserSnapshot.runId).toBeNull();
+      expect(loserSnapshot.expiresAt).not.toBeNull();
+    } finally {
+      await Promise.resolve(started.shutdown?.());
+      await new Promise<void>((resolve) => started.server.close(() => resolve()));
+    }
+  });
+});
+
+function pluginRecord(id: string): InstalledPluginRecord {
+  const manifest: PluginManifest = {
+    name: id,
+    title: 'Routine Plugin',
+    version: '1.0.0',
+    description: 'Routine snapshot fixture.',
+    od: {
+      kind: 'skill',
+      taskKind: 'new-generation',
+      useCase: { query: 'Handle {{prompt}}' },
+      inputs: [{ name: 'prompt', type: 'string', required: true }],
+      capabilities: ['prompt:inject'],
+    },
+  } as PluginManifest;
+  return {
+    id,
+    title: 'Routine Plugin',
+    version: '1.0.0',
+    sourceKind: 'local',
+    source: `/tmp/${id}`,
+    fsPath: `/tmp/${id}`,
+    trust: 'trusted',
+    capabilitiesGranted: ['prompt:inject'],
+    installedAt: Date.now(),
+    updatedAt: Date.now(),
+    manifest,
   };
 }

--- a/apps/daemon/tests/routine-schedule-claims.test.ts
+++ b/apps/daemon/tests/routine-schedule-claims.test.ts
@@ -91,6 +91,93 @@ function makeRun(id: string, overrides: Record<string, unknown> = {}) {
 }
 
 describe('routine scheduled loser cleanup', () => {
+  it('prepares a winning scheduled reuse run after the slot claim is persisted', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-17T10:00:00.000Z'));
+
+    const started = await startServer({ port: 0, returnServer: true }) as {
+      url: string;
+      server: http.Server;
+      shutdown?: () => Promise<void> | void;
+    };
+    const dataDir = process.env.OD_DATA_DIR;
+    if (!dataDir) throw new Error('OD_DATA_DIR is required for daemon route tests');
+    const db = openDatabase(tmp, { dataDir });
+    const projectId = 'routine-winner-project';
+    const routinePlugin = pluginRecord('routine-winner-plugin');
+    upsertInstalledPlugin(db, routinePlugin);
+    insertProject(db, {
+      id: projectId,
+      name: 'Routine winner target',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    const previousSnapshot = createSnapshot(db, {
+      projectId,
+      pluginId: routinePlugin.id,
+      pluginVersion: routinePlugin.version,
+      manifestSourceDigest: '2'.repeat(64),
+      taskKind: 'new-generation',
+      inputs: { prompt: 'previous prompt' },
+      resolvedContext: { items: [] },
+      capabilitiesGranted: ['prompt:inject'],
+      capabilitiesRequired: ['prompt:inject'],
+      assetsStaged: [],
+      connectorsRequired: [],
+      connectorsResolved: [],
+      mcpServers: [],
+      query: 'Previous {{prompt}}',
+    });
+    linkSnapshotToProject(db, previousSnapshot.snapshotId, projectId);
+
+    try {
+      const createRoutine = await fetch(`${started.url}/api/routines`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          name: 'Scheduled winner routine',
+          prompt: 'fresh prompt',
+          schedule: { kind: 'hourly', minute: 1 },
+          target: { mode: 'reuse', projectId },
+          context: { pluginIds: [routinePlugin.id] },
+          agentId: 'codex',
+          enabled: true,
+        }),
+      });
+      expect(createRoutine.status).toBe(201);
+      const created = await createRoutine.json() as { routine: { id: string } };
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      vi.useRealTimers();
+      let run: { projectId: string; conversationId: string; agentRunId: string } | undefined;
+      for (let attempt = 0; attempt < 200; attempt += 1) {
+        run = db.prepare(
+          `SELECT project_id AS projectId, conversation_id AS conversationId, agent_run_id AS agentRunId
+             FROM routine_runs
+            WHERE routine_id = ?`,
+        ).get(created.routine.id) as typeof run;
+        if (run?.conversationId?.startsWith('routine-conv-')) break;
+        await sleep(10);
+      }
+      expect(run).toBeDefined();
+      if (!run) return;
+      expect(run.projectId).toBe(projectId);
+      expect(run.conversationId).toMatch(/^routine-conv-/);
+      expect(run.agentRunId).toMatch(/^[0-9a-f-]{36}$/);
+      expect(db.prepare(
+        `SELECT COUNT(*) AS n FROM conversations WHERE project_id = ?`,
+      ).get(projectId)).toEqual({ n: 1 });
+      expect(db.prepare(
+        `SELECT COUNT(*) AS n FROM applied_plugin_snapshots WHERE project_id = ?`,
+      ).get(projectId)).toEqual({ n: 2 });
+      expect(getProject(db, projectId)?.appliedPluginSnapshotId)
+        .not.toBe(previousSnapshot.snapshotId);
+    } finally {
+      await Promise.resolve(started.shutdown?.());
+      await new Promise<void>((resolve) => started.server.close(() => resolve()));
+    }
+  });
+
   it('does not let a discarded reuse-mode loser replace the shared project snapshot pin', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-17T10:00:00.000Z'));
@@ -148,7 +235,7 @@ describe('routine scheduled loser cleanup', () => {
       const created = await createRoutine.json() as { routine: { id: string } };
       const slotAt = Date.UTC(2026, 4, 17, 10, 1);
       insertScheduledRoutineRun(db, {
-        ...makeRun('winning-run', {
+        ...makeRun('rollback-winning-run', {
           routineId: created.routine.id,
           projectId,
           conversationId: 'winning-conversation',
@@ -157,30 +244,93 @@ describe('routine scheduled loser cleanup', () => {
       }, slotAt);
 
       await vi.advanceTimersByTimeAsync(60_000);
-      vi.useRealTimers();
-      let snapshotCount = 0;
-      for (let attempt = 0; attempt < 200; attempt += 1) {
-        await sleep(10);
-        snapshotCount = (db.prepare(
-          `SELECT COUNT(*) AS n FROM applied_plugin_snapshots WHERE project_id = ?`,
-        ).get(projectId) as { n: number }).n;
-        if (snapshotCount > 1) break;
-      }
-
-      expect(snapshotCount).toBeGreaterThan(1);
+      const snapshotCount = (db.prepare(
+        `SELECT COUNT(*) AS n FROM applied_plugin_snapshots WHERE project_id = ?`,
+      ).get(projectId) as { n: number }).n;
+      expect(snapshotCount).toBe(1);
       expect(getProject(db, projectId)?.appliedPluginSnapshotId)
         .toBe(previousSnapshot.snapshotId);
-      const loserSnapshot = db.prepare(
-        `SELECT run_id AS runId, expires_at AS expiresAt
-           FROM applied_plugin_snapshots
-          WHERE project_id = ?
-            AND id <> ?`,
-      ).get(projectId, previousSnapshot.snapshotId) as {
-        runId: string | null;
-        expiresAt: number | null;
-      };
-      expect(loserSnapshot.runId).toBeNull();
-      expect(loserSnapshot.expiresAt).not.toBeNull();
+    } finally {
+      await Promise.resolve(started.shutdown?.());
+      await new Promise<void>((resolve) => started.server.close(() => resolve()));
+    }
+  });
+
+  it('does not create provisional database state for a reuse-mode loser before the slot is won', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-17T10:00:00.000Z'));
+
+    const started = await startServer({ port: 0, returnServer: true }) as {
+      url: string;
+      server: http.Server;
+      shutdown?: () => Promise<void> | void;
+    };
+    const dataDir = process.env.OD_DATA_DIR;
+    if (!dataDir) throw new Error('OD_DATA_DIR is required for daemon route tests');
+    const db = openDatabase(tmp, { dataDir });
+    const projectId = 'routine-rollback-failure-project';
+    const routinePlugin = pluginRecord('routine-rollback-plugin');
+    upsertInstalledPlugin(db, routinePlugin);
+    insertProject(db, {
+      id: projectId,
+      name: 'Routine rollback target',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    const previousSnapshot = createSnapshot(db, {
+      projectId,
+      pluginId: routinePlugin.id,
+      pluginVersion: routinePlugin.version,
+      manifestSourceDigest: '1'.repeat(64),
+      taskKind: 'new-generation',
+      inputs: { prompt: 'previous prompt' },
+      resolvedContext: { items: [] },
+      capabilitiesGranted: ['prompt:inject'],
+      capabilitiesRequired: ['prompt:inject'],
+      assetsStaged: [],
+      connectorsRequired: [],
+      connectorsResolved: [],
+      mcpServers: [],
+      query: 'Previous {{prompt}}',
+    });
+    linkSnapshotToProject(db, previousSnapshot.snapshotId, projectId);
+
+    try {
+      const createRoutine = await fetch(`${started.url}/api/routines`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          name: 'Scheduled rollback routine',
+          prompt: 'fresh prompt',
+          schedule: { kind: 'hourly', minute: 1 },
+          target: { mode: 'reuse', projectId },
+          context: { pluginIds: [routinePlugin.id] },
+          agentId: 'codex',
+          enabled: true,
+        }),
+      });
+      expect(createRoutine.status).toBe(201);
+      const created = await createRoutine.json() as { routine: { id: string } };
+      const slotAt = Date.UTC(2026, 4, 17, 10, 1);
+      insertScheduledRoutineRun(db, {
+        ...makeRun('winning-run', {
+          routineId: created.routine.id,
+          projectId,
+          conversationId: 'rollback-winning-conversation',
+          agentRunId: 'rollback-winning-agent-run',
+        }),
+      }, slotAt);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(getProject(db, projectId)?.appliedPluginSnapshotId)
+        .toBe(previousSnapshot.snapshotId);
+      expect(db.prepare(
+        `SELECT COUNT(*) AS n FROM conversations WHERE project_id = ?`,
+      ).get(projectId)).toEqual({ n: 0 });
+      expect(db.prepare(
+        `SELECT COUNT(*) AS n FROM applied_plugin_snapshots WHERE project_id = ?`,
+      ).get(projectId)).toEqual({ n: 1 });
     } finally {
       await Promise.resolve(started.shutdown?.());
       await new Promise<void>((resolve) => started.server.close(() => resolve()));

--- a/apps/daemon/tests/routine-schedule-claims.test.ts
+++ b/apps/daemon/tests/routine-schedule-claims.test.ts
@@ -256,6 +256,218 @@ describe('routine scheduled loser cleanup', () => {
     }
   });
 
+  it('does not expose a phantom canceled run when a duplicate scheduled slot is lost', async () => {
+    // Reviewer regression: `server.ts` now creates the in-memory
+    // `design.runs` entry before `insertScheduledRoutineRun()` decides
+    // whether this daemon won the slot. The loser path used to call
+    // `design.runs.finish(run, 'canceled')`, which surfaced a phantom
+    // canceled chat run via `/api/runs` even though no `routine_runs` row,
+    // conversation, or messages were ever committed. The fix routes the
+    // never-inserted path through `design.runs.drop()` so duplicate losers
+    // do not leak in-memory runs back through the public API.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-17T10:00:00.000Z'));
+
+    const started = await startServer({ port: 0, returnServer: true }) as {
+      url: string;
+      server: http.Server;
+      shutdown?: () => Promise<void> | void;
+    };
+    const dataDir = process.env.OD_DATA_DIR;
+    if (!dataDir) throw new Error('OD_DATA_DIR is required for daemon route tests');
+    const db = openDatabase(tmp, { dataDir });
+    const projectId = 'routine-phantom-loser-project';
+    insertProject(db, {
+      id: projectId,
+      name: 'Routine phantom loser target',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    try {
+      const createRoutine = await fetch(`${started.url}/api/routines`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          name: 'Scheduled phantom-loser routine',
+          prompt: 'fresh prompt',
+          schedule: { kind: 'hourly', minute: 1 },
+          target: { mode: 'reuse', projectId },
+          agentId: 'codex',
+          enabled: true,
+        }),
+      });
+      expect(createRoutine.status).toBe(201);
+      const created = await createRoutine.json() as { routine: { id: string } };
+      const slotAt = Date.UTC(2026, 4, 17, 10, 1);
+      // Pre-claim the slot from a sibling daemon so the loser branch fires
+      // in this process. The winning row carries the same routine and slot.
+      insertScheduledRoutineRun(db, {
+        ...makeRun('phantom-winning-run', {
+          routineId: created.routine.id,
+          projectId,
+          conversationId: 'phantom-winning-conversation',
+          agentRunId: 'phantom-winning-agent-run',
+        }),
+      }, slotAt);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      await vi.advanceTimersByTimeAsync(0);
+      vi.useRealTimers();
+
+      // Wait until at least one tick after the scheduled timer fired so the
+      // loser branch has had a chance to clean up.
+      await sleep(50);
+
+      // The only routine_runs row is the pre-seeded winner; the loser
+      // never made it through `insertScheduledRoutineRun()`.
+      const rows = db.prepare(
+        `SELECT id FROM routine_runs WHERE routine_id = ? ORDER BY id`,
+      ).all(created.routine.id) as Array<{ id: string }>;
+      expect(rows).toEqual([{ id: 'phantom-winning-run' }]);
+
+      // `/api/runs` must not surface the loser's in-memory chat run as
+      // `canceled` — `design.runs.drop()` removes it from the registry.
+      const runsRes = await fetch(`${started.url}/api/runs`);
+      expect(runsRes.status).toBe(200);
+      const runsJson = await runsRes.json() as {
+        runs: Array<{ status: string; assistantMessageId: string | null }>;
+      };
+      const phantom = runsJson.runs.find((run) =>
+        typeof run.assistantMessageId === 'string'
+        && run.assistantMessageId.startsWith('routine-assistant-'));
+      expect(phantom).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+      await Promise.resolve(started.shutdown?.());
+      await new Promise<void>((resolve) => started.server.close(() => resolve()));
+    }
+  });
+
+  it('restores the reused project pin when the snapshot resolver throws mid-link', async () => {
+    // Reviewer regression: `resolveRoutinePluginSnapshot()` only assigns
+    // `resolvedRoutineSnapshot` AFTER the resolver returns, but
+    // `resolvePluginSnapshot()` already calls `linkSnapshotToProject()`
+    // inside `finalizeOk()` before linking the conversation or run. If
+    // `linkSnapshotToConversation()` throws (e.g. a CHECK constraint, a
+    // missing conversation row, a trigger), `discard()` previously landed
+    // with `resolvedRoutineSnapshot === null` and never restored the
+    // project's prior pin — leaving the reused project pointed at a
+    // snapshot the routine never durably claimed.
+    //
+    // The fix captures the intermediate pin in `partiallyAppliedSnapshotId`
+    // when the resolver throws, and `discard()` falls back to it when
+    // `resolvedRoutineSnapshot` is still null. This test forces the link
+    // step to fail via a SQLite trigger on `conversations` (the resolver
+    // links the snapshot to the conversation row before returning, and
+    // that link path updates `conversations.applied_plugin_snapshot_id`).
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-17T10:00:00.000Z'));
+
+    const started = await startServer({ port: 0, returnServer: true }) as {
+      url: string;
+      server: http.Server;
+      shutdown?: () => Promise<void> | void;
+    };
+    const dataDir = process.env.OD_DATA_DIR;
+    if (!dataDir) throw new Error('OD_DATA_DIR is required for daemon route tests');
+    const db = openDatabase(tmp, { dataDir });
+    const projectId = 'routine-mid-link-rollback-project';
+    const routinePlugin = pluginRecord('routine-mid-link-plugin');
+    upsertInstalledPlugin(db, routinePlugin);
+    insertProject(db, {
+      id: projectId,
+      name: 'Routine mid-link rollback target',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    const previousSnapshot = createSnapshot(db, {
+      projectId,
+      pluginId: routinePlugin.id,
+      pluginVersion: routinePlugin.version,
+      manifestSourceDigest: '3'.repeat(64),
+      taskKind: 'new-generation',
+      inputs: { prompt: 'previous prompt' },
+      resolvedContext: { items: [] },
+      capabilitiesGranted: ['prompt:inject'],
+      capabilitiesRequired: ['prompt:inject'],
+      assetsStaged: [],
+      connectorsRequired: [],
+      connectorsResolved: [],
+      mcpServers: [],
+      query: 'Previous {{prompt}}',
+    });
+    linkSnapshotToProject(db, previousSnapshot.snapshotId, projectId);
+
+    try {
+      const createRoutine = await fetch(`${started.url}/api/routines`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          name: 'Scheduled mid-link rollback routine',
+          prompt: 'fresh prompt',
+          schedule: { kind: 'hourly', minute: 1 },
+          target: { mode: 'reuse', projectId },
+          context: { pluginIds: [routinePlugin.id] },
+          agentId: 'codex',
+          enabled: true,
+        }),
+      });
+      expect(createRoutine.status).toBe(201);
+      const created = await createRoutine.json() as { routine: { id: string } };
+
+      // Trigger after `linkSnapshotToProject()` but during
+      // `linkSnapshotToConversation()`. The resolver runs
+      // `UPDATE applied_plugin_snapshots SET conversation_id = ?, expires_at = NULL`
+      // followed by `UPDATE conversations SET applied_plugin_snapshot_id = ?`.
+      // We fail on the conversations.applied_plugin_snapshot_id update so the
+      // project pin has already moved but the resolver throws before
+      // returning a snapshot to the caller.
+      db.exec(`
+        DROP TRIGGER IF EXISTS fail_routine_conv_snapshot_link;
+        CREATE TRIGGER fail_routine_conv_snapshot_link
+        BEFORE UPDATE OF applied_plugin_snapshot_id ON conversations
+        WHEN NEW.applied_plugin_snapshot_id IS NOT NULL
+          AND NEW.id LIKE 'routine-conv-%'
+        BEGIN
+          SELECT RAISE(ABORT, 'routine conversation snapshot link failed');
+        END;
+      `);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      await vi.advanceTimersByTimeAsync(0);
+      vi.useRealTimers();
+
+      // Wait for the routine_runs row to land in a terminal failed state —
+      // the scheduled prepare-failure path patches the row to 'failed'
+      // after the slot claim is accepted.
+      let stored: { status: string } | undefined;
+      for (let attempt = 0; attempt < 200; attempt += 1) {
+        stored = db.prepare(
+          `SELECT status FROM routine_runs WHERE routine_id = ?`,
+        ).get(created.routine.id) as typeof stored;
+        if (stored?.status === 'failed') break;
+        await sleep(10);
+      }
+      expect(stored?.status).toBe('failed');
+
+      // The reused project's pin must point back at the pre-existing
+      // snapshot, not at the half-applied one. Without the rollback fix,
+      // `applied_plugin_snapshot_id` would still be the resolver's new id.
+      expect(getProject(db, projectId)?.appliedPluginSnapshotId)
+        .toBe(previousSnapshot.snapshotId);
+    } finally {
+      vi.useRealTimers();
+      try {
+        db.exec('DROP TRIGGER IF EXISTS fail_routine_conv_snapshot_link');
+      } catch {
+        // The test may fail before the trigger exists.
+      }
+      await Promise.resolve(started.shutdown?.());
+      await new Promise<void>((resolve) => started.server.close(() => resolve()));
+    }
+  });
+
   it('does not create provisional database state for a reuse-mode loser before the slot is won', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-17T10:00:00.000Z'));

--- a/apps/daemon/tests/routines.test.ts
+++ b/apps/daemon/tests/routines.test.ts
@@ -485,6 +485,39 @@ describe('RoutineService scheduled run idempotency', () => {
     });
   });
 
+  it('returns prepared IDs from successful manual runs', async () => {
+    const persistence = new SharedRoutinePersistence([fixtureRoutine()]);
+    const service = new RoutineService(persistence);
+
+    service.setRunHandler(async () => ({
+      projectId: 'routine-pending-project',
+      conversationId: 'routine-pending-conversation',
+      agentRunId: 'routine-pending-run',
+      completion: Promise.resolve({ status: 'succeeded' as const }),
+      prepare: (run: RoutineRun) => {
+        run.projectId = 'real-project';
+        run.conversationId = 'real-conversation';
+        run.agentRunId = 'real-agent-run';
+      },
+    }));
+
+    const started = await service.runNow('routine-1');
+    await Promise.resolve();
+
+    expect(started).toMatchObject({
+      projectId: 'real-project',
+      conversationId: 'real-conversation',
+      agentRunId: 'real-agent-run',
+    });
+    expect(persistence.runs).toHaveLength(1);
+    expect(persistence.runs[0]).toMatchObject({
+      trigger: 'manual',
+      projectId: 'real-project',
+      conversationId: 'real-conversation',
+      agentRunId: 'real-agent-run',
+    });
+  });
+
   it('still finalizes the failed row when prepare cleanup itself throws', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-17T10:00:00.000Z'));

--- a/apps/daemon/tests/routines.test.ts
+++ b/apps/daemon/tests/routines.test.ts
@@ -31,6 +31,7 @@ function partsIn(timezone: string, at: Date): Record<string, string> {
 class SharedRoutinePersistence {
   readonly runs: RoutineRun[] = [];
   readonly claimedSlots = new Set<string>();
+  failScheduledInsertAttempts = 0;
 
   constructor(private readonly routines: Routine[]) {}
 
@@ -38,8 +39,18 @@ class SharedRoutinePersistence {
     return this.routines;
   }
 
-  insertRun(run: RoutineRun): void {
+  insertRun(run: RoutineRun, options: { scheduledSlotAt?: number } = {}): boolean {
+    if (options.scheduledSlotAt != null) {
+      if (this.failScheduledInsertAttempts > 0) {
+        this.failScheduledInsertAttempts -= 1;
+        throw new Error('scheduled slot claim unavailable');
+      }
+      const key = `${run.routineId}:${options.scheduledSlotAt}`;
+      if (this.claimedSlots.has(key)) return false;
+      this.claimedSlots.add(key);
+    }
     this.runs.push(run);
+    return true;
   }
 
   updateRun(id: string, patch: Partial<RoutineRun>): void {
@@ -49,13 +60,6 @@ class SharedRoutinePersistence {
 
   getLatestRun(routineId: string): RoutineRun | null {
     return this.runs.find((run) => run.routineId === routineId) ?? null;
-  }
-
-  claimScheduledSlot(routineId: string, slotAt: number): boolean {
-    const key = `${routineId}:${slotAt}`;
-    if (this.claimedSlots.has(key)) return false;
-    this.claimedSlots.add(key);
-    return true;
   }
 }
 
@@ -68,6 +72,7 @@ function fixtureRoutine(overrides: Partial<Routine> = {}): Routine {
     target: { mode: 'create_each_run' },
     skillId: null,
     agentId: null,
+    context: {},
     enabled: true,
     nextRunAt: null,
     lastRun: null,
@@ -77,12 +82,14 @@ function fixtureRoutine(overrides: Partial<Routine> = {}): Routine {
   };
 }
 
-function handlerStart(agentRunId: string): RoutineRunHandlerStart {
+function handlerStart(agentRunId: string, onStart?: () => void): RoutineRunHandlerStart {
+  const start = onStart ? { start: onStart } : {};
   return {
     projectId: 'project-1',
     conversationId: 'conversation-1',
     agentRunId,
     completion: Promise.resolve({ status: 'succeeded' }),
+    ...start,
   };
 }
 
@@ -239,12 +246,10 @@ describe('RoutineService scheduled run idempotency', () => {
     const starts: string[] = [];
 
     first.setRunHandler(async ({ runId }) => {
-      starts.push(runId);
-      return handlerStart('agent-run-1');
+      return handlerStart('agent-run-1', () => starts.push(runId));
     });
     second.setRunHandler(async ({ runId }) => {
-      starts.push(runId);
-      return handlerStart('agent-run-2');
+      return handlerStart('agent-run-2', () => starts.push(runId));
     });
 
     try {
@@ -259,6 +264,40 @@ describe('RoutineService scheduled run idempotency', () => {
     } finally {
       first.stop();
       second.stop();
+    }
+  });
+
+  it('retries the same scheduled slot when durable run insertion fails', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-17T10:00:00.000Z'));
+
+    const persistence = new SharedRoutinePersistence([fixtureRoutine()]);
+    persistence.failScheduledInsertAttempts = 1;
+    const service = new RoutineService(persistence);
+    const starts: string[] = [];
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    service.setRunHandler(async ({ runId }) => {
+      return handlerStart('agent-run-1', () => starts.push(runId));
+    });
+
+    try {
+      service.start();
+
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(starts).toHaveLength(0);
+      expect(persistence.runs).toHaveLength(0);
+      expect(persistence.claimedSlots.size).toBe(0);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(starts).toHaveLength(1);
+      expect(persistence.runs).toHaveLength(1);
+      expect(persistence.claimedSlots).toEqual(new Set(['routine-1:1779012060000']));
+    } finally {
+      service.stop();
+      errors.mockRestore();
     }
   });
 });

--- a/apps/daemon/tests/routines.test.ts
+++ b/apps/daemon/tests/routines.test.ts
@@ -457,6 +457,34 @@ describe('RoutineService scheduled run idempotency', () => {
     }
   });
 
+  it('prepares manual runs exactly once through the service path', async () => {
+    const persistence = new SharedRoutinePersistence([fixtureRoutine()]);
+    const service = new RoutineService(persistence);
+    let prepareCalls = 0;
+
+    service.setRunHandler(async () => ({
+      projectId: 'project-1',
+      conversationId: 'conversation-1',
+      agentRunId: 'agent-run-1',
+      completion: Promise.resolve({ status: 'succeeded' as const }),
+      prepare: () => {
+        prepareCalls += 1;
+      },
+    }));
+
+    await service.runNow('routine-1');
+    await Promise.resolve();
+
+    expect(prepareCalls).toBe(1);
+    expect(persistence.runs).toHaveLength(1);
+    expect(persistence.runs[0]).toMatchObject({
+      trigger: 'manual',
+      projectId: 'project-1',
+      conversationId: 'conversation-1',
+      agentRunId: 'agent-run-1',
+    });
+  });
+
   it('still finalizes the failed row when prepare cleanup itself throws', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-17T10:00:00.000Z'));

--- a/apps/daemon/tests/routines.test.ts
+++ b/apps/daemon/tests/routines.test.ts
@@ -390,6 +390,73 @@ describe('RoutineService scheduled run idempotency', () => {
     }
   });
 
+  it('does not persist scheduled placeholder IDs when prepare fails before assigning real IDs', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-17T10:00:00.000Z'));
+
+    const persistence = new SharedRoutinePersistence([fixtureRoutine()]);
+    const updatePatches: Array<Partial<RoutineRun>> = [];
+    const originalUpdate = persistence.updateRun.bind(persistence);
+    persistence.updateRun = (id: string, patch: Partial<RoutineRun>) => {
+      updatePatches.push({ ...patch });
+      originalUpdate(id, patch);
+    };
+
+    const service = new RoutineService(persistence);
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    let discardCalls = 0;
+
+    service.setRunHandler(async ({ runId }) => {
+      return {
+        projectId: `routine-pending-project-${runId}`,
+        conversationId: `routine-pending-conv-${runId}`,
+        agentRunId: 'agent-run-1',
+        completion: Promise.resolve({ status: 'canceled' as const }),
+        prepare: () => {
+          // Mirrors createRoutineConversation() failing before
+          // persistPreparedRun() can copy real IDs onto the chat run or
+          // routine run.
+          throw new Error('project create failed');
+        },
+        discard: () => {
+          discardCalls += 1;
+        },
+        start: () => {
+          throw new Error('start should not run after a failed prepare');
+        },
+      };
+    });
+
+    try {
+      service.start();
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(discardCalls).toBe(1);
+      expect(persistence.runs).toHaveLength(1);
+      const stored = persistence.runs[0]!;
+      expect(stored.status).toBe('failed');
+      expect(stored.completedAt).toBeTypeOf('number');
+      expect(stored.error).toContain('project create failed');
+      expect(stored.projectId).toBe('');
+      expect(stored.conversationId).toBe('');
+      expect(stored.agentRunId).toBe('agent-run-1');
+      expect(stored.projectId).not.toContain('routine-pending-project');
+      expect(stored.conversationId).not.toContain('routine-pending-conv');
+
+      const failurePatch = updatePatches.find((patch) => patch.status === 'failed');
+      expect(failurePatch).toBeDefined();
+      expect(failurePatch?.projectId).toBe('');
+      expect(failurePatch?.conversationId).toBe('');
+      expect(failurePatch?.agentRunId).toBe('agent-run-1');
+    } finally {
+      service.stop();
+      errors.mockRestore();
+    }
+  });
+
   it('still finalizes the failed row when prepare cleanup itself throws', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-17T10:00:00.000Z'));

--- a/apps/daemon/tests/routines.test.ts
+++ b/apps/daemon/tests/routines.test.ts
@@ -300,6 +300,52 @@ describe('RoutineService scheduled run idempotency', () => {
       errors.mockRestore();
     }
   });
+
+  it('retries the same scheduled slot when duplicate loser cleanup fails', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-17T10:00:00.000Z'));
+
+    const persistence = new SharedRoutinePersistence([fixtureRoutine()]);
+    persistence.claimedSlots.add('routine-1:1779012060000');
+    const service = new RoutineService(persistence);
+    let discardAttempts = 0;
+    let discardFailures = 1;
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    service.setRunHandler(async ({ runId }) => {
+      return {
+        ...handlerStart(runId),
+        discard: () => {
+          discardAttempts += 1;
+          if (discardFailures > 0) {
+            discardFailures -= 1;
+            throw new Error('duplicate loser cleanup failed');
+          }
+        },
+      };
+    });
+
+    try {
+      service.start();
+
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(discardAttempts).toBe(1);
+      expect(persistence.runs).toHaveLength(0);
+      expect(persistence.claimedSlots).toEqual(new Set(['routine-1:1779012060000']));
+
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(discardAttempts).toBe(2);
+      expect(persistence.runs).toHaveLength(0);
+      expect(errors.mock.calls.some((call) =>
+        call.some((value) => String(value).includes('duplicate loser cleanup failed')),
+      )).toBe(true);
+    } finally {
+      service.stop();
+      errors.mockRestore();
+    }
+  });
 });
 
 describe('routine validation', () => {

--- a/apps/daemon/tests/routines.test.ts
+++ b/apps/daemon/tests/routines.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   nextRunAtForSchedule,
+  RoutineService,
+  type Routine,
+  type RoutineRun,
+  type RoutineRunHandlerStart,
   validateSchedule,
   validateTarget,
 } from '../src/routines.js';
@@ -23,6 +27,68 @@ function partsIn(timezone: string, at: Date): Record<string, string> {
   if (out.hour === '24') out.hour = '00';
   return out;
 }
+
+class SharedRoutinePersistence {
+  readonly runs: RoutineRun[] = [];
+  readonly claimedSlots = new Set<string>();
+
+  constructor(private readonly routines: Routine[]) {}
+
+  list(): Routine[] {
+    return this.routines;
+  }
+
+  insertRun(run: RoutineRun): void {
+    this.runs.push(run);
+  }
+
+  updateRun(id: string, patch: Partial<RoutineRun>): void {
+    const run = this.runs.find((candidate) => candidate.id === id);
+    if (run) Object.assign(run, patch);
+  }
+
+  getLatestRun(routineId: string): RoutineRun | null {
+    return this.runs.find((run) => run.routineId === routineId) ?? null;
+  }
+
+  claimScheduledSlot(routineId: string, slotAt: number): boolean {
+    const key = `${routineId}:${slotAt}`;
+    if (this.claimedSlots.has(key)) return false;
+    this.claimedSlots.add(key);
+    return true;
+  }
+}
+
+function fixtureRoutine(overrides: Partial<Routine> = {}): Routine {
+  return {
+    id: 'routine-1',
+    name: 'Daily brief',
+    prompt: 'Summarize the day',
+    schedule: { kind: 'hourly', minute: 1 },
+    target: { mode: 'create_each_run' },
+    skillId: null,
+    agentId: null,
+    enabled: true,
+    nextRunAt: null,
+    lastRun: null,
+    createdAt: Date.UTC(2026, 4, 17, 0, 0),
+    updatedAt: Date.UTC(2026, 4, 17, 0, 0),
+    ...overrides,
+  };
+}
+
+function handlerStart(agentRunId: string): RoutineRunHandlerStart {
+  return {
+    projectId: 'project-1',
+    conversationId: 'conversation-1',
+    agentRunId,
+    completion: Promise.resolve({ status: 'succeeded' }),
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe('nextRunAtForSchedule DST handling', () => {
   it('does not fire before the requested wall time on a spring-forward gap day', () => {
@@ -159,6 +225,41 @@ describe('nextRunAtForSchedule DST handling', () => {
     expect(parts.day).toBe('15');
     expect(parts.hour).toBe('08');
     expect(parts.minute).toBe('30');
+  });
+});
+
+describe('RoutineService scheduled run idempotency', () => {
+  it('starts only one scheduled run when two scheduler instances fire the same slot', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-17T10:00:00.000Z'));
+
+    const persistence = new SharedRoutinePersistence([fixtureRoutine()]);
+    const first = new RoutineService(persistence);
+    const second = new RoutineService(persistence);
+    const starts: string[] = [];
+
+    first.setRunHandler(async ({ runId }) => {
+      starts.push(runId);
+      return handlerStart('agent-run-1');
+    });
+    second.setRunHandler(async ({ runId }) => {
+      starts.push(runId);
+      return handlerStart('agent-run-2');
+    });
+
+    try {
+      first.start();
+      second.start();
+
+      await vi.advanceTimersByTimeAsync(61_000);
+
+      expect(starts).toHaveLength(1);
+      expect(persistence.runs).toHaveLength(1);
+      expect(persistence.claimedSlots).toEqual(new Set(['routine-1:1779012060000']));
+    } finally {
+      first.stop();
+      second.stop();
+    }
   });
 });
 

--- a/apps/daemon/tests/routines.test.ts
+++ b/apps/daemon/tests/routines.test.ts
@@ -301,6 +301,156 @@ describe('RoutineService scheduled run idempotency', () => {
     }
   });
 
+  it('terminates the in-memory run and persists real IDs when prepare fails after assigning them', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-17T10:00:00.000Z'));
+
+    const persistence = new SharedRoutinePersistence([fixtureRoutine()]);
+    const updatePatches: Array<Partial<RoutineRun>> = [];
+    const originalUpdate = persistence.updateRun.bind(persistence);
+    persistence.updateRun = (id: string, patch: Partial<RoutineRun>) => {
+      updatePatches.push({ ...patch });
+      originalUpdate(id, patch);
+    };
+
+    const service = new RoutineService(persistence);
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    let discardCalls = 0;
+    let completionResolved = false;
+    let resolveCompletion!: () => void;
+    const completion = new Promise<{ status: 'canceled' }>((resolve) => {
+      resolveCompletion = () => {
+        completionResolved = true;
+        resolve({ status: 'canceled' });
+      };
+    });
+
+    service.setRunHandler(async () => {
+      return {
+        // Placeholder IDs mirror server.ts's `scheduledPlaceholder*`
+        // values — these are what the row gets inserted with before
+        // `prepare()` patches them with real IDs.
+        projectId: 'routine-pending-project',
+        conversationId: 'routine-pending-conversation',
+        agentRunId: 'routine-pending-run',
+        completion,
+        prepare: (run: RoutineRun) => {
+          // Match persistPreparedRun(): mutate the routine run with real
+          // IDs before any later fallible work could throw.
+          run.projectId = 'real-project';
+          run.conversationId = 'real-conversation';
+          run.agentRunId = 'real-agent-run';
+          throw new Error('prepare exploded');
+        },
+        discard: () => {
+          discardCalls += 1;
+          resolveCompletion();
+        },
+        start: () => {
+          throw new Error('start should not run after a failed prepare');
+        },
+      };
+    });
+
+    try {
+      service.start();
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      await vi.advanceTimersByTimeAsync(0);
+
+      // The in-memory chat run was terminated, releasing the completion
+      // promise so it does not leak.
+      expect(discardCalls).toBe(1);
+      expect(completionResolved).toBe(true);
+
+      // The persisted row ends in the terminal failed state and carries
+      // the real IDs that prepare() assigned — no `routine-pending-*`
+      // placeholders left behind.
+      expect(persistence.runs).toHaveLength(1);
+      const stored = persistence.runs[0]!;
+      expect(stored.status).toBe('failed');
+      expect(stored.projectId).toBe('real-project');
+      expect(stored.conversationId).toBe('real-conversation');
+      expect(stored.agentRunId).toBe('real-agent-run');
+      expect(stored.completedAt).toBeTypeOf('number');
+      expect(stored.error).toContain('prepare exploded');
+
+      // The failure-path updateRun explicitly carried the real IDs so the
+      // real persistence layer (column-level UPDATE) replaces the
+      // placeholders, not just the in-memory shared reference.
+      const failurePatch = updatePatches.find((patch) => patch.status === 'failed');
+      expect(failurePatch).toBeDefined();
+      expect(failurePatch?.projectId).toBe('real-project');
+      expect(failurePatch?.conversationId).toBe('real-conversation');
+      expect(failurePatch?.agentRunId).toBe('real-agent-run');
+    } finally {
+      service.stop();
+      errors.mockRestore();
+    }
+  });
+
+  it('still finalizes the failed row when prepare cleanup itself throws', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-17T10:00:00.000Z'));
+
+    const persistence = new SharedRoutinePersistence([fixtureRoutine()]);
+    const service = new RoutineService(persistence);
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    let discardCalls = 0;
+
+    service.setRunHandler(async () => {
+      return {
+        projectId: 'routine-pending-project',
+        conversationId: 'routine-pending-conversation',
+        agentRunId: 'routine-pending-run',
+        completion: Promise.resolve({ status: 'canceled' as const }),
+        prepare: (run: RoutineRun) => {
+          run.projectId = 'real-project';
+          run.conversationId = 'real-conversation';
+          run.agentRunId = 'real-agent-run';
+          throw new Error('prepare exploded');
+        },
+        discard: () => {
+          discardCalls += 1;
+          throw new Error('cleanup blew up');
+        },
+        start: () => {},
+      };
+    });
+
+    try {
+      service.start();
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(discardCalls).toBe(1);
+
+      // The cleanup failure is surfaced via console.error and does not
+      // swallow the prepare failure — the routine row is still finalized
+      // and the original prepare error reaches the scheduler.
+      expect(errors.mock.calls.some((call) =>
+        call.some((value) => String(value).includes('cleanup blew up')),
+      )).toBe(true);
+      expect(errors.mock.calls.some((call) =>
+        call.some((value) => String(value).includes('prepare exploded')),
+      )).toBe(true);
+
+      expect(persistence.runs).toHaveLength(1);
+      const stored = persistence.runs[0]!;
+      expect(stored.status).toBe('failed');
+      expect(stored.projectId).toBe('real-project');
+      expect(stored.conversationId).toBe('real-conversation');
+      expect(stored.agentRunId).toBe('real-agent-run');
+      expect(stored.error).toContain('prepare exploded');
+    } finally {
+      service.stop();
+      errors.mockRestore();
+    }
+  });
+
   it('retries the same scheduled slot when duplicate loser cleanup fails', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-17T10:00:00.000Z'));


### PR DESCRIPTION
Fixes #1641

## Why

A scheduled Routine could be triggered twice for the same planned time slot when more than one daemon process/instance had the scheduler active. The existing in-memory `inflight` guard only protected a single process, so stable users could get duplicate unattended Routine runs for one schedule tick.

This PR adds a persistence-backed idempotency boundary at the scheduler fire point so every `(routineId, slotAt)` can only be claimed once across daemon processes.

## What users will see

Scheduled Routines continue to behave the same from the UI, but a Routine scheduled for one time slot should create at most one run even if multiple daemon instances are active.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; daemon scheduler behavior only.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/routines.test.ts`
- Did the test go red on `main` and green on this branch? yes — the new scheduler idempotency test failed on the pre-fix implementation with two starts for one slot, and passes on this branch.
- Additional DB coverage: `apps/daemon/tests/routine-schedule-claims.test.ts` verifies two SQLite connections contend for the same scheduled slot and only one claim succeeds.

## Validation

- [x] `corepack pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/routines.test.ts tests/routine-schedule-claims.test.ts`
- [x] `git diff --check`
- [x] `corepack pnpm guard`
- [x] `PATH=/Users/cyh/.nvm/versions/node/v24.13.0/bin:$PATH corepack pnpm typecheck`
