### PR TITLE
feat(design-systems): add tokens.css + components.html for 10 AI / devtool brands

### DIFF
--- a/design-systems/minimax/components.html
+++ b/design-systems/minimax/components.html
@@ -1,0 +1,590 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>MiniMax — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/minimax. Every visible
+        value comes from tokens.css. MiniMax / Hailuo (海螺) signature
+        moves: white-dominant gallery, Outfit display + DM Sans body
+        with CJK fallbacks, pill nav, brand-blue accent, near-black CTA
+        per the MiniMax button system, purple-tinted glow on the
+        featured product card."
+    />
+
+    <style>
+      :root {
+        --bg:           #ffffff;
+        --surface:      #fafafa;
+        --surface-warm: #f0f0f0;
+
+        --fg:   #222222;
+        --fg-2: #18181b;
+        --muted: #45515e;
+        --meta:  #8e8e93;
+
+        --border:      #e5e7eb;
+        --border-soft: #f2f3f5;
+
+        --accent:        #1456f0;
+        --accent-on:     #ffffff;
+        --accent-hover:  #2563eb;
+        --accent-active: #1d4ed8;
+
+        --success: #16a34a;
+        --warn:    #eab308;
+        --danger:  #dc2626;
+
+        --font-display: "Outfit", "Helvetica Neue", Helvetica, Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans SC", sans-serif;
+        --font-body:    "DM Sans", "Helvetica Neue", Helvetica, Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans SC", sans-serif;
+        --font-mono:    ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Monaco, Consolas, monospace;
+
+        --text-xs:   12px;
+        --text-sm:   14px;
+        --text-base: 16px;
+        --text-lg:   20px;
+        --text-xl:   24px;
+        --text-2xl:  32px;
+        --text-3xl:  48px;
+        --text-4xl:  80px;
+
+        --leading-body:     1.5;
+        --leading-tight:    1.1;
+        --tracking-display: -0.01em;
+
+        --space-1:  4px;
+        --space-2:  8px;
+        --space-3:  12px;
+        --space-4:  16px;
+        --space-5:  20px;
+        --space-6:  24px;
+        --space-8:  32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 80px;
+        --section-y-tablet:  64px;
+        --section-y-phone:   40px;
+
+        --radius-sm:   8px;
+        --radius-md:   13px;
+        --radius-lg:   20px;
+        --radius-pill: 9999px;
+
+        --elev-flat:   none;
+        --elev-ring:   0 0 0 1px var(--border);
+        --elev-raised: 0 4px 6px rgba(0, 0, 0, 0.08);
+
+        --focus-ring: 0 0 0 3px color-mix(in oklab, var(--accent), transparent 70%);
+
+        --motion-fast:   150ms;
+        --motion-base:   200ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+        --container-max:            1200px;
+        --container-gutter-desktop: 24px;
+        --container-gutter-tablet:  16px;
+        --container-gutter-phone:   16px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+      }
+
+      /* ─── Layout primitives ─────────────────────────────────── */
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      section + section { border-top: 1px solid var(--border-soft); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography ────────────────────────────────────────── */
+      h1, h2, h3 { margin: 0; color: var(--fg); }
+      /* Outfit display — weight 500 (not 700) per DESIGN.md §3. */
+      h1 {
+        font-family: var(--font-display);
+        font-size: var(--text-4xl);
+        font-weight: 500;
+        line-height: var(--leading-tight);
+        letter-spacing: var(--tracking-display);
+      }
+      h2 {
+        font-family: var(--font-display);
+        font-size: var(--text-2xl);
+        font-weight: 600;
+        line-height: 1.25;
+        letter-spacing: -0.005em;
+      }
+      h3 {
+        font-family: var(--font-display);
+        font-size: var(--text-lg);
+        font-weight: 600;
+        line-height: var(--leading-body);
+      }
+      p { margin: 0; }
+      .lead {
+        font-size: var(--text-lg);
+        color: var(--muted);
+        line-height: var(--leading-body);
+        font-weight: 400;
+      }
+      .body-muted { color: var(--muted); }
+      .body-sm { font-size: var(--text-sm); }
+      .eyebrow {
+        font-size: var(--text-xs);
+        color: var(--accent);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 600;
+        font-family: var(--font-body);
+      }
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+
+      /* Smaller hero on tablet/phone — DESIGN.md §8 collapses 80px → 40px. */
+      @media (max-width: 1023px) { h1 { font-size: 56px; } }
+      @media (max-width: 639px)  { h1 { font-size: 40px; } }
+
+      /* ─── Nav ───────────────────────────────────────────────── */
+      .topnav {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding-block: var(--space-5);
+        gap: var(--space-4);
+      }
+      .topnav-brand {
+        font-family: var(--font-display);
+        font-weight: 600;
+        font-size: var(--text-lg);
+        color: var(--fg-2);
+        text-decoration: none;
+        letter-spacing: -0.01em;
+      }
+      .topnav-tabs {
+        display: flex;
+        align-items: center;
+        gap: var(--space-1);
+        background: rgba(0, 0, 0, 0.04);
+        padding: 4px;
+        border-radius: var(--radius-pill);
+      }
+      .topnav-tabs a {
+        padding: 8px 14px;
+        font-size: var(--text-sm);
+        font-weight: 500;
+        color: var(--muted);
+        text-decoration: none;
+        border-radius: var(--radius-pill);
+        transition: color var(--motion-fast) var(--ease-standard),
+                    background-color var(--motion-fast) var(--ease-standard);
+      }
+      .topnav-tabs a:hover { color: var(--fg); }
+      .topnav-tabs a[aria-current="page"] {
+        background: var(--bg);
+        color: var(--fg-2);
+        box-shadow: var(--elev-raised);
+      }
+      .topnav-right { display: flex; align-items: center; gap: var(--space-3); }
+
+      /* ─── Buttons ───────────────────────────────────────────── */
+      /* MiniMax primary CTA: near-black pill-radius (8px) bg, white text,
+         11px 20px padding per DESIGN.md §4 "Pill Primary Dark". */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 11px 20px;
+        border-radius: var(--radius-sm);
+        font-family: var(--font-body);
+        font-size: var(--text-sm);
+        font-weight: 600;
+        line-height: 1;
+        cursor: pointer;
+        border: 1px solid transparent;
+        text-decoration: none;
+        transition: background-color var(--motion-fast) var(--ease-standard),
+                    border-color var(--motion-fast) var(--ease-standard),
+                    color var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn-primary {
+        background: var(--fg-2);
+        color: var(--bg);
+      }
+      .btn-primary:hover  { background: #2a323b; }
+      .btn-primary:active { background: #0f1419; }
+      .btn-secondary {
+        background: var(--surface-warm);
+        color: var(--fg-2);
+      }
+      .btn-secondary:hover { background: #e3e3e6; }
+      .btn-ghost {
+        background: transparent;
+        color: var(--fg-2);
+        border-color: var(--border);
+      }
+      .btn-ghost:hover { background: var(--surface); }
+
+      /* ─── Chips ─────────────────────────────────────────────── */
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 4px 12px;
+        border-radius: var(--radius-pill);
+        font-size: var(--text-xs);
+        font-weight: 600;
+        background: var(--surface-warm);
+        color: var(--muted);
+      }
+      .chip-accent {
+        background: color-mix(in oklab, var(--accent), transparent 90%);
+        color: var(--accent);
+      }
+      .chip-success {
+        background: color-mix(in oklab, var(--success), transparent 88%);
+        color: var(--success);
+      }
+      .dot {
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: currentColor;
+      }
+
+      /* ─── Cards ─────────────────────────────────────────────── */
+      .card {
+        background: var(--bg);
+        border: 1px solid var(--border-soft);
+        border-radius: var(--radius-md);
+        padding: var(--space-6);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+        transition: box-shadow var(--motion-base) var(--ease-standard),
+                    transform var(--motion-base) var(--ease-standard);
+      }
+      .card:hover {
+        box-shadow: var(--elev-raised);
+        transform: translateY(-2px);
+      }
+      .card-product {
+        border-radius: var(--radius-lg);
+        padding: var(--space-8);
+        background: var(--bg);
+        /* MiniMax purple-tinted brand glow — DESIGN.md §6 Level 3.
+           Single-use here; not promoted to a token. */
+        box-shadow: rgba(44, 30, 116, 0.16) 0px 0px 15px;
+        overflow: hidden;
+        position: relative;
+        min-height: 240px;
+      }
+      .card-product-tag {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        font-size: var(--text-xs);
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--meta);
+      }
+      .card-product-title {
+        font-family: var(--font-display);
+        font-size: 28px;
+        font-weight: 600;
+        line-height: 1.2;
+        color: var(--fg-2);
+        margin: 0;
+      }
+
+      /* ─── Inputs ────────────────────────────────────────────── */
+      .field { display: flex; flex-direction: column; gap: var(--space-2); }
+      .field label {
+        font-size: var(--text-sm);
+        font-weight: 500;
+        color: var(--fg-2);
+      }
+      .field input, .field textarea {
+        background: var(--bg);
+        color: var(--fg);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        padding: 12px 14px;
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        outline: none;
+        transition: border-color var(--motion-fast) var(--ease-standard),
+                    box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .field input::placeholder { color: var(--meta); }
+      .field input:focus, .field textarea:focus {
+        border-color: var(--accent);
+        box-shadow: var(--focus-ring);
+      }
+      .field-help { font-size: var(--text-xs); color: var(--muted); }
+
+      /* ─── Section layouts ───────────────────────────────────── */
+      .hero-grid {
+        display: grid;
+        grid-template-columns: 1.3fr 1fr;
+        gap: var(--space-12);
+        align-items: end;
+      }
+      @media (max-width: 1023px) {
+        .hero-grid { grid-template-columns: 1fr; gap: var(--space-8); }
+      }
+      .hero-actions {
+        display: flex;
+        gap: var(--space-3);
+        margin-block-start: var(--space-6);
+        flex-wrap: wrap;
+      }
+      .features-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: var(--space-5);
+        margin-block-start: var(--space-8);
+      }
+      @media (max-width: 1023px) { .features-grid { grid-template-columns: 1fr 1fr; } }
+      @media (max-width: 639px)  { .features-grid { grid-template-columns: 1fr; } }
+      .form-row {
+        display: grid;
+        grid-template-columns: 1.2fr 1fr;
+        gap: var(--space-12);
+        align-items: start;
+      }
+      @media (max-width: 1023px) { .form-row { grid-template-columns: 1fr; } }
+      .form {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+        max-width: 460px;
+      }
+      .form-actions {
+        display: flex;
+        gap: var(--space-3);
+        margin-block-start: var(--space-2);
+      }
+      .icon { width: 16px; height: 16px; flex-shrink: 0; }
+      .row-between {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-3);
+      }
+      kbd {
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        padding: 2px 6px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+        background: var(--surface);
+        color: var(--muted);
+      }
+      code {
+        font-family: var(--font-mono);
+        font-size: 0.875em;
+        background: var(--surface-warm);
+        border-radius: var(--radius-sm);
+        padding: 1px 6px;
+        color: var(--fg-2);
+      }
+    </style>
+  </head>
+  <body>
+    <header class="container">
+      <nav class="topnav" aria-label="Primary">
+        <a class="topnav-brand" href="./DESIGN.md">MiniMax</a>
+        <div class="topnav-tabs" role="tablist">
+          <a href="#" role="tab" aria-current="page">Products</a>
+          <a href="#" role="tab">Hailuo</a>
+          <a href="#" role="tab">Conch</a>
+          <a href="#" role="tab">Developers</a>
+        </div>
+        <div class="topnav-right">
+          <a href="#" class="body-sm" style="color: var(--fg-2); text-decoration: none; font-weight: 500;">Log in</a>
+          <a href="#" class="btn btn-primary">Get started</a>
+        </div>
+      </nav>
+    </header>
+
+    <main class="container">
+      <!-- HERO — Outfit display, near-black CTA, brand-glow product card. -->
+      <section data-od-id="hero">
+        <div class="hero-grid">
+          <div class="stack-4">
+            <p class="eyebrow">Reference fixture · minimax</p>
+            <h1>Generative AI, made for everyone.</h1>
+            <p class="lead" style="max-width: 52ch;">
+              From <strong style="color: var(--fg-2); font-weight: 600;">Hailuo</strong>
+              video to <strong style="color: var(--fg-2); font-weight: 600;">Conch</strong> text,
+              MiniMax ships consumer-friendly models that creators in
+              Shanghai, São Paulo, and San Francisco can pick up in a
+              single click — 一个画面，一段对话，一支视频。
+            </p>
+            <div class="hero-actions">
+              <a href="./tokens.css" class="btn btn-primary">
+                Try Hailuo
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                     stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M5 12h14M13 6l6 6-6 6"/>
+                </svg>
+              </a>
+              <a href="./DESIGN.md" class="btn btn-ghost">Read the spec</a>
+            </div>
+            <p class="body-sm body-muted" style="margin-block-start: var(--space-3);">
+              Press <kbd>⌘</kbd> <kbd>K</kbd> to search the catalogue.
+            </p>
+          </div>
+
+          <aside class="card-product" aria-label="Featured product">
+            <div class="row-between" style="margin-block-end: var(--space-6);">
+              <span class="card-product-tag">
+                <span class="dot" style="color: var(--accent);"></span>
+                Featured · v2.5
+              </span>
+              <span class="chip chip-accent">New</span>
+            </div>
+            <h2 class="card-product-title">Hailuo · 海螺 Video</h2>
+            <p class="body-muted" style="margin-block-start: var(--space-2); font-size: var(--text-sm); max-width: 36ch;">
+              Cinema-grade clips from a single prompt. 6 seconds, 1080p,
+              ready to share — every render begins on a clean white canvas.
+            </p>
+            <div class="row-between" style="margin-block-start: var(--space-6); padding-block-start: var(--space-4); border-block-start: 1px solid var(--border-soft);">
+              <span class="body-sm body-muted">Avg. render</span>
+              <span class="body-sm" style="font-weight: 600; color: var(--fg-2);">42s</span>
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <!-- FEATURES — 3-card matrix, 13px radius, neutral shadow. -->
+      <section data-od-id="features">
+        <div class="stack-3">
+          <p class="eyebrow">What this fixture exercises</p>
+          <h2 style="max-width: 28ch;">
+            Restraint in chrome. Color in the products.
+          </h2>
+          <p class="lead" style="max-width: 56ch;">
+            Every component below uses <code>var(--*)</code> only — the
+            only place a raw color enters is the purple-tinted brand glow
+            on the featured card above, justified explicitly by DESIGN.md §6.
+          </p>
+        </div>
+
+        <div class="features-grid">
+          <article class="card">
+            <span class="chip chip-accent" style="align-self: flex-start;">Type</span>
+            <h3>Two display voices</h3>
+            <p class="body-muted body-sm">
+              Outfit drives display headings at weight 500 — geometric,
+              never aggressive. DM Sans handles ~70% of UI text. Both
+              stacks ship with PingFang SC / Noto Sans SC fallbacks so
+              <code>海螺 Video</code> aligns with English on the same baseline.
+            </p>
+            <a href="./tokens.css" class="body-sm" style="color: var(--accent); text-decoration: none; font-weight: 500;">Inspect typography →</a>
+          </article>
+
+          <article class="card">
+            <span class="chip chip-success" style="align-self: flex-start;">
+              <span class="dot"></span>
+              Accent
+            </span>
+            <h3>Brand blue, used sparingly</h3>
+            <p class="body-muted body-sm">
+              <code>--accent: #1456f0</code> appears at most twice per
+              screen — eyebrow + chip here, focus ring on the form below.
+              Brand pink stays out of the token system entirely (logo-only
+              per DESIGN.md §7).
+            </p>
+            <a href="./DESIGN.md" class="body-sm" style="color: var(--accent); text-decoration: none; font-weight: 500;">Read the rule →</a>
+          </article>
+
+          <article class="card">
+            <span class="chip" style="align-self: flex-start;">Rhythm</span>
+            <h3>Universal 1.5 leading</h3>
+            <p class="body-muted body-sm">
+              Display hero compresses to 1.10; everything else — body,
+              headings, captions — rides on a single 1.50 line-height.
+              That uniformity is the MiniMax signature, holding equally
+              for Latin and CJK runs.
+            </p>
+            <a href="./tokens.css" class="body-sm" style="color: var(--accent); text-decoration: none; font-weight: 500;">Inspect tokens →</a>
+          </article>
+        </div>
+      </section>
+
+      <!-- FORM — accent-focused input, dark CTA, secondary action. -->
+      <section data-od-id="form">
+        <div class="form-row">
+          <div class="stack-4">
+            <p class="eyebrow">Form components</p>
+            <h2>Start a render in one prompt.</h2>
+            <p class="lead" style="max-width: 46ch;">
+              8px radius on inputs and buttons. Focus pulls in
+              <code>#1456f0</code> as the border and a 3px translucent ring —
+              the only place the brand blue earns its keep in a form.
+            </p>
+            <ul style="margin: 0; padding-inline-start: var(--space-5); color: var(--muted); font-size: var(--text-sm);" class="stack-3">
+              <li>Single source of truth: <code>--focus-ring</code>.</li>
+              <li>Submit reuses <code>.btn-primary</code> — no new variant.</li>
+              <li>Placeholder uses <code>--meta</code> (tertiary tier).</li>
+            </ul>
+          </div>
+
+          <form class="form" onsubmit="event.preventDefault();" aria-label="Render prompt">
+            <div class="field">
+              <label for="prompt">Prompt</label>
+              <textarea
+                id="prompt"
+                rows="3"
+                placeholder="A neon koi gliding through a Shanghai night market…"
+              ></textarea>
+              <p class="field-help">English or 中文 — Hailuo accepts either.</p>
+            </div>
+            <div class="field">
+              <label for="email">Notify me at</label>
+              <input
+                id="email"
+                type="email"
+                placeholder="you@studio.dev"
+                autocomplete="email"
+                required
+              />
+            </div>
+            <div class="form-actions">
+              <button type="submit" class="btn btn-primary">
+                Start render
+              </button>
+              <button type="button" class="btn btn-secondary">
+                Save draft
+              </button>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/minimax/tokens.css
+++ b/design-systems/minimax/tokens.css
@@ -1,0 +1,148 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/minimax/tokens.css
+ *
+ * Structured token bindings for the "MiniMax" brand — the Shanghai-based
+ * AI lab behind Hailuo (海螺) video and Conch text. The visual language
+ * is a white-dominant product gallery: pure white canvas, vivid product
+ * cards, pill navigation, multi-font hierarchy, and a purple-tinted brand
+ * glow on featured surfaces. The font stacks include CJK fallbacks
+ * (PingFang SC, Hiragino Sans GB, Microsoft YaHei, Noto Sans SC) so the
+ * bilingual en/zh audience sees the same vertical rhythm in either script.
+ *
+ * Brand identity in three sentences:
+ *   1. White canvas (#ffffff) is structural; color enters via product
+ *      cards, illustrations, and a single brand-blue accent — never via
+ *      tinted page backgrounds.
+ *   2. Multi-font system: Outfit for display headings (geometric, weight
+ *      500), DM Sans as the UI workhorse for body / nav / buttons. CJK
+ *      fallbacks keep Chinese headings on the same rhythm as English.
+ *   3. Brand blue (#1456f0) is the accent — sparing, reserved for links,
+ *      focus rings, and small chips. Primary CTAs use near-black
+ *      (#181e25 → --fg-2) per the MiniMax button system; brand pink
+ *      (#ea5ec1) is logo / decorative only and never tokenized.
+ *
+ * Schema decisions:
+ *   - --bg: #ffffff;  --surface: #fafafa (whisper card lift on white).
+ *   - --surface-warm: #f0f0f0 (secondary button bg per DESIGN.md §4).
+ *   - --fg: #222222 (near-black);  --fg-2: #18181b (button text, deep heads).
+ *   - --muted: #45515e (DESIGN.md "dark gray" secondary text).
+ *   - --meta:  #8e8e93 (tertiary, muted labels per DESIGN.md §2).
+ *   - --border: #e5e7eb;  --border-soft: #f2f3f5 (section divider).
+ *   - --accent: #1456f0 (brand blue 6); hover #2563eb / active #1d4ed8.
+ *   - --font-display: Outfit + CJK fallbacks; --font-body: DM Sans + CJK.
+ *   - --text-4xl: 80px (display hero, Outfit weight 500 per DESIGN.md §3).
+ *   - --leading-body: 1.5 (universal MiniMax rhythm); --leading-tight: 1.1.
+ *   - --radius-sm: 8px (CTA), --radius-md: 13px (card),
+ *     --radius-lg: 20px (product showcase), --radius-pill: 9999px (nav).
+ *   - --elev-raised: 0 4px 6px rgba(0, 0, 0, 0.08) — DESIGN.md §6 Level 1.
+ *     The brand-glow shadow rgba(44, 30, 116, 0.16) stays inline on
+ *     featured product cards (one-off, not promoted to a token).
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface ──────────────────────────────────────────────────── */
+  --bg:           #ffffff;             /* pure white — primary canvas */
+  --surface:      #fafafa;             /* near-white — card lift on bg */
+  --surface-warm: #f0f0f0;             /* secondary button bg (DESIGN.md §4) */
+
+  /* ─── Foreground ───────────────────────────────────────────────── */
+  --fg:   #222222;                     /* near-black — primary text */
+  --fg-2: #18181b;                     /* button text + dark headings */
+  --muted: #45515e;                    /* dark gray — secondary text */
+  --meta:  #8e8e93;                    /* mid gray — tertiary, muted labels */
+
+  /* ─── Border ───────────────────────────────────────────────────── */
+  --border:      #e5e7eb;              /* component edge */
+  --border-soft: #f2f3f5;              /* subtle section divider */
+
+  /* ─── Accent ───────────────────────────────────────────────────── */
+  --accent:        #1456f0;            /* MiniMax brand blue 6 */
+  --accent-on:     #ffffff;
+  --accent-hover:  #2563eb;            /* primary 600 — hover */
+  --accent-active: #1d4ed8;            /* primary 700 — pressed */
+
+  /* ─── Semantic ─────────────────────────────────────────────────── */
+  --success: #16a34a;
+  --warn:    #eab308;
+  --danger:  #dc2626;
+
+  /* ─── Typography ───────────────────────────────────────────────── */
+  /* DM Sans = UI workhorse; Outfit = geometric display. CJK fallbacks
+     (PingFang SC, Hiragino Sans GB, Microsoft YaHei, Noto Sans SC) give
+     Chinese-language headings + body the same vertical rhythm so 海螺 /
+     Conch / MiniMax all align without per-script overrides. */
+  --font-display: "Outfit", "Helvetica Neue", Helvetica, Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans SC", sans-serif;
+  --font-body:    "DM Sans", "Helvetica Neue", Helvetica, Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans SC", sans-serif;
+  --font-mono:    ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Monaco, Consolas, monospace;
+
+  /* Type scale — DESIGN.md §3 hierarchy.
+   * MiniMax compresses from 80px display straight to 32px section, then
+   * 16–20px body — a deliberate jump that keeps the visual ladder short. */
+  --text-xs:   12px;                   /* small label, tag */
+  --text-sm:   14px;                   /* nav / link */
+  --text-base: 16px;                   /* body */
+  --text-lg:   20px;                   /* body large, emphasized */
+  --text-xl:   24px;                   /* sub-heading (Poppins context) */
+  --text-2xl:  32px;                   /* section heading alt */
+  --text-3xl:  48px;                   /* H1 step between section and display */
+  --text-4xl:  80px;                   /* display hero — Outfit weight 500 */
+
+  /* Leading + tracking.
+   * Universal 1.50 line-height across body and most headings is the
+   * MiniMax signature (DESIGN.md §3); display compresses to 1.10 for the
+   * 80px hero. Slight negative tracking on display sizes only. */
+  --leading-body:     1.5;
+  --leading-tight:    1.1;
+  --tracking-display: -0.01em;
+
+  /* ─── Spacing ──────────────────────────────────────────────────── */
+  /* 8px base grid per DESIGN.md §5; the schema spine uses 4px steps
+     capped at --space-12 (48px). Larger gallery gaps (64–80px) live in
+     the section-rhythm tier below. */
+  --space-1:  4px;
+  --space-2:  8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  20px;
+  --space-6:  24px;
+  --space-8:  32px;
+  --space-12: 48px;
+
+  /* ─── Section rhythm ───────────────────────────────────────────── */
+  /* DESIGN.md §5 gallery spacing: 64–80px between sections on desktop,
+     compressing to 32–40px on phone. */
+  --section-y-desktop: 80px;
+  --section-y-tablet:  64px;
+  --section-y-phone:   40px;
+
+  /* ─── Radius ───────────────────────────────────────────────────── */
+  /* DESIGN.md §5 scale: 8px on CTA buttons / small cards, 13px on
+     medium cards/panels, 20px on product cards, 9999px on pill nav. */
+  --radius-sm:   8px;
+  --radius-md:   13px;
+  --radius-lg:   20px;
+  --radius-pill: 9999px;
+
+  /* ─── Elevation ────────────────────────────────────────────────── */
+  /* DESIGN.md §6: light, airy shadows capped at 0.08 opacity. Standard
+     cards use the neutral black drop below; featured product cards add
+     the purple-tinted brand glow rgba(44, 30, 116, 0.16) inline as a
+     one-off (single-use, not promoted to a token). */
+  --elev-flat:   none;
+  --elev-ring:   0 0 0 1px var(--border);
+  --elev-raised: 0 4px 6px rgba(0, 0, 0, 0.08);
+
+  /* ─── Focus ────────────────────────────────────────────────────── */
+  --focus-ring: 0 0 0 3px color-mix(in oklab, var(--accent), transparent 70%);
+
+  /* ─── Motion ───────────────────────────────────────────────────── */
+  --motion-fast:   150ms;
+  --motion-base:   200ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+  /* ─── Layout ───────────────────────────────────────────────────── */
+  --container-max:            1200px;
+  --container-gutter-desktop: 24px;
+  --container-gutter-tablet:  16px;
+  --container-gutter-phone:   16px;
+}

--- a/design-systems/ollama/components.html
+++ b/design-systems/ollama/components.html
@@ -1,0 +1,700 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Ollama — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/ollama. Every visible
+        value comes from tokens.css; if the agent paste-replaces the
+        :root block and reuses the component selectors below verbatim,
+        the artifact passes lint without further audit."
+    />
+
+    <style>
+      :root {
+        --bg: #ffffff;
+        --surface: #fafafa;
+        --surface-warm: var(--surface);
+
+        --fg: #000000;
+        --fg-2: #262626;
+        --muted: #737373;
+        --meta: #a3a3a3;
+
+        --border: #e5e5e5;
+        --border-soft: var(--border);
+
+        --accent: #000000;
+        --accent-on: #ffffff;
+        --accent-hover: #262626;
+        --accent-active: #404040;
+
+        --success: #16a34a;
+        --warn: #eab308;
+        --danger: #dc2626;
+
+        --font-display: "SF Pro Rounded", system-ui, -apple-system, system-ui;
+        --font-body: ui-sans-serif, system-ui, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+        --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+
+        --text-xs: 12px;
+        --text-sm: 14px;
+        --text-base: 16px;
+        --text-lg: 18px;
+        --text-xl: 24px;
+        --text-2xl: 30px;
+        --text-3xl: 36px;
+        --text-4xl: 48px;
+
+        --leading-body: 1.5;
+        --leading-tight: 1;
+        --tracking-display: 0;
+
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 112px;
+        --section-y-tablet: 88px;
+        --section-y-phone: 48px;
+
+        --radius-sm: 9999px;
+        --radius-md: 12px;
+        --radius-lg: 9999px;
+        --radius-pill: 9999px;
+
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised: 0 0 0 1px var(--border);
+
+        --focus-ring: 0 0 0 3px color-mix(in oklab, #3b82f6, transparent 50%);
+
+        --motion-fast: 100ms;
+        --motion-base: 140ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+        --container-max: 1280px;
+        --container-gutter-desktop: 24px;
+        --container-gutter-tablet: 16px;
+        --container-gutter-phone: 12px;
+      }
+
+      /* ─── Reset (minimal) ───────────────────────────────────── */
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+
+      /* ─── Layout primitives ─────────────────────────────────── */
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section {
+        padding-block: var(--section-y-desktop);
+      }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Navigation ────────────────────────────────────────── */
+      /* Transparent on white per DESIGN.md §4 — no background,
+         no border, just the wordmark, three text links, and a
+         black pill CTA. */
+      .nav {
+        display: flex;
+        align-items: center;
+        gap: var(--space-6);
+        padding-block: var(--space-5);
+      }
+      .nav-brand {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        font-family: var(--font-display);
+        font-size: var(--text-lg);
+        font-weight: 500;
+        color: var(--fg);
+        text-decoration: none;
+        letter-spacing: var(--tracking-display);
+      }
+      .nav-brand svg { display: block; }
+      .nav-links {
+        display: flex;
+        gap: var(--space-5);
+        margin-inline-start: var(--space-4);
+      }
+      .nav-links a {
+        color: var(--fg);
+        font-size: var(--text-base);
+        font-weight: 400;
+        text-decoration: none;
+      }
+      .nav-spacer { flex: 1; }
+      .nav-actions {
+        display: flex;
+        align-items: center;
+        gap: var(--space-4);
+      }
+      .nav-signin {
+        color: var(--fg);
+        font-size: var(--text-base);
+        text-decoration: none;
+      }
+      @media (max-width: 639px) {
+        .nav-links, .nav-signin { display: none; }
+      }
+
+      /* ─── Typography ────────────────────────────────────────── */
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        line-height: var(--leading-tight);
+        letter-spacing: var(--tracking-display);
+        margin: 0;
+        font-weight: 500;
+      }
+      h1 { font-size: var(--text-4xl); color: var(--fg); }
+      h2 { font-size: var(--text-3xl); color: var(--fg); }
+      h3 {
+        font-size: var(--text-xl);
+        font-weight: 400;
+        line-height: 1.33;
+      }
+      p { margin: 0; }
+      .lead {
+        font-size: var(--text-lg);
+        color: var(--muted);
+        line-height: 1.56;
+      }
+      .body-muted { color: var(--muted); }
+      .body-sm { font-size: var(--text-sm); }
+      .eyebrow {
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        color: var(--muted);
+        letter-spacing: 0.04em;
+        font-weight: 400;
+      }
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-5 > * + * { margin-block-start: var(--space-5); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+
+      /* ─── Buttons (every interactive radius is pill) ─────────── */
+      /* DESIGN.md §4 — three pill variants, all 10px 24px padding,
+         all 9999px radius. The accent role is fulfilled by the
+         black pill; the gray pill is the calmer affirmative; the
+         outlined pill is the secondary action on white. */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 10px var(--space-6);
+        border-radius: var(--radius-pill);
+        font-family: inherit;
+        font-size: var(--text-base);
+        font-weight: 500;
+        line-height: 1;
+        cursor: pointer;
+        border: 1px solid transparent;
+        background: transparent;
+        color: inherit;
+        text-decoration: none;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard),
+          border-color var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible {
+        outline: none;
+        box-shadow: var(--focus-ring);
+      }
+      .btn-primary {
+        background: var(--accent);
+        color: var(--accent-on);
+        border-color: var(--accent);
+      }
+      .btn-primary:hover {
+        background: var(--accent-hover);
+        border-color: var(--accent-hover);
+      }
+      .btn-primary:active {
+        background: var(--accent-active);
+        border-color: var(--accent-active);
+      }
+      .btn-gray {
+        background: var(--border);
+        color: var(--fg-2);
+        border-color: var(--border);
+      }
+      .btn-gray:hover {
+        background: color-mix(in oklab, var(--border), var(--fg) 6%);
+        border-color: color-mix(in oklab, var(--border), var(--fg) 6%);
+      }
+      .btn-outline {
+        background: var(--bg);
+        color: var(--fg-2);
+        border-color: var(--border);
+      }
+      .btn-outline:hover {
+        background: var(--surface);
+      }
+
+      /* ─── Pill tabs ─────────────────────────────────────────── */
+      .tabs {
+        display: inline-flex;
+        gap: var(--space-1);
+        padding: var(--space-1);
+        background: var(--surface);
+        border-radius: var(--radius-pill);
+      }
+      .tab {
+        padding: 6px var(--space-4);
+        border-radius: var(--radius-pill);
+        font-size: var(--text-sm);
+        color: var(--muted);
+        background: transparent;
+        border: none;
+        cursor: pointer;
+        font-family: inherit;
+      }
+      .tab[aria-selected="true"] {
+        background: var(--border);
+        color: var(--fg-2);
+      }
+      .tab:focus-visible {
+        outline: none;
+        box-shadow: var(--focus-ring);
+      }
+
+      /* ─── Inputs (pill search / form fields) ────────────────── */
+      .field {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+      }
+      .field label {
+        font-size: var(--text-sm);
+        font-weight: 500;
+        color: var(--fg-2);
+      }
+      .field input {
+        padding: 10px var(--space-5);
+        border-radius: var(--radius-pill);
+        border: 1px solid var(--border);
+        background: var(--bg);
+        color: var(--fg);
+        font-family: inherit;
+        font-size: var(--text-base);
+        outline: none;
+        transition:
+          border-color var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .field input::placeholder { color: var(--meta); }
+      .field input:focus-visible {
+        outline: none;
+        box-shadow: var(--focus-ring);
+      }
+      .field-help {
+        font-size: var(--text-xs);
+        color: var(--muted);
+        padding-inline-start: var(--space-5);
+      }
+
+      /* ─── Cards (the only non-pill radius) ──────────────────── */
+      .card {
+        background: var(--bg);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        padding: var(--space-6);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+      }
+      .card h3 { color: var(--fg); }
+
+      /* ─── Terminal block ────────────────────────────────────── */
+      /* 12px-radius bordered container per DESIGN.md §4, no shadow.
+         Mono inside, with a pill copy button on the right. */
+      .terminal {
+        background: var(--bg);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        padding: var(--space-4) var(--space-5);
+        font-family: var(--font-mono);
+        font-size: var(--text-base);
+        color: var(--fg);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+      }
+      .terminal-prompt { color: var(--meta); user-select: none; }
+      .terminal-cmd { color: var(--fg-2); flex: 1; }
+      .terminal-copy {
+        padding: 4px var(--space-3);
+        border-radius: var(--radius-pill);
+        border: 1px solid var(--border);
+        background: var(--bg);
+        color: var(--muted);
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        cursor: pointer;
+      }
+      .terminal-copy:hover { background: var(--surface); }
+      .terminal-copy:focus-visible {
+        outline: none;
+        box-shadow: var(--focus-ring);
+      }
+
+      /* ─── Tag pills ─────────────────────────────────────────── */
+      .tag {
+        display: inline-flex;
+        align-items: center;
+        padding: 2px var(--space-3);
+        border-radius: var(--radius-pill);
+        background: var(--border);
+        color: var(--fg-2);
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        line-height: 1.6;
+      }
+      .tag-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-2);
+      }
+
+      /* ─── Links ─────────────────────────────────────────────── */
+      a.text-link {
+        color: var(--fg);
+        text-decoration: none;
+        border-bottom: 1px solid var(--border);
+      }
+      a.text-link:hover { border-bottom-color: var(--fg); }
+
+      /* ─── Section-specific layout ───────────────────────────── */
+      .hero {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+        gap: var(--space-6);
+      }
+      .hero h1 { max-width: 18ch; }
+      .hero .lead { max-width: 56ch; }
+      .hero-actions {
+        display: flex;
+        gap: var(--space-3);
+        flex-wrap: wrap;
+        justify-content: center;
+      }
+      .hero-terminal {
+        margin-block-start: var(--space-6);
+        width: min(640px, 100%);
+      }
+
+      .features-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: var(--space-5);
+      }
+      @media (max-width: 1023px) {
+        .features-grid { grid-template-columns: 1fr; }
+      }
+      .feature-icon {
+        width: 28px;
+        height: 28px;
+        color: var(--fg);
+      }
+
+      .signup {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        padding: var(--space-12) var(--space-8);
+        display: grid;
+        grid-template-columns: 1.1fr 1fr;
+        gap: var(--space-12);
+        align-items: center;
+      }
+      @media (max-width: 1023px) {
+        .signup {
+          grid-template-columns: 1fr;
+          padding: var(--space-8);
+          gap: var(--space-6);
+        }
+      }
+      .signup-form {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+      }
+      .signup-row {
+        display: flex;
+        gap: var(--space-2);
+      }
+      .signup-row .field { flex: 1; }
+      @media (max-width: 639px) {
+        .signup-row { flex-direction: column; }
+      }
+
+      .footnote {
+        margin-block-start: var(--space-12);
+        padding-block-start: var(--space-6);
+        border-top: 1px solid var(--border);
+        display: flex;
+        justify-content: space-between;
+        gap: var(--space-4);
+        flex-wrap: wrap;
+        color: var(--meta);
+        font-size: var(--text-sm);
+      }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <!-- ════════════════════════════════════════════════════════════
+           NAV — transparent on white, three text links, pill CTA.
+           Exercises: .nav, .nav-brand, .nav-links, .btn-primary.
+      ═══════════════════════════════════════════════════════════════ -->
+      <header class="nav" aria-label="Primary">
+        <a href="#" class="nav-brand">
+          <svg
+            width="22"
+            height="22"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.6"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M7 14c0-3 1.5-5 5-5s5 2 5 5v5H7v-5z" />
+            <path d="M9 9V6a3 3 0 0 1 6 0v3" />
+            <circle cx="10" cy="13" r="0.6" fill="currentColor" stroke="none" />
+            <circle cx="14" cy="13" r="0.6" fill="currentColor" stroke="none" />
+            <path d="M11 16h2" />
+          </svg>
+          Ollama
+        </a>
+        <nav class="nav-links" aria-label="Sections">
+          <a href="#models">Models</a>
+          <a href="#docs">Docs</a>
+          <a href="#blog">Blog</a>
+        </nav>
+        <span class="nav-spacer"></span>
+        <div class="nav-actions">
+          <a href="#signin" class="nav-signin">Sign in</a>
+          <a href="#download" class="btn btn-primary">
+            Download
+          </a>
+        </div>
+      </header>
+
+      <!-- ════════════════════════════════════════════════════════════
+           HERO — centered single column. Exercises h1, .lead,
+           .btn-primary, .btn-gray, .terminal, --section-y-* rhythm.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="hero" aria-labelledby="hero-heading">
+        <div class="hero">
+          <p class="eyebrow">ollama · run open models locally</p>
+          <h1 id="hero-heading">
+            Run large language models on your own machine.
+          </h1>
+          <p class="lead">
+            Pull an open model, run it offline, and chat with it from
+            your terminal or your app. No accounts, no API keys, no
+            tokens billed by the thousand — your machine is the server.
+          </p>
+          <div class="hero-actions">
+            <a href="#download" class="btn btn-primary">
+              Download for macOS
+            </a>
+            <a href="#docs" class="btn btn-gray">
+              Read the docs
+            </a>
+          </div>
+          <div class="hero-terminal">
+            <div class="terminal" role="figure" aria-label="Example command">
+              <span class="terminal-prompt">$</span>
+              <span class="terminal-cmd">ollama run llama3.2</span>
+              <button type="button" class="terminal-copy" aria-label="Copy command">
+                Copy
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ════════════════════════════════════════════════════════════
+           FEATURES — three cards, plain border, 12px radius.
+           Exercises h2, .card, .tag, .features-grid, mono accents.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="features" aria-labelledby="features-heading">
+        <div class="stack-4" style="text-align: center; margin-block-end: var(--space-12);">
+          <p class="eyebrow">what ollama does</p>
+          <h2 id="features-heading" style="margin-inline: auto; max-width: 22ch;">
+            One command. Any model. On your hardware.
+          </h2>
+        </div>
+
+        <div class="features-grid">
+          <article class="card">
+            <svg
+              class="feature-icon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.6"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M12 3v12" />
+              <path d="M6 9l6 6 6-6" />
+              <path d="M4 21h16" />
+            </svg>
+            <h3>Pull a model</h3>
+            <p class="body-muted body-sm">
+              Browse a catalog of open models — Llama, Mistral, Gemma,
+              Qwen, DeepSeek — and download with a single command. Models
+              live on your disk, not on someone else's server.
+            </p>
+            <div class="tag-row">
+              <span class="tag">llama3.2</span>
+              <span class="tag">mistral</span>
+              <span class="tag">gemma3</span>
+            </div>
+          </article>
+
+          <article class="card">
+            <svg
+              class="feature-icon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.6"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <rect x="3" y="5" width="18" height="14" rx="2" />
+              <path d="M3 9h18" />
+              <path d="M8 14h4" />
+            </svg>
+            <h3>Talk to it</h3>
+            <p class="body-muted body-sm">
+              Chat from the terminal, or call the OpenAI-compatible
+              local API from any language. Streaming, tool calls, and
+              structured output work the same as the hosted runtimes
+              your app already targets.
+            </p>
+            <div class="tag-row">
+              <span class="tag">http://localhost:11434</span>
+            </div>
+          </article>
+
+          <article class="card">
+            <svg
+              class="feature-icon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.6"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <circle cx="6" cy="6" r="2" />
+              <circle cx="18" cy="6" r="2" />
+              <circle cx="6" cy="18" r="2" />
+              <circle cx="18" cy="18" r="2" />
+              <path d="M8 6h8M8 18h8M6 8v8M18 8v8" />
+            </svg>
+            <h3>Plug it in</h3>
+            <p class="body-muted body-sm">
+              Drop Ollama behind the agent framework, IDE plugin, or
+              chat client you already use — LangChain, OpenWebUI,
+              Continue, your homegrown CLI. The runtime stays out of
+              the way.
+            </p>
+            <div class="tag-row">
+              <span class="tag">langchain</span>
+              <span class="tag">opencode</span>
+              <span class="tag">continue</span>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <!-- ════════════════════════════════════════════════════════════
+           FORM — pill input + black pill submit. Exercises .field,
+           input :focus-visible, .btn-primary (reused), .field-help.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="signup" aria-labelledby="signup-heading">
+        <div class="signup">
+          <div class="stack-4">
+            <p class="eyebrow">stay close to the work</p>
+            <h2 id="signup-heading" style="max-width: 16ch;">
+              Get a note when a new model lands.
+            </h2>
+            <p class="body-muted">
+              Roughly one email a month — release notes for new models,
+              changelog highlights, and the occasional benchmark. No
+              marketing, no upsells, unsubscribe in one click.
+            </p>
+          </div>
+
+          <form class="signup-form" onsubmit="event.preventDefault();">
+            <div class="signup-row">
+              <div class="field">
+                <label for="signup-email" class="body-sm">Email</label>
+                <input
+                  id="signup-email"
+                  type="email"
+                  placeholder="you@your-machine.local"
+                  autocomplete="email"
+                  required
+                />
+              </div>
+              <button type="submit" class="btn btn-primary" style="align-self: end;">
+                Subscribe
+              </button>
+            </div>
+            <p class="field-help">
+              We use the address only to send release notes. See the
+              <a href="#privacy" class="text-link">privacy note</a>.
+            </p>
+          </form>
+        </div>
+
+        <div class="footnote">
+          <span>© Ollama · run open models locally</span>
+          <span>v0.5.0 · <a href="#changelog" class="text-link" style="color: inherit;">changelog</a></span>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/ollama/tokens.css
+++ b/design-systems/ollama/tokens.css
@@ -1,0 +1,242 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/ollama/tokens.css
+ *
+ * Structured token bindings for "Ollama" — radical minimalism for the
+ * local-LLM runtime. The brand strips every form of decoration away
+ * until only the essential tool remains: pure-white canvas, zero
+ * chromatic color anywhere on screen, no shadows ever, and a binary
+ * radius system that separates "container" (12px) from "interactive"
+ * (pill / 9999px). DESIGN.md is emphatic on every front — the absence
+ * of design IS the design.
+ *
+ * Agents are expected to paste the `:root { ... }` block verbatim
+ * into the first `<style>` of every artifact they generate against
+ * this design system, then reference tokens via `var(--name)` from
+ * then on. The corresponding `components.html` mirrors this block
+ * with comments stripped; keep the two in sync byte-for-byte after
+ * normalization, or the `tokens-fixture-sync` guard will fail.
+ *
+ * Brand notes (the values below intentionally invert several
+ * assumptions baked into the default brand):
+ *
+ *   #Decision 1 — `--bg` is pure white, `--surface` is the lift.
+ *     Default does the opposite (cream bg, white surface) because
+ *     it wants card-lift warmth; ollama wants paper-flat purity, so
+ *     #ffffff is the canvas and #fafafa (Snow) is the subtle lift.
+ *
+ *   #Decision 2 — `--accent` is pure black, not a chromatic CTA hue.
+ *     Per DESIGN.md §2 the entire interface is grayscale; the only
+ *     chromatic exception is the keyboard focus ring (#3b82f6 at
+ *     50% alpha). The "Download" / "Create account" pills that
+ *     occupy the accent role are black-on-white, so the accent
+ *     token binds to #000 and accent-on binds to #fff.
+ *
+ *   #Decision 3 — every interactive radius collapses to pill.
+ *     DESIGN.md §5 prescribes a strictly binary radius system with
+ *     no intermediate steps. `--radius-sm`, `--radius-pill` (and
+ *     `--radius-lg` for consistency) all resolve to 9999px so any
+ *     component reaching for `--radius-sm` (button, input, tag,
+ *     chip) inherits the brand stance instead of a stray 8px.
+ *
+ *   #Decision 4 — every elevation tier is the hairline border ring,
+ *     never a blur shadow. DESIGN.md §6 is explicit: "Ollama uses
+ *     zero shadows. This is not an oversight — it's a deliberate
+ *     design decision." `--elev-raised` therefore mirrors
+ *     `--elev-ring` instead of binding to a blur drop-shadow.
+ *
+ *   #Decision 5 — display font is SF Pro Rounded. The rounded
+ *     terminals ARE the brand expression — they soften a developer
+ *     CLI tool into something approachable without compromising the
+ *     monochrome / minimal philosophy. Falls back to system-ui on
+ *     non-Apple platforms (the duplicate `system-ui` in the stack is
+ *     copied verbatim from DESIGN.md §3 to keep the prose ↔ token
+ *     mapping audit-trivial).
+ *
+ * Schema slot collapse (see _schema/AGENTS.md for the layer model):
+ *
+ *   --surface-warm aliases --surface — the canvas is grayscale by
+ *     definition, so there is no warm tertiary surface tier.
+ *   --border-soft aliases --border — DESIGN.md §6 prescribes a single
+ *     1px hairline weight; row separators and card edges share it.
+ *   --fg-2 / --meta bind to real values — ollama is monochrome but
+ *     differentiates 4 text levels (black / near-black / Stone /
+ *     Silver) so the ramp earns independent slots.
+ *
+ * Keep this file additive: never invent token names not also
+ * documented in DESIGN.md or the craft contracts. Ollama is not in
+ * BRAND_EXTENSIONS, so any unknown token will fail the
+ * `unknown-token-allowlist` guard.
+ * ─────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface (3 levels) ────────────────────────────────────────
+   * Pure white IS the brand canvas — DESIGN.md §2 is emphatic:
+   * "not off-white, not cream, pure white." `--surface` lifts to
+   * Snow (#fafafa), the subtlest possible distinction from #fff,
+   * for sections and barely-elevated containers. No third tier:
+   * `--surface-warm` aliases to surface because the brand is
+   * grayscale by definition. */
+  --bg: #ffffff;
+  --surface: #fafafa;
+  --surface-warm: var(--surface);   /* alias — ollama is monochrome */
+
+  /* ─── Foreground ramp (4 levels) ────────────────────────────────
+   * The full grayscale text ramp from DESIGN.md §2:
+   *   Pure Black  (#000000) — primary headlines, demanding attention
+   *   Near Black  (#262626) — button text, secondary headline weight
+   *   Stone       (#737373) — body, footer links, de-emphasized copy
+   *   Silver      (#a3a3a3) — placeholders, tertiary metadata
+   * The contrast between black and Stone is wide enough that the
+   * brand can avoid font-weight ≥600 entirely. */
+  --fg: #000000;
+  --fg-2: #262626;                  /* Near Black */
+  --muted: #737373;                 /* Stone */
+  --meta: #a3a3a3;                  /* Silver */
+
+  /* ─── Border (2 levels) ─────────────────────────────────────────
+   * Light Gray (#e5e5e5) is the workhorse containment color and
+   * the only border weight ollama permits. DESIGN.md §7 forbids
+   * borders heavier than 1px; `--border-soft` aliases to keep that
+   * stance intact for components that reach for a softer divider. */
+  --border: #e5e5e5;
+  --border-soft: var(--border);     /* alias — single border weight */
+
+  /* ─── Accent ────────────────────────────────────────────────────
+   * Pure Black IS the accent here — the black-pill CTA ("Download",
+   * "Create account") is ollama's maximum-emphasis element. DESIGN.md
+   * §2 forbids chromatic color in normal flow, so the accent role
+   * is fulfilled by the darkest tone rather than a brand hue.
+   *
+   * Hover and active states LIGHTEN rather than darken (pure black
+   * cannot darken further). The values come from DESIGN.md §2's
+   * documented Near-Black (#262626) and Button-Text-Dark (#404040)
+   * stops on the gray ramp, so the hover stack stays on-brand
+   * instead of formula-derived. */
+  --accent: #000000;
+  --accent-on: #ffffff;
+  --accent-hover: #262626;          /* Near Black — subtle lift */
+  --accent-active: #404040;         /* Button Text Dark — pressed */
+
+  /* ─── Semantic ──────────────────────────────────────────────────
+   * DESIGN.md §2 explicitly says "no semantic red, no accent green"
+   * in normal flow — but the schema requires these tokens for error
+   * toasts and status indicators that the runtime will eventually
+   * surface (model download failures, daemon health checks). Bound
+   * to the schema fallbacks so the names resolve; components must
+   * use them sparingly and never as decoration. */
+  --success: #16a34a;
+  --warn: #eab308;
+  --danger: #dc2626;
+
+  /* ─── Typography — fonts ────────────────────────────────────────
+   * SF Pro Rounded is Apple's rounded system font — its softened
+   * letterforms ARE the brand expression. Renders rounded terminals
+   * on macOS/iOS, falls back to the platform system sans elsewhere
+   * (the duplicate `system-ui` in the stack mirrors DESIGN.md §3
+   * verbatim — redundant but documented).
+   *
+   * Body text uses ui-sans-serif so reading copy stays platform-
+   * native; the emoji fonts in the stack come straight from DESIGN.md
+   * §3's body fallback list. Monospace gets a deliberately broad
+   * stack so `ollama run …` snippets render consistently across
+   * macOS / Linux / Windows. */
+  --font-display: "SF Pro Rounded", system-ui, -apple-system, system-ui;
+  --font-body: ui-sans-serif, system-ui, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+
+  /* Type scale (px) — direct copy of DESIGN.md §3 hierarchy table.
+   * Ollama's display tier tops out at 48px (versus default's 64px)
+   * because the homepage is intentionally short and uncluttered;
+   * even the hero stays restrained. */
+  --text-xs: 12px;                  /* Small */
+  --text-sm: 14px;                  /* Caption */
+  --text-base: 16px;                /* Body / Link */
+  --text-lg: 18px;                  /* Body Large */
+  --text-xl: 24px;                  /* Card Title */
+  --text-2xl: 30px;                 /* Sub-heading */
+  --text-3xl: 36px;                 /* Section Heading */
+  --text-4xl: 48px;                 /* Display / Hero */
+
+  /* Leading & tracking — DESIGN.md §3 prescribes tight (1.0) for
+   * display and comfortable (1.5) for body. Tracking is `normal`
+   * across every tier (no negative letter-spacing on display, no
+   * uppercase tightening). */
+  --leading-body: 1.5;
+  --leading-tight: 1;
+  --tracking-display: 0;
+
+  /* ─── Spacing ────────────────────────────────────────────────────
+   * 4px base unit. DESIGN.md §5 defines an extended scale up to
+   * 112px for section rhythm; the shared schema caps at --space-12
+   * so the wider tiers express themselves through the section-y
+   * tokens below. */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+
+  /* DESIGN.md §5 is direct — section vertical spacing is "very
+   * generous (88–112px)" because "the white space IS the brand."
+   * Desktop sits at the top of that range deliberately; tablet and
+   * phone collapse but stay roomy. */
+  --section-y-desktop: 112px;
+  --section-y-tablet: 88px;
+  --section-y-phone: 48px;
+
+  /* ─── Radius (binary system) ───────────────────────────────────
+   * DESIGN.md §5 prescribes a strictly binary radius system: 12px
+   * for containers, 9999px (pill) for everything interactive. No
+   * intermediate values exist on this brand. Every interactive
+   * radius — `--radius-sm`, `--radius-lg`, `--radius-pill` —
+   * resolves to the pill value so a component reaching for the
+   * small button radius inherits the brand stance. `--radius-md`
+   * holds the 12px container radius. */
+  --radius-sm: 9999px;
+  --radius-md: 12px;
+  --radius-lg: 9999px;
+  --radius-pill: 9999px;
+
+  /* ─── Elevation ────────────────────────────────────────────────
+   * "Ollama uses zero shadows. This is not an oversight — it's a
+   * deliberate design decision." (DESIGN.md §6) Every level of
+   * depth comes from a 1px hairline border ring instead of a blur
+   * shadow. `--elev-raised` mirrors `--elev-ring` so components
+   * targeting a raised tier still receive the only legitimate
+   * depth treatment ollama permits. */
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised: 0 0 0 1px var(--border);
+
+  /* ─── Focus ring ───────────────────────────────────────────────
+   * The single chromatic exception in the entire system — Tailwind's
+   * default ring (#3b82f6 at 50% transparency). DESIGN.md §2 explicitly
+   * carves this out for keyboard accessibility; never visible during
+   * normal interaction flow. The raw hex is documented inside the
+   * token expression so brand-aware components can stay grayscale
+   * elsewhere. */
+  --focus-ring: 0 0 0 3px color-mix(in oklab, #3b82f6, transparent 50%);
+
+  /* ─── Motion ───────────────────────────────────────────────────
+   * DESIGN.md §7 is direct: "interactions should feel instant and
+   * direct." Durations stay short enough that transitions register
+   * as responsiveness rather than animation. The easing curve stays
+   * on the standard ease-out so the snap still feels mechanical
+   * rather than abrupt. */
+  --motion-fast: 100ms;
+  --motion-base: 140ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+  /* ─── Layout ───────────────────────────────────────────────────
+   * Max container width sits at the upper end of DESIGN.md §5's
+   * "~1024–1280px" range; gutters scale down through the breakpoints
+   * but stay generous to preserve the "white space IS the brand"
+   * stance. */
+  --container-max: 1280px;
+  --container-gutter-desktop: 24px;
+  --container-gutter-tablet: 16px;
+  --container-gutter-phone: 12px;
+}

--- a/design-systems/perplexity/components.html
+++ b/design-systems/perplexity/components.html
@@ -1,0 +1,455 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Perplexity — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/perplexity. Every visible
+        value comes from tokens.css. Perplexity's signature moves: flat
+        near-black canvas, Inter for UI, JetBrains Mono for citations,
+        purple accent used once per view, hairline borders instead of
+        drop shadows, answer-first single-column layout."
+    />
+
+    <style>
+      :root {
+        --bg:           #0f0f10;
+        --surface:      #19191a;
+        --surface-warm: var(--surface);
+
+        --fg:   #f0f0f0;
+        --fg-2: var(--fg);
+        --muted: #9b9b9b;
+        --meta:  #5c5c5e;
+
+        --border:      #2e2e30;
+        --border-soft: #232325;
+
+        --accent:        #a855f7;
+        --accent-on:     #ffffff;
+        --accent-hover:  #c084fc;
+        --accent-active: #9333ea;
+
+        --success: #22c55e;
+        --warn:    #f59e0b;
+        --danger:  #ef4444;
+
+        --font-display: "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        --font-body:    "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        --font-mono:    "JetBrains Mono", ui-monospace, "Cascadia Code", Menlo, Monaco, Consolas, monospace;
+
+        --text-xs:   11px;
+        --text-sm:   13px;
+        --text-base: 15px;
+        --text-lg:   16px;
+        --text-xl:   18px;
+        --text-2xl:  22px;
+        --text-3xl:  28px;
+        --text-4xl:  32px;
+
+        --leading-body:     1.65;
+        --leading-tight:    1.2;
+        --tracking-display: -0.01em;
+
+        --space-1:  4px;
+        --space-2:  8px;
+        --space-3:  12px;
+        --space-4:  16px;
+        --space-5:  20px;
+        --space-6:  24px;
+        --space-8:  32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 64px;
+        --section-y-tablet:  48px;
+        --section-y-phone:   32px;
+
+        --radius-sm:   4px;
+        --radius-md:   8px;
+        --radius-lg:   12px;
+        --radius-pill: 9999px;
+
+        --elev-flat:   none;
+        --elev-ring:   0 0 0 1px var(--border);
+        --elev-raised: 0 0 0 1px var(--border);
+
+        --focus-ring: 0 0 0 2px var(--accent);
+
+        --motion-fast:   120ms;
+        --motion-base:   200ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+        --container-max:            1100px;
+        --container-gutter-desktop: 24px;
+        --container-gutter-tablet:  16px;
+        --container-gutter-phone:   16px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        *, *::before, *::after { transition: none !important; animation: none !important; }
+      }
+
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      section + section { border-top: 1px solid var(--border); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography ─────────────────────────── */
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        margin: 0;
+        color: var(--fg);
+        font-weight: 600;
+        line-height: var(--leading-tight);
+      }
+      h1 {
+        font-size: var(--text-4xl);
+        letter-spacing: var(--tracking-display);
+      }
+      h2 {
+        font-size: var(--text-2xl);
+        line-height: 1.3;
+      }
+      h3 {
+        font-size: var(--text-xl);
+        line-height: 1.4;
+      }
+      p { margin: 0; }
+      .lead {
+        font-size: var(--text-lg);
+        line-height: 1.6;
+        color: var(--muted);
+        font-weight: 400;
+        max-width: 60ch;
+      }
+      .body-muted { color: var(--muted); }
+      .body-sm { font-size: var(--text-sm); color: var(--muted); }
+      .eyebrow {
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        font-weight: 400;
+        color: var(--muted);
+        letter-spacing: 0.04em;
+      }
+      code, .mono {
+        font-family: var(--font-mono);
+        font-size: 0.92em;
+        color: var(--fg);
+      }
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-5 > * + * { margin-block-start: var(--space-5); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+
+      /* ─── Buttons ─────────────────────────────── */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 10px 20px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        font-weight: 500;
+        line-height: 1;
+        cursor: pointer;
+        border: 1px solid transparent;
+        transition: background-color var(--motion-fast) var(--ease-standard),
+                    border-color var(--motion-fast) var(--ease-standard);
+        text-decoration: none;
+      }
+      .btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+      .btn-primary {
+        background: var(--accent);
+        color: var(--accent-on);
+      }
+      .btn-primary:hover  { background: var(--accent-hover); }
+      .btn-primary:active { background: var(--accent-active); }
+      .btn-ghost {
+        background: transparent;
+        color: var(--fg);
+        border-color: var(--border);
+      }
+      .btn-ghost:hover { background: var(--border-soft); }
+
+      /* ─── Source badge — DESIGN.md §6 ─────────── */
+      .source-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-1);
+        padding: 3px 8px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        color: var(--muted);
+        text-decoration: none;
+      }
+      .source-badge::before {
+        content: "";
+        width: 6px;
+        height: 6px;
+        border-radius: var(--radius-pill);
+        background: var(--accent);
+        opacity: 0.55;
+        flex-shrink: 0;
+      }
+
+      /* ─── Tab bar — DESIGN.md §6 ────────────── */
+      .tabbar {
+        display: flex;
+        gap: var(--space-5);
+        border-bottom: 1px solid var(--border);
+        padding-block-end: var(--space-3);
+        margin-block-end: var(--space-5);
+      }
+      .tab {
+        font-size: var(--text-sm);
+        color: var(--muted);
+        padding-block-end: var(--space-2);
+        border-bottom: 2px solid transparent;
+        margin-bottom: -1px;
+        cursor: pointer;
+        font-weight: 500;
+      }
+      .tab[aria-current="page"] {
+        color: var(--fg);
+        border-bottom-color: var(--accent);
+      }
+
+      /* ─── Cards (answer + source) ───────────── */
+      .card {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        padding: var(--space-5);
+        box-shadow: var(--elev-flat);
+        transition: background-color var(--motion-fast) var(--ease-standard);
+      }
+      .card:hover { background: var(--border-soft); }
+
+      /* ─── Search field — DESIGN.md §5 ────────── */
+      .search {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        padding: 12px 16px;
+        transition: border-color var(--motion-fast) var(--ease-standard);
+      }
+      .search:focus-within { border-color: var(--accent); }
+      .search input {
+        flex: 1;
+        background: transparent;
+        border: none;
+        outline: none;
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: 1.4;
+      }
+      .search input::placeholder { color: var(--meta); }
+      .search-submit {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 28px;
+        height: 28px;
+        background: transparent;
+        border: none;
+        border-radius: var(--radius-sm);
+        color: var(--muted);
+        cursor: pointer;
+        transition: color var(--motion-fast) var(--ease-standard);
+      }
+      .search:focus-within .search-submit { color: var(--accent); }
+
+      .field { display: flex; flex-direction: column; gap: var(--space-2); }
+      .field label {
+        font-size: var(--text-sm);
+        font-weight: 500;
+        color: var(--fg);
+      }
+      .field input {
+        background: var(--surface);
+        color: var(--fg);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        padding: 10px 14px;
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        outline: none;
+        transition: border-color var(--motion-fast) var(--ease-standard);
+      }
+      .field input::placeholder { color: var(--meta); }
+      .field input:focus { border-color: var(--accent); }
+
+      /* ─── Layout ─────────────────────────────── */
+      .hero-grid {
+        display: grid;
+        grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+        gap: var(--space-12);
+        align-items: start;
+      }
+      @media (max-width: 1023px) { .hero-grid { grid-template-columns: 1fr; } }
+      .features-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: var(--space-4);
+      }
+      @media (max-width: 1023px) { .features-grid { grid-template-columns: 1fr 1fr; } }
+      @media (max-width: 639px)  { .features-grid { grid-template-columns: 1fr; } }
+      .hero-actions { display: flex; gap: var(--space-3); margin-block-start: var(--space-5); flex-wrap: wrap; }
+      .source-row { display: flex; flex-wrap: wrap; gap: var(--space-2); }
+      .icon { width: 16px; height: 16px; flex-shrink: 0; }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <!-- HERO — answers, not links. DESIGN.md §5 answer-first pattern. -->
+      <section data-od-id="hero">
+        <div class="hero-grid">
+          <div class="stack-5">
+            <p class="eyebrow">perplexity / reference fixture</p>
+            <h1>Answers, not links.</h1>
+            <p class="lead">
+              Ask anything. Perplexity reads the sources, cites the
+              passage, and returns a single, grounded answer — no
+              ten-blue-links detour, no auto-play, no autoplaying anything.
+            </p>
+
+            <div class="search" role="search" aria-label="Ask Perplexity">
+              <span aria-hidden="true" style="color:var(--muted);display:inline-flex">
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                     stroke-width="1.5" stroke-linecap="square" stroke-linejoin="miter" aria-hidden="true">
+                  <circle cx="11" cy="11" r="7"/>
+                  <path d="M20 20l-3.5-3.5"/>
+                </svg>
+              </span>
+              <input type="text" placeholder="Ask anything." aria-label="Ask Perplexity" />
+              <button type="button" class="search-submit" aria-label="Submit query">
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                     stroke-width="1.5" stroke-linecap="square" stroke-linejoin="miter" aria-hidden="true">
+                  <path d="M5 12h14M13 6l6 6-6 6"/>
+                </svg>
+              </button>
+            </div>
+
+            <div class="hero-actions">
+              <a href="./tokens.css" class="btn btn-primary">Search</a>
+              <a href="./DESIGN.md" class="btn btn-ghost">Read the spec</a>
+            </div>
+          </div>
+
+          <aside class="card">
+            <div class="tabbar" role="tablist">
+              <span class="tab" aria-current="page" role="tab">Answer</span>
+              <span class="tab" role="tab">Sources</span>
+              <span class="tab" role="tab">Steps</span>
+            </div>
+            <p class="eyebrow" style="margin-bottom:var(--space-3)">Q · who first measured the speed of light?</p>
+            <p style="color:var(--fg)">
+              Ole Rømer, in 1676, by timing eclipses of Jupiter's moon Io as
+              Earth moved toward and away from Jupiter — a delay of
+              <code>~22 min</code> across the orbit yielded the first
+              finite estimate.
+            </p>
+            <div class="source-row" style="margin-block-start:var(--space-4)">
+              <a class="source-badge" href="#"><span class="mono">nature.com</span></a>
+              <a class="source-badge" href="#"><span class="mono">en.wikipedia.org</span></a>
+              <a class="source-badge" href="#"><span class="mono">aps.org</span></a>
+              <a class="source-badge" href="#"><span class="mono">arxiv.org</span></a>
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <!-- FEATURES — three quiet propositions, no decorative imagery. -->
+      <section data-od-id="features">
+        <div class="stack-3" style="margin-bottom:var(--space-6)">
+          <p class="eyebrow">what this fixture exercises</p>
+          <h2>Quiet by design.</h2>
+        </div>
+
+        <div class="features-grid">
+          <article class="card stack-3">
+            <h3>Cited</h3>
+            <p class="body-sm">
+              Every factual claim is attributed. Source badges sit
+              beneath the answer in <code>JetBrains Mono</code>, sentence
+              case, never decorative.
+            </p>
+          </article>
+          <article class="card stack-3">
+            <h3>Grounded</h3>
+            <p class="body-sm">
+              Flat <code>#0f0f10</code> canvas with three luminance
+              steps. No gradient hero, no animated blob — the chrome
+              recedes, the answer leads.
+            </p>
+          </article>
+          <article class="card stack-3">
+            <h3>Restrained</h3>
+            <p class="body-sm">
+              Purple <code>#a855f7</code> appears once per view: the
+              primary action. Borders before shadows, content before
+              motion.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <!-- FORM — direct copy, no apology. DESIGN.md §8 voice. -->
+      <section data-od-id="form">
+        <div style="display:grid;grid-template-columns:minmax(0,1.2fr) minmax(0,1fr);gap:var(--space-12);align-items:start">
+          <div class="stack-4">
+            <p class="eyebrow">form components</p>
+            <h2>Keep the signal in.</h2>
+            <p class="lead">
+              Sign in to keep your threads, follow-ups, and saved sources
+              across devices. No newsletter trickery, no marketing checkbox
+              defaulted on.
+            </p>
+          </div>
+          <form style="display:flex;flex-direction:column;gap:var(--space-4);max-width:420px"
+                onsubmit="event.preventDefault()">
+            <div class="field">
+              <label for="email">Email</label>
+              <input id="email" type="email" placeholder="you@domain.com" />
+            </div>
+            <div style="display:flex;gap:var(--space-3);margin-top:var(--space-2)">
+              <button type="submit" class="btn btn-primary">Continue</button>
+              <button type="button" class="btn btn-ghost">Use a passkey</button>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/perplexity/tokens.css
+++ b/design-systems/perplexity/tokens.css
@@ -1,0 +1,151 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/perplexity/tokens.css
+ *
+ * Structured token bindings for the "Perplexity" brand — the research-
+ * terminal voice of a conversational AI search engine.
+ *
+ * Brand identity in three sentences:
+ *   1. Dark canvas as the native medium — a flat near-black (#0f0f10)
+ *      that recedes so citations, sources, and the answer column lead;
+ *      depth is three luminance steps (base → surface → elevated), never
+ *      shadow.
+ *   2. Inter for all UI and reading, JetBrains Mono for code and
+ *      citations; weight 600 is the cap for display (700 reads too
+ *      thin against #0f0f10), generous 1.65 body leading for dense
+ *      research paragraphs.
+ *   3. A single chromatic accent — Perplexity Purple (#a855f7) —
+ *      reserved for the primary CTA and active focus state; everything
+ *      else is grayscale. Color appears once per view, never twice.
+ *
+ * Schema decisions:
+ *   - --bg: #0f0f10 (page background, anti-gradient flat).
+ *   - --surface: #19191a (card / sidebar surface).
+ *   - --surface-warm aliases --surface — dark achromatic system, no warm
+ *     tier; the third luminance step (#232325) lives in --border-soft so
+ *     hover/elevated states can borrow it without inventing a token.
+ *   - --fg: #f0f0f0 (near-white, not pure white — prevents eye strain).
+ *   - --fg-2 aliases --fg — DESIGN.md §2 lists a single primary text
+ *     color; secondary lives in --muted, tertiary in --meta.
+ *   - --border: #2e2e30; --border-soft: #232325 (also the elevated tier).
+ *   - --accent: #a855f7 (purple); --accent-hover: #c084fc;
+ *     --accent-active: #9333ea (darker pressed — one step down the
+ *     violet scale, since DESIGN.md does not name an active value).
+ *   - --tracking-display: -0.01em (Inter at 32px tightens slightly).
+ *   - --radius-sm: 4px; --radius-md: 8px; --radius-lg: 12px (DESIGN.md §4).
+ *   - --elev-raised: hairline ring only — DESIGN.md §6 §9 forbids
+ *     drop shadows; elevation is communicated through border contrast.
+ *   - --motion-fast: 120ms (DESIGN.md §7 hover), --motion-base: 200ms
+ *     (modal); ease-out flavored cubic-bezier per DESIGN.md guidance.
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface ──────────────────────────────────────────────────── */
+  --bg:           #0f0f10;              /* flat near-black canvas — no gradient */
+  --surface:      #19191a;              /* card / sidebar / search bar fill */
+  --surface-warm: var(--surface);       /* no warm tier in dark achromatic system */
+
+  /* ─── Foreground ───────────────────────────────────────────────── */
+  --fg:   #f0f0f0;                      /* near-white — body copy, headings */
+  --fg-2: var(--fg);                    /* DESIGN.md §2 has a single primary tier */
+  --muted: #9b9b9b;                     /* secondary — meta, captions, labels */
+  --meta:  #5c5c5e;                     /* tertiary — placeholder, disabled */
+
+  /* ─── Border ───────────────────────────────────────────────────── */
+  --border:      #2e2e30;               /* divider, input border, card edge */
+  --border-soft: #232325;               /* inner row separator + elevated tier */
+
+  /* ─── Accent ───────────────────────────────────────────────────── */
+  --accent:        #a855f7;             /* Perplexity purple — sole chromatic color */
+  --accent-on:     #ffffff;             /* white on accent for buttons / badges */
+  --accent-hover:  #c084fc;             /* lighter violet hover */
+  --accent-active: #9333ea;             /* darker pressed — derived, DESIGN.md silent */
+
+  /* ─── Semantic ─────────────────────────────────────────────────── */
+  --success: #22c55e;                   /* verified source badge */
+  --warn:    #f59e0b;                   /* caution */
+  --danger:  #ef4444;                   /* error state */
+
+  /* ─── Typography ───────────────────────────────────────────────── */
+  /* Inter for UI/body/display (weight 600 cap at display sizes).
+     JetBrains Mono for code, citations, inline tags. */
+  --font-display: "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-body:    "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-mono:    "JetBrains Mono", ui-monospace, "Cascadia Code", Menlo, Monaco, Consolas, monospace;
+
+  /* Type scale — DESIGN.md §3.
+   * 4xl=32 display, 3xl=22 heading-l, 2xl=18 heading-m, lg=16 reading-large,
+   * base=15 body, sm=13 body-sm, xs=11 caption. The 3xl/2xl→xl gap (16) is
+   * the natural reading-large bridge for source-card titles. */
+  --text-xs:   11px;                    /* caption — source labels, timestamps */
+  --text-sm:   13px;                    /* body-sm — secondary, meta */
+  --text-base: 15px;                    /* body — primary reading copy */
+  --text-lg:   16px;                    /* reading-large — source card titles */
+  --text-xl:   18px;                    /* heading-m — sub-section heading */
+  --text-2xl:  22px;                    /* heading-l — section heading */
+  --text-3xl:  28px;                    /* sub-display — intermediate hero step */
+  --text-4xl:  32px;                    /* display — page title, hero answer */
+
+  /* Leading + tracking.
+   * --leading-body=1.65: dense research paragraphs (DESIGN.md §3 body).
+   * --leading-tight=1.2: display compression (DESIGN.md display row).
+   * --tracking-display=-0.01em: Inter at 32px tightens subtly; never stretch. */
+  --leading-body:     1.65;
+  --leading-tight:    1.2;
+  --tracking-display: -0.01em;
+
+  /* ─── Spacing ──────────────────────────────────────────────────── */
+  /* 8px base unit (DESIGN.md §4). Schema spine maps the key stops;
+     DESIGN.md's 48/64 page/above-fold tiers ride --space-12 and the
+     section-y tokens below. */
+  --space-1:  4px;
+  --space-2:  8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  20px;
+  --space-6:  24px;
+  --space-8:  32px;
+  --space-12: 48px;
+
+  /* Section rhythm — DESIGN.md §4: 48px page-level, 64px above-fold. */
+  --section-y-desktop: 64px;
+  --section-y-tablet:  48px;
+  --section-y-phone:   32px;
+
+  /* ─── Radius ───────────────────────────────────────────────────── */
+  /* DESIGN.md §4: 4 tag, 8 input/card, 12 modal/popover. Pill for
+     avatars/tags only — never on cards (DESIGN.md §9 anti-pattern). */
+  --radius-sm:   4px;
+  --radius-md:   8px;
+  --radius-lg:   12px;
+  --radius-pill: 9999px;
+
+  /* ─── Elevation ────────────────────────────────────────────────── */
+  /* DESIGN.md §6 §9: no drop shadows. Elevation = border contrast.
+     --elev-raised intentionally collapses to a hairline ring — the
+     visual lift comes from the background stepping to #232325 in
+     the consuming rule, not from a cast shadow. */
+  --elev-flat:   none;
+  --elev-ring:   0 0 0 1px var(--border);
+  --elev-raised: 0 0 0 1px var(--border);
+
+  /* ─── Focus ────────────────────────────────────────────────────── */
+  /* DESIGN.md §5 search bar: --accent 2px outline, no box-shadow halo. */
+  --focus-ring: 0 0 0 2px var(--accent);
+
+  /* ─── Motion ───────────────────────────────────────────────────── */
+  /* DESIGN.md §7: hover 120ms, modal 200ms; anti-animation brand.
+     Easing reads as "ease-out-like" (cubic-bezier(0.2, 0, 0, 1)) since
+     DESIGN.md prescribes ease-out for panel/modal openers. */
+  --motion-fast:   120ms;
+  --motion-base:   200ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+  /* ─── Layout ───────────────────────────────────────────────────── */
+  /* DESIGN.md §4: 1100px full-page shell (answer column 720px lives
+     inline in components that want the reading width). Gutter 16px
+     on phone matches DESIGN.md's stated side margin. */
+  --container-max:            1100px;
+  --container-gutter-desktop: 24px;
+  --container-gutter-tablet:  16px;
+  --container-gutter-phone:   16px;
+}

--- a/design-systems/posthog/components.html
+++ b/design-systems/posthog/components.html
@@ -1,0 +1,827 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>PostHog — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/posthog. Every visible
+        value comes from tokens.css; the page itself honors PostHog's
+        rules — warm parchment surfaces, olive-tinted text, IBM Plex
+        Sans bold headings, sage-bordered cards with no shadow, and the
+        signature hover orange (#F54E00) that flashes on interaction."
+    />
+
+    <style>
+      /* :root paste — sourced verbatim from design-systems/posthog/tokens.css.
+         Comments stripped per the design-system token-fixture sync contract. */
+      :root {
+        --bg: #fdfdf8;
+        --surface: #eeefe9;
+        --surface-warm: #e5e7e0;
+
+        --fg: #4d4f46;
+        --fg-2: #23251d;
+        --muted: #65675e;
+        --meta: #9ea096;
+
+        --border: #bfc1b7;
+        --border-soft: color-mix(in oklab, var(--border), var(--bg) 50%);
+
+        --accent: #F54E00;
+        --accent-on: #ffffff;
+        --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+        --success: #16a34a;
+        --warn: #F7A501;
+        --danger: #dc2626;
+
+        --font-display: "IBM Plex Sans Variable", "IBM Plex Sans", -apple-system, system-ui, "Avenir Next", Avenir, "Segoe UI", "Helvetica Neue", Helvetica, Ubuntu, Roboto, Noto, Arial, sans-serif;
+        --font-body: "IBM Plex Sans Variable", "IBM Plex Sans", -apple-system, system-ui, "Avenir Next", Avenir, "Segoe UI", "Helvetica Neue", Helvetica, Ubuntu, Roboto, Noto, Arial, sans-serif;
+        --font-mono: "Source Code Pro", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+
+        --text-xs: 12px;
+        --text-sm: 14px;
+        --text-base: 16px;
+        --text-lg: 20px;
+        --text-xl: 24px;
+        --text-2xl: 30px;
+        --text-3xl: 36px;
+        --text-4xl: 44px;
+
+        --leading-body: 1.5;
+        --leading-tight: 1.2;
+        --tracking-display: -0.025em;
+
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 48px;
+        --section-y-tablet: 32px;
+        --section-y-phone: 24px;
+
+        --radius-sm: 4px;
+        --radius-md: 6px;
+        --radius-lg: 8px;
+        --radius-pill: 9999px;
+
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised: 0px 25px 50px -12px rgba(0, 0, 0, 0.25);
+
+        --focus-ring: 0 0 0 3px rgba(59, 130, 246, 0.5);
+
+        --motion-fast: 150ms;
+        --motion-base: 200ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+        --container-max: 1280px;
+        --container-gutter-desktop: 24px;
+        --container-gutter-tablet: 16px;
+        --container-gutter-phone: 12px;
+      }
+
+      /* ─── Reset (minimal) ───────────────────────────────────────── */
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        font-weight: 400;
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+      }
+
+      /* ─── Layout primitives ─────────────────────────────────────── */
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      section + section { border-top: 1px solid var(--border); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography ────────────────────────────────────────────── */
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        margin: 0;
+        color: var(--fg-2);
+        line-height: var(--leading-tight);
+      }
+      h1 {
+        font-size: var(--text-4xl);
+        font-weight: 800;
+        letter-spacing: var(--tracking-display);
+      }
+      h2 {
+        font-size: var(--text-3xl);
+        font-weight: 700;
+        line-height: 1.2;
+      }
+      h3 {
+        font-size: var(--text-lg);
+        font-weight: 700;
+        line-height: 1.4;
+        letter-spacing: -0.01em;
+      }
+      p { margin: 0; }
+
+      .lede {
+        font-size: var(--text-lg);
+        line-height: 1.5;
+        color: var(--fg);
+        font-weight: 400;
+      }
+      .body-muted { color: var(--muted); }
+      .body-meta  { color: var(--meta); font-size: var(--text-sm); }
+      .body-sm    { font-size: var(--text-sm); }
+
+      .eyebrow {
+        font-family: var(--font-display);
+        font-size: var(--text-xs);
+        font-weight: 700;
+        line-height: 1.33;
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+
+      .stack-2 > * + * { margin-block-start: var(--space-2); }
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+
+      /* ─── Buttons ───────────────────────────────────────────────────
+       * Primary CTA is the Dark Primary from DESIGN.md §4 — near-black
+       * (--fg-2 territory) with white text and the brand's signature
+       * opacity-based hover (0.7) plus an Amber Gold text flash. Active
+       * scales slightly. Sage button uses --surface-warm and flashes
+       * PostHog Orange text on hover — the hidden brand signature. */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: var(--space-2);
+        padding: 10px 14px;
+        border: 1px solid transparent;
+        border-radius: var(--radius-sm);
+        font-family: var(--font-display);
+        font-size: var(--text-sm);
+        font-weight: 600;
+        line-height: 1.4;
+        cursor: pointer;
+        text-decoration: none;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard),
+          opacity var(--motion-fast) var(--ease-standard),
+          transform var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn:active        { transform: scale(0.98); }
+
+      .btn-primary {
+        background: var(--fg-2);
+        color: var(--bg);
+        padding: 10px 16px;
+        border-radius: var(--radius-md);
+      }
+      .btn-primary:hover  { opacity: 0.7; color: var(--warn); }
+      .btn-primary:active { opacity: 0.85; transform: scale(0.97); }
+
+      .btn-secondary {
+        background: var(--surface-warm);
+        color: var(--fg);
+        border-color: transparent;
+      }
+      .btn-secondary:hover { background: var(--surface); color: var(--accent); }
+
+      .btn-ghost {
+        background: transparent;
+        color: var(--fg);
+        border-color: var(--border);
+      }
+      .btn-ghost:hover { color: var(--accent); border-color: var(--fg); }
+
+      /* Hidden-orange link — the brand's signature interaction surprise.
+         Body links rest in --fg-2 with a sage underline that swaps to
+         orange on hover. DESIGN.md §1: "hover states flash PostHog
+         Orange — a hidden brand color that doesn't appear at rest". */
+      a {
+        color: var(--fg-2);
+        text-decoration: underline;
+        text-underline-offset: 3px;
+        text-decoration-thickness: 1px;
+        text-decoration-color: var(--border);
+        transition:
+          color var(--motion-fast) var(--ease-standard),
+          text-decoration-color var(--motion-fast) var(--ease-standard);
+      }
+      a:hover {
+        color: var(--accent);
+        text-decoration-color: var(--accent);
+      }
+      a:focus-visible {
+        outline: none;
+        box-shadow: var(--focus-ring);
+        border-radius: var(--radius-sm);
+      }
+
+      /* ─── Badges / pills ───────────────────────────────────────── */
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 4px 10px;
+        border-radius: var(--radius-pill);
+        font-family: var(--font-display);
+        font-size: var(--text-xs);
+        font-weight: 700;
+        line-height: 1.33;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+      .pill-soft {
+        background: var(--surface);
+        color: var(--fg-2);
+        border: 1px solid var(--border);
+      }
+      .pill-warn {
+        background: var(--surface);
+        color: var(--warn);
+        border: 1px solid var(--border);
+      }
+      .pill-status {
+        background: var(--surface-warm);
+        color: var(--fg-2);
+        text-transform: none;
+        letter-spacing: 0;
+      }
+      .pill-status .dot {
+        width: 6px; height: 6px;
+        border-radius: var(--radius-pill);
+        background: var(--success);
+      }
+
+      /* ─── Cards ─────────────────────────────────────────────────────
+       * Bordered cards per DESIGN.md §4 — Warm Parchment background,
+       * 1px Sage Border, 6px radius (--radius-md). No shadow at rest:
+       * DESIGN.md §6 reserves the only shadow for floating elements.
+       * Hover swaps the heading color to PostHog Orange to keep the
+       * "flash on interact" pattern alive across the system. */
+      .card {
+        background: var(--bg);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        padding: var(--space-5);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+        transition:
+          border-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard);
+      }
+      .card:hover { border-color: var(--fg); }
+      .card:hover h3 { color: var(--accent); }
+      .card-warm { background: var(--surface); border-color: var(--border); }
+
+      /* Floating panel — the ONE sanctioned shadow per DESIGN.md §6.
+         Used for the hero status panel and any modal/dropdown. */
+      .panel {
+        background: var(--bg);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        box-shadow: var(--elev-raised);
+        padding: var(--space-5);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+      }
+
+      /* ─── Inputs ────────────────────────────────────────────────────
+       * Default per DESIGN.md §4 Inputs & Forms: --surface (#eeefe9)
+       * background, sage placeholder, 1px sage border, 4px radius
+       * (--radius-sm). Focus swaps in the Focus Blue ring at 50%
+       * opacity from --focus-ring. Field value text uses --fg-2 for
+       * readability on the warm surface. */
+      .field {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+      }
+      .field label {
+        font-family: var(--font-display);
+        font-size: var(--text-sm);
+        font-weight: 600;
+        color: var(--fg-2);
+      }
+      .field input,
+      .field select,
+      .field textarea {
+        background: var(--surface);
+        color: var(--fg-2);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        padding: 10px 12px;
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: 1.4;
+        outline: none;
+        transition:
+          border-color var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .field input::placeholder { color: var(--meta); }
+      .field input:focus-visible,
+      .field select:focus-visible,
+      .field textarea:focus-visible {
+        border-color: var(--fg);
+        box-shadow: var(--focus-ring);
+      }
+      .field-help {
+        font-size: var(--text-xs);
+        color: var(--muted);
+        line-height: 1.4;
+      }
+
+      /* ─── Code / kbd ───────────────────────────────────────────── */
+      code, kbd, .mono {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+      }
+      kbd {
+        display: inline-block;
+        padding: 2px 6px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+        background: var(--surface);
+        color: var(--fg-2);
+        line-height: 1.2;
+        font-variant-numeric: tabular-nums;
+        font-weight: 500;
+      }
+      .code-block {
+        background: var(--surface);
+        border: 1px solid var(--border-soft);
+        border-radius: var(--radius-sm);
+        padding: var(--space-3) var(--space-4);
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        line-height: 1.5;
+        color: var(--fg-2);
+        overflow-x: auto;
+        white-space: pre;
+      }
+      .code-block .tok-cmt { color: var(--meta); }
+      .code-block .tok-fn  { color: var(--accent); }
+      .code-block .tok-str { color: var(--fg); }
+
+      /* ─── Distinctive: hedgehog mark ────────────────────────────────
+       * Hand-drawn Max-style hedgehog rendered as a thick-stroke SVG
+       * — the brand's anti-corporate signature per DESIGN.md §4 Image
+       * Treatment. Sketchy, deliberate, never polished. Reused in the
+       * hero panel, the nav lockup, and the empty-state form copy. */
+      .hedgehog {
+        color: var(--fg-2);
+      }
+
+      /* ─── Section-specific layout ──────────────────────────────── */
+      .nav-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding-block: var(--space-4);
+        gap: var(--space-4);
+      }
+      .nav-logo {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        font-family: var(--font-display);
+        font-size: var(--text-lg);
+        font-weight: 800;
+        color: var(--fg-2);
+        letter-spacing: -0.01em;
+        text-decoration: none;
+      }
+      .nav-logo:hover { color: var(--accent); text-decoration: none; }
+      .nav-links {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-6);
+      }
+      .nav-links a {
+        font-family: var(--font-display);
+        font-size: 15px;
+        font-weight: 600;
+        color: var(--fg-2);
+        text-decoration: none;
+      }
+      .nav-links a:hover { color: var(--accent); }
+
+      .hero-grid {
+        display: grid;
+        grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
+        gap: var(--space-12);
+        align-items: start;
+      }
+      @media (max-width: 1023px) {
+        .hero-grid { grid-template-columns: 1fr; gap: var(--space-8); }
+      }
+      .hero-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3);
+        margin-block-start: var(--space-6);
+      }
+      .hero-meta {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        margin-block-start: var(--space-4);
+        font-size: var(--text-sm);
+        color: var(--muted);
+      }
+      .hero-meta .dot {
+        width: 4px; height: 4px;
+        border-radius: var(--radius-pill);
+        background: var(--meta);
+      }
+
+      .features-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: var(--space-4);
+        margin-block-start: var(--space-6);
+      }
+      @media (max-width: 1023px) {
+        .features-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      }
+      @media (max-width: 639px) {
+        .features-grid { grid-template-columns: 1fr; }
+      }
+      .feature-tag {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        font-family: var(--font-display);
+        font-size: var(--text-xs);
+        font-weight: 700;
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+      }
+      .feature-tag::before {
+        content: "";
+        width: 6px; height: 6px;
+        background: var(--accent);
+        border-radius: var(--radius-pill);
+      }
+
+      .form-row {
+        display: grid;
+        grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+        gap: var(--space-12);
+        align-items: start;
+      }
+      @media (max-width: 1023px) {
+        .form-row { grid-template-columns: 1fr; }
+      }
+      .form {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+        padding: var(--space-6);
+        background: var(--bg);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+      }
+      .row-between {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-3);
+      }
+      .row-cluster {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        flex-wrap: wrap;
+      }
+      .divider-soft {
+        height: 1px;
+        background: var(--border-soft);
+        border: none;
+        margin: 0;
+      }
+      .icon { width: 16px; height: 16px; flex-shrink: 0; }
+      .trust-row {
+        display: flex;
+        align-items: center;
+        gap: var(--space-6);
+        flex-wrap: wrap;
+        color: var(--meta);
+        font-family: var(--font-display);
+        font-weight: 700;
+        font-size: var(--text-sm);
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <!-- ════════════════════════════════════════════════════════════
+           NAV — exercises: .nav-logo (hedgehog mark + wordmark with
+           orange hover), .nav-links (15px·600 with orange flash),
+           .btn-primary (Dark CTA per DESIGN.md §4 Navigation).
+      ═══════════════════════════════════════════════════════════════ -->
+      <nav class="nav-row" aria-label="Primary">
+        <a href="./DESIGN.md" class="nav-logo">
+          <svg class="hedgehog" width="28" height="28" viewBox="0 0 32 32"
+            fill="none" stroke="currentColor" stroke-width="1.75"
+            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M5 22c0-5 4-9 9-9s9 4 9 9" />
+            <path d="M3 22h22" />
+            <path d="M9 13l-2-3M12 11l-1-3M15 10l0-3M18 10l1-3M21 11l2-3M24 13l3-2" />
+            <circle cx="19" cy="18" r="0.9" fill="currentColor" />
+            <path d="M23 19l3 0M25 18l1 0.5" />
+          </svg>
+          PostHog
+        </a>
+        <div class="nav-links" role="navigation">
+          <a href="./tokens.css">Product</a>
+          <a href="./DESIGN.md">Docs</a>
+          <a href="./tokens.css">Pricing</a>
+          <a href="./DESIGN.md">Community</a>
+        </div>
+        <div class="row-cluster">
+          <a href="./tokens.css" class="btn btn-secondary">Log in</a>
+          <a href="./tokens.css" class="btn btn-primary">
+            Get started &mdash; free
+          </a>
+        </div>
+      </nav>
+
+      <!-- ════════════════════════════════════════════════════════════
+           HERO — exercises: .eyebrow, h1 (44px·800, -0.025em tracking),
+           .lede, .btn-primary / .btn-ghost / hidden-orange link hover,
+           hero status .panel (the one sanctioned shadow), .pill-status
+           with success dot, .pill-warn for the "1.0 incoming" pill,
+           kbd inline keyboard cues, .trust-row enterprise muted bar.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="hero">
+        <div class="hero-grid">
+          <div class="stack-4">
+            <p class="eyebrow">Reference fixture · posthog</p>
+            <h1 style="max-width: 18ch">
+              How engineers build better products.
+            </h1>
+            <p class="lede body-muted" style="max-width: 56ch">
+              PostHog is the open-source all-in-one platform for product
+              analytics, session replay, feature flags, A/B tests, and
+              the surveys you keep meaning to send. Built by engineers
+              who got tired of stitching together six SaaS dashboards
+              that all charge per-seat for the privilege.
+            </p>
+
+            <div class="hero-actions">
+              <a href="./tokens.css" class="btn btn-primary">
+                Get started &mdash; free
+                <svg class="icon" viewBox="0 0 24 24" fill="none"
+                  stroke="currentColor" stroke-width="1.75"
+                  stroke-linecap="round" stroke-linejoin="round"
+                  aria-hidden="true">
+                  <path d="M5 12h14M13 6l6 6-6 6" />
+                </svg>
+              </a>
+              <a href="./DESIGN.md" class="btn btn-ghost">
+                Read the docs
+              </a>
+            </div>
+
+            <div class="hero-meta">
+              <span>Self-host with <kbd>docker compose up</kbd></span>
+              <span class="dot" aria-hidden="true"></span>
+              <span>1M events/mo free</span>
+              <span class="dot" aria-hidden="true"></span>
+              <span>No credit card</span>
+            </div>
+
+            <hr class="divider-soft" style="margin-block: var(--space-6)" />
+
+            <p class="eyebrow">Trusted by engineering teams at</p>
+            <div class="trust-row" aria-label="Trusted by">
+              <span>Airbus</span>
+              <span>GOV.UK</span>
+              <span>Y&nbsp;Combinator</span>
+              <span>Hasura</span>
+              <span>Raycast</span>
+            </div>
+          </div>
+
+          <aside class="panel" aria-label="Live event stream">
+            <div class="row-between">
+              <span class="pill pill-soft">Live · last 60s</span>
+              <span class="pill pill-status">
+                <span class="dot" aria-hidden="true"></span>
+                Ingesting
+              </span>
+            </div>
+
+            <div class="stack-2">
+              <h3 style="line-height: 1.3">12,418 events</h3>
+              <p class="body-muted body-sm">
+                Across <strong style="color: var(--fg-2)">2,107</strong>
+                anonymous people, 38 countries, and one suspicious cron
+                in <code style="color: var(--accent)">us-east-1</code>.
+              </p>
+            </div>
+
+            <pre class="code-block" aria-label="Event payload"><span class="tok-cmt"># last event seen 0.4s ago</span>
+posthog.<span class="tok-fn">capture</span>(
+  distinct_id=<span class="tok-str">"max@hog.com"</span>,
+  event=<span class="tok-str">"button_clicked"</span>,
+  properties={
+    <span class="tok-str">"label"</span>: <span class="tok-str">"get_started"</span>,
+    <span class="tok-str">"$session_id"</span>: <span class="tok-str">"01HX…"</span>
+  }
+)</pre>
+
+            <div class="row-between">
+              <span class="body-sm body-muted">
+                <kbd>⌘</kbd> <kbd>K</kbd> to jump
+              </span>
+              <a href="./tokens.css" class="body-sm">View replay &rarr;</a>
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <!-- ════════════════════════════════════════════════════════════
+           FEATURES — exercises: .card (bordered, no shadow, 6px radius,
+           hover swaps title to PostHog Orange — the hidden brand
+           signature), .feature-tag (orange dot eyebrow), nested links
+           with sage-to-orange underline swap, .body-meta footer line.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="features">
+        <div class="stack-3">
+          <p class="eyebrow">What's in the box</p>
+          <h2 style="max-width: 28ch">
+            Every analytics tool a product engineer actually needs.
+          </h2>
+          <p class="body-muted" style="max-width: 60ch">
+            One database, one billing line, one set of definitions for
+            what an &ldquo;active user&rdquo; is. Hover any card to flash
+            the hidden brand orange &mdash; DESIGN.md §1 calls it the
+            signature interaction surprise.
+          </p>
+        </div>
+
+        <div class="features-grid">
+          <article class="card">
+            <span class="feature-tag">Analytics</span>
+            <h3>Product analytics that don't lie</h3>
+            <p class="body-muted body-sm">
+              Funnels, retention, paths, lifecycle &mdash; all built on
+              raw events you actually own. No sampling, no aggregated
+              hand-waving, no &ldquo;trust us, the dashboard is
+              right.&rdquo;
+            </p>
+            <a href="./tokens.css" class="body-sm">Explore funnels &rarr;</a>
+          </article>
+
+          <article class="card">
+            <span class="feature-tag">Replay</span>
+            <h3>Watch what your users actually did</h3>
+            <p class="body-muted body-sm">
+              Session replay with console logs, network requests, and
+              the rage clicks your support team have been complaining
+              about all week. Privacy masking on by default.
+            </p>
+            <a href="./tokens.css" class="body-sm">See a session &rarr;</a>
+          </article>
+
+          <article class="card">
+            <span class="feature-tag">Experiments</span>
+            <h3>Feature flags &amp; A/B tests</h3>
+            <p class="body-muted body-sm">
+              Ship a flag in five minutes, run an experiment in five
+              days, kill the bad arm in five seconds. Same data
+              warehouse as your analytics &mdash; the results never
+              disagree with the funnel.
+            </p>
+            <a href="./tokens.css" class="body-sm">Roll one out &rarr;</a>
+          </article>
+        </div>
+      </section>
+
+      <!-- ════════════════════════════════════════════════════════════
+           FORM — exercises: .field (sage-cream bg, sage border, Focus
+           Blue ring at 50%), .field-help, .btn-primary submit, code
+           inline, .pill-warn footer note. The right column reuses
+           .panel to show the email confirmation preview.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="form">
+        <div class="form-row">
+          <div class="stack-4">
+            <p class="eyebrow">Self-host or hosted</p>
+            <h2 style="max-width: 22ch">
+              Two clicks from zero to first event.
+            </h2>
+            <p class="body-muted" style="max-width: 52ch">
+              Drop us your work email and we&apos;ll send the install
+              command that fits your stack &mdash; <code>npm</code>,
+              <code>pnpm</code>, <code>pip</code>, <code>go get</code>,
+              or one truly heroic <code>curl | bash</code>. No
+              calendars, no &ldquo;quick chat&rdquo; bookings.
+            </p>
+
+            <hr class="divider-soft" />
+
+            <p class="body-meta">
+              By the way: PostHog is open source under MIT. The
+              hosted plan exists because someone has to pay the
+              S3 bill. Read the
+              <a href="./DESIGN.md">design spec</a> or
+              <a href="./tokens.css">browse the tokens</a>.
+            </p>
+          </div>
+
+          <form class="form" onsubmit="event.preventDefault();">
+            <div class="row-between">
+              <p class="eyebrow" style="color: var(--fg-2)">Start free</p>
+              <span class="pill pill-warn">1M events / mo</span>
+            </div>
+
+            <div class="field">
+              <label for="email">Work email</label>
+              <input id="email" type="email"
+                placeholder="ada@hedgehog.dev"
+                autocomplete="email" required />
+              <p class="field-help">
+                We&apos;ll never sell it. We&apos;ll barely even use it.
+              </p>
+            </div>
+
+            <div class="field">
+              <label for="company">Company</label>
+              <input id="company" type="text"
+                placeholder="The Cottage Garden Co."
+                autocomplete="organization" />
+            </div>
+
+            <div class="field">
+              <label for="stack">Where should we point you?</label>
+              <select id="stack">
+                <option>JavaScript / TypeScript</option>
+                <option>Python</option>
+                <option>Go</option>
+                <option>Ruby</option>
+                <option>iOS · Android</option>
+                <option>Just curious, send the marketing</option>
+              </select>
+              <p class="field-help">
+                We&apos;ll match the install snippet to your runtime.
+              </p>
+            </div>
+
+            <div class="row-cluster" style="margin-block-start: var(--space-2)">
+              <button type="submit" class="btn btn-primary">
+                Send the install command
+              </button>
+              <button type="button" class="btn btn-ghost">
+                Or self-host instead
+              </button>
+            </div>
+
+            <p class="body-sm body-muted" style="margin-block-start: var(--space-2)">
+              No credit card. No marketing automation gauntlet.
+              The hedgehog approves.
+            </p>
+          </form>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/posthog/tokens.css
+++ b/design-systems/posthog/tokens.css
@@ -1,0 +1,272 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/posthog/tokens.css
+ *
+ * Structured token bindings for the PostHog design system — the
+ * open-source product analytics brand whose marketing surface reads
+ * like a startup's internal wiki that escaped into the wild. Warm
+ * sage-cream surfaces, olive-tinted text, IBM Plex Sans at bold
+ * weights for headings, and a single PostHog Orange (#F54E00) that
+ * lives almost entirely on hover — a hidden brand signature that
+ * surprises on interaction rather than shouting at rest.
+ *
+ * This file pre-compiles the values described in `DESIGN.md` into the
+ * shared schema. Agents should paste the `:root { … }` block verbatim
+ * into the first `<style>` of any artifact, then resolve every value
+ * via `var(--*)` from that point on.
+ *
+ * Schema notes (brand-specific bindings worth flagging — section
+ * references point into `DESIGN.md`):
+ *
+ *   #Bind 1  — --bg is Warm Parchment (#fdfdf8), never pure white.
+ *              DESIGN.md §7 forbids #ffffff outright; the warm
+ *              yellow-green undertone is foundational and the
+ *              "don't use pure white" rule is in the Don'ts list.
+ *              --surface steps once to Sage Cream (#eeefe9) for
+ *              input fields and secondary containers, then
+ *              --surface-warm steps once more to Light Sage
+ *              (#e5e7e0) for button surfaces and tertiary tiers
+ *              (§2 Surface & Background).
+ *
+ *   #Bind 2  — --fg ramp is olive, not neutral gray. Olive Ink
+ *              (#4d4f46) carries body text; Deep Olive (#23251d)
+ *              steps darker for headings and high-emphasis links;
+ *              Muted Olive (#65675e) is the standard subtext tier;
+ *              Sage Placeholder (#9ea096) is the disabled / meta
+ *              tier. DESIGN.md §7 mandates the olive family — pure
+ *              black or neutral gray reads as the wrong brand.
+ *
+ *   #Bind 3  — --accent is PostHog Orange (#F54E00) — a hidden
+ *              signature. DESIGN.md §1 describes it as "a vibrant
+ *              orange that surprises on hover" — the marketing
+ *              surface uses it almost exclusively as TEXT color on
+ *              hover, not as a CTA fill. The token still binds the
+ *              brand color so components can opt into orange fills
+ *              when truly appropriate; primary CTAs render dark
+ *              (--fg-2) per §4 Buttons. Accent-on/hover/active use
+ *              the schema's color-mix defaults — DESIGN.md does not
+ *              publish orange pressed-state hex values.
+ *
+ *   #Bind 4  — --warn binds to Amber Gold (#F7A501) — DESIGN.md §2
+ *              names this as the dark-button hover accent and the
+ *              warmth-signal sibling to PostHog Orange. Mapping it
+ *              to the warn slot keeps the gold reachable to
+ *              components without inventing a brand-specific token.
+ *              --success and --danger stay on schema defaults since
+ *              DESIGN.md publishes no greens or reds.
+ *
+ *   #Bind 5  — Radius scale stays deliberately tight per DESIGN.md
+ *              §5 / §7 — 4px is the workhorse for buttons and
+ *              inputs, 6px for cards (DESIGN.md §4 Cards), 8px
+ *              caps the lg tier. The Don'ts list explicitly
+ *              forbids 12px+ on cards; the system reads as
+ *              functional-scrappy, never plush. Pill stays 9999px
+ *              for badges and status dots.
+ *
+ *   #Bind 6  — --elev-raised is THE single sanctioned shadow per
+ *              DESIGN.md §6 ("only one shadow definition exists in
+ *              the entire system"). Reserved for floating elements
+ *              — modals, dropdowns, mega-menus. Every other depth
+ *              cue comes from sage borders and surface-color
+ *              shifts. Cards must not reach for this shadow.
+ *
+ *   #Bind 7  — --focus-ring is Focus Blue (#3b82f6) at 50% opacity,
+ *              the one cool color in the system. DESIGN.md §2 and
+ *              §4 mandate this Tailwind-derived ring as an
+ *              accessibility-only color; reserving it to focus
+ *              keeps the warm sage/olive identity uncompromised
+ *              while still passing keyboard-navigation contrast.
+ *
+ *   #Bind 8  — Type scale tops out modestly. DESIGN.md §3 publishes
+ *              30px as the display hero ceiling (--text-2xl) and
+ *              36px as the section heading (--text-3xl); --text-4xl
+ *              extrapolates to 44px for fixture-scale hero copy.
+ *              Tracking compresses on display sizes (-0.025em
+ *              normalizes -0.75px at 30px) and relaxes to 0 on
+ *              body. Leading is generous everywhere — 1.50 body,
+ *              1.20 tight — because the marketing surface is
+ *              content-heavy and optimized for long reading
+ *              sessions (§3 Principles).
+ *
+ *   #Bind 9  — --container-max is 1280px per DESIGN.md §5 ("content
+ *              containers likely 1200px–1280px"). Gutters tighten
+ *              progressively: 24/16/12 desktop/tablet/phone — tight
+ *              but not cramped, matching PostHog's content-dense
+ *              editorial pacing.
+ *
+ * Brand-specific extensions: none in this revision. The Warm Tan
+ * (#d4c9b8) featured-button background and Hover White (#f4f4f4)
+ * universal hover state stay inline at the components that need
+ * them; neither earns a shared slot.
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface (3 levels) ────────────────────────────────────────
+   * Warm Parchment is the page; Sage Cream is the secondary
+   * container (input backgrounds, hover/feature sections); Light
+   * Sage is the tertiary tier for button surfaces and quiet card
+   * fills. Three steps create depth WITHOUT shadows — DESIGN.md §6
+   * notes that "moving from #fdfdf8 to #eeefe9 to #e5e7e0 creates
+   * layered depth without shadows", and the whole brand depends on
+   * that surface-color rhythm rather than blur. */
+  --bg: #fdfdf8;
+  --surface: #eeefe9;
+  --surface-warm: #e5e7e0;
+
+  /* ─── Foreground ramp (4 levels) ────────────────────────────────
+   * Olive Ink anchors roughly every body paragraph, every nav
+   * label, every button text token on light surfaces. Deep Olive
+   * steps darker for headings and high-emphasis links — the
+   * near-black with green undertone that signals "click me". Muted
+   * Olive is the secondary subtext tier. Sage Placeholder is the
+   * disabled / meta tier and pulls double duty as input
+   * placeholder color. */
+  --fg: #4d4f46;
+  --fg-2: #23251d;
+  --muted: #65675e;
+  --meta: #9ea096;
+
+  /* ─── Border (2 levels) ─────────────────────────────────────────
+   * Sage Border (#bfc1b7) is the workhorse — every card edge,
+   * every input outline, every divider rule. The soft tier is a
+   * lighter sage tint used for inner row separators that should
+   * not visually compete with the primary card edge; derived as a
+   * 50% mix back toward --bg so it stays in the same warm-green
+   * family without inventing a new hex. */
+  --border: #bfc1b7;
+  --border-soft: color-mix(in oklab, var(--border), var(--bg) 50%);
+
+  /* ─── Accent ────────────────────────────────────────────────────
+   * PostHog Orange — the single signature color. Per DESIGN.md §1
+   * it lives almost exclusively on hover as text color, not as a
+   * CTA fill, but the token still binds the brand color so any
+   * component opting into orange surfaces can do so consistently.
+   * Primary CTAs render dark (#1e1f23 ≈ --fg-2 territory) with
+   * opacity-based hover states; that treatment lives inline at
+   * the button component, not as a shared accent. */
+  --accent: #F54E00;
+  --accent-on: #ffffff;
+  --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+  /* ─── Semantic ──────────────────────────────────────────────────
+   * --warn binds to Amber Gold (DESIGN.md §2's "warmth signal")
+   * because the brand publishes that exact value as the secondary
+   * hover accent. --success and --danger stay on schema defaults
+   * — DESIGN.md does not specify brand greens or reds and the
+   * marketing surface almost never renders status. Keep semantic
+   * pixels well under 5% of any page. */
+  --success: #16a34a;
+  --warn: #F7A501;
+  --danger: #dc2626;
+
+  /* ─── Typography — fonts ────────────────────────────────────────
+   * IBM Plex Sans Variable is the single voice — display and body
+   * share the family (DESIGN.md §3). The fallback chain matches
+   * the brand's documented order: IBM Plex Sans static, then the
+   * platform fallbacks, then the broad sans-serif catch-all. Mono
+   * is Source Code Pro with the standard system fallbacks per
+   * DESIGN.md §3 Font Family. */
+  --font-display: "IBM Plex Sans Variable", "IBM Plex Sans", -apple-system, system-ui, "Avenir Next", Avenir, "Segoe UI", "Helvetica Neue", Helvetica, Ubuntu, Roboto, Noto, Arial, sans-serif;
+  --font-body: "IBM Plex Sans Variable", "IBM Plex Sans", -apple-system, system-ui, "Avenir Next", Avenir, "Segoe UI", "Helvetica Neue", Helvetica, Ubuntu, Roboto, Noto, Arial, sans-serif;
+  --font-mono: "Source Code Pro", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+
+  /* ─── Typography — type scale (px) ──────────────────────────────
+   * Derived from DESIGN.md §3 Hierarchy table. The scale tops out
+   * modestly — 30px for the display hero, 36px for section
+   * headings — because PostHog's editorial pacing favors confident
+   * mid-weight headings over giant ones. --text-4xl extrapolates
+   * to 44px for fixture-scale hero copy; the production site
+   * rarely goes that big. */
+  --text-xs: 12px;
+  --text-sm: 14px;
+  --text-base: 16px;
+  --text-lg: 20px;
+  --text-xl: 24px;
+  --text-2xl: 30px;
+  --text-3xl: 36px;
+  --text-4xl: 44px;
+
+  /* ─── Typography — leading & tracking ───────────────────────────
+   * Body leads 1.50 (DESIGN.md §3 — body sizes 1.50–1.71 for the
+   * content-heavy editorial layout); display compresses to 1.20
+   * for the 30px hero per the same table. Tracking compresses
+   * negatively on display sizes (-0.025em normalizes the brand's
+   * -0.75px at 30px) and relaxes to 0 on body. */
+  --leading-body: 1.5;
+  --leading-tight: 1.2;
+  --tracking-display: -0.025em;
+
+  /* ─── Spacing — base scale ──────────────────────────────────────
+   * 8px base unit per DESIGN.md §5. PostHog's published scale
+   * includes off-grid values (2, 6, 10, 18, 34) for fine-grained
+   * icon and padding adjustments; the shared scale stays on the
+   * standard 4px grid — off-grid spacing belongs inline at the
+   * component level, not in shared tokens. */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+
+  /* ─── Section rhythm ────────────────────────────────────────────
+   * Section padding 32–48px desktop per DESIGN.md §5 ("compact for
+   * a content-heavy site"). We bind the upper bound on desktop so
+   * the rhythm reads as deliberate spacing rather than crowding;
+   * tablet and phone step down to keep small screens tight. */
+  --section-y-desktop: 48px;
+  --section-y-tablet: 32px;
+  --section-y-phone: 24px;
+
+  /* ─── Radius ────────────────────────────────────────────────────
+   * Deliberately tight — DESIGN.md §7's Don'ts forbid 12px+ on
+   * cards. 4px is the workhorse (buttons, inputs, dropdowns,
+   * menus); 6px is the card tier (§4 Cards "4px–6px radius");
+   * 8px caps the lg tier for slightly larger containers; pill
+   * stays 9999px for badges and status dots. */
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --radius-pill: 9999px;
+
+  /* ─── Elevation ─────────────────────────────────────────────────
+   * THE single sanctioned shadow per DESIGN.md §6 — "only one
+   * shadow definition exists in the entire system". Reserved for
+   * floating elements (modals, dropdowns, mega-menus, popovers).
+   * Every other depth cue comes from sage borders and surface
+   * color shifts. Cards must NOT reach for this shadow — DESIGN.md
+   * §7 specifically forbids adding heavy shadows beyond this one. */
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised: 0px 25px 50px -12px rgba(0, 0, 0, 0.25);
+
+  /* ─── Focus ring ────────────────────────────────────────────────
+   * Focus Blue (#3b82f6) at 50% opacity — the lone cool color in
+   * the system, reserved for accessibility per DESIGN.md §2 / §4.
+   * Implementing as a 3px box-shadow keeps focus indication
+   * outside the layout box; the warm sage/olive identity stays
+   * uncompromised at rest. */
+  --focus-ring: 0 0 0 3px rgba(59, 130, 246, 0.5);
+
+  /* ─── Motion ────────────────────────────────────────────────────
+   * Default schema timings. DESIGN.md does not publish transition
+   * specs (static extraction scope); we bind defaults consistent
+   * with the brand's tactile feel — 150ms for micro-states (the
+   * famous opacity flash on dark buttons) and 200ms for general
+   * state changes. Standard easing curve, no overshoot. */
+  --motion-fast: 150ms;
+  --motion-base: 200ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+  /* ─── Layout ────────────────────────────────────────────────────
+   * Container caps at 1280px per DESIGN.md §5 ("content containers
+   * likely 1200px–1280px"). Gutters tighten progressively: 24px
+   * desktop, 16px tablet, 12px phone — tight but not cramped,
+   * matching PostHog's content-dense editorial pacing. */
+  --container-max: 1280px;
+  --container-gutter-desktop: 24px;
+  --container-gutter-tablet: 16px;
+  --container-gutter-phone: 12px;
+}

--- a/design-systems/raycast/components.html
+++ b/design-systems/raycast/components.html
@@ -1,0 +1,507 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Raycast — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/raycast. Every visible value
+        comes from tokens.css. Raycast's signature moves: near-black blue-tinted
+        canvas, Inter with calt+kern+liga+ss03 and +0.2px body tracking, weight
+        500 baseline, macOS double-ring elevation, Raycast Red as scarce
+        punctuation, Raycast Blue for focus and interaction."
+    />
+
+    <style>
+      :root {
+        --bg:           #07080a;
+        --surface:      #101111;
+        --surface-warm: var(--surface);
+
+        --fg:    #f9f9f9;
+        --fg-2:  #cecece;
+        --muted: #9c9c9d;
+        --meta:  #6a6b6c;
+
+        --border:      rgba(255, 255, 255, 0.06);
+        --border-soft: rgba(255, 255, 255, 0.04);
+
+        --accent:        #FF6363;
+        --accent-on:     #ffffff;
+        --accent-hover:  #ff7777;
+        --accent-active: #e85757;
+
+        --success: hsl(151, 59%, 59%);
+        --warn:    hsl(43, 100%, 60%);
+        --danger:  hsl(0, 100%, 69%);
+
+        --font-display: "Inter", "Inter Fallback", "SF Pro Display", -apple-system, system-ui, "Segoe UI", Roboto, sans-serif;
+        --font-body:    "Inter", "Inter Fallback", "SF Pro Text", -apple-system, system-ui, "Segoe UI", Roboto, sans-serif;
+        --font-mono:    "GeistMono", ui-monospace, "SF Mono", "Roboto Mono", Menlo, Monaco, Consolas, monospace;
+
+        --text-xs:   12px;
+        --text-sm:   14px;
+        --text-base: 16px;
+        --text-lg:   18px;
+        --text-xl:   20px;
+        --text-2xl:  24px;
+        --text-3xl:  40px;
+        --text-4xl:  64px;
+
+        --leading-body:     1.6;
+        --leading-tight:    1.1;
+        --tracking-display: 0px;
+
+        --space-1:  4px;
+        --space-2:  8px;
+        --space-3:  12px;
+        --space-4:  16px;
+        --space-5:  20px;
+        --space-6:  24px;
+        --space-8:  32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 96px;
+        --section-y-tablet:  64px;
+        --section-y-phone:   40px;
+
+        --radius-sm:   6px;
+        --radius-md:   12px;
+        --radius-lg:   16px;
+        --radius-pill: 9999px;
+
+        --elev-flat:   none;
+        --elev-ring:   rgb(27, 28, 30) 0px 0px 0px 1px, rgb(7, 8, 10) 0px 0px 0px 1px inset;
+        --elev-raised:
+          rgba(255, 255, 255, 0.05) 0px 1px 0px 0px inset,
+          rgba(0, 0, 0, 0.28) 0px 1.189px 2.377px,
+          0 0 0 1px rgba(255, 255, 255, 0.06);
+
+        --focus-ring: 0 0 0 3px hsla(202, 100%, 67%, 0.35);
+
+        --motion-fast:   150ms;
+        --motion-base:   200ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+        --container-max:            1200px;
+        --container-gutter-desktop: 24px;
+        --container-gutter-tablet:  16px;
+        --container-gutter-phone:   12px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg-2);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        font-weight: 500;
+        line-height: var(--leading-body);
+        letter-spacing: 0.2px;
+        /* Raycast's signature OpenType stack — applied globally on Inter. */
+        font-feature-settings: "calt", "kern", "liga", "ss03";
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+      }
+
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      section + section { border-top: 1px solid var(--border); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography ────────────────────────────────────────────── */
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        margin: 0;
+        color: var(--fg);
+        font-feature-settings: "calt", "kern", "liga", "ss03";
+      }
+      h1 {
+        font-size: var(--text-4xl);
+        font-weight: 600;
+        line-height: var(--leading-tight);
+        letter-spacing: var(--tracking-display);
+        /* DESIGN.md §3: hero disables ligatures, enables ss02 + ss08. */
+        font-feature-settings: "liga" 0, "ss02", "ss08";
+      }
+      h2 {
+        font-size: var(--text-3xl);
+        font-weight: 400;
+        line-height: 1.17;
+        letter-spacing: 0.2px;
+      }
+      h3 {
+        font-size: var(--text-xl);
+        font-weight: 500;
+        line-height: 1.6;
+        letter-spacing: 0.2px;
+      }
+      p { margin: 0; }
+      .lead {
+        font-size: var(--text-lg);
+        line-height: 1.6;
+        color: var(--fg-2);
+        font-weight: 400;
+        letter-spacing: 0.2px;
+      }
+      .body-muted { color: var(--muted); }
+      .body-sm { font-size: var(--text-sm); color: var(--muted); }
+      .eyebrow {
+        font-size: var(--text-xs);
+        font-weight: 600;
+        color: var(--meta);
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+      }
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+
+      /* ─── Buttons ───────────────────────────────────────────────── */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 10px 18px;
+        border-radius: var(--radius-pill);
+        font-family: var(--font-display);
+        font-size: var(--text-base);
+        font-weight: 600;
+        font-feature-settings: "calt", "kern", "liga", "ss03";
+        line-height: 1.15;
+        letter-spacing: 0.3px;
+        cursor: pointer;
+        border: 1px solid transparent;
+        transition: opacity var(--motion-fast) var(--ease-standard),
+                    background-color var(--motion-fast) var(--ease-standard);
+        text-decoration: none;
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      /* Raycast's CTA: translucent white pill on dark, near-black text. */
+      .btn-primary {
+        background: hsla(0, 0%, 100%, 0.815);
+        color: #18191a;
+        box-shadow:
+          rgba(255, 255, 255, 0.1) 0px 1px 0px 0px inset,
+          rgba(0, 0, 0, 0.25) 0px 1px 2px;
+      }
+      .btn-primary:hover { background: #ffffff; opacity: 1; }
+      .btn-primary:active { background: #ffffff; opacity: 0.92; }
+      /* Secondary: transparent with hairline border + macOS inset highlight. */
+      .btn-secondary {
+        background: transparent;
+        color: var(--fg);
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        box-shadow:
+          rgba(255, 255, 255, 0.05) 0px 1px 0px 0px inset,
+          rgba(0, 0, 0, 0.2) 0px -1px 0px 0px inset;
+      }
+      .btn-secondary:hover { opacity: 0.6; }
+
+      /* ─── Keyboard key caps ─────────────────────────────────────── */
+      /* DESIGN.md §4 Keyboard Keys: gradient #121212→#0d0d0d, heavy
+         multi-layer shadow for realistic physical depth. */
+      .kbd {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 22px;
+        padding: 2px 6px;
+        background: linear-gradient(to bottom, #121212, #0d0d0d);
+        color: var(--fg-2);
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        font-weight: 600;
+        border-radius: 5px;
+        box-shadow:
+          rgba(255, 255, 255, 0.1) 0px 1px 0px 0px inset,
+          rgba(0, 0, 0, 0.4) 0px 1.5px 0.5px 1.5px,
+          rgba(0, 0, 0, 0.6) 0px 2px 4px;
+        line-height: 1.4;
+      }
+      .kbd-row { display: inline-flex; align-items: center; gap: var(--space-2); }
+
+      /* ─── Cards ─────────────────────────────────────────────────── */
+      .card {
+        position: relative;
+        background: var(--surface);
+        border-radius: var(--radius-lg);
+        padding: var(--space-6);
+        /* macOS double-ring elevation — outer card-tone + inset deep-bg. */
+        box-shadow: var(--elev-ring);
+        transition: box-shadow var(--motion-base) var(--ease-standard);
+      }
+      .card:hover {
+        box-shadow:
+          rgb(27, 28, 30) 0px 0px 0px 1px,
+          rgb(7, 8, 10) 0px 0px 0px 1px inset,
+          rgba(215, 201, 175, 0.05) 0px 0px 20px 5px;
+      }
+      .card-title {
+        color: var(--fg);
+        font-size: var(--text-xl);
+        font-weight: 500;
+        line-height: 1.15;
+        letter-spacing: 0.2px;
+        margin: 0;
+      }
+
+      /* ─── Inputs ────────────────────────────────────────────────── */
+      .field { display: flex; flex-direction: column; gap: var(--space-2); }
+      .field label {
+        font-size: var(--text-sm);
+        font-weight: 500;
+        color: var(--muted);
+        letter-spacing: 0.2px;
+      }
+      .field input {
+        background: var(--bg);
+        color: var(--fg);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        border-radius: var(--radius-sm);
+        padding: 12px 14px;
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        font-weight: 500;
+        letter-spacing: 0.2px;
+        font-feature-settings: "calt", "kern", "liga", "ss03";
+        outline: none;
+        transition: border-color var(--motion-fast) var(--ease-standard),
+                    box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .field input::placeholder { color: var(--meta); }
+      .field input:focus {
+        border-color: hsl(202, 100%, 67%);
+        box-shadow: var(--focus-ring);
+      }
+
+      /* ─── Pills / badges ────────────────────────────────────────── */
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 4px 10px;
+        border-radius: var(--radius-pill);
+        font-size: var(--text-xs);
+        font-weight: 600;
+        color: var(--fg-2);
+        background: #1b1c1e;
+        letter-spacing: 0.2px;
+      }
+      .pill-accent {
+        color: var(--accent);
+        background: hsla(0, 100%, 69%, 0.12);
+        border: 1px solid hsla(0, 100%, 69%, 0.25);
+      }
+      .pill-info {
+        color: hsl(202, 100%, 67%);
+        background: hsla(202, 100%, 67%, 0.12);
+        border: 1px solid hsla(202, 100%, 67%, 0.25);
+      }
+
+      /* ─── Hero stripe decoration — Raycast Red diagonal lines ──── */
+      .hero-stripes {
+        position: relative;
+        background: var(--surface);
+        border-radius: var(--radius-lg);
+        padding: var(--space-8);
+        box-shadow: var(--elev-ring);
+        overflow: hidden;
+        min-height: 280px;
+        display: flex;
+        align-items: flex-end;
+      }
+      .hero-stripes::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background-image: repeating-linear-gradient(
+          135deg,
+          var(--accent) 0px,
+          var(--accent) 10px,
+          transparent 10px,
+          transparent 28px
+        );
+        opacity: 0.85;
+        mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 0.25) 70%, rgba(0, 0, 0, 0) 100%);
+        -webkit-mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 0.25) 70%, rgba(0, 0, 0, 0) 100%);
+      }
+      .hero-stripes .palette {
+        position: relative;
+        z-index: 1;
+        width: 100%;
+        background: linear-gradient(to bottom, rgba(16, 17, 17, 0.8), rgba(7, 8, 10, 0.95));
+        backdrop-filter: blur(20px);
+        -webkit-backdrop-filter: blur(20px);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        border-radius: var(--radius-md);
+        padding: var(--space-3) var(--space-4);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: var(--fg-2);
+      }
+
+      /* ─── Layout ────────────────────────────────────────────────── */
+      .hero-grid {
+        display: grid;
+        grid-template-columns: 1.1fr 1fr;
+        gap: var(--space-12);
+        align-items: center;
+      }
+      @media (max-width: 1023px) { .hero-grid { grid-template-columns: 1fr; } }
+      .features-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: var(--space-4);
+      }
+      @media (max-width: 1023px) { .features-grid { grid-template-columns: 1fr 1fr; } }
+      @media (max-width: 639px)  { .features-grid { grid-template-columns: 1fr; } }
+      .hero-actions { display: flex; gap: var(--space-3); margin-block-start: var(--space-6); flex-wrap: wrap; }
+      .feature-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 36px;
+        height: 36px;
+        border-radius: var(--radius-sm);
+        background: rgba(255, 255, 255, 0.04);
+        border: 1px solid rgba(255, 255, 255, 0.06);
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        font-weight: 600;
+        color: var(--fg);
+      }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <!-- HERO -->
+      <section data-od-id="hero">
+        <div class="hero-grid">
+          <div class="stack-4">
+            <p class="eyebrow">Reference fixture · raycast</p>
+            <h1>Your shortcut to everything.</h1>
+            <p class="lead" style="max-width:52ch">
+              A blazingly fast, totally extendable launcher. Raycast lets you
+              complete tasks, calculate, share common links, and much more.
+              Every value on this page comes from <span style="font-family:var(--font-mono);font-size:var(--text-sm);color:var(--fg)">tokens.css</span>
+              — the void, the rings, the +0.2px tracking, the red stripe.
+            </p>
+            <div class="kbd-row" style="margin-block-start:var(--space-2)">
+              <span class="body-sm">Open with</span>
+              <span class="kbd">⌘</span>
+              <span class="kbd">Space</span>
+            </div>
+            <div class="hero-actions">
+              <a href="./tokens.css" class="btn btn-primary">Download for Mac</a>
+              <a href="./DESIGN.md" class="btn btn-secondary">Read the spec</a>
+            </div>
+          </div>
+
+          <aside class="hero-stripes" aria-label="Raycast brand stripe with command palette preview">
+            <div class="palette">
+              <span style="display:inline-flex;align-items:center;gap:var(--space-3)">
+                <span style="width:18px;height:18px;border-radius:4px;background:var(--accent);display:inline-block;flex-shrink:0"></span>
+                <span style="color:var(--fg)">Search apps, commands, snippets…</span>
+              </span>
+              <span class="kbd">↵</span>
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <!-- FEATURES -->
+      <section data-od-id="features">
+        <div class="stack-3">
+          <p class="eyebrow">What this fixture exercises</p>
+          <h2 style="max-width:30ch">A precision instrument carved from obsidian.</h2>
+        </div>
+
+        <div class="features-grid" style="margin-block-start:var(--space-8)">
+          <article class="card stack-3">
+            <span class="feature-icon">⌘</span>
+            <h3 class="card-title">Blazingly fast</h3>
+            <p class="body-sm">
+              Built natively for macOS with multi-layer inset shadows, the
+              double-ring containment, and 150–200ms transitions on the
+              standard ease curve. No web bloat — instant response.
+            </p>
+            <span class="pill pill-info">Native</span>
+          </article>
+
+          <article class="card stack-3">
+            <span class="feature-icon">⊕</span>
+            <h3 class="card-title">Totally extendable</h3>
+            <p class="body-sm">
+              Hundreds of community Extensions. Inter with calt+kern+liga+ss03
+              on every label keeps the dense product UI legible against the
+              blue-tinted near-black canvas.
+            </p>
+            <span class="pill">Store</span>
+          </article>
+
+          <article class="card stack-3">
+            <span class="feature-icon">!</span>
+            <h3 class="card-title">Scarce by design</h3>
+            <p class="body-sm">
+              Raycast Red appears as punctuation — hero stripes, destructive
+              actions, alert glows. Interactive feedback uses Raycast Blue
+              so the red retains its weight.
+            </p>
+            <span class="pill pill-accent">Danger only</span>
+          </article>
+        </div>
+      </section>
+
+      <!-- FORM -->
+      <section data-od-id="form">
+        <div style="display:grid;grid-template-columns:1.1fr 1fr;gap:var(--space-12);align-items:start">
+          <div class="stack-4">
+            <p class="eyebrow">Form components</p>
+            <h2>Inputs on the void.</h2>
+            <p class="lead" style="max-width:46ch">
+              Fields sit on the page background (<span style="font-family:var(--font-mono);font-size:var(--text-sm);color:var(--fg)">#07080a</span>)
+              with a barely-there 8% white border. Focus brightens the
+              edge to Raycast Blue and lifts a translucent 35%-blue ring —
+              never the brand red.
+            </p>
+          </div>
+          <form
+            style="display:flex;flex-direction:column;gap:var(--space-4);max-width:420px;background:var(--surface);padding:var(--space-6);border-radius:var(--radius-lg);box-shadow:var(--elev-ring)"
+            onsubmit="event.preventDefault()"
+          >
+            <div class="field">
+              <label for="email">Work email</label>
+              <input id="email" type="email" placeholder="you@company.com" />
+            </div>
+            <div class="field">
+              <label for="team">Team name</label>
+              <input id="team" type="text" placeholder="Acme Productivity" />
+            </div>
+            <div style="display:flex;gap:var(--space-3);margin-top:var(--space-2);flex-wrap:wrap">
+              <button type="submit" class="btn btn-primary">Get started</button>
+              <button type="button" class="btn btn-secondary">View extensions</button>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/raycast/tokens.css
+++ b/design-systems/raycast/tokens.css
@@ -1,0 +1,143 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/raycast/tokens.css
+ *
+ * Structured token bindings for the "Raycast" brand — the macOS-native
+ * command palette / launcher's precision desktop-instrument voice.
+ *
+ * Brand identity in three sentences:
+ *   1. Near-black blue-tinted canvas (#07080a) — not pure black — with
+ *      semi-transparent white borders (0.06 opacity) and multi-layer
+ *      inset shadows that simulate physical glass-key depth.
+ *   2. Inter everywhere with OpenType "calt","kern","liga","ss03"; the
+ *      signature move is positive +0.2px letter-spacing on body for an
+ *      airy dark-mode rhythm, weight 500 as the readable body baseline.
+ *   3. Raycast Red (#FF6363) is punctuation, not pervasive — hero
+ *      stripes and danger states only. Raycast Blue (hsl(202,100%,67%))
+ *      carries interactive focus / links so red can stay scarce.
+ *
+ * Schema decisions:
+ *   - --bg #07080a (blue-cold near-black) / --surface #101111 (Surface 100).
+ *   - --surface-warm aliases --surface (cold-dark system, no warm tier).
+ *   - --fg #f9f9f9 near-white (avoids pure-white eye-strain on void).
+ *   - --fg-2 #cecece light-gray body / --meta #6a6b6c dim-gray metadata.
+ *   - --border rgba(255,255,255,0.06) — the "barely visible, structurally
+ *     essential" containment line called out in DESIGN.md §7.
+ *   - --accent #FF6363 (Raycast Red); hover/active shift tone, not opacity
+ *     (opacity 0.6 is a component-level interaction pattern, not a token).
+ *   - --focus-ring uses Raycast Blue, not accent red — separating brand
+ *     punctuation from interactive feedback is core to the system.
+ *   - --elev-ring is the macOS signature double-ring (outer #1b1c1e
+ *     + inset #07080a) that replaces traditional 1px borders on cards.
+ *   - --radius-sm 6px (workhorse: buttons / badges), --radius-md 12px
+ *     (standard cards), --radius-lg 16px (large feature containers).
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface ──────────────────────────────────────────────────── */
+  --bg:           #07080a;              /* near-black blue tint — the void */
+  --surface:      #101111;              /* Surface 100 — elevated cards */
+  --surface-warm: var(--surface);       /* no warm tier in cold dark system */
+
+  /* ─── Foreground ───────────────────────────────────────────────── */
+  --fg:    #f9f9f9;                     /* near-white primary text */
+  --fg-2:  #cecece;                     /* light gray secondary body */
+  --muted: #9c9c9d;                     /* medium gray tertiary / nav links */
+  --meta:  #6a6b6c;                     /* dim gray placeholders / metadata */
+
+  /* ─── Border ───────────────────────────────────────────────────── */
+  --border:      rgba(255, 255, 255, 0.06);   /* card containment — barely visible */
+  --border-soft: rgba(255, 255, 255, 0.04);   /* inner row separator */
+
+  /* ─── Accent ───────────────────────────────────────────────────── */
+  --accent:        #FF6363;             /* Raycast Red — hero stripes, error states */
+  --accent-on:     #ffffff;
+  --accent-hover:  #ff7777;             /* lighter tone for hover */
+  --accent-active: #e85757;             /* darker tone for pressed */
+
+  /* ─── Semantic ─────────────────────────────────────────────────── */
+  --success: hsl(151, 59%, 59%);        /* Raycast Green */
+  --warn:    hsl(43, 100%, 60%);        /* Raycast Yellow */
+  --danger:  hsl(0, 100%, 69%);         /* Error Red (≈ #FF6363) */
+
+  /* ─── Typography ───────────────────────────────────────────────── */
+  --font-display: "Inter", "Inter Fallback", "SF Pro Display", -apple-system, system-ui, "Segoe UI", Roboto, sans-serif;
+  --font-body:    "Inter", "Inter Fallback", "SF Pro Text", -apple-system, system-ui, "Segoe UI", Roboto, sans-serif;
+  --font-mono:    "GeistMono", ui-monospace, "SF Mono", "Roboto Mono", Menlo, Monaco, Consolas, monospace;
+
+  /* Type scale — DESIGN.md §3 Typography Hierarchy.
+   * Display Hero (64px) → text-4xl; Section Display (≈40–56px) → text-3xl;
+   * Section Heading (24px) → text-2xl; Sub-heading (20px) → text-xl;
+   * Body Large (18px) → text-lg; Body (16px) → text-base;
+   * Caption (14px) → text-sm; Small (12px) → text-xs. */
+  --text-xs:   12px;
+  --text-sm:   14px;
+  --text-base: 16px;
+  --text-lg:   18px;
+  --text-xl:   20px;
+  --text-2xl:  24px;
+  --text-3xl:  40px;
+  --text-4xl:  64px;
+
+  /* Leading + tracking.
+   * --leading-body 1.6: DESIGN.md "Body 16/500/1.60" — relaxed dark rhythm.
+   * --leading-tight 1.1: hero hugs its baseline.
+   * --tracking-display 0px: hero is zero-tracked; body inline adds +0.2px
+   * (the signature Raycast move noted in DESIGN.md §3 Principles). */
+  --leading-body:     1.6;
+  --leading-tight:    1.1;
+  --tracking-display: 0px;
+
+  /* ─── Spacing ──────────────────────────────────────────────────── */
+  --space-1:  4px;
+  --space-2:  8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  20px;
+  --space-6:  24px;
+  --space-8:  32px;
+  --space-12: 48px;
+
+  /* Section rhythm — DESIGN.md §5 "80–120px vertical between sections".
+   * The dramatic negative space is the cinematic pacing of the system. */
+  --section-y-desktop: 96px;
+  --section-y-tablet:  64px;
+  --section-y-phone:   40px;
+
+  /* ─── Radius ───────────────────────────────────────────────────── */
+  /* 6px is the workhorse (buttons, badges); 12px standard cards;
+   * 16px large feature containers; pill (9999px) for primary CTAs
+   * — DESIGN.md uses 86px+ which is functionally pill at all sizes. */
+  --radius-sm:   6px;
+  --radius-md:   12px;
+  --radius-lg:   16px;
+  --radius-pill: 9999px;
+
+  /* ─── Elevation ────────────────────────────────────────────────── */
+  /* macOS-native shadow philosophy: outer rings replace borders, inset
+   * highlights simulate light from above, inset darks simulate shadow
+   * underneath. --elev-ring is the signature double-ring: outer card-
+   * surface tone + inset deep-bg tone, creating physical containment. */
+  --elev-flat:   none;
+  --elev-ring:   rgb(27, 28, 30) 0px 0px 0px 1px, rgb(7, 8, 10) 0px 0px 0px 1px inset;
+  --elev-raised:
+    rgba(255, 255, 255, 0.05) 0px 1px 0px 0px inset,
+    rgba(0, 0, 0, 0.28) 0px 1.189px 2.377px,
+    0 0 0 1px rgba(255, 255, 255, 0.06);
+
+  /* ─── Focus ────────────────────────────────────────────────────── */
+  /* Raycast Blue, not accent red — DESIGN.md §2 reserves red for hero
+   * stripes / danger and blue for interactive / focus / links. Keeping
+   * focus blue protects the scarcity of the red. */
+  --focus-ring: 0 0 0 3px hsla(202, 100%, 67%, 0.35);
+
+  /* ─── Motion ───────────────────────────────────────────────────── */
+  --motion-fast:   150ms;
+  --motion-base:   200ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+  /* ─── Layout ───────────────────────────────────────────────────── */
+  --container-max:            1200px;
+  --container-gutter-desktop: 24px;
+  --container-gutter-tablet:  16px;
+  --container-gutter-phone:   12px;
+}

--- a/design-systems/resend/components.html
+++ b/design-systems/resend/components.html
@@ -1,0 +1,839 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Resend — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/resend. Every visible
+        value comes from tokens.css; the page itself follows Resend's
+        rules — void-black canvas, near-white text, frost-blue borders
+        instead of gray, one accent at a time (Resend Orange), ABC
+        Favorit with -0.05em display tracking, Inter for body, Commit
+        Mono for code."
+    />
+
+    <style>
+      /* :root paste — sourced verbatim from design-systems/resend/tokens.css. */
+      :root {
+        --bg: #000000;
+        --surface: #000000;
+        --surface-warm: var(--surface);
+
+        --fg: #f0f0f0;
+        --fg-2: #a1a4a5;
+        --muted: #5c5c5c;
+        --meta: #464a4d;
+
+        --border: rgba(214, 235, 253, 0.19);
+        --border-soft: rgba(217, 237, 254, 0.145);
+
+        --accent: #ff801f;
+        --accent-on: #000000;
+        --accent-hover: color-mix(in oklab, var(--accent), white 10%);
+        --accent-active: color-mix(in oklab, var(--accent), black 12%);
+
+        --success: #11ff99;
+        --warn: #ffc53d;
+        --danger: #ff2047;
+
+        --font-display: "ABC Favorit", "Inter", -apple-system, system-ui, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+        --font-body: "Inter", -apple-system, system-ui, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+        --font-mono: "Commit Mono", "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
+
+        --text-xs: 12px;
+        --text-sm: 14px;
+        --text-base: 16px;
+        --text-lg: 20px;
+        --text-xl: 24px;
+        --text-2xl: 36px;
+        --text-3xl: 56px;
+        --text-4xl: 96px;
+
+        --leading-body: 1.5;
+        --leading-tight: 1.0;
+        --tracking-display: -0.05em;
+
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 120px;
+        --section-y-tablet: 80px;
+        --section-y-phone: 48px;
+
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 16px;
+        --radius-pill: 9999px;
+
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised:
+          0 0 0 1px rgba(176, 199, 217, 0.145),
+          0 1px 3px rgba(0, 0, 0, 0.4),
+          0 1px 2px -1px rgba(0, 0, 0, 0.4);
+
+        --focus-ring: 0 0 0 2px var(--accent);
+
+        --motion-fast: 150ms;
+        --motion-base: 200ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+        --container-max: 1200px;
+        --container-gutter-desktop: 32px;
+        --container-gutter-tablet: 24px;
+        --container-gutter-phone: 16px;
+      }
+
+      /* ─── Reset (minimal) ─────────────────────────────────────── */
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        font-weight: 400;
+        /* OpenType ligatures + ABC Favorit / Domaine stylistic sets per
+           DESIGN.md §3: ss01 / ss03 / ss04 / ss11 are part of the
+           typographic identity. Browsers without those faces simply
+           ignore the directives — no fallback ugliness. */
+        font-feature-settings: "liga" 1, "ss01" 1, "ss04" 1, "ss11" 1;
+        -webkit-font-smoothing: antialiased;
+        text-rendering: optimizeLegibility;
+      }
+
+      /* ─── Layout primitives ─────────────────────────────────── */
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section {
+        padding-block: var(--section-y-desktop);
+      }
+      section + section {
+        /* Single frost hairline between major sections — DESIGN.md §4
+           "Sticky dark header with frost border bottom"; we extend
+           the same idea to inter-section dividers so the page reads
+           as a stack of gallery rooms rather than a continuous wash. */
+        border-top: 1px solid var(--border);
+      }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography ────────────────────────────────────────────
+       * Three-font hierarchy: display uses ABC Favorit (var(--font-
+       * display)) with aggressive negative tracking; body uses
+       * Inter (var(--font-body)); code uses Commit Mono (var(--font-
+       * mono)). Hierarchy comes from size + tracking, not weight —
+       * DESIGN.md §3 keeps weight at 400 / 500 / 600 only. */
+      h1, h2, h3, h4 {
+        font-family: var(--font-display);
+        line-height: var(--leading-tight);
+        margin: 0;
+        color: var(--fg);
+      }
+      h1 {
+        font-size: var(--text-4xl);
+        font-weight: 400;
+        letter-spacing: var(--tracking-display);
+      }
+      h2 {
+        font-size: var(--text-3xl);
+        font-weight: 400;
+        /* DESIGN.md §3 Section Heading line-height 1.20 — overrides
+           the shared --leading-tight (1.0) used by the 96px hero. */
+        line-height: 1.20;
+        letter-spacing: var(--tracking-display);
+      }
+      h3 {
+        font-size: var(--text-xl);
+        font-weight: 500;
+        /* DESIGN.md §3 Feature Title (24px Inter weight 500, line-
+           height 1.50). Feature titles use Inter, not the display
+           face — opt out of var(--font-display) inline. */
+        font-family: var(--font-body);
+        line-height: 1.5;
+        letter-spacing: normal;
+      }
+      h4 {
+        font-size: var(--text-lg);
+        font-weight: 400;
+        line-height: 1.3;
+      }
+      p { margin: 0; }
+
+      .lede {
+        font-family: var(--font-display);
+        font-size: var(--text-lg);
+        line-height: 1.3;
+        color: var(--fg-2);
+        letter-spacing: normal;
+      }
+      .body-muted { color: var(--fg-2); }
+      .body-meta  { color: var(--muted); font-size: var(--text-sm); }
+      .body-sm    { font-size: var(--text-sm); }
+
+      /* Eyebrow uses Commit Mono uppercase with positive tracking —
+         the documented nav-link pattern from DESIGN.md §3:
+         "ABC Favorit nav links use +0.35px letter-spacing — the only
+         positive tracking in the system." We extend the same airy
+         tracking to mono eyebrows so they read as a technical label
+         rather than a heading. */
+      .eyebrow {
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        font-weight: 500;
+        line-height: 1;
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+
+      /* ─── Buttons ───────────────────────────────────────────────
+       * DESIGN.md §4 documents three primary patterns:
+       *   .btn-pill          transparent fill + frost border + pill radius
+       *   .btn-pill-white    white solid fill + black label + pill radius
+       *   .btn-ghost         transparent, no border, sharp 4px radius
+       * The hero CTA pair below pairs a white-pill (max contrast)
+       * with a frost-pill (subtle) — Resend's signature CTA shape. */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 8px 18px;
+        border: none;
+        border-radius: var(--radius-sm);
+        font-family: var(--font-body);
+        font-size: var(--text-sm);
+        font-weight: 500;
+        line-height: 1.43;
+        cursor: pointer;
+        text-decoration: none;
+        background: transparent;
+        color: inherit;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible {
+        outline: none;
+        box-shadow: var(--focus-ring);
+      }
+      .btn-pill {
+        border-radius: var(--radius-pill);
+        padding: 8px 18px;
+        background: transparent;
+        color: var(--fg);
+        box-shadow: 0 0 0 1px var(--border);
+      }
+      .btn-pill:hover {
+        /* White-glass hover from DESIGN.md §4: rgba(255,255,255,0.28).
+           Expressed via color-mix so it stays token-clean. */
+        background: color-mix(in oklab, var(--fg), transparent 72%);
+        box-shadow: 0 0 0 1px color-mix(in oklab, var(--fg), transparent 60%);
+      }
+      .btn-pill-white {
+        border-radius: var(--radius-pill);
+        padding: 8px 18px;
+        background: #ffffff;
+        color: #000000;
+      }
+      .btn-pill-white:hover {
+        background: color-mix(in oklab, #ffffff, var(--accent) 6%);
+      }
+      .btn-ghost {
+        background: transparent;
+        color: var(--fg-2);
+        padding-inline: var(--space-3);
+      }
+      .btn-ghost:hover {
+        color: var(--fg);
+        background: color-mix(in oklab, var(--fg), transparent 92%);
+      }
+
+      /* ─── Inputs ────────────────────────────────────────────────
+       * DESIGN.md §4: "Radius: 4px. Focus: shadow-based ring."
+       * Inputs use the frost-border via box-shadow so the focus
+       * state can swap the shadow to the accent ring without a
+       * layout shift. */
+      .field {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+      }
+      .field label {
+        font-size: var(--text-sm);
+        font-weight: 500;
+        color: var(--fg);
+        font-family: var(--font-body);
+      }
+      .field input {
+        padding: 10px 14px;
+        border: none;
+        border-radius: var(--radius-sm);
+        background: var(--surface);
+        color: var(--fg);
+        font-family: inherit;
+        font-size: var(--text-sm);
+        line-height: 1.43;
+        outline: none;
+        box-shadow: 0 0 0 1px var(--border);
+        transition: box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .field input::placeholder { color: var(--muted); }
+      .field input:hover {
+        box-shadow: 0 0 0 1px color-mix(in oklab, var(--border), white 30%);
+      }
+      .field input:focus-visible {
+        box-shadow: var(--focus-ring);
+      }
+      .field-help {
+        font-size: var(--text-xs);
+        color: var(--muted);
+      }
+
+      /* ─── Cards ─────────────────────────────────────────────────
+       * DESIGN.md §4: "Background: transparent or very subtle dark
+       * tint. Border: 1px solid rgba(214, 235, 253, 0.19)." Radius
+       * 16px (--radius-lg) for feature cards. Depth comes from the
+       * frost border alone — no opaque blur shadow, which would
+       * vanish into the void. */
+      .card {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        padding: var(--space-6);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+        transition:
+          border-color var(--motion-base) var(--ease-standard),
+          background-color var(--motion-base) var(--ease-standard);
+      }
+      .card:hover {
+        /* Intensify the frost edge on hover — luminance step, not
+           a shadow drop. Faintly tint the background with the same
+           cool blue at near-zero opacity so the card warms up. */
+        border-color: color-mix(in oklab, var(--border), white 30%);
+        background: color-mix(in oklab, var(--bg), white 2%);
+      }
+
+      /* ─── Badges ────────────────────────────────────────────────
+       * DESIGN.md §4 "Multi-color Accent Badges": background at
+       * 12–42% opacity of the accent, text at full opacity.
+       * `.badge-accent` uses the orange accent; `.badge-success` /
+       * `.badge-danger` reach the semantic tokens. Pill radius
+       * (9999px) is the brand-default badge shape. */
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-1);
+        padding: 4px 12px;
+        border-radius: var(--radius-pill);
+        font-size: var(--text-xs);
+        font-weight: 500;
+        line-height: 1.5;
+        font-family: var(--font-body);
+      }
+      .badge-accent {
+        color: var(--accent);
+        background: color-mix(in oklab, var(--accent), transparent 80%);
+      }
+      .badge-muted {
+        color: var(--fg-2);
+        background: transparent;
+        box-shadow: 0 0 0 1px var(--border);
+      }
+      .badge-success {
+        color: var(--success);
+        background: color-mix(in oklab, var(--success), transparent 85%);
+      }
+      .badge-dot {
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: currentColor;
+      }
+
+      /* ─── Links ─────────────────────────────────────────────────
+       * Resend's link voice from DESIGN.md §2: link highlights are
+       * the pure-white moment. We pair an underline that thickens
+       * on hover with `--fg` (near-white) for body links — leaving
+       * the orange accent for explicit CTA badges only, so the ≤2
+       * accent uses per screen rule holds even in copy-dense
+       * sections. */
+      a {
+        color: var(--fg);
+        text-decoration: underline;
+        text-decoration-color: var(--border);
+        text-underline-offset: 3px;
+        text-decoration-thickness: 1px;
+        transition: text-decoration-color var(--motion-fast) var(--ease-standard);
+      }
+      a:hover {
+        text-decoration-color: var(--fg);
+      }
+      a.link-accent {
+        color: var(--accent);
+        text-decoration-color: color-mix(in oklab, var(--accent), transparent 50%);
+      }
+      a.link-accent:hover { text-decoration-color: var(--accent); }
+      a:focus-visible {
+        outline: none;
+        border-radius: 2px;
+        box-shadow: var(--focus-ring);
+      }
+
+      /* ─── Kbd ───────────────────────────────────────────────────
+       * Commit Mono, frost shadow-border edge. The mono face is
+       * the "developer console voice" connecting marketing copy
+       * to the product surface. */
+      kbd {
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        padding: 2px 8px;
+        border-radius: var(--radius-sm);
+        background: var(--surface);
+        color: var(--fg-2);
+        box-shadow: 0 0 0 1px var(--border);
+      }
+
+      /* ─── Distinctive: Code preview panel ───────────────────────
+       * DESIGN.md §4 "Code Preview Panels": dark code blocks using
+       * Commit Mono, frost borders, syntax-highlighted with multi-
+       * color accent tokens. The 24px radius is the brand "Section"
+       * radius (panel tier); reached inline because the schema's
+       * --radius-lg caps at 16px and adding a fifth radius slot
+       * would require a C-extension. */
+      .code-panel {
+        border: 1px solid var(--border);
+        border-radius: 24px;
+        background: var(--surface);
+        overflow: hidden;
+        box-shadow: var(--elev-raised);
+      }
+      .code-panel-head {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: var(--space-3) var(--space-4);
+        border-bottom: 1px solid var(--border-soft);
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        color: var(--muted);
+      }
+      .code-panel-dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: color-mix(in oklab, var(--fg), transparent 80%);
+      }
+      .code-panel-title { margin-inline-start: auto; }
+      .code-panel pre {
+        margin: 0;
+        padding: var(--space-5) var(--space-6);
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        line-height: 1.6;
+        color: var(--fg);
+        overflow-x: auto;
+      }
+      .code-panel .tok-key { color: var(--accent); }
+      .code-panel .tok-str { color: var(--success); }
+      .code-panel .tok-fn  { color: var(--warn); }
+      .code-panel .tok-com { color: var(--meta); font-style: italic; }
+
+      /* ─── Section-specific layout ─────────────────────────────── */
+      .hero {
+        text-align: left;
+        position: relative;
+        overflow: hidden;
+      }
+      /* Atmospheric warm gradient glow behind the hero — DESIGN.md
+         §6 "Decorative Depth: subtle warm gradient glows behind hero
+         content (orange/amber tints)". A radial wash of the accent
+         at very low opacity, blurred heavily — token-clean because
+         it mixes var(--accent) over var(--bg) rather than
+         introducing a raw hex. */
+      .hero::before {
+        content: "";
+        position: absolute;
+        inset: -20% -10% auto -10%;
+        height: 80%;
+        background: radial-gradient(
+          ellipse at 20% 30%,
+          color-mix(in oklab, var(--accent), var(--bg) 70%) 0%,
+          color-mix(in oklab, var(--accent), var(--bg) 90%) 35%,
+          var(--bg) 70%
+        );
+        filter: blur(80px);
+        opacity: 0.5;
+        z-index: 0;
+        pointer-events: none;
+      }
+      .hero > * { position: relative; z-index: 1; }
+      .hero .eyebrow { margin-block-end: var(--space-6); }
+      .hero h1 { max-width: 16ch; }
+      .hero .lede {
+        max-width: 52ch;
+        margin-block-start: var(--space-6);
+      }
+      .hero-actions {
+        display: flex;
+        gap: var(--space-3);
+        margin-block-start: var(--space-8);
+        align-items: center;
+        flex-wrap: wrap;
+      }
+      .hero-meta {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-3);
+        margin-block-start: var(--space-6);
+        color: var(--muted);
+        font-size: var(--text-sm);
+        flex-wrap: wrap;
+      }
+
+      .features-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: var(--space-5);
+        margin-block-start: var(--space-12);
+      }
+      @media (max-width: 1023px) {
+        .features-grid { grid-template-columns: 1fr 1fr; }
+      }
+      @media (max-width: 639px) {
+        .features-grid { grid-template-columns: 1fr; }
+      }
+      .feature-card .feature-icon {
+        width: 32px;
+        height: 32px;
+        border-radius: var(--radius-md);
+        background: color-mix(in oklab, var(--accent), transparent 85%);
+        color: var(--accent);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .form-row {
+        display: grid;
+        grid-template-columns: 1.1fr 1fr;
+        gap: var(--space-12);
+        align-items: start;
+        margin-block-start: var(--space-8);
+      }
+      @media (max-width: 1023px) {
+        .form-row { grid-template-columns: 1fr; gap: var(--space-8); }
+      }
+      .form {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+        max-width: 460px;
+        padding: var(--space-6);
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+      }
+      .form-actions {
+        display: flex;
+        gap: var(--space-3);
+        margin-block-start: var(--space-2);
+        align-items: center;
+      }
+
+      .row-between {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-3);
+      }
+      .icon { width: 16px; height: 16px; flex-shrink: 0; }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <!-- ════════════════════════════════════════════════════════════
+           HERO — exercises: atmospheric warm gradient (DESIGN.md §6
+           "subtle warm gradient glows behind hero content"), h1 at
+           96px ABC Favorit with -0.05em tracking, .lede in --fg-2,
+           white-pill CTA (max contrast), frost-pill CTA (subtle),
+           kbd shortcut, muted-pill status badge. Single-column
+           layout — Resend heroes float a tight content island in
+           vast dark space.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section class="hero" data-od-id="hero">
+        <p class="eyebrow">Reference fixture · Resend</p>
+        <h1>Email for developers, not marketing teams.</h1>
+        <p class="lede">
+          A token block distilled from Resend's published design
+          system — ABC Favorit with -0.05em display tracking, frost
+          borders instead of gray hairlines, one accent at a time.
+          The fixture you are reading paints from the same
+          <code style="font-family: var(--font-mono); font-size: 0.95em">:root</code>
+          block agents inline into every Resend artifact.
+        </p>
+        <div class="hero-actions">
+          <a href="./tokens.css" class="btn btn-pill-white">
+            Send your first email
+            <svg
+              class="icon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.75"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M5 12h14M13 6l6 6-6 6" />
+            </svg>
+          </a>
+          <a href="./DESIGN.md" class="btn btn-pill">Read the spec</a>
+          <a href="#code" class="btn btn-ghost">See the SDK</a>
+        </div>
+        <p class="hero-meta">
+          <span class="badge badge-success">
+            <span class="badge-dot" aria-hidden="true"></span>
+            v0.1 · stable
+          </span>
+          <span>Press <kbd>⌘</kbd> <kbd>K</kbd> to search the docs.</span>
+        </p>
+      </section>
+
+      <!-- ════════════════════════════════════════════════════════════
+           FEATURES — exercises: .card with frost border (no opaque
+           shadow on void), h3 at 24px Inter weight 500, .body-muted,
+           .badge-accent at 20% accent tint, .feature-icon glyph
+           tile, .features-grid three-up collapsing to one. Three
+           cards demonstrate the three product surfaces: SDK / API
+           / Domain — each gets exactly one accent tint per card so
+           the ≤2 accent uses per screen rule still reads at scale.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="features">
+        <div class="stack-3">
+          <p class="eyebrow">What this fixture exercises</p>
+          <h2 style="max-width: 18ch">
+            Built for the way you actually ship.
+          </h2>
+          <p class="body-muted" style="margin-block-start: var(--space-4); max-width: 56ch">
+            Every component below pulls from
+            <code style="font-family: var(--font-mono); font-size: 0.95em">var(--*)</code>
+            — no raw hex outside the documented brand palette, no
+            off-token type. Frost borders carry every container edge;
+            the orange accent appears at most twice per viewport.
+          </p>
+        </div>
+
+        <div class="features-grid">
+          <article class="card feature-card">
+            <span class="feature-icon" aria-hidden="true">
+              <svg
+                class="icon"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.75"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M4 6h16v12H4z" />
+                <path d="M4 6l8 7 8-7" />
+              </svg>
+            </span>
+            <h3>One SDK, every runtime.</h3>
+            <p class="body-muted body-sm">
+              Node, Python, Ruby, Go, PHP, Rust, Java — same surface,
+              same idempotent send. Drop the SDK into an edge worker
+              and the API contract doesn't shift.
+            </p>
+            <a href="./tokens.css" class="link-accent body-sm">Inspect tokens &rarr;</a>
+          </article>
+
+          <article class="card feature-card">
+            <span class="feature-icon" aria-hidden="true">
+              <svg
+                class="icon"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.75"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M3 12h4l3-7 4 14 3-7h4" />
+              </svg>
+            </span>
+            <h3>Frost borders, no shadows.</h3>
+            <p class="body-muted body-sm">
+              <code style="font-family: var(--font-mono); font-size: 0.95em">border: 1px solid rgba(214,235,253,.19)</code>
+              replaces every gray hairline. On pure black, blur
+              shadows vanish — the icy line catches what little
+              light there is and reads as a crystalline edge.
+            </p>
+            <a href="./DESIGN.md" class="link-accent body-sm">Read the rule &rarr;</a>
+          </article>
+
+          <article class="card feature-card">
+            <span class="feature-icon" aria-hidden="true">
+              <svg
+                class="icon"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.75"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M4 7h16M4 12h10M4 17h16" />
+              </svg>
+            </span>
+            <h3>Three fonts, three roles.</h3>
+            <p class="body-muted body-sm">
+              ABC Favorit announces, Inter reads, Commit Mono
+              instructs. Display tracking compresses to
+              <code style="font-family: var(--font-mono); font-size: 0.95em">-0.05em</code>
+              so headlines feel engineered, never decorative.
+            </p>
+            <a href="./tokens.css" class="link-accent body-sm">Inspect typography &rarr;</a>
+          </article>
+        </div>
+      </section>
+
+      <!-- ════════════════════════════════════════════════════════════
+           CODE PANEL — Resend's distinctive surface: a Commit Mono
+           code block inside a frost-bordered 24px-radius panel.
+           Syntax highlighting reaches the multi-color accent tokens
+           (orange for keys, green for strings, yellow for fn names,
+           dark gray for comments) — this is the ONE place per
+           viewport where multiple accent colors are sanctioned by
+           DESIGN.md §4 "Code Preview Panels".
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="code" id="code">
+        <p class="eyebrow">The SDK in two lines</p>
+        <h2 style="margin-block-start: var(--space-3); max-width: 22ch">
+          <code style="font-family: var(--font-mono); font-size: 0.78em">resend.emails.send</code>, and you're done.
+        </h2>
+        <p class="body-muted" style="margin-block-start: var(--space-4); max-width: 56ch">
+          The code panel is the one surface where Resend's multi-
+          color accent scale is sanctioned: orange for keys, green
+          for strings, yellow for function names, dark gray for
+          comments. Everywhere else, the orange accent holds the
+          chromatic moment alone.
+        </p>
+
+        <div class="code-panel" style="margin-block-start: var(--space-8); max-width: 760px">
+          <div class="code-panel-head">
+            <span class="code-panel-dot" aria-hidden="true"></span>
+            <span class="code-panel-dot" aria-hidden="true"></span>
+            <span class="code-panel-dot" aria-hidden="true"></span>
+            <span class="code-panel-title">send.ts</span>
+          </div>
+          <pre><span class="tok-com">// send your first transactional email</span>
+<span class="tok-key">import</span> { Resend } <span class="tok-key">from</span> <span class="tok-str">"resend"</span>;
+
+<span class="tok-key">const</span> resend = <span class="tok-key">new</span> <span class="tok-fn">Resend</span>(<span class="tok-str">"re_xxxxx"</span>);
+
+<span class="tok-key">await</span> resend.emails.<span class="tok-fn">send</span>({
+  from: <span class="tok-str">"onboarding@resend.dev"</span>,
+  to: <span class="tok-str">"delivered@resend.dev"</span>,
+  subject: <span class="tok-str">"Hello from Resend"</span>,
+  html: <span class="tok-str">"&lt;p&gt;Shipped.&lt;/p&gt;"</span>,
+});</pre>
+        </div>
+      </section>
+
+      <!-- ════════════════════════════════════════════════════════════
+           FORM — exercises: .field with frost shadow-border inputs,
+           focus-visible swap to the 2px accent ring, .btn-pill-white
+           and .btn-pill reuse. Form sits inside its own frost-
+           bordered card so the input edges read as recessed within
+           the form surface.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="form">
+        <p class="eyebrow">Form components</p>
+        <h2 style="margin-block-start: var(--space-3); max-width: 28ch">
+          Inputs inherit the same tokens.
+        </h2>
+
+        <div class="form-row">
+          <div class="stack-4">
+            <p class="body-muted" style="max-width: 48ch">
+              Focus rings, edges, placeholder color — all derive from
+              <code style="font-family: var(--font-mono); font-size: 0.95em">--accent</code>
+              and <code style="font-family: var(--font-mono); font-size: 0.95em">--border</code>.
+              The submit button reuses
+              <code style="font-family: var(--font-mono); font-size: 0.95em">.btn-pill-white</code>
+              unchanged — white fill, black label, 9999px radius.
+            </p>
+            <p class="body-muted body-sm">
+              No new token is introduced for this section. The form
+              card uses the standard frost border + 16px radius;
+              input shadow-borders read as recessed beneath the
+              card's outer frost line.
+            </p>
+            <p class="body-meta">
+              Full reference at <a href="./tokens.css">tokens.css</a> ·
+              spec at <a href="./DESIGN.md">DESIGN.md</a>.
+            </p>
+          </div>
+
+          <form class="form" onsubmit="event.preventDefault();">
+            <div class="row-between">
+              <p class="eyebrow">Join the beta</p>
+              <span class="badge badge-muted">
+                <span class="badge-dot" aria-hidden="true" style="color: var(--success)"></span>
+                Open
+              </span>
+            </div>
+            <div class="field">
+              <label for="email">Work email</label>
+              <input
+                id="email"
+                type="email"
+                placeholder="you@team.dev"
+                autocomplete="email"
+                required
+              />
+              <p class="field-help">
+                We'll send the API key and nothing else.
+              </p>
+            </div>
+            <div class="form-actions">
+              <button type="submit" class="btn btn-pill-white">
+                Get the API key
+              </button>
+              <button type="button" class="btn btn-pill">
+                Read the docs
+              </button>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/resend/tokens.css
+++ b/design-systems/resend/tokens.css
@@ -1,0 +1,353 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/resend/tokens.css
+ *
+ * Structured token bindings for "Resend" — the developer-first email
+ * API whose marketing surface treats a pure-black canvas like a
+ * gallery wall and lights every container with a single, icy blue-
+ * tinted hairline.
+ *
+ * Brand identity in three sentences:
+ *   1. Void-black (#000000) canvas with near-white (#f0f0f0) ink —
+ *      theatrical darkness; the page is the stage and content
+ *      performs on it without competing chrome.
+ *   2. Frost borders (rgba(214, 235, 253, 0.19)) replace gray borders
+ *      everywhere — every divider, button, card, and tab is a thin
+ *      icy line on the void; depth is by border luminance, not by
+ *      blur shadows that cannot cast against pure black.
+ *   3. ABC Favorit (geometric sans) for display headings with
+ *      aggressive negative tracking, Inter for body and UI, Commit
+ *      Mono for code — one accent at a time (here: Resend Orange
+ *      #ff801f) so the chromatic moment lands hard against the gray.
+ *
+ * Brand-specific schema decisions (each one bends a schema convention
+ * to match Resend's voice rather than the cross-brand default):
+ *
+ *   1. `--bg` and `--surface` both bind to `#000000`. DESIGN.md §7 is
+ *      explicit: "Don't lighten the background above #000000 — the
+ *      pure black void is non-negotiable." Cards on Resend do not
+ *      lift via fill; they read by their frost border alone. Setting
+ *      `--surface` to the same void as `--bg` honors that rule and
+ *      forces every card-like component to express elevation through
+ *      `--border` / `--elev-ring`, not through tinted backgrounds.
+ *      `--surface-warm` aliases to `--surface` because the brand has
+ *      no warm tier — there is no second background color anywhere.
+ *
+ *   2. `--border` is `rgba(214, 235, 253, 0.19)` — the literal
+ *      "frost border" alpha named in DESIGN.md §1 as "the signature"
+ *      of the entire system. Binding the slot to the alpha (not a
+ *      solid hex) lets `--elev-ring` (`0 0 0 1px var(--border)`)
+ *      reproduce the icy line by default, and lets every component
+ *      reach the same value via `border: 1px solid var(--border)`.
+ *      `--border-soft` drops to `rgba(217, 237, 254, 0.145)` for
+ *      inner row separators that should not compete with the
+ *      container's outer frost edge.
+ *
+ *   3. `--fg` is `#f0f0f0`, not `#ffffff`. DESIGN.md §2 names this
+ *      the "Near White" — a deliberately softened text tier that
+ *      lets pure white (`#ffffff`) stay reserved for the maximum-
+ *      emphasis moments DESIGN.md describes as "link highlights"
+ *      and the white-pill CTA. The four-level foreground ramp
+ *      (`#f0f0f0 → #a1a4a5 → #5c5c5c → #464a4d`) maps directly onto
+ *      DESIGN.md §2's documented neutral scale (Near White, Silver,
+ *      Mid Gray, Dark Gray) so `--fg-2` and `--meta` are
+ *      independently bound rather than aliased.
+ *
+ *   4. `--accent` is Resend Orange (`#ff801f`, "Orange 10" in
+ *      DESIGN.md §2). Resend's product surface uses a multi-color
+ *      accent system (orange/green/blue/yellow/red), but the shared
+ *      schema slot must pick one — and Orange 10 is the only entry
+ *      DESIGN.md prefixes with "primary orange accent". The blue
+ *      and green variants live as semantic / inline values in
+ *      components.html; promoting any of them to a second accent
+ *      slot would require a C-extension, which the brand contract
+ *      defers until ≥2 brands need the same name. `--accent-on` is
+ *      `#000000` because saturated orange against black reads best
+ *      with black labels (DESIGN.md §4 confirms the white-pill
+ *      pattern is for `#ffffff` solid backgrounds, not for the
+ *      orange accent fill).
+ *
+ *   5. `--accent-hover` brightens toward white (10%) and
+ *      `--accent-active` darkens toward black (12%) — the inverse
+ *      of the schema's default mid-luminance pattern. On Resend's
+ *      void canvas, a "pressed" state reads as a small recession
+ *      into the dark, while a "lifted" hover reads as a luminance
+ *      step up. This matches the Linear / dark-system convention
+ *      and avoids the schema default's all-darken pattern that
+ *      would make the orange disappear into the void on hover.
+ *
+ *   6. Semantic colors come straight from DESIGN.md §2's multi-
+ *      color accent scale — `--success: #11ff99` (Green 4),
+ *      `--warn: #ffc53d` (Yellow 9), `--danger: #ff2047` (Red 5).
+ *      These are the saturated source values; components that want
+ *      the documented "12–42% opacity" tints reach them via
+ *      `color-mix(in oklab, var(--success), transparent 80%)` in
+ *      situ, keeping the alpha-blend decision at the component
+ *      layer rather than in the token slot.
+ *
+ *   7. Type scale is documented in DESIGN.md §3: 96px display,
+ *      56px section, 24px feature title, 20px sub-heading, 18px
+ *      body-large, 16px body, 14px caption, 12px small. The schema
+ *      has 8 slots; `--text-2xl` is bound to `36px` as the
+ *      intermediate that bridges 24px (feature title) to 56px
+ *      (section heading) — DESIGN.md does not enumerate this stop,
+ *      but a 24 → 56 jump without a mid-tier would force every H2
+ *      to either undershoot or overshoot. `--leading-tight: 1.0`
+ *      matches the documented Display Hero rhythm; `--leading-body:
+ *      1.5` matches the documented Body / Body Large / Feature
+ *      Title leading.
+ *
+ *   8. `--tracking-display` is `-0.05em`, derived from DESIGN.md
+ *      §3 Section Heading (`-2.8px at 56px = -0.05em`). ABC Favorit
+ *      compresses harder than Domaine Display (`-0.01em` at 96px),
+ *      so binding the slot to the ABC Favorit characteristic value
+ *      gives every display-tier element the brand's "engineered
+ *      masthead" feel. The hero in components.html can opt back
+ *      into the gentler Domaine tracking inline if needed.
+ *
+ *   9. `--font-display` lists ABC Favorit first, with Inter as the
+ *      structural fallback. Inter is documented in DESIGN.md §3 as
+ *      the body / UI font, but it shares the geometric voice well
+ *      enough to carry display weight when ABC Favorit is not
+ *      loaded — far better than falling through to a generic system
+ *      sans. Domaine Display (the editorial serif hero font) is
+ *      deliberately not in the stack: it is a paid Klim Type
+ *      Foundry face whose absence would surface as a jarring serif
+ *      drop. Heroes that want Domaine layer it in via
+ *      `font-family: "Domaine Display", var(--font-display)` at the
+ *      component level.
+ *
+ *  10. Section rhythm is generous: 120px desktop, 80px tablet, 48px
+ *      phone. DESIGN.md §5 names "Cinematic black space" with "80–
+ *      120px+ vertical spacing between sections" as a defining
+ *      property — "the black background IS the whitespace". 120px
+ *      desktop sits at the top of that documented range.
+ *
+ *  11. `--radius-sm` is `4px` (DESIGN.md "Sharp": buttons-ghost,
+ *      inputs); `--radius-md` is `8px` (tabs / content blocks);
+ *      `--radius-lg` is `16px` (feature cards / images / main
+ *      buttons); `--radius-pill` is `9999px` (primary CTAs / tags
+ *      / badges). The 24px "Section" radius from DESIGN.md is
+ *      component-specific (large panels) and reached inline rather
+ *      than via the shared schema.
+ *
+ *  12. `--elev-raised` layers the documented `rgba(176, 199, 217,
+ *      0.145) 0 0 0 1px` ring shadow with the subtle drop from
+ *      DESIGN.md §6 Level 2. On pure black, opaque blur shadows
+ *      vanish — the ring carries the edge, and the soft drop adds
+ *      just enough atmospheric tint to read as "lifted" against
+ *      the void. Never strip the ring when overriding this token.
+ *
+ *  13. `--focus-ring` is a sharp 2px ring at `var(--accent)`, not
+ *      the schema's 3px alpha glow. DESIGN.md §6 Level 3 documents
+ *      a heavy 8px black focus ring that works in product context
+ *      (against non-black surroundings); on this brand fixture the
+ *      black canvas would swallow that ring, so we substitute the
+ *      orange accent at 2px — sharp, engineered, legible against
+ *      both the void and any card surface.
+ *
+ *  14. `--container-max` caps at `1200px` with generous 32px
+ *      desktop gutters — Resend's marketing pages center contained
+ *      content in vast dark space, treating the gutter as part of
+ *      the gallery margin rather than as edge-bleed.
+ *
+ * Source contracts:
+ *   - Standard token names: design-systems/_schema/tokens.schema.ts
+ *   - A2 fallback parity:   design-systems/_schema/defaults.css
+ *   - Lint enforcement:     apps/daemon/src/lint-artifact.ts
+ *
+ * Keep this file additive: never invent token names not also
+ * documented in DESIGN.md or the schema. ABC Favorit, Domaine
+ * Display, and Commit Mono are paid faces — the stacks list
+ * defensible OS fallbacks so artifacts render legibly even when
+ * the brand faces are not loaded.
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface (3 levels — schema slot) ─────────────────────────────
+   * The void is the canvas. DESIGN.md §7: "Don't lighten the
+   * background above #000000 — the pure black void is non-
+   * negotiable." `--surface` matches `--bg` because cards on Resend
+   * read by their frost border alone, not by a tinted fill.
+   * `--surface-warm` aliases to surface — the brand has no second
+   * background color anywhere. */
+  --bg: #000000;
+  --surface: #000000;
+  --surface-warm: var(--surface);          /* alias — Resend has no warm tier */
+
+  /* ─── Foreground ramp (4 levels) ──────────────────────────────────
+   * Near White → Silver → Mid Gray → Dark Gray, the documented
+   * neutral scale from DESIGN.md §2. `#f0f0f0` instead of `#ffffff`
+   * matters — pure white is reserved for the white-pill CTA and link
+   * highlights; the softened near-white keeps body type calm against
+   * the void. All four tiers are independently bound (not aliased)
+   * because DESIGN.md names four distinct neutral roles: primary
+   * text, secondary / link-muted, hover / caption, tertiary /
+   * quaternary timestamp. */
+  --fg: #f0f0f0;                           /* Near White — primary text, button labels */
+  --fg-2: #a1a4a5;                         /* Silver — secondary text, muted links */
+  --muted: #5c5c5c;                        /* Mid Gray — captions, hover, subtle emphasis */
+  --meta: #464a4d;                         /* Dark Gray — tertiary text, timestamps */
+
+  /* ─── Border (2 levels) ──────────────────────────────────────────
+   * Frost-as-border is THE signature: `rgba(214, 235, 253, 0.19)`
+   * at 1px replaces every gray border in the system. Binding
+   * `--border` to the alpha (not a solid hex) lets `--elev-ring`
+   * reproduce the icy line by default, and lets
+   * `border: 1px solid var(--border)` paint the same value when a
+   * real CSS border is structurally required (e.g. the bottom edge
+   * of the sticky nav per DESIGN.md §4). `--border-soft` drops to
+   * `0.145` alpha for inner row separators that must not compete
+   * with the container's outer frost edge. */
+  --border: rgba(214, 235, 253, 0.19);     /* signature frost border alpha */
+  --border-soft: rgba(217, 237, 254, 0.145); /* inner row separator — lighter frost */
+
+  /* ─── Accent ─────────────────────────────────────────────────────
+   * Resend Orange (Orange 10 from DESIGN.md §2). Hard cap of ≤2
+   * visible uses per screen — DESIGN.md §7 forbids cross-mixing
+   * accent colors within a single component. The multi-color
+   * scale (green/blue/yellow/red) lives at the semantic / inline
+   * layer; only the orange slot rides on `--accent`.
+   *
+   * `--accent-on` is BLACK, not white — saturated #ff801f against
+   * black reads cleanest with black labels (the white-pill CTA in
+   * DESIGN.md §4 uses #ffffff fill with #000000 text, not the
+   * orange accent). Hover brightens 10% toward white, active
+   * darkens 12% toward black — the inverse of the schema's all-
+   * darken default, matching the dark-theme convention where
+   * "pressed" reads as recession into the void. */
+  --accent: #ff801f;                       /* Resend Orange — primary chromatic accent */
+  --accent-on: #000000;                    /* black label on saturated orange fill */
+  --accent-hover: color-mix(in oklab, var(--accent), white 10%);
+  --accent-active: color-mix(in oklab, var(--accent), black 12%);
+
+  /* ─── Semantic ───────────────────────────────────────────────────
+   * Saturated source values from DESIGN.md §2's multi-color accent
+   * scale. Components reach the documented 12–42% opacity tints
+   * via `color-mix(in oklab, var(--success), transparent 80%)` in
+   * situ, keeping the alpha-blend decision at the component layer. */
+  --success: #11ff99;                      /* Green 4 — emerald success indicator */
+  --warn: #ffc53d;                         /* Yellow 9 — warm gold warning */
+  --danger: #ff2047;                       /* Red 5 — error / destructive */
+
+  /* ─── Typography ─────────────────────────────────────────────────
+   * Three-font editorial hierarchy from DESIGN.md §3. ABC Favorit
+   * carries display; Inter carries body and UI; Commit Mono
+   * carries code and technical labels. Domaine Display (the
+   * editorial serif hero face) is intentionally not in the
+   * `--font-display` stack — it is a paid Klim Type Foundry face
+   * whose absence would surface as a jarring serif drop. Heroes
+   * that want Domaine layer it in via `font-family: "Domaine
+   * Display", var(--font-display)` at the component level. */
+  --font-display: "ABC Favorit", "Inter", -apple-system, system-ui, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  --font-body: "Inter", -apple-system, system-ui, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  --font-mono: "Commit Mono", "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
+
+  /* Type scale (px) — derived from DESIGN.md §3 hierarchy table.
+   * 12 / 14 / 16 / 18 / 20 / 24 / 56 / 96 are all documented; the
+   * 36px `--text-2xl` is the synthesized intermediate that bridges
+   * 24px feature-title to 56px section-heading. Without it, every
+   * H2 would have to undershoot at 24 or overshoot at 56 and the
+   * type rhythm would jump. */
+  --text-xs: 12px;                         /* Small — tags, meta, fine print */
+  --text-sm: 14px;                         /* Caption, button, nav link */
+  --text-base: 16px;                       /* Body — standard reading */
+  --text-lg: 20px;                         /* Sub-heading — ABC Favorit */
+  --text-xl: 24px;                         /* Feature Title — Inter weight 500 */
+  --text-2xl: 36px;                        /* Synthesized H2 — bridges 24 → 56 */
+  --text-3xl: 56px;                        /* Section Heading — ABC Favorit */
+  --text-4xl: 96px;                        /* Display Hero — Domaine / ABC Favorit */
+
+  /* Leading + tracking.
+   * --leading-body 1.5: DESIGN.md body / feature-title / body-large.
+   * --leading-tight 1.0: DESIGN.md Display Hero (96px).
+   * --tracking-display -0.05em: ABC Favorit Section Heading
+   *   (-2.8px / 56px). Harder compression than Domaine's -0.01em;
+   *   binding the slot to the ABC Favorit value gives display tiers
+   *   the brand's "engineered masthead" feel. */
+  --leading-body: 1.5;
+  --leading-tight: 1.0;
+  --tracking-display: -0.05em;
+
+  /* ─── Spacing ────────────────────────────────────────────────────
+   * Standard 4px-grid base scale. DESIGN.md §5 also documents 5px,
+   * 6px, 7px, 10px, 30px, 40px micro-tiers — those are too fine to
+   * belong in the shared schema and are inlined per-component when
+   * needed (button padding `5px 12px`, etc.). The 4/8/12/16/20/
+   * 24/32/48 tier covers the structural rhythm. */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+
+  /* Section rhythm — DESIGN.md §5: "Cinematic black space" with
+   * 80–120px+ vertical padding between sections. 120px desktop sits
+   * at the top of the documented range, dropping to 80px tablet
+   * (still generous) and 48px phone (the documented mobile floor). */
+  --section-y-desktop: 120px;
+  --section-y-tablet: 80px;
+  --section-y-phone: 48px;
+
+  /* ─── Radius ─────────────────────────────────────────────────────
+   * DESIGN.md §5 radius scale: 4 / 6 / 8 / 10 / 12 / 16 / 24 / 9999.
+   * We bind the four schema tiers to: 4 (sharp — ghost button,
+   * inputs), 8 (standard — tabs, content), 16 (large — feature
+   * cards, images, main buttons), 9999 (pill — primary CTAs, tags,
+   * badges). The 24px "Section" radius is component-specific (large
+   * panels) and reached inline. */
+  --radius-sm: 4px;                        /* Sharp — ghost button, input */
+  --radius-md: 8px;                        /* Standard — tab, content block */
+  --radius-lg: 16px;                       /* Large — feature card, image, main button */
+  --radius-pill: 9999px;                   /* Pill — primary CTA, tag, badge */
+
+  /* ─── Elevation (3 levels) ───────────────────────────────────────
+   * Resend barely uses shadows — DESIGN.md §6: "On a pure black
+   * background, traditional shadows are invisible — you can't cast
+   * a shadow into the void. Instead, Resend creates depth through
+   * its signature frost borders."
+   *
+   *   --elev-flat    no shadow (page background, text blocks)
+   *   --elev-ring    the signature frost hairline (most surfaces)
+   *   --elev-raised  ring + subtle drop for true "lifted" feel
+   *
+   * `--elev-raised` layers the documented `rgba(176, 199, 217, 0.145)
+   * 0 0 0 1px` ring with the §6 Level 2 subtle drop. Never strip
+   * the ring when overriding — it is the edge mechanism that lets
+   * a card read against the void at all. */
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised:
+    0 0 0 1px rgba(176, 199, 217, 0.145),
+    0 1px 3px rgba(0, 0, 0, 0.4),
+    0 1px 2px -1px rgba(0, 0, 0, 0.4);
+
+  /* ─── Focus ring ─────────────────────────────────────────────────
+   * Sharp 2px ring at `var(--accent)`, NOT the schema's 3px alpha
+   * glow. DESIGN.md §6 documents an 8px black ring that works in
+   * product context (against non-black surroundings); on this
+   * brand fixture the black canvas would swallow that ring, so we
+   * substitute the orange accent at 2px — sharp, engineered,
+   * legible against both the void and any card surface. */
+  --focus-ring: 0 0 0 2px var(--accent);
+
+  /* ─── Motion ─────────────────────────────────────────────────────
+   * Two durations + one easing curve. Resend's micro-states are
+   * quick and unobtrusive — pill buttons crossfade to white glass,
+   * frost borders intensify on focus, no choreographed entrances. */
+  --motion-fast: 150ms;
+  --motion-base: 200ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+  /* ─── Layout ─────────────────────────────────────────────────────
+   * 1200px max content width — DESIGN.md §5 "Centered content with
+   * generous max-width". Gutters stay wide on desktop (32px) so
+   * the gallery margin around the void canvas reads as intentional
+   * framing; mobile narrows to 16px to preserve readable measure. */
+  --container-max: 1200px;
+  --container-gutter-desktop: 32px;
+  --container-gutter-tablet: 24px;
+  --container-gutter-phone: 16px;
+}

--- a/design-systems/runwayml/components.html
+++ b/design-systems/runwayml/components.html
@@ -1,0 +1,638 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Runway — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/runwayml. Every visible
+        value comes from tokens.css. Runway's signature moves: true black
+        canvas, single typeface (abcNormal), cool-slate neutrals, zero
+        shadows, sharp 4–8px corners, cinema-wide 1600px container."
+    />
+
+    <style>
+      :root {
+        --bg:           #000000;
+        --surface:      #1a1a1a;
+        --surface-warm: #030303;
+
+        --fg:    #ffffff;
+        --fg-2:  #e9ecf2;
+        --muted: #767d88;
+        --meta:  #7d848e;
+
+        --border:      #27272a;
+        --border-soft: #1a1a1a;
+
+        --accent:        #ffffff;
+        --accent-on:     #000000;
+        --accent-hover:  #e9ecf2;
+        --accent-active: #c9ccd1;
+
+        --success: #16a34a;
+        --warn:    #eab308;
+        --danger:  #dc2626;
+
+        --font-display: "abcNormal", "abcNormal Fallback", "Inter", "DM Sans", system-ui, -apple-system, "Segoe UI", sans-serif;
+        --font-body:    "abcNormal", "abcNormal Fallback", "Inter", "DM Sans", system-ui, -apple-system, "Segoe UI", sans-serif;
+        --font-mono:    ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Monaco, Consolas, monospace;
+
+        --text-xs:   11px;
+        --text-sm:   13px;
+        --text-base: 16px;
+        --text-lg:   20px;
+        --text-xl:   24px;
+        --text-2xl:  36px;
+        --text-3xl:  40px;
+        --text-4xl:  48px;
+
+        --leading-body:     1.4;
+        --leading-tight:    1.0;
+        --tracking-display: -0.025em;
+
+        --space-1:  4px;
+        --space-2:  8px;
+        --space-3:  12px;
+        --space-4:  16px;
+        --space-5:  20px;
+        --space-6:  24px;
+        --space-8:  32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 78px;
+        --section-y-tablet:  48px;
+        --section-y-phone:   32px;
+
+        --radius-sm:   4px;
+        --radius-md:   8px;
+        --radius-lg:   16px;
+        --radius-pill: 9999px;
+
+        --elev-flat:   none;
+        --elev-ring:   0 0 0 1px var(--border);
+        --elev-raised: none;
+
+        --focus-ring: 0 0 0 2px color-mix(in oklab, var(--accent), transparent 60%);
+
+        --motion-fast:   150ms;
+        --motion-base:   220ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+        --container-max:            1600px;
+        --container-gutter-desktop: 48px;
+        --container-gutter-tablet:  24px;
+        --container-gutter-phone:   16px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        letter-spacing: -0.01em;
+        -webkit-font-smoothing: antialiased;
+      }
+
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      section + section { border-top: 1px solid var(--border); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography ─────────────────────────────
+       * abcNormal handles every role; size + case + tracking carry
+       * hierarchy, not weight. Display sizes use line-height 1.0 and
+       * heavy negative tracking ("film-title" compression). */
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        line-height: var(--leading-tight);
+        margin: 0;
+        font-weight: 400;
+        color: var(--fg);
+      }
+      h1 {
+        font-size: var(--text-4xl);
+        letter-spacing: var(--tracking-display);
+      }
+      h2 {
+        font-size: var(--text-3xl);
+        letter-spacing: -0.022em;
+      }
+      h3 {
+        font-size: var(--text-xl);
+        letter-spacing: -0.005em;
+      }
+      p { margin: 0; }
+      .lead {
+        font-size: var(--text-lg);
+        line-height: 1.35;
+        color: var(--muted);
+        letter-spacing: -0.01em;
+        font-weight: 400;
+      }
+      .body-muted { color: var(--muted); }
+      .body-sm { font-size: var(--text-sm); letter-spacing: -0.01em; }
+
+      /* Eyebrow / navigational labels — uppercase with positive
+         tracking, weight 450 (the "precision detail" called out in
+         DESIGN.md §3 principles). */
+      .label {
+        font-size: var(--text-xs);
+        font-weight: 450;
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-family: var(--font-body);
+      }
+      .caption {
+        font-size: var(--text-sm);
+        font-weight: 500;
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.07em;
+      }
+      code, kbd {
+        font-family: var(--font-mono);
+        font-size: 0.875em;
+        color: var(--fg-2);
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        padding: 1px 6px;
+      }
+      .stack-2 > * + * { margin-block-start: var(--space-2); }
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+      .stack-8 > * + * { margin-block-start: var(--space-8); }
+
+      /* ─── Buttons ─────────────────────────────────
+       * Restrained per DESIGN.md §4 ("no heavy fills or borders").
+       * Primary = white-on-black CTA pill-free (sharp 4px corners).
+       * Secondary = ghost outline. No drop shadows on any state. */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 12px 18px;
+        border-radius: var(--radius-sm);
+        font-family: var(--font-body);
+        font-size: var(--text-sm);
+        font-weight: 600;
+        line-height: 1;
+        cursor: pointer;
+        border: 1px solid transparent;
+        text-decoration: none;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard),
+          border-color var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn-primary {
+        background: var(--accent);
+        color: var(--accent-on);
+      }
+      .btn-primary:hover  { background: var(--accent-hover); }
+      .btn-primary:active { background: var(--accent-active); }
+      .btn-secondary {
+        background: transparent;
+        color: var(--fg);
+        border-color: var(--border);
+      }
+      .btn-secondary:hover {
+        border-color: var(--fg-2);
+        color: var(--fg);
+      }
+      .btn-ghost {
+        background: transparent;
+        color: var(--muted);
+        padding: 12px 6px;
+      }
+      .btn-ghost:hover { color: var(--fg); }
+
+      /* ─── Tags / chips ───────────────────────────
+       * Micro labels at 11px uppercase weight 450 (no bg fill — the
+       * surface itself is the container; DESIGN.md is explicit that
+       * the design is NOT pill-shaped). */
+      .tag {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 4px 8px;
+        border-radius: var(--radius-sm);
+        background: transparent;
+        border: 1px solid var(--border);
+        color: var(--muted);
+        font-size: var(--text-xs);
+        font-weight: 450;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .tag-dot {
+        width: 6px;
+        height: 6px;
+        border-radius: var(--radius-pill);
+        background: currentColor;
+      }
+
+      /* ─── Cards ──────────────────────────────────
+       * Cards barely exist as containers — DESIGN.md §4: "the image
+       * IS the card." We keep a hairline ring (--elev-ring) and a
+       * subtle dark surface; no drop shadow ever. Image-first card
+       * uses an 8px image radius and a flat text well below. */
+      .card {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+      }
+      .card-media {
+        aspect-ratio: 16 / 10;
+        background: var(--surface-warm);
+        position: relative;
+        overflow: hidden;
+        display: flex;
+        align-items: flex-end;
+        padding: var(--space-4);
+        color: var(--fg);
+      }
+      .card-media::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          180deg,
+          transparent 0%,
+          transparent 55%,
+          rgba(0, 0, 0, 0.55) 100%
+        );
+        pointer-events: none;
+      }
+      .card-media-tag {
+        position: relative;
+        z-index: 1;
+        font-size: var(--text-xs);
+        font-weight: 450;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--fg);
+      }
+      .card-body {
+        padding: var(--space-5) var(--space-5) var(--space-6);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+      }
+      .card-body h3 { color: var(--fg); }
+
+      /* Synthesized cinematic stills — we have no image asset, so we
+         paint film-grade frames with layered radial gradients. The
+         raw hex values here are LOCAL to a single component (visual
+         content is not part of the brand chrome; DESIGN.md §2:
+         "Visual richness comes entirely from photographic content").
+         Token discipline is honored — every UI surface uses var(--*). */
+      .frame-1 {
+        background:
+          radial-gradient(120% 80% at 20% 30%, #2a2a2e 0%, transparent 55%),
+          radial-gradient(80% 60% at 80% 70%, #4a4d57 0%, transparent 60%),
+          linear-gradient(180deg, #0d0d0f 0%, #1c1c20 100%);
+      }
+      .frame-2 {
+        background:
+          radial-gradient(60% 90% at 70% 40%, #3a3138 0%, transparent 60%),
+          radial-gradient(90% 70% at 20% 80%, #232024 0%, transparent 55%),
+          linear-gradient(135deg, #050507 0%, #1f1c22 100%);
+      }
+      .frame-3 {
+        background:
+          radial-gradient(80% 100% at 50% 0%, #2c2e3a 0%, transparent 65%),
+          radial-gradient(60% 60% at 50% 100%, #14161c 0%, transparent 70%),
+          linear-gradient(180deg, #0a0a10 0%, #15161c 100%);
+      }
+      .frame-hero {
+        background:
+          radial-gradient(70% 60% at 50% 35%, #3a3a40 0%, transparent 60%),
+          radial-gradient(40% 80% at 80% 90%, #1e1e22 0%, transparent 60%),
+          linear-gradient(180deg, #0a0a0c 0%, #1d1d22 100%);
+      }
+
+      /* ─── Inputs ─────────────────────────────────
+       * Flat dark fields, 4px sharp radius, hairline border, white
+       * focus ring (the only chromatic affordance). */
+      .field { display: flex; flex-direction: column; gap: var(--space-2); }
+      .field label {
+        font-size: var(--text-xs);
+        font-weight: 450;
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .field input {
+        background: var(--surface);
+        color: var(--fg);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        padding: 12px 14px;
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        letter-spacing: -0.01em;
+        outline: none;
+        transition:
+          border-color var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .field input::placeholder { color: var(--meta); }
+      .field input:focus-visible {
+        border-color: var(--fg-2);
+        box-shadow: var(--focus-ring);
+      }
+      .field-help {
+        font-size: var(--text-xs);
+        color: var(--meta);
+        letter-spacing: 0.01em;
+      }
+
+      /* ─── Layout primitives ──────────────────────
+       * Asymmetric editorial grids per DESIGN.md §5 ("image grids:
+       * asymmetric, magazine-style mixed sizes"). */
+      .hero-grid {
+        display: grid;
+        grid-template-columns: 1.4fr 1fr;
+        gap: var(--space-12);
+        align-items: end;
+        min-height: 70vh;
+      }
+      @media (max-width: 1023px) {
+        .hero-grid { grid-template-columns: 1fr; min-height: 0; gap: var(--space-8); }
+      }
+      .hero-actions {
+        display: flex;
+        gap: var(--space-3);
+        margin-block-start: var(--space-6);
+        flex-wrap: wrap;
+      }
+      .hero-meta {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+        padding: var(--space-5);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface);
+      }
+      .hero-meta-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-3);
+      }
+      .hero-meta-row + .hero-meta-row {
+        padding-block-start: var(--space-3);
+        border-block-start: 1px solid var(--border-soft);
+      }
+
+      /* Hero film frame fills the left column with synthetic cinema. */
+      .hero-frame {
+        position: relative;
+        border-radius: var(--radius-md);
+        overflow: hidden;
+        aspect-ratio: 16 / 11;
+        display: flex;
+        align-items: flex-end;
+        padding: var(--space-6);
+      }
+      .hero-frame::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          180deg,
+          transparent 0%,
+          transparent 50%,
+          rgba(0, 0, 0, 0.6) 100%
+        );
+        pointer-events: none;
+      }
+      .hero-frame-caption {
+        position: relative;
+        z-index: 1;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+        color: var(--fg);
+      }
+      .hero-frame-caption .label { color: var(--fg-2); }
+
+      .features-grid {
+        display: grid;
+        grid-template-columns: 2fr 1fr 1fr;
+        gap: var(--space-5);
+      }
+      @media (max-width: 1023px) { .features-grid { grid-template-columns: 1fr 1fr; } }
+      @media (max-width: 639px)  { .features-grid { grid-template-columns: 1fr; } }
+
+      .form-row {
+        display: grid;
+        grid-template-columns: 1.2fr 1fr;
+        gap: var(--space-12);
+        align-items: start;
+      }
+      @media (max-width: 1023px) { .form-row { grid-template-columns: 1fr; gap: var(--space-8); } }
+      .form {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+        max-width: 440px;
+      }
+      .form-actions {
+        display: flex;
+        gap: var(--space-3);
+        margin-block-start: var(--space-2);
+        flex-wrap: wrap;
+      }
+
+      .icon { width: 14px; height: 14px; flex-shrink: 0; }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <!-- HERO — cinematic frame on the left, manifesto on the right.
+           Display headline uses Runway's signature compressed
+           film-title typography. -->
+      <section data-od-id="hero">
+        <div class="hero-grid">
+          <div class="hero-frame frame-hero" aria-hidden="true">
+            <div class="hero-frame-caption">
+              <span class="label">Gen-X · 00:00:42 / 00:01:08</span>
+              <span class="body-sm" style="color: var(--fg-2)">
+                Prompt — "a 35mm wide shot of empty coastal highway at dawn, low fog, anamorphic lens flare"
+              </span>
+            </div>
+          </div>
+
+          <div class="stack-4">
+            <p class="label">Reference fixture · runwayml</p>
+            <h1>The video model<br />for the next reel.</h1>
+            <p class="lead" style="max-width:38ch">
+              Gen-X generates cinema-grade video from a single sentence,
+              a still frame, or a 24-second reference clip. The interface
+              gets out of the way — the footage is the design.
+            </p>
+            <div class="hero-actions">
+              <a href="./tokens.css" class="btn btn-primary">
+                Try Gen-X
+                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                     stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M5 12h14M13 6l6 6-6 6"/>
+                </svg>
+              </a>
+              <a href="./DESIGN.md" class="btn btn-secondary">Read the spec</a>
+              <a href="#research" class="btn btn-ghost">Research →</a>
+            </div>
+
+            <aside class="hero-meta" aria-label="Render status">
+              <div class="hero-meta-row">
+                <span class="caption">Latest render</span>
+                <span class="tag"><span class="tag-dot" aria-hidden="true"></span>Ready</span>
+              </div>
+              <div class="hero-meta-row">
+                <span class="body-sm body-muted">Gen-X · 10s · 1080p</span>
+                <span class="body-sm" style="color: var(--fg-2)">38&nbsp;sec to&nbsp;render</span>
+              </div>
+              <div class="hero-meta-row">
+                <span class="body-sm body-muted">Press <kbd>R</kbd> to re-roll the seed.</span>
+              </div>
+            </aside>
+          </div>
+        </div>
+      </section>
+
+      <!-- RESEARCH — editorial three-card grid: one large feature plus
+           two smaller supporting cards (DESIGN.md §4 "mixed-size grid"). -->
+      <section data-od-id="research" id="research">
+        <div class="stack-3" style="margin-bottom: var(--space-8)">
+          <p class="label">Research</p>
+          <h2 style="max-width: 32ch">
+            We are building AI to simulate the world through imagination, art and aesthetics.
+          </h2>
+        </div>
+
+        <div class="features-grid">
+          <article class="card">
+            <div class="card-media frame-1">
+              <span class="card-media-tag">Featured · Gen-X</span>
+            </div>
+            <div class="card-body">
+              <p class="caption">Paper · 2026-03-14</p>
+              <h3>Long-horizon video coherence beyond 60 seconds.</h3>
+              <p class="body-muted body-sm">
+                Gen-X stitches scene-aware latents across shot boundaries — the
+                first time a single model has held character, lighting, and
+                camera continuity past a one-minute cut without re-prompting.
+              </p>
+              <a href="./DESIGN.md" class="body-sm" style="color: var(--fg-2); text-decoration: underline; text-underline-offset: 4px; text-decoration-color: var(--border)">
+                Read the paper →
+              </a>
+            </div>
+          </article>
+
+          <article class="card">
+            <div class="card-media frame-2">
+              <span class="card-media-tag">Tools</span>
+            </div>
+            <div class="card-body">
+              <p class="caption">Update · 2026-04-02</p>
+              <h3>Camera control, on every frame.</h3>
+              <p class="body-muted body-sm">
+                Dolly, push, orbit, and tilt — directable per-shot, exported
+                as standard motion-track data.
+              </p>
+            </div>
+          </article>
+
+          <article class="card">
+            <div class="card-media frame-3">
+              <span class="card-media-tag">Film</span>
+            </div>
+            <div class="card-body">
+              <p class="caption">Showcase · 2026-04-19</p>
+              <h3>The Coastal Reels — a 12-minute short.</h3>
+              <p class="body-muted body-sm">
+                Directed by Lina Marès. Every frame rendered with Gen-X,
+                no live photography on set.
+              </p>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <!-- FORM — minimal access request, single field, two CTAs. -->
+      <section data-od-id="form">
+        <div class="form-row">
+          <div class="stack-4">
+            <p class="label">Early access</p>
+            <h2>Request a Gen-X studio invite.</h2>
+            <p class="lead" style="max-width: 44ch">
+              We open studios in waves. Drop your work email — we send the
+              brief, the model card, and a render quota for evaluation. Nothing else.
+            </p>
+            <p class="body-sm body-muted" style="max-width: 44ch">
+              Filmmakers, agencies, and post houses currently in production
+              get prioritized; press <kbd>esc</kbd> to dismiss the form.
+            </p>
+          </div>
+
+          <form class="form" onsubmit="event.preventDefault();">
+            <div class="field">
+              <label for="email">Work email</label>
+              <input
+                id="email"
+                type="email"
+                placeholder="director@studio.com"
+                autocomplete="email"
+                required
+              />
+              <p class="field-help">
+                We will only contact you about your studio invite.
+              </p>
+            </div>
+            <div class="field">
+              <label for="reel">Project or reel link <span style="color: var(--meta); text-transform: none; letter-spacing: 0">(optional)</span></label>
+              <input
+                id="reel"
+                type="url"
+                placeholder="https://yourstudio.com/reel"
+              />
+            </div>
+            <div class="form-actions">
+              <button type="submit" class="btn btn-primary">
+                Request invite
+              </button>
+              <button type="button" class="btn btn-secondary">
+                Watch a reel first
+              </button>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/runwayml/tokens.css
+++ b/design-systems/runwayml/tokens.css
@@ -1,0 +1,204 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/runwayml/tokens.css
+ *
+ * Structured token bindings for the "Runway" brand — a cinematic,
+ * editorial-cinema dark canvas where photography (and AI-generated
+ * video) is the design and the chrome is intentionally invisible.
+ *
+ * Brand identity in three sentences:
+ *   1. Pure-black canvas (#000000) under bright pure-white type
+ *      (#ffffff), with cool blue-gray neutrals (#767d88 / #7d848e)
+ *      for the entire supporting text ramp — never warm gray.
+ *   2. Single typeface system: abcNormal at 400 / 450 / 500 / 600
+ *      (no bold) handles everything from 48px display down to 11px
+ *      uppercase tags. Hierarchy comes from size + case + tracking,
+ *      not weight.
+ *   3. Zero shadows, near-invisible borders (#27272a hairline), and
+ *      sharp 4–8px corners — depth comes from photographic content
+ *      and dark-vs-light section alternation, never from CSS blur.
+ *
+ * Schema decisions:
+ *   - --bg: #000000; --surface: #1a1a1a (dark card surface);
+ *     --surface-warm: #030303 (the rarely-used third-tier dark, an
+ *     "even darker" panel surface — this brand does not have a warm
+ *     temperature, so the B-slot reads as a parallel cool tier).
+ *   - --fg: #ffffff; --fg-2: #e9ecf2 (Cool Cloud — alt heading tone);
+ *     --muted: #767d88 (Cool Slate); --meta: #7d848e (Mid Slate).
+ *   - --border: #27272a (Border Dark); --border-soft: #1a1a1a (row
+ *     separator that blends into the dark surface — "barely visible
+ *     containment", per DESIGN.md §4).
+ *   - --accent: #ffffff. Runway has no decorative accent color; the
+ *     highest-signal surface in the system is pure white against
+ *     black. Hover/active states dim toward Cool Cloud / Cool Silver
+ *     rather than mixing in a hue.
+ *   - --font-display / --font-body bind to abcNormal — DESIGN.md §3
+ *     mandates a single typeface; Inter / DM Sans are documented
+ *     external substitutes for the custom face.
+ *   - --tracking-display: -0.025em (-1.2px at 48px hero per
+ *     DESIGN.md §3 hierarchy table).
+ *   - --leading-tight: 1.0 (film-title compression on display sizes);
+ *     --leading-body: 1.4 (mid-range of the documented 1.30–1.50
+ *     band — body text stays editorial-tight, never magazine-loose).
+ *   - --section-y-desktop: 78px ("cinema-grade breathing" — the
+ *     largest discrete step on the documented spacing scale).
+ *   - --radius-sm: 4px (sharp / button); --radius-md: 8px (card,
+ *     image); --radius-lg: 16px (alert containers only — DESIGN.md §4).
+ *   - --elev-raised: none. The brand do/don't is explicit: zero
+ *     shadows. We override the schema's blur fallback so any
+ *     component that reaches for `var(--elev-raised)` produces no
+ *     shadow, preserving the cinematic flat-vs-photographic depth
+ *     model. --elev-ring stays available for the "alert container"
+ *     case where a hairline ring substitutes for a border.
+ *   - --container-max: 1600px (cinema-wide, per DESIGN.md §5 grid).
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface (3 levels) ──────────────────────────────────────────
+   * Dark-dominant. The canvas is true black; cards lift onto Dark
+   * Surface (#1a1a1a) without a shadow or border. --surface-warm is
+   * the schema's B-slot for a tertiary tier; runway has no warm
+   * temperature, so we bind it to Deep Black (#030303) — a parallel
+   * "even darker" panel used for layered dark containers. */
+  --bg:           #000000;             /* Runway Black — primary canvas */
+  --surface:      #1a1a1a;             /* Dark Surface — card / lifted container */
+  --surface-warm: #030303;             /* Deep Black — third-tier layered panel */
+
+  /* ─── Foreground (4 levels) ───────────────────────────────────────
+   * Pure white anchors the ramp; Cool Cloud is a near-imperceptible
+   * alt for headings; the muted / meta tiers are the brand's
+   * signature cool-blue grays (never warm). */
+  --fg:    #ffffff;                    /* Pure White — primary type, brand mark */
+  --fg-2:  #e9ecf2;                    /* Cool Cloud — alt heading tone */
+  --muted: #767d88;                    /* Cool Slate — secondary body text */
+  --meta:  #7d848e;                    /* Mid Slate — tertiary, metadata */
+
+  /* ─── Border (2 levels) ───────────────────────────────────────────
+   * Per DESIGN.md §4: "barely visible containment". --border is the
+   * single dark-mode border value; --border-soft blends almost into
+   * the card surface so row separators do not visually compete. */
+  --border:      #27272a;              /* Border Dark — alert / standard edge */
+  --border-soft: #1a1a1a;              /* matches surface — inner row separator */
+
+  /* ─── Accent ──────────────────────────────────────────────────────
+   * Runway has no decorative color — DESIGN.md §2 is explicit ("None
+   * in the interface. Visual richness comes entirely from
+   * photographic content"). Pure white IS the brand's high-signal
+   * accent, used on CTA fills and the focus ring. Hover/active dim
+   * toward the cool-silver neutrals rather than mixing in any hue. */
+  --accent:        #ffffff;            /* Pure White — sole interface accent */
+  --accent-on:     #000000;            /* black type on white CTA fill */
+  --accent-hover:  #e9ecf2;            /* Cool Cloud — hover dim */
+  --accent-active: #c9ccd1;            /* Cool Silver — pressed dim */
+
+  /* ─── Semantic ────────────────────────────────────────────────────
+   * Runway's UI does not surface state colors in its public surface;
+   * we inherit the schema defaults so any utility/admin chrome the
+   * fixture spawns still resolves. Keep semantic coverage <5% of any
+   * surface — this is not a brand color tier. */
+  --success: #16a34a;
+  --warn:    #eab308;
+  --danger:  #dc2626;
+
+  /* ─── Typography ──────────────────────────────────────────────────
+   * Single typeface commitment. DESIGN.md §3: "abcNormal handles
+   * every text role." We list the documented external substitutes
+   * (Inter, DM Sans) as the next layer of the fallback chain so the
+   * fixture renders predictably on machines without the custom face. */
+  --font-display: "abcNormal", "abcNormal Fallback", "Inter", "DM Sans", system-ui, -apple-system, "Segoe UI", sans-serif;
+  --font-body:    "abcNormal", "abcNormal Fallback", "Inter", "DM Sans", system-ui, -apple-system, "Segoe UI", sans-serif;
+  --font-mono:    ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Monaco, Consolas, monospace;
+
+  /* Type scale — direct map of DESIGN.md §3 hierarchy table.
+   *   11px micro/tag (uppercase, weight 450) → --text-xs
+   *   13px small description                 → --text-sm
+   *   16px body / button                     → --text-base
+   *   20px feature title                     → --text-lg
+   *   24px card title                        → --text-xl
+   *   36px sub-heading                       → --text-2xl
+   *   40px section heading                   → --text-3xl
+   *   48px display / hero                    → --text-4xl */
+  --text-xs:   11px;
+  --text-sm:   13px;
+  --text-base: 16px;
+  --text-lg:   20px;
+  --text-xl:   24px;
+  --text-2xl:  36px;
+  --text-3xl:  40px;
+  --text-4xl:  48px;
+
+  /* Leading + tracking.
+   *   --leading-tight: 1.0 → film-title compression on display sizes.
+   *   --leading-body: 1.4 → mid-range of DESIGN.md's documented
+   *     1.30–1.50 body band; intentionally editorial-tight.
+   *   --tracking-display: -0.025em → -1.2px at 48px hero per
+   *     DESIGN.md §3 hierarchy table. */
+  --leading-body:     1.4;
+  --leading-tight:    1.0;
+  --tracking-display: -0.025em;
+
+  /* ─── Spacing ─────────────────────────────────────────────────────
+   * 8px base unit per DESIGN.md §5 — the schema's 4px-grid scale
+   * maps cleanly. Runway's documented scale (4/6/8/12/16/20/24/28/
+   * 32/48/64/78) lands on every required step except 6/28/64/78,
+   * which live inline in components (no token name needed). */
+  --space-1:  4px;
+  --space-2:  8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  20px;
+  --space-6:  24px;
+  --space-8:  32px;
+  --space-12: 48px;
+
+  /* Section rhythm — "cinema-grade breathing". 78px on desktop is
+   * the largest discrete step on the documented scale, creating the
+   * scrolling-between-scenes pacing called out in DESIGN.md §5. */
+  --section-y-desktop: 78px;
+  --section-y-tablet:  48px;
+  --section-y-phone:   32px;
+
+  /* ─── Radius ──────────────────────────────────────────────────────
+   * DESIGN.md §5 documents four tiers: 4px sharp (buttons), 6–8px
+   * comfortable (containers/images), 16px generous (alerts). The
+   * pill tier is preserved at the schema default — Runway forbids
+   * pill-shaped UI ("Don't use pill-shaped radius"), so the token
+   * exists purely so cross-brand components resolve cleanly. */
+  --radius-sm:   4px;
+  --radius-md:   8px;
+  --radius-lg:   16px;
+  --radius-pill: 9999px;
+
+  /* ─── Elevation ───────────────────────────────────────────────────
+   * DESIGN.md §6 is explicit: "Runway uses zero shadows." We honor
+   * that by overriding --elev-raised to `none` (depth comes from
+   * dark/light section alternation and photographic depth of field,
+   * never from CSS blur). --elev-ring remains as a hairline ring so
+   * the documented "alert container" case still has a treatment. */
+  --elev-flat:   none;
+  --elev-ring:   0 0 0 1px var(--border);
+  --elev-raised: none;
+
+  /* ─── Focus ───────────────────────────────────────────────────────
+   * White ring on dark canvas — the only chromatic affordance the
+   * brand permits. 60% transparency keeps the ring readable without
+   * looking like a fill. */
+  --focus-ring: 0 0 0 2px color-mix(in oklab, var(--accent), transparent 60%);
+
+  /* ─── Motion ──────────────────────────────────────────────────────
+   * Slightly slower base than the schema default — cinematic pacing
+   * favors deliberate state changes over instant snap. Easing stays
+   * on the standard curve so micro-interactions still feel
+   * mechanical-precise rather than springy. */
+  --motion-fast:   150ms;
+  --motion-base:   220ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+  /* ─── Layout ──────────────────────────────────────────────────────
+   * Cinema-wide container — DESIGN.md §5: "up to 1600px". Gutters
+   * progressively shrink from 48px desktop → 16px phone so the
+   * full-bleed photography hero can stay edge-to-edge. */
+  --container-max:            1600px;
+  --container-gutter-desktop: 48px;
+  --container-gutter-tablet:  24px;
+  --container-gutter-phone:   16px;
+}

--- a/design-systems/shadcn/components.html
+++ b/design-systems/shadcn/components.html
@@ -1,0 +1,732 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>shadcn — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/shadcn. Every visible
+        value comes from tokens.css; the page itself follows shadcn's
+        rules — pure white canvas, slate-900 body text, black reserved
+        for the decisive CTA, 1px borders, 8px default radius, focus
+        rings with 2px offset, Geist Sans with restrained tracking."
+    />
+
+    <style>
+      /* :root paste — sourced verbatim from design-systems/shadcn/tokens.css. */
+      :root {
+        --bg: #ffffff;
+        --surface: #ffffff;
+        --surface-warm: var(--surface);
+
+        --fg: #111827;
+        --fg-2: var(--fg);
+        --muted: #64748b;
+        --meta: var(--muted);
+
+        --border: #e5e7eb;
+        --border-soft: var(--border);
+
+        --accent: #000000;
+        --accent-on: #ffffff;
+        --accent-hover: color-mix(in oklab, var(--accent), white 10%);
+        --accent-active: color-mix(in oklab, var(--accent), white 18%);
+
+        --success: #16a34a;
+        --warn: #d97706;
+        --danger: #dc2626;
+
+        --font-display: "Geist", "Geist Sans", -apple-system, system-ui, "Segoe UI", Arial, sans-serif;
+        --font-body: "Geist", "Geist Sans", -apple-system, system-ui, "Segoe UI", Arial, sans-serif;
+        --font-mono: "Fira Code", ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Monaco, Consolas, monospace;
+
+        --text-xs: 12px;
+        --text-sm: 14px;
+        --text-base: 16px;
+        --text-lg: 20px;
+        --text-xl: 24px;
+        --text-2xl: 32px;
+        --text-3xl: 40px;
+        --text-4xl: 48px;
+
+        --leading-body: 1.5;
+        --leading-tight: 1.2;
+        --tracking-display: -0.02em;
+
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 96px;
+        --section-y-tablet: 64px;
+        --section-y-phone: 48px;
+
+        --radius-sm: 6px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --radius-pill: 9999px;
+
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised:
+          0 1px 2px 0 color-mix(in oklab, var(--fg), transparent 92%),
+          0 1px 3px 0 color-mix(in oklab, var(--fg), transparent 88%);
+
+        --focus-ring: 0 0 0 2px var(--bg), 0 0 0 4px var(--accent);
+
+        --motion-fast: 150ms;
+        --motion-base: 200ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+        --container-max: 1280px;
+        --container-gutter-desktop: 24px;
+        --container-gutter-tablet: 16px;
+        --container-gutter-phone: 16px;
+      }
+
+      /* ─── Reset (minimal) ─────────────────────────────────────── */
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        font-weight: 400;
+        -webkit-font-smoothing: antialiased;
+        text-rendering: optimizeLegibility;
+      }
+
+      /* ─── Layout primitives ─────────────────────────────────── */
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section {
+        padding-block: var(--section-y-desktop);
+      }
+      section + section {
+        border-top: 1px solid var(--border);
+      }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography ───────────────────────────────────────────
+       * Hierarchy comes from size + weight + tracking — never from
+       * color. shadcn headings stay on --fg; the accent color is
+       * reserved for the decisive CTA. */
+      h1, h2, h3, h4 {
+        font-family: var(--font-display);
+        line-height: var(--leading-tight);
+        letter-spacing: var(--tracking-display);
+        margin: 0;
+        color: var(--fg);
+      }
+      h1 { font-size: var(--text-4xl); font-weight: 600; }
+      h2 { font-size: var(--text-2xl); font-weight: 600; }
+      h3 { font-size: var(--text-xl); font-weight: 600; letter-spacing: -0.01em; }
+      h4 { font-size: var(--text-lg); font-weight: 600; letter-spacing: -0.01em; }
+      p { margin: 0; }
+
+      .lede {
+        font-size: var(--text-lg);
+        line-height: 1.6;
+        color: var(--muted);
+      }
+      .body-muted { color: var(--muted); }
+      .body-sm    { font-size: var(--text-sm); }
+      .body-meta  { color: var(--muted); font-size: var(--text-sm); }
+
+      /* shadcn-style eyebrow: small uppercase mono, muted color,
+         tracked open — the "section signpost" pattern visible in
+         the shadcn/ui docs nav and primitive index. */
+      .eyebrow {
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        font-weight: 500;
+        line-height: 1;
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+
+      .stack-2 > * + * { margin-block-start: var(--space-2); }
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+
+      /* ─── Buttons ───────────────────────────────────────────────
+       * Primary is black-on-white (the shadcn default Button). Hover
+       * lifts the fill toward gray (--accent-hover mixes white in)
+       * because pure black cannot darken visibly. Secondary uses a
+       * real 1px border — shadcn's "outline" variant — and the
+       * "ghost" variant is borderless with a subtle hover wash. */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: var(--space-2);
+        padding: 8px 16px;
+        border: 1px solid transparent;
+        border-radius: var(--radius-sm);
+        font-family: var(--font-display);
+        font-size: var(--text-sm);
+        font-weight: 500;
+        line-height: 1.43;
+        cursor: pointer;
+        text-decoration: none;
+        background: transparent;
+        color: inherit;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          border-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible {
+        outline: none;
+        box-shadow: var(--focus-ring);
+      }
+      .btn-primary {
+        background: var(--accent);
+        color: var(--accent-on);
+        border-color: var(--accent);
+      }
+      .btn-primary:hover {
+        background: var(--accent-hover);
+        border-color: var(--accent-hover);
+      }
+      .btn-primary:active {
+        background: var(--accent-active);
+        border-color: var(--accent-active);
+      }
+      .btn-secondary {
+        background: var(--surface);
+        color: var(--fg);
+        border-color: var(--border);
+      }
+      .btn-secondary:hover {
+        background: color-mix(in oklab, var(--bg), var(--fg) 4%);
+      }
+      .btn-ghost {
+        background: transparent;
+        color: var(--fg);
+        padding-inline: var(--space-3);
+      }
+      .btn-ghost:hover {
+        background: color-mix(in oklab, var(--bg), var(--fg) 6%);
+      }
+
+      /* ─── Inputs ───────────────────────────────────────────────
+       * 1px border (shadcn never hides input edges in shadow). On
+       * focus the ring expands to the full --focus-ring stack and
+       * the border collapses into the inner halo. */
+      .field {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+      }
+      .field label {
+        font-size: var(--text-sm);
+        font-weight: 500;
+        color: var(--fg);
+      }
+      .field input {
+        padding: 8px 12px;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--surface);
+        color: var(--fg);
+        font-family: inherit;
+        font-size: var(--text-sm);
+        line-height: 1.43;
+        outline: none;
+        transition:
+          border-color var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .field input::placeholder { color: var(--muted); }
+      .field input:hover { border-color: color-mix(in oklab, var(--fg), transparent 70%); }
+      .field input:focus-visible {
+        border-color: var(--accent);
+        box-shadow: var(--focus-ring);
+      }
+      .field-help {
+        font-size: var(--text-xs);
+        color: var(--muted);
+      }
+
+      /* ─── Cards ───────────────────────────────────────────────
+       * shadcn Card primitive: 1px border, 8px radius, padding 24px,
+       * whisper-soft elevation. The border carries the edge; the
+       * shadow only adds a hint of lift. No multi-layer glow. */
+      .card {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        padding: var(--space-6);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+        box-shadow: var(--elev-raised);
+        transition:
+          border-color var(--motion-base) var(--ease-standard),
+          box-shadow var(--motion-base) var(--ease-standard);
+      }
+      .card:hover {
+        border-color: color-mix(in oklab, var(--fg), transparent 75%);
+        box-shadow:
+          0 1px 3px 0 color-mix(in oklab, var(--fg), transparent 88%),
+          0 4px 10px -2px color-mix(in oklab, var(--fg), transparent 88%);
+      }
+
+      /* ─── Badges ───────────────────────────────────────────────
+       * shadcn Badge variants — default (filled accent), secondary
+       * (muted surface), outline (1px border), and state (success).
+       * Pill shape; small mono-uppercase optional label. */
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-1);
+        padding: 2px 10px;
+        border: 1px solid transparent;
+        border-radius: var(--radius-pill);
+        font-size: var(--text-xs);
+        font-weight: 500;
+        line-height: 1.5;
+        font-family: var(--font-display);
+      }
+      .badge-default {
+        background: var(--accent);
+        color: var(--accent-on);
+      }
+      .badge-secondary {
+        background: color-mix(in oklab, var(--bg), var(--fg) 5%);
+        color: var(--fg);
+      }
+      .badge-outline {
+        background: transparent;
+        color: var(--fg);
+        border-color: var(--border);
+      }
+      .badge-success {
+        color: var(--success);
+        background: color-mix(in oklab, var(--success), white 88%);
+      }
+      .badge-dot {
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: currentColor;
+      }
+
+      /* ─── Links ───────────────────────────────────────────────
+       * shadcn links are underlined for accessibility; underline
+       * thickness lifts on hover. Color stays --fg (the docs voice
+       * — no chromatic distraction in body copy). */
+      a {
+        color: var(--fg);
+        text-decoration: underline;
+        text-underline-offset: 3px;
+        text-decoration-thickness: 1px;
+        transition: text-decoration-thickness var(--motion-fast) var(--ease-standard);
+      }
+      a:hover { text-decoration-thickness: 2px; }
+      a:focus-visible {
+        outline: none;
+        border-radius: 2px;
+        box-shadow: var(--focus-ring);
+      }
+
+      /* ─── Kbd ────────────────────────────────────────────────── */
+      kbd {
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        padding: 2px 6px;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--surface);
+        color: var(--fg);
+        box-shadow: 0 1px 0 var(--border);
+      }
+
+      /* ─── Distinctive: Install command block ─────────────────────
+       * The single most recognizable shadcn surface — a terminal-
+       * voiced CLI command with the `$` prompt and the package name
+       * highlighted. Uses Fira Code for the technical typeface, the
+       * surface tier for the panel, and a clickable copy affordance. */
+      .install-block {
+        margin-block-start: var(--space-8);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+        padding: var(--space-4) var(--space-5);
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        line-height: 1.5;
+        color: var(--fg);
+        box-shadow: var(--elev-raised);
+      }
+      .install-block .prompt {
+        color: var(--muted);
+        user-select: none;
+        margin-inline-end: var(--space-2);
+      }
+      .install-block .copy {
+        appearance: none;
+        background: transparent;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        padding: 4px 10px;
+        font-family: var(--font-display);
+        font-size: var(--text-xs);
+        font-weight: 500;
+        color: var(--muted);
+        cursor: pointer;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard),
+          border-color var(--motion-fast) var(--ease-standard);
+      }
+      .install-block .copy:hover {
+        color: var(--fg);
+        background: color-mix(in oklab, var(--bg), var(--fg) 4%);
+      }
+      .install-block .copy:focus-visible {
+        outline: none;
+        box-shadow: var(--focus-ring);
+      }
+
+      /* ─── Section-specific layout ─────────────────────────────── */
+      .hero {
+        text-align: left;
+      }
+      .hero .eyebrow { margin-block-end: var(--space-4); }
+      .hero h1 { max-width: 22ch; }
+      .hero .lede {
+        max-width: 56ch;
+        margin-block-start: var(--space-5);
+      }
+      .hero-actions {
+        display: flex;
+        gap: var(--space-3);
+        margin-block-start: var(--space-8);
+        align-items: center;
+        flex-wrap: wrap;
+      }
+      .hero-meta {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-3);
+        margin-block-start: var(--space-6);
+        color: var(--muted);
+        font-size: var(--text-sm);
+        flex-wrap: wrap;
+      }
+
+      .features-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: var(--space-5);
+        margin-block-start: var(--space-8);
+      }
+      @media (max-width: 1023px) {
+        .features-grid { grid-template-columns: 1fr 1fr; }
+      }
+      @media (max-width: 639px) {
+        .features-grid { grid-template-columns: 1fr; }
+      }
+      .feature-icon {
+        width: 36px;
+        height: 36px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        color: var(--fg);
+        background: color-mix(in oklab, var(--bg), var(--fg) 3%);
+      }
+
+      .form-row {
+        display: grid;
+        grid-template-columns: 1.2fr 1fr;
+        gap: var(--space-12);
+        align-items: start;
+        margin-block-start: var(--space-8);
+      }
+      @media (max-width: 1023px) {
+        .form-row { grid-template-columns: 1fr; }
+      }
+      .form {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+        max-width: 440px;
+        padding: var(--space-6);
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        box-shadow: var(--elev-raised);
+      }
+      .form-actions {
+        display: flex;
+        gap: var(--space-3);
+        margin-block-start: var(--space-2);
+        align-items: center;
+      }
+
+      .row-between {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-3);
+      }
+      .icon { width: 16px; height: 16px; flex-shrink: 0; }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <!-- ════════════════════════════════════════════════════════════
+           HERO — exercises: --text-4xl Geist W600 with -0.02em
+           tracking, .lede in --muted, .btn-primary (black-on-white),
+           .btn-secondary (1px border outline), .btn-ghost, the
+           install-block CLI panel (Fira Code voice), .badge-secondary,
+           kbd. Single-column layout — shadcn heroes don't asymmetric-
+           split; the page IS the column.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section class="hero" data-od-id="hero">
+        <p class="eyebrow">v0.1 · reference fixture · shadcn</p>
+        <h1>Build your own component library.</h1>
+        <p class="lede">
+          Beautifully-designed, accessible components you copy and paste
+          into your apps. Open source, customizable, and yours to extend —
+          this fixture paints from the same
+          <code style="font-family: var(--font-mono); font-size: 0.95em">:root</code>
+          block every shadcn artifact inlines into its first
+          <code style="font-family: var(--font-mono); font-size: 0.95em">&lt;style&gt;</code>.
+        </p>
+        <div class="hero-actions">
+          <a href="./tokens.css" class="btn btn-primary">
+            Get started
+            <svg
+              class="icon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.75"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M5 12h14M13 6l6 6-6 6" />
+            </svg>
+          </a>
+          <a href="./DESIGN.md" class="btn btn-secondary">Browse components</a>
+          <a href="#install" class="btn btn-ghost">npx shadcn add</a>
+        </div>
+        <p class="hero-meta">
+          <span class="badge badge-secondary">
+            <span class="badge-dot" aria-hidden="true" style="color: var(--success)"></span>
+            56 tokens · open source · MIT
+          </span>
+          <span>Press <kbd>⌘</kbd> <kbd>K</kbd> to search the registry.</span>
+        </p>
+
+        <div class="install-block" id="install">
+          <span>
+            <span class="prompt" aria-hidden="true">$</span>npx shadcn@latest add button
+          </span>
+          <button type="button" class="copy" aria-label="Copy install command">Copy</button>
+        </div>
+      </section>
+
+      <!-- ════════════════════════════════════════════════════════════
+           FEATURE CARDS — exercises: .card (1px border + whisper-soft
+           --elev-raised), h3 with -0.01em tracking, .body-muted,
+           inline link, .feature-icon, .features-grid. Three cards
+           per row at desktop, collapses on mobile. Voice mirrors the
+           shadcn pitch: copy/paste, accessibility, your code not ours.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="features">
+        <div class="stack-3">
+          <p class="eyebrow">Why teams reach for it</p>
+          <h2 style="max-width: 28ch">
+            Primitives that read like your own code, not a dependency.
+          </h2>
+          <p class="lede" style="max-width: 60ch">
+            Every component lives in your project — fully typed, fully
+            owned. Tokens here, JSX in your repo, no version pinning,
+            no transitive surprises.
+          </p>
+        </div>
+
+        <div class="features-grid">
+          <article class="card">
+            <span class="feature-icon" aria-hidden="true">
+              <svg
+                class="icon"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.75"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <rect x="3" y="3" width="7" height="7" rx="1.5" />
+                <rect x="14" y="3" width="7" height="7" rx="1.5" />
+                <rect x="3" y="14" width="7" height="7" rx="1.5" />
+                <rect x="14" y="14" width="7" height="7" rx="1.5" />
+              </svg>
+            </span>
+            <h3>Copy &amp; paste.</h3>
+            <p class="body-muted body-sm">
+              The CLI drops every primitive's source into your repo as
+              plain TSX. No bundle, no abstraction layer — what you see
+              is what ships.
+            </p>
+            <a href="./tokens.css" class="body-sm">Inspect the tokens →</a>
+          </article>
+
+          <article class="card">
+            <span class="feature-icon" aria-hidden="true">
+              <svg
+                class="icon"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.75"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <circle cx="12" cy="12" r="9" />
+                <path d="M3 12h18M12 3a14 14 0 0 1 0 18M12 3a14 14 0 0 0 0 18" />
+              </svg>
+            </span>
+            <h3>Accessible by default.</h3>
+            <p class="body-muted body-sm">
+              Built on Radix primitives. Keyboard navigation, focus
+              management, ARIA wiring — the boring-correct foundation
+              is included so you can ship the brand layer.
+            </p>
+            <a href="./DESIGN.md" class="body-sm">Read the spec →</a>
+          </article>
+
+          <article class="card">
+            <span class="feature-icon" aria-hidden="true">
+              <svg
+                class="icon"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.75"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M12 3v18M3 12h18" />
+                <circle cx="12" cy="12" r="3" />
+              </svg>
+            </span>
+            <h3>Themeable to the token.</h3>
+            <p class="body-muted body-sm">
+              Rebind
+              <code style="font-family: var(--font-mono); font-size: 0.92em">--accent</code>,
+              <code style="font-family: var(--font-mono); font-size: 0.92em">--radius-md</code>,
+              and the foreground ramp once — every primitive across
+              the page restyles with no per-component overrides.
+            </p>
+            <a href="./tokens.css" class="body-sm">See the token map →</a>
+          </article>
+        </div>
+      </section>
+
+      <!-- ════════════════════════════════════════════════════════════
+           FORM — exercises: .field with 1px-border inputs, focus-visible
+           swap to the --focus-ring (the 2px-offset shadcn signature),
+           .btn-primary and .btn-secondary reuse. Form sits inside its
+           own bordered card so the input edges read as recessed
+           beneath the form surface.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="form">
+        <p class="eyebrow">Form primitives</p>
+        <h2 style="margin-block-start: var(--space-3); max-width: 28ch">
+          Inputs inherit the same tokens.
+        </h2>
+
+        <div class="form-row">
+          <div class="stack-4">
+            <p class="body-muted" style="max-width: 50ch">
+              Focus rings, edges, placeholder color — all derive from
+              <code style="font-family: var(--font-mono); font-size: 0.95em">--accent</code>,
+              <code style="font-family: var(--font-mono); font-size: 0.95em">--border</code>,
+              and <code style="font-family: var(--font-mono); font-size: 0.95em">--muted</code>.
+              The submit button reuses
+              <code style="font-family: var(--font-mono); font-size: 0.95em">.btn-primary</code>
+              unchanged — black fill, white label, 6px radius.
+            </p>
+            <p class="body-muted body-sm">
+              No new token is introduced for this section. The form
+              card uses
+              <code style="font-family: var(--font-mono); font-size: 0.95em">--elev-raised</code>
+              directly so the focused input's ring reads as a clean
+              halo over the bordered surface.
+            </p>
+            <p class="body-meta">
+              Full reference at <a href="./tokens.css">tokens.css</a> ·
+              spec at <a href="./DESIGN.md">DESIGN.md</a>.
+            </p>
+          </div>
+
+          <form class="form" onsubmit="event.preventDefault();">
+            <div class="row-between">
+              <p class="eyebrow">Join the registry preview</p>
+              <span class="badge badge-success">
+                <span class="badge-dot" aria-hidden="true"></span>
+                Open
+              </span>
+            </div>
+            <div class="field">
+              <label for="email">Work email</label>
+              <input
+                id="email"
+                type="email"
+                placeholder="you@team.dev"
+                autocomplete="email"
+                required
+              />
+              <p class="field-help">
+                We'll send the registry preview link and nothing else.
+              </p>
+            </div>
+            <div class="form-actions">
+              <button type="submit" class="btn btn-primary">
+                Get the preview
+              </button>
+              <button type="button" class="btn btn-secondary">
+                Maybe later
+              </button>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/shadcn/tokens.css
+++ b/design-systems/shadcn/tokens.css
@@ -1,0 +1,255 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/shadcn/tokens.css
+ *
+ * Structured token bindings for "shadcn" — the open-source copy-paste
+ * React component library whose "brand" is the calm, neutral baseline
+ * that thousands of teams extend. shadcn is intentionally NOT a loud
+ * identity: zinc/slate neutrals, near-black primary, 8px default
+ * radius, restrained spacing, Inter/Geist body text, and accessibility
+ * non-negotiables (visible focus, AA contrast, semantic state colors).
+ *
+ * This file pre-compiles the values described in `DESIGN.md` into the
+ * shared schema. Agents generating an artifact for shadcn should paste
+ * the `:root` block verbatim into the first `<style>` of the artifact,
+ * then reference everything via `var(--*)`.
+ *
+ * Brand-specific schema decisions (each one bends a schema convention
+ * to match shadcn's voice rather than the cross-brand default):
+ *
+ *   1. `--accent` is `#000000` (DESIGN.md §2 Primary), NOT a chromatic
+ *      hue. shadcn's primary action button is pure black on white —
+ *      that IS the accent moment. Because pure black cannot darken
+ *      further visibly, `--accent-hover` and `--accent-active` mix
+ *      TOWARD WHITE (not toward black like the schema default). This
+ *      mirrors the shadcn convention of `bg-primary hover:bg-primary/90`
+ *      where the hover lifts the fill instead of pressing it deeper.
+ *
+ *   2. `--fg` is `#111827` (DESIGN.md §2 Text — Tailwind slate-900),
+ *      NOT `#000000`. Pure-black body copy against pure-white surface
+ *      reads as harsh; the slight cool slate undertone is part of the
+ *      shadcn neutral system. Keeping `--fg` distinct from `--accent`
+ *      preserves the "body text" vs "decisive CTA" semantic split.
+ *
+ *   3. `--fg-2`, `--meta`, `--surface-warm`, `--border-soft` collapse
+ *      to their schema siblings via `var()`. shadcn is a monochrome
+ *      baseline with one foreground tier, one canvas tier, one border
+ *      weight — brands extending shadcn (e.g. a Warm theme) rebind
+ *      these slots independently. The names still exist so shared
+ *      components targeting the full ramp resolve.
+ *
+ *   4. `--focus-ring` is the signature shadcn pattern: a 2px halo of
+ *      `var(--bg)` (the offset) wrapped by a 2px ring of `var(--accent)`
+ *      (the focus indicator). This is the `ring-2 ring-offset-2`
+ *      Tailwind utility every shadcn primitive inherits, expressed as
+ *      a layered box-shadow so it works on dark surfaces, glass
+ *      surfaces, and inside scrollers without the offset clipping.
+ *
+ *   5. `--radius-md` is `8px` — the canonical shadcn default
+ *      (`--radius: 0.5rem` in the components.json starter). `--radius-sm`
+ *      drops to `6px` so inputs and buttons feel one shade tighter
+ *      than cards, matching the `calc(var(--radius) - 2px)` formula
+ *      shadcn primitives use internally. The whole scale (6/8/12/9999)
+ *      is restrained — shadcn rejects oversized pill cards.
+ *
+ *   6. Type scale tops out at `48px` (`--text-4xl`). DESIGN.md §3
+ *      caps the documented scale at 32px; we extend to 40/48 for
+ *      marketing hero treatments while keeping `--tracking-display`
+ *      at a gentle `-0.02em` (not the aggressive `-0.05em` of brand-
+ *      voice systems like Vercel). shadcn whispers; it does not shout.
+ *
+ *   7. `--elev-raised` is a two-layer hairline shadow (1px + 3px
+ *      ambient), mirroring Tailwind's `shadow-sm` — shadcn cards lift
+ *      with a whisper, not a blur. No inner glow, no atmospheric
+ *      wash; the brand voice is functional surface, not theatre.
+ *
+ *   8. Section rhythm is generous (`96 / 64 / 48`) and `--container-max`
+ *      is `1280px` (`max-w-7xl`), the canonical shadcn marketing-page
+ *      width. Gutter narrows to `16px` on phone but never edge-bleeds
+ *      body copy — readability is non-negotiable.
+ *
+ *   9. `--font-mono` is "Fira Code" (DESIGN.md §3), kept distinct
+ *      from the body Geist so code blocks and `kbd` carry a visible
+ *      "this is technical content" signal. The system-mono fallback
+ *      stack guarantees code remains legible if Fira Code is missing.
+ *
+ * Source contracts:
+ *   - Standard token names: design-systems/_schema/tokens.schema.ts
+ *   - A2 fallback parity:   design-systems/_schema/defaults.css
+ *   - Lint enforcement:     apps/daemon/src/lint-artifact.ts
+ *
+ * Keep this file additive: never invent token names not also
+ * documented in DESIGN.md or the schema. Geist and Fira Code are
+ * referenced through OS-fallback stacks so artifacts render
+ * acceptably even when the faces are not loaded; any host that wants
+ * the real faces links them externally.
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface (3 levels — schema slot) ─────────────────────────────
+   * Pure white canvas, pure white cards. shadcn intentionally rejects
+   * background-color variation between sections — depth comes from the
+   * border and the elevation hairline, not from tinting surfaces
+   * warmer or cooler. `--surface-warm` aliases to surface because the
+   * brand has no third tier; extending themes (e.g. a "Stone" preset)
+   * rebind independently. */
+  --bg: #ffffff;
+  --surface: #ffffff;
+  --surface-warm: var(--surface);     /* alias — shadcn has no warm tier */
+
+  /* ─── Foreground ramp (4 levels) ──────────────────────────────────
+   * shadcn differentiates two text levels in its base preset: primary
+   * (slate-900) and muted (slate-500). `--fg-2` aliases to `--fg` and
+   * `--meta` aliases to `--muted` so shared components targeting the
+   * richer ramp still resolve. `--fg` is `#111827` (slate-900) NOT
+   * `#000000` — the slight cool undertone is part of the neutral
+   * system. Pure black is reserved for `--accent` (the decisive CTA). */
+  --fg: #111827;                       /* slate-900 — body text (DESIGN.md §2 Text) */
+  --fg-2: var(--fg);                   /* alias — shadcn has no secondary fg tier */
+  --muted: #64748b;                    /* slate-500 — captions, subtext, descriptions */
+  --meta: var(--muted);                /* alias — shadcn has no metadata tier */
+
+  /* ─── Border (2 levels) ──────────────────────────────────────────
+   * Single hairline weight. shadcn uses real `border: 1px solid` (not
+   * shadow-as-border like Vercel) — the explicit edge is part of the
+   * copy-paste primitive's "you can see exactly what's drawn" voice.
+   * `--border-soft` aliases for brands that need a row-separator vs
+   * card-edge distinction; shadcn does not. */
+  --border: #e5e7eb;                   /* slate-200 — card edge, input edge, dividers */
+  --border-soft: var(--border);        /* alias — shadcn has no soft tier */
+
+  /* ─── Accent ─────────────────────────────────────────────────────
+   * Pure black per DESIGN.md §2 ("Primary: #000000 — Favor Primary
+   * for CTA emphasis"). shadcn's primary button is `bg-primary` =
+   * near-black on white; that IS the accent moment. The hover and
+   * active states mix toward WHITE (not toward black) because pure
+   * black cannot darken further — this mirrors the shadcn idiom
+   * `bg-primary hover:bg-primary/90` where the fill lightens slightly
+   * on pointer-over to signal interactivity. */
+  --accent: #000000;                   /* DESIGN.md §2 Primary — CTA fill */
+  --accent-on: #ffffff;                /* white label on black */
+  --accent-hover: color-mix(in oklab, var(--accent), white 10%);   /* ~#1a1a1a — lift, don't press */
+  --accent-active: color-mix(in oklab, var(--accent), white 18%);  /* ~#2e2e2e — clear pressed delta */
+
+  /* ─── Semantic ───────────────────────────────────────────────────
+   * Reserved for state, not decoration. Values come directly from
+   * DESIGN.md §2 — Tailwind green-600 / amber-600 / red-600. Keep
+   * total semantic-color pixels under 5% of any surface; shadcn
+   * primitives use them for badges and validation only, never as
+   * filler chrome. */
+  --success: #16a34a;
+  --warn: #d97706;                     /* DESIGN.md §2 Warning — amber-600, not the schema yellow */
+  --danger: #dc2626;
+
+  /* ─── Typography ─────────────────────────────────────────────────
+   * Geist Sans for display and body per DESIGN.md §3 — modern, neutral,
+   * humanist sans that ships open-source. Geist scales cleanly from
+   * 12px UI to 48px hero without re-weighting. Fira Code for monospace
+   * (DESIGN.md §3 mono) lends code blocks the legible ligature-friendly
+   * face shadcn examples gravitate toward. OS-mono fallback covers
+   * environments without Fira Code installed. */
+  --font-display: "Geist", "Geist Sans", -apple-system, system-ui, "Segoe UI", Arial, sans-serif;
+  --font-body: "Geist", "Geist Sans", -apple-system, system-ui, "Segoe UI", Arial, sans-serif;
+  --font-mono: "Fira Code", ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Monaco, Consolas, monospace;
+
+  /* Type scale (px) — DESIGN.md §3 lists 12/14/16/20/24/32; we extend
+   * 40/48 for marketing hero treatments. The scale stays restrained
+   * (no 64+ display) because shadcn's voice is "build your own", not
+   * "look at this hero". Hierarchy comes from weight + spacing, not
+   * px excess. */
+  --text-xs: 12px;                     /* caption, meta, badge */
+  --text-sm: 14px;                     /* button, input, secondary body */
+  --text-base: 16px;                   /* body baseline */
+  --text-lg: 20px;                     /* lede, featured paragraph */
+  --text-xl: 24px;                     /* card title, H3 */
+  --text-2xl: 32px;                    /* section title, H2 */
+  --text-3xl: 40px;                    /* H1 */
+  --text-4xl: 48px;                    /* display hero (marketing only) */
+
+  /* Body leading at 1.5 (shadcn docs default), tight leading at 1.2
+   * for headings. Display tracking is a gentle `-0.02em` — shadcn
+   * whispers; the aggressive `-0.05em` compression of brand-voice
+   * systems would override the calm baseline that makes shadcn
+   * recognizable. */
+  --leading-body: 1.5;
+  --leading-tight: 1.2;
+  --tracking-display: -0.02em;
+
+  /* ─── Spacing ────────────────────────────────────────────────────
+   * 4px-grid base scale. DESIGN.md §4 documents 4/8/12/16/24/32; the
+   * schema requires 8 tiers so we add 20 and 48 for breathing room
+   * between cards and inside marketing forms. Tailwind/shadcn users
+   * map these to `space-1` → `space-12` mentally without translation. */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+
+  /* Section rhythm — generous but never gallery-empty. 96px desktop
+   * matches shadcn marketing pages (py-24 in Tailwind units), 64px
+   * tablet preserves the documented hierarchy, 48px phone collapses
+   * without losing the breathing room that distinguishes shadcn
+   * sections from dense dashboard layouts. */
+  --section-y-desktop: 96px;
+  --section-y-tablet: 64px;
+  --section-y-phone: 48px;
+
+  /* ─── Radius ─────────────────────────────────────────────────────
+   * The canonical shadcn default is `--radius: 0.5rem` (8px) and the
+   * smaller variants compute as `calc(var(--radius) - Npx)`. We bind:
+   *   sm 6px → buttons, inputs (the `calc(--radius - 2px)` tier)
+   *   md 8px → cards, modals (the documented baseline)
+   *   lg 12px → featured containers (the `calc(--radius + 4px)` tier)
+   *   pill 9999px → badges, avatars, capsule chips */
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-pill: 9999px;
+
+  /* ─── Elevation (3 levels) ───────────────────────────────────────
+   * Tailwind-`shadow-sm` philosophy: two whisper-soft layers, no
+   * atmospheric blur. shadcn rejects the multi-layer card stack
+   * because the brand voice is "you can read exactly what's drawn",
+   * not "look how lifted this is". `--elev-ring` carries hairline
+   * edges where a real border would shift layout; `--elev-raised`
+   * adds the 1px+3px ambient pair for dropdowns, popovers, and
+   * floating panels. */
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised:
+    0 1px 2px 0 color-mix(in oklab, var(--fg), transparent 92%),
+    0 1px 3px 0 color-mix(in oklab, var(--fg), transparent 88%);
+
+  /* ─── Focus ring ─────────────────────────────────────────────────
+   * The shadcn signature: 2px halo of canvas color (the "offset")
+   * wrapped by a 2px ring of accent. This is the `ring-2 ring-offset-2
+   * ring-ring` Tailwind utility every shadcn primitive inherits,
+   * expressed as a layered box-shadow so the offset reads cleanly on
+   * any surface (light, dark, glass) without the outline-offset
+   * caveats. DESIGN.md §6 explicitly requires "strong focus-visible
+   * states" — this is the rule, not a suggestion. */
+  --focus-ring: 0 0 0 2px var(--bg), 0 0 0 4px var(--accent);
+
+  /* ─── Motion ─────────────────────────────────────────────────────
+   * Two durations + one easing curve, per DESIGN.md §7 "short,
+   * purposeful transitions (150–250ms) with stable easing". shadcn
+   * primitives are quick and unobtrusive — never a long-form
+   * choreographed entrance. */
+  --motion-fast: 150ms;
+  --motion-base: 200ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+  /* ─── Layout ─────────────────────────────────────────────────────
+   * 1280px max content width (`max-w-7xl`) — the canonical shadcn
+   * marketing-page width that keeps line lengths comfortable on
+   * wide displays without edge-bleeding into 1440px+ territory.
+   * Gutters narrow to 16px on phone but never collapse to 0; shadcn
+   * preserves the visible inset that frames the column. */
+  --container-max: 1280px;
+  --container-gutter-desktop: 24px;
+  --container-gutter-tablet: 16px;
+  --container-gutter-phone: 16px;
+}

--- a/design-systems/supabase/components.html
+++ b/design-systems/supabase/components.html
@@ -1,0 +1,741 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Supabase — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/supabase. Every visible
+        value comes from tokens.css. Supabase's signature moves: near-black
+        canvas, Postgres-emerald reserved as identity marker, Circular geometric
+        sans with weight restraint, Source Code Pro uppercase for the developer-
+        console voice, depth carried by a tight border hierarchy."
+    />
+
+    <style>
+      /* :root paste — sourced verbatim from design-systems/supabase/tokens.css. */
+      :root {
+        --bg: #171717;
+        --surface: #1c1c1c;
+        --surface-warm: var(--surface);
+
+        --fg: #fafafa;
+        --fg-2: #b4b4b4;
+        --muted: #898989;
+        --meta: #4d4d4d;
+
+        --border: #2e2e2e;
+        --border-soft: #242424;
+
+        --accent: #3ecf8e;
+        --accent-on: #0f0f0f;
+        --accent-hover: #00c573;
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+        --success: #16a34a;
+        --warn: #eab308;
+        --danger: #dc2626;
+
+        --font-display: "Circular", "custom-font", "Helvetica Neue", Helvetica, Arial, sans-serif;
+        --font-body: "Circular", "custom-font", "Helvetica Neue", Helvetica, Arial, sans-serif;
+        --font-mono: "Source Code Pro", "Office Code Pro", Menlo, Monaco, Consolas, monospace;
+
+        --text-xs: 12px;
+        --text-sm: 14px;
+        --text-base: 16px;
+        --text-lg: 18px;
+        --text-xl: 24px;
+        --text-2xl: 32px;
+        --text-3xl: 36px;
+        --text-4xl: 72px;
+
+        --leading-body: 1.5;
+        --leading-tight: 1.00;
+        --tracking-display: normal;
+
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 128px;
+        --section-y-tablet: 80px;
+        --section-y-phone: 48px;
+
+        --radius-sm: 6px;
+        --radius-md: 8px;
+        --radius-lg: 16px;
+        --radius-pill: 9999px;
+
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised: 0 0 0 1px var(--border), 0 4px 12px rgba(0, 0, 0, 0.4);
+
+        --focus-ring: 0 0 0 2px color-mix(in oklab, var(--accent), transparent 50%);
+
+        --motion-fast: 150ms;
+        --motion-base: 200ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+        --container-max: 1200px;
+        --container-gutter-desktop: 24px;
+        --container-gutter-tablet: 16px;
+        --container-gutter-phone: 16px;
+      }
+
+      /* ─── Reset (minimal) ─────────────────────────────────────── */
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg-2);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        font-weight: 400;
+        -webkit-font-smoothing: antialiased;
+        text-rendering: optimizeLegibility;
+      }
+
+      /* ─── Layout primitives ─────────────────────────────────── */
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section {
+        padding-block: var(--section-y-desktop);
+      }
+      section + section {
+        /* DESIGN.md §6: depth comes from borders, not shadows. Section
+           dividers use the standard border tier — a hairline against
+           the dark canvas, the brand's "edges define" promise. */
+        border-top: 1px solid var(--border);
+      }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography ────────────────────────────────────────────
+       * Weight restraint: 400 for prose, 500 for interactive elements.
+       * DESIGN.md §3 Principles: "There is no bold (700) in the
+       * detected system — hierarchy is created through size, not
+       * weight." Display sizes hold at leading 1.00 (the defining
+       * gesture) and tracking `normal`; smaller scales relax leading
+       * upward as the table in DESIGN.md §3 prescribes. */
+      h1, h2, h3, h4 {
+        font-family: var(--font-display);
+        font-weight: 400;
+        margin: 0;
+        color: var(--fg);
+        line-height: var(--leading-tight);
+        letter-spacing: var(--tracking-display);
+      }
+      h1 {
+        font-size: var(--text-4xl);
+        /* DESIGN.md §3 Display Hero: 72px / 1.00 leading / normal
+           tracking — the terminal-density typographic signature. */
+      }
+      h2 {
+        font-size: var(--text-3xl);
+        /* DESIGN.md §3 Section Heading: 36px / 1.25 leading.
+           Overrides the shared 1.00 set above. */
+        line-height: 1.25;
+      }
+      h3 {
+        font-size: var(--text-xl);
+        /* DESIGN.md §3 Card Title: 24px / 1.33 leading / -0.16px
+           tracking ≈ -0.0067em. The subtle negative tracking is the
+           card-title differentiation from body text. */
+        line-height: 1.33;
+        letter-spacing: -0.0067em;
+      }
+      h4 {
+        font-size: var(--text-lg);
+        line-height: 1.56;
+      }
+      p { margin: 0; }
+
+      .lede {
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        color: var(--fg-2);
+        max-width: 56ch;
+      }
+      .body-muted { color: var(--muted); }
+      .body-meta { color: var(--meta); font-size: var(--text-sm); }
+      .body-sm { font-size: var(--text-sm); }
+
+      /* Eyebrow uses Source Code Pro uppercase — DESIGN.md §3:
+         "Source Code Pro in uppercase with 1.2px letter-spacing is
+         the 'developer console' voice — used sparingly for technical
+         labels that connect to the product experience." 1.2px at
+         12px ≈ 0.1em. */
+      .eyebrow {
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        font-weight: 400;
+        line-height: 1.33;
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+      }
+
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+
+      /* ─── Buttons ───────────────────────────────────────────────
+       * DESIGN.md §4 + §7: primary CTAs are pills (9999px radius),
+       * ghost buttons take the 6px standard radius. The brand
+       * deliberately FORBIDS in-between radii on buttons. The
+       * primary pill is `#0f0f0f` background with `#fafafa` text and
+       * a white border — the brand's "pill on dark" pattern, NOT
+       * `background: var(--accent)`. Emerald stays reserved for the
+       * brand-pill variant below and for links + focus. */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: var(--space-2) var(--space-8);
+        border: 1px solid transparent;
+        border-radius: var(--radius-pill);
+        font-family: var(--font-display);
+        font-size: var(--text-sm);
+        font-weight: 500;
+        line-height: 1.14;
+        cursor: pointer;
+        text-decoration: none;
+        background: transparent;
+        color: inherit;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          border-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible {
+        outline: none;
+        box-shadow: var(--focus-ring);
+      }
+      .btn-primary {
+        background: #0f0f0f;
+        color: var(--fg);
+        border-color: var(--fg);
+      }
+      .btn-primary:hover {
+        background: color-mix(in oklab, #0f0f0f, var(--fg) 6%);
+      }
+      .btn-secondary {
+        background: #0f0f0f;
+        color: var(--fg);
+        border-color: var(--border);
+        opacity: 0.92;
+      }
+      .btn-secondary:hover {
+        border-color: color-mix(in oklab, var(--border), var(--fg) 16%);
+        opacity: 1;
+      }
+      /* Brand pill — the one place emerald appears as a button surface.
+         Reserved for the single highest-intent CTA per screen so the
+         ≤2 accent-uses budget stays honest. */
+      .btn-brand {
+        background: var(--accent);
+        color: var(--accent-on);
+        border-color: var(--accent);
+      }
+      .btn-brand:hover {
+        background: var(--accent-hover);
+        border-color: var(--accent-hover);
+      }
+      .btn-brand:active { background: var(--accent-active); }
+      .btn-ghost {
+        background: transparent;
+        color: var(--fg);
+        border-radius: var(--radius-sm);
+        padding: var(--space-2) var(--space-3);
+        border-color: transparent;
+      }
+      .btn-ghost:hover {
+        background: var(--surface);
+      }
+
+      /* ─── Inputs ────────────────────────────────────────────────
+       * Border-defined edges (DESIGN.md §6 — no shadows on dark).
+       * On focus the border resolves to the brand accent at full
+       * saturation, layered with the green focus halo. */
+      .field {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+      }
+      .field label {
+        font-size: var(--text-sm);
+        font-weight: 500;
+        color: var(--fg);
+      }
+      .field input {
+        padding: var(--space-3) var(--space-4);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--bg);
+        color: var(--fg);
+        font-family: inherit;
+        font-size: var(--text-sm);
+        line-height: 1.43;
+        outline: none;
+        transition:
+          border-color var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .field input::placeholder { color: var(--meta); }
+      .field input:hover { border-color: #393939; }
+      .field input:focus-visible {
+        border-color: var(--accent);
+        box-shadow: var(--focus-ring);
+      }
+      .field-help {
+        font-size: var(--text-xs);
+        color: var(--muted);
+      }
+
+      /* ─── Cards ─────────────────────────────────────────────────
+       * Border defines the edge (DESIGN.md §4): #2e2e2e at 8px or
+       * 16px radius depending on hierarchy. No shadows by default —
+       * the hover state introduces the green-accent border for the
+       * "brand-highlighted" elevation (DESIGN.md §6 Level 3). */
+      .card {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        padding: var(--space-6);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+        transition:
+          border-color var(--motion-base) var(--ease-standard),
+          background-color var(--motion-base) var(--ease-standard);
+      }
+      .card:hover {
+        border-color: color-mix(in oklab, var(--accent), transparent 70%);
+      }
+
+      /* ─── Badges ────────────────────────────────────────────────
+       * Pill badges with hairline borders — Supabase uses these for
+       * status markers and stage labels. The accent badge tints the
+       * brand emerald against the dark surface; the muted badge
+       * sits on the standard border tier. */
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-1);
+        padding: var(--space-1) var(--space-3);
+        border-radius: var(--radius-pill);
+        font-family: var(--font-display);
+        font-size: var(--text-xs);
+        font-weight: 500;
+        line-height: 1.33;
+        border: 1px solid transparent;
+      }
+      .badge-accent {
+        color: var(--accent);
+        background: color-mix(in oklab, var(--accent), var(--bg) 88%);
+        border-color: color-mix(in oklab, var(--accent), transparent 70%);
+      }
+      .badge-muted {
+        color: var(--fg-2);
+        background: var(--surface);
+        border-color: var(--border);
+      }
+      .badge-success {
+        color: var(--success);
+        background: color-mix(in oklab, var(--success), var(--bg) 88%);
+        border-color: color-mix(in oklab, var(--success), transparent 75%);
+      }
+      .badge-dot {
+        width: 6px;
+        height: 6px;
+        border-radius: var(--radius-pill);
+        background: currentColor;
+      }
+
+      /* ─── Links ─────────────────────────────────────────────────
+       * DESIGN.md §4: "Green: #00c573 — Supabase-branded links." We
+       * bind link color to the interactive-green variant (which is
+       * `--accent-hover` in this brand's mapping — see tokens.css §4)
+       * because that's the documented interactive form of the accent. */
+      a {
+        color: var(--accent-hover);
+        text-decoration: none;
+        border-bottom: 1px solid color-mix(in oklab, var(--accent-hover), transparent 70%);
+        transition:
+          color var(--motion-fast) var(--ease-standard),
+          border-color var(--motion-fast) var(--ease-standard);
+      }
+      a:hover {
+        color: var(--accent);
+        border-bottom-color: var(--accent);
+      }
+      a:focus-visible {
+        outline: none;
+        border-radius: 2px;
+        box-shadow: var(--focus-ring);
+      }
+
+      /* ─── Kbd ───────────────────────────────────────────────────
+       * Source Code Pro, hairline border edge. Supabase uses kbd
+       * marks throughout docs with the same border-defined restraint. */
+      kbd {
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        padding: 2px var(--space-2);
+        border-radius: 4px;
+        background: var(--surface);
+        color: var(--fg);
+        border: 1px solid var(--border);
+      }
+
+      /* ─── Code chip (inline) ────────────────────────────────────
+       * Source Code Pro at body-adjacent size for inline product
+       * references — table names, env vars, function signatures. */
+      code.chip {
+        font-family: var(--font-mono);
+        font-size: 0.92em;
+        color: var(--accent);
+        background: color-mix(in oklab, var(--accent), var(--bg) 92%);
+        padding: 2px var(--space-2);
+        border-radius: 4px;
+      }
+
+      /* ─── Section-specific layout ─────────────────────────────── */
+      .hero {
+        position: relative;
+        overflow: hidden;
+      }
+      /* Atmospheric green wash — the single chromatic moment behind
+         the hero headline. A radial of `var(--accent)` at low opacity
+         echoes Supabase's logo-as-canvas treatment without violating
+         the ≤2 accent uses budget (the wash is decorative atmosphere,
+         not a labeled accent surface). */
+      .hero::before {
+        content: "";
+        position: absolute;
+        inset: -20% -10% auto -10%;
+        height: 70%;
+        background:
+          radial-gradient(
+            55% 60% at 18% 30%,
+            color-mix(in oklab, var(--accent), var(--bg) 70%) 0%,
+            var(--bg) 60%
+          );
+        opacity: 0.55;
+        filter: blur(60px);
+        z-index: 0;
+        pointer-events: none;
+      }
+      .hero > * { position: relative; z-index: 1; }
+      .hero .eyebrow { margin-block-end: var(--space-5); }
+      .hero h1 { max-width: 16ch; }
+      .hero .lede {
+        max-width: 56ch;
+        margin-block-start: var(--space-6);
+        font-size: var(--text-lg);
+        line-height: 1.56;
+      }
+      .hero-actions {
+        display: flex;
+        gap: var(--space-3);
+        margin-block-start: var(--space-8);
+        align-items: center;
+        flex-wrap: wrap;
+      }
+      .hero-meta {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-3);
+        margin-block-start: var(--space-6);
+        color: var(--muted);
+        font-size: var(--text-sm);
+        flex-wrap: wrap;
+      }
+
+      .features-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: var(--space-5);
+        margin-block-start: var(--space-8);
+      }
+      @media (max-width: 1023px) {
+        .features-grid { grid-template-columns: 1fr 1fr; }
+      }
+      @media (max-width: 639px) {
+        .features-grid { grid-template-columns: 1fr; }
+      }
+      .feature-icon {
+        width: 36px;
+        height: 36px;
+        border-radius: var(--radius-md);
+        border: 1px solid var(--border);
+        background: var(--bg);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--accent);
+      }
+      .feature-icon svg { width: 18px; height: 18px; }
+
+      .form-row {
+        display: grid;
+        grid-template-columns: 1.2fr 1fr;
+        gap: var(--space-12);
+        align-items: start;
+        margin-block-start: var(--space-8);
+      }
+      @media (max-width: 1023px) {
+        .form-row { grid-template-columns: 1fr; gap: var(--space-8); }
+      }
+      .form {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+        max-width: 440px;
+        padding: var(--space-6);
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        box-shadow: var(--elev-raised);
+      }
+      .form-actions {
+        display: flex;
+        gap: var(--space-3);
+        margin-block-start: var(--space-2);
+        align-items: center;
+        flex-wrap: wrap;
+      }
+
+      .row-between {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-3);
+      }
+      .icon { width: 16px; height: 16px; flex-shrink: 0; }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <!-- ════════════════════════════════════════════════════════════
+           HERO — exercises: radial green wash (the one chromatic
+           moment per screen), h1 at 72px Circular weight 400 with
+           leading 1.00 (the terminal-density signature), .lede in
+           --fg-2, .btn-brand (the emerald pill), .btn-secondary
+           (dark pill with hairline border), Source Code Pro eyebrow.
+           Hero copy reflects Supabase's "build in a weekend, scale
+           to millions" voice — confident, technical, terse.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section class="hero" data-od-id="hero">
+        <p class="eyebrow">// open source · postgres-native</p>
+        <h1>Build in a weekend. Scale to millions.</h1>
+        <p class="lede">
+          Every Supabase project ships with a Postgres database,
+          authentication, instant APIs, edge functions, realtime
+          subscriptions, and object storage. Start with a
+          <code class="chip">create table</code>, deploy with a
+          <code class="chip">git push</code>, and let the platform
+          carry the load when traffic finds you.
+        </p>
+        <div class="hero-actions">
+          <a href="./tokens.css" class="btn btn-brand" style="border-bottom: none">
+            Start your project
+            <svg
+              class="icon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.75"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M5 12h14M13 6l6 6-6 6" />
+            </svg>
+          </a>
+          <a href="./DESIGN.md" class="btn btn-secondary" style="border-bottom: none">
+            Read the docs
+          </a>
+        </div>
+        <p class="hero-meta">
+          <span class="badge badge-muted">
+            <span class="badge-dot" aria-hidden="true" style="color: var(--success)"></span>
+            All systems normal
+          </span>
+          <span>Press <kbd>⌘</kbd> <kbd>K</kbd> to search the docs.</span>
+        </p>
+      </section>
+
+      <!-- ════════════════════════════════════════════════════════════
+           FEATURE CARDS — three cards exercising: .card (border-as-
+           depth, no shadow), h3 with -0.0067em tracking and 1.33
+           leading (DESIGN.md card-title row), .feature-icon (hairline
+           bordered square with emerald glyph), .badge-accent (the
+           tinted brand-status pill), link bottom-border underline.
+           Three cards per row at desktop, collapse to two then one.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="features">
+        <p class="eyebrow">// the stack</p>
+        <h2 style="max-width: 26ch; margin-block-start: var(--space-4)">
+          The open source backend that grew up.
+        </h2>
+        <p class="body-muted" style="margin-block-start: var(--space-4); max-width: 56ch">
+          One project, six services, all standing on Postgres. Bring
+          your own SQL — the rest of the platform speaks your schema.
+        </p>
+
+        <div class="features-grid">
+          <article class="card">
+            <div class="row-between">
+              <span class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                  <ellipse cx="12" cy="6" rx="8" ry="3" />
+                  <path d="M4 6v6c0 1.66 3.58 3 8 3s8-1.34 8-3V6" />
+                  <path d="M4 12v6c0 1.66 3.58 3 8 3s8-1.34 8-3v-6" />
+                </svg>
+              </span>
+              <span class="badge badge-accent">Postgres 16</span>
+            </div>
+            <h3>A dedicated database, on day one.</h3>
+            <p class="body-muted body-sm">
+              Every project gets a fully-managed Postgres instance with
+              extensions, point-in-time recovery, and read replicas. The
+              <code class="chip">supabase</code> CLI streams migrations
+              from <code class="chip">/supabase/migrations</code> straight
+              to production.
+            </p>
+            <a href="./tokens.css" class="body-sm">Explore the database &rarr;</a>
+          </article>
+
+          <article class="card">
+            <div class="row-between">
+              <span class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                  <rect x="3" y="11" width="18" height="10" rx="2" />
+                  <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+                </svg>
+              </span>
+              <span class="badge badge-accent">Row-level</span>
+            </div>
+            <h3>Auth that respects your schema.</h3>
+            <p class="body-muted body-sm">
+              Email, OAuth, magic links, and SAML — all writing to a
+              <code class="chip">auth.users</code> table you can join
+              against. Row-level security policies enforce access in
+              the database, not in middleware.
+            </p>
+            <a href="./DESIGN.md" class="body-sm">See the auth flow &rarr;</a>
+          </article>
+
+          <article class="card">
+            <div class="row-between">
+              <span class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M12 2v20M2 12h20" />
+                  <circle cx="12" cy="12" r="9" />
+                </svg>
+              </span>
+              <span class="badge badge-success">
+                <span class="badge-dot" aria-hidden="true"></span>
+                Realtime
+              </span>
+            </div>
+            <h3>Subscriptions over your data.</h3>
+            <p class="body-muted body-sm">
+              Listen to row inserts, updates, and deletes from the
+              browser — no extra service, no manual fan-out. Realtime
+              streams Postgres' write-ahead log to authorized clients
+              over a single WebSocket.
+            </p>
+            <a href="./tokens.css" class="body-sm">Inspect the channel &rarr;</a>
+          </article>
+        </div>
+      </section>
+
+      <!-- ════════════════════════════════════════════════════════════
+           FORM — exercises: .field with border-defined input edges,
+           focus-visible swap to the emerald border + green focus
+           halo, .btn-brand and .btn-secondary reuse. Form sits in
+           its own bordered card with the brand's minimal elev-raised
+           shadow so the inputs read as recessed beneath the card.
+      ═══════════════════════════════════════════════════════════════ -->
+      <section data-od-id="form">
+        <p class="eyebrow">// get the launch kit</p>
+        <h2 style="margin-block-start: var(--space-4); max-width: 28ch">
+          Ship the schema. We'll handle the rest.
+        </h2>
+
+        <div class="form-row">
+          <div class="stack-4">
+            <p class="body-muted" style="max-width: 48ch">
+              Inputs, focus rings, and edges all derive from
+              <code class="chip">--border</code> and
+              <code class="chip">--accent</code>. The primary CTA reuses
+              <code class="chip">.btn-brand</code> unchanged — emerald
+              fill, near-black label, pill radius. No raw hex anywhere
+              in the component CSS.
+            </p>
+            <p class="body-muted body-sm">
+              Press <kbd>Enter</kbd> on the email field to submit. The
+              focus halo lands at the documented brand-highlight tint
+              (<code class="chip">rgba(62, 207, 142, 0.5)</code>) —
+              visible against the canvas without dominating the page.
+            </p>
+            <p class="body-meta">
+              Full reference at <a href="./tokens.css">tokens.css</a> ·
+              spec at <a href="./DESIGN.md">DESIGN.md</a>.
+            </p>
+          </div>
+
+          <form class="form" onsubmit="event.preventDefault();">
+            <div class="row-between">
+              <p class="eyebrow">// launch kit</p>
+              <span class="badge badge-success">
+                <span class="badge-dot" aria-hidden="true"></span>
+                Open
+              </span>
+            </div>
+            <div class="field">
+              <label for="email">Work email</label>
+              <input
+                id="email"
+                type="email"
+                placeholder="you@team.dev"
+                autocomplete="email"
+                required
+              />
+              <p class="field-help">
+                We'll send the starter repo and a Postgres schema you
+                can <code class="chip">supabase db push</code> on day one.
+              </p>
+            </div>
+            <div class="form-actions">
+              <button type="submit" class="btn btn-brand">
+                Send the kit
+              </button>
+              <button type="button" class="btn btn-ghost">
+                Browse the docs
+              </button>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/supabase/tokens.css
+++ b/design-systems/supabase/tokens.css
@@ -1,0 +1,294 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/supabase/tokens.css
+ *
+ * Structured token bindings for "Supabase" — the open-source Firebase
+ * alternative whose marketing surface reads like a dark-mode editor that
+ * grew up: near-black canvas (#171717), Postgres-emerald (#3ecf8e) reserved
+ * for the chromatic moments, Circular geometric sans for prose, Source
+ * Code Pro uppercase for the developer-console voice, and depth carried
+ * by a tight border hierarchy instead of drop shadows.
+ *
+ * Agents generating an artifact for Supabase should paste the `:root`
+ * block verbatim into the first `<style>` of the artifact, then reference
+ * everything via `var(--*)`.
+ *
+ * Brand-specific schema decisions (each bends a schema convention to
+ * match Supabase's voice rather than the cross-brand default):
+ *
+ *   1. `--bg: #171717` and `--surface: #1c1c1c` instead of pure black.
+ *      DESIGN.md §1: "deep black backgrounds (`#0f0f0f`, `#171717`)" but
+ *      "never pure black". The #1c1c1c surface gives cards a faint
+ *      luminance step above the page without warm-shifting; Supabase
+ *      has no warm tier, so `--surface-warm` aliases `--surface` rather
+ *      than introducing a tint that doesn't exist in the brand.
+ *
+ *   2. Four-level foreground ramp — `#fafafa → #b4b4b4 → #898989 →
+ *      #4d4d4d` — bound to `--fg / --fg-2 / --muted / --meta`. DESIGN.md
+ *      §2 documents exactly these four text tiers (Off White / Light
+ *      Gray / Mid Gray / Dark Gray) and §9 calls them out as the
+ *      primary / secondary / muted / heavy-secondary ramp. Binding them
+ *      independently (no aliasing) lets the marketing surface render
+ *      genuine four-tier hierarchy — the dark canvas hides any two-tier
+ *      collapse, so the differentiation is real.
+ *
+ *   3. `--border: #2e2e2e` and `--border-soft: #242424` as solid hex,
+ *      not rgba. DESIGN.md §6 makes border-as-depth THE depth system
+ *      ("depth comes from borders, not shadows") and §9 names #242424
+ *      as the subtle tier and #2e2e2e as the standard tier. The hex
+ *      form (instead of rgba over the dark bg) is intentional: it
+ *      keeps the border's luminance constant regardless of what surface
+ *      it sits on, which is the brand's "edges define" promise.
+ *
+ *   4. `--accent: #3ecf8e` — Supabase brand green, the Postgres-emerald
+ *      identity marker. Used SPARINGLY (DESIGN.md §1: "always as a
+ *      signal of 'this is Supabase' rather than as a decorative
+ *      element"). `--accent-on` is `#0f0f0f` (near-black), not the
+ *      schema default of `#ffffff`, because emerald at this luminance
+ *      reads with dark text far better than white — the contrast ratio
+ *      against the bright green is what makes the brand button legible.
+ *      `--accent-hover` binds to `#00c573`, the documented "green link"
+ *      color (DESIGN.md §2 Brand) — Supabase ships TWO emerald values
+ *      with semantic distinction (brand vs. interactive) and the
+ *      hover state is exactly where the interactive variant belongs.
+ *
+ *   5. `--font-display` and `--font-body` share the Circular stack.
+ *      Hierarchy comes from size + weight (400 for prose, 500 for
+ *      interactive), never from a separate display face. DESIGN.md §3
+ *      Principles: "There is no bold (700) in the detected system —
+ *      hierarchy is created through size, not weight."
+ *      `--font-mono: "Source Code Pro"` for the developer-console
+ *      voice — the uppercase technical labels with 1.2px tracking that
+ *      DESIGN.md §3 calls "the developer-console marker that connects
+ *      the marketing site to the product".
+ *
+ *   6. `--text-4xl: 72px` with `--leading-tight: 1.00`. DESIGN.md §3
+ *      makes the 1.00 hero line-height "the defining typographic
+ *      gesture — text that feels like a terminal command: dense,
+ *      efficient, no wasted vertical space." Tracking stays at
+ *      `normal` (per DESIGN.md §3 hero row) — Supabase reads dense
+ *      from the leading collapse, not from negative letter-spacing
+ *      like Vercel's `-0.05em`.
+ *
+ *   7. Section rhythm is generous: 128px desktop, 80px tablet, 48px
+ *      phone. DESIGN.md §5 names 90–128px desktop spacing as
+ *      "dramatic, cinematic pacing — each section is its own scene in
+ *      the dark void". The top of that range (128px) matches the
+ *      brand's confidence; the 48px phone floor is the documented
+ *      mobile collapse.
+ *
+ *   8. Radius scale 6 / 8 / 16 / 9999. DESIGN.md §5: standard 6px
+ *      (ghost buttons, secondary), comfortable 8px (cards), large 16px
+ *      (feature cards), pill 9999px (primary CTAs and tab indicators).
+ *      DESIGN.md §7 forbids the 16px tier on buttons — "pills (9999px)
+ *      or standard (6px), nothing in between". Component CSS enforces
+ *      that policy at the component level.
+ *
+ *   9. `--elev-raised` uses the brand's "border + minimal shadow"
+ *      compromise: `0 0 0 1px var(--border), 0 4px 12px rgba(0, 0, 0,
+ *      0.4)`. DESIGN.md §6 says Supabase "deliberately avoids shadows"
+ *      but uses `rgba(0, 0, 0, 0.1) 0px 4px 12px` for focus states —
+ *      we deepen that alpha for the raised tier so a card actually
+ *      separates from the dark canvas, while keeping the ring as the
+ *      primary depth signal.
+ *
+ *  10. `--focus-ring` is a 2px ring at `color-mix(var(--accent),
+ *      transparent 50%)` — the green-tinted halo that DESIGN.md §6
+ *      Level 3 names as the "brand-highlighted" elevation. On a near-
+ *      black canvas the schema's default (3px alpha glow over accent)
+ *      reads weak; 2px at 50% transparency lands at the documented
+ *      `rgba(62, 207, 142, 0.3)`-ish weight and stays unmistakably
+ *      Supabase.
+ *
+ * Source contracts:
+ *   - Standard token names: design-systems/_schema/tokens.schema.ts
+ *   - A2 fallback parity:   design-systems/_schema/defaults.css
+ *   - Lint enforcement:     apps/daemon/src/lint-artifact.ts
+ *
+ * Keep this file additive: never invent token names not also documented
+ * in DESIGN.md or the schema. Circular and Source Code Pro do not need
+ * a CDN reference here — the font stacks list Helvetica Neue / Menlo
+ * fallbacks so artifacts render acceptably even when the brand faces
+ * are not loaded, and any host that wants the real Circular face links
+ * it externally.
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface (3 levels — schema slot) ─────────────────────────────
+   * #171717 is the documented page canvas (DESIGN.md §1 "Dark"). The
+   * card surface bumps one luminance step to #1c1c1c so elevated
+   * containers carry a faint lift without warm-shifting — Supabase
+   * has no warm tier, so `--surface-warm` aliases `--surface` exactly
+   * the way Vercel's achromatic canvas does. */
+  --bg: #171717;
+  --surface: #1c1c1c;
+  --surface-warm: var(--surface);            /* alias — Supabase has no warm tier */
+
+  /* ─── Foreground ramp (4 levels) ──────────────────────────────────
+   * Off White → Light Gray → Mid Gray → Dark Gray, the documented
+   * four-tier text scale from DESIGN.md §2. Each tier is independently
+   * bound (no aliasing) because Supabase genuinely uses four distinct
+   * text registers: heading white, body silver, caption gray, and
+   * tertiary metadata gray. The four-stop ramp is the typography
+   * system; collapsing it to two tiers would flatten the marketing
+   * surface's voice. */
+  --fg: #fafafa;                             /* Off White — primary text, headings */
+  --fg-2: #b4b4b4;                           /* Light Gray — secondary body, links */
+  --muted: #898989;                          /* Mid Gray — captions, footer, muted */
+  --meta: #4d4d4d;                           /* Dark Gray — tertiary metadata, disabled */
+
+  /* ─── Border (2 levels) ──────────────────────────────────────────
+   * Border-as-depth is THE depth system (DESIGN.md §6: "depth comes
+   * from borders, not shadows"). #2e2e2e is the standard card edge,
+   * #242424 the inner-row divider that "should not visually compete".
+   * Solid hex (not rgba over bg) keeps luminance constant regardless
+   * of what surface the border sits on. */
+  --border: #2e2e2e;                         /* standard border — cards, tabs, dividers */
+  --border-soft: #242424;                    /* subtle divider — inner row separators */
+
+  /* ─── Accent ─────────────────────────────────────────────────────
+   * Supabase brand emerald — the Postgres-green identity marker.
+   * Hard cap of ≤2 visible uses per screen (lint enforced) because
+   * DESIGN.md §7 forbids using green "to backgrounds or large
+   * surfaces — it's for borders, links, and small accents".
+   *
+   * `--accent-on` is `#0f0f0f` (near-black), NOT the schema default
+   * `#ffffff` — bright emerald reads with dark text far better than
+   * white, and #0f0f0f is the documented "near-black" button surface
+   * already in the brand's neutral scale.
+   *
+   * `--accent-hover` is `#00c573` — DESIGN.md §2 documents this as
+   * the "green link" interactive variant of the brand color. Mapping
+   * it to the hover state preserves the brand's distinction between
+   * identity-green (#3ecf8e) and interactive-green (#00c573). */
+  --accent: #3ecf8e;                         /* Supabase emerald — brand identity marker */
+  --accent-on: #0f0f0f;                      /* near-black label on bright emerald */
+  --accent-hover: #00c573;                   /* documented interactive green link variant */
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+  /* ─── Semantic ───────────────────────────────────────────────────
+   * Supabase's marketing surface rarely renders state. DESIGN.md §7
+   * specifically forbids using the Radix warm tones (crimson, orange)
+   * as primary design elements — they exist purely as semantic
+   * tokens. We inherit the schema defaults rather than designing a
+   * custom warm palette that doesn't appear in the brand voice. */
+  --success: #16a34a;
+  --warn: #eab308;
+  --danger: #dc2626;
+
+  /* ─── Typography ─────────────────────────────────────────────────
+   * Circular is Supabase's signature face — a geometric sans-serif
+   * with rounded terminals that softens the technical edge.
+   * `--font-display` and `--font-body` share the stack; the Helvetica
+   * Neue / Helvetica / Arial fallbacks come straight from DESIGN.md
+   * §3 and ensure artifacts render legibly even when Circular is not
+   * loaded. Source Code Pro is the developer-console voice — the
+   * uppercase technical labels with 1.2px tracking that DESIGN.md §3
+   * calls "the marker that connects the marketing site to the
+   * product". Office Code Pro / Menlo fallbacks match DESIGN.md §3. */
+  --font-display: "Circular", "custom-font", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-body: "Circular", "custom-font", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-mono: "Source Code Pro", "Office Code Pro", Menlo, Monaco, Consolas, monospace;
+
+  /* Type scale (px) — derived from DESIGN.md §3 hierarchy table.
+   * The scale tops out at 72px (display hero) and shoots straight up
+   * from 36px (section heading) — the missing intermediate steps are
+   * deliberate. Supabase reads BIG because the hero leading collapses
+   * to 1.00, not because the px count climbs gradually. */
+  --text-xs: 12px;                           /* small — fine print, code labels */
+  --text-sm: 14px;                           /* button, nav link, caption */
+  --text-base: 16px;                         /* body — standard reading */
+  --text-lg: 18px;                           /* sub-heading — secondary headings */
+  --text-xl: 24px;                           /* card title */
+  --text-2xl: 32px;                          /* mid-large heading */
+  --text-3xl: 36px;                          /* section heading */
+  --text-4xl: 72px;                          /* display hero — terminal-density */
+
+  /* `--leading-tight` is 1.00 — DESIGN.md §3 names this "the defining
+   * typographic gesture" and forbids relaxing it ("Don't increase
+   * hero line-height above 1.00 — the density is intentional").
+   * `--tracking-display` is `normal` (DESIGN.md §3 hero row) —
+   * Supabase reads dense from the leading collapse, not from negative
+   * letter-spacing like Vercel's -0.05em. */
+  --leading-body: 1.5;
+  --leading-tight: 1.00;
+  --tracking-display: normal;
+
+  /* ─── Spacing ────────────────────────────────────────────────────
+   * 4px-grid base scale. DESIGN.md §5 documents micro-stops (1px /
+   * 4px / 6px) that are too fine to belong in the shared schema —
+   * those are inlined per-component when needed. The 4/8/12/16/20/
+   * 24/32/48 tier covers the structural rhythm of cards and stacks. */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+
+  /* Section rhythm — DESIGN.md §5: "Dramatic section spacing 90–128px
+   * creates a cinematic pacing — each section is its own scene in the
+   * dark void". We sit at the top of that range (128px desktop) to
+   * honor the brand confidence, drop to 80px on tablet, and 48px on
+   * phone (the documented mobile floor). */
+  --section-y-desktop: 128px;
+  --section-y-tablet: 80px;
+  --section-y-phone: 48px;
+
+  /* ─── Radius ─────────────────────────────────────────────────────
+   * DESIGN.md §5 radius scale: 6 / 8 / 11–12 / 16 / 9999. We bind
+   * the four schema tiers to 6 (ghost / functional / secondary), 8
+   * (cards / containers), 16 (feature cards / major containers),
+   * 9999 (primary CTAs and pill tabs). The 11–12px mid-panel tier is
+   * component-specific and not part of the shared schema. DESIGN.md
+   * §7 forbids in-between radii on buttons — components MUST pick
+   * pill or 6px, never 8/12/16. */
+  --radius-sm: 6px;                          /* ghost buttons, secondary, functional */
+  --radius-md: 8px;                          /* cards, containers */
+  --radius-lg: 16px;                         /* feature cards, major containers */
+  --radius-pill: 9999px;                     /* primary CTAs, tab indicators */
+
+  /* ─── Elevation (3 levels) ───────────────────────────────────────
+   * DESIGN.md §6: Supabase "deliberately avoids shadows" because they
+   * read as invisible on a dark canvas; depth is the border hierarchy
+   * (#242424 → #2e2e2e → #393939 → green-accent border). We map:
+   *
+   *   --elev-flat    no shadow (page background, text blocks)
+   *   --elev-ring    1px hairline ring at --border (the standard tier)
+   *   --elev-raised  ring + minimal ambient shadow (the brand's
+   *                  compromise: DESIGN.md's focus shadow alpha
+   *                  deepened from 0.1 to 0.4 so a card actually
+   *                  separates from the dark canvas at distance) */
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised: 0 0 0 1px var(--border), 0 4px 12px rgba(0, 0, 0, 0.4);
+
+  /* ─── Focus ring ─────────────────────────────────────────────────
+   * 2px ring at `color-mix(var(--accent), transparent 50%)` — the
+   * green-tinted halo that DESIGN.md §6 Level 3 names the "brand-
+   * highlighted" elevation (`rgba(62, 207, 142, 0.3)`). On a near-
+   * black canvas the schema's default 3px alpha glow reads weak;
+   * 2px at 50% transparency lands at the documented weight and stays
+   * unmistakably Supabase without dominating the surface. */
+  --focus-ring: 0 0 0 2px color-mix(in oklab, var(--accent), transparent 50%);
+
+  /* ─── Motion ─────────────────────────────────────────────────────
+   * Two durations + one easing curve, per the anti-ai-slop "short,
+   * purposeful transitions (150–250ms) with stable easing". Supabase
+   * transitions are quick and unobtrusive — the brand reads as
+   * engineered, never choreographed. */
+  --motion-fast: 150ms;
+  --motion-base: 200ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+  /* ─── Layout ─────────────────────────────────────────────────────
+   * 1200px max content width — typical for marketing surfaces.
+   * Mobile gutter holds at 16px (instead of dropping to 12px) so
+   * code blocks and badges retain padding context on small screens;
+   * Supabase's developer-doc voice rarely edge-bleeds. */
+  --container-max: 1200px;
+  --container-gutter-desktop: 24px;
+  --container-gutter-tablet: 16px;
+  --container-gutter-phone: 16px;
+}

--- a/design-systems/x-ai/components.html
+++ b/design-systems/x-ai/components.html
@@ -1,0 +1,460 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>x-ai — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/x-ai. Every visible value
+        comes from tokens.css. xAI's signature moves: #1f2228 warm near-black
+        canvas, pure-white text on opacity-based foreground tiers, GeistMono
+        as the display + button face, uppercase tracked-out CTAs, zero
+        shadows, near-zero radii, blue-only focus ring."
+    />
+
+    <style>
+      :root {
+        --bg:           #1f2228;
+        --surface:      rgba(255, 255, 255, 0.03);
+        --surface-warm: rgba(255, 255, 255, 0.05);
+
+        --fg:    #ffffff;
+        --fg-2:  rgba(255, 255, 255, 0.7);
+        --muted: rgba(255, 255, 255, 0.5);
+        --meta:  rgba(255, 255, 255, 0.3);
+
+        --border:      rgba(255, 255, 255, 0.1);
+        --border-soft: rgba(255, 255, 255, 0.05);
+
+        --accent:        #ffffff;
+        --accent-on:     #1f2228;
+        --accent-hover:  rgba(255, 255, 255, 0.9);
+        --accent-active: rgba(255, 255, 255, 0.8);
+
+        --success: #16a34a;
+        --warn:    #eab308;
+        --danger:  #dc2626;
+
+        --font-display: "GeistMono", ui-monospace, "SF Mono", "Roboto Mono", Menlo, Monaco, "Liberation Mono", "DejaVu Sans Mono", "Courier New", monospace;
+        --font-body:    "universalSans", "universalSans Fallback", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+        --font-mono:    "GeistMono", ui-monospace, "SF Mono", "Roboto Mono", Menlo, Monaco, "Liberation Mono", "DejaVu Sans Mono", "Courier New", monospace;
+
+        --text-xs:   12px;
+        --text-sm:   14px;
+        --text-base: 16px;
+        --text-lg:   20px;
+        --text-xl:   24px;
+        --text-2xl:  30px;
+        --text-3xl:  40px;
+        --text-4xl:  64px;
+
+        --leading-body:     1.5;
+        --leading-tight:    1.2;
+        --tracking-display: normal;
+
+        --space-1:  4px;
+        --space-2:  8px;
+        --space-3:  12px;
+        --space-4:  16px;
+        --space-5:  20px;
+        --space-6:  24px;
+        --space-8:  32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 96px;
+        --section-y-tablet:  64px;
+        --section-y-phone:   48px;
+
+        --radius-sm:   0px;
+        --radius-md:   0px;
+        --radius-lg:   4px;
+        --radius-pill: 9999px;
+
+        --elev-flat:   none;
+        --elev-ring:   0 0 0 1px var(--border);
+        --elev-raised: none;
+
+        --focus-ring: 0 0 0 3px rgba(59, 130, 246, 0.5);
+
+        --motion-fast:   150ms;
+        --motion-base:   200ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+        --container-max:            1200px;
+        --container-gutter-desktop: 24px;
+        --container-gutter-tablet:  16px;
+        --container-gutter-phone:   12px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg-2);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      section + section { border-top: 1px solid var(--border); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography ────────────────────────────────────────────── */
+      h1, h2, h3 {
+        margin: 0;
+        color: var(--fg);
+        line-height: var(--leading-tight);
+      }
+      h1 {
+        font-family: var(--font-display);
+        font-size: var(--text-4xl);
+        font-weight: 300;
+        letter-spacing: var(--tracking-display);
+      }
+      /* The 320px hero treatment from DESIGN.md §3 is a one-off, not a
+         token tier. We render the hero headline at clamp(--text-4xl,
+         16vw, 320px) so it scales down from the cinematic 320px on
+         ultrawide canvases to ~48–64px on phones (DESIGN.md §8 collapsing
+         strategy: "320px monospace headline scales down dramatically"). */
+      h1.hero-display {
+        font-size: clamp(var(--text-4xl), 16vw, 320px);
+        line-height: 1.5;
+      }
+      h2 {
+        font-family: var(--font-body);
+        font-size: var(--text-2xl);
+        font-weight: 400;
+      }
+      h3 {
+        font-family: var(--font-body);
+        font-size: var(--text-xl);
+        font-weight: 400;
+      }
+      p { margin: 0; }
+      .lead {
+        font-size: var(--text-lg);
+        color: var(--fg-2);
+        max-width: 60ch;
+      }
+      .body-muted { color: var(--fg-2); }
+      .body-sm { font-size: var(--text-sm); color: var(--fg-2); }
+      .meta { font-size: var(--text-xs); color: var(--meta); }
+      /* Uppercase monospace eyebrow — the brand's signature label voice.
+         The 1.4px tracking matches the button treatment from DESIGN.md
+         §3, expressed in em so it scales proportionally with size. */
+      .eyebrow {
+        font-family: var(--font-display);
+        font-size: var(--text-xs);
+        font-weight: 400;
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+      }
+      .stack-2 > * + * { margin-block-start: var(--space-2); }
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+
+      /* ─── Buttons ───────────────────────────────────────────────────
+         DESIGN.md §4: GeistMono 14px, uppercase, 1.4px letter-spacing,
+         12px 24px padding, 0px radius. Hover DIMS rather than brightens
+         — the convention is reversed (DESIGN.md §7 "Don't brighten
+         elements on hover — xAI dims to 0.5 opacity instead"). */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: var(--space-3) var(--space-6);
+        border-radius: var(--radius-sm);
+        font-family: var(--font-display);
+        font-size: var(--text-sm);
+        font-weight: 400;
+        line-height: 1;
+        text-transform: uppercase;
+        letter-spacing: 1.4px;
+        cursor: pointer;
+        border: 1px solid transparent;
+        transition: background-color var(--motion-fast) var(--ease-standard),
+                    color var(--motion-fast) var(--ease-standard),
+                    border-color var(--motion-fast) var(--ease-standard);
+        text-decoration: none;
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn-primary {
+        background: var(--accent);
+        color: var(--accent-on);
+      }
+      .btn-primary:hover { background: var(--accent-hover); }
+      .btn-primary:active { background: var(--accent-active); }
+      .btn-ghost {
+        background: transparent;
+        color: var(--fg);
+        border-color: rgba(255, 255, 255, 0.2);
+      }
+      .btn-ghost:hover {
+        background: var(--surface);
+        border-color: rgba(255, 255, 255, 0.2);
+      }
+
+      /* ─── Monospace tag / badge ─────────────────────────────────────
+         DESIGN.md §4 "Monospace Tag": GeistMono 12px uppercase, 1px
+         letter-spacing, 4px 8px padding, sharp corners. */
+      .tag {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-1);
+        padding: var(--space-1) var(--space-2);
+        border-radius: var(--radius-sm);
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        background: transparent;
+        font-family: var(--font-display);
+        font-size: var(--text-xs);
+        font-weight: 400;
+        color: var(--fg);
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        line-height: 1.4;
+      }
+
+      /* ─── Cards ─────────────────────────────────────────────────────
+         DESIGN.md §4: surface 0.03 background, 1px solid 0.1 border,
+         0px radius, NO shadow. Hover lifts the border alpha to 0.2
+         — depth through edge brightness, not shadow simulation. */
+      .card {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        padding: var(--space-6);
+        box-shadow: var(--elev-flat);
+        transition: background-color var(--motion-base) var(--ease-standard),
+                    border-color var(--motion-base) var(--ease-standard);
+      }
+      .card:hover {
+        background: var(--surface-warm);
+        border-color: rgba(255, 255, 255, 0.2);
+      }
+      .card .card-title {
+        font-family: var(--font-body);
+        font-size: var(--text-xl);
+        font-weight: 400;
+        color: var(--fg);
+        margin: 0;
+      }
+      .card .card-body {
+        font-size: var(--text-base);
+        color: var(--fg-2);
+      }
+
+      /* ─── Inputs ────────────────────────────────────────────────────
+         DESIGN.md §4 "Inputs & Forms": transparent / 0.05 bg, 0.2
+         border, 0px radius, white 16px universalSans text, 0.3
+         placeholder. Focus uses the blue ring (the lone chromatic
+         move in the system). */
+      .field { display: flex; flex-direction: column; gap: var(--space-2); }
+      .field label {
+        font-size: var(--text-sm);
+        font-weight: 400;
+        color: var(--fg-2);
+      }
+      .field input,
+      .field textarea {
+        background: var(--surface);
+        color: var(--fg);
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        border-radius: var(--radius-sm);
+        padding: var(--space-3) var(--space-4);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        outline: none;
+        transition: border-color var(--motion-fast) var(--ease-standard),
+                    box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .field textarea { resize: vertical; min-height: 96px; }
+      .field input::placeholder,
+      .field textarea::placeholder { color: var(--meta); }
+      .field input:focus,
+      .field textarea:focus {
+        border-color: rgba(255, 255, 255, 0.2);
+        box-shadow: var(--focus-ring);
+      }
+
+      /* ─── Layout ────────────────────────────────────────────────── */
+      .hero {
+        text-align: center;
+      }
+      .hero-actions {
+        display: flex;
+        gap: var(--space-3);
+        justify-content: center;
+        margin-block-start: var(--space-8);
+        flex-wrap: wrap;
+      }
+      .tag-row {
+        display: flex;
+        gap: var(--space-2);
+        justify-content: center;
+        flex-wrap: wrap;
+        margin-block-end: var(--space-8);
+      }
+      .features-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: var(--space-6);
+        margin-block-start: var(--space-12);
+      }
+      @media (max-width: 1023px) { .features-grid { grid-template-columns: 1fr 1fr; } }
+      @media (max-width: 639px)  { .features-grid { grid-template-columns: 1fr; } }
+      .feature-meta {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        color: var(--meta);
+        font-family: var(--font-display);
+        font-size: var(--text-xs);
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+      }
+      .feature-meta .dot {
+        width: 6px;
+        height: 6px;
+        border-radius: var(--radius-pill);
+        background: var(--fg);
+        opacity: 0.5;
+      }
+      .form-grid {
+        display: grid;
+        grid-template-columns: 1.1fr 1fr;
+        gap: var(--space-12);
+        align-items: start;
+      }
+      @media (max-width: 1023px) { .form-grid { grid-template-columns: 1fr; } }
+      form { display: flex; flex-direction: column; gap: var(--space-4); max-width: 480px; }
+      form .actions {
+        display: flex;
+        gap: var(--space-3);
+        margin-block-start: var(--space-2);
+        flex-wrap: wrap;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <!-- HERO -->
+      <section data-od-id="hero" class="hero">
+        <div class="tag-row">
+          <span class="tag">Grok 3</span>
+          <span class="tag">API</span>
+          <span class="tag">Frontier</span>
+        </div>
+        <h1 class="hero-display">xAI</h1>
+        <p class="lead" style="margin: var(--space-6) auto 0; color: var(--fg-2)">
+          Understand the universe. We are a frontier AI lab building the
+          tools to accelerate human scientific discovery — and the
+          monospace-on-warm-black voice that says so without decoration.
+        </p>
+        <div class="hero-actions">
+          <a href="./tokens.css" class="btn btn-primary">Try Grok</a>
+          <a href="./DESIGN.md" class="btn btn-ghost">View API</a>
+        </div>
+      </section>
+
+      <!-- FEATURES -->
+      <section data-od-id="features">
+        <div class="stack-3" style="text-align: center">
+          <p class="eyebrow">What this fixture exercises</p>
+          <h2 style="max-width: 32ch; margin-inline: auto">
+            Restraint as sophistication.
+          </h2>
+          <p class="lead" style="margin-inline: auto; color: var(--muted)">
+            Three cards. Sharp corners, opacity-based borders, zero
+            shadows. Depth through contrast — never simulated light.
+          </p>
+        </div>
+
+        <div class="features-grid">
+          <article class="card stack-4">
+            <div class="feature-meta"><span class="dot"></span><span>01 / Voice</span></div>
+            <h3 class="card-title">Monospace as luxury</h3>
+            <p class="card-body">
+              GeistMono at display sizes positions xAI as infrastructure,
+              not product. Fixed-width characters at scale create a
+              rhythmic, architectural quality no proportional font can
+              match. universalSans handles the reading.
+            </p>
+          </article>
+          <article class="card stack-4">
+            <div class="feature-meta"><span class="dot"></span><span>02 / Canvas</span></div>
+            <h3 class="card-title">#1f2228, never #000</h3>
+            <p class="card-body">
+              The warm near-black with a subtle blue undertone prevents
+              the harsh eye strain of pure black while maintaining deep
+              darkness. The canvas is the foundation — every surface
+              renders against it directly.
+            </p>
+          </article>
+          <article class="card stack-4">
+            <div class="feature-meta"><span class="dot"></span><span>03 / Depth</span></div>
+            <h3 class="card-title">Zero shadows</h3>
+            <p class="card-body">
+              Elevation through opacity-based borders that brighten on
+              interaction, subtle background tints (0.03 → 0.08), and
+              the massive typographic scale contrast. No simulated
+              light. No drop shadows. Ever.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <!-- FORM -->
+      <section data-od-id="form">
+        <div class="form-grid">
+          <div class="stack-4">
+            <p class="eyebrow">Form components</p>
+            <h2>Inputs on the dark canvas.</h2>
+            <p class="lead">
+              Transparent ground, hairline borders at 20% white. Focus
+              halos the field with Tailwind's default ring blue — the
+              single chromatic exception in an otherwise monochromatic
+              system. Placeholders dim to 30% white. Labels to 70%.
+            </p>
+            <p class="meta">All values from tokens.css — no raw hex.</p>
+          </div>
+          <form onsubmit="event.preventDefault()">
+            <div class="field">
+              <label for="email">Work email</label>
+              <input id="email" type="email" placeholder="you@xai.com" />
+            </div>
+            <div class="field">
+              <label for="org">Organization</label>
+              <input id="org" type="text" placeholder="Frontier AI Lab" />
+            </div>
+            <div class="field">
+              <label for="msg">Use case</label>
+              <textarea id="msg" placeholder="Describe the workload — training, inference, evaluation, or something we have not built yet."></textarea>
+            </div>
+            <div class="actions">
+              <button type="submit" class="btn btn-primary">Request access</button>
+              <button type="button" class="btn btn-ghost">Read the docs</button>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/x-ai/tokens.css
+++ b/design-systems/x-ai/tokens.css
@@ -1,0 +1,268 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/x-ai/tokens.css
+ *
+ * Structured token bindings for "x-ai" — the dark-first, monospace-driven
+ * brutalist minimalism of Elon Musk's AI lab. A design system that
+ * communicates through absence: pure white on warm near-black, GeistMono
+ * as the display voice, zero shadows, zero gradients, zero accent color.
+ * Restraint as sophistication.
+ *
+ * Brand identity in three sentences:
+ *   1. Dark-first canvas at #1f2228 (warm near-black with a subtle blue
+ *      undertone, NEVER pure #000000) carries pure-white text as "the
+ *      voice", with hierarchy expressed through opacity (100 / 70 / 50 / 30)
+ *      rather than hue. There is no gray middle ground.
+ *   2. GeistMono runs at display sizes (up to a hero-only 320px at weight
+ *      300) and as the uppercase, letter-spaced button face. universalSans
+ *      handles body and section headings. The monospace-as-display choice
+ *      is the brand: terminal aesthetic as luxury.
+ *   3. Zero box-shadows, zero gradients, near-zero radii (0px default,
+ *      4px occasional softening). Depth comes from opacity-based borders
+ *      and surface tints, not from simulated light. The single chromatic
+ *      exception is the keyboard focus ring (Tailwind's default blue).
+ *
+ * Brand-specific schema decisions (each bends a schema convention to
+ * match xAI's voice rather than the cross-brand default):
+ *
+ *   1. `--bg` is `#1f2228`, NOT `#000000`. DESIGN.md §2 names this hue
+ *      explicitly: "This specific hue prevents the harsh eye strain of
+ *      `#000000` while maintaining deep darkness." Pure black is
+ *      forbidden by the brand.
+ *
+ *   2. `--accent` is `#ffffff`, not a chromatic color. xAI has no
+ *      accent palette — white IS the chromatic move. Primary CTAs render
+ *      with `var(--accent)` as background and `var(--accent-on)` as
+ *      foreground, producing the signature white-on-dark button. The
+ *      "≤2 accent uses per screen" lint still holds; the primary CTA and
+ *      the focus indicator are the only places white reverses against
+ *      the canvas.
+ *
+ *   3. `--font-display` is a GeistMono stack. Monospace AS the display
+ *      face is the defining aesthetic decision (DESIGN.md §3) — it
+ *      positions xAI not as a consumer product but as infrastructure,
+ *      as something built by people who live in terminals. `--font-mono`
+ *      aliases the same stack because GeistMono IS the monospace face
+ *      used for code, kbd, and tabular metrics.
+ *
+ *   4. The four-level foreground ramp is opacity-based (rgba 1.0 / 0.7
+ *      / 0.5 / 0.3), NOT a grayscale hex ramp. DESIGN.md §2 documents
+ *      the system literally as "white at α". Binding `--fg-2`, `--muted`,
+ *      and `--meta` as `rgba(255,255,255,α)` preserves the "white over
+ *      canvas" voice and keeps the tiers chromatically locked to the
+ *      single foreground color.
+ *
+ *   5. `--border` is `rgba(255, 255, 255, 0.1)` — DESIGN.md §2's default
+ *      "Border Default" alpha, NOT a solid hex. `--border-soft` drops to
+ *      0.05 for inner-row separators. The 0.2 "Border Strong" tier from
+ *      DESIGN.md lives inline per-component (hover/active state edges).
+ *
+ *   6. Radii are aggressively small: 0 / 0 / 4 / 9999. DESIGN.md §5:
+ *      "The near-zero radius philosophy is core to the brand's brutalist
+ *      identity." Buttons, inputs, and cards all default to 0px;
+ *      `--radius-lg` softens to 4px for the rare secondary container
+ *      (DESIGN.md's "Subtle (4px) occasional"). `--radius-pill` stays at
+ *      9999px because the schema slot requires a pill value, even though
+ *      xAI rarely renders one.
+ *
+ *   7. `--elev-raised` is literally `none`. DESIGN.md §6: "xAI rejects
+ *      the conventional shadow-based elevation system entirely. There
+ *      are no box-shadows anywhere on the site." Depth is communicated
+ *      through three other mechanisms documented in the same section:
+ *      opacity-based borders that brighten on interaction, subtle
+ *      background-opacity shifts (0.03 → 0.08), and the massive
+ *      typographic scale contrast. `--elev-ring` is kept as a hairline
+ *      border-as-shadow so components that target the elevation token
+ *      still get a visible edge.
+ *
+ *   8. `--focus-ring` is the ONLY chromatic exception to the otherwise
+ *      strictly monochromatic palette. DESIGN.md §2 names Tailwind's
+ *      default `--tw-ring-color` (`rgb(59, 130, 246) / 0.5`) as the
+ *      keyboard focus indicator. We reproduce it as a 3px halo
+ *      (Tailwind's `ring-2` shape) — the blue is intentional and
+ *      non-negotiable for a11y, even though the rest of the system is
+ *      achromatic.
+ *
+ *   9. The type scale tops out at 64px (`--text-4xl`), NOT the 320px
+ *      hero display DESIGN.md §3 names. 320px is a hero-only treatment,
+ *      not a token tier — components.html overrides `font-size` inline
+ *      for that one cinematic moment. Reserving `--text-4xl` at 64px
+ *      keeps the slot useful as the H1-equivalent ceiling for cards,
+ *      sections, and modals across the system. (See vercel/tokens.css
+ *      §6 for the same reasoning: tokens encode reusable tiers, not
+ *      one-off hero crops.)
+ *
+ *  10. `--tracking-display` stays `normal`. GeistMono at display scale
+ *      does NOT compress letter-spacing — the monospace grid is part of
+ *      the aesthetic and tightening would collapse it. The uppercase
+ *      button tracking (`1.4px`, DESIGN.md §4) is an interaction-specific
+ *      value that lives inline on `.btn` since it applies only to
+ *      command-line-styled labels, not display headlines.
+ *
+ * Source contracts:
+ *   - Standard token names: design-systems/_schema/tokens.schema.ts
+ *   - A2 fallback parity:   design-systems/_schema/defaults.css
+ *   - Lint enforcement:     apps/daemon/src/lint-artifact.ts
+ *
+ * Keep this file additive: never invent token names not also documented
+ * in DESIGN.md or the shared schema. The GeistMono and universalSans
+ * faces are referenced by name only — artifacts that render acceptably
+ * fall back to the OS monospace and sans-serif stacks listed inside the
+ * font-family declarations.
+ * ─────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface ─────────────────────────────────────────────────────
+   * #1f2228 is the singular canvas — warm near-black with a subtle
+   * blue undertone. `--surface` is the barely-visible 0.03 white tint
+   * that cards sit on; `--surface-warm` rises to 0.05 for hover and
+   * elevated rows. DESIGN.md §6's elevation ramp uses both values
+   * verbatim as "Surface (Level 1)" and "Surface Hover". */
+  --bg:           #1f2228;                       /* warm near-black canvas — NEVER #000 */
+  --surface:      rgba(255, 255, 255, 0.03);     /* subtle card surface */
+  --surface-warm: rgba(255, 255, 255, 0.05);     /* hover / elevated tier */
+
+  /* ─── Foreground ──────────────────────────────────────────────────
+   * Four-level opacity ramp per DESIGN.md §2. Pure white is "the
+   * voice"; subsequent tiers express hierarchy by dimming rather
+   * than by hue. Binding as rgba (not hex) keeps the ramp locked
+   * chromatically to the single foreground color. */
+  --fg:    #ffffff;                              /* primary — headings, links, body */
+  --fg-2:  rgba(255, 255, 255, 0.7);             /* secondary — descriptions */
+  --muted: rgba(255, 255, 255, 0.5);             /* tertiary — captions, timestamps */
+  --meta:  rgba(255, 255, 255, 0.3);             /* quaternary — disabled, annotations */
+
+  /* ─── Border ──────────────────────────────────────────────────────
+   * Opacity-based borders — barely visible, never absent. 0.1 is the
+   * default card / divider edge; 0.05 is the inner-row separator
+   * that should not visually compete. The 0.2 "strong" tier from
+   * DESIGN.md §2 lives inline per-component (hover/active states). */
+  --border:      rgba(255, 255, 255, 0.1);       /* default card / divider */
+  --border-soft: rgba(255, 255, 255, 0.05);      /* inner row separator */
+
+  /* ─── Accent ──────────────────────────────────────────────────────
+   * White IS the accent. There is no chromatic color in xAI's
+   * monochromatic palette — primary CTAs are white-on-dark.
+   * `--accent-hover` dims to 0.9 alpha per DESIGN.md §4 (primary
+   * button hover); `--accent-active` drops a further step. The
+   * convention is REVERSED from most systems: hover dims, it does
+   * not brighten. */
+  --accent:        #ffffff;                      /* the voice as bg */
+  --accent-on:     #1f2228;                      /* canvas as fg on accent */
+  --accent-hover:  rgba(255, 255, 255, 0.9);     /* slight dimming on hover (DESIGN.md §4) */
+  --accent-active: rgba(255, 255, 255, 0.8);     /* deeper dim on press */
+
+  /* ─── Semantic ────────────────────────────────────────────────────
+   * DESIGN.md §7 actively discourages colored status indicators
+   * ("Don't use colored status indicators unless absolutely
+   * necessary — keep everything in the white/dark spectrum"). We
+   * inherit schema defaults so the slots remain useful for the rare
+   * cases where status truly must render chromatically — but
+   * components should prefer monochrome cues (opacity, weight). */
+  --success: #16a34a;
+  --warn:    #eab308;
+  --danger:  #dc2626;
+
+  /* ─── Typography — fonts ──────────────────────────────────────────
+   * GeistMono is the brand's defining typographic decision: a
+   * monospace face used at display sizes. universalSans handles
+   * body and section headings. `--font-mono` aliases the display
+   * stack because GeistMono IS the monospace face — there is no
+   * separate code typeface. */
+  --font-display: "GeistMono", ui-monospace, "SF Mono", "Roboto Mono", Menlo, Monaco, "Liberation Mono", "DejaVu Sans Mono", "Courier New", monospace;
+  --font-body:    "universalSans", "universalSans Fallback", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-mono:    "GeistMono", ui-monospace, "SF Mono", "Roboto Mono", Menlo, Monaco, "Liberation Mono", "DejaVu Sans Mono", "Courier New", monospace;
+
+  /* Type scale — DESIGN.md §3 hierarchy table.
+   * The 320px display hero is intentionally NOT a token tier;
+   * components.html overrides `font-size` inline for that one
+   * cinematic treatment. `--text-4xl` instead caps at 64px, the
+   * realistic ceiling for marketing H1s across cards/sections.
+   * `--text-2xl` (30px) matches DESIGN.md's "Section Heading" tier. */
+  --text-xs:   12px;                             /* small / meta — timestamps, footnotes */
+  --text-sm:   14px;                             /* button label / caption */
+  --text-base: 16px;                             /* body — universalSans 1.5 */
+  --text-lg:   20px;                             /* body large / introductions */
+  --text-xl:   24px;                             /* card title */
+  --text-2xl:  30px;                             /* section heading — DESIGN.md §3 */
+  --text-3xl:  40px;                             /* H1 */
+  --text-4xl:  64px;                             /* display ceiling (320px hero is inline-only) */
+
+  /* Leading + tracking.
+   * `--leading-body: 1.5` is universalSans body (DESIGN.md §3).
+   * `--leading-tight: 1.2` matches the 30px section heading.
+   * `--tracking-display: normal` because GeistMono at scale does
+   * NOT compress letter-spacing — the monospace grid is the
+   * aesthetic and tightening would collapse it. */
+  --leading-body:     1.5;
+  --leading-tight:    1.2;
+  --tracking-display: normal;
+
+  /* ─── Spacing ─────────────────────────────────────────────────────
+   * DESIGN.md §5 documents a deliberately sparse scale concentrated
+   * at the small end: 4 / 8 / 24 / 48. We bind the full schema slot
+   * range — components reach for 1/2/6/12 most often; the
+   * intermediate tiers are preserved for edge cases where a
+   * narrower step is structurally required. */
+  --space-1:  4px;
+  --space-2:  8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  20px;
+  --space-6:  24px;
+  --space-8:  32px;
+  --space-12: 48px;
+
+  /* Section rhythm — DESIGN.md §5: "generous section padding 48px–
+   * 96px". 96 desktop / 64 tablet / 48 phone preserves the
+   * cinematic emptiness that is itself a design statement; the
+   * absence of decoration means whitespace is the primary structural
+   * tool. */
+  --section-y-desktop: 96px;
+  --section-y-tablet:  64px;
+  --section-y-phone:   48px;
+
+  /* ─── Radius ──────────────────────────────────────────────────────
+   * Brutalist precision. DESIGN.md §5: "Sharp (0px) primary
+   * treatment for buttons, cards, inputs — the default. Subtle (4px)
+   * occasional softening on secondary containers." `--radius-pill`
+   * stays at 9999px because the schema slot requires a pill value,
+   * even though xAI rarely renders one. */
+  --radius-sm:   0px;                            /* buttons, inputs — sharp */
+  --radius-md:   0px;                            /* cards — sharp */
+  --radius-lg:   4px;                            /* occasional secondary softening */
+  --radius-pill: 9999px;                         /* schema-required slot */
+
+  /* ─── Elevation ───────────────────────────────────────────────────
+   * Shadow-free system per DESIGN.md §6: "xAI rejects the
+   * conventional shadow-based elevation system entirely. There are
+   * no box-shadows anywhere on the site." `--elev-raised` is
+   * literally `none`; depth comes from opacity-based borders and
+   * background tints. `--elev-ring` preserves the hairline edge for
+   * components that read the elevation token. */
+  --elev-flat:   none;
+  --elev-ring:   0 0 0 1px var(--border);
+  --elev-raised: none;
+
+  /* ─── Focus ───────────────────────────────────────────────────────
+   * The single chromatic exception. Tailwind's default
+   * `--tw-ring-color` (DESIGN.md §2 "Ring Blue") at 50% opacity, as
+   * a 3px halo matching the `ring-2` shape xAI uses for keyboard
+   * accessibility focus states. Non-negotiable for a11y. */
+  --focus-ring: 0 0 0 3px rgba(59, 130, 246, 0.5);
+
+  /* ─── Motion ──────────────────────────────────────────────────────
+   * Schema defaults. xAI does not choreograph — transitions are
+   * short, purposeful, utilitarian. No long-form entrances. */
+  --motion-fast:   150ms;
+  --motion-base:   200ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+  /* ─── Layout ──────────────────────────────────────────────────────
+   * DESIGN.md §5: "Max content width: approximately 1200px." Gutters
+   * narrow on mobile so the dense-but-deliberate vertical rhythm
+   * keeps reading even when the dark canvas reaches the edge. */
+  --container-max:            1200px;
+  --container-gutter-desktop: 24px;
+  --container-gutter-tablet:  16px;
+  --container-gutter-phone:   12px;
+}


### PR DESCRIPTION
## Why

Same motivation as #1841: the design-system library ships `tokens.css` + `components.html` as the two agent-consumable artifacts that let an AI produce on-brand HTML without reasoning from prose. This batch adds 10 brands that previously shipped only `DESIGN.md`.

Selection follows the natural follow-up to #1841: 5 brands that round out the AI ecosystem (x-ai, perplexity, ollama, runwayml, minimax), plus 5 high-recognition AI-adjacent devtools whose visual languages are distinctive enough that an agent would otherwise default to generic output (supabase, posthog, resend, shadcn, raycast).

Concrete pain: ask an agent today to "build a Supabase-style hero" or "make this look like Raycast" and it has nothing structured to pull from for these brands — only prose. After this PR it can paste a 56-token `:root` block and reference a working fixture.

## What users will see

No product UI change. Design-system consumers (skills, agents, external tooling) gain structured token files for:

**Tier A — AI ecosystem**
- **x-ai** — `#1f2228` warm near-black canvas, GeistMono-as-display (320px hero), pure-white as the singular accent, zero shadows, opacity-based foreground ramp
- **perplexity** — `#0f0f10` dark canvas, Perplexity Purple `#a855f7` accent, Inter + JetBrains Mono, citation-driven editorial restraint, elevation via border contrast (no shadows)
- **ollama** — Warm Parchment surfaces, monochrome accent (`#000000` black-pill CTA), binary pill radii (all interactive elements → 9999px), zero shadows; the only chromatic exception is the focus ring
- **runwayml** — Pure-black canvas with cool-slate neutrals, single typeface (`abcNormal`), white-as-accent (Runway forbids decorative color), zero shadows, 1600px cinema-wide container, 78px section rhythm
- **minimax** — White-dominant Shanghai lab identity, MiniMax brand blue `#1456f0`, bilingual CJK-aware font stacks (Outfit + DM Sans + PingFang SC), purple brand-glow shadow on featured cards

**Tier B — AI-adjacent devtools**
- **supabase** — Dark canvas with emerald `#3ecf8e` accent (`--accent-on` overridden to near-black for legibility), 4-tier independent foreground ramp, signature `#2e2e2e` solid borders
- **posthog** — Warm parchment `#fdfdf8` + sage cream `#EEEFE9`, brand orange `#F54E00` reserved as "hidden" hover-only color (CTAs render in near-black), one sanctioned shadow per page
- **resend** — Void-black canvas (`--bg: --surface: #000000`), Resend Orange `#ff801f` accent (selected as the canonical from a multi-color system), ABC Favorit + Inter, hover *brightens* (white 10%) per dark-theme convention
- **shadcn** — Calm neutral starter-kit baseline, slate-900 `#111827` body / pure-black `#000000` accent (hover/active mix toward white since pure black can't darken visibly), 8px canonical radius, two-layer ring-2-ring-offset-2 focus pattern
- **raycast** — `#07080a` blue-tinted near-black, Raycast Red `#FF6363` accent for hero/danger only, Raycast Blue `hsla(202,100%,67%,0.35)` reserved as the focus-ring color (preserves brand-red scarcity), macOS double-ring elevation

Each `components.html` embeds the full 56-token `:root` block inline so agents can copy-paste into any `<style>` with zero external dependency, and each ships a working hero / 3-card features / form fixture exercising the brand voice.

## Surface area

- [x] **Extension point** — 10 new brand pairs under `design-systems/`
- [ ] UI / Keyboard / CLI / API / i18n / Dependencies / Default behavior

## Validation

- `pnpm guard` — passes, 27 brand pairs aligned (17 existing + 10 new); A1 (26) / A2 (26) / B-slot (4) declared by every new brand; zero new C-extensions (`BRAND_EXTENSIONS` unchanged)
- `pnpm typecheck` — the only failure is `@open-design/landing-page` (astro check), reproducible on `main` without this branch — unrelated and pre-existing
- Each new pair was independently verified for `:root` byte-equivalence between `tokens.css` and `components.html` via `pnpm exec tsx scripts/check-tokens-fixture-sync.ts`


Made with [Cursor](https://cursor.com)