### PR TITLE
fix: limit page-count control width to 120px for better visual balance

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -22525,6 +22525,9 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   min-height: 56px;
   resize: vertical;
 }
+.plugin-inputs-form__input[type='number'] {
+  max-width: 120px;
+}
 
 /* ============================================================
    Note: the entry-view home redesign (left rail, centered hero,


### PR DESCRIPTION
## Summary

Fixes the issue where the page-count control in the Slide deck prefilled prompt appears too wide and visually unbalanced.

## Current behavior

After selecting Slide deck and auto-filling the prompt, the inline page-count number input stretches too long within the composer, making the prefilled prompt look awkward and reducing visual polish.

## Expected behavior

The page-count control should use a compact width (120px) that fits its content and feels visually aligned with the rest of the inline prompt tokens.

## Changes

- Added `max-width: 120px` to `.plugin-inputs-form__input[type='number']`
- Applies to all number inputs in plugin forms (page count, quantity, etc.)
- Maintains full functionality while reducing visual footprint
- Does not affect other input types (text, select, textarea, etc.)

## Why 120px?

- Sufficient for typical page counts (1-999+)
- Leaves room for spinner controls
- Visually balanced with surrounding text
- Consistent with compact inline control patterns

## Testing

- Tested with Slide deck plugin page-count control
- Verified number input still accepts values correctly
- Verified other input types (text, select, textarea) unaffected
- Verified visual balance in prefilled prompts

## Surface area

- [x] UI-only change (CSS, layout, visual polish)
- [ ] New user-facing feature
- [ ] Changes to core workflows (project creation, design generation, export)
- [ ] API or data model changes
- [ ] Configuration or settings changes
- [ ] Performance-sensitive code
- [ ] Security-sensitive code

## Screenshots

Before: Page-count control stretches too wide
After: Compact 120px width, visually balanced

Fixes #2085