### PR TITLE
Follow up #1989: cover Windows agent PATH setup

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1395,9 +1395,17 @@ export function createAgentRuntimeEnv(
   const nodeBinDir = path.dirname(nodeBin);
   if (nodeBinDir) {
     const existingPath = typeof env.PATH === 'string' ? env.PATH : '';
-    const parts = existingPath.split(path.delimiter).filter((p) => p.length > 0);
-    if (!parts.includes(nodeBinDir)) {
-      env.PATH = [nodeBinDir, ...parts].join(path.delimiter);
+    const seenPathParts = new Set();
+    const parts = [nodeBinDir, ...existingPath.split(path.delimiter)]
+      .filter((p) => p.length > 0)
+      .filter((p) => {
+        const key = process.platform === 'win32' ? p.toLowerCase() : p;
+        if (seenPathParts.has(key)) return false;
+        seenPathParts.add(key);
+        return true;
+      });
+    if (parts.length > 0) {
+      env.PATH = parts.join(path.delimiter);
     }
   }
 
@@ -1408,6 +1416,10 @@ export function createAgentRuntimeEnv(
   }
 
   return env;
+}
+
+function isBenignStdinClosedError(err): boolean {
+  return err?.code === 'EPIPE' || err?.code === 'EOF' || err?.message === 'write EOF';
 }
 
 export function createAgentRuntimeToolPrompt(
@@ -8802,7 +8814,7 @@ export async function startServer({
           // the same condition via UV_EOF. Both mean the child exited before
           // reading stdin — the process exit/close handlers already route
           // the underlying failure to SSE via stderr, so swallow these here.
-          if (err.code !== 'EPIPE' && err.code !== 'EOF' && err.message !== 'write EOF') {
+          if (!isBenignStdinClosedError(err)) {
             send(
               'error',
               createSseErrorPayload(
@@ -9368,7 +9380,7 @@ export async function startServer({
           // Swallow EPIPE here for the same reason as the listener above —
           // a fast-exiting child has already routed its failure through
           // stderr / exit handlers.
-          if (err && err.code !== 'EPIPE') throw err;
+          if (!isBenignStdinClosedError(err)) throw err;
         }
         run.stdinOpen = true;
       } else {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1382,11 +1382,24 @@ export function createAgentRuntimeEnv(
   toolTokenGrant: { token?: string } | null = null,
   nodeBin: string = process.execPath,
 ): NodeJS.ProcessEnv {
-  const env = {
+  const env: NodeJS.ProcessEnv = {
     ...baseEnv,
     OD_DAEMON_URL: daemonUrl,
     OD_NODE_BIN: nodeBin,
   };
+
+  // Ensure the node binary directory is on PATH so agent sub-processes —
+  // in particular npm .cmd shims on Windows that run `"node" script.js` —
+  // can find the same node binary that runs the daemon even when the daemon
+  // was launched with a full path to node and the directory was not on PATH.
+  const nodeBinDir = path.dirname(nodeBin);
+  if (nodeBinDir) {
+    const existingPath = typeof env.PATH === 'string' ? env.PATH : '';
+    const parts = existingPath.split(path.delimiter).filter((p) => p.length > 0);
+    if (!parts.includes(nodeBinDir)) {
+      env.PATH = [nodeBinDir, ...parts].join(path.delimiter);
+    }
+  }
 
   if (toolTokenGrant?.token) {
     env.OD_TOOL_TOKEN = toolTokenGrant.token;
@@ -8784,7 +8797,12 @@ export async function startServer({
         // crash the daemon. Swallow it — the regular exit/close handlers
         // below already route the underlying failure to SSE via stderr.
         child.stdin.on('error', (err) => {
-          if (err.code !== 'EPIPE') {
+          // EPIPE = Unix broken-pipe when child closes its stdin read end
+          // early. 'write EOF' (err.code 'EOF') = Windows equivalent of
+          // the same condition via UV_EOF. Both mean the child exited before
+          // reading stdin — the process exit/close handlers already route
+          // the underlying failure to SSE via stderr, so swallow these here.
+          if (err.code !== 'EPIPE' && err.code !== 'EOF' && err.message !== 'write EOF') {
             send(
               'error',
               createSseErrorPayload(

--- a/apps/daemon/tests/agent-runtime-env.test.ts
+++ b/apps/daemon/tests/agent-runtime-env.test.ts
@@ -1,22 +1,40 @@
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import { createAgentRuntimeEnv, createAgentRuntimeToolPrompt } from '../src/server.js';
 
 describe('agent runtime tool environment', () => {
   it('injects daemon URL and run-scoped tool token into agent sessions', () => {
+    const nodeBin = path.join('opt', 'open-design', 'bin', 'node');
+    const nodeBinDir = path.dirname(nodeBin);
     const env = createAgentRuntimeEnv(
       { PATH: '/bin', OD_TOOL_TOKEN: 'stale-token' },
       'http://127.0.0.1:7456',
       { token: 'fresh-token' },
-      '/opt/open-design/bin/node',
+      nodeBin,
     );
 
     expect(env).toMatchObject({
-      PATH: '/bin',
+      PATH: [nodeBinDir, '/bin'].join(path.delimiter),
       OD_DAEMON_URL: 'http://127.0.0.1:7456',
-      OD_NODE_BIN: '/opt/open-design/bin/node',
+      OD_NODE_BIN: nodeBin,
       OD_TOOL_TOKEN: 'fresh-token',
     });
+  });
+
+  it('prepends and dedupes the daemon node binary directory on PATH', () => {
+    const nodeBin = path.join('opt', 'open-design', 'bin', 'node');
+    const nodeBinDir = path.dirname(nodeBin);
+    const env = createAgentRuntimeEnv(
+      {
+        PATH: ['/usr/bin', nodeBinDir, '/bin', nodeBinDir].join(path.delimiter),
+      },
+      'http://127.0.0.1:7456',
+      null,
+      nodeBin,
+    );
+
+    expect(env.PATH?.split(path.delimiter)).toEqual([nodeBinDir, '/usr/bin', '/bin']);
   });
 
   it('does not leak stale inherited tool tokens when no run token was minted', () => {


### PR DESCRIPTION
## Why

Follow-up for #1989. I am opening this because the Windows Copilot CLI subprocess fix needs a small proof that the daemon prepends the running Node binary directory without duplicating PATH entries. The pain addressed is Windows GUI launches where child agent subprocesses inherit a minimal or mismatched PATH and cannot find the expected Node runtime cleanly.

## What users will see

Windows users running agent-backed flows from the desktop app should have more reliable child-agent process startup, with closed stdin handled as a benign subprocess shutdown condition where appropriate.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; daemon runtime behavior only.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/agent-runtime-env.test.ts`
- Did the test go red on `main` and green on this branch? Not checked against `main`; this is a focused follow-up to the active #1989 branch, adding daemon coverage for the intended PATH invariant.
- Native Windows Copilot smoke: not run locally.

## Validation

- `corepack pnpm install --frozen-lockfile` (completed with the existing local packaged `od` bin warning)
- `corepack pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/agent-runtime-env.test.ts`
- `corepack pnpm --filter @open-design/daemon typecheck`
- `corepack pnpm guard`
