### PR TITLE
Add desktop updater UI flow

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -29,9 +29,9 @@ import {
 } from "@open-design/sidecar";
 import { readProcessStamp } from "@open-design/platform";
 
-import { createDesktopRuntime } from "./runtime.js";
+import { createDesktopRuntime, type DesktopRuntime } from "./runtime.js";
 import { attachDesktopProcessErrorFilter } from "./uncaught-exception.js";
-import { createDesktopUpdater, type DesktopUpdater } from "./updater.js";
+import { createDesktopUpdater, createDesktopUpdaterScheduler, type DesktopUpdater, type DesktopUpdaterScheduler } from "./updater.js";
 
 // Re-export pure URL-policy helpers so the packaged workspace's
 // vitest can pin their behaviour without spinning up a full Electron
@@ -273,17 +273,6 @@ function installDesktopMenu(updater: DesktopUpdater): () => void {
   return updater.subscribe(rebuild);
 }
 
-function scheduleStartupUpdateCheck(updater: DesktopUpdater): void {
-  if (!updater.shouldAutoCheck()) return;
-  setTimeout(() => {
-    void updater.checkForUpdates().then(async (status) => {
-      if (status.state === "downloaded") await showUpdateResultDialog(updater, status);
-    }).catch((error: unknown) => {
-      console.error("desktop update auto-check failed", error);
-    });
-  }, 5000).unref();
-}
-
 const REGISTER_DESKTOP_AUTH_RETRY_DELAYS_MS = [120, 240, 480, 960, 1500];
 const REGISTER_DESKTOP_AUTH_TIMEOUT_MS = 800;
 
@@ -375,7 +364,39 @@ export async function runDesktopMain(
     );
   }
 
-  const desktop = await createDesktopRuntime({
+  const updater = createDesktopUpdater(
+    {
+      currentVersion: options.update?.currentVersion,
+      downloadRoot: options.update?.downloadRoot,
+      runtimeBase: runtime.base,
+      source: runtime.source,
+    },
+    { openPath: (path) => shell.openPath(path) },
+  );
+  let desktop: DesktopRuntime | null = null;
+  let disposeMenu: () => void = () => undefined;
+  let updateScheduler: DesktopUpdaterScheduler | null = null;
+  let ipcServer: JsonIpcServerHandle | null = null;
+  let shuttingDown = false;
+
+  async function shutdown(): Promise<void> {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    await options.beforeShutdown?.().catch((error: unknown) => {
+      console.error("desktop beforeShutdown failed", error);
+    });
+    updateScheduler?.stop("shutdown");
+    disposeMenu();
+    await ipcServer?.close().catch(() => undefined);
+    await desktop?.close().catch(() => undefined);
+    app.quit();
+  }
+
+  function shutdownAndExit(): void {
+    void shutdown().finally(() => process.exit(0));
+  }
+
+  desktop = await createDesktopRuntime({
     desktopAuthSecret,
     discoverUrl: options.discoverWebUrl ?? createWebDiscovery(runtime),
     discoverDaemonUrl: options.discoverDaemonUrl,
@@ -386,36 +407,17 @@ export async function runDesktopMain(
     // runtime then mints a FRESH token (new nonce + new exp — replay
     // protection still works) and POSTs once more.
     registerDesktopAuthWithDaemon: () => registerDesktopAuthWithDaemon(runtime, desktopAuthSecret),
+    requestQuit: shutdownAndExit,
+    updater,
   });
-  const updater = createDesktopUpdater(
-    {
-      currentVersion: options.update?.currentVersion,
-      downloadRoot: options.update?.downloadRoot,
-      runtimeBase: runtime.base,
-      source: runtime.source,
-    },
-    { openPath: (path) => shell.openPath(path) },
-  );
-  const disposeMenu = installDesktopMenu(updater);
-  scheduleStartupUpdateCheck(updater);
-  let ipcServer: JsonIpcServerHandle | null = null;
-  let shuttingDown = false;
-
-  async function shutdown(): Promise<void> {
-    if (shuttingDown) return;
-    shuttingDown = true;
-    await options.beforeShutdown?.().catch((error: unknown) => {
-      console.error("desktop beforeShutdown failed", error);
-    });
-    disposeMenu();
-    await ipcServer?.close().catch(() => undefined);
-    await desktop.close().catch(() => undefined);
-    app.quit();
-  }
-
-  function shutdownAndExit(): void {
-    void shutdown().finally(() => process.exit(0));
-  }
+  disposeMenu = installDesktopMenu(updater);
+  updateScheduler = createDesktopUpdaterScheduler(updater, {
+    backoffInitialMs: updater.config.checkBackoffInitialMs,
+    backoffMaxMs: updater.config.checkBackoffMaxMs,
+    initialDelayMs: updater.config.checkInitialDelayMs,
+    intervalMs: updater.config.checkIntervalMs,
+  });
+  if (updater.shouldAutoCheck()) updateScheduler.start();
 
   attachParentMonitor(shutdown);
 
@@ -429,19 +431,23 @@ export async function runDesktopMain(
     socketPath: runtime.ipc,
     handler: async (message: unknown) => {
       const request = normalizeDesktopSidecarMessage(message);
+      const activeDesktop = desktop;
+      if (activeDesktop == null) {
+        throw new Error("desktop runtime is not initialized");
+      }
       switch (request.type) {
         case SIDECAR_MESSAGES.STATUS:
-          return { ...desktop.status(), update: await updater.status() };
+          return { ...activeDesktop.status(), update: await updater.status() };
         case SIDECAR_MESSAGES.EVAL:
-          return await desktop.eval(request.input as DesktopEvalInput);
+          return await activeDesktop.eval(request.input as DesktopEvalInput);
         case SIDECAR_MESSAGES.SCREENSHOT:
-          return await desktop.screenshot(request.input as DesktopScreenshotInput);
+          return await activeDesktop.screenshot(request.input as DesktopScreenshotInput);
         case SIDECAR_MESSAGES.CONSOLE:
-          return desktop.console();
+          return activeDesktop.console();
         case SIDECAR_MESSAGES.CLICK:
-          return await desktop.click(request.input as DesktopClickInput);
+          return await activeDesktop.click(request.input as DesktopClickInput);
         case SIDECAR_MESSAGES.EXPORT_PDF:
-          return await desktop.exportPdf(request.input as DesktopExportPdfInput);
+          return await activeDesktop.exportPdf(request.input as DesktopExportPdfInput);
         case SIDECAR_MESSAGES.UPDATE:
           return await updater.handle((request.input as DesktopUpdateInput).action);
         case SIDECAR_MESSAGES.SHUTDOWN:
@@ -464,7 +470,7 @@ export async function runDesktopMain(
   });
 
   app.on("activate", () => {
-    desktop.show();
+    desktop?.show();
   });
 
   for (const signal of ["SIGINT", "SIGTERM"] as const) {

--- a/apps/desktop/src/main/preload.cts
+++ b/apps/desktop/src/main/preload.cts
@@ -5,10 +5,14 @@ import type {
   OpenDesignHostActionResult,
   OpenDesignHostFailure,
   OpenDesignHostProjectImportResult,
+  OpenDesignHostUpdaterActionOptions,
+  OpenDesignHostUpdaterStatusListener,
+  OpenDesignHostUpdaterStatusSnapshot,
 } from '@open-design/host';
 
 const OPEN_DESIGN_HOST_GLOBAL: typeof import('@open-design/host').OPEN_DESIGN_HOST_GLOBAL = '__od__';
 const OPEN_DESIGN_HOST_VERSION: typeof import('@open-design/host').OPEN_DESIGN_HOST_VERSION = 1;
+const UPDATER_STATUS_EVENT = 'od:update:status-changed';
 
 type PrintPdfOptions = {
   deck?: boolean;
@@ -116,6 +120,40 @@ const shell = {
   },
 };
 
+function invokeUpdater(
+  action: 'check' | 'download' | 'install' | 'status',
+  options?: OpenDesignHostUpdaterActionOptions,
+): Promise<OpenDesignHostUpdaterStatusSnapshot> {
+  return ipcRenderer.invoke(`od:update:${action}`, options ?? null);
+}
+
+const updater = {
+  check: (options?: OpenDesignHostUpdaterActionOptions): Promise<OpenDesignHostUpdaterStatusSnapshot> =>
+    invokeUpdater('check', options),
+  download: (options?: OpenDesignHostUpdaterActionOptions): Promise<OpenDesignHostUpdaterStatusSnapshot> =>
+    invokeUpdater('download', options),
+  install: (options?: OpenDesignHostUpdaterActionOptions): Promise<OpenDesignHostUpdaterStatusSnapshot> =>
+    invokeUpdater('install', options),
+  quit: async (options?: OpenDesignHostUpdaterActionOptions): Promise<OpenDesignHostActionResult> => {
+    try {
+      return await ipcRenderer.invoke('od:update:quit', options ?? null);
+    } catch (error) {
+      return actionFailure(reasonFromError(error));
+    }
+  },
+  status: (options?: OpenDesignHostUpdaterActionOptions): Promise<OpenDesignHostUpdaterStatusSnapshot> =>
+    invokeUpdater('status', options),
+  subscribe: (listener: OpenDesignHostUpdaterStatusListener): (() => void) => {
+    const handler = (_event: unknown, status: OpenDesignHostUpdaterStatusSnapshot): void => {
+      listener(status);
+    };
+    ipcRenderer.on(UPDATER_STATUS_EVENT, handler);
+    return () => {
+      ipcRenderer.removeListener(UPDATER_STATUS_EVENT, handler);
+    };
+  },
+};
+
 const hostBridge = {
   version: OPEN_DESIGN_HOST_VERSION,
   client: {
@@ -138,6 +176,7 @@ const hostBridge = {
     setVisible: (visible: boolean): void =>
       ipcRenderer.send('desktop-pet:set-visible', Boolean(visible)),
   },
+  updater,
 } satisfies OpenDesignHostBridge;
 
 contextBridge.exposeInMainWorld(OPEN_DESIGN_HOST_GLOBAL, hostBridge);

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -4,10 +4,19 @@ import { dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { BrowserWindow, dialog, ipcMain, screen, shell } from "electron";
-import type { DesktopExportPdfInput, DesktopExportPdfResult } from "@open-design/sidecar-proto";
+import {
+  DESKTOP_UPDATE_CHANNELS,
+  DESKTOP_UPDATE_MODES,
+  DESKTOP_UPDATE_STATES,
+  type DesktopExportPdfInput,
+  type DesktopExportPdfResult,
+  type DesktopUpdateStatusSnapshot,
+} from "@open-design/sidecar-proto";
+import type { OpenDesignHostActionResult, OpenDesignHostUpdaterActionOptions } from "@open-design/host";
 
 import { createElectronPdfTarget, exportPdfFromHtml, savePrintReadyDocumentAsPdf } from "./pdf-export.js";
 import type { PrintReadyPdfOptions } from "./pdf-export.js";
+import type { DesktopUpdater } from "./updater.js";
 
 /**
  * Result of validating a candidate path before exposing it to a
@@ -208,6 +217,14 @@ const MAX_CONSOLE_ENTRIES = 200;
 const DESKTOP_PET_WINDOW_WIDTH = 360;
 const DESKTOP_PET_WINDOW_HEIGHT = 300;
 const DESKTOP_PET_WINDOW_MARGIN = 24;
+const UPDATER_STATUS_EVENT = "od:update:status-changed";
+const UPDATER_IPC_CHANNELS = [
+  "od:update:status",
+  "od:update:check",
+  "od:update:download",
+  "od:update:install",
+  "od:update:quit",
+] as const;
 
 export type DesktopEvalInput = {
   expression: string;
@@ -300,6 +317,8 @@ export type DesktopRuntimeOptions = {
    * skip it (the lazy retry then collapses into a single attempt).
    */
   registerDesktopAuthWithDaemon?: () => Promise<boolean>;
+  requestQuit?: () => void;
+  updater?: DesktopUpdater;
 };
 
 const DESKTOP_IMPORT_TOKEN_HEADER = "X-OD-Desktop-Import-Token";
@@ -776,6 +795,36 @@ function parsePrintReadyPdfOptions(value: unknown): PrintReadyPdfOptions {
   return deck === true ? { deck: true } : {};
 }
 
+function unavailableUpdaterStatus(): DesktopUpdateStatusSnapshot {
+  return {
+    arch: process.arch,
+    capabilities: {
+      canApplyInPlace: false,
+      canDownload: false,
+      canOpenInstaller: false,
+      requiresManualInstall: false,
+    },
+    channel: DESKTOP_UPDATE_CHANNELS.BETA,
+    currentVersion: "0.0.0",
+    enabled: false,
+    error: {
+      code: "updater-unavailable",
+      message: "Desktop updater is not available.",
+    },
+    mode: DESKTOP_UPDATE_MODES.PACKAGE_LAUNCHER,
+    platform: process.platform,
+    state: DESKTOP_UPDATE_STATES.UNSUPPORTED,
+    supported: false,
+  };
+}
+
+function checkOptionsFromHost(options: unknown): { autoDownload?: boolean } | undefined {
+  const input = options as OpenDesignHostUpdaterActionOptions | null | undefined;
+  const payload = input?.payload;
+  if (payload == null || typeof payload.autoDownload !== "boolean") return undefined;
+  return { autoDownload: payload.autoDownload };
+}
+
 export async function createDesktopRuntime(options: DesktopRuntimeOptions): Promise<DesktopRuntime> {
   const preloadPath = options.preloadPath ?? join(dirname(fileURLToPath(import.meta.url)), "preload.cjs");
 
@@ -788,6 +837,9 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
   ipcMain.removeHandler("dialog:pick-and-import");
   ipcMain.removeHandler("shell:open-external");
   ipcMain.removeHandler("shell:open-path");
+  for (const channel of UPDATER_IPC_CHANNELS) {
+    ipcMain.removeHandler(channel);
+  }
   ipcMain.handle("shell:open-external", async (_event, url: string) => {
     if (!isHttpUrl(url)) return false;
     try {
@@ -930,6 +982,53 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
   installWindowChromeCssHook(window);
   showWindowButtons(window);
   attachDownloadSaveAsDialog(window);
+
+  const sendUpdaterStatus = (status = options.updater?.snapshot() ?? unavailableUpdaterStatus()) => {
+    if (window.isDestroyed()) return;
+    window.webContents.send(UPDATER_STATUS_EVENT, status);
+  };
+  const unsubscribeUpdater = options.updater?.subscribe(() => sendUpdaterStatus()) ?? (() => undefined);
+  const requireMainWindowSender = (event: Electron.IpcMainInvokeEvent): void => {
+    if (event.sender !== window.webContents) {
+      throw new Error("updater IPC is only available to the main Open Design window");
+    }
+  };
+  ipcMain.handle("od:update:status", async (event) => {
+    requireMainWindowSender(event);
+    const status = await (options.updater?.status() ?? unavailableUpdaterStatus());
+    sendUpdaterStatus(status);
+    return status;
+  });
+  ipcMain.handle("od:update:check", async (event, updaterOptions: unknown) => {
+    requireMainWindowSender(event);
+    const status = await (options.updater?.checkForUpdates(checkOptionsFromHost(updaterOptions)) ?? unavailableUpdaterStatus());
+    sendUpdaterStatus(status);
+    return status;
+  });
+  ipcMain.handle("od:update:download", async (event) => {
+    requireMainWindowSender(event);
+    const status = await (options.updater?.downloadUpdate() ?? unavailableUpdaterStatus());
+    sendUpdaterStatus(status);
+    return status;
+  });
+  ipcMain.handle("od:update:install", async (event) => {
+    requireMainWindowSender(event);
+    const status = await (options.updater?.installUpdate() ?? unavailableUpdaterStatus());
+    sendUpdaterStatus(status);
+    return status;
+  });
+  ipcMain.handle("od:update:quit", async (event): Promise<OpenDesignHostActionResult> => {
+    requireMainWindowSender(event);
+    const status = await (options.updater?.status() ?? unavailableUpdaterStatus());
+    if (status.installResult == null) {
+      return { ok: false, reason: "installer has not been opened" };
+    }
+    if (options.requestQuit == null) {
+      return { ok: false, reason: "desktop quit is not available" };
+    }
+    setTimeout(() => options.requestQuit?.(), 0);
+    return { ok: true };
+  });
 
   ipcMain.removeAllListeners("desktop-pet:set-visible");
   ipcMain.on("desktop-pet:set-visible", (event, visible: unknown) => {
@@ -1100,7 +1199,11 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
         clearTimeout(timer);
         timer = null;
       }
+      unsubscribeUpdater();
       ipcMain.removeAllListeners("desktop-pet:set-visible");
+      for (const channel of UPDATER_IPC_CHANNELS) {
+        ipcMain.removeHandler(channel);
+      }
       if (!petWindow.isDestroyed()) petWindow.close();
       if (!window.isDestroyed()) window.close();
     },

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -38,6 +38,10 @@ export const DESKTOP_UPDATE_ENV = Object.freeze({
   AUTO_CHECK: "OD_UPDATE_AUTO_CHECK",
   AUTO_DOWNLOAD: "OD_UPDATE_AUTO_DOWNLOAD",
   AUTO_OPEN: "OD_UPDATE_AUTO_OPEN",
+  CHECK_BACKOFF_INITIAL_MS: "OD_UPDATE_CHECK_BACKOFF_INITIAL_MS",
+  CHECK_BACKOFF_MAX_MS: "OD_UPDATE_CHECK_BACKOFF_MAX_MS",
+  CHECK_INITIAL_DELAY_MS: "OD_UPDATE_CHECK_INITIAL_DELAY_MS",
+  CHECK_INTERVAL_MS: "OD_UPDATE_CHECK_INTERVAL_MS",
   CHANNEL: "OD_UPDATE_CHANNEL",
   CURRENT_VERSION: "OD_UPDATE_CURRENT_VERSION",
   DOWNLOAD_ROOT: "OD_UPDATE_DOWNLOAD_ROOT",
@@ -50,8 +54,17 @@ export const DESKTOP_UPDATE_ENV = Object.freeze({
 
 const DEFAULT_RELEASE_ORIGIN = "https://releases.open-design.ai";
 const OWNERSHIP_SENTINEL = ".open-design-updater-root.json";
-const STATE_FILE = "state.json";
+const STORE_METADATA_FILE = "metadata.json";
+const RELEASES_DIR = "releases";
+const STAGING_DIR = "staging";
+const BACK_DIR = ".back";
 const UPDATE_ROOT_VERSION = 1;
+const STORE_METADATA_VERSION = 1;
+const BETA_POLL_INTERVAL_MS = 15 * 60 * 1000;
+const STABLE_POLL_INTERVAL_MS = 6 * 60 * 60 * 1000;
+const DEFAULT_POLL_INITIAL_DELAY_MS = 5000;
+const DEFAULT_POLL_BACKOFF_INITIAL_MS = 60 * 1000;
+const DEFAULT_POLL_BACKOFF_MAX_MS = 30 * 60 * 1000;
 
 export type DesktopUpdaterConfigInput = {
   appVersion?: string | null;
@@ -70,6 +83,10 @@ export type DesktopUpdaterConfig = {
   autoCheck: boolean;
   autoDownload: boolean;
   autoOpen: boolean;
+  checkBackoffInitialMs: number;
+  checkBackoffMaxMs: number;
+  checkInitialDelayMs: number;
+  checkIntervalMs: number;
   channel: DesktopUpdateChannel;
   currentVersion: string;
   downloadRoot: string;
@@ -83,9 +100,12 @@ export type DesktopUpdaterConfig = {
 
 export type DesktopUpdaterDeps = {
   fetch?: typeof globalThis.fetch;
+  logger?: DesktopUpdaterLogger;
   now?: () => Date;
   openPath?: (path: string) => Promise<string>;
 };
+
+type DesktopUpdaterLogger = Pick<Console, "error" | "warn">;
 
 type UpdateCandidate = {
   arch: string;
@@ -97,22 +117,48 @@ type UpdateCandidate = {
   version: string;
 };
 
-type PersistedUpdateState = {
+type UpdateReleaseRef = {
+  arch: string;
   artifact: DesktopUpdateArtifactSnapshot;
+  artifactPath: string;
   checksum: DesktopUpdateChecksumSnapshot;
+  checksumPath: string;
   channel: DesktopUpdateChannel;
-  downloadPath: string;
   downloadedAt: string;
+  key: string;
   metadata: Record<string, unknown>;
-  platform: string;
+  metadataPath: string;
   platformKey: string;
-  verified: true;
-  version: 1;
-  updateVersion: string;
+  version: string;
+};
+
+type IncomingRef = {
+  arch: string;
+  artifact: DesktopUpdateArtifactSnapshot;
+  channel: DesktopUpdateChannel;
+  cycleId: string;
+  metadata: Record<string, unknown>;
+  platformKey: string;
+  startedAt: string;
+  version: string;
+};
+
+type UpdateStoreMetadata = {
+  active?: UpdateReleaseRef;
+  incoming?: IncomingRef;
+  installFrozen?: boolean;
+  installResult?: DesktopUpdateStatusSnapshot["installResult"];
+  lastCheckedAt?: string;
+  version: typeof STORE_METADATA_VERSION;
+};
+
+type LoadedRelease = {
+  path: string;
+  ref: UpdateReleaseRef;
 };
 
 type OwnedRoot =
-  | { ok: true; manifestPath: string; realRoot: string }
+  | { metadataPath: string; ok: true; realRoot: string }
   | { error: DesktopUpdateErrorSnapshot; ok: false };
 
 type ActionOptions = {
@@ -121,6 +167,7 @@ type ActionOptions = {
 
 export type DesktopUpdater = {
   checkForUpdates(options?: ActionOptions): Promise<DesktopUpdateStatusSnapshot>;
+  config: DesktopUpdaterConfig;
   downloadUpdate(): Promise<DesktopUpdateStatusSnapshot>;
   handle(action: DesktopUpdateAction): Promise<DesktopUpdateStatusSnapshot>;
   installUpdate(): Promise<DesktopUpdateStatusSnapshot>;
@@ -128,6 +175,12 @@ export type DesktopUpdater = {
   snapshot(): DesktopUpdateStatusSnapshot;
   status(): Promise<DesktopUpdateStatusSnapshot>;
   subscribe(listener: () => void): () => void;
+};
+
+export type DesktopUpdaterScheduler = {
+  isRunning(): boolean;
+  start(): void;
+  stop(reason?: string): void;
 };
 
 function isTruthyEnv(value: string | undefined): boolean | null {
@@ -159,6 +212,17 @@ function normalizeDownloadRoot(value: string): string {
   return resolve(value);
 }
 
+function durationEnv(value: string | undefined, fallback: number, name: string): number {
+  if (value == null || value.length === 0) return fallback;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) throw new Error(`${name} must be a non-negative number of milliseconds`);
+  return parsed;
+}
+
+function defaultPollIntervalMs(channel: DesktopUpdateChannel): number {
+  return channel === DESKTOP_UPDATE_CHANNELS.BETA ? BETA_POLL_INTERVAL_MS : STABLE_POLL_INTERVAL_MS;
+}
+
 export function resolveDesktopUpdaterConfig(input: DesktopUpdaterConfigInput): DesktopUpdaterConfig {
   const env = input.env ?? process.env;
   const mode = normalizeMode(env[DESKTOP_UPDATE_ENV.MODE], input.mode ?? DESKTOP_UPDATE_MODES.PACKAGE_LAUNCHER);
@@ -182,6 +246,26 @@ export function resolveDesktopUpdaterConfig(input: DesktopUpdaterConfigInput): D
     autoCheck: isTruthyEnv(env[DESKTOP_UPDATE_ENV.AUTO_CHECK]) ?? enabled,
     autoDownload: isTruthyEnv(env[DESKTOP_UPDATE_ENV.AUTO_DOWNLOAD]) ?? true,
     autoOpen: isTruthyEnv(env[DESKTOP_UPDATE_ENV.AUTO_OPEN]) ?? false,
+    checkBackoffInitialMs: durationEnv(
+      env[DESKTOP_UPDATE_ENV.CHECK_BACKOFF_INITIAL_MS],
+      DEFAULT_POLL_BACKOFF_INITIAL_MS,
+      DESKTOP_UPDATE_ENV.CHECK_BACKOFF_INITIAL_MS,
+    ),
+    checkBackoffMaxMs: durationEnv(
+      env[DESKTOP_UPDATE_ENV.CHECK_BACKOFF_MAX_MS],
+      DEFAULT_POLL_BACKOFF_MAX_MS,
+      DESKTOP_UPDATE_ENV.CHECK_BACKOFF_MAX_MS,
+    ),
+    checkInitialDelayMs: durationEnv(
+      env[DESKTOP_UPDATE_ENV.CHECK_INITIAL_DELAY_MS],
+      DEFAULT_POLL_INITIAL_DELAY_MS,
+      DESKTOP_UPDATE_ENV.CHECK_INITIAL_DELAY_MS,
+    ),
+    checkIntervalMs: durationEnv(
+      env[DESKTOP_UPDATE_ENV.CHECK_INTERVAL_MS],
+      defaultPollIntervalMs(channel),
+      DESKTOP_UPDATE_ENV.CHECK_INTERVAL_MS,
+    ),
     channel,
     currentVersion,
     downloadRoot,
@@ -255,6 +339,31 @@ function artifactFileName(candidate: UpdateCandidate): string {
   ].join("-") + ext;
 }
 
+function releaseKey(candidate: UpdateCandidate, checksum: DesktopUpdateChecksumSnapshot): string {
+  const digest = checksum.value == null ? checksum.url ?? candidate.artifact.url : checksum.value;
+  return [
+    sanitizePathSegment(candidate.version),
+    sanitizePathSegment(candidate.platformKey),
+    sanitizePathSegment(candidate.arch),
+    sanitizePathSegment(createHash("sha256").update(digest).digest("hex").slice(0, 12)),
+  ].join("-");
+}
+
+function releaseMatchesCandidate(
+  saved: UpdateReleaseRef,
+  candidate: UpdateCandidate,
+): boolean {
+  if (saved.channel !== candidate.channel) return false;
+  if (saved.platformKey !== candidate.platformKey) return false;
+  if (saved.arch !== candidate.arch) return false;
+  if (saved.version !== candidate.version) return false;
+  if (saved.artifact.url !== candidate.artifact.url) return false;
+  if (saved.checksum.algorithm !== candidate.checksum.algorithm) return false;
+  if (candidate.checksum.url != null && saved.checksum.url !== candidate.checksum.url) return false;
+  if (candidate.checksum.value != null && saved.checksum.value !== candidate.checksum.value) return false;
+  return true;
+}
+
 function containsPath(root: string, path: string): boolean {
   const rel = relative(root, path);
   return rel === "" || (rel.length > 0 && !rel.startsWith("..") && !isAbsolute(rel));
@@ -275,12 +384,102 @@ async function readJson<T>(path: string): Promise<T | null> {
   }
 }
 
+async function readJsonStrict<T>(path: string): Promise<T> {
+  return JSON.parse(await readFile(path, "utf8")) as T;
+}
+
 async function directoryIsEmpty(path: string): Promise<boolean> {
   const entries = await readdir(path);
   return entries.length === 0;
 }
 
-async function ensureOwnedUpdateRoot(config: DesktopUpdaterConfig): Promise<OwnedRoot> {
+function storeShapeError(root: string, message: string, details?: unknown): DesktopUpdateErrorSnapshot {
+  return createError("update-store-invalid-shape", message, {
+    root,
+    ...(details === undefined ? {} : { details }),
+  });
+}
+
+function logStoreError(logger: DesktopUpdaterLogger, error: DesktopUpdateErrorSnapshot): void {
+  logger.error("[open-design updater] invalid update store", error);
+}
+
+function isAllowedRootEntry(name: string): boolean {
+  return name === OWNERSHIP_SENTINEL ||
+    name === STORE_METADATA_FILE ||
+    name === RELEASES_DIR ||
+    name === STAGING_DIR ||
+    name === BACK_DIR;
+}
+
+function isUpdateStoreMetadata(value: unknown): value is UpdateStoreMetadata {
+  if (!isRecord(value) || value.version !== STORE_METADATA_VERSION) return false;
+  if (value.active != null && !isUpdateReleaseRef(value.active)) return false;
+  if (value.incoming != null && !isIncomingRef(value.incoming)) return false;
+  if (value.installFrozen != null && typeof value.installFrozen !== "boolean") return false;
+  if (value.installResult != null && !isInstallResult(value.installResult)) return false;
+  if (value.lastCheckedAt != null && typeof value.lastCheckedAt !== "string") return false;
+  return true;
+}
+
+function isArtifactSnapshot(value: unknown): value is DesktopUpdateArtifactSnapshot {
+  if (!isRecord(value)) return false;
+  if (stringField(value, "platformKey") == null) return false;
+  if (stringField(value, "type") == null) return false;
+  if (stringField(value, "url") == null) return false;
+  if (value.name != null && typeof value.name !== "string") return false;
+  if (value.size != null && (typeof value.size !== "number" || !Number.isFinite(value.size))) return false;
+  return true;
+}
+
+function isChecksumSnapshot(value: unknown): value is DesktopUpdateChecksumSnapshot {
+  if (!isRecord(value)) return false;
+  if (value.algorithm !== "sha256" && value.algorithm !== "sha512") return false;
+  if (value.value != null && typeof value.value !== "string") return false;
+  if (value.url != null && typeof value.url !== "string") return false;
+  return true;
+}
+
+function isUpdateReleaseRef(value: unknown): value is UpdateReleaseRef {
+  if (!isRecord(value)) return false;
+  return stringField(value, "arch") != null &&
+    isArtifactSnapshot(value.artifact) &&
+    stringField(value, "artifactPath") != null &&
+    isChecksumSnapshot(value.checksum) &&
+    stringField(value, "checksumPath") != null &&
+    (value.channel === DESKTOP_UPDATE_CHANNELS.STABLE || value.channel === DESKTOP_UPDATE_CHANNELS.BETA) &&
+    stringField(value, "downloadedAt") != null &&
+    stringField(value, "key") != null &&
+    isRecord(value.metadata) &&
+    stringField(value, "metadataPath") != null &&
+    stringField(value, "platformKey") != null &&
+    stringField(value, "version") != null;
+}
+
+function isIncomingRef(value: unknown): value is IncomingRef {
+  if (!isRecord(value)) return false;
+  return stringField(value, "arch") != null &&
+    isArtifactSnapshot(value.artifact) &&
+    (value.channel === DESKTOP_UPDATE_CHANNELS.STABLE || value.channel === DESKTOP_UPDATE_CHANNELS.BETA) &&
+    stringField(value, "cycleId") != null &&
+    isRecord(value.metadata) &&
+    stringField(value, "platformKey") != null &&
+    stringField(value, "startedAt") != null &&
+    stringField(value, "version") != null;
+}
+
+function isInstallResult(value: unknown): value is NonNullable<DesktopUpdateStatusSnapshot["installResult"]> {
+  if (!isRecord(value)) return false;
+  if (stringField(value, "openedAt") == null) return false;
+  if (stringField(value, "path") == null) return false;
+  if (value.dryRun != null && typeof value.dryRun !== "boolean") return false;
+  return true;
+}
+
+async function ensureOwnedUpdateRoot(
+  config: DesktopUpdaterConfig,
+  logger: DesktopUpdaterLogger = console,
+): Promise<OwnedRoot> {
   const root = normalizeDownloadRoot(config.downloadRoot);
   try {
     await mkdir(root, { recursive: true });
@@ -293,7 +492,7 @@ async function ensureOwnedUpdateRoot(config: DesktopUpdaterConfig): Promise<Owne
     }
     const realRoot = await realpath(root);
     const sentinelPath = join(realRoot, OWNERSHIP_SENTINEL);
-    const manifestPath = join(realRoot, STATE_FILE);
+    const metadataPath = join(realRoot, STORE_METADATA_FILE);
     const sentinel = await readJson<{ namespace?: string; version?: number }>(sentinelPath);
     if (sentinel != null) {
       if (sentinel.version !== UPDATE_ROOT_VERSION) {
@@ -302,26 +501,68 @@ async function ensureOwnedUpdateRoot(config: DesktopUpdaterConfig): Promise<Owne
           error: createError("update-root-version-mismatch", `update root has unsupported ownership marker version at ${sentinelPath}`),
         };
       }
-      return { ok: true, manifestPath, realRoot };
+    } else {
+      if (!(await directoryIsEmpty(realRoot))) {
+        return {
+          ok: false,
+          error: createError(
+            "update-root-not-owned",
+            `update root is not empty and has no Open Design updater ownership marker: ${realRoot}`,
+          ),
+        };
+      }
+      await writeJson(sentinelPath, {
+        createdAt: new Date().toISOString(),
+        owner: "open-design-updater",
+        source: config.source,
+        version: UPDATE_ROOT_VERSION,
+      });
     }
 
-    if (!(await directoryIsEmpty(realRoot))) {
-      return {
-        ok: false,
-        error: createError(
-          "update-root-not-owned",
-          `update root is not empty and has no Open Design updater ownership marker: ${realRoot}`,
-        ),
-      };
+    const entries = await readdir(realRoot);
+    const unexpected = entries.filter((entry) => !isAllowedRootEntry(entry));
+    if (unexpected.length > 0) {
+      const error = storeShapeError(realRoot, "update store contains unexpected root entries", { unexpected });
+      logStoreError(logger, error);
+      return { ok: false, error };
     }
 
-    await writeJson(sentinelPath, {
-      createdAt: new Date().toISOString(),
-      owner: "open-design-updater",
-      source: config.source,
-      version: UPDATE_ROOT_VERSION,
-    });
-    return { ok: true, manifestPath, realRoot };
+    for (const dirName of [RELEASES_DIR, STAGING_DIR, BACK_DIR]) {
+      const path = join(realRoot, dirName);
+      let entry;
+      try {
+        entry = await lstat(path);
+      } catch {
+        continue;
+      }
+      if (!entry.isDirectory() || entry.isSymbolicLink()) {
+        const error = storeShapeError(realRoot, `update store entry ${dirName} must be a plain directory`, { path });
+        logStoreError(logger, error);
+        return { ok: false, error };
+      }
+      const realDir = await realpath(path);
+      if (!containsPath(realRoot, realDir)) {
+        const error = storeShapeError(realRoot, `update store entry ${dirName} escapes update root`, { path, realDir });
+        logStoreError(logger, error);
+        return { ok: false, error };
+      }
+    }
+
+    try {
+      await access(metadataPath);
+    } catch {
+      const nonSentinelEntries = entries.filter((entry) => entry !== OWNERSHIP_SENTINEL);
+      if (nonSentinelEntries.length > 0) {
+        const error = storeShapeError(realRoot, "update store metadata.json is missing for a non-empty store", {
+          entries: nonSentinelEntries,
+        });
+        logStoreError(logger, error);
+        return { ok: false, error };
+      }
+      await writeJson(metadataPath, { version: STORE_METADATA_VERSION });
+    }
+
+    return { ok: true, metadataPath, realRoot };
   } catch (error) {
     return {
       ok: false,
@@ -402,14 +643,15 @@ export function compareVersions(a: string, b: string): number {
   return 0;
 }
 
-function releaseVersion(metadata: Record<string, unknown>): string | null {
-  return (
-    stringField(metadata, "releaseVersion") ??
-    stringField(metadata, "betaVersion") ??
-    stringField(metadata, "nightlyVersion") ??
-    stringField(metadata, "stableVersion") ??
-    stringField(metadata, "baseVersion")
-  );
+function metadataChannel(metadata: Record<string, unknown>): DesktopUpdateChannel | null {
+  const channel = stringField(metadata, "channel");
+  if (channel === DESKTOP_UPDATE_CHANNELS.STABLE || channel === DESKTOP_UPDATE_CHANNELS.BETA) return channel;
+  return null;
+}
+
+function releaseVersionForChannel(metadata: Record<string, unknown>, channel: DesktopUpdateChannel): string | null {
+  if (channel === DESKTOP_UPDATE_CHANNELS.BETA) return stringField(metadata, "betaVersion");
+  return stringField(metadata, "releaseVersion") ?? stringField(metadata, "stableVersion");
 }
 
 function selectedMacPlatformKey(platforms: Record<string, unknown>, arch: string): string {
@@ -442,6 +684,25 @@ function selectUpdateCandidate(
     };
   }
 
+  const channel = metadataChannel(metadata);
+  if (channel == null) {
+    return {
+      ok: false,
+      state: DESKTOP_UPDATE_STATES.ERROR,
+      error: createError("metadata-channel-unsupported", "release metadata does not include a supported update channel"),
+    };
+  }
+  if (channel !== config.channel) {
+    return {
+      ok: false,
+      state: DESKTOP_UPDATE_STATES.ERROR,
+      error: createError(
+        "metadata-channel-mismatch",
+        `release metadata channel ${channel} does not match configured update channel ${config.channel}`,
+      ),
+    };
+  }
+
   const platforms = objectField(metadata, "platforms");
   if (platforms == null) {
     return {
@@ -459,12 +720,12 @@ function selectUpdateCandidate(
       error: createError("no-compatible-artifact", `release metadata does not include an enabled ${platformKey} artifact`),
     };
   }
-  const version = releaseVersion(metadata);
+  const version = releaseVersionForChannel(metadata, config.channel);
   if (version == null) {
     return {
       ok: false,
       state: DESKTOP_UPDATE_STATES.ERROR,
-      error: createError("metadata-missing-version", "release metadata does not include a release version"),
+      error: createError("metadata-missing-version", `release metadata does not include a ${config.channel} update version`),
     };
   }
   const artifacts = objectField(platform, "artifacts");
@@ -572,24 +833,6 @@ async function downloadToFile(
   );
 }
 
-async function removeContainedEntry(root: string, path: string): Promise<boolean> {
-  const resolved = resolve(path);
-  if (!containsPath(root, resolved)) return false;
-  let entry;
-  try {
-    entry = await lstat(resolved);
-  } catch {
-    return false;
-  }
-  if (entry.isSymbolicLink()) return false;
-  if (entry.isDirectory()) {
-    const real = await realpath(resolved).catch(() => null);
-    if (real == null || !containsPath(root, real)) return false;
-  }
-  await rm(resolved, { force: true, recursive: true });
-  return true;
-}
-
 async function ensureOwnedSubdir(root: string, name: string): Promise<string> {
   if (name.length === 0 || name.includes("\0") || /[\\/]/.test(name)) {
     throw new Error(`update subdirectory must be a simple path segment: ${name}`);
@@ -606,46 +849,130 @@ async function ensureOwnedSubdir(root: string, name: string): Promise<string> {
   return realDir;
 }
 
-async function existingOwnedSubdir(root: string, name: string): Promise<string | null> {
-  const dir = join(root, name);
-  let entry;
-  try {
-    entry = await lstat(dir);
-  } catch {
-    return null;
+async function cleanupBackDirectory(root: string, logger: DesktopUpdaterLogger): Promise<void> {
+  const backDir = join(root, BACK_DIR);
+  const entry = await lstat(backDir).catch(() => null);
+  if (entry == null) return;
+  if (!entry.isDirectory() || entry.isSymbolicLink()) {
+    logger.warn("[open-design updater] skipped invalid update backup directory", backDir);
+    return;
   }
-  if (!entry.isDirectory() || entry.isSymbolicLink()) return null;
-  const realDir = await realpath(dir).catch(() => null);
-  if (realDir == null || !containsPath(root, realDir)) return null;
-  return realDir;
-}
-
-async function cleanupOwnedUpdateRoot(root: string, keepPaths: readonly string[]): Promise<void> {
-  const keep = new Set(keepPaths.map((path) => resolve(path)));
-  for (const child of ["tmp", "artifacts"]) {
-    const dir = await existingOwnedSubdir(root, child);
-    if (dir == null) continue;
-    const entries = await readdir(dir).catch(() => []);
-    for (const entry of entries) {
-      const path = join(dir, entry);
-      if (keep.has(resolve(path))) continue;
-      await removeContainedEntry(root, path).catch(() => false);
+  const realBackDir = await realpath(backDir).catch(() => null);
+  if (realBackDir == null || !containsPath(root, realBackDir)) {
+    logger.warn("[open-design updater] skipped escaped update backup directory", backDir);
+    return;
+  }
+  const entries = await readdir(backDir);
+  await Promise.all(entries.map(async (entry) => {
+    const path = join(backDir, entry);
+    const resolved = resolve(path);
+    if (!containsPath(root, resolved)) return;
+    const stats = await lstat(resolved).catch(() => null);
+    if (stats == null || stats.isSymbolicLink()) return;
+    if (stats.isDirectory()) {
+      const real = await realpath(resolved).catch(() => null);
+      if (real == null || !containsPath(root, real)) return;
     }
+    await rm(resolved, { force: true, recursive: true }).catch((error: unknown) => {
+      logger.warn("[open-design updater] failed to clean update backup entry", error);
+    });
+  }));
+}
+
+function scheduleBackCleanup(root: string, logger: DesktopUpdaterLogger): void {
+  void cleanupBackDirectory(root, logger).catch((error: unknown) => {
+    logger.warn("[open-design updater] failed to clean update backup directory", error);
+  });
+}
+
+async function readStoreMetadata(root: OwnedRoot & { ok: true }, logger: DesktopUpdaterLogger): Promise<
+  | { metadata: UpdateStoreMetadata; ok: true }
+  | { error: DesktopUpdateErrorSnapshot; ok: false }
+> {
+  try {
+    const metadata = await readJsonStrict<unknown>(root.metadataPath);
+    if (!isUpdateStoreMetadata(metadata)) {
+      const error = storeShapeError(root.realRoot, "updates/metadata.json does not match the updater store schema", {
+        path: root.metadataPath,
+      });
+      logStoreError(logger, error);
+      return { ok: false, error };
+    }
+    return { ok: true, metadata };
+  } catch (error) {
+    const storeError = storeShapeError(root.realRoot, "updates/metadata.json could not be read as JSON", {
+      path: root.metadataPath,
+      reason: error instanceof Error ? error.message : String(error),
+    });
+    logStoreError(logger, storeError);
+    return { ok: false, error: storeError };
   }
 }
 
-function persistedState(value: unknown): PersistedUpdateState | null {
-  if (!isRecord(value)) return null;
-  if (value.version !== 1 || value.verified !== true) return null;
-  if (typeof value.updateVersion !== "string" || typeof value.downloadPath !== "string") return null;
-  if (typeof value.platform !== "string" || typeof value.platformKey !== "string") return null;
-  if (value.channel !== DESKTOP_UPDATE_CHANNELS.STABLE && value.channel !== DESKTOP_UPDATE_CHANNELS.BETA) return null;
-  if (!isRecord(value.metadata) || !isRecord(value.artifact) || !isRecord(value.checksum)) return null;
-  const artifact = value.artifact as DesktopUpdateArtifactSnapshot;
-  const checksum = value.checksum as DesktopUpdateChecksumSnapshot;
-  if (typeof artifact.url !== "string" || artifact.url.length === 0) return null;
-  if (checksum.algorithm !== "sha256" && checksum.algorithm !== "sha512") return null;
-  return value as PersistedUpdateState;
+async function writeStoreMetadata(root: OwnedRoot & { ok: true }, metadata: UpdateStoreMetadata): Promise<void> {
+  await writeJson(root.metadataPath, metadata);
+}
+
+function releaseSnapshot(active: LoadedRelease): DesktopUpdateStatusSnapshot["active"] {
+  const ref = active.ref;
+  return {
+    arch: ref.arch,
+    artifact: ref.artifact,
+    checksum: ref.checksum,
+    channel: ref.channel,
+    downloadedAt: ref.downloadedAt,
+    key: ref.key,
+    metadata: ref.metadata,
+    path: active.path,
+    platformKey: ref.platformKey,
+    version: ref.version,
+  };
+}
+
+function incomingSnapshot(incoming: IncomingRef, progress?: DesktopUpdateProgressSnapshot): DesktopUpdateStatusSnapshot["incoming"] {
+  return {
+    arch: incoming.arch,
+    artifact: incoming.artifact,
+    channel: incoming.channel,
+    key: incoming.cycleId,
+    metadata: incoming.metadata,
+    ...(progress == null ? {} : { progress }),
+    startedAt: incoming.startedAt,
+    version: incoming.version,
+  };
+}
+
+async function loadActiveRelease(
+  root: OwnedRoot & { ok: true },
+  metadata: UpdateStoreMetadata,
+  config: DesktopUpdaterConfig,
+  logger: DesktopUpdaterLogger,
+): Promise<{ active: LoadedRelease | null; ok: true } | { error: DesktopUpdateErrorSnapshot; ok: false }> {
+  const active = metadata.active;
+  if (active == null) return { ok: true, active: null };
+  if (compareVersions(active.version, config.currentVersion) <= 0) return { ok: true, active: null };
+  const artifactPath = resolve(root.realRoot, active.artifactPath);
+  if (!containsPath(root.realRoot, artifactPath)) {
+    const error = storeShapeError(root.realRoot, "active release artifact path escaped update root", { artifactPath });
+    logStoreError(logger, error);
+    return { ok: false, error };
+  }
+  try {
+    const file = await stat(artifactPath);
+    if (!file.isFile()) {
+      const error = storeShapeError(root.realRoot, "active release artifact is not a file", { artifactPath });
+      logStoreError(logger, error);
+      return { ok: false, error };
+    }
+  } catch (error) {
+    const storeError = storeShapeError(root.realRoot, "active release artifact is missing", {
+      artifactPath,
+      reason: error instanceof Error ? error.message : String(error),
+    });
+    logStoreError(logger, storeError);
+    return { ok: false, error: storeError };
+  }
+  return { ok: true, active: { path: artifactPath, ref: active } };
 }
 
 export function createDesktopUpdater(
@@ -654,15 +981,17 @@ export function createDesktopUpdater(
 ): DesktopUpdater {
   const config = resolveDesktopUpdaterConfig(configInput);
   const fetchImpl = deps.fetch ?? globalThis.fetch;
+  const logger = deps.logger ?? console;
   const now = deps.now ?? (() => new Date());
   const openPath = deps.openPath ?? (async () => "openPath is not available");
   const listeners = new Set<() => void>();
   let candidate: UpdateCandidate | null = null;
-  let downloadPath: string | null = null;
-  let checksum: DesktopUpdateChecksumSnapshot | null = null;
+  let activeRelease: LoadedRelease | null = null;
+  let incomingRelease: IncomingRef | null = null;
   let metadata: Record<string, unknown> | null = null;
   let lastCheckedAt: string | undefined;
   let installResult: DesktopUpdateStatusSnapshot["installResult"];
+  let installFrozen = false;
   let progress: DesktopUpdateProgressSnapshot | undefined;
   let state: DesktopUpdateState = DESKTOP_UPDATE_STATES.IDLE;
   let error: DesktopUpdateErrorSnapshot | undefined;
@@ -686,23 +1015,31 @@ export function createDesktopUpdater(
 
   function snapshot(): DesktopUpdateStatusSnapshot {
     const statusSupported = supported();
+    const active = activeRelease == null ? undefined : releaseSnapshot(activeRelease);
+    const activeArtifact = activeRelease?.ref.artifact ?? (state === DESKTOP_UPDATE_STATES.AVAILABLE ? candidate?.artifact : undefined);
+    const activeChecksum = activeRelease?.ref.checksum ?? (state === DESKTOP_UPDATE_STATES.AVAILABLE ? candidate?.checksum : undefined);
+    const availableVersion = activeRelease?.ref.version ?? candidate?.version;
+    const downloadPath = activeRelease?.path;
+    const incoming = incomingRelease == null ? undefined : incomingSnapshot(incomingRelease, progress);
     return {
+      ...(active == null ? {} : { active }),
       arch: config.arch,
-      ...(candidate?.artifact == null ? {} : { artifact: candidate.artifact }),
-      ...(candidate?.artifact.url == null ? {} : { artifactUrl: candidate.artifact.url }),
-      ...(candidate?.version == null ? {} : { availableVersion: candidate.version }),
+      ...(activeArtifact == null ? {} : { artifact: activeArtifact }),
+      ...(activeArtifact?.url == null ? {} : { artifactUrl: activeArtifact.url }),
+      ...(availableVersion == null ? {} : { availableVersion }),
       capabilities: capabilitiesFor({ mode: config.mode, platform: config.platform, supported: statusSupported }),
       channel: config.channel,
-      ...(checksum == null ? {} : { checksum }),
+      ...(activeChecksum == null ? {} : { checksum: activeChecksum }),
       currentVersion: config.currentVersion,
       ...(downloadPath == null ? {} : { downloadPath }),
       enabled: config.enabled,
       ...(error == null ? {} : { error }),
+      ...(incoming == null ? {} : { incoming }),
       ...(installResult == null ? {} : { installResult }),
       ...(lastCheckedAt == null ? {} : { lastCheckedAt }),
       ...(metadata == null ? {} : { metadata }),
       mode: config.mode,
-      paths: { downloadRoot: config.downloadRoot },
+      paths: { downloadRoot: config.downloadRoot, manifestPath: join(config.downloadRoot, STORE_METADATA_FILE) },
       platform: config.platform,
       ...(progress == null ? {} : { progress }),
       state,
@@ -729,57 +1066,91 @@ export function createDesktopUpdater(
     return null;
   }
 
-  async function restoreDownloadedState(): Promise<DesktopUpdateStatusSnapshot | null> {
-    const root = await ensureOwnedUpdateRoot(config);
-    if (!root.ok) return setState(DESKTOP_UPDATE_STATES.ERROR, root.error);
-    const saved = persistedState(await readJson(root.manifestPath));
-    if (saved == null) return null;
-    const resolvedDownload = resolve(saved.downloadPath);
-    if (!containsPath(root.realRoot, resolvedDownload)) {
-      return setState(DESKTOP_UPDATE_STATES.ERROR, createError("download-path-escaped", "saved update path is outside the update root"));
+  async function openStore(): Promise<
+    | { metadata: UpdateStoreMetadata; ok: true; root: OwnedRoot & { ok: true } }
+    | { ok: false; status: DesktopUpdateStatusSnapshot }
+  > {
+    const root = await ensureOwnedUpdateRoot(config, logger);
+    if (!root.ok) return { ok: false, status: setState(DESKTOP_UPDATE_STATES.ERROR, root.error) };
+    const loaded = await readStoreMetadata(root, logger);
+    if (!loaded.ok) return { ok: false, status: setState(DESKTOP_UPDATE_STATES.ERROR, loaded.error) };
+    return { ok: true, root, metadata: loaded.metadata };
+  }
+
+  async function restoreStoreState(): Promise<DesktopUpdateStatusSnapshot | null> {
+    const opened = await openStore();
+    if (!opened.ok) return opened.status;
+    if (opened.metadata.incoming != null) {
+      const storeError = storeShapeError(opened.root.realRoot, "update store has an interrupted incoming transaction", {
+        incoming: opened.metadata.incoming,
+      });
+      logStoreError(logger, storeError);
+      return setState(DESKTOP_UPDATE_STATES.ERROR, storeError);
     }
-    try {
-      await access(resolvedDownload);
-      const file = await stat(resolvedDownload);
-      if (!file.isFile()) return null;
-    } catch {
-      return null;
-    }
-    candidate = {
-      arch: config.arch,
-      artifact: saved.artifact,
-      checksum: saved.checksum,
-      channel: saved.channel,
-      metadata: saved.metadata,
-      platformKey: saved.platformKey,
-      version: saved.updateVersion,
-    };
-    checksum = saved.checksum;
-    metadata = saved.metadata;
-    downloadPath = resolvedDownload;
-    return setState(DESKTOP_UPDATE_STATES.DOWNLOADED);
+    const loadedActive = await loadActiveRelease(opened.root, opened.metadata, config, logger);
+    if (!loadedActive.ok) return setState(DESKTOP_UPDATE_STATES.ERROR, loadedActive.error);
+    activeRelease = loadedActive.active;
+    installFrozen = opened.metadata.installFrozen === true;
+    installResult = opened.metadata.installResult;
+    lastCheckedAt = opened.metadata.lastCheckedAt;
+    metadata = activeRelease?.ref.metadata ?? null;
+    candidate = null;
+    incomingRelease = null;
+    progress = undefined;
+    return setState(activeRelease == null ? DESKTOP_UPDATE_STATES.IDLE : DESKTOP_UPDATE_STATES.DOWNLOADED);
+  }
+
+  async function writeMetadataPatch(
+    patch: (current: UpdateStoreMetadata) => UpdateStoreMetadata,
+  ): Promise<(OwnedRoot & { ok: true }) | null> {
+    const opened = await openStore();
+    if (!opened.ok) return null;
+    await writeStoreMetadata(opened.root, patch(opened.metadata));
+    return opened.root;
   }
 
   async function checkForCandidate(options: ActionOptions = {}): Promise<DesktopUpdateStatusSnapshot> {
     const unsupported = unsupportedStatus();
     if (unsupported != null) return unsupported;
-    setState(DESKTOP_UPDATE_STATES.CHECKING);
+    if (installFrozen || installResult != null) return snapshot();
+    if (state === DESKTOP_UPDATE_STATES.IDLE) {
+      const restored = await restoreStoreState();
+      if (restored?.state === DESKTOP_UPDATE_STATES.ERROR) return restored;
+      if (installFrozen || installResult != null) return snapshot();
+    }
+    const keepDownloadedVisible = activeRelease != null;
+    if (!keepDownloadedVisible) setState(DESKTOP_UPDATE_STATES.CHECKING);
     try {
       const body = await fetchJson(fetchImpl, config.metadataUrl);
       lastCheckedAt = now().toISOString();
       metadata = body;
+      const root = await writeMetadataPatch((current) => ({
+        ...current,
+        lastCheckedAt,
+      }));
+      if (root != null) scheduleBackCleanup(root.realRoot, logger);
       const selected = selectUpdateCandidate(body, config);
       if (!selected.ok) return setState(selected.state, selected.error);
       if (compareVersions(selected.candidate.version, config.currentVersion) <= 0) {
         candidate = null;
-        checksum = null;
-        downloadPath = null;
+        activeRelease = null;
+        await writeMetadataPatch((current) => ({
+          ...current,
+          active: undefined,
+          incoming: undefined,
+          lastCheckedAt,
+        }));
         return setState(DESKTOP_UPDATE_STATES.NOT_AVAILABLE);
       }
+      if (activeRelease != null && releaseMatchesCandidate(activeRelease.ref, selected.candidate)) {
+        candidate = selected.candidate;
+        metadata = selected.candidate.metadata;
+        return setState(DESKTOP_UPDATE_STATES.DOWNLOADED);
+      }
       candidate = selected.candidate;
-      checksum = selected.candidate.checksum;
-      downloadPath = null;
-      const available = setState(DESKTOP_UPDATE_STATES.AVAILABLE);
+      const available = activeRelease == null
+        ? setState(DESKTOP_UPDATE_STATES.AVAILABLE)
+        : setState(DESKTOP_UPDATE_STATES.DOWNLOADED);
       if (options.autoDownload ?? config.autoDownload) return await downloadUpdate();
       return available;
     } catch (checkError) {
@@ -793,67 +1164,120 @@ export function createDesktopUpdater(
   async function downloadUpdate(): Promise<DesktopUpdateStatusSnapshot> {
     const unsupported = unsupportedStatus();
     if (unsupported != null) return unsupported;
+    if (installFrozen || installResult != null) return snapshot();
     if (candidate == null) {
       const checked = await checkForCandidate({ autoDownload: false });
       if (checked.state !== DESKTOP_UPDATE_STATES.AVAILABLE || candidate == null) return checked;
     }
-    const root = await ensureOwnedUpdateRoot(config);
-    if (!root.ok) return setState(DESKTOP_UPDATE_STATES.ERROR, root.error);
-    setState(DESKTOP_UPDATE_STATES.DOWNLOADING);
+    if (activeRelease != null && releaseMatchesCandidate(activeRelease.ref, candidate)) {
+      return setState(DESKTOP_UPDATE_STATES.DOWNLOADED);
+    }
+    const opened = await openStore();
+    if (!opened.ok) return opened.status;
     const nextCandidate = candidate;
     const outputName = artifactFileName(nextCandidate);
+    const cycleId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+    const startedAt = now().toISOString();
+    incomingRelease = {
+      arch: nextCandidate.arch,
+      artifact: nextCandidate.artifact,
+      channel: nextCandidate.channel,
+      cycleId,
+      metadata: nextCandidate.metadata,
+      platformKey: nextCandidate.platformKey,
+      startedAt,
+      version: nextCandidate.version,
+    };
+    progress = undefined;
+    await writeStoreMetadata(opened.root, {
+      ...opened.metadata,
+      incoming: incomingRelease,
+    });
+    setState(activeRelease == null ? DESKTOP_UPDATE_STATES.DOWNLOADING : DESKTOP_UPDATE_STATES.DOWNLOADED);
     let tmpPath: string | null = null;
+    let stagingDir: string | null = null;
+    const failDownload = async (nextError: DesktopUpdateErrorSnapshot): Promise<DesktopUpdateStatusSnapshot> => {
+      if (stagingDir != null) await rm(stagingDir, { force: true, recursive: true }).catch(() => undefined);
+      incomingRelease = null;
+      progress = undefined;
+      await writeStoreMetadata(opened.root, {
+        ...opened.metadata,
+        incoming: undefined,
+      });
+      return setState(DESKTOP_UPDATE_STATES.ERROR, nextError);
+    };
     try {
-      const artifactsDir = await ensureOwnedSubdir(root.realRoot, "artifacts");
-      const tmpDir = await ensureOwnedSubdir(root.realRoot, "tmp");
-      const finalPath = join(artifactsDir, outputName);
-      tmpPath = join(tmpDir, `${outputName}.${process.pid}.${Date.now()}.download`);
-      if (!containsPath(root.realRoot, finalPath) || !containsPath(root.realRoot, tmpPath)) {
-        return setState(DESKTOP_UPDATE_STATES.ERROR, createError("download-path-escaped", "resolved update download path escaped update root"));
+      const stagingRoot = await ensureOwnedSubdir(opened.root.realRoot, STAGING_DIR);
+      const releasesRoot = await ensureOwnedSubdir(opened.root.realRoot, RELEASES_DIR);
+      stagingDir = join(stagingRoot, cycleId);
+      if (!containsPath(opened.root.realRoot, stagingDir)) {
+        return await failDownload(createError("download-path-escaped", "resolved update staging path escaped update root"));
+      }
+      await mkdir(stagingDir, { recursive: true });
+      tmpPath = join(stagingDir, outputName);
+      if (!containsPath(opened.root.realRoot, tmpPath)) {
+        return await failDownload(createError("download-path-escaped", "resolved update download path escaped update root"));
       }
       const resolvedChecksum = await resolveChecksum(fetchImpl, nextCandidate.checksum);
-      checksum = resolvedChecksum;
-      await rm(tmpPath, { force: true });
       await downloadToFile(fetchImpl, nextCandidate.artifact.url, tmpPath, (nextProgress) => {
         progress = nextProgress;
         emit();
       });
       const digest = await hashFile(tmpPath, resolvedChecksum.algorithm);
       if (resolvedChecksum.value == null || digest.toLowerCase() !== resolvedChecksum.value.toLowerCase()) {
-        await rm(tmpPath, { force: true });
-        return setState(
-          DESKTOP_UPDATE_STATES.ERROR,
+        return await failDownload(
           createError("checksum-mismatch", "downloaded update checksum did not match release metadata", {
             actual: digest,
             expected: resolvedChecksum.value,
           }),
         );
       }
-      await mkdir(dirname(finalPath), { recursive: true });
-      await rm(finalPath, { force: true });
-      await rename(tmpPath, finalPath);
-      downloadPath = finalPath;
-      progress = undefined;
-      const persisted: PersistedUpdateState = {
+      const key = releaseKey(nextCandidate, resolvedChecksum);
+      const releaseDir = join(releasesRoot, key);
+      if (!containsPath(opened.root.realRoot, releaseDir)) {
+        return await failDownload(createError("download-path-escaped", "resolved release path escaped update root"));
+      }
+      await writeJson(join(stagingDir, "metadata.json"), nextCandidate.metadata);
+      await writeJson(join(stagingDir, "checksum.json"), resolvedChecksum);
+      try {
+        await rename(stagingDir, releaseDir);
+      } catch (renameError) {
+        return await failDownload(createError("release-promote-failed", renameError instanceof Error ? renameError.message : String(renameError)));
+      }
+      const releaseRef: UpdateReleaseRef = {
+        arch: nextCandidate.arch,
         artifact: nextCandidate.artifact,
+        artifactPath: relative(opened.root.realRoot, join(releaseDir, outputName)),
         checksum: resolvedChecksum,
+        checksumPath: relative(opened.root.realRoot, join(releaseDir, "checksum.json")),
         channel: nextCandidate.channel,
-        downloadPath: finalPath,
         downloadedAt: now().toISOString(),
+        key,
         metadata: nextCandidate.metadata,
-        platform: config.platform,
+        metadataPath: relative(opened.root.realRoot, join(releaseDir, "metadata.json")),
         platformKey: nextCandidate.platformKey,
-        updateVersion: nextCandidate.version,
-        verified: true,
-        version: 1,
+        version: nextCandidate.version,
       };
-      await writeJson(root.manifestPath, persisted);
-      await cleanupOwnedUpdateRoot(root.realRoot, [finalPath, root.manifestPath]);
+      progress = undefined;
+      activeRelease = { path: join(opened.root.realRoot, releaseRef.artifactPath), ref: releaseRef };
+      incomingRelease = null;
+      await writeStoreMetadata(opened.root, {
+        ...opened.metadata,
+        active: releaseRef,
+        incoming: undefined,
+        installFrozen: false,
+        installResult: undefined,
+        lastCheckedAt,
+        version: STORE_METADATA_VERSION,
+      });
       const downloaded = setState(DESKTOP_UPDATE_STATES.DOWNLOADED);
       if (config.autoOpen) return await installUpdate();
       return downloaded;
     } catch (downloadError) {
-      if (tmpPath != null) await rm(tmpPath, { force: true }).catch(() => undefined);
+      if (stagingDir != null) await rm(stagingDir, { force: true, recursive: true }).catch(() => undefined);
+      incomingRelease = null;
+      progress = undefined;
+      await writeMetadataPatch((current) => ({ ...current, incoming: undefined }));
       return setState(
         DESKTOP_UPDATE_STATES.ERROR,
         createError("download-failed", downloadError instanceof Error ? downloadError.message : String(downloadError)),
@@ -864,20 +1288,21 @@ export function createDesktopUpdater(
   async function installUpdate(): Promise<DesktopUpdateStatusSnapshot> {
     const unsupported = unsupportedStatus();
     if (unsupported != null) return unsupported;
-    if (downloadPath == null) {
-      const restored = await restoreDownloadedState();
-      if (restored == null || downloadPath == null) {
+    if (installFrozen && installResult != null) return snapshot();
+    if (activeRelease == null) {
+      const restored = await restoreStoreState();
+      if (restored == null || activeRelease == null) {
         return setState(DESKTOP_UPDATE_STATES.ERROR, createError("update-not-downloaded", "no downloaded update package is available"));
       }
     }
-    const root = await ensureOwnedUpdateRoot(config);
-    if (!root.ok) return setState(DESKTOP_UPDATE_STATES.ERROR, root.error);
-    const resolvedDownload = resolve(downloadPath);
-    if (!containsPath(root.realRoot, resolvedDownload)) {
+    const opened = await openStore();
+    if (!opened.ok) return opened.status;
+    const resolvedDownload = activeRelease.path;
+    if (!containsPath(opened.root.realRoot, resolvedDownload)) {
       return setState(DESKTOP_UPDATE_STATES.ERROR, createError("download-path-escaped", "download path is outside the update root"));
     }
     setState(DESKTOP_UPDATE_STATES.INSTALLING);
-    const installChecksum = checksum;
+    const installChecksum = activeRelease.ref.checksum;
     if (installChecksum?.value == null) {
       return setState(DESKTOP_UPDATE_STATES.ERROR, createError("checksum-missing", "downloaded update checksum is missing"));
     }
@@ -912,6 +1337,16 @@ export function createDesktopUpdater(
         openedAt,
         path: resolvedDownload,
       };
+      installFrozen = true;
+      await writeStoreMetadata(opened.root, {
+        ...opened.metadata,
+        active: activeRelease.ref,
+        incoming: undefined,
+        installFrozen: true,
+        installResult,
+        lastCheckedAt,
+        version: STORE_METADATA_VERSION,
+      });
       return setState(DESKTOP_UPDATE_STATES.DOWNLOADED);
     } catch (installError) {
       return setState(
@@ -929,6 +1364,7 @@ export function createDesktopUpdater(
 
   return {
     checkForUpdates: (options) => serialized(() => checkForCandidate(options)),
+    config,
     downloadUpdate: () => serialized(downloadUpdate),
     handle(action) {
       switch (action) {
@@ -949,7 +1385,7 @@ export function createDesktopUpdater(
       const unsupported = unsupportedStatus();
       if (unsupported != null) return unsupported;
       if (state === DESKTOP_UPDATE_STATES.IDLE) {
-        const restored = await restoreDownloadedState();
+        const restored = await restoreStoreState();
         if (restored != null) return restored;
       }
       return snapshot();
@@ -960,5 +1396,88 @@ export function createDesktopUpdater(
         listeners.delete(listener);
       };
     },
+  };
+}
+
+export function createDesktopUpdaterScheduler(
+  updater: DesktopUpdater,
+  options: {
+    backoffInitialMs: number;
+    backoffMaxMs: number;
+    initialDelayMs: number;
+    intervalMs: number;
+    logger?: DesktopUpdaterLogger;
+  },
+): DesktopUpdaterScheduler {
+  const logger = options.logger ?? console;
+  let running = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let failureCount = 0;
+  let tickRunning = false;
+  let unsubscribe: (() => void) | null = null;
+
+  const clearTimer = () => {
+    if (timer == null) return;
+    clearTimeout(timer);
+    timer = null;
+  };
+
+  const stop = (_reason?: string) => {
+    if (!running && timer == null) return;
+    running = false;
+    clearTimer();
+    unsubscribe?.();
+    unsubscribe = null;
+  };
+
+  const nextDelay = (status: DesktopUpdateStatusSnapshot | null): number => {
+    if (status != null && status.state !== DESKTOP_UPDATE_STATES.ERROR) {
+      failureCount = 0;
+      return options.intervalMs;
+    }
+    failureCount += 1;
+    const backoff = options.backoffInitialMs * 2 ** Math.max(0, failureCount - 1);
+    return Math.min(options.backoffMaxMs, backoff);
+  };
+
+  const schedule = (delayMs: number) => {
+    if (!running || timer != null) return;
+    timer = setTimeout(() => {
+      timer = null;
+      void tick();
+    }, delayMs);
+    timer.unref?.();
+  };
+
+  const tick = async () => {
+    if (!running || tickRunning) return;
+    tickRunning = true;
+    let status: DesktopUpdateStatusSnapshot | null = null;
+    try {
+      status = await updater.checkForUpdates();
+      if (status.installResult != null) {
+        stop("installer-opened");
+        return;
+      }
+    } catch (error) {
+      logger.warn("[open-design updater] scheduled update check failed", error);
+    } finally {
+      tickRunning = false;
+    }
+    if (running) schedule(nextDelay(status));
+  };
+
+  return {
+    isRunning: () => running,
+    start() {
+      if (running) return;
+      if (updater.snapshot().installResult != null) return;
+      running = true;
+      unsubscribe = updater.subscribe(() => {
+        if (updater.snapshot().installResult != null) stop("installer-opened");
+      });
+      schedule(options.initialDelayMs);
+    },
+    stop,
   };
 }

--- a/apps/desktop/tests/main/preload-host-boundary.test.ts
+++ b/apps/desktop/tests/main/preload-host-boundary.test.ts
@@ -17,6 +17,10 @@ describe("desktop preload host boundary", () => {
     expect(runtimeRequires).toEqual(["'electron'"]);
     expect(source).toContain("OPEN_DESIGN_HOST_GLOBAL");
     expect(source).toContain("satisfies OpenDesignHostBridge");
+    expect(source).toContain("updater");
+    expect(source).toContain("invokeUpdater('install'");
+    expect(source).toContain("od:update:quit");
+    expect(source).toContain("od:update:status-changed");
     expect(source).not.toContain("@open-design/contracts");
     expect(source).not.toContain("exposeInMainWorld('electronAPI'");
     expect(source).not.toContain('exposeInMainWorld("__odDesktop"');

--- a/apps/desktop/tests/main/updater-host-boundary.test.ts
+++ b/apps/desktop/tests/main/updater-host-boundary.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const desktopRoot = join(here, "../..");
+
+function source(relativePath: string): string {
+  return readFileSync(join(desktopRoot, relativePath), "utf8");
+}
+
+describe("desktop updater host boundary", () => {
+  it("routes renderer updater calls through the canonical host IPC surface", () => {
+    const runtime = source("src/main/runtime.ts");
+    expect(runtime).toContain("od:update:status");
+    expect(runtime).toContain("od:update:check");
+    expect(runtime).toContain("od:update:download");
+    expect(runtime).toContain("od:update:install");
+    expect(runtime).toContain("od:update:quit");
+    expect(runtime).toContain("UPDATER_STATUS_EVENT");
+    expect(runtime).toContain("event.sender !== window.webContents");
+  });
+
+  it("does not turn automatic startup checks into native desktop dialogs", () => {
+    const main = source("src/main/index.ts");
+    const scheduleStart = main.indexOf("updateScheduler = createDesktopUpdaterScheduler");
+    const nextSection = main.indexOf("attachParentMonitor", scheduleStart);
+    expect(scheduleStart).toBeGreaterThanOrEqual(0);
+    expect(nextSection).toBeGreaterThan(scheduleStart);
+    const scheduleBody = main.slice(scheduleStart, nextSection);
+    expect(scheduleBody).toContain("updateScheduler.start()");
+    expect(scheduleBody).not.toContain("showUpdateResultDialog");
+  });
+
+  it("keeps installer launch separate from desktop process shutdown", () => {
+    const runtime = source("src/main/runtime.ts");
+    const installStart = runtime.indexOf('ipcMain.handle("od:update:install"');
+    const installEnd = runtime.indexOf('ipcMain.handle("od:update:quit"');
+    expect(installStart).toBeGreaterThanOrEqual(0);
+    expect(installEnd).toBeGreaterThan(installStart);
+    const installHandler = runtime.slice(installStart, installEnd);
+    expect(installHandler).toContain("installUpdate()");
+    expect(installHandler).not.toContain("quit");
+    expect(installHandler).not.toContain("process.exit");
+    expect(installHandler).not.toContain("shutdown");
+  });
+
+  it("exposes process quit only as an explicit post-installer-open action", () => {
+    const runtime = source("src/main/runtime.ts");
+    const quitStart = runtime.indexOf('ipcMain.handle("od:update:quit"');
+    const quitEnd = runtime.indexOf('ipcMain.removeAllListeners("desktop-pet:set-visible"');
+    expect(quitStart).toBeGreaterThanOrEqual(0);
+    expect(quitEnd).toBeGreaterThan(quitStart);
+    const quitHandler = runtime.slice(quitStart, quitEnd);
+    expect(quitHandler).toContain("status.installResult == null");
+    expect(quitHandler).toContain("requestQuit");
+    expect(quitHandler).not.toContain("installUpdate()");
+  });
+});

--- a/apps/desktop/tests/main/updater.test.ts
+++ b/apps/desktop/tests/main/updater.test.ts
@@ -5,7 +5,7 @@ import { createServer, type Server } from "node:http";
 import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   DESKTOP_UPDATE_CHANNELS,
@@ -13,10 +13,18 @@ import {
   SIDECAR_SOURCES,
 } from "@open-design/sidecar-proto";
 
-import { compareVersions, createDesktopUpdater, DESKTOP_UPDATE_ENV, resolveDesktopUpdaterConfig } from "../../src/main/updater.js";
+import {
+  compareVersions,
+  createDesktopUpdater,
+  createDesktopUpdaterScheduler,
+  DESKTOP_UPDATE_ENV,
+  resolveDesktopUpdaterConfig,
+} from "../../src/main/updater.js";
 
 type FixtureServer = {
+  artifactRequests: () => number;
   close: () => Promise<void>;
+  metadataRequests: () => number;
   metadataUrl: string;
 };
 
@@ -41,9 +49,12 @@ async function createUpdaterFixture(options: {
   const channel = options.channel ?? "stable";
   const artifactBody = options.artifactBody ?? "open design updater fixture";
   const digest = createHash("sha256").update(artifactBody).digest("hex");
+  let artifactRequests = 0;
+  let metadataRequests = 0;
   const server = createServer((request, response) => {
     const url = request.url ?? "/";
     if (url === "/metadata.json") {
+      metadataRequests += 1;
       response.setHeader("content-type", "application/json");
       const betaVersion = prereleaseCounterParts(version);
       response.end(JSON.stringify({
@@ -78,6 +89,7 @@ async function createUpdaterFixture(options: {
       return;
     }
     if (url === "/artifact.dmg") {
+      artifactRequests += 1;
       response.setHeader("content-length", String(Buffer.byteLength(artifactBody)));
       response.end(artifactBody);
       return;
@@ -95,11 +107,13 @@ async function createUpdaterFixture(options: {
   });
   const address = serverAddress(server);
   return {
+    artifactRequests: () => artifactRequests,
     close: async () => {
       await new Promise<void>((resolveClose, rejectClose) => {
         server.close((error) => (error == null ? resolveClose() : rejectClose(error)));
       });
     },
+    metadataRequests: () => metadataRequests,
     metadataUrl: `http://${address}/metadata.json`,
   };
 }
@@ -134,7 +148,7 @@ function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
 }
 
 async function waitForRequestCount(requests: readonly unknown[], count: number): Promise<void> {
-  for (let attempt = 0; attempt < 20; attempt += 1) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
     if (requests.length >= count) return;
     await new Promise<void>((resolveWait) => setImmediate(resolveWait));
   }
@@ -183,6 +197,8 @@ describe("desktop updater", () => {
       expect(checked.availableVersion).toBe("1.0.1");
       expect(checked.checksum?.algorithm).toBe("sha256");
       expect(checked.downloadPath).toEqual(expect.any(String));
+      expect(checked.paths?.manifestPath).toBe(join(root, "metadata.json"));
+      expect(checked.active?.path).toBe(checked.downloadPath);
       expect(relative(await realpath(root), checked.downloadPath ?? "")).not.toMatch(/^\.\./);
       expect(await readFile(checked.downloadPath ?? "", "utf8")).toBe("open design updater fixture");
 
@@ -194,6 +210,59 @@ describe("desktop updater", () => {
       expect(installed.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       expect(installed.installResult?.dryRun).toBe(true);
       expect(installed.installResult?.path).toBe(checked.downloadPath);
+    } finally {
+      await fixture.close();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("reuses an already verified matching download during auto-check", async () => {
+    const root = makeRoot();
+    const fixture = await createUpdaterFixture();
+    try {
+      const updater = createDesktopUpdater({
+        arch: "arm64",
+        downloadRoot: root,
+        env: updaterEnv(fixture.metadataUrl),
+        source: SIDECAR_SOURCES.TOOLS_PACK,
+      });
+
+      const first = await updater.checkForUpdates();
+      expect(first.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
+      expect(first.downloadPath).toEqual(expect.any(String));
+      expect(fixture.artifactRequests()).toBe(1);
+
+      const second = await updater.checkForUpdates();
+      expect(second.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
+      expect(second.downloadPath).toBe(first.downloadPath);
+      expect(second.availableVersion).toBe(first.availableVersion);
+      expect(fixture.artifactRequests()).toBe(1);
+    } finally {
+      await fixture.close();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("reports old flat updater stores as protocol errors without repairing them", async () => {
+    const root = makeRoot();
+    const fixture = await createUpdaterFixture();
+    try {
+      await writeFile(join(root, ".open-design-updater-root.json"), JSON.stringify({
+        owner: "open-design-updater",
+        version: 1,
+      }));
+      await writeFile(join(root, "state.json"), "{}");
+      const updater = createDesktopUpdater({
+        arch: "arm64",
+        downloadRoot: root,
+        env: updaterEnv(fixture.metadataUrl),
+        source: SIDECAR_SOURCES.TOOLS_PACK,
+      });
+
+      const checked = await updater.status();
+      expect(checked.state).toBe(DESKTOP_UPDATE_STATES.ERROR);
+      expect(checked.error?.code).toBe("update-store-invalid-shape");
+      expect(existsSync(join(root, "state.json"))).toBe(true);
     } finally {
       await fixture.close();
       rmSync(root, { force: true, recursive: true });
@@ -238,6 +307,53 @@ describe("desktop updater", () => {
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       expect(checked.channel).toBe(DESKTOP_UPDATE_CHANNELS.BETA);
       expect(checked.availableVersion).toBe("1.0.1-beta.2");
+    } finally {
+      await fixture.close();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects beta metadata when the configured updater channel is stable", async () => {
+    const root = makeRoot();
+    const fixture = await createUpdaterFixture({ channel: "beta", version: "1.0.1-beta.2" });
+    try {
+      const updater = createDesktopUpdater({
+        arch: "arm64",
+        downloadRoot: root,
+        env: updaterEnv(fixture.metadataUrl),
+        source: SIDECAR_SOURCES.TOOLS_PACK,
+      });
+
+      const checked = await updater.checkForUpdates();
+      expect(checked.state).toBe(DESKTOP_UPDATE_STATES.ERROR);
+      expect(checked.channel).toBe(DESKTOP_UPDATE_CHANNELS.STABLE);
+      expect(checked.error?.code).toBe("metadata-channel-mismatch");
+      expect(checked.downloadPath).toBeUndefined();
+    } finally {
+      await fixture.close();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects stable metadata when the configured updater channel is beta", async () => {
+    const root = makeRoot();
+    const fixture = await createUpdaterFixture({ channel: "stable", version: "1.0.2" });
+    try {
+      const updater = createDesktopUpdater({
+        arch: "arm64",
+        downloadRoot: root,
+        env: {
+          ...updaterEnv(fixture.metadataUrl),
+          [DESKTOP_UPDATE_ENV.CURRENT_VERSION]: "1.0.1-beta.1",
+        },
+        source: SIDECAR_SOURCES.TOOLS_PACK,
+      });
+
+      const checked = await updater.checkForUpdates();
+      expect(checked.state).toBe(DESKTOP_UPDATE_STATES.ERROR);
+      expect(checked.channel).toBe(DESKTOP_UPDATE_CHANNELS.BETA);
+      expect(checked.error?.code).toBe("metadata-channel-mismatch");
+      expect(checked.downloadPath).toBeUndefined();
     } finally {
       await fixture.close();
       rmSync(root, { force: true, recursive: true });
@@ -348,6 +464,160 @@ describe("desktop updater", () => {
     }
   });
 
+  it("starts and stops scheduled polling idempotently", async () => {
+    const root = makeRoot();
+    const fetchImpl = vi.fn(async () => metadataResponse("1.0.1"));
+    try {
+      const updater = createDesktopUpdater(
+        {
+          arch: "arm64",
+          downloadRoot: root,
+          env: {
+            ...updaterEnv("https://example.invalid/metadata.json"),
+            [DESKTOP_UPDATE_ENV.AUTO_DOWNLOAD]: "0",
+          },
+          source: SIDECAR_SOURCES.TOOLS_PACK,
+        },
+        { fetch: fetchImpl },
+      );
+      await updater.checkForUpdates({ autoDownload: false });
+      fetchImpl.mockClear();
+      vi.useFakeTimers();
+      const scheduler = createDesktopUpdaterScheduler(updater, {
+        backoffInitialMs: 100,
+        backoffMaxMs: 1000,
+        initialDelayMs: 10,
+        intervalMs: 100,
+      });
+
+      scheduler.start();
+      scheduler.start();
+      expect(scheduler.isRunning()).toBe(true);
+      await vi.advanceTimersByTimeAsync(10);
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      scheduler.stop("test");
+      scheduler.stop("test");
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      expect(scheduler.isRunning()).toBe(false);
+    } finally {
+      vi.useRealTimers();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("does not re-enter polling while a scheduled check is still running", async () => {
+    const root = makeRoot();
+    const requests: Array<{ resolve: (response: Response) => void }> = [];
+    let blockScheduledFetch = false;
+    const fetchImpl: typeof globalThis.fetch = async () => {
+      if (!blockScheduledFetch) return metadataResponse("1.0.1");
+      const request = deferred<Response>();
+      requests.push(request);
+      return await request.promise;
+    };
+    try {
+      const updater = createDesktopUpdater(
+        {
+          arch: "arm64",
+          downloadRoot: root,
+          env: {
+            ...updaterEnv("https://example.invalid/metadata.json"),
+            [DESKTOP_UPDATE_ENV.AUTO_DOWNLOAD]: "0",
+          },
+          source: SIDECAR_SOURCES.TOOLS_PACK,
+        },
+        { fetch: fetchImpl },
+      );
+      await updater.checkForUpdates({ autoDownload: false });
+      blockScheduledFetch = true;
+      vi.useFakeTimers();
+      const scheduler = createDesktopUpdaterScheduler(updater, {
+        backoffInitialMs: 100,
+        backoffMaxMs: 1000,
+        initialDelayMs: 10,
+        intervalMs: 100,
+      });
+
+      scheduler.start();
+      await vi.advanceTimersByTimeAsync(10);
+      expect(requests).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(500);
+      expect(requests).toHaveLength(1);
+      requests[0]?.resolve(metadataResponse("1.0.1"));
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+      scheduler.stop("test");
+    } finally {
+      vi.useRealTimers();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("stops scheduled polling after the installer has been opened", async () => {
+    const root = makeRoot();
+    const fixture = await createUpdaterFixture();
+    try {
+      const updater = createDesktopUpdater({
+        arch: "arm64",
+        downloadRoot: root,
+        env: updaterEnv(fixture.metadataUrl),
+        source: SIDECAR_SOURCES.TOOLS_PACK,
+      });
+      const scheduler = createDesktopUpdaterScheduler(updater, {
+        backoffInitialMs: 100,
+        backoffMaxMs: 1000,
+        initialDelayMs: 10,
+        intervalMs: 100,
+      });
+
+      await updater.checkForUpdates();
+      scheduler.start();
+      expect(scheduler.isRunning()).toBe(true);
+      await updater.installUpdate();
+      expect(scheduler.isRunning()).toBe(false);
+      const requestsBeforeFrozenCheck = fixture.artifactRequests();
+      await updater.checkForUpdates();
+      expect(fixture.artifactRequests()).toBe(requestsBeforeFrozenCheck);
+    } finally {
+      await fixture.close();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("restores installer-open freeze before polling on cold start", async () => {
+    const root = makeRoot();
+    const fixture = await createUpdaterFixture();
+    try {
+      const updater = createDesktopUpdater({
+        arch: "arm64",
+        downloadRoot: root,
+        env: updaterEnv(fixture.metadataUrl),
+        source: SIDECAR_SOURCES.TOOLS_PACK,
+      });
+
+      const downloaded = await updater.checkForUpdates();
+      const installed = await updater.installUpdate();
+      expect(installed.installResult?.path).toBe(downloaded.downloadPath);
+      const metadataRequestsBeforeRestart = fixture.metadataRequests();
+
+      const restarted = createDesktopUpdater({
+        arch: "arm64",
+        downloadRoot: root,
+        env: updaterEnv(fixture.metadataUrl),
+        source: SIDECAR_SOURCES.TOOLS_PACK,
+      });
+      const checked = await restarted.checkForUpdates();
+
+      expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
+      expect(checked.installResult?.path).toBe(downloaded.downloadPath);
+      expect(fixture.metadataRequests()).toBe(metadataRequestsBeforeRestart);
+    } finally {
+      await fixture.close();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   it("defaults counted beta nightly builds to the beta update channel", () => {
     const root = makeRoot();
     try {
@@ -451,11 +721,11 @@ describe("desktop updater", () => {
         source: SIDECAR_SOURCES.TOOLS_PACK,
       });
       await updater.status();
-      symlinkSync(outside, join(root, "artifacts"), "dir");
+      symlinkSync(outside, join(root, "staging"), "dir");
 
       const checked = await updater.checkForUpdates();
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.ERROR);
-      expect(checked.error?.code).toBe("download-failed");
+      expect(checked.error?.code).toBe("update-store-invalid-shape");
       expect(existsSync(outsideMarker)).toBe(true);
     } finally {
       await fixture.close();

--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -15,6 +15,7 @@
 import type { ReactNode } from 'react';
 import { EntryHelpMenu } from './EntryHelpMenu';
 import { Icon } from './Icon';
+import { UpdaterPopup } from './UpdaterPopup';
 import { useT } from '../i18n';
 
 export type EntryView =
@@ -82,6 +83,7 @@ export function EntryNavRail({ view, onViewChange, onNewProject }: Props) {
             draggable={false}
           />
         </button>
+        <UpdaterPopup />
         <NavButton
           ariaLabel={t('entry.navNewProject')}
           tooltip={t('entry.navNewProject')}

--- a/apps/web/src/components/UpdaterPopup.tsx
+++ b/apps/web/src/components/UpdaterPopup.tsx
@@ -1,0 +1,216 @@
+import { useEffect, useMemo, useState, type CSSProperties } from 'react';
+
+import { Icon } from './Icon';
+import {
+  deriveUpdaterModel,
+  openUpdaterInstaller,
+  quitAfterUpdaterInstallerOpen,
+  readUpdaterStatus,
+  subscribeToUpdaterStatus,
+  type UpdaterModel,
+} from '../lib/updater';
+import type { OpenDesignHostUpdaterStatusSnapshot } from '@open-design/host';
+
+type InstallState = 'idle' | 'opening' | 'opened';
+type QuitState = 'idle' | 'quitting';
+
+function versionText(model: UpdaterModel): string {
+  const version = model.availableVersion;
+  return version == null ? 'A new version is ready.' : `Open Design ${version} is ready.`;
+}
+
+function navLabel(model: UpdaterModel): string {
+  if (model.errorMessage != null) return 'Update failed';
+  if (model.installerOpened) return 'Installer opened';
+  if (model.downloadProgress != null || model.busy) {
+    const percent = model.downloadProgress?.percent;
+    return percent == null ? 'Downloading update' : `Downloading update ${percent}%`;
+  }
+  if (model.hasDownloadedInstaller) return 'Update ready';
+  return 'Update available';
+}
+
+export function UpdaterPopup() {
+  const [model, setModel] = useState<UpdaterModel>(() => deriveUpdaterModel(null));
+  const [dismissedPromptKey, setDismissedPromptKey] = useState<string | null>(null);
+  const [panelOpen, setPanelOpen] = useState(false);
+  const [installState, setInstallState] = useState<InstallState>('idle');
+  const [quitState, setQuitState] = useState<QuitState>('idle');
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    const applyStatus = (status: OpenDesignHostUpdaterStatusSnapshot) => {
+      if (!mounted) return;
+      setModel(deriveUpdaterModel(status, { hostAvailable: true }));
+    };
+    const unsubscribe = subscribeToUpdaterStatus(applyStatus);
+    void readUpdaterStatus({ payload: { source: 'updater-popup:mount' } }).then((result) => {
+      if (!mounted) return;
+      if (result.ok) {
+        setModel(result.model);
+      } else {
+        setModel(deriveUpdaterModel(null, { hostAvailable: false }));
+      }
+    });
+    return () => {
+      mounted = false;
+      unsubscribe();
+    };
+  }, []);
+
+  const isPanelOpen = useMemo(() => {
+    if (actionError != null) return true;
+    if (panelOpen) return true;
+    if (!model.shouldPrompt || model.promptKey == null) return false;
+    return model.promptKey !== dismissedPromptKey;
+  }, [actionError, dismissedPromptKey, model.promptKey, model.shouldPrompt, panelOpen]);
+
+  if (model.environment !== 'desktop' || !model.shouldShowControl) return null;
+
+  const close = () => {
+    if (model.promptKey != null) setDismissedPromptKey(model.promptKey);
+    setPanelOpen(false);
+    setInstallState('idle');
+    setQuitState('idle');
+    setActionError(null);
+  };
+
+  const openInstaller = async () => {
+    setInstallState('opening');
+    setActionError(null);
+    const result = await openUpdaterInstaller({ payload: { source: 'updater-popup' } });
+    if (!result.ok) {
+      setActionError(result.reason);
+      setInstallState('idle');
+      return;
+    }
+    setModel(result.model);
+    if (result.model.errorMessage != null) {
+      setActionError(result.model.errorMessage);
+      setInstallState('idle');
+      return;
+    }
+    setInstallState('opened');
+    setPanelOpen(true);
+  };
+
+  const quitOpenDesign = async () => {
+    setQuitState('quitting');
+    setActionError(null);
+    const result = await quitAfterUpdaterInstallerOpen({ payload: { source: 'updater-popup' } });
+    if (!result.ok) {
+      setActionError(result.reason);
+      setQuitState('idle');
+    }
+  };
+
+  const opened = installState === 'opened' || model.installerOpened;
+  const statusError = model.errorMessage;
+  const failed = actionError != null || statusError != null;
+  const title = failed ? (opened ? 'Could not quit' : 'Update failed') : opened ? 'Installer opened' : 'Update ready';
+  const body = failed
+    ? opened
+      ? 'Open Design could not quit.'
+      : statusError ?? 'The installer could not be opened.'
+    : opened
+    ? 'The installer is open. Quit Open Design before replacing the app.'
+    : versionText(model);
+  const progress = model.downloadProgress;
+  const progressStyle = {
+    '--updater-progress': `${progress?.percent ?? 100}%`,
+  } as CSSProperties;
+  const controlDisabled = model.busy && !model.hasDownloadedInstaller && !model.installerOpened;
+  const controlLabel = navLabel(model);
+  const canOpenInstaller = model.canOpenInstaller && model.hasDownloadedInstaller;
+
+  return (
+    <div className="entry-updater-menu">
+      <button
+        aria-disabled={controlDisabled ? 'true' : undefined}
+        aria-expanded={isPanelOpen}
+        aria-label={controlLabel}
+        className={`entry-nav-rail__btn entry-updater-menu__button${isPanelOpen ? ' is-active' : ''}${controlDisabled ? ' is-disabled' : ''}`}
+        data-testid="entry-nav-updater"
+        data-tooltip={controlLabel}
+        type="button"
+        onClick={() => {
+          if (controlDisabled) return;
+          setPanelOpen((open) => !open);
+        }}
+      >
+        <Icon name={opened ? 'check' : 'download'} size={18} />
+        {progress != null ? (
+          <span
+            aria-label={controlLabel}
+            aria-valuemax={100}
+            aria-valuemin={0}
+            {...(progress.percent == null ? {} : { 'aria-valuenow': progress.percent })}
+            className="entry-updater-menu__progress"
+            data-testid="entry-nav-updater-progress"
+            role="progressbar"
+            style={progressStyle}
+          />
+        ) : null}
+      </button>
+      {isPanelOpen ? (
+        <section
+          aria-labelledby="updater-popup-title"
+          className="updater-popup"
+          data-testid="updater-popup"
+          role="dialog"
+        >
+          <div className="updater-popup__icon">
+            <Icon name={opened ? 'check' : 'download'} size={20} />
+          </div>
+          <div className="updater-popup__body">
+            <h2 id="updater-popup-title">{title}</h2>
+            <p>{body}</p>
+            {actionError != null && actionError !== body ? <p className="updater-popup__error">{actionError}</p> : null}
+          </div>
+          <div className="updater-popup__actions">
+            {opened ? (
+              <>
+                <button className="updater-popup__button" type="button" onClick={close}>
+                  Done
+                </button>
+                <button
+                  className="updater-popup__button updater-popup__button--primary"
+                  data-testid="updater-quit-button"
+                  disabled={!model.canQuitAfterInstallerOpen || quitState === 'quitting'}
+                  type="button"
+                  onClick={() => {
+                    void quitOpenDesign();
+                  }}
+                >
+                  {quitState === 'quitting' ? 'Quitting...' : 'Quit Open Design'}
+                </button>
+              </>
+            ) : failed ? (
+              <button className="updater-popup__button" type="button" onClick={close}>
+                Done
+              </button>
+            ) : (
+              <>
+                <button className="updater-popup__button" type="button" onClick={close}>
+                  Later
+                </button>
+                <button
+                  className="updater-popup__button updater-popup__button--primary"
+                  data-testid="updater-install-button"
+                  disabled={installState === 'opening' || !canOpenInstaller}
+                  type="button"
+                  onClick={() => {
+                    void openInstaller();
+                  }}
+                >
+                  {installState === 'opening' ? 'Opening...' : 'Open installer'}
+                </button>
+              </>
+            )}
+          </div>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2547,6 +2547,103 @@ a.avatar-item:visited {
 }
 .modal .row { display: flex; justify-content: flex-end; gap: 8px; margin-top: 4px; }
 
+.updater-popup {
+  position: absolute;
+  top: 0;
+  left: calc(100% + 12px);
+  z-index: 80;
+  width: min(360px, calc(100vw - var(--entry-rail-width, 56px) - 24px));
+  display: grid;
+  grid-template-columns: 44px minmax(0, 1fr);
+  gap: 14px;
+  padding: 18px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-elevated);
+  color: var(--text);
+  box-shadow: var(--shadow-lg);
+  -webkit-app-region: no-drag;
+}
+
+[dir='rtl'] .entry-updater-menu .updater-popup {
+  left: auto;
+  right: calc(100% + 12px);
+}
+
+.updater-popup__icon {
+  width: 44px;
+  height: 44px;
+  display: grid;
+  place-items: center;
+  border-radius: 8px;
+  background: color-mix(in oklab, var(--accent) 12%, var(--bg-subtle));
+  color: var(--accent);
+}
+
+.updater-popup__body {
+  min-width: 0;
+}
+
+.updater-popup__body h2 {
+  margin: 0;
+  font-size: 16px;
+  line-height: 1.25;
+  font-weight: 650;
+}
+
+.updater-popup__body p {
+  margin: 6px 0 0;
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.updater-popup__error {
+  color: var(--red) !important;
+}
+
+.updater-popup__actions {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+  min-height: 34px;
+}
+
+.updater-popup__button {
+  min-height: 34px;
+  padding: 0 12px;
+  border: 1px solid var(--border-strong);
+  border-radius: 7px;
+  background: var(--bg-panel);
+  color: var(--text);
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.updater-popup__button:hover {
+  border-color: var(--text-muted);
+}
+
+.updater-popup__button:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.updater-popup__button--primary {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: #ffffff;
+}
+
+@media (max-width: 560px) {
+  .updater-popup {
+    width: calc(100vw - var(--entry-rail-width, 56px) - 18px);
+  }
+}
+
 /* Compact rename modal */
 .modal-rename {
   width: 420px;

--- a/apps/web/src/lib/updater.ts
+++ b/apps/web/src/lib/updater.ts
@@ -1,0 +1,178 @@
+import {
+  OPEN_DESIGN_HOST_UPDATER_STATES,
+  checkHostUpdater,
+  downloadHostUpdater,
+  getHostUpdaterStatus,
+  installHostUpdater,
+  isOpenDesignHostAvailable,
+  quitHostAfterUpdaterInstallerOpen,
+  subscribeHostUpdater,
+  type OpenDesignHostActionResult,
+  type OpenDesignHostFailure,
+  type OpenDesignHostUpdaterActionOptions,
+  type OpenDesignHostUpdaterResult,
+  type OpenDesignHostUpdaterStatusListener,
+  type OpenDesignHostUpdaterStatusSnapshot,
+} from '@open-design/host';
+
+export type UpdaterEnvironment = 'desktop' | 'web';
+
+export type UpdaterDownloadProgress = {
+  percent: number | null;
+  receivedBytes: number;
+  totalBytes: number | null;
+};
+
+export type UpdaterActionResult =
+  | { ok: true; model: UpdaterModel; status: OpenDesignHostUpdaterStatusSnapshot }
+  | OpenDesignHostFailure;
+
+export type UpdaterModel = {
+  availableVersion: string | null;
+  busy: boolean;
+  canCheck: boolean;
+  canDownload: boolean;
+  canOpenInstaller: boolean;
+  canQuitAfterInstallerOpen: boolean;
+  currentVersion: string | null;
+  downloadProgress: UpdaterDownloadProgress | null;
+  enabled: boolean;
+  environment: UpdaterEnvironment;
+  errorMessage: string | null;
+  hasDownloadedInstaller: boolean;
+  installerOpened: boolean;
+  promptKey: string | null;
+  shouldShowControl: boolean;
+  shouldPrompt: boolean;
+  status: OpenDesignHostUpdaterStatusSnapshot | null;
+  supported: boolean;
+};
+
+function modelFromHostResult(result: OpenDesignHostUpdaterResult): UpdaterActionResult {
+  if (!result.ok) return result;
+  return {
+    ok: true,
+    model: deriveUpdaterModel(result.status, { hostAvailable: true }),
+    status: result.status,
+  };
+}
+
+function clampPercent(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function downloadProgressFromStatus(
+  status: OpenDesignHostUpdaterStatusSnapshot | null,
+): UpdaterDownloadProgress | null {
+  if (status == null) return null;
+  const sourceProgress = status.incoming?.progress ?? status.progress;
+  if (sourceProgress == null && status.state !== OPEN_DESIGN_HOST_UPDATER_STATES.DOWNLOADING) return null;
+
+  const receivedBytes = Math.max(0, sourceProgress?.receivedBytes ?? 0);
+  const totalBytes =
+    typeof sourceProgress?.totalBytes === 'number' && sourceProgress.totalBytes > 0
+      ? sourceProgress.totalBytes
+      : null;
+  const percent = totalBytes == null ? null : clampPercent((receivedBytes / totalBytes) * 100);
+  return {
+    percent,
+    receivedBytes,
+    totalBytes,
+  };
+}
+
+export function deriveUpdaterModel(
+  status: OpenDesignHostUpdaterStatusSnapshot | null,
+  options: { hostAvailable?: boolean } = {},
+): UpdaterModel {
+  const hostAvailable = options.hostAvailable ?? isOpenDesignHostAvailable();
+  const environment: UpdaterEnvironment = hostAvailable ? 'desktop' : 'web';
+  const state = status?.state;
+  const busy =
+    state === OPEN_DESIGN_HOST_UPDATER_STATES.CHECKING ||
+    state === OPEN_DESIGN_HOST_UPDATER_STATES.DOWNLOADING ||
+    state === OPEN_DESIGN_HOST_UPDATER_STATES.INSTALLING;
+  const canOpenInstaller = Boolean(
+    hostAvailable &&
+    status?.enabled &&
+    status.supported &&
+    status.capabilities.canOpenInstaller,
+  );
+  const hasDownloadedInstaller = Boolean(
+    state === OPEN_DESIGN_HOST_UPDATER_STATES.DOWNLOADED &&
+    status?.downloadPath,
+  );
+  const installerOpened = status?.installResult != null;
+  const availableVersion = status?.availableVersion ?? null;
+  const currentVersion = status?.currentVersion ?? null;
+  const downloadProgress = downloadProgressFromStatus(status);
+  const promptKey =
+    status == null || availableVersion == null
+      ? null
+      : [
+          status.channel,
+          currentVersion ?? 'unknown-current',
+          availableVersion,
+          status.downloadPath ?? status.artifactUrl ?? status.artifact?.url ?? 'unknown-artifact',
+        ].join(':');
+  const canQuitAfterInstallerOpen = hostAvailable && installerOpened;
+  const hasVisibleUpdaterState = Boolean(
+    hostAvailable &&
+    status?.enabled &&
+    status.supported &&
+    (busy ||
+      downloadProgress != null ||
+      availableVersion != null ||
+      hasDownloadedInstaller ||
+      installerOpened ||
+      status.error != null),
+  );
+
+  return {
+    availableVersion,
+    busy,
+    canCheck: hostAvailable && Boolean(status?.enabled) && !busy,
+    canDownload: hostAvailable && Boolean(status?.enabled && status.capabilities.canDownload) && !busy,
+    canOpenInstaller,
+    canQuitAfterInstallerOpen,
+    currentVersion,
+    downloadProgress,
+    enabled: Boolean(status?.enabled),
+    environment,
+    errorMessage: status?.error?.message ?? null,
+    hasDownloadedInstaller,
+    installerOpened,
+    promptKey,
+    shouldShowControl: hasVisibleUpdaterState,
+    shouldPrompt: canOpenInstaller && hasDownloadedInstaller && !installerOpened,
+    status,
+    supported: Boolean(status?.supported),
+  };
+}
+
+export async function readUpdaterStatus(options?: OpenDesignHostUpdaterActionOptions): Promise<UpdaterActionResult> {
+  return modelFromHostResult(await getHostUpdaterStatus(options));
+}
+
+export async function checkForUpdaterUpdate(options?: OpenDesignHostUpdaterActionOptions): Promise<UpdaterActionResult> {
+  return modelFromHostResult(await checkHostUpdater(options));
+}
+
+export async function downloadUpdaterUpdate(options?: OpenDesignHostUpdaterActionOptions): Promise<UpdaterActionResult> {
+  return modelFromHostResult(await downloadHostUpdater(options));
+}
+
+export async function openUpdaterInstaller(options?: OpenDesignHostUpdaterActionOptions): Promise<UpdaterActionResult> {
+  return modelFromHostResult(await installHostUpdater(options));
+}
+
+export async function quitAfterUpdaterInstallerOpen(
+  options?: OpenDesignHostUpdaterActionOptions,
+): Promise<OpenDesignHostActionResult> {
+  return await quitHostAfterUpdaterInstallerOpen(options);
+}
+
+export function subscribeToUpdaterStatus(listener: OpenDesignHostUpdaterStatusListener): () => void {
+  return subscribeHostUpdater(listener);
+}

--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -171,6 +171,43 @@
   flex-direction: row-reverse;
   text-align: right;
 }
+
+.entry-updater-menu {
+  position: relative;
+  display: inline-flex;
+}
+.entry-updater-menu__button {
+  position: relative;
+  overflow: hidden;
+}
+.entry-updater-menu__button.is-disabled {
+  cursor: default;
+  color: var(--text-faint);
+}
+.entry-updater-menu__button.is-disabled:hover {
+  background: transparent;
+  color: var(--text-faint);
+}
+.entry-updater-menu__progress {
+  position: absolute;
+  left: 6px;
+  right: 6px;
+  bottom: 4px;
+  height: 3px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  pointer-events: none;
+}
+.entry-updater-menu__progress::after {
+  content: '';
+  display: block;
+  width: var(--updater-progress, 100%);
+  height: 100%;
+  border-radius: inherit;
+  background: var(--accent);
+  transition: width 180ms cubic-bezier(0.23, 1, 0.32, 1);
+}
 .entry-nav-rail__logo {
   appearance: none;
   width: 36px;

--- a/apps/web/tests/components/UpdaterPopup.test.tsx
+++ b/apps/web/tests/components/UpdaterPopup.test.tsx
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { OpenDesignHostUpdaterStatusListener, OpenDesignHostUpdaterStatusSnapshot } from '@open-design/host';
+import { installMockOpenDesignHost } from '@open-design/host/testing';
+
+import { UpdaterPopup } from '../../src/components/UpdaterPopup';
+
+function idleStatus(): OpenDesignHostUpdaterStatusSnapshot {
+  return {
+    arch: 'arm64',
+    capabilities: {
+      canApplyInPlace: false,
+      canDownload: true,
+      canOpenInstaller: true,
+      requiresManualInstall: true,
+    },
+    channel: 'beta',
+    currentVersion: '1.2.3-beta.3',
+    enabled: true,
+    mode: 'package-launcher',
+    platform: 'darwin',
+    state: 'idle',
+    supported: true,
+  };
+}
+
+function downloadedStatus(overrides: Partial<OpenDesignHostUpdaterStatusSnapshot> = {}): OpenDesignHostUpdaterStatusSnapshot {
+  return {
+    ...idleStatus(),
+    availableVersion: '1.2.3-beta.4',
+    downloadPath: '/tmp/open-design-updater/Open Design Beta.dmg',
+    state: 'downloaded',
+    ...overrides,
+  };
+}
+
+describe('UpdaterPopup', () => {
+  let restoreHost: (() => void) | null = null;
+
+  afterEach(() => {
+    cleanup();
+    restoreHost?.();
+    restoreHost = null;
+  });
+
+  it('waits for host status and opens the installer from the popup', async () => {
+    let status = downloadedStatus();
+    const install = vi.fn(async () => {
+      status = downloadedStatus({
+        installResult: {
+          dryRun: true,
+          openedAt: '2026-05-19T00:00:00.000Z',
+          path: status.downloadPath ?? '/tmp/open-design-updater/Open Design Beta.dmg',
+        },
+      });
+      return status;
+    });
+    const quit = vi.fn(async () => ({ ok: true as const }));
+    restoreHost = installMockOpenDesignHost({
+      host: {
+        updater: {
+          install,
+          quit,
+          status: vi.fn(async () => status),
+        },
+      },
+    });
+
+    render(<UpdaterPopup />);
+
+    expect(await screen.findByRole('dialog', { name: 'Update ready' })).toBeTruthy();
+    fireEvent.click(screen.getByTestId('updater-install-button'));
+    expect(await screen.findByRole('dialog', { name: 'Installer opened' })).toBeTruthy();
+    fireEvent.click(screen.getByTestId('updater-quit-button'));
+    expect(install).toHaveBeenCalledWith({ payload: { source: 'updater-popup' } });
+    expect(quit).toHaveBeenCalledWith({ payload: { source: 'updater-popup' } });
+  });
+
+  it('reacts to updater subscription events without polling-only behavior', async () => {
+    const listeners = new Set<OpenDesignHostUpdaterStatusListener>();
+    restoreHost = installMockOpenDesignHost({
+      host: {
+        updater: {
+          status: vi.fn(async () => idleStatus()),
+          subscribe: vi.fn((listener) => {
+            listeners.add(listener);
+            return () => listeners.delete(listener);
+          }),
+        },
+      },
+    });
+
+    render(<UpdaterPopup />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.queryByTestId('updater-popup')).toBeNull();
+
+    act(() => {
+      for (const listener of listeners) listener(downloadedStatus());
+    });
+    expect(await screen.findByRole('dialog', { name: 'Update ready' })).toBeTruthy();
+    expect(screen.getByTestId('entry-nav-updater')).toBeTruthy();
+  });
+
+  it('shows disabled left-rail progress while an update is downloading', async () => {
+    restoreHost = installMockOpenDesignHost({
+      host: {
+        updater: {
+          status: vi.fn(async () => downloadedStatus({
+            progress: {
+              receivedBytes: 50,
+              totalBytes: 100,
+            },
+            state: 'downloading',
+          })),
+        },
+      },
+    });
+
+    render(<UpdaterPopup />);
+
+    const trigger = await screen.findByTestId('entry-nav-updater');
+    expect(trigger.getAttribute('aria-disabled')).toBe('true');
+    expect(screen.queryByTestId('updater-popup')).toBeNull();
+    expect(screen.getByRole('progressbar', { name: 'Downloading update 50%' }).getAttribute('aria-valuenow')).toBe('50');
+  });
+
+  it('keeps the popup open when opening the installer returns an updater error state', async () => {
+    restoreHost = installMockOpenDesignHost({
+      host: {
+        updater: {
+          install: vi.fn(async () => downloadedStatus({
+            error: {
+              code: 'open-installer-failed',
+              message: 'fixture open failed',
+            },
+            state: 'error',
+          })),
+          status: vi.fn(async () => downloadedStatus()),
+        },
+      },
+    });
+
+    render(<UpdaterPopup />);
+    expect(await screen.findByRole('dialog', { name: 'Update ready' })).toBeTruthy();
+    fireEvent.click(screen.getByTestId('updater-install-button'));
+    expect(await screen.findByRole('dialog', { name: 'Update failed' })).toBeTruthy();
+    expect(screen.getByText('fixture open failed')).toBeTruthy();
+  });
+
+  it('renders status errors as failed updates instead of a disabled ready action', async () => {
+    restoreHost = installMockOpenDesignHost({
+      host: {
+        updater: {
+          status: vi.fn(async () => downloadedStatus({
+            downloadPath: undefined,
+            error: {
+              code: 'update-store-invalid-shape',
+              message: 'update store contains unexpected root entries',
+            },
+            state: 'error',
+          })),
+        },
+      },
+    });
+
+    render(<UpdaterPopup />);
+
+    const trigger = await screen.findByTestId('entry-nav-updater');
+    fireEvent.click(trigger);
+    expect(await screen.findByRole('dialog', { name: 'Update failed' })).toBeTruthy();
+    expect(screen.getByText('update store contains unexpected root entries')).toBeTruthy();
+    expect(screen.queryByTestId('updater-install-button')).toBeNull();
+  });
+});

--- a/apps/web/tests/lib/updater.test.ts
+++ b/apps/web/tests/lib/updater.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { OpenDesignHostUpdaterStatusSnapshot } from '@open-design/host';
+import { installMockOpenDesignHost } from '@open-design/host/testing';
+
+import {
+  deriveUpdaterModel,
+  openUpdaterInstaller,
+  quitAfterUpdaterInstallerOpen,
+  readUpdaterStatus,
+} from '../../src/lib/updater';
+
+function downloadedStatus(overrides: Partial<OpenDesignHostUpdaterStatusSnapshot> = {}): OpenDesignHostUpdaterStatusSnapshot {
+  return {
+    arch: 'arm64',
+    artifact: {
+      name: 'Open Design Beta.dmg',
+      platformKey: 'macAppleSilicon',
+      type: 'dmg',
+      url: 'https://fixture.test/Open Design Beta.dmg',
+    },
+    availableVersion: '1.2.3-beta.4',
+    capabilities: {
+      canApplyInPlace: false,
+      canDownload: true,
+      canOpenInstaller: true,
+      requiresManualInstall: true,
+    },
+    channel: 'beta',
+    currentVersion: '1.2.3-beta.3',
+    downloadPath: '/tmp/open-design-updater/Open Design Beta.dmg',
+    enabled: true,
+    mode: 'package-launcher',
+    platform: 'darwin',
+    state: 'downloaded',
+    supported: true,
+    ...overrides,
+  };
+}
+
+describe('web updater model', () => {
+  let restoreHost: (() => void) | null = null;
+
+  afterEach(() => {
+    restoreHost?.();
+    restoreHost = null;
+  });
+
+  it('treats missing host capabilities as the web environment', () => {
+    const model = deriveUpdaterModel(null, { hostAvailable: false });
+    expect(model.environment).toBe('web');
+    expect(model.shouldPrompt).toBe(false);
+    expect(model.shouldShowControl).toBe(false);
+    expect(model.canOpenInstaller).toBe(false);
+  });
+
+  it('derives a desktop prompt only after a compatible installer is downloaded', () => {
+    const model = deriveUpdaterModel(downloadedStatus(), { hostAvailable: true });
+    expect(model.environment).toBe('desktop');
+    expect(model.shouldPrompt).toBe(true);
+    expect(model.hasDownloadedInstaller).toBe(true);
+    expect(model.canOpenInstaller).toBe(true);
+    expect(model.shouldShowControl).toBe(true);
+    expect(model.promptKey).toContain('1.2.3-beta.4');
+  });
+
+  it('derives left-rail download progress from updater snapshots', () => {
+    const model = deriveUpdaterModel(
+      downloadedStatus({
+        progress: {
+          receivedBytes: 25,
+          totalBytes: 100,
+        },
+        state: 'downloading',
+      }),
+      { hostAvailable: true },
+    );
+    expect(model.busy).toBe(true);
+    expect(model.shouldShowControl).toBe(true);
+    expect(model.downloadProgress).toEqual({
+      percent: 25,
+      receivedBytes: 25,
+      totalBytes: 100,
+    });
+  });
+
+  it('keeps the downloaded installer visible while a newer incoming download reports progress', () => {
+    const model = deriveUpdaterModel(
+      downloadedStatus({
+        incoming: {
+          arch: 'arm64',
+          artifact: {
+            name: 'Open Design Beta 1.2.3-beta.5.dmg',
+            platformKey: 'macAppleSilicon',
+            type: 'dmg',
+            url: 'https://fixture.test/Open Design Beta 1.2.3-beta.5.dmg',
+          },
+          channel: 'beta',
+          key: '1.2.3-beta.5-mac-arm64',
+          progress: {
+            receivedBytes: 64,
+            totalBytes: 256,
+          },
+          startedAt: '2026-05-19T00:00:00.000Z',
+          version: '1.2.3-beta.5',
+        },
+        state: 'downloaded',
+      }),
+      { hostAvailable: true },
+    );
+
+    expect(model.busy).toBe(false);
+    expect(model.hasDownloadedInstaller).toBe(true);
+    expect(model.shouldPrompt).toBe(true);
+    expect(model.downloadProgress).toEqual({
+      percent: 25,
+      receivedBytes: 64,
+      totalBytes: 256,
+    });
+  });
+
+  it('does not keep prompting after the installer has been opened', () => {
+    const model = deriveUpdaterModel(
+      downloadedStatus({
+        installResult: {
+          dryRun: true,
+          openedAt: '2026-05-19T00:00:00.000Z',
+          path: '/tmp/open-design-updater/Open Design Beta.dmg',
+        },
+      }),
+      { hostAvailable: true },
+    );
+    expect(model.installerOpened).toBe(true);
+    expect(model.canQuitAfterInstallerOpen).toBe(true);
+    expect(model.shouldPrompt).toBe(false);
+  });
+
+  it('routes status, install, and quit requests through host helpers with flexible payloads', async () => {
+    const status = downloadedStatus();
+    const statusFn = vi.fn(async () => status);
+    const install = vi.fn(async () => downloadedStatus({
+      installResult: {
+        dryRun: true,
+        openedAt: '2026-05-19T00:00:00.000Z',
+        path: status.downloadPath ?? '/tmp/open-design-updater/Open Design Beta.dmg',
+      },
+    }));
+    const quit = vi.fn(async () => ({ ok: true as const }));
+    restoreHost = installMockOpenDesignHost({
+      host: {
+        updater: {
+          install,
+          quit,
+          status: statusFn,
+        },
+      },
+    });
+
+    await expect(readUpdaterStatus({ payload: { source: 'test-status' } })).resolves.toMatchObject({
+      ok: true,
+      model: { shouldPrompt: true },
+    });
+    await expect(openUpdaterInstaller({ payload: { source: 'test-popup' } })).resolves.toMatchObject({
+      ok: true,
+      model: { installerOpened: true, shouldPrompt: false },
+    });
+    await expect(quitAfterUpdaterInstallerOpen({ payload: { source: 'test-quit' } })).resolves.toEqual({
+      ok: true,
+    });
+
+    expect(statusFn).toHaveBeenCalledWith({ payload: { source: 'test-status' } });
+    expect(install).toHaveBeenCalledWith({ payload: { source: 'test-popup' } });
+    expect(quit).toHaveBeenCalledWith({ payload: { source: 'test-quit' } });
+  });
+});

--- a/e2e/specs/mac.spec.ts
+++ b/e2e/specs/mac.spec.ts
@@ -33,6 +33,27 @@ const healthExpression = `
     };
   })()
 `;
+const updaterPopupExpression = `
+  (() => {
+    const popup = document.querySelector('[data-testid="updater-popup"]');
+    const button = document.querySelector('[data-testid="updater-install-button"]');
+    return {
+      installButtonVisible: button instanceof HTMLButtonElement && !button.disabled,
+      text: popup?.textContent?.trim() ?? null,
+      title: popup?.querySelector('h2')?.textContent?.trim() ?? null,
+      visible: popup instanceof HTMLElement,
+    };
+  })()
+`;
+const clickUpdaterInstallExpression = `
+  (() => {
+    const button = document.querySelector('[data-testid="updater-install-button"]');
+    if (!(button instanceof HTMLButtonElement)) return { clicked: false, reason: 'missing-install-button' };
+    if (button.disabled) return { clicked: false, reason: 'install-button-disabled' };
+    button.click();
+    return { clicked: true };
+  })()
+`;
 
 type DesktopStatus = {
   state?: string;
@@ -123,6 +144,18 @@ type HealthEvalValue = {
   title: string;
 };
 
+type UpdaterPopupEvalValue = {
+  installButtonVisible: boolean;
+  text: string | null;
+  title: string | null;
+  visible: boolean;
+};
+
+type UpdaterClickEvalValue = {
+  clicked: boolean;
+  reason?: string;
+};
+
 const shouldRunPackagedMacSmoke = process.platform === 'darwin' && process.env.OD_PACKAGED_E2E_MAC === '1';
 const macDescribe = shouldRunPackagedMacSmoke ? describe : describe.skip;
 const shouldRunDesktopMacSmoke = process.platform === 'darwin' && process.env.OD_DESKTOP_SMOKE === '1';
@@ -151,7 +184,7 @@ macDescribe('packaged mac runtime smoke', () => {
       process.env.OD_UPDATE_METADATA_URL = updaterFixture.info.metadataUrl;
       process.env.OD_UPDATE_CURRENT_VERSION = '99.0.0-beta.0';
       process.env.OD_UPDATE_OPEN_DRY_RUN = '1';
-      process.env.OD_UPDATE_AUTO_CHECK = '0';
+      process.env.OD_UPDATE_AUTO_CHECK = '1';
 
       const start = await runToolsPackJson<MacStartResult>('start');
       started = true;
@@ -180,15 +213,26 @@ macDescribe('packaged mac runtime smoke', () => {
       expect(value.health.ok).toBe(true);
       expect(value.health.version).toEqual(expect.any(String));
 
-      const updateStatus = await runToolsPackJson<MacInspectResult>('inspect', ['--update-action', 'check']);
+      const popup = await waitForUpdaterPopup();
+      expect(popup.visible).toBe(true);
+      expect(popup.title).toBe('Update ready');
+      expect(popup.installButtonVisible).toBe(true);
+      expect(popup.text ?? '').toContain(updaterFixture.info.version);
+
+      const updateStatus = await runToolsPackJson<MacInspectResult>('inspect', ['--update-action', 'status']);
       expect(updateStatus.update?.state).toBe('downloaded');
       expect(updateStatus.update?.channel).toBe('beta');
       expect(updateStatus.update?.currentVersion).toBe('99.0.0-beta.0');
       expect(updateStatus.update?.availableVersion).toBe(updaterFixture.info.version);
       expectPathInside(updateStatus.update?.downloadPath ?? '', join(runtimeNamespaceRoot, 'updates'));
-      const updateInstall = await runToolsPackJson<MacInspectResult>('inspect', ['--update-action', 'install']);
+
+      const clickInstall = await runToolsPackJson<MacInspectResult>('inspect', ['--expr', clickUpdaterInstallExpression]);
+      const clickValue = assertUpdaterClickEvalValue(clickInstall.eval?.value);
+      expect(clickValue.clicked).toBe(true);
+      const updateInstall = await waitForUpdaterInstallerOpened();
       expect(updateInstall.update?.state).toBe('downloaded');
       expect(updateInstall.update?.installResult?.dryRun).toBe(true);
+      expectPathInside(updateInstall.update?.installResult?.path ?? '', join(runtimeNamespaceRoot, 'updates'));
 
       await mkdir(dirname(screenshotPath), { recursive: true });
       const screenshot = await runToolsPackJson<MacInspectResult>('inspect', ['--path', screenshotPath]);
@@ -232,6 +276,11 @@ macDescribe('packaged mac runtime smoke', () => {
         },
         stop,
         uninstall,
+        update: {
+          popup,
+          status: updateStatus.update,
+          install: updateInstall.update,
+        },
       });
       passed = true;
     } finally {
@@ -1592,6 +1641,47 @@ async function waitForHealthyDesktop(): Promise<MacInspectResult> {
   throw new Error(`packaged mac runtime did not become healthy: ${formatUnknown(lastResult)}`);
 }
 
+async function waitForUpdaterPopup(): Promise<UpdaterPopupEvalValue> {
+  const timeoutMs = 90_000;
+  const startedAt = Date.now();
+  let lastResult: unknown = null;
+
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const inspect = await runToolsPackJson<MacInspectResult>('inspect', ['--expr', updaterPopupExpression]);
+      lastResult = inspect;
+      if (inspect.status?.state === 'running' && inspect.eval?.ok === true) {
+        const value = asUpdaterPopupEvalValue(inspect.eval.value);
+        if (value?.visible === true && value.installButtonVisible === true) return value;
+      }
+    } catch (error) {
+      lastResult = error;
+    }
+    await delay(1000);
+  }
+
+  throw new Error(`packaged mac updater popup did not appear: ${formatUnknown(lastResult)}`);
+}
+
+async function waitForUpdaterInstallerOpened(): Promise<MacInspectResult> {
+  const timeoutMs = 60_000;
+  const startedAt = Date.now();
+  let lastResult: unknown = null;
+
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const inspect = await runToolsPackJson<MacInspectResult>('inspect', ['--update-action', 'status']);
+      lastResult = inspect;
+      if (inspect.update?.installResult?.path != null) return inspect;
+    } catch (error) {
+      lastResult = error;
+    }
+    await delay(1000);
+  }
+
+  throw new Error(`packaged mac updater did not observe installer open: ${formatUnknown(lastResult)}`);
+}
+
 function assertLogPathsAndContent(result: LogsResult): void {
   expect(result.namespace).toBe(namespace);
   for (const app of ['desktop', 'web', 'daemon']) {
@@ -1637,11 +1727,35 @@ function assertHealthEvalValue(value: unknown): HealthEvalValue {
   return normalized;
 }
 
+function assertUpdaterClickEvalValue(value: unknown): UpdaterClickEvalValue {
+  const normalized = asUpdaterClickEvalValue(value);
+  if (normalized == null) {
+    throw new Error(`unexpected updater click eval value: ${formatUnknown(value)}`);
+  }
+  return normalized;
+}
+
 function asHealthEvalValue(value: unknown): HealthEvalValue | null {
   if (!isRecord(value)) return null;
   if (typeof value.href !== 'string' || typeof value.status !== 'number' || typeof value.title !== 'string') return null;
   if (!isRecord(value.health)) return null;
   return value as HealthEvalValue;
+}
+
+function asUpdaterPopupEvalValue(value: unknown): UpdaterPopupEvalValue | null {
+  if (!isRecord(value)) return null;
+  if (typeof value.visible !== 'boolean') return null;
+  if (typeof value.installButtonVisible !== 'boolean') return null;
+  if (value.title != null && typeof value.title !== 'string') return null;
+  if (value.text != null && typeof value.text !== 'string') return null;
+  return value as UpdaterPopupEvalValue;
+}
+
+function asUpdaterClickEvalValue(value: unknown): UpdaterClickEvalValue | null {
+  if (!isRecord(value)) return null;
+  if (typeof value.clicked !== 'boolean') return null;
+  if (value.reason != null && typeof value.reason !== 'string') return null;
+  return value as UpdaterClickEvalValue;
 }
 
 function expectPathInside(filePath: string, expectedRoot: string): void {

--- a/packages/host/src/index.ts
+++ b/packages/host/src/index.ts
@@ -48,6 +48,141 @@ export type OpenDesignHostPdfPrintOptions = {
   deck?: boolean;
 };
 
+export const OPEN_DESIGN_HOST_UPDATER_ACTIONS = Object.freeze({
+  CHECK: "check",
+  DOWNLOAD: "download",
+  INSTALL: "install",
+  QUIT: "quit",
+  STATUS: "status",
+} as const);
+
+export type OpenDesignHostUpdaterAction =
+  (typeof OPEN_DESIGN_HOST_UPDATER_ACTIONS)[keyof typeof OPEN_DESIGN_HOST_UPDATER_ACTIONS];
+type OpenDesignHostUpdaterStatusAction = Exclude<
+  OpenDesignHostUpdaterAction,
+  typeof OPEN_DESIGN_HOST_UPDATER_ACTIONS.QUIT
+>;
+
+export const OPEN_DESIGN_HOST_UPDATER_STATES = Object.freeze({
+  AVAILABLE: "available",
+  CHECKING: "checking",
+  DOWNLOADED: "downloaded",
+  DOWNLOADING: "downloading",
+  ERROR: "error",
+  IDLE: "idle",
+  INSTALLING: "installing",
+  NOT_AVAILABLE: "not-available",
+  UNSUPPORTED: "unsupported",
+} as const);
+
+export type OpenDesignHostUpdaterState =
+  (typeof OPEN_DESIGN_HOST_UPDATER_STATES)[keyof typeof OPEN_DESIGN_HOST_UPDATER_STATES];
+
+export type OpenDesignHostUpdaterMode = "js-incremental" | "package-launcher";
+export type OpenDesignHostUpdaterChannel = "beta" | "stable";
+
+export type OpenDesignHostUpdaterActionOptions = {
+  payload?: Record<string, unknown>;
+};
+
+export type OpenDesignHostUpdaterCapabilitySet = {
+  canApplyInPlace: boolean;
+  canDownload: boolean;
+  canOpenInstaller: boolean;
+  requiresManualInstall: boolean;
+};
+
+export type OpenDesignHostUpdaterPathSnapshot = {
+  downloadRoot?: string;
+  manifestPath?: string;
+};
+
+export type OpenDesignHostUpdaterChecksumSnapshot = {
+  algorithm: "sha256" | "sha512";
+  url?: string;
+  value?: string;
+};
+
+export type OpenDesignHostUpdaterArtifactSnapshot = {
+  name?: string;
+  platformKey?: string;
+  size?: number;
+  type?: string;
+  url: string;
+};
+
+export type OpenDesignHostUpdaterProgressSnapshot = {
+  receivedBytes: number;
+  totalBytes?: number;
+};
+
+export type OpenDesignHostUpdaterErrorSnapshot = {
+  code: string;
+  details?: unknown;
+  message: string;
+};
+
+export type OpenDesignHostUpdaterInstallResult = {
+  dryRun?: boolean;
+  openedAt: string;
+  path: string;
+};
+
+export type OpenDesignHostUpdaterReleaseSnapshot = {
+  arch: string;
+  artifact: OpenDesignHostUpdaterArtifactSnapshot;
+  checksum: OpenDesignHostUpdaterChecksumSnapshot;
+  channel: OpenDesignHostUpdaterChannel;
+  downloadedAt: string;
+  key: string;
+  metadata?: Record<string, unknown>;
+  path: string;
+  platformKey: string;
+  version: string;
+};
+
+export type OpenDesignHostUpdaterIncomingSnapshot = {
+  arch: string;
+  artifact: OpenDesignHostUpdaterArtifactSnapshot;
+  channel: OpenDesignHostUpdaterChannel;
+  key?: string;
+  metadata?: Record<string, unknown>;
+  progress?: OpenDesignHostUpdaterProgressSnapshot;
+  startedAt: string;
+  version: string;
+};
+
+export type OpenDesignHostUpdaterStatusSnapshot = {
+  active?: OpenDesignHostUpdaterReleaseSnapshot;
+  arch: string;
+  artifact?: OpenDesignHostUpdaterArtifactSnapshot;
+  artifactUrl?: string;
+  availableVersion?: string;
+  capabilities: OpenDesignHostUpdaterCapabilitySet;
+  channel: OpenDesignHostUpdaterChannel;
+  checksum?: OpenDesignHostUpdaterChecksumSnapshot;
+  currentVersion: string;
+  downloadPath?: string;
+  enabled: boolean;
+  error?: OpenDesignHostUpdaterErrorSnapshot;
+  incoming?: OpenDesignHostUpdaterIncomingSnapshot;
+  installResult?: OpenDesignHostUpdaterInstallResult;
+  lastCheckedAt?: string;
+  metadata?: Record<string, unknown>;
+  mode: OpenDesignHostUpdaterMode;
+  paths?: OpenDesignHostUpdaterPathSnapshot;
+  platform: string;
+  progress?: OpenDesignHostUpdaterProgressSnapshot;
+  state: OpenDesignHostUpdaterState;
+  supported: boolean;
+};
+
+export type OpenDesignHostUpdaterResult =
+  | { ok: true; status: OpenDesignHostUpdaterStatusSnapshot }
+  | OpenDesignHostFailure;
+
+export type OpenDesignHostUpdaterStatusListener = (status: OpenDesignHostUpdaterStatusSnapshot) => void;
+
 export type OpenDesignHostBridge = {
   client: OpenDesignHostClient;
   pdf: {
@@ -62,6 +197,14 @@ export type OpenDesignHostBridge = {
   shell: {
     openExternal(url: string): Promise<OpenDesignHostActionResult>;
     openPath(projectId: string): Promise<OpenDesignHostActionResult>;
+  };
+  updater: {
+    check(options?: OpenDesignHostUpdaterActionOptions): Promise<OpenDesignHostUpdaterStatusSnapshot>;
+    download(options?: OpenDesignHostUpdaterActionOptions): Promise<OpenDesignHostUpdaterStatusSnapshot>;
+    install(options?: OpenDesignHostUpdaterActionOptions): Promise<OpenDesignHostUpdaterStatusSnapshot>;
+    quit(options?: OpenDesignHostUpdaterActionOptions): Promise<OpenDesignHostActionResult>;
+    status(options?: OpenDesignHostUpdaterActionOptions): Promise<OpenDesignHostUpdaterStatusSnapshot>;
+    subscribe(listener: OpenDesignHostUpdaterStatusListener): () => void;
   };
   version: typeof OPEN_DESIGN_HOST_VERSION;
 };
@@ -104,6 +247,19 @@ export function isOpenDesignHostBridge(value: unknown): value is OpenDesignHostB
 
   const pet = value.pet;
   if (!isRecord(pet) || !hasFunction(pet, "setVisible")) return false;
+
+  const updater = value.updater;
+  if (
+    !isRecord(updater) ||
+    !hasFunction(updater, "status") ||
+    !hasFunction(updater, "check") ||
+    !hasFunction(updater, "download") ||
+    !hasFunction(updater, "install") ||
+    !hasFunction(updater, "quit") ||
+    !hasFunction(updater, "subscribe")
+  ) {
+    return false;
+  }
 
   return true;
 }
@@ -228,5 +384,76 @@ export function setHostPetVisible(visible: boolean, scope: OpenDesignHostGlobalS
     return { ok: true };
   } catch (error) {
     return unavailable(error instanceof Error ? error.message : String(error));
+  }
+}
+
+async function runHostUpdaterAction(
+  action: OpenDesignHostUpdaterStatusAction,
+  options?: OpenDesignHostUpdaterActionOptions,
+  scope: OpenDesignHostGlobalScope = globalThis,
+): Promise<OpenDesignHostUpdaterResult> {
+  const host = getOpenDesignHost(scope);
+  if (host == null) return unavailable("Open Design host is not available");
+  try {
+    return {
+      ok: true,
+      status: await host.updater[action](options),
+    };
+  } catch (error) {
+    return unavailable(error instanceof Error ? error.message : String(error));
+  }
+}
+
+export async function getHostUpdaterStatus(
+  options?: OpenDesignHostUpdaterActionOptions,
+  scope: OpenDesignHostGlobalScope = globalThis,
+): Promise<OpenDesignHostUpdaterResult> {
+  return await runHostUpdaterAction(OPEN_DESIGN_HOST_UPDATER_ACTIONS.STATUS, options, scope);
+}
+
+export async function checkHostUpdater(
+  options?: OpenDesignHostUpdaterActionOptions,
+  scope: OpenDesignHostGlobalScope = globalThis,
+): Promise<OpenDesignHostUpdaterResult> {
+  return await runHostUpdaterAction(OPEN_DESIGN_HOST_UPDATER_ACTIONS.CHECK, options, scope);
+}
+
+export async function downloadHostUpdater(
+  options?: OpenDesignHostUpdaterActionOptions,
+  scope: OpenDesignHostGlobalScope = globalThis,
+): Promise<OpenDesignHostUpdaterResult> {
+  return await runHostUpdaterAction(OPEN_DESIGN_HOST_UPDATER_ACTIONS.DOWNLOAD, options, scope);
+}
+
+export async function installHostUpdater(
+  options?: OpenDesignHostUpdaterActionOptions,
+  scope: OpenDesignHostGlobalScope = globalThis,
+): Promise<OpenDesignHostUpdaterResult> {
+  return await runHostUpdaterAction(OPEN_DESIGN_HOST_UPDATER_ACTIONS.INSTALL, options, scope);
+}
+
+export async function quitHostAfterUpdaterInstallerOpen(
+  options?: OpenDesignHostUpdaterActionOptions,
+  scope: OpenDesignHostGlobalScope = globalThis,
+): Promise<OpenDesignHostActionResult> {
+  const host = getOpenDesignHost(scope);
+  if (host == null) return unavailable("Open Design host is not available");
+  try {
+    return await host.updater.quit(options);
+  } catch (error) {
+    return unavailable(error instanceof Error ? error.message : String(error));
+  }
+}
+
+export function subscribeHostUpdater(
+  listener: OpenDesignHostUpdaterStatusListener,
+  scope: OpenDesignHostGlobalScope = globalThis,
+): () => void {
+  const host = getOpenDesignHost(scope);
+  if (host == null) return () => undefined;
+  try {
+    return host.updater.subscribe(listener);
+  } catch {
+    return () => undefined;
   }
 }

--- a/packages/host/src/testing.ts
+++ b/packages/host/src/testing.ts
@@ -3,14 +3,16 @@ import {
   OPEN_DESIGN_HOST_VERSION,
   type OpenDesignHostBridge,
   type OpenDesignHostGlobalScope,
+  type OpenDesignHostUpdaterStatusSnapshot,
 } from "./index.js";
 
-export type MockOpenDesignHost = Partial<Omit<OpenDesignHostBridge, "client" | "pdf" | "pet" | "project" | "shell">> & {
+export type MockOpenDesignHost = Partial<Omit<OpenDesignHostBridge, "client" | "pdf" | "pet" | "project" | "shell" | "updater">> & {
   client?: Partial<OpenDesignHostBridge["client"]>;
   pdf?: Partial<OpenDesignHostBridge["pdf"]>;
   pet?: Partial<OpenDesignHostBridge["pet"]>;
   project?: Partial<OpenDesignHostBridge["project"]>;
   shell?: Partial<OpenDesignHostBridge["shell"]>;
+  updater?: Partial<OpenDesignHostBridge["updater"]>;
 };
 
 export type MockOpenDesignHostOptions = {
@@ -19,6 +21,22 @@ export type MockOpenDesignHostOptions = {
 };
 
 function defaultHost(): OpenDesignHostBridge {
+  const updaterStatus: OpenDesignHostUpdaterStatusSnapshot = {
+    arch: "arm64",
+    capabilities: {
+      canApplyInPlace: false,
+      canDownload: true,
+      canOpenInstaller: true,
+      requiresManualInstall: true,
+    },
+    channel: "beta",
+    currentVersion: "1.0.0-beta.0",
+    enabled: true,
+    mode: "package-launcher",
+    platform: "darwin",
+    state: "idle",
+    supported: true,
+  };
   return {
     version: OPEN_DESIGN_HOST_VERSION,
     client: {
@@ -43,6 +61,14 @@ function defaultHost(): OpenDesignHostBridge {
     pet: {
       setVisible: () => undefined,
     },
+    updater: {
+      check: async () => updaterStatus,
+      download: async () => updaterStatus,
+      install: async () => updaterStatus,
+      quit: async () => ({ ok: true }),
+      status: async () => updaterStatus,
+      subscribe: () => () => undefined,
+    },
   };
 }
 
@@ -56,6 +82,7 @@ export function createMockOpenDesignHost(overrides: MockOpenDesignHost = {}): Op
     project: { ...base.project, ...overrides.project },
     pdf: { ...base.pdf, ...overrides.pdf },
     pet: { ...base.pet, ...overrides.pet },
+    updater: { ...base.updater, ...overrides.updater },
   };
 }
 

--- a/packages/host/tests/index.test.ts
+++ b/packages/host/tests/index.test.ts
@@ -7,8 +7,11 @@ import { describe, expect, it, vi } from "vitest";
 import {
   OPEN_DESIGN_HOST_GLOBAL,
   OPEN_DESIGN_HOST_VERSION,
+  checkHostUpdater,
   detectOpenDesignHostClientType,
+  getHostUpdaterStatus,
   getOpenDesignHost,
+  installHostUpdater,
   isOpenDesignHostAvailable,
   isOpenDesignHostBridge,
   normalizeOpenDesignHostProjectImportResult,
@@ -16,7 +19,9 @@ import {
   pickAndImportHostProject,
   printHostPdf,
   openHostProjectPath,
+  quitHostAfterUpdaterInstallerOpen,
   setHostPetVisible,
+  subscribeHostUpdater,
 } from "../src/index.js";
 import { createMockOpenDesignHost, installMockOpenDesignHost } from "../src/testing.js";
 
@@ -64,6 +69,10 @@ describe("open-design host contract", () => {
     expect(isOpenDesignHostBridge({
       ...createMockOpenDesignHost(),
       shell: { openExternal: async () => ({ ok: true }) },
+    })).toBe(false);
+    expect(isOpenDesignHostBridge({
+      ...createMockOpenDesignHost(),
+      updater: { status: async () => createMockOpenDesignHost().updater.status() },
     })).toBe(false);
   });
 
@@ -186,6 +195,77 @@ describe("open-design host contract", () => {
     expect(pickAndImport).toHaveBeenCalledWith({ skillId: "skill-1" });
     expect(print).toHaveBeenCalledWith("<html></html>", "nonce", { deck: true });
     expect(setVisible).toHaveBeenCalledWith(true);
+  });
+
+  it("routes updater status, actions, and subscriptions through package-owned helpers", async () => {
+    const status = {
+      arch: "arm64",
+      availableVersion: "1.0.1-beta.1",
+      capabilities: {
+        canApplyInPlace: false,
+        canDownload: true,
+        canOpenInstaller: true,
+        requiresManualInstall: true,
+      },
+      channel: "beta" as const,
+      currentVersion: "1.0.0-beta.0",
+      downloadPath: "/tmp/Open Design Beta.dmg",
+      enabled: true,
+      mode: "package-launcher" as const,
+      platform: "darwin",
+      state: "downloaded" as const,
+      supported: true,
+    };
+    const check = vi.fn(async () => status);
+    const install = vi.fn(async () => status);
+    const quit = vi.fn(async () => ({ ok: true as const }));
+    const statusFn = vi.fn(async () => status);
+    const unsubscribe = vi.fn();
+    const subscribe = vi.fn(() => unsubscribe);
+    const scope: Record<string, unknown> = {};
+    scope[OPEN_DESIGN_HOST_GLOBAL] = createMockOpenDesignHost({
+      updater: { check, install, quit, status: statusFn, subscribe },
+    });
+
+    await expect(getHostUpdaterStatus({ payload: { source: "mount" } }, scope)).resolves.toEqual({
+      ok: true,
+      status,
+    });
+    await expect(checkHostUpdater({ payload: { source: "button" } }, scope)).resolves.toEqual({
+      ok: true,
+      status,
+    });
+    await expect(installHostUpdater({ payload: { source: "popup" } }, scope)).resolves.toEqual({
+      ok: true,
+      status,
+    });
+    await expect(quitHostAfterUpdaterInstallerOpen({ payload: { source: "opened-popup" } }, scope)).resolves.toEqual({
+      ok: true,
+    });
+
+    const listener = vi.fn();
+    expect(subscribeHostUpdater(listener, scope)).toBe(unsubscribe);
+    expect(statusFn).toHaveBeenCalledWith({ payload: { source: "mount" } });
+    expect(check).toHaveBeenCalledWith({ payload: { source: "button" } });
+    expect(install).toHaveBeenCalledWith({ payload: { source: "popup" } });
+    expect(quit).toHaveBeenCalledWith({ payload: { source: "opened-popup" } });
+    expect(subscribe).toHaveBeenCalledWith(listener);
+  });
+
+  it("wraps updater action throws into structured failures", async () => {
+    const scope: Record<string, unknown> = {};
+    scope[OPEN_DESIGN_HOST_GLOBAL] = createMockOpenDesignHost({
+      updater: {
+        check: vi.fn(async () => {
+          throw new Error("updater failed");
+        }),
+      },
+    });
+
+    await expect(checkHostUpdater(undefined, scope)).resolves.toEqual({
+      ok: false,
+      reason: "updater failed",
+    });
   });
 
   it("installs and restores test hosts without exposing callers to the global key", () => {

--- a/packages/sidecar-proto/src/index.ts
+++ b/packages/sidecar-proto/src/index.ts
@@ -268,7 +268,32 @@ export type DesktopUpdateInstallResult = {
   path: string;
 };
 
+export type DesktopUpdateReleaseSnapshot = {
+  arch: string;
+  artifact: DesktopUpdateArtifactSnapshot;
+  checksum: DesktopUpdateChecksumSnapshot;
+  channel: DesktopUpdateChannel;
+  downloadedAt: string;
+  key: string;
+  metadata?: Record<string, unknown>;
+  path: string;
+  platformKey: string;
+  version: string;
+};
+
+export type DesktopUpdateIncomingSnapshot = {
+  arch: string;
+  artifact: DesktopUpdateArtifactSnapshot;
+  channel: DesktopUpdateChannel;
+  key?: string;
+  metadata?: Record<string, unknown>;
+  progress?: DesktopUpdateProgressSnapshot;
+  startedAt: string;
+  version: string;
+};
+
 export type DesktopUpdateStatusSnapshot = {
+  active?: DesktopUpdateReleaseSnapshot;
   arch: string;
   artifact?: DesktopUpdateArtifactSnapshot;
   artifactUrl?: string;
@@ -280,6 +305,7 @@ export type DesktopUpdateStatusSnapshot = {
   downloadPath?: string;
   enabled: boolean;
   error?: DesktopUpdateErrorSnapshot;
+  incoming?: DesktopUpdateIncomingSnapshot;
   installResult?: DesktopUpdateInstallResult;
   lastCheckedAt?: string;
   metadata?: Record<string, unknown>;


### PR DESCRIPTION
## Why

This PR closes the release-beta desktop updater hardening loop. While validating packaged desktop updates, we needed a single host contract where desktop injects updater capability, web models it through `@open-design/host`, and the UI can drive the end-to-end flow without directly reading `window.__od__`.

It also addresses stale local update data discovered during manual validation: old flat `updates` stores can no longer make the UI look ready with a disabled installer action. Invalid updater store shape now goes through the updater error channel with audit-ready detail.

## What users will see

Desktop users see an updater indicator in the left rail with download progress. Clicking it opens a popup from that location. When an update is ready, the popup exposes `Open installer`; after opening the installer, polling stops and mac users can explicitly quit Open Design from the popup to finish DMG installation.

If the local updater store is invalid, users see `Update failed` instead of a misleading ready state or disabled installer button.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Draft PR: manual release-beta package validation was performed locally. Screenshot attachment can be added during final review if needed.

## Bug fix verification

-

## Validation

- `git diff --check`
- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/desktop test`
- `pnpm --filter @open-design/web test -- tests/lib/updater.test.ts tests/components/UpdaterPopup.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm tools-pack mac build --dir .tmp/tools-pack-release-beta-manual --namespace release-beta --portable --app-version 0.8.0-beta.5 --to dmg`
- Manual release-beta package validation: restored valid updater store and confirmed downloaded state exposes an enabled `Open installer` action.
- Manual abnormal-store validation: simulated old flat `updates` shape, confirmed inspect reports `update-store-invalid-shape`, left rail shows `Update failed`, and the popup does not render a disabled installer action.
