### PR TITLE
feat(daemon): consume design system manifests

### DIFF
--- a/apps/daemon/src/design-systems.ts
+++ b/apps/daemon/src/design-systems.ts
@@ -1,7 +1,8 @@
-// Design-system registry. Scans <projectRoot>/design-systems/* for DESIGN.md
-// files. Title comes from the first H1. Category comes from a
-// `> Category: <name>` blockquote line beneath the H1. Summary is the first
-// paragraph between the H1 and the next heading (Category line stripped).
+// Design-system registry. Scans <projectRoot>/design-systems/* for design
+// system projects. Project folders may opt into manifest.json; legacy folders
+// with only DESIGN.md remain valid. Without a manifest, title comes from the
+// first H1, category from a `> Category: <name>` blockquote line beneath the
+// H1, and summary from the first paragraph between the H1 and next heading.
 
 import { readdir, readFile, stat } from 'node:fs/promises';
 import path from 'node:path';
@@ -19,6 +20,18 @@ export type DesignSystemSummary = {
 };
 
 type ColorToken = { name: string; value: string };
+type DesignSystemProjectManifest = {
+  schemaVersion: 'od-design-system-project/v1';
+  id: string;
+  name: string;
+  category: string;
+  description?: string;
+  files: {
+    design: 'DESIGN.md';
+    tokens: 'tokens.css';
+    components?: 'components.html';
+  };
+};
 
 export async function listDesignSystems(root: string): Promise<DesignSystemSummary[]> {
   const out: DesignSystemSummary[] = [];
@@ -30,18 +43,20 @@ export async function listDesignSystems(root: string): Promise<DesignSystemSumma
   }
   for (const entry of entries) {
     if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
-    const designPath = path.join(root, entry.name, 'DESIGN.md');
+    const brandRoot = path.join(root, entry.name);
+    const manifest = await readProjectManifest(brandRoot, entry.name);
+    const designPath = path.join(brandRoot, manifest?.files.design ?? 'DESIGN.md');
     try {
       const stats = await stat(designPath);
       if (!stats.isFile()) continue;
       const raw = await readFile(designPath, 'utf8');
       const titleMatch = /^#\s+(.+?)\s*$/m.exec(raw);
-      const title = cleanTitle(titleMatch?.[1] ?? entry.name);
+      const title = manifest?.name ?? cleanTitle(titleMatch?.[1] ?? entry.name);
       out.push({
         id: entry.name,
         title,
-        category: extractCategory(raw) ?? 'Uncategorized',
-        summary: summarize(raw),
+        category: manifest?.category ?? extractCategory(raw) ?? 'Uncategorized',
+        summary: manifest?.description?.trim() || summarize(raw),
         swatches: extractSwatches(raw),
         surface: extractSurface(raw),
         body: raw,
@@ -54,7 +69,9 @@ export async function listDesignSystems(root: string): Promise<DesignSystemSumma
 }
 
 export async function readDesignSystem(root: string, id: string): Promise<string | null> {
-  const file = path.join(root, id, 'DESIGN.md');
+  const brandRoot = path.join(root, id);
+  const manifest = await readProjectManifest(brandRoot, id);
+  const file = path.join(brandRoot, manifest?.files.design ?? 'DESIGN.md');
   try {
     return await readFile(file, 'utf8');
   } catch {
@@ -83,9 +100,13 @@ export async function readDesignSystemAssets(
   root: string,
   id: string,
 ): Promise<DesignSystemAssets> {
+  const brandRoot = path.join(root, id);
+  const manifest = await readProjectManifest(brandRoot, id);
   const [tokensCss, fixtureHtml] = await Promise.all([
-    readFileOptional(path.join(root, id, 'tokens.css')),
-    readFileOptional(path.join(root, id, 'components.html')),
+    readFileOptional(path.join(brandRoot, manifest?.files.tokens ?? 'tokens.css')),
+    manifest?.files.components === undefined && manifest !== null
+      ? Promise.resolve(undefined)
+      : readFileOptional(path.join(brandRoot, manifest?.files.components ?? 'components.html')),
   ]);
   return { tokensCss, fixtureHtml };
 }
@@ -184,6 +205,46 @@ function isAbsenceError(err: unknown): boolean {
   if (typeof err !== 'object' || err === null) return false;
   const code = (err as { code?: unknown }).code;
   return code === 'ENOENT' || code === 'ENOTDIR';
+}
+
+async function readProjectManifest(
+  brandRoot: string,
+  expectedId: string,
+): Promise<DesignSystemProjectManifest | null> {
+  let raw: string | undefined;
+  try {
+    raw = await readFileOptional(path.join(brandRoot, 'manifest.json'));
+  } catch {
+    return null;
+  }
+  if (raw === undefined) return null;
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isProjectManifest(parsed, expectedId)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function isProjectManifest(value: unknown, expectedId: string): value is DesignSystemProjectManifest {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  if (record.schemaVersion !== 'od-design-system-project/v1') return false;
+  if (record.id !== expectedId) return false;
+  if (typeof record.name !== 'string' || record.name.trim().length === 0) return false;
+  if (typeof record.category !== 'string' || record.category.trim().length === 0) return false;
+  if (record.description !== undefined && typeof record.description !== 'string') return false;
+
+  const files = record.files;
+  if (typeof files !== 'object' || files === null || Array.isArray(files)) return false;
+  const fileRecord = files as Record<string, unknown>;
+  return (
+    fileRecord.design === 'DESIGN.md' &&
+    fileRecord.tokens === 'tokens.css' &&
+    (fileRecord.components === undefined || fileRecord.components === 'components.html')
+  );
 }
 
 function summarize(raw: string): string {

--- a/apps/daemon/tests/design-system-assets.test.ts
+++ b/apps/daemon/tests/design-system-assets.test.ts
@@ -16,6 +16,8 @@ import { describe, expect, it } from 'vitest';
 
 import {
   isDesignTokenChannelEnabled,
+  listDesignSystems,
+  readDesignSystem,
   readDesignSystemAssets,
   resolveDesignSystemAssets,
 } from '../src/design-systems.js';
@@ -27,6 +29,29 @@ function fresh(): string {
 function brandDir(root: string, id: string): string {
   const dir = path.join(root, id);
   mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeDesignSystemProject(
+  root: string,
+  id: string,
+  {
+    manifest,
+    design = '# Markdown Title\n\n> Category: Markdown Category\n> Markdown summary.\n',
+    tokens = ':root { --bg: #fff; }',
+    components = '<button>fixture</button>',
+  }: {
+    manifest?: Record<string, unknown>;
+    design?: string;
+    tokens?: string;
+    components?: string | null;
+  } = {},
+): string {
+  const dir = brandDir(root, id);
+  writeFileSync(path.join(dir, 'DESIGN.md'), design);
+  writeFileSync(path.join(dir, 'tokens.css'), tokens);
+  if (components !== null) writeFileSync(path.join(dir, 'components.html'), components);
+  if (manifest) writeFileSync(path.join(dir, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
   return dir;
 }
 
@@ -113,6 +138,99 @@ describe('readDesignSystemAssets', () => {
 
     const assets = await readDesignSystemAssets(root, 'partial');
     expect(assets.tokensCss).toBe(':root { --x: 1; }');
+    expect(assets.fixtureHtml).toBeUndefined();
+  });
+});
+
+describe('Design System Project manifest runtime consumption', () => {
+  it('uses manifest name/category/description for listings while still reading DESIGN.md body', async () => {
+    const root = fresh();
+    writeDesignSystemProject(root, 'project-system', {
+      manifest: {
+        schemaVersion: 'od-design-system-project/v1',
+        id: 'project-system',
+        name: 'Project System',
+        category: 'Imported',
+        description: 'Description from manifest.',
+        source: { type: 'local', path: '/tmp/project' },
+        files: {
+          design: 'DESIGN.md',
+          tokens: 'tokens.css',
+          components: 'components.html',
+        },
+      },
+      design: '# Markdown Title\n\n> Category: Markdown Category\n> Markdown summary.\n\nBody.\n',
+    });
+
+    const systems = await listDesignSystems(root);
+    expect(systems).toHaveLength(1);
+    expect(systems[0]).toMatchObject({
+      id: 'project-system',
+      title: 'Project System',
+      category: 'Imported',
+      summary: 'Description from manifest.',
+      body: '# Markdown Title\n\n> Category: Markdown Category\n> Markdown summary.\n\nBody.\n',
+    });
+
+    await expect(readDesignSystem(root, 'project-system')).resolves.toContain('# Markdown Title');
+  });
+
+  it('keeps DESIGN.md-only systems working next to project manifests', async () => {
+    const root = fresh();
+    writeDesignSystemProject(root, 'project-system', {
+      manifest: {
+        schemaVersion: 'od-design-system-project/v1',
+        id: 'project-system',
+        name: 'Project System',
+        category: 'Imported',
+        description: 'Description from manifest.',
+        source: { type: 'bundled' },
+        files: {
+          design: 'DESIGN.md',
+          tokens: 'tokens.css',
+        },
+      },
+      components: null,
+    });
+    writeDesignSystemProject(root, 'legacy-system', {
+      design: '# Legacy System\n\n> Category: Legacy\n> Legacy summary.\n\nBody.\n',
+      components: null,
+    });
+
+    const systems = await listDesignSystems(root);
+    expect(systems.map((s) => s.id).sort()).toEqual(['legacy-system', 'project-system']);
+    expect(systems.find((s) => s.id === 'legacy-system')).toMatchObject({
+      title: 'Legacy System',
+      category: 'Legacy',
+      summary: 'Legacy summary.',
+    });
+    expect(systems.find((s) => s.id === 'project-system')).toMatchObject({
+      title: 'Project System',
+      category: 'Imported',
+      summary: 'Description from manifest.',
+    });
+  });
+
+  it('reads manifest-declared tokens and skips missing optional components.html', async () => {
+    const root = fresh();
+    writeDesignSystemProject(root, 'tokens-only-project', {
+      manifest: {
+        schemaVersion: 'od-design-system-project/v1',
+        id: 'tokens-only-project',
+        name: 'Tokens Only Project',
+        category: 'Imported',
+        source: { type: 'bundled' },
+        files: {
+          design: 'DESIGN.md',
+          tokens: 'tokens.css',
+        },
+      },
+      tokens: ':root { --accent: #2F6FEB; }',
+      components: null,
+    });
+
+    const assets = await readDesignSystemAssets(root, 'tokens-only-project');
+    expect(assets.tokensCss).toBe(':root { --accent: #2F6FEB; }');
     expect(assets.fixtureHtml).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Why

This PR is the runtime-consumption step for Design System Projects. PR1 defines the manifest contract and PR2 adds the first bundled sample; this PR makes the daemon recognize that manifest at discovery time while keeping legacy `DESIGN.md` folders working.

The pain being addressed is that picker/agent behavior still inferred display metadata from markdown even when a design system project had a machine-readable manifest. Runtime now has one project-aware path for listing metadata and structured assets without removing the old fallback.

## What users will see

No new UI surface is added. In existing design-system pickers, systems with a valid `manifest.json` can now display the manifest `name`, `category`, and `description`; systems without a manifest continue to display the metadata inferred from `DESIGN.md`.

Agents still receive `DESIGN.md`, and when the token channel is enabled they can receive `tokens.css`; `components.html` is consumed when declared/present and skipped when optional.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No UI surface changed.

## Bug fix verification

Not a bug fix.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/design-system-assets.test.ts`
- `pnpm guard`
- `pnpm typecheck`
- Manual smoke with `listDesignSystems('./design-systems')` and `readDesignSystemAssets('./design-systems', 'default')`

Notes: local validation emitted the existing Node engine warning because this machine is on Node v25.2.1 while the repo expects Node ~24. I also accidentally invoked the full daemon test suite through the package script; it hit an unrelated existing/flaky `chat-route.test.ts` assertion, while the targeted design-system test file passed.
