### PR TITLE
fix(nix): prebuild host package for web build

### DIFF
--- a/nix/package-web.nix
+++ b/nix/package-web.nix
@@ -57,6 +57,7 @@ in
       runHook preBuild
       for target in \
         packages/contracts \
+        packages/host \
         packages/sidecar-proto \
         packages/sidecar \
         packages/platform


### PR DESCRIPTION
## Why

I hit a post-merge `nix-check` failure while tracing the new `@open-design/host` dependency. The Nix web package prebuilt several workspace packages before `next build`, but it skipped `packages/host`, so web builds on the Nix path could not resolve that package's `dist/*` exports.

## What users will see

No product-visible change. Maintainers should see `nix-check` stop failing on main for web builds that import `@open-design/host`.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A

## Bug fix verification

- Test path that reproduces the bug: `.github/workflows/nix-check.yml` → `nix/package-web.nix` web build path
- Did the test go red on `main` and green on this branch? no — I confirmed the red failure from the existing GitHub Actions logs, but I could not rerun the Nix build locally because `nix` is not installed in this environment.

## Validation

- `pnpm guard` *(fails on current main with a pre-existing `@open-design/contracts` export error in `apps/daemon/src/design-systems.ts`)*
- `pnpm typecheck` *(fails on current main with a pre-existing `packages/host/tests/index.test.ts` missing `vitest` types error)*
- `nix build .#web` *(not runnable here: `nix` command is not installed in this environment)*