### PR TITLE
fix: localize Design systems page title

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -805,7 +805,7 @@ export function EntryShell({
               ) : (
                 <div className="entry-section">
                   <header className="entry-section__head">
-                    <h1 className="entry-section__title">Design systems</h1>
+                    <h1 className="entry-section__title">{t('entry.navDesignSystems')}</h1>
                   </header>
                   <DesignSystemsTab
                     systems={designSystems}


### PR DESCRIPTION
Fixes #2080

## Why
When the system language is set to Chinese, the Design systems page title still displays "Design systems" in English, creating an inconsistent localization experience. This PR fixes the gap by using the existing translation key.

## Changes
- Replace hardcoded "Design systems" with `t('entry.navDesignSystems')`
- Uses existing translation key (already defined in en.ts and zh-CN.ts)

## Testing
- Page title now displays as "设计体系" in Chinese
- English remains "Design systems"
- Only 1 line changed, minimal risk

## Surface area
- [x] UI

## Bug fix verification
**Before**: Design systems page title was hardcoded as "Design systems" in English, even when system language was set to Chinese.
**After**: Page title now correctly displays "设计体系" in Chinese locale and "Design systems" in English locale, using the existing `t('entry.navDesignSystems')` translation key.