### PR TITLE
Add preview iframe keep-alive pool

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1142,7 +1142,7 @@ function AppInner() {
           || previous.customInstructions !== updated.customInstructions
         )
       ) {
-        iframeKeepAlivePool.evictProject(updated.id);
+        iframeKeepAlivePool.evictProject(updated.id, { includeActive: true });
       }
       return curr.map((p) => (p.id === updated.id ? updated : p));
     });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -28,6 +28,10 @@ import {
   DesignSystemDetailView,
 } from './components/DesignSystemFlow';
 import {
+  IframeKeepAliveProvider,
+  useIframeKeepAlivePool,
+} from './components/IframeKeepAlivePool';
+import {
   SettingsDialog,
   switchApiProtocolConfig,
   updateCurrentApiProtocolConfig,
@@ -171,7 +175,16 @@ export function resolveSettingsCloseConfig(
 }
 
 export function App() {
+  return (
+    <IframeKeepAliveProvider>
+      <AppInner />
+    </IframeKeepAliveProvider>
+  );
+}
+
+function AppInner() {
   const { t } = useI18n();
+  const iframeKeepAlivePool = useIframeKeepAlivePool();
   const clientType = useMemo(() => detectClientType(), []);
   // Observability marker. `apps/web/src/observability/white-screen.ts`
   // keys its "app actually mounted" success condition on this attribute
@@ -1076,12 +1089,13 @@ export function App() {
   const handleDeleteProject = useCallback(async (id: string) => {
     const ok = await deleteProjectApi(id);
     if (!ok) return false;
+    iframeKeepAlivePool.evictProject(id, { includeActive: true });
     setProjects((curr) => curr.filter((p) => p.id !== id));
     if (route.kind === 'project' && route.projectId === id) {
       navigate({ kind: 'home', view: 'home' });
     }
     return true;
-  }, [route]);
+  }, [iframeKeepAlivePool, route]);
 
   const handleRenameProject = useCallback(async (id: string, name: string) => {
     const trimmed = name.trim();
@@ -1118,8 +1132,21 @@ export function App() {
   }, [route]);
 
   const handleProjectChange = useCallback((updated: Project) => {
-    setProjects((curr) => curr.map((p) => (p.id === updated.id ? updated : p)));
-  }, []);
+    setProjects((curr) => {
+      const previous = curr.find((p) => p.id === updated.id);
+      if (
+        previous
+        && (
+          previous.skillId !== updated.skillId
+          || previous.designSystemId !== updated.designSystemId
+          || previous.customInstructions !== updated.customInstructions
+        )
+      ) {
+        iframeKeepAlivePool.evictProject(updated.id);
+      }
+      return curr.map((p) => (p.id === updated.id ? updated : p));
+    });
+  }, [iframeKeepAlivePool]);
 
   const activeProject =
     route.kind === 'project'

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1148,6 +1148,55 @@ function AppInner() {
     });
   }, [iframeKeepAlivePool]);
 
+  // ProjectView's prompt-context signature derives from SkillSummary /
+  // DesignSystemSummary fields, so a body-only registry edit (same name,
+  // description, etc.) leaves every signature unchanged and the active
+  // preview keeps serving stale prompt context. Settings → Skills /
+  // Settings → Design Systems call back through these handlers after
+  // every successful mutation; we drop any pool entry whose project
+  // depends on the affected id — active or parked — so the next mount
+  // recomposes the system prompt with the new body. A ref tracks
+  // projects so the callback is stable across renders.
+  const projectsRef = useRef<Project[]>(projects);
+  useEffect(() => {
+    projectsRef.current = projects;
+  }, [projects]);
+
+  const handleSkillsChanged = useCallback(
+    (affectedSkillId?: string) => {
+      void fetchSkills().then((list) => setSkills(list));
+      void fetchDesignTemplates().then((list) => setDesignTemplates(list));
+      iframeKeepAlivePool.evictMatching(
+        (entry) => {
+          const proj = projectsRef.current.find((p) => p.id === entry.projectId);
+          if (!proj) return false;
+          if (affectedSkillId) return proj.skillId === affectedSkillId;
+          return proj.skillId != null;
+        },
+        { includeActive: true },
+      );
+    },
+    [iframeKeepAlivePool],
+  );
+
+  const handleDesignSystemsChanged = useCallback(
+    (affectedDesignSystemId?: string) => {
+      void fetchDesignSystems().then((list) => setDesignSystems(list));
+      iframeKeepAlivePool.evictMatching(
+        (entry) => {
+          const proj = projectsRef.current.find((p) => p.id === entry.projectId);
+          if (!proj) return false;
+          if (affectedDesignSystemId) {
+            return proj.designSystemId === affectedDesignSystemId;
+          }
+          return proj.designSystemId != null;
+        },
+        { includeActive: true },
+      );
+    },
+    [iframeKeepAlivePool],
+  );
+
   const activeProject =
     route.kind === 'project'
       ? (projects.find((p) => p.id === route.projectId) ?? null)
@@ -1550,6 +1599,8 @@ function AppInner() {
           daemonMediaProvidersFetchState={daemonMediaProvidersFetchState}
           mediaProvidersNotice={mediaProvidersNotice}
           onReloadMediaProviders={reloadMediaProvidersFromDaemon}
+          onSkillsChanged={handleSkillsChanged}
+          onDesignSystemsChanged={handleDesignSystemsChanged}
         />
       ) : null}
       <MemoryToast onOpenMemory={() => openSettings('memory')} />

--- a/apps/web/src/components/DesignSystemsSection.tsx
+++ b/apps/web/src/components/DesignSystemsSection.tsx
@@ -20,6 +20,13 @@ import { orderDesignSystemGroups } from './design-system-group-order';
 interface Props {
   cfg: AppConfig;
   setCfg: Dispatch<SetStateAction<AppConfig>>;
+  /**
+   * Notified after a successful design-system mutation (today: import).
+   * Lets App.tsx evict preview iframes whose project depends on the
+   * affected design system; body-only edits on existing systems would
+   * also flow through here when an edit affordance lands.
+   */
+  onDesignSystemsChanged?: (affectedDesignSystemId?: string) => void;
 }
 
 function toggleCraftSlug(current: string[], slug: string, enabled: boolean): string[] {
@@ -29,7 +36,7 @@ function toggleCraftSlug(current: string[], slug: string, enabled: boolean): str
   return Array.from(next);
 }
 
-export function DesignSystemsSection({ cfg, setCfg }: Props) {
+export function DesignSystemsSection({ cfg, setCfg, onDesignSystemsChanged }: Props) {
   const t = useT();
   const cardRefs = useRef(new Map<string, HTMLDivElement>());
   const [designSystems, setDesignSystems] = useState<DesignSystemSummary[]>([]);
@@ -230,6 +237,7 @@ export function DesignSystemsSection({ cfg, setCfg }: Props) {
     setImportPath('');
     setImportedDesignSystem(result.designSystem);
     setImportMessage(result.designSystem.title);
+    onDesignSystemsChanged?.(result.designSystem.id);
   }
 
   function viewImportedDesignSystem() {

--- a/apps/web/src/components/DesignSystemsSection.tsx
+++ b/apps/web/src/components/DesignSystemsSection.tsx
@@ -21,10 +21,10 @@ interface Props {
   cfg: AppConfig;
   setCfg: Dispatch<SetStateAction<AppConfig>>;
   /**
-   * Notified after a successful design-system mutation (today: import).
+   * Notified after a successful design-system mutation.
    * Lets App.tsx evict preview iframes whose project depends on the
-   * affected design system; body-only edits on existing systems would
-   * also flow through here when an edit affordance lands.
+   * affected design system; body-only edits on existing systems also
+   * flow through here.
    */
   onDesignSystemsChanged?: (affectedDesignSystemId?: string) => void;
 }
@@ -185,6 +185,7 @@ export function DesignSystemsSection({ cfg, setCfg, onDesignSystemsChanged }: Pr
           .map((d) => (d.id === targetId ? { ...d, title: updated.title } : d))
           .sort((a, b) => a.title.localeCompare(b.title)),
       );
+      onDesignSystemsChanged?.(targetId);
     }
     // Ignore a stale completion: the user cancelled or opened another rename
     // while this PATCH was in flight, so the modal state now belongs to a

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -100,6 +100,11 @@ import {
 } from '../comments';
 import { applyPodMemberRemoval } from '../lib/pod-members';
 import { AnnotationHoverPopover, BoardComposerPopover } from './BoardComposerPopover';
+import {
+  OD_PREVIEW_KEEP_ALIVE,
+  PooledIframe,
+  previewIframeKeepAliveKey,
+} from './IframeKeepAlivePool';
 import type {
   ChatCommentAttachment,
   PreviewComment,
@@ -4367,6 +4372,7 @@ function HtmlViewer({
   const [srcDocTransportResetKey, setSrcDocTransportResetKey] = useState(0);
   const [srcDocShellReady, setSrcDocShellReady] = useState(false);
   const wasUrlLoadPreviewRef = useRef(useUrlLoadPreview);
+  const urlPreviewKeepAliveKey = previewIframeKeepAliveKey(projectId, file.name);
   // Reset the shell-ready latch whenever the srcDoc iframe re-mounts. The
   // next shell will post `od:srcdoc-transport-ready` (or fire onLoad) and
   // flip this back to true. See #2253.
@@ -6700,28 +6706,54 @@ function HtmlViewer({
                   sendDisabledReason="当前正有任务在执行"
                 >
                   <div className="artifact-preview-transport-stack">
-                    <iframe
-                      ref={urlPreviewIframeRef}
-                      data-testid={useUrlLoadPreview ? 'artifact-preview-frame' : 'artifact-preview-frame-url-load'}
-                      data-od-render-mode="url-load"
-                      data-od-active={useUrlLoadPreview ? 'true' : 'false'}
-                      aria-hidden={useUrlLoadPreview ? undefined : true}
-                      tabIndex={useUrlLoadPreview ? 0 : -1}
-                      title={file.name}
-                      sandbox="allow-scripts allow-downloads"
-                      src={urlTransportSrc}
-                      onLoad={() => {
-                        const frame = urlPreviewIframeRef.current;
-                        if (useUrlLoadPreview) iframeRef.current = frame;
-                        dcViewportRestoreAtRef.current = Date.now();
-                        frame?.contentWindow?.postMessage({
-                          type: '__dc_set_viewport',
-                          ...dcViewportRef.current,
-                        }, '*');
-                        syncBridgeModes(frame);
-                        if (useUrlLoadPreview) restorePreviewScrollPosition();
-                      }}
-                    />
+                    {OD_PREVIEW_KEEP_ALIVE ? (
+                      <PooledIframe
+                        ref={urlPreviewIframeRef}
+                        cacheKey={urlPreviewKeepAliveKey}
+                        data-testid={useUrlLoadPreview ? 'artifact-preview-frame' : 'artifact-preview-frame-url-load'}
+                        data-od-render-mode="url-load"
+                        data-od-active={useUrlLoadPreview ? 'true' : 'false'}
+                        aria-hidden={useUrlLoadPreview ? undefined : true}
+                        tabIndex={useUrlLoadPreview ? 0 : -1}
+                        title={file.name}
+                        sandbox="allow-scripts allow-downloads"
+                        src={urlTransportSrc}
+                        onLoad={() => {
+                          const frame = urlPreviewIframeRef.current;
+                          if (useUrlLoadPreview) iframeRef.current = frame;
+                          dcViewportRestoreAtRef.current = Date.now();
+                          frame?.contentWindow?.postMessage({
+                            type: '__dc_set_viewport',
+                            ...dcViewportRef.current,
+                          }, '*');
+                          syncBridgeModes(frame);
+                          if (useUrlLoadPreview) restorePreviewScrollPosition();
+                        }}
+                      />
+                    ) : (
+                      <iframe
+                        ref={urlPreviewIframeRef}
+                        data-testid={useUrlLoadPreview ? 'artifact-preview-frame' : 'artifact-preview-frame-url-load'}
+                        data-od-render-mode="url-load"
+                        data-od-active={useUrlLoadPreview ? 'true' : 'false'}
+                        aria-hidden={useUrlLoadPreview ? undefined : true}
+                        tabIndex={useUrlLoadPreview ? 0 : -1}
+                        title={file.name}
+                        sandbox="allow-scripts allow-downloads"
+                        src={urlTransportSrc}
+                        onLoad={() => {
+                          const frame = urlPreviewIframeRef.current;
+                          if (useUrlLoadPreview) iframeRef.current = frame;
+                          dcViewportRestoreAtRef.current = Date.now();
+                          frame?.contentWindow?.postMessage({
+                            type: '__dc_set_viewport',
+                            ...dcViewportRef.current,
+                          }, '*');
+                          syncBridgeModes(frame);
+                          if (useUrlLoadPreview) restorePreviewScrollPosition();
+                        }}
+                      />
+                    )}
                     <iframe
                       key={srcDocTransportResetKey}
                       ref={srcDocPreviewIframeRef}

--- a/apps/web/src/components/IframeKeepAlivePool.tsx
+++ b/apps/web/src/components/IframeKeepAlivePool.tsx
@@ -82,14 +82,16 @@ export function IframeKeepAliveProvider({
   const parkedHostRef = useRef<HTMLDivElement | null>(null);
   const entriesRef = useRef<Map<string, PoolEntry>>(new Map());
   const activeKeysRef = useRef<Set<string>>(new Set());
-  const [, forceRender] = useState(0);
+  const [poolRevision, bumpPoolRevision] = useState(0);
 
-  const removeEntry = (key: string) => {
+  const removeEntry = (key: string): boolean => {
     const entry = entriesRef.current.get(key);
-    if (!entry) return;
+    if (!entry) return false;
+    const wasActive = activeKeysRef.current.has(key);
     entry.element.remove();
     entriesRef.current.delete(key);
     activeKeysRef.current.delete(key);
+    return wasActive;
   };
 
   const enforceLimit = () => {
@@ -133,32 +135,33 @@ export function IframeKeepAliveProvider({
       enforceLimit();
     },
     evict(key) {
-      removeEntry(key);
-      forceRender((value) => value + 1);
+      if (removeEntry(key)) bumpPoolRevision((value) => value + 1);
     },
     evictProject(projectId, options) {
+      let removedActive = false;
       for (const entry of Array.from(entriesRef.current.values())) {
         if (
           entry.projectId === projectId
           && (options?.includeActive || !activeKeysRef.current.has(entry.key))
         ) {
-          removeEntry(entry.key);
+          removedActive = removeEntry(entry.key) || removedActive;
         }
       }
-      forceRender((value) => value + 1);
+      if (removedActive) bumpPoolRevision((value) => value + 1);
     },
     evictMatching(predicate, options) {
+      let removedActive = false;
       for (const entry of Array.from(entriesRef.current.values())) {
         if (
           (options?.includeActive || !activeKeysRef.current.has(entry.key))
           && predicate(entry)
         ) {
-          removeEntry(entry.key);
+          removedActive = removeEntry(entry.key) || removedActive;
         }
       }
-      forceRender((value) => value + 1);
+      if (removedActive) bumpPoolRevision((value) => value + 1);
     },
-  }), [maxEntries]);
+  }), [maxEntries, poolRevision]);
 
   useEffect(() => () => {
     for (const key of Array.from(entriesRef.current.keys())) removeEntry(key);

--- a/apps/web/src/components/IframeKeepAlivePool.tsx
+++ b/apps/web/src/components/IframeKeepAlivePool.tsx
@@ -32,7 +32,10 @@ interface IframeKeepAlivePoolValue {
   release(key: string): void;
   evict(key: string): void;
   evictProject(projectId: string, options?: { includeActive?: boolean }): void;
-  evictMatching(predicate: (entry: PoolEntry) => boolean): void;
+  evictMatching(
+    predicate: (entry: PoolEntry) => boolean,
+    options?: { includeActive?: boolean },
+  ): void;
 }
 
 const IframeKeepAliveContext = createContext<IframeKeepAlivePoolValue | null>(null);
@@ -144,9 +147,12 @@ export function IframeKeepAliveProvider({
       }
       forceRender((value) => value + 1);
     },
-    evictMatching(predicate) {
+    evictMatching(predicate, options) {
       for (const entry of Array.from(entriesRef.current.values())) {
-        if (!activeKeysRef.current.has(entry.key) && predicate(entry)) {
+        if (
+          (options?.includeActive || !activeKeysRef.current.has(entry.key))
+          && predicate(entry)
+        ) {
           removeEntry(entry.key);
         }
       }
@@ -212,7 +218,10 @@ export function useIframeKeepAlivePool(): IframeKeepAlivePoolValue {
           if (entry.projectId === projectId) removeFallbackEntry(entry.key);
         }
       },
-      evictMatching(predicate) {
+      evictMatching(predicate, _options) {
+        // Fallback pool only attaches a single active entry at a time and
+        // never parks, so includeActive is a no-op here — we always
+        // remove any matching entry regardless.
         for (const entry of Array.from(fallbackEntriesRef.current.values())) {
           if (predicate(entry)) removeFallbackEntry(entry.key);
         }

--- a/apps/web/src/components/IframeKeepAlivePool.tsx
+++ b/apps/web/src/components/IframeKeepAlivePool.tsx
@@ -1,0 +1,391 @@
+import {
+  createContext,
+  forwardRef,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  type CSSProperties,
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+  type Ref,
+  type SyntheticEvent,
+} from 'react';
+
+export const OD_PREVIEW_KEEP_ALIVE =
+  typeof process === 'undefined' || process.env.OD_PREVIEW_KEEP_ALIVE !== '0';
+export const DEFAULT_IFRAME_KEEP_ALIVE_POOL_SIZE = 5;
+
+interface PoolEntry {
+  key: string;
+  projectId: string;
+  fileName: string;
+  element: HTMLIFrameElement;
+  lastUsedAt: number;
+}
+
+interface IframeKeepAlivePoolValue {
+  attach(key: string, host: HTMLElement, create: () => HTMLIFrameElement): HTMLIFrameElement;
+  release(key: string): void;
+  evict(key: string): void;
+  evictProject(projectId: string, options?: { includeActive?: boolean }): void;
+  evictMatching(predicate: (entry: PoolEntry) => boolean): void;
+}
+
+const IframeKeepAliveContext = createContext<IframeKeepAlivePoolValue | null>(null);
+const subscribeToNoopStore = () => () => {};
+const getClientSnapshot = () => false;
+const getServerSnapshot = () => true;
+
+function useIsServerRender() {
+  return useSyncExternalStore(
+    subscribeToNoopStore,
+    getClientSnapshot,
+    getServerSnapshot,
+  );
+}
+
+export function previewIframeKeepAliveKey(projectId: string, fileName: string): string {
+  return `${projectId}\0${fileName}`;
+}
+
+function parkIframeElement(frame: HTMLIFrameElement) {
+  frame.onload = null;
+  frame.removeAttribute('data-testid');
+  frame.setAttribute('data-od-active', 'false');
+  frame.setAttribute('aria-hidden', 'true');
+  frame.setAttribute('tabindex', '-1');
+}
+
+function parseKeepAliveKey(key: string): { projectId: string; fileName: string } {
+  const separator = key.indexOf('\0');
+  if (separator < 0) return { projectId: key, fileName: '' };
+  return {
+    projectId: key.slice(0, separator),
+    fileName: key.slice(separator + 1),
+  };
+}
+
+export function IframeKeepAliveProvider({
+  children,
+  maxEntries = DEFAULT_IFRAME_KEEP_ALIVE_POOL_SIZE,
+}: {
+  children: ReactNode;
+  maxEntries?: number;
+}) {
+  const parkedHostRef = useRef<HTMLDivElement | null>(null);
+  const entriesRef = useRef<Map<string, PoolEntry>>(new Map());
+  const activeKeysRef = useRef<Set<string>>(new Set());
+  const [, forceRender] = useState(0);
+
+  const removeEntry = (key: string) => {
+    const entry = entriesRef.current.get(key);
+    if (!entry) return;
+    entry.element.remove();
+    entriesRef.current.delete(key);
+    activeKeysRef.current.delete(key);
+  };
+
+  const enforceLimit = () => {
+    const inactive = Array.from(entriesRef.current.values())
+      .filter((entry) => !activeKeysRef.current.has(entry.key))
+      .sort((a, b) => a.lastUsedAt - b.lastUsedAt);
+    while (entriesRef.current.size > maxEntries && inactive.length > 0) {
+      const evicted = inactive.shift();
+      if (!evicted) break;
+      removeEntry(evicted.key);
+    }
+  };
+
+  const pool = useMemo<IframeKeepAlivePoolValue>(() => ({
+    attach(key, host, create) {
+      let entry = entriesRef.current.get(key);
+      if (!entry) {
+        const { projectId, fileName } = parseKeepAliveKey(key);
+        entry = {
+          key,
+          projectId,
+          fileName,
+          element: create(),
+          lastUsedAt: Date.now(),
+        };
+        entriesRef.current.set(key, entry);
+      }
+      entry.lastUsedAt = Date.now();
+      activeKeysRef.current.add(key);
+      host.appendChild(entry.element);
+      return entry.element;
+    },
+    release(key) {
+      const entry = entriesRef.current.get(key);
+      const parkedHost = parkedHostRef.current;
+      activeKeysRef.current.delete(key);
+      if (entry && parkedHost) {
+        parkIframeElement(entry.element);
+        parkedHost.appendChild(entry.element);
+      }
+      enforceLimit();
+    },
+    evict(key) {
+      removeEntry(key);
+      forceRender((value) => value + 1);
+    },
+    evictProject(projectId, options) {
+      for (const entry of Array.from(entriesRef.current.values())) {
+        if (
+          entry.projectId === projectId
+          && (options?.includeActive || !activeKeysRef.current.has(entry.key))
+        ) {
+          removeEntry(entry.key);
+        }
+      }
+      forceRender((value) => value + 1);
+    },
+    evictMatching(predicate) {
+      for (const entry of Array.from(entriesRef.current.values())) {
+        if (!activeKeysRef.current.has(entry.key) && predicate(entry)) {
+          removeEntry(entry.key);
+        }
+      }
+      forceRender((value) => value + 1);
+    },
+  }), [maxEntries]);
+
+  useEffect(() => () => {
+    for (const key of Array.from(entriesRef.current.keys())) removeEntry(key);
+  }, []);
+
+  return (
+    <IframeKeepAliveContext.Provider value={pool}>
+      {children}
+      <div
+        ref={parkedHostRef}
+        className="iframe-keep-alive-pool"
+        aria-hidden="true"
+      />
+    </IframeKeepAliveContext.Provider>
+  );
+}
+
+export function useIframeKeepAlivePool(): IframeKeepAlivePoolValue {
+  const pool = useContext(IframeKeepAliveContext);
+  const fallbackEntriesRef = useRef<Map<string, PoolEntry>>(new Map());
+  const fallbackActiveKeysRef = useRef<Set<string>>(new Set());
+  const fallbackPool = useMemo<IframeKeepAlivePoolValue>(() => {
+    const removeFallbackEntry = (key: string) => {
+      const entry = fallbackEntriesRef.current.get(key);
+      if (!entry) return;
+      entry.element.remove();
+      fallbackEntriesRef.current.delete(key);
+      fallbackActiveKeysRef.current.delete(key);
+    };
+    return {
+      attach(key, host, create) {
+        let entry = fallbackEntriesRef.current.get(key);
+        if (!entry) {
+          const { projectId, fileName } = parseKeepAliveKey(key);
+          entry = {
+            key,
+            projectId,
+            fileName,
+            element: create(),
+            lastUsedAt: Date.now(),
+          };
+          fallbackEntriesRef.current.set(key, entry);
+        }
+        entry.lastUsedAt = Date.now();
+        fallbackActiveKeysRef.current.add(key);
+        host.appendChild(entry.element);
+        return entry.element;
+      },
+      release(key) {
+        removeFallbackEntry(key);
+      },
+      evict(key) {
+        removeFallbackEntry(key);
+      },
+      evictProject(projectId) {
+        for (const entry of Array.from(fallbackEntriesRef.current.values())) {
+          if (entry.projectId === projectId) removeFallbackEntry(entry.key);
+        }
+      },
+      evictMatching(predicate) {
+        for (const entry of Array.from(fallbackEntriesRef.current.values())) {
+          if (predicate(entry)) removeFallbackEntry(entry.key);
+        }
+      },
+    };
+  }, []);
+  useEffect(() => () => {
+    for (const key of Array.from(fallbackEntriesRef.current.keys())) {
+      const entry = fallbackEntriesRef.current.get(key);
+      entry?.element.remove();
+      fallbackEntriesRef.current.delete(key);
+      fallbackActiveKeysRef.current.delete(key);
+    }
+  }, []);
+  if (!pool) {
+    return fallbackPool;
+  }
+  return pool;
+}
+
+type PooledIframeProps = ComponentPropsWithoutRef<'iframe'> & {
+  cacheKey: string;
+  src: string;
+};
+
+function setForwardedRef(ref: Ref<HTMLIFrameElement> | undefined, value: HTMLIFrameElement | null) {
+  if (typeof ref === 'function') {
+    ref(value);
+  } else if (ref) {
+    (ref as { current: HTMLIFrameElement | null }).current = value;
+  }
+}
+
+function propNameToAttributeName(name: string): string {
+  if (name === 'className') return 'class';
+  if (name === 'htmlFor') return 'for';
+  if (name === 'srcDoc') return 'srcdoc';
+  if (name === 'tabIndex') return 'tabindex';
+  if (name.startsWith('data-') || name.startsWith('aria-')) return name;
+  return name.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`).toLowerCase();
+}
+
+function setAttribute(frame: HTMLIFrameElement, name: string, value: unknown) {
+  if (value == null || value === false) {
+    frame.removeAttribute(name);
+    return;
+  }
+  if (value === true) {
+    frame.setAttribute(name, '');
+    return;
+  }
+  const next = String(value);
+  if (frame.getAttribute(name) !== next) frame.setAttribute(name, next);
+}
+
+function syncStyle(
+  frame: HTMLIFrameElement,
+  style: CSSProperties | undefined,
+  appliedStyleKeys: Set<string>,
+) {
+  if (!style) {
+    frame.removeAttribute('style');
+    appliedStyleKeys.clear();
+    return;
+  }
+  for (const key of Array.from(appliedStyleKeys)) {
+    if (!(key in style)) {
+      frame.style.setProperty(key, '');
+      appliedStyleKeys.delete(key);
+    }
+  }
+  for (const [key, value] of Object.entries(style)) {
+    const cssKey = key.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`);
+    appliedStyleKeys.add(cssKey);
+    if (value == null) {
+      frame.style.setProperty(cssKey, '');
+    } else {
+      frame.style.setProperty(cssKey, String(value));
+    }
+  }
+}
+
+function syncIframeProps(
+  frame: HTMLIFrameElement,
+  props: PooledIframeProps,
+  appliedAttributes: Set<string>,
+  appliedStyleKeys: Set<string>,
+) {
+  const nextAttributes = new Set<string>();
+  for (const [name, value] of Object.entries(props)) {
+    if (
+      name === 'cacheKey'
+      || name === 'src'
+      || name === 'style'
+      || name === 'children'
+      || name === 'dangerouslySetInnerHTML'
+      || name.startsWith('on')
+    ) {
+      continue;
+    }
+    const attributeName = propNameToAttributeName(name);
+    nextAttributes.add(attributeName);
+    setAttribute(frame, attributeName, value);
+  }
+
+  for (const previous of Array.from(appliedAttributes)) {
+    if (!nextAttributes.has(previous)) frame.removeAttribute(previous);
+  }
+  appliedAttributes.clear();
+  for (const attribute of nextAttributes) appliedAttributes.add(attribute);
+
+  syncStyle(frame, props.style, appliedStyleKeys);
+  frame.onload = props.onLoad
+    ? (event) => props.onLoad?.(event as unknown as SyntheticEvent<HTMLIFrameElement>)
+    : null;
+  setAttribute(frame, 'src', props.src);
+}
+
+export const PooledIframe = forwardRef<HTMLIFrameElement, PooledIframeProps>(function PooledIframe({
+  cacheKey,
+  src,
+  ...props
+}, forwardedRef) {
+  const isServerRender = useIsServerRender();
+  if (isServerRender) return <iframe {...props} src={src} />;
+  return (
+    <ClientPooledIframe
+      ref={forwardedRef}
+      cacheKey={cacheKey}
+      src={src}
+      {...props}
+    />
+  );
+});
+
+const ClientPooledIframe = forwardRef<HTMLIFrameElement, PooledIframeProps>(function ClientPooledIframe({
+  cacheKey,
+  src,
+  ...props
+}, forwardedRef) {
+  const pool = useIframeKeepAlivePool();
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const propsRef = useRef<PooledIframeProps>({ cacheKey, src, ...props });
+  const appliedAttributesRef = useRef<Set<string>>(new Set());
+  const appliedStyleKeysRef = useRef<Set<string>>(new Set());
+  propsRef.current = { cacheKey, src, ...props };
+
+  useLayoutEffect(() => {
+    const host = hostRef.current;
+    if (!host) return undefined;
+    const frame = pool.attach(cacheKey, host, () => document.createElement('iframe'));
+    iframeRef.current = frame;
+    return () => {
+      setForwardedRef(forwardedRef, null);
+      iframeRef.current = null;
+      pool.release(cacheKey);
+    };
+  }, [cacheKey, pool, forwardedRef]);
+
+  useLayoutEffect(() => {
+    const frame = iframeRef.current;
+    if (!frame) return;
+    syncIframeProps(
+      frame,
+      propsRef.current,
+      appliedAttributesRef.current,
+      appliedStyleKeysRef.current,
+    );
+    setForwardedRef(forwardedRef, frame);
+  });
+
+  return (
+    <span ref={hostRef} className="pooled-iframe-host" />
+  );
+});

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1361,7 +1361,7 @@ export function ProjectView({
   useEffect(() => {
     if (previousPromptContextSignatureRef.current === activePromptContextSignature) return;
     previousPromptContextSignatureRef.current = activePromptContextSignature;
-    iframeKeepAlivePool.evictProject(project.id);
+    iframeKeepAlivePool.evictProject(project.id, { includeActive: true });
   }, [activePromptContextSignature, iframeKeepAlivePool, project.id]);
 
   // When the URL points at a specific file, fire an open request so the

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -146,6 +146,7 @@ import {
   CritiqueTheaterMount,
   useCritiqueTheaterEnabled,
 } from './Theater';
+import { useIframeKeepAlivePool } from './IframeKeepAlivePool';
 import { decideAutoOpenAfterWrite } from './auto-open-file';
 import { buildRepoImportPrompt, designSystemNeedsRepoConnect } from './design-system-github-evidence';
 import { collectReferencedJsxNames } from '../runtime/jsx-module-refs';
@@ -507,6 +508,7 @@ export function ProjectView({
 }: Props) {
   const { locale, t } = useI18n();
   const analytics = useAnalytics();
+  const iframeKeepAlivePool = useIframeKeepAlivePool();
   // P0 page_view page_name=chat_panel — fire once per project mount.
   // ProjectView outlives conversation switches (ChatPane is keyed by
   // activeConversationId so it remounts when the user switches chats,
@@ -1273,6 +1275,7 @@ export function ProjectView({
   );
   const handleProjectEvent = useCallback((evt: ProjectEvent) => {
     if (evt.type === 'file-changed') {
+      iframeKeepAlivePool.evictProject(project.id);
       coalescedFileChangedRefresh();
       return;
     }
@@ -1321,8 +1324,45 @@ export function ProjectView({
     // Live artifact events come from chat-turn-emitted artifacts; they
     // also imply the conversation transcript changed.
     setDesignMdRefreshKey((n) => n + 1);
-  }, [onProjectsRefresh, refreshLiveArtifacts, project.id, coalescedFileChangedRefresh]);
+  }, [coalescedFileChangedRefresh, iframeKeepAlivePool, onProjectsRefresh, refreshLiveArtifacts, project.id]);
   useProjectFileEvents(project.id, daemonLive, handleProjectEvent);
+
+  const activePromptContextSignature = useMemo(() => {
+    const skill = project.skillId
+      ? (skills.find((s) => s.id === project.skillId) ??
+        designTemplates.find((s) => s.id === project.skillId))
+      : null;
+    const designSystem = project.designSystemId
+      ? designSystems.find((d) => d.id === project.designSystemId)
+      : null;
+    return JSON.stringify({
+      designSystem: designSystem
+        ? {
+            id: designSystem.id,
+            title: designSystem.title,
+            category: designSystem.category,
+            summary: designSystem.summary,
+            source: designSystem.source ?? null,
+          }
+        : null,
+      skill: skill
+        ? {
+            id: skill.id,
+            name: skill.name,
+            description: skill.description,
+            mode: skill.mode,
+            source: skill.source ?? null,
+            upstream: skill.upstream,
+          }
+        : null,
+    });
+  }, [designSystems, designTemplates, project.designSystemId, project.skillId, skills]);
+  const previousPromptContextSignatureRef = useRef(activePromptContextSignature);
+  useEffect(() => {
+    if (previousPromptContextSignatureRef.current === activePromptContextSignature) return;
+    previousPromptContextSignatureRef.current = activePromptContextSignature;
+    iframeKeepAlivePool.evictProject(project.id);
+  }, [activePromptContextSignature, iframeKeepAlivePool, project.id]);
 
   // When the URL points at a specific file, fire an open request so the
   // FileWorkspace promotes it to an active tab. We watch routeFileName

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -182,6 +182,16 @@ interface Props {
   daemonMediaProvidersFetchState?: 'idle' | 'ok' | 'error';
   mediaProvidersNotice?: string | null;
   onReloadMediaProviders?: () => Promise<AppConfig['mediaProviders'] | null>;
+  /**
+   * Notified by Settings → Skills after a successful skill registry
+   * mutation (create / edit / delete). App.tsx uses this to drop preview
+   * iframes whose project depends on the affected skill — body-only
+   * edits do not move SkillSummary fields, so ProjectView's signature
+   * path can miss them.
+   */
+  onSkillsChanged?: (affectedSkillId?: string) => void;
+  /** Same channel for design-system registry mutations. */
+  onDesignSystemsChanged?: (affectedDesignSystemId?: string) => void;
 }
 
 export interface AgentRefreshOptions {
@@ -804,6 +814,8 @@ export function SettingsDialog({
   daemonMediaProvidersFetchState = 'idle',
   mediaProvidersNotice,
   onReloadMediaProviders,
+  onSkillsChanged,
+  onDesignSystemsChanged,
 }: Props) {
   const { t, locale, setLocale } = useI18n();
   const analytics = useAnalytics();
@@ -3362,11 +3374,16 @@ export function SettingsDialog({
               cfg={cfg}
               setCfg={setCfg}
               onSkillsRefresh={onSkillsRefresh}
+              onSkillsChanged={onSkillsChanged}
             />
           ) : null}
 
           {activeSection === 'designSystems' ? (
-            <DesignSystemsSection cfg={cfg} setCfg={setCfg} />
+            <DesignSystemsSection
+              cfg={cfg}
+              setCfg={setCfg}
+              onDesignSystemsChanged={onDesignSystemsChanged}
+            />
           ) : null}
 
           {activeSection === 'instructions' ? (

--- a/apps/web/src/components/SkillsSection.tsx
+++ b/apps/web/src/components/SkillsSection.tsx
@@ -35,6 +35,14 @@ interface Props {
   cfg: AppConfig;
   setCfg: Dispatch<SetStateAction<AppConfig>>;
   onSkillsRefresh?: () => Promise<void> | void;
+  /**
+   * Fires after every successful skill registry mutation so the App
+   * shell can refresh derived state and evict any preview iframe whose
+   * project depends on the affected skill — body-only edits do not move
+   * any SkillSummary field, so ProjectView's signature-based eviction
+   * cannot see them on its own.
+   */
+  onSkillsChanged?: (affectedSkillId?: string) => void;
 }
 
 type SourceFilter = 'all' | 'user' | 'built-in';
@@ -69,7 +77,7 @@ function parseTriggers(raw: string): string[] {
     .filter(Boolean);
 }
 
-export function SkillsSection({ cfg, setCfg, onSkillsRefresh }: Props) {
+export function SkillsSection({ cfg, setCfg, onSkillsRefresh, onSkillsChanged }: Props) {
   const t = useT();
 
   const [skills, setSkills] = useState<SkillSummary[]>([]);
@@ -307,7 +315,8 @@ export function SkillsSection({ cfg, setCfg, onSkillsRefresh }: Props) {
     setEditingId(null);
     setCreating(false);
     setDraft(EMPTY_DRAFT);
-  }, [draft, draftSaving, editingId, onSkillsRefresh, refresh]);
+    onSkillsChanged?.(updated.id);
+  }, [draft, draftSaving, editingId, onSkillsChanged, onSkillsRefresh, refresh]);
 
   const armDelete = useCallback((id: string) => {
     setConfirmDeleteId(id);
@@ -349,8 +358,9 @@ export function SkillsSection({ cfg, setCfg, onSkillsRefresh }: Props) {
         setEditingId(null);
         setDraft(EMPTY_DRAFT);
       }
+      onSkillsChanged?.(id);
     },
-    [editingId, expandedId, onSkillsRefresh, refresh, setCfg],
+    [editingId, expandedId, onSkillsChanged, onSkillsRefresh, refresh, setCfg],
   );
 
   const toggleEnabled = useCallback(

--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -40,6 +40,14 @@
   min-height: 0;
 }
 
+.iframe-keep-alive-pool {
+  display: none;
+}
+
+.pooled-iframe-host {
+  display: contents;
+}
+
 .workspace-tabs-chrome.app-chrome-header {
   min-width: 0;
   max-width: 100%;

--- a/apps/web/tests/components/App.previewKeepAlive.test.tsx
+++ b/apps/web/tests/components/App.previewKeepAlive.test.tsx
@@ -1,0 +1,268 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { App } from '../../src/App';
+import type { AppConfig, Project } from '../../src/types';
+import {
+  fetchComposioConfigFromDaemon,
+  fetchDaemonConfig,
+  fetchMediaProvidersFromDaemon,
+  loadConfig,
+  mergeDaemonConfig,
+  saveConfig,
+  syncComposioConfigToDaemon,
+  syncConfigToDaemon,
+} from '../../src/state/config';
+import {
+  daemonIsLive,
+  fetchAgents,
+  fetchAppVersionInfo,
+  fetchDesignSystems,
+  fetchDesignTemplates,
+  fetchPromptTemplates,
+  fetchSkills,
+} from '../../src/providers/registry';
+import { listProjects, listTemplates } from '../../src/state/projects';
+import { useIframeKeepAlivePool } from '../../src/components/IframeKeepAlivePool';
+
+const evictProjectMock = vi.fn();
+const useRouteMock = vi.fn(() => ({
+  kind: 'project' as const,
+  projectId: 'project-1',
+  conversationId: null,
+  fileName: null,
+}));
+
+vi.mock('../../src/router', () => ({
+  navigate: vi.fn(),
+  useRoute: () => useRouteMock(),
+}));
+
+vi.mock('../../src/components/IframeKeepAlivePool', async () => {
+  const actual = await vi.importActual<typeof import('../../src/components/IframeKeepAlivePool')>(
+    '../../src/components/IframeKeepAlivePool',
+  );
+  return {
+    ...actual,
+    useIframeKeepAlivePool: vi.fn(),
+  };
+});
+
+vi.mock('../../src/components/EntryView', () => ({
+  EntryView: () => <div>Entry view</div>,
+}));
+
+vi.mock('../../src/components/ProjectView', () => ({
+  ProjectView: ({
+    project,
+    onProjectChange,
+  }: {
+    project: Project;
+    onProjectChange: (project: Project) => void;
+  }) => (
+    <div>
+      <button
+        type="button"
+        onClick={() =>
+          onProjectChange({
+            ...project,
+            skillId: 'fresh-skill',
+          })
+        }
+      >
+        Change skill
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          onProjectChange({
+            ...project,
+            designSystemId: 'fresh-design-system',
+          })
+        }
+      >
+        Change design system
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          onProjectChange({
+            ...project,
+            customInstructions: 'Fresh project instructions',
+          })
+        }
+      >
+        Change custom instructions
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('../../src/components/SettingsDialog', () => ({
+  SettingsDialog: () => null,
+}));
+
+vi.mock('../../src/components/pet/PetOverlay', () => ({
+  PetOverlay: () => null,
+}));
+
+vi.mock('../../src/components/pet/pets', () => ({
+  migrateCustomPetAtlas: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../../src/components/WorkspaceTabsBar', () => ({
+  WorkspaceTabsBar: () => null,
+}));
+
+vi.mock('../../src/components/MemoryToast', () => ({
+  MemoryToast: () => null,
+}));
+
+vi.mock('../../src/components/PrivacyConsentModal', () => ({
+  PrivacyConsentModal: () => null,
+}));
+
+vi.mock('../../src/providers/registry', async () => {
+  const actual = await vi.importActual<typeof import('../../src/providers/registry')>(
+    '../../src/providers/registry',
+  );
+  return {
+    ...actual,
+    daemonIsLive: vi.fn(),
+    fetchAgents: vi.fn(),
+    fetchAppVersionInfo: vi.fn(),
+    fetchDesignSystems: vi.fn(),
+    fetchDesignTemplates: vi.fn(),
+    fetchPromptTemplates: vi.fn(),
+    fetchSkills: vi.fn(),
+  };
+});
+
+vi.mock('../../src/state/projects', async () => {
+  const actual = await vi.importActual<typeof import('../../src/state/projects')>(
+    '../../src/state/projects',
+  );
+  return {
+    ...actual,
+    listProjects: vi.fn(),
+    listTemplates: vi.fn(),
+  };
+});
+
+vi.mock('../../src/state/config', async () => {
+  const actual = await vi.importActual<typeof import('../../src/state/config')>(
+    '../../src/state/config',
+  );
+  return {
+    ...actual,
+    fetchComposioConfigFromDaemon: vi.fn(),
+    fetchDaemonConfig: vi.fn(),
+    fetchMediaProvidersFromDaemon: vi.fn(),
+    loadConfig: vi.fn(),
+    mergeDaemonConfig: vi.fn(),
+    saveConfig: vi.fn(),
+    syncComposioConfigToDaemon: vi.fn().mockResolvedValue(true),
+    syncConfigToDaemon: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+const mockedDaemonIsLive = vi.mocked(daemonIsLive);
+const mockedFetchAgents = vi.mocked(fetchAgents);
+const mockedFetchAppVersionInfo = vi.mocked(fetchAppVersionInfo);
+const mockedFetchDesignSystems = vi.mocked(fetchDesignSystems);
+const mockedFetchDesignTemplates = vi.mocked(fetchDesignTemplates);
+const mockedFetchPromptTemplates = vi.mocked(fetchPromptTemplates);
+const mockedFetchSkills = vi.mocked(fetchSkills);
+const mockedListProjects = vi.mocked(listProjects);
+const mockedListTemplates = vi.mocked(listTemplates);
+const mockedFetchComposioConfigFromDaemon = vi.mocked(fetchComposioConfigFromDaemon);
+const mockedFetchDaemonConfig = vi.mocked(fetchDaemonConfig);
+const mockedFetchMediaProvidersFromDaemon = vi.mocked(fetchMediaProvidersFromDaemon);
+const mockedLoadConfig = vi.mocked(loadConfig);
+const mockedMergeDaemonConfig = vi.mocked(mergeDaemonConfig);
+const mockedUseIframeKeepAlivePool = vi.mocked(useIframeKeepAlivePool);
+
+const baseConfig: AppConfig = {
+  mode: 'api',
+  apiKey: '',
+  apiProtocol: 'anthropic',
+  apiVersion: '',
+  baseUrl: 'https://api.anthropic.com',
+  model: 'claude-sonnet-4-5',
+  apiProviderBaseUrl: 'https://api.anthropic.com',
+  apiProtocolConfigs: {},
+  agentId: null,
+  skillId: null,
+  designSystemId: null,
+  onboardingCompleted: true,
+  mediaProviders: {},
+  agentModels: {},
+  agentCliEnv: {},
+  privacyDecisionAt: 1778244000000,
+};
+
+const project: Project = {
+  id: 'project-1',
+  name: 'Project 1',
+  skillId: 'old-skill',
+  designSystemId: 'old-design-system',
+  customInstructions: 'Old project instructions',
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+describe('App preview keep-alive invalidation', () => {
+  beforeEach(() => {
+    mockedUseIframeKeepAlivePool.mockReturnValue({
+      attach: vi.fn(),
+      release: vi.fn(),
+      evict: vi.fn(),
+      evictProject: evictProjectMock,
+      evictMatching: vi.fn(),
+    });
+    mockedDaemonIsLive.mockResolvedValue(true);
+    mockedFetchAgents.mockResolvedValue([]);
+    mockedFetchSkills.mockResolvedValue([]);
+    mockedFetchDesignTemplates.mockResolvedValue([]);
+    mockedFetchDesignSystems.mockResolvedValue([]);
+    mockedFetchPromptTemplates.mockResolvedValue([]);
+    mockedFetchAppVersionInfo.mockResolvedValue(null);
+    mockedListProjects.mockResolvedValue([project]);
+    mockedListTemplates.mockResolvedValue([]);
+    mockedFetchDaemonConfig.mockResolvedValue({});
+    mockedFetchComposioConfigFromDaemon.mockResolvedValue(null);
+    mockedFetchMediaProvidersFromDaemon.mockResolvedValue({ status: 'ok', providers: {} });
+    mockedMergeDaemonConfig.mockImplementation((local) => local);
+    mockedLoadConfig.mockReturnValue({ ...baseConfig });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      }),
+    );
+    window.history.replaceState(null, '', '/projects/project-1');
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    'Change skill',
+    'Change design system',
+    'Change custom instructions',
+  ])('evicts the active preview when the open project prompt context changes: %s', async (buttonName) => {
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole('button', { name: buttonName }));
+
+    await waitFor(() => {
+      expect(evictProjectMock).toHaveBeenCalledWith('project-1', { includeActive: true });
+    });
+  });
+});

--- a/apps/web/tests/components/App.previewKeepAlive.test.tsx
+++ b/apps/web/tests/components/App.previewKeepAlive.test.tsx
@@ -28,6 +28,7 @@ import { listProjects, listTemplates } from '../../src/state/projects';
 import { useIframeKeepAlivePool } from '../../src/components/IframeKeepAlivePool';
 
 const evictProjectMock = vi.fn();
+const evictMatchingMock = vi.fn();
 const useRouteMock = vi.fn(() => ({
   kind: 'project' as const,
   projectId: 'project-1',
@@ -58,9 +59,11 @@ vi.mock('../../src/components/ProjectView', () => ({
   ProjectView: ({
     project,
     onProjectChange,
+    onOpenSettings,
   }: {
     project: Project;
     onProjectChange: (project: Project) => void;
+    onOpenSettings: (section?: string) => void;
   }) => (
     <div>
       <button
@@ -96,12 +99,42 @@ vi.mock('../../src/components/ProjectView', () => ({
       >
         Change custom instructions
       </button>
+      <button type="button" onClick={() => onOpenSettings('skills')}>
+        Open settings
+      </button>
     </div>
   ),
 }));
 
 vi.mock('../../src/components/SettingsDialog', () => ({
-  SettingsDialog: () => null,
+  SettingsDialog: ({
+    onSkillsChanged,
+    onDesignSystemsChanged,
+  }: {
+    onSkillsChanged?: (id?: string) => void;
+    onDesignSystemsChanged?: (id?: string) => void;
+  }) => (
+    <div>
+      <button
+        type="button"
+        onClick={() => onSkillsChanged?.('old-skill')}
+      >
+        Trigger skill body change
+      </button>
+      <button
+        type="button"
+        onClick={() => onSkillsChanged?.('unrelated-skill')}
+      >
+        Trigger unrelated skill change
+      </button>
+      <button
+        type="button"
+        onClick={() => onDesignSystemsChanged?.('old-design-system')}
+      >
+        Trigger design system change
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock('../../src/components/pet/PetOverlay', () => ({
@@ -220,7 +253,7 @@ describe('App preview keep-alive invalidation', () => {
       release: vi.fn(),
       evict: vi.fn(),
       evictProject: evictProjectMock,
-      evictMatching: vi.fn(),
+      evictMatching: evictMatchingMock,
     });
     mockedDaemonIsLive.mockResolvedValue(true);
     mockedFetchAgents.mockResolvedValue([]);
@@ -264,5 +297,76 @@ describe('App preview keep-alive invalidation', () => {
     await waitFor(() => {
       expect(evictProjectMock).toHaveBeenCalledWith('project-1', { includeActive: true });
     });
+  });
+
+  // Regression for the mrcfps follow-up on PR #2190: ProjectView's
+  // signature only hashes SkillSummary / DesignSystemSummary fields, so a
+  // body-only registry edit leaves every signature unchanged and the
+  // signature-driven eviction path silently misses it. Settings →
+  // Skills / Design Systems now call back through App.tsx after every
+  // mutation so the pool drops any project that depends on the affected
+  // id — active or parked — regardless of which summary fields moved.
+  it('evicts pool entries for projects that use a changed skill, even on body-only edits', async () => {
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Open settings' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Trigger skill body change' }));
+
+    await waitFor(() => {
+      expect(evictMatchingMock).toHaveBeenCalled();
+    });
+    const [predicate, options] = evictMatchingMock.mock.calls.at(-1) ?? [];
+    expect(options).toEqual({ includeActive: true });
+    expect(typeof predicate).toBe('function');
+    expect(
+      (predicate as (entry: { projectId: string; key: string; fileName: string }) => boolean)({
+        key: 'project-1 file.html',
+        projectId: 'project-1',
+        fileName: 'file.html',
+      }),
+    ).toBe(true);
+  });
+
+  it('does not evict pool entries for projects that use a different skill', async () => {
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Open settings' }));
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Trigger unrelated skill change' }),
+    );
+
+    await waitFor(() => {
+      expect(evictMatchingMock).toHaveBeenCalled();
+    });
+    const [predicate] = evictMatchingMock.mock.calls.at(-1) ?? [];
+    expect(
+      (predicate as (entry: { projectId: string; key: string; fileName: string }) => boolean)({
+        key: 'project-1 file.html',
+        projectId: 'project-1',
+        fileName: 'file.html',
+      }),
+    ).toBe(false);
+  });
+
+  it('evicts pool entries for projects that use a changed design system', async () => {
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Open settings' }));
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Trigger design system change' }),
+    );
+
+    await waitFor(() => {
+      expect(evictMatchingMock).toHaveBeenCalled();
+    });
+    const [predicate, options] = evictMatchingMock.mock.calls.at(-1) ?? [];
+    expect(options).toEqual({ includeActive: true });
+    expect(
+      (predicate as (entry: { projectId: string; key: string; fileName: string }) => boolean)({
+        key: 'project-1 file.html',
+        projectId: 'project-1',
+        fileName: 'file.html',
+      }),
+    ).toBe(true);
   });
 });

--- a/apps/web/tests/components/DesignSystemsSection.test.tsx
+++ b/apps/web/tests/components/DesignSystemsSection.test.tsx
@@ -69,6 +69,30 @@ describe('DesignSystemsSection rename (issue #2811)', () => {
     });
   });
 
+  it('notifies the parent after renaming a design system without changing its id', async () => {
+    const onDesignSystemsChanged = vi.fn();
+    render(
+      <DesignSystemsSection
+        cfg={cfg}
+        setCfg={() => {}}
+        onDesignSystemsChanged={onDesignSystemsChanged}
+      />,
+    );
+
+    const renameButton = await screen.findByRole('button', {
+      name: /Rename Acme Design System/i,
+    });
+    fireEvent.click(renameButton);
+
+    const input = screen.getByDisplayValue('Acme Design System');
+    fireEvent.change(input, { target: { value: 'Acme v2' } });
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/ }));
+
+    await waitFor(() => {
+      expect(onDesignSystemsChanged).toHaveBeenCalledWith('user:acme');
+    });
+  });
+
   it('keeps the rename modal open with the typed title when the update fails', async () => {
     vi.mocked(updateDesignSystemDraft).mockResolvedValueOnce(null);
     render(<DesignSystemsSection cfg={cfg} setCfg={() => {}} />);

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -34,6 +34,12 @@ import {
   serializeInspectOverrides,
   updateInspectOverride,
 } from '../../src/components/FileViewer';
+import {
+  IframeKeepAliveProvider,
+  PooledIframe,
+  previewIframeKeepAliveKey,
+  useIframeKeepAlivePool,
+} from '../../src/components/IframeKeepAlivePool';
 import type { InspectOverrideMap } from '../../src/components/FileViewer';
 import type { LiveArtifact, LiveArtifactWorkspaceEntry, PreviewComment, ProjectFile } from '../../src/types';
 import { I18nProvider } from '../../src/i18n';
@@ -385,6 +391,139 @@ describe('FileViewer SVG artifacts', () => {
     expect(sourceMarkup).not.toContain('<img');
   });
 
+  it('keeps a URL-loaded preview iframe alive while the viewer unmounts and remounts', () => {
+    const file = baseFile({
+      name: 'page.html',
+      path: 'page.html',
+      mime: 'text/html',
+      kind: 'html',
+      artifactManifest: {
+        version: 1,
+        kind: 'html',
+        title: 'Page',
+        entry: 'page.html',
+        renderer: 'html',
+        exports: ['html'],
+      },
+    });
+
+    function Shell() {
+      const [visible, setVisible] = useState(true);
+      return (
+        <IframeKeepAliveProvider>
+          <button type="button" onClick={() => setVisible((next) => !next)}>
+            {visible ? 'Leave project' : 'Return project'}
+          </button>
+          {visible ? (
+            <FileViewer
+              projectId="project-1"
+              projectKind="prototype"
+              file={file}
+              liveHtml="<html><body>hi</body></html>"
+            />
+          ) : (
+            <div data-testid="home-view" />
+          )}
+        </IframeKeepAliveProvider>
+      );
+    }
+
+    const { container } = render(<Shell />);
+
+    const firstFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    expect(firstFrame.getAttribute('src')).toBe('/api/projects/project-1/raw/page.html?v=1710000000&r=0');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Leave project' }));
+
+    expect(screen.queryByTestId('artifact-preview-frame')).toBeNull();
+    expect(screen.getByTestId('home-view')).toBeTruthy();
+    const parkedFrame = container.querySelector<HTMLIFrameElement>('.iframe-keep-alive-pool iframe');
+    expect(parkedFrame).toBe(firstFrame);
+    expect(parkedFrame?.getAttribute('src')).toBe('/api/projects/project-1/raw/page.html?v=1710000000&r=0');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Return project' }));
+
+    expect(screen.getByTestId('artifact-preview-frame')).toBe(firstFrame);
+  });
+
+  it('evicts least-recent inactive preview iframes once the pool exceeds its limit', () => {
+    function Harness({ activeKey }: { activeKey: string | null }) {
+      return (
+        <IframeKeepAliveProvider maxEntries={2}>
+          {activeKey ? (
+            <PooledIframe
+              cacheKey={previewIframeKeepAliveKey('project-1', `${activeKey}.html`)}
+              src={`/api/projects/project-1/raw/${activeKey}.html?v=1&r=0`}
+              title={`${activeKey}.html`}
+              sandbox="allow-scripts allow-downloads"
+              data-testid="pooled-frame"
+              data-od-render-mode="url-load"
+              data-od-active="true"
+            />
+          ) : null}
+        </IframeKeepAliveProvider>
+      );
+    }
+
+    const { container, rerender } = render(<Harness activeKey="one" />);
+    const firstFrame = screen.getByTestId('pooled-frame');
+    rerender(<Harness activeKey={null} />);
+    rerender(<Harness activeKey="two" />);
+    const secondFrame = screen.getByTestId('pooled-frame');
+    rerender(<Harness activeKey={null} />);
+    rerender(<Harness activeKey="three" />);
+    const thirdFrame = screen.getByTestId('pooled-frame');
+    rerender(<Harness activeKey={null} />);
+
+    const parkedFrames = Array.from(
+      container.querySelectorAll<HTMLIFrameElement>('.iframe-keep-alive-pool iframe'),
+    );
+    expect(parkedFrames).toEqual([secondFrame, thirdFrame]);
+    expect(parkedFrames).not.toContain(firstFrame);
+  });
+
+  it('evicts inactive preview iframes for a project when the project is invalidated', () => {
+    function Harness({ active }: { active: boolean }) {
+      const pool = useIframeKeepAlivePool();
+      return (
+        <>
+          <button type="button" onClick={() => pool.evictProject('project-1')}>
+            Invalidate project
+          </button>
+          {active ? (
+            <PooledIframe
+              cacheKey={previewIframeKeepAliveKey('project-1', 'page.html')}
+              src="/api/projects/project-1/raw/page.html?v=1&r=0"
+              title="page.html"
+              sandbox="allow-scripts allow-downloads"
+              data-testid="pooled-frame"
+              data-od-render-mode="url-load"
+              data-od-active="true"
+            />
+          ) : null}
+        </>
+      );
+    }
+
+    const { container, rerender } = render(
+      <IframeKeepAliveProvider>
+        <Harness active />
+      </IframeKeepAliveProvider>,
+    );
+    const firstFrame = screen.getByTestId('pooled-frame');
+
+    rerender(
+      <IframeKeepAliveProvider>
+        <Harness active={false} />
+      </IframeKeepAliveProvider>,
+    );
+    expect(container.querySelector('.iframe-keep-alive-pool iframe')).toBe(firstFrame);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Invalidate project' }));
+
+    expect(container.querySelector('.iframe-keep-alive-pool iframe')).toBeNull();
+  });
+
   it('URL-loads a plain HTML preview iframe instead of inlining via srcDoc', () => {
     const file = baseFile({
       name: 'page.html',
@@ -587,14 +726,13 @@ describe('FileViewer SVG artifacts', () => {
 
     const { container } = render(<Switcher />);
     const getFrame = () => container.querySelector<HTMLIFrameElement>('[data-testid="artifact-preview-frame"]');
-    const initialFrame = getFrame();
-    expect(initialFrame?.getAttribute('src')).toBe('/api/projects/project-1/raw/first.html?v=1710000000&r=0');
+    expect(getFrame()?.getAttribute('src')).toBe('/api/projects/project-1/raw/first.html?v=1710000000&r=0');
 
     const observationsBeforeSwitch = observedCommittedSrcs.length;
     fireEvent.click(screen.getByRole('button', { name: 'Switch file' }));
 
     const nextFrame = getFrame();
-    expect(nextFrame).toBe(initialFrame);
+    expect(nextFrame).toBeTruthy();
     expect(observedCommittedSrcs[observationsBeforeSwitch]).toBe(
       '/api/projects/project-1/raw/second.html?v=1710000000&r=0',
     );

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -524,6 +524,44 @@ describe('FileViewer SVG artifacts', () => {
     expect(container.querySelector('.iframe-keep-alive-pool iframe')).toBeNull();
   });
 
+  it('reattaches a fresh visible iframe after active project invalidation', () => {
+    function Harness() {
+      const pool = useIframeKeepAlivePool();
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() => pool.evictProject('project-1', { includeActive: true })}
+          >
+            Invalidate active project
+          </button>
+          <PooledIframe
+            cacheKey={previewIframeKeepAliveKey('project-1', 'page.html')}
+            src="/api/projects/project-1/raw/page.html?v=1&r=0"
+            title="page.html"
+            sandbox="allow-scripts allow-downloads"
+            data-testid="pooled-frame"
+            data-od-render-mode="url-load"
+            data-od-active="true"
+          />
+        </>
+      );
+    }
+
+    render(
+      <IframeKeepAliveProvider>
+        <Harness />
+      </IframeKeepAliveProvider>,
+    );
+    const firstFrame = screen.getByTestId('pooled-frame');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Invalidate active project' }));
+
+    const secondFrame = screen.getByTestId('pooled-frame');
+    expect(secondFrame).not.toBe(firstFrame);
+    expect(secondFrame.getAttribute('src')).toBe('/api/projects/project-1/raw/page.html?v=1&r=0');
+  });
+
   it('URL-loads a plain HTML preview iframe instead of inlining via srcDoc', () => {
     const file = baseFile({
       name: 'page.html',

--- a/apps/web/tests/components/ProjectView.previewKeepAlive.test.tsx
+++ b/apps/web/tests/components/ProjectView.previewKeepAlive.test.tsx
@@ -1,0 +1,256 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ProjectView } from '../../src/components/ProjectView';
+import { useIframeKeepAlivePool } from '../../src/components/IframeKeepAlivePool';
+import type {
+  AgentInfo,
+  AppConfig,
+  Conversation,
+  DesignSystemSummary,
+  Project,
+  SkillSummary,
+} from '../../src/types';
+import {
+  createConversation,
+  listConversations,
+  listMessages,
+  loadTabs,
+} from '../../src/state/projects';
+import { fetchPreviewComments } from '../../src/providers/registry';
+
+const evictProjectMock = vi.fn();
+
+vi.mock('../../src/i18n', () => ({
+  useT: () => (key: string) => key,
+  useI18n: () => ({
+    t: (key: string) => key,
+    locale: 'en',
+    setLocale: () => {},
+  }),
+}));
+
+vi.mock('../../src/router', () => ({
+  navigate: vi.fn(),
+}));
+
+vi.mock('../../src/components/IframeKeepAlivePool', async () => {
+  const actual = await vi.importActual<typeof import('../../src/components/IframeKeepAlivePool')>(
+    '../../src/components/IframeKeepAlivePool',
+  );
+  return {
+    ...actual,
+    useIframeKeepAlivePool: vi.fn(),
+  };
+});
+
+vi.mock('../../src/providers/anthropic', () => ({
+  streamMessage: vi.fn(),
+}));
+
+vi.mock('../../src/providers/daemon', () => ({
+  fetchChatRunStatus: vi.fn(),
+  listActiveChatRuns: vi.fn().mockResolvedValue([]),
+  reattachDaemonRun: vi.fn(),
+  streamViaDaemon: vi.fn(),
+}));
+
+vi.mock('../../src/providers/project-events', () => ({
+  useProjectFileEvents: vi.fn(),
+}));
+
+vi.mock('../../src/providers/registry', async () => {
+  const actual = await vi.importActual<typeof import('../../src/providers/registry')>(
+    '../../src/providers/registry',
+  );
+  return {
+    ...actual,
+    deletePreviewComment: vi.fn(),
+    fetchDesignSystem: vi.fn(),
+    fetchLiveArtifacts: vi.fn().mockResolvedValue([]),
+    fetchPreviewComments: vi.fn(),
+    fetchProjectFiles: vi.fn().mockResolvedValue([]),
+    fetchSkill: vi.fn(),
+    getTemplate: vi.fn(),
+    patchPreviewCommentStatus: vi.fn(),
+    upsertPreviewComment: vi.fn(),
+    writeProjectTextFile: vi.fn(),
+  };
+});
+
+vi.mock('../../src/state/projects', async () => {
+  const actual = await vi.importActual<typeof import('../../src/state/projects')>(
+    '../../src/state/projects',
+  );
+  return {
+    ...actual,
+    createConversation: vi.fn(),
+    listConversations: vi.fn(),
+    listMessages: vi.fn(),
+    loadTabs: vi.fn(),
+    patchConversation: vi.fn(),
+    patchProject: vi.fn(),
+    saveMessage: vi.fn(),
+    saveTabs: vi.fn(),
+  };
+});
+
+vi.mock('../../src/components/AppChromeHeader', () => ({
+  AppChromeHeader: ({ children }: { children: ReactNode }) => <header>{children}</header>,
+}));
+
+vi.mock('../../src/components/AvatarMenu', () => ({
+  AvatarMenu: () => null,
+}));
+
+vi.mock('../../src/components/FileWorkspace', () => ({
+  FileWorkspace: () => <div data-testid="file-workspace" />,
+}));
+
+vi.mock('../../src/components/Loading', () => ({
+  CenteredLoader: () => <div data-testid="loader" />,
+}));
+
+vi.mock('../../src/components/ChatPane', () => ({
+  ChatPane: () => <div data-testid="chat-pane" />,
+}));
+
+const mockedUseIframeKeepAlivePool = vi.mocked(useIframeKeepAlivePool);
+const mockedListConversations = vi.mocked(listConversations);
+const mockedCreateConversation = vi.mocked(createConversation);
+const mockedListMessages = vi.mocked(listMessages);
+const mockedLoadTabs = vi.mocked(loadTabs);
+const mockedFetchPreviewComments = vi.mocked(fetchPreviewComments);
+
+const config: AppConfig = {
+  mode: 'api',
+  apiKey: '',
+  baseUrl: '',
+  model: '',
+  agentId: null,
+  skillId: null,
+  designSystemId: null,
+};
+
+const project: Project = {
+  id: 'project-1',
+  name: 'Project 1',
+  skillId: 'skill-1',
+  designSystemId: 'ds-1',
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+const conversation: Conversation = {
+  id: 'conv-1',
+  projectId: project.id,
+  title: null,
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+const skill: SkillSummary = {
+  id: 'skill-1',
+  name: 'Prompt skill',
+  description: 'Old prompt context',
+  triggers: ['prompt'],
+  mode: 'prototype',
+  previewType: 'html',
+  designSystemRequired: false,
+  defaultFor: [],
+  upstream: null,
+  hasBody: true,
+  examplePrompt: 'Create a prototype.',
+  aggregatesExamples: false,
+};
+
+const designSystem: DesignSystemSummary = {
+  id: 'ds-1',
+  title: 'Design System',
+  category: 'product',
+  summary: 'Old system context',
+};
+
+function renderProjectView(props?: {
+  skills?: SkillSummary[];
+  designSystems?: DesignSystemSummary[];
+}) {
+  return render(
+    <ProjectView
+      project={project}
+      routeFileName={null}
+      config={config}
+      agents={[] as AgentInfo[]}
+      skills={props?.skills ?? [skill]}
+      designTemplates={[] as SkillSummary[]}
+      designSystems={props?.designSystems ?? [designSystem]}
+      daemonLive
+      onModeChange={vi.fn()}
+      onAgentChange={vi.fn()}
+      onAgentModelChange={vi.fn()}
+      onRefreshAgents={vi.fn()}
+      onOpenSettings={vi.fn()}
+      onBack={vi.fn()}
+      onClearPendingPrompt={vi.fn()}
+      onTouchProject={vi.fn()}
+      onProjectChange={vi.fn()}
+      onProjectsRefresh={vi.fn()}
+    />,
+  );
+}
+
+describe('ProjectView preview keep-alive invalidation', () => {
+  beforeEach(() => {
+    mockedUseIframeKeepAlivePool.mockReturnValue({
+      attach: vi.fn(),
+      release: vi.fn(),
+      evict: vi.fn(),
+      evictProject: evictProjectMock,
+      evictMatching: vi.fn(),
+    });
+    mockedListConversations.mockResolvedValue([conversation]);
+    mockedCreateConversation.mockResolvedValue(conversation);
+    mockedListMessages.mockResolvedValue([]);
+    mockedLoadTabs.mockResolvedValue({ tabs: [], active: null });
+    mockedFetchPreviewComments.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('evicts the active preview when registry prompt context changes for the open project', async () => {
+    const view = renderProjectView();
+
+    view.rerender(
+      <ProjectView
+        project={project}
+        routeFileName={null}
+        config={config}
+        agents={[] as AgentInfo[]}
+        skills={[{ ...skill, description: 'Fresh prompt context' }]}
+        designTemplates={[] as SkillSummary[]}
+        designSystems={[designSystem]}
+        daemonLive
+        onModeChange={vi.fn()}
+        onAgentChange={vi.fn()}
+        onAgentModelChange={vi.fn()}
+        onRefreshAgents={vi.fn()}
+        onOpenSettings={vi.fn()}
+        onBack={vi.fn()}
+        onClearPendingPrompt={vi.fn()}
+        onTouchProject={vi.fn()}
+        onProjectChange={vi.fn()}
+        onProjectsRefresh={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(evictProjectMock).toHaveBeenCalledWith('project-1', { includeActive: true });
+    });
+  });
+});

--- a/apps/web/tests/components/SkillsSection.test.tsx
+++ b/apps/web/tests/components/SkillsSection.test.tsx
@@ -41,10 +41,14 @@ function makeSkill(overrides: Partial<SkillSummary>): SkillSummary {
 
 function renderSkillsSection(
   skills: SkillSummary[],
-  options?: { onSkillsRefresh?: () => void | Promise<void> },
+  options?: {
+    onSkillsRefresh?: () => void | Promise<void>;
+    onSkillsChanged?: (id?: string) => void;
+  },
 ) {
   const setCfg = vi.fn();
   const onSkillsRefresh = options?.onSkillsRefresh;
+  const onSkillsChanged = options?.onSkillsChanged;
   globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = input.toString();
     if (url === '/api/skills' && (!init || init.method === undefined)) {
@@ -74,6 +78,37 @@ function renderSkillsSection(
         headers: { 'content-type': 'application/json' },
       });
     }
+    if (url.startsWith('/api/skills/') && init?.method === 'PUT') {
+      const id = decodeURIComponent(url.split('/').pop() ?? '');
+      const payload = init.body
+        ? (JSON.parse(init.body as string) as { name?: string; description?: string; body?: string; triggers?: string[] })
+        : {};
+      const updated = makeSkill({
+        id,
+        name: payload.name ?? id,
+        description: payload.description ?? '',
+        triggers: payload.triggers ?? [],
+        source: 'user',
+      });
+      return new Response(JSON.stringify({ skill: updated }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    if (url.match(/^\/api\/skills\/[^/]+\/files$/) && (!init || init.method === undefined)) {
+      return new Response(JSON.stringify({ files: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    if (url.match(/^\/api\/skills\/[^/]+$/) && (!init || init.method === undefined)) {
+      const id = decodeURIComponent(url.split('/').pop() ?? '');
+      const summary = makeSkill({ id });
+      return new Response(JSON.stringify({ ...summary, body: '' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
     return new Response(JSON.stringify({}), { status: 404 });
   }) as typeof fetch;
 
@@ -82,9 +117,15 @@ function renderSkillsSection(
       cfg={TEST_CONFIG}
       setCfg={setCfg}
       onSkillsRefresh={onSkillsRefresh}
+      onSkillsChanged={onSkillsChanged}
     />,
   );
-  return { fetchMock: globalThis.fetch as ReturnType<typeof vi.fn>, setCfg, onSkillsRefresh };
+  return {
+    fetchMock: globalThis.fetch as ReturnType<typeof vi.fn>,
+    setCfg,
+    onSkillsRefresh,
+    onSkillsChanged,
+  };
 }
 
 describe('SkillsSection', () => {
@@ -199,5 +240,60 @@ describe('SkillsSection', () => {
           url.toString() === '/api/skills/import' && init?.method === 'POST',
       ),
     ).toBe(true);
+  });
+
+  // Regression for the mrcfps follow-up on PR #2190: when a user edits
+  // only the body of a skill (no name/description/trigger changes), the
+  // SkillSummary fields ProjectView hashes do not move and the
+  // signature-driven eviction misses the change. SkillsSection must
+  // notify the App shell so the preview keep-alive pool can drop any
+  // entry whose project uses this skill.
+  it('notifies onSkillsChanged after a body-only edit', async () => {
+    const onSkillsChanged = vi.fn();
+    renderSkillsSection(
+      [
+        makeSkill({
+          id: 'user-skill',
+          name: 'User skill',
+          description: 'Original description',
+          triggers: ['ping'],
+          source: 'user',
+        }),
+      ],
+      { onSkillsChanged },
+    );
+
+    const row = await screen.findByTestId('skill-row-user-skill');
+    fireEvent.click(within(row).getByTestId('skills-edit'));
+    const form = await within(row).findByTestId('skills-edit-form');
+    const bodyField = within(form).getAllByRole('textbox').at(-1) as HTMLTextAreaElement;
+    fireEvent.change(bodyField, { target: { value: 'A fresh body that did not exist before.' } });
+    fireEvent.click(within(form).getByTestId('skills-save'));
+
+    await waitFor(() => {
+      expect(onSkillsChanged).toHaveBeenCalledWith('user-skill');
+    });
+  });
+
+  it('notifies onSkillsChanged after a delete', async () => {
+    const onSkillsChanged = vi.fn();
+    renderSkillsSection(
+      [
+        makeSkill({
+          id: 'user-skill',
+          name: 'User skill',
+          source: 'user',
+        }),
+      ],
+      { onSkillsChanged },
+    );
+
+    const row = await screen.findByTestId('skill-row-user-skill');
+    fireEvent.click(within(row).getByTestId('skills-delete'));
+    fireEvent.click(within(row).getByTestId('skills-delete-confirm'));
+
+    await waitFor(() => {
+      expect(onSkillsChanged).toHaveBeenCalledWith('user-skill');
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add an OD_PREVIEW_KEEP_ALIVE-gated LRU iframe pool for URL-loaded HTML previews, defaulting to 5 entries
- keep inactive preview iframes parked offscreen and restore them across Hub/Workspace navigation without remounting
- evict stale preview iframes on file-change SSE, project deletion, project prompt-context changes, and active skill/design-system registry changes
- preserve the existing srcDoc fallback path and SSR/static markup behavior

Fixes #1888.

## Surface area

- [x] **UI** — web preview/runtime behavior in `apps/web` for URL-loaded HTML previews
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `OD_PREVIEW_KEEP_ALIVE` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — keep-alive is enabled by default with a 5-entry LRU, while stale previews are evicted on file/project/prompt-context changes
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Validation
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/FileViewer.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`
