### PR TITLE
feat(design-systems): add tokens.css + components.html for 10 SaaS / consumer brands

### DIFF
--- a/design-systems/arc/components.html
+++ b/design-systems/arc/components.html
@@ -1,0 +1,432 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Arc — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/arc. Frosted glass over a peach-coral
+        Sunset gradient, squircle-soft radii, editorial Argent CF serif for the hero,
+        Inter for product chrome."
+    />
+
+    <style>
+      :root {
+        --bg: #fdf3ec;
+        --surface: #ffffff;
+        --surface-warm: #fff4ea;
+
+        --fg: #1a1a1f;
+        --fg-2: #54545a;
+        --muted: #8c8c93;
+        --meta: var(--muted);
+
+        --border: #ece5db;
+        --border-soft: #f6f0e8;
+
+        --accent: #ff5f5f;
+        --accent-on: #ffffff;
+        --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+        --success: #48bb78;
+        --warn: #f6ad55;
+        --danger: #f56565;
+
+        --font-display: "Argent CF", "Source Serif Pro", Georgia, serif;
+        --font-body: "Inter", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+        --font-mono: "Berkeley Mono", ui-monospace, Menlo, Consolas, monospace;
+
+        --text-xs: 12px;
+        --text-sm: 13px;
+        --text-base: 15px;
+        --text-lg: 18px;
+        --text-xl: 22px;
+        --text-2xl: 32px;
+        --text-3xl: 40px;
+        --text-4xl: 72px;
+
+        --leading-body: 1.55;
+        --leading-tight: 1.05;
+        --tracking-display: -0.03em;
+
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 96px;
+        --section-y-tablet: 64px;
+        --section-y-phone: 48px;
+
+        --radius-sm: 8px;
+        --radius-md: 12px;
+        --radius-lg: 16px;
+        --radius-pill: 9999px;
+
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised: 0 8px 32px rgba(0, 0, 0, 0.08);
+
+        --focus-ring: 0 0 0 4px color-mix(in oklab, var(--accent), transparent 80%);
+
+        --motion-fast: 200ms;
+        --motion-base: 320ms;
+        --ease-standard: cubic-bezier(0.32, 0.72, 0, 1);
+
+        --container-max: 1200px;
+        --container-gutter-desktop: 32px;
+        --container-gutter-tablet: 24px;
+        --container-gutter-phone: 16px;
+      }
+
+      /* ─── Reset ─────────────────────────────────────────────── */
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        background-image:
+          radial-gradient(circle at 0% 0%, rgba(255, 126, 95, 0.22), transparent 55%),
+          radial-gradient(circle at 100% 5%, rgba(255, 95, 95, 0.16), transparent 50%),
+          radial-gradient(circle at 50% 100%, rgba(254, 180, 123, 0.20), transparent 60%);
+        background-attachment: fixed;
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+
+      /* ─── Layout ─────────────────────────────────────────────── */
+      .container { max-width: var(--container-max); margin-inline: auto; padding-inline: var(--container-gutter-desktop); }
+      section { padding-block: var(--section-y-desktop); }
+      section + section { border-top: 1px solid var(--border-soft); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography — editorial serif hero, sans-only product ─ */
+      h1, h2, h3 { margin: 0; line-height: var(--leading-tight); }
+      h1 {
+        font-family: var(--font-display);   /* Argent CF — marketing only */
+        font-weight: 400;                    /* Editorial serif: weight stays calm */
+        font-size: var(--text-4xl);
+        letter-spacing: var(--tracking-display);
+      }
+      h2 {
+        font-family: var(--font-display);   /* Section titles also Argent CF */
+        font-weight: 400;
+        font-size: var(--text-3xl);
+        letter-spacing: -0.02em;
+      }
+      h3 {
+        font-family: var(--font-body);      /* Inter for in-product hierarchy */
+        font-weight: 600;
+        font-size: var(--text-xl);
+        letter-spacing: -0.01em;
+      }
+      p { margin: 0; }
+      .lead {
+        font-size: var(--text-lg);
+        color: var(--fg-2);
+        line-height: var(--leading-body);
+      }
+      .body-muted { color: var(--muted); }
+      .body-sm { font-size: var(--text-sm); }
+      .body-fg2 { color: var(--fg-2); }
+      .eyebrow {
+        font-family: var(--font-body);
+        font-size: var(--text-xs);
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-weight: 500;
+      }
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+
+      /* ─── Buttons — Sunset gradient on primary, glass on secondary ─ */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 10px 20px;
+        border-radius: var(--radius-md);   /* 12px — squircle-soft */
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        font-weight: 500;
+        line-height: 1;
+        cursor: pointer;
+        border: none;
+        text-decoration: none;
+        transition:
+          box-shadow var(--motion-fast) var(--ease-standard),
+          transform var(--motion-fast) var(--ease-standard),
+          background-color var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn:active { transform: translateY(0); }
+
+      /* Primary: the Sunset gradient — peach (#ff7e5f) to soft coral (#feb47b) */
+      .btn-primary {
+        background: linear-gradient(135deg, #ff7e5f 0%, #feb47b 100%);
+        color: #ffffff;
+        box-shadow: 0 4px 16px rgba(255, 127, 95, 0.30);
+      }
+      .btn-primary:hover {
+        box-shadow: 0 8px 24px rgba(255, 127, 95, 0.40);
+        transform: translateY(-1px);
+      }
+
+      /* Secondary: frosted glass — translucent white over the gradient backdrop */
+      .btn-secondary {
+        background: rgba(255, 255, 255, 0.72);
+        -webkit-backdrop-filter: blur(20px) saturate(180%);
+        backdrop-filter: blur(20px) saturate(180%);
+        color: var(--fg);
+        box-shadow: var(--elev-ring);
+      }
+      .btn-secondary:hover {
+        background: rgba(255, 255, 255, 0.88);
+      }
+
+      /* Subtle: theme-tinted ghost (DESIGN.md §4) */
+      .btn-subtle {
+        background: transparent;
+        color: var(--accent);
+        padding-inline: var(--space-3);
+      }
+      .btn-subtle:hover { background: color-mix(in oklab, var(--accent), transparent 90%); }
+
+      /* ─── Inputs — command-bar feel ──────────────────────────── */
+      .field { display: flex; flex-direction: column; gap: var(--space-2); }
+      .field label { font-size: var(--text-sm); font-weight: 500; color: var(--fg-2); }
+      .field input {
+        padding: 14px 18px;
+        border-radius: var(--radius-md);
+        border: 1px solid var(--border);
+        background: rgba(255, 255, 255, 0.85);
+        -webkit-backdrop-filter: blur(40px);
+        backdrop-filter: blur(40px);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        outline: none;
+        transition:
+          border-color var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .field input:focus-visible {
+        border-color: color-mix(in oklab, var(--accent), white 30%);
+        box-shadow: var(--focus-ring);
+      }
+      .field input::placeholder { color: var(--muted); }
+      .field-help { font-size: var(--text-xs); color: var(--muted); }
+
+      /* ─── Cards — frosted panes, long-throw soft shadow ─────── */
+      .card {
+        background: var(--surface);
+        border: 1px solid var(--border-soft);
+        border-radius: var(--radius-lg);   /* 16px — squircle-soft pane */
+        padding: var(--space-6);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+        box-shadow: var(--elev-raised);
+        transition:
+          transform var(--motion-base) var(--ease-standard),
+          box-shadow var(--motion-base) var(--ease-standard);
+      }
+      .card:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 16px 40px rgba(0, 0, 0, 0.10);
+      }
+
+      /* ─── Pills — theme color at 16% alpha ──────────────────── */
+      .pill {
+        display: inline-flex; align-items: center; gap: var(--space-2);
+        padding: 4px 10px;
+        border-radius: var(--radius-pill);
+        font-size: var(--text-xs);
+        font-weight: 600;
+        line-height: 1.4;
+        background: color-mix(in oklab, var(--accent), transparent 84%);
+        color: var(--accent);
+      }
+      .pill-success {
+        background: color-mix(in oklab, var(--success), transparent 86%);
+        color: var(--success);
+      }
+      .pill-dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
+
+      /* ─── Hero meta panel — warm-inset frosted aside ─────────── */
+      .hero-meta {
+        display: flex; flex-direction: column; gap: var(--space-4);
+        padding: var(--space-6);
+        border: 1px solid var(--border-soft);
+        border-radius: var(--radius-lg);
+        background: rgba(255, 255, 255, 0.70);
+        -webkit-backdrop-filter: blur(24px) saturate(180%);
+        backdrop-filter: blur(24px) saturate(180%);
+        box-shadow: var(--elev-raised);
+      }
+      .hero-meta-row { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); }
+
+      /* ─── Links & kbd ─────────────────────────────────────────── */
+      a { color: var(--accent); text-decoration: none; transition: color var(--motion-fast) var(--ease-standard); }
+      a:hover { color: var(--accent-hover); text-decoration: underline; text-underline-offset: 3px; }
+      kbd {
+        font-family: var(--font-mono); font-size: var(--text-xs);
+        padding: 2px 6px; border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+        background: var(--surface-warm);
+        color: var(--fg-2);
+      }
+
+      /* ─── Layout helpers ────────────────────────────────────── */
+      .hero-grid {
+        display: grid;
+        grid-template-columns: 1.5fr 1fr;
+        gap: var(--space-12);
+        align-items: end;
+      }
+      @media (max-width: 1023px) {
+        .hero-grid { grid-template-columns: 1fr; gap: var(--space-8); align-items: stretch; }
+      }
+      .hero-actions { display: flex; gap: var(--space-3); margin-block-start: var(--space-6); flex-wrap: wrap; }
+      .features-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: var(--space-5);
+      }
+      @media (max-width: 1023px) { .features-grid { grid-template-columns: 1fr 1fr; } }
+      @media (max-width: 639px)  { .features-grid { grid-template-columns: 1fr; } }
+      .form-row { display: grid; grid-template-columns: 1.4fr 1fr; gap: var(--space-12); align-items: start; }
+      @media (max-width: 1023px) { .form-row { grid-template-columns: 1fr; } }
+      .form { display: flex; flex-direction: column; gap: var(--space-4); max-width: 440px; }
+      .form-actions { display: flex; gap: var(--space-3); margin-block-start: var(--space-2); flex-wrap: wrap; }
+      .icon { width: 16px; height: 16px; flex-shrink: 0; }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <section data-od-id="hero">
+        <div class="hero-grid">
+          <div class="stack-4">
+            <p class="eyebrow">Reference fixture · arc</p>
+            <h1>Let the internet flow through you.</h1>
+            <p class="lead" style="max-width: 48ch">
+              A calmer browser for a loud web. Sidebar-first, gradient-warm, frosted at every
+              edge — Arc treats the chrome as scenery, so the page feels like home, not a tab.
+            </p>
+            <div class="hero-actions">
+              <a href="./tokens.css" class="btn btn-primary">
+                Try Arc
+                <svg class="icon" viewBox="0 0 24 24" fill="none"
+                  stroke="currentColor" stroke-width="1.75"
+                  stroke-linecap="round" stroke-linejoin="round"
+                  aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+              </a>
+              <a href="./DESIGN.md" class="btn btn-secondary">Read the brief</a>
+              <a href="#form" class="btn btn-subtle">Reserve an invite →</a>
+            </div>
+          </div>
+          <aside class="hero-meta" aria-label="System status">
+            <div class="hero-meta-row">
+              <span class="body-sm body-fg2">Today's space</span>
+              <span class="pill">
+                <span class="pill-dot" aria-hidden="true"></span>
+                Sunset
+              </span>
+            </div>
+            <div class="hero-meta-row">
+              <span class="body-sm body-fg2">Tabs open</span>
+              <span class="body-sm" style="font-variant-numeric: tabular-nums">37 across 3 spaces</span>
+            </div>
+            <div class="hero-meta-row">
+              <span class="body-sm body-fg2">Status</span>
+              <span class="pill pill-success">
+                <span class="pill-dot" aria-hidden="true"></span>
+                Synced
+              </span>
+            </div>
+            <p class="body-sm body-muted">
+              Press <kbd>⌘</kbd> <kbd>T</kbd> for the command bar — or just start typing where you are.
+            </p>
+          </aside>
+        </div>
+      </section>
+
+      <section data-od-id="features">
+        <div class="stack-3">
+          <p class="eyebrow">What this fixture exercises</p>
+          <h2 style="max-width: 22ch">Warmth, on purpose. Geometry, with kindness.</h2>
+        </div>
+        <div class="features-grid" style="margin-block-start: var(--space-8)">
+          <article class="card">
+            <span class="pill" aria-hidden="true">Atmosphere</span>
+            <h3>Frosted glass over a Sunset gradient</h3>
+            <p class="body-muted body-sm">
+              The canvas is peach cream, never pure white. Cards float as translucent
+              white panes — a single soft shadow does the lifting.
+            </p>
+            <a href="./tokens.css" class="body-sm">Inspect tokens →</a>
+          </article>
+          <article class="card">
+            <span class="pill" aria-hidden="true">Geometry</span>
+            <h3>Squircle-soft, every edge</h3>
+            <p class="body-muted body-sm">
+              8px on tabs, 12px on buttons, 16px on cards, 9999px on space pills.
+              No sharp corners anywhere — the browser gets out of your way.
+            </p>
+            <a href="./DESIGN.md" class="body-sm">Read the rule →</a>
+          </article>
+          <article class="card">
+            <span class="pill" aria-hidden="true">Voice</span>
+            <h3>Editorial when it matters</h3>
+            <p class="body-muted body-sm">
+              Argent CF serif speaks publicly; Inter handles the chrome. A 72px hero
+              with -0.03em tracking is the only place the marketing gets loud.
+            </p>
+            <a href="./tokens.css" class="body-sm">Inspect type →</a>
+          </article>
+        </div>
+      </section>
+
+      <section data-od-id="form" id="form">
+        <div class="form-row">
+          <div class="stack-4">
+            <p class="eyebrow">Form components</p>
+            <h2>Reserve an invite.</h2>
+            <p class="body-muted" style="max-width: 48ch">
+              The command bar treatment — frosted background, 12px squircle, 4px coral
+              halo on focus — extends straight into the form layer. One language, one mood.
+            </p>
+          </div>
+          <form class="form" onsubmit="event.preventDefault();">
+            <div class="field">
+              <label for="email">Where should we send your invite?</label>
+              <input id="email" type="email" placeholder="you@thebrowser.company" autocomplete="email" required />
+              <p class="field-help">We'll only send your invite, not a newsletter — promise.</p>
+            </div>
+            <div class="form-actions">
+              <button type="submit" class="btn btn-primary">Get my invite</button>
+              <button type="button" class="btn btn-secondary">Watch the demo</button>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/arc/tokens.css
+++ b/design-systems/arc/tokens.css
@@ -1,0 +1,137 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/arc/tokens.css
+ *
+ * Structured token bindings for "Design System Inspired by Arc Browser".
+ * Frosted glass over a peach-coral gradient: editorial warmth, squircle-
+ * soft geometry, sidebar-first calm. The browser that browses for you.
+ *
+ * Key brand decisions encoded here:
+ *   - Warm peach-cream canvas (#fdf3ec) — never pure white, always tinted
+ *   - Bright frosted-pane white (#ffffff) as the opaque approximation of
+ *     Arc's translucent rgba(255,255,255,0.7) glass surfaces
+ *   - Arc Coral (#ff5f5f) is the named brand color; the Sunset gradient
+ *     (peach → coral) is composed inline by primary CTAs in components,
+ *     so --accent stays a single resolvable value
+ *   - Squircle-soft 8 / 12 / 16 px radii — every edge softened, never sharp
+ *   - Editorial Argent CF serif for marketing display, Inter for product
+ *   - Apple-style spring easing (0.32, 0.72, 0, 1) at 200/320 ms
+ *   - Single long-throw shadow (0 8px 32px rgba(0,0,0,0.08)) — no harsh
+ *     elevation; depth comes from the gradient backdrop, not box edges
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface ─────────────────────────────────────────────────────
+   * Peach-cream canvas. Cards float above as bright white frosted
+   * panes; the warm tier holds hero meta panels and sidebar washes. */
+  --bg: #fdf3ec;             /* Peach Cream — the calm canvas, barely warm */
+  --surface: #ffffff;        /* Frosted Pane — opaque approximation of glass */
+  --surface-warm: #fff4ea;   /* Warm Inset — hero meta, sidebar pill background */
+
+  /* ─── Foreground ──────────────────────────────────────────────────
+   * Three ink tiers from DESIGN.md §2 — never pure black, always
+   * slightly warm so type sits inside the peach atmosphere. */
+  --fg: #1a1a1f;             /* Ink Primary — body text, headings */
+  --fg-2: #54545a;           /* Ink Secondary — sidebar tabs at rest, sub-headings */
+  --muted: #8c8c93;          /* Ink Muted — captions, URL bar, metadata */
+  --meta: var(--muted);      /* alias — same muted tier suffices for metadata */
+
+  /* ─── Border ──────────────────────────────────────────────────────
+   * Borders are rare in Arc — DESIGN.md prefers tinted background
+   * washes. When present, they're hairline-thin and warm-toned. */
+  --border: #ece5db;         /* Warm hairline — card edge over peach cream */
+  --border-soft: #f6f0e8;    /* Softer inner separator — barely visible row line */
+
+  /* ─── Accent ──────────────────────────────────────────────────────
+   * Arc Coral — the marketing brand color used on arc.net. Components
+   * compose the Sunset gradient (peach #ff7e5f → coral #feb47b) inline
+   * for primary CTAs; --accent itself stays a single resolvable color
+   * so color-mix derivations work everywhere. */
+  --accent: #ff5f5f;
+  --accent-on: #ffffff;
+  --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+  /* ─── Semantic ────────────────────────────────────────────────────
+   * DESIGN.md §2 semantic palette — mid-saturated to harmonize with
+   * the warm atmosphere, not clinical Tailwind reds. */
+  --success: #48bb78;
+  --warn: #f6ad55;
+  --danger: #f56565;
+
+  /* ─── Typography ──────────────────────────────────────────────────
+   * Inter for product chrome; Argent CF (editorial display serif)
+   * only for marketing — when Arc speaks publicly, it speaks in serif.
+   * Berkeley Mono for code, URL bar, devtools. */
+  --font-display: "Argent CF", "Source Serif Pro", Georgia, serif;
+  --font-body: "Inter", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-mono: "Berkeley Mono", ui-monospace, Menlo, Consolas, monospace;
+
+  /* Type scale — DESIGN.md §3. 72px hero, 40px section, 32px h1,
+   * 22px h2, 18px featured body, 15px body, 13px tab/code, 12px caption.
+   * Tabs render small (13px) so a long sidebar of 30+ tabs stays scannable. */
+  --text-xs: 12px;           /* Caption — URL bar protocol, metadata */
+  --text-sm: 13px;           /* Tab Title / Code */
+  --text-base: 15px;         /* Body — settings prose, tooltips */
+  --text-lg: 18px;           /* Featured body — intro paragraphs */
+  --text-xl: 22px;           /* Page H2 — sub-section */
+  --text-2xl: 32px;          /* Page H1 — settings, command bar header */
+  --text-3xl: 40px;          /* Section Heading — Argent CF marketing */
+  --text-4xl: 72px;          /* Marketing Hero — Argent CF editorial display */
+
+  --leading-body: 1.55;      /* Generous body line-height — long-form reading */
+  --leading-tight: 1.05;     /* Hero line-height — Argent CF squeezed tight */
+  --tracking-display: -0.03em; /* ≈ -2.16px at 72px — editorial density */
+
+  /* ─── Spacing ─────────────────────────────────────────────────────
+   * 4px base. Pane internal padding lands on space-6 (24px) per
+   * DESIGN.md §5. */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+
+  /* Section rhythm — generous editorial pacing on marketing pages. */
+  --section-y-desktop: 96px;
+  --section-y-tablet: 64px;
+  --section-y-phone: 48px;
+
+  /* ─── Radius ──────────────────────────────────────────────────────
+   * Squircle-soft: 8px on tabs/chips, 12px on buttons & command bar,
+   * 16px on cards/panes, 9999px on space pills. Every edge softened. */
+  --radius-sm: 8px;          /* Tabs / chips */
+  --radius-md: 12px;         /* Buttons / command bar input */
+  --radius-lg: 16px;         /* Cards / panes */
+  --radius-pill: 9999px;     /* Spaces, bookmarks folder pills */
+
+  /* ─── Elevation ───────────────────────────────────────────────────
+   * Single long-throw soft shadow — DESIGN.md §1 calls out this exact
+   * value as the signature card lift over the gradient backdrop. */
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised: 0 8px 32px rgba(0, 0, 0, 0.08);
+
+  /* ─── Focus ring ──────────────────────────────────────────────────
+   * 4px coral halo at 20% alpha — DESIGN.md §4 specifies this exact
+   * focus treatment for the command bar input. Wider and softer than
+   * the schema default, in keeping with Arc's frosted-glass language. */
+  --focus-ring: 0 0 0 4px color-mix(in oklab, var(--accent), transparent 80%);
+
+  /* ─── Motion ──────────────────────────────────────────────────────
+   * Apple-style spring curve from DESIGN.md §6. 200ms for hover,
+   * 320ms for tab create/close — Arc's motion is spring, not bounce. */
+  --motion-fast: 200ms;
+  --motion-base: 320ms;
+  --ease-standard: cubic-bezier(0.32, 0.72, 0, 1);
+
+  /* ─── Layout ──────────────────────────────────────────────────────
+   * 1200px max — wide enough for sidebar + content but never enterprise-
+   * dense. Generous gutters echo the 24px pane padding. */
+  --container-max: 1200px;
+  --container-gutter-desktop: 32px;
+  --container-gutter-tablet: 24px;
+  --container-gutter-phone: 16px;
+}

--- a/design-systems/cal/components.html
+++ b/design-systems/cal/components.html
@@ -1,0 +1,376 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Cal — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/cal. Pure-white canvas, charcoal
+        (#242424) text, link-blue reserved for hyperlinks, and a multi-layer
+        ring-shadow stack that replaces CSS borders."
+    />
+
+    <style>
+      :root {
+        --bg: #ffffff;
+        --surface: #ffffff;
+        --surface-warm: var(--surface);
+
+        --fg: #242424;
+        --fg-2: #111111;
+        --muted: #898989;
+        --meta: var(--muted);
+
+        --border: rgba(34, 42, 53, 0.08);
+        --border-soft: rgba(34, 42, 53, 0.05);
+
+        --accent: #0099ff;
+        --accent-on: #ffffff;
+        --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+        --success: #16a34a;
+        --warn: #eab308;
+        --danger: #dc2626;
+
+        --font-display: "Cal Sans", "Inter", -apple-system, "Segoe UI", Arial, sans-serif;
+        --font-body: "Inter", -apple-system, "Segoe UI", Arial, sans-serif;
+        --font-mono: "Roboto Mono", ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Monaco, Consolas, monospace;
+
+        --text-xs: 12px;
+        --text-sm: 14px;
+        --text-base: 16px;
+        --text-lg: 20px;
+        --text-xl: 24px;
+        --text-2xl: 32px;
+        --text-3xl: 48px;
+        --text-4xl: 64px;
+
+        --leading-body: 1.5;
+        --leading-tight: 1.1;
+        --tracking-display: 0;
+
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 96px;
+        --section-y-tablet: 64px;
+        --section-y-phone: 48px;
+
+        --radius-sm: 8px;
+        --radius-md: 12px;
+        --radius-lg: 16px;
+        --radius-pill: 9999px;
+
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised:
+          0 1px 5px -4px rgba(19, 19, 22, 0.7),
+          0 0 0 1px rgba(34, 42, 53, 0.08),
+          0 4px 8px rgba(34, 42, 53, 0.05);
+
+        --focus-ring: 0 0 0 3px color-mix(in oklab, var(--accent), transparent 70%);
+
+        --motion-fast: 150ms;
+        --motion-base: 200ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+        --container-max: 1200px;
+        --container-gutter-desktop: 24px;
+        --container-gutter-tablet: 16px;
+        --container-gutter-phone: 12px;
+      }
+
+      /* ─── Reset ─────────────────────────────────────────────── */
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+
+      /* ─── Layout ─────────────────────────────────────────────── */
+      .container { max-width: var(--container-max); margin-inline: auto; padding-inline: var(--container-gutter-desktop); }
+      section { padding-block: var(--section-y-desktop); }
+      section + section { border-top: 1px solid var(--border); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography — Cal Sans for display, Inter for body ─── */
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        font-weight: 600;              /* Cal Sans is designed for weight 600 */
+        line-height: var(--leading-tight);
+        letter-spacing: var(--tracking-display);
+        color: var(--fg);
+        margin: 0;
+      }
+      h1 { font-size: var(--text-4xl); }
+      h2 { font-size: var(--text-3xl); }
+      h3 { font-size: var(--text-xl); line-height: 1.3; }
+      p { margin: 0; }
+      .lead {
+        font-family: var(--font-body);
+        font-size: var(--text-lg);
+        color: var(--muted);
+        line-height: var(--leading-body);
+        font-weight: 400;
+      }
+      .body-muted { color: var(--muted); }
+      .body-sm { font-size: var(--text-sm); }
+      .eyebrow {
+        font-family: var(--font-body);
+        font-size: var(--text-xs);
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 500;
+      }
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+
+      /* ─── Buttons — charcoal-on-white primary, ghost secondary ─ */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 10px 16px;
+        border-radius: var(--radius-sm);
+        font-family: var(--font-body);
+        font-size: var(--text-sm);
+        font-weight: 500;
+        line-height: 1;
+        cursor: pointer;
+        border: none;
+        transition: background-color var(--motion-fast) var(--ease-standard),
+                    box-shadow var(--motion-fast) var(--ease-standard),
+                    opacity var(--motion-fast) var(--ease-standard);
+        text-decoration: none;
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      /* Primary: charcoal (#242424) on white — Cal.com's signature CTA */
+      .btn-primary {
+        background: var(--fg);
+        color: #ffffff;
+      }
+      .btn-primary:hover { opacity: 0.85; }
+      .btn-primary:active { opacity: 0.75; }
+      /* Secondary: white with ring-shadow border — uses the elevation system */
+      .btn-secondary {
+        background: var(--surface);
+        color: var(--fg);
+        box-shadow: var(--elev-ring);
+      }
+      .btn-secondary:hover {
+        box-shadow:
+          0 0 0 1px rgba(34, 42, 53, 0.12),
+          0 1px 2px rgba(34, 42, 53, 0.04);
+      }
+
+      /* ─── Inputs — minimal, ring-on-focus ─────────────────────── */
+      .field { display: flex; flex-direction: column; gap: var(--space-2); }
+      .field label {
+        font-size: var(--text-sm);
+        font-weight: 500;
+        color: var(--fg-2);
+      }
+      .field input {
+        padding: 10px 12px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-sm);
+        outline: none;
+        transition: border-color var(--motion-fast) var(--ease-standard),
+                    box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .field input:focus-visible {
+        border-color: var(--accent);
+        box-shadow: var(--focus-ring);
+      }
+      .field input::placeholder { color: var(--muted); }
+      .field-help { font-size: var(--text-xs); color: var(--muted); }
+
+      /* ─── Cards — white surface, multi-layer ring-shadow stack ─ */
+      .card {
+        background: var(--surface);
+        border-radius: var(--radius-md);
+        padding: var(--space-6);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+        box-shadow: var(--elev-raised);  /* Cal.com's workhorse card shadow */
+        transition: box-shadow var(--motion-base) var(--ease-standard);
+      }
+      .card:hover {
+        box-shadow:
+          0 2px 8px -4px rgba(19, 19, 22, 0.7),
+          0 0 0 1px rgba(34, 42, 53, 0.1),
+          0 8px 16px rgba(34, 42, 53, 0.06);
+      }
+
+      /* ─── Badges ────────────────────────────────────────────── */
+      .badge {
+        display: inline-flex; align-items: center; gap: var(--space-2);
+        padding: 3px var(--space-2);
+        border-radius: var(--radius-pill);
+        font-family: var(--font-body);
+        font-size: var(--text-xs); font-weight: 500; line-height: 1.6;
+      }
+      .badge-success { color: var(--success); background: color-mix(in oklab, var(--success), transparent 90%); }
+      .badge-muted { color: var(--muted); background: color-mix(in oklab, var(--muted), transparent 92%); }
+      .badge-dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
+
+      /* ─── Links — the only blue in the system ───────────────── */
+      a { color: var(--accent); text-decoration: underline; text-underline-offset: 3px; }
+      a:hover { color: var(--accent-hover); }
+      a.card-link { text-decoration: none; color: var(--fg-2); font-weight: 500; }
+      a.card-link:hover { color: var(--accent); }
+      kbd {
+        font-family: var(--font-mono); font-size: var(--text-xs);
+        padding: 2px 6px; border-radius: var(--radius-sm);
+        background: var(--surface); color: var(--muted);
+        box-shadow: var(--elev-ring);
+      }
+
+      /* ─── Layout helpers ────────────────────────────────────── */
+      .hero-grid { display: grid; grid-template-columns: 1.4fr 1fr; gap: var(--space-12); align-items: end; }
+      @media (max-width: 1023px) { .hero-grid { grid-template-columns: 1fr; gap: var(--space-8); } }
+      .hero-actions { display: flex; gap: var(--space-3); margin-block-start: var(--space-6); flex-wrap: wrap; }
+      .hero-meta {
+        display: flex; flex-direction: column; gap: var(--space-3);
+        padding: var(--space-4);
+        border-radius: var(--radius-md);
+        background: var(--surface);
+        box-shadow: var(--elev-raised);
+      }
+      .features-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--space-5); }
+      @media (max-width: 1023px) { .features-grid { grid-template-columns: 1fr 1fr; } }
+      @media (max-width: 639px) { .features-grid { grid-template-columns: 1fr; } }
+      .form-row { display: grid; grid-template-columns: 1.4fr 1fr; gap: var(--space-12); align-items: start; }
+      @media (max-width: 1023px) { .form-row { grid-template-columns: 1fr; } }
+      .form { display: flex; flex-direction: column; gap: var(--space-4); max-width: 420px; }
+      .form-actions { display: flex; gap: var(--space-3); margin-block-start: var(--space-2); }
+      .icon { width: 16px; height: 16px; flex-shrink: 0; }
+      .row-between { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <section data-od-id="hero">
+        <div class="hero-grid">
+          <div class="stack-4">
+            <p class="eyebrow">Reference fixture · cal</p>
+            <h1>Scheduling infrastructure for everyone.</h1>
+            <p class="lead" style="max-width: 52ch">
+              Open-source meetings, calendars, and booking links that just work —
+              for individuals, teams, and the developers building the next wave
+              of scheduling on top of an API they can read.
+            </p>
+            <div class="hero-actions">
+              <a href="./tokens.css" class="btn btn-primary" style="text-decoration: none">
+                View tokens
+                <svg class="icon" viewBox="0 0 24 24" fill="none"
+                  stroke="currentColor" stroke-width="1.75"
+                  stroke-linecap="round" stroke-linejoin="round"
+                  aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+              </a>
+              <a href="./DESIGN.md" class="btn btn-secondary" style="text-decoration: none">Read the spec</a>
+            </div>
+          </div>
+          <aside class="hero-meta" aria-label="Booking status">
+            <div class="row-between">
+              <span class="body-sm" style="color: var(--fg-2)">Booking API</span>
+              <span class="badge badge-success">
+                <span class="badge-dot" aria-hidden="true"></span>
+                Operational
+              </span>
+            </div>
+            <p class="body-sm" style="color: var(--muted)">Last reviewed <time datetime="2026-05-15">2026-05-15</time> · v1.0</p>
+            <p class="body-sm" style="color: var(--muted)">Press <kbd>⌘</kbd> <kbd>K</kbd> to search availability.</p>
+          </aside>
+        </div>
+      </section>
+
+      <section data-od-id="features">
+        <div class="stack-3">
+          <p class="eyebrow">What this fixture exercises</p>
+          <h2 style="max-width: 22ch">A calendar that gets out of the way.</h2>
+        </div>
+        <div class="features-grid" style="margin-block-start: var(--space-8)">
+          <article class="card">
+            <h3>Monochrome by design</h3>
+            <p class="body-muted body-sm">
+              Pure white canvas, charcoal (#242424) text, and a single
+              link-blue. Boldness comes from contrast, not from color.
+            </p>
+            <a href="./tokens.css" class="body-sm card-link">Inspect tokens →</a>
+          </article>
+          <article class="card">
+            <h3>Cal Sans speaks. Inter explains.</h3>
+            <p class="body-muted body-sm">
+              A custom geometric display face for headings, Inter for body.
+              The font pairing enforces a clear typographic division —
+              Cal Sans is never used below 16px.
+            </p>
+            <a href="./DESIGN.md" class="body-sm card-link">Read the pairing →</a>
+          </article>
+          <article class="card">
+            <h3>Shadows do the bordering</h3>
+            <p class="body-muted body-sm">
+              A multi-layer ring + contact + ambient shadow stack replaces
+              CSS borders. Surfaces feel like physical cards sitting on a
+              table — never floating, never flat.
+            </p>
+            <a href="./tokens.css" class="body-sm card-link">Inspect elevation →</a>
+          </article>
+        </div>
+      </section>
+
+      <section data-od-id="form">
+        <div class="form-row">
+          <div class="stack-4">
+            <p class="eyebrow">Form components</p>
+            <h2>Get scheduling at the speed of Cal.</h2>
+            <p class="body-muted" style="max-width: 48ch">
+              Inputs are minimal: hairline border, charcoal text, and the
+              one link-blue makes its second appearance only on the focus
+              ring — exactly where it earns its keep.
+            </p>
+          </div>
+          <form class="form" onsubmit="event.preventDefault();">
+            <div class="field">
+              <label for="email">Work email</label>
+              <input id="email" type="email" placeholder="you@company.com" autocomplete="email" required />
+              <p class="field-help">We'll send your booking link and nothing else.</p>
+            </div>
+            <div class="form-actions">
+              <button type="submit" class="btn btn-primary">Create my link</button>
+              <button type="button" class="btn btn-secondary">See a demo</button>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/cal/tokens.css
+++ b/design-systems/cal/tokens.css
@@ -1,0 +1,265 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/cal/tokens.css
+ *
+ * Structured token bindings for "Design System Inspired by Cal.com" —
+ * open-source scheduling infrastructure rendered as a grayscale photograph.
+ * Pure-white canvas, near-black charcoal text, one reserved link-blue, and
+ * a multi-layer shadow stack that replaces CSS borders with ring-shadows.
+ *
+ * This file pre-compiles the values described in `DESIGN.md` into the
+ * shared schema. Agents generating an artifact for cal should paste the
+ * `:root` block verbatim into the first `<style>` of the artifact, then
+ * reference everything via `var(--*)`.
+ *
+ * Brand-specific schema decisions (each bends a schema convention to
+ * match Cal.com's voice rather than the cross-brand default):
+ *
+ *   1. `--fg` is `#242424` (Charcoal), NOT `#000000`. DESIGN.md §2 names
+ *      it the "signature near-black, warmer than pure black" — the
+ *      micro-warmth is what keeps the canvas from feeling harsh, the
+ *      same role `#171717` plays for Vercel. `--fg-2` independently
+ *      binds to `#111111` (Midnight) because Cal uses it for highest-
+ *      contrast nav links and deep emphasis; `--muted` lands on
+ *      `#898989` (Mid Gray) for descriptions, the third documented
+ *      tier in the grayscale palette.
+ *
+ *   2. `--accent` is `#0099ff` (Link Blue), the ONLY non-grayscale
+ *      value in the brand. DESIGN.md §2 calls it "the only blue in
+ *      the system, reserved strictly for hyperlinks" — color is a
+ *      "foreign substance" deliberately quarantined to text links and
+ *      focus rings. Primary CTAs use `--fg` (Charcoal) as the button
+ *      background, mirroring Cal.com's signature dark-on-white button.
+ *      Keeping the link-blue in `--accent` (not promoting Charcoal to
+ *      double-duty) preserves the lint's "≤2 accent uses per screen"
+ *      semantic and matches where blue actually appears in product.
+ *
+ *   3. `--border` is `rgba(34, 42, 53, 0.08)` — the literal Cal.com
+ *      ring-shadow alpha, NOT a solid hex. DESIGN.md §1 + §6 calls
+ *      out the shadow-as-border technique: surfaces use `0 0 0 1px`
+ *      ring shadows instead of CSS borders, "avoiding CSS border
+ *      entirely". Binding `--border` to the same alpha lets
+ *      `--elev-ring` reproduce the Cal hairline by default, and lets
+ *      `border: 1px solid var(--border)` match exactly when a true
+ *      border is structurally needed. `--border-soft` drops to 0.05
+ *      alpha (the same value used in the diffused-shadow layer of
+ *      the card stack) for inner separators that shouldn't compete.
+ *
+ *   4. `--surface-warm` aliases to `--surface` and `--meta` aliases to
+ *      `--muted`. Cal.com is intentionally monochrome — there is no
+ *      warm surface tier and no fourth gray below `--muted`. Following
+ *      the schema, an unused tier collapses via `var()` instead of
+ *      introducing a fabricated value.
+ *
+ *   5. `--elev-raised` is the full multi-layer Cal card stack
+ *      (`0 1px 5px -4px rgba(19,19,22,0.7), 0 0 0 1px rgba(34,42,53,0.08),
+ *      0 4px 8px rgba(34,42,53,0.05)`), reproduced VERBATIM from
+ *      DESIGN.md §6 Level 2. The composition is the workhorse: a sharp
+ *      contact shadow at the bottom edge (the `-4px` spread lifts the
+ *      blur off the top), a ring-shadow that paints the hairline edge,
+ *      and a soft diffused ambient at 5% alpha. Drop any layer and
+ *      the card stops looking "built" — it floats.
+ *
+ *   6. The type scale tops out at 64px (`--text-4xl`) per DESIGN.md §3
+ *      "Display Hero: Cal Sans 64px / 600 / 1.10". `--leading-tight`
+ *      is 1.1 to match. `--tracking-display` is `0` (not negative)
+ *      because Cal Sans was DESIGNED with extremely tight default
+ *      letter-spacing at large sizes — DESIGN.md §3 lists letter-
+ *      spacing 0px at 64/48/24 and warns that adding negative tracking
+ *      at small sizes cramps the font. Positive tracking compensation
+ *      for sub-24px Cal Sans usage stays a component-local concern.
+ *
+ *   7. `--font-display` leads with `Cal Sans` (the custom geometric
+ *      display face by Mark Davis, open-source via Google Fonts),
+ *      falling back to Inter so artifacts render legibly when Cal
+ *      Sans is not loaded. `--font-body` is Inter ("rock-solid"
+ *      body face per DESIGN.md §3). `--font-mono` leads with
+ *      Roboto Mono per the documented code-block font.
+ *
+ *   8. Section rhythm is generous: `96px` desktop, `64px` tablet,
+ *      `48px` phone (`--section-y-*`). DESIGN.md §5 demands "80px–96px
+ *      vertical between major sections (generous)" and DESIGN.md §7
+ *      forbids dropping below 48px on any breakpoint — "the generous
+ *      whitespace is core to the premium monochrome aesthetic".
+ *      Container caps at `1200px` (the documented max content width).
+ *
+ * Source contracts:
+ *   - Standard token names: design-systems/_schema/tokens.schema.ts
+ *   - A2 fallback parity:   design-systems/_schema/defaults.css
+ *   - Lint enforcement:     apps/daemon/src/lint-artifact.ts
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface ─────────────────────────────────────────────────────
+   * Cal.com's canvas is achromatic and uniform — pure white page, pure
+   * white cards, no warm tier anywhere. `--surface-warm` aliases to
+   * `--surface` because the brand explicitly forbids background tinting
+   * (DESIGN.md §2: "boldness through monochrome"); depth comes from the
+   * multi-layer shadow stack, not from surface-color variation. */
+  --bg: #ffffff;                  /* Pure White — the dominant canvas */
+  --surface: #ffffff;              /* White card surface — depth via shadow, not color */
+  --surface-warm: var(--surface);  /* alias — Cal.com has no warm tier */
+
+  /* ─── Foreground ──────────────────────────────────────────────────
+   * Three grayscale tiers from DESIGN.md §2 palette: Charcoal (#242424,
+   * the warmer-than-black signature), Midnight (#111111, deepest text
+   * for nav and high-contrast emphasis), and Mid Gray (#898989, the
+   * documented secondary / muted tier). `--meta` collapses to `--muted`
+   * because Cal has no fourth tier — there is no tertiary gray below
+   * Mid Gray in the brand spec. */
+  --fg: #242424;                   /* Charcoal — primary text, button bg, signature near-black */
+  --fg-2: #111111;                 /* Midnight — deepest text, nav, high-contrast emphasis */
+  --muted: #898989;                /* Mid Gray — descriptions, secondary labels, muted content */
+  --meta: var(--muted);            /* alias — Cal has only three grayscale tiers */
+
+  /* ─── Border ──────────────────────────────────────────────────────
+   * Shadow-as-border is THE signature: `rgba(34, 42, 53, 0.08)` at 1px
+   * spread replaces CSS borders throughout (DESIGN.md §1 + §6). Binding
+   * `--border` to the alpha (not a solid hex) lets `--elev-ring`
+   * reproduce the Cal hairline by default, and lets `border: 1px solid
+   * var(--border)` paint the same value when a real border is
+   * structurally required. `--border-soft` drops to 0.05 (the diffused-
+   * shadow layer alpha) for inner row separators that must not compete
+   * with the card edge. */
+  --border: rgba(34, 42, 53, 0.08);       /* signature ring-shadow alpha — used as border */
+  --border-soft: rgba(34, 42, 53, 0.05);  /* inner separator — quieter than the card edge */
+
+  /* ─── Accent ──────────────────────────────────────────────────────
+   * Link Blue (#0099ff) — the ONLY chromatic color in the entire
+   * system. DESIGN.md §2: "reserved strictly for hyperlinks". Cal's
+   * marketing site treats color as "a foreign substance"; primary CTAs
+   * use `--fg` (Charcoal) as the button background, not `--accent`,
+   * which keeps the blue exclusively where it appears in product:
+   * inline text links and the focus-ring tint. */
+  --accent: #0099ff;               /* Link Blue — only non-grayscale color, link-only */
+  --accent-on: #ffffff;            /* white label on the rare blue surface */
+  --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+  /* ─── Semantic ────────────────────────────────────────────────────
+   * Cal.com's marketing surface rarely renders state. We inherit the
+   * schema defaults (no grayscale-shift) — the product UI does show
+   * greens and blues in scheduling screenshots, but per DESIGN.md §2
+   * those colors belong to the product image, not the marketing frame. */
+  --success: #16a34a;
+  --warn: #eab308;
+  --danger: #dc2626;
+
+  /* ─── Typography ──────────────────────────────────────────────────
+   * Cal Sans + Inter — the documented two-face pairing (DESIGN.md §3).
+   * Cal Sans is exclusively for headings (24px+) with extremely tight
+   * default letter-spacing; Inter is "rock-solid" body. The font stacks
+   * fall through to system-installed faces so artifacts render legibly
+   * even when Cal Sans / Inter are not loaded. */
+  --font-display: "Cal Sans", "Inter", -apple-system, "Segoe UI", Arial, sans-serif;
+  --font-body: "Inter", -apple-system, "Segoe UI", Arial, sans-serif;
+  --font-mono: "Roboto Mono", ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Monaco, Consolas, monospace;
+
+  /* Type scale (px) — derived from DESIGN.md §3 hierarchy table. The
+   * scale tops out at 64px (display hero, Cal Sans 600 / 1.10) and
+   * keeps the documented 48 / 24 / 20 / 16 / 14 / 12 anchors. The
+   * `--text-2xl` step at 32px bridges the 24→48 gap so cross-brand
+   * components reading `--text-2xl` get a sensible section-title size
+   * even though DESIGN.md does not list 32px explicitly. */
+  --text-xs: 12px;                 /* caption / micro / Cal Sans label */
+  --text-sm: 14px;                 /* caption / nav micro / Roboto Mono code */
+  --text-base: 16px;               /* body / UI label / card title */
+  --text-lg: 20px;                 /* sub-heading (Cal Sans 600 / 1.20 / +0.2px) */
+  --text-xl: 24px;                 /* feature heading (Cal Sans 600 / 1.30) */
+  --text-2xl: 32px;                /* bridge tier (24→48) for cross-brand consumers */
+  --text-3xl: 48px;                /* section heading (Cal Sans 600 / 1.10) */
+  --text-4xl: 64px;                /* display hero (Cal Sans 600 / 1.10) */
+
+  /* `--leading-tight` is 1.1 to match DESIGN.md's "Cal Sans display
+   * 1.10" and "Section Heading 1.10" rows. `--leading-body` is 1.5,
+   * the documented Inter body-text leading. `--tracking-display` is
+   * `0` — Cal Sans is DESIGNED with extremely tight default letter-
+   * spacing at large sizes, and DESIGN.md §3 lists tracking 0px at
+   * 64 / 48 / 24px. Negative tracking at display would over-cramp it. */
+  --leading-body: 1.5;
+  --leading-tight: 1.1;
+  --tracking-display: 0;
+
+  /* ─── Spacing ─────────────────────────────────────────────────────
+   * 4px-grid base scale matching the schema defaults. Cal.com's DESIGN
+   * §5 spacing scale (1/2/3/4/6/8/12/16/20/24/28 sub-tiers) covers many
+   * micro-padding values that are too fine for the shared schema; those
+   * stay component-local. The 4/8/12/16/20/24/32/48 tier here covers
+   * the structural rhythm — the deliberate jump from 28px to 80px in
+   * DESIGN.md is preserved by the `--section-y-*` tier below. */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+
+  /* Section rhythm — DESIGN.md §5: "80px–96px vertical between major
+   * sections (generous)" + §7 forbids dropping below 48px on mobile.
+   * We anchor at the upper end (96px desktop), step down to 64px on
+   * tablet, and bottom out at the 48px mobile floor. The whitespace
+   * is the design — DESIGN.md §5 calls it "lavish section spacing". */
+  --section-y-desktop: 96px;
+  --section-y-tablet: 64px;
+  --section-y-phone: 48px;
+
+  /* ─── Radius ──────────────────────────────────────────────────────
+   * DESIGN.md §5 documents an unusually wide radius scale (2/4/6/8/12/
+   * 16/29/100/1000/9999). We bind the four schema tiers to: 8 (the
+   * "standard interactive element" radius for buttons / inputs /
+   * images), 12 (medium containers), 16 (large section containers),
+   * 9999 (pill for badges and rounded actions). The intermediate
+   * 29px / 100px tiers are component-specific and stay inline. */
+  --radius-sm: 8px;                /* buttons, inputs, standard interactive */
+  --radius-md: 12px;               /* cards, medium containers */
+  --radius-lg: 16px;               /* large section containers */
+  --radius-pill: 9999px;           /* pill badges, fully rounded actions */
+
+  /* ─── Elevation ───────────────────────────────────────────────────
+   * Cal.com's depth system is shadow-LED via multi-layer compositing
+   * (DESIGN.md §6: "11 shadow definitions"). Three sanctioned levels:
+   *
+   *   --elev-flat    no shadow (page canvas, basic text containers)
+   *   --elev-ring    the signature 1px ring-as-border (most surfaces)
+   *   --elev-raised  the workhorse card stack (Level 2 in DESIGN.md §6)
+   *
+   * `--elev-raised` is reproduced VERBATIM from DESIGN.md §6 Level 2:
+   *   contact: 0 1px 5px -4px rgba(19,19,22,0.7)   — sharp bottom edge
+   *   ring:    0 0 0 1px rgba(34,42,53,0.08)        — hairline border
+   *   ambient: 0 4px 8px rgba(34,42,53,0.05)        — soft diffused depth
+   * Drop any layer and the card loses the "physical card on a table"
+   * quality that DESIGN.md §6 calls out as the system's signature. */
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised:
+    0 1px 5px -4px rgba(19, 19, 22, 0.7),
+    0 0 0 1px rgba(34, 42, 53, 0.08),
+    0 4px 8px rgba(34, 42, 53, 0.05);
+
+  /* ─── Focus ring ──────────────────────────────────────────────────
+   * The schema default (a soft alpha glow at `--accent`) reproduces
+   * Cal.com's focus aesthetic well — DESIGN.md §2 names the focus
+   * indicator as "Focus Ring: #3b82f6 at 50% opacity", and our Link
+   * Blue accent tinted to ~30% alpha sits in the same family without
+   * introducing a brand-foreign hue. */
+  --focus-ring: 0 0 0 3px color-mix(in oklab, var(--accent), transparent 70%);
+
+  /* ─── Motion ──────────────────────────────────────────────────────
+   * Two durations + one easing curve. Cal.com's transitions are quick
+   * and unobtrusive — DESIGN.md §4 describes hover as a simple opacity
+   * reduction, never a long-form choreographed entrance. */
+  --motion-fast: 150ms;
+  --motion-base: 200ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+  /* ─── Layout ──────────────────────────────────────────────────────
+   * 1200px max content width per DESIGN.md §5: "~1200px content
+   * container, centered". Gutters narrow on mobile so body copy stays
+   * comfortable on small screens — Cal.com does not edge-bleed text
+   * at any breakpoint. */
+  --container-max: 1200px;
+  --container-gutter-desktop: 24px;
+  --container-gutter-tablet: 16px;
+  --container-gutter-phone: 12px;
+}

--- a/design-systems/canva/components.html
+++ b/design-systems/canva/components.html
@@ -1,0 +1,461 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Canva — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/canva. White canvas, vivid
+        purple→cyan gradient on hero CTAs, 12px card radii, soft cool shadows."
+    />
+
+    <style>
+      :root {
+        --bg: #ffffff;
+        --surface: #f4f5f7;
+        --surface-warm: var(--surface);
+
+        --fg: #0e1318;
+        --fg-2: #3c4043;
+        --muted: #5f6368;
+        --meta: #9aa0a6;
+
+        --border: #e1e3e6;
+        --border-soft: var(--border);
+
+        --accent: #7d2ae8;
+        --accent-on: #ffffff;
+        --accent-hover: #6815d4;
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+        --success: #00b894;
+        --warn: #ffb020;
+        --danger: #ff5757;
+
+        --font-display: "Canva Sans", "YS Text", system-ui, -apple-system, sans-serif;
+        --font-body: "Canva Sans", "YS Text", system-ui, -apple-system, sans-serif;
+        --font-mono: "JetBrains Mono", ui-monospace, Menlo, Consolas, monospace;
+
+        --text-xs: 11px;
+        --text-sm: 12px;
+        --text-base: 14px;
+        --text-lg: 16px;
+        --text-xl: 18px;
+        --text-2xl: 24px;
+        --text-3xl: 36px;
+        --text-4xl: 64px;
+
+        --leading-body: 1.5;
+        --leading-tight: 1.15;
+        --tracking-display: -0.02em;
+
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 96px;
+        --section-y-tablet: 64px;
+        --section-y-phone: 48px;
+
+        --radius-sm: 8px;
+        --radius-md: 12px;
+        --radius-lg: 16px;
+        --radius-pill: 9999px;
+
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised: 0 2px 8px rgba(0, 0, 0, 0.06);
+
+        --focus-ring: 0 0 0 3px rgba(125, 42, 232, 0.16);
+
+        --motion-fast: 180ms;
+        --motion-base: 280ms;
+        --ease-standard: cubic-bezier(0.4, 0, 0.2, 1);
+
+        --container-max: 1320px;
+        --container-gutter-desktop: 32px;
+        --container-gutter-tablet: 24px;
+        --container-gutter-phone: 16px;
+      }
+
+      /* ─── Reset ─────────────────────────────────────────────── */
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg-2);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+
+      /* ─── Layout ─────────────────────────────────────────────── */
+      .container { max-width: var(--container-max); margin-inline: auto; padding-inline: var(--container-gutter-desktop); }
+      section { padding-block: var(--section-y-desktop); }
+      section + section { border-top: 1px solid var(--border); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography — weight contrast carries hierarchy ─────── */
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        color: var(--fg);
+        line-height: var(--leading-tight);
+        margin: 0;
+      }
+      h1 {
+        font-size: var(--text-4xl);
+        font-weight: 800;
+        letter-spacing: var(--tracking-display);
+        line-height: 1.05;
+      }
+      h2 {
+        font-size: var(--text-2xl);
+        font-weight: 700;
+        letter-spacing: -0.005em;
+        line-height: 1.2;
+      }
+      h3 {
+        font-size: var(--text-xl);
+        font-weight: 600;
+        line-height: 1.3;
+      }
+      p { margin: 0; }
+      .lead {
+        font-size: var(--text-lg);
+        color: var(--muted);
+        line-height: var(--leading-body);
+        font-weight: 400;
+      }
+      .body-muted { color: var(--muted); }
+      .body-sm { font-size: var(--text-sm); }
+      .eyebrow {
+        font-size: var(--text-xs);
+        font-weight: 600;
+        color: var(--accent);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+
+      /* ─── Buttons — soft rectangles, single gradient moment ─── */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 12px 20px;
+        border-radius: var(--radius-sm);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        font-weight: 600;
+        line-height: 1.2;
+        cursor: pointer;
+        border: 1px solid transparent;
+        text-decoration: none;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          border-color var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard),
+          transform var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn:active { transform: translateY(0); }
+      /* Primary: the brand gradient — purple origin → cyan terminus.
+         The single visible gradient on the page; do not repeat. */
+      .btn-primary {
+        background: linear-gradient(135deg, #7d2ae8, #00c4cc);
+        color: var(--accent-on);
+        box-shadow: 0 2px 8px rgba(125, 42, 232, 0.2);
+      }
+      .btn-primary:hover {
+        box-shadow: 0 4px 14px rgba(125, 42, 232, 0.3);
+        transform: translateY(-1px);
+      }
+      /* Secondary: white card with cool hairline border. */
+      .btn-secondary {
+        background: var(--bg);
+        color: var(--fg);
+        border-color: var(--border);
+      }
+      .btn-secondary:hover {
+        background: var(--surface);
+        border-color: #c7cdd3;
+      }
+      /* Subtle / tertiary: purple-tinted ghost. */
+      .btn-subtle {
+        background: rgba(125, 42, 232, 0.08);
+        color: var(--accent);
+      }
+      .btn-subtle:hover { background: rgba(125, 42, 232, 0.14); }
+
+      /* ─── Inputs — soft, purple focus ring ──────────────────── */
+      .field { display: flex; flex-direction: column; gap: var(--space-2); }
+      .field label {
+        font-size: var(--text-sm);
+        font-weight: 600;
+        color: var(--fg);
+      }
+      .field input {
+        padding: 10px 14px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        outline: none;
+        transition:
+          border-color var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .field input:focus-visible {
+        border-color: var(--accent);
+        box-shadow: var(--focus-ring);
+      }
+      .field input::placeholder { color: var(--meta); }
+      .field-help { font-size: var(--text-xs); color: var(--muted); }
+
+      /* ─── Cards — 12px radius, soft cool shadow that grows ──── */
+      .card {
+        background: var(--bg);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        padding: var(--space-6);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+        transition:
+          box-shadow var(--motion-fast) var(--ease-standard),
+          transform var(--motion-fast) var(--ease-standard);
+      }
+      .card:hover {
+        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+        transform: translateY(-2px);
+      }
+      .card-thumb {
+        aspect-ratio: 4 / 3;
+        border-radius: var(--radius-sm);
+        margin-block-end: var(--space-2);
+      }
+      .card-thumb-coral { background: linear-gradient(135deg, #ff7059, #ff9633); }
+      .card-thumb-mint { background: linear-gradient(135deg, #48c997, #3ea6ff); }
+      .card-thumb-lavender { background: linear-gradient(135deg, #9b87f5, #7d2ae8); }
+
+      /* ─── Chips / category tags — pill, uppercase ───────────── */
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        padding: 4px 10px;
+        border-radius: var(--radius-pill);
+        font-size: var(--text-xs);
+        font-weight: 600;
+        line-height: 1.2;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      .chip-coral { background: rgba(255, 112, 89, 0.14); color: #c2412c; }
+      .chip-mint { background: rgba(72, 201, 151, 0.16); color: #1d8a5d; }
+      .chip-lavender { background: rgba(155, 135, 245, 0.18); color: #5b3fcf; }
+
+      /* ─── Pro badge — gradient pill, purple → pink ──────────── */
+      .pro-badge {
+        display: inline-flex;
+        align-items: center;
+        padding: 2px var(--space-2);
+        border-radius: var(--radius-pill);
+        background: linear-gradient(135deg, #7d2ae8, #ff5757);
+        color: var(--accent-on);
+        font-size: 10px;
+        font-weight: 700;
+        line-height: 1.4;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+      }
+
+      /* ─── Links ─────────────────────────────────────────────── */
+      a { color: var(--accent); text-decoration: none; font-weight: 600; }
+      a:hover { text-decoration: underline; text-underline-offset: 3px; }
+      kbd {
+        font-family: var(--font-mono); font-size: var(--text-xs);
+        padding: 2px 6px; border-radius: var(--radius-sm);
+        border: 1px solid var(--border); background: var(--surface); color: var(--muted);
+      }
+
+      /* ─── Layout helpers ────────────────────────────────────── */
+      .hero-grid {
+        display: grid;
+        grid-template-columns: 1.3fr 1fr;
+        gap: var(--space-12);
+        align-items: center;
+      }
+      @media (max-width: 1023px) {
+        .hero-grid { grid-template-columns: 1fr; gap: var(--space-8); }
+      }
+      .hero-actions {
+        display: flex; gap: var(--space-3);
+        margin-block-start: var(--space-6);
+        flex-wrap: wrap;
+      }
+      .hero-meta {
+        display: flex; flex-direction: column; gap: var(--space-4);
+        padding: var(--space-6);
+        border-radius: var(--radius-lg);
+        background: var(--surface);
+      }
+      .features-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: var(--space-6);
+      }
+      @media (max-width: 1023px) { .features-grid { grid-template-columns: 1fr 1fr; gap: var(--space-4); } }
+      @media (max-width: 639px) { .features-grid { grid-template-columns: 1fr; } }
+      .form-row {
+        display: grid;
+        grid-template-columns: 1.2fr 1fr;
+        gap: var(--space-12);
+        align-items: start;
+      }
+      @media (max-width: 1023px) { .form-row { grid-template-columns: 1fr; } }
+      .form {
+        display: flex; flex-direction: column;
+        gap: var(--space-4);
+        max-width: 420px;
+        padding: var(--space-6);
+        background: var(--surface);
+        border-radius: var(--radius-lg);
+      }
+      .form-actions {
+        display: flex; gap: var(--space-3);
+        margin-block-start: var(--space-2);
+      }
+      .icon { width: 16px; height: 16px; flex-shrink: 0; }
+      .row-between {
+        display: flex; align-items: center;
+        justify-content: space-between;
+        gap: var(--space-3);
+      }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <section data-od-id="hero">
+        <div class="hero-grid">
+          <div class="stack-4">
+            <p class="eyebrow">Reference fixture · canva</p>
+            <h1>Design anything.<br />Publish anywhere.</h1>
+            <p class="lead" style="max-width: 52ch">
+              From social posts to slide decks, posters to videos — drag, drop, done.
+              Canva makes great design accessible to every team, every brief, every brand.
+            </p>
+            <div class="hero-actions">
+              <a href="./tokens.css" class="btn btn-primary">
+                Start designing — it's free
+                <svg class="icon" viewBox="0 0 24 24" fill="none"
+                  stroke="currentColor" stroke-width="2"
+                  stroke-linecap="round" stroke-linejoin="round"
+                  aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+              </a>
+              <a href="./DESIGN.md" class="btn btn-secondary">Read the spec</a>
+            </div>
+          </div>
+          <aside class="hero-meta" aria-label="Workspace status">
+            <div class="row-between">
+              <span style="font-weight: 600; color: var(--fg)">Magic Studio</span>
+              <span class="pro-badge">Pro</span>
+            </div>
+            <p class="body-sm body-muted">
+              Generate images, copy, and full layouts from a single prompt.
+              Active across <strong style="color: var(--fg)">12 brand kits</strong>.
+            </p>
+            <div class="row-between body-sm">
+              <span class="body-muted">Last edited</span>
+              <span><time datetime="2026-05-18">2 minutes ago</time></span>
+            </div>
+            <p class="body-sm body-muted">
+              Tip: press <kbd>⌘</kbd> <kbd>K</kbd> to jump to any template.
+            </p>
+          </aside>
+        </div>
+      </section>
+
+      <section data-od-id="features">
+        <div class="stack-3">
+          <p class="eyebrow">A template for every brief</p>
+          <h2 style="max-width: 24ch">Start from anything. Make it your own.</h2>
+        </div>
+        <div class="features-grid" style="margin-block-start: var(--space-8)">
+          <article class="card">
+            <div class="card-thumb card-thumb-coral" aria-hidden="true"></div>
+            <span class="chip chip-coral">Social</span>
+            <h3>Instagram Story</h3>
+            <p class="body-muted body-sm">
+              1080 × 1920 vertical templates, ready for Reels and Stories.
+              Drop in your logo, swap fonts, publish straight to your handle.
+            </p>
+            <a href="./tokens.css" class="body-sm">Browse 1,240 templates →</a>
+          </article>
+          <article class="card">
+            <div class="card-thumb card-thumb-mint" aria-hidden="true"></div>
+            <span class="chip chip-mint">Education</span>
+            <h3>Lesson plans &amp; worksheets</h3>
+            <p class="body-muted body-sm">
+              Printable A4 and US Letter formats for teachers. Subject-tagged
+              and tested against grade-level readability scores.
+            </p>
+            <a href="./tokens.css" class="body-sm">Open the classroom kit →</a>
+          </article>
+          <article class="card">
+            <div class="card-thumb card-thumb-lavender" aria-hidden="true"></div>
+            <span class="chip chip-lavender">Personal</span>
+            <h3>Invitations &amp; cards</h3>
+            <p class="body-muted body-sm">
+              Birthday, wedding, save-the-date — print at home or order
+              through Canva Print with two-day shipping to most countries.
+            </p>
+            <a href="./tokens.css" class="body-sm">Pick an occasion →</a>
+          </article>
+        </div>
+      </section>
+
+      <section data-od-id="form">
+        <div class="form-row">
+          <div class="stack-4">
+            <p class="eyebrow">Get started</p>
+            <h2>Bring your team into Canva.</h2>
+            <p class="body-muted" style="max-width: 48ch">
+              Drop your work email and we'll set up your free Canva workspace —
+              brand kit, folders, and approvals included. No credit card needed.
+            </p>
+          </div>
+          <form class="form" onsubmit="event.preventDefault();">
+            <div class="field">
+              <label for="email">Work email</label>
+              <input id="email" type="email" placeholder="you@yourcompany.com" autocomplete="email" required />
+              <p class="field-help">We'll use this to create your team workspace.</p>
+            </div>
+            <div class="form-actions">
+              <button type="submit" class="btn btn-primary">Create workspace</button>
+              <button type="button" class="btn btn-subtle">See a demo</button>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/canva/tokens.css
+++ b/design-systems/canva/tokens.css
@@ -1,0 +1,147 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/canva/tokens.css
+ *
+ * Structured token bindings for "Design System Inspired by Canva".
+ * Consumer-friendly design platform: white canvas, vivid purple→cyan
+ * gradient, generously rounded geometry, weight-driven hierarchy.
+ *
+ * Key brand decisions encoded here:
+ *   - Pure white canvas (#ffffff) — Canva looks inviting, never tinted
+ *   - Canva Purple (#7d2ae8) as the single accent — gradient origin
+ *   - Four ink tiers (#0e1318 → #3c4043 → #5f6368 → #9aa0a6) — weight
+ *     contrast and ink-tier contrast carry hierarchy together
+ *   - 12px card / 8px button radii — soft, friendly, never sharp
+ *   - Cool soft shadows (rgba(0,0,0,0.06)) — never warm-tinted
+ *   - Compressed type scale (14px body, 18px H3, 64px hero) — cards
+ *     and templates must read at thumbnail scale
+ *   - Material-style easing (0.4,0,0.2,1) at 180ms — friendly micro-lift
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface ─────────────────────────────────────────────────────
+   * White canvas with cool-gray subtle break. Canva never tints its
+   * neutral surfaces — the purple/cyan gradient is the only colored
+   * brand moment on an otherwise calm white page. */
+  --bg: #ffffff;             /* Canvas — the primary white background */
+  --surface: #f4f5f7;        /* Surface Subtle — section break, sidebar */
+  --surface-warm: var(--surface); /* alias — Canva has no warm tier; palette is cool-neutral */
+
+  /* ─── Foreground ──────────────────────────────────────────────────
+   * Four-tier ink stack from DESIGN.md §2: Primary → Secondary →
+   * Muted → Faint. Each tier is materially distinct so weight + tier
+   * together carry hierarchy (the palette stays neutral). */
+  --fg: #0e1318;             /* Ink Primary — headings, max-emphasis text */
+  --fg-2: #3c4043;           /* Ink Secondary — body prose */
+  --muted: #5f6368;          /* Ink Muted — captions, descriptions */
+  --meta: #9aa0a6;           /* Ink Faint — placeholder, disabled label */
+
+  /* ─── Border ──────────────────────────────────────────────────────
+   * Cool-gray hairlines. Canva uses two visible border tiers
+   * (Default + Strong on hover); --border-soft has no distinct value
+   * in DESIGN.md, so it aliases to keep the schema satisfied without
+   * inventing a tier the brand does not specify. */
+  --border: #e1e3e6;         /* Border Default — standard card hairline */
+  --border-soft: var(--border); /* alias — DESIGN.md specifies no softer tier */
+
+  /* ─── Accent ──────────────────────────────────────────────────────
+   * Canva Purple — the gradient origin. The full purple→cyan gradient
+   * lives in component CSS as a linear-gradient(135deg, ...) on hero
+   * CTAs and Pro/Magic moments; the token itself is the solid purple
+   * used as the always-resolvable single-value accent. */
+  --accent: #7d2ae8;         /* Canva Purple — gradient origin, solid CTA */
+  --accent-on: #ffffff;
+  --accent-hover: #6815d4;   /* DESIGN.md §4 — explicit hover value */
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+  /* ─── Semantic ────────────────────────────────────────────────────
+   * Brand-specific semantic palette from DESIGN.md §2. Error reuses
+   * Canva Pink (#ff5757) — the same hue is the tertiary brand accent
+   * (Magic Studio), so destructive feedback inherits brand warmth. */
+  --success: #00b894;        /* Success — saved, exported */
+  --warn: #ffb020;           /* Warning — storage limit, advisory */
+  --danger: #ff5757;         /* Error — also the Magic Studio pink */
+
+  /* ─── Typography ──────────────────────────────────────────────────
+   * Canva Sans for everything — geometric rounded sans, no serifs.
+   * JetBrains Mono only inside devtools / code blocks. */
+  --font-display: "Canva Sans", "YS Text", system-ui, -apple-system, sans-serif;
+  --font-body: "Canva Sans", "YS Text", system-ui, -apple-system, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, Menlo, Consolas, monospace;
+
+  /* Type scale — DESIGN.md §3. Compressed by design: 64px hero, 36px
+   * H1, then steps of 24/18/16/14/12/11. Tag (11px) is the floor so
+   * uppercase category chips on template tiles stay legible. */
+  --text-xs: 11px;           /* Tag — uppercase category chip */
+  --text-sm: 12px;           /* Caption — metadata, hint text */
+  --text-base: 14px;         /* Body — standard UI prose */
+  --text-lg: 16px;           /* Body Large — lede, marketing body */
+  --text-xl: 18px;           /* H3 — sub-section, card title */
+  --text-2xl: 24px;          /* H2 — section heading */
+  --text-3xl: 36px;          /* H1 — page heading */
+  --text-4xl: 64px;          /* Hero — marketing display, "Design anything." */
+
+  --leading-body: 1.5;
+  --leading-tight: 1.15;     /* H1 baseline — tight enough for 3-line card titles */
+  --tracking-display: -0.02em; /* ≈ -1.28px at 64px — hero only */
+
+  /* ─── Spacing ─────────────────────────────────────────────────────
+   * 4px base unit. Scale 4/8/12/16/20/24/32/48 covers everything in
+   * DESIGN.md §5 except 64 and 96 which surface only as section-y. */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+
+  /* Section rhythm — generous on desktop (96px = scale top) so the
+   * white canvas breathes between marketing bands; compresses on
+   * narrower viewports following the 4px grid. */
+  --section-y-desktop: 96px;
+  --section-y-tablet: 64px;
+  --section-y-phone: 48px;
+
+  /* ─── Radius ──────────────────────────────────────────────────────
+   * Ultra-soft. Buttons / inputs at 8px, cards at 12px (the Canva
+   * template tile), larger panels at 16px. Pills (9999px) reserved
+   * for chips, tags, and the Pro/Magic badge. */
+  --radius-sm: 8px;          /* Buttons, inputs, secondary chrome */
+  --radius-md: 12px;         /* Cards, template tiles — the Canva default */
+  --radius-lg: 16px;         /* Featured panels, hero cards */
+  --radius-pill: 9999px;     /* Chips, tags, Pro/Magic badge */
+
+  /* ─── Elevation ───────────────────────────────────────────────────
+   * Soft cool-toned shadows that grow on hover (DESIGN.md §4 card +
+   * button shadows). --elev-raised matches the resting button shadow
+   * — `0 2px 8px rgba(0,0,0,0.06)`. Components scale up to the hover
+   * variant `0 8px 24px rgba(0,0,0,0.08)` inline. */
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised: 0 2px 8px rgba(0, 0, 0, 0.06);
+
+  /* ─── Focus ring ──────────────────────────────────────────────────
+   * Purple-tinted 3px ring, taken verbatim from DESIGN.md §4 input
+   * focus spec — `0 0 0 3px rgba(125, 42, 232, 0.16)`. Soft enough to
+   * sit beside a 1px purple border without crowding it. */
+  --focus-ring: 0 0 0 3px rgba(125, 42, 232, 0.16);
+
+  /* ─── Motion ──────────────────────────────────────────────────────
+   * Friendly micro-interactions: 180ms hover (Canva's signature card
+   * lift) and 280ms for menu / dialog open (DESIGN.md §6). Easing is
+   * Material-style cubic-bezier(0.4, 0, 0.2, 1) — eases out softly
+   * rather than the snappier (0.2, 0, 0, 1) used by enterprise brands. */
+  --motion-fast: 180ms;
+  --motion-base: 280ms;
+  --ease-standard: cubic-bezier(0.4, 0, 0.2, 1);
+
+  /* ─── Layout ──────────────────────────────────────────────────────
+   * 1320px container with 32px gutter (DESIGN.md §5). Wider than
+   * enterprise (Cohere 1440 is editor-led; Canva 1320 fits a 4-col
+   * template grid at 300px per tile + gaps comfortably). */
+  --container-max: 1320px;
+  --container-gutter-desktop: 32px;
+  --container-gutter-tablet: 24px;
+  --container-gutter-phone: 16px;
+}

--- a/design-systems/duolingo/components.html
+++ b/design-systems/duolingo/components.html
@@ -1,0 +1,532 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Duolingo — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/duolingo. Owl-green gamified
+        universe, chunky 4px tactile shadows, big confident type, friendly pill geometry."
+    />
+
+    <style>
+      :root {
+        --bg: #ffffff;
+        --surface: #f7f7f7;
+        --surface-warm: var(--surface);
+
+        --fg: #3c3c3c;
+        --fg-2: var(--fg);
+        --muted: #777777;
+        --meta: #afafaf;
+
+        --border: #e5e5e5;
+        --border-soft: var(--border);
+
+        --accent: #58cc02;
+        --accent-on: #ffffff;
+        --accent-hover: #89e219;
+        --accent-active: #58a700;
+
+        --success: #58cc02;
+        --warn: #ffc800;
+        --danger: #ff4b4b;
+
+        --font-display: "Feather Bold", "DIN Round Pro", "Helvetica Neue", sans-serif;
+        --font-body: "Mona Sans", "Helvetica Neue", system-ui, sans-serif;
+        --font-mono: "JetBrains Mono", ui-monospace, Menlo, Monaco, Consolas, monospace;
+
+        --text-xs: 12px;
+        --text-sm: 13px;
+        --text-base: 15px;
+        --text-lg: 18px;
+        --text-xl: 24px;
+        --text-2xl: 32px;
+        --text-3xl: 40px;
+        --text-4xl: 56px;
+
+        --leading-body: 1.5;
+        --leading-tight: 1.15;
+        --tracking-display: -0.01em;
+
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 80px;
+        --section-y-tablet: 56px;
+        --section-y-phone: 40px;
+
+        --radius-sm: 12px;
+        --radius-md: 16px;
+        --radius-lg: 20px;
+        --radius-pill: 9999px;
+
+        --elev-flat: none;
+        --elev-ring: 0 0 0 2px var(--border);
+        --elev-raised: 0 4px 0 #d7d7d7;
+
+        --focus-ring: 0 0 0 3px rgba(28, 176, 246, 0.2);
+
+        --motion-fast: 180ms;
+        --motion-base: 320ms;
+        --ease-standard: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+        --container-max: 1080px;
+        --container-gutter-desktop: 24px;
+        --container-gutter-tablet: 20px;
+        --container-gutter-phone: 16px;
+      }
+
+      /* ─── Reset ─────────────────────────────────────────────── */
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+
+      /* ─── Layout ────────────────────────────────────────────── */
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      section + section { border-top: 2px solid var(--border); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography — Feather Bold @ 800 across chrome ─────── */
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        font-weight: 800;
+        line-height: var(--leading-tight);
+        margin: 0;
+        color: var(--fg);
+      }
+      h1 {
+        font-size: var(--text-4xl);
+        letter-spacing: var(--tracking-display);
+        line-height: 1.05;
+      }
+      h2 { font-size: var(--text-2xl); letter-spacing: -0.005em; }
+      h3 { font-size: var(--text-lg); font-weight: 700; line-height: 1.25; }
+      p { margin: 0; }
+      .lead { font-size: var(--text-lg); color: var(--fg); line-height: var(--leading-body); }
+      .body-muted { color: var(--muted); }
+      .body-meta { color: var(--meta); }
+      .body-sm { font-size: var(--text-sm); }
+      .eyebrow {
+        display: inline-block;
+        font-family: var(--font-display);
+        font-size: var(--text-xs);
+        color: var(--accent-active);
+        background: color-mix(in oklab, var(--accent), transparent 82%);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 800;
+        padding: var(--space-1) var(--space-3);
+        border-radius: var(--radius-pill);
+      }
+      .stack-2 > * + * { margin-block-start: var(--space-2); }
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+
+      /* ─── Buttons — chunky 4px bottom-shadow tactile press ──── */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: var(--space-2);
+        padding: 14px var(--space-6);
+        border-radius: var(--radius-md);
+        font-family: var(--font-display);
+        font-size: var(--text-base);
+        font-weight: 800;
+        line-height: 1.2;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        cursor: pointer;
+        border: none;
+        text-decoration: none;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          transform var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+
+      /* Primary — Owl Green with darker green underside */
+      .btn-primary {
+        background: var(--accent);
+        color: var(--accent-on);
+        box-shadow: 0 4px 0 var(--accent-active);
+      }
+      .btn-primary:hover { background: var(--accent-hover); }
+      .btn-primary:active {
+        transform: translateY(4px);
+        box-shadow: 0 0 0 var(--accent-active);
+      }
+
+      /* Secondary — White with neutral underside */
+      .btn-secondary {
+        background: var(--bg);
+        color: var(--muted);
+        border: 2px solid var(--border);
+        box-shadow: 0 4px 0 var(--border);
+        padding: 12px calc(var(--space-6) - 2px);
+      }
+      .btn-secondary:hover { color: var(--fg); border-color: var(--meta); }
+      .btn-secondary:active {
+        transform: translateY(4px);
+        box-shadow: 0 0 0 var(--border);
+      }
+
+      /* Streak — Bee Yellow with warm underside */
+      .btn-streak {
+        background: var(--warn);
+        color: var(--fg);
+        box-shadow: 0 4px 0 color-mix(in oklab, var(--warn), black 18%);
+      }
+      .btn-streak:hover { background: color-mix(in oklab, var(--warn), white 8%); }
+      .btn-streak:active {
+        transform: translateY(4px);
+        box-shadow: 0 0 0 color-mix(in oklab, var(--warn), black 18%);
+      }
+
+      /* ─── Inputs — thick borders, soft eel-blue focus glow ─── */
+      .field { display: flex; flex-direction: column; gap: var(--space-2); }
+      .field label {
+        font-family: var(--font-display);
+        font-size: var(--text-sm);
+        font-weight: 800;
+        color: var(--fg);
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+      }
+      .field input {
+        padding: 14px var(--space-4);
+        border-radius: var(--radius-sm);
+        border: 2px solid var(--border);
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        outline: none;
+        transition:
+          border-color var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .field input::placeholder { color: var(--meta); }
+      .field input:hover { border-color: var(--meta); }
+      .field input:focus-visible {
+        border-color: var(--accent);
+        box-shadow: var(--focus-ring);
+      }
+      .field-help { font-size: var(--text-xs); color: var(--muted); }
+
+      /* ─── Cards / Lesson tiles — chunky offset shadow ───────── */
+      .card {
+        background: var(--bg);
+        border: 2px solid var(--border);
+        border-radius: var(--radius-md);
+        padding: var(--space-6);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+        box-shadow: var(--elev-raised);
+        transition:
+          transform var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .card:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 6px 0 #d7d7d7;
+      }
+      .card-icon {
+        width: 56px;
+        height: 56px;
+        border-radius: var(--radius-pill);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--accent-on);
+        font-family: var(--font-display);
+        font-weight: 800;
+        font-size: var(--text-xl);
+        box-shadow: 0 3px 0 color-mix(in oklab, currentColor, black 22%);
+      }
+      .card-icon-green { background: var(--accent); }
+      .card-icon-red { background: var(--danger); }
+      .card-icon-yellow { background: var(--warn); color: var(--fg); }
+
+      /* ─── Badges + chips ────────────────────────────────────── */
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: var(--space-1) var(--space-3);
+        border-radius: var(--radius-pill);
+        font-family: var(--font-display);
+        font-size: var(--text-xs);
+        font-weight: 800;
+        letter-spacing: 0.04em;
+        line-height: 1.6;
+        text-transform: uppercase;
+      }
+      .badge-success { color: var(--accent-on); background: var(--success); }
+      .badge-streak  { color: var(--fg); background: var(--warn); }
+      .badge-muted   { color: var(--muted); background: var(--surface); border: 2px solid var(--border); }
+      .badge-dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
+
+      /* ─── Progress bar ──────────────────────────────────────── */
+      .progress {
+        position: relative;
+        background: var(--border);
+        border-radius: var(--radius-pill);
+        height: 16px;
+        overflow: hidden;
+      }
+      .progress > .progress-fill {
+        height: 100%;
+        width: 64%;
+        background: var(--accent);
+        border-radius: var(--radius-pill);
+        box-shadow: inset 0 -4px 0 var(--accent-active);
+      }
+
+      /* ─── Mascot panel ──────────────────────────────────────── */
+      .mascot-card {
+        background: var(--surface);
+        border: 2px solid var(--border);
+        border-radius: var(--radius-lg);
+        padding: var(--space-6);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+        box-shadow: var(--elev-raised);
+      }
+      .mascot-row {
+        display: flex;
+        align-items: center;
+        gap: var(--space-4);
+      }
+      .mascot-svg {
+        width: 96px;
+        height: 96px;
+        flex-shrink: 0;
+        filter: drop-shadow(0 3px 0 var(--accent-active));
+      }
+      .row-between { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); }
+
+      /* ─── Links + kbd ───────────────────────────────────────── */
+      a { color: var(--accent-active); text-decoration: none; font-weight: 700; }
+      a:hover { text-decoration: underline; text-underline-offset: 3px; }
+      kbd {
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        padding: 2px var(--space-2);
+        border-radius: var(--radius-sm);
+        border: 2px solid var(--border);
+        background: var(--bg);
+        color: var(--muted);
+        box-shadow: 0 2px 0 var(--border);
+      }
+
+      /* ─── Layout helpers ────────────────────────────────────── */
+      .hero-grid {
+        display: grid;
+        grid-template-columns: 1.4fr 1fr;
+        gap: var(--space-12);
+        align-items: center;
+      }
+      @media (max-width: 1023px) {
+        .hero-grid { grid-template-columns: 1fr; gap: var(--space-8); }
+      }
+      .hero-actions {
+        display: flex;
+        gap: var(--space-3);
+        margin-block-start: var(--space-6);
+        flex-wrap: wrap;
+      }
+      .features-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: var(--space-5);
+      }
+      @media (max-width: 1023px) { .features-grid { grid-template-columns: 1fr 1fr; } }
+      @media (max-width: 639px)  { .features-grid { grid-template-columns: 1fr; } }
+      .form-row {
+        display: grid;
+        grid-template-columns: 1.2fr 1fr;
+        gap: var(--space-12);
+        align-items: start;
+      }
+      @media (max-width: 1023px) { .form-row { grid-template-columns: 1fr; } }
+      .form {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+        max-width: 420px;
+        background: var(--bg);
+        border: 2px solid var(--border);
+        border-radius: var(--radius-md);
+        padding: var(--space-6);
+        box-shadow: var(--elev-raised);
+      }
+      .form-actions { display: flex; gap: var(--space-3); margin-block-start: var(--space-2); }
+      .icon { width: 18px; height: 18px; flex-shrink: 0; }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <section data-od-id="hero">
+        <div class="hero-grid">
+          <div class="stack-6">
+            <span class="eyebrow">Reference fixture · duolingo</span>
+            <div class="stack-4">
+              <h1>Free language learning for the world.</h1>
+              <p class="lead" style="max-width: 48ch">
+                15 minutes a day can teach you a language. Practice with bite-sized lessons,
+                keep your streak alive, and let Duo the owl cheer you on every step of the way.
+              </p>
+            </div>
+            <div class="hero-actions">
+              <a href="./tokens.css" class="btn btn-primary">
+                Get started — it's free
+                <svg class="icon" viewBox="0 0 24 24" fill="none"
+                  stroke="currentColor" stroke-width="3"
+                  stroke-linecap="round" stroke-linejoin="round"
+                  aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+              </a>
+              <a href="./DESIGN.md" class="btn btn-secondary">I already have an account</a>
+            </div>
+          </div>
+          <aside class="mascot-card" aria-label="Today's lesson">
+            <div class="mascot-row">
+              <svg class="mascot-svg" viewBox="0 0 96 96" aria-hidden="true">
+                <ellipse cx="48" cy="58" rx="34" ry="32" fill="var(--accent)"/>
+                <ellipse cx="48" cy="58" rx="22" ry="22" fill="color-mix(in oklab, var(--accent), white 22%)"/>
+                <circle cx="36" cy="46" r="9" fill="#ffffff"/>
+                <circle cx="60" cy="46" r="9" fill="#ffffff"/>
+                <circle cx="36" cy="48" r="4.5" fill="var(--fg)"/>
+                <circle cx="60" cy="48" r="4.5" fill="var(--fg)"/>
+                <circle cx="34.5" cy="46.5" r="1.6" fill="#ffffff"/>
+                <circle cx="58.5" cy="46.5" r="1.6" fill="#ffffff"/>
+                <path d="M40 60 L48 67 L56 60 Z" fill="var(--warn)"/>
+                <path d="M22 32 Q30 18 42 26" fill="none" stroke="var(--accent-active)" stroke-width="6" stroke-linecap="round"/>
+                <path d="M74 32 Q66 18 54 26" fill="none" stroke="var(--accent-active)" stroke-width="6" stroke-linecap="round"/>
+              </svg>
+              <div class="stack-2">
+                <h3>Spanish · Unit 3</h3>
+                <p class="body-sm body-muted">Order food at the café</p>
+              </div>
+            </div>
+            <div class="stack-2">
+              <div class="row-between">
+                <span class="body-sm" style="font-family: var(--font-display); font-weight: 800">Lesson progress</span>
+                <span class="body-sm" style="color: var(--muted)">3 / 5 crowns</span>
+              </div>
+              <div class="progress" aria-label="Lesson progress 64%">
+                <div class="progress-fill"></div>
+              </div>
+            </div>
+            <div class="row-between">
+              <span class="badge badge-streak">
+                <span class="badge-dot" aria-hidden="true"></span>
+                14 day streak
+              </span>
+              <span class="body-sm" style="color: var(--muted)">+15 XP today</span>
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <section data-od-id="features">
+        <div class="stack-3">
+          <span class="eyebrow">What this fixture exercises</span>
+          <h2 style="max-width: 22ch">Joy is the curriculum.</h2>
+          <p class="body-muted" style="max-width: 56ch">
+            Every surface is built for the next correct answer — green to celebrate,
+            chunky shadows to invite the press, and Duo waiting on the other side.
+          </p>
+        </div>
+        <div class="features-grid" style="margin-block-start: var(--space-8)">
+          <article class="card">
+            <span class="card-icon card-icon-green" aria-hidden="true">✓</span>
+            <h3>Owl green throughout</h3>
+            <p class="body-muted body-sm">
+              --accent (#58cc02) covers 30%+ of every screen. Primary CTA, correct
+              answer, progress fill — they're all the same affirming green.
+            </p>
+            <a href="./tokens.css" class="body-sm">Inspect tokens →</a>
+          </article>
+          <article class="card">
+            <span class="card-icon card-icon-yellow" aria-hidden="true">★</span>
+            <h3>Tactile 4px shadow</h3>
+            <p class="body-muted body-sm">
+              --elev-raised drops a hard 4px offset under every button. On :active
+              we translateY(4px) and zero the shadow — the button literally presses.
+            </p>
+            <a href="./DESIGN.md" class="body-sm">Read the rule →</a>
+          </article>
+          <article class="card">
+            <span class="card-icon card-icon-red" aria-hidden="true">!</span>
+            <h3>Big confident type</h3>
+            <p class="body-muted body-sm">
+              --text-4xl (56px) is +25% over typical product brands. Feather Bold at
+              800 is the default — we never whisper, we never apologize for size.
+            </p>
+            <a href="./tokens.css" class="body-sm">Inspect ladder →</a>
+          </article>
+        </div>
+      </section>
+
+      <section data-od-id="form">
+        <div class="form-row">
+          <div class="stack-4">
+            <span class="eyebrow">Start your streak</span>
+            <h2>One inbox is all it takes.</h2>
+            <p class="body-muted" style="max-width: 48ch">
+              We'll send a friendly nudge when Duo notices you missed a day. No tricks,
+              no spam — just the kind of gentle accountability that turns 15 minutes
+              into a year-long habit.
+            </p>
+            <p class="body-meta body-sm">
+              Press <kbd>⌘</kbd> <kbd>K</kbd> to search the lesson library.
+            </p>
+          </div>
+          <form class="form" onsubmit="event.preventDefault();">
+            <div class="field">
+              <label for="email">Email</label>
+              <input id="email" type="email" placeholder="you@duolingo.com" autocomplete="email" required />
+              <p class="field-help">Free forever · 600M+ learners worldwide</p>
+            </div>
+            <div class="form-actions">
+              <button type="submit" class="btn btn-primary">Create account</button>
+              <button type="button" class="btn btn-secondary">Sign in</button>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/duolingo/tokens.css
+++ b/design-systems/duolingo/tokens.css
@@ -1,0 +1,130 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/duolingo/tokens.css
+ *
+ * Structured token bindings for "Design System Inspired by Duolingo".
+ * Bright owl-green gamified universe: chunky 4px bottom-shadows, big
+ * confident type, friendly pill geometry, mascot-driven warmth.
+ *
+ * Key brand decisions encoded here:
+ *   - Owl Green (#58cc02) — dominant brand color, primary CTA + correct answer
+ *   - Snow white canvas (#ffffff) — never tinted; optical clarity is the foundation
+ *   - 4px chunky offset shadow (--elev-raised) — the "tactile press" signature
+ *   - Feather Bold + Mona Sans — rounded display + Swiss workhorse body
+ *   - Display starts at 56px — Duolingo never whispers; size is identity
+ *   - Pill-and-rounded radii — 16px cards, 12px buttons/inputs, 9999px chips
+ *   - Spring easing (back-out, slight overshoot) — gamified joy in motion
+ *   - Eel-blue focus ring (#1cb0f6 tinted) — playful contrast to the green brand
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface ─────────────────────────────────────────────────────
+   * Snow white canvas with Eel as the section-break tone. Pure optical
+   * clarity — Duolingo never tints the page itself, only the chrome. */
+  --bg: #ffffff;             /* Snow — primary background, the page canvas */
+  --surface: #f7f7f7;        /* Eel — section break, secondary surface, lesson row */
+  --surface-warm: var(--surface); /* alias — palette has no third (warm) surface tier */
+
+  /* ─── Foreground ──────────────────────────────────────────────────
+   * Three real text tiers: Eel Black for primary, Wolf for secondary,
+   * Hare for tertiary. Each tier carries clear, child-readable contrast. */
+  --fg: #3c3c3c;             /* Eel Black — primary text, headings, button labels */
+  --fg-2: var(--fg);         /* alias — single primary text weight throughout */
+  --muted: #777777;          /* Wolf — secondary text, captions, dividers */
+  --meta: #afafaf;           /* Hare — tertiary metadata, placeholder, disabled */
+
+  /* ─── Border ──────────────────────────────────────────────────────
+   * Swan grey at thick 2–3px on most surfaces. Borders are visual,
+   * never hairlines — they read as part of the chunky aesthetic. */
+  --border: #e5e5e5;         /* Swan — standard 2px border, card edge */
+  --border-soft: var(--border); /* alias — single border tier (no inner-row separation) */
+
+  /* ─── Accent ──────────────────────────────────────────────────────
+   * Owl Green — the brand IS this green. Used liberally in 30%+ of the
+   * surface for buttons, progress bars, success states, brand chrome. */
+  --accent: #58cc02;
+  --accent-on: #ffffff;
+  --accent-hover: #89e219;   /* Owl Green Light — hover state, soft fills */
+  --accent-active: #58a700;  /* Owl Green Deep — pressed state, the chunky shadow color */
+
+  /* ─── Semantic ────────────────────────────────────────────────────
+   * Success IS owl green — DESIGN.md: "primary CTA, correct answer" are
+   * the same affordance. Bee Yellow warns; Cardinal Red marks wrong. */
+  --success: #58cc02;        /* Owl Green — "correct answer" is the brand */
+  --warn: #ffc800;           /* Bee Yellow — pro badge, achievement glow */
+  --danger: #ff4b4b;         /* Cardinal Red — wrong answer, life lost */
+
+  /* ─── Typography ──────────────────────────────────────────────────
+   * Feather Bold (rounded display) drives chrome and headings; Mona Sans
+   * carries body. Default weight is 800 — Duolingo never whispers. */
+  --font-display: "Feather Bold", "DIN Round Pro", "Helvetica Neue", sans-serif;
+  --font-body: "Mona Sans", "Helvetica Neue", system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, Menlo, Monaco, Consolas, monospace;
+
+  /* Type scale — DESIGN.md §3. Display 56px is +25–40% above typical
+   * product brands; the ladder favors round whole-pixel sizes. */
+  --text-xs: 12px;           /* Tiny utility, progress numerals */
+  --text-sm: 13px;           /* Caption — XP counter, metadata */
+  --text-base: 15px;         /* Body — standard prose */
+  --text-lg: 18px;           /* H3 / lesson row title / featured body */
+  --text-xl: 24px;           /* H2 — section heading */
+  --text-2xl: 32px;          /* H1 — page title */
+  --text-3xl: 40px;          /* Sub-display — hero secondary, marketing eyebrow */
+  --text-4xl: 56px;          /* Display — onboarding hero, never timid */
+
+  --leading-body: 1.5;
+  --leading-tight: 1.15;     /* Headings — slight breathing under big rounded faces */
+  --tracking-display: -0.01em; /* ≈ -0.56px at 56px — confident, not condensed */
+
+  /* ─── Spacing ─────────────────────────────────────────────────────
+   * 4px base unit (DESIGN.md §5): 4, 8, 12, 16, 20, 24, 32, 48. */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+
+  /* Section rhythm — generous on desktop, tight on phone so the lesson
+   * tree column reads as a continuous flow rather than chunked pages. */
+  --section-y-desktop: 80px;
+  --section-y-tablet: 56px;
+  --section-y-phone: 40px;
+
+  /* ─── Radius ──────────────────────────────────────────────────────
+   * Pill-and-rounded everywhere. Cards 16px (DESIGN.md §4), buttons +
+   * inputs 12px, chips and progress bars 9999px — friendly forever. */
+  --radius-sm: 12px;         /* Inputs, buttons — friendly compact corners */
+  --radius-md: 16px;         /* Cards, lesson tiles — primary signature */
+  --radius-lg: 20px;         /* Featured containers, modals */
+  --radius-pill: 9999px;     /* Chips, progress bars, avatars */
+
+  /* ─── Elevation ───────────────────────────────────────────────────
+   * Chunky 4px bottom-shadow IS Duolingo. Buttons and cards cast a hard
+   * offset shadow that reads as a 3D button waiting to be pressed. The
+   * raised value pairs with translateY(4px) on :active to "press" it. */
+  --elev-flat: none;
+  --elev-ring: 0 0 0 2px var(--border); /* 2px ring matches the chunky border weight */
+  --elev-raised: 0 4px 0 #d7d7d7; /* Hard tactile shadow — the press affordance */
+
+  /* ─── Focus ring ──────────────────────────────────────────────────
+   * Eel Blue 20% tint (DESIGN.md §4 inputs) — playful contrast against
+   * the ambient owl-green brand; signals "you can interact with this". */
+  --focus-ring: 0 0 0 3px rgba(28, 176, 246, 0.2);
+
+  /* ─── Motion ──────────────────────────────────────────────────────
+   * 180ms button press, 320ms skill-node unlock; back-out spring with
+   * slight overshoot (DESIGN.md §6). Every state change feels gamified. */
+  --motion-fast: 180ms;
+  --motion-base: 320ms;
+  --ease-standard: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  /* ─── Layout ──────────────────────────────────────────────────────
+   * 1080px container (DESIGN.md §5) — narrower than a SaaS deck because
+   * Duolingo content reads vertically as a focused lesson tree column. */
+  --container-max: 1080px;
+  --container-gutter-desktop: 24px;
+  --container-gutter-tablet: 20px;
+  --container-gutter-phone: 16px;
+}

--- a/design-systems/framer/components.html
+++ b/design-systems/framer/components.html
@@ -1,0 +1,438 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Framer — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/framer. Void black canvas,
+        Framer Blue accent, GT Walsheim display with extreme negative
+        letter-spacing, pill buttons, blue ring-shadow elevation."
+    />
+
+    <style>
+      :root {
+        --bg: #000000;
+        --surface: #090909;
+        --surface-warm: var(--surface);
+
+        --fg: #ffffff;
+        --fg-2: #a6a6a6;
+        --muted: rgba(255, 255, 255, 0.6);
+        --meta: rgba(255, 255, 255, 0.4);
+
+        --border: rgba(0, 153, 255, 0.15);
+        --border-soft: rgba(255, 255, 255, 0.06);
+
+        --accent: #0099ff;
+        --accent-on: #ffffff;
+        --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+        --success: #16a34a;
+        --warn: #eab308;
+        --danger: #dc2626;
+
+        --font-display: "GT Walsheim Framer Medium", "GT Walsheim Medium", "GT Walsheim", -apple-system, "Segoe UI", Inter, sans-serif;
+        --font-body: "Inter Variable", "Inter", -apple-system, "Segoe UI", Arial, sans-serif;
+        --font-mono: "Azeret Mono", ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+
+        --text-xs: 12px;
+        --text-sm: 14px;
+        --text-base: 15px;
+        --text-lg: 18px;
+        --text-xl: 22px;
+        --text-2xl: 32px;
+        --text-3xl: 62px;
+        --text-4xl: 110px;
+
+        --leading-body: 1.3;
+        --leading-tight: 0.95;
+        --tracking-display: -0.05em;
+
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 120px;
+        --section-y-tablet: 80px;
+        --section-y-phone: 60px;
+
+        --radius-sm: 8px;
+        --radius-md: 12px;
+        --radius-lg: 20px;
+        --radius-pill: 9999px;
+
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised:
+          0 0.5px 0 0.5px rgba(255, 255, 255, 0.1),
+          0 10px 30px rgba(0, 0, 0, 0.25);
+
+        --focus-ring: 0 0 0 3px color-mix(in oklab, var(--accent), transparent 70%);
+
+        --motion-fast: 150ms;
+        --motion-base: 200ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+        --container-max: 1200px;
+        --container-gutter-desktop: 24px;
+        --container-gutter-tablet: 16px;
+        --container-gutter-phone: 12px;
+      }
+
+      /* ─── Reset ─────────────────────────────────────────────── */
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+        font-feature-settings: "cv01", "cv05", "cv09", "cv11", "ss03", "ss07";
+      }
+
+      /* ─── Layout ─────────────────────────────────────────────── */
+      .container { max-width: var(--container-max); margin-inline: auto; padding-inline: var(--container-gutter-desktop); }
+      section { padding-block: var(--section-y-desktop); }
+      section + section { border-top: 1px solid var(--border-soft); }
+      @media (max-width: 1199px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 809px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography — GT Walsheim display, Inter body ───────── */
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        font-weight: 500;              /* GT Walsheim Medium — the brand weight, never bold */
+        line-height: var(--leading-tight);
+        margin: 0;
+        color: var(--fg);
+      }
+      /* Display hero: 110px on desktop, scaling down on smaller breakpoints.
+         The most extreme 0.85 line-height is reserved for this size only. */
+      h1 {
+        font-size: var(--text-4xl);
+        line-height: 0.85;
+        letter-spacing: var(--tracking-display);
+      }
+      h2 {
+        font-size: var(--text-3xl);
+        letter-spacing: var(--tracking-display);
+      }
+      h3 {
+        font-size: var(--text-xl);
+        font-family: var(--font-body);
+        font-weight: 700;
+        letter-spacing: -0.025em;
+        line-height: 1.2;
+      }
+      @media (max-width: 1199px) {
+        h1 { font-size: 85px; }
+        h2 { font-size: 48px; }
+      }
+      @media (max-width: 809px) {
+        h1 { font-size: 56px; letter-spacing: -0.04em; }
+        h2 { font-size: 36px; }
+      }
+      p { margin: 0; }
+      .lead { font-size: var(--text-lg); color: var(--fg-2); line-height: var(--leading-body); }
+      .body-muted { color: var(--fg-2); }
+      .body-sm { font-size: var(--text-sm); }
+      .eyebrow {
+        font-family: var(--font-body);
+        font-size: 11px;
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.18em;
+        font-weight: 500;
+      }
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-5 > * + * { margin-block-start: var(--space-5); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+
+      /* ─── Buttons — pill shapes, no sharp corners ────────────── */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 10px 18px;
+        border-radius: var(--radius-pill); /* Pill — DESIGN.md: never sharp corners */
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        font-weight: 500;
+        line-height: 1;
+        cursor: pointer;
+        border: none;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard),
+          transform var(--motion-base) var(--ease-standard);
+        text-decoration: none;
+      }
+      .btn:active { transform: scale(0.97); }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+
+      /* Primary: solid white pill on void — DESIGN.md §4 primary CTA */
+      .btn-primary {
+        background: #ffffff;
+        color: #000000;
+      }
+      .btn-primary:hover { background: color-mix(in oklab, #ffffff, black 6%); }
+
+      /* Secondary: frosted glass pill on dark — DESIGN.md §4 frosted variant */
+      .btn-secondary {
+        background: rgba(255, 255, 255, 0.1);
+        color: var(--fg);
+        backdrop-filter: blur(8px);
+      }
+      .btn-secondary:hover { background: rgba(255, 255, 255, 0.18); }
+
+      /* ─── Inputs — dark surface, blue focus ring ─────────────── */
+      .field { display: flex; flex-direction: column; gap: var(--space-2); }
+      .field label { font-size: var(--text-sm); font-weight: 500; color: var(--fg); }
+      .field input {
+        padding: 12px 14px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border-soft);
+        background: var(--surface);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        outline: none;
+        transition:
+          border-color var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .field input::placeholder { color: var(--meta); }
+      .field input:hover { border-color: var(--border); }
+      .field input:focus-visible {
+        border-color: var(--accent);
+        box-shadow: var(--focus-ring);
+      }
+      .field-help { font-size: var(--text-xs); color: var(--muted); }
+
+      /* ─── Cards — near-black surface, Framer Blue ring shadow ── */
+      .card {
+        background: var(--surface);
+        border-radius: var(--radius-md);
+        padding: var(--space-6);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+        box-shadow: var(--elev-ring); /* Framer Blue 1px ring — the signature */
+        transition: box-shadow var(--motion-base) var(--ease-standard);
+      }
+      .card:hover {
+        box-shadow:
+          0 0 0 1px rgba(0, 153, 255, 0.28),
+          var(--elev-raised);
+      }
+      .card .card-eyebrow {
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        color: var(--accent);
+        letter-spacing: 0.04em;
+      }
+
+      /* ─── Badges ────────────────────────────────────────────── */
+      .badge {
+        display: inline-flex; align-items: center; gap: var(--space-2);
+        padding: 4px 10px;
+        border-radius: var(--radius-pill);
+        font-size: var(--text-xs); font-weight: 500; line-height: 1.4;
+      }
+      .badge-accent {
+        color: var(--accent);
+        background: color-mix(in oklab, var(--accent), transparent 88%);
+        box-shadow: inset 0 0 0 1px var(--border);
+      }
+      .badge-muted {
+        color: var(--muted);
+        background: rgba(255, 255, 255, 0.06);
+      }
+      .badge-dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
+
+      /* ─── Links ─────────────────────────────────────────────── */
+      a { color: var(--accent); text-decoration: none; }
+      a:hover { text-decoration: underline; text-underline-offset: 3px; }
+      kbd {
+        font-family: var(--font-mono); font-size: var(--text-xs);
+        padding: 2px 6px; border-radius: var(--radius-sm);
+        border: 1px solid var(--border); background: var(--surface); color: var(--fg-2);
+      }
+
+      /* ─── Layout helpers ────────────────────────────────────── */
+      .hero { display: flex; flex-direction: column; gap: var(--space-8); }
+      .hero-headline { max-width: 16ch; }
+      .hero-lead { max-width: 48ch; }
+      .hero-actions { display: flex; gap: var(--space-3); flex-wrap: wrap; }
+      .hero-meta {
+        display: flex; align-items: center; gap: var(--space-3);
+        margin-block-start: var(--space-6);
+        color: var(--meta); font-size: var(--text-sm);
+      }
+      .hero-divider { width: 4px; height: 4px; border-radius: 50%; background: var(--border-soft); }
+
+      .features-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--space-5); }
+      @media (max-width: 1199px) { .features-grid { grid-template-columns: 1fr 1fr; } }
+      @media (max-width: 809px) { .features-grid { grid-template-columns: 1fr; } }
+
+      .form-row { display: grid; grid-template-columns: 1.2fr 1fr; gap: var(--space-12); align-items: start; }
+      @media (max-width: 1199px) { .form-row { grid-template-columns: 1fr; } }
+      .form {
+        display: flex; flex-direction: column; gap: var(--space-4);
+        max-width: 460px;
+        padding: var(--space-6);
+        background: var(--surface);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--elev-raised); /* Floating elevated stack */
+      }
+      .form-actions { display: flex; gap: var(--space-3); margin-block-start: var(--space-2); }
+      .icon { width: 16px; height: 16px; flex-shrink: 0; }
+      .row-between { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); }
+
+      /* ─── Background glow — subtle blue radial behind hero ──── */
+      .hero-glow {
+        position: relative;
+        isolation: isolate;
+      }
+      .hero-glow::before {
+        content: "";
+        position: absolute;
+        inset: -10% -20% auto -20%;
+        height: 60%;
+        background: radial-gradient(50% 60% at 50% 0%, rgba(0, 153, 255, 0.15), transparent 70%);
+        z-index: -1;
+        pointer-events: none;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <section data-od-id="hero" class="hero-glow">
+        <div class="hero">
+          <div class="stack-6">
+            <p class="eyebrow">Reference fixture · framer</p>
+            <h1 class="hero-headline">The&nbsp;internet is your canvas.</h1>
+            <p class="lead hero-lead">
+              Design and ship production-grade sites without writing the
+              boilerplate. Every interaction, every breakpoint, every motion
+              curve — composed on the void, rendered to the open web.
+            </p>
+            <div class="hero-actions">
+              <a href="./tokens.css" class="btn btn-primary">
+                Start designing
+                <svg class="icon" viewBox="0 0 24 24" fill="none"
+                  stroke="currentColor" stroke-width="1.75"
+                  stroke-linecap="round" stroke-linejoin="round"
+                  aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+              </a>
+              <a href="./DESIGN.md" class="btn btn-secondary">Read the spec</a>
+            </div>
+          </div>
+          <div class="hero-meta">
+            <span>v1.0</span>
+            <span class="hero-divider" aria-hidden="true"></span>
+            <span>Press <kbd>⌘</kbd> <kbd>K</kbd> to search tokens</span>
+            <span class="hero-divider" aria-hidden="true"></span>
+            <span class="badge badge-accent">
+              <span class="badge-dot" aria-hidden="true"></span>
+              Live preview
+            </span>
+          </div>
+        </div>
+      </section>
+
+      <section data-od-id="features">
+        <div class="stack-4">
+          <p class="eyebrow">What this fixture exercises</p>
+          <h2 style="max-width: 18ch">Craft is the product, polish is the proof.</h2>
+        </div>
+        <div class="features-grid" style="margin-block-start: var(--space-8)">
+          <article class="card">
+            <span class="card-eyebrow">01 · CANVAS</span>
+            <h3>Pure void, no compromise.</h3>
+            <p class="body-muted body-sm">
+              --bg (#000000) → --surface (#090909) → --accent (#0099ff).
+              Absolute black is the foundation — never charcoal, never
+              brown-tinted dark gray. The void is the design.
+            </p>
+            <a href="./tokens.css" class="body-sm">Inspect surface tokens →</a>
+          </article>
+          <article class="card">
+            <span class="card-eyebrow">02 · TYPE</span>
+            <h3>Compressed, spring-loaded.</h3>
+            <p class="body-muted body-sm">
+              GT Walsheim Medium at -0.05em tracking gives display
+              text the breathless density Framer is known for. Inter
+              for body, with six OpenType features for refined micro-type.
+            </p>
+            <a href="./DESIGN.md" class="body-sm">Read the typography rules →</a>
+          </article>
+          <article class="card">
+            <span class="card-eyebrow">03 · DEPTH</span>
+            <h3>Blue rings, white edges.</h3>
+            <p class="body-muted body-sm">
+              Cards are contained by a 1px Framer Blue ring shadow
+              (rgba(0, 153, 255, 0.15)) — depth comes from light tints,
+              not from heavy drop shadows. The blue is the brand.
+            </p>
+            <a href="./tokens.css" class="body-sm">Inspect elevation →</a>
+          </article>
+        </div>
+      </section>
+
+      <section data-od-id="form">
+        <div class="form-row">
+          <div class="stack-5">
+            <p class="eyebrow">Form components</p>
+            <h2>Inputs in the void.</h2>
+            <p class="body-muted" style="max-width: 44ch">
+              Form fields sit on the near-black surface with subtle
+              translucent borders. Focus lights up the Framer Blue ring —
+              a halo, not a hard edge, so the void stays sacred even
+              while you type.
+            </p>
+            <div class="row-between" style="max-width: 44ch">
+              <span class="badge badge-muted">
+                <span class="badge-dot" aria-hidden="true"></span>
+                No tracking
+              </span>
+              <span class="body-sm" style="color: var(--meta)">Updated <time datetime="2026-05-18">2026-05-18</time></span>
+            </div>
+          </div>
+          <form class="form" onsubmit="event.preventDefault();">
+            <div class="field">
+              <label for="email">Work email</label>
+              <input id="email" type="email" placeholder="you@studio.com" autocomplete="email" required />
+              <p class="field-help">We'll send a beta invite and nothing else.</p>
+            </div>
+            <div class="field">
+              <label for="project">Project name</label>
+              <input id="project" type="text" placeholder="Untitled canvas" autocomplete="off" />
+              <p class="field-help">You can rename it any time from the editor.</p>
+            </div>
+            <div class="form-actions">
+              <button type="submit" class="btn btn-primary">Request access</button>
+              <button type="button" class="btn btn-secondary">View showcase</button>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/framer/tokens.css
+++ b/design-systems/framer/tokens.css
@@ -1,0 +1,238 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/framer/tokens.css
+ *
+ * Structured token bindings for "Design System Inspired by Framer".
+ * Pure black void canvas, Framer Blue accent, GT Walsheim display with
+ * extreme negative letter-spacing, Inter body with OpenType features,
+ * and a blue-tinted ring-shadow elevation system.
+ *
+ * Brand-specific schema decisions (each one bends a schema convention
+ * to match Framer's voice rather than the cross-brand default):
+ *
+ *   1. `--bg` is `#000000` (Void Black). DESIGN.md §1 names this as
+ *      "absolute void, not warm or gray-tinted" — Framer's identity
+ *      hinges on pure black. `#0a0a0a` or any near-black tint reads
+ *      as a generic dark theme; the void IS the brand. `--surface`
+ *      sits at `#090909` (Near Black) for elevated dark surfaces.
+ *
+ *   2. `--border` is `rgba(0, 153, 255, 0.15)` — the literal Framer
+ *      Blue ring-shadow alpha. DESIGN.md §6 Level 1 names this single
+ *      value as the "Framer Blue glow ring" used for card containment.
+ *      Binding `--border` to the blue alpha lets `--elev-ring`
+ *      (`0 0 0 1px var(--border)`) reproduce Framer's signature blue
+ *      hairline by default. `--border-soft` drops to a translucent
+ *      white for inner row separators that should not light up.
+ *
+ *   3. `--accent` is Framer Blue (`#0099ff`), the one-and-only chromatic
+ *      move. DESIGN.md §2 forbids decorative use ("one-accent-color
+ *      system"). Primary CTAs in Framer are SOLID WHITE, not blue —
+ *      the components.html encodes that by using `#ffffff` as the
+ *      primary button background, so `--accent` stays reserved for
+ *      links, borders, focus rings, and the chromatic moments where
+ *      blue actually appears.
+ *
+ *   4. Type scale climbs to 110px (`--text-4xl`) — the GT Walsheim
+ *      display hero size from DESIGN.md §3. `--leading-tight` drops
+ *      to `0.95` (the section-display tier) so headings across the
+ *      scale read compressed-but-not-overlapping; the most extreme
+ *      0.85 line-height is reserved for the display hero h1 inline.
+ *      `--tracking-display` is `-0.05em`, the em-relative form of
+ *      "-5.5px at 110px" that scales proportionally with size.
+ *
+ *   5. Section rhythm is generous: `120px` desktop, `80px` tablet,
+ *      `60px` phone. DESIGN.md §5 describes "80–120px between sections"
+ *      with whitespace manifesting as "void" — the black background
+ *      means generous padding reads as dramatic pause, not as wasted
+ *      space. Container caps at `1200px` per DESIGN.md §5.
+ *
+ *   6. `--radius-sm: 8px` (DESIGN.md §5: standard component radius
+ *      for code blocks / buttons / interactive elements). Pill
+ *      buttons go via `--radius-pill` and override locally — the
+ *      40px–100px pill range from DESIGN.md is button-specific and
+ *      not part of the shared schema.
+ *
+ *   7. `--elev-raised` reproduces the multi-layer Framer card stack
+ *      from DESIGN.md §6 Level 3 verbatim: a 0.5px white top-edge
+ *      highlight (simulating light hitting the top surface) plus a
+ *      deep ambient 30px shadow (true floating depth). Never drop
+ *      either layer when overriding — both are required for the
+ *      "built-not-pasted-onto-page" quality DESIGN.md describes.
+ *
+ *   8. Foreground ramp binds all four tiers (#ffffff →
+ *      rgba(255,255,255,0.6) → rgba(255,255,255,0.4)) so cross-brand
+ *      components targeting `--fg-2`, `--muted`, or `--meta` resolve
+ *      to Framer's actual ghost-white tiers instead of collapsing.
+ *      `--fg-2` binds to Muted Silver (#a6a6a6), the documented
+ *      secondary text color from DESIGN.md §2.
+ *
+ * Source contracts:
+ *   - Standard token names: design-systems/_schema/tokens.schema.ts
+ *   - A2 fallback parity:   design-systems/_schema/defaults.css
+ *   - Lint enforcement:     apps/daemon/src/lint-artifact.ts
+ *
+ * Keep this file additive: never invent token names not also
+ * documented in DESIGN.md or the schema. GT Walsheim / Inter / Azeret
+ * Mono are not bundled — the font stacks list system fallbacks so
+ * artifacts render acceptably even when the custom faces are not
+ * loaded, and any host that wants the real faces links them externally.
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface ─────────────────────────────────────────────────────
+   * The void: pure black canvas with a near-black elevated surface.
+   * No warm tier — `--surface-warm` aliases to surface because the
+   * brand explicitly forbids tinted backgrounds (DESIGN.md §7 don't:
+   * "no warm dark backgrounds, no charcoal, no brownish blacks"). */
+  --bg: #000000;                       /* Void Black — the foundation canvas */
+  --surface: #090909;                  /* Near Black — elevated dark surface */
+  --surface-warm: var(--surface);      /* alias — Framer has no warm tier */
+
+  /* ─── Foreground ramp (4 levels) ──────────────────────────────────
+   * Pure white headings, muted silver body, ghost white tertiary,
+   * fainter placeholder/disabled. `--fg-2` and `--muted` and `--meta`
+   * are independently bound (not aliased) because Framer genuinely
+   * uses distinct text tiers across heading, body, caption, and
+   * placeholder per DESIGN.md §2. */
+  --fg: #ffffff;                       /* Pure White — headings, primary text */
+  --fg-2: #a6a6a6;                     /* Muted Silver — body description */
+  --muted: rgba(255, 255, 255, 0.6);   /* Ghost White — captions, tertiary */
+  --meta: rgba(255, 255, 255, 0.4);    /* Faint White — placeholders, disabled */
+
+  /* ─── Border ──────────────────────────────────────────────────────
+   * Blue ring-shadow as border is THE signature: `rgba(0, 153, 255,
+   * 0.15)` at 1px spread is the literal Framer Blue glow ring from
+   * DESIGN.md §6 Level 1. Binding `--border` to the blue alpha (not
+   * a solid hex) lets `--elev-ring` reproduce Framer's hairline by
+   * default. `--border-soft` drops to a translucent white for inner
+   * row separators that should not light up the section. */
+  --border: rgba(0, 153, 255, 0.15);   /* signature Framer Blue ring alpha */
+  --border-soft: rgba(255, 255, 255, 0.06); /* inner separator on dark */
+
+  /* ─── Accent ──────────────────────────────────────────────────────
+   * Framer Blue — the cold, electric one-accent-color of the system.
+   * DESIGN.md §2 forbids decorative use ("one-accent-color system").
+   * Used in links, ring borders, focus rings, and badge tints.
+   *
+   * Primary CTAs in Framer are SOLID WHITE PILL on black, not blue.
+   * components.html encodes that pattern via `background: #ffffff`
+   * on the primary button, so `--accent` stays reserved for the
+   * chromatic moments where blue actually appears. */
+  --accent: #0099ff;                   /* Framer Blue */
+  --accent-on: #ffffff;                /* white label when --accent is bg */
+  --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+  /* ─── Semantic ────────────────────────────────────────────────────
+   * Framer's marketing surface rarely renders state. Inherit schema
+   * defaults — the brand has no defined success/warn/danger palette
+   * of its own; the only declared color is Framer Blue. */
+  --success: #16a34a;
+  --warn: #eab308;
+  --danger: #dc2626;
+
+  /* ─── Typography ──────────────────────────────────────────────────
+   * GT Walsheim Medium for display, Inter for body, Azeret Mono for
+   * code. All three lead with the custom faces and fall back to
+   * system sans/mono so artifacts render legibly even when the
+   * Framer-licensed fonts are not loaded. */
+  --font-display: "GT Walsheim Framer Medium", "GT Walsheim Medium", "GT Walsheim", -apple-system, "Segoe UI", Inter, sans-serif;
+  --font-body: "Inter Variable", "Inter", -apple-system, "Segoe UI", Arial, sans-serif;
+  --font-mono: "Azeret Mono", ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+
+  /* Type scale (px) — DESIGN.md §3. Tops out at 110px display hero;
+   * Framer reads HUGE because GT Walsheim at extreme negative tracking
+   * compresses the headline into a spring-loaded block. */
+  --text-xs: 12px;                     /* Small Caption */
+  --text-sm: 14px;                     /* Caption / Label */
+  --text-base: 15px;                   /* Body / Nav / UI */
+  --text-lg: 18px;                     /* Body Large */
+  --text-xl: 22px;                     /* Feature Title */
+  --text-2xl: 32px;                    /* Feature Heading */
+  --text-3xl: 62px;                    /* Section Heading */
+  --text-4xl: 110px;                   /* Display Hero — spring-loaded */
+
+  /* `--leading-tight: 0.95` sits at the Section-Display tier from
+   * DESIGN.md §3. The most extreme 0.85 line-height is reserved for
+   * the display hero h1 (applied inline in components.html).
+   * `--tracking-display: -0.05em` is the em-relative form of
+   * "-5.5px at 110px" — letter-spacing in em scales proportionally
+   * with size, matching DESIGN.md §3's principle that tracking
+   * scales with font size. */
+  --leading-body: 1.3;
+  --leading-tight: 0.95;
+  --tracking-display: -0.05em;
+
+  /* ─── Spacing ─────────────────────────────────────────────────────
+   * 4/8-grid base scale per DESIGN.md §5. The 1/2/3/5/6/10/15/20/30/
+   * 35px sub-tier increments from DESIGN.md are inlined per-component
+   * because they are too fine to belong in the shared schema. */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+
+  /* Section rhythm — DESIGN.md §5: "80–120px between sections" desktop,
+   * "120px desktop → 60px mobile" per §8 collapsing strategy. We sit
+   * at the upper end of the desktop range (120px) so whitespace reads
+   * as dramatic void, drop to 80px on tablet, and 60px on phone (the
+   * documented mobile floor). */
+  --section-y-desktop: 120px;
+  --section-y-tablet: 80px;
+  --section-y-phone: 60px;
+
+  /* ─── Radius ──────────────────────────────────────────────────────
+   * DESIGN.md §5 radius scale: 1/5–7/8/10–12/15–20/30–40/100. We bind
+   * the four schema tiers to: 8 (button/input/code-block), 12 (cards
+   * and product screenshots), 20 (large containers), 9999 (full pill).
+   * The 40px–100px pill-button range from DESIGN.md is button-specific
+   * and is reached via `--radius-pill` with a local override. */
+  --radius-sm: 8px;                    /* buttons, inputs, code blocks */
+  --radius-md: 12px;                   /* cards, product screenshots */
+  --radius-lg: 20px;                   /* large containers, feature cards */
+  --radius-pill: 9999px;               /* full pill — CTAs, tag elements */
+
+  /* ─── Elevation (3 levels) ────────────────────────────────────────
+   * Framer's depth system is shadow-led, not blur-led. Three levels:
+   *
+   *   --elev-flat    no shadow (page background, void areas)
+   *   --elev-ring    the signature Framer Blue 1px ring (most cards)
+   *   --elev-raised  the multi-layer floating stack (DESIGN.md §6 L3)
+   *
+   * `--elev-raised` is reproduced VERBATIM from DESIGN.md §6 Level 3:
+   *   0.5px white top-edge highlight (light hitting the top surface)
+   *   30px deep ambient shadow at 0.25 alpha (true floating depth)
+   * Never drop either layer when overriding — both are required for
+   * the "floating not pasted-on" quality of Framer's elevated cards. */
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised:
+    0 0.5px 0 0.5px rgba(255, 255, 255, 0.1),
+    0 10px 30px rgba(0, 0, 0, 0.25);
+
+  /* ─── Focus ring ──────────────────────────────────────────────────
+   * Blue glow halo — `rgba(0, 153, 255, 0.15)` (Blue Glow) is the
+   * Framer focus tint per DESIGN.md §2. We reproduce it as a 3px
+   * alpha ring at `var(--accent)` so the halo softens around inputs
+   * without overpowering the void canvas. */
+  --focus-ring: 0 0 0 3px color-mix(in oklab, var(--accent), transparent 70%);
+
+  /* ─── Motion ──────────────────────────────────────────────────────
+   * Standard durations + standard easing. Framer's boldness is in
+   * type, color, and product polish — never in long-form animation. */
+  --motion-fast: 150ms;
+  --motion-base: 200ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+  /* ─── Layout ──────────────────────────────────────────────────────
+   * ~1200px max content width per DESIGN.md §5. Gutters narrow on
+   * mobile so the void surrounding content stays generous on phones
+   * without crushing the dramatic margin. */
+  --container-max: 1200px;
+  --container-gutter-desktop: 24px;
+  --container-gutter-tablet: 16px;
+  --container-gutter-phone: 12px;
+}

--- a/design-systems/loom/components.html
+++ b/design-systems/loom/components.html
@@ -1,0 +1,446 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Loom — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/loom. Async video for work:
+        signature purple #625df5, soft 4/6/8 px geometry, Inter typography,
+        shadow-only depth, video-thumbnail-centric layout."
+    />
+
+    <style>
+      :root {
+        --bg: #ffffff;
+        --surface: #f7f7f8;
+        --surface-warm: var(--surface);
+
+        --fg: #1f1f23;
+        --fg-2: var(--fg);
+        --muted: #6b6d76;
+        --meta: #9b9ca3;
+
+        --border: #e4e4e7;
+        --border-soft: var(--border);
+
+        --accent: #625df5;
+        --accent-on: #ffffff;
+        --accent-hover: #5048e5;
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+        --success: #16a34a;
+        --warn: #eab308;
+        --danger: #d64770;
+
+        --font-display: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+        --font-body: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+        --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+
+        --text-xs: 11px;
+        --text-sm: 12px;
+        --text-base: 14px;
+        --text-lg: 16px;
+        --text-xl: 18px;
+        --text-2xl: 22px;
+        --text-3xl: 28px;
+        --text-4xl: 40px;
+
+        --leading-body: 1.5;
+        --leading-tight: 1.2;
+        --tracking-display: -0.01em;
+
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 72px;
+        --section-y-tablet: 48px;
+        --section-y-phone: 32px;
+
+        --radius-sm: 4px;
+        --radius-md: 6px;
+        --radius-lg: 8px;
+        --radius-pill: 9999px;
+
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised: 0 1px 3px rgba(31, 31, 35, 0.08), 0 4px 12px rgba(31, 31, 35, 0.04);
+
+        --focus-ring: 0 0 0 3px color-mix(in oklab, var(--accent), transparent 85%);
+
+        --motion-fast: 100ms;
+        --motion-base: 200ms;
+        --ease-standard: cubic-bezier(0.22, 1, 0.36, 1);
+
+        --container-max: 1200px;
+        --container-gutter-desktop: 24px;
+        --container-gutter-tablet: 20px;
+        --container-gutter-phone: 16px;
+      }
+
+      /* ─── Reset ─────────────────────────────────────────────── */
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+
+      /* ─── Layout ─────────────────────────────────────────────── */
+      .container { max-width: var(--container-max); margin-inline: auto; padding-inline: var(--container-gutter-desktop); }
+      section { padding-block: var(--section-y-desktop); }
+      section + section { border-top: 1px solid var(--border); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography — Inter, moderate weight contrast ─────── */
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        line-height: var(--leading-tight);
+        margin: 0;
+        color: var(--fg);
+      }
+      h1 { font-size: var(--text-4xl); font-weight: 700; letter-spacing: var(--tracking-display); }
+      h2 { font-size: var(--text-2xl); font-weight: 600; letter-spacing: var(--tracking-display); }
+      h3 { font-size: var(--text-xl); font-weight: 600; }
+      p { margin: 0; }
+      .lead { font-size: var(--text-lg); color: var(--muted); line-height: var(--leading-body); }
+      .body-muted { color: var(--muted); }
+      .body-sm { font-size: var(--text-sm); }
+      .meta { color: var(--meta); font-size: var(--text-xs); }
+      .eyebrow {
+        font-size: var(--text-xs);
+        color: var(--accent);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 600;
+      }
+      .stack-2 > * + * { margin-block-start: var(--space-2); }
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+
+      /* ─── Buttons — 6px corners, friendly motion ───────────── */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 10px var(--space-4);
+        border-radius: var(--radius-md);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        font-weight: 500;
+        line-height: var(--leading-tight);
+        cursor: pointer;
+        border: 1px solid transparent;
+        transition: background-color var(--motion-fast) var(--ease-standard),
+                    color var(--motion-fast) var(--ease-standard),
+                    border-color var(--motion-fast) var(--ease-standard),
+                    box-shadow var(--motion-fast) var(--ease-standard);
+        text-decoration: none;
+        min-height: 44px;
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn:active { transform: translateY(0); }
+      .btn-primary {
+        background: var(--accent);
+        color: var(--accent-on);
+      }
+      .btn-primary:hover { background: var(--accent-hover); }
+      .btn-primary:active { background: var(--accent-active); }
+      .btn-secondary {
+        background: var(--surface);
+        color: var(--fg);
+        border-color: var(--border);
+      }
+      .btn-secondary:hover { background: color-mix(in oklab, var(--surface), black 4%); }
+
+      /* ─── Inputs — 4px corners, purple focus ring ──────────── */
+      .field { display: flex; flex-direction: column; gap: var(--space-2); }
+      .field label { font-size: var(--text-sm); font-weight: 500; color: var(--fg); }
+      .field input {
+        padding: 10px var(--space-3);
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-tight);
+        min-height: 44px;
+        outline: none;
+        transition: border-color var(--motion-fast) var(--ease-standard),
+                    box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .field input:focus-visible {
+        border-color: var(--accent);
+        box-shadow: var(--focus-ring);
+      }
+      .field input::placeholder { color: var(--meta); }
+      .field-help { font-size: var(--text-xs); color: var(--muted); }
+
+      /* ─── Cards — shadow-only depth, 8px radius ────────────── */
+      .card {
+        background: var(--bg);
+        border-radius: var(--radius-lg);
+        padding: var(--space-6);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+        box-shadow: var(--elev-raised);
+        transition: transform var(--motion-base) var(--ease-standard),
+                    box-shadow var(--motion-base) var(--ease-standard);
+      }
+      .card:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 12px rgba(31, 31, 35, 0.12), 0 8px 24px rgba(31, 31, 35, 0.08);
+      }
+
+      /* ─── Thumbnail — video-first ─────────────────────────── */
+      .thumbnail {
+        position: relative;
+        aspect-ratio: 16 / 10;
+        border-radius: var(--radius-lg);
+        overflow: hidden;
+        background:
+          radial-gradient(120% 90% at 20% 0%, color-mix(in oklab, var(--accent), white 20%) 0%, transparent 55%),
+          linear-gradient(135deg, var(--accent) 0%, color-mix(in oklab, var(--accent), black 30%) 100%);
+        box-shadow: var(--elev-raised);
+      }
+      .thumbnail-play {
+        position: absolute; inset: 0;
+        display: grid; place-items: center;
+      }
+      .thumbnail-play-circle {
+        width: 64px; height: 64px;
+        border-radius: var(--radius-pill);
+        background: rgba(255, 255, 255, 0.95);
+        display: grid; place-items: center;
+        color: var(--accent);
+        box-shadow: 0 8px 24px rgba(31, 31, 35, 0.18);
+      }
+      .thumbnail-meta {
+        position: absolute; left: var(--space-3); bottom: var(--space-3);
+        display: inline-flex; align-items: center; gap: var(--space-2);
+        padding: var(--space-1) var(--space-2);
+        border-radius: var(--radius-sm);
+        background: rgba(31, 31, 35, 0.72);
+        color: #ffffff;
+        font-size: var(--text-xs);
+        font-family: var(--font-mono);
+        letter-spacing: 0.02em;
+      }
+
+      /* ─── Badges & dots ────────────────────────────────────── */
+      .badge {
+        display: inline-flex; align-items: center; gap: var(--space-2);
+        padding: 3px var(--space-2);
+        border-radius: var(--radius-pill);
+        font-size: var(--text-xs);
+        font-weight: 500;
+        line-height: 1.6;
+      }
+      .badge-recording { color: var(--danger); background: color-mix(in oklab, var(--danger), transparent 88%); }
+      .badge-muted { color: var(--muted); background: var(--surface); border: 1px solid var(--border); }
+      .badge-dot { width: 8px; height: 8px; border-radius: var(--radius-pill); background: currentColor; }
+
+      /* ─── Links ────────────────────────────────────────────── */
+      a { color: var(--accent); text-decoration: none; }
+      a:hover { color: var(--accent-hover); text-decoration: underline; text-underline-offset: 3px; }
+      kbd {
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        padding: 2px 6px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+        background: var(--surface);
+        color: var(--muted);
+      }
+
+      /* ─── Layout helpers ──────────────────────────────────── */
+      .hero-grid {
+        display: grid;
+        grid-template-columns: 1.05fr 1fr;
+        gap: var(--space-12);
+        align-items: center;
+      }
+      @media (max-width: 1023px) { .hero-grid { grid-template-columns: 1fr; gap: var(--space-8); } }
+      .hero-actions { display: flex; gap: var(--space-3); margin-block-start: var(--space-6); flex-wrap: wrap; }
+      .features-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--space-5); }
+      @media (max-width: 1023px) { .features-grid { grid-template-columns: 1fr 1fr; } }
+      @media (max-width: 639px) { .features-grid { grid-template-columns: 1fr; } }
+      .form-row { display: grid; grid-template-columns: 1.2fr 1fr; gap: var(--space-12); align-items: start; }
+      @media (max-width: 1023px) { .form-row { grid-template-columns: 1fr; } }
+      .form { display: flex; flex-direction: column; gap: var(--space-4); max-width: 420px; }
+      .form-actions { display: flex; gap: var(--space-3); margin-block-start: var(--space-2); }
+      .icon { width: 16px; height: 16px; flex-shrink: 0; }
+      .row-between { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); }
+      .feature-icon {
+        width: 36px; height: 36px;
+        display: grid; place-items: center;
+        border-radius: var(--radius-md);
+        background: color-mix(in oklab, var(--accent), transparent 88%);
+        color: var(--accent);
+      }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <section data-od-id="hero">
+        <div class="hero-grid">
+          <div class="stack-4">
+            <p class="eyebrow">Reference fixture · loom</p>
+            <h1>Async video for work that actually moves.</h1>
+            <p class="lead" style="max-width: 52ch">
+              Record your screen, your voice, and your face in one click. Send a Loom
+              instead of scheduling a meeting — your teammates watch when it fits their day.
+            </p>
+            <div class="hero-actions">
+              <a href="./tokens.css" class="btn btn-primary">
+                <svg class="icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                  <circle cx="12" cy="12" r="6" />
+                </svg>
+                Record a video
+              </a>
+              <a href="./DESIGN.md" class="btn btn-secondary">
+                Watch a demo
+                <svg class="icon" viewBox="0 0 24 24" fill="none"
+                  stroke="currentColor" stroke-width="1.75"
+                  stroke-linecap="round" stroke-linejoin="round"
+                  aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+              </a>
+            </div>
+            <p class="meta" style="margin-block-start: var(--space-4)">
+              Press <kbd>⇧</kbd> <kbd>⌘</kbd> <kbd>L</kbd> anywhere to start a new recording.
+            </p>
+          </div>
+
+          <figure class="thumbnail" aria-label="Loom video thumbnail preview">
+            <div class="thumbnail-play">
+              <span class="thumbnail-play-circle" aria-hidden="true">
+                <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                  <path d="M8 5v14l11-7z"/>
+                </svg>
+              </span>
+            </div>
+            <figcaption class="thumbnail-meta">
+              <span class="badge badge-recording" style="background: rgba(214, 71, 112, 0.18); color: #ffffff">
+                <span class="badge-dot" aria-hidden="true"></span>
+                REC
+              </span>
+              02:14 · Q3 product review
+            </figcaption>
+          </figure>
+        </div>
+      </section>
+
+      <section data-od-id="features">
+        <div class="stack-3">
+          <p class="eyebrow">Why teams send a Loom instead</p>
+          <h2 style="max-width: 26ch">Show, don't type. Loom replaces the meeting that should have been an email.</h2>
+        </div>
+        <div class="features-grid" style="margin-block-start: var(--space-8)">
+          <article class="card">
+            <span class="feature-icon" aria-hidden="true">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none"
+                stroke="currentColor" stroke-width="1.75"
+                stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="12" r="9"/>
+                <circle cx="12" cy="12" r="3.5" fill="currentColor"/>
+              </svg>
+            </span>
+            <h3>Press record. Get back to work.</h3>
+            <p class="body-muted body-sm">
+              One keyboard shortcut, no setup. Loom captures your screen and camera and
+              uploads while you keep typing — the link is in your clipboard before the
+              recording stops processing.
+            </p>
+            <a href="./tokens.css" class="body-sm">See the shortcut →</a>
+          </article>
+          <article class="card">
+            <span class="feature-icon" aria-hidden="true">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none"
+                stroke="currentColor" stroke-width="1.75"
+                stroke-linecap="round" stroke-linejoin="round">
+                <rect x="3" y="6" width="14" height="12" rx="2"/>
+                <path d="M17 10l4-2v8l-4-2z"/>
+              </svg>
+            </span>
+            <h3>Watched on their time, not yours.</h3>
+            <p class="body-muted body-sm">
+              Viewers can speed up, jump chapters, react with an emoji, or reply with a
+              comment threaded to the exact second. Async by default — no calendar
+              gymnastics across timezones.
+            </p>
+            <a href="./DESIGN.md" class="body-sm">Read the rationale →</a>
+          </article>
+          <article class="card">
+            <span class="feature-icon" aria-hidden="true">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none"
+                stroke="currentColor" stroke-width="1.75"
+                stroke-linecap="round" stroke-linejoin="round">
+                <path d="M4 6h12a4 4 0 010 8H8l-4 4V6z"/>
+              </svg>
+            </span>
+            <h3>Friendly by default.</h3>
+            <p class="body-muted body-sm">
+              Soft 8px cards, Inter type, the signature purple — Loom feels like a
+              well-made productivity app, not enterprise software. Approachable,
+              clean, professional without ever being corporate.
+            </p>
+            <a href="./tokens.css" class="body-sm">Inspect the system →</a>
+          </article>
+        </div>
+      </section>
+
+      <section data-od-id="form">
+        <div class="form-row">
+          <div class="stack-4">
+            <p class="eyebrow">Get the desktop app</p>
+            <h2>Install Loom in under a minute.</h2>
+            <p class="body-muted" style="max-width: 48ch">
+              The desktop app gives you global hotkeys, multi-monitor capture, and
+              instant uploads. Drop your work email and we'll send a download link —
+              no marketing follow-ups.
+            </p>
+            <div class="row-between" style="max-width: 360px">
+              <span class="badge badge-muted">
+                <span class="badge-dot" style="color: var(--success)" aria-hidden="true"></span>
+                macOS, Windows, Linux
+              </span>
+              <span class="meta">v2.4 · 38 MB</span>
+            </div>
+          </div>
+          <form class="form" onsubmit="event.preventDefault();">
+            <div class="field">
+              <label for="email">Work email</label>
+              <input id="email" type="email" placeholder="you@company.com" autocomplete="email" required />
+              <p class="field-help">We'll send a download link and nothing else.</p>
+            </div>
+            <div class="form-actions">
+              <button type="submit" class="btn btn-primary">Get the app</button>
+              <button type="button" class="btn btn-secondary">Use in browser</button>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/loom/tokens.css
+++ b/design-systems/loom/tokens.css
@@ -1,0 +1,138 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/loom/tokens.css
+ *
+ * Structured token bindings for "Design System Inspired by Loom".
+ * Async video for work: bright neutral canvas, signature purple (#625df5),
+ * soft-rounded geometry, Inter typography, video-thumbnail-centric layouts.
+ *
+ * Key brand decisions encoded here:
+ *   - Pure white (#ffffff) canvas with cool-neutral Snow (#f7f7f8) surfaces
+ *   - Loom Purple (#625df5) — signals creativity and "record" without shouting
+ *   - Three-tier text stack: ink #1f1f23 → slate #6b6d76 → mist #9b9ca3
+ *   - Soft-rounded geometry: 4 / 6 / 8 px ladder — friendly, not corporate
+ *   - Inter throughout with broad system fallback — system-native if Inter absent
+ *   - Shadow-only depth (DESIGN.md §6 forbids borders on cards)
+ *   - 200ms ease-out card hover, 100ms button press (DESIGN.md §9)
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface ─────────────────────────────────────────────────────
+   * Bright white canvas — Loom is used in office light. Snow surfaces
+   * are cool-neutral, never warm — keeps focus on the video frame. */
+  --bg: #ffffff;
+  --surface: #f7f7f8;        /* Snow — sidebars, cards, lifted panels */
+  --surface-warm: var(--surface); /* alias — no warm tier in the cool-neutral palette */
+
+  /* ─── Foreground ──────────────────────────────────────────────────
+   * Three text tiers: ink for primary, slate for metadata, mist
+   * reserved for placeholders / disabled (DESIGN.md §7 forbids it
+   * for body copy). --fg-2 collapses to --fg — Loom uses a single
+   * emphatic text weight on headings, not a softer secondary. */
+  --fg: #1f1f23;             /* Ink — primary text, all headings */
+  --fg-2: var(--fg);         /* alias — single emphatic text tier */
+  --muted: #6b6d76;          /* Slate — timestamps, secondary copy (4.5:1 on white) */
+  --meta: #9b9ca3;           /* Mist — placeholders, disabled, micro-metadata only */
+
+  /* ─── Border ──────────────────────────────────────────────────────
+   * Cool light gray — present enough to delineate inputs without
+   * stealing focus from the video thumbnail. Cards rely on shadow
+   * instead of border (DESIGN.md §6). */
+  --border: #e4e4e7;
+  --border-soft: var(--border); /* alias — single border tier */
+
+  /* ─── Accent ──────────────────────────────────────────────────────
+   * Loom Purple — the brand's emotional center. Used for CTAs,
+   * the record button, active states, and video-progress fills. */
+  --accent: #625df5;
+  --accent-on: #ffffff;
+  --accent-hover: #5048e5;   /* DESIGN.md §2 — explicit hover binding */
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+  /* ─── Semantic ────────────────────────────────────────────────────
+   * Loom's danger is a pink-leaning red (#d64770) chosen to live
+   * peacefully with the purple accent. DESIGN.md §7 warns it must
+   * pair with a light surface — never use as body text on white. */
+  --success: #16a34a;
+  --warn: #eab308;
+  --danger: #d64770;         /* Loom Error — use only with tinted surface */
+
+  /* ─── Typography ──────────────────────────────────────────────────
+   * Inter throughout, with broad system fallbacks so the friendly
+   * geometric sans appears even before web-font load. Mono stack
+   * matches DESIGN.md §3 byte-for-byte (SFMono-Regular, no JetBrains). */
+  --font-display: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  --font-body: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+
+  /* Type scale — derived from DESIGN.md §3 (11/12/14/18/22/28).
+   * --text-lg interpolated at 16px (featured body / intro paragraphs).
+   * --text-4xl extended to 40px for marketing hero surfaces — product
+   * UI tops out at the 28px Display tier called out in DESIGN.md. */
+  --text-xs: 11px;           /* Micro — keyboard hints, status chips */
+  --text-sm: 12px;           /* Caption — timestamps, helper text */
+  --text-base: 14px;         /* Body / Button (DESIGN.md baseline) */
+  --text-lg: 16px;           /* Featured body — intro paragraphs */
+  --text-xl: 18px;           /* H2 — feature titles */
+  --text-2xl: 22px;          /* H1 — section heading */
+  --text-3xl: 28px;          /* Display — DESIGN.md ceiling for product UI */
+  --text-4xl: 40px;          /* Hero — marketing-surface extension */
+
+  --leading-body: 1.5;       /* DESIGN.md body */
+  --leading-tight: 1.2;      /* DESIGN.md display / button (§7 forbids 1.0) */
+  --tracking-display: -0.01em; /* Subtle — Inter is friendly, not aggressive */
+
+  /* ─── Spacing ─────────────────────────────────────────────────────
+   * 4 / 8 base unit. Loom's signature rhythm is the 16px gap
+   * (--space-4) called out explicitly in DESIGN.md §5. */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+
+  /* ─── Section rhythm ──────────────────────────────────────────────
+   * Generous whitespace — Loom is content-first, never crowded.
+   * Sits between Cohere's 60px and Mistral's 80px. */
+  --section-y-desktop: 72px;
+  --section-y-tablet: 48px;
+  --section-y-phone: 32px;
+
+  /* ─── Radius ──────────────────────────────────────────────────────
+   * The 4 / 6 / 8 ladder IS the Loom geometry signature: friendly
+   * without being childish. DESIGN.md §4 binds each tier explicitly:
+   *   sm 4px → inputs · md 6px → buttons · lg 8px → cards / thumbnails */
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --radius-pill: 9999px;     /* Avatars, status dots, badges */
+
+  /* ─── Elevation ───────────────────────────────────────────────────
+   * Two-layer shadow gives lifted feel without harsh edges. Values
+   * match DESIGN.md §2 --shadow-card byte-for-byte. */
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised: 0 1px 3px rgba(31, 31, 35, 0.08), 0 4px 12px rgba(31, 31, 35, 0.04);
+
+  /* ─── Focus ring ──────────────────────────────────────────────────
+   * 3px purple halo at ~15% — DESIGN.md §4 input-field spec.
+   * color-mix(transparent 85%) ≈ rgba(98, 93, 245, 0.15). */
+  --focus-ring: 0 0 0 3px color-mix(in oklab, var(--accent), transparent 85%);
+
+  /* ─── Motion ──────────────────────────────────────────────────────
+   * Ease-out throughout (DESIGN.md §9): 100ms button press,
+   * 200ms card hover. Snappy but not sudden — async tool feel. */
+  --motion-fast: 100ms;
+  --motion-base: 200ms;
+  --ease-standard: cubic-bezier(0.22, 1, 0.36, 1);
+
+  /* ─── Layout ──────────────────────────────────────────────────────
+   * 1200px container — comfortable for two-up video grids without
+   * pushing thumbnails to the edge. Gutters scale gently. */
+  --container-max: 1200px;
+  --container-gutter-desktop: 24px;
+  --container-gutter-tablet: 20px;
+  --container-gutter-phone: 16px;
+}

--- a/design-systems/meta/components.html
+++ b/design-systems/meta/components.html
@@ -1,0 +1,398 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Meta — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/meta. Photography-first retail polish:
+        white canvas, Optimistic VF type, Meta Blue (#0064E0) pill CTAs, gallery whitespace."
+    />
+
+    <style>
+      :root {
+        --bg: #ffffff;
+        --surface: #f7f8fa;
+        --surface-warm: #f2f0e6;
+
+        --fg: #1c2b33;
+        --fg-2: #5d6c7b;
+        --muted: #65676b;
+        --meta: #8595a4;
+
+        --border: #ced0d4;
+        --border-soft: #dee3e9;
+
+        --accent: #0064e0;
+        --accent-on: #ffffff;
+        --accent-hover: #0143b5;
+        --accent-active: #004bb9;
+
+        --success: #31a24c;
+        --warn: #f7b928;
+        --danger: #e41e3f;
+
+        --font-display: "Optimistic VF", "Optimistic", Inter, Montserrat, Helvetica, Arial, "Noto Sans", sans-serif;
+        --font-body: "Optimistic VF", "Optimistic", Inter, Montserrat, Helvetica, Arial, "Noto Sans", sans-serif;
+        --font-mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Monaco, Consolas, monospace;
+
+        --text-xs: 12px;
+        --text-sm: 14px;
+        --text-base: 16px;
+        --text-lg: 18px;
+        --text-xl: 28px;
+        --text-2xl: 36px;
+        --text-3xl: 48px;
+        --text-4xl: 64px;
+
+        --leading-body: 1.5;
+        --leading-tight: 1.16;
+        --tracking-display: -0.01em;
+
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 80px;
+        --section-y-tablet: 64px;
+        --section-y-phone: 48px;
+
+        --radius-sm: 8px;
+        --radius-md: 20px;
+        --radius-lg: 24px;
+        --radius-pill: 100px;
+
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised:
+          0 12px 28px 0 rgba(0, 0, 0, 0.2),
+          0 2px 4px 0 rgba(0, 0, 0, 0.1);
+
+        --focus-ring: 0 0 0 3px color-mix(in oklab, var(--accent), transparent 70%);
+
+        --motion-fast: 150ms;
+        --motion-base: 200ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+        --container-max: 1440px;
+        --container-gutter-desktop: 40px;
+        --container-gutter-tablet: 24px;
+        --container-gutter-phone: 16px;
+      }
+
+      /* ─── Reset ─────────────────────────────────────────────── */
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+        font-feature-settings: "ss01", "ss02";
+      }
+
+      /* ─── Layout ─────────────────────────────────────────────── */
+      .container { max-width: var(--container-max); margin-inline: auto; padding-inline: var(--container-gutter-desktop); }
+      section { padding-block: var(--section-y-desktop); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* Alternating light cadence — DESIGN.md §1 walkthrough rhythm */
+      .surface-soft { background: var(--surface); }
+
+      /* ─── Typography — Optimistic VF, weight carries hierarchy ── */
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        line-height: var(--leading-tight);
+        margin: 0;
+        color: var(--fg);
+      }
+      h1 { font-size: var(--text-4xl); font-weight: 500; letter-spacing: var(--tracking-display); }
+      h2 { font-size: var(--text-3xl); font-weight: 500; letter-spacing: var(--tracking-display); }
+      h3 { font-size: var(--text-lg); font-weight: 700; }
+      p { margin: 0; }
+      .lead { font-size: var(--text-lg); color: var(--fg-2); line-height: 1.44; font-weight: 300; }
+      .body-muted { color: var(--fg-2); }
+      .body-meta { color: var(--muted); }
+      .body-sm { font-size: var(--text-sm); }
+      .eyebrow {
+        font-size: var(--text-xs);
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-weight: 500;
+      }
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+      .stack-8 > * + * { margin-block-start: var(--space-8); }
+
+      @media (max-width: 1023px) {
+        h1 { font-size: var(--text-3xl); }
+      }
+      @media (max-width: 639px) {
+        h1 { font-size: var(--text-2xl); }
+        h2 { font-size: var(--text-xl); }
+      }
+
+      /* ─── Buttons — Meta Blue pill ───────────────────────────── */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 10px 22px;
+        border-radius: var(--radius-pill);
+        font-family: var(--font-body);
+        font-size: var(--text-sm);
+        font-weight: 500;
+        line-height: 1.43;
+        letter-spacing: -0.14px;
+        cursor: pointer;
+        border: none;
+        text-decoration: none;
+        transition:
+          background-color var(--motion-base) var(--ease-standard),
+          color var(--motion-base) var(--ease-standard),
+          transform var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      /* Primary: Meta Blue pill — the only chromatic action */
+      .btn-primary {
+        background: var(--accent);
+        color: var(--accent-on);
+      }
+      .btn-primary:hover { background: var(--accent-hover); transform: scale(1.02); }
+      .btn-primary:active { background: var(--accent-active); transform: scale(0.98); }
+      /* Secondary: outlined pill, Dark Charcoal at 50% opacity per DESIGN.md §4 */
+      .btn-secondary {
+        background: transparent;
+        color: color-mix(in oklab, var(--fg), transparent 50%);
+        box-shadow: inset 0 0 0 2px rgba(10, 19, 23, 0.12);
+      }
+      .btn-secondary:hover {
+        background: color-mix(in oklab, var(--fg-2), transparent 30%);
+        color: var(--bg);
+        box-shadow: inset 0 0 0 2px transparent;
+      }
+
+      /* ─── Inputs — Dolly form pattern ────────────────────────── */
+      .field { display: flex; flex-direction: column; gap: var(--space-2); }
+      .field label { font-size: var(--text-sm); font-weight: 500; color: var(--fg); }
+      .field input {
+        padding: 12px 14px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        outline: none;
+        transition:
+          border-color var(--motion-base) var(--ease-standard),
+          box-shadow var(--motion-base) var(--ease-standard);
+      }
+      .field input:focus-visible {
+        border-color: var(--accent);
+        box-shadow: var(--focus-ring);
+      }
+      .field input::placeholder { color: var(--muted); }
+      .field-help { font-size: var(--text-xs); color: var(--muted); }
+
+      /* ─── Cards — 20px radius, dual-shadow elevation on hover ─ */
+      .card {
+        background: var(--bg);
+        border-radius: var(--radius-md);
+        padding: var(--space-8);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+        box-shadow: var(--elev-ring);
+        transition:
+          transform var(--motion-base) var(--ease-standard),
+          box-shadow var(--motion-base) var(--ease-standard);
+      }
+      .card:hover {
+        transform: translateY(-2px);
+        box-shadow: var(--elev-raised);
+      }
+      .card-feature {
+        background: var(--surface-warm);
+        border-radius: var(--radius-lg);
+      }
+
+      /* ─── Badges ─────────────────────────────────────────────── */
+      .badge {
+        display: inline-flex; align-items: center; gap: var(--space-2);
+        padding: 4px 10px;
+        border-radius: var(--radius-pill);
+        font-size: var(--text-xs); font-weight: 700; line-height: 1.43;
+      }
+      .badge-success { color: var(--success); background: color-mix(in oklab, var(--success), transparent 88%); }
+      .badge-muted { color: var(--muted); background: var(--surface); }
+      .badge-dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
+
+      /* ─── Links ──────────────────────────────────────────────── */
+      a { color: var(--accent); text-decoration: none; transition: color var(--motion-fast) var(--ease-standard); }
+      a:hover { color: var(--accent-hover); text-decoration: underline; text-underline-offset: 3px; }
+      kbd {
+        font-family: var(--font-mono); font-size: var(--text-xs);
+        padding: 2px 6px; border-radius: var(--radius-sm);
+        border: 1px solid var(--border-soft); background: var(--surface); color: var(--muted);
+      }
+
+      /* ─── Layout helpers ─────────────────────────────────────── */
+      .hero-grid { display: grid; grid-template-columns: 1.5fr 1fr; gap: var(--space-12); align-items: end; }
+      @media (max-width: 1023px) { .hero-grid { grid-template-columns: 1fr; gap: var(--space-8); } }
+      .hero-actions { display: flex; gap: var(--space-3); margin-block-start: var(--space-8); flex-wrap: wrap; }
+      .hero-meta {
+        display: flex; flex-direction: column; gap: var(--space-4);
+        padding: var(--space-6);
+        border-radius: var(--radius-md);
+        background: var(--surface);
+        box-shadow: var(--elev-ring);
+      }
+      .features-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--space-6); }
+      @media (max-width: 1023px) { .features-grid { grid-template-columns: 1fr 1fr; gap: var(--space-4); } }
+      @media (max-width: 639px) { .features-grid { grid-template-columns: 1fr; } }
+      .form-row { display: grid; grid-template-columns: 1.4fr 1fr; gap: var(--space-12); align-items: start; }
+      @media (max-width: 1023px) { .form-row { grid-template-columns: 1fr; gap: var(--space-8); } }
+      .form { display: flex; flex-direction: column; gap: var(--space-5); max-width: 440px; }
+      .form-actions { display: flex; gap: var(--space-3); margin-block-start: var(--space-2); }
+      .icon { width: 16px; height: 16px; flex-shrink: 0; }
+      .row-between { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); }
+
+      /* Brand mark — gradient logotype dot (Meta's blue → purple → magenta) */
+      .brand-mark {
+        display: inline-flex; align-items: center; gap: var(--space-2);
+        font-size: var(--text-sm); font-weight: 700; color: var(--fg);
+      }
+      .brand-mark::before {
+        content: "";
+        width: 14px; height: 14px;
+        border-radius: 50%;
+        background: linear-gradient(135deg, #0064e0 0%, #6441d2 50%, #d6311f 100%);
+      }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <section data-od-id="hero">
+        <div class="hero-grid">
+          <div class="stack-6">
+            <span class="brand-mark">From Meta</span>
+            <h1 style="max-width: 16ch">Build what brings us closer.</h1>
+            <p class="lead" style="max-width: 56ch">
+              From mixed reality to open-source AI, we ship the platforms and tools that
+              billions of people use to create, connect, and discover what's next.
+            </p>
+            <div class="hero-actions">
+              <a href="./tokens.css" class="btn btn-primary">
+                Explore products
+                <svg class="icon" viewBox="0 0 24 24" fill="none"
+                  stroke="currentColor" stroke-width="2"
+                  stroke-linecap="round" stroke-linejoin="round"
+                  aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+              </a>
+              <a href="./DESIGN.md" class="btn btn-secondary">Inside Meta</a>
+            </div>
+          </div>
+          <aside class="hero-meta" aria-label="Newsroom">
+            <div class="row-between">
+              <span class="eyebrow">Newsroom</span>
+              <span class="badge badge-success">
+                <span class="badge-dot" aria-hidden="true"></span>
+                Live
+              </span>
+            </div>
+            <p class="body-sm body-muted" style="line-height: 1.5">
+              Llama 4 ships with native multimodal reasoning. Quest 4 introduces full-color
+              passthrough across the entire device family.
+            </p>
+            <p class="body-sm body-meta">
+              Updated <time datetime="2026-05-15">2026-05-15</time> · Press
+              <kbd>⌘</kbd> <kbd>K</kbd> to search the press library.
+            </p>
+          </aside>
+        </div>
+      </section>
+
+      <section class="surface-soft" data-od-id="features">
+        <div class="stack-3">
+          <p class="eyebrow">What we build</p>
+          <h2 style="max-width: 22ch">Three product families, one long-running thesis.</h2>
+          <p class="lead" style="max-width: 60ch">
+            Every Meta surface — phone, headset, glasses, model, API — is built so the next
+            billion creators can move at the speed of imagination.
+          </p>
+        </div>
+        <div class="features-grid stack-8" style="margin-block-start: var(--space-12)">
+          <article class="card">
+            <span class="eyebrow">Meta AI</span>
+            <h3>An assistant that meets you where you are.</h3>
+            <p class="body-muted body-sm">
+              Llama-powered, multimodal, available in every Meta app — and open-weight
+              for anyone who wants to build on top.
+            </p>
+            <a href="./tokens.css" class="body-sm">Try Meta AI →</a>
+          </article>
+          <article class="card card-feature">
+            <span class="eyebrow">Reality Labs</span>
+            <h3>Mixed reality, finally for everyone.</h3>
+            <p class="body-muted body-sm">
+              Quest headsets and Ray-Ban Meta glasses share one platform — pass-through
+              video, spatial audio, and on-device AI built in.
+            </p>
+            <a href="./DESIGN.md" class="body-sm">Inside Reality Labs →</a>
+          </article>
+          <article class="card">
+            <span class="eyebrow">Open source</span>
+            <h3>The infrastructure of the open web.</h3>
+            <p class="body-muted body-sm">
+              PyTorch, Llama, React, GraphQL — Meta open-sources the technology that
+              billions of products depend on, every day.
+            </p>
+            <a href="./tokens.css" class="body-sm">Browse the catalog →</a>
+          </article>
+        </div>
+      </section>
+
+      <section data-od-id="form">
+        <div class="form-row">
+          <div class="stack-4">
+            <p class="eyebrow">Stay close to what's next</p>
+            <h2 style="max-width: 18ch">Get the Meta brief.</h2>
+            <p class="body-muted" style="max-width: 48ch">
+              Quarterly updates on our research, product launches, and open-source releases —
+              written by the people who built them. No marketing copy, no tracking pixels.
+            </p>
+          </div>
+          <form class="form" onsubmit="event.preventDefault();">
+            <div class="field">
+              <label for="email">Work email</label>
+              <input id="email" type="email" placeholder="you@company.com" autocomplete="email" required />
+              <p class="field-help">One short email per quarter. Unsubscribe in one click.</p>
+            </div>
+            <div class="form-actions">
+              <button type="submit" class="btn btn-primary">Subscribe</button>
+              <button type="button" class="btn btn-secondary">Read past issues</button>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/meta/tokens.css
+++ b/design-systems/meta/tokens.css
@@ -1,0 +1,263 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/meta/tokens.css
+ *
+ * Structured token bindings for "Design System Inspired by Meta (Store)".
+ * Photography-first retail: pure white canvas, Optimistic VF typography,
+ * Meta Blue (#0064E0) reserved for action, generous gallery whitespace,
+ * pill-shaped CTAs, dual-shadow elevation.
+ *
+ * Brand-specific schema decisions (each one bends a schema convention to
+ * match Meta's voice rather than the cross-brand default):
+ *
+ *   1. `--bg` is pure white (#FFFFFF), `--surface` is Warm Gray
+ *      (#F7F8FA — Dolly's --flat-card-bg), and `--surface-warm` is
+ *      independently bound to Linen (#F2F0E6) — the "warm off-white for
+ *      lifestyle-adjacent sections" called out in DESIGN.md §2. Three
+ *      genuinely different surface tiers ladder up: white for browsing,
+ *      warm gray for card differentiation, linen for the lifestyle /
+ *      Ray-Ban-adjacent moments. Aliasing `--surface-warm` to surface
+ *      would collapse a meaningful brand tier.
+ *
+ *   2. The foreground ramp binds four distinct tiers — Dark Charcoal
+ *      (#1C2B33) → Slate Gray (#5D6C7B) → Secondary Text (#65676B) →
+ *      CTA Disabled Text (#8595A4). DESIGN.md §2 names each one as a
+ *      shipped Dolly/FDS token with its own role (heading vs body vs
+ *      caption vs muted/disabled), so `--fg-2` and `--meta` are bound
+ *      independently rather than aliased to `--fg` / `--muted`.
+ *
+ *   3. `--accent` is Meta Blue (#0064E0), NOT Facebook Blue (#1877F2).
+ *      DESIGN.md §7 ("Don'ts") explicitly forbids Facebook Blue as a
+ *      primary CTA color — the corporate Meta Store layer overlays a
+ *      slightly deeper, more saturated blue on the FDS gray ramp.
+ *      `--accent-hover` and `--accent-active` are bound to the exact
+ *      Meta Blue Hover (#0143B5) and Pressed (#004BB9) hexes from
+ *      DESIGN.md §2 rather than computed via `color-mix()`, because
+ *      the Dolly hover/pressed pair is hand-tuned to land on different
+ *      hue points than a flat luminance darken.
+ *
+ *   4. Semantic colors bind to the Dolly-store palette: Success Green
+ *      (#31A24C), Warning Amber (#F7B928), Error Red (#E41E3F) — the
+ *      "badge" tier from DESIGN.md §2. Darker store-confirmation
+ *      variants (#007D1E, #C80A28) live in components, not the schema,
+ *      because they are state overrides on top of the shared semantic
+ *      slot rather than the slot itself.
+ *
+ *   5. `--font-display` and `--font-body` share the Optimistic VF
+ *      stack with the documented fallbacks (Montserrat, Helvetica,
+ *      Arial, Noto Sans). Inter is added as a humanist sans bridge for
+ *      hosts that have neither Optimistic nor Montserrat installed —
+ *      it matches Optimistic's geometric warmth more closely than the
+ *      Helvetica/Arial fallbacks alone. The variable font keeps weight
+ *      300/400/500/700 all available; component CSS picks the weight,
+ *      not the face.
+ *
+ *   6. The type scale tracks DESIGN.md §3 verbatim: 12 / 14 / 16 / 18
+ *      / 28 / 36 / 48 / 64. The 18px tier (`--text-lg`) is Meta's
+ *      primary body size — Body and Heading 3 BOTH live there per
+ *      DESIGN.md §3 — while `--text-base` (16px) is Body Compact
+ *      reserved for navigation and dense UI. Display tracking stays
+ *      neutral (`-0.01em`) because DESIGN.md §3 specifies negative
+ *      letter-spacing only at small sizes (`-0.14px` to `-0.16px` on
+ *      14–16px UI text), not on display headlines.
+ *
+ *   7. Section rhythm is gallery-generous: 80 / 64 / 48 px desktop /
+ *      tablet / phone, mirroring the responsive padding ladder
+ *      DESIGN.md §8 prescribes ("Section padding: 80 → 64 → 48 → 32").
+ *      The 32px floor folds into component-level overrides on the
+ *      smallest viewports rather than into the shared schema.
+ *
+ *   8. Radius scale: 8 / 20 / 24 / 100. DESIGN.md §5 explicitly
+ *      enumerates these four tiers — 8px inputs, 20px standard cards
+ *      (--card-corner-radius), 24px feature cards & ghost buttons,
+ *      100px pill — and `--radius-pill` is bound to literal `100px`
+ *      (not the schema's 9999px sentinel) because the brand's pill
+ *      radius IS 100px and that value flows into actual padding /
+ *      stroke calculations on Meta-Blue CTAs.
+ *
+ *   9. `--elev-raised` reproduces DESIGN.md §6 Level 2 dual-shadow
+ *      pattern verbatim: a small sharp shadow (0 2px 4px rgba(0,0,0,
+ *      0.1)) for direct-light contact + a large diffused shadow
+ *      (0 12px 28px rgba(0,0,0,0.2)) for ambient-light depth.
+ *      Reordering or dropping a layer breaks Meta's "physically
+ *      plausible depth" feel — the brand specifically uses two
+ *      shadows together, not one blurred soft shadow.
+ *
+ *  10. Container caps at 1440px per DESIGN.md §5 ("Max container
+ *      width: ~1440px"), wider than Vercel's 1200 because the store
+ *      surfaces full-bleed cinematic product photography that needs
+ *      the room. Gutters step 40 / 24 / 16 to preserve generous
+ *      breathing room around hero imagery on every breakpoint.
+ *
+ * Source contracts:
+ *   - Standard token names: design-systems/_schema/tokens.schema.ts
+ *   - A2 fallback parity:   design-systems/_schema/defaults.css
+ *   - Lint enforcement:     apps/daemon/src/lint-artifact.ts
+ *
+ * Optimistic VF is not embedded; the stack falls back through
+ * Montserrat → Helvetica → Arial → Noto Sans so artifacts render
+ * acceptably on hosts that haven't loaded the commissioned face.
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface (3 levels — schema slot) ─────────────────────────────
+   * Binary plus a warm tier: pure white for browsing/information,
+   * Warm Gray for flat card differentiation, Linen as the lifestyle-
+   * adjacent warm off-white. DESIGN.md §1 calls out the binary
+   * white/dark cadence; Linen lives between for Ray-Ban-flavored
+   * sections where pure white feels too cold. Dark immersive
+   * surfaces (#1C1E21 / #181A1B / #000000) are component-level
+   * overrides, not surface tokens — they're product-context, not
+   * canvas. */
+  --bg: #ffffff;                       /* White — primary canvas, nav, default cards */
+  --surface: #f7f8fa;                  /* Warm Gray — flat card, subtle differentiation */
+  --surface-warm: #f2f0e6;             /* Linen — lifestyle-adjacent warm off-white */
+
+  /* ─── Foreground ramp (4 levels) ──────────────────────────────────
+   * Dark Charcoal heading → Slate Gray body → Secondary Text caption
+   * → CTA Disabled muted blue-gray. DESIGN.md §2 names each tier as
+   * a shipped Dolly/FDS token with its own role, so the four-level
+   * ramp resolves to four distinct values rather than aliasing. */
+  --fg: #1c2b33;                       /* Dark Charcoal — Dolly primary text, headings */
+  --fg-2: #5d6c7b;                     /* Slate Gray — Meta Store secondary text, body */
+  --muted: #65676b;                    /* Secondary Text — captions, labels, timestamps */
+  --meta: #8595a4;                     /* CTA Disabled — placeholder, muted blue-gray */
+
+  /* ─── Border (2 levels) ──────────────────────────────────────────
+   * Standard divider for input/card edges, lighter inner divider for
+   * Dolly section separators that should not visually compete. */
+  --border: #ced0d4;                   /* Divider — content separators, input borders */
+  --border-soft: #dee3e9;              /* Divider Gray — lighter Dolly inner separator */
+
+  /* ─── Accent ─────────────────────────────────────────────────────
+   * Meta Blue is the single action color. DESIGN.md §7 forbids
+   * Facebook Blue (#1877F2) for primary CTAs — Meta Blue (#0064E0)
+   * is the deeper, more saturated corporate-store variant. Hover
+   * and active states are hand-tuned hexes from DESIGN.md §2, not
+   * `color-mix()` derivations, because Dolly's interactive states
+   * shift hue, not just luminance. */
+  --accent: #0064e0;                   /* Meta Blue — primary CTA, links, focus */
+  --accent-on: #ffffff;                /* white label on Meta Blue */
+  --accent-hover: #0143b5;             /* Meta Blue Hover — hand-tuned, not a darken */
+  --accent-active: #004bb9;            /* Meta Blue Pressed — deepest interactive state */
+
+  /* ─── Semantic ───────────────────────────────────────────────────
+   * Dolly badge tier — bright enough to read on white surfaces.
+   * Darker store-confirmation variants (#007D1E success, #C80A28
+   * error) are component-level state overrides, not slot bindings. */
+  --success: #31a24c;                  /* Success Green — badge, positive indicators */
+  --warn: #f7b928;                     /* Warning Amber — attention, caution badges */
+  --danger: #e41e3f;                   /* Error Red — critical badges, notifications */
+
+  /* ─── Typography ─────────────────────────────────────────────────
+   * Optimistic VF is Meta's commissioned variable face; the documented
+   * fallbacks (Montserrat → Helvetica → Arial → Noto Sans) ensure
+   * artifacts read consistently on hosts without the licensed font.
+   * Inter bridges between Optimistic and Helvetica when neither the
+   * commissioned face nor Montserrat is loaded — it's the closest
+   * humanist geometric sans available system-wide. Display and body
+   * share one stack; weight (300/400/500/700) and size carry hierarchy. */
+  --font-display: "Optimistic VF", "Optimistic", Inter, Montserrat, Helvetica, Arial, "Noto Sans", sans-serif;
+  --font-body: "Optimistic VF", "Optimistic", Inter, Montserrat, Helvetica, Arial, "Noto Sans", sans-serif;
+  --font-mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Monaco, Consolas, monospace;
+
+  /* Type scale — DESIGN.md §3 verbatim. The 18px tier (text-lg) is
+   * Meta's primary body size (Body AND Heading 3 both live at 18/?);
+   * 16px (text-base) is Body Compact for navigation and dense UI.
+   * Display 1 lands at 64px on desktop; Display 2 at 48px; Heading 1
+   * at 36px; Heading 2 at 28px. */
+  --text-xs: 12px;                     /* Small — footer, legal, timestamps */
+  --text-sm: 14px;                     /* Caption — labels, button text, metadata */
+  --text-base: 16px;                   /* Body Compact — navigation, dense UI */
+  --text-lg: 18px;                     /* Body / Heading 3 — primary reading size */
+  --text-xl: 28px;                     /* Heading 2 — light-weight subheading */
+  --text-2xl: 36px;                    /* Heading 1 — major section heading */
+  --text-3xl: 48px;                    /* Display 2 — section heroes, product titles */
+  --text-4xl: 64px;                    /* Display 1 — hero headlines on desktop */
+
+  /* Body leading 1.5 (16px Body Compact ratio); tight leading 1.16
+   * (Display 1 ratio) for hero headlines. Display tracking stays
+   * neutral (-0.01em) — DESIGN.md §3 reserves negative tracking for
+   * small UI (-0.14px on Caption / Button), not for headlines. */
+  --leading-body: 1.5;
+  --leading-tight: 1.16;
+  --tracking-display: -0.01em;
+
+  /* ─── Spacing ────────────────────────────────────────────────────
+   * 8px-base scale per DESIGN.md §5 ("Base unit: 8px"). The 1px /
+   * 10px / 14px / 18px sub-tiers from DESIGN.md (hairlines, card
+   * horizontal padding, caption rhythm, body vertical rhythm) are
+   * inlined per-component because they are too fine to belong in
+   * the shared schema. */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+
+  /* Section rhythm — DESIGN.md §8: "Section padding: 80 → 64 → 48
+   * → 32 as viewport narrows". We bind the documented desktop /
+   * tablet / phone tiers; the 32px ultra-narrow floor falls into
+   * component-level @media overrides, not the schema. */
+  --section-y-desktop: 80px;
+  --section-y-tablet: 64px;
+  --section-y-phone: 48px;
+
+  /* ─── Radius ─────────────────────────────────────────────────────
+   * DESIGN.md §5 enumerates 8 / 20 / 24 / 100 px. Pill is literal
+   * 100px (not 9999px sentinel) because Meta's pill radius IS 100px
+   * — DESIGN.md §4 buttons specify "Border radius: fully rounded
+   * pill (100px)". For most components 100px and 9999px render
+   * identically, but 100px flows correctly into outline / focus
+   * geometry calculations in product. */
+  --radius-sm: 8px;                    /* Inputs, small UI, glimmer placeholders */
+  --radius-md: 20px;                   /* --card-corner-radius — standard cards */
+  --radius-lg: 24px;                   /* Feature cards, ghost buttons */
+  --radius-pill: 100px;                /* Pill buttons, tags, badges (DESIGN.md §5) */
+
+  /* ─── Elevation ──────────────────────────────────────────────────
+   * Three sanctioned levels. `--elev-raised` is DESIGN.md §6 Level 2
+   * dual-shadow pattern reproduced verbatim: small sharp shadow for
+   * direct-light contact + large diffused shadow for ambient-light
+   * depth. Together they create "physically plausible depth without
+   * heavy visual weight" — never collapse to a single soft blur.
+   * Most surface differentiation in Meta comes from background
+   * color shifts (white → soft gray → dark), not shadow; cards in
+   * dark sections SHOULD use --elev-flat per DESIGN.md §7 ("Don'ts"). */
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised:
+    0 12px 28px 0 rgba(0, 0, 0, 0.2),
+    0 2px 4px 0 rgba(0, 0, 0, 0.1);
+
+  /* ─── Focus ring ─────────────────────────────────────────────────
+   * DESIGN.md §4 inputs: "Focus: border color shifts to accent blue,
+   * 3px outer ring". DESIGN.md §4 buttons: "Focus: 3px ring in accent
+   * color". The schema-default 3px alpha glow at the accent matches
+   * Meta's documented behavior; the inner-element border-color shift
+   * is component-level. */
+  --focus-ring: 0 0 0 3px color-mix(in oklab, var(--accent), transparent 70%);
+
+  /* ─── Motion ─────────────────────────────────────────────────────
+   * DESIGN.md §4 buttons: "Transition: background 200ms ease,
+   * transform 150ms ease". Two durations, one easing curve. The
+   * scale(1.1) hover and scale(0.9) press transforms from DESIGN.md
+   * are component-level animation, not schema. */
+  --motion-fast: 150ms;
+  --motion-base: 200ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+  /* ─── Layout ─────────────────────────────────────────────────────
+   * DESIGN.md §5: "Max container width: ~1440px, centered with auto
+   * margins". Wider than Vercel/Mistral because Meta surfaces full-
+   * bleed cinematic product photography that needs the room. Gutters
+   * step 40 / 24 / 16 — DESIGN.md §5 names "Page horizontal padding:
+   * 24-40px depending on breakpoint" and §8 collapses to 16px on
+   * mobile to preserve gallery-style breathing room. */
+  --container-max: 1440px;
+  --container-gutter-desktop: 40px;
+  --container-gutter-tablet: 24px;
+  --container-gutter-phone: 16px;
+}

--- a/design-systems/sentry/components.html
+++ b/design-systems/sentry/components.html
@@ -1,0 +1,387 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Sentry — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/sentry. Dark-mode-first developer tool
+        aesthetic — deep purple-black canvas, Rubik UI, Monaco code, signature lime-green pop."
+    />
+
+    <style>
+      :root {
+        --bg: #1f1633;
+        --surface: #150f23;
+        --surface-warm: var(--surface);
+
+        --fg: #ffffff;
+        --fg-2: #e5e7eb;
+        --muted: #9d96b3;
+        --meta: var(--muted);
+
+        --border: #362d59;
+        --border-soft: var(--border);
+
+        --accent: #6a5fc1;
+        --accent-on: #ffffff;
+        --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+        --success: #16a34a;
+        --warn: #eab308;
+        --danger: #dc2626;
+
+        --font-display: "Dammit Sans", "Rubik", -apple-system, system-ui, "Segoe UI", Helvetica, Arial, sans-serif;
+        --font-body: "Rubik", -apple-system, system-ui, "Segoe UI", Helvetica, Arial, sans-serif;
+        --font-mono: Monaco, Menlo, "Ubuntu Mono", ui-monospace, monospace;
+
+        --text-xs: 12px;
+        --text-sm: 14px;
+        --text-base: 16px;
+        --text-lg: 20px;
+        --text-xl: 24px;
+        --text-2xl: 30px;
+        --text-3xl: 60px;
+        --text-4xl: 88px;
+
+        --leading-body: 1.5;
+        --leading-tight: 1.2;
+        --tracking-display: normal;
+
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 80px;
+        --section-y-tablet: 64px;
+        --section-y-phone: 48px;
+
+        --radius-sm: 6px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --radius-pill: 9999px;
+
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+
+        --focus-ring: 0 0 0 2px var(--accent);
+
+        --motion-fast: 150ms;
+        --motion-base: 200ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+        --container-max: 1152px;
+        --container-gutter-desktop: 64px;
+        --container-gutter-tablet: 32px;
+        --container-gutter-phone: 24px;
+      }
+
+      /* ─── Reset ─────────────────────────────────────────────── */
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+
+      /* ─── Layout ─────────────────────────────────────────────── */
+      .container { max-width: var(--container-max); margin-inline: auto; padding-inline: var(--container-gutter-desktop); }
+      section { padding-block: var(--section-y-desktop); }
+      section + section { border-top: 1px solid var(--border); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography — Rubik workhorse; Dammit Sans hero only ── */
+      h1, h2, h3 {
+        font-family: var(--font-body);  /* Rubik for section + card headings */
+        line-height: var(--leading-tight);
+        margin: 0;
+        color: var(--fg);
+      }
+      h1 {
+        font-family: var(--font-display); /* Dammit Sans — hero only */
+        font-size: var(--text-4xl);
+        font-weight: 700;
+        letter-spacing: var(--tracking-display);
+      }
+      h2 { font-size: var(--text-2xl); font-weight: 400; }
+      h3 { font-size: var(--text-xl); font-weight: 500; }
+      p { margin: 0; }
+      .lead { font-size: var(--text-lg); color: var(--fg-2); line-height: var(--leading-body); }
+      .body-muted { color: var(--muted); }
+      .body-sm { font-size: var(--text-sm); }
+      /* Uppercase eyebrow — Sentry's systematic "technical label" pattern */
+      .eyebrow {
+        font-size: var(--text-xs);
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.2px;
+        font-weight: 600;
+      }
+      /* Lime-green eyebrow — the signature pop accent. Per DESIGN.md §9:
+         "Use once per section maximum." Raw hex is justified here because
+         the lime is a brand-identity color not represented in the shared
+         schema and DESIGN.md explicitly anchors its usage. */
+      .eyebrow-pop {
+        font-size: var(--text-xs);
+        color: #c2ef4e;
+        text-transform: uppercase;
+        letter-spacing: 0.25px;
+        font-weight: 600;
+      }
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+
+      /* ─── Buttons — uppercase, letter-spaced, purple-tinted ──── */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 12px 16px;
+        border-radius: var(--radius-md);
+        font-family: var(--font-body);
+        font-size: var(--text-sm);
+        font-weight: 700;
+        line-height: 1;
+        cursor: pointer;
+        border: none;
+        text-transform: uppercase;
+        letter-spacing: 0.2px;
+        transition: background-color var(--motion-fast) var(--ease-standard),
+                    box-shadow var(--motion-fast) var(--ease-standard),
+                    color var(--motion-fast) var(--ease-standard);
+        text-decoration: none;
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      /* Primary white solid — DESIGN.md "White Solid": high-visibility CTA
+         on dark backgrounds. Hover transitions to Sentry Purple. */
+      .btn-primary {
+        background: var(--fg);
+        color: var(--bg);
+      }
+      .btn-primary:hover { background: var(--accent); color: var(--accent-on); }
+      .btn-primary:active { background: var(--accent-active); }
+      /* Secondary muted purple — DESIGN.md "Primary Muted Purple": tactile
+         inset shadow, the workhorse button. */
+      .btn-secondary {
+        background: #79628c;            /* Muted Purple — DESIGN.md §4 button bg */
+        color: var(--fg);
+        border: 1px solid #584674;      /* DESIGN.md §4 button border */
+        box-shadow: rgba(0, 0, 0, 0.1) 0 1px 3px 0 inset;  /* tactile pressed */
+      }
+      .btn-secondary:hover {
+        background: color-mix(in oklab, #79628c, white 6%);
+        box-shadow: rgba(0, 0, 0, 0.18) 0 8px 24px;
+      }
+
+      /* ─── Inputs — light context on dark surfaces ─────────────── */
+      .field { display: flex; flex-direction: column; gap: var(--space-2); }
+      .field label { font-size: var(--text-sm); font-weight: 500; color: var(--fg); }
+      .field input {
+        padding: 8px 12px;
+        border-radius: var(--radius-sm);     /* 6px — DESIGN.md inputs */
+        border: 1px solid #cfcfdb;           /* DESIGN.md "Input Border" — light context */
+        background: var(--fg);               /* white input on dark surface */
+        color: var(--bg);
+        font-family: var(--font-body);
+        font-size: var(--text-sm);
+        outline: none;
+        transition: border-color var(--motion-fast) var(--ease-standard),
+                    box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .field input:focus-visible {
+        border-color: #cfcfdb;
+        box-shadow: rgba(0, 0, 0, 0.15) 0 2px 10px inset;  /* DESIGN.md §4 input focus */
+      }
+      .field input::placeholder { color: var(--muted); }
+      .field-help { font-size: var(--text-xs); color: var(--muted); }
+
+      /* ─── Cards — dark surfaces with elevated shadow ──────────── */
+      .card {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        padding: var(--space-6);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+        box-shadow: var(--elev-raised);
+      }
+      .card h3 { color: var(--fg); }
+      .card a { color: var(--accent); font-weight: 500; }
+      .card a:hover { color: var(--fg); }
+
+      /* ─── Badges ────────────────────────────────────────────── */
+      .badge {
+        display: inline-flex; align-items: center; gap: var(--space-2);
+        padding: 3px var(--space-2);
+        border-radius: var(--radius-pill);
+        font-size: var(--text-xs); font-weight: 600; line-height: 1.6;
+        text-transform: uppercase; letter-spacing: 0.2px;
+      }
+      .badge-success {
+        color: var(--success);
+        background: color-mix(in oklab, var(--success), transparent 82%);
+      }
+      .badge-muted {
+        color: var(--muted);
+        background: color-mix(in oklab, var(--muted), transparent 80%);
+      }
+      .badge-dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
+
+      /* ─── Links ─────────────────────────────────────────────── */
+      a { color: var(--accent); text-decoration: none; }
+      a:hover { text-decoration: underline; text-underline-offset: 3px; }
+      kbd {
+        font-family: var(--font-mono); font-size: var(--text-xs);
+        padding: 2px 6px; border-radius: var(--radius-sm);
+        border: 1px solid var(--border); background: var(--surface); color: var(--fg-2);
+      }
+      code {
+        font-family: var(--font-mono);
+        color: #dcdcaa;                       /* DESIGN.md "Code Yellow" — syntax tokens */
+        font-size: 0.95em;
+      }
+
+      /* ─── Layout helpers ────────────────────────────────────── */
+      .hero {
+        /* Ambient purple glow — DESIGN.md §6 Level 4 signature treatment.
+           Inlined per-component because it's hero-specific, not generic. */
+        box-shadow: rgba(22, 15, 36, 0.9) 0 4px 4px 9px;
+      }
+      .hero-grid { display: grid; grid-template-columns: 1.4fr 1fr; gap: var(--space-12); align-items: end; }
+      @media (max-width: 1023px) { .hero-grid { grid-template-columns: 1fr; gap: var(--space-8); } }
+      .hero-actions { display: flex; gap: var(--space-3); margin-block-start: var(--space-6); flex-wrap: wrap; }
+      .hero-meta {
+        display: flex; flex-direction: column; gap: var(--space-3);
+        padding: var(--space-4);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface);
+      }
+      .features-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--space-5); }
+      @media (max-width: 1023px) { .features-grid { grid-template-columns: 1fr 1fr; } }
+      @media (max-width: 639px) { .features-grid { grid-template-columns: 1fr; } }
+      .form-row { display: grid; grid-template-columns: 1.4fr 1fr; gap: var(--space-12); align-items: start; }
+      @media (max-width: 1023px) { .form-row { grid-template-columns: 1fr; } }
+      .form { display: flex; flex-direction: column; gap: var(--space-4); max-width: 420px; }
+      .form-actions { display: flex; gap: var(--space-3); margin-block-start: var(--space-2); }
+      .icon { width: 16px; height: 16px; flex-shrink: 0; }
+      .row-between { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <section data-od-id="hero" class="hero">
+        <div class="hero-grid">
+          <div class="stack-4">
+            <p class="eyebrow-pop">Reference fixture · sentry</p>
+            <h1>Code breaks. Fix it faster.</h1>
+            <p class="lead" style="max-width: 52ch">
+              Application monitoring built for the late-night debugging session.
+              Errors, traces, and replays threaded together so you ship without surprises.
+            </p>
+            <div class="hero-actions">
+              <a href="./tokens.css" class="btn btn-primary">
+                View tokens
+                <svg class="icon" viewBox="0 0 24 24" fill="none"
+                  stroke="currentColor" stroke-width="1.75"
+                  stroke-linecap="round" stroke-linejoin="round"
+                  aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+              </a>
+              <a href="./DESIGN.md" class="btn btn-secondary">Read the spec</a>
+            </div>
+          </div>
+          <aside class="hero-meta" aria-label="System status">
+            <div class="row-between">
+              <span class="body-sm">API status</span>
+              <span class="badge badge-success">
+                <span class="badge-dot" aria-hidden="true"></span>
+                Operational
+              </span>
+            </div>
+            <p class="body-sm body-muted">Last reviewed <time datetime="2026-05-18">2026-05-18</time> · v1.0</p>
+            <p class="body-sm body-muted">Press <kbd>⌘</kbd> <kbd>K</kbd> to jump to <code>traces</code>.</p>
+          </aside>
+        </div>
+      </section>
+
+      <section data-od-id="features">
+        <div class="stack-3">
+          <p class="eyebrow">What this fixture exercises</p>
+          <h2 style="max-width: 24ch">Dark purple void, warm-tinted shadows, surgical accents.</h2>
+        </div>
+        <div class="features-grid" style="margin-block-start: var(--space-8)">
+          <article class="card">
+            <h3>Warm purple-black</h3>
+            <p class="body-muted body-sm">
+              --bg (#1f1633) → --surface (#150f23). Never pure black.
+              The warmth is what separates Sentry from a generic terminal-dark UI.
+            </p>
+            <a href="./tokens.css" class="body-sm">Inspect tokens →</a>
+          </article>
+          <article class="card">
+            <h3>Uppercase as system</h3>
+            <p class="body-muted body-sm">
+              Buttons, eyebrows, badges — all letter-spaced 0.2px uppercase. Rubik
+              500–700. A systematic "technical label" pattern throughout.
+            </p>
+            <a href="./DESIGN.md" class="body-sm">Read the rule →</a>
+          </article>
+          <article class="card">
+            <h3>Tactile inset buttons</h3>
+            <p class="body-muted body-sm">
+              Muted purple (#79628c) with a subtle inset shadow — buttons feel
+              pressed INTO the surface. Hover lifts with a warm purple cast.
+            </p>
+            <a href="./tokens.css" class="body-sm">Inspect shadows →</a>
+          </article>
+        </div>
+      </section>
+
+      <section data-od-id="form">
+        <div class="form-row">
+          <div class="stack-4">
+            <p class="eyebrow">Form components</p>
+            <h2>Inputs lit on the dark purple void.</h2>
+            <p class="body-muted" style="max-width: 48ch">
+              White input fields cut against the warm purple canvas — the same
+              light-context pattern Sentry uses for sign-in and onboarding flows.
+              Focus rings stay Sentry Purple (<code>#6a5fc1</code>).
+            </p>
+          </div>
+          <form class="form" onsubmit="event.preventDefault();">
+            <div class="field">
+              <label for="email">Work email</label>
+              <input id="email" type="email" placeholder="you@sentry.io" autocomplete="email" required />
+              <p class="field-help">We'll wire up your first project. No spam, ever.</p>
+            </div>
+            <div class="form-actions">
+              <button type="submit" class="btn btn-primary">Get started</button>
+              <button type="button" class="btn btn-secondary">Talk to sales</button>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/sentry/tokens.css
+++ b/design-systems/sentry/tokens.css
@@ -1,0 +1,219 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/sentry/tokens.css
+ *
+ * Structured token bindings for "Design System Inspired by Sentry".
+ * Dark-mode-first developer tool aesthetic: deep purple-black canvas
+ * (#1f1633, #150f23) lit by warm purples (#6a5fc1, #79628c, #422082)
+ * and punctuated by a signature lime-green pop (#c2ef4e).
+ *
+ * This file pre-compiles the values described in `DESIGN.md` into the
+ * shared schema. Agents generating an artifact for Sentry should paste
+ * the `:root` block verbatim into the first `<style>` of the artifact,
+ * then reference everything via `var(--*)`.
+ *
+ * Brand-specific schema decisions (each one bends a schema convention
+ * to match Sentry's "monitoring for developers" voice):
+ *
+ *   1. `--bg` is `#1f1633` — DESIGN.md §2 names this "the defining
+ *      color of the brand". Never `#000000` — the warm purple-black
+ *      is what separates Sentry from a generic terminal-dark UI
+ *      ("Warm purple tones replace the typical cool grays of
+ *      developer tools" — DESIGN.md §1). `--surface` recesses to
+ *      `#150f23` (the documented "deeper sections, footer" tier).
+ *      Cards visually lift via inset/ambient shadow and frosted
+ *      glass overlays, not via a lighter solid surface — Sentry's
+ *      depth language is light-on-dark, not paper-on-paper.
+ *
+ *   2. `--accent` is Sentry Purple `#6a5fc1` (the documented link /
+ *      hover / focus color from DESIGN.md §2 + §9), not the famous
+ *      lime green `#c2ef4e`. The schema's `--accent` slot is the
+ *      cross-brand interactive anchor — links, focus rings, hover
+ *      states — and DESIGN.md explicitly maps that role to Sentry
+ *      Purple. Lime green is the brand's "pop" highlight ("once per
+ *      section maximum" per DESIGN.md §9), which appears as a
+ *      single deliberate hex in components.html where the design
+ *      intent justifies it; it does not earn a shared schema slot.
+ *
+ *   3. `--focus-ring` is a sharp 2px solid ring at `var(--accent)`,
+ *      not the schema's 3px alpha glow. DESIGN.md §4 documents the
+ *      focus outline as `rgb(106, 95, 193) solid 0.125rem` — a
+ *      crisp engineered indicator. The atmospheric glow form would
+ *      blur into the warm purple bg and lose legibility against
+ *      `#1f1633`.
+ *
+ *   4. `--font-display` leads with "Dammit Sans" — Sentry's
+ *      irreverent display face used "ONLY for hero/display headings"
+ *      (DESIGN.md §7). Rubik sits second in the stack as the
+ *      workhorse fallback so any heading that loses Dammit Sans
+ *      degrades to Rubik (the brand's primary UI face), not to a
+ *      generic sans. `--font-body` is Rubik-first with the
+ *      DESIGN.md §3 fallback chain. `--font-mono` is Monaco-first
+ *      because Sentry's "developer-tool trinity" (DESIGN.md §1)
+ *      explicitly chose Monaco over the schema's SF Mono default.
+ *
+ *   5. Type scale tops at 88px (`--text-4xl`) with `--text-3xl` at
+ *      60px. DESIGN.md §3 documents Display Hero at 88px Dammit
+ *      Sans weight 700 and Display Secondary at 60px — the brand's
+ *      voice ("Code breaks. Fix it faster.") reads BIG by px count,
+ *      not just by tracking compression. `--tracking-display` is
+ *      `normal` because DESIGN.md §3 explicitly specifies
+ *      "letter-spacing: normal" at hero scale; the typographic
+ *      drama lives in size and weight, not in negative tracking.
+ *
+ *   6. `--leading-tight` is `1.2` (the upper end of DESIGN.md §3's
+ *      documented "1.10–1.25" heading range). `--leading-body` is
+ *      `1.5` per the body row of the same hierarchy table.
+ *
+ *   7. Radius scale spans 6 → 8 → 12 → 9999 to honor DESIGN.md §5's
+ *      five-step ladder (6 inputs → 8 buttons/cards → 10–12
+ *      containers → 13 primary muted → 18 pill containers).
+ *      `--radius-sm` recesses to 6px (form input floor) instead of
+ *      the schema's 8px default; per-component 13px and 18px values
+ *      remain inline where DESIGN.md is explicit about a specific
+ *      shape.
+ *
+ *   8. `--elev-raised` reproduces DESIGN.md §6 Level 2
+ *      ("rgba(0, 0, 0, 0.1) 0px 10px 15px -3px" — the standard
+ *      card elevation). The signature ambient purple glow
+ *      (`rgba(22, 15, 36, 0.9) 0px 4px 4px 9px`) is hero-specific
+ *      and inlined per-component; encoding it into the shared
+ *      raised tier would over-shadow every card.
+ *
+ *   9. Section rhythm is 80/64/48 (desktop/tablet/phone),
+ *      matching DESIGN.md §5's "dark breathing room" floor of
+ *      64–80px+ vertical padding between sections. Container caps
+ *      at 1152px — Sentry's documented XL breakpoint max-width.
+ *
+ * Source contracts:
+ *   - Standard token names: design-systems/_schema/tokens.schema.ts
+ *   - A2 fallback parity:   design-systems/_schema/defaults.css
+ *   - Lint enforcement:     apps/daemon/src/lint-artifact.ts
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface ─────────────────────────────────────────────────────
+   * Warm purple-black void: every background sits between #1f1633
+   * (canvas) and #150f23 (deeper). Never pure black. */
+  --bg: #1f1633;                       /* Deep Purple — the defining brand canvas */
+  --surface: #150f23;                  /* Darker Purple — deeper sections, recessed wells */
+  --surface-warm: var(--surface);      /* alias — Sentry has no warm tier (palette is purple-cool) */
+
+  /* ─── Foreground ──────────────────────────────────────────────────
+   * Pure white primary with progressively dimmed purple-grays for
+   * tertiary text. The mid-tier (#9d96b3) is purple-mauve so meta
+   * text stays on-brand even when small. */
+  --fg: #ffffff;                       /* Pure White — primary text on dark bg */
+  --fg-2: #e5e7eb;                     /* Light Gray — secondary text, descriptions */
+  --muted: #9d96b3;                    /* Purple-mauve — captions, tertiary text (warm-tinted, never neutral gray) */
+  --meta: var(--muted);                /* alias — no separate placeholder/disabled tier */
+
+  /* ─── Border ──────────────────────────────────────────────────────
+   * Border Purple anchors all structural lines — DESIGN.md §7
+   * explicitly forbids neutral grays (#666, #999) for borders. */
+  --border: #362d59;                   /* Border Purple — dividers, card edges */
+  --border-soft: var(--border);        /* alias — no softer separator tier documented */
+
+  /* ─── Accent ──────────────────────────────────────────────────────
+   * Sentry Purple — the brand's interactive anchor. Links, focus
+   * rings, hover states. Lime green (#c2ef4e) is the once-per-screen
+   * pop highlight and lives inline in components, not in the shared
+   * accent slot. */
+  --accent: #6a5fc1;                   /* Sentry Purple — links, hover, focus */
+  --accent-on: #ffffff;                /* white text on accent backgrounds */
+  --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+  /* ─── Semantic ────────────────────────────────────────────────────
+   * Sentry's monitoring surface uses standard semantic colors —
+   * status pills must remain unambiguous against the warm purple
+   * palette and not collapse into the brand spectrum. */
+  --success: #16a34a;
+  --warn: #eab308;
+  --danger: #dc2626;
+
+  /* ─── Typography ──────────────────────────────────────────────────
+   * The "developer-tool trinity" — Dammit Sans for irreverent
+   * display, Rubik for everything functional, Monaco for code.
+   * Dammit Sans is hero-only; Rubik covers 90% of the type system. */
+  --font-display: "Dammit Sans", "Rubik", -apple-system, system-ui, "Segoe UI", Helvetica, Arial, sans-serif;
+  --font-body: "Rubik", -apple-system, system-ui, "Segoe UI", Helvetica, Arial, sans-serif;
+  --font-mono: Monaco, Menlo, "Ubuntu Mono", ui-monospace, monospace;
+
+  /* Type scale — DESIGN.md §3 hierarchy. 88px display hero, 60px
+   * display secondary, 30px section heading. Sentry reads BIG by
+   * px count, not by tracking compression. */
+  --text-xs: 12px;                     /* Small Caption */
+  --text-sm: 14px;                     /* Button / Caption */
+  --text-base: 16px;                   /* Body / Code */
+  --text-lg: 20px;                     /* Feature Title */
+  --text-xl: 24px;                     /* Card Title */
+  --text-2xl: 30px;                    /* Section Heading */
+  --text-3xl: 60px;                    /* Display Secondary */
+  --text-4xl: 88px;                    /* Display Hero — billboard scale */
+
+  /* Body 1.50, headings 1.20 (upper end of DESIGN.md's 1.10–1.25).
+   * Display letter-spacing is `normal` — DESIGN.md §3 explicitly
+   * specifies normal tracking at hero scale. */
+  --leading-body: 1.5;
+  --leading-tight: 1.2;
+  --tracking-display: normal;
+
+  /* ─── Spacing ─────────────────────────────────────────────────────
+   * 8px base unit per DESIGN.md §5. Mid-tier values (5/12/40/etc.)
+   * appear inline per-component where DESIGN.md is specific. */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+
+  /* Section rhythm — DESIGN.md §5 "dark breathing room" of 64–80px+
+   * between sections. The dark canvas IS the visual rest. */
+  --section-y-desktop: 80px;
+  --section-y-tablet: 64px;
+  --section-y-phone: 48px;
+
+  /* ─── Radius ──────────────────────────────────────────────────────
+   * DESIGN.md §5 radius ladder: 6 (inputs) → 8 (buttons/cards) →
+   * 12 (containers/glass) → 9999 (pills). The 13px primary-button
+   * radius and 18px image-container radius stay inline per-component
+   * since they're shape-specific, not structural. */
+  --radius-sm: 6px;                    /* Minimal — form inputs */
+  --radius-md: 8px;                    /* Standard — buttons, cards */
+  --radius-lg: 12px;                   /* Comfortable — containers, glass panels */
+  --radius-pill: 9999px;               /* Full pill — badges, status chips */
+
+  /* ─── Elevation ───────────────────────────────────────────────────
+   * Level 2 card stack per DESIGN.md §6. The signature ambient
+   * purple glow (Level 4) and inset button shadow (Level -1) are
+   * inlined per-component — they're brand-signature treatments,
+   * not generic card chrome. */
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised: 0 10px 15px -3px rgba(0, 0, 0, 0.1);  /* card float */
+
+  /* ─── Focus ring ──────────────────────────────────────────────────
+   * Sharp 2px solid ring at Sentry Purple — DESIGN.md §4 documents
+   * `rgb(106, 95, 193) solid 0.125rem` as the focus outline. An
+   * atmospheric alpha glow would dilute against the warm purple bg. */
+  --focus-ring: 0 0 0 2px var(--accent);
+
+  /* ─── Motion ──────────────────────────────────────────────────────
+   * Standard durations — Sentry's drama lives in shadow and color,
+   * not in choreographed motion. */
+  --motion-fast: 150ms;
+  --motion-base: 200ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+  /* ─── Layout ──────────────────────────────────────────────────────
+   * 1152px max content width — Sentry's documented XL breakpoint.
+   * Gutters tighten on smaller breakpoints; DESIGN.md describes
+   * "Responsive padding: 2rem (mobile) → 4rem (tablet+)". */
+  --container-max: 1152px;
+  --container-gutter-desktop: 64px;
+  --container-gutter-tablet: 32px;
+  --container-gutter-phone: 24px;
+}

--- a/design-systems/warp/components.html
+++ b/design-systems/warp/components.html
@@ -1,0 +1,411 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Warp — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/warp. Warm dark canvas,
+        Matter Regular at every tier, almost-monochromatic warm grays,
+        ghostly mist borders instead of shadows."
+    />
+
+    <style>
+      :root {
+        --bg: #161412;
+        --surface: #1f1d1b;
+        --surface-warm: var(--surface);
+
+        --fg: #faf9f6;
+        --fg-2: #afaeac;
+        --muted: #868584;
+        --meta: #666469;
+
+        --border: rgba(226, 226, 226, 0.35);
+        --border-soft: var(--border);
+
+        --accent: #353534;
+        --accent-on: #afaeac;
+        --accent-hover: #454545;
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+        --success: #16a34a;
+        --warn: #eab308;
+        --danger: #dc2626;
+
+        --font-display: "Matter Regular", "Matter", "Inter", ui-sans-serif, system-ui, sans-serif;
+        --font-body: "Matter Regular", "Matter", "Inter", ui-sans-serif, system-ui, sans-serif;
+        --font-mono: "Geist Mono", "Matter Mono Regular", ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
+
+        --text-xs: 12px;
+        --text-sm: 14px;
+        --text-base: 18px;
+        --text-lg: 24px;
+        --text-xl: 32px;
+        --text-2xl: 48px;
+        --text-3xl: 56px;
+        --text-4xl: 80px;
+
+        --leading-body: 1.4;
+        --leading-tight: 1.0;
+        --tracking-display: -0.03em;
+
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 120px;
+        --section-y-tablet: 80px;
+        --section-y-phone: 56px;
+
+        --radius-sm: 6px;
+        --radius-md: 12px;
+        --radius-lg: 14px;
+        --radius-pill: 9999px;
+
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised: 0 5px 15px rgba(0, 0, 0, 0.2);
+
+        --focus-ring: 0 0 0 2px rgba(250, 249, 246, 0.5);
+
+        --motion-fast: 150ms;
+        --motion-base: 200ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+        --container-max: 1500px;
+        --container-gutter-desktop: 32px;
+        --container-gutter-tablet: 24px;
+        --container-gutter-phone: 16px;
+      }
+
+      /* ─── Reset ─────────────────────────────────────────────── */
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+
+      /* ─── Layout ─────────────────────────────────────────────── */
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      section + section { border-top: 1px solid var(--border-soft); }
+      @media (max-width: 1499px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 809px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography — Matter Regular at every tier ─────────── */
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        font-weight: 400;              /* Single weight throughout — DESIGN.md §3 */
+        line-height: var(--leading-tight);
+        color: var(--fg);
+        margin: 0;
+      }
+      h1 {
+        font-size: var(--text-4xl);
+        letter-spacing: var(--tracking-display);
+      }
+      h2 {
+        font-size: var(--text-2xl);
+        letter-spacing: -0.02em;        /* ≈ -0.96px at 48px */
+        line-height: 1.1;
+      }
+      h3 {
+        font-size: var(--text-lg);
+        letter-spacing: -0.015em;       /* DESIGN.md Body Heading: 0 to -0.72px */
+        line-height: 1.2;
+      }
+      p { margin: 0; color: var(--fg-2); }
+      .lead {
+        font-size: 20px;                /* DESIGN.md Body Large is 20px — between --text-base (18) and --text-lg (24) */
+        color: var(--fg-2);
+        line-height: var(--leading-body);
+        letter-spacing: -0.01em;
+      }
+      .body-muted { color: var(--muted); }
+      .body-sm { font-size: var(--text-sm); color: var(--fg-2); }
+      /* Editorial uppercase eyebrow — DESIGN.md §3 magazine signal */
+      .eyebrow {
+        font-size: var(--text-xs);
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.2em;          /* ≈ 2.4px at 12px — DESIGN.md Small Label */
+        font-weight: 400;
+      }
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-5 > * + * { margin-block-start: var(--space-5); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+
+      /* ─── Buttons — restrained dark pills ───────────────────── */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 14px var(--space-5);
+        border-radius: var(--radius-pill); /* DESIGN.md §4 dark pill — primary CTA */
+        font-family: var(--font-body);
+        font-size: 16px;                   /* DESIGN.md Button Text — UI tier, not body baseline */
+        font-weight: 500;                  /* Matter Medium — only emphasis allowed */
+        line-height: 1.2;
+        cursor: pointer;
+        border: none;
+        transition: background-color var(--motion-fast) var(--ease-standard),
+                    color var(--motion-fast) var(--ease-standard);
+        text-decoration: none;
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn:active { background: var(--accent-active); }
+      /* Primary: Earth Gray pill — the brand's restrained CTA */
+      .btn-primary {
+        background: var(--accent);
+        color: var(--accent-on);
+      }
+      .btn-primary:hover { background: var(--accent-hover); color: var(--fg); }
+      /* Ghost: text-only, underline on hover — DESIGN.md §4 */
+      .btn-ghost {
+        background: transparent;
+        color: var(--fg);
+        padding-inline: var(--space-3);
+      }
+      .btn-ghost:hover { text-decoration: underline; text-underline-offset: 4px; }
+
+      /* ─── Inputs — warm dark, brightness-shift focus ────────── */
+      .field { display: flex; flex-direction: column; gap: var(--space-2); }
+      .field label {
+        font-size: var(--text-sm);
+        font-weight: 400;
+        color: var(--fg-2);
+      }
+      .field input {
+        padding: 14px var(--space-4);
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+        background: var(--surface);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: 16px;
+        outline: none;
+        transition: border-color var(--motion-fast) var(--ease-standard),
+                    box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .field input:focus-visible {
+        /* DESIGN.md §4 inputs: "Border brightness increase, no colored rings" */
+        border-color: var(--fg);
+        box-shadow: var(--focus-ring);
+      }
+      .field input::placeholder { color: var(--meta); }
+      .field-help { font-size: var(--text-xs); color: var(--muted); }
+
+      /* ─── Cards — bordered, no shadow ───────────────────────── */
+      .card {
+        background: var(--surface);
+        border: 1px solid var(--border);  /* Mist Border containment, not shadow */
+        border-radius: var(--radius-md);
+        padding: var(--space-6) var(--space-6) var(--space-8);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+        transition: border-color var(--motion-base) var(--ease-standard);
+      }
+      .card:hover { border-color: var(--fg-2); }
+      .card-eyebrow {
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        color: var(--meta);
+        letter-spacing: 0;
+      }
+
+      /* ─── Badges ────────────────────────────────────────────── */
+      .badge {
+        display: inline-flex; align-items: center; gap: var(--space-2);
+        padding: 4px var(--space-3);
+        border-radius: var(--radius-pill);
+        border: 1px solid var(--border);
+        font-size: var(--text-xs); font-weight: 400; line-height: 1.4;
+        color: var(--fg-2);
+        background: transparent;
+      }
+      .badge-success { color: var(--success); border-color: color-mix(in oklab, var(--success), transparent 60%); }
+      .badge-dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
+
+      /* ─── Links + kbd ───────────────────────────────────────── */
+      a { color: var(--fg); text-decoration: underline; text-decoration-color: var(--meta); text-underline-offset: 4px; }
+      a:hover { text-decoration-color: var(--fg); }
+      kbd {
+        font-family: var(--font-mono); font-size: var(--text-xs);
+        padding: 3px 8px; border-radius: var(--radius-sm);
+        border: 1px solid var(--border); background: var(--surface); color: var(--fg-2);
+      }
+
+      /* ─── Layout helpers ────────────────────────────────────── */
+      .hero-grid {
+        display: grid;
+        grid-template-columns: 1.4fr 1fr;
+        gap: var(--space-12);
+        align-items: end;
+      }
+      @media (max-width: 1023px) { .hero-grid { grid-template-columns: 1fr; gap: var(--space-8); } }
+      .hero-actions {
+        display: flex; gap: var(--space-3);
+        margin-block-start: var(--space-6);
+        flex-wrap: wrap;
+      }
+      .hero-meta {
+        display: flex; flex-direction: column; gap: var(--space-3);
+        padding: var(--space-5);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface);
+      }
+      .features-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: var(--space-5);
+      }
+      @media (max-width: 1023px) { .features-grid { grid-template-columns: 1fr; } }
+      .form-row {
+        display: grid;
+        grid-template-columns: 1.4fr 1fr;
+        gap: var(--space-12);
+        align-items: start;
+      }
+      @media (max-width: 1023px) { .form-row { grid-template-columns: 1fr; } }
+      .form { display: flex; flex-direction: column; gap: var(--space-4); max-width: 420px; }
+      .form-actions { display: flex; gap: var(--space-3); margin-block-start: var(--space-2); }
+      .icon { width: 16px; height: 16px; flex-shrink: 0; }
+      .row-between { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); }
+
+      /* ─── Hero scroll prompt — terminal monospace flavor ───── */
+      .prompt {
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        color: var(--meta);
+      }
+      .prompt b { color: var(--fg); font-weight: 400; }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <section data-od-id="hero">
+        <div class="hero-grid">
+          <div class="stack-5">
+            <p class="eyebrow">Reference fixture · warp</p>
+            <h1>The AI terminal,<br />made for flow.</h1>
+            <p class="lead" style="max-width: 48ch">
+              Warp turns the command line into a calm, considered space —
+              block-based, AI-native, and quietly productive. A terminal
+              you'd sit with, not just type into.
+            </p>
+            <div class="hero-actions">
+              <a href="./tokens.css" class="btn btn-primary">
+                View tokens
+                <svg class="icon" viewBox="0 0 24 24" fill="none"
+                  stroke="currentColor" stroke-width="1.75"
+                  stroke-linecap="round" stroke-linejoin="round"
+                  aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+              </a>
+              <a href="./DESIGN.md" class="btn btn-ghost">Read the spec</a>
+            </div>
+          </div>
+          <aside class="hero-meta" aria-label="System status">
+            <div class="row-between">
+              <span class="body-sm">Beta channel</span>
+              <span class="badge badge-success">
+                <span class="badge-dot" aria-hidden="true"></span>
+                Operational
+              </span>
+            </div>
+            <p class="prompt"><b>~ warp</b> · last reviewed <time datetime="2026-05-15">2026-05-15</time></p>
+            <p class="body-sm body-muted">Press <kbd>⌘</kbd> <kbd>P</kbd> to open the command palette.</p>
+          </aside>
+        </div>
+      </section>
+
+      <section data-od-id="features">
+        <div class="stack-3">
+          <p class="eyebrow">What this fixture exercises</p>
+          <h2 style="max-width: 24ch">Restraint through warmth — every tier, one weight.</h2>
+        </div>
+        <div class="features-grid" style="margin-block-start: var(--space-8)">
+          <article class="card">
+            <p class="card-eyebrow">01 / canvas</p>
+            <h3>Earth, not eclipse.</h3>
+            <p class="body-sm">
+              The canvas is warm near-black with reddish undertones —
+              charred wood, not a clinical OLED void. Pure white is
+              never used; text is Warm Parchment <code>(--fg)</code>.
+            </p>
+            <a href="./tokens.css" class="body-sm">Inspect tokens →</a>
+          </article>
+          <article class="card">
+            <p class="card-eyebrow">02 / typography</p>
+            <h3>One weight carries everything.</h3>
+            <p class="body-sm">
+              Matter Regular at 80px hero, 24px heading, 18px body.
+              Bold weight is forbidden; size and tracking carry the
+              hierarchy with editorial calm.
+            </p>
+            <a href="./DESIGN.md" class="body-sm">Read the rule →</a>
+          </article>
+          <article class="card">
+            <p class="card-eyebrow">03 / depth</p>
+            <h3>Borders, not shadows.</h3>
+            <p class="body-sm">
+              Mist Border at 35% opacity creates ghostly containment.
+              No glow, no glass, no gradients — depth comes from
+              opacity shifts and warm photography, never CSS shadow.
+            </p>
+            <a href="./tokens.css" class="body-sm">Inspect radius →</a>
+          </article>
+        </div>
+      </section>
+
+      <section data-od-id="form">
+        <div class="form-row">
+          <div class="stack-4">
+            <p class="eyebrow">Get the beta</p>
+            <h2>One terminal, all your shells.</h2>
+            <p class="body-muted" style="max-width: 46ch; font-size: var(--text-base)">
+              We'll send a download link and nothing else. Focus rings
+              are warm parchment, not blue — the monochromatic palette
+              holds, even at the input level.
+            </p>
+          </div>
+          <form class="form" onsubmit="event.preventDefault();">
+            <div class="field">
+              <label for="email">Work email</label>
+              <input id="email" type="email" placeholder="you@warp.dev" autocomplete="email" required />
+              <p class="field-help">No marketing — just the download link.</p>
+            </div>
+            <div class="form-actions">
+              <button type="submit" class="btn btn-primary">Request access</button>
+              <button type="button" class="btn btn-ghost">Read the docs</button>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/warp/tokens.css
+++ b/design-systems/warp/tokens.css
@@ -1,0 +1,156 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/warp/tokens.css
+ *
+ * Structured token bindings for "Design System Inspired by Warp".
+ * Warm dark canvas, near-black like charred wood. Almost monochromatic
+ * warm grays. Matter Regular (weight 400) carries every tier — even
+ * the 80px hero. Restraint through warmth.
+ *
+ * Key brand decisions encoded here:
+ *   - Warm near-black canvas (#161412) — never cold/blue dark
+ *   - Warm Parchment (#faf9f6) text — barely-cream, never pure white
+ *   - Earth Gray (#353534) as the brand "accent" — the dark pill CTA
+ *     IS the brand signal; no chromatic accent (DESIGN.md §2 forbids)
+ *   - Four-tier text system: parchment → ash → stone → muted-purple
+ *   - Mist Border (rgba(226, 226, 226, 0.35)) for ghostly containment
+ *   - Pill radius reserved for primary CTA; cards stay at 12–14px
+ *   - Almost-flat elevation — depth via borders + opacity, not shadow
+ *   - Focus ring uses the FG (parchment), not a colored glow — DESIGN.md
+ *     "Border brightness increase, no colored rings"
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface ─────────────────────────────────────────────────────
+   * Deep warm void. Pure black would feel cold; the reddish-earthen
+   * undertone (R>G>B, all near 20) makes the canvas feel like charred
+   * wood. Surface is bg + a perceptual ~4% lift, matching the
+   * "Frosted Veil" rgba(255,255,255,0.04) overlay DESIGN.md describes. */
+  --bg: #161412;             /* Deep Void — warm near-black, earth-toned */
+  --surface: #1f1d1b;        /* Frosted Veil resolved over bg */
+  --surface-warm: var(--surface); /* alias — already warm; no separate tier */
+
+  /* ─── Foreground ──────────────────────────────────────────────────
+   * Four warm tiers, no cool grays. Parchment is the headline tone —
+   * its barely-cream undertone is what makes the dark canvas feel
+   * inviting rather than austere. Meta carries Purple-Tint Gray, the
+   * underlined-link tone DESIGN.md §2 calls out. */
+  --fg: #faf9f6;             /* Warm Parchment — primary headlines */
+  --fg-2: #afaeac;           /* Ash Gray — body paragraphs, button text */
+  --muted: #868584;          /* Stone Gray — secondary descriptions */
+  --meta: #666469;           /* Purple-Tint Gray — links, tertiary content */
+
+  /* ─── Border ──────────────────────────────────────────────────────
+   * Semi-transparent borders create the "ghostly containment" Warp
+   * uses instead of shadows. 35% opacity is the canonical value;
+   * inner separators alias to the same line — the brand never uses
+   * a stronger or weaker tier (monochromatic restraint). */
+  --border: rgba(226, 226, 226, 0.35); /* Mist Border */
+  --border-soft: var(--border);        /* alias — single border tier */
+
+  /* ─── Accent ──────────────────────────────────────────────────────
+   * Warp's "accent" is restrained: Earth Gray, the dark pill CTA bg.
+   * DESIGN.md §2 explicitly forbids bold accent colors — interactive
+   * states are communicated through opacity and underline, never hue.
+   * accent-on is Ash Gray (#afaeac), the muted button-text color
+   * DESIGN.md §4 specifies for the dark pill. */
+  --accent: #353534;
+  --accent-on: #afaeac;
+  --accent-hover: #454545;   /* Dark Charcoal — slightly lighter pill */
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+  /* ─── Semantic ────────────────────────────────────────────────────
+   * Warp's marketing site has no surfaced semantic colors — these
+   * exist only for component-level state messaging. Schema defaults
+   * are accepted as-is to keep the warm palette unburdened. */
+  --success: #16a34a;
+  --warn: #eab308;
+  --danger: #dc2626;
+
+  /* ─── Typography ──────────────────────────────────────────────────
+   * Matter is the entire system: geometric sans with soft character,
+   * approachable in a way most developer-tool fonts are not. Inter
+   * appears in DESIGN.md §3 as the "UI supplement" fallback before
+   * generic system sans. Geist Mono is the code/terminal display
+   * face; Matter Mono is the prose-aligned mono companion. */
+  --font-display: "Matter Regular", "Matter", "Inter", ui-sans-serif, system-ui, sans-serif;
+  --font-body: "Matter Regular", "Matter", "Inter", ui-sans-serif, system-ui, sans-serif;
+  --font-mono: "Geist Mono", "Matter Mono Regular", ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
+
+  /* Type scale — DESIGN.md §3 hierarchy. Body baseline is 18px (not
+   * the more conventional 16); Warp's editorial pacing wants more
+   * breathing room per line. Display hero at 80px with -0.03em
+   * tracking (≈ -2.4px) is the billboard moment. */
+  --text-xs: 12px;           /* Small Label — uppercase 2.4px tracking */
+  --text-sm: 14px;           /* Caption — uppercase 1.4px tracking */
+  --text-base: 18px;         /* Body — DESIGN.md body baseline */
+  --text-lg: 24px;           /* Body Heading */
+  --text-xl: 32px;           /* Sub-heading */
+  --text-2xl: 48px;          /* Section Heading */
+  --text-3xl: 56px;          /* Section Display */
+  --text-4xl: 80px;          /* Display Hero — billboard scale */
+
+  --leading-body: 1.4;       /* Body Large lh — relaxed editorial */
+  --leading-tight: 1.0;      /* Display Hero lh — maximum compression */
+  --tracking-display: -0.03em; /* ≈ -2.4px at 80px — hero compression */
+
+  /* ─── Spacing ─────────────────────────────────────────────────────
+   * 8px base unit (DESIGN.md §5). Schema defaults match Warp's scale
+   * exactly — no override needed. */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+
+  /* ─── Section rhythm ──────────────────────────────────────────────
+   * Generous, contemplative pacing. DESIGN.md §5: "80px–120px vertical
+   * between major sections." Desktop uses the upper bound — Warp's
+   * marketing site reads like a magazine, each section a page-turn. */
+  --section-y-desktop: 120px;
+  --section-y-tablet: 80px;
+  --section-y-phone: 56px;
+
+  /* ─── Radius ──────────────────────────────────────────────────────
+   * Warp's radius scale (DESIGN.md §5) ranges 4–14px for content,
+   * 50px+ for pills. Standard components live in the soft 6–14px tier;
+   * the primary CTA reaches for --radius-pill. */
+  --radius-sm: 6px;          /* Inputs, tags, small containers */
+  --radius-md: 12px;         /* Feature cards */
+  --radius-lg: 14px;         /* Large prominent containers */
+  --radius-pill: 9999px;     /* Dark pill button — primary CTA */
+
+  /* ─── Elevation ───────────────────────────────────────────────────
+   * Almost-flat. DESIGN.md §6: "remarkably flat — almost zero shadow
+   * usage." Depth comes from semi-transparent borders (the ring tier)
+   * and the rare ambient shadow lifted directly from DESIGN.md's
+   * inferred Level 3 treatment. */
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised: 0 5px 15px rgba(0, 0, 0, 0.2);
+
+  /* ─── Focus ring ──────────────────────────────────────────────────
+   * NO colored ring. DESIGN.md §4: "Border brightness increase, no
+   * colored rings (consistent with the monochromatic palette)." A
+   * 50%-opacity warm parchment glow is the brightest legal indicator. */
+  --focus-ring: 0 0 0 2px rgba(250, 249, 246, 0.5);
+
+  /* ─── Motion ──────────────────────────────────────────────────────
+   * Standard cadence — DESIGN.md doesn't specify timing, and the
+   * brand's calm character is carried by typography and color rather
+   * than animation choreography. Schema defaults preserved. */
+  --motion-fast: 150ms;
+  --motion-base: 200ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+  /* ─── Layout ──────────────────────────────────────────────────────
+   * 1500px container — DESIGN.md §5 calls out the breakpoint exactly.
+   * Wide cinematic compositions let nature photography breathe; phone
+   * gutter steps down through the responsive scale (32 → 24 → 16). */
+  --container-max: 1500px;
+  --container-gutter-desktop: 32px;
+  --container-gutter-tablet: 24px;
+  --container-gutter-phone: 16px;
+}

--- a/design-systems/webflow/components.html
+++ b/design-systems/webflow/components.html
@@ -1,0 +1,413 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Webflow — reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/webflow. White marketing canvas,
+        Webflow Blue (#146ef5) accent, conservative 4px corners, 5-layer cascading
+        shadow on raised surfaces, WF Visual Sans Variable + Inconsolata."
+    />
+
+    <style>
+      :root {
+        --bg: #ffffff;
+        --surface: #ffffff;
+        --surface-warm: var(--surface);
+
+        --fg: #080808;
+        --fg-2: #363636;
+        --muted: #5a5a5a;
+        --meta: #ababab;
+
+        --border: #d8d8d8;
+        --border-soft: #ebebeb;
+
+        --accent: #146ef5;
+        --accent-on: #ffffff;
+        --accent-hover: #0055d4;
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+        --success: #00d722;
+        --warn: #ffae13;
+        --danger: #ee1d36;
+
+        --font-display: "WF Visual Sans Variable", "Inter", Arial, system-ui, sans-serif;
+        --font-body: "WF Visual Sans Variable", "Inter", Arial, system-ui, sans-serif;
+        --font-mono: "Inconsolata", ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
+
+        --text-xs: 12px;
+        --text-sm: 14px;
+        --text-base: 16px;
+        --text-lg: 20px;
+        --text-xl: 24px;
+        --text-2xl: 32px;
+        --text-3xl: 56px;
+        --text-4xl: 80px;
+
+        --leading-body: 1.6;
+        --leading-tight: 1.04;
+        --tracking-display: -0.01em;
+
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+
+        --section-y-desktop: 96px;
+        --section-y-tablet: 64px;
+        --section-y-phone: 48px;
+
+        --radius-sm: 4px;
+        --radius-md: 4px;
+        --radius-lg: 8px;
+        --radius-pill: 9999px;
+
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised:
+          0px 84px 24px rgba(0, 0, 0, 0),
+          0px 54px 22px rgba(0, 0, 0, 0.01),
+          0px 30px 18px rgba(0, 0, 0, 0.04),
+          0px 13px 13px rgba(0, 0, 0, 0.08),
+          0px 3px 7px rgba(0, 0, 0, 0.09);
+
+        --focus-ring: 0 0 0 3px color-mix(in oklab, var(--accent), transparent 70%);
+
+        --motion-fast: 150ms;
+        --motion-base: 200ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+        --container-max: 1200px;
+        --container-gutter-desktop: 24px;
+        --container-gutter-tablet: 16px;
+        --container-gutter-phone: 12px;
+      }
+
+      /* ─── Reset ─────────────────────────────────────────────── */
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        font-weight: 500;
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+
+      /* ─── Layout ─────────────────────────────────────────────── */
+      .container { max-width: var(--container-max); margin-inline: auto; padding-inline: var(--container-gutter-desktop); }
+      section { padding-block: var(--section-y-desktop); }
+      section + section { border-top: 1px solid var(--border); }
+      @media (max-width: 991px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 479px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+
+      /* ─── Typography — display 600, body 500 (DESIGN.md §3) ── */
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        font-weight: 600;
+        line-height: var(--leading-tight);
+        color: var(--fg);
+        margin: 0;
+      }
+      h1 { font-size: var(--text-4xl); letter-spacing: var(--tracking-display); }
+      h2 { font-size: var(--text-3xl); letter-spacing: normal; }
+      h3 { font-size: var(--text-xl); font-weight: 500; line-height: 1.3; }
+      p { margin: 0; color: var(--fg-2); }
+      .lead { font-size: var(--text-lg); color: var(--fg-2); line-height: 1.4; }
+      .body-muted { color: var(--muted); }
+      .body-sm { font-size: var(--text-sm); }
+      /* Uppercase eyebrow — DESIGN.md §3 Micro Uppercase: 10–15px,
+         weight 500–600, wide tracking. We use 12px / 600 / 0.12em. */
+      .eyebrow {
+        font-family: var(--font-display);
+        font-size: var(--text-xs);
+        color: var(--accent);
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        font-weight: 600;
+        line-height: 1.3;
+      }
+      .stack-3 > * + * { margin-block-start: var(--space-3); }
+      .stack-4 > * + * { margin-block-start: var(--space-4); }
+      .stack-6 > * + * { margin-block-start: var(--space-6); }
+
+      /* ─── Buttons — 4px radius, 6px translate hover (DESIGN.md §4) */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: 12px 20px;
+        border-radius: var(--radius-sm);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        font-weight: 500;
+        line-height: 1;
+        letter-spacing: -0.01em;
+        cursor: pointer;
+        border: 1px solid transparent;
+        text-decoration: none;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard),
+          border-color var(--motion-fast) var(--ease-standard),
+          transform var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn .btn-icon {
+        transition: transform var(--motion-fast) var(--ease-standard);
+      }
+      /* The signature translate(6px) on the trailing icon — DESIGN.md §7 */
+      .btn:hover .btn-icon { transform: translateX(6px); }
+
+      /* Primary: Webflow Blue */
+      .btn-primary { background: var(--accent); color: var(--accent-on); }
+      .btn-primary:hover { background: var(--accent-hover); }
+      .btn-primary:active { background: var(--accent-active); }
+
+      /* Secondary: outlined, near-black ink — the precise builder look */
+      .btn-secondary {
+        background: var(--bg);
+        color: var(--fg);
+        border-color: var(--border);
+      }
+      .btn-secondary:hover { border-color: #898989; } /* DESIGN.md §2 Border Hover */
+
+      /* ─── Inputs — 4px radius, blue focus ring ──────────────── */
+      .field { display: flex; flex-direction: column; gap: var(--space-2); }
+      .field label {
+        font-size: var(--text-sm);
+        font-weight: 500;
+        color: var(--fg);
+      }
+      .field input {
+        padding: 12px 14px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        font-weight: 500;
+        outline: none;
+        transition:
+          border-color var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .field input:hover { border-color: #898989; }
+      .field input:focus-visible {
+        border-color: var(--accent);
+        box-shadow: var(--focus-ring);
+      }
+      .field input::placeholder { color: var(--meta); font-weight: 500; }
+      .field-help { font-size: var(--text-xs); color: var(--muted); }
+
+      /* ─── Cards — 1px border, 5-layer cascading shadow ──────── */
+      .card {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        padding: var(--space-6);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+        box-shadow: var(--elev-raised);
+        transition:
+          transform var(--motion-base) var(--ease-standard),
+          border-color var(--motion-base) var(--ease-standard);
+      }
+      .card:hover {
+        transform: translateY(-2px);
+        border-color: #898989;
+      }
+      .card .card-link {
+        color: var(--accent);
+        font-weight: 500;
+        margin-block-start: auto;
+        padding-block-start: var(--space-2);
+      }
+
+      /* ─── Badges — blue 10% tint, 4px radius (DESIGN.md §4) ─── */
+      .badge {
+        display: inline-flex; align-items: center; gap: var(--space-2);
+        padding: 4px var(--space-2);
+        border-radius: var(--radius-sm);
+        font-size: var(--text-xs);
+        font-weight: 550;
+        line-height: 1.2;
+        font-family: var(--font-display);
+      }
+      .badge-accent {
+        color: var(--accent);
+        background: color-mix(in oklab, var(--accent), transparent 90%);
+      }
+      .badge-success {
+        color: var(--success);
+        background: color-mix(in oklab, var(--success), transparent 88%);
+      }
+      .badge-dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
+
+      /* ─── Links + kbd ───────────────────────────────────────── */
+      a { color: var(--accent); text-decoration: none; }
+      a:hover { color: var(--accent-hover); text-decoration: underline; text-underline-offset: 3px; }
+      kbd {
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        padding: 2px 6px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+        background: var(--surface);
+        color: var(--muted);
+      }
+
+      /* ─── Section helpers ───────────────────────────────────── */
+      .hero-grid { display: grid; grid-template-columns: 1.4fr 1fr; gap: var(--space-12); align-items: end; }
+      @media (max-width: 991px) { .hero-grid { grid-template-columns: 1fr; gap: var(--space-8); } }
+      .hero-actions { display: flex; gap: var(--space-3); margin-block-start: var(--space-6); flex-wrap: wrap; }
+      .hero-meta {
+        display: flex; flex-direction: column; gap: var(--space-3);
+        padding: var(--space-5);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface);
+        box-shadow: var(--elev-raised);
+      }
+      .meta-row {
+        display: flex; align-items: center; justify-content: space-between;
+        gap: var(--space-3);
+        padding-block: var(--space-2);
+      }
+      .meta-row + .meta-row { border-top: 1px solid var(--border-soft); }
+      .features-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--space-6); }
+      @media (max-width: 991px) { .features-grid { grid-template-columns: 1fr 1fr; } }
+      @media (max-width: 479px) { .features-grid { grid-template-columns: 1fr; } }
+      .form-row { display: grid; grid-template-columns: 1.1fr 1fr; gap: var(--space-12); align-items: start; }
+      @media (max-width: 991px) { .form-row { grid-template-columns: 1fr; } }
+      .form { display: flex; flex-direction: column; gap: var(--space-4); max-width: 440px; }
+      .form-actions { display: flex; gap: var(--space-3); margin-block-start: var(--space-2); }
+      .icon { width: 16px; height: 16px; flex-shrink: 0; }
+      .row-between { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <section data-od-id="hero">
+        <div class="hero-grid">
+          <div class="stack-4">
+            <p class="eyebrow">Reference fixture · webflow</p>
+            <h1>Design and build production-ready websites — visually.</h1>
+            <p class="lead" style="max-width: 52ch">
+              The visual web platform for designers. Drag, configure, and ship sites
+              that meet the standards of the production web — no shortcuts, no compromises.
+            </p>
+            <div class="hero-actions">
+              <a href="./tokens.css" class="btn btn-primary">
+                Start building
+                <svg class="icon btn-icon" viewBox="0 0 24 24" fill="none"
+                  stroke="currentColor" stroke-width="1.75"
+                  stroke-linecap="round" stroke-linejoin="round"
+                  aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+              </a>
+              <a href="./DESIGN.md" class="btn btn-secondary">Read the spec</a>
+            </div>
+          </div>
+          <aside class="hero-meta" aria-label="System status">
+            <div class="meta-row">
+              <span class="body-sm body-muted">Render status</span>
+              <span class="badge badge-success">
+                <span class="badge-dot" aria-hidden="true"></span>
+                Live
+              </span>
+            </div>
+            <div class="meta-row">
+              <span class="body-sm body-muted">Brand version</span>
+              <span class="badge badge-accent">v1.0</span>
+            </div>
+            <div class="meta-row">
+              <span class="body-sm body-muted">Shortcut</span>
+              <span class="body-sm"><kbd>⌘</kbd> <kbd>K</kbd></span>
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <section data-od-id="features">
+        <div class="stack-3">
+          <p class="eyebrow">What this fixture exercises</p>
+          <h2 style="max-width: 22ch">A precise builder, made for the production web.</h2>
+        </div>
+        <div class="features-grid" style="margin-block-start: var(--space-8)">
+          <article class="card">
+            <h3>Webflow Blue, on purpose</h3>
+            <p class="body-muted body-sm">
+              --accent (#146ef5) is the single chromatic move — CTAs, links,
+              focus rings. Hover darkens to the documented #0055d4, not a formula.
+            </p>
+            <a href="./tokens.css" class="card-link body-sm">Inspect accents →</a>
+          </article>
+          <article class="card">
+            <h3>Five-layer cascading shadow</h3>
+            <p class="body-muted body-sm">
+              --elev-raised stacks five shadows from 84px presence to 3px contact.
+              Cards feel built into the page, not floating above it.
+            </p>
+            <a href="./DESIGN.md" class="card-link body-sm">Read the rule →</a>
+          </article>
+          <article class="card">
+            <h3>Sharp, conservative corners</h3>
+            <p class="body-muted body-sm">
+              --radius-sm and --radius-md sit at 4px; --radius-lg caps at 8px.
+              Nothing rounds beyond functional — precise, builder-grade geometry.
+            </p>
+            <a href="./tokens.css" class="card-link body-sm">Inspect radius →</a>
+          </article>
+        </div>
+      </section>
+
+      <section data-od-id="form">
+        <div class="form-row">
+          <div class="stack-4">
+            <p class="eyebrow">Form components</p>
+            <h2>Inputs on the white canvas.</h2>
+            <p class="body-muted" style="max-width: 48ch">
+              Border Gray (#d8d8d8) at rest, Border Hover (#898989) on hover,
+              Webflow Blue focus ring. The same precision applies to every interactive
+              surface — buttons, inputs, cards.
+            </p>
+          </div>
+          <form class="form" onsubmit="event.preventDefault();">
+            <div class="field">
+              <label for="email">Work email</label>
+              <input id="email" type="email" placeholder="you@studio.com" autocomplete="email" required />
+              <p class="field-help">We'll send a workspace invite — nothing else.</p>
+            </div>
+            <div class="form-actions">
+              <button type="submit" class="btn btn-primary">
+                Get started
+                <svg class="icon btn-icon" viewBox="0 0 24 24" fill="none"
+                  stroke="currentColor" stroke-width="1.75"
+                  stroke-linecap="round" stroke-linejoin="round"
+                  aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+              </button>
+              <button type="button" class="btn btn-secondary">Talk to sales</button>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/webflow/tokens.css
+++ b/design-systems/webflow/tokens.css
@@ -1,0 +1,191 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/webflow/tokens.css
+ *
+ * Structured token bindings for "Design System Inspired by Webflow".
+ * The visual web builder: a white marketing-grade canvas, near-black
+ * ink, the signature Webflow Blue (#146ef5), conservative 4px corners,
+ * and a five-layer cascading shadow that gives every card a built-not-
+ * floating quality.
+ *
+ * Key brand decisions encoded here:
+ *   - White canvas with near-black (#080808) text — DESIGN.md §1 / §9.
+ *     The marketing site does NOT shift surfaces warm; section variation
+ *     comes from borders + the 5-layer shadow stack, not from tinting.
+ *   - Webflow Blue (#146ef5) as the single accent, with the documented
+ *     darker Button Hover Blue (#0055d4) as `--accent-hover` (not a
+ *     formulaic black-mix — Webflow's docs specify the hover value).
+ *   - Four-tier foreground ramp: #080808 → #363636 → #5a5a5a → #ababab,
+ *     matching the Near Black / Gray 700 / Mid Gray / Gray 300 scale
+ *     from DESIGN.md §2 so cross-brand components targeting --fg-2 and
+ *     --meta resolve to Webflow's actual gray ramp.
+ *   - Conservative radius (4px–8px). DESIGN.md §7 forbids rounding
+ *     beyond 8px for functional elements — sharp, precise, tool-like.
+ *   - Five-layer cascading shadow on --elev-raised, reproduced verbatim
+ *     from DESIGN.md §2 / §6: the stack is the depth signature and
+ *     should never be flattened to a single blur.
+ *   - WF Visual Sans Variable display + body, Inconsolata for code —
+ *     the dual identity DESIGN.md §3 calls out (design + code).
+ *   - Webflow Green / Yellow / Red bound to semantic tokens (DESIGN.md
+ *     §2 Secondary Accents) so semantic state stays inside the brand
+ *     palette rather than borrowing the schema's generic hues.
+ *
+ * Source contracts:
+ *   - Standard token names: design-systems/_schema/tokens.schema.ts
+ *   - A2 fallback parity:   design-systems/_schema/defaults.css
+ *   - Lint enforcement:     apps/daemon/src/lint-artifact.ts
+ * ─────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── Surface (no warm tier) ───────────────────────────────────────
+   * Webflow's marketing canvas is pure white. Sections do not shift
+   * background color — depth comes from the 5-layer shadow stack and
+   * 1px borders, not from tinted surfaces. `--surface-warm` aliases
+   * to surface because the brand has no warmer tier. */
+  --bg: #ffffff;                      /* White — the page canvas */
+  --surface: #ffffff;                 /* White — cards stay flush with the canvas */
+  --surface-warm: var(--surface);     /* alias — Webflow has no warm tier */
+
+  /* ─── Foreground ramp (4 levels) ──────────────────────────────────
+   * Near Black → Gray 700 → Mid Gray → Gray 300, the four documented
+   * text tiers from DESIGN.md §2 (headings / body / captions / muted).
+   * `#080808` instead of `#000000` matters — DESIGN.md §1 / §9 names
+   * the near-black explicitly. The four tiers are independently bound
+   * (not aliased) because Webflow's marketing site genuinely uses all
+   * four: H1 black, body Gray 700, captions Mid Gray, placeholder /
+   * disabled Gray 300. */
+  --fg: #080808;                      /* Near Black — primary text */
+  --fg-2: #363636;                    /* Gray 700 — body description */
+  --muted: #5a5a5a;                   /* Mid Gray — captions, link text */
+  --meta: #ababab;                    /* Gray 300 — placeholder, disabled */
+
+  /* ─── Border (2 levels) ──────────────────────────────────────────
+   * Borders are visible and structural in Webflow — `1px solid #d8d8d8`
+   * is the documented card edge (DESIGN.md §4). `--border-soft` drops
+   * to a paler tint for inner row separators that must not visually
+   * compete with the card outline. */
+  --border: #d8d8d8;                  /* Border Gray — card / divider edge */
+  --border-soft: #ebebeb;             /* paler tint — inner row separator */
+
+  /* ─── Accent ─────────────────────────────────────────────────────
+   * Webflow Blue (#146ef5): primary CTA, link, focus ring, badge tint.
+   * `--accent-hover` is the documented Button Hover Blue (#0055d4),
+   * NOT a formulaic black-mix — Webflow's brand spec names the darker
+   * value, so we honor it verbatim instead of computing one. Hard cap
+   * of ≤2 visible uses per screen (schema lint). */
+  --accent: #146ef5;                  /* Webflow Blue — primary brand signal */
+  --accent-on: #ffffff;               /* white label on saturated blue */
+  --accent-hover: #0055d4;            /* Button Hover Blue — documented value */
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+
+  /* ─── Semantic ───────────────────────────────────────────────────
+   * Bound to Webflow's secondary palette (DESIGN.md §2) so state
+   * colors live inside the brand instead of borrowing the schema's
+   * generic semantic hues. Webflow Green / Yellow / Red are vivid
+   * enough to read as state without falling out of the system. */
+  --success: #00d722;                 /* Webflow Green */
+  --warn: #ffae13;                    /* Webflow Yellow */
+  --danger: #ee1d36;                  /* Webflow Red */
+
+  /* ─── Typography — fonts ─────────────────────────────────────────
+   * WF Visual Sans Variable is Webflow's custom variable face used at
+   * weight 500–600 throughout. Inter/Arial fall back so artifacts
+   * render legibly when the brand face is not loaded. Inconsolata is
+   * the companion monospace from DESIGN.md §3 — the "design + code"
+   * dual identity is part of the brand voice. */
+  --font-display: "WF Visual Sans Variable", "Inter", Arial, system-ui, sans-serif;
+  --font-body: "WF Visual Sans Variable", "Inter", Arial, system-ui, sans-serif;
+  --font-mono: "Inconsolata", ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
+
+  /* Type scale (px) — DESIGN.md §3 hierarchy table. Display hero is
+   * 80px (the big marketing-page number), section heading is 56px,
+   * sub-heading 32px, feature 24px, body 20px, body-standard 16px,
+   * caption 14px. The schema's 8 tiers map directly onto Webflow's
+   * documented sizes. */
+  --text-xs: 12px;                    /* badge uppercase / micro */
+  --text-sm: 14px;                    /* caption */
+  --text-base: 16px;                  /* body standard / button */
+  --text-lg: 20px;                    /* body */
+  --text-xl: 24px;                    /* feature title */
+  --text-2xl: 32px;                   /* sub-heading */
+  --text-3xl: 56px;                   /* section heading */
+  --text-4xl: 80px;                   /* display hero */
+
+  /* `--leading-tight` is 1.04 (DESIGN.md §3 display + section line-
+   * height). `--leading-body` is 1.6 (the documented body-standard
+   * ratio). `--tracking-display` is `-0.01em`, the em-relative form
+   * of Webflow's `-0.8px at 80px` display tracking — scales correctly
+   * with size. */
+  --leading-body: 1.6;
+  --leading-tight: 1.04;
+  --tracking-display: -0.01em;
+
+  /* ─── Spacing ────────────────────────────────────────────────────
+   * 4px-grid base. DESIGN.md §5's fractional scale (2.4 / 3.2 / 5.6 /
+   * 7.2 / 9.6) is component-internal micro-padding and is inlined
+   * per-component; the 4/8/12/16/20/24/32/48 tier carries the
+   * structural rhythm. */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+
+  /* Section rhythm — Webflow's marketing sections breathe but stay
+   * tighter than a gallery: 96px desktop, 64px tablet, 48px phone
+   * (matching the documented 992 / 768 / 479 breakpoints in §8). */
+  --section-y-desktop: 96px;
+  --section-y-tablet: 64px;
+  --section-y-phone: 48px;
+
+  /* ─── Radius ─────────────────────────────────────────────────────
+   * DESIGN.md §5: 2 / 4 / 8 / 50%. The "Do" list (§7) is explicit:
+   * 4px is the default, do NOT round beyond 8px for functional
+   * elements. We bind sm/md to 4px (buttons, inputs, cards), lg to
+   * 8px (featured containers), pill to 9999px (badges, avatars). */
+  --radius-sm: 4px;                   /* buttons, inputs, chips */
+  --radius-md: 4px;                   /* cards, modals — same conservative 4px */
+  --radius-lg: 8px;                   /* featured containers — the soft cap */
+  --radius-pill: 9999px;              /* badges, avatars */
+
+  /* ─── Elevation (3 levels, raised = 5-layer cascade) ─────────────
+   * The 5-layer shadow stack from DESIGN.md §2 / §6 is the depth
+   * signature. The outer layer at 84px is a "presence" cushion (alpha
+   * 0), the inner 3px layer is the contact shadow, and three middle
+   * layers create the smooth falloff. Never flatten this stack to a
+   * single blur — the cascade is what makes Webflow cards feel
+   * physically built rather than digitally floating. */
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised:
+    0px 84px 24px rgba(0, 0, 0, 0),
+    0px 54px 22px rgba(0, 0, 0, 0.01),
+    0px 30px 18px rgba(0, 0, 0, 0.04),
+    0px 13px 13px rgba(0, 0, 0, 0.08),
+    0px 3px 7px rgba(0, 0, 0, 0.09);
+
+  /* ─── Focus ring ─────────────────────────────────────────────────
+   * Webflow Blue at 30% — the accent is already the brand's focus
+   * color in product, so the schema default (alpha glow of accent)
+   * matches without override. */
+  --focus-ring: 0 0 0 3px color-mix(in oklab, var(--accent), transparent 70%);
+
+  /* ─── Motion ─────────────────────────────────────────────────────
+   * 150 / 200ms with standard easing. Webflow's marketing site uses a
+   * 6px translate hover on buttons (DESIGN.md §4) — that micro-move
+   * runs at --motion-fast. */
+  --motion-fast: 150ms;
+  --motion-base: 200ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+
+  /* ─── Layout ─────────────────────────────────────────────────────
+   * 1200px max content width — Webflow's marketing pages cap around
+   * this width to keep line lengths readable. Breakpoints from
+   * DESIGN.md §8 (992 / 768 / 479) gate the gutter scale. */
+  --container-max: 1200px;
+  --container-gutter-desktop: 24px;
+  --container-gutter-tablet: 16px;
+  --container-gutter-phone: 12px;
+}


### PR DESCRIPTION
## Why

Same motivation as #1841 and #2023: the design-system library ships `tokens.css` + `components.html` as the two agent-consumable artifacts that let an AI produce on-brand HTML without reasoning from prose. This batch adds 10 more brands that previously shipped only `DESIGN.md`.

Selection: Tier B (AI-adjacent devtools / SaaS) — `sentry`, `framer`, `webflow`, `warp`, `arc` — completes the developer-tools shelf alongside #2023's supabase/posthog/resend/shadcn/raycast. Tier C (productivity / consumer) — `cal`, `loom`, `canva`, `meta`, `duolingo` — broadens the catalogue beyond pure devtools to scheduling, async video, mass-consumer design, social/corporate, and gamified consumer surfaces, so agents have meaningful reference points outside the engineering aesthetic cluster.

Concrete pain: "make this look like Duolingo / Canva / Arc / Sentry" currently degrades to generic output because there's no structured `:root` to paste. After this PR an agent gets a 56-token block + working fixture for each.

## What users will see

No product UI change. Design-system consumers (skills, agents, external tooling) gain structured token files for:

**Tier B — AI-adjacent devtools / SaaS**
- **sentry** — `#1f1633` deep brand purple canvas, Sentry Purple `#6a5fc1` accent for interactive (lime `#c2ef4e` reserved as inline once-per-section pop), no neutral grays, frosted-glass depth, sharp 2px solid focus ring per DESIGN.md §4
- **framer** — Pure void `#000000` + near-black `#090909` surfaces, Framer Blue `#0099ff` accent (ring-shadow alpha bound to `--border` for signature blue hairline), 4-tier white foreground ramp, pill radii on all interactive, 110px display hero with `-0.05em` em-relative tracking
- **webflow** — White canvas + `#080808` near-black text per DESIGN.md (not the dark-canvas hint I gave the subagent), Webflow Blue with documented `#0055d4` hover, four independently-bound foreground levels, 5-layer cascading elevation shadow reproduced verbatim
- **warp** — Monochromatic warm-grays per DESIGN.md (no chromatic accent, no gradient, no glass), Warm Parchment text on warm near-black, Earth Gray `#353534` pill CTA as the "restrained accent", brightest-legal Warm Parchment focus ring at 50% alpha (color ring would dilute against the warm-dark canvas)
- **arc** — Warm peach-cream `#fdf3ec` canvas with frosted body layering three soft radial Sunset washes, Arc Coral `#ff5f5f` as solvable `--accent` (Sunset gradient composed inline in primary CTA so token derivations stay valid), independently-bound warm surface tier, 4px focus halo per DESIGN.md §4

**Tier C — productivity / consumer**
- **cal** — Minimalist black/white, `#242424` Charcoal text (not pure black, the warm signature), Link Blue `#0099ff` as the single non-grayscale value reserved for hyperlinks, Charcoal-as-CTA pattern (Vercel-style), shadow-as-border alpha bound to `--border`
- **loom** — Loom purple accent with three-tier text stack (Ink/Slate/Mist), independently-bound Mist for placeholders/disabled per DESIGN.md §7, easeOutQuart standard easing for "friendly snappy" voice
- **canva** — Compressed 11/12/14/16/18/24/36/64 type scale, Canva purple `#7d2ae8` accent (Pro/Magic moment gradient composed inline on the primary CTA), independently-bound brand semantic colors (Canva Pink doubles as `--danger`)
- **meta** — Pure white canvas, Meta Blue `#0064E0` pill CTAs, Optimistic VF type, dual-shadow elevation, 1440px gallery container; gradient brand mark stays inline as a decorative `.brand-mark` dot — no new tokens
- **duolingo** — Owl green `#58cc02` accent that also IS `--success` (DESIGN.md: green literally means "correct"), chunky 4px hard-offset shadow encoded as `--elev-raised` for the tactile press affordance, primary-button shadow uses `var(--accent-active)` (`#58a700` deep-green underside), back-out spring easing `cubic-bezier(0.34, 1.56, 0.64, 1)` at 320ms for gamified overshoot

Each `components.html` embeds the full 56-token `:root` block inline so agents can copy-paste it into any `<style>` with zero external dependency, and each ships a working hero / 3-card features / form fixture exercising the brand voice.

## Surface area

- [x] **Extension point** — 10 new brand pairs under `design-systems/`
- [ ] UI / Keyboard / CLI / API / i18n / Dependencies / Default behavior

## Validation

- `pnpm guard` — passes, 36 brand pairs aligned (26 existing + 10 new); A1 (26) / A2 (26) / B-slot (4) declared by every new brand; zero new C-extensions (`BRAND_EXTENSIONS` unchanged)
- Each new pair was independently verified for `:root` byte-equivalence between `tokens.css` and `components.html` via `pnpm exec tsx scripts/check-tokens-fixture-sync.ts`
- The remaining `apps/landing-page` astro typecheck failure is pre-existing on main and unrelated to this PR (also noted in #2023)


Made with [Cursor](https://cursor.com)