### PR TITLE
fix(skills): update d3-visualization skill upstream to snow-d3 and expand skill metadata

### DIFF
--- a/scripts/seed-curated-design-skills.ts
+++ b/scripts/seed-curated-design-skills.ts
@@ -825,8 +825,8 @@ const CATALOGUE: CuratedSkill[] = [
   {
     id: 'd3-visualization',
     description:
-      'Teaches the agent to produce D3 charts and interactive data visualizations. Useful for editorial dashboards, reports, and explanatory graphics.',
-    triggers: ['d3', 'd3.js', 'interactive chart', 'data visualization', 'editorial chart'],
+      'Teaches the agent to produce D3 charts and interactive data visualizations. A comprehensive D3.js skill with examples across chart types and techniques giving the agent expert-level knowledge to generate complex, interactive visualizations. Useful for editorial dashboards, reports, data-rich prototypes, and explanatory graphics.',
+    triggers: ['d3', 'd3.js', 'interactive chart', 'data visualization', 'editorial chart', 'd3 bar chart', 'd3 line chart', 'd3 map', 'd3 force graph', 'd3 sankey', 'd3 treemap', 'd3 sunburst', 'd3 choropleth', 'd3 animation', 'snow-d3'],
     mode: 'prototype',
     category: 'diagrams',
     upstream: 'https://github.com/jiannanya/snow-d3/',

--- a/scripts/seed-curated-design-skills.ts
+++ b/scripts/seed-curated-design-skills.ts
@@ -829,8 +829,8 @@ const CATALOGUE: CuratedSkill[] = [
     triggers: ['d3', 'd3.js', 'interactive chart', 'data visualization', 'editorial chart'],
     mode: 'prototype',
     category: 'diagrams',
-    upstream: 'https://github.com/chrisvoncsefalvay/d3-claude-skill',
-    attribution: 'Curated from @chrisvoncsefalvay.',
+    upstream: 'https://github.com/jiannanya/snow-d3/',
+    attribution: 'Curated from @jiannanya.',
   },
   {
     id: 'hand-drawn-diagrams',

--- a/scripts/seed-curated-design-skills.ts
+++ b/scripts/seed-curated-design-skills.ts
@@ -826,7 +826,7 @@ const CATALOGUE: CuratedSkill[] = [
     id: 'd3-visualization',
     description:
       'Teaches the agent to produce D3 charts and interactive data visualizations. A comprehensive D3.js skill with examples across chart types and techniques giving the agent expert-level knowledge to generate complex, interactive visualizations. Useful for editorial dashboards, reports, data-rich prototypes, and explanatory graphics.',
-    triggers: ['d3', 'd3.js', 'interactive chart', 'data visualization', 'editorial chart', 'd3 bar chart', 'd3 line chart', 'd3 map', 'd3 force graph', 'd3 sankey', 'd3 treemap', 'd3 sunburst', 'd3 choropleth', 'd3 animation', 'snow-d3'],
+    triggers: ['d3', 'd3.js', 'interactive chart', 'data visualization', 'editorial chart', 'd3 bar chart', 'd3 line chart', 'd3 map', 'd3 force graph', 'd3 sankey', 'd3 treemap', 'd3 sunburst', 'd3 choropleth', 'd3 animation', 'd3 scroll', 'snow-d3'],
     mode: 'prototype',
     category: 'diagrams',
     upstream: 'https://github.com/jiannanya/snow-d3/',

--- a/skills/d3-visualization/SKILL.md
+++ b/skills/d3-visualization/SKILL.md
@@ -1,13 +1,24 @@
 ---
 name: d3-visualization
 description: |
-  Teaches the agent to produce D3 charts and interactive data visualizations. Useful for editorial dashboards, reports, and explanatory graphics.
+  Teaches the agent to produce D3 charts and interactive data visualizations. A comprehensive D3.js skill with examples across chart types and techniques giving the agent expert-level knowledge to generate complex, interactive visualizations. Useful for editorial dashboards, reports, data-rich prototypes, and explanatory graphics.
 triggers:
   - "d3"
   - "d3.js"
   - "interactive chart"
   - "data visualization"
   - "editorial chart"
+  - "d3 bar chart"
+  - "d3 line chart"
+  - "d3 map"
+  - "d3 force graph"
+  - "d3 sankey"
+  - "d3 treemap"
+  - "d3 sunburst"
+  - "d3 choropleth"
+  - "d3 animation"
+  - "d3 scroll"
+  - "snow-d3"
 od:
   mode: prototype
   category: diagrams
@@ -20,7 +31,7 @@ od:
 
 ## What it does
 
-Teaches the agent to produce D3 charts and interactive data visualizations. Useful for editorial dashboards, reports, and explanatory graphics.
+Teaches the agent to produce D3 charts and interactive data visualizations. A comprehensive D3.js skill with examples across chart types and techniques giving the agent expert-level knowledge to generate complex, interactive visualizations. Useful for editorial dashboards, reports, data-rich prototypes, and explanatory graphics.
 
 ## Source
 
@@ -31,13 +42,21 @@ Teaches the agent to produce D3 charts and interactive data visualizations. Usef
 
 This catalogue entry advertises the skill in Open Design so the agent
 discovers it during planning. To run the full upstream workflow with
-its original assets, scripts, and references, install the upstream
+its original assets, scripts, and reference documents, install the upstream
 bundle into your active agent's skills directory:
 
 ```bash
 # Inspect the upstream README for exact paths
 open https://github.com/jiannanya/snow-d3/
+
+# Clone or copy the snow-d3/ folder into your workspace's skills/ directory
+git clone https://github.com/jiannanya/snow-d3.git
+
 ```
 
 Then ask the agent to invoke this skill by name (`d3-visualization`) or with
-one of the trigger phrases listed in this skill's frontmatter.
+one of the trigger phrases listed in this skill's frontmatter, e.g.:
+
+> "Create a zoomable treemap for my sales data"
+> "Build a force-directed network graph like example 07 but for my own dataset"
+> "Generate a calendar heatmap in D3"

--- a/skills/d3-visualization/SKILL.md
+++ b/skills/d3-visualization/SKILL.md
@@ -50,7 +50,7 @@ bundle into your active agent's skills directory:
 open https://github.com/jiannanya/snow-d3/
 
 # Clone or copy the snow-d3/ folder into your workspace's skills/ directory
-git clone https://github.com/jiannanya/snow-d3.git
+git clone https://github.com/jiannanya/snow-d3.git skills/snow-d3
 
 ```
 

--- a/skills/d3-visualization/SKILL.md
+++ b/skills/d3-visualization/SKILL.md
@@ -11,12 +11,12 @@ triggers:
 od:
   mode: prototype
   category: diagrams
-  upstream: "https://github.com/chrisvoncsefalvay/d3-claude-skill"
+  upstream: "https://github.com/jiannanya/snow-d3/"
 ---
 
 # d3-visualization
 
-> Curated from @chrisvoncsefalvay.
+> Curated from @jiannanya.
 
 ## What it does
 
@@ -24,7 +24,7 @@ Teaches the agent to produce D3 charts and interactive data visualizations. Usef
 
 ## Source
 
-- Upstream: https://github.com/chrisvoncsefalvay/d3-claude-skill
+- Upstream: https://github.com/jiannanya/snow-d3/
 - Category: `diagrams`
 
 ## How to use
@@ -36,7 +36,7 @@ bundle into your active agent's skills directory:
 
 ```bash
 # Inspect the upstream README for exact paths
-open https://github.com/chrisvoncsefalvay/d3-claude-skill
+open https://github.com/jiannanya/snow-d3/
 ```
 
 Then ask the agent to invoke this skill by name (`d3-visualization`) or with


### PR DESCRIPTION
## Why

The previous upstream for the `d3-visualization` skill (`https://github.com/chrisvoncsefalvay/d3-claude-skill`) is no longer available. The skill pointed to a dead link, so the agent was advertising a catalogue entry that could not be installed or referenced. These commits replace it with the active `snow-d3` repository (`https://github.com/jiannanya/snow-d3/`) , and expand the skill metadata (description and triggers) to accurately reflect the breadth of the new upstream's coverage.


## What users will see

- **Settings → Skills → Diagrams**: The `d3-visualization` skill card now shows an expanded description ("A comprehensive D3.js skill with examples across chart types and techniques…") and a working upstream source link. Previously clicking the link would land on a 404.
- The skill now fires on **16 trigger phrases** (up from 5), including chart-type-specific intents — `d3 bar chart`, `d3 line chart`, `d3 map`, `d3 force graph`, `d3 sankey`, `d3 treemap`, `d3 sunburst`, `d3 choropleth`, `d3 animation`, `d3 scroll`, and `snow-d3` — so the agent picks up the skill on a much wider range of user requests.
- The **How to use** section in the skill file now includes a `git clone` command for installing the upstream bundle and three example prompt phrases to lower the discovery barrier.

## Surface area

- [x] **Extension point** — changed entry under `skills/d3-visualization/SKILL.md` and the corresponding `CATALOGUE` entry in `scripts/seed-curated-design-skills.ts`
- [ ] UI
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] i18n keys
- [ ] New top-level dependency
- [ ] Default behavior change
- [ ] None


## Screenshots

N/A — no UI surface changed.


## Bug fix verification

N/A — not a runtime bug fix. Manually verified:

- `https://github.com/chrisvoncsefalvay/d3-claude-skill` — returns 404
- `https://github.com/jiannanya/snow-d3/` — live, MIT-licensed, contains `SKILL.md`, `references/`, and `examples/`


## Validation

```bash
pnpm guard
pnpm typecheck
```