### PR TITLE
Fix native pnpm executable invocation

### DIFF
--- a/packages/platform/tests/index.test.ts
+++ b/packages/platform/tests/index.test.ts
@@ -655,6 +655,17 @@ describe("createPackageManagerInvocation", () => {
     expect(invocation.windowsVerbatimArguments).toBeUndefined();
   });
 
+  it("executes native npm_execpath directly instead of loading it through Node", () => {
+    setPlatform("linux");
+    const invocation = createPackageManagerInvocation(["--filter", "@open-design/desktop", "build"], {
+      npm_execpath: "/home/u/.local/share/pnpm/.tools/@pnpm+linux-x64/10.33.2/node_modules/@pnpm/linux-x64/pnpm",
+    } as NodeJS.ProcessEnv);
+    expect(invocation).toEqual({
+      args: ["--filter", "@open-design/desktop", "build"],
+      command: "/home/u/.local/share/pnpm/.tools/@pnpm+linux-x64/10.33.2/node_modules/@pnpm/linux-x64/pnpm",
+    });
+  });
+
   it("uses binary npm_execpath directly on POSIX", () => {
     setPlatform("linux");
     const invocation = createPackageManagerInvocation(["install"], {


### PR DESCRIPTION
## Why

While reproducing local setup with Node 24, `pnpm tools-dev` failed during the desktop build even though `pnpm --filter @open-design/desktop build` succeeded directly. The launcher wrapped `npm_execpath` with `process.execPath`, but pnpm 10 can expose a platform-native `@pnpm/linux-x64/pnpm` executable there. Node then tried to parse the ELF binary as JavaScript and crashed with `SyntaxError: Invalid or unexpected token`.

This blocks contributors whose Corepack/pnpm setup resolves `npm_execpath` to a native pnpm binary.

## What users will see

`pnpm tools-dev` starts normally under Node 24 / pnpm 10 when `npm_execpath` points at a native pnpm executable. The daemon, web, and desktop processes come up instead of failing during the desktop build step.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — no UI surface changed.

## Bug fix verification

- Test path that reproduces the bug: `packages/platform/tests/index.test.ts`
- Did the test go red on `main` and green on this branch? yes. The native `npm_execpath` regression test failed before the implementation change and passed after the fix.
- Additional manual verification: `pnpm tools-dev` now starts daemon, web, and desktop successfully.

## Validation

- `pnpm --filter @open-design/platform test`
- `pnpm --filter @open-design/platform typecheck`
- `pnpm --filter @open-design/platform build`
- `pnpm guard`
- `pnpm typecheck`
- `pnpm tools-dev`
