### PR TITLE
feat(design-systems): add next 20 brand token fixtures

### DIFF
--- a/design-systems/bmw-m/components.html
+++ b/design-systems/bmw-m/components.html
@@ -1,0 +1,342 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>BMW M - reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/bmw-m: precise motorsport interface with white engineering calm and sharp M color signals."
+    />
+    <style>
+      :root {
+        --bg: #f7f8fa;
+        --surface: #ffffff;
+        --surface-warm: #eef3f8;
+        --fg: #111827;
+        --fg-2: #334155;
+        --muted: #64748b;
+        --meta: #0066b1;
+        --border: #d7dee8;
+        --border-soft: #edf1f6;
+        --accent: #0066b1;
+        --accent-on: #ffffff;
+        --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+        --success: #16a34a;
+        --warn: #f59e0b;
+        --danger: #e4002b;
+        --font-display: "BMWTypeNext", "Helvetica Neue", Arial, sans-serif;
+        --font-body: "BMWTypeNext", "Helvetica Neue", Arial, sans-serif;
+        --font-mono: "SF Mono", ui-monospace, Menlo, monospace;
+        --text-xs: 12px;
+        --text-sm: 14px;
+        --text-base: 16px;
+        --text-lg: 18px;
+        --text-xl: 24px;
+        --text-2xl: 36px;
+        --text-3xl: 56px;
+        --text-4xl: 78px;
+        --leading-body: 1.5;
+        --leading-tight: 1.02;
+        --tracking-display: -0.025em;
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+        --section-y-desktop: 104px;
+        --section-y-tablet: 76px;
+        --section-y-phone: 52px;
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 14px;
+        --radius-pill: 9999px;
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised: 0 22px 56px rgba(17, 24, 39, 0.12);
+        --focus-ring: 0 0 0 4px rgba(0, 102, 177, 0.24);
+        --motion-fast: 130ms;
+        --motion-base: 220ms;
+        --ease-standard: cubic-bezier(0.16, 1, 0.3, 1);
+        --container-max: 1220px;
+        --container-gutter-desktop: 40px;
+        --container-gutter-tablet: 28px;
+        --container-gutter-phone: 18px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        min-height: 100vh;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+      .page {
+        min-height: 100vh;
+        background: linear-gradient(135deg, #f7f8fa 0%, #ffffff 52%, #dbeafe 100%);
+      }
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+      h1, h2, h3, p { margin: 0; }
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        line-height: var(--leading-tight);
+        letter-spacing: var(--tracking-display);
+      }
+      h1 { max-width: 820px; font-size: var(--text-4xl); font-weight: 700; }
+      h2 { font-size: var(--text-3xl); font-weight: 650; }
+      h3 { font-size: var(--text-xl); font-weight: 650; }
+      .eyebrow {
+        color: var(--meta);
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+      .lead {
+        max-width: 620px;
+        color: var(--fg-2);
+        font-size: var(--text-lg);
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+        gap: var(--space-8);
+        align-items: center;
+      }
+      .stack > * + * { margin-block-start: var(--space-4); }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3);
+        margin-block-start: var(--space-6);
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 44px;
+        padding: 0 var(--space-5);
+        border: 1px solid transparent;
+        border-radius: var(--radius-md);
+        font: 700 var(--text-sm) / 1 var(--font-body);
+        text-decoration: none;
+        cursor: pointer;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          border-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard),
+          transform var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn-primary { background: var(--accent); color: var(--accent-on); }
+      .btn-primary:hover { background: var(--accent-hover); transform: translateY(-1px); }
+      .btn-secondary { background: var(--surface); color: var(--fg); border-color: var(--border); box-shadow: var(--elev-ring); }
+      .btn-secondary:hover { border-color: var(--accent); color: var(--accent); }
+      .panel {
+        background: color-mix(in oklab, var(--surface), transparent 4%);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--elev-raised);
+        overflow: hidden;
+      }
+      .panel-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+        padding: var(--space-5);
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .status {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        color: var(--meta);
+        font: 700 var(--text-xs) / 1 var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .status::before {
+        width: 8px;
+        height: 8px;
+        border-radius: var(--radius-pill);
+        background: var(--success);
+        content: "";
+      }
+      .metric-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .metric {
+        padding: var(--space-5);
+        border-right: 1px solid var(--border-soft);
+      }
+      .metric:last-child { border-right: 0; }
+      .metric strong {
+        display: block;
+        font-family: var(--font-display);
+        font-size: var(--text-2xl);
+        line-height: var(--leading-tight);
+      }
+      .metric span { color: var(--muted); font-size: var(--text-sm); }
+      .card-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-4);
+        padding: var(--space-5);
+      }
+      .mini-card {
+        min-height: 148px;
+        padding: var(--space-5);
+        border: 1px solid var(--border-soft);
+        border-radius: var(--radius-md);
+        background: var(--surface-warm);
+      }
+      .mini-card p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      .swatches {
+        display: flex;
+        gap: var(--space-2);
+        margin-block-start: var(--space-4);
+      }
+      .swatch {
+        width: 32px;
+        height: 32px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+      }
+      .swatch.accent { background: var(--accent); }
+      .swatch.surface { background: var(--surface); }
+      .swatch.warm { background: var(--surface-warm); }
+      .swatch.fg { background: var(--fg); }
+      .field {
+        display: grid;
+        gap: var(--space-2);
+        margin-block-start: var(--space-5);
+      }
+      label { color: var(--fg-2); font-size: var(--text-sm); font-weight: 700; }
+      input {
+        width: 100%;
+        min-height: 46px;
+        padding: 0 var(--space-4);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--surface);
+        color: var(--fg);
+        font: inherit;
+      }
+      input:focus { outline: none; box-shadow: var(--focus-ring); border-color: var(--accent); }
+      .lower {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: var(--space-4);
+      }
+      .tile {
+        padding: var(--space-5);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface);
+      }
+      .tile p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      @media (max-width: 860px) {
+        .hero, .lower { grid-template-columns: 1fr; }
+        .metric-grid, .card-row { grid-template-columns: 1fr; }
+        .metric { border-right: 0; border-bottom: 1px solid var(--border-soft); }
+        .metric:last-child { border-bottom: 0; }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <section>
+        <div class="container hero">
+          <div class="stack">
+            <p class="eyebrow">BMW M design system</p>
+            <h1>Motorsport cockpit</h1>
+            <p class="lead">White engineering surfaces, M-stripe accents, and track-day telemetry.</p>
+            <div class="actions" aria-label="Reference actions">
+              <a class="btn btn-primary" href="#">Primary motorsport blue CTA</a>
+              <a class="btn btn-secondary" href="#">Secondary action</a>
+            </div>
+          </div>
+          <article class="panel" aria-label="BMW M component preview">
+            <div class="panel-head">
+              <div>
+                <p class="eyebrow">Live module</p>
+                <h3>track telemetry module</h3>
+              </div>
+              <span class="status">online</span>
+            </div>
+            <div class="metric-grid">
+              <div class="metric"><strong>98%</strong><span>Signal quality</span></div>
+              <div class="metric"><strong>24</strong><span>Active flows</span></div>
+              <div class="metric"><strong>3.2s</strong><span>Response time</span></div>
+            </div>
+            <div class="card-row">
+              <div class="mini-card">
+                <h3>Palette</h3>
+                <p>precise motorsport interface with white engineering calm and sharp M color signals.</p>
+                <div class="swatches" aria-label="Token swatches">
+                  <span class="swatch accent"></span>
+                  <span class="swatch surface"></span>
+                  <span class="swatch warm"></span>
+                  <span class="swatch fg"></span>
+                </div>
+              </div>
+              <div class="mini-card">
+                <h3>Control</h3>
+                <p>Focus, hover, and status states share the same brand signal.</p>
+                <div class="field">
+                  <label for="bmw-m-input">Reference input</label>
+                  <input id="bmw-m-input" value="BMW M system token" />
+                </div>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+      <section>
+        <div class="container lower">
+          <article class="tile">
+            <p class="eyebrow">Typography</p>
+            <h2>Display rhythm</h2>
+            <p>Headlines use the brand display stack with the declared scale and leading.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Surface</p>
+            <h2>Layer system</h2>
+            <p>Cards, warm panels, borders, and raised states resolve through shared tokens.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Interaction</p>
+            <h2>Motion states</h2>
+            <p>Buttons, inputs, and panels use brand-specific focus rings and easing.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/bmw-m/tokens.css
+++ b/design-systems/bmw-m/tokens.css
@@ -1,0 +1,64 @@
+/* design-systems/bmw-m/tokens.css
+ *
+ * Structured token bindings for BMW M.
+ * precise motorsport interface with white engineering calm and sharp M color signals.
+ */
+
+:root {
+  --bg: #f7f8fa;
+  --surface: #ffffff;
+  --surface-warm: #eef3f8;
+  --fg: #111827;
+  --fg-2: #334155;
+  --muted: #64748b;
+  --meta: #0066b1;
+  --border: #d7dee8;
+  --border-soft: #edf1f6;
+  --accent: #0066b1;
+  --accent-on: #ffffff;
+  --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+  --success: #16a34a;
+  --warn: #f59e0b;
+  --danger: #e4002b;
+  --font-display: "BMWTypeNext", "Helvetica Neue", Arial, sans-serif;
+  --font-body: "BMWTypeNext", "Helvetica Neue", Arial, sans-serif;
+  --font-mono: "SF Mono", ui-monospace, Menlo, monospace;
+  --text-xs: 12px;
+  --text-sm: 14px;
+  --text-base: 16px;
+  --text-lg: 18px;
+  --text-xl: 24px;
+  --text-2xl: 36px;
+  --text-3xl: 56px;
+  --text-4xl: 78px;
+  --leading-body: 1.5;
+  --leading-tight: 1.02;
+  --tracking-display: -0.025em;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+  --section-y-desktop: 104px;
+  --section-y-tablet: 76px;
+  --section-y-phone: 52px;
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 14px;
+  --radius-pill: 9999px;
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised: 0 22px 56px rgba(17, 24, 39, 0.12);
+  --focus-ring: 0 0 0 4px rgba(0, 102, 177, 0.24);
+  --motion-fast: 130ms;
+  --motion-base: 220ms;
+  --ease-standard: cubic-bezier(0.16, 1, 0.3, 1);
+  --container-max: 1220px;
+  --container-gutter-desktop: 40px;
+  --container-gutter-tablet: 28px;
+  --container-gutter-phone: 18px;
+}

--- a/design-systems/bugatti/components.html
+++ b/design-systems/bugatti/components.html
@@ -1,0 +1,342 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Bugatti - reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/bugatti: hyper-luxury automotive calm with deep blue, chrome edges, and gallery spacing."
+    />
+    <style>
+      :root {
+        --bg: #07111f;
+        --surface: #101d2f;
+        --surface-warm: #16283f;
+        --fg: #f7fbff;
+        --fg-2: #d6e0ee;
+        --muted: #8fa1b7;
+        --meta: #b7c7d9;
+        --border: #2c405c;
+        --border-soft: #1c2d44;
+        --accent: #1b4d8f;
+        --accent-on: #ffffff;
+        --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+        --success: #2fbf71;
+        --warn: #d9b45f;
+        --danger: #c1121f;
+        --font-display: "Bugatti Display", "Didot", Georgia, serif;
+        --font-body: "Avenir Next", Inter, Arial, sans-serif;
+        --font-mono: "SF Mono", ui-monospace, Menlo, monospace;
+        --text-xs: 12px;
+        --text-sm: 14px;
+        --text-base: 16px;
+        --text-lg: 19px;
+        --text-xl: 26px;
+        --text-2xl: 42px;
+        --text-3xl: 64px;
+        --text-4xl: 88px;
+        --leading-body: 1.58;
+        --leading-tight: 1;
+        --tracking-display: -0.015em;
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+        --section-y-desktop: 120px;
+        --section-y-tablet: 84px;
+        --section-y-phone: 60px;
+        --radius-sm: 8px;
+        --radius-md: 14px;
+        --radius-lg: 22px;
+        --radius-pill: 9999px;
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised: 0 28px 86px rgba(0, 0, 0, 0.46);
+        --focus-ring: 0 0 0 4px rgba(183, 199, 217, 0.28);
+        --motion-fast: 170ms;
+        --motion-base: 280ms;
+        --ease-standard: cubic-bezier(0.16, 1, 0.3, 1);
+        --container-max: 1200px;
+        --container-gutter-desktop: 42px;
+        --container-gutter-tablet: 30px;
+        --container-gutter-phone: 20px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        min-height: 100vh;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+      .page {
+        min-height: 100vh;
+        background: radial-gradient(circle at 72% 16%, rgba(183, 199, 217, 0.20), transparent 34%), linear-gradient(135deg, #07111f 0%, #16283f 100%);
+      }
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+      h1, h2, h3, p { margin: 0; }
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        line-height: var(--leading-tight);
+        letter-spacing: var(--tracking-display);
+      }
+      h1 { max-width: 820px; font-size: var(--text-4xl); font-weight: 700; }
+      h2 { font-size: var(--text-3xl); font-weight: 650; }
+      h3 { font-size: var(--text-xl); font-weight: 650; }
+      .eyebrow {
+        color: var(--meta);
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+      .lead {
+        max-width: 620px;
+        color: var(--fg-2);
+        font-size: var(--text-lg);
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+        gap: var(--space-8);
+        align-items: center;
+      }
+      .stack > * + * { margin-block-start: var(--space-4); }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3);
+        margin-block-start: var(--space-6);
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 44px;
+        padding: 0 var(--space-5);
+        border: 1px solid transparent;
+        border-radius: var(--radius-md);
+        font: 700 var(--text-sm) / 1 var(--font-body);
+        text-decoration: none;
+        cursor: pointer;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          border-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard),
+          transform var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn-primary { background: var(--accent); color: var(--accent-on); }
+      .btn-primary:hover { background: var(--accent-hover); transform: translateY(-1px); }
+      .btn-secondary { background: var(--surface); color: var(--fg); border-color: var(--border); box-shadow: var(--elev-ring); }
+      .btn-secondary:hover { border-color: var(--accent); color: var(--accent); }
+      .panel {
+        background: color-mix(in oklab, var(--surface), transparent 4%);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--elev-raised);
+        overflow: hidden;
+      }
+      .panel-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+        padding: var(--space-5);
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .status {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        color: var(--meta);
+        font: 700 var(--text-xs) / 1 var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .status::before {
+        width: 8px;
+        height: 8px;
+        border-radius: var(--radius-pill);
+        background: var(--success);
+        content: "";
+      }
+      .metric-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .metric {
+        padding: var(--space-5);
+        border-right: 1px solid var(--border-soft);
+      }
+      .metric:last-child { border-right: 0; }
+      .metric strong {
+        display: block;
+        font-family: var(--font-display);
+        font-size: var(--text-2xl);
+        line-height: var(--leading-tight);
+      }
+      .metric span { color: var(--muted); font-size: var(--text-sm); }
+      .card-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-4);
+        padding: var(--space-5);
+      }
+      .mini-card {
+        min-height: 148px;
+        padding: var(--space-5);
+        border: 1px solid var(--border-soft);
+        border-radius: var(--radius-md);
+        background: var(--surface-warm);
+      }
+      .mini-card p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      .swatches {
+        display: flex;
+        gap: var(--space-2);
+        margin-block-start: var(--space-4);
+      }
+      .swatch {
+        width: 32px;
+        height: 32px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+      }
+      .swatch.accent { background: var(--accent); }
+      .swatch.surface { background: var(--surface); }
+      .swatch.warm { background: var(--surface-warm); }
+      .swatch.fg { background: var(--fg); }
+      .field {
+        display: grid;
+        gap: var(--space-2);
+        margin-block-start: var(--space-5);
+      }
+      label { color: var(--fg-2); font-size: var(--text-sm); font-weight: 700; }
+      input {
+        width: 100%;
+        min-height: 46px;
+        padding: 0 var(--space-4);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--surface);
+        color: var(--fg);
+        font: inherit;
+      }
+      input:focus { outline: none; box-shadow: var(--focus-ring); border-color: var(--accent); }
+      .lower {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: var(--space-4);
+      }
+      .tile {
+        padding: var(--space-5);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface);
+      }
+      .tile p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      @media (max-width: 860px) {
+        .hero, .lower { grid-template-columns: 1fr; }
+        .metric-grid, .card-row { grid-template-columns: 1fr; }
+        .metric { border-right: 0; border-bottom: 1px solid var(--border-soft); }
+        .metric:last-child { border-bottom: 0; }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <section>
+        <div class="container hero">
+          <div class="stack">
+            <p class="eyebrow">Bugatti design system</p>
+            <h1>Hyper-luxury salon</h1>
+            <p class="lead">Deep French blue, polished chrome, and composed automotive prestige.</p>
+            <div class="actions" aria-label="Reference actions">
+              <a class="btn btn-primary" href="#">Primary blue chrome action</a>
+              <a class="btn btn-secondary" href="#">Secondary action</a>
+            </div>
+          </div>
+          <article class="panel" aria-label="Bugatti component preview">
+            <div class="panel-head">
+              <div>
+                <p class="eyebrow">Live module</p>
+                <h3>gallery specification panel</h3>
+              </div>
+              <span class="status">online</span>
+            </div>
+            <div class="metric-grid">
+              <div class="metric"><strong>98%</strong><span>Signal quality</span></div>
+              <div class="metric"><strong>24</strong><span>Active flows</span></div>
+              <div class="metric"><strong>3.2s</strong><span>Response time</span></div>
+            </div>
+            <div class="card-row">
+              <div class="mini-card">
+                <h3>Palette</h3>
+                <p>hyper-luxury automotive calm with deep blue, chrome edges, and gallery spacing.</p>
+                <div class="swatches" aria-label="Token swatches">
+                  <span class="swatch accent"></span>
+                  <span class="swatch surface"></span>
+                  <span class="swatch warm"></span>
+                  <span class="swatch fg"></span>
+                </div>
+              </div>
+              <div class="mini-card">
+                <h3>Control</h3>
+                <p>Focus, hover, and status states share the same brand signal.</p>
+                <div class="field">
+                  <label for="bugatti-input">Reference input</label>
+                  <input id="bugatti-input" value="Bugatti system token" />
+                </div>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+      <section>
+        <div class="container lower">
+          <article class="tile">
+            <p class="eyebrow">Typography</p>
+            <h2>Display rhythm</h2>
+            <p>Headlines use the brand display stack with the declared scale and leading.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Surface</p>
+            <h2>Layer system</h2>
+            <p>Cards, warm panels, borders, and raised states resolve through shared tokens.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Interaction</p>
+            <h2>Motion states</h2>
+            <p>Buttons, inputs, and panels use brand-specific focus rings and easing.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/bugatti/tokens.css
+++ b/design-systems/bugatti/tokens.css
@@ -1,0 +1,64 @@
+/* design-systems/bugatti/tokens.css
+ *
+ * Structured token bindings for Bugatti.
+ * hyper-luxury automotive calm with deep blue, chrome edges, and gallery spacing.
+ */
+
+:root {
+  --bg: #07111f;
+  --surface: #101d2f;
+  --surface-warm: #16283f;
+  --fg: #f7fbff;
+  --fg-2: #d6e0ee;
+  --muted: #8fa1b7;
+  --meta: #b7c7d9;
+  --border: #2c405c;
+  --border-soft: #1c2d44;
+  --accent: #1b4d8f;
+  --accent-on: #ffffff;
+  --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+  --success: #2fbf71;
+  --warn: #d9b45f;
+  --danger: #c1121f;
+  --font-display: "Bugatti Display", "Didot", Georgia, serif;
+  --font-body: "Avenir Next", Inter, Arial, sans-serif;
+  --font-mono: "SF Mono", ui-monospace, Menlo, monospace;
+  --text-xs: 12px;
+  --text-sm: 14px;
+  --text-base: 16px;
+  --text-lg: 19px;
+  --text-xl: 26px;
+  --text-2xl: 42px;
+  --text-3xl: 64px;
+  --text-4xl: 88px;
+  --leading-body: 1.58;
+  --leading-tight: 1;
+  --tracking-display: -0.015em;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+  --section-y-desktop: 120px;
+  --section-y-tablet: 84px;
+  --section-y-phone: 60px;
+  --radius-sm: 8px;
+  --radius-md: 14px;
+  --radius-lg: 22px;
+  --radius-pill: 9999px;
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised: 0 28px 86px rgba(0, 0, 0, 0.46);
+  --focus-ring: 0 0 0 4px rgba(183, 199, 217, 0.28);
+  --motion-fast: 170ms;
+  --motion-base: 280ms;
+  --ease-standard: cubic-bezier(0.16, 1, 0.3, 1);
+  --container-max: 1200px;
+  --container-gutter-desktop: 42px;
+  --container-gutter-tablet: 30px;
+  --container-gutter-phone: 20px;
+}

--- a/design-systems/cisco/components.html
+++ b/design-systems/cisco/components.html
@@ -1,0 +1,342 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Cisco - reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/cisco: navy-charcoal infrastructure surfaces with one electric Cisco Blue signal."
+    />
+    <style>
+      :root {
+        --bg: #0f1720;
+        --surface: #1b2530;
+        --surface-warm: #243447;
+        --fg: #ffffff;
+        --fg-2: #e8ebf1;
+        --muted: #9e9ea2;
+        --meta: #64bbe3;
+        --border: #58585b;
+        --border-soft: rgba(232, 235, 241, 0.14);
+        --accent: #049fd9;
+        --accent-on: #001923;
+        --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+        --success: #6cc04a;
+        --warn: #ffcc00;
+        --danger: #cf2030;
+        --font-display: "CiscoSansTT", Inter, Arial, sans-serif;
+        --font-body: "CiscoSansTT", Inter, Arial, sans-serif;
+        --font-mono: "IBM Plex Mono", ui-monospace, Menlo, monospace;
+        --text-xs: 12px;
+        --text-sm: 14px;
+        --text-base: 16px;
+        --text-lg: 18px;
+        --text-xl: 24px;
+        --text-2xl: 32px;
+        --text-3xl: 56px;
+        --text-4xl: 72px;
+        --leading-body: 1.55;
+        --leading-tight: 1.05;
+        --tracking-display: -0.02em;
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+        --section-y-desktop: 104px;
+        --section-y-tablet: 76px;
+        --section-y-phone: 52px;
+        --radius-sm: 12px;
+        --radius-md: 20px;
+        --radius-lg: 28px;
+        --radius-pill: 9999px;
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised: 0 24px 80px rgba(0, 0, 0, 0.32);
+        --focus-ring: 0 0 0 4px rgba(100, 187, 227, 0.32);
+        --motion-fast: 160ms;
+        --motion-base: 240ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+        --container-max: 1240px;
+        --container-gutter-desktop: 40px;
+        --container-gutter-tablet: 28px;
+        --container-gutter-phone: 20px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        min-height: 100vh;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+      .page {
+        min-height: 100vh;
+        background: radial-gradient(circle at 80% 15%, rgba(4, 159, 217, 0.28), transparent 34%), linear-gradient(135deg, #0f1720 0%, #1b2530 100%);
+      }
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+      h1, h2, h3, p { margin: 0; }
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        line-height: var(--leading-tight);
+        letter-spacing: var(--tracking-display);
+      }
+      h1 { max-width: 820px; font-size: var(--text-4xl); font-weight: 700; }
+      h2 { font-size: var(--text-3xl); font-weight: 650; }
+      h3 { font-size: var(--text-xl); font-weight: 650; }
+      .eyebrow {
+        color: var(--meta);
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+      .lead {
+        max-width: 620px;
+        color: var(--fg-2);
+        font-size: var(--text-lg);
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+        gap: var(--space-8);
+        align-items: center;
+      }
+      .stack > * + * { margin-block-start: var(--space-4); }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3);
+        margin-block-start: var(--space-6);
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 44px;
+        padding: 0 var(--space-5);
+        border: 1px solid transparent;
+        border-radius: var(--radius-md);
+        font: 700 var(--text-sm) / 1 var(--font-body);
+        text-decoration: none;
+        cursor: pointer;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          border-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard),
+          transform var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn-primary { background: var(--accent); color: var(--accent-on); }
+      .btn-primary:hover { background: var(--accent-hover); transform: translateY(-1px); }
+      .btn-secondary { background: var(--surface); color: var(--fg); border-color: var(--border); box-shadow: var(--elev-ring); }
+      .btn-secondary:hover { border-color: var(--accent); color: var(--accent); }
+      .panel {
+        background: color-mix(in oklab, var(--surface), transparent 4%);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--elev-raised);
+        overflow: hidden;
+      }
+      .panel-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+        padding: var(--space-5);
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .status {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        color: var(--meta);
+        font: 700 var(--text-xs) / 1 var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .status::before {
+        width: 8px;
+        height: 8px;
+        border-radius: var(--radius-pill);
+        background: var(--success);
+        content: "";
+      }
+      .metric-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .metric {
+        padding: var(--space-5);
+        border-right: 1px solid var(--border-soft);
+      }
+      .metric:last-child { border-right: 0; }
+      .metric strong {
+        display: block;
+        font-family: var(--font-display);
+        font-size: var(--text-2xl);
+        line-height: var(--leading-tight);
+      }
+      .metric span { color: var(--muted); font-size: var(--text-sm); }
+      .card-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-4);
+        padding: var(--space-5);
+      }
+      .mini-card {
+        min-height: 148px;
+        padding: var(--space-5);
+        border: 1px solid var(--border-soft);
+        border-radius: var(--radius-md);
+        background: var(--surface-warm);
+      }
+      .mini-card p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      .swatches {
+        display: flex;
+        gap: var(--space-2);
+        margin-block-start: var(--space-4);
+      }
+      .swatch {
+        width: 32px;
+        height: 32px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+      }
+      .swatch.accent { background: var(--accent); }
+      .swatch.surface { background: var(--surface); }
+      .swatch.warm { background: var(--surface-warm); }
+      .swatch.fg { background: var(--fg); }
+      .field {
+        display: grid;
+        gap: var(--space-2);
+        margin-block-start: var(--space-5);
+      }
+      label { color: var(--fg-2); font-size: var(--text-sm); font-weight: 700; }
+      input {
+        width: 100%;
+        min-height: 46px;
+        padding: 0 var(--space-4);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--surface);
+        color: var(--fg);
+        font: inherit;
+      }
+      input:focus { outline: none; box-shadow: var(--focus-ring); border-color: var(--accent); }
+      .lower {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: var(--space-4);
+      }
+      .tile {
+        padding: var(--space-5);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface);
+      }
+      .tile p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      @media (max-width: 860px) {
+        .hero, .lower { grid-template-columns: 1fr; }
+        .metric-grid, .card-row { grid-template-columns: 1fr; }
+        .metric { border-right: 0; border-bottom: 1px solid var(--border-soft); }
+        .metric:last-child { border-bottom: 0; }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <section>
+        <div class="container hero">
+          <div class="stack">
+            <p class="eyebrow">Cisco design system</p>
+            <h1>Infrastructure operations</h1>
+            <p class="lead">Network telemetry, trust signals, and calm enterprise scale.</p>
+            <div class="actions" aria-label="Reference actions">
+              <a class="btn btn-primary" href="#">Primary rounded trust pill</a>
+              <a class="btn btn-secondary" href="#">Secondary action</a>
+            </div>
+          </div>
+          <article class="panel" aria-label="Cisco component preview">
+            <div class="panel-head">
+              <div>
+                <p class="eyebrow">Live module</p>
+                <h3>dark telemetry panel</h3>
+              </div>
+              <span class="status">online</span>
+            </div>
+            <div class="metric-grid">
+              <div class="metric"><strong>98%</strong><span>Signal quality</span></div>
+              <div class="metric"><strong>24</strong><span>Active flows</span></div>
+              <div class="metric"><strong>3.2s</strong><span>Response time</span></div>
+            </div>
+            <div class="card-row">
+              <div class="mini-card">
+                <h3>Palette</h3>
+                <p>navy-charcoal infrastructure surfaces with one electric Cisco Blue signal.</p>
+                <div class="swatches" aria-label="Token swatches">
+                  <span class="swatch accent"></span>
+                  <span class="swatch surface"></span>
+                  <span class="swatch warm"></span>
+                  <span class="swatch fg"></span>
+                </div>
+              </div>
+              <div class="mini-card">
+                <h3>Control</h3>
+                <p>Focus, hover, and status states share the same brand signal.</p>
+                <div class="field">
+                  <label for="cisco-input">Reference input</label>
+                  <input id="cisco-input" value="Cisco system token" />
+                </div>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+      <section>
+        <div class="container lower">
+          <article class="tile">
+            <p class="eyebrow">Typography</p>
+            <h2>Display rhythm</h2>
+            <p>Headlines use the brand display stack with the declared scale and leading.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Surface</p>
+            <h2>Layer system</h2>
+            <p>Cards, warm panels, borders, and raised states resolve through shared tokens.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Interaction</p>
+            <h2>Motion states</h2>
+            <p>Buttons, inputs, and panels use brand-specific focus rings and easing.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/cisco/tokens.css
+++ b/design-systems/cisco/tokens.css
@@ -1,0 +1,64 @@
+/* design-systems/cisco/tokens.css
+ *
+ * Structured token bindings for Cisco.
+ * navy-charcoal infrastructure surfaces with one electric Cisco Blue signal.
+ */
+
+:root {
+  --bg: #0f1720;
+  --surface: #1b2530;
+  --surface-warm: #243447;
+  --fg: #ffffff;
+  --fg-2: #e8ebf1;
+  --muted: #9e9ea2;
+  --meta: #64bbe3;
+  --border: #58585b;
+  --border-soft: rgba(232, 235, 241, 0.14);
+  --accent: #049fd9;
+  --accent-on: #001923;
+  --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+  --success: #6cc04a;
+  --warn: #ffcc00;
+  --danger: #cf2030;
+  --font-display: "CiscoSansTT", Inter, Arial, sans-serif;
+  --font-body: "CiscoSansTT", Inter, Arial, sans-serif;
+  --font-mono: "IBM Plex Mono", ui-monospace, Menlo, monospace;
+  --text-xs: 12px;
+  --text-sm: 14px;
+  --text-base: 16px;
+  --text-lg: 18px;
+  --text-xl: 24px;
+  --text-2xl: 32px;
+  --text-3xl: 56px;
+  --text-4xl: 72px;
+  --leading-body: 1.55;
+  --leading-tight: 1.05;
+  --tracking-display: -0.02em;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+  --section-y-desktop: 104px;
+  --section-y-tablet: 76px;
+  --section-y-phone: 52px;
+  --radius-sm: 12px;
+  --radius-md: 20px;
+  --radius-lg: 28px;
+  --radius-pill: 9999px;
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised: 0 24px 80px rgba(0, 0, 0, 0.32);
+  --focus-ring: 0 0 0 4px rgba(100, 187, 227, 0.32);
+  --motion-fast: 160ms;
+  --motion-base: 240ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --container-max: 1240px;
+  --container-gutter-desktop: 40px;
+  --container-gutter-tablet: 28px;
+  --container-gutter-phone: 20px;
+}

--- a/design-systems/composio/components.html
+++ b/design-systems/composio/components.html
@@ -1,0 +1,342 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Composio - reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/composio: dark agent-integration workspace with violet-blue signals and dense connector cards."
+    />
+    <style>
+      :root {
+        --bg: #090b14;
+        --surface: #121626;
+        --surface-warm: #1b2140;
+        --fg: #f8fafc;
+        --fg-2: #cbd5e1;
+        --muted: #94a3b8;
+        --meta: #8b5cf6;
+        --border: #27324a;
+        --border-soft: #1d2638;
+        --accent: #6d5dfc;
+        --accent-on: #ffffff;
+        --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+        --success: #22c55e;
+        --warn: #fbbf24;
+        --danger: #fb7185;
+        --font-display: "Inter", system-ui, sans-serif;
+        --font-body: "Inter", system-ui, sans-serif;
+        --font-mono: "JetBrains Mono", ui-monospace, Menlo, monospace;
+        --text-xs: 12px;
+        --text-sm: 13px;
+        --text-base: 15px;
+        --text-lg: 17px;
+        --text-xl: 22px;
+        --text-2xl: 32px;
+        --text-3xl: 48px;
+        --text-4xl: 64px;
+        --leading-body: 1.55;
+        --leading-tight: 1.06;
+        --tracking-display: -0.02em;
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+        --section-y-desktop: 96px;
+        --section-y-tablet: 68px;
+        --section-y-phone: 48px;
+        --radius-sm: 10px;
+        --radius-md: 14px;
+        --radius-lg: 22px;
+        --radius-pill: 9999px;
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised: 0 22px 60px rgba(0, 0, 0, 0.36);
+        --focus-ring: 0 0 0 4px rgba(109, 93, 252, 0.30);
+        --motion-fast: 140ms;
+        --motion-base: 220ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+        --container-max: 1180px;
+        --container-gutter-desktop: 32px;
+        --container-gutter-tablet: 24px;
+        --container-gutter-phone: 16px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        min-height: 100vh;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+      .page {
+        min-height: 100vh;
+        background: radial-gradient(circle at 75% 10%, rgba(109, 93, 252, 0.28), transparent 34%), #090b14;
+      }
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+      h1, h2, h3, p { margin: 0; }
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        line-height: var(--leading-tight);
+        letter-spacing: var(--tracking-display);
+      }
+      h1 { max-width: 820px; font-size: var(--text-4xl); font-weight: 700; }
+      h2 { font-size: var(--text-3xl); font-weight: 650; }
+      h3 { font-size: var(--text-xl); font-weight: 650; }
+      .eyebrow {
+        color: var(--meta);
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+      .lead {
+        max-width: 620px;
+        color: var(--fg-2);
+        font-size: var(--text-lg);
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+        gap: var(--space-8);
+        align-items: center;
+      }
+      .stack > * + * { margin-block-start: var(--space-4); }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3);
+        margin-block-start: var(--space-6);
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 44px;
+        padding: 0 var(--space-5);
+        border: 1px solid transparent;
+        border-radius: var(--radius-md);
+        font: 700 var(--text-sm) / 1 var(--font-body);
+        text-decoration: none;
+        cursor: pointer;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          border-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard),
+          transform var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn-primary { background: var(--accent); color: var(--accent-on); }
+      .btn-primary:hover { background: var(--accent-hover); transform: translateY(-1px); }
+      .btn-secondary { background: var(--surface); color: var(--fg); border-color: var(--border); box-shadow: var(--elev-ring); }
+      .btn-secondary:hover { border-color: var(--accent); color: var(--accent); }
+      .panel {
+        background: color-mix(in oklab, var(--surface), transparent 4%);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--elev-raised);
+        overflow: hidden;
+      }
+      .panel-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+        padding: var(--space-5);
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .status {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        color: var(--meta);
+        font: 700 var(--text-xs) / 1 var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .status::before {
+        width: 8px;
+        height: 8px;
+        border-radius: var(--radius-pill);
+        background: var(--success);
+        content: "";
+      }
+      .metric-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .metric {
+        padding: var(--space-5);
+        border-right: 1px solid var(--border-soft);
+      }
+      .metric:last-child { border-right: 0; }
+      .metric strong {
+        display: block;
+        font-family: var(--font-display);
+        font-size: var(--text-2xl);
+        line-height: var(--leading-tight);
+      }
+      .metric span { color: var(--muted); font-size: var(--text-sm); }
+      .card-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-4);
+        padding: var(--space-5);
+      }
+      .mini-card {
+        min-height: 148px;
+        padding: var(--space-5);
+        border: 1px solid var(--border-soft);
+        border-radius: var(--radius-md);
+        background: var(--surface-warm);
+      }
+      .mini-card p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      .swatches {
+        display: flex;
+        gap: var(--space-2);
+        margin-block-start: var(--space-4);
+      }
+      .swatch {
+        width: 32px;
+        height: 32px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+      }
+      .swatch.accent { background: var(--accent); }
+      .swatch.surface { background: var(--surface); }
+      .swatch.warm { background: var(--surface-warm); }
+      .swatch.fg { background: var(--fg); }
+      .field {
+        display: grid;
+        gap: var(--space-2);
+        margin-block-start: var(--space-5);
+      }
+      label { color: var(--fg-2); font-size: var(--text-sm); font-weight: 700; }
+      input {
+        width: 100%;
+        min-height: 46px;
+        padding: 0 var(--space-4);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--surface);
+        color: var(--fg);
+        font: inherit;
+      }
+      input:focus { outline: none; box-shadow: var(--focus-ring); border-color: var(--accent); }
+      .lower {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: var(--space-4);
+      }
+      .tile {
+        padding: var(--space-5);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface);
+      }
+      .tile p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      @media (max-width: 860px) {
+        .hero, .lower { grid-template-columns: 1fr; }
+        .metric-grid, .card-row { grid-template-columns: 1fr; }
+        .metric { border-right: 0; border-bottom: 1px solid var(--border-soft); }
+        .metric:last-child { border-bottom: 0; }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <section>
+        <div class="container hero">
+          <div class="stack">
+            <p class="eyebrow">Composio design system</p>
+            <h1>Agent integration grid</h1>
+            <p class="lead">Connector cards, AI tool calls, and compact developer surfaces.</p>
+            <div class="actions" aria-label="Reference actions">
+              <a class="btn btn-primary" href="#">Primary agent connector action</a>
+              <a class="btn btn-secondary" href="#">Secondary action</a>
+            </div>
+          </div>
+          <article class="panel" aria-label="Composio component preview">
+            <div class="panel-head">
+              <div>
+                <p class="eyebrow">Live module</p>
+                <h3>integration node card</h3>
+              </div>
+              <span class="status">online</span>
+            </div>
+            <div class="metric-grid">
+              <div class="metric"><strong>98%</strong><span>Signal quality</span></div>
+              <div class="metric"><strong>24</strong><span>Active flows</span></div>
+              <div class="metric"><strong>3.2s</strong><span>Response time</span></div>
+            </div>
+            <div class="card-row">
+              <div class="mini-card">
+                <h3>Palette</h3>
+                <p>dark agent-integration workspace with violet-blue signals and dense connector cards.</p>
+                <div class="swatches" aria-label="Token swatches">
+                  <span class="swatch accent"></span>
+                  <span class="swatch surface"></span>
+                  <span class="swatch warm"></span>
+                  <span class="swatch fg"></span>
+                </div>
+              </div>
+              <div class="mini-card">
+                <h3>Control</h3>
+                <p>Focus, hover, and status states share the same brand signal.</p>
+                <div class="field">
+                  <label for="composio-input">Reference input</label>
+                  <input id="composio-input" value="Composio system token" />
+                </div>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+      <section>
+        <div class="container lower">
+          <article class="tile">
+            <p class="eyebrow">Typography</p>
+            <h2>Display rhythm</h2>
+            <p>Headlines use the brand display stack with the declared scale and leading.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Surface</p>
+            <h2>Layer system</h2>
+            <p>Cards, warm panels, borders, and raised states resolve through shared tokens.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Interaction</p>
+            <h2>Motion states</h2>
+            <p>Buttons, inputs, and panels use brand-specific focus rings and easing.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/composio/tokens.css
+++ b/design-systems/composio/tokens.css
@@ -1,0 +1,64 @@
+/* design-systems/composio/tokens.css
+ *
+ * Structured token bindings for Composio.
+ * dark agent-integration workspace with violet-blue signals and dense connector cards.
+ */
+
+:root {
+  --bg: #090b14;
+  --surface: #121626;
+  --surface-warm: #1b2140;
+  --fg: #f8fafc;
+  --fg-2: #cbd5e1;
+  --muted: #94a3b8;
+  --meta: #8b5cf6;
+  --border: #27324a;
+  --border-soft: #1d2638;
+  --accent: #6d5dfc;
+  --accent-on: #ffffff;
+  --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+  --success: #22c55e;
+  --warn: #fbbf24;
+  --danger: #fb7185;
+  --font-display: "Inter", system-ui, sans-serif;
+  --font-body: "Inter", system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, Menlo, monospace;
+  --text-xs: 12px;
+  --text-sm: 13px;
+  --text-base: 15px;
+  --text-lg: 17px;
+  --text-xl: 22px;
+  --text-2xl: 32px;
+  --text-3xl: 48px;
+  --text-4xl: 64px;
+  --leading-body: 1.55;
+  --leading-tight: 1.06;
+  --tracking-display: -0.02em;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+  --section-y-desktop: 96px;
+  --section-y-tablet: 68px;
+  --section-y-phone: 48px;
+  --radius-sm: 10px;
+  --radius-md: 14px;
+  --radius-lg: 22px;
+  --radius-pill: 9999px;
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised: 0 22px 60px rgba(0, 0, 0, 0.36);
+  --focus-ring: 0 0 0 4px rgba(109, 93, 252, 0.30);
+  --motion-fast: 140ms;
+  --motion-base: 220ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --container-max: 1180px;
+  --container-gutter-desktop: 32px;
+  --container-gutter-tablet: 24px;
+  --container-gutter-phone: 16px;
+}

--- a/design-systems/expo/components.html
+++ b/design-systems/expo/components.html
@@ -1,0 +1,342 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Expo - reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/expo: developer-console minimalism with black-and-white precision and native app launch energy."
+    />
+    <style>
+      :root {
+        --bg: #ffffff;
+        --surface: #f6f7f9;
+        --surface-warm: #eef2ff;
+        --fg: #0b0d12;
+        --fg-2: #353945;
+        --muted: #6b7280;
+        --meta: #4630eb;
+        --border: #dfe3ea;
+        --border-soft: #edf0f5;
+        --accent: #000020;
+        --accent-on: #ffffff;
+        --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+        --success: #00a36c;
+        --warn: #f59e0b;
+        --danger: #e5484d;
+        --font-display: "Inter", system-ui, sans-serif;
+        --font-body: "Inter", system-ui, sans-serif;
+        --font-mono: "Geist Mono", "SF Mono", ui-monospace, Menlo, monospace;
+        --text-xs: 12px;
+        --text-sm: 14px;
+        --text-base: 16px;
+        --text-lg: 18px;
+        --text-xl: 22px;
+        --text-2xl: 32px;
+        --text-3xl: 48px;
+        --text-4xl: 68px;
+        --leading-body: 1.52;
+        --leading-tight: 1.06;
+        --tracking-display: -0.025em;
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+        --section-y-desktop: 96px;
+        --section-y-tablet: 68px;
+        --section-y-phone: 48px;
+        --radius-sm: 8px;
+        --radius-md: 14px;
+        --radius-lg: 22px;
+        --radius-pill: 9999px;
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised: 0 18px 48px rgba(0, 0, 32, 0.12);
+        --focus-ring: 0 0 0 4px rgba(70, 48, 235, 0.24);
+        --motion-fast: 140ms;
+        --motion-base: 220ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+        --container-max: 1160px;
+        --container-gutter-desktop: 32px;
+        --container-gutter-tablet: 24px;
+        --container-gutter-phone: 16px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        min-height: 100vh;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+      .page {
+        min-height: 100vh;
+        background: radial-gradient(circle at 84% 14%, rgba(70, 48, 235, 0.16), transparent 34%), #ffffff;
+      }
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+      h1, h2, h3, p { margin: 0; }
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        line-height: var(--leading-tight);
+        letter-spacing: var(--tracking-display);
+      }
+      h1 { max-width: 820px; font-size: var(--text-4xl); font-weight: 700; }
+      h2 { font-size: var(--text-3xl); font-weight: 650; }
+      h3 { font-size: var(--text-xl); font-weight: 650; }
+      .eyebrow {
+        color: var(--meta);
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+      .lead {
+        max-width: 620px;
+        color: var(--fg-2);
+        font-size: var(--text-lg);
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+        gap: var(--space-8);
+        align-items: center;
+      }
+      .stack > * + * { margin-block-start: var(--space-4); }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3);
+        margin-block-start: var(--space-6);
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 44px;
+        padding: 0 var(--space-5);
+        border: 1px solid transparent;
+        border-radius: var(--radius-md);
+        font: 700 var(--text-sm) / 1 var(--font-body);
+        text-decoration: none;
+        cursor: pointer;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          border-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard),
+          transform var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn-primary { background: var(--accent); color: var(--accent-on); }
+      .btn-primary:hover { background: var(--accent-hover); transform: translateY(-1px); }
+      .btn-secondary { background: var(--surface); color: var(--fg); border-color: var(--border); box-shadow: var(--elev-ring); }
+      .btn-secondary:hover { border-color: var(--accent); color: var(--accent); }
+      .panel {
+        background: color-mix(in oklab, var(--surface), transparent 4%);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--elev-raised);
+        overflow: hidden;
+      }
+      .panel-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+        padding: var(--space-5);
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .status {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        color: var(--meta);
+        font: 700 var(--text-xs) / 1 var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .status::before {
+        width: 8px;
+        height: 8px;
+        border-radius: var(--radius-pill);
+        background: var(--success);
+        content: "";
+      }
+      .metric-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .metric {
+        padding: var(--space-5);
+        border-right: 1px solid var(--border-soft);
+      }
+      .metric:last-child { border-right: 0; }
+      .metric strong {
+        display: block;
+        font-family: var(--font-display);
+        font-size: var(--text-2xl);
+        line-height: var(--leading-tight);
+      }
+      .metric span { color: var(--muted); font-size: var(--text-sm); }
+      .card-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-4);
+        padding: var(--space-5);
+      }
+      .mini-card {
+        min-height: 148px;
+        padding: var(--space-5);
+        border: 1px solid var(--border-soft);
+        border-radius: var(--radius-md);
+        background: var(--surface-warm);
+      }
+      .mini-card p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      .swatches {
+        display: flex;
+        gap: var(--space-2);
+        margin-block-start: var(--space-4);
+      }
+      .swatch {
+        width: 32px;
+        height: 32px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+      }
+      .swatch.accent { background: var(--accent); }
+      .swatch.surface { background: var(--surface); }
+      .swatch.warm { background: var(--surface-warm); }
+      .swatch.fg { background: var(--fg); }
+      .field {
+        display: grid;
+        gap: var(--space-2);
+        margin-block-start: var(--space-5);
+      }
+      label { color: var(--fg-2); font-size: var(--text-sm); font-weight: 700; }
+      input {
+        width: 100%;
+        min-height: 46px;
+        padding: 0 var(--space-4);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--surface);
+        color: var(--fg);
+        font: inherit;
+      }
+      input:focus { outline: none; box-shadow: var(--focus-ring); border-color: var(--accent); }
+      .lower {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: var(--space-4);
+      }
+      .tile {
+        padding: var(--space-5);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface);
+      }
+      .tile p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      @media (max-width: 860px) {
+        .hero, .lower { grid-template-columns: 1fr; }
+        .metric-grid, .card-row { grid-template-columns: 1fr; }
+        .metric { border-right: 0; border-bottom: 1px solid var(--border-soft); }
+        .metric:last-child { border-bottom: 0; }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <section>
+        <div class="container hero">
+          <div class="stack">
+            <p class="eyebrow">Expo design system</p>
+            <h1>App launch console</h1>
+            <p class="lead">Developer shipping surfaces with crisp black, code density, and mobile previews.</p>
+            <div class="actions" aria-label="Reference actions">
+              <a class="btn btn-primary" href="#">Primary black launch action</a>
+              <a class="btn btn-secondary" href="#">Secondary action</a>
+            </div>
+          </div>
+          <article class="panel" aria-label="Expo component preview">
+            <div class="panel-head">
+              <div>
+                <p class="eyebrow">Live module</p>
+                <h3>native build panel</h3>
+              </div>
+              <span class="status">online</span>
+            </div>
+            <div class="metric-grid">
+              <div class="metric"><strong>98%</strong><span>Signal quality</span></div>
+              <div class="metric"><strong>24</strong><span>Active flows</span></div>
+              <div class="metric"><strong>3.2s</strong><span>Response time</span></div>
+            </div>
+            <div class="card-row">
+              <div class="mini-card">
+                <h3>Palette</h3>
+                <p>developer-console minimalism with black-and-white precision and native app launch energy.</p>
+                <div class="swatches" aria-label="Token swatches">
+                  <span class="swatch accent"></span>
+                  <span class="swatch surface"></span>
+                  <span class="swatch warm"></span>
+                  <span class="swatch fg"></span>
+                </div>
+              </div>
+              <div class="mini-card">
+                <h3>Control</h3>
+                <p>Focus, hover, and status states share the same brand signal.</p>
+                <div class="field">
+                  <label for="expo-input">Reference input</label>
+                  <input id="expo-input" value="Expo system token" />
+                </div>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+      <section>
+        <div class="container lower">
+          <article class="tile">
+            <p class="eyebrow">Typography</p>
+            <h2>Display rhythm</h2>
+            <p>Headlines use the brand display stack with the declared scale and leading.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Surface</p>
+            <h2>Layer system</h2>
+            <p>Cards, warm panels, borders, and raised states resolve through shared tokens.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Interaction</p>
+            <h2>Motion states</h2>
+            <p>Buttons, inputs, and panels use brand-specific focus rings and easing.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/expo/tokens.css
+++ b/design-systems/expo/tokens.css
@@ -1,0 +1,64 @@
+/* design-systems/expo/tokens.css
+ *
+ * Structured token bindings for Expo.
+ * developer-console minimalism with black-and-white precision and native app launch energy.
+ */
+
+:root {
+  --bg: #ffffff;
+  --surface: #f6f7f9;
+  --surface-warm: #eef2ff;
+  --fg: #0b0d12;
+  --fg-2: #353945;
+  --muted: #6b7280;
+  --meta: #4630eb;
+  --border: #dfe3ea;
+  --border-soft: #edf0f5;
+  --accent: #000020;
+  --accent-on: #ffffff;
+  --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+  --success: #00a36c;
+  --warn: #f59e0b;
+  --danger: #e5484d;
+  --font-display: "Inter", system-ui, sans-serif;
+  --font-body: "Inter", system-ui, sans-serif;
+  --font-mono: "Geist Mono", "SF Mono", ui-monospace, Menlo, monospace;
+  --text-xs: 12px;
+  --text-sm: 14px;
+  --text-base: 16px;
+  --text-lg: 18px;
+  --text-xl: 22px;
+  --text-2xl: 32px;
+  --text-3xl: 48px;
+  --text-4xl: 68px;
+  --leading-body: 1.52;
+  --leading-tight: 1.06;
+  --tracking-display: -0.025em;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+  --section-y-desktop: 96px;
+  --section-y-tablet: 68px;
+  --section-y-phone: 48px;
+  --radius-sm: 8px;
+  --radius-md: 14px;
+  --radius-lg: 22px;
+  --radius-pill: 9999px;
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised: 0 18px 48px rgba(0, 0, 32, 0.12);
+  --focus-ring: 0 0 0 4px rgba(70, 48, 235, 0.24);
+  --motion-fast: 140ms;
+  --motion-base: 220ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --container-max: 1160px;
+  --container-gutter-desktop: 32px;
+  --container-gutter-tablet: 24px;
+  --container-gutter-phone: 16px;
+}

--- a/design-systems/ferrari/components.html
+++ b/design-systems/ferrari/components.html
@@ -1,0 +1,342 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Ferrari - reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/ferrari: Italian performance luxury with racing red, carbon black, and premium editorial spacing."
+    />
+    <style>
+      :root {
+        --bg: #0b0b0b;
+        --surface: #171717;
+        --surface-warm: #23130f;
+        --fg: #fffaf0;
+        --fg-2: #e8dcc8;
+        --muted: #a89f91;
+        --meta: #ffd200;
+        --border: #342a24;
+        --border-soft: #241f1b;
+        --accent: #dc0000;
+        --accent-on: #ffffff;
+        --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+        --success: #0f9d58;
+        --warn: #ffd200;
+        --danger: #ff3b30;
+        --font-display: "Ferrari Sans", "Helvetica Neue", Arial, sans-serif;
+        --font-body: "Ferrari Sans", "Helvetica Neue", Arial, sans-serif;
+        --font-mono: "SF Mono", ui-monospace, Menlo, monospace;
+        --text-xs: 12px;
+        --text-sm: 14px;
+        --text-base: 16px;
+        --text-lg: 19px;
+        --text-xl: 26px;
+        --text-2xl: 40px;
+        --text-3xl: 62px;
+        --text-4xl: 88px;
+        --leading-body: 1.5;
+        --leading-tight: 0.98;
+        --tracking-display: -0.03em;
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+        --section-y-desktop: 112px;
+        --section-y-tablet: 80px;
+        --section-y-phone: 56px;
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 14px;
+        --radius-pill: 9999px;
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised: 0 26px 80px rgba(0, 0, 0, 0.48);
+        --focus-ring: 0 0 0 4px rgba(220, 0, 0, 0.30);
+        --motion-fast: 130ms;
+        --motion-base: 220ms;
+        --ease-standard: cubic-bezier(0.16, 1, 0.3, 1);
+        --container-max: 1240px;
+        --container-gutter-desktop: 40px;
+        --container-gutter-tablet: 28px;
+        --container-gutter-phone: 18px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        min-height: 100vh;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+      .page {
+        min-height: 100vh;
+        background: linear-gradient(135deg, #0b0b0b 0%, #23130f 52%, #dc0000 100%);
+      }
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+      h1, h2, h3, p { margin: 0; }
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        line-height: var(--leading-tight);
+        letter-spacing: var(--tracking-display);
+      }
+      h1 { max-width: 820px; font-size: var(--text-4xl); font-weight: 700; }
+      h2 { font-size: var(--text-3xl); font-weight: 650; }
+      h3 { font-size: var(--text-xl); font-weight: 650; }
+      .eyebrow {
+        color: var(--meta);
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+      .lead {
+        max-width: 620px;
+        color: var(--fg-2);
+        font-size: var(--text-lg);
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+        gap: var(--space-8);
+        align-items: center;
+      }
+      .stack > * + * { margin-block-start: var(--space-4); }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3);
+        margin-block-start: var(--space-6);
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 44px;
+        padding: 0 var(--space-5);
+        border: 1px solid transparent;
+        border-radius: var(--radius-md);
+        font: 700 var(--text-sm) / 1 var(--font-body);
+        text-decoration: none;
+        cursor: pointer;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          border-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard),
+          transform var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn-primary { background: var(--accent); color: var(--accent-on); }
+      .btn-primary:hover { background: var(--accent-hover); transform: translateY(-1px); }
+      .btn-secondary { background: var(--surface); color: var(--fg); border-color: var(--border); box-shadow: var(--elev-ring); }
+      .btn-secondary:hover { border-color: var(--accent); color: var(--accent); }
+      .panel {
+        background: color-mix(in oklab, var(--surface), transparent 4%);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--elev-raised);
+        overflow: hidden;
+      }
+      .panel-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+        padding: var(--space-5);
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .status {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        color: var(--meta);
+        font: 700 var(--text-xs) / 1 var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .status::before {
+        width: 8px;
+        height: 8px;
+        border-radius: var(--radius-pill);
+        background: var(--success);
+        content: "";
+      }
+      .metric-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .metric {
+        padding: var(--space-5);
+        border-right: 1px solid var(--border-soft);
+      }
+      .metric:last-child { border-right: 0; }
+      .metric strong {
+        display: block;
+        font-family: var(--font-display);
+        font-size: var(--text-2xl);
+        line-height: var(--leading-tight);
+      }
+      .metric span { color: var(--muted); font-size: var(--text-sm); }
+      .card-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-4);
+        padding: var(--space-5);
+      }
+      .mini-card {
+        min-height: 148px;
+        padding: var(--space-5);
+        border: 1px solid var(--border-soft);
+        border-radius: var(--radius-md);
+        background: var(--surface-warm);
+      }
+      .mini-card p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      .swatches {
+        display: flex;
+        gap: var(--space-2);
+        margin-block-start: var(--space-4);
+      }
+      .swatch {
+        width: 32px;
+        height: 32px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+      }
+      .swatch.accent { background: var(--accent); }
+      .swatch.surface { background: var(--surface); }
+      .swatch.warm { background: var(--surface-warm); }
+      .swatch.fg { background: var(--fg); }
+      .field {
+        display: grid;
+        gap: var(--space-2);
+        margin-block-start: var(--space-5);
+      }
+      label { color: var(--fg-2); font-size: var(--text-sm); font-weight: 700; }
+      input {
+        width: 100%;
+        min-height: 46px;
+        padding: 0 var(--space-4);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--surface);
+        color: var(--fg);
+        font: inherit;
+      }
+      input:focus { outline: none; box-shadow: var(--focus-ring); border-color: var(--accent); }
+      .lower {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: var(--space-4);
+      }
+      .tile {
+        padding: var(--space-5);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface);
+      }
+      .tile p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      @media (max-width: 860px) {
+        .hero, .lower { grid-template-columns: 1fr; }
+        .metric-grid, .card-row { grid-template-columns: 1fr; }
+        .metric { border-right: 0; border-bottom: 1px solid var(--border-soft); }
+        .metric:last-child { border-bottom: 0; }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <section>
+        <div class="container hero">
+          <div class="stack">
+            <p class="eyebrow">Ferrari design system</p>
+            <h1>Performance atelier</h1>
+            <p class="lead">Rosso Corsa drama, black carbon surfaces, and luxury product restraint.</p>
+            <div class="actions" aria-label="Reference actions">
+              <a class="btn btn-primary" href="#">Primary rosso performance CTA</a>
+              <a class="btn btn-secondary" href="#">Secondary action</a>
+            </div>
+          </div>
+          <article class="panel" aria-label="Ferrari component preview">
+            <div class="panel-head">
+              <div>
+                <p class="eyebrow">Live module</p>
+                <h3>carbon product plate</h3>
+              </div>
+              <span class="status">online</span>
+            </div>
+            <div class="metric-grid">
+              <div class="metric"><strong>98%</strong><span>Signal quality</span></div>
+              <div class="metric"><strong>24</strong><span>Active flows</span></div>
+              <div class="metric"><strong>3.2s</strong><span>Response time</span></div>
+            </div>
+            <div class="card-row">
+              <div class="mini-card">
+                <h3>Palette</h3>
+                <p>Italian performance luxury with racing red, carbon black, and premium editorial spacing.</p>
+                <div class="swatches" aria-label="Token swatches">
+                  <span class="swatch accent"></span>
+                  <span class="swatch surface"></span>
+                  <span class="swatch warm"></span>
+                  <span class="swatch fg"></span>
+                </div>
+              </div>
+              <div class="mini-card">
+                <h3>Control</h3>
+                <p>Focus, hover, and status states share the same brand signal.</p>
+                <div class="field">
+                  <label for="ferrari-input">Reference input</label>
+                  <input id="ferrari-input" value="Ferrari system token" />
+                </div>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+      <section>
+        <div class="container lower">
+          <article class="tile">
+            <p class="eyebrow">Typography</p>
+            <h2>Display rhythm</h2>
+            <p>Headlines use the brand display stack with the declared scale and leading.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Surface</p>
+            <h2>Layer system</h2>
+            <p>Cards, warm panels, borders, and raised states resolve through shared tokens.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Interaction</p>
+            <h2>Motion states</h2>
+            <p>Buttons, inputs, and panels use brand-specific focus rings and easing.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/ferrari/tokens.css
+++ b/design-systems/ferrari/tokens.css
@@ -1,0 +1,64 @@
+/* design-systems/ferrari/tokens.css
+ *
+ * Structured token bindings for Ferrari.
+ * Italian performance luxury with racing red, carbon black, and premium editorial spacing.
+ */
+
+:root {
+  --bg: #0b0b0b;
+  --surface: #171717;
+  --surface-warm: #23130f;
+  --fg: #fffaf0;
+  --fg-2: #e8dcc8;
+  --muted: #a89f91;
+  --meta: #ffd200;
+  --border: #342a24;
+  --border-soft: #241f1b;
+  --accent: #dc0000;
+  --accent-on: #ffffff;
+  --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+  --success: #0f9d58;
+  --warn: #ffd200;
+  --danger: #ff3b30;
+  --font-display: "Ferrari Sans", "Helvetica Neue", Arial, sans-serif;
+  --font-body: "Ferrari Sans", "Helvetica Neue", Arial, sans-serif;
+  --font-mono: "SF Mono", ui-monospace, Menlo, monospace;
+  --text-xs: 12px;
+  --text-sm: 14px;
+  --text-base: 16px;
+  --text-lg: 19px;
+  --text-xl: 26px;
+  --text-2xl: 40px;
+  --text-3xl: 62px;
+  --text-4xl: 88px;
+  --leading-body: 1.5;
+  --leading-tight: 0.98;
+  --tracking-display: -0.03em;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+  --section-y-desktop: 112px;
+  --section-y-tablet: 80px;
+  --section-y-phone: 56px;
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 14px;
+  --radius-pill: 9999px;
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised: 0 26px 80px rgba(0, 0, 0, 0.48);
+  --focus-ring: 0 0 0 4px rgba(220, 0, 0, 0.30);
+  --motion-fast: 130ms;
+  --motion-base: 220ms;
+  --ease-standard: cubic-bezier(0.16, 1, 0.3, 1);
+  --container-max: 1240px;
+  --container-gutter-desktop: 40px;
+  --container-gutter-tablet: 28px;
+  --container-gutter-phone: 18px;
+}

--- a/design-systems/ibm/components.html
+++ b/design-systems/ibm/components.html
@@ -1,0 +1,342 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>IBM - reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/ibm: white Carbon surfaces, square geometry, IBM Plex typography, and a single engineered blue signal."
+    />
+    <style>
+      :root {
+        --bg: #ffffff;
+        --surface: #f4f4f4;
+        --surface-warm: #edf5ff;
+        --fg: #161616;
+        --fg-2: #525252;
+        --muted: #6f6f6f;
+        --meta: #8d8d8d;
+        --border: #c6c6c6;
+        --border-soft: #e0e0e0;
+        --accent: #0f62fe;
+        --accent-on: #ffffff;
+        --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+        --success: #24a148;
+        --warn: #f1c21b;
+        --danger: #da1e28;
+        --font-display: "IBM Plex Sans", "Helvetica Neue", Arial, sans-serif;
+        --font-body: "IBM Plex Sans", "Helvetica Neue", Arial, sans-serif;
+        --font-mono: "IBM Plex Mono", "SF Mono", Menlo, monospace;
+        --text-xs: 12px;
+        --text-sm: 14px;
+        --text-base: 16px;
+        --text-lg: 18px;
+        --text-xl: 20px;
+        --text-2xl: 32px;
+        --text-3xl: 42px;
+        --text-4xl: 60px;
+        --leading-body: 1.5;
+        --leading-tight: 1.17;
+        --tracking-display: 0;
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+        --section-y-desktop: 96px;
+        --section-y-tablet: 72px;
+        --section-y-phone: 48px;
+        --radius-sm: 0px;
+        --radius-md: 0px;
+        --radius-lg: 0px;
+        --radius-pill: 9999px;
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised: 0 2px 6px rgba(0, 0, 0, 0.12);
+        --focus-ring: 0 0 0 2px #ffffff, 0 0 0 4px #0f62fe;
+        --motion-fast: 110ms;
+        --motion-base: 180ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0.38, 0.9);
+        --container-max: 1312px;
+        --container-gutter-desktop: 32px;
+        --container-gutter-tablet: 24px;
+        --container-gutter-phone: 16px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        min-height: 100vh;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+      .page {
+        min-height: 100vh;
+        background: linear-gradient(135deg, #ffffff 0%, #f4f4f4 52%, #edf5ff 100%);
+      }
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+      h1, h2, h3, p { margin: 0; }
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        line-height: var(--leading-tight);
+        letter-spacing: var(--tracking-display);
+      }
+      h1 { max-width: 820px; font-size: var(--text-4xl); font-weight: 700; }
+      h2 { font-size: var(--text-3xl); font-weight: 650; }
+      h3 { font-size: var(--text-xl); font-weight: 650; }
+      .eyebrow {
+        color: var(--meta);
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+      .lead {
+        max-width: 620px;
+        color: var(--fg-2);
+        font-size: var(--text-lg);
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+        gap: var(--space-8);
+        align-items: center;
+      }
+      .stack > * + * { margin-block-start: var(--space-4); }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3);
+        margin-block-start: var(--space-6);
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 44px;
+        padding: 0 var(--space-5);
+        border: 1px solid transparent;
+        border-radius: var(--radius-md);
+        font: 700 var(--text-sm) / 1 var(--font-body);
+        text-decoration: none;
+        cursor: pointer;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          border-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard),
+          transform var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn-primary { background: var(--accent); color: var(--accent-on); }
+      .btn-primary:hover { background: var(--accent-hover); transform: translateY(-1px); }
+      .btn-secondary { background: var(--surface); color: var(--fg); border-color: var(--border); box-shadow: var(--elev-ring); }
+      .btn-secondary:hover { border-color: var(--accent); color: var(--accent); }
+      .panel {
+        background: color-mix(in oklab, var(--surface), transparent 4%);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--elev-raised);
+        overflow: hidden;
+      }
+      .panel-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+        padding: var(--space-5);
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .status {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        color: var(--meta);
+        font: 700 var(--text-xs) / 1 var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .status::before {
+        width: 8px;
+        height: 8px;
+        border-radius: var(--radius-pill);
+        background: var(--success);
+        content: "";
+      }
+      .metric-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .metric {
+        padding: var(--space-5);
+        border-right: 1px solid var(--border-soft);
+      }
+      .metric:last-child { border-right: 0; }
+      .metric strong {
+        display: block;
+        font-family: var(--font-display);
+        font-size: var(--text-2xl);
+        line-height: var(--leading-tight);
+      }
+      .metric span { color: var(--muted); font-size: var(--text-sm); }
+      .card-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-4);
+        padding: var(--space-5);
+      }
+      .mini-card {
+        min-height: 148px;
+        padding: var(--space-5);
+        border: 1px solid var(--border-soft);
+        border-radius: var(--radius-md);
+        background: var(--surface-warm);
+      }
+      .mini-card p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      .swatches {
+        display: flex;
+        gap: var(--space-2);
+        margin-block-start: var(--space-4);
+      }
+      .swatch {
+        width: 32px;
+        height: 32px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+      }
+      .swatch.accent { background: var(--accent); }
+      .swatch.surface { background: var(--surface); }
+      .swatch.warm { background: var(--surface-warm); }
+      .swatch.fg { background: var(--fg); }
+      .field {
+        display: grid;
+        gap: var(--space-2);
+        margin-block-start: var(--space-5);
+      }
+      label { color: var(--fg-2); font-size: var(--text-sm); font-weight: 700; }
+      input {
+        width: 100%;
+        min-height: 46px;
+        padding: 0 var(--space-4);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--surface);
+        color: var(--fg);
+        font: inherit;
+      }
+      input:focus { outline: none; box-shadow: var(--focus-ring); border-color: var(--accent); }
+      .lower {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: var(--space-4);
+      }
+      .tile {
+        padding: var(--space-5);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface);
+      }
+      .tile p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      @media (max-width: 860px) {
+        .hero, .lower { grid-template-columns: 1fr; }
+        .metric-grid, .card-row { grid-template-columns: 1fr; }
+        .metric { border-right: 0; border-bottom: 1px solid var(--border-soft); }
+        .metric:last-child { border-bottom: 0; }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <section>
+        <div class="container hero">
+          <div class="stack">
+            <p class="eyebrow">IBM design system</p>
+            <h1>Carbon command center</h1>
+            <p class="lead">Enterprise products, data modules, and precise blue actions.</p>
+            <div class="actions" aria-label="Reference actions">
+              <a class="btn btn-primary" href="#">Primary rectangular Carbon action</a>
+              <a class="btn btn-secondary" href="#">Secondary action</a>
+            </div>
+          </div>
+          <article class="panel" aria-label="IBM component preview">
+            <div class="panel-head">
+              <div>
+                <p class="eyebrow">Live module</p>
+                <h3>grid-aligned module</h3>
+              </div>
+              <span class="status">online</span>
+            </div>
+            <div class="metric-grid">
+              <div class="metric"><strong>98%</strong><span>Signal quality</span></div>
+              <div class="metric"><strong>24</strong><span>Active flows</span></div>
+              <div class="metric"><strong>3.2s</strong><span>Response time</span></div>
+            </div>
+            <div class="card-row">
+              <div class="mini-card">
+                <h3>Palette</h3>
+                <p>white Carbon surfaces, square geometry, IBM Plex typography, and a single engineered blue signal.</p>
+                <div class="swatches" aria-label="Token swatches">
+                  <span class="swatch accent"></span>
+                  <span class="swatch surface"></span>
+                  <span class="swatch warm"></span>
+                  <span class="swatch fg"></span>
+                </div>
+              </div>
+              <div class="mini-card">
+                <h3>Control</h3>
+                <p>Focus, hover, and status states share the same brand signal.</p>
+                <div class="field">
+                  <label for="ibm-input">Reference input</label>
+                  <input id="ibm-input" value="IBM system token" />
+                </div>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+      <section>
+        <div class="container lower">
+          <article class="tile">
+            <p class="eyebrow">Typography</p>
+            <h2>Display rhythm</h2>
+            <p>Headlines use the brand display stack with the declared scale and leading.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Surface</p>
+            <h2>Layer system</h2>
+            <p>Cards, warm panels, borders, and raised states resolve through shared tokens.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Interaction</p>
+            <h2>Motion states</h2>
+            <p>Buttons, inputs, and panels use brand-specific focus rings and easing.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/ibm/tokens.css
+++ b/design-systems/ibm/tokens.css
@@ -1,0 +1,64 @@
+/* design-systems/ibm/tokens.css
+ *
+ * Structured token bindings for IBM.
+ * white Carbon surfaces, square geometry, IBM Plex typography, and a single engineered blue signal.
+ */
+
+:root {
+  --bg: #ffffff;
+  --surface: #f4f4f4;
+  --surface-warm: #edf5ff;
+  --fg: #161616;
+  --fg-2: #525252;
+  --muted: #6f6f6f;
+  --meta: #8d8d8d;
+  --border: #c6c6c6;
+  --border-soft: #e0e0e0;
+  --accent: #0f62fe;
+  --accent-on: #ffffff;
+  --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+  --success: #24a148;
+  --warn: #f1c21b;
+  --danger: #da1e28;
+  --font-display: "IBM Plex Sans", "Helvetica Neue", Arial, sans-serif;
+  --font-body: "IBM Plex Sans", "Helvetica Neue", Arial, sans-serif;
+  --font-mono: "IBM Plex Mono", "SF Mono", Menlo, monospace;
+  --text-xs: 12px;
+  --text-sm: 14px;
+  --text-base: 16px;
+  --text-lg: 18px;
+  --text-xl: 20px;
+  --text-2xl: 32px;
+  --text-3xl: 42px;
+  --text-4xl: 60px;
+  --leading-body: 1.5;
+  --leading-tight: 1.17;
+  --tracking-display: 0;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+  --section-y-desktop: 96px;
+  --section-y-tablet: 72px;
+  --section-y-phone: 48px;
+  --radius-sm: 0px;
+  --radius-md: 0px;
+  --radius-lg: 0px;
+  --radius-pill: 9999px;
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised: 0 2px 6px rgba(0, 0, 0, 0.12);
+  --focus-ring: 0 0 0 2px #ffffff, 0 0 0 4px #0f62fe;
+  --motion-fast: 110ms;
+  --motion-base: 180ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0.38, 0.9);
+  --container-max: 1312px;
+  --container-gutter-desktop: 32px;
+  --container-gutter-tablet: 24px;
+  --container-gutter-phone: 16px;
+}

--- a/design-systems/kraken/components.html
+++ b/design-systems/kraken/components.html
@@ -1,0 +1,342 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Kraken - reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/kraken: dark crypto exchange interface with violet signal, chart density, and confident controls."
+    />
+    <style>
+      :root {
+        --bg: #0b1020;
+        --surface: #121a33;
+        --surface-warm: #1b2450;
+        --fg: #f8fafc;
+        --fg-2: #cbd5e1;
+        --muted: #8b95aa;
+        --meta: #7d5cff;
+        --border: #26314f;
+        --border-soft: #1b2740;
+        --accent: #7132f5;
+        --accent-on: #ffffff;
+        --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+        --success: #00c853;
+        --warn: #ffb020;
+        --danger: #ff4d6d;
+        --font-display: "Inter", system-ui, sans-serif;
+        --font-body: "Inter", system-ui, sans-serif;
+        --font-mono: "Roboto Mono", "SF Mono", ui-monospace, Menlo, monospace;
+        --text-xs: 11px;
+        --text-sm: 13px;
+        --text-base: 15px;
+        --text-lg: 17px;
+        --text-xl: 22px;
+        --text-2xl: 30px;
+        --text-3xl: 44px;
+        --text-4xl: 60px;
+        --leading-body: 1.48;
+        --leading-tight: 1.08;
+        --tracking-display: -0.015em;
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+        --section-y-desktop: 88px;
+        --section-y-tablet: 64px;
+        --section-y-phone: 44px;
+        --radius-sm: 8px;
+        --radius-md: 12px;
+        --radius-lg: 18px;
+        --radius-pill: 9999px;
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised: 0 24px 70px rgba(0, 0, 0, 0.42);
+        --focus-ring: 0 0 0 4px rgba(113, 50, 245, 0.32);
+        --motion-fast: 120ms;
+        --motion-base: 200ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+        --container-max: 1280px;
+        --container-gutter-desktop: 32px;
+        --container-gutter-tablet: 24px;
+        --container-gutter-phone: 16px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        min-height: 100vh;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+      .page {
+        min-height: 100vh;
+        background: radial-gradient(circle at 78% 12%, rgba(113, 50, 245, 0.30), transparent 34%), #0b1020;
+      }
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+      h1, h2, h3, p { margin: 0; }
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        line-height: var(--leading-tight);
+        letter-spacing: var(--tracking-display);
+      }
+      h1 { max-width: 820px; font-size: var(--text-4xl); font-weight: 700; }
+      h2 { font-size: var(--text-3xl); font-weight: 650; }
+      h3 { font-size: var(--text-xl); font-weight: 650; }
+      .eyebrow {
+        color: var(--meta);
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+      .lead {
+        max-width: 620px;
+        color: var(--fg-2);
+        font-size: var(--text-lg);
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+        gap: var(--space-8);
+        align-items: center;
+      }
+      .stack > * + * { margin-block-start: var(--space-4); }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3);
+        margin-block-start: var(--space-6);
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 44px;
+        padding: 0 var(--space-5);
+        border: 1px solid transparent;
+        border-radius: var(--radius-md);
+        font: 700 var(--text-sm) / 1 var(--font-body);
+        text-decoration: none;
+        cursor: pointer;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          border-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard),
+          transform var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn-primary { background: var(--accent); color: var(--accent-on); }
+      .btn-primary:hover { background: var(--accent-hover); transform: translateY(-1px); }
+      .btn-secondary { background: var(--surface); color: var(--fg); border-color: var(--border); box-shadow: var(--elev-ring); }
+      .btn-secondary:hover { border-color: var(--accent); color: var(--accent); }
+      .panel {
+        background: color-mix(in oklab, var(--surface), transparent 4%);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--elev-raised);
+        overflow: hidden;
+      }
+      .panel-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+        padding: var(--space-5);
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .status {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        color: var(--meta);
+        font: 700 var(--text-xs) / 1 var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .status::before {
+        width: 8px;
+        height: 8px;
+        border-radius: var(--radius-pill);
+        background: var(--success);
+        content: "";
+      }
+      .metric-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .metric {
+        padding: var(--space-5);
+        border-right: 1px solid var(--border-soft);
+      }
+      .metric:last-child { border-right: 0; }
+      .metric strong {
+        display: block;
+        font-family: var(--font-display);
+        font-size: var(--text-2xl);
+        line-height: var(--leading-tight);
+      }
+      .metric span { color: var(--muted); font-size: var(--text-sm); }
+      .card-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-4);
+        padding: var(--space-5);
+      }
+      .mini-card {
+        min-height: 148px;
+        padding: var(--space-5);
+        border: 1px solid var(--border-soft);
+        border-radius: var(--radius-md);
+        background: var(--surface-warm);
+      }
+      .mini-card p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      .swatches {
+        display: flex;
+        gap: var(--space-2);
+        margin-block-start: var(--space-4);
+      }
+      .swatch {
+        width: 32px;
+        height: 32px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+      }
+      .swatch.accent { background: var(--accent); }
+      .swatch.surface { background: var(--surface); }
+      .swatch.warm { background: var(--surface-warm); }
+      .swatch.fg { background: var(--fg); }
+      .field {
+        display: grid;
+        gap: var(--space-2);
+        margin-block-start: var(--space-5);
+      }
+      label { color: var(--fg-2); font-size: var(--text-sm); font-weight: 700; }
+      input {
+        width: 100%;
+        min-height: 46px;
+        padding: 0 var(--space-4);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--surface);
+        color: var(--fg);
+        font: inherit;
+      }
+      input:focus { outline: none; box-shadow: var(--focus-ring); border-color: var(--accent); }
+      .lower {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: var(--space-4);
+      }
+      .tile {
+        padding: var(--space-5);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface);
+      }
+      .tile p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      @media (max-width: 860px) {
+        .hero, .lower { grid-template-columns: 1fr; }
+        .metric-grid, .card-row { grid-template-columns: 1fr; }
+        .metric { border-right: 0; border-bottom: 1px solid var(--border-soft); }
+        .metric:last-child { border-bottom: 0; }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <section>
+        <div class="container hero">
+          <div class="stack">
+            <p class="eyebrow">Kraken design system</p>
+            <h1>Crypto trading terminal</h1>
+            <p class="lead">Dense exchange modules, purple action, and high-contrast market states.</p>
+            <div class="actions" aria-label="Reference actions">
+              <a class="btn btn-primary" href="#">Primary exchange action</a>
+              <a class="btn btn-secondary" href="#">Secondary action</a>
+            </div>
+          </div>
+          <article class="panel" aria-label="Kraken component preview">
+            <div class="panel-head">
+              <div>
+                <p class="eyebrow">Live module</p>
+                <h3>market data panel</h3>
+              </div>
+              <span class="status">online</span>
+            </div>
+            <div class="metric-grid">
+              <div class="metric"><strong>98%</strong><span>Signal quality</span></div>
+              <div class="metric"><strong>24</strong><span>Active flows</span></div>
+              <div class="metric"><strong>3.2s</strong><span>Response time</span></div>
+            </div>
+            <div class="card-row">
+              <div class="mini-card">
+                <h3>Palette</h3>
+                <p>dark crypto exchange interface with violet signal, chart density, and confident controls.</p>
+                <div class="swatches" aria-label="Token swatches">
+                  <span class="swatch accent"></span>
+                  <span class="swatch surface"></span>
+                  <span class="swatch warm"></span>
+                  <span class="swatch fg"></span>
+                </div>
+              </div>
+              <div class="mini-card">
+                <h3>Control</h3>
+                <p>Focus, hover, and status states share the same brand signal.</p>
+                <div class="field">
+                  <label for="kraken-input">Reference input</label>
+                  <input id="kraken-input" value="Kraken system token" />
+                </div>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+      <section>
+        <div class="container lower">
+          <article class="tile">
+            <p class="eyebrow">Typography</p>
+            <h2>Display rhythm</h2>
+            <p>Headlines use the brand display stack with the declared scale and leading.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Surface</p>
+            <h2>Layer system</h2>
+            <p>Cards, warm panels, borders, and raised states resolve through shared tokens.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Interaction</p>
+            <h2>Motion states</h2>
+            <p>Buttons, inputs, and panels use brand-specific focus rings and easing.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/kraken/tokens.css
+++ b/design-systems/kraken/tokens.css
@@ -1,0 +1,64 @@
+/* design-systems/kraken/tokens.css
+ *
+ * Structured token bindings for Kraken.
+ * dark crypto exchange interface with violet signal, chart density, and confident controls.
+ */
+
+:root {
+  --bg: #0b1020;
+  --surface: #121a33;
+  --surface-warm: #1b2450;
+  --fg: #f8fafc;
+  --fg-2: #cbd5e1;
+  --muted: #8b95aa;
+  --meta: #7d5cff;
+  --border: #26314f;
+  --border-soft: #1b2740;
+  --accent: #7132f5;
+  --accent-on: #ffffff;
+  --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+  --success: #00c853;
+  --warn: #ffb020;
+  --danger: #ff4d6d;
+  --font-display: "Inter", system-ui, sans-serif;
+  --font-body: "Inter", system-ui, sans-serif;
+  --font-mono: "Roboto Mono", "SF Mono", ui-monospace, Menlo, monospace;
+  --text-xs: 11px;
+  --text-sm: 13px;
+  --text-base: 15px;
+  --text-lg: 17px;
+  --text-xl: 22px;
+  --text-2xl: 30px;
+  --text-3xl: 44px;
+  --text-4xl: 60px;
+  --leading-body: 1.48;
+  --leading-tight: 1.08;
+  --tracking-display: -0.015em;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+  --section-y-desktop: 88px;
+  --section-y-tablet: 64px;
+  --section-y-phone: 44px;
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 18px;
+  --radius-pill: 9999px;
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised: 0 24px 70px rgba(0, 0, 0, 0.42);
+  --focus-ring: 0 0 0 4px rgba(113, 50, 245, 0.32);
+  --motion-fast: 120ms;
+  --motion-base: 200ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --container-max: 1280px;
+  --container-gutter-desktop: 32px;
+  --container-gutter-tablet: 24px;
+  --container-gutter-phone: 16px;
+}

--- a/design-systems/lamborghini/components.html
+++ b/design-systems/lamborghini/components.html
@@ -1,0 +1,342 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Lamborghini - reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/lamborghini: sharp black-gold performance interface with angular premium energy."
+    />
+    <style>
+      :root {
+        --bg: #050505;
+        --surface: #141414;
+        --surface-warm: #211b0b;
+        --fg: #f8f4e6;
+        --fg-2: #d8ceb0;
+        --muted: #9b927d;
+        --meta: #d4af37;
+        --border: #3a321d;
+        --border-soft: #282315;
+        --accent: #d4af37;
+        --accent-on: #050505;
+        --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+        --success: #39a852;
+        --warn: #f7c948;
+        --danger: #e63946;
+        --font-display: "Lamborghini", "Eurostile", Arial, sans-serif;
+        --font-body: "Inter", Arial, sans-serif;
+        --font-mono: "SF Mono", ui-monospace, Menlo, monospace;
+        --text-xs: 12px;
+        --text-sm: 14px;
+        --text-base: 16px;
+        --text-lg: 18px;
+        --text-xl: 26px;
+        --text-2xl: 42px;
+        --text-3xl: 64px;
+        --text-4xl: 90px;
+        --leading-body: 1.48;
+        --leading-tight: 0.96;
+        --tracking-display: -0.025em;
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+        --section-y-desktop: 112px;
+        --section-y-tablet: 80px;
+        --section-y-phone: 56px;
+        --radius-sm: 2px;
+        --radius-md: 6px;
+        --radius-lg: 10px;
+        --radius-pill: 9999px;
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised: 0 28px 84px rgba(0, 0, 0, 0.54);
+        --focus-ring: 0 0 0 4px rgba(212, 175, 55, 0.32);
+        --motion-fast: 120ms;
+        --motion-base: 210ms;
+        --ease-standard: cubic-bezier(0.16, 1, 0.3, 1);
+        --container-max: 1240px;
+        --container-gutter-desktop: 40px;
+        --container-gutter-tablet: 28px;
+        --container-gutter-phone: 18px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        min-height: 100vh;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+      .page {
+        min-height: 100vh;
+        background: linear-gradient(135deg, #050505 0%, #211b0b 62%, #d4af37 100%);
+      }
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+      h1, h2, h3, p { margin: 0; }
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        line-height: var(--leading-tight);
+        letter-spacing: var(--tracking-display);
+      }
+      h1 { max-width: 820px; font-size: var(--text-4xl); font-weight: 700; }
+      h2 { font-size: var(--text-3xl); font-weight: 650; }
+      h3 { font-size: var(--text-xl); font-weight: 650; }
+      .eyebrow {
+        color: var(--meta);
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+      .lead {
+        max-width: 620px;
+        color: var(--fg-2);
+        font-size: var(--text-lg);
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+        gap: var(--space-8);
+        align-items: center;
+      }
+      .stack > * + * { margin-block-start: var(--space-4); }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3);
+        margin-block-start: var(--space-6);
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 44px;
+        padding: 0 var(--space-5);
+        border: 1px solid transparent;
+        border-radius: var(--radius-md);
+        font: 700 var(--text-sm) / 1 var(--font-body);
+        text-decoration: none;
+        cursor: pointer;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          border-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard),
+          transform var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn-primary { background: var(--accent); color: var(--accent-on); }
+      .btn-primary:hover { background: var(--accent-hover); transform: translateY(-1px); }
+      .btn-secondary { background: var(--surface); color: var(--fg); border-color: var(--border); box-shadow: var(--elev-ring); }
+      .btn-secondary:hover { border-color: var(--accent); color: var(--accent); }
+      .panel {
+        background: color-mix(in oklab, var(--surface), transparent 4%);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--elev-raised);
+        overflow: hidden;
+      }
+      .panel-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+        padding: var(--space-5);
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .status {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        color: var(--meta);
+        font: 700 var(--text-xs) / 1 var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .status::before {
+        width: 8px;
+        height: 8px;
+        border-radius: var(--radius-pill);
+        background: var(--success);
+        content: "";
+      }
+      .metric-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .metric {
+        padding: var(--space-5);
+        border-right: 1px solid var(--border-soft);
+      }
+      .metric:last-child { border-right: 0; }
+      .metric strong {
+        display: block;
+        font-family: var(--font-display);
+        font-size: var(--text-2xl);
+        line-height: var(--leading-tight);
+      }
+      .metric span { color: var(--muted); font-size: var(--text-sm); }
+      .card-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-4);
+        padding: var(--space-5);
+      }
+      .mini-card {
+        min-height: 148px;
+        padding: var(--space-5);
+        border: 1px solid var(--border-soft);
+        border-radius: var(--radius-md);
+        background: var(--surface-warm);
+      }
+      .mini-card p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      .swatches {
+        display: flex;
+        gap: var(--space-2);
+        margin-block-start: var(--space-4);
+      }
+      .swatch {
+        width: 32px;
+        height: 32px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+      }
+      .swatch.accent { background: var(--accent); }
+      .swatch.surface { background: var(--surface); }
+      .swatch.warm { background: var(--surface-warm); }
+      .swatch.fg { background: var(--fg); }
+      .field {
+        display: grid;
+        gap: var(--space-2);
+        margin-block-start: var(--space-5);
+      }
+      label { color: var(--fg-2); font-size: var(--text-sm); font-weight: 700; }
+      input {
+        width: 100%;
+        min-height: 46px;
+        padding: 0 var(--space-4);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--surface);
+        color: var(--fg);
+        font: inherit;
+      }
+      input:focus { outline: none; box-shadow: var(--focus-ring); border-color: var(--accent); }
+      .lower {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: var(--space-4);
+      }
+      .tile {
+        padding: var(--space-5);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface);
+      }
+      .tile p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      @media (max-width: 860px) {
+        .hero, .lower { grid-template-columns: 1fr; }
+        .metric-grid, .card-row { grid-template-columns: 1fr; }
+        .metric { border-right: 0; border-bottom: 1px solid var(--border-soft); }
+        .metric:last-child { border-bottom: 0; }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <section>
+        <div class="container hero">
+          <div class="stack">
+            <p class="eyebrow">Lamborghini design system</p>
+            <h1>Supercar configurator</h1>
+            <p class="lead">Angular luxury, black-gold contrast, and aggressive performance cards.</p>
+            <div class="actions" aria-label="Reference actions">
+              <a class="btn btn-primary" href="#">Primary gold wedge action</a>
+              <a class="btn btn-secondary" href="#">Secondary action</a>
+            </div>
+          </div>
+          <article class="panel" aria-label="Lamborghini component preview">
+            <div class="panel-head">
+              <div>
+                <p class="eyebrow">Live module</p>
+                <h3>angular spec tile</h3>
+              </div>
+              <span class="status">online</span>
+            </div>
+            <div class="metric-grid">
+              <div class="metric"><strong>98%</strong><span>Signal quality</span></div>
+              <div class="metric"><strong>24</strong><span>Active flows</span></div>
+              <div class="metric"><strong>3.2s</strong><span>Response time</span></div>
+            </div>
+            <div class="card-row">
+              <div class="mini-card">
+                <h3>Palette</h3>
+                <p>sharp black-gold performance interface with angular premium energy.</p>
+                <div class="swatches" aria-label="Token swatches">
+                  <span class="swatch accent"></span>
+                  <span class="swatch surface"></span>
+                  <span class="swatch warm"></span>
+                  <span class="swatch fg"></span>
+                </div>
+              </div>
+              <div class="mini-card">
+                <h3>Control</h3>
+                <p>Focus, hover, and status states share the same brand signal.</p>
+                <div class="field">
+                  <label for="lamborghini-input">Reference input</label>
+                  <input id="lamborghini-input" value="Lamborghini system token" />
+                </div>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+      <section>
+        <div class="container lower">
+          <article class="tile">
+            <p class="eyebrow">Typography</p>
+            <h2>Display rhythm</h2>
+            <p>Headlines use the brand display stack with the declared scale and leading.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Surface</p>
+            <h2>Layer system</h2>
+            <p>Cards, warm panels, borders, and raised states resolve through shared tokens.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Interaction</p>
+            <h2>Motion states</h2>
+            <p>Buttons, inputs, and panels use brand-specific focus rings and easing.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/lamborghini/tokens.css
+++ b/design-systems/lamborghini/tokens.css
@@ -1,0 +1,64 @@
+/* design-systems/lamborghini/tokens.css
+ *
+ * Structured token bindings for Lamborghini.
+ * sharp black-gold performance interface with angular premium energy.
+ */
+
+:root {
+  --bg: #050505;
+  --surface: #141414;
+  --surface-warm: #211b0b;
+  --fg: #f8f4e6;
+  --fg-2: #d8ceb0;
+  --muted: #9b927d;
+  --meta: #d4af37;
+  --border: #3a321d;
+  --border-soft: #282315;
+  --accent: #d4af37;
+  --accent-on: #050505;
+  --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+  --success: #39a852;
+  --warn: #f7c948;
+  --danger: #e63946;
+  --font-display: "Lamborghini", "Eurostile", Arial, sans-serif;
+  --font-body: "Inter", Arial, sans-serif;
+  --font-mono: "SF Mono", ui-monospace, Menlo, monospace;
+  --text-xs: 12px;
+  --text-sm: 14px;
+  --text-base: 16px;
+  --text-lg: 18px;
+  --text-xl: 26px;
+  --text-2xl: 42px;
+  --text-3xl: 64px;
+  --text-4xl: 90px;
+  --leading-body: 1.48;
+  --leading-tight: 0.96;
+  --tracking-display: -0.025em;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+  --section-y-desktop: 112px;
+  --section-y-tablet: 80px;
+  --section-y-phone: 56px;
+  --radius-sm: 2px;
+  --radius-md: 6px;
+  --radius-lg: 10px;
+  --radius-pill: 9999px;
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised: 0 28px 84px rgba(0, 0, 0, 0.54);
+  --focus-ring: 0 0 0 4px rgba(212, 175, 55, 0.32);
+  --motion-fast: 120ms;
+  --motion-base: 210ms;
+  --ease-standard: cubic-bezier(0.16, 1, 0.3, 1);
+  --container-max: 1240px;
+  --container-gutter-desktop: 40px;
+  --container-gutter-tablet: 28px;
+  --container-gutter-phone: 18px;
+}

--- a/design-systems/mastercard/components.html
+++ b/design-systems/mastercard/components.html
@@ -1,0 +1,342 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Mastercard - reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/mastercard: putty-cream editorial canvas, orbital geometry, and warm payment-network restraint."
+    />
+    <style>
+      :root {
+        --bg: #f3f0ee;
+        --surface: #fcfbfa;
+        --surface-warm: #f7e8de;
+        --fg: #141413;
+        --fg-2: #262627;
+        --muted: #696969;
+        --meta: #9a3a0a;
+        --border: #d1cdc7;
+        --border-soft: #e7e1dc;
+        --accent: #cf4500;
+        --accent-on: #ffffff;
+        --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+        --success: #2e7d32;
+        --warn: #f79e1b;
+        --danger: #eb001b;
+        --font-display: "MarkForMC", "Sofia Sans", Arial, sans-serif;
+        --font-body: "MarkForMC", "Sofia Sans", Arial, sans-serif;
+        --font-mono: "MarkOffcForMC", ui-monospace, Menlo, monospace;
+        --text-xs: 12px;
+        --text-sm: 14px;
+        --text-base: 16px;
+        --text-lg: 18px;
+        --text-xl: 24px;
+        --text-2xl: 36px;
+        --text-3xl: 48px;
+        --text-4xl: 64px;
+        --leading-body: 1.4;
+        --leading-tight: 1;
+        --tracking-display: -0.02em;
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+        --section-y-desktop: 104px;
+        --section-y-tablet: 72px;
+        --section-y-phone: 52px;
+        --radius-sm: 20px;
+        --radius-md: 40px;
+        --radius-lg: 64px;
+        --radius-pill: 9999px;
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised: 0 24px 48px rgba(20, 20, 19, 0.10);
+        --focus-ring: 0 0 0 4px rgba(207, 69, 0, 0.24);
+        --motion-fast: 180ms;
+        --motion-base: 260ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+        --container-max: 1180px;
+        --container-gutter-desktop: 36px;
+        --container-gutter-tablet: 28px;
+        --container-gutter-phone: 20px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        min-height: 100vh;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+      .page {
+        min-height: 100vh;
+        background: radial-gradient(circle at 12% 30%, #eb001b 0 9%, transparent 10%), radial-gradient(circle at 21% 30%, #f79e1b 0 9%, transparent 10%), linear-gradient(135deg, #f3f0ee 0%, #fcfbfa 100%);
+      }
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+      h1, h2, h3, p { margin: 0; }
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        line-height: var(--leading-tight);
+        letter-spacing: var(--tracking-display);
+      }
+      h1 { max-width: 820px; font-size: var(--text-4xl); font-weight: 700; }
+      h2 { font-size: var(--text-3xl); font-weight: 650; }
+      h3 { font-size: var(--text-xl); font-weight: 650; }
+      .eyebrow {
+        color: var(--meta);
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+      .lead {
+        max-width: 620px;
+        color: var(--fg-2);
+        font-size: var(--text-lg);
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+        gap: var(--space-8);
+        align-items: center;
+      }
+      .stack > * + * { margin-block-start: var(--space-4); }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3);
+        margin-block-start: var(--space-6);
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 44px;
+        padding: 0 var(--space-5);
+        border: 1px solid transparent;
+        border-radius: var(--radius-md);
+        font: 700 var(--text-sm) / 1 var(--font-body);
+        text-decoration: none;
+        cursor: pointer;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          border-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard),
+          transform var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn-primary { background: var(--accent); color: var(--accent-on); }
+      .btn-primary:hover { background: var(--accent-hover); transform: translateY(-1px); }
+      .btn-secondary { background: var(--surface); color: var(--fg); border-color: var(--border); box-shadow: var(--elev-ring); }
+      .btn-secondary:hover { border-color: var(--accent); color: var(--accent); }
+      .panel {
+        background: color-mix(in oklab, var(--surface), transparent 4%);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--elev-raised);
+        overflow: hidden;
+      }
+      .panel-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+        padding: var(--space-5);
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .status {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        color: var(--meta);
+        font: 700 var(--text-xs) / 1 var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .status::before {
+        width: 8px;
+        height: 8px;
+        border-radius: var(--radius-pill);
+        background: var(--success);
+        content: "";
+      }
+      .metric-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .metric {
+        padding: var(--space-5);
+        border-right: 1px solid var(--border-soft);
+      }
+      .metric:last-child { border-right: 0; }
+      .metric strong {
+        display: block;
+        font-family: var(--font-display);
+        font-size: var(--text-2xl);
+        line-height: var(--leading-tight);
+      }
+      .metric span { color: var(--muted); font-size: var(--text-sm); }
+      .card-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-4);
+        padding: var(--space-5);
+      }
+      .mini-card {
+        min-height: 148px;
+        padding: var(--space-5);
+        border: 1px solid var(--border-soft);
+        border-radius: var(--radius-md);
+        background: var(--surface-warm);
+      }
+      .mini-card p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      .swatches {
+        display: flex;
+        gap: var(--space-2);
+        margin-block-start: var(--space-4);
+      }
+      .swatch {
+        width: 32px;
+        height: 32px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+      }
+      .swatch.accent { background: var(--accent); }
+      .swatch.surface { background: var(--surface); }
+      .swatch.warm { background: var(--surface-warm); }
+      .swatch.fg { background: var(--fg); }
+      .field {
+        display: grid;
+        gap: var(--space-2);
+        margin-block-start: var(--space-5);
+      }
+      label { color: var(--fg-2); font-size: var(--text-sm); font-weight: 700; }
+      input {
+        width: 100%;
+        min-height: 46px;
+        padding: 0 var(--space-4);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--surface);
+        color: var(--fg);
+        font: inherit;
+      }
+      input:focus { outline: none; box-shadow: var(--focus-ring); border-color: var(--accent); }
+      .lower {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: var(--space-4);
+      }
+      .tile {
+        padding: var(--space-5);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface);
+      }
+      .tile p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      @media (max-width: 860px) {
+        .hero, .lower { grid-template-columns: 1fr; }
+        .metric-grid, .card-row { grid-template-columns: 1fr; }
+        .metric { border-right: 0; border-bottom: 1px solid var(--border-soft); }
+        .metric:last-child { border-bottom: 0; }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <section>
+        <div class="container hero">
+          <div class="stack">
+            <p class="eyebrow">Mastercard design system</p>
+            <h1>Payments orbit</h1>
+            <p class="lead">Warm editorial finance built from circles, pills, and signal orange.</p>
+            <div class="actions" aria-label="Reference actions">
+              <a class="btn btn-primary" href="#">Primary warm black pill</a>
+              <a class="btn btn-secondary" href="#">Secondary action</a>
+            </div>
+          </div>
+          <article class="panel" aria-label="Mastercard component preview">
+            <div class="panel-head">
+              <div>
+                <p class="eyebrow">Live module</p>
+                <h3>orbital cream capsule</h3>
+              </div>
+              <span class="status">online</span>
+            </div>
+            <div class="metric-grid">
+              <div class="metric"><strong>98%</strong><span>Signal quality</span></div>
+              <div class="metric"><strong>24</strong><span>Active flows</span></div>
+              <div class="metric"><strong>3.2s</strong><span>Response time</span></div>
+            </div>
+            <div class="card-row">
+              <div class="mini-card">
+                <h3>Palette</h3>
+                <p>putty-cream editorial canvas, orbital geometry, and warm payment-network restraint.</p>
+                <div class="swatches" aria-label="Token swatches">
+                  <span class="swatch accent"></span>
+                  <span class="swatch surface"></span>
+                  <span class="swatch warm"></span>
+                  <span class="swatch fg"></span>
+                </div>
+              </div>
+              <div class="mini-card">
+                <h3>Control</h3>
+                <p>Focus, hover, and status states share the same brand signal.</p>
+                <div class="field">
+                  <label for="mastercard-input">Reference input</label>
+                  <input id="mastercard-input" value="Mastercard system token" />
+                </div>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+      <section>
+        <div class="container lower">
+          <article class="tile">
+            <p class="eyebrow">Typography</p>
+            <h2>Display rhythm</h2>
+            <p>Headlines use the brand display stack with the declared scale and leading.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Surface</p>
+            <h2>Layer system</h2>
+            <p>Cards, warm panels, borders, and raised states resolve through shared tokens.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Interaction</p>
+            <h2>Motion states</h2>
+            <p>Buttons, inputs, and panels use brand-specific focus rings and easing.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/mastercard/tokens.css
+++ b/design-systems/mastercard/tokens.css
@@ -1,0 +1,64 @@
+/* design-systems/mastercard/tokens.css
+ *
+ * Structured token bindings for Mastercard.
+ * putty-cream editorial canvas, orbital geometry, and warm payment-network restraint.
+ */
+
+:root {
+  --bg: #f3f0ee;
+  --surface: #fcfbfa;
+  --surface-warm: #f7e8de;
+  --fg: #141413;
+  --fg-2: #262627;
+  --muted: #696969;
+  --meta: #9a3a0a;
+  --border: #d1cdc7;
+  --border-soft: #e7e1dc;
+  --accent: #cf4500;
+  --accent-on: #ffffff;
+  --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+  --success: #2e7d32;
+  --warn: #f79e1b;
+  --danger: #eb001b;
+  --font-display: "MarkForMC", "Sofia Sans", Arial, sans-serif;
+  --font-body: "MarkForMC", "Sofia Sans", Arial, sans-serif;
+  --font-mono: "MarkOffcForMC", ui-monospace, Menlo, monospace;
+  --text-xs: 12px;
+  --text-sm: 14px;
+  --text-base: 16px;
+  --text-lg: 18px;
+  --text-xl: 24px;
+  --text-2xl: 36px;
+  --text-3xl: 48px;
+  --text-4xl: 64px;
+  --leading-body: 1.4;
+  --leading-tight: 1;
+  --tracking-display: -0.02em;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+  --section-y-desktop: 104px;
+  --section-y-tablet: 72px;
+  --section-y-phone: 52px;
+  --radius-sm: 20px;
+  --radius-md: 40px;
+  --radius-lg: 64px;
+  --radius-pill: 9999px;
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised: 0 24px 48px rgba(20, 20, 19, 0.10);
+  --focus-ring: 0 0 0 4px rgba(207, 69, 0, 0.24);
+  --motion-fast: 180ms;
+  --motion-base: 260ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --container-max: 1180px;
+  --container-gutter-desktop: 36px;
+  --container-gutter-tablet: 28px;
+  --container-gutter-phone: 20px;
+}

--- a/design-systems/miro/components.html
+++ b/design-systems/miro/components.html
@@ -1,0 +1,342 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Miro - reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/miro: whiteboard canvas with sunny yellow, ink-black controls, and collaborative board energy."
+    />
+    <style>
+      :root {
+        --bg: #fff7c2;
+        --surface: #ffffff;
+        --surface-warm: #fff3a3;
+        --fg: #050038;
+        --fg-2: #322b6b;
+        --muted: #605a8a;
+        --meta: #f7c600;
+        --border: #ded9ff;
+        --border-soft: #eeeaff;
+        --accent: #ffd02f;
+        --accent-on: #050038;
+        --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+        --success: #1a7f37;
+        --warn: #ff9f1c;
+        --danger: #d92d20;
+        --font-display: "Formular", Inter, Arial, sans-serif;
+        --font-body: "Formular", Inter, Arial, sans-serif;
+        --font-mono: "IBM Plex Mono", ui-monospace, Menlo, monospace;
+        --text-xs: 12px;
+        --text-sm: 14px;
+        --text-base: 16px;
+        --text-lg: 18px;
+        --text-xl: 24px;
+        --text-2xl: 38px;
+        --text-3xl: 56px;
+        --text-4xl: 76px;
+        --leading-body: 1.5;
+        --leading-tight: 1.02;
+        --tracking-display: -0.025em;
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+        --section-y-desktop: 104px;
+        --section-y-tablet: 72px;
+        --section-y-phone: 52px;
+        --radius-sm: 10px;
+        --radius-md: 18px;
+        --radius-lg: 28px;
+        --radius-pill: 9999px;
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised: 0 16px 40px rgba(5, 0, 56, 0.14);
+        --focus-ring: 0 0 0 4px rgba(255, 208, 47, 0.38);
+        --motion-fast: 150ms;
+        --motion-base: 230ms;
+        --ease-standard: cubic-bezier(0.22, 1, 0.36, 1);
+        --container-max: 1220px;
+        --container-gutter-desktop: 36px;
+        --container-gutter-tablet: 28px;
+        --container-gutter-phone: 18px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        min-height: 100vh;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+      .page {
+        min-height: 100vh;
+        background: radial-gradient(circle at 18% 22%, #ffffff 0 12%, transparent 13%), linear-gradient(135deg, #fff7c2 0%, #ffd02f 100%);
+      }
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+      h1, h2, h3, p { margin: 0; }
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        line-height: var(--leading-tight);
+        letter-spacing: var(--tracking-display);
+      }
+      h1 { max-width: 820px; font-size: var(--text-4xl); font-weight: 700; }
+      h2 { font-size: var(--text-3xl); font-weight: 650; }
+      h3 { font-size: var(--text-xl); font-weight: 650; }
+      .eyebrow {
+        color: var(--meta);
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+      .lead {
+        max-width: 620px;
+        color: var(--fg-2);
+        font-size: var(--text-lg);
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+        gap: var(--space-8);
+        align-items: center;
+      }
+      .stack > * + * { margin-block-start: var(--space-4); }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3);
+        margin-block-start: var(--space-6);
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 44px;
+        padding: 0 var(--space-5);
+        border: 1px solid transparent;
+        border-radius: var(--radius-md);
+        font: 700 var(--text-sm) / 1 var(--font-body);
+        text-decoration: none;
+        cursor: pointer;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          border-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard),
+          transform var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn-primary { background: var(--accent); color: var(--accent-on); }
+      .btn-primary:hover { background: var(--accent-hover); transform: translateY(-1px); }
+      .btn-secondary { background: var(--surface); color: var(--fg); border-color: var(--border); box-shadow: var(--elev-ring); }
+      .btn-secondary:hover { border-color: var(--accent); color: var(--accent); }
+      .panel {
+        background: color-mix(in oklab, var(--surface), transparent 4%);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--elev-raised);
+        overflow: hidden;
+      }
+      .panel-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+        padding: var(--space-5);
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .status {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        color: var(--meta);
+        font: 700 var(--text-xs) / 1 var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .status::before {
+        width: 8px;
+        height: 8px;
+        border-radius: var(--radius-pill);
+        background: var(--success);
+        content: "";
+      }
+      .metric-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .metric {
+        padding: var(--space-5);
+        border-right: 1px solid var(--border-soft);
+      }
+      .metric:last-child { border-right: 0; }
+      .metric strong {
+        display: block;
+        font-family: var(--font-display);
+        font-size: var(--text-2xl);
+        line-height: var(--leading-tight);
+      }
+      .metric span { color: var(--muted); font-size: var(--text-sm); }
+      .card-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-4);
+        padding: var(--space-5);
+      }
+      .mini-card {
+        min-height: 148px;
+        padding: var(--space-5);
+        border: 1px solid var(--border-soft);
+        border-radius: var(--radius-md);
+        background: var(--surface-warm);
+      }
+      .mini-card p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      .swatches {
+        display: flex;
+        gap: var(--space-2);
+        margin-block-start: var(--space-4);
+      }
+      .swatch {
+        width: 32px;
+        height: 32px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+      }
+      .swatch.accent { background: var(--accent); }
+      .swatch.surface { background: var(--surface); }
+      .swatch.warm { background: var(--surface-warm); }
+      .swatch.fg { background: var(--fg); }
+      .field {
+        display: grid;
+        gap: var(--space-2);
+        margin-block-start: var(--space-5);
+      }
+      label { color: var(--fg-2); font-size: var(--text-sm); font-weight: 700; }
+      input {
+        width: 100%;
+        min-height: 46px;
+        padding: 0 var(--space-4);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--surface);
+        color: var(--fg);
+        font: inherit;
+      }
+      input:focus { outline: none; box-shadow: var(--focus-ring); border-color: var(--accent); }
+      .lower {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: var(--space-4);
+      }
+      .tile {
+        padding: var(--space-5);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface);
+      }
+      .tile p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      @media (max-width: 860px) {
+        .hero, .lower { grid-template-columns: 1fr; }
+        .metric-grid, .card-row { grid-template-columns: 1fr; }
+        .metric { border-right: 0; border-bottom: 1px solid var(--border-soft); }
+        .metric:last-child { border-bottom: 0; }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <section>
+        <div class="container hero">
+          <div class="stack">
+            <p class="eyebrow">Miro design system</p>
+            <h1>Infinite workshop board</h1>
+            <p class="lead">Collaborative sticky notes, bright yellow signal, and playful whiteboard structure.</p>
+            <div class="actions" aria-label="Reference actions">
+              <a class="btn btn-primary" href="#">Primary board control pill</a>
+              <a class="btn btn-secondary" href="#">Secondary action</a>
+            </div>
+          </div>
+          <article class="panel" aria-label="Miro component preview">
+            <div class="panel-head">
+              <div>
+                <p class="eyebrow">Live module</p>
+                <h3>sticky workshop tile</h3>
+              </div>
+              <span class="status">online</span>
+            </div>
+            <div class="metric-grid">
+              <div class="metric"><strong>98%</strong><span>Signal quality</span></div>
+              <div class="metric"><strong>24</strong><span>Active flows</span></div>
+              <div class="metric"><strong>3.2s</strong><span>Response time</span></div>
+            </div>
+            <div class="card-row">
+              <div class="mini-card">
+                <h3>Palette</h3>
+                <p>whiteboard canvas with sunny yellow, ink-black controls, and collaborative board energy.</p>
+                <div class="swatches" aria-label="Token swatches">
+                  <span class="swatch accent"></span>
+                  <span class="swatch surface"></span>
+                  <span class="swatch warm"></span>
+                  <span class="swatch fg"></span>
+                </div>
+              </div>
+              <div class="mini-card">
+                <h3>Control</h3>
+                <p>Focus, hover, and status states share the same brand signal.</p>
+                <div class="field">
+                  <label for="miro-input">Reference input</label>
+                  <input id="miro-input" value="Miro system token" />
+                </div>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+      <section>
+        <div class="container lower">
+          <article class="tile">
+            <p class="eyebrow">Typography</p>
+            <h2>Display rhythm</h2>
+            <p>Headlines use the brand display stack with the declared scale and leading.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Surface</p>
+            <h2>Layer system</h2>
+            <p>Cards, warm panels, borders, and raised states resolve through shared tokens.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Interaction</p>
+            <h2>Motion states</h2>
+            <p>Buttons, inputs, and panels use brand-specific focus rings and easing.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/miro/tokens.css
+++ b/design-systems/miro/tokens.css
@@ -1,0 +1,64 @@
+/* design-systems/miro/tokens.css
+ *
+ * Structured token bindings for Miro.
+ * whiteboard canvas with sunny yellow, ink-black controls, and collaborative board energy.
+ */
+
+:root {
+  --bg: #fff7c2;
+  --surface: #ffffff;
+  --surface-warm: #fff3a3;
+  --fg: #050038;
+  --fg-2: #322b6b;
+  --muted: #605a8a;
+  --meta: #f7c600;
+  --border: #ded9ff;
+  --border-soft: #eeeaff;
+  --accent: #ffd02f;
+  --accent-on: #050038;
+  --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+  --success: #1a7f37;
+  --warn: #ff9f1c;
+  --danger: #d92d20;
+  --font-display: "Formular", Inter, Arial, sans-serif;
+  --font-body: "Formular", Inter, Arial, sans-serif;
+  --font-mono: "IBM Plex Mono", ui-monospace, Menlo, monospace;
+  --text-xs: 12px;
+  --text-sm: 14px;
+  --text-base: 16px;
+  --text-lg: 18px;
+  --text-xl: 24px;
+  --text-2xl: 38px;
+  --text-3xl: 56px;
+  --text-4xl: 76px;
+  --leading-body: 1.5;
+  --leading-tight: 1.02;
+  --tracking-display: -0.025em;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+  --section-y-desktop: 104px;
+  --section-y-tablet: 72px;
+  --section-y-phone: 52px;
+  --radius-sm: 10px;
+  --radius-md: 18px;
+  --radius-lg: 28px;
+  --radius-pill: 9999px;
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised: 0 16px 40px rgba(5, 0, 56, 0.14);
+  --focus-ring: 0 0 0 4px rgba(255, 208, 47, 0.38);
+  --motion-fast: 150ms;
+  --motion-base: 230ms;
+  --ease-standard: cubic-bezier(0.22, 1, 0.36, 1);
+  --container-max: 1220px;
+  --container-gutter-desktop: 36px;
+  --container-gutter-tablet: 28px;
+  --container-gutter-phone: 18px;
+}

--- a/design-systems/pacman/components.html
+++ b/design-systems/pacman/components.html
@@ -1,0 +1,342 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Pac-Man - reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/pacman: classic arcade maze language with black board, yellow signal, and rounded score capsules."
+    />
+    <style>
+      :root {
+        --bg: #050505;
+        --surface: #101014;
+        --surface-warm: #1f1b08;
+        --fg: #fff7d6;
+        --fg-2: #f6e79c;
+        --muted: #b9a85d;
+        --meta: #ffcc00;
+        --border: #2338ff;
+        --border-soft: #17218a;
+        --accent: #ffcc00;
+        --accent-on: #050505;
+        --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+        --success: #00ff66;
+        --warn: #ff9900;
+        --danger: #ff3b3b;
+        --font-display: "Press Start 2P", "Arial Black", system-ui, sans-serif;
+        --font-body: "Inter", system-ui, sans-serif;
+        --font-mono: "Press Start 2P", ui-monospace, monospace;
+        --text-xs: 10px;
+        --text-sm: 12px;
+        --text-base: 14px;
+        --text-lg: 16px;
+        --text-xl: 20px;
+        --text-2xl: 30px;
+        --text-3xl: 44px;
+        --text-4xl: 64px;
+        --leading-body: 1.6;
+        --leading-tight: 1.08;
+        --tracking-display: 0;
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+        --section-y-desktop: 84px;
+        --section-y-tablet: 60px;
+        --section-y-phone: 44px;
+        --radius-sm: 10px;
+        --radius-md: 18px;
+        --radius-lg: 9999px;
+        --radius-pill: 9999px;
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised: 0 0 0 2px #2338ff, 0 22px 60px rgba(0, 0, 0, 0.46);
+        --focus-ring: 0 0 0 4px rgba(255, 204, 0, 0.34);
+        --motion-fast: 90ms;
+        --motion-base: 160ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+        --container-max: 1080px;
+        --container-gutter-desktop: 32px;
+        --container-gutter-tablet: 24px;
+        --container-gutter-phone: 16px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        min-height: 100vh;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+      .page {
+        min-height: 100vh;
+        background: radial-gradient(circle at 16% 28%, #ffcc00 0 10%, transparent 11%), linear-gradient(135deg, #050505 0%, #101014 100%);
+      }
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+      h1, h2, h3, p { margin: 0; }
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        line-height: var(--leading-tight);
+        letter-spacing: var(--tracking-display);
+      }
+      h1 { max-width: 820px; font-size: var(--text-4xl); font-weight: 700; }
+      h2 { font-size: var(--text-3xl); font-weight: 650; }
+      h3 { font-size: var(--text-xl); font-weight: 650; }
+      .eyebrow {
+        color: var(--meta);
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+      .lead {
+        max-width: 620px;
+        color: var(--fg-2);
+        font-size: var(--text-lg);
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+        gap: var(--space-8);
+        align-items: center;
+      }
+      .stack > * + * { margin-block-start: var(--space-4); }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3);
+        margin-block-start: var(--space-6);
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 44px;
+        padding: 0 var(--space-5);
+        border: 1px solid transparent;
+        border-radius: var(--radius-md);
+        font: 700 var(--text-sm) / 1 var(--font-body);
+        text-decoration: none;
+        cursor: pointer;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          border-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard),
+          transform var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn-primary { background: var(--accent); color: var(--accent-on); }
+      .btn-primary:hover { background: var(--accent-hover); transform: translateY(-1px); }
+      .btn-secondary { background: var(--surface); color: var(--fg); border-color: var(--border); box-shadow: var(--elev-ring); }
+      .btn-secondary:hover { border-color: var(--accent); color: var(--accent); }
+      .panel {
+        background: color-mix(in oklab, var(--surface), transparent 4%);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--elev-raised);
+        overflow: hidden;
+      }
+      .panel-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+        padding: var(--space-5);
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .status {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        color: var(--meta);
+        font: 700 var(--text-xs) / 1 var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .status::before {
+        width: 8px;
+        height: 8px;
+        border-radius: var(--radius-pill);
+        background: var(--success);
+        content: "";
+      }
+      .metric-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .metric {
+        padding: var(--space-5);
+        border-right: 1px solid var(--border-soft);
+      }
+      .metric:last-child { border-right: 0; }
+      .metric strong {
+        display: block;
+        font-family: var(--font-display);
+        font-size: var(--text-2xl);
+        line-height: var(--leading-tight);
+      }
+      .metric span { color: var(--muted); font-size: var(--text-sm); }
+      .card-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-4);
+        padding: var(--space-5);
+      }
+      .mini-card {
+        min-height: 148px;
+        padding: var(--space-5);
+        border: 1px solid var(--border-soft);
+        border-radius: var(--radius-md);
+        background: var(--surface-warm);
+      }
+      .mini-card p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      .swatches {
+        display: flex;
+        gap: var(--space-2);
+        margin-block-start: var(--space-4);
+      }
+      .swatch {
+        width: 32px;
+        height: 32px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+      }
+      .swatch.accent { background: var(--accent); }
+      .swatch.surface { background: var(--surface); }
+      .swatch.warm { background: var(--surface-warm); }
+      .swatch.fg { background: var(--fg); }
+      .field {
+        display: grid;
+        gap: var(--space-2);
+        margin-block-start: var(--space-5);
+      }
+      label { color: var(--fg-2); font-size: var(--text-sm); font-weight: 700; }
+      input {
+        width: 100%;
+        min-height: 46px;
+        padding: 0 var(--space-4);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--surface);
+        color: var(--fg);
+        font: inherit;
+      }
+      input:focus { outline: none; box-shadow: var(--focus-ring); border-color: var(--accent); }
+      .lower {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: var(--space-4);
+      }
+      .tile {
+        padding: var(--space-5);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface);
+      }
+      .tile p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      @media (max-width: 860px) {
+        .hero, .lower { grid-template-columns: 1fr; }
+        .metric-grid, .card-row { grid-template-columns: 1fr; }
+        .metric { border-right: 0; border-bottom: 1px solid var(--border-soft); }
+        .metric:last-child { border-bottom: 0; }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <section>
+        <div class="container hero">
+          <div class="stack">
+            <p class="eyebrow">Pac-Man design system</p>
+            <h1>Maze chase cabinet</h1>
+            <p class="lead">Black arcade board, yellow hero action, and playful maze modules.</p>
+            <div class="actions" aria-label="Reference actions">
+              <a class="btn btn-primary" href="#">Primary yellow arcade pill</a>
+              <a class="btn btn-secondary" href="#">Secondary action</a>
+            </div>
+          </div>
+          <article class="panel" aria-label="Pac-Man component preview">
+            <div class="panel-head">
+              <div>
+                <p class="eyebrow">Live module</p>
+                <h3>blue maze panel</h3>
+              </div>
+              <span class="status">online</span>
+            </div>
+            <div class="metric-grid">
+              <div class="metric"><strong>98%</strong><span>Signal quality</span></div>
+              <div class="metric"><strong>24</strong><span>Active flows</span></div>
+              <div class="metric"><strong>3.2s</strong><span>Response time</span></div>
+            </div>
+            <div class="card-row">
+              <div class="mini-card">
+                <h3>Palette</h3>
+                <p>classic arcade maze language with black board, yellow signal, and rounded score capsules.</p>
+                <div class="swatches" aria-label="Token swatches">
+                  <span class="swatch accent"></span>
+                  <span class="swatch surface"></span>
+                  <span class="swatch warm"></span>
+                  <span class="swatch fg"></span>
+                </div>
+              </div>
+              <div class="mini-card">
+                <h3>Control</h3>
+                <p>Focus, hover, and status states share the same brand signal.</p>
+                <div class="field">
+                  <label for="pacman-input">Reference input</label>
+                  <input id="pacman-input" value="Pac-Man system token" />
+                </div>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+      <section>
+        <div class="container lower">
+          <article class="tile">
+            <p class="eyebrow">Typography</p>
+            <h2>Display rhythm</h2>
+            <p>Headlines use the brand display stack with the declared scale and leading.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Surface</p>
+            <h2>Layer system</h2>
+            <p>Cards, warm panels, borders, and raised states resolve through shared tokens.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Interaction</p>
+            <h2>Motion states</h2>
+            <p>Buttons, inputs, and panels use brand-specific focus rings and easing.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/pacman/tokens.css
+++ b/design-systems/pacman/tokens.css
@@ -1,0 +1,64 @@
+/* design-systems/pacman/tokens.css
+ *
+ * Structured token bindings for Pac-Man.
+ * classic arcade maze language with black board, yellow signal, and rounded score capsules.
+ */
+
+:root {
+  --bg: #050505;
+  --surface: #101014;
+  --surface-warm: #1f1b08;
+  --fg: #fff7d6;
+  --fg-2: #f6e79c;
+  --muted: #b9a85d;
+  --meta: #ffcc00;
+  --border: #2338ff;
+  --border-soft: #17218a;
+  --accent: #ffcc00;
+  --accent-on: #050505;
+  --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+  --success: #00ff66;
+  --warn: #ff9900;
+  --danger: #ff3b3b;
+  --font-display: "Press Start 2P", "Arial Black", system-ui, sans-serif;
+  --font-body: "Inter", system-ui, sans-serif;
+  --font-mono: "Press Start 2P", ui-monospace, monospace;
+  --text-xs: 10px;
+  --text-sm: 12px;
+  --text-base: 14px;
+  --text-lg: 16px;
+  --text-xl: 20px;
+  --text-2xl: 30px;
+  --text-3xl: 44px;
+  --text-4xl: 64px;
+  --leading-body: 1.6;
+  --leading-tight: 1.08;
+  --tracking-display: 0;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+  --section-y-desktop: 84px;
+  --section-y-tablet: 60px;
+  --section-y-phone: 44px;
+  --radius-sm: 10px;
+  --radius-md: 18px;
+  --radius-lg: 9999px;
+  --radius-pill: 9999px;
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised: 0 0 0 2px #2338ff, 0 22px 60px rgba(0, 0, 0, 0.46);
+  --focus-ring: 0 0 0 4px rgba(255, 204, 0, 0.34);
+  --motion-fast: 90ms;
+  --motion-base: 160ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --container-max: 1080px;
+  --container-gutter-desktop: 32px;
+  --container-gutter-tablet: 24px;
+  --container-gutter-phone: 16px;
+}

--- a/design-systems/revolut/components.html
+++ b/design-systems/revolut/components.html
@@ -1,0 +1,342 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Revolut - reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/revolut: premium consumer-finance surfaces with bright blue action and polished dashboard cards."
+    />
+    <style>
+      :root {
+        --bg: #f7f8fb;
+        --surface: #ffffff;
+        --surface-warm: #eef4ff;
+        --fg: #111827;
+        --fg-2: #334155;
+        --muted: #64748b;
+        --meta: #0666eb;
+        --border: #dbe3ef;
+        --border-soft: #edf2f7;
+        --accent: #0666eb;
+        --accent-on: #ffffff;
+        --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+        --success: #16a34a;
+        --warn: #f59e0b;
+        --danger: #ef4444;
+        --font-display: "Inter", system-ui, sans-serif;
+        --font-body: "Inter", system-ui, sans-serif;
+        --font-mono: "SF Mono", ui-monospace, Menlo, monospace;
+        --text-xs: 12px;
+        --text-sm: 14px;
+        --text-base: 16px;
+        --text-lg: 18px;
+        --text-xl: 24px;
+        --text-2xl: 36px;
+        --text-3xl: 54px;
+        --text-4xl: 76px;
+        --leading-body: 1.5;
+        --leading-tight: 1.02;
+        --tracking-display: -0.03em;
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+        --section-y-desktop: 104px;
+        --section-y-tablet: 72px;
+        --section-y-phone: 52px;
+        --radius-sm: 12px;
+        --radius-md: 20px;
+        --radius-lg: 30px;
+        --radius-pill: 9999px;
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised: 0 24px 64px rgba(17, 24, 39, 0.12);
+        --focus-ring: 0 0 0 4px rgba(6, 102, 235, 0.22);
+        --motion-fast: 150ms;
+        --motion-base: 240ms;
+        --ease-standard: cubic-bezier(0.22, 1, 0.36, 1);
+        --container-max: 1180px;
+        --container-gutter-desktop: 36px;
+        --container-gutter-tablet: 28px;
+        --container-gutter-phone: 18px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        min-height: 100vh;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+      .page {
+        min-height: 100vh;
+        background: radial-gradient(circle at 80% 8%, rgba(6, 102, 235, 0.20), transparent 36%), #f7f8fb;
+      }
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+      h1, h2, h3, p { margin: 0; }
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        line-height: var(--leading-tight);
+        letter-spacing: var(--tracking-display);
+      }
+      h1 { max-width: 820px; font-size: var(--text-4xl); font-weight: 700; }
+      h2 { font-size: var(--text-3xl); font-weight: 650; }
+      h3 { font-size: var(--text-xl); font-weight: 650; }
+      .eyebrow {
+        color: var(--meta);
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+      .lead {
+        max-width: 620px;
+        color: var(--fg-2);
+        font-size: var(--text-lg);
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+        gap: var(--space-8);
+        align-items: center;
+      }
+      .stack > * + * { margin-block-start: var(--space-4); }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3);
+        margin-block-start: var(--space-6);
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 44px;
+        padding: 0 var(--space-5);
+        border: 1px solid transparent;
+        border-radius: var(--radius-md);
+        font: 700 var(--text-sm) / 1 var(--font-body);
+        text-decoration: none;
+        cursor: pointer;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          border-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard),
+          transform var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn-primary { background: var(--accent); color: var(--accent-on); }
+      .btn-primary:hover { background: var(--accent-hover); transform: translateY(-1px); }
+      .btn-secondary { background: var(--surface); color: var(--fg); border-color: var(--border); box-shadow: var(--elev-ring); }
+      .btn-secondary:hover { border-color: var(--accent); color: var(--accent); }
+      .panel {
+        background: color-mix(in oklab, var(--surface), transparent 4%);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--elev-raised);
+        overflow: hidden;
+      }
+      .panel-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+        padding: var(--space-5);
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .status {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        color: var(--meta);
+        font: 700 var(--text-xs) / 1 var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .status::before {
+        width: 8px;
+        height: 8px;
+        border-radius: var(--radius-pill);
+        background: var(--success);
+        content: "";
+      }
+      .metric-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .metric {
+        padding: var(--space-5);
+        border-right: 1px solid var(--border-soft);
+      }
+      .metric:last-child { border-right: 0; }
+      .metric strong {
+        display: block;
+        font-family: var(--font-display);
+        font-size: var(--text-2xl);
+        line-height: var(--leading-tight);
+      }
+      .metric span { color: var(--muted); font-size: var(--text-sm); }
+      .card-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-4);
+        padding: var(--space-5);
+      }
+      .mini-card {
+        min-height: 148px;
+        padding: var(--space-5);
+        border: 1px solid var(--border-soft);
+        border-radius: var(--radius-md);
+        background: var(--surface-warm);
+      }
+      .mini-card p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      .swatches {
+        display: flex;
+        gap: var(--space-2);
+        margin-block-start: var(--space-4);
+      }
+      .swatch {
+        width: 32px;
+        height: 32px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+      }
+      .swatch.accent { background: var(--accent); }
+      .swatch.surface { background: var(--surface); }
+      .swatch.warm { background: var(--surface-warm); }
+      .swatch.fg { background: var(--fg); }
+      .field {
+        display: grid;
+        gap: var(--space-2);
+        margin-block-start: var(--space-5);
+      }
+      label { color: var(--fg-2); font-size: var(--text-sm); font-weight: 700; }
+      input {
+        width: 100%;
+        min-height: 46px;
+        padding: 0 var(--space-4);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--surface);
+        color: var(--fg);
+        font: inherit;
+      }
+      input:focus { outline: none; box-shadow: var(--focus-ring); border-color: var(--accent); }
+      .lower {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: var(--space-4);
+      }
+      .tile {
+        padding: var(--space-5);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface);
+      }
+      .tile p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      @media (max-width: 860px) {
+        .hero, .lower { grid-template-columns: 1fr; }
+        .metric-grid, .card-row { grid-template-columns: 1fr; }
+        .metric { border-right: 0; border-bottom: 1px solid var(--border-soft); }
+        .metric:last-child { border-bottom: 0; }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <section>
+        <div class="container hero">
+          <div class="stack">
+            <p class="eyebrow">Revolut design system</p>
+            <h1>Money command center</h1>
+            <p class="lead">Modern finance cards, clean white space, and electric blue movement.</p>
+            <div class="actions" aria-label="Reference actions">
+              <a class="btn btn-primary" href="#">Primary finance pill CTA</a>
+              <a class="btn btn-secondary" href="#">Secondary action</a>
+            </div>
+          </div>
+          <article class="panel" aria-label="Revolut component preview">
+            <div class="panel-head">
+              <div>
+                <p class="eyebrow">Live module</p>
+                <h3>money account card</h3>
+              </div>
+              <span class="status">online</span>
+            </div>
+            <div class="metric-grid">
+              <div class="metric"><strong>98%</strong><span>Signal quality</span></div>
+              <div class="metric"><strong>24</strong><span>Active flows</span></div>
+              <div class="metric"><strong>3.2s</strong><span>Response time</span></div>
+            </div>
+            <div class="card-row">
+              <div class="mini-card">
+                <h3>Palette</h3>
+                <p>premium consumer-finance surfaces with bright blue action and polished dashboard cards.</p>
+                <div class="swatches" aria-label="Token swatches">
+                  <span class="swatch accent"></span>
+                  <span class="swatch surface"></span>
+                  <span class="swatch warm"></span>
+                  <span class="swatch fg"></span>
+                </div>
+              </div>
+              <div class="mini-card">
+                <h3>Control</h3>
+                <p>Focus, hover, and status states share the same brand signal.</p>
+                <div class="field">
+                  <label for="revolut-input">Reference input</label>
+                  <input id="revolut-input" value="Revolut system token" />
+                </div>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+      <section>
+        <div class="container lower">
+          <article class="tile">
+            <p class="eyebrow">Typography</p>
+            <h2>Display rhythm</h2>
+            <p>Headlines use the brand display stack with the declared scale and leading.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Surface</p>
+            <h2>Layer system</h2>
+            <p>Cards, warm panels, borders, and raised states resolve through shared tokens.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Interaction</p>
+            <h2>Motion states</h2>
+            <p>Buttons, inputs, and panels use brand-specific focus rings and easing.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/revolut/tokens.css
+++ b/design-systems/revolut/tokens.css
@@ -1,0 +1,64 @@
+/* design-systems/revolut/tokens.css
+ *
+ * Structured token bindings for Revolut.
+ * premium consumer-finance surfaces with bright blue action and polished dashboard cards.
+ */
+
+:root {
+  --bg: #f7f8fb;
+  --surface: #ffffff;
+  --surface-warm: #eef4ff;
+  --fg: #111827;
+  --fg-2: #334155;
+  --muted: #64748b;
+  --meta: #0666eb;
+  --border: #dbe3ef;
+  --border-soft: #edf2f7;
+  --accent: #0666eb;
+  --accent-on: #ffffff;
+  --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+  --success: #16a34a;
+  --warn: #f59e0b;
+  --danger: #ef4444;
+  --font-display: "Inter", system-ui, sans-serif;
+  --font-body: "Inter", system-ui, sans-serif;
+  --font-mono: "SF Mono", ui-monospace, Menlo, monospace;
+  --text-xs: 12px;
+  --text-sm: 14px;
+  --text-base: 16px;
+  --text-lg: 18px;
+  --text-xl: 24px;
+  --text-2xl: 36px;
+  --text-3xl: 54px;
+  --text-4xl: 76px;
+  --leading-body: 1.5;
+  --leading-tight: 1.02;
+  --tracking-display: -0.03em;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+  --section-y-desktop: 104px;
+  --section-y-tablet: 72px;
+  --section-y-phone: 52px;
+  --radius-sm: 12px;
+  --radius-md: 20px;
+  --radius-lg: 30px;
+  --radius-pill: 9999px;
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised: 0 24px 64px rgba(17, 24, 39, 0.12);
+  --focus-ring: 0 0 0 4px rgba(6, 102, 235, 0.22);
+  --motion-fast: 150ms;
+  --motion-base: 240ms;
+  --ease-standard: cubic-bezier(0.22, 1, 0.36, 1);
+  --container-max: 1180px;
+  --container-gutter-desktop: 36px;
+  --container-gutter-tablet: 28px;
+  --container-gutter-phone: 18px;
+}

--- a/design-systems/sanity/components.html
+++ b/design-systems/sanity/components.html
@@ -1,0 +1,342 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Sanity - reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/sanity: clean content studio with near-white surfaces, red intent, and schema-first hierarchy."
+    />
+    <style>
+      :root {
+        --bg: #f8f8f7;
+        --surface: #ffffff;
+        --surface-warm: #fff1ef;
+        --fg: #171717;
+        --fg-2: #3f3f46;
+        --muted: #71717a;
+        --meta: #f03e2f;
+        --border: #e4e4e7;
+        --border-soft: #f1f1f2;
+        --accent: #f03e2f;
+        --accent-on: #ffffff;
+        --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+        --success: #16a34a;
+        --warn: #f59e0b;
+        --danger: #dc2626;
+        --font-display: "Inter", system-ui, sans-serif;
+        --font-body: "Inter", system-ui, sans-serif;
+        --font-mono: "Roboto Mono", ui-monospace, Menlo, monospace;
+        --text-xs: 12px;
+        --text-sm: 14px;
+        --text-base: 16px;
+        --text-lg: 18px;
+        --text-xl: 22px;
+        --text-2xl: 32px;
+        --text-3xl: 46px;
+        --text-4xl: 64px;
+        --leading-body: 1.55;
+        --leading-tight: 1.08;
+        --tracking-display: -0.02em;
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+        --section-y-desktop: 96px;
+        --section-y-tablet: 68px;
+        --section-y-phone: 48px;
+        --radius-sm: 6px;
+        --radius-md: 10px;
+        --radius-lg: 16px;
+        --radius-pill: 9999px;
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised: 0 18px 42px rgba(23, 23, 23, 0.10);
+        --focus-ring: 0 0 0 4px rgba(240, 62, 47, 0.24);
+        --motion-fast: 140ms;
+        --motion-base: 210ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+        --container-max: 1180px;
+        --container-gutter-desktop: 32px;
+        --container-gutter-tablet: 24px;
+        --container-gutter-phone: 16px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        min-height: 100vh;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+      .page {
+        min-height: 100vh;
+        background: linear-gradient(135deg, #ffffff 0%, #fff1ef 100%);
+      }
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+      h1, h2, h3, p { margin: 0; }
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        line-height: var(--leading-tight);
+        letter-spacing: var(--tracking-display);
+      }
+      h1 { max-width: 820px; font-size: var(--text-4xl); font-weight: 700; }
+      h2 { font-size: var(--text-3xl); font-weight: 650; }
+      h3 { font-size: var(--text-xl); font-weight: 650; }
+      .eyebrow {
+        color: var(--meta);
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+      .lead {
+        max-width: 620px;
+        color: var(--fg-2);
+        font-size: var(--text-lg);
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+        gap: var(--space-8);
+        align-items: center;
+      }
+      .stack > * + * { margin-block-start: var(--space-4); }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3);
+        margin-block-start: var(--space-6);
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 44px;
+        padding: 0 var(--space-5);
+        border: 1px solid transparent;
+        border-radius: var(--radius-md);
+        font: 700 var(--text-sm) / 1 var(--font-body);
+        text-decoration: none;
+        cursor: pointer;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          border-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard),
+          transform var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn-primary { background: var(--accent); color: var(--accent-on); }
+      .btn-primary:hover { background: var(--accent-hover); transform: translateY(-1px); }
+      .btn-secondary { background: var(--surface); color: var(--fg); border-color: var(--border); box-shadow: var(--elev-ring); }
+      .btn-secondary:hover { border-color: var(--accent); color: var(--accent); }
+      .panel {
+        background: color-mix(in oklab, var(--surface), transparent 4%);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--elev-raised);
+        overflow: hidden;
+      }
+      .panel-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+        padding: var(--space-5);
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .status {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        color: var(--meta);
+        font: 700 var(--text-xs) / 1 var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .status::before {
+        width: 8px;
+        height: 8px;
+        border-radius: var(--radius-pill);
+        background: var(--success);
+        content: "";
+      }
+      .metric-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .metric {
+        padding: var(--space-5);
+        border-right: 1px solid var(--border-soft);
+      }
+      .metric:last-child { border-right: 0; }
+      .metric strong {
+        display: block;
+        font-family: var(--font-display);
+        font-size: var(--text-2xl);
+        line-height: var(--leading-tight);
+      }
+      .metric span { color: var(--muted); font-size: var(--text-sm); }
+      .card-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-4);
+        padding: var(--space-5);
+      }
+      .mini-card {
+        min-height: 148px;
+        padding: var(--space-5);
+        border: 1px solid var(--border-soft);
+        border-radius: var(--radius-md);
+        background: var(--surface-warm);
+      }
+      .mini-card p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      .swatches {
+        display: flex;
+        gap: var(--space-2);
+        margin-block-start: var(--space-4);
+      }
+      .swatch {
+        width: 32px;
+        height: 32px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+      }
+      .swatch.accent { background: var(--accent); }
+      .swatch.surface { background: var(--surface); }
+      .swatch.warm { background: var(--surface-warm); }
+      .swatch.fg { background: var(--fg); }
+      .field {
+        display: grid;
+        gap: var(--space-2);
+        margin-block-start: var(--space-5);
+      }
+      label { color: var(--fg-2); font-size: var(--text-sm); font-weight: 700; }
+      input {
+        width: 100%;
+        min-height: 46px;
+        padding: 0 var(--space-4);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--surface);
+        color: var(--fg);
+        font: inherit;
+      }
+      input:focus { outline: none; box-shadow: var(--focus-ring); border-color: var(--accent); }
+      .lower {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: var(--space-4);
+      }
+      .tile {
+        padding: var(--space-5);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface);
+      }
+      .tile p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      @media (max-width: 860px) {
+        .hero, .lower { grid-template-columns: 1fr; }
+        .metric-grid, .card-row { grid-template-columns: 1fr; }
+        .metric { border-right: 0; border-bottom: 1px solid var(--border-soft); }
+        .metric:last-child { border-bottom: 0; }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <section>
+        <div class="container hero">
+          <div class="stack">
+            <p class="eyebrow">Sanity design system</p>
+            <h1>Structured content studio</h1>
+            <p class="lead">Content models, red editorial actions, and studio-grade surfaces.</p>
+            <div class="actions" aria-label="Reference actions">
+              <a class="btn btn-primary" href="#">Primary studio action</a>
+              <a class="btn btn-secondary" href="#">Secondary action</a>
+            </div>
+          </div>
+          <article class="panel" aria-label="Sanity component preview">
+            <div class="panel-head">
+              <div>
+                <p class="eyebrow">Live module</p>
+                <h3>schema document panel</h3>
+              </div>
+              <span class="status">online</span>
+            </div>
+            <div class="metric-grid">
+              <div class="metric"><strong>98%</strong><span>Signal quality</span></div>
+              <div class="metric"><strong>24</strong><span>Active flows</span></div>
+              <div class="metric"><strong>3.2s</strong><span>Response time</span></div>
+            </div>
+            <div class="card-row">
+              <div class="mini-card">
+                <h3>Palette</h3>
+                <p>clean content studio with near-white surfaces, red intent, and schema-first hierarchy.</p>
+                <div class="swatches" aria-label="Token swatches">
+                  <span class="swatch accent"></span>
+                  <span class="swatch surface"></span>
+                  <span class="swatch warm"></span>
+                  <span class="swatch fg"></span>
+                </div>
+              </div>
+              <div class="mini-card">
+                <h3>Control</h3>
+                <p>Focus, hover, and status states share the same brand signal.</p>
+                <div class="field">
+                  <label for="sanity-input">Reference input</label>
+                  <input id="sanity-input" value="Sanity system token" />
+                </div>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+      <section>
+        <div class="container lower">
+          <article class="tile">
+            <p class="eyebrow">Typography</p>
+            <h2>Display rhythm</h2>
+            <p>Headlines use the brand display stack with the declared scale and leading.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Surface</p>
+            <h2>Layer system</h2>
+            <p>Cards, warm panels, borders, and raised states resolve through shared tokens.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Interaction</p>
+            <h2>Motion states</h2>
+            <p>Buttons, inputs, and panels use brand-specific focus rings and easing.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/sanity/tokens.css
+++ b/design-systems/sanity/tokens.css
@@ -1,0 +1,64 @@
+/* design-systems/sanity/tokens.css
+ *
+ * Structured token bindings for Sanity.
+ * clean content studio with near-white surfaces, red intent, and schema-first hierarchy.
+ */
+
+:root {
+  --bg: #f8f8f7;
+  --surface: #ffffff;
+  --surface-warm: #fff1ef;
+  --fg: #171717;
+  --fg-2: #3f3f46;
+  --muted: #71717a;
+  --meta: #f03e2f;
+  --border: #e4e4e7;
+  --border-soft: #f1f1f2;
+  --accent: #f03e2f;
+  --accent-on: #ffffff;
+  --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+  --success: #16a34a;
+  --warn: #f59e0b;
+  --danger: #dc2626;
+  --font-display: "Inter", system-ui, sans-serif;
+  --font-body: "Inter", system-ui, sans-serif;
+  --font-mono: "Roboto Mono", ui-monospace, Menlo, monospace;
+  --text-xs: 12px;
+  --text-sm: 14px;
+  --text-base: 16px;
+  --text-lg: 18px;
+  --text-xl: 22px;
+  --text-2xl: 32px;
+  --text-3xl: 46px;
+  --text-4xl: 64px;
+  --leading-body: 1.55;
+  --leading-tight: 1.08;
+  --tracking-display: -0.02em;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+  --section-y-desktop: 96px;
+  --section-y-tablet: 68px;
+  --section-y-phone: 48px;
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 16px;
+  --radius-pill: 9999px;
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised: 0 18px 42px rgba(23, 23, 23, 0.10);
+  --focus-ring: 0 0 0 4px rgba(240, 62, 47, 0.24);
+  --motion-fast: 140ms;
+  --motion-base: 210ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --container-max: 1180px;
+  --container-gutter-desktop: 32px;
+  --container-gutter-tablet: 24px;
+  --container-gutter-phone: 16px;
+}

--- a/design-systems/tetris/components.html
+++ b/design-systems/tetris/components.html
@@ -1,0 +1,342 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Tetris - reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/tetris: arcade grid system with black board surfaces and bright geometric block colors."
+    />
+    <style>
+      :root {
+        --bg: #050816;
+        --surface: #10162a;
+        --surface-warm: #17203a;
+        --fg: #f8fafc;
+        --fg-2: #cbd5e1;
+        --muted: #94a3b8;
+        --meta: #00f0f0;
+        --border: #26324f;
+        --border-soft: #1c2740;
+        --accent: #00f0f0;
+        --accent-on: #061018;
+        --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+        --success: #00f000;
+        --warn: #f0f000;
+        --danger: #f00000;
+        --font-display: "Press Start 2P", "Arial Black", system-ui, sans-serif;
+        --font-body: "Inter", system-ui, sans-serif;
+        --font-mono: "Press Start 2P", ui-monospace, monospace;
+        --text-xs: 10px;
+        --text-sm: 12px;
+        --text-base: 14px;
+        --text-lg: 16px;
+        --text-xl: 20px;
+        --text-2xl: 28px;
+        --text-3xl: 40px;
+        --text-4xl: 56px;
+        --leading-body: 1.6;
+        --leading-tight: 1.1;
+        --tracking-display: 0;
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+        --section-y-desktop: 80px;
+        --section-y-tablet: 60px;
+        --section-y-phone: 44px;
+        --radius-sm: 0px;
+        --radius-md: 0px;
+        --radius-lg: 4px;
+        --radius-pill: 9999px;
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised: 0 18px 0 rgba(0, 0, 0, 0.32);
+        --focus-ring: 0 0 0 4px rgba(0, 240, 240, 0.32);
+        --motion-fast: 80ms;
+        --motion-base: 140ms;
+        --ease-standard: steps(2, end);
+        --container-max: 1100px;
+        --container-gutter-desktop: 32px;
+        --container-gutter-tablet: 24px;
+        --container-gutter-phone: 16px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        min-height: 100vh;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+      .page {
+        min-height: 100vh;
+        background: linear-gradient(135deg, #050816 0%, #10162a 100%);
+      }
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+      h1, h2, h3, p { margin: 0; }
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        line-height: var(--leading-tight);
+        letter-spacing: var(--tracking-display);
+      }
+      h1 { max-width: 820px; font-size: var(--text-4xl); font-weight: 700; }
+      h2 { font-size: var(--text-3xl); font-weight: 650; }
+      h3 { font-size: var(--text-xl); font-weight: 650; }
+      .eyebrow {
+        color: var(--meta);
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+      .lead {
+        max-width: 620px;
+        color: var(--fg-2);
+        font-size: var(--text-lg);
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+        gap: var(--space-8);
+        align-items: center;
+      }
+      .stack > * + * { margin-block-start: var(--space-4); }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3);
+        margin-block-start: var(--space-6);
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 44px;
+        padding: 0 var(--space-5);
+        border: 1px solid transparent;
+        border-radius: var(--radius-md);
+        font: 700 var(--text-sm) / 1 var(--font-body);
+        text-decoration: none;
+        cursor: pointer;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          border-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard),
+          transform var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn-primary { background: var(--accent); color: var(--accent-on); }
+      .btn-primary:hover { background: var(--accent-hover); transform: translateY(-1px); }
+      .btn-secondary { background: var(--surface); color: var(--fg); border-color: var(--border); box-shadow: var(--elev-ring); }
+      .btn-secondary:hover { border-color: var(--accent); color: var(--accent); }
+      .panel {
+        background: color-mix(in oklab, var(--surface), transparent 4%);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--elev-raised);
+        overflow: hidden;
+      }
+      .panel-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+        padding: var(--space-5);
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .status {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        color: var(--meta);
+        font: 700 var(--text-xs) / 1 var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .status::before {
+        width: 8px;
+        height: 8px;
+        border-radius: var(--radius-pill);
+        background: var(--success);
+        content: "";
+      }
+      .metric-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .metric {
+        padding: var(--space-5);
+        border-right: 1px solid var(--border-soft);
+      }
+      .metric:last-child { border-right: 0; }
+      .metric strong {
+        display: block;
+        font-family: var(--font-display);
+        font-size: var(--text-2xl);
+        line-height: var(--leading-tight);
+      }
+      .metric span { color: var(--muted); font-size: var(--text-sm); }
+      .card-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-4);
+        padding: var(--space-5);
+      }
+      .mini-card {
+        min-height: 148px;
+        padding: var(--space-5);
+        border: 1px solid var(--border-soft);
+        border-radius: var(--radius-md);
+        background: var(--surface-warm);
+      }
+      .mini-card p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      .swatches {
+        display: flex;
+        gap: var(--space-2);
+        margin-block-start: var(--space-4);
+      }
+      .swatch {
+        width: 32px;
+        height: 32px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+      }
+      .swatch.accent { background: var(--accent); }
+      .swatch.surface { background: var(--surface); }
+      .swatch.warm { background: var(--surface-warm); }
+      .swatch.fg { background: var(--fg); }
+      .field {
+        display: grid;
+        gap: var(--space-2);
+        margin-block-start: var(--space-5);
+      }
+      label { color: var(--fg-2); font-size: var(--text-sm); font-weight: 700; }
+      input {
+        width: 100%;
+        min-height: 46px;
+        padding: 0 var(--space-4);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--surface);
+        color: var(--fg);
+        font: inherit;
+      }
+      input:focus { outline: none; box-shadow: var(--focus-ring); border-color: var(--accent); }
+      .lower {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: var(--space-4);
+      }
+      .tile {
+        padding: var(--space-5);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface);
+      }
+      .tile p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      @media (max-width: 860px) {
+        .hero, .lower { grid-template-columns: 1fr; }
+        .metric-grid, .card-row { grid-template-columns: 1fr; }
+        .metric { border-right: 0; border-bottom: 1px solid var(--border-soft); }
+        .metric:last-child { border-bottom: 0; }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <section>
+        <div class="container hero">
+          <div class="stack">
+            <p class="eyebrow">Tetris design system</p>
+            <h1>Falling-block arcade</h1>
+            <p class="lead">Grid rhythm, bright tetromino colors, and crisp game-state modules.</p>
+            <div class="actions" aria-label="Reference actions">
+              <a class="btn btn-primary" href="#">Primary arcade block button</a>
+              <a class="btn btn-secondary" href="#">Secondary action</a>
+            </div>
+          </div>
+          <article class="panel" aria-label="Tetris component preview">
+            <div class="panel-head">
+              <div>
+                <p class="eyebrow">Live module</p>
+                <h3>scoreboard grid panel</h3>
+              </div>
+              <span class="status">online</span>
+            </div>
+            <div class="metric-grid">
+              <div class="metric"><strong>98%</strong><span>Signal quality</span></div>
+              <div class="metric"><strong>24</strong><span>Active flows</span></div>
+              <div class="metric"><strong>3.2s</strong><span>Response time</span></div>
+            </div>
+            <div class="card-row">
+              <div class="mini-card">
+                <h3>Palette</h3>
+                <p>arcade grid system with black board surfaces and bright geometric block colors.</p>
+                <div class="swatches" aria-label="Token swatches">
+                  <span class="swatch accent"></span>
+                  <span class="swatch surface"></span>
+                  <span class="swatch warm"></span>
+                  <span class="swatch fg"></span>
+                </div>
+              </div>
+              <div class="mini-card">
+                <h3>Control</h3>
+                <p>Focus, hover, and status states share the same brand signal.</p>
+                <div class="field">
+                  <label for="tetris-input">Reference input</label>
+                  <input id="tetris-input" value="Tetris system token" />
+                </div>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+      <section>
+        <div class="container lower">
+          <article class="tile">
+            <p class="eyebrow">Typography</p>
+            <h2>Display rhythm</h2>
+            <p>Headlines use the brand display stack with the declared scale and leading.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Surface</p>
+            <h2>Layer system</h2>
+            <p>Cards, warm panels, borders, and raised states resolve through shared tokens.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Interaction</p>
+            <h2>Motion states</h2>
+            <p>Buttons, inputs, and panels use brand-specific focus rings and easing.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/tetris/tokens.css
+++ b/design-systems/tetris/tokens.css
@@ -1,0 +1,64 @@
+/* design-systems/tetris/tokens.css
+ *
+ * Structured token bindings for Tetris.
+ * arcade grid system with black board surfaces and bright geometric block colors.
+ */
+
+:root {
+  --bg: #050816;
+  --surface: #10162a;
+  --surface-warm: #17203a;
+  --fg: #f8fafc;
+  --fg-2: #cbd5e1;
+  --muted: #94a3b8;
+  --meta: #00f0f0;
+  --border: #26324f;
+  --border-soft: #1c2740;
+  --accent: #00f0f0;
+  --accent-on: #061018;
+  --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+  --success: #00f000;
+  --warn: #f0f000;
+  --danger: #f00000;
+  --font-display: "Press Start 2P", "Arial Black", system-ui, sans-serif;
+  --font-body: "Inter", system-ui, sans-serif;
+  --font-mono: "Press Start 2P", ui-monospace, monospace;
+  --text-xs: 10px;
+  --text-sm: 12px;
+  --text-base: 14px;
+  --text-lg: 16px;
+  --text-xl: 20px;
+  --text-2xl: 28px;
+  --text-3xl: 40px;
+  --text-4xl: 56px;
+  --leading-body: 1.6;
+  --leading-tight: 1.1;
+  --tracking-display: 0;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+  --section-y-desktop: 80px;
+  --section-y-tablet: 60px;
+  --section-y-phone: 44px;
+  --radius-sm: 0px;
+  --radius-md: 0px;
+  --radius-lg: 4px;
+  --radius-pill: 9999px;
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised: 0 18px 0 rgba(0, 0, 0, 0.32);
+  --focus-ring: 0 0 0 4px rgba(0, 240, 240, 0.32);
+  --motion-fast: 80ms;
+  --motion-base: 140ms;
+  --ease-standard: steps(2, end);
+  --container-max: 1100px;
+  --container-gutter-desktop: 32px;
+  --container-gutter-tablet: 24px;
+  --container-gutter-phone: 16px;
+}

--- a/design-systems/theverge/components.html
+++ b/design-systems/theverge/components.html
@@ -1,0 +1,342 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>The Verge - reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/theverge: high-energy technology magazine with black surfaces, magenta signal, and dense editorial cards."
+    />
+    <style>
+      :root {
+        --bg: #050505;
+        --surface: #111111;
+        --surface-warm: #211022;
+        --fg: #ffffff;
+        --fg-2: #e5e7eb;
+        --muted: #9ca3af;
+        --meta: #ff00a8;
+        --border: #2b2b2b;
+        --border-soft: #1d1d1d;
+        --accent: #ff00a8;
+        --accent-on: #ffffff;
+        --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+        --success: #22c55e;
+        --warn: #facc15;
+        --danger: #ef4444;
+        --font-display: "PolySans", "Helvetica Neue", Arial, sans-serif;
+        --font-body: "Inter", "Helvetica Neue", Arial, sans-serif;
+        --font-mono: "IBM Plex Mono", ui-monospace, Menlo, monospace;
+        --text-xs: 12px;
+        --text-sm: 14px;
+        --text-base: 16px;
+        --text-lg: 19px;
+        --text-xl: 26px;
+        --text-2xl: 42px;
+        --text-3xl: 66px;
+        --text-4xl: 96px;
+        --leading-body: 1.48;
+        --leading-tight: 0.95;
+        --tracking-display: -0.035em;
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+        --section-y-desktop: 88px;
+        --section-y-tablet: 64px;
+        --section-y-phone: 44px;
+        --radius-sm: 4px;
+        --radius-md: 8px;
+        --radius-lg: 12px;
+        --radius-pill: 9999px;
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised: 0 24px 70px rgba(255, 0, 168, 0.12);
+        --focus-ring: 0 0 0 4px rgba(255, 0, 168, 0.30);
+        --motion-fast: 120ms;
+        --motion-base: 200ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+        --container-max: 1240px;
+        --container-gutter-desktop: 36px;
+        --container-gutter-tablet: 28px;
+        --container-gutter-phone: 18px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        min-height: 100vh;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+      .page {
+        min-height: 100vh;
+        background: linear-gradient(135deg, #050505 0%, #211022 62%, #ff00a8 100%);
+      }
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+      h1, h2, h3, p { margin: 0; }
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        line-height: var(--leading-tight);
+        letter-spacing: var(--tracking-display);
+      }
+      h1 { max-width: 820px; font-size: var(--text-4xl); font-weight: 700; }
+      h2 { font-size: var(--text-3xl); font-weight: 650; }
+      h3 { font-size: var(--text-xl); font-weight: 650; }
+      .eyebrow {
+        color: var(--meta);
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+      .lead {
+        max-width: 620px;
+        color: var(--fg-2);
+        font-size: var(--text-lg);
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+        gap: var(--space-8);
+        align-items: center;
+      }
+      .stack > * + * { margin-block-start: var(--space-4); }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3);
+        margin-block-start: var(--space-6);
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 44px;
+        padding: 0 var(--space-5);
+        border: 1px solid transparent;
+        border-radius: var(--radius-md);
+        font: 700 var(--text-sm) / 1 var(--font-body);
+        text-decoration: none;
+        cursor: pointer;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          border-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard),
+          transform var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn-primary { background: var(--accent); color: var(--accent-on); }
+      .btn-primary:hover { background: var(--accent-hover); transform: translateY(-1px); }
+      .btn-secondary { background: var(--surface); color: var(--fg); border-color: var(--border); box-shadow: var(--elev-ring); }
+      .btn-secondary:hover { border-color: var(--accent); color: var(--accent); }
+      .panel {
+        background: color-mix(in oklab, var(--surface), transparent 4%);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--elev-raised);
+        overflow: hidden;
+      }
+      .panel-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+        padding: var(--space-5);
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .status {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        color: var(--meta);
+        font: 700 var(--text-xs) / 1 var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .status::before {
+        width: 8px;
+        height: 8px;
+        border-radius: var(--radius-pill);
+        background: var(--success);
+        content: "";
+      }
+      .metric-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .metric {
+        padding: var(--space-5);
+        border-right: 1px solid var(--border-soft);
+      }
+      .metric:last-child { border-right: 0; }
+      .metric strong {
+        display: block;
+        font-family: var(--font-display);
+        font-size: var(--text-2xl);
+        line-height: var(--leading-tight);
+      }
+      .metric span { color: var(--muted); font-size: var(--text-sm); }
+      .card-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-4);
+        padding: var(--space-5);
+      }
+      .mini-card {
+        min-height: 148px;
+        padding: var(--space-5);
+        border: 1px solid var(--border-soft);
+        border-radius: var(--radius-md);
+        background: var(--surface-warm);
+      }
+      .mini-card p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      .swatches {
+        display: flex;
+        gap: var(--space-2);
+        margin-block-start: var(--space-4);
+      }
+      .swatch {
+        width: 32px;
+        height: 32px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+      }
+      .swatch.accent { background: var(--accent); }
+      .swatch.surface { background: var(--surface); }
+      .swatch.warm { background: var(--surface-warm); }
+      .swatch.fg { background: var(--fg); }
+      .field {
+        display: grid;
+        gap: var(--space-2);
+        margin-block-start: var(--space-5);
+      }
+      label { color: var(--fg-2); font-size: var(--text-sm); font-weight: 700; }
+      input {
+        width: 100%;
+        min-height: 46px;
+        padding: 0 var(--space-4);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--surface);
+        color: var(--fg);
+        font: inherit;
+      }
+      input:focus { outline: none; box-shadow: var(--focus-ring); border-color: var(--accent); }
+      .lower {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: var(--space-4);
+      }
+      .tile {
+        padding: var(--space-5);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface);
+      }
+      .tile p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      @media (max-width: 860px) {
+        .hero, .lower { grid-template-columns: 1fr; }
+        .metric-grid, .card-row { grid-template-columns: 1fr; }
+        .metric { border-right: 0; border-bottom: 1px solid var(--border-soft); }
+        .metric:last-child { border-bottom: 0; }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <section>
+        <div class="container hero">
+          <div class="stack">
+            <p class="eyebrow">The Verge design system</p>
+            <h1>Tech culture front page</h1>
+            <p class="lead">Editorial density, neon-magenta signal, and magazine section rhythm.</p>
+            <div class="actions" aria-label="Reference actions">
+              <a class="btn btn-primary" href="#">Primary neon editorial CTA</a>
+              <a class="btn btn-secondary" href="#">Secondary action</a>
+            </div>
+          </div>
+          <article class="panel" aria-label="The Verge component preview">
+            <div class="panel-head">
+              <div>
+                <p class="eyebrow">Live module</p>
+                <h3>story rail card</h3>
+              </div>
+              <span class="status">online</span>
+            </div>
+            <div class="metric-grid">
+              <div class="metric"><strong>98%</strong><span>Signal quality</span></div>
+              <div class="metric"><strong>24</strong><span>Active flows</span></div>
+              <div class="metric"><strong>3.2s</strong><span>Response time</span></div>
+            </div>
+            <div class="card-row">
+              <div class="mini-card">
+                <h3>Palette</h3>
+                <p>high-energy technology magazine with black surfaces, magenta signal, and dense editorial cards.</p>
+                <div class="swatches" aria-label="Token swatches">
+                  <span class="swatch accent"></span>
+                  <span class="swatch surface"></span>
+                  <span class="swatch warm"></span>
+                  <span class="swatch fg"></span>
+                </div>
+              </div>
+              <div class="mini-card">
+                <h3>Control</h3>
+                <p>Focus, hover, and status states share the same brand signal.</p>
+                <div class="field">
+                  <label for="theverge-input">Reference input</label>
+                  <input id="theverge-input" value="The Verge system token" />
+                </div>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+      <section>
+        <div class="container lower">
+          <article class="tile">
+            <p class="eyebrow">Typography</p>
+            <h2>Display rhythm</h2>
+            <p>Headlines use the brand display stack with the declared scale and leading.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Surface</p>
+            <h2>Layer system</h2>
+            <p>Cards, warm panels, borders, and raised states resolve through shared tokens.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Interaction</p>
+            <h2>Motion states</h2>
+            <p>Buttons, inputs, and panels use brand-specific focus rings and easing.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/theverge/tokens.css
+++ b/design-systems/theverge/tokens.css
@@ -1,0 +1,64 @@
+/* design-systems/theverge/tokens.css
+ *
+ * Structured token bindings for The Verge.
+ * high-energy technology magazine with black surfaces, magenta signal, and dense editorial cards.
+ */
+
+:root {
+  --bg: #050505;
+  --surface: #111111;
+  --surface-warm: #211022;
+  --fg: #ffffff;
+  --fg-2: #e5e7eb;
+  --muted: #9ca3af;
+  --meta: #ff00a8;
+  --border: #2b2b2b;
+  --border-soft: #1d1d1d;
+  --accent: #ff00a8;
+  --accent-on: #ffffff;
+  --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+  --success: #22c55e;
+  --warn: #facc15;
+  --danger: #ef4444;
+  --font-display: "PolySans", "Helvetica Neue", Arial, sans-serif;
+  --font-body: "Inter", "Helvetica Neue", Arial, sans-serif;
+  --font-mono: "IBM Plex Mono", ui-monospace, Menlo, monospace;
+  --text-xs: 12px;
+  --text-sm: 14px;
+  --text-base: 16px;
+  --text-lg: 19px;
+  --text-xl: 26px;
+  --text-2xl: 42px;
+  --text-3xl: 66px;
+  --text-4xl: 96px;
+  --leading-body: 1.48;
+  --leading-tight: 0.95;
+  --tracking-display: -0.035em;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+  --section-y-desktop: 88px;
+  --section-y-tablet: 64px;
+  --section-y-phone: 44px;
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-pill: 9999px;
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised: 0 24px 70px rgba(255, 0, 168, 0.12);
+  --focus-ring: 0 0 0 4px rgba(255, 0, 168, 0.30);
+  --motion-fast: 120ms;
+  --motion-base: 200ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --container-max: 1240px;
+  --container-gutter-desktop: 36px;
+  --container-gutter-tablet: 28px;
+  --container-gutter-phone: 18px;
+}

--- a/design-systems/vodafone/components.html
+++ b/design-systems/vodafone/components.html
@@ -1,0 +1,342 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Vodafone - reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/vodafone: bright red telecom clarity balanced by white service surfaces and practical controls."
+    />
+    <style>
+      :root {
+        --bg: #ffffff;
+        --surface: #f4f4f4;
+        --surface-warm: #fff1f1;
+        --fg: #1f1f1f;
+        --fg-2: #4a4d4e;
+        --muted: #6f7375;
+        --meta: #a61218;
+        --border: #d8d8d8;
+        --border-soft: #eeeeee;
+        --accent: #e60000;
+        --accent-on: #ffffff;
+        --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+        --success: #008a00;
+        --warn: #f5b400;
+        --danger: #bd0000;
+        --font-display: "Vodafone", "Vodafone Rg", Arial, sans-serif;
+        --font-body: "Vodafone", "Vodafone Rg", Arial, sans-serif;
+        --font-mono: ui-monospace, "SF Mono", Menlo, monospace;
+        --text-xs: 12px;
+        --text-sm: 14px;
+        --text-base: 16px;
+        --text-lg: 19px;
+        --text-xl: 24px;
+        --text-2xl: 36px;
+        --text-3xl: 48px;
+        --text-4xl: 68px;
+        --leading-body: 1.48;
+        --leading-tight: 1.08;
+        --tracking-display: -0.015em;
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+        --section-y-desktop: 96px;
+        --section-y-tablet: 68px;
+        --section-y-phone: 48px;
+        --radius-sm: 8px;
+        --radius-md: 16px;
+        --radius-lg: 24px;
+        --radius-pill: 9999px;
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised: 0 18px 44px rgba(0, 0, 0, 0.12);
+        --focus-ring: 0 0 0 4px rgba(230, 0, 0, 0.22);
+        --motion-fast: 150ms;
+        --motion-base: 220ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+        --container-max: 1200px;
+        --container-gutter-desktop: 36px;
+        --container-gutter-tablet: 24px;
+        --container-gutter-phone: 16px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        min-height: 100vh;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+      .page {
+        min-height: 100vh;
+        background: linear-gradient(135deg, #e60000 0%, #a61218 100%);
+      }
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+      h1, h2, h3, p { margin: 0; }
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        line-height: var(--leading-tight);
+        letter-spacing: var(--tracking-display);
+      }
+      h1 { max-width: 820px; font-size: var(--text-4xl); font-weight: 700; }
+      h2 { font-size: var(--text-3xl); font-weight: 650; }
+      h3 { font-size: var(--text-xl); font-weight: 650; }
+      .eyebrow {
+        color: var(--meta);
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+      .lead {
+        max-width: 620px;
+        color: var(--fg-2);
+        font-size: var(--text-lg);
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+        gap: var(--space-8);
+        align-items: center;
+      }
+      .stack > * + * { margin-block-start: var(--space-4); }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3);
+        margin-block-start: var(--space-6);
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 44px;
+        padding: 0 var(--space-5);
+        border: 1px solid transparent;
+        border-radius: var(--radius-md);
+        font: 700 var(--text-sm) / 1 var(--font-body);
+        text-decoration: none;
+        cursor: pointer;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          border-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard),
+          transform var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn-primary { background: var(--accent); color: var(--accent-on); }
+      .btn-primary:hover { background: var(--accent-hover); transform: translateY(-1px); }
+      .btn-secondary { background: var(--surface); color: var(--fg); border-color: var(--border); box-shadow: var(--elev-ring); }
+      .btn-secondary:hover { border-color: var(--accent); color: var(--accent); }
+      .panel {
+        background: color-mix(in oklab, var(--surface), transparent 4%);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--elev-raised);
+        overflow: hidden;
+      }
+      .panel-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+        padding: var(--space-5);
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .status {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        color: var(--meta);
+        font: 700 var(--text-xs) / 1 var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .status::before {
+        width: 8px;
+        height: 8px;
+        border-radius: var(--radius-pill);
+        background: var(--success);
+        content: "";
+      }
+      .metric-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .metric {
+        padding: var(--space-5);
+        border-right: 1px solid var(--border-soft);
+      }
+      .metric:last-child { border-right: 0; }
+      .metric strong {
+        display: block;
+        font-family: var(--font-display);
+        font-size: var(--text-2xl);
+        line-height: var(--leading-tight);
+      }
+      .metric span { color: var(--muted); font-size: var(--text-sm); }
+      .card-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-4);
+        padding: var(--space-5);
+      }
+      .mini-card {
+        min-height: 148px;
+        padding: var(--space-5);
+        border: 1px solid var(--border-soft);
+        border-radius: var(--radius-md);
+        background: var(--surface-warm);
+      }
+      .mini-card p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      .swatches {
+        display: flex;
+        gap: var(--space-2);
+        margin-block-start: var(--space-4);
+      }
+      .swatch {
+        width: 32px;
+        height: 32px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+      }
+      .swatch.accent { background: var(--accent); }
+      .swatch.surface { background: var(--surface); }
+      .swatch.warm { background: var(--surface-warm); }
+      .swatch.fg { background: var(--fg); }
+      .field {
+        display: grid;
+        gap: var(--space-2);
+        margin-block-start: var(--space-5);
+      }
+      label { color: var(--fg-2); font-size: var(--text-sm); font-weight: 700; }
+      input {
+        width: 100%;
+        min-height: 46px;
+        padding: 0 var(--space-4);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--surface);
+        color: var(--fg);
+        font: inherit;
+      }
+      input:focus { outline: none; box-shadow: var(--focus-ring); border-color: var(--accent); }
+      .lower {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: var(--space-4);
+      }
+      .tile {
+        padding: var(--space-5);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface);
+      }
+      .tile p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      @media (max-width: 860px) {
+        .hero, .lower { grid-template-columns: 1fr; }
+        .metric-grid, .card-row { grid-template-columns: 1fr; }
+        .metric { border-right: 0; border-bottom: 1px solid var(--border-soft); }
+        .metric:last-child { border-bottom: 0; }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <section>
+        <div class="container hero">
+          <div class="stack">
+            <p class="eyebrow">Vodafone design system</p>
+            <h1>Connected service hub</h1>
+            <p class="lead">High-contrast red, direct consumer utility, and rounded service cards.</p>
+            <div class="actions" aria-label="Reference actions">
+              <a class="btn btn-primary" href="#">Primary red service CTA</a>
+              <a class="btn btn-secondary" href="#">Secondary action</a>
+            </div>
+          </div>
+          <article class="panel" aria-label="Vodafone component preview">
+            <div class="panel-head">
+              <div>
+                <p class="eyebrow">Live module</p>
+                <h3>rounded utility card</h3>
+              </div>
+              <span class="status">online</span>
+            </div>
+            <div class="metric-grid">
+              <div class="metric"><strong>98%</strong><span>Signal quality</span></div>
+              <div class="metric"><strong>24</strong><span>Active flows</span></div>
+              <div class="metric"><strong>3.2s</strong><span>Response time</span></div>
+            </div>
+            <div class="card-row">
+              <div class="mini-card">
+                <h3>Palette</h3>
+                <p>bright red telecom clarity balanced by white service surfaces and practical controls.</p>
+                <div class="swatches" aria-label="Token swatches">
+                  <span class="swatch accent"></span>
+                  <span class="swatch surface"></span>
+                  <span class="swatch warm"></span>
+                  <span class="swatch fg"></span>
+                </div>
+              </div>
+              <div class="mini-card">
+                <h3>Control</h3>
+                <p>Focus, hover, and status states share the same brand signal.</p>
+                <div class="field">
+                  <label for="vodafone-input">Reference input</label>
+                  <input id="vodafone-input" value="Vodafone system token" />
+                </div>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+      <section>
+        <div class="container lower">
+          <article class="tile">
+            <p class="eyebrow">Typography</p>
+            <h2>Display rhythm</h2>
+            <p>Headlines use the brand display stack with the declared scale and leading.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Surface</p>
+            <h2>Layer system</h2>
+            <p>Cards, warm panels, borders, and raised states resolve through shared tokens.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Interaction</p>
+            <h2>Motion states</h2>
+            <p>Buttons, inputs, and panels use brand-specific focus rings and easing.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/vodafone/tokens.css
+++ b/design-systems/vodafone/tokens.css
@@ -1,0 +1,64 @@
+/* design-systems/vodafone/tokens.css
+ *
+ * Structured token bindings for Vodafone.
+ * bright red telecom clarity balanced by white service surfaces and practical controls.
+ */
+
+:root {
+  --bg: #ffffff;
+  --surface: #f4f4f4;
+  --surface-warm: #fff1f1;
+  --fg: #1f1f1f;
+  --fg-2: #4a4d4e;
+  --muted: #6f7375;
+  --meta: #a61218;
+  --border: #d8d8d8;
+  --border-soft: #eeeeee;
+  --accent: #e60000;
+  --accent-on: #ffffff;
+  --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+  --success: #008a00;
+  --warn: #f5b400;
+  --danger: #bd0000;
+  --font-display: "Vodafone", "Vodafone Rg", Arial, sans-serif;
+  --font-body: "Vodafone", "Vodafone Rg", Arial, sans-serif;
+  --font-mono: ui-monospace, "SF Mono", Menlo, monospace;
+  --text-xs: 12px;
+  --text-sm: 14px;
+  --text-base: 16px;
+  --text-lg: 19px;
+  --text-xl: 24px;
+  --text-2xl: 36px;
+  --text-3xl: 48px;
+  --text-4xl: 68px;
+  --leading-body: 1.48;
+  --leading-tight: 1.08;
+  --tracking-display: -0.015em;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+  --section-y-desktop: 96px;
+  --section-y-tablet: 68px;
+  --section-y-phone: 48px;
+  --radius-sm: 8px;
+  --radius-md: 16px;
+  --radius-lg: 24px;
+  --radius-pill: 9999px;
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised: 0 18px 44px rgba(0, 0, 0, 0.12);
+  --focus-ring: 0 0 0 4px rgba(230, 0, 0, 0.22);
+  --motion-fast: 150ms;
+  --motion-base: 220ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --container-max: 1200px;
+  --container-gutter-desktop: 36px;
+  --container-gutter-tablet: 24px;
+  --container-gutter-phone: 16px;
+}

--- a/design-systems/webex/components.html
+++ b/design-systems/webex/components.html
@@ -1,0 +1,342 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Webex - reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/webex: cool collaboration surfaces with teal and violet meeting signals."
+    />
+    <style>
+      :root {
+        --bg: #f6f8fb;
+        --surface: #ffffff;
+        --surface-warm: #eef8f6;
+        --fg: #0f172a;
+        --fg-2: #334155;
+        --muted: #64748b;
+        --meta: #12a594;
+        --border: #dbe4ee;
+        --border-soft: #edf2f7;
+        --accent: #00a3a6;
+        --accent-on: #ffffff;
+        --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+        --success: #22c55e;
+        --warn: #f59e0b;
+        --danger: #e11d48;
+        --font-display: "CiscoSansTT", Inter, Arial, sans-serif;
+        --font-body: "CiscoSansTT", Inter, Arial, sans-serif;
+        --font-mono: "SF Mono", ui-monospace, Menlo, monospace;
+        --text-xs: 12px;
+        --text-sm: 14px;
+        --text-base: 16px;
+        --text-lg: 18px;
+        --text-xl: 22px;
+        --text-2xl: 32px;
+        --text-3xl: 44px;
+        --text-4xl: 60px;
+        --leading-body: 1.55;
+        --leading-tight: 1.1;
+        --tracking-display: -0.015em;
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+        --section-y-desktop: 96px;
+        --section-y-tablet: 68px;
+        --section-y-phone: 48px;
+        --radius-sm: 12px;
+        --radius-md: 18px;
+        --radius-lg: 28px;
+        --radius-pill: 9999px;
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised: 0 20px 50px rgba(15, 23, 42, 0.10);
+        --focus-ring: 0 0 0 4px rgba(0, 163, 166, 0.24);
+        --motion-fast: 160ms;
+        --motion-base: 240ms;
+        --ease-standard: cubic-bezier(0.22, 1, 0.36, 1);
+        --container-max: 1180px;
+        --container-gutter-desktop: 36px;
+        --container-gutter-tablet: 28px;
+        --container-gutter-phone: 18px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        min-height: 100vh;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+      .page {
+        min-height: 100vh;
+        background: radial-gradient(circle at 18% 12%, rgba(0, 163, 166, 0.22), transparent 34%), radial-gradient(circle at 82% 4%, rgba(91, 77, 246, 0.20), transparent 35%), #f6f8fb;
+      }
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+      h1, h2, h3, p { margin: 0; }
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        line-height: var(--leading-tight);
+        letter-spacing: var(--tracking-display);
+      }
+      h1 { max-width: 820px; font-size: var(--text-4xl); font-weight: 700; }
+      h2 { font-size: var(--text-3xl); font-weight: 650; }
+      h3 { font-size: var(--text-xl); font-weight: 650; }
+      .eyebrow {
+        color: var(--meta);
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+      .lead {
+        max-width: 620px;
+        color: var(--fg-2);
+        font-size: var(--text-lg);
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+        gap: var(--space-8);
+        align-items: center;
+      }
+      .stack > * + * { margin-block-start: var(--space-4); }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3);
+        margin-block-start: var(--space-6);
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 44px;
+        padding: 0 var(--space-5);
+        border: 1px solid transparent;
+        border-radius: var(--radius-md);
+        font: 700 var(--text-sm) / 1 var(--font-body);
+        text-decoration: none;
+        cursor: pointer;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          border-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard),
+          transform var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn-primary { background: var(--accent); color: var(--accent-on); }
+      .btn-primary:hover { background: var(--accent-hover); transform: translateY(-1px); }
+      .btn-secondary { background: var(--surface); color: var(--fg); border-color: var(--border); box-shadow: var(--elev-ring); }
+      .btn-secondary:hover { border-color: var(--accent); color: var(--accent); }
+      .panel {
+        background: color-mix(in oklab, var(--surface), transparent 4%);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--elev-raised);
+        overflow: hidden;
+      }
+      .panel-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+        padding: var(--space-5);
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .status {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        color: var(--meta);
+        font: 700 var(--text-xs) / 1 var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .status::before {
+        width: 8px;
+        height: 8px;
+        border-radius: var(--radius-pill);
+        background: var(--success);
+        content: "";
+      }
+      .metric-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .metric {
+        padding: var(--space-5);
+        border-right: 1px solid var(--border-soft);
+      }
+      .metric:last-child { border-right: 0; }
+      .metric strong {
+        display: block;
+        font-family: var(--font-display);
+        font-size: var(--text-2xl);
+        line-height: var(--leading-tight);
+      }
+      .metric span { color: var(--muted); font-size: var(--text-sm); }
+      .card-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-4);
+        padding: var(--space-5);
+      }
+      .mini-card {
+        min-height: 148px;
+        padding: var(--space-5);
+        border: 1px solid var(--border-soft);
+        border-radius: var(--radius-md);
+        background: var(--surface-warm);
+      }
+      .mini-card p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      .swatches {
+        display: flex;
+        gap: var(--space-2);
+        margin-block-start: var(--space-4);
+      }
+      .swatch {
+        width: 32px;
+        height: 32px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+      }
+      .swatch.accent { background: var(--accent); }
+      .swatch.surface { background: var(--surface); }
+      .swatch.warm { background: var(--surface-warm); }
+      .swatch.fg { background: var(--fg); }
+      .field {
+        display: grid;
+        gap: var(--space-2);
+        margin-block-start: var(--space-5);
+      }
+      label { color: var(--fg-2); font-size: var(--text-sm); font-weight: 700; }
+      input {
+        width: 100%;
+        min-height: 46px;
+        padding: 0 var(--space-4);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--surface);
+        color: var(--fg);
+        font: inherit;
+      }
+      input:focus { outline: none; box-shadow: var(--focus-ring); border-color: var(--accent); }
+      .lower {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: var(--space-4);
+      }
+      .tile {
+        padding: var(--space-5);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface);
+      }
+      .tile p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      @media (max-width: 860px) {
+        .hero, .lower { grid-template-columns: 1fr; }
+        .metric-grid, .card-row { grid-template-columns: 1fr; }
+        .metric { border-right: 0; border-bottom: 1px solid var(--border-soft); }
+        .metric:last-child { border-bottom: 0; }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <section>
+        <div class="container hero">
+          <div class="stack">
+            <p class="eyebrow">Webex design system</p>
+            <h1>Collaboration room</h1>
+            <p class="lead">Soft collaboration gradients, meeting controls, and calm status color.</p>
+            <div class="actions" aria-label="Reference actions">
+              <a class="btn btn-primary" href="#">Primary meeting pill action</a>
+              <a class="btn btn-secondary" href="#">Secondary action</a>
+            </div>
+          </div>
+          <article class="panel" aria-label="Webex component preview">
+            <div class="panel-head">
+              <div>
+                <p class="eyebrow">Live module</p>
+                <h3>soft room tile</h3>
+              </div>
+              <span class="status">online</span>
+            </div>
+            <div class="metric-grid">
+              <div class="metric"><strong>98%</strong><span>Signal quality</span></div>
+              <div class="metric"><strong>24</strong><span>Active flows</span></div>
+              <div class="metric"><strong>3.2s</strong><span>Response time</span></div>
+            </div>
+            <div class="card-row">
+              <div class="mini-card">
+                <h3>Palette</h3>
+                <p>cool collaboration surfaces with teal and violet meeting signals.</p>
+                <div class="swatches" aria-label="Token swatches">
+                  <span class="swatch accent"></span>
+                  <span class="swatch surface"></span>
+                  <span class="swatch warm"></span>
+                  <span class="swatch fg"></span>
+                </div>
+              </div>
+              <div class="mini-card">
+                <h3>Control</h3>
+                <p>Focus, hover, and status states share the same brand signal.</p>
+                <div class="field">
+                  <label for="webex-input">Reference input</label>
+                  <input id="webex-input" value="Webex system token" />
+                </div>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+      <section>
+        <div class="container lower">
+          <article class="tile">
+            <p class="eyebrow">Typography</p>
+            <h2>Display rhythm</h2>
+            <p>Headlines use the brand display stack with the declared scale and leading.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Surface</p>
+            <h2>Layer system</h2>
+            <p>Cards, warm panels, borders, and raised states resolve through shared tokens.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Interaction</p>
+            <h2>Motion states</h2>
+            <p>Buttons, inputs, and panels use brand-specific focus rings and easing.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/webex/tokens.css
+++ b/design-systems/webex/tokens.css
@@ -1,0 +1,64 @@
+/* design-systems/webex/tokens.css
+ *
+ * Structured token bindings for Webex.
+ * cool collaboration surfaces with teal and violet meeting signals.
+ */
+
+:root {
+  --bg: #f6f8fb;
+  --surface: #ffffff;
+  --surface-warm: #eef8f6;
+  --fg: #0f172a;
+  --fg-2: #334155;
+  --muted: #64748b;
+  --meta: #12a594;
+  --border: #dbe4ee;
+  --border-soft: #edf2f7;
+  --accent: #00a3a6;
+  --accent-on: #ffffff;
+  --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+  --success: #22c55e;
+  --warn: #f59e0b;
+  --danger: #e11d48;
+  --font-display: "CiscoSansTT", Inter, Arial, sans-serif;
+  --font-body: "CiscoSansTT", Inter, Arial, sans-serif;
+  --font-mono: "SF Mono", ui-monospace, Menlo, monospace;
+  --text-xs: 12px;
+  --text-sm: 14px;
+  --text-base: 16px;
+  --text-lg: 18px;
+  --text-xl: 22px;
+  --text-2xl: 32px;
+  --text-3xl: 44px;
+  --text-4xl: 60px;
+  --leading-body: 1.55;
+  --leading-tight: 1.1;
+  --tracking-display: -0.015em;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+  --section-y-desktop: 96px;
+  --section-y-tablet: 68px;
+  --section-y-phone: 48px;
+  --radius-sm: 12px;
+  --radius-md: 18px;
+  --radius-lg: 28px;
+  --radius-pill: 9999px;
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised: 0 20px 50px rgba(15, 23, 42, 0.10);
+  --focus-ring: 0 0 0 4px rgba(0, 163, 166, 0.24);
+  --motion-fast: 160ms;
+  --motion-base: 240ms;
+  --ease-standard: cubic-bezier(0.22, 1, 0.36, 1);
+  --container-max: 1180px;
+  --container-gutter-desktop: 36px;
+  --container-gutter-tablet: 28px;
+  --container-gutter-phone: 18px;
+}

--- a/design-systems/wired/components.html
+++ b/design-systems/wired/components.html
@@ -1,0 +1,342 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>WIRED - reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/wired: authoritative technology journalism with monochrome discipline and sharp red alerts."
+    />
+    <style>
+      :root {
+        --bg: #ffffff;
+        --surface: #f2f2f2;
+        --surface-warm: #fff0f0;
+        --fg: #000000;
+        --fg-2: #333333;
+        --muted: #666666;
+        --meta: #e10600;
+        --border: #d0d0d0;
+        --border-soft: #e8e8e8;
+        --accent: #e10600;
+        --accent-on: #ffffff;
+        --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+        --success: #0f8a3b;
+        --warn: #f5a400;
+        --danger: #c40000;
+        --font-display: "Druk Wide", "Arial Black", Impact, sans-serif;
+        --font-body: "Exchange", Georgia, serif;
+        --font-mono: "IBM Plex Mono", ui-monospace, Menlo, monospace;
+        --text-xs: 12px;
+        --text-sm: 14px;
+        --text-base: 17px;
+        --text-lg: 20px;
+        --text-xl: 28px;
+        --text-2xl: 44px;
+        --text-3xl: 68px;
+        --text-4xl: 96px;
+        --leading-body: 1.55;
+        --leading-tight: 0.92;
+        --tracking-display: -0.02em;
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+        --section-y-desktop: 88px;
+        --section-y-tablet: 64px;
+        --section-y-phone: 44px;
+        --radius-sm: 0px;
+        --radius-md: 0px;
+        --radius-lg: 0px;
+        --radius-pill: 9999px;
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised: 0 16px 40px rgba(0, 0, 0, 0.14);
+        --focus-ring: 0 0 0 4px rgba(225, 6, 0, 0.24);
+        --motion-fast: 120ms;
+        --motion-base: 200ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+        --container-max: 1180px;
+        --container-gutter-desktop: 34px;
+        --container-gutter-tablet: 26px;
+        --container-gutter-phone: 18px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        min-height: 100vh;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+      .page {
+        min-height: 100vh;
+        background: linear-gradient(135deg, #ffffff 0%, #f2f2f2 70%, #fff0f0 100%);
+      }
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+      h1, h2, h3, p { margin: 0; }
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        line-height: var(--leading-tight);
+        letter-spacing: var(--tracking-display);
+      }
+      h1 { max-width: 820px; font-size: var(--text-4xl); font-weight: 700; }
+      h2 { font-size: var(--text-3xl); font-weight: 650; }
+      h3 { font-size: var(--text-xl); font-weight: 650; }
+      .eyebrow {
+        color: var(--meta);
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+      .lead {
+        max-width: 620px;
+        color: var(--fg-2);
+        font-size: var(--text-lg);
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+        gap: var(--space-8);
+        align-items: center;
+      }
+      .stack > * + * { margin-block-start: var(--space-4); }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3);
+        margin-block-start: var(--space-6);
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 44px;
+        padding: 0 var(--space-5);
+        border: 1px solid transparent;
+        border-radius: var(--radius-md);
+        font: 700 var(--text-sm) / 1 var(--font-body);
+        text-decoration: none;
+        cursor: pointer;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          border-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard),
+          transform var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn-primary { background: var(--accent); color: var(--accent-on); }
+      .btn-primary:hover { background: var(--accent-hover); transform: translateY(-1px); }
+      .btn-secondary { background: var(--surface); color: var(--fg); border-color: var(--border); box-shadow: var(--elev-ring); }
+      .btn-secondary:hover { border-color: var(--accent); color: var(--accent); }
+      .panel {
+        background: color-mix(in oklab, var(--surface), transparent 4%);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--elev-raised);
+        overflow: hidden;
+      }
+      .panel-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+        padding: var(--space-5);
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .status {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        color: var(--meta);
+        font: 700 var(--text-xs) / 1 var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .status::before {
+        width: 8px;
+        height: 8px;
+        border-radius: var(--radius-pill);
+        background: var(--success);
+        content: "";
+      }
+      .metric-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .metric {
+        padding: var(--space-5);
+        border-right: 1px solid var(--border-soft);
+      }
+      .metric:last-child { border-right: 0; }
+      .metric strong {
+        display: block;
+        font-family: var(--font-display);
+        font-size: var(--text-2xl);
+        line-height: var(--leading-tight);
+      }
+      .metric span { color: var(--muted); font-size: var(--text-sm); }
+      .card-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-4);
+        padding: var(--space-5);
+      }
+      .mini-card {
+        min-height: 148px;
+        padding: var(--space-5);
+        border: 1px solid var(--border-soft);
+        border-radius: var(--radius-md);
+        background: var(--surface-warm);
+      }
+      .mini-card p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      .swatches {
+        display: flex;
+        gap: var(--space-2);
+        margin-block-start: var(--space-4);
+      }
+      .swatch {
+        width: 32px;
+        height: 32px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+      }
+      .swatch.accent { background: var(--accent); }
+      .swatch.surface { background: var(--surface); }
+      .swatch.warm { background: var(--surface-warm); }
+      .swatch.fg { background: var(--fg); }
+      .field {
+        display: grid;
+        gap: var(--space-2);
+        margin-block-start: var(--space-5);
+      }
+      label { color: var(--fg-2); font-size: var(--text-sm); font-weight: 700; }
+      input {
+        width: 100%;
+        min-height: 46px;
+        padding: 0 var(--space-4);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--surface);
+        color: var(--fg);
+        font: inherit;
+      }
+      input:focus { outline: none; box-shadow: var(--focus-ring); border-color: var(--accent); }
+      .lower {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: var(--space-4);
+      }
+      .tile {
+        padding: var(--space-5);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface);
+      }
+      .tile p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      @media (max-width: 860px) {
+        .hero, .lower { grid-template-columns: 1fr; }
+        .metric-grid, .card-row { grid-template-columns: 1fr; }
+        .metric { border-right: 0; border-bottom: 1px solid var(--border-soft); }
+        .metric:last-child { border-bottom: 0; }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <section>
+        <div class="container hero">
+          <div class="stack">
+            <p class="eyebrow">WIRED design system</p>
+            <h1>Future-culture dossier</h1>
+            <p class="lead">Black-and-white editorial grid, red urgency, and dense story modules.</p>
+            <div class="actions" aria-label="Reference actions">
+              <a class="btn btn-primary" href="#">Primary red editorial block</a>
+              <a class="btn btn-secondary" href="#">Secondary action</a>
+            </div>
+          </div>
+          <article class="panel" aria-label="WIRED component preview">
+            <div class="panel-head">
+              <div>
+                <p class="eyebrow">Live module</p>
+                <h3>monochrome story cell</h3>
+              </div>
+              <span class="status">online</span>
+            </div>
+            <div class="metric-grid">
+              <div class="metric"><strong>98%</strong><span>Signal quality</span></div>
+              <div class="metric"><strong>24</strong><span>Active flows</span></div>
+              <div class="metric"><strong>3.2s</strong><span>Response time</span></div>
+            </div>
+            <div class="card-row">
+              <div class="mini-card">
+                <h3>Palette</h3>
+                <p>authoritative technology journalism with monochrome discipline and sharp red alerts.</p>
+                <div class="swatches" aria-label="Token swatches">
+                  <span class="swatch accent"></span>
+                  <span class="swatch surface"></span>
+                  <span class="swatch warm"></span>
+                  <span class="swatch fg"></span>
+                </div>
+              </div>
+              <div class="mini-card">
+                <h3>Control</h3>
+                <p>Focus, hover, and status states share the same brand signal.</p>
+                <div class="field">
+                  <label for="wired-input">Reference input</label>
+                  <input id="wired-input" value="WIRED system token" />
+                </div>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+      <section>
+        <div class="container lower">
+          <article class="tile">
+            <p class="eyebrow">Typography</p>
+            <h2>Display rhythm</h2>
+            <p>Headlines use the brand display stack with the declared scale and leading.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Surface</p>
+            <h2>Layer system</h2>
+            <p>Cards, warm panels, borders, and raised states resolve through shared tokens.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Interaction</p>
+            <h2>Motion states</h2>
+            <p>Buttons, inputs, and panels use brand-specific focus rings and easing.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/wired/tokens.css
+++ b/design-systems/wired/tokens.css
@@ -1,0 +1,64 @@
+/* design-systems/wired/tokens.css
+ *
+ * Structured token bindings for WIRED.
+ * authoritative technology journalism with monochrome discipline and sharp red alerts.
+ */
+
+:root {
+  --bg: #ffffff;
+  --surface: #f2f2f2;
+  --surface-warm: #fff0f0;
+  --fg: #000000;
+  --fg-2: #333333;
+  --muted: #666666;
+  --meta: #e10600;
+  --border: #d0d0d0;
+  --border-soft: #e8e8e8;
+  --accent: #e10600;
+  --accent-on: #ffffff;
+  --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+  --success: #0f8a3b;
+  --warn: #f5a400;
+  --danger: #c40000;
+  --font-display: "Druk Wide", "Arial Black", Impact, sans-serif;
+  --font-body: "Exchange", Georgia, serif;
+  --font-mono: "IBM Plex Mono", ui-monospace, Menlo, monospace;
+  --text-xs: 12px;
+  --text-sm: 14px;
+  --text-base: 17px;
+  --text-lg: 20px;
+  --text-xl: 28px;
+  --text-2xl: 44px;
+  --text-3xl: 68px;
+  --text-4xl: 96px;
+  --leading-body: 1.55;
+  --leading-tight: 0.92;
+  --tracking-display: -0.02em;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+  --section-y-desktop: 88px;
+  --section-y-tablet: 64px;
+  --section-y-phone: 44px;
+  --radius-sm: 0px;
+  --radius-md: 0px;
+  --radius-lg: 0px;
+  --radius-pill: 9999px;
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised: 0 16px 40px rgba(0, 0, 0, 0.14);
+  --focus-ring: 0 0 0 4px rgba(225, 6, 0, 0.24);
+  --motion-fast: 120ms;
+  --motion-base: 200ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --container-max: 1180px;
+  --container-gutter-desktop: 34px;
+  --container-gutter-tablet: 26px;
+  --container-gutter-phone: 18px;
+}

--- a/design-systems/zapier/components.html
+++ b/design-systems/zapier/components.html
@@ -1,0 +1,342 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Zapier - reference components</title>
+    <meta
+      name="description"
+      content="Reference fixture for design-systems/zapier: warm automation workspace with off-white canvas, orange connectors, and approachable cards."
+    />
+    <style>
+      :root {
+        --bg: #fff7ed;
+        --surface: #ffffff;
+        --surface-warm: #ffedd5;
+        --fg: #2d2a26;
+        --fg-2: #574f45;
+        --muted: #7c6f64;
+        --meta: #ff4f00;
+        --border: #eadfd3;
+        --border-soft: #f4eadf;
+        --accent: #ff4f00;
+        --accent-on: #ffffff;
+        --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+        --accent-active: color-mix(in oklab, var(--accent), black 14%);
+        --success: #15803d;
+        --warn: #d97706;
+        --danger: #dc2626;
+        --font-display: "Degular", Inter, system-ui, sans-serif;
+        --font-body: "Inter", system-ui, sans-serif;
+        --font-mono: "Roboto Mono", ui-monospace, Menlo, monospace;
+        --text-xs: 12px;
+        --text-sm: 14px;
+        --text-base: 16px;
+        --text-lg: 18px;
+        --text-xl: 24px;
+        --text-2xl: 36px;
+        --text-3xl: 52px;
+        --text-4xl: 72px;
+        --leading-body: 1.5;
+        --leading-tight: 1.02;
+        --tracking-display: -0.025em;
+        --space-1: 4px;
+        --space-2: 8px;
+        --space-3: 12px;
+        --space-4: 16px;
+        --space-5: 20px;
+        --space-6: 24px;
+        --space-8: 32px;
+        --space-12: 48px;
+        --section-y-desktop: 96px;
+        --section-y-tablet: 68px;
+        --section-y-phone: 48px;
+        --radius-sm: 8px;
+        --radius-md: 12px;
+        --radius-lg: 20px;
+        --radius-pill: 9999px;
+        --elev-flat: none;
+        --elev-ring: 0 0 0 1px var(--border);
+        --elev-raised: 0 18px 44px rgba(45, 42, 38, 0.12);
+        --focus-ring: 0 0 0 4px rgba(255, 79, 0, 0.24);
+        --motion-fast: 140ms;
+        --motion-base: 220ms;
+        --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+        --container-max: 1160px;
+        --container-gutter-desktop: 32px;
+        --container-gutter-tablet: 24px;
+        --container-gutter-phone: 16px;
+      }
+
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; }
+      body {
+        min-height: 100vh;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: var(--text-base);
+        line-height: var(--leading-body);
+        -webkit-font-smoothing: antialiased;
+      }
+      .page {
+        min-height: 100vh;
+        background: linear-gradient(135deg, #fff7ed 0%, #ffedd5 58%, #ffffff 100%);
+      }
+      .container {
+        max-width: var(--container-max);
+        margin-inline: auto;
+        padding-inline: var(--container-gutter-desktop);
+      }
+      section { padding-block: var(--section-y-desktop); }
+      @media (max-width: 1023px) {
+        .container { padding-inline: var(--container-gutter-tablet); }
+        section { padding-block: var(--section-y-tablet); }
+      }
+      @media (max-width: 639px) {
+        .container { padding-inline: var(--container-gutter-phone); }
+        section { padding-block: var(--section-y-phone); }
+      }
+      h1, h2, h3, p { margin: 0; }
+      h1, h2, h3 {
+        font-family: var(--font-display);
+        line-height: var(--leading-tight);
+        letter-spacing: var(--tracking-display);
+      }
+      h1 { max-width: 820px; font-size: var(--text-4xl); font-weight: 700; }
+      h2 { font-size: var(--text-3xl); font-weight: 650; }
+      h3 { font-size: var(--text-xl); font-weight: 650; }
+      .eyebrow {
+        color: var(--meta);
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+      .lead {
+        max-width: 620px;
+        color: var(--fg-2);
+        font-size: var(--text-lg);
+      }
+      .hero {
+        display: grid;
+        grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+        gap: var(--space-8);
+        align-items: center;
+      }
+      .stack > * + * { margin-block-start: var(--space-4); }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-3);
+        margin-block-start: var(--space-6);
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 44px;
+        padding: 0 var(--space-5);
+        border: 1px solid transparent;
+        border-radius: var(--radius-md);
+        font: 700 var(--text-sm) / 1 var(--font-body);
+        text-decoration: none;
+        cursor: pointer;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          border-color var(--motion-fast) var(--ease-standard),
+          color var(--motion-fast) var(--ease-standard),
+          transform var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+      .btn:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+      .btn-primary { background: var(--accent); color: var(--accent-on); }
+      .btn-primary:hover { background: var(--accent-hover); transform: translateY(-1px); }
+      .btn-secondary { background: var(--surface); color: var(--fg); border-color: var(--border); box-shadow: var(--elev-ring); }
+      .btn-secondary:hover { border-color: var(--accent); color: var(--accent); }
+      .panel {
+        background: color-mix(in oklab, var(--surface), transparent 4%);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--elev-raised);
+        overflow: hidden;
+      }
+      .panel-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+        padding: var(--space-5);
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .status {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        color: var(--meta);
+        font: 700 var(--text-xs) / 1 var(--font-mono);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+      .status::before {
+        width: 8px;
+        height: 8px;
+        border-radius: var(--radius-pill);
+        background: var(--success);
+        content: "";
+      }
+      .metric-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        border-bottom: 1px solid var(--border-soft);
+      }
+      .metric {
+        padding: var(--space-5);
+        border-right: 1px solid var(--border-soft);
+      }
+      .metric:last-child { border-right: 0; }
+      .metric strong {
+        display: block;
+        font-family: var(--font-display);
+        font-size: var(--text-2xl);
+        line-height: var(--leading-tight);
+      }
+      .metric span { color: var(--muted); font-size: var(--text-sm); }
+      .card-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: var(--space-4);
+        padding: var(--space-5);
+      }
+      .mini-card {
+        min-height: 148px;
+        padding: var(--space-5);
+        border: 1px solid var(--border-soft);
+        border-radius: var(--radius-md);
+        background: var(--surface-warm);
+      }
+      .mini-card p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      .swatches {
+        display: flex;
+        gap: var(--space-2);
+        margin-block-start: var(--space-4);
+      }
+      .swatch {
+        width: 32px;
+        height: 32px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+      }
+      .swatch.accent { background: var(--accent); }
+      .swatch.surface { background: var(--surface); }
+      .swatch.warm { background: var(--surface-warm); }
+      .swatch.fg { background: var(--fg); }
+      .field {
+        display: grid;
+        gap: var(--space-2);
+        margin-block-start: var(--space-5);
+      }
+      label { color: var(--fg-2); font-size: var(--text-sm); font-weight: 700; }
+      input {
+        width: 100%;
+        min-height: 46px;
+        padding: 0 var(--space-4);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--surface);
+        color: var(--fg);
+        font: inherit;
+      }
+      input:focus { outline: none; box-shadow: var(--focus-ring); border-color: var(--accent); }
+      .lower {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: var(--space-4);
+      }
+      .tile {
+        padding: var(--space-5);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface);
+      }
+      .tile p { color: var(--muted); font-size: var(--text-sm); margin-block-start: var(--space-3); }
+      @media (max-width: 860px) {
+        .hero, .lower { grid-template-columns: 1fr; }
+        .metric-grid, .card-row { grid-template-columns: 1fr; }
+        .metric { border-right: 0; border-bottom: 1px solid var(--border-soft); }
+        .metric:last-child { border-bottom: 0; }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <section>
+        <div class="container hero">
+          <div class="stack">
+            <p class="eyebrow">Zapier design system</p>
+            <h1>Automation builder</h1>
+            <p class="lead">Friendly workflow blocks, orange actions, and practical productivity rhythm.</p>
+            <div class="actions" aria-label="Reference actions">
+              <a class="btn btn-primary" href="#">Primary orange automation button</a>
+              <a class="btn btn-secondary" href="#">Secondary action</a>
+            </div>
+          </div>
+          <article class="panel" aria-label="Zapier component preview">
+            <div class="panel-head">
+              <div>
+                <p class="eyebrow">Live module</p>
+                <h3>workflow step card</h3>
+              </div>
+              <span class="status">online</span>
+            </div>
+            <div class="metric-grid">
+              <div class="metric"><strong>98%</strong><span>Signal quality</span></div>
+              <div class="metric"><strong>24</strong><span>Active flows</span></div>
+              <div class="metric"><strong>3.2s</strong><span>Response time</span></div>
+            </div>
+            <div class="card-row">
+              <div class="mini-card">
+                <h3>Palette</h3>
+                <p>warm automation workspace with off-white canvas, orange connectors, and approachable cards.</p>
+                <div class="swatches" aria-label="Token swatches">
+                  <span class="swatch accent"></span>
+                  <span class="swatch surface"></span>
+                  <span class="swatch warm"></span>
+                  <span class="swatch fg"></span>
+                </div>
+              </div>
+              <div class="mini-card">
+                <h3>Control</h3>
+                <p>Focus, hover, and status states share the same brand signal.</p>
+                <div class="field">
+                  <label for="zapier-input">Reference input</label>
+                  <input id="zapier-input" value="Zapier system token" />
+                </div>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+      <section>
+        <div class="container lower">
+          <article class="tile">
+            <p class="eyebrow">Typography</p>
+            <h2>Display rhythm</h2>
+            <p>Headlines use the brand display stack with the declared scale and leading.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Surface</p>
+            <h2>Layer system</h2>
+            <p>Cards, warm panels, borders, and raised states resolve through shared tokens.</p>
+          </article>
+          <article class="tile">
+            <p class="eyebrow">Interaction</p>
+            <h2>Motion states</h2>
+            <p>Buttons, inputs, and panels use brand-specific focus rings and easing.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design-systems/zapier/tokens.css
+++ b/design-systems/zapier/tokens.css
@@ -1,0 +1,64 @@
+/* design-systems/zapier/tokens.css
+ *
+ * Structured token bindings for Zapier.
+ * warm automation workspace with off-white canvas, orange connectors, and approachable cards.
+ */
+
+:root {
+  --bg: #fff7ed;
+  --surface: #ffffff;
+  --surface-warm: #ffedd5;
+  --fg: #2d2a26;
+  --fg-2: #574f45;
+  --muted: #7c6f64;
+  --meta: #ff4f00;
+  --border: #eadfd3;
+  --border-soft: #f4eadf;
+  --accent: #ff4f00;
+  --accent-on: #ffffff;
+  --accent-hover: color-mix(in oklab, var(--accent), black 8%);
+  --accent-active: color-mix(in oklab, var(--accent), black 14%);
+  --success: #15803d;
+  --warn: #d97706;
+  --danger: #dc2626;
+  --font-display: "Degular", Inter, system-ui, sans-serif;
+  --font-body: "Inter", system-ui, sans-serif;
+  --font-mono: "Roboto Mono", ui-monospace, Menlo, monospace;
+  --text-xs: 12px;
+  --text-sm: 14px;
+  --text-base: 16px;
+  --text-lg: 18px;
+  --text-xl: 24px;
+  --text-2xl: 36px;
+  --text-3xl: 52px;
+  --text-4xl: 72px;
+  --leading-body: 1.5;
+  --leading-tight: 1.02;
+  --tracking-display: -0.025em;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+  --section-y-desktop: 96px;
+  --section-y-tablet: 68px;
+  --section-y-phone: 48px;
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 20px;
+  --radius-pill: 9999px;
+  --elev-flat: none;
+  --elev-ring: 0 0 0 1px var(--border);
+  --elev-raised: 0 18px 44px rgba(45, 42, 38, 0.12);
+  --focus-ring: 0 0 0 4px rgba(255, 79, 0, 0.24);
+  --motion-fast: 140ms;
+  --motion-base: 220ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --container-max: 1160px;
+  --container-gutter-desktop: 32px;
+  --container-gutter-tablet: 24px;
+  --container-gutter-phone: 16px;
+}


### PR DESCRIPTION
## Why

I am opening this PR to continue the 152-brand design-system coverage push with the next recommended batch of high-signal brands. The pain being addressed is catalogue incompleteness: agents can only reliably use brand-specific tokens and standalone component references for brands that have both `tokens.css` and `components.html`.

This batch prioritizes recognizable brands across enterprise, telecom, fintech, automotive, media, developer tooling, and game surfaces so the design-system catalogue gains broader visual coverage instead of another narrow cluster.

## What users will see

Users and agents selecting these design systems will now have structured tokens plus a standalone component fixture for: IBM, Cisco, Mastercard, Vodafone, Webex, Zapier, Miro, Sanity, Expo, Composio, Revolut, Kraken, Ferrari, Lamborghini, Bugatti, BMW M, The Verge, WIRED, Tetris, and Pac-Man.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable. This does not change app UI; it adds design-system extension fixtures.

## Bug fix verification

Not applicable. This is not a bug fix.

## Validation

- `pnpm exec tsx scripts/check-tokens-fixture-sync.ts`
- `pnpm guard`
- `pnpm typecheck`
- Clean worktree verification: `/Users/chaoxiaoche/Desktop/open-design/node_modules/.bin/tsx scripts/check-tokens-fixture-sync.ts`
