### PR TITLE
Follow up #1617: use official version-manager links

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -15,7 +15,7 @@ Run the full product locally.
 
 The daemon scans your **`PATH`** (plus common user toolchain directories). If you install a CLI with **`npm install -g`** or **Homebrew** and Open Design still shows it as *not installed*, the GUI may be starting with a minimal `PATH` that does not include your global npm or Homebrew `bin` directory (common on macOS when the app is not launched from a full login shell). Ensure the executable’s directory is on `PATH` for the process that runs the daemon, then use **Rescan** in **Settings → Execution & model**.
 
-[`nvm`](https://www.nvmnode.com) / [`fnm`](https://www.fnmnode.com) are optional convenience tools, not required project setup. If you use one, install/select Node 24 before running pnpm:
+[`nvm`](https://github.com/nvm-sh/nvm) / [`fnm`](https://github.com/Schniz/fnm) are optional convenience tools, not required project setup. If you use one, install/select Node 24 before running pnpm:
 
 ```bash
 # nvm

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -15,7 +15,7 @@ Run the full product locally.
 
 The daemon scans your **`PATH`** (plus common user toolchain directories). If you install a CLI with **`npm install -g`** or **Homebrew** and Open Design still shows it as *not installed*, the GUI may be starting with a minimal `PATH` that does not include your global npm or Homebrew `bin` directory (common on macOS when the app is not launched from a full login shell). Ensure the executable’s directory is on `PATH` for the process that runs the daemon, then use **Rescan** in **Settings → Execution & model**.
 
-`nvm` / `fnm` are optional convenience tools, not required project setup. If you use one, install/select Node 24 before running pnpm:
+[`nvm`](https://www.nvmnode.com) / [`fnm`](https://www.fnmnode.com) are optional convenience tools, not required project setup. If you use one, install/select Node 24 before running pnpm:
 
 ```bash
 # nvm


### PR DESCRIPTION
## Why

Follow-up for #1617. I am opening this because the Quickstart's optional Node version-manager links should point to the official upstream project roots rather than lookalike domains. The pain addressed is contributor onboarding trust: new contributors should land on the canonical `nvm` and `fnm` projects.

## What users will see

Quickstart readers who click `nvm` or `fnm` will land on the official GitHub repositories for those tools.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; docs-only link target correction.

## Bug fix verification

- Test path that reproduces the bug: not applicable; link targets were verified by inspecting `QUICKSTART.md`.
- Did the test go red on `main` and green on this branch? No; docs-only correction.

## Validation

- `corepack pnpm install --frozen-lockfile` (completed with the existing local packaged `od` bin warning)
- `rg -n "nvm|fnm" QUICKSTART.md`
- `corepack pnpm guard`
- `corepack pnpm typecheck`
