### PR TITLE
feat(lint): add cta-class-mismatch rule to lintArtifact

### DIFF
--- a/apps/daemon/src/lint-artifact.ts
+++ b/apps/daemon/src/lint-artifact.ts
@@ -445,6 +445,15 @@ export function lintArtifact(rawHtml: unknown): LintFinding[] {
     });
   }
 
+  // ── P1-4: CTA class mismatch across commerce regions ─────────────
+  // Group every commerce CTA (purchase/signup verb in <a> or <button>)
+  // across the page by class signature; if two or more distinct
+  // signatures coexist, the page's primary action style is ambiguous.
+  // Advisory P1 — outline / secondary variants are a legitimate design
+  // choice, so callers can ignore the warning when intentional.
+  const ctaFinding = detectCtaClassMismatch(html);
+  if (ctaFinding) out.push(ctaFinding);
+
   // ── P2-1: missing comment-mode anchor on <section> ────────────────
   // Either `data-od-id` (web/mobile prototypes) or `data-screen-label`
   // (decks) counts. Whichever the artifact uses, every <section> should
@@ -997,4 +1006,100 @@ function isGlobalThemeScopeSelector(s: string): boolean {
     return true;
   }
   return false;
+}
+
+const COMMERCE_CTA_VERBS = [
+  /\bbuy\b/i,
+  /\bpurchase\b/i,
+  /\bcheckout\b/i,
+  /\border\s+now\b/i,
+  /\bplace\s+order\b/i,
+  /\bplace\s+your\s+order\b/i,
+  /\bget\s+started\b/i,
+  /\bshop\s+now\b/i,
+  /\badd\s+to\s+cart\b/i,
+  /\bsubscribe\b/i,
+  /\bsign\s+up\b/i,
+  /\bstart\s+free\b/i,
+  /\bbook\s+now\b/i,
+  /\breserve\b/i,
+];
+
+function detectCtaClassMismatch(html: string): LintFinding | null {
+  const regions = [...extractCommerceRegions(html), ...extractMainBody(html)];
+  if (regions.length === 0) return null;
+  const ctas: { classes: Set<string>; signature: string; snippet: string }[] = [];
+  const ctaRe = /<(?:a|button)\b[^>]*\bclass\s*=\s*["']([^"']*)["'][^>]*>([\s\S]*?)<\/(?:a|button)>/gi;
+  const seen = new Set<number>();
+  for (const region of regions) {
+    for (const m of region.body.matchAll(ctaRe)) {
+      const text = stripTags(m[2] ?? '');
+      if (!isCommerceCtaText(text)) continue;
+      const tokens = (m[1] ?? '').split(/\s+/).filter(Boolean);
+      if (tokens.length === 0) continue;
+      const absolute = region.start + (m.index ?? 0);
+      if (seen.has(absolute)) continue;
+      seen.add(absolute);
+      const classes = new Set(tokens);
+      ctas.push({
+        classes,
+        signature: [...classes].sort().join(' '),
+        snippet: m[0],
+      });
+    }
+  }
+  if (ctas.length < 2) return null;
+  const signatures = new Set(ctas.map((c) => c.signature));
+  if (signatures.size < 2) return null;
+  const counts = new Map<string, number>();
+  for (const c of ctas) {
+    for (const cls of c.classes) counts.set(cls, (counts.get(cls) ?? 0) + 1);
+  }
+  const majority = [...counts.entries()].filter(([, n]) => n >= ctas.length - 1 && n < ctas.length);
+  const odd = ctas.find((c) => majority.some(([cls]) => !c.classes.has(cls))) ?? ctas[0];
+  if (!odd) return null;
+  return {
+    severity: 'P1',
+    id: 'cta-class-mismatch',
+    message: `${ctas.length} commerce CTAs across the page use ${signatures.size} different class signatures — the primary action style is inconsistent.`,
+    fix: 'Pick one button class set (e.g. `btn btn-primary`) and apply it to every purchase / signup CTA across header, hero, and main. Outline / secondary variants should use a different verb so they are not confused with the primary action.',
+    snippet: clip(odd.snippet),
+  };
+}
+
+function extractMainBody(html: string): { body: string; start: number }[] {
+  const out: { body: string; start: number }[] = [];
+  for (const m of html.matchAll(/<main\b[^>]*>([\s\S]*?)<\/main>/gi)) {
+    const body = m[1];
+    if (!body) continue;
+    const start = (m.index ?? 0) + m[0].indexOf(body);
+    out.push({ body, start });
+  }
+  return out;
+}
+
+function extractCommerceRegions(html: string): { body: string; start: number }[] {
+  const regions: { body: string; start: number }[] = [];
+  const patterns = [
+    /<header\b[^>]*>([\s\S]*?)<\/header>/gi,
+    /<nav\b[^>]*>([\s\S]*?)<\/nav>/gi,
+    /<section\b[^>]*\bclass\s*=\s*["'][^"']*\bhero\b[^"']*["'][^>]*>([\s\S]*?)<\/section>/gi,
+  ];
+  for (const re of patterns) {
+    for (const m of html.matchAll(re)) {
+      const body = m[1];
+      if (!body) continue;
+      const start = (m.index ?? 0) + m[0].indexOf(body);
+      regions.push({ body, start });
+    }
+  }
+  return regions;
+}
+
+function isCommerceCtaText(text: string): boolean {
+  return COMMERCE_CTA_VERBS.some((re) => re.test(text));
+}
+
+function stripTags(s: string): string {
+  return s.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
 }

--- a/apps/daemon/tests/lint-artifact.test.ts
+++ b/apps/daemon/tests/lint-artifact.test.ts
@@ -1222,3 +1222,96 @@ describe('trust-gradient', () => {
     expect(findings.find((f) => f.id === 'trust-gradient')).toBeDefined();
   });
 });
+
+describe('cta-class-mismatch', () => {
+  it('flags a header CTA on .btn when other CTAs use .btn .btn-primary', () => {
+    const html = `
+      <header><a class="btn" href="catalog.html">Buy now</a></header>
+      <main>
+        <a class="btn btn-primary" href="cart.html">Buy now</a>
+        <a class="btn btn-primary" href="signup.html">Sign up</a>
+      </main>
+    `;
+    const findings = lintArtifact(html);
+    const hit = requiredFinding(findings, 'cta-class-mismatch');
+    expect(hit.severity).toBe('P1');
+    expect(hit.snippet).toContain('btn');
+  });
+
+  it('does not fire when every commerce CTA shares the same class signature', () => {
+    const html = `
+      <header><a class="btn btn-primary">Buy now</a></header>
+      <main>
+        <a class="btn btn-primary">Buy now</a>
+        <a class="btn btn-primary">Sign up</a>
+      </main>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'cta-class-mismatch')).toBeUndefined();
+  });
+
+  it('does not fire when only a single commerce CTA exists', () => {
+    const html = `
+      <header><a class="btn">Buy now</a></header>
+      <main><p>Read more about us</p></main>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'cta-class-mismatch')).toBeUndefined();
+  });
+
+  it('fires when two CTAs in main use divergent button classes', () => {
+    const html = `
+      <main>
+        <a class="btn-primary">Buy now</a>
+        <button class="btn-outline">Sign up</button>
+      </main>
+    `;
+    const findings = lintArtifact(html);
+    const hit = requiredFinding(findings, 'cta-class-mismatch');
+    expect(hit.message).toContain('2 different class signatures');
+  });
+
+  it('ignores non-commerce CTAs even when they have divergent classes', () => {
+    const html = `
+      <header><a class="btn">About us</a></header>
+      <main>
+        <a class="btn btn-primary">Read more</a>
+        <a class="btn-outline">Contact</a>
+      </main>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'cta-class-mismatch')).toBeUndefined();
+  });
+
+  it('skips CTAs that carry no class attribute tokens', () => {
+    const html = `
+      <header><a class="">Buy now</a></header>
+      <main><a class="btn btn-primary">Sign up</a></main>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'cta-class-mismatch')).toBeUndefined();
+  });
+
+  it('treats class order as irrelevant when comparing signatures', () => {
+    const html = `
+      <header><a class="btn-primary btn">Buy now</a></header>
+      <main><a class="btn btn-primary">Sign up</a></main>
+    `;
+    const findings = lintArtifact(html);
+    expect(findings.find((f) => f.id === 'cta-class-mismatch')).toBeUndefined();
+  });
+
+  it('points the snippet at the divergent CTA when one is missing a class the others share', () => {
+    const html = `
+      <header><a class="btn">Buy now</a></header>
+      <main>
+        <a class="btn btn-primary">Buy now</a>
+        <a class="btn btn-primary">Sign up</a>
+      </main>
+    `;
+    const findings = lintArtifact(html);
+    const hit = requiredFinding(findings, 'cta-class-mismatch');
+    expect(hit.snippet).toContain('btn');
+    expect(hit.snippet).not.toContain('btn-primary');
+  });
+});


### PR DESCRIPTION
Closes #2251

## Why

Adds a `cta-class-mismatch` lint rule so generated pages whose commerce CTAs use divergent button classes are flagged as a P1 advisory — the inconsistency case the issue calls out (`<a class="btn">` in the header while other CTAs use `btn-primary`).

## What users will see

A new advisory finding `cta-class-mismatch` (severity P1) appears on the artifact lint badge when a page contains two or more commerce CTAs (`<a>` / `<button>` whose text matches Buy / Purchase / Checkout / Order now / Get started / Shop now / Add to cart / Subscribe / Sign up / Start free / Book now / Reserve) across `<header>`, `<nav>`, `<section class="hero">`, or `<main>` whose `class` attributes resolve to different class sets. The snippet points at the odd-CTA-out so the agent can promote it to the shared class signature. P1 surfaces as a warning in the chat UI and does **not** gate emit — outline / secondary variants remain a legitimate design choice when the divergence is intentional.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal lint rule addition only

Daemon-internal: one rule block plus two small helpers (`detectCtaClassMismatch`, `extractMainBody`) inside the existing `apps/daemon/src/lint-artifact.ts` seam (the maintainer-identified home for new lint rules). No new file, no new export, no contract change. The finding rides the existing `POST /api/artifacts/lint` response.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run tests/lint-artifact.test.ts` — 105 tests pass.
- `pnpm --filter @open-design/daemon typecheck` — clean.

## Redesign note

This PR was reset on 2026-05-20 after the original `cta-hierarchy-mismatch` rule went through five review rounds of edge-case patching (alpha=0 handling, grouped selectors, background-color cascade, rightmost-compound selectors, attribute-selector whitespace). Each round caught a real bug but the underlying detection — "guess the primary button class by painted-background regex + name hints" — kept producing the next edge case. The current implementation drops the painted-background / name-hint heuristics entirely and reduces the rule to a class-set comparison across commerce CTAs, which matches the actual invariant the issue describes (inconsistent treatment across related CTAs) and removes the CSS-parsing surface that drove the edge-case loop.
