### PR TITLE
fix(daemon): make ACP model detection timeout configurable

### DIFF
--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 
 const ACP_PROTOCOL_VERSION = 1;
 const DEFAULT_TIMEOUT_MS = 15_000;
+const MAX_TIMEOUT_MS = 24 * 60 * 60 * 1000;
 // Gap-between-chunks watchdog for an ACP session stage. The timer resets on
 // every line received from the agent, so this bounds *silent* periods, not
 // total runtime. Default kept in line with the outer chat-run inactivity
@@ -73,6 +74,12 @@ interface AttachAcpSessionOptions {
 
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+function resolveAcpTimeoutMs(env: NodeJS.ProcessEnv, fallbackMs: number): number {
+  const raw = Number(env.OD_ACP_TIMEOUT_MS);
+  if (!Number.isFinite(raw)) return fallbackMs;
+  return Math.min(MAX_TIMEOUT_MS, Math.max(0, Math.floor(raw)));
 }
 
 function asObject(value: unknown): JsonObject | null {
@@ -308,6 +315,7 @@ export async function detectAcpModels({
   clientVersion = 'runtime-adapter',
   defaultModelOption = { id: 'default', label: 'Default (CLI config)' },
 }: DetectAcpModelsOptions): Promise<ModelOption[]> {
+  const effectiveTimeoutMs = resolveAcpTimeoutMs(env, timeoutMs);
   return await new Promise<ModelOption[]>((resolve, reject) => {
     const child = spawn(bin, args, {
       cwd,
@@ -322,11 +330,11 @@ export async function detectAcpModels({
     let expectedId = 1;
     let nextId = 2;
 
-    let timer: TimerHandle;
+    let timer: TimerHandle | null = null;
     const finish = <T extends ModelOption[] | Error>(fn: (value: T) => void, value: T) => {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
+      if (timer) clearTimeout(timer);
       try {
         child.stdin.end();
       } catch {}
@@ -394,9 +402,11 @@ export async function detectAcpModels({
       }
     });
 
-    timer = setTimeout(() => {
-      fail(`ACP model detection timed out after ${timeoutMs}ms`);
-    }, timeoutMs);
+    if (effectiveTimeoutMs > 0) {
+      timer = setTimeout(() => {
+        fail(`ACP model detection timed out after ${effectiveTimeoutMs}ms`);
+      }, effectiveTimeoutMs);
+    }
 
     writeRpc(1, 'initialize', {
       protocolVersion: ACP_PROTOCOL_VERSION,

--- a/apps/daemon/tests/acp-timeout-env.test.ts
+++ b/apps/daemon/tests/acp-timeout-env.test.ts
@@ -1,0 +1,128 @@
+import assert from 'node:assert/strict';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test, vi } from 'vitest';
+import { detectAcpModels } from '../src/acp.js';
+
+function writeStallingProbe(): { dir: string; bin: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'od-acp-timeout-'));
+  const bin = join(dir, 'stall-acp-probe.mjs');
+  writeFileSync(
+    bin,
+    'process.stdin.resume();\nsetTimeout(() => {}, 60_000);\n',
+    'utf8',
+  );
+  chmodSync(bin, 0o755);
+  return { dir, bin };
+}
+
+function writeDelayedSuccessProbe(delayMs: number): { dir: string; bin: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'od-acp-timeout-'));
+  const bin = join(dir, 'delayed-acp-probe.mjs');
+  writeFileSync(
+    bin,
+    [
+      'process.stdin.setEncoding("utf8");',
+      'let buffer = "";',
+      'process.stdin.on("data", (chunk) => {',
+      '  buffer += chunk;',
+      '  for (;;) {',
+      '    const idx = buffer.indexOf("\\n");',
+      '    if (idx === -1) break;',
+      '    const line = buffer.slice(0, idx).trim();',
+      '    buffer = buffer.slice(idx + 1);',
+      '    if (!line) continue;',
+      '    const message = JSON.parse(line);',
+      '    setTimeout(() => {',
+      '      process.stdout.write(JSON.stringify({ id: message.id, result: message.method === "session/new" ? { sessionId: "s1" } : {} }) + "\\n");',
+      `    }, ${delayMs});`,
+      '  }',
+      '});',
+      'process.stdin.resume();',
+    ].join('\n'),
+    'utf8',
+  );
+  chmodSync(bin, 0o755);
+  return { dir, bin };
+}
+
+test('detectAcpModels uses OD_ACP_TIMEOUT_MS from the ACP probe environment', async () => {
+  const { dir, bin } = writeStallingProbe();
+  try {
+    const started = Date.now();
+    await assert.rejects(
+      detectAcpModels({
+        bin: process.execPath,
+        args: [bin],
+        env: { OD_ACP_TIMEOUT_MS: '123' },
+        timeoutMs: 15_000,
+      }),
+      /ACP model detection timed out after 123ms/,
+    );
+    assert.ok(
+      Date.now() - started < 5_000,
+      'expected OD_ACP_TIMEOUT_MS to bound the probe instead of waiting for the 15s caller timeout',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('detectAcpModels ignores invalid OD_ACP_TIMEOUT_MS values', async () => {
+  const { dir, bin } = writeStallingProbe();
+  try {
+    await assert.rejects(
+      detectAcpModels({
+        bin: process.execPath,
+        args: [bin],
+        env: { OD_ACP_TIMEOUT_MS: 'not-a-number' },
+        timeoutMs: 50,
+      }),
+      /ACP model detection timed out after 50ms/,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('detectAcpModels caps oversized OD_ACP_TIMEOUT_MS values before scheduling timers', async () => {
+  vi.useFakeTimers();
+  const timeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+  try {
+    const probe = detectAcpModels({
+      bin: process.execPath,
+      args: ['-e', 'process.stdin.resume()'],
+      env: { OD_ACP_TIMEOUT_MS: '10000000000' },
+      timeoutMs: 15_000,
+    });
+    probe.catch(() => {});
+
+    const scheduledDelay = timeoutSpy.mock.calls
+      .map((call) => call[1])
+      .find((delay) => delay === 24 * 60 * 60 * 1000);
+
+    assert.equal(scheduledDelay, 24 * 60 * 60 * 1000);
+    await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1000);
+    await assert.rejects(probe, /ACP model detection timed out after 86400000ms/);
+  } finally {
+    timeoutSpy.mockRestore();
+    vi.useRealTimers();
+  }
+});
+
+test('detectAcpModels treats OD_ACP_TIMEOUT_MS=0 as disabling the ACP probe timeout', async () => {
+  const { dir, bin } = writeDelayedSuccessProbe(120);
+  try {
+    const models = await detectAcpModels({
+      bin: process.execPath,
+      args: [bin],
+      env: { OD_ACP_TIMEOUT_MS: '0' },
+      timeoutMs: 50,
+    });
+
+    assert.deepEqual(models, [{ id: 'default', label: 'Default (CLI config)' }]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Fixes #1469

## Why

#1734 already fixed the ACP stage watchdog that produced `ACP response timed out after 180000ms`: it raised the default to match the outer chat inactivity watchdog and added `OD_ACP_STAGE_TIMEOUT_MS`.

This PR handles the remaining ACP timeout from the same issue: the initial ACP model-detection probe still used a fixed `15_000ms` timeout. That can fail before slower local / hybrid ACP backends have time to initialize and report models.

This intentionally keeps the scope narrower than the closed #1527 attempt: no UI, no config file, no docs sweep, and no stage-timeout changes. It only wires the model-detection probe to an env var using the same bounded timer pattern already used elsewhere in the daemon.

## What users will see

Users running slower ACP-compatible CLIs can start Open Design with `OD_ACP_TIMEOUT_MS=<milliseconds>` to allow more time for ACP model discovery. Defaults are unchanged when the env var is absent or invalid. Setting `OD_ACP_TIMEOUT_MS=0` disables the ACP model-detection probe timeout, matching the existing watchdog escape-hatch convention used by `OD_ACP_STAGE_TIMEOUT_MS`.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — no UI surface touched.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/acp-timeout-env.test.ts` → `detectAcpModels uses OD_ACP_TIMEOUT_MS from the ACP probe environment`.
- Did the test go red on `main` and green on this branch? Yes. With only the test added on current `main`, it failed after 15.019s with `ACP model detection timed out after 15000ms` instead of the expected `123ms`; after this change, the focused ACP suite passes.
- Additional coverage verifies invalid values fall back to the caller default, oversized values are capped before scheduling Node timers, and `OD_ACP_TIMEOUT_MS=0` disables the ACP probe timeout instead of scheduling an immediate failure.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/acp-timeout-env.test.ts tests/acp.test.ts` from `apps/daemon` → 19/19 pass.
- `pnpm --filter @open-design/daemon typecheck` → pass.
- `pnpm guard` → pass.

Local note: this machine is running Node v26.0.0, so pnpm emitted the existing engine warning for the repo's `~24` target during validation.
