### PR TITLE
fix(tools-dev): build daemon before spawning so MCP launchers can res…

### DIFF
--- a/tools/dev/src/index.ts
+++ b/tools/dev/src/index.ts
@@ -413,6 +413,7 @@ async function spawnDaemonRuntime(
   const logHandle = await openAppLog(config, APP_KEYS.DAEMON);
 
   try {
+    await buildDaemon(config, logHandle);
     await logHandle.write(`\n[tools-dev] launching daemon at ${new Date().toISOString()}\n`);
     if (webPort != null) await logHandle.write(`[tools-dev] trusting web origin port ${webPort}\n`);
     if (spawnOptions.requireDesktopAuth) {
@@ -477,6 +478,19 @@ async function spawnWebRuntime(config: ToolDevConfig, options: CliOptions): Prom
   } finally {
     await logHandle.close();
   }
+}
+
+async function buildDaemon(config: ToolDevConfig, logHandle: FileHandle): Promise<void> {
+  await logHandle.write(`\n[tools-dev] building @open-design/daemon at ${new Date().toISOString()}\n`);
+  const invocation = createPackageManagerInvocation(["--filter", "@open-design/daemon", "build"], process.env);
+  await runLoggedCommand({
+    args: invocation.args,
+    command: invocation.command,
+    cwd: config.workspaceRoot,
+    env: process.env,
+    logFd: logHandle.fd,
+    windowsVerbatimArguments: invocation.windowsVerbatimArguments,
+  });
 }
 
 async function buildDesktop(config: ToolDevConfig, logHandle: FileHandle): Promise<void> {


### PR DESCRIPTION
Fixes #695

## Why

- **Use case.** Reproducing the Kimi CLI failure from #695 in a fresh source clone. After upgrading to `v0.4.1`, doing a clean reinstall, and confirming Open Design was sending the right Kimi model id (`kimi-code/kimi-for-coding`), Kimi was still failing with `json-rpc id 3: Internal error` on every prompt. Capturing the Kimi-side trace (`KIMI_LOG_LEVEL=trace`) showed the real cause: the `open-design-live-artifacts` MCP child was crashing with `MODULE_NOT_FOUND` on `apps/daemon/dist/cli.js`, because a source clone has never built the daemon and the `od` bin in `apps/daemon/package.json` resolves to `./dist/cli.js`. Kimi reports the MCP "Connection closed" through the prompt RPC, so the user-visible failure is a generic `Internal error`, not a missing-build error.
- **Pain being addressed.** `pnpm tools-dev` is documented as the single dev-lifecycle entrypoint, but it silently launches a daemon whose MCP child cannot start unless `pnpm --filter @open-design/daemon build` was already run. ACP agents that ship an MCP child (`mcpDiscovery: 'mature-acp'`, currently Kimi and Hermes — verified in `apps/daemon/src/runtimes/mcp.ts:13`) are the ones that hit this; Claude/Codex/Gemini don't attach the MCP server so they don't surface the missing build. This is exactly the foot-gun called out as a follow-up in #695.

## What users will see

- `pnpm tools-dev`, `pnpm tools-dev run web`, and `pnpm tools-dev start` always produce a working daemon on a fresh clone — no manual `pnpm --filter @open-design/daemon build` step required before the first Kimi/Hermes session.
- First daemon launch is a few seconds slower while `tsc -p tsconfig.json` runs (the daemon log line `[tools-dev] building @open-design/daemon at …` mirrors the existing `[tools-dev] building @open-design/desktop at …` line).
- No UI change.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — internal refactor, docs, tests, or translation update only (dev-tooling fix, no runtime/UI/contract change)

## Screenshots

N/A — dev-tooling fix, no UI surface.

## Bug fix verification

- Test path that reproduces the bug: no automated red spec. The failure mode is "fresh source clone → `pnpm tools-dev run web` → start a Kimi session → MCP child crashes with `MODULE_NOT_FOUND` on `apps/daemon/dist/cli.js`", which crosses tools-dev → daemon → MCP-child process boundaries that aren't easy to assert from a single Vitest harness.
- Manual verification on this branch: deleted `apps/daemon/dist/`, ran `pnpm tools-dev run web`, confirmed the daemon log now shows `[tools-dev] building @open-design/daemon at …`, `apps/daemon/dist/cli.js` exists before the daemon binds a port, and the `od mcp live-artifacts` MCP child no longer throws `MODULE_NOT_FOUND`.
- A red e2e spec that asserts "after a clean clone, `pnpm tools-dev` produces a daemon whose `od` bin resolves" would be the right follow-up; it'd live in `e2e/tests/` rather than a package unit test because it spans `tools-dev` and the daemon CLI bin.

## Validation

- `pnpm guard` — passes (Node 24.15.0 via nvm, pnpm 10.33.2)
- `pnpm typecheck` — passes (exit 0 across all workspace packages)
- `pnpm --filter @open-design/tools-dev build` — passes
- `pnpm --filter @open-design/tools-dev test` — passes (13/13)