### PR TITLE
fix: show notice when Inspect resolves to annotated ancestor

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -200,12 +200,18 @@ type InspectStyleSnapshot = {
   lineHeight?: string;
 };
 
+type InspectClickedDescendant = {
+  label: string;
+  text: string;
+};
+
 type InspectTarget = {
   elementId: string;
   selector: string;
   label: string;
   text: string;
   style: InspectStyleSnapshot;
+  clickedDescendant?: InspectClickedDescendant;
 };
 
 const MAX_CACHED_SLIDE_STATES = 64;
@@ -2102,6 +2108,22 @@ function InspectPanel({
           ×
         </button>
       </header>
+
+      {target.clickedDescendant ? (
+        <div className="inspect-ancestor-notice" data-testid="inspect-ancestor-notice">
+          <div className="inspect-ancestor-notice-icon" aria-hidden>
+            i
+          </div>
+          <div className="inspect-ancestor-notice-text">
+            You clicked <strong>{target.clickedDescendant.label}</strong>
+            {target.clickedDescendant.text
+              ? ` ("${target.clickedDescendant.text.slice(0, 40)}${target.clickedDescendant.text.length > 40 ? '...' : ''}")`
+              : ''}
+            , but it has no <code>data-od-id</code> annotation. Editing{' '}
+            <strong>{target.label || target.elementId}</strong> instead, the nearest annotated ancestor.
+          </div>
+        </div>
+      ) : null}
 
       <section className="inspect-section">
         <div className="inspect-section-label">Colors</div>
@@ -4705,16 +4727,32 @@ function HtmlViewer({
     function onMessage(ev: MessageEvent) {
       if (!isOurPreviewIframeSource(ev.source)) return;
       const data = ev.data as
-        | { type?: string; elementId?: string; selector?: string; label?: string; text?: string; style?: InspectStyleSnapshot }
+        | {
+            type?: string;
+            elementId?: string;
+            selector?: string;
+            label?: string;
+            text?: string;
+            style?: InspectStyleSnapshot;
+            clickedDescendant?: Partial<InspectClickedDescendant>;
+          }
         | null;
       if (!data || data.type !== 'od:comment-target') return;
       if (!data.elementId || !data.selector) return;
+      const clickedDescendant =
+        data.clickedDescendant && typeof data.clickedDescendant === 'object'
+          ? {
+              label: String(data.clickedDescendant.label || ''),
+              text: String(data.clickedDescendant.text || ''),
+            }
+          : null;
       setActiveInspectTarget({
         elementId: String(data.elementId),
         selector: String(data.selector),
         label: String(data.label || ''),
         text: String(data.text || ''),
         style: data.style && typeof data.style === 'object' ? data.style : {},
+        ...(clickedDescendant ? { clickedDescendant } : {}),
       });
       setInspectError(null);
       setInspectSavedAt(null);

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -11538,6 +11538,44 @@ button.connector-action.is-loading {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+.inspect-ancestor-notice {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px;
+  color: var(--text);
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border));
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--accent) 8%, var(--bg-panel));
+  font-size: 11px;
+  line-height: 1.4;
+}
+.inspect-ancestor-notice-icon {
+  display: grid;
+  place-items: center;
+  flex: 0 0 16px;
+  width: 16px;
+  height: 16px;
+  color: var(--accent);
+  border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+}
+.inspect-ancestor-notice-text {
+  min-width: 0;
+}
+.inspect-ancestor-notice-text strong {
+  font-weight: 600;
+}
+.inspect-ancestor-notice-text code {
+  padding: 1px 3px;
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--text) 8%, transparent);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
 
 /* MCP Copy button floats above a syntax-highlighted <pre>; .ghost's
    transparent background let the dark code surface bleed through and

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -909,7 +909,7 @@ function meaningfulDomFallbackTarget(el) {
 
   return true;
 }
-  function targetFrom(el, allowDomFallback){
+  function targetFrom(el, allowDomFallback, clickedEl){
     var id = el.getAttribute('data-od-id') || el.getAttribute('data-screen-label');
     var selector = annotatedSelectorFor(el);
     if (!id && allowDomFallback && meaningfulDomFallbackTarget(el)) {
@@ -922,7 +922,7 @@ function meaningfulDomFallbackTarget(el) {
     var cls = typeof el.className === 'string' && el.className.trim() ? '.' + el.className.trim().split(/\\s+/).slice(0,2).join('.') : '';
     var html = '';
     try { html = (el.outerHTML || '').replace(/\\s+/g, ' ').match(/^<[^>]+>/)?.[0] || ''; } catch (_) {}
-    return {
+    var payload = {
       type: 'od:comment-target',
       elementId: id,
       selector: selector,
@@ -932,6 +932,15 @@ function meaningfulDomFallbackTarget(el) {
       htmlHint: html.slice(0, 180),
       style: styleSnapshot(el)
     };
+    if (clickedEl && clickedEl !== el) {
+      var clickedTag = clickedEl.tagName ? clickedEl.tagName.toLowerCase() : 'element';
+      var clickedCls = typeof clickedEl.className === 'string' && clickedEl.className.trim() ? '.' + clickedEl.className.trim().split(/\\s+/).slice(0,2).join('.') : '';
+      payload.clickedDescendant = {
+        label: clickedTag + clickedCls,
+        text: (clickedEl.textContent || '').replace(/\\s+/g, ' ').trim().slice(0, 80)
+      };
+    }
+    return payload;
   }
   function allTargets(){
     var annotatedNodes = document.querySelectorAll('[data-od-id], [data-screen-label]');
@@ -1004,15 +1013,18 @@ function meaningfulDomFallbackTarget(el) {
     return commentEnabled && !inspectEnabled && document.querySelectorAll('[data-od-id], [data-screen-label]').length === 0;
   }
   function closestTarget(event){
-    var el = event.target;
+    var clicked = event.target;
+    var el = clicked;
     var fallback = null;
     var allowDomFallback = mode === 'picker' && canUseDomFallback();
     while (el && el !== document.documentElement) {
-      if (el.getAttribute && (el.hasAttribute('data-od-id') || el.hasAttribute('data-screen-label'))) return el;
-if (!fallback && allowDomFallback && meaningfulDomFallbackTarget(el)) fallback = el;
+      if (el.getAttribute && (el.hasAttribute('data-od-id') || el.hasAttribute('data-screen-label'))) {
+        return { target: el, clicked: clicked };
+      }
+      if (!fallback && allowDomFallback && meaningfulDomFallbackTarget(el)) fallback = el;
       el = el.parentElement;
     }
-    return fallback;
+    return fallback ? { target: fallback, clicked: clicked } : null;
   }
   function applyOverride(elementId, selector, prop, value){
     if (!elementId || !prop) return;
@@ -1123,20 +1135,20 @@ if (!fallback && allowDomFallback && meaningfulDomFallbackTarget(el)) fallback =
   function pickerActive(){ return inspectEnabled || (commentEnabled && mode === 'picker'); }
   document.addEventListener('mouseover', function(ev){
     if (!pickerActive()) return;
-    var el = closestTarget(ev);
-    if (!el) return;
-    var payload = targetFrom(el, commentEnabled && mode === 'picker' && !inspectEnabled);
+    var result = closestTarget(ev);
+    if (!result) return;
+    var payload = targetFrom(result.target, commentEnabled && mode === 'picker' && !inspectEnabled);
     if (!payload || payload.elementId === hoveredId) return;
     hoveredId = payload.elementId;
     window.parent.postMessage(Object.assign({}, payload, { type: 'od:comment-hover' }), '*');
   }, true);
   document.addEventListener('mouseout', function(ev){
     if (!pickerActive()) return;
-    var el = closestTarget(ev);
-    if (!el) return;
+    var result = closestTarget(ev);
+    if (!result) return;
     var next = ev.relatedTarget;
     while (next && next !== document.documentElement) {
-      if (next === el) return;
+      if (next === result.target) return;
       next = next.parentElement;
     }
     hoveredId = null;
@@ -1144,11 +1156,11 @@ if (!fallback && allowDomFallback && meaningfulDomFallbackTarget(el)) fallback =
   }, true);
   document.addEventListener('click', function(ev){
     if (!pickerActive()) return;
-    var el = closestTarget(ev);
-    if (el) {
+    var result = closestTarget(ev);
+    if (result) {
       ev.preventDefault();
       ev.stopPropagation();
-      var payload = targetFrom(el, commentEnabled && mode === 'picker' && !inspectEnabled);
+      var payload = targetFrom(result.target, commentEnabled && mode === 'picker' && !inspectEnabled, result.clicked);
       if (payload) window.parent.postMessage(payload, '*');
       return;
     }

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -1217,6 +1217,37 @@ describe('FileViewer tweaks toolbar', () => {
     expect(screen.queryByPlaceholderText('Type anywhere to add a note')).toBeNull();
   });
 
+  it('shows an inspect notice when a clicked child resolves to an annotated ancestor', async () => {
+    render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
+        liveHtml='<html><body><main data-od-id="hero"><h1>Hero</h1></main></body></html>'
+      />,
+    );
+
+    const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    fireEvent.click(screen.getByTestId('inspect-mode-toggle'));
+
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: {
+        type: 'od:comment-target',
+        elementId: 'hero',
+        selector: '[data-od-id="hero"]',
+        label: 'main',
+        text: 'Hero',
+        style: {},
+        clickedDescendant: {
+          label: 'h1',
+          text: 'Hero',
+        },
+      },
+    }));
+
+    const notice = await screen.findByTestId('inspect-ancestor-notice');
+    expect(notice.textContent).toContain('You clicked h1');
+    expect(notice.textContent).toContain('Editing main instead');
+  });
+
   it('keeps the Draw bar open after queueing an annotation', () => {
     render(
       <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}

--- a/apps/web/tests/runtime/srcdoc-bridge-empty-targets.test.ts
+++ b/apps/web/tests/runtime/srcdoc-bridge-empty-targets.test.ts
@@ -171,6 +171,31 @@ describe('selection bridge — empty annotation surface (#890)', () => {
       .filter((message) => message?.type === 'od:comment-target');
     expect(clickMessages).toHaveLength(1);
     expect(clickMessages[0].elementId).toBe('hero');
+    expect(clickMessages[0].clickedDescendant).toEqual({
+      label: 'h1',
+      text: 'Hero',
+    });
+  });
+
+  it('does not add clickedDescendant when the annotated target itself is clicked', async () => {
+    const { win, parentPostMessage } = setupBridgeDom(
+      '<main data-od-id="hero">Hero</main>',
+      'inspect',
+    );
+
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 10));
+    parentPostMessage.mockClear();
+
+    win.document.querySelector('[data-od-id="hero"]')!.dispatchEvent(
+      new win.MouseEvent('click', { bubbles: true, cancelable: true }),
+    );
+
+    const clickMessages = parentPostMessage.mock.calls
+      .map((call) => call[0])
+      .filter((message) => message?.type === 'od:comment-target');
+    expect(clickMessages).toHaveLength(1);
+    expect(clickMessages[0].elementId).toBe('hero');
+    expect(clickMessages[0].clickedDescendant).toBeUndefined();
   });
 
   it('does not invent fallback targets in Inspect mode for unannotated elements', async () => {


### PR DESCRIPTION
Fixes #1022.\n\nThis refreshes the narrow Option 1 behavior from the earlier closed PR on top of current main:\n\n- Keeps Inspect persistence anchored to stable annotated selectors.\n- Changes the iframe selection bridge so a click payload can report both the clicked element and the resolved annotated ancestor.\n- Shows an Inspect panel notice when those differ, so users know they clicked an unannotated child but are editing the nearest annotated ancestor.\n- Preserves the existing DOM-selector fallback for Picker mode on fully unannotated pages.\n\nValidation run locally:\n\n- pnpm --filter @open-design/web typecheck\n- vitest tests/runtime/srcdoc-bridge-empty-targets.test.ts tests/components/FileViewer.test.tsx\n\nCredit to the prior #1099 discussion and implementation for the original shape; this PR ports the approach to current main and adds focused coverage for the current bridge behavior.