### PR TITLE
add plugin capability trust controls

### DIFF
--- a/apps/daemon/src/plugins/apply.ts
+++ b/apps/daemon/src/plugins/apply.ts
@@ -115,7 +115,11 @@ export function applyPlugin(input: ApplyInput): ApplyComputed {
   const { resolved: connectorsResolved, required: connectorsRequired } =
     resolveConnectorBindings(manifest, input.connectorProbe);
   const required = requiredCapabilities(manifest);
-  const granted = resolveCapabilitiesGranted({ manifest, trust });
+  const granted = resolveCapabilitiesGranted({
+    manifest,
+    trust,
+    capabilitiesGranted: input.plugin.capabilitiesGranted,
+  });
   const taskKind = (manifest.od?.taskKind ?? 'new-generation') as AppliedPluginSnapshot['taskKind'];
 
   // Spec §23.3.3: when the plugin omits `od.pipeline`, fall back to

--- a/apps/daemon/src/plugins/trust.ts
+++ b/apps/daemon/src/plugins/trust.ts
@@ -65,8 +65,12 @@ export function requiredCapabilities(manifest: PluginManifest): string[] {
 export function resolveCapabilitiesGranted(args: {
   manifest: PluginManifest;
   trust: TrustTier;
+  capabilitiesGranted?: readonly string[] | undefined;
 }): string[] {
   const out = new Set(defaultCapabilities(args.trust));
+  for (const cap of args.capabilitiesGranted ?? []) {
+    if (typeof cap === 'string' && cap.length > 0) out.add(cap);
+  }
   if (args.trust === 'trusted') {
     for (const cap of requiredCapabilities(args.manifest)) {
       out.add(stripOptionalSuffix(cap));
@@ -95,6 +99,11 @@ const KNOWN_TOP_LEVEL_CAPABILITIES = new Set<string>([
   // surfaces require an explicit capability so a restricted plugin
   // cannot smuggle arbitrary UI through the GenUI layer.
   'genui:custom-component',
+  'genui:form',
+  'genui:choice',
+  'genui:confirmation',
+  'genui:oauth-prompt',
+  'pipeline:*',
 ]);
 
 const SCOPED_CONNECTOR_RE = /^connector:[a-z0-9][a-z0-9_-]*$/;

--- a/apps/daemon/tests/plugins-dod-e2e.test.ts
+++ b/apps/daemon/tests/plugins-dod-e2e.test.ts
@@ -32,6 +32,7 @@ import { installFromLocalFolder } from '../src/plugins/installer.js';
 import { getInstalledPlugin } from '../src/plugins/registry.js';
 import { createSnapshot, getSnapshot } from '../src/plugins/snapshots.js';
 import { resolvePluginSnapshot, capabilitiesRequiredError } from '../src/plugins/resolve-snapshot.js';
+import { grantCapabilities } from '../src/plugins/trust.js';
 import { renderPluginBlock } from '@open-design/contracts';
 import { checkConnectorAccess, ToolTokenRegistry } from '../src/tool-tokens.js';
 import { FIRST_PARTY_ATOMS, type AtomCatalogEntry } from '../src/plugins/atoms.js';
@@ -256,6 +257,88 @@ describe('Plan §8 e2e — daemon-side anchors', () => {
     const gateResult = checkConnectorAccess(grant, 'slack');
     expect(gateResult.ok).toBe(false);
     expect(plugin.trust).toBe('restricted');
+  });
+
+  it('persistent trust grants satisfy derived GenUI surface-kind and pipeline capabilities', async () => {
+    const folder = path.join(tmpRoot, 'derived-capability-plugin');
+    await mkdir(folder, { recursive: true });
+    const manifest = {
+      $schema: 'https://open-design.ai/schemas/plugin.v1.json',
+      name: 'derived-capability-plugin',
+      title: 'Derived Capability Plugin',
+      version: '1.0.0',
+      description: 'requires GenUI and pipeline capabilities',
+      license: 'MIT',
+      od: {
+        kind: 'skill',
+        taskKind: 'new-generation',
+        useCase: { query: 'Run the guided workflow.' },
+        capabilities: ['prompt:inject'],
+        genui: {
+          surfaces: [
+            {
+              id: 'intake',
+              kind: 'form',
+              persist: 'run',
+              schema: {
+                type: 'object',
+                properties: { topic: { type: 'string' } },
+              },
+            },
+          ],
+        },
+        pipeline: {
+          stages: [{ id: 'draft', atoms: ['todo-write'] }],
+        },
+      },
+    };
+    await writeFile(path.join(folder, 'open-design.json'), JSON.stringify(manifest));
+    await writeFile(
+      path.join(folder, 'SKILL.md'),
+      '---\nname: derived-capability-plugin\ndescription: requires derived capabilities\n---\n# Derived\n',
+    );
+    await installLocal(folder);
+    db.prepare('UPDATE installed_plugins SET trust = ? WHERE id = ?')
+      .run('restricted', 'derived-capability-plugin');
+
+    const missing = resolvePluginSnapshot({
+      db,
+      body: { pluginId: 'derived-capability-plugin' },
+      projectId: 'project-1',
+      registry: REGISTRY_VIEW,
+    });
+    expect(missing).toBeDefined();
+    expect(missing?.ok).toBe(false);
+    if (missing && !missing.ok) {
+      expect(missing.status).toBe(409);
+      expect(missing.body.error.code).toBe('capabilities-required');
+      expect(missing.body.error.data?.missing).toEqual(
+        expect.arrayContaining(['genui:form', 'pipeline:*']),
+      );
+    }
+
+    const next = grantCapabilities({
+      db,
+      pluginId: 'derived-capability-plugin',
+      capabilities: ['genui:form', 'pipeline:*'],
+    });
+    expect(next).toEqual(expect.arrayContaining(['genui:form', 'pipeline:*']));
+
+    const granted = resolvePluginSnapshot({
+      db,
+      body: { pluginId: 'derived-capability-plugin' },
+      projectId: 'project-1',
+      registry: REGISTRY_VIEW,
+    });
+    expect(granted?.ok).toBe(true);
+    if (granted?.ok) {
+      expect(granted.snapshot.capabilitiesGranted).toEqual(
+        expect.arrayContaining(['genui:form', 'pipeline:*']),
+      );
+      expect(granted.snapshot.capabilitiesRequired).toEqual(
+        expect.arrayContaining(['genui:form', 'pipeline:*']),
+      );
+    }
   });
 
   it('e2e-8 apply purity regression: 100 applies → 0 FS mutation, snapshot count grows by 100', async () => {

--- a/apps/daemon/tests/plugins-trust.test.ts
+++ b/apps/daemon/tests/plugins-trust.test.ts
@@ -85,6 +85,26 @@ describe('validateCapabilityList', () => {
     ]);
   });
 
+  it('accepts capabilities derived by requiredCapabilities for GenUI surfaces and pipelines', () => {
+    const { accepted, rejected } = validateCapabilityList([
+      'genui:form',
+      'genui:choice',
+      'genui:confirmation',
+      'genui:oauth-prompt',
+      'genui:custom-component',
+      'pipeline:*',
+    ]);
+    expect(rejected).toEqual([]);
+    expect(accepted.sort()).toEqual([
+      'genui:choice',
+      'genui:confirmation',
+      'genui:custom-component',
+      'genui:form',
+      'genui:oauth-prompt',
+      'pipeline:*',
+    ]);
+  });
+
   it('rejects unknown shapes without dropping good entries', () => {
     const { accepted, rejected } = validateCapabilityList([
       'fs:read',

--- a/apps/web/src/components/PluginDetailView.tsx
+++ b/apps/web/src/components/PluginDetailView.tsx
@@ -9,7 +9,11 @@
 
 import { useEffect, useState } from 'react';
 import type { ApplyResult, InstalledPluginRecord } from '@open-design/contracts';
-import { applyPlugin } from '../state/projects';
+import {
+  applyPlugin,
+  grantPluginCapabilities,
+  type PluginCapabilityTrustAction,
+} from '../state/projects';
 import { navigate } from '../router';
 import { useI18n } from '../i18n';
 
@@ -23,6 +27,10 @@ export function PluginDetailView(props: Props) {
   const [error, setError] = useState<string | null>(null);
   const [applying, setApplying] = useState(false);
   const [applied, setApplied] = useState<ApplyResult | null>(null);
+  const [selectedCapabilities, setSelectedCapabilities] = useState<string[]>([]);
+  const [pendingTrustAction, setPendingTrustAction] = useState<PluginCapabilityTrustAction | null>(null);
+  const [trustMessage, setTrustMessage] = useState<string | null>(null);
+  const [trustError, setTrustError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -68,6 +76,13 @@ export function PluginDetailView(props: Props) {
   const required = od.connectors?.required ?? [];
   const optional = od.connectors?.optional ?? [];
   const capabilities = od.capabilities ?? [];
+  const capabilitiesGranted = new Set(plugin.capabilitiesGranted ?? []);
+  const declaredGrantedCount = capabilities.filter((cap: string) => capabilitiesGranted.has(cap)).length;
+  const selectedGrantedCount = selectedCapabilities.filter((cap) => capabilitiesGranted.has(cap)).length;
+  const selectedRequestedCount = selectedCapabilities.length - selectedGrantedCount;
+  const selectedGrantableCapabilities = selectedCapabilities.filter((cap) => !capabilitiesGranted.has(cap));
+  const selectedRevokableCapabilities = selectedCapabilities.filter((cap) => capabilitiesGranted.has(cap));
+  const trustPending = pendingTrustAction !== null;
   // Plan §6 Phase 2B / spec §11.6 — show a sandboxed iframe of the
   // plugin's preview entry when one is declared. The daemon serves
   // it under `/api/plugins/:id/preview` with the §9.2 CSP +
@@ -93,6 +108,46 @@ export function PluginDetailView(props: Props) {
     // applied snapshot. Inside an existing project, the ChatComposer
     // mount of PluginsSection consumes the same ApplyResult.
     navigate({ kind: 'home', view: 'home' });
+  };
+
+  const toggleCapability = (capability: string, checked: boolean) => {
+    setSelectedCapabilities((current) => (
+      checked
+        ? Array.from(new Set([...current, capability]))
+        : current.filter((entry) => entry !== capability)
+    ));
+    setTrustMessage(null);
+    setTrustError(null);
+  };
+
+  const onCapabilityAction = async (action: PluginCapabilityTrustAction) => {
+    const capabilitiesForAction =
+      action === 'grant' ? selectedGrantableCapabilities : selectedRevokableCapabilities;
+    if (capabilitiesForAction.length === 0) return;
+    setPendingTrustAction(action);
+    setTrustMessage(null);
+    setTrustError(null);
+    const outcome = await grantPluginCapabilities(
+      plugin.id,
+      capabilitiesForAction,
+      action,
+    );
+    setPendingTrustAction(null);
+    if (!outcome.ok) {
+      setTrustError(outcome.message);
+      return;
+    }
+    if (outcome.plugin) {
+      setPlugin(outcome.plugin);
+    } else {
+      setPlugin({
+        ...plugin,
+        capabilitiesGranted: outcome.capabilitiesGranted,
+      });
+    }
+    const completed = new Set(capabilitiesForAction);
+    setSelectedCapabilities((current) => current.filter((cap) => !completed.has(cap)));
+    setTrustMessage(outcome.message);
   };
 
   return (
@@ -124,13 +179,75 @@ export function PluginDetailView(props: Props) {
         {capabilities.length === 0 ? (
           <div>None declared (defaults to <code>prompt:inject</code>).</div>
         ) : (
-          <ul>
-            {capabilities.map((c: string) => (
-              <li key={c}>
-                <code>{c}</code>
-              </li>
-            ))}
-          </ul>
+          <>
+            <div className="plugin-detail__trust-toolbar" role="group" aria-label="Capability trust action">
+              <button
+                type="button"
+                className="plugin-detail__trust-action"
+                onClick={() => onCapabilityAction('grant')}
+                disabled={trustPending || selectedGrantableCapabilities.length === 0}
+              >
+                {pendingTrustAction === 'grant'
+                  ? 'Granting...'
+                  : 'Grant selected capabilities'}
+              </button>
+              <button
+                type="button"
+                className="plugin-detail__trust-action plugin-detail__trust-action--revoke"
+                onClick={() => onCapabilityAction('revoke')}
+                disabled={trustPending || selectedRevokableCapabilities.length === 0}
+              >
+                {pendingTrustAction === 'revoke'
+                  ? 'Revoking...'
+                  : 'Revoke selected capabilities'}
+              </button>
+            </div>
+            <ul className="plugin-detail__capability-list">
+              {capabilities.map((c: string) => {
+                const granted = capabilitiesGranted.has(c);
+                return (
+                  <li
+                    key={c}
+                    className="plugin-detail__capability-row"
+                    data-granted={granted}
+                    data-testid={`plugin-capability-${c}`}
+                  >
+                    <label>
+                      <input
+                        type="checkbox"
+                        checked={selectedCapabilities.includes(c)}
+                        onChange={(event) => toggleCapability(c, event.currentTarget.checked)}
+                        disabled={trustPending}
+                      />
+                      <code>{c}</code>
+                    </label>
+                    <span className="plugin-detail__capability-status">
+                      {granted ? 'Granted' : 'Requested'}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+            <div className="plugin-detail__trust-summary">
+              {plugin.trust === 'restricted' ? (
+                <span>{capabilities.length - declaredGrantedCount} requested · {declaredGrantedCount} granted</span>
+              ) : (
+                <span>{plugin.trust} plugin · {declaredGrantedCount} granted</span>
+              )}
+              {selectedCapabilities.length > 0 ? (
+                <span>{selectedRequestedCount} grantable · {selectedGrantedCount} revokable</span>
+              ) : null}
+              {selectedCapabilities.length > 0 && selectedRequestedCount === 0 ? (
+                <span>Selected capabilities are already granted</span>
+              ) : null}
+            </div>
+            {trustMessage ? (
+              <div className="plugin-detail__trust-message" role="status">{trustMessage}</div>
+            ) : null}
+            {trustError ? (
+              <div className="plugin-detail__trust-error" role="alert">{trustError}</div>
+            ) : null}
+          </>
         )}
       </section>
 

--- a/apps/web/src/components/PluginDetailView.tsx
+++ b/apps/web/src/components/PluginDetailView.tsx
@@ -36,6 +36,13 @@ export function PluginDetailView(props: Props) {
 
   useEffect(() => {
     let cancelled = false;
+    setPlugin(null);
+    setError(null);
+    setApplied(null);
+    setSelectedCapabilities([]);
+    setPendingTrustAction(null);
+    setTrustMessage(null);
+    setTrustError(null);
     void fetch(`/api/plugins/${encodeURIComponent(props.pluginId)}`)
       .then((r) => {
         if (!r.ok) throw new Error(`HTTP ${r.status}`);
@@ -78,12 +85,14 @@ export function PluginDetailView(props: Props) {
   const required = od.connectors?.required ?? [];
   const optional = od.connectors?.optional ?? [];
   const capabilities = requiredGrantableCapabilities(plugin);
+  const visibleCapabilities = new Set(capabilities);
   const capabilitiesGranted = new Set(plugin.capabilitiesGranted ?? []);
   const declaredGrantedCount = capabilities.filter((cap: string) => capabilitiesGranted.has(cap)).length;
-  const selectedGrantedCount = selectedCapabilities.filter((cap) => capabilitiesGranted.has(cap)).length;
-  const selectedRequestedCount = selectedCapabilities.length - selectedGrantedCount;
-  const selectedGrantableCapabilities = selectedCapabilities.filter((cap) => !capabilitiesGranted.has(cap));
-  const selectedRevokableCapabilities = selectedCapabilities.filter((cap) => capabilitiesGranted.has(cap));
+  const selectedVisibleCapabilities = selectedCapabilities.filter((cap) => visibleCapabilities.has(cap));
+  const selectedGrantedCount = selectedVisibleCapabilities.filter((cap) => capabilitiesGranted.has(cap)).length;
+  const selectedRequestedCount = selectedVisibleCapabilities.length - selectedGrantedCount;
+  const selectedGrantableCapabilities = selectedVisibleCapabilities.filter((cap) => !capabilitiesGranted.has(cap));
+  const selectedRevokableCapabilities = selectedVisibleCapabilities.filter((cap) => capabilitiesGranted.has(cap));
   const trustPending = pendingTrustAction !== null;
   // Plan §6 Phase 2B / spec §11.6 — show a sandboxed iframe of the
   // plugin's preview entry when one is declared. The daemon serves
@@ -236,10 +245,10 @@ export function PluginDetailView(props: Props) {
               ) : (
                 <span>{plugin.trust} plugin · {declaredGrantedCount} granted</span>
               )}
-              {selectedCapabilities.length > 0 ? (
+              {selectedVisibleCapabilities.length > 0 ? (
                 <span>{selectedRequestedCount} grantable · {selectedGrantedCount} revokable</span>
               ) : null}
-              {selectedCapabilities.length > 0 && selectedRequestedCount === 0 ? (
+              {selectedVisibleCapabilities.length > 0 && selectedRequestedCount === 0 ? (
                 <span>Selected capabilities are already granted</span>
               ) : null}
             </div>

--- a/apps/web/src/components/PluginDetailView.tsx
+++ b/apps/web/src/components/PluginDetailView.tsx
@@ -21,6 +21,8 @@ interface Props {
   pluginId: string;
 }
 
+type ConnectorRef = { id?: string; tools?: string[] };
+
 export function PluginDetailView(props: Props) {
   const { locale } = useI18n();
   const [plugin, setPlugin] = useState<InstalledPluginRecord | null>(null);
@@ -75,7 +77,7 @@ export function PluginDetailView(props: Props) {
   const surfaces = od.genui?.surfaces ?? [];
   const required = od.connectors?.required ?? [];
   const optional = od.connectors?.optional ?? [];
-  const capabilities = od.capabilities ?? [];
+  const capabilities = requiredGrantableCapabilities(plugin);
   const capabilitiesGranted = new Set(plugin.capabilitiesGranted ?? []);
   const declaredGrantedCount = capabilities.filter((cap: string) => capabilitiesGranted.has(cap)).length;
   const selectedGrantedCount = selectedCapabilities.filter((cap) => capabilitiesGranted.has(cap)).length;
@@ -258,7 +260,7 @@ export function PluginDetailView(props: Props) {
             <>
               <h3>Required</h3>
               <ul>
-                {required.map((c: { id: string; tools?: string[] }) => (
+                {required.map((c: ConnectorRef) => (
                   <li key={c.id}>
                     <code>{c.id}</code>
                     {c.tools && c.tools.length > 0 ? ` · ${c.tools.join(', ')}` : ''}
@@ -271,7 +273,7 @@ export function PluginDetailView(props: Props) {
             <>
               <h3>Optional</h3>
               <ul>
-                {optional.map((c: { id: string; tools?: string[] }) => (
+                {optional.map((c: ConnectorRef) => (
                   <li key={c.id}>
                     <code>{c.id}</code>
                     {c.tools && c.tools.length > 0 ? ` · ${c.tools.join(', ')}` : ''}
@@ -367,4 +369,24 @@ export function PluginDetailView(props: Props) {
       </footer>
     </div>
   );
+}
+
+function requiredGrantableCapabilities(plugin: InstalledPluginRecord): string[] {
+  const od = plugin.manifest?.od;
+  const capabilities = new Set<string>();
+
+  for (const capability of od?.capabilities ?? []) {
+    if (typeof capability === 'string' && capability.length > 0) {
+      capabilities.add(capability);
+    }
+  }
+
+  for (const connector of od?.connectors?.required ?? []) {
+    const id = connector?.id;
+    if (typeof id === 'string' && id.length > 0) {
+      capabilities.add(`connector:${id}`);
+    }
+  }
+
+  return Array.from(capabilities.values()).sort();
 }

--- a/apps/web/src/components/PluginDetailView.tsx
+++ b/apps/web/src/components/PluginDetailView.tsx
@@ -371,13 +371,25 @@ export function PluginDetailView(props: Props) {
   );
 }
 
+// Mirror of the daemon capability resolver `requiredCapabilities()` in
+// `apps/daemon/src/plugins/trust.ts`. The apply gate in
+// `resolve-snapshot.ts` computes its 409 `capabilities-required` set from
+// that exact derivation, so the detail-page checklist must surface a
+// selectable row for every capability the gate can block on — manifest
+// `od.capabilities`, plus the implied `mcp:<name>`, `connector:<id>`,
+// `genui:<kind>`, and `pipeline:*` requirements. Two entries the daemon
+// resolver emits are intentionally omitted here: the implicit
+// `prompt:inject` floor (always granted for restricted installs, never a
+// 409 cause) and the `?`-suffixed optional-connector markers (not a
+// grantable capability shape). Keep this aligned with that resolver.
 function requiredGrantableCapabilities(plugin: InstalledPluginRecord): string[] {
   const od = plugin.manifest?.od;
   const capabilities = new Set<string>();
 
-  for (const capability of od?.capabilities ?? []) {
-    if (typeof capability === 'string' && capability.length > 0) {
-      capabilities.add(capability);
+  for (const mcp of od?.context?.mcp ?? []) {
+    const name = mcp?.name;
+    if (typeof name === 'string' && name.length > 0) {
+      capabilities.add(`mcp:${name}`);
     }
   }
 
@@ -385,6 +397,23 @@ function requiredGrantableCapabilities(plugin: InstalledPluginRecord): string[] 
     const id = connector?.id;
     if (typeof id === 'string' && id.length > 0) {
       capabilities.add(`connector:${id}`);
+    }
+  }
+
+  for (const surface of od?.genui?.surfaces ?? []) {
+    const kind = surface?.kind;
+    if (typeof kind === 'string' && kind.length > 0) {
+      capabilities.add(`genui:${kind}`);
+    }
+  }
+
+  if ((od?.pipeline?.stages?.length ?? 0) > 0) {
+    capabilities.add('pipeline:*');
+  }
+
+  for (const capability of od?.capabilities ?? []) {
+    if (typeof capability === 'string' && capability.length > 0) {
+      capabilities.add(capability);
     }
   }
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -22668,6 +22668,115 @@ body.desktop-pet-shell .pet-task-item {
   outline-offset: 1px;
 }
 
+/* Marketplace detail trust controls — compact, operational styling
+   that keeps capability review readable without turning the detail
+   page into another card surface. */
+.plugin-detail__capabilities {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.plugin-detail__trust-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+.plugin-detail__trust-action {
+  appearance: none;
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: white;
+  border-radius: var(--radius-sm, 6px);
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.plugin-detail__trust-action--revoke {
+  border-color: var(--border);
+  background: var(--bg-subtle);
+  color: var(--text);
+}
+.plugin-detail__trust-action:hover:not(:disabled) {
+  filter: brightness(0.96);
+}
+.plugin-detail__trust-action--revoke:hover:not(:disabled) {
+  border-color: var(--danger, #c33);
+  color: var(--danger, #c33);
+}
+.plugin-detail__trust-action:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.plugin-detail__capability-list {
+  display: grid;
+  gap: 8px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.plugin-detail__capability-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 6px);
+  background: var(--bg);
+  padding: 8px 10px;
+}
+.plugin-detail__capability-row[data-granted='true'] {
+  border-color: color-mix(in srgb, var(--green) 22%, var(--border));
+  background: color-mix(in srgb, var(--green-bg) 55%, var(--bg));
+}
+.plugin-detail__capability-row label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+.plugin-detail__capability-row input {
+  flex: 0 0 auto;
+}
+.plugin-detail__capability-row code {
+  overflow-wrap: anywhere;
+}
+.plugin-detail__capability-status {
+  flex: 0 0 auto;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 2px 8px;
+  color: var(--text-muted);
+  background: var(--bg-subtle);
+  font-size: 10.5px;
+  font-weight: 650;
+  line-height: 1.2;
+}
+.plugin-detail__capability-row[data-granted='true'] .plugin-detail__capability-status {
+  border-color: color-mix(in srgb, var(--green) 24%, var(--border));
+  color: var(--green);
+  background: var(--green-bg);
+}
+.plugin-detail__trust-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.plugin-detail__trust-message,
+.plugin-detail__trust-error {
+  font-size: 12px;
+  line-height: 1.45;
+}
+.plugin-detail__trust-message {
+  color: var(--green);
+}
+.plugin-detail__trust-error {
+  color: var(--danger, #c33);
+}
+
 /* PluginDetailsModal — manifest inspector launched from each card on
    PluginLoopHome. Single-scroll layout with sticky header + footer so
    long manifests (workflow stages, context bundles, surfaces) remain

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -876,6 +876,55 @@ export async function setPluginMarketplaceTrust(
   }
 }
 
+export type PluginCapabilityTrustAction = 'grant' | 'revoke';
+
+export interface PluginCapabilityTrustOutcome {
+  ok: boolean;
+  plugin?: InstalledPluginRecord;
+  capabilitiesGranted: string[];
+  message: string;
+}
+
+export async function grantPluginCapabilities(
+  pluginId: string,
+  capabilities: string[],
+  action: PluginCapabilityTrustAction = 'grant',
+): Promise<PluginCapabilityTrustOutcome> {
+  try {
+    const resp = await fetch(`/api/plugins/${encodeURIComponent(pluginId)}/trust`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ capabilities, action }),
+    });
+    if (!resp.ok) {
+      return {
+        ok: false,
+        capabilitiesGranted: [],
+        message: await readErrorMessage(resp),
+      };
+    }
+    const json = (await resp.json().catch(() => null)) as {
+      plugin?: InstalledPluginRecord;
+      capabilitiesGranted?: string[];
+      message?: string;
+    } | null;
+    return {
+      ok: true,
+      ...(json?.plugin ? { plugin: json.plugin } : {}),
+      capabilitiesGranted: json?.capabilitiesGranted ?? json?.plugin?.capabilitiesGranted ?? [],
+      message: json?.message ?? (
+        action === 'revoke' ? 'Capabilities revoked.' : 'Capabilities granted.'
+      ),
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      capabilitiesGranted: [],
+      message: (err as Error).message,
+    };
+  }
+}
+
 async function readPluginMarketplaceOutcome(
   resp: Response,
   successMessage: string,

--- a/apps/web/tests/components/PluginDetailView.test.tsx
+++ b/apps/web/tests/components/PluginDetailView.test.tsx
@@ -33,6 +33,25 @@ function makePlugin(capabilitiesGranted: string[]): InstalledPluginRecord {
   };
 }
 
+function makeRouteSwitchPlugin(): InstalledPluginRecord {
+  return {
+    ...makePlugin(['prompt:inject']),
+    id: 'route-switch-plugin',
+    title: 'Route Switch Plugin',
+    source: '/tmp/route-switch',
+    manifest: {
+      name: 'route-switch-plugin',
+      version: '1.0.0',
+      description: 'A second restricted plugin fixture.',
+      od: {
+        kind: 'scenario',
+        capabilities: ['prompt:inject', 'net:http'],
+      },
+    },
+    fsPath: '/tmp/route-switch',
+  };
+}
+
 function makeConnectorOnlyPlugin(capabilitiesGranted: string[]): InstalledPluginRecord {
   return {
     ...makePlugin(capabilitiesGranted),
@@ -114,13 +133,18 @@ function makePipelinePlugin(capabilitiesGranted: string[]): InstalledPluginRecor
 }
 
 let currentPlugin: InstalledPluginRecord;
+let routeSwitchPlugin: InstalledPluginRecord;
 let fetchMock: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   currentPlugin = makePlugin(['prompt:inject']);
+  routeSwitchPlugin = makeRouteSwitchPlugin();
   fetchMock = vi.fn(async (url, init) => {
     if (url === '/api/plugins/sample-plugin' && !init) {
       return new Response(JSON.stringify(currentPlugin), { status: 200 });
+    }
+    if (url === '/api/plugins/route-switch-plugin' && !init) {
+      return new Response(JSON.stringify(routeSwitchPlugin), { status: 200 });
     }
     if (url === '/api/plugins/sample-plugin/trust') {
       const body = JSON.parse(String(init?.body)) as {
@@ -149,6 +173,26 @@ beforeEach(() => {
         capabilitiesGranted: currentPlugin.capabilitiesGranted,
         plugin: currentPlugin,
       }), { status: body.action === 'grant' ? 201 : 200 });
+    }
+    if (url === '/api/plugins/route-switch-plugin/trust') {
+      const body = JSON.parse(String(init?.body)) as {
+        action: 'grant' | 'revoke';
+        capabilities: string[];
+      };
+      routeSwitchPlugin = {
+        ...routeSwitchPlugin,
+        capabilitiesGranted: Array.from(new Set([
+          ...routeSwitchPlugin.capabilitiesGranted,
+          ...body.capabilities,
+        ])).sort(),
+      };
+      return new Response(JSON.stringify({
+        ok: true,
+        id: routeSwitchPlugin.id,
+        action: body.action,
+        capabilitiesGranted: routeSwitchPlugin.capabilitiesGranted,
+        plugin: routeSwitchPlugin,
+      }), { status: 201 });
     }
     throw new Error(`unexpected fetch ${url}`);
   });
@@ -319,6 +363,35 @@ describe('PluginDetailView trust controls', () => {
       expect.objectContaining({
         method: 'POST',
         body: JSON.stringify({ capabilities: ['genui:form'], action: 'grant' }),
+      }),
+    );
+  });
+
+  it('does not carry pending trust selection across plugin detail route changes', async () => {
+    const { rerender } = render(<PluginDetailView pluginId="sample-plugin" />);
+
+    fireEvent.click(await screen.findByLabelText('fs:read'));
+    expect(screen.getByText('1 grantable · 0 revokable')).toBeTruthy();
+
+    rerender(<PluginDetailView pluginId="route-switch-plugin" />);
+
+    const http = await screen.findByLabelText('net:http');
+    await waitFor(() => {
+      expect(screen.queryByText('1 grantable · 0 revokable')).toBeNull();
+    });
+    expect(screen.getByRole('button', { name: 'Grant selected capabilities' })).toHaveProperty('disabled', true);
+
+    fireEvent.click(http);
+    fireEvent.click(screen.getByRole('button', { name: 'Grant selected capabilities' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('plugin-capability-net:http').textContent).toContain('Granted');
+    });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      '/api/plugins/route-switch-plugin/trust',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ capabilities: ['net:http'], action: 'grant' }),
       }),
     );
   });

--- a/apps/web/tests/components/PluginDetailView.test.tsx
+++ b/apps/web/tests/components/PluginDetailView.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { InstalledPluginRecord } from '@open-design/contracts';
+import { PluginDetailView } from '../../src/components/PluginDetailView';
+
+vi.mock('../../src/router', () => ({
+  navigate: vi.fn(),
+}));
+
+function makePlugin(capabilitiesGranted: string[]): InstalledPluginRecord {
+  return {
+    id: 'sample-plugin',
+    title: 'Sample Plugin',
+    version: '1.0.0',
+    sourceKind: 'local',
+    source: '/tmp/sample',
+    trust: 'restricted',
+    capabilitiesGranted,
+    manifest: {
+      name: 'sample-plugin',
+      version: '1.0.0',
+      description: 'A restricted plugin fixture.',
+      od: {
+        kind: 'scenario',
+        capabilities: ['prompt:inject', 'fs:read'],
+      },
+    },
+    fsPath: '/tmp/sample',
+    installedAt: 0,
+    updatedAt: 0,
+  };
+}
+
+let currentPlugin: InstalledPluginRecord;
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  currentPlugin = makePlugin(['prompt:inject']);
+  fetchMock = vi.fn(async (url, init) => {
+    if (url === '/api/plugins/sample-plugin' && !init) {
+      return new Response(JSON.stringify(currentPlugin), { status: 200 });
+    }
+    if (url === '/api/plugins/sample-plugin/trust') {
+      const body = JSON.parse(String(init?.body)) as {
+        action: 'grant' | 'revoke';
+        capabilities: string[];
+      };
+      if (body.action === 'grant') {
+        currentPlugin = {
+          ...currentPlugin,
+          capabilitiesGranted: Array.from(new Set([
+            ...currentPlugin.capabilitiesGranted,
+            ...body.capabilities,
+          ])).sort(),
+        };
+      } else {
+        const drop = new Set(body.capabilities);
+        currentPlugin = {
+          ...currentPlugin,
+          capabilitiesGranted: currentPlugin.capabilitiesGranted.filter((cap) => !drop.has(cap)),
+        };
+      }
+      return new Response(JSON.stringify({
+        ok: true,
+        id: currentPlugin.id,
+        action: body.action,
+        capabilitiesGranted: currentPlugin.capabilitiesGranted,
+        plugin: currentPlugin,
+      }), { status: body.action === 'grant' ? 201 : 200 });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  });
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  cleanup();
+});
+
+describe('PluginDetailView trust controls', () => {
+  it('grants a requested capability and refreshes the row state', async () => {
+    render(<PluginDetailView pluginId="sample-plugin" />);
+
+    const fsRead = await screen.findByLabelText('fs:read');
+    expect(screen.getByTestId('plugin-capability-fs:read').textContent).toContain('Requested');
+
+    fireEvent.click(fsRead);
+    fireEvent.click(screen.getByRole('button', { name: 'Grant selected capabilities' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('plugin-capability-fs:read').textContent).toContain('Granted');
+    });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      '/api/plugins/sample-plugin/trust',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ capabilities: ['fs:read'], action: 'grant' }),
+      }),
+    );
+  });
+
+  it('revokes a granted capability and refreshes the row state', async () => {
+    currentPlugin = makePlugin(['prompt:inject', 'fs:read']);
+
+    render(<PluginDetailView pluginId="sample-plugin" />);
+
+    const fsRead = await screen.findByLabelText('fs:read');
+    expect(screen.getByTestId('plugin-capability-fs:read').textContent).toContain('Granted');
+
+    fireEvent.click(fsRead);
+    fireEvent.click(screen.getByRole('button', { name: 'Revoke selected capabilities' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('plugin-capability-fs:read').textContent).toContain('Requested');
+    });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      '/api/plugins/sample-plugin/trust',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ capabilities: ['fs:read'], action: 'revoke' }),
+      }),
+    );
+  });
+});

--- a/apps/web/tests/components/PluginDetailView.test.tsx
+++ b/apps/web/tests/components/PluginDetailView.test.tsx
@@ -50,6 +50,69 @@ function makeConnectorOnlyPlugin(capabilitiesGranted: string[]): InstalledPlugin
   };
 }
 
+// Fixture matrix mirroring the daemon `requiredCapabilities()` derivation —
+// each manifest declares a required capability only through an implied
+// section (no duplicate entry in `od.capabilities`), so the checklist must
+// derive a grantable row or the restricted plugin is stuck on the CLI path.
+function makeMcpOnlyPlugin(capabilitiesGranted: string[]): InstalledPluginRecord {
+  return {
+    ...makePlugin(capabilitiesGranted),
+    manifest: {
+      name: 'sample-plugin',
+      version: '1.0.0',
+      description: 'A restricted MCP-context plugin fixture.',
+      od: {
+        kind: 'scenario',
+        context: {
+          mcp: [{ name: 'figma' }],
+        },
+      },
+    },
+  };
+}
+
+function makeGenuiComponentPlugin(capabilitiesGranted: string[]): InstalledPluginRecord {
+  return {
+    ...makePlugin(capabilitiesGranted),
+    manifest: {
+      name: 'sample-plugin',
+      version: '1.0.0',
+      description: 'A restricted GenUI custom-component plugin fixture.',
+      od: {
+        kind: 'scenario',
+        genui: {
+          surfaces: [
+            {
+              id: 'critique-panel',
+              kind: 'form',
+              persist: 'run',
+              component: { path: './surfaces/critique-panel.tsx' },
+            },
+          ],
+        },
+        capabilities: ['genui:custom-component'],
+      },
+    },
+  };
+}
+
+function makePipelinePlugin(capabilitiesGranted: string[]): InstalledPluginRecord {
+  return {
+    ...makePlugin(capabilitiesGranted),
+    manifest: {
+      name: 'sample-plugin',
+      version: '1.0.0',
+      description: 'A restricted pipeline plugin fixture.',
+      od: {
+        kind: 'scenario',
+        pipeline: {
+          stages: [{ id: 'draft', atoms: ['generate'] }],
+        },
+      },
+    },
+  };
+}
+
 let currentPlugin: InstalledPluginRecord;
 let fetchMock: ReturnType<typeof vi.fn>;
 
@@ -164,5 +227,64 @@ describe('PluginDetailView trust controls', () => {
         body: JSON.stringify({ capabilities: ['connector:slack'], action: 'grant' }),
       }),
     );
+  });
+
+  it('grants a capability derived from an MCP context server', async () => {
+    currentPlugin = makeMcpOnlyPlugin(['prompt:inject']);
+
+    render(<PluginDetailView pluginId="sample-plugin" />);
+
+    const figma = await screen.findByLabelText('mcp:figma');
+    expect(screen.getByTestId('plugin-capability-mcp:figma').textContent).toContain('Requested');
+
+    fireEvent.click(figma);
+    fireEvent.click(screen.getByRole('button', { name: 'Grant selected capabilities' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('plugin-capability-mcp:figma').textContent).toContain('Granted');
+    });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      '/api/plugins/sample-plugin/trust',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ capabilities: ['mcp:figma'], action: 'grant' }),
+      }),
+    );
+  });
+
+  it('derives a GenUI surface kind row and grants the custom-component capability', async () => {
+    currentPlugin = makeGenuiComponentPlugin(['prompt:inject']);
+
+    render(<PluginDetailView pluginId="sample-plugin" />);
+
+    // The surface kind feeds `genui:<kind>` (mirroring the daemon resolver)
+    // and the manifest-declared `genui:custom-component` is the grantable row.
+    await screen.findByLabelText('genui:custom-component');
+    expect(screen.getByTestId('plugin-capability-genui:form')).toBeTruthy();
+
+    fireEvent.click(screen.getByLabelText('genui:custom-component'));
+    fireEvent.click(screen.getByRole('button', { name: 'Grant selected capabilities' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('plugin-capability-genui:custom-component').textContent,
+      ).toContain('Granted');
+    });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      '/api/plugins/sample-plugin/trust',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ capabilities: ['genui:custom-component'], action: 'grant' }),
+      }),
+    );
+  });
+
+  it('derives a pipeline:* row from declared pipeline stages', async () => {
+    currentPlugin = makePipelinePlugin(['prompt:inject']);
+
+    render(<PluginDetailView pluginId="sample-plugin" />);
+
+    await screen.findByLabelText('pipeline:*');
+    expect(screen.getByTestId('plugin-capability-pipeline:*').textContent).toContain('Requested');
   });
 });

--- a/apps/web/tests/components/PluginDetailView.test.tsx
+++ b/apps/web/tests/components/PluginDetailView.test.tsx
@@ -33,6 +33,23 @@ function makePlugin(capabilitiesGranted: string[]): InstalledPluginRecord {
   };
 }
 
+function makeConnectorOnlyPlugin(capabilitiesGranted: string[]): InstalledPluginRecord {
+  return {
+    ...makePlugin(capabilitiesGranted),
+    manifest: {
+      name: 'sample-plugin',
+      version: '1.0.0',
+      description: 'A restricted connector plugin fixture.',
+      od: {
+        kind: 'scenario',
+        connectors: {
+          required: [{ id: 'slack', tools: ['channels.list'] }],
+        },
+      },
+    },
+  };
+}
+
 let currentPlugin: InstalledPluginRecord;
 let fetchMock: ReturnType<typeof vi.fn>;
 
@@ -121,6 +138,30 @@ describe('PluginDetailView trust controls', () => {
       expect.objectContaining({
         method: 'POST',
         body: JSON.stringify({ capabilities: ['fs:read'], action: 'revoke' }),
+      }),
+    );
+  });
+
+  it('grants a capability derived from required connectors', async () => {
+    currentPlugin = makeConnectorOnlyPlugin(['prompt:inject']);
+
+    render(<PluginDetailView pluginId="sample-plugin" />);
+
+    const slack = await screen.findByLabelText('connector:slack');
+    expect(screen.getByTestId('plugin-capability-connector:slack').textContent).toContain('Requested');
+    expect(screen.getByRole('button', { name: 'Grant selected capabilities' })).toHaveProperty('disabled', true);
+
+    fireEvent.click(slack);
+    fireEvent.click(screen.getByRole('button', { name: 'Grant selected capabilities' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('plugin-capability-connector:slack').textContent).toContain('Granted');
+    });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      '/api/plugins/sample-plugin/trust',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ capabilities: ['connector:slack'], action: 'grant' }),
       }),
     );
   });

--- a/apps/web/tests/components/PluginDetailView.test.tsx
+++ b/apps/web/tests/components/PluginDetailView.test.tsx
@@ -279,12 +279,47 @@ describe('PluginDetailView trust controls', () => {
     );
   });
 
-  it('derives a pipeline:* row from declared pipeline stages', async () => {
+  it('derives and grants GenUI surface-kind and pipeline capabilities', async () => {
     currentPlugin = makePipelinePlugin(['prompt:inject']);
 
     render(<PluginDetailView pluginId="sample-plugin" />);
 
-    await screen.findByLabelText('pipeline:*');
+    const pipeline = await screen.findByLabelText('pipeline:*');
     expect(screen.getByTestId('plugin-capability-pipeline:*').textContent).toContain('Requested');
+
+    fireEvent.click(pipeline);
+    fireEvent.click(screen.getByRole('button', { name: 'Grant selected capabilities' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('plugin-capability-pipeline:*').textContent).toContain('Granted');
+    });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      '/api/plugins/sample-plugin/trust',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ capabilities: ['pipeline:*'], action: 'grant' }),
+      }),
+    );
+
+    cleanup();
+    currentPlugin = makeGenuiComponentPlugin(['prompt:inject']);
+    render(<PluginDetailView pluginId="sample-plugin" />);
+
+    const genuiForm = await screen.findByLabelText('genui:form');
+    expect(screen.getByTestId('plugin-capability-genui:form').textContent).toContain('Requested');
+
+    fireEvent.click(genuiForm);
+    fireEvent.click(screen.getByRole('button', { name: 'Grant selected capabilities' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('plugin-capability-genui:form').textContent).toContain('Granted');
+    });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      '/api/plugins/sample-plugin/trust',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ capabilities: ['genui:form'], action: 'grant' }),
+      }),
+    );
   });
 });

--- a/apps/web/tests/state/projects.test.ts
+++ b/apps/web/tests/state/projects.test.ts
@@ -3,6 +3,7 @@ import {
   applyPlugin,
   contributeGeneratedPluginToOpenDesign,
   createPluginShareProject,
+  grantPluginCapabilities,
   importFolderProject,
   installGeneratedPluginFolder,
   listPlugins,
@@ -55,6 +56,71 @@ describe('applyPlugin', () => {
       inputs: {},
       grantCaps: [],
       locale: 'zh-CN',
+    });
+  });
+});
+
+describe('grantPluginCapabilities', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('posts selected capabilities to the daemon trust endpoint', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(
+      JSON.stringify({
+        ok: true,
+        id: 'sample-plugin',
+        action: 'grant',
+        capabilitiesGranted: ['fs:read'],
+        plugin: {
+          id: 'sample-plugin',
+          title: 'Sample Plugin',
+          version: '1.0.0',
+          sourceKind: 'local',
+          source: '/tmp/sample',
+          trust: 'restricted',
+          capabilitiesGranted: ['fs:read'],
+          manifest: { name: 'sample-plugin', version: '1.0.0' },
+          fsPath: '/tmp/sample',
+          installedAt: 0,
+          updatedAt: 0,
+        },
+      }),
+      { status: 201, headers: { 'content-type': 'application/json' } },
+    ));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const outcome = await grantPluginCapabilities('sample-plugin', ['fs:read'], 'grant');
+
+    expect(outcome.ok).toBe(true);
+    expect(outcome.capabilitiesGranted).toEqual(['fs:read']);
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/plugins/sample-plugin/trust',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ capabilities: ['fs:read'], action: 'grant' }),
+      }),
+    );
+  });
+
+  it('preserves daemon validation errors for rejected capabilities', async () => {
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response(
+      JSON.stringify({
+        error: {
+          message: 'Capability validation failed',
+          data: { errors: ['bad-cap'] },
+        },
+      }),
+      { status: 400, headers: { 'content-type': 'application/json' } },
+    )));
+
+    const outcome = await grantPluginCapabilities('sample-plugin', ['bad-cap'], 'revoke');
+
+    expect(outcome).toMatchObject({
+      ok: false,
+      message: 'Capability validation failed: bad-cap',
+      capabilitiesGranted: [],
     });
   });
 });


### PR DESCRIPTION
Fixes #2147

## Why

Plugin registry Phase 3 already has the daemon trust endpoint and CLI flow for granting or revoking plugin capabilities, but the marketplace detail page still rendered declared capabilities as a read-only list. This PR closes that UI gap so users can review requested capabilities and grant or revoke them without leaving the app.

## What users will see

`PluginDetailView` now shows each declared capability as a checklist row with a visible `Requested` or `Granted` state. Selecting capabilities enables explicit `Grant selected capabilities` and `Revoke selected capabilities` actions; successful mutations refresh the displayed grant state from the daemon response and validation failures are surfaced inline.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached from this headless workspace. The UI change is covered by `PluginDetailView.test.tsx` and uses existing app tokens/classes.

## Bug fix verification

-

## Validation

- `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/state/projects.test.ts tests/components/PluginDetailView.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`

Note: this workspace is on Node v26.0.0 while the repo declares `node: ~24`, so pnpm emitted engine warnings during validation; the commands above completed successfully.