### PR TITLE
feat(web): add name-substring rank tier to @skill mention sort

### DIFF
--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -2068,11 +2068,12 @@ function skillMatchesQuery(skill: SkillSummary, query: string): boolean {
 
 function skillMentionRank(skill: SkillSummary, query: string): number {
   const q = query.trim().toLowerCase();
-  if (!q) return 1;
+  if (!q) return 2;
   const id = skill.id.toLowerCase();
   const name = skill.name.toLowerCase();
   if (id.startsWith(q) || name.startsWith(q)) return 0;
-  return 1;
+  if (id.includes(q) || name.includes(q)) return 1;
+  return 2;
 }
 
 function mcpServerMatchesQuery(server: McpServerConfig, query: string): boolean {

--- a/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
+++ b/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
@@ -268,6 +268,66 @@ describe('ChatComposer context pickers', () => {
     expect(skillNames.indexOf('Audit Helper 9')).toBeLessThan(skillNames.indexOf('Accessibility Review'));
   });
 
+  it('ranks name or id substring matches above description-only matches', async () => {
+    skills = [
+      makeSkill({
+        id: 'story-brief',
+        name: 'Story Brief',
+        description: 'Use when planning audit work.',
+        triggers: ['writing'],
+      }),
+      makeSkill({
+        id: 'field-audit-template',
+        name: 'Field Audit Template',
+        description: 'Field-survey audit template.',
+        triggers: ['field'],
+      }),
+      makeSkill({
+        id: 'audit-helper-1',
+        name: 'Audit Helper 1',
+        description: 'Audit support workflow.',
+        triggers: ['audit-1'],
+      }),
+    ];
+    renderComposer();
+    const input = screen.getByTestId('chat-composer-input') as HTMLTextAreaElement;
+
+    fireEvent.change(input, {
+      target: { value: '@audit', selectionStart: 6 },
+    });
+
+    await waitFor(() => expect(screen.getByText('Audit Helper 1')).toBeTruthy());
+    const skillNames = Array.from(
+      screen.getByTestId('mention-popover').querySelectorAll('.mention-item strong'),
+      (node) => node.textContent,
+    );
+
+    expect(skillNames.indexOf('Audit Helper 1')).toBeLessThan(skillNames.indexOf('Field Audit Template'));
+    expect(skillNames.indexOf('Field Audit Template')).toBeLessThan(skillNames.indexOf('Story Brief'));
+  });
+
+  it('preserves input order among skills sharing the same rank tier', async () => {
+    skills = [
+      makeSkill({ id: 'audit-zulu', name: 'Audit Zulu', triggers: ['audit'] }),
+      makeSkill({ id: 'audit-alpha', name: 'Audit Alpha', triggers: ['audit'] }),
+      makeSkill({ id: 'audit-mike', name: 'Audit Mike', triggers: ['audit'] }),
+    ];
+    renderComposer();
+    const input = screen.getByTestId('chat-composer-input') as HTMLTextAreaElement;
+
+    fireEvent.change(input, {
+      target: { value: '@audit', selectionStart: 6 },
+    });
+
+    await waitFor(() => expect(screen.getByText('Audit Zulu')).toBeTruthy());
+    const skillNames = Array.from(
+      screen.getByTestId('mention-popover').querySelectorAll('.mention-item strong'),
+      (node) => node.textContent,
+    );
+
+    expect(skillNames.slice(0, 3)).toEqual(['Audit Zulu', 'Audit Alpha', 'Audit Mike']);
+  });
+
   it('applies a plugin from @ search and keeps the plugin token inline', async () => {
     renderComposer();
     const input = screen.getByTestId('chat-composer-input') as HTMLTextAreaElement;


### PR DESCRIPTION
Follows up on #2170. That PR added a binary prefix-vs-rest rank for the `@` skill picker; this adds one more tier so a substring match in `id` or `name` outranks a match that only hit `description`, `mode`, `surface`, or `triggers`.

## Why

After #2170, the picker correctly puts `Audit Helper N` (name-prefix) above `Story Brief` (description-only). But a skill like `Field Audit Template` — whose `name` contains `audit` mid-word — ties with `Story Brief` because both land in the same "everything except prefix" bucket. Users typing `@audit` expect a skill whose name visibly contains it to appear before a skill that doesn't.

## What users will see

Typing `@audit`:

- **Tier 0** (top): `Audit Helper 1` — `id` or `name` starts with `audit`
- **Tier 1** (middle): `Field Audit Template` — `id` or `name` contains `audit` but doesn't start with it
- **Tier 2** (bottom): `Story Brief` — match only via `description`, `triggers`, or other fields

Empty `@` order is unchanged (all skills share one tier; stable sort preserves input order).

## Surface area

- [x] **UI** — `ChatComposer` `@`-mention sort order. No DOM, CSS, or component changes.
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — every user who types `@` followed by a query sees the refined ordering; pure list-layer change.
- [ ] **None**

## Validation

- `pnpm guard` — passes.
- `pnpm typecheck` — passes.
- `pnpm --filter @open-design/web typecheck` — passes.
- `pnpm --filter @open-design/web test` — 172 files, 1627 tests, all green. Two new cases in `apps/web/tests/components/ChatComposer.context-pickers.test.tsx`: `ranks name or id substring matches above description-only matches` and `preserves input order among skills sharing the same rank tier`. The first one goes red on the 2-tier function from #2170 (substring match ties with description-only); green on this branch.

## Screenshots

Skills tab on `@art` (local catalogue doesn't carry an `audit` skill set; `art` exercises the same three tiers):

![Skills tab on @art — three rank tiers visible](https://github.com/user-attachments/assets/5c1d40d7-38b4-4607-90c6-126ec52051ea)

- Tier 0: `article-magazine`, `artifacts-builder` — name starts with `art`
- Tier 1 (new in this PR): `algorithmic-art` — name contains `art` mid-word
- Tier 2: `brand-guidelines` — matches only via other fields
