### PR TITLE
Pin daemon data dir in agent runtime env

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1384,6 +1384,7 @@ export function createAgentRuntimeEnv(
 ): NodeJS.ProcessEnv {
   const env = {
     ...baseEnv,
+    OD_DATA_DIR: RUNTIME_DATA_DIR,
     OD_DAEMON_URL: daemonUrl,
     OD_NODE_BIN: nodeBin,
   };

--- a/apps/daemon/tests/agent-runtime-env.test.ts
+++ b/apps/daemon/tests/agent-runtime-env.test.ts
@@ -32,6 +32,17 @@ describe('agent runtime tool environment', () => {
     expect(env.OD_TOOL_TOKEN).toBeUndefined();
   });
 
+  it('pins the daemon runtime data dir into agent sessions', () => {
+    const env = createAgentRuntimeEnv(
+      { PATH: '/bin' },
+      'http://127.0.0.1:7456',
+      null,
+      '/opt/open-design/bin/node',
+    );
+
+    expect(env.OD_DATA_DIR).toBe(process.env.OD_DATA_DIR);
+  });
+
   it('describes daemon URL and token availability without exposing the token', () => {
     const prompt = createAgentRuntimeToolPrompt('http://127.0.0.1:7456', {
       token: 'secret-run-token',


### PR DESCRIPTION
## Summary
- Pin OD_DATA_DIR in createAgentRuntimeEnv to the daemon's resolved runtime data dir
- Add regression coverage for agent sessions launched without inherited OD_DATA_DIR

## Tests
- pnpm exec vitest run -c vitest.config.ts tests/agent-runtime-env.test.ts
- pnpm --filter @open-design/daemon typecheck
- git diff --check

Fixes #1537