### PR TITLE
Disable HTTPS for Caddy server on Nix

### DIFF
--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -61,7 +61,7 @@
       persist_config off
     }
 
-    ${cfg.webFrontend.host}:${toString cfg.webFrontend.port} {
+    http://${cfg.webFrontend.host}:${toString cfg.webFrontend.port} {
       handle /api/* {
         reverse_proxy 127.0.0.1:${toString cfg.port} {
           flush_interval -1

--- a/nix/nixos.nix
+++ b/nix/nixos.nix
@@ -41,7 +41,7 @@
       persist_config off
     }
 
-    ${cfg.webFrontend.host}:${toString cfg.webFrontend.port} {
+    http://${cfg.webFrontend.host}:${toString cfg.webFrontend.port} {
       handle /api/* {
         reverse_proxy 127.0.0.1:${toString cfg.port} {
           flush_interval -1


### PR DESCRIPTION
## Why

I've set up the _open-design_ and _open-design-web_ services via Home Manager. However, I could not get the front-end to work. In my web browser I'd get an error page. Looking at the developer tools, I could see I was getting an HTTP 400. Running `curl` gave me a better idea of what's going on:

```
❯ curl http://127.0.0.1:5174/index.html
Client sent an HTTP request to an HTTPS server.
```

I've never used Caddy before, but it looks like the `auto_https off` config is insufficient

## What users will see

Instead of seeing an HTTP 400 error in a browser, the user will now see the Open Design UI.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only


## Bug fix verification

I don't know how you want to test Nix changes. I can work on a test with some guidance.


## Validation

Since the service file in Nix pointed at a read-only copy of the Caddy config, I copied the config from the generated service file and replicated the issue. I don't know if there's a better fix, but making the change to explicitly specify the `http://` scheme in the bind URL fixed the issue for me.

