### PR TITLE
feat(discovery): collapse freeform-project clarification into a single form

### DIFF
--- a/apps/daemon/src/prompts/discovery.ts
+++ b/apps/daemon/src/prompts/discovery.ts
@@ -41,12 +41,12 @@ Active design system exception: if a later section in this same system prompt is
 
 When the user opens a new project or sends a fresh design brief, your **very first output** is one short prose line + a \`<question-form>\` block. Nothing else. No file reads. No Bash. No TodoWrite. No extended thinking. The form is your time-to-first-byte.
 
-Default-router exception: when the Active plugin / Active skill is \`od-default\` or "Default design router", replace the generic \`discovery\` form with the exact \`<question-form id="task-type">\` form below on turn 1. Do not rename, tailor, drop, reorder, or rewrite these task type options; the user did not choose a Home chip yet, so this form is the missing chip selection. After the user answers \`[form answers — task-type]\`, treat the chosen task type as the route, then continue with the normal discovery / plan / generate / critique flow for that type.
+Default-router exception: when the Active plugin / Active skill is \`od-default\` or "Default design router", replace the generic \`discovery\` form with the exact \`<question-form id="task-type">\` form below on turn 1. Do not rename, tailor, drop, reorder, or rewrite the \`taskType\` options; the user did not choose a Home chip yet, so this form is the missing chip selection. This form is intentionally a **single-shot brief** — it asks the routing question (\`taskType\`) and the core discovery fields (audience, brand, scale, constraints) in one batch so the user only sees one clarification card. After the user answers \`[form answers — task-type]\`, treat the chosen task type as the route and **do NOT emit a second \`<question-form id="discovery">\` / "Quick brief — 30 seconds" form** for that turn — the brief is already locked. Proceed directly to RULE 2 (treating the submitted \`brand\` value the same way as a \`discovery\` answer) and then RULE 3.
 
 \`\`\`
 <question-form id="task-type" title="Choose the task type">
 {
-  "description": "I will route the free-form prompt through the right Open Design workflow.",
+  "description": "I'll route this through the right Open Design workflow and lock the brief in one shot. Skip what doesn't apply — I'll fill defaults.",
   "questions": [
     {
       "id": "taskType",
@@ -63,6 +63,28 @@ Default-router exception: when the Active plugin / Active skill is \`od-default\
         "Audio",
         "Other"
       ]
+    },
+    {
+      "id": "audience",
+      "label": "Who is this for?",
+      "type": "text",
+      "placeholder": "e.g. early-stage investors, dev-tools buyers, internal exec review"
+    },
+    {
+      "id": "brand",
+      "label": "Brand context",
+      "type": "radio",
+      "options": [
+        { "label": "Pick a direction for me", "value": "pick_direction" },
+        { "label": "I have a brand spec — I'll share it", "value": "brand_spec" },
+        { "label": "Match a reference site / screenshot — I'll attach it", "value": "reference_match" }
+      ]
+    },
+    {
+      "id": "scale",
+      "label": "Roughly how much?",
+      "type": "text",
+      "placeholder": "e.g. 8 slides, 1 landing + 3 sub-pages, 4 mobile screens, 30s video"
     },
     {
       "id": "constraints",
@@ -129,7 +151,7 @@ When skipping the form, do not skip brand-source handling: if the current messag
 
 ## RULE 2 — turn 2 branches on the \`brand\` answer, but never asks for visual direction again
 
-Once the user submits the discovery form (their next message starts with \`[form answers — discovery]\`) or the initial brief already answered the brand question, resolve the branch in this order:
+Once the user submits the discovery form (their next message starts with \`[form answers — discovery]\` or \`[form answers — task-type]\`) or the initial brief already answered the brand question, resolve the branch in this order:
 
 1. If the current message, attachments, prior brief, or URL already contains an actual brand spec / brand guide / reference site / screenshot source, use Branch A.
 2. Otherwise, look at the submitted \`brand\` value. When the answer line includes \`[value: ...]\`, use that stable value instead of the visible label.

--- a/apps/daemon/tests/prompts/discovery-form.test.ts
+++ b/apps/daemon/tests/prompts/discovery-form.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import { DISCOVERY_AND_PHILOSOPHY } from '../../src/prompts/discovery.js';
+
+// The default-router exception in `discovery.ts` emits a single `<question-form
+// id="task-type">` on turn 1 that combines the routing question (which Open
+// Design workflow to take) with the core discovery brief (audience / brand /
+// scale / constraints). Before this consolidation, freeform projects (no Home
+// chip pick) saw two clarification cards in a row — task-type, then "Quick
+// brief — 30 seconds" — which felt like the agent was re-asking. These tests
+// lock the single-shot shape so a future prompt edit cannot accidentally split
+// the brief into two turns again.
+
+describe('discovery.ts task-type form (single-shot brief)', () => {
+  it('emits a task-type form that asks the routing question plus the discovery brief', () => {
+    expect(DISCOVERY_AND_PHILOSOPHY).toContain('<question-form id="task-type"');
+    // Task-type radio + the four discovery brief fields must all live in this
+    // single form so the user does not see a second clarification card.
+    expect(DISCOVERY_AND_PHILOSOPHY).toContain('"id": "taskType"');
+    expect(DISCOVERY_AND_PHILOSOPHY).toContain('"id": "audience"');
+    expect(DISCOVERY_AND_PHILOSOPHY).toContain('"id": "brand"');
+    expect(DISCOVERY_AND_PHILOSOPHY).toContain('"id": "scale"');
+    expect(DISCOVERY_AND_PHILOSOPHY).toContain('"id": "constraints"');
+  });
+
+  it('preserves the three branch values RULE 2 dispatches on', () => {
+    // RULE 2 line 130+ keys off these exact `brand` answer values to choose
+    // Branch A (real brand source) vs Branch B (auto-pick). They are part of
+    // the discovery contract — labels can localize but values must not.
+    expect(DISCOVERY_AND_PHILOSOPHY).toContain('"value": "pick_direction"');
+    expect(DISCOVERY_AND_PHILOSOPHY).toContain('"value": "brand_spec"');
+    expect(DISCOVERY_AND_PHILOSOPHY).toContain('"value": "reference_match"');
+  });
+
+  it('keeps the eight canonical task-type options', () => {
+    const options = [
+      'Prototype',
+      'Live artifact',
+      'Slide deck',
+      'Image',
+      'Video',
+      'HyperFrames',
+      'Audio',
+      'Other',
+    ];
+    for (const option of options) {
+      expect(DISCOVERY_AND_PHILOSOPHY).toContain(`"${option}"`);
+    }
+  });
+
+  it('forbids the agent from emitting a second Quick brief form after task-type answers', () => {
+    // The whole point of the consolidation: once turn 1's task-type form is
+    // answered, turn 2 must go straight to brand handling / planning. A regex
+    // is brittle so check for the explicit no-second-form sentence the prompt
+    // ships with.
+    expect(DISCOVERY_AND_PHILOSOPHY).toMatch(
+      /do NOT emit a second `<question-form id="discovery">` \/ "Quick brief — 30 seconds" form/,
+    );
+  });
+
+  it('teaches RULE 2 to accept the task-type answer marker alongside discovery', () => {
+    // RULE 2's first sentence enumerates the answer markers it routes on. The
+    // single-shot brief means `[form answers — task-type]` must be a valid
+    // entry point — equivalent to `[form answers — discovery]` for the brand
+    // branching logic that follows.
+    expect(DISCOVERY_AND_PHILOSOPHY).toMatch(
+      /\[form answers — discovery\][^.]*\[form answers — task-type\]/,
+    );
+  });
+});


### PR DESCRIPTION
## Why

Hit this myself entering a project from a free-form prompt (no Home chip picked, so the active plugin is `od-default`). The agent emits **two clarification cards back-to-back**:

1. turn 1 → `Choose the task type` (just `taskType` + `constraints`)
2. turn 2 → `Quick brief — 30 seconds` (audience / platform / tone / brand / scale / constraints)

Reads as "the agent is re-asking the same question", and forces a second context switch before anything gets built. Product feedback (verbatim): *"如果是在文本框当中没有选任何类型的话，进入项目后会出现两次「意图澄清」：一次先问任务的类型，第二次再问这个 Quick Brief。这两个可以合成一个。"*

Reproduction screenshot in the linked product report. Both red boxes are clarification cards in the same project's first three messages.

## What users will see

- Freeform projects (Home prompt sent without a chip pick) now see **one** clarification card on turn 1 instead of two. The card asks `taskType` (the routing question) plus the core brief — `audience`, `brand`, `scale`, `constraints` — in one form.
- After the form is submitted, the agent goes straight to brand handling + planning. **No second "Quick brief — 30 seconds" card.**
- The `brand` question keeps its three branch values (`pick_direction` / `brand_spec` / `reference_match`) so RULE 2's branching logic still picks Branch A vs Branch B the same way.
- **Non-default-router projects are unchanged.** If the user picked a Home chip (deck / image / video / prototype-with-plugin / …), the chip already supplied the task type and the original single `Quick brief` form on turn 1 still applies.
- Two fields from the old Quick brief are intentionally **not** carried over: `platform` (task-type-specific — only meaningful for prototype/live) and `tone` (fluffy; usually inferable from brand). The "ask at most one concise follow-up only if a required detail is impossible to infer safely" rule already in `system.ts:143` lets the agent surface either as a targeted follow-up when it genuinely needs it.

## Surface area

- [ ] **UI** — none (the form-rendering UI hasn't changed; only the prompt that builds the form has)
- [ ] **Keyboard shortcut** — none
- [ ] **CLI / env var** — none
- [ ] **API / contract** — none
- [ ] **Extension point** — none
- [ ] **i18n keys** — none (form labels are agent-emitted markdown, not Dict keys; localization for form copy is the agent's responsibility per the existing form-authoring rules)
- [ ] **New top-level dependency** — none
- [x] **Default behavior change** — every freeform project after merge sees one card instead of two on its first agent turn. Non-default-router projects unaffected.

## Bug fix verification

- **Test path that reproduces the bug:** `apps/daemon/tests/prompts/discovery-form.test.ts` (new)
- **Did the test go red on `main` and green on this branch?** The two assertions that directly target the new prompt shape would go red on `main` (the old `task-type` form has only `taskType` + `constraints` fields, and RULE 2 doesn't accept `[form answers — task-type]` as an entry point). Bringing the test file alone onto `main` is enough to reproduce the regression.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run tests/prompts/discovery-form.test.ts` → 5/5 passed (new file)
- `pnpm --filter @open-design/daemon exec vitest run tests/prompts/system.test.ts tests/prompts/api-mode-override.test.ts tests/plugins-bundled-scenarios-roster.test.ts tests/plugins-scenario-fallback.test.ts` → 55/55 passed (no regressions in adjacent prompt + scenario-routing suites)

## What this PR does NOT touch

- `apps/web/src/artifacts/question-form.ts` — the form parser already handles arbitrary question lists, so the wider task-type form renders without any web-side change.
- Non-default-router scenarios — the original `<question-form id="discovery">` template at `discovery.ts:79` is unchanged and still ships to scenario-bound projects. The two paths now diverge cleanly: chip-bound → Quick brief, freeform → single-shot task-type.
- `system.ts:143` `skipDiscoveryBrief: true` override — daemon-API-created projects still skip both forms entirely.