### PR TITLE
feat(design-systems): import local project systems

### DIFF
--- a/apps/daemon/src/design-system-import.ts
+++ b/apps/daemon/src/design-system-import.ts
@@ -1,0 +1,568 @@
+import { copyFile, mkdir, readFile, readdir, realpath, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+export type LocalDesignSystemImportResult = {
+  id: string;
+  dir: string;
+  files: string[];
+};
+
+export type LocalDesignSystemImportOptions = {
+  now?: Date;
+  name?: string;
+  reservedIds?: Iterable<string>;
+};
+
+type ProjectScan = {
+  sourceRoot: string;
+  packageName: string | undefined;
+  packageDescription: string | undefined;
+  packageTech: string[];
+  readmeExcerpt: string | undefined;
+  cssVariables: CssVariable[];
+  tailwindSignals: string[];
+  assets: AssetCandidate[];
+  components: ComponentSignal[];
+};
+
+type CssVariable = {
+  name: string;
+  value: string;
+  source: string;
+};
+
+type AssetCandidate = {
+  absPath: string;
+  relPath: string;
+  size: number;
+};
+
+type ComponentSignal = {
+  name: string;
+  relPath: string;
+};
+
+const IGNORED_DIRS = new Set([
+  '.git',
+  '.hg',
+  '.next',
+  '.nuxt',
+  '.od',
+  '.tmp',
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+  'out',
+  'target',
+]);
+
+const STYLE_EXTENSIONS = new Set(['.css', '.scss', '.sass', '.less']);
+const COMPONENT_EXTENSIONS = new Set(['.tsx', '.jsx', '.vue', '.svelte']);
+const ASSET_EXTENSIONS = new Set(['.svg', '.png', '.jpg', '.jpeg', '.webp', '.ico']);
+const COMPONENT_NAMES = ['Button', 'Input', 'Card', 'Nav', 'Navbar', 'Sidebar'];
+const TOKEN_FALLBACKS = {
+  bg: '#f8fafc',
+  surface: '#ffffff',
+  surfaceWarm: '#f3f4f6',
+  fg: '#111827',
+  fg2: '#374151',
+  muted: '#6b7280',
+  meta: '#9ca3af',
+  border: '#d1d5db',
+  borderSoft: '#e5e7eb',
+  accent: '#2563eb',
+  accentOn: '#ffffff',
+  accentHover: '#1d4ed8',
+  accentActive: '#1e40af',
+  success: '#16a34a',
+  warn: '#d97706',
+  danger: '#dc2626',
+  fontSans: 'Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+  fontSerif: 'Georgia, "Times New Roman", serif',
+  fontMono: '"SFMono-Regular", Consolas, "Liberation Mono", monospace',
+  radius: '10px',
+};
+
+export async function importLocalDesignSystemProject(
+  sourceRootInput: string,
+  userDesignSystemsRoot: string,
+  options: LocalDesignSystemImportOptions = {},
+): Promise<LocalDesignSystemImportResult> {
+  const sourceRoot = await realpath(sourceRootInput);
+  const sourceStats = await stat(sourceRoot);
+  if (!sourceStats.isDirectory()) {
+    throw new LocalDesignSystemImportError('BAD_REQUEST', 'local project path must be a directory');
+  }
+
+  const scan = await scanProject(sourceRoot);
+  const displayName = cleanDisplayName(options.name ?? scan.packageName ?? path.basename(sourceRoot));
+  const id = await nextAvailableSlug(userDesignSystemsRoot, slugify(displayName), options.reservedIds);
+  const outDir = path.join(userDesignSystemsRoot, id);
+  await mkdir(outDir, { recursive: true });
+
+  const files = ['DESIGN.md', 'tokens.css', 'components.html', 'manifest.json'];
+  await writeFile(path.join(outDir, 'DESIGN.md'), renderDesignMd(id, displayName, scan), 'utf8');
+  await writeFile(path.join(outDir, 'tokens.css'), renderTokensCss(scan), 'utf8');
+  await writeFile(path.join(outDir, 'components.html'), renderComponentsHtml(displayName), 'utf8');
+  await writeFile(
+    path.join(outDir, 'manifest.json'),
+    `${JSON.stringify(renderManifest(id, displayName, scan, options.now ?? new Date()), null, 2)}\n`,
+    'utf8',
+  );
+
+  const copiedAssets = await copyAssets(scan.assets, outDir);
+  files.push(...copiedAssets);
+  return { id, dir: outDir, files };
+}
+
+export class LocalDesignSystemImportError extends Error {
+  constructor(
+    readonly code: 'BAD_REQUEST' | 'INTERNAL_ERROR',
+    message: string,
+  ) {
+    super(message);
+    this.name = 'LocalDesignSystemImportError';
+  }
+}
+
+async function scanProject(sourceRoot: string): Promise<ProjectScan> {
+  const [packageJson, readmeExcerpt, files] = await Promise.all([
+    readPackageJson(sourceRoot),
+    readReadme(sourceRoot),
+    walkProject(sourceRoot),
+  ]);
+  const styleFiles = files
+    .filter((file) => STYLE_EXTENSIONS.has(path.extname(file.absPath).toLowerCase()))
+    .slice(0, 80);
+  const cssVariables = (await Promise.all(styleFiles.map((file) => readCssVariables(file.absPath, file.relPath))))
+    .flat()
+    .slice(0, 80);
+  return {
+    sourceRoot,
+    packageName: packageJson.name,
+    packageDescription: packageJson.description,
+    packageTech: packageJson.tech,
+    readmeExcerpt,
+    cssVariables,
+    tailwindSignals: await readTailwindSignals(sourceRoot),
+    assets: await findAssets(sourceRoot, files),
+    components: findComponentSignals(files),
+  };
+}
+
+async function readPackageJson(
+  sourceRoot: string,
+): Promise<{ name: string | undefined; description: string | undefined; tech: string[] }> {
+  try {
+    const parsed = JSON.parse(await readFile(path.join(sourceRoot, 'package.json'), 'utf8')) as Record<string, unknown>;
+    const deps = {
+      ...(isRecord(parsed.dependencies) ? parsed.dependencies : {}),
+      ...(isRecord(parsed.devDependencies) ? parsed.devDependencies : {}),
+    };
+    return {
+      name: typeof parsed.name === 'string' ? parsed.name : undefined,
+      description: typeof parsed.description === 'string' ? parsed.description : undefined,
+      tech: Object.keys(deps).filter((name) =>
+        ['@tailwindcss', 'tailwindcss', 'react', 'vue', 'svelte', 'next', 'vite', 'framer-motion'].some((needle) =>
+          name.includes(needle),
+        ),
+      ),
+    };
+  } catch {
+    return { name: undefined, description: undefined, tech: [] };
+  }
+}
+
+async function readReadme(sourceRoot: string): Promise<string | undefined> {
+  for (const name of ['README.md', 'README.zh-CN.md', 'readme.md']) {
+    try {
+      const raw = await readFile(path.join(sourceRoot, name), 'utf8');
+      return compactMarkdown(raw).slice(0, 1400);
+    } catch {
+      // Try the next common readme name.
+    }
+  }
+  return undefined;
+}
+
+async function walkProject(sourceRoot: string): Promise<Array<{ absPath: string; relPath: string; size: number }>> {
+  const out: Array<{ absPath: string; relPath: string; size: number }> = [];
+  const queue = [sourceRoot];
+  while (queue.length > 0 && out.length < 900) {
+    const current = queue.shift()!;
+    let entries = [];
+    try {
+      entries = await readdir(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.name.startsWith('.') && entry.name !== '.storybook') continue;
+      const absPath = path.join(current, entry.name);
+      const relPath = path.relative(sourceRoot, absPath);
+      if (entry.isDirectory()) {
+        if (!IGNORED_DIRS.has(entry.name)) queue.push(absPath);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      try {
+        const info = await stat(absPath);
+        if (info.size > 512 * 1024) continue;
+        out.push({ absPath, relPath, size: info.size });
+      } catch {
+        // Skip files that disappear during the scan.
+      }
+    }
+  }
+  return out;
+}
+
+async function readCssVariables(absPath: string, relPath: string): Promise<CssVariable[]> {
+  try {
+    const raw = await readFile(absPath, 'utf8');
+    const vars: CssVariable[] = [];
+    for (const match of raw.matchAll(/(--[a-zA-Z0-9-_]+)\s*:\s*([^;{}]+);/g)) {
+      const name = match[1];
+      const value = match[2]?.trim();
+      if (name === undefined || value === undefined) continue;
+      if (value.length === 0 || value.length > 120) continue;
+      vars.push({ name, value, source: relPath });
+    }
+    return vars;
+  } catch {
+    return [];
+  }
+}
+
+async function readTailwindSignals(sourceRoot: string): Promise<string[]> {
+  const candidates = [
+    'tailwind.config.ts',
+    'tailwind.config.js',
+    'tailwind.config.mjs',
+    'tailwind.config.cjs',
+  ];
+  for (const candidate of candidates) {
+    try {
+      const raw = await readFile(path.join(sourceRoot, candidate), 'utf8');
+      const signals = new Set<string>();
+      for (const key of ['colors', 'fontFamily', 'borderRadius', 'spacing', 'boxShadow']) {
+        if (new RegExp(`\\b${key}\\s*:`).test(raw)) signals.add(key);
+      }
+      return Array.from(signals);
+    } catch {
+      // Try the next config name.
+    }
+  }
+  return [];
+}
+
+async function findAssets(
+  sourceRoot: string,
+  files: Array<{ absPath: string; relPath: string; size: number }>,
+): Promise<AssetCandidate[]> {
+  return files
+    .filter((file) => {
+      const ext = path.extname(file.relPath).toLowerCase();
+      const rel = normalizeRel(file.relPath);
+      if (!ASSET_EXTENSIONS.has(ext) || file.size > 2 * 1024 * 1024) return false;
+      const isAssetRoot =
+        rel.startsWith('assets/') || rel.startsWith('public/') || rel.startsWith('src/assets/');
+      return isAssetRoot && /(logo|icon|favicon|mark|brand|avatar)/i.test(path.basename(file.relPath));
+    })
+    .slice(0, 12)
+    .map((file) => ({
+      absPath: file.absPath,
+      relPath: normalizeRel(path.relative(sourceRoot, file.absPath)),
+      size: file.size,
+    }));
+}
+
+function findComponentSignals(files: Array<{ absPath: string; relPath: string }>): ComponentSignal[] {
+  const found = new Map<string, ComponentSignal>();
+  for (const file of files) {
+    if (!COMPONENT_EXTENSIONS.has(path.extname(file.relPath).toLowerCase())) continue;
+    const basename = path.basename(file.relPath).replace(/\.[^.]+$/, '');
+    const component = COMPONENT_NAMES.find((name) => basename.toLowerCase().includes(name.toLowerCase()));
+    if (component && !found.has(component)) {
+      found.set(component, { name: component, relPath: normalizeRel(file.relPath) });
+    }
+  }
+  return Array.from(found.values()).slice(0, 10);
+}
+
+async function copyAssets(assets: AssetCandidate[], outDir: string): Promise<string[]> {
+  if (assets.length === 0) return [];
+  const assetsDir = path.join(outDir, 'assets');
+  await mkdir(assetsDir, { recursive: true });
+  const copied: string[] = [];
+  for (const asset of assets) {
+    const targetName = slugify(path.basename(asset.relPath, path.extname(asset.relPath))) + path.extname(asset.relPath).toLowerCase();
+    await copyFile(asset.absPath, path.join(assetsDir, targetName));
+    copied.push(`assets/${targetName}`);
+  }
+  return copied;
+}
+
+async function nextAvailableSlug(
+  root: string,
+  preferred: string,
+  reservedIds: Iterable<string> = [],
+): Promise<string> {
+  await mkdir(root, { recursive: true });
+  const base = preferred || 'imported-design-system';
+  const reserved = new Set(reservedIds);
+  for (let index = 1; index < 1000; index += 1) {
+    const id = index === 1 ? base : `${base}-${index}`;
+    if (reserved.has(id)) continue;
+    try {
+      await stat(path.join(root, id));
+    } catch {
+      return id;
+    }
+  }
+  throw new LocalDesignSystemImportError('INTERNAL_ERROR', 'could not allocate design system id');
+}
+
+function renderManifest(id: string, name: string, scan: ProjectScan, now: Date) {
+  return {
+    schemaVersion: 'od-design-system-project/v1',
+    id,
+    name,
+    category: 'Imported',
+    description: scan.packageDescription ?? `Extracted from local project ${path.basename(scan.sourceRoot)}.`,
+    source: {
+      type: 'local',
+      path: scan.sourceRoot,
+      importedAt: now.toISOString(),
+    },
+    files: {
+      design: 'DESIGN.md',
+      tokens: 'tokens.css',
+      components: 'components.html',
+    },
+    ...(scan.assets.length > 0 ? { assetsDir: 'assets' } : {}),
+  };
+}
+
+function renderDesignMd(id: string, name: string, scan: ProjectScan): string {
+  const colors = tokenCandidates(scan.cssVariables, ['color', 'accent', 'primary', 'background', 'surface', 'border'])
+    .slice(0, 16)
+    .map((token) => `- \`${token.name}: ${token.value}\` from \`${token.source}\``);
+  const components = scan.components.map((component) => `- ${component.name}: \`${component.relPath}\``);
+  const assets = scan.assets.map((asset) => `- \`${asset.relPath}\``);
+  return [
+    `# ${name}`,
+    '',
+    '> Category: Imported',
+    '> Surface: web',
+    '',
+    scan.packageDescription ?? `Imported design system extracted from \`${scan.sourceRoot}\`.`,
+    '',
+    '## Source',
+    '',
+    `- Project path: \`${scan.sourceRoot}\``,
+    `- Design system id: \`${id}\``,
+    scan.packageTech.length > 0 ? `- Detected stack: ${scan.packageTech.map((item) => `\`${item}\``).join(', ')}` : '- Detected stack: not declared',
+    scan.tailwindSignals.length > 0 ? `- Tailwind signals: ${scan.tailwindSignals.join(', ')}` : '- Tailwind signals: none detected',
+    '',
+    '## Product Notes',
+    '',
+    scan.readmeExcerpt ?? 'No README summary was found. Preserve the imported tokens and component proportions when generating new work.',
+    '',
+    '## Visual Tokens',
+    '',
+    colors.length > 0 ? colors.join('\n') : '- No CSS custom properties were found; tokens.css uses a neutral fallback palette.',
+    '',
+    '## Component Signals',
+    '',
+    components.length > 0 ? components.join('\n') : '- No common Button/Input/Card/Nav/Sidebar component files were detected.',
+    '',
+    '## Assets',
+    '',
+    assets.length > 0 ? assets.join('\n') : '- No logo/icon assets were copied for this import.',
+    '',
+    '## Agent Guidance',
+    '',
+    '- Use `tokens.css` as the first source of truth for color, radius, spacing, and type.',
+    '- Treat `components.html` as a compact fixture for proportions and state styling.',
+    '- When a token is a direct extraction from the source project, preserve its semantic role before inventing new values.',
+    '',
+  ].join('\n');
+}
+
+function renderTokensCss(scan: ProjectScan): string {
+  const picked = pickDesignTokens(scan.cssVariables);
+  const cssVarLines = scan.cssVariables
+    .slice(0, 40)
+    .map((token) => `  ${token.name}: ${token.value};`)
+    .join('\n');
+  return `:root {
+  --bg: ${picked.bg};
+  --surface: ${picked.surface};
+  --surface-warm: ${picked.surfaceWarm};
+  --fg: ${picked.fg};
+  --fg-2: ${picked.fg2};
+  --muted: ${picked.muted};
+  --meta: ${picked.meta};
+  --border: ${picked.border};
+  --border-soft: ${picked.borderSoft};
+  --accent: ${picked.accent};
+  --accent-on: ${picked.accentOn};
+  --accent-hover: ${picked.accentHover};
+  --accent-active: ${picked.accentActive};
+  --success: ${picked.success};
+  --warn: ${picked.warn};
+  --danger: ${picked.danger};
+
+  --font-sans: ${picked.fontSans};
+  --font-serif: ${picked.fontSerif};
+  --font-mono: ${picked.fontMono};
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-md: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.375rem;
+  --text-2xl: 1.75rem;
+  --text-3xl: 2.25rem;
+  --leading-tight: 1.15;
+  --leading-body: 1.55;
+  --tracking-tight: 0;
+
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.5rem;
+  --space-6: 2rem;
+  --space-8: 3rem;
+  --section-y: clamp(3rem, 7vw, 6rem);
+
+  --radius-sm: 6px;
+  --radius-md: ${picked.radius};
+  --radius-lg: 14px;
+  --elev-1: 0 1px 2px rgb(15 23 42 / 8%);
+  --elev-2: 0 18px 45px rgb(15 23 42 / 14%);
+  --focus-ring: 0 0 0 3px color-mix(in srgb, var(--accent) 28%, transparent);
+  --motion-fast: 140ms ease;
+  --motion-med: 220ms ease;
+  --container: 1120px;
+  --grid-gap: var(--space-5);
+${cssVarLines ? `\n  /* Extracted source variables */\n${cssVarLines}` : ''}
+}
+`;
+}
+
+function renderComponentsHtml(name: string): string {
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>${escapeHtml(name)} components</title>
+    <link rel="stylesheet" href="./tokens.css" />
+    <style>
+      body { margin: 0; font-family: var(--font-sans); color: var(--fg); background: var(--bg); }
+      main { max-width: 960px; margin: 0 auto; padding: var(--space-8) var(--space-5); }
+      nav { display: flex; align-items: center; justify-content: space-between; gap: var(--space-4); border-bottom: 1px solid var(--border-soft); padding-bottom: var(--space-4); }
+      .brand { font-weight: 700; font-size: var(--text-lg); }
+      .card { margin-top: var(--space-6); background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg); box-shadow: var(--elev-1); padding: var(--space-6); }
+      .row { display: flex; flex-wrap: wrap; gap: var(--space-3); align-items: center; }
+      button { border: 1px solid transparent; border-radius: var(--radius-md); padding: 0.7rem 1rem; font: inherit; cursor: pointer; transition: background var(--motion-fast), border-color var(--motion-fast); }
+      .primary { background: var(--accent); color: var(--accent-on); }
+      .secondary { background: var(--surface-warm); border-color: var(--border); color: var(--fg); }
+      input { min-width: 240px; border: 1px solid var(--border); border-radius: var(--radius-md); padding: 0.7rem 0.85rem; font: inherit; color: var(--fg); background: var(--surface); }
+      h1 { margin: var(--space-6) 0 var(--space-2); font-size: var(--text-3xl); line-height: var(--leading-tight); }
+      p { color: var(--fg-2); line-height: var(--leading-body); }
+    </style>
+  </head>
+  <body>
+    <main>
+      <nav>
+        <div class="brand">${escapeHtml(name)}</div>
+        <div class="row"><button class="secondary">Preview</button><button class="primary">Create</button></div>
+      </nav>
+      <section class="card">
+        <h1>Component fixture</h1>
+        <p>This fixture gives agents a compact reference for imported tokens, common controls, and card proportions.</p>
+        <div class="row">
+          <button class="primary">Primary action</button>
+          <button class="secondary">Secondary</button>
+          <input value="Input value" aria-label="Example input" />
+        </div>
+      </section>
+    </main>
+  </body>
+</html>
+`;
+}
+
+function pickDesignTokens(tokens: CssVariable[]): typeof TOKEN_FALLBACKS {
+  const valueFor = (needles: string[], fallback: string, validator: (value: string) => boolean = Boolean) =>
+    tokenCandidates(tokens, needles).find((token) => validator(token.value))?.value ?? fallback;
+  return {
+    ...TOKEN_FALLBACKS,
+    bg: valueFor(['background', 'bg'], TOKEN_FALLBACKS.bg, isColorValue),
+    surface: valueFor(['surface', 'card', 'popover'], TOKEN_FALLBACKS.surface, isColorValue),
+    surfaceWarm: valueFor(['muted', 'subtle', 'secondary'], TOKEN_FALLBACKS.surfaceWarm, isColorValue),
+    fg: valueFor(['foreground', 'text', 'fg'], TOKEN_FALLBACKS.fg, isColorValue),
+    fg2: valueFor(['text-secondary', 'secondary-foreground'], TOKEN_FALLBACKS.fg2, isColorValue),
+    muted: valueFor(['muted', 'placeholder'], TOKEN_FALLBACKS.muted, isColorValue),
+    border: valueFor(['border'], TOKEN_FALLBACKS.border, isColorValue),
+    accent: valueFor(['accent', 'primary', 'brand'], TOKEN_FALLBACKS.accent, isColorValue),
+    success: valueFor(['success', 'positive'], TOKEN_FALLBACKS.success, isColorValue),
+    warn: valueFor(['warning', 'warn'], TOKEN_FALLBACKS.warn, isColorValue),
+    danger: valueFor(['danger', 'error', 'destructive'], TOKEN_FALLBACKS.danger, isColorValue),
+    radius: valueFor(['radius'], TOKEN_FALLBACKS.radius, (value) => /^\d/.test(value)),
+    fontSans: valueFor(['font-sans', 'font-family', 'font'], TOKEN_FALLBACKS.fontSans),
+  };
+}
+
+function tokenCandidates(tokens: CssVariable[], needles: string[]): CssVariable[] {
+  return tokens.filter((token) => needles.some((needle) => token.name.toLowerCase().includes(needle)));
+}
+
+function isColorValue(value: string): boolean {
+  return /^(#(?:[0-9a-f]{3,8})|rgb[a]?\(|hsl[a]?\(|oklch\(|color-mix\(|var\()/i.test(value.trim());
+}
+
+function compactMarkdown(raw: string): string {
+  return raw
+    .replace(/```[\s\S]*?```/g, '')
+    .replace(/!\[[^\]]*]\([^)]*\)/g, '')
+    .replace(/\[[^\]]+]\([^)]*\)/g, (match) => match.replace(/^\[([^\]]+)].*$/, '$1'))
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(0, 16)
+    .join('\n');
+}
+
+function cleanDisplayName(value: string): string {
+  return value.replace(/^@[^/]+\//, '').replace(/[-_]+/g, ' ').trim() || 'Imported Design System';
+}
+
+function slugify(value: string): string {
+  const slug = value
+    .toLowerCase()
+    .replace(/^@[^/]+\//, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug || 'imported-design-system';
+}
+
+function normalizeRel(value: string): string {
+  return value.split(path.sep).join('/');
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/apps/daemon/src/static-resource-routes.ts
+++ b/apps/daemon/src/static-resource-routes.ts
@@ -14,6 +14,10 @@ import {
 import { listCodexPets, readCodexPetSpritesheet } from './codex-pets.js';
 import { syncCommunityPets } from './community-pets-sync.js';
 import { readDesignSystem } from './design-systems.js';
+import {
+  LocalDesignSystemImportError,
+  importLocalDesignSystemProject,
+} from './design-system-import.js';
 import { renderDesignSystemPreview } from './design-system-preview.js';
 import { renderDesignSystemShowcase } from './design-system-showcase.js';
 import { listPromptTemplates, readPromptTemplate } from './prompt-templates.js';
@@ -26,6 +30,7 @@ export interface RegisterStaticResourceRoutesDeps extends RouteDeps<'http' | 'pa
 export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticResourceRoutesDeps) {
   const {
     RUNTIME_DATA_DIR,
+    RUNTIME_DATA_DIR_CANONICAL,
     DESIGN_SYSTEMS_DIR,
     USER_DESIGN_SYSTEMS_DIR,
     DESIGN_TEMPLATES_DIR,
@@ -606,6 +611,69 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
       res.json({ designSystem });
     } catch (err: any) {
       res.status(500).json({ error: String(err) });
+    }
+  });
+
+  app.post('/api/design-systems/import/local', async (req, res) => {
+    if (!requireLocalOrigin(req, res)) return;
+    try {
+      const body = req.body && typeof req.body === 'object' ? req.body : {};
+      const inputPath =
+        typeof body.baseDir === 'string'
+          ? body.baseDir
+          : typeof body.path === 'string'
+            ? body.path
+            : typeof body.localPath === 'string'
+              ? body.localPath
+              : '';
+      if (!path.isAbsolute(inputPath)) {
+        return sendApiError(res, 400, 'BAD_REQUEST', 'local project path must be absolute');
+      }
+      let sourceRoot: string;
+      let sourceStats: fs.Stats;
+      try {
+        sourceRoot = fs.realpathSync.native(inputPath);
+        sourceStats = fs.statSync(sourceRoot);
+      } catch {
+        return sendApiError(res, 400, 'BAD_REQUEST', 'local project path was not found');
+      }
+      if (!sourceStats.isDirectory()) {
+        return sendApiError(res, 400, 'BAD_REQUEST', 'local project path must be a directory');
+      }
+      const sourceParent = path.dirname(sourceRoot);
+      if (sourceRoot === sourceParent) {
+        return sendApiError(res, 400, 'BAD_REQUEST', 'local project path cannot be a filesystem root');
+      }
+      try {
+        const runtimeRoot = fs.realpathSync.native(RUNTIME_DATA_DIR_CANONICAL);
+        if (sourceRoot === runtimeRoot || sourceRoot.startsWith(`${runtimeRoot}${path.sep}`)) {
+          return sendApiError(res, 400, 'BAD_REQUEST', 'cannot import Open Design runtime data');
+        }
+      } catch {
+        // The runtime data directory may not exist yet in first-run tests.
+      }
+
+      const before = await listAllDesignSystems();
+      const result = await importLocalDesignSystemProject(sourceRoot, USER_DESIGN_SYSTEMS_DIR, {
+        name: typeof body.name === 'string' ? body.name : undefined,
+        reservedIds: before.map((system) => system.id),
+      });
+      const systems = await listAllDesignSystems();
+      const designSystem = systems.find((system) => system.id === result.id);
+      if (!designSystem) {
+        return sendApiError(
+          res,
+          500,
+          'INTERNAL_ERROR',
+          `imported design system was not found in catalog: ${result.dir}`,
+        );
+      }
+      res.status(201).json({ designSystem });
+    } catch (err: any) {
+      if (err instanceof LocalDesignSystemImportError) {
+        return sendApiError(res, err.code === 'BAD_REQUEST' ? 400 : 500, err.code, err.message);
+      }
+      sendApiError(res, 500, 'INTERNAL_ERROR', String(err));
     }
   });
 

--- a/apps/daemon/tests/design-system-import.test.ts
+++ b/apps/daemon/tests/design-system-import.test.ts
@@ -1,0 +1,110 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { importLocalDesignSystemProject } from '../src/design-system-import.js';
+import { listDesignSystems, readDesignSystemAssets } from '../src/design-systems.js';
+
+describe('importLocalDesignSystemProject', () => {
+  let tempRoot: string;
+  let sourceRoot: string;
+  let userDesignSystemsRoot: string;
+
+  beforeEach(() => {
+    tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'od-ds-import-'));
+    sourceRoot = path.join(tempRoot, 'source-app');
+    userDesignSystemsRoot = path.join(tempRoot, 'user-design-systems');
+    fs.mkdirSync(path.join(sourceRoot, 'src', 'components'), { recursive: true });
+    fs.mkdirSync(path.join(sourceRoot, 'src', 'styles'), { recursive: true });
+    fs.mkdirSync(path.join(sourceRoot, 'public'), { recursive: true });
+    fs.writeFileSync(
+      path.join(sourceRoot, 'package.json'),
+      JSON.stringify({
+        name: '@acme/kami-app',
+        description: 'A focused workspace for AI design reviews.',
+        dependencies: { react: '^18.0.0', tailwindcss: '^3.0.0' },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(sourceRoot, 'README.md'),
+      '# Kami App\n\nA calm review surface with crisp cards and bright primary actions.\n',
+    );
+    fs.writeFileSync(
+      path.join(sourceRoot, 'src', 'styles', 'tokens.css'),
+      ':root { --color-primary: #ff3366; --color-background: #101014; --radius-card: 12px; }',
+    );
+    fs.writeFileSync(
+      path.join(sourceRoot, 'tailwind.config.ts'),
+      'export default { theme: { extend: { colors: {}, fontFamily: {}, borderRadius: {} } } }',
+    );
+    fs.writeFileSync(path.join(sourceRoot, 'src', 'components', 'Button.tsx'), 'export function Button() {}');
+    fs.writeFileSync(path.join(sourceRoot, 'public', 'logo.svg'), '<svg xmlns="http://www.w3.org/2000/svg" />');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it('generates a design-system project from a local app directory', async () => {
+    const result = await importLocalDesignSystemProject(sourceRoot, userDesignSystemsRoot, {
+      now: new Date('2026-05-18T09:00:00.000Z'),
+    });
+
+    expect(result.id).toBe('kami-app');
+    expect(result.files).toEqual(
+      expect.arrayContaining(['DESIGN.md', 'tokens.css', 'components.html', 'manifest.json', 'assets/logo.svg']),
+    );
+
+    const manifest = JSON.parse(fs.readFileSync(path.join(result.dir, 'manifest.json'), 'utf8')) as Record<string, unknown>;
+    expect(manifest).toMatchObject({
+      schemaVersion: 'od-design-system-project/v1',
+      id: 'kami-app',
+      name: 'kami app',
+      category: 'Imported',
+      source: {
+        type: 'local',
+        path: fs.realpathSync.native(sourceRoot),
+        importedAt: '2026-05-18T09:00:00.000Z',
+      },
+      files: {
+        design: 'DESIGN.md',
+        tokens: 'tokens.css',
+        components: 'components.html',
+      },
+      assetsDir: 'assets',
+    });
+
+    const design = fs.readFileSync(path.join(result.dir, 'DESIGN.md'), 'utf8');
+    expect(design).toContain('A focused workspace for AI design reviews.');
+    expect(design).toContain('Button: `src/components/Button.tsx`');
+    expect(design).toContain('`--color-primary: #ff3366`');
+
+    const assets = await readDesignSystemAssets(userDesignSystemsRoot, 'kami-app');
+    expect(assets.tokensCss).toContain('--accent: #ff3366;');
+    expect(assets.tokensCss).toContain('--bg: #101014;');
+    expect(assets.fixtureHtml).toContain('Component fixture');
+
+    const systems = await listDesignSystems(userDesignSystemsRoot);
+    expect(systems).toMatchObject([
+      {
+        id: 'kami-app',
+        title: 'kami app',
+        category: 'Imported',
+        summary: 'A focused workspace for AI design reviews.',
+      },
+    ]);
+  });
+
+  it('allocates a new slug instead of colliding with existing systems', async () => {
+    const first = await importLocalDesignSystemProject(sourceRoot, userDesignSystemsRoot, {
+      reservedIds: ['kami-app'],
+    });
+    const second = await importLocalDesignSystemProject(sourceRoot, userDesignSystemsRoot, {
+      reservedIds: ['kami-app'],
+    });
+
+    expect(first.id).toBe('kami-app-2');
+    expect(second.id).toBe('kami-app-3');
+  });
+});

--- a/apps/daemon/tests/static-resource-routes.test.ts
+++ b/apps/daemon/tests/static-resource-routes.test.ts
@@ -89,6 +89,7 @@ describe('static resource mutation routes', () => {
     ['POST', '/api/skills/install'],
     ['DELETE', '/api/skills/demo-skill'],
     ['POST', '/api/design-systems/install'],
+    ['POST', '/api/design-systems/import/local'],
     ['DELETE', '/api/design-systems/demo-system'],
   ])('rejects cross-origin %s %s before catalog or filesystem work', async (method, route) => {
     catalogReadCount = 0;
@@ -100,12 +101,28 @@ describe('static resource mutation routes', () => {
       },
     };
     if (method === 'POST') {
-      init.body = JSON.stringify({ source: 'local', path: tempRoot });
+      init.body = JSON.stringify({ source: 'local', path: tempRoot, baseDir: tempRoot });
     }
     const res = await fetch(`${baseUrl}${route}`, init);
 
     expect(res.status).toBe(403);
     expect(await res.json()).toMatchObject({ code: 'FORBIDDEN' });
+    expect(catalogReadCount).toBe(0);
+  });
+
+  it('returns a bad request for a missing local design-system import path', async () => {
+    catalogReadCount = 0;
+    const res = await fetch(`${baseUrl}/api/design-systems/import/local`, {
+      method: 'POST',
+      headers: {
+        Origin: baseUrl,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ baseDir: path.join(tempRoot, 'missing-project') }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ code: 'BAD_REQUEST' });
     expect(catalogReadCount).toBe(0);
   });
 });

--- a/apps/web/src/components/DesignSystemsSection.tsx
+++ b/apps/web/src/components/DesignSystemsSection.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import type { Dispatch, SetStateAction } from 'react';
+import type { Dispatch, FormEvent, SetStateAction } from 'react';
 import { useT } from '../i18n';
 import type { AppConfig } from '../types';
 import type { DesignSystemSummary } from '@open-design/contracts';
 import {
   fetchDesignSystem,
   fetchDesignSystems,
+  importLocalDesignSystem,
 } from '../providers/registry';
 
 // Sibling Settings section that hosts the design-systems registry.
@@ -26,6 +27,10 @@ export function DesignSystemsSection({ cfg, setCfg }: Props) {
   const [previewId, setPreviewId] = useState<string | null>(null);
   const [previewBody, setPreviewBody] = useState<string | null>(null);
   const [previewLoading, setPreviewLoading] = useState(false);
+  const [importPath, setImportPath] = useState('');
+  const [importing, setImporting] = useState(false);
+  const [importMessage, setImportMessage] = useState<string | null>(null);
+  const [importError, setImportError] = useState<string | null>(null);
 
   useEffect(() => {
     fetchDesignSystems().then(setDesignSystems);
@@ -105,8 +110,53 @@ export function DesignSystemsSection({ cfg, setCfg }: Props) {
     });
   }
 
+  async function handleLocalImport(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const baseDir = importPath.trim();
+    if (!baseDir || importing) return;
+    setImporting(true);
+    setImportError(null);
+    setImportMessage(null);
+    const result = await importLocalDesignSystem({ baseDir });
+    setImporting(false);
+    if ('error' in result) {
+      setImportError(result.error.message);
+      return;
+    }
+    setDesignSystems((current) => {
+      const withoutDuplicate = current.filter((system) => system.id !== result.designSystem.id);
+      return [...withoutDuplicate, result.designSystem].sort((a, b) => a.title.localeCompare(b.title));
+    });
+    setCategoryFilter(result.designSystem.category);
+    setPreviewId(null);
+    setPreviewBody(null);
+    setImportPath('');
+    setImportMessage(`Imported ${result.designSystem.title}`);
+  }
+
   return (
     <section className="settings-section settings-design-systems">
+      <form className="library-install-form" onSubmit={handleLocalImport}>
+        <div className="library-install-row">
+          <input
+            type="text"
+            className="library-search"
+            placeholder="/path/to/project"
+            value={importPath}
+            onChange={(e) => setImportPath(e.target.value)}
+          />
+          <button
+            type="submit"
+            className="library-install-submit"
+            disabled={importing || importPath.trim().length === 0}
+          >
+            {importing ? t('settings.libraryLoading') : 'Import from project'}
+          </button>
+        </div>
+        {importError ? <p className="library-install-error">{importError}</p> : null}
+        {importMessage ? <p className="library-install-status">{importMessage}</p> : null}
+      </form>
+
       <div className="library-toolbar">
         <input
           type="search"

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -19072,6 +19072,12 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   margin: 0;
 }
 
+.library-install-status {
+  color: var(--text-secondary);
+  font-size: 12px;
+  margin: 0;
+}
+
 .library-source-badge {
   display: inline-block;
   font-size: 10px;

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -6,6 +6,8 @@ import type {
   ConnectorDetailResponse,
   ConnectorListResponse,
   ConnectorStatusResponse,
+  ImportLocalDesignSystemRequest,
+  ImportLocalDesignSystemResponse,
 } from '@open-design/contracts';
 import type {
   AgentInfo,
@@ -347,6 +349,42 @@ export async function fetchDesignSystem(id: string): Promise<DesignSystemDetail 
     return (await resp.json()) as DesignSystemDetail;
   } catch {
     return null;
+  }
+}
+
+export async function importLocalDesignSystem(
+  input: ImportLocalDesignSystemRequest,
+): Promise<ImportLocalDesignSystemResponse | { error: SkillImportError }> {
+  try {
+    const resp = await fetch('/api/design-systems/import/local', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    });
+    if (!resp.ok) {
+      const payload = (await resp.json().catch(() => null)) as
+        | { error?: SkillImportError | string; message?: string }
+        | null;
+      const error = payload?.error;
+      return {
+        error:
+          typeof error === 'object' && error !== null
+            ? error
+            : {
+                message:
+                  typeof error === 'string'
+                    ? error
+                    : payload?.message ?? `Import failed (${resp.status}).`,
+              },
+      };
+    }
+    return (await resp.json()) as ImportLocalDesignSystemResponse;
+  } catch (err) {
+    return {
+      error: {
+        message: err instanceof Error ? err.message : 'Import request failed.',
+      },
+    };
   }
 }
 

--- a/packages/contracts/src/api/registry.ts
+++ b/packages/contracts/src/api/registry.ts
@@ -164,6 +164,17 @@ export interface DesignSystemResponse {
   designSystem: DesignSystemDetail;
 }
 
+export interface ImportLocalDesignSystemRequest {
+  /** Absolute local project directory selected by the user. */
+  baseDir: string;
+  /** Optional display name override for the generated design-system project. */
+  name?: string;
+}
+
+export interface ImportLocalDesignSystemResponse {
+  designSystem: DesignSystemSummary;
+}
+
 export interface HealthResponse {
   ok: true;
   service?: 'daemon';


### PR DESCRIPTION
## Why

This is PR4 in the design-system-project rollout. The immediate use case is letting users point Open Design at an existing local app and turn it into a selectable design system without waiting for GitHub import or the full built-in catalog migration.

The pain addressed is that stored projects already have style signals in README/package metadata, CSS variables, Tailwind config, assets, and common components, but Open Design could not package those signals into the manifest/tokens/DESIGN.md contract that the daemon and agent now understand.

## What users will see

Settings → Design Systems now has an “Import from project” local path field. After entering an absolute project path, Open Design generates an imported design-system project and the new item appears in the Design Systems picker/category list.

The generated project includes `manifest.json`, `DESIGN.md`, `tokens.css`, `components.html`, and copied logo/icon assets when detected. Existing built-in and legacy DESIGN.md systems continue to show normally.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Browser smoke verified the Settings → Design Systems entry point: the local import form renders, a temp local project imports successfully, and the imported item appears under the Imported category. No screenshot attached from this Codex run.

## Bug fix verification

-

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/design-system-import.test.ts tests/static-resource-routes.test.ts`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- `pnpm typecheck`
- Browser smoke at `http://127.0.0.1:17573/`: opened Settings → Design Systems, confirmed form renders, imported a temp local project, confirmed success message/category/list entry

Note: commands emit the existing local warning that Node `v25.2.1` does not match the repo target `~24`; validation still passed.
