### PR TITLE
Fix mac tools-pack Node fallback

### DIFF
--- a/tools/pack/src/mac/app.ts
+++ b/tools/pack/src/mac/app.ts
@@ -1,5 +1,7 @@
-import { chmod, cp, mkdir, readdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join, relative } from "node:path";
+
+import { rebuild, type RebuildOptions } from "@electron/rebuild";
 
 import type { ToolPackConfig } from "../config.js";
 import {
@@ -17,7 +19,12 @@ import {
 } from "../mac-prebundle.js";
 import { copyBundledResourceTrees } from "../resources.js";
 import { runEsbuild, runNpmInstall, runPnpm } from "./commands.js";
-import { INTERNAL_PACKAGES } from "./constants.js";
+import {
+  ELECTRON_BUILDER_BUILD_DEPENDENCIES_FROM_SOURCE,
+  ELECTRON_REBUILD_MODE,
+  ELECTRON_REBUILD_NATIVE_MODULES,
+  INTERNAL_PACKAGES,
+} from "./constants.js";
 import { resolveMacInstallIdentity } from "./identity.js";
 import { readPackagedVersion } from "./manifest.js";
 import type { MacPaths, PackedTarballInfo } from "./types.js";
@@ -129,9 +136,82 @@ export async function copyResourceTree(config: ToolPackConfig, paths: MacPaths):
     workspaceRoot: config.workspaceRoot,
     resourceRoot: paths.resourceRoot,
   });
-  await mkdir(join(paths.resourceRoot, "bin"), { recursive: true });
-  await cp(process.execPath, join(paths.resourceRoot, "bin", "node"));
-  await chmod(join(paths.resourceRoot, "bin", "node"), 0o755);
+}
+
+export function renderMacPackagedConfig(options: {
+  appVersion: string;
+  config: ToolPackConfig;
+  usePrebundledStandaloneWeb: boolean;
+}): string {
+  return `${JSON.stringify(
+    {
+      appVersion: options.appVersion,
+      ...(options.usePrebundledStandaloneWeb ? { daemonCliEntryRelative: MAC_PREBUNDLED_DAEMON_CLI_RELATIVE_PATH } : {}),
+      ...(options.usePrebundledStandaloneWeb
+        ? { daemonSidecarEntryRelative: MAC_PREBUNDLED_DAEMON_SIDECAR_RELATIVE_PATH }
+        : {}),
+      namespace: options.config.namespace,
+      ...(options.config.telemetryRelayUrl == null ? {} : { telemetryRelayUrl: options.config.telemetryRelayUrl }),
+      ...(options.config.posthogKey == null ? {} : { posthogKey: options.config.posthogKey }),
+      ...(options.config.posthogHost == null ? {} : { posthogHost: options.config.posthogHost }),
+      ...(options.usePrebundledStandaloneWeb ? { webSidecarEntryRelative: MAC_PREBUNDLED_WEB_SIDECAR_RELATIVE_PATH } : {}),
+      webOutputMode: options.config.webOutputMode,
+      ...(options.config.portable ? {} : { namespaceBaseRoot: options.config.roots.runtime.namespaceBaseRoot }),
+    },
+    null,
+    2,
+  )}\n`;
+}
+
+export function createMacElectronRebuildOptions(
+  config: ToolPackConfig,
+  appRoot: string,
+): RebuildOptions {
+  return {
+    arch: process.arch,
+    buildFromSource: ELECTRON_BUILDER_BUILD_DEPENDENCIES_FROM_SOURCE,
+    buildPath: appRoot,
+    electronVersion: config.electronVersion,
+    force: true,
+    mode: ELECTRON_REBUILD_MODE,
+    onlyModules: [...ELECTRON_REBUILD_NATIVE_MODULES],
+    platform: "darwin",
+    projectRootPath: appRoot,
+  };
+}
+
+function nativeRebuildOutputPath(appRoot: string): string {
+  return join(appRoot, "node_modules", "better-sqlite3", "build", "Release", "better_sqlite3.node");
+}
+
+export async function validateMacNativeRebuildOutput(appRoot: string): Promise<string | null> {
+  const nativePath = nativeRebuildOutputPath(appRoot);
+  try {
+    const metadata = await stat(nativePath);
+    if (metadata.size < 100_000) return `native module output is too small: ${nativePath}`;
+    return null;
+  } catch {
+    return `native module output is missing: ${nativePath}`;
+  }
+}
+
+export async function runMacElectronRebuild(
+  config: ToolPackConfig,
+  appRoot: string,
+): Promise<void> {
+  const foundModules = new Set<string>();
+  const rebuildResult = rebuild(createMacElectronRebuildOptions(config, appRoot));
+  rebuildResult.lifecycle.on("modules-found", (modules: string[]) => {
+    for (const moduleName of modules) foundModules.add(moduleName);
+    process.stderr.write(`[tools-pack mac] rebuilding Electron ABI modules: ${modules.join(", ") || "none"}\n`);
+  });
+  await rebuildResult;
+  const missingModules = ELECTRON_REBUILD_NATIVE_MODULES.filter((moduleName) => !foundModules.has(moduleName));
+  if (missingModules.length > 0) {
+    throw new Error(`Electron ABI rebuild did not discover required native module(s): ${missingModules.join(", ")}`);
+  }
+  const nativeValidationError = await validateMacNativeRebuildOutput(appRoot);
+  if (nativeValidationError != null) throw new Error(nativeValidationError);
 }
 
 export async function collectWorkspaceTarballs(
@@ -228,24 +308,13 @@ export async function writeAssembledApp(
   );
   await writeFile(
     paths.packagedConfigPath,
-    `${JSON.stringify(
-      {
-        appVersion: packagedVersion,
-        ...(usePrebundledStandaloneWeb ? { daemonCliEntryRelative: MAC_PREBUNDLED_DAEMON_CLI_RELATIVE_PATH } : {}),
-        ...(usePrebundledStandaloneWeb ? { daemonSidecarEntryRelative: MAC_PREBUNDLED_DAEMON_SIDECAR_RELATIVE_PATH } : {}),
-        namespace: config.namespace,
-        nodeCommandRelative: "open-design/bin/node",
-        ...(config.telemetryRelayUrl == null ? {} : { telemetryRelayUrl: config.telemetryRelayUrl }),
-        ...(config.posthogKey == null ? {} : { posthogKey: config.posthogKey }),
-        ...(config.posthogHost == null ? {} : { posthogHost: config.posthogHost }),
-        ...(usePrebundledStandaloneWeb ? { webSidecarEntryRelative: MAC_PREBUNDLED_WEB_SIDECAR_RELATIVE_PATH } : {}),
-        webOutputMode: config.webOutputMode,
-        ...(config.portable ? {} : { namespaceBaseRoot: config.roots.runtime.namespaceBaseRoot }),
-      },
-      null,
-      2,
-    )}\n`,
+    renderMacPackagedConfig({
+      appVersion: packagedVersion,
+      config,
+      usePrebundledStandaloneWeb,
+    }),
     "utf8",
   );
   await runNpmInstall(paths.assembledAppRoot);
+  await runMacElectronRebuild(config, paths.assembledAppRoot);
 }

--- a/tools/pack/src/mac/app.ts
+++ b/tools/pack/src/mac/app.ts
@@ -184,14 +184,20 @@ function nativeRebuildOutputPath(appRoot: string): string {
   return join(appRoot, "node_modules", "better-sqlite3", "build", "Release", "better_sqlite3.node");
 }
 
+function formatMacNativeRebuildOutputStatError(nativePath: string, error: unknown): string {
+  if ((error as NodeJS.ErrnoException).code === "ENOENT") return `native module output is missing: ${nativePath}`;
+  const detail = error instanceof Error ? error.message : String(error);
+  return `native module output could not be inspected: ${nativePath}: ${detail}`;
+}
+
 export async function validateMacNativeRebuildOutput(appRoot: string): Promise<string | null> {
   const nativePath = nativeRebuildOutputPath(appRoot);
   try {
     const metadata = await stat(nativePath);
     if (metadata.size < 100_000) return `native module output is too small: ${nativePath}`;
     return null;
-  } catch {
-    return `native module output is missing: ${nativePath}`;
+  } catch (error) {
+    return formatMacNativeRebuildOutputStatError(nativePath, error);
   }
 }
 

--- a/tools/pack/src/mac/constants.ts
+++ b/tools/pack/src/mac/constants.ts
@@ -18,6 +18,9 @@ export const DESKTOP_LOG_ECHO_ENV = "OD_DESKTOP_LOG_ECHO";
 export const WEB_STANDALONE_HOOK_CONFIG_ENV = "OD_TOOLS_PACK_WEB_STANDALONE_HOOK_CONFIG";
 export const WEB_STANDALONE_RESOURCE_NAME = "open-design-web-standalone";
 export const ELECTRON_BUILDER_ASAR = false;
+export const ELECTRON_BUILDER_BUILD_DEPENDENCIES_FROM_SOURCE = false;
+export const ELECTRON_REBUILD_MODE = "sequential" as const;
+export const ELECTRON_REBUILD_NATIVE_MODULES = ["better-sqlite3"] as const;
 export const ELECTRON_BUILDER_FILE_PATTERNS = [
   "**/*",
   "!**/node_modules/.bin",

--- a/tools/pack/src/mac/report.ts
+++ b/tools/pack/src/mac/report.ts
@@ -4,7 +4,10 @@ import type { ToolPackConfig } from "../config.js";
 import { MAC_PREBUNDLED_APP_DIR_NAME } from "../mac-prebundle.js";
 import {
   ELECTRON_BUILDER_ASAR,
+  ELECTRON_BUILDER_BUILD_DEPENDENCIES_FROM_SOURCE,
   ELECTRON_BUILDER_FILE_PATTERNS,
+  ELECTRON_REBUILD_MODE,
+  ELECTRON_REBUILD_NATIVE_MODULES,
   MAC_ELECTRON_LANGUAGES,
   WEB_STANDALONE_RESOURCE_NAME,
 } from "./constants.js";
@@ -47,6 +50,11 @@ export async function collectMacSizeReport(
       compression: config.macCompression,
       electronLanguages: MAC_ELECTRON_LANGUAGES,
       filePatterns: ELECTRON_BUILDER_FILE_PATTERNS,
+      nativeRebuild: {
+        buildFromSource: ELECTRON_BUILDER_BUILD_DEPENDENCIES_FROM_SOURCE,
+        mode: ELECTRON_REBUILD_MODE,
+        modules: ELECTRON_REBUILD_NATIVE_MODULES,
+      },
       targets,
       webOutputMode: config.webOutputMode,
     },

--- a/tools/pack/src/mac/types.ts
+++ b/tools/pack/src/mac/types.ts
@@ -146,6 +146,11 @@ export type MacSizeReport = {
     compression: ToolPackConfig["macCompression"];
     electronLanguages: readonly string[];
     filePatterns: readonly string[];
+    nativeRebuild: {
+      buildFromSource: boolean;
+      mode: "parallel" | "sequential";
+      modules: readonly string[];
+    };
     targets: ElectronBuilderTarget[];
     webOutputMode: ToolPackConfig["webOutputMode"];
   };

--- a/tools/pack/tests/mac.test.ts
+++ b/tools/pack/tests/mac.test.ts
@@ -9,6 +9,7 @@ import {
   copyResourceTree,
   createMacElectronRebuildOptions,
   renderMacPackagedConfig,
+  validateMacNativeRebuildOutput,
 } from "../src/mac/app.js";
 import { resolveSeededAppConfigPaths, seedPackagedAppConfig, writeLaunchPackagedConfig } from "../src/mac/index.js";
 import { resolveMacPaths } from "../src/mac/paths.js";
@@ -217,6 +218,35 @@ describe("createMacElectronRebuildOptions", () => {
         platform: "darwin",
         projectRootPath: appRoot,
       });
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});
+
+describe("validateMacNativeRebuildOutput", () => {
+  it("reports a missing rebuilt native module as missing output", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-tools-pack-mac-"));
+    try {
+      await expect(validateMacNativeRebuildOutput(root)).resolves.toBe(
+        `native module output is missing: ${join(root, "node_modules", "better-sqlite3", "build", "Release", "better_sqlite3.node")}`,
+      );
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("preserves non-ENOENT filesystem diagnostics from stat failures", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-tools-pack-mac-"));
+    try {
+      const buildPath = join(root, "node_modules", "better-sqlite3", "build");
+      const nativePath = join(buildPath, "Release", "better_sqlite3.node");
+      await mkdir(dirname(buildPath), { recursive: true });
+      await writeFile(buildPath, "not a directory", "utf8");
+
+      await expect(validateMacNativeRebuildOutput(root)).resolves.toContain(
+        `native module output could not be inspected: ${nativePath}: ENOTDIR: not a directory, stat '${nativePath}'`,
+      );
     } finally {
       await rm(root, { force: true, recursive: true });
     }

--- a/tools/pack/tests/mac.test.ts
+++ b/tools/pack/tests/mac.test.ts
@@ -1,11 +1,26 @@
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { access, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import os, { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
 import type { ToolPackConfig } from "../src/config.js";
+import {
+  copyResourceTree,
+  createMacElectronRebuildOptions,
+  renderMacPackagedConfig,
+} from "../src/mac/app.js";
 import { resolveSeededAppConfigPaths, seedPackagedAppConfig, writeLaunchPackagedConfig } from "../src/mac/index.js";
+import { resolveMacPaths } from "../src/mac/paths.js";
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 function makeConfig(root: string, overrides: Partial<ToolPackConfig> = {}): ToolPackConfig {
   return {
@@ -127,6 +142,81 @@ describe("seedPackagedAppConfig", () => {
       await expect(
         readFile(join(config.roots.runtime.namespaceRoot, "data", "app-config.json"), "utf8"),
       ).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});
+
+describe("copyResourceTree", () => {
+  it("does not embed the build machine Node launcher into mac resources", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-tools-pack-mac-"));
+    try {
+      const config = makeConfig(root);
+      const paths = resolveMacPaths(config);
+      const resourceNames = [
+        "skills",
+        "design-templates",
+        "design-systems",
+        "craft",
+        "plugins/_official",
+        "plugins/registry",
+        "assets/frames",
+        "assets/community-pets",
+        "prompt-templates",
+      ];
+
+      for (const name of resourceNames) {
+        await mkdir(join(root, name), { recursive: true });
+      }
+
+      await copyResourceTree(config, paths);
+
+      expect(await pathExists(join(paths.resourceRoot, "bin", "node"))).toBe(false);
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});
+
+describe("renderMacPackagedConfig", () => {
+  it("omits nodeCommandRelative so packaged mac sidecars use Electron as Node", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-tools-pack-mac-"));
+    try {
+      const config = makeConfig(root);
+
+      const packagedConfig = JSON.parse(
+        renderMacPackagedConfig({
+          appVersion: "1.2.3",
+          config,
+          usePrebundledStandaloneWeb: true,
+        }),
+      ) as Record<string, unknown>;
+      expect(packagedConfig).not.toHaveProperty("nodeCommandRelative");
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});
+
+describe("createMacElectronRebuildOptions", () => {
+  it("targets the packaged Electron ABI for required native modules", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-tools-pack-mac-"));
+    try {
+      const config = makeConfig(root, { electronVersion: "41.3.0" });
+      const appRoot = join(root, "assembled", "app");
+
+      expect(createMacElectronRebuildOptions(config, appRoot)).toMatchObject({
+        arch: process.arch,
+        buildFromSource: false,
+        buildPath: appRoot,
+        electronVersion: "41.3.0",
+        force: true,
+        mode: "sequential",
+        onlyModules: ["better-sqlite3"],
+        platform: "darwin",
+        projectRootPath: appRoot,
+      });
     } finally {
       await rm(root, { force: true, recursive: true });
     }


### PR DESCRIPTION
## Why

Closes #1275.

The mac tools-pack build copied `process.execPath` into `Contents/Resources/open-design/bin/node` and configured packaged sidecars to launch it. On Homebrew Node 21+ that file is only a small launcher, so packaged daemon startup can fail when `libnode.*.dylib` and related dylibs are not present in the app bundle.

## What changed

- Stop embedding the build-machine Node launcher in mac resources.
- Omit `nodeCommandRelative` from the mac packaged config so sidecars use the existing Electron-as-Node fallback.
- Rebuild `better-sqlite3` in the assembled mac app for the packaged Electron ABI, matching the Windows packaging pattern.
- Preserve non-`ENOENT` native rebuild inspection diagnostics instead of rewriting every filesystem failure as missing output.
- Add mac packaging regressions for no bundled launcher, no node command override, Electron rebuild options, and native rebuild output diagnostics.

## What users will see

Users should not see a UI change. Mac packaged builds made from Homebrew Node 21+ should launch normally instead of aborting the daemon sidecar because the copied `bin/node` launcher cannot find `libnode.*.dylib`. If the native module rebuild output cannot be inspected for a non-missing-file reason, the packaged build now reports the original filesystem diagnostic instead of a generic missing-output message.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — mac packaged sidecars launch through Electron-as-Node instead of a bundled build-machine Node launcher; mac packaging rebuilds required native modules for the packaged Electron ABI
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Verification

- `pnpm --filter @open-design/tools-pack exec vitest run tests/mac.test.ts`
- `pnpm --filter @open-design/tools-pack test`
- `pnpm --filter @open-design/tools-pack typecheck`
- `pnpm --filter @open-design/tools-pack build`
- `pnpm --filter @open-design/packaged exec vitest run -c vitest.config.ts tests/sidecars.test.ts`
- `pnpm guard`
- `git diff --check`
- `pnpm tools-pack mac build --to app --namespace codex-node-fallback --portable`
- `test ! -e '.tmp/tools-pack/out/mac/namespaces/codex-node-fallback/builder/mac-arm64/Open Design.app/Contents/Resources/open-design/bin/node'`
- Verified packaged config has no `nodeCommandRelative`.
- `ELECTRON_RUN_AS_NODE=1 '.tmp/tools-pack/out/mac/namespaces/codex-node-fallback/builder/mac-arm64/Open Design.app/Contents/MacOS/Open Design' -p 'process.versions.node + " modules=" + process.versions.modules'` -> `24.15.0 modules=145`
- `pnpm tools-pack mac start --namespace codex-node-fallback` -> running, visible app window; daemon log has no `NODE_MODULE_VERSION` / `libnode` failure.
- Follow-up: `PATH=/Users/cyh/.nvm/versions/node/v24.15.0/bin:$PATH pnpm --filter @open-design/tools-pack exec vitest run tests/mac.test.ts`
- Follow-up: `PATH=/Users/cyh/.nvm/versions/node/v24.15.0/bin:$PATH pnpm --filter @open-design/tools-pack test`
- Follow-up: `PATH=/Users/cyh/.nvm/versions/node/v24.15.0/bin:$PATH pnpm --filter @open-design/tools-pack typecheck`
- Follow-up: `git diff --check`
