### PR TITLE
fix: sync landing source-of-truth paths

### DIFF
--- a/.github/workflows/landing-page-ci.yml
+++ b/.github/workflows/landing-page-ci.yml
@@ -10,6 +10,8 @@ on:
       - .github/workflows/blog-indexing-monitor.yml
       # Landing page sources
       - apps/landing-page/**
+      # Design template source of truth for the homepage.
+      - design-templates/open-design-landing/**
       # Content sources globbed by Astro content collections — without
       # these the deploy can be silently skipped when only Markdown
       # content is touched.
@@ -30,6 +32,7 @@ on:
       - .github/workflows/blog-indexing-on-deploy.yml
       - .github/workflows/blog-indexing-monitor.yml
       - apps/landing-page/**
+      - design-templates/open-design-landing/**
       - skills/**
       - design-systems/**
       - craft/**

--- a/.github/workflows/landing-page-deploy.yml
+++ b/.github/workflows/landing-page-deploy.yml
@@ -10,6 +10,8 @@ on:
       - .github/workflows/landing-page-ci.yml
       # Landing page sources
       - apps/landing-page/**
+      # Design template source of truth for the homepage.
+      - design-templates/open-design-landing/**
       # Content sources — Astro content collections glob these at build
       # time. Adding/removing a SKILL.md, DESIGN.md, craft principle, or
       # live-artifact template MUST trigger a redeploy or the published

--- a/apps/landing-page/AGENTS.md
+++ b/apps/landing-page/AGENTS.md
@@ -96,6 +96,7 @@ Tightly coupled with:
 when **any** of these change:
 
 - `apps/landing-page/**`
+- `design-templates/open-design-landing/**`
 - `skills/**`
 - `design-systems/**`
 - `craft/**`

--- a/apps/landing-page/app/_components/sub-page-layout.astro
+++ b/apps/landing-page/app/_components/sub-page-layout.astro
@@ -5,7 +5,7 @@
  *
  * The homepage (`/`) intentionally does NOT use this layout — its
  * chrome (rails, topbar, full hero, mega-word footer) stays in
- * lockstep with `skills/open-design-landing/example.html`. This
+ * lockstep with `design-templates/open-design-landing/example.html`. This
  * layout is the lighter sibling: same Atelier Zero tokens, same
  * sticky nav, but no editorial side rails or hero, and a compact
  * footer focused on the site map.

--- a/apps/landing-page/app/_components/wire.tsx
+++ b/apps/landing-page/app/_components/wire.tsx
@@ -44,7 +44,7 @@ type Contributor = {
 
 // SSR-safe initial list. Used until the GitHub fetch resolves AND as
 // the permanent fallback when the network is unavailable. Mirrors the
-// canonical wire row in `skills/open-design-landing/example.html` so
+// canonical wire row in `design-templates/open-design-landing/example.html` so
 // hydration is byte-stable against the static reference rendering.
 const FALLBACK: ReadonlyArray<Contributor> = [
   { handle: 'tw93', role: 'kami', href: 'https://github.com/tw93' },

--- a/apps/landing-page/app/globals.css
+++ b/apps/landing-page/app/globals.css
@@ -1,9 +1,9 @@
 /*
  * Atelier Zero — landing page styles.
  *
- * Mirrors `skills/open-design-landing/example.html` <style> block 1:1.
+ * Mirrors `design-templates/open-design-landing/example.html` <style> block 1:1.
  * When the canonical example.html changes, mirror the diff here so the
- * skill's known-good rendering stays in lockstep with the deployed site.
+ * template's known-good rendering stays in lockstep with the deployed site.
  *
  * Font loading lives in `_components/font-stylesheet.astro` — a server
  * component injected into every page's <head>. We used to `@import` it

--- a/apps/landing-page/app/page.tsx
+++ b/apps/landing-page/app/page.tsx
@@ -1,7 +1,7 @@
 /*
  * Open Design — Atelier Zero landing page.
  *
- * Mirrors `skills/open-design-landing/example.html` 1:1. When the canonical
+ * Mirrors `design-templates/open-design-landing/example.html` 1:1. When the canonical
  * example.html changes, mirror the diff here and into `app/globals.css`.
  *
  * Static React component rendered by Astro. The Header and Wire components
@@ -54,7 +54,7 @@ const arrowPlus = (
 
 const NBSP = '\u00A0';
 
-// Canonical project URLs. Keep in sync with skills/open-design-landing/example.html.
+// Canonical project URLs. Keep in sync with design-templates/open-design-landing/example.html.
 //
 // `data-github-version` invariant: every wrapper must contain ONLY the version
 // string (e.g. `v0.3.0`), never any surrounding label or punctuation. The


### PR DESCRIPTION
Fixes #1998

## Why

I am opening this for the issue #1998 bug follow-up. The landing page now treats `design-templates/open-design-landing/example.html` as the canonical homepage rendering, but several landing-page comments still pointed reviewers at the removed `skills/open-design-landing/example.html` path.

The deployment pain is that changes limited to `design-templates/open-design-landing/**` could skip landing-page CI/deploy because both workflows omitted `design-templates/**` from their path filters.

## What users will see

No product UI changes. Contributors and reviewers will see the current canonical design-template path in landing-page source comments, and GitHub Actions will run landing-page validation/deploy when the design-template source of truth changes.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this is a workflow/comment/docs fix with no UI surface.

## Bug fix verification

- Test path that reproduces the bug: one-off Node invariant check for stale `skills/open-design-landing/example.html` references in the four named landing-page files and missing `design-templates/**` filters in the two workflow files.
- Did the test go red on `main` and green on this branch? yes. It failed on `main` for all four stale comments plus both missing workflow filters, then passed after this change.

## Validation

- `git diff --check`
- one-off Node invariant check for #1998 path/filter requirements
- `pnpm guard`
- `pnpm --filter @open-design/landing-page typecheck`
- `pnpm typecheck`

Note: the local shell is on Node v26 while the repo requests Node `~24`, so pnpm printed engine warnings during install/typecheck. The validation commands above completed successfully.
