### PR TITLE
fix(ci): anchor PR inactivity clock to author responses

### DIFF
--- a/.github/workflows/pr-author-inactivity.yml
+++ b/.github/workflows/pr-author-inactivity.yml
@@ -27,7 +27,13 @@ name: PR author inactivity
 on:
   schedule:
     - cron: '0 */6 * * *'
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Log planned actions without commenting or closing PRs"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   issues: write
@@ -49,6 +55,7 @@ jobs:
             const REMINDER_MARKER = '<!-- pr-author-inactivity:reminder -->';
             const REMINDER_MS = 72 * 60 * 60 * 1000;
             const CLOSE_MS = 120 * 60 * 60 * 1000;
+            const DRY_RUN = core.getBooleanInput('dry_run');
 
             function ts(value) {
               return value ? new Date(value).getTime() : 0;
@@ -183,8 +190,18 @@ jobs:
               });
 
               const inactiveFor = now - feedbackAt;
+              const inactiveHours = Math.floor(inactiveFor / 3600000);
 
               if (inactiveFor >= CLOSE_MS) {
+                const line = DRY_RUN
+                  ? `#${pr.number}: would close after ${inactiveHours}h of author inactivity`
+                  : `#${pr.number}: closed after ${inactiveHours}h of author inactivity`;
+
+                if (DRY_RUN) {
+                  summary.push(line);
+                  continue;
+                }
+
                 await github.rest.issues.createComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
@@ -203,11 +220,20 @@ jobs:
                   state: 'closed',
                 });
 
-                summary.push(`#${pr.number}: closed after ${Math.floor(inactiveFor / 3600000)}h of author inactivity`);
+                summary.push(line);
                 continue;
               }
 
               if (inactiveFor >= REMINDER_MS && !reminderSent) {
+                const line = DRY_RUN
+                  ? `#${pr.number}: would remind after ${inactiveHours}h of author inactivity`
+                  : `#${pr.number}: reminded after ${inactiveHours}h of author inactivity`;
+
+                if (DRY_RUN) {
+                  summary.push(line);
+                  continue;
+                }
+
                 await github.rest.issues.createComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
@@ -221,13 +247,14 @@ jobs:
                   ].join('\n'),
                 });
 
-                summary.push(`#${pr.number}: reminded after ${Math.floor(inactiveFor / 3600000)}h of author inactivity`);
+                summary.push(line);
               }
             }
 
             if (summary.length === 0) {
-              core.info('No inactive PRs needed action.');
-              await core.summary.addRaw('No inactive PRs needed action.').write();
+              const line = DRY_RUN ? 'Dry run: no inactive PRs would need action.' : 'No inactive PRs needed action.';
+              core.info(line);
+              await core.summary.addRaw(line).write();
               return;
             }
 
@@ -236,6 +263,6 @@ jobs:
             }
 
             await core.summary
-              .addHeading('PR author inactivity actions')
+              .addHeading(DRY_RUN ? 'PR author inactivity dry run' : 'PR author inactivity actions')
               .addList(summary)
               .write();

--- a/.github/workflows/pr-author-inactivity.yml
+++ b/.github/workflows/pr-author-inactivity.yml
@@ -118,19 +118,6 @@ jobs:
                 .filter(Boolean);
             }
 
-            function debugFeedbackShape(kind, item) {
-              return JSON.stringify({
-                kind,
-                login: item?.user?.login,
-                author_association: item?.author_association,
-                authorAssociation: item?.authorAssociation,
-                state: item?.state,
-                created_at: item?.created_at,
-                submitted_at: item?.submitted_at,
-                body_preview: item?.body?.slice?.(0, 80),
-              });
-            }
-
             const now = Date.now();
             const summary = [];
             const diagnostics = [];
@@ -167,18 +154,6 @@ jobs:
                 }),
               ]);
 
-              if (DRY_RUN && pr.number === 642) {
-                for (const comment of comments.slice(0, 5)) {
-                  core.info(`DEBUG #642 comment ${debugFeedbackShape('comment', comment)}`);
-                }
-                for (const review of reviews.slice(0, 5)) {
-                  core.info(`DEBUG #642 review ${debugFeedbackShape('review', review)}`);
-                }
-                for (const reviewComment of reviewComments.slice(0, 5)) {
-                  core.info(`DEBUG #642 reviewComment ${debugFeedbackShape('reviewComment', reviewComment)}`);
-                }
-              }
-
               const candidateTrustedLogins = new Set();
               for (const comment of comments) {
                 const login = comment.user?.login;
@@ -207,10 +182,6 @@ jobs:
                   }
                 }),
               );
-
-              if (DRY_RUN && pr.number === 642) {
-                core.info(`DEBUG #642 trustedLogins ${JSON.stringify([...trustedLogins])}`);
-              }
 
               let latestAuthorResponseAt = 0;
 

--- a/.github/workflows/pr-author-inactivity.yml
+++ b/.github/workflows/pr-author-inactivity.yml
@@ -68,7 +68,8 @@ jobs:
             const TRUSTED_ASSOCIATIONS = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
 
             function isTrustedReviewer(actor) {
-              return Boolean(actor?.user?.login) && TRUSTED_ASSOCIATIONS.has(actor.author_association);
+              const association = actor?.author_association || actor?.authorAssociation;
+              return Boolean(actor?.user?.login) && TRUSTED_ASSOCIATIONS.has(association);
             }
 
             async function paginate(method, params) {

--- a/.github/workflows/pr-author-inactivity.yml
+++ b/.github/workflows/pr-author-inactivity.yml
@@ -65,11 +65,32 @@ jobs:
               return Boolean(login && login.endsWith('[bot]'));
             }
 
-            const TRUSTED_ASSOCIATIONS = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
+            const TRUSTED_PERMISSIONS = new Set(['admin', 'maintain', 'write', 'triage']);
+            const trustedReviewerCache = new Map();
 
-            function isTrustedReviewer(actor) {
-              const association = actor?.author_association || actor?.authorAssociation;
-              return Boolean(actor?.user?.login) && TRUSTED_ASSOCIATIONS.has(association);
+            async function isTrustedReviewer(login) {
+              if (!login || isBot(login)) {
+                return false;
+              }
+
+              if (trustedReviewerCache.has(login)) {
+                return trustedReviewerCache.get(login);
+              }
+
+              try {
+                const response = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  username: login,
+                });
+
+                const trusted = TRUSTED_PERMISSIONS.has(response.data.permission);
+                trustedReviewerCache.set(login, trusted);
+                return trusted;
+              } catch (error) {
+                trustedReviewerCache.set(login, false);
+                return false;
+              }
             }
 
             async function paginate(method, params) {
@@ -84,11 +105,11 @@ jobs:
               direction: 'asc',
             });
 
-            function collectFeedbackAt(author, collection, getLogin, getTimestamp, predicate = () => true) {
+            function collectFeedbackAt(author, trustedLogins, collection, getLogin, getTimestamp, predicate = () => true) {
               return collection
                 .filter((item) => {
                   const login = getLogin(item);
-                  if (!login || login === author || isBot(login) || !isTrustedReviewer(item)) {
+                  if (!login || login === author || isBot(login) || !trustedLogins.has(login)) {
                     return false;
                   }
                   return predicate(item);
@@ -158,6 +179,39 @@ jobs:
                 }
               }
 
+              const candidateTrustedLogins = new Set();
+              for (const comment of comments) {
+                const login = comment.user?.login;
+                if (login && login !== author && !isBot(login)) {
+                  candidateTrustedLogins.add(login);
+                }
+              }
+              for (const review of reviews) {
+                const login = review.user?.login;
+                if (login && login !== author && !isBot(login)) {
+                  candidateTrustedLogins.add(login);
+                }
+              }
+              for (const reviewComment of reviewComments) {
+                const login = reviewComment.user?.login;
+                if (login && login !== author && !isBot(login)) {
+                  candidateTrustedLogins.add(login);
+                }
+              }
+
+              const trustedLogins = new Set();
+              await Promise.all(
+                [...candidateTrustedLogins].map(async (login) => {
+                  if (await isTrustedReviewer(login)) {
+                    trustedLogins.add(login);
+                  }
+                }),
+              );
+
+              if (DRY_RUN && pr.number === 642) {
+                core.info(`DEBUG #642 trustedLogins ${JSON.stringify([...trustedLogins])}`);
+              }
+
               let latestAuthorResponseAt = 0;
 
               for (const comment of comments) {
@@ -195,9 +249,10 @@ jobs:
               }
 
               const feedbackAts = [
-                ...collectFeedbackAt(author, comments, (comment) => comment.user?.login, (comment) => ts(comment.created_at)),
+                ...collectFeedbackAt(author, trustedLogins, comments, (comment) => comment.user?.login, (comment) => ts(comment.created_at)),
                 ...collectFeedbackAt(
                   author,
+                  trustedLogins,
                   reviews,
                   (review) => review.user?.login,
                   (review) => ts(review.submitted_at || review.created_at),
@@ -206,7 +261,7 @@ jobs:
                     return state !== 'APPROVED' && state !== 'DISMISSED' && state !== 'PENDING';
                   },
                 ),
-                ...collectFeedbackAt(author, reviewComments, (reviewComment) => reviewComment.user?.login, (reviewComment) => ts(reviewComment.created_at)),
+                ...collectFeedbackAt(author, trustedLogins, reviewComments, (reviewComment) => reviewComment.user?.login, (reviewComment) => ts(reviewComment.created_at)),
               ].filter((feedbackAt) => feedbackAt > latestAuthorResponseAt);
 
               if (feedbackAts.length === 0) {

--- a/.github/workflows/pr-author-inactivity.yml
+++ b/.github/workflows/pr-author-inactivity.yml
@@ -97,6 +97,19 @@ jobs:
                 .filter(Boolean);
             }
 
+            function debugFeedbackShape(kind, item) {
+              return JSON.stringify({
+                kind,
+                login: item?.user?.login,
+                author_association: item?.author_association,
+                authorAssociation: item?.authorAssociation,
+                state: item?.state,
+                created_at: item?.created_at,
+                submitted_at: item?.submitted_at,
+                body_preview: item?.body?.slice?.(0, 80),
+              });
+            }
+
             const now = Date.now();
             const summary = [];
             const diagnostics = [];
@@ -132,6 +145,18 @@ jobs:
                   issue_number: pr.number,
                 }),
               ]);
+
+              if (DRY_RUN && pr.number === 642) {
+                for (const comment of comments.slice(0, 5)) {
+                  core.info(`DEBUG #642 comment ${debugFeedbackShape('comment', comment)}`);
+                }
+                for (const review of reviews.slice(0, 5)) {
+                  core.info(`DEBUG #642 review ${debugFeedbackShape('review', review)}`);
+                }
+                for (const reviewComment of reviewComments.slice(0, 5)) {
+                  core.info(`DEBUG #642 reviewComment ${debugFeedbackShape('reviewComment', reviewComment)}`);
+                }
+              }
 
               let latestAuthorResponseAt = 0;
 

--- a/.github/workflows/pr-author-inactivity.yml
+++ b/.github/workflows/pr-author-inactivity.yml
@@ -4,16 +4,19 @@ name: PR author inactivity
 # for more than 3 days, and close after more than 5 days.
 #
 # Inactivity heuristic:
-# - We look for the latest trusted non-author feedback on an open PR via:
-#   1) issue comments,
-#   2) non-approval reviews, or
-#   3) inline review comments.
-# - We then check whether the PR author responded after that feedback via:
+# - We look for the PR author's latest response via:
 #   1) an issue comment,
 #   2) a submitted pull-request review,
 #   3) an inline review comment reply, or
 #   4) a commit / force-push timeline event.
-# - If not, we remind once after 72h and close after 120h.
+# - We then find the first trusted human reviewer / maintainer feedback that
+#   arrived after that author response via:
+#   1) issue comments,
+#   2) non-approval reviews, or
+#   3) inline review comments.
+# - Only author activity resets the clock. Later reviewer / maintainer bumps do
+#   not. If that feedback goes unanswered, we remind once after 72h and close
+#   after 120h.
 #
 # Bot feedback note: trusted human reviewers / maintainers are the trigger for
 # this workflow. Bot-authored reviews and comments (e.g. CodeRabbit, Codex) are
@@ -73,6 +76,19 @@ jobs:
               direction: 'asc',
             });
 
+            function collectFeedbackAt(author, collection, getLogin, getTimestamp, predicate = () => true) {
+              return collection
+                .filter((item) => {
+                  const login = getLogin(item);
+                  if (!login || login === author || isBot(login) || !isTrustedReviewer(item)) {
+                    return false;
+                  }
+                  return predicate(item);
+                })
+                .map((item) => getTimestamp(item))
+                .filter(Boolean);
+            }
+
             const now = Date.now();
             const summary = [];
 
@@ -104,40 +120,6 @@ jobs:
                   issue_number: pr.number,
                 }),
               ]);
-
-              let latestFeedbackAt = 0;
-
-              for (const comment of comments) {
-                const login = comment.user?.login;
-                if (login === author || isBot(login) || !isTrustedReviewer(comment)) {
-                  continue;
-                }
-                latestFeedbackAt = Math.max(latestFeedbackAt, ts(comment.created_at));
-              }
-
-              for (const review of reviews) {
-                const login = review.user?.login;
-                const state = review.state?.toUpperCase();
-                if (login === author || isBot(login) || !isTrustedReviewer(review)) {
-                  continue;
-                }
-                if (state === 'APPROVED' || state === 'DISMISSED' || state === 'PENDING') {
-                  continue;
-                }
-                latestFeedbackAt = Math.max(latestFeedbackAt, ts(review.submitted_at || review.created_at));
-              }
-
-              for (const reviewComment of reviewComments) {
-                const login = reviewComment.user?.login;
-                if (login === author || isBot(login) || !isTrustedReviewer(reviewComment)) {
-                  continue;
-                }
-                latestFeedbackAt = Math.max(latestFeedbackAt, ts(reviewComment.created_at));
-              }
-
-              if (!latestFeedbackAt) {
-                continue;
-              }
 
               let latestAuthorResponseAt = 0;
 
@@ -175,15 +157,32 @@ jobs:
                 latestAuthorResponseAt = Math.max(latestAuthorResponseAt, ts(event.created_at));
               }
 
-              if (latestAuthorResponseAt > latestFeedbackAt) {
+              const feedbackAts = [
+                ...collectFeedbackAt(author, comments, (comment) => comment.user?.login, (comment) => ts(comment.created_at)),
+                ...collectFeedbackAt(
+                  author,
+                  reviews,
+                  (review) => review.user?.login,
+                  (review) => ts(review.submitted_at || review.created_at),
+                  (review) => {
+                    const state = review.state?.toUpperCase();
+                    return state !== 'APPROVED' && state !== 'DISMISSED' && state !== 'PENDING';
+                  },
+                ),
+                ...collectFeedbackAt(author, reviewComments, (reviewComment) => reviewComment.user?.login, (reviewComment) => ts(reviewComment.created_at)),
+              ].filter((feedbackAt) => feedbackAt > latestAuthorResponseAt);
+
+              if (feedbackAts.length === 0) {
                 continue;
               }
 
+              const feedbackAt = Math.min(...feedbackAts);
+
               const reminderSent = comments.some((comment) => {
-                return ts(comment.created_at) > latestFeedbackAt && comment.body?.includes(REMINDER_MARKER);
+                return ts(comment.created_at) > feedbackAt && comment.body?.includes(REMINDER_MARKER);
               });
 
-              const inactiveFor = now - latestFeedbackAt;
+              const inactiveFor = now - feedbackAt;
 
               if (inactiveFor >= CLOSE_MS) {
                 await github.rest.issues.createComment({

--- a/.github/workflows/pr-author-inactivity.yml
+++ b/.github/workflows/pr-author-inactivity.yml
@@ -55,7 +55,7 @@ jobs:
             const REMINDER_MARKER = '<!-- pr-author-inactivity:reminder -->';
             const REMINDER_MS = 72 * 60 * 60 * 1000;
             const CLOSE_MS = 120 * 60 * 60 * 1000;
-            const DRY_RUN = core.getBooleanInput('dry_run');
+            const DRY_RUN = String(context.payload.inputs?.dry_run || 'false').toLowerCase() === 'true';
 
             function ts(value) {
               return value ? new Date(value).getTime() : 0;

--- a/.github/workflows/pr-author-inactivity.yml
+++ b/.github/workflows/pr-author-inactivity.yml
@@ -98,10 +98,14 @@ jobs:
 
             const now = Date.now();
             const summary = [];
+            const diagnostics = [];
 
             for (const pr of pulls) {
               const author = pr.user?.login;
               if (!author || pr.draft || isBot(author)) {
+                if (DRY_RUN) {
+                  diagnostics.push(`#${pr.number}: skipped (${!author ? 'missing-author' : pr.draft ? 'draft' : 'bot-author'})`);
+                }
                 continue;
               }
 
@@ -180,6 +184,11 @@ jobs:
               ].filter((feedbackAt) => feedbackAt > latestAuthorResponseAt);
 
               if (feedbackAts.length === 0) {
+                if (DRY_RUN) {
+                  diagnostics.push(
+                    `#${pr.number}: skipped (no outstanding trusted feedback after author response; latestAuthorResponseAt=${latestAuthorResponseAt ? new Date(latestAuthorResponseAt).toISOString() : 'none'})`,
+                  );
+                }
                 continue;
               }
 
@@ -191,6 +200,7 @@ jobs:
 
               const inactiveFor = now - feedbackAt;
               const inactiveHours = Math.floor(inactiveFor / 3600000);
+              const feedbackAtIso = new Date(feedbackAt).toISOString();
 
               if (inactiveFor >= CLOSE_MS) {
                 const line = DRY_RUN
@@ -198,6 +208,9 @@ jobs:
                   : `#${pr.number}: closed after ${inactiveHours}h of author inactivity`;
 
                 if (DRY_RUN) {
+                  diagnostics.push(
+                    `#${pr.number}: action=would-close latestAuthorResponseAt=${latestAuthorResponseAt ? new Date(latestAuthorResponseAt).toISOString() : 'none'} firstOutstandingFeedbackAt=${feedbackAtIso} reminderSent=${reminderSent}`,
+                  );
                   summary.push(line);
                   continue;
                 }
@@ -230,6 +243,9 @@ jobs:
                   : `#${pr.number}: reminded after ${inactiveHours}h of author inactivity`;
 
                 if (DRY_RUN) {
+                  diagnostics.push(
+                    `#${pr.number}: action=would-remind latestAuthorResponseAt=${latestAuthorResponseAt ? new Date(latestAuthorResponseAt).toISOString() : 'none'} firstOutstandingFeedbackAt=${feedbackAtIso} reminderSent=${reminderSent}`,
+                  );
                   summary.push(line);
                   continue;
                 }
@@ -248,6 +264,19 @@ jobs:
                 });
 
                 summary.push(line);
+                continue;
+              }
+
+              if (DRY_RUN) {
+                diagnostics.push(
+                  `#${pr.number}: skipped (already-reminded-or-below-threshold) latestAuthorResponseAt=${latestAuthorResponseAt ? new Date(latestAuthorResponseAt).toISOString() : 'none'} firstOutstandingFeedbackAt=${feedbackAtIso} inactiveHours=${inactiveHours} reminderSent=${reminderSent}`,
+                );
+              }
+            }
+
+            if (DRY_RUN) {
+              for (const line of diagnostics) {
+                core.info(line);
               }
             }
 


### PR DESCRIPTION
<!-- No linked issue; this is a maintainer workflow fix. -->

## Why

- **Use case** — while checking why the new PR inactivity workflow never hit any PRs, we inspected `#642` and found that repeated maintainer follow-up comments kept resetting the inactivity clock.
- **Pain being addressed** — there were actually two bugs in the workflow logic:
  1. the inactivity clock was anchored to the latest feedback overall instead of the first feedback after the author's last response, so queue-management bumps and housekeeping comments could indefinitely postpone reminder/close thresholds;
  2. the trusted-reviewer filter relied on `author_association`, but on the live Actions payload for `#642` the maintainers/reviewers showed up as `CONTRIBUTOR`, so the workflow silently discarded exactly the feedback it was supposed to act on.

## What users will see

- PR authors are now measured against the **first trusted reviewer/maintainer feedback that arrived after their last response**, instead of the most recent feedback overall.
- Only author activity resets the inactivity clock: comment, submitted PR review, inline reply, commit, or force-push.
- Later maintainer/reviewer nudges no longer buy the PR another 72h/120h window.
- Trusted reviewers are now determined by **repository collaborator permission** (`admin` / `maintain` / `write` / `triage`) instead of `author_association`, so the workflow behaves correctly on the real GitHub Actions payload shape.
- Manual `workflow_dispatch` runs now expose a `dry_run` toggle that prints the PRs the workflow would remind/close without posting comments or closing anything.
- On the current queue, PR `#642` now shows up as `would close` in dry-run output instead of being skipped.

## Surface area

- [ ] **UI** — n/a
- [ ] **Keyboard shortcut** — n/a
- [ ] **CLI / env var** — n/a
- [ ] **API / contract** — n/a
- [ ] **Extension point** — n/a
- [ ] **i18n keys** — n/a
- [ ] **New top-level dependency** — n/a
- [x] **Default behavior change** — changes when the public PR queue auto-reminder/auto-close workflow fires.
- [ ] **None**

## Screenshots

n/a — workflow-only change.

## Bug fix verification

- Test path that reproduces the bug: manual `workflow_dispatch` dry run against live repo data.
- Did the test go red on `main` and green on this branch? yes:
  - before the fix, the workflow reported `Dry run: no inactive PRs would need action.` and skipped `#642`;
  - after the fix, the workflow reports `#642: would close after 309h of author inactivity` along with many other stale PRs that would now be reminded/closed.
- A formal repo test harness for this workflow logic does not exist yet; verification here is the live dry run plus YAML validation.

## Validation

- `pnpm dlx js-yaml .github/workflows/pr-author-inactivity.yml`
- Manual `workflow_dispatch` dry run on this branch:
  - run: `https://github.com/nexu-io/open-design/actions/runs/26079043224`
  - `#642: action=would-close latestAuthorResponseAt=none firstOutstandingFeedbackAt=2026-05-06T08:27:06.000Z reminderSent=false`
  - `#642: would close after 309h of author inactivity`
- Confirmed the workflow now produces a real action list again, including many `would close` / `would remind` entries for similar stale PRs.
- Confirmed the workflow still preserves the earlier queue-management fixes:
  - author PR reviews count as responses
  - bot reviews/comments remain excluded from the feedback trigger
  - dry-run mode performs no side effects (no comments, no closes)