### PR TITLE
fix(mcp): support no-auth local HTTP servers

### DIFF
--- a/apps/daemon/src/mcp-config.ts
+++ b/apps/daemon/src/mcp-config.ts
@@ -27,6 +27,7 @@ import path from 'node:path';
 // minimal mirror in the daemon keeps the existing module-resolution shape
 // for the rest of the codebase intact. Both sides MUST stay in sync.
 export type McpTransport = 'stdio' | 'sse' | 'http';
+export type McpAuthMode = 'none' | 'oauth';
 
 export interface McpServerConfig {
   id: string;
@@ -34,6 +35,7 @@ export interface McpServerConfig {
   templateId?: string;
   transport: McpTransport;
   enabled: boolean;
+  authMode?: McpAuthMode;
   command?: string;
   args?: string[];
   env?: Record<string, string>;
@@ -71,6 +73,7 @@ export interface McpTemplate {
   label: string;
   description: string;
   transport: McpTransport;
+  authMode?: McpAuthMode;
   category: McpTemplateCategory;
   homepage?: string;
   // One-liner prompt shown in the UI so the user has a concrete starting
@@ -88,6 +91,7 @@ const VALID_TRANSPORTS: ReadonlySet<McpTransport> = new Set([
   'sse',
   'http',
 ]);
+const VALID_AUTH_MODES: ReadonlySet<McpAuthMode> = new Set(['none', 'oauth']);
 
 // Slug rule for server ids. The id flows into agent-facing config files
 // (Claude Code's `mcpServers` map keys, ACP `name`) and in some cases into
@@ -125,6 +129,41 @@ function sanitizeStringArray(raw: unknown): string[] | undefined {
   if (!Array.isArray(raw)) return undefined;
   const out = raw.filter((v): v is string => typeof v === 'string');
   return out.length > 0 ? out : undefined;
+}
+
+function normalizeHost(hostname: string): string {
+  return hostname
+    .replace(/^\[|\]$/g, '')
+    .toLowerCase()
+    .replace(/\.+$/g, '');
+}
+
+function isLoopbackHost(hostname: string): boolean {
+  const host = normalizeHost(hostname);
+  if (host === 'localhost' || host === '::1') return true;
+  if (/^127(?:\.\d{1,3}){3}$/.test(host)) return true;
+  const mapped = /^::ffff:(127(?:\.\d{1,3}){3})$/i.exec(host)?.[1];
+  return Boolean(mapped);
+}
+
+export function inferMcpAuthModeForUrl(rawUrl: string | undefined): McpAuthMode {
+  if (!rawUrl) return 'oauth';
+  try {
+    return isLoopbackHost(new URL(rawUrl).hostname) ? 'none' : 'oauth';
+  } catch {
+    return 'oauth';
+  }
+}
+
+function sanitizeMcpAuthMode(raw: unknown): McpAuthMode | undefined {
+  return typeof raw === 'string' && VALID_AUTH_MODES.has(raw as McpAuthMode)
+    ? (raw as McpAuthMode)
+    : undefined;
+}
+
+function effectiveMcpAuthMode(server: McpServerConfig): McpAuthMode {
+  if (server.transport !== 'http' && server.transport !== 'sse') return 'none';
+  return server.authMode ?? inferMcpAuthModeForUrl(server.url);
 }
 
 /**
@@ -170,6 +209,7 @@ export function sanitizeMcpServer(raw: unknown): McpServerConfig | null {
     }
     if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
     next.url = parsed.toString();
+    next.authMode = sanitizeMcpAuthMode(raw.authMode) ?? inferMcpAuthModeForUrl(next.url);
     const headers = sanitizeStringMap(raw.headers);
     if (headers) next.headers = headers;
   }
@@ -286,7 +326,10 @@ export function buildClaudeMcpJson(
         type: s.transport, // 'sse' | 'http'
         url: s.url,
       };
-      const headers = mergeAuthHeader(s.headers, tokens[s.id]);
+      const headers = mergeAuthHeader(
+        s.headers,
+        effectiveMcpAuthMode(s) === 'oauth' ? tokens[s.id] : undefined,
+      );
       if (headers && Object.keys(headers).length > 0) entry.headers = headers;
       out[s.id] = entry;
     }
@@ -375,6 +418,7 @@ export const MCP_TEMPLATES: McpTemplate[] = [
     description:
       'Image and video generation MCP from higgsfield.ai. Exposes Soul, Nano Banana, Flux, Kling, Veo, Seedance, and 25+ other models. Endpoint is streamable HTTP at /mcp; click "Connect" after saving — Open Design completes OAuth and stores the token server-side, so no terminal step is needed and the connection survives across chat turns and cloud deployments.',
     transport: 'http',
+    authMode: 'oauth',
     category: 'image-generation',
     homepage: 'https://higgsfield.ai/mcp?tab=openclaw',
     example:
@@ -481,6 +525,7 @@ export const MCP_TEMPLATES: McpTemplate[] = [
     description:
       'Hosted streamable-HTTP MCP wrapping Google Nano Banana for image generation, editing, virtual try-on and product placement. The endpoint is managed by AceDataCloud — no local install, just paste your platform API token as the Authorization header (acquire at platform.acedata.cloud). Complements Higgsfield by giving the agent virtual-try-on and "place product in scene" tools that the OpenClaw catalog does not expose directly.',
     transport: 'http',
+    authMode: 'none',
     category: 'image-generation',
     homepage: 'https://github.com/AceDataCloud/MCPNanoBanana',
     example:
@@ -502,6 +547,7 @@ export const MCP_TEMPLATES: McpTemplate[] = [
     description:
       'Hosted streamable-HTTP MCP wrapping ByteDance Seedream v3 / v4 / v4.5 / v5 (text-to-image) and SeedEdit v3 (image-to-image). Strongest free-form Chinese-prompt support of any image model in the picker, plus reproducible-seed control on v3. Use this when Higgsfield / Nano Banana misses the aesthetic you want.',
     transport: 'http',
+    authMode: 'none',
     category: 'image-generation',
     homepage: 'https://github.com/AceDataCloud/MCPSeedream',
     example:
@@ -749,6 +795,7 @@ export const MCP_TEMPLATES: McpTemplate[] = [
     description:
       'Companion to Figma-Context: where Framelink reads, figma-use *writes* — 90+ tools to create frames, text, components, variants, set layouts, render JSX into the canvas, export PNG/SVG, query nodes via XPath, lint for WCAG / auto-layout / hardcoded colors, and analyze design systems. Runs as a local HTTP MCP server on port 38451; no API key. Two prerequisites the user owns: (1) start Figma with remote debugging — macOS: `open -a Figma --args --remote-debugging-port=9222` (Figma 126+ needs `figma-use daemon start --pipe` instead), and (2) leave `npx figma-use mcp serve` running in a terminal. Then this template wires the daemon to that endpoint.',
     transport: 'http',
+    authMode: 'none',
     category: 'design-systems',
     homepage: 'https://github.com/dannote/figma-use',
     example:
@@ -962,6 +1009,7 @@ export const MCP_TEMPLATES: McpTemplate[] = [
     description:
       'Hosted MCP that converts Deckrun Markdown into pixel-perfect branded PDFs, narrated MP4 videos, and MP3 audio from one source. The free tier exposes `get_slide_format` + `generate_slide_deck` (PDF) with no API key required and no signup — just connect and go. Add a paid `DECKRUN_API_KEY` later for video / audio generation, themes, voices and async jobs.',
     transport: 'http',
+    authMode: 'none',
     category: 'publishing',
     homepage: 'https://agenticdecks.com',
     example:

--- a/apps/daemon/src/mcp-routes.ts
+++ b/apps/daemon/src/mcp-routes.ts
@@ -135,6 +135,11 @@ export function registerMcpRoutes(app: Express, ctx: RegisterMcpRoutesDeps) {
       if (!server.url) {
         return res.status(400).json({ error: 'server has no URL configured' });
       }
+      if (server.authMode === 'none') {
+        return res
+          .status(400)
+          .json({ error: 'server is configured for no managed OAuth' });
+      }
       const redirectUri = mcpOAuthCallbackUrl(req);
       console.log(
         `[mcp-oauth] start serverId=${serverId} url=${server.url} redirect=${redirectUri}`,

--- a/apps/daemon/tests/mcp-config.test.ts
+++ b/apps/daemon/tests/mcp-config.test.ts
@@ -73,6 +73,26 @@ describe('mcp-config storage', () => {
     expect(written.servers[0]?.headers?.Authorization).toBe('Bearer abc');
   });
 
+  it('defaults loopback HTTP servers to no managed OAuth', () => {
+    const out = sanitizeMcpServer({
+      id: 'figma-use',
+      transport: 'http',
+      enabled: true,
+      url: 'http://localhost:38451/mcp',
+    });
+    expect(out?.authMode).toBe('none');
+  });
+
+  it('defaults remote HTTP servers to managed OAuth for backward compatibility', () => {
+    const out = sanitizeMcpServer({
+      id: 'higgsfield',
+      transport: 'http',
+      enabled: true,
+      url: 'https://mcp.higgsfield.ai/mcp',
+    });
+    expect(out?.authMode).toBe('oauth');
+  });
+
   it('drops invalid entries silently', async () => {
     const written = await writeMcpConfig(dataDir, {
       servers: [
@@ -208,6 +228,22 @@ describe('buildClaudeMcpJson', () => {
     expect(out.mcpServers.higgsfield?.headers).toEqual({
       Authorization: 'Bearer access-tok-xyz',
     });
+  });
+
+  it('does not inject a stored OAuth token into no-auth HTTP servers', () => {
+    const out = buildClaudeMcpJson(
+      [
+        {
+          id: 'figma-use',
+          transport: 'http',
+          enabled: true,
+          authMode: 'none',
+          url: 'http://localhost:38451/mcp',
+        },
+      ],
+      { 'figma-use': 'stale-token' },
+    ) as { mcpServers: Record<string, Record<string, unknown>> };
+    expect(out.mcpServers['figma-use']?.headers).toBeUndefined();
   });
 
   it("does NOT overwrite a user-pinned Authorization header even when a token exists", () => {
@@ -749,6 +785,7 @@ describe('MCP_TEMPLATES', () => {
     // remote-debugging port.
     expect(tpl?.transport).toBe('http');
     expect(tpl?.url).toBe('http://localhost:38451/mcp');
+    expect(tpl?.authMode).toBe('none');
     expect(tpl?.headerFields ?? []).toEqual([]);
   });
 

--- a/apps/web/src/components/McpClientSection.tsx
+++ b/apps/web/src/components/McpClientSection.tsx
@@ -63,9 +63,50 @@ function genLocalId(): string {
   return `mcp-row-${NEXT_LOCAL_ID++}`;
 }
 
+function isLoopbackMcpUrl(rawUrl: string | undefined): boolean {
+  if (!rawUrl) return false;
+  try {
+    const host = new URL(rawUrl)
+      .hostname
+      .replace(/^\[|\]$/g, '')
+      .toLowerCase()
+      .replace(/\.+$/g, '');
+    if (host === 'localhost' || host === '::1') return true;
+    if (/^127(?:\.\d{1,3}){3}$/.test(host)) return true;
+    return /^::ffff:127(?:\.\d{1,3}){3}$/i.test(host);
+  } catch {
+    return false;
+  }
+}
+
+function inferMcpAuthMode(url: string | undefined): NonNullable<McpServerConfig['authMode']> {
+  return isLoopbackMcpUrl(url) ? 'none' : 'oauth';
+}
+
+function effectiveMcpAuthMode(
+  row: Pick<McpServerConfig, 'transport' | 'url' | 'authMode'>,
+): NonNullable<McpServerConfig['authMode']> {
+  if (row.transport !== 'http' && row.transport !== 'sse') return 'none';
+  return row.authMode ?? inferMcpAuthMode(row.url);
+}
+
+function authModeAfterUrlChange(
+  row: Pick<McpServerConfig, 'url' | 'authMode'>,
+  nextUrl: string,
+): NonNullable<McpServerConfig['authMode']> {
+  const previousInferred = inferMcpAuthMode(row.url);
+  if (!row.authMode || row.authMode === previousInferred) {
+    return inferMcpAuthMode(nextUrl);
+  }
+  return row.authMode;
+}
+
 function rowsFromServers(servers: McpServerConfig[]): DraftRow[] {
   return servers.map((s) => ({
     ...s,
+    ...(s.transport === 'http' || s.transport === 'sse'
+      ? { authMode: effectiveMcpAuthMode(s) }
+      : {}),
     _envText: s.env ? mapToText(s.env) : '',
     _headersText: s.headers ? mapToText(s.headers) : '',
     _localId: genLocalId(),
@@ -109,6 +150,7 @@ function rowsToServers(rows: DraftRow[]): McpServerConfig[] {
       const env = textToMap(r._envText);
       if (env) out.env = env;
     } else {
+      out.authMode = effectiveMcpAuthMode(r);
       if (r.url) out.url = r.url;
       const headers = textToMap(r._headersText);
       if (headers) out.headers = headers;
@@ -132,6 +174,9 @@ function rowFromTemplate(
     templateId: tpl.id,
     transport: tpl.transport,
     enabled: true,
+    ...(tpl.transport === 'http' || tpl.transport === 'sse'
+      ? { authMode: tpl.authMode ?? inferMcpAuthMode(tpl.url) }
+      : {}),
     command: tpl.command,
     args: tpl.args ? [...tpl.args] : undefined,
     url: tpl.url,
@@ -647,6 +692,7 @@ interface RowProps {
 
 function McpRow({ row, idx, total, template, onChange, onRemove, onMoveUp, onMoveDown }: RowProps) {
   const isHttpLike = row.transport === 'http' || row.transport === 'sse';
+  const usesManagedOAuth = isHttpLike && effectiveMcpAuthMode(row) === 'oauth';
   const [expanded, setExpanded] = useState<boolean>(false);
   const summaryTitle = row.label?.trim() || row.id || 'Unnamed MCP server';
   const [showMcpExample, setShowMcpExample] = useState<boolean>(false);
@@ -766,12 +812,26 @@ function McpRow({ row, idx, total, template, onChange, onRemove, onMoveUp, onMov
           ) : null}
 
           {isHttpLike && !row._isNew && row.id ? (
-            <McpOAuthControl serverId={row.id} />
+            usesManagedOAuth ? (
+              <McpOAuthControl serverId={row.id} />
+            ) : (
+              <div className="mcp-oauth-hint hint">
+                <strong>No managed OAuth.</strong> Open Design will use this
+                server as configured. Add headers below if the server needs a
+                token.
+              </div>
+            )
           ) : null}
-          {isHttpLike && row._isNew ? (
+          {isHttpLike && row._isNew && usesManagedOAuth ? (
             <div className="mcp-oauth-hint hint">
               Save first, then click <strong>Connect</strong> to grant Open Design
               access via the provider's OAuth flow.
+            </div>
+          ) : null}
+          {isHttpLike && row._isNew && !usesManagedOAuth ? (
+            <div className="mcp-oauth-hint hint">
+              <strong>No managed OAuth.</strong> Save this server and Open Design
+              will use it directly.
             </div>
           ) : null}
 
@@ -789,9 +849,15 @@ function McpRow({ row, idx, total, template, onChange, onRemove, onMoveUp, onMov
               <span className="mcp-row-field-label">Transport</span>
               <select
                 value={row.transport}
-                onChange={(e) =>
-                  onChange({ transport: e.target.value as DraftRow['transport'] })
-                }
+                onChange={(e) => {
+                  const transport = e.target.value as DraftRow['transport'];
+                  onChange({
+                    transport,
+                    ...(transport === 'http' || transport === 'sse'
+                      ? { authMode: row.authMode ?? inferMcpAuthMode(row.url) }
+                      : { authMode: undefined }),
+                  });
+                }}
               >
                 <option value="stdio">stdio</option>
                 <option value="sse">SSE</option>
@@ -843,12 +909,29 @@ function McpRow({ row, idx, total, template, onChange, onRemove, onMoveUp, onMov
           ) : (
             <>
               <label className="mcp-row-field mcp-row-field-stack">
+                <span className="mcp-row-field-label">OAuth mode</span>
+                <select
+                  value={effectiveMcpAuthMode(row)}
+                  onChange={(e) =>
+                    onChange({
+                      authMode: e.target.value as NonNullable<McpServerConfig['authMode']>,
+                    })
+                  }
+                >
+                  <option value="none">No managed OAuth</option>
+                  <option value="oauth">Managed OAuth</option>
+                </select>
+              </label>
+              <label className="mcp-row-field mcp-row-field-stack">
                 <span className="mcp-row-field-label">URL</span>
                 <input
                   type="text"
                   value={row.url ?? ''}
                   placeholder="https://mcp.higgsfield.ai/mcp"
-                  onChange={(e) => onChange({ url: e.target.value })}
+                  onChange={(e) => {
+                    const url = e.target.value;
+                    onChange({ url, authMode: authModeAfterUrlChange(row, url) });
+                  }}
                   spellCheck={false}
                 />
               </label>

--- a/apps/web/tests/components/McpClientSection.oauth.test.tsx
+++ b/apps/web/tests/components/McpClientSection.oauth.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { McpClientSection } from '../../src/components/McpClientSection';
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('McpClientSection OAuth controls', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.endsWith('/api/mcp/servers')) {
+        return jsonResponse({
+          servers: [
+            {
+              id: 'figma-use',
+              label: 'figma-use',
+              templateId: 'figma-use',
+              transport: 'http',
+              enabled: true,
+              url: 'http://localhost:38451/mcp',
+            },
+          ],
+          templates: [],
+        });
+      }
+      if (url.startsWith('/api/mcp/oauth/status')) {
+        return jsonResponse({ connected: false });
+      }
+      return jsonResponse({});
+    }));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('does not force managed OAuth for saved localhost HTTP MCP servers', async () => {
+    render(<McpClientSection />);
+
+    const expand = await screen.findByRole('button', {
+      name: /Expand this MCP server/i,
+    });
+    fireEvent.click(expand);
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/No managed OAuth/i).length).toBeGreaterThan(0);
+    });
+    expect(screen.queryByRole('button', { name: /^Connect$/i })).toBeNull();
+  });
+
+  it('infers no managed OAuth when a custom HTTP row is pointed at localhost', async () => {
+    render(<McpClientSection />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /Add server/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Custom server/i }));
+    const expandButtons = screen.getAllByRole('button', {
+      name: /Expand this MCP server/i,
+    });
+    fireEvent.click(expandButtons[expandButtons.length - 1]!);
+
+    fireEvent.change(screen.getByLabelText('Transport'), {
+      target: { value: 'http' },
+    });
+    fireEvent.change(screen.getByLabelText('URL'), {
+      target: { value: 'http://localhost:38451/mcp' },
+    });
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('OAuth mode') as HTMLSelectElement).value).toBe(
+        'none',
+      );
+    });
+    expect(screen.queryByRole('button', { name: /^Connect$/i })).toBeNull();
+  });
+});

--- a/packages/contracts/src/api/mcp.ts
+++ b/packages/contracts/src/api/mcp.ts
@@ -10,6 +10,7 @@
 // per-spawn config files (e.g. project-cwd `.mcp.json` for Claude Code).
 
 export type McpTransport = 'stdio' | 'sse' | 'http';
+export type McpAuthMode = 'none' | 'oauth';
 
 export interface McpServerConfig {
   /** Stable slug (lowercase, alphanumeric + dash/underscore). Doubles as the
@@ -28,6 +29,10 @@ export interface McpServerConfig {
    * spawn so users can keep credentials around without them being wired into
    * every run. */
   enabled: boolean;
+  /** HTTP/SSE only: whether Open Design should offer its managed OAuth flow.
+   * `none` means no daemon-managed OAuth; credentials, if any, are supplied
+   * by headers or by a trusted local server. */
+  authMode?: McpAuthMode;
 
   // ── stdio ──
   command?: string;
@@ -76,6 +81,8 @@ export interface McpTemplate {
   label: string;
   description: string;
   transport: McpTransport;
+  /** HTTP/SSE only. Defaults are inferred by URL when omitted. */
+  authMode?: McpAuthMode;
   /** Picker grouping. Required so the UI can always find a home for the
    * template — fall back to `utilities` for true grab-bag entries. */
   category: McpTemplateCategory;


### PR DESCRIPTION
Fixes #1412

## Why

I opened this PR for the upstream Figma MCP bug where local HTTP MCP servers such as `figma-use` could read from Figma but write operations surfaced as `user cancelled MCP tool call`.

The pain was that Settings treated every HTTP/SSE MCP server as daemon-managed OAuth and pushed users toward `/api/mcp/oauth/start`, even when the server is a trusted localhost process with no OAuth provider.

## What users will see

Settings -> External MCP servers now shows an `OAuth mode` selector for HTTP/SSE servers. Localhost HTTP servers, including the built-in `figma-use` template and custom `http://localhost:*` rows, default to `No managed OAuth` and do not show the OAuth Connect flow. Remote OAuth servers such as Higgsfield still default to `Managed OAuth`.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. The changed UI is the existing Settings -> External MCP servers row state; regression coverage exercises the visible Connect/no-managed-OAuth behavior directly.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/McpClientSection.oauth.test.tsx`
- Did the test go red on `main` and green on this branch? yes, the custom localhost HTTP-row spec failed with `expected 'oauth' to be 'none'` before the URL-inference fix and passes on this branch.

## Validation

- `corepack pnpm exec vitest run tests/mcp-config.test.ts -c vitest.config.ts` from `apps/daemon` - passed, 72 tests
- `corepack pnpm exec vitest run tests/components/McpClientSection.oauth.test.tsx tests/components/McpJsonHelper.test.tsx -c vitest.config.ts` from `apps/web` - passed, 3 tests
- `corepack pnpm --filter @open-design/contracts build` - passed
- `corepack pnpm --filter @open-design/registry-protocol build` - passed
- `corepack pnpm --filter @open-design/web typecheck` - passed
- `corepack pnpm exec tsc -p tsconfig.json --noEmit` from `apps/daemon` - passed
- `corepack pnpm exec tsc -p tsconfig.tests.json --noEmit` from `apps/daemon` - passed
- `corepack pnpm guard` - passed
- `corepack pnpm --filter @open-design/daemon typecheck` - blocked before TypeScript because the package script invokes plain `pnpm`, which resolves to `10.28.2` in this environment while the repo requires `>=10.33.2 <11`; Node is also `v26.0.0` while the repo expects `~24`.
- `corepack pnpm typecheck` - blocked for the same nested plain-`pnpm` / Node engine mismatch.
