### PR TITLE
feat(daemon): add Phase 2C CLI wrappers

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -148,6 +148,7 @@ const PROJECT_STRING_FLAGS = new Set([
   'daemon-url', 'name', 'skill', 'design-system', 'plugin', 'metadata-json',
   'pending-prompt', 'project', 'conversation', 'message', 'path', 'as',
   'agent', 'model', 'snapshot-id', 'inputs', 'grant-caps', 'editor',
+  'title', 'against',
 ]);
 const PROJECT_BOOLEAN_FLAGS = new Set(['help', 'h', 'json', 'follow']);
 // `od automation …` mirrors the Automations tab. Same surface, same
@@ -742,6 +743,22 @@ function parseFlags(argv, opts = {}) {
     } else {
       out[key] = true;
     }
+  }
+  return out;
+}
+
+function positionalArgs(argv, stringFlags = new Set()) {
+  const out = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a) continue;
+    if (!a.startsWith('--')) {
+      out.push(a);
+      continue;
+    }
+    const eq = a.indexOf('=');
+    const key = eq >= 0 ? a.slice(2, eq) : a.slice(2);
+    if (eq < 0 && stringFlags.has(key)) i++;
   }
   return out;
 }
@@ -4200,6 +4217,7 @@ async function runProject(args) {
     console.log(`Usage:
   od project create [--name "<title>"] [--skill <id>] [--design-system <id>]
                     [--plugin <id>] [--inputs <json>] [--metadata-json <path|->]
+  od project import <baseDir> [--name "<title>"]
   od project list                         List projects.
   od project info <id>                    Print one project.
   od project delete <id>                  Delete a project.
@@ -4304,6 +4322,29 @@ Common options:
       }
       if (flags.json) return process.stdout.write(JSON.stringify(data, null, 2) + '\n');
       console.log(`[project] created ${data.project?.id ?? id} (conversation ${data.conversationId})`);
+      return;
+    }
+    case 'import': {
+      const [baseDir] = positionalArgs(rest, PROJECT_STRING_FLAGS);
+      if (!baseDir) {
+        console.error('Usage: od project import <baseDir> [--name "<title>"]');
+        process.exit(2);
+      }
+      const body = { baseDir };
+      if (typeof flags.name === 'string' && flags.name.length > 0) body.name = flags.name;
+      if (typeof flags.skill === 'string' && flags.skill.length > 0) body.skillId = flags.skill;
+      if (typeof flags['design-system'] === 'string' && flags['design-system'].length > 0) {
+        body.designSystemId = flags['design-system'];
+      }
+      const resp = await fetch(`${base}/api/import/folder`, {
+        method:  'POST',
+        headers: { 'content-type': 'application/json' },
+        body:    JSON.stringify(body),
+      });
+      if (!resp.ok) return structuredHttpFailure(resp);
+      const data = await resp.json();
+      if (flags.json) return process.stdout.write(JSON.stringify(data, null, 2) + '\n');
+      console.log(`[project] imported ${data.project?.id ?? '-'} (conversation ${data.conversationId ?? '-'})`);
       return;
     }
     case 'delete': {
@@ -4532,6 +4573,8 @@ async function runFiles(args) {
   od files upload <projectId> <localpath> [--as <relpath>]
                                                Upload a local file.
   od files delete <projectId> <name>           Delete a project file.
+  od files diff   <projectId> <relpathA> [<relpathB> | --against -]
+                                               Print a unified diff.
 
 Common options:
   --daemon-url <url>   Open Design daemon HTTP base.
@@ -4644,15 +4687,142 @@ Common options:
       console.log(`[files] deleted ${name}`);
       return;
     }
+    case 'diff': {
+      const positional = positionalArgs(rest, PROJECT_STRING_FLAGS);
+      const [id, relA, relB] = positional;
+      const against = typeof flags.against === 'string' ? flags.against : null;
+      if (!id || !relA || (!relB && !against) || (relB && against)) {
+        console.error('Usage: od files diff <projectId> <relpathA> [<relpathB> | --against -]');
+        process.exit(2);
+      }
+      const left = await fetchProjectFileText(base, id, relA);
+      const rightLabel = against ?? relB;
+      const right = against === '-'
+        ? await readStdinUtf8()
+        : await fetchProjectFileText(base, id, rightLabel);
+      const diff = createUnifiedDiff(`a/${relA}`, `b/${rightLabel}`, left, right);
+      if (flags.json) return process.stdout.write(JSON.stringify({ diff }, null, 2) + '\n');
+      process.stdout.write(diff);
+      return;
+    }
     default:
       console.error(`unknown subcommand: od files ${sub}`);
       process.exit(2);
   }
 }
 
+function encodeProjectRelpath(rel) {
+  return String(rel).split('/').map(encodeURIComponent).join('/');
+}
+
+async function fetchProjectFileText(base, id, rel) {
+  const resp = await fetch(
+    `${base}/api/projects/${encodeURIComponent(id)}/files/${encodeProjectRelpath(rel)}`,
+  );
+  if (!resp.ok) return structuredHttpFailure(resp, 'project-not-found');
+  const buf = Buffer.from(await resp.arrayBuffer());
+  return buf.toString('utf8');
+}
+
+async function readStdinUtf8() {
+  const fs = await import('node:fs');
+  return fs.readFileSync(0, 'utf8');
+}
+
+function createUnifiedDiff(leftLabel, rightLabel, leftText, rightText) {
+  if (leftText === rightText) return '';
+  const leftLines = splitDiffLines(leftText);
+  const rightLines = splitDiffLines(rightText);
+  let prefix = 0;
+  while (
+    prefix < leftLines.length
+    && prefix < rightLines.length
+    && leftLines[prefix] === rightLines[prefix]
+  ) {
+    prefix++;
+  }
+  let leftEnd = leftLines.length;
+  let rightEnd = rightLines.length;
+  while (
+    leftEnd > prefix
+    && rightEnd > prefix
+    && leftLines[leftEnd - 1] === rightLines[rightEnd - 1]
+  ) {
+    leftEnd--;
+    rightEnd--;
+  }
+  const oldMid = leftLines.slice(prefix, leftEnd);
+  const newMid = rightLines.slice(prefix, rightEnd);
+  const body = diffLineBody(oldMid, newMid);
+  if (body.length === 0) {
+    body.push(...oldMid.map((line) => `-${line}`), ...newMid.map((line) => `+${line}`));
+  }
+  const oldStart = oldMid.length === 0 ? prefix : prefix + 1;
+  const newStart = newMid.length === 0 ? prefix : prefix + 1;
+  return [
+    `--- ${leftLabel}`,
+    `+++ ${rightLabel}`,
+    `@@ -${formatDiffRange(oldStart, oldMid.length)} +${formatDiffRange(newStart, newMid.length)} @@`,
+    ...body,
+  ].join('\n') + '\n';
+}
+
+function splitDiffLines(text) {
+  const normalized = String(text).replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  if (normalized.length === 0) return [];
+  const lines = normalized.split('\n');
+  if (lines[lines.length - 1] === '') lines.pop();
+  return lines;
+}
+
+function formatDiffRange(start, length) {
+  return length === 1 ? String(start) : `${start},${length}`;
+}
+
+function diffLineBody(oldLines, newLines) {
+  if (oldLines.length === 0) return newLines.map((line) => `+${line}`);
+  if (newLines.length === 0) return oldLines.map((line) => `-${line}`);
+  if (oldLines.length * newLines.length > 1_000_000) {
+    return [...oldLines.map((line) => `-${line}`), ...newLines.map((line) => `+${line}`)];
+  }
+  const width = newLines.length + 1;
+  const lcs = Array.from(
+    { length: oldLines.length + 1 },
+    () => new Uint32Array(width),
+  );
+  for (let i = oldLines.length - 1; i >= 0; i--) {
+    for (let j = newLines.length - 1; j >= 0; j--) {
+      lcs[i][j] = oldLines[i] === newLines[j]
+        ? lcs[i + 1][j + 1] + 1
+        : Math.max(lcs[i + 1][j], lcs[i][j + 1]);
+    }
+  }
+  const out = [];
+  let i = 0;
+  let j = 0;
+  while (i < oldLines.length && j < newLines.length) {
+    if (oldLines[i] === newLines[j]) {
+      out.push(` ${oldLines[i]}`);
+      i++;
+      j++;
+    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+      out.push(`-${oldLines[i]}`);
+      i++;
+    } else {
+      out.push(`+${newLines[j]}`);
+      j++;
+    }
+  }
+  while (i < oldLines.length) out.push(`-${oldLines[i++]}`);
+  while (j < newLines.length) out.push(`+${newLines[j++]}`);
+  return out;
+}
+
 async function runConversation(args) {
   if (args.length === 0 || args[0] === 'help' || args.includes('--help') || args.includes('-h')) {
     console.log(`Usage:
+  od conversation new  <projectId> [--title "<title>"]
+                                           Create a conversation in a project.
   od conversation list <projectId>           List conversations in a project.
   od conversation info <conversationId>      Print one conversation.
 
@@ -4666,6 +4836,25 @@ Common options:
   const flags = parseFlags(rest, { string: PROJECT_STRING_FLAGS, boolean: PROJECT_BOOLEAN_FLAGS });
   const base = (await projectDaemonUrl(flags)).replace(/\/$/, '');
   switch (sub) {
+    case 'new': {
+      const [id] = positionalArgs(rest, PROJECT_STRING_FLAGS);
+      if (!id) {
+        console.error('Usage: od conversation new <projectId> [--title "<title>"]');
+        process.exit(2);
+      }
+      const body = {};
+      if (typeof flags.title === 'string') body.title = flags.title;
+      const resp = await fetch(`${base}/api/projects/${encodeURIComponent(id)}/conversations`, {
+        method:  'POST',
+        headers: { 'content-type': 'application/json' },
+        body:    JSON.stringify(body),
+      });
+      if (!resp.ok) return structuredHttpFailure(resp, 'project-not-found');
+      const data = await resp.json();
+      if (flags.json) return process.stdout.write(JSON.stringify(data, null, 2) + '\n');
+      console.log(`[conversation] created ${data.conversation?.id ?? '-'}`);
+      return;
+    }
     case 'list': {
       const id = rest.find((a) => !a.startsWith('-'));
       if (!id) {

--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -195,6 +195,7 @@ const RECOVERABLE_EXIT_CODES = {
   'snapshot-stale':           72,
   'genui-surface-awaiting':   73,
   'desktop-auth-pending':     74,
+  'desktop-import-token-rejected': 75,
 };
 const PLUGIN_LIST_FILTER_FLAGS = new Set([
   ...PLUGIN_STRING_FLAGS,
@@ -902,19 +903,36 @@ function exitWithStructuredError({ code, message, data }) {
 async function structuredHttpFailure(resp, fallbackCode = 'daemon-not-running') {
   let parsed;
   try { parsed = await resp.json(); } catch { parsed = {}; }
-  const errCode = parsed?.error?.code;
+  const errCode = normalizeRecoverableErrorCode(parsed?.error?.code, parsed?.error?.message);
   if (errCode && errCode in RECOVERABLE_EXIT_CODES) {
     exitWithStructuredError({
       code:    errCode,
       message: parsed.error.message ?? `HTTP ${resp.status}`,
-      data:    parsed.error.data,
+      data:    structuredErrorData(parsed.error),
     });
   }
   exitWithStructuredError({
     code:    fallbackCode,
     message: parsed?.error?.message ?? `HTTP ${resp.status}: ${await resp.text().catch(() => '')}`,
-    data:    parsed?.error?.data,
+    data:    structuredErrorData(parsed?.error),
   });
+}
+
+function normalizeRecoverableErrorCode(code, message) {
+  if (code === 'DESKTOP_AUTH_PENDING') return 'desktop-auth-pending';
+  if (code === 'FORBIDDEN' && /desktop import token rejected/i.test(String(message ?? ''))) {
+    return 'desktop-import-token-rejected';
+  }
+  return code;
+}
+
+function structuredErrorData(error) {
+  if (!error || typeof error !== 'object') return undefined;
+  const data = {};
+  if ('data' in error && error.data !== undefined) Object.assign(data, error.data);
+  if ('details' in error && error.details !== undefined) data.details = error.details;
+  if (typeof error.retryable === 'boolean') data.retryable = error.retryable;
+  return Object.keys(data).length > 0 ? data : undefined;
 }
 
 async function runPlugin(args) {
@@ -4803,9 +4821,9 @@ function createUnifiedDiff(leftLabel, rightLabel, leftText, rightText) {
 }
 
 function splitDiffLines(text) {
-  const normalized = String(text).replace(/\r\n/g, '\n').replace(/\r/g, '\n');
-  if (normalized.length === 0) return [];
-  return normalized.match(/[^\n]*(?:\n|$)/g).filter((line) => line.length > 0);
+  const value = String(text);
+  if (value.length === 0) return [];
+  return value.match(/.*?(?:\r\n|\n|\r|$)/gs).filter((line) => line.length > 0);
 }
 
 function formatDiffRange(start, length) {
@@ -4852,8 +4870,15 @@ function diffLineBody(oldLines, newLines) {
 }
 
 function diffLine(prefix, line) {
-  if (String(line).endsWith('\n')) return `${prefix}${String(line).slice(0, -1)}`;
-  return `${prefix}${line}\n\\ No newline at end of file`;
+  const value = String(line);
+  if (value.endsWith('\r\n')) return `${prefix}${renderDiffLineContent(value.slice(0, -1))}`;
+  if (value.endsWith('\n')) return `${prefix}${renderDiffLineContent(value.slice(0, -1))}`;
+  if (value.endsWith('\r')) return `${prefix}${renderDiffLineContent(value)}`;
+  return `${prefix}${renderDiffLineContent(value)}\n\\ No newline at end of file`;
+}
+
+function renderDiffLineContent(value) {
+  return String(value).replace(/\r/g, '\\r');
 }
 
 async function runConversation(args) {

--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -9,6 +9,8 @@ import { runDesignSystemsToolCli } from './tools-design-systems-cli.js';
 import { runLiveArtifactsToolCli } from './tools-live-artifacts-cli.js';
 import { splitResearchSubcommand } from './research/cli-args.js';
 import { resolveDaemonUrl } from './daemon-url.js';
+import { requestJsonIpc } from '@open-design/sidecar';
+import { SIDECAR_ENV, SIDECAR_MESSAGES } from '@open-design/sidecar-proto';
 
 const argv = process.argv.slice(2);
 
@@ -192,6 +194,7 @@ const RECOVERABLE_EXIT_CODES = {
   'plugin-requires-daemon':   71,
   'snapshot-stale':           72,
   'genui-surface-awaiting':   73,
+  'desktop-auth-pending':     74,
 };
 const PLUGIN_LIST_FILTER_FLAGS = new Set([
   ...PLUGIN_STRING_FLAGS,
@@ -4326,19 +4329,25 @@ Common options:
     }
     case 'import': {
       const [baseDir] = positionalArgs(rest, PROJECT_STRING_FLAGS);
-      if (!baseDir) {
+      const importBaseDir = typeof baseDir === 'string' ? baseDir.trim() : '';
+      if (!importBaseDir) {
         console.error('Usage: od project import <baseDir> [--name "<title>"]');
         process.exit(2);
       }
-      const body = { baseDir };
+      const body = { baseDir: importBaseDir };
       if (typeof flags.name === 'string' && flags.name.length > 0) body.name = flags.name;
       if (typeof flags.skill === 'string' && flags.skill.length > 0) body.skillId = flags.skill;
       if (typeof flags['design-system'] === 'string' && flags['design-system'].length > 0) {
         body.designSystemId = flags['design-system'];
       }
+      const headers = { 'content-type': 'application/json' };
+      const importToken = await mintCliImportToken(importBaseDir);
+      if (importToken != null) {
+        headers['x-od-desktop-import-token'] = importToken;
+      }
       const resp = await fetch(`${base}/api/import/folder`, {
         method:  'POST',
-        headers: { 'content-type': 'application/json' },
+        headers,
         body:    JSON.stringify(body),
       });
       if (!resp.ok) return structuredHttpFailure(resp);
@@ -4729,6 +4738,32 @@ async function readStdinUtf8() {
   return fs.readFileSync(0, 'utf8');
 }
 
+async function mintCliImportToken(baseDir) {
+  const socketPath = process.env[SIDECAR_ENV.IPC_PATH];
+  if (typeof socketPath !== 'string' || socketPath.length === 0) return null;
+  let result;
+  try {
+    result = await requestJsonIpc(
+      socketPath,
+      { type: SIDECAR_MESSAGES.MINT_IMPORT_TOKEN, input: { baseDir } },
+      { timeoutMs: 800 },
+    );
+  } catch {
+    return null;
+  }
+  if (result?.ok === true && typeof result.token === 'string' && result.token.length > 0) {
+    return result.token;
+  }
+  if (result?.ok === false && result.code === 'DESKTOP_AUTH_PENDING') {
+    exitWithStructuredError({
+      code: 'desktop-auth-pending',
+      message: result.message ?? 'desktop auth required but secret not yet registered',
+      data: { retryable: result.retryable === true },
+    });
+  }
+  return null;
+}
+
 function createUnifiedDiff(leftLabel, rightLabel, leftText, rightText) {
   if (leftText === rightText) return '';
   const leftLines = splitDiffLines(leftText);
@@ -4755,7 +4790,7 @@ function createUnifiedDiff(leftLabel, rightLabel, leftText, rightText) {
   const newMid = rightLines.slice(prefix, rightEnd);
   const body = diffLineBody(oldMid, newMid);
   if (body.length === 0) {
-    body.push(...oldMid.map((line) => `-${line}`), ...newMid.map((line) => `+${line}`));
+    body.push(...oldMid.map((line) => diffLine('-', line)), ...newMid.map((line) => diffLine('+', line)));
   }
   const oldStart = oldMid.length === 0 ? prefix : prefix + 1;
   const newStart = newMid.length === 0 ? prefix : prefix + 1;
@@ -4770,9 +4805,7 @@ function createUnifiedDiff(leftLabel, rightLabel, leftText, rightText) {
 function splitDiffLines(text) {
   const normalized = String(text).replace(/\r\n/g, '\n').replace(/\r/g, '\n');
   if (normalized.length === 0) return [];
-  const lines = normalized.split('\n');
-  if (lines[lines.length - 1] === '') lines.pop();
-  return lines;
+  return normalized.match(/[^\n]*(?:\n|$)/g).filter((line) => line.length > 0);
 }
 
 function formatDiffRange(start, length) {
@@ -4780,10 +4813,10 @@ function formatDiffRange(start, length) {
 }
 
 function diffLineBody(oldLines, newLines) {
-  if (oldLines.length === 0) return newLines.map((line) => `+${line}`);
-  if (newLines.length === 0) return oldLines.map((line) => `-${line}`);
+  if (oldLines.length === 0) return newLines.map((line) => diffLine('+', line));
+  if (newLines.length === 0) return oldLines.map((line) => diffLine('-', line));
   if (oldLines.length * newLines.length > 1_000_000) {
-    return [...oldLines.map((line) => `-${line}`), ...newLines.map((line) => `+${line}`)];
+    return [...oldLines.map((line) => diffLine('-', line)), ...newLines.map((line) => diffLine('+', line))];
   }
   const width = newLines.length + 1;
   const lcs = Array.from(
@@ -4802,20 +4835,25 @@ function diffLineBody(oldLines, newLines) {
   let j = 0;
   while (i < oldLines.length && j < newLines.length) {
     if (oldLines[i] === newLines[j]) {
-      out.push(` ${oldLines[i]}`);
+      out.push(diffLine(' ', oldLines[i]));
       i++;
       j++;
     } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
-      out.push(`-${oldLines[i]}`);
+      out.push(diffLine('-', oldLines[i]));
       i++;
     } else {
-      out.push(`+${newLines[j]}`);
+      out.push(diffLine('+', newLines[j]));
       j++;
     }
   }
-  while (i < oldLines.length) out.push(`-${oldLines[i++]}`);
-  while (j < newLines.length) out.push(`+${newLines[j++]}`);
+  while (i < oldLines.length) out.push(diffLine('-', oldLines[i++]));
+  while (j < newLines.length) out.push(diffLine('+', newLines[j++]));
   return out;
+}
+
+function diffLine(prefix, line) {
+  if (String(line).endsWith('\n')) return `${prefix}${String(line).slice(0, -1)}`;
+  return `${prefix}${line}\n\\ No newline at end of file`;
 }
 
 async function runConversation(args) {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1467,6 +1467,10 @@ export function createAgentRuntimeEnv(
     OD_DAEMON_URL: daemonUrl,
     OD_NODE_BIN: nodeBin,
   };
+  const sidecarIpcPath = process.env[SIDECAR_ENV.IPC_PATH];
+  if (typeof sidecarIpcPath === 'string' && sidecarIpcPath.length > 0) {
+    env[SIDECAR_ENV.IPC_PATH] = sidecarIpcPath;
+  }
 
   // Ensure the node binary directory is on PATH so agent sub-processes —
   // in particular npm .cmd shims on Windows that run `"node" script.js` —

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1467,7 +1467,7 @@ export function createAgentRuntimeEnv(
     OD_DAEMON_URL: daemonUrl,
     OD_NODE_BIN: nodeBin,
   };
-  const sidecarIpcPath = process.env[SIDECAR_ENV.IPC_PATH];
+  const sidecarIpcPath = baseEnv[SIDECAR_ENV.IPC_PATH];
   if (typeof sidecarIpcPath === 'string' && sidecarIpcPath.length > 0) {
     env[SIDECAR_ENV.IPC_PATH] = sidecarIpcPath;
   }

--- a/apps/daemon/src/sidecar/server.ts
+++ b/apps/daemon/src/sidecar/server.ts
@@ -1,3 +1,5 @@
+import { randomBytes } from "node:crypto";
+
 import {
   APP_KEYS,
   OPEN_DESIGN_SIDECAR_CONTRACT,
@@ -7,6 +9,7 @@ import {
   type DaemonStatusSnapshot,
   type DesktopExportPdfInput,
   type DesktopExportPdfResult,
+  type MintImportTokenResult,
   type SidecarStamp,
 } from "@open-design/sidecar-proto";
 import {
@@ -18,7 +21,13 @@ import {
 } from "@open-design/sidecar";
 
 import { startDaemonRuntime, type StartedDaemonRuntime } from "../daemon-startup.js";
-import { isDesktopAuthGateActive, setDesktopAuthSecret } from "../desktop-auth.js";
+import {
+  getDesktopAuthSecret,
+  isDesktopAuthGateActive,
+  isDesktopAuthRegistered,
+  setDesktopAuthSecret,
+  signDesktopImportToken,
+} from "../desktop-auth.js";
 
 /**
  * PR #974 round 6 (mrcfps): pure wrapper that overlays the live
@@ -36,6 +45,7 @@ export function withCurrentDesktopAuthGate(snapshot: DaemonStatusSnapshot): Daem
 const DAEMON_PORT_ENV = SIDECAR_ENV.DAEMON_PORT;
 const WEB_PORT_ENV = SIDECAR_ENV.WEB_PORT;
 const TOOLS_DEV_PARENT_PID_ENV = SIDECAR_ENV.TOOLS_DEV_PARENT_PID;
+const DESKTOP_IMPORT_TOKEN_TTL_MS = 60_000;
 
 export type DaemonSidecarHandle = {
   status(): Promise<DaemonStatusSnapshot>;
@@ -76,6 +86,33 @@ function attachParentMonitor(stop: () => Promise<void>): void {
     void stop().finally(() => process.exit(0));
   }, 1000);
   timer.unref();
+}
+
+export function mintImportTokenForCli(baseDir: string): MintImportTokenResult {
+  if (!isDesktopAuthGateActive()) {
+    return {
+      ok: false,
+      code: "DESKTOP_AUTH_INACTIVE",
+      message: "desktop import auth gate is inactive",
+      retryable: false,
+    };
+  }
+  const secret = getDesktopAuthSecret();
+  if (secret == null || !isDesktopAuthRegistered()) {
+    return {
+      ok: false,
+      code: "DESKTOP_AUTH_PENDING",
+      message: "desktop auth required but secret not yet registered",
+      retryable: true,
+    };
+  }
+  const nonce = randomBytes(16).toString("base64url");
+  const expiresAt = new Date(Date.now() + DESKTOP_IMPORT_TOKEN_TTL_MS).toISOString();
+  return {
+    ok: true,
+    expiresAt,
+    token: signDesktopImportToken(secret, baseDir, { nonce, exp: expiresAt }),
+  };
 }
 
 export async function startDaemonSidecar(runtime: SidecarRuntimeContext<SidecarStamp>): Promise<DaemonSidecarHandle> {
@@ -152,6 +189,8 @@ export async function startDaemonSidecar(runtime: SidecarRuntimeContext<SidecarS
           // renderer→arbitrary-baseDir→shell.openPath bypass.
           setDesktopAuthSecret(Buffer.from(request.input.secret, "base64"));
           return { accepted: true };
+        case SIDECAR_MESSAGES.MINT_IMPORT_TOKEN:
+          return mintImportTokenForCli(request.input.baseDir);
       }
     },
   });

--- a/apps/daemon/tests/agent-runtime-env.test.ts
+++ b/apps/daemon/tests/agent-runtime-env.test.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { SIDECAR_ENV } from '@open-design/sidecar-proto';
 
 import { createAgentRuntimeEnv, createAgentRuntimeToolPrompt } from '../src/server.js';
@@ -87,9 +87,19 @@ describe('agent runtime tool environment', () => {
     expect(env.OD_DATA_DIR).toBe(process.env.OD_DATA_DIR);
   });
 
-  it('injects the daemon sidecar IPC path into agent wrapper sessions', () => {
-    const previousIpcPath = process.env[SIDECAR_ENV.IPC_PATH];
-    process.env[SIDECAR_ENV.IPC_PATH] = '/tmp/open-design/ipc/daemon.sock';
+  it('passes the daemon sidecar IPC path from the explicit base env into agent wrapper sessions', () => {
+    const env = createAgentRuntimeEnv(
+      { PATH: '/bin', [SIDECAR_ENV.IPC_PATH]: '/tmp/open-design/ipc/daemon.sock' },
+      'http://127.0.0.1:7456',
+      null,
+      '/opt/open-design/bin/node',
+    );
+
+    expect(env[SIDECAR_ENV.IPC_PATH]).toBe('/tmp/open-design/ipc/daemon.sock');
+  });
+
+  it('does not pull the daemon sidecar IPC path from ambient process state', () => {
+    vi.stubEnv(SIDECAR_ENV.IPC_PATH, '/tmp/open-design/ipc/stale.sock');
     try {
       const env = createAgentRuntimeEnv(
         { PATH: '/bin' },
@@ -98,10 +108,9 @@ describe('agent runtime tool environment', () => {
         '/opt/open-design/bin/node',
       );
 
-      expect(env[SIDECAR_ENV.IPC_PATH]).toBe('/tmp/open-design/ipc/daemon.sock');
+      expect(env[SIDECAR_ENV.IPC_PATH]).toBeUndefined();
     } finally {
-      if (previousIpcPath === undefined) delete process.env[SIDECAR_ENV.IPC_PATH];
-      else process.env[SIDECAR_ENV.IPC_PATH] = previousIpcPath;
+      vi.unstubAllEnvs();
     }
   });
 

--- a/apps/daemon/tests/agent-runtime-env.test.ts
+++ b/apps/daemon/tests/agent-runtime-env.test.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
+import { SIDECAR_ENV } from '@open-design/sidecar-proto';
 
 import { createAgentRuntimeEnv, createAgentRuntimeToolPrompt } from '../src/server.js';
 import { applyAgentLaunchEnv } from '../src/runtimes/launch.js';
@@ -84,6 +85,24 @@ describe('agent runtime tool environment', () => {
     );
 
     expect(env.OD_DATA_DIR).toBe(process.env.OD_DATA_DIR);
+  });
+
+  it('injects the daemon sidecar IPC path into agent wrapper sessions', () => {
+    const previousIpcPath = process.env[SIDECAR_ENV.IPC_PATH];
+    process.env[SIDECAR_ENV.IPC_PATH] = '/tmp/open-design/ipc/daemon.sock';
+    try {
+      const env = createAgentRuntimeEnv(
+        { PATH: '/bin' },
+        'http://127.0.0.1:7456',
+        null,
+        '/opt/open-design/bin/node',
+      );
+
+      expect(env[SIDECAR_ENV.IPC_PATH]).toBe('/tmp/open-design/ipc/daemon.sock');
+    } finally {
+      if (previousIpcPath === undefined) delete process.env[SIDECAR_ENV.IPC_PATH];
+      else process.env[SIDECAR_ENV.IPC_PATH] = previousIpcPath;
+    }
   });
 
   it('describes daemon URL and token availability without exposing the token', () => {

--- a/apps/daemon/tests/cli-phase2c.test.ts
+++ b/apps/daemon/tests/cli-phase2c.test.ts
@@ -165,20 +165,12 @@ describe('Phase 2C CLI wrappers', () => {
       });
       sidecarServers.push(sidecar);
 
-      const previousIpcPath = process.env[SIDECAR_ENV.IPC_PATH];
-      process.env[SIDECAR_ENV.IPC_PATH] = ipcPath;
-      let wrapperEnv: NodeJS.ProcessEnv;
-      try {
-        wrapperEnv = createAgentRuntimeEnv(
-          { PATH: process.env.PATH },
-          baseUrl,
-          null,
-          process.execPath,
-        );
-      } finally {
-        if (previousIpcPath === undefined) delete process.env[SIDECAR_ENV.IPC_PATH];
-        else process.env[SIDECAR_ENV.IPC_PATH] = previousIpcPath;
-      }
+      const wrapperEnv = createAgentRuntimeEnv(
+        { PATH: process.env.PATH, [SIDECAR_ENV.IPC_PATH]: ipcPath },
+        baseUrl,
+        null,
+        process.execPath,
+      );
 
       const imported = await runCli(
         ['project', 'import', `  ${folder}  `, '--name', 'Gated CLI Import', '--json'],

--- a/apps/daemon/tests/cli-phase2c.test.ts
+++ b/apps/daemon/tests/cli-phase2c.test.ts
@@ -1,13 +1,18 @@
 import type http from 'node:http';
 import { spawn } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import url from 'node:url';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { createJsonIpcServer } from '@open-design/sidecar';
+import { SIDECAR_MESSAGES, normalizeDaemonSidecarMessage } from '@open-design/sidecar-proto';
 
 import { startServer } from '../src/server.js';
+import { resetDesktopAuthForTests, setDesktopAuthSecret } from '../src/desktop-auth.js';
+import { mintImportTokenForCli } from '../src/sidecar/server.js';
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '../../..');
@@ -19,6 +24,7 @@ describe('Phase 2C CLI wrappers', () => {
   let baseUrl: string;
   let shutdown: (() => Promise<void> | void) | undefined;
   const tempDirs: string[] = [];
+  const sidecarServers: { close(): Promise<void> }[] = [];
 
   beforeAll(async () => {
     const started = (await startServer({ port: 0, returnServer: true })) as {
@@ -31,10 +37,14 @@ describe('Phase 2C CLI wrappers', () => {
     shutdown = started.shutdown;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    for (const sidecar of sidecarServers.splice(0)) {
+      await sidecar.close();
+    }
     for (const dir of tempDirs.splice(0)) {
       rmSync(dir, { recursive: true, force: true });
     }
+    resetDesktopAuthForTests();
   });
 
   afterAll(async () => {
@@ -50,11 +60,12 @@ describe('Phase 2C CLI wrappers', () => {
 
   async function runCli(
     args: string[],
-    options: { input?: string; timeout?: number } = {},
+    options: { input?: string; timeout?: number; env?: NodeJS.ProcessEnv } = {},
   ): Promise<{ stdout: string; stderr: string }> {
     const env: NodeJS.ProcessEnv = {
       ...process.env,
       OD_DAEMON_URL: baseUrl,
+      ...options.env,
     };
     delete env.NODE_OPTIONS;
 
@@ -129,6 +140,60 @@ describe('Phase 2C CLI wrappers', () => {
     expect(conversationBody.conversation.title).toBe('Follow-up');
   });
 
+  it('imports through the CLI when desktop import auth gate is active', async () => {
+    const folder = makeFolder();
+    await writeFile(path.join(folder, 'index.html'), '<!doctype html>');
+    const secret = randomBytes(32);
+    setDesktopAuthSecret(secret);
+
+    try {
+      const ipcRoot = makeFolder();
+      const ipcPath = path.join(ipcRoot, 'daemon.sock');
+      const sidecar = await createJsonIpcServer({
+        socketPath: ipcPath,
+        handler: async (message) => {
+          const request = normalizeDaemonSidecarMessage(message);
+          switch (request.type) {
+            case SIDECAR_MESSAGES.STATUS:
+              return { desktopAuthGateActive: true, state: 'running', url: baseUrl };
+            case SIDECAR_MESSAGES.MINT_IMPORT_TOKEN:
+              return mintImportTokenForCli(request.input.baseDir);
+            default:
+              throw new Error(`unexpected test IPC message: ${request.type}`);
+          }
+        },
+      });
+      sidecarServers.push(sidecar);
+
+      const imported = await runCli(
+        ['project', 'import', `  ${folder}  `, '--name', 'Gated CLI Import', '--json'],
+        {
+          env: {
+            OD_SIDECAR_IPC_PATH: ipcPath,
+          },
+        },
+      );
+      const importBody = JSON.parse(imported.stdout) as {
+        project: {
+          id: string;
+          name: string;
+          metadata?: { importedFrom?: string; fromTrustedPicker?: boolean };
+        };
+        conversationId: string;
+        entryFile: string | null;
+      };
+
+      expect(importBody.project.id).toBeTruthy();
+      expect(importBody.project.name).toBe('Gated CLI Import');
+      expect(importBody.project.metadata?.importedFrom).toBe('folder');
+      expect(importBody.project.metadata?.fromTrustedPicker).toBe(true);
+      expect(importBody.conversationId).toBeTruthy();
+      expect(importBody.entryFile).toBe('index.html');
+    } finally {
+      resetDesktopAuthForTests();
+    }
+  });
+
   it('prints unified diffs for project files and stdin comparisons', async () => {
     const folder = makeFolder();
     await writeFile(path.join(folder, 'a.txt'), 'one\ntwo\n');
@@ -151,5 +216,56 @@ describe('Phase 2C CLI wrappers', () => {
     expect(stdinDiff.stdout).toContain('+++ b/-');
     expect(stdinDiff.stdout).toContain('-two');
     expect(stdinDiff.stdout).toContain('+four');
+  });
+
+  it('prints EOF-newline-only file diffs', async () => {
+    const folder = makeFolder();
+    await writeFile(path.join(folder, 'with-newline.txt'), 'same\n');
+    await writeFile(path.join(folder, 'without-newline.txt'), 'same');
+    const imported = await runCli(['project', 'import', folder, '--json']);
+    const importBody = JSON.parse(imported.stdout) as { project: { id: string } };
+
+    const fileDiff = await runCli([
+      'files',
+      'diff',
+      importBody.project.id,
+      'with-newline.txt',
+      'without-newline.txt',
+    ]);
+
+    expect(fileDiff.stdout).toContain('--- a/with-newline.txt');
+    expect(fileDiff.stdout).toContain('+++ b/without-newline.txt');
+    expect(fileDiff.stdout).toContain('\\ No newline at end of file');
+    expect(fileDiff.stdout).toContain('-same');
+    expect(fileDiff.stdout).toContain('+same');
+  });
+});
+
+describe('mintImportTokenForCli', () => {
+  afterEach(() => {
+    resetDesktopAuthForTests();
+  });
+
+  it('reports inactive when desktop import auth gate is dormant', () => {
+    const result = mintImportTokenForCli('/tmp/open-design-cli-import');
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: 'DESKTOP_AUTH_INACTIVE',
+      retryable: false,
+    });
+  });
+
+  it('returns a desktop import token bound to a requested baseDir', () => {
+    const secret = randomBytes(32);
+    setDesktopAuthSecret(secret);
+
+    const result = mintImportTokenForCli('/tmp/open-design-cli-import');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.token).toMatch(/~/);
+      expect(result.expiresAt).toMatch(/Z$/);
+    }
   });
 });

--- a/apps/daemon/tests/cli-phase2c.test.ts
+++ b/apps/daemon/tests/cli-phase2c.test.ts
@@ -106,6 +106,54 @@ describe('Phase 2C CLI wrappers', () => {
     });
   }
 
+  async function runCliExpectFailure(
+    args: string[],
+    options: { input?: string; timeout?: number; env?: NodeJS.ProcessEnv } = {},
+  ): Promise<{ code: number | null; stdout: string; stderr: string }> {
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      OD_DAEMON_URL: baseUrl,
+      ...options.env,
+    };
+    delete env.NODE_OPTIONS;
+
+    return await new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, [TSX_CLI, CLI_SRC, ...args], {
+        cwd: path.join(__dirname, '..'),
+        env,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      let stdout = '';
+      let stderr = '';
+      const timeout = setTimeout(() => {
+        child.kill('SIGTERM');
+        reject(new Error(`CLI timed out: od ${args.join(' ')}`));
+      }, options.timeout ?? 20_000);
+
+      child.stdout.setEncoding('utf8');
+      child.stderr.setEncoding('utf8');
+      child.stdout.on('data', (chunk) => {
+        stdout += chunk;
+      });
+      child.stderr.on('data', (chunk) => {
+        stderr += chunk;
+      });
+      child.on('error', (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+      child.on('close', (code) => {
+        clearTimeout(timeout);
+        if (code === 0) {
+          reject(new Error(`od ${args.join(' ')} unexpectedly exited 0\nstdout:\n${stdout}\nstderr:\n${stderr}`));
+          return;
+        }
+        resolve({ code, stdout, stderr });
+      });
+      child.stdin.end(options.input ?? '');
+    });
+  }
+
   it('imports a folder and creates a conversation through the CLI', async () => {
     const folder = makeFolder();
     await writeFile(path.join(folder, 'index.html'), '<!doctype html>');
@@ -197,6 +245,45 @@ describe('Phase 2C CLI wrappers', () => {
     }
   });
 
+  it('preserves desktop-auth-pending when CLI token minting cannot reach sidecar IPC', async () => {
+    const folder = makeFolder();
+    await writeFile(path.join(folder, 'index.html'), '<!doctype html>');
+    setDesktopAuthSecret(randomBytes(32));
+    setDesktopAuthSecret(null);
+
+    const failed = await runCliExpectFailure(
+      ['project', 'import', folder, '--name', 'Pending CLI Import', '--json'],
+      { env: { [SIDECAR_ENV.IPC_PATH]: path.join(folder, 'missing-daemon.sock') } },
+    );
+
+    expect(failed.code).toBe(74);
+    const envelope = JSON.parse(failed.stderr) as {
+      error?: { code?: string; message?: string; data?: { retryable?: boolean } };
+    };
+    expect(envelope.error?.code).toBe('desktop-auth-pending');
+    expect(envelope.error?.message).toMatch(/desktop auth required/i);
+    expect(envelope.error?.data?.retryable).toBe(true);
+  });
+
+  it('preserves desktop-import-token-rejected when CLI token minting falls through to HTTP rejection', async () => {
+    const folder = makeFolder();
+    await writeFile(path.join(folder, 'index.html'), '<!doctype html>');
+    setDesktopAuthSecret(randomBytes(32));
+
+    const failed = await runCliExpectFailure(
+      ['project', 'import', folder, '--name', 'Rejected CLI Import', '--json'],
+      { env: { [SIDECAR_ENV.IPC_PATH]: path.join(folder, 'missing-daemon.sock') } },
+    );
+
+    expect(failed.code).toBe(75);
+    const envelope = JSON.parse(failed.stderr) as {
+      error?: { code?: string; message?: string; data?: { details?: { reason?: string } } };
+    };
+    expect(envelope.error?.code).toBe('desktop-import-token-rejected');
+    expect(envelope.error?.message).toMatch(/desktop import token rejected/i);
+    expect(envelope.error?.data?.details?.reason).toMatch(/token missing/i);
+  });
+
   it('prints unified diffs for project files and stdin comparisons', async () => {
     const folder = makeFolder();
     await writeFile(path.join(folder, 'a.txt'), 'one\ntwo\n');
@@ -240,6 +327,27 @@ describe('Phase 2C CLI wrappers', () => {
     expect(fileDiff.stdout).toContain('+++ b/without-newline.txt');
     expect(fileDiff.stdout).toContain('\\ No newline at end of file');
     expect(fileDiff.stdout).toContain('-same');
+    expect(fileDiff.stdout).toContain('+same');
+  });
+
+  it('prints CRLF-to-LF-only file diffs', async () => {
+    const folder = makeFolder();
+    await writeFile(path.join(folder, 'crlf.txt'), 'same\r\n');
+    await writeFile(path.join(folder, 'lf.txt'), 'same\n');
+    const imported = await runCli(['project', 'import', folder, '--json']);
+    const importBody = JSON.parse(imported.stdout) as { project: { id: string } };
+
+    const fileDiff = await runCli([
+      'files',
+      'diff',
+      importBody.project.id,
+      'crlf.txt',
+      'lf.txt',
+    ]);
+
+    expect(fileDiff.stdout).toContain('--- a/crlf.txt');
+    expect(fileDiff.stdout).toContain('+++ b/lf.txt');
+    expect(fileDiff.stdout).toContain('-same\\r');
     expect(fileDiff.stdout).toContain('+same');
   });
 });

--- a/apps/daemon/tests/cli-phase2c.test.ts
+++ b/apps/daemon/tests/cli-phase2c.test.ts
@@ -1,0 +1,155 @@
+import type http from 'node:http';
+import { spawn } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import url from 'node:url';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { startServer } from '../src/server.js';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const CLI_SRC = path.join(__dirname, '../src/cli.ts');
+const TSX_CLI = path.join(REPO_ROOT, 'node_modules', 'tsx', 'dist', 'cli.mjs');
+
+describe('Phase 2C CLI wrappers', () => {
+  let server: http.Server;
+  let baseUrl: string;
+  let shutdown: (() => Promise<void> | void) | undefined;
+  const tempDirs: string[] = [];
+
+  beforeAll(async () => {
+    const started = (await startServer({ port: 0, returnServer: true })) as {
+      url: string;
+      server: http.Server;
+      shutdown?: () => Promise<void> | void;
+    };
+    baseUrl = started.url;
+    server = started.server;
+    shutdown = started.shutdown;
+  });
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  afterAll(async () => {
+    await Promise.resolve(shutdown?.());
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  function makeFolder(): string {
+    const dir = mkdtempSync(path.join(tmpdir(), 'od-cli-phase2c-'));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  async function runCli(
+    args: string[],
+    options: { input?: string; timeout?: number } = {},
+  ): Promise<{ stdout: string; stderr: string }> {
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      OD_DAEMON_URL: baseUrl,
+    };
+    delete env.NODE_OPTIONS;
+
+    return await new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, [TSX_CLI, CLI_SRC, ...args], {
+        cwd: path.join(__dirname, '..'),
+        env,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      let stdout = '';
+      let stderr = '';
+      const timeout = setTimeout(() => {
+        child.kill('SIGTERM');
+        reject(new Error(`CLI timed out: od ${args.join(' ')}`));
+      }, options.timeout ?? 20_000);
+
+      child.stdout.setEncoding('utf8');
+      child.stderr.setEncoding('utf8');
+      child.stdout.on('data', (chunk) => {
+        stdout += chunk;
+      });
+      child.stderr.on('data', (chunk) => {
+        stderr += chunk;
+      });
+      child.on('error', (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+      child.on('close', (code) => {
+        clearTimeout(timeout);
+        if (code === 0) {
+          resolve({ stdout, stderr });
+          return;
+        }
+        reject(new Error(`od ${args.join(' ')} exited ${code}\nstdout:\n${stdout}\nstderr:\n${stderr}`));
+      });
+      child.stdin.end(options.input ?? '');
+    });
+  }
+
+  it('imports a folder and creates a conversation through the CLI', async () => {
+    const folder = makeFolder();
+    await writeFile(path.join(folder, 'index.html'), '<!doctype html>');
+
+    const imported = await runCli(['project', 'import', folder, '--name', 'CLI Import', '--json']);
+    const importBody = JSON.parse(imported.stdout) as {
+      project: { id: string; name: string; metadata?: { importedFrom?: string } };
+      conversationId: string;
+      entryFile: string | null;
+    };
+
+    expect(importBody.project.id).toBeTruthy();
+    expect(importBody.project.name).toBe('CLI Import');
+    expect(importBody.project.metadata?.importedFrom).toBe('folder');
+    expect(importBody.conversationId).toBeTruthy();
+    expect(importBody.entryFile).toBe('index.html');
+
+    const created = await runCli([
+      'conversation',
+      'new',
+      importBody.project.id,
+      '--title',
+      'Follow-up',
+      '--json',
+    ]);
+    const conversationBody = JSON.parse(created.stdout) as {
+      conversation: { id: string; projectId: string; title: string | null };
+    };
+
+    expect(conversationBody.conversation.id).toBeTruthy();
+    expect(conversationBody.conversation.projectId).toBe(importBody.project.id);
+    expect(conversationBody.conversation.title).toBe('Follow-up');
+  });
+
+  it('prints unified diffs for project files and stdin comparisons', async () => {
+    const folder = makeFolder();
+    await writeFile(path.join(folder, 'a.txt'), 'one\ntwo\n');
+    await writeFile(path.join(folder, 'b.txt'), 'one\nthree\n');
+    const imported = await runCli(['project', 'import', folder, '--json']);
+    const importBody = JSON.parse(imported.stdout) as { project: { id: string } };
+
+    const fileDiff = await runCli(['files', 'diff', importBody.project.id, 'a.txt', 'b.txt']);
+    expect(fileDiff.stdout).toContain('--- a/a.txt');
+    expect(fileDiff.stdout).toContain('+++ b/b.txt');
+    expect(fileDiff.stdout).toContain('@@');
+    expect(fileDiff.stdout).toContain('-two');
+    expect(fileDiff.stdout).toContain('+three');
+
+    const stdinDiff = await runCli(
+      ['files', 'diff', importBody.project.id, 'a.txt', '--against', '-'],
+      { input: 'one\nfour\n' },
+    );
+    expect(stdinDiff.stdout).toContain('--- a/a.txt');
+    expect(stdinDiff.stdout).toContain('+++ b/-');
+    expect(stdinDiff.stdout).toContain('-two');
+    expect(stdinDiff.stdout).toContain('+four');
+  });
+});

--- a/apps/daemon/tests/cli-phase2c.test.ts
+++ b/apps/daemon/tests/cli-phase2c.test.ts
@@ -8,9 +8,9 @@ import path from 'node:path';
 import url from 'node:url';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { createJsonIpcServer } from '@open-design/sidecar';
-import { SIDECAR_MESSAGES, normalizeDaemonSidecarMessage } from '@open-design/sidecar-proto';
+import { SIDECAR_ENV, SIDECAR_MESSAGES, normalizeDaemonSidecarMessage } from '@open-design/sidecar-proto';
 
-import { startServer } from '../src/server.js';
+import { createAgentRuntimeEnv, startServer } from '../src/server.js';
 import { resetDesktopAuthForTests, setDesktopAuthSecret } from '../src/desktop-auth.js';
 import { mintImportTokenForCli } from '../src/sidecar/server.js';
 
@@ -165,13 +165,24 @@ describe('Phase 2C CLI wrappers', () => {
       });
       sidecarServers.push(sidecar);
 
+      const previousIpcPath = process.env[SIDECAR_ENV.IPC_PATH];
+      process.env[SIDECAR_ENV.IPC_PATH] = ipcPath;
+      let wrapperEnv: NodeJS.ProcessEnv;
+      try {
+        wrapperEnv = createAgentRuntimeEnv(
+          { PATH: process.env.PATH },
+          baseUrl,
+          null,
+          process.execPath,
+        );
+      } finally {
+        if (previousIpcPath === undefined) delete process.env[SIDECAR_ENV.IPC_PATH];
+        else process.env[SIDECAR_ENV.IPC_PATH] = previousIpcPath;
+      }
+
       const imported = await runCli(
         ['project', 'import', `  ${folder}  `, '--name', 'Gated CLI Import', '--json'],
-        {
-          env: {
-            OD_SIDECAR_IPC_PATH: ipcPath,
-          },
-        },
+        { env: wrapperEnv },
       );
       const importBody = JSON.parse(imported.stdout) as {
         project: {

--- a/packages/sidecar-proto/src/index.ts
+++ b/packages/sidecar-proto/src/index.ts
@@ -72,6 +72,7 @@ export const SIDECAR_MESSAGES = Object.freeze({
   CONSOLE: "console",
   EVAL: "eval",
   EXPORT_PDF: "export-pdf",
+  MINT_IMPORT_TOKEN: "mint-import-token",
   REGISTER_DESKTOP_AUTH: "register-desktop-auth",
   SCREENSHOT: "screenshot",
   SHUTDOWN: "shutdown",
@@ -357,10 +358,25 @@ export type RegisterDesktopAuthResult = {
   accepted: true;
 };
 
+export type MintImportTokenInput = {
+  baseDir: string;
+};
+
+export type MintImportTokenMessage = {
+  input: MintImportTokenInput;
+  type: typeof SIDECAR_MESSAGES.MINT_IMPORT_TOKEN;
+};
+
+export type MintImportTokenResult =
+  | { ok: true; expiresAt: string; token: string }
+  | { ok: false; code: "DESKTOP_AUTH_INACTIVE"; message: string; retryable: false }
+  | { ok: false; code: "DESKTOP_AUTH_PENDING"; message: string; retryable: true };
+
 export type DaemonSidecarMessage =
   | SidecarStatusMessage
   | SidecarShutdownMessage
-  | RegisterDesktopAuthMessage;
+  | RegisterDesktopAuthMessage
+  | MintImportTokenMessage;
 export type WebSidecarMessage = SidecarStatusMessage | SidecarShutdownMessage;
 export type DesktopSidecarMessage =
   | SidecarStatusMessage
@@ -552,6 +568,12 @@ function normalizeRegisterDesktopAuthInput(input: unknown): RegisterDesktopAuthI
   return { secret };
 }
 
+function normalizeMintImportTokenInput(input: unknown): MintImportTokenInput {
+  const value = assertObject(input, "mint-import-token input");
+  assertKnownKeys(value, ["baseDir"], "mint-import-token input");
+  return { baseDir: normalizeNonEmptyString(value.baseDir, "mint-import-token baseDir") };
+}
+
 function normalizeBoolean(value: unknown, label: string): boolean {
   if (typeof value !== "boolean") throw new Error(`${label} must be a boolean`);
   return value;
@@ -599,6 +621,10 @@ export function normalizeDaemonSidecarMessage(input: unknown): DaemonSidecarMess
   if (type === SIDECAR_MESSAGES.REGISTER_DESKTOP_AUTH) {
     assertKnownKeys(value, ["input", "type"], "daemon sidecar message");
     return { input: normalizeRegisterDesktopAuthInput(value.input), type };
+  }
+  if (type === SIDECAR_MESSAGES.MINT_IMPORT_TOKEN) {
+    assertKnownKeys(value, ["input", "type"], "daemon sidecar message");
+    return { input: normalizeMintImportTokenInput(value.input), type };
   }
   throw new SidecarContractError(SIDECAR_ERROR_CODES.UNKNOWN_MESSAGE, `unknown daemon sidecar message: ${type}`);
 }

--- a/packages/sidecar-proto/tests/index.test.ts
+++ b/packages/sidecar-proto/tests/index.test.ts
@@ -84,6 +84,29 @@ describe("open-design sidecar contract", () => {
     expect(normalizeDaemonSidecarMessage(message)).toEqual(message);
   });
 
+  it("accepts a mint-import-token payload with a baseDir", () => {
+    const message = {
+      input: { baseDir: "/Users/u/project" },
+      type: SIDECAR_MESSAGES.MINT_IMPORT_TOKEN,
+    };
+    expect(normalizeDaemonSidecarMessage(message)).toEqual(message);
+  });
+
+  it("rejects malformed mint-import-token payloads", () => {
+    expect(() =>
+      normalizeDaemonSidecarMessage({
+        input: { baseDir: "" },
+        type: SIDECAR_MESSAGES.MINT_IMPORT_TOKEN,
+      }),
+    ).toThrow(/baseDir/i);
+    expect(() =>
+      normalizeDaemonSidecarMessage({
+        input: { baseDir: "/Users/u/project", extra: true },
+        type: SIDECAR_MESSAGES.MINT_IMPORT_TOKEN,
+      }),
+    ).toThrow(/extra/i);
+  });
+
   it("rejects register-desktop-auth payloads that are not base64-shaped", () => {
     expect(() =>
       normalizeDaemonSidecarMessage({


### PR DESCRIPTION
## Summary

- add `od project import <baseDir> [--name]` as a thin wrapper over `POST /api/import/folder`
- add `od conversation new <projectId> [--title]` as a thin wrapper over `POST /api/projects/:id/conversations`
- add `od files diff <projectId> <relpathA> [<relpathB> | --against -]` with CLI-side unified diff output using existing project file reads
- make CLI folder import compatible with the desktop import-auth gate by minting a one-shot import token through daemon sidecar IPC when the gate is active
- preserve EOF-newline-only and CRLF-vs-LF-only file changes in `od files diff`
- preserve desktop-auth pending / token-rejected structured errors when CLI import token minting falls back to HTTP
- add CLI e2e coverage for folder import, gated folder import, conversation creation, file-to-file diff, stdin diff, EOF-newline-only diffs, CRLF-vs-LF diffs, and desktop-auth HTTP fallback errors

Closes #2178.

## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — changed daemon sidecar IPC contract for CLI import-token minting
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Testing

- `pnpm install` (recreated workspace links after rebase; warnings only for local Node v26 vs repo `~24`, plus missing packaged `od` bin before daemon build)
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/cli-phase2c.test.ts -t "desktop-auth-pending|CRLF-to-LF"` (red before fix: 2 failing regressions)
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/cli-phase2c.test.ts -t "desktop-auth-pending|desktop-import-token-rejected|CRLF-to-LF"` (red before final error mapping: token rejection still exited as `daemon-not-running`)
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/cli-phase2c.test.ts -t "desktop-auth-pending|desktop-import-token-rejected|CRLF-to-LF"`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/cli-phase2c.test.ts tests/agent-runtime-env.test.ts`
- `pnpm --filter @open-design/sidecar-proto test`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/sidecar-startup.test.ts tests/sidecar-status-snapshot.test.ts`
- `pnpm --filter @open-design/sidecar-proto typecheck`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- `pnpm typecheck` (passes; existing landing-page Astro/Shiki warnings/hints only)
- `pnpm --filter @open-design/daemon test` (266 files passed, 3178 tests passed, 1 skipped, 4 todo)
- `git diff --check`

Notes: local environment is Node v26.0.0 while the repo declares Node `~24`, so pnpm prints engine warnings during checks.
