### PR TITLE
fix(web): add CJK font fallback for Chinese/Japanese/Korean UI

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -18721,6 +18721,11 @@ body.desktop-pet-shell .pet-task-item {
   line-height: 1.35;
 }
 
+/* --- CJK (Chinese / Japanese / Korean) Comfort Pass --- */
+:lang(zh), :lang(zh-CN), :lang(zh-TW), :lang(ja), :lang(ko) {
+  --sans: "Inter", "PingFang SC", "Microsoft YaHei", "Noto Sans SC", "Hiragino Sans GB", "Source Han Sans SC", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+}
+
 /* --- Arabic & Persian Comfort Pass --- */
 [dir="rtl"] {
   --sans: "Cairo", "Inter", "Vazirmatn", "Noto Sans Arabic", "Segoe UI Arabic", "Tahoma", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;


### PR DESCRIPTION
## Summary

- When switching the UI language to Chinese, Japanese, or Korean, button and label text rendered as empty boxes (□□□) because the `--sans` font stack contained only Latin fonts with no CJK-capable fallbacks.
- Added a `:lang(zh), :lang(zh-CN), :lang(zh-TW), :lang(ja), :lang(ko)` comfort pass (mirroring the existing Arabic/Persian one) with system CJK fonts: PingFang SC, Microsoft YaHei, Noto Sans SC, Hiragino Sans GB, and Source Han Sans SC.

## Surface area

- [x] Web UI — internationalization / font rendering
- [ ] Daemon
- [ ] Desktop
- [ ] Packages (contracts, sidecar, platform)
- [ ] Tools (dev, pack)
- [ ] Skills / Design systems / Craft
- [ ] E2E tests
- [ ] Documentation

**Changed file:** `apps/web/src/index.css` — CSS custom property `--sans` override scoped to `:lang(zh|ja|ko)` selectors.

## Validation

### Actually ran (on Windows 11 + WSL2 + Chrome):

- [x] Switch UI language to 简体中文 — all buttons, labels, menus, and dialog text render correctly with Microsoft YaHei
- [x] Switch UI language back to English — confirmed no regression

### Planned (not yet verified):

- [ ] Switch UI language to 繁體中文
- [ ] Switch UI language to 日本語
- [ ] Switch UI language to 한국어
- [ ] Verify on macOS (should hit PingFang SC)
- [ ] Verify on Linux with Noto Sans SC installed
- [ ] Confirm Arabic/RTL UI remains unaffected

## Test plan

No automated test added — this is a pure CSS font-stack change with no logic. Visual verification in browser is the appropriate validation.