### PR TITLE
feat(landing-page): add /tutorials/ channel for YouTube content

### DIFF
--- a/apps/landing-page/app/_components/header.tsx
+++ b/apps/landing-page/app/_components/header.tsx
@@ -20,7 +20,7 @@ const ext = {
 
 export interface HeaderProps {
   /** Nav highlight target. `'home'` is the default for `/`. */
-  active?: 'home' | 'skills' | 'systems' | 'templates' | 'craft' | 'blog';
+  active?: 'home' | 'skills' | 'systems' | 'templates' | 'craft' | 'tutorials' | 'blog';
   /**
    * Live counts from the Markdown catalogs. Required so we can never
    * silently render stale fallback numbers when a caller forgets to
@@ -82,6 +82,11 @@ export function Header({
             <li>
               <a href='/craft/' className={linkClass('craft')}>
                 Craft<span className='num'>{counts.craft}</span>
+              </a>
+            </li>
+            <li>
+              <a href='/tutorials/' className={linkClass('tutorials')}>
+                Tutorials
               </a>
             </li>
             <li>

--- a/apps/landing-page/app/content.config.ts
+++ b/apps/landing-page/app/content.config.ts
@@ -87,4 +87,26 @@ const blog = defineCollection({
   }),
 });
 
-export const collections = { skills, systems, craft, templates, blog };
+// Tutorials live in `app/content/tutorials/*.md`. Each entry maps to a
+// single YouTube video and renders an in-page player on `/tutorials/<slug>/`.
+// We embed via `https://www.youtube-nocookie.com/embed/<youtubeId>` so the
+// page does not require a cookie consent banner.
+const tutorials = defineCollection({
+  loader: glob({
+    pattern: ['*.md', '!_*.md'],
+    base: './app/content/tutorials',
+  }),
+  schema: z.object({
+    title: z.string(),
+    youtubeId: z.string().regex(/^[\w-]{11}$/, 'youtubeId must be 11 chars'),
+    summary: z.string(),
+    date: z.coerce.date(),
+    category: z.enum(['Getting started', 'Tutorial', 'Demo', 'Review', 'Community']),
+    durationSeconds: z.number().int().positive(),
+    author: z.string(),
+    official: z.boolean().default(false),
+    thumbnail: z.string().url().optional(),
+  }),
+});
+
+export const collections = { skills, systems, craft, templates, blog, tutorials };

--- a/apps/landing-page/app/content/tutorials/open-design-31-skills-72-systems-popular-ai.md
+++ b/apps/landing-page/app/content/tutorials/open-design-31-skills-72-systems-popular-ai.md
@@ -1,0 +1,19 @@
+---
+title: 'Open Design — 31 Skills, 72 Design Systems, Apache 2.0'
+youtubeId: XD86FRkGfsI
+summary: Popular AI Tools positions Open Design as the free, Apache-2.0 alternative to Claude Design's $20–$200/mo paid tier — local-first, model-agnostic, and shipped with 31 professional skills and 72 brand-grade design systems.
+date: 2026-05-02
+category: Demo
+durationSeconds: 628
+author: Popular Ai Tools
+official: false
+---
+
+Popular AI Tools' overview of Open Design as the licensed, packaged alternative to Claude Design — focused on what you get out of the box.
+
+The video covers:
+
+- Why Apache 2.0 matters versus Claude Design's paid tiers ($20–$200/mo)
+- The 31 professional skills shipped in the repo
+- The 72 brand-grade design systems and what they unlock
+- Local-first runtime: no SaaS, no key sharing, no vendor lock-in

--- a/apps/landing-page/app/content/tutorials/open-design-design-engine-codedigipt.md
+++ b/apps/landing-page/app/content/tutorials/open-design-design-engine-codedigipt.md
@@ -1,0 +1,19 @@
+---
+title: 'Open Design — Turn AI Agents Into a Full Design Engine'
+youtubeId: Z9_ruLqDJkM
+summary: Codedigipt walks through Open Design as an open-source alternative to Claude Design — covering multi-AI tool support, the built-in design systems library, and how reusable skills compose into a full design engine.
+date: 2026-05-03
+category: Demo
+durationSeconds: 924
+author: Codedigipt
+official: false
+---
+
+Codedigipt's longer-form walkthrough of Open Design, focused on the "AI agents as a design engine" angle.
+
+What's covered:
+
+- Multi-AI tool support — Claude, Codex, Cursor, Gemini CLI, DeepSeek
+- Built-in design systems and how they translate prompts into brand-faithful UI
+- Reusable skills as a composable layer above the agent
+- A full end-to-end demo from prompt to output

--- a/apps/landing-page/app/content/tutorials/open-design-feature-tour-silicon-hotpot.md
+++ b/apps/landing-page/app/content/tutorials/open-design-feature-tour-silicon-hotpot.md
@@ -1,0 +1,25 @@
+---
+title: 'Open Design 全功能巡游：PPT、原型、生图、视频，还有桌面宠物'
+youtubeId: iFoPlwKTwrU
+summary: 硅基麻辣拌 在 Open Design 从 6K 冲到 16K Star 的窗口期，把项目当时所有能跑的能力——PPT、海报、App 原型、草图生图、HyperFrame 动效、视频、桌面宠物——一口气过了一遍。
+date: 2026-05-03
+category: Demo
+durationSeconds: 783
+author: 硅基麻辣拌
+official: false
+---
+
+硅基麻辣拌 给 Open Design 做的一次"宽度优先"的能力巡游——视频带时间戳，可以按需跳到自己最想看的能力。
+
+章节速览：
+
+- 00:00 — Claude Design 太贵？开源平替来了
+- 00:54 — 本地部署 + 接入 Codex
+- 02:05 — 首页：PPT、海报、原型、动效全都有
+- 03:26 — 实测做 PPT：先问需求再生成
+- 05:59 — 灵魂手绘变成图
+- 07:09 — 草图秒变 App 原型
+- 08:09 — 代码生成动画：SVG + CSS
+- 09:29 — 生图、视频、HyperFrame 动态演示
+- 10:13 — 桌面宠物
+- 12:03 — 支持 Codex / Claude Code / Cursor / OpenCode

--- a/apps/landing-page/app/content/tutorials/open-design-full-walkthrough-yuya-mei.md
+++ b/apps/landing-page/app/content/tutorials/open-design-full-walkthrough-yuya-mei.md
@@ -1,0 +1,19 @@
+---
+title: '开源版 Claude Design？Open Design 完整体验'
+youtubeId: WDD4QsOB_78
+summary: Yuya Mei 把 Open Design 当成一个 local-first 的 Claude Design alternative 来使用，连接 Claude Code、Codex、Cursor、Gemini CLI、DeepSeek 把已有的 AI coding workflow 升级成完整的设计引擎。
+date: 2026-05-06
+category: Demo
+durationSeconds: 691
+author: By Yuya Mei
+official: false
+---
+
+Yuya Mei 把 Open Design 跟自己已经在用的多家 coding agent（Claude Code / Codex / Cursor / Gemini CLI / DeepSeek）串到一起，演示同一份产品需求在不同后端下的产出差异。
+
+重点段落：
+
+- 为什么"模型可替换"这个属性会改变整个设计工作流
+- 接入不同 coding agent 时的实际感受与产出质量
+- Skills 和 Design Systems 在跨模型场景里的兜底作用
+- 适合谁、不适合谁的真实判断

--- a/apps/landing-page/app/content/tutorials/open-design-in-20-minutes-coding-menace.md
+++ b/apps/landing-page/app/content/tutorials/open-design-in-20-minutes-coding-menace.md
@@ -1,0 +1,22 @@
+---
+title: 'Open Design in 20 Minutes — Full Setup + Demo'
+youtubeId: QOqWZzecjuY
+summary: CodingMenace's hands-on tour from first impressions through full installation, then walks you through creating prototypes — a complete getting-started session in just over 20 minutes.
+date: 2026-05-05
+category: Getting started
+durationSeconds: 1324
+author: CodingMenace
+official: false
+---
+
+CodingMenace's hands-on getting-started session — from first impressions through install to your first generated prototype, all inside 22 minutes.
+
+Chapter map:
+
+- 00:00 — First impressions
+- 01:23 — Exploring features
+- 07:31 — Installing Open Design
+- 13:02 — Creating prototypes
+- 21:31 — Closing thoughts
+
+If you'd rather watch one video before deciding whether to clone the repo, this is the one.

--- a/apps/landing-page/app/content/tutorials/open-design-install-demo-systems-chase-ai.md
+++ b/apps/landing-page/app/content/tutorials/open-design-install-demo-systems-chase-ai.md
@@ -13,10 +13,9 @@ Chase AI's structured tutorial on Open Design — every section gated by a times
 
 Chapter map:
 
-- 00:00 — What is Open Design
+- 00:00 — Open Design
 - 03:17 — Install + demo
 - 08:31 — Design systems
-- 14:06 — Dashboard
 - 12:40 — Final verdict
 
 Chase frames Open Design as building on the foundation laid by Huashu Design — same surface area, but with a GUI that mirrors Claude Design's UX.

--- a/apps/landing-page/app/content/tutorials/open-design-install-demo-systems-chase-ai.md
+++ b/apps/landing-page/app/content/tutorials/open-design-install-demo-systems-chase-ai.md
@@ -1,0 +1,22 @@
+---
+title: 'Another Open Source Repo Just Cloned Claude Design'
+youtubeId: BGQ9i3fvNds
+summary: Chase AI takes Open Design through install, demo, design systems, and dashboard in one structured tutorial — with a candid verdict on whether it's worth your time today.
+date: 2026-05-01
+category: Tutorial
+durationSeconds: 827
+author: Chase AI
+official: false
+---
+
+Chase AI's structured tutorial on Open Design — every section gated by a timestamp so you can skip straight to whichever piece you want to learn.
+
+Chapter map:
+
+- 00:00 — What is Open Design
+- 03:17 — Install + demo
+- 08:31 — Design systems
+- 14:06 — Dashboard
+- 12:40 — Final verdict
+
+Chase frames Open Design as building on the foundation laid by Huashu Design — same surface area, but with a GUI that mirrors Claude Design's UX.

--- a/apps/landing-page/app/content/tutorials/open-design-overview-worldofai.md
+++ b/apps/landing-page/app/content/tutorials/open-design-overview-worldofai.md
@@ -1,0 +1,19 @@
+---
+title: 'Open Source Claude Design — Fully Free AI Design System'
+youtubeId: 8XcbyliBwc4
+summary: WorldofAI breaks down how Open Design works, why the project blew up on GitHub, and how to use it to generate landing pages, pitch decks, and mobile apps without locking into a single model or paid subscription.
+date: 2026-05-05
+category: Demo
+durationSeconds: 707
+author: WorldofAI
+official: false
+---
+
+WorldofAI's overview of Open Design as the open-source alternative to Claude Design — what it is, who it's for, and what shipping with it actually looks like.
+
+The video covers:
+
+- Why Open Design changes the calculus for developers and designers building with AI
+- Generating stunning landing pages, pitch decks, and mobile apps from a single prompt
+- The model-portability story: Claude, Codex, Cursor, Gemini CLI, DeepSeek
+- Live walkthrough of a real prototype generated end-to-end

--- a/apps/landing-page/app/content/tutorials/open-design-prototype-design-ai-suifeng.md
+++ b/apps/landing-page/app/content/tutorials/open-design-prototype-design-ai-suifeng.md
@@ -1,0 +1,19 @@
+---
+title: 'Open Design 基础用法：免费开源 AI 原型设计'
+youtubeId: iIHo_FVDIe0
+summary: AI随风 把 Open Design 当 Claude Design / Google Stitch 的开源平替来上手——从 git clone 到本地 CLI（Claude Code / Codex）接入，再到内置 Skills 与品牌设计风格的实操。
+date: 2026-05-04
+category: Getting started
+durationSeconds: 704
+author: AI随风
+official: false
+---
+
+AI随风 的 Open Design 基础用法手把手教程，定位非常清楚：开源、免费、可本地部署、模型自定义。
+
+视频特点：
+
+- 完整跑通 `git clone → corepack pnpm` 这条路径
+- 自动接 Claude Code、Codex 等本地 CLI 的实测体验
+- 内置 Skills 与几十个品牌网站设计风格如何取用
+- 用同一份需求做出原型 / 图片 / 视频 / PPT 四种产出

--- a/apps/landing-page/app/content/tutorials/open-design-replacing-claude-design-jack-roberts.md
+++ b/apps/landing-page/app/content/tutorials/open-design-replacing-claude-design-jack-roberts.md
@@ -1,0 +1,23 @@
+---
+title: 'I Replaced Claude Design… 100% UNLIMITED'
+youtubeId: ju-T6uQNPSg
+summary: Jack Roberts replaces Claude Design with Open Design end-to-end — installing the repo, building a project with Claude Code, switching to ChatGPT mid-project, and adding AI images on a free model setup.
+date: 2026-05-01
+category: Getting started
+durationSeconds: 953
+author: Jack Roberts
+official: false
+---
+
+Jack Roberts shows what a real Claude Design → Open Design migration looks like — including the trick of switching the underlying model halfway through a project without losing context.
+
+Chapter map:
+
+- 00:00 — Claude limits are brutal
+- 01:30 — Open Design walkthrough
+- 03:45 — Installing the repo
+- 06:20 — Building with Claude Code
+- 09:15 — Switching to ChatGPT mid-project
+- 11:30 — Adding AI images
+- 13:45 — Free model setup
+- 15:00 — When to use what

--- a/apps/landing-page/app/content/tutorials/open-design-revolutionary-approach-01coder.md
+++ b/apps/landing-page/app/content/tutorials/open-design-revolutionary-approach-01coder.md
@@ -1,0 +1,19 @@
+---
+title: '42k ⭐ Open Design — 颠覆传统的设计方式'
+youtubeId: Zktt5gwh6DU
+summary: 01Coder 在 Open Design 冲到 42k Star 时做的中文深度评测，从产品定位、技术架构到实际产出质量逐项拆解。
+date: 2026-05-17
+category: Review
+durationSeconds: 745
+author: 01Coder
+official: false
+---
+
+01Coder 在 Open Design 触达 42k ⭐ 的节点上做的一期评测，串起产品定位、技术架构、与 Claude Design 的差异，以及社区接下来可能的走向。
+
+视频内容：
+
+- 从 Star 增长曲线讲起，复盘开源到底踩中了哪几个点
+- 本地 daemon × 多模型路由：到底不锁单一供应商的意义在哪
+- Skills + Design Systems 双层架构跟传统设计工具的根本差异
+- 产出实测，以及它最适合什么类型的产品团队

--- a/apps/landing-page/app/content/tutorials/open-design-vibe-coders-dream-sean-kochel.md
+++ b/apps/landing-page/app/content/tutorials/open-design-vibe-coders-dream-sean-kochel.md
@@ -1,0 +1,24 @@
+---
+title: 'Open Design Is Every Vibe Coder''s Dream'
+youtubeId: MmTBkDmunk4
+summary: Sean Kochel demos the new open-source competitor to Claude Design across landing page, mobile app, and desktop app prototypes — turning rough PRDs into shippable UI in minutes.
+date: 2026-05-04
+category: Demo
+durationSeconds: 815
+author: Sean Kochel
+official: false
+---
+
+Sean Kochel runs Open Design through three back-to-back demos — landing page, mobile app, desktop app — to show how a vibe-coding workflow plugs into the project.
+
+Chapter map:
+
+- 00:00 — Intro
+- 00:14 — Repo overview
+- 02:56 — Landing page demo
+- 05:15 — Results
+- 06:32 — Mobile app demo
+- 08:02 — Results
+- 09:46 — Mobile app option 2
+- 10:47 — Desktop app demo
+- 11:34 — Results

--- a/apps/landing-page/app/content/tutorials/open-design-vs-claude-design-better-stack.md
+++ b/apps/landing-page/app/content/tutorials/open-design-vs-claude-design-better-stack.md
@@ -1,0 +1,19 @@
+---
+title: 'Why 40k Developers Abandoned Claude Design'
+youtubeId: B3coWv2ZV68
+summary: Better Stack walks through how Open Design works under the hood, sets it up locally, and stress-tests the output by redesigning a YouTube channel searcher with a non-Claude model.
+date: 2026-05-15
+category: Review
+durationSeconds: 446
+author: Better Stack
+official: false
+---
+
+Better Stack breaks down the architecture choices that let Open Design run on whatever coding agent you already have installed — Claude Code, Codex, Cursor, Gemini CLI, or DeepSeek — and benchmarks the result side-by-side with the original Claude Design output.
+
+The walkthrough covers:
+
+- How the local-first daemon swaps in different model providers without changing skills
+- The 72 brand-grade design systems and how they shape generated UI
+- A real redesign test: rebuilding a YouTube channel searcher front-end with a non-Claude model
+- Where the output still falls behind Claude Design, and where it wins

--- a/apps/landing-page/app/pages/tutorials/[slug].astro
+++ b/apps/landing-page/app/pages/tutorials/[slug].astro
@@ -33,7 +33,8 @@ const { entry } = Astro.props;
 const { Content } = await render(entry);
 const sourceUrl = `https://github.com/nexu-io/open-design/blob/main/apps/landing-page/app/content/tutorials/${entry.id}.md`;
 const youtubeUrl = `https://www.youtube.com/watch?v=${entry.data.youtubeId}`;
-const embedUrl = `https://www.youtube-nocookie.com/embed/${entry.data.youtubeId}?rel=0&modestbranding=1`;
+const thumbnailUrl =
+  entry.data.thumbnail ?? `https://i.ytimg.com/vi/${entry.data.youtubeId}/maxresdefault.jpg`;
 
 const counts = await getCatalogCounts();
 const github = await getGithubRepoMeta();
@@ -86,16 +87,32 @@ const fmtDuration = (seconds: number) => {
           <div class='container'>
             <a class='tut-back' href='/tutorials/'>← Back to Tutorials</a>
 
-            <div class='tut-player'>
-              <iframe
-                src={embedUrl}
-                title={entry.data.title}
-                loading='lazy'
-                allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share'
-                referrerpolicy='strict-origin-when-cross-origin'
-                allowfullscreen
-              ></iframe>
-            </div>
+            <a
+              class='tut-player'
+              href={youtubeUrl}
+              target='_blank'
+              rel='noreferrer noopener'
+              aria-label={`Watch "${entry.data.title}" on YouTube`}
+            >
+              <img
+                class='tut-player-thumb'
+                src={thumbnailUrl}
+                alt={`Thumbnail for ${entry.data.title}`}
+                loading='eager'
+              />
+              <span class='tut-player-overlay' aria-hidden='true'>
+                <span class='tut-player-button'>
+                  <svg viewBox='0 0 68 48' width='68' height='48'>
+                    <path
+                      d='M66.52 7.74c-.78-2.93-2.49-5.41-5.42-6.19C55.79.13 34 0 34 0S12.21.13 6.9 1.55c-2.93.78-4.63 3.26-5.42 6.19C.06 13.05 0 24 0 24s.06 10.95 1.48 16.26c.78 2.93 2.49 5.41 5.42 6.19C12.21 47.87 34 48 34 48s21.79-.13 27.1-1.55c2.93-.78 4.64-3.26 5.42-6.19C67.94 34.95 68 24 68 24s-.06-10.95-1.48-16.26z'
+                      fill='#cc0000'
+                    />
+                    <path d='M27 34V14l18 10z' fill='#fff' />
+                  </svg>
+                </span>
+                <span class='tut-player-cta'>Watch on YouTube ↗</span>
+              </span>
+            </a>
 
             <div class='tut-detail-head'>
               <span class='tut-card-cat'>
@@ -177,6 +194,7 @@ const fmtDuration = (seconds: number) => {
       }
       .tut-player {
         position: relative;
+        display: block;
         width: 100%;
         aspect-ratio: 16 / 9;
         background: #000;
@@ -184,14 +202,72 @@ const fmtDuration = (seconds: number) => {
         box-shadow: var(--shadow);
         margin-bottom: 36px;
         overflow: hidden;
+        text-decoration: none;
+        cursor: pointer;
       }
-      .tut-player iframe {
+      .tut-player-thumb {
         position: absolute;
         inset: 0;
         width: 100%;
         height: 100%;
-        border: 0;
-        display: block;
+        object-fit: cover;
+        object-position: center;
+        filter: saturate(0.96) contrast(1.02);
+        transition: transform 320ms cubic-bezier(0.23, 1, 0.32, 1);
+      }
+      .tut-player:hover .tut-player-thumb {
+        transform: scale(1.02);
+      }
+      .tut-player-overlay {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 18px;
+        background: linear-gradient(
+          180deg,
+          rgba(21, 20, 15, 0.05) 0%,
+          rgba(21, 20, 15, 0.25) 60%,
+          rgba(21, 20, 15, 0.55) 100%
+        );
+        transition: background 200ms ease;
+      }
+      .tut-player:hover .tut-player-overlay {
+        background: linear-gradient(
+          180deg,
+          rgba(21, 20, 15, 0.1) 0%,
+          rgba(21, 20, 15, 0.32) 60%,
+          rgba(21, 20, 15, 0.62) 100%
+        );
+      }
+      .tut-player-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        transition: transform 200ms cubic-bezier(0.23, 1, 0.32, 1), filter 200ms ease;
+        filter: drop-shadow(0 8px 22px rgba(0, 0, 0, 0.45));
+      }
+      .tut-player:hover .tut-player-button {
+        transform: scale(1.06);
+      }
+      .tut-player-cta {
+        font-family: var(--sans);
+        font-weight: 600;
+        font-size: 13px;
+        letter-spacing: 0.04em;
+        color: var(--paper);
+        padding: 8px 14px;
+        border: 1px solid rgba(255, 255, 255, 0.32);
+        border-radius: 999px;
+        background: rgba(21, 20, 15, 0.42);
+        backdrop-filter: blur(4px);
+        transition: background 200ms ease, border-color 200ms ease;
+      }
+      .tut-player:hover .tut-player-cta {
+        background: rgba(21, 20, 15, 0.62);
+        border-color: rgba(255, 255, 255, 0.5);
       }
       .tut-detail-head {
         margin-bottom: 32px;

--- a/apps/landing-page/app/pages/tutorials/[slug].astro
+++ b/apps/landing-page/app/pages/tutorials/[slug].astro
@@ -1,0 +1,367 @@
+---
+/*
+ * Tutorial detail — `/tutorials/[slug]/`
+ *
+ * Static route generated from the `tutorials` Content Collection. Renders a
+ * single video player above the editorial body. The iframe uses
+ * `https://www.youtube-nocookie.com/embed/<id>` so the page does not require
+ * a cookie consent banner. The body Markdown is optional — if a tutorial has
+ * no notes, only the player + metadata + CTA back to the index is shown.
+ */
+import { getCollection, render } from 'astro:content';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import HeaderEnhancer from '../../_components/header-enhancer.astro';
+import { Header, type HeaderProps } from '../../_components/header';
+import SeoHead from '../../_components/seo-head.astro';
+import SiteFooter from '../../_components/site-footer.astro';
+import Topbar from '../../_components/topbar.astro';
+import { getCatalogCounts } from '../../_lib/catalog';
+import { getGithubRepoMeta } from '../../_lib/github';
+import '../../globals.css';
+import '../../sub-pages.css';
+
+export async function getStaticPaths() {
+  const tutorials = await getCollection('tutorials');
+  return tutorials.map((entry) => ({
+    params: { slug: entry.id },
+    props: { entry },
+  }));
+}
+
+const { entry } = Astro.props;
+const { Content } = await render(entry);
+const sourceUrl = `https://github.com/nexu-io/open-design/blob/main/apps/landing-page/app/content/tutorials/${entry.id}.md`;
+const youtubeUrl = `https://www.youtube.com/watch?v=${entry.data.youtubeId}`;
+const embedUrl = `https://www.youtube-nocookie.com/embed/${entry.data.youtubeId}?rel=0&modestbranding=1`;
+
+const counts = await getCatalogCounts();
+const github = await getGithubRepoMeta();
+const headerHtml = renderToStaticMarkup(
+  createElement<HeaderProps>(Header, {
+    counts,
+    github,
+    brandHref: '/',
+    active: 'tutorials',
+  }),
+);
+
+const fmtDate = (d: Date) =>
+  d.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+
+const fmtDuration = (seconds: number) => {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+  return `${m}:${String(s).padStart(2, '0')}`;
+};
+---
+
+<!doctype html>
+<html lang='en'>
+  <head>
+    <meta charset='utf-8' />
+    <meta name='viewport' content='width=device-width, initial-scale=1' />
+    <SeoHead
+      kind='article'
+      title={`${entry.data.title} — Open Design Tutorials`}
+      description={entry.data.summary}
+      pathname={Astro.url.pathname}
+      datePublished={entry.data.date}
+      category={entry.data.category}
+    />
+  </head>
+  <body>
+    <div class='shell'>
+      <Topbar github={github} />
+      <Fragment set:html={headerHtml} />
+
+      <main class='tut-detail-shell'>
+        <article class='tut-detail'>
+          <div class='container'>
+            <a class='tut-back' href='/tutorials/'>← Back to Tutorials</a>
+
+            <div class='tut-player'>
+              <iframe
+                src={embedUrl}
+                title={entry.data.title}
+                loading='lazy'
+                allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share'
+                referrerpolicy='strict-origin-when-cross-origin'
+                allowfullscreen
+              ></iframe>
+            </div>
+
+            <div class='tut-detail-head'>
+              <span class='tut-card-cat'>
+                {entry.data.category}
+                {entry.data.official && (
+                  <span class='tut-badge-official'>Official</span>
+                )}
+              </span>
+              <h1 class='tut-detail-title'>{entry.data.title}</h1>
+              <p class='tut-detail-summary'>{entry.data.summary}</p>
+
+              <div class='tut-detail-meta'>
+                <span>{entry.data.author}</span>
+                <span>{fmtDate(entry.data.date)}</span>
+                <span>{fmtDuration(entry.data.durationSeconds)}</span>
+                <a
+                  class='tut-detail-yt'
+                  href={youtubeUrl}
+                  target='_blank'
+                  rel='noreferrer noopener'
+                >
+                  Open on YouTube ↗
+                </a>
+              </div>
+            </div>
+
+            <hr class='tut-rule' />
+
+            <div class='tut-body'>
+              <Content />
+            </div>
+
+            <hr class='tut-rule' />
+
+            <div class='tut-foot'>
+              <a class='tut-back' href='/tutorials/'>← Back to Tutorials</a>
+              <a
+                class='tut-source'
+                href={sourceUrl}
+                target='_blank'
+                rel='noreferrer noopener'
+              >
+                View source on GitHub ↗
+              </a>
+            </div>
+          </div>
+        </article>
+      </main>
+      <SiteFooter counts={counts} />
+    </div>
+
+    <HeaderEnhancer />
+
+    <style>
+      .tut-detail-shell {
+        position: relative;
+        z-index: 2;
+      }
+      .tut-detail-shell + .sub-footer {
+        margin-top: 0;
+      }
+      .tut-detail {
+        padding: 56px 0 96px;
+      }
+      .tut-detail .container {
+        max-width: 920px;
+      }
+      .tut-back {
+        display: inline-block;
+        font-family: var(--sans);
+        font-size: 13px;
+        color: var(--ink-mute);
+        text-decoration: none;
+        margin-bottom: 28px;
+        transition: color 160ms ease;
+      }
+      .tut-back:hover {
+        color: var(--coral);
+      }
+      .tut-player {
+        position: relative;
+        width: 100%;
+        aspect-ratio: 16 / 9;
+        background: #000;
+        border: 1px solid var(--line);
+        box-shadow: var(--shadow);
+        margin-bottom: 36px;
+        overflow: hidden;
+      }
+      .tut-player iframe {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        border: 0;
+        display: block;
+      }
+      .tut-detail-head {
+        margin-bottom: 32px;
+      }
+      .tut-card-cat {
+        font-family: var(--sans);
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        color: var(--coral);
+        display: inline-flex;
+        align-items: center;
+        gap: 12px;
+        margin-bottom: 14px;
+      }
+      .tut-card-cat::before {
+        content: '';
+        width: 18px;
+        height: 1px;
+        background: var(--coral);
+      }
+      .tut-badge-official {
+        margin-left: 2px;
+        padding: 2px 7px;
+        border: 1px solid var(--coral);
+        border-radius: 999px;
+        font-size: 9.5px;
+        letter-spacing: 0.16em;
+        color: var(--coral);
+      }
+      .tut-detail-title {
+        font-family: var(--serif);
+        font-weight: 500;
+        font-size: clamp(34px, 4vw, 52px);
+        line-height: 1.08;
+        letter-spacing: -0.018em;
+        color: var(--ink);
+        margin: 12px 0 18px;
+      }
+      .tut-detail-summary {
+        font-family: var(--serif);
+        font-style: italic;
+        font-size: clamp(17px, 1.6vw, 20px);
+        line-height: 1.45;
+        color: var(--ink-soft);
+        max-width: 60ch;
+        margin-bottom: 22px;
+      }
+      .tut-detail-meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px 10px;
+        font-family: var(--mono);
+        font-size: 11px;
+        letter-spacing: 0.06em;
+        color: var(--ink-faint);
+      }
+      .tut-detail-meta span + span::before,
+      .tut-detail-meta span + a::before {
+        content: '';
+        display: inline-block;
+        width: 14px;
+        height: 1px;
+        margin-right: 10px;
+        vertical-align: middle;
+        background: var(--line);
+      }
+      .tut-detail-yt {
+        font-family: var(--sans);
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0;
+        color: var(--ink);
+        text-decoration: none;
+        margin-left: auto;
+        transition: color 160ms ease;
+      }
+      .tut-detail-yt:hover {
+        color: var(--coral);
+      }
+      .tut-rule {
+        border: 0;
+        border-top: 1px solid var(--line);
+        margin: 0 0 36px;
+      }
+      .tut-body {
+        font-family: var(--body);
+        font-size: 17px;
+        line-height: 1.7;
+        color: var(--ink-soft);
+      }
+      .tut-body :global(p) {
+        margin: 0 0 1.4em;
+      }
+      .tut-body :global(h2) {
+        font-family: var(--serif);
+        font-weight: 500;
+        font-size: clamp(24px, 2.4vw, 30px);
+        line-height: 1.2;
+        letter-spacing: -0.012em;
+        color: var(--ink);
+        margin: 1.8em 0 0.6em;
+      }
+      .tut-body :global(h3) {
+        font-family: var(--sans);
+        font-weight: 600;
+        font-size: 18px;
+        color: var(--ink);
+        margin: 1.6em 0 0.5em;
+      }
+      .tut-body :global(a) {
+        color: var(--coral);
+        text-decoration: underline;
+        text-underline-offset: 3px;
+      }
+      .tut-body :global(strong) {
+        color: var(--ink);
+        font-weight: 600;
+      }
+      .tut-body :global(ul),
+      .tut-body :global(ol) {
+        padding-left: 1.4em;
+        margin: 0 0 1.4em;
+      }
+      .tut-body :global(li) {
+        margin-bottom: 0.4em;
+      }
+      .tut-foot {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 16px;
+        margin-top: 8px;
+      }
+      .tut-foot .tut-back {
+        margin-bottom: 0;
+      }
+      .tut-source {
+        font-family: var(--sans);
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--ink);
+        text-decoration: none;
+        transition: color 160ms ease;
+      }
+      .tut-source:hover {
+        color: var(--coral);
+      }
+      @media (max-width: 760px) {
+        .tut-detail {
+          padding: 36px 0 64px;
+        }
+        .tut-foot {
+          align-items: flex-start;
+          flex-direction: column;
+        }
+        .tut-detail-meta {
+          flex-direction: column;
+          align-items: flex-start;
+          gap: 6px;
+        }
+        .tut-detail-meta span + span::before,
+        .tut-detail-meta span + a::before {
+          display: none;
+        }
+        .tut-detail-yt {
+          margin-left: 0;
+        }
+      }
+    </style>
+  </body>
+</html>

--- a/apps/landing-page/app/pages/tutorials/index.astro
+++ b/apps/landing-page/app/pages/tutorials/index.astro
@@ -1,0 +1,613 @@
+---
+/*
+ * Tutorials index — `/tutorials/`
+ *
+ * Editorial gallery of Open Design YouTube tutorials. One card per video.
+ * Cards link to `/tutorials/<slug>/` where the video plays inline via a
+ * privacy-enhanced `youtube-nocookie.com` iframe.
+ *
+ * Entries come from the `tutorials` Content Collection defined in
+ * `app/content.config.ts`. Sorted by date descending. The category strip
+ * mirrors the `/blog/` filter UX so the magazine aesthetic stays uniform.
+ */
+import { getCollection } from 'astro:content';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import HeaderEnhancer from '../../_components/header-enhancer.astro';
+import { Header, type HeaderProps } from '../../_components/header';
+import SeoHead from '../../_components/seo-head.astro';
+import SiteFooter from '../../_components/site-footer.astro';
+import Topbar from '../../_components/topbar.astro';
+import { getCatalogCounts } from '../../_lib/catalog';
+import { getGithubRepoMeta } from '../../_lib/github';
+import '../../globals.css';
+import '../../sub-pages.css';
+
+const tutorials = (await getCollection('tutorials')).sort(
+  (a, b) => b.data.date.getTime() - a.data.date.getTime(),
+);
+
+const counts = await getCatalogCounts();
+const github = await getGithubRepoMeta();
+const headerHtml = renderToStaticMarkup(
+  createElement<HeaderProps>(Header, {
+    counts,
+    github,
+    brandHref: '/',
+    active: 'tutorials',
+  }),
+);
+
+const seoTitle = 'Tutorials — Open Design';
+const seoDescription =
+  'Watch Open Design from the inside — getting-started walkthroughs, plugin tutorials, demos, and community deep-dives, curated from YouTube and embedded for in-page playback.';
+
+const categoryChips = [
+  { label: 'All', value: 'all' },
+  { label: 'Getting started', value: 'getting-started' },
+  { label: 'Tutorials', value: 'tutorial' },
+  { label: 'Demos', value: 'demo' },
+  { label: 'Reviews', value: 'review' },
+  { label: 'Community', value: 'community' },
+];
+
+const fmtDate = (d: Date) =>
+  d.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+
+const fmtDuration = (seconds: number) => {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+  return `${m}:${String(s).padStart(2, '0')}`;
+};
+
+const categoryValue = (category: string) => category.toLowerCase().replace(/\s+/g, '-');
+
+const ytThumb = (id: string) => `https://i.ytimg.com/vi/${id}/hqdefault.jpg`;
+
+const featuredTutorial = tutorials[0];
+const cardTutorials = tutorials.slice(1);
+---
+
+<!doctype html>
+<html lang='en'>
+  <head>
+    <meta charset='utf-8' />
+    <meta name='viewport' content='width=device-width, initial-scale=1' />
+    <SeoHead
+      kind='website'
+      title={seoTitle}
+      description={seoDescription}
+      pathname={Astro.url.pathname}
+    />
+  </head>
+  <body>
+    <div class='shell'>
+      <Topbar github={github} />
+      <Fragment set:html={headerHtml} />
+
+      <main class='tut-shell'>
+        <section class='tut-masthead'>
+          <div class='container'>
+            <h1 class='tut-title'>Tutorials</h1>
+            <p class='tut-sub'>
+              Watch Open Design from the inside — getting-started walkthroughs,
+              plugin tutorials, demos, and community deep-dives. Each video
+              plays in-page; the source link points back to the original
+              YouTube channel.
+            </p>
+          </div>
+        </section>
+
+        {
+          featuredTutorial && (
+            <section
+              class='tut-feature'
+              data-featured
+              data-category={categoryValue(featuredTutorial.data.category)}
+            >
+              <div class='container'>
+                <a
+                  class='tut-feature-card'
+                  href={`/tutorials/${featuredTutorial.id}/`}
+                  style={`--accent-index: 1;`}
+                >
+                  <span class='tut-feature-thumb'>
+                    <img
+                      src={featuredTutorial.data.thumbnail ?? ytThumb(featuredTutorial.data.youtubeId)}
+                      alt={`Thumbnail for ${featuredTutorial.data.title}`}
+                      loading='eager'
+                    />
+                    <span class='tut-play' aria-hidden='true'>▶</span>
+                    <span class='tut-duration-pill'>
+                      {fmtDuration(featuredTutorial.data.durationSeconds)}
+                    </span>
+                  </span>
+                  <span class='tut-feature-copy'>
+                    <span class='tut-card-cat'>
+                      {featuredTutorial.data.category}
+                      {featuredTutorial.data.official && (
+                        <span class='tut-badge-official'>Official</span>
+                      )}
+                    </span>
+                    <h2 class='tut-feature-title'>{featuredTutorial.data.title}</h2>
+                    <p class='tut-feature-summary'>{featuredTutorial.data.summary}</p>
+                    <span class='tut-feature-meta'>
+                      <span>{featuredTutorial.data.author}</span>
+                      <span>·</span>
+                      <span>{fmtDate(featuredTutorial.data.date)}</span>
+                      <span class='tut-feature-cta'>Watch →</span>
+                    </span>
+                  </span>
+                </a>
+              </div>
+            </section>
+          )
+        }
+
+        <section class='tut-categories'>
+          <div class='container'>
+            <div class='tut-category-strip' aria-label='Tutorial categories'>
+              {categoryChips.map((category, index) => (
+                <a
+                  class:list={['tut-chip', index === 0 && 'is-active']}
+                  href={category.value === 'all' ? '/tutorials/' : `/tutorials/?category=${category.value}`}
+                  data-category-filter={category.value}
+                >
+                  {category.label}
+                </a>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section class='tut-list'>
+          <div class='container'>
+            {
+              tutorials.length === 0 ? (
+                <p class='tut-empty'>
+                  No tutorials yet. We're curating the first batch — check back soon, or
+                  <a href='https://github.com/nexu-io/open-design/issues/new' target='_blank' rel='noreferrer noopener'>
+                    {' '}suggest a video
+                  </a>.
+                </p>
+              ) : cardTutorials.length === 0 ? null : (
+                <ol class='tut-grid'>
+                  {cardTutorials.map((entry, idx) => (
+                    <li
+                      class='tut-card'
+                      data-tut-item
+                      data-category={categoryValue(entry.data.category)}
+                    >
+                      <a
+                        class='tut-card-link'
+                        href={`/tutorials/${entry.id}/`}
+                        style={`--accent-index: ${idx + 2};`}
+                      >
+                        <span class='tut-card-thumb'>
+                          <img
+                            src={entry.data.thumbnail ?? ytThumb(entry.data.youtubeId)}
+                            alt={`Thumbnail for ${entry.data.title}`}
+                            loading='lazy'
+                          />
+                          <span class='tut-play' aria-hidden='true'>▶</span>
+                          <span class='tut-duration-pill'>
+                            {fmtDuration(entry.data.durationSeconds)}
+                          </span>
+                        </span>
+                        <span class='tut-card-body'>
+                          <span class='tut-card-cat'>
+                            {entry.data.category}
+                            {entry.data.official && (
+                              <span class='tut-badge-official'>Official</span>
+                            )}
+                          </span>
+                          <h2 class='tut-card-title'>{entry.data.title}</h2>
+                          <p class='tut-card-summary'>{entry.data.summary}</p>
+                          <span class='tut-card-foot'>
+                            <span class='tut-card-author'>{entry.data.author}</span>
+                            <span class='tut-card-date'>{fmtDate(entry.data.date)}</span>
+                            <span class='tut-card-cta'>Watch →</span>
+                          </span>
+                        </span>
+                      </a>
+                    </li>
+                  ))}
+                </ol>
+              )
+            }
+            <p class='tut-empty is-filter-empty' data-tut-empty hidden>
+              No tutorials in this category yet. More are on the way.
+            </p>
+          </div>
+        </section>
+      </main>
+      <SiteFooter counts={counts} />
+    </div>
+
+    <script is:inline>
+      (() => {
+        const normalize = (value) => (value || 'all').toLowerCase();
+        const params = new URLSearchParams(window.location.search);
+        const active = normalize(params.get('category'));
+        const filters = document.querySelectorAll('[data-category-filter]');
+        const items = document.querySelectorAll('[data-tut-item]');
+        const featured = document.querySelector('[data-featured]');
+        const empty = document.querySelector('[data-tut-empty]');
+
+        let visibleCount = 0;
+        for (const item of items) {
+          const matches =
+            active === 'all' || item.getAttribute('data-category') === active;
+          item.hidden = !matches;
+          if (matches) visibleCount += 1;
+        }
+        if (featured) {
+          const matches =
+            active === 'all' || featured.getAttribute('data-category') === active;
+          featured.hidden = !matches;
+          if (matches) visibleCount += 1;
+        }
+
+        for (const filter of filters) {
+          const isActive = filter.getAttribute('data-category-filter') === active;
+          filter.classList.toggle('is-active', isActive);
+          if (isActive) filter.setAttribute('aria-current', 'page');
+          else filter.removeAttribute('aria-current');
+        }
+
+        if (empty) empty.hidden = visibleCount !== 0;
+      })();
+    </script>
+    <HeaderEnhancer />
+
+    <style>
+      .tut-shell {
+        position: relative;
+        z-index: 2;
+      }
+      .tut-shell + .sub-footer {
+        margin-top: 0;
+      }
+      .tut-masthead {
+        padding: 24px 0 14px;
+        border-bottom: 1px solid var(--line-soft);
+      }
+      .tut-title {
+        font-family: var(--sans);
+        font-weight: 800;
+        letter-spacing: -0.028em;
+        font-size: clamp(46px, 5.4vw, 78px);
+        line-height: 0.94;
+        color: var(--ink);
+        margin: 0 0 8px;
+      }
+      .tut-sub {
+        font-family: var(--body);
+        font-size: 17px;
+        line-height: 1.48;
+        color: var(--ink-soft);
+        max-width: 64ch;
+        margin-bottom: 0;
+      }
+      .tut-categories {
+        padding: 12px 0 0;
+      }
+      .tut-category-strip {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        margin: 0 0 14px;
+      }
+      .tut-chip {
+        display: inline-flex;
+        align-items: center;
+        min-height: 34px;
+        padding: 8px 14px;
+        border: 1px solid var(--line);
+        border-radius: 999px;
+        font-family: var(--sans);
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--ink-mute);
+        background: rgba(247, 241, 222, 0.38);
+        text-decoration: none;
+        transition: background 160ms ease, border-color 160ms ease, color 160ms ease;
+      }
+      .tut-chip:hover {
+        color: var(--ink);
+        border-color: rgba(21, 20, 15, 0.42);
+        background: rgba(247, 241, 222, 0.72);
+      }
+      .tut-chip.is-active {
+        color: var(--paper);
+        background: var(--ink);
+        border-color: var(--ink);
+      }
+      .tut-feature {
+        padding: 14px 0 16px;
+      }
+      .tut-feature-card {
+        display: grid;
+        grid-template-columns: minmax(0, 1.04fr) minmax(320px, 0.96fr);
+        min-height: 252px;
+        border: 1px solid var(--line);
+        background: var(--bone);
+        color: var(--ink);
+        text-decoration: none;
+        box-shadow: var(--shadow);
+        overflow: hidden;
+      }
+      .tut-feature-thumb,
+      .tut-card-thumb {
+        position: relative;
+        display: block;
+        overflow: hidden;
+        background: var(--bone);
+        border-bottom: 1px solid var(--line);
+      }
+      .tut-feature-thumb {
+        min-height: 252px;
+        height: clamp(232px, 25vw, 282px);
+        border-right: 1px solid var(--line);
+        border-bottom: 0;
+      }
+      .tut-card-thumb {
+        aspect-ratio: 16 / 9;
+        min-height: 0;
+      }
+      .tut-feature-thumb img,
+      .tut-card-thumb img {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        object-position: center;
+        filter: saturate(0.96) contrast(1.02);
+      }
+      .tut-feature-thumb::before,
+      .tut-card-thumb::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        z-index: 1;
+        pointer-events: none;
+        background-image: linear-gradient(
+          180deg,
+          rgba(247, 241, 222, 0.06),
+          rgba(21, 20, 15, 0.18)
+        );
+      }
+      .tut-play {
+        position: absolute;
+        z-index: 2;
+        left: 50%;
+        top: 50%;
+        transform: translate(-50%, -50%);
+        width: 56px;
+        height: 56px;
+        border-radius: 50%;
+        background: rgba(21, 20, 15, 0.78);
+        color: var(--paper);
+        font-size: 18px;
+        line-height: 56px;
+        text-align: center;
+        padding-left: 4px;
+        backdrop-filter: blur(2px);
+        transition: transform 180ms ease, background 180ms ease;
+      }
+      .tut-card-link:hover .tut-play,
+      .tut-feature-card:hover .tut-play {
+        background: var(--coral);
+        transform: translate(-50%, -50%) scale(1.05);
+      }
+      .tut-duration-pill {
+        position: absolute;
+        z-index: 2;
+        right: 12px;
+        bottom: 12px;
+        padding: 4px 8px;
+        border-radius: 3px;
+        font-family: var(--mono);
+        font-size: 11px;
+        letter-spacing: 0.06em;
+        background: rgba(21, 20, 15, 0.82);
+        color: var(--paper);
+      }
+      .tut-feature-copy {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        gap: 11px;
+        padding: 26px 36px;
+      }
+      .tut-feature-title {
+        font-family: var(--serif);
+        font-size: clamp(31px, 3vw, 43px);
+        font-weight: 500;
+        line-height: 1.06;
+        letter-spacing: -0.02em;
+        color: var(--ink);
+      }
+      .tut-feature-summary {
+        font-family: var(--body);
+        font-size: 15px;
+        line-height: 1.42;
+        color: var(--ink-mute);
+        max-width: 56ch;
+      }
+      .tut-feature-meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        padding-top: 12px;
+        border-top: 1px solid var(--line-soft);
+        font-family: var(--mono);
+        font-size: 11px;
+        letter-spacing: 0.06em;
+        color: var(--ink-faint);
+      }
+      .tut-feature-cta {
+        margin-left: auto;
+        font-family: var(--sans);
+        font-size: 13px;
+        letter-spacing: 0;
+        color: var(--ink);
+      }
+      .tut-list {
+        padding: 4px 0 64px;
+      }
+      .tut-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 22px;
+        list-style: none;
+      }
+      .tut-card {
+        min-width: 0;
+      }
+      .tut-card-link {
+        display: flex;
+        flex-direction: column;
+        min-height: 100%;
+        border: 1px solid var(--line);
+        background: rgba(247, 241, 222, 0.46);
+        color: var(--ink);
+        text-decoration: none;
+        overflow: hidden;
+        transition: background 180ms ease, transform 180ms ease;
+      }
+      .tut-card-link:hover {
+        background: var(--paper-warm);
+        transform: translateY(-2px);
+      }
+      .tut-card-body {
+        display: flex;
+        flex: 1;
+        flex-direction: column;
+        gap: 12px;
+        padding: 22px 24px;
+      }
+      .tut-card-cat {
+        font-family: var(--sans);
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        color: var(--coral);
+        display: inline-flex;
+        align-items: center;
+        gap: 12px;
+      }
+      .tut-card-cat::before {
+        content: '';
+        width: 18px;
+        height: 1px;
+        background: var(--coral);
+      }
+      .tut-badge-official {
+        margin-left: 2px;
+        padding: 2px 7px;
+        border: 1px solid var(--coral);
+        border-radius: 999px;
+        font-size: 9.5px;
+        letter-spacing: 0.16em;
+        color: var(--coral);
+      }
+      .tut-card-title {
+        font-family: var(--serif);
+        font-weight: 500;
+        font-size: clamp(22px, 1.8vw, 28px);
+        line-height: 1.16;
+        letter-spacing: -0.012em;
+        color: var(--ink);
+      }
+      .tut-card-summary {
+        font-family: var(--body);
+        font-size: 14.5px;
+        line-height: 1.55;
+        color: var(--ink-mute);
+      }
+      .tut-card-foot {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        margin-top: auto;
+        padding-top: 16px;
+        border-top: 1px solid var(--line-soft);
+        font-family: var(--mono);
+        font-size: 11px;
+        letter-spacing: 0.06em;
+        color: var(--ink-faint);
+      }
+      .tut-card-cta {
+        margin-left: auto;
+        color: var(--ink);
+        font-family: var(--sans);
+        font-size: 13px;
+        letter-spacing: 0;
+      }
+      .tut-empty {
+        font-family: var(--body);
+        color: var(--ink-mute);
+        padding: 32px 0;
+      }
+      .tut-empty a {
+        color: var(--coral);
+        text-decoration: underline;
+        text-underline-offset: 3px;
+      }
+      .tut-empty.is-filter-empty {
+        border-top: 1px solid var(--line);
+      }
+      @media (max-width: 980px) {
+        .tut-feature-card {
+          grid-template-columns: 1fr;
+        }
+        .tut-feature-thumb {
+          border-right: 0;
+          border-bottom: 1px solid var(--line);
+          aspect-ratio: 16 / 9;
+          height: auto;
+        }
+        .tut-grid {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+      @media (max-width: 760px) {
+        .tut-masthead {
+          padding: 22px 0 18px;
+        }
+        .tut-title {
+          font-size: clamp(42px, 13vw, 50px);
+          margin-bottom: 10px;
+        }
+        .tut-sub {
+          font-size: 15.5px;
+          line-height: 1.35;
+          margin-bottom: 12px;
+        }
+        .tut-feature-copy {
+          padding: 22px 20px;
+        }
+        .tut-feature-title {
+          font-size: clamp(25px, 7vw, 32px);
+        }
+        .tut-grid {
+          grid-template-columns: 1fr;
+        }
+        .tut-card-body {
+          padding: 20px 20px;
+        }
+      }
+    </style>
+  </body>
+</html>


### PR DESCRIPTION
## Why

While reviewing what OD's marketing site offers a curious developer landing on `open-design.ai`, the path was: read the landing page → click into Skills/Systems/Templates/Craft (catalogue surfaces) → bounce. There was no surface for "watch someone using this thing." Meanwhile YouTube already has a healthy crop of community-produced walkthroughs (Better Stack, WorldofAI, CodingMenace, 01Coder, 硅基麻辣拌, etc.) and that social proof was hidden from people who didn't already know to search YouTube.

This PR adds an editorial **/tutorials/** channel as a first-class destination on the marketing site, so video content the community has already produced can show up alongside the blog and the catalogue surfaces.

## What users will see

- A new **Tutorials** entry in the site header (between Craft and Blog).
- `/tutorials/` — magazine-style list page with a featured masthead card, then a card grid for the rest. Each card shows the YouTube thumbnail with a play overlay, duration pill, category, title, summary, channel, date. Same category-chip filter UX as `/blog/`.
- `/tutorials/<slug>/` — detail page with a full-width 16:9 thumbnail facade (YouTube-style red play button + "Watch on YouTube ↗" pill), then category, title, summary, author, date, duration, an "Open on YouTube ↗" CTA, optional Markdown notes (chapter timestamps for many entries), and a "View source on GitHub ↗" link back to the `.md` source. Clicking the thumbnail opens the canonical `youtube.com/watch?v=<id>` page in a new tab.
- Twelve seed videos, sorted newest first — a mix of English and Chinese reviews/demos/getting-started walkthroughs sourced from YouTube as of 2026-05-19.

## Why click-through, not inline embed

The original implementation (commit `03909c9`) used an inline `youtube-nocookie.com/embed/<id>` iframe so videos could play without leaving the site. In practice that didn't work: YouTube's embedder identity check rejected the request with `PLAYABILITY_ERROR_CODE_EMBEDDER_IDENTITY_MISSING_REFERRER` and rendered an in-frame "Sign in to confirm you're not a bot" challenge instead of the player. Removing the iframe's `referrerpolicy` attribute did not fix it, and the alternative — setting a site-wide Referrer-Policy that always sends a full referrer to a third party — is a privacy regression we don't want to ship.

Commit `b57fb04` replaces the iframe with a click-through facade: a high-resolution thumbnail (`maxresdefault.jpg`), a YouTube-style red play button rendered as inline SVG, and a "Watch on YouTube ↗" pill, all wrapped in an anchor that opens the canonical YouTube page. The detail page still renders all the editorial content (title, summary, author, date, duration, chapter notes), so it remains a useful in-site landing for SEO and social shares — only the playback itself moves off-site.

## Surface area

- [x] **UI** — new \`/tutorials/\` index + \`[slug]\` detail routes in \`apps/landing-page\`, plus a new \`Tutorials\` nav item in the shared \`Header\` component.
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [ ] Default behavior change
- [ ] None

> Note: the surface-area list scopes UI to \`apps/web\` / \`apps/desktop\`, but the change here lives in \`apps/landing-page\` (the open-design.ai marketing site). Calling it out explicitly so reviewers know what to look at.

## Screenshots

Live preview deployed to a Cloudflare Pages branch (does not affect production \`open-design.ai\`):

- List: https://feat-landing-tutorials-chann.open-design-landing.pages.dev/tutorials/
- Detail (English, getting-started): https://feat-landing-tutorials-chann.open-design-landing.pages.dev/tutorials/open-design-in-20-minutes-coding-menace/
- Detail (Chinese, demo): https://feat-landing-tutorials-chann.open-design-landing.pages.dev/tutorials/open-design-feature-tour-silicon-hotpot/

The new branch \`feat/landing-tutorials-channel-v2\` will redeploy under its own preview slug once Cloudflare Pages picks it up; the URLs above belong to the prior branch and remain valid until that preview is torn down.

## Implementation notes

- **No third-party JS, no new top-level deps**: the channel is built on existing Astro 6 + React 18 SSR primitives already in \`apps/landing-page\`. The play button is inline SVG. The thumbnail comes straight from \`i.ytimg.com/vi/<id>/{maxresdefault,hqdefault}.jpg\`. The category-filter behaviour mirrors \`/blog/\` exactly.
- **Content schema**: \`tutorials\` Content Collection added to \`app/content.config.ts\` with a typed schema (\`title\`, \`youtubeId\`, \`summary\`, \`date\`, \`category\`, \`durationSeconds\`, \`author\`, \`official\` default \`false\`, optional \`thumbnail\`). \`youtubeId\` is regex-validated to 11 chars.
- **Header**: \`HeaderProps['active']\` extended with \`'tutorials'\`. The brand-href and counts plumbing is unchanged.

## Validation

- \`astro check\` on \`apps/landing-page\` — 0 errors, 0 warnings, 43 hints (all pre-existing in the codebase).
- \`astro build\` on \`apps/landing-page\` — 878 pages built including 12 \`/tutorials/<slug>/\` detail pages and the index.
- Manual smoke test on the deployed Cloudflare Pages preview (link above): all 12 detail pages render, thumbnail click-through opens the right YouTube URL in a new tab, category filter \`?category=getting-started\` is wired correctly, Header \`Tutorials\` entry highlights when active.
- Did not run repo-root \`pnpm guard\` / \`pnpm typecheck\` because \`better-sqlite3\`'s native build fails on this machine's Python toolchain — irrelevant to the landing-page-only changes here, but flagging so reviewers can confirm green CI.