### PR TITLE
fix(web): show unavailable state for missing examples

### DIFF
--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -751,10 +751,10 @@ export type SkillExampleResult =
   | { error: string };
 
 // Returns a discriminated result so callers can distinguish a real
-// failure (network error, daemon unreachable, non-2xx) from a normal
-// load. Previously this collapsed every failure into `null`, which
-// left the example preview modal stuck at its loading state with no
-// recovery affordance. Issue #860.
+// failure (network error, daemon unreachable, server error) from a
+// normal load or a missing shipped preview. Previously this collapsed
+// every failure into `null`, which left the example preview modal stuck
+// at its loading state with no recovery affordance. Issue #860.
 //
 // `previewType` is the skill's `od.preview.type` (defaults to `'html'`
 // daemon-side). Anything other than `'html'` short-circuits to an
@@ -770,6 +770,9 @@ export async function fetchSkillExample(
   try {
     const resp = await fetch(`/api/skills/${encodeURIComponent(id)}/example`);
     if (!resp.ok) {
+      if (resp.status === 404) {
+        return { unavailable: true, kind: 'html' };
+      }
       return { error: `HTTP ${resp.status}` };
     }
     return { html: await resp.text() };

--- a/apps/web/tests/providers/registry.test.ts
+++ b/apps/web/tests/providers/registry.test.ts
@@ -94,17 +94,30 @@ describe('fetchSkillExample', () => {
     expect(fetchMock).toHaveBeenCalledWith('/api/skills/blog-post/example');
   });
 
-  it('forwards the html fetch and returns a discriminated error on non-2xx', async () => {
+  it('treats missing html previews as unavailable instead of an error', async () => {
     const fetchMock = vi.fn(
       async () => new Response('not found', { status: 404 }),
     );
     vi.stubGlobal('fetch', fetchMock);
 
     await expect(fetchSkillExample('design-brief', 'html')).resolves.toEqual({
-      error: 'HTTP 404',
+      unavailable: true,
+      kind: 'html',
     });
     // Confirm the dispatch did call through to the daemon for the html
     // path (i.e. the short-circuit above only catches non-html types).
+    expect(fetchMock).toHaveBeenCalledWith('/api/skills/design-brief/example');
+  });
+
+  it('forwards real html preview fetch failures as discriminated errors', async () => {
+    const fetchMock = vi.fn(
+      async () => new Response('server error', { status: 500 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchSkillExample('design-brief', 'html')).resolves.toEqual({
+      error: 'HTTP 500',
+    });
     expect(fetchMock).toHaveBeenCalledWith('/api/skills/design-brief/example');
   });
 });


### PR DESCRIPTION
Fixes #1218

## Why

Some Examples without a shipped `example.html` currently hit the HTML preview endpoint, receive a 404, and fall into the generic fetch-error modal. That message suggests Open Design or the daemon is broken even when the real state is simply that the skill has no shipped preview asset.

## What users will see

Opening an Example whose HTML preview asset is missing now shows the existing unavailable-preview state instead of the misleading "example HTML failed to fetch" error. Real fetch failures, such as 500 responses or network errors, still surface as errors.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the root `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No new UI component or styling was added. This routes a missing HTML preview 404 into the already-existing unavailable-preview modal state, so the change is covered by the provider regression test and the existing unavailable-preview component coverage.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/providers/registry.test.ts`
- The 404 HTML preview case now expects `{ unavailable: true, kind: 'html' }`.
- A separate 500 case keeps real HTML preview failures on `{ error: 'HTTP 500' }`.

## Validation

- `pnpm --filter @open-design/web test -- tests/providers/registry.test.ts` (163 files, 1546 tests passed)
- `pnpm --filter @open-design/web typecheck`
- `git diff --check`
