### PR TITLE
fix(pack): add missing package.json fields for Linux AppImage build

### DIFF
--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -447,12 +447,19 @@ async function writeAssembledApp(
   }
 
   const version = await readPackagedVersion(config);
+
   const packageJson = {
     name: "open-design-packaged",
     version,
     private: true,
     main: "main.cjs",
     dependencies,
+    description: "Local-first design product: detects your installed code-agent CLI, runs design skills + design systems, streams artifacts into a sandboxed preview.",
+    author: "Open Design Team",
+    repository: {
+      type: "git",
+      url: "https://github.com/nexu-io/open-design.git"
+    }
   };
   await writeFile(paths.assembledPackageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8");
 


### PR DESCRIPTION
Fix electron-builder failure in `pnpm exec tools-pack linux build --to appimage` by adding required description, author, and repository fields to generated package.json in tools/pack/src/linux.ts.

<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works.
     Delete this whole block if the PR genuinely doesn't close any issue. -->
Fixes #

## Why

Executing `pnpm exec tools-pack linux build --to appimage` failed because `electron-builder` could not find the `repository` field in the dynamically generated `package.json`. Additionally, it could not auto-detect the repository from `.git/config` due to running within an isolated assembly directory. This resulted in a crash: `TypeError: Cannot read properties of null (reading 'provider')`.

This PR fixes the Linux AppImage build by populating the required metadata (`description`, `author`, `repository`) in `tools/pack/src/linux.ts`.

## What users will see

No user-facing changes. Developers can now successfully build Linux AppImage packages.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

<img width="1273" height="582" alt="image" src="https://github.com/user-attachments/assets/bb37ec0f-c802-4417-8540-9145b4b368a9" />

## Bug fix verification

- Command: `pnpm exec tools-pack linux build --to appimage`
- Before: `electron-builder` crashes with `Cannot read properties of null (reading 'provider')`.
- After: Packaging completes successfully, and the `.AppImage` file is generated.

## Validation

- Verified `pnpm exec tools-pack linux build --to appimage` on a Linux environment.
- Ran `pnpm typecheck` to ensure script integrity.
