### PR TITLE
feat(design-systems): add default project manifest

### DIFF
--- a/design-systems/default/manifest.json
+++ b/design-systems/default/manifest.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": "od-design-system-project/v1",
+  "id": "default",
+  "name": "Neutral Modern",
+  "category": "Starter",
+  "description": "A clean, product-oriented default for B2B tools, dashboards, and utility pages.",
+  "source": {
+    "type": "bundled",
+    "origin": "hand-authored"
+  },
+  "files": {
+    "design": "DESIGN.md",
+    "tokens": "tokens.css",
+    "components": "components.html"
+  }
+}


### PR DESCRIPTION
## Why

This PR is the second step in the design-system project work: after defining the manifest contract, it gives one real bundled design system the new project shape so the contract is exercised by actual repository content.

The pain being addressed is that the manifest schema and guard need a concrete bundled sample before daemon/picker/agent runtime consumption starts. `default` is the smallest representative choice because it already has `DESIGN.md`, `tokens.css`, and `components.html`.

## What users will see

No visible UI change yet. The `default` design system keeps working through the existing `DESIGN.md` path, and now also has a `manifest.json` that points at its existing design, token, and component fixture files.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No UI surface changed.

## Bug fix verification

Not a bug fix.

## Validation

- `pnpm exec tsx scripts/check-design-system-manifests.ts`
- `node --import tsx --test scripts/check-design-system-manifests.test.ts`
- `pnpm guard`
- `pnpm typecheck`

Notes: local validation emitted the existing Node engine warning because this machine is on Node v25.2.1 while the repo expects Node ~24.
