### PR TITLE
feat(daemon): consume component manifests

### DIFF
--- a/apps/daemon/src/design-systems.ts
+++ b/apps/daemon/src/design-systems.ts
@@ -6,6 +6,11 @@
 import { readdir, readFile, stat } from 'node:fs/promises';
 import path from 'node:path';
 
+import {
+  extractComponentsManifest,
+  summarizeComponentsManifestForPrompt,
+} from '@open-design/contracts';
+
 export type DesignSystemSurface = 'web' | 'image' | 'video' | 'audio';
 
 export type DesignSystemSummary = {
@@ -73,10 +78,14 @@ export async function readDesignSystem(root: string, id: string): Promise<string
  *
  * - `tokensCss`     — verbatim content of `<brand>/tokens.css`.
  * - `fixtureHtml`   — verbatim content of `<brand>/components.html`.
+ * - `componentsManifest` — concise summary derived from components.html
+ *                          for prompt injection; when absent, callers
+ *                          can fall back to `fixtureHtml`.
  */
 export type DesignSystemAssets = {
   tokensCss?: string | undefined;
   fixtureHtml?: string | undefined;
+  componentsManifest?: string | undefined;
 };
 
 export async function readDesignSystemAssets(
@@ -87,7 +96,7 @@ export async function readDesignSystemAssets(
     readFileOptional(path.join(root, id, 'tokens.css')),
     readFileOptional(path.join(root, id, 'components.html')),
   ]);
-  return { tokensCss, fixtureHtml };
+  return withComponentsManifest(id, { tokensCss, fixtureHtml });
 }
 
 /**
@@ -154,10 +163,42 @@ export async function resolveDesignSystemAssets(
   }
 
   const userInstalled = await readDesignSystemAssets(userInstalledRoot, designSystemId);
-  return {
+  return withComponentsManifest(designSystemId, {
     tokensCss: builtIn.tokensCss ?? userInstalled.tokensCss,
     fixtureHtml: builtIn.fixtureHtml ?? userInstalled.fixtureHtml,
-  };
+  });
+}
+
+function withComponentsManifest(
+  designSystemId: string,
+  assets: Pick<DesignSystemAssets, 'tokensCss' | 'fixtureHtml'>,
+): DesignSystemAssets {
+  const componentsManifest = buildComponentsManifestSummary(
+    designSystemId,
+    assets.fixtureHtml,
+    assets.tokensCss,
+  );
+  return { ...assets, componentsManifest };
+}
+
+function buildComponentsManifestSummary(
+  designSystemId: string,
+  fixtureHtml: string | undefined,
+  tokensCss: string | undefined,
+): string | undefined {
+  if (fixtureHtml === undefined || fixtureHtml.trim().length === 0) {
+    return undefined;
+  }
+
+  try {
+    const manifest =
+      tokensCss === undefined
+        ? extractComponentsManifest({ brandId: designSystemId, fixtureHtml })
+        : extractComponentsManifest({ brandId: designSystemId, fixtureHtml, tokensCss });
+    return summarizeComponentsManifestForPrompt(manifest);
+  } catch {
+    return undefined;
+  }
 }
 
 async function readFileOptional(file: string): Promise<string | undefined> {

--- a/apps/daemon/src/prompts/system.ts
+++ b/apps/daemon/src/prompts/system.ts
@@ -185,10 +185,13 @@ export interface ComposeInput {
   // - `designSystemTokensCss`    — verbatim `tokens.css` :root contract
   //                                that the agent pastes into the
   //                                artifact's <style>.
-  // - `designSystemFixtureHtml`  — verbatim `components.html` reference
-  //                                fixture demonstrating button / card /
-  //                                type-scale shapes wired to the tokens.
+  // - `designSystemComponentsManifest` — concise structured summary
+  //                                      derived from components.html.
+  // - `designSystemFixtureHtml`        — verbatim `components.html`
+  //                                      fallback when no manifest can
+  //                                      be derived.
   designSystemTokensCss?: string | undefined;
+  designSystemComponentsManifest?: string | undefined;
   designSystemFixtureHtml?: string | undefined;
   // Craft references the active skill opted into via `od.craft.requires`.
   // The daemon resolves the slug list to file contents and concatenates
@@ -271,6 +274,7 @@ export function composeSystemPrompt({
   designSystemBody,
   designSystemTitle,
   designSystemTokensCss,
+  designSystemComponentsManifest,
   designSystemFixtureHtml,
   craftBody,
   craftSections,
@@ -348,18 +352,23 @@ export function composeSystemPrompt({
   // sets voice and intent; the tokens.css block below is the SAME
   // contract in machine-readable form — names + values the agent pastes
   // verbatim instead of re-deriving from prose. The components.html
-  // fixture grounds the token vocabulary in worked component shapes
-  // (button / card / type roles) so the agent can copy fragments
-  // directly. Both blocks are individually gated: missing files (today,
-  // every brand except `default` and `kami`) skip silently, preserving
-  // the legacy DESIGN.md-only behaviour for the other ~138 brands.
+  // manifest grounds the token vocabulary in worked component shapes
+  // (button / card / type roles) without injecting the full HTML fixture.
+  // If manifest extraction fails or is unavailable, the composer falls
+  // back to the verbatim components.html fixture. Both blocks are
+  // individually gated: missing files skip silently, preserving the
+  // legacy DESIGN.md-only behaviour for prose-only brands.
   if (designSystemTokensCss && designSystemTokensCss.trim().length > 0) {
     parts.push(
       `\n\n## Active design system tokens${designSystemTitle ? ` — ${designSystemTitle}` : ''}\n\nThe block below is this brand's tokens.css contract — every \`:root\` custom property and any scoped override (e.g. \`:root[lang=...]\`) the brand defines. **Paste the unscoped \`:root { ... }\` block verbatim into the artifact's first \`<style>\`** so every \`var(--*)\` reference resolves at runtime.\n\nDo not invent new tokens. Do not redefine these values. Do not write raw hex outside this :root block. The DESIGN.md above is prose; this is the binding contract.\n\n\`\`\`css\n${designSystemTokensCss.trim()}\n\`\`\``,
     );
   }
 
-  if (designSystemFixtureHtml && designSystemFixtureHtml.trim().length > 0) {
+  if (designSystemComponentsManifest && designSystemComponentsManifest.trim().length > 0) {
+    parts.push(
+      `\n\n## Reference component manifest${designSystemTitle ? ` — ${designSystemTitle}` : ''}\n\nA compact structured summary derived from this brand's components.html fixture. Use it as the component inventory for generated artifacts: match the listed selectors, component groups, class names, token references, focus behavior, and spacing cadence. Prefer these manifest entries over inventing new component shapes.\n\n\`\`\`text\n${designSystemComponentsManifest.trim()}\n\`\`\``,
+    );
+  } else if (designSystemFixtureHtml && designSystemFixtureHtml.trim().length > 0) {
     parts.push(
       `\n\n## Reference fixture${designSystemTitle ? ` — ${designSystemTitle}` : ''}\n\nA self-contained worked artifact in this design system. Match its component shapes (button structure, card structure, type-scale rhythm, focus ring, spacing cadence) when generating new artifacts. Copying fragments is encouraged as long as you keep the \`var(--*)\` references intact — they are already wired to the tokens above.\n\n\`\`\`html\n${designSystemFixtureHtml.trim()}\n\`\`\``,
     );

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -7759,7 +7759,8 @@ export async function startServer({
 
     let designSystemBody;
     let designSystemTitle;
-    // Compiled (tokens.css + components.html) form of the active brand.
+    // Compiled (tokens.css + components manifest / components.html)
+    // form of the active brand.
     // Default-on as of PR-D — every chat that picks a brand with
     // `tokens.css` + `components.html` siblings (today: `default` and
     // `kami`; every other brand falls through silently because the
@@ -7772,6 +7773,7 @@ export async function startServer({
     // `true`, etc.) keeps the new default. Drift on prose-only brands
     // is pinned by `scripts/check-design-system-flag-parity.ts`.
     let designSystemTokensCss;
+    let designSystemComponentsManifest;
     let designSystemFixtureHtml;
     if (effectiveDesignSystemId) {
       const systems = await listAllDesignSystems();
@@ -7791,6 +7793,7 @@ export async function startServer({
         USER_DESIGN_SYSTEMS_DIR,
       );
       designSystemTokensCss = assets.tokensCss;
+      designSystemComponentsManifest = assets.componentsManifest;
       designSystemFixtureHtml = assets.fixtureHtml;
     }
 
@@ -7946,6 +7949,7 @@ export async function startServer({
       designSystemBody,
       designSystemTitle,
       designSystemTokensCss,
+      designSystemComponentsManifest,
       designSystemFixtureHtml,
       craftBody,
       craftSections,

--- a/apps/daemon/tests/design-system-assets.test.ts
+++ b/apps/daemon/tests/design-system-assets.test.ts
@@ -43,6 +43,7 @@ describe('readDesignSystemAssets', () => {
     const assets = await readDesignSystemAssets(root, 'sample');
     expect(assets.tokensCss).toContain('--bg: #fff');
     expect(assets.fixtureHtml).toContain('fixture');
+    expect(assets.componentsManifest).toContain('components.manifest schema v1 for sample');
   });
 
   it('returns the single field that exists when its sibling is missing (per-file independence)', async () => {
@@ -60,6 +61,7 @@ describe('readDesignSystemAssets', () => {
     const fixtureOnly = await readDesignSystemAssets(root, 'fixture-only');
     expect(fixtureOnly.tokensCss).toBeUndefined();
     expect(fixtureOnly.fixtureHtml).toBe('<p>only</p>');
+    expect(fixtureOnly.componentsManifest).toContain('components.manifest schema v1 for fixture-only');
   });
 
   it('returns an empty object when the brand directory has neither file', async () => {
@@ -179,6 +181,7 @@ describe('resolveDesignSystemAssets (PR-D server-layer asset resolution)', () =>
     const assets = await resolveDesignSystemAssets('sample', builtInRoot, userRoot, {});
     expect(assets.tokensCss).toBe(':root { --bg: #fff; }');
     expect(assets.fixtureHtml).toBe('<button>btn</button>');
+    expect(assets.componentsManifest).toContain('Buttons and calls to action');
   });
 
   it('returns empty (kill switch) when OD_DESIGN_TOKEN_CHANNEL is `0`, even if files are on disk', async () => {
@@ -193,6 +196,7 @@ describe('resolveDesignSystemAssets (PR-D server-layer asset resolution)', () =>
     });
     expect(assets.tokensCss).toBeUndefined();
     expect(assets.fixtureHtml).toBeUndefined();
+    expect(assets.componentsManifest).toBeUndefined();
   });
 
   it('still returns the assets under the legacy explicit opt-in `OD_DESIGN_TOKEN_CHANNEL=1`', async () => {
@@ -207,6 +211,7 @@ describe('resolveDesignSystemAssets (PR-D server-layer asset resolution)', () =>
     });
     expect(assets.tokensCss).toContain('--bg: #fff');
     expect(assets.fixtureHtml).toContain('<button>');
+    expect(assets.componentsManifest).toContain('Buttons and calls to action');
   });
 
   it('falls back to user-installed root for files missing in built-in (per-file independence)', async () => {
@@ -220,6 +225,7 @@ describe('resolveDesignSystemAssets (PR-D server-layer asset resolution)', () =>
     const assets = await resolveDesignSystemAssets('split', builtInRoot, userRoot, {});
     expect(assets.tokensCss).toBe(':root { --bg: built-in; }');
     expect(assets.fixtureHtml).toBe('<from-user-installed/>');
+    expect(assets.componentsManifest).toContain('components.manifest schema v1 for split');
   });
 
   it('returns the built-in assets verbatim when both files are present built-in (skips the user-installed roundtrip)', async () => {
@@ -237,6 +243,7 @@ describe('resolveDesignSystemAssets (PR-D server-layer asset resolution)', () =>
     const assets = await resolveDesignSystemAssets('sample', builtInRoot, userRoot, {});
     expect(assets.tokensCss).toBe(':root { --bg: built-in; }');
     expect(assets.fixtureHtml).toBe('<from-built-in/>');
+    expect(assets.componentsManifest).toContain('components.manifest schema v1 for sample');
   });
 
   it('returns undefined for both fields when the brand ships neither file in either root (legacy ~138-brand fallback)', async () => {
@@ -247,6 +254,7 @@ describe('resolveDesignSystemAssets (PR-D server-layer asset resolution)', () =>
     const assets = await resolveDesignSystemAssets('prose-only', builtInRoot, userRoot, {});
     expect(assets.tokensCss).toBeUndefined();
     expect(assets.fixtureHtml).toBeUndefined();
+    expect(assets.componentsManifest).toBeUndefined();
   });
 
   it('returns undefined for both fields when the brand directory does not exist in either root', async () => {
@@ -256,5 +264,6 @@ describe('resolveDesignSystemAssets (PR-D server-layer asset resolution)', () =>
     const assets = await resolveDesignSystemAssets('nonexistent', builtInRoot, userRoot, {});
     expect(assets.tokensCss).toBeUndefined();
     expect(assets.fixtureHtml).toBeUndefined();
+    expect(assets.componentsManifest).toBeUndefined();
   });
 });

--- a/apps/daemon/tests/prompts/system.test.ts
+++ b/apps/daemon/tests/prompts/system.test.ts
@@ -305,6 +305,8 @@ describe('composeSystemPrompt', () => {
   describe('design-system token + fixture injection (#PR-C)', () => {
     const sampleTokensCss = ':root {\n  --bg: #ffffff;\n  --fg: #111111;\n  --accent: #0050d8;\n}';
     const sampleFixtureHtml = '<!doctype html>\n<html lang="en">\n  <body><button class="btn btn-primary">Subscribe</button></body>\n</html>';
+    const sampleComponentsManifest =
+      'components.manifest schema v1 for default\nAvailable component groups:\n- Buttons and calls to action: selectors .btn, .btn-primary; tokens --accent';
 
     it('appends BOTH a tokens block and a fixture block when both inputs are present', () => {
       const prompt = composeSystemPrompt({
@@ -323,6 +325,22 @@ describe('composeSystemPrompt', () => {
       expect(prompt).toContain('class="btn btn-primary"');
     });
 
+    it('prefers the component manifest over the full fixture when both are present', () => {
+      const prompt = composeSystemPrompt({
+        designSystemTitle: 'default',
+        designSystemBody: '# Neutral Modern\n\n> Category: Utility\n\nProse description.',
+        designSystemTokensCss: sampleTokensCss,
+        designSystemComponentsManifest: sampleComponentsManifest,
+        designSystemFixtureHtml: sampleFixtureHtml,
+      });
+
+      expect(prompt).toContain('## Reference component manifest — default');
+      expect(prompt).toContain('components.manifest schema v1 for default');
+      expect(prompt).toContain('Buttons and calls to action');
+      expect(prompt).not.toContain('## Reference fixture — default');
+      expect(prompt).not.toContain('class="btn btn-primary"');
+    });
+
     it('keeps the prompt byte-equivalent to the legacy path when both inputs are omitted', () => {
       const baseline = composeSystemPrompt({
         designSystemTitle: 'default',
@@ -332,11 +350,13 @@ describe('composeSystemPrompt', () => {
         designSystemTitle: 'default',
         designSystemBody: '# Neutral Modern\n\nProse only.',
         designSystemTokensCss: undefined,
+        designSystemComponentsManifest: undefined,
         designSystemFixtureHtml: undefined,
       });
 
       expect(withFlagOffEquivalent).toBe(baseline);
       expect(withFlagOffEquivalent).not.toContain('## Active design system tokens');
+      expect(withFlagOffEquivalent).not.toContain('## Reference component manifest');
       expect(withFlagOffEquivalent).not.toContain('## Reference fixture');
     });
 
@@ -356,18 +376,27 @@ describe('composeSystemPrompt', () => {
       });
       expect(fixtureOnly).not.toContain('## Active design system tokens');
       expect(fixtureOnly).toContain('## Reference fixture — default');
+
+      const manifestOnly = composeSystemPrompt({
+        designSystemTitle: 'default',
+        designSystemBody: '# x\n\nbody',
+        designSystemComponentsManifest: sampleComponentsManifest,
+      });
+      expect(manifestOnly).not.toContain('## Active design system tokens');
+      expect(manifestOnly).toContain('## Reference component manifest — default');
     });
 
-    it('places the tokens + fixture blocks AFTER the DESIGN.md prose block (prose sets voice, structured form binds names)', () => {
+    it('places the tokens + component manifest blocks AFTER the DESIGN.md prose block (prose sets voice, structured form binds names)', () => {
       const prompt = composeSystemPrompt({
         designSystemTitle: 'default',
         designSystemBody: 'PROSE_BODY_MARKER',
         designSystemTokensCss: sampleTokensCss,
+        designSystemComponentsManifest: sampleComponentsManifest,
         designSystemFixtureHtml: sampleFixtureHtml,
       });
       const proseAt = prompt.indexOf('PROSE_BODY_MARKER');
       const tokensAt = prompt.indexOf('## Active design system tokens');
-      const fixtureAt = prompt.indexOf('## Reference fixture');
+      const fixtureAt = prompt.indexOf('## Reference component manifest');
       expect(proseAt).toBeGreaterThan(0);
       expect(tokensAt).toBeGreaterThan(proseAt);
       expect(fixtureAt).toBeGreaterThan(tokensAt);
@@ -378,9 +407,11 @@ describe('composeSystemPrompt', () => {
         designSystemTitle: 'default',
         designSystemBody: '# x\n\nbody',
         designSystemTokensCss: '   \n  \t  ',
+        designSystemComponentsManifest: '\n\t',
         designSystemFixtureHtml: '\n\n',
       });
       expect(prompt).not.toContain('## Active design system tokens');
+      expect(prompt).not.toContain('## Reference component manifest');
       expect(prompt).not.toContain('## Reference fixture');
     });
   });

--- a/packages/contracts/src/design-systems/components-manifest.ts
+++ b/packages/contracts/src/design-systems/components-manifest.ts
@@ -1,0 +1,450 @@
+export const COMPONENTS_MANIFEST_SCHEMA_VERSION = 1 as const;
+
+export type ComponentsManifestSchemaVersion = typeof COMPONENTS_MANIFEST_SCHEMA_VERSION;
+
+export type ComponentManifestGroupId =
+  | 'buttons'
+  | 'inputs'
+  | 'cards'
+  | 'badges'
+  | 'links'
+  | 'keyboard'
+  | 'icons'
+  | 'typography'
+  | 'layout';
+
+export type ComponentManifestGroup = {
+  id: ComponentManifestGroupId;
+  label: string;
+  present: boolean;
+  selectors: string[];
+  classes: string[];
+  elements: string[];
+  tokenReferences: string[];
+};
+
+export type ComponentManifestLiteralInventory = {
+  colorExpressions: number;
+  pixelValues: number;
+  hardcodedFontFamilies: number;
+};
+
+export type ComponentsManifest = {
+  schemaVersion: ComponentsManifestSchemaVersion;
+  brandId: string;
+  source: {
+    componentsHtml: 'components.html';
+    tokensCss?: 'tokens.css';
+  };
+  fixture: {
+    title?: string;
+    description?: string;
+    styleBlockCount: number;
+    selectorCount: number;
+    classCount: number;
+    elementCount: number;
+  };
+  tokens: {
+    declared: string[];
+    referenced: string[];
+    unusedDeclared: string[];
+    undeclaredReferenced: string[];
+  };
+  selectors: string[];
+  classes: string[];
+  elements: string[];
+  groups: ComponentManifestGroup[];
+  literals: ComponentManifestLiteralInventory;
+};
+
+export type ExtractComponentsManifestInput = {
+  brandId: string;
+  fixtureHtml: string;
+  tokensCss?: string;
+};
+
+type ComponentGroupDefinition = {
+  id: ComponentManifestGroupId;
+  label: string;
+  selectorMatchers: RegExp[];
+  classMatchers: RegExp[];
+  elementMatchers: RegExp[];
+};
+
+const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
+  {
+    id: 'buttons',
+    label: 'Buttons and calls to action',
+    selectorMatchers: [/\bbutton\b/i, /\.btn(?:\b|[-_:])/i, /\[type=["']?(?:button|submit|reset)/i],
+    classMatchers: [/^btn(?:$|-)/i, /button/i, /cta/i],
+    elementMatchers: [/^button$/i],
+  },
+  {
+    id: 'inputs',
+    label: 'Form fields and controls',
+    selectorMatchers: [/\binput\b/i, /\btextarea\b/i, /\bselect\b/i, /\.field(?:\b|[-_:])/i, /\blabel\b/i],
+    classMatchers: [/^field(?:$|-)/i, /input/i, /control/i, /form/i],
+    elementMatchers: [/^(input|textarea|select|label|form)$/i],
+  },
+  {
+    id: 'cards',
+    label: 'Cards and panels',
+    selectorMatchers: [/\.card(?:\b|[-_:])/i, /\.panel(?:\b|[-_:])/i, /\.tile(?:\b|[-_:])/i],
+    classMatchers: [/^card(?:$|-)/i, /^panel(?:$|-)/i, /^tile(?:$|-)/i],
+    elementMatchers: [],
+  },
+  {
+    id: 'badges',
+    label: 'Badges, chips, and status labels',
+    selectorMatchers: [/\.badge(?:\b|[-_:])/i, /\.chip(?:\b|[-_:])/i, /\.tag(?:\b|[-_:])/i, /\.pill(?:\b|[-_:])/i],
+    classMatchers: [/^badge(?:$|-)/i, /^chip(?:$|-)/i, /^tag(?:$|-)/i, /^pill(?:$|-)/i, /status/i],
+    elementMatchers: [],
+  },
+  {
+    id: 'links',
+    label: 'Links and inline actions',
+    selectorMatchers: [/\ba\b/i, /\.link(?:\b|[-_:])/i],
+    classMatchers: [/^link(?:$|-)/i],
+    elementMatchers: [/^a$/i],
+  },
+  {
+    id: 'keyboard',
+    label: 'Keyboard hints',
+    selectorMatchers: [/\bkbd\b/i, /\.kbd(?:\b|[-_:])/i],
+    classMatchers: [/^kbd(?:$|-)/i, /keyboard/i, /shortcut/i],
+    elementMatchers: [/^kbd$/i],
+  },
+  {
+    id: 'icons',
+    label: 'Icon slots',
+    selectorMatchers: [/\.icon(?:\b|[-_:])/i, /\[aria-hidden=["']true["']\]/i],
+    classMatchers: [/^icon(?:$|-)/i],
+    elementMatchers: [/^svg$/i],
+  },
+  {
+    id: 'typography',
+    label: 'Typography scale and text utilities',
+    selectorMatchers: [/\bh[1-6]\b/i, /\.lead(?:\b|[-_:])/i, /\.eyebrow(?:\b|[-_:])/i, /\.body-(?:muted|sm|small)\b/i],
+    classMatchers: [/^lead$/i, /^eyebrow$/i, /^body-(?:muted|sm|small)$/i, /caption/i],
+    elementMatchers: [/^h[1-6]$/i, /^p$/i],
+  },
+  {
+    id: 'layout',
+    label: 'Layout primitives',
+    selectorMatchers: [
+      /\.container(?:\b|[-_:])/i,
+      /\.stack-\d+\b/i,
+      /\.row-(?:between|center|start|end)\b/i,
+      /\bsection\b/i,
+      /\bmain\b/i,
+      /\bnav\b/i,
+    ],
+    classMatchers: [/^container$/i, /^stack-\d+$/i, /^row-(?:between|center|start|end)$/i, /grid/i, /layout/i],
+    elementMatchers: [/^(main|section|nav|header|footer)$/i],
+  },
+];
+
+export function extractComponentsManifest({
+  brandId,
+  fixtureHtml,
+  tokensCss,
+}: ExtractComponentsManifestInput): ComponentsManifest {
+  const styleBlocks = extractStyleBlocks(fixtureHtml);
+  const css = styleBlocks.join('\n\n');
+  const selectors = extractCssSelectors(css);
+  const selectorTokenReferences = extractSelectorTokenReferences(css);
+  const classes = extractHtmlClasses(fixtureHtml);
+  const elements = extractHtmlElements(fixtureHtml);
+  const declaredTokens = parseTokenNames(tokensCss ?? extractFirstRootBody(css) ?? '');
+  const referencedTokens = extractTokenReferences(fixtureHtml);
+
+  return {
+    schemaVersion: COMPONENTS_MANIFEST_SCHEMA_VERSION,
+    brandId,
+    source:
+      tokensCss === undefined
+        ? { componentsHtml: 'components.html' }
+        : { componentsHtml: 'components.html', tokensCss: 'tokens.css' },
+    fixture: {
+      ...optionalText('title', extractTitle(fixtureHtml)),
+      ...optionalText('description', extractMetaDescription(fixtureHtml)),
+      styleBlockCount: styleBlocks.length,
+      selectorCount: selectors.length,
+      classCount: classes.length,
+      elementCount: elements.length,
+    },
+    tokens: {
+      declared: declaredTokens,
+      referenced: referencedTokens,
+      unusedDeclared: declaredTokens.filter((token) => !referencedTokens.includes(token)),
+      undeclaredReferenced:
+        declaredTokens.length === 0 ? [] : referencedTokens.filter((token) => !declaredTokens.includes(token)),
+    },
+    selectors,
+    classes,
+    elements,
+    groups: COMPONENT_GROUPS.map((definition) =>
+      buildGroupManifest(definition, {
+        selectors,
+        selectorTokenReferences,
+        classes,
+        elements,
+        referencedTokens,
+      }),
+    ),
+    literals: countLiterals(stripRootBlocks(stripCssComments(css))),
+  };
+}
+
+export function summarizeComponentsManifestForPrompt(manifest: ComponentsManifest): string {
+  const presentGroups = manifest.groups
+    .filter((group) => group.present)
+    .map((group) => {
+      const selectors = group.selectors.slice(0, 8).join(', ') || 'none';
+      const tokens = group.tokenReferences.slice(0, 10).join(', ') || 'none';
+      return `- ${group.label}: selectors ${selectors}; tokens ${tokens}`;
+    });
+
+  return [
+    `components.manifest schema v${manifest.schemaVersion} for ${manifest.brandId}`,
+    `Fixture: ${manifest.fixture.selectorCount} selectors, ${manifest.fixture.classCount} classes, ${manifest.tokens.declared.length} declared tokens, ${manifest.tokens.referenced.length} referenced tokens.`,
+    'Available component groups:',
+    ...(presentGroups.length > 0 ? presentGroups : ['- none detected']),
+  ].join('\n');
+}
+
+function buildGroupManifest(
+  definition: ComponentGroupDefinition,
+  inventory: {
+    selectors: string[];
+    selectorTokenReferences: Map<string, string[]>;
+    classes: string[];
+    elements: string[];
+    referencedTokens: string[];
+  },
+): ComponentManifestGroup {
+  const selectors = inventory.selectors.filter((selector) =>
+    definition.selectorMatchers.some((matcher) => matcher.test(selector)),
+  );
+  const classes = inventory.classes.filter((className) =>
+    definition.classMatchers.some((matcher) => matcher.test(className)),
+  );
+  const elements = inventory.elements.filter((element) =>
+    definition.elementMatchers.some((matcher) => matcher.test(element)),
+  );
+  const tokenReferences = uniqueSorted(
+    selectors.flatMap((selector) => inventory.selectorTokenReferences.get(selector) ?? []),
+  );
+
+  return {
+    id: definition.id,
+    label: definition.label,
+    present: selectors.length > 0 || classes.length > 0 || elements.length > 0,
+    selectors,
+    classes,
+    elements,
+    tokenReferences: tokenReferences.filter((token) => inventory.referencedTokens.includes(token)),
+  };
+}
+
+function extractStyleBlocks(html: string): string[] {
+  const blocks: string[] = [];
+  const stylePattern = /<style\b[^>]*>([\s\S]*?)<\/style>/gi;
+  let match: RegExpExecArray | null;
+  while ((match = stylePattern.exec(html)) !== null) {
+    blocks.push((match[1] ?? '').trim());
+  }
+  return blocks;
+}
+
+function extractCssSelectors(css: string): string[] {
+  const selectors = new Set<string>();
+  const commentlessCss = stripContainerAtRuleHeaders(stripCssComments(css));
+  const selectorPattern = /(?:^|[{}])\s*([^@{}][^{}]*?)\s*\{/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = selectorPattern.exec(commentlessCss)) !== null) {
+    const rawSelectorList = match[1]?.trim();
+    if (rawSelectorList == null || rawSelectorList.length === 0) continue;
+    if (rawSelectorList.includes(':root')) continue;
+    if (/^(?:from|to|\d+(?:\.\d+)?%)$/i.test(rawSelectorList)) continue;
+
+    for (const selector of splitSelectorList(rawSelectorList)) {
+      const normalized = normalizeSelector(selector);
+      if (normalized.length > 0 && !normalized.startsWith('@')) {
+        selectors.add(normalized);
+      }
+    }
+  }
+
+  return [...selectors].sort((a, b) => a.localeCompare(b));
+}
+
+function extractSelectorTokenReferences(css: string): Map<string, string[]> {
+  const referencesBySelector = new Map<string, Set<string>>();
+  const commentlessCss = stripContainerAtRuleHeaders(stripCssComments(css));
+  const rulePattern = /(?:^|[{}])\s*([^@{}][^{}]*?)\s*\{([^{}]*)\}/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = rulePattern.exec(commentlessCss)) !== null) {
+    const rawSelectorList = match[1]?.trim();
+    const rawBody = match[2] ?? '';
+    if (rawSelectorList == null || rawSelectorList.length === 0) continue;
+    if (rawSelectorList.includes(':root')) continue;
+    if (/^(?:from|to|\d+(?:\.\d+)?%)$/i.test(rawSelectorList)) continue;
+
+    const tokenReferences = extractTokenReferences(rawBody);
+    if (tokenReferences.length === 0) continue;
+
+    for (const selector of splitSelectorList(rawSelectorList)) {
+      const normalized = normalizeSelector(selector);
+      if (normalized.length === 0 || normalized.startsWith('@')) continue;
+      const selectorReferences = referencesBySelector.get(normalized) ?? new Set<string>();
+      for (const token of tokenReferences) {
+        selectorReferences.add(token);
+      }
+      referencesBySelector.set(normalized, selectorReferences);
+    }
+  }
+
+  return new Map(
+    [...referencesBySelector.entries()]
+      .map(([selector, references]) => [selector, [...references].sort((a, b) => a.localeCompare(b))] as const)
+      .sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+function splitSelectorList(selectorList: string): string[] {
+  const selectors: string[] = [];
+  let depth = 0;
+  let start = 0;
+
+  for (let index = 0; index < selectorList.length; index += 1) {
+    const char = selectorList[index];
+    if (char === '(' || char === '[') {
+      depth += 1;
+      continue;
+    }
+    if (char === ')' || char === ']') {
+      depth = Math.max(0, depth - 1);
+      continue;
+    }
+    if (char === ',' && depth === 0) {
+      selectors.push(selectorList.slice(start, index));
+      start = index + 1;
+    }
+  }
+
+  selectors.push(selectorList.slice(start));
+  return selectors;
+}
+
+function normalizeSelector(selector: string): string {
+  return selector.trim().replace(/\s+/g, ' ');
+}
+
+function extractHtmlClasses(html: string): string[] {
+  const classes = new Set<string>();
+  const classPattern = /\bclass\s*=\s*(["'])(.*?)\1/gis;
+  let match: RegExpExecArray | null;
+  while ((match = classPattern.exec(html)) !== null) {
+    const classValue = match[2] ?? '';
+    for (const className of classValue.split(/\s+/)) {
+      if (className.length > 0) classes.add(className);
+    }
+  }
+  return [...classes].sort((a, b) => a.localeCompare(b));
+}
+
+function extractHtmlElements(html: string): string[] {
+  const elements = new Set<string>();
+  const elementPattern = /<\s*([a-z][a-z0-9-]*)\b/gi;
+  let match: RegExpExecArray | null;
+  while ((match = elementPattern.exec(html)) !== null) {
+    const element = match[1]?.toLowerCase();
+    if (element == null || element.startsWith('!')) continue;
+    elements.add(element);
+  }
+  return [...elements].sort((a, b) => a.localeCompare(b));
+}
+
+function parseTokenNames(css: string): string[] {
+  const tokens = new Set<string>();
+  const tokenPattern = /(--[a-zA-Z0-9_-]+)\s*:/g;
+  let match: RegExpExecArray | null;
+  while ((match = tokenPattern.exec(stripCssComments(css))) !== null) {
+    const token = match[1];
+    if (token != null) tokens.add(token);
+  }
+  return [...tokens].sort((a, b) => a.localeCompare(b));
+}
+
+function extractTokenReferences(source: string): string[] {
+  const tokens = new Set<string>();
+  const tokenPattern = /var\(\s*(--[a-zA-Z0-9_-]+)/g;
+  let match: RegExpExecArray | null;
+  while ((match = tokenPattern.exec(source)) !== null) {
+    const token = match[1];
+    if (token != null) tokens.add(token);
+  }
+  return [...tokens].sort((a, b) => a.localeCompare(b));
+}
+
+function extractFirstRootBody(css: string): string | null {
+  return stripCssComments(css).match(/:root(?!\[)\s*\{([\s\S]*?)\}/)?.[1] ?? null;
+}
+
+function stripRootBlocks(css: string): string {
+  return css.replace(/:root(?:\[[^\]]+\])?\s*\{[\s\S]*?\}/g, '');
+}
+
+function stripCssComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+function stripContainerAtRuleHeaders(css: string): string {
+  return css.replace(/@(media|supports|container|layer)\b[^{]*\{/gi, '{');
+}
+
+function countLiterals(css: string): ComponentManifestLiteralInventory {
+  return {
+    colorExpressions: countMatches(
+      css,
+      /(?:#[0-9a-f]{3,8}\b|rgba?\([^)]*\)|hsla?\([^)]*\)|oklch\([^)]*\)|color-mix\([^)]*\))/gi,
+    ),
+    pixelValues: countMatches(css, /(?<![\w-])-?\d*\.?\d+px\b/g),
+    hardcodedFontFamilies: countMatches(css, /\bfont-family\s*:\s*(?!var\()/gi),
+  };
+}
+
+function countMatches(source: string, pattern: RegExp): number {
+  return [...source.matchAll(pattern)].length;
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values)].sort((a, b) => a.localeCompare(b));
+}
+
+function extractTitle(html: string): string | undefined {
+  const value = /<title\b[^>]*>([\s\S]*?)<\/title>/i.exec(html)?.[1]?.trim().replace(/\s+/g, ' ');
+  return value == null || value.length === 0 ? undefined : decodeBasicEntities(value);
+}
+
+function extractMetaDescription(html: string): string | undefined {
+  const match = /<meta\b(?=[^>]*\bname\s*=\s*["']description["'])(?=[^>]*\bcontent\s*=\s*(["'])([\s\S]*?)\1)[^>]*>/i.exec(html);
+  const value = match?.[2]?.trim().replace(/\s+/g, ' ');
+  return value == null || value.length === 0 ? undefined : decodeBasicEntities(value);
+}
+
+function decodeBasicEntities(value: string): string {
+  return value
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>');
+}
+
+function optionalText<Key extends string>(key: Key, value: string | undefined): Record<Key, string> | Record<string, never> {
+  return value === undefined ? {} : { [key]: value } as Record<Key, string>;
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -21,6 +21,7 @@ export * from './api/registry.js';
 export * from './api/research.js';
 export * from './api/version.js';
 export * from './examples.js';
+export * from './design-systems/components-manifest.js';
 export * from './sse/common.js';
 export * from './sse/chat.js';
 export * from './sse/proxy.js';

--- a/packages/contracts/tests/components-manifest.test.ts
+++ b/packages/contracts/tests/components-manifest.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractComponentsManifest, summarizeComponentsManifestForPrompt } from '../src/design-systems/components-manifest.js';
+
+describe('components manifest extraction', () => {
+  it('summarizes tokens, selectors, html classes, and component groups deterministically', () => {
+    const manifest = extractComponentsManifest({
+      brandId: 'sample',
+      tokensCss: ':root { --bg: #fff; --accent: #05f; --radius-md: 12px; }',
+      fixtureHtml: `
+        <!doctype html>
+        <html>
+          <head>
+            <title>Sample fixture</title>
+            <meta name="description" content="A compact fixture." />
+            <style>
+              :root { --bg: #fff; --accent: #05f; --radius-md: 12px; }
+              .btn, button {
+                color: var(--accent);
+                border-radius: var(--radius-md);
+              }
+              .card { background: var(--bg); }
+              .stack-4 { gap: 16px; }
+            </style>
+          </head>
+          <body>
+            <main class="stack-4">
+              <article class="card">
+                <button class="btn">Ship</button>
+              </article>
+            </main>
+          </body>
+        </html>
+      `,
+    });
+
+    expect(manifest.schemaVersion).toBe(1);
+    expect(manifest.fixture).toMatchObject({
+      title: 'Sample fixture',
+      description: 'A compact fixture.',
+      styleBlockCount: 1,
+      selectorCount: 4,
+      classCount: 3,
+    });
+    expect(manifest.tokens.declared).toEqual(['--accent', '--bg', '--radius-md']);
+    expect(manifest.tokens.referenced).toEqual(['--accent', '--bg', '--radius-md']);
+    expect(manifest.selectors).toEqual(['.btn', '.card', '.stack-4', 'button']);
+    expect(manifest.classes).toEqual(['btn', 'card', 'stack-4']);
+    expect(manifest.groups.find((group) => group.id === 'buttons')).toMatchObject({
+      present: true,
+      selectors: ['.btn', 'button'],
+      classes: ['btn'],
+      elements: ['button'],
+    });
+    expect(manifest.groups.find((group) => group.id === 'layout')).toMatchObject({
+      present: true,
+      selectors: ['.stack-4'],
+      classes: ['stack-4'],
+      elements: ['main'],
+    });
+    expect(manifest.literals.pixelValues).toBe(1);
+  });
+
+  it('can render a concise prompt summary from a manifest', () => {
+    const manifest = extractComponentsManifest({
+      brandId: 'sample',
+      fixtureHtml: '<style>.btn { color: var(--accent); }</style><button class="btn">Ship</button>',
+    });
+
+    expect(summarizeComponentsManifestForPrompt(manifest)).toContain('components.manifest schema v1 for sample');
+    expect(summarizeComponentsManifestForPrompt(manifest)).toContain('Buttons and calls to action');
+  });
+});

--- a/scripts/check-components-manifest-extraction.ts
+++ b/scripts/check-components-manifest-extraction.ts
@@ -1,0 +1,109 @@
+import { readFile, readdir } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  extractComponentsManifest,
+  summarizeComponentsManifestForPrompt,
+} from '../packages/contracts/src/design-systems/components-manifest.ts';
+
+const repoRoot = path.resolve(import.meta.dirname, '..');
+const designSystemsRoot = path.join(repoRoot, 'design-systems');
+const skippedDesignSystemDirectories = new Set(['_schema']);
+
+type BrandSources = {
+  id: string;
+  fixturePath: string;
+  tokensCss: string;
+  fixtureHtml: string;
+};
+
+export async function checkComponentsManifestExtraction(): Promise<boolean> {
+  const sources = await discoverBrandSources();
+  const violations: string[] = [];
+  let selectorCount = 0;
+  let groupCount = 0;
+
+  for (const source of sources) {
+    try {
+      const manifest = extractComponentsManifest({
+        brandId: source.id,
+        fixtureHtml: source.fixtureHtml,
+        tokensCss: source.tokensCss,
+      });
+      const summary = summarizeComponentsManifestForPrompt(manifest);
+
+      selectorCount += manifest.fixture.selectorCount;
+      groupCount += manifest.groups.filter((group) => group.present).length;
+
+      if (manifest.fixture.styleBlockCount === 0) {
+        violations.push(`[${source.id}] ${toRepositoryPath(source.fixturePath)} has no <style> blocks to summarize.`);
+      }
+      if (manifest.fixture.selectorCount === 0) {
+        violations.push(`[${source.id}] ${toRepositoryPath(source.fixturePath)} produced a manifest with zero CSS selectors.`);
+      }
+      if (!summary.includes(`components.manifest schema v${manifest.schemaVersion} for ${source.id}`)) {
+        violations.push(`[${source.id}] manifest summary is missing its schema/id header.`);
+      }
+    } catch (err) {
+      violations.push(
+        `[${source.id}] failed to extract manifest from ${toRepositoryPath(source.fixturePath)}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+
+  if (violations.length > 0) {
+    console.error('Design system component manifest extraction violations:');
+    for (const violation of violations) {
+      console.error(`- ${violation}`);
+    }
+    console.error('Every compiled design system must remain consumable through the structured component manifest path.');
+    return false;
+  }
+
+  console.log(
+    `Design system component manifest extraction passed: ${sources.length} fixtures summarized (${selectorCount} selectors across ${groupCount} present component groups).`,
+  );
+  return true;
+}
+
+async function discoverBrandSources(): Promise<BrandSources[]> {
+  const entries = await readdir(designSystemsRoot, { withFileTypes: true });
+  const sources: BrandSources[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() || skippedDesignSystemDirectories.has(entry.name)) continue;
+
+    const brandRoot = path.join(designSystemsRoot, entry.name);
+    const tokensPath = path.join(brandRoot, 'tokens.css');
+    const fixturePath = path.join(brandRoot, 'components.html');
+    const [tokensCss, fixtureHtml] = await Promise.all([
+      readFile(tokensPath, 'utf8'),
+      readFile(fixturePath, 'utf8'),
+    ]);
+    sources.push({
+      id: entry.name,
+      fixturePath,
+      tokensCss,
+      fixtureHtml,
+    });
+  }
+
+  return sources.sort((a, b) => a.id.localeCompare(b.id));
+}
+
+function toRepositoryPath(filePath: string): string {
+  return path.relative(repoRoot, filePath).split(path.sep).join('/');
+}
+
+const isMain = process.argv[1] === fileURLToPath(import.meta.url);
+if (isMain) {
+  checkComponentsManifestExtraction().then((passed) => {
+    process.exitCode = passed ? 0 : 1;
+  }, (err: unknown) => {
+    console.error(err);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/check-design-system-flag-parity.ts
+++ b/scripts/check-design-system-flag-parity.ts
@@ -182,6 +182,7 @@ export async function checkDesignSystemFlagParity(): Promise<boolean> {
       designSystemBody: brand.designMd,
       designSystemTitle: brand.title,
       designSystemTokensCss: brand.assets.tokensCss,
+      designSystemComponentsManifest: brand.assets.componentsManifest,
       designSystemFixtureHtml: brand.assets.fixtureHtml,
     });
 

--- a/scripts/extract-components-manifest.ts
+++ b/scripts/extract-components-manifest.ts
@@ -1,0 +1,168 @@
+import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  extractComponentsManifest,
+  summarizeComponentsManifestForPrompt,
+  type ComponentsManifest,
+} from '../packages/contracts/src/design-systems/components-manifest.ts';
+
+const repoRoot = path.resolve(import.meta.dirname, '..');
+const designSystemsRoot = path.join(repoRoot, 'design-systems');
+const skippedDesignSystemDirectories = new Set(['_schema']);
+
+type CliOptions = {
+  brandId?: string;
+  outPath?: string;
+  compact: boolean;
+  promptSummary: boolean;
+  help: boolean;
+};
+
+type ManifestCollection = {
+  schemaVersion: 1;
+  count: number;
+  manifests: ComponentsManifest[];
+};
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    console.log(usage());
+    return;
+  }
+
+  const brandIds = options.brandId === undefined ? await discoverBrandIds() : [options.brandId];
+  const manifests = await Promise.all(brandIds.map((brandId) => readManifest(brandId)));
+
+  const output = options.promptSummary
+    ? manifests.map((manifest) => summarizeComponentsManifestForPrompt(manifest)).join('\n\n')
+    : JSON.stringify(toCollection(manifests), null, options.compact ? 0 : 2);
+
+  if (options.outPath === undefined) {
+    console.log(output);
+    return;
+  }
+
+  const resolvedOutPath = path.resolve(repoRoot, options.outPath);
+  await mkdir(path.dirname(resolvedOutPath), { recursive: true });
+  await writeFile(resolvedOutPath, `${output}\n`, 'utf8');
+  console.log(
+    `Wrote ${manifests.length} component manifest${manifests.length === 1 ? '' : 's'} to ${toRepositoryPath(resolvedOutPath)}.`,
+  );
+}
+
+function parseArgs(args: string[]): CliOptions {
+  const options: CliOptions = {
+    compact: false,
+    promptSummary: false,
+    help: false,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+      continue;
+    }
+    if (arg === '--compact') {
+      options.compact = true;
+      continue;
+    }
+    if (arg === '--prompt-summary') {
+      options.promptSummary = true;
+      continue;
+    }
+    if (arg === '--brand' || arg === '--design-system') {
+      const value = args[index + 1];
+      if (value === undefined || value.startsWith('--')) {
+        throw new Error(`${arg} requires a design-system id.`);
+      }
+      options.brandId = value;
+      index += 1;
+      continue;
+    }
+    if (arg === '--out') {
+      const value = args[index + 1];
+      if (value === undefined || value.startsWith('--')) {
+        throw new Error('--out requires a path.');
+      }
+      options.outPath = value;
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}\n\n${usage()}`);
+  }
+
+  return options;
+}
+
+async function discoverBrandIds(): Promise<string[]> {
+  const entries = await readdir(designSystemsRoot, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isDirectory() && !skippedDesignSystemDirectories.has(entry.name))
+    .map((entry) => entry.name)
+    .sort((a, b) => a.localeCompare(b));
+}
+
+async function readManifest(brandId: string): Promise<ComponentsManifest> {
+  const brandRoot = path.join(designSystemsRoot, brandId);
+  const fixturePath = path.join(brandRoot, 'components.html');
+  const tokensPath = path.join(brandRoot, 'tokens.css');
+
+  const [fixtureHtml, tokensCss] = await Promise.all([readFile(fixturePath, 'utf8'), readOptionalFile(tokensPath)]);
+  return tokensCss === undefined
+    ? extractComponentsManifest({ brandId, fixtureHtml })
+    : extractComponentsManifest({ brandId, fixtureHtml, tokensCss });
+}
+
+async function readOptionalFile(filePath: string): Promise<string | undefined> {
+  try {
+    return await readFile(filePath, 'utf8');
+  } catch (err) {
+    if (isAbsenceError(err)) return undefined;
+    throw err;
+  }
+}
+
+function isAbsenceError(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false;
+  const code = (err as { code?: unknown }).code;
+  return code === 'ENOENT' || code === 'ENOTDIR';
+}
+
+function toCollection(manifests: ComponentsManifest[]): ManifestCollection {
+  return {
+    schemaVersion: 1,
+    count: manifests.length,
+    manifests,
+  };
+}
+
+function toRepositoryPath(filePath: string): string {
+  return path.relative(repoRoot, filePath).split(path.sep).join('/');
+}
+
+function usage(): string {
+  return [
+    'Usage: pnpm exec tsx scripts/extract-components-manifest.ts [options]',
+    '',
+    'Options:',
+    '  --brand <id>           Extract one design-system id instead of all ids.',
+    '  --design-system <id>   Alias for --brand.',
+    '  --out <path>           Write output under the repository root instead of stdout.',
+    '  --compact              Emit compact JSON when not using --prompt-summary.',
+    '  --prompt-summary       Emit the short text summary intended for agent prompts.',
+    '  --help                 Show this help text.',
+  ].join('\n');
+}
+
+const isMain = process.argv[1] === fileURLToPath(import.meta.url);
+if (isMain) {
+  main().catch((err: unknown) => {
+    console.error(err instanceof Error ? err.message : err);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/guard.ts
+++ b/scripts/guard.ts
@@ -2,6 +2,7 @@ import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
 
 import { checkDesignSystemFlagParity } from "./check-design-system-flag-parity.ts";
+import { checkComponentsManifestExtraction } from "./check-components-manifest-extraction.ts";
 import {
   checkDesignSystemA1RequiredTokens,
   checkDesignSystemA2DefaultsParity,
@@ -711,6 +712,7 @@ const checks: GuardCheck[] = [
   { name: "design system unknown token allowlist", run: checkDesignSystemUnknownTokens },
   { name: "design system A2 defaults parity", run: checkDesignSystemA2DefaultsParity },
   { name: "design system flag parity", run: checkDesignSystemFlagParity },
+  { name: "design system component manifest extraction", run: checkComponentsManifestExtraction },
 ];
 
 const results: boolean[] = [];


### PR DESCRIPTION
## Why

This is the productization step after #2051. The manifest extractor makes `components.html` structurally consumable, but the daemon still injected the full fixture HTML into agent prompts. I am opening this PR to switch the runtime path to the smaller structured component summary while preserving the existing fixture fallback.

The pain addressed is prompt mass and ad hoc consumption: agents should receive the component inventory, selectors, token references, and groups directly, with `components.html` remaining a safety net rather than the primary prompt payload.

Stacked on #2051; base branch is `codex/design-manifest-extractor`.

## What users will see

No UI changes. For projects with an active compiled design system, the daemon now injects `tokens.css` plus a `Reference component manifest` summary into the agent system prompt. If manifest extraction is unavailable, it falls back to the old full `Reference fixture` HTML block.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; no UI surface changed.

## Bug fix verification

Not a bug fix.

## Validation

- `pnpm exec tsx scripts/check-components-manifest-extraction.ts`
- `pnpm guard`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/design-system-assets.test.ts tests/prompts/system.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm typecheck`

Additional note: an accidental full daemon suite run completed 2547/2548 tests with one existing chat-route timing failure (`tests/chat-route.test.ts > keeps Claude stream runs alive while structured output is still flowing`). The targeted daemon tests above passed afterward.
