### PR TITLE
Read design-system usage and manifest cache

### DIFF
--- a/apps/daemon/src/design-systems.ts
+++ b/apps/daemon/src/design-systems.ts
@@ -14,6 +14,7 @@ import { mkdir, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import path from 'node:path';
 
 import {
+  type ComponentsManifest,
   extractComponentsManifest,
   summarizeComponentsManifestForPrompt,
 } from '@open-design/contracts';
@@ -90,6 +91,30 @@ type DesignSystemProjectManifest = {
     design: 'DESIGN.md';
     tokens: 'tokens.css';
     components?: 'components.html';
+  };
+  assetsDir?: 'assets';
+  previewDir?: 'preview';
+  usage?: string;
+  componentsManifest?: string;
+  fonts?: Array<{
+    family: string;
+    file: string;
+    weight?: number | string;
+    style?: string;
+  }>;
+  preview?: {
+    dir: string;
+    pages: Array<{
+      path: string;
+      role?: string;
+      title?: string;
+    }>;
+  };
+  sourceFiles?: {
+    scanned?: string;
+    evidence?: string;
+    tokens?: string;
+    snippets?: string;
   };
 };
 
@@ -307,15 +332,22 @@ export async function readDesignSystem(
  * hand-authored or derived tokens.
  *
  * - `tokensCss`     — verbatim content of `<brand>/tokens.css`.
+ * - `usageMd`       — optional agent-facing router for the package.
  * - `fixtureHtml`   — verbatim content of `<brand>/components.html`.
  * - `componentsManifest` — concise summary derived from components.html
+ *                          or read from components.manifest.json cache
  *                          for prompt injection; when absent, callers
  *                          can fall back to `fixtureHtml`.
+ * - `pullIndex`     — short manifest-derived file index. It lists
+ *                     richer preview/source evidence paths without
+ *                     loading those files into the push prompt.
  */
 export type DesignSystemAssets = {
+  usageMd?: string | undefined;
   tokensCss?: string | undefined;
   fixtureHtml?: string | undefined;
   componentsManifest?: string | undefined;
+  pullIndex?: string | undefined;
 };
 
 export async function readDesignSystemAssets(
@@ -326,13 +358,21 @@ export async function readDesignSystemAssets(
   if (!dirId) return {};
   const brandRoot = path.join(root, dirId);
   const manifest = await readProjectManifest(brandRoot, dirId);
-  const [tokensCss, fixtureHtml] = await Promise.all([
+  const [usageMd, tokensCss, fixtureHtml, componentsManifestJson] = await Promise.all([
+    readManifestFileOptional(brandRoot, manifest?.usage ?? 'USAGE.md'),
     readFileOptional(path.join(brandRoot, manifest?.files.tokens ?? 'tokens.css')),
     manifest?.files.components === undefined && manifest !== null
       ? Promise.resolve(undefined)
       : readFileOptional(path.join(brandRoot, manifest?.files.components ?? 'components.html')),
+    readManifestFileOptional(brandRoot, manifest?.componentsManifest ?? 'components.manifest.json'),
   ]);
-  return withComponentsManifest(id, { tokensCss, fixtureHtml });
+  return withComponentsManifest(id, {
+    usageMd,
+    tokensCss,
+    fixtureHtml,
+    componentsManifestJson,
+    pullIndex: buildDesignSystemPullIndex(manifest),
+  });
 }
 
 export function isDesignTokenChannelEnabled(
@@ -348,7 +388,13 @@ export async function resolveDesignSystemAssets(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<DesignSystemAssets> {
   if (!isDesignTokenChannelEnabled(env)) {
-    return { tokensCss: undefined, fixtureHtml: undefined };
+    return {
+      usageMd: undefined,
+      tokensCss: undefined,
+      fixtureHtml: undefined,
+      componentsManifest: undefined,
+      pullIndex: undefined,
+    };
   }
 
   const builtIn = await readDesignSystemAssets(builtInRoot, designSystemId);
@@ -358,21 +404,40 @@ export async function resolveDesignSystemAssets(
 
   const userInstalled = await readDesignSystemAssets(userInstalledRoot, designSystemId);
   return withComponentsManifest(designSystemId, {
+    usageMd: builtIn.usageMd ?? userInstalled.usageMd,
     tokensCss: builtIn.tokensCss ?? userInstalled.tokensCss,
     fixtureHtml: builtIn.fixtureHtml ?? userInstalled.fixtureHtml,
+    componentsManifestJson: undefined,
+    componentsManifest: builtIn.componentsManifest ?? userInstalled.componentsManifest,
+    pullIndex: builtIn.pullIndex ?? userInstalled.pullIndex,
   });
 }
 
 function withComponentsManifest(
   designSystemId: string,
-  assets: Pick<DesignSystemAssets, 'tokensCss' | 'fixtureHtml'>,
+  assets: Pick<DesignSystemAssets, 'usageMd' | 'tokensCss' | 'fixtureHtml' | 'componentsManifest' | 'pullIndex'> & {
+    componentsManifestJson?: string | undefined;
+  },
 ): DesignSystemAssets {
-  const componentsManifest = buildComponentsManifestSummary(
-    designSystemId,
-    assets.fixtureHtml,
-    assets.tokensCss,
-  );
-  return { ...assets, componentsManifest };
+  const { componentsManifestJson, ...publicAssets } = assets;
+  const componentsManifest =
+    publicAssets.componentsManifest
+    ?? summarizeComponentsManifestCache(componentsManifestJson)
+    ?? buildComponentsManifestSummary(
+      designSystemId,
+      publicAssets.fixtureHtml,
+      publicAssets.tokensCss,
+    );
+  return { ...publicAssets, componentsManifest };
+}
+
+function summarizeComponentsManifestCache(raw: string | undefined): string | undefined {
+  if (raw === undefined || raw.trim().length === 0) return undefined;
+  try {
+    return summarizeComponentsManifestForPrompt(JSON.parse(raw) as ComponentsManifest);
+  } catch {
+    return undefined;
+  }
 }
 
 function buildComponentsManifestSummary(
@@ -393,6 +458,40 @@ function buildComponentsManifestSummary(
   } catch {
     return undefined;
   }
+}
+
+function buildDesignSystemPullIndex(
+  manifest: DesignSystemProjectManifest | null,
+): string | undefined {
+  if (manifest === null) return undefined;
+  const entries: string[] = [];
+  const add = (filePath: string | undefined, label: string): void => {
+    if (!filePath || !isSafeManifestPath(filePath)) return;
+    entries.push(`- ${filePath}: ${label}`);
+  };
+
+  if (manifest.preview?.pages) {
+    for (const page of manifest.preview.pages) {
+      if (!isSafeManifestPath(page.path)) continue;
+      const labelParts = [page.title, page.role].filter((part) => typeof part === 'string' && part.trim().length > 0);
+      entries.push(`- ${page.path}: ${labelParts.join('; ') || 'preview page'}`);
+    }
+  } else if (manifest.previewDir === 'preview') {
+    entries.push('- preview/: preview pages');
+  }
+
+  if (manifest.assetsDir === 'assets') entries.push('- assets/: brand assets');
+  for (const font of manifest.fonts ?? []) {
+    add(font.file, `font: ${font.family}${font.weight ? ` ${font.weight}` : ''}${font.style ? ` ${font.style}` : ''}`);
+  }
+
+  add(manifest.sourceFiles?.scanned, 'scanned source file inventory');
+  add(manifest.sourceFiles?.evidence, 'import evidence notes');
+  add(manifest.sourceFiles?.tokens, 'source-token evidence');
+  add(manifest.sourceFiles?.snippets, 'source snippet index');
+
+  if (entries.length === 0) return undefined;
+  return ['Additional design-system files declared by manifest.json:', ...entries].join('\n');
 }
 
 export async function createUserDesignSystem(
@@ -2303,6 +2402,21 @@ async function readFileOptional(file: string): Promise<string | undefined> {
     if (isAbsenceError(err)) return undefined;
     throw err;
   }
+}
+
+async function readManifestFileOptional(
+  brandRoot: string,
+  relativePath: string,
+): Promise<string | undefined> {
+  if (!isSafeManifestPath(relativePath)) return undefined;
+  return readFileOptional(path.join(brandRoot, relativePath));
+}
+
+function isSafeManifestPath(relativePath: string): boolean {
+  if (relativePath.trim().length === 0) return false;
+  if (path.isAbsolute(relativePath)) return false;
+  const parts = relativePath.split(/[\\/]+/);
+  return parts.every((part) => part.length > 0 && part !== '.' && part !== '..');
 }
 
 function isAbsenceError(err: unknown): boolean {

--- a/apps/daemon/src/prompts/system.ts
+++ b/apps/daemon/src/prompts/system.ts
@@ -156,6 +156,8 @@ Active design system exception: the active design system is the visual direction
 - When a downstream framework mentions "active direction" or "theme tokens", bind those fields from the active design system instead of the built-in direction library.
 `;
 
+const DEFAULT_DESIGN_SYSTEM_USAGE = `Read DESIGN.md for visual principles, paste tokens.css verbatim into the first <style> when it is provided, and match component shapes from the reference component manifest or fixture when available. Treat any pull-layer index as optional context for deeper inspection; do not assume those files have already been loaded.`;
+
 export interface ComposeInput {
   agentId?: string | null | undefined;
   includeCodexImagegenOverride?: boolean | undefined;
@@ -182,6 +184,8 @@ export interface ComposeInput {
   // prose still sets the high-level voice and the structured form
   // disambiguates token names + worked component shapes.
   //
+  // - `designSystemUsageMd`      — optional USAGE.md router that tells
+  //                                agents how to consume this package.
   // - `designSystemTokensCss`    — verbatim `tokens.css` :root contract
   //                                that the agent pastes into the
   //                                artifact's <style>.
@@ -190,9 +194,14 @@ export interface ComposeInput {
   // - `designSystemFixtureHtml`        — verbatim `components.html`
   //                                      fallback when no manifest can
   //                                      be derived.
+  // - `designSystemPullIndex`          — lightweight manifest-derived
+  //                                      list of richer files available
+  //                                      for later pull-channel work.
+  designSystemUsageMd?: string | undefined;
   designSystemTokensCss?: string | undefined;
   designSystemComponentsManifest?: string | undefined;
   designSystemFixtureHtml?: string | undefined;
+  designSystemPullIndex?: string | undefined;
   // Craft references the active skill opted into via `od.craft.requires`.
   // The daemon resolves the slug list to file contents and concatenates
   // them with section headers; we inject them between the DESIGN.md and
@@ -273,9 +282,11 @@ export function composeSystemPrompt({
   skillMode,
   designSystemBody,
   designSystemTitle,
+  designSystemUsageMd,
   designSystemTokensCss,
   designSystemComponentsManifest,
   designSystemFixtureHtml,
+  designSystemPullIndex,
   craftBody,
   craftSections,
   memoryBody,
@@ -343,6 +354,14 @@ export function composeSystemPrompt({
   }
 
   if (activeDesignSystemBody && activeDesignSystemBody.length > 0) {
+    const usageBlock =
+      designSystemUsageMd && designSystemUsageMd.trim().length > 0
+        ? designSystemUsageMd.trim()
+        : DEFAULT_DESIGN_SYSTEM_USAGE;
+    parts.push(
+      `\n\n## How to use this design system${designSystemTitle ? ` — ${designSystemTitle}` : ''}\n\n${usageBlock}`,
+    );
+
     parts.push(
       `\n\n## Active design system${designSystemTitle ? ` — ${designSystemTitle}` : ''}\n\nTreat the following DESIGN.md as authoritative for color, typography, spacing, and component rules. Do not invent tokens outside this palette. When you copy the active skill's seed template, bind these tokens into its \`:root\` block before generating any layout.\n\n${activeDesignSystemBody}`,
     );
@@ -371,6 +390,12 @@ export function composeSystemPrompt({
   } else if (designSystemFixtureHtml && designSystemFixtureHtml.trim().length > 0) {
     parts.push(
       `\n\n## Reference fixture${designSystemTitle ? ` — ${designSystemTitle}` : ''}\n\nA self-contained worked artifact in this design system. Match its component shapes (button structure, card structure, type-scale rhythm, focus ring, spacing cadence) when generating new artifacts. Copying fragments is encouraged as long as you keep the \`var(--*)\` references intact — they are already wired to the tokens above.\n\n\`\`\`html\n${designSystemFixtureHtml.trim()}\n\`\`\``,
+    );
+  }
+
+  if (designSystemPullIndex && designSystemPullIndex.trim().length > 0) {
+    parts.push(
+      `\n\n## Pull-layer files available on demand${designSystemTitle ? ` — ${designSystemTitle}` : ''}\n\nThis design-system package declares richer files for inspection, source evidence, or human preview. Keep the push prompt light: use the index below to decide what to read later if the host exposes a design-system file-reading tool.\n\n\`\`\`text\n${designSystemPullIndex.trim()}\n\`\`\``,
     );
   }
 

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -8088,9 +8088,11 @@ export async function startServer({
     // including the structured ones. Any other value (unset, `1`,
     // `true`, etc.) keeps the new default. Drift on prose-only brands
     // is pinned by `scripts/check-design-system-flag-parity.ts`.
+    let designSystemUsageMd;
     let designSystemTokensCss;
     let designSystemComponentsManifest;
     let designSystemFixtureHtml;
+    let designSystemPullIndex;
     if (effectiveDesignSystemId) {
       let systems = await listAllDesignSystems();
       let summary = systems.find((s) => s.id === effectiveDesignSystemId);
@@ -8116,9 +8118,11 @@ export async function startServer({
           DESIGN_SYSTEMS_DIR,
           USER_DESIGN_SYSTEMS_DIR,
         );
+        designSystemUsageMd = assets.usageMd;
         designSystemTokensCss = assets.tokensCss;
         designSystemComponentsManifest = assets.componentsManifest;
         designSystemFixtureHtml = assets.fixtureHtml;
+        designSystemPullIndex = assets.pullIndex;
       }
     }
 
@@ -8273,9 +8277,11 @@ export async function startServer({
       skillMode,
       designSystemBody,
       designSystemTitle,
+      designSystemUsageMd,
       designSystemTokensCss,
       designSystemComponentsManifest,
       designSystemFixtureHtml,
+      designSystemPullIndex,
       craftBody,
       craftSections,
       memoryBody,

--- a/apps/daemon/tests/design-system-assets.test.ts
+++ b/apps/daemon/tests/design-system-assets.test.ts
@@ -235,6 +235,91 @@ describe('Design System Project manifest runtime consumption', () => {
     expect(assets.tokensCss).toBe(':root { --accent: #2F6FEB; }');
     expect(assets.fixtureHtml).toBeUndefined();
   });
+
+  it('reads USAGE.md, committed component cache, and manifest pull index without loading rich files', async () => {
+    const root = fresh();
+    const dir = writeDesignSystemProject(root, 'hybrid-project', {
+      manifest: {
+        schemaVersion: 'od-design-system-project/v1',
+        id: 'hybrid-project',
+        name: 'Hybrid Project',
+        category: 'Imported',
+        source: { type: 'local', path: '/tmp/project' },
+        files: {
+          design: 'DESIGN.md',
+          tokens: 'tokens.css',
+          components: 'components.html',
+        },
+        usage: 'USAGE.md',
+        componentsManifest: 'components.manifest.json',
+        assetsDir: 'assets',
+        fonts: [{ family: 'Inter', weight: 500, file: 'fonts/Inter-Medium.woff2' }],
+        preview: {
+          dir: 'preview',
+          pages: [
+            { path: 'preview/colors.html', role: 'colors', title: 'Colors' },
+            { path: 'preview/app.html', role: 'app', title: 'App Preview' },
+          ],
+        },
+        sourceFiles: {
+          scanned: 'source/scanned-files.json',
+          evidence: 'source/evidence.md',
+          tokens: 'source/tokens.source.json',
+          snippets: 'source/snippets/INDEX.json',
+        },
+      },
+      tokens: ':root { --accent: #00aa55; }',
+      components: '<button class="btn">Derived should lose to cache</button>',
+    });
+    writeFileSync(path.join(dir, 'USAGE.md'), '## Read Order\n\nUse cache first.');
+    writeFileSync(
+      path.join(dir, 'components.manifest.json'),
+      `${JSON.stringify({
+        schemaVersion: 1,
+        brandId: 'cache-brand',
+        source: { componentsHtml: 'components.html', tokensCss: 'tokens.css' },
+        fixture: {
+          styleBlockCount: 1,
+          selectorCount: 3,
+          classCount: 2,
+          elementCount: 1,
+        },
+        tokens: {
+          declared: ['--accent'],
+          referenced: ['--accent'],
+          unusedDeclared: [],
+          undeclaredReferenced: [],
+        },
+        selectors: ['.cached-button'],
+        classes: ['cached-button'],
+        elements: ['button'],
+        groups: [
+          {
+            id: 'buttons',
+            label: 'Cached buttons',
+            present: true,
+            selectors: ['.cached-button'],
+            classes: ['cached-button'],
+            elements: ['button'],
+            tokenReferences: ['--accent'],
+          },
+        ],
+        literals: {
+          colorExpressions: 0,
+          pixelValues: 0,
+          hardcodedFontFamilies: 0,
+        },
+      }, null, 2)}\n`,
+    );
+
+    const assets = await readDesignSystemAssets(root, 'hybrid-project');
+    expect(assets.usageMd).toContain('Use cache first');
+    expect(assets.componentsManifest).toContain('components.manifest schema v1 for cache-brand');
+    expect(assets.componentsManifest).toContain('Cached buttons');
+    expect(assets.pullIndex).toContain('preview/colors.html: Colors; colors');
+    expect(assets.pullIndex).toContain('fonts/Inter-Medium.woff2: font: Inter 500');
+    expect(assets.pullIndex).toContain('source/snippets/INDEX.json: source snippet index');
+  });
 });
 
 // Reviewer feedback (nettee, PR-D #1544): the parity guard at

--- a/apps/daemon/tests/prompts/system.test.ts
+++ b/apps/daemon/tests/prompts/system.test.ts
@@ -325,6 +325,31 @@ describe('composeSystemPrompt', () => {
       expect(prompt).toContain('class="btn btn-primary"');
     });
 
+    it('places USAGE.md before DESIGN.md so it acts as the package router', () => {
+      const prompt = composeSystemPrompt({
+        designSystemTitle: 'default',
+        designSystemBody: 'PROSE_BODY_MARKER',
+        designSystemUsageMd: 'Read Order: inspect the manifest cache before source evidence.',
+      });
+
+      const usageAt = prompt.indexOf('## How to use this design system — default');
+      const proseAt = prompt.indexOf('## Active design system — default');
+      expect(usageAt).toBeGreaterThan(0);
+      expect(proseAt).toBeGreaterThan(usageAt);
+      expect(prompt).toContain('Read Order: inspect the manifest cache before source evidence.');
+    });
+
+    it('injects a small default usage router for legacy brands with no USAGE.md', () => {
+      const prompt = composeSystemPrompt({
+        designSystemTitle: 'legacy',
+        designSystemBody: '# Legacy\n\nProse description.',
+      });
+
+      expect(prompt).toContain('## How to use this design system — legacy');
+      expect(prompt).toContain('Read DESIGN.md for visual principles');
+      expect(prompt).toContain('do not assume those files have already been loaded');
+    });
+
     it('prefers the component manifest over the full fixture when both are present', () => {
       const prompt = composeSystemPrompt({
         designSystemTitle: 'default',
@@ -384,6 +409,20 @@ describe('composeSystemPrompt', () => {
       });
       expect(manifestOnly).not.toContain('## Active design system tokens');
       expect(manifestOnly).toContain('## Reference component manifest — default');
+    });
+
+    it('adds the pull-layer index without loading pull-layer file contents', () => {
+      const prompt = composeSystemPrompt({
+        designSystemTitle: 'default',
+        designSystemBody: '# x\n\nbody',
+        designSystemPullIndex:
+          'Additional design-system files declared by manifest.json:\n- preview/colors.html: Colors; colors\n- source/evidence.md: import evidence notes',
+      });
+
+      expect(prompt).toContain('## Pull-layer files available on demand — default');
+      expect(prompt).toContain('preview/colors.html: Colors; colors');
+      expect(prompt).toContain('source/evidence.md: import evidence notes');
+      expect(prompt).toContain('Keep the push prompt light');
     });
 
     it('places the tokens + component manifest blocks AFTER the DESIGN.md prose block (prose sets voice, structured form binds names)', () => {


### PR DESCRIPTION
## Why

This is PR2 in the design-system import-structure stack. PR0 taught the repo the manifest fields, and PR1 made local/GitHub importers write the hybrid package. This PR connects daemon prompt assembly to that structure so imported brands can explain how to consume themselves without pushing all preview/source evidence into every run.

The pain being addressed is the missing middle layer between files on disk and agent behavior: without USAGE.md and an indexed cache, the daemon can only inject DESIGN.md, tokens, and a derived fixture summary, so richer imported evidence remains invisible unless future tooling guesses where to look.

## What users will see

When a project uses a design system with USAGE.md, the agent receives that usage router before DESIGN.md. When components.manifest.json exists, the daemon uses that committed cache summary instead of deriving the summary every run. Imported design systems can also expose a lightweight manifest-derived pull index in the prompt; the actual rich files stay out of the push prompt.

Legacy design systems continue to work: missing USAGE.md gets a small default usage note, missing cache falls back to runtime derivation from components.html, and missing pull-layer metadata injects nothing.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A, daemon prompt assembly only.

## Bug fix verification

N/A, not a bug fix.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/design-system-assets.test.ts tests/prompts/system.test.ts` from `apps/daemon`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`

Note: validation emits the existing engine warning because this machine is on Node v25.2.1 while the repo expects Node ~24.