### PR TITLE
[codex] Restrict GitHub Actions triggers

### DIFF
--- a/.github/workflows/blog-3day-report.yml
+++ b/.github/workflows/blog-3day-report.yml
@@ -40,7 +40,7 @@ concurrency:
 jobs:
   report:
     name: Daily 3-day traffic digest
-    if: github.repository == 'nexu-io/open-design'
+    if: (github.event_name != 'workflow_dispatch' || contains(fromJSON('["development","test","main"]'), github.ref_name)) && github.repository == 'nexu-io/open-design'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/blog-indexing-monitor.yml
+++ b/.github/workflows/blog-indexing-monitor.yml
@@ -38,7 +38,7 @@ concurrency:
 jobs:
   monitor:
     name: Monitor recent blog URLs
-    if: github.repository == 'nexu-io/open-design'
+    if: (github.event_name != 'workflow_dispatch' || contains(fromJSON('["development","test","main"]'), github.ref_name)) && github.repository == 'nexu-io/open-design'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/.github/workflows/blog-indexing-on-deploy.yml
+++ b/.github/workflows/blog-indexing-on-deploy.yml
@@ -39,6 +39,8 @@ jobs:
   index:
     name: Index newly deployed blog posts
     if: >-
+      (github.event_name != 'workflow_dispatch' || contains(fromJSON('["development","test","main"]'), github.ref_name))
+      &&
       github.repository == 'nexu-io/open-design'
       && (
         github.event_name == 'workflow_dispatch'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ concurrency:
 
 jobs:
   change_scopes:
+    if: github.event_name != 'workflow_dispatch' || contains(fromJSON('["development","test","main"]'), github.ref_name)
     name: Detect CI change scopes
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/contributor-card-bot.yml
+++ b/.github/workflows/contributor-card-bot.yml
@@ -12,6 +12,10 @@ name: Contributor Card Bot
 # want to recognize. They can be re-added later via a workflow_run handoff.
 on:
   pull_request_target:
+    branches:
+      - development
+      - test
+      - main
     types: [closed]
   issues:
     types: [opened]

--- a/.github/workflows/contributor-card-bot.yml
+++ b/.github/workflows/contributor-card-bot.yml
@@ -44,6 +44,7 @@ jobs:
   recognize:
     name: Render and post contributor card
     if: |
+      (github.event_name != 'workflow_dispatch' || contains(fromJSON('["development","test","main"]'), github.ref_name)) &&
       github.repository == 'nexu-io/open-design' &&
       (
         (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true) ||

--- a/.github/workflows/critique-conformance.yml
+++ b/.github/workflows/critique-conformance.yml
@@ -24,6 +24,7 @@ on:
 
 jobs:
   run:
+    if: github.event_name != 'workflow_dispatch' || contains(fromJSON('["development","test","main"]'), github.ref_name)
     name: nightly conformance + ratchet snapshot
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build-and-push:
+    if: github.event_name != 'workflow_dispatch' || contains(fromJSON('["development","test","main"]'), github.ref_name)
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,12 +2,10 @@ name: Docker image
 
 # Phase 5 / spec §15.5 — multi-arch image builds.
 #
-# Pushes to ghcr.io on:
-#   - tag (v*.*.*)    → ghcr.io/<owner>/od:<tag> + :latest
+# Pushes to ghcr.io when run manually for a selected ref.
 
 on:
-  push:
-    tags: ['v*.*.*']
+  workflow_dispatch:
 
 jobs:
   build-and-push:

--- a/.github/workflows/landing-page-ci.yml
+++ b/.github/workflows/landing-page-ci.yml
@@ -52,6 +52,7 @@ concurrency:
 
 jobs:
   validate:
+    if: github.event_name != 'workflow_dispatch' || contains(fromJSON('["development","test","main"]'), github.ref_name)
     name: Validate landing page
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/landing-page-ci.yml
+++ b/.github/workflows/landing-page-ci.yml
@@ -2,6 +2,10 @@ name: landing-page-ci
 
 on:
   pull_request:
+    branches:
+      - development
+      - test
+      - main
     paths:
       # Workflow files
       - .github/workflows/landing-page-ci.yml

--- a/.github/workflows/landing-page-deploy.yml
+++ b/.github/workflows/landing-page-deploy.yml
@@ -35,7 +35,7 @@ concurrency:
 jobs:
   deploy:
     name: Deploy landing page
-    if: github.repository == 'nexu-io/open-design'
+    if: (github.event_name != 'workflow_dispatch' || contains(fromJSON('["development","test","main"]'), github.ref_name)) && github.repository == 'nexu-io/open-design'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   metrics:
     name: Generate repository metrics SVG
-    if: github.repository == 'nexu-io/open-design'
+    if: (github.event_name != 'workflow_dispatch' || contains(fromJSON('["development","test","main"]'), github.ref_name)) && github.repository == 'nexu-io/open-design'
     runs-on: ubuntu-latest
     steps:
       - name: Generate Open Design bot token

--- a/.github/workflows/nix-check.yml
+++ b/.github/workflows/nix-check.yml
@@ -31,6 +31,7 @@ permissions:
 
 jobs:
   build:
+    if: github.event_name != 'workflow_dispatch' || contains(fromJSON('["development","test","main"]'), github.ref_name)
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pr-author-inactivity.yml
+++ b/.github/workflows/pr-author-inactivity.yml
@@ -45,7 +45,7 @@ concurrency:
 
 jobs:
   triage:
-    if: github.repository == 'nexu-io/open-design'
+    if: (github.event_name != 'workflow_dispatch' || contains(fromJSON('["development","test","main"]'), github.ref_name)) && github.repository == 'nexu-io/open-design'
     runs-on: ubuntu-latest
     steps:
       - name: Remind or close inactive PRs

--- a/.github/workflows/refresh-contributors-wall.yml
+++ b/.github/workflows/refresh-contributors-wall.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   refresh:
     name: Refresh contributors wall cache bust
-    if: github.repository == 'nexu-io/open-design'
+    if: (github.event_name != 'workflow_dispatch' || contains(fromJSON('["development","test","main"]'), github.ref_name)) && github.repository == 'nexu-io/open-design'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -45,7 +45,7 @@ env:
 jobs:
   metadata:
     name: Prepare beta metadata
-    if: github.repository == 'nexu-io/open-design'
+    if: (github.event_name != 'workflow_dispatch' || contains(fromJSON('["development","test","main"]'), github.ref_name)) && github.repository == 'nexu-io/open-design'
     runs-on: ubuntu-latest
     env:
       OPEN_DESIGN_BETA_METADATA_URL: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}/beta/latest/metadata.json

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -22,6 +22,7 @@ env:
 
 jobs:
   metadata:
+    if: github.event_name != 'workflow_dispatch' || contains(fromJSON('["development","test","main"]'), github.ref_name)
     name: Prepare preview metadata
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -36,7 +36,7 @@ env:
 jobs:
   metadata:
     name: Prepare release metadata
-    if: github.repository == 'nexu-io/open-design'
+    if: (github.event_name != 'workflow_dispatch' || contains(fromJSON('["development","test","main"]'), github.ref_name)) && github.repository == 'nexu-io/open-design'
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/seo-daily-report.yml
+++ b/.github/workflows/seo-daily-report.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   report:
     name: Post SEO daily report to Feishu
-    if: github.repository == 'nexu-io/open-design'
+    if: (github.event_name != 'workflow_dispatch' || contains(fromJSON('["development","test","main"]'), github.ref_name)) && github.repository == 'nexu-io/open-design'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   stale:
-    if: github.repository == 'nexu-io/open-design'
+    if: (github.event_name != 'workflow_dispatch' || contains(fromJSON('["development","test","main"]'), github.ref_name)) && github.repository == 'nexu-io/open-design'
     runs-on: ubuntu-latest
     steps:
       - name: Exempt org-member issues from staling


### PR DESCRIPTION
## Summary
- Restricts branch-based GitHub Actions triggers to development, test, and main.
- Removes security scan execution from promotion branches where applicable.
- Keeps test/main promotion workflows available without rerunning development security checks.

## Validation
- Parsed all workflow YAML in the changed worktree with PyYAML.
- Ran the branch trigger policy scan and confirmed zero remaining branch/tag trigger violations in the targeted worktree.
- Ran agent-final-check where the base checkout was clean; dirty base checkouts were preserved and edited only through isolated worktrees.

