### PR TITLE
fix(daemon): surface discovery form answers to agents

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1868,6 +1868,48 @@ export function telemetryPromptFromRunRequest(message, currentPrompt) {
   return typeof currentPrompt === 'string' ? currentPrompt : message;
 }
 
+const FORM_ANSWERS_HEADER_RE = /^\s*\[form answers\s+(?:\u2014|-)\s*([^\]\r\n]+)\]/i;
+
+function formAnswerTransitionForCurrentPrompt(currentPrompt) {
+  if (typeof currentPrompt !== 'string') return null;
+  const trimmed = currentPrompt.trim();
+  if (!trimmed) return null;
+  const match = FORM_ANSWERS_HEADER_RE.exec(trimmed);
+  if (!match) return null;
+  const rawFormId = (match[1] || 'form').trim() || 'form';
+  const formId = rawFormId.replace(/[^\w.-]/g, '') || 'form';
+  const lines = [
+    '## Latest user turn - form answers submitted',
+    trimmed,
+    '',
+    `The user has answered the ${formId} form. Do not emit another ${formId} form.`,
+  ];
+  if (formId.toLowerCase() === 'discovery') {
+    lines.push(
+      'Continue with RULE 2 / RULE 3 now. For Branch B answers, build now instead of asking another brief.',
+    );
+  } else {
+    lines.push(
+      'Treat these form answers as the active user turn instead of replaying the transcript as a fresh request.',
+    );
+  }
+  return lines.join('\n');
+}
+
+export function composeChatUserRequestForAgent(message, currentPrompt) {
+  const body =
+    typeof message === 'string' && message.trim()
+      ? message
+      : '(No extra typed instruction.)';
+  const transition = formAnswerTransitionForCurrentPrompt(currentPrompt);
+  if (!transition) return body;
+  return [
+    transition,
+    '## Full conversation transcript',
+    body,
+  ].join('\n\n');
+}
+
 export function createFinalizedMessageTelemetryReporter({
   design,
   db,
@@ -9197,6 +9239,10 @@ export async function startServer({
       research,
       message,
     );
+    const userRequestPrompt = composeChatUserRequestForAgent(
+      message,
+      currentPrompt,
+    );
     const clientInstructionPrompt = [researchCommandContract, runContextPrompt, systemPrompt]
       .map((part) => (typeof part === 'string' ? part.trim() : ''))
       .filter(Boolean)
@@ -9215,7 +9261,7 @@ export async function startServer({
           : linkedDirsHint
             ? `# Instructions${linkedDirsHint}\n\n---\n`
             : '',
-      `# User request\n\n${message || '(No extra typed instruction.)'}${attachmentHint}${commentHint}`,
+      `# User request\n\n${userRequestPrompt}${attachmentHint}${commentHint}`,
       safeImages.length
         ? `\n\n${safeImages.map((p) => `@${p}`).join(' ')}`
         : '',

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -2,9 +2,11 @@ import type http from 'node:http';
 import { randomUUID } from 'node:crypto';
 import {
   chmodSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   promises as fsp,
+  readFileSync,
   realpathSync,
   rmSync,
   symlinkSync,
@@ -715,6 +717,76 @@ setInterval(() => {}, 1000);
         delete process.env.OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS;
       } else {
         process.env.OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS = previous;
+      }
+    }
+  });
+
+  it('marks submitted discovery form answers as the active turn before the transcript', async () => {
+    const captureDir = mkdtempSync(join(tmpdir(), 'od-form-answer-prompt-'));
+    tempDirs.push(captureDir);
+    const capturePath = join(captureDir, 'prompt.txt');
+    const previousCapturePath = process.env.OD_CAPTURE_PROMPT_PATH;
+    process.env.OD_CAPTURE_PROMPT_PATH = capturePath;
+    try {
+      await withFakeAgent(
+        'opencode',
+        `
+const fs = require('node:fs');
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => { input += chunk; });
+process.stdin.on('end', () => {
+  fs.writeFileSync(process.env.OD_CAPTURE_PROMPT_PATH, input, 'utf8');
+  console.log(JSON.stringify({ type: 'text', part: { text: 'building now' } }));
+});
+`,
+        async () => {
+          const formAnswers = [
+            '[form answers — discovery]',
+            '- output: Dashboard / tool UI',
+            '- brand: Pick a direction for me [value: pick_direction]',
+          ].join('\n');
+          const transcript = [
+            '## user',
+            'Design a metrics dashboard.',
+            '',
+            '## assistant',
+            '<question-form id="discovery" title="Quick brief — 30 seconds"></question-form>',
+            '',
+            '## user',
+            formAnswers,
+          ].join('\n');
+
+          const createResponse = await fetch(`${baseUrl}/api/runs`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              agentId: 'opencode',
+              message: transcript,
+              currentPrompt: formAnswers,
+            }),
+          });
+          expect(createResponse.status).toBe(202);
+          const { runId } = await createResponse.json() as { runId: string };
+          const statusBody = await waitForRunStatus(baseUrl, runId);
+
+          expect(statusBody.status).toBe('succeeded');
+          expect(existsSync(capturePath)).toBe(true);
+          const prompt = readFileSync(capturePath, 'utf8');
+          const transitionIdx = prompt.indexOf('## Latest user turn - form answers submitted');
+          const transcriptIdx = prompt.indexOf('## Full conversation transcript');
+          expect(transitionIdx).toBeGreaterThan(-1);
+          expect(transcriptIdx).toBeGreaterThan(transitionIdx);
+          expect(prompt).toContain('The user has answered the discovery form. Do not emit another discovery form.');
+          expect(prompt).toContain('Continue with RULE 2 / RULE 3 now.');
+          expect(prompt).toContain(formAnswers);
+        },
+      );
+    } finally {
+      if (previousCapturePath == null) {
+        delete process.env.OD_CAPTURE_PROMPT_PATH;
+      } else {
+        process.env.OD_CAPTURE_PROMPT_PATH = previousCapturePath;
       }
     }
   });

--- a/apps/daemon/tests/telemetry-message-finalization.test.ts
+++ b/apps/daemon/tests/telemetry-message-finalization.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  composeChatUserRequestForAgent,
   createFinalizedMessageTelemetryReporter,
   shouldReportRunCompletedFromMessage,
   telemetryPromptFromRunRequest,
@@ -55,6 +56,37 @@ describe('Langfuse message finalization gate', () => {
     expect(telemetryPromptFromRunRequest('legacy prompt', undefined)).toBe(
       'legacy prompt',
     );
+  });
+
+  it('promotes discovery form answers above the transcript with a build-now instruction', () => {
+    const currentPrompt = [
+      '[form answers \u2014 discovery]',
+      '- output: Dashboard / tool UI',
+      '- brand: Pick a direction for me [value: pick_direction]',
+    ].join('\n');
+    const prompt = composeChatUserRequestForAgent(
+      '## user\ninitial brief\n\n## assistant\n<form/>',
+      currentPrompt,
+    );
+
+    expect(prompt).toContain('## Latest user turn - form answers submitted');
+    expect(prompt).toContain(currentPrompt);
+    expect(prompt).toContain('The user has answered the discovery form.');
+    expect(prompt).toContain('For Branch B answers, build now instead of asking another brief.');
+    expect(prompt.indexOf('## Full conversation transcript')).toBeGreaterThan(
+      prompt.indexOf(currentPrompt),
+    );
+  });
+
+  it('keeps non-discovery form answers active without forcing the build transition', () => {
+    const prompt = composeChatUserRequestForAgent(
+      '## user\ninitial brief',
+      '[form answers - task-type]\n- taskType: Slide deck',
+    );
+
+    expect(prompt).toContain('The user has answered the task-type form.');
+    expect(prompt).toContain('Treat these form answers as the active user turn');
+    expect(prompt).not.toContain('build now instead of asking another brief');
   });
 
   it('invokes Langfuse reporting once when the final message write is marked', () => {


### PR DESCRIPTION
Fixes #787

## Why

I picked this up from #787 after the OpenCode + Opus 4.7 report that the agent could loop between viewing references and asking the Quick brief instead of entering the build phase.

The pain is in the daemon prompt handoff for local CLI agents: the web client already sends `currentPrompt` with the latest user turn, but the daemon only embedded the flattened transcript in `# User request`. When the latest turn is `[form answers — discovery]`, that means the user has answered the brief and the agent should transition into RULE 2 / RULE 3 instead of treating the transcript like a fresh request.

## What users will see

After submitting the discovery Quick brief, local CLI agents get an explicit “form answers submitted” active-turn block before the transcript. For the discovery form, the prompt now says to continue into RULE 2 / RULE 3 and build instead of emitting another discovery form.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not a UI surface change.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/chat-route.test.ts` (`marks submitted discovery form answers as the active turn before the transcript`)
- Did the test go red on `main` and green on this branch? yes — before the source change, the route test failed because the spawned fake OpenCode CLI did not receive the `## Latest user turn - form answers submitted` transition block. It passes after the fix.

## Validation

- `corepack pnpm exec vitest run -c vitest.config.ts tests/telemetry-message-finalization.test.ts`
- `corepack pnpm exec vitest run -c vitest.config.ts tests/chat-route.test.ts -t "marks submitted discovery form answers"`
- `corepack pnpm exec vitest run -c vitest.config.ts tests/chat-route.test.ts`
- `corepack pnpm --filter @open-design/contracts build`
- `corepack pnpm --filter @open-design/registry-protocol build`
- `corepack pnpm exec tsc -p tsconfig.json --noEmit` from `apps/daemon`
- `corepack pnpm exec tsc -p tsconfig.tests.json --noEmit` from `apps/daemon`
- `corepack pnpm --filter @open-design/daemon build`
- `corepack pnpm guard`

Environment note: this runner is on Node `v26.0.0`, while the repo asks for Node `~24`, so pnpm printed engine warnings during validation. The commands above exited 0.
