### PR TITLE
fix: prevent form help text truncation in left panel

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -14320,7 +14320,14 @@ button.ghost.mcp-copy-btn:hover:not(:disabled) {
   gap: 4px;
 }
 .qf-required { color: var(--accent); }
-.qf-help { font-size: 11px; color: var(--text-muted); margin-top: -2px; }
+.qf-help {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-top: -2px;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  line-height: 1.4;
+}
 .qf-options {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary

Fixes #2225

This PR fixes the truncation of form helper text in the left panel by adding proper word-wrapping CSS properties to the  class.

## Problem

Long helper text in the question form was being truncated and not fully visible in the narrow left panel, making it difficult for users to understand what input is expected.

## Solution

Added CSS properties to  to ensure text wraps properly:
- `word-wrap: break-word` - allows long words to break and wrap
- `overflow-wrap: break-word` - modern standard for word wrapping
- `line-height: 1.4` - improves readability of wrapped text

## Changes

- Modified `apps/web/src/index.css` to update the `.qf-help` style rule

## Testing

The fix ensures that:
- Long helper text wraps to multiple lines instead of being cut off
- Text remains fully readable in narrow panel widths
- No layout changes to the overall form structure
- Maintains consistent styling with the rest of the form

## Screenshots

Before: Helper text was truncated (see issue #2225)
After: Helper text wraps properly and is fully visible

## Notes

This is a minimal CSS-only fix that preserves the existing panel width and doesn't require tooltips or other UI changes, as suggested by the maintainer.