### PR TITLE
fix(web): scope daemon transcript to active agent

### DIFF
--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -117,11 +117,23 @@ function buildPriorRunContextWarning(history: ChatMessage[]): string | null {
   ].join('\n');
 }
 
-export function buildDaemonTranscript(history: ChatMessage[]): string {
-  const transcript = history
+function scopeHistoryToAgent(history: ChatMessage[], targetAgentId?: string): ChatMessage[] {
+  if (!targetAgentId) return history;
+  for (let i = history.length - 1; i >= 0; i -= 1) {
+    const message = history[i];
+    if (message?.role === 'assistant' && message.agentId && message.agentId !== targetAgentId) {
+      return history.slice(i + 1);
+    }
+  }
+  return history;
+}
+
+export function buildDaemonTranscript(history: ChatMessage[], targetAgentId?: string): string {
+  const scopedHistory = scopeHistoryToAgent(history, targetAgentId);
+  const transcript = scopedHistory
     .map((m) => `## ${m.role}\n${truncateForTranscript(m.content.trim())}`)
     .join('\n\n');
-  const warning = buildPriorRunContextWarning(history);
+  const warning = buildPriorRunContextWarning(scopedHistory);
   return warning ? `${warning}\n\n${transcript}` : transcript;
 }
 
@@ -218,7 +230,7 @@ export async function streamViaDaemon({
   // Local CLIs are single-turn print-mode programs, so we collapse the whole
   // chat into one string. If this becomes too noisy for long histories, the
   // fix is to only include the final user turn.
-  const transcript = buildDaemonTranscript(history);
+  const transcript = buildDaemonTranscript(history, agentId);
   const request: ChatRequest = {
     agentId,
     message: transcript,

--- a/apps/web/tests/providers/sse.test.ts
+++ b/apps/web/tests/providers/sse.test.ts
@@ -67,6 +67,62 @@ describe('streamViaDaemon', () => {
     expect(body.currentPrompt).toBe('post-consent revision');
   });
 
+  it('drops prior assistant turns from another agent when composing daemon transcript', async () => {
+    const handlers = createDaemonHandlers();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/runs') return jsonResponse({ runId: 'run-1' });
+      if (url === '/api/runs/run-1/events') {
+        return sseResponse('event: end\ndata: {"code":0,"status":"succeeded"}\n\n');
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await streamViaDaemon({
+      agentId: 'gemini',
+      history: [
+        { id: '1', role: 'user', content: 'build a canvas editor' },
+        {
+          id: '2',
+          role: 'assistant',
+          content: 'claude transcript with a large tool trace',
+          agentId: 'claude',
+        },
+        { id: '3', role: 'user', content: 'now continue with gemini' },
+      ],
+      systemPrompt: '',
+      signal: new AbortController().signal,
+      handlers,
+    });
+
+    const [, createRunInit] = fetchMock.mock.calls[0] as unknown as [RequestInfo | URL, RequestInit];
+    const body = JSON.parse(String(createRunInit.body));
+    expect(body.message).not.toContain('build a canvas editor');
+    expect(body.message).not.toContain('claude transcript with a large tool trace');
+    expect(body.message).toContain('now continue with gemini');
+    expect(body.currentPrompt).toBe('now continue with gemini');
+  });
+
+  it('keeps same-agent context after the most recent different-agent boundary', () => {
+    const transcript = buildDaemonTranscript(
+      [
+        { id: '1', role: 'user', content: 'first claude request' },
+        { id: '2', role: 'assistant', content: 'claude response', agentId: 'claude' },
+        { id: '3', role: 'user', content: 'first gemini request' },
+        { id: '4', role: 'assistant', content: 'gemini response', agentId: 'gemini' },
+        { id: '5', role: 'user', content: 'second gemini request' },
+      ],
+      'gemini',
+    );
+
+    expect(transcript).not.toContain('first claude request');
+    expect(transcript).not.toContain('claude response');
+    expect(transcript).toContain('first gemini request');
+    expect(transcript).toContain('gemini response');
+    expect(transcript).toContain('second gemini request');
+  });
+
   it('extracts only the latest user prompt for telemetry', () => {
     expect(
       latestUserPromptFromHistory([


### PR DESCRIPTION
Fixes #1311

## Why

I am fixing the confirmed Gemini hang from issue #1311: when a user switches an existing daemon conversation from Claude/Anthropic to Gemini, the web client currently sends Gemini the entire accumulated Claude transcript. That can include large prior tool traces and causes Gemini CLI runs to stall behind the daemon inactivity watchdog.

The pain addressed is a user-facing conversation recovery bug: Gemini works in a fresh chat but can hang in an existing chat after the user changes local agents.

## What users will see

When users switch local agents mid-conversation, the next daemon run is scoped to the selected agent. Prior assistant output from a different local agent is no longer replayed into the new agent's prompt; same-agent context after the switch is still preserved.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No UI surface changed.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/providers/sse.test.ts`
- Did the test go red on `main` and green on this branch? Yes. The new regression failed before the source change with `expected ... not to contain 'build a canvas editor'`, then passed after the transcript scoping fix.

## Validation

- `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/providers/sse.test.ts` — 32/32 passing
- `pnpm --filter @open-design/web typecheck` — passing
- `pnpm guard` — passing
- `git diff --check` — passing

Note: this local machine is running Node `v26.0.0`, so pnpm printed the repo's expected engine warning (`node ~24`) during package-scoped commands. The listed commands still exited successfully after dependency install.
