### PR TITLE
fix(workspace-tabs): keep search popover inside the viewport

### DIFF
--- a/apps/web/src/components/WorkspaceTabsBar.tsx
+++ b/apps/web/src/components/WorkspaceTabsBar.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useT } from '../i18n';
 import { navigate, type EntryHomeView, type Route } from '../router';
 import type { Project } from '../types';
@@ -252,6 +253,7 @@ export function WorkspaceTabsBar({ route, projects }: Props) {
   const [maxVisibleTabs, setMaxVisibleTabs] = useState(MAX_VISIBLE_CHROME_TABS);
   const stripRef = useRef<HTMLDivElement | null>(null);
   const menuRef = useRef<HTMLDivElement | null>(null);
+  const popoverRef = useRef<HTMLDivElement | null>(null);
   const searchInputRef = useRef<HTMLInputElement | null>(null);
 
   const projectById = useMemo(
@@ -335,7 +337,16 @@ export function WorkspaceTabsBar({ route, projects }: Props) {
   useEffect(() => {
     if (!tabsMenuOpen) return;
     function onPointerDown(event: MouseEvent) {
-      if (!menuRef.current?.contains(event.target as Node)) {
+      const target = event.target as Node;
+      const insideTrigger = menuRef.current?.contains(target) ?? false;
+      // The popover is rendered through a portal into document.body to
+      // escape the `contain: layout` containment block on
+      // `.workspace-tabs-strip` (which would otherwise resolve our
+      // fixed positioning against the strip instead of the viewport).
+      // The portaled node is outside menuRef's subtree, so we also have
+      // to count clicks inside it as "inside the menu".
+      const insidePopover = popoverRef.current?.contains(target) ?? false;
+      if (!insideTrigger && !insidePopover) {
         setTabsMenuOpen(false);
       }
     }
@@ -469,8 +480,14 @@ export function WorkspaceTabsBar({ route, projects }: Props) {
           >
             <Icon name="search" size={15} />
           </button>
-          {tabsMenuOpen ? (
-            <div className="workspace-tabs-popover" role="dialog" aria-label="Search tabs">
+          {tabsMenuOpen && typeof document !== 'undefined'
+            ? createPortal(
+                <div
+                  className="workspace-tabs-popover"
+                  role="dialog"
+                  aria-label="Search tabs"
+                  ref={popoverRef}
+                >
               <div className="workspace-tabs-search">
                 <Icon name="search" size={14} />
                 <input
@@ -525,8 +542,10 @@ export function WorkspaceTabsBar({ route, projects }: Props) {
                   <div className="workspace-tabs-empty">No tabs found</div>
                 )}
               </div>
-            </div>
-          ) : null}
+                </div>,
+                document.body,
+              )
+            : null}
         </div>
       </div>
       <div className="workspace-tabs-drag" aria-hidden />

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -712,11 +712,17 @@ code {
   -webkit-app-region: no-drag;
 }
 .workspace-tabs-popover {
-  position: absolute;
-  top: calc(100% + 7px);
-  right: 0;
+  /* Anchored to the viewport, not to .workspace-tabs-actions, because the
+     actions group sits next to the tab strip on the left side of the chrome
+     header — not the right. `position: absolute; right: 0` against that
+     narrow inline-flex container made the 380px popover hang off the left
+     edge of the window. Fixed positioning keeps it inside the viewport
+     regardless of where the actions group lands as tabs accumulate. */
+  position: fixed;
+  top: calc(var(--workspace-tabs-chrome-height, 38px) + 7px);
+  right: max(10px, env(safe-area-inset-right));
   width: min(380px, calc(100vw - 24px));
-  max-height: min(620px, calc(100vh - 72px));
+  max-height: min(620px, calc(100vh - var(--workspace-tabs-chrome-height, 38px) - 24px));
   padding: 8px;
   border: 1px solid var(--border);
   border-radius: 8px;


### PR DESCRIPTION
## Why

I hit this myself while running `pnpm tools-dev` to evaluate Open Design as a design tool — the very first time I clicked the search (🔍) icon in the workspace-tabs chrome bar, the popover opened mostly off-screen to the left, with the input and result rows clipped against the Electron window frame. Filing this as a small UI-correctness fix so the control is usable on first contact.

## What users will see

Clicking the search (🔍) icon in the workspace-tabs chrome bar at the top of the window now opens a fully on-screen popover (search input + open-tab list), instead of one that hangs off the left edge of the window with the input and rows clipped. No new control, no new behavior — same popover, same keyboard / outside-click dismissal, just landing inside the viewport where the user can actually read and interact with it.

## Surface area

- [x] **UI** — fixes a clipping bug on the existing workspace-tabs search popover in `apps/web`
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

Before / after captures of the popover opened from the search icon in the workspace-tabs chrome bar. I'll attach the PNGs in a follow-up comment on this PR — the relevant frame in each is the area immediately under the search icon (top-left of the chrome bar).

- **Before:** popover anchored to `.workspace-tabs-actions` (a narrow inline-flex container on the left of the chrome row). 
<img width="651" height="330" alt="image" src="https://github.com/user-attachments/assets/70f9ed56-8e07-4b61-b3bb-a72eeedf8ebe" />

- **After:** popover renders inside the viewport (top-right, anchored via portal + `position: fixed`), input and `Home / Start a new project` row fully visible and clickable.
<img width="1282" height="173" alt="image" src="https://github.com/user-attachments/assets/2929aa4f-2712-4468-b739-863c6323645f" />

## Bug fix verification

This is a presentational regression in pure CSS/DOM-layout space. No targeted unit test was cheap to write — the failure mode is "computed left of popover is negative against the visible viewport," which depends on the live containment-block tree and the Electron window's actual right edge. Instead I verified manually with `pnpm tools-dev` against the running Electron window on macOS, both before and after the change, with one open tab (the worst case the bug surfaces in). Happy to add a Playwright-style visual test if maintainers prefer; the hook already exists in repo tooling but the failure isn't reachable from a JSDOM render.

## Validation

- `corepack pnpm --filter @open-design/web typecheck` — clean
- `corepack pnpm tools-dev` — locally on macOS, opened the Electron window, clicked the workspace-tabs search icon, verified the popover lands inside the viewport at top-right and that input + tab rows are fully visible
- Outside-click + Escape dismissal still work (now checked against both the trigger ref and a new ref on the portaled popover so clicks inside the popover don't close it prematurely)
- Verified the underlying containment cause: `.workspace-tabs-strip` has `contain: layout style`, which establishes a containing block for fixed descendants; portaling the popover into `document.body` via `createPortal` is what actually breaks it out of the strip's containment

## Notes for reviewers

Two commits in this PR:

1. **CSS fix** (`3cc6344`'s predecessor): change `position: absolute; right: 0` against the actions group to `position: fixed; top: var(--workspace-tabs-chrome-height, 38px) + 7px; right: max(10px, env(safe-area-inset-right))`.
2. **Portal fix** (`3cc6344`): per @chatgpt-codex-connector review, CSS alone was insufficient because `.workspace-tabs-strip` has `contain: layout style`, which establishes a containing block for fixed descendants. The popover now renders through `createPortal(..., document.body)` to escape the containment. Outside-click handler updated to track a second ref on the portaled node.