### PR TITLE
fix: polish Windows chrome and selected rows

### DIFF
--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -1217,6 +1217,7 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
     minWidth: 900,
     show: true,
     title: "Open Design",
+    autoHideMenuBar: true,
     ...MAC_WINDOW_CHROME,
     webPreferences: {
       additionalArguments: osLocaleAdditionalArguments(options.osLocale),

--- a/apps/desktop/tests/main/window-chrome.test.ts
+++ b/apps/desktop/tests/main/window-chrome.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, test } from "vitest";
+
+const runtimeSource = readFileSync(new URL("../../src/main/runtime.ts", import.meta.url), "utf8");
+
+describe("desktop BrowserWindow chrome options", () => {
+  test("hides Electron's native menu bar in the Windows/Linux app window", () => {
+    const browserWindowBlock = /new BrowserWindow\(\{([\s\S]*?)title: "Open Design",([\s\S]*?)webPreferences:/.exec(runtimeSource)?.[0] ?? "";
+
+    expect(browserWindowBlock).toContain("autoHideMenuBar: true");
+  });
+});

--- a/apps/web/src/styles/primitives.css
+++ b/apps/web/src/styles/primitives.css
@@ -247,7 +247,12 @@ textarea { resize: vertical; font-family: inherit; }
 }
 .od-select-option.selected {
   color: var(--text);
+  background: color-mix(in srgb, var(--selected) 9%, var(--bg-subtle));
   font-weight: 600;
+}
+.od-select-option.selected:hover:not(:disabled),
+.od-select-option.selected.active:not(:disabled) {
+  background: color-mix(in srgb, var(--selected) 13%, var(--bg-subtle));
 }
 .od-select-option:disabled {
   opacity: 0.45;

--- a/apps/web/src/styles/workspace/mention-home.css
+++ b/apps/web/src/styles/workspace/mention-home.css
@@ -673,7 +673,10 @@
    narrow viewports. The kicker/title/subtitle should keep their
    normal width but reserve right-side gutter for the chrome. */
 .modal-settings .modal-head {
+  position: relative;
+  z-index: 2;
   padding-right: calc(var(--modal-padding) + 56px);
+  background: var(--bg-elevated);
 }
 
 /* Compact settings header: place subtitle on the same line as the h2
@@ -1005,6 +1008,8 @@
   display: none;
 }
 .settings-content {
+  position: relative;
+  z-index: 1;
   min-width: 0;
   min-height: 0;
   /* Top inset matches `.settings-sidebar`'s `padding-top: 16` so the first

--- a/apps/web/tests/styles/settings-polish.test.ts
+++ b/apps/web/tests/styles/settings-polish.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const indexCss = readFileSync(new URL('../../src/index.css', import.meta.url), 'utf8');
+const primitivesCss = readFileSync(new URL('../../src/styles/primitives.css', import.meta.url), 'utf8');
+const mentionHomeCss = readFileSync(new URL('../../src/styles/workspace/mention-home.css', import.meta.url), 'utf8');
+
+function cssBlock(css: string, selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = new RegExp(`${escaped}\\s*\\{([^}]*)\\}`).exec(css);
+  if (!match) throw new Error(`Missing CSS block for ${selector}`);
+  return match[1] ?? '';
+}
+
+function ruleValue(block: string, property: string): string {
+  const match = new RegExp(`(?:^|;)\\s*${property}:\\s*([^;]+);`).exec(block);
+  if (!match) throw new Error(`Missing CSS property ${property}`);
+  return match[1]!.trim();
+}
+
+describe('settings polish CSS', () => {
+  it('keeps the global stylesheet as an import manifest after the CSS split', () => {
+    const nonImportLines = indexCss
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && !line.startsWith('@import'));
+
+    expect(nonImportLines).toEqual([]);
+  });
+
+  it('paints selected select options as a full-row state, not text-only emphasis', () => {
+    const option = cssBlock(primitivesCss, '.od-select-option');
+    const selected = cssBlock(primitivesCss, '.od-select-option.selected');
+    const selectedHover = cssBlock(primitivesCss, '.od-select-option.selected:hover:not(:disabled),\n.od-select-option.selected.active:not(:disabled)');
+
+    expect(ruleValue(option, 'width')).toBe('100%');
+    expect(ruleValue(option, 'display')).toBe('grid');
+    expect(ruleValue(selected, 'background')).toBe('color-mix(in srgb, var(--selected) 9%, var(--bg-subtle))');
+    expect(ruleValue(selectedHover, 'background')).toBe('color-mix(in srgb, var(--selected) 13%, var(--bg-subtle))');
+  });
+
+  it('keeps the settings header above scrolling content rows', () => {
+    const head = cssBlock(mentionHomeCss, '.modal-settings .modal-head');
+    const body = cssBlock(mentionHomeCss, '.modal-settings .modal-body');
+    const content = cssBlock(mentionHomeCss, '.settings-content');
+
+    expect(ruleValue(body, 'overflow')).toBe('hidden');
+    expect(ruleValue(head, 'position')).toBe('relative');
+    expect(ruleValue(head, 'z-index')).toBe('2');
+    expect(ruleValue(head, 'background')).toBe('var(--bg-elevated)');
+    expect(ruleValue(content, 'position')).toBe('relative');
+    expect(ruleValue(content, 'z-index')).toBe('1');
+  });
+});


### PR DESCRIPTION
Fixes #1836

## Why

I picked this up from the Windows UI polish report in #1836. The user-facing pain is that the Windows desktop window showed extra native chrome that consumed vertical space, while selected option rows in shared settings/select UI read as text-only emphasis instead of a full-row selection state. The settings header also needed an explicit stacking boundary so scrolling content cannot visually cover it.

## What users will see

On Windows, the native Electron menu bar is hidden by default, removing the extra top strip from the desktop client. In settings/select lists, the currently selected option now gets a full-width row highlight, and the settings header stays visually above scrolling content.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached: this runner cannot launch or capture a real Windows desktop client. The changed behavior is covered by regression tests for the BrowserWindow menu-bar option and the CSS row/header invariants.

## Bug fix verification

- Test paths that reproduce the bug:
  - `apps/desktop/tests/main/window-chrome.test.ts`
  - `apps/web/tests/styles/settings-polish.test.ts`
- Did the tests go red on `main` and green on this branch? yes. `window-chrome.test.ts` failed before the `autoHideMenuBar` fix; `settings-polish.test.ts` failed before the selected-row background and settings header/content z-index fixes.

## Validation

- `pnpm install` (completed; warned that current Node is `v26.0.0` while repo expects `~24`)
- `pnpm --filter @open-design/desktop test -- --run tests/main/window-chrome.test.ts`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/styles/settings-polish.test.ts`
- `pnpm --filter @open-design/desktop typecheck`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`
