### PR TITLE
Fix home entry actions

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -57,6 +57,7 @@ import type {
   PluginShareProjectOutcome,
 } from '../state/projects';
 import { TasksView } from './TasksView';
+import { Toast } from './Toast';
 
 // The topbar chips (GitHub star, model switcher, Use everywhere)
 // collapse into the settings dropdown when the viewport gets
@@ -104,6 +105,28 @@ function defaultPluginInputsForCreate(
     style,
     ...(aspect ? { aspect } : {}),
   };
+}
+
+function formatPickAndImportErrorDetails(details: unknown): string | undefined {
+  if (typeof details === 'string' && details.length > 0) return details;
+  if (details == null || typeof details !== 'object') return undefined;
+  const record = details as Record<string, unknown>;
+  const error = record.error;
+  if (error != null && typeof error === 'object') {
+    const errRecord = error as Record<string, unknown>;
+    const message = errRecord.message;
+    const nestedDetails = errRecord.details;
+    if (typeof message === 'string' && message.length > 0) {
+      if (nestedDetails != null && typeof nestedDetails === 'object') {
+        const nestedReason = (nestedDetails as Record<string, unknown>).reason;
+        if (typeof nestedReason === 'string' && nestedReason.length > 0) {
+          return `${message} (${nestedReason})`;
+        }
+      }
+      return message;
+    }
+  }
+  return undefined;
 }
 
 // Theme options exposed in the avatar-popover appearance submenu.
@@ -294,6 +317,10 @@ export function EntryShell({
   const [newProjectOpen, setNewProjectOpen] = useState(false);
   const [newProjectInitialTab, setNewProjectInitialTab] =
     useState<CreateTab>('prototype');
+  const [folderImportError, setFolderImportError] = useState<{
+    message: string;
+    details?: string;
+  } | null>(null);
   const [integrationTab, setIntegrationTab] = useState<IntegrationTab>(integrationInitialTab);
   const [homePromptHandoff, setHomePromptHandoff] = useState<HomePromptHandoff | null>(null);
   const avatarMenuRef = useRef<HTMLDivElement | null>(null);
@@ -432,6 +459,17 @@ export function EntryShell({
         await onImportFolderResponse(result.response);
         return;
       }
+      const reason = 'reason' in result && typeof result.reason === 'string'
+        ? result.reason
+        : 'unknown failure';
+      const details = 'details' in result && result.details != null
+        ? formatPickAndImportErrorDetails(result.details)
+        : undefined;
+      setFolderImportError({
+        message: `Open folder failed: ${reason}`,
+        ...(details ? { details } : {}),
+      });
+      return;
     }
     openNewProject('prototype');
   }
@@ -838,6 +876,14 @@ export function EntryShell({
         }}
         onClose={() => setNewProjectOpen(false)}
       />
+      {folderImportError ? (
+        <Toast
+          message={folderImportError.message}
+          details={folderImportError.details ?? null}
+          role="alert"
+          onDismiss={() => setFolderImportError(null)}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -12,6 +12,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   defaultScenarioPluginIdForKind,
   type ConnectorDetail,
+  type ImportFolderResponse,
   type InstalledPluginRecord,
 } from '@open-design/contracts';
 import { LOCALE_LABEL, LOCALES, useI18n, useT, type Locale } from '../i18n';
@@ -49,7 +50,7 @@ import { IntegrationsView, type IntegrationTab } from './IntegrationsView';
 import { InlineModelSwitcher } from './InlineModelSwitcher';
 import { NewProjectModal } from './NewProjectModal';
 import { PluginsView } from './PluginsView';
-import type { CreateInput } from './NewProjectPanel';
+import type { CreateInput, CreateTab } from './NewProjectPanel';
 import type { PluginLoopSubmit } from './PluginLoopHome';
 import type {
   PluginShareAction,
@@ -218,6 +219,7 @@ interface Props {
   ) => Promise<PluginShareProjectOutcome>;
   onImportClaudeDesign: (file: File) => Promise<void> | void;
   onImportFolder?: (baseDir: string) => Promise<void> | void;
+  onImportFolderResponse?: (response: ImportFolderResponse) => Promise<void> | void;
   onOpenProject: (id: string) => void;
   onOpenLiveArtifact: (projectId: string, artifactId: string) => void;
   onDeleteProject: (id: string) => void;
@@ -268,6 +270,7 @@ export function EntryShell({
   onCreatePluginShareProject,
   onImportClaudeDesign,
   onImportFolder,
+  onImportFolderResponse,
   onOpenProject,
   onOpenLiveArtifact,
   onDeleteProject,
@@ -289,6 +292,8 @@ export function EntryShell({
   const [languageExpanded, setLanguageExpanded] = useState(false);
   const [appearanceExpanded, setAppearanceExpanded] = useState(false);
   const [newProjectOpen, setNewProjectOpen] = useState(false);
+  const [newProjectInitialTab, setNewProjectInitialTab] =
+    useState<CreateTab>('prototype');
   const [integrationTab, setIntegrationTab] = useState<IntegrationTab>(integrationInitialTab);
   const [homePromptHandoff, setHomePromptHandoff] = useState<HomePromptHandoff | null>(null);
   const avatarMenuRef = useRef<HTMLDivElement | null>(null);
@@ -330,6 +335,11 @@ export function EntryShell({
   function openIntegrationTab(tab: IntegrationTab) {
     setIntegrationTab(tab);
     changeView('integrations');
+  }
+
+  function openNewProject(tab: CreateTab = 'prototype') {
+    setNewProjectInitialTab(tab);
+    setNewProjectOpen(true);
   }
 
   const previewSystem = useMemo(
@@ -411,7 +421,19 @@ export function EntryShell({
     // pick + HMAC-gated import). On the web (no electronAPI) or when
     // the bridge is older, fall back to opening the New Project modal
     // so the user can paste a baseDir manually.
-    setNewProjectOpen(true);
+    if (
+      typeof window !== 'undefined' &&
+      typeof window.electronAPI?.pickAndImport === 'function' &&
+      onImportFolderResponse
+    ) {
+      const result = await window.electronAPI.pickAndImport();
+      if (!result || ('canceled' in result && result.canceled === true)) return;
+      if (result.ok === true) {
+        await onImportFolderResponse(result.response);
+        return;
+      }
+    }
+    openNewProject('prototype');
   }
 
   // Dismiss the avatar dropdown on outside-click / Escape so it
@@ -667,7 +689,7 @@ export function EntryShell({
         <EntryNavRail
           view={view}
           onViewChange={changeView}
-          onNewProject={() => setNewProjectOpen(true)}
+          onNewProject={() => openNewProject()}
         />
         <main className="entry-main entry-main--scroll">
           <div className="entry-main__topbar">
@@ -722,8 +744,7 @@ export function EntryShell({
                   // existing modal-based create flow still owns the
                   // template picker UI. Future tabs (e.g. live-artifact
                   // import) can reuse the same callback.
-                  void tab;
-                  setNewProjectOpen(true);
+                  openNewProject(tab);
                 }}
                 promptHandoff={homePromptHandoff}
                 skills={skills}
@@ -799,6 +820,7 @@ export function EntryShell({
       ) : null}
       <NewProjectModal
         open={newProjectOpen}
+        initialTab={newProjectInitialTab}
         skills={skills}
         designSystems={designSystems}
         defaultDesignSystemId={defaultDesignSystemId}

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -31,6 +31,7 @@ import type {
   SkillSummary,
 } from '../types';
 import { apiProtocolLabel } from '../utils/apiProtocol';
+import { formatPickAndImportFailure } from '../utils/pickAndImportError';
 import { CenteredLoader } from './Loading';
 import { DesignsTab } from './DesignsTab';
 import { DesignSystemPreviewModal } from './DesignSystemPreviewModal';
@@ -105,28 +106,6 @@ function defaultPluginInputsForCreate(
     style,
     ...(aspect ? { aspect } : {}),
   };
-}
-
-function formatPickAndImportErrorDetails(details: unknown): string | undefined {
-  if (typeof details === 'string' && details.length > 0) return details;
-  if (details == null || typeof details !== 'object') return undefined;
-  const record = details as Record<string, unknown>;
-  const error = record.error;
-  if (error != null && typeof error === 'object') {
-    const errRecord = error as Record<string, unknown>;
-    const message = errRecord.message;
-    const nestedDetails = errRecord.details;
-    if (typeof message === 'string' && message.length > 0) {
-      if (nestedDetails != null && typeof nestedDetails === 'object') {
-        const nestedReason = (nestedDetails as Record<string, unknown>).reason;
-        if (typeof nestedReason === 'string' && nestedReason.length > 0) {
-          return `${message} (${nestedReason})`;
-        }
-      }
-      return message;
-    }
-  }
-  return undefined;
 }
 
 // Theme options exposed in the avatar-popover appearance submenu.
@@ -321,6 +300,7 @@ export function EntryShell({
     message: string;
     details?: string;
   } | null>(null);
+  const [chipImporting, setChipImporting] = useState(false);
   const [integrationTab, setIntegrationTab] = useState<IntegrationTab>(integrationInitialTab);
   const [homePromptHandoff, setHomePromptHandoff] = useState<HomePromptHandoff | null>(null);
   const avatarMenuRef = useRef<HTMLDivElement | null>(null);
@@ -443,6 +423,7 @@ export function EntryShell({
   // project. Browser-only shells fall back to the existing modal
   // path so the user can paste a baseDir.
   async function handleChipFolderImport() {
+    if (chipImporting) return;
     // PR #974 trust boundary: the renderer cannot pick a folder directly
     // anymore — the bridge exposes `pickAndImport` instead (atomic
     // pick + HMAC-gated import). On the web (no electronAPI) or when
@@ -453,22 +434,18 @@ export function EntryShell({
       typeof window.electronAPI?.pickAndImport === 'function' &&
       onImportFolderResponse
     ) {
-      const result = await window.electronAPI.pickAndImport();
-      if (!result || ('canceled' in result && result.canceled === true)) return;
-      if (result.ok === true) {
-        await onImportFolderResponse(result.response);
-        return;
+      setChipImporting(true);
+      try {
+        const result = await window.electronAPI.pickAndImport();
+        if (!result || ('canceled' in result && result.canceled === true)) return;
+        if (result.ok === true) {
+          await onImportFolderResponse(result.response);
+          return;
+        }
+        setFolderImportError(formatPickAndImportFailure(result));
+      } finally {
+        setChipImporting(false);
       }
-      const reason = 'reason' in result && typeof result.reason === 'string'
-        ? result.reason
-        : 'unknown failure';
-      const details = 'details' in result && result.details != null
-        ? formatPickAndImportErrorDetails(result.details)
-        : undefined;
-      setFolderImportError({
-        message: `Open folder failed: ${reason}`,
-        ...(details ? { details } : {}),
-      });
       return;
     }
     openNewProject('prototype');

--- a/apps/web/src/components/EntryView.tsx
+++ b/apps/web/src/components/EntryView.tsx
@@ -337,6 +337,7 @@ export function EntryView({
       onCreatePluginShareProject={onCreatePluginShareProject}
       onImportClaudeDesign={onImportClaudeDesign}
       {...(onImportFolder ? { onImportFolder } : {})}
+      {...(onImportFolderResponse ? { onImportFolderResponse } : {})}
       onOpenProject={onOpenProject}
       onOpenLiveArtifact={onOpenLiveArtifact}
       onDeleteProject={onDeleteProject}

--- a/apps/web/src/components/NewProjectModal.tsx
+++ b/apps/web/src/components/NewProjectModal.tsx
@@ -18,7 +18,7 @@ import type {
   SkillSummary,
 } from '../types';
 import { Icon } from './Icon';
-import { NewProjectPanel, type CreateInput } from './NewProjectPanel';
+import { NewProjectPanel, type CreateInput, type CreateTab } from './NewProjectPanel';
 
 interface Props {
   open: boolean;
@@ -36,6 +36,7 @@ interface Props {
   onImportFolder?: (baseDir: string) => Promise<void> | void;
   onOpenConnectorsTab?: () => void;
   onClose: () => void;
+  initialTab?: CreateTab;
 }
 
 export function NewProjectModal({
@@ -54,6 +55,7 @@ export function NewProjectModal({
   onImportFolder,
   onOpenConnectorsTab,
   onClose,
+  initialTab,
 }: Props) {
   const closeRef = useRef<HTMLButtonElement | null>(null);
 
@@ -125,6 +127,7 @@ export function NewProjectModal({
             {...(onImportClaudeDesign ? { onImportClaudeDesign } : {})}
             {...(onImportFolder ? { onImportFolder } : {})}
             {...(onOpenConnectorsTab ? { onOpenConnectorsTab } : {})}
+            {...(initialTab ? { initialTab } : {})}
           />
         </div>
       </div>

--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -162,6 +162,7 @@ interface Props {
   connectorsLoading?: boolean;
   onOpenConnectorsTab?: () => void;
   loading?: boolean;
+  initialTab?: CreateTab;
 }
 
 const TAB_LABEL_KEYS: Record<CreateTab, keyof Dict> = {
@@ -217,6 +218,7 @@ export function NewProjectPanel({
   connectorsLoading = false,
   onOpenConnectorsTab,
   loading = false,
+  initialTab = 'prototype',
 }: Props) {
   const t = useT();
   const analytics = useAnalytics();
@@ -232,7 +234,7 @@ export function NewProjectPanel({
   const [importFolderError, setImportFolderError] = useState<
     { message: string; details?: string } | null
   >(null);
-  const [tab, setTab] = useState<CreateTab>('prototype');
+  const [tab, setTab] = useState<CreateTab>(initialTab);
   // Media tab consolidates image / video / audio. The active surface picks
   // which set of options + skill resolution applies; submission still maps
   // back to the existing image/video/audio ProjectKind branches so the

--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -42,39 +42,10 @@ import {
   VIDEO_LENGTHS_SEC,
   VIDEO_MODELS,
 } from '../media/models';
+import { formatPickAndImportFailure } from '../utils/pickAndImportError';
 import { Icon } from './Icon';
 import { Skeleton } from './Loading';
 import { Toast } from './Toast';
-
-/**
- * Best-effort flattening of the `details` field that the
- * pickAndImport main-process handler attaches when the daemon returned
- * a structured error envelope (PR #974 round-4 mrcfps). Daemon errors
- * carry `error.message` and sometimes nested `error.details.reason`;
- * we surface the most operator-actionable string we can find without
- * over-coupling to any particular error code.
- */
-function formatPickAndImportErrorDetails(details: unknown): string | undefined {
-  if (typeof details === 'string' && details.length > 0) return details;
-  if (details == null || typeof details !== 'object') return undefined;
-  const record = details as Record<string, unknown>;
-  const error = record.error;
-  if (error != null && typeof error === 'object') {
-    const errRecord = error as Record<string, unknown>;
-    const message = errRecord.message;
-    const nestedDetails = errRecord.details;
-    if (typeof message === 'string' && message.length > 0) {
-      if (nestedDetails != null && typeof nestedDetails === 'object') {
-        const nestedReason = (nestedDetails as Record<string, unknown>).reason;
-        if (typeof nestedReason === 'string' && nestedReason.length > 0) {
-          return `${message} (${nestedReason})`;
-        }
-      }
-      return message;
-    }
-  }
-  return undefined;
-}
 
 // Snapshot of a curated prompt template, captured at New Project time and
 // folded into ProjectMetadata.promptTemplate. The user may have edited the
@@ -604,16 +575,7 @@ export function NewProjectPanel({
         // network errors). The pickAndImport handler already pre-shapes
         // these into a `{ ok: false, reason, details? }` envelope.
         if ('canceled' in result && result.canceled === true) return;
-        const reason = 'reason' in result && typeof result.reason === 'string'
-          ? result.reason
-          : 'unknown failure';
-        const details = 'details' in result && result.details != null
-          ? formatPickAndImportErrorDetails(result.details)
-          : undefined;
-        setImportFolderError({
-          message: `Open folder failed: ${reason}`,
-          ...(details ? { details } : {}),
-        });
+        setImportFolderError(formatPickAndImportFailure(result));
       } finally {
         setImportingFolder(false);
       }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -575,7 +575,7 @@ code {
   padding-left: 0;
   overflow: visible;
   contain: layout style;
-  -webkit-app-region: no-drag;
+  -webkit-app-region: drag;
 }
 .workspace-tab {
   position: relative;
@@ -594,6 +594,7 @@ code {
   overflow: hidden;
   contain: layout style;
   transition: background 100ms ease, border-color 100ms ease, color 100ms ease;
+  -webkit-app-region: no-drag;
 }
 .workspace-tab + .workspace-tab::before {
   content: '';

--- a/apps/web/src/utils/pickAndImportError.ts
+++ b/apps/web/src/utils/pickAndImportError.ts
@@ -1,0 +1,46 @@
+import type { DesktopPickAndImportResult } from '../types/electron';
+
+/**
+ * Best-effort flattening of the `details` field that the
+ * pickAndImport main-process handler attaches when the daemon returned
+ * a structured error envelope (PR #974 round-4 mrcfps). Daemon errors
+ * carry `error.message` and sometimes nested `error.details.reason`;
+ * we surface the most operator-actionable string we can find without
+ * over-coupling to any particular error code.
+ */
+export function formatPickAndImportErrorDetails(details: unknown): string | undefined {
+  if (typeof details === 'string' && details.length > 0) return details;
+  if (details == null || typeof details !== 'object') return undefined;
+  const record = details as Record<string, unknown>;
+  const error = record.error;
+  if (error != null && typeof error === 'object') {
+    const errRecord = error as Record<string, unknown>;
+    const message = errRecord.message;
+    const nestedDetails = errRecord.details;
+    if (typeof message === 'string' && message.length > 0) {
+      if (nestedDetails != null && typeof nestedDetails === 'object') {
+        const nestedReason = (nestedDetails as Record<string, unknown>).reason;
+        if (typeof nestedReason === 'string' && nestedReason.length > 0) {
+          return `${message} (${nestedReason})`;
+        }
+      }
+      return message;
+    }
+  }
+  return undefined;
+}
+
+export function formatPickAndImportFailure(
+  result: DesktopPickAndImportResult,
+): { message: string; details?: string } {
+  const reason = 'reason' in result && typeof result.reason === 'string'
+    ? result.reason
+    : 'unknown failure';
+  const details = 'details' in result && result.details != null
+    ? formatPickAndImportErrorDetails(result.details)
+    : undefined;
+  return {
+    message: `Open folder failed: ${reason}`,
+    ...(details ? { details } : {}),
+  };
+}


### PR DESCRIPTION
## Why

While checking the desktop home flow, the primary quick-start actions did not match the intended behavior: From folder still routed through the New Project modal instead of opening the native folder picker, From template opened the modal at the default tab, and the macOS top drag area only worked in part of the empty tab strip.

This addresses a user-facing desktop navigation issue so the home shortcuts do exactly what their labels imply and the titlebar drag region behaves consistently.

## What users will see

On Home, clicking From folder in the quick-start chip rail opens the native system folder picker in desktop builds and imports the selected folder. Browser-only or older desktop bridge environments still fall back to the existing New Project modal.

Clicking From template still opens the existing New Project modal, but it now lands directly on the From template tab. On macOS, the empty workspace tab strip area to the right of the new-tab and search buttons is draggable.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached: this is a behavior-only change to existing Home entry points. The main visible result is a native OS folder picker, which is outside the web screenshot surface; From template reuses the existing modal UI and only changes the initially selected tab.

## Bug fix verification

No red spec was added. This is a narrow desktop/home interaction wiring fix: the relevant behavior depends on the Electron preload bridge and native folder picker, and the existing bridge contract is already typed and reused from NewProjectPanel.

## Validation

- `pnpm guard`
- `pnpm --filter @open-design/web typecheck`
- `pnpm typecheck`

Notes: validation passed under Node `v22.22.0`; the workspace emitted the expected engine warning because this repo targets Node `~24`. `pnpm typecheck` also reported existing Astro hints in `apps/landing-page/app/_components/seo-head.astro` with 0 errors.