### PR TITLE
Fix GitHub rate-limit fallback for marketplace plugins

### DIFF
--- a/apps/daemon/src/plugins/installer.ts
+++ b/apps/daemon/src/plugins/installer.ts
@@ -181,8 +181,10 @@ async function* installFromGithub(
           return;
         }
       }
-      if (lastError && isRetryableGithubCandidateError(lastError)) continue;
-      if (lastError) break;
+      if (lastError) {
+        if (shouldTryNextGithubRefCandidate(lastError)) continue;
+        if (!isRetryableGithubCandidateError(lastError)) break;
+      }
     }
 
     const tarballUrl = githubTarballUrl(parsed.owner, parsed.repo, candidate.ref);
@@ -199,13 +201,13 @@ async function* installFromGithub(
         return;
       }
     }
-    if (!lastError || !isRetryableGithubCandidateError(lastError)) break;
+    if (!lastError || !shouldTryNextGithubRefCandidate(lastError)) break;
   }
 
   yield {
     kind: 'error',
     message: lastError
-      ? `${lastError}. Tried GitHub archive URL(s): ${triedUrls.join(', ')}`
+      ? `GitHub install failed: ${lastError}. Tried GitHub fetch URL(s): ${triedUrls.join(', ')}`
       : `GitHub source ${opts.source} did not produce an installable archive`,
     warnings: [],
   };
@@ -264,7 +266,19 @@ function githubContentsUrl(owner: string, repo: string, subpath: string, ref: st
 }
 
 function isRetryableGithubCandidateError(message: string): boolean {
-  return /^Fetch failed: 404\b/.test(message) || /^Subpath .+ not found inside archive$/.test(message);
+  return /^Fetch failed: 404\b/.test(message)
+    || isGithubRateLimitError(message)
+    || /^Subpath .+ not found inside archive$/.test(message);
+}
+
+function shouldTryNextGithubRefCandidate(message: string): boolean {
+  return /^Fetch failed: 404\b/.test(message)
+    || /^Subpath .+ not found inside archive$/.test(message);
+}
+
+function isGithubRateLimitError(message: string): boolean {
+  return /^Fetch failed: 429\b/.test(message)
+    || /^Fetch failed: 403\b/.test(message);
 }
 
 async function* installFromGithubContents(

--- a/apps/daemon/tests/plugins-installer-archive.test.ts
+++ b/apps/daemon/tests/plugins-installer-archive.test.ts
@@ -169,6 +169,77 @@ describe('archive installer', () => {
     expect(row).toEqual({ source_kind: 'github', source });
   });
 
+  it.each([
+    [403, 'Forbidden', '{"message":"API rate limit exceeded for 127.0.0.1"}'],
+    [429, 'Too Many Requests', 'too many requests'],
+  ])('falls back to codeload when GitHub contents returns %i for a plugin subpath', async (status, statusText, body) => {
+    const tarball = await buildFixtureTarball({
+      rootPrefix: 'open-design-main',
+      pluginSubpath: 'plugins/community/import-smoke-test',
+    });
+    const urlsSeen: string[] = [];
+    const contentsUrl =
+      'https://api.github.com/repos/nexu-io/open-design/contents/plugins/community/import-smoke-test?ref=main';
+    const tarballUrl = 'https://codeload.github.com/nexu-io/open-design/tar.gz/main';
+    const fetcher: ArchiveFetcher = async (u) => {
+      urlsSeen.push(u);
+      if (u === contentsUrl) {
+        return makeResponse(body, status, statusText);
+      }
+      if (u === tarballUrl) return makeResponse(tarball);
+      return makeResponse('not found', 404, 'Not Found');
+    };
+
+    let success = false;
+    let error: string | undefined;
+    const source = 'github:nexu-io/open-design@main/plugins/community/import-smoke-test';
+    for await (const ev of installPlugin(db, {
+      source,
+      roots: { userPluginsRoot: pluginsRoot },
+      fetcher,
+    })) {
+      if (ev.kind === 'success') success = true;
+      if (ev.kind === 'error') error = ev.message;
+    }
+
+    if (!success) {
+      throw new Error(`install failed: ${error}`);
+    }
+    expect(urlsSeen).toEqual([contentsUrl, tarballUrl]);
+    const row = db.prepare(`SELECT source_kind, source FROM installed_plugins WHERE id = 'sample-plugin'`).get();
+    expect(row).toEqual({ source_kind: 'github', source });
+  });
+
+  it('reports both GitHub contents and codeload URLs when subpath fallback fails', async () => {
+    const urlsSeen: string[] = [];
+    const contentsUrl =
+      'https://api.github.com/repos/nexu-io/open-design/contents/plugins/community/import-smoke-test?ref=main';
+    const tarballUrl = 'https://codeload.github.com/nexu-io/open-design/tar.gz/main';
+    const fetcher: ArchiveFetcher = async (u) => {
+      urlsSeen.push(u);
+      if (u === contentsUrl) {
+        return makeResponse('too many requests', 429, 'Too Many Requests');
+      }
+      if (u === tarballUrl) return makeResponse('server unavailable', 503, 'Service Unavailable');
+      return makeResponse('not found', 404, 'Not Found');
+    };
+
+    let error: string | undefined;
+    const source = 'github:nexu-io/open-design@main/plugins/community/import-smoke-test';
+    for await (const ev of installPlugin(db, {
+      source,
+      roots: { userPluginsRoot: pluginsRoot },
+      fetcher,
+    })) {
+      if (ev.kind === 'error') error = ev.message;
+    }
+
+    expect(urlsSeen).toEqual([contentsUrl, tarballUrl]);
+    expect(error).toContain('GitHub install failed');
+    expect(error).toContain('Fetch failed: 503 Service Unavailable');
+    expect(error).toContain(`Tried GitHub fetch URL(s): ${contentsUrl}, ${tarballUrl}`);
+  });
+
   it('extracts a https://*.tgz source (records source_kind=url)', async () => {
     const tarball = await buildFixtureTarball({ rootPrefix: 'sample-plugin-1.0.0' });
     let success = false;


### PR DESCRIPTION
Fixes #2050

## Why

Marketplace plugin installs can resolve to GitHub subpath sources such as `github:nexu-io/open-design@main/plugins/community/import-smoke-test`. I worked on this because #2050 reports that when the GitHub Contents API is rate-limited, the install fails and the plugin never appears in Installed.

The pain addressed here is a production Preview 0.8.0 install failure: a transient GitHub API limit was treated as terminal even though the installer already supports codeload/tarball installs for the same source.

## What users will see

Installing a marketplace plugin still behaves the same in the Plugins page, but if GitHub Contents returns 403 or 429 for a subpath source, the daemon now falls back to the codeload tarball path automatically. If both fetch paths fail, the install error says GitHub install failed and lists the GitHub fetch URLs that were attempted.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; daemon install behavior only.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/plugins-installer-archive.test.ts`
- Did the test go red on `main` and green on this branch? yes. The new 403/429 fallback tests failed before the installer change because only the Contents API URL was attempted; they pass after the change.

## Validation

- `pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/plugins-installer-archive.test.ts` — 10 passed
- `pnpm --filter @open-design/daemon typecheck` — passed
- `pnpm guard` — passed

Notes: this machine has Node `v26.0.0`, so pnpm emitted engine warnings because the repo target is Node `~24`. Upstream has `main` and `docs/preview-v0.8.0-branch-guidance` heads, but no `preview/v0.8.0` code branch head, so this PR targets `main`.