### PR TITLE
fix: localize Projects page title

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -772,7 +772,7 @@ export function EntryShell({
               ) : (
                 <div className="entry-section">
                   <header className="entry-section__head">
-                    <h1 className="entry-section__title">Projects</h1>
+                    <h1 className="entry-section__title">{t('entry.navProjects')}</h1>
                   </header>
                   <DesignsTab
                     projects={projects}


### PR DESCRIPTION
Fixes #2077

## Why
When the system language is set to Chinese, the Projects page title still displays "Projects" in English, creating an inconsistent localization experience. This PR fixes the gap by using the existing translation key.

## Changes
- Replace hardcoded "Projects" with `t('entry.navProjects')`
- Uses existing translation key (already defined in en.ts and zh-CN.ts)

## Testing
- Page title now displays as "项目" in Chinese
- English remains "Projects"
- Only 1 line changed, minimal risk

## Surface area
- [x] UI