### PR TITLE
MVP Helm chart

### DIFF
--- a/charts/open-design/.helmignore
+++ b/charts/open-design/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/open-design/Chart.yaml
+++ b/charts/open-design/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: open-design
+description: A Helm chart for deploying Open Design on Kubernetes
+type: application
+version: 0.1.0
+appVersion: "0.7.0"

--- a/charts/open-design/README.md
+++ b/charts/open-design/README.md
@@ -36,7 +36,7 @@ nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
 ```
 
 #### Authentication Proxy
-An authentication proxy (NGINX) is introduced to front the application. By default (`authProxy.enabled: true`), this proxy runs as a sidecar container alongside the main application. The Kubernetes Service routes traffic to the proxy, which handles authentication for the API and health checks, proxying valid requests to the application.
+An authentication proxy (NGINX) is introduced to front the application. This proxy runs as a mandatory sidecar container alongside the main application. The Kubernetes Service routes traffic to the proxy, which handles authentication for the API and health checks, proxying valid requests to the application.
 
 #### Security Context
 This chart adheres to strict security defaults:
@@ -62,10 +62,9 @@ This chart adheres to strict security defaults:
 | ---------------------- | ---------------------------------------------------------- | ----------------------- |
 | `config.nodeEnv`       | Node.js environment (`production` or `development`)        | `production`            |
 | `config.allowedOrigins`| CORS allowed origins (leave empty for default)             | `""`                    |
-| `config.publicBaseUrl` | Public base URL used by the application                    | `http://localhost:7456` |
+| `config.publicBaseUrl` | Public base URL used by the application (derived dynamically if empty) | `""`                    |
 | `config.nodeOptions`   | V8 engine memory optimizations                             | `--max-old-space-size=192`|
 | `config.webPort`       | Web server listening port                                  | `7456`                  |
-| `config.proxyPort`     | Proxy server listening port                                | `8080`                  |
 | `config.bindHost`      | Host to bind the web server to                             | `"127.0.0.1"`           |
 | `config.apiToken`      | API authentication token (auto-generated and persisted if empty) | `""`                    |
 
@@ -73,7 +72,6 @@ This chart adheres to strict security defaults:
 
 | Name                                   | Description                                       | Value                                            |
 | -------------------------------------- | ------------------------------------------------- | ------------------------------------------------ |
-| `authProxy.enabled`                    | Enable the NGINX authentication proxy             | `true`                                           |
 | `authProxy.image`                      | NGINX proxy image                                 | `nginxinc/nginx-unprivileged:1.25-alpine-slim`   |
 | `authProxy.port`                       | Proxy server port inside the container            | `8080`                                           |
 | `authProxy.securityContext`            | Security context for the proxy container          | `{...}`                                          |

--- a/charts/open-design/README.md
+++ b/charts/open-design/README.md
@@ -35,7 +35,7 @@ nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
 nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
 ```
 
-**Path Constraints**: If you configure a non-root ingress path (e.g., `/app`), the chart enforces a strict guardrail: you **must** explicitly set `config.publicBaseUrl` to include this sub-path. Otherwise, the deployment will cleanly fail during rendering.
+**Path Constraints**: Non-root ingress path prefixes (sub-paths) are explicitly **unsupported** by the proxy routing stack. Ingress paths must be configured as `/`.
 
 #### Authentication Proxy
 An authentication proxy (NGINX) is introduced to front the application. This proxy runs as a mandatory sidecar container alongside the main application. The Kubernetes Service routes traffic to the proxy, which handles authentication for the API and health checks, proxying valid requests to the application.
@@ -60,15 +60,15 @@ This chart adheres to strict security defaults:
 
 ### Application Configuration
 
-| Name                   | Description                                                | Value                   |
-| ---------------------- | ---------------------------------------------------------- | ----------------------- |
-| `config.nodeEnv`       | Node.js environment (`production` or `development`)        | `production`            |
-| `config.allowedOrigins`| CORS allowed origins (leave empty for default)             | `""`                    |
-| `config.publicBaseUrl` | Public base URL used by the application (derived dynamically if empty) | `""`                    |
-| `config.nodeOptions`   | V8 engine memory optimizations                             | `--max-old-space-size=192`|
-| `config.webPort`       | Web server listening port                                  | `7456`                  |
-| `config.bindHost`      | Host to bind the web server to                             | `"127.0.0.1"`           |
-| `config.apiToken`      | API authentication token (must be changed from default) | `"secure-default-token-change-me"` |
+| Name                   | Description                                                                                                   | Value                                |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| `config.nodeEnv`       | Node.js environment (`production` or `development`)                                                           | `production`                         |
+| `config.allowedOrigins`| CORS allowed origins. Mandatory if service.type is LoadBalancer or NodePort to prevent 403 render failures.   | `""`                                 |
+| `config.publicBaseUrl` | Public base URL used by the application (derived dynamically if empty)                                        | `""`                                 |
+| `config.nodeOptions`   | V8 engine memory optimizations                                                                                | `--max-old-space-size=192`           |
+| `config.webPort`       | Web server listening port                                                                                     | `7456`                               |
+| `config.bindHost`      | Host to bind the web server to                                                                                | `"127.0.0.1"`                        |
+| `config.apiToken`      | API authentication token (must be changed from default)                                                       | `"secure-default-token-change-me"`   |
 
 ### Auth Proxy Parameters
 

--- a/charts/open-design/README.md
+++ b/charts/open-design/README.md
@@ -61,6 +61,8 @@ This chart adheres to strict security defaults:
 | `config.allowedOrigins`| CORS allowed origins (leave empty for default)             | `""`                    |
 | `config.publicBaseUrl` | Public base URL used by the application                    | `http://localhost:7456` |
 | `config.nodeOptions`   | V8 engine memory optimizations                             | `--max-old-space-size=192`|
+| `config.webPort`       | Web server listening port                                  | `7456`                  |
+| `config.apiToken`      | API authentication token (auto-generated if left empty)    | `""`                    |
 
 ### Network & Ingress Parameters
 
@@ -114,6 +116,8 @@ This chart adheres to strict security defaults:
 | `nodeSelector`                                                    | Node labels for pod assignment                  | `{}`               |
 | `tolerations`                                                     | Tolerations for pod assignment                  | `[]`               |
 | `affinity`                                                        | Affinity rules for pod assignment               | `{}`               |
+| `initContainers`                                                  | Additional init containers to add to the pod    | `[]`               |
+| `sidecars`                                                        | Additional sidecar containers to add to the pod | `[]`               |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/open-design/README.md
+++ b/charts/open-design/README.md
@@ -35,6 +35,9 @@ nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
 nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
 ```
 
+#### Authentication Proxy
+An authentication proxy (NGINX) is introduced to front the application. By default (`authProxy.enabled: true`), this proxy runs as a sidecar container alongside the main application. The Kubernetes Service routes traffic to the proxy, which handles authentication for the API and health checks, proxying valid requests to the application.
+
 #### Security Context
 This chart adheres to strict security defaults:
 - Runs as non-root user `1001`.
@@ -62,7 +65,33 @@ This chart adheres to strict security defaults:
 | `config.publicBaseUrl` | Public base URL used by the application                    | `http://localhost:7456` |
 | `config.nodeOptions`   | V8 engine memory optimizations                             | `--max-old-space-size=192`|
 | `config.webPort`       | Web server listening port                                  | `7456`                  |
-| `config.apiToken`      | API authentication token (auto-generated if left empty)    | `""`                    |
+| `config.proxyPort`     | Proxy server listening port                                | `8080`                  |
+| `config.bindHost`      | Host to bind the web server to                             | `"127.0.0.1"`           |
+| `config.apiToken`      | API authentication token (auto-generated and persisted if empty) | `""`                    |
+
+### Auth Proxy Parameters
+
+| Name                                   | Description                                       | Value                                            |
+| -------------------------------------- | ------------------------------------------------- | ------------------------------------------------ |
+| `authProxy.enabled`                    | Enable the NGINX authentication proxy             | `true`                                           |
+| `authProxy.image`                      | NGINX proxy image                                 | `nginxinc/nginx-unprivileged:1.25-alpine-slim`   |
+| `authProxy.port`                       | Proxy server port inside the container            | `8080`                                           |
+| `authProxy.securityContext`            | Security context for the proxy container          | `{...}`                                          |
+
+### Health Check Parameters
+
+| Name                                        | Description                                        | Value  |
+| ------------------------------------------- | -------------------------------------------------- | ------ |
+| `livenessProbe.enabled`                     | Enable liveness probe                              | `true` |
+| `livenessProbe.initialDelaySeconds`         | Initial delay seconds for liveness probe           | `20`   |
+| `livenessProbe.periodSeconds`               | Period seconds for liveness probe                  | `30`   |
+| `livenessProbe.timeoutSeconds`              | Timeout seconds for liveness probe                 | `5`    |
+| `livenessProbe.failureThreshold`            | Failure threshold for liveness probe               | `3`    |
+| `readinessProbe.enabled`                    | Enable readiness probe                             | `true` |
+| `readinessProbe.initialDelaySeconds`        | Initial delay seconds for readiness probe          | `5`    |
+| `readinessProbe.periodSeconds`              | Period seconds for readiness probe                 | `10`   |
+| `readinessProbe.timeoutSeconds`             | Timeout seconds for readiness probe                | `5`    |
+| `readinessProbe.failureThreshold`           | Failure threshold for readiness probe              | `3`    |
 
 ### Network & Ingress Parameters
 

--- a/charts/open-design/README.md
+++ b/charts/open-design/README.md
@@ -35,6 +35,8 @@ nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
 nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
 ```
 
+**Path Constraints**: If you configure a non-root ingress path (e.g., `/app`), the chart enforces a strict guardrail: you **must** explicitly set `config.publicBaseUrl` to include this sub-path. Otherwise, the deployment will cleanly fail during rendering.
+
 #### Authentication Proxy
 An authentication proxy (NGINX) is introduced to front the application. This proxy runs as a mandatory sidecar container alongside the main application. The Kubernetes Service routes traffic to the proxy, which handles authentication for the API and health checks, proxying valid requests to the application.
 
@@ -66,7 +68,7 @@ This chart adheres to strict security defaults:
 | `config.nodeOptions`   | V8 engine memory optimizations                             | `--max-old-space-size=192`|
 | `config.webPort`       | Web server listening port                                  | `7456`                  |
 | `config.bindHost`      | Host to bind the web server to                             | `"127.0.0.1"`           |
-| `config.apiToken`      | API authentication token (auto-generated and persisted if empty) | `""`                    |
+| `config.apiToken`      | API authentication token (must be changed from default) | `"secure-default-token-change-me"` |
 
 ### Auth Proxy Parameters
 

--- a/charts/open-design/README.md
+++ b/charts/open-design/README.md
@@ -1,0 +1,132 @@
+<!--- app-name: Open Design -->
+
+## Introduction
+This chart bootstraps an [Open Design](https://github.com/nexu-io/open-design) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+- Kubernetes 1.23+
+- Helm 3.8.0+
+- PV provisioner support in the underlying infrastructure (if persistence is enabled)
+
+## Installing the Chart
+To install the chart with the release name `my-release`:
+
+```console
+helm install my-release ./charts/open-design
+```
+
+These commands deploy an Open Design application on the Kubernetes cluster in the default configuration.
+
+> **Tip**: List all releases using `helm list`
+
+### Architecture and Configuration Notes
+
+#### SQLite State & Concurrency Limitations
+The current Open Design runtime stores state in local files and SQLite under `/app/.od`. Because SQLite does not support concurrent writes from multiple network replicas, **this chart is strictly limited to 1 replica**. 
+
+Horizontal Pod Autoscaling (HPA) is disabled by default. Do not enable HPA or scale the deployment beyond `replicas: 1` unless you have modified the application to externalize the state to a standalone database.
+
+#### Server-Sent Events (SSE) and Ingress
+Open Design relies on Server-Sent Events (SSE) for real-time streaming. If you enable the Ingress resource, it is critical to disable reverse-proxy buffering. If you are using the NGINX Ingress Controller, this chart automatically applies the required annotations by default:
+
+```yaml
+nginx.ingress.kubernetes.io/proxy-buffering: "off"
+nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+```
+
+#### Security Context
+This chart adheres to strict security defaults:
+- Runs as non-root user `1001`.
+- Drops all kernel capabilities (`ALL`).
+- Enforces a `readOnlyRootFilesystem`.
+- Prevents privilege escalation.
+
+## Parameters
+
+### Global & Image Parameters
+
+| Name               | Description                               | Value                        |
+| ------------------ | ----------------------------------------- | ---------------------------- |
+| `commonLabels`     | Custom labels injected into all resources | `{app.kubernetes.io/environment: production}`  |
+| `image.repository` | Open Design image repository              | `vanjayak/open-design`       |
+| `image.pullPolicy` | Image pull policy                         | `IfNotPresent`               |
+| `image.tag`        | Image tag (overrides AppVersion)          | `latest`                     |
+
+### Application Configuration
+
+| Name                   | Description                                                | Value                   |
+| ---------------------- | ---------------------------------------------------------- | ----------------------- |
+| `config.nodeEnv`       | Node.js environment (`production` or `development`)        | `production`            |
+| `config.allowedOrigins`| CORS allowed origins (leave empty for default)             | `""`                    |
+| `config.publicBaseUrl` | Public base URL used by the application                    | `http://localhost:7456` |
+| `config.nodeOptions`   | V8 engine memory optimizations                             | `--max-old-space-size=192`|
+
+### Network & Ingress Parameters
+
+| Name                                    | Description                                                  | Value                      |
+| --------------------------------------- | ------------------------------------------------------------ | -------------------------- |
+| `service.type`                          | Kubernetes Service type                                      | `ClusterIP`                |
+| `service.port`                          | Service HTTP port                                            | `80`                       |
+| `ingress.enabled`                       | Enable ingress record generation                             | `false`                    |
+| `ingress.className`                     | Ingress class name                                           | `nginx`                    |
+| `ingress.annotations`                   | Additional custom annotations for Ingress (e.g., SSE fixes)  | `{...}`                    |
+| `ingress.hosts[0].host`                 | Hostname for the ingress record                              | `open-design.local`        |
+| `ingress.tls`                           | TLS configuration for ingress records                        | `[]`                       |
+
+### Persistence Parameters
+
+| Name                       | Description                                                  | Value           |
+| -------------------------- | ------------------------------------------------------------ | --------------- |
+| `persistence.enabled`      | Enable PVC for SQLite and file state                         | `true`          |
+| `persistence.storageClass` | Storage class (leave empty to use cluster default)           | `""`            |
+| `persistence.accessMode`   | PVC Access Mode                                              | `ReadWriteOnce` |
+| `persistence.size`         | PVC Storage Request                                          | `10Gi`          |
+
+### Resources & Autoscaling Parameters
+
+| Name                                | Description                                                     | Value     |
+| ----------------------------------- | --------------------------------------------------------------- | --------- |
+| `replicaCount`                      | Number of application replicas                                  | `1`       |
+| `resources.limits.cpu`              | CPU limits for the container                                    | `1000m`   |
+| `resources.limits.memory`           | Memory limits for the container                                 | `1024Mi`  |
+| `resources.requests.cpu`            | CPU requests for the container                                  | `200m`    |
+| `resources.requests.memory`         | Memory requests for the container                               | `256Mi`   |
+| `hpa.enabled`                       | Enable Horizontal Pod Autoscaler (WARNING: Breaks SQLite)       | `false`   |
+
+### Security & Scheduling Parameters
+
+| Name                                                              | Description                                     | Value              |
+| ----------------------------------------------------------------- | ----------------------------------------------- | ------------------ |
+| `podSecurityContext.fsGroupChangePolicy`                          | Set filesystem group change policy              | `Always`           |
+| `podSecurityContext.sysctls`                                      | Set kernel settings using the sysctl interface  | `[]`               |
+| `podSecurityContext.supplementalGroups`                           | Set filesystem extra groups                     | `[]`               |
+| `podSecurityContext.fsGroup`                                      | Group ID for the persistent volume              | `1001`             |
+| `containerSecurityContext.seLinuxOptions`                         | Set SELinux options in container                | `{}`               |
+| `containerSecurityContext.runAsUser`                              | Run the application as this UID                 | `1001`             |
+| `containerSecurityContext.runAsGroup`                             | Run the application as this GID                 | `1001`             |
+| `containerSecurityContext.runAsNonRoot`                           | Set container's Security Context runAsNonRoot   | `true`             |
+| `containerSecurityContext.privileged`                             | Set container's Security Context privileged     | `false`            |
+| `containerSecurityContext.readOnlyRootFilesystem`                 | Enforce read-only root FS                       | `true`             |
+| `containerSecurityContext.allowPrivilegeEscalation`               | Set container's Security Context allowPrivilegeEscalation | `false`            |
+| `containerSecurityContext.capabilities.drop`                      | List of capabilities to be dropped              | `["ALL"]`          |
+| `containerSecurityContext.seccompProfile.type`                    | Set container's Security Context seccomp profile| `"RuntimeDefault"` |
+| `nodeSelector`                                                    | Node labels for pod assignment                  | `{}`               |
+| `tolerations`                                                     | Tolerations for pod assignment                  | `[]`               |
+| `affinity`                                                        | Affinity rules for pod assignment               | `{}`               |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+helm install my-release --set config.nodeEnv=development ./charts/open-design
+```
+
+The above command sets the Open Design node environment to `development`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```console
+helm install my-release -f values.yaml ./charts/open-design
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/charts/open-design/templates/_helpers.tpl
+++ b/charts/open-design/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "open-design.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "open-design.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "open-design.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels injected into all resources.
+*/}}
+{{- define "open-design.labels" -}}
+helm.sh/chart: {{ include "open-design.chart" . }}
+{{ include "open-design.selectorLabels" . }}
+{{- if .Values.image.tag }}
+app.kubernetes.io/version: {{ .Values.image.tag | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels used by Services and HPAs.
+*/}}
+{{- define "open-design.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "open-design.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/open-design/templates/configmap.yaml
+++ b/charts/open-design/templates/configmap.yaml
@@ -13,9 +13,13 @@ data:
   NODE_OPTIONS: {{ .Values.config.nodeOptions | quote }}
 {{- $publicBaseUrl := .Values.config.publicBaseUrl }}
 {{- if and (not $publicBaseUrl) .Values.ingress.enabled .Values.ingress.hosts }}
-  {{- $scheme := ternary "https://" "http://" (gt (len .Values.ingress.tls) 0) }}
-  {{- $firstHost := (index .Values.ingress.hosts 0).host }}
-  {{- $publicBaseUrl = printf "%s%s" $scheme $firstHost }}
+  {{- if eq (len .Values.ingress.hosts) 1 }}
+    {{- $scheme := ternary "https://" "http://" (gt (len .Values.ingress.tls) 0) }}
+    {{- $firstHost := (index .Values.ingress.hosts 0).host }}
+    {{- $publicBaseUrl = printf "%s%s" $scheme $firstHost }}
+  {{- else if gt (len .Values.ingress.hosts) 1 }}
+    {{- fail "CRITICAL ERROR: Multiple ingress hosts configured. You must explicitly set config.publicBaseUrl to define the canonical origin for OAuth callbacks." }}
+  {{- end }}
 {{- end }}
 {{- if $publicBaseUrl }}
   OD_PUBLIC_BASE_URL: {{ $publicBaseUrl | quote }}

--- a/charts/open-design/templates/configmap.yaml
+++ b/charts/open-design/templates/configmap.yaml
@@ -34,9 +34,13 @@ data:
     {{- end }}
     {{- $origins = join "," $hostList }}
   {{- else if not $origins }}
-    {{- /* Synthesize default local origins for port-forwarding when Ingress is disabled */ -}}
-    {{- $localProxy := printf "http://localhost:%v" .Values.authProxy.port }}
-    {{- $localSvc := printf "http://localhost:%v" .Values.service.port }}
-    {{- $origins = printf "%s,%s" $localProxy $localSvc }}
+    {{- if or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort") }}
+      {{- fail "CRITICAL ERROR: service.type is set to LoadBalancer or NodePort but config.allowedOrigins is empty. You must explicitly configure config.allowedOrigins when exposing the service directly without an Ingress." }}
+    {{- else }}
+      {{- /* Synthesize default local origins for port-forwarding when Ingress is disabled */ -}}
+      {{- $localProxy := printf "http://localhost:%v" .Values.authProxy.port }}
+      {{- $localSvc := printf "http://localhost:%v" .Values.service.port }}
+      {{- $origins = printf "%s,%s" $localProxy $localSvc }}
+    {{- end }}
   {{- end }}
   OD_ALLOWED_ORIGINS: {{ $origins | quote }}

--- a/charts/open-design/templates/configmap.yaml
+++ b/charts/open-design/templates/configmap.yaml
@@ -5,15 +5,21 @@ metadata:
   labels:
     {{- include "open-design.labels" . | nindent 4 }}
 data:
-  OD_BIND_HOST: {{ if .Values.authProxy.enabled }}{{ .Values.config.bindHost | quote }}{{ else }}"0.0.0.0"{{ end }}
+  OD_BIND_HOST: {{ .Values.config.bindHost | quote }}
   OD_PORT: {{ .Values.config.webPort | quote }}
   OD_WEB_PORT: {{ .Values.config.webPort | quote }}
   PROXY_PORT: {{ .Values.authProxy.port | quote }}
   NODE_ENV: {{ .Values.config.nodeEnv | quote }}
   NODE_OPTIONS: {{ .Values.config.nodeOptions | quote }}
-{{- if .Values.config.publicBaseUrl }}
-  OD_PUBLIC_BASE_URL: {{ .Values.config.publicBaseUrl | quote }}
-  {{- end }}
+{{- $publicBaseUrl := .Values.config.publicBaseUrl }}
+{{- if and (not $publicBaseUrl) .Values.ingress.enabled .Values.ingress.hosts }}
+  {{- $scheme := ternary "https://" "http://" (gt (len .Values.ingress.tls) 0) }}
+  {{- $firstHost := (index .Values.ingress.hosts 0).host }}
+  {{- $publicBaseUrl = printf "%s%s" $scheme $firstHost }}
+{{- end }}
+{{- if $publicBaseUrl }}
+  OD_PUBLIC_BASE_URL: {{ $publicBaseUrl | quote }}
+{{- end }}
 
 {{- $origins := .Values.config.allowedOrigins }}
   {{- if and .Values.ingress.enabled (not $origins) }}

--- a/charts/open-design/templates/configmap.yaml
+++ b/charts/open-design/templates/configmap.yaml
@@ -14,9 +14,15 @@ data:
 {{- $publicBaseUrl := .Values.config.publicBaseUrl }}
 {{- if and (not $publicBaseUrl) .Values.ingress.enabled .Values.ingress.hosts }}
   {{- if eq (len .Values.ingress.hosts) 1 }}
-    {{- $scheme := ternary "https://" "http://" (gt (len .Values.ingress.tls) 0) }}
-    {{- $firstHost := (index .Values.ingress.hosts 0).host }}
-    {{- $publicBaseUrl = printf "%s%s" $scheme $firstHost }}
+    {{- $singleHost := (index .Values.ingress.hosts 0).host }}
+    {{- $isSecure := false }}
+    {{- range $.Values.ingress.tls }}
+      {{- if has $singleHost .hosts }}
+        {{- $isSecure = true }}
+      {{- end }}
+    {{- end }}
+    {{- $scheme := ternary "https://" "http://" $isSecure }}
+    {{- $publicBaseUrl = printf "%s%s" $scheme $singleHost }}
   {{- else if gt (len .Values.ingress.hosts) 1 }}
     {{- fail "CRITICAL ERROR: Multiple ingress hosts configured. You must explicitly set config.publicBaseUrl to define the canonical origin for OAuth callbacks." }}
   {{- end }}

--- a/charts/open-design/templates/configmap.yaml
+++ b/charts/open-design/templates/configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "open-design.fullname" . }}
+  labels:
+    {{- include "open-design.labels" . | nindent 4 }}
+data:
+  OD_BIND_HOST: "0.0.0.0"
+  OD_PORT: "7456"
+  OD_WEB_PORT: "7456"
+
+  NODE_ENV: {{ .Values.config.nodeEnv | quote }}
+  NODE_OPTIONS: {{ .Values.config.nodeOptions | quote }}
+  OD_ALLOWED_ORIGINS: {{ .Values.config.allowedOrigins | quote }}
+  OD_PUBLIC_BASE_URL: {{ .Values.config.publicBaseUrl | quote }}

--- a/charts/open-design/templates/configmap.yaml
+++ b/charts/open-design/templates/configmap.yaml
@@ -12,7 +12,9 @@ data:
 
   NODE_ENV: {{ .Values.config.nodeEnv | quote }}
   NODE_OPTIONS: {{ .Values.config.nodeOptions | quote }}
+{{- if .Values.config.publicBaseUrl }}
   OD_PUBLIC_BASE_URL: {{ .Values.config.publicBaseUrl | quote }}
+  {{- end }}
 
 {{- $origins := .Values.config.allowedOrigins }}
   {{- if and .Values.ingress.enabled (not $origins) }}

--- a/charts/open-design/templates/configmap.yaml
+++ b/charts/open-design/templates/configmap.yaml
@@ -28,9 +28,16 @@ data:
 {{- $origins := .Values.config.allowedOrigins }}
   {{- if and .Values.ingress.enabled (not $origins) }}
     {{- $hostList := list }}
-    {{- $scheme := ternary "https://" "http://" (gt (len .Values.ingress.tls) 0) }}
     {{- range .Values.ingress.hosts }}
-      {{- $hostList = append $hostList (printf "%s%s" $scheme .host) }}
+      {{- $currentHost := .host }}
+      {{- $isSecure := false }}
+      {{- range $.Values.ingress.tls }}
+        {{- if has $currentHost .hosts }}
+          {{- $isSecure = true }}
+        {{- end }}
+      {{- end }}
+      {{- $scheme := ternary "https://" "http://" $isSecure }}
+      {{- $hostList = append $hostList (printf "%s%s" $scheme $currentHost) }}
     {{- end }}
     {{- $origins = join "," $hostList }}
   {{- else if not $origins }}

--- a/charts/open-design/templates/configmap.yaml
+++ b/charts/open-design/templates/configmap.yaml
@@ -23,5 +23,10 @@ data:
       {{- $hostList = append $hostList (printf "%s%s" $scheme .host) }}
     {{- end }}
     {{- $origins = join "," $hostList }}
+  {{- else if not $origins }}
+    {{- /* Synthesize default local origins for port-forwarding when Ingress is disabled */ -}}
+    {{- $localProxy := printf "http://localhost:%v" .Values.authProxy.port }}
+    {{- $localSvc := printf "http://localhost:%v" .Values.service.port }}
+    {{- $origins = printf "%s,%s" $localProxy $localSvc }}
   {{- end }}
   OD_ALLOWED_ORIGINS: {{ $origins | quote }}

--- a/charts/open-design/templates/configmap.yaml
+++ b/charts/open-design/templates/configmap.yaml
@@ -6,10 +6,20 @@ metadata:
     {{- include "open-design.labels" . | nindent 4 }}
 data:
   OD_BIND_HOST: "0.0.0.0"
-  OD_PORT: "7456"
-  OD_WEB_PORT: "7456"
+  OD_PORT: {{ .Values.config.webPort | quote }}
+  OD_WEB_PORT: {{ .Values.config.webPort | quote }}
 
   NODE_ENV: {{ .Values.config.nodeEnv | quote }}
   NODE_OPTIONS: {{ .Values.config.nodeOptions | quote }}
-  OD_ALLOWED_ORIGINS: {{ .Values.config.allowedOrigins | quote }}
   OD_PUBLIC_BASE_URL: {{ .Values.config.publicBaseUrl | quote }}
+
+{{- $origins := .Values.config.allowedOrigins }}
+  {{- if and .Values.ingress.enabled (not $origins) }}
+    {{- $hostList := list }}
+    {{- $scheme := ternary "https://" "http://" (gt (len .Values.ingress.tls) 0) }}
+    {{- range .Values.ingress.hosts }}
+      {{- $hostList = append $hostList (printf "%s%s" $scheme .host) }}
+    {{- end }}
+    {{- $origins = join "," $hostList }}
+  {{- end }}
+  OD_ALLOWED_ORIGINS: {{ $origins | quote }}

--- a/charts/open-design/templates/configmap.yaml
+++ b/charts/open-design/templates/configmap.yaml
@@ -5,9 +5,10 @@ metadata:
   labels:
     {{- include "open-design.labels" . | nindent 4 }}
 data:
-  OD_BIND_HOST: "0.0.0.0"
+  OD_BIND_HOST: {{ .Values.config.bindHost | quote }}
   OD_PORT: {{ .Values.config.webPort | quote }}
   OD_WEB_PORT: {{ .Values.config.webPort | quote }}
+  PROXY_PORT: {{ .Values.config.proxyPort | quote }}
 
   NODE_ENV: {{ .Values.config.nodeEnv | quote }}
   NODE_OPTIONS: {{ .Values.config.nodeOptions | quote }}

--- a/charts/open-design/templates/configmap.yaml
+++ b/charts/open-design/templates/configmap.yaml
@@ -5,11 +5,10 @@ metadata:
   labels:
     {{- include "open-design.labels" . | nindent 4 }}
 data:
-  OD_BIND_HOST: {{ .Values.config.bindHost | quote }}
+  OD_BIND_HOST: {{ if .Values.authProxy.enabled }}{{ .Values.config.bindHost | quote }}{{ else }}"0.0.0.0"{{ end }}
   OD_PORT: {{ .Values.config.webPort | quote }}
   OD_WEB_PORT: {{ .Values.config.webPort | quote }}
-  PROXY_PORT: {{ .Values.config.proxyPort | quote }}
-
+  PROXY_PORT: {{ .Values.authProxy.port | quote }}
   NODE_ENV: {{ .Values.config.nodeEnv | quote }}
   NODE_OPTIONS: {{ .Values.config.nodeOptions | quote }}
 {{- if .Values.config.publicBaseUrl }}

--- a/charts/open-design/templates/deployment.yaml
+++ b/charts/open-design/templates/deployment.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
           checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+          checksum/proxy-config: {{ include (print $.Template.BasePath "/proxy-configmap.yaml") . | sha256sum }}
           checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         {{- include "open-design.selectorLabels" . | nindent 8 }}

--- a/charts/open-design/templates/deployment.yaml
+++ b/charts/open-design/templates/deployment.yaml
@@ -131,6 +131,9 @@ spec:
             - name: proxy-tmp
               mountPath: /tmp
         {{- end }}
+        {{- if .Values.sidecars }}
+        {{- toYaml .Values.sidecars | nindent 8 }}
+        {{- end }}
       volumes:
         - name: storage
           {{- if .Values.persistence.enabled }}

--- a/charts/open-design/templates/deployment.yaml
+++ b/charts/open-design/templates/deployment.yaml
@@ -16,6 +16,9 @@ spec:
       {{- include "open-design.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+          checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+          checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         {{- include "open-design.selectorLabels" . | nindent 8 }}
     spec:
@@ -40,6 +43,12 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "open-design.fullname" . }}
+          env:
+            - name: OD_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "open-design.fullname" . }}
+                  key: OD_API_TOKEN
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             {{- omit .Values.livenessProbe "enabled" | toYaml | nindent 12 }}

--- a/charts/open-design/templates/deployment.yaml
+++ b/charts/open-design/templates/deployment.yaml
@@ -30,7 +30,6 @@ spec:
         {{- if .Values.initContainers }}
         {{- toYaml .Values.initContainers | nindent 8 }}
         {{- end }}
-        {{- if .Values.authProxy.enabled }}
         - name: auth-proxy-init
           image: {{ .Values.authProxy.image }}
           securityContext:
@@ -54,7 +53,6 @@ spec:
               mountPath: /etc/nginx/conf.d
             - name: proxy-tmp
               mountPath: /tmp
-        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -99,7 +97,6 @@ spec:
               mountPath: /app/.od
             - name: tmp
               mountPath: /tmp
-{{- if .Values.authProxy.enabled }}
         - name: auth-proxy
           image: {{ .Values.authProxy.image }}
           securityContext:
@@ -130,7 +127,6 @@ spec:
               readOnly: true
             - name: proxy-tmp
               mountPath: /tmp
-        {{- end }}
         {{- if .Values.sidecars }}
         {{- toYaml .Values.sidecars | nindent 8 }}
         {{- end }}
@@ -144,7 +140,6 @@ spec:
           {{- end }}
         - name: tmp
           emptyDir: {}
-      {{- if .Values.authProxy.enabled }}
         - name: proxy-template
           configMap:
             name: {{ include "open-design.fullname" . }}-proxy
@@ -152,7 +147,6 @@ spec:
           emptyDir: {}
         - name: proxy-tmp
           emptyDir: {}
-        {{- end }}
 {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/open-design/templates/deployment.yaml
+++ b/charts/open-design/templates/deployment.yaml
@@ -26,10 +26,35 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.initContainers }}
       initContainers:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- if .Values.initContainers }}
+        {{- toYaml .Values.initContainers | nindent 8 }}
+        {{- end }}
+        {{- if .Values.authProxy.enabled }}
+        - name: auth-proxy-init
+          image: {{ .Values.authProxy.image }}
+          securityContext:
+            {{- toYaml .Values.authProxy.securityContext | nindent 12 }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - envsubst '$PROXY_PORT $OD_BIND_HOST $OD_WEB_PORT $PROXY_API_TOKEN' < /etc/nginx/templates/default.conf.template > /etc/nginx/conf.d/default.conf
+          envFrom:
+            - configMapRef:
+                name: {{ include "open-design.fullname" . }}
+          env:
+            - name: PROXY_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "open-design.fullname" . }}
+                  key: OD_API_TOKEN
+          volumeMounts:
+            - name: proxy-template
+              mountPath: /etc/nginx/templates
+            - name: proxy-config
+              mountPath: /etc/nginx/conf.d
+            - name: proxy-tmp
+              mountPath: /tmp
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -38,7 +63,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 7456
+              containerPort: {{ .Values.config.webPort }}
               protocol: TCP
           envFrom:
             - configMapRef:
@@ -51,11 +76,21 @@ spec:
                   key: OD_API_TOKEN
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
-            {{- omit .Values.livenessProbe "enabled" | toYaml | nindent 12 }}
+            exec:
+              command: ["wget", "-qO-", "http://{{ .Values.config.bindHost }}:{{ .Values.config.webPort }}/api/health"]
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           {{- end }}
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
-            {{- omit .Values.readinessProbe "enabled" | toYaml | nindent 12 }}
+            exec:
+              command: ["wget", "-qO-", "http://{{ .Values.config.bindHost }}:{{ .Values.config.webPort }}/api/health"]
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
@@ -64,9 +99,38 @@ spec:
               mountPath: /app/.od
             - name: tmp
               mountPath: /tmp
-      {{- with .Values.sidecars }}
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+{{- if .Values.authProxy.enabled }}
+        - name: auth-proxy
+          image: {{ .Values.authProxy.image }}
+          securityContext:
+            {{- toYaml .Values.authProxy.securityContext | nindent 12 }}
+          ports:
+            - name: http-proxy
+              containerPort: {{ .Values.authProxy.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /nginx-health
+              port: http-proxy
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http-proxy
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          volumeMounts:
+            - name: proxy-config
+              mountPath: /etc/nginx/conf.d
+              readOnly: true
+            - name: proxy-tmp
+              mountPath: /tmp
+        {{- end }}
       volumes:
         - name: storage
           {{- if .Values.persistence.enabled }}
@@ -77,6 +141,15 @@ spec:
           {{- end }}
         - name: tmp
           emptyDir: {}
+      {{- if .Values.authProxy.enabled }}
+        - name: proxy-template
+          configMap:
+            name: {{ include "open-design.fullname" . }}-proxy
+        - name: proxy-config
+          emptyDir: {}
+        - name: proxy-tmp
+          emptyDir: {}
+        {{- end }}
 {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/open-design/templates/deployment.yaml
+++ b/charts/open-design/templates/deployment.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "open-design.fullname" . }}
+  labels:
+    {{- include "open-design.labels" . | nindent 4 }}
+
+spec:
+  {{- if not .Values.hpa.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "open-design.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "open-design.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 7456
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "open-design.fullname" . }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            {{- omit .Values.livenessProbe "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            {{- omit .Values.readinessProbe "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: storage
+              mountPath: /app/.od
+            - name: tmp
+              mountPath: /tmp
+      {{- with .Values.sidecars }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: storage
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "open-design.fullname" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: tmp
+          emptyDir: {}
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/open-design/templates/hpa.yaml
+++ b/charts/open-design/templates/hpa.yaml
@@ -1,0 +1,30 @@
+# WARNING: SQLite does not support concurrent writes from multiple replicas.
+# Only enable HPA if open-design has been configured with an external database.
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "open-design.fullname" . }}
+  labels:
+    {{- include "open-design.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "open-design.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetMemoryUtilizationPercentage }}
+{{- end }}

--- a/charts/open-design/templates/ingress.yaml
+++ b/charts/open-design/templates/ingress.yaml
@@ -1,9 +1,8 @@
 {{- if .Values.ingress.enabled -}}
-{{- if not .Values.config.publicBaseUrl -}}
-  {{- $firstHostBlock := index .Values.ingress.hosts 0 }}
-  {{- range $firstHostBlock.paths }}
+{{- range .Values.ingress.hosts }}
+  {{- range .paths }}
     {{- if ne .path "/" }}
-      {{- fail "CRITICAL ERROR: A non-root ingress path prefix is configured. You must explicitly set config.publicBaseUrl to include the sub-path." }}
+      {{- fail "CRITICAL ERROR: Non-root ingress path prefixes (sub-paths) are not supported by the proxy routing stack. Ingress paths must be fixed to '/'." }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/open-design/templates/ingress.yaml
+++ b/charts/open-design/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "open-design.fullname" . }}
+  labels:
+    {{- include "open-design.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "open-design.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/open-design/templates/ingress.yaml
+++ b/charts/open-design/templates/ingress.yaml
@@ -1,4 +1,12 @@
 {{- if .Values.ingress.enabled -}}
+{{- if not .Values.config.publicBaseUrl -}}
+  {{- $firstHostBlock := index .Values.ingress.hosts 0 }}
+  {{- range $firstHostBlock.paths }}
+    {{- if ne .path "/" }}
+      {{- fail "CRITICAL ERROR: A non-root ingress path prefix is configured. You must explicitly set config.publicBaseUrl to include the sub-path." }}
+    {{- end }}
+  {{- end }}
+{{- end }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/charts/open-design/templates/proxy-configmap.yaml
+++ b/charts/open-design/templates/proxy-configmap.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.authProxy.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "open-design.fullname" . }}-proxy
+  labels:
+    {{- include "open-design.labels" . | nindent 4 }}
+data:
+  default.conf.template: |
+    server {
+        listen ${PROXY_PORT};
+        
+        location /nginx-health {
+            return 200 "healthy\n";
+            add_header Content-Type text/plain;
+        }
+        
+        location / {
+            proxy_pass http://${OD_BIND_HOST}:${OD_WEB_PORT};
+            proxy_set_header Host $host;
+        }
+
+        location /api/ {
+            proxy_pass http://${OD_BIND_HOST}:${OD_WEB_PORT};
+            proxy_set_header Host $host;
+            proxy_set_header Authorization "Bearer ${PROXY_API_TOKEN}";
+            
+            # Critical for Server-Sent Events (SSE)
+            proxy_buffering off;
+            proxy_read_timeout 600s;
+            proxy_send_timeout 600s;
+            proxy_set_header Connection '';
+            http2_push_preload on;
+        }
+    }
+{{- end }}

--- a/charts/open-design/templates/proxy-configmap.yaml
+++ b/charts/open-design/templates/proxy-configmap.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.authProxy.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -42,4 +41,3 @@ data:
             http2_push_preload on;
         }
     }
-{{- end }}

--- a/charts/open-design/templates/proxy-configmap.yaml
+++ b/charts/open-design/templates/proxy-configmap.yaml
@@ -18,11 +18,20 @@ data:
         location / {
             proxy_pass http://${OD_BIND_HOST}:${OD_WEB_PORT};
             proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+            proxy_set_header X-Forwarded-Host $http_x_forwarded_host;
         }
 
         location /api/ {
             proxy_pass http://${OD_BIND_HOST}:${OD_WEB_PORT};
             proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+            proxy_set_header X-Forwarded-Host $http_x_forwarded_host;
+            
             proxy_set_header Authorization "Bearer ${PROXY_API_TOKEN}";
             
             # Critical for Server-Sent Events (SSE)

--- a/charts/open-design/templates/pvc.yaml
+++ b/charts/open-design/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.persistence.enabled -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "open-design.fullname" . }}
+  labels:
+    {{- include "open-design.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/open-design/templates/secret.yaml
+++ b/charts/open-design/templates/secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "open-design.fullname" . }}
+  labels:
+    {{- include "open-design.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if .Values.config.apiToken }}
+  OD_API_TOKEN: {{ .Values.config.apiToken | b64enc | quote }}
+  {{- else }}
+  OD_API_TOKEN: {{ randAlphaNum 32 | b64enc | quote }}
+  {{- end }}

--- a/charts/open-design/templates/secret.yaml
+++ b/charts/open-design/templates/secret.yaml
@@ -9,5 +9,10 @@ data:
   {{- if .Values.config.apiToken }}
   OD_API_TOKEN: {{ .Values.config.apiToken | b64enc | quote }}
   {{- else }}
+  {{- $existingSecret := lookup "v1" "Secret" .Release.Namespace (include "open-design.fullname" .) }}
+  {{- if $existingSecret }}
+  OD_API_TOKEN: {{ index $existingSecret.data "OD_API_TOKEN" }}
+  {{- else }}
   OD_API_TOKEN: {{ randAlphaNum 32 | b64enc | quote }}
+  {{- end }}
   {{- end }}

--- a/charts/open-design/templates/secret.yaml
+++ b/charts/open-design/templates/secret.yaml
@@ -2,17 +2,10 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "open-design.fullname" . }}
-  labels:
-    {{- include "open-design.labels" . | nindent 4 }}
 type: Opaque
 data:
   {{- if .Values.config.apiToken }}
   OD_API_TOKEN: {{ .Values.config.apiToken | b64enc | quote }}
   {{- else }}
-  {{- $existingSecret := lookup "v1" "Secret" .Release.Namespace (include "open-design.fullname" .) }}
-  {{- if $existingSecret }}
-  OD_API_TOKEN: {{ index $existingSecret.data "OD_API_TOKEN" }}
-  {{- else }}
-  OD_API_TOKEN: {{ randAlphaNum 32 | b64enc | quote }}
-  {{- end }}
+  {{- fail "CRITICAL ERROR: config.apiToken cannot be empty." }}
   {{- end }}

--- a/charts/open-design/templates/service.yaml
+++ b/charts/open-design/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "open-design.fullname" . }}
+  labels:
+    {{- include "open-design.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "open-design.selectorLabels" . | nindent 4 }}

--- a/charts/open-design/templates/service.yaml
+++ b/charts/open-design/templates/service.yaml
@@ -8,11 +8,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      {{- if .Values.authProxy.enabled }}
       targetPort: http-proxy
-      {{- else }}
-      targetPort: http
-      {{- end }}
       protocol: TCP
       name: http
   selector:

--- a/charts/open-design/templates/service.yaml
+++ b/charts/open-design/templates/service.yaml
@@ -8,7 +8,11 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
+      {{- if .Values.authProxy.enabled }}
+      targetPort: http-proxy
+      {{- else }}
       targetPort: http
+      {{- end }}
       protocol: TCP
       name: http
   selector:

--- a/charts/open-design/values.yaml
+++ b/charts/open-design/values.yaml
@@ -19,7 +19,7 @@ config:
   nodeOptions: "--max-old-space-size=192"
   webPort: 7456
   bindHost: "127.0.0.1"
-  apiToken: "" # Auto-generated if left empty
+  apiToken: "secure-default-token-change-me"
 
 service:
   type: ClusterIP

--- a/charts/open-design/values.yaml
+++ b/charts/open-design/values.yaml
@@ -1,0 +1,112 @@
+# Safety constraint for SQLite data consistency
+replicaCount: 1
+
+commonLabels:
+  app.kubernetes.io/environment: "production"
+
+image:
+  repository: vanjayak/open-design
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+config:
+# The runtime environment for the Node.js process. 
+# Must be either "production" or "development". 
+# For Staging clusters, leave this as "production".
+  nodeEnv: "production"
+  allowedOrigins: ""
+  publicBaseUrl: "http://localhost:7456"
+  nodeOptions: "--max-old-space-size=192"
+  webPort: 7456
+
+service:
+  type: ClusterIP
+  port: 80
+
+persistence:
+  enabled: true
+  storageClass: ""
+  accessMode: ReadWriteOnce
+  size: 10Gi
+
+ingress:
+  enabled: false
+  className: "nginx"
+  annotations:
+    # Critical: Disables proxy buffering so Server-Sent Events (SSE) stream in real-time
+    nginx.ingress.kubernetes.io/proxy-buffering: "off"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+  hosts:
+    - host: open-design.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  ## example for tls configuration:
+  #  - secretName: open-design-tls
+  #    hosts:
+  #      - open-design.local
+
+resources:
+  limits:
+    cpu: 1000m
+    memory: 1024Mi
+  requests:
+    cpu: 200m
+    memory: 256Mi
+
+containerSecurityContext:
+  seLinuxOptions: {}
+  runAsUser: 1001
+  runAsGroup: 1001
+  runAsNonRoot: true
+  privileged: false
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  seccompProfile:
+    type: "RuntimeDefault"
+
+podSecurityContext:
+  fsGroupChangePolicy: Always
+  sysctls: []
+  supplementalGroups: []
+  fsGroup: 1001
+
+livenessProbe:
+  enabled: true
+  httpGet:
+    path: /api/health
+    port: http
+  initialDelaySeconds: 20
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  enabled: true
+  httpGet:
+    path: /api/health
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+# WARNING: Do not enable HPA if using the default SQLite storage. 
+# Concurrent writes from multiple pods will corrupt the database file.
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+affinity: {}
+tolerations: []
+
+initContainers: []
+sidecars: []

--- a/charts/open-design/values.yaml
+++ b/charts/open-design/values.yaml
@@ -18,7 +18,6 @@ config:
   publicBaseUrl: ""
   nodeOptions: "--max-old-space-size=192"
   webPort: 7456
-  proxyPort: 8080
   bindHost: "127.0.0.1"
   apiToken: "" # Auto-generated if left empty
 

--- a/charts/open-design/values.yaml
+++ b/charts/open-design/values.yaml
@@ -18,6 +18,7 @@ config:
   publicBaseUrl: "http://localhost:7456"
   nodeOptions: "--max-old-space-size=192"
   webPort: 7456
+  apiToken: "" # Auto-generated if left empty
 
 service:
   type: ClusterIP

--- a/charts/open-design/values.yaml
+++ b/charts/open-design/values.yaml
@@ -15,7 +15,7 @@ config:
 # For Staging clusters, leave this as "production".
   nodeEnv: "production"
   allowedOrigins: ""
-  publicBaseUrl: "http://localhost:7456"
+  publicBaseUrl: ""
   nodeOptions: "--max-old-space-size=192"
   webPort: 7456
   proxyPort: 8080

--- a/charts/open-design/values.yaml
+++ b/charts/open-design/values.yaml
@@ -78,7 +78,6 @@ podSecurityContext:
   fsGroup: 1001
 
 authProxy:
-  enabled: true
   image: "nginxinc/nginx-unprivileged:1.25-alpine-slim"
   port: 8080
   securityContext:

--- a/charts/open-design/values.yaml
+++ b/charts/open-design/values.yaml
@@ -18,6 +18,8 @@ config:
   publicBaseUrl: "http://localhost:7456"
   nodeOptions: "--max-old-space-size=192"
   webPort: 7456
+  proxyPort: 8080
+  bindHost: "127.0.0.1"
   apiToken: "" # Auto-generated if left empty
 
 service:
@@ -76,11 +78,21 @@ podSecurityContext:
   supplementalGroups: []
   fsGroup: 1001
 
+authProxy:
+  enabled: true
+  image: "nginxinc/nginx-unprivileged:1.25-alpine-slim"
+  port: 8080
+  securityContext:
+    runAsUser: 101
+    runAsGroup: 101
+    runAsNonRoot: true
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+
 livenessProbe:
   enabled: true
-  httpGet:
-    path: /api/health
-    port: http
   initialDelaySeconds: 20
   periodSeconds: 30
   timeoutSeconds: 5
@@ -88,9 +100,6 @@ livenessProbe:
 
 readinessProbe:
   enabled: true
-  httpGet:
-    path: /api/health
-    port: http
   initialDelaySeconds: 5
   periodSeconds: 10
   timeoutSeconds: 5


### PR DESCRIPTION
<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works.
     Delete this whole block if the PR genuinely doesn't close any issue. -->
Resolves #1029 

## Why

<!-- Why are you opening this PR? Cover two things:
       - Your use case — what made you write this today? Did you hit it yourself
         while building on top of OD, are you scratching an itch for a team, or
         are you speculatively adding for others? All are fine, but say which.
       - The pain being addressed — user-facing problem, technical debt, a prod
         issue, or unblocking another change.
     For non-trivial features, please open a discussion or issue first to align
     on scope and UX before writing code. -->

I'm fulfilling an open feature request #1029 to provide a provider-neutral Kubernetes deployment method, which is now feasible since the Docker runtime dependencies are in place. 

Introducing a first MVP Helm Chart.

## What users will see

Users can now deploy Open Design natively on Kubernetes using a standard Helm chart. The deployment features:

* **State & Storage Guardrails:** A pre-configured `PersistentVolumeClaim` (PVC) for SQLite database paired with a single-replica.
* **Production Security:** Hardened container configurations running as non-root with a read-only root filesystem.
* **Optimized Routing:** Pre-configured Ingress rules tailored to handle real-time Server-Sent Events (SSE) streaming seamlessly.

## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Validation

<!-- What you actually ran. Default minimum: `pnpm guard` + `pnpm typecheck`,
     plus the package-scoped tests/build for the files you changed
     (e.g. `pnpm --filter @open-design/web test`). -->

* Ran `pnpm guard` + `pnpm typecheck`
* `helm lint charts/open-design` passes with 0 errors.
* Rendered manifests validated via `helm template`.
* Smoke tested locally via Docker Desktop Kubernetes.
* Verified `/api/health` returns successfully.
* Verified basic UI loading at the root `/` path.
* Verified ingress functionality:
  * Testing /api/health
`curl -i -H "Host: open-design.local" http://localhost/api/health`
  * Testing UI asset loading
`curl -i -H "Host: open-design.local" http://localhost/ `

## Screenshots
N/A

## Bug fix verification
N/A