### PR TITLE
fix(daemon): handle Codex stream reconnect events

### DIFF
--- a/apps/daemon/src/json-event-stream.ts
+++ b/apps/daemon/src/json-event-stream.ts
@@ -71,6 +71,16 @@ function extractErrorMessage(value: unknown, fallback: string): string {
   return fallback;
 }
 
+function isRecoverableCodexReconnect(message: string): boolean {
+  return (
+    message.startsWith('Reconnecting...') &&
+    (
+      message.includes('timeout waiting for child process to exit') ||
+      message.includes('stream disconnected before completion')
+    )
+  );
+}
+
 function formatOpenCodeUsage(tokens: unknown): Usage | null {
   if (!isRecord(tokens)) return null;
   const usage: Usage = {};
@@ -272,11 +282,7 @@ function handleCodexEvent(obj: unknown, onEvent: StreamEventHandler, state: Pars
 if (obj.type === 'error') {
   const message = extractErrorMessage(obj.message ?? obj.error, 'Codex error');
   // Reconnecting events are recoverable — treat as status warning, not fatal
-  if (
-    typeof message === 'string' &&
-    message.includes('Reconnecting...') &&
-    message.includes('timeout waiting for child process to exit')
-  ) {
+  if (isRecoverableCodexReconnect(message)) {
     onEvent({ type: 'status', label: message });
     return true;
   }

--- a/apps/daemon/tests/json-event-stream.test.ts
+++ b/apps/daemon/tests/json-event-stream.test.ts
@@ -476,6 +476,32 @@ test('codex json stream treats reconnect errors as status warnings not fatal (re
   ]);
 });
 
+test('codex json stream treats stream disconnect reconnect errors as status warnings not fatal', () => {
+  const { events, handler } = collectEvents('codex');
+
+  handler.feed(
+    JSON.stringify({ type: 'thread.started', thread_id: 'thr-1' }) + '\n' +
+    JSON.stringify({ type: 'turn.started' }) + '\n' +
+    JSON.stringify({
+      type: 'error',
+      message: 'Reconnecting... 2/5 (stream disconnected before completion: Connection reset by peer (os error 54))',
+    }) + '\n' +
+    JSON.stringify({ type: 'item.completed', item: { id: 'item-0', type: 'agent_message', text: 'OK' } }) + '\n' +
+    JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 5, output_tokens: 2, cached_input_tokens: 0 } }) + '\n',
+  );
+
+  assert.deepEqual(events, [
+    { type: 'status', label: 'initializing' },
+    { type: 'status', label: 'running' },
+    {
+      type: 'status',
+      label: 'Reconnecting... 2/5 (stream disconnected before completion: Connection reset by peer (os error 54))',
+    },
+    { type: 'text_delta', delta: 'OK' },
+    { type: 'usage', usage: { input_tokens: 5, output_tokens: 2, cached_read_tokens: 0 } },
+  ]);
+});
+
 test('codex json stream still treats real errors as fatal after reconnect warnings', () => {
   const { events, handler } = collectEvents('codex');
 
@@ -487,5 +513,23 @@ test('codex json stream still treats real errors as fatal after reconnect warnin
   assert.deepEqual(events, [
     { type: 'status', label: 'Reconnecting... 2/5 (timeout waiting for child process to exit)' },
     { type: 'error', message: 'Authentication failed: invalid API key' },
+  ]);
+});
+
+test('codex json stream does not downgrade non-reconnect errors that mention reconnect text', () => {
+  const { events, handler } = collectEvents('codex');
+
+  handler.feed(
+    JSON.stringify({
+      type: 'error',
+      message: 'Authentication failed after Reconnecting... stream disconnected before completion',
+    }) + '\n',
+  );
+
+  assert.deepEqual(events, [
+    {
+      type: 'error',
+      message: 'Authentication failed after Reconnecting... stream disconnected before completion',
+    },
   ]);
 });


### PR DESCRIPTION
## Summary

- Treat Codex `Reconnecting...` JSON error frames for `stream disconnected before completion` as recoverable status events instead of fatal adapter errors.
- Keep existing timeout-reconnect handling intact.
- Add regression coverage for the reported reconnect shape and a guard that non-reconnect errors mentioning reconnect text still remain fatal.

Fixes #2268.

## Verification

- `PATH="$HOME/.nvm/versions/node/v24.14.1/bin:$PATH" pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/json-event-stream.test.ts`
- `PATH="$HOME/.nvm/versions/node/v24.14.1/bin:$PATH" pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/json-event-stream.test.ts -t "stream disconnect|non-reconnect"`
- `PATH="$HOME/.nvm/versions/node/v24.14.1/bin:$PATH" pnpm --dir apps/daemon run typecheck`
- `git diff --check`

## Notes

I also tried the full daemon suite. It initially failed because `better-sqlite3` had been installed under Node 25 while the repo requires Node 24. After rebuilding `better-sqlite3` under Node 24, the full suite command stopped producing progress and had to be stopped manually, so I am not listing it as passing.
