### PR TITLE
fix(web): scope design-systems surface chip counts to active style filter

### DIFF
--- a/apps/web/src/components/DesignSystemsTab.tsx
+++ b/apps/web/src/components/DesignSystemsTab.tsx
@@ -105,7 +105,10 @@ export function DesignSystemsTab({
     return editable.filter((system) => (system.status ?? 'draft') === userFilter);
   }, [systems, userFilter]);
 
-  const surfaceCounts = useMemo(() => {
+  // Total systems per surface, ignoring every active filter. Drives the
+  // "this surface is now empty" fallback below — that guard must react to
+  // the catalog itself, not to a transient style/search filter.
+  const surfaceTotals = useMemo(() => {
     const counts: Record<SurfaceFilter, number> = { all: librarySystems.length, web: 0, image: 0, video: 0, audio: 0 };
     for (const s of librarySystems) counts[surfaceOf(s)]++;
     return counts;
@@ -124,17 +127,21 @@ export function DesignSystemsTab({
   // If the currently selected surface has zero items, fall back to 'all'.
   // If the current category is no longer present in the filtered list, fall back to 'All'.
   useEffect(() => {
-    if (surfaceFilter !== 'all' && surfaceCounts[surfaceFilter] === 0) {
+    if (surfaceFilter !== 'all' && surfaceTotals[surfaceFilter] === 0) {
       setSurfaceFilter('all');
       setCategory('All');
     } else if (category !== 'All' && !categories.includes(category)) {
       setCategory('All');
     }
-  }, [systems, surfaceFilter, surfaceCounts, category, categories]);
+  }, [systems, surfaceFilter, surfaceTotals, category, categories]);
 
-  const filtered = useMemo(() => {
+  // Systems matching the active style category and search text, before the
+  // surface filter is applied. Both the surface pill counts and the visible
+  // grid derive from this so a surface chip always reports its own result
+  // set rather than the unfiltered catalog total.
+  const queryScoped = useMemo(() => {
     const q = filter.trim().toLowerCase();
-    return surfaceScoped.filter((s) => {
+    return librarySystems.filter((s) => {
       if (category !== 'All' && (s.category || 'Uncategorized') !== category) return false;
       if (!q) return true;
       const summary = localizeDesignSystemSummary(locale, s).toLowerCase();
@@ -149,7 +156,22 @@ export function DesignSystemsTab({
         categoryLabel.includes(q)
       );
     });
-  }, [surfaceScoped, filter, category, locale]);
+  }, [librarySystems, filter, category, locale]);
+
+  const surfaceCounts = useMemo(() => {
+    const counts: Record<SurfaceFilter, number> = {
+      all: queryScoped.length, web: 0, image: 0, video: 0, audio: 0,
+    };
+    for (const s of queryScoped) counts[surfaceOf(s)]++;
+    return counts;
+  }, [queryScoped]);
+
+  const filtered = useMemo(
+    () => surfaceFilter === 'all'
+      ? queryScoped
+      : queryScoped.filter((s) => surfaceOf(s) === surfaceFilter),
+    [queryScoped, surfaceFilter],
+  );
 
   // Category metadata is authored in English; keep raw values in state for
   // filtering while localizing the visible labels for the current UI locale.
@@ -363,7 +385,13 @@ export function DesignSystemsTab({
           aria-label={t('ds.surfaceLabel')}
         >
           <span className="examples-filter-label">{t('ds.surfaceLabel')}</span>
-          {SURFACE_PILLS.filter((p) => p.value === 'all' || surfaceCounts[p.value] > 0).map((p) => (
+          {/* Hide chips with no items in the active style/search filter, but
+              always keep "all" and the currently selected surface — otherwise a
+              transient search could remove the active chip and leave the grid
+              filtered with no chip showing aria-selected. */}
+          {SURFACE_PILLS.filter(
+            (p) => p.value === surfaceFilter || p.value === 'all' || surfaceCounts[p.value] > 0,
+          ).map((p) => (
             <button
               key={p.value}
               type="button"
@@ -371,10 +399,7 @@ export function DesignSystemsTab({
               aria-selected={surfaceFilter === p.value}
               data-testid={`design-systems-surface-${p.value}`}
               className={`filter-pill ${surfaceFilter === p.value ? 'active' : ''}`}
-              onClick={() => {
-                setSurfaceFilter(p.value);
-                setCategory('All');
-              }}
+              onClick={() => setSurfaceFilter(p.value)}
             >
               {t(p.labelKey)}
               <span className="filter-pill-count">{surfaceCounts[p.value]}</span>

--- a/apps/web/tests/components/DesignSystemsTab.test.tsx
+++ b/apps/web/tests/components/DesignSystemsTab.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { DesignSystemSummary } from '@open-design/contracts';
 
 import { DesignSystemsTab } from '../../src/components/DesignSystemsTab';
@@ -12,14 +12,32 @@ vi.mock('../../src/providers/registry', async () => {
   );
   return {
     ...actual,
+    fetchDesignSystemShowcase: vi.fn(async () => null),
     updateDesignSystemDraft: vi.fn(async () => null),
     deleteDesignSystemDraft: vi.fn(async () => true),
   };
 });
 
+// DesignSystemCard lazy-loads its showcase iframe through an
+// IntersectionObserver; an idle observer keeps thumbnails (and the registry
+// fetch) out of the way so the tests only exercise filtering.
+const originalIntersectionObserver = globalThis.IntersectionObserver;
+
+class IdleIntersectionObserver {
+  observe() {}
+  disconnect() {}
+  unobserve() {}
+}
+
+beforeEach(() => {
+  globalThis.IntersectionObserver =
+    IdleIntersectionObserver as unknown as typeof IntersectionObserver;
+});
+
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
+  globalThis.IntersectionObserver = originalIntersectionObserver;
 });
 
 const systems: DesignSystemSummary[] = [
@@ -83,5 +101,136 @@ describe('DesignSystemsTab', () => {
 
     fireEvent.click(screen.getByText('Edit'));
     expect(onOpenSystem).toHaveBeenCalledWith('user:acme');
+  });
+});
+
+// --- #2062: built-in library surface-chip filtering -----------------------
+
+function ds(
+  overrides: Partial<DesignSystemSummary> & Pick<DesignSystemSummary, 'id' | 'title'>,
+): DesignSystemSummary {
+  return {
+    id: overrides.id,
+    title: overrides.title,
+    category: overrides.category ?? 'Uncategorized',
+    summary: overrides.summary ?? `${overrides.title} summary`,
+    surface: overrides.surface ?? 'web',
+  };
+}
+
+// Two style categories, each spanning more than one surface, so a style
+// filter genuinely narrows every surface count. None set `source`/`isEditable`,
+// so they populate the built-in library section the surface chips belong to.
+//   Retro:  web x2, image x1   Social: web x1, image x1
+const librarySystems: DesignSystemSummary[] = [
+  ds({ id: 'retro-web-1', title: 'Retro Web One', category: 'Retro', surface: 'web' }),
+  ds({ id: 'retro-web-2', title: 'Retro Web Two', category: 'Retro', surface: 'web' }),
+  ds({ id: 'retro-img-1', title: 'Retro Image One', category: 'Retro', surface: 'image' }),
+  ds({ id: 'social-web-1', title: 'Social Web One', category: 'Social', surface: 'web' }),
+  ds({ id: 'social-img-1', title: 'Social Image One', category: 'Social', surface: 'image' }),
+];
+
+function renderTab(items: DesignSystemSummary[] = librarySystems) {
+  return render(
+    <DesignSystemsTab
+      systems={items}
+      selectedId={null}
+      onSelect={vi.fn()}
+      onPreview={vi.fn()}
+    />,
+  );
+}
+
+// The surface pill renders its label and a `.filter-pill-count` span; read
+// the count back by the visible label so assertions describe the UI.
+function surfacePillCount(label: string): string | null {
+  for (const pill of screen.getAllByRole('tab')) {
+    const countEl = pill.querySelector('.filter-pill-count');
+    const labelText = (pill.textContent ?? '').replace(countEl?.textContent ?? '', '');
+    if (labelText === label) return countEl?.textContent ?? null;
+  }
+  return null;
+}
+
+function selectCategory(value: string) {
+  fireEvent.change(screen.getByTestId('design-systems-category-select'), {
+    target: { value },
+  });
+}
+
+describe('DesignSystemsTab surface filtering', () => {
+  it('scopes surface pill counts to the selected style category', () => {
+    // Regression: nexu-io/open-design#2062 — surface chips kept showing the
+    // unfiltered totals after a style category was applied. The counts must
+    // describe the filtered result set, otherwise "All 149 / Web 149" is a
+    // lie about what the user is looking at.
+    renderTab();
+
+    expect(surfacePillCount('All')).toBe('5');
+    expect(surfacePillCount('Web')).toBe('3');
+    expect(surfacePillCount('Image')).toBe('2');
+
+    selectCategory('Retro');
+
+    expect(surfacePillCount('All')).toBe('3');
+    expect(surfacePillCount('Web')).toBe('2');
+    expect(surfacePillCount('Image')).toBe('1');
+  });
+
+  it('keeps the style category when a surface chip refines within it', () => {
+    // Regression: nexu-io/open-design#2062 — clicking a surface chip reset
+    // the style category to "All", discarding the user's filter instead of
+    // refining inside it. The category survives when it still has matches
+    // for the chosen surface.
+    renderTab();
+    selectCategory('Retro');
+
+    fireEvent.click(screen.getByRole('tab', { name: /^Web/ }));
+
+    expect(
+      (screen.getByTestId('design-systems-category-select') as HTMLSelectElement).value,
+    ).toBe('Retro');
+    expect(screen.getByText('Retro Web One')).toBeTruthy();
+    expect(screen.getByText('Retro Web Two')).toBeTruthy();
+    // A web system from a different category must not leak back in.
+    expect(screen.queryByText('Social Web One')).toBeNull();
+  });
+
+  it('hides a surface chip that has no systems in the selected style category', () => {
+    // Consequence of the #2062 fix: a chip whose count drops to zero for the
+    // active style category falls away, the same way a globally-empty
+    // surface already does — so a chip never advertises an empty result set.
+    const webOnlyCategory: DesignSystemSummary[] = [
+      ds({ id: 'tools-web-1', title: 'Tools Web One', category: 'Tools', surface: 'web' }),
+      ds({ id: 'retro-web-1', title: 'Retro Web One', category: 'Retro', surface: 'web' }),
+      ds({ id: 'retro-img-1', title: 'Retro Image One', category: 'Retro', surface: 'image' }),
+    ];
+    renderTab(webOnlyCategory);
+    expect(screen.queryByRole('tab', { name: /^Image/ })).not.toBeNull();
+
+    selectCategory('Tools');
+
+    // Tools has only web systems, so the Image chip no longer applies.
+    expect(screen.queryByRole('tab', { name: /^Image/ })).toBeNull();
+    expect(surfacePillCount('Web')).toBe('1');
+  });
+
+  it('keeps the active surface chip visible when a search filters out all of its results', () => {
+    // PR #2141 review (Looper): the scoped-count hide rule must never remove
+    // the chip the user is currently on. Select Image, then search for text
+    // only web systems match — the Image chip must stay, and stay selected,
+    // so the active filter is visible instead of an empty grid with no chip.
+    renderTab();
+    fireEvent.click(screen.getByRole('tab', { name: /^Image/ }));
+
+    fireEvent.change(screen.getByTestId('design-systems-search'), {
+      target: { value: 'Web' },
+    });
+
+    const imageTab = screen.queryByRole('tab', { name: /^Image/ });
+    expect(imageTab).not.toBeNull();
+    expect(imageTab?.getAttribute('aria-selected')).toBe('true');
+    // ...and it honestly reports zero matches for the current search.
+    expect(surfacePillCount('Image')).toBe('0');
   });
 });


### PR DESCRIPTION
Fixes #2062

## Why

I hit this while browsing the **Design systems** page on the 0.8.0 line: I
picked a style category to narrow the list, and the surface chips kept
advertising `All 150 / Web 150` even though the grid had clearly shrunk to a
handful of cards — the counts were lying about what I was looking at. Then,
trying to refine further by clicking a surface chip, the style category I'd
selected was silently thrown away.

The pain is a trust/usability bug on a primary browse surface: the two filter
controls contradict each other (the chip counts say one thing, the grid shows
another), and clicking one control destroys the other's state instead of
composing with it. Issue #2062 reports it with a clear repro.

## What users will see

On the **Design systems** page:

- After picking a style category from the dropdown, the surface chips
  (`All` / `Web` / `Image` / …) now show the count **for that category**
  instead of the whole-catalog total. A surface with no items in the selected
  category drops out of the chip row.
- Clicking a surface chip now **refines within** the selected style category
  instead of resetting the category dropdown back to "All".

## Surface area

- [x] **UI** — Design systems page filter behavior in `apps/web`
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

Two namespaced runtimes — current `main` (buggy) vs this branch (fixed) — on
the Design systems page, same `Themed & Unique` style category.

**Before — `main`, bug present**

Step A · no filter — chips read `All 150 / Web 150`.

<img width="900" alt="main, no filter — chips All 150 / Web 150" src="https://github.com/user-attachments/assets/3b136d5d-9108-4418-97cd-f21d47bd7b6b" />

Step B · style category `Themed & Unique` selected — the grid shrinks to 8
cards, but the chips still read `All 150 / Web 150` (stale, wrong).

<img width="900" alt="main, category selected — grid shrank to 8 but chips still say All 150 / Web 150" src="https://github.com/user-attachments/assets/d6cbe77a-867a-4411-b566-b3dc92a602c5" />

Step C · `Web` chip clicked — the category dropdown snaps back to `All`; the
style filter is lost.

<img width="900" alt="main, Web chip clicked — category dropdown reset to All" src="https://github.com/user-attachments/assets/b176f851-65f3-4380-806b-e951d13bdeeb" />

**After — this branch, fixed**

Step A · no filter — chips read `All 150 / Web 150` (same baseline).

<img width="900" alt="branch, no filter — chips All 150 / Web 150" src="https://github.com/user-attachments/assets/0a261808-5e49-44ec-bc27-bd4ade6e80d4" />

Step B · style category `Themed & Unique` selected — chips update to
`All 8 / Web 8`, matching the filtered grid.

<img width="900" alt="branch, category selected — chips update to All 8 / Web 8" src="https://github.com/user-attachments/assets/b08adf0b-dd48-440d-a27b-e4b832cfbc9d" />

Step C · `Web` chip clicked — the category dropdown stays on
`Themed & Unique`; the chip refined within the filter.

<img width="900" alt="branch, Web chip clicked — category dropdown stays on Themed & Unique" src="https://github.com/user-attachments/assets/ed9b12d8-8a7d-4c4b-8cf7-8e7b32cdefac" />

## Bug fix verification

- Test path that reproduces the bug:
  `apps/web/tests/components/DesignSystemsTab.test.tsx`
- Did the test go red on `main` and green on this branch? **Yes** — confirmed
  by stashing the source fix and re-running: the 3 original tests fail on
  `main` (`'5'` vs `'3'` counts, `'All'` vs `'Retro'` category), all pass on
  the branch.
- The 4 tests: (1) surface chip counts scoped to the selected style category;
  (2) style category preserved when a chip refines within it; (3) a surface
  chip with no items in the selected category is hidden; (4) the active
  surface chip stays visible when a search filters out all of its results
  (review follow-up — red before commit `48139fdf`, green after).

Implementation note: the `useEffect` that recovers from a now-empty surface
keeps reading an unscoped `surfaceTotals` count, deliberately separate from
the new category/search-scoped `surfaceCounts` — so that "this surface is
empty" guard still reacts to the catalog itself, not to a transient filter.
Relatedly, the chip row always renders `all` and the currently-selected
surface chip so a transient search can never hide the active filter.

## Validation

- `pnpm --filter @open-design/web test` — 1596 passed (170 files), including
  the 4 new tests
- `pnpm --filter @open-design/web typecheck` — clean
- `pnpm guard` — pass
- Manual A/B verification on two namespaced runtimes (this branch vs
  `origin/main`), driven through Playwright — counts and dropdown state
  confirmed against the accessibility tree, not eyeballed. See Screenshots.
