### PR TITLE
fix(daemon): fail disallowed connector tool selections

### DIFF
--- a/apps/daemon/src/json-event-stream.ts
+++ b/apps/daemon/src/json-event-stream.ts
@@ -45,31 +45,41 @@ function stringifyContent(value: unknown): string {
   }
 }
 
-function parseJsonObjectFromContent(value: string): JsonObject | null {
+function parseJsonObjectsFromContent(value: string): JsonObject[] {
   const trimmed = value.trim();
-  if (!trimmed) return null;
+  if (!trimmed) return [];
   const direct = safeParseJson(trimmed);
-  if (isRecord(direct)) return direct;
+  if (isRecord(direct)) return [direct];
+  const objects: JsonObject[] = [];
   for (const line of trimmed.split(/\r?\n/u)) {
     const parsedLine = safeParseJson(line.trim());
-    if (isRecord(parsedLine)) return parsedLine;
+    if (isRecord(parsedLine)) objects.push(parsedLine);
   }
-  return null;
+  return objects;
 }
 
 function extractConnectorApiError(value: JsonObject): JsonObject | null {
   if (isRecord(value.error)) {
     if (typeof value.error.code === 'string') return value.error;
-    if (isRecord(value.error.data) && isRecord(value.error.data.error)) return value.error.data.error;
+    if (isRecord(value.error.data) && isRecord(value.error.data.error)) {
+      const wrappedError = value.error.data.error;
+      if (typeof wrappedError.code === 'string') return wrappedError;
+    }
   }
   return null;
 }
 
 function connectorToolSelectionErrorMessage(content: string): string | null {
-  const parsed = parseJsonObjectFromContent(content);
-  if (!parsed) return null;
-  const error = extractConnectorApiError(parsed);
-  if (!error || error.code !== 'CONNECTOR_TOOL_NOT_FOUND') return null;
+  if (!content.includes('CONNECTOR_TOOL_NOT_FOUND')) return null;
+  let error: JsonObject | null = null;
+  for (const parsed of parseJsonObjectsFromContent(content)) {
+    const parsedError = extractConnectorApiError(parsed);
+    if (parsedError?.code === 'CONNECTOR_TOOL_NOT_FOUND') {
+      error = parsedError;
+      break;
+    }
+  }
+  if (!error) return null;
   const details = isRecord(error.details) ? error.details : {};
   const connectorId = typeof details.connectorId === 'string' && details.connectorId
     ? details.connectorId

--- a/apps/daemon/src/json-event-stream.ts
+++ b/apps/daemon/src/json-event-stream.ts
@@ -45,6 +45,44 @@ function stringifyContent(value: unknown): string {
   }
 }
 
+function parseJsonObjectFromContent(value: string): JsonObject | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const direct = safeParseJson(trimmed);
+  if (isRecord(direct)) return direct;
+  for (const line of trimmed.split(/\r?\n/u)) {
+    const parsedLine = safeParseJson(line.trim());
+    if (isRecord(parsedLine)) return parsedLine;
+  }
+  return null;
+}
+
+function extractConnectorApiError(value: JsonObject): JsonObject | null {
+  if (isRecord(value.error)) {
+    if (typeof value.error.code === 'string') return value.error;
+    if (isRecord(value.error.data) && isRecord(value.error.data.error)) return value.error.data.error;
+  }
+  return null;
+}
+
+function connectorToolSelectionErrorMessage(content: string): string | null {
+  const parsed = parseJsonObjectFromContent(content);
+  if (!parsed) return null;
+  const error = extractConnectorApiError(parsed);
+  if (!error || error.code !== 'CONNECTOR_TOOL_NOT_FOUND') return null;
+  const details = isRecord(error.details) ? error.details : {};
+  const connectorId = typeof details.connectorId === 'string' && details.connectorId
+    ? details.connectorId
+    : undefined;
+  const toolName = typeof details.toolName === 'string' && details.toolName
+    ? details.toolName
+    : 'the requested connector tool';
+  const target = connectorId
+    ? `Connector tool ${toolName} is not allowed for connector ${connectorId}.`
+    : `Connector tool ${toolName} is not allowed.`;
+  return `${target} Re-list the connector catalog and choose one of the currently allowed read-only tools.`;
+}
+
 function extractErrorMessage(value: unknown, fallback: string): string {
   if (typeof value === 'string') {
     const parsed = safeParseJson(value);
@@ -346,12 +384,18 @@ if (obj.type === 'error') {
           },
         });
       }
+      const content = stringifyContent(item.aggregated_output ?? '');
       onEvent({
         type: 'tool_result',
         toolUseId: item.id,
-        content: stringifyContent(item.aggregated_output ?? ''),
+        content,
         isError: typeof item.exit_code === 'number' ? item.exit_code !== 0 : item.status === 'failed',
       });
+      const connectorToolError = connectorToolSelectionErrorMessage(content);
+      if (connectorToolError && !state.codexErrorEmitted) {
+        state.codexErrorEmitted = true;
+        onEvent({ type: 'error', message: connectorToolError });
+      }
       return true;
     }
   }

--- a/apps/daemon/tests/json-event-stream.test.ts
+++ b/apps/daemon/tests/json-event-stream.test.ts
@@ -449,6 +449,70 @@ test('codex json stream emits command execution tool events', () => {
   ]);
 });
 
+test('codex json stream surfaces disallowed connector tool selections as terminal errors', () => {
+  const { events, handler } = collectEvents('codex');
+  const connectorError = JSON.stringify({
+    ok: false,
+    status: 404,
+    error: {
+      code: 'CONNECTOR_TOOL_NOT_FOUND',
+      message: 'connector tool is not allowed',
+      details: {
+        connectorId: 'github',
+        toolName: 'github.github_list_notifications',
+      },
+    },
+  });
+
+  handler.feed(
+    JSON.stringify({
+      type: 'item.started',
+      item: {
+        id: 'item-connector',
+        type: 'command_execution',
+        command: 'od tools connectors execute --connector github --tool github.github_list_notifications --input .daily-digest-tmp/notifications.json',
+        aggregated_output: '',
+        exit_code: null,
+        status: 'in_progress',
+      },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'item.completed',
+      item: {
+        id: 'item-connector',
+        type: 'command_execution',
+        command: 'od tools connectors execute --connector github --tool github.github_list_notifications --input .daily-digest-tmp/notifications.json',
+        aggregated_output: `${connectorError}\n`,
+        exit_code: 1,
+        status: 'failed',
+      },
+    }) +
+    '\n',
+  );
+
+  assert.deepEqual(events, [
+    {
+      type: 'tool_use',
+      id: 'item-connector',
+      name: 'Bash',
+      input: {
+        command: 'od tools connectors execute --connector github --tool github.github_list_notifications --input .daily-digest-tmp/notifications.json',
+      },
+    },
+    {
+      type: 'tool_result',
+      toolUseId: 'item-connector',
+      content: `${connectorError}\n`,
+      isError: true,
+    },
+    {
+      type: 'error',
+      message: 'Connector tool github.github_list_notifications is not allowed for connector github. Re-list the connector catalog and choose one of the currently allowed read-only tools.',
+    },
+  ]);
+});
+
 test('unhandled structured events fall back to raw', () => {
   const { events, handler } = collectEvents('codex');
 

--- a/apps/daemon/tests/json-event-stream.test.ts
+++ b/apps/daemon/tests/json-event-stream.test.ts
@@ -513,6 +513,140 @@ test('codex json stream surfaces disallowed connector tool selections as termina
   ]);
 });
 
+test('codex json stream finds connector tool errors after earlier noise json output', () => {
+  const { events, handler } = collectEvents('codex');
+  const noiseLine = JSON.stringify({
+    event: 'running',
+    message: 'starting connector call',
+  });
+  const connectorError = JSON.stringify({
+    ok: false,
+    status: 404,
+    error: {
+      code: 'CONNECTOR_TOOL_NOT_FOUND',
+      message: 'connector tool is not allowed',
+      details: {
+        connectorId: 'github',
+        toolName: 'github.github_list_notifications',
+      },
+    },
+  });
+
+  handler.feed(
+    JSON.stringify({
+      type: 'item.started',
+      item: {
+        id: 'item-connector-noise',
+        type: 'command_execution',
+        command: 'od tools connectors execute --connector github --tool github.github_list_notifications --input .daily-digest-tmp/notifications.json',
+        aggregated_output: '',
+        exit_code: null,
+        status: 'in_progress',
+      },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'item.completed',
+      item: {
+        id: 'item-connector-noise',
+        type: 'command_execution',
+        command: 'od tools connectors execute --connector github --tool github.github_list_notifications --input .daily-digest-tmp/notifications.json',
+        aggregated_output: `${noiseLine}\n${connectorError}\n`,
+        exit_code: 1,
+        status: 'failed',
+      },
+    }) +
+    '\n',
+  );
+
+  assert.deepEqual(events, [
+    {
+      type: 'tool_use',
+      id: 'item-connector-noise',
+      name: 'Bash',
+      input: {
+        command: 'od tools connectors execute --connector github --tool github.github_list_notifications --input .daily-digest-tmp/notifications.json',
+      },
+    },
+    {
+      type: 'tool_result',
+      toolUseId: 'item-connector-noise',
+      content: `${noiseLine}\n${connectorError}\n`,
+      isError: true,
+    },
+    {
+      type: 'error',
+      message: 'Connector tool github.github_list_notifications is not allowed for connector github. Re-list the connector catalog and choose one of the currently allowed read-only tools.',
+    },
+  ]);
+});
+
+test('codex json stream surfaces wrapped connector tool errors as terminal errors', () => {
+  const { events, handler } = collectEvents('codex');
+  const connectorError = JSON.stringify({
+    error: {
+      data: {
+        error: {
+          code: 'CONNECTOR_TOOL_NOT_FOUND',
+          message: 'connector tool is not allowed',
+          details: {
+            connectorId: 'github',
+            toolName: 'github.github_list_notifications',
+          },
+        },
+      },
+    },
+  });
+
+  handler.feed(
+    JSON.stringify({
+      type: 'item.started',
+      item: {
+        id: 'item-connector-wrapped',
+        type: 'command_execution',
+        command: 'od tools connectors execute --connector github --tool github.github_list_notifications --input .daily-digest-tmp/notifications.json',
+        aggregated_output: '',
+        exit_code: null,
+        status: 'in_progress',
+      },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'item.completed',
+      item: {
+        id: 'item-connector-wrapped',
+        type: 'command_execution',
+        command: 'od tools connectors execute --connector github --tool github.github_list_notifications --input .daily-digest-tmp/notifications.json',
+        aggregated_output: `${connectorError}\n`,
+        exit_code: 1,
+        status: 'failed',
+      },
+    }) +
+    '\n',
+  );
+
+  assert.deepEqual(events, [
+    {
+      type: 'tool_use',
+      id: 'item-connector-wrapped',
+      name: 'Bash',
+      input: {
+        command: 'od tools connectors execute --connector github --tool github.github_list_notifications --input .daily-digest-tmp/notifications.json',
+      },
+    },
+    {
+      type: 'tool_result',
+      toolUseId: 'item-connector-wrapped',
+      content: `${connectorError}\n`,
+      isError: true,
+    },
+    {
+      type: 'error',
+      message: 'Connector tool github.github_list_notifications is not allowed for connector github. Re-list the connector catalog and choose one of the currently allowed read-only tools.',
+    },
+  ]);
+});
+
 test('unhandled structured events fall back to raw', () => {
   const { events, handler } = collectEvents('codex');
 


### PR DESCRIPTION
Fixes #1497

## Why

Orbit daily digest runs can hit a bad connector-tool selection when Codex tries a tool that is not allowed by the current connected account. In the reported packaged run, the daemon had already received a structured `CONNECTOR_TOOL_NOT_FOUND` result, but the run stayed idle until the 600s inactivity watchdog fired.

This PR makes that connector selection failure visible to the daemon as an agent stream error, so the run fails with the actionable connector diagnostic instead of burning the full stall timeout.

## What users will see

Orbit/Codex runs that select a connector tool outside the current allowed read-only catalog now fail promptly with a connector tool-selection message naming the connector and tool. Users no longer wait 10 minutes for a generic stalled-agent error in this case.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No UI surface changed.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/json-event-stream.test.ts`
- Did the test go red on `main` and green on this branch? yes — the new Codex connector-tool regression test failed before the parser change because only `tool_result` was emitted; it passes after emitting the connector selection error.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/json-event-stream.test.ts` — passed, 22 tests.
- `pnpm --filter @open-design/daemon typecheck` — passed.
- `pnpm guard` — passed.
- Baseline note: an accidental full `pnpm --filter @open-design/daemon test -- json-event-stream` run executed the full daemon suite under local Node v26.0.0 and hit unrelated existing timeouts in `tests/finalize-route-abort.test.ts` and `tests/plugins-headless-run.test.ts`; the focused parser test passed in that run as well.
