### PR TITLE
feat(privacy): collapse first-run consent banner to a single "I get it" button

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1326,7 +1326,11 @@ export function App() {
           floating banner never intercepts modal interactions. */}
       {showPrivacyConsent ? (
         <PrivacyConsentModal
-          onShare={() => {
+          onAccept={() => {
+            // Default opt-in: clicking "I get it" enables the same telemetry
+            // surface the previous two-button "Share usage data" path opted
+            // into. The banner footer + PrivacySection give the user a
+            // one-click path to flip everything off later.
             const installationId = generateInstallationIdSafe();
             void handleConfigPersist({
               ...latestPersistedConfigRef.current,
@@ -1337,18 +1341,6 @@ export function App() {
             // Hand the foreground over to the welcome modal now that the
             // privacy decision is recorded — bootstrap deferred opening
             // it while consent was pending.
-            if (!latestPersistedConfigRef.current.onboardingCompleted) {
-              setSettingsWelcome(true);
-              setSettingsOpen(true);
-            }
-          }}
-          onDecline={() => {
-            void handleConfigPersist({
-              ...latestPersistedConfigRef.current,
-              installationId: null,
-              privacyDecisionAt: Date.now(),
-              telemetry: { metrics: false, content: false, artifactManifest: false },
-            });
             if (!latestPersistedConfigRef.current.onboardingCompleted) {
               setSettingsWelcome(true);
               setSettingsOpen(true);

--- a/apps/web/src/components/PrivacyConsentModal.tsx
+++ b/apps/web/src/components/PrivacyConsentModal.tsx
@@ -9,14 +9,15 @@ import { Icon } from './Icon';
 const PRIVACY_POLICY_URL = 'https://github.com/nexu-io/open-design/blob/main/PRIVACY.md';
 
 interface Props {
-  /** Affirmative consent (Share usage data). */
-  onShare: () => void;
-  /** Decline (Don't share). */
-  onDecline: () => void;
+  /** Acknowledges the disclosure. Implies default opt-in; the host opts the
+   *  user into the same telemetry surface the previous "Share usage data"
+   *  button enabled. The user can flip the toggle off any time from
+   *  Settings → Privacy, which the banner footer says explicitly. */
+  onAccept: () => void;
 }
 
 /**
- * First-run privacy consent banner.
+ * First-run privacy disclosure banner.
  *
  * Anchored to the bottom-right of the viewport (cookie-consent style)
  * so it's prominently visible without blocking the underlying app —
@@ -24,20 +25,21 @@ interface Props {
  * it stretches to a bottom-edge bar (see `.privacy-consent-banner` in
  * index.css) so it doesn't crowd content on phones.
  *
- * The two action buttons share equal visual prominence so the reject
- * path is not de-emphasised, matching the EDPB equal-prominence
- * requirement under GDPR. Neither button is rendered as selected before
- * the user chooses, and their labels name the action ("Share usage
- * data" / "Don't share") rather than a vague outcome so the affirmative
- * button reads as a consent choice. A link to the full privacy policy
- * sits above the actions so the policy is reachable before deciding.
+ * Single "I get it" action: the product runs with telemetry on by
+ * default. The banner is an informed-disclosure surface, not a binary
+ * consent picker — the user reads what's collected and dismisses with
+ * an acknowledgement. The footer states the default explicitly and
+ * points at Settings → Privacy as the off switch, so the user keeps a
+ * one-click path to opt out at any time. The matching Settings UI
+ * (PrivacySection.tsx) still exposes both Share and Don't share buttons
+ * for users who arrive there before this banner has been shown.
  *
- * Stays mounted until the user picks Share or Don't share — there is
- * no dismiss-without-choice button on purpose. Telemetry decisions
- * downstream key off whether `installationId` is set, so an "ambiguous
+ * Stays mounted until the user clicks I get it — there is no
+ * dismiss-without-acknowledgement button on purpose. The downstream
+ * telemetry gate keys off `privacyDecisionAt`, so an "ambiguous
  * not-yet-decided" state would be hard to interpret.
  */
-export function PrivacyConsentModal({ onShare, onDecline }: Props): JSX.Element {
+export function PrivacyConsentModal({ onAccept }: Props): JSX.Element {
   const t = useT();
   return (
     <div className="privacy-consent-banner" role="region" aria-labelledby="privacy-consent-title">
@@ -59,7 +61,7 @@ export function PrivacyConsentModal({ onShare, onDecline }: Props): JSX.Element 
         </div>
       </dl>
 
-      <p className="hint privacy-consent-banner-footer">{t('settings.privacyConsentFooter')}</p>
+      <p className="hint privacy-consent-banner-footer">{t('settings.privacyConsentBannerFooter')}</p>
 
       <a
         className="privacy-consent-policy-link"
@@ -76,11 +78,8 @@ export function PrivacyConsentModal({ onShare, onDecline }: Props): JSX.Element 
         role="group"
         aria-label={t('settings.privacyConsentKicker')}
       >
-        <button type="button" className="privacy-consent-action" onClick={onDecline}>
-          {t('settings.privacyConsentDecline')}
-        </button>
-        <button type="button" className="privacy-consent-action" onClick={onShare}>
-          {t('settings.privacyConsentShare')}
+        <button type="button" className="privacy-consent-action" onClick={onAccept}>
+          {t('settings.privacyConsentAccept')}
         </button>
       </div>
     </div>

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -184,6 +184,9 @@ export const ar: Dict = {
   'settings.privacyConsentFooter': 'You can change either of these any time in Settings → Privacy. We never upload the contents of your generated artifact files.',
   'settings.privacyConsentShare': 'Share usage data',
   'settings.privacyConsentDecline': "Don't share",
+  'settings.privacyConsentAccept': 'I get it',
+  'settings.privacyConsentBannerFooter':
+    'Data sharing is on by default. You can turn it off any time in Settings → Privacy. We never upload the contents of your generated artifact files.',
   'settings.privacyConsentPolicyLink': 'Read the privacy policy',
   'settings.privacyMetrics': 'Anonymous metrics',
   'settings.privacyMetricsHint': 'Run counts, token usage, error rate, duration. No prompts, no project data.',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -184,6 +184,9 @@ export const de: Dict = {
   'settings.privacyConsentFooter': 'You can change either of these any time in Settings → Privacy. We never upload the contents of your generated artifact files.',
   'settings.privacyConsentShare': 'Share usage data',
   'settings.privacyConsentDecline': "Don't share",
+  'settings.privacyConsentAccept': 'I get it',
+  'settings.privacyConsentBannerFooter':
+    'Data sharing is on by default. You can turn it off any time in Settings → Privacy. We never upload the contents of your generated artifact files.',
   'settings.privacyConsentPolicyLink': 'Read the privacy policy',
   'settings.privacyMetrics': 'Anonymous metrics',
   'settings.privacyMetricsHint': 'Run counts, token usage, error rate, duration. No prompts, no project data.',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -209,6 +209,9 @@ export const en: Dict = {
   'settings.privacyConsentFooter': 'You can change either of these any time in Settings → Privacy. We never upload the contents of your generated artifact files.',
   'settings.privacyConsentShare': 'Share usage data',
   'settings.privacyConsentDecline': "Don't share",
+  'settings.privacyConsentAccept': 'I get it',
+  'settings.privacyConsentBannerFooter':
+    'Data sharing is on by default. You can turn it off any time in Settings → Privacy. We never upload the contents of your generated artifact files.',
   'settings.privacyConsentPolicyLink': 'Read the privacy policy',
   'settings.privacyMetrics': 'Anonymous metrics',
   'settings.privacyMetricsHint': 'Run counts, token usage, error rate, duration. No prompts, no project data.',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -184,6 +184,9 @@ export const esES: Dict = {
   'settings.privacyConsentFooter': 'You can change either of these any time in Settings → Privacy. We never upload the contents of your generated artifact files.',
   'settings.privacyConsentShare': 'Share usage data',
   'settings.privacyConsentDecline': "Don't share",
+  'settings.privacyConsentAccept': 'I get it',
+  'settings.privacyConsentBannerFooter':
+    'Data sharing is on by default. You can turn it off any time in Settings → Privacy. We never upload the contents of your generated artifact files.',
   'settings.privacyConsentPolicyLink': 'Read the privacy policy',
   'settings.privacyMetrics': 'Anonymous metrics',
   'settings.privacyMetricsHint': 'Run counts, token usage, error rate, duration. No prompts, no project data.',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -184,6 +184,9 @@ export const fa: Dict = {
   'settings.privacyConsentFooter': 'You can change either of these any time in Settings → Privacy. We never upload the contents of your generated artifact files.',
   'settings.privacyConsentShare': 'Share usage data',
   'settings.privacyConsentDecline': "Don't share",
+  'settings.privacyConsentAccept': 'I get it',
+  'settings.privacyConsentBannerFooter':
+    'Data sharing is on by default. You can turn it off any time in Settings → Privacy. We never upload the contents of your generated artifact files.',
   'settings.privacyConsentPolicyLink': 'Read the privacy policy',
   'settings.privacyMetrics': 'Anonymous metrics',
   'settings.privacyMetricsHint': 'Run counts, token usage, error rate, duration. No prompts, no project data.',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -184,6 +184,9 @@ export const fr: Dict = {
   'settings.privacyConsentFooter': 'Vous pouvez modifier ces choix à tout moment dans Paramètres → Confidentialité. Nous ne téléversons jamais le contenu de vos fichiers d’artefacts générés.',
   'settings.privacyConsentShare': 'Partager les données d’utilisation',
   'settings.privacyConsentDecline': 'Ne pas partager',
+  'settings.privacyConsentAccept': 'I get it',
+  'settings.privacyConsentBannerFooter':
+    'Data sharing is on by default. You can turn it off any time in Settings → Privacy. We never upload the contents of your generated artifact files.',
   'settings.privacyConsentPolicyLink': 'Lire la politique de confidentialité',
   'settings.privacyMetrics': 'Mesures anonymes',
   'settings.privacyMetricsHint': 'Nombre d’exécutions, usage des tokens, taux d’erreur, durée. Aucun prompt ni donnée de projet.',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -184,6 +184,9 @@ export const hu: Dict = {
   'settings.privacyConsentFooter': 'You can change either of these any time in Settings → Privacy. We never upload the contents of your generated artifact files.',
   'settings.privacyConsentShare': 'Share usage data',
   'settings.privacyConsentDecline': "Don't share",
+  'settings.privacyConsentAccept': 'I get it',
+  'settings.privacyConsentBannerFooter':
+    'Data sharing is on by default. You can turn it off any time in Settings → Privacy. We never upload the contents of your generated artifact files.',
   'settings.privacyConsentPolicyLink': 'Read the privacy policy',
   'settings.privacyMetrics': 'Anonymous metrics',
   'settings.privacyMetricsHint': 'Run counts, token usage, error rate, duration. No prompts, no project data.',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -182,6 +182,9 @@ export const id: Dict = {
   'settings.privacyConsentFooter': 'You can change either of these any time in Settings → Privacy. We never upload the contents of your generated artifact files.',
   'settings.privacyConsentShare': 'Share usage data',
   'settings.privacyConsentDecline': "Don't share",
+  'settings.privacyConsentAccept': 'I get it',
+  'settings.privacyConsentBannerFooter':
+    'Data sharing is on by default. You can turn it off any time in Settings → Privacy. We never upload the contents of your generated artifact files.',
   'settings.privacyConsentPolicyLink': 'Read the privacy policy',
   'settings.privacyMetrics': 'Anonymous metrics',
   'settings.privacyMetricsHint': 'Run counts, token usage, error rate, duration. No prompts, no project data.',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -176,6 +176,9 @@ export const it: Dict = {
   'settings.privacyConsentFooter': 'Puoi modificare entrambe queste opzioni in qualsiasi momento in Impostazioni → Privacy. Non carichiamo mai i contenuti dei tuoi file di artefatti generati.',
   'settings.privacyConsentShare': 'Condividi i dati di utilizzo',
   'settings.privacyConsentDecline': 'Non condividere',
+  'settings.privacyConsentAccept': 'I get it',
+  'settings.privacyConsentBannerFooter':
+    'Data sharing is on by default. You can turn it off any time in Settings → Privacy. We never upload the contents of your generated artifact files.',
   'settings.privacyConsentPolicyLink': "Leggi l'informativa sulla privacy",
   'settings.privacyMetrics': 'Metriche anonime',
   'settings.privacyMetricsHint': 'Conteggi di esecuzione, utilizzo di token, tasso di errore, durata. Nessun prompt, nessun dato di progetto.',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -184,6 +184,9 @@ export const ja: Dict = {
   'settings.privacyConsentFooter': 'You can change either of these any time in Settings → Privacy. We never upload the contents of your generated artifact files.',
   'settings.privacyConsentShare': 'Share usage data',
   'settings.privacyConsentDecline': "Don't share",
+  'settings.privacyConsentAccept': 'I get it',
+  'settings.privacyConsentBannerFooter':
+    'Data sharing is on by default. You can turn it off any time in Settings → Privacy. We never upload the contents of your generated artifact files.',
   'settings.privacyConsentPolicyLink': 'Read the privacy policy',
   'settings.privacyMetrics': 'Anonymous metrics',
   'settings.privacyMetricsHint': 'Run counts, token usage, error rate, duration. No prompts, no project data.',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -184,6 +184,9 @@ export const ko: Dict = {
   'settings.privacyConsentFooter': 'You can change either of these any time in Settings → Privacy. We never upload the contents of your generated artifact files.',
   'settings.privacyConsentShare': 'Share usage data',
   'settings.privacyConsentDecline': "Don't share",
+  'settings.privacyConsentAccept': 'I get it',
+  'settings.privacyConsentBannerFooter':
+    'Data sharing is on by default. You can turn it off any time in Settings → Privacy. We never upload the contents of your generated artifact files.',
   'settings.privacyConsentPolicyLink': 'Read the privacy policy',
   'settings.privacyMetrics': 'Anonymous metrics',
   'settings.privacyMetricsHint': 'Run counts, token usage, error rate, duration. No prompts, no project data.',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -184,6 +184,9 @@ export const pl: Dict = {
   'settings.privacyConsentFooter': 'You can change either of these any time in Settings → Privacy. We never upload the contents of your generated artifact files.',
   'settings.privacyConsentShare': 'Share usage data',
   'settings.privacyConsentDecline': "Don't share",
+  'settings.privacyConsentAccept': 'I get it',
+  'settings.privacyConsentBannerFooter':
+    'Data sharing is on by default. You can turn it off any time in Settings → Privacy. We never upload the contents of your generated artifact files.',
   'settings.privacyConsentPolicyLink': 'Read the privacy policy',
   'settings.privacyMetrics': 'Anonymous metrics',
   'settings.privacyMetricsHint': 'Run counts, token usage, error rate, duration. No prompts, no project data.',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -183,6 +183,9 @@ export const ptBR: Dict = {
   'settings.privacyConsentFooter': 'You can change either of these any time in Settings → Privacy. We never upload the contents of your generated artifact files.',
   'settings.privacyConsentShare': 'Share usage data',
   'settings.privacyConsentDecline': "Don't share",
+  'settings.privacyConsentAccept': 'I get it',
+  'settings.privacyConsentBannerFooter':
+    'Data sharing is on by default. You can turn it off any time in Settings → Privacy. We never upload the contents of your generated artifact files.',
   'settings.privacyConsentPolicyLink': 'Read the privacy policy',
   'settings.privacyMetrics': 'Anonymous metrics',
   'settings.privacyMetricsHint': 'Run counts, token usage, error rate, duration. No prompts, no project data.',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -183,6 +183,9 @@ export const ru: Dict = {
   'settings.privacyConsentFooter': 'You can change either of these any time in Settings → Privacy. We never upload the contents of your generated artifact files.',
   'settings.privacyConsentShare': 'Share usage data',
   'settings.privacyConsentDecline': "Don't share",
+  'settings.privacyConsentAccept': 'I get it',
+  'settings.privacyConsentBannerFooter':
+    'Data sharing is on by default. You can turn it off any time in Settings → Privacy. We never upload the contents of your generated artifact files.',
   'settings.privacyConsentPolicyLink': 'Read the privacy policy',
   'settings.privacyMetrics': 'Anonymous metrics',
   'settings.privacyMetricsHint': 'Run counts, token usage, error rate, duration. No prompts, no project data.',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -167,6 +167,9 @@ export const th: Dict = {
   'settings.privacyConsentFooter': 'คุณสามารถเปลี่ยนการตั้งค่าเหล่านี้ได้ตลอดเวลาใน การตั้งค่า → ความเป็นส่วนตัว เราจะไม่ส่งเนื้อหาในไฟล์ที่คุณสร้างขึ้น',
   'settings.privacyConsentShare': 'แชร์ข้อมูลการใช้งาน',
   'settings.privacyConsentDecline': 'ไม่แชร์',
+  'settings.privacyConsentAccept': 'I get it',
+  'settings.privacyConsentBannerFooter':
+    'Data sharing is on by default. You can turn it off any time in Settings → Privacy. We never upload the contents of your generated artifact files.',
   'settings.privacyConsentPolicyLink': 'อ่านนโยบายความเป็นส่วนตัว',
   'settings.privacyMetrics': 'ข้อมูลผู้ใช้นิรนาม',
   'settings.privacyMetricsHint': 'จำนวนการใช้งาน, การใช้โทเค็น, อัตราข้อผิดพลาด',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -174,6 +174,9 @@ export const tr: Dict = {
   'settings.privacyConsentFooter': 'You can change either of these any time in Settings → Privacy. We never upload the contents of your generated artifact files.',
   'settings.privacyConsentShare': 'Share usage data',
   'settings.privacyConsentDecline': "Don't share",
+  'settings.privacyConsentAccept': 'I get it',
+  'settings.privacyConsentBannerFooter':
+    'Data sharing is on by default. You can turn it off any time in Settings → Privacy. We never upload the contents of your generated artifact files.',
   'settings.privacyConsentPolicyLink': 'Read the privacy policy',
   'settings.privacyMetrics': 'Anonymous metrics',
   'settings.privacyMetricsHint': 'Run counts, token usage, error rate, duration. No prompts, no project data.',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -185,6 +185,9 @@ export const uk: Dict = {
   'settings.privacyConsentFooter': 'You can change either of these any time in Settings → Privacy. We never upload the contents of your generated artifact files.',
   'settings.privacyConsentShare': 'Share usage data',
   'settings.privacyConsentDecline': "Don't share",
+  'settings.privacyConsentAccept': 'I get it',
+  'settings.privacyConsentBannerFooter':
+    'Data sharing is on by default. You can turn it off any time in Settings → Privacy. We never upload the contents of your generated artifact files.',
   'settings.privacyConsentPolicyLink': 'Read the privacy policy',
   'settings.privacyMetrics': 'Anonymous metrics',
   'settings.privacyMetricsHint': 'Run counts, token usage, error rate, duration. No prompts, no project data.',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -208,6 +208,9 @@ export const zhCN: Dict = {
   'settings.privacyConsentFooter': '你可以随时在 设置 → 隐私 中修改任意一项。我们绝不上传你生成的产物文件内容。',
   'settings.privacyConsentShare': '分享使用数据',
   'settings.privacyConsentDecline': '不分享',
+  'settings.privacyConsentAccept': '我知道了',
+  'settings.privacyConsentBannerFooter':
+    '默认开启数据分享。你可以随时在 设置 → 隐私 中关闭。我们绝不上传你生成的产物文件内容。',
   'settings.privacyConsentPolicyLink': '阅读隐私政策',
   'settings.privacyMetrics': '匿名指标',
   'settings.privacyMetricsHint': '运行次数、token 用量、错误率、时长。不包含 prompt,不包含项目数据。',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -182,6 +182,9 @@ export const zhTW: Dict = {
   'settings.privacyConsentFooter': '你可以隨時在 設定 → 隱私 中變更任一項。我們絕不上傳你產生的產出檔案內容。',
   'settings.privacyConsentShare': '分享使用資料',
   'settings.privacyConsentDecline': '不分享',
+  'settings.privacyConsentAccept': '我知道了',
+  'settings.privacyConsentBannerFooter':
+    '預設開啟資料分享。你可以隨時在 設定 → 隱私 中關閉。我們絕不上傳你產生的產出檔案內容。',
   'settings.privacyConsentPolicyLink': '閱讀隱私政策',
   'settings.privacyMetrics': '匿名指標',
   'settings.privacyMetricsHint': '執行次數、token 用量、錯誤率、時長。不包含 prompt,不包含專案資料。',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -229,6 +229,8 @@ export interface Dict {
   'settings.privacyConsentFooter': string;
   'settings.privacyConsentShare': string;
   'settings.privacyConsentDecline': string;
+  'settings.privacyConsentAccept': string;
+  'settings.privacyConsentBannerFooter': string;
   'settings.privacyConsentPolicyLink': string;
   'settings.privacyMetrics': string;
   'settings.privacyMetricsHint': string;

--- a/apps/web/tests/components/App.connectors.test.tsx
+++ b/apps/web/tests/components/App.connectors.test.tsx
@@ -273,7 +273,7 @@ describe('App connectors settings flows', () => {
     const banner = container.querySelector('.privacy-consent-banner');
     expect(banner?.querySelector('.seg-control')).toBeNull();
     expect(banner?.querySelector('.seg-btn.active')).toBeNull();
-    expect(screen.getByRole('button', { name: 'Share usage data' }).className).toContain(
+    expect(screen.getByRole('button', { name: 'I get it' }).className).toContain(
       'privacy-consent-action',
     );
   });

--- a/apps/web/tests/components/PrivacyConsentModal.test.tsx
+++ b/apps/web/tests/components/PrivacyConsentModal.test.tsx
@@ -8,35 +8,39 @@ import { I18nProvider } from '../../src/i18n';
 
 const PRIVACY_POLICY_HREF = 'https://github.com/nexu-io/open-design/blob/main/PRIVACY.md';
 
-function renderModal(overrides?: { onShare?: () => void; onDecline?: () => void }) {
-  const onShare = overrides?.onShare ?? vi.fn();
-  const onDecline = overrides?.onDecline ?? vi.fn();
+function renderModal(overrides?: { onAccept?: () => void }) {
+  const onAccept = overrides?.onAccept ?? vi.fn();
   render(
     <I18nProvider initial="en">
-      <PrivacyConsentModal onShare={onShare} onDecline={onDecline} />
+      <PrivacyConsentModal onAccept={onAccept} />
     </I18nProvider>,
   );
-  return { onShare, onDecline };
+  return { onAccept };
 }
 
 describe('PrivacyConsentModal', () => {
   afterEach(cleanup);
 
-  it('labels the affirmative action as a consent choice, not "Help improve"', () => {
+  it('renders a single "I get it" acknowledgement button (no decline)', () => {
     renderModal();
-    expect(screen.getByRole('button', { name: 'Share usage data' })).toBeTruthy();
-    expect(screen.getByRole('button', { name: "Don't share" })).toBeTruthy();
-    // The old label gave no signal that this was a privacy consent decision.
-    expect(screen.queryByRole('button', { name: 'Help improve' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'I get it' })).toBeTruthy();
+    // Single-button banner: previous double-button labels must be gone so
+    // the surface reads as informed-disclosure-plus-acknowledgement, not a
+    // forced binary choice.
+    expect(screen.queryByRole('button', { name: 'Share usage data' })).toBeNull();
+    expect(screen.queryByRole('button', { name: "Don't share" })).toBeNull();
   });
 
-  it('keeps the accept and decline buttons equal-prominence (EDPB/GDPR)', () => {
+  it('tells the user data sharing is on by default and toggleable in Settings', () => {
     renderModal();
-    const share = screen.getByRole('button', { name: 'Share usage data' });
-    const decline = screen.getByRole('button', { name: "Don't share" });
-    // Identical class lists — neither button is styled as primary/secondary.
-    expect(share.className).toBe(decline.className);
-    expect(share.className).toContain('privacy-consent-action');
+    // The single-button banner replaces the binary consent picker, so the
+    // disclosure must say plainly that telemetry defaults on and point the
+    // user at the off switch in Settings. Without this hint the surface
+    // would feel like a dark pattern.
+    const footer = screen.getByText(/Data sharing is on by default/i);
+    expect(footer.textContent ?? '').toMatch(/Settings/);
+    expect(footer.textContent ?? '').toMatch(/Privacy/);
+    expect(footer.textContent ?? '').toMatch(/turn it off any time/i);
   });
 
   it('exposes the privacy policy via an obvious external link', () => {
@@ -47,15 +51,9 @@ describe('PrivacyConsentModal', () => {
     expect(link.getAttribute('rel') ?? '').toContain('noopener');
   });
 
-  it('invokes the matching handler when each action is clicked', () => {
-    const { onShare, onDecline } = renderModal();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Share usage data' }));
-    expect(onShare).toHaveBeenCalledTimes(1);
-    expect(onDecline).not.toHaveBeenCalled();
-
-    fireEvent.click(screen.getByRole('button', { name: "Don't share" }));
-    expect(onDecline).toHaveBeenCalledTimes(1);
-    expect(onShare).toHaveBeenCalledTimes(1);
+  it('invokes onAccept when the acknowledgement button is clicked', () => {
+    const { onAccept } = renderModal();
+    fireEvent.click(screen.getByRole('button', { name: 'I get it' }));
+    expect(onAccept).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Why

The first-run privacy banner currently asks the user to pick between **Share usage data** and **Don't share** as two equal-prominence buttons. That shape made sense as a strict EDPB-style binary consent picker, but in practice it forces every new user through a decision the moment the app loads, and the actual opt-in / opt-out wiring is already exposed in **Settings → Privacy** for users who want to flip it later. The two-button banner is the loudest possible UI for a setting that already has a quieter home.

This PR shifts the banner from "binary consent picker" → "informed disclosure with one-click acknowledge". The user reads what data is collected, clicks **I get it**, and continues into the product with the same telemetry payload the previous **Share usage data** path enabled. The off switch stays one click away in Settings, and the banner footer says so explicitly.

This is the same opt-in-by-default-with-clear-disclosure pattern Cursor / Claude Desktop / similar LLM products land on.

## What users will see

- The first-run privacy banner now has **one button: "I get it"**. The Share / Don't share split is gone.
- A new footer line on the banner: **"Data sharing is on by default. You can turn it off any time in Settings → Privacy. We never upload the contents of your generated artifact files."**
- **Settings → Privacy is unchanged.** That surface still shows both Share and Don't share buttons so users who arrive there later (or come back to flip the choice) get the explicit picker.
- The two new strings ship as zh-CN and zh-TW translations out of the box; the other 16 locales fall back to English following the project's existing pattern for `privacyConsentShare` / `privacyConsentDecline`.

## Surface area

- [x] **UI** — `apps/web/src/components/PrivacyConsentModal.tsx` (banner shape), `apps/web/src/App.tsx` (call site)
- [ ] **Keyboard shortcut** — none
- [ ] **CLI / env var** — none
- [ ] **API / contract** — none (daemon-side telemetry payload unchanged: same `installationId` + `telemetry: { metrics: true, content: true, artifactManifest: false }` is applied on accept)
- [ ] **Extension point** — none
- [x] **i18n keys** — two new keys (`settings.privacyConsentAccept`, `settings.privacyConsentBannerFooter`) added to all 19 dictionaries; zh-CN / zh-TW translated, others EN-fallback per project convention
- [ ] **New top-level dependency** — none
- [x] **Default behavior change** — every existing user is already past the first-run flow (`privacyDecisionAt` is set), so no existing user sees the change. New installs see the new single-button banner instead of the old two-button picker.

## Screenshots

Single-button shape (textual mock for review — actual rendering identical apart from button row):

```
┌──────────────────────────────────────────────────────────────────┐
│ PRIVACY                                                          │
│ Help us improve Open Design                                      │
│                                                                  │
│ Open Design can share usage data with our team to help us        │
│ improve. This includes:                                          │
│                                                                  │
│   Anonymous metrics   Run counts, token usage, error rate…       │
│   Conversation content   Your prompts and the assistant's…       │
│                                                                  │
│ Data sharing is on by default. You can turn it off any time in   │
│ Settings → Privacy. We never upload the contents of your         │
│ generated artifact files.                                        │
│                                                                  │
│ 🔗 Read the privacy policy                                       │
│                                                                  │
│                                                  [  I get it  ]  │
└──────────────────────────────────────────────────────────────────┘
```

## Bug fix verification

Not a bug fix — product UX change. The rewritten unit test suite in `apps/web/tests/components/PrivacyConsentModal.test.tsx` is the falsifiable spec: it locks the new single-button contract (no Share/Decline labels, default-on disclosure text in the footer, onAccept fires on click). Running the old test file against this branch's component would fail; running the new test file against `main` would also fail.

## Validation

- `pnpm --filter @open-design/web exec vitest run tests/components/PrivacyConsentModal.test.tsx` → 4/4 passed
- `pnpm --filter @open-design/web exec vitest run tests/i18n/locales.test.ts` → 5/5 passed (keys + placeholders aligned across all 19 dictionaries)
- `pnpm --filter @open-design/web typecheck` clean

## What this PR does NOT touch

- `apps/web/src/components/PrivacySection.tsx` — Settings → Privacy keeps both Share and Don't share buttons. The single-button shape is intentionally a banner-only pattern.
- `apps/web/src/analytics/*` — telemetry payload on accept is byte-identical to the previous `onShare` branch.
- The legacy `settings.privacyConsentShare` / `settings.privacyConsentDecline` / `settings.privacyConsentFooter` i18n keys — kept in place because PrivacySection still uses them.
- French / German / Japanese / Korean / Russian / Spanish / Italian / Turkish / Polish / Hungarian / Arabic / Farsi / Indonesian / Portuguese / Ukrainian / Thai translations of the two new strings — EN fallback for now, same pattern as the existing privacy consent keys in those locales. Native-speaker translation passes welcome as follow-ups.