### PR TITLE
fix: prevent long template names from being obscured by Official badge

### DIFF
--- a/apps/web/src/styles/home/plugins-view.css
+++ b/apps/web/src/styles/home/plugins-view.css
@@ -328,6 +328,17 @@
   font-weight: 650;
 }
 
+.plugins-view__row-title > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.plugins-view__row-title > .trust-badge {
+  flex: 0 0 auto;
+}
+
 .plugins-view__row-main p {
   margin: 5px 0 0;
   color: var(--text-muted);


### PR DESCRIPTION
Fixes #2208

Added CSS rules to truncate long template names with ellipsis while keeping the Official badge fully visible.

Changes:
- Title span: min-width: 0, overflow: hidden, text-overflow: ellipsis, white-space: nowrap
- Badge: flex: 0 0 auto to prevent shrinking

This prevents visual collision between long titles and the badge on plugin/template cards.