### PR TITLE
fix(web): wrap local cli status paths

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -12838,7 +12838,7 @@ button.ghost.mcp-copy-btn:hover:not(:disabled) {
 .status-pill {
   display: inline-flex;
   align-self: flex-start;
-  align-items: center;
+  align-items: flex-start;
   flex-wrap: wrap;
   gap: 6px;
   max-width: 100%;
@@ -14348,7 +14348,7 @@ button.ghost.mcp-copy-btn:hover:not(:disabled) {
 .op-waiting {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
+  align-items: flex-start;
   gap: 8px;
   max-width: 100%;
   padding: 8px 12px;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -12839,7 +12839,9 @@ button.ghost.mcp-copy-btn:hover:not(:disabled) {
   display: inline-flex;
   align-self: flex-start;
   align-items: center;
+  flex-wrap: wrap;
   gap: 6px;
+  max-width: 100%;
   padding: 3px 12px;
   background: var(--bg-subtle);
   border: 1px solid var(--border);
@@ -12848,7 +12850,11 @@ button.ghost.mcp-copy-btn:hover:not(:disabled) {
   color: var(--text-muted);
 }
 .status-label { letter-spacing: 0.02em; }
-.status-detail { color: var(--text); }
+.status-detail {
+  min-width: 0;
+  color: var(--text);
+  overflow-wrap: anywhere;
+}
 
 /* Grouped tool / action card — the collapsible pill from screenshot 9 */
 .action-card {
@@ -14344,6 +14350,7 @@ button.ghost.mcp-copy-btn:hover:not(:disabled) {
   flex-wrap: wrap;
   align-items: center;
   gap: 8px;
+  max-width: 100%;
   padding: 8px 12px;
   border: 1px solid var(--border);
   border-radius: var(--radius);
@@ -14365,12 +14372,16 @@ button.ghost.mcp-copy-btn:hover:not(:disabled) {
   color: var(--text);
 }
 .op-waiting-detail {
+  min-width: 0;
+  max-width: 100%;
   font-family: var(--mono);
   font-size: 11px;
   background: var(--bg-panel);
   padding: 1px 6px;
   border-radius: 4px;
   color: var(--text-muted);
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 .op-waiting-hint {
   flex-basis: 100%;


### PR DESCRIPTION
Fixes #2206

## Why

I picked this up from the reported Local CLI startup overflow. Long filesystem paths can appear in the chat startup/status card and should not push past the card boundary.

## What users will see

Long Local CLI startup/status details wrap inside the chat status card instead of overflowing horizontally.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Before: the issue screenshot shows the long Local CLI path extending beyond the chat status card.

After: I verified the changed CSS in headless Chrome with a 260px card and a long unbroken Local CLI path. The measured `.card`, `.op-waiting`, `.op-waiting-detail`, `.status-pill`, and `.status-detail` all had `scrollWidth <= clientWidth`, so no horizontal overflow was present.

## Bug fix verification

- Test path that reproduces the bug: not added; this is a visual CSS overflow fix and a focused red spec would require a synthetic layout fixture rather than exercising the product flow.
- Did the test go red on `main` and green on this branch? no; verified with targeted component tests, static review, and headless Chrome layout measurement instead.

## Validation

- `pnpm install`
- `pnpm guard`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --dir apps/web exec vitest run tests/components/AssistantMessage.test.tsx`
- `git diff --check`
- Subagent review: no blocker found; confirmed the CSS-only change is scoped to `WaitingPill` / `StatusPill` path/status detail overflow.
- Headless Chrome layout measurement: long startup/status path stayed within the 260px card with no horizontal overflow.