### PR TITLE
feat(skills): add existing-PPTX cleanup path to pptx-html-fidelity-audit

### DIFF
--- a/skills/pptx-html-fidelity-audit/SKILL.md
+++ b/skills/pptx-html-fidelity-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pptx-html-fidelity-audit
-description: Audit a python-pptx export against its source HTML deck, identify layout/content drift (footer overflow, cropped content, missing italic/em, lost styling, off-rhythm spacing), and re-export with strict footer-rail + cursor-flow layout discipline. Use this skill whenever the user has a .pptx that was generated from an HTML slide deck and asks to compare/audit/verify/fix the export — including phrases like "compare ppt with html", "fidelity audit", "fix the pptx", "ppt is cut off", "footer overlap", "italic missing in pptx", "re-export the deck", "pptx-html-fidelity-audit", or any case where a python-pptx → HTML round-trip needs verification or repair. Also trigger when the user shows you a deck.html and a deck.pptx side by side and is debugging visual differences.
+description: Audit a python-pptx export against its source HTML deck, identify layout/content drift (footer overflow, cropped content, missing italic/em, lost styling, off-rhythm spacing), and re-export with strict footer-rail + cursor-flow layout discipline. Also handles the inverse case — the user has ONLY an externally-authored .pptx with no HTML source and wants it cleaned up, redesigned, or refreshed — by ingesting the deck, diagnosing its design problems, reconstructing it as an Open Design HTML deck that preserves order and content, and re-exporting an editable .pptx. Use this skill whenever the user has a .pptx that was generated from an HTML slide deck and asks to compare/audit/verify/fix the export — phrases like "compare ppt with html", "fidelity audit", "fix the pptx", "ppt is cut off", "footer overlap", "italic missing in pptx", "re-export the deck", "pptx-html-fidelity-audit" — OR when the user hands you only a PowerPoint file and asks to "clean up this deck", "improve this PowerPoint", "redesign these slides", "refresh this presentation", "make this deck consistent", or there is no source HTML to audit against. Also trigger when the user shows you a deck.html and a deck.pptx side by side and is debugging visual differences.
 triggers:
   - "pptx fidelity"
   - "pptx audit"
@@ -9,6 +9,12 @@ triggers:
   - "footer overlap"
   - "verify pptx"
   - "html to pptx"
+  - "clean up this deck"
+  - "improve this powerpoint"
+  - "redesign these slides"
+  - "refresh this presentation"
+  - "no source html"
+  - "美化这个 ppt"
 od:
   mode: utility
   scenario: engineering
@@ -37,7 +43,21 @@ The user has:
 - A PPTX file generated from that deck via python-pptx (or similar).
 - A suspicion (or visible evidence) that the PPTX doesn't match the HTML — text bleeding into the footer, italic words gone flat, hero slides not centered, sections cropped, tag styling lost.
 
-If the user only has *one* of those two artifacts, this skill doesn't apply yet — first generate the missing one, or ask the user to provide it.
+### Two modes — pick by what the user has
+
+| What the user has | Mode | Go to |
+|---|---|---|
+| HTML deck **and** a .pptx generated from it | **Audit** — verify/repair drift | [Workflow](#workflow) below (unchanged) |
+| Only an externally-authored .pptx, **no HTML source** | **Reconstruction** — clean up / redesign | [Reconstruction workflow](#reconstruction-workflow-existing-pptx-cleanup) |
+| Only an HTML deck, no .pptx | Not this skill yet | Generate the .pptx first (the project's PPTX export does this), then return for an audit |
+
+The Audit mode assumes an HTML source of truth to measure the .pptx against.
+Reconstruction mode is for the common real-world case where the user was
+*handed* a PowerPoint file (built in PowerPoint/Keynote/Google Slides, no HTML
+anywhere) and wants it materially better while keeping the message, the slide
+order, and editable text. It does not audit against a source — it *rebuilds*
+the source as an Open Design HTML deck, then re-exports through the same
+disciplined pipeline.
 
 ## Why this is hard (and why a skill helps)
 
@@ -189,9 +209,99 @@ Zero violations is the gate for "this re-export is shippable". Don't claim the a
 
 ---
 
+## Reconstruction workflow (existing-PPTX cleanup)
+
+Use this when the user has **only a .pptx and no HTML source**. The goal is a
+materially better, still-editable PowerPoint that preserves the message, the
+slide order, and all factual content. It reuses the same extractor, the same
+re-export pipeline, and the same verifier as Audit mode — only the middle
+(rebuild instead of compare) differs. Five steps; don't skip any.
+
+### R1 — Extract content and assets
+
+```
+python scripts/extract_pptx.py <deck.pptx> -o pptx_dump.json --assets-dir assets/
+```
+
+`--assets-dir` is required here (unlike Audit mode): the dump now also carries
+per-slide `notes`, per-shape `table.rows`, and per-shape `image` metadata, and
+the image blobs are written into `assets/` so the rebuilt deck can re-embed
+logos and charts. This is the ground truth — the deck's real content, not its
+intended content.
+
+### R2 — Diagnose design quality (not just rails)
+
+Build the audit table using the existing format and severity rubric from Step
+3 / `references/audit-table-template.md`, but scored against *design-quality*
+problems rather than only rail overflow:
+
+- inconsistent fonts / too many families
+- colour drift, accidental near-duplicate colours, low contrast
+- overcrowded slides, wall-of-text, no whitespace discipline
+- weak or missing visual hierarchy, inconsistent title placement
+- mismatched chart/table styling, inconsistent number formats
+- low-quality decorative images, stock-art clutter
+- slides that should be split, merged, or moved to an appendix
+
+Severity reuses 🔴/🟠/🟡/🟢. After the table, write the 2–3 systemic causes —
+same discipline as Audit mode: a redesign that names the systemic cause is
+smaller and more consistent than per-slide patching.
+
+### R3 — Choose a reconstruction strategy
+
+| Strategy | Use when |
+|---|---|
+| Light edit | Deck is mostly clean; only formatting/consistency fixes needed |
+| Full rebuild | Deck is messy/inconsistent; needs a real redesign |
+| **Hybrid (default)** | Preserve complex charts/images/tables from `assets/` as-is; rebuild text, layout, and hierarchy around them |
+
+Default to **hybrid**. Never invent data, claims, citations, logos, or brand
+assets. Any content that cannot be confidently preserved or interpreted goes
+into the risks file (R5), not into a guess.
+
+### R4 — Reconstruct as an Open Design HTML deck
+
+Rebuild the deck as a single-file HTML deck using the `<section class="slide">`
+convention this skill already expects (see the example in *When this skill
+applies*). Reuse a theme from `design-templates/html-ppt/` so typography,
+colour, and spacing come from one token system instead of the source deck's
+drift. Hard rules:
+
+- Preserve slide order unless the user explicitly asks to restructure; if a
+  reorder genuinely improves the executive flow, propose it in the change log
+  rather than doing it silently.
+- Preserve every factual string, number, table (`table.rows`), and speaker
+  note (`notes`) from the dump. Re-embed images from `assets/` by filename.
+- Improve hierarchy, alignment, whitespace, and headlines so each slide leads
+  with its takeaway. Keep ≤2 font families. Don't shrink body text below
+  readable size just to fit — split the slide instead.
+- Carry speaker notes into the HTML deck's presenter-notes mechanism; if a
+  note cannot be carried, list it in the risks file.
+
+### R5 — Re-export, gate, and deliver
+
+Hand the rebuilt HTML to the project's existing PPTX export (the "Export as
+PPTX" action / `handleExportAsPptx`). That pipeline already applies Step 4's
+footer-rail + cursor-flow discipline and runs `scripts/verify_layout.py` as a
+mandatory gate. Then:
+
+- Confirm `verify_layout.py` exits 0 (zero rail violations) on the new file.
+- Run `extract_pptx.py` on the input and the output and confirm the slide
+  count matches (unless a documented split/merge changed it on purpose).
+- Produce the two deliverables: a change log from
+  `references/change-log-template.md` and a fidelity-risk list from
+  `references/risks-template.md`.
+
+Acceptance is the same bar as the project mandate: the refreshed deck opens
+cleanly in PowerPoint, stays editable (real text boxes, not flattened images),
+preserves the source message and slide order, looks materially better, and
+ships with a transparent record of what changed and what needs manual review.
+
+---
+
 ## Output to the user
 
-After Step 5 passes, report:
+After Step 5 (Audit) **or** R5 (Reconstruction) passes, report:
 
 1. **Audit table** — the table from Step 3.
 2. **Root causes** — 1-paragraph systemic explanation.
@@ -199,23 +309,31 @@ After Step 5 passes, report:
 4. **Verification** — "0 rail violations across N slides, file size X KB".
 5. **Path** — absolute path to the re-exported `.pptx`.
 
+For **Reconstruction** runs, also deliver two files alongside the `.pptx`:
+
+6. **Change log** — `change-log.md` written from `references/change-log-template.md`: summary + a per-slide change table.
+7. **Risks / manual review** — `issues.md` written from `references/risks-template.md`: every content item that could not be confidently preserved (charts kept as images, unverifiable notes, ambiguous data), so the user knows exactly what to eyeball.
+
 The user is reading for two reasons: confirming the visible bugs are fixed, and trusting the systemic fix is right. Cover both.
 
 ---
 
 ## Bundled resources
 
-- `scripts/extract_pptx.py` — dump every shape on every slide as JSON. Run before the audit. **Important:** also run on the *original* export to compare, and on the *re-exported* one to confirm.
+- `scripts/extract_pptx.py` — dump every shape on every slide as JSON. Run before the audit. **Important:** also run on the *original* export to compare, and on the *re-exported* one to confirm. For Reconstruction, add `--assets-dir` to also pull speaker notes, table cells, and image blobs.
 - `scripts/verify_layout.py` — post-export rail checker. Returns nonzero exit code on violations so it slots into a CI pipeline if needed.
 - `references/layout-discipline.md` — the full footer-rail + cursor-flow rule set with code snippets for each common slide type (hero, content, pipeline, two-column, observation grid).
 - `references/font-discipline.md` — five-layer font audit: mapping, presence, variable-vs-static traps, the three XML language slots (`latin` / `ea` / `cs`), CJK + Latin italic interaction.
 - `references/audit-table-template.md` — copy-pasteable table template with severity legend.
+- `references/change-log-template.md` — Reconstruction deliverable: summary + per-slide change table.
+- `references/risks-template.md` — Reconstruction deliverable: fidelity-risk / manual-review list.
 
 Read the references when:
 
 - The deck has slide types beyond what the SKILL.md covers (multi-column dashboards, embedded images, charts) → `layout-discipline.md`.
 - The audit shows 🟡 typography issues — italic missing, CJK falling back, unexpected `Calibri` / `Microsoft JhengHei` in the XML → `font-discipline.md`.
 - You want to drop the audit table directly into a report or markdown deliverable → `audit-table-template.md`.
+- You finished a Reconstruction run and need the user-facing deliverables → `change-log-template.md`, `risks-template.md`.
 
 ---
 

--- a/skills/pptx-html-fidelity-audit/references/change-log-template.md
+++ b/skills/pptx-html-fidelity-audit/references/change-log-template.md
@@ -1,0 +1,38 @@
+# Change Log Template (Reconstruction deliverable)
+
+Copy this into `change-log.md` next to the re-exported `.pptx`. Keep it
+factual and terse — it is the user's record of exactly what changed and why,
+and the basis for trusting the redesign preserved their message.
+
+---
+
+# Change Log
+
+## Summary
+
+- One or two sentences: what was redesigned and the systemic goal
+  (e.g. "Rebuilt for one type system and consistent hierarchy; preserved
+  original slide order and all factual content").
+- State the strategy used: light edit / full rebuild / **hybrid**.
+- State the theme used from `design-templates/html-ppt/`.
+
+## Slide-Level Changes
+
+| Slide | Changes |
+|---|---|
+| 1 | Improved title hierarchy and spacing |
+| 2 | Converted dense paragraph into a three-part structure |
+| 3 | Standardized chart styling; preserved source values |
+| … | … |
+
+## Preserved As-Is
+
+- Slide order: unchanged (or: describe and justify any reorder).
+- Speaker notes: carried into presenter notes (or: list slides where notes
+  could not be carried — these also appear in `issues.md`).
+- Charts / tables / logos: list which were preserved from `assets/` verbatim.
+
+## Reorder / Restructure (only if done)
+
+- If slides were split, merged, or moved to an appendix, list each change
+  with the reason. If none, write "None — original order preserved."

--- a/skills/pptx-html-fidelity-audit/references/risks-template.md
+++ b/skills/pptx-html-fidelity-audit/references/risks-template.md
@@ -1,0 +1,42 @@
+# Risks / Manual-Review Template (Reconstruction deliverable)
+
+Copy this into `issues.md` next to the re-exported `.pptx`. Its job is to be
+honest about what the redesign could *not* confidently preserve, so the user
+knows exactly where to put their eyes before sending the deck.
+
+A Reconstruction run is only acceptable if this file lists every item that was
+flattened, dropped, approximated, or could not be verified. An empty section
+must say "None" explicitly — silence is not acceptance.
+
+---
+
+# Risks / Manual Review
+
+## Content not fully preserved
+
+- Slide N: chart was preserved as an image because the source data was not
+  recoverable from the .pptx — values cannot be edited in PowerPoint.
+- Slide N: table re-typeset from extracted cell text; verify merged cells /
+  number formatting against the original.
+
+## Fidelity risks (HTML → PPTX export)
+
+- Fonts: any face that may substitute on the user's machine (non-standard
+  family with no embedded fallback).
+- Speaker notes: list any slide whose notes could not be carried over.
+- Animations / transitions / embedded video or audio from the original: not
+  reconstructed (state explicitly if the source had any).
+- Anything `verify_layout.py` flagged and how it was resolved (or that it
+  exited 0 across N slides).
+
+## Could not interpret / assumptions made
+
+- Any ambiguous content where intent was inferred — state the assumption so
+  the user can correct it. Never invent data, logos, or citations to fill a
+  gap; record the gap here instead.
+
+## Manual checks recommended before sending
+
+- Open in PowerPoint (not just LibreOffice/preview) and confirm: no clipped
+  text, images/logos intact, slide count = <input count>, notes present where
+  expected.

--- a/skills/pptx-html-fidelity-audit/scripts/extract_pptx.py
+++ b/skills/pptx-html-fidelity-audit/scripts/extract_pptx.py
@@ -5,11 +5,21 @@ Extract every shape on every slide of a .pptx into a JSON dump.
 Usage:
     python extract_pptx.py <path/to/deck.pptx>            # prints to stdout
     python extract_pptx.py <path/to/deck.pptx> -o dump.json
+    python extract_pptx.py <path/to/deck.pptx> -o dump.json --assets-dir assets/
 
 The dump captures the *actual* state of the export — text content, position,
 size, and per-run typography (font name, size, bold, italic, color). Use this
 as the ground truth for the fidelity audit; do not trust the export script's
 intent.
+
+For the reconstruction workflow (rebuilding an externally-authored deck that
+has no HTML source), the dump also carries the content a faithful redesign
+must preserve: per-slide speaker `notes`, per-shape `table` cell text, and
+per-shape `image` metadata. Pass `--assets-dir <dir>` to also write the image
+blobs to disk so the rebuilt deck can re-embed logos/charts. All of these are
+*additive* — existing keys are unchanged, so the audit workflow and the
+`extract_pptx.py deck.pptx > pptx_dump.json` invocation behave exactly as
+before.
 
 Coordinates are reported in inches (rounded to 3 decimals) so they're
 human-readable when comparing against rails like CONTENT_MAX_Y = 6.70".
@@ -24,6 +34,7 @@ from pathlib import Path
 try:
     from pptx import Presentation
     from pptx.util import Emu
+    from pptx.enum.shapes import MSO_SHAPE_TYPE
 except ImportError:
     sys.stderr.write(
         "python-pptx is required. Install with: pip install python-pptx\n"
@@ -73,7 +84,36 @@ def extract_runs(text_frame) -> list[dict]:
     return runs
 
 
-def extract_shape(shape) -> dict:
+def extract_table(shape) -> dict:
+    """Cell text as a row-major matrix. Geometry stays on the shape dict."""
+    table = shape.table
+    rows = []
+    for row in table.rows:
+        rows.append([cell.text for cell in row.cells])
+    return {"rows": rows}
+
+
+def extract_image(shape, *, assets_dir: Path | None,
+                  slide_index: int, shape_index: int) -> dict:
+    """Image metadata; optionally write the blob to assets_dir.
+
+    When assets_dir is None the blob is not written and `filename` is null,
+    but the dump still records that an image occupies this shape so the
+    reconstruction can decide whether it needs the asset re-extracted.
+    """
+    img = shape.image
+    info: dict = {"content_type": img.content_type, "filename": None}
+    if assets_dir is not None:
+        ext = (img.ext or "bin").lstrip(".")
+        name = f"slide-{slide_index:03d}-img-{shape_index:03d}.{ext}"
+        assets_dir.mkdir(parents=True, exist_ok=True)
+        (assets_dir / name).write_bytes(img.blob)
+        info["filename"] = name
+    return info
+
+
+def extract_shape(shape, *, assets_dir: Path | None = None,
+                   slide_index: int = 0, shape_index: int = 0) -> dict:
     data = {
         "name": shape.name,
         "shape_type": str(shape.shape_type) if shape.shape_type is not None else None,
@@ -89,10 +129,30 @@ def extract_shape(shape) -> dict:
         tf = shape.text_frame
         data["text"] = tf.text
         data["runs"] = extract_runs(tf)
+    if shape.has_table:
+        data["table"] = extract_table(shape)
+    if shape.shape_type == MSO_SHAPE_TYPE.PICTURE:
+        try:
+            data["image"] = extract_image(
+                shape, assets_dir=assets_dir,
+                slide_index=slide_index, shape_index=shape_index,
+            )
+        except (AttributeError, KeyError, ValueError):
+            # Linked/placeholder pictures with no embedded blob: record the
+            # slot so the redesign knows an image was here, even if we can't
+            # recover the bytes.
+            data["image"] = {"content_type": None, "filename": None}
     return data
 
 
-def extract_pptx(path: Path) -> dict:
+def slide_notes(slide) -> str | None:
+    if not slide.has_notes_slide:
+        return None
+    text = slide.notes_slide.notes_text_frame.text
+    return text if text.strip() else None
+
+
+def extract_pptx(path: Path, assets_dir: Path | None = None) -> dict:
     prs = Presentation(str(path))
     canvas = {
         "width_in": emu_to_in(prs.slide_width),
@@ -100,8 +160,15 @@ def extract_pptx(path: Path) -> dict:
     }
     slides = []
     for i, slide in enumerate(prs.slides, 1):
-        shapes = [extract_shape(s) for s in slide.shapes]
-        slides.append({"index": i, "shapes": shapes})
+        shapes = [
+            extract_shape(s, assets_dir=assets_dir, slide_index=i, shape_index=j)
+            for j, s in enumerate(slide.shapes, 1)
+        ]
+        slides.append({
+            "index": i,
+            "notes": slide_notes(slide),
+            "shapes": shapes,
+        })
     return {
         "source": str(path),
         "canvas": canvas,
@@ -114,12 +181,16 @@ def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
     ap.add_argument("path", type=Path, help=".pptx file to extract")
     ap.add_argument("-o", "--output", type=Path, help="write JSON to this path; default stdout")
+    ap.add_argument("--assets-dir", type=Path, default=None,
+                    help="if set, write embedded image blobs into this directory "
+                         "and record their filenames in the dump (for the "
+                         "reconstruction workflow). Default: do not extract blobs.")
     args = ap.parse_args()
 
     if not args.path.exists():
         ap.error(f"file not found: {args.path}")
 
-    data = extract_pptx(args.path)
+    data = extract_pptx(args.path, assets_dir=args.assets_dir)
     payload = json.dumps(data, ensure_ascii=False, indent=2)
     if args.output:
         args.output.write_text(payload, encoding="utf-8")


### PR DESCRIPTION
## Why

The `pptx-html-fidelity-audit` skill explicitly bails when the user has only a `.pptx` and no HTML source ("If the user only has *one* of those two artifacts, this skill doesn't apply yet"). That branch excludes a common real-world workflow: a user is handed an externally-authored deck and wants to clean it up, but there is no matching HTML source to audit against.

The pain: Open Design already ships strong PPTX *origination* (deck skills + agent-driven `handleExportAsPptx` + `verify_layout` gate), but there was no path to *ingest and improve an existing, externally-authored deck*. That bailed-out branch is exactly the real-world "user handed a messy PowerPoint and needs it improved" workflow. This adds that path by reusing the existing extractor, the existing re-export pipeline, and the existing geometry gate — no new tooling surface.

## What users will see

When a user hands Open Design only a `.pptx` (no HTML source) and asks to "clean up this deck" / "redesign these slides" / "refresh this presentation", the agent now: extracts the deck (text, speaker notes, tables, image blobs), diagnoses its design problems, rebuilds it as an Open Design HTML deck preserving slide order and content, re-exports an editable `.pptx` through the existing gated pipeline, and delivers a change log + a fidelity-risk list. No new UI, CLI, or settings — it's a new branch inside an existing skill, triggered by natural-language intent.

## Surface area

- [x] **Extension point** — change to `skills/pptx-html-fidelity-audit` (skill body + bundled extractor script + two new reference templates)
- [ ] UI / Keyboard shortcut / CLI / API / i18n / dependency / default-behavior change — none

## Screenshots

N/A — no UI surface. The change is a skill workflow + a Python helper script under `skills/`.

## Bug fix verification

Not a bug fix; no red spec applicable. Local validation performed:

- `pnpm guard` exit 0 (residual-JS check passes — change is Python-under-`skills/` + Markdown, no new project-owned TS/JS).
- `pnpm typecheck` exit 0 across the workspace. One regression introduced by this PR was caught and fixed: the landing-page Astro content collection parses `SKILL.md` frontmatter with strict `js-yaml`, which rejected a bare colon-space in the new `description`; reworded so both strict `js-yaml` and the daemon's lenient `parseFrontmatter` accept it.
- Extractor round-trip proven on a synthesized messy deck: `--assets-dir` run captured speaker notes, table cell matrix, and wrote the image blob; legacy stdout invocation keeps all original keys (`image.filename: null`) — fully backward-compatible.
- `verify_layout.py` unchanged and still gates correctly (flagged the deliberately-overcrowded slide).
- The daemon's real `parseFrontmatter` (the `listSkills()` code path) loads the edited skill: `name`, `od.mode: utility`, `od.scenario: engineering`, updated description, and all new triggers including the CJK one.

### Changes
- `skills/pptx-html-fidelity-audit/SKILL.md` — two-mode branch (Audit vs. Reconstruction) replacing the single-artifact bail; new 5-step Reconstruction workflow; frontmatter `description`/`triggers` updated.
- `skills/pptx-html-fidelity-audit/scripts/extract_pptx.py` — additive capture of per-slide speaker notes, per-shape table cells, and image metadata; optional `--assets-dir` to write image blobs. Existing keys and the `extract_pptx.py deck.pptx > dump.json` invocation are unchanged.
- `skills/pptx-html-fidelity-audit/references/change-log-template.md`, `references/risks-template.md` — new Reconstruction deliverable templates.
