### PR TITLE
fix(packaged): honor OD_DATA_DIR in desktop runtime

### DIFF
--- a/apps/daemon/tests/folder-import-route.test.ts
+++ b/apps/daemon/tests/folder-import-route.test.ts
@@ -1,6 +1,6 @@
 import type http from 'node:http';
 import { mkdtempSync, rmSync, symlinkSync } from 'node:fs';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
@@ -228,6 +228,46 @@ describe('POST /api/import/folder', () => {
       project: { metadata: { baseDir?: string } };
     };
     expect(after.project.metadata.baseDir).toBe(originalBaseDir);
+  });
+
+  it('writes generated artifact files into metadata.baseDir instead of the daemon projects dir', async () => {
+    const real = makeFolder();
+    await writeFile(path.join(real, 'index.html'), '<!doctype html>');
+    const importResp = await importFolder({ baseDir: real });
+    expect(importResp.status).toBe(200);
+    const { project } = (await importResp.json()) as {
+      project: { id: string; metadata: { baseDir: string } };
+    };
+
+    const saveResp = await fetch(`${baseUrl}/api/projects/${project.id}/files`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        artifact: true,
+        artifactManifest: {
+          exports: ['html'],
+          kind: 'html',
+          renderer: 'html',
+          title: 'Generated',
+        },
+        content: '<!doctype html><h1>Generated</h1>',
+        name: 'generated.html',
+      }),
+    });
+
+    expect(saveResp.status).toBe(200);
+    expect(await readFile(path.join(project.metadata.baseDir, 'generated.html'), 'utf8')).toContain(
+      'Generated',
+    );
+    expect(
+      await readFile(path.join(project.metadata.baseDir, 'generated.html.artifact.json'), 'utf8'),
+    ).toContain('"entry": "generated.html"');
+
+    const dataDir = process.env.OD_DATA_DIR;
+    if (!dataDir) throw new Error('OD_DATA_DIR is required for daemon route tests');
+    await expect(stat(path.join(dataDir, 'projects', project.id, 'generated.html'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
   });
 
   it('refuses raw reads through a descendant symlink that escapes the folder', async () => {

--- a/apps/packaged/src/errors.ts
+++ b/apps/packaged/src/errors.ts
@@ -1,0 +1,9 @@
+export class PackagedPathAccessError extends Error {
+  readonly title: string;
+
+  constructor(message: string, options?: { cause?: unknown; title?: string }) {
+    super(message, options);
+    this.name = "PackagedPathAccessError";
+    this.title = options?.title ?? "Open Design cannot access its data folder";
+  }
+}

--- a/apps/packaged/src/index.ts
+++ b/apps/packaged/src/index.ts
@@ -73,7 +73,7 @@ async function main(): Promise<void> {
   const config = await readPackagedConfig();
   const argvStamp = readProcessStamp(process.argv.slice(1), OPEN_DESIGN_SIDECAR_CONTRACT);
   const namespace = argvStamp?.namespace ?? config.namespace;
-  const paths = resolvePackagedNamespacePaths(config, namespace);
+  const paths = resolvePackagedNamespacePaths(config, namespace, process.env);
   const stamp = argvStamp ?? createPackagedDesktopStamp(namespace);
 
   await ensurePackagedNamespacePaths(paths);

--- a/apps/packaged/src/index.ts
+++ b/apps/packaged/src/index.ts
@@ -17,8 +17,8 @@ import { app, dialog } from "electron";
 
 import { readPackagedConfig } from "./config.js";
 import { writePackagedDesktopIdentity } from "./identity.js";
+import { PackagedPathAccessError } from "./errors.js";
 import {
-  PackagedPathAccessError,
   applyPackagedElectronPathOverrides,
   claimPackagedSingleInstanceLock,
   ensurePackagedNamespacePaths,

--- a/apps/packaged/src/launch.ts
+++ b/apps/packaged/src/launch.ts
@@ -5,24 +5,14 @@ import { userInfo } from "node:os";
 
 import { app } from "electron";
 
+import { PackagedPathAccessError } from "./errors.js";
 import type { PackagedNamespacePaths } from "./paths.js";
-
-export class PackagedPathAccessError extends Error {
-  readonly title: string;
-
-  constructor(message: string, options?: { cause?: unknown; title?: string }) {
-    super(message, options);
-    this.name = "PackagedPathAccessError";
-    this.title = options?.title ?? "Open Design cannot access its data folder";
-  }
-}
 
 export type PackagedSingleInstanceApp = {
   on: (event: "second-instance", listener: () => void) => unknown;
   quit: () => void;
   requestSingleInstanceLock: () => boolean;
 };
-
 type PathDiagnostic = {
   exists: boolean;
   mode?: number;

--- a/apps/packaged/src/paths.ts
+++ b/apps/packaged/src/paths.ts
@@ -56,7 +56,10 @@ function resolvePackagedDataRoot(
   const odDataDir = env.OD_DATA_DIR?.trim();
   if (odDataDir) {
     const expanded = expandHomePrefix(odDataDir);
-    if (!isAbsolute(expanded) && !win32.isAbsolute(expanded)) {
+    const isAbs = process.platform === "win32"
+      ? win32.isAbsolute(expanded)
+      : isAbsolute(expanded);
+    if (!isAbs) {
       throw new PackagedPathAccessError(
         [
           "Open Design's packaged runtime requires OD_DATA_DIR to be an absolute path.",

--- a/apps/packaged/src/paths.ts
+++ b/apps/packaged/src/paths.ts
@@ -1,10 +1,9 @@
 import { homedir } from "node:os";
-import { isAbsolute, join, win32 } from "node:path";
+import { isAbsolute, join, resolve, win32 } from "node:path";
 
 import { APP_KEYS, normalizeNamespace } from "@open-design/sidecar-proto";
 
 import type { PackagedConfig } from "./config.js";
-import { PackagedPathAccessError } from "./errors.js";
 
 export type PackagedNamespacePaths = {
   cacheRoot: string;
@@ -42,14 +41,6 @@ function expandHomePrefix(raw: string): string {
   return raw;
 }
 
-function getScopedPackagedDataRootNamespace(raw: string): string | null {
-  const parts = raw.replace(/[\\/]+$/g, "").split(/[\\/]+/);
-  const last = parts.length - 1;
-  if (last < 2) return null;
-  if (parts[last - 2] !== "namespaces" || parts[last] !== "data") return null;
-  return parts[last - 1] ?? null;
-}
-
 function resolvePackagedDataRoot(
   config: Pick<PackagedConfig, "namespaceBaseRoot">,
   namespace: string,
@@ -58,41 +49,8 @@ function resolvePackagedDataRoot(
   const odDataDir = env.OD_DATA_DIR?.trim();
   if (odDataDir) {
     const expanded = expandHomePrefix(odDataDir);
-    const isAbs = process.platform === "win32" ? win32.isAbsolute(expanded) : isAbsolute(expanded);
-    if (!isAbs) {
-      throw new PackagedPathAccessError(
-        [
-          "Open Design's packaged runtime requires OD_DATA_DIR to be an absolute path.",
-          "",
-          `Configured value: ${odDataDir}`,
-          "",
-          "Set OD_DATA_DIR to an absolute path (for example, C:\\Users\\You\\OpenDesign on Windows or /Users/you/OpenDesign on macOS/Linux) and relaunch Open Design.",
-        ].join("\n"),
-        { title: "Open Design cannot start with this OD_DATA_DIR" },
-      );
-    }
-
-    const scopedNamespace = getScopedPackagedDataRootNamespace(expanded);
-    if (scopedNamespace) {
-      if (scopedNamespace !== namespace) {
-        throw new PackagedPathAccessError(
-          [
-            "Open Design's packaged runtime requires OD_DATA_DIR to target the active namespace.",
-            "",
-            `Configured value: ${odDataDir}`,
-            `Configured namespace: ${scopedNamespace}`,
-            `Active namespace: ${namespace}`,
-            "",
-            "Use an unscoped absolute base path or relaunch the matching packaged namespace.",
-          ].join("\n"),
-          { title: "Open Design cannot start with this OD_DATA_DIR" },
-        );
-      }
-
-      return expanded;
-    }
-
-    return join(expanded, "namespaces", namespace, "data");
+    const overrideRoot = isAbsolute(expanded) || win32.isAbsolute(expanded) ? expanded : resolve(expanded);
+    return join(overrideRoot, "namespaces", namespace, "data");
   }
 
   return join(config.namespaceBaseRoot, namespace, "data");

--- a/apps/packaged/src/paths.ts
+++ b/apps/packaged/src/paths.ts
@@ -1,8 +1,10 @@
-import { join } from "node:path";
+import { homedir } from "node:os";
+import { isAbsolute, join, win32 } from "node:path";
 
 import { APP_KEYS, normalizeNamespace } from "@open-design/sidecar-proto";
 
 import type { PackagedConfig } from "./config.js";
+import { PackagedPathAccessError } from "./errors.js";
 
 export type PackagedNamespacePaths = {
   cacheRoot: string;
@@ -30,13 +32,80 @@ export type PackagedNamespacePaths = {
   webIdentityPath: string;
 };
 
+const HOME_BARE_TOKENS = new Set(["~", "$HOME", "${HOME}"]);
+const HOME_PREFIX_RE = /^(~|\$\{HOME\}|\$HOME)[/\\](.*)$/;
+
+function expandHomePrefix(raw: string): string {
+  if (HOME_BARE_TOKENS.has(raw)) return homedir();
+  const match = HOME_PREFIX_RE.exec(raw);
+  if (match) return join(homedir(), match[2] ?? "");
+  return raw;
+}
+
+function getScopedPackagedDataRootNamespace(raw: string): string | null {
+  const parts = raw.replace(/[\\/]+$/g, "").split(/[\\/]+/);
+  const last = parts.length - 1;
+  if (last < 2) return null;
+  if (parts[last - 2] !== "namespaces" || parts[last] !== "data") return null;
+  return parts[last - 1] ?? null;
+}
+
+function resolvePackagedDataRoot(
+  config: Pick<PackagedConfig, "namespaceBaseRoot">,
+  namespace: string,
+  env: NodeJS.ProcessEnv = {},
+): string {
+  const odDataDir = env.OD_DATA_DIR?.trim();
+  if (odDataDir) {
+    const expanded = expandHomePrefix(odDataDir);
+    const isAbs = process.platform === "win32" ? win32.isAbsolute(expanded) : isAbsolute(expanded);
+    if (!isAbs) {
+      throw new PackagedPathAccessError(
+        [
+          "Open Design's packaged runtime requires OD_DATA_DIR to be an absolute path.",
+          "",
+          `Configured value: ${odDataDir}`,
+          "",
+          "Set OD_DATA_DIR to an absolute path (for example, C:\\Users\\You\\OpenDesign on Windows or /Users/you/OpenDesign on macOS/Linux) and relaunch Open Design.",
+        ].join("\n"),
+        { title: "Open Design cannot start with this OD_DATA_DIR" },
+      );
+    }
+
+    const scopedNamespace = getScopedPackagedDataRootNamespace(expanded);
+    if (scopedNamespace) {
+      if (scopedNamespace !== namespace) {
+        throw new PackagedPathAccessError(
+          [
+            "Open Design's packaged runtime requires OD_DATA_DIR to target the active namespace.",
+            "",
+            `Configured value: ${odDataDir}`,
+            `Configured namespace: ${scopedNamespace}`,
+            `Active namespace: ${namespace}`,
+            "",
+            "Use an unscoped absolute base path or relaunch the matching packaged namespace.",
+          ].join("\n"),
+          { title: "Open Design cannot start with this OD_DATA_DIR" },
+        );
+      }
+
+      return expanded;
+    }
+
+    return join(expanded, "namespaces", namespace, "data");
+  }
+
+  return join(config.namespaceBaseRoot, namespace, "data");
+}
+
 export function resolvePackagedNamespacePaths(
   config: PackagedConfig,
   namespace = config.namespace,
+  env: NodeJS.ProcessEnv = {},
 ): PackagedNamespacePaths {
   const normalizedNamespace = normalizeNamespace(namespace);
   const namespaceRoot = join(config.namespaceBaseRoot, normalizedNamespace);
-  const dataRoot = join(namespaceRoot, "data");
+  const dataRoot = resolvePackagedDataRoot(config, normalizedNamespace, env);
   // Channel root = parent of the `namespaces/` directory. With the default
   // packaged layout this resolves to `<electronApp.userData>` — e.g.
   // `~/Library/Application Support/Open Design Nightly/` on mac. Custom

--- a/apps/packaged/src/paths.ts
+++ b/apps/packaged/src/paths.ts
@@ -41,6 +41,12 @@ function expandHomePrefix(raw: string): string {
   return raw;
 }
 
+function isAlreadyScopedPackagedDataRoot(raw: string, namespace: string): boolean {
+  const parts = raw.replace(/[\\/]+$/g, "").split(/[\\/]+/);
+  const last = parts.length - 1;
+  return parts[last - 2] === "namespaces" && parts[last - 1] === namespace && parts[last] === "data";
+}
+
 function resolvePackagedDataRoot(
   config: Pick<PackagedConfig, "namespaceBaseRoot">,
   namespace: string,
@@ -51,6 +57,9 @@ function resolvePackagedDataRoot(
     const expanded = expandHomePrefix(odDataDir);
     if (!isAbsolute(expanded) && !win32.isAbsolute(expanded)) {
       throw new Error("OD_DATA_DIR must be an absolute path in packaged mode.");
+    }
+    if (isAlreadyScopedPackagedDataRoot(expanded, namespace)) {
+      return expanded;
     }
     return join(expanded, "namespaces", namespace, "data");
   }

--- a/apps/packaged/src/paths.ts
+++ b/apps/packaged/src/paths.ts
@@ -4,6 +4,7 @@ import { isAbsolute, join, win32 } from "node:path";
 import { APP_KEYS, normalizeNamespace } from "@open-design/sidecar-proto";
 
 import type { PackagedConfig } from "./config.js";
+import { PackagedPathAccessError } from "./errors.js";
 
 export type PackagedNamespacePaths = {
   cacheRoot: string;
@@ -56,7 +57,16 @@ function resolvePackagedDataRoot(
   if (odDataDir) {
     const expanded = expandHomePrefix(odDataDir);
     if (!isAbsolute(expanded) && !win32.isAbsolute(expanded)) {
-      throw new Error("OD_DATA_DIR must be an absolute path in packaged mode.");
+      throw new PackagedPathAccessError(
+        [
+          "Open Design's packaged runtime requires OD_DATA_DIR to be an absolute path.",
+          "",
+          `Configured value: ${odDataDir}`,
+          "",
+          "Set OD_DATA_DIR to an absolute path (for example, C:\\\\Users\\\\You\\\\OpenDesign on Windows or /Users/you/OpenDesign on macOS/Linux) and relaunch Open Design.",
+        ].join("\n"),
+        { title: "Open Design cannot start with this OD_DATA_DIR" },
+      );
     }
     if (isAlreadyScopedPackagedDataRoot(expanded, namespace)) {
       return expanded;

--- a/apps/packaged/src/paths.ts
+++ b/apps/packaged/src/paths.ts
@@ -42,10 +42,12 @@ function expandHomePrefix(raw: string): string {
   return raw;
 }
 
-function isAlreadyScopedPackagedDataRoot(raw: string, namespace: string): boolean {
+function getScopedPackagedDataRootNamespace(raw: string): string | null {
   const parts = raw.replace(/[\\/]+$/g, "").split(/[\\/]+/);
   const last = parts.length - 1;
-  return parts[last - 2] === "namespaces" && parts[last - 1] === namespace && parts[last] === "data";
+  if (last < 2) return null;
+  if (parts[last - 2] !== "namespaces" || parts[last] !== "data") return null;
+  return parts[last - 1] ?? null;
 }
 
 function resolvePackagedDataRoot(
@@ -71,7 +73,22 @@ function resolvePackagedDataRoot(
         { title: "Open Design cannot start with this OD_DATA_DIR" },
       );
     }
-    if (isAlreadyScopedPackagedDataRoot(expanded, namespace)) {
+    const scopedNamespace = getScopedPackagedDataRootNamespace(expanded);
+    if (scopedNamespace) {
+      if (scopedNamespace !== namespace) {
+        throw new PackagedPathAccessError(
+          [
+            "Open Design's packaged runtime requires OD_DATA_DIR to target the active namespace.",
+            "",
+            `Configured value: ${odDataDir}`,
+            `Configured namespace: ${scopedNamespace}`,
+            `Active namespace: ${namespace}`,
+            "",
+            "Use an unscoped absolute base path or relaunch the matching packaged namespace.",
+          ].join("\n"),
+          { title: "Open Design cannot start with this OD_DATA_DIR" },
+        );
+      }
       return expanded;
     }
     return join(expanded, "namespaces", namespace, "data");

--- a/apps/packaged/src/paths.ts
+++ b/apps/packaged/src/paths.ts
@@ -1,5 +1,5 @@
 import { homedir } from "node:os";
-import { isAbsolute, join, resolve, win32 } from "node:path";
+import { isAbsolute, join, win32 } from "node:path";
 
 import { APP_KEYS, normalizeNamespace } from "@open-design/sidecar-proto";
 
@@ -49,8 +49,10 @@ function resolvePackagedDataRoot(
   const odDataDir = env.OD_DATA_DIR?.trim();
   if (odDataDir) {
     const expanded = expandHomePrefix(odDataDir);
-    const overrideRoot = isAbsolute(expanded) || win32.isAbsolute(expanded) ? expanded : resolve(expanded);
-    return join(overrideRoot, "namespaces", namespace, "data");
+    if (!isAbsolute(expanded) && !win32.isAbsolute(expanded)) {
+      throw new Error("OD_DATA_DIR must be an absolute path in packaged mode.");
+    }
+    return join(expanded, "namespaces", namespace, "data");
   }
 
   return join(config.namespaceBaseRoot, namespace, "data");

--- a/apps/packaged/tests/launch.test.ts
+++ b/apps/packaged/tests/launch.test.ts
@@ -8,8 +8,8 @@ vi.mock("electron", () => ({
   app: {},
 }));
 
+import { PackagedPathAccessError } from "../src/errors.js";
 import {
-  PackagedPathAccessError,
   claimPackagedSingleInstanceLock,
   verifyPackagedDataRootWritable,
 } from "../src/launch.js";

--- a/apps/packaged/tests/paths.test.ts
+++ b/apps/packaged/tests/paths.test.ts
@@ -1,30 +1,34 @@
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
 import { resolvePackagedNamespacePaths } from "../src/paths.js";
 import type { PackagedConfig } from "../src/config.js";
 
+function fakeConfig(): PackagedConfig {
+  return {
+    appVersion: null,
+    daemonCliEntry: null,
+    daemonSidecarEntry: null,
+    namespace: "release-stable-win",
+    namespaceBaseRoot: join("C:", "Users", "Fred", "AppData", "Roaming", "Open Design", "namespaces"),
+    nodeCommand: null,
+    posthogHost: null,
+    posthogKey: null,
+    resourceRoot: join("C:", "Program Files", "Open Design", "resources", "open-design"),
+    telemetryRelayUrl: null,
+    webOutputMode: "server",
+    webSidecarEntry: null,
+    webStandaloneRoot: null,
+  };
+}
+
 describe("resolvePackagedNamespacePaths", () => {
   it("models update downloads as a namespace-scoped root beside data", () => {
-    const config: PackagedConfig = {
-      appVersion: "1.2.3",
-      daemonCliEntry: null,
-      daemonSidecarEntry: null,
-      namespace: "release",
-      namespaceBaseRoot: "/tmp/open-design-packaged/namespaces",
-      nodeCommand: null,
-      resourceRoot: "/tmp/open-design-packaged/resources",
-      telemetryRelayUrl: null,
-      posthogKey: null,
-      posthogHost: null,
-      webSidecarEntry: null,
-      webStandaloneRoot: null,
-      webOutputMode: "server",
-    };
+    const config = fakeConfig();
+    const paths = resolvePackagedNamespacePaths(config, config.namespace);
 
-    const paths = resolvePackagedNamespacePaths(config);
-    expect(paths.namespaceRoot).toBe(join(config.namespaceBaseRoot, "release"));
+    expect(paths.namespaceRoot).toBe(join(config.namespaceBaseRoot, config.namespace));
     expect(paths.dataRoot).toBe(join(paths.namespaceRoot, "data"));
     expect(paths.updateRoot).toBe(join(paths.namespaceRoot, "updates"));
     expect(paths.installerObservationRoot).toBe(join(paths.dataRoot, "observations", "installer"));
@@ -48,5 +52,56 @@ describe("resolvePackagedNamespacePaths", () => {
     };
 
     expect(() => resolvePackagedNamespacePaths(config, "../release")).toThrow(/namespace/);
+  });
+
+  it("defaults daemon dataRoot to the namespace-scoped packaged data directory", () => {
+    const config = fakeConfig();
+
+    expect(resolvePackagedNamespacePaths(config, config.namespace).dataRoot).toBe(
+      join(config.namespaceBaseRoot, config.namespace, "data"),
+    );
+  });
+
+  it("uses OD_DATA_DIR as the packaged daemon dataRoot when provided", () => {
+    const config = fakeConfig();
+    const override = join("C:", "Users", "Fred", "MyProject", "design", ".od");
+
+    expect(
+      resolvePackagedNamespacePaths(config, config.namespace, { OD_DATA_DIR: override }).dataRoot,
+    ).toBe(override);
+  });
+
+  it("forwards the OD_DATA_DIR-resolved dataRoot into sidecar launch paths", () => {
+    const config = fakeConfig();
+    const override = join("C:", "Users", "Fred", "MyProject", "design", ".od");
+    const paths = resolvePackagedNamespacePaths(config, config.namespace, {
+      OD_DATA_DIR: override,
+    });
+
+    expect(paths.dataRoot).toBe(override);
+    expect(paths.namespaceRoot).toBe(join(config.namespaceBaseRoot, config.namespace));
+    expect(paths.runtimeRoot).toBe(join(config.namespaceBaseRoot, config.namespace, "runtime"));
+  });
+
+  it("does not read process.env implicitly so headless can keep namespace-root OD_DATA_DIR semantics", () => {
+    const config = fakeConfig();
+    const original = process.env.OD_DATA_DIR;
+    try {
+      process.env.OD_DATA_DIR = join("C:", "Users", "Fred", "MyProject", "design", ".od");
+      expect(resolvePackagedNamespacePaths(config).dataRoot).toBe(
+        join(config.namespaceBaseRoot, config.namespace, "data"),
+      );
+    } finally {
+      if (original == null) delete process.env.OD_DATA_DIR;
+      else process.env.OD_DATA_DIR = original;
+    }
+  });
+
+  it("resolves relative OD_DATA_DIR values against the packaged process cwd", () => {
+    const config = fakeConfig();
+
+    expect(
+      resolvePackagedNamespacePaths(config, config.namespace, { OD_DATA_DIR: "project/.od" }).dataRoot,
+    ).toBe(resolve("project/.od"));
   });
 });

--- a/apps/packaged/tests/paths.test.ts
+++ b/apps/packaged/tests/paths.test.ts
@@ -86,6 +86,25 @@ describe("resolvePackagedNamespacePaths", () => {
     expect(stable.dataRoot).not.toBe(beta.dataRoot);
   });
 
+  it("preserves already-scoped packaged OD_DATA_DIR values as the final daemon dataRoot", () => {
+    const config = fakeConfig();
+    const override = join(
+      "C:",
+      "Users",
+      "Fred",
+      "AppData",
+      "Roaming",
+      "Open Design",
+      "namespaces",
+      config.namespace,
+      "data",
+    );
+
+    expect(
+      resolvePackagedNamespacePaths(config, config.namespace, { OD_DATA_DIR: override }).dataRoot,
+    ).toBe(override);
+  });
+
   it("forwards the OD_DATA_DIR-resolved dataRoot into sidecar launch paths", () => {
     const config = fakeConfig();
     const override = join("C:", "Users", "Fred", "MyProject", "design", ".od");

--- a/apps/packaged/tests/paths.test.ts
+++ b/apps/packaged/tests/paths.test.ts
@@ -1,10 +1,18 @@
 import { join } from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { PackagedConfig } from "../src/config.js";
 import { PackagedPathAccessError } from "../src/errors.js";
 import { resolvePackagedNamespacePaths } from "../src/paths.js";
+
+function stubPlatform(value: NodeJS.Platform): () => void {
+  const original = process.platform;
+  Object.defineProperty(process, "platform", { value, configurable: true });
+  return () => {
+    Object.defineProperty(process, "platform", { value: original, configurable: true });
+  };
+}
 
 function fakeConfig(): PackagedConfig {
   return {
@@ -25,6 +33,16 @@ function fakeConfig(): PackagedConfig {
 }
 
 describe("resolvePackagedNamespacePaths", () => {
+  let restorePlatform: () => void = () => {};
+
+  beforeEach(() => {
+    restorePlatform = stubPlatform("win32");
+  });
+
+  afterEach(() => {
+    restorePlatform();
+  });
+
   it("models update downloads as a namespace-scoped root beside data", () => {
     const config = fakeConfig();
     const paths = resolvePackagedNamespacePaths(config, config.namespace);
@@ -155,5 +173,26 @@ describe("resolvePackagedNamespacePaths", () => {
     expect(err.title).toMatch(/OD_DATA_DIR/);
     expect(err.message).toContain("project/.od");
     expect(err.message).toMatch(/absolute path/);
+  });
+
+  it("rejects Windows-style OD_DATA_DIR values on non-Windows hosts so the absolute-path guard is platform-correct", () => {
+    const config = fakeConfig();
+    const restore = stubPlatform("linux");
+    try {
+      expect(
+        () =>
+          resolvePackagedNamespacePaths(config, config.namespace, {
+            OD_DATA_DIR: "C:\\Users\\Fred\\OD",
+          }),
+      ).toThrow(PackagedPathAccessError);
+      expect(
+        () =>
+          resolvePackagedNamespacePaths(config, config.namespace, {
+            OD_DATA_DIR: "\\\\server\\share",
+          }),
+      ).toThrow(PackagedPathAccessError);
+    } finally {
+      restore();
+    }
   });
 });

--- a/apps/packaged/tests/paths.test.ts
+++ b/apps/packaged/tests/paths.test.ts
@@ -124,6 +124,28 @@ describe("resolvePackagedNamespacePaths", () => {
     ).toBe(override);
   });
 
+  it("rejects already-scoped OD_DATA_DIR values that point at a different packaged namespace", () => {
+    const config = fakeConfig();
+    const override = join(
+      "C:",
+      "Users",
+      "Fred",
+      "AppData",
+      "Roaming",
+      "Open Design",
+      "namespaces",
+      "release-beta-win",
+      "data",
+    );
+
+    expect(
+      () =>
+        resolvePackagedNamespacePaths(config, config.namespace, {
+          OD_DATA_DIR: override,
+        }),
+    ).toThrow(PackagedPathAccessError);
+  });
+
   it("forwards the OD_DATA_DIR-resolved dataRoot into sidecar launch paths", () => {
     const config = fakeConfig();
     const override = join("C:", "Users", "Fred", "MyProject", "design", ".od");

--- a/apps/packaged/tests/paths.test.ts
+++ b/apps/packaged/tests/paths.test.ts
@@ -2,8 +2,9 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { resolvePackagedNamespacePaths } from "../src/paths.js";
 import type { PackagedConfig } from "../src/config.js";
+import { PackagedPathAccessError } from "../src/errors.js";
+import { resolvePackagedNamespacePaths } from "../src/paths.js";
 
 function fakeConfig(): PackagedConfig {
   return {
@@ -136,6 +137,23 @@ describe("resolvePackagedNamespacePaths", () => {
 
     expect(
       () => resolvePackagedNamespacePaths(config, config.namespace, { OD_DATA_DIR: "project/.od" }),
-    ).toThrow(/OD_DATA_DIR must be an absolute path/);
+    ).toThrow(/OD_DATA_DIR.*absolute path/);
+  });
+
+  it("surfaces the relative-OD_DATA_DIR rejection as PackagedPathAccessError so packaged main() can show a dialog", () => {
+    const config = fakeConfig();
+
+    let captured: unknown;
+    try {
+      resolvePackagedNamespacePaths(config, config.namespace, { OD_DATA_DIR: "project/.od" });
+    } catch (error) {
+      captured = error;
+    }
+
+    expect(captured).toBeInstanceOf(PackagedPathAccessError);
+    const err = captured as PackagedPathAccessError;
+    expect(err.title).toMatch(/OD_DATA_DIR/);
+    expect(err.message).toContain("project/.od");
+    expect(err.message).toMatch(/absolute path/);
   });
 });

--- a/apps/packaged/tests/paths.test.ts
+++ b/apps/packaged/tests/paths.test.ts
@@ -62,13 +62,28 @@ describe("resolvePackagedNamespacePaths", () => {
     );
   });
 
-  it("uses OD_DATA_DIR as the packaged daemon dataRoot when provided", () => {
+  it("uses OD_DATA_DIR as a base for the namespace-scoped packaged daemon dataRoot", () => {
     const config = fakeConfig();
     const override = join("C:", "Users", "Fred", "MyProject", "design", ".od");
 
     expect(
       resolvePackagedNamespacePaths(config, config.namespace, { OD_DATA_DIR: override }).dataRoot,
-    ).toBe(override);
+    ).toBe(join(override, "namespaces", config.namespace, "data"));
+  });
+
+  it("keeps shared OD_DATA_DIR overrides isolated across packaged namespaces", () => {
+    const config = fakeConfig();
+    const override = join("C:", "Users", "Fred", "MyProject", "design", ".od");
+    const stable = resolvePackagedNamespacePaths(config, "release-stable-win", {
+      OD_DATA_DIR: override,
+    });
+    const beta = resolvePackagedNamespacePaths(config, "release-beta-win", {
+      OD_DATA_DIR: override,
+    });
+
+    expect(stable.dataRoot).toBe(join(override, "namespaces", "release-stable-win", "data"));
+    expect(beta.dataRoot).toBe(join(override, "namespaces", "release-beta-win", "data"));
+    expect(stable.dataRoot).not.toBe(beta.dataRoot);
   });
 
   it("forwards the OD_DATA_DIR-resolved dataRoot into sidecar launch paths", () => {
@@ -78,7 +93,7 @@ describe("resolvePackagedNamespacePaths", () => {
       OD_DATA_DIR: override,
     });
 
-    expect(paths.dataRoot).toBe(override);
+    expect(paths.dataRoot).toBe(join(override, "namespaces", config.namespace, "data"));
     expect(paths.namespaceRoot).toBe(join(config.namespaceBaseRoot, config.namespace));
     expect(paths.runtimeRoot).toBe(join(config.namespaceBaseRoot, config.namespace, "runtime"));
   });
@@ -102,6 +117,6 @@ describe("resolvePackagedNamespacePaths", () => {
 
     expect(
       resolvePackagedNamespacePaths(config, config.namespace, { OD_DATA_DIR: "project/.od" }).dataRoot,
-    ).toBe(resolve("project/.od"));
+    ).toBe(join(resolve("project/.od"), "namespaces", config.namespace, "data"));
   });
 });

--- a/apps/packaged/tests/paths.test.ts
+++ b/apps/packaged/tests/paths.test.ts
@@ -1,4 +1,4 @@
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
@@ -112,11 +112,11 @@ describe("resolvePackagedNamespacePaths", () => {
     }
   });
 
-  it("resolves relative OD_DATA_DIR values against the packaged process cwd", () => {
+  it("rejects relative OD_DATA_DIR values instead of resolving them against cwd", () => {
     const config = fakeConfig();
 
     expect(
-      resolvePackagedNamespacePaths(config, config.namespace, { OD_DATA_DIR: "project/.od" }).dataRoot,
-    ).toBe(join(resolve("project/.od"), "namespaces", config.namespace, "data"));
+      () => resolvePackagedNamespacePaths(config, config.namespace, { OD_DATA_DIR: "project/.od" }),
+    ).toThrow(/OD_DATA_DIR must be an absolute path/);
   });
 });


### PR DESCRIPTION
Fixes #1977

## Why

Windows desktop users can select a project folder through Open folder and set `OD_DATA_DIR`, but the packaged runtime still launched the daemon with the namespace AppData data root. That meant the UI remembered the selected folder while project data kept landing under `%APPDATA%\Open Design\namespaces\release-stable-win\data\projects\...`.

This bug blocks the documented custom-folder workflow for packaged Windows installs, especially `.bat` launchers or other wrappers that set `OD_DATA_DIR` to keep Open Design data next to a project checkout.

## What users will see

Launching the packaged desktop with `OD_DATA_DIR=C:\Users\Fred\MyProject\design\.od` now routes daemon data to that directory instead of the default namespace AppData data root. Folder-imported projects also keep generated artifact writes inside the selected folder instead of creating shadow files under the daemon projects directory.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this is packaged runtime path routing and daemon file persistence behavior.

## Bug fix verification

- Test path that reproduces the bug: `apps/packaged/tests/paths.test.ts`
- Did the test go red on `main` and green on this branch? yes. I temporarily reverse-applied the packaged runtime source change while keeping the new path tests; the `OD_DATA_DIR` assertions failed by resolving to `C:/Users/Fred/AppData/Roaming/Open Design/namespaces/release-stable-win/data` instead of the override. Restoring the source change made the tests green.
- Additional regression coverage: `apps/daemon/tests/folder-import-route.test.ts` now verifies generated artifact files for imported-folder projects are written to `metadata.baseDir`, not `<OD_DATA_DIR>/projects/<id>`.

## Validation

- `pnpm install`
- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/packaged exec vitest run -c vitest.config.ts tests/paths.test.ts tests/sidecars.test.ts`
- `pnpm --filter @open-design/packaged run typecheck`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/folder-import-route.test.ts`
- `pnpm --filter @open-design/daemon run typecheck`

Validation was run in this workspace with Node `v26.0.0` and pnpm `10.33.2`; pnpm reported the repo's expected Node `~24` engine warning, but the listed commands exited successfully. Vitest also emitted the existing Vite `ES2024` target warning during the packaged tests.
