### PR TITLE
feat(web): unify plugin trust badges

### DIFF
--- a/apps/web/src/components/PluginLoopHome.tsx
+++ b/apps/web/src/components/PluginLoopHome.tsx
@@ -12,6 +12,7 @@ import {
 import { useI18n } from '../i18n';
 import { Icon } from './Icon';
 import { PluginDetailsModal } from './PluginDetailsModal';
+import { TrustBadge } from './TrustBadge';
 import { authorInitials, derivePluginSourceLinks } from '../runtime/plugin-source';
 
 export interface PluginLoopSubmit {
@@ -237,11 +238,7 @@ export function PluginLoopHome({ onSubmit }: Props) {
               >
                 <div className="plugin-loop-home__card-head">
                   <span className="plugin-loop-home__card-title">{p.title}</span>
-                  <span
-                    className={`plugin-loop-home__card-trust trust-${p.trust}`}
-                  >
-                    {p.trust}
-                  </span>
+                  <TrustBadge trust={p.trust} />
                 </div>
                 {p.manifest?.description ? (
                   <div className="plugin-loop-home__card-desc">

--- a/apps/web/src/components/PluginsView.tsx
+++ b/apps/web/src/components/PluginsView.tsx
@@ -27,6 +27,7 @@ import {
 import { Icon } from './Icon';
 import { PluginDetailsModal } from './PluginDetailsModal';
 import { PluginsHomeSection } from './PluginsHomeSection';
+import { TrustBadge } from './TrustBadge';
 import { useI18n } from '../i18n';
 import type { PluginUseAction } from './plugins-home/useActions';
 
@@ -478,9 +479,7 @@ function PluginShareConfirmModal({
           <div className="plugin-details-modal__head-titles">
             <div className="plugin-details-modal__head-row">
               <h2 className="plugin-details-modal__title">{actionTitle}</h2>
-              <span className="plugin-details-modal__trust trust-bundled">
-                Action plugin
-              </span>
+              <TrustBadge trust="official" label="Action plugin" />
             </div>
             <div className="plugin-details-modal__meta">
               <span>{details.eyebrow}</span>
@@ -542,7 +541,9 @@ function PluginShareConfirmModal({
               </div>
               <div>
                 <dt>Trust</dt>
-                <dd>{sourceRecord.trust}</dd>
+                <dd>
+                  <TrustBadge trust={sourceRecord.trust} />
+                </dd>
               </div>
             </dl>
           </section>
@@ -740,9 +741,7 @@ function AvailablePluginsPanel({
                 <div className="plugins-view__available-main">
                   <div className="plugins-view__row-title">
                     <span>{title}</span>
-                    <span className={`plugins-view__trust trust-${plugin.marketplace.trust}`}>
-                      {plugin.marketplace.trust}
-                    </span>
+                    <TrustBadge trust={plugin.marketplace.trust} />
                   </div>
                   {plugin.entry.description ? <p>{plugin.entry.description}</p> : null}
                   <div className="plugins-view__meta">
@@ -795,8 +794,6 @@ function AvailablePluginDetailsModal({
 }) {
   const title = plugin.entry.title ?? plugin.entry.name;
   const sourceName = plugin.marketplace.manifest.name ?? plugin.marketplace.url;
-  const trustClass =
-    plugin.marketplace.trust === 'official' ? 'bundled' : plugin.marketplace.trust;
   const publisher = plugin.entry.publisher;
   const publisherLabel =
     publisher?.id ?? publisher?.github ?? publisher?.url ?? null;
@@ -824,9 +821,7 @@ function AvailablePluginDetailsModal({
               >
                 {title}
               </h2>
-              <span className={`plugin-details-modal__trust trust-${trustClass}`}>
-                {plugin.marketplace.trust}
-              </span>
+              <TrustBadge trust={plugin.marketplace.trust} />
             </div>
             <div className="plugin-details-modal__meta">
               <span>{plugin.entry.name}</span>
@@ -1055,7 +1050,7 @@ function SourcesPanel({
                   {marketplace.url}
                 </a>
                 <div className="plugins-view__meta">
-                  <span>{marketplace.trust}</span>
+                  <TrustBadge trust={marketplace.trust} />
                   <span>{marketplace.manifest.plugins?.length ?? 0} plugins</span>
                   {marketplace.version ? <span>catalog v{marketplace.version}</span> : null}
                 </div>

--- a/apps/web/src/components/TrustBadge.tsx
+++ b/apps/web/src/components/TrustBadge.tsx
@@ -1,0 +1,70 @@
+import type {
+  MarketplaceTrust,
+  TrustTier,
+} from '@open-design/contracts';
+
+type TrustBadgeTrust = TrustTier | MarketplaceTrust;
+type NormalizedTrustTier = 'official' | 'trusted' | 'restricted';
+
+interface Props {
+  trust: TrustBadgeTrust;
+  label?: string;
+  className?: string;
+  variant?: 'default' | 'overlay';
+}
+
+const TRUST_META: Record<
+  NormalizedTrustTier,
+  { label: string; description: string }
+> = {
+  official: {
+    label: 'Official',
+    description: 'Open Design official',
+  },
+  trusted: {
+    label: 'Trusted',
+    description: 'Community trusted',
+  },
+  restricted: {
+    label: 'Restricted',
+    description: 'Restricted source',
+  },
+};
+
+export function TrustBadge({
+  trust,
+  label,
+  className,
+  variant = 'default',
+}: Props) {
+  const tier = normalizeTrustTier(trust);
+  const meta = TRUST_META[tier];
+  const text = label ?? meta.label;
+  const classes = [
+    'plugin-trust-badge',
+    `plugin-trust-badge--${tier}`,
+    variant === 'overlay' ? 'plugin-trust-badge--overlay' : '',
+    className ?? '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <span
+      className={classes}
+      data-trust-tier={tier}
+      data-trust-source={trust}
+      title={meta.description}
+      aria-label={`${meta.description}: ${text}`}
+    >
+      <span className="plugin-trust-badge__dot" aria-hidden />
+      <span>{text}</span>
+    </span>
+  );
+}
+
+export function normalizeTrustTier(trust: TrustBadgeTrust): NormalizedTrustTier {
+  if (trust === 'bundled' || trust === 'official') return 'official';
+  if (trust === 'trusted') return 'trusted';
+  return 'restricted';
+}

--- a/apps/web/src/components/plugin-details/PluginByline.tsx
+++ b/apps/web/src/components/plugin-details/PluginByline.tsx
@@ -13,6 +13,7 @@
 import { useState } from 'react';
 import type { InstalledPluginRecord } from '@open-design/contracts';
 import { Icon } from '../Icon';
+import { TrustBadge } from '../TrustBadge';
 import {
   authorInitials,
   derivePluginSourceLinks,
@@ -25,7 +26,6 @@ interface Props {
 
 export function PluginByline({ record, variant = 'default' }: Props) {
   const links = derivePluginSourceLinks(record);
-  const trust = record.trust;
   const version = record.version;
 
   return (
@@ -47,7 +47,7 @@ export function PluginByline({ record, variant = 'default' }: Props) {
           ) : (
             <span className="plugin-byline__name">{links.sourceLabel}</span>
           )}
-          <span className={`plugin-byline__trust trust-${trust}`}>{trust}</span>
+          <TrustBadge trust={record.trust} />
           <span className="plugin-byline__version">v{version}</span>
         </div>
         {variant === 'default' ? (

--- a/apps/web/src/components/plugin-details/PluginMetaSections.tsx
+++ b/apps/web/src/components/plugin-details/PluginMetaSections.tsx
@@ -32,6 +32,7 @@ import type {
   PluginManifest,
 } from '@open-design/contracts';
 import { Icon } from '../Icon';
+import { TrustBadge } from '../TrustBadge';
 import { authorInitials, derivePluginSourceLinks } from '../../runtime/plugin-source';
 import { resolvePluginQueryFallback } from '../../state/projects';
 
@@ -137,9 +138,7 @@ export function PluginMetaSections({ record, omit, compact, heading }: Props) {
           <span className="plugin-meta-sections__heading-meta">
             <span>v{record.version}</span>
             <span>·</span>
-            <span className={`plugin-meta-sections__trust trust-${record.trust}`}>
-              {record.trust}
-            </span>
+            <TrustBadge trust={record.trust} />
             {record.sourceKind ? (
               <>
                 <span>·</span>
@@ -526,9 +525,7 @@ export function PluginMetaSections({ record, omit, compact, heading }: Props) {
           <div>
             <dt>Trust</dt>
             <dd>
-              <span className={`plugin-details-modal__trust trust-${record.trust}`}>
-                {record.trust}
-              </span>
+              <TrustBadge trust={record.trust} />
             </dd>
           </div>
           {record.pinnedRef ? (

--- a/apps/web/src/components/plugin-details/PluginScenarioDetail.tsx
+++ b/apps/web/src/components/plugin-details/PluginScenarioDetail.tsx
@@ -13,6 +13,7 @@ import type {
   PluginManifest,
 } from '@open-design/contracts';
 import { Icon } from '../Icon';
+import { TrustBadge } from '../TrustBadge';
 import { PluginPreviewHero } from './PluginPreviewHero';
 import { PluginMetaSections } from './PluginMetaSections';
 import { PluginShareMenu } from './PluginShareMenu';
@@ -81,11 +82,7 @@ export function PluginScenarioDetail({
           <div className="plugin-details-modal__head-titles">
             <div className="plugin-details-modal__head-row">
               <h2 className="plugin-details-modal__title">{record.title}</h2>
-              <span
-                className={`plugin-details-modal__trust trust-${record.trust}`}
-              >
-                {record.trust}
-              </span>
+              <TrustBadge trust={record.trust} />
             </div>
             <div className="plugin-details-modal__meta">
               <span>v{record.version}</span>

--- a/apps/web/src/components/plugins-home/PluginCard.tsx
+++ b/apps/web/src/components/plugins-home/PluginCard.tsx
@@ -16,6 +16,7 @@ import { useMemo, useState } from 'react';
 import type { InstalledPluginRecord } from '@open-design/contracts';
 import type { PluginShareAction } from '../../state/projects';
 import { Icon } from '../Icon';
+import { TrustBadge } from '../TrustBadge';
 import { PreviewSurface } from './cards/PreviewSurface';
 import { inferPluginPreview } from './preview';
 import type { PluginUseAction } from './useActions';
@@ -93,9 +94,7 @@ export function PluginCard({
 
       <div className="plugins-home__card-overlay">
         <div className="plugins-home__card-overlay-top">
-          <span className={`plugins-home__trust trust-${record.trust}`}>
-            {record.trust}
-          </span>
+          <TrustBadge trust={record.trust} variant="overlay" />
           {isFeatured ? (
             <span className="plugins-home__overlay-featured" aria-hidden>
               <Icon name="star" size={11} />
@@ -249,9 +248,7 @@ export function PluginCard({
           ) : null}
           {record.title}
         </span>
-        <span className={`plugins-home__trust trust-${record.trust}`}>
-          {record.trust}
-        </span>
+        <TrustBadge trust={record.trust} />
       </div>
     </article>
   );

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -20511,6 +20511,63 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   text-decoration-thickness: 2px;
 }
 
+/* Unified trust badge for plugin registry surfaces. Installed
+   `bundled` plugins and marketplace `official` sources both render as
+   the user-facing Official tier. */
+.plugin-trust-badge {
+  --trust-fg: var(--text-muted);
+  --trust-bg: var(--bg-subtle);
+  --trust-border: var(--border);
+  --trust-dot: var(--trust-fg);
+
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex: 0 0 auto;
+  min-height: 20px;
+  max-width: 100%;
+  padding: 2px 8px;
+  border: 1px solid var(--trust-border);
+  border-radius: 999px;
+  background: var(--trust-bg);
+  color: var(--trust-fg);
+  font-size: 10.5px;
+  font-weight: 650;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+.plugin-trust-badge__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--trust-dot);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--trust-dot) 18%, transparent);
+}
+.plugin-trust-badge--official {
+  --trust-fg: var(--blue);
+  --trust-bg: var(--blue-bg);
+  --trust-border: color-mix(in srgb, var(--blue) 22%, var(--border));
+}
+.plugin-trust-badge--trusted {
+  --trust-fg: var(--green);
+  --trust-bg: var(--green-bg);
+  --trust-border: color-mix(in srgb, var(--green) 24%, var(--border));
+}
+.plugin-trust-badge--restricted {
+  --trust-fg: var(--amber);
+  --trust-bg: var(--amber-bg);
+  --trust-border: color-mix(in srgb, var(--amber) 28%, var(--border));
+}
+.plugin-trust-badge--overlay {
+  --trust-fg: #fff;
+  --trust-bg: rgba(255, 255, 255, 0.18);
+  --trust-border: rgba(255, 255, 255, 0.24);
+  --trust-dot: #fff;
+
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+}
+
 /* PluginLoopHome — the minimum-closed-loop Home entry: a single prompt
    textarea + plugin grid with "Use example query" affordance. Replaces
    the tabbed NewProjectPanel on Home until the plugin-first UX matures. */
@@ -20688,26 +20745,6 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-.plugin-loop-home__card-trust {
-  font-size: 10.5px;
-  padding: 1px 6px;
-  border-radius: 999px;
-  background: var(--bg-subtle);
-  color: var(--text-muted);
-  text-transform: capitalize;
-}
-.plugin-loop-home__card-trust.trust-bundled {
-  background: rgba(0, 120, 200, 0.08);
-  color: rgb(0, 100, 170);
-}
-.plugin-loop-home__card-trust.trust-trusted {
-  background: rgba(0, 160, 80, 0.1);
-  color: rgb(0, 110, 60);
-}
-.plugin-loop-home__card-trust.trust-restricted {
-  background: rgba(200, 120, 0, 0.1);
-  color: rgb(160, 90, 0);
 }
 .plugin-loop-home__card-desc {
   color: var(--text-muted);
@@ -20905,27 +20942,6 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   letter-spacing: -0.015em;
   line-height: 1.2;
   color: var(--text);
-}
-.plugin-details-modal__trust {
-  font-size: 11px;
-  padding: 2px 8px;
-  border-radius: 999px;
-  background: var(--bg-subtle);
-  color: var(--text-muted);
-  text-transform: capitalize;
-  font-weight: 500;
-}
-.plugin-details-modal__trust.trust-bundled {
-  background: rgba(0, 120, 200, 0.08);
-  color: rgb(0, 100, 170);
-}
-.plugin-details-modal__trust.trust-trusted {
-  background: rgba(0, 160, 80, 0.1);
-  color: rgb(0, 110, 60);
-}
-.plugin-details-modal__trust.trust-restricted {
-  background: rgba(200, 120, 0, 0.1);
-  color: rgb(160, 90, 0);
 }
 .plugin-details-modal__meta {
   display: flex;
@@ -22034,24 +22050,6 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   color: var(--text-muted);
   font-variant-numeric: tabular-nums;
 }
-.plugin-meta-sections__trust {
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  font-weight: 600;
-  font-size: 10px;
-  padding: 1px 6px;
-  border-radius: 4px;
-  background: var(--surface-2, color-mix(in srgb, var(--text) 6%, transparent));
-}
-.plugin-meta-sections__trust.trust-trusted,
-.plugin-meta-sections__trust.trust-bundled {
-  color: var(--accent);
-  background: color-mix(in srgb, var(--accent) 12%, transparent);
-}
-.plugin-meta-sections__trust.trust-restricted {
-  color: var(--warn, #b16500);
-  background: color-mix(in srgb, var(--warn, #b16500) 14%, transparent);
-}
 .plugin-meta-sections.is-compact .plugin-meta-sections__heading {
   padding: 2px 0 10px;
 }
@@ -22250,28 +22248,6 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   font-size: 13px;
   font-weight: 600;
   color: var(--text);
-}
-.plugin-byline__trust {
-  font-size: 10.5px;
-  font-weight: 600;
-  text-transform: capitalize;
-  letter-spacing: 0.02em;
-  padding: 2px 8px;
-  border-radius: 999px;
-  background: var(--bg-subtle);
-  color: var(--text-muted);
-}
-.plugin-byline__trust.trust-bundled {
-  background: rgba(0, 120, 200, 0.1);
-  color: rgb(0, 100, 170);
-}
-.plugin-byline__trust.trust-trusted {
-  background: rgba(0, 160, 80, 0.12);
-  color: rgb(0, 110, 60);
-}
-.plugin-byline__trust.trust-restricted {
-  background: rgba(200, 120, 0, 0.12);
-  color: rgb(160, 90, 0);
 }
 .plugin-byline__version {
   font-size: 11px;

--- a/apps/web/src/styles/home/plugins-home.css
+++ b/apps/web/src/styles/home/plugins-home.css
@@ -840,37 +840,6 @@
   color: var(--accent);
 }
 
-/* Trust pill — mirrors the project view styling. */
-.plugins-home__trust {
-  font-size: 10.5px;
-  padding: 1px 7px;
-  border-radius: 999px;
-  background: var(--bg-subtle);
-  color: var(--text-muted);
-  text-transform: capitalize;
-  flex: 0 0 auto;
-}
-.plugins-home__trust.trust-bundled {
-  background: var(--blue-bg);
-  color: var(--blue);
-}
-.plugins-home__trust.trust-trusted {
-  background: var(--green-bg);
-  color: var(--green);
-}
-.plugins-home__trust.trust-restricted {
-  background: var(--amber-bg);
-  color: var(--amber);
-}
-/* Inside the overlay the trust pill needs glassy chrome to read
-   over the dark gradient. */
-.plugins-home__card-overlay .plugins-home__trust {
-  background: rgba(255, 255, 255, 0.18);
-  color: white;
-  backdrop-filter: blur(6px);
-  -webkit-backdrop-filter: blur(6px);
-}
-
 /* Card action buttons — overlay variant */
 .plugins-home__action {
   appearance: none;

--- a/apps/web/src/styles/home/plugins-view.css
+++ b/apps/web/src/styles/home/plugins-view.css
@@ -335,15 +335,6 @@
   line-height: 1.45;
 }
 
-.plugins-view__trust {
-  flex: 0 0 auto;
-  padding: 2px 6px;
-  border-radius: 999px;
-  font-size: 10.5px;
-  font-weight: 650;
-  text-transform: uppercase;
-}
-
 .plugins-view__meta {
   display: flex;
   flex-wrap: wrap;
@@ -353,7 +344,7 @@
   font-size: 11.5px;
 }
 
-.plugins-view__meta span {
+.plugins-view__meta > span {
   padding: 2px 6px;
   border: 1px solid var(--border-soft);
   border-radius: 999px;

--- a/apps/web/tests/components/TrustBadge.test.tsx
+++ b/apps/web/tests/components/TrustBadge.test.tsx
@@ -1,0 +1,41 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { TrustBadge } from '../../src/components/TrustBadge';
+
+describe('TrustBadge', () => {
+  it('normalizes bundled installed plugins to the user-facing Official tier', () => {
+    const html = renderToStaticMarkup(<TrustBadge trust="bundled" />);
+
+    expect(html).toContain('Official');
+    expect(html).toContain('plugin-trust-badge--official');
+    expect(html).toContain('data-trust-tier="official"');
+    expect(html).toContain('Open Design official');
+  });
+
+  it('uses one visual API for marketplace trust tiers', () => {
+    const html = renderToStaticMarkup(
+      <>
+        <TrustBadge trust="official" />
+        <TrustBadge trust="trusted" />
+        <TrustBadge trust="restricted" />
+      </>,
+    );
+
+    expect(html).toContain('plugin-trust-badge--official');
+    expect(html).toContain('plugin-trust-badge--trusted');
+    expect(html).toContain('plugin-trust-badge--restricted');
+    expect(html).toContain('Community trusted');
+    expect(html).toContain('Restricted source');
+  });
+
+  it('allows contextual text while preserving the trust tier styling', () => {
+    const html = renderToStaticMarkup(
+      <TrustBadge trust="official" label="Action plugin" />,
+    );
+
+    expect(html).toContain('Action plugin');
+    expect(html).toContain('plugin-trust-badge--official');
+    expect(html).toContain('aria-label="Open Design official: Action plugin"');
+  });
+});


### PR DESCRIPTION
Fixes #2074

## Why

This follows `docs/plans/plugin-registry.md` §P2.7. While reviewing the plugin registry UI, the trust tier treatment was split across plugin cards, detail surfaces, marketplace rows, source rows, and confirmation dialogs, with `bundled` sometimes exposed as an implementation term instead of the user-facing official tier.

The pain addressed is visual inconsistency in a security-adjacent signal. Users should be able to recognize Official, Trusted, and Restricted badges immediately wherever plugin provenance appears.

## What users will see

Plugin trust badges now share one visual language across Home plugin cards, plugin details, Available marketplace entries, Available details, Sources, and plugin share/install confirmation surfaces. Bundled Open Design plugins display as `Official`; marketplace `official`, `trusted`, and `restricted` sources use the same badge component and color semantics.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Home plugin card official badge:

![Home plugin card official badge](https://imgbed.kami.fit:444/file/1779098554242_trust-badge-home-official.png)

Registry available entries:

![Registry available entries](https://imgbed.kami.fit:444/file/1779098557570_trust-badges-registry-available.png)

Registry detail drawer:

![Registry detail drawer](https://imgbed.kami.fit:444/file/1779098548326_trust-badges-registry-detail.png)

Registry sources tab:

![Registry sources tab](https://imgbed.kami.fit:444/file/1779098549185_trust-badges-registry-sources.png)

## Bug fix verification

- Not a bug fix; roadmap UI consistency slice. Added `apps/web/tests/components/TrustBadge.test.tsx` to lock tier normalization and shared badge semantics.

## Validation

- `corepack pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/components/TrustBadge.test.tsx tests/components/PluginDetailsModal.dispatch.test.tsx tests/components/plugins-home-section.test.tsx tests/components/PluginsView.test.tsx`
- `corepack pnpm --filter @open-design/web typecheck`
- `corepack pnpm guard`
- `git diff --check`
- Local Playwright screenshots included above.

Note: this local machine runs Node v26.0.0 while the repo asks for Node ~24, so pnpm prints engine warnings; the commands above exited 0.
