### PR TITLE
fix(web): improve replace modal button hover contrast

### DIFF
--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -781,6 +781,7 @@
 }
 .home-hero-confirm__primary:hover {
   background: var(--accent-strong);
+  color: white;
 }
 
 /* ------------------------------------------------------------


### PR DESCRIPTION
Fixes #2096

## Why

The Replace button text in the prompt replacement modal became difficult to read on hover in dark theme, making the confirmation action unclear and reducing accessibility.

## What users will see

Users will now see improved text contrast and readability for the Replace button when hovering inside the replacement confirmation modal.

## Surface area

- [x] UI — new page / dialog / panel / menu item / setting / empty state in apps/web or apps/desktop (including Electron menu bar)
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [ ] Default behavior change
- [ ] None

## Screenshots

Before: issue reporter screenshot
<img width="2560" height="1738" alt="issue" src="https://github.com/user-attachments/assets/528d1e01-93e5-448f-9c90-e121f28a4d89" />

After:
<img width="800" height="581" alt="Fix" src="https://github.com/user-attachments/assets/b6cb287d-677b-419b-b5b7-f10e5612c651" />


## Bug fix verification

- Test path that reproduces the bug:
  - Open the prompt replacement confirmation modal.
  - Hover over the Replace button in dark theme.
- Verified locally that the button text remains readable after the style update.

## Validation

- pnpm tools-dev
- pnpm --filter web dev
- Verified UI behavior manually in browser