### PR TITLE
fix(web): resolve pointer html artifact previews

### DIFF
--- a/apps/web/src/artifacts/pointer.ts
+++ b/apps/web/src/artifacts/pointer.ts
@@ -1,0 +1,80 @@
+interface HtmlPointerArtifactTargetInput {
+  content: string;
+  candidateFileName: string;
+  projectFiles: Array<{ name: string; path?: string }>;
+}
+
+const MAX_POINTER_TEXT_BYTES = 100;
+const POINTER_TARGET_RE =
+  /^(?:见|see)(?:\s*[:：]\s*|\s+)[`"'“”‘’]?(.+?\.html?)[`"'“”‘’]?[.。]?$/iu;
+const SCRIPT_OR_STYLE_RE = /<(script|style)\b[^>]*>[\s\S]*?<\/\1>/gi;
+const HTML_TAG_RE = /<[^>]+>/g;
+
+export function resolveHtmlPointerArtifactTarget(
+  input: HtmlPointerArtifactTargetInput,
+): string | null {
+  const pointerText = visiblePointerText(input.content);
+  if (!pointerText || utf8ByteLength(pointerText) > MAX_POINTER_TEXT_BYTES) {
+    return null;
+  }
+
+  const match = POINTER_TARGET_RE.exec(pointerText);
+  if (!match) return null;
+
+  const target = normalizeTarget(match[1] ?? '');
+  if (!target || target === input.candidateFileName || !isSafeHtmlTarget(target)) {
+    return null;
+  }
+
+  const projectFileNames = input.projectFiles
+    .map((file) => file.path || file.name)
+    .filter((name) => name.toLowerCase().endsWith('.html') || name.toLowerCase().endsWith('.htm'));
+
+  if (projectFileNames.includes(target)) return target;
+
+  const basenameMatches = projectFileNames.filter((name) => basename(name) === target);
+  const [basenameMatch] = basenameMatches;
+  if (basenameMatches.length === 1 && basenameMatch && basenameMatch !== input.candidateFileName) {
+    return basenameMatch;
+  }
+
+  return null;
+}
+
+function visiblePointerText(content: string): string {
+  const stripped = content
+    .replace(/^\uFEFF/, '')
+    .replace(SCRIPT_OR_STYLE_RE, ' ')
+    .replace(HTML_TAG_RE, ' ');
+  return decodeBasicHtmlEntities(stripped).replace(/\s+/g, ' ').trim();
+}
+
+function normalizeTarget(value: string): string {
+  return value.trim().replace(/^[`"'“”‘’]+|[`"'“”‘’]+$/g, '');
+}
+
+function isSafeHtmlTarget(value: string): boolean {
+  if (!/\.(?:html?|HTML?)$/.test(value)) return false;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(value)) return false;
+  if (value.startsWith('/') || value.includes('\\') || value.includes('\0')) return false;
+  return value.split('/').every((segment) => segment && segment !== '.' && segment !== '..');
+}
+
+function basename(value: string): string {
+  const i = value.lastIndexOf('/');
+  return i >= 0 ? value.slice(i + 1) : value;
+}
+
+function utf8ByteLength(value: string): number {
+  return new TextEncoder().encode(value).length;
+}
+
+function decodeBasicHtmlEntities(value: string): string {
+  return value
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&');
+}

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -9,6 +9,7 @@ import {
   type PointerEvent as ReactPointerEvent,
 } from 'react';
 import { createHtmlArtifactManifest, inferLegacyManifest } from '../artifacts/manifest';
+import { resolveHtmlPointerArtifactTarget } from '../artifacts/pointer';
 import { validateHtmlArtifact } from '../artifacts/validate';
 import { createArtifactParser } from '../artifacts/parser';
 import { useT } from '../i18n';
@@ -372,6 +373,7 @@ export function ProjectView({
   const [artifact, setArtifact] = useState<Artifact | null>(null);
   const [filesRefresh, setFilesRefresh] = useState(0);
   const [projectFiles, setProjectFiles] = useState<ProjectFile[]>([]);
+  const projectFilesRef = useRef<ProjectFile[]>([]);
   const [liveArtifacts, setLiveArtifacts] = useState<LiveArtifactSummary[]>([]);
   const [liveArtifactEvents, setLiveArtifactEvents] = useState<LiveArtifactEventItem[]>([]);
   const [workspaceFocused, setWorkspaceFocused] = useState(false);
@@ -812,9 +814,14 @@ export function ProjectView({
 
   const refreshProjectFiles = useCallback(async (): Promise<ProjectFile[]> => {
     const next = await fetchProjectFiles(project.id);
+    projectFilesRef.current = next;
     setProjectFiles(next);
     return next;
   }, [project.id]);
+
+  useEffect(() => {
+    projectFilesRef.current = projectFiles;
+  }, [projectFiles]);
 
   const refreshLiveArtifacts = useCallback(async (): Promise<LiveArtifactSummary[]> => {
     const next = await fetchLiveArtifacts(project.id);
@@ -1820,7 +1827,7 @@ export function ProjectView({
           // up as a real tab (not just the synthetic "live" stream).
           setArtifact((prev) => {
             if (!prev || !prev.html) return prev;
-            void persistArtifact(prev);
+            void refreshProjectFiles().then((nextFiles) => persistArtifact(prev, nextFiles));
             return prev;
           });
           // Refetch the file list directly (rather than just bumping the
@@ -2044,13 +2051,37 @@ export function ProjectView({
   );
 
   const persistArtifact = useCallback(
-    async (art: Artifact) => {
+    async (art: Artifact, projectFilesSnapshot?: ProjectFile[]) => {
       const baseName = (art.identifier || art.title || 'artifact')
         .toLowerCase()
         .replace(/[^a-z0-9_-]+/g, '-')
         .replace(/^-+|-+$/g, '')
         .slice(0, 60) || 'artifact';
       const ext = artifactExtensionFor(art);
+      // Pick a name that doesn't collide with an existing project file.
+      // The first run uses `<base>.<ext>`; subsequent runs append `-2`, `-3`…
+      // so prior artifacts aren't silently overwritten.
+      const currentProjectFiles = projectFilesSnapshot ?? projectFilesRef.current;
+      const existing = new Set(currentProjectFiles.map((f) => f.name));
+      let fileName = `${baseName}${ext}`;
+      let n = 2;
+      while (existing.has(fileName) && savedArtifactRef.current !== fileName) {
+        fileName = `${baseName}-${n}${ext}`;
+        n += 1;
+      }
+      if (ext === '.html') {
+        const pointerTarget = resolveHtmlPointerArtifactTarget({
+          content: art.html,
+          candidateFileName: fileName,
+          projectFiles: currentProjectFiles,
+        });
+        if (pointerTarget) {
+          if (savedArtifactRef.current === pointerTarget) return;
+          savedArtifactRef.current = pointerTarget;
+          requestOpenFile(pointerTarget);
+          return;
+        }
+      }
       // Pre-write structural gate for HTML artifacts (#50, #1143). Reject
       // bodies that obviously aren't a complete document — usually a one-line
       // prose summary the model emitted inside `<artifact type="text/html">`
@@ -2062,16 +2093,6 @@ export function ProjectView({
           setError(`Refused to save artifact "${art.identifier || art.title || 'untitled'}": ${validation.reason}`);
           return;
         }
-      }
-      // Pick a name that doesn't collide with an existing project file.
-      // The first run uses `<base>.<ext>`; subsequent runs append `-2`, `-3`…
-      // so prior artifacts aren't silently overwritten.
-      const existing = new Set(projectFiles.map((f) => f.name));
-      let fileName = `${baseName}${ext}`;
-      let n = 2;
-      while (existing.has(fileName) && savedArtifactRef.current !== fileName) {
-        fileName = `${baseName}-${n}${ext}`;
-        n += 1;
       }
       if (savedArtifactRef.current === fileName) return;
       savedArtifactRef.current = fileName;
@@ -2133,7 +2154,7 @@ export function ProjectView({
         );
       }
     },
-    [project.id, projectFiles, requestOpenFile],
+    [project.id, project.designSystemId, project.skillId, requestOpenFile],
   );
 
   const handleContinueRemainingTasks = useCallback(

--- a/apps/web/tests/artifacts/pointer.test.ts
+++ b/apps/web/tests/artifacts/pointer.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveHtmlPointerArtifactTarget } from '../../src/artifacts/pointer';
+
+describe('resolveHtmlPointerArtifactTarget', () => {
+  it('resolves a short Chinese pointer artifact to an existing HTML file', () => {
+    const result = resolveHtmlPointerArtifactTarget({
+      content: '见 worker-edition-v2.html',
+      candidateFileName: 'worker-edition-v2-3.html',
+      projectFiles: [
+        { name: 'worker-edition-v2.html' },
+        { name: 'worker-edition-v2-3.html' },
+      ],
+    });
+
+    expect(result).toBe('worker-edition-v2.html');
+  });
+
+  it('resolves a minimal HTML wrapper whose visible body only points elsewhere', () => {
+    const result = resolveHtmlPointerArtifactTarget({
+      content:
+        '<!doctype html><html><body>见 <a href="worker-edition-v2.html">worker-edition-v2.html</a></body></html>',
+      candidateFileName: 'worker-edition-v2-3.html',
+      projectFiles: [{ name: 'worker-edition-v2.html' }],
+    });
+
+    expect(result).toBe('worker-edition-v2.html');
+  });
+
+  it('returns null when the pointer target is not an existing project HTML file', () => {
+    const result = resolveHtmlPointerArtifactTarget({
+      content: '见 worker-edition-v2.html',
+      candidateFileName: 'worker-edition-v2-3.html',
+      projectFiles: [{ name: 'summary.html' }],
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when a basename pointer would match multiple nested files', () => {
+    const result = resolveHtmlPointerArtifactTarget({
+      content: 'see index.html',
+      candidateFileName: 'index-2.html',
+      projectFiles: [
+        { name: 'desktop/index.html' },
+        { name: 'mobile/index.html' },
+      ],
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('does not treat real prose that mentions an HTML file as a pointer artifact', () => {
+    const result = resolveHtmlPointerArtifactTarget({
+      content: 'I updated worker-edition-v2.html with the final responsive layout and accessibility fixes.',
+      candidateFileName: 'worker-edition-v2-3.html',
+      projectFiles: [{ name: 'worker-edition-v2.html' }],
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -118,7 +118,9 @@ vi.mock('../../src/components/AvatarMenu', () => ({
 }));
 
 vi.mock('../../src/components/FileWorkspace', () => ({
-  FileWorkspace: () => <div data-testid="file-workspace" />,
+  FileWorkspace: ({ openRequest }: { openRequest?: { name: string; nonce: number } | null }) => (
+    <div data-testid="file-workspace" data-open-request-name={openRequest?.name ?? ''} />
+  ),
 }));
 
 vi.mock('../../src/components/Loading', () => ({
@@ -461,6 +463,44 @@ describe('ProjectView API empty response handling', () => {
     await waitFor(() => expect(mockedWriteProjectTextFile).toHaveBeenCalled());
     expect(screen.queryByText(/provider ended the request/i)).toBeNull();
     expect(screen.queryByText('empty_response:deepseek-chat')).toBeNull();
+  });
+
+  it('opens the real HTML page instead of saving a pointer artifact as the preview entry', async () => {
+    const realPage = {
+      name: 'worker-edition-v2.html',
+      path: 'worker-edition-v2.html',
+      kind: 'html',
+      mime: 'text/html',
+      size: 60_000,
+      mtime: 1,
+    };
+    mockedFetchProjectFiles.mockResolvedValue([realPage] as never);
+    const artifact =
+      '<artifact identifier="worker-edition-v2" type="text/html" title="合同审查报告">' +
+      '见 worker-edition-v2.html' +
+      '</artifact>';
+    mockedStreamMessage.mockImplementation(async (
+      _cfg: AppConfig,
+      _system: string,
+      _history: ChatMessage[],
+      _signal: AbortSignal,
+      handlers: StreamHandlers,
+    ) => {
+      handlers.onDelta(artifact);
+      handlers.onDone('');
+    });
+    renderProjectView();
+
+    await sendTestPrompt();
+
+    await waitFor(() => {
+      expect(hasSavedAssistantMessage((message) => message.runStatus === 'succeeded')).toBe(true);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('file-workspace').dataset.openRequestName).toBe('worker-edition-v2.html');
+    });
+    expect(mockedWriteProjectTextFile).not.toHaveBeenCalled();
+    expect(screen.queryByText(/Refused to save artifact/i)).toBeNull();
   });
 
   it('injects ElevenLabs voice options into API-mode audio project prompts', async () => {


### PR DESCRIPTION
Fixes #536

## Why

I picked this up from #536 after the prior daemon-side regression guard merged. That guard handles the later "real page shrank to a pointer" case, but the issue still called out first-emission pointer artifacts and preview selection as separate remaining work.

The user-facing pain is that an agent can write the real HTML page, then finish with an `<artifact>` block whose content is only a short pointer like `见 worker-edition-v2.html`. The web app then saved/opened that pointer as the artifact entry, so users saw a dead-end pointer page instead of the generated page.

## What users will see

When a final HTML artifact is only a short pointer to another existing project HTML file, Open Design opens the real target file and does not persist the pointer as the preview artifact entry. Normal HTML artifacts still save and open as before.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. This is a preview-selection behavior fix covered by tests; there is no new visible control or entry point.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/ProjectView.api-empty-response.test.tsx` (`opens the real HTML page instead of saving a pointer artifact as the preview entry`) and `apps/web/tests/artifacts/pointer.test.ts`
- Did the test go red on `main` and green on this branch? yes. The focused helper spec first failed with `expected null to be 'worker-edition-v2.html'`, then passed after the resolver/wiring.

## Validation

- `PATH=/Users/cyh/.nvm/versions/node/v24.13.0/bin:$PATH pnpm exec vitest run -c vitest.config.ts tests/components/ProjectView.api-empty-response.test.tsx tests/artifacts/pointer.test.ts` from `apps/web`
- `PATH=/Users/cyh/.nvm/versions/node/v24.13.0/bin:$PATH pnpm --filter @open-design/web test`
- `PATH=/Users/cyh/.nvm/versions/node/v24.13.0/bin:$PATH pnpm --filter @open-design/web typecheck`
- `PATH=/Users/cyh/.nvm/versions/node/v24.13.0/bin:$PATH pnpm guard`
- `PATH=/Users/cyh/.nvm/versions/node/v24.13.0/bin:$PATH pnpm typecheck`
