### PR TITLE
fix: validate plugin connector refs in doctor

### DIFF
--- a/apps/daemon/src/plugins/connector-probe.ts
+++ b/apps/daemon/src/plugins/connector-probe.ts
@@ -1,0 +1,34 @@
+import type { ConnectorCatalogDefinition, ConnectorStatus } from '../connectors/catalog.js';
+import type { ConnectorService } from '../connectors/service.js';
+import type { ConnectorCatalogEntry, ConnectorGateStatus, ConnectorProbe } from './connector-gate.js';
+
+function toGateStatus(status: ConnectorStatus): ConnectorGateStatus {
+  if (status === 'connected') return 'connected';
+  if (status === 'available') return 'pending';
+  return 'unavailable';
+}
+
+function catalogEntryFor(
+  service: ConnectorService,
+  definition: ConnectorCatalogDefinition,
+): ConnectorCatalogEntry {
+  const status = service.getStatus(definition);
+  return {
+    id: definition.id,
+    status: toGateStatus(status.status),
+    ...(status.accountLabel === undefined ? {} : { accountLabel: status.accountLabel }),
+    allowedToolNames: definition.allowedToolNames.slice(),
+  };
+}
+
+export function buildConnectorProbe(service: ConnectorService): ConnectorProbe {
+  const entries = new Map<string, ConnectorCatalogEntry>();
+  for (const definition of service.listFastDefinitions()) {
+    entries.set(definition.id, catalogEntryFor(service, definition));
+  }
+  return {
+    get(connectorId: string) {
+      return entries.get(connectorId);
+    },
+  };
+}

--- a/apps/daemon/src/plugins/index.ts
+++ b/apps/daemon/src/plugins/index.ts
@@ -85,6 +85,7 @@ export * from './atoms/rewrite-plan.js';
 export * from './atoms/token-map.js';
 export * from './bundled.js';
 export * from './connector-gate.js';
+export * from './connector-probe.js';
 export * from './export.js';
 export * from './doctor.js';
 export * from './installer.js';

--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -8,10 +8,12 @@ import { ArtifactRegressionError } from './artifact-stub-guard.js';
 import { listDesignSystems } from './design-systems.js';
 import {
   FIRST_PARTY_ATOMS,
+  buildConnectorProbe,
   getInstalledPlugin,
   listInstalledPlugins,
   resolvePluginSnapshot,
 } from './plugins/index.js';
+import { connectorService } from './connectors/service.js';
 import type { RouteDeps } from './server-context.js';
 import { listSkills } from './skills.js';
 
@@ -234,6 +236,7 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
             typeof designSystemId === 'string' && designSystemId.length > 0
               ? { id: designSystemId }
               : undefined,
+          connectorProbe: buildConnectorProbe(connectorService),
         });
         if (resolved && !resolved.ok) {
           if (!explicitPlugin) {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -70,6 +70,7 @@ import {
 import {
   applyDiffReviewDecisionToCwd,
   applyPlugin,
+  buildConnectorProbe,
   defaultBundledRoot,
   doctorPlugin,
   FIRST_PARTY_ATOMS,
@@ -328,7 +329,7 @@ import { registerChatRoutes } from './chat-routes.js';
 import { registerStaticResourceRoutes } from './static-resource-routes.js';
 import { registerRoutineRoutes, routineDbRowToContract } from './routine-routes.js';
 import { assertServerContextSatisfiesRoutes } from './route-context-contract.js';
-import { configureConnectorCredentialStore, ConnectorServiceError, FileConnectorCredentialStore } from './connectors/service.js';
+import { configureConnectorCredentialStore, connectorService, ConnectorServiceError, FileConnectorCredentialStore } from './connectors/service.js';
 import { composioConnectorProvider } from './connectors/composio.js';
 import { configureComposioConfigStore } from './connectors/composio-config.js';
 import { CHAT_TOOL_ENDPOINTS, CHAT_TOOL_OPERATIONS, toolTokenRegistry } from './tool-tokens.js';
@@ -4628,7 +4629,8 @@ export async function startServer({
       const locale = typeof body.locale === 'string' ? body.locale : undefined;
 
       const registry = await loadPluginRegistryView();
-      const computed = applyPlugin({ plugin, inputs, registry, locale });
+      const connectorProbe = buildConnectorProbe(connectorService);
+      const computed = applyPlugin({ plugin, inputs, registry, locale, connectorProbe });
       // Plan §3.B2 — apply-time grants are merged into the snapshot's
       // capabilitiesGranted so the §9 capability gate sees them, but
       // they are NOT written back to installed_plugins.capabilities_granted.
@@ -4712,6 +4714,7 @@ export async function startServer({
       });
 
       const registry = await loadPluginRegistryView();
+      const connectorProbe = buildConnectorProbe(connectorService);
       const resolved = resolvePluginSnapshot({
         db,
         body: {
@@ -4728,6 +4731,7 @@ export async function startServer({
         projectId: id,
         conversationId: cid,
         registry,
+        connectorProbe,
       });
       if (resolved && !resolved.ok) {
         res.status(resolved.status).json(resolved.body);
@@ -4760,7 +4764,8 @@ export async function startServer({
       const plugin = getInstalledPlugin(db, req.params.id);
       if (!plugin) return res.status(404).json({ error: 'plugin not found' });
       const registry = await loadPluginRegistryView();
-      const report = doctorPlugin(plugin, registry);
+      const connectorProbe = buildConnectorProbe(connectorService);
+      const report = doctorPlugin(plugin, registry, { connectorProbe });
       res.json(report);
     } catch (err) {
       res.status(500).json({ error: String(err) });
@@ -9549,6 +9554,7 @@ export async function startServer({
           ? req.body.conversationId
           : null,
         registry: registryView,
+        connectorProbe: buildConnectorProbe(connectorService),
       });
       if (resolved && !resolved.ok) {
         if (!explicitPlugin) {

--- a/apps/daemon/tests/plugins-doctor-route.test.ts
+++ b/apps/daemon/tests/plugins-doctor-route.test.ts
@@ -1,0 +1,115 @@
+import http from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { startServer } from '../src/server.js';
+
+type StartedServer = { server: http.Server; url: string };
+
+let server: http.Server | undefined;
+let baseUrl = '';
+let pluginRoot = '';
+
+async function closeServer(): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    if (!server) return resolve(undefined);
+    server.close((error?: Error) => (error ? reject(error) : resolve(undefined)));
+  });
+  server = undefined;
+}
+
+async function installPlugin(source: string): Promise<void> {
+  const resp = await fetch(`${baseUrl}/api/plugins/install`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', accept: 'text/event-stream' },
+    body: JSON.stringify({ source }),
+  });
+  expect(resp.status).toBe(200);
+  if (!resp.body) throw new Error('install stream missing body');
+
+  const reader = resp.body.getReader();
+  const decoder = new TextDecoder();
+  let raw = '';
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    raw += decoder.decode(value, { stream: true });
+  }
+  if (!raw.includes('event: success')) {
+    throw new Error(`installer did not finalize:\n${raw}`);
+  }
+}
+
+beforeEach(async () => {
+  pluginRoot = await mkdtemp(path.join(os.tmpdir(), 'od-doctor-route-'));
+  const started = await startServer({ port: 0, returnServer: true }) as StartedServer;
+  server = started.server;
+  baseUrl = started.url;
+});
+
+afterEach(async () => {
+  await closeServer();
+  await rm(pluginRoot, { recursive: true, force: true });
+});
+
+describe('POST /api/plugins/:id/doctor', () => {
+  it('fails plugins that require a connector missing from the live connector catalog', async () => {
+    const pluginId = `missing-connector-${randomUUID()}`;
+    const folder = path.join(pluginRoot, pluginId);
+    await mkdir(folder, { recursive: true });
+    await writeFile(
+      path.join(folder, 'open-design.json'),
+      JSON.stringify({
+        $schema: 'https://open-design.ai/schemas/plugin.v1.json',
+        name: pluginId,
+        title: 'Missing Connector Fixture',
+        version: '1.0.0',
+        description: 'requires a connector that is not in the catalog',
+        license: 'MIT',
+        od: {
+          kind: 'skill',
+          taskKind: 'new-generation',
+          useCase: { query: 'Check connectors.' },
+          connectors: {
+            required: [
+              { id: 'definitely_missing_connector', tools: ['missing_tool'] },
+            ],
+          },
+          capabilities: [
+            'prompt:inject',
+            'connector:definitely_missing_connector',
+          ],
+        },
+      }),
+    );
+    await writeFile(
+      path.join(folder, 'SKILL.md'),
+      `---\nname: ${pluginId}\ndescription: missing connector fixture\n---\n# Fixture\n`,
+    );
+    await installPlugin(folder);
+
+    const resp = await fetch(`${baseUrl}/api/plugins/${encodeURIComponent(pluginId)}/doctor`, {
+      method: 'POST',
+    });
+
+    expect(resp.status).toBe(200);
+    const report = await resp.json() as {
+      ok: boolean;
+      issues: Array<{ severity: string; code: string; message: string; field?: string }>;
+    };
+    expect(report.ok).toBe(false);
+    expect(report.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: 'error',
+          code: 'connector.unknown-connector',
+          field: 'od.connectors',
+        }),
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
Fixes #2165

## Why

This closes the F7 cleanup gap from `docs/plans/plugins-implementation.md`: plugin manifests could declare `od.connectors.required[]` entries for connectors that do not exist in the daemon connector catalog, and `/api/plugins/:id/doctor` still reported the plugin as OK.

The pain is a validation mismatch: the pure doctor code already knew how to fail unknown connector refs when given a probe, but the server never constructed or passed that probe. That meant authors could ship a plugin that only failed later when connector bindings were resolved.

## What users will see

`od plugin doctor` / the daemon doctor endpoint now fails plugins that require a connector id missing from the live connector catalog. Apply/project/run plugin resolution also uses the same connector catalog snapshot, so doctor and apply paths agree on connector existence and status.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — changed validation behavior for existing plugin doctor/apply HTTP paths; no response shape change
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — existing plugin doctor calls now fail unknown required connector ids instead of passing them
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No UI surface.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/plugins-doctor-route.test.ts`
- Did the test go red on `main` and green on this branch? yes. Before the fix, the new test failed with `expected true to be false` because doctor returned `ok: true`; after wiring the connector probe, it passes.

## Validation

- `pnpm install` (needed because this fresh checkout had no `node_modules`; warned that current Node is `v26.0.0` while the repo wants `~24`)
- `pnpm exec vitest run -c vitest.config.ts tests/plugins-doctor-route.test.ts` from `apps/daemon` — pass
- `pnpm exec vitest run -c vitest.config.ts tests/plugins-connector-gate.test.ts tests/plugins-doctor-route.test.ts tests/plugins-dod-e2e.test.ts tests/plugins-headless-run.test.ts` from `apps/daemon` — pass, 21 tests
- `pnpm guard` — pass
- `pnpm --filter @open-design/daemon typecheck` — pass
- `pnpm --filter @open-design/daemon test` — one unrelated/flaky failure: `tests/chat-route.test.ts > /api/chat > keeps Claude stream runs alive while structured output is still flowing` timed out waiting for status in the full concurrent suite. Rerunning that exact test in isolation with `pnpm exec vitest run -c vitest.config.ts tests/chat-route.test.ts -t "keeps Claude stream runs alive while structured output is still flowing"` passed.
