### PR TITLE
fix: discover Codex models from installed CLI

### DIFF
--- a/apps/daemon/src/runtimes/defs/codex.ts
+++ b/apps/daemon/src/runtimes/defs/codex.ts
@@ -1,13 +1,61 @@
 import { DEFAULT_MODEL_OPTION, clampCodexReasoning } from './shared.js';
+import type { RuntimeModelOption } from '../types.js';
 import type { RuntimeAgentDef } from '../types.js';
+
+export function parseCodexDebugModels(stdout: string): RuntimeModelOption[] | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(String(stdout || ''));
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const models = (parsed as { models?: unknown }).models;
+  if (!Array.isArray(models)) return null;
+
+  const out = [DEFAULT_MODEL_OPTION];
+  const seen = new Set<string>([DEFAULT_MODEL_OPTION.id]);
+  for (const raw of models) {
+    if (!raw || typeof raw !== 'object') continue;
+    const entry = raw as {
+      slug?: unknown;
+      id?: unknown;
+      display_name?: unknown;
+      name?: unknown;
+      visibility?: unknown;
+    };
+    if (entry.visibility === 'hidden') continue;
+    const id =
+      typeof entry.slug === 'string'
+        ? entry.slug.trim()
+        : typeof entry.id === 'string'
+          ? entry.id.trim()
+          : '';
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    const label =
+      typeof entry.display_name === 'string' && entry.display_name.trim()
+        ? entry.display_name.trim()
+        : typeof entry.name === 'string' && entry.name.trim()
+          ? entry.name.trim()
+          : id;
+    out.push({ id, label });
+  }
+  return out.length > 1 ? out : null;
+}
 
 export const codexAgentDef = {
     id: 'codex',
     name: 'Codex CLI',
     bin: 'codex',
     versionArgs: ['--version'],
-    // Codex doesn't have a `models` subcommand; ship the most common ids
-    // as a hint. Users can supply other ids via the custom-model input.
+    // Codex exposes its installed model catalog through `debug models` on
+    // recent CLIs. Older builds fall back to these static hints.
+    listModels: {
+      args: ['debug', 'models'],
+      parse: parseCodexDebugModels,
+      timeoutMs: 5000,
+    },
     fallbackModels: [
       DEFAULT_MODEL_OPTION,
       { id: 'gpt-5.5', label: 'gpt-5.5' },

--- a/apps/daemon/src/runtimes/detection.ts
+++ b/apps/daemon/src/runtimes/detection.ts
@@ -10,24 +10,34 @@ import type {
   DetectedAgent,
   RuntimeAgentDef,
   RuntimeCapabilityMap,
+  RuntimeModelSource,
   RuntimeModelOption,
 } from './types.js';
+
+type FetchedRuntimeModels = {
+  models: RuntimeModelOption[];
+  source: RuntimeModelSource;
+};
 
 async function fetchModels(
   def: RuntimeAgentDef,
   resolvedBin: string,
   env: NodeJS.ProcessEnv,
-): Promise<RuntimeModelOption[]> {
+): Promise<FetchedRuntimeModels> {
   if (typeof def.fetchModels === 'function') {
     try {
       const parsed = await def.fetchModels(resolvedBin, env);
-      if (!parsed || parsed.length === 0) return def.fallbackModels;
-      return parsed;
+      if (!parsed || parsed.length === 0) {
+        return { models: def.fallbackModels, source: 'fallback' };
+      }
+      return { models: parsed, source: 'live' };
     } catch {
-      return def.fallbackModels;
+      return { models: def.fallbackModels, source: 'fallback' };
     }
   }
-  if (!def.listModels) return def.fallbackModels;
+  if (!def.listModels) {
+    return { models: def.fallbackModels, source: 'fallback' };
+  }
   try {
     const { stdout } = await execAgentFile(resolvedBin, def.listModels.args, {
       env,
@@ -41,10 +51,12 @@ async function fetchModels(
     // Empty / null parse result means the CLI didn't actually return a
     // usable list (e.g. cursor-agent's "No models available"); fall back
     // to the static hint so the picker isn't stuck on Default-only.
-    if (!parsed || parsed.length === 0) return def.fallbackModels;
-    return parsed;
+    if (!parsed || parsed.length === 0) {
+      return { models: def.fallbackModels, source: 'fallback' };
+    }
+    return { models: parsed, source: 'live' };
   } catch {
-    return def.fallbackModels;
+    return { models: def.fallbackModels, source: 'fallback' };
   }
 }
 
@@ -109,6 +121,7 @@ function unavailableAgent(def: RuntimeAgentDef): DetectedAgent {
   return {
     ...stripFns(def),
     models: def.fallbackModels ?? [DEFAULT_MODEL_OPTION],
+    modelsSource: 'fallback',
     available: false,
     ...installMetaForAgent(def.id),
   };
@@ -164,11 +177,12 @@ async function probe(
     }
     agentCapabilities.set(def.id, caps);
   }
-  const models = await fetchModels(def, launch.launchPath, probeEnv);
+  const modelResult = await fetchModels(def, launch.launchPath, probeEnv);
   const auth = await probeAgentAuthStatus(def.id, launch.launchPath, probeEnv);
   return {
     ...stripFns(def),
-    models,
+    models: modelResult.models,
+    modelsSource: modelResult.source,
     available: true,
     path: launch.selectedPath,
     version: outcome.version,
@@ -184,7 +198,7 @@ async function probe(
 
 function stripFns(
   def: RuntimeAgentDef,
-): Omit<DetectedAgent, 'models' | 'available' | 'path' | 'version'> {
+): Omit<DetectedAgent, 'models' | 'modelsSource' | 'available' | 'path' | 'version'> {
   // Drop the buildArgs / listModels closures but keep declarative metadata
   // (reasoningOptions, streamFormat, name, bin, etc.). `models` is
   // populated separately by `fetchModels`, so we strip the static

--- a/apps/daemon/src/runtimes/types.ts
+++ b/apps/daemon/src/runtimes/types.ts
@@ -7,6 +7,8 @@ export type RuntimeModelOption = {
   label: string;
 };
 
+export type RuntimeModelSource = 'live' | 'fallback';
+
 export type RuntimeReasoningOption = RuntimeModelOption;
 
 export type RuntimeBuildOptions = {
@@ -87,6 +89,7 @@ export type DetectedAgent = Omit<
   | 'env'
 > & {
   models: RuntimeModelOption[];
+  modelsSource: RuntimeModelSource;
   available: boolean;
   authStatus?: 'ok' | 'missing' | 'unknown';
   authMessage?: string;

--- a/apps/daemon/tests/runtimes/registry-and-args.test.ts
+++ b/apps/daemon/tests/runtimes/registry-and-args.test.ts
@@ -161,6 +161,71 @@ test('codex model picker includes current OpenAI choices in priority order', asy
   }
 });
 
+test('codex parses live model catalog from debug models JSON', () => {
+  assert.ok(codex.listModels, 'codex must define live model discovery');
+  const parsed = codex.listModels.parse(JSON.stringify({
+    models: [
+      {
+        slug: 'gpt-6-codex',
+        display_name: 'GPT-6 Codex',
+        visibility: 'list',
+      },
+      {
+        slug: 'gpt-6-codex-mini',
+        display_name: 'GPT-6 Codex Mini',
+        visibility: 'list',
+      },
+      {
+        slug: 'gpt-hidden-internal',
+        display_name: 'Hidden internal',
+        visibility: 'hidden',
+      },
+    ],
+  }));
+
+  assert.deepEqual(parsed, [
+    { id: 'default', label: 'Default (CLI config)' },
+    { id: 'gpt-6-codex', label: 'GPT-6 Codex' },
+    { id: 'gpt-6-codex-mini', label: 'GPT-6 Codex Mini' },
+  ]);
+});
+
+test('codex detection surfaces live debug models separately from fallback models', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'od-agents-codex-live-models-'));
+  try {
+    await withEnvSnapshot(['PATH', 'OD_AGENT_HOME'], async () => {
+      const codexBin = join(dir, 'codex');
+      writeFileSync(
+        codexBin,
+        `#!/bin/sh
+if [ "$1" = "--version" ]; then echo "codex-cli 9.9.9"; exit 0; fi
+if [ "$1" = "debug" ] && [ "$2" = "models" ]; then
+  printf '%s\\n' '{"models":[{"slug":"gpt-6-codex","display_name":"GPT-6 Codex","visibility":"list"}]}'
+  exit 0
+fi
+exit 2
+`,
+      );
+      chmodSync(codexBin, 0o755);
+      process.env.OD_AGENT_HOME = dir;
+      process.env.PATH = dir;
+
+      const agents = await detectAgents();
+      const detected = agents.find((agent) => agent.id === 'codex');
+
+      assert.ok(detected);
+      assert.equal(detected.available, true);
+      assert.equal(detected.modelsSource, 'live');
+      assert.deepEqual(detected.models.map((m: { id: string }) => m.id), [
+        'default',
+        'gpt-6-codex',
+      ]);
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('codex picker includes gpt-5.1 model family', () => {
   const pickerModels = new Set(codex.fallbackModels.map((model) => model.id));
 

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -2183,6 +2183,15 @@ export function SettingsDialog({
                 const selectValue = customActive
                   ? CUSTOM_MODEL_SENTINEL
                   : modelValue;
+                const modelSource = selected.modelsSource ?? 'fallback';
+                const modelSourceLabel =
+                  modelSource === 'live'
+                    ? t('settings.modelSourceLive')
+                    : t('settings.modelSourceFallback');
+                const modelSourceHint =
+                  modelSource === 'live'
+                    ? t('settings.modelPickerLiveHint')
+                    : t('settings.modelPickerFallbackHint');
                 return (
                   <div className="agent-model-row">
                     <div className="agent-model-row-head">
@@ -2193,6 +2202,11 @@ export function SettingsDialog({
                         <label className="field">
                           <span className="field-label">
                             {t('settings.modelPicker')}
+                            <span
+                              className={`agent-model-source-badge ${modelSource}`}
+                            >
+                              {modelSourceLabel}
+                            </span>
                           </span>
                           <div className="agent-model-select-wrap">
                             <select
@@ -2229,7 +2243,7 @@ export function SettingsDialog({
                           </div>
                         </label>
                         <p className="hint agent-model-row-hint">
-                          {t('settings.modelPickerHint')}
+                          {modelSourceHint}
                         </p>
                       </>
                     ) : null}

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -136,9 +136,15 @@ export const ar: Dict = {
   'settings.themeDark': 'داكن',
   'settings.agentModelHead': 'النموذج لـ:',
   'settings.modelPicker': 'النموذج',
+  'settings.modelSourceLive': 'Live from CLI',
+  'settings.modelSourceFallback': 'Fallback list',
   'settings.reasoningPicker': 'جهد التفكير',
   'settings.modelPickerHint':
     'يتم جلبه من CLI عندما يعرض أمر `models`. "الافتراضي" يترك الخيار لإعدادات CLI؛ "مخصص..." يسمح لك بكتابة أي معرف نموذج يقبله CLI.',
+  'settings.modelPickerLiveHint':
+    'Models were refreshed from the installed CLI. Default still uses the CLI config.',
+  'settings.modelPickerFallbackHint':
+    'Using Open Design fallback models because the installed CLI did not return live model metadata. Rescan after updating or logging in to the CLI.',
   'settings.cliEnvTitle': 'CLI config locations',
   'settings.cliEnvHint':
     'Set non-secret config directories for packaged app runs and agent detection.',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -136,9 +136,15 @@ export const de: Dict = {
   'settings.themeDark': 'Dunkel',
   'settings.agentModelHead': 'Modell für:',
   'settings.modelPicker': 'Modell',
+  'settings.modelSourceLive': 'Live from CLI',
+  'settings.modelSourceFallback': 'Fallback list',
   'settings.reasoningPicker': 'Reasoning-Aufwand',
   'settings.modelPickerHint':
     'Wird aus der CLI geladen, wenn sie einen `models`-Befehl anbietet. „Standard“ überlässt die Auswahl der CLI-Konfiguration; mit „Benutzerdefiniert…“ können Sie jede von der CLI akzeptierte Modell-ID eingeben.',
+  'settings.modelPickerLiveHint':
+    'Models were refreshed from the installed CLI. Default still uses the CLI config.',
+  'settings.modelPickerFallbackHint':
+    'Using Open Design fallback models because the installed CLI did not return live model metadata. Rescan after updating or logging in to the CLI.',
   'settings.cliEnvTitle': 'CLI config locations',
   'settings.cliEnvHint':
     'Set non-secret config directories for packaged app runs and agent detection.',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -142,9 +142,15 @@ export const en: Dict = {
   'settings.themeDark': 'Dark',
   'settings.agentModelHead': 'Model for:',
   'settings.modelPicker': 'Model',
+  'settings.modelSourceLive': 'Live from CLI',
+  'settings.modelSourceFallback': 'Fallback list',
   'settings.reasoningPicker': 'Reasoning effort',
   'settings.modelPickerHint':
     'Default uses the CLI’s own config. Custom… lets you type any model id.',
+  'settings.modelPickerLiveHint':
+    'Models were refreshed from the installed CLI. Default still uses the CLI’s own config.',
+  'settings.modelPickerFallbackHint':
+    'Using Open Design’s fallback model list because the installed CLI did not return live model metadata. Rescan after updating or logging in to the CLI.',
   'settings.cliEnvTitle': 'Advanced: proxy & custom paths',
   'settings.cliEnvHint':
     'Use these only if you route CLI traffic through your own proxy or installed the binary in a non-standard location. Secrets stay in local app config and only the selected CLI sees them.',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -136,9 +136,15 @@ export const esES: Dict = {
   'settings.themeDark': 'Oscuro',
   'settings.agentModelHead': 'Modelo para:',
   'settings.modelPicker': 'Modelo',
+  'settings.modelSourceLive': 'Live from CLI',
+  'settings.modelSourceFallback': 'Fallback list',
   'settings.reasoningPicker': 'Esfuerzo de razonamiento',
   'settings.modelPickerHint':
     'Se obtiene de la CLI cuando expone un comando `models`. «Predeterminado» deja la elección a la propia configuración de la CLI; «Personalizado…» permite escribir cualquier id de modelo aceptado por la CLI.',
+  'settings.modelPickerLiveHint':
+    'Models were refreshed from the installed CLI. Default still uses the CLI config.',
+  'settings.modelPickerFallbackHint':
+    'Using Open Design fallback models because the installed CLI did not return live model metadata. Rescan after updating or logging in to the CLI.',
   'settings.cliEnvTitle': 'CLI config locations',
   'settings.cliEnvHint':
     'Set non-secret config directories for packaged app runs and agent detection.',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -136,9 +136,15 @@ export const fa: Dict = {
   'settings.themeDark': 'تاریک',
   'settings.agentModelHead': 'مدل برای:',
   'settings.modelPicker': 'مدل',
+  'settings.modelSourceLive': 'Live from CLI',
+  'settings.modelSourceFallback': 'Fallback list',
   'settings.reasoningPicker': 'سطح استدلال',
   'settings.modelPickerHint':
     'هنگامی که CLI یک دستور `models` را ارائه می‌دهد از آن دریافت می‌شود. «پیش‌فرض» انتخاب را به پیکربندی خود CLI واگذار می‌کند؛ «سفارشی…» به شما امکان می‌دهد هر شناسه مدلی را که CLI می‌پذیرد تایپ کنید.',
+  'settings.modelPickerLiveHint':
+    'Models were refreshed from the installed CLI. Default still uses the CLI config.',
+  'settings.modelPickerFallbackHint':
+    'Using Open Design fallback models because the installed CLI did not return live model metadata. Rescan after updating or logging in to the CLI.',
   'settings.cliEnvTitle': 'CLI config locations',
   'settings.cliEnvHint':
     'Set non-secret config directories for packaged app runs and agent detection.',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -136,9 +136,15 @@ export const fr: Dict = {
   'settings.themeDark': 'Sombre',
   'settings.agentModelHead': 'Modèle pour :',
   'settings.modelPicker': 'Modèle',
+  'settings.modelSourceLive': 'En direct depuis la CLI',
+  'settings.modelSourceFallback': 'Liste de secours',
   'settings.reasoningPicker': 'Effort de raisonnement',
   'settings.modelPickerHint':
     'Par défaut utilise la configuration propre de la CLI. Personnalisé… vous permet de saisir n’importe quel identifiant de modèle.',
+  'settings.modelPickerLiveHint':
+    'Les modèles ont été actualisés depuis la CLI installée. Par défaut utilise toujours la configuration propre de la CLI.',
+  'settings.modelPickerFallbackHint':
+    'Utilisation de la liste de modèles de secours d’Open Design, car la CLI installée n’a pas renvoyé de métadonnées de modèle en direct. Relancez l’analyse après avoir mis à jour la CLI ou vous y être connecté.',
   'settings.cliEnvTitle': 'Avancé : proxy et chemins personnalisés',
   'settings.cliEnvHint':
     'Utilisez ces réglages uniquement si vous routez le trafic CLI via votre propre proxy ou si le binaire est installé à un emplacement non standard. Les secrets restent dans la configuration locale de l’app et seule la CLI sélectionnée les voit.',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -136,9 +136,15 @@ export const hu: Dict = {
   'settings.themeDark': 'Sötét',
   'settings.agentModelHead': 'Modell ehhez:',
   'settings.modelPicker': 'Modell',
+  'settings.modelSourceLive': 'Live from CLI',
+  'settings.modelSourceFallback': 'Fallback list',
   'settings.reasoningPicker': 'Gondolkodási erőfeszítés',
   'settings.modelPickerHint':
     'A CLI-tól kérdezi le, ha az közzéteszi a `models` parancsot. Az „Alapértelmezett" a CLI saját konfigjára bízza a választást; az „Egyedi…" tetszőleges, a CLI által elfogadott modell-id-t enged megadni.',
+  'settings.modelPickerLiveHint':
+    'Models were refreshed from the installed CLI. Default still uses the CLI config.',
+  'settings.modelPickerFallbackHint':
+    'Using Open Design fallback models because the installed CLI did not return live model metadata. Rescan after updating or logging in to the CLI.',
   'settings.cliEnvTitle': 'CLI config locations',
   'settings.cliEnvHint':
     'Set non-secret config directories for packaged app runs and agent detection.',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -136,9 +136,15 @@ export const id: Dict = {
   'settings.themeDark': 'Gelap',
   'settings.agentModelHead': 'Model untuk:',
   'settings.modelPicker': 'Model',
+  'settings.modelSourceLive': 'Live from CLI',
+  'settings.modelSourceFallback': 'Fallback list',
   'settings.reasoningPicker': 'Kekuatan penalaran',
   'settings.modelPickerHint':
     'Diambil dari CLI jika tersedia. "Default" mengikuti konfigurasi CLI; "Custom..." untuk mengetik model id sendiri.',
+  'settings.modelPickerLiveHint':
+    'Models were refreshed from the installed CLI. Default still uses the CLI config.',
+  'settings.modelPickerFallbackHint':
+    'Using Open Design fallback models because the installed CLI did not return live model metadata. Rescan after updating or logging in to the CLI.',
   'settings.cliEnvTitle': 'Lokasi konfigurasi CLI',
   'settings.cliEnvHint': 'Atur direktori konfigurasi non-rahasia untuk menjalankan aplikasi paket dan deteksi agent.',
   'settings.cliEnvClaudeConfigDir': 'Direktori konfigurasi Claude Code',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -132,9 +132,15 @@ export const it: Dict = {
   'settings.themeLight': 'Chiaro',
   'settings.themeDark': 'Scuro',
   'settings.modelPicker': 'Modello',
+  'settings.modelSourceLive': 'Live from CLI',
+  'settings.modelSourceFallback': 'Fallback list',
   'settings.reasoningPicker': 'Sforzo di ragionamento',
   'settings.modelPickerHint':
     'Recuperato dalla CLI quando espone un comando `models`. "Predefinito" lascia la scelta alla configurazione della CLI; "Personalizzato…" ti permette di inserire qualsiasi identificatore di modello accettato dalla CLI.',
+  'settings.modelPickerLiveHint':
+    'Models were refreshed from the installed CLI. Default still uses the CLI config.',
+  'settings.modelPickerFallbackHint':
+    'Using Open Design fallback models because the installed CLI did not return live model metadata. Rescan after updating or logging in to the CLI.',
   'settings.cliEnvTitle': 'Posizioni di configurazione CLI',
   'settings.cliEnvHint':
     'Imposta directory di configurazione non segrete per esecuzioni di app impacchettate e rilevamento agenti.',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -136,9 +136,15 @@ export const ja: Dict = {
   'settings.themeDark': 'ダーク',
   'settings.agentModelHead': 'モデル：',
   'settings.modelPicker': 'モデル',
+  'settings.modelSourceLive': 'Live from CLI',
+  'settings.modelSourceFallback': 'Fallback list',
   'settings.reasoningPicker': '推論の強さ',
   'settings.modelPickerHint':
     'CLI が `models` コマンドを公開している場合に取得されます。「デフォルト」は CLI 自身の設定に委ね、「カスタム…」は CLI が受け付ける任意のモデル ID を入力できます。',
+  'settings.modelPickerLiveHint':
+    'Models were refreshed from the installed CLI. Default still uses the CLI config.',
+  'settings.modelPickerFallbackHint':
+    'Using Open Design fallback models because the installed CLI did not return live model metadata. Rescan after updating or logging in to the CLI.',
   'settings.cliEnvTitle': 'CLI config locations',
   'settings.cliEnvHint':
     'Set non-secret config directories for packaged app runs and agent detection.',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -136,9 +136,15 @@ export const ko: Dict = {
   'settings.themeDark': '다크',
   'settings.agentModelHead': '모델:',
   'settings.modelPicker': '모델',
+  'settings.modelSourceLive': 'Live from CLI',
+  'settings.modelSourceFallback': 'Fallback list',
   'settings.reasoningPicker': '추론 (Reasoning)',
   'settings.modelPickerHint':
     'CLI가 `models` 명령어를 지원할 때 가져옵니다. "Default"는 CLI 자체 설정을 따르며, "직접 입력…"을 선택하면 CLI가 허용하는 모델 ID를 입력할 수 있습니다.',
+  'settings.modelPickerLiveHint':
+    'Models were refreshed from the installed CLI. Default still uses the CLI config.',
+  'settings.modelPickerFallbackHint':
+    'Using Open Design fallback models because the installed CLI did not return live model metadata. Rescan after updating or logging in to the CLI.',
   'settings.cliEnvTitle': 'CLI config locations',
   'settings.cliEnvHint':
     'Set non-secret config directories for packaged app runs and agent detection.',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -136,9 +136,15 @@ export const pl: Dict = {
   'settings.themeDark': 'Ciemny',
   'settings.agentModelHead': 'Model dla:',
   'settings.modelPicker': 'Model',
+  'settings.modelSourceLive': 'Live from CLI',
+  'settings.modelSourceFallback': 'Fallback list',
   'settings.reasoningPicker': 'Poziom rozumowania',
   'settings.modelPickerHint':
       'Pobierane z CLI, gdy obsługuje ono polecenie `models`. „Domyślne” pozostawia wybór konfiguracji CLI; „Własne…” pozwala wpisać dowolne ID modelu akceptowane przez CLI.',
+  'settings.modelPickerLiveHint':
+    'Models were refreshed from the installed CLI. Default still uses the CLI config.',
+  'settings.modelPickerFallbackHint':
+    'Using Open Design fallback models because the installed CLI did not return live model metadata. Rescan after updating or logging in to the CLI.',
   'settings.cliEnvTitle': 'CLI config locations',
   'settings.cliEnvHint':
     'Set non-secret config directories for packaged app runs and agent detection.',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -136,9 +136,15 @@ export const ptBR: Dict = {
   'settings.themeDark': 'Escuro',
   'settings.agentModelHead': 'Modelo para:',
   'settings.modelPicker': 'Modelo',
+  'settings.modelSourceLive': 'Live from CLI',
+  'settings.modelSourceFallback': 'Fallback list',
   'settings.reasoningPicker': 'Esforço de raciocínio',
   'settings.modelPickerHint':
     'Buscado na CLI quando ela expõe um comando `models`. "Padrão" deixa a escolha para a configuração da própria CLI; "Personalizado…" permite digitar qualquer id de modelo aceito pela CLI.',
+  'settings.modelPickerLiveHint':
+    'Models were refreshed from the installed CLI. Default still uses the CLI config.',
+  'settings.modelPickerFallbackHint':
+    'Using Open Design fallback models because the installed CLI did not return live model metadata. Rescan after updating or logging in to the CLI.',
   'settings.cliEnvTitle': 'CLI config locations',
   'settings.cliEnvHint':
     'Set non-secret config directories for packaged app runs and agent detection.',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -136,9 +136,15 @@ export const ru: Dict = {
   'settings.themeDark': 'Тёмная',
   'settings.agentModelHead': 'Модель для:',
   'settings.modelPicker': 'Модель',
+  'settings.modelSourceLive': 'Live from CLI',
+  'settings.modelSourceFallback': 'Fallback list',
   'settings.reasoningPicker': 'Сложность рассуждений',
   'settings.modelPickerHint':
     'Получается из CLI, если он поддерживает команду `models`. «По умолчанию» оставляет выбор конфигурации CLI, а «Пользовательская…» позволяет ввести любой ID модели, который CLI принимает.',
+  'settings.modelPickerLiveHint':
+    'Models were refreshed from the installed CLI. Default still uses the CLI config.',
+  'settings.modelPickerFallbackHint':
+    'Using Open Design fallback models because the installed CLI did not return live model metadata. Rescan after updating or logging in to the CLI.',
   'settings.cliEnvTitle': 'CLI config locations',
   'settings.cliEnvHint':
     'Set non-secret config directories for packaged app runs and agent detection.',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -130,8 +130,14 @@ export const th: Dict = {
   'settings.themeDark': 'มืด',
   'settings.agentModelHead': 'โมเดลสำหรับ:',
   'settings.modelPicker': 'โมเดล',
+  'settings.modelSourceLive': 'Live from CLI',
+  'settings.modelSourceFallback': 'Fallback list',
   'settings.reasoningPicker': 'ความพยายามในการให้เหตุผล',
   'settings.modelPickerHint': 'ดึงข้อมูลจาก CLI เมื่อมีคำสั่ง `models`',
+  'settings.modelPickerLiveHint':
+    'Models were refreshed from the installed CLI. Default still uses the CLI config.',
+  'settings.modelPickerFallbackHint':
+    'Using Open Design fallback models because the installed CLI did not return live model metadata. Rescan after updating or logging in to the CLI.',
   'settings.cliEnvTitle': 'ตำแหน่งการตั้งค่า CLI',
   'settings.cliEnvHint': 'ตั้งค่าไดเรกทอรีการกำหนดค่า (ที่ไม่เป็นความลับ) สำหรับแอปพลิเคชัน',
   'settings.cliEnvClaudeConfigDir': 'ไดเรกทอรีการตั้งค่า Claude Code',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -136,9 +136,15 @@ export const tr: Dict = {
   'settings.themeDark': 'Koyu',
   'settings.agentModelHead': 'Model için:',
   'settings.modelPicker': 'Model',
+  'settings.modelSourceLive': 'Live from CLI',
+  'settings.modelSourceFallback': 'Fallback list',
   'settings.reasoningPicker': 'Akıl yürütme eforu',
   'settings.modelPickerHint':
     'Bir `models` komutu açığa çıkaran CLI’lardan getirilir. "Varsayılan" seçimi CLI’ın kendi ayarına bırakır; "Özel…" CLI’ın kabul edeceği herhangi bir model kimliği seçmenize izin verir.',
+  'settings.modelPickerLiveHint':
+    'Models were refreshed from the installed CLI. Default still uses the CLI config.',
+  'settings.modelPickerFallbackHint':
+    'Using Open Design fallback models because the installed CLI did not return live model metadata. Rescan after updating or logging in to the CLI.',
   'settings.modelCustom': 'Özel (aşağıya yazın)…',
   'settings.modelCustomLabel': 'Özel model kimliği',
   'settings.modelCustomPlaceholder': 'örn. anthropic/claude-sonnet-4-6',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -137,9 +137,15 @@ export const uk: Dict = {
   'settings.themeDark': 'Темна',
   'settings.agentModelHead': 'Модель для:',
   'settings.modelPicker': 'Модель',
+  'settings.modelSourceLive': 'Live from CLI',
+  'settings.modelSourceFallback': 'Fallback list',
   'settings.reasoningPicker': 'Інтенсивність міркувань',
   'settings.modelPickerHint':
     'Отримується з CLI, коли він виявляє команду `models`. «За замовчуванням» залишає вибір конфігурації CLI; «Власна…» дозволяє ввести будь-яке ID моделі, яке приймає CLI.',
+  'settings.modelPickerLiveHint':
+    'Models were refreshed from the installed CLI. Default still uses the CLI config.',
+  'settings.modelPickerFallbackHint':
+    'Using Open Design fallback models because the installed CLI did not return live model metadata. Rescan after updating or logging in to the CLI.',
   'settings.cliEnvTitle': 'CLI config locations',
   'settings.cliEnvHint':
     'Set non-secret config directories for packaged app runs and agent detection.',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -142,9 +142,15 @@ export const zhCN: Dict = {
   'settings.themeDark': '深色',
   'settings.agentModelHead': '模型：',
   'settings.modelPicker': '模型',
+  'settings.modelSourceLive': 'Live from CLI',
+  'settings.modelSourceFallback': 'Fallback list',
   'settings.reasoningPicker': '推理强度',
   'settings.modelPickerHint':
     '当 CLI 提供 `models` 命令时会自动拉取。选择「默认」则沿用 CLI 自身的配置；选择「自定义」可手动输入任何 CLI 支持的模型 id。',
+  'settings.modelPickerLiveHint':
+    'Models were refreshed from the installed CLI. Default still uses the CLI config.',
+  'settings.modelPickerFallbackHint':
+    'Using Open Design fallback models because the installed CLI did not return live model metadata. Rescan after updating or logging in to the CLI.',
   'settings.cliEnvTitle': 'CLI 配置位置',
   'settings.cliEnvHint':
     '为打包版应用运行和 agent 检测设置非敏感配置目录。',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -135,9 +135,15 @@ export const zhTW: Dict = {
   'settings.themeDark': '深色',
   'settings.agentModelHead': '模型：',
   'settings.modelPicker': '模型',
+  'settings.modelSourceLive': 'Live from CLI',
+  'settings.modelSourceFallback': 'Fallback list',
   'settings.reasoningPicker': '推理強度',
   'settings.modelPickerHint':
     '當 CLI 提供 `models` 命令時會自動拉取。選擇「預設」則沿用 CLI 自身的設定；選擇「自訂」可手動輸入任何 CLI 支援的模型 id。',
+  'settings.modelPickerLiveHint':
+    'Models were refreshed from the installed CLI. Default still uses the CLI config.',
+  'settings.modelPickerFallbackHint':
+    'Using Open Design fallback models because the installed CLI did not return live model metadata. Rescan after updating or logging in to the CLI.',
   'settings.cliEnvTitle': 'CLI 設定位置',
   'settings.cliEnvHint':
     '為打包版應用執行和 agent 偵測設定非敏感設定目錄。',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -166,8 +166,12 @@ export interface Dict {
   'settings.themeDark': string;
   'settings.agentModelHead': string;
   'settings.modelPicker': string;
+  'settings.modelSourceLive': string;
+  'settings.modelSourceFallback': string;
   'settings.reasoningPicker': string;
   'settings.modelPickerHint': string;
+  'settings.modelPickerLiveHint': string;
+  'settings.modelPickerFallbackHint': string;
   'settings.cliEnvTitle': string;
   'settings.cliEnvHint': string;
   'settings.cliEnvClaudeConfigDir': string;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5065,10 +5065,39 @@ a.avatar-item:visited {
 }
 .agent-model-row .field { gap: 4px; }
 .agent-model-row .field-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
   font-size: 11.5px;
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--text-muted);
+}
+.agent-model-source-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 18px;
+  padding: 2px 6px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-subtle);
+  color: var(--text-muted);
+  font-size: 10.5px;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0;
+  text-transform: none;
+}
+.agent-model-source-badge.live {
+  border-color: var(--green-border);
+  background: var(--green-bg);
+  color: var(--green);
+}
+.agent-model-source-badge.fallback {
+  border-color: var(--amber-border, color-mix(in srgb, var(--amber) 28%, var(--border)));
+  background: var(--amber-bg);
+  color: var(--amber);
 }
 .agent-model-row .hint { margin: 0; font-size: 11.5px; }
 .agent-model-select-wrap {

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -764,6 +764,50 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
     );
   });
 
+  it('labels live CLI model metadata in the model picker', () => {
+    renderSettingsDialog(
+      { mode: 'daemon', agentId: 'codex' },
+      {
+        agents: [
+          {
+            ...availableAgents[0]!,
+            modelsSource: 'live',
+            models: [
+              { id: 'default', label: 'Default' },
+              { id: 'gpt-6-codex', label: 'GPT-6 Codex' },
+            ],
+          },
+        ],
+      },
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: /Local CLI/i }));
+    expect(screen.getByText('Live from CLI')).toBeTruthy();
+    expect(
+      screen.getByText(/Models were refreshed from the installed CLI/i),
+    ).toBeTruthy();
+  });
+
+  it('labels fallback CLI model metadata in the model picker', () => {
+    renderSettingsDialog(
+      { mode: 'daemon', agentId: 'codex' },
+      {
+        agents: [
+          {
+            ...availableAgents[0]!,
+            modelsSource: 'fallback',
+          },
+        ],
+      },
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: /Local CLI/i }));
+    expect(screen.getByText('Fallback list')).toBeTruthy();
+    expect(
+      screen.getByText(/installed CLI did not return live model metadata/i),
+    ).toBeTruthy();
+  });
+
   it('shows an empty state when no local CLI agents are detected', () => {
     renderSettingsDialog(
       { mode: 'daemon', agentId: null },

--- a/packages/contracts/src/api/registry.ts
+++ b/packages/contracts/src/api/registry.ts
@@ -13,6 +13,8 @@ export interface AgentInfo {
   path?: string;
   version?: string | null;
   models?: AgentModelOption[];
+  /** Whether models came from the installed CLI or Open Design's static fallback. */
+  modelsSource?: 'live' | 'fallback';
   reasoningOptions?: AgentModelOption[];
   /** HTTPS URL to install or download the CLI (vendor docs, GitHub README, npm). */
   installUrl?: string;


### PR DESCRIPTION
Fixes #651

## Why

Open Design only exposed Codex models from a static fallback list, so users with an updated Codex CLI could still miss the current model catalog in Settings.

This PR adds live discovery through the installed Codex CLI and keeps the existing fallback path when the CLI is older, unavailable, or does not return usable metadata.

## What users will see

Settings -> Local CLI -> Model now shows whether the model list came live from the installed CLI or from Open Design's fallback list.

When live discovery works, the picker includes models returned by `codex debug models`. When it does not, users still get the fallback list plus a hint to rescan after updating or logging in to Codex.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [x] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. The UI change is a small source badge and explanatory hint in the existing Settings model picker.

## Bug fix verification

- Test path that reproduces the bug:
  - `apps/daemon/tests/runtimes/registry-and-args.test.ts`
  - `apps/web/tests/components/SettingsDialog.execution.test.tsx`
- Did the test go red on `main` and green on this branch? yes
  - The daemon specs failed on `main` because Codex had no live `listModels` hook or `modelsSource` marker.
  - The Settings specs failed on `main` because the model picker did not label live vs fallback metadata.

## Validation

- `corepack pnpm exec vitest run -c vitest.config.ts tests/runtimes/registry-and-args.test.ts` from `apps/daemon`
- `corepack pnpm exec vitest run -c vitest.config.ts tests/components/SettingsDialog.execution.test.tsx` from `apps/web`
- `corepack pnpm exec vitest run -c vitest.config.ts tests/i18n/locales.test.ts` from `apps/web`
- `corepack pnpm guard`
- `corepack pnpm --filter @open-design/contracts build`
- `corepack pnpm typecheck`
- `git diff --check`
