### PR TITLE
Remove Live artifact from home hero tabs

### DIFF
--- a/apps/web/src/components/home-hero/chips.ts
+++ b/apps/web/src/components/home-hero/chips.ts
@@ -90,23 +90,6 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
     },
   },
   {
-    id: 'live-artifact',
-    label: 'Live artifact',
-    icon: 'pencil',
-    group: 'create',
-    hint: 'Build an interactive HTML/CSS/JS artifact you can preview live.',
-    // Live artifact shares web-prototype's seed today — the difference
-    // is intent (interactive HTML/CSS/JS) vs static prototype, not the
-    // underlying template. The chip keeps a distinct id so active-state
-    // tracking + analytics see "user picked live-artifact" rather than
-    // "user picked prototype".
-    action: {
-      kind: 'apply-scenario',
-      pluginId: 'example-web-prototype',
-      projectKind: 'prototype',
-    },
-  },
-  {
     id: 'deck',
     label: 'Slide deck',
     icon: 'present',

--- a/apps/web/tests/components/HomeHero.rail.test.tsx
+++ b/apps/web/tests/components/HomeHero.rail.test.tsx
@@ -133,14 +133,6 @@ describe('HomeHero intent rail', () => {
       pluginId: 'example-hyperframes',
       projectKind: 'video',
     });
-    // Live artifact shares web-prototype's seed (interactive HTML/CSS/JS
-    // is a flavour of prototype) but keeps a distinct chip id + label
-    // so the rail's active state tracks user intent independently from
-    // the Prototype chip.
-    expect(findChip('live-artifact')?.action).toMatchObject({
-      kind: 'apply-scenario',
-      pluginId: 'example-web-prototype',
-      projectKind: 'prototype',
-    });
+    expect(findChip('live-artifact')).toBeUndefined();
   });
 });

--- a/e2e/ui/entry-chrome-flows.test.ts
+++ b/e2e/ui/entry-chrome-flows.test.ts
@@ -171,7 +171,7 @@ test('entry top navigation matches the current home tab structure', async ({ pag
   await expect(page.getByTestId('entry-nav-integrations')).toBeVisible();
   await expect(page.getByTestId('home-hero-rail')).toBeVisible();
   await expect(page.getByTestId('home-hero-rail-prototype')).toBeVisible();
-  await expect(page.getByTestId('home-hero-rail-live-artifact')).toBeVisible();
+  await expect(page.getByTestId('home-hero-rail-live-artifact')).toHaveCount(0);
   await expect(page.getByTestId('home-hero-rail-deck')).toBeVisible();
   await expect(page.getByTestId('home-hero-rail-image')).toBeVisible();
   await expect(page.getByTestId('home-hero-rail-video')).toBeVisible();


### PR DESCRIPTION
## Why

This removes the Home hero `Live artifact` tab that was called out from the current app entry experience. The pain being addressed is a redundant/default entry point in the first-run Home rail: it routes through the same bundled web prototype seed as Prototype, so keeping it as a separate primary tab adds visual clutter without a distinct flow.

## What users will see

On Home, the plugin tab rail no longer shows `Live artifact`. The remaining primary tabs start with Prototype, Slide deck, Image, Video, HyperFrames, and Audio. Existing live artifact project support and internal creation paths are unchanged.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached from CLI. User-visible change is the removal of the `Live artifact` chip from the Home hero rail shown in the issue/request screenshot.

## Bug fix verification

-

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web test -- tests/components/HomeHero.rail.test.tsx`
- `pnpm --filter e2e typecheck`

Note: commands ran under Node `v22.22.0`, so pnpm printed the repo's expected Node `~24` engine warning, but all listed checks passed.
