### PR TITLE
feat: sync CLI-installed Claude Code MCP servers and skills in Settings

### DIFF
--- a/apps/daemon/src/claude-code/reader.ts
+++ b/apps/daemon/src/claude-code/reader.ts
@@ -1,0 +1,9 @@
+import fs from 'node:fs';
+
+export function detectAvailability(home: string): boolean {
+  try {
+    return fs.statSync(home).isDirectory();
+  } catch {
+    return false;
+  }
+}

--- a/apps/daemon/src/claude-code/reader.ts
+++ b/apps/daemon/src/claude-code/reader.ts
@@ -1,7 +1,9 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import type { ClaudeCodeMcpServer } from '@open-design/contracts';
+import type { ClaudeCodeMcpServer, ClaudeCodeSkill } from '@open-design/contracts';
+
+import { parseFrontmatter } from '../frontmatter.js';
 
 export function detectAvailability(home: string): boolean {
   try {
@@ -105,4 +107,45 @@ export function readUserMcpServers(home: string): ClaudeCodeMcpServer[] {
     source: 'user' as const,
     ...classifyTransport(entry),
   }));
+}
+
+function readSkillFile(
+  skillMdPath: string,
+  source: 'user' | 'plugin',
+  extra: Partial<ClaudeCodeSkill> = {},
+): ClaudeCodeSkill | null {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(skillMdPath, 'utf8');
+  } catch {
+    return null;
+  }
+  let data: Record<string, unknown> = {};
+  try {
+    const parsed = parseFrontmatter(raw) as { data?: Record<string, unknown> };
+    data = parsed.data ?? {};
+  } catch {
+    data = {};
+  }
+  const idFromFm = typeof data.name === 'string' && data.name.length > 0 ? data.name : null;
+  const fallbackId = path.basename(path.dirname(skillMdPath));
+  const description = typeof data.description === 'string' ? data.description : undefined;
+  return {
+    id: idFromFm ?? fallbackId,
+    source,
+    description,
+    path: skillMdPath,
+    ...extra,
+  };
+}
+
+export function readUserSkills(home: string): ClaudeCodeSkill[] {
+  const root = path.join(home, 'skills');
+  const out: ClaudeCodeSkill[] = [];
+  for (const entry of safeReaddir(root)) {
+    const skillMd = path.join(root, entry, 'SKILL.md');
+    const skill = readSkillFile(skillMd, 'user');
+    if (skill) out.push(skill);
+  }
+  return out;
 }

--- a/apps/daemon/src/claude-code/reader.ts
+++ b/apps/daemon/src/claude-code/reader.ts
@@ -149,3 +149,41 @@ export function readUserSkills(home: string): ClaudeCodeSkill[] {
   }
   return out;
 }
+
+function findSkillMdFiles(root: string, maxDepth: number): string[] {
+  const out: string[] = [];
+  const walk = (dir: string, depth: number): void => {
+    if (depth > maxDepth) return;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isFile() && entry.name === 'SKILL.md') {
+        out.push(full);
+      } else if (
+        entry.isDirectory() &&
+        entry.name !== '.claude-plugin' &&
+        entry.name !== 'node_modules'
+      ) {
+        walk(full, depth + 1);
+      }
+    }
+  };
+  walk(root, 0);
+  return out;
+}
+
+export function readPluginSkills(home: string): ClaudeCodeSkill[] {
+  const out: ClaudeCodeSkill[] = [];
+  for (const { pluginName, pluginVersion, versionDir } of readPluginManifests(home)) {
+    for (const skillMd of findSkillMdFiles(versionDir, 4)) {
+      const skill = readSkillFile(skillMd, 'plugin', { pluginName, pluginVersion });
+      if (skill) out.push(skill);
+    }
+  }
+  return out;
+}

--- a/apps/daemon/src/claude-code/reader.ts
+++ b/apps/daemon/src/claude-code/reader.ts
@@ -33,6 +33,62 @@ function classifyTransport(entry: RawMcpEntry): TransportFields {
   return { transport: 'unknown' };
 }
 
+function safeReaddir(dir: string): string[] {
+  try {
+    return fs.readdirSync(dir);
+  } catch {
+    return [];
+  }
+}
+
+interface PluginRecord {
+  manifest: Record<string, unknown>;
+  pluginName: string;
+  pluginVersion: string;
+  versionDir: string;
+}
+
+function readPluginManifests(home: string): PluginRecord[] {
+  const cacheRoot = path.join(home, 'plugins', 'cache');
+  const out: PluginRecord[] = [];
+  for (const marketplace of safeReaddir(cacheRoot)) {
+    for (const plugin of safeReaddir(path.join(cacheRoot, marketplace))) {
+      for (const version of safeReaddir(path.join(cacheRoot, marketplace, plugin))) {
+        const versionDir = path.join(cacheRoot, marketplace, plugin, version);
+        const manifestPath = path.join(versionDir, '.claude-plugin', 'plugin.json');
+        let manifest: Record<string, unknown>;
+        try {
+          manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as Record<string, unknown>;
+        } catch {
+          continue;
+        }
+        const manifestName = typeof manifest.name === 'string' ? manifest.name : plugin;
+        const manifestVersion = typeof manifest.version === 'string' ? manifest.version : version;
+        out.push({ manifest, pluginName: manifestName, pluginVersion: manifestVersion, versionDir });
+      }
+    }
+  }
+  return out;
+}
+
+export function readPluginMcpServers(home: string): ClaudeCodeMcpServer[] {
+  const out: ClaudeCodeMcpServer[] = [];
+  for (const { manifest, pluginName, pluginVersion } of readPluginManifests(home)) {
+    const servers = manifest.mcpServers;
+    if (!servers || typeof servers !== 'object') continue;
+    for (const [name, entry] of Object.entries(servers as Record<string, RawMcpEntry>)) {
+      out.push({
+        name,
+        source: 'plugin',
+        pluginName,
+        pluginVersion,
+        ...classifyTransport(entry),
+      });
+    }
+  }
+  return out;
+}
+
 export function readUserMcpServers(home: string): ClaudeCodeMcpServer[] {
   const configPath = path.join(home, '..', '.claude.json');
   let parsed: { mcpServers?: Record<string, RawMcpEntry> };

--- a/apps/daemon/src/claude-code/reader.ts
+++ b/apps/daemon/src/claude-code/reader.ts
@@ -1,4 +1,7 @@
 import fs from 'node:fs';
+import path from 'node:path';
+
+import type { ClaudeCodeMcpServer } from '@open-design/contracts';
 
 export function detectAvailability(home: string): boolean {
   try {
@@ -6,4 +9,44 @@ export function detectAvailability(home: string): boolean {
   } catch {
     return false;
   }
+}
+
+interface RawMcpEntry {
+  command?: string;
+  args?: string[];
+  url?: string;
+  type?: string;
+}
+
+type TransportFields = Pick<ClaudeCodeMcpServer, 'transport' | 'command' | 'url'>;
+
+function classifyTransport(entry: RawMcpEntry): TransportFields {
+  if (typeof entry.command === 'string' && entry.command.length > 0) {
+    const args = Array.isArray(entry.args) ? entry.args : [];
+    const cmd = [entry.command, ...args].join(' ').trim();
+    return { transport: 'stdio', command: cmd };
+  }
+  if (typeof entry.url === 'string' && entry.url.length > 0) {
+    if (entry.type === 'sse') return { transport: 'sse', url: entry.url };
+    return { transport: 'http', url: entry.url };
+  }
+  return { transport: 'unknown' };
+}
+
+export function readUserMcpServers(home: string): ClaudeCodeMcpServer[] {
+  const configPath = path.join(home, '..', '.claude.json');
+  let parsed: { mcpServers?: Record<string, RawMcpEntry> };
+  try {
+    const raw = fs.readFileSync(configPath, 'utf8');
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  const servers = parsed.mcpServers;
+  if (!servers || typeof servers !== 'object') return [];
+  return Object.entries(servers).map(([name, entry]) => ({
+    name,
+    source: 'user' as const,
+    ...classifyTransport(entry),
+  }));
 }

--- a/apps/daemon/src/claude-code/routes.ts
+++ b/apps/daemon/src/claude-code/routes.ts
@@ -1,0 +1,58 @@
+import os from 'node:os';
+import path from 'node:path';
+
+import type {
+  ClaudeCodeInstalledMcpServersResponse,
+  ClaudeCodeInstalledSkillsResponse,
+  ClaudeCodeMcpServer,
+  ClaudeCodeSkill,
+} from '@open-design/contracts';
+import type { Express } from 'express';
+
+import {
+  detectAvailability,
+  readPluginMcpServers,
+  readPluginSkills,
+  readUserMcpServers,
+  readUserSkills,
+} from './reader.js';
+
+function resolveHome(): string {
+  return process.env.OD_CLAUDE_HOME ?? path.join(os.homedir(), '.claude');
+}
+
+function sortMcp(a: ClaudeCodeMcpServer, b: ClaudeCodeMcpServer): number {
+  if (a.source !== b.source) return a.source === 'user' ? -1 : 1;
+  return a.name.localeCompare(b.name);
+}
+
+function sortSkill(a: ClaudeCodeSkill, b: ClaudeCodeSkill): number {
+  if (a.source !== b.source) return a.source === 'user' ? -1 : 1;
+  return a.id.localeCompare(b.id);
+}
+
+export function registerClaudeCodeRoutes(app: Express): void {
+  app.get('/api/claude-code/mcp-servers', (_req, res) => {
+    const home = resolveHome();
+    if (!detectAvailability(home)) {
+      const payload: ClaudeCodeInstalledMcpServersResponse = { available: false, servers: [] };
+      res.json(payload);
+      return;
+    }
+    const servers = [...readUserMcpServers(home), ...readPluginMcpServers(home)].sort(sortMcp);
+    const payload: ClaudeCodeInstalledMcpServersResponse = { available: true, servers };
+    res.json(payload);
+  });
+
+  app.get('/api/claude-code/skills', (_req, res) => {
+    const home = resolveHome();
+    if (!detectAvailability(home)) {
+      const payload: ClaudeCodeInstalledSkillsResponse = { available: false, skills: [] };
+      res.json(payload);
+      return;
+    }
+    const skills = [...readUserSkills(home), ...readPluginSkills(home)].sort(sortSkill);
+    const payload: ClaudeCodeInstalledSkillsResponse = { available: true, skills };
+    res.json(payload);
+  });
+}

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -23,6 +23,7 @@ import {
   sanitizeCustomModel,
   spawnEnvForAgent,
 } from './agents.js';
+import { registerClaudeCodeRoutes } from './claude-code/routes.js';
 import { findSkillById, listSkills } from './skills.js';
 import { validateLinkedDirs } from './linked-dirs.js';
 import { listCodexPets, readCodexPetSpritesheet } from './codex-pets.js';
@@ -1845,6 +1846,8 @@ export async function startServer({ port = 7456, host = process.env.OD_BIND_HOST
       res.status(500).json({ error: String(err) });
     }
   });
+
+  registerClaudeCodeRoutes(app);
 
   app.get('/api/skills/:id', async (req, res) => {
     try {

--- a/apps/daemon/tests/claude-code-reader.test.ts
+++ b/apps/daemon/tests/claude-code-reader.test.ts
@@ -2,7 +2,11 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
-import { detectAvailability, readUserMcpServers } from '../src/claude-code/reader.js';
+import {
+  detectAvailability,
+  readPluginMcpServers,
+  readUserMcpServers,
+} from '../src/claude-code/reader.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -58,5 +62,35 @@ describe('readUserMcpServers', () => {
   it('returns [] without throwing when .claude.json is malformed', () => {
     const home = path.join(FIXTURES, 'claude-home-malformed-json', 'home');
     expect(readUserMcpServers(home)).toEqual([]);
+  });
+});
+
+describe('readPluginMcpServers', () => {
+  it('returns servers declared in plugin manifests with plugin attribution', () => {
+    const home = path.join(FIXTURES, 'claude-home-plugin-mcp', 'home');
+    const servers = readPluginMcpServers(home);
+    expect(servers.map((s) => s.name).sort()).toEqual(['github', 'sentry']);
+
+    const gh = servers.find((s) => s.name === 'github')!;
+    expect(gh.source).toBe('plugin');
+    expect(gh.pluginName).toBe('example-pack');
+    expect(gh.pluginVersion).toBe('1.2.3');
+    expect(gh.transport).toBe('stdio');
+    expect(gh.command).toBe('node /abs/github.js');
+
+    const sentry = servers.find((s) => s.name === 'sentry')!;
+    expect(sentry.transport).toBe('sse');
+    expect(sentry.url).toBe('https://sentry.example/sse');
+  });
+
+  it('returns [] when no plugin cache exists', () => {
+    expect(readPluginMcpServers(path.join(FIXTURES, 'claude-home-empty'))).toEqual([]);
+  });
+
+  it('skips plugins with malformed manifests without crashing the scan', () => {
+    const home = path.join(FIXTURES, 'claude-home-plugin-mcp', 'home');
+    const servers = readPluginMcpServers(home);
+    expect(servers.every((s) => s.pluginName !== 'broken')).toBe(true);
+    expect(servers.some((s) => s.pluginName === 'example-pack')).toBe(true);
   });
 });

--- a/apps/daemon/tests/claude-code-reader.test.ts
+++ b/apps/daemon/tests/claude-code-reader.test.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
-import { detectAvailability } from '../src/claude-code/reader.js';
+import { detectAvailability, readUserMcpServers } from '../src/claude-code/reader.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -15,5 +15,48 @@ describe('detectAvailability', () => {
 
   it('returns true when the home dir exists', () => {
     expect(detectAvailability(path.join(FIXTURES, 'claude-home-empty'))).toBe(true);
+  });
+});
+
+describe('readUserMcpServers', () => {
+  it('parses user-scope MCP servers from <home>/../.claude.json', () => {
+    const home = path.join(FIXTURES, 'claude-home-user-mcp', 'home');
+    const servers = readUserMcpServers(home);
+    expect(servers.map((s) => s.name).sort()).toEqual([
+      'filesystem',
+      'remote-http',
+      'remote-sse',
+      'weird',
+    ]);
+
+    const filesystem = servers.find((s) => s.name === 'filesystem')!;
+    expect(filesystem.source).toBe('user');
+    expect(filesystem.transport).toBe('stdio');
+    expect(filesystem.command).toBe('node /abs/fs-server.js');
+    expect(filesystem.url).toBeUndefined();
+
+    const sse = servers.find((s) => s.name === 'remote-sse')!;
+    expect(sse.transport).toBe('sse');
+    expect(sse.url).toBe('https://example.com/sse');
+    expect(sse.command).toBeUndefined();
+
+    const http = servers.find((s) => s.name === 'remote-http')!;
+    expect(http.transport).toBe('http');
+    expect(http.url).toBe('https://example.com/http');
+
+    const weird = servers.find((s) => s.name === 'weird')!;
+    expect(weird.transport).toBe('unknown');
+    expect(weird.command).toBeUndefined();
+    expect(weird.url).toBeUndefined();
+  });
+
+  it('returns [] when .claude.json is missing', () => {
+    const home = path.join(FIXTURES, 'claude-home-empty');
+    expect(readUserMcpServers(home)).toEqual([]);
+  });
+
+  it('returns [] without throwing when .claude.json is malformed', () => {
+    const home = path.join(FIXTURES, 'claude-home-malformed-json', 'home');
+    expect(readUserMcpServers(home)).toEqual([]);
   });
 });

--- a/apps/daemon/tests/claude-code-reader.test.ts
+++ b/apps/daemon/tests/claude-code-reader.test.ts
@@ -6,6 +6,7 @@ import {
   detectAvailability,
   readPluginMcpServers,
   readUserMcpServers,
+  readUserSkills,
 } from '../src/claude-code/reader.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -92,5 +93,32 @@ describe('readPluginMcpServers', () => {
     const servers = readPluginMcpServers(home);
     expect(servers.every((s) => s.pluginName !== 'broken')).toBe(true);
     expect(servers.some((s) => s.pluginName === 'example-pack')).toBe(true);
+  });
+});
+
+describe('readUserSkills', () => {
+  it('returns skills parsed from ~/.claude/skills/<name>/SKILL.md', () => {
+    const home = path.join(FIXTURES, 'claude-home-user-skills', 'home');
+    const skills = readUserSkills(home);
+    const ids = skills.map((s) => s.id);
+    expect(ids).toContain('web-animation-design');
+
+    const wad = skills.find((s) => s.id === 'web-animation-design')!;
+    expect(wad.source).toBe('user');
+    expect(wad.description).toContain('animations');
+    expect(wad.path.endsWith('SKILL.md')).toBe(true);
+  });
+
+  it('falls back to directory name when SKILL.md has no frontmatter', () => {
+    const home = path.join(FIXTURES, 'claude-home-user-skills', 'home');
+    const skills = readUserSkills(home);
+    const noFm = skills.find((s) => s.id === 'no-frontmatter');
+    expect(noFm).toBeDefined();
+    expect(noFm!.description).toBeUndefined();
+    expect(noFm!.source).toBe('user');
+  });
+
+  it('returns [] when ~/.claude/skills does not exist', () => {
+    expect(readUserSkills(path.join(FIXTURES, 'claude-home-empty'))).toEqual([]);
   });
 });

--- a/apps/daemon/tests/claude-code-reader.test.ts
+++ b/apps/daemon/tests/claude-code-reader.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 import {
   detectAvailability,
   readPluginMcpServers,
+  readPluginSkills,
   readUserMcpServers,
   readUserSkills,
 } from '../src/claude-code/reader.js';
@@ -120,5 +121,24 @@ describe('readUserSkills', () => {
 
   it('returns [] when ~/.claude/skills does not exist', () => {
     expect(readUserSkills(path.join(FIXTURES, 'claude-home-empty'))).toEqual([]);
+  });
+});
+
+describe('readPluginSkills', () => {
+  it('finds SKILL.md files under plugin cache and attributes plugin name/version', () => {
+    const home = path.join(FIXTURES, 'claude-home-plugin-skills', 'home');
+    const skills = readPluginSkills(home);
+    const ids = skills.map((s) => s.id).sort();
+    expect(ids).toContain('brainstorming');
+    expect(ids).toContain('research');
+
+    const b = skills.find((s) => s.id === 'brainstorming')!;
+    expect(b.source).toBe('plugin');
+    expect(b.pluginName).toBe('skills-pack');
+    expect(b.pluginVersion).toBe('2.0.0');
+  });
+
+  it('returns [] when no plugin cache exists', () => {
+    expect(readPluginSkills(path.join(FIXTURES, 'claude-home-empty'))).toEqual([]);
   });
 });

--- a/apps/daemon/tests/claude-code-reader.test.ts
+++ b/apps/daemon/tests/claude-code-reader.test.ts
@@ -1,0 +1,19 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { detectAvailability } from '../src/claude-code/reader.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const FIXTURES = path.join(__dirname, 'fixtures');
+
+describe('detectAvailability', () => {
+  it('returns false when the home dir does not exist', () => {
+    expect(detectAvailability(path.join(FIXTURES, 'claude-home-does-not-exist'))).toBe(false);
+  });
+
+  it('returns true when the home dir exists', () => {
+    expect(detectAvailability(path.join(FIXTURES, 'claude-home-empty'))).toBe(true);
+  });
+});

--- a/apps/daemon/tests/claude-code-routes.test.ts
+++ b/apps/daemon/tests/claude-code-routes.test.ts
@@ -1,0 +1,76 @@
+import http from 'node:http';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import express from 'express';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { registerClaudeCodeRoutes } from '../src/claude-code/routes.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const FIXTURES = path.join(__dirname, 'fixtures');
+
+let server: http.Server;
+let port: number;
+
+beforeEach(async () => {
+  const app = express();
+  registerClaudeCodeRoutes(app);
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, () => {
+      const addr = server.address();
+      if (addr && typeof addr === 'object') port = addr.port;
+      resolve();
+    });
+  });
+});
+
+afterEach(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  delete process.env.OD_CLAUDE_HOME;
+});
+
+async function get(pathname: string): Promise<{ status: number; body: any }> {
+  const res = await fetch(`http://127.0.0.1:${port}${pathname}`);
+  return { status: res.status, body: await res.json() };
+}
+
+describe('GET /api/claude-code/mcp-servers', () => {
+  it('returns available=false when home does not exist', async () => {
+    process.env.OD_CLAUDE_HOME = path.join(FIXTURES, 'does-not-exist');
+    const { status, body } = await get('/api/claude-code/mcp-servers');
+    expect(status).toBe(200);
+    expect(body).toEqual({ available: false, servers: [] });
+  });
+
+  it('sorts user-scope before plugin-scope, alphabetical within', async () => {
+    process.env.OD_CLAUDE_HOME = path.join(FIXTURES, 'claude-home-mixed', 'home');
+    const { status, body } = await get('/api/claude-code/mcp-servers');
+    expect(status).toBe(200);
+    expect(body.available).toBe(true);
+    expect(body.servers.map((s: any) => `${s.source}:${s.name}`)).toEqual([
+      'user:alpha',
+      'user:zulu',
+      'plugin:beta',
+    ]);
+  });
+});
+
+describe('GET /api/claude-code/skills', () => {
+  it('returns available=false when home does not exist', async () => {
+    process.env.OD_CLAUDE_HOME = path.join(FIXTURES, 'does-not-exist');
+    const { body } = await get('/api/claude-code/skills');
+    expect(body).toEqual({ available: false, skills: [] });
+  });
+
+  it('sorts user-scope skills before plugin-scope skills', async () => {
+    process.env.OD_CLAUDE_HOME = path.join(FIXTURES, 'claude-home-mixed', 'home');
+    const { body } = await get('/api/claude-code/skills');
+    expect(body.available).toBe(true);
+    expect(body.skills.map((s: any) => `${s.source}:${s.id}`)).toEqual([
+      'user:zskill',
+      'plugin:askill',
+    ]);
+  });
+});

--- a/apps/daemon/tests/fixtures/claude-home-malformed-json/.claude.json
+++ b/apps/daemon/tests/fixtures/claude-home-malformed-json/.claude.json
@@ -1,0 +1,1 @@
+{ "mcpServers": {

--- a/apps/daemon/tests/fixtures/claude-home-mixed/.claude.json
+++ b/apps/daemon/tests/fixtures/claude-home-mixed/.claude.json
@@ -1,0 +1,1 @@
+{ "mcpServers": { "alpha": { "command": "node", "args": ["/x.js"] }, "zulu": { "url": "https://x/sse", "type": "sse" } } }

--- a/apps/daemon/tests/fixtures/claude-home-mixed/home/plugins/cache/exampleco/p1/1.0.0/.claude-plugin/plugin.json
+++ b/apps/daemon/tests/fixtures/claude-home-mixed/home/plugins/cache/exampleco/p1/1.0.0/.claude-plugin/plugin.json
@@ -1,0 +1,1 @@
+{ "name": "p1", "version": "1.0.0", "mcpServers": { "beta": { "command": "node", "args": ["/y.js"] } } }

--- a/apps/daemon/tests/fixtures/claude-home-mixed/home/plugins/cache/exampleco/p1/1.0.0/askill/SKILL.md
+++ b/apps/daemon/tests/fixtures/claude-home-mixed/home/plugins/cache/exampleco/p1/1.0.0/askill/SKILL.md
@@ -1,0 +1,4 @@
+---
+name: askill
+description: a plugin skill
+---

--- a/apps/daemon/tests/fixtures/claude-home-mixed/home/skills/zskill/SKILL.md
+++ b/apps/daemon/tests/fixtures/claude-home-mixed/home/skills/zskill/SKILL.md
@@ -1,0 +1,4 @@
+---
+name: zskill
+description: z
+---

--- a/apps/daemon/tests/fixtures/claude-home-plugin-mcp/home/plugins/cache/exampleco/broken/9.9.9/.claude-plugin/plugin.json
+++ b/apps/daemon/tests/fixtures/claude-home-plugin-mcp/home/plugins/cache/exampleco/broken/9.9.9/.claude-plugin/plugin.json
@@ -1,0 +1,1 @@
+not json

--- a/apps/daemon/tests/fixtures/claude-home-plugin-mcp/home/plugins/cache/exampleco/example-pack/1.2.3/.claude-plugin/plugin.json
+++ b/apps/daemon/tests/fixtures/claude-home-plugin-mcp/home/plugins/cache/exampleco/example-pack/1.2.3/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "example-pack",
+  "version": "1.2.3",
+  "mcpServers": {
+    "github": { "command": "node", "args": ["/abs/github.js"] },
+    "sentry": { "url": "https://sentry.example/sse", "type": "sse" }
+  }
+}

--- a/apps/daemon/tests/fixtures/claude-home-plugin-mcp/home/plugins/cache/exampleco/no-mcp/0.1.0/.claude-plugin/plugin.json
+++ b/apps/daemon/tests/fixtures/claude-home-plugin-mcp/home/plugins/cache/exampleco/no-mcp/0.1.0/.claude-plugin/plugin.json
@@ -1,0 +1,1 @@
+{"name":"no-mcp","version":"0.1.0"}

--- a/apps/daemon/tests/fixtures/claude-home-plugin-skills/home/plugins/cache/exampleco/skills-pack/2.0.0/.claude-plugin/plugin.json
+++ b/apps/daemon/tests/fixtures/claude-home-plugin-skills/home/plugins/cache/exampleco/skills-pack/2.0.0/.claude-plugin/plugin.json
@@ -1,0 +1,1 @@
+{"name":"skills-pack","version":"2.0.0"}

--- a/apps/daemon/tests/fixtures/claude-home-plugin-skills/home/plugins/cache/exampleco/skills-pack/2.0.0/brainstorming/SKILL.md
+++ b/apps/daemon/tests/fixtures/claude-home-plugin-skills/home/plugins/cache/exampleco/skills-pack/2.0.0/brainstorming/SKILL.md
@@ -1,0 +1,4 @@
+---
+name: brainstorming
+description: Use before any creative work.
+---

--- a/apps/daemon/tests/fixtures/claude-home-plugin-skills/home/plugins/cache/exampleco/skills-pack/2.0.0/nested/research/SKILL.md
+++ b/apps/daemon/tests/fixtures/claude-home-plugin-skills/home/plugins/cache/exampleco/skills-pack/2.0.0/nested/research/SKILL.md
@@ -1,0 +1,4 @@
+---
+name: research
+description: Deep research skill nested one level deeper.
+---

--- a/apps/daemon/tests/fixtures/claude-home-user-mcp/.claude.json
+++ b/apps/daemon/tests/fixtures/claude-home-user-mcp/.claude.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "filesystem": { "command": "node", "args": ["/abs/fs-server.js"] },
+    "remote-sse":  { "url": "https://example.com/sse", "type": "sse" },
+    "remote-http": { "url": "https://example.com/http", "type": "http" },
+    "weird":       { "foo": "bar" }
+  }
+}

--- a/apps/daemon/tests/fixtures/claude-home-user-skills/home/skills/no-frontmatter/SKILL.md
+++ b/apps/daemon/tests/fixtures/claude-home-user-skills/home/skills/no-frontmatter/SKILL.md
@@ -1,0 +1,1 @@
+Just body text without any frontmatter at all.

--- a/apps/daemon/tests/fixtures/claude-home-user-skills/home/skills/web-animation-design/SKILL.md
+++ b/apps/daemon/tests/fixtures/claude-home-user-skills/home/skills/web-animation-design/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: web-animation-design
+description: Use when designing UI animations, transitions, and motion.
+---
+Body text.

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { CSSProperties, Dispatch, SetStateAction } from 'react';
+import type {
+  ClaudeCodeInstalledMcpServersResponse,
+  ClaudeCodeInstalledSkillsResponse,
+} from '@open-design/contracts';
 import { LOCALE_LABEL, LOCALES, useI18n } from '../i18n';
 import type { Locale } from '../i18n';
 import { AgentIcon } from './AgentIcon';
@@ -1490,6 +1494,9 @@ function IntegrationsSection() {
   const [copied, setCopied] = useState(false);
   const [info, setInfo] = useState<McpInstallInfo | null>(null);
   const [infoError, setInfoError] = useState<string | null>(null);
+  const [ccMcp, setCcMcp] = useState<ClaudeCodeInstalledMcpServersResponse | null>(null);
+  const [ccSkills, setCcSkills] = useState<ClaudeCodeInstalledSkillsResponse | null>(null);
+  const [ccRefreshTick, setCcRefreshTick] = useState(0);
   const pickerRef = useRef<HTMLDivElement | null>(null);
   // The reset is wired through a ref-driven timer rather than effect
   // cleanup so re-clicks during the 2s window restart the countdown.
@@ -1544,6 +1551,37 @@ function IntegrationsSection() {
       cancelled = true;
     };
   }, []);
+
+  // Sync display of Claude Code CLI-installed MCP servers and skills.
+  // Only fires when the user has the Claude Code client selected — keeps
+  // the daemon scan off the critical path for users on other clients.
+  useEffect(() => {
+    if (clientId !== 'claude') {
+      setCcMcp(null);
+      setCcSkills(null);
+      return;
+    }
+    let cancelled = false;
+    fetch('/api/claude-code/mcp-servers')
+      .then((res) => res.json() as Promise<ClaudeCodeInstalledMcpServersResponse>)
+      .then((data) => {
+        if (!cancelled) setCcMcp(data);
+      })
+      .catch(() => {
+        if (!cancelled) setCcMcp({ available: false, servers: [] });
+      });
+    fetch('/api/claude-code/skills')
+      .then((res) => res.json() as Promise<ClaudeCodeInstalledSkillsResponse>)
+      .then((data) => {
+        if (!cancelled) setCcSkills(data);
+      })
+      .catch(() => {
+        if (!cancelled) setCcSkills({ available: false, skills: [] });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [clientId, ccRefreshTick]);
 
   const client = MCP_CLIENTS.find((c) => c.id === clientId) ?? MCP_CLIENTS[0]!;
   const snippet = info ? client.buildSnippet(info) : '';
@@ -1787,6 +1825,14 @@ function IntegrationsSection() {
           </span>
         </div>
 
+        {clientId === 'claude' ? (
+          <ClaudeCodeInstalledPanel
+            mcp={ccMcp}
+            skills={ccSkills}
+            onRefresh={() => setCcRefreshTick((n) => n + 1)}
+          />
+        ) : null}
+
         <div style={{ marginTop: 20, lineHeight: 1.55 }}>
           <p
             style={{
@@ -1838,6 +1884,204 @@ function IntegrationsSection() {
         </p>
       </div>
     </section>
+  );
+}
+
+function ClaudeCodeInstalledPanel({
+  mcp,
+  skills,
+  onRefresh,
+}: {
+  mcp: ClaudeCodeInstalledMcpServersResponse | null;
+  skills: ClaudeCodeInstalledSkillsResponse | null;
+  onRefresh: () => void;
+}) {
+  const loaded = mcp !== null && skills !== null;
+  const notDetected = mcp?.available === false && skills?.available === false;
+
+  if (notDetected) {
+    return (
+      <div
+        className="empty-card"
+        style={{ marginTop: 14, fontSize: 13, lineHeight: 1.5 }}
+      >
+        Claude Code config not detected at <code>~/.claude/</code>. Install
+        Claude Code and run <code>claude mcp add</code> or install a plugin
+        to manage them from here.
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <ClaudeCodeListSection
+        title="Installed MCP servers"
+        emptyHelp="No MCP servers detected. Run `claude mcp add` to register one."
+        loaded={loaded}
+        onRefresh={onRefresh}
+        items={(mcp?.servers ?? []).map((s) => ({
+          key: `${s.source}:${s.name}`,
+          primary: s.name,
+          source: s.source,
+          pluginLabel:
+            s.source === 'plugin' && s.pluginName
+              ? s.pluginVersion
+                ? `${s.pluginName}@${s.pluginVersion}`
+                : s.pluginName
+              : null,
+          description: undefined,
+        }))}
+      />
+      <ClaudeCodeListSection
+        title="Installed skills"
+        emptyHelp="No skills detected under `~/.claude/skills/` or installed plugins."
+        loaded={loaded}
+        onRefresh={onRefresh}
+        items={(skills?.skills ?? []).map((s) => ({
+          key: `${s.source}:${s.id}:${s.path}`,
+          primary: s.id,
+          source: s.source,
+          pluginLabel:
+            s.source === 'plugin' && s.pluginName
+              ? s.pluginVersion
+                ? `${s.pluginName}@${s.pluginVersion}`
+                : s.pluginName
+              : null,
+          description: s.description,
+        }))}
+      />
+    </>
+  );
+}
+
+function ClaudeCodeListSection({
+  title,
+  emptyHelp,
+  loaded,
+  onRefresh,
+  items,
+}: {
+  title: string;
+  emptyHelp: string;
+  loaded: boolean;
+  onRefresh: () => void;
+  items: Array<{
+    key: string;
+    primary: string;
+    source: 'user' | 'plugin';
+    pluginLabel: string | null;
+    description?: string;
+  }>;
+}) {
+  return (
+    <div style={{ marginTop: 20 }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          marginBottom: 8,
+        }}
+      >
+        <p
+          style={{
+            margin: 0,
+            fontSize: 11,
+            color: 'var(--text-muted)',
+            textTransform: 'uppercase',
+            letterSpacing: '0.05em',
+            fontWeight: 600,
+          }}
+        >
+          {title}
+        </p>
+        <button
+          type="button"
+          className="ghost"
+          onClick={onRefresh}
+          style={{ padding: '2px 8px', fontSize: 12 }}
+          aria-label={`Refresh ${title}`}
+        >
+          <Icon name="refresh" size={12} />
+        </button>
+      </div>
+      {!loaded ? (
+        <p style={{ margin: 0, fontSize: 12, color: 'var(--text-muted)' }}>
+          Loading…
+        </p>
+      ) : items.length === 0 ? (
+        <p style={{ margin: 0, fontSize: 12, color: 'var(--text-muted)' }}>
+          {emptyHelp}
+        </p>
+      ) : (
+        <ul style={{ margin: 0, padding: 0, listStyle: 'none' }}>
+          {items.map((item) => (
+            <li
+              key={item.key}
+              style={{
+                padding: '6px 0',
+                borderBottom: '1px solid var(--border)',
+                fontSize: 13,
+                lineHeight: 1.4,
+              }}
+            >
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  flexWrap: 'wrap',
+                }}
+              >
+                <span
+                  style={{
+                    fontFamily:
+                      'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+                  }}
+                >
+                  {item.primary}
+                </span>
+                <span
+                  style={{
+                    fontSize: 11,
+                    padding: '1px 6px',
+                    borderRadius: 4,
+                    background: 'var(--bg-subtle)',
+                    border: '1px solid var(--border)',
+                    color: 'var(--text-muted)',
+                    textTransform: 'lowercase',
+                  }}
+                >
+                  {item.source}
+                </span>
+                {item.pluginLabel ? (
+                  <span
+                    style={{ fontSize: 11, color: 'var(--text-muted)' }}
+                  >
+                    {item.pluginLabel}
+                  </span>
+                ) : null}
+              </div>
+              {item.description ? (
+                <div
+                  style={{
+                    marginTop: 2,
+                    fontSize: 12,
+                    color: 'var(--text-muted)',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                  title={item.description}
+                >
+                  {item.description}
+                </div>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
   );
 }
 

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -269,6 +269,17 @@ export function SettingsDialog({
       }
     };
   }, [initial.theme]);
+
+  // Prevent the page beneath from scrolling while the dialog is open —
+  // otherwise the page's scrollbar and the dialog's internal scrollbar
+  // sit side by side on the right edge.
+  useEffect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, []);
   const [showApiKey, setShowApiKey] = useState(false);
   const [languageOpen, setLanguageOpen] = useState(false);
   const [activeSection, setActiveSection] = useState<SettingsSection>(initialSection);
@@ -1974,47 +1985,78 @@ function ClaudeCodeListSection({
   }>;
 }) {
   return (
-    <div style={{ marginTop: 20 }}>
+    <div
+      style={{
+        marginTop: 20,
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'flex-start',
+        alignItems: 'stretch',
+        gap: 10,
+        minWidth: 0,
+      }}
+    >
       <div
         style={{
           display: 'flex',
           alignItems: 'center',
-          justifyContent: 'space-between',
-          marginBottom: 8,
+          gap: 8,
         }}
       >
-        <p
+        <h4
           style={{
             margin: 0,
-            fontSize: 11,
-            color: 'var(--text-muted)',
-            textTransform: 'uppercase',
-            letterSpacing: '0.05em',
+            fontSize: 13,
             fontWeight: 600,
+            color: 'var(--text)',
           }}
         >
           {title}
-        </p>
+        </h4>
         <button
           type="button"
           className="ghost"
           onClick={onRefresh}
-          style={{ padding: '2px 8px', fontSize: 12 }}
+          style={{
+            width: 22,
+            height: 22,
+            padding: 0,
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexShrink: 0,
+          }}
           aria-label={`Refresh ${title}`}
         >
           <Icon name="refresh" size={12} />
         </button>
       </div>
       {!loaded ? (
-        <p style={{ margin: 0, fontSize: 12, color: 'var(--text-muted)' }}>
+        <p
+          style={{
+            margin: 0,
+            fontSize: 12,
+            color: 'var(--text-muted)',
+            textAlign: 'center',
+            padding: '12px 0',
+          }}
+        >
           Loading…
         </p>
       ) : items.length === 0 ? (
-        <p style={{ margin: 0, fontSize: 12, color: 'var(--text-muted)' }}>
+        <p
+          style={{
+            margin: 0,
+            fontSize: 12,
+            color: 'var(--text-muted)',
+            textAlign: 'center',
+            padding: '12px 0',
+          }}
+        >
           {emptyHelp}
         </p>
       ) : (
-        <ul style={{ margin: 0, padding: 0, listStyle: 'none' }}>
+        <ul style={{ margin: 0, padding: 0, listStyle: 'none', minWidth: 0 }}>
           {items.map((item) => (
             <li
               key={item.key}
@@ -2023,6 +2065,8 @@ function ClaudeCodeListSection({
                 borderBottom: '1px solid var(--border)',
                 fontSize: 13,
                 lineHeight: 1.4,
+                minWidth: 0,
+                overflowWrap: 'anywhere',
               }}
             >
               <div
@@ -2031,12 +2075,15 @@ function ClaudeCodeListSection({
                   alignItems: 'center',
                   gap: 8,
                   flexWrap: 'wrap',
+                  minWidth: 0,
                 }}
               >
                 <span
                   style={{
                     fontFamily:
                       'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+                    overflowWrap: 'anywhere',
+                    minWidth: 0,
                   }}
                 >
                   {item.primary}
@@ -2050,13 +2097,19 @@ function ClaudeCodeListSection({
                     border: '1px solid var(--border)',
                     color: 'var(--text-muted)',
                     textTransform: 'lowercase',
+                    flexShrink: 0,
                   }}
                 >
                   {item.source}
                 </span>
                 {item.pluginLabel ? (
                   <span
-                    style={{ fontSize: 11, color: 'var(--text-muted)' }}
+                    style={{
+                      fontSize: 11,
+                      color: 'var(--text-muted)',
+                      overflowWrap: 'anywhere',
+                      minWidth: 0,
+                    }}
                   >
                     {item.pluginLabel}
                   </span>
@@ -2068,11 +2121,8 @@ function ClaudeCodeListSection({
                     marginTop: 2,
                     fontSize: 12,
                     color: 'var(--text-muted)',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
+                    overflowWrap: 'anywhere',
                   }}
-                  title={item.description}
                 >
                   {item.description}
                 </div>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1056,7 +1056,7 @@ code {
   .modal-settings { max-height: 90vh; }
 }
 .modal-settings .modal-body {
-  overflow-y: auto;
+  overflow: hidden;
   flex: 1;
   min-height: 0;
   display: grid;
@@ -1109,6 +1109,8 @@ code {
   padding: 22px 12px;
   background: var(--bg-subtle);
   border-right: 1px solid var(--border);
+  overflow-y: auto;
+  min-height: 0;
 }
 .settings-nav-item {
   width: 100%;

--- a/packages/contracts/src/api/claude-code.ts
+++ b/packages/contracts/src/api/claude-code.ts
@@ -1,0 +1,28 @@
+export interface ClaudeCodeMcpServer {
+  name: string;
+  source: 'user' | 'plugin';
+  pluginName?: string;
+  pluginVersion?: string;
+  transport: 'stdio' | 'sse' | 'http' | 'unknown';
+  command?: string;
+  url?: string;
+}
+
+export interface ClaudeCodeSkill {
+  id: string;
+  source: 'user' | 'plugin';
+  pluginName?: string;
+  pluginVersion?: string;
+  description?: string;
+  path: string;
+}
+
+export interface ClaudeCodeInstalledMcpServersResponse {
+  available: boolean;
+  servers: ClaudeCodeMcpServer[];
+}
+
+export interface ClaudeCodeInstalledSkillsResponse {
+  available: boolean;
+  skills: ClaudeCodeSkill[];
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -4,6 +4,7 @@ export * from './tasks';
 export * from './api/app-config';
 export * from './api/artifacts';
 export * from './api/chat';
+export * from './api/claude-code';
 export * from './api/connectors';
 export * from './api/comments';
 export * from './api/files';


### PR DESCRIPTION
## Summary
- Adds read-only display of Claude Code CLI-installed MCP servers and skills in **Settings → MCP server** when the "Claude Code" client is selected
- Covers both user-scope (`~/.claude.json` `mcpServers`, `~/.claude/skills/`) and plugin-registered (`~/.claude/plugins/cache/.../plugin.json` + plugin `SKILL.md` files)
- Graceful empty state when Claude Code is not installed (`~/.claude/` absent)
- No mutation of `~/.claude/*` in this PR; enable/disable and uninstall are deferred per product direction

Closes #1838

## Implementation

**Daemon** (`apps/daemon`)
- New `src/claude-code/reader.ts` — five pure readers (`detectAvailability`, `readUserMcpServers`, `readPluginMcpServers`, `readUserSkills`, `readPluginSkills`). Takes a `home: string` arg so tests use fixtures via `OD_CLAUDE_HOME` env override. Reuses the existing `parseFrontmatter` helper from `frontmatter.ts` for SKILL.md frontmatter parsing — no new dependency.
- New `src/claude-code/routes.ts` — `registerClaudeCodeRoutes(app)` registers `GET /api/claude-code/mcp-servers` and `GET /api/claude-code/skills`. Both routes return `{ available, servers | skills }`. Results sorted user-scope first, then plugin, alphabetical within each.
- Per-source errors (malformed `.claude.json`, unreadable SKILL.md, broken plugin manifest) caught at the reader boundary — partial results returned, route never 500s.

**Contracts** (`packages/contracts`)
- New `api/claude-code.ts` exporting `ClaudeCodeMcpServer`, `ClaudeCodeSkill`, and the two response shapes. Pure TypeScript, re-exported from the root barrel.

**Web** (`apps/web`)
- Extended `IntegrationsSection` in `SettingsDialog.tsx`: when Claude Code is the active client, two new sections render below the install snippet — one per kind — with title, refresh button, list rows showing name + source badge + plugin attribution + description (skills only).
- Body-scroll lock matching the existing `PreviewModal` pattern, removing the page-level scrollbar when the dialog is open.
- `.modal-body` switched to `overflow: hidden` and `.settings-sidebar` got its own `overflow-y: auto`, so the right content column is the sole vertical scroll container while the sidebar scrolls independently when needed.

## Tests

- `apps/daemon/tests/claude-code-reader.test.ts` — 13 cases over fixture directories: missing home, empty home, user MCP (stdio/sse/http/unknown), malformed `.claude.json`, plugin MCP with attribution, broken manifest skipped, user skills with frontmatter and fallback, plugin skills with nested SKILL.md.
- `apps/daemon/tests/claude-code-routes.test.ts` — 4 cases against a stub Express app pointed at the `claude-home-mixed` fixture: 200 + `available:false` when home doesn't exist; sort-order verification (user before plugin, alphabetical within).
- Manual smoke against the developer's real `~/.claude/`: 0 user MCP, 0 plugin MCP, 1 user skill (`web-animation-design`), 18 plugin skills correctly attributed across `superpowers@5.0.2` and `academic-research-skills@3.7.0`.

## Test plan
- [ ] `pnpm guard` clean
- [ ] `pnpm --filter @open-design/contracts typecheck` clean
- [ ] `pnpm --filter @open-design/daemon test` — 778 tests pass, including 17 new
- [ ] `pnpm --filter @open-design/web typecheck` clean
- [ ] Manual: open Settings → MCP server → Claude Code → verify list rendering, sort order, plugin attribution, refresh button (`↻`), long names wrap inside the column
- [ ] Manual: rename `~/.claude` temporarily → verify the "Claude Code config not detected" empty state
- [ ] Manual: switch client dropdown to Cursor/Codex/etc. → verify both new sections disappear
- [ ] Manual: confirm only one vertical scrollbar appears on the right (sidebar scrolls independently when its content is taller than the dialog)

## Pre-existing infra noise (unchanged by this PR)
- `pnpm --filter @open-design/daemon build` reports two TS2835 errors in `packages/contracts/src/index.ts` lines 20–21 (extensionless re-exports of `./prompts/system` and `./critique`) — present on `main` too. The contracts package itself typechecks cleanly via its own tsconfig.