### PR TITLE
feat(design-systems): define project manifest contract

### DIFF
--- a/design-systems/README.md
+++ b/design-systems/README.md
@@ -46,7 +46,62 @@ will read it as part of its system prompt.
 Folders use ASCII slugs — dotted brands are normalized (`linear.app` →
 `linear-app`, `x.ai` → `x-ai`, etc.).
 
-## File shape
+## Design System Project Shape
+
+The current runtime still supports legacy folders that contain only
+`DESIGN.md`. New imported or packaged systems should use the project shape
+below so picker, daemon, agents, validators, and future importers can all
+discover the same files without guessing.
+
+```text
+design-systems/<slug>/
+├── manifest.json       ← machine-readable project entry
+├── DESIGN.md           ← canonical design prose for agents
+├── tokens.css          ← canonical compiled CSS custom properties
+├── components.html     ← optional standalone component fixture
+├── assets/             ← optional brand assets
+└── preview/            ← optional static preview pages
+```
+
+`manifest.json` is validated by `pnpm guard` when present. PR1 does not
+require every bundled system to ship a manifest; old `DESIGN.md` systems are
+skipped by the manifest guard and continue to work.
+
+Minimum v1 manifest:
+
+```json
+{
+  "schemaVersion": "od-design-system-project/v1",
+  "id": "default",
+  "name": "Neutral Modern",
+  "category": "Starter",
+  "description": "A clean, product-oriented default.",
+  "source": {
+    "type": "bundled",
+    "origin": "hand-authored"
+  },
+  "files": {
+    "design": "DESIGN.md",
+    "tokens": "tokens.css",
+    "components": "components.html"
+  }
+}
+```
+
+For v1, file locations are intentionally fixed:
+
+- `files.design` must be `DESIGN.md`.
+- `files.tokens` must be `tokens.css`.
+- `files.components` is optional and, when declared, must be
+  `components.html`.
+- `assetsDir` is optional and, when declared, must be `assets`.
+- `previewDir` is optional and, when declared, must be `preview`.
+
+The schema source of truth lives in
+[`_schema/manifest.schema.ts`](_schema/manifest.schema.ts). The guard lives in
+[`../scripts/check-design-system-manifests.ts`](../scripts/check-design-system-manifests.ts).
+
+## Legacy File Shape
 
 The first H1 is the title shown in the picker. The line immediately after
 the H1 is parsed for `> Category: <name>` and used to group the dropdown:

--- a/design-systems/_schema/AGENTS.md
+++ b/design-systems/_schema/AGENTS.md
@@ -1,22 +1,41 @@
-# `_schema/` — the shared token contract
+# `_schema/` — design-system contracts
 
-This directory codifies the structural contract that every brand under
-`design-systems/<brand>/` must satisfy. It is the input to the drift
-guard (`scripts/check-tokens-fixture-sync.ts`) and the future derive
-script that will bulk-generate `tokens.css` for the ~140 brands that do
-not yet have hand-authored tokens.
+This directory codifies the structural contracts for design systems.
+`tokens.schema.ts` is the token contract that every tokenized brand under
+`design-systems/<brand>/` must satisfy. `manifest.schema.ts` is the
+project contract for folders that opt into the Design System Project
+shape by adding `manifest.json`; legacy `DESIGN.md`-only folders remain
+valid until they are migrated.
 
 ```
 _schema/
-├── tokens.schema.ts   ← canonical schema (TS, machine-enforced)
+├── manifest.schema.ts ← project manifest schema (TS, machine-enforced when present)
+├── tokens.schema.ts   ← canonical token schema (TS, machine-enforced)
 ├── defaults.css       ← A2 fallback values (CSS, human reference)
 └── AGENTS.md          ← this file
 ```
 
-The TypeScript schema is the source of truth. `defaults.css` is a
-human-readable mirror of the A2 `fallback` fields and exists so that
-reviewers can scan real CSS without parsing a TS array — drift between
-the two is enforced by the `design-system: A2 defaults parity` guard.
+The TypeScript schemas are the source of truth. `defaults.css` is a
+human-readable mirror of the A2 `fallback` fields in `tokens.schema.ts`
+and exists so that reviewers can scan real CSS without parsing a TS
+array — drift between the two is enforced by the `design-system: A2
+defaults parity` guard. Manifest shape is enforced by
+`scripts/check-design-system-manifests.ts` for any
+`design-systems/<brand>/manifest.json` that exists.
+
+## Project manifest contract
+
+Design System Project folders use fixed v1 file names:
+
+- `manifest.json` — machine-readable project entry.
+- `DESIGN.md` — canonical design prose.
+- `tokens.css` — canonical compiled tokens.
+- `components.html` — optional standalone component fixture.
+- `assets/` — optional brand assets.
+- `preview/` — optional static preview pages.
+
+The manifest guard validates only folders that ship `manifest.json`; it
+does not require the bundled catalog to migrate all at once.
 
 ## Four layers, two questions
 

--- a/design-systems/_schema/manifest.schema.ts
+++ b/design-systems/_schema/manifest.schema.ts
@@ -1,0 +1,224 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * design-systems/_schema/manifest.schema.ts
+ *
+ * Canonical contract for an Open Design Design System Project.
+ *
+ * `DESIGN.md` remains the prose source that agents read. The project
+ * manifest is the stable discovery layer around it: picker / daemon /
+ * importer code can find the canonical design prose, compiled tokens,
+ * optional component fixtures, and optional preview/assets directories
+ * without guessing from folder contents.
+ *
+ * PR1 deliberately defines the contract without changing runtime
+ * discovery. Existing DESIGN.md-only systems stay valid; this schema is
+ * enforced only for folders that choose to ship `manifest.json`.
+ * ─────────────────────────────────────────────────────────────────── */
+
+export const DESIGN_SYSTEM_PROJECT_SCHEMA_VERSION = "od-design-system-project/v1" as const;
+
+export type DesignSystemProjectSource =
+  | {
+      readonly type: "bundled";
+      /** Human-readable origin, e.g. upstream repo/package, when known. */
+      readonly origin?: string;
+    }
+  | {
+      readonly type: "local";
+      /** Absolute path selected by the user at import time. */
+      readonly path: string;
+      readonly importedAt?: string;
+    }
+  | {
+      readonly type: "github";
+      readonly url: string;
+      readonly branch?: string;
+      readonly commit?: string;
+      readonly importedAt?: string;
+    };
+
+export type DesignSystemProjectFiles = {
+  /**
+   * Canonical design prose for agent prompts. V1 keeps this fixed so
+   * DESIGN.md-only fallback and project manifests share the same source.
+   */
+  readonly design: "DESIGN.md";
+  /**
+   * Canonical compiled token stylesheet. New project manifests require
+   * it; legacy folders without a manifest may still be DESIGN.md-only.
+   */
+  readonly tokens: "tokens.css";
+  /**
+   * Optional standalone component fixture. First-class in the contract,
+   * but optional for MVP imports and prose-only brands.
+   */
+  readonly components?: "components.html";
+};
+
+export type DesignSystemProjectManifest = {
+  readonly schemaVersion: typeof DESIGN_SYSTEM_PROJECT_SCHEMA_VERSION;
+  /** Folder slug and stable picker id. Must match /^[a-z0-9-]+$/. */
+  readonly id: string;
+  readonly name: string;
+  readonly category: string;
+  readonly description?: string;
+  readonly source: DesignSystemProjectSource;
+  readonly files: DesignSystemProjectFiles;
+  /** Optional static assets root. V1 fixes the directory name. */
+  readonly assetsDir?: "assets";
+  /** Optional preview root. V1 fixes the directory name. */
+  readonly previewDir?: "preview";
+};
+
+export type DesignSystemManifestValidationResult =
+  | { readonly ok: true; readonly manifest: DesignSystemProjectManifest }
+  | { readonly ok: false; readonly errors: readonly string[] };
+
+const ALLOWED_TOP_LEVEL_KEYS = new Set([
+  "schemaVersion",
+  "id",
+  "name",
+  "category",
+  "description",
+  "source",
+  "files",
+  "assetsDir",
+  "previewDir",
+]);
+
+const ALLOWED_SOURCE_KEYS: Record<DesignSystemProjectSource["type"], ReadonlySet<string>> = {
+  bundled: new Set(["type", "origin"]),
+  local: new Set(["type", "path", "importedAt"]),
+  github: new Set(["type", "url", "branch", "commit", "importedAt"]),
+};
+
+const ALLOWED_FILES_KEYS = new Set(["design", "tokens", "components"]);
+
+export function parseDesignSystemProjectManifest(
+  raw: string,
+): DesignSystemManifestValidationResult {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch (error) {
+    return {
+      ok: false,
+      errors: [`manifest.json is not valid JSON: ${error instanceof Error ? error.message : String(error)}`],
+    };
+  }
+
+  return validateDesignSystemProjectManifest(value);
+}
+
+export function validateDesignSystemProjectManifest(
+  value: unknown,
+): DesignSystemManifestValidationResult {
+  const errors: string[] = [];
+
+  if (!isRecord(value)) {
+    return { ok: false, errors: ["manifest must be a JSON object"] };
+  }
+
+  rejectUnknownKeys(errors, "$", value, ALLOWED_TOP_LEVEL_KEYS);
+
+  expectLiteral(errors, "$.schemaVersion", value.schemaVersion, DESIGN_SYSTEM_PROJECT_SCHEMA_VERSION);
+  expectSlug(errors, "$.id", value.id);
+  expectNonEmptyString(errors, "$.name", value.name);
+  expectNonEmptyString(errors, "$.category", value.category);
+  if (value.description !== undefined) expectNonEmptyString(errors, "$.description", value.description);
+
+  validateSource(errors, value.source);
+  validateFiles(errors, value.files);
+
+  if (value.assetsDir !== undefined) expectLiteral(errors, "$.assetsDir", value.assetsDir, "assets");
+  if (value.previewDir !== undefined) expectLiteral(errors, "$.previewDir", value.previewDir, "preview");
+
+  if (errors.length > 0) return { ok: false, errors };
+  return { ok: true, manifest: value as DesignSystemProjectManifest };
+}
+
+function validateSource(errors: string[], value: unknown): void {
+  if (!isRecord(value)) {
+    errors.push("$.source must be an object");
+    return;
+  }
+
+  const type = value.type;
+  if (type !== "bundled" && type !== "local" && type !== "github") {
+    errors.push("$.source.type must be one of bundled, local, github");
+    return;
+  }
+
+  rejectUnknownKeys(errors, "$.source", value, ALLOWED_SOURCE_KEYS[type]);
+
+  if (type === "bundled") {
+    if (value.origin !== undefined) expectNonEmptyString(errors, "$.source.origin", value.origin);
+    return;
+  }
+
+  if (type === "local") {
+    expectNonEmptyString(errors, "$.source.path", value.path);
+    if (value.importedAt !== undefined) expectIsoDateTime(errors, "$.source.importedAt", value.importedAt);
+    return;
+  }
+
+  expectNonEmptyString(errors, "$.source.url", value.url);
+  if (value.branch !== undefined) expectNonEmptyString(errors, "$.source.branch", value.branch);
+  if (value.commit !== undefined) expectNonEmptyString(errors, "$.source.commit", value.commit);
+  if (value.importedAt !== undefined) expectIsoDateTime(errors, "$.source.importedAt", value.importedAt);
+}
+
+function validateFiles(errors: string[], value: unknown): void {
+  if (!isRecord(value)) {
+    errors.push("$.files must be an object");
+    return;
+  }
+
+  rejectUnknownKeys(errors, "$.files", value, ALLOWED_FILES_KEYS);
+  expectLiteral(errors, "$.files.design", value.design, "DESIGN.md");
+  expectLiteral(errors, "$.files.tokens", value.tokens, "tokens.css");
+  if (value.components !== undefined) {
+    expectLiteral(errors, "$.files.components", value.components, "components.html");
+  }
+}
+
+function rejectUnknownKeys(
+  errors: string[],
+  pathLabel: string,
+  value: Record<string, unknown>,
+  allowed: ReadonlySet<string>,
+): void {
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) errors.push(`${pathLabel}.${key} is not part of the v1 design-system project schema`);
+  }
+}
+
+function expectLiteral(
+  errors: string[],
+  pathLabel: string,
+  value: unknown,
+  expected: string,
+): void {
+  if (value !== expected) errors.push(`${pathLabel} must be ${JSON.stringify(expected)}`);
+}
+
+function expectNonEmptyString(errors: string[], pathLabel: string, value: unknown): void {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    errors.push(`${pathLabel} must be a non-empty string`);
+  }
+}
+
+function expectSlug(errors: string[], pathLabel: string, value: unknown): void {
+  if (typeof value !== "string" || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)) {
+    errors.push(`${pathLabel} must be a lowercase slug matching /^[a-z0-9]+(?:-[a-z0-9]+)*$/`);
+  }
+}
+
+function expectIsoDateTime(errors: string[], pathLabel: string, value: unknown): void {
+  if (typeof value !== "string" || Number.isNaN(Date.parse(value))) {
+    errors.push(`${pathLabel} must be an ISO-like datetime string`);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/scripts/check-design-system-manifests.test.ts
+++ b/scripts/check-design-system-manifests.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DESIGN_SYSTEM_PROJECT_SCHEMA_VERSION,
+  validateDesignSystemProjectManifest,
+} from "../design-systems/_schema/manifest.schema.ts";
+
+test("design-system project manifest schema accepts the v1 minimum shape", () => {
+  const result = validateDesignSystemProjectManifest({
+    schemaVersion: DESIGN_SYSTEM_PROJECT_SCHEMA_VERSION,
+    id: "cherry-studio",
+    name: "Cherry Studio",
+    category: "Imported",
+    description: "Extracted from an existing project.",
+    source: {
+      type: "github",
+      url: "https://github.com/cherryhq/cherry-studio",
+      branch: "main",
+      commit: "abc123",
+      importedAt: "2026-05-18T00:00:00.000Z",
+    },
+    files: {
+      design: "DESIGN.md",
+      tokens: "tokens.css",
+    },
+  });
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.manifest.files.design, "DESIGN.md");
+    assert.equal(result.manifest.files.tokens, "tokens.css");
+    assert.equal(result.manifest.files.components, undefined);
+  }
+});
+
+test("design-system project manifest schema keeps components.html optional but fixed when declared", () => {
+  const accepted = validateDesignSystemProjectManifest({
+    schemaVersion: DESIGN_SYSTEM_PROJECT_SCHEMA_VERSION,
+    id: "default",
+    name: "Neutral Modern",
+    category: "Starter",
+    source: { type: "bundled", origin: "hand-authored" },
+    files: {
+      design: "DESIGN.md",
+      tokens: "tokens.css",
+      components: "components.html",
+    },
+  });
+  assert.equal(accepted.ok, true);
+
+  const rejected = validateDesignSystemProjectManifest({
+    schemaVersion: DESIGN_SYSTEM_PROJECT_SCHEMA_VERSION,
+    id: "default",
+    name: "Neutral Modern",
+    category: "Starter",
+    source: { type: "bundled" },
+    files: {
+      design: "DESIGN.md",
+      tokens: "tokens.css",
+      components: "preview/components.html",
+    },
+  });
+  assert.equal(rejected.ok, false);
+  if (!rejected.ok) {
+    assert.match(rejected.errors.join("\n"), /\$\.files\.components/);
+  }
+});
+
+test("design-system project manifest schema rejects path drift and unknown keys", () => {
+  const result = validateDesignSystemProjectManifest({
+    schemaVersion: DESIGN_SYSTEM_PROJECT_SCHEMA_VERSION,
+    id: "Bad Slug",
+    name: "Bad",
+    category: "Imported",
+    source: {
+      type: "local",
+      path: "/tmp/project",
+      unexpected: true,
+    },
+    files: {
+      design: "design.md",
+      tokens: "colors.css",
+    },
+    extra: "field",
+  });
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    const errors = result.errors.join("\n");
+    assert.match(errors, /\$\.id/);
+    assert.match(errors, /\$\.source\.unexpected/);
+    assert.match(errors, /\$\.files\.design/);
+    assert.match(errors, /\$\.files\.tokens/);
+    assert.match(errors, /\$\.extra/);
+  }
+});

--- a/scripts/check-design-system-manifests.ts
+++ b/scripts/check-design-system-manifests.ts
@@ -1,0 +1,108 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * scripts/check-design-system-manifests.ts
+ *
+ * Guard for the Design System Project contract. PR1 only validates folders
+ * that opt into the project shape by shipping `manifest.json`; legacy
+ * DESIGN.md-only systems remain valid and are intentionally skipped.
+ *
+ * Run standalone: `pnpm exec tsx scripts/check-design-system-manifests.ts`
+ * Or as part of `pnpm guard` (registered in scripts/guard.ts).
+ * ─────────────────────────────────────────────────────────────────── */
+
+import { access, readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { parseDesignSystemProjectManifest } from "../design-systems/_schema/manifest.schema.ts";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const designSystemsRoot = path.join(repoRoot, "design-systems");
+const SKIPPED_DIRECTORIES = new Set(["_schema"]);
+
+function toRepositoryPath(filePath: string): string {
+  return path.relative(repoRoot, filePath).split(path.sep).join("/");
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function discoverManifestPaths(): Promise<string[]> {
+  let entries;
+  try {
+    entries = await readdir(designSystemsRoot, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const manifestPaths: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory() || SKIPPED_DIRECTORIES.has(entry.name)) continue;
+    const manifestPath = path.join(designSystemsRoot, entry.name, "manifest.json");
+    if (await exists(manifestPath)) manifestPaths.push(manifestPath);
+  }
+  manifestPaths.sort((a, b) => a.localeCompare(b));
+  return manifestPaths;
+}
+
+export async function checkDesignSystemManifests(): Promise<boolean> {
+  const manifestPaths = await discoverManifestPaths();
+  const violations: string[] = [];
+
+  for (const manifestPath of manifestPaths) {
+    const brandRoot = path.dirname(manifestPath);
+    const folderSlug = path.basename(brandRoot);
+    const repositoryManifestPath = toRepositoryPath(manifestPath);
+    const parsed = parseDesignSystemProjectManifest(await readFile(manifestPath, "utf8"));
+
+    if (!parsed.ok) {
+      for (const error of parsed.errors) violations.push(`${repositoryManifestPath}: ${error}`);
+      continue;
+    }
+
+    const manifest = parsed.manifest;
+    if (manifest.id !== folderSlug) {
+      violations.push(`${repositoryManifestPath}: $.id must match folder slug "${folderSlug}"`);
+    }
+
+    const requiredFiles = [
+      manifest.files.design,
+      manifest.files.tokens,
+      ...(manifest.files.components === undefined ? [] : [manifest.files.components]),
+    ];
+    for (const fileName of requiredFiles) {
+      const target = path.join(brandRoot, fileName);
+      if (!(await exists(target))) {
+        violations.push(`${repositoryManifestPath}: ${fileName} is declared but ${toRepositoryPath(target)} does not exist`);
+      }
+    }
+
+    if (manifest.assetsDir !== undefined && !(await exists(path.join(brandRoot, manifest.assetsDir)))) {
+      violations.push(`${repositoryManifestPath}: assetsDir is declared but ${manifest.assetsDir}/ does not exist`);
+    }
+    if (manifest.previewDir !== undefined && !(await exists(path.join(brandRoot, manifest.previewDir)))) {
+      violations.push(`${repositoryManifestPath}: previewDir is declared but ${manifest.previewDir}/ does not exist`);
+    }
+  }
+
+  if (violations.length > 0) {
+    console.error("Design system manifest violations:");
+    for (const violation of violations) console.error(`- ${violation}`);
+    return false;
+  }
+
+  console.log(
+    `Design system manifest check passed: ${manifestPaths.length} project manifest${manifestPaths.length === 1 ? "" : "s"} valid; DESIGN.md-only systems skipped.`,
+  );
+  return true;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const ok = await checkDesignSystemManifests();
+  if (!ok) process.exitCode = 1;
+}

--- a/scripts/guard.ts
+++ b/scripts/guard.ts
@@ -1,6 +1,7 @@
 import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
 
+import { checkDesignSystemManifests } from "./check-design-system-manifests.ts";
 import { checkDesignSystemFlagParity } from "./check-design-system-flag-parity.ts";
 import {
   checkDesignSystemA1RequiredTokens,
@@ -704,6 +705,7 @@ const checks: GuardCheck[] = [
   { name: "web test layout", run: checkWebTestLayout },
   { name: "tools layout", run: checkToolsLayout },
   { name: "style policy", run: checkStylePolicy },
+  { name: "design system manifests", run: checkDesignSystemManifests },
   { name: "design system token-fixture sync", run: checkDesignSystemTokenFixtureSync },
   { name: "design system A1 required tokens", run: checkDesignSystemA1RequiredTokens },
   { name: "design system A2 required tokens", run: checkDesignSystemA2RequiredTokens },


### PR DESCRIPTION
## Why

This PR starts the “extract design systems from existing projects” path by defining the project shape those imports will produce. The immediate need is to give imported and packaged design systems a stable contract before runtime consumption or importer work begins.

The pain being addressed is that `DESIGN.md` alone is enough for prose guidance, but not enough for Open Design to reliably discover compiled tokens, optional component fixtures, preview assets, or source provenance without guessing from folder contents.

## What users will see

No visible UI change yet. Existing `DESIGN.md` design systems continue to work as before; folders that opt into `manifest.json` now have a documented and guarded project format.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No UI surface changed.

## Bug fix verification

Not a bug fix.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm guard`
- `pnpm typecheck`
- `node --import tsx --test scripts/check-design-system-manifests.test.ts`

Notes: local validation emitted the existing Node engine warning because this machine is on Node v25.2.1 while the repo expects Node ~24.
