### PR TITLE
Fix homepage localization for chip labels and translations

### DIFF
--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -2351,6 +2351,52 @@ function getPluginQueryPreview(plugin: InstalledPluginRecord): string {
   return trimmed.length > 96 ? `${trimmed.slice(0, 96)}…` : trimmed;
 }
 
+interface TypeTabBarProps {
+  activeChipId: string | null;
+  pendingChipId: string | null;
+  pendingPluginId: string | null;
+  pluginsLoading: boolean;
+  onPickChip: (chip: HomeHeroChip) => void;
+}
+
+function TypeTabBar({
+  activeChipId,
+  pendingChipId,
+  pendingPluginId,
+  pluginsLoading,
+  onPickChip,
+}: TypeTabBarProps) {
+  const chips = useMemo(() => chipsForGroup('create'), []);
+  const t = useT();
+  return (
+    <div className="home-hero__type-tabs" role="tablist" aria-label="Output type">
+      {chips.map((chip) => {
+        const isActive = activeChipId === chip.id;
+        const isPending = pendingChipId === chip.id;
+        const cls = ['home-hero__type-tab'];
+        if (isActive) cls.push('is-active');
+        if (isPending) cls.push('is-pending');
+        return (
+          <button
+            key={chip.id}
+            type="button"
+            role="tab"
+            className={cls.join(' ')}
+            data-chip-id={chip.id}
+            data-testid={`home-hero-rail-${chip.id}`}
+            onClick={() => onPickChip(chip)}
+            disabled={pluginsLoading || isPending || pendingPluginId !== null}
+            aria-selected={isActive}
+            title={chip.hint ?? t(chip.labelKey as any)}
+          >
+            <span>{t(chip.labelKey as any)}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 interface RailGroupProps {
   group: ChipGroup;
   activeChipId: string | null;

--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -2351,51 +2351,6 @@ function getPluginQueryPreview(plugin: InstalledPluginRecord): string {
   return trimmed.length > 96 ? `${trimmed.slice(0, 96)}…` : trimmed;
 }
 
-interface TypeTabBarProps {
-  activeChipId: string | null;
-  pendingChipId: string | null;
-  pendingPluginId: string | null;
-  pluginsLoading: boolean;
-  onPickChip: (chip: HomeHeroChip) => void;
-}
-
-function TypeTabBar({
-  activeChipId,
-  pendingChipId,
-  pendingPluginId,
-  pluginsLoading,
-  onPickChip,
-}: TypeTabBarProps) {
-  const chips = useMemo(() => chipsForGroup('create'), []);
-  const t = useT();
-  return (
-    <div className="home-hero__type-tabs" role="tablist" aria-label="Output type">
-      {chips.map((chip) => {
-        const isActive = activeChipId === chip.id;
-        const isPending = pendingChipId === chip.id;
-        const cls = ['home-hero__type-tab'];
-        if (isActive) cls.push('is-active');
-        if (isPending) cls.push('is-pending');
-        return (
-          <button
-            key={chip.id}
-            type="button"
-            role="tab"
-            className={cls.join(' ')}
-            data-chip-id={chip.id}
-            data-testid={`home-hero-rail-${chip.id}`}
-            onClick={() => onPickChip(chip)}
-            disabled={pluginsLoading || isPending || pendingPluginId !== null}
-            aria-selected={isActive}
-            title={homeHeroChipTitle(chip, t)}
-          >
-         <span>{homeHeroChipLabel(chip.id, t)}</span>
-          </button>
-        );
-      })}
-    </div>
-  );
-}
 
 interface RailGroupProps {
   group: ChipGroup;

--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -2387,9 +2387,9 @@ function TypeTabBar({
             onClick={() => onPickChip(chip)}
             disabled={pluginsLoading || isPending || pendingPluginId !== null}
             aria-selected={isActive}
-            title={chip.hint ?? t(chip.labelKey as any)}
+            title={homeHeroChipTitle(chip, t)}
           >
-            <span>{t(chip.labelKey as any)}</span>
+           <span>{t(chip.labelKey)}</span>
           </button>
         );
       })}

--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -2389,7 +2389,7 @@ function TypeTabBar({
             aria-selected={isActive}
             title={homeHeroChipTitle(chip, t)}
           >
-           <span>{t(chip.labelKey)}</span>
+         <span>{chip.group === 'create' ? t(chip.labelKey) : homeHeroChipLabel(chip.id, t)}</span>
           </button>
         );
       })}

--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -2389,7 +2389,7 @@ function TypeTabBar({
             aria-selected={isActive}
             title={homeHeroChipTitle(chip, t)}
           >
-         <span>{chip.group === 'create' ? t(chip.labelKey) : homeHeroChipLabel(chip.id, t)}</span>
+         <span>{homeHeroChipLabel(chip.id, t)}</span>
           </button>
         );
       })}

--- a/apps/web/src/components/home-hero/chips.ts
+++ b/apps/web/src/components/home-hero/chips.ts
@@ -62,7 +62,7 @@ export type ChipGroup = 'create' | 'migrate';
 
 export interface HomeHeroChip {
   id: string;
-  label: string;
+  labelKey: string;
   icon: IconName;
   group: ChipGroup;
   hint?: string;
@@ -72,7 +72,7 @@ export interface HomeHeroChip {
 export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   {
     id: 'prototype',
-    label: 'Prototype',
+    labelKey: 'homeHero.chip.prototype',
     icon: 'palette',
     group: 'create',
     // Prototype now binds to the bundled `example-web-prototype` plugin,
@@ -109,7 +109,7 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   },
   {
     id: 'deck',
-    label: 'Slide deck',
+    labelKey: 'homeHero.chip.deck',
     icon: 'present',
     group: 'create',
     // Slide deck binds to `example-simple-deck`, which ships a 353-line
@@ -130,7 +130,7 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   },
   {
     id: 'image',
-    label: 'Image',
+    labelKey: 'homeHero.chip.image',
     icon: 'image',
     group: 'create',
     action: {
@@ -147,7 +147,7 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   },
   {
     id: 'video',
-    label: 'Video',
+    labelKey: 'homeHero.chip.video',
     icon: 'play',
     group: 'create',
     action: {
@@ -164,7 +164,7 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   },
   {
     id: 'hyperframes',
-    label: 'HyperFrames',
+    labelKey: 'homeHero.chip.hyperframes',
     icon: 'orbit',
     group: 'create',
     hint: 'Author HTML-based motion: captions, audio-reactive visuals, scene transitions.',
@@ -176,7 +176,7 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   },
   {
     id: 'audio',
-    label: 'Audio',
+    labelKey: 'homeHero.chip.audio',
     icon: 'mic',
     group: 'create',
     action: {
@@ -193,7 +193,7 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   },
   {
     id: 'create-plugin',
-    label: 'Create plugin',
+    labelKey: 'homeHero.chip.create-plugin',
     icon: 'edit',
     group: 'migrate',
     hint: 'Author a reusable Open Design plugin and add it to My plugins.',
@@ -201,7 +201,7 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   },
   {
     id: 'figma',
-    label: 'From Figma',
+    labelKey: 'homeHero.chip.figma',
     icon: 'import',
     group: 'migrate',
     hint: 'Migrate a Figma frame into the active design system.',
@@ -216,8 +216,16 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
     },
   },
   {
+    id: 'folder',
+    labelKey: 'homeHero.chip.folder',
+    icon: 'folder',
+    group: 'migrate',
+    hint: 'Import an existing local folder and continue editing.',
+    action: { kind: 'import-folder' },
+  },
+  {
     id: 'template',
-    label: 'From template',
+    labelKey: 'homeHero.chip.template',
     icon: 'file-code',
     group: 'migrate',
     hint: 'Start from a bundled template.',

--- a/apps/web/src/components/home-hero/chips.ts
+++ b/apps/web/src/components/home-hero/chips.ts
@@ -22,6 +22,7 @@
 import type { ProjectKind, ProjectMetadata } from '@open-design/contracts';
 import type { DefaultScenarioPluginId } from '@open-design/contracts';
 import type { IconName } from '../Icon';
+import type { Dict } from '../../i18n/types';
 
 // Plugin ids the chip rail can dispatch to. Most chips route to a
 // `DefaultScenarioPluginId` so the same fallback table the daemon
@@ -62,7 +63,7 @@ export type ChipGroup = 'create' | 'migrate';
 
 export interface HomeHeroChip {
   id: string;
-  labelKey: string;
+  labelKey: keyof Dict;
   icon: IconName;
   group: ChipGroup;
   hint?: string;

--- a/apps/web/src/components/home-hero/chips.ts
+++ b/apps/web/src/components/home-hero/chips.ts
@@ -61,14 +61,23 @@ export type ChipAction =
 // narrow viewports without horizontal scrolling.
 export type ChipGroup = 'create' | 'migrate';
 
-export interface HomeHeroChip {
+export interface CreateChip {
   id: string;
   labelKey: keyof Dict;
   icon: IconName;
-  group: ChipGroup;
-  hint?: string;
+  group: 'create';
   action: ChipAction;
 }
+
+export interface MigrateChip {
+  id: string;
+  icon: IconName;
+  group: 'migrate';
+  hint: string;
+  action: ChipAction;
+}
+
+export type HomeHeroChip = CreateChip | MigrateChip;
 
 export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   {
@@ -194,7 +203,6 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   },
   {
     id: 'create-plugin',
-    labelKey: 'homeHero.chip.createPlugin',
     icon: 'edit',
     group: 'migrate',
     hint: 'Author a reusable Open Design plugin and add it to My plugins.',
@@ -202,7 +210,6 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   },
   {
     id: 'figma',
-    labelKey: 'homeHero.chip.figma',
     icon: 'import',
     group: 'migrate',
     hint: 'Migrate a Figma frame into the active design system.',
@@ -218,7 +225,6 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   },
   {
     id: 'folder',
-    labelKey: 'homeHero.chip.folder',
     icon: 'folder',
     group: 'migrate',
     hint: 'Import an existing local folder and continue editing.',
@@ -226,7 +232,6 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   },
   {
     id: 'template',
-    labelKey: 'homeHero.chip.template',
     icon: 'file-code',
     group: 'migrate',
     hint: 'Start from a bundled template.',

--- a/apps/web/src/components/home-hero/chips.ts
+++ b/apps/web/src/components/home-hero/chips.ts
@@ -34,7 +34,8 @@ import type { Dict } from '../../i18n/types';
 // independently of the default-binding mapping.
 export type ChipScenarioPluginId =
   | DefaultScenarioPluginId
-  | 'example-hyperframes';
+  | 'example-hyperframes'
+  | 'example-live-artifact';
 
 export type ChipAction =
   | {
@@ -64,6 +65,7 @@ export type ChipGroup = 'create' | 'migrate';
 export interface CreateChip {
   id: string;
   labelKey: keyof Dict;
+  hint?: string;
   icon: IconName;
   group: 'create';
   action: ChipAction;
@@ -102,7 +104,7 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   },
   {
     id: 'live-artifact',
-    label: 'Live artifact',
+    labelKey: 'homeHero.chip.liveArtifact',
     icon: 'refresh',
     group: 'create',
     hint: 'Build a refreshable artifact backed by connector or local data.',
@@ -222,13 +224,6 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
         targetStack: 'React 18 + Tailwind',
       },
     },
-  },
-  {
-    id: 'folder',
-    icon: 'folder',
-    group: 'migrate',
-    hint: 'Import an existing local folder and continue editing.',
-    action: { kind: 'import-folder' },
   },
   {
     id: 'template',

--- a/apps/web/src/components/home-hero/chips.ts
+++ b/apps/web/src/components/home-hero/chips.ts
@@ -22,7 +22,6 @@
 import type { ProjectKind, ProjectMetadata } from '@open-design/contracts';
 import type { DefaultScenarioPluginId } from '@open-design/contracts';
 import type { IconName } from '../Icon';
-import type { Dict } from '../../i18n/types';
 
 // Plugin ids the chip rail can dispatch to. Most chips route to a
 // `DefaultScenarioPluginId` so the same fallback table the daemon
@@ -64,7 +63,6 @@ export type ChipGroup = 'create' | 'migrate';
 
 export interface CreateChip {
   id: string;
-  labelKey: keyof Dict;
   hint?: string;
   icon: IconName;
   group: 'create';
@@ -84,7 +82,6 @@ export type HomeHeroChip = CreateChip | MigrateChip;
 export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   {
     id: 'prototype',
-    labelKey: 'homeHero.chip.prototype',
     icon: 'palette',
     group: 'create',
     // Prototype now binds to the bundled `example-web-prototype` plugin,
@@ -104,7 +101,6 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   },
   {
     id: 'live-artifact',
-    labelKey: 'homeHero.chip.liveArtifact',
     icon: 'refresh',
     group: 'create',
     hint: 'Build a refreshable artifact backed by connector or local data.',
@@ -121,7 +117,6 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   },
   {
     id: 'deck',
-    labelKey: 'homeHero.chip.deck',
     icon: 'present',
     group: 'create',
     // Slide deck binds to `example-simple-deck`, which ships a 353-line
@@ -142,7 +137,6 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   },
   {
     id: 'image',
-    labelKey: 'homeHero.chip.image',
     icon: 'image',
     group: 'create',
     action: {
@@ -159,7 +153,6 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   },
   {
     id: 'video',
-    labelKey: 'homeHero.chip.video',
     icon: 'play',
     group: 'create',
     action: {
@@ -176,7 +169,6 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   },
   {
     id: 'hyperframes',
-    labelKey: 'homeHero.chip.hyperframes',
     icon: 'orbit',
     group: 'create',
     hint: 'Author HTML-based motion: captions, audio-reactive visuals, scene transitions.',
@@ -188,7 +180,6 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   },
   {
     id: 'audio',
-    labelKey: 'homeHero.chip.audio',
     icon: 'mic',
     group: 'create',
     action: {

--- a/apps/web/src/components/home-hero/chips.ts
+++ b/apps/web/src/components/home-hero/chips.ts
@@ -193,7 +193,7 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   },
   {
     id: 'create-plugin',
-    labelKey: 'homeHero.chip.create-plugin',
+    labelKey: 'homeHero.chip.createPlugin',
     icon: 'edit',
     group: 'migrate',
     hint: 'Author a reusable Open Design plugin and add it to My plugins.',

--- a/apps/web/src/components/home-hero/chips.ts
+++ b/apps/web/src/components/home-hero/chips.ts
@@ -194,6 +194,7 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   },
   {
     id: 'create-plugin',
+    labelKey: 'homeHero.chip.createPlugin',
     icon: 'edit',
     group: 'migrate',
     hint: 'Author a reusable Open Design plugin and add it to My plugins.',
@@ -201,6 +202,7 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   },
   {
     id: 'figma',
+    labelKey: 'homeHero.chip.figma',
     icon: 'import',
     group: 'migrate',
     hint: 'Migrate a Figma frame into the active design system.',
@@ -216,6 +218,7 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   },
   {
     id: 'folder',
+    labelKey: 'homeHero.chip.folder',
     icon: 'folder',
     group: 'migrate',
     hint: 'Import an existing local folder and continue editing.',
@@ -223,6 +226,7 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   },
   {
     id: 'template',
+    labelKey: 'homeHero.chip.template',
     icon: 'file-code',
     group: 'migrate',
     hint: 'Start from a bundled template.',

--- a/apps/web/src/components/home-hero/chips.ts
+++ b/apps/web/src/components/home-hero/chips.ts
@@ -194,7 +194,6 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   },
   {
     id: 'create-plugin',
-    labelKey: 'homeHero.chip.createPlugin',
     icon: 'edit',
     group: 'migrate',
     hint: 'Author a reusable Open Design plugin and add it to My plugins.',
@@ -202,7 +201,6 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   },
   {
     id: 'figma',
-    labelKey: 'homeHero.chip.figma',
     icon: 'import',
     group: 'migrate',
     hint: 'Migrate a Figma frame into the active design system.',
@@ -218,7 +216,6 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   },
   {
     id: 'folder',
-    labelKey: 'homeHero.chip.folder',
     icon: 'folder',
     group: 'migrate',
     hint: 'Import an existing local folder and continue editing.',
@@ -226,7 +223,6 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   },
   {
     id: 'template',
-    labelKey: 'homeHero.chip.template',
     icon: 'file-code',
     group: 'migrate',
     hint: 'Start from a bundled template.',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -498,7 +498,8 @@ export const zhCN: Dict = {
   'recentProjects.title': '最近项目',
   'recentProjects.viewAll': '查看全部',
   'recentProjects.empty': '还没有项目 — 输入 Prompt 即可开始。',
-  'pluginsHome.title': 'Community',
+  
+  'pluginsHome.title': '官方入门',
   'pluginsHome.subtitle': '当前运行环境内置的 Open Design 工作流。选择一个加载 starter prompt，或浏览插件市场查看更多。',
   'pluginsHome.browseRegistry': '浏览插件市场',
   'pluginsHome.count': '{filtered} / {total}',

--- a/apps/web/tests/components/HomeHero.rail.test.tsx
+++ b/apps/web/tests/components/HomeHero.rail.test.tsx
@@ -12,6 +12,7 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { InstalledPluginRecord } from '@open-design/contracts';
 
+import { I18nProvider } from '../../src/i18n';
 import { HomeHero } from '../../src/components/HomeHero';
 import {
   HOME_HERO_CHIPS,
@@ -246,4 +247,38 @@ describe('HomeHero intent rail', () => {
       },
     });
   });
+  
+  it('renders localized chip labels and tooltips in zh-CN', () => {
+  render(
+    <I18nProvider initial="zh-CN">
+      <HomeHero
+        prompt=""
+        onPromptChange={() => undefined}
+        onSubmit={() => undefined}
+        activePluginTitle={null}
+        activeChipId={null}
+        onClearActivePlugin={() => undefined}
+        pluginOptions={[]}
+        pluginsLoading={false}
+        pendingPluginId={null}
+        pendingChipId={null}
+        onPickPlugin={vi.fn()}
+        onPickChip={vi.fn()}
+        contextItemCount={0}
+        error={null}
+      />
+    </I18nProvider>
+  );
+
+  // Prototype chip label should be zh-CN
+  const prototypeChip = screen.getByTestId('home-hero-rail-prototype');
+  expect(prototypeChip.textContent).toContain('原型');
+
+  // HyperFrames tooltip should be the zh-CN string
+  const hyperframes = screen.getByTestId('home-hero-rail-hyperframes');
+  expect(hyperframes.getAttribute('title')).toBe(
+    '创作基于 HTML 的动态内容：字幕、音频响应视觉和场景转场。'
+  );
+});
+  
 });

--- a/apps/web/tests/components/HomeHero.rail.test.tsx
+++ b/apps/web/tests/components/HomeHero.rail.test.tsx
@@ -273,6 +273,11 @@ describe('HomeHero intent rail', () => {
   // Prototype chip label should be zh-CN
   const prototypeChip = screen.getByTestId('home-hero-rail-prototype');
   expect(prototypeChip.textContent).toContain('原型');
+  
+  // Live artifact chip label and tooltip should be zh-CN
+  const liveArtifact = screen.getByTestId('home-hero-rail-live-artifact');
+  expect(liveArtifact.textContent).toContain('实时制品');
+  expect(liveArtifact.getAttribute('title')).toBe('构建可实时预览的交互式 HTML/CSS/JS 制品。');
 
   // HyperFrames tooltip should be the zh-CN string
   const hyperframes = screen.getByTestId('home-hero-rail-hyperframes');

--- a/apps/web/tests/components/HomeHero.rail.test.tsx
+++ b/apps/web/tests/components/HomeHero.rail.test.tsx
@@ -279,6 +279,20 @@ describe('HomeHero intent rail', () => {
   expect(hyperframes.getAttribute('title')).toBe(
     '创作基于 HTML 的动态内容：字幕、音频响应视觉和场景转场。'
   );
+
+  // Open shortcuts menu to expose migrate chips
+  fireEvent.click(screen.getByTestId('home-hero-shortcuts-trigger'));
+
+  // Migrate chip labels should be zh-CN
+  expect(screen.getByTestId('home-hero-rail-create-plugin').textContent).toContain('创建插件');
+  expect(screen.getByTestId('home-hero-rail-figma').textContent).toContain('来自 Figma');
+  expect(screen.getByTestId('home-hero-rail-template').textContent).toContain('来自模板');
+
+  // Migrate chip tooltips should be zh-CN
+  expect(screen.getByTestId('home-hero-rail-create-plugin').getAttribute('title')).toBe('创作可复用的 Open Design 插件，并添加到我的插件。');
+  expect(screen.getByTestId('home-hero-rail-figma').getAttribute('title')).toBe('将 Figma 画框迁移到当前设计体系。');
+  expect(screen.getByTestId('home-hero-rail-template').getAttribute('title')).toBe('从内置模板开始。');
+  
 });
   
 });


### PR DESCRIPTION
Fixes #2076 

## Why

This PR addresses incomplete localization on the homepage in 0.8.0-preview.

While using the Chinese language setting, several homepage UI elements were still displayed in English. This was mainly due to hardcoded chip labels and missing or inconsistent translation entries, leading to a mixed-language experience.

Additionally, some direct English-to-Chinese translations resulted in vague or unclear meanings. This PR improves those cases by choosing more context-appropriate translations for better clarity and UX.

## What users will see

When switching to Chinese:

- Homepage category chips (Prototype, Image, Video, etc.) are properly localized
- "starter" section is now consistently translated as 官方入门
- Previously untranslated items (e.g. HyperFrames handling) are now consistent
- Ambiguous translations have been refined to better match intended meaning
- No mixed English/Chinese UI remains on the homepage

## Surface area

- [x] UI
- [x] i18n keys
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] New top-level dependency
- [ ] Default behavior change
- [ ] None

## Screenshots

<!-- Not required for this PR -->

## Bug fix verification
Before this fix, homepage category chips (Prototype, Image, Video, etc.) showed hardcoded English labels even when the language was set to Chinese. The HyperFrames tooltip also displayed the raw English hint string ("Author HTML-based motion...") instead of the localized version. After this fix, all chip labels and tooltips render correct zh-CN strings with no English fallbacks remaining on the homepage.


## Validation

- Verified changes locally using `pnpm dev`
- Switched language to Chinese and confirmed all homepage elements are localized
- Ensured no raw i18n keys or English fallbacks remain in homepage UI