### PR TITLE
fix: link od bin after fresh install

### DIFF
--- a/apps/daemon/bin/od.mjs
+++ b/apps/daemon/bin/od.mjs
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const entryDir = dirname(fileURLToPath(import.meta.url));
+const distEntry = resolve(entryDir, "../dist/cli.js");
+
+if (!existsSync(distEntry)) {
+  throw new Error(
+    `Open Design daemon dist entry not found at ${distEntry}. Run "pnpm --filter @open-design/daemon build" first.`,
+  );
+}
+
+await import(pathToFileURL(distEntry).href);

--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -6,7 +6,7 @@
   "main": "./dist/cli.js",
   "types": "./dist/cli.d.ts",
   "bin": {
-    "od": "./dist/cli.js"
+    "od": "./bin/od.mjs"
   },
   "exports": {
     ".": {
@@ -20,6 +20,7 @@
     }
   },
   "files": [
+    "bin",
     "dist",
     "package.json"
   ],

--- a/nix/pnpm-deps.nix
+++ b/nix/pnpm-deps.nix
@@ -10,5 +10,5 @@
   # 2. Run the relevant nix build/flake check
   # 3. Copy the expected hash printed by Nix into the matching field below
   daemonHash = "sha256-nSMVyVSHfcXV5fLMXM3tfdQxZRb+FNF6P4iuJw/Z8Mo=";
-  webHash = "sha256-QOufFb3Hb5js3jK6QEl3WfnxNAa4DdZfMKoALTHY4hI=";
+  webHash = "sha256-IlXE7iNoT/+mcVbtzhJdcP5fNs7Hk8AYZMxfJ33dXck=";
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "description": "Local-first design product: detects your installed code-agent CLI, runs design skills + design systems, streams artifacts into a sandboxed preview.",
   "license": "Apache-2.0",
   "bin": {
-    "od": "./apps/daemon/dist/cli.js"
+    "od": "./apps/daemon/bin/od.mjs"
   },
   "scripts": {
     "postinstall": "node ./scripts/postinstall.mjs",
@@ -15,7 +15,7 @@
     "tools-pack": "pnpm exec tools-pack",
     "tools-serve": "pnpm exec tools-serve",
     "nix:update-hash": "node --experimental-strip-types ./scripts/update-nix-pnpm-deps-hash.ts",
-    "guard": "tsx ./scripts/guard.ts && node --import tsx --test scripts/style-policy.test.ts scripts/approve-fork-pr-workflows.test.ts",
+    "guard": "tsx ./scripts/guard.ts && node --import tsx --test scripts/style-policy.test.ts scripts/approve-fork-pr-workflows.test.ts scripts/postinstall.test.ts",
     "i18n:check": "tsx ./scripts/i18n-check.ts",
     "i18n:coverage": "tsx ./scripts/i18n-coverage-report.ts",
     "sync:community-pets": "node --experimental-strip-types scripts/sync-community-pets.ts",
@@ -25,6 +25,7 @@
     "typecheck": "pnpm -r --workspace-concurrency=4 --if-present run typecheck && tsc -p scripts/tsconfig.json --noEmit"
   },
   "devDependencies": {
+    "@open-design/daemon": "workspace:*",
     "@open-design/tools-dev": "workspace:*",
     "@open-design/tools-pack": "workspace:*",
     "@open-design/tools-serve": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
 
   .:
     devDependencies:
+      '@open-design/daemon':
+        specifier: workspace:*
+        version: link:apps/daemon
       '@open-design/tools-dev':
         specifier: workspace:*
         version: link:tools/dev

--- a/scripts/guard.ts
+++ b/scripts/guard.ts
@@ -70,6 +70,8 @@ const residualAllowedExactPaths = new Set([
   // executed directly by Node and are not loaded by the app runtime.
   "scripts/import-prompt-templates.mjs",
   "scripts/postinstall.mjs",
+  // Checked-in bin shim so pnpm can link `od` before daemon dist output exists.
+  "apps/daemon/bin/od.mjs",
   "apps/packaged/esbuild.config.mjs",
   // Browser service workers must be served as JavaScript files.
   "apps/web/public/od-notifications-sw.js",

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -17,6 +17,7 @@ const buildTargets = [
   "packages/sidecar-proto",
   "packages/sidecar",
   "packages/diagnostics",
+  "apps/daemon",
   "tools/dev",
   "tools/pack",
   "tools/serve",

--- a/scripts/postinstall.test.ts
+++ b/scripts/postinstall.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+const repoRoot = join(import.meta.dirname, "..");
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(join(repoRoot, path), "utf8"));
+}
+
+function readPackageJson(path: string): Record<string, unknown> {
+  const manifest = readJson(path);
+  assert(typeof manifest === "object" && manifest !== null);
+  return manifest as Record<string, unknown>;
+}
+
+function packageName(manifest: unknown): string {
+  assert(typeof manifest === "object" && manifest !== null);
+  const name = (manifest as { name?: unknown }).name;
+  assert(typeof name === "string");
+  return name;
+}
+
+function packageBinTargets(manifest: unknown): string[] {
+  assert(typeof manifest === "object" && manifest !== null);
+  const bin = (manifest as { bin?: unknown }).bin;
+  if (typeof bin === "string") return [bin];
+  if (typeof bin !== "object" || bin === null) return [];
+  return Object.values(bin).filter((value): value is string => typeof value === "string");
+}
+
+function dependencySpecifier(manifest: Record<string, unknown>, name: string): string | undefined {
+  const dependencyFields = ["dependencies", "devDependencies", "optionalDependencies", "peerDependencies"] as const;
+  for (const field of dependencyFields) {
+    const dependencies = manifest[field];
+    if (typeof dependencies !== "object" || dependencies === null) continue;
+    const specifier = (dependencies as Record<string, unknown>)[name];
+    if (typeof specifier === "string") return specifier;
+  }
+  return undefined;
+}
+
+function distDelegatingBinTargets(directory: string, manifest: unknown): string[] {
+  return packageBinTargets(manifest).filter((binTarget) => {
+    if (binTarget.startsWith("./dist/")) return true;
+    const source = readFileSync(join(repoRoot, directory, binTarget), "utf8");
+    return source.includes("../dist/") || source.includes("./dist/") || source.includes("/dist/");
+  });
+}
+
+function workspaceDependencyNames(manifest: unknown): Set<string> {
+  assert(typeof manifest === "object" && manifest !== null);
+  const dependencyFields = ["dependencies", "optionalDependencies", "peerDependencies"] as const;
+  const names = new Set<string>();
+
+  for (const field of dependencyFields) {
+    const dependencies = (manifest as Record<string, unknown>)[field];
+    if (typeof dependencies !== "object" || dependencies === null) continue;
+    for (const [name, version] of Object.entries(dependencies)) {
+      if (typeof version === "string" && version.startsWith("workspace:")) {
+        names.add(name);
+      }
+    }
+  }
+
+  return names;
+}
+
+function postinstallBuildTargets(): Set<string> {
+  const source = readFileSync(join(repoRoot, "scripts/postinstall.mjs"), "utf8");
+  const targets = [...source.matchAll(/"([^"]+)"/g)]
+    .map((match) => match[1])
+    .filter((value): value is string => value != null && /^(?:apps|packages|tools)\//.test(value));
+  return new Set(targets);
+}
+
+function workspacePackageDirectories(): string[] {
+  const scopedPackageDirectories = ["apps", "packages", "tools"].flatMap((scope) =>
+    readdirSync(join(repoRoot, scope), { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => `${scope}/${entry.name}`),
+  );
+  return ["e2e", ...scopedPackageDirectories]
+    .filter((directory) => existsSync(join(repoRoot, directory, "package.json")))
+    .sort();
+}
+
+test("workspace bin entries use checked-in targets so pnpm can link them before postinstall", () => {
+  const manifests = new Map(
+    workspacePackageDirectories().map((directory) => [
+      directory,
+      readJson(`${directory}/package.json`),
+    ]),
+  );
+  const consumedWorkspacePackages = new Set<string>();
+  for (const manifest of manifests.values()) {
+    for (const name of workspaceDependencyNames(manifest)) {
+      consumedWorkspacePackages.add(name);
+    }
+  }
+
+  const unlinkableBins = [...manifests.entries()]
+    .filter(([, manifest]) => consumedWorkspacePackages.has(packageName(manifest)))
+    .flatMap(([directory, manifest]) =>
+      packageBinTargets(manifest).map((binTarget) => ({
+        binTarget,
+        directory,
+        resolvedPath: join(repoRoot, directory, binTarget),
+      })),
+    )
+    .filter(({ resolvedPath }) => !existsSync(resolvedPath))
+    .map(({ binTarget, directory }) => `${directory}:${binTarget}`);
+
+  assert.deepEqual(unlinkableBins, []);
+});
+
+test("root workspace depends on the daemon package so pnpm exec resolves the od bin", () => {
+  const rootManifest = readPackageJson("package.json");
+  const daemonManifest = readPackageJson("apps/daemon/package.json");
+
+  assert.equal(dependencySpecifier(rootManifest, "@open-design/daemon"), "workspace:*");
+  assert.deepEqual((daemonManifest as { bin?: unknown }).bin, {
+    od: "./bin/od.mjs",
+  });
+  assert.equal(existsSync(join(repoRoot, "apps/daemon/bin/od.mjs")), true);
+});
+
+test("postinstall builds workspace packages whose linkable bins delegate to dist", () => {
+  const manifests = new Map(
+    workspacePackageDirectories().map((directory) => [
+      directory,
+      readJson(`${directory}/package.json`),
+    ]),
+  );
+  const consumedWorkspacePackages = new Set<string>();
+  for (const manifest of manifests.values()) {
+    for (const name of workspaceDependencyNames(manifest)) {
+      consumedWorkspacePackages.add(name);
+    }
+  }
+
+  const missingBuildTargets = [...manifests.entries()]
+    .filter(([, manifest]) => consumedWorkspacePackages.has(packageName(manifest)))
+    .filter(([directory, manifest]) => distDelegatingBinTargets(directory, manifest).length > 0)
+    .map(([directory]) => directory)
+    .filter((directory) => !postinstallBuildTargets().has(directory));
+
+  assert.deepEqual(missingBuildTargets, []);
+});

--- a/scripts/postinstall.test.ts
+++ b/scripts/postinstall.test.ts
@@ -120,6 +120,9 @@ test("root workspace depends on the daemon package so pnpm exec resolves the od 
   const daemonManifest = readPackageJson("apps/daemon/package.json");
 
   assert.equal(dependencySpecifier(rootManifest, "@open-design/daemon"), "workspace:*");
+  assert.deepEqual((rootManifest as { bin?: unknown }).bin, {
+    od: "./apps/daemon/bin/od.mjs",
+  });
   assert.deepEqual((daemonManifest as { bin?: unknown }).bin, {
     od: "./bin/od.mjs",
   });

--- a/scripts/postinstall.test.ts
+++ b/scripts/postinstall.test.ts
@@ -49,9 +49,11 @@ function distDelegatingBinTargets(directory: string, manifest: unknown): string[
   });
 }
 
-function workspaceDependencyNames(manifest: unknown): Set<string> {
+function workspaceDependencyNames(manifest: unknown, includeDevDependencies = false): Set<string> {
   assert(typeof manifest === "object" && manifest !== null);
-  const dependencyFields = ["dependencies", "optionalDependencies", "peerDependencies"] as const;
+  const dependencyFields = includeDevDependencies
+    ? ["dependencies", "devDependencies", "optionalDependencies", "peerDependencies"]
+    : ["dependencies", "optionalDependencies", "peerDependencies"];
   const names = new Set<string>();
 
   for (const field of dependencyFields) {
@@ -130,6 +132,7 @@ test("root workspace depends on the daemon package so pnpm exec resolves the od 
 });
 
 test("postinstall builds workspace packages whose linkable bins delegate to dist", () => {
+  const rootManifest = readPackageJson("package.json");
   const manifests = new Map(
     workspacePackageDirectories().map((directory) => [
       directory,
@@ -137,6 +140,9 @@ test("postinstall builds workspace packages whose linkable bins delegate to dist
     ]),
   );
   const consumedWorkspacePackages = new Set<string>();
+  for (const name of workspaceDependencyNames(rootManifest, true)) {
+    consumedWorkspacePackages.add(name);
+  }
   for (const manifest of manifests.values()) {
     for (const name of workspaceDependencyNames(manifest)) {
       consumedWorkspacePackages.add(name);


### PR DESCRIPTION
Fixes #1997

## Why

I picked this up from #1997 after a fresh install reported that `pnpm exec od` fell through to the system `od` binary.

The pain is install-time: pnpm links workspace bins before the root `postinstall` script runs. A bin target that points directly at `apps/daemon/dist/cli.js` cannot be linked on a brand-new clone because daemon dist output does not exist yet, so pnpm warns with `ENOENT` and leaves `od` unavailable at the workspace root.

## What users will see

After a fresh `pnpm install`, `pnpm exec od` resolves to Open Design's CLI instead of `/usr/bin/od`, and the install no longer logs the daemon `dist/cli.js` bin-link `ENOENT` warning.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [x] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

Root `package.json` now has `@open-design/daemon: workspace:*` as a dev dependency so pnpm exposes the daemon package's `od` bin in root `node_modules/.bin`. This is a workspace link only; it does not add an external package or shipped third-party bytes. It makes the existing daemon package bin discoverable by `pnpm exec`.

## Screenshots

No UI change.

## Bug fix verification

- Test path that reproduces the bug: `scripts/postinstall.test.ts`
- Did the test go red on `main` and green on this branch? yes. Before the fix, the focused test failed with `missingBuildTargets` containing `apps/daemon`; before the shim/root dependency, clean install still reproduced the bin-link warning and `pnpm exec od` resolved to `/usr/bin/od`. On this branch the script test is green and clean install resolves `od` to `./node_modules/.bin/od`.

## Validation

- `node --import tsx --test scripts/postinstall.test.ts`
- `pnpm install` from a cleaned `node_modules` and `dist` state under Node `v24.13.0`; no `Failed to create bin`, `ENOENT`, or `apps/daemon/dist/cli.js` warning appeared.
- `pnpm exec which od` -> `./node_modules/.bin/od`
- `pnpm exec od --help` prints the Open Design CLI usage.
- `pnpm --filter @open-design/daemon pack --dry-run` includes `bin/od.mjs`.
- `pnpm guard`
- `pnpm typecheck`
