### PR TITLE
Replace #1614: open WSL folders with Explorer

### DIFF
--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -1,13 +1,18 @@
+import { execFile } from "node:child_process";
 import { createHmac, randomBytes } from "node:crypto";
 import { mkdir, writeFile, realpath, stat } from "node:fs/promises";
+import { release } from "node:os";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 
 import { BrowserWindow, dialog, ipcMain, shell } from "electron";
 import type { DesktopExportPdfInput, DesktopExportPdfResult } from "@open-design/sidecar-proto";
 
 import { createElectronPdfTarget, exportPdfFromHtml, savePrintReadyDocumentAsPdf } from "./pdf-export.js";
 import type { PrintReadyPdfOptions } from "./pdf-export.js";
+
+const execFileAsync = promisify(execFile);
 
 /**
  * Result of validating a candidate path before exposing it to a
@@ -853,6 +858,18 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
     const validated = await validateExistingDirectory(resolved.context.resolvedDir);
     if (!validated.ok) return `open-path: ${validated.reason}`;
     try {
+      if (release().toLowerCase().includes("microsoft")) {
+        try {
+          const { stdout } = await execFileAsync("wslpath", ["-w", validated.resolved]);
+          const windowsPath = stdout.trim();
+          if (windowsPath.length > 0) {
+            await execFileAsync("explorer.exe", [windowsPath]);
+            return "";
+          }
+        } catch {
+          // Fall through to Electron's default opener for non-standard WSL setups.
+        }
+      }
       return await shell.openPath(validated.resolved);
     } catch (err) {
       return err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Why

Replacement follow-up for #1614. I am opening this because the original PR is conflicted, but the WSL folder-opening behavior is small and salvageable on current `main`. The pain addressed is WSL users hitting Electron's Linux opener instead of Windows Explorer when opening validated project folders.

## What users will see

When running inside WSL, opening a project folder should hand the resolved folder path to `explorer.exe` using `wslpath -w`, while non-WSL environments keep the existing Electron `shell.openPath` behavior.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached; this is native shell-launch behavior. I did not have a WSL desktop session available for manual verification.

## Bug fix verification

- Test path that reproduces the bug: not added; the change is a narrow native integration path around Electron shell opening.
- Did the test go red on `main` and green on this branch? No.
- Manual WSL verification: not run locally; this was validated by desktop typecheck/build only.

## Validation

- `corepack pnpm install --frozen-lockfile` (completed with the existing local packaged `od` bin warning)
- `corepack pnpm --filter @open-design/desktop typecheck`
- `corepack pnpm --filter @open-design/desktop build`
- `corepack pnpm guard`
