### PR TITLE
Fix Cursor Agent live model id parsing

### DIFF
--- a/apps/daemon/src/runtimes/defs/cursor-agent.ts
+++ b/apps/daemon/src/runtimes/defs/cursor-agent.ts
@@ -1,5 +1,31 @@
-import { DEFAULT_MODEL_OPTION, parseLineSeparatedModels } from './shared.js';
+import { DEFAULT_MODEL_OPTION } from './shared.js';
 import type { RuntimeAgentDef } from '../types.js';
+import type { RuntimeModelOption } from '../types.js';
+
+export function parseCursorAgentModels(stdout: string): RuntimeModelOption[] | null {
+  const lines = String(stdout || '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith('#'));
+  if (lines.length === 0) return null;
+
+  const out = [DEFAULT_MODEL_OPTION];
+  const seen = new Set<string>([DEFAULT_MODEL_OPTION.id]);
+  for (const line of lines) {
+    if (/^(available models|models)$/i.test(line)) continue;
+
+    const match = line.match(/^([A-Za-z0-9][A-Za-z0-9._/:@-]*)(?:\s+-\s+(.+))?$/);
+    if (!match) continue;
+    const id = match[1];
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+
+    const label = match[2]?.trim() || id;
+    out.push({ id, label });
+  }
+
+  return out.length > 1 ? out : null;
+}
 
 export const cursorAgentDef = {
     id: 'cursor-agent',
@@ -15,7 +41,7 @@ export const cursorAgentDef = {
       parse: (stdout) => {
         const trimmed = String(stdout || '').trim();
         if (!trimmed || /no models available/i.test(trimmed)) return null;
-        return parseLineSeparatedModels(trimmed);
+        return parseCursorAgentModels(trimmed);
       },
     },
     fallbackModels: [

--- a/apps/daemon/tests/runtimes/env-and-detection.test.ts
+++ b/apps/daemon/tests/runtimes/env-and-detection.test.ts
@@ -426,6 +426,42 @@ test('detectAgents marks Cursor Agent auth ok when cursor-agent status succeeds'
   }
 });
 
+test('detectAgents surfaces Cursor Agent model labels without putting labels in ids', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'od-cursor-model-labels-'));
+  try {
+    await withEnvSnapshot(['PATH', 'OD_AGENT_HOME'], async () => {
+      const bin = join(dir, process.platform === 'win32' ? 'cursor-agent.cmd' : 'cursor-agent');
+      if (process.platform === 'win32') {
+        writeFileSync(
+          bin,
+          '@echo off\r\nif "%~1"=="--version" echo 2026.05.16-test& exit /b 0\r\nif "%~1"=="models" (\r\n  echo Available models\r\n  echo auto - Auto\r\n  echo composer-2.5 - Composer 2.5 (current)\r\n  exit /b 0\r\n)\r\nif "%~1"=="status" echo Authenticated& exit /b 0\r\nexit /b 0\r\n',
+        );
+      } else {
+        writeFileSync(
+          bin,
+          '#!/bin/sh\nif [ "$1" = "--version" ]; then echo "2026.05.16-test"; exit 0; fi\nif [ "$1" = "models" ]; then printf "%s\\n" "Available models" "auto - Auto" "composer-2.5 - Composer 2.5 (current)"; exit 0; fi\nif [ "$1" = "status" ]; then echo "Authenticated"; exit 0; fi\nexit 0\n',
+        );
+        chmodSync(bin, 0o755);
+      }
+      process.env.PATH = dir;
+      process.env.OD_AGENT_HOME = dir;
+
+      const agents = await detectAgents();
+      const detected = agents.find((agent) => agent.id === 'cursor-agent');
+
+      assert.equal(detected?.available, true);
+      assert.equal(detected?.modelsSource, 'live');
+      assert.deepEqual(detected?.models, [
+        { id: 'default', label: 'Default (CLI config)' },
+        { id: 'auto', label: 'Auto' },
+        { id: 'composer-2.5', label: 'Composer 2.5 (current)' },
+      ]);
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('detectAgents keeps Cursor Agent available when auth is missing', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'od-cursor-auth-missing-'));
   try {

--- a/apps/daemon/tests/runtimes/registry-and-args.test.ts
+++ b/apps/daemon/tests/runtimes/registry-and-args.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest';
 import {
-  AGENT_DEFS, assert, chmodSync, codex, detectAgents, join, mkdtempSync, rmSync, tmpdir, withEnvSnapshot, withPlatform, writeFileSync,
+  AGENT_DEFS, assert, chmodSync, codex, cursorAgent, detectAgents, join, mkdtempSync, rmSync, tmpdir, withEnvSnapshot, withPlatform, writeFileSync,
 } from './helpers/test-helpers.js';
 import { readLocalAgentProfileDefs } from '../../src/runtimes/registry.js';
 
@@ -323,6 +323,23 @@ test('codex picker includes gpt-5.1 model family', () => {
 
   assert.equal(pickerModels.has('gpt-5.1'), true);
   assert.equal(pickerModels.has('gpt-5.1-codex-mini'), true);
+});
+
+test('cursor-agent parses live model ids separately from display labels', () => {
+  assert.ok(cursorAgent.listModels, 'cursor-agent must define live model discovery');
+  const parsed = cursorAgent.listModels.parse([
+    'Available models',
+    'auto - Auto',
+    'composer-2.5 - Composer 2.5 (current)',
+    'grok-4.3 - Grok 4.3 1M',
+  ].join('\n'));
+
+  assert.deepEqual(parsed, [
+    { id: 'default', label: 'Default (CLI config)' },
+    { id: 'auto', label: 'Auto' },
+    { id: 'composer-2.5', label: 'Composer 2.5 (current)' },
+    { id: 'grok-4.3', label: 'Grok 4.3 1M' },
+  ]);
 });
 
 // Recent Codex CLI versions reject a bare `-` argv sentinel; passing it


### PR DESCRIPTION
## Why

The Cursor Agent model picker started receiving live model rows in the form `id - display label`, for example `composer-2.5 - Composer 2.5 (current)`. The daemon treated each full row as the model id, so selecting a listed model saved and spawned Cursor Agent with `--model "composer-2.5 - Composer 2.5 (current)"`, which Cursor rejects even though `composer-2.5` is available.

This fixes the user-facing failure where picking Cursor Agent live models from Settings / inline switcher immediately fails at run time.

## What users will see

Cursor Agent live model entries still show friendly labels such as `Composer 2.5 (current)`, but Open Design now passes only the model id such as `composer-2.5` to the CLI.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable. No UI layout changed.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/runtimes/registry-and-args.test.ts` (`cursor-agent parses live model ids separately from display labels`)
- Did the test go red on `main` and green on this branch? yes. The red run showed the old parser returning ids like `composer-2.5 - Composer 2.5 (current)` and even treating `Available models` as an id; the fixed branch returns `{ id: 'composer-2.5', label: 'Composer 2.5 (current)' }`.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/runtimes/registry-and-args.test.ts -t "cursor-agent parses live model ids"`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/runtimes/env-and-detection.test.ts -t "Cursor Agent model labels"`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- `pnpm --filter @open-design/daemon test` currently fails outside this change with 5 existing/adjacent failures: Claude guidance assertions expecting `/login` or `configured Claude profile` in `tests/chat-route.test.ts` / `tests/connection-test.test.ts`, plus `tests/origin-validation.test.ts` expecting OD_WEB_PORT origin allowance to return 200 but receiving 403.
