### PR TITLE
fix(daemon): ensure node binary dir is on PATH for agent sub-processes on Windows

### DIFF
--- a/apps/daemon/src/runtimes/launch.ts
+++ b/apps/daemon/src/runtimes/launch.ts
@@ -39,19 +39,40 @@ export function resolveAgentLaunch(
 export function applyAgentLaunchEnv(
   env: NodeJS.ProcessEnv,
   launch: Pick<AgentLaunchResolution, 'childPathPrepend'>,
+  nodeBinDir: string = path.dirname(process.execPath),
 ): NodeJS.ProcessEnv {
-  if (launch.childPathPrepend.length === 0) return env;
+  // Build the ordered list of directories to guarantee are at the front of
+  // PATH: the running Node binary directory first (so npm .cmd shims on
+  // Windows that invoke bare "node" find the correct binary even when the
+  // daemon was GUI-launched without a nodejs entry on PATH), then the agent
+  // wrapper/shim directory.  Using process.execPath as the default means
+  // every call site — detectAgents, connection tests, and chat runs —
+  // consistently reaches the correct Node binary without each caller having
+  // to duplicate the dirname(process.execPath) prepend independently.
+  const toPrepend = [...(nodeBinDir ? [nodeBinDir] : []), ...launch.childPathPrepend];
+  if (toPrepend.length === 0) return env;
   // Case-insensitive key lookup — Windows uses 'Path', not 'PATH'.
   // Using env.PATH directly would be undefined on Windows, yielding a
-  // one-entry PATH that contains only childPathPrepend and discards all
-  // system paths (including the node binary dir).  Find the actual key
-  // name so we update in place rather than adding a conflicting duplicate.
+  // one-entry PATH that contains only toPrepend and discards all system
+  // paths.  Find the actual key name so we update in place rather than
+  // adding a conflicting duplicate key.
   const pathKey = Object.keys(env).find((k) => k.toLowerCase() === 'path') ?? 'PATH';
   const existing = typeof env[pathKey] === 'string' ? (env[pathKey] as string) : '';
-  const merged = [...launch.childPathPrepend, ...existing.split(delimiter)]
-    .filter((entry, index, entries) => entry.length > 0 && entries.indexOf(entry) === index)
-    .join(delimiter);
-  return { ...env, [pathKey]: merged };
+  const normalize = (p: string) => {
+    const trimmed = p.replace(/[/\\]+$/, '');
+    return process.platform === 'win32' ? trimmed.toLowerCase() : trimmed;
+  };
+  const existingParts = existing.split(delimiter).filter((e) => e.length > 0);
+  const seen = new Set<string>();
+  const merged: string[] = [];
+  for (const entry of [...toPrepend, ...existingParts]) {
+    const n = normalize(entry);
+    if (!seen.has(n)) {
+      seen.add(n);
+      merged.push(entry);
+    }
+  }
+  return { ...env, [pathKey]: merged.join(delimiter) };
 }
 
 function tryResolveCodexNativeBinary(wrapperPath: string): {

--- a/apps/daemon/src/runtimes/launch.ts
+++ b/apps/daemon/src/runtimes/launch.ts
@@ -41,11 +41,17 @@ export function applyAgentLaunchEnv(
   launch: Pick<AgentLaunchResolution, 'childPathPrepend'>,
 ): NodeJS.ProcessEnv {
   if (launch.childPathPrepend.length === 0) return env;
-  const existing = typeof env.PATH === 'string' ? env.PATH : '';
-  const PATH = [...launch.childPathPrepend, ...existing.split(delimiter)]
+  // Case-insensitive key lookup — Windows uses 'Path', not 'PATH'.
+  // Using env.PATH directly would be undefined on Windows, yielding a
+  // one-entry PATH that contains only childPathPrepend and discards all
+  // system paths (including the node binary dir).  Find the actual key
+  // name so we update in place rather than adding a conflicting duplicate.
+  const pathKey = Object.keys(env).find((k) => k.toLowerCase() === 'path') ?? 'PATH';
+  const existing = typeof env[pathKey] === 'string' ? (env[pathKey] as string) : '';
+  const merged = [...launch.childPathPrepend, ...existing.split(delimiter)]
     .filter((entry, index, entries) => entry.length > 0 && entries.indexOf(entry) === index)
     .join(delimiter);
-  return { ...env, PATH };
+  return { ...env, [pathKey]: merged };
 }
 
 function tryResolveCodexNativeBinary(wrapperPath: string): {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1394,7 +1394,14 @@ export function createAgentRuntimeEnv(
   // was launched with a full path to node and the directory was not on PATH.
   const nodeBinDir = path.dirname(nodeBin);
   if (nodeBinDir) {
-    const existingPath = typeof env.PATH === 'string' ? env.PATH : '';
+    // On Windows, process.env spreads with the search path under 'Path' rather
+    // than 'PATH'. Locate the key case-insensitively so we read and write the
+    // same entry that child_process.spawn consults. If we blindly write a new
+    // 'PATH' key alongside an existing 'Path', Node's case-insensitive env
+    // de-duplication on Windows lets the new key win — dropping all inherited
+    // directories (git, npm, agent shims, etc.) from the child's search path.
+    const pathKey = Object.keys(env).find((k) => k.toLowerCase() === 'path') ?? 'PATH';
+    const existingPath = typeof env[pathKey] === 'string' ? (env[pathKey] as string) : '';
     const parts = existingPath.split(path.delimiter).filter((p) => p.length > 0);
     const normalize = (p: string) => p.replace(/[/\\]+$/, '');
     const normalizedDir = normalize(nodeBinDir);
@@ -1405,7 +1412,7 @@ export function createAgentRuntimeEnv(
         : n === normalizedDir;
     });
     if (!alreadyIncluded) {
-      env.PATH = [nodeBinDir, ...parts].join(path.delimiter);
+      env[pathKey] = [nodeBinDir, ...parts].join(path.delimiter);
     }
   }
 

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1382,11 +1382,24 @@ export function createAgentRuntimeEnv(
   toolTokenGrant: { token?: string } | null = null,
   nodeBin: string = process.execPath,
 ): NodeJS.ProcessEnv {
-  const env = {
+  const env: NodeJS.ProcessEnv = {
     ...baseEnv,
     OD_DAEMON_URL: daemonUrl,
     OD_NODE_BIN: nodeBin,
   };
+
+  // Ensure the node binary directory is on PATH so agent sub-processes —
+  // in particular npm .cmd shims on Windows that run `"node" script.js` —
+  // can find the same node binary that runs the daemon even when the daemon
+  // was launched with a full path to node and the directory was not on PATH.
+  const nodeBinDir = path.dirname(nodeBin);
+  if (nodeBinDir) {
+    const existingPath = typeof env.PATH === 'string' ? env.PATH : '';
+    const parts = existingPath.split(path.delimiter).filter((p) => p.length > 0);
+    if (!parts.includes(nodeBinDir)) {
+      env.PATH = [nodeBinDir, ...parts].join(path.delimiter);
+    }
+  }
 
   if (toolTokenGrant?.token) {
     env.OD_TOOL_TOKEN = toolTokenGrant.token;
@@ -8784,7 +8797,12 @@ export async function startServer({
         // crash the daemon. Swallow it — the regular exit/close handlers
         // below already route the underlying failure to SSE via stderr.
         child.stdin.on('error', (err) => {
-          if (err.code !== 'EPIPE') {
+          // EPIPE = Unix broken-pipe when child closes its stdin read end
+          // early. 'write EOF' (err.code 'EOF') = Windows equivalent of
+          // the same condition via UV_EOF. Both mean the child exited before
+          // reading stdin — the process exit/close handlers already route
+          // the underlying failure to SSE via stderr, so swallow these here.
+          if (err.code !== 'EPIPE' && err.code !== 'EOF' && err.message !== 'write EOF') {
             send(
               'error',
               createSseErrorPayload(

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1396,7 +1396,15 @@ export function createAgentRuntimeEnv(
   if (nodeBinDir) {
     const existingPath = typeof env.PATH === 'string' ? env.PATH : '';
     const parts = existingPath.split(path.delimiter).filter((p) => p.length > 0);
-    if (!parts.includes(nodeBinDir)) {
+    const normalize = (p: string) => p.replace(/[/\\]+$/, '');
+    const normalizedDir = normalize(nodeBinDir);
+    const alreadyIncluded = parts.some((p) => {
+      const n = normalize(p);
+      return process.platform === 'win32'
+        ? n.toLowerCase() === normalizedDir.toLowerCase()
+        : n === normalizedDir;
+    });
+    if (!alreadyIncluded) {
       env.PATH = [nodeBinDir, ...parts].join(path.delimiter);
     }
   }

--- a/apps/daemon/tests/agent-runtime-env.test.ts
+++ b/apps/daemon/tests/agent-runtime-env.test.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import { createAgentRuntimeEnv, createAgentRuntimeToolPrompt } from '../src/server.js';
+import { applyAgentLaunchEnv } from '../src/runtimes/launch.js';
 
 describe('agent runtime tool environment', () => {
   it('injects daemon URL and run-scoped tool token into agent sessions', () => {
@@ -95,5 +96,43 @@ describe('agent runtime tool environment', () => {
     expect(prompt).toContain('Daemon URL: `http://127.0.0.1:7456`');
     expect(prompt).toContain('`OD_TOOL_TOKEN` is not available');
     expect(prompt).not.toContain('Bearer');
+  });
+});
+
+describe('applyAgentLaunchEnv', () => {
+  it('returns env unchanged when childPathPrepend is empty', () => {
+    const base = { Path: 'C:\\Windows\\system32', OTHER: 'val' };
+    const result = applyAgentLaunchEnv(base, { childPathPrepend: [] });
+    expect(result).toBe(base);
+  });
+
+  it('prepends childPathPrepend entries to PATH when key is uppercase', () => {
+    const base = { PATH: '/usr/bin' };
+    const result = applyAgentLaunchEnv(base, { childPathPrepend: ['/opt/copilot'] });
+    expect(result.PATH).toBe(`/opt/copilot${path.delimiter}/usr/bin`);
+    expect(result['Path']).toBeUndefined();
+  });
+
+  it('uses the existing Windows-style Path key instead of adding a competing PATH key', () => {
+    // This is the Windows GUI regression: env.PATH is undefined when the actual
+    // key is 'Path'.  The old code created a fresh PATH = just childPathPrepend,
+    // discarding the system paths and the node directory prepended by
+    // createAgentRuntimeEnv, which caused '"node" is not recognized' errors.
+    const base = { Path: 'C:\\Program Files\\nodejs;C:\\Windows\\system32' };
+    const result = applyAgentLaunchEnv(base, { childPathPrepend: ['C:\\Users\\user\\AppData\\Roaming\\npm'] });
+
+    // The existing 'Path' key must be updated in place.
+    expect(result.Path).toBe(
+      `C:\\Users\\user\\AppData\\Roaming\\npm${path.delimiter}C:\\Program Files\\nodejs${path.delimiter}C:\\Windows\\system32`,
+    );
+    // A competing uppercase 'PATH' key must NOT be created.
+    expect(result.PATH).toBeUndefined();
+  });
+
+  it('deduplicates entries already present in Path', () => {
+    const existing = 'C:\\opt\\bin;C:\\Windows\\system32';
+    const base = { Path: existing };
+    const result = applyAgentLaunchEnv(base, { childPathPrepend: ['C:\\opt\\bin'] });
+    expect(result.Path).toBe(existing);
   });
 });

--- a/apps/daemon/tests/agent-runtime-env.test.ts
+++ b/apps/daemon/tests/agent-runtime-env.test.ts
@@ -100,17 +100,17 @@ describe('agent runtime tool environment', () => {
 });
 
 describe('applyAgentLaunchEnv', () => {
-  it('returns env unchanged when childPathPrepend is empty', () => {
-    const base = { Path: 'C:\\Windows\\system32', OTHER: 'val' };
-    const result = applyAgentLaunchEnv(base, { childPathPrepend: [] });
+  it('returns env unchanged when childPathPrepend is empty and no node dir is provided', () => {
+    const base = { Path: ['/usr/local/bin', '/usr/bin'].join(path.delimiter), OTHER: 'val' };
+    const result = applyAgentLaunchEnv(base, { childPathPrepend: [] }, '');
     expect(result).toBe(base);
   });
 
   it('prepends childPathPrepend entries to PATH when key is uppercase', () => {
     const base = { PATH: '/usr/bin' };
-    const result = applyAgentLaunchEnv(base, { childPathPrepend: ['/opt/copilot'] });
+    const result = applyAgentLaunchEnv(base, { childPathPrepend: ['/opt/copilot'] }, '');
     expect(result.PATH).toBe(`/opt/copilot${path.delimiter}/usr/bin`);
-    expect(result['Path']).toBeUndefined();
+    expect(result.Path).toBeUndefined();
   });
 
   it('uses the existing Windows-style Path key instead of adding a competing PATH key', () => {
@@ -118,21 +118,23 @@ describe('applyAgentLaunchEnv', () => {
     // key is 'Path'.  The old code created a fresh PATH = just childPathPrepend,
     // discarding the system paths and the node directory prepended by
     // createAgentRuntimeEnv, which caused '"node" is not recognized' errors.
-    const base = { Path: 'C:\\Program Files\\nodejs;C:\\Windows\\system32' };
-    const result = applyAgentLaunchEnv(base, { childPathPrepend: ['C:\\Users\\user\\AppData\\Roaming\\npm'] });
+    // Pure POSIX paths + path.delimiter keep the assertion correct on all platforms;
+    // the real Windows C:\...;... shape is covered by winTest in launch.test.ts.
+    const base = { Path: ['/opt/nodejs', '/usr/bin'].join(path.delimiter) };
+    const result = applyAgentLaunchEnv(base, { childPathPrepend: ['/opt/agent/bin'] }, '');
 
     // The existing 'Path' key must be updated in place.
     expect(result.Path).toBe(
-      `C:\\Users\\user\\AppData\\Roaming\\npm${path.delimiter}C:\\Program Files\\nodejs${path.delimiter}C:\\Windows\\system32`,
+      ['/opt/agent/bin', '/opt/nodejs', '/usr/bin'].join(path.delimiter),
     );
     // A competing uppercase 'PATH' key must NOT be created.
     expect(result.PATH).toBeUndefined();
   });
 
   it('deduplicates entries already present in Path', () => {
-    const existing = 'C:\\opt\\bin;C:\\Windows\\system32';
+    const existing = ['/opt/bin', '/usr/bin'].join(path.delimiter);
     const base = { Path: existing };
-    const result = applyAgentLaunchEnv(base, { childPathPrepend: ['C:\\opt\\bin'] });
+    const result = applyAgentLaunchEnv(base, { childPathPrepend: ['/opt/bin'] }, '');
     expect(result.Path).toBe(existing);
   });
 });

--- a/apps/daemon/tests/agent-runtime-env.test.ts
+++ b/apps/daemon/tests/agent-runtime-env.test.ts
@@ -43,6 +43,24 @@ describe('agent runtime tool environment', () => {
     expect(env.PATH).toBe(`/opt/node${path.delimiter}/bin`);
   });
 
+  it('updates the existing path key in place when the base env uses Windows-style Path casing', () => {
+    // Windows GUI launches commonly spread process.env where the search path is
+    // stored under 'Path' rather than 'PATH'. The function must read and update
+    // that same key so child_process.spawn (which de-duplicates env keys
+    // case-insensitively on Windows) does not discard the inherited directories.
+    const env = createAgentRuntimeEnv(
+      { Path: `/usr/local/bin` },
+      'http://127.0.0.1:7456',
+      null,
+      '/opt/node/node',
+    );
+
+    // The original 'Path' key must be updated with the prepended node dir.
+    expect(env.Path).toBe(`/opt/node${path.delimiter}/usr/local/bin`);
+    // A competing uppercase 'PATH' key must NOT be created alongside it.
+    expect(env.PATH).toBeUndefined();
+  });
+
   it('does not leak stale inherited tool tokens when no run token was minted', () => {
     const env = createAgentRuntimeEnv(
       { PATH: '/bin', OD_TOOL_TOKEN: 'stale-token' },

--- a/apps/daemon/tests/agent-runtime-env.test.ts
+++ b/apps/daemon/tests/agent-runtime-env.test.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import { createAgentRuntimeEnv, createAgentRuntimeToolPrompt } from '../src/server.js';
@@ -12,11 +14,33 @@ describe('agent runtime tool environment', () => {
     );
 
     expect(env).toMatchObject({
-      PATH: '/bin',
+      PATH: `/opt/open-design/bin${path.delimiter}/bin`,
       OD_DAEMON_URL: 'http://127.0.0.1:7456',
       OD_NODE_BIN: '/opt/open-design/bin/node',
       OD_TOOL_TOKEN: 'fresh-token',
     });
+  });
+
+  it('prepends node binary directory to PATH when not already present', () => {
+    const env = createAgentRuntimeEnv(
+      { PATH: '/bin' },
+      'http://127.0.0.1:7456',
+      null,
+      '/opt/node/node',
+    );
+
+    expect(env.PATH).toBe(`/opt/node${path.delimiter}/bin`);
+  });
+
+  it('does not duplicate node binary directory when already present in PATH', () => {
+    const env = createAgentRuntimeEnv(
+      { PATH: `/opt/node${path.delimiter}/bin` },
+      'http://127.0.0.1:7456',
+      null,
+      '/opt/node/node',
+    );
+
+    expect(env.PATH).toBe(`/opt/node${path.delimiter}/bin`);
   });
 
   it('does not leak stale inherited tool tokens when no run token was minted', () => {

--- a/apps/daemon/tests/runtimes/launch.test.ts
+++ b/apps/daemon/tests/runtimes/launch.test.ts
@@ -16,8 +16,9 @@ import {
 } from './helpers/test-helpers.js';
 
 const fsTest = process.platform === 'win32' ? test.skip : test;
+const winTest = process.platform === 'win32' ? test : test.skip;
 
-test('applyAgentLaunchEnv prepends the selected executable dirname and dedupes PATH', () => {
+test('applyAgentLaunchEnv prepends nodeBinDir and wrapper dir, deduping PATH', () => {
   const launch = {
     childPathPrepend: ['/opt/tools/bin', '/opt/tools/bin'],
   };
@@ -25,9 +26,66 @@ test('applyAgentLaunchEnv prepends the selected executable dirname and dedupes P
   const env = applyAgentLaunchEnv(
     { PATH: ['/usr/bin', '/opt/tools/bin', '/bin', '/usr/bin'].join(delimiter) },
     launch,
+    '/node/bin',
   );
 
-  assert.equal(env.PATH, ['/opt/tools/bin', '/usr/bin', '/bin'].join(delimiter));
+  assert.equal(
+    env.PATH,
+    ['/node/bin', '/opt/tools/bin', '/usr/bin', '/bin'].join(delimiter),
+  );
+});
+
+test('applyAgentLaunchEnv updates the Path key in-place without creating a competing PATH key', () => {
+  // On Windows, process.env spreads the search path under 'Path' (not 'PATH').
+  // This test uses POSIX-compatible paths so it runs cross-platform and
+  // exercises the key-casing fix across the full CI matrix.
+  const base: NodeJS.ProcessEnv = {
+    Path: ['/usr/local/bin', '/usr/bin'].join(delimiter),
+  };
+  const launch = { childPathPrepend: ['/opt/agent/bin'] };
+
+  const env = applyAgentLaunchEnv(base, launch, '/opt/node/bin');
+
+  // Original 'Path' key must be updated in-place.
+  assert.ok('Path' in env, 'original Path key must be preserved');
+  // No competing uppercase 'PATH' key may be created alongside it.
+  assert.equal(env.PATH, undefined, 'no spurious uppercase PATH key must be created');
+
+  const parts = (env.Path as string).split(delimiter);
+  assert.equal(parts[0], '/opt/node/bin', 'Node dir must be first in Path');
+  assert.equal(parts[1], '/opt/agent/bin', 'wrapper dir must follow Node dir');
+  assert.ok(parts.includes('/usr/local/bin'), '/usr/local/bin must be retained');
+  assert.ok(parts.includes('/usr/bin'), '/usr/bin must be retained');
+});
+
+winTest('applyAgentLaunchEnv injects Node binary dir and wrapper dir into a Windows env that has only Path and no nodejs entry', () => {
+  // On Windows, GUI-launched daemons inherit process.env with 'Path' (not
+  // 'PATH') and the nodejs install directory is often absent from the
+  // search path (desktop shortcut / Electron launcher bypasses shell PATH).
+  const windowsBase: NodeJS.ProcessEnv = {
+    Path: 'C:\\Windows\\System32;C:\\Windows',
+    TEMP: 'C:\\Users\\User\\AppData\\Local\\Temp',
+  };
+  const launch = { childPathPrepend: ['C:\\Users\\User\\AppData\\Roaming\\npm'] };
+
+  const env = applyAgentLaunchEnv(windowsBase, launch, 'C:\\Program Files\\nodejs');
+
+  // Original 'Path' key must be updated in-place — no competing 'PATH' key.
+  assert.ok('Path' in env, 'original Path key must be preserved');
+  assert.equal(env.PATH, undefined, 'no spurious uppercase PATH key must be created');
+
+  // Windows PATH delimiter is ';'.
+  const parts = (env.Path as string).split(';');
+
+  // Node binary directory must come first.
+  assert.equal(parts[0], 'C:\\Program Files\\nodejs', 'Node dir must be first in Path');
+  // Agent wrapper directory must follow immediately after.
+  assert.equal(parts[1], 'C:\\Users\\User\\AppData\\Roaming\\npm', 'wrapper dir must follow Node dir');
+  // Original system entries must be fully preserved.
+  assert.ok(parts.includes('C:\\Windows\\System32'), 'System32 must be retained');
+  assert.ok(parts.includes('C:\\Windows'), 'Windows dir must be retained');
+  // No empty entries from splitting.
+  assert.ok(parts.every((p: string) => p.length > 0), 'no empty path entries allowed');
 });
 
 fsTest('resolveAgentLaunch selects nvm-installed codex under a minimal PATH and prepends its dirname', () => {


### PR DESCRIPTION
## Why

Every message sent to the Copilot chat agent on Windows failed immediately
with:

  agent exited with code 1 '"node"'
  '"node"' is not recognized as an internal or external command,
  operable program or batch file.

Two independent root causes were found:

1. **Node binary directory missing from child PATH.** `pnpm tools-dev`
   launches the daemon using a full path to `node.exe` (e.g.
   `C:\Program Files\nodejs\node.exe`) without guaranteeing that directory
   is in `process.env.PATH`. The daemon wraps `copilot.cmd` inside
   `cmd.exe /d /s /c "..."` via `createCommandInvocation`. The npm shim
   inside `copilot.cmd` then calls `"node" npm-loader.js ...` by bare name,
   which cmd.exe cannot resolve when the nodejs directory is absent from
   PATH — producing the error above.

2. **Windows stdin broken-pipe error not swallowed.** On Unix, writing to
   a child's stdin after the child has closed its read end raises
   `err.code === 'EPIPE'`, which was already swallowed. On Windows the
   libuv equivalent is `err.code === 'EOF'` / `err.message === 'write EOF'`
   (UV_EOF). The original guard only covered `EPIPE`, so on Windows this
   error was forwarded to the frontend as `AGENT_EXECUTION_FAILED` even
   though the real failure was already being reported through stderr and
   the exit handler.

## What users will see

Sending a message to the Copilot agent cli on Windwos no longer shows an immediate
"agent exited with code 1" error banner. The Copilot CLI starts normally
and returns an AI response.

## Surface area

- [x] **Default behavior change** — `createAgentRuntimeEnv` now prepends
  `path.dirname(nodeBin)` to the child's PATH when that directory is not
  already present. On systems where the nodejs directory is already on PATH
  this is a no-op.
- [ ] **UI**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **None**

## Screenshots

<img width="643" height="850" alt="image" src="https://github.com/user-attachments/assets/8364633a-6e8f-438f-8076-90fb9612266e" />

<img width="633" height="1379" alt="image" src="https://github.com/user-attachments/assets/907b4ab9-0152-4f4c-a45f-beecd71a3b31" />


## Bug fix verification

- Before patch: sent any message to Copilot → confirmed
   `stdin: write EOF`, exit code 1.
- Applied patch, rebuilt daemon
  (`pnpm --filter @open-design/daemon build`), restarted
  `pnpm tools-dev run web --daemon-port 3987 --web-port 10656`.
- After patch: sent the same message → Copilot responded normally,
  error banner gone.

## Validation

```
pnpm --filter @open-design/daemon build          # tsc exits 0, no errors
pnpm tools-dev run web --daemon-port 3987 --web-port 10656
# manual chat message to Copilot agent → response received, no error banner
```