### PR TITLE
Show design-system manifest and source evidence

### DIFF
--- a/apps/daemon/src/design-systems.ts
+++ b/apps/daemon/src/design-systems.ts
@@ -76,6 +76,17 @@ export type DesignSystemPullFileDetail = {
   content: string;
 };
 
+export type DesignSystemPackageInfo = {
+  manifest?: DesignSystemProjectManifest;
+  sourceEvidence?: {
+    scannedFileCount?: number;
+    tokenCount?: number;
+    snippetCount?: number;
+    confidence?: Record<string, string | number>;
+    evidenceExcerpt?: string;
+  };
+};
+
 export type DesignSystemRevision = {
   id: string;
   designSystemId: string;
@@ -330,6 +341,24 @@ export async function readDesignSystem(
   } catch {
     return null;
   }
+}
+
+export async function readDesignSystemPackageInfo(
+  root: string,
+  id: string,
+  options: { idPrefix?: string } = {},
+): Promise<DesignSystemPackageInfo | null> {
+  const dirId = stripPrefixAndValidateId(id, options.idPrefix);
+  if (!dirId) return null;
+  const brandRoot = path.join(root, dirId);
+  const manifest = await readProjectManifest(brandRoot, dirId);
+  if (manifest === null) return null;
+
+  const sourceEvidence = await readDesignSystemSourceEvidence(brandRoot, manifest);
+  return {
+    manifest,
+    ...(sourceEvidence ? { sourceEvidence } : {}),
+  };
 }
 
 /**
@@ -647,6 +676,59 @@ function isTextDesignSystemPullFile(relativePath: string): boolean {
     '.yaml',
     '.yml',
   ]).has(ext);
+}
+
+async function readDesignSystemSourceEvidence(
+  brandRoot: string,
+  manifest: DesignSystemProjectManifest,
+): Promise<DesignSystemPackageInfo['sourceEvidence'] | undefined> {
+  const [scanned, tokens, snippets, evidence] = await Promise.all([
+    readManifestJsonOptional(brandRoot, manifest.sourceFiles?.scanned),
+    readManifestJsonOptional(brandRoot, manifest.sourceFiles?.tokens),
+    readManifestJsonOptional(brandRoot, manifest.sourceFiles?.snippets),
+    readManifestFileOptional(brandRoot, manifest.sourceFiles?.evidence ?? ''),
+  ]);
+
+  const out: NonNullable<DesignSystemPackageInfo['sourceEvidence']> = {};
+  if (scanned && typeof scanned === 'object' && !Array.isArray(scanned)) {
+    const files = (scanned as { files?: unknown }).files;
+    if (Array.isArray(files)) out.scannedFileCount = files.length;
+  }
+  if (tokens && typeof tokens === 'object' && !Array.isArray(tokens)) {
+    const tokenCount = (tokens as { tokenCount?: unknown }).tokenCount;
+    if (typeof tokenCount === 'number') out.tokenCount = tokenCount;
+    const confidence = (tokens as { confidence?: unknown }).confidence;
+    if (confidence && typeof confidence === 'object' && !Array.isArray(confidence)) {
+      const cleanConfidence: Record<string, string | number> = {};
+      for (const [key, value] of Object.entries(confidence)) {
+        if (typeof value === 'string' || typeof value === 'number') cleanConfidence[key] = value;
+      }
+      if (Object.keys(cleanConfidence).length > 0) out.confidence = cleanConfidence;
+    }
+  }
+  if (snippets && typeof snippets === 'object' && !Array.isArray(snippets)) {
+    const entries = (snippets as { snippets?: unknown }).snippets;
+    if (Array.isArray(entries)) out.snippetCount = entries.length;
+  }
+  if (typeof evidence === 'string' && evidence.trim().length > 0) {
+    out.evidenceExcerpt = evidence.trim().split(/\r?\n/).filter(Boolean).slice(0, 5).join('\n');
+  }
+
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+async function readManifestJsonOptional(
+  brandRoot: string,
+  relativePath: string | undefined,
+): Promise<unknown | undefined> {
+  if (!relativePath) return undefined;
+  const raw = await readManifestFileOptional(brandRoot, relativePath);
+  if (raw === undefined) return undefined;
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return undefined;
+  }
 }
 
 export async function createUserDesignSystem(

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -71,6 +71,7 @@ import {
   listUserDesignSystemFiles,
   listUserDesignSystemRevisions,
   readDesignSystem,
+  readDesignSystemPackageInfo,
   readUserDesignSystemFile,
   resolveDesignSystemAssets,
   updateUserDesignSystem,
@@ -2637,6 +2638,16 @@ export async function startServer({
     );
   }
 
+  async function readAvailableDesignSystemPackageInfo(id) {
+    if (typeof id === 'string' && id.startsWith('user:')) {
+      return readDesignSystemPackageInfo(USER_DESIGN_SYSTEMS_DIR, id, { idPrefix: 'user:' });
+    }
+    return (
+      (await readDesignSystemPackageInfo(DESIGN_SYSTEMS_DIR, id))
+      ?? (await readDesignSystemPackageInfo(USER_DESIGN_SYSTEMS_DIR, id))
+    );
+  }
+
   function isProjectUsableDesignSystem(summary) {
     return summary?.status !== 'draft';
   }
@@ -4501,7 +4512,8 @@ export async function startServer({
       const body = projectBody ?? await readAvailableDesignSystem(req.params.id);
       if (body === null || !summary)
         return res.status(404).json({ error: 'design system not found' });
-      const detail = { ...summary, body };
+      const packageInfo = await readAvailableDesignSystemPackageInfo(req.params.id);
+      const detail = { ...summary, body, ...(packageInfo ? { packageInfo } : {}) };
       res.json({ ...detail, designSystem: detail });
     } catch (err) {
       res.status(500).json({ error: String(err) });

--- a/apps/daemon/tests/design-system-assets.test.ts
+++ b/apps/daemon/tests/design-system-assets.test.ts
@@ -19,6 +19,7 @@ import {
   listDesignSystems,
   readDesignSystem,
   readDesignSystemAssets,
+  readDesignSystemPackageInfo,
   readDesignSystemPullFile,
   resolveDesignSystemAssets,
 } from '../src/design-systems.js';
@@ -373,6 +374,61 @@ describe('Design System Project manifest runtime consumption', () => {
     });
     await expect(readDesignSystemPullFile(root, 'pull-project', 'preview/spacing.html')).resolves.toBeNull();
     await expect(readDesignSystemPullFile(root, 'pull-project', '../pull-project/preview/colors.html')).resolves.toBeNull();
+  });
+
+  it('summarizes manifest and source evidence for the detail page', async () => {
+    const root = fresh();
+    const dir = writeDesignSystemProject(root, 'detail-project', {
+      manifest: {
+        schemaVersion: 'od-design-system-project/v1',
+        id: 'detail-project',
+        name: 'Detail Project',
+        category: 'Imported',
+        source: { type: 'local', path: '/tmp/project' },
+        files: {
+          design: 'DESIGN.md',
+          tokens: 'tokens.css',
+          components: 'components.html',
+        },
+        usage: 'USAGE.md',
+        componentsManifest: 'components.manifest.json',
+        importMode: 'hybrid',
+        preview: {
+          dir: 'preview',
+          pages: [{ path: 'preview/colors.html', role: 'colors', title: 'Colors' }],
+        },
+        sourceFiles: {
+          scanned: 'source/scanned-files.json',
+          evidence: 'source/evidence.md',
+          tokens: 'source/tokens.source.json',
+          snippets: 'source/snippets/INDEX.json',
+        },
+      },
+    });
+    mkdirSync(path.join(dir, 'source', 'snippets'), { recursive: true });
+    writeFileSync(path.join(dir, 'source', 'scanned-files.json'), JSON.stringify({ files: [{ path: 'Button.tsx' }] }));
+    writeFileSync(path.join(dir, 'source', 'evidence.md'), '# Evidence\n\n- Buttons matched source.');
+    writeFileSync(path.join(dir, 'source', 'tokens.source.json'), JSON.stringify({
+      tokenCount: 7,
+      confidence: { color: 'high', spacing: 0.4 },
+    }));
+    writeFileSync(path.join(dir, 'source', 'snippets', 'INDEX.json'), JSON.stringify({
+      snippets: [{ path: 'source/snippets/Button.tsx' }],
+    }));
+
+    await expect(readDesignSystemPackageInfo(root, 'detail-project')).resolves.toMatchObject({
+      manifest: {
+        usage: 'USAGE.md',
+        importMode: 'hybrid',
+        preview: { pages: [{ path: 'preview/colors.html' }] },
+      },
+      sourceEvidence: {
+        scannedFileCount: 1,
+        tokenCount: 7,
+        snippetCount: 1,
+        confidence: { color: 'high', spacing: 0.4 },
+      },
+    });
   });
 });
 

--- a/apps/web/src/components/DesignSystemFlow.tsx
+++ b/apps/web/src/components/DesignSystemFlow.tsx
@@ -1351,6 +1351,7 @@ export function DesignSystemDetailView({
                 </button>
               ) : null}
             </div>
+            <DesignSystemPackageCard system={system} />
             <div className="ds-warning-card">
               <Icon name="help-circle" />
               <span>
@@ -1576,6 +1577,146 @@ function findWorkspaceActivityMessage(messages: ChatMessage[]): ChatMessage | nu
       return message;
   }
   return null;
+}
+
+function DesignSystemPackageCard({ system }: { system: DesignSystemDetail }) {
+  const info = system.packageInfo;
+  const manifest = info?.manifest;
+  const evidence = info?.sourceEvidence;
+  const sourceLabel = manifest?.source?.type ? sourceTypeLabel(manifest.source.type) : sourceTypeLabel(system.source);
+  const previewPages = manifest?.preview?.pages ?? [];
+  const sourceFiles = manifest?.sourceFiles;
+  const sourceFileCount = [sourceFiles?.scanned, sourceFiles?.evidence, sourceFiles?.tokens, sourceFiles?.snippets]
+    .filter(Boolean)
+    .length;
+  const protocolItems = [
+    manifest?.usage ? manifest.usage : null,
+    manifest?.files?.design ?? 'DESIGN.md',
+    manifest?.files?.tokens ?? 'tokens.css',
+    manifest?.files?.components,
+    manifest?.componentsManifest,
+  ].filter((item): item is string => typeof item === 'string' && item.length > 0);
+  const evidenceStats = [
+    evidence?.scannedFileCount !== undefined ? { label: 'Scanned files', value: String(evidence.scannedFileCount) } : null,
+    evidence?.tokenCount !== undefined ? { label: 'Source tokens', value: String(evidence.tokenCount) } : null,
+    evidence?.snippetCount !== undefined ? { label: 'Snippets', value: String(evidence.snippetCount) } : null,
+    manifest?.fonts?.length ? { label: 'Fonts', value: String(manifest.fonts.length) } : null,
+  ].filter((item): item is { label: string; value: string } => item !== null);
+  const confidence = evidence?.confidence ? Object.entries(evidence.confidence) : [];
+
+  return (
+    <section className="ds-package-card">
+      <div className="ds-package-card__head">
+        <span>
+          <strong>{manifest ? 'Structured import package' : 'Legacy design system'}</strong>
+          <small>
+            {manifest
+              ? `${sourceLabel} · ${manifest.importMode ?? 'normalized'} mode · manifest indexed`
+              : `${sourceLabel} · DESIGN.md-only fallback`}
+          </small>
+        </span>
+        <span className={manifest ? 'ds-package-pill is-ready' : 'ds-package-pill'}>
+          {manifest ? 'Hybrid ready' : 'Fallback'}
+        </span>
+      </div>
+
+      <div className="ds-package-grid">
+        <div>
+          <h2>Agent push layer</h2>
+          <div className="ds-package-chips">
+            {protocolItems.map((item) => (
+              <code key={item}>{item}</code>
+            ))}
+          </div>
+        </div>
+        <div>
+          <h2>Pull layer</h2>
+          <div className="ds-package-metrics">
+            <span><strong>{previewPages.length}</strong><small>Preview pages</small></span>
+            <span><strong>{sourceFileCount}</strong><small>Evidence indexes</small></span>
+            <span><strong>{manifest?.assetsDir ? 'Yes' : 'No'}</strong><small>Assets</small></span>
+          </div>
+        </div>
+      </div>
+
+      {evidenceStats.length > 0 || confidence.length > 0 ? (
+        <div className="ds-evidence-panel">
+          <div className="ds-evidence-stats">
+            {evidenceStats.map((item) => (
+              <span key={item.label}>
+                <strong>{item.value}</strong>
+                <small>{item.label}</small>
+              </span>
+            ))}
+          </div>
+          {confidence.length > 0 ? (
+            <div className="ds-confidence-row">
+              {confidence.map(([key, value]) => (
+                <span key={key}>{key}: {String(value)}</span>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {manifest ? (
+        <div className="ds-package-files">
+          <PackageFileGroup
+            title="Preview"
+            files={previewPages.map((page) => ({
+              path: page.path ?? '',
+              meta: [page.title, page.role].filter(Boolean).join(' · '),
+            }))}
+          />
+          <PackageFileGroup
+            title="Source evidence"
+            files={[
+              sourceFiles?.scanned ? { path: sourceFiles.scanned, meta: 'Scanned file inventory' } : null,
+              sourceFiles?.evidence ? { path: sourceFiles.evidence, meta: 'Evidence notes' } : null,
+              sourceFiles?.tokens ? { path: sourceFiles.tokens, meta: 'Token extraction evidence' } : null,
+              sourceFiles?.snippets ? { path: sourceFiles.snippets, meta: 'Snippet index' } : null,
+            ].filter((item): item is { path: string; meta: string } => item !== null)}
+          />
+        </div>
+      ) : null}
+      {evidence?.evidenceExcerpt ? (
+        <pre className="ds-evidence-excerpt">{evidence.evidenceExcerpt}</pre>
+      ) : null}
+    </section>
+  );
+}
+
+function PackageFileGroup({
+  title,
+  files,
+}: {
+  title: string;
+  files: Array<{ path: string; meta?: string }>;
+}) {
+  const visibleFiles = files.filter((file) => file.path.length > 0);
+  if (visibleFiles.length === 0) return null;
+  return (
+    <div>
+      <h2>{title}</h2>
+      <div className="ds-package-file-list">
+        {visibleFiles.map((file) => (
+          <span key={file.path}>
+            <code>{file.path}</code>
+            {file.meta ? <small>{file.meta}</small> : null}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function sourceTypeLabel(value: string | undefined): string {
+  if (value === 'github') return 'GitHub import';
+  if (value === 'local') return 'Local import';
+  if (value === 'bundled' || value === 'built-in') return 'Bundled';
+  if (value === 'user') return 'User workspace';
+  if (value === 'installed') return 'Installed';
+  return 'Design system';
 }
 
 function WorkspaceActivityCard({

--- a/apps/web/src/styles/design-system-flow.css
+++ b/apps/web/src/styles/design-system-flow.css
@@ -593,6 +593,7 @@
 .ds-warning-card,
 .ds-generation-review-card,
 .ds-workspace-activity-card,
+.ds-package-card,
 .ds-revision-card,
 .ds-revision-history,
 .ds-review-section,
@@ -790,6 +791,129 @@
   margin-bottom: 24px;
   border-color: color-mix(in srgb, var(--accent) 35%, var(--border));
   background: color-mix(in srgb, var(--accent) 9%, var(--bg-panel));
+}
+.ds-package-card {
+  display: grid;
+  gap: 14px;
+  padding: 16px;
+  margin-bottom: 18px;
+}
+.ds-package-card__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+}
+.ds-package-card__head > span:first-child {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+.ds-package-card__head small,
+.ds-package-card h2,
+.ds-package-file-list small,
+.ds-evidence-stats small {
+  color: var(--text-muted);
+}
+.ds-package-pill {
+  flex: 0 0 auto;
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+.ds-package-pill.is-ready {
+  border-color: color-mix(in srgb, var(--green) 36%, var(--border));
+  color: var(--green);
+}
+.ds-package-grid,
+.ds-package-files {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+.ds-package-grid > div,
+.ds-package-files > div,
+.ds-evidence-panel {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-subtle);
+}
+.ds-package-card h2 {
+  margin: 0;
+  font-size: 11px;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+.ds-package-chips,
+.ds-package-file-list,
+.ds-confidence-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.ds-package-chips code,
+.ds-package-file-list code {
+  max-width: 100%;
+  overflow: hidden;
+  padding: 4px 7px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--bg-panel);
+  color: var(--text);
+  font: 11px/1.35 var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ds-package-metrics,
+.ds-evidence-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+.ds-package-metrics span,
+.ds-evidence-stats span {
+  display: grid;
+  gap: 2px;
+}
+.ds-package-metrics strong,
+.ds-evidence-stats strong {
+  font-size: 16px;
+}
+.ds-package-metrics small,
+.ds-evidence-stats small {
+  font-size: 11px;
+}
+.ds-package-file-list span {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+.ds-confidence-row span {
+  padding: 4px 7px;
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border));
+  border-radius: 999px;
+  color: var(--text-muted);
+  font-size: 11px;
+}
+.ds-evidence-excerpt {
+  max-height: 160px;
+  overflow: auto;
+  margin: 0;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-subtle);
+  color: var(--text-muted);
+  white-space: pre-wrap;
+  font: 12px/1.45 var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
 }
 .ds-warning-card span {
   flex: 1;
@@ -1264,8 +1388,14 @@
   }
   .ds-resource-row,
   .ds-files-panel,
-  .ds-publish-card {
+  .ds-publish-card,
+  .ds-package-grid,
+  .ds-package-files {
     grid-template-columns: 1fr;
+  }
+  .ds-package-metrics,
+  .ds-evidence-stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
   .ds-github-access-methods {
     grid-template-columns: 1fr;

--- a/packages/contracts/src/api/registry.ts
+++ b/packages/contracts/src/api/registry.ts
@@ -162,6 +162,49 @@ export interface DesignSystemSummary {
 
 export interface DesignSystemDetail extends DesignSystemSummary {
   body: string;
+  packageInfo?: DesignSystemPackageInfo;
+}
+
+export interface DesignSystemPackageInfo {
+  manifest?: {
+    schemaVersion: string;
+    id: string;
+    name: string;
+    category: string;
+    source?: { type?: string; url?: string; path?: string; branch?: string; commit?: string; importedAt?: string };
+    files?: {
+      design?: string;
+      tokens?: string;
+      components?: string;
+    };
+    usage?: string;
+    componentsManifest?: string;
+    importMode?: string;
+    craft?: {
+      applies?: string[];
+      suggested?: string[];
+      exemptions?: string[];
+    };
+    fonts?: Array<{ family?: string; weight?: string | number; style?: string; file?: string }>;
+    preview?: {
+      dir?: string;
+      pages?: Array<{ path?: string; role?: string; title?: string }>;
+    };
+    sourceFiles?: {
+      scanned?: string;
+      evidence?: string;
+      tokens?: string;
+      snippets?: string;
+    };
+    assetsDir?: string;
+  };
+  sourceEvidence?: {
+    scannedFileCount?: number;
+    tokenCount?: number;
+    snippetCount?: number;
+    confidence?: Record<string, string | number>;
+    evidenceExcerpt?: string;
+  };
 }
 
 export interface DesignSystemsResponse {


### PR DESCRIPTION
## Why

This is PR5 in the design-system import-structure stack. PR0-PR4 made Open Design understand, generate, push, and pull the richer hybrid package, but the design-system detail page still presented it mostly as prose/files. This PR folds the package structure into a user-facing overview so reviewers can see why an imported system is trustworthy and what evidence exists behind it.

The pain being addressed is reviewability. Without a manifest/source-evidence summary, users have to infer whether an import is legacy, hybrid, source-backed, or missing evidence by opening raw files one by one.

## What users will see

On a design-system detail page, the Design System tab now shows a package overview card:

- whether the system is a structured import package or legacy fallback
- push-layer files such as `USAGE.md`, `DESIGN.md`, `tokens.css`, `components.html`, and `components.manifest.json`
- pull-layer counts for preview pages, source evidence indexes, and assets
- source evidence metrics such as scanned files, extracted tokens, snippets, and confidence
- manifest-declared preview/source paths and a short evidence excerpt when available

Legacy design systems still render cleanly as DESIGN.md-only fallback.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not captured in this CLI-only pass. The changed surface is the existing design-system detail page, Design System tab, where the new package overview card appears below the publish card.

## Bug fix verification

N/A, not a bug fix.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/design-system-assets.test.ts` from `apps/daemon`
- `pnpm --filter @open-design/contracts build`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- `pnpm --filter @open-design/web build`
- `git diff --check`

Notes:
- validation emits the existing engine warning because this machine is on Node v25.2.1 while the repo expects Node ~24
- web build emits existing CSS optimizer warnings for plugin-detail keyframes; the build succeeds