### PR TITLE
Add design-system pull-file tool

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -4,6 +4,7 @@ import { runDaemonCliStartup } from './daemon-startup.js';
 import { runLiveArtifactsMcpServer } from './mcp-live-artifacts-server.js';
 import { runArtifactsCli } from './artifacts-cli.js';
 import { runConnectorsToolCli } from './tools-connectors-cli.js';
+import { runDesignSystemsToolCli } from './tools-design-systems-cli.js';
 import { runLiveArtifactsToolCli } from './tools-live-artifacts-cli.js';
 import { splitResearchSubcommand } from './research/cli-args.js';
 import { resolveDaemonUrl } from './daemon-url.js';
@@ -232,6 +233,16 @@ if (argv[0] === 'tools' && argv[1] === 'live-artifacts') {
       process.stderr.write(`${JSON.stringify({ ok: false, error: { message } })}\n`);
       process.exitCode = 1;
     });
+} else if (argv[0] === 'tools' && argv[1] === 'design-systems') {
+  runDesignSystemsToolCli(argv.slice(2))
+    .then(({ exitCode }) => {
+      process.exitCode = exitCode;
+    })
+    .catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`${JSON.stringify({ ok: false, error: { message } })}\n`);
+      process.exitCode = 1;
+    });
 } else {
   await runDaemonCliStartup(argv, { printHelp: printRootHelp });
 }
@@ -249,6 +260,9 @@ function printRootHelp() {
 
   od tools connectors <list|execute|github-design-context> [options]
       Discover and execute configured connectors.
+
+  od tools design-systems read --path <manifest-declared-path>
+      Read active design-system pull-layer files through daemon wrapper commands.
 
   od mcp live-artifacts
       Start the MCP server exposing live-artifact and connector tools.

--- a/apps/daemon/src/design-system-tool-routes.ts
+++ b/apps/daemon/src/design-system-tool-routes.ts
@@ -1,0 +1,104 @@
+import type { Express, Request, Response } from 'express';
+
+import type { ToolTokenGrant } from './tool-tokens.js';
+import { readDesignSystemPullFile } from './design-systems.js';
+
+type ProjectRecord = {
+  id: string;
+  designSystemId?: string | null;
+};
+
+type SendApiError = (
+  res: Response,
+  status: number,
+  code: string,
+  message: string,
+  extras?: Record<string, unknown>,
+) => void;
+
+export type RegisterDesignSystemToolRoutesDeps = {
+  auth: {
+    authorizeToolRequest: (req: Request, res: Response, operation: string) => ToolTokenGrant | null;
+  };
+  http: {
+    sendApiError: SendApiError;
+  };
+  paths: {
+    DESIGN_SYSTEMS_DIR: string;
+    USER_DESIGN_SYSTEMS_DIR: string;
+  };
+  projects: {
+    getProject: (id: string) => ProjectRecord | null | undefined;
+  };
+};
+
+export function registerDesignSystemToolRoutes(
+  app: Express,
+  ctx: RegisterDesignSystemToolRoutesDeps,
+): void {
+  const { authorizeToolRequest } = ctx.auth;
+  const { sendApiError } = ctx.http;
+
+  app.post('/api/tools/design-systems/read', async (req, res) => {
+    try {
+      const grant = authorizeToolRequest(req, res, 'design-systems:read');
+      if (!grant) return;
+
+      const project = ctx.projects.getProject(grant.projectId);
+      const activeDesignSystemId = project?.designSystemId;
+      if (!activeDesignSystemId) {
+        return sendApiError(res, 404, 'DESIGN_SYSTEM_NOT_FOUND', 'project has no active design system');
+      }
+
+      const requestedDesignSystemId = typeof req.body?.designSystemId === 'string'
+        ? req.body.designSystemId
+        : undefined;
+      if (requestedDesignSystemId !== undefined && requestedDesignSystemId !== activeDesignSystemId) {
+        return sendApiError(res, 403, 'DESIGN_SYSTEM_DENIED', 'designSystemId is derived from the tool token project', {
+          details: { requestedDesignSystemId, activeDesignSystemId },
+        });
+      }
+
+      const requestedPath = typeof req.body?.path === 'string' ? req.body.path : '';
+      if (!requestedPath) {
+        return sendApiError(res, 400, 'INVALID_INPUT', 'path is required');
+      }
+
+      const file = await readActiveDesignSystemPullFile(
+        ctx.paths.DESIGN_SYSTEMS_DIR,
+        ctx.paths.USER_DESIGN_SYSTEMS_DIR,
+        activeDesignSystemId,
+        requestedPath,
+      );
+      if (!file) {
+        return sendApiError(
+          res,
+          404,
+          'DESIGN_SYSTEM_FILE_NOT_FOUND',
+          'design system file was not found or is not declared in manifest.json',
+          { details: { path: requestedPath } },
+        );
+      }
+
+      res.json({ file });
+    } catch (error) {
+      sendApiError(res, 500, 'INTERNAL_ERROR', error instanceof Error ? error.message : String(error));
+    }
+  });
+}
+
+async function readActiveDesignSystemPullFile(
+  builtInRoot: string,
+  userRoot: string,
+  designSystemId: string,
+  relativePath: string,
+) {
+  if (designSystemId.startsWith('user:')) {
+    return readDesignSystemPullFile(userRoot, designSystemId, relativePath);
+  }
+
+  return (
+    (await readDesignSystemPullFile(builtInRoot, designSystemId, relativePath))
+    ?? (await readDesignSystemPullFile(userRoot, designSystemId, relativePath))
+  );
+}

--- a/apps/daemon/src/design-systems.ts
+++ b/apps/daemon/src/design-systems.ts
@@ -66,6 +66,16 @@ export type DesignSystemFileDetail = DesignSystemFileSummary & {
   content: string;
 };
 
+export type DesignSystemPullFileDetail = {
+  path: string;
+  name: string;
+  kind: DesignSystemFileKind;
+  size: number;
+  updatedAt: string;
+  encoding: 'utf8' | 'base64';
+  content: string;
+};
+
 export type DesignSystemRevision = {
   id: string;
   designSystemId: string;
@@ -375,6 +385,48 @@ export async function readDesignSystemAssets(
   });
 }
 
+export async function readDesignSystemPullFile(
+  root: string,
+  id: string,
+  relativePath: string,
+): Promise<DesignSystemPullFileDetail | null> {
+  const dirId = stripPrefixAndValidateId(id, id.startsWith('user:') ? 'user:' : '');
+  const cleanPath = sanitizeRelativeFilePath(relativePath);
+  if (!dirId || !cleanPath) return null;
+
+  const brandRoot = path.join(root, dirId);
+  const manifest = await readProjectManifest(brandRoot, dirId);
+  if (manifest === null) return null;
+
+  const allowed = await buildDesignSystemPullFileAllowlist(brandRoot, manifest);
+  if (!allowed.has(cleanPath)) return null;
+
+  const resolvedRoot = path.resolve(brandRoot);
+  const filePath = path.resolve(brandRoot, cleanPath);
+  if (filePath !== resolvedRoot && !filePath.startsWith(`${resolvedRoot}${path.sep}`)) {
+    return null;
+  }
+
+  try {
+    const stats = await stat(filePath);
+    if (!stats.isFile()) return null;
+    const bytes = await readFile(filePath);
+    const encoding = isTextDesignSystemPullFile(cleanPath) ? 'utf8' : 'base64';
+    return {
+      path: cleanPath,
+      name: path.basename(cleanPath),
+      kind: classifyDesignSystemFile(cleanPath, false),
+      size: stats.size,
+      updatedAt: stats.mtime.toISOString(),
+      encoding,
+      content: encoding === 'utf8' ? bytes.toString('utf8') : bytes.toString('base64'),
+    };
+  } catch (err) {
+    if (isAbsenceError(err)) return null;
+    throw err;
+  }
+}
+
 export function isDesignTokenChannelEnabled(
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
@@ -492,6 +544,109 @@ function buildDesignSystemPullIndex(
 
   if (entries.length === 0) return undefined;
   return ['Additional design-system files declared by manifest.json:', ...entries].join('\n');
+}
+
+async function buildDesignSystemPullFileAllowlist(
+  brandRoot: string,
+  manifest: DesignSystemProjectManifest,
+): Promise<Set<string>> {
+  const allowed = new Set<string>();
+  const add = (filePath: string | undefined): void => {
+    const cleanPath = typeof filePath === 'string' ? sanitizeRelativeFilePath(filePath) : null;
+    if (cleanPath) allowed.add(cleanPath);
+  };
+
+  for (const page of manifest.preview?.pages ?? []) add(page.path);
+  add(manifest.sourceFiles?.scanned);
+  add(manifest.sourceFiles?.evidence);
+  add(manifest.sourceFiles?.tokens);
+  add(manifest.sourceFiles?.snippets);
+
+  if (manifest.assetsDir === 'assets') {
+    await addFilesUnderDeclaredDir(brandRoot, 'assets', allowed);
+  }
+
+  if (manifest.sourceFiles?.snippets) {
+    await addSnippetIndexEntries(brandRoot, manifest.sourceFiles.snippets, allowed);
+  }
+
+  return allowed;
+}
+
+async function addFilesUnderDeclaredDir(
+  brandRoot: string,
+  dir: string,
+  allowed: Set<string>,
+): Promise<void> {
+  if (!isSafeManifestPath(dir)) return;
+  const absoluteDir = path.join(brandRoot, dir);
+  let entries;
+  try {
+    entries = await readdir(absoluteDir, { withFileTypes: true });
+  } catch (err) {
+    if (isAbsenceError(err)) return;
+    throw err;
+  }
+  await Promise.all(entries.map(async (entry) => {
+    const relativePath = `${dir}/${entry.name}`;
+    if (!isSafeManifestPath(relativePath)) return;
+    if (entry.isDirectory()) {
+      await addFilesUnderDeclaredDir(brandRoot, relativePath, allowed);
+    } else if (entry.isFile()) {
+      allowed.add(relativePath);
+    }
+  }));
+}
+
+async function addSnippetIndexEntries(
+  brandRoot: string,
+  indexPath: string,
+  allowed: Set<string>,
+): Promise<void> {
+  if (!isSafeManifestPath(indexPath)) return;
+  let raw: string | undefined;
+  try {
+    raw = await readFileOptional(path.join(brandRoot, indexPath));
+  } catch {
+    return;
+  }
+  if (raw === undefined) return;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return;
+    const snippets = (parsed as { snippets?: unknown }).snippets;
+    if (!Array.isArray(snippets)) return;
+    for (const snippet of snippets) {
+      if (!snippet || typeof snippet !== 'object' || Array.isArray(snippet)) continue;
+      const snippetPath = (snippet as { path?: unknown }).path;
+      if (typeof snippetPath === 'string') {
+        const cleanPath = sanitizeRelativeFilePath(snippetPath);
+        if (cleanPath?.startsWith('source/snippets/')) allowed.add(cleanPath);
+      }
+    }
+  } catch {
+    // A malformed snippets index should not widen the allowlist.
+  }
+}
+
+function isTextDesignSystemPullFile(relativePath: string): boolean {
+  const ext = path.extname(relativePath).toLowerCase();
+  return new Set([
+    '.css',
+    '.html',
+    '.js',
+    '.jsx',
+    '.json',
+    '.md',
+    '.mjs',
+    '.svg',
+    '.ts',
+    '.tsx',
+    '.txt',
+    '.xml',
+    '.yaml',
+    '.yml',
+  ]).has(ext);
 }
 
 export async function createUserDesignSystem(

--- a/apps/daemon/src/prompts/system.ts
+++ b/apps/daemon/src/prompts/system.ts
@@ -395,7 +395,7 @@ export function composeSystemPrompt({
 
   if (designSystemPullIndex && designSystemPullIndex.trim().length > 0) {
     parts.push(
-      `\n\n## Pull-layer files available on demand${designSystemTitle ? ` — ${designSystemTitle}` : ''}\n\nThis design-system package declares richer files for inspection, source evidence, or human preview. Keep the push prompt light: use the index below to decide what to read later if the host exposes a design-system file-reading tool.\n\n\`\`\`text\n${designSystemPullIndex.trim()}\n\`\`\``,
+      `\n\n## Pull-layer files available on demand${designSystemTitle ? ` — ${designSystemTitle}` : ''}\n\nThis design-system package declares richer files for inspection, source evidence, or human preview. Keep the push prompt light: use the index below to decide what to read later. When the runtime tool environment is available, read a listed path with \`\"$OD_NODE_BIN\" \"$OD_BIN\" tools design-systems read --path <path>\`; the daemon will reject paths outside this manifest allowlist.\n\n\`\`\`text\n${designSystemPullIndex.trim()}\n\`\`\``,
     );
   }
 

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -331,6 +331,7 @@ import { registerActiveContextRoutes } from './active-context-routes.js';
 import { registerMcpRoutes } from './mcp-routes.js';
 import { registerXaiRoutes } from './xai-routes.js';
 import { registerLiveArtifactRoutes } from './live-artifact-routes.js';
+import { registerDesignSystemToolRoutes } from './design-system-tool-routes.js';
 import { registerDeployRoutes, registerDeploymentCheckRoutes } from './deploy-routes.js';
 import { registerMediaRoutes } from './media-routes.js';
 import { registerProjectRoutes, registerProjectArtifactRoutes, registerProjectFileRoutes, registerProjectUploadRoutes } from './project-routes.js';
@@ -3923,6 +3924,12 @@ export async function startServer({
     auth: authDeps,
     liveArtifacts: liveArtifactDeps,
     projectStore: projectStoreDeps,
+  });
+  registerDesignSystemToolRoutes(app, {
+    auth: authDeps,
+    http: httpDeps,
+    paths: pathDeps,
+    projects: { getProject },
   });
   app.use('/artifacts', express.static(ARTIFACTS_DIR));
   registerDeployRoutes(app, {

--- a/apps/daemon/src/tool-tokens.ts
+++ b/apps/daemon/src/tool-tokens.ts
@@ -9,6 +9,7 @@ export const CHAT_TOOL_ENDPOINTS = [
   '/api/tools/live-artifacts/update',
   '/api/tools/connectors/list',
   '/api/tools/connectors/execute',
+  '/api/tools/design-systems/read',
 ] as const;
 
 export const CHAT_TOOL_OPERATIONS = [
@@ -18,6 +19,7 @@ export const CHAT_TOOL_OPERATIONS = [
   'live-artifacts:update',
   'connectors:list',
   'connectors:execute',
+  'design-systems:read',
 ] as const;
 
 export type ToolEndpoint = (typeof CHAT_TOOL_ENDPOINTS)[number] | (string & {});

--- a/apps/daemon/src/tools-design-systems-cli.ts
+++ b/apps/daemon/src/tools-design-systems-cli.ts
@@ -1,0 +1,160 @@
+type JsonObject = Record<string, unknown>;
+
+interface ToolCliResult {
+  exitCode: number;
+}
+
+interface ParsedOptions {
+  command: string | undefined;
+  path?: string;
+  designSystemId?: string;
+  help: boolean;
+}
+
+const DESIGN_SYSTEMS_USAGE = `Usage:
+  od tools design-systems read --path <manifest-declared-path> [--design-system <id>]
+
+Environment:
+  OD_NODE_BIN     Node-compatible runtime for agent wrapper invocations
+  OD_BIN          Open Design CLI script for agent wrapper invocations
+  OD_DAEMON_URL   Daemon base URL injected into agent runs
+  OD_TOOL_TOKEN   Bearer token injected into agent runs
+
+Agent runtime invocation:
+  "$OD_NODE_BIN" "$OD_BIN" tools design-systems read --path preview/colors.html
+`;
+
+function writeJson(value: unknown, stream: NodeJS.WriteStream = process.stdout): void {
+  stream.write(`${JSON.stringify(value)}\n`);
+}
+
+function fail(message: string, details?: unknown): ToolCliResult {
+  writeJson({ ok: false, error: { message, ...(details === undefined ? {} : { details }) } }, process.stderr);
+  return { exitCode: 1 };
+}
+
+function parseOptions(args: string[]): ParsedOptions | { error: string } {
+  const [command, ...rest] = args;
+  const options: ParsedOptions = {
+    command: command === '-h' || command === '--help' ? undefined : command,
+    help: command === '-h' || command === '--help',
+  };
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index];
+    if (arg === '--path') {
+      const value = rest[++index];
+      if (!value) return { error: '--path requires a relative file path' };
+      options.path = value;
+    } else if (arg === '--design-system') {
+      const value = rest[++index];
+      if (!value) return { error: '--design-system requires an id' };
+      options.designSystemId = value;
+    } else if (arg === '-h' || arg === '--help') {
+      options.help = true;
+    } else {
+      return { error: `unknown option: ${arg}` };
+    }
+  }
+
+  return options;
+}
+
+function daemonUrl(): URL | { error: string } {
+  const rawUrl = process.env.OD_DAEMON_URL;
+  if (!rawUrl) return { error: 'OD_DAEMON_URL is required' };
+  try {
+    const url = new URL(rawUrl);
+    url.pathname = url.pathname.replace(/\/+$/u, '');
+    url.search = '';
+    url.hash = '';
+    return url;
+  } catch {
+    return { error: 'OD_DAEMON_URL must be a valid URL' };
+  }
+}
+
+function toolToken(): string | { error: string } {
+  const token = process.env.OD_TOOL_TOKEN;
+  if (!token) return { error: 'OD_TOOL_TOKEN is required' };
+  return token;
+}
+
+function endpoint(baseUrl: URL, pathname: string): string {
+  const url = new URL(baseUrl.toString());
+  url.pathname = `${url.pathname}${pathname}`.replace(/\/+/gu, '/');
+  return url.toString();
+}
+
+async function requestJson(baseUrl: URL, token: string, pathname: string, init: RequestInit = {}): Promise<{ status: number; body: unknown }> {
+  const response = await fetch(endpoint(baseUrl, pathname), {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/json',
+      ...(init.body === undefined ? {} : { 'Content-Type': 'application/json' }),
+      ...init.headers,
+    },
+  });
+  const text = await response.text();
+  let body: unknown = text;
+  if (text.length > 0) {
+    try {
+      body = JSON.parse(text) as unknown;
+    } catch {
+      body = { message: text };
+    }
+  }
+  return { status: response.status, body };
+}
+
+function normalizeCliError(body: unknown): JsonObject {
+  const rawError = body && typeof body === 'object' && 'error' in body ? (body as JsonObject).error : body;
+  if (typeof rawError === 'string') return { message: rawError };
+  if (!rawError || typeof rawError !== 'object') return { message: String(rawError ?? 'request failed') };
+  const error = rawError as JsonObject;
+  return {
+    ...(typeof error.code === 'string' ? { code: error.code } : {}),
+    message: typeof error.message === 'string' ? error.message : String(error.error ?? 'request failed'),
+    ...(error.details === undefined ? {} : { details: error.details }),
+  };
+}
+
+async function printApiResult(response: { status: number; body: unknown }): Promise<ToolCliResult> {
+  if (response.status < 200 || response.status >= 300) {
+    writeJson({ ok: false, status: response.status, error: normalizeCliError(response.body) }, process.stderr);
+    return { exitCode: 1 };
+  }
+  const body = response.body && typeof response.body === 'object' && !Array.isArray(response.body)
+    ? response.body as JsonObject
+    : { result: response.body };
+  writeJson({ ok: true, ...body });
+  return { exitCode: 0 };
+}
+
+export async function runDesignSystemsToolCli(args: string[]): Promise<ToolCliResult> {
+  const options = parseOptions(args);
+  if ('error' in options) return fail(options.error);
+  if (options.help || !options.command) {
+    process.stdout.write(DESIGN_SYSTEMS_USAGE);
+    return { exitCode: options.command ? 0 : 1 };
+  }
+
+  const baseUrl = daemonUrl();
+  if ('error' in baseUrl) return fail(baseUrl.error);
+  const token = toolToken();
+  if (typeof token !== 'string') return fail(token.error);
+
+  if (options.command !== 'read') return fail(`unknown design-systems command: ${options.command}`);
+  if (!options.path) return fail('read requires --path <manifest-declared-path>');
+
+  return printApiResult(
+    await requestJson(baseUrl, token, '/api/tools/design-systems/read', {
+      method: 'POST',
+      body: JSON.stringify({
+        path: options.path,
+        ...(options.designSystemId ? { designSystemId: options.designSystemId } : {}),
+      }),
+    }),
+  );
+}

--- a/apps/daemon/tests/design-system-assets.test.ts
+++ b/apps/daemon/tests/design-system-assets.test.ts
@@ -19,6 +19,7 @@ import {
   listDesignSystems,
   readDesignSystem,
   readDesignSystemAssets,
+  readDesignSystemPullFile,
   resolveDesignSystemAssets,
 } from '../src/design-systems.js';
 
@@ -319,6 +320,59 @@ describe('Design System Project manifest runtime consumption', () => {
     expect(assets.pullIndex).toContain('preview/colors.html: Colors; colors');
     expect(assets.pullIndex).toContain('fonts/Inter-Medium.woff2: font: Inter 500');
     expect(assets.pullIndex).toContain('source/snippets/INDEX.json: source snippet index');
+  });
+
+  it('allows pull reads only for manifest-declared rich-layer files', async () => {
+    const root = fresh();
+    const dir = writeDesignSystemProject(root, 'pull-project', {
+      manifest: {
+        schemaVersion: 'od-design-system-project/v1',
+        id: 'pull-project',
+        name: 'Pull Project',
+        category: 'Imported',
+        source: { type: 'local', path: '/tmp/project' },
+        files: {
+          design: 'DESIGN.md',
+          tokens: 'tokens.css',
+          components: 'components.html',
+        },
+        assetsDir: 'assets',
+        preview: {
+          dir: 'preview',
+          pages: [{ path: 'preview/colors.html', role: 'colors', title: 'Colors' }],
+        },
+        sourceFiles: {
+          snippets: 'source/snippets/INDEX.json',
+        },
+      },
+    });
+    mkdirSync(path.join(dir, 'preview'), { recursive: true });
+    mkdirSync(path.join(dir, 'source', 'snippets'), { recursive: true });
+    mkdirSync(path.join(dir, 'assets', 'icons'), { recursive: true });
+    writeFileSync(path.join(dir, 'preview', 'colors.html'), '<h1>Colors</h1>');
+    writeFileSync(path.join(dir, 'preview', 'spacing.html'), '<h1>Spacing</h1>');
+    writeFileSync(path.join(dir, 'source', 'snippets', 'INDEX.json'), `${JSON.stringify({
+      schemaVersion: 1,
+      snippets: [{ path: 'source/snippets/Button.tsx', role: 'button' }],
+    })}\n`);
+    writeFileSync(path.join(dir, 'source', 'snippets', 'Button.tsx'), 'export function Button() {}');
+    writeFileSync(path.join(dir, 'assets', 'icons', 'mark.svg'), '<svg />');
+
+    await expect(readDesignSystemPullFile(root, 'pull-project', 'preview/colors.html')).resolves.toMatchObject({
+      path: 'preview/colors.html',
+      encoding: 'utf8',
+      content: '<h1>Colors</h1>',
+    });
+    await expect(readDesignSystemPullFile(root, 'pull-project', 'source/snippets/Button.tsx')).resolves.toMatchObject({
+      path: 'source/snippets/Button.tsx',
+      content: 'export function Button() {}',
+    });
+    await expect(readDesignSystemPullFile(root, 'pull-project', 'assets/icons/mark.svg')).resolves.toMatchObject({
+      path: 'assets/icons/mark.svg',
+      content: '<svg />',
+    });
+    await expect(readDesignSystemPullFile(root, 'pull-project', 'preview/spacing.html')).resolves.toBeNull();
+    await expect(readDesignSystemPullFile(root, 'pull-project', '../pull-project/preview/colors.html')).resolves.toBeNull();
   });
 });
 

--- a/apps/daemon/tests/design-system-tool-routes.test.ts
+++ b/apps/daemon/tests/design-system-tool-routes.test.ts
@@ -1,0 +1,158 @@
+import express from 'express';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import http from 'node:http';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { registerDesignSystemToolRoutes } from '../src/design-system-tool-routes.js';
+
+type JsonFetchResult = { status: number; body: Record<string, any> };
+
+let server: http.Server | undefined;
+
+afterEach(async () => {
+  await new Promise<void>((resolve, reject) => {
+    if (!server) return resolve();
+    server.close((error?: Error) => (error ? reject(error) : resolve()));
+  });
+  server = undefined;
+});
+
+function fresh(): string {
+  return mkdtempSync(path.join(tmpdir(), 'od-design-system-tool-routes-'));
+}
+
+function writeHybridDesignSystem(root: string, id: string): string {
+  const dir = path.join(root, id);
+  mkdirSync(path.join(dir, 'preview'), { recursive: true });
+  writeFileSync(path.join(dir, 'DESIGN.md'), '# Test\n');
+  writeFileSync(path.join(dir, 'tokens.css'), ':root { --bg: #fff; }');
+  writeFileSync(path.join(dir, 'components.html'), '<button>ok</button>');
+  writeFileSync(path.join(dir, 'preview', 'colors.html'), '<h1>Colors</h1>');
+  writeFileSync(path.join(dir, 'preview', 'spacing.html'), '<h1>Spacing</h1>');
+  writeFileSync(path.join(dir, 'manifest.json'), `${JSON.stringify({
+    schemaVersion: 'od-design-system-project/v1',
+    id,
+    name: 'Test',
+    category: 'Imported',
+    source: { type: 'local', path: '/tmp/source' },
+    files: {
+      design: 'DESIGN.md',
+      tokens: 'tokens.css',
+      components: 'components.html',
+    },
+    preview: {
+      dir: 'preview',
+      pages: [{ path: 'preview/colors.html', role: 'colors', title: 'Colors' }],
+    },
+  }, null, 2)}\n`);
+  return dir;
+}
+
+async function startRouteServer(options: {
+  builtInRoot: string;
+  userRoot: string;
+  activeDesignSystemId: string | null;
+}): Promise<string> {
+  const app = express();
+  app.use(express.json());
+  registerDesignSystemToolRoutes(app, {
+    auth: {
+      authorizeToolRequest: (_req, _res, operation) => {
+        expect(operation).toBe('design-systems:read');
+        return {
+          token: 'token',
+          runId: 'run-1',
+          projectId: 'project-1',
+          allowedEndpoints: ['/api/tools/design-systems/read'],
+          allowedOperations: ['design-systems:read'],
+          issuedAt: new Date(0).toISOString(),
+          expiresAt: new Date(60_000).toISOString(),
+        };
+      },
+    },
+    http: {
+      sendApiError: (res, status, code, message, extras = {}) => {
+        res.status(status).json({ error: { code, message, ...extras } });
+      },
+    },
+    paths: {
+      DESIGN_SYSTEMS_DIR: options.builtInRoot,
+      USER_DESIGN_SYSTEMS_DIR: options.userRoot,
+    },
+    projects: {
+      getProject: () => ({
+        id: 'project-1',
+        designSystemId: options.activeDesignSystemId,
+      }),
+    },
+  });
+
+  server = app.listen(0);
+  await new Promise<void>((resolve) => server?.once('listening', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('unexpected listen address');
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function jsonFetch(url: string, body: Record<string, unknown>): Promise<JsonFetchResult> {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer token',
+    },
+    body: JSON.stringify(body),
+  });
+  return { status: response.status, body: await response.json() as Record<string, any> };
+}
+
+describe('design-system pull tool route', () => {
+  it('reads manifest-allowed files from the active design system', async () => {
+    const builtInRoot = fresh();
+    const userRoot = fresh();
+    writeHybridDesignSystem(builtInRoot, 'pull-brand');
+    const baseUrl = await startRouteServer({
+      builtInRoot,
+      userRoot,
+      activeDesignSystemId: 'pull-brand',
+    });
+
+    const response = await jsonFetch(`${baseUrl}/api/tools/design-systems/read`, {
+      path: 'preview/colors.html',
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.file).toMatchObject({
+      path: 'preview/colors.html',
+      encoding: 'utf8',
+      content: '<h1>Colors</h1>',
+    });
+  });
+
+  it('rejects unlisted files and non-active design-system ids', async () => {
+    const builtInRoot = fresh();
+    const userRoot = fresh();
+    writeHybridDesignSystem(builtInRoot, 'pull-brand');
+    const baseUrl = await startRouteServer({
+      builtInRoot,
+      userRoot,
+      activeDesignSystemId: 'pull-brand',
+    });
+
+    const unlisted = await jsonFetch(`${baseUrl}/api/tools/design-systems/read`, {
+      path: 'preview/spacing.html',
+    });
+    expect(unlisted.status).toBe(404);
+    expect(unlisted.body.error.code).toBe('DESIGN_SYSTEM_FILE_NOT_FOUND');
+
+    const mismatch = await jsonFetch(`${baseUrl}/api/tools/design-systems/read`, {
+      designSystemId: 'other-brand',
+      path: 'preview/colors.html',
+    });
+    expect(mismatch.status).toBe(403);
+    expect(mismatch.body.error.code).toBe('DESIGN_SYSTEM_DENIED');
+  });
+});


### PR DESCRIPTION
## Why

This is PR4 in the design-system import-structure stack. PR2 made the daemon push a lightweight pull-layer index, but agents still had no sanctioned way to read those richer files. This PR adds the missing pull channel: a run-scoped design-system file reader that lets agents inspect manifest-declared preview/source/snippet/asset files only when needed.

The pain being addressed is fidelity without prompt bloat. Imported packages can preserve rich evidence and previews, while the push prompt stays small and the read path remains bounded by manifest.json rather than arbitrary filesystem access.

## What users will see

Agents can now call `\"$OD_NODE_BIN\" \"$OD_BIN\" tools design-systems read --path <path>` for paths listed in the design-system pull index. The daemon derives the active design system from the run's project, rejects non-active design-system ids, and rejects files outside the manifest allowlist.

For text files the response includes UTF-8 content; binary assets are returned as base64. Existing projects without a rich manifest are unchanged.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A, daemon tool endpoint and CLI wrapper only.

## Bug fix verification

N/A, not a bug fix.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/design-system-assets.test.ts tests/design-system-tool-routes.test.ts tests/prompts/system.test.ts tests/tool-tokens.test.ts` from `apps/daemon`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- `git diff --check`

Note: validation emits the existing engine warning because this machine is on Node v25.2.1 while the repo expects Node ~24.