### PR TITLE
fix(plugins): reject symlinked plugin assets

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -5212,17 +5212,26 @@ export async function startServer({
       const fsp = await import('node:fs/promises');
       const resolved = path.resolve(plugin.fsPath, relpath);
       // Final containment check — `resolved` must stay under fsPath.
-      const root = path.resolve(plugin.fsPath) + path.sep;
-      if (!(resolved + path.sep).startsWith(root) && resolved !== path.resolve(plugin.fsPath)) {
+      const root = path.resolve(plugin.fsPath);
+      const rootWithSep = root.endsWith(path.sep) ? root : `${root}${path.sep}`;
+      if (!(resolved + path.sep).startsWith(rootWithSep) && resolved !== root) {
         return res.status(400).json({ error: 'asset escape rejected' });
       }
-      let stat;
+      const relativeSegments = path.relative(root, resolved).split(path.sep).filter(Boolean);
+      let current = root;
       try {
-        stat = await fsp.lstat(resolved);
+        const rootStat = await fsp.lstat(current);
+        if (rootStat.isSymbolicLink()) {
+          return res.status(404).json({ error: 'asset not found' });
+        }
+        for (const segment of relativeSegments) {
+          current = path.join(current, segment);
+          const stat = await fsp.lstat(current);
+          if (stat.isSymbolicLink()) {
+            return res.status(404).json({ error: 'asset not found' });
+          }
+        }
       } catch {
-        return res.status(404).json({ error: 'asset not found' });
-      }
-      if (stat.isSymbolicLink()) {
         return res.status(404).json({ error: 'asset not found' });
       }
       try {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -5216,6 +5216,25 @@ export async function startServer({
       if (!(resolved + path.sep).startsWith(root) && resolved !== path.resolve(plugin.fsPath)) {
         return res.status(400).json({ error: 'asset escape rejected' });
       }
+      let stat;
+      try {
+        stat = await fsp.lstat(resolved);
+      } catch {
+        return res.status(404).json({ error: 'asset not found' });
+      }
+      if (stat.isSymbolicLink()) {
+        return res.status(404).json({ error: 'asset not found' });
+      }
+      try {
+        const rootReal = await fsp.realpath(plugin.fsPath);
+        const resolvedReal = await fsp.realpath(resolved);
+        const rootRealWithSep = rootReal.endsWith(path.sep) ? rootReal : `${rootReal}${path.sep}`;
+        if (resolvedReal !== rootReal && !resolvedReal.startsWith(rootRealWithSep)) {
+          return res.status(400).json({ error: 'asset escape rejected' });
+        }
+      } catch {
+        return res.status(404).json({ error: 'asset not found' });
+      }
       let buf;
       try {
         buf = await fsp.readFile(resolved);

--- a/apps/daemon/tests/plugins-asset-route.test.ts
+++ b/apps/daemon/tests/plugins-asset-route.test.ts
@@ -84,11 +84,15 @@ beforeAll(async () => {
   await writeFile(secretPath, 'outside secret');
   await writeFile(path.join(outsideDir, 'nested-secret.txt'), 'nested outside secret');
   const installedSurfacesDir = path.join(defaultRegistryRoots().userPluginsRoot, 'asset-plugin', 'surfaces');
+  const installedInternalDir = path.join(defaultRegistryRoots().userPluginsRoot, 'asset-plugin', 'internal-assets');
+  await mkdir(installedInternalDir, { recursive: true });
+  await writeFile(path.join(installedInternalDir, 'nested-internal.txt'), 'nested internal secret');
   await symlink(
     secretPath,
     path.join(installedSurfacesDir, 'leak.txt'),
   );
   await symlink(outsideDir, path.join(installedSurfacesDir, 'linked-outside'), 'dir');
+  await symlink(installedInternalDir, path.join(installedSurfacesDir, 'linked-internal'), 'dir');
   void migratePlugins;
   void upsertInstalledPlugin;
   void Database;
@@ -139,7 +143,13 @@ describe('GET /api/plugins/:id/asset/*', () => {
 
   it('rejects assets reached through a symlinked directory inside the plugin root', async () => {
     const resp = await fetch(`${baseUrl}/api/plugins/asset-plugin/asset/surfaces/linked-outside/nested-secret.txt`);
-    expect(resp.status).toBe(400);
+    expect(resp.status).toBe(404);
     expect(await resp.text()).not.toContain('nested outside secret');
+  });
+
+  it('rejects assets reached through an internal symlinked directory inside the plugin root', async () => {
+    const resp = await fetch(`${baseUrl}/api/plugins/asset-plugin/asset/surfaces/linked-internal/nested-internal.txt`);
+    expect(resp.status).toBe(404);
+    expect(await resp.text()).not.toContain('nested internal secret');
   });
 });

--- a/apps/daemon/tests/plugins-asset-route.test.ts
+++ b/apps/daemon/tests/plugins-asset-route.test.ts
@@ -12,13 +12,13 @@
 
 import type http from 'node:http';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
 import { startServer } from '../src/server.js';
 import { migratePlugins } from '../src/plugins/persistence.js';
-import { upsertInstalledPlugin } from '../src/plugins/registry.js';
+import { defaultRegistryRoots, upsertInstalledPlugin } from '../src/plugins/registry.js';
 
 let server: http.Server;
 let baseUrl: string;
@@ -78,6 +78,12 @@ beforeAll(async () => {
       if (done) break;
     }
   }
+  const secretPath = path.join(pluginRoot, 'secret.txt');
+  await writeFile(secretPath, 'outside secret');
+  await symlink(
+    secretPath,
+    path.join(defaultRegistryRoots().userPluginsRoot, 'asset-plugin', 'surfaces', 'leak.txt'),
+  );
   void migratePlugins;
   void upsertInstalledPlugin;
   void Database;
@@ -86,6 +92,7 @@ beforeAll(async () => {
 afterAll(async () => {
   await Promise.resolve(shutdown?.());
   await new Promise<void>((resolve) => server.close(() => resolve()));
+  await rm(path.join(defaultRegistryRoots().userPluginsRoot, 'asset-plugin'), { recursive: true, force: true });
   await rm(pluginRoot, { recursive: true, force: true });
 });
 
@@ -116,5 +123,11 @@ describe('GET /api/plugins/:id/asset/*', () => {
   it('returns 404 for a missing asset under a known plugin', async () => {
     const resp = await fetch(`${baseUrl}/api/plugins/asset-plugin/asset/does/not/exist.html`);
     expect(resp.status).toBe(404);
+  });
+
+  it('rejects symlinked assets inside the plugin root', async () => {
+    const resp = await fetch(`${baseUrl}/api/plugins/asset-plugin/asset/surfaces/leak.txt`);
+    expect(resp.status).toBe(404);
+    expect(await resp.text()).not.toContain('outside secret');
   });
 });

--- a/apps/daemon/tests/plugins-asset-route.test.ts
+++ b/apps/daemon/tests/plugins-asset-route.test.ts
@@ -79,17 +79,23 @@ beforeAll(async () => {
     }
   }
   const secretPath = path.join(pluginRoot, 'secret.txt');
+  const outsideDir = path.join(pluginRoot, 'outside');
+  await mkdir(outsideDir, { recursive: true });
   await writeFile(secretPath, 'outside secret');
+  await writeFile(path.join(outsideDir, 'nested-secret.txt'), 'nested outside secret');
+  const installedSurfacesDir = path.join(defaultRegistryRoots().userPluginsRoot, 'asset-plugin', 'surfaces');
   await symlink(
     secretPath,
-    path.join(defaultRegistryRoots().userPluginsRoot, 'asset-plugin', 'surfaces', 'leak.txt'),
+    path.join(installedSurfacesDir, 'leak.txt'),
   );
+  await symlink(outsideDir, path.join(installedSurfacesDir, 'linked-outside'), 'dir');
   void migratePlugins;
   void upsertInstalledPlugin;
   void Database;
 });
 
 afterAll(async () => {
+  await fetch(`${baseUrl}/api/plugins/asset-plugin/uninstall`, { method: 'POST' }).catch(() => undefined);
   await Promise.resolve(shutdown?.());
   await new Promise<void>((resolve) => server.close(() => resolve()));
   await rm(path.join(defaultRegistryRoots().userPluginsRoot, 'asset-plugin'), { recursive: true, force: true });
@@ -129,5 +135,11 @@ describe('GET /api/plugins/:id/asset/*', () => {
     const resp = await fetch(`${baseUrl}/api/plugins/asset-plugin/asset/surfaces/leak.txt`);
     expect(resp.status).toBe(404);
     expect(await resp.text()).not.toContain('outside secret');
+  });
+
+  it('rejects assets reached through a symlinked directory inside the plugin root', async () => {
+    const resp = await fetch(`${baseUrl}/api/plugins/asset-plugin/asset/surfaces/linked-outside/nested-secret.txt`);
+    expect(resp.status).toBe(400);
+    expect(await resp.text()).not.toContain('nested outside secret');
   });
 });


### PR DESCRIPTION
Fixes #2000

## Why

Plugin assets should not be served through symlinks. A plugin package can otherwise expose files through symlinked entries inside its asset tree, which makes the daemon asset route harder to reason about and weakens the installed-plugin filesystem boundary.

## What users will see

No UI changes. Plugin asset requests that traverse a symlinked file or directory now return `404` instead of serving the target file.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this is daemon asset-route behavior with no UI surface.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/plugins-asset-route.test.ts`
- The regression tests cover direct symlinked assets, symlinked directories that escape the installed plugin tree, and symlinked directories that point to another location inside the installed plugin tree.

## Validation

- `pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/plugins-asset-route.test.ts`
- `pnpm --dir apps/daemon typecheck`
- `git diff --check`
