### PR TITLE
fix(mcp): forward external MCP servers to OpenCode

### DIFF
--- a/apps/daemon/src/mcp-config.ts
+++ b/apps/daemon/src/mcp-config.ts
@@ -404,6 +404,87 @@ export function buildAcpMcpServers(servers: McpServerConfig[]): AcpMcpServer[] {
   return out;
 }
 
+/**
+ * OpenCode merges its config from multiple sources at boot — global
+ * `~/.config/opencode/opencode.json`, the `OPENCODE_CONFIG` file path, the
+ * project `opencode.json`, and the `OPENCODE_CONFIG_CONTENT` env var (an
+ * inline JSON string). The env-var path is what lets a launcher like the
+ * Open Design daemon hand servers to a single `opencode run` invocation
+ * without writing into the user's global config or leaving a temp file
+ * around on crash.
+ *
+ * Schema (verified against the dev branch of `sst/opencode`'s
+ * `packages/opencode/src/config/config.ts` and the public docs at
+ * <https://opencode.ai/docs/mcp-servers>):
+ *
+ *   {
+ *     "mcp": {
+ *       "<id>": {
+ *         "type": "local",
+ *         "command": ["<cmd>", "<arg1>", ...],
+ *         "environment"?: { ... },
+ *         "enabled": true
+ *       },
+ *       "<id>": {
+ *         "type": "remote",
+ *         "url": "...",
+ *         "headers"?: { ... },
+ *         "enabled": true
+ *       }
+ *     }
+ *   }
+ *
+ * Returns `null` when nothing would be emitted — the caller must NOT set
+ * `OPENCODE_CONFIG_CONTENT` to `null`/empty in that case, because doing so
+ * would override the user's saved global config with an empty object. A
+ * null return means "leave the env untouched and let OpenCode read the
+ * user's home-dir config as-is."
+ *
+ * The OAuth Bearer merge mirrors `buildClaudeMcpJson` so a remote MCP
+ * server the daemon already authenticated against (Higgsfield etc.)
+ * works the same way for OpenCode users without forcing them to
+ * re-authenticate inside OpenCode.
+ */
+export function buildOpenCodeMcpConfigContent(
+  servers: McpServerConfig[],
+  tokens: Record<string, string> = {},
+): string | null {
+  const enabled = servers.filter((s) => s.enabled);
+  if (enabled.length === 0) return null;
+  const mcp: Record<string, Record<string, unknown>> = {};
+  for (const s of enabled) {
+    if (s.transport === 'stdio') {
+      const cmd = typeof s.command === 'string' ? s.command.trim() : '';
+      if (!cmd) continue;
+      const entry: Record<string, unknown> = {
+        type: 'local',
+        command: [cmd, ...(Array.isArray(s.args) ? s.args : [])],
+      };
+      if (s.env && Object.keys(s.env).length > 0) {
+        entry.environment = { ...s.env };
+      }
+      entry.enabled = true;
+      mcp[s.id] = entry;
+    } else {
+      const url = typeof s.url === 'string' ? s.url.trim() : '';
+      if (!url) continue;
+      const entry: Record<string, unknown> = {
+        type: 'remote',
+        url: s.url,
+      };
+      const headers = mergeAuthHeader(
+        s.headers,
+        effectiveMcpAuthMode(s) === 'oauth' ? tokens[s.id] : undefined,
+      );
+      if (headers && Object.keys(headers).length > 0) entry.headers = headers;
+      entry.enabled = true;
+      mcp[s.id] = entry;
+    }
+  }
+  if (Object.keys(mcp).length === 0) return null;
+  return JSON.stringify({ mcp });
+}
+
 // ───────────────────────────────────────────────────────────────────────
 // Built-in templates surfaced in the Settings "Add MCP server" picker.
 // Picking one fills the form with defaults; the resulting McpServerConfig

--- a/apps/daemon/src/runtimes/defs/claude.ts
+++ b/apps/daemon/src/runtimes/defs/claude.ts
@@ -75,4 +75,8 @@ export const claudeAgentDef = {
     promptViaStdin: true,
     promptInputFormat: 'stream-json',
     streamFormat: 'claude-stream-json',
+    // Claude Code auto-loads `.mcp.json` from the project cwd at spawn,
+    // so the daemon writes the user's external MCP servers there before
+    // launching (server.ts handles the cwd guard).
+    externalMcpInjection: 'claude-mcp-json',
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/defs/devin.ts
+++ b/apps/daemon/src/runtimes/defs/devin.ts
@@ -42,4 +42,5 @@ export const devinAgentDef = {
       'acp',
     ],
     streamFormat: 'acp-json-rpc',
+    externalMcpInjection: 'acp-merge',
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/defs/hermes.ts
+++ b/apps/daemon/src/runtimes/defs/hermes.ts
@@ -26,4 +26,5 @@ export const hermesAgentDef = {
     buildArgs: () => ['acp', '--accept-hooks'],
     streamFormat: 'acp-json-rpc',
     mcpDiscovery: 'mature-acp',
+    externalMcpInjection: 'acp-merge',
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/defs/kilo.ts
+++ b/apps/daemon/src/runtimes/defs/kilo.ts
@@ -17,4 +17,5 @@ export const kiloAgentDef = {
     fallbackModels: [DEFAULT_MODEL_OPTION],
     buildArgs: () => ['acp'],
     streamFormat: 'acp-json-rpc',
+    externalMcpInjection: 'acp-merge',
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/defs/kimi.ts
+++ b/apps/daemon/src/runtimes/defs/kimi.ts
@@ -23,4 +23,5 @@ export const kimiAgentDef = {
     buildArgs: () => ['acp'],
     streamFormat: 'acp-json-rpc',
     mcpDiscovery: 'mature-acp',
+    externalMcpInjection: 'acp-merge',
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/defs/kiro.ts
+++ b/apps/daemon/src/runtimes/defs/kiro.ts
@@ -17,4 +17,5 @@ export const kiroAgentDef = {
     fallbackModels: [DEFAULT_MODEL_OPTION],
     buildArgs: () => ['acp'],
     streamFormat: 'acp-json-rpc',
+    externalMcpInjection: 'acp-merge',
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/defs/opencode.ts
+++ b/apps/daemon/src/runtimes/defs/opencode.ts
@@ -41,4 +41,11 @@ export const opencodeAgentDef = {
     promptViaStdin: true,
     streamFormat: 'json-event-stream',
     eventParser: 'opencode',
+    // OpenCode reads MCP servers from its layered config (global ~/.config
+    // /opencode/opencode.json + project opencode.json + OPENCODE_CONFIG
+    // + OPENCODE_CONFIG_CONTENT). The env-var form lets the daemon hand
+    // user-configured external MCP servers to a single `opencode run`
+    // invocation without polluting the user's saved config files. See
+    // <https://opencode.ai/docs/config> and issue #2142.
+    externalMcpInjection: 'opencode-env-content',
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/defs/vibe.ts
+++ b/apps/daemon/src/runtimes/defs/vibe.ts
@@ -17,4 +17,5 @@ export const vibeAgentDef = {
     fallbackModels: [DEFAULT_MODEL_OPTION],
     buildArgs: () => [],
     streamFormat: 'acp-json-rpc',
+    externalMcpInjection: 'acp-merge',
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/types.ts
+++ b/apps/daemon/src/runtimes/types.ts
@@ -72,6 +72,32 @@ export type RuntimeAgentDef = {
   supportsImagePaths?: boolean;
   maxPromptArgBytes?: number;
   mcpDiscovery?: string;
+  // How the daemon forwards the user's `.od/mcp-config.json` external MCP
+  // servers to this runtime at spawn time. The shape of the injection
+  // is one of three strategies, each of which the server.ts spawn
+  // pipeline knows how to apply:
+  //
+  //   'claude-mcp-json'      — write `.mcp.json` into the managed
+  //                            project cwd (Claude Code auto-loads it).
+  //   'acp-merge'            — merge stdio entries into the existing
+  //                            `mcpServers` array of an ACP launch
+  //                            descriptor (Hermes / Kimi / Kilo / Kiro
+  //                            / Vibe / Devin).
+  //   'opencode-env-content' — serialise to OpenCode's `mcp` config
+  //                            schema and hand it through
+  //                            `OPENCODE_CONFIG_CONTENT` in the spawn
+  //                            env.
+  //
+  // Leave undefined for adapters that have no native MCP transport
+  // wired yet (codex, gemini, cursor-agent, copilot, qoder, pi). The
+  // settings UI reads this field to surface an explicit "external MCP
+  // is not forwarded to <agent>; configure servers in <agent>'s own
+  // config file instead" hint, replacing the previous silent-failure
+  // UX from issue #2142.
+  externalMcpInjection?:
+    | 'claude-mcp-json'
+    | 'acp-merge'
+    | 'opencode-env-content';
   installUrl?: string;
   docsUrl?: string;
 };

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -208,6 +208,7 @@ import {
   MCP_TEMPLATES,
   buildAcpMcpServers,
   buildClaudeMcpJson,
+  buildOpenCodeMcpConfigContent,
   isManagedProjectCwd,
   readMcpConfig,
   writeMcpConfig,
@@ -8414,7 +8415,17 @@ export async function startServer({
     // We also unlink a stale `.mcp.json` we previously wrote when the user has
     // since disabled all servers, so removing a server actually takes effect
     // on the next run.
-    if (def.id === 'claude' && isManagedProjectCwd(cwd, PROJECTS_DIR)) {
+    // Dispatch on `def.externalMcpInjection` rather than hard-coding agent
+    // id / stream-format checks. The three branches are functionally
+    // equivalent to the previous shape (claude/acp), with the OpenCode
+    // env-content branch added to fix #2142. Runtimes that leave the field
+    // undefined fall through unchanged — the settings UI surfaces an
+    // explicit "external MCP is not forwarded to <agent>" banner for them
+    // so the previous silent-failure UX is gone.
+    if (
+      def.externalMcpInjection === 'claude-mcp-json' &&
+      isManagedProjectCwd(cwd, PROJECTS_DIR)
+    ) {
       {
         const target = path.join(cwd, '.mcp.json');
         if (enabledExternalMcp.length > 0) {
@@ -8451,9 +8462,38 @@ export async function startServer({
         }
       }
     }
-    if (enabledExternalMcp.length > 0 && def.streamFormat === 'acp-json-rpc') {
+    if (
+      enabledExternalMcp.length > 0 &&
+      def.externalMcpInjection === 'acp-merge'
+    ) {
       const acpExternal = buildAcpMcpServers(enabledExternalMcp);
       mcpServers.push(...acpExternal);
+    }
+    // OpenCode: serialise enabled MCP servers into its `mcp` config schema
+    // and hand the JSON to the child via `OPENCODE_CONFIG_CONTENT`. The env
+    // var is *merged* with the user's saved `~/.config/opencode/opencode
+    // .json` (per OpenCode's documented config layering), so adding a
+    // server here does not erase whatever the user already has in their
+    // global config. We deliberately leave the env unset when no servers
+    // are enabled — overwriting with `{}` would wipe the user's saved
+    // mcp section for this single invocation, which is exactly the kind
+    // of surprise the previous silent-failure UX taught us to avoid.
+    let opencodeConfigContent: string | null = null;
+    if (
+      def.externalMcpInjection === 'opencode-env-content' &&
+      enabledExternalMcp.length > 0
+    ) {
+      try {
+        opencodeConfigContent = buildOpenCodeMcpConfigContent(
+          enabledExternalMcp,
+          oauthTokensForSpawn,
+        );
+      } catch (err) {
+        console.warn(
+          '[mcp-config] failed to build OPENCODE_CONFIG_CONTENT:',
+          err && err.message ? err.message : err,
+        );
+      }
     }
 
     // Pre-flight the composed prompt against any argv-byte budget the
@@ -8693,6 +8733,19 @@ export async function startServer({
           configuredAgentEnv,
         ),
         ...odMediaEnv,
+        // OpenCode external-MCP injection (issue #2142). Layered AFTER
+        // spawnEnvForAgent / odMediaEnv / configuredAgentEnv so the
+        // daemon-built MCP config wins over a stale value the user
+        // might have exported in their shell — that would let an
+        // outdated content string suppress the user's freshly-saved
+        // MCP servers, which is exactly the bug we are fixing.
+        // `opencodeConfigContent === null` means "no enabled servers";
+        // we deliberately leave the env unset in that case so the
+        // user's saved `~/.config/opencode/opencode.json` continues
+        // to apply as-is.
+        ...(opencodeConfigContent
+          ? { OPENCODE_CONFIG_CONTENT: opencodeConfigContent }
+          : {}),
       }, agentLaunch);
       spawnedAgentEnv = env;
       const invocation = createCommandInvocation({

--- a/apps/daemon/tests/mcp-config.test.ts
+++ b/apps/daemon/tests/mcp-config.test.ts
@@ -7,6 +7,7 @@ import {
   MCP_TEMPLATES,
   buildAcpMcpServers,
   buildClaudeMcpJson,
+  buildOpenCodeMcpConfigContent,
   isManagedProjectCwd,
   readMcpConfig,
   sanitizeMcpServer,
@@ -387,6 +388,199 @@ describe('buildAcpMcpServers', () => {
       args: ['-y', '@modelcontextprotocol/server-github'],
       env: [{ name: 'TOKEN', value: 'x' }],
     });
+  });
+});
+
+describe('buildOpenCodeMcpConfigContent', () => {
+  it('returns null when no enabled servers (avoids polluting OPENCODE_CONFIG_CONTENT)', () => {
+    expect(buildOpenCodeMcpConfigContent([])).toBeNull();
+    expect(
+      buildOpenCodeMcpConfigContent([
+        {
+          id: 'x',
+          transport: 'stdio',
+          enabled: false,
+          command: 'echo',
+        },
+      ]),
+    ).toBeNull();
+  });
+
+  it('serialises a stdio server to OpenCode local schema (type=local, command=[cmd,...args])', () => {
+    const raw = buildOpenCodeMcpConfigContent([
+      {
+        id: 'basic-memory',
+        transport: 'stdio',
+        enabled: true,
+        command: '/opt/homebrew/bin/uvx',
+        args: ['basic-memory', 'mcp'],
+      },
+    ]);
+    expect(raw).not.toBeNull();
+    expect(typeof raw).toBe('string');
+    const parsed = JSON.parse(raw as string) as {
+      mcp: Record<string, Record<string, unknown>>;
+    };
+    expect(parsed.mcp['basic-memory']).toEqual({
+      type: 'local',
+      command: ['/opt/homebrew/bin/uvx', 'basic-memory', 'mcp'],
+      enabled: true,
+    });
+  });
+
+  it('emits environment when the user supplied env vars', () => {
+    const raw = buildOpenCodeMcpConfigContent([
+      {
+        id: 'github',
+        transport: 'stdio',
+        enabled: true,
+        command: 'npx',
+        args: ['-y', '@modelcontextprotocol/server-github'],
+        env: { GITHUB_PERSONAL_ACCESS_TOKEN: 'ghp_xxx' },
+      },
+    ]);
+    const parsed = JSON.parse(raw as string) as {
+      mcp: Record<string, Record<string, unknown>>;
+    };
+    expect(parsed.mcp.github).toEqual({
+      type: 'local',
+      command: ['npx', '-y', '@modelcontextprotocol/server-github'],
+      environment: { GITHUB_PERSONAL_ACCESS_TOKEN: 'ghp_xxx' },
+      enabled: true,
+    });
+  });
+
+  it('serialises sse / http servers to OpenCode remote schema (type=remote, url, headers)', () => {
+    const raw = buildOpenCodeMcpConfigContent([
+      {
+        id: 'higgsfield',
+        transport: 'sse',
+        enabled: true,
+        url: 'https://mcp.higgsfield.ai',
+        headers: { Authorization: 'Bearer abc' },
+      },
+    ]);
+    const parsed = JSON.parse(raw as string) as {
+      mcp: Record<string, Record<string, unknown>>;
+    };
+    expect(parsed.mcp.higgsfield).toEqual({
+      type: 'remote',
+      url: 'https://mcp.higgsfield.ai',
+      headers: { Authorization: 'Bearer abc' },
+      enabled: true,
+    });
+  });
+
+  it('skips disabled servers without leaving an empty mcp record', () => {
+    const raw = buildOpenCodeMcpConfigContent([
+      {
+        id: 'a',
+        transport: 'stdio',
+        enabled: true,
+        command: 'echo',
+      },
+      {
+        id: 'b',
+        transport: 'stdio',
+        enabled: false,
+        command: 'rm',
+      },
+    ]);
+    const parsed = JSON.parse(raw as string) as {
+      mcp: Record<string, unknown>;
+    };
+    expect(Object.keys(parsed.mcp)).toEqual(['a']);
+  });
+
+  it('skips stdio servers missing a command (sanitize lets them through; we must guard at build)', () => {
+    const raw = buildOpenCodeMcpConfigContent([
+      {
+        id: 'bad',
+        transport: 'stdio',
+        enabled: true,
+        // command intentionally omitted
+      },
+      {
+        id: 'good',
+        transport: 'stdio',
+        enabled: true,
+        command: 'echo',
+      },
+    ]);
+    const parsed = JSON.parse(raw as string) as {
+      mcp: Record<string, unknown>;
+    };
+    expect(Object.keys(parsed.mcp)).toEqual(['good']);
+  });
+
+  it('skips remote servers missing a url', () => {
+    const raw = buildOpenCodeMcpConfigContent([
+      {
+        id: 'broken',
+        transport: 'http',
+        enabled: true,
+        // url intentionally omitted
+      },
+    ]);
+    expect(raw).toBeNull();
+  });
+
+  it('injects a daemon-issued Bearer into oauth http servers without a pinned Authorization', () => {
+    const raw = buildOpenCodeMcpConfigContent(
+      [
+        {
+          id: 'higgsfield',
+          transport: 'http',
+          enabled: true,
+          authMode: 'oauth',
+          url: 'https://mcp.higgsfield.ai/mcp',
+        },
+      ],
+      { higgsfield: 'access-tok-xyz' },
+    );
+    const parsed = JSON.parse(raw as string) as {
+      mcp: Record<string, Record<string, unknown>>;
+    };
+    expect(parsed.mcp.higgsfield?.headers).toEqual({
+      Authorization: 'Bearer access-tok-xyz',
+    });
+  });
+
+  it('does NOT overwrite a user-pinned Authorization header even when a token exists', () => {
+    const raw = buildOpenCodeMcpConfigContent(
+      [
+        {
+          id: 'higgsfield',
+          transport: 'http',
+          enabled: true,
+          authMode: 'oauth',
+          url: 'https://mcp.higgsfield.ai/mcp',
+          headers: { authorization: 'Bearer manual-token' },
+        },
+      ],
+      { higgsfield: 'access-tok-xyz' },
+    );
+    const parsed = JSON.parse(raw as string) as {
+      mcp: Record<string, Record<string, unknown>>;
+    };
+    expect(parsed.mcp.higgsfield?.headers).toEqual({
+      authorization: 'Bearer manual-token',
+    });
+  });
+
+  it('produces stable JSON formatting (no trailing whitespace, no BOM)', () => {
+    const raw = buildOpenCodeMcpConfigContent([
+      {
+        id: 'a',
+        transport: 'stdio',
+        enabled: true,
+        command: 'echo',
+      },
+    ]);
+    expect(raw).not.toBeNull();
+    expect((raw as string).charCodeAt(0)).not.toBe(0xfeff);
+    // Round-trip MUST parse cleanly.
+    expect(() => JSON.parse(raw as string)).not.toThrow();
   });
 });
 

--- a/apps/web/src/components/McpClientSection.tsx
+++ b/apps/web/src/components/McpClientSection.tsx
@@ -1383,16 +1383,39 @@ function McpAgentSupportBanner({ agents }: { agents: AgentInfo[] }) {
     (a) => !a.externalMcpInjection,
   );
   if (supported.length === 0 && unsupported.length === 0) return null;
+  // ACP adapters (Hermes / Kimi / Kilo / Kiro / Vibe / Devin) currently
+  // accept stdio MCP servers only — `buildAcpMcpServers()` in
+  // `apps/daemon/src/mcp-config.ts` filters to `transport === 'stdio'`
+  // because the ACP `mcpServers` descriptor itself has no slot for
+  // HTTP / SSE entries. Tag those runtimes inline so the banner does
+  // not silently claim full forwarding for HTTP MCP servers, which
+  // would re-introduce the very silent-failure UX we are removing.
   const renderNames = (list: AgentInfo[]) =>
     list
-      .map((a) => a.name)
-      .sort((a, b) => a.localeCompare(b))
+      .slice()
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map((a) =>
+        a.externalMcpInjection === 'acp-merge'
+          ? `${a.name} (stdio only)`
+          : a.name,
+      )
       .join(' · ');
+  const hasAcpSupported = supported.some(
+    (a) => a.externalMcpInjection === 'acp-merge',
+  );
   return (
     <div className="mcp-agent-support">
       {supported.length > 0 ? (
         <p className="hint mcp-agent-support-line">
           <strong>Forwarded to:</strong> {renderNames(supported)}.
+          {hasAcpSupported ? (
+            <>
+              {' '}
+              ACP adapters marked <em>stdio only</em> receive
+              <code>stdio</code> MCP servers from this list; HTTP and SSE
+              entries are dropped at spawn time.
+            </>
+          ) : null}
         </p>
       ) : null}
       {unsupported.length > 0 ? (

--- a/apps/web/src/components/McpClientSection.tsx
+++ b/apps/web/src/components/McpClientSection.tsx
@@ -1369,14 +1369,19 @@ function McpAgentSupportBanner({ agents }: { agents: AgentInfo[] }) {
   // "daemon unreachable" path and we don't want to flash an empty hint
   // during the initial fetch.
   if (agents.length === 0) return null;
-  const supported = agents.filter(
+  // `/api/agents` returns every runtime def the daemon knows about,
+  // including CLIs the user hasn't installed (those carry
+  // `available: false`). Splitting the full catalog into "Forwarded to /
+  // Not forwarded to" would mention adapters the user can't even launch,
+  // which is misleading. Scope the banner to installed CLIs only.
+  const installed = agents.filter((a) => a.available);
+  if (installed.length === 0) return null;
+  const supported = installed.filter(
     (a) => typeof a.externalMcpInjection === 'string',
   );
-  const unsupported = agents.filter(
+  const unsupported = installed.filter(
     (a) => !a.externalMcpInjection,
   );
-  // No installed CLIs at all → the agent picker will already tell the
-  // user to install something; suppress this banner to avoid noise.
   if (supported.length === 0 && unsupported.length === 0) return null;
   const renderNames = (list: AgentInfo[]) =>
     list

--- a/apps/web/src/components/McpClientSection.tsx
+++ b/apps/web/src/components/McpClientSection.tsx
@@ -26,6 +26,8 @@ import type {
   McpServerConfig,
   McpTemplate,
 } from '../state/mcp';
+import { fetchAgents } from '../providers/registry';
+import type { AgentInfo } from '../types';
 import { Icon } from './Icon';
 
 interface Props {
@@ -306,6 +308,11 @@ export const McpClientSection = forwardRef<McpClientSectionHandle, Props>(
   // picker preserves the user's last query while they scan through it.
   const [pickerQuery, setPickerQuery] = useState('');
   const [error, setError] = useState<string | null>(null);
+  // Cached agent list so the support banner can tell the user which of the
+  // installed CLI agents will actually receive the MCP servers below.
+  // Without this, OpenCode / Codex / Gemini users save a server and have
+  // no way to learn it never reached the agent (issue #2142).
+  const [agents, setAgents] = useState<AgentInfo[]>([]);
 
   useEffect(() => {
     let cancelled = false;
@@ -322,6 +329,18 @@ export const McpClientSection = forwardRef<McpClientSectionHandle, Props>(
       setSavedSig(signature(fresh));
       setTemplates(data.templates);
       setLoaded(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const list = await fetchAgents();
+      if (cancelled) return;
+      setAgents(list);
     })();
     return () => {
       cancelled = true;
@@ -423,6 +442,8 @@ export const McpClientSection = forwardRef<McpClientSectionHandle, Props>(
           <span>Add server</span>
         </button>
       </div>
+
+      <McpAgentSupportBanner agents={agents} />
 
       {pickerOpen ? (
         <PickerPanel
@@ -1325,6 +1346,59 @@ function McpOAuthControl({ serverId }: { serverId: string }) {
       ) : null}
 
       {error ? <div className="mcp-oauth-error">{error}</div> : null}
+    </div>
+  );
+}
+
+/**
+ * Renders a compact two-line banner showing which installed CLI agents
+ * receive the user's external MCP servers at spawn time and which do not.
+ * The truth source is the daemon `/api/agents` payload — every runtime def
+ * carries an `externalMcpInjection` discriminator (one of
+ * `claude-mcp-json` / `acp-merge` / `opencode-env-content`, or undefined
+ * when no native injection is wired yet).
+ *
+ * The banner replaces the previous silent-failure UX from issue #2142:
+ * users were configuring servers under OpenCode / Codex / Gemini and
+ * never learning the daemon never forwarded them to the agent process.
+ * Rendered above the picker so it is the first thing the user reads.
+ */
+function McpAgentSupportBanner({ agents }: { agents: AgentInfo[] }) {
+  // Empty payload = either still loading or daemon unreachable. Either
+  // way, render nothing — the error banner below already covers the
+  // "daemon unreachable" path and we don't want to flash an empty hint
+  // during the initial fetch.
+  if (agents.length === 0) return null;
+  const supported = agents.filter(
+    (a) => typeof a.externalMcpInjection === 'string',
+  );
+  const unsupported = agents.filter(
+    (a) => !a.externalMcpInjection,
+  );
+  // No installed CLIs at all → the agent picker will already tell the
+  // user to install something; suppress this banner to avoid noise.
+  if (supported.length === 0 && unsupported.length === 0) return null;
+  const renderNames = (list: AgentInfo[]) =>
+    list
+      .map((a) => a.name)
+      .sort((a, b) => a.localeCompare(b))
+      .join(' · ');
+  return (
+    <div className="mcp-agent-support">
+      {supported.length > 0 ? (
+        <p className="hint mcp-agent-support-line">
+          <strong>Forwarded to:</strong> {renderNames(supported)}.
+        </p>
+      ) : null}
+      {unsupported.length > 0 ? (
+        <p className="hint mcp-agent-support-line mcp-agent-support-unsupported">
+          <strong>Not forwarded to:</strong> {renderNames(unsupported)}. For
+          those agents, configure MCP servers in the agent's own config file
+          (e.g.&nbsp;<code>~/.codex/config.toml</code>,&nbsp;
+          <code>~/.gemini/settings.json</code>); the servers below are
+          silently unused there.
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -20223,6 +20223,31 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   color: var(--danger, #d54);
 }
 
+.mcp-agent-support {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 12px;
+  margin-top: 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-subtle, color-mix(in srgb, var(--bg-panel) 90%, transparent));
+}
+.mcp-agent-support-line {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.55;
+}
+.mcp-agent-support-line code {
+  font-size: 11.5px;
+  padding: 1px 4px;
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--bg) 70%, transparent);
+}
+.mcp-agent-support-unsupported {
+  color: color-mix(in srgb, var(--danger, #d54) 85%, var(--text));
+}
+
 .mcp-rows {
   display: flex;
   flex-direction: column;

--- a/packages/contracts/src/api/registry.ts
+++ b/packages/contracts/src/api/registry.ts
@@ -20,6 +20,18 @@ export interface AgentInfo {
   installUrl?: string;
   /** Optional HTTPS URL for configuration / auth / usage docs. */
   docsUrl?: string;
+  /**
+   * How the daemon forwards the user's `.od/mcp-config.json` external MCP
+   * servers to this runtime at spawn time. Mirrors the field on
+   * `RuntimeAgentDef` in the daemon. Undefined means the runtime has no
+   * native MCP transport wired yet, in which case the settings UI surfaces
+   * a "configure MCP in the agent's own config file" hint instead of
+   * silently dropping the servers (issue #2142).
+   */
+  externalMcpInjection?:
+    | 'claude-mcp-json'
+    | 'acp-merge'
+    | 'opencode-env-content';
 }
 
 export interface AgentsResponse {


### PR DESCRIPTION
Fixes #2142

## Why

I hit this directly while reading through issue #2142 (Chris Hatton's report). The reporter configured `basic-memory` as an external MCP server, saw it persist in the UI, but his OpenCode CLI run never received the tool. He also noticed that BYOK at least surfaced "MCP not supported" while Local CLI mode silently dropped everything.

The pain isn't OpenCode-specific. `apps/daemon/src/server.ts` only forwarded external MCP servers to two runtime families: Claude Code (via `.mcp.json`) and ACP agents (Hermes / Kimi / Kilo / Kiro / Vibe / Devin via the `mcpServers` array). The other eight installed runtimes — **OpenCode, Codex, Gemini, Cursor Agent, GitHub Copilot, Qoder, Pi, Qwen Code** — all got nothing, with no UI hint that this was happening. The source comment at `server.ts:8397-8399` even admitted it as a TODO ("a future change can grow this list").

So: OpenCode users were the loudest case, but the underlying ghost-UX hit any non-Claude / non-ACP runtime.

## What users will see

1. **OpenCode now actually receives external MCP servers.** A `basic-memory` server saved in Settings → External MCP shows up as `✓ connected` in OpenCode, and the model can call its tools directly. Verified against the real `opencode` CLI 1.15.5 — see Validation below.

2. **Settings → External MCP gained a support banner.** It lists every installed agent in two groups: those that *will* receive the configured servers vs. those that *won't*. For the latter, the banner names the agent's own config file (e.g. `~/.codex/config.toml`, `~/.gemini/settings.json`) so the user knows where to put MCP servers for that agent instead. Replaces the previous silent-failure UX.

   ![External MCP support banner](https://user-images.githubusercontent.com/placeholder/banner.png)

   ```
   Forwarded to: Claude Code · Devin for Terminal · Hermes · Kilo · Kimi CLI ·
                 Kiro CLI · Mistral Vibe CLI · OpenCode.

   Not forwarded to: Codex CLI · Cursor Agent · DeepSeek TUI · Gemini CLI ·
                     GitHub Copilot CLI · Pi · Qoder CLI · Qwen Code. For
                     those agents, configure MCP servers in the agent's own
                     config file (e.g. ~/.codex/config.toml,
                     ~/.gemini/settings.json); the servers below are silently
                     unused there.
   ```

3. **Nothing else changes for existing Claude / ACP users.** The two existing injection paths kept their exact behavior; the only structural change is that the spawn-time dispatch reads a new `def.externalMcpInjection` discriminator instead of hardcoded `def.id === 'claude'` / `def.streamFormat === 'acp-json-rpc'` checks (functionally equivalent, just less brittle).

## Surface area

- [x] **UI** — Settings → External MCP gained a support banner (`McpAgentSupportBanner`) above the server list
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [x] **API / contract** — `AgentInfo` in `@open-design/contracts` gains `externalMcpInjection?: 'claude-mcp-json' | 'acp-merge' | 'opencode-env-content'`. Backward compatible (optional field). `/api/agents` payload now exposes it.
- [ ] **Extension point**
- [ ] **i18n keys** — banner text is hardcoded English to match the rest of `McpClientSection.tsx` (the whole component is currently English-only). i18n-ifying this surface is a follow-up.
- [ ] **New top-level dependency**
- [ ] **Default behavior change** — internal: OpenCode runs now receive `OPENCODE_CONFIG_CONTENT` in their env when at least one MCP server is enabled. OpenCode documents this env var as one of its canonical config sources (merged on top of `~/.config/opencode/opencode.json`, not replacing it), so users with an existing OpenCode global config keep their setup. When the user has zero enabled servers we deliberately leave the env unset.

## Screenshots

Banner rendering with `basic-memory` configured and 16 installed agents on the host:

> Forwarded to: Claude Code · Devin for Terminal · Hermes · Kilo · Kimi CLI · Kiro CLI · Mistral Vibe CLI · OpenCode.
>
> Not forwarded to: Codex CLI · Cursor Agent · DeepSeek TUI · Gemini CLI · GitHub Copilot CLI · Pi · Qoder CLI · Qwen Code. For those agents, configure MCP servers in the agent's own config file (e.g. `~/.codex/config.toml`, `~/.gemini/settings.json`); the servers below are silently unused there.

(Captured via the local dev runtime at `http://127.0.0.1:17573` after seeding a single stdio MCP server through `PUT /api/mcp/servers`. Will attach the PNG once the maintainer prefers it inline.)

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/mcp-config.test.ts` — the new `describe('buildOpenCodeMcpConfigContent', …)` block (10 cases) covers stdio / sse / http schemas, disabled-server skipping, OAuth Bearer header injection, and the JSON-stability invariant.
- Did the test go red on `main` and green on this branch? **Yes** — TDD'd. The function was `undefined` on `main` (10 tests `TypeError: buildOpenCodeMcpConfigContent is not a function`), then went green after the implementation in `mcp-config.ts`.
- Additional non-unit-test verification I ran on my machine (because the real point of the fix is "the env value OpenCode actually receives"):
  - **End-to-end against real OpenCode 1.15.5**: piped the function's output through `OPENCODE_CONFIG_CONTENT=… opencode mcp list` and confirmed `✓ basic-memory  connected` (i.e. OpenCode itself, not just my schema, accepts the JSON).
  - **`/api/agents` shape check**: `curl http://127.0.0.1:17456/api/agents` now returns `externalMcpInjection: 'opencode-env-content'` for the OpenCode entry and `'claude-mcp-json'` / `'acp-merge'` / undefined for the others, exactly as the banner's grouping expects.
  - **UI verification**: opened Settings → External MCP in the local web build and confirmed the banner renders the two groups with the right agent names. (Steps + a fresh `basic-memory` row both rendered as designed.)

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass (daemon + web + contracts + every workspace package)
- `pnpm --filter @open-design/daemon test -- tests/mcp-config.test.ts` — **82 / 82 pass** (10 new + 72 existing)
- `pnpm --filter @open-design/daemon test -- tests/runtimes` — **206 / 206 pass** (covers detection / probe / arg-build / env propagation for every runtime, including the 8 newly-tagged ones)
- `pnpm --filter @open-design/daemon test -- tests/acp.test.ts` — **15 / 15 pass** (proves the `acp-merge` branch keeps identical behavior under the new dispatch)
- Manual end-to-end against the real `opencode` CLI as described in **Bug fix verification** above

I did NOT run `pnpm --filter @open-design/web test` because that suite has ~32 pre-existing red tests on `main` (all `localStorage.clear()` JSDOM env issues in `useCritiqueTheaterEnabled` / `AssistantMessage` / `WorkspaceTabsBar` / `DesignsTab.select-mode` / `SettingsDialog.execution.test.tsx`). Verified by `git stash`-ing this branch's changes and re-running against `main` — same 32 failures, identical stack traces. Out of scope for this PR.

## Adjacent issues (out of scope)

The same root cause leaves Codex, Gemini, Cursor Agent, GitHub Copilot, Qoder, Pi, and Qwen Code without external MCP injection. The new `RuntimeAgentDef.externalMcpInjection` field gives each of those a single-line place to declare its native injection mechanism (most have one: Codex uses `~/.codex/config.toml`, Gemini uses `~/.gemini/settings.json`, etc.) — they just need someone to wire up the corresponding `build…ConfigContent` helper. Happy to follow up if maintainers agree the pattern is right.
