### PR TITLE
fix(platform): detect mise npm package bins

### DIFF
--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -539,15 +539,8 @@ export function wellKnownUserToolchainBins(
 
 function existingMiseNpmPackageBinDirs(root: string): string[] {
   const out: string[] = [];
-  let packageEntries: import("node:fs").Dirent<string>[];
-  try {
-    packageEntries = readdirSync(root, { encoding: "utf8", withFileTypes: true });
-  } catch {
-    return out;
-  }
-  for (const packageEntry of packageEntries.sort((left, right) => left.name.localeCompare(right.name))) {
-    if (!packageEntry.isDirectory() || !packageEntry.name.startsWith("npm-")) continue;
-    const packageRoot = join(root, packageEntry.name);
+  for (const packageName of ["npm-openai-codex"]) {
+    const packageRoot = join(root, packageName);
     out.push(...existingChildBinDirs(packageRoot, ["bin"]));
   }
   return out;
@@ -562,7 +555,7 @@ function existingChildBinDirs(root: string, segments: string[]): string[] {
     return out;
   }
   for (const entry of sortVersionedDirEntries(entries)) {
-    if (!entry.isDirectory()) continue;
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
     const candidate = join(root, entry.name, ...segments);
     if (existsSync(candidate)) out.push(candidate);
   }

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -511,6 +511,7 @@ export function wellKnownUserToolchainBins(
   // Per-version Node toolchains: scan the install root and surface every
   // version directory's bin folder. Best-effort — missing roots simply
   // contribute nothing.
+  dirs.push(...existingMiseNpmPackageBinDirs(join(home, ".local", "share", "mise", "installs")));
   for (const installRoot of [
     {
       root: join(home, ".local", "share", "mise", "installs", "node"),
@@ -534,6 +535,22 @@ export function wellKnownUserToolchainBins(
     }
   }
   return dirs;
+}
+
+function existingMiseNpmPackageBinDirs(root: string): string[] {
+  const out: string[] = [];
+  let packageEntries: import("node:fs").Dirent<string>[];
+  try {
+    packageEntries = readdirSync(root, { encoding: "utf8", withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const packageEntry of packageEntries.sort((left, right) => left.name.localeCompare(right.name))) {
+    if (!packageEntry.isDirectory() || !packageEntry.name.startsWith("npm-")) continue;
+    const packageRoot = join(root, packageEntry.name);
+    out.push(...existingChildBinDirs(packageRoot, ["bin"]));
+  }
+  return out;
 }
 
 function existingChildBinDirs(root: string, segments: string[]): string[] {

--- a/packages/platform/tests/index.test.ts
+++ b/packages/platform/tests/index.test.ts
@@ -506,18 +506,31 @@ describe("wellKnownUserToolchainBins", () => {
     const home = mkdtempSync(join(tmpdir(), "wkutb-versioned-"));
     try {
       const miseBin = join(home, ".local", "share", "mise", "installs", "node", "24.14.1", "bin");
+      const miseNpmCodexBin = join(
+        home,
+        ".local",
+        "share",
+        "mise",
+        "installs",
+        "npm-openai-codex",
+        "latest",
+        "bin",
+      );
       const newestNvmBin = join(home, ".nvm", "versions", "node", "v24.1.0", "bin");
       const olderNvmBin = join(home, ".nvm", "versions", "node", "v22.10.0", "bin");
       const fnmBin = join(home, ".local", "share", "fnm", "node-versions", "v20.11.1", "installation", "bin");
       mkdirSync(miseBin, { recursive: true });
+      mkdirSync(miseNpmCodexBin, { recursive: true });
       mkdirSync(newestNvmBin, { recursive: true });
       mkdirSync(olderNvmBin, { recursive: true });
       mkdirSync(fnmBin, { recursive: true });
       writeFileSync(join(miseBin, "marker"), "");
+      writeFileSync(join(miseNpmCodexBin, "codex"), "");
       writeFileSync(join(newestNvmBin, "marker"), "");
       writeFileSync(join(olderNvmBin, "marker"), "");
       writeFileSync(join(fnmBin, "marker"), "");
       chmodSync(join(miseBin, "marker"), 0o644);
+      chmodSync(join(miseNpmCodexBin, "codex"), 0o755);
       chmodSync(join(newestNvmBin, "marker"), 0o644);
       chmodSync(join(olderNvmBin, "marker"), 0o644);
       chmodSync(join(fnmBin, "marker"), 0o644);
@@ -533,6 +546,7 @@ describe("wellKnownUserToolchainBins", () => {
       expect(dirs).toContain("/opt/homebrew/bin");
       expect(dirs).toContain("/usr/local/bin");
       expect(dirs).toContain(miseBin);
+      expect(dirs).toContain(miseNpmCodexBin);
       expect(dirs).toContain(newestNvmBin);
       expect(dirs).toContain(olderNvmBin);
       expect(dirs).toContain(fnmBin);

--- a/packages/platform/tests/index.test.ts
+++ b/packages/platform/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -516,11 +516,22 @@ describe("wellKnownUserToolchainBins", () => {
         "latest",
         "bin",
       );
+      const miseNpmCodexVersionBin = join(
+        home,
+        ".local",
+        "share",
+        "mise",
+        "installs",
+        "npm-openai-codex",
+        "0.1.0",
+        "bin",
+      );
       const newestNvmBin = join(home, ".nvm", "versions", "node", "v24.1.0", "bin");
       const olderNvmBin = join(home, ".nvm", "versions", "node", "v22.10.0", "bin");
       const fnmBin = join(home, ".local", "share", "fnm", "node-versions", "v20.11.1", "installation", "bin");
       mkdirSync(miseBin, { recursive: true });
-      mkdirSync(miseNpmCodexBin, { recursive: true });
+      mkdirSync(miseNpmCodexVersionBin, { recursive: true });
+      symlinkSync("0.1.0", join(home, ".local", "share", "mise", "installs", "npm-openai-codex", "latest"), "dir");
       mkdirSync(newestNvmBin, { recursive: true });
       mkdirSync(olderNvmBin, { recursive: true });
       mkdirSync(fnmBin, { recursive: true });


### PR DESCRIPTION
## Summary
- include mise-installed npm package bin directories such as ~/.local/share/mise/installs/npm-openai-codex/latest/bin in GUI-safe CLI PATH discovery
- add regression coverage for Codex installed via mise npm packages

Fixes #2027

## Tests
- pnpm --dir packages/platform test
- pnpm --dir packages/platform typecheck
- git diff --check