### PR TITLE
Follow up #1535: test preview zoom pass-through

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -480,7 +480,9 @@ export function effectivePreviewScale(
   const availableWidth = Math.max(1, canvasSize.width - canvasPadding);
   const availableHeight = Math.max(1, canvasSize.height - canvasPadding);
   const fitScale = Math.min(1, availableWidth / preset.width, availableHeight / preset.height);
-  return Math.min(previewScale, fitScale);
+  // Allow user to zoom beyond the fit-to-canvas scale for detailed inspection
+  // Only apply fitScale as a minimum when user zoom is below 100%
+  return previewScale >= 1 ? previewScale : Math.min(previewScale, fitScale);
 }
 
 function previewScaleShellStyle(

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -473,16 +473,9 @@ export function effectivePreviewScale(
   previewScale: number,
   canvasSize?: PreviewCanvasSize,
 ) {
-  if (viewport === 'desktop') return previewScale;
-  const preset = PREVIEW_VIEWPORT_PRESETS.find((item) => item.id === viewport);
-  if (!preset?.width || !preset.height || !canvasSize?.width || !canvasSize.height) return previewScale;
-  const canvasPadding = 48;
-  const availableWidth = Math.max(1, canvasSize.width - canvasPadding);
-  const availableHeight = Math.max(1, canvasSize.height - canvasPadding);
-  const fitScale = Math.min(1, availableWidth / preset.width, availableHeight / preset.height);
-  // Allow user to zoom beyond the fit-to-canvas scale for detailed inspection
-  // Only apply fitScale as a minimum when user zoom is below 100%
-  return previewScale >= 1 ? previewScale : Math.min(previewScale, fitScale);
+  void viewport;
+  void canvasSize;
+  return previewScale;
 }
 
 function previewScaleShellStyle(

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -71,9 +71,10 @@ describe('FileViewer preview scale', () => {
     expect(effectivePreviewScale('desktop', 1.5, { width: 320, height: 480 })).toBe(1.5);
   });
 
-  it('clamps mobile and tablet overlay scale to the iframe auto-fit scale', () => {
-    expect(effectivePreviewScale('mobile', 1, { width: 390, height: 844 })).toBeLessThan(1);
-    expect(effectivePreviewScale('tablet', 1.25, { width: 820, height: 700 })).toBeLessThan(1);
+  it('uses the requested zoom for mobile and tablet preview overlays', () => {
+    expect(effectivePreviewScale('mobile', 0.75, { width: 390, height: 844 })).toBe(0.75);
+    expect(effectivePreviewScale('mobile', 1.5, { width: 390, height: 844 })).toBe(1.5);
+    expect(effectivePreviewScale('tablet', 1.25, { width: 820, height: 700 })).toBe(1.25);
   });
 });
 


### PR DESCRIPTION
## Why

Follow-up for #1535. I am opening this because the preview zoom branch changes mobile/tablet zoom semantics, and the existing regression coverage still described the old clamp behavior. The pain addressed is reviewer confidence: the tests now assert that requested zoom values pass through for small preview viewports.

## What users will see

Users will be able to use the requested preview zoom on mobile and tablet overlays instead of being forced back to the old fit-scale clamp.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached; the behavioral proof is covered by the focused FileViewer unit regression.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/FileViewer.test.tsx`
- Did the test go red on `main` and green on this branch? Not checked against `main`; this is a follow-up to the active #1535 branch to align its test expectations with its intended behavior.

## Validation

- `corepack pnpm install --frozen-lockfile` (completed with the existing local packaged `od` bin warning)
- `corepack pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/FileViewer.test.tsx`
- `corepack pnpm --filter @open-design/web typecheck`
- `corepack pnpm guard`
