### PR TITLE
fix(daemon): preserve Windows chat attachments

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -852,6 +852,32 @@ function isPathWithin(base, target) {
   );
 }
 
+export function resolveSafeProjectAttachments(cwd, attachments, opts = {}) {
+  if (!cwd || !Array.isArray(attachments)) return [];
+  const pathImpl = opts.pathImpl ?? path;
+  const existsSync = opts.existsSync ?? fs.existsSync;
+  const root = pathImpl.resolve(cwd);
+  const out = [];
+
+  for (const attachment of attachments) {
+    if (typeof attachment !== 'string' || attachment.length === 0) continue;
+    try {
+      const abs = pathImpl.resolve(root, attachment);
+      const relativePath = pathImpl.relative(root, abs);
+      const withinRoot =
+        relativePath === '' ||
+        (relativePath.length > 0 &&
+          !relativePath.startsWith('..') &&
+          !pathImpl.isAbsolute(relativePath));
+      if (withinRoot && existsSync(abs)) out.push(attachment);
+    } catch {
+      // Drop malformed paths; attachments are advisory prompt context.
+    }
+  }
+
+  return out;
+}
+
 function resolveProcessResourcesPath() {
   if (
     typeof process.resourcesPath === 'string' &&
@@ -8103,19 +8129,7 @@ export async function startServer({
     // explicit list at the bottom of the user message so the agent knows
     // to Read it.
     const safeAttachments = cwd
-      ? (Array.isArray(attachments) ? attachments : [])
-          .filter((p) => typeof p === 'string' && p.length > 0)
-          .filter((p) => {
-            try {
-              const abs = path.resolve(cwd, p);
-              return (
-                (abs === cwd || abs.startsWith(cwd + path.sep)) &&
-                fs.existsSync(abs)
-              );
-            } catch {
-              return false;
-            }
-          })
+      ? resolveSafeProjectAttachments(cwd, attachments)
       : [];
 
     // Local code agents don't accept a separate "system" channel the way the

--- a/apps/daemon/tests/chat-attachments.test.ts
+++ b/apps/daemon/tests/chat-attachments.test.ts
@@ -1,0 +1,31 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { resolveSafeProjectAttachments } from '../src/server.js';
+
+describe('resolveSafeProjectAttachments', () => {
+  it('keeps Windows attachments when root and attachment path use different separators and drive casing', () => {
+    const existing = new Set([
+      'C:\\Users\\Designer\\Open Design\\m5-logo.png',
+      'c:\\users\\designer\\open design\\assets\\mark.png',
+    ]);
+
+    const safe = resolveSafeProjectAttachments(
+      'C:/Users/Designer/Open Design/',
+      [
+        'm5-logo.png',
+        'c:/users/designer/open design/assets/mark.png',
+        'C:/Users/Designer/Open Design Adjacent/secret.png',
+        '..\\secret.png',
+      ],
+      {
+        existsSync: (target: string) => existing.has(target),
+        pathImpl: path.win32,
+      },
+    );
+
+    expect(safe).toEqual([
+      'm5-logo.png',
+      'c:/users/designer/open design/assets/mark.png',
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes #1741

## Why

I am opening this PR to fix the Windows Local CLI attachment path bug reported in #1741. The user can upload a PNG successfully and see the composer chip, but the daemon drops the attachment before composing the local agent prompt.

The pain being addressed is user-facing: attached project files appear accepted in the UI but are invisible to the agent on Windows because the daemon's path guard relies on raw string-prefix matching.

## What users will see

On Windows, attached chat files that upload successfully remain listed in the local CLI agent prompt as attached project files, so the agent can read the PNG or other project asset the user just staged.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No UI surface changed.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/chat-attachments.test.ts`
- Did the test go red on `main` and green on this branch? yes. The new spec first failed with `resolveSafeProjectAttachments is not a function`, then passed after wiring the normalized attachment guard.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/chat-attachments.test.ts` from `apps/daemon` — passed, 1 test
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/chat-attachments.test.ts tests/chat-route.test.ts` — passed, 26 tests
- `pnpm --filter @open-design/daemon typecheck` — passed
- `pnpm guard` — passed
- `git diff --check` — passed

Note: this machine is running Node `v26.0.0` while the repo declares Node `~24`, so pnpm printed engine warnings during validation.