### PR TITLE
feat(daemon): emit clean-URL vercel.json for multi-page deploys

### DIFF
--- a/apps/daemon/src/deploy.ts
+++ b/apps/daemon/src/deploy.ts
@@ -327,6 +327,18 @@ export async function buildDeployFilePlan(projectsRoot: string, projectId: strin
     }
   }
 
+  if (!files.has('vercel.json') && !visited.has('vercel.json')) {
+    try {
+      const rootVercel = await readProjectFile(projectsRoot, projectId, 'vercel.json', options.metadata);
+      files.set('vercel.json', {
+        file: 'vercel.json',
+        data: rootVercel.buffer,
+        contentType: rootVercel.mime,
+        sourcePath: 'vercel.json',
+      });
+    } catch {}
+  }
+
   const fileList = Array.from(files.values());
   const routing = buildVercelRoutingConfig(fileList);
   if (routing) {

--- a/apps/daemon/src/deploy.ts
+++ b/apps/daemon/src/deploy.ts
@@ -1451,7 +1451,7 @@ export function buildVercelRoutingConfig(files: DeployFile[]): VercelRoutingConf
     const original = Buffer.isBuffer(f.data) || f.data instanceof Uint8Array
       ? Buffer.from(f.data).toString('utf8')
       : String(f.data);
-    const rewritten = rewriteAnchorHrefsToCleanRoutes(original, pathToRoute);
+    const rewritten = rewriteAnchorHrefsToCleanRoutes(original, pathToRoute, f.file);
     if (rewritten !== original) {
       rewrittenHtml.set(f.file, rewritten);
     }
@@ -1473,14 +1473,21 @@ function htmlPathToCleanRoute(filePath: string) {
   return `/${stripped}`;
 }
 
-function rewriteAnchorHrefsToCleanRoutes(html: string, pathToRoute: Map<string, string>) {
+function rewriteAnchorHrefsToCleanRoutes(html: string, pathToRoute: Map<string, string>, currentFile: string) {
+  const currentDir = path.posix.dirname(currentFile);
   return html.replace(/<a\b([^<>]*?)\bhref\s*=\s*(["'])([^"']+)\2([^<>]*)>/gi, (match, pre, quote, href, post) => {
     if (isExternalUrl(href)) return match;
     if (href.startsWith('#')) return match;
-    const cleaned = href.replace(/^\.\//, '').replace(/^\//, '');
-    const route = pathToRoute.get(cleaned);
+    const splitIdx = href.search(/[?#]/);
+    const pathnamePart = splitIdx >= 0 ? href.slice(0, splitIdx) : href;
+    const suffix = splitIdx >= 0 ? href.slice(splitIdx) : '';
+    if (!pathnamePart) return match;
+    const resolved = pathnamePart.startsWith('/')
+      ? pathnamePart.replace(/^\/+/, '')
+      : path.posix.normalize(`${currentDir}/${pathnamePart}`);
+    const route = pathToRoute.get(resolved);
     if (!route) return match;
-    return `<a${pre}href=${quote}${route}${quote}${post}>`;
+    return `<a${pre}href=${quote}${route}${suffix}${quote}${post}>`;
   });
 }
 

--- a/apps/daemon/src/deploy.ts
+++ b/apps/daemon/src/deploy.ts
@@ -336,7 +336,15 @@ export async function buildDeployFilePlan(projectsRoot: string, projectId: strin
         contentType: rootVercel.mime,
         sourcePath: 'vercel.json',
       });
-    } catch {}
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException | undefined)?.code;
+      if (code !== 'ENOENT') {
+        const message = (err as Error | undefined)?.message ?? String(err);
+        console.warn(
+          `daemon: failed to read project vercel.json (${code ?? 'unknown'}): ${message} — continuing with generated cleanUrls config`,
+        );
+      }
+    }
   }
 
   const fileList = Array.from(files.values());
@@ -1483,27 +1491,29 @@ export function buildVercelRoutingConfig(files: DeployFile[]): VercelRoutingConf
   const routes: string[] = [];
   const pathToRoute = new Map<string, string>();
   for (const f of htmlFiles) {
-    const route = htmlPathToCleanRoute(f.file);
+    const fileKey = f.file.replace(/^\/+/, '');
+    const route = htmlPathToCleanRoute(fileKey);
     routes.push(route);
-    pathToRoute.set(f.file, route);
-    const source = f.sourcePath;
+    pathToRoute.set(fileKey, route);
+    const source = f.sourcePath ? f.sourcePath.replace(/^\/+/, '') : f.sourcePath;
     // First-writer-wins when two emitted files share a sourcePath: htmlFiles
     // is ordered by file insertion, so the earlier deploy path keeps the
     // alias. Overwriting silently would let a later duplicate steal an
     // anchor target the earlier file is rendering links to.
-    if (source && source !== f.file && !pathToRoute.has(source)) {
+    if (source && source !== fileKey && !pathToRoute.has(source)) {
       pathToRoute.set(source, route);
     }
   }
 
   const rewrittenHtml = new Map<string, string>();
   for (const f of htmlFiles) {
+    const fileKey = f.file.replace(/^\/+/, '');
     const original = Buffer.isBuffer(f.data) || f.data instanceof Uint8Array
       ? Buffer.from(f.data).toString('utf8')
       : String(f.data);
-    const rewritten = rewriteAnchorHrefsToCleanRoutes(original, pathToRoute, f.file);
+    const rewritten = rewriteAnchorHrefsToCleanRoutes(original, pathToRoute, fileKey);
     if (rewritten !== original) {
-      rewrittenHtml.set(f.file, rewritten);
+      rewrittenHtml.set(fileKey, rewritten);
     }
   }
 
@@ -1518,7 +1528,8 @@ export function buildVercelRoutingConfig(files: DeployFile[]): VercelRoutingConf
 }
 
 function htmlPathToCleanRoute(filePath: string) {
-  if (filePath === 'index.html') return '/';
+  if (/^index\.html?$/i.test(filePath)) return '/';
+  if (/\/index\.html?$/i.test(filePath)) return `/${filePath.replace(/\/index\.html?$/i, '')}`;
   const stripped = filePath.replace(/\.html?$/i, '');
   return `/${stripped}`;
 }
@@ -1531,7 +1542,7 @@ function rewriteAnchorHrefsToCleanRoutes(html: string, pathToRoute: Map<string, 
   // would silently be rewritten, changing runtime JS behavior or
   // mutating comment contents.
   const rawTextRanges = htmlRawTextRanges(html);
-  return html.replace(/<a\b([^<>]*?)\bhref\s*=\s*(["'])([^"']+)\2([^<>]*)>/gi, (match, pre, quote, href, post, offset) => {
+  return html.replace(/<a\b([^<>]*?\s)href\s*=\s*(["'])([^"']+)\2([^<>]*)>/gi, (match, pre, quote, href, post, offset) => {
     if (isOffsetInRanges(Number(offset), rawTextRanges)) return match;
     if (isExternalUrl(href)) return match;
     if (href.startsWith('#')) return match;

--- a/apps/daemon/src/deploy.ts
+++ b/apps/daemon/src/deploy.ts
@@ -1475,7 +1475,14 @@ function htmlPathToCleanRoute(filePath: string) {
 
 function rewriteAnchorHrefsToCleanRoutes(html: string, pathToRoute: Map<string, string>, currentFile: string) {
   const currentDir = path.posix.dirname(currentFile);
-  return html.replace(/<a\b([^<>]*?)\bhref\s*=\s*(["'])([^"']+)\2([^<>]*)>/gi, (match, pre, quote, href, post) => {
+  // Gate by absolute offset so anchor-looking text inside `<script>` /
+  // `<style>` / HTML comments stays verbatim. Without this, an inline
+  // script string literal or a stale commented-out `<a href="...">`
+  // would silently be rewritten, changing runtime JS behavior or
+  // mutating comment contents.
+  const rawTextRanges = htmlRawTextRanges(html);
+  return html.replace(/<a\b([^<>]*?)\bhref\s*=\s*(["'])([^"']+)\2([^<>]*)>/gi, (match, pre, quote, href, post, offset) => {
+    if (isOffsetInRanges(offset, rawTextRanges)) return match;
     if (isExternalUrl(href)) return match;
     if (href.startsWith('#')) return match;
     const splitIdx = href.search(/[?#]/);

--- a/apps/daemon/src/deploy.ts
+++ b/apps/daemon/src/deploy.ts
@@ -318,6 +318,18 @@ export async function buildDeployFilePlan(projectsRoot: string, projectId: strin
     }
   }
 
+  const fileList = Array.from(files.values());
+  const routing = buildVercelRoutingConfig(fileList);
+  if (routing) {
+    for (const [filePath, rewritten] of routing.rewrittenHtml) {
+      const existing = files.get(filePath);
+      if (existing) {
+        files.set(filePath, { ...existing, data: Buffer.from(rewritten, 'utf8') });
+      }
+    }
+    files.set(routing.vercelJson.file, routing.vercelJson);
+  }
+
   return {
     entryPath,
     html,
@@ -1410,6 +1422,66 @@ export function analyzeDeployPlan(input: {
 
 function formatMib(bytes: number) {
   return `${(bytes / (1024 * 1024)).toFixed(2)} MiB`;
+}
+
+export type VercelRoutingConfig = {
+  vercelJson: DeployFile;
+  rewrittenHtml: Map<string, string>;
+  routes: string[];
+};
+
+export function buildVercelRoutingConfig(files: DeployFile[]): VercelRoutingConfig | null {
+  const htmlFiles = files.filter((f) => /\.html?$/i.test(f.file));
+  if (htmlFiles.length < 2) return null;
+
+  const routes: string[] = [];
+  const pathToRoute = new Map<string, string>();
+  for (const f of htmlFiles) {
+    const route = htmlPathToCleanRoute(f.file);
+    routes.push(route);
+    pathToRoute.set(f.file, route);
+    const source = f.sourcePath;
+    if (source && source !== f.file && !pathToRoute.has(source)) {
+      pathToRoute.set(source, route);
+    }
+  }
+
+  const rewrittenHtml = new Map<string, string>();
+  for (const f of htmlFiles) {
+    const original = Buffer.isBuffer(f.data) || f.data instanceof Uint8Array
+      ? Buffer.from(f.data).toString('utf8')
+      : String(f.data);
+    const rewritten = rewriteAnchorHrefsToCleanRoutes(original, pathToRoute);
+    if (rewritten !== original) {
+      rewrittenHtml.set(f.file, rewritten);
+    }
+  }
+
+  const vercelJson: DeployFile = {
+    file: 'vercel.json',
+    data: Buffer.from(JSON.stringify({ cleanUrls: true }), 'utf8'),
+    contentType: 'application/json',
+    sourcePath: 'vercel.json',
+  };
+
+  return { vercelJson, rewrittenHtml, routes };
+}
+
+function htmlPathToCleanRoute(filePath: string) {
+  if (filePath === 'index.html') return '/';
+  const stripped = filePath.replace(/\.html?$/i, '');
+  return `/${stripped}`;
+}
+
+function rewriteAnchorHrefsToCleanRoutes(html: string, pathToRoute: Map<string, string>) {
+  return html.replace(/<a\b([^<>]*?)\bhref\s*=\s*(["'])([^"']+)\2([^<>]*)>/gi, (match, pre, quote, href, post) => {
+    if (isExternalUrl(href)) return match;
+    if (href.startsWith('#')) return match;
+    const cleaned = href.replace(/^\.\//, '').replace(/^\//, '');
+    const route = pathToRoute.get(cleaned);
+    if (!route) return match;
+    return `<a${pre}href=${quote}${route}${quote}${post}>`;
+  });
 }
 
 // One-shot orchestrator: build the file plan, run the analyzer, and

--- a/apps/daemon/src/deploy.ts
+++ b/apps/daemon/src/deploy.ts
@@ -315,6 +315,15 @@ export async function buildDeployFilePlan(projectsRoot: string, projectId: strin
       for (const ref of extractCssReferences(projectFile.buffer.toString('utf8'))) {
         pending.push({ ref, base: cssBase });
       }
+    } else if (/\.html?$/i.test(safePath)) {
+      const htmlBase = path.posix.dirname(safePath);
+      const htmlText = projectFile.buffer.toString('utf8');
+      for (const ref of extractHtmlReferences(htmlText)) {
+        pending.push({ ref, base: htmlBase });
+      }
+      for (const ref of extractInlineCssReferences(htmlText)) {
+        pending.push({ ref, base: htmlBase });
+      }
     }
   }
 
@@ -327,7 +336,13 @@ export async function buildDeployFilePlan(projectsRoot: string, projectId: strin
         files.set(filePath, { ...existing, data: Buffer.from(rewritten, 'utf8') });
       }
     }
-    files.set(routing.vercelJson.file, routing.vercelJson);
+    // Invariant: anchor rewrites above unconditionally point to clean routes,
+    // so the deploy plan must always carry a vercel.json with cleanUrls:true.
+    // Merge into the user's file when it is a plain object; otherwise the
+    // routing config takes precedence over malformed or non-object data.
+    const existingVercel = files.get(routing.vercelJson.file);
+    const mergedVercel = existingVercel ? mergeUserVercelJson(existingVercel) : null;
+    files.set(routing.vercelJson.file, mergedVercel ?? routing.vercelJson);
   }
 
   return {
@@ -336,6 +351,25 @@ export async function buildDeployFilePlan(projectsRoot: string, projectId: strin
     files: Array.from(files.values()),
     missing,
     invalid,
+  };
+}
+
+function mergeUserVercelJson(existing: DeployFile): DeployFile | null {
+  const text = Buffer.isBuffer(existing.data) || existing.data instanceof Uint8Array
+    ? Buffer.from(existing.data).toString('utf8')
+    : String(existing.data);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+  const merged = { ...(parsed as Record<string, unknown>), cleanUrls: true };
+  return {
+    ...existing,
+    data: Buffer.from(JSON.stringify(merged), 'utf8'),
+    contentType: 'application/json',
   };
 }
 
@@ -1441,6 +1475,10 @@ export function buildVercelRoutingConfig(files: DeployFile[]): VercelRoutingConf
     routes.push(route);
     pathToRoute.set(f.file, route);
     const source = f.sourcePath;
+    // First-writer-wins when two emitted files share a sourcePath: htmlFiles
+    // is ordered by file insertion, so the earlier deploy path keeps the
+    // alias. Overwriting silently would let a later duplicate steal an
+    // anchor target the earlier file is rendering links to.
     if (source && source !== f.file && !pathToRoute.has(source)) {
       pathToRoute.set(source, route);
     }
@@ -1482,7 +1520,7 @@ function rewriteAnchorHrefsToCleanRoutes(html: string, pathToRoute: Map<string, 
   // mutating comment contents.
   const rawTextRanges = htmlRawTextRanges(html);
   return html.replace(/<a\b([^<>]*?)\bhref\s*=\s*(["'])([^"']+)\2([^<>]*)>/gi, (match, pre, quote, href, post, offset) => {
-    if (isOffsetInRanges(offset, rawTextRanges)) return match;
+    if (isOffsetInRanges(Number(offset), rawTextRanges)) return match;
     if (isExternalUrl(href)) return match;
     if (href.startsWith('#')) return match;
     const splitIdx = href.search(/[?#]/);
@@ -1492,6 +1530,7 @@ function rewriteAnchorHrefsToCleanRoutes(html: string, pathToRoute: Map<string, 
     const resolved = pathnamePart.startsWith('/')
       ? pathnamePart.replace(/^\/+/, '')
       : path.posix.normalize(`${currentDir}/${pathnamePart}`);
+    if (resolved.startsWith('..')) return match;
     const route = pathToRoute.get(resolved);
     if (!route) return match;
     return `<a${pre}href=${quote}${route}${suffix}${quote}${post}>`;

--- a/apps/daemon/tests/deploy.test.ts
+++ b/apps/daemon/tests/deploy.test.ts
@@ -760,6 +760,124 @@ describe('deploy plan and analyzer', () => {
     expect(JSON.parse(Buffer.from(emitted!.data).toString('utf8'))).toEqual({ cleanUrls: true });
   });
 
+  it('preserves a root vercel.json that the manifest omits from supportingFiles', async () => {
+    const { projectsRoot, projectId, dir } = await setupProject();
+    await writeFile(
+      path.join(dir, 'index.html'),
+      '<!doctype html><a href="about.html">about</a>',
+    );
+    await writeFile(path.join(dir, 'about.html'), '<!doctype html><h1>About</h1>');
+    const userVercel = {
+      headers: [{ source: '/(.*)', headers: [{ key: 'X-Frame-Options', value: 'DENY' }] }],
+      redirects: [{ source: '/old', destination: '/about', permanent: true }],
+    };
+    await writeFile(path.join(dir, 'vercel.json'), JSON.stringify(userVercel));
+    await writeFile(
+      path.join(dir, 'index.html.artifact.json'),
+      JSON.stringify({
+        version: 1,
+        kind: 'html',
+        entry: 'index.html',
+        renderer: 'html',
+        exports: ['html'],
+        supportingFiles: ['about.html'],
+      }),
+    );
+
+    const plan = await buildDeployFilePlan(projectsRoot, projectId, 'index.html');
+    const emitted = plan.files.find((f) => f.file === 'vercel.json');
+    expect(emitted).toBeDefined();
+    const parsed = JSON.parse(Buffer.from(emitted!.data).toString('utf8'));
+    expect(parsed.cleanUrls).toBe(true);
+    expect(parsed.headers).toEqual(userVercel.headers);
+    expect(parsed.redirects).toEqual(userVercel.redirects);
+  });
+
+  it('falls back to cleanUrls vercel.json when the root file is malformed JSON and absent from supportingFiles', async () => {
+    const { projectsRoot, projectId, dir } = await setupProject();
+    await writeFile(
+      path.join(dir, 'index.html'),
+      '<!doctype html><a href="about.html">about</a>',
+    );
+    await writeFile(path.join(dir, 'about.html'), '<!doctype html><h1>About</h1>');
+    await writeFile(path.join(dir, 'vercel.json'), 'not json');
+    await writeFile(
+      path.join(dir, 'index.html.artifact.json'),
+      JSON.stringify({
+        version: 1,
+        kind: 'html',
+        entry: 'index.html',
+        renderer: 'html',
+        exports: ['html'],
+        supportingFiles: ['about.html'],
+      }),
+    );
+
+    const plan = await buildDeployFilePlan(projectsRoot, projectId, 'index.html');
+    const emitted = plan.files.find((f) => f.file === 'vercel.json');
+    expect(emitted).toBeDefined();
+    const parsed = JSON.parse(Buffer.from(emitted!.data).toString('utf8'));
+    expect(parsed.cleanUrls).toBe(true);
+    expect(parsed.headers).toBeUndefined();
+    expect(parsed.redirects).toBeUndefined();
+  });
+
+  it('falls back to cleanUrls vercel.json when the root file is a JSON array and absent from supportingFiles', async () => {
+    const { projectsRoot, projectId, dir } = await setupProject();
+    await writeFile(
+      path.join(dir, 'index.html'),
+      '<!doctype html><a href="about.html">about</a>',
+    );
+    await writeFile(path.join(dir, 'about.html'), '<!doctype html><h1>About</h1>');
+    await writeFile(path.join(dir, 'vercel.json'), JSON.stringify(['not', 'an', 'object']));
+    await writeFile(
+      path.join(dir, 'index.html.artifact.json'),
+      JSON.stringify({
+        version: 1,
+        kind: 'html',
+        entry: 'index.html',
+        renderer: 'html',
+        exports: ['html'],
+        supportingFiles: ['about.html'],
+      }),
+    );
+
+    const plan = await buildDeployFilePlan(projectsRoot, projectId, 'index.html');
+    const emitted = plan.files.find((f) => f.file === 'vercel.json');
+    expect(emitted).toBeDefined();
+    const parsed = JSON.parse(Buffer.from(emitted!.data).toString('utf8'));
+    expect(parsed.cleanUrls).toBe(true);
+    expect(parsed.headers).toBeUndefined();
+    expect(parsed.redirects).toBeUndefined();
+  });
+
+  it('tolerates a non-ENOENT read error on the root vercel.json probe', async () => {
+    const { projectsRoot, projectId, dir } = await setupProject();
+    await writeFile(
+      path.join(dir, 'index.html'),
+      '<!doctype html><a href="about.html">about</a>',
+    );
+    await writeFile(path.join(dir, 'about.html'), '<!doctype html><h1>About</h1>');
+    await mkdir(path.join(dir, 'vercel.json'));
+    await writeFile(
+      path.join(dir, 'index.html.artifact.json'),
+      JSON.stringify({
+        version: 1,
+        kind: 'html',
+        entry: 'index.html',
+        renderer: 'html',
+        exports: ['html'],
+        supportingFiles: ['about.html'],
+      }),
+    );
+
+    const plan = await buildDeployFilePlan(projectsRoot, projectId, 'index.html');
+    expect(plan.invalid).not.toContain('vercel.json');
+    const emitted = plan.files.find((f) => f.file === 'vercel.json');
+    expect(emitted).toBeDefined();
+    expect(JSON.parse(Buffer.from(emitted!.data).toString('utf8'))).toEqual({ cleanUrls: true });
+  });
+
   it('flags missing assets as broken-reference warnings', () => {
     const { warnings } = analyzeDeployPlan({
       entryPath: 'index.html',

--- a/apps/daemon/tests/deploy.test.ts
+++ b/apps/daemon/tests/deploy.test.ts
@@ -878,6 +878,39 @@ describe('deploy plan and analyzer', () => {
     expect(JSON.parse(Buffer.from(emitted!.data).toString('utf8'))).toEqual({ cleanUrls: true });
   });
 
+  it('warns once with the error code on a non-ENOENT vercel.json probe failure', async () => {
+    const { projectsRoot, projectId, dir } = await setupProject();
+    await writeFile(
+      path.join(dir, 'index.html'),
+      '<!doctype html><a href="about.html">about</a>',
+    );
+    await writeFile(path.join(dir, 'about.html'), '<!doctype html><h1>About</h1>');
+    await mkdir(path.join(dir, 'vercel.json'));
+    await writeFile(
+      path.join(dir, 'index.html.artifact.json'),
+      JSON.stringify({
+        version: 1,
+        kind: 'html',
+        entry: 'index.html',
+        renderer: 'html',
+        exports: ['html'],
+        supportingFiles: ['about.html'],
+      }),
+    );
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const plan = await buildDeployFilePlan(projectsRoot, projectId, 'index.html');
+      const emitted = plan.files.find((f) => f.file === 'vercel.json');
+      expect(emitted).toBeDefined();
+      expect(JSON.parse(Buffer.from(emitted!.data).toString('utf8'))).toEqual({ cleanUrls: true });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0]?.[0]).toMatch(/EISDIR/);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it('flags missing assets as broken-reference warnings', () => {
     const { warnings } = analyzeDeployPlan({
       entryPath: 'index.html',
@@ -2613,6 +2646,57 @@ describe('vercel routing config for multi-page deploys', () => {
       '<a href="/docs/guide">Sibling dot</a>' +
       '<a href="/">Parent</a>' +
       '<a href="/docs/about">Absolute</a>',
+    );
+  });
+
+  it('collapses nested index.html to its parent directory route and rewrites sibling anchors to it', () => {
+    const docsAboutHtml =
+      '<a href="index.html">Docs Home</a>' +
+      '<a href="/docs/index.html">Abs Docs Home</a>';
+    const result = buildVercelRoutingConfig([
+      htmlFile('index.html', '<!doctype html><h1>Home</h1>'),
+      htmlFile('docs/index.html', '<!doctype html><h1>Docs</h1>'),
+      htmlFile('docs/about.html', docsAboutHtml),
+    ]);
+    expect(result).not.toBeNull();
+    expect(result!.routes.sort()).toEqual(['/', '/docs', '/docs/about']);
+    const rewrittenAbout = result!.rewrittenHtml.get('docs/about.html');
+    expect(rewrittenAbout).toBe(
+      '<a href="/docs">Docs Home</a>' +
+      '<a href="/docs">Abs Docs Home</a>',
+    );
+  });
+
+  it('collapses nested index.htm to its parent directory route', () => {
+    const result = buildVercelRoutingConfig([
+      htmlFile('index.html', '<!doctype html><h1>Home</h1>'),
+      htmlFile('docs/index.htm', '<!doctype html><h1>Docs</h1>'),
+      htmlFile('docs/about.html', '<!doctype html><h1>About</h1>'),
+    ]);
+    expect(result).not.toBeNull();
+    expect(result!.routes.sort()).toEqual(['/', '/docs', '/docs/about']);
+  });
+
+  it('collapses root-level index.htm to / symmetrically with index.html', () => {
+    const result = buildVercelRoutingConfig([
+      htmlFile('index.htm', '<!doctype html><h1>Home</h1>'),
+      htmlFile('about.html', '<!doctype html><h1>About</h1>'),
+    ]);
+    expect(result).not.toBeNull();
+    expect(result!.routes.sort()).toEqual(['/', '/about']);
+  });
+
+  it('rewrites only the real href when a sibling data-href attribute is present', () => {
+    const pricingHtml =
+      '<a class="x" data-href="page.html" href="about.html">click</a>';
+    const result = buildVercelRoutingConfig([
+      htmlFile('index.html', '<!doctype html><h1>Home</h1>'),
+      htmlFile('pricing.html', pricingHtml),
+      htmlFile('about.html', '<!doctype html><h1>About</h1>'),
+    ]);
+    const rewrittenPricing = result!.rewrittenHtml.get('pricing.html');
+    expect(rewrittenPricing).toBe(
+      '<a class="x" data-href="page.html" href="/about">click</a>',
     );
   });
 

--- a/apps/daemon/tests/deploy.test.ts
+++ b/apps/daemon/tests/deploy.test.ts
@@ -648,6 +648,118 @@ describe('deploy plan and analyzer', () => {
     expect(plan.invalid).toEqual([]);
   });
 
+  it('walks references inside supporting html pages so multi-page deploys ship their assets', async () => {
+    const { projectsRoot, projectId, dir } = await setupProject();
+    await writeFile(
+      path.join(dir, 'index.html'),
+      '<!doctype html><meta name="viewport" content="width=device-width"><a href="pages/about.html">about</a>',
+    );
+    await writeFile(
+      path.join(dir, 'index.html.artifact.json'),
+      JSON.stringify({
+        version: 1,
+        kind: 'html',
+        entry: 'index.html',
+        renderer: 'html',
+        exports: ['html'],
+        supportingFiles: ['pages/about.html'],
+      }),
+    );
+    await mkdir(path.join(dir, 'pages'), { recursive: true });
+    await writeFile(path.join(dir, 'pages', 'about.html'), '<img src="logo.png">');
+    await writeFile(path.join(dir, 'pages', 'logo.png'), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+
+    const plan = await buildDeployFilePlan(projectsRoot, projectId, 'index.html');
+    const planFiles = plan.files.map((f) => f.file);
+    expect(planFiles).toContain('pages/logo.png');
+    expect(plan.missing).toEqual([]);
+  });
+
+  it('preserves a user-supplied vercel.json while still emitting cleanUrls', async () => {
+    const { projectsRoot, projectId, dir } = await setupProject();
+    await writeFile(
+      path.join(dir, 'index.html'),
+      '<!doctype html><a href="about.html">about</a>',
+    );
+    await writeFile(path.join(dir, 'about.html'), '<!doctype html><h1>About</h1>');
+    const userVercel = {
+      headers: [{ source: '/(.*)', headers: [{ key: 'X-Frame-Options', value: 'DENY' }] }],
+      redirects: [{ source: '/old', destination: '/about', permanent: true }],
+    };
+    await writeFile(path.join(dir, 'vercel.json'), JSON.stringify(userVercel));
+    await writeFile(
+      path.join(dir, 'index.html.artifact.json'),
+      JSON.stringify({
+        version: 1,
+        kind: 'html',
+        entry: 'index.html',
+        renderer: 'html',
+        exports: ['html'],
+        supportingFiles: ['about.html', 'vercel.json'],
+      }),
+    );
+
+    const plan = await buildDeployFilePlan(projectsRoot, projectId, 'index.html');
+    const emitted = plan.files.find((f) => f.file === 'vercel.json');
+    expect(emitted).toBeDefined();
+    const parsed = JSON.parse(Buffer.from(emitted!.data).toString('utf8'));
+    expect(parsed.cleanUrls).toBe(true);
+    expect(parsed.headers).toEqual(userVercel.headers);
+    expect(parsed.redirects).toEqual(userVercel.redirects);
+  });
+
+  it('falls back to cleanUrls vercel.json when user file is malformed JSON', async () => {
+    const { projectsRoot, projectId, dir } = await setupProject();
+    await writeFile(
+      path.join(dir, 'index.html'),
+      '<!doctype html><a href="about.html">about</a>',
+    );
+    await writeFile(path.join(dir, 'about.html'), '<!doctype html><h1>About</h1>');
+    await writeFile(path.join(dir, 'vercel.json'), 'not json');
+    await writeFile(
+      path.join(dir, 'index.html.artifact.json'),
+      JSON.stringify({
+        version: 1,
+        kind: 'html',
+        entry: 'index.html',
+        renderer: 'html',
+        exports: ['html'],
+        supportingFiles: ['about.html', 'vercel.json'],
+      }),
+    );
+
+    const plan = await buildDeployFilePlan(projectsRoot, projectId, 'index.html');
+    const emitted = plan.files.find((f) => f.file === 'vercel.json');
+    expect(emitted).toBeDefined();
+    expect(JSON.parse(Buffer.from(emitted!.data).toString('utf8'))).toEqual({ cleanUrls: true });
+  });
+
+  it('falls back to cleanUrls vercel.json when user file is a JSON array', async () => {
+    const { projectsRoot, projectId, dir } = await setupProject();
+    await writeFile(
+      path.join(dir, 'index.html'),
+      '<!doctype html><a href="about.html">about</a>',
+    );
+    await writeFile(path.join(dir, 'about.html'), '<!doctype html><h1>About</h1>');
+    await writeFile(path.join(dir, 'vercel.json'), JSON.stringify(['not', 'an', 'object']));
+    await writeFile(
+      path.join(dir, 'index.html.artifact.json'),
+      JSON.stringify({
+        version: 1,
+        kind: 'html',
+        entry: 'index.html',
+        renderer: 'html',
+        exports: ['html'],
+        supportingFiles: ['about.html', 'vercel.json'],
+      }),
+    );
+
+    const plan = await buildDeployFilePlan(projectsRoot, projectId, 'index.html');
+    const emitted = plan.files.find((f) => f.file === 'vercel.json');
+    expect(emitted).toBeDefined();
+    expect(JSON.parse(Buffer.from(emitted!.data).toString('utf8'))).toEqual({ cleanUrls: true });
+  });
+
   it('flags missing assets as broken-reference warnings', () => {
     const { warnings } = analyzeDeployPlan({
       entryPath: 'index.html',

--- a/apps/daemon/tests/deploy.test.ts
+++ b/apps/daemon/tests/deploy.test.ts
@@ -2364,5 +2364,44 @@ describe('vercel routing config for multi-page deploys', () => {
     const rewrittenPricing = result!.rewrittenHtml.get('pricing.html');
     expect(rewrittenPricing).toBe('<a href="/">Home</a><a href="/">Abs home</a>');
   });
+
+  it('resolves anchor hrefs relative to the current html file directory for nested deploys', () => {
+    const docsPageHtml =
+      '<a href="about.html">Sibling</a>' +
+      '<a href="./guide.html">Sibling dot</a>' +
+      '<a href="../index.html">Parent</a>' +
+      '<a href="/docs/about.html">Absolute</a>';
+    const result = buildVercelRoutingConfig([
+      htmlFile('index.html', '<!doctype html><h1>Home</h1>'),
+      htmlFile('docs/page.html', docsPageHtml),
+      htmlFile('docs/about.html', '<!doctype html><h1>About</h1>'),
+      htmlFile('docs/guide.html', '<!doctype html><h1>Guide</h1>'),
+    ]);
+    const rewrittenPage = result!.rewrittenHtml.get('docs/page.html');
+    expect(rewrittenPage).toBe(
+      '<a href="/docs/about">Sibling</a>' +
+      '<a href="/docs/guide">Sibling dot</a>' +
+      '<a href="/">Parent</a>' +
+      '<a href="/docs/about">Absolute</a>',
+    );
+  });
+
+  it('preserves query strings and fragments when rewriting anchor hrefs', () => {
+    const pricingHtml =
+      '<a href="about.html?utm=x">Tracked</a>' +
+      '<a href="about.html#team">Fragment</a>' +
+      '<a href="about.html?utm=x#team">Both</a>';
+    const result = buildVercelRoutingConfig([
+      htmlFile('index.html', '<!doctype html><h1>Home</h1>'),
+      htmlFile('pricing.html', pricingHtml),
+      htmlFile('about.html', '<!doctype html><h1>About</h1>'),
+    ]);
+    const rewrittenPricing = result!.rewrittenHtml.get('pricing.html');
+    expect(rewrittenPricing).toBe(
+      '<a href="/about?utm=x">Tracked</a>' +
+      '<a href="/about#team">Fragment</a>' +
+      '<a href="/about?utm=x#team">Both</a>',
+    );
+  });
 });
 

--- a/apps/daemon/tests/deploy.test.ts
+++ b/apps/daemon/tests/deploy.test.ts
@@ -9,6 +9,7 @@ import {
   analyzeDeployPlan,
   buildDeployFilePlan,
   buildDeployFileSet,
+  buildVercelRoutingConfig,
   checkDeploymentUrl,
   chunkCloudflarePagesAssetUploads,
   CLOUDFLARE_PAGES_ASSET_MAX_BYTES,
@@ -2303,3 +2304,65 @@ describe('deployment link readiness', () => {
     expect(isVercelProtectedResponse(new Response(null, { headers }), 'Authentication Required')).toBe(true);
   });
 });
+
+describe('vercel routing config for multi-page deploys', () => {
+  function htmlFile(file: string, body: string, sourcePath = file) {
+    return { file, data: Buffer.from(body, 'utf8'), contentType: 'text/html', sourcePath };
+  }
+
+  it('returns null for a single-page deploy file set', () => {
+    const result = buildVercelRoutingConfig([
+      htmlFile('index.html', '<!doctype html><a href="https://example.com">x</a>', 'landing.html'),
+      { file: 'styles.css', data: Buffer.from('body{}'), contentType: 'text/css', sourcePath: 'styles.css' },
+    ]);
+    expect(result).toBeNull();
+  });
+
+  it('emits vercel.json with cleanUrls true when the file set has multiple html pages', () => {
+    const result = buildVercelRoutingConfig([
+      htmlFile('index.html', '<!doctype html><h1>Landing</h1>', 'landing.html'),
+      htmlFile('pricing.html', '<!doctype html><h1>Pricing</h1>'),
+      htmlFile('about.html', '<!doctype html><h1>About</h1>'),
+    ]);
+    expect(result).not.toBeNull();
+    expect(result!.vercelJson.file).toBe('vercel.json');
+    expect(JSON.parse(Buffer.from(result!.vercelJson.data).toString('utf8'))).toEqual({ cleanUrls: true });
+    expect(result!.routes.sort()).toEqual(['/', '/about', '/pricing']);
+  });
+
+  it('rewrites intra-set anchor hrefs to clean routes and leaves external/hash/missing-target links alone', () => {
+    const pricingHtml =
+      '<a href="about.html">About</a>' +
+      '<a href="./about.html">About dot</a>' +
+      '<a href="missing.html">Missing</a>' +
+      '<a href="https://example.com/about.html">External</a>' +
+      '<a href="#section">Hash</a>' +
+      '<a href="mailto:hi@example.com">Mail</a>';
+    const result = buildVercelRoutingConfig([
+      htmlFile('index.html', '<!doctype html><a href="pricing.html">Pricing</a>', 'landing.html'),
+      htmlFile('pricing.html', pricingHtml),
+      htmlFile('about.html', '<!doctype html><h1>About</h1>'),
+    ]);
+    expect(result).not.toBeNull();
+    const rewrittenPricing = result!.rewrittenHtml.get('pricing.html');
+    expect(rewrittenPricing).toBe(
+      '<a href="/about">About</a>' +
+      '<a href="/about">About dot</a>' +
+      '<a href="missing.html">Missing</a>' +
+      '<a href="https://example.com/about.html">External</a>' +
+      '<a href="#section">Hash</a>' +
+      '<a href="mailto:hi@example.com">Mail</a>',
+    );
+  });
+
+  it('rewrites the entry source name back to the root path', () => {
+    const pricingHtml = '<a href="landing.html">Home</a><a href="/landing.html">Abs home</a>';
+    const result = buildVercelRoutingConfig([
+      htmlFile('index.html', '<!doctype html><h1>Landing</h1>', 'landing.html'),
+      htmlFile('pricing.html', pricingHtml),
+    ]);
+    const rewrittenPricing = result!.rewrittenHtml.get('pricing.html');
+    expect(rewrittenPricing).toBe('<a href="/">Home</a><a href="/">Abs home</a>');
+  });
+});
+

--- a/apps/daemon/tests/deploy.test.ts
+++ b/apps/daemon/tests/deploy.test.ts
@@ -2403,5 +2403,23 @@ describe('vercel routing config for multi-page deploys', () => {
       '<a href="/about?utm=x#team">Both</a>',
     );
   });
+
+  it('leaves anchor-looking text inside script and comment regions unchanged while rewriting real anchors', () => {
+    const pricingHtml =
+      '<script>const tpl = \'<a href="about.html">Script</a>\';</script>' +
+      '<!-- <a href="about.html">Comment</a> -->' +
+      '<a href="about.html">Real</a>';
+    const result = buildVercelRoutingConfig([
+      htmlFile('index.html', '<!doctype html><h1>Home</h1>'),
+      htmlFile('pricing.html', pricingHtml),
+      htmlFile('about.html', '<!doctype html><h1>About</h1>'),
+    ]);
+    const rewrittenPricing = result!.rewrittenHtml.get('pricing.html');
+    expect(rewrittenPricing).toBe(
+      '<script>const tpl = \'<a href="about.html">Script</a>\';</script>' +
+      '<!-- <a href="about.html">Comment</a> -->' +
+      '<a href="/about">Real</a>',
+    );
+  });
 });
 


### PR DESCRIPTION
Closes #1077

## Why

Issue #1077 asks for deploying the entire project to Vercel as a unified multi-page web app — today `buildDeployFilePlan` ships whatever HTML is reachable from the entry page, but Vercel serves each file at its literal `.html` URL and the intra-project anchor hrefs (`<a href="pricing.html">`) keep their `.html` suffix, so the result reads like a folder of disconnected static pages instead of a site. The walker-side gap is being addressed by #2063 (anchor traversal collects sibling `.html` pages into the file set); this PR is the routing-side gap that sits one layer above the walker: once a multi-page file set exists, it needs `vercel.json` with `cleanUrls: true` AND its anchor hrefs rewritten so the page-to-page navigation lands on the clean routes Vercel will actually serve.

Speculatively adding for the issue's `help wanted` queue — the helper composes cleanly with #2063 without depending on it (single-page deploys are still byte-identical, so this layer is a no-op until the walker side starts feeding it multi-page sets).

## What users will see

For users who deploy a project containing two or more linked HTML pages to Vercel, page-to-page navigation now works: clicking a `<a href="pricing.html">` link in the deployed site lands on `/pricing` (a real, addressable URL served by Vercel) instead of 404'ing or showing the raw `.html` extension. The entry page's source name resolves to `/` so the project's "home" link works the same way. Single-page deploys — today's default — produce a byte-identical upload and see no change.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

The change is an internal `apps/daemon/src/deploy.ts` extension: a new pure helper `buildVercelRoutingConfig(files)` and its integration into `buildDeployFilePlan`. No new API endpoint, no contract change, no user-visible surface until a multi-page file set actually reaches the planner (gated by the walker-side work in #2063).

## Bug fix verification

Not a bug fix — this is the routing layer for the multi-page deploy feature requested in #1077.

## Validation

- `pnpm --filter @open-design/daemon test` — 4 new `vercel routing config for multi-page deploys` cases pass; the one pre-existing failure in `tests/xai-tokens.test.ts` is unrelated to this diff.
- `pnpm --filter @open-design/daemon build` — typecheck green.

## Adjacent issues

- #2063 (open) is the complementary walker-side change that grows the deploy file set to include linked sibling HTML pages. The two PRs compose: this routing helper is a no-op for single-page sets, so it stays dormant on `main` until #2063 lands and the file plan starts including siblings, at which point the routing layer activates automatically.
- #1431 was a closed-unmerged earlier attempt at the full issue; this PR keeps strictly to the routing layer and leaves the walker decision to the #2063 conversation.
