### PR TITLE
docs: document ACP runtime integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -734,6 +734,7 @@ open-design/
 │   ├── architecture.md            ← topologies, data flow, components
 │   ├── skills-protocol.md         ← extended SKILL.md od: frontmatter
 │   ├── agent-adapters.md          ← per-CLI detection + dispatch
+│   ├── new-agent-runtime-acp.md   ← ACP-over-stdio runtime integration guide
 │   ├── modes.md                   ← prototype / deck / template / design-system
 │   ├── references.md              ← long-form provenance
 │   ├── roadmap.md                 ← phased delivery

--- a/docs/agent-adapters.md
+++ b/docs/agent-adapters.md
@@ -1,8 +1,10 @@
 # Agent Adapters
 
-**Parent:** [`spec.md`](spec.md) · **Siblings:** [`architecture.md`](architecture.md) · [`skills-protocol.md`](skills-protocol.md) · [`modes.md`](modes.md)
+**Parent:** [`spec.md`](spec.md) · **Siblings:** [`architecture.md`](architecture.md) · [`skills-protocol.md`](skills-protocol.md) · [`new-agent-runtime-acp.md`](new-agent-runtime-acp.md) · [`modes.md`](modes.md)
 
 The adapter layer is OD's most load-bearing design decision. We delegate the **entire agent loop** — model calls, tool use, context management, permission handling, resume, cancel — to the user's existing code agent CLI. OD's job is to detect it, feed it a skill + prompt + working directory, and stream its output back to the web UI.
+
+If you're adding a new ACP-backed runtime, start with [`new-agent-runtime-acp.md`](new-agent-runtime-acp.md) for the expected stdio transport, JSON-RPC message flow, and process lifecycle contract.
 
 > **Thesis:** The code agent space has already converged on a few strong implementations (Claude Code, Codex, Devin for Terminal, Cursor Agent, Gemini CLI, OpenCode, OpenClaw, Qoder CLI). Reimplementing another one is worse than just talking to all of them.
 >

--- a/docs/new-agent-runtime-acp.md
+++ b/docs/new-agent-runtime-acp.md
@@ -1,0 +1,116 @@
+# New agent runtime expectations: ACP over stdio
+
+This note documents the preferred integration shape for a new Open Design agent runtime.
+
+## Recommendation
+
+New agent runtimes should expose an **ACP over stdio** CLI mode.
+
+In practice, Open Design expects to spawn a local executable and speak JSON-RPC over the child process streams:
+
+```text
+Open Design daemon
+  └─ spawn your-agent acp
+       ├─ stdin  <- ACP JSON-RPC requests/responses
+       ├─ stdout -> ACP JSON-RPC responses/notifications
+       └─ stderr -> logs and diagnostics only
+```
+
+If the runtime's real implementation is a local or remote server, keep that detail behind a thin CLI wrapper:
+
+```text
+your-agent acp
+  └─ connects to your runtime server / SDK / model backend
+```
+
+That wrapper keeps Open Design on the standard ACP subprocess transport and avoids requiring a daemon-side network transport adapter.
+
+## Why stdio, not an ACP server?
+
+The ACP protocol uses JSON-RPC, but transport matters.
+
+The ACP transport documentation defines **stdio** as communication over standard input and standard output. In that transport, the client launches the agent as a subprocess, the agent reads from `stdin`, writes protocol messages to `stdout`, and writes logs to `stderr`.
+
+ACP's remote HTTP/WebSocket transport is still described as a draft/proposal rather than the established compatibility path. Open Design's implemented ACP adapters therefore use stdio subprocesses today.
+
+## Messages Open Design sends
+
+For `streamFormat: 'acp-json-rpc'`, Open Design currently drives a session with these JSON-RPC methods:
+
+1. `initialize`
+   - Sent first.
+   - Includes Open Design client metadata and `clientCapabilities`.
+2. `session/new`
+   - Creates a working session.
+   - Includes the project working directory.
+   - May include MCP server descriptors when the runtime is allowed to use Open Design-provided tools.
+3. `session/set_config_option` or `session/set_model` *(optional)*
+   - Sent when the user selected a non-default model.
+   - Open Design prefers `session/set_config_option` when `session/new` reports a model config option; otherwise it falls back to `session/set_model`.
+4. `session/prompt`
+   - Sends the composed user/system prompt as text content.
+   - A successful response marks the prompt as complete.
+5. `session/cancel`
+   - Sent on user cancellation when a session exists and stdin is still writable.
+
+## Messages Open Design expects from the agent
+
+The runtime should support the corresponding JSON-RPC responses and notifications:
+
+1. Response to `initialize`.
+2. Response to `session/new`.
+   - Must include a usable `sessionId`.
+   - Should report the current model if available.
+   - Should report model config options if model selection is supported through config options.
+3. Notifications using `session/update`.
+   - Open Design currently maps:
+     - `agent_thought_chunk` to thinking output.
+     - `agent_message_chunk` to assistant text output.
+4. Optional `session/request_permission` requests.
+   - Open Design auto-selects an approve/allow-style option when available.
+   - If no acceptable option is present, the turn fails fast.
+5. Response to `session/prompt`.
+   - Should include usage metadata when available.
+   - This response tells Open Design the turn is finished.
+
+## Process lifecycle expectations
+
+- Keep protocol messages on `stdout` parseable as JSON-RPC lines.
+- Write human-readable logs and diagnostics to `stderr`.
+- Return clear JSON-RPC errors for protocol failures.
+- After `session/prompt` completes, either exit cleanly when stdin closes or tolerate Open Design sending `SIGTERM` after a short grace period.
+- Implement `session/cancel` if possible. Open Design falls back to process termination when the transport is no longer usable.
+- Avoid interactive terminal prompts. If permission is required, use ACP permission requests instead.
+
+## Open Design adapter shape
+
+An ACP runtime definition in Open Design is intentionally small:
+
+```ts
+export const myAgentDef = {
+  id: 'my-agent',
+  name: 'My Agent',
+  bin: 'my-agent',
+  versionArgs: ['--version'],
+  fallbackModels: [{ id: 'default', label: 'default' }],
+  buildArgs: () => ['acp'],
+  streamFormat: 'acp-json-rpc',
+} satisfies RuntimeAgentDef;
+```
+
+Existing examples include Devin, Hermes, Kimi, Kiro, Kilo, and Vibe runtime definitions under `apps/daemon/src/runtimes/defs/`.
+
+## Fact sources
+
+- ACP transport documentation: <https://agentclientprotocol.com/protocol/transports>
+  - ACP uses JSON-RPC.
+  - The stdio transport uses standard input and standard output.
+  - In stdio mode, the client launches the agent as a subprocess.
+  - The agent reads from `stdin`, writes protocol messages to `stdout`, and uses `stderr` for logs.
+- ACP remote transport RFD: <https://agentclientprotocol.com/rfds/streamable-http-websocket-transport>
+  - Describes Streamable HTTP / WebSocket as the proposed remote transport direction.
+  - Notes that ACP's standard transport has historically been stdio and that a standard remote transport is still being defined.
+- Open Design implementation:
+  - `apps/daemon/src/acp.ts` implements the ACP JSON-RPC session lifecycle.
+  - `apps/daemon/src/server.ts` spawns ACP runtimes as child processes with piped stdio.
+  - `apps/daemon/src/runtimes/defs/*.ts` contains existing ACP runtime definitions using `streamFormat: 'acp-json-rpc'`.


### PR DESCRIPTION
## Why

I wrote this while clarifying how a custom agent runtime should integrate with Open Design. The pain addressed is ambiguity around whether new runtimes should expose a CLI/stdin-stdout ACP mode or an ACP server/client transport.

## What users will see

Users and runtime authors will see a new docs page explaining Open Design's preferred ACP over stdio integration shape, expected JSON-RPC messages, process lifecycle expectations, and source links.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — docs only.

## Bug fix verification

N/A — not a bug fix.

## Validation

- `pnpm guard` — failed before docs-only change validation completed: `@open-design/contracts` did not provide `extractComponentsManifest` imported by `apps/daemon/src/design-systems.ts`.
- `pnpm typecheck` — failed before docs-only change validation completed: `@open-design/registry-protocol` could not resolve `zod`; pnpm also reported local `node_modules` missing.