### PR TITLE
fix(web): allow LAN access to Next.js dev server(#2061)

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from 'next';
+import { networkInterfaces } from 'node:os';
 import { dirname, isAbsolute, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -42,8 +43,26 @@ function resolveDevTsconfigPath() {
 
 const DEV_TSCONFIG_PATH = resolveDevTsconfigPath();
 
+function resolveAllowedDevOrigins(): string[] {
+  const hosts = new Set<string>(['127.0.0.1', 'localhost', '[::1]']);
+  if (process.env.OD_HOST) hosts.add(process.env.OD_HOST.trim());
+  if (process.env.OD_BIND_HOST) hosts.add(process.env.OD_BIND_HOST.trim());
+  for (const iface of Object.values(networkInterfaces())) {
+    for (const entry of iface ?? []) {
+      if (!entry.address || entry.internal) continue;
+      hosts.add(entry.address);
+    }
+  }
+  return [...hosts].filter((host) => host.length > 0);
+}
+
+const ALLOWED_DEV_ORIGINS = resolveAllowedDevOrigins();
+
 const nextConfig: NextConfig = {
-  allowedDevOrigins: ['127.0.0.1'],
+  // Next.js dev rejects cross-origin requests for HMR/static chunks unless
+  // the host is explicitly allowlisted. Include loopback + local interface
+  // addresses so opening the app via LAN IP keeps HMR and dynamic chunks alive.
+  allowedDevOrigins: ALLOWED_DEV_ORIGINS,
   outputFileTracingRoot: WORKSPACE_ROOT,
   reactStrictMode: true,
   turbopack: {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -43,14 +43,22 @@ function resolveDevTsconfigPath() {
 
 const DEV_TSCONFIG_PATH = resolveDevTsconfigPath();
 
+function toAllowedDevHost(address: string): string {
+  // IPv6 literals must be bracketed to match the hostname form produced by
+  // `new URL(origin).hostname` (e.g. ::1 → [::1], fe80::1 → [fe80::1]).
+  if (address.startsWith("[")) return address;
+  if (address.includes(":")) return `[${address}]`;
+  return address;
+}
+
 function resolveAllowedDevOrigins(): string[] {
   const hosts = new Set<string>(['127.0.0.1', 'localhost', '[::1]']);
-  if (process.env.OD_HOST) hosts.add(process.env.OD_HOST.trim());
-  if (process.env.OD_BIND_HOST) hosts.add(process.env.OD_BIND_HOST.trim());
+  if (process.env.OD_HOST) hosts.add(toAllowedDevHost(process.env.OD_HOST.trim()));
+  if (process.env.OD_BIND_HOST) hosts.add(toAllowedDevHost(process.env.OD_BIND_HOST.trim()));
   for (const iface of Object.values(networkInterfaces())) {
     for (const entry of iface ?? []) {
       if (!entry.address || entry.internal) continue;
-      hosts.add(entry.address);
+      hosts.add(toAllowedDevHost(entry.address));
     }
   }
   return [...hosts].filter((host) => host.length > 0);

--- a/apps/web/sidecar/server.ts
+++ b/apps/web/sidecar/server.ts
@@ -10,7 +10,7 @@ import { request as createHttpsRequest } from "node:https";
 import { existsSync, readFileSync } from "node:fs";
 import { readFile, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
-import { createServer as createTcpServer, type AddressInfo, type Server as TcpServer } from "node:net";
+import { createServer as createTcpServer, type AddressInfo, type Server as TcpServer, type Socket } from "node:net";
 import { dirname, isAbsolute, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -27,9 +27,10 @@ import {
   type SidecarRuntimeContext,
 } from "@open-design/sidecar";
 
-const HOST = process.env.OD_HOST || "127.0.0.1";
-if (process.env.OD_HOST != null && !/^[a-zA-Z0-9._\-:[\]@]+$/.test(process.env.OD_HOST)) {
-  throw new Error(`OD_HOST contains invalid characters: ${process.env.OD_HOST}`);
+const HOST = process.env.OD_BIND_HOST || process.env.OD_HOST || "127.0.0.1";
+const rawHost = process.env.OD_BIND_HOST ?? process.env.OD_HOST;
+if (rawHost != null && !/^[a-zA-Z0-9._\-:[\]@]+$/.test(rawHost)) {
+  throw new Error(`OD_BIND_HOST / OD_HOST contains invalid characters: ${rawHost}`);
 }
 const DAEMON_HOST = "127.0.0.1";
 const STANDALONE_BACKEND_HOST = "127.0.0.1";
@@ -47,6 +48,11 @@ const require = createRequire(import.meta.url);
 type NextApp = {
   close?: () => Promise<void>;
   getRequestHandler(): (request: IncomingMessage, response: ServerResponse) => Promise<void>;
+  getUpgradeHandler?: () => (
+    request: IncomingMessage,
+    socket: Socket,
+    head: Buffer,
+  ) => Promise<void> | void;
   prepare(): Promise<void>;
 };
 
@@ -242,12 +248,22 @@ function resolveHttpProxyTarget(
 export function normalizeDaemonProxyOriginHeader(options: {
   daemonOrigin: string;
   origin: string | undefined;
+  webHostHeader?: string | undefined;
   webPort: number;
 }): string | undefined {
   if (options.origin == null || options.origin.length === 0) return options.origin;
 
   const schemes = ["http", "https"];
   const loopbackHosts = ["127.0.0.1", "localhost", "[::1]", HOST];
+  const hostHeader = options.webHostHeader;
+  if (hostHeader != null && hostHeader.length > 0) {
+    try {
+      const webHost = new URL(`http://${hostHeader}`).hostname;
+      if (webHost.length > 0) loopbackHosts.push(webHost);
+    } catch {
+      // Ignore malformed Host values; fall back to explicit loopback hosts.
+    }
+  }
   const allowedWebOrigins = new Set(
     schemes.flatMap((scheme) => loopbackHosts.map((host) => `${scheme}://${host}:${options.webPort}`)),
   );
@@ -267,6 +283,7 @@ async function proxyHttpRequest(
     const origin = normalizeDaemonProxyOriginHeader({
       daemonOrigin: target.origin,
       origin: typeof request.headers.origin === "string" ? request.headers.origin : undefined,
+      webHostHeader: typeof request.headers.host === "string" ? request.headers.host : undefined,
       webPort: options.daemonWebPort,
     });
     if (origin == null || origin.length === 0) {
@@ -607,6 +624,16 @@ function createDaemonProxyHandler(
       return;
     }
 
+    // Next.js dev can reject module/script asset requests with a 403
+    // when a LAN origin header is present (for example when opening the
+    // app via http://192.168.x.x:<port>). These are same-host requests
+    // flowing through our sidecar, so stripping Origin before handing
+    // off to Next keeps LAN development working while daemon APIs still
+    // enforce strict origin checks in the branch above.
+    if (typeof request.headers.origin === "string" && request.headers.origin.length > 0) {
+      delete request.headers.origin;
+    }
+
     void fallback(request, response).catch((error: unknown) => {
       response.statusCode = 500;
       response.end(error instanceof Error ? error.message : String(error));
@@ -624,6 +651,22 @@ async function startRegularNextSidecar(
   const daemonOrigin = resolveDaemonOrigin();
   const handleRequest = app.getRequestHandler();
   const httpServer = createHttpServer(createDaemonProxyHandler(daemonOrigin, handleRequest));
+  const handleUpgrade = app.getUpgradeHandler?.();
+  if (handleUpgrade != null) {
+    httpServer.on("upgrade", (request, socket, head) => {
+      // Mirror the HTTP path behavior for LAN dev: do not pass browser
+      // Origin through to Next's HMR websocket endpoint when the app is
+      // opened over a non-loopback host.
+      if (typeof request.headers.origin === "string" && request.headers.origin.length > 0) {
+        delete request.headers.origin;
+      }
+      // `http.Server` types the upgrade socket as `Duplex`; Next's handler
+      // expects `net.Socket`. At runtime this is always a TCP socket.
+      void Promise.resolve(handleUpgrade(request, socket as Socket, head)).catch(() => {
+        if (!socket.destroyed) socket.destroy();
+      });
+    });
+  }
 
   return await createWebSidecarHandle(runtime, httpServer, async () => {
     await app.close?.();

--- a/apps/web/sidecar/server.ts
+++ b/apps/web/sidecar/server.ts
@@ -32,6 +32,15 @@ const rawHost = process.env.OD_BIND_HOST ?? process.env.OD_HOST;
 if (rawHost != null && !/^[a-zA-Z0-9._\-:[\]@]+$/.test(rawHost)) {
   throw new Error(`OD_BIND_HOST / OD_HOST contains invalid characters: ${rawHost}`);
 }
+// IPv6 literals must be bracketed for use in URL authority components
+// (e.g. ::1 → [::1], :: → [::]). Already-bracketed or IPv4 hosts pass
+// through unchanged.
+export function toUrlHost(host: string): string {
+  if (host.startsWith("[")) return host;
+  if (host.includes(":")) return `[${host}]`;
+  return host;
+}
+const URL_HOST = toUrlHost(HOST);
 const DAEMON_HOST = "127.0.0.1";
 const STANDALONE_BACKEND_HOST = "127.0.0.1";
 const DAEMON_PORT_ENV = SIDECAR_ENV.DAEMON_PORT;
@@ -237,7 +246,7 @@ function resolveHttpProxyTarget(
 
   let parsedRequestUrl: URL;
   try {
-    parsedRequestUrl = new URL(requestUrl, `http://${HOST}`);
+    parsedRequestUrl = new URL(requestUrl, `http://${URL_HOST}`);
   } catch {
     return null;
   }
@@ -254,7 +263,7 @@ export function normalizeDaemonProxyOriginHeader(options: {
   if (options.origin == null || options.origin.length === 0) return options.origin;
 
   const schemes = ["http", "https"];
-  const loopbackHosts = ["127.0.0.1", "localhost", "[::1]", HOST];
+  const loopbackHosts = ["127.0.0.1", "localhost", "[::1]", URL_HOST];
   const hostHeader = options.webHostHeader;
   if (hostHeader != null && hostHeader.length > 0) {
     try {
@@ -543,7 +552,7 @@ async function createWebSidecarHandle(
     pid: process.pid,
     state: "running",
     updatedAt: new Date().toISOString(),
-    url: `http://${HOST}:${port}`,
+    url: `http://${URL_HOST}:${port}`,
   };
   let ipcServer: JsonIpcServerHandle | null = null;
   let stopped = false;
@@ -607,6 +616,24 @@ async function createWebSidecarHandle(
   };
 }
 
+export function isSameHostRequest(req: IncomingMessage): boolean {
+  const origin = typeof req.headers.origin === "string" ? req.headers.origin : null;
+  const host = typeof req.headers.host === "string" ? req.headers.host : null;
+  if (!origin || !host) return false;
+  try {
+    // Compare the Origin's hostname with the Host header's hostname. When
+    // they match the request is same-host (e.g. a browser opened via LAN IP
+    // loading assets from the same IP) and the Origin can be stripped safely.
+    // A genuine cross-origin request will have a mismatched hostname and must
+    // retain its Origin so Next.js can enforce its own cross-origin guard.
+    const originHostname = new URL(origin).hostname;
+    const requestHostname = new URL(`http://${host}`).hostname;
+    return originHostname === requestHostname;
+  } catch {
+    return false;
+  }
+}
+
 function createDaemonProxyHandler(
   daemonOrigin: string | null,
   fallback: (request: IncomingMessage, response: ServerResponse) => Promise<void>,
@@ -630,8 +657,13 @@ function createDaemonProxyHandler(
     // flowing through our sidecar, so stripping Origin before handing
     // off to Next keeps LAN development working while daemon APIs still
     // enforce strict origin checks in the branch above.
+    // Only strip when the Origin hostname matches the Host header —
+    // genuinely cross-origin requests must retain their Origin so
+    // Next.js can enforce its own cross-origin guard.
     if (typeof request.headers.origin === "string" && request.headers.origin.length > 0) {
-      delete request.headers.origin;
+      if (isSameHostRequest(request)) {
+        delete request.headers.origin;
+      }
     }
 
     void fallback(request, response).catch((error: unknown) => {
@@ -656,9 +688,12 @@ async function startRegularNextSidecar(
     httpServer.on("upgrade", (request, socket, head) => {
       // Mirror the HTTP path behavior for LAN dev: do not pass browser
       // Origin through to Next's HMR websocket endpoint when the app is
-      // opened over a non-loopback host.
+      // opened over a non-loopback host. Only strip when same-host so
+      // genuine cross-origin upgrade requests are still validated.
       if (typeof request.headers.origin === "string" && request.headers.origin.length > 0) {
-        delete request.headers.origin;
+        if (isSameHostRequest(request)) {
+          delete request.headers.origin;
+        }
       }
       // `http.Server` types the upgrade socket as `Duplex`; Next's handler
       // expects `net.Socket`. At runtime this is always a TCP socket.

--- a/apps/web/tests/sidecar-proxy.test.ts
+++ b/apps/web/tests/sidecar-proxy.test.ts
@@ -8,10 +8,12 @@ import {
   createStandaloneBackendEnv,
   createStandaloneParentMonitorImport,
   createStandaloneServerArgs,
+  isSameHostRequest,
   normalizeDaemonProxyOriginHeader,
   resolveDaemonProxyTarget,
   resolveStandaloneBackendOrigin,
   resolveStandaloneServerEntry,
+  toUrlHost,
 } from '../sidecar/server';
 
 describe('resolveDaemonProxyTarget', () => {
@@ -170,6 +172,28 @@ describe('normalizeDaemonProxyOriginHeader', () => {
     ).toBe('https://example.com');
   });
 
+  it('allows the web host header when it matches the origin', () => {
+    expect(
+      normalizeDaemonProxyOriginHeader({
+        daemonOrigin: 'http://127.0.0.1:7456',
+        origin: 'http://192.168.1.5:3000',
+        webHostHeader: '192.168.1.5:3000',
+        webPort: 3000,
+      }),
+    ).toBe('http://127.0.0.1:7456');
+  });
+
+  it('accepts IPv6 web host headers', () => {
+    expect(
+      normalizeDaemonProxyOriginHeader({
+        daemonOrigin: 'http://127.0.0.1:7456',
+        origin: 'http://[::1]:3000',
+        webHostHeader: '[::1]:3000',
+        webPort: 3000,
+      }),
+    ).toBe('http://127.0.0.1:7456');
+  });
+
   it('preserves absent and null origins for daemon policy to handle', () => {
     expect(
       normalizeDaemonProxyOriginHeader({
@@ -185,5 +209,69 @@ describe('normalizeDaemonProxyOriginHeader', () => {
         webPort: 3000,
       }),
     ).toBe('null');
+  });
+});
+
+describe('toUrlHost', () => {
+  it('passes IPv4 addresses through unchanged', () => {
+    expect(toUrlHost('127.0.0.1')).toBe('127.0.0.1');
+    expect(toUrlHost('192.168.1.1')).toBe('192.168.1.1');
+  });
+
+  it('brackets bare IPv6 literals', () => {
+    expect(toUrlHost('::1')).toBe('[::1]');
+    expect(toUrlHost('::')).toBe('[::]');
+    expect(toUrlHost('fe80::1')).toBe('[fe80::1]');
+  });
+
+  it('does not double-bracket already-bracketed IPv6', () => {
+    expect(toUrlHost('[::1]')).toBe('[::1]');
+    expect(toUrlHost('[fe80::1]')).toBe('[fe80::1]');
+  });
+
+  it('passes hostnames through unchanged', () => {
+    expect(toUrlHost('localhost')).toBe('localhost');
+    expect(toUrlHost('my-machine.local')).toBe('my-machine.local');
+  });
+});
+
+describe('isSameHostRequest', () => {
+  function mockReq(origin: string | null, host: string | null) {
+    return {
+      headers: {
+        ...(origin != null ? { origin } : {}),
+        ...(host != null ? { host } : {}),
+      },
+    } as Parameters<typeof isSameHostRequest>[0];
+  }
+
+  it('detects same-host IPv4 origin and host header', () => {
+    const req = mockReq('http://127.0.0.1:3000', '127.0.0.1:3000');
+    expect(isSameHostRequest(req)).toBe(true);
+  });
+
+  it('detects same-host IPv6 origin and host header', () => {
+    const req = mockReq('http://[::1]:3000', '[::1]:3000');
+    expect(isSameHostRequest(req)).toBe(true);
+  });
+
+  it('detects a foreign cross-origin request', () => {
+    const req = mockReq('https://evil.example.com', '127.0.0.1:3000');
+    expect(isSameHostRequest(req)).toBe(false);
+  });
+
+  it('detects a foreign origin on a LAN host', () => {
+    const req = mockReq('https://evil.example.com', '192.168.1.5:3000');
+    expect(isSameHostRequest(req)).toBe(false);
+  });
+
+  it('returns false when origin is missing', () => {
+    const req = mockReq(null, '127.0.0.1:3000');
+    expect(isSameHostRequest(req)).toBe(false);
+  });
+
+  it('returns false when host is missing', () => {
+    const req = mockReq('http://127.0.0.1:3000', null);
+    expect(isSameHostRequest(req)).toBe(false);
   });
 });


### PR DESCRIPTION
Next.js allowedDevOrigins was hardcoded to 127.0.0.1, blocking HMR and static chunks when opening the dev server via a LAN IP. Additionally, the web sidecar did not strip Origin headers for non-proxy requests, causing Next.js to reject same-host LAN requests as cross-origin.

- Dynamically resolve allowedDevOrigins from network interfaces, OD_HOST, and OD_BIND_HOST to include LAN/WLAN IPs
- Strip Origin header in the web sidecar before forwarding to Next.js for non-daemon-proxy requests and HMR WebSocket upgrades
- Read OD_BIND_HOST in addition to OD_HOST for sidecar bind host
- Pass web Host header through proxy origin normalization

Fixes #2061

## Why

Why are you opening this PR? Cover two things:
       - Your use case — what made you write this today? are you scratching an itch for a team.
       - The pain being addressed — user-facing problem.
     For non-trivial features, please open a discussion or issue first to align
     on scope and UX before writing code.


## What users will see

Describe the change from a user's perspective, not in code terms. Examples:
       - "Run the following command: OD_API_TOKEN=xxxx OD_BIND_HOST=0.0.0.0 pnpm tools-dev run web --daemon-port 17456 --web-port 17573 → Open the browser and enter the IP address of LAN. Then you can access it normally."



## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only


## Screenshots

<img width="1136" height="596" alt="image" src="https://github.com/user-attachments/assets/1dd7c6da-5495-4da6-84b0-834c94e35805" />



## Bug fix verification

- Test path that reproduces the bug: N/A — this is a network-layer bug
    that requires a second device (or at minimum a second network interface)
    to reproduce. The failure mode is Next.js rejecting requests with a
    403 when the Host header is a LAN IP not listed in allowedDevOrigins,
    and the web sidecar passing cross-origin headers through to Next.js
    for same-host LAN requests.
  - Did the test go red on main and green on this branch? N/A — see above.
  - Verification instead:
    1. Confirmed `allowedDevOrigins` was the single point of failure by
       inspecting Next.js's `blockCrossSiteDEV` (block-cross-site-dev.js)
       and `isCsrfOriginAllowed` (csrf-protection.js) — only 127.0.0.1
       and localhost wildcards were allowed.
    2. Confirmed the web sidecar was passing Origin through unchanged on
       non-daemon-proxy requests, which triggers Next.js's cross-origin
       block for LAN IPs.
    3. After the fix, `resolveAllowedDevOrigins()` enumerates all
       non-internal network interface addresses at config time, and the
       sidecar strips Origin for non-proxy requests and HMR upgrades.

-


## Validation

  - [x] `pnpm guard`
  - [x] `pnpm typecheck`
  - [x] `pnpm --filter @open-design/web typecheck` (clean, no new errors)
  - [x] `pnpm --filter @open-design/web test -- tests/sidecar-proxy.test.ts -t "isSameHostRequest"`
  - [x] `pnpm --filter @open-design/web test -- tests/sidecar-proxy.test.ts -t "toUrlHost"`

-
