### PR TITLE
fix(daemon): reconcile missing artifact manifests

### DIFF
--- a/apps/daemon/src/artifact-manifest.ts
+++ b/apps/daemon/src/artifact-manifest.ts
@@ -15,6 +15,10 @@ type ValidationResult =
   | { ok: true; value: JsonRecord | null }
   | { ok: false; error: string };
 
+type ValidationOptions = {
+  preserveUpdatedAt?: boolean;
+};
+
 const ALLOWED_KINDS = new Set<string>([
   'html',
   'deck',
@@ -79,7 +83,11 @@ function validateSupportingPath(value: unknown): string | null {
   return null;
 }
 
-export function validateArtifactManifestInput(manifest: unknown, entry: unknown): ValidationResult {
+export function validateArtifactManifestInput(
+  manifest: unknown,
+  entry: unknown,
+  options: ValidationOptions = {},
+): ValidationResult {
   if (manifest == null) return { ok: true, value: null };
   if (!isPlainObject(manifest)) {
     return { ok: false, error: 'artifactManifest must be an object' };
@@ -191,10 +199,14 @@ export function validateArtifactManifestInput(manifest: unknown, entry: unknown)
     return { ok: false, error: `artifact entry exceeds max length (${MAX_ENTRY_LENGTH})` };
   }
 
-  return { ok: true, value: sanitizeManifest(manifest, safeEntry) };
+  return { ok: true, value: sanitizeManifest(manifest, safeEntry, options) };
 }
 
-export function sanitizeManifest(manifest: JsonRecord, entry: string): JsonRecord {
+export function sanitizeManifest(
+  manifest: JsonRecord,
+  entry: string,
+  options: ValidationOptions = {},
+): JsonRecord {
   const now = new Date().toISOString();
   return {
     version: MANIFEST_VERSION,
@@ -208,7 +220,10 @@ export function sanitizeManifest(manifest: JsonRecord, entry: string): JsonRecor
       ? manifest.supportingFiles.map((x) => String(x).replace(/\\/g, '/'))
       : undefined,
     createdAt: typeof manifest.createdAt === 'string' ? manifest.createdAt : now,
-    updatedAt: now,
+    updatedAt:
+      options.preserveUpdatedAt && typeof manifest.updatedAt === 'string'
+        ? manifest.updatedAt
+        : now,
     sourceSkillId: manifest.sourceSkillId,
     designSystemId: manifest.designSystemId ?? undefined,
     metadata: manifest.metadata,
@@ -220,7 +235,7 @@ export function parsePersistedManifest(raw: string, fallbackEntry: string): Json
     const parsed = JSON.parse(raw);
     if (!parsed || parsed.version !== MANIFEST_VERSION) return null;
     const entry = typeof parsed.entry === 'string' && parsed.entry ? parsed.entry : fallbackEntry;
-    const result = validateArtifactManifestInput(parsed, entry);
+    const result = validateArtifactManifestInput(parsed, entry, { preserveUpdatedAt: true });
     return result.ok ? result.value : null;
   } catch {
     return null;

--- a/apps/daemon/src/finalize-design.ts
+++ b/apps/daemon/src/finalize-design.ts
@@ -37,6 +37,7 @@ import { readDesignSystem } from './design-systems.js';
 import {
   listFiles,
   readProjectFile,
+  reconcileHtmlArtifactManifest,
   resolveProjectDir,
   validateProjectPath,
 } from './projects.js';
@@ -160,6 +161,14 @@ export async function resolveCurrentArtifact(
     }
     if (safeTabName) {
       const sidecarPath = path.join(dir, `${safeTabName}.artifact.json`);
+      if (!fs.existsSync(sidecarPath)) {
+        await reconcileHtmlArtifactManifest(
+          projectsRoot,
+          projectId,
+          safeTabName,
+          metadata ?? undefined,
+        );
+      }
       if (fs.existsSync(sidecarPath)) {
         const file = await readProjectFile(
           projectsRoot,
@@ -179,7 +188,21 @@ export async function resolveCurrentArtifact(
   }
 
   const files = await listFiles(projectsRoot, projectId, { metadata: metadata ?? undefined });
-  const candidates = files
+  await Promise.all(
+    files.map((f) => {
+      if (fs.existsSync(path.join(dir, `${f.name}.artifact.json`))) return null;
+      return reconcileHtmlArtifactManifest(
+        projectsRoot,
+        projectId,
+        f.name,
+        metadata ?? undefined,
+      );
+    }),
+  );
+  const reconciledFiles = await listFiles(projectsRoot, projectId, {
+    metadata: metadata ?? undefined,
+  });
+  const candidates = reconciledFiles
     .filter((f) => {
       // Require a real sidecar on disk; an inferred manifest does not count.
       return fs.existsSync(path.join(dir, `${f.name}.artifact.json`));

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -744,6 +744,8 @@ export async function reconcileHtmlArtifactManifest(projectsRoot, projectId, nam
   const validated = validateArtifactManifestInput(
     {
       ...inferred,
+      createdAt: new Date(targetStat.mtimeMs).toISOString(),
+      updatedAt: new Date(targetStat.mtimeMs).toISOString(),
       metadata: {
         ...inferredMetadata,
         inferred: true,
@@ -751,6 +753,7 @@ export async function reconcileHtmlArtifactManifest(projectsRoot, projectId, nam
       },
     },
     safeName,
+    { preserveUpdatedAt: true },
   );
   if (!validated.ok || !validated.value) return null;
   await writeFile(manifestTarget, JSON.stringify(validated.value, null, 2));

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -703,6 +703,60 @@ function artifactManifestNameFor(name) {
   return `${name}.artifact.json`;
 }
 
+export async function reconcileHtmlArtifactManifest(projectsRoot, projectId, name, metadata?) {
+  const dir = resolveProjectDir(projectsRoot, projectId, metadata);
+  const safeName = validateProjectPath(name);
+  const ext = path.extname(safeName).toLowerCase();
+  if (ext !== '.html' && ext !== '.htm') return null;
+
+  let target;
+  try {
+    target = await resolveSafeReal(dir, safeName);
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return null;
+    throw err;
+  }
+
+  let targetStat;
+  try {
+    targetStat = await stat(target);
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return null;
+    throw err;
+  }
+  if (!targetStat.isFile()) return null;
+
+  const manifestFileName = artifactManifestNameFor(safeName);
+  const manifestTarget = await resolveSafeReal(dir, manifestFileName);
+  try {
+    const raw = await readFile(manifestTarget, 'utf8');
+    return parseManifest(raw);
+  } catch (err) {
+    if (!err || err.code !== 'ENOENT') throw err;
+  }
+
+  const inferred = inferLegacyManifest(safeName);
+  if (!inferred) return null;
+  const inferredMetadata =
+    inferred.metadata && typeof inferred.metadata === 'object' && !Array.isArray(inferred.metadata)
+      ? inferred.metadata
+      : {};
+  const validated = validateArtifactManifestInput(
+    {
+      ...inferred,
+      metadata: {
+        ...inferredMetadata,
+        inferred: true,
+        reconciled: true,
+      },
+    },
+    safeName,
+  );
+  if (!validated.ok || !validated.value) return null;
+  await writeFile(manifestTarget, JSON.stringify(validated.value, null, 2));
+  return validated.value;
+}
+
 async function readManifestForPath(projectDirPath, relPath) {
   const manifestPath = path.join(projectDirPath, artifactManifestNameFor(relPath));
   try {

--- a/apps/daemon/tests/artifact-manifest.test.ts
+++ b/apps/daemon/tests/artifact-manifest.test.ts
@@ -57,6 +57,27 @@ describe('validateArtifactManifestInput', () => {
     expect(res.ok).toBe(true);
     if (res.ok) expect(res.value?.status).toBe('streaming');
   });
+
+  it('preserves an existing updatedAt timestamp when requested', () => {
+    const res = validateArtifactManifestInput(
+      { ...validBase(), updatedAt: '2026-05-01T00:00:00.000Z' },
+      'index.html',
+      { preserveUpdatedAt: true },
+    );
+
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.value?.updatedAt).toBe('2026-05-01T00:00:00.000Z');
+  });
+
+  it('stamps updatedAt at validation time by default', () => {
+    const res = validateArtifactManifestInput(
+      { ...validBase(), updatedAt: '2026-05-01T00:00:00.000Z' },
+      'index.html',
+    );
+
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.value?.updatedAt).not.toBe('2026-05-01T00:00:00.000Z');
+  });
 });
 
 describe('inferLegacyManifest', () => {

--- a/apps/daemon/tests/finalize-design.test.ts
+++ b/apps/daemon/tests/finalize-design.test.ts
@@ -248,35 +248,38 @@ describe('resolveCurrentArtifact', () => {
     expect(sidecar.metadata?.reconciled).toBe(true);
   });
 
-  it('selects a newly reconciled HTML artifact over an older sidecar when no tab is active', async () => {
+  it('keeps a newer persisted artifact ahead of an older reconciled HTML file when no tab is active', async () => {
     const { db, projectsRoot } = setupResolverFixture();
+    const projectDir = path.join(projectsRoot, PROJECT_ID);
+    const staleHtmlMtime = new Date('2026-05-01T00:00:00.000Z');
 
-    await writeProjectFile(projectsRoot, PROJECT_ID, 'older.html', '<p>older</p>', {
+    await writeProjectFile(projectsRoot, PROJECT_ID, 'newer.html', '<p>newer</p>', {
       artifactManifest: {
         version: 1,
         kind: 'html',
-        title: 'Older',
-        entry: 'older.html',
+        title: 'Newer',
+        entry: 'newer.html',
         renderer: 'html',
         exports: ['html'],
-        updatedAt: '2026-05-01T00:00:00.000Z',
+        updatedAt: '2026-05-07T00:00:00.000Z',
       },
     });
-    await writeProjectFile(projectsRoot, PROJECT_ID, 'resumed.html', '<p>resumed</p>');
+    await writeProjectFile(projectsRoot, PROJECT_ID, 'stale.html', '<p>stale</p>');
+    fs.utimesSync(path.join(projectDir, 'stale.html'), staleHtmlMtime, staleHtmlMtime);
 
     const out = await resolveCurrentArtifact(db, projectsRoot, PROJECT_ID);
 
     expect(out).not.toBeNull();
-    expect(out!.name).toBe('resumed.html');
-    expect(out!.body).toBe('<p>resumed</p>');
-    const sidecarPath = path.join(projectsRoot, PROJECT_ID, 'resumed.html.artifact.json');
+    expect(out!.name).toBe('newer.html');
+    expect(out!.body).toBe('<p>newer</p>');
+    const sidecarPath = path.join(projectDir, 'stale.html.artifact.json');
     expect(fs.existsSync(sidecarPath)).toBe(true);
     const sidecar = JSON.parse(fs.readFileSync(sidecarPath, 'utf8')) as {
       updatedAt?: string;
       metadata?: { reconciled?: boolean };
     };
     expect(sidecar.metadata?.reconciled).toBe(true);
-    expect(sidecar.updatedAt).not.toBe('2026-05-01T00:00:00.000Z');
+    expect(sidecar.updatedAt).toBe(staleHtmlMtime.toISOString());
   });
 
   // PR #832 P3 fix from @lefarcen: a malformed tabs row (e.g. an

--- a/apps/daemon/tests/finalize-design.test.ts
+++ b/apps/daemon/tests/finalize-design.test.ts
@@ -220,6 +220,65 @@ describe('resolveCurrentArtifact', () => {
     expect(out).toBeNull();
   });
 
+  it('reconciles an active HTML artifact that is missing its sidecar', async () => {
+    const { db, projectsRoot } = setupResolverFixture();
+
+    // Mirrors a resumed/Continue run that wrote the HTML deliverable but
+    // terminated before durable artifact sidecar registration completed.
+    await writeProjectFile(projectsRoot, PROJECT_ID, 'resumed.html', '<p>resumed</p>');
+    setActiveTab(db, 'resumed.html');
+
+    const out = await resolveCurrentArtifact(db, projectsRoot, PROJECT_ID);
+
+    expect(out).not.toBeNull();
+    expect(out!.name).toBe('resumed.html');
+    expect(out!.body).toBe('<p>resumed</p>');
+    expect(out!.manifest?.entry).toBe('resumed.html');
+    expect(out!.manifest?.kind).toBe('html');
+    const sidecarPath = path.join(projectsRoot, PROJECT_ID, 'resumed.html.artifact.json');
+    expect(fs.existsSync(sidecarPath)).toBe(true);
+    const sidecar = JSON.parse(fs.readFileSync(sidecarPath, 'utf8')) as {
+      entry?: string;
+      kind?: string;
+      metadata?: { inferred?: boolean; reconciled?: boolean };
+    };
+    expect(sidecar.entry).toBe('resumed.html');
+    expect(sidecar.kind).toBe('html');
+    expect(sidecar.metadata?.inferred).toBe(true);
+    expect(sidecar.metadata?.reconciled).toBe(true);
+  });
+
+  it('selects a newly reconciled HTML artifact over an older sidecar when no tab is active', async () => {
+    const { db, projectsRoot } = setupResolverFixture();
+
+    await writeProjectFile(projectsRoot, PROJECT_ID, 'older.html', '<p>older</p>', {
+      artifactManifest: {
+        version: 1,
+        kind: 'html',
+        title: 'Older',
+        entry: 'older.html',
+        renderer: 'html',
+        exports: ['html'],
+        updatedAt: '2026-05-01T00:00:00.000Z',
+      },
+    });
+    await writeProjectFile(projectsRoot, PROJECT_ID, 'resumed.html', '<p>resumed</p>');
+
+    const out = await resolveCurrentArtifact(db, projectsRoot, PROJECT_ID);
+
+    expect(out).not.toBeNull();
+    expect(out!.name).toBe('resumed.html');
+    expect(out!.body).toBe('<p>resumed</p>');
+    const sidecarPath = path.join(projectsRoot, PROJECT_ID, 'resumed.html.artifact.json');
+    expect(fs.existsSync(sidecarPath)).toBe(true);
+    const sidecar = JSON.parse(fs.readFileSync(sidecarPath, 'utf8')) as {
+      updatedAt?: string;
+      metadata?: { reconciled?: boolean };
+    };
+    expect(sidecar.metadata?.reconciled).toBe(true);
+    expect(sidecar.updatedAt).not.toBe('2026-05-01T00:00:00.000Z');
+  });
+
   // PR #832 P3 fix from @lefarcen: a malformed tabs row (e.g. an
   // attacker with DB write access setting tabs.name = `../../../etc/passwd`)
   // would otherwise cause path.join to compose a probe URL outside the


### PR DESCRIPTION
Fixes #1564

## Why

A resumed prototype run can leave a real HTML deliverable on disk without the durable `<entry>.artifact.json` sidecar. That makes the file visible in the project file panel through legacy inference, but invisible to strict current-artifact/finalize code that intentionally requires a real sidecar.

This PR repairs that partial-success state in the finalize/current-artifact path so existing recovered HTML can become a registered artifact instead of silently falling out of scope.

## What users will see

When a Continue/resume run has written an HTML artifact but missed sidecar registration, later finalize/current-artifact flows can recover it. The daemon reconstructs and persists a real artifact manifest for the HTML file, so the artifact becomes visible to result/finalization code.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; daemon artifact reconciliation only.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/finalize-design.test.ts`
- Did the test go red on `main` and green on this branch? yes. The new active-tab regression failed on main with `expected null not to be null`, and the new no-active-tab ranking regression failed before the re-list fix with `expected 'older.html' to be 'resumed.html'`.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/daemon test -- finalize-design.test.ts` (red before fix; green after first reconciliation fix; a second red case exposed stale fallback ranking)
- `pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/finalize-design.test.ts` (41 passed)
- `pnpm guard`
- `pnpm typecheck`

Note: this workspace currently runs Node `v26.0.0`, so pnpm reports the existing engine warning (`wanted: {"node":"~24"}`) during validation. Commands still completed successfully where listed above.
