### PR TITLE
fix(web): expand skill mention picker

### DIFF
--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -1029,21 +1029,8 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
     const filteredSkills = mention
       ? skills
           .filter((s) => !stagedSkillIds.has(s.id))
-          .filter((s) => {
-            if (!mentionQuery) return true;
-            return [
-              s.id,
-              s.name,
-              s.description,
-              s.mode,
-              s.surface ?? '',
-              ...s.triggers,
-            ]
-              .join(' ')
-              .toLowerCase()
-              .includes(mentionQuery);
-          })
-          .slice(0, 8)
+          .filter((s) => skillMatchesQuery(s, mentionQuery))
+          .sort((a, b) => skillMentionRank(a, mentionQuery) - skillMentionRank(b, mentionQuery))
       : [];
 
     return (
@@ -2077,6 +2064,15 @@ function skillMatchesQuery(skill: SkillSummary, query: string): boolean {
     .join(' ')
     .toLowerCase()
     .includes(q);
+}
+
+function skillMentionRank(skill: SkillSummary, query: string): number {
+  const q = query.trim().toLowerCase();
+  if (!q) return 1;
+  const id = skill.id.toLowerCase();
+  const name = skill.name.toLowerCase();
+  if (id.startsWith(q) || name.startsWith(q)) return 0;
+  return 1;
 }
 
 function mcpServerMatchesQuery(server: McpServerConfig, query: string): boolean {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2283,9 +2283,9 @@ a.avatar-item:visited {
 /* -------- Mention popover ------------------------------------------- */
 .mention-popover {
   order: -1;
-  flex: 0 0 clamp(248px, 38vh, 320px);
+  flex: 0 0 clamp(300px, 52vh, 480px);
   min-height: 248px;
-  max-height: 320px;
+  max-height: min(480px, 72vh);
   margin: 0 0 6px;
   background: var(--bg-panel);
   border: 1px solid var(--border);

--- a/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
+++ b/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
@@ -54,6 +54,24 @@ const SKILL = {
   aggregatesExamples: false,
 };
 
+function makeSkill(overrides: Partial<typeof SKILL>): typeof SKILL {
+  return {
+    ...SKILL,
+    id: overrides.id ?? SKILL.id,
+    name: overrides.name ?? SKILL.name,
+    description: overrides.description ?? SKILL.description,
+    triggers: overrides.triggers ?? SKILL.triggers,
+    mode: overrides.mode ?? SKILL.mode,
+    previewType: overrides.previewType ?? SKILL.previewType,
+    designSystemRequired: overrides.designSystemRequired ?? SKILL.designSystemRequired,
+    defaultFor: overrides.defaultFor ?? SKILL.defaultFor,
+    upstream: overrides.upstream ?? SKILL.upstream,
+    hasBody: overrides.hasBody ?? SKILL.hasBody,
+    examplePrompt: overrides.examplePrompt ?? SKILL.examplePrompt,
+    aggregatesExamples: overrides.aggregatesExamples ?? SKILL.aggregatesExamples,
+  };
+}
+
 const MCP_SERVER = {
   id: 'slack',
   label: 'Slack MCP',
@@ -207,6 +225,47 @@ describe('ChatComposer context pickers', () => {
     await waitFor(() => expect(onProjectSkillChange).toHaveBeenCalledWith('deck-builder'));
     expect(input.value).toBe('@Deck Builder ');
     expect(screen.getByTestId('chat-composer-mention-overlay').textContent).toContain('@Deck Builder');
+  });
+
+  it('shows all matching skills and ranks exact prefix matches first', async () => {
+    skills = [
+      makeSkill({
+        id: 'story-brief',
+        name: 'Story Brief',
+        description: 'Use when planning audit work.',
+        triggers: ['writing'],
+      }),
+      ...Array.from({ length: 9 }, (_, index) =>
+        makeSkill({
+          id: `audit-helper-${index + 1}`,
+          name: `Audit Helper ${index + 1}`,
+          description: `Audit support workflow ${index + 1}.`,
+          triggers: [`audit-${index + 1}`],
+        }),
+      ),
+      makeSkill({
+        id: 'accessibility-review',
+        name: 'Accessibility Review',
+        description: 'Audit accessible interaction details.',
+        triggers: ['a11y-audit'],
+      }),
+    ];
+    renderComposer();
+    const input = screen.getByTestId('chat-composer-input') as HTMLTextAreaElement;
+
+    fireEvent.change(input, {
+      target: { value: '@audit', selectionStart: 6 },
+    });
+
+    await waitFor(() => expect(screen.getByText('Audit Helper 9')).toBeTruthy());
+    const skillNames = Array.from(
+      screen.getByTestId('mention-popover').querySelectorAll('.mention-item strong'),
+      (node) => node.textContent,
+    );
+
+    expect(skillNames).toContain('Audit Helper 9');
+    expect(skillNames.indexOf('Audit Helper 1')).toBeLessThan(skillNames.indexOf('Story Brief'));
+    expect(skillNames.indexOf('Audit Helper 9')).toBeLessThan(skillNames.indexOf('Accessibility Review'));
   });
 
   it('applies a plugin from @ search and keeps the plugin token inline', async () => {


### PR DESCRIPTION
Fixes #1661

## Why

Users with more than a handful of installed skills could not discover or reach skills outside the first eight `@` mention results. This PR follows the scoped first pass from the issue discussion: keep the existing composer filtering, prioritize exact/prefix skill matches, and remove the skill-only result cap while leaving other mention surfaces scoped separately.

## What users will see

Typing `@` in the chat composer can now show the full matching skill list inside the existing scrollable popover. When users keep typing, skills whose id or display name starts with the typed query appear ahead of weaker description/trigger matches.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Local visual check captured the Skills tab at `e2e/.tmp/skill-picker-skills-tab.png`: `Audit Helper 1` through `Audit Helper 12` render before the weaker `Story Brief` description match. I could not attach the image from this headless CLI session because the available upload paths reject binary files, but the screenshot was generated through `pnpm tools-dev run web` + Playwright against this branch.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/ChatComposer.context-pickers.test.tsx`
- Did the test go red on `main` and green on this branch? yes — on the upstream/main-based branch before the source fix, the new test failed because `Audit Helper 9` was missing from the eight-item-capped list; after the fix, the same test passes.

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass
- `pnpm --filter @open-design/web typecheck` — pass
- `pnpm exec vitest run -c vitest.config.ts tests/components/ChatComposer.context-pickers.test.tsx` from `apps/web` — pass, 6/6 tests
- `pnpm --filter @open-design/web build` — pass
- `pnpm --filter @open-design/web test` — fails in this runtime due unrelated Node 26/jsdom `window.localStorage` availability in `AssistantMessage.test.tsx`, `DesignsTab.select-mode.test.tsx`, `SettingsDialog.execution.test.tsx`, `WorkspaceTabsBar.test.tsx`, and `Theater/hooks/useCritiqueTheaterEnabled.test.tsx`; the new ChatComposer context picker test passes inside that run. The repo pins Node `~24`, but this machine only exposes Node 26.
