### PR TITLE
Wire design system import semantics

### DIFF
--- a/apps/daemon/src/design-system-github-import.ts
+++ b/apps/daemon/src/design-system-github-import.ts
@@ -14,7 +14,7 @@ const execFileAsync = promisify(execFile);
 
 export type GitHubDesignSystemImportOptions = Pick<
   LocalDesignSystemImportOptions,
-  'name' | 'now' | 'reservedIds'
+  'craftApplies' | 'importMode' | 'name' | 'now' | 'reservedIds'
 > & {
   branch?: string;
   gitBin?: string;
@@ -63,6 +63,8 @@ export async function importGitHubDesignSystemProject(
       fallbackName: parsed.repo,
       ...(options.name ? { name: options.name } : {}),
       ...(options.reservedIds ? { reservedIds: options.reservedIds } : {}),
+      ...(options.importMode ? { importMode: options.importMode } : {}),
+      ...(options.craftApplies ? { craftApplies: options.craftApplies } : {}),
       source: {
         type: 'github',
         url: parsed.cloneUrl,

--- a/apps/daemon/src/design-system-import.ts
+++ b/apps/daemon/src/design-system-import.ts
@@ -15,6 +15,8 @@ export type LocalDesignSystemImportOptions = {
   fallbackName?: string;
   reservedIds?: Iterable<string>;
   source?: DesignSystemProjectSource;
+  importMode?: 'normalized' | 'hybrid' | 'verbatim';
+  craftApplies?: string[];
 };
 
 export type DesignSystemProjectSource =
@@ -135,6 +137,8 @@ export async function importLocalDesignSystemProject(
   const id = await nextAvailableSlug(userDesignSystemsRoot, slugify(displayName), options.reservedIds);
   const outDir = path.join(userDesignSystemsRoot, id);
   await mkdir(outDir, { recursive: true });
+  const importMode = normalizeImportMode(options.importMode);
+  const craftApplies = normalizeCraftList(options.craftApplies);
 
   const files = ['USAGE.md', 'DESIGN.md', 'tokens.css', 'components.html', 'components.manifest.json', 'manifest.json'];
   const designMd = renderDesignMd(id, displayName, scan);
@@ -159,7 +163,11 @@ export async function importLocalDesignSystemProject(
   files.push(...(await writeSourceEvidenceFiles(outDir, scan)));
   await writeFile(
     path.join(outDir, 'manifest.json'),
-    `${JSON.stringify(renderManifest(id, displayName, scan, options.now ?? new Date(), options.source), null, 2)}\n`,
+    `${JSON.stringify(
+      renderManifest(id, displayName, scan, options.now ?? new Date(), options.source, importMode, craftApplies),
+      null,
+      2,
+    )}\n`,
     'utf8',
   );
 
@@ -410,6 +418,8 @@ function renderManifest(
   scan: ProjectScan,
   now: Date,
   sourceOverride: DesignSystemProjectSource | undefined,
+  importMode: 'normalized' | 'hybrid' | 'verbatim',
+  craftApplies: string[],
 ) {
   const importedAt = now.toISOString();
   const source = sourceOverride ?? {
@@ -434,10 +444,10 @@ function renderManifest(
     },
     usage: 'USAGE.md',
     componentsManifest: 'components.manifest.json',
-    importMode: 'hybrid',
+    importMode,
     craft: {
-      applies: [],
-      suggested: ['color'],
+      applies: craftApplies,
+      suggested: craftApplies.includes('color') ? [] : ['color'],
       exemptions: [],
     },
     ...(scan.assets.length > 0 ? { assetsDir: 'assets' } : {}),
@@ -467,6 +477,24 @@ function renderManifest(
       snippets: 'source/snippets/INDEX.json',
     },
   };
+}
+
+function normalizeImportMode(value: unknown): 'normalized' | 'hybrid' | 'verbatim' {
+  return value === 'normalized' || value === 'verbatim' || value === 'hybrid' ? value : 'hybrid';
+}
+
+function normalizeCraftList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== 'string') continue;
+    const slug = entry.trim().toLowerCase();
+    if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug) || seen.has(slug)) continue;
+    seen.add(slug);
+    out.push(slug);
+  }
+  return out;
 }
 
 function renderDesignMd(id: string, name: string, scan: ProjectScan): string {

--- a/apps/daemon/src/design-systems.ts
+++ b/apps/daemon/src/design-systems.ts
@@ -137,6 +137,12 @@ type DesignSystemProjectManifest = {
     tokens?: string;
     snippets?: string;
   };
+  importMode?: 'normalized' | 'hybrid' | 'verbatim';
+  craft?: {
+    applies?: string[];
+    suggested?: string[];
+    exemptions?: string[];
+  };
 };
 
 export type DesignSystemProvenance = {
@@ -387,6 +393,9 @@ export type DesignSystemAssets = {
   fixtureHtml?: string | undefined;
   componentsManifest?: string | undefined;
   pullIndex?: string | undefined;
+  importMode?: 'normalized' | 'hybrid' | 'verbatim' | undefined;
+  craftApplies?: string[] | undefined;
+  craftExemptions?: string[] | undefined;
 };
 
 export async function readDesignSystemAssets(
@@ -411,6 +420,9 @@ export async function readDesignSystemAssets(
     fixtureHtml,
     componentsManifestJson,
     pullIndex: buildDesignSystemPullIndex(manifest),
+    importMode: manifest?.importMode,
+    craftApplies: manifest?.craft?.applies,
+    craftExemptions: manifest?.craft?.exemptions,
   });
 }
 
@@ -475,6 +487,9 @@ export async function resolveDesignSystemAssets(
       fixtureHtml: undefined,
       componentsManifest: undefined,
       pullIndex: undefined,
+      importMode: undefined,
+      craftApplies: undefined,
+      craftExemptions: undefined,
     };
   }
 
@@ -491,12 +506,25 @@ export async function resolveDesignSystemAssets(
     componentsManifestJson: undefined,
     componentsManifest: builtIn.componentsManifest ?? userInstalled.componentsManifest,
     pullIndex: builtIn.pullIndex ?? userInstalled.pullIndex,
+    importMode: builtIn.importMode ?? userInstalled.importMode,
+    craftApplies: builtIn.craftApplies ?? userInstalled.craftApplies,
+    craftExemptions: builtIn.craftExemptions ?? userInstalled.craftExemptions,
   });
 }
 
 function withComponentsManifest(
   designSystemId: string,
-  assets: Pick<DesignSystemAssets, 'usageMd' | 'tokensCss' | 'fixtureHtml' | 'componentsManifest' | 'pullIndex'> & {
+  assets: Pick<
+    DesignSystemAssets,
+    | 'usageMd'
+    | 'tokensCss'
+    | 'fixtureHtml'
+    | 'componentsManifest'
+    | 'pullIndex'
+    | 'importMode'
+    | 'craftApplies'
+    | 'craftExemptions'
+  > & {
     componentsManifestJson?: string | undefined;
   },
 ): DesignSystemAssets {

--- a/apps/daemon/src/prompts/system.ts
+++ b/apps/daemon/src/prompts/system.ts
@@ -158,6 +158,21 @@ Active design system exception: the active design system is the visual direction
 
 const DEFAULT_DESIGN_SYSTEM_USAGE = `Read DESIGN.md for visual principles, paste tokens.css verbatim into the first <style> when it is provided, and match component shapes from the reference component manifest or fixture when available. Treat any pull-layer index as optional context for deeper inspection; do not assume those files have already been loaded.`;
 
+function renderDesignSystemImportModeGuidance(
+  importMode: ComposeInput['designSystemImportMode'],
+): string | undefined {
+  if (importMode === 'normalized') {
+    return 'This package is normalized. Treat tokens.css and DESIGN.md as the contract, and prefer OD token names over source-project names. Use pull-layer source evidence only as optional background.';
+  }
+  if (importMode === 'hybrid') {
+    return 'This package is hybrid. Build with OD-normalized tokens first, then inspect pull-layer source evidence or snippets only when original component behavior, density, or naming would materially improve fidelity.';
+  }
+  if (importMode === 'verbatim') {
+    return 'This package is verbatim-oriented. Preserve source semantics and source naming as much as possible. Before translating component behavior, inspect the relevant pull-layer source evidence or snippets when the runtime tool is available.';
+  }
+  return undefined;
+}
+
 export interface ComposeInput {
   agentId?: string | null | undefined;
   includeCodexImagegenOverride?: boolean | undefined;
@@ -202,6 +217,7 @@ export interface ComposeInput {
   designSystemComponentsManifest?: string | undefined;
   designSystemFixtureHtml?: string | undefined;
   designSystemPullIndex?: string | undefined;
+  designSystemImportMode?: 'normalized' | 'hybrid' | 'verbatim' | undefined;
   // Craft references the active skill opted into via `od.craft.requires`.
   // The daemon resolves the slug list to file contents and concatenates
   // them with section headers; we inject them between the DESIGN.md and
@@ -287,6 +303,7 @@ export function composeSystemPrompt({
   designSystemComponentsManifest,
   designSystemFixtureHtml,
   designSystemPullIndex,
+  designSystemImportMode,
   craftBody,
   craftSections,
   memoryBody,
@@ -365,6 +382,13 @@ export function composeSystemPrompt({
     parts.push(
       `\n\n## Active design system${designSystemTitle ? ` — ${designSystemTitle}` : ''}\n\nTreat the following DESIGN.md as authoritative for color, typography, spacing, and component rules. Do not invent tokens outside this palette. When you copy the active skill's seed template, bind these tokens into its \`:root\` block before generating any layout.\n\n${activeDesignSystemBody}`,
     );
+
+    const importModeGuidance = renderDesignSystemImportModeGuidance(designSystemImportMode);
+    if (importModeGuidance) {
+      parts.push(
+        `\n\n## Design system import mode${designSystemTitle ? ` — ${designSystemTitle}` : ''}\n\n${importModeGuidance}`,
+      );
+    }
   }
 
   // Structured (compiled) form of the active brand. The DESIGN.md above

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -8061,13 +8061,6 @@ export async function startServer({
 
     let craftBody;
     let craftSections;
-    if (skillCraftRequires.length > 0) {
-      const loaded = await loadCraftSections(CRAFT_DIR, skillCraftRequires);
-      if (loaded.body) {
-        craftBody = loaded.body;
-        craftSections = loaded.sections;
-      }
-    }
 
     // Personal-memory body is always recomputed at compose time so a
     // memory the user just edited in settings shows up on the very next
@@ -8112,6 +8105,9 @@ export async function startServer({
     let designSystemComponentsManifest;
     let designSystemFixtureHtml;
     let designSystemPullIndex;
+    let designSystemImportMode;
+    let designSystemCraftApplies = [];
+    let designSystemCraftExemptions = [];
     if (effectiveDesignSystemId) {
       let systems = await listAllDesignSystems();
       let summary = systems.find((s) => s.id === effectiveDesignSystemId);
@@ -8142,6 +8138,21 @@ export async function startServer({
         designSystemComponentsManifest = assets.componentsManifest;
         designSystemFixtureHtml = assets.fixtureHtml;
         designSystemPullIndex = assets.pullIndex;
+        designSystemImportMode = assets.importMode;
+        designSystemCraftApplies = Array.isArray(assets.craftApplies) ? assets.craftApplies : [];
+        designSystemCraftExemptions = Array.isArray(assets.craftExemptions) ? assets.craftExemptions : [];
+      }
+    }
+
+    const excludedCraft = new Set(designSystemCraftExemptions);
+    const requestedCraft = Array.from(
+      new Set([...skillCraftRequires, ...designSystemCraftApplies]),
+    ).filter((slug) => !excludedCraft.has(slug));
+    if (requestedCraft.length > 0) {
+      const loaded = await loadCraftSections(CRAFT_DIR, requestedCraft);
+      if (loaded.body) {
+        craftBody = loaded.body;
+        craftSections = loaded.sections;
       }
     }
 
@@ -8301,6 +8312,7 @@ export async function startServer({
       designSystemComponentsManifest,
       designSystemFixtureHtml,
       designSystemPullIndex,
+      designSystemImportMode,
       craftBody,
       craftSections,
       memoryBody,

--- a/apps/daemon/src/static-resource-routes.ts
+++ b/apps/daemon/src/static-resource-routes.ts
@@ -630,8 +630,12 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
       }
 
       const before = await listAllDesignSystems();
+      const importMode = normalizeDesignSystemImportMode(body.importMode);
+      const craftApplies = normalizeDesignSystemCraftApplies(body.craftApplies);
       const result = await importLocalDesignSystemProject(sourceRoot, USER_DESIGN_SYSTEMS_DIR, {
-        name: typeof body.name === 'string' ? body.name : undefined,
+        ...(typeof body.name === 'string' ? { name: body.name } : {}),
+        ...(importMode ? { importMode } : {}),
+        ...(craftApplies ? { craftApplies } : {}),
         reservedIds: before.map((system) => system.id),
       });
       const systems = await listAllDesignSystems();
@@ -664,13 +668,17 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
             ? body.url
             : '';
       const before = await listAllDesignSystems();
+      const importMode = normalizeDesignSystemImportMode(body.importMode);
+      const craftApplies = normalizeDesignSystemCraftApplies(body.craftApplies);
       const result = await importGitHubDesignSystemProject(
         githubUrl,
         path.join(PROJECT_ROOT, '.tmp'),
         USER_DESIGN_SYSTEMS_DIR,
         {
-          name: typeof body.name === 'string' ? body.name : undefined,
-          branch: typeof body.branch === 'string' ? body.branch : undefined,
+          ...(typeof body.name === 'string' ? { name: body.name } : {}),
+          ...(typeof body.branch === 'string' ? { branch: body.branch } : {}),
+          ...(importMode ? { importMode } : {}),
+          ...(craftApplies ? { craftApplies } : {}),
           reservedIds: before.map((system) => system.id),
         },
       );
@@ -712,6 +720,24 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
     }
   });
 
+}
+
+function normalizeDesignSystemImportMode(value: unknown): 'normalized' | 'hybrid' | 'verbatim' | undefined {
+  return value === 'normalized' || value === 'hybrid' || value === 'verbatim' ? value : undefined;
+}
+
+function normalizeDesignSystemCraftApplies(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== 'string') continue;
+    const slug = entry.trim().toLowerCase();
+    if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug) || seen.has(slug)) continue;
+    seen.add(slug);
+    out.push(slug);
+  }
+  return out;
 }
 
 function assembleExample(templateHtml: string, slidesHtml: string, title: string) {

--- a/apps/daemon/tests/design-system-assets.test.ts
+++ b/apps/daemon/tests/design-system-assets.test.ts
@@ -254,6 +254,12 @@ describe('Design System Project manifest runtime consumption', () => {
         },
         usage: 'USAGE.md',
         componentsManifest: 'components.manifest.json',
+        importMode: 'verbatim',
+        craft: {
+          applies: ['color'],
+          suggested: [],
+          exemptions: ['typography'],
+        },
         assetsDir: 'assets',
         fonts: [{ family: 'Inter', weight: 500, file: 'fonts/Inter-Medium.woff2' }],
         preview: {
@@ -316,6 +322,9 @@ describe('Design System Project manifest runtime consumption', () => {
 
     const assets = await readDesignSystemAssets(root, 'hybrid-project');
     expect(assets.usageMd).toContain('Use cache first');
+    expect(assets.importMode).toBe('verbatim');
+    expect(assets.craftApplies).toEqual(['color']);
+    expect(assets.craftExemptions).toEqual(['typography']);
     expect(assets.componentsManifest).toContain('components.manifest schema v1 for cache-brand');
     expect(assets.componentsManifest).toContain('Cached buttons');
     expect(assets.pullIndex).toContain('preview/colors.html: Colors; colors');

--- a/apps/daemon/tests/design-system-github-import.test.ts
+++ b/apps/daemon/tests/design-system-github-import.test.ts
@@ -99,6 +99,8 @@ exit 1
       {
         gitBin: fakeGit,
         now: new Date('2026-05-18T10:00:00.000Z'),
+        importMode: 'normalized',
+        craftApplies: ['color'],
       },
     );
 
@@ -121,7 +123,10 @@ exit 1
       },
       usage: 'USAGE.md',
       componentsManifest: 'components.manifest.json',
-      importMode: 'hybrid',
+      importMode: 'normalized',
+      craft: {
+        applies: ['color'],
+      },
       sourceFiles: {
         scanned: 'source/scanned-files.json',
         evidence: 'source/evidence.md',

--- a/apps/daemon/tests/design-system-import.test.ts
+++ b/apps/daemon/tests/design-system-import.test.ts
@@ -197,4 +197,22 @@ describe('importLocalDesignSystemProject', () => {
     expect(first.id).toBe('kami-app-2');
     expect(second.id).toBe('kami-app-3');
   });
+
+  it('writes selected importMode and applied craft semantics into manifest', async () => {
+    const result = await importLocalDesignSystemProject(sourceRoot, userDesignSystemsRoot, {
+      now: new Date('2026-05-18T09:00:00.000Z'),
+      importMode: 'verbatim',
+      craftApplies: ['color', 'accessibility-baseline', 'color'],
+    });
+
+    const manifest = JSON.parse(fs.readFileSync(path.join(result.dir, 'manifest.json'), 'utf8')) as Record<string, unknown>;
+    expect(manifest).toMatchObject({
+      importMode: 'verbatim',
+      craft: {
+        applies: ['color', 'accessibility-baseline'],
+        suggested: [],
+        exemptions: [],
+      },
+    });
+  });
 });

--- a/apps/daemon/tests/prompts/system.test.ts
+++ b/apps/daemon/tests/prompts/system.test.ts
@@ -425,6 +425,18 @@ describe('composeSystemPrompt', () => {
       expect(prompt).toContain('Keep the push prompt light');
     });
 
+    it('adds importMode guidance when the manifest declares consumption semantics', () => {
+      const prompt = composeSystemPrompt({
+        designSystemTitle: 'source-heavy',
+        designSystemBody: '# x\n\nbody',
+        designSystemImportMode: 'verbatim',
+      });
+
+      expect(prompt).toContain('## Design system import mode — source-heavy');
+      expect(prompt).toContain('Preserve source semantics and source naming');
+      expect(prompt).toContain('pull-layer source evidence or snippets');
+    });
+
     it('places the tokens + component manifest blocks AFTER the DESIGN.md prose block (prose sets voice, structured form binds names)', () => {
       const prompt = composeSystemPrompt({
         designSystemTitle: 'default',

--- a/apps/web/src/components/DesignSystemsSection.tsx
+++ b/apps/web/src/components/DesignSystemsSection.tsx
@@ -20,6 +20,13 @@ interface Props {
   setCfg: Dispatch<SetStateAction<AppConfig>>;
 }
 
+function toggleCraftSlug(current: string[], slug: string, enabled: boolean): string[] {
+  const next = new Set(current);
+  if (enabled) next.add(slug);
+  else next.delete(slug);
+  return Array.from(next);
+}
+
 export function DesignSystemsSection({ cfg, setCfg }: Props) {
   const t = useT();
   const [designSystems, setDesignSystems] = useState<DesignSystemSummary[]>([]);
@@ -29,7 +36,9 @@ export function DesignSystemsSection({ cfg, setCfg }: Props) {
   const [previewBody, setPreviewBody] = useState<string | null>(null);
   const [previewLoading, setPreviewLoading] = useState(false);
   const [importPath, setImportPath] = useState('');
-  const [importMode, setImportMode] = useState<'local' | 'github'>('local');
+  const [importSource, setImportSource] = useState<'local' | 'github'>('local');
+  const [packageImportMode, setPackageImportMode] = useState<'normalized' | 'hybrid' | 'verbatim'>('hybrid');
+  const [craftApplies, setCraftApplies] = useState<string[]>([]);
   const [importing, setImporting] = useState(false);
   const [importMessage, setImportMessage] = useState<string | null>(null);
   const [importError, setImportError] = useState<string | null>(null);
@@ -119,10 +128,14 @@ export function DesignSystemsSection({ cfg, setCfg }: Props) {
     setImporting(true);
     setImportError(null);
     setImportMessage(null);
+    const importOptions = {
+      importMode: packageImportMode,
+      craftApplies,
+    };
     const result =
-      importMode === 'github'
-        ? await importGitHubDesignSystem({ githubUrl: importTarget })
-        : await importLocalDesignSystem({ baseDir: importTarget });
+      importSource === 'github'
+        ? await importGitHubDesignSystem({ githubUrl: importTarget, ...importOptions })
+        : await importLocalDesignSystem({ baseDir: importTarget, ...importOptions });
     setImporting(false);
     if ('error' in result) {
       setImportError(result.error.message);
@@ -145,24 +158,73 @@ export function DesignSystemsSection({ cfg, setCfg }: Props) {
         <div className="seg-control">
           <button
             type="button"
-            className={importMode === 'local' ? 'active' : ''}
-            onClick={() => setImportMode('local')}
+            className={importSource === 'local' ? 'active' : ''}
+            onClick={() => setImportSource('local')}
           >
             Local
           </button>
           <button
             type="button"
-            className={importMode === 'github' ? 'active' : ''}
-            onClick={() => setImportMode('github')}
+            className={importSource === 'github' ? 'active' : ''}
+            onClick={() => setImportSource('github')}
           >
             GitHub
           </button>
+        </div>
+        <div className="library-import-options">
+          <div className="library-import-option-group">
+            <span className="library-import-option-label">Structure</span>
+            <div className="seg-control library-import-mode-control">
+              <button
+                type="button"
+                className={packageImportMode === 'hybrid' ? 'active' : ''}
+                onClick={() => setPackageImportMode('hybrid')}
+              >
+                Hybrid
+              </button>
+              <button
+                type="button"
+                className={packageImportMode === 'normalized' ? 'active' : ''}
+                onClick={() => setPackageImportMode('normalized')}
+              >
+                Normalized
+              </button>
+              <button
+                type="button"
+                className={packageImportMode === 'verbatim' ? 'active' : ''}
+                onClick={() => setPackageImportMode('verbatim')}
+              >
+                Verbatim
+              </button>
+            </div>
+          </div>
+          <div className="library-import-option-group">
+            <span className="library-import-option-label">Craft</span>
+            <label className="library-import-checkbox">
+              <input
+                type="checkbox"
+                checked={craftApplies.includes('color')}
+                onChange={(e) => setCraftApplies((current) => toggleCraftSlug(current, 'color', e.target.checked))}
+              />
+              <span>Color</span>
+            </label>
+            <label className="library-import-checkbox">
+              <input
+                type="checkbox"
+                checked={craftApplies.includes('accessibility-baseline')}
+                onChange={(e) =>
+                  setCraftApplies((current) => toggleCraftSlug(current, 'accessibility-baseline', e.target.checked))
+                }
+              />
+              <span>Accessibility</span>
+            </label>
+          </div>
         </div>
         <div className="library-install-row">
           <input
             type="text"
             className="library-search"
-            placeholder={importMode === 'github' ? 'https://github.com/owner/repo' : '/path/to/project'}
+            placeholder={importSource === 'github' ? 'https://github.com/owner/repo' : '/path/to/project'}
             value={importPath}
             onChange={(e) => setImportPath(e.target.value)}
           />

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -19219,6 +19219,45 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   width: fit-content;
 }
 
+.library-import-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 16px;
+  align-items: center;
+}
+
+.library-import-option-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.library-import-option-label {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.library-import-mode-control button {
+  font-size: 11px;
+}
+
+.library-import-checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.library-import-checkbox input {
+  margin: 0;
+}
+
 .library-install-row {
   display: flex;
   gap: 8px;

--- a/design-systems/_schema/manifest.schema.ts
+++ b/design-systems/_schema/manifest.schema.ts
@@ -110,9 +110,9 @@ export type DesignSystemProjectManifest = {
   readonly usage?: string;
   /** Optional rebuildable cache derived from components.html + tokens.css. */
   readonly componentsManifest?: string;
-  /** Optional importer mode metadata. Runtime does not consume this in PR0. */
+  /** Importer mode metadata. Defaults to hybrid for imported packages. */
   readonly importMode?: DesignSystemProjectImportMode;
-  /** Optional craft metadata. Runtime and guard semantics are deferred. */
+  /** Optional craft metadata consumed by prompt assembly and guard checks. */
   readonly craft?: DesignSystemProjectCraft;
   /** Optional webfont files copied into the package. */
   readonly fonts?: readonly DesignSystemProjectFont[];
@@ -268,9 +268,9 @@ function validateCraft(errors: string[], value: unknown): void {
   }
 
   rejectUnknownKeys(errors, "$.craft", value, ALLOWED_CRAFT_KEYS);
-  expectStringArray(errors, "$.craft.applies", value.applies);
-  expectStringArray(errors, "$.craft.suggested", value.suggested);
-  expectStringArray(errors, "$.craft.exemptions", value.exemptions);
+  expectSlugArray(errors, "$.craft.applies", value.applies);
+  expectSlugArray(errors, "$.craft.suggested", value.suggested);
+  expectSlugArray(errors, "$.craft.exemptions", value.exemptions);
 }
 
 function validateFonts(errors: string[], value: unknown): void {
@@ -362,15 +362,15 @@ function expectNonEmptyString(errors: string[], pathLabel: string, value: unknow
   }
 }
 
-function expectStringArray(errors: string[], pathLabel: string, value: unknown): void {
+function expectSlugArray(errors: string[], pathLabel: string, value: unknown): void {
   if (!Array.isArray(value)) {
-    errors.push(`${pathLabel} must be an array of strings`);
+    errors.push(`${pathLabel} must be an array of lowercase slugs`);
     return;
   }
 
   value.forEach((entry, index) => {
-    if (typeof entry !== "string" || entry.trim().length === 0) {
-      errors.push(`${pathLabel}[${index}] must be a non-empty string`);
+    if (typeof entry !== "string" || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(entry)) {
+      errors.push(`${pathLabel}[${index}] must be a lowercase slug matching /^[a-z0-9]+(?:-[a-z0-9]+)*$/`);
     }
   });
 }

--- a/packages/contracts/src/api/registry.ts
+++ b/packages/contracts/src/api/registry.ts
@@ -354,6 +354,10 @@ export interface ImportLocalDesignSystemRequest {
   baseDir: string;
   /** Optional display name override for the generated design-system project. */
   name?: string;
+  /** Import structure mode. Defaults to hybrid for real project imports. */
+  importMode?: 'normalized' | 'hybrid' | 'verbatim';
+  /** Craft sections that should actively apply when this system is used. */
+  craftApplies?: string[];
 }
 
 export interface ImportLocalDesignSystemResponse {
@@ -367,6 +371,10 @@ export interface ImportGitHubDesignSystemRequest {
   branch?: string;
   /** Optional display name override for the generated design-system project. */
   name?: string;
+  /** Import structure mode. Defaults to hybrid for real project imports. */
+  importMode?: 'normalized' | 'hybrid' | 'verbatim';
+  /** Craft sections that should actively apply when this system is used. */
+  craftApplies?: string[];
 }
 
 export interface ImportGitHubDesignSystemResponse {

--- a/scripts/check-design-system-manifests.test.ts
+++ b/scripts/check-design-system-manifests.test.ts
@@ -3,8 +3,10 @@ import test from "node:test";
 
 import {
   DESIGN_SYSTEM_PROJECT_SCHEMA_VERSION,
+  type DesignSystemProjectManifest,
   validateDesignSystemProjectManifest,
 } from "../design-systems/_schema/manifest.schema.ts";
+import { validateManifestSemantics } from "./check-design-system-manifests.ts";
 
 test("design-system project manifest schema accepts the v1 minimum shape", () => {
   const result = validateDesignSystemProjectManifest({
@@ -121,7 +123,7 @@ test("design-system project manifest schema accepts import-project optional inde
     importMode: "hybrid",
     craft: {
       applies: ["color"],
-      suggested: ["accessibility"],
+      suggested: ["accessibility-baseline"],
       exemptions: [],
     },
     fonts: [
@@ -150,6 +152,66 @@ test("design-system project manifest schema accepts import-project optional inde
     assert.equal(result.manifest.importMode, "hybrid");
     assert.equal(result.manifest.preview?.pages.length, 2);
   }
+});
+
+test("design-system project manifest schema requires craft slug format", () => {
+  const result = validateDesignSystemProjectManifest({
+    schemaVersion: DESIGN_SYSTEM_PROJECT_SCHEMA_VERSION,
+    id: "cherry-studio",
+    name: "Cherry Studio",
+    category: "AI & LLM",
+    source: { type: "local", path: "/tmp/cherry-studio" },
+    files: {
+      design: "DESIGN.md",
+      tokens: "tokens.css",
+    },
+    craft: {
+      applies: ["Color"],
+      suggested: ["accessibility baseline"],
+      exemptions: [""],
+    },
+  });
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    const errors = result.errors.join("\n");
+    assert.match(errors, /\$\.craft\.applies\[0\]/);
+    assert.match(errors, /\$\.craft\.suggested\[0\]/);
+    assert.match(errors, /\$\.craft\.exemptions\[0\]/);
+  }
+});
+
+test("design-system manifest semantics connect craft and importMode declarations to known evidence", () => {
+  const manifest: DesignSystemProjectManifest = {
+    schemaVersion: DESIGN_SYSTEM_PROJECT_SCHEMA_VERSION,
+    id: "cherry-studio",
+    name: "Cherry Studio",
+    category: "AI & LLM",
+    source: { type: "local", path: "/tmp/cherry-studio" },
+    files: {
+      design: "DESIGN.md",
+      tokens: "tokens.css",
+    },
+    importMode: "verbatim",
+    craft: {
+      applies: ["color", "missing-craft"],
+      suggested: [],
+      exemptions: ["color"],
+    },
+    sourceFiles: {
+      scanned: "source/scanned-files.json",
+    },
+  };
+  const violations: string[] = [];
+
+  validateManifestSemantics(violations, "design-systems/cherry-studio/manifest.json", manifest, new Set(["color"]));
+
+  assert.deepEqual(violations, [
+    'design-systems/cherry-studio/manifest.json: $.craft.applies references unknown craft "missing-craft"',
+    'design-systems/cherry-studio/manifest.json: craft "color" cannot be both applied and exempted',
+    "design-systems/cherry-studio/manifest.json: verbatim imports must declare sourceFiles.tokens",
+    "design-systems/cherry-studio/manifest.json: verbatim imports must declare sourceFiles.snippets",
+  ]);
 });
 
 test("design-system project manifest schema rejects unsafe import-project paths", () => {

--- a/scripts/check-design-system-manifests.ts
+++ b/scripts/check-design-system-manifests.ts
@@ -15,10 +15,12 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { parseDesignSystemProjectManifest } from "../design-systems/_schema/manifest.schema.ts";
+import type { DesignSystemProjectManifest } from "../design-systems/_schema/manifest.schema.ts";
 import { extractComponentsManifest } from "../packages/contracts/src/design-systems/components-manifest.ts";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 const designSystemsRoot = path.join(repoRoot, "design-systems");
+const craftRoot = path.join(repoRoot, "craft");
 const SKIPPED_DIRECTORIES = new Set(["_schema"]);
 
 function toRepositoryPath(filePath: string): string {
@@ -58,6 +60,7 @@ async function discoverManifestPaths(): Promise<string[]> {
 
 export async function checkDesignSystemManifests(): Promise<boolean> {
   const manifestPaths = await discoverManifestPaths();
+  const craftSlugs = await discoverCraftSlugs();
   const violations: string[] = [];
 
   for (const manifestPath of manifestPaths) {
@@ -75,6 +78,7 @@ export async function checkDesignSystemManifests(): Promise<boolean> {
     if (manifest.id !== folderSlug) {
       violations.push(`${repositoryManifestPath}: $.id must match folder slug "${folderSlug}"`);
     }
+    validateManifestSemantics(violations, repositoryManifestPath, manifest, craftSlugs);
 
     const requiredFiles = [
       manifest.files.design,
@@ -114,6 +118,59 @@ export async function checkDesignSystemManifests(): Promise<boolean> {
     `Design system manifest check passed: ${manifestPaths.length} project manifest${manifestPaths.length === 1 ? "" : "s"} valid; DESIGN.md-only systems skipped.`,
   );
   return true;
+}
+
+async function discoverCraftSlugs(): Promise<Set<string>> {
+  try {
+    const entries = await readdir(craftRoot, { withFileTypes: true });
+    return new Set(
+      entries
+        .filter((entry) => entry.isFile() && entry.name.endsWith(".md") && entry.name !== "README.md")
+        .map((entry) => entry.name.slice(0, -".md".length)),
+    );
+  } catch {
+    return new Set();
+  }
+}
+
+export function validateManifestSemantics(
+  violations: string[],
+  repositoryManifestPath: string,
+  manifest: DesignSystemProjectManifest,
+  craftSlugs: ReadonlySet<string>,
+): void {
+  const applies = manifest.craft?.applies ?? [];
+  const suggested = manifest.craft?.suggested ?? [];
+  const exemptions = manifest.craft?.exemptions ?? [];
+  const declaredCraft = [
+    ...applies.map((slug) => ({ slug, field: "applies" })),
+    ...suggested.map((slug) => ({ slug, field: "suggested" })),
+    ...exemptions.map((slug) => ({ slug, field: "exemptions" })),
+  ];
+  for (const { slug, field } of declaredCraft) {
+    if (!craftSlugs.has(slug)) {
+      violations.push(`${repositoryManifestPath}: $.craft.${field} references unknown craft "${slug}"`);
+    }
+  }
+
+  const exemptionsSet = new Set(exemptions);
+  for (const slug of applies) {
+    if (exemptionsSet.has(slug)) {
+      violations.push(`${repositoryManifestPath}: craft "${slug}" cannot be both applied and exempted`);
+    }
+  }
+
+  if (manifest.importMode === "hybrid" && manifest.source?.type !== "bundled" && manifest.sourceFiles === undefined) {
+    violations.push(`${repositoryManifestPath}: hybrid imports must declare sourceFiles evidence`);
+  }
+  if (manifest.importMode === "verbatim" && manifest.source?.type !== "bundled") {
+    if (manifest.sourceFiles?.tokens === undefined) {
+      violations.push(`${repositoryManifestPath}: verbatim imports must declare sourceFiles.tokens`);
+    }
+    if (manifest.sourceFiles?.snippets === undefined) {
+      violations.push(`${repositoryManifestPath}: verbatim imports must declare sourceFiles.snippets`);
+    }
+  }
 }
 
 async function requireDeclaredPathExists(


### PR DESCRIPTION
## Why

This is PR6 in the design-system import stack. PR0-PR5 taught the repo to recognize, generate, push, pull, and display the richer hybrid package structure; this PR makes the manifest semantics active so imported packages can say how agents should consume source evidence and which craft references apply.

The pain being addressed is that `importMode` and `craft` were visible metadata only. Importers could write them, but guards, prompts, and the import UI did not yet honor those declarations.

## What users will see

Settings → Design Systems import now exposes a Structure selector (`Hybrid`, `Normalized`, `Verbatim`) and craft checkboxes for color/accessibility. Imported local and GitHub design-system packages persist those selections into `manifest.json`.

When a project uses a design system with these declarations, the daemon prompt now includes import-mode guidance and loads the declared craft references alongside any skill-required craft.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope.
- [x] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached for this stacked PR; the visible change is the existing Design Systems settings import form gaining compact options. `@open-design/web` typecheck and build cover the UI compile path.

## Bug fix verification

-

## Validation

- `pnpm exec tsx --test scripts/check-design-system-manifests.test.ts`
- `pnpm exec tsx scripts/check-design-system-manifests.ts`
- `pnpm exec vitest run -c vitest.config.ts tests/design-system-assets.test.ts tests/design-system-import.test.ts tests/design-system-github-import.test.ts tests/prompts/system.test.ts` from `apps/daemon`
- `pnpm --filter @open-design/contracts build`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- `pnpm --filter @open-design/web build`
- `pnpm typecheck`
- `git diff --check`

Note: commands emit the existing Node engine warning because this machine is on Node v25.2.1 while the repo expects `~24`.
