### PR TITLE
fix(deploy): follow sidebar anchor links to sibling .html pages

### DIFF
--- a/apps/daemon/src/deploy.ts
+++ b/apps/daemon/src/deploy.ts
@@ -316,6 +316,23 @@ export async function buildDeployFilePlan(projectsRoot: string, projectId: strin
         pending.push({ ref, base: cssBase });
       }
     }
+
+    if (/\.html?$/i.test(safePath)) {
+      // Transitively walk references inside a sibling HTML page.
+      // Without this, multi-page designs would deploy the sub-page
+      // markup but miss its CSS / JS / image dependencies (which may
+      // differ from the entry page's references). `visited` guards
+      // against cycles, and the deeper sibling-of-sibling links keep
+      // resolving through this same loop.
+      const htmlBase = path.posix.dirname(safePath);
+      const htmlSource = projectFile.buffer.toString('utf8');
+      for (const ref of extractHtmlReferences(htmlSource)) {
+        pending.push({ ref, base: htmlBase });
+      }
+      for (const ref of extractInlineCssReferences(htmlSource)) {
+        pending.push({ ref, base: htmlBase });
+      }
+    }
   }
 
   return {
@@ -1563,18 +1580,41 @@ function rewriteHtmlAttributes(rawAttrs: string, tagName: string, attrs: Map<str
 }
 
 function shouldCollectHref(tagName: string, attrs: Map<string, string>) {
-  if (tagName !== 'link') return false;
-  const rel = String(attrs.get('rel') || '').toLowerCase();
-  if (!rel) return false;
-  return rel.split(/\s+/).some((item) => (
-    item === 'stylesheet' ||
-    item === 'icon' ||
-    item === 'apple-touch-icon' ||
-    item === 'manifest' ||
-    item === 'preload' ||
-    item === 'modulepreload' ||
-    item === 'prefetch'
-  ));
+  if (tagName === 'link') {
+    const rel = String(attrs.get('rel') || '').toLowerCase();
+    if (!rel) return false;
+    return rel.split(/\s+/).some((item) => (
+      item === 'stylesheet' ||
+      item === 'icon' ||
+      item === 'apple-touch-icon' ||
+      item === 'manifest' ||
+      item === 'preload' ||
+      item === 'modulepreload' ||
+      item === 'prefetch'
+    ));
+  }
+  if (tagName === 'a') {
+    // Follow same-origin relative navigation to a sibling HTML page.
+    // Multi-page designs (admin consoles, decks with separate
+    // sub-pages, knowledge bases) declare their pages via these
+    // links, and without following them the deploy plan ships only
+    // the entry page — Cloudflare Pages then serves index.html as a
+    // SPA fallback for every other path, so every sidebar click looks
+    // like a no-op even though the link is correct.
+    //
+    // Strictly local references only: skip protocol URLs (`https:`,
+    // `mailto:`, `tel:`, `javascript:`), scheme-relative URLs (`//cdn`),
+    // hash anchors (`#section`), and non-HTML targets so external
+    // resources and SPA fragments don't get pulled into the deploy
+    // plan.
+    const href = String(attrs.get('href') || '');
+    if (!href) return false;
+    if (/^[a-z][a-z0-9+.-]*:/i.test(href)) return false;
+    if (href.startsWith('//')) return false;
+    if (href.startsWith('#')) return false;
+    return /\.html?(?:[?#]|$)/i.test(href);
+  }
+  return false;
 }
 
 function rewriteHtmlReference(raw: string, baseDir: string) {

--- a/apps/daemon/tests/deploy.test.ts
+++ b/apps/daemon/tests/deploy.test.ts
@@ -647,6 +647,66 @@ describe('deploy plan and analyzer', () => {
     expect(plan.invalid).toEqual([]);
   });
 
+  it('follows sidebar anchor links to sibling .html pages so multi-page admin designs ship complete', async () => {
+    // Reproduces the upstream user report: a generated admin console
+    // with a sidebar of <a href="dashboard.html">…</a> links deployed
+    // only the entry page. Every other sidebar click resolved to the
+    // host's SPA fallback (index.html) so the UI looked frozen.
+    const { projectsRoot, projectId, dir } = await setupProject();
+    await writeFile(
+      path.join(dir, 'index.html'),
+      [
+        '<!doctype html><meta name="viewport" content="width=device-width">',
+        '<aside class="sidebar">',
+        '  <a href="index.html">Overview</a>',
+        '  <a href="dashboard.html">Dashboard</a>',
+        '  <a href="users.html">Users</a>',
+        '  <a href="https://example.com/external">External</a>',  // not collected
+        '  <a href="mailto:hi@example.com">Mail</a>',              // not collected
+        '  <a href="#section">In-page</a>',                        // not collected
+        '</aside>',
+      ].join('\n'),
+    );
+    await writeFile(path.join(dir, 'dashboard.html'), '<!doctype html><h1>Dashboard</h1>');
+    await writeFile(path.join(dir, 'users.html'), '<!doctype html><h1>Users</h1>');
+
+    const plan = await buildDeployFilePlan(projectsRoot, projectId, 'index.html');
+    const filenames = plan.files.map((f) => f.file).sort();
+    expect(filenames).toContain('dashboard.html');
+    expect(filenames).toContain('users.html');
+    expect(plan.missing).toEqual([]);
+    expect(plan.invalid).toEqual([]);
+  });
+
+  it('transitively follows references inside sibling .html pages', async () => {
+    // A sibling page can pull in its own CSS / image / further sibling
+    // pages; those should land in the deploy plan too, otherwise the
+    // sibling renders unstyled or missing assets.
+    const { projectsRoot, projectId, dir } = await setupProject();
+    await writeFile(
+      path.join(dir, 'index.html'),
+      '<!doctype html><a href="dashboard.html">D</a>',
+    );
+    await writeFile(
+      path.join(dir, 'dashboard.html'),
+      '<!doctype html><link rel="stylesheet" href="assets/dashboard.css"><img src="assets/logo.png"><a href="reports.html">R</a>',
+    );
+    await writeFile(path.join(dir, 'reports.html'), '<!doctype html><h1>Reports</h1>');
+    await writeFile(path.join(dir, 'assets'), '');
+    // overwrite the placeholder with a real directory
+    await import('node:fs/promises').then((m) => m.rm(path.join(dir, 'assets')));
+    await import('node:fs/promises').then((m) => m.mkdir(path.join(dir, 'assets')));
+    await writeFile(path.join(dir, 'assets/dashboard.css'), 'body { background: #fff }');
+    await writeFile(path.join(dir, 'assets/logo.png'), 'fake-png');
+
+    const plan = await buildDeployFilePlan(projectsRoot, projectId, 'index.html');
+    const filenames = plan.files.map((f) => f.file).sort();
+    expect(filenames).toContain('dashboard.html');
+    expect(filenames).toContain('reports.html');
+    expect(filenames).toContain('assets/dashboard.css');
+    expect(filenames).toContain('assets/logo.png');
+  });
+
   it('flags missing assets as broken-reference warnings', () => {
     const { warnings } = analyzeDeployPlan({
       entryPath: 'index.html',


### PR DESCRIPTION
## Why

`buildDeployFilePlan` in `apps/daemon/src/deploy.ts` doesn't follow sibling `.html` pages when building the upload set for a multi-page design:

1. `shouldCollectHref` only accepts `<link>` tags (stylesheet / icon / preload rels). `<a href>` is hard-rejected, so sibling page references like `<a href="dashboard.html">` are dropped before the walk sees them.
2. The transitive walk re-extracts references for `.css` files but not for `.html` files, so even a sibling page that makes it in has its own asset/nested-page references silently skipped.

Symptom: only the entry page ships. A SPA-fallback host then serves the entry HTML for every other path, so sidebar navigation appears frozen even though every link target is correct.

## The change

**Fix 1** — `shouldCollectHref` accepts `<a>` targets that look like same-origin relative navigation to a sibling HTML page. Strict filter: protocol URLs (`https:`, `mailto:`, …), scheme-relative URLs (`//cdn`), hash anchors (`#section`), and non-HTML extensions are still rejected, so external links and SPA fragments stay out of the plan.

**Fix 2** — the pending-queue loop now extracts `<script src>` / `<link>` / `<img src>` / inline `style="…"` references from sibling HTML pages, mirroring the existing behavior for CSS. `visited` guards against link cycles.

Single-page designs see no behavior change.

## Surface area

- [x] **API / contract** — internal change in deploy plan logic; deploy file set may be larger than before for multi-page designs. No public contract changes.

## Bug fix verification

- **Test path**: `apps/daemon/tests/deploy.test.ts`
- New cases in `describe('deploy plan and analyzer')`:
  - `'follows sidebar anchor links to sibling .html pages so multi-page admin designs ship complete'` — verifies sibling pages land in the plan; external / mailto / hash-anchor links remain skipped.
  - `'transitively follows references inside sibling .html pages'` — sibling-of-sibling pages and their CSS / image references all land in the plan.
- Both red on `main`, green on this branch.

## Validation

- `pnpm --filter @open-design/daemon typecheck` → green
- `pnpm --filter @open-design/daemon test -- tests/deploy.test.ts` → new cases green
- End-to-end verified against a sample multi-page design: every reachable HTML page plus its assets lands in the upload set; the resulting deploy returns distinct content per route.